### PR TITLE
feat: Phase B — Multi-Hop Retrieval & Faithfulness Evaluation

### DIFF
--- a/src/Content/Application/Application.AI.Common/Interfaces/RAG/IAnswerFaithfulnessEvaluator.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/RAG/IAnswerFaithfulnessEvaluator.cs
@@ -1,0 +1,15 @@
+using Domain.AI.RAG.Models;
+
+namespace Application.AI.Common.Interfaces.RAG;
+
+/// <summary>
+/// Evaluates whether an assembled answer is faithful to the retrieved context.
+/// </summary>
+public interface IAnswerFaithfulnessEvaluator
+{
+    /// <summary>Evaluate faithfulness of the answer against the supporting context.</summary>
+    Task<FaithfulnessEvaluation> EvaluateAsync(
+        string answer,
+        IReadOnlyList<RerankedResult> supportingContext,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Content/Application/Application.AI.Common/Interfaces/RAG/IIterativeRetriever.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/RAG/IIterativeRetriever.cs
@@ -1,0 +1,16 @@
+using Domain.AI.RAG.Models;
+
+namespace Application.AI.Common.Interfaces.RAG;
+
+/// <summary>
+/// Orchestrates multi-hop iterative retrieval for complex queries.
+/// </summary>
+public interface IIterativeRetriever
+{
+    /// <summary>Execute iterative multi-hop retrieval for a complex query.</summary>
+    Task<IterativeRetrievalResult> RetrieveIterativelyAsync(
+        string query,
+        int topKPerHop,
+        string? collectionName = null,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Content/Application/Application.AI.Common/Interfaces/RAG/IQueryDecomposer.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/RAG/IQueryDecomposer.cs
@@ -1,0 +1,12 @@
+using Domain.AI.RAG.Models;
+
+namespace Application.AI.Common.Interfaces.RAG;
+
+/// <summary>
+/// Decomposes complex queries into ordered sub-queries with dependency tracking.
+/// </summary>
+public interface IQueryDecomposer
+{
+    /// <summary>Decompose a complex query into ordered sub-queries.</summary>
+    Task<DecomposedQuery> DecomposeAsync(string query, CancellationToken cancellationToken = default);
+}

--- a/src/Content/Application/Application.AI.Common/Interfaces/RAG/ISufficiencyEvaluator.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/RAG/ISufficiencyEvaluator.cs
@@ -1,0 +1,16 @@
+using Domain.AI.RAG.Models;
+
+namespace Application.AI.Common.Interfaces.RAG;
+
+/// <summary>
+/// Evaluates whether retrieved context is sufficient to answer a sub-query.
+/// Returns a score between 0.0 (insufficient) and 1.0 (fully sufficient).
+/// </summary>
+public interface ISufficiencyEvaluator
+{
+    /// <summary>Evaluate sufficiency of retrieved results for a sub-query.</summary>
+    Task<double> EvaluateAsync(
+        string subQuery,
+        IReadOnlyList<RetrievalResult> results,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Content/Domain/Domain.AI/RAG/Models/DecomposedQuery.cs
+++ b/src/Content/Domain/Domain.AI/RAG/Models/DecomposedQuery.cs
@@ -1,0 +1,17 @@
+namespace Domain.AI.RAG.Models;
+
+/// <summary>
+/// The result of decomposing a complex query into ordered sub-queries.
+/// </summary>
+public sealed record DecomposedQuery
+{
+    /// <summary>The original user query before decomposition.</summary>
+    public required string OriginalQuery { get; init; }
+
+    /// <summary>The ordered list of sub-queries. Guaranteed at least one.</summary>
+    public required IReadOnlyList<SubQuery> SubQueries { get; init; }
+
+    /// <summary>Whether any sub-query has dependencies requiring sequential execution.</summary>
+    public bool RequiresSequentialExecution =>
+        SubQueries.Any(sq => sq.DependsOnOrders.Count > 0);
+}

--- a/src/Content/Domain/Domain.AI/RAG/Models/FaithfulnessEvaluation.cs
+++ b/src/Content/Domain/Domain.AI/RAG/Models/FaithfulnessEvaluation.cs
@@ -1,0 +1,22 @@
+namespace Domain.AI.RAG.Models;
+
+/// <summary>
+/// Result of evaluating whether an answer is faithful to the retrieved context.
+/// </summary>
+public sealed record FaithfulnessEvaluation
+{
+    /// <summary>Whether the answer is considered faithful overall.</summary>
+    public required bool IsFaithful { get; init; }
+
+    /// <summary>Faithfulness score (0.0–1.0) where 1.0 means fully grounded.</summary>
+    public required double Score { get; init; }
+
+    /// <summary>Claims not supported by the retrieved context.</summary>
+    public IReadOnlyList<string> HallucinatedClaims { get; init; } = [];
+
+    /// <summary>Claims supported by the retrieved context.</summary>
+    public IReadOnlyList<string> SupportedClaims { get; init; } = [];
+
+    /// <summary>Optional reasoning from the evaluator.</summary>
+    public string? Reasoning { get; init; }
+}

--- a/src/Content/Domain/Domain.AI/RAG/Models/HopResult.cs
+++ b/src/Content/Domain/Domain.AI/RAG/Models/HopResult.cs
@@ -1,0 +1,22 @@
+namespace Domain.AI.RAG.Models;
+
+/// <summary>
+/// The result of a single retrieval hop within the iterative retrieval loop.
+/// </summary>
+public sealed record HopResult
+{
+    /// <summary>The sub-query used for retrieval in this hop.</summary>
+    public required SubQuery SubQuery { get; init; }
+
+    /// <summary>The retrieval results obtained for this hop's sub-query.</summary>
+    public required IReadOnlyList<RetrievalResult> Results { get; init; }
+
+    /// <summary>Sufficiency score (0.0–1.0) for this hop's context.</summary>
+    public required double SufficiencyScore { get; init; }
+
+    /// <summary>The 1-based hop number within the iterative sequence.</summary>
+    public required int HopNumber { get; init; }
+
+    /// <summary>Whether the context was deemed sufficient.</summary>
+    public required bool IsSufficient { get; init; }
+}

--- a/src/Content/Domain/Domain.AI/RAG/Models/IterativeRetrievalResult.cs
+++ b/src/Content/Domain/Domain.AI/RAG/Models/IterativeRetrievalResult.cs
@@ -1,0 +1,19 @@
+namespace Domain.AI.RAG.Models;
+
+/// <summary>
+/// Aggregate result of multi-hop iterative retrieval.
+/// </summary>
+public sealed record IterativeRetrievalResult
+{
+    /// <summary>Ordered list of hop results from each iteration.</summary>
+    public required IReadOnlyList<HopResult> Hops { get; init; }
+
+    /// <summary>All results aggregated across hops, deduplicated by chunk ID.</summary>
+    public required IReadOnlyList<RetrievalResult> AggregatedResults { get; init; }
+
+    /// <summary>Total token count consumed across all hops.</summary>
+    public required int TotalTokensUsed { get; init; }
+
+    /// <summary>Whether the token budget was exhausted before completion.</summary>
+    public required bool BudgetExhausted { get; init; }
+}

--- a/src/Content/Domain/Domain.AI/RAG/Models/SubQuery.cs
+++ b/src/Content/Domain/Domain.AI/RAG/Models/SubQuery.cs
@@ -1,0 +1,19 @@
+namespace Domain.AI.RAG.Models;
+
+/// <summary>
+/// A single sub-query produced by decomposing a complex query into smaller,
+/// independently-retrievable parts. Each sub-query has an execution order
+/// and may declare dependencies on other sub-queries whose results must be
+/// available before this sub-query can be meaningfully answered.
+/// </summary>
+public sealed record SubQuery
+{
+    /// <summary>The natural language text of this sub-query.</summary>
+    public required string Text { get; init; }
+
+    /// <summary>The 1-based execution order within the decomposition.</summary>
+    public required int Order { get; init; }
+
+    /// <summary>Orders of sub-queries that must complete before this one executes.</summary>
+    public IReadOnlyList<int> DependsOnOrders { get; init; } = [];
+}

--- a/src/Content/Domain/Domain.Common/Config/AI/RAG/FaithfulnessConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/RAG/FaithfulnessConfig.cs
@@ -1,0 +1,16 @@
+namespace Domain.Common.Config.AI.RAG;
+
+/// <summary>
+/// Configuration for post-assembly answer faithfulness evaluation.
+/// </summary>
+public sealed class FaithfulnessConfig
+{
+    /// <summary>Enable post-assembly faithfulness evaluation.</summary>
+    public bool Enabled { get; set; } = true;
+
+    /// <summary>Score threshold below which the answer is considered unfaithful.</summary>
+    public double HallucinationThreshold { get; set; } = 0.3;
+
+    /// <summary>Whether to require citation support for every claim.</summary>
+    public bool RequireCitationSupport { get; set; } = true;
+}

--- a/src/Content/Domain/Domain.Common/Config/AI/RAG/MultiHopConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/RAG/MultiHopConfig.cs
@@ -1,0 +1,22 @@
+namespace Domain.Common.Config.AI.RAG;
+
+/// <summary>
+/// Configuration for multi-hop iterative retrieval.
+/// </summary>
+public sealed class MultiHopConfig
+{
+    /// <summary>Enable multi-hop iterative retrieval for complex queries.</summary>
+    public bool Enabled { get; set; } = true;
+
+    /// <summary>Maximum number of retrieval iterations (hops).</summary>
+    public int MaxHops { get; set; } = 3;
+
+    /// <summary>Token budget allocated per individual hop.</summary>
+    public int TokenBudgetPerHop { get; set; } = 1024;
+
+    /// <summary>Minimum sufficiency score (0.0–1.0) to consider a sub-query answered.</summary>
+    public double MinSufficiencyScore { get; set; } = 0.7;
+
+    /// <summary>Number of results to retrieve per hop.</summary>
+    public int TopKPerHop { get; set; } = 5;
+}

--- a/src/Content/Domain/Domain.Common/Config/AI/RAG/RagConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/RAG/RagConfig.cs
@@ -10,14 +10,17 @@ namespace Domain.Common.Config.AI.RAG;
 /// Configuration hierarchy:
 /// <code>
 /// AppConfig.AI.Rag
-/// ├── Ingestion      — Chunking strategy, token targets, RAPTOR summaries
-/// ├── Retrieval      — Top-K, RRF constant, hybrid search toggle
-/// ├── VectorStore    — Provider, endpoint, embedding model, dimensions
-/// ├── GraphRag       — Graph provider, community level, entity extraction
-/// ├── Reranker       — Reranking strategy and model selection
-/// ├── Crag           — Corrective RAG thresholds and web fallback
-/// ├── QueryTransform — RAG-Fusion, HyDE, query classification toggles
-/// └── ModelTiering   — Per-operation model tier assignment
+/// ├── Ingestion          — Chunking strategy, token targets, RAPTOR summaries
+/// ├── Retrieval          — Top-K, RRF constant, hybrid search toggle
+/// ├── VectorStore        — Provider, endpoint, embedding model, dimensions
+/// ├── GraphRag           — Graph provider, community level, entity extraction
+/// ├── Reranker           — Reranking strategy and model selection
+/// ├── Crag               — Corrective RAG thresholds and web fallback
+/// ├── QueryTransform     — RAG-Fusion, HyDE, query classification toggles
+/// ├── ModelTiering       — Per-operation model tier assignment
+/// ├── ComplexityRouting  — Cost-aware tier selection and pipeline optimization
+/// ├── MultiHop           — Iterative multi-hop retrieval for complex queries
+/// └── Faithfulness       — Post-assembly answer faithfulness evaluation
 /// </code>
 /// </para>
 /// </remarks>
@@ -76,4 +79,10 @@ public class RagConfig
     /// cost-aware tier selection and pipeline optimization.
     /// </summary>
     public ComplexityRoutingConfig ComplexityRouting { get; set; } = new();
+
+    /// <summary>Gets or sets the multi-hop iterative retrieval configuration.</summary>
+    public MultiHopConfig MultiHop { get; set; } = new();
+
+    /// <summary>Gets or sets the faithfulness evaluation configuration.</summary>
+    public FaithfulnessConfig Faithfulness { get; set; } = new();
 }

--- a/src/Content/Infrastructure/Infrastructure.AI.RAG/DependencyInjection.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.RAG/DependencyInjection.cs
@@ -39,6 +39,8 @@ public static class DependencyInjection
 		AddRagEvaluation(services, appConfig);
 		AddRagGraphRag(services, appConfig);
 		AddRagComplexityRouting(services);
+		AddRagMultiHop(services, appConfig);
+		AddRagFaithfulness(services, appConfig);
 		AddRagOrchestration(services, appConfig);
 
 		return services;
@@ -226,6 +228,25 @@ public static class DependencyInjection
 	{
 		services.AddSingleton<IQueryComplexityClassifier, QueryComplexityClassifier>();
 		services.AddSingleton<IRetrievalDecisionGate, RetrievalDecisionGate>();
+	}
+
+	/// <summary>
+	/// Registers Phase B multi-hop iterative retrieval services: query decomposer,
+	/// sufficiency evaluator, and iterative retriever.
+	/// </summary>
+	private static void AddRagMultiHop(IServiceCollection services, AppConfig appConfig)
+	{
+		services.AddSingleton<IQueryDecomposer, QueryDecomposer>();
+		services.AddSingleton<ISufficiencyEvaluator, SufficiencyEvaluator>();
+		services.AddSingleton<IIterativeRetriever, IterativeRetriever>();
+	}
+
+	/// <summary>
+	/// Registers Phase B answer faithfulness evaluation services.
+	/// </summary>
+	private static void AddRagFaithfulness(IServiceCollection services, AppConfig appConfig)
+	{
+		services.AddSingleton<IAnswerFaithfulnessEvaluator, AnswerFaithfulnessEvaluator>();
 	}
 
 	/// <summary>

--- a/src/Content/Infrastructure/Infrastructure.AI.RAG/DependencyInjection.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.RAG/DependencyInjection.cs
@@ -232,6 +232,9 @@ public static class DependencyInjection
 	/// Registers the top-level RAG orchestrator that coordinates all pipeline
 	/// stages (classify, retrieve, rerank, evaluate, assemble) into a single
 	/// <see cref="IRagOrchestrator.SearchAsync"/> entry point.
+	/// Phase B optional services (iterative retriever, faithfulness evaluator)
+	/// are resolved via <see cref="ServiceProviderServiceExtensions.GetService{T}"/>
+	/// and remain null when not registered.
 	/// </summary>
 	private static void AddRagOrchestration(IServiceCollection services, AppConfig appConfig)
 	{
@@ -246,8 +249,10 @@ public static class DependencyInjection
 				sp.GetRequiredService<QueryRouter>(),
 				sp.GetRequiredService<IOptionsMonitor<AppConfig>>(),
 				sp.GetRequiredService<ILogger<RagOrchestrator>>(),
-				sp.GetRequiredService<IQueryComplexityClassifier>(),
-				sp.GetRequiredService<IRetrievalDecisionGate>()));
+				sp.GetService<IQueryComplexityClassifier>(),
+				sp.GetService<IRetrievalDecisionGate>(),
+				sp.GetService<IIterativeRetriever>(),
+				sp.GetService<IAnswerFaithfulnessEvaluator>()));
 	}
 
 	/// <summary>

--- a/src/Content/Infrastructure/Infrastructure.AI.RAG/Evaluation/AnswerFaithfulnessEvaluator.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.RAG/Evaluation/AnswerFaithfulnessEvaluator.cs
@@ -80,6 +80,7 @@ public sealed class AnswerFaithfulnessEvaluator : IAnswerFaithfulnessEvaluator
         IReadOnlyList<RerankedResult> supportingContext,
         CancellationToken cancellationToken = default)
     {
+        ArgumentException.ThrowIfNullOrWhiteSpace(answer);
         cancellationToken.ThrowIfCancellationRequested();
 
         if (supportingContext.Count == 0)

--- a/src/Content/Infrastructure/Infrastructure.AI.RAG/Evaluation/AnswerFaithfulnessEvaluator.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.RAG/Evaluation/AnswerFaithfulnessEvaluator.cs
@@ -1,0 +1,203 @@
+using System.Text.Json;
+using Application.AI.Common.Interfaces.RAG;
+using Domain.AI.RAG.Models;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
+
+namespace Infrastructure.AI.RAG.Evaluation;
+
+/// <summary>
+/// LLM-based evaluator that checks whether an assembled answer is faithful to the
+/// retrieved context. Decomposes the answer into individual claims, verifies each
+/// claim against the supporting context, and identifies hallucinated claims that
+/// are not grounded in the source material.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The evaluator uses claim-level decomposition rather than holistic scoring to
+/// provide actionable feedback: specific hallucinated claims can be removed or
+/// flagged, enabling targeted corrective action rather than blanket re-retrieval.
+/// </para>
+/// <para>
+/// On any LLM failure, the evaluator returns a conservative unfaithful result
+/// (score 0.0) as a fail-safe, triggering corrective action.
+/// </para>
+/// </remarks>
+public sealed class AnswerFaithfulnessEvaluator : IAnswerFaithfulnessEvaluator
+{
+    private readonly IRagModelRouter _modelRouter;
+    private readonly ILogger<AnswerFaithfulnessEvaluator> _logger;
+
+    private const string SystemPrompt = """
+        You are a faithfulness evaluator for a RAG (Retrieval-Augmented Generation) system.
+        Given an answer and the retrieved context chunks it was generated from, evaluate whether
+        the answer is faithful to the context.
+
+        **Your task:**
+        1. Decompose the answer into individual factual claims.
+        2. For each claim, check if it is supported by the retrieved context.
+        3. Classify each claim as "supported" or "hallucinated".
+        4. Compute an overall faithfulness score (proportion of supported claims).
+
+        **Scoring:**
+        - 1.0: Every claim is directly supported by the context.
+        - 0.7-0.99: Most claims supported, minor unsupported details.
+        - 0.4-0.69: Mix of supported and unsupported claims.
+        - 0.0-0.39: Most claims are not supported by the context.
+
+        **Important:**
+        - A claim is hallucinated if it states a specific fact not found in any context chunk.
+        - Generic/obvious statements (e.g., "this is important") are not claims and should be ignored.
+        - If a claim contradicts the context, it is hallucinated.
+        - If a claim is a reasonable inference from the context, it is supported.
+
+        Respond with JSON only:
+        {
+            "is_faithful": true/false,
+            "score": 0.0-1.0,
+            "supported_claims": ["claim 1", "claim 2"],
+            "hallucinated_claims": ["claim X"],
+            "reasoning": "brief explanation"
+        }
+        """;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AnswerFaithfulnessEvaluator"/> class.
+    /// </summary>
+    /// <param name="modelRouter">Model router for resolving the LLM client.</param>
+    /// <param name="logger">Logger for evaluation diagnostics.</param>
+    public AnswerFaithfulnessEvaluator(
+        IRagModelRouter modelRouter,
+        ILogger<AnswerFaithfulnessEvaluator> logger)
+    {
+        _modelRouter = modelRouter;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<FaithfulnessEvaluation> EvaluateAsync(
+        string answer,
+        IReadOnlyList<RerankedResult> supportingContext,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (supportingContext.Count == 0)
+        {
+            _logger.LogDebug("No supporting context for faithfulness evaluation; returning unfaithful");
+            return new FaithfulnessEvaluation
+            {
+                IsFaithful = false,
+                Score = 0.0,
+                HallucinatedClaims = [],
+                SupportedClaims = [],
+                Reasoning = "No supporting context available to verify faithfulness.",
+            };
+        }
+
+        try
+        {
+            var client = _modelRouter.GetClientForOperation("faithfulness_evaluation");
+
+            var contextText = string.Join("\n---\n", supportingContext.Select((r, i) =>
+                $"[Chunk {i + 1}] (rerank score: {r.RerankScore:F2})\n{r.RetrievalResult.Chunk.Content}"));
+
+            var userPrompt = $"""
+                **Answer to evaluate:**
+                {answer}
+
+                **Retrieved context chunks:**
+                {contextText}
+
+                Evaluate whether the answer is faithful to the context.
+                """;
+
+            var messages = new List<ChatMessage>
+            {
+                new(ChatRole.System, SystemPrompt),
+                new(ChatRole.User, userPrompt),
+            };
+
+            var response = await client.GetResponseAsync(messages, cancellationToken: cancellationToken);
+            var content = response.Text?.Trim() ?? string.Empty;
+
+            return ParseEvaluation(content);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Faithfulness evaluation failed, returning conservative unfaithful result");
+            return CreateFallback();
+        }
+    }
+
+    private FaithfulnessEvaluation ParseEvaluation(string content)
+    {
+        try
+        {
+            var jsonStart = content.IndexOf('{');
+            var jsonEnd = content.LastIndexOf('}');
+            if (jsonStart < 0 || jsonEnd < 0 || jsonEnd <= jsonStart)
+                return CreateFallback();
+
+            var json = content[jsonStart..(jsonEnd + 1)];
+            using var doc = JsonDocument.Parse(json);
+            var root = doc.RootElement;
+
+            var isFaithful = root.TryGetProperty("is_faithful", out var faithfulProp)
+                && faithfulProp.GetBoolean();
+            var score = root.TryGetProperty("score", out var scoreProp)
+                ? Math.Clamp(scoreProp.GetDouble(), 0.0, 1.0)
+                : 0.0;
+            var reasoning = root.TryGetProperty("reasoning", out var reasonProp)
+                ? reasonProp.GetString()
+                : null;
+
+            var supportedClaims = ParseStringArray(root, "supported_claims");
+            var hallucinatedClaims = ParseStringArray(root, "hallucinated_claims");
+
+            return new FaithfulnessEvaluation
+            {
+                IsFaithful = isFaithful,
+                Score = score,
+                SupportedClaims = supportedClaims,
+                HallucinatedClaims = hallucinatedClaims,
+                Reasoning = reasoning,
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to parse faithfulness evaluation JSON, returning fallback");
+            return CreateFallback();
+        }
+    }
+
+    private static IReadOnlyList<string> ParseStringArray(JsonElement root, string propertyName)
+    {
+        if (!root.TryGetProperty(propertyName, out var arrayProp)
+            || arrayProp.ValueKind != JsonValueKind.Array)
+            return [];
+
+        var items = new List<string>();
+        foreach (var element in arrayProp.EnumerateArray())
+        {
+            var text = element.GetString();
+            if (!string.IsNullOrWhiteSpace(text))
+                items.Add(text);
+        }
+        return items;
+    }
+
+    private static FaithfulnessEvaluation CreateFallback() =>
+        new()
+        {
+            IsFaithful = false,
+            Score = 0.0,
+            HallucinatedClaims = [],
+            SupportedClaims = [],
+            Reasoning = "Faithfulness evaluation failed; returning conservative unfaithful result.",
+        };
+}

--- a/src/Content/Infrastructure/Infrastructure.AI.RAG/Evaluation/SufficiencyEvaluator.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.RAG/Evaluation/SufficiencyEvaluator.cs
@@ -53,6 +53,7 @@ public sealed class SufficiencyEvaluator : ISufficiencyEvaluator
         IReadOnlyList<RetrievalResult> results,
         CancellationToken cancellationToken = default)
     {
+        ArgumentException.ThrowIfNullOrWhiteSpace(subQuery);
         cancellationToken.ThrowIfCancellationRequested();
 
         if (results.Count == 0)

--- a/src/Content/Infrastructure/Infrastructure.AI.RAG/Evaluation/SufficiencyEvaluator.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.RAG/Evaluation/SufficiencyEvaluator.cs
@@ -1,0 +1,128 @@
+using System.Text.Json;
+using Application.AI.Common.Interfaces.RAG;
+using Domain.AI.RAG.Models;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
+
+namespace Infrastructure.AI.RAG.Evaluation;
+
+/// <summary>
+/// LLM-based evaluator that assesses whether retrieved chunks sufficiently answer
+/// a sub-query. Returns a score between 0.0 (completely insufficient) and 1.0
+/// (fully sufficient). Returns 0.0 immediately for empty result sets without
+/// calling the LLM. Falls back to 0.5 (uncertain) on any LLM failure.
+/// </summary>
+public sealed class SufficiencyEvaluator : ISufficiencyEvaluator
+{
+    private readonly IRagModelRouter _modelRouter;
+    private readonly ILogger<SufficiencyEvaluator> _logger;
+
+    private const double DefaultScore = 0.5;
+
+    private const string SystemPrompt = """
+        You are a retrieval sufficiency evaluator for a RAG system. Given a sub-query and a set of
+        retrieved document chunks, assess whether the chunks contain enough information to fully
+        answer the sub-query.
+
+        **Scoring guide:**
+        - **0.9-1.0**: Chunks directly and completely answer the sub-query with specific details.
+        - **0.7-0.89**: Chunks address the main question but may lack minor details.
+        - **0.5-0.69**: Chunks are partially relevant but miss key aspects of the question.
+        - **0.3-0.49**: Chunks are tangentially related but do not meaningfully answer the question.
+        - **0.0-0.29**: Chunks are irrelevant to the sub-query.
+
+        Respond with JSON only: {"score": 0.0-1.0, "reasoning": "brief explanation"}
+        """;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SufficiencyEvaluator"/> class.
+    /// </summary>
+    /// <param name="modelRouter">Model router for resolving the LLM client.</param>
+    /// <param name="logger">Logger for evaluation diagnostics.</param>
+    public SufficiencyEvaluator(
+        IRagModelRouter modelRouter,
+        ILogger<SufficiencyEvaluator> logger)
+    {
+        _modelRouter = modelRouter;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<double> EvaluateAsync(
+        string subQuery,
+        IReadOnlyList<RetrievalResult> results,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (results.Count == 0)
+        {
+            _logger.LogDebug("No results to evaluate sufficiency for sub-query; returning 0.0");
+            return 0.0;
+        }
+
+        try
+        {
+            var client = _modelRouter.GetClientForOperation("sufficiency_evaluation");
+
+            var chunksText = string.Join("\n---\n", results.Select((r, i) =>
+                $"[Chunk {i + 1}] (score: {r.FusedScore:F2})\n{r.Chunk.Content}"));
+
+            var userPrompt = $"""
+                **Sub-query:** {subQuery}
+
+                **Retrieved chunks:**
+                {chunksText}
+
+                Evaluate whether these chunks sufficiently answer the sub-query.
+                """;
+
+            var messages = new List<ChatMessage>
+            {
+                new(ChatRole.System, SystemPrompt),
+                new(ChatRole.User, userPrompt),
+            };
+
+            var response = await client.GetResponseAsync(messages, cancellationToken: cancellationToken);
+            var content = response.Text?.Trim() ?? string.Empty;
+
+            return ParseScore(content);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Sufficiency evaluation failed, returning default score {Score}", DefaultScore);
+            return DefaultScore;
+        }
+    }
+
+    private double ParseScore(string content)
+    {
+        try
+        {
+            var jsonStart = content.IndexOf('{');
+            var jsonEnd = content.LastIndexOf('}');
+            if (jsonStart < 0 || jsonEnd < 0 || jsonEnd <= jsonStart)
+                return DefaultScore;
+
+            var json = content[jsonStart..(jsonEnd + 1)];
+            using var doc = JsonDocument.Parse(json);
+
+            if (doc.RootElement.TryGetProperty("score", out var scoreProp))
+            {
+                var score = scoreProp.GetDouble();
+                return Math.Clamp(score, 0.0, 1.0);
+            }
+
+            return DefaultScore;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to parse sufficiency score, returning default");
+            return DefaultScore;
+        }
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI.RAG/Orchestration/RagOrchestrator.MultiHop.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.RAG/Orchestration/RagOrchestrator.MultiHop.cs
@@ -1,0 +1,97 @@
+using System.Diagnostics;
+using Application.AI.Common.Interfaces.RAG;
+using Domain.AI.RAG.Enums;
+using Domain.AI.RAG.Models;
+using Microsoft.Extensions.Logging;
+
+namespace Infrastructure.AI.RAG.Orchestration;
+
+public sealed partial class RagOrchestrator
+{
+    private async Task<RagAssembledContext> ExecuteMultiHopPipelineAsync(
+        string query, int topKPerHop, string? collectionName,
+        CancellationToken cancellationToken)
+    {
+        var retriever = _iterativeRetriever
+            ?? throw new InvalidOperationException("IterativeRetriever is not configured but multi-hop was requested.");
+
+        using var activity = ActivitySource.StartActivity("rag.orchestrator.multi_hop_pipeline");
+        var ragConfig = _configMonitor.CurrentValue.AI.Rag;
+
+        _logger.LogInformation("Entering multi-hop pipeline for complex query");
+
+        // Step 1: Iterative retrieval
+        var iterativeResult = await retriever.RetrieveIterativelyAsync(
+            query, topKPerHop, collectionName, cancellationToken);
+
+        activity?.SetTag("rag.multi_hop.hop_count", iterativeResult.Hops.Count);
+        activity?.SetTag("rag.multi_hop.total_tokens", iterativeResult.TotalTokensUsed);
+        activity?.SetTag("rag.multi_hop.budget_exhausted", iterativeResult.BudgetExhausted);
+
+        if (iterativeResult.AggregatedResults.Count == 0)
+        {
+            _logger.LogWarning("Multi-hop retrieval returned 0 results");
+            return CreateEmptyContext("No relevant documents found after multi-hop retrieval.");
+        }
+
+        // Step 2: Rerank the aggregated results
+        var reranked = await _reranker.RerankAsync(
+            query, iterativeResult.AggregatedResults, topKPerHop, cancellationToken);
+
+        // Step 3: Assemble context
+        var assembled = await _contextAssembler.AssembleAsync(
+            reranked, DefaultMaxTokens, cancellationToken);
+
+        // Step 4: Faithfulness evaluation (if enabled)
+        if (ragConfig.Faithfulness.Enabled && _faithfulnessEvaluator is not null)
+        {
+            var faithfulness = await _faithfulnessEvaluator.EvaluateAsync(
+                assembled.AssembledText, reranked, cancellationToken);
+
+            activity?.SetTag("rag.faithfulness.score", faithfulness.Score);
+            activity?.SetTag("rag.faithfulness.is_faithful", faithfulness.IsFaithful);
+            activity?.SetTag("rag.faithfulness.hallucinated_count", faithfulness.HallucinatedClaims.Count);
+
+            var isUnfaithful = faithfulness.Score <= ragConfig.Faithfulness.HallucinationThreshold;
+
+            if (isUnfaithful)
+            {
+                _logger.LogWarning(
+                    "Faithfulness below threshold: score={Score:F2} < {Threshold:F2}, hallucinated={Count} claims. Triggering CRAG refinement.",
+                    faithfulness.Score, ragConfig.Faithfulness.HallucinationThreshold, faithfulness.HallucinatedClaims.Count);
+
+                var cragEval = await _cragEvaluator.EvaluateAsync(
+                    query, iterativeResult.AggregatedResults, cancellationToken);
+
+                if (cragEval.Action == CorrectionAction.Accept || cragEval.Action == CorrectionAction.Refine)
+                {
+                    var filtered = FilterWeakChunks(reranked, cragEval.WeakChunkIds);
+                    return await _contextAssembler.AssembleAsync(
+                        filtered, DefaultMaxTokens, cancellationToken);
+                }
+
+                _logger.LogWarning("CRAG also rejected after faithfulness failure; returning best available");
+            }
+            else
+            {
+                _logger.LogInformation(
+                    "Faithfulness check passed: score={Score:F2}, {Supported} supported claims",
+                    faithfulness.Score, faithfulness.SupportedClaims.Count);
+            }
+        }
+
+        return assembled;
+    }
+
+    private static IReadOnlyList<RerankedResult> FilterWeakChunks(
+        IReadOnlyList<RerankedResult> results,
+        IReadOnlyList<string> weakChunkIds)
+    {
+        if (weakChunkIds.Count == 0) return results;
+
+        var weakSet = weakChunkIds.ToHashSet();
+        return results
+            .Where(r => !weakSet.Contains(r.RetrievalResult.Chunk.Id))
+            .ToList();
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI.RAG/Orchestration/RagOrchestrator.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.RAG/Orchestration/RagOrchestrator.cs
@@ -37,7 +37,7 @@ namespace Infrastructure.AI.RAG.Orchestration;
 /// multi-hop iterative retrieval with post-assembly faithfulness evaluation.
 /// </para>
 /// </remarks>
-public sealed class RagOrchestrator : IRagOrchestrator
+public sealed partial class RagOrchestrator : IRagOrchestrator
 {
     private static readonly ActivitySource ActivitySource = new("Infrastructure.AI.RAG.Orchestration");
 
@@ -328,7 +328,14 @@ public sealed class RagOrchestrator : IRagOrchestrator
                 query, decision.TopK, collectionName, cancellationToken);
         }
 
-        // Step 1: Retrieve with decision's topK
+        // Step 1: CRAG evaluation path (reuses existing vector pipeline loop with refinement)
+        if (decision.UseCragEvaluation)
+        {
+            return await ExecuteVectorPipelineAsync(
+                query, decision.TopK, collectionName, cancellationToken);
+        }
+
+        // Step 2: Retrieve with decision's topK
         var candidates = await _hybridRetriever.RetrieveAsync(
             query, decision.TopK, collectionName, cancellationToken);
 
@@ -347,7 +354,7 @@ public sealed class RagOrchestrator : IRagOrchestrator
 
         IReadOnlyList<RerankedResult> reranked;
 
-        // Step 2: Conditional reranking
+        // Step 3: Conditional reranking
         if (decision.UseReranking)
         {
             reranked = await _reranker.RerankAsync(
@@ -355,7 +362,6 @@ public sealed class RagOrchestrator : IRagOrchestrator
         }
         else
         {
-            // Convert retrieval results directly to reranked results (preserve order, skip reranker)
             reranked = candidates.Select((r, i) => new RerankedResult
             {
                 RetrievalResult = r,
@@ -365,100 +371,11 @@ public sealed class RagOrchestrator : IRagOrchestrator
             }).ToList();
         }
 
-        // Step 3: Conditional CRAG evaluation (reuses existing vector pipeline loop logic)
-        if (decision.UseCragEvaluation)
-        {
-            return await ExecuteVectorPipelineAsync(
-                query, decision.TopK, collectionName, cancellationToken);
-        }
-
         // Step 4: Direct assembly (skip CRAG)
         _logger.LogInformation(
             "Routed pipeline: assembling {Count} results without CRAG (complexity={Complexity})",
             reranked.Count, decision.Complexity);
         return await _contextAssembler.AssembleAsync(reranked, DefaultMaxTokens, cancellationToken);
-    }
-
-    private async Task<RagAssembledContext> ExecuteMultiHopPipelineAsync(
-        string query, int topKPerHop, string? collectionName,
-        CancellationToken cancellationToken)
-    {
-        using var activity = ActivitySource.StartActivity("rag.orchestrator.multi_hop_pipeline");
-        var ragConfig = _configMonitor.CurrentValue.AI.Rag;
-
-        _logger.LogInformation("Entering multi-hop pipeline for complex query");
-
-        // Step 1: Iterative retrieval
-        var iterativeResult = await _iterativeRetriever!.RetrieveIterativelyAsync(
-            query, topKPerHop, collectionName, cancellationToken);
-
-        activity?.SetTag("rag.multi_hop.hop_count", iterativeResult.Hops.Count);
-        activity?.SetTag("rag.multi_hop.total_tokens", iterativeResult.TotalTokensUsed);
-        activity?.SetTag("rag.multi_hop.budget_exhausted", iterativeResult.BudgetExhausted);
-
-        if (iterativeResult.AggregatedResults.Count == 0)
-        {
-            _logger.LogWarning("Multi-hop retrieval returned 0 results");
-            return CreateEmptyContext("No relevant documents found after multi-hop retrieval.");
-        }
-
-        // Step 2: Rerank the aggregated results
-        var reranked = await _reranker.RerankAsync(
-            query, iterativeResult.AggregatedResults, topKPerHop, cancellationToken);
-
-        // Step 3: Assemble context
-        var assembled = await _contextAssembler.AssembleAsync(
-            reranked, DefaultMaxTokens, cancellationToken);
-
-        // Step 4: Faithfulness evaluation (if enabled)
-        if (ragConfig.Faithfulness.Enabled && _faithfulnessEvaluator is not null)
-        {
-            var faithfulness = await _faithfulnessEvaluator.EvaluateAsync(
-                assembled.AssembledText, reranked, cancellationToken);
-
-            activity?.SetTag("rag.faithfulness.score", faithfulness.Score);
-            activity?.SetTag("rag.faithfulness.is_faithful", faithfulness.IsFaithful);
-            activity?.SetTag("rag.faithfulness.hallucinated_count", faithfulness.HallucinatedClaims.Count);
-
-            if (!faithfulness.IsFaithful)
-            {
-                _logger.LogWarning(
-                    "Faithfulness evaluation failed: score={Score:F2}, hallucinated={Count} claims. Triggering CRAG refinement.",
-                    faithfulness.Score, faithfulness.HallucinatedClaims.Count);
-
-                var cragEval = await _cragEvaluator.EvaluateAsync(
-                    query, iterativeResult.AggregatedResults, cancellationToken);
-
-                if (cragEval.Action == CorrectionAction.Accept || cragEval.Action == CorrectionAction.Refine)
-                {
-                    var filtered = FilterWeakChunks(reranked, cragEval.WeakChunkIds);
-                    return await _contextAssembler.AssembleAsync(
-                        filtered, DefaultMaxTokens, cancellationToken);
-                }
-
-                _logger.LogWarning("CRAG also rejected after faithfulness failure; returning best available");
-            }
-            else
-            {
-                _logger.LogInformation(
-                    "Faithfulness check passed: score={Score:F2}, {Supported} supported claims",
-                    faithfulness.Score, faithfulness.SupportedClaims.Count);
-            }
-        }
-
-        return assembled;
-    }
-
-    private static IReadOnlyList<RerankedResult> FilterWeakChunks(
-        IReadOnlyList<RerankedResult> results,
-        IReadOnlyList<string> weakChunkIds)
-    {
-        if (weakChunkIds.Count == 0) return results;
-
-        var weakSet = weakChunkIds.ToHashSet();
-        return results
-            .Where(r => !weakSet.Contains(r.RetrievalResult.Chunk.Id))
-            .ToList();
     }
 
     private static RagAssembledContext CreateEmptyContext(string reasoning) => new()

--- a/src/Content/Infrastructure/Infrastructure.AI.RAG/Orchestration/RagOrchestrator.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.RAG/Orchestration/RagOrchestrator.cs
@@ -21,15 +21,20 @@ namespace Infrastructure.AI.RAG.Orchestration;
 /// Pipeline flow for vector-based strategies:
 /// <list type="number">
 ///   <item>Classify query via <see cref="QueryRouter"/> (if classification enabled).</item>
-///   <item>Retrieve via <see cref="IHybridRetriever"/>.</item>
+///   <item>Retrieve via <see cref="IHybridRetriever"/> or <see cref="IIterativeRetriever"/> (complex queries).</item>
 ///   <item>Rerank via <see cref="IReranker"/>.</item>
 ///   <item>Evaluate via <see cref="ICragEvaluator"/> — may trigger refinement loop.</item>
+///   <item>Evaluate via <see cref="IAnswerFaithfulnessEvaluator"/> — may trigger CRAG fallback (complex queries).</item>
 ///   <item>Assemble via <see cref="IRagContextAssembler"/>.</item>
 /// </list>
 /// </para>
 /// <para>
 /// For <see cref="RetrievalStrategy.GraphRag"/>, the pipeline bypasses vector
 /// retrieval and delegates directly to <see cref="IGraphRagService.GlobalSearchAsync"/>.
+/// </para>
+/// <para>
+/// For <see cref="QueryComplexity.Complex"/> queries (Phase B), the pipeline uses
+/// multi-hop iterative retrieval with post-assembly faithfulness evaluation.
 /// </para>
 /// </remarks>
 public sealed class RagOrchestrator : IRagOrchestrator
@@ -51,6 +56,8 @@ public sealed class RagOrchestrator : IRagOrchestrator
     private readonly ILogger<RagOrchestrator> _logger;
     private readonly IQueryComplexityClassifier? _complexityClassifier;
     private readonly IRetrievalDecisionGate? _decisionGate;
+    private readonly IIterativeRetriever? _iterativeRetriever;
+    private readonly IAnswerFaithfulnessEvaluator? _faithfulnessEvaluator;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="RagOrchestrator"/> class.
@@ -66,6 +73,8 @@ public sealed class RagOrchestrator : IRagOrchestrator
     /// <param name="logger">Logger for recording pipeline decisions.</param>
     /// <param name="complexityClassifier">Optional complexity classifier for tiered routing. Null disables complexity routing.</param>
     /// <param name="decisionGate">Optional retrieval decision gate. Null disables complexity routing.</param>
+    /// <param name="iterativeRetriever">Optional multi-hop iterative retriever for complex queries. Null disables multi-hop.</param>
+    /// <param name="faithfulnessEvaluator">Optional post-assembly faithfulness evaluator. Null disables faithfulness checks.</param>
     public RagOrchestrator(
         IHybridRetriever hybridRetriever,
         IReranker reranker,
@@ -77,7 +86,9 @@ public sealed class RagOrchestrator : IRagOrchestrator
         IOptionsMonitor<AppConfig> configMonitor,
         ILogger<RagOrchestrator> logger,
         IQueryComplexityClassifier? complexityClassifier = null,
-        IRetrievalDecisionGate? decisionGate = null)
+        IRetrievalDecisionGate? decisionGate = null,
+        IIterativeRetriever? iterativeRetriever = null,
+        IAnswerFaithfulnessEvaluator? faithfulnessEvaluator = null)
     {
         ArgumentNullException.ThrowIfNull(hybridRetriever);
         ArgumentNullException.ThrowIfNull(reranker);
@@ -99,6 +110,8 @@ public sealed class RagOrchestrator : IRagOrchestrator
         _logger = logger;
         _complexityClassifier = complexityClassifier;
         _decisionGate = decisionGate;
+        _iterativeRetriever = iterativeRetriever;
+        _faithfulnessEvaluator = faithfulnessEvaluator;
     }
 
     /// <inheritdoc />
@@ -305,6 +318,16 @@ public sealed class RagOrchestrator : IRagOrchestrator
         activity?.SetTag("rag.use_reranking", decision.UseReranking);
         activity?.SetTag("rag.use_crag", decision.UseCragEvaluation);
 
+        // Phase B: Complex tier uses multi-hop iterative retrieval
+        var ragConfig = _configMonitor.CurrentValue.AI.Rag;
+        if (decision.Complexity == QueryComplexity.Complex
+            && ragConfig.MultiHop.Enabled
+            && _iterativeRetriever is not null)
+        {
+            return await ExecuteMultiHopPipelineAsync(
+                query, decision.TopK, collectionName, cancellationToken);
+        }
+
         // Step 1: Retrieve with decision's topK
         var candidates = await _hybridRetriever.RetrieveAsync(
             query, decision.TopK, collectionName, cancellationToken);
@@ -354,6 +377,76 @@ public sealed class RagOrchestrator : IRagOrchestrator
             "Routed pipeline: assembling {Count} results without CRAG (complexity={Complexity})",
             reranked.Count, decision.Complexity);
         return await _contextAssembler.AssembleAsync(reranked, DefaultMaxTokens, cancellationToken);
+    }
+
+    private async Task<RagAssembledContext> ExecuteMultiHopPipelineAsync(
+        string query, int topKPerHop, string? collectionName,
+        CancellationToken cancellationToken)
+    {
+        using var activity = ActivitySource.StartActivity("rag.orchestrator.multi_hop_pipeline");
+        var ragConfig = _configMonitor.CurrentValue.AI.Rag;
+
+        _logger.LogInformation("Entering multi-hop pipeline for complex query");
+
+        // Step 1: Iterative retrieval
+        var iterativeResult = await _iterativeRetriever!.RetrieveIterativelyAsync(
+            query, topKPerHop, collectionName, cancellationToken);
+
+        activity?.SetTag("rag.multi_hop.hop_count", iterativeResult.Hops.Count);
+        activity?.SetTag("rag.multi_hop.total_tokens", iterativeResult.TotalTokensUsed);
+        activity?.SetTag("rag.multi_hop.budget_exhausted", iterativeResult.BudgetExhausted);
+
+        if (iterativeResult.AggregatedResults.Count == 0)
+        {
+            _logger.LogWarning("Multi-hop retrieval returned 0 results");
+            return CreateEmptyContext("No relevant documents found after multi-hop retrieval.");
+        }
+
+        // Step 2: Rerank the aggregated results
+        var reranked = await _reranker.RerankAsync(
+            query, iterativeResult.AggregatedResults, topKPerHop, cancellationToken);
+
+        // Step 3: Assemble context
+        var assembled = await _contextAssembler.AssembleAsync(
+            reranked, DefaultMaxTokens, cancellationToken);
+
+        // Step 4: Faithfulness evaluation (if enabled)
+        if (ragConfig.Faithfulness.Enabled && _faithfulnessEvaluator is not null)
+        {
+            var faithfulness = await _faithfulnessEvaluator.EvaluateAsync(
+                assembled.AssembledText, reranked, cancellationToken);
+
+            activity?.SetTag("rag.faithfulness.score", faithfulness.Score);
+            activity?.SetTag("rag.faithfulness.is_faithful", faithfulness.IsFaithful);
+            activity?.SetTag("rag.faithfulness.hallucinated_count", faithfulness.HallucinatedClaims.Count);
+
+            if (!faithfulness.IsFaithful)
+            {
+                _logger.LogWarning(
+                    "Faithfulness evaluation failed: score={Score:F2}, hallucinated={Count} claims. Triggering CRAG refinement.",
+                    faithfulness.Score, faithfulness.HallucinatedClaims.Count);
+
+                var cragEval = await _cragEvaluator.EvaluateAsync(
+                    query, iterativeResult.AggregatedResults, cancellationToken);
+
+                if (cragEval.Action == CorrectionAction.Accept || cragEval.Action == CorrectionAction.Refine)
+                {
+                    var filtered = FilterWeakChunks(reranked, cragEval.WeakChunkIds);
+                    return await _contextAssembler.AssembleAsync(
+                        filtered, DefaultMaxTokens, cancellationToken);
+                }
+
+                _logger.LogWarning("CRAG also rejected after faithfulness failure; returning best available");
+            }
+            else
+            {
+                _logger.LogInformation(
+                    "Faithfulness check passed: score={Score:F2}, {Supported} supported claims",
+                    faithfulness.Score, faithfulness.SupportedClaims.Count);
+            }
+        }
+
+        return assembled;
     }
 
     private static IReadOnlyList<RerankedResult> FilterWeakChunks(

--- a/src/Content/Infrastructure/Infrastructure.AI.RAG/QueryTransform/QueryDecomposer.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.RAG/QueryTransform/QueryDecomposer.cs
@@ -1,0 +1,194 @@
+using System.Text.Json;
+using Application.AI.Common.Interfaces.RAG;
+using Domain.AI.RAG.Models;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
+
+namespace Infrastructure.AI.RAG.QueryTransform;
+
+/// <summary>
+/// LLM-based query decomposer that breaks complex multi-part queries into ordered
+/// sub-queries with dependency tracking. Uses few-shot prompting to produce structured
+/// decompositions. Falls back to a single sub-query wrapping the original on any failure.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The decomposer identifies independent sub-questions that can be answered via separate
+/// retrieval passes, and establishes dependency ordering when a sub-question requires
+/// context from a prior answer. This enables the <see cref="IIterativeRetriever"/> to
+/// execute sub-queries in the correct order and inject prior hop results as context.
+/// </para>
+/// </remarks>
+public sealed class QueryDecomposer : IQueryDecomposer
+{
+    private readonly IRagModelRouter _modelRouter;
+    private readonly ILogger<QueryDecomposer> _logger;
+
+    private const string SystemPrompt = """
+        You are a query decomposition engine for a RAG (Retrieval-Augmented Generation) system.
+        Your job is to break complex, multi-part questions into smaller, independently-retrievable sub-queries.
+
+        **Rules:**
+        1. Each sub-query should target a single concept or fact that can be answered by one retrieval pass.
+        2. Assign a 1-based sequential order to each sub-query.
+        3. If a sub-query depends on the answer to a prior sub-query, set "depends_on" to an array of those order numbers.
+        4. If the query is already simple and cannot be decomposed, return a single sub-query with the original text.
+        5. Keep sub-query text concise but self-contained (understandable without seeing other sub-queries).
+
+        **Examples:**
+
+        User: "What chunking strategies are available and how do they compare for code files?"
+        Response:
+        {
+            "sub_queries": [
+                {"text": "What chunking strategies are available in the RAG pipeline?", "order": 1, "depends_on": []},
+                {"text": "How do the chunking strategies compare for code files?", "order": 2, "depends_on": [1]}
+            ]
+        }
+
+        User: "Based on the architecture docs and the deployment guide, what changes are needed to support multi-tenant GraphRAG?"
+        Response:
+        {
+            "sub_queries": [
+                {"text": "What is the current GraphRAG architecture?", "order": 1, "depends_on": []},
+                {"text": "What does the deployment guide specify about multi-tenancy?", "order": 2, "depends_on": []},
+                {"text": "What changes are needed to support multi-tenant GraphRAG given the architecture and deployment constraints?", "order": 3, "depends_on": [1, 2]}
+            ]
+        }
+
+        User: "What is the default topK value?"
+        Response:
+        {
+            "sub_queries": [
+                {"text": "What is the default topK value?", "order": 1, "depends_on": []}
+            ]
+        }
+
+        Respond with JSON only. No explanation, no markdown fences.
+        """;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="QueryDecomposer"/> class.
+    /// </summary>
+    /// <param name="modelRouter">Model router for resolving the LLM client.</param>
+    /// <param name="logger">Logger for decomposition diagnostics.</param>
+    public QueryDecomposer(
+        IRagModelRouter modelRouter,
+        ILogger<QueryDecomposer> logger)
+    {
+        _modelRouter = modelRouter;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<DecomposedQuery> DecomposeAsync(
+        string query,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(query);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        try
+        {
+            var client = _modelRouter.GetClientForOperation("query_decomposition");
+            var messages = new List<ChatMessage>
+            {
+                new(ChatRole.System, SystemPrompt),
+                new(ChatRole.User, query),
+            };
+
+            var response = await client.GetResponseAsync(messages, cancellationToken: cancellationToken);
+            var content = response.Text?.Trim() ?? string.Empty;
+
+            return ParseDecomposition(query, content);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Query decomposition failed, falling back to single sub-query");
+            return CreateFallback(query);
+        }
+    }
+
+    private DecomposedQuery ParseDecomposition(string originalQuery, string content)
+    {
+        try
+        {
+            var jsonStart = content.IndexOf('{');
+            var jsonEnd = content.LastIndexOf('}');
+            if (jsonStart < 0 || jsonEnd < 0 || jsonEnd <= jsonStart)
+                return CreateFallback(originalQuery);
+
+            var json = content[jsonStart..(jsonEnd + 1)];
+            using var doc = JsonDocument.Parse(json);
+            var root = doc.RootElement;
+
+            if (!root.TryGetProperty("sub_queries", out var subQueriesElement)
+                || subQueriesElement.ValueKind != JsonValueKind.Array)
+                return CreateFallback(originalQuery);
+
+            var subQueries = new List<SubQuery>();
+            foreach (var item in subQueriesElement.EnumerateArray())
+            {
+                var text = item.GetProperty("text").GetString() ?? string.Empty;
+                var order = item.TryGetProperty("order", out var orderProp)
+                    ? orderProp.GetInt32()
+                    : subQueries.Count + 1;
+
+                var dependsOn = new List<int>();
+                if (item.TryGetProperty("depends_on", out var depsProp)
+                    && depsProp.ValueKind == JsonValueKind.Array)
+                {
+                    foreach (var dep in depsProp.EnumerateArray())
+                        dependsOn.Add(dep.GetInt32());
+                }
+
+                subQueries.Add(new SubQuery
+                {
+                    Text = text,
+                    Order = order,
+                    DependsOnOrders = dependsOn,
+                });
+            }
+
+            if (subQueries.Count == 0)
+                return CreateFallback(originalQuery);
+
+            subQueries.Sort((a, b) => a.Order.CompareTo(b.Order));
+
+            _logger.LogDebug(
+                "Decomposed query into {Count} sub-queries, sequential={Sequential}",
+                subQueries.Count,
+                subQueries.Any(sq => sq.DependsOnOrders.Count > 0));
+
+            return new DecomposedQuery
+            {
+                OriginalQuery = originalQuery,
+                SubQueries = subQueries,
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to parse decomposition JSON, falling back to single sub-query");
+            return CreateFallback(originalQuery);
+        }
+    }
+
+    private static DecomposedQuery CreateFallback(string originalQuery) =>
+        new()
+        {
+            OriginalQuery = originalQuery,
+            SubQueries =
+            [
+                new SubQuery
+                {
+                    Text = originalQuery,
+                    Order = 1,
+                    DependsOnOrders = [],
+                }
+            ],
+        };
+}

--- a/src/Content/Infrastructure/Infrastructure.AI.RAG/Retrieval/IterativeRetriever.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.RAG/Retrieval/IterativeRetriever.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using Application.AI.Common.Interfaces.RAG;
 using Domain.AI.RAG.Models;
 using Domain.Common.Config;
@@ -29,6 +30,9 @@ namespace Infrastructure.AI.RAG.Retrieval;
 /// </remarks>
 public sealed class IterativeRetriever : IIterativeRetriever
 {
+    private static readonly ActivitySource ActivitySource =
+        new("Infrastructure.AI.RAG.Retrieval.IterativeRetriever");
+
     private readonly IQueryDecomposer _decomposer;
     private readonly IHybridRetriever _hybridRetriever;
     private readonly ISufficiencyEvaluator _sufficiencyEvaluator;
@@ -64,6 +68,8 @@ public sealed class IterativeRetriever : IIterativeRetriever
         string? collectionName = null,
         CancellationToken cancellationToken = default)
     {
+        using var activity = ActivitySource.StartActivity("rag.iterative_retriever.retrieve");
+
         var multiHopConfig = _configMonitor.CurrentValue.AI.Rag.MultiHop;
         var maxHops = multiHopConfig.MaxHops;
         var tokenBudgetPerHop = multiHopConfig.TokenBudgetPerHop;
@@ -119,14 +125,25 @@ public sealed class IterativeRetriever : IIterativeRetriever
                 subQuery.Text, candidates, cancellationToken);
             var isSufficient = sufficiencyScore >= minSufficiency;
 
-            hops.Add(new HopResult
+            var hopResult = new HopResult
             {
                 SubQuery = subQuery,
                 Results = candidates,
                 SufficiencyScore = sufficiencyScore,
                 HopNumber = hopNumber,
                 IsSufficient = isSufficient,
-            });
+            };
+            hops.Add(hopResult);
+
+            activity?.AddEvent(new ActivityEvent("hop_completed", tags: new ActivityTagsCollection
+            {
+                { "rag.hop.number", hopNumber },
+                { "rag.hop.sub_query_order", subQuery.Order },
+                { "rag.hop.sufficiency_score", sufficiencyScore },
+                { "rag.hop.is_sufficient", isSufficient },
+                { "rag.hop.result_count", candidates.Count },
+                { "rag.hop.tokens", hopTokens },
+            }));
 
             foreach (var result in candidates)
             {
@@ -151,6 +168,12 @@ public sealed class IterativeRetriever : IIterativeRetriever
         var aggregatedResults = allResults.Values
             .OrderByDescending(r => r.FusedScore)
             .ToList();
+
+        activity?.SetTag("rag.iterative.total_hops", hops.Count);
+        activity?.SetTag("rag.iterative.total_results", aggregatedResults.Count);
+        activity?.SetTag("rag.iterative.total_tokens", totalTokensUsed);
+        activity?.SetTag("rag.iterative.budget_exhausted", budgetExhausted);
+        activity?.SetTag("rag.iterative.sub_query_count", decomposed.SubQueries.Count);
 
         _logger.LogInformation(
             "Iterative retrieval complete: {Hops} hops, {Results} unique results, {Tokens} tokens, budgetExhausted={BudgetExhausted}",

--- a/src/Content/Infrastructure/Infrastructure.AI.RAG/Retrieval/IterativeRetriever.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.RAG/Retrieval/IterativeRetriever.cs
@@ -20,7 +20,7 @@ namespace Infrastructure.AI.RAG.Retrieval;
 ///   <item>Retrieve via <see cref="IHybridRetriever"/> with configured <c>TopKPerHop</c>.</item>
 ///   <item>Evaluate sufficiency via <see cref="ISufficiencyEvaluator"/>.</item>
 ///   <item>If sufficient (score >= threshold), record the hop and move to the next sub-query.</item>
-///   <item>If insufficient, refine the sub-query with prior context and re-retrieve (up to <c>MaxHops</c>).</item>
+///   <item>If insufficient, record the hop and move to the next sub-query (up to <c>MaxHops</c> total).</item>
 /// </list>
 /// </para>
 /// <para>
@@ -68,6 +68,9 @@ public sealed class IterativeRetriever : IIterativeRetriever
         string? collectionName = null,
         CancellationToken cancellationToken = default)
     {
+        ArgumentException.ThrowIfNullOrWhiteSpace(query);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(topKPerHop);
+
         using var activity = ActivitySource.StartActivity("rag.iterative_retriever.retrieve");
 
         var multiHopConfig = _configMonitor.CurrentValue.AI.Rag.MultiHop;

--- a/src/Content/Infrastructure/Infrastructure.AI.RAG/Retrieval/IterativeRetriever.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.RAG/Retrieval/IterativeRetriever.cs
@@ -1,0 +1,191 @@
+using Application.AI.Common.Interfaces.RAG;
+using Domain.AI.RAG.Models;
+using Domain.Common.Config;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Infrastructure.AI.RAG.Retrieval;
+
+/// <summary>
+/// Multi-hop iterative retriever that decomposes complex queries into sub-queries,
+/// retrieves per sub-query in dependency order, evaluates sufficiency, and aggregates
+/// results across hops. Enforces a hard cap on iterations (<c>MaxHops</c>) and a
+/// per-hop token budget to prevent context window overflow.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The retrieval loop for each sub-query:
+/// <list type="number">
+///   <item>Retrieve via <see cref="IHybridRetriever"/> with configured <c>TopKPerHop</c>.</item>
+///   <item>Evaluate sufficiency via <see cref="ISufficiencyEvaluator"/>.</item>
+///   <item>If sufficient (score >= threshold), record the hop and move to the next sub-query.</item>
+///   <item>If insufficient, refine the sub-query with prior context and re-retrieve (up to <c>MaxHops</c>).</item>
+/// </list>
+/// </para>
+/// <para>
+/// Dependencies are resolved by injecting the content from completed dependent sub-queries
+/// into the refinement prompt, enabling later sub-queries to leverage prior hop results.
+/// </para>
+/// </remarks>
+public sealed class IterativeRetriever : IIterativeRetriever
+{
+    private readonly IQueryDecomposer _decomposer;
+    private readonly IHybridRetriever _hybridRetriever;
+    private readonly ISufficiencyEvaluator _sufficiencyEvaluator;
+    private readonly IOptionsMonitor<AppConfig> _configMonitor;
+    private readonly ILogger<IterativeRetriever> _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="IterativeRetriever"/> class.
+    /// </summary>
+    /// <param name="decomposer">Query decomposer for splitting complex queries.</param>
+    /// <param name="hybridRetriever">Hybrid retriever for per-hop retrieval.</param>
+    /// <param name="sufficiencyEvaluator">Evaluator for assessing retrieval sufficiency.</param>
+    /// <param name="configMonitor">Application configuration monitor.</param>
+    /// <param name="logger">Logger for retrieval diagnostics.</param>
+    public IterativeRetriever(
+        IQueryDecomposer decomposer,
+        IHybridRetriever hybridRetriever,
+        ISufficiencyEvaluator sufficiencyEvaluator,
+        IOptionsMonitor<AppConfig> configMonitor,
+        ILogger<IterativeRetriever> logger)
+    {
+        _decomposer = decomposer;
+        _hybridRetriever = hybridRetriever;
+        _sufficiencyEvaluator = sufficiencyEvaluator;
+        _configMonitor = configMonitor;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<IterativeRetrievalResult> RetrieveIterativelyAsync(
+        string query,
+        int topKPerHop,
+        string? collectionName = null,
+        CancellationToken cancellationToken = default)
+    {
+        var multiHopConfig = _configMonitor.CurrentValue.AI.Rag.MultiHop;
+        var maxHops = multiHopConfig.MaxHops;
+        var tokenBudgetPerHop = multiHopConfig.TokenBudgetPerHop;
+        var minSufficiency = multiHopConfig.MinSufficiencyScore;
+        var totalTokenBudget = maxHops * tokenBudgetPerHop;
+
+        var decomposed = await _decomposer.DecomposeAsync(query, cancellationToken);
+        _logger.LogInformation(
+            "Decomposed query into {SubQueryCount} sub-queries, sequential={Sequential}",
+            decomposed.SubQueries.Count, decomposed.RequiresSequentialExecution);
+
+        var hops = new List<HopResult>();
+        var allResults = new Dictionary<string, RetrievalResult>();
+        var totalTokensUsed = 0;
+        var budgetExhausted = false;
+        var hopNumber = 0;
+        var completedSubQueryResults = new Dictionary<int, IReadOnlyList<RetrievalResult>>();
+
+        foreach (var subQuery in decomposed.SubQueries.OrderBy(sq => sq.Order))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (hopNumber >= maxHops)
+            {
+                _logger.LogInformation("Max hops ({MaxHops}) reached, stopping iteration", maxHops);
+                break;
+            }
+
+            if (totalTokensUsed >= totalTokenBudget)
+            {
+                _logger.LogInformation("Token budget exhausted ({Used}/{Budget})", totalTokensUsed, totalTokenBudget);
+                budgetExhausted = true;
+                break;
+            }
+
+            var effectiveQuery = BuildEffectiveQuery(subQuery, completedSubQueryResults);
+            hopNumber++;
+
+            var candidates = await _hybridRetriever.RetrieveAsync(
+                effectiveQuery, topKPerHop, collectionName, cancellationToken);
+
+            var hopTokens = candidates.Sum(r => r.Chunk.Tokens);
+            totalTokensUsed += hopTokens;
+
+            if (totalTokensUsed > totalTokenBudget)
+            {
+                budgetExhausted = true;
+                _logger.LogDebug("Token budget exceeded on hop {Hop}: {Used}/{Budget}",
+                    hopNumber, totalTokensUsed, totalTokenBudget);
+            }
+
+            var sufficiencyScore = await _sufficiencyEvaluator.EvaluateAsync(
+                subQuery.Text, candidates, cancellationToken);
+            var isSufficient = sufficiencyScore >= minSufficiency;
+
+            hops.Add(new HopResult
+            {
+                SubQuery = subQuery,
+                Results = candidates,
+                SufficiencyScore = sufficiencyScore,
+                HopNumber = hopNumber,
+                IsSufficient = isSufficient,
+            });
+
+            foreach (var result in candidates)
+            {
+                if (allResults.TryGetValue(result.Chunk.Id, out var existing))
+                {
+                    if (result.FusedScore > existing.FusedScore)
+                        allResults[result.Chunk.Id] = result;
+                }
+                else
+                {
+                    allResults[result.Chunk.Id] = result;
+                }
+            }
+
+            completedSubQueryResults[subQuery.Order] = candidates;
+
+            _logger.LogDebug(
+                "Hop {Hop}: sub-query order={Order}, sufficiency={Score:F2}, sufficient={IsSufficient}, tokens={Tokens}",
+                hopNumber, subQuery.Order, sufficiencyScore, isSufficient, hopTokens);
+        }
+
+        var aggregatedResults = allResults.Values
+            .OrderByDescending(r => r.FusedScore)
+            .ToList();
+
+        _logger.LogInformation(
+            "Iterative retrieval complete: {Hops} hops, {Results} unique results, {Tokens} tokens, budgetExhausted={BudgetExhausted}",
+            hops.Count, aggregatedResults.Count, totalTokensUsed, budgetExhausted);
+
+        return new IterativeRetrievalResult
+        {
+            Hops = hops,
+            AggregatedResults = aggregatedResults,
+            TotalTokensUsed = totalTokensUsed,
+            BudgetExhausted = budgetExhausted,
+        };
+    }
+
+    private string BuildEffectiveQuery(
+        SubQuery subQuery,
+        Dictionary<int, IReadOnlyList<RetrievalResult>> completedResults)
+    {
+        if (subQuery.DependsOnOrders.Count == 0)
+            return subQuery.Text;
+
+        var contextParts = new List<string>();
+        foreach (var depOrder in subQuery.DependsOnOrders)
+        {
+            if (completedResults.TryGetValue(depOrder, out var depResults) && depResults.Count > 0)
+            {
+                var contextSnippet = string.Join(" ", depResults.Select(r => r.Chunk.Content).Take(3));
+                contextParts.Add($"[Context from step {depOrder}]: {contextSnippet}");
+            }
+        }
+
+        if (contextParts.Count == 0)
+            return subQuery.Text;
+
+        var context = string.Join("\n", contextParts);
+        return $"{subQuery.Text}\n\nPrior context:\n{context}";
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.RAG.Tests/Evaluation/AnswerFaithfulnessEvaluatorTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.RAG.Tests/Evaluation/AnswerFaithfulnessEvaluatorTests.cs
@@ -1,0 +1,153 @@
+using Application.AI.Common.Interfaces.RAG;
+using Domain.AI.RAG.Models;
+using FluentAssertions;
+using Infrastructure.AI.RAG.Evaluation;
+using Infrastructure.AI.RAG.Tests.Helpers;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Infrastructure.AI.RAG.Tests.Evaluation;
+
+public sealed class AnswerFaithfulnessEvaluatorTests
+{
+    private readonly Mock<IRagModelRouter> _mockRouter = new();
+    private readonly Mock<IChatClient> _mockChatClient = new();
+
+    public AnswerFaithfulnessEvaluatorTests()
+    {
+        _mockRouter
+            .Setup(r => r.GetClientForOperation("faithfulness_evaluation"))
+            .Returns(_mockChatClient.Object);
+    }
+
+    private AnswerFaithfulnessEvaluator CreateEvaluator()
+        => new(
+            _mockRouter.Object,
+            Mock.Of<ILogger<AnswerFaithfulnessEvaluator>>());
+
+    private void SetupChatResponse(string jsonResponse)
+    {
+        _mockChatClient
+            .Setup(c => c.GetResponseAsync(
+                It.IsAny<IList<ChatMessage>>(),
+                It.IsAny<ChatOptions>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ChatResponse(
+                new ChatMessage(ChatRole.Assistant, jsonResponse)));
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_FaithfulAnswer_ReturnsHighScore()
+    {
+        SetupChatResponse("""
+            {
+                "is_faithful": true,
+                "score": 0.95,
+                "supported_claims": ["The default topK is 10", "CRAG evaluation runs after reranking"],
+                "hallucinated_claims": [],
+                "reasoning": "All claims are directly supported by the retrieved context."
+            }
+            """);
+        var evaluator = CreateEvaluator();
+        var context = RagTestData.CreateRerankedResults(3);
+
+        var result = await evaluator.EvaluateAsync("The default topK is 10 and CRAG runs after reranking.", context);
+
+        result.IsFaithful.Should().BeTrue();
+        result.Score.Should().BeGreaterThanOrEqualTo(0.9);
+        result.SupportedClaims.Should().HaveCount(2);
+        result.HallucinatedClaims.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_HallucinatedAnswer_ReturnsFlaggedClaims()
+    {
+        SetupChatResponse("""
+            {
+                "is_faithful": false,
+                "score": 0.2,
+                "supported_claims": ["The system uses hybrid retrieval"],
+                "hallucinated_claims": ["The system uses GPT-5 for classification", "FAISS supports 10 billion vectors natively"],
+                "reasoning": "Two claims have no support in the context."
+            }
+            """);
+        var evaluator = CreateEvaluator();
+        var context = RagTestData.CreateRerankedResults(3);
+
+        var result = await evaluator.EvaluateAsync("Hallucinated answer text", context);
+
+        result.IsFaithful.Should().BeFalse();
+        result.Score.Should().BeLessThan(0.5);
+        result.HallucinatedClaims.Should().HaveCount(2);
+        result.HallucinatedClaims.Should().Contain(c => c.Contains("GPT-5"));
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_PartiallyFaithful_ReturnsMiddleScore()
+    {
+        SetupChatResponse("""
+            {
+                "is_faithful": false,
+                "score": 0.55,
+                "supported_claims": ["The pipeline has 5 stages", "Reranking improves accuracy"],
+                "hallucinated_claims": ["The pipeline uses quantum computing"],
+                "reasoning": "Most claims are supported but one is fabricated."
+            }
+            """);
+        var evaluator = CreateEvaluator();
+        var context = RagTestData.CreateRerankedResults(3);
+
+        var result = await evaluator.EvaluateAsync("Partially faithful answer", context);
+
+        result.Score.Should().BeInRange(0.4, 0.7);
+        result.SupportedClaims.Should().NotBeEmpty();
+        result.HallucinatedClaims.Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_EmptyContext_ReturnsUnfaithful()
+    {
+        var evaluator = CreateEvaluator();
+        IReadOnlyList<RerankedResult> emptyContext = [];
+
+        var result = await evaluator.EvaluateAsync("Any answer", emptyContext);
+
+        result.IsFaithful.Should().BeFalse();
+        result.Score.Should().Be(0.0);
+        _mockChatClient.Verify(
+            c => c.GetResponseAsync(
+                It.IsAny<IList<ChatMessage>>(),
+                It.IsAny<ChatOptions>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_LlmReturnsInvalidJson_ReturnsFallbackEvaluation()
+    {
+        SetupChatResponse("I cannot evaluate this answer.");
+        var evaluator = CreateEvaluator();
+        var context = RagTestData.CreateRerankedResults(3);
+
+        var result = await evaluator.EvaluateAsync("Some answer", context);
+
+        result.IsFaithful.Should().BeFalse();
+        result.Score.Should().Be(0.0);
+        result.Reasoning.Should().Contain("failed");
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_CancellationRequested_ThrowsOperationCanceledException()
+    {
+        var cts = new CancellationTokenSource();
+        cts.Cancel();
+        var evaluator = CreateEvaluator();
+        var context = RagTestData.CreateRerankedResults(3);
+
+        var act = () => evaluator.EvaluateAsync("test", context, cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.RAG.Tests/Evaluation/SufficiencyEvaluatorTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.RAG.Tests/Evaluation/SufficiencyEvaluatorTests.cs
@@ -1,0 +1,106 @@
+using Application.AI.Common.Interfaces.RAG;
+using Domain.AI.RAG.Models;
+using FluentAssertions;
+using Infrastructure.AI.RAG.Evaluation;
+using Infrastructure.AI.RAG.Tests.Helpers;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Infrastructure.AI.RAG.Tests.Evaluation;
+
+public sealed class SufficiencyEvaluatorTests
+{
+    private readonly Mock<IRagModelRouter> _mockRouter = new();
+    private readonly Mock<IChatClient> _mockChatClient = new();
+
+    public SufficiencyEvaluatorTests()
+    {
+        _mockRouter
+            .Setup(r => r.GetClientForOperation("sufficiency_evaluation"))
+            .Returns(_mockChatClient.Object);
+    }
+
+    private SufficiencyEvaluator CreateEvaluator()
+        => new(
+            _mockRouter.Object,
+            Mock.Of<ILogger<SufficiencyEvaluator>>());
+
+    private void SetupChatResponse(string response)
+    {
+        _mockChatClient
+            .Setup(c => c.GetResponseAsync(
+                It.IsAny<IList<ChatMessage>>(),
+                It.IsAny<ChatOptions>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ChatResponse(
+                new ChatMessage(ChatRole.Assistant, response)));
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_SufficientContext_ReturnsHighScore()
+    {
+        SetupChatResponse("""{"score": 0.92, "reasoning": "Context fully addresses the question"}""");
+        var evaluator = CreateEvaluator();
+        var results = RagTestData.CreateRetrievalResults(3);
+
+        var score = await evaluator.EvaluateAsync("What is the default topK?", results);
+
+        score.Should().BeGreaterThanOrEqualTo(0.9);
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_InsufficientContext_ReturnsLowScore()
+    {
+        SetupChatResponse("""{"score": 0.25, "reasoning": "Context does not address the question"}""");
+        var evaluator = CreateEvaluator();
+        var results = RagTestData.CreateRetrievalResults(2);
+
+        var score = await evaluator.EvaluateAsync("Unrelated sub-query", results);
+
+        score.Should().BeLessThan(0.5);
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_EmptyResults_ReturnsZero()
+    {
+        var evaluator = CreateEvaluator();
+        IReadOnlyList<RetrievalResult> emptyResults = [];
+
+        var score = await evaluator.EvaluateAsync("Any sub-query", emptyResults);
+
+        score.Should().Be(0.0);
+        _mockChatClient.Verify(
+            c => c.GetResponseAsync(
+                It.IsAny<IList<ChatMessage>>(),
+                It.IsAny<ChatOptions>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_LlmReturnsInvalidResponse_ReturnsDefaultScore()
+    {
+        SetupChatResponse("I'm not sure how to evaluate this.");
+        var evaluator = CreateEvaluator();
+        var results = RagTestData.CreateRetrievalResults(3);
+
+        var score = await evaluator.EvaluateAsync("Some sub-query", results);
+
+        score.Should().Be(0.5);
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_CancellationRequested_ThrowsOperationCanceledException()
+    {
+        var cts = new CancellationTokenSource();
+        cts.Cancel();
+        var evaluator = CreateEvaluator();
+        var results = RagTestData.CreateRetrievalResults(3);
+
+        var act = () => evaluator.EvaluateAsync("test", results, cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.RAG.Tests/Helpers/RagTestData.cs
+++ b/src/Content/Tests/Infrastructure.AI.RAG.Tests/Helpers/RagTestData.cs
@@ -165,6 +165,122 @@ internal static class RagTestData
         return config;
     }
 
+    public static SubQuery CreateSubQuery(
+        string text = "What is the default chunking strategy?",
+        int order = 1,
+        IReadOnlyList<int>? dependsOnOrders = null) =>
+        new()
+        {
+            Text = text,
+            Order = order,
+            DependsOnOrders = dependsOnOrders ?? []
+        };
+
+    public static DecomposedQuery CreateDecomposedQuery(
+        string originalQuery = "Complex multi-part query",
+        params string[] subQueryTexts)
+    {
+        var texts = subQueryTexts.Length > 0
+            ? subQueryTexts
+            : new[] { "Sub-query 1: first part", "Sub-query 2: second part" };
+
+        var subQueries = texts.Select((text, i) => new SubQuery
+        {
+            Text = text,
+            Order = i + 1,
+            DependsOnOrders = i > 0 ? [i] : []
+        }).ToList();
+
+        return new DecomposedQuery
+        {
+            OriginalQuery = originalQuery,
+            SubQueries = subQueries
+        };
+    }
+
+    public static HopResult CreateHopResult(
+        SubQuery? subQuery = null,
+        IReadOnlyList<RetrievalResult>? results = null,
+        double sufficiencyScore = 0.8,
+        int hopNumber = 1,
+        bool? isSufficient = null) =>
+        new()
+        {
+            SubQuery = subQuery ?? CreateSubQuery(),
+            Results = results ?? CreateRetrievalResults(3),
+            SufficiencyScore = sufficiencyScore,
+            HopNumber = hopNumber,
+            IsSufficient = isSufficient ?? sufficiencyScore >= 0.7
+        };
+
+    public static IterativeRetrievalResult CreateIterativeRetrievalResult(
+        IReadOnlyList<HopResult>? hops = null,
+        int totalTokensUsed = 512,
+        bool budgetExhausted = false)
+    {
+        var effectiveHops = hops ?? [CreateHopResult()];
+        var aggregated = effectiveHops
+            .SelectMany(h => h.Results)
+            .GroupBy(r => r.Chunk.Id)
+            .Select(g => g.OrderByDescending(r => r.FusedScore).First())
+            .ToList();
+
+        return new IterativeRetrievalResult
+        {
+            Hops = effectiveHops,
+            AggregatedResults = aggregated,
+            TotalTokensUsed = totalTokensUsed,
+            BudgetExhausted = budgetExhausted
+        };
+    }
+
+    public static FaithfulnessEvaluation CreateFaithfulEvaluation(double score = 0.9) =>
+        new()
+        {
+            IsFaithful = true,
+            Score = score,
+            SupportedClaims = ["Claim A is supported by chunk-1", "Claim B is supported by chunk-2"],
+            HallucinatedClaims = [],
+            Reasoning = "All claims are grounded in the retrieved context."
+        };
+
+    public static FaithfulnessEvaluation CreateUnfaithfulEvaluation(
+        IReadOnlyList<string>? hallucinatedClaims = null) =>
+        new()
+        {
+            IsFaithful = false,
+            Score = 0.3,
+            SupportedClaims = ["Claim A is supported by chunk-1"],
+            HallucinatedClaims = hallucinatedClaims ?? ["Claim X has no source", "Claim Y contradicts chunk-2"],
+            Reasoning = "Multiple claims are not grounded in the retrieved context."
+        };
+
+    public static MultiHopConfig CreateMultiHopConfig(Action<MultiHopConfig>? configure = null)
+    {
+        var config = new MultiHopConfig
+        {
+            Enabled = true,
+            MaxHops = 3,
+            TokenBudgetPerHop = 1024,
+            MinSufficiencyScore = 0.7,
+            TopKPerHop = 5,
+        };
+        configure?.Invoke(config);
+        return config;
+    }
+
+    public static FaithfulnessConfig CreateFaithfulnessConfig(Action<FaithfulnessConfig>? configure = null)
+    {
+        var config = new FaithfulnessConfig
+        {
+            Enabled = true,
+            HallucinationThreshold = 0.3,
+            RequireCitationSupport = true,
+        };
+        configure?.Invoke(config);
+        return config;
+    }
+
     public static IOptionsMonitor<AppConfig> CreateConfigMonitor(
         Action<AppConfig>? configure = null)
     {
@@ -188,6 +304,20 @@ internal static class RagTestData
             ComplexTopK = 15,
             SkipRerankForSimple = true,
             SkipCragForSimple = true,
+        };
+        appConfig.AI.Rag.MultiHop = new MultiHopConfig
+        {
+            Enabled = true,
+            MaxHops = 3,
+            TokenBudgetPerHop = 1024,
+            MinSufficiencyScore = 0.7,
+            TopKPerHop = 5,
+        };
+        appConfig.AI.Rag.Faithfulness = new FaithfulnessConfig
+        {
+            Enabled = true,
+            HallucinationThreshold = 0.3,
+            RequireCitationSupport = true,
         };
 
         configure?.Invoke(appConfig);

--- a/src/Content/Tests/Infrastructure.AI.RAG.Tests/Orchestration/MultiHopIntegrationTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.RAG.Tests/Orchestration/MultiHopIntegrationTests.cs
@@ -1,0 +1,212 @@
+using Application.AI.Common.Interfaces.RAG;
+using Domain.AI.RAG.Enums;
+using Domain.AI.RAG.Models;
+using Domain.Common.Config;
+using FluentAssertions;
+using Infrastructure.AI.RAG.Orchestration;
+using Infrastructure.AI.RAG.QueryTransform;
+using Infrastructure.AI.RAG.Tests.Helpers;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Infrastructure.AI.RAG.Tests.Orchestration;
+
+/// <summary>
+/// End-to-end integration tests for the multi-hop retrieval path.
+/// </summary>
+public sealed class MultiHopIntegrationTests
+{
+    private readonly Mock<IHybridRetriever> _mockRetriever = new();
+    private readonly Mock<IReranker> _mockReranker = new();
+    private readonly Mock<ICragEvaluator> _mockCrag = new();
+    private readonly Mock<IRagContextAssembler> _mockAssembler = new();
+    private readonly Mock<IGraphRagService> _mockGraphRag = new();
+    private readonly Mock<IQueryComplexityClassifier> _mockClassifier = new();
+    private readonly Mock<IIterativeRetriever> _mockIterativeRetriever = new();
+    private readonly Mock<IAnswerFaithfulnessEvaluator> _mockFaithfulness = new();
+
+    private RagOrchestrator CreateOrchestrator(Action<AppConfig>? configure = null)
+    {
+        var config = RagTestData.CreateConfigMonitor(c =>
+        {
+            c.AI.Rag.ComplexityRouting.Enabled = true;
+            c.AI.Rag.MultiHop.Enabled = true;
+            c.AI.Rag.Faithfulness.Enabled = true;
+            configure?.Invoke(c);
+        });
+
+        var gate = new RetrievalDecisionGate(config, Mock.Of<ILogger<RetrievalDecisionGate>>());
+        var queryRouter = new QueryRouter(
+            Mock.Of<IQueryClassifier>(),
+            Mock.Of<IServiceProvider>(),
+            config,
+            Mock.Of<ILogger<QueryRouter>>());
+
+        return new RagOrchestrator(
+            _mockRetriever.Object,
+            _mockReranker.Object,
+            _mockCrag.Object,
+            _mockAssembler.Object,
+            _mockGraphRag.Object,
+            feedbackScorer: null,
+            queryRouter,
+            config,
+            Mock.Of<ILogger<RagOrchestrator>>(),
+            _mockClassifier.Object,
+            gate,
+            _mockIterativeRetriever.Object,
+            _mockFaithfulness.Object);
+    }
+
+    [Fact]
+    public async Task ComplexQuery_FullMultiHopPipeline_ReturnsAssembledContext()
+    {
+        _mockClassifier
+            .Setup(c => c.ClassifyAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(RagTestData.CreateComplexClassification(0.85));
+
+        var iterativeResult = RagTestData.CreateIterativeRetrievalResult(
+            hops:
+            [
+                RagTestData.CreateHopResult(
+                    subQuery: RagTestData.CreateSubQuery("What is the architecture?", 1),
+                    results: RagTestData.CreateRetrievalResults(3),
+                    sufficiencyScore: 0.9,
+                    hopNumber: 1,
+                    isSufficient: true),
+                RagTestData.CreateHopResult(
+                    subQuery: RagTestData.CreateSubQuery("What needs to change for multi-tenancy?", 2, [1]),
+                    results: RagTestData.CreateRetrievalResults(2),
+                    sufficiencyScore: 0.8,
+                    hopNumber: 2,
+                    isSufficient: true),
+            ],
+            totalTokensUsed: 800);
+        _mockIterativeRetriever
+            .Setup(r => r.RetrieveIterativelyAsync(
+                It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(iterativeResult);
+
+        var rerankedResults = RagTestData.CreateRerankedResults(5);
+        _mockReranker
+            .Setup(r => r.RerankAsync(
+                It.IsAny<string>(), It.IsAny<IReadOnlyList<RetrievalResult>>(),
+                It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(rerankedResults);
+
+        _mockAssembler
+            .Setup(a => a.AssembleAsync(
+                It.IsAny<IReadOnlyList<RerankedResult>>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new RagAssembledContext
+            {
+                AssembledText = "Comprehensive multi-hop answer covering architecture and multi-tenancy changes.",
+                TotalTokens = 350,
+                WasTruncated = false,
+            });
+
+        _mockFaithfulness
+            .Setup(f => f.EvaluateAsync(
+                It.IsAny<string>(), It.IsAny<IReadOnlyList<RerankedResult>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(RagTestData.CreateFaithfulEvaluation(0.92));
+
+        var orchestrator = CreateOrchestrator();
+        var result = await orchestrator.SearchAsync(
+            "Based on the architecture and deployment docs, what changes support multi-tenant GraphRAG?");
+
+        result.AssembledText.Should().Contain("multi-hop answer");
+        result.TotalTokens.Should().Be(350);
+
+        _mockClassifier.Verify(c => c.ClassifyAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Once);
+        _mockIterativeRetriever.Verify(r => r.RetrieveIterativelyAsync(
+            It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()), Times.Once);
+        _mockReranker.Verify(r => r.RerankAsync(
+            It.IsAny<string>(), It.IsAny<IReadOnlyList<RetrievalResult>>(),
+            It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Once);
+        _mockFaithfulness.Verify(f => f.EvaluateAsync(
+            It.IsAny<string>(), It.IsAny<IReadOnlyList<RerankedResult>>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task ComplexQuery_MultiHopDisabled_UsesStandardPipeline()
+    {
+        _mockClassifier
+            .Setup(c => c.ClassifyAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(RagTestData.CreateComplexClassification());
+
+        var retrievalResults = RagTestData.CreateRetrievalResults(5);
+        _mockRetriever
+            .Setup(r => r.RetrieveAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(retrievalResults);
+
+        var rerankedResults = RagTestData.CreateRerankedResults(5);
+        _mockReranker
+            .Setup(r => r.RerankAsync(
+                It.IsAny<string>(), It.IsAny<IReadOnlyList<RetrievalResult>>(),
+                It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(rerankedResults);
+
+        _mockCrag
+            .Setup(c => c.EvaluateAsync(
+                It.IsAny<string>(), It.IsAny<IReadOnlyList<RetrievalResult>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(RagTestData.CreateAcceptEvaluation());
+
+        _mockAssembler
+            .Setup(a => a.AssembleAsync(
+                It.IsAny<IReadOnlyList<RerankedResult>>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new RagAssembledContext
+            {
+                AssembledText = "Standard pipeline result",
+                TotalTokens = 200,
+                WasTruncated = false,
+            });
+
+        var orchestrator = CreateOrchestrator(c => c.AI.Rag.MultiHop.Enabled = false);
+        var result = await orchestrator.SearchAsync("Complex query with multi-hop disabled");
+
+        result.AssembledText.Should().Be("Standard pipeline result");
+        _mockIterativeRetriever.Verify(
+            r => r.RetrieveIterativelyAsync(
+                It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task ComplexQuery_FaithfulnessDisabled_SkipsFaithfulnessCheck()
+    {
+        _mockClassifier
+            .Setup(c => c.ClassifyAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(RagTestData.CreateComplexClassification());
+
+        var iterativeResult = RagTestData.CreateIterativeRetrievalResult();
+        _mockIterativeRetriever
+            .Setup(r => r.RetrieveIterativelyAsync(
+                It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(iterativeResult);
+
+        _mockReranker
+            .Setup(r => r.RerankAsync(
+                It.IsAny<string>(), It.IsAny<IReadOnlyList<RetrievalResult>>(),
+                It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(RagTestData.CreateRerankedResults(3));
+
+        _mockAssembler
+            .Setup(a => a.AssembleAsync(
+                It.IsAny<IReadOnlyList<RerankedResult>>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new RagAssembledContext
+            {
+                AssembledText = "Answer without faithfulness check",
+                TotalTokens = 100,
+                WasTruncated = false,
+            });
+
+        var orchestrator = CreateOrchestrator(c => c.AI.Rag.Faithfulness.Enabled = false);
+        var result = await orchestrator.SearchAsync("Complex query, no faithfulness");
+
+        result.AssembledText.Should().Be("Answer without faithfulness check");
+        _mockFaithfulness.Verify(
+            f => f.EvaluateAsync(
+                It.IsAny<string>(), It.IsAny<IReadOnlyList<RerankedResult>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.RAG.Tests/Orchestration/RagOrchestratorMultiHopTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.RAG.Tests/Orchestration/RagOrchestratorMultiHopTests.cs
@@ -1,0 +1,285 @@
+using Application.AI.Common.Interfaces.RAG;
+using Domain.AI.RAG.Enums;
+using Domain.AI.RAG.Models;
+using Domain.Common.Config;
+using FluentAssertions;
+using Infrastructure.AI.RAG.Orchestration;
+using Infrastructure.AI.RAG.QueryTransform;
+using Infrastructure.AI.RAG.Tests.Helpers;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Infrastructure.AI.RAG.Tests.Orchestration;
+
+/// <summary>
+/// Tests for the multi-hop retrieval path in RagOrchestrator.
+/// Verifies that Complex-tier queries route through the iterative retriever
+/// and that faithfulness evaluation triggers CRAG refinement when needed.
+/// </summary>
+public sealed class RagOrchestratorMultiHopTests
+{
+    private readonly Mock<IHybridRetriever> _mockRetriever = new();
+    private readonly Mock<IReranker> _mockReranker = new();
+    private readonly Mock<ICragEvaluator> _mockCrag = new();
+    private readonly Mock<IRagContextAssembler> _mockAssembler = new();
+    private readonly Mock<IGraphRagService> _mockGraphRag = new();
+    private readonly Mock<IQueryComplexityClassifier> _mockClassifier = new();
+    private readonly Mock<IIterativeRetriever> _mockIterativeRetriever = new();
+    private readonly Mock<IAnswerFaithfulnessEvaluator> _mockFaithfulness = new();
+
+    private RagOrchestrator CreateOrchestrator(Action<AppConfig>? configure = null)
+    {
+        var config = RagTestData.CreateConfigMonitor(c =>
+        {
+            c.AI.Rag.ComplexityRouting.Enabled = true;
+            c.AI.Rag.MultiHop.Enabled = true;
+            c.AI.Rag.Faithfulness.Enabled = true;
+            configure?.Invoke(c);
+        });
+
+        var gate = new RetrievalDecisionGate(config, Mock.Of<ILogger<RetrievalDecisionGate>>());
+        var queryRouter = new QueryRouter(
+            Mock.Of<IQueryClassifier>(),
+            Mock.Of<IServiceProvider>(),
+            config,
+            Mock.Of<ILogger<QueryRouter>>());
+
+        return new RagOrchestrator(
+            _mockRetriever.Object,
+            _mockReranker.Object,
+            _mockCrag.Object,
+            _mockAssembler.Object,
+            _mockGraphRag.Object,
+            feedbackScorer: null,
+            queryRouter,
+            config,
+            Mock.Of<ILogger<RagOrchestrator>>(),
+            _mockClassifier.Object,
+            gate,
+            _mockIterativeRetriever.Object,
+            _mockFaithfulness.Object);
+    }
+
+    [Fact]
+    public async Task SearchAsync_ComplexQuery_UsesIterativeRetriever()
+    {
+        _mockClassifier
+            .Setup(c => c.ClassifyAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(RagTestData.CreateComplexClassification());
+
+        var iterativeResult = RagTestData.CreateIterativeRetrievalResult();
+        _mockIterativeRetriever
+            .Setup(r => r.RetrieveIterativelyAsync(
+                It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(iterativeResult);
+
+        var rerankedResults = RagTestData.CreateRerankedResults(3);
+        _mockReranker
+            .Setup(r => r.RerankAsync(
+                It.IsAny<string>(), It.IsAny<IReadOnlyList<RetrievalResult>>(),
+                It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(rerankedResults);
+
+        _mockAssembler
+            .Setup(a => a.AssembleAsync(
+                It.IsAny<IReadOnlyList<RerankedResult>>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new RagAssembledContext
+            {
+                AssembledText = "Multi-hop assembled answer",
+                TotalTokens = 200,
+                WasTruncated = false,
+            });
+
+        _mockFaithfulness
+            .Setup(f => f.EvaluateAsync(
+                It.IsAny<string>(), It.IsAny<IReadOnlyList<RerankedResult>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(RagTestData.CreateFaithfulEvaluation());
+
+        var orchestrator = CreateOrchestrator();
+        var result = await orchestrator.SearchAsync(
+            "Based on the architecture and deployment docs, what changes support multi-tenant GraphRAG?");
+
+        result.AssembledText.Should().Be("Multi-hop assembled answer");
+        _mockIterativeRetriever.Verify(
+            r => r.RetrieveIterativelyAsync(
+                It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+        _mockRetriever.Verify(
+            r => r.RetrieveAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()),
+            Times.Never,
+            "Complex queries should use IterativeRetriever, not HybridRetriever directly");
+    }
+
+    [Fact]
+    public async Task SearchAsync_UnfaithfulAnswer_TriggersRefinement()
+    {
+        _mockClassifier
+            .Setup(c => c.ClassifyAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(RagTestData.CreateComplexClassification());
+
+        var iterativeResult = RagTestData.CreateIterativeRetrievalResult();
+        _mockIterativeRetriever
+            .Setup(r => r.RetrieveIterativelyAsync(
+                It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(iterativeResult);
+
+        var rerankedResults = RagTestData.CreateRerankedResults(3);
+        _mockReranker
+            .Setup(r => r.RerankAsync(
+                It.IsAny<string>(), It.IsAny<IReadOnlyList<RetrievalResult>>(),
+                It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(rerankedResults);
+
+        var assembleCallCount = 0;
+        _mockAssembler
+            .Setup(a => a.AssembleAsync(
+                It.IsAny<IReadOnlyList<RerankedResult>>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() =>
+            {
+                assembleCallCount++;
+                return new RagAssembledContext
+                {
+                    AssembledText = assembleCallCount == 1 ? "Unfaithful first attempt" : "Refined faithful answer",
+                    TotalTokens = 150,
+                    WasTruncated = false,
+                };
+            });
+
+        _mockFaithfulness
+            .Setup(f => f.EvaluateAsync(
+                It.IsAny<string>(), It.IsAny<IReadOnlyList<RerankedResult>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(RagTestData.CreateUnfaithfulEvaluation());
+
+        _mockCrag
+            .Setup(c => c.EvaluateAsync(
+                It.IsAny<string>(), It.IsAny<IReadOnlyList<RetrievalResult>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(RagTestData.CreateAcceptEvaluation());
+
+        var orchestrator = CreateOrchestrator();
+        var result = await orchestrator.SearchAsync("Complex unfaithful query");
+
+        _mockFaithfulness.Verify(
+            f => f.EvaluateAsync(
+                It.IsAny<string>(), It.IsAny<IReadOnlyList<RerankedResult>>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+        _mockCrag.Verify(
+            c => c.EvaluateAsync(
+                It.IsAny<string>(), It.IsAny<IReadOnlyList<RetrievalResult>>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task SearchAsync_FaithfulAnswer_ReturnsDirectly()
+    {
+        _mockClassifier
+            .Setup(c => c.ClassifyAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(RagTestData.CreateComplexClassification());
+
+        var iterativeResult = RagTestData.CreateIterativeRetrievalResult();
+        _mockIterativeRetriever
+            .Setup(r => r.RetrieveIterativelyAsync(
+                It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(iterativeResult);
+
+        var rerankedResults = RagTestData.CreateRerankedResults(3);
+        _mockReranker
+            .Setup(r => r.RerankAsync(
+                It.IsAny<string>(), It.IsAny<IReadOnlyList<RetrievalResult>>(),
+                It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(rerankedResults);
+
+        _mockAssembler
+            .Setup(a => a.AssembleAsync(
+                It.IsAny<IReadOnlyList<RerankedResult>>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new RagAssembledContext
+            {
+                AssembledText = "Faithful multi-hop answer",
+                TotalTokens = 180,
+                WasTruncated = false,
+            });
+
+        _mockFaithfulness
+            .Setup(f => f.EvaluateAsync(
+                It.IsAny<string>(), It.IsAny<IReadOnlyList<RerankedResult>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(RagTestData.CreateFaithfulEvaluation());
+
+        var orchestrator = CreateOrchestrator();
+        var result = await orchestrator.SearchAsync("Complex faithful query");
+
+        result.AssembledText.Should().Be("Faithful multi-hop answer");
+        _mockCrag.Verify(
+            c => c.EvaluateAsync(
+                It.IsAny<string>(), It.IsAny<IReadOnlyList<RetrievalResult>>(), It.IsAny<CancellationToken>()),
+            Times.Never,
+            "Faithful answer should not trigger CRAG refinement");
+    }
+
+    [Fact]
+    public async Task SearchAsync_MultiHopDisabled_FallsBackToStandardRouting()
+    {
+        _mockClassifier
+            .Setup(c => c.ClassifyAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(RagTestData.CreateComplexClassification());
+
+        var retrievalResults = RagTestData.CreateRetrievalResults(3);
+        _mockRetriever
+            .Setup(r => r.RetrieveAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(retrievalResults);
+
+        var rerankedResults = RagTestData.CreateRerankedResults(3);
+        _mockReranker
+            .Setup(r => r.RerankAsync(It.IsAny<string>(), It.IsAny<IReadOnlyList<RetrievalResult>>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(rerankedResults);
+
+        _mockCrag
+            .Setup(c => c.EvaluateAsync(It.IsAny<string>(), It.IsAny<IReadOnlyList<RetrievalResult>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(RagTestData.CreateAcceptEvaluation());
+
+        _mockAssembler
+            .Setup(a => a.AssembleAsync(It.IsAny<IReadOnlyList<RerankedResult>>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new RagAssembledContext { AssembledText = "Standard pipeline result", TotalTokens = 100, WasTruncated = false });
+
+        var orchestrator = CreateOrchestrator(c => c.AI.Rag.MultiHop.Enabled = false);
+        var result = await orchestrator.SearchAsync("Complex query but multi-hop disabled");
+
+        _mockIterativeRetriever.Verify(
+            r => r.RetrieveIterativelyAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()),
+            Times.Never,
+            "Should not use iterative retriever when multi-hop is disabled");
+        _mockRetriever.Verify(
+            r => r.RetrieveAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()),
+            Times.AtLeastOnce,
+            "Should fall back to standard hybrid retriever");
+    }
+
+    [Fact]
+    public async Task SearchAsync_MultiHopReturnsNoResults_ReturnsEmptyContext()
+    {
+        _mockClassifier
+            .Setup(c => c.ClassifyAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(RagTestData.CreateComplexClassification());
+
+        var emptyResult = new IterativeRetrievalResult
+        {
+            Hops = [RagTestData.CreateHopResult(results: [])],
+            AggregatedResults = [],
+            TotalTokensUsed = 64,
+            BudgetExhausted = false,
+        };
+        _mockIterativeRetriever
+            .Setup(r => r.RetrieveIterativelyAsync(
+                It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(emptyResult);
+
+        var orchestrator = CreateOrchestrator();
+        var result = await orchestrator.SearchAsync("Complex query with no matching docs");
+
+        result.TotalTokens.Should().Be(0);
+        result.AssembledText.Should().Contain("No relevant documents found");
+        _mockReranker.Verify(
+            r => r.RerankAsync(It.IsAny<string>(), It.IsAny<IReadOnlyList<RetrievalResult>>(), It.IsAny<int>(), It.IsAny<CancellationToken>()),
+            Times.Never,
+            "Should not rerank when iterative retrieval returned 0 results");
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.RAG.Tests/QueryTransform/QueryDecomposerTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.RAG.Tests/QueryTransform/QueryDecomposerTests.cs
@@ -1,0 +1,157 @@
+using Application.AI.Common.Interfaces.RAG;
+using Domain.AI.RAG.Models;
+using FluentAssertions;
+using Infrastructure.AI.RAG.QueryTransform;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Infrastructure.AI.RAG.Tests.QueryTransform;
+
+public sealed class QueryDecomposerTests
+{
+    private readonly Mock<IRagModelRouter> _mockRouter = new();
+    private readonly Mock<IChatClient> _mockChatClient = new();
+
+    public QueryDecomposerTests()
+    {
+        _mockRouter
+            .Setup(r => r.GetClientForOperation("query_decomposition"))
+            .Returns(_mockChatClient.Object);
+    }
+
+    private QueryDecomposer CreateDecomposer()
+        => new(
+            _mockRouter.Object,
+            Mock.Of<ILogger<QueryDecomposer>>());
+
+    private void SetupChatResponse(string jsonResponse)
+    {
+        _mockChatClient
+            .Setup(c => c.GetResponseAsync(
+                It.IsAny<IList<ChatMessage>>(),
+                It.IsAny<ChatOptions>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ChatResponse(
+                new ChatMessage(ChatRole.Assistant, jsonResponse)));
+    }
+
+    [Fact]
+    public async Task DecomposeAsync_ComplexMultiPartQuery_ReturnsOrderedSubQueries()
+    {
+        SetupChatResponse("""
+            {
+                "sub_queries": [
+                    {"text": "What chunking strategies are available?", "order": 1, "depends_on": []},
+                    {"text": "How does RAPTOR summarization work?", "order": 2, "depends_on": []},
+                    {"text": "How do chunking strategies interact with RAPTOR?", "order": 3, "depends_on": [1, 2]}
+                ]
+            }
+            """);
+        var decomposer = CreateDecomposer();
+
+        var result = await decomposer.DecomposeAsync(
+            "How do the chunking strategies interact with RAPTOR summarization in the ingestion pipeline?");
+
+        result.SubQueries.Should().HaveCount(3);
+        result.SubQueries[0].Order.Should().Be(1);
+        result.SubQueries[1].Order.Should().Be(2);
+        result.SubQueries[2].Order.Should().Be(3);
+        result.OriginalQuery.Should().Contain("chunking strategies");
+    }
+
+    [Fact]
+    public async Task DecomposeAsync_SimpleQuery_ReturnsSingleSubQuery()
+    {
+        SetupChatResponse("""
+            {
+                "sub_queries": [
+                    {"text": "What is the default topK value?", "order": 1, "depends_on": []}
+                ]
+            }
+            """);
+        var decomposer = CreateDecomposer();
+
+        var result = await decomposer.DecomposeAsync("What is the default topK value?");
+
+        result.SubQueries.Should().HaveCount(1);
+        result.SubQueries[0].Text.Should().Be("What is the default topK value?");
+        result.SubQueries[0].DependsOnOrders.Should().BeEmpty();
+        result.RequiresSequentialExecution.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task DecomposeAsync_QueryWithDependencies_SetsDependsOnOrders()
+    {
+        SetupChatResponse("""
+            {
+                "sub_queries": [
+                    {"text": "What is the architecture?", "order": 1, "depends_on": []},
+                    {"text": "What are the deployment requirements?", "order": 2, "depends_on": [1]}
+                ]
+            }
+            """);
+        var decomposer = CreateDecomposer();
+
+        var result = await decomposer.DecomposeAsync(
+            "Based on the architecture, what are the deployment requirements?");
+
+        result.SubQueries[1].DependsOnOrders.Should().Contain(1);
+    }
+
+    [Fact]
+    public async Task DecomposeAsync_SetsRequiresSequentialExecution_WhenDependenciesExist()
+    {
+        SetupChatResponse("""
+            {
+                "sub_queries": [
+                    {"text": "Part A", "order": 1, "depends_on": []},
+                    {"text": "Part B depends on A", "order": 2, "depends_on": [1]}
+                ]
+            }
+            """);
+        var decomposer = CreateDecomposer();
+
+        var result = await decomposer.DecomposeAsync("Query with dependencies");
+
+        result.RequiresSequentialExecution.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task DecomposeAsync_EmptyQuery_ThrowsArgumentException()
+    {
+        var decomposer = CreateDecomposer();
+
+        var act = () => decomposer.DecomposeAsync("");
+
+        await act.Should().ThrowAsync<ArgumentException>();
+    }
+
+    [Fact]
+    public async Task DecomposeAsync_LlmReturnsInvalidJson_ReturnsSingleSubQueryFallback()
+    {
+        SetupChatResponse("I cannot decompose this query into structured JSON.");
+        var decomposer = CreateDecomposer();
+
+        var result = await decomposer.DecomposeAsync("Some complex query");
+
+        result.SubQueries.Should().HaveCount(1);
+        result.SubQueries[0].Text.Should().Be("Some complex query");
+        result.SubQueries[0].Order.Should().Be(1);
+        result.SubQueries[0].DependsOnOrders.Should().BeEmpty();
+        result.RequiresSequentialExecution.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task DecomposeAsync_CancellationRequested_ThrowsOperationCanceledException()
+    {
+        var cts = new CancellationTokenSource();
+        cts.Cancel();
+        var decomposer = CreateDecomposer();
+
+        var act = () => decomposer.DecomposeAsync("test query", cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.RAG.Tests/Retrieval/IterativeRetrieverTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.RAG.Tests/Retrieval/IterativeRetrieverTests.cs
@@ -1,0 +1,298 @@
+using Application.AI.Common.Interfaces.RAG;
+using Domain.AI.RAG.Models;
+using Domain.Common.Config;
+using FluentAssertions;
+using Infrastructure.AI.RAG.Retrieval;
+using Infrastructure.AI.RAG.Tests.Helpers;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Infrastructure.AI.RAG.Tests.Retrieval;
+
+public sealed class IterativeRetrieverTests
+{
+    private readonly Mock<IQueryDecomposer> _mockDecomposer = new();
+    private readonly Mock<IHybridRetriever> _mockRetriever = new();
+    private readonly Mock<ISufficiencyEvaluator> _mockSufficiency = new();
+
+    private IterativeRetriever CreateIterativeRetriever(Action<AppConfig>? configure = null)
+    {
+        var config = RagTestData.CreateConfigMonitor(configure);
+        return new IterativeRetriever(
+            _mockDecomposer.Object,
+            _mockRetriever.Object,
+            _mockSufficiency.Object,
+            config,
+            Mock.Of<ILogger<IterativeRetriever>>());
+    }
+
+    [Fact]
+    public async Task RetrieveIterativelyAsync_SimpleQuery_SingleHop()
+    {
+        var decomposed = new DecomposedQuery
+        {
+            OriginalQuery = "What is the default topK?",
+            SubQueries = [new SubQuery { Text = "What is the default topK?", Order = 1 }],
+        };
+        _mockDecomposer
+            .Setup(d => d.DecomposeAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(decomposed);
+        _mockRetriever
+            .Setup(r => r.RetrieveAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(RagTestData.CreateRetrievalResults(3));
+        _mockSufficiency
+            .Setup(s => s.EvaluateAsync(It.IsAny<string>(), It.IsAny<IReadOnlyList<RetrievalResult>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(0.9);
+
+        var retriever = CreateIterativeRetriever();
+        var result = await retriever.RetrieveIterativelyAsync("What is the default topK?", topKPerHop: 5);
+
+        result.Hops.Should().HaveCount(1);
+        result.Hops[0].IsSufficient.Should().BeTrue();
+        result.AggregatedResults.Should().HaveCount(3);
+        result.BudgetExhausted.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task RetrieveIterativelyAsync_ComplexQuery_MultipleHops()
+    {
+        var decomposed = new DecomposedQuery
+        {
+            OriginalQuery = "Complex query",
+            SubQueries =
+            [
+                new SubQuery { Text = "Part A", Order = 1 },
+                new SubQuery { Text = "Part B", Order = 2 },
+            ],
+        };
+        _mockDecomposer
+            .Setup(d => d.DecomposeAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(decomposed);
+
+        var resultsA = new List<RetrievalResult>
+        {
+            RagTestData.CreateRetrievalResult("chunk-a1", "Content A1", fusedScore: 0.9),
+            RagTestData.CreateRetrievalResult("chunk-a2", "Content A2", fusedScore: 0.8),
+        };
+        var resultsB = new List<RetrievalResult>
+        {
+            RagTestData.CreateRetrievalResult("chunk-b1", "Content B1", fusedScore: 0.85),
+        };
+
+        var callCount = 0;
+        _mockRetriever
+            .Setup(r => r.RetrieveAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() =>
+            {
+                callCount++;
+                return callCount == 1 ? resultsA : resultsB;
+            });
+        _mockSufficiency
+            .Setup(s => s.EvaluateAsync(It.IsAny<string>(), It.IsAny<IReadOnlyList<RetrievalResult>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(0.85);
+
+        var retriever = CreateIterativeRetriever();
+        var result = await retriever.RetrieveIterativelyAsync("Complex query", topKPerHop: 5);
+
+        result.Hops.Should().HaveCount(2);
+        result.AggregatedResults.Should().HaveCount(3);
+    }
+
+    [Fact]
+    public async Task RetrieveIterativelyAsync_RespectsMaxHopsCap()
+    {
+        var subQueries = Enumerable.Range(1, 5)
+            .Select(i => new SubQuery { Text = $"Part {i}", Order = i })
+            .ToList();
+        var decomposed = new DecomposedQuery { OriginalQuery = "Many parts", SubQueries = subQueries };
+        _mockDecomposer
+            .Setup(d => d.DecomposeAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(decomposed);
+        _mockRetriever
+            .Setup(r => r.RetrieveAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(RagTestData.CreateRetrievalResults(2));
+        _mockSufficiency
+            .Setup(s => s.EvaluateAsync(It.IsAny<string>(), It.IsAny<IReadOnlyList<RetrievalResult>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(0.85);
+
+        var retriever = CreateIterativeRetriever(c => c.AI.Rag.MultiHop.MaxHops = 3);
+        var result = await retriever.RetrieveIterativelyAsync("Many parts", topKPerHop: 5);
+
+        result.Hops.Should().HaveCountLessThanOrEqualTo(3);
+    }
+
+    [Fact]
+    public async Task RetrieveIterativelyAsync_EnforceTokenBudget()
+    {
+        var decomposed = new DecomposedQuery
+        {
+            OriginalQuery = "Budget test",
+            SubQueries =
+            [
+                new SubQuery { Text = "Part 1", Order = 1 },
+                new SubQuery { Text = "Part 2", Order = 2 },
+                new SubQuery { Text = "Part 3", Order = 3 },
+            ],
+        };
+        _mockDecomposer
+            .Setup(d => d.DecomposeAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(decomposed);
+        _mockRetriever
+            .Setup(r => r.RetrieveAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<RetrievalResult>
+            {
+                RagTestData.CreateRetrievalResult("chunk-big", "This is a long content string that should consume a meaningful portion of the token budget for testing purposes.", fusedScore: 0.9),
+            });
+        _mockSufficiency
+            .Setup(s => s.EvaluateAsync(It.IsAny<string>(), It.IsAny<IReadOnlyList<RetrievalResult>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(0.85);
+
+        var retriever = CreateIterativeRetriever(c => c.AI.Rag.MultiHop.TokenBudgetPerHop = 10);
+        var result = await retriever.RetrieveIterativelyAsync("Budget test", topKPerHop: 5);
+
+        result.BudgetExhausted.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task RetrieveIterativelyAsync_SubQueryDependencies_ExecutesInOrder()
+    {
+        var decomposed = new DecomposedQuery
+        {
+            OriginalQuery = "Dependent query",
+            SubQueries =
+            [
+                new SubQuery { Text = "What is the architecture?", Order = 1 },
+                new SubQuery { Text = "Based on the architecture, what needs changing?", Order = 2, DependsOnOrders = [1] },
+            ],
+        };
+        _mockDecomposer
+            .Setup(d => d.DecomposeAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(decomposed);
+
+        var executionOrder = new List<string>();
+        _mockRetriever
+            .Setup(r => r.RetrieveAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .Returns<string, int, string?, CancellationToken>((query, _, _, _) =>
+            {
+                executionOrder.Add(query);
+                return Task.FromResult<IReadOnlyList<RetrievalResult>>(RagTestData.CreateRetrievalResults(2));
+            });
+        _mockSufficiency
+            .Setup(s => s.EvaluateAsync(It.IsAny<string>(), It.IsAny<IReadOnlyList<RetrievalResult>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(0.85);
+
+        var retriever = CreateIterativeRetriever();
+        await retriever.RetrieveIterativelyAsync("Dependent query", topKPerHop: 5);
+
+        executionOrder.Should().HaveCount(2);
+        executionOrder[0].Should().Contain("architecture");
+    }
+
+    [Fact]
+    public async Task RetrieveIterativelyAsync_SufficientFirstHop_StopsEarly()
+    {
+        var decomposed = new DecomposedQuery
+        {
+            OriginalQuery = "Simple",
+            SubQueries = [new SubQuery { Text = "Simple question", Order = 1 }],
+        };
+        _mockDecomposer
+            .Setup(d => d.DecomposeAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(decomposed);
+        _mockRetriever
+            .Setup(r => r.RetrieveAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(RagTestData.CreateRetrievalResults(3));
+        _mockSufficiency
+            .Setup(s => s.EvaluateAsync(It.IsAny<string>(), It.IsAny<IReadOnlyList<RetrievalResult>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(0.95);
+
+        var retriever = CreateIterativeRetriever();
+        var result = await retriever.RetrieveIterativelyAsync("Simple", topKPerHop: 5);
+
+        result.Hops.Should().HaveCount(1);
+        result.Hops[0].IsSufficient.Should().BeTrue();
+        _mockRetriever.Verify(
+            r => r.RetrieveAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task RetrieveIterativelyAsync_AggregatesResultsAcrossHops()
+    {
+        var decomposed = new DecomposedQuery
+        {
+            OriginalQuery = "Multi-hop",
+            SubQueries =
+            [
+                new SubQuery { Text = "Part 1", Order = 1 },
+                new SubQuery { Text = "Part 2", Order = 2 },
+            ],
+        };
+        _mockDecomposer
+            .Setup(d => d.DecomposeAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(decomposed);
+
+        var callIndex = 0;
+        _mockRetriever
+            .Setup(r => r.RetrieveAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() =>
+            {
+                callIndex++;
+                return new List<RetrievalResult>
+                {
+                    RagTestData.CreateRetrievalResult($"chunk-hop{callIndex}-1", $"Content from hop {callIndex}", fusedScore: 0.9),
+                    RagTestData.CreateRetrievalResult($"chunk-hop{callIndex}-2", $"More content from hop {callIndex}", fusedScore: 0.8),
+                };
+            });
+        _mockSufficiency
+            .Setup(s => s.EvaluateAsync(It.IsAny<string>(), It.IsAny<IReadOnlyList<RetrievalResult>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(0.85);
+
+        var retriever = CreateIterativeRetriever();
+        var result = await retriever.RetrieveIterativelyAsync("Multi-hop", topKPerHop: 5);
+
+        result.AggregatedResults.Should().HaveCount(4);
+    }
+
+    [Fact]
+    public async Task RetrieveIterativelyAsync_DeduplicatesChunksAcrossHops()
+    {
+        var decomposed = new DecomposedQuery
+        {
+            OriginalQuery = "Overlap query",
+            SubQueries =
+            [
+                new SubQuery { Text = "Part 1", Order = 1 },
+                new SubQuery { Text = "Part 2", Order = 2 },
+            ],
+        };
+        _mockDecomposer
+            .Setup(d => d.DecomposeAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(decomposed);
+
+        var sharedChunk = RagTestData.CreateRetrievalResult("chunk-shared", "Shared content", fusedScore: 0.9);
+        var uniqueA = RagTestData.CreateRetrievalResult("chunk-a", "Unique A", fusedScore: 0.8);
+        var uniqueB = RagTestData.CreateRetrievalResult("chunk-b", "Unique B", fusedScore: 0.7);
+
+        var callCount = 0;
+        _mockRetriever
+            .Setup(r => r.RetrieveAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() =>
+            {
+                callCount++;
+                return callCount == 1
+                    ? new List<RetrievalResult> { sharedChunk, uniqueA }
+                    : new List<RetrievalResult> { sharedChunk, uniqueB };
+            });
+        _mockSufficiency
+            .Setup(s => s.EvaluateAsync(It.IsAny<string>(), It.IsAny<IReadOnlyList<RetrievalResult>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(0.85);
+
+        var retriever = CreateIterativeRetriever();
+        var result = await retriever.RetrieveIterativelyAsync("Overlap query", topKPerHop: 5);
+
+        result.AggregatedResults.Should().HaveCount(3);
+        result.AggregatedResults.Select(r => r.Chunk.Id).Should().OnlyHaveUniqueItems();
+    }
+}


### PR DESCRIPTION
## Summary

Phase B of the RAG Level 2.5 → Level 4 upgrade. Adds multi-hop iterative retrieval for complex queries and post-assembly answer faithfulness evaluation with claim-level hallucination detection.

### What's new
- **Query decomposition** — LLM splits complex queries into ordered sub-queries with dependency tracking
- **Iterative multi-hop retrieval** — Executes sub-queries in dependency order, evaluates sufficiency per hop, enforces token budget, deduplicates across hops
- **Sufficiency evaluation** — LLM-based scoring (0.0–1.0) determines whether retrieved chunks answer each sub-query
- **Answer faithfulness evaluation** — Claim-level decomposition checks each factual claim against retrieved context, identifies hallucinations
- **Orchestrator integration** — Complex queries (from Phase A classifier) route through multi-hop pipeline; unfaithful answers trigger CRAG refinement fallback
- **Config-driven thresholds** — `FaithfulnessConfig.HallucinationThreshold` controls the faithfulness gate (not just LLM verdict)
- **OTel tracing** — Per-hop ActivityEvents with sufficiency scores, token usage, and faithfulness metrics

### Architecture
- 5 domain models (sealed records with immutable properties)
- 4 application interfaces (IQueryDecomposer, ISufficiencyEvaluator, IIterativeRetriever, IAnswerFaithfulnessEvaluator)
- 4 infrastructure implementations with LLM-based evaluation and conservative fallbacks
- RagOrchestrator split into partial class (RagOrchestrator.MultiHop.cs) for file size compliance
- All new services registered as singletons via DI, optional resolution (GetService<T>) for backward compatibility
- 26 files changed, +2,458 lines

### Review fixes applied
- Input validation on all public method boundaries
- Wasted double-retrieval in routed pipeline eliminated (CRAG check moved before retrieval)
- Dead config properties wired into faithfulness evaluation
- Null-forgiving operator replaced with explicit guard
- Inaccurate XML doc corrected

## Test plan

- [x] 86/86 RAG unit + integration tests passing
- [x] Build: 0 errors, 165 warnings (all pre-existing)
- [x] Final code review: 0 CRITICAL, 0 HIGH (all fixed), 5 MEDIUM, 3 LOW
- [ ] Manual verification of multi-hop pipeline with real LLM (requires Azure OpenAI endpoint)
- [ ] Verify OTel traces appear in Jaeger for multi-hop queries

🤖 Generated with [Claude Code](https://claude.com/claude-code)