### PR TITLE
feat: add drift detection and learnings subsystems (Phase 2+3)

### DIFF
--- a/planning/phase3-quality-loop/implementation/code_review/section-18-diff.md
+++ b/planning/phase3-quality-loop/implementation/code_review/section-18-diff.md
@@ -1,0 +1,515 @@
+diff --git a/planning/phase3-quality-loop/implementation/deep_implement_config.json b/planning/phase3-quality-loop/implementation/deep_implement_config.json
+index 8045c0e..a9874af 100644
+--- a/planning/phase3-quality-loop/implementation/deep_implement_config.json
++++ b/planning/phase3-quality-loop/implementation/deep_implement_config.json
+@@ -88,6 +88,14 @@
+     "section-15-learnings-sse": {
+       "status": "complete",
+       "commit_hash": "204ead3"
++    },
++    "section-16-escalation-bridge": {
++      "status": "complete",
++      "commit_hash": "474400c"
++    },
++    "section-17-learnings-bridge": {
++      "status": "complete",
++      "commit_hash": "4b8197a"
+     }
+   },
+   "pre_commit": {
+diff --git a/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/DependencyInjection.cs b/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/DependencyInjection.cs
+index 970a77f..015b387 100644
+--- a/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/DependencyInjection.cs
++++ b/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/DependencyInjection.cs
+@@ -1,4 +1,5 @@
+ using Application.AI.Common.Interfaces.KnowledgeGraph;
++using Application.AI.Common.Interfaces.Learnings;
+ using Application.AI.Common.Interfaces.RAG;
+ using Application.AI.Common.Interfaces.Skills;
+ using Domain.Common.Config;
+@@ -156,6 +157,20 @@ public static class DependencyInjection
+                     sp.GetRequiredService<ILogger<GraphSkillAmendmentProvider>>()));
+         }
+ 
++        // --- Learnings Store (keyed DI) ---
++
++        services.AddKeyedSingleton<ILearningsStore>("graph", (sp, _) =>
++            new Learnings.GraphLearningsStore(
++                sp.GetRequiredService<IKnowledgeGraphStore>(),
++                sp.GetRequiredService<ILogger<Learnings.GraphLearningsStore>>()));
++
++        services.AddKeyedSingleton<ILearningsStore>("in_memory", (_, _) =>
++            new Learnings.InMemoryLearningsStore());
++
++        var learningsProvider = appConfig.AI.Learnings.StoreProvider;
++        services.AddSingleton<ILearningsStore>(sp =>
++            sp.GetRequiredKeyedService<ILearningsStore>(learningsProvider));
++
+         return services;
+     }
+ }
+diff --git a/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.cs b/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.cs
+index 619c10e..c68269f 100644
+--- a/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.cs
++++ b/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.cs
+@@ -1,12 +1,16 @@
+ using Application.AI.Common.Interfaces;
+ using Application.AI.Common.Interfaces.A2A;
++using Application.AI.Common.Interfaces.DriftDetection;
++using Application.AI.Common.Interfaces.Learnings;
+ using Application.AI.Common.Interfaces.MetaHarness;
+ using Application.AI.Common.Interfaces.Skills;
+ using Application.AI.Common.Interfaces.Memory;
+ using Application.AI.Common.Interfaces.Traces;
+ using Application.AI.Common.Interfaces.Escalation;
+ using Application.AI.Common.Interfaces.Resilience;
++using Infrastructure.AI.DriftDetection;
+ using Infrastructure.AI.Escalation;
++using Infrastructure.AI.Learnings;
+ using Infrastructure.AI.Memory;
+ using Infrastructure.AI.Resilience;
+ using Infrastructure.AI.Security;
+@@ -249,6 +253,8 @@ public static class DependencyInjection
+ 
+         RegisterEscalationServices(services);
+         RegisterResilienceServices(services, appConfig);
++        RegisterDriftDetectionServices(services);
++        RegisterLearningsServices(services, appConfig);
+ 
+         return services;
+     }
+@@ -264,6 +270,7 @@ public static class DependencyInjection
+         services.AddSingleton<IEscalationNotifier, CompositeEscalationNotifier>();
+         services.AddSingleton<IEscalationNotificationChannel, NoOpSlackNotifier>();
+         services.AddSingleton<IEscalationNotificationChannel, NoOpTeamsNotifier>();
++        services.AddSingleton<IEscalationNotificationChannel, DriftEscalationBridge>();
+     }
+ 
+     /// <summary>
+@@ -285,6 +292,78 @@ public static class DependencyInjection
+         }
+     }
+ 
++    /// <summary>
++    /// Registers drift detection pipeline: scorer, baseline store, audit, notifier, EWMA state,
++    /// and the main detection service.
++    /// </summary>
++    private static void RegisterDriftDetectionServices(IServiceCollection services)
++    {
++        services.AddKeyedSingleton<IDriftScorer>("ewma", (sp, _) =>
++            new EwmaDriftScorer(
++                sp.GetRequiredService<IEwmaStateStore>(),
++                sp.GetRequiredService<IOptionsMonitor<AppConfig>>(),
++                sp.GetService<TimeProvider>() ?? TimeProvider.System,
++                sp.GetRequiredService<ILogger<EwmaDriftScorer>>()));
++
++        services.AddKeyedSingleton<IDriftBaselineStore>("graph", (sp, _) =>
++            new GraphDriftBaselineStore(
++                sp.GetRequiredService<Application.AI.Common.Interfaces.KnowledgeGraph.IKnowledgeGraphStore>(),
++                sp.GetRequiredService<ILogger<GraphDriftBaselineStore>>()));
++
++        services.AddKeyedSingleton<IDriftBaselineStore>("in_memory", (_, _) =>
++            new InMemoryDriftBaselineStore());
++
++        services.AddSingleton<IDriftBaselineStore>(sp =>
++            sp.GetRequiredKeyedService<IDriftBaselineStore>("graph"));
++
++        services.AddSingleton<IDriftAuditStore>(sp =>
++            new JsonlDriftAuditStore(
++                sp.GetRequiredService<IOptionsMonitor<AppConfig>>(),
++                sp.GetService<TimeProvider>() ?? TimeProvider.System,
++                sp.GetRequiredService<ILogger<JsonlDriftAuditStore>>()));
++
++        services.AddSingleton<IDriftNotifier, CompositeDriftNotifier>();
++
++        services.AddSingleton<IEwmaStateStore>(sp =>
++            new GraphEwmaStateStore(
++                sp.GetRequiredService<Application.AI.Common.Interfaces.KnowledgeGraph.IKnowledgeGraphStore>(),
++                sp.GetRequiredService<ILogger<GraphEwmaStateStore>>()));
++
++        services.AddSingleton<IDriftDetectionService>(sp =>
++            new DefaultDriftDetectionService(
++                sp.GetRequiredKeyedService<IDriftScorer>("ewma"),
++                sp.GetRequiredService<IDriftBaselineStore>(),
++                sp.GetRequiredService<IDriftAuditStore>(),
++                sp.GetRequiredService<IDriftNotifier>(),
++                sp.GetRequiredService<IEscalationService>(),
++                sp.GetRequiredService<Application.AI.Common.Interfaces.KnowledgeGraph.IKnowledgeGraphStore>(),
++                sp.GetRequiredService<IOptionsMonitor<AppConfig>>(),
++                sp.GetService<TimeProvider>() ?? TimeProvider.System,
++                sp.GetRequiredService<ILogger<DefaultDriftDetectionService>>()));
++    }
++
++    /// <summary>
++    /// Registers learnings subsystem: decay service, drift bridge, and conditional
++    /// pruning background service.
++    /// </summary>
++    private static void RegisterLearningsServices(IServiceCollection services, AppConfig appConfig)
++    {
++        services.AddSingleton<ILearningDecayService>(sp =>
++            new DefaultLearningDecayService(
++                sp.GetRequiredService<ILearningsStore>(),
++                sp.GetRequiredService<IOptionsMonitor<Domain.Common.Config.AI.Learnings.LearningsConfig>>(),
++                sp.GetService<TimeProvider>() ?? TimeProvider.System,
++                sp.GetRequiredService<ILogger<DefaultLearningDecayService>>()));
++
++        services.AddSingleton<ILearningsDriftBridge, LearningsDriftBridge>();
++
++        if (appConfig.AI.Learnings.Enabled)
++        {
++            services.AddSingleton<LearningsPruningBackgroundService>();
++            services.AddHostedService(sp => sp.GetRequiredService<LearningsPruningBackgroundService>());
++        }
++    }
++
+     private static void RegisterAIClients(IServiceCollection services, AppConfig appConfig)
+     {
+         var framework = appConfig.AI.AgentFramework;
+diff --git a/src/Content/Presentation/Presentation.AgentHub/DependencyInjection.cs b/src/Content/Presentation/Presentation.AgentHub/DependencyInjection.cs
+index 0c38047..daf6566 100644
+--- a/src/Content/Presentation/Presentation.AgentHub/DependencyInjection.cs
++++ b/src/Content/Presentation/Presentation.AgentHub/DependencyInjection.cs
+@@ -1,7 +1,9 @@
+ using System.Diagnostics;
+ using System.Threading.RateLimiting;
+ using Application.AI.Common.Interfaces;
++using Application.AI.Common.Interfaces.DriftDetection;
+ using Application.AI.Common.Interfaces.Escalation;
++using Application.AI.Common.Interfaces.Learnings;
+ using Microsoft.AspNetCore.Authentication;
+ using Microsoft.AspNetCore.Authentication.JwtBearer;
+ using Microsoft.AspNetCore.Http;
+@@ -184,6 +186,8 @@ public static class DependencyInjection
+ 
+         services.AddSingleton<IAgUiEventWriterAccessor, AgUiEventWriterAccessor>();
+         services.AddSingleton<IEscalationNotificationChannel, AgUiEscalationNotifier>();
++        services.AddSingleton<IDriftNotificationChannel, AgUiDriftNotifier>();
++        services.AddSingleton<ILearningNotificationChannel, AgUiLearningNotifier>();
+ 
+         // Scoped: AgUiRunHandler takes per-request dependencies (ClaimsPrincipal, CancellationToken).
+         services.AddScoped<AgUi.AgUiRunHandler>();
+diff --git a/src/Content/Presentation/Presentation.Common/Extensions/IServiceCollectionExtensions.cs b/src/Content/Presentation/Presentation.Common/Extensions/IServiceCollectionExtensions.cs
+index df1dedf..5c7e70f 100644
+--- a/src/Content/Presentation/Presentation.Common/Extensions/IServiceCollectionExtensions.cs
++++ b/src/Content/Presentation/Presentation.Common/Extensions/IServiceCollectionExtensions.cs
+@@ -15,6 +15,7 @@ using Domain.Common.Config.Observability;
+ using Infrastructure.AI;
+ using Infrastructure.AI.Connectors;
+ using Infrastructure.AI.Governance;
++using Infrastructure.AI.KnowledgeGraph;
+ using Infrastructure.AI.RAG;
+ using Infrastructure.AI.MCP;
+ using Infrastructure.APIAccess;
+@@ -83,6 +84,10 @@ public static class IServiceCollectionExtensions
+         services.Configure<CacheConfig>(configuration.GetSection("AppConfig:Cache"));
+         services.Configure<EscalationConfig>(configuration.GetSection("AppConfig:AI:Governance:Escalation"));
+         services.Configure<ResilienceConfig>(configuration.GetSection("AppConfig:AI:Resilience"));
++        services.Configure<Domain.Common.Config.AI.DriftDetection.DriftDetectionConfig>(
++            configuration.GetSection("AppConfig:AI:DriftDetection"));
++        services.Configure<Domain.Common.Config.AI.Learnings.LearningsConfig>(
++            configuration.GetSection("AppConfig:AI:Learnings"));
+ 
+         return services;
+     }
+@@ -244,6 +249,7 @@ public static class IServiceCollectionExtensions
+ 
+         // Infrastructure layer
+         services.AddInfrastructureCommonDependencies();
++        services.AddKnowledgeGraphDependencies(appConfig);
+         // RAG must register before Infrastructure.AI — tool registrations depend on IRagOrchestrator
+         services.AddRagDependencies(appConfig);
+         services.AddInfrastructureAIDependencies(appConfig);
+diff --git a/src/Content/Presentation/Presentation.Common/Presentation.Common.csproj b/src/Content/Presentation/Presentation.Common/Presentation.Common.csproj
+index 9ce30e0..7e87909 100644
+--- a/src/Content/Presentation/Presentation.Common/Presentation.Common.csproj
++++ b/src/Content/Presentation/Presentation.Common/Presentation.Common.csproj
+@@ -15,6 +15,7 @@
+     <!-- Infrastructure layer -->
+     <ProjectReference Include="..\..\Infrastructure\Infrastructure.Common\Infrastructure.Common.csproj" />
+     <ProjectReference Include="..\..\Infrastructure\Infrastructure.AI\Infrastructure.AI.csproj" />
++    <ProjectReference Include="..\..\Infrastructure\Infrastructure.AI.KnowledgeGraph\Infrastructure.AI.KnowledgeGraph.csproj" />
+     <ProjectReference Include="..\..\Infrastructure\Infrastructure.AI.Governance\Infrastructure.AI.Governance.csproj" />
+     <ProjectReference Include="..\..\Infrastructure\Infrastructure.AI.RAG\Infrastructure.AI.RAG.csproj" />
+     <ProjectReference Include="..\..\Infrastructure\Infrastructure.AI.Connectors\Infrastructure.AI.Connectors.csproj" />
+diff --git a/src/Content/Tests/Infrastructure.AI.Tests/DependencyInjectionTests.cs b/src/Content/Tests/Infrastructure.AI.Tests/DependencyInjectionTests.cs
+index a8a44d3..ce2a35f 100644
+--- a/src/Content/Tests/Infrastructure.AI.Tests/DependencyInjectionTests.cs
++++ b/src/Content/Tests/Infrastructure.AI.Tests/DependencyInjectionTests.cs
+@@ -6,11 +6,14 @@ using Domain.Common.Config;
+ using Domain.Common.Config.AI.Resilience;
+ using FluentAssertions;
+ using Infrastructure.AI.Escalation;
++using Infrastructure.AI.KnowledgeGraph;
+ using Infrastructure.AI.Resilience;
++using MediatR;
+ using Microsoft.Extensions.DependencyInjection;
+ using Microsoft.Extensions.Hosting;
+ using Microsoft.Extensions.Logging;
+ using Microsoft.Extensions.Options;
++using Moq;
+ using Xunit;
+ 
+ namespace Infrastructure.AI.Tests;
+@@ -24,8 +27,11 @@ public sealed class DependencyInjectionTests
+ 
+         // Register dependencies that Infrastructure.AI expects
+         services.AddLogging(b => b.AddConsole());
++        services.AddSingleton(TimeProvider.System);
+         services.AddSingleton<IOptionsMonitor<AppConfig>>(
+             new OptionsMonitorStub(config));
++        services.AddSingleton<ISender>(new Mock<ISender>().Object);
++        services.AddKnowledgeGraphDependencies(config);
+ 
+         return services;
+     }
+diff --git a/src/Content/Tests/Infrastructure.AI.Tests/DriftLearningsDiTests.cs b/src/Content/Tests/Infrastructure.AI.Tests/DriftLearningsDiTests.cs
+new file mode 100644
+index 0000000..e1cbf03
+--- /dev/null
++++ b/src/Content/Tests/Infrastructure.AI.Tests/DriftLearningsDiTests.cs
+@@ -0,0 +1,233 @@
++using Application.AI.Common.Interfaces.DriftDetection;
++using Application.AI.Common.Interfaces.Escalation;
++using Application.AI.Common.Interfaces.Learnings;
++using MediatR;
++using Domain.Common.Config;
++using Domain.Common.Config.AI;
++using Domain.Common.Config.AI.DriftDetection;
++using Domain.Common.Config.AI.Learnings;
++using FluentAssertions;
++using Infrastructure.AI.DriftDetection;
++using Infrastructure.AI.KnowledgeGraph;
++using Infrastructure.AI.Learnings;
++using Microsoft.Extensions.DependencyInjection;
++using Microsoft.Extensions.Hosting;
++using Microsoft.Extensions.Logging;
++using Microsoft.Extensions.Logging.Abstractions;
++using Microsoft.Extensions.Options;
++using Moq;
++using Xunit;
++
++namespace Infrastructure.AI.Tests;
++
++/// <summary>
++/// DI registration tests for Phase 3 drift detection and learnings services.
++/// Verifies that all services resolve correctly from the container.
++/// </summary>
++public sealed class DriftLearningsDiTests
++{
++    [Fact]
++    public void DriftDetection_Service_Resolves()
++    {
++        var sp = CreateServiceProvider();
++
++        var service = sp.GetService<IDriftDetectionService>();
++
++        service.Should().NotBeNull();
++        service.Should().BeOfType<DefaultDriftDetectionService>();
++    }
++
++    [Fact]
++    public void DriftDetection_KeyedScorer_Resolves_Ewma()
++    {
++        var sp = CreateServiceProvider();
++
++        var scorer = sp.GetRequiredKeyedService<IDriftScorer>("ewma");
++
++        scorer.Should().NotBeNull();
++        scorer.Should().BeOfType<EwmaDriftScorer>();
++    }
++
++    [Fact]
++    public void DriftDetection_BaselineStore_Graph_Resolves()
++    {
++        var sp = CreateServiceProvider();
++
++        var store = sp.GetRequiredKeyedService<IDriftBaselineStore>("graph");
++
++        store.Should().NotBeNull();
++        store.Should().BeOfType<GraphDriftBaselineStore>();
++    }
++
++    [Fact]
++    public void DriftDetection_BaselineStore_InMemory_Resolves()
++    {
++        var sp = CreateServiceProvider();
++
++        var store = sp.GetRequiredKeyedService<IDriftBaselineStore>("in_memory");
++
++        store.Should().NotBeNull();
++        store.Should().BeOfType<InMemoryDriftBaselineStore>();
++    }
++
++    [Fact]
++    public void DriftDetection_BaselineStore_Default_ResolvesGraph()
++    {
++        var sp = CreateServiceProvider();
++
++        var store = sp.GetService<IDriftBaselineStore>();
++
++        store.Should().NotBeNull();
++        store.Should().BeOfType<GraphDriftBaselineStore>();
++    }
++
++    [Fact]
++    public void DriftDetection_AuditStore_Resolves()
++    {
++        var sp = CreateServiceProvider();
++
++        var store = sp.GetService<IDriftAuditStore>();
++
++        store.Should().NotBeNull();
++        store.Should().BeOfType<JsonlDriftAuditStore>();
++    }
++
++    [Fact]
++    public void DriftDetection_Notifier_Resolves()
++    {
++        var sp = CreateServiceProvider();
++
++        var notifier = sp.GetService<IDriftNotifier>();
++
++        notifier.Should().NotBeNull();
++        notifier.Should().BeOfType<CompositeDriftNotifier>();
++    }
++
++    [Fact]
++    public void DriftDetection_EwmaStateStore_Resolves()
++    {
++        var sp = CreateServiceProvider();
++
++        var store = sp.GetService<IEwmaStateStore>();
++
++        store.Should().NotBeNull();
++        store.Should().BeOfType<GraphEwmaStateStore>();
++    }
++
++    [Fact]
++    public void DriftEscalationBridge_RegisteredAsNotificationChannel()
++    {
++        var sp = CreateServiceProvider();
++
++        var channels = sp.GetServices<IEscalationNotificationChannel>().ToList();
++
++        channels.Should().Contain(c => c is DriftEscalationBridge);
++    }
++
++    [Fact]
++    public void Learnings_DecayService_Resolves()
++    {
++        var sp = CreateServiceProvider();
++
++        var service = sp.GetService<ILearningDecayService>();
++
++        service.Should().NotBeNull();
++        service.Should().BeOfType<DefaultLearningDecayService>();
++    }
++
++    [Fact]
++    public void Learnings_DriftBridge_Resolves()
++    {
++        var sp = CreateServiceProvider();
++
++        var bridge = sp.GetService<ILearningsDriftBridge>();
++
++        bridge.Should().NotBeNull();
++        bridge.Should().BeOfType<LearningsDriftBridge>();
++    }
++
++    [Fact]
++    public void LearningsPruningService_RegisteredWhenEnabled()
++    {
++        var sp = CreateServiceProvider(learningsEnabled: true);
++
++        var services = sp.GetServices<IHostedService>().ToList();
++
++        services.Should().Contain(s => s is LearningsPruningBackgroundService);
++    }
++
++    [Fact]
++    public void LearningsPruningService_NotRegisteredWhenDisabled()
++    {
++        var sp = CreateServiceProvider(learningsEnabled: false);
++
++        var services = sp.GetServices<IHostedService>().ToList();
++
++        services.Should().NotContain(s => s is LearningsPruningBackgroundService);
++    }
++
++    [Fact]
++    public void AIConfig_BindsDriftDetectionConfig_Defaults()
++    {
++        var config = new AppConfig();
++
++        config.AI.DriftDetection.Should().NotBeNull();
++        config.AI.DriftDetection.Enabled.Should().BeTrue();
++        config.AI.DriftDetection.EwmaLambda.Should().BeApproximately(0.2, 0.001);
++    }
++
++    [Fact]
++    public void AIConfig_BindsLearningsConfig_Defaults()
++    {
++        var config = new AppConfig();
++
++        config.AI.Learnings.Should().NotBeNull();
++        config.AI.Learnings.Enabled.Should().BeTrue();
++        config.AI.Learnings.StoreProvider.Should().Be("graph");
++        config.AI.Learnings.BaselineAdjustmentThreshold.Should().BeApproximately(0.8, 0.001);
++    }
++
++    private static ServiceProvider CreateServiceProvider(bool learningsEnabled = true)
++    {
++        var appConfig = new AppConfig
++        {
++            AI = new AIConfig
++            {
++                DriftDetection = new DriftDetectionConfig(),
++                Learnings = new LearningsConfig { Enabled = learningsEnabled }
++            }
++        };
++
++        var services = new ServiceCollection();
++        services.AddOptions();
++        services.AddSingleton(TimeProvider.System);
++        services.AddSingleton(NullLoggerFactory.Instance);
++        services.AddSingleton(typeof(ILogger<>), typeof(NullLogger<>));
++        services.AddSingleton<IOptionsMonitor<AppConfig>>(new OptionsMonitorStub(appConfig));
++        services.AddSingleton<IOptionsMonitor<LearningsConfig>>(
++            new LearningsConfigMonitorStub(appConfig.AI.Learnings));
++        services.AddSingleton<ISender>(new Mock<ISender>().Object);
++
++        // Register knowledge graph (provides IKnowledgeGraphStore for graph-backed stores)
++        services.AddKnowledgeGraphDependencies(appConfig);
++
++        // Register Infrastructure.AI services (drift, learnings, escalation, etc.)
++        services.AddInfrastructureAIDependencies(appConfig);
++
++        return services.BuildServiceProvider();
++    }
++
++    private sealed class OptionsMonitorStub(AppConfig config) : IOptionsMonitor<AppConfig>
++    {
++        public AppConfig CurrentValue => config;
++        public AppConfig Get(string? name) => config;
++        public IDisposable? OnChange(Action<AppConfig, string?> listener) => null;
++    }
++
++    private sealed class LearningsConfigMonitorStub(LearningsConfig config) : IOptionsMonitor<LearningsConfig>
++    {
++        public LearningsConfig CurrentValue => config;
++        public LearningsConfig Get(string? name) => config;
++        public IDisposable? OnChange(Action<LearningsConfig, string?> listener) => null;
++    }
++}
+diff --git a/src/Content/Tests/Infrastructure.AI.Tests/Infrastructure.AI.Tests.csproj b/src/Content/Tests/Infrastructure.AI.Tests/Infrastructure.AI.Tests.csproj
+index 52b5326..9f9e258 100644
+--- a/src/Content/Tests/Infrastructure.AI.Tests/Infrastructure.AI.Tests.csproj
++++ b/src/Content/Tests/Infrastructure.AI.Tests/Infrastructure.AI.Tests.csproj
+@@ -25,6 +25,7 @@
+ 
+   <ItemGroup>
+     <ProjectReference Include="../../Infrastructure/Infrastructure.AI/Infrastructure.AI.csproj" />
++    <ProjectReference Include="../../Infrastructure/Infrastructure.AI.KnowledgeGraph/Infrastructure.AI.KnowledgeGraph.csproj" />
+     <ProjectReference Include="../../Infrastructure/Infrastructure.AI.MCP/Infrastructure.AI.MCP.csproj" />
+     <ProjectReference Include="../../Application/Application.AI.Common/Application.AI.Common.csproj" />
+     <ProjectReference Include="../../Application/Application.Core/Application.Core.csproj" />

--- a/planning/phase3-quality-loop/implementation/code_review/section-18-interview.md
+++ b/planning/phase3-quality-loop/implementation/code_review/section-18-interview.md
@@ -1,0 +1,24 @@
+# Section 18 — Code Review Interview
+
+## Review Verdict: WARNING (no CRITICAL/HIGH)
+
+## Findings Triage
+
+### Auto-Fixed (applied without interview)
+
+1. **MEDIUM: Hardcoded default baseline store provider** (`DependencyInjection.cs:316`)
+   - Added documenting comment explaining why graph is always the default
+   - Drift baselines require persistent storage for EWMA continuity — in-memory is only for testing keyed resolution
+   - Unlike ILearningsStore which has a config-driven StoreProvider, DriftDetectionConfig has no BaselineProvider property by design
+
+### Let Go
+
+2. **LOW: OptionsMonitorStub duplication** — Pre-existing pattern across 4+ test files. Refactoring test helpers is out of scope for this section.
+
+3. **LOW: DependencyInjection.cs at 400 lines** — Well-structured with private helper methods. The file is at the soft limit but readability is maintained through method extraction.
+
+## Test Results After Fixes
+
+- DriftLearningsDiTests: 15/15 passed
+- DependencyInjectionTests: 13/13 passed (regressions fixed)
+- Total: 28/28 passed

--- a/planning/phase3-quality-loop/implementation/code_review/section-18-review.md
+++ b/planning/phase3-quality-loop/implementation/code_review/section-18-review.md
@@ -1,0 +1,26 @@
+# Section 18 — Code Review
+
+## Verdict: WARNING (no CRITICAL/HIGH)
+
+### MEDIUM: Hardcoded default baseline store provider
+- `Infrastructure.AI/DependencyInjection.cs:316-317` — IDriftBaselineStore default hardcoded to "graph"
+- Inconsistent with ILearningsStore (resolves from config) and IKnowledgeGraphStore (resolves from config)
+- DriftDetectionConfig has no BaselineProvider property
+
+### LOW: OptionsMonitorStub duplicated 4 times across test files
+- Pre-existing pattern, this diff adds one more instance
+- Suggestion: extract to shared TestHelpers
+
+### LOW: Infrastructure.AI/DependencyInjection.cs at 400 lines
+- At the soft limit, well-structured with helper methods
+- One more subsystem would push past
+
+### Verified — No Issues
+- All 9 constructor parameter orders correct
+- Composition root ordering correct (KnowledgeGraph → RAG → Infrastructure.AI)
+- Conditional registration follows existing patterns
+- Config bindings match existing pattern
+- Keyed DI pattern consistent with KnowledgeGraph
+- TimeProvider fallback pattern consistent
+- Test coverage: 15 resolution tests
+- No security issues

--- a/planning/phase3-quality-loop/implementation/deep_implement_config.json
+++ b/planning/phase3-quality-loop/implementation/deep_implement_config.json
@@ -88,6 +88,14 @@
     "section-15-learnings-sse": {
       "status": "complete",
       "commit_hash": "204ead3"
+    },
+    "section-16-escalation-bridge": {
+      "status": "complete",
+      "commit_hash": "474400c"
+    },
+    "section-17-learnings-bridge": {
+      "status": "complete",
+      "commit_hash": "4b8197a"
     }
   },
   "pre_commit": {

--- a/planning/phase3-quality-loop/implementation/deep_implement_config.json
+++ b/planning/phase3-quality-loop/implementation/deep_implement_config.json
@@ -84,6 +84,10 @@
     "section-14-drift-sse": {
       "status": "complete",
       "commit_hash": "5f0fb94"
+    },
+    "section-15-learnings-sse": {
+      "status": "complete",
+      "commit_hash": "204ead3"
     }
   },
   "pre_commit": {

--- a/planning/phase3-quality-loop/implementation/deep_implement_config.json
+++ b/planning/phase3-quality-loop/implementation/deep_implement_config.json
@@ -76,6 +76,14 @@
     "section-12-learnings-store": {
       "status": "complete",
       "commit_hash": "bbad49f"
+    },
+    "section-13-command-handlers": {
+      "status": "complete",
+      "commit_hash": "c7f1a9c"
+    },
+    "section-14-drift-sse": {
+      "status": "complete",
+      "commit_hash": "5f0fb94"
     }
   },
   "pre_commit": {

--- a/planning/phase3-quality-loop/sections/section-13-command-handlers.md
+++ b/planning/phase3-quality-loop/sections/section-13-command-handlers.md
@@ -601,3 +601,43 @@ public static class LearningsMetrics
 - `TimeProvider` injected everywhere — never use `DateTimeOffset.UtcNow` directly.
 - Namespace: `Application.Core.CQRS.Learnings` for handlers, `Application.AI.Common.OpenTelemetry.Metrics` for metrics, `Domain.AI.Telemetry.Conventions` for conventions.
 - XML docs on all public types and methods — this is a template, docs are teaching material.
+
+---
+
+## Actual Implementation Notes
+
+**Status:** Complete. Build green, 59 tests pass (34 new + 25 pre-existing).
+
+### Deviations from Plan
+
+| # | Planned | Actual | Rationale |
+|---|---------|--------|-----------|
+| 1 | Sequential embedding in RecallQueryHandler (foreach loop) | Parallel embedding via `Task.WhenAll` | Code review fix — O(n) sequential API calls replaced with parallel for performance |
+| 2 | MinRelevance filter after diversity injection (step 10) | MinRelevance filter BEFORE diversity injection | Code review fix — filtering after diversity could remove injected diversity picks that were below threshold, defeating the purpose |
+| 3 | Bare `_ = _mediator.Send(...)` fire-and-forget | Wrapped in `RecordAccessSafeAsync` helper with try/catch | Code review fix — unhandled exceptions in fire-and-forget would crash the process |
+| 4 | ImproveLearningCommandHandler disabled returns `default!` | Returns `CreateDisabledPlaceholder(request.LearningId)` with valid `LearningEntry` | Code review fix — null return violated caller expectations; matches RememberHandler pattern |
+| 5 | RecordLearningAccessCommandHandler ignores UpdateAsync result | Logs UpdateAsync failures at Warning level | Code review fix — silent failures hid store errors |
+| 6 | Baseline adjustment threshold signaling in ImproveLearningCommandHandler (step 8) | Deferred — handler returns updated entry, section-17 bridge checks threshold | Keeps handler focused on EMA; bridge owns cross-concern coordination |
+| 7 | `CosineSimilarity` and `ApplyDiversityInjection` as `private static` | Made `internal static` | Enables direct unit testing without going through full handler pipeline |
+
+### Additional Changes Not in Plan
+
+- `Application.Core.Tests.csproj`: Added `<PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />` for `FakeTimeProvider`
+- All test files use a shared helper pattern: `CreateOptions(LearningsConfig)` wrapping `Mock<IOptionsMonitor<AppConfig>>`
+
+### Test Coverage
+
+| Test File | Test Count |
+|-----------|-----------|
+| RememberCommandHandlerTests | 7 |
+| RecallQueryHandlerTests | 7 |
+| ForgetCommandHandlerTests | 3 |
+| ImproveLearningCommandHandlerTests | 8 |
+| RecordLearningAccessCommandHandlerTests | 3 |
+| LearningsMetricsTests | 6 |
+| **Total new tests** | **34** |
+
+### Code Review Trail
+
+- Review: `planning/phase3-quality-loop/implementation/code_review/section-13-review.md`
+- Interview: `planning/phase3-quality-loop/implementation/code_review/section-13-interview.md`

--- a/planning/phase3-quality-loop/sections/section-14-drift-sse.md
+++ b/planning/phase3-quality-loop/sections/section-14-drift-sse.md
@@ -271,3 +271,39 @@ dotnet test src/Content/Tests/Presentation.AgentHub.Tests/Presentation.AgentHub.
 ```
 
 All 7 tests should pass. The notifier depends on `IDriftNotificationChannel` (section 05) and domain types (section 01) being available at compile time. If those sections are not yet implemented, create minimal stub interfaces/records to unblock compilation, or implement this section after sections 01 and 05 are complete.
+
+---
+
+## Actual Implementation Notes
+
+**Status:** Complete. Build green, 12 tests pass.
+
+### Deviations from Plan
+
+| # | Planned | Actual | Rationale |
+|---|---------|--------|-----------|
+| 1 | Plan specified 7 tests | 12 tests implemented | Code review identified 3 missing coverage areas: OperationCanceledException propagation, null-writer for resolved path, writer-throws for resolved path |
+| 2 | `MapToEvent` allocated Dictionary before severity switch | Early return for `DriftSeverity.None` before allocation | Code review fix — avoided wasted allocation for the no-drift case |
+| 3 | Plan mentioned DriftEscalateEvent with optional EscalationId | Used `string.Empty` sentinel as default | Matches plan's "simplest approach" — clients correlate with escalation-requested events by timestamp and scope |
+
+### Test Coverage
+
+| Test | Description |
+|------|-------------|
+| NotifyDriftDetectedAsync_WarnSeverity_WritesDriftWarnEvent | Warn → DriftWarnEvent with correct fields |
+| NotifyDriftDetectedAsync_AlertSeverity_WritesDriftAlertEvent | Alert → DriftAlertEvent with BaselineId |
+| NotifyDriftDetectedAsync_EscalateSeverity_WritesDriftEscalateEvent | Escalate → DriftEscalateEvent with empty EscalationId |
+| NotifyDriftDetectedAsync_NoneSeverity_DoesNotWrite | None → no SSE event emitted |
+| NotifyDriftResolvedAsync_WritesDriftResolvedEvent | Resolved drift → DriftResolvedEvent with resolution details |
+| NotifyDriftResolvedAsync_NullResolution_DoesNotWrite | Unresolved drift → no event |
+| NotifyDriftDetectedAsync_NoWriter_SilentlyReturns | No active run → silent no-op |
+| NotifyDriftDetectedAsync_WriterThrows_CatchesAndDoesNotThrow | Non-cancellation exception → caught |
+| NotifyDriftDetectedAsync_DimensionsMapCorrectly | Enum→string keys, Deviation values |
+| NotifyDriftDetectedAsync_OperationCanceledException_Propagates | Cancellation → propagates (not swallowed) |
+| NotifyDriftResolvedAsync_NoWriter_SilentlyReturns | No active run for resolved path |
+| NotifyDriftResolvedAsync_WriterThrows_CatchesAndDoesNotThrow | Exception handling for resolved path |
+
+### Code Review Trail
+
+- Review: `planning/phase3-quality-loop/implementation/code_review/section-14-review.md`
+- Interview: `planning/phase3-quality-loop/implementation/code_review/section-14-interview.md`

--- a/planning/phase3-quality-loop/sections/section-15-learnings-sse.md
+++ b/planning/phase3-quality-loop/sections/section-15-learnings-sse.md
@@ -340,7 +340,14 @@ After implementation, run:
 
 ```powershell
 dotnet build src/Content/Presentation/Presentation.AgentHub/Presentation.AgentHub.csproj
-dotnet test src/Content/Tests/Presentation.AgentHub.Tests/Presentation.AgentHub.Tests.csproj --filter "FullyQualifiedName~AgUiLearningNotifier or FullyQualifiedName~AgUiLearningEventSerialization"
+dotnet test src/Content/Tests/Presentation.AgentHub.Tests/Presentation.AgentHub.Tests.csproj --filter "FullyQualifiedName~AgUiLearningNotifier|FullyQualifiedName~AgUiLearningEventSerialization"
 ```
 
-All 11 tests (6 notifier + 5 serialization) should pass. The notifier depends on `ILearningNotificationChannel` (section 06) and domain types (section 02) being available at compile time. If those sections are not yet implemented, create minimal stub interfaces/records to unblock compilation, or implement this section after sections 02 and 06 are complete.
+All 16 tests (9 notifier + 7 serialization) should pass. Notifier depends on `ILearningNotificationChannel` (section 06) and domain types (section 02).
+
+## Implementation Notes
+
+- **Tests added beyond spec**: Code review identified 3 test gaps (OperationCanceledException propagation for Applied path, round-trip deserialization for Applied and Forgotten events). Total: 16 tests vs. planned 11.
+- **Filter syntax**: dotnet test uses `|` not `or` for filter disjunction.
+- **AgUiEvents.cs at 382 lines**: Approaching 400-line limit. Plan to split into partial classes before Phase 4 adds more event types.
+- **DI registration**: Not included in this section — covered by section 18.

--- a/planning/phase3-quality-loop/sections/section-16-escalation-bridge.md
+++ b/planning/phase3-quality-loop/sections/section-16-escalation-bridge.md
@@ -240,8 +240,15 @@ Note: The full DI registration is handled in Section 18, but the bridge class it
 
 2. **Escalation resolved before requested notification:** In the composite fan-out, `NotifyEscalationRequestedAsync` fires before `NotifyEscalationResolvedAsync` (the escalation service calls `RecordAndNotifyRequestAsync` during creation and `ResolveEscalationAsync` during resolution). So the tracking dictionary will always be populated before resolution fires.
 
-3. **Memory leak from unresolved escalations:** If an escalation is requested but never resolved (process crash), the tracked request stays in the dictionary. Since escalations have timeouts (default 300s), this is bounded. For production hardening, a periodic cleanup of entries older than max timeout could be added, but is not required for this implementation.
+3. **Memory leak from unresolved escalations:** Addressed: `NotifyEscalationExpiringAsync` now removes tracked entries when escalations expire, preventing unbounded dictionary growth.
 
-4. **Circular dependency prevention:** The bridge injects `IDriftDetectionService` and `ISender`. The drift detection service does NOT inject the bridge. The escalation flow is: DriftService -> IEscalationService -> CompositeNotifier -> DriftEscalationBridge -> IDriftDetectionService (for resolution). This is a callback-style cycle through the notification system, not a constructor injection cycle. DI resolves correctly because all are singletons and the bridge never calls back into the escalation path.
+4. **Circular dependency prevention:** The bridge injects `IDriftNotifier` (not `IDriftDetectionService` — the service has no resolution method) and `ISender`. The escalation flow is: DriftService -> IEscalationService -> CompositeNotifier -> DriftEscalationBridge -> IDriftNotifier (for resolution notification). DI resolves correctly because all are singletons and the bridge never calls back into the escalation path.
+
+## Implementation Notes
+
+- **IDriftNotifier instead of IDriftDetectionService**: The spec called for `IDriftDetectionService` but that interface has no drift resolution method. The bridge uses `IDriftNotifier` to fan out resolution notifications (e.g., to AgUiDriftNotifier for SSE events).
+- **Synthetic DriftEvent**: The bridge builds a minimal `DriftEvent` for notifications. `AgUiDriftNotifier` only reads `EventId`, `Resolution.*` fields, so the minimal `DriftScore` is sufficient.
+- **Confidence constant**: `EscalationResolutionConfidence = 0.8` extracted to named constant per code review.
+- **13 tests**: 12 original + 1 expiring-cleanup test added during review.
 
 5. **Constant sharing:** `DriftEscalationBridge.DriftDetectionToolName` is the single source of truth for the `"drift_detection"` tool name convention. `DefaultDriftDetectionService` (Section 8) should reference this constant when building escalation requests rather than using a string literal.

--- a/planning/phase3-quality-loop/sections/section-17-learnings-bridge.md
+++ b/planning/phase3-quality-loop/sections/section-17-learnings-bridge.md
@@ -333,15 +333,24 @@ From `DriftDetectionConfig` (section-03):
 
 ---
 
-## Implementation Checklist
+## Implementation Checklist (Completed)
 
-1. Create test file `src/Content/Tests/Infrastructure.AI.Tests/Learnings/LearningsDriftBridgeTests.cs` with all test stubs
-2. Create interface `src/Content/Application/Application.AI.Common/Interfaces/Learnings/ILearningsDriftBridge.cs`
-3. Create implementation `src/Content/Infrastructure/Infrastructure.AI/Learnings/LearningsDriftBridge.cs`
-4. Modify `src/Content/Application/Application.Core/CQRS/Learnings/ImproveLearningCommandHandler.cs` to inject and call the bridge
-5. Update handler test file `src/Content/Tests/Application.Core.Tests/CQRS/Learnings/ImproveLearningCommandHandlerTests.cs` to verify bridge integration (add test: `Handle_AboveThreshold_DriftSource_CallsBridge`, `Handle_BelowThreshold_DoesNotCallBridge`)
-6. Verify build: `dotnet build src/AgenticHarness.slnx`
-7. Run tests: `dotnet test src/AgenticHarness.slnx`
+1. [x] Created test file `src/Content/Tests/Infrastructure.AI.Tests/Learnings/LearningsDriftBridgeTests.cs` — 12 tests
+2. [x] Created interface `src/Content/Application/Application.AI.Common/Interfaces/Learnings/ILearningsDriftBridge.cs`
+3. [x] Created implementation `src/Content/Infrastructure/Infrastructure.AI/Learnings/LearningsDriftBridge.cs`
+4. [x] Modified `src/Content/Application/Application.Core/CQRS/Learnings/ImproveLearningCommandHandler.cs` — added `ILearningsDriftBridge` injection + call
+5. [x] Updated `src/Content/Tests/Application.Core.Tests/CQRS/Learnings/ImproveLearningCommandHandlerTests.cs` — 3 new tests (`Handle_SuccessfulUpdate_CallsBridge`, `Handle_BridgeFailure_StillReturnsSuccess`, `Handle_Disabled_DoesNotCallBridge`)
+6. [x] Build verified: `dotnet build src/AgenticHarness.slnx` — 0 errors
+7. [x] Tests verified: 23/23 passed (12 bridge + 11 handler)
+
+## Deviations from Plan
+
+1. **DriftScope enum**: Plan referenced `DriftScope.Task` and `DriftScope.Global` — actual enum values are `Agent`, `Skill`, `TaskType`. Tests adjusted.
+2. **Defensive parsing**: Code review identified unguarded `Enum.Parse` on graph node properties. Changed to `TryParse`/`TryGetValue` with graceful no-op on corruption. Matches section-16 pattern.
+3. **Post-baseline try/catch**: Code review identified missing exception guard around audit+resolution side effects. Added `try/catch (Exception ex) when (ex is not OperationCanceledException)` — matches DriftEscalationBridge.
+4. **JsonStringEnumConverter**: Added for serialized Resolution data readability (default System.Text.Json serializes enums as numbers).
+5. **Additional test**: `CheckAndAdjustBaselineAsync_CorruptedNodeScope_ReturnsSuccess` added for corrupted graph node edge case.
+6. **Handler tests**: Plan suggested `Handle_AboveThreshold_DriftSource_CallsBridge` and `Handle_BelowThreshold_DoesNotCallBridge`. Actual tests: `Handle_SuccessfulUpdate_CallsBridge`, `Handle_BridgeFailure_StillReturnsSuccess`, `Handle_Disabled_DoesNotCallBridge` — better coverage of the handler's responsibility (calling bridge, tolerating failure).
 
 ## Conventions
 

--- a/planning/phase3-quality-loop/sections/section-18-di-registration.md
+++ b/planning/phase3-quality-loop/sections/section-18-di-registration.md
@@ -268,16 +268,38 @@ MediatR command handlers (`RememberCommandHandler`, `RecallQueryHandler`, etc. f
 
 Verify that the assembly containing the command handlers (`Application.Core`) is already scanned. Check `Application.Core/DependencyInjection.cs` for the MediatR assembly registration.
 
-## File Summary
+## Actual Implementation
+
+### Deviations from Plan
+
+1. **AIConfig.cs already had DriftDetection and Learnings properties** — Added in sections 03-04. Step 1 (Update AIConfig.cs) was skipped entirely.
+
+2. **Config section bindings pulled forward from section-19** — `Configure<DriftDetectionConfig>` and `Configure<LearningsConfig>` were added to `RegisterConfigSections` in this section because `DefaultLearningDecayService` takes `IOptionsMonitor<LearningsConfig>` (not `IOptionsMonitor<AppConfig>`). Section-19 can skip these bindings.
+
+3. **Existing DependencyInjectionTests required updates** — The new drift/learnings registrations introduced transitive dependencies (`ISender` for `DriftEscalationBridge`, `TimeProvider`, `IKnowledgeGraphStore`) that the existing test helper didn't provide. Fixed by adding `TimeProvider.System`, `Mock<ISender>`, and `AddKnowledgeGraphDependencies` to `CreateBaseServices`.
+
+4. **Hardcoded baseline store default** — Unlike `ILearningsStore` which resolves from `LearningsConfig.StoreProvider`, `IDriftBaselineStore` defaults to `"graph"` because `DriftDetectionConfig` has no `BaselineProvider` property. Documented with a comment explaining EWMA continuity requires persistent storage.
+
+5. **Project references added** — `Presentation.Common.csproj` and `Infrastructure.AI.Tests.csproj` both needed `Infrastructure.AI.KnowledgeGraph` project references for the `AddKnowledgeGraphDependencies` extension method.
+
+### Files Created/Modified
 
 | File | Action |
 |------|--------|
-| `src/Content/Domain/Domain.Common/Config/AI/AIConfig.cs` | Add `DriftDetection` and `Learnings` properties |
-| `src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.cs` | Add `RegisterDriftDetectionServices` + `RegisterLearningsServices`, add `DriftEscalationBridge` to escalation channels |
-| `src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/DependencyInjection.cs` | Add keyed `ILearningsStore` registrations |
-| `src/Content/Presentation/Presentation.AgentHub/DependencyInjection.cs` | Add `AgUiDriftNotifier` and `AgUiLearningNotifier` |
-| `src/Content/Presentation/Presentation.Common/Extensions/IServiceCollectionExtensions.cs` | Ensure `AddKnowledgeGraphDependencies` is called (if not already) |
-| `src/Content/Tests/Infrastructure.AI.Tests/DriftLearningsDiTests.cs` | New test class with all DI resolution tests |
+| `src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.cs` | Added `RegisterDriftDetectionServices` + `RegisterLearningsServices`, added `DriftEscalationBridge` to escalation channels |
+| `src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/DependencyInjection.cs` | Added keyed `ILearningsStore` registrations ("graph"/"in_memory" + config-driven default) |
+| `src/Content/Presentation/Presentation.AgentHub/DependencyInjection.cs` | Added `AgUiDriftNotifier` and `AgUiLearningNotifier` channel registrations |
+| `src/Content/Presentation/Presentation.Common/Extensions/IServiceCollectionExtensions.cs` | Added `AddKnowledgeGraphDependencies` to composition root + `Configure<DriftDetectionConfig>`/`Configure<LearningsConfig>` section bindings |
+| `src/Content/Presentation/Presentation.Common/Presentation.Common.csproj` | Added project reference to Infrastructure.AI.KnowledgeGraph |
+| `src/Content/Tests/Infrastructure.AI.Tests/DriftLearningsDiTests.cs` | New: 15 DI resolution tests |
+| `src/Content/Tests/Infrastructure.AI.Tests/DependencyInjectionTests.cs` | Updated: added TimeProvider, ISender mock, KnowledgeGraph deps to test helper |
+| `src/Content/Tests/Infrastructure.AI.Tests/Infrastructure.AI.Tests.csproj` | Added project reference to Infrastructure.AI.KnowledgeGraph |
+
+### Test Results
+
+- DriftLearningsDiTests: 15/15 passed
+- DependencyInjectionTests: 13/13 passed (no regressions)
+- Total new + regression-verified: 28/28 passed
 
 ## Key Patterns to Follow
 

--- a/planning/phase3-quality-loop/sections/section-19-appsettings.md
+++ b/planning/phase3-quality-loop/sections/section-19-appsettings.md
@@ -4,7 +4,7 @@
 
 This section adds `DriftDetection` and `Learnings` JSON config blocks to both `appsettings.json` files (`Presentation.AgentHub` and `Presentation.ConsoleUI`). These blocks provide concrete values for the config POCOs defined in section-03 (`DriftDetectionConfig`) and section-04 (`LearningsConfig`), which bind automatically through the .NET Options pattern.
 
-No C# code changes are needed beyond the JSON edits and two new `services.Configure<T>()` lines in the shared config registration method.
+No C# code changes are needed beyond the JSON edits — the two `services.Configure<T>()` lines were already added in section 18 (DI registration).
 
 ## Dependencies
 
@@ -18,8 +18,8 @@ No C# code changes are needed beyond the JSON edits and two new `services.Config
 |------|--------|
 | `src/Content/Presentation/Presentation.AgentHub/appsettings.json` | Add `DriftDetection` and `Learnings` blocks under `AppConfig.AI` |
 | `src/Content/Presentation/Presentation.ConsoleUI/appsettings.json` | Add `DriftDetection` and `Learnings` blocks under `AppConfig.AI` |
-| `src/Content/Presentation/Presentation.Common/Extensions/IServiceCollectionExtensions.cs` | Add two `services.Configure<>()` lines for direct injection |
-| `src/Content/Tests/Presentation.Common.Tests/Extensions/IServiceCollectionExtensionsTests.cs` | Add config binding tests |
+| `src/Content/Presentation/Presentation.Common/Extensions/IServiceCollectionExtensions.cs` | Already done in section 18 — no changes needed |
+| `src/Content/Tests/Presentation.Common.Tests/Extensions/IServiceCollectionExtensionsTests.cs` | Add 4 config binding tests |
 
 ---
 
@@ -145,6 +145,7 @@ Design notes:
 - `PruneIntervalHours: 24` -- the `LearningsPruningBackgroundService` (section 11) runs once per day.
 - `BaselineAdjustmentThreshold: 0.8` -- when a learning's `FeedbackWeight` exceeds this value, it signals that the drift baseline should be adjusted (section 17 integration). High threshold ensures only well-validated learnings trigger baseline changes.
 - `BiasCorrection: true` -- applies bias-corrected EMA for learnings with fewer than 5 updates, preventing early feedback scores from being overweighted.
+- `DecayBiasAlpha: 0.25` -- bias correction alpha for the decay EMA calculation. Added to match the `LearningsConfig.DecayBiasAlpha` property defined in section 04.
 
 ### Placement in JSON
 
@@ -197,3 +198,9 @@ dotnet test src/Content/Tests/Presentation.Common.Tests/Presentation.Common.Test
 ```
 
 Expected: all existing config binding tests continue passing, plus the 4 new tests (`DriftDetectionConfig_BindsFromAppsettings`, `LearningsConfig_BindsFromAppsettings`, `RegisterConfigSections_BindsDriftDetectionConfig`, `RegisterConfigSections_BindsLearningsConfig`) pass.
+
+## Implementation Notes
+
+- The `services.Configure<DriftDetectionConfig>()` and `services.Configure<LearningsConfig>()` calls were already added in section 18 (DI registration), so no changes to `IServiceCollectionExtensions.cs` were needed in this section.
+- `DecayBiasAlpha` property exists on `LearningsConfig` (added in section 04) but was not in the original plan for this section. Added to JSON blocks and tests for completeness.
+- All 18 tests pass (14 existing + 4 new).

--- a/planning/phase3-quality-loop/sections/section-20-verification.md
+++ b/planning/phase3-quality-loop/sections/section-20-verification.md
@@ -183,6 +183,18 @@ Tests are created as part of the TDD workflow in each section (sections 1-19). T
 
 The actual count may vary based on implementation decisions made during the TDD cycle in each section. The important criteria are: all tests pass, no regressions, and 80%+ coverage on new code.
 
+## Verification Results (Actual)
+
+**Build:** 0 errors, 153 warnings (all pre-existing)
+
+**Full test suite:** 4,282 tests across 17 assemblies
+- Passed: 4,263
+- Failed: 19 (all pre-existing)
+  - 9 AgentFactoryTests (Application.AI.Common.Tests) — pre-existing
+  - 9 MetricsE2E (Presentation.AgentHub.Tests) — requires Docker
+  - 1 PollyProviderHealthMonitorTests (Infrastructure.AI.Tests) — flaky concurrency assertion
+- Phase 3 regressions: **0**
+
 ---
 
 ## Regression Checklist

--- a/src/Content/Application/Application.AI.Common/Interfaces/Learnings/ILearningsDriftBridge.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Learnings/ILearningsDriftBridge.cs
@@ -1,0 +1,33 @@
+using Domain.AI.Learnings;
+using Domain.Common;
+
+namespace Application.AI.Common.Interfaces.Learnings;
+
+/// <summary>
+/// Bridge that adjusts drift baselines when high-confidence learnings originating
+/// from drift events receive sufficient positive feedback.
+/// </summary>
+/// <remarks>
+/// Called by <c>ImproveLearningCommandHandler</c> after updating a learning's feedback weight.
+/// The bridge checks whether the learning meets the criteria for baseline adjustment:
+/// <list type="number">
+///   <item>Learning's <c>Source.SourceType</c> is <c>DriftDetection</c></item>
+///   <item>Learning's <c>FeedbackWeight</c> exceeds <c>LearningsConfig.BaselineAdjustmentThreshold</c></item>
+/// </list>
+/// If both conditions are met, the bridge triggers a drift baseline update for the affected scope
+/// and resolves the originating drift event.
+/// </remarks>
+public interface ILearningsDriftBridge
+{
+    /// <summary>
+    /// Checks whether the given learning qualifies for drift baseline adjustment
+    /// and, if so, orchestrates the update, audit, and resolution.
+    /// </summary>
+    /// <param name="learning">The learning entry after feedback weight update.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>
+    /// Success if adjustment was performed or was not needed.
+    /// Failure if the baseline update itself failed.
+    /// </returns>
+    Task<Result> CheckAndAdjustBaselineAsync(LearningEntry learning, CancellationToken ct);
+}

--- a/src/Content/Application/Application.AI.Common/OpenTelemetry/Metrics/LearningsMetrics.cs
+++ b/src/Content/Application/Application.AI.Common/OpenTelemetry/Metrics/LearningsMetrics.cs
@@ -1,0 +1,40 @@
+using System.Diagnostics.Metrics;
+using Domain.AI.Telemetry.Conventions;
+using Domain.Common.Telemetry;
+
+namespace Application.AI.Common.OpenTelemetry.Metrics;
+
+/// <summary>
+/// OTel metric instruments for the learnings subsystem.
+/// Recorded by command handlers on remember, recall, forget, improve, and prune operations.
+/// </summary>
+/// <remarks>
+/// Pruned counter is recorded by <c>LearningPruningBackgroundService</c> (Section 11).
+/// All other counters are recorded by their respective CQRS handlers (Section 13).
+/// </remarks>
+public static class LearningsMetrics
+{
+    /// <summary>Learnings captured. Tags: category, scope.</summary>
+    public static Counter<long> Remembered { get; } =
+        AppInstrument.Meter.CreateCounter<long>(LearningConventions.Remembered, "{learning}", "Learnings remembered");
+
+    /// <summary>Learnings recalled.</summary>
+    public static Counter<long> Recalled { get; } =
+        AppInstrument.Meter.CreateCounter<long>(LearningConventions.Recalled, "{learning}", "Learnings recalled");
+
+    /// <summary>Learnings soft-deleted.</summary>
+    public static Counter<long> Forgotten { get; } =
+        AppInstrument.Meter.CreateCounter<long>(LearningConventions.Forgotten, "{learning}", "Learnings forgotten");
+
+    /// <summary>Learnings feedback-improved.</summary>
+    public static Counter<long> Improved { get; } =
+        AppInstrument.Meter.CreateCounter<long>(LearningConventions.Improved, "{learning}", "Learnings improved");
+
+    /// <summary>Expired learnings pruned by background service.</summary>
+    public static Counter<long> Pruned { get; } =
+        AppInstrument.Meter.CreateCounter<long>(LearningConventions.Pruned, "{learning}", "Learnings pruned");
+
+    /// <summary>Recall pipeline duration histogram.</summary>
+    public static Histogram<double> RecallDurationMs { get; } =
+        AppInstrument.Meter.CreateHistogram<double>(LearningConventions.RecallDurationMs, "ms", "Recall query duration");
+}

--- a/src/Content/Application/Application.Core/CQRS/Learnings/ForgetCommandHandler.cs
+++ b/src/Content/Application/Application.Core/CQRS/Learnings/ForgetCommandHandler.cs
@@ -1,0 +1,47 @@
+using Application.AI.Common.Interfaces.Learnings;
+using Application.AI.Common.OpenTelemetry.Metrics;
+using Domain.Common;
+using Domain.Common.Config;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Application.Core.CQRS.Learnings;
+
+/// <summary>
+/// Soft-deletes a learning entry from the store with an audit reason.
+/// </summary>
+public sealed class ForgetCommandHandler : IRequestHandler<ForgetCommand, Result>
+{
+    private readonly ILearningsStore _store;
+    private readonly IOptionsMonitor<AppConfig> _options;
+    private readonly ILogger<ForgetCommandHandler> _logger;
+
+    /// <summary>Initializes a new instance of the <see cref="ForgetCommandHandler"/> class.</summary>
+    public ForgetCommandHandler(
+        ILearningsStore store,
+        IOptionsMonitor<AppConfig> options,
+        ILogger<ForgetCommandHandler> logger)
+    {
+        _store = store;
+        _options = options;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<Result> Handle(ForgetCommand request, CancellationToken cancellationToken)
+    {
+        if (!_options.CurrentValue.AI.Learnings.Enabled)
+        {
+            _logger.LogDebug("Learnings subsystem disabled, skipping forget");
+            return Result.Success();
+        }
+
+        var result = await _store.SoftDeleteAsync(request.LearningId, request.Reason, cancellationToken);
+        if (!result.IsSuccess)
+            return result;
+
+        LearningsMetrics.Forgotten.Add(1);
+        return Result.Success();
+    }
+}

--- a/src/Content/Application/Application.Core/CQRS/Learnings/ImproveLearningCommandHandler.cs
+++ b/src/Content/Application/Application.Core/CQRS/Learnings/ImproveLearningCommandHandler.cs
@@ -1,0 +1,107 @@
+using Application.AI.Common.Interfaces.Learnings;
+using Application.AI.Common.OpenTelemetry.Metrics;
+using Domain.AI.Learnings;
+using Domain.Common;
+using Domain.Common.Config;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Application.Core.CQRS.Learnings;
+
+/// <summary>
+/// Updates a learning's feedback weight using exponential moving average (EMA)
+/// with optional bias correction for early updates.
+/// </summary>
+/// <remarks>
+/// <para>EMA formula: <c>newWeight = alpha * normalized + (1 - alpha) * currentWeight</c></para>
+/// <para>Bias correction (first 5 updates): <c>corrected = weight / (1 - (1 - alpha)^updateCount)</c></para>
+/// <para>The updated entry is returned to callers. The section-17 bridge inspects the
+/// <see cref="LearningEntry.FeedbackWeight"/> against <c>BaselineAdjustmentThreshold</c>
+/// to decide whether drift baselines should be recalibrated.</para>
+/// </remarks>
+public sealed class ImproveLearningCommandHandler : IRequestHandler<ImproveLearningCommand, Result<LearningEntry>>
+{
+    private readonly ILearningsStore _store;
+    private readonly IOptionsMonitor<AppConfig> _options;
+    private readonly TimeProvider _timeProvider;
+    private readonly ILogger<ImproveLearningCommandHandler> _logger;
+
+    /// <summary>Initializes a new instance of the <see cref="ImproveLearningCommandHandler"/> class.</summary>
+    public ImproveLearningCommandHandler(
+        ILearningsStore store,
+        IOptionsMonitor<AppConfig> options,
+        TimeProvider timeProvider,
+        ILogger<ImproveLearningCommandHandler> logger)
+    {
+        _store = store;
+        _options = options;
+        _timeProvider = timeProvider;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<Result<LearningEntry>> Handle(
+        ImproveLearningCommand request, CancellationToken cancellationToken)
+    {
+        var config = _options.CurrentValue.AI.Learnings;
+        if (!config.Enabled)
+        {
+            _logger.LogDebug("Learnings subsystem disabled, skipping improve");
+            return Result<LearningEntry>.Success(CreateDisabledPlaceholder(request.LearningId));
+        }
+
+        var getResult = await _store.GetAsync(request.LearningId, cancellationToken);
+        if (!getResult.IsSuccess || getResult.Value is null)
+            return Result<LearningEntry>.NotFound($"Learning {request.LearningId} not found");
+
+        var learning = getResult.Value;
+        var alpha = config.FeedbackAlpha;
+        var normalized = (request.FeedbackScore - 1.0) / 4.0;
+        var newWeight = alpha * normalized + (1 - alpha) * learning.FeedbackWeight;
+
+        if (config.BiasCorrection && learning.UpdateCount < 5)
+        {
+            var correctionFactor = 1.0 / (1.0 - Math.Pow(1.0 - alpha, learning.UpdateCount + 1));
+            newWeight = Math.Clamp(newWeight * correctionFactor, 0.0, 1.0);
+        }
+
+        var updated = learning with
+        {
+            FeedbackWeight = newWeight,
+            UpdateCount = learning.UpdateCount + 1,
+            LastReinforcedAt = _timeProvider.GetUtcNow(),
+            Content = request.ReinforcementContent ?? learning.Content
+        };
+
+        var updateResult = await _store.UpdateAsync(updated, cancellationToken);
+        if (!updateResult.IsSuccess)
+            return Result<LearningEntry>.Fail(updateResult.Errors.ToArray());
+
+        LearningsMetrics.Improved.Add(1);
+        return Result<LearningEntry>.Success(updated);
+    }
+
+    private LearningEntry CreateDisabledPlaceholder(Guid learningId) => new()
+    {
+        LearningId = learningId,
+        Category = LearningCategory.FactualCorrection,
+        DecayClass = DecayClass.Volatile,
+        Scope = new LearningScope { IsGlobal = true },
+        Content = string.Empty,
+        Source = new LearningSource
+        {
+            SourceType = LearningSourceType.ManualEntry,
+            SourceId = string.Empty,
+            SourceDescription = "Disabled no-op"
+        },
+        Provenance = new LearningProvenance
+        {
+            OriginPipeline = "disabled",
+            OriginTask = "disabled",
+            OriginTimestamp = _timeProvider.GetUtcNow(),
+            Confidence = 0
+        },
+        CreatedAt = _timeProvider.GetUtcNow()
+    };
+}

--- a/src/Content/Application/Application.Core/CQRS/Learnings/ImproveLearningCommandHandler.cs
+++ b/src/Content/Application/Application.Core/CQRS/Learnings/ImproveLearningCommandHandler.cs
@@ -16,13 +16,14 @@ namespace Application.Core.CQRS.Learnings;
 /// <remarks>
 /// <para>EMA formula: <c>newWeight = alpha * normalized + (1 - alpha) * currentWeight</c></para>
 /// <para>Bias correction (first 5 updates): <c>corrected = weight / (1 - (1 - alpha)^updateCount)</c></para>
-/// <para>The updated entry is returned to callers. The section-17 bridge inspects the
-/// <see cref="LearningEntry.FeedbackWeight"/> against <c>BaselineAdjustmentThreshold</c>
-/// to decide whether drift baselines should be recalibrated.</para>
+/// <para>After a successful weight update, the <see cref="ILearningsDriftBridge"/> checks whether
+/// the learning qualifies for drift baseline adjustment. Bridge failure is non-critical —
+/// the learning update always succeeds independently.</para>
 /// </remarks>
 public sealed class ImproveLearningCommandHandler : IRequestHandler<ImproveLearningCommand, Result<LearningEntry>>
 {
     private readonly ILearningsStore _store;
+    private readonly ILearningsDriftBridge _driftBridge;
     private readonly IOptionsMonitor<AppConfig> _options;
     private readonly TimeProvider _timeProvider;
     private readonly ILogger<ImproveLearningCommandHandler> _logger;
@@ -30,11 +31,13 @@ public sealed class ImproveLearningCommandHandler : IRequestHandler<ImproveLearn
     /// <summary>Initializes a new instance of the <see cref="ImproveLearningCommandHandler"/> class.</summary>
     public ImproveLearningCommandHandler(
         ILearningsStore store,
+        ILearningsDriftBridge driftBridge,
         IOptionsMonitor<AppConfig> options,
         TimeProvider timeProvider,
         ILogger<ImproveLearningCommandHandler> logger)
     {
         _store = store;
+        _driftBridge = driftBridge;
         _options = options;
         _timeProvider = timeProvider;
         _logger = logger;
@@ -77,6 +80,14 @@ public sealed class ImproveLearningCommandHandler : IRequestHandler<ImproveLearn
         var updateResult = await _store.UpdateAsync(updated, cancellationToken);
         if (!updateResult.IsSuccess)
             return Result<LearningEntry>.Fail(updateResult.Errors.ToArray());
+
+        var bridgeResult = await _driftBridge.CheckAndAdjustBaselineAsync(updated, cancellationToken);
+        if (!bridgeResult.IsSuccess)
+        {
+            _logger.LogWarning(
+                "Drift baseline adjustment failed for learning {LearningId}: {Reason}",
+                updated.LearningId, string.Join("; ", bridgeResult.Errors));
+        }
 
         LearningsMetrics.Improved.Add(1);
         return Result<LearningEntry>.Success(updated);

--- a/src/Content/Application/Application.Core/CQRS/Learnings/RecallQueryHandler.cs
+++ b/src/Content/Application/Application.Core/CQRS/Learnings/RecallQueryHandler.cs
@@ -1,0 +1,174 @@
+using System.Diagnostics;
+using Application.AI.Common.Interfaces.Learnings;
+using Application.AI.Common.Interfaces.RAG;
+using Application.AI.Common.OpenTelemetry.Metrics;
+using Domain.AI.Learnings;
+using Domain.Common;
+using Domain.Common.Config;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Application.Core.CQRS.Learnings;
+
+/// <summary>
+/// Retrieves and ranks learnings by blending semantic relevance with feedback weight and freshness.
+/// Applies diversity injection to avoid echo-chamber effects in recall results.
+/// </summary>
+/// <remarks>
+/// Scoring formula: <c>finalScore = (1 - alpha) * relevance + alpha * min(feedback * freshness, ceiling)</c>.
+/// Learning content is embedded on-the-fly for cosine similarity since <see cref="LearningEntry"/>
+/// does not store pre-computed embeddings.
+/// </remarks>
+public sealed class RecallQueryHandler : IRequestHandler<RecallQuery, Result<IReadOnlyList<WeightedLearning>>>
+{
+    private readonly ILearningsStore _store;
+    private readonly ILearningDecayService _decayService;
+    private readonly IEmbeddingService _embeddingService;
+    private readonly IMediator _mediator;
+    private readonly IOptionsMonitor<AppConfig> _options;
+    private readonly TimeProvider _timeProvider;
+    private readonly ILogger<RecallQueryHandler> _logger;
+
+    /// <summary>Initializes a new instance of the <see cref="RecallQueryHandler"/> class.</summary>
+    public RecallQueryHandler(
+        ILearningsStore store,
+        ILearningDecayService decayService,
+        IEmbeddingService embeddingService,
+        IMediator mediator,
+        IOptionsMonitor<AppConfig> options,
+        TimeProvider timeProvider,
+        ILogger<RecallQueryHandler> logger)
+    {
+        _store = store;
+        _decayService = decayService;
+        _embeddingService = embeddingService;
+        _mediator = mediator;
+        _options = options;
+        _timeProvider = timeProvider;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<Result<IReadOnlyList<WeightedLearning>>> Handle(
+        RecallQuery request, CancellationToken cancellationToken)
+    {
+        var sw = Stopwatch.StartNew();
+        var config = _options.CurrentValue.AI.Learnings;
+
+        if (!config.Enabled)
+        {
+            _logger.LogDebug("Learnings subsystem disabled, skipping recall");
+            return Result<IReadOnlyList<WeightedLearning>>.Success(Array.Empty<WeightedLearning>());
+        }
+
+        var criteria = new LearningSearchCriteria { Scope = request.Scope };
+        var searchResult = await _store.SearchAsync(criteria, cancellationToken);
+        if (!searchResult.IsSuccess)
+            return Result<IReadOnlyList<WeightedLearning>>.Fail(searchResult.Errors.ToArray());
+
+        var candidates = searchResult.Value!;
+        if (candidates.Count == 0)
+            return Result<IReadOnlyList<WeightedLearning>>.Success(Array.Empty<WeightedLearning>());
+
+        var queryEmbedding = await _embeddingService.EmbedQueryAsync(request.Context, cancellationToken);
+
+        var embeddingTasks = candidates
+            .Select(l => _embeddingService.EmbedQueryAsync(l.Content, cancellationToken))
+            .ToArray();
+        var contentEmbeddings = await Task.WhenAll(embeddingTasks);
+
+        var scored = new List<WeightedLearning>(candidates.Count);
+        for (var i = 0; i < candidates.Count; i++)
+        {
+            var learning = candidates[i];
+            var relevanceScore = CosineSimilarity(queryEmbedding.Span, contentEmbeddings[i].Span);
+            var feedbackScore = learning.FeedbackWeight;
+            var freshnessScore = await _decayService.CalculateFreshnessAsync(learning, cancellationToken);
+
+            var finalScore = (1 - config.FeedbackAlpha) * relevanceScore
+                           + config.FeedbackAlpha * Math.Min(feedbackScore * freshnessScore, config.FeedbackCeiling);
+
+            scored.Add(new WeightedLearning
+            {
+                Learning = learning,
+                RelevanceScore = relevanceScore,
+                FeedbackScore = feedbackScore,
+                FreshnessScore = freshnessScore,
+                FinalScore = finalScore
+            });
+        }
+
+        scored.Sort((a, b) => b.FinalScore.CompareTo(a.FinalScore));
+
+        if (request.MinRelevance > 0)
+            scored = scored.Where(r => r.RelevanceScore >= request.MinRelevance).ToList();
+
+        List<WeightedLearning> results = ApplyDiversityInjection(scored, request.MaxResults, config.DiversityInjectionRatio);
+        results = results.Take(request.MaxResults).ToList();
+
+        _ = RecordAccessSafeAsync(results);
+
+        sw.Stop();
+        LearningsMetrics.Recalled.Add(results.Count);
+        LearningsMetrics.RecallDurationMs.Record(sw.Elapsed.TotalMilliseconds);
+
+        return Result<IReadOnlyList<WeightedLearning>>.Success(results);
+    }
+
+    private async Task RecordAccessSafeAsync(List<WeightedLearning> results)
+    {
+        try
+        {
+            await _mediator.Send(new RecordLearningAccessCommand
+            {
+                LearningIds = results.Select(r => r.Learning.LearningId).ToList(),
+                AccessedAt = _timeProvider.GetUtcNow()
+            }, CancellationToken.None);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Failed to record learning access for {Count} learnings", results.Count);
+        }
+    }
+
+    internal static List<WeightedLearning> ApplyDiversityInjection(
+        List<WeightedLearning> sorted, int maxResults, double diversityRatio)
+    {
+        if (sorted.Count < 2 || diversityRatio <= 0)
+            return sorted.Take(maxResults).ToList();
+
+        var slotsToReplace = (int)Math.Floor(maxResults * diversityRatio);
+        if (slotsToReplace < 1)
+            return sorted.Take(maxResults).ToList();
+
+        var topCount = Math.Min(maxResults - slotsToReplace, sorted.Count);
+        var top = sorted.Take(topCount).ToList();
+        var remaining = sorted.Skip(topCount).ToList();
+
+        if (remaining.Count == 0)
+            return top;
+
+        var diversityPicks = remaining.OrderBy(_ => Random.Shared.Next()).Take(slotsToReplace).ToList();
+        top.AddRange(diversityPicks);
+
+        return top;
+    }
+
+    internal static double CosineSimilarity(ReadOnlySpan<float> a, ReadOnlySpan<float> b)
+    {
+        if (a.Length != b.Length || a.Length == 0)
+            return 0.0;
+
+        double dot = 0, normA = 0, normB = 0;
+        for (var i = 0; i < a.Length; i++)
+        {
+            dot += a[i] * (double)b[i];
+            normA += a[i] * (double)a[i];
+            normB += b[i] * (double)b[i];
+        }
+
+        var magnitude = Math.Sqrt(normA) * Math.Sqrt(normB);
+        return magnitude == 0 ? 0.0 : dot / magnitude;
+    }
+}

--- a/src/Content/Application/Application.Core/CQRS/Learnings/RecordLearningAccessCommandHandler.cs
+++ b/src/Content/Application/Application.Core/CQRS/Learnings/RecordLearningAccessCommandHandler.cs
@@ -1,0 +1,48 @@
+using Application.AI.Common.Interfaces.Learnings;
+using Domain.Common;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace Application.Core.CQRS.Learnings;
+
+/// <summary>
+/// Updates <see cref="Domain.AI.Learnings.LearningEntry.LastAccessedAt"/> on entries
+/// retrieved during recall. Designed as a fire-and-forget side effect -- tolerates
+/// missing entries silently since learnings may be deleted between recall and access recording.
+/// </summary>
+public sealed class RecordLearningAccessCommandHandler : IRequestHandler<RecordLearningAccessCommand, Result>
+{
+    private readonly ILearningsStore _store;
+    private readonly ILogger<RecordLearningAccessCommandHandler> _logger;
+
+    /// <summary>Initializes a new instance of the <see cref="RecordLearningAccessCommandHandler"/> class.</summary>
+    public RecordLearningAccessCommandHandler(
+        ILearningsStore store,
+        ILogger<RecordLearningAccessCommandHandler> logger)
+    {
+        _store = store;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<Result> Handle(RecordLearningAccessCommand request, CancellationToken cancellationToken)
+    {
+        foreach (var learningId in request.LearningIds)
+        {
+            var getResult = await _store.GetAsync(learningId, cancellationToken);
+            if (!getResult.IsSuccess || getResult.Value is null)
+            {
+                _logger.LogDebug("Learning {LearningId} not found during access recording, skipping", learningId);
+                continue;
+            }
+
+            var updated = getResult.Value with { LastAccessedAt = request.AccessedAt };
+            var updateResult = await _store.UpdateAsync(updated, cancellationToken);
+            if (!updateResult.IsSuccess)
+                _logger.LogWarning("Failed to update LastAccessedAt for learning {LearningId}: {Errors}",
+                    learningId, string.Join(", ", updateResult.Errors));
+        }
+
+        return Result.Success();
+    }
+}

--- a/src/Content/Application/Application.Core/CQRS/Learnings/RememberCommandHandler.cs
+++ b/src/Content/Application/Application.Core/CQRS/Learnings/RememberCommandHandler.cs
@@ -1,0 +1,115 @@
+using Application.AI.Common.Interfaces.Learnings;
+using Application.AI.Common.OpenTelemetry.Metrics;
+using Domain.AI.Learnings;
+using Domain.AI.Telemetry.Conventions;
+using Domain.Common;
+using Domain.Common.Config;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Application.Core.CQRS.Learnings;
+
+/// <summary>
+/// Captures a new learning by persisting it to the store and emitting a notification.
+/// Maps <see cref="LearningCategory"/> to default <see cref="Domain.AI.Learnings.DecayClass"/>
+/// when no explicit decay class is provided on the command.
+/// </summary>
+public sealed class RememberCommandHandler : IRequestHandler<RememberCommand, Result<LearningEntry>>
+{
+    private readonly ILearningsStore _store;
+    private readonly ILearningNotificationChannel _notifications;
+    private readonly IOptionsMonitor<AppConfig> _options;
+    private readonly TimeProvider _timeProvider;
+    private readonly ILogger<RememberCommandHandler> _logger;
+
+    /// <summary>Initializes a new instance of the <see cref="RememberCommandHandler"/> class.</summary>
+    public RememberCommandHandler(
+        ILearningsStore store,
+        ILearningNotificationChannel notifications,
+        IOptionsMonitor<AppConfig> options,
+        TimeProvider timeProvider,
+        ILogger<RememberCommandHandler> logger)
+    {
+        _store = store;
+        _notifications = notifications;
+        _options = options;
+        _timeProvider = timeProvider;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<Result<LearningEntry>> Handle(RememberCommand request, CancellationToken cancellationToken)
+    {
+        if (!_options.CurrentValue.AI.Learnings.Enabled)
+        {
+            _logger.LogDebug("Learnings subsystem disabled, skipping remember");
+            return Result<LearningEntry>.Success(CreatePlaceholder(request));
+        }
+
+        var decayClass = request.DecayClass ?? MapCategoryToDecayClass(request.Category);
+        var now = _timeProvider.GetUtcNow();
+
+        var entry = new LearningEntry
+        {
+            LearningId = Guid.NewGuid(),
+            Category = request.Category,
+            DecayClass = decayClass,
+            Scope = request.Scope,
+            Content = request.Content,
+            Source = request.Source,
+            Provenance = request.Provenance,
+            FeedbackWeight = 1.0,
+            UpdateCount = 0,
+            CreatedAt = now,
+            LastAccessedAt = now,
+            LastReinforcedAt = now
+        };
+
+        var saveResult = await _store.SaveAsync(entry, cancellationToken);
+        if (!saveResult.IsSuccess)
+            return Result<LearningEntry>.Fail(saveResult.Errors.ToArray());
+
+        try
+        {
+            await _notifications.NotifyLearningCapturedAsync(entry, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to notify learning captured for {LearningId}", entry.LearningId);
+        }
+
+        LearningsMetrics.Remembered.Add(1,
+            new KeyValuePair<string, object?>(LearningConventions.Category, request.Category.ToString().ToLowerInvariant()),
+            new KeyValuePair<string, object?>(LearningConventions.Scope, GetScopeTag(request.Scope)));
+
+        return Result<LearningEntry>.Success(entry);
+    }
+
+    internal static DecayClass MapCategoryToDecayClass(LearningCategory category) => category switch
+    {
+        LearningCategory.FactualCorrection => DecayClass.Permanent,
+        LearningCategory.DomainKnowledge => DecayClass.Permanent,
+        LearningCategory.InstructionUpdate => DecayClass.Stable,
+        LearningCategory.StylePreference => DecayClass.Stable,
+        LearningCategory.ToolUsagePattern => DecayClass.Stable,
+        _ => DecayClass.Stable
+    };
+
+    private static string GetScopeTag(LearningScope scope) =>
+        scope.AgentId is not null ? LearningConventions.ScopeValues.Agent :
+        scope.TeamId is not null ? LearningConventions.ScopeValues.Team :
+        LearningConventions.ScopeValues.Global;
+
+    private LearningEntry CreatePlaceholder(RememberCommand request) => new()
+    {
+        LearningId = Guid.Empty,
+        Category = request.Category,
+        DecayClass = request.DecayClass ?? MapCategoryToDecayClass(request.Category),
+        Scope = request.Scope,
+        Content = request.Content,
+        Source = request.Source,
+        Provenance = request.Provenance,
+        CreatedAt = _timeProvider.GetUtcNow()
+    };
+}

--- a/src/Content/Domain/Domain.AI/Telemetry/Conventions/LearningConventions.cs
+++ b/src/Content/Domain/Domain.AI/Telemetry/Conventions/LearningConventions.cs
@@ -1,0 +1,93 @@
+namespace Domain.AI.Telemetry.Conventions;
+
+/// <summary>
+/// OTel attribute names and metric identifiers for the learnings subsystem.
+/// Used by command handlers to tag spans, structured logs, and metric recordings
+/// with consistent, discoverable dimension keys.
+/// </summary>
+public static class LearningConventions
+{
+    // ── Attribute name constants (span/log attribute keys) ──
+
+    /// <summary>Unique learning entry identifier.</summary>
+    public const string LearningId = "agent.learning.id";
+
+    /// <summary>The agent associated with the learning scope.</summary>
+    public const string AgentId = "agent.learning.agent_id";
+
+    /// <summary>Learning category classification.</summary>
+    public const string Category = "agent.learning.category";
+
+    /// <summary>Temporal decay class for the learning.</summary>
+    public const string DecayClass = "agent.learning.decay_class";
+
+    /// <summary>Learning visibility scope level.</summary>
+    public const string Scope = "agent.learning.scope";
+
+    // ── Metric identifier constants (instrument names) ──
+
+    /// <summary>Counter of learnings captured via Remember. Tags: category, scope.</summary>
+    public const string Remembered = "agent.learning.remembered";
+
+    /// <summary>Counter of learnings retrieved via Recall.</summary>
+    public const string Recalled = "agent.learning.recalled";
+
+    /// <summary>Counter of learnings soft-deleted via Forget.</summary>
+    public const string Forgotten = "agent.learning.forgotten";
+
+    /// <summary>Counter of learnings feedback-improved via Improve.</summary>
+    public const string Improved = "agent.learning.improved";
+
+    /// <summary>Counter of expired learnings pruned by background service.</summary>
+    public const string Pruned = "agent.learning.pruned";
+
+    /// <summary>Histogram of recall pipeline duration in milliseconds.</summary>
+    public const string RecallDurationMs = "agent.learning.recall_duration_ms";
+
+    // ── Well-known tag value classes ──
+
+    /// <summary>Well-known values for the <see cref="Category"/> attribute.</summary>
+    public static class CategoryValues
+    {
+        /// <summary>Factual correction category.</summary>
+        public const string FactualCorrection = "factual_correction";
+
+        /// <summary>Style preference category.</summary>
+        public const string StylePreference = "style_preference";
+
+        /// <summary>Tool usage pattern category.</summary>
+        public const string ToolUsagePattern = "tool_usage_pattern";
+
+        /// <summary>Domain knowledge category.</summary>
+        public const string DomainKnowledge = "domain_knowledge";
+
+        /// <summary>Instruction update category.</summary>
+        public const string InstructionUpdate = "instruction_update";
+    }
+
+    /// <summary>Well-known values for the <see cref="DecayClass"/> attribute.</summary>
+    public static class DecayClassValues
+    {
+        /// <summary>Short-lived, fast-decaying knowledge.</summary>
+        public const string Volatile = "volatile";
+
+        /// <summary>Long-lived, slow-decaying knowledge.</summary>
+        public const string Stable = "stable";
+
+        /// <summary>Immortal knowledge that never decays.</summary>
+        public const string Permanent = "permanent";
+    }
+
+    /// <summary>Well-known values for the <see cref="Scope"/> attribute.</summary>
+    public static class ScopeValues
+    {
+        /// <summary>Scoped to a specific agent.</summary>
+        public const string Agent = "agent";
+
+        /// <summary>Scoped to a team of agents.</summary>
+        public const string Team = "team";
+
+        /// <summary>Visible to all agents.</summary>
+        public const string Global = "global";
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/DependencyInjection.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/DependencyInjection.cs
@@ -1,4 +1,5 @@
 using Application.AI.Common.Interfaces.KnowledgeGraph;
+using Application.AI.Common.Interfaces.Learnings;
 using Application.AI.Common.Interfaces.RAG;
 using Application.AI.Common.Interfaces.Skills;
 using Domain.Common.Config;
@@ -155,6 +156,20 @@ public static class DependencyInjection
                     sp.GetRequiredService<IKnowledgeGraphStore>(),
                     sp.GetRequiredService<ILogger<GraphSkillAmendmentProvider>>()));
         }
+
+        // --- Learnings Store (keyed DI) ---
+
+        services.AddKeyedSingleton<ILearningsStore>("graph", (sp, _) =>
+            new Learnings.GraphLearningsStore(
+                sp.GetRequiredService<IKnowledgeGraphStore>(),
+                sp.GetRequiredService<ILogger<Learnings.GraphLearningsStore>>()));
+
+        services.AddKeyedSingleton<ILearningsStore>("in_memory", (_, _) =>
+            new Learnings.InMemoryLearningsStore());
+
+        var learningsProvider = appConfig.AI.Learnings.StoreProvider;
+        services.AddSingleton<ILearningsStore>(sp =>
+            sp.GetRequiredKeyedService<ILearningsStore>(learningsProvider));
 
         return services;
     }

--- a/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.cs
@@ -1,12 +1,16 @@
 using Application.AI.Common.Interfaces;
 using Application.AI.Common.Interfaces.A2A;
+using Application.AI.Common.Interfaces.DriftDetection;
+using Application.AI.Common.Interfaces.Learnings;
 using Application.AI.Common.Interfaces.MetaHarness;
 using Application.AI.Common.Interfaces.Skills;
 using Application.AI.Common.Interfaces.Memory;
 using Application.AI.Common.Interfaces.Traces;
 using Application.AI.Common.Interfaces.Escalation;
 using Application.AI.Common.Interfaces.Resilience;
+using Infrastructure.AI.DriftDetection;
 using Infrastructure.AI.Escalation;
+using Infrastructure.AI.Learnings;
 using Infrastructure.AI.Memory;
 using Infrastructure.AI.Resilience;
 using Infrastructure.AI.Security;
@@ -249,6 +253,8 @@ public static class DependencyInjection
 
         RegisterEscalationServices(services);
         RegisterResilienceServices(services, appConfig);
+        RegisterDriftDetectionServices(services);
+        RegisterLearningsServices(services, appConfig);
 
         return services;
     }
@@ -264,6 +270,7 @@ public static class DependencyInjection
         services.AddSingleton<IEscalationNotifier, CompositeEscalationNotifier>();
         services.AddSingleton<IEscalationNotificationChannel, NoOpSlackNotifier>();
         services.AddSingleton<IEscalationNotificationChannel, NoOpTeamsNotifier>();
+        services.AddSingleton<IEscalationNotificationChannel, DriftEscalationBridge>();
     }
 
     /// <summary>
@@ -282,6 +289,79 @@ public static class DependencyInjection
             services.AddSingleton<LlmRetryQueue>();
             services.AddSingleton<ILlmRetryQueue>(sp => sp.GetRequiredService<LlmRetryQueue>());
             services.AddHostedService(sp => sp.GetRequiredService<LlmRetryQueue>());
+        }
+    }
+
+    /// <summary>
+    /// Registers drift detection pipeline: scorer, baseline store, audit, notifier, EWMA state,
+    /// and the main detection service.
+    /// </summary>
+    private static void RegisterDriftDetectionServices(IServiceCollection services)
+    {
+        services.AddKeyedSingleton<IDriftScorer>("ewma", (sp, _) =>
+            new EwmaDriftScorer(
+                sp.GetRequiredService<IEwmaStateStore>(),
+                sp.GetRequiredService<IOptionsMonitor<AppConfig>>(),
+                sp.GetService<TimeProvider>() ?? TimeProvider.System,
+                sp.GetRequiredService<ILogger<EwmaDriftScorer>>()));
+
+        services.AddKeyedSingleton<IDriftBaselineStore>("graph", (sp, _) =>
+            new GraphDriftBaselineStore(
+                sp.GetRequiredService<Application.AI.Common.Interfaces.KnowledgeGraph.IKnowledgeGraphStore>(),
+                sp.GetRequiredService<ILogger<GraphDriftBaselineStore>>()));
+
+        services.AddKeyedSingleton<IDriftBaselineStore>("in_memory", (_, _) =>
+            new InMemoryDriftBaselineStore());
+
+        // Default to graph — drift baselines require persistent storage for EWMA continuity
+        services.AddSingleton<IDriftBaselineStore>(sp =>
+            sp.GetRequiredKeyedService<IDriftBaselineStore>("graph"));
+
+        services.AddSingleton<IDriftAuditStore>(sp =>
+            new JsonlDriftAuditStore(
+                sp.GetRequiredService<IOptionsMonitor<AppConfig>>(),
+                sp.GetService<TimeProvider>() ?? TimeProvider.System,
+                sp.GetRequiredService<ILogger<JsonlDriftAuditStore>>()));
+
+        services.AddSingleton<IDriftNotifier, CompositeDriftNotifier>();
+
+        services.AddSingleton<IEwmaStateStore>(sp =>
+            new GraphEwmaStateStore(
+                sp.GetRequiredService<Application.AI.Common.Interfaces.KnowledgeGraph.IKnowledgeGraphStore>(),
+                sp.GetRequiredService<ILogger<GraphEwmaStateStore>>()));
+
+        services.AddSingleton<IDriftDetectionService>(sp =>
+            new DefaultDriftDetectionService(
+                sp.GetRequiredKeyedService<IDriftScorer>("ewma"),
+                sp.GetRequiredService<IDriftBaselineStore>(),
+                sp.GetRequiredService<IDriftAuditStore>(),
+                sp.GetRequiredService<IDriftNotifier>(),
+                sp.GetRequiredService<IEscalationService>(),
+                sp.GetRequiredService<Application.AI.Common.Interfaces.KnowledgeGraph.IKnowledgeGraphStore>(),
+                sp.GetRequiredService<IOptionsMonitor<AppConfig>>(),
+                sp.GetService<TimeProvider>() ?? TimeProvider.System,
+                sp.GetRequiredService<ILogger<DefaultDriftDetectionService>>()));
+    }
+
+    /// <summary>
+    /// Registers learnings subsystem: decay service, drift bridge, and conditional
+    /// pruning background service.
+    /// </summary>
+    private static void RegisterLearningsServices(IServiceCollection services, AppConfig appConfig)
+    {
+        services.AddSingleton<ILearningDecayService>(sp =>
+            new DefaultLearningDecayService(
+                sp.GetRequiredService<ILearningsStore>(),
+                sp.GetRequiredService<IOptionsMonitor<Domain.Common.Config.AI.Learnings.LearningsConfig>>(),
+                sp.GetService<TimeProvider>() ?? TimeProvider.System,
+                sp.GetRequiredService<ILogger<DefaultLearningDecayService>>()));
+
+        services.AddSingleton<ILearningsDriftBridge, LearningsDriftBridge>();
+
+        if (appConfig.AI.Learnings.Enabled)
+        {
+            services.AddSingleton<LearningsPruningBackgroundService>();
+            services.AddHostedService(sp => sp.GetRequiredService<LearningsPruningBackgroundService>());
         }
     }
 

--- a/src/Content/Infrastructure/Infrastructure.AI/DriftDetection/DriftEscalationBridge.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/DriftDetection/DriftEscalationBridge.cs
@@ -1,0 +1,173 @@
+using System.Collections.Concurrent;
+using Application.AI.Common.Interfaces.DriftDetection;
+using Application.AI.Common.Interfaces.Escalation;
+using Application.Core.CQRS.Learnings;
+using Domain.AI.DriftDetection;
+using Domain.AI.Escalation;
+using Domain.AI.Learnings;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace Infrastructure.AI.DriftDetection;
+
+/// <summary>
+/// Bridges escalation resolutions back into the drift detection and learnings systems.
+/// When a drift-originated escalation resolves, updates the drift event and optionally
+/// creates a learning entry from approver corrections.
+/// </summary>
+/// <remarks>
+/// Registered as an <see cref="IEscalationNotificationChannel"/> in DI. The
+/// <c>CompositeEscalationNotifier</c> automatically fans out to this channel.
+/// Only processes escalations where <c>ToolName == "drift_detection"</c>.
+/// </remarks>
+public sealed class DriftEscalationBridge : IEscalationNotificationChannel
+{
+    /// <summary>Convention: tool name used by drift detection when queuing escalations.</summary>
+    public const string DriftDetectionToolName = "drift_detection";
+
+    /// <summary>
+    /// Confidence for escalation-resolution learnings. High because a human reviewed,
+    /// but not 1.0 because approver corrections may be contextual.
+    /// </summary>
+    private const double EscalationResolutionConfidence = 0.8;
+
+    private readonly ConcurrentDictionary<Guid, EscalationRequest> _trackedDriftEscalations = new();
+    private readonly IDriftNotifier _driftNotifier;
+    private readonly ISender _sender;
+    private readonly TimeProvider _timeProvider;
+    private readonly ILogger<DriftEscalationBridge> _logger;
+
+    /// <summary>Initializes a new <see cref="DriftEscalationBridge"/>.</summary>
+    public DriftEscalationBridge(
+        IDriftNotifier driftNotifier,
+        ISender sender,
+        TimeProvider timeProvider,
+        ILogger<DriftEscalationBridge> logger)
+    {
+        _driftNotifier = driftNotifier;
+        _sender = sender;
+        _timeProvider = timeProvider;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public Task NotifyEscalationRequestedAsync(EscalationRequest request, CancellationToken ct)
+    {
+        if (string.Equals(request.ToolName, DriftDetectionToolName, StringComparison.Ordinal))
+        {
+            _trackedDriftEscalations.TryAdd(request.EscalationId, request);
+            _logger.LogDebug("Tracking drift-originated escalation {EscalationId}.", request.EscalationId);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public async Task NotifyEscalationResolvedAsync(EscalationOutcome outcome, CancellationToken ct)
+    {
+        if (!_trackedDriftEscalations.TryRemove(outcome.EscalationId, out var request))
+            return;
+
+        try
+        {
+            await NotifyDriftResolvedAsync(request, outcome, ct);
+            await TryCreateLearningAsync(request, outcome, ct);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogWarning(ex, "Failed to process drift escalation resolution for {EscalationId}.",
+                outcome.EscalationId);
+        }
+    }
+
+    /// <inheritdoc />
+    public Task NotifyEscalationExpiringAsync(EscalationRequest request, TimeSpan remaining, CancellationToken ct)
+    {
+        if (_trackedDriftEscalations.TryRemove(request.EscalationId, out _))
+        {
+            _logger.LogDebug("Removed expiring drift escalation {EscalationId} from tracking.", request.EscalationId);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private async Task NotifyDriftResolvedAsync(
+        EscalationRequest request, EscalationOutcome outcome, CancellationToken ct)
+    {
+        var resolution = new DriftResolution
+        {
+            ResolvedBy = DriftResolutionType.EscalationResolved,
+            ResolutionId = outcome.EscalationId.ToString(),
+            ResolvedAt = outcome.ResolvedAt,
+        };
+
+        var driftEvent = new DriftEvent
+        {
+            EventId = outcome.EscalationId,
+            DriftScore = BuildMinimalDriftScore(request),
+            Resolution = resolution,
+            DetectedAt = request.RequestedAt,
+        };
+
+        await _driftNotifier.NotifyDriftResolvedAsync(driftEvent, ct);
+
+        _logger.LogInformation("Drift escalation {EscalationId} resolved via {ResolutionType}.",
+            outcome.EscalationId, outcome.ResolutionType);
+    }
+
+    private async Task TryCreateLearningAsync(
+        EscalationRequest request, EscalationOutcome outcome, CancellationToken ct)
+    {
+        var reasons = outcome.Decisions
+            .Where(d => !string.IsNullOrWhiteSpace(d.Reason))
+            .Select(d => $"Correction from {d.ApproverName}: {d.Reason}")
+            .ToList();
+
+        if (reasons.Count == 0)
+            return;
+
+        var content = string.Join("; ", reasons);
+        var category = outcome.IsApproved
+            ? LearningCategory.InstructionUpdate
+            : LearningCategory.FactualCorrection;
+
+        var command = new RememberCommand
+        {
+            Content = content,
+            Category = category,
+            Scope = new LearningScope { AgentId = request.AgentId },
+            Source = new LearningSource
+            {
+                SourceType = LearningSourceType.EscalationResolution,
+                SourceId = outcome.EscalationId.ToString(),
+                SourceDescription = $"Escalation resolution for drift in {request.AgentId}",
+            },
+            Provenance = new LearningProvenance
+            {
+                OriginPipeline = "DriftEscalationBridge",
+                OriginTask = "escalation_resolution",
+                OriginTimestamp = _timeProvider.GetUtcNow(),
+                Confidence = EscalationResolutionConfidence,
+            },
+        };
+
+        await _sender.Send(command, ct);
+
+        _logger.LogInformation("Created learning from drift escalation {EscalationId} with {ReasonCount} corrections.",
+            outcome.EscalationId, reasons.Count);
+    }
+
+    private static DriftScore BuildMinimalDriftScore(EscalationRequest request) => new()
+    {
+        ScoreId = Guid.TryParse(
+            request.Arguments.GetValueOrDefault("score_id"), out var scoreId) ? scoreId : Guid.Empty,
+        BaselineId = Guid.Empty,
+        Scope = DriftScope.Agent,
+        ScopeIdentifier = request.AgentId,
+        Dimensions = new Dictionary<DriftDimension, DriftDimensionScore>().AsReadOnly(),
+        OverallDrift = 0,
+        Severity = Enum.TryParse<DriftSeverity>(
+            request.Arguments.GetValueOrDefault("severity"), out var sev) ? sev : DriftSeverity.Escalate,
+        ScoredAt = request.RequestedAt,
+    };
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Learnings/LearningsDriftBridge.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Learnings/LearningsDriftBridge.cs
@@ -1,0 +1,176 @@
+using System.Text.Json;
+using Application.AI.Common.Interfaces.DriftDetection;
+using Application.AI.Common.Interfaces.KnowledgeGraph;
+using Application.AI.Common.Interfaces.Learnings;
+using Domain.AI.DriftDetection;
+using Domain.AI.KnowledgeGraph.Models;
+using Domain.AI.Learnings;
+using Domain.Common;
+using Domain.Common.Config;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Infrastructure.AI.Learnings;
+
+/// <summary>
+/// Adjusts drift baselines when high-confidence learnings originating from drift events
+/// receive sufficient positive feedback. Resolves the originating drift event and records
+/// an audit trail.
+/// </summary>
+/// <remarks>
+/// <para>Invoked by <c>ImproveLearningCommandHandler</c> after each feedback weight update.
+/// The bridge is a best-effort side effect — failures are propagated but do not roll back
+/// the learning update itself.</para>
+/// <para>Idempotent: if the drift event is already resolved, subsequent calls no-op.</para>
+/// </remarks>
+public sealed class LearningsDriftBridge : ILearningsDriftBridge
+{
+    private static readonly JsonSerializerOptions s_jsonOptions = new()
+    {
+        Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+    };
+
+    private readonly IDriftDetectionService _driftService;
+    private readonly IDriftAuditStore _auditStore;
+    private readonly IKnowledgeGraphStore _graphStore;
+    private readonly IOptionsMonitor<AppConfig> _options;
+    private readonly TimeProvider _timeProvider;
+    private readonly ILogger<LearningsDriftBridge> _logger;
+
+    /// <summary>Initializes a new instance of the <see cref="LearningsDriftBridge"/> class.</summary>
+    public LearningsDriftBridge(
+        IDriftDetectionService driftService,
+        IDriftAuditStore auditStore,
+        IKnowledgeGraphStore graphStore,
+        IOptionsMonitor<AppConfig> options,
+        TimeProvider timeProvider,
+        ILogger<LearningsDriftBridge> logger)
+    {
+        _driftService = driftService;
+        _auditStore = auditStore;
+        _graphStore = graphStore;
+        _options = options;
+        _timeProvider = timeProvider;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<Result> CheckAndAdjustBaselineAsync(LearningEntry learning, CancellationToken ct)
+    {
+        var config = _options.CurrentValue.AI;
+
+        if (!config.Learnings.Enabled || !config.DriftDetection.Enabled)
+            return Result.Success();
+
+        if (learning.Source.SourceType != LearningSourceType.DriftDetection)
+            return Result.Success();
+
+        if (learning.FeedbackWeight < config.Learnings.BaselineAdjustmentThreshold)
+            return Result.Success();
+
+        var nodeId = $"driftevent:{learning.Source.SourceId}";
+        var node = await _graphStore.GetNodeAsync(nodeId, ct);
+        if (node is null)
+        {
+            _logger.LogWarning(
+                "Drift event node {NodeId} not found — may have been pruned. Skipping baseline adjustment.",
+                nodeId);
+            return Result.Success();
+        }
+
+        if (node.Properties.ContainsKey("Resolution"))
+        {
+            _logger.LogDebug(
+                "Drift event {NodeId} already resolved. Skipping duplicate baseline adjustment.",
+                nodeId);
+            return Result.Success();
+        }
+
+        if (!node.Properties.TryGetValue("Scope", out var scopeStr) ||
+            !Enum.TryParse<DriftScope>(scopeStr, out var scope) ||
+            !node.Properties.TryGetValue("ScopeIdentifier", out var scopeIdentifier))
+        {
+            _logger.LogWarning(
+                "Drift event node {NodeId} has corrupted scope data. Skipping baseline adjustment.",
+                nodeId);
+            return Result.Success();
+        }
+
+        var updateRequest = new DriftBaselineUpdateRequest
+        {
+            Scope = scope,
+            ScopeIdentifier = scopeIdentifier
+        };
+
+        var updateResult = await _driftService.UpdateBaselineAsync(updateRequest, ct);
+        if (!updateResult.IsSuccess)
+            return Result.Fail(updateResult.Errors.ToArray());
+
+        var now = _timeProvider.GetUtcNow();
+
+        try
+        {
+            await RecordAuditAsync(node, learning, now, ct);
+            await ResolveEventNodeAsync(node, learning, now, ct);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogWarning(ex,
+                "Post-baseline side effects failed for learning {LearningId}. Baseline was updated successfully.",
+                learning.LearningId);
+        }
+
+        _logger.LogInformation(
+            "Baseline adjusted for {Scope}:{ScopeIdentifier} from learning {LearningId} (weight: {Weight:F3}).",
+            scope, scopeIdentifier, learning.LearningId, learning.FeedbackWeight);
+
+        return Result.Success();
+    }
+
+    private async Task RecordAuditAsync(
+        GraphNode node, LearningEntry learning, DateTimeOffset now, CancellationToken ct)
+    {
+        var eventId = Guid.TryParse(node.Properties.GetValueOrDefault("EventId", ""), out var eid)
+            ? eid
+            : Guid.Empty;
+
+        var auditRecord = new DriftAuditRecord
+        {
+            RecordId = Guid.NewGuid(),
+            EventId = eventId,
+            RecordType = DriftAuditRecordType.BaselineUpdated,
+            Payload = JsonSerializer.Serialize(new
+            {
+                LearningId = learning.LearningId,
+                FeedbackWeight = learning.FeedbackWeight,
+                Threshold = _options.CurrentValue.AI.Learnings.BaselineAdjustmentThreshold
+            }, s_jsonOptions),
+            RecordedAt = now
+        };
+
+        var result = await _auditStore.RecordAsync(auditRecord, ct);
+        if (!result.IsSuccess)
+        {
+            _logger.LogWarning("Failed to record baseline-adjusted audit for event {EventId}.", eventId);
+        }
+    }
+
+    private async Task ResolveEventNodeAsync(
+        GraphNode node, LearningEntry learning, DateTimeOffset now, CancellationToken ct)
+    {
+        var resolution = new DriftResolution
+        {
+            ResolvedBy = DriftResolutionType.BaselineAdjusted,
+            ResolutionId = learning.LearningId.ToString(),
+            ResolvedAt = now
+        };
+
+        var updatedProperties = new Dictionary<string, string>(node.Properties)
+        {
+            ["Resolution"] = JsonSerializer.Serialize(resolution, s_jsonOptions)
+        };
+
+        var updatedNode = node with { Properties = updatedProperties.AsReadOnly() };
+        await _graphStore.AddNodesAsync([updatedNode], ct);
+    }
+}

--- a/src/Content/Presentation/Presentation.AgentHub/AgUi/AgUiEventType.cs
+++ b/src/Content/Presentation/Presentation.AgentHub/AgUi/AgUiEventType.cs
@@ -67,4 +67,16 @@ public static class AgUiEventType
 
     /// <summary>Warns that a pending escalation is approaching its timeout deadline.</summary>
     public const string EscalationExpiring = "ESCALATION_EXPIRING";
+
+    /// <summary>Signals that drift was detected at warn severity.</summary>
+    public const string DriftWarn = "DRIFT_WARN";
+
+    /// <summary>Signals that drift was detected at alert severity.</summary>
+    public const string DriftAlert = "DRIFT_ALERT";
+
+    /// <summary>Signals that drift was detected at escalate severity.</summary>
+    public const string DriftEscalate = "DRIFT_ESCALATE";
+
+    /// <summary>Signals that a previously detected drift has been resolved.</summary>
+    public const string DriftResolved = "DRIFT_RESOLVED";
 }

--- a/src/Content/Presentation/Presentation.AgentHub/AgUi/AgUiEventType.cs
+++ b/src/Content/Presentation/Presentation.AgentHub/AgUi/AgUiEventType.cs
@@ -79,4 +79,13 @@ public static class AgUiEventType
 
     /// <summary>Signals that a previously detected drift has been resolved.</summary>
     public const string DriftResolved = "DRIFT_RESOLVED";
+
+    /// <summary>Signals that a new learning has been captured.</summary>
+    public const string LearningCaptured = "LEARNING_CAPTURED";
+
+    /// <summary>Signals that a learning was applied during agent execution.</summary>
+    public const string LearningApplied = "LEARNING_APPLIED";
+
+    /// <summary>Signals that a learning has been forgotten (soft-deleted).</summary>
+    public const string LearningForgotten = "LEARNING_FORGOTTEN";
 }

--- a/src/Content/Presentation/Presentation.AgentHub/AgUi/AgUiEvents.cs
+++ b/src/Content/Presentation/Presentation.AgentHub/AgUi/AgUiEvents.cs
@@ -25,6 +25,9 @@ namespace Presentation.AgentHub.AgUi;
 [JsonDerivedType(typeof(DriftAlertEvent), AgUiEventType.DriftAlert)]
 [JsonDerivedType(typeof(DriftEscalateEvent), AgUiEventType.DriftEscalate)]
 [JsonDerivedType(typeof(DriftResolvedEvent), AgUiEventType.DriftResolved)]
+[JsonDerivedType(typeof(LearningCapturedEvent), AgUiEventType.LearningCaptured)]
+[JsonDerivedType(typeof(LearningAppliedEvent), AgUiEventType.LearningApplied)]
+[JsonDerivedType(typeof(LearningForgottenEvent), AgUiEventType.LearningForgotten)]
 public abstract record AgUiEvent;
 
 /// <summary>
@@ -307,4 +310,73 @@ public sealed record DriftResolvedEvent : AgUiEvent
     /// <summary>When the drift was resolved.</summary>
     [JsonPropertyName("resolvedAt")]
     public required DateTimeOffset ResolvedAt { get; init; }
+}
+
+/// <summary>
+/// Signals that the agent has captured a new learning. Emitted after a
+/// <c>RememberCommand</c> successfully persists a learning entry.
+/// </summary>
+public sealed record LearningCapturedEvent : AgUiEvent
+{
+    /// <summary>Unique identifier for the learning entry.</summary>
+    [JsonPropertyName("learningId")]
+    public required string LearningId { get; init; }
+
+    /// <summary>Learning category (e.g. "FactualCorrection", "StylePreference").</summary>
+    [JsonPropertyName("category")]
+    public required string Category { get; init; }
+
+    /// <summary>Agent ID this learning is scoped to, if any.</summary>
+    [JsonPropertyName("agentId")]
+    public string? AgentId { get; init; }
+
+    /// <summary>Team ID this learning is scoped to, if any.</summary>
+    [JsonPropertyName("teamId")]
+    public string? TeamId { get; init; }
+
+    /// <summary>Whether this is a global learning.</summary>
+    [JsonPropertyName("isGlobal")]
+    public required bool IsGlobal { get; init; }
+
+    /// <summary>Human-readable description of the learning source.</summary>
+    [JsonPropertyName("sourceDescription")]
+    public required string SourceDescription { get; init; }
+}
+
+/// <summary>
+/// Signals that a previously captured learning was applied during agent execution.
+/// The learning's content influenced the agent's response or tool usage.
+/// </summary>
+public sealed record LearningAppliedEvent : AgUiEvent
+{
+    /// <summary>The learning that was applied.</summary>
+    [JsonPropertyName("learningId")]
+    public required string LearningId { get; init; }
+
+    /// <summary>The agent that applied the learning.</summary>
+    [JsonPropertyName("agentId")]
+    public required string AgentId { get; init; }
+
+    /// <summary>Learning category for display.</summary>
+    [JsonPropertyName("category")]
+    public required string Category { get; init; }
+
+    /// <summary>Optional summary of the context in which the learning was applied.</summary>
+    [JsonPropertyName("contextSummary")]
+    public string? ContextSummary { get; init; }
+}
+
+/// <summary>
+/// Signals that a learning has been forgotten (soft-deleted) and will no longer
+/// influence future agent behavior.
+/// </summary>
+public sealed record LearningForgottenEvent : AgUiEvent
+{
+    /// <summary>The learning that was forgotten.</summary>
+    [JsonPropertyName("learningId")]
+    public required string LearningId { get; init; }
+
+    /// <summary>Reason for forgetting this learning.</summary>
+    [JsonPropertyName("reason")]
+    public required string Reason { get; init; }
 }

--- a/src/Content/Presentation/Presentation.AgentHub/AgUi/AgUiEvents.cs
+++ b/src/Content/Presentation/Presentation.AgentHub/AgUi/AgUiEvents.cs
@@ -21,6 +21,10 @@ namespace Presentation.AgentHub.AgUi;
 [JsonDerivedType(typeof(EscalationRequestedEvent), AgUiEventType.EscalationRequested)]
 [JsonDerivedType(typeof(EscalationResolvedEvent), AgUiEventType.EscalationResolved)]
 [JsonDerivedType(typeof(EscalationExpiringEvent), AgUiEventType.EscalationExpiring)]
+[JsonDerivedType(typeof(DriftWarnEvent), AgUiEventType.DriftWarn)]
+[JsonDerivedType(typeof(DriftAlertEvent), AgUiEventType.DriftAlert)]
+[JsonDerivedType(typeof(DriftEscalateEvent), AgUiEventType.DriftEscalate)]
+[JsonDerivedType(typeof(DriftResolvedEvent), AgUiEventType.DriftResolved)]
 public abstract record AgUiEvent;
 
 /// <summary>
@@ -184,4 +188,123 @@ public sealed record EscalationExpiringEvent : AgUiEvent
     /// <summary>Seconds remaining before the escalation times out.</summary>
     [JsonPropertyName("remainingSeconds")]
     public required int RemainingSeconds { get; init; }
+}
+
+/// <summary>
+/// Signals that quality drift was detected at warning severity.
+/// The agent's output quality has deviated from baseline but not critically.
+/// </summary>
+public sealed record DriftWarnEvent : AgUiEvent
+{
+    /// <summary>The scope level at which drift was measured (e.g. "Agent", "Skill").</summary>
+    [JsonPropertyName("scope")]
+    public required string Scope { get; init; }
+
+    /// <summary>Identifier of the entity within the scope.</summary>
+    [JsonPropertyName("scopeIdentifier")]
+    public required string ScopeIdentifier { get; init; }
+
+    /// <summary>Per-dimension deviation values keyed by dimension name.</summary>
+    [JsonPropertyName("dimensions")]
+    public required IReadOnlyDictionary<string, double> Dimensions { get; init; }
+
+    /// <summary>Maximum deviation across all dimensions (sigma units).</summary>
+    [JsonPropertyName("maxDeviation")]
+    public required double MaxDeviation { get; init; }
+
+    /// <summary>Severity classification string.</summary>
+    [JsonPropertyName("severity")]
+    public required string Severity { get; init; }
+}
+
+/// <summary>
+/// Signals that quality drift was detected at alert severity.
+/// Includes the baseline ID for correlation with baseline store records.
+/// </summary>
+public sealed record DriftAlertEvent : AgUiEvent
+{
+    /// <summary>The scope level at which drift was measured.</summary>
+    [JsonPropertyName("scope")]
+    public required string Scope { get; init; }
+
+    /// <summary>Identifier of the entity within the scope.</summary>
+    [JsonPropertyName("scopeIdentifier")]
+    public required string ScopeIdentifier { get; init; }
+
+    /// <summary>Per-dimension deviation values keyed by dimension name.</summary>
+    [JsonPropertyName("dimensions")]
+    public required IReadOnlyDictionary<string, double> Dimensions { get; init; }
+
+    /// <summary>Maximum deviation across all dimensions (sigma units).</summary>
+    [JsonPropertyName("maxDeviation")]
+    public required double MaxDeviation { get; init; }
+
+    /// <summary>Severity classification string.</summary>
+    [JsonPropertyName("severity")]
+    public required string Severity { get; init; }
+
+    /// <summary>The baseline this score was compared against.</summary>
+    [JsonPropertyName("baselineId")]
+    public required string BaselineId { get; init; }
+}
+
+/// <summary>
+/// Signals that quality drift was detected at escalation severity.
+/// An escalation request has been triggered and is awaiting human review.
+/// </summary>
+public sealed record DriftEscalateEvent : AgUiEvent
+{
+    /// <summary>The scope level at which drift was measured.</summary>
+    [JsonPropertyName("scope")]
+    public required string Scope { get; init; }
+
+    /// <summary>Identifier of the entity within the scope.</summary>
+    [JsonPropertyName("scopeIdentifier")]
+    public required string ScopeIdentifier { get; init; }
+
+    /// <summary>Per-dimension deviation values keyed by dimension name.</summary>
+    [JsonPropertyName("dimensions")]
+    public required IReadOnlyDictionary<string, double> Dimensions { get; init; }
+
+    /// <summary>Maximum deviation across all dimensions (sigma units).</summary>
+    [JsonPropertyName("maxDeviation")]
+    public required double MaxDeviation { get; init; }
+
+    /// <summary>Severity classification string.</summary>
+    [JsonPropertyName("severity")]
+    public required string Severity { get; init; }
+
+    /// <summary>The baseline this score was compared against.</summary>
+    [JsonPropertyName("baselineId")]
+    public required string BaselineId { get; init; }
+
+    /// <summary>
+    /// Escalation correlation ID. Empty when the escalation has not yet been queued;
+    /// clients correlate drift-escalate events with escalation-requested events by timestamp and scope.
+    /// </summary>
+    [JsonPropertyName("escalationId")]
+    public required string EscalationId { get; init; }
+}
+
+/// <summary>
+/// Signals that a previously detected drift has been resolved through
+/// learning application, baseline adjustment, manual dismissal, or escalation resolution.
+/// </summary>
+public sealed record DriftResolvedEvent : AgUiEvent
+{
+    /// <summary>The drift event that was resolved.</summary>
+    [JsonPropertyName("eventId")]
+    public required string EventId { get; init; }
+
+    /// <summary>How the drift was resolved (e.g. "LearningApplied", "BaselineAdjusted").</summary>
+    [JsonPropertyName("resolutionType")]
+    public required string ResolutionType { get; init; }
+
+    /// <summary>Identifier of the resolving entity (learning ID, escalation ID, etc.).</summary>
+    [JsonPropertyName("resolvedBy")]
+    public required string ResolvedBy { get; init; }
+
+    /// <summary>When the drift was resolved.</summary>
+    [JsonPropertyName("resolvedAt")]
+    public required DateTimeOffset ResolvedAt { get; init; }
 }

--- a/src/Content/Presentation/Presentation.AgentHub/DependencyInjection.cs
+++ b/src/Content/Presentation/Presentation.AgentHub/DependencyInjection.cs
@@ -1,7 +1,9 @@
 using System.Diagnostics;
 using System.Threading.RateLimiting;
 using Application.AI.Common.Interfaces;
+using Application.AI.Common.Interfaces.DriftDetection;
 using Application.AI.Common.Interfaces.Escalation;
+using Application.AI.Common.Interfaces.Learnings;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Http;
@@ -184,6 +186,8 @@ public static class DependencyInjection
 
         services.AddSingleton<IAgUiEventWriterAccessor, AgUiEventWriterAccessor>();
         services.AddSingleton<IEscalationNotificationChannel, AgUiEscalationNotifier>();
+        services.AddSingleton<IDriftNotificationChannel, AgUiDriftNotifier>();
+        services.AddSingleton<ILearningNotificationChannel, AgUiLearningNotifier>();
 
         // Scoped: AgUiRunHandler takes per-request dependencies (ClaimsPrincipal, CancellationToken).
         services.AddScoped<AgUi.AgUiRunHandler>();

--- a/src/Content/Presentation/Presentation.AgentHub/Notifications/AgUiDriftNotifier.cs
+++ b/src/Content/Presentation/Presentation.AgentHub/Notifications/AgUiDriftNotifier.cs
@@ -1,0 +1,134 @@
+using Application.AI.Common.Interfaces.DriftDetection;
+using Domain.AI.DriftDetection;
+using Microsoft.Extensions.Logging;
+using Presentation.AgentHub.AgUi;
+
+namespace Presentation.AgentHub.Notifications;
+
+/// <summary>
+/// AG-UI notification channel for drift detection events. Translates domain drift
+/// records into AG-UI SSE events and writes them to the active run's event stream.
+/// </summary>
+/// <remarks>
+/// If no AG-UI run is active (i.e., drift was detected from the ConsoleUI
+/// or a non-SSE context), the notifier silently skips event emission. This is by design --
+/// drift notifications also flow through other channels (logging, audit store).
+/// </remarks>
+public sealed class AgUiDriftNotifier : IDriftNotificationChannel
+{
+    private readonly IAgUiEventWriterAccessor _writerAccessor;
+    private readonly ILogger<AgUiDriftNotifier> _logger;
+
+    /// <summary>Initializes a new <see cref="AgUiDriftNotifier"/>.</summary>
+    public AgUiDriftNotifier(
+        IAgUiEventWriterAccessor writerAccessor,
+        ILogger<AgUiDriftNotifier> logger)
+    {
+        _writerAccessor = writerAccessor;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task NotifyDriftDetectedAsync(DriftScore score, CancellationToken ct)
+    {
+        var writer = _writerAccessor.Writer;
+        if (writer is null)
+        {
+            _logger.LogDebug("No AG-UI writer active; skipping drift-detected event for {Scope}:{ScopeIdentifier}.",
+                score.Scope, score.ScopeIdentifier);
+            return;
+        }
+
+        var evt = MapToEvent(score);
+        if (evt is null)
+            return;
+
+        try
+        {
+            await writer.WriteAsync(evt, ct);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogWarning(ex, "Failed to write drift-detected event for {Scope}:{ScopeIdentifier}.",
+                score.Scope, score.ScopeIdentifier);
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task NotifyDriftResolvedAsync(DriftEvent driftEvent, CancellationToken ct)
+    {
+        var writer = _writerAccessor.Writer;
+        if (writer is null)
+        {
+            _logger.LogDebug("No AG-UI writer active; skipping drift-resolved event for {EventId}.",
+                driftEvent.EventId);
+            return;
+        }
+
+        if (driftEvent.Resolution is null)
+        {
+            _logger.LogWarning("Cannot emit resolved event for unresolved drift {EventId}.", driftEvent.EventId);
+            return;
+        }
+
+        var evt = new DriftResolvedEvent
+        {
+            EventId = driftEvent.EventId.ToString(),
+            ResolutionType = driftEvent.Resolution.ResolvedBy.ToString(),
+            ResolvedBy = driftEvent.Resolution.ResolutionId,
+            ResolvedAt = driftEvent.Resolution.ResolvedAt,
+        };
+
+        try
+        {
+            await writer.WriteAsync(evt, ct);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogWarning(ex, "Failed to write drift-resolved event for {EventId}.",
+                driftEvent.EventId);
+        }
+    }
+
+    private static AgUiEvent? MapToEvent(DriftScore score)
+    {
+        if (score.Severity == DriftSeverity.None)
+            return null;
+
+        var dimensions = score.Dimensions.ToDictionary(
+            kvp => kvp.Key.ToString(),
+            kvp => kvp.Value.Deviation);
+
+        return score.Severity switch
+        {
+            DriftSeverity.Warn => new DriftWarnEvent
+            {
+                Scope = score.Scope.ToString(),
+                ScopeIdentifier = score.ScopeIdentifier,
+                Dimensions = dimensions,
+                MaxDeviation = score.OverallDrift,
+                Severity = score.Severity.ToString(),
+            },
+            DriftSeverity.Alert => new DriftAlertEvent
+            {
+                Scope = score.Scope.ToString(),
+                ScopeIdentifier = score.ScopeIdentifier,
+                Dimensions = dimensions,
+                MaxDeviation = score.OverallDrift,
+                Severity = score.Severity.ToString(),
+                BaselineId = score.BaselineId.ToString(),
+            },
+            DriftSeverity.Escalate => new DriftEscalateEvent
+            {
+                Scope = score.Scope.ToString(),
+                ScopeIdentifier = score.ScopeIdentifier,
+                Dimensions = dimensions,
+                MaxDeviation = score.OverallDrift,
+                Severity = score.Severity.ToString(),
+                BaselineId = score.BaselineId.ToString(),
+                EscalationId = string.Empty,
+            },
+            _ => null,
+        };
+    }
+}

--- a/src/Content/Presentation/Presentation.AgentHub/Notifications/AgUiLearningNotifier.cs
+++ b/src/Content/Presentation/Presentation.AgentHub/Notifications/AgUiLearningNotifier.cs
@@ -1,0 +1,90 @@
+using Application.AI.Common.Interfaces.Learnings;
+using Domain.AI.Learnings;
+using Microsoft.Extensions.Logging;
+using Presentation.AgentHub.AgUi;
+
+namespace Presentation.AgentHub.Notifications;
+
+/// <summary>
+/// AG-UI notification channel for learning events. Translates domain learning
+/// records into AG-UI SSE events and writes them to the active run's event stream.
+/// </summary>
+/// <remarks>
+/// If no AG-UI run is active (e.g., the learning was captured from ConsoleUI or
+/// a background pruning job), the notifier silently skips event emission.
+/// </remarks>
+public sealed class AgUiLearningNotifier : ILearningNotificationChannel
+{
+    private readonly IAgUiEventWriterAccessor _writerAccessor;
+    private readonly ILogger<AgUiLearningNotifier> _logger;
+
+    /// <summary>Initializes a new <see cref="AgUiLearningNotifier"/>.</summary>
+    public AgUiLearningNotifier(
+        IAgUiEventWriterAccessor writerAccessor,
+        ILogger<AgUiLearningNotifier> logger)
+    {
+        _writerAccessor = writerAccessor;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task NotifyLearningCapturedAsync(LearningEntry learning, CancellationToken ct)
+    {
+        var writer = _writerAccessor.Writer;
+        if (writer is null)
+        {
+            _logger.LogDebug("No AG-UI writer active; skipping learning-captured event for {LearningId}.",
+                learning.LearningId);
+            return;
+        }
+
+        var evt = new LearningCapturedEvent
+        {
+            LearningId = learning.LearningId.ToString(),
+            Category = learning.Category.ToString(),
+            AgentId = learning.Scope.AgentId,
+            TeamId = learning.Scope.TeamId,
+            IsGlobal = learning.Scope.IsGlobal,
+            SourceDescription = learning.Source.SourceDescription,
+        };
+
+        try
+        {
+            await writer.WriteAsync(evt, ct);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogWarning(ex, "Failed to write learning-captured event for {LearningId}.",
+                learning.LearningId);
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task NotifyLearningAppliedAsync(LearningEntry learning, string agentId, CancellationToken ct)
+    {
+        var writer = _writerAccessor.Writer;
+        if (writer is null)
+        {
+            _logger.LogDebug("No AG-UI writer active; skipping learning-applied event for {LearningId}.",
+                learning.LearningId);
+            return;
+        }
+
+        var evt = new LearningAppliedEvent
+        {
+            LearningId = learning.LearningId.ToString(),
+            AgentId = agentId,
+            Category = learning.Category.ToString(),
+        };
+
+        try
+        {
+            await writer.WriteAsync(evt, ct);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogWarning(ex, "Failed to write learning-applied event for {LearningId}.",
+                learning.LearningId);
+        }
+    }
+}

--- a/src/Content/Presentation/Presentation.AgentHub/appsettings.json
+++ b/src/Content/Presentation/Presentation.AgentHub/appsettings.json
@@ -94,6 +94,31 @@
           "MaxQueueSize": 100
         }
       },
+      "DriftDetection": {
+        "Enabled": true,
+        "EwmaLambda": 0.2,
+        "ControlLimitWidth": 3.0,
+        "MinSamplesForBaseline": 20,
+        "BaselineWindowDays": 7,
+        "WarnThresholdSigma": 1.5,
+        "AlertThresholdSigma": 2.5,
+        "EscalateThresholdSigma": 3.0,
+        "EscalationEnabled": true,
+        "AuditPath": "data/audit"
+      },
+      "Learnings": {
+        "Enabled": true,
+        "StoreProvider": "graph",
+        "FeedbackAlpha": 0.25,
+        "FeedbackCeiling": 0.3,
+        "DiversityInjectionRatio": 0.15,
+        "VolatileShelfLifeDays": 7,
+        "StableShelfLifeDays": 180,
+        "PruneIntervalHours": 24,
+        "BaselineAdjustmentThreshold": 0.8,
+        "BiasCorrection": true,
+        "DecayBiasAlpha": 0.25
+      },
       "Permissions": {
         "DefaultBehavior": "Ask",
         "DefaultAutonomyLevel": "Supervised",

--- a/src/Content/Presentation/Presentation.Common/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Content/Presentation/Presentation.Common/Extensions/IServiceCollectionExtensions.cs
@@ -15,6 +15,7 @@ using Domain.Common.Config.Observability;
 using Infrastructure.AI;
 using Infrastructure.AI.Connectors;
 using Infrastructure.AI.Governance;
+using Infrastructure.AI.KnowledgeGraph;
 using Infrastructure.AI.RAG;
 using Infrastructure.AI.MCP;
 using Infrastructure.APIAccess;
@@ -83,6 +84,10 @@ public static class IServiceCollectionExtensions
         services.Configure<CacheConfig>(configuration.GetSection("AppConfig:Cache"));
         services.Configure<EscalationConfig>(configuration.GetSection("AppConfig:AI:Governance:Escalation"));
         services.Configure<ResilienceConfig>(configuration.GetSection("AppConfig:AI:Resilience"));
+        services.Configure<Domain.Common.Config.AI.DriftDetection.DriftDetectionConfig>(
+            configuration.GetSection("AppConfig:AI:DriftDetection"));
+        services.Configure<Domain.Common.Config.AI.Learnings.LearningsConfig>(
+            configuration.GetSection("AppConfig:AI:Learnings"));
 
         return services;
     }
@@ -244,6 +249,7 @@ public static class IServiceCollectionExtensions
 
         // Infrastructure layer
         services.AddInfrastructureCommonDependencies();
+        services.AddKnowledgeGraphDependencies(appConfig);
         // RAG must register before Infrastructure.AI — tool registrations depend on IRagOrchestrator
         services.AddRagDependencies(appConfig);
         services.AddInfrastructureAIDependencies(appConfig);

--- a/src/Content/Presentation/Presentation.Common/Presentation.Common.csproj
+++ b/src/Content/Presentation/Presentation.Common/Presentation.Common.csproj
@@ -15,6 +15,7 @@
     <!-- Infrastructure layer -->
     <ProjectReference Include="..\..\Infrastructure\Infrastructure.Common\Infrastructure.Common.csproj" />
     <ProjectReference Include="..\..\Infrastructure\Infrastructure.AI\Infrastructure.AI.csproj" />
+    <ProjectReference Include="..\..\Infrastructure\Infrastructure.AI.KnowledgeGraph\Infrastructure.AI.KnowledgeGraph.csproj" />
     <ProjectReference Include="..\..\Infrastructure\Infrastructure.AI.Governance\Infrastructure.AI.Governance.csproj" />
     <ProjectReference Include="..\..\Infrastructure\Infrastructure.AI.RAG\Infrastructure.AI.RAG.csproj" />
     <ProjectReference Include="..\..\Infrastructure\Infrastructure.AI.Connectors\Infrastructure.AI.Connectors.csproj" />

--- a/src/Content/Presentation/Presentation.ConsoleUI/appsettings.json
+++ b/src/Content/Presentation/Presentation.ConsoleUI/appsettings.json
@@ -107,6 +107,31 @@
           "MaxQueueSize": 100
         }
       },
+      "DriftDetection": {
+        "Enabled": true,
+        "EwmaLambda": 0.2,
+        "ControlLimitWidth": 3.0,
+        "MinSamplesForBaseline": 20,
+        "BaselineWindowDays": 7,
+        "WarnThresholdSigma": 1.5,
+        "AlertThresholdSigma": 2.5,
+        "EscalateThresholdSigma": 3.0,
+        "EscalationEnabled": true,
+        "AuditPath": "data/audit"
+      },
+      "Learnings": {
+        "Enabled": true,
+        "StoreProvider": "graph",
+        "FeedbackAlpha": 0.25,
+        "FeedbackCeiling": 0.3,
+        "DiversityInjectionRatio": 0.15,
+        "VolatileShelfLifeDays": 7,
+        "StableShelfLifeDays": 180,
+        "PruneIntervalHours": 24,
+        "BaselineAdjustmentThreshold": 0.8,
+        "BiasCorrection": true,
+        "DecayBiasAlpha": 0.25
+      },
       "Permissions": {
         "DefaultBehavior": "Ask",
         "DefaultAutonomyLevel": "Supervised",

--- a/src/Content/Tests/Application.Core.Tests/Application.Core.Tests.csproj
+++ b/src/Content/Tests/Application.Core.Tests/Application.Core.Tests.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="coverlet.collector" />
     <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
     <PackageReference Include="Moq" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />

--- a/src/Content/Tests/Application.Core.Tests/CQRS/Learnings/ForgetCommandHandlerTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/CQRS/Learnings/ForgetCommandHandlerTests.cs
@@ -1,0 +1,83 @@
+using Application.AI.Common.Interfaces.Learnings;
+using Application.Core.CQRS.Learnings;
+using Domain.Common;
+using Domain.Common.Config;
+using Domain.Common.Config.AI;
+using Domain.Common.Config.AI.Learnings;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Application.Core.Tests.CQRS.Learnings;
+
+/// <summary>
+/// Tests for <see cref="ForgetCommandHandler"/>.
+/// </summary>
+public sealed class ForgetCommandHandlerTests
+{
+    private readonly Mock<ILearningsStore> _store = new();
+    private readonly ForgetCommandHandler _handler;
+
+    public ForgetCommandHandlerTests()
+    {
+        _handler = CreateHandler();
+    }
+
+    [Fact]
+    public async Task Handle_ValidId_SoftDeletesLearning()
+    {
+        var learningId = Guid.NewGuid();
+        _store.Setup(s => s.SoftDeleteAsync(learningId, "outdated", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Success());
+
+        var result = await _handler.Handle(
+            new ForgetCommand { LearningId = learningId, Reason = "outdated" },
+            CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        _store.Verify(s => s.SoftDeleteAsync(learningId, "outdated", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_NotFound_ReturnsNotFound()
+    {
+        var learningId = Guid.NewGuid();
+        _store.Setup(s => s.SoftDeleteAsync(learningId, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.NotFound("Not found"));
+
+        var result = await _handler.Handle(
+            new ForgetCommand { LearningId = learningId, Reason = "cleanup" },
+            CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.FailureType.Should().Be(ResultFailureType.NotFound);
+    }
+
+    [Fact]
+    public async Task Handle_Disabled_ReturnsSuccessNoOp()
+    {
+        var handler = CreateHandler(new LearningsConfig { Enabled = false });
+
+        var result = await handler.Handle(
+            new ForgetCommand { LearningId = Guid.NewGuid(), Reason = "test" },
+            CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        _store.Verify(s => s.SoftDeleteAsync(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    private ForgetCommandHandler CreateHandler(LearningsConfig? config = null) => new(
+        _store.Object,
+        CreateOptions(config ?? new LearningsConfig()),
+        NullLogger<ForgetCommandHandler>.Instance);
+
+    private static IOptionsMonitor<AppConfig> CreateOptions(LearningsConfig config)
+    {
+        var appConfig = new AppConfig { AI = new AIConfig { Learnings = config } };
+        var mock = new Mock<IOptionsMonitor<AppConfig>>();
+        mock.Setup(m => m.CurrentValue).Returns(appConfig);
+        return mock.Object;
+    }
+}

--- a/src/Content/Tests/Application.Core.Tests/CQRS/Learnings/ImproveLearningCommandHandlerTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/CQRS/Learnings/ImproveLearningCommandHandlerTests.cs
@@ -1,0 +1,205 @@
+using Application.AI.Common.Interfaces.Learnings;
+using Application.Core.CQRS.Learnings;
+using Domain.AI.Learnings;
+using Domain.Common;
+using Domain.Common.Config;
+using Domain.Common.Config.AI;
+using Domain.Common.Config.AI.Learnings;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Time.Testing;
+using Moq;
+using Xunit;
+
+namespace Application.Core.Tests.CQRS.Learnings;
+
+/// <summary>
+/// Tests for <see cref="ImproveLearningCommandHandler"/>.
+/// </summary>
+public sealed class ImproveLearningCommandHandlerTests
+{
+    private readonly Mock<ILearningsStore> _store = new();
+    private readonly FakeTimeProvider _timeProvider = new(new DateTimeOffset(2026, 5, 14, 12, 0, 0, TimeSpan.Zero));
+
+    [Fact]
+    public async Task Handle_AppliesEmaToFeedbackWeight()
+    {
+        var learning = CreateLearning(feedbackWeight: 1.0, updateCount: 0);
+        SetupGetAndUpdate(learning);
+        var config = new LearningsConfig { FeedbackAlpha = 0.25, BiasCorrection = false };
+        var handler = CreateHandler(config);
+
+        var result = await handler.Handle(
+            new ImproveLearningCommand { LearningId = learning.LearningId, FeedbackScore = 4.0 },
+            CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        // normalized = (4.0 - 1.0) / 4.0 = 0.75
+        // newWeight = 0.25 * 0.75 + 0.75 * 1.0 = 0.9375
+        result.Value!.FeedbackWeight.Should().BeApproximately(0.9375, 0.001);
+    }
+
+    [Fact]
+    public async Task Handle_EmaCalculation_KnownInputs()
+    {
+        var learning = CreateLearning(feedbackWeight: 0.6, updateCount: 3);
+        SetupGetAndUpdate(learning);
+        var config = new LearningsConfig { FeedbackAlpha = 0.25, BiasCorrection = false };
+        var handler = CreateHandler(config);
+
+        var result = await handler.Handle(
+            new ImproveLearningCommand { LearningId = learning.LearningId, FeedbackScore = 5.0 },
+            CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        // normalized = (5.0 - 1.0) / 4.0 = 1.0
+        // newWeight = 0.25 * 1.0 + 0.75 * 0.6 = 0.7
+        result.Value!.FeedbackWeight.Should().BeApproximately(0.7, 0.001);
+    }
+
+    [Fact]
+    public async Task Handle_BiasCorrection_NewLearning()
+    {
+        var learning = CreateLearning(feedbackWeight: 1.0, updateCount: 1);
+        SetupGetAndUpdate(learning);
+        var config = new LearningsConfig { FeedbackAlpha = 0.25, BiasCorrection = true };
+        var handler = CreateHandler(config);
+
+        var result = await handler.Handle(
+            new ImproveLearningCommand { LearningId = learning.LearningId, FeedbackScore = 4.0 },
+            CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        // normalized = 0.75
+        // rawWeight = 0.25 * 0.75 + 0.75 * 1.0 = 0.9375
+        // correctionFactor = 1 / (1 - (0.75)^2) = 1 / (1 - 0.5625) = 1 / 0.4375 ≈ 2.2857
+        // corrected = clamp(0.9375 * 2.2857, 0, 1) = clamp(2.1429, 0, 1) = 1.0
+        result.Value!.FeedbackWeight.Should().BeApproximately(1.0, 0.001);
+    }
+
+    [Fact]
+    public async Task Handle_BiasCorrection_Disabled_NoAdjustment()
+    {
+        var learning = CreateLearning(feedbackWeight: 1.0, updateCount: 1);
+        SetupGetAndUpdate(learning);
+        var config = new LearningsConfig { FeedbackAlpha = 0.25, BiasCorrection = false };
+        var handler = CreateHandler(config);
+
+        var result = await handler.Handle(
+            new ImproveLearningCommand { LearningId = learning.LearningId, FeedbackScore = 4.0 },
+            CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        // Without bias correction: 0.25 * 0.75 + 0.75 * 1.0 = 0.9375
+        result.Value!.FeedbackWeight.Should().BeApproximately(0.9375, 0.001);
+    }
+
+    [Fact]
+    public async Task Handle_IncrementsUpdateCount()
+    {
+        var learning = CreateLearning(updateCount: 2);
+        SetupGetAndUpdate(learning);
+        var handler = CreateHandler();
+
+        var result = await handler.Handle(
+            new ImproveLearningCommand { LearningId = learning.LearningId, FeedbackScore = 3.0 },
+            CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.UpdateCount.Should().Be(3);
+    }
+
+    [Fact]
+    public async Task Handle_SetsLastReinforcedAt()
+    {
+        var learning = CreateLearning();
+        SetupGetAndUpdate(learning);
+        var handler = CreateHandler();
+
+        var result = await handler.Handle(
+            new ImproveLearningCommand { LearningId = learning.LearningId, FeedbackScore = 3.0 },
+            CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.LastReinforcedAt.Should().Be(_timeProvider.GetUtcNow());
+    }
+
+    [Fact]
+    public async Task Handle_LearningNotFound_ReturnsNotFound()
+    {
+        var learningId = Guid.NewGuid();
+        _store.Setup(s => s.GetAsync(learningId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<LearningEntry?>.Success(null));
+        var handler = CreateHandler();
+
+        var result = await handler.Handle(
+            new ImproveLearningCommand { LearningId = learningId, FeedbackScore = 3.0 },
+            CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.FailureType.Should().Be(ResultFailureType.NotFound);
+    }
+
+    [Fact]
+    public async Task Handle_Disabled_ReturnsSuccessNoOp()
+    {
+        var handler = CreateHandler(new LearningsConfig { Enabled = false });
+
+        var result = await handler.Handle(
+            new ImproveLearningCommand { LearningId = Guid.NewGuid(), FeedbackScore = 3.0 },
+            CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        _store.Verify(s => s.GetAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    private ImproveLearningCommandHandler CreateHandler(LearningsConfig? config = null) => new(
+        _store.Object,
+        CreateOptions(config ?? new LearningsConfig { BiasCorrection = false }),
+        _timeProvider,
+        NullLogger<ImproveLearningCommandHandler>.Instance);
+
+    private void SetupGetAndUpdate(LearningEntry learning)
+    {
+        _store.Setup(s => s.GetAsync(learning.LearningId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<LearningEntry?>.Success(learning));
+        _store.Setup(s => s.UpdateAsync(It.IsAny<LearningEntry>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Success());
+    }
+
+    private static LearningEntry CreateLearning(
+        double feedbackWeight = 1.0,
+        int updateCount = 0) => new()
+    {
+        LearningId = Guid.NewGuid(),
+        Category = LearningCategory.FactualCorrection,
+        DecayClass = DecayClass.Permanent,
+        Scope = new LearningScope { AgentId = "agent-1" },
+        Content = "Test content",
+        Source = new LearningSource
+        {
+            SourceType = LearningSourceType.DriftDetection,
+            SourceId = "drift-1",
+            SourceDescription = "Test drift"
+        },
+        Provenance = new LearningProvenance
+        {
+            OriginPipeline = "test",
+            OriginTask = "test",
+            OriginTimestamp = DateTimeOffset.UtcNow,
+            Confidence = 1.0
+        },
+        CreatedAt = DateTimeOffset.UtcNow,
+        FeedbackWeight = feedbackWeight,
+        UpdateCount = updateCount
+    };
+
+    private static IOptionsMonitor<AppConfig> CreateOptions(LearningsConfig config)
+    {
+        var appConfig = new AppConfig { AI = new AIConfig { Learnings = config } };
+        var mock = new Mock<IOptionsMonitor<AppConfig>>();
+        mock.Setup(m => m.CurrentValue).Returns(appConfig);
+        return mock.Object;
+    }
+}

--- a/src/Content/Tests/Application.Core.Tests/CQRS/Learnings/ImproveLearningCommandHandlerTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/CQRS/Learnings/ImproveLearningCommandHandlerTests.cs
@@ -20,7 +20,15 @@ namespace Application.Core.Tests.CQRS.Learnings;
 public sealed class ImproveLearningCommandHandlerTests
 {
     private readonly Mock<ILearningsStore> _store = new();
+    private readonly Mock<ILearningsDriftBridge> _driftBridge = new();
     private readonly FakeTimeProvider _timeProvider = new(new DateTimeOffset(2026, 5, 14, 12, 0, 0, TimeSpan.Zero));
+
+    public ImproveLearningCommandHandlerTests()
+    {
+        _driftBridge
+            .Setup(b => b.CheckAndAdjustBaselineAsync(It.IsAny<LearningEntry>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Success());
+    }
 
     [Fact]
     public async Task Handle_AppliesEmaToFeedbackWeight()
@@ -156,6 +164,7 @@ public sealed class ImproveLearningCommandHandlerTests
 
     private ImproveLearningCommandHandler CreateHandler(LearningsConfig? config = null) => new(
         _store.Object,
+        _driftBridge.Object,
         CreateOptions(config ?? new LearningsConfig { BiasCorrection = false }),
         _timeProvider,
         NullLogger<ImproveLearningCommandHandler>.Instance);
@@ -194,6 +203,53 @@ public sealed class ImproveLearningCommandHandlerTests
         FeedbackWeight = feedbackWeight,
         UpdateCount = updateCount
     };
+
+    [Fact]
+    public async Task Handle_SuccessfulUpdate_CallsBridge()
+    {
+        var learning = CreateLearning(feedbackWeight: 0.9);
+        SetupGetAndUpdate(learning);
+        var handler = CreateHandler();
+
+        await handler.Handle(
+            new ImproveLearningCommand { LearningId = learning.LearningId, FeedbackScore = 5.0 },
+            CancellationToken.None);
+
+        _driftBridge.Verify(
+            b => b.CheckAndAdjustBaselineAsync(It.IsAny<LearningEntry>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_BridgeFailure_StillReturnsSuccess()
+    {
+        var learning = CreateLearning(feedbackWeight: 0.9);
+        SetupGetAndUpdate(learning);
+        _driftBridge
+            .Setup(b => b.CheckAndAdjustBaselineAsync(It.IsAny<LearningEntry>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Fail("Bridge error"));
+        var handler = CreateHandler();
+
+        var result = await handler.Handle(
+            new ImproveLearningCommand { LearningId = learning.LearningId, FeedbackScore = 5.0 },
+            CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Handle_Disabled_DoesNotCallBridge()
+    {
+        var handler = CreateHandler(new LearningsConfig { Enabled = false });
+
+        await handler.Handle(
+            new ImproveLearningCommand { LearningId = Guid.NewGuid(), FeedbackScore = 3.0 },
+            CancellationToken.None);
+
+        _driftBridge.Verify(
+            b => b.CheckAndAdjustBaselineAsync(It.IsAny<LearningEntry>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
 
     private static IOptionsMonitor<AppConfig> CreateOptions(LearningsConfig config)
     {

--- a/src/Content/Tests/Application.Core.Tests/CQRS/Learnings/LearningsMetricsTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/CQRS/Learnings/LearningsMetricsTests.cs
@@ -1,0 +1,54 @@
+using Application.AI.Common.OpenTelemetry.Metrics;
+using FluentAssertions;
+using Xunit;
+
+namespace Application.Core.Tests.CQRS.Learnings;
+
+/// <summary>
+/// Smoke tests for <see cref="LearningsMetrics"/> instrument creation.
+/// Verifies static instruments are non-null and have correct names.
+/// </summary>
+public sealed class LearningsMetricsTests
+{
+    [Fact]
+    public void Remembered_Counter_IsNotNull()
+    {
+        LearningsMetrics.Remembered.Should().NotBeNull();
+        LearningsMetrics.Remembered.Name.Should().Be("agent.learning.remembered");
+    }
+
+    [Fact]
+    public void Recalled_Counter_IsNotNull()
+    {
+        LearningsMetrics.Recalled.Should().NotBeNull();
+        LearningsMetrics.Recalled.Name.Should().Be("agent.learning.recalled");
+    }
+
+    [Fact]
+    public void Forgotten_Counter_IsNotNull()
+    {
+        LearningsMetrics.Forgotten.Should().NotBeNull();
+        LearningsMetrics.Forgotten.Name.Should().Be("agent.learning.forgotten");
+    }
+
+    [Fact]
+    public void Improved_Counter_IsNotNull()
+    {
+        LearningsMetrics.Improved.Should().NotBeNull();
+        LearningsMetrics.Improved.Name.Should().Be("agent.learning.improved");
+    }
+
+    [Fact]
+    public void Pruned_Counter_IsNotNull()
+    {
+        LearningsMetrics.Pruned.Should().NotBeNull();
+        LearningsMetrics.Pruned.Name.Should().Be("agent.learning.pruned");
+    }
+
+    [Fact]
+    public void RecallDurationMs_Histogram_IsNotNull()
+    {
+        LearningsMetrics.RecallDurationMs.Should().NotBeNull();
+        LearningsMetrics.RecallDurationMs.Name.Should().Be("agent.learning.recall_duration_ms");
+    }
+}

--- a/src/Content/Tests/Application.Core.Tests/CQRS/Learnings/RecallQueryHandlerTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/CQRS/Learnings/RecallQueryHandlerTests.cs
@@ -1,0 +1,242 @@
+using Application.AI.Common.Interfaces.Learnings;
+using Application.AI.Common.Interfaces.RAG;
+using Application.Core.CQRS.Learnings;
+using Domain.AI.Learnings;
+using Domain.Common;
+using Domain.Common.Config;
+using Domain.Common.Config.AI;
+using Domain.Common.Config.AI.Learnings;
+using FluentAssertions;
+using MediatR;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Time.Testing;
+using Moq;
+using Xunit;
+
+namespace Application.Core.Tests.CQRS.Learnings;
+
+/// <summary>
+/// Tests for <see cref="RecallQueryHandler"/>.
+/// </summary>
+public sealed class RecallQueryHandlerTests
+{
+    private readonly Mock<ILearningsStore> _store = new();
+    private readonly Mock<ILearningDecayService> _decayService = new();
+    private readonly Mock<IEmbeddingService> _embeddingService = new();
+    private readonly Mock<IMediator> _mediator = new();
+    private readonly FakeTimeProvider _timeProvider = new(new DateTimeOffset(2026, 5, 14, 12, 0, 0, TimeSpan.Zero));
+    private readonly LearningsConfig _config = new();
+
+    public RecallQueryHandlerTests()
+    {
+        _mediator.Setup(m => m.Send(It.IsAny<RecordLearningAccessCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Success());
+    }
+
+    [Fact]
+    public async Task Handle_MatchingLearnings_ReturnsSortedByFinalScore()
+    {
+        var learnings = new List<LearningEntry>
+        {
+            CreateLearning("high relevance"),
+            CreateLearning("medium relevance"),
+            CreateLearning("low relevance")
+        };
+
+        SetupStore(learnings);
+        SetupEmbeddingsWithSimilarities([0.9, 0.5, 0.7]);
+        _decayService.Setup(d => d.CalculateFreshnessAsync(It.IsAny<LearningEntry>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1.0);
+
+        var handler = CreateHandler();
+        var result = await handler.Handle(CreateQuery(), CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.Should().HaveCount(3);
+        result.Value[0].RelevanceScore.Should().BeApproximately(0.9, 0.01);
+        result.Value[0].FinalScore.Should().BeGreaterThan(result.Value[1].FinalScore);
+    }
+
+    [Fact]
+    public async Task Handle_FeedbackCeiling_CapsInfluence()
+    {
+        var learning = CreateLearning("high feedback", feedbackWeight: 5.0);
+        SetupStore([learning]);
+        SetupUniformEmbedding(0.8);
+        _decayService.Setup(d => d.CalculateFreshnessAsync(It.IsAny<LearningEntry>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1.0);
+
+        var config = new LearningsConfig { FeedbackAlpha = 0.25, FeedbackCeiling = 0.3 };
+        var handler = CreateHandler(config);
+        var result = await handler.Handle(CreateQuery(), CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        var wl = result.Value![0];
+        var expectedFinal = (1 - 0.25) * 0.8 + 0.25 * Math.Min(5.0 * 1.0, 0.3);
+        wl.FinalScore.Should().BeApproximately(expectedFinal, 0.01);
+    }
+
+    [Fact]
+    public async Task Handle_FiresRecordLearningAccessCommand()
+    {
+        var learnings = new List<LearningEntry> { CreateLearning("l1"), CreateLearning("l2") };
+        SetupStore(learnings);
+        SetupUniformEmbedding(0.8);
+        _decayService.Setup(d => d.CalculateFreshnessAsync(It.IsAny<LearningEntry>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1.0);
+
+        var handler = CreateHandler();
+        await handler.Handle(CreateQuery(), CancellationToken.None);
+
+        _mediator.Verify(
+            m => m.Send(It.Is<RecordLearningAccessCommand>(c => c.LearningIds.Count == 2), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_EmptyResults_ReturnsEmptyList()
+    {
+        _store.Setup(s => s.SearchAsync(It.IsAny<LearningSearchCriteria>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<IReadOnlyList<LearningEntry>>.Success(Array.Empty<LearningEntry>()));
+
+        var handler = CreateHandler();
+        var result = await handler.Handle(CreateQuery(), CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Handle_UsesEmbeddingServiceForRelevance()
+    {
+        SetupStore([CreateLearning("test")]);
+        SetupUniformEmbedding(0.5);
+        _decayService.Setup(d => d.CalculateFreshnessAsync(It.IsAny<LearningEntry>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1.0);
+
+        var handler = CreateHandler();
+        await handler.Handle(CreateQuery("my query"), CancellationToken.None);
+
+        _embeddingService.Verify(
+            e => e.EmbedQueryAsync("my query", It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_Disabled_ReturnsSuccessEmptyList()
+    {
+        var handler = CreateHandler(new LearningsConfig { Enabled = false });
+        var result = await handler.Handle(CreateQuery(), CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeEmpty();
+        _store.Verify(s => s.SearchAsync(It.IsAny<LearningSearchCriteria>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_DiversityInjection_SkippedWhenTooFewResults()
+    {
+        SetupStore([CreateLearning("only one")]);
+        SetupUniformEmbedding(0.8);
+        _decayService.Setup(d => d.CalculateFreshnessAsync(It.IsAny<LearningEntry>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1.0);
+
+        var handler = CreateHandler(new LearningsConfig { DiversityInjectionRatio = 0.15 });
+        var result = await handler.Handle(CreateQuery(maxResults: 10), CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().HaveCount(1);
+    }
+
+    private RecallQueryHandler CreateHandler(LearningsConfig? config = null) => new(
+        _store.Object,
+        _decayService.Object,
+        _embeddingService.Object,
+        _mediator.Object,
+        CreateOptions(config ?? _config),
+        _timeProvider,
+        NullLogger<RecallQueryHandler>.Instance);
+
+    private void SetupStore(IReadOnlyList<LearningEntry> learnings)
+    {
+        _store.Setup(s => s.SearchAsync(It.IsAny<LearningSearchCriteria>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<IReadOnlyList<LearningEntry>>.Success(learnings));
+    }
+
+    private void SetupEmbeddingsWithSimilarities(double[] similarities)
+    {
+        var queryVector = CreateVector(1.0f, 0.0f, 0.0f);
+        var callCount = 0;
+
+        _embeddingService.Setup(e => e.EmbedQueryAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() =>
+            {
+                var index = callCount++;
+                if (index == 0) return new ReadOnlyMemory<float>(queryVector);
+
+                var sim = (float)similarities[index - 1];
+                var perpComponent = (float)Math.Sqrt(1 - sim * sim);
+                return new ReadOnlyMemory<float>([sim, perpComponent, 0]);
+            });
+    }
+
+    private void SetupUniformEmbedding(double similarity)
+    {
+        var queryVector = CreateVector(1.0f, 0.0f, 0.0f);
+        var sim = (float)similarity;
+        var perpComponent = (float)Math.Sqrt(1 - sim * sim);
+        var contentVector = new float[] { sim, perpComponent, 0 };
+        var callCount = 0;
+
+        _embeddingService.Setup(e => e.EmbedQueryAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() =>
+            {
+                var index = callCount++;
+                return index == 0
+                    ? new ReadOnlyMemory<float>(queryVector)
+                    : new ReadOnlyMemory<float>(contentVector);
+            });
+    }
+
+    private static float[] CreateVector(float x, float y, float z) => [x, y, z];
+
+    private static RecallQuery CreateQuery(string context = "test context", int maxResults = 10) => new()
+    {
+        Context = context,
+        Scope = new LearningScope { AgentId = "agent-1" },
+        MaxResults = maxResults
+    };
+
+    private static LearningEntry CreateLearning(string content, double feedbackWeight = 1.0) => new()
+    {
+        LearningId = Guid.NewGuid(),
+        Category = LearningCategory.FactualCorrection,
+        DecayClass = DecayClass.Permanent,
+        Scope = new LearningScope { AgentId = "agent-1" },
+        Content = content,
+        Source = new LearningSource
+        {
+            SourceType = LearningSourceType.HumanCorrection,
+            SourceId = "src-1",
+            SourceDescription = "Test"
+        },
+        Provenance = new LearningProvenance
+        {
+            OriginPipeline = "test",
+            OriginTask = "test",
+            OriginTimestamp = DateTimeOffset.UtcNow,
+            Confidence = 1.0
+        },
+        CreatedAt = DateTimeOffset.UtcNow,
+        FeedbackWeight = feedbackWeight
+    };
+
+    private static IOptionsMonitor<AppConfig> CreateOptions(LearningsConfig config)
+    {
+        var appConfig = new AppConfig { AI = new AIConfig { Learnings = config } };
+        var mock = new Mock<IOptionsMonitor<AppConfig>>();
+        mock.Setup(m => m.CurrentValue).Returns(appConfig);
+        return mock.Object;
+    }
+}

--- a/src/Content/Tests/Application.Core.Tests/CQRS/Learnings/RecordLearningAccessCommandHandlerTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/CQRS/Learnings/RecordLearningAccessCommandHandlerTests.cs
@@ -1,0 +1,105 @@
+using Application.AI.Common.Interfaces.Learnings;
+using Application.Core.CQRS.Learnings;
+using Domain.AI.Learnings;
+using Domain.Common;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Application.Core.Tests.CQRS.Learnings;
+
+/// <summary>
+/// Tests for <see cref="RecordLearningAccessCommandHandler"/>.
+/// </summary>
+public sealed class RecordLearningAccessCommandHandlerTests
+{
+    private readonly Mock<ILearningsStore> _store = new();
+    private readonly RecordLearningAccessCommandHandler _handler;
+
+    public RecordLearningAccessCommandHandlerTests()
+    {
+        _handler = new RecordLearningAccessCommandHandler(
+            _store.Object,
+            NullLogger<RecordLearningAccessCommandHandler>.Instance);
+    }
+
+    [Fact]
+    public async Task Handle_UpdatesLastAccessedAt()
+    {
+        var learningId = Guid.NewGuid();
+        var accessedAt = new DateTimeOffset(2026, 5, 14, 12, 0, 0, TimeSpan.Zero);
+        var learning = CreateLearning(learningId);
+
+        _store.Setup(s => s.GetAsync(learningId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<LearningEntry?>.Success(learning));
+        _store.Setup(s => s.UpdateAsync(It.IsAny<LearningEntry>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Success());
+
+        var result = await _handler.Handle(
+            new RecordLearningAccessCommand { LearningIds = [learningId], AccessedAt = accessedAt },
+            CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        _store.Verify(s => s.UpdateAsync(
+            It.Is<LearningEntry>(e => e.LastAccessedAt == accessedAt),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_MissingLearning_SkipsWithoutError()
+    {
+        var learningId = Guid.NewGuid();
+        _store.Setup(s => s.GetAsync(learningId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<LearningEntry?>.Success(null));
+
+        var result = await _handler.Handle(
+            new RecordLearningAccessCommand
+            {
+                LearningIds = [learningId],
+                AccessedAt = DateTimeOffset.UtcNow
+            },
+            CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        _store.Verify(s => s.UpdateAsync(It.IsAny<LearningEntry>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_EmptyIdList_ReturnsSuccess()
+    {
+        var result = await _handler.Handle(
+            new RecordLearningAccessCommand
+            {
+                LearningIds = [],
+                AccessedAt = DateTimeOffset.UtcNow
+            },
+            CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        _store.Verify(s => s.GetAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    private static LearningEntry CreateLearning(Guid id) => new()
+    {
+        LearningId = id,
+        Category = LearningCategory.FactualCorrection,
+        DecayClass = DecayClass.Permanent,
+        Scope = new LearningScope { IsGlobal = true },
+        Content = "Test content",
+        Source = new LearningSource
+        {
+            SourceType = LearningSourceType.HumanCorrection,
+            SourceId = "src-1",
+            SourceDescription = "Test"
+        },
+        Provenance = new LearningProvenance
+        {
+            OriginPipeline = "test",
+            OriginTask = "test",
+            OriginTimestamp = DateTimeOffset.UtcNow,
+            Confidence = 1.0
+        },
+        CreatedAt = DateTimeOffset.UtcNow
+    };
+}

--- a/src/Content/Tests/Application.Core.Tests/CQRS/Learnings/RememberCommandHandlerTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/CQRS/Learnings/RememberCommandHandlerTests.cs
@@ -1,0 +1,191 @@
+using Application.AI.Common.Interfaces.Learnings;
+using Application.Core.CQRS.Learnings;
+using Domain.AI.Learnings;
+using Domain.Common;
+using Domain.Common.Config;
+using Domain.Common.Config.AI;
+using Domain.Common.Config.AI.Learnings;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Time.Testing;
+using Moq;
+using Xunit;
+
+namespace Application.Core.Tests.CQRS.Learnings;
+
+/// <summary>
+/// Tests for <see cref="RememberCommandHandler"/>.
+/// </summary>
+public sealed class RememberCommandHandlerTests
+{
+    private readonly Mock<ILearningsStore> _store = new();
+    private readonly Mock<ILearningNotificationChannel> _notifications = new();
+    private readonly FakeTimeProvider _timeProvider = new(new DateTimeOffset(2026, 5, 14, 12, 0, 0, TimeSpan.Zero));
+    private readonly RememberCommandHandler _handler;
+    private readonly LearningsConfig _learningsConfig = new();
+
+    public RememberCommandHandlerTests()
+    {
+        _store.Setup(s => s.SaveAsync(It.IsAny<LearningEntry>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Success());
+
+        _handler = new RememberCommandHandler(
+            _store.Object,
+            _notifications.Object,
+            CreateOptions(_learningsConfig),
+            _timeProvider,
+            NullLogger<RememberCommandHandler>.Instance);
+    }
+
+    [Fact]
+    public async Task Handle_ValidInput_SavesLearningToStore()
+    {
+        var command = CreateCommand();
+        LearningEntry? savedEntry = null;
+        _store.Setup(s => s.SaveAsync(It.IsAny<LearningEntry>(), It.IsAny<CancellationToken>()))
+            .Callback<LearningEntry, CancellationToken>((e, _) => savedEntry = e)
+            .ReturnsAsync(Result.Success());
+
+        await _handler.Handle(command, CancellationToken.None);
+
+        savedEntry.Should().NotBeNull();
+        savedEntry!.Content.Should().Be(command.Content);
+        savedEntry.Category.Should().Be(command.Category);
+        savedEntry.Scope.Should().Be(command.Scope);
+        savedEntry.Source.Should().Be(command.Source);
+        savedEntry.Provenance.Should().Be(command.Provenance);
+        savedEntry.FeedbackWeight.Should().Be(1.0);
+        savedEntry.UpdateCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Handle_FactualCorrection_SetsPermanentDecay()
+    {
+        var command = CreateCommand(category: LearningCategory.FactualCorrection);
+        LearningEntry? saved = null;
+        _store.Setup(s => s.SaveAsync(It.IsAny<LearningEntry>(), It.IsAny<CancellationToken>()))
+            .Callback<LearningEntry, CancellationToken>((e, _) => saved = e)
+            .ReturnsAsync(Result.Success());
+
+        await _handler.Handle(command, CancellationToken.None);
+
+        saved!.DecayClass.Should().Be(DecayClass.Permanent);
+    }
+
+    [Fact]
+    public async Task Handle_StylePreference_SetsStableDecay()
+    {
+        var command = CreateCommand(category: LearningCategory.StylePreference);
+        LearningEntry? saved = null;
+        _store.Setup(s => s.SaveAsync(It.IsAny<LearningEntry>(), It.IsAny<CancellationToken>()))
+            .Callback<LearningEntry, CancellationToken>((e, _) => saved = e)
+            .ReturnsAsync(Result.Success());
+
+        await _handler.Handle(command, CancellationToken.None);
+
+        saved!.DecayClass.Should().Be(DecayClass.Stable);
+    }
+
+    [Fact]
+    public async Task Handle_ExplicitDecayClass_OverridesDefault()
+    {
+        var command = CreateCommand(category: LearningCategory.FactualCorrection, decayClass: DecayClass.Volatile);
+        LearningEntry? saved = null;
+        _store.Setup(s => s.SaveAsync(It.IsAny<LearningEntry>(), It.IsAny<CancellationToken>()))
+            .Callback<LearningEntry, CancellationToken>((e, _) => saved = e)
+            .ReturnsAsync(Result.Success());
+
+        await _handler.Handle(command, CancellationToken.None);
+
+        saved!.DecayClass.Should().Be(DecayClass.Volatile);
+    }
+
+    [Fact]
+    public async Task Handle_ValidInput_EmitsLearningCapturedNotification()
+    {
+        var command = CreateCommand();
+
+        await _handler.Handle(command, CancellationToken.None);
+
+        _notifications.Verify(
+            n => n.NotifyLearningCapturedAsync(It.IsAny<LearningEntry>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ValidInput_ReturnsSuccessWithEntry()
+    {
+        var command = CreateCommand();
+
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBeNull();
+        result.Value!.Content.Should().Be(command.Content);
+    }
+
+    [Fact]
+    public async Task Handle_Disabled_ReturnsSuccessNoOp()
+    {
+        var handler = CreateHandler(new LearningsConfig { Enabled = false });
+        var command = CreateCommand();
+
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        _store.Verify(s => s.SaveAsync(It.IsAny<LearningEntry>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_UsesTimeProviderForTimestamps()
+    {
+        var command = CreateCommand();
+        LearningEntry? saved = null;
+        _store.Setup(s => s.SaveAsync(It.IsAny<LearningEntry>(), It.IsAny<CancellationToken>()))
+            .Callback<LearningEntry, CancellationToken>((e, _) => saved = e)
+            .ReturnsAsync(Result.Success());
+
+        await _handler.Handle(command, CancellationToken.None);
+
+        saved!.CreatedAt.Should().Be(_timeProvider.GetUtcNow());
+    }
+
+    private RememberCommandHandler CreateHandler(LearningsConfig? config = null) => new(
+        _store.Object,
+        _notifications.Object,
+        CreateOptions(config ?? _learningsConfig),
+        _timeProvider,
+        NullLogger<RememberCommandHandler>.Instance);
+
+    private static RememberCommand CreateCommand(
+        LearningCategory category = LearningCategory.FactualCorrection,
+        DecayClass? decayClass = null) => new()
+    {
+        Content = "Test learning content",
+        Category = category,
+        Scope = new LearningScope { AgentId = "agent-1" },
+        Source = new LearningSource
+        {
+            SourceType = LearningSourceType.HumanCorrection,
+            SourceId = "test-source-1",
+            SourceDescription = "Test correction"
+        },
+        Provenance = new LearningProvenance
+        {
+            OriginPipeline = "test_pipeline",
+            OriginTask = "test_task",
+            OriginTimestamp = DateTimeOffset.UtcNow,
+            Confidence = 0.95
+        },
+        DecayClass = decayClass
+    };
+
+    private static IOptionsMonitor<AppConfig> CreateOptions(LearningsConfig config)
+    {
+        var appConfig = new AppConfig { AI = new AIConfig { Learnings = config } };
+        var mock = new Mock<IOptionsMonitor<AppConfig>>();
+        mock.Setup(m => m.CurrentValue).Returns(appConfig);
+        return mock.Object;
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/DependencyInjectionTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/DependencyInjectionTests.cs
@@ -6,11 +6,14 @@ using Domain.Common.Config;
 using Domain.Common.Config.AI.Resilience;
 using FluentAssertions;
 using Infrastructure.AI.Escalation;
+using Infrastructure.AI.KnowledgeGraph;
 using Infrastructure.AI.Resilience;
+using MediatR;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Moq;
 using Xunit;
 
 namespace Infrastructure.AI.Tests;
@@ -24,8 +27,11 @@ public sealed class DependencyInjectionTests
 
         // Register dependencies that Infrastructure.AI expects
         services.AddLogging(b => b.AddConsole());
+        services.AddSingleton(TimeProvider.System);
         services.AddSingleton<IOptionsMonitor<AppConfig>>(
             new OptionsMonitorStub(config));
+        services.AddSingleton<ISender>(new Mock<ISender>().Object);
+        services.AddKnowledgeGraphDependencies(config);
 
         return services;
     }

--- a/src/Content/Tests/Infrastructure.AI.Tests/DriftDetection/DriftEscalationBridgeTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/DriftDetection/DriftEscalationBridgeTests.cs
@@ -1,0 +1,307 @@
+using Application.Core.CQRS.Learnings;
+using Domain.AI.DriftDetection;
+using Domain.AI.Escalation;
+using Domain.AI.Governance;
+using Domain.AI.Learnings;
+using Domain.Common;
+using FluentAssertions;
+using Infrastructure.AI.DriftDetection;
+using MediatR;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Time.Testing;
+using Moq;
+using Application.AI.Common.Interfaces.DriftDetection;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.DriftDetection;
+
+/// <summary>
+/// Tests for <see cref="DriftEscalationBridge"/> -- verifies escalation-to-drift
+/// resolution bridging and learning creation from approver corrections.
+/// </summary>
+public sealed class DriftEscalationBridgeTests
+{
+    private readonly Mock<IDriftNotifier> _driftNotifierMock = new();
+    private readonly Mock<ISender> _senderMock = new();
+    private readonly FakeTimeProvider _timeProvider = new();
+    private readonly DriftEscalationBridge _sut;
+
+    public DriftEscalationBridgeTests()
+    {
+        _timeProvider.SetUtcNow(new DateTimeOffset(2026, 5, 15, 12, 0, 0, TimeSpan.Zero));
+
+        _driftNotifierMock
+            .Setup(n => n.NotifyDriftResolvedAsync(It.IsAny<DriftEvent>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _senderMock
+            .Setup(s => s.Send(It.IsAny<RememberCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<LearningEntry>.Success(CreateLearningEntry()));
+
+        _sut = new DriftEscalationBridge(
+            _driftNotifierMock.Object,
+            _senderMock.Object,
+            _timeProvider,
+            NullLogger<DriftEscalationBridge>.Instance);
+    }
+
+    [Fact]
+    public async Task NotifyEscalationResolvedAsync_DriftOriginated_NotifiesDriftResolved()
+    {
+        var request = CreateTestRequest(DriftEscalationBridge.DriftDetectionToolName);
+        var outcome = CreateTestOutcome(request.EscalationId, approved: true, reason: "Accepted");
+
+        await _sut.NotifyEscalationRequestedAsync(request, CancellationToken.None);
+        await _sut.NotifyEscalationResolvedAsync(outcome, CancellationToken.None);
+
+        _driftNotifierMock.Verify(
+            n => n.NotifyDriftResolvedAsync(It.Is<DriftEvent>(e =>
+                e.Resolution != null &&
+                e.Resolution.ResolvedBy == DriftResolutionType.EscalationResolved &&
+                e.Resolution.ResolutionId == outcome.EscalationId.ToString() &&
+                e.Resolution.ResolvedAt == outcome.ResolvedAt),
+            CancellationToken.None),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task NotifyEscalationResolvedAsync_DriftOriginated_CreatesLearning()
+    {
+        var request = CreateTestRequest(DriftEscalationBridge.DriftDetectionToolName);
+        var outcome = CreateTestOutcome(request.EscalationId, approved: false, reason: "Output was incorrect");
+
+        await _sut.NotifyEscalationRequestedAsync(request, CancellationToken.None);
+        await _sut.NotifyEscalationResolvedAsync(outcome, CancellationToken.None);
+
+        _senderMock.Verify(
+            s => s.Send(It.Is<RememberCommand>(cmd =>
+                cmd.Source.SourceType == LearningSourceType.EscalationResolution &&
+                cmd.Source.SourceId == outcome.EscalationId.ToString() &&
+                cmd.Content.Contains("Output was incorrect") &&
+                cmd.Category == LearningCategory.FactualCorrection &&
+                cmd.Provenance.OriginPipeline == "DriftEscalationBridge" &&
+                cmd.Provenance.Confidence == 0.8),
+            CancellationToken.None),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task NotifyEscalationResolvedAsync_NonDrift_IgnoresResolution()
+    {
+        var request = CreateTestRequest("code_execution");
+        var outcome = CreateTestOutcome(request.EscalationId, approved: true, reason: "OK");
+
+        await _sut.NotifyEscalationRequestedAsync(request, CancellationToken.None);
+        await _sut.NotifyEscalationResolvedAsync(outcome, CancellationToken.None);
+
+        _driftNotifierMock.Verify(
+            n => n.NotifyDriftResolvedAsync(It.IsAny<DriftEvent>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _senderMock.Verify(
+            s => s.Send(It.IsAny<RememberCommand>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task NotifyEscalationResolvedAsync_UnknownId_IgnoresResolution()
+    {
+        var outcome = CreateTestOutcome(Guid.NewGuid(), approved: true, reason: "OK");
+
+        await _sut.NotifyEscalationResolvedAsync(outcome, CancellationToken.None);
+
+        _driftNotifierMock.Verify(
+            n => n.NotifyDriftResolvedAsync(It.IsAny<DriftEvent>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task NotifyEscalationResolvedAsync_FiltersByToolName()
+    {
+        var driftRequest = CreateTestRequest(DriftEscalationBridge.DriftDetectionToolName);
+        var otherRequest = CreateTestRequest("code_execution");
+        var driftOutcome = CreateTestOutcome(driftRequest.EscalationId, approved: true, reason: "Fixed");
+        var otherOutcome = CreateTestOutcome(otherRequest.EscalationId, approved: true, reason: "OK");
+
+        await _sut.NotifyEscalationRequestedAsync(driftRequest, CancellationToken.None);
+        await _sut.NotifyEscalationRequestedAsync(otherRequest, CancellationToken.None);
+        await _sut.NotifyEscalationResolvedAsync(otherOutcome, CancellationToken.None);
+        await _sut.NotifyEscalationResolvedAsync(driftOutcome, CancellationToken.None);
+
+        _driftNotifierMock.Verify(
+            n => n.NotifyDriftResolvedAsync(It.IsAny<DriftEvent>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task NotifyEscalationResolvedAsync_NoReasons_SkipsLearningCreation()
+    {
+        var request = CreateTestRequest(DriftEscalationBridge.DriftDetectionToolName);
+        var outcome = CreateTestOutcome(request.EscalationId, approved: true, reason: null);
+
+        await _sut.NotifyEscalationRequestedAsync(request, CancellationToken.None);
+        await _sut.NotifyEscalationResolvedAsync(outcome, CancellationToken.None);
+
+        _driftNotifierMock.Verify(
+            n => n.NotifyDriftResolvedAsync(It.IsAny<DriftEvent>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+        _senderMock.Verify(
+            s => s.Send(It.IsAny<RememberCommand>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task NotifyEscalationResolvedAsync_Approved_UsesInstructionUpdateCategory()
+    {
+        var request = CreateTestRequest(DriftEscalationBridge.DriftDetectionToolName);
+        var outcome = CreateTestOutcome(request.EscalationId, approved: true, reason: "New behavior accepted");
+
+        await _sut.NotifyEscalationRequestedAsync(request, CancellationToken.None);
+        await _sut.NotifyEscalationResolvedAsync(outcome, CancellationToken.None);
+
+        _senderMock.Verify(
+            s => s.Send(It.Is<RememberCommand>(cmd =>
+                cmd.Category == LearningCategory.InstructionUpdate),
+            CancellationToken.None),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task NotifyEscalationResolvedAsync_Denied_UsesFactualCorrectionCategory()
+    {
+        var request = CreateTestRequest(DriftEscalationBridge.DriftDetectionToolName);
+        var outcome = CreateTestOutcome(request.EscalationId, approved: false, reason: "Regression confirmed");
+
+        await _sut.NotifyEscalationRequestedAsync(request, CancellationToken.None);
+        await _sut.NotifyEscalationResolvedAsync(outcome, CancellationToken.None);
+
+        _senderMock.Verify(
+            s => s.Send(It.Is<RememberCommand>(cmd =>
+                cmd.Category == LearningCategory.FactualCorrection),
+            CancellationToken.None),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task NotifyEscalationExpiringAsync_DoesNotNotifyDrift()
+    {
+        var request = CreateTestRequest(DriftEscalationBridge.DriftDetectionToolName);
+
+        await _sut.NotifyEscalationExpiringAsync(request, TimeSpan.FromSeconds(30), CancellationToken.None);
+
+        _driftNotifierMock.Verify(
+            n => n.NotifyDriftResolvedAsync(It.IsAny<DriftEvent>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task NotifyEscalationExpiringAsync_RemovesTrackedEntry()
+    {
+        var request = CreateTestRequest(DriftEscalationBridge.DriftDetectionToolName);
+        var outcome = CreateTestOutcome(request.EscalationId, approved: true, reason: "OK");
+
+        await _sut.NotifyEscalationRequestedAsync(request, CancellationToken.None);
+        await _sut.NotifyEscalationExpiringAsync(request, TimeSpan.FromSeconds(30), CancellationToken.None);
+        await _sut.NotifyEscalationResolvedAsync(outcome, CancellationToken.None);
+
+        _driftNotifierMock.Verify(
+            n => n.NotifyDriftResolvedAsync(It.IsAny<DriftEvent>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task NotifyEscalationResolvedAsync_Exception_DoesNotThrow()
+    {
+        var request = CreateTestRequest(DriftEscalationBridge.DriftDetectionToolName);
+        var outcome = CreateTestOutcome(request.EscalationId, approved: true, reason: "OK");
+
+        _driftNotifierMock
+            .Setup(n => n.NotifyDriftResolvedAsync(It.IsAny<DriftEvent>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("Notifier failed"));
+
+        await _sut.NotifyEscalationRequestedAsync(request, CancellationToken.None);
+
+        var act = () => _sut.NotifyEscalationResolvedAsync(outcome, CancellationToken.None);
+
+        await act.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public void DriftDetectionToolName_MatchesConvention()
+    {
+        DriftEscalationBridge.DriftDetectionToolName.Should().Be("drift_detection");
+    }
+
+    [Fact]
+    public async Task NotifyEscalationResolvedAsync_ScopeDerivedFromRequest()
+    {
+        var request = CreateTestRequest(DriftEscalationBridge.DriftDetectionToolName);
+        var outcome = CreateTestOutcome(request.EscalationId, approved: false, reason: "Wrong output");
+
+        await _sut.NotifyEscalationRequestedAsync(request, CancellationToken.None);
+        await _sut.NotifyEscalationResolvedAsync(outcome, CancellationToken.None);
+
+        _senderMock.Verify(
+            s => s.Send(It.Is<RememberCommand>(cmd =>
+                cmd.Scope.AgentId == request.AgentId),
+            CancellationToken.None),
+            Times.Once);
+    }
+
+    private static EscalationRequest CreateTestRequest(string toolName) => new()
+    {
+        EscalationId = Guid.NewGuid(),
+        AgentId = "test-agent",
+        ToolName = toolName,
+        Arguments = new Dictionary<string, string>
+        {
+            ["score_id"] = Guid.NewGuid().ToString(),
+            ["severity"] = "Escalate",
+        }.AsReadOnly(),
+        Description = "Drift detected in Agent:test-agent — overall 3.50σ",
+        RiskLevel = RiskLevel.High,
+        Priority = EscalationPriority.Blocking,
+        Approvers = ["admin@company.com"],
+        RequestedAt = DateTimeOffset.UtcNow,
+    };
+
+    private static EscalationOutcome CreateTestOutcome(Guid escalationId, bool approved, string? reason) => new()
+    {
+        EscalationId = escalationId,
+        IsApproved = approved,
+        Decisions =
+        [
+            new ApproverDecision
+            {
+                ApproverName = "admin@company.com",
+                Approved = approved,
+                Reason = reason,
+                RespondedAt = DateTimeOffset.UtcNow,
+            },
+        ],
+        ResolutionType = approved ? EscalationResolutionType.Approved : EscalationResolutionType.Denied,
+        ResolvedAt = DateTimeOffset.UtcNow,
+    };
+
+    private static LearningEntry CreateLearningEntry() => new()
+    {
+        LearningId = Guid.NewGuid(),
+        Category = LearningCategory.FactualCorrection,
+        DecayClass = DecayClass.Permanent,
+        Scope = new LearningScope { AgentId = "test-agent" },
+        Content = "Test learning",
+        Source = new LearningSource
+        {
+            SourceType = LearningSourceType.EscalationResolution,
+            SourceId = "test",
+            SourceDescription = "Test",
+        },
+        Provenance = new LearningProvenance
+        {
+            OriginPipeline = "DriftEscalationBridge",
+            OriginTask = "escalation_resolution",
+            OriginTimestamp = DateTimeOffset.UtcNow,
+            Confidence = 0.8,
+        },
+        CreatedAt = DateTimeOffset.UtcNow,
+    };
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/DriftLearningsDiTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/DriftLearningsDiTests.cs
@@ -1,0 +1,233 @@
+using Application.AI.Common.Interfaces.DriftDetection;
+using Application.AI.Common.Interfaces.Escalation;
+using Application.AI.Common.Interfaces.Learnings;
+using MediatR;
+using Domain.Common.Config;
+using Domain.Common.Config.AI;
+using Domain.Common.Config.AI.DriftDetection;
+using Domain.Common.Config.AI.Learnings;
+using FluentAssertions;
+using Infrastructure.AI.DriftDetection;
+using Infrastructure.AI.KnowledgeGraph;
+using Infrastructure.AI.Learnings;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Infrastructure.AI.Tests;
+
+/// <summary>
+/// DI registration tests for Phase 3 drift detection and learnings services.
+/// Verifies that all services resolve correctly from the container.
+/// </summary>
+public sealed class DriftLearningsDiTests
+{
+    [Fact]
+    public void DriftDetection_Service_Resolves()
+    {
+        var sp = CreateServiceProvider();
+
+        var service = sp.GetService<IDriftDetectionService>();
+
+        service.Should().NotBeNull();
+        service.Should().BeOfType<DefaultDriftDetectionService>();
+    }
+
+    [Fact]
+    public void DriftDetection_KeyedScorer_Resolves_Ewma()
+    {
+        var sp = CreateServiceProvider();
+
+        var scorer = sp.GetRequiredKeyedService<IDriftScorer>("ewma");
+
+        scorer.Should().NotBeNull();
+        scorer.Should().BeOfType<EwmaDriftScorer>();
+    }
+
+    [Fact]
+    public void DriftDetection_BaselineStore_Graph_Resolves()
+    {
+        var sp = CreateServiceProvider();
+
+        var store = sp.GetRequiredKeyedService<IDriftBaselineStore>("graph");
+
+        store.Should().NotBeNull();
+        store.Should().BeOfType<GraphDriftBaselineStore>();
+    }
+
+    [Fact]
+    public void DriftDetection_BaselineStore_InMemory_Resolves()
+    {
+        var sp = CreateServiceProvider();
+
+        var store = sp.GetRequiredKeyedService<IDriftBaselineStore>("in_memory");
+
+        store.Should().NotBeNull();
+        store.Should().BeOfType<InMemoryDriftBaselineStore>();
+    }
+
+    [Fact]
+    public void DriftDetection_BaselineStore_Default_ResolvesGraph()
+    {
+        var sp = CreateServiceProvider();
+
+        var store = sp.GetService<IDriftBaselineStore>();
+
+        store.Should().NotBeNull();
+        store.Should().BeOfType<GraphDriftBaselineStore>();
+    }
+
+    [Fact]
+    public void DriftDetection_AuditStore_Resolves()
+    {
+        var sp = CreateServiceProvider();
+
+        var store = sp.GetService<IDriftAuditStore>();
+
+        store.Should().NotBeNull();
+        store.Should().BeOfType<JsonlDriftAuditStore>();
+    }
+
+    [Fact]
+    public void DriftDetection_Notifier_Resolves()
+    {
+        var sp = CreateServiceProvider();
+
+        var notifier = sp.GetService<IDriftNotifier>();
+
+        notifier.Should().NotBeNull();
+        notifier.Should().BeOfType<CompositeDriftNotifier>();
+    }
+
+    [Fact]
+    public void DriftDetection_EwmaStateStore_Resolves()
+    {
+        var sp = CreateServiceProvider();
+
+        var store = sp.GetService<IEwmaStateStore>();
+
+        store.Should().NotBeNull();
+        store.Should().BeOfType<GraphEwmaStateStore>();
+    }
+
+    [Fact]
+    public void DriftEscalationBridge_RegisteredAsNotificationChannel()
+    {
+        var sp = CreateServiceProvider();
+
+        var channels = sp.GetServices<IEscalationNotificationChannel>().ToList();
+
+        channels.Should().Contain(c => c is DriftEscalationBridge);
+    }
+
+    [Fact]
+    public void Learnings_DecayService_Resolves()
+    {
+        var sp = CreateServiceProvider();
+
+        var service = sp.GetService<ILearningDecayService>();
+
+        service.Should().NotBeNull();
+        service.Should().BeOfType<DefaultLearningDecayService>();
+    }
+
+    [Fact]
+    public void Learnings_DriftBridge_Resolves()
+    {
+        var sp = CreateServiceProvider();
+
+        var bridge = sp.GetService<ILearningsDriftBridge>();
+
+        bridge.Should().NotBeNull();
+        bridge.Should().BeOfType<LearningsDriftBridge>();
+    }
+
+    [Fact]
+    public void LearningsPruningService_RegisteredWhenEnabled()
+    {
+        var sp = CreateServiceProvider(learningsEnabled: true);
+
+        var services = sp.GetServices<IHostedService>().ToList();
+
+        services.Should().Contain(s => s is LearningsPruningBackgroundService);
+    }
+
+    [Fact]
+    public void LearningsPruningService_NotRegisteredWhenDisabled()
+    {
+        var sp = CreateServiceProvider(learningsEnabled: false);
+
+        var services = sp.GetServices<IHostedService>().ToList();
+
+        services.Should().NotContain(s => s is LearningsPruningBackgroundService);
+    }
+
+    [Fact]
+    public void AIConfig_BindsDriftDetectionConfig_Defaults()
+    {
+        var config = new AppConfig();
+
+        config.AI.DriftDetection.Should().NotBeNull();
+        config.AI.DriftDetection.Enabled.Should().BeTrue();
+        config.AI.DriftDetection.EwmaLambda.Should().BeApproximately(0.2, 0.001);
+    }
+
+    [Fact]
+    public void AIConfig_BindsLearningsConfig_Defaults()
+    {
+        var config = new AppConfig();
+
+        config.AI.Learnings.Should().NotBeNull();
+        config.AI.Learnings.Enabled.Should().BeTrue();
+        config.AI.Learnings.StoreProvider.Should().Be("graph");
+        config.AI.Learnings.BaselineAdjustmentThreshold.Should().BeApproximately(0.8, 0.001);
+    }
+
+    private static ServiceProvider CreateServiceProvider(bool learningsEnabled = true)
+    {
+        var appConfig = new AppConfig
+        {
+            AI = new AIConfig
+            {
+                DriftDetection = new DriftDetectionConfig(),
+                Learnings = new LearningsConfig { Enabled = learningsEnabled }
+            }
+        };
+
+        var services = new ServiceCollection();
+        services.AddOptions();
+        services.AddSingleton(TimeProvider.System);
+        services.AddSingleton(NullLoggerFactory.Instance);
+        services.AddSingleton(typeof(ILogger<>), typeof(NullLogger<>));
+        services.AddSingleton<IOptionsMonitor<AppConfig>>(new OptionsMonitorStub(appConfig));
+        services.AddSingleton<IOptionsMonitor<LearningsConfig>>(
+            new LearningsConfigMonitorStub(appConfig.AI.Learnings));
+        services.AddSingleton<ISender>(new Mock<ISender>().Object);
+
+        // Register knowledge graph (provides IKnowledgeGraphStore for graph-backed stores)
+        services.AddKnowledgeGraphDependencies(appConfig);
+
+        // Register Infrastructure.AI services (drift, learnings, escalation, etc.)
+        services.AddInfrastructureAIDependencies(appConfig);
+
+        return services.BuildServiceProvider();
+    }
+
+    private sealed class OptionsMonitorStub(AppConfig config) : IOptionsMonitor<AppConfig>
+    {
+        public AppConfig CurrentValue => config;
+        public AppConfig Get(string? name) => config;
+        public IDisposable? OnChange(Action<AppConfig, string?> listener) => null;
+    }
+
+    private sealed class LearningsConfigMonitorStub(LearningsConfig config) : IOptionsMonitor<LearningsConfig>
+    {
+        public LearningsConfig CurrentValue => config;
+        public LearningsConfig Get(string? name) => config;
+        public IDisposable? OnChange(Action<LearningsConfig, string?> listener) => null;
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Infrastructure.AI.Tests.csproj
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Infrastructure.AI.Tests.csproj
@@ -25,6 +25,7 @@
 
   <ItemGroup>
     <ProjectReference Include="../../Infrastructure/Infrastructure.AI/Infrastructure.AI.csproj" />
+    <ProjectReference Include="../../Infrastructure/Infrastructure.AI.KnowledgeGraph/Infrastructure.AI.KnowledgeGraph.csproj" />
     <ProjectReference Include="../../Infrastructure/Infrastructure.AI.MCP/Infrastructure.AI.MCP.csproj" />
     <ProjectReference Include="../../Application/Application.AI.Common/Application.AI.Common.csproj" />
     <ProjectReference Include="../../Application/Application.Core/Application.Core.csproj" />

--- a/src/Content/Tests/Infrastructure.AI.Tests/Learnings/LearningsDriftBridgeTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Learnings/LearningsDriftBridgeTests.cs
@@ -1,0 +1,408 @@
+using System.Text.Json;
+using Application.AI.Common.Interfaces.DriftDetection;
+using Application.AI.Common.Interfaces.KnowledgeGraph;
+using Domain.AI.DriftDetection;
+using Domain.AI.KnowledgeGraph.Models;
+using Domain.AI.Learnings;
+using Domain.Common;
+using Domain.Common.Config;
+using Domain.Common.Config.AI;
+using Domain.Common.Config.AI.DriftDetection;
+using Domain.Common.Config.AI.Learnings;
+using FluentAssertions;
+using Infrastructure.AI.Learnings;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Time.Testing;
+using Moq;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Learnings;
+
+/// <summary>
+/// Tests for <see cref="LearningsDriftBridge"/>.
+/// Verifies that high-confidence learnings originating from drift events trigger
+/// baseline adjustment and drift event resolution.
+/// </summary>
+public sealed class LearningsDriftBridgeTests
+{
+    private readonly Mock<IDriftDetectionService> _driftService = new();
+    private readonly Mock<IDriftAuditStore> _auditStore = new();
+    private readonly Mock<IKnowledgeGraphStore> _graphStore = new();
+    private readonly FakeTimeProvider _timeProvider = new(new DateTimeOffset(2025, 6, 15, 10, 0, 0, TimeSpan.Zero));
+
+    [Fact]
+    public async Task CheckAndAdjustBaselineAsync_HighWeight_DriftSource_TriggersBaselineUpdate()
+    {
+        var learning = CreateLearning(
+            sourceType: LearningSourceType.DriftDetection,
+            sourceId: "evt-123",
+            feedbackWeight: 0.85);
+        SetupDriftEventNode("evt-123", DriftScope.Skill, "code_review");
+        _driftService
+            .Setup(s => s.UpdateBaselineAsync(It.IsAny<DriftBaselineUpdateRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<DriftBaseline>.Success(CreateBaseline(DriftScope.Skill, "code_review")));
+        _auditStore
+            .Setup(s => s.RecordAsync(It.IsAny<DriftAuditRecord>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Success());
+        var bridge = CreateBridge();
+
+        var result = await bridge.CheckAndAdjustBaselineAsync(learning, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        _driftService.Verify(s => s.UpdateBaselineAsync(
+            It.Is<DriftBaselineUpdateRequest>(r =>
+                r.Scope == DriftScope.Skill &&
+                r.ScopeIdentifier == "code_review"),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task CheckAndAdjustBaselineAsync_HighWeight_NonDriftSource_NoBaselineUpdate()
+    {
+        var learning = CreateLearning(
+            sourceType: LearningSourceType.HumanCorrection,
+            sourceId: "manual-1",
+            feedbackWeight: 0.9);
+        var bridge = CreateBridge();
+
+        var result = await bridge.CheckAndAdjustBaselineAsync(learning, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        _driftService.Verify(
+            s => s.UpdateBaselineAsync(It.IsAny<DriftBaselineUpdateRequest>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task CheckAndAdjustBaselineAsync_BelowThreshold_NoBaselineUpdate()
+    {
+        var learning = CreateLearning(
+            sourceType: LearningSourceType.DriftDetection,
+            sourceId: "evt-200",
+            feedbackWeight: 0.5);
+        var bridge = CreateBridge();
+
+        var result = await bridge.CheckAndAdjustBaselineAsync(learning, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        _driftService.Verify(
+            s => s.UpdateBaselineAsync(It.IsAny<DriftBaselineUpdateRequest>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task CheckAndAdjustBaselineAsync_BaselineAdjusted_RecordsDriftAuditEntry()
+    {
+        var learning = CreateLearning(
+            sourceType: LearningSourceType.DriftDetection,
+            sourceId: "evt-456",
+            feedbackWeight: 0.85);
+        SetupDriftEventNode("evt-456", DriftScope.Agent, "agent-1");
+        SetupSuccessfulUpdate();
+        var bridge = CreateBridge();
+
+        await bridge.CheckAndAdjustBaselineAsync(learning, CancellationToken.None);
+
+        _auditStore.Verify(s => s.RecordAsync(
+            It.Is<DriftAuditRecord>(r =>
+                r.RecordType == DriftAuditRecordType.BaselineUpdated &&
+                r.RecordedAt == _timeProvider.GetUtcNow()),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task CheckAndAdjustBaselineAsync_BaselineAdjusted_ResolvesDriftEvent()
+    {
+        var learning = CreateLearning(
+            sourceType: LearningSourceType.DriftDetection,
+            sourceId: "evt-789",
+            feedbackWeight: 0.85);
+        SetupDriftEventNode("evt-789", DriftScope.Skill, "summarization");
+        SetupSuccessfulUpdate();
+        var bridge = CreateBridge();
+
+        await bridge.CheckAndAdjustBaselineAsync(learning, CancellationToken.None);
+
+        _graphStore.Verify(s => s.AddNodesAsync(
+            It.Is<IReadOnlyList<GraphNode>>(nodes =>
+                nodes.Count == 1 &&
+                nodes[0].Properties.ContainsKey("Resolution") &&
+                nodes[0].Properties["Resolution"].Contains("BaselineAdjusted")),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task CheckAndAdjustBaselineAsync_DriftDetectionDisabled_NoOp()
+    {
+        var learning = CreateLearning(
+            sourceType: LearningSourceType.DriftDetection,
+            sourceId: "evt-100",
+            feedbackWeight: 0.85);
+        var bridge = CreateBridge(driftEnabled: false);
+
+        var result = await bridge.CheckAndAdjustBaselineAsync(learning, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        _driftService.Verify(
+            s => s.UpdateBaselineAsync(It.IsAny<DriftBaselineUpdateRequest>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _graphStore.Verify(
+            s => s.GetNodeAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task CheckAndAdjustBaselineAsync_LearningsDisabled_NoOp()
+    {
+        var learning = CreateLearning(
+            sourceType: LearningSourceType.DriftDetection,
+            sourceId: "evt-101",
+            feedbackWeight: 0.85);
+        var bridge = CreateBridge(learningsEnabled: false);
+
+        var result = await bridge.CheckAndAdjustBaselineAsync(learning, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        _driftService.Verify(
+            s => s.UpdateBaselineAsync(It.IsAny<DriftBaselineUpdateRequest>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task CheckAndAdjustBaselineAsync_DriftEventNodeNotFound_LogsWarning_ReturnsSuccess()
+    {
+        var learning = CreateLearning(
+            sourceType: LearningSourceType.DriftDetection,
+            sourceId: "evt-pruned",
+            feedbackWeight: 0.85);
+        _graphStore
+            .Setup(s => s.GetNodeAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((GraphNode?)null);
+        var bridge = CreateBridge();
+
+        var result = await bridge.CheckAndAdjustBaselineAsync(learning, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        _driftService.Verify(
+            s => s.UpdateBaselineAsync(It.IsAny<DriftBaselineUpdateRequest>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task CheckAndAdjustBaselineAsync_UpdateBaselineFails_ReturnsFailure()
+    {
+        var learning = CreateLearning(
+            sourceType: LearningSourceType.DriftDetection,
+            sourceId: "evt-fail",
+            feedbackWeight: 0.85);
+        SetupDriftEventNode("evt-fail", DriftScope.TaskType, "task-1");
+        _driftService
+            .Setup(s => s.UpdateBaselineAsync(It.IsAny<DriftBaselineUpdateRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<DriftBaseline>.Fail("Baseline store unreachable"));
+        var bridge = CreateBridge();
+
+        var result = await bridge.CheckAndAdjustBaselineAsync(learning, CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.Contains("Baseline store unreachable"));
+    }
+
+    [Fact]
+    public async Task CheckAndAdjustBaselineAsync_UsesTimeProviderForResolvedAt()
+    {
+        var learning = CreateLearning(
+            sourceType: LearningSourceType.DriftDetection,
+            sourceId: "evt-time",
+            feedbackWeight: 0.85);
+        SetupDriftEventNode("evt-time", DriftScope.Agent, "global-agent");
+        SetupSuccessfulUpdate();
+        var bridge = CreateBridge();
+
+        await bridge.CheckAndAdjustBaselineAsync(learning, CancellationToken.None);
+
+        _graphStore.Verify(s => s.AddNodesAsync(
+            It.Is<IReadOnlyList<GraphNode>>(nodes =>
+                nodes.Count == 1 &&
+                nodes[0].Properties["Resolution"].Contains("2025-06-15")),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task CheckAndAdjustBaselineAsync_CorruptedNodeScope_ReturnsSuccess()
+    {
+        var learning = CreateLearning(
+            sourceType: LearningSourceType.DriftDetection,
+            sourceId: "evt-corrupt",
+            feedbackWeight: 0.85);
+        var corruptedNode = new GraphNode
+        {
+            Id = "driftevent:evt-corrupt",
+            Name = "DriftEvent:corrupt",
+            Type = "DriftEvent",
+            Properties = new Dictionary<string, string>
+            {
+                ["EventId"] = "evt-corrupt",
+                ["Scope"] = "INVALID_SCOPE_VALUE",
+                ["ScopeIdentifier"] = "something"
+            }.AsReadOnly()
+        };
+        _graphStore
+            .Setup(s => s.GetNodeAsync("driftevent:evt-corrupt", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(corruptedNode);
+        var bridge = CreateBridge();
+
+        var result = await bridge.CheckAndAdjustBaselineAsync(learning, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        _driftService.Verify(
+            s => s.UpdateBaselineAsync(It.IsAny<DriftBaselineUpdateRequest>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task CheckAndAdjustBaselineAsync_AlreadyResolved_Skips()
+    {
+        var learning = CreateLearning(
+            sourceType: LearningSourceType.DriftDetection,
+            sourceId: "evt-resolved",
+            feedbackWeight: 0.9);
+        SetupDriftEventNode("evt-resolved", DriftScope.Skill, "code_review", alreadyResolved: true);
+        var bridge = CreateBridge();
+
+        var result = await bridge.CheckAndAdjustBaselineAsync(learning, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        _driftService.Verify(
+            s => s.UpdateBaselineAsync(It.IsAny<DriftBaselineUpdateRequest>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    private LearningsDriftBridge CreateBridge(
+        bool driftEnabled = true,
+        bool learningsEnabled = true,
+        double threshold = 0.8) => new(
+        _driftService.Object,
+        _auditStore.Object,
+        _graphStore.Object,
+        CreateOptions(driftEnabled, learningsEnabled, threshold),
+        _timeProvider,
+        NullLogger<LearningsDriftBridge>.Instance);
+
+    private void SetupDriftEventNode(
+        string eventId,
+        DriftScope scope,
+        string scopeIdentifier,
+        bool alreadyResolved = false)
+    {
+        var properties = new Dictionary<string, string>
+        {
+            ["EventId"] = eventId,
+            ["ScoreId"] = Guid.NewGuid().ToString(),
+            ["BaselineId"] = Guid.NewGuid().ToString(),
+            ["Scope"] = scope.ToString(),
+            ["ScopeIdentifier"] = scopeIdentifier,
+            ["Severity"] = DriftSeverity.Alert.ToString(),
+            ["OverallDrift"] = "2.5",
+            ["ScoredAt"] = DateTimeOffset.UtcNow.ToString("o"),
+            ["DimensionsJson"] = "{}"
+        };
+
+        if (alreadyResolved)
+        {
+            var resolution = new DriftResolution
+            {
+                ResolvedBy = DriftResolutionType.ManualDismissal,
+                ResolutionId = "prior-resolution",
+                ResolvedAt = DateTimeOffset.UtcNow.AddHours(-1)
+            };
+            properties["Resolution"] = JsonSerializer.Serialize(resolution);
+        }
+
+        var node = new GraphNode
+        {
+            Id = $"driftevent:{eventId}",
+            Name = $"DriftEvent:{scope}:{scopeIdentifier}",
+            Type = "DriftEvent",
+            Properties = properties.AsReadOnly()
+        };
+
+        _graphStore
+            .Setup(s => s.GetNodeAsync($"driftevent:{eventId}", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(node);
+    }
+
+    private void SetupSuccessfulUpdate()
+    {
+        _driftService
+            .Setup(s => s.UpdateBaselineAsync(It.IsAny<DriftBaselineUpdateRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<DriftBaseline>.Success(CreateBaseline(DriftScope.Skill, "default")));
+        _auditStore
+            .Setup(s => s.RecordAsync(It.IsAny<DriftAuditRecord>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Success());
+    }
+
+    private static DriftBaseline CreateBaseline(DriftScope scope, string identifier) => new()
+    {
+        BaselineId = Guid.NewGuid(),
+        Scope = scope,
+        ScopeIdentifier = identifier,
+        Dimensions = new Dictionary<DriftDimension, double>().AsReadOnly(),
+        DimensionSigmas = new Dictionary<DriftDimension, double>().AsReadOnly(),
+        SampleCount = 20,
+        WindowStart = DateTimeOffset.UtcNow.AddDays(-7),
+        WindowEnd = DateTimeOffset.UtcNow,
+        CreatedAt = DateTimeOffset.UtcNow
+    };
+
+    private static LearningEntry CreateLearning(
+        LearningSourceType sourceType = LearningSourceType.DriftDetection,
+        string sourceId = "evt-default",
+        double feedbackWeight = 1.0) => new()
+    {
+        LearningId = Guid.NewGuid(),
+        Category = LearningCategory.FactualCorrection,
+        DecayClass = DecayClass.Permanent,
+        Scope = new LearningScope { AgentId = "agent-1" },
+        Content = "Test learning content",
+        Source = new LearningSource
+        {
+            SourceType = sourceType,
+            SourceId = sourceId,
+            SourceDescription = "Test drift source"
+        },
+        Provenance = new LearningProvenance
+        {
+            OriginPipeline = "DriftDetection",
+            OriginTask = "drift_detection",
+            OriginTimestamp = DateTimeOffset.UtcNow,
+            Confidence = 0.9
+        },
+        CreatedAt = DateTimeOffset.UtcNow,
+        FeedbackWeight = feedbackWeight,
+        UpdateCount = 3
+    };
+
+    private static IOptionsMonitor<AppConfig> CreateOptions(
+        bool driftEnabled,
+        bool learningsEnabled,
+        double threshold)
+    {
+        var appConfig = new AppConfig
+        {
+            AI = new AIConfig
+            {
+                DriftDetection = new DriftDetectionConfig { Enabled = driftEnabled },
+                Learnings = new LearningsConfig
+                {
+                    Enabled = learningsEnabled,
+                    BaselineAdjustmentThreshold = threshold
+                }
+            }
+        };
+        var mock = new Mock<IOptionsMonitor<AppConfig>>();
+        mock.Setup(m => m.CurrentValue).Returns(appConfig);
+        return mock.Object;
+    }
+}

--- a/src/Content/Tests/Presentation.AgentHub.Tests/AgUi/AgUiLearningEventSerializationTests.cs
+++ b/src/Content/Tests/Presentation.AgentHub.Tests/AgUi/AgUiLearningEventSerializationTests.cs
@@ -1,0 +1,158 @@
+using System.Text.Json;
+using FluentAssertions;
+using Presentation.AgentHub.AgUi;
+using Xunit;
+
+namespace Presentation.AgentHub.Tests.AgUi;
+
+/// <summary>
+/// Serialization tests for learning-related AG-UI events.
+/// Verifies correct JSON discriminator and property names on the wire.
+/// </summary>
+public class AgUiLearningEventSerializationTests
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    [Fact]
+    public void LearningCapturedEvent_Serializes_WithCorrectTypeDiscriminator()
+    {
+        var evt = new LearningCapturedEvent
+        {
+            LearningId = "learning-001",
+            Category = "FactualCorrection",
+            AgentId = "research-agent",
+            TeamId = "team-alpha",
+            IsGlobal = false,
+            SourceDescription = "User corrected date format",
+        };
+
+        var json = JsonSerializer.Serialize<AgUiEvent>(evt, JsonOptions);
+
+        json.Should().Contain("\"type\":\"LEARNING_CAPTURED\"");
+        json.Should().Contain("\"learningId\":\"learning-001\"");
+        json.Should().Contain("\"category\":\"FactualCorrection\"");
+        json.Should().Contain("\"agentId\":\"research-agent\"");
+        json.Should().Contain("\"teamId\":\"team-alpha\"");
+        json.Should().Contain("\"sourceDescription\":\"User corrected date format\"");
+    }
+
+    [Fact]
+    public void LearningAppliedEvent_Serializes_WithCorrectTypeDiscriminator()
+    {
+        var evt = new LearningAppliedEvent
+        {
+            LearningId = "learning-002",
+            AgentId = "code-writer",
+            Category = "StylePreference",
+        };
+
+        var json = JsonSerializer.Serialize<AgUiEvent>(evt, JsonOptions);
+
+        json.Should().Contain("\"type\":\"LEARNING_APPLIED\"");
+        json.Should().Contain("\"learningId\":\"learning-002\"");
+        json.Should().Contain("\"agentId\":\"code-writer\"");
+        json.Should().Contain("\"category\":\"StylePreference\"");
+    }
+
+    [Fact]
+    public void LearningForgottenEvent_Serializes_WithCorrectTypeDiscriminator()
+    {
+        var evt = new LearningForgottenEvent
+        {
+            LearningId = "learning-003",
+            Reason = "Superseded by newer learning",
+        };
+
+        var json = JsonSerializer.Serialize<AgUiEvent>(evt, JsonOptions);
+
+        json.Should().Contain("\"type\":\"LEARNING_FORGOTTEN\"");
+        json.Should().Contain("\"learningId\":\"learning-003\"");
+        json.Should().Contain("\"reason\":\"Superseded by newer learning\"");
+    }
+
+    [Fact]
+    public void LearningCapturedEvent_Deserializes_BackToCorrectType()
+    {
+        var original = new LearningCapturedEvent
+        {
+            LearningId = "round-trip-learning",
+            Category = "ToolUsagePattern",
+            AgentId = "agent-1",
+            TeamId = "team-1",
+            IsGlobal = false,
+            SourceDescription = "Agent discovered efficient API call pattern",
+        };
+
+        var json = JsonSerializer.Serialize<AgUiEvent>(original, JsonOptions);
+        var deserialized = JsonSerializer.Deserialize<AgUiEvent>(json, JsonOptions);
+
+        deserialized.Should().BeOfType<LearningCapturedEvent>();
+        var result = (LearningCapturedEvent)deserialized!;
+        result.LearningId.Should().Be("round-trip-learning");
+        result.Category.Should().Be("ToolUsagePattern");
+        result.AgentId.Should().Be("agent-1");
+        result.TeamId.Should().Be("team-1");
+        result.IsGlobal.Should().BeFalse();
+        result.SourceDescription.Should().Be("Agent discovered efficient API call pattern");
+    }
+
+    [Fact]
+    public void LearningAppliedEvent_Deserializes_BackToCorrectType()
+    {
+        var original = new LearningAppliedEvent
+        {
+            LearningId = "round-trip-applied",
+            AgentId = "code-writer",
+            Category = "StylePreference",
+            ContextSummary = "Applied during code formatting",
+        };
+
+        var json = JsonSerializer.Serialize<AgUiEvent>(original, JsonOptions);
+        var deserialized = JsonSerializer.Deserialize<AgUiEvent>(json, JsonOptions);
+
+        deserialized.Should().BeOfType<LearningAppliedEvent>();
+        var result = (LearningAppliedEvent)deserialized!;
+        result.LearningId.Should().Be("round-trip-applied");
+        result.AgentId.Should().Be("code-writer");
+        result.Category.Should().Be("StylePreference");
+        result.ContextSummary.Should().Be("Applied during code formatting");
+    }
+
+    [Fact]
+    public void LearningForgottenEvent_Deserializes_BackToCorrectType()
+    {
+        var original = new LearningForgottenEvent
+        {
+            LearningId = "round-trip-forgotten",
+            Reason = "Superseded by newer learning",
+        };
+
+        var json = JsonSerializer.Serialize<AgUiEvent>(original, JsonOptions);
+        var deserialized = JsonSerializer.Deserialize<AgUiEvent>(json, JsonOptions);
+
+        deserialized.Should().BeOfType<LearningForgottenEvent>();
+        var result = (LearningForgottenEvent)deserialized!;
+        result.LearningId.Should().Be("round-trip-forgotten");
+        result.Reason.Should().Be("Superseded by newer learning");
+    }
+
+    [Fact]
+    public void LearningAppliedEvent_WithNullOptionalFields_OmitsThem()
+    {
+        var evt = new LearningAppliedEvent
+        {
+            LearningId = "learning-004",
+            AgentId = "agent-1",
+            Category = "FactualCorrection",
+            ContextSummary = null,
+        };
+
+        var json = JsonSerializer.Serialize<AgUiEvent>(evt, JsonOptions);
+
+        json.Should().NotContain("\"contextSummary\"");
+    }
+}

--- a/src/Content/Tests/Presentation.AgentHub.Tests/Notifications/AgUiDriftNotifierTests.cs
+++ b/src/Content/Tests/Presentation.AgentHub.Tests/Notifications/AgUiDriftNotifierTests.cs
@@ -1,0 +1,286 @@
+using Domain.AI.DriftDetection;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Presentation.AgentHub.AgUi;
+using Presentation.AgentHub.Notifications;
+using Xunit;
+
+namespace Presentation.AgentHub.Tests.Notifications;
+
+/// <summary>
+/// Tests for <see cref="AgUiDriftNotifier"/> -- verifies correct domain-to-AG-UI
+/// event translation and writer invocation for drift detection events.
+/// </summary>
+public sealed class AgUiDriftNotifierTests
+{
+    private readonly Mock<IAgUiEventWriterAccessor> _accessorMock = new();
+    private readonly Mock<IAgUiEventWriter> _writerMock = new();
+    private readonly AgUiDriftNotifier _sut;
+
+    public AgUiDriftNotifierTests()
+    {
+        _accessorMock.Setup(a => a.Writer).Returns(_writerMock.Object);
+        _writerMock
+            .Setup(w => w.WriteAsync(It.IsAny<AgUiEvent>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        _sut = new AgUiDriftNotifier(
+            _accessorMock.Object,
+            NullLogger<AgUiDriftNotifier>.Instance);
+    }
+
+    [Fact]
+    public async Task NotifyDriftDetectedAsync_WarnSeverity_WritesDriftWarnEvent()
+    {
+        var score = CreateDriftScore(DriftSeverity.Warn);
+
+        await _sut.NotifyDriftDetectedAsync(score, CancellationToken.None);
+
+        _writerMock.Verify(
+            w => w.WriteAsync(It.Is<DriftWarnEvent>(e =>
+                e.Scope == "Agent" &&
+                e.ScopeIdentifier == "test-agent" &&
+                e.MaxDeviation == 1.5 &&
+                e.Severity == "Warn" &&
+                e.Dimensions.Count == 2),
+            CancellationToken.None),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task NotifyDriftDetectedAsync_AlertSeverity_WritesDriftAlertEvent()
+    {
+        var score = CreateDriftScore(DriftSeverity.Alert);
+
+        await _sut.NotifyDriftDetectedAsync(score, CancellationToken.None);
+
+        _writerMock.Verify(
+            w => w.WriteAsync(It.Is<DriftAlertEvent>(e =>
+                e.Scope == "Agent" &&
+                e.ScopeIdentifier == "test-agent" &&
+                e.BaselineId == score.BaselineId.ToString() &&
+                e.Severity == "Alert"),
+            CancellationToken.None),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task NotifyDriftDetectedAsync_EscalateSeverity_WritesDriftEscalateEvent()
+    {
+        var score = CreateDriftScore(DriftSeverity.Escalate);
+
+        await _sut.NotifyDriftDetectedAsync(score, CancellationToken.None);
+
+        _writerMock.Verify(
+            w => w.WriteAsync(It.Is<DriftEscalateEvent>(e =>
+                e.Scope == "Agent" &&
+                e.ScopeIdentifier == "test-agent" &&
+                e.BaselineId == score.BaselineId.ToString() &&
+                e.EscalationId == string.Empty &&
+                e.Severity == "Escalate"),
+            CancellationToken.None),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task NotifyDriftDetectedAsync_NoneSeverity_DoesNotWrite()
+    {
+        var score = CreateDriftScore(DriftSeverity.None);
+
+        await _sut.NotifyDriftDetectedAsync(score, CancellationToken.None);
+
+        _writerMock.Verify(
+            w => w.WriteAsync(It.IsAny<AgUiEvent>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task NotifyDriftResolvedAsync_WritesDriftResolvedEvent()
+    {
+        var resolvedAt = DateTimeOffset.UtcNow;
+        var driftEvent = new DriftEvent
+        {
+            EventId = Guid.NewGuid(),
+            DriftScore = CreateDriftScore(DriftSeverity.Alert),
+            Resolution = new DriftResolution
+            {
+                ResolvedBy = DriftResolutionType.LearningApplied,
+                ResolutionId = "learning-123",
+                ResolvedAt = resolvedAt,
+            },
+            DetectedAt = resolvedAt.AddMinutes(-5),
+        };
+
+        await _sut.NotifyDriftResolvedAsync(driftEvent, CancellationToken.None);
+
+        _writerMock.Verify(
+            w => w.WriteAsync(It.Is<DriftResolvedEvent>(e =>
+                e.EventId == driftEvent.EventId.ToString() &&
+                e.ResolutionType == "LearningApplied" &&
+                e.ResolvedBy == "learning-123" &&
+                e.ResolvedAt == resolvedAt),
+            CancellationToken.None),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task NotifyDriftResolvedAsync_NullResolution_DoesNotWrite()
+    {
+        var driftEvent = new DriftEvent
+        {
+            EventId = Guid.NewGuid(),
+            DriftScore = CreateDriftScore(DriftSeverity.Alert),
+            Resolution = null,
+            DetectedAt = DateTimeOffset.UtcNow,
+        };
+
+        await _sut.NotifyDriftResolvedAsync(driftEvent, CancellationToken.None);
+
+        _writerMock.Verify(
+            w => w.WriteAsync(It.IsAny<AgUiEvent>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task NotifyDriftDetectedAsync_NoWriter_SilentlyReturns()
+    {
+        _accessorMock.Setup(a => a.Writer).Returns((IAgUiEventWriter?)null);
+        var sut = new AgUiDriftNotifier(
+            _accessorMock.Object,
+            NullLogger<AgUiDriftNotifier>.Instance);
+
+        var score = CreateDriftScore(DriftSeverity.Warn);
+
+        await sut.NotifyDriftDetectedAsync(score, CancellationToken.None);
+
+        _writerMock.Verify(
+            w => w.WriteAsync(It.IsAny<AgUiEvent>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task NotifyDriftDetectedAsync_WriterThrows_CatchesAndDoesNotThrow()
+    {
+        _writerMock
+            .Setup(w => w.WriteAsync(It.IsAny<AgUiEvent>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("Stream closed"));
+
+        var score = CreateDriftScore(DriftSeverity.Warn);
+
+        var act = () => _sut.NotifyDriftDetectedAsync(score, CancellationToken.None);
+
+        await act.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task NotifyDriftDetectedAsync_DimensionsMapCorrectly()
+    {
+        var score = CreateDriftScore(DriftSeverity.Warn);
+
+        await _sut.NotifyDriftDetectedAsync(score, CancellationToken.None);
+
+        _writerMock.Verify(
+            w => w.WriteAsync(It.Is<DriftWarnEvent>(e =>
+                e.Dimensions.ContainsKey("Faithfulness") &&
+                e.Dimensions.ContainsKey("Relevance") &&
+                Math.Abs(e.Dimensions["Faithfulness"] - 1.5) < 0.001 &&
+                Math.Abs(e.Dimensions["Relevance"] - 0.8) < 0.001),
+            CancellationToken.None),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task NotifyDriftDetectedAsync_OperationCanceledException_Propagates()
+    {
+        _writerMock
+            .Setup(w => w.WriteAsync(It.IsAny<AgUiEvent>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new OperationCanceledException());
+
+        var score = CreateDriftScore(DriftSeverity.Warn);
+
+        var act = () => _sut.NotifyDriftDetectedAsync(score, CancellationToken.None);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    [Fact]
+    public async Task NotifyDriftResolvedAsync_NoWriter_SilentlyReturns()
+    {
+        _accessorMock.Setup(a => a.Writer).Returns((IAgUiEventWriter?)null);
+        var sut = new AgUiDriftNotifier(
+            _accessorMock.Object,
+            NullLogger<AgUiDriftNotifier>.Instance);
+
+        var driftEvent = new DriftEvent
+        {
+            EventId = Guid.NewGuid(),
+            DriftScore = CreateDriftScore(DriftSeverity.Alert),
+            Resolution = new DriftResolution
+            {
+                ResolvedBy = DriftResolutionType.ManualDismissal,
+                ResolutionId = "op-1",
+                ResolvedAt = DateTimeOffset.UtcNow,
+            },
+            DetectedAt = DateTimeOffset.UtcNow,
+        };
+
+        await sut.NotifyDriftResolvedAsync(driftEvent, CancellationToken.None);
+
+        _writerMock.Verify(
+            w => w.WriteAsync(It.IsAny<AgUiEvent>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task NotifyDriftResolvedAsync_WriterThrows_CatchesAndDoesNotThrow()
+    {
+        _writerMock
+            .Setup(w => w.WriteAsync(It.IsAny<AgUiEvent>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("Stream closed"));
+
+        var driftEvent = new DriftEvent
+        {
+            EventId = Guid.NewGuid(),
+            DriftScore = CreateDriftScore(DriftSeverity.Alert),
+            Resolution = new DriftResolution
+            {
+                ResolvedBy = DriftResolutionType.BaselineAdjusted,
+                ResolutionId = "baseline-456",
+                ResolvedAt = DateTimeOffset.UtcNow,
+            },
+            DetectedAt = DateTimeOffset.UtcNow,
+        };
+
+        var act = () => _sut.NotifyDriftResolvedAsync(driftEvent, CancellationToken.None);
+
+        await act.Should().NotThrowAsync();
+    }
+
+    private static DriftScore CreateDriftScore(DriftSeverity severity) => new()
+    {
+        ScoreId = Guid.NewGuid(),
+        BaselineId = Guid.NewGuid(),
+        Scope = DriftScope.Agent,
+        ScopeIdentifier = "test-agent",
+        Dimensions = new Dictionary<DriftDimension, DriftDimensionScore>
+        {
+            [DriftDimension.Faithfulness] = new()
+            {
+                CurrentValue = 0.75,
+                BaselineValue = 0.90,
+                EwmaValue = 0.78,
+                Deviation = 1.5,
+            },
+            [DriftDimension.Relevance] = new()
+            {
+                CurrentValue = 0.85,
+                BaselineValue = 0.92,
+                EwmaValue = 0.87,
+                Deviation = 0.8,
+            },
+        },
+        OverallDrift = 1.5,
+        Severity = severity,
+        ScoredAt = DateTimeOffset.UtcNow,
+    };
+}

--- a/src/Content/Tests/Presentation.AgentHub.Tests/Notifications/AgUiLearningNotifierTests.cs
+++ b/src/Content/Tests/Presentation.AgentHub.Tests/Notifications/AgUiLearningNotifierTests.cs
@@ -1,0 +1,200 @@
+using Domain.AI.Learnings;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Presentation.AgentHub.AgUi;
+using Presentation.AgentHub.Notifications;
+using Xunit;
+
+namespace Presentation.AgentHub.Tests.Notifications;
+
+/// <summary>
+/// Tests for <see cref="AgUiLearningNotifier"/> -- verifies correct domain-to-AG-UI
+/// event translation and writer invocation for learning lifecycle events.
+/// </summary>
+public sealed class AgUiLearningNotifierTests
+{
+    private readonly Mock<IAgUiEventWriterAccessor> _accessorMock = new();
+    private readonly Mock<IAgUiEventWriter> _writerMock = new();
+    private readonly AgUiLearningNotifier _sut;
+
+    public AgUiLearningNotifierTests()
+    {
+        _accessorMock.Setup(a => a.Writer).Returns(_writerMock.Object);
+        _writerMock
+            .Setup(w => w.WriteAsync(It.IsAny<AgUiEvent>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        _sut = new AgUiLearningNotifier(
+            _accessorMock.Object,
+            NullLogger<AgUiLearningNotifier>.Instance);
+    }
+
+    [Fact]
+    public async Task NotifyLearningCapturedAsync_EmitsLearningCapturedEvent()
+    {
+        var entry = CreateLearningEntry();
+
+        await _sut.NotifyLearningCapturedAsync(entry, CancellationToken.None);
+
+        _writerMock.Verify(
+            w => w.WriteAsync(It.Is<LearningCapturedEvent>(e =>
+                e.LearningId == entry.LearningId.ToString() &&
+                e.Category == "FactualCorrection" &&
+                e.AgentId == "test-agent" &&
+                e.TeamId == "test-team" &&
+                e.IsGlobal == false &&
+                e.SourceDescription == "User corrected date format"),
+            CancellationToken.None),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task NotifyLearningAppliedAsync_EmitsLearningAppliedEvent()
+    {
+        var entry = CreateLearningEntry();
+
+        await _sut.NotifyLearningAppliedAsync(entry, "research-agent", CancellationToken.None);
+
+        _writerMock.Verify(
+            w => w.WriteAsync(It.Is<LearningAppliedEvent>(e =>
+                e.LearningId == entry.LearningId.ToString() &&
+                e.AgentId == "research-agent" &&
+                e.Category == "FactualCorrection"),
+            CancellationToken.None),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task NotifyLearningCapturedAsync_NoActiveWriter_DoesNotWrite()
+    {
+        _accessorMock.Setup(a => a.Writer).Returns((IAgUiEventWriter?)null);
+        var sut = new AgUiLearningNotifier(
+            _accessorMock.Object,
+            NullLogger<AgUiLearningNotifier>.Instance);
+
+        var entry = CreateLearningEntry();
+
+        await sut.NotifyLearningCapturedAsync(entry, CancellationToken.None);
+
+        _writerMock.Verify(
+            w => w.WriteAsync(It.IsAny<AgUiEvent>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task NotifyLearningCapturedAsync_WriterThrows_CatchesAndDoesNotThrow()
+    {
+        _writerMock
+            .Setup(w => w.WriteAsync(It.IsAny<AgUiEvent>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("Stream closed"));
+
+        var entry = CreateLearningEntry();
+
+        var act = () => _sut.NotifyLearningCapturedAsync(entry, CancellationToken.None);
+
+        await act.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task NotifyLearningCapturedAsync_OperationCanceledException_Propagates()
+    {
+        _writerMock
+            .Setup(w => w.WriteAsync(It.IsAny<AgUiEvent>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new OperationCanceledException());
+
+        var entry = CreateLearningEntry();
+
+        var act = () => _sut.NotifyLearningCapturedAsync(entry, CancellationToken.None);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    [Fact]
+    public async Task NotifyLearningAppliedAsync_NoActiveWriter_DoesNotWrite()
+    {
+        _accessorMock.Setup(a => a.Writer).Returns((IAgUiEventWriter?)null);
+        var sut = new AgUiLearningNotifier(
+            _accessorMock.Object,
+            NullLogger<AgUiLearningNotifier>.Instance);
+
+        var entry = CreateLearningEntry();
+
+        await sut.NotifyLearningAppliedAsync(entry, "agent-1", CancellationToken.None);
+
+        _writerMock.Verify(
+            w => w.WriteAsync(It.IsAny<AgUiEvent>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task NotifyLearningAppliedAsync_OperationCanceledException_Propagates()
+    {
+        _writerMock
+            .Setup(w => w.WriteAsync(It.IsAny<AgUiEvent>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new OperationCanceledException());
+
+        var entry = CreateLearningEntry();
+
+        var act = () => _sut.NotifyLearningAppliedAsync(entry, "agent-1", CancellationToken.None);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    [Fact]
+    public async Task NotifyLearningAppliedAsync_WriterThrows_CatchesAndDoesNotThrow()
+    {
+        _writerMock
+            .Setup(w => w.WriteAsync(It.IsAny<AgUiEvent>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("Stream closed"));
+
+        var entry = CreateLearningEntry();
+
+        var act = () => _sut.NotifyLearningAppliedAsync(entry, "agent-1", CancellationToken.None);
+
+        await act.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task NotifyLearningCapturedAsync_GlobalScope_SetsIsGlobalTrue()
+    {
+        var entry = CreateLearningEntry() with
+        {
+            Scope = new LearningScope { AgentId = null, TeamId = null, IsGlobal = true },
+        };
+
+        await _sut.NotifyLearningCapturedAsync(entry, CancellationToken.None);
+
+        _writerMock.Verify(
+            w => w.WriteAsync(It.Is<LearningCapturedEvent>(e =>
+                e.AgentId == null &&
+                e.TeamId == null &&
+                e.IsGlobal == true),
+            CancellationToken.None),
+            Times.Once);
+    }
+
+    private static LearningEntry CreateLearningEntry() => new()
+    {
+        LearningId = Guid.NewGuid(),
+        Category = LearningCategory.FactualCorrection,
+        DecayClass = DecayClass.Permanent,
+        Scope = new LearningScope { AgentId = "test-agent", TeamId = "test-team", IsGlobal = false },
+        Content = "Always use ISO 8601 date formats",
+        Source = new LearningSource
+        {
+            SourceType = LearningSourceType.HumanCorrection,
+            SourceId = "correction-1",
+            SourceDescription = "User corrected date format",
+        },
+        Provenance = new LearningProvenance
+        {
+            OriginPipeline = "chat",
+            OriginTask = "date-formatting",
+            OriginTimestamp = DateTimeOffset.UtcNow,
+            Confidence = 0.95,
+        },
+        FeedbackWeight = 1.0,
+        UpdateCount = 0,
+        CreatedAt = DateTimeOffset.UtcNow,
+    };
+}

--- a/src/Content/Tests/Presentation.Common.Tests/Extensions/IServiceCollectionExtensionsTests.cs
+++ b/src/Content/Tests/Presentation.Common.Tests/Extensions/IServiceCollectionExtensionsTests.cs
@@ -1,6 +1,8 @@
 using Domain.Common.Config;
 using Domain.Common.Config.AI;
+using Domain.Common.Config.AI.DriftDetection;
 using Domain.Common.Config.AI.Governance;
+using Domain.Common.Config.AI.Learnings;
 using Domain.Common.Config.AI.Resilience;
 using Domain.Common.Config.Cache;
 using FluentAssertions;
@@ -257,6 +259,118 @@ public sealed class IServiceCollectionExtensionsTests
         resConfig.Timeout.PerAttemptSeconds.Should().Be(30);
         resConfig.DegradedMode.RetryQueueTtlSeconds.Should().Be(300);
         resConfig.DegradedMode.MaxQueueSize.Should().Be(100);
+    }
+
+    // -- DriftDetectionConfig and LearningsConfig bindings --
+
+    [Fact]
+    public void DriftDetectionConfig_BindsFromAppsettings()
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["AppConfig:AI:DriftDetection:Enabled"] = "true",
+                ["AppConfig:AI:DriftDetection:EwmaLambda"] = "0.2",
+                ["AppConfig:AI:DriftDetection:ControlLimitWidth"] = "3.0",
+                ["AppConfig:AI:DriftDetection:MinSamplesForBaseline"] = "20",
+                ["AppConfig:AI:DriftDetection:BaselineWindowDays"] = "7",
+                ["AppConfig:AI:DriftDetection:WarnThresholdSigma"] = "1.5",
+                ["AppConfig:AI:DriftDetection:AlertThresholdSigma"] = "2.5",
+                ["AppConfig:AI:DriftDetection:EscalateThresholdSigma"] = "3.0",
+                ["AppConfig:AI:DriftDetection:EscalationEnabled"] = "true",
+                ["AppConfig:AI:DriftDetection:AuditPath"] = "data/audit",
+            })
+            .Build();
+
+        var driftConfig = config.GetSection("AppConfig:AI:DriftDetection").Get<DriftDetectionConfig>();
+
+        driftConfig.Should().NotBeNull();
+        driftConfig!.Enabled.Should().BeTrue();
+        driftConfig.EwmaLambda.Should().Be(0.2);
+        driftConfig.ControlLimitWidth.Should().Be(3.0);
+        driftConfig.MinSamplesForBaseline.Should().Be(20);
+        driftConfig.BaselineWindowDays.Should().Be(7);
+        driftConfig.WarnThresholdSigma.Should().Be(1.5);
+        driftConfig.AlertThresholdSigma.Should().Be(2.5);
+        driftConfig.EscalateThresholdSigma.Should().Be(3.0);
+        driftConfig.EscalationEnabled.Should().BeTrue();
+        driftConfig.AuditPath.Should().Be("data/audit");
+    }
+
+    [Fact]
+    public void LearningsConfig_BindsFromAppsettings()
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["AppConfig:AI:Learnings:Enabled"] = "true",
+                ["AppConfig:AI:Learnings:StoreProvider"] = "graph",
+                ["AppConfig:AI:Learnings:FeedbackAlpha"] = "0.25",
+                ["AppConfig:AI:Learnings:FeedbackCeiling"] = "0.3",
+                ["AppConfig:AI:Learnings:DiversityInjectionRatio"] = "0.15",
+                ["AppConfig:AI:Learnings:VolatileShelfLifeDays"] = "7",
+                ["AppConfig:AI:Learnings:StableShelfLifeDays"] = "180",
+                ["AppConfig:AI:Learnings:PruneIntervalHours"] = "24",
+                ["AppConfig:AI:Learnings:BaselineAdjustmentThreshold"] = "0.8",
+                ["AppConfig:AI:Learnings:BiasCorrection"] = "true",
+                ["AppConfig:AI:Learnings:DecayBiasAlpha"] = "0.25",
+            })
+            .Build();
+
+        var learningsConfig = config.GetSection("AppConfig:AI:Learnings").Get<LearningsConfig>();
+
+        learningsConfig.Should().NotBeNull();
+        learningsConfig!.Enabled.Should().BeTrue();
+        learningsConfig.StoreProvider.Should().Be("graph");
+        learningsConfig.FeedbackAlpha.Should().Be(0.25);
+        learningsConfig.FeedbackCeiling.Should().Be(0.3);
+        learningsConfig.DiversityInjectionRatio.Should().Be(0.15);
+        learningsConfig.VolatileShelfLifeDays.Should().Be(7);
+        learningsConfig.StableShelfLifeDays.Should().Be(180);
+        learningsConfig.PruneIntervalHours.Should().Be(24);
+        learningsConfig.BaselineAdjustmentThreshold.Should().Be(0.8);
+        learningsConfig.BiasCorrection.Should().BeTrue();
+        learningsConfig.DecayBiasAlpha.Should().Be(0.25);
+    }
+
+    [Fact]
+    public void RegisterConfigSections_BindsDriftDetectionConfig()
+    {
+        var services = new ServiceCollection();
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["AppConfig:AI:DriftDetection:Enabled"] = "true",
+                ["AppConfig:AI:DriftDetection:EwmaLambda"] = "0.2",
+            })
+            .Build();
+
+        services.RegisterConfigSections(config);
+        var provider = services.BuildServiceProvider();
+
+        var driftConfig = provider.GetRequiredService<IOptionsMonitor<DriftDetectionConfig>>().CurrentValue;
+        driftConfig.Enabled.Should().BeTrue();
+        driftConfig.EwmaLambda.Should().Be(0.2);
+    }
+
+    [Fact]
+    public void RegisterConfigSections_BindsLearningsConfig()
+    {
+        var services = new ServiceCollection();
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["AppConfig:AI:Learnings:Enabled"] = "true",
+                ["AppConfig:AI:Learnings:FeedbackAlpha"] = "0.25",
+            })
+            .Build();
+
+        services.RegisterConfigSections(config);
+        var provider = services.BuildServiceProvider();
+
+        var learningsConfig = provider.GetRequiredService<IOptionsMonitor<LearningsConfig>>().CurrentValue;
+        learningsConfig.Enabled.Should().BeTrue();
+        learningsConfig.FeedbackAlpha.Should().Be(0.25);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- **Phase 2 (Escalation + Resilience):** Adds escalation workflow with supervisor approval, resilient chat client with Polly-based circuit breaker/retry/fallback chain, degraded-mode retry queue, provider health monitoring, and AG-UI escalation SSE events. 21 sections, 185 tests.
- **Phase 3 (Quality Loop — Drift Detection + Learnings):** Adds EWMA-based statistical drift detection with configurable sigma thresholds, cross-session learnings with Remember/Recall/Forget/Improve operations, feedback-weighted retrieval with diversity injection, graph and in-memory store backends, learning decay with pruning, drift-escalation bridge (Phase 2 integration), learnings-drift bridge for baseline adjustment, AG-UI SSE notifiers, and full DI/config wiring. 20 sections, ~100 new tests.
- **Cross-phase integration:** Drift escalation triggers Phase 2 `IEscalationService`; escalation resolutions create learnings via `DriftEscalationBridge`; high-confidence learnings adjust drift baselines via learnings-drift bridge.
- **Total:** 4,263 tests passing, 0 regressions, 853 files changed.

## Test plan

- [x] `dotnet build src/AgenticHarness.slnx` — 0 errors
- [x] `dotnet test src/AgenticHarness.slnx` — 4,263 passed, 19 pre-existing failures (9 AgentFactory, 9 Docker/Testcontainers, 1 flaky concurrency)
- [x] Phase 3 drift tests pass: `--filter "FullyQualifiedName~Drift|FullyQualifiedName~Ewma|FullyQualifiedName~Baseline"`
- [x] Phase 3 learnings tests pass: `--filter "FullyQualifiedName~Learning|FullyQualifiedName~Decay|FullyQualifiedName~Remember|FullyQualifiedName~Recall|FullyQualifiedName~Forget|FullyQualifiedName~Improve"`
- [x] Config binding verified: DriftDetectionConfig and LearningsConfig bind correctly from appsettings.json in both AgentHub and ConsoleUI
- [x] Cross-phase integration: DriftEscalationBridge receives escalation notifications, learnings-drift bridge triggers baseline adjustments

🤖 Generated with [Claude Code](https://claude.com/claude-code)