### PR TITLE
feat: Tool Output Compression — tiered compression pipeline for context savings

### DIFF
--- a/docs/superpowers/plans/2026-05-23-conversation-knowledge-bridge.md
+++ b/docs/superpowers/plans/2026-05-23-conversation-knowledge-bridge.md
@@ -1,0 +1,1100 @@
+# Conversation-to-Knowledge Bridge Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Automatically extract notable facts from agent conversations and persist them to the knowledge graph for cross-session recall.
+
+**Architecture:** A MediatR pipeline behavior (`KnowledgeExtractionBehavior`) fires post-turn, calling `IConversationFactExtractor` which uses an economy-tier LLM via `IModelRouter.RouteOperationAsync("fact_extraction")` to extract structured facts, then persists each via `IKnowledgeMemory.RememberAsync()`. Fire-and-forget — zero latency impact on agent responses.
+
+**Tech Stack:** C# .NET 10, MediatR, Microsoft.Extensions.AI (`IChatClient.GetResponseAsync`), System.Text.Json, IModelRouter, IKnowledgeMemory, xUnit + Moq + FluentAssertions
+
+**Spec:** `docs/superpowers/specs/2026-05-22-conversation-knowledge-bridge-design.md`
+
+---
+
+## File Structure
+
+```
+NEW FILES:
+  src/Content/Domain/Domain.AI/KnowledgeGraph/Models/ConversationFact.cs
+  src/Content/Domain/Domain.Common/Config/AI/KnowledgeBridgeConfig.cs
+  src/Content/Application/Application.AI.Common/Interfaces/KnowledgeGraph/IConversationFactExtractor.cs
+  src/Content/Application/Application.AI.Common/MediatRBehaviors/KnowledgeExtractionBehavior.cs
+  src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/Memory/ConversationFactExtractor.cs
+  src/Content/Tests/Infrastructure.AI.KnowledgeGraph.Tests/Memory/ConversationFactExtractorTests.cs
+  src/Content/Tests/Application.AI.Common.Tests/MediatRBehaviors/KnowledgeExtractionBehaviorTests.cs
+
+MODIFIED FILES:
+  src/Content/Domain/Domain.Common/Config/AI/AIConfig.cs              — add KnowledgeBridge property
+  src/Content/Application/Application.AI.Common/DependencyInjection.cs — register behavior
+  src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/DependencyInjection.cs — register extractor
+  src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.cs  — bind config
+```
+
+---
+
+### Task 1: Domain Model — ConversationFact
+
+**Files:**
+- Create: `src/Content/Domain/Domain.AI/KnowledgeGraph/Models/ConversationFact.cs`
+
+- [ ] **Step 1: Create the ConversationFact record**
+
+```csharp
+// src/Content/Domain/Domain.AI/KnowledgeGraph/Models/ConversationFact.cs
+namespace Domain.AI.KnowledgeGraph.Models;
+
+/// <summary>
+/// A fact extracted from a conversation turn by the knowledge bridge.
+/// Persisted to the knowledge graph via <see cref="Application.AI.Common.Interfaces.KnowledgeGraph.IKnowledgeMemory.RememberAsync"/>.
+/// </summary>
+public sealed record ConversationFact
+{
+    /// <summary>
+    /// Deterministic key for idempotent upserts. Format: <c>{conversationId}:{turnNumber}:{factIndex}</c>.
+    /// </summary>
+    public required string Key { get; init; }
+
+    /// <summary>
+    /// Human-readable description of the fact (e.g., "User prefers PostgreSQL over SQL Server").
+    /// </summary>
+    public required string Content { get; init; }
+
+    /// <summary>
+    /// Entity type category. One of: Preference, Decision, Fact, Correction.
+    /// Defaults to "Fact".
+    /// </summary>
+    public string EntityType { get; init; } = "Fact";
+
+    /// <summary>
+    /// LLM confidence in the extraction (0.0–1.0). Facts below the configured
+    /// <c>KnowledgeBridgeConfig.MinConfidence</c> threshold are discarded.
+    /// </summary>
+    public double Confidence { get; init; }
+}
+```
+
+- [ ] **Step 2: Verify build**
+
+Run: `dotnet build src/AgenticHarness.slnx`
+Expected: Build succeeds with 0 errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/Content/Domain/Domain.AI/KnowledgeGraph/Models/ConversationFact.cs
+git commit -m "feat(bridge): add ConversationFact domain model"
+```
+
+---
+
+### Task 2: Configuration POCO — KnowledgeBridgeConfig
+
+**Files:**
+- Create: `src/Content/Domain/Domain.Common/Config/AI/KnowledgeBridgeConfig.cs`
+- Modify: `src/Content/Domain/Domain.Common/Config/AI/AIConfig.cs`
+
+- [ ] **Step 1: Create the config class**
+
+```csharp
+// src/Content/Domain/Domain.Common/Config/AI/KnowledgeBridgeConfig.cs
+namespace Domain.Common.Config.AI;
+
+/// <summary>
+/// Configuration for the Conversation-to-Knowledge Bridge.
+/// Controls whether fact extraction runs, confidence thresholds, and timeout behavior.
+/// Bound to <c>AppConfig:AI:KnowledgeBridge</c>.
+/// </summary>
+public sealed class KnowledgeBridgeConfig
+{
+    /// <summary>
+    /// Master toggle. When false, <c>KnowledgeExtractionBehavior</c> passes through
+    /// with zero overhead — no LLM calls, no background tasks.
+    /// </summary>
+    public bool Enabled { get; set; } = true;
+
+    /// <summary>
+    /// Minimum LLM confidence (0.0–1.0) required to persist an extracted fact.
+    /// Facts below this threshold are silently discarded.
+    /// </summary>
+    public double MinConfidence { get; set; } = 0.7;
+
+    /// <summary>
+    /// Hard timeout in seconds for the background extraction LLM call.
+    /// Prevents runaway requests from consuming resources indefinitely.
+    /// </summary>
+    public int ExtractionTimeoutSeconds { get; set; } = 10;
+
+    /// <summary>
+    /// Operation name passed to <c>IModelRouter.RouteOperationAsync</c> to resolve
+    /// the extraction LLM client. Should map to the economy tier in
+    /// <c>ModelRoutingConfig.OperationOverrides</c>.
+    /// </summary>
+    public string RoutingOperationName { get; set; } = "fact_extraction";
+}
+```
+
+- [ ] **Step 2: Add the property to AIConfig**
+
+In `src/Content/Domain/Domain.Common/Config/AI/AIConfig.cs`, add the property after the `ModelRouting` property (around line 118). Add the new property and update the XML doc tree in the class remarks.
+
+Add this property after the `ModelRouting` property:
+
+```csharp
+/// <summary>
+/// Conversation-to-Knowledge Bridge configuration controlling automatic
+/// fact extraction from agent turns into the knowledge graph.
+/// </summary>
+public KnowledgeBridgeConfig KnowledgeBridge { get; set; } = new();
+```
+
+And add this line to the configuration hierarchy XML doc (in the `<code>` block in the class remarks), after the `ModelRouting` line:
+
+```
+/// ├── KnowledgeBridge    — Conversation-to-Knowledge Bridge: fact extraction, confidence, timeout
+```
+
+- [ ] **Step 3: Verify build**
+
+Run: `dotnet build src/AgenticHarness.slnx`
+Expected: Build succeeds with 0 errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/Content/Domain/Domain.Common/Config/AI/KnowledgeBridgeConfig.cs src/Content/Domain/Domain.Common/Config/AI/AIConfig.cs
+git commit -m "feat(bridge): add KnowledgeBridgeConfig and wire into AIConfig"
+```
+
+---
+
+### Task 3: Application Interface — IConversationFactExtractor
+
+**Files:**
+- Create: `src/Content/Application/Application.AI.Common/Interfaces/KnowledgeGraph/IConversationFactExtractor.cs`
+
+- [ ] **Step 1: Create the interface**
+
+```csharp
+// src/Content/Application/Application.AI.Common/Interfaces/KnowledgeGraph/IConversationFactExtractor.cs
+using Domain.AI.KnowledgeGraph.Models;
+
+namespace Application.AI.Common.Interfaces.KnowledgeGraph;
+
+/// <summary>
+/// Extracts notable facts from a user/assistant message pair using an LLM.
+/// Facts are returned as structured <see cref="ConversationFact"/> records
+/// for persistence via <see cref="IKnowledgeMemory.RememberAsync"/>.
+/// </summary>
+/// <remarks>
+/// Implementations should:
+/// <list type="bullet">
+///   <item><description>Use an economy-tier model via <c>IModelRouter.RouteOperationAsync</c></description></item>
+///   <item><description>Return an empty list for routine turns (greetings, acknowledgments)</description></item>
+///   <item><description>Catch all exceptions internally and return an empty list on failure</description></item>
+///   <item><description>Wrap user content in XML tags to defend against prompt injection</description></item>
+/// </list>
+/// </remarks>
+public interface IConversationFactExtractor
+{
+    /// <summary>
+    /// Analyzes a conversation turn and extracts notable facts.
+    /// </summary>
+    /// <param name="userMessage">The user's message from this turn.</param>
+    /// <param name="assistantResponse">The assistant's response from this turn.</param>
+    /// <param name="conversationId">Conversation ID for deterministic key generation.</param>
+    /// <param name="turnNumber">Turn number for deterministic key generation.</param>
+    /// <param name="cancellationToken">Cancellation token with extraction timeout.</param>
+    /// <returns>
+    /// Extracted facts ordered by confidence descending. Empty list when no notable
+    /// facts are found or when extraction fails.
+    /// </returns>
+    Task<IReadOnlyList<ConversationFact>> ExtractAsync(
+        string userMessage,
+        string assistantResponse,
+        string conversationId,
+        int turnNumber,
+        CancellationToken cancellationToken = default);
+}
+```
+
+- [ ] **Step 2: Verify build**
+
+Run: `dotnet build src/AgenticHarness.slnx`
+Expected: Build succeeds with 0 errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/Content/Application/Application.AI.Common/Interfaces/KnowledgeGraph/IConversationFactExtractor.cs
+git commit -m "feat(bridge): add IConversationFactExtractor interface"
+```
+
+---
+
+### Task 4: Infrastructure Implementation — ConversationFactExtractor + Tests
+
+**Files:**
+- Create: `src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/Memory/ConversationFactExtractor.cs`
+- Create: `src/Content/Tests/Infrastructure.AI.KnowledgeGraph.Tests/Memory/ConversationFactExtractorTests.cs`
+
+This task follows TDD. Write the tests first, then the implementation.
+
+- [ ] **Step 1: Write the test class**
+
+```csharp
+// src/Content/Tests/Infrastructure.AI.KnowledgeGraph.Tests/Memory/ConversationFactExtractorTests.cs
+using Application.AI.Common.Interfaces.Routing;
+using Domain.AI.KnowledgeGraph.Models;
+using Domain.AI.Routing.Models;
+using Infrastructure.AI.KnowledgeGraph.Memory;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+using FluentAssertions;
+
+namespace Infrastructure.AI.KnowledgeGraph.Tests.Memory;
+
+public class ConversationFactExtractorTests
+{
+    private readonly Mock<IModelRouter> _mockRouter = new();
+    private readonly Mock<IChatClient> _mockClient = new();
+    private readonly ConversationFactExtractor _sut;
+
+    public ConversationFactExtractorTests()
+    {
+        var routingDecision = new ModelRoutingDecision
+        {
+            SelectedTier = new ModelTier
+            {
+                Name = "economy",
+                ClientType = Domain.Common.Config.AI.AIAgentFrameworkClientType.OpenAI,
+                DeploymentName = "gpt-4o-mini",
+                EstimatedCostPer1KTokens = 0.00015m
+            },
+            Client = _mockClient.Object,
+            Complexity = Domain.AI.Routing.Enums.TaskComplexity.Trivial,
+            Source = Domain.AI.Routing.Enums.ClassificationSource.Heuristic,
+            Confidence = 1.0
+        };
+
+        _mockRouter
+            .Setup(r => r.RouteOperationAsync("fact_extraction", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(routingDecision);
+
+        _sut = new ConversationFactExtractor(
+            _mockRouter.Object,
+            NullLogger<ConversationFactExtractor>.Instance);
+    }
+
+    [Fact]
+    public async Task ExtractAsync_ValidJson_ReturnsFactsWithDeterministicKeys()
+    {
+        SetupLlmResponse("""
+            [
+              {"key": "user_prefers_postgresql", "content": "User prefers PostgreSQL", "entity_type": "Preference", "confidence": 0.92},
+              {"key": "deadline_june", "content": "Deployment deadline is June 15", "entity_type": "Decision", "confidence": 0.88}
+            ]
+            """);
+
+        var result = await _sut.ExtractAsync("I prefer PostgreSQL", "Noted, I'll use PostgreSQL", "conv-1", 3);
+
+        result.Should().HaveCount(2);
+        result[0].Key.Should().Be("conv-1:3:0");
+        result[0].Content.Should().Be("User prefers PostgreSQL");
+        result[0].EntityType.Should().Be("Preference");
+        result[0].Confidence.Should().Be(0.92);
+        result[1].Key.Should().Be("conv-1:3:1");
+    }
+
+    [Fact]
+    public async Task ExtractAsync_EmptyArray_ReturnsEmptyList()
+    {
+        SetupLlmResponse("[]");
+
+        var result = await _sut.ExtractAsync("run the tests", "Tests passed.", "conv-1", 1);
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ExtractAsync_MalformedJson_ReturnsEmptyList()
+    {
+        SetupLlmResponse("this is not json at all");
+
+        var result = await _sut.ExtractAsync("hello", "hi there", "conv-1", 1);
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ExtractAsync_AllBelowConfidence_ReturnsEmptyList()
+    {
+        SetupLlmResponse("""
+            [
+              {"key": "low_conf", "content": "Might prefer dark mode", "entity_type": "Preference", "confidence": 0.3}
+            ]
+            """);
+
+        var result = await _sut.ExtractAsync("maybe dark mode?", "I can set that up", "conv-1", 1);
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ExtractAsync_MixedConfidence_ReturnsOnlyAboveThreshold()
+    {
+        SetupLlmResponse("""
+            [
+              {"key": "high", "content": "PostgreSQL preferred", "entity_type": "Preference", "confidence": 0.9},
+              {"key": "low", "content": "Maybe uses VS Code", "entity_type": "Fact", "confidence": 0.4},
+              {"key": "medium", "content": "Project deadline June", "entity_type": "Decision", "confidence": 0.75}
+            ]
+            """);
+
+        var result = await _sut.ExtractAsync("user msg", "assistant msg", "conv-1", 2);
+
+        result.Should().HaveCount(2);
+        result[0].Key.Should().Be("conv-1:2:0");
+        result[0].Confidence.Should().Be(0.9);
+        result[1].Key.Should().Be("conv-1:2:1");
+        result[1].Confidence.Should().Be(0.75);
+    }
+
+    [Fact]
+    public async Task ExtractAsync_LlmThrows_ReturnsEmptyList()
+    {
+        _mockClient
+            .Setup(c => c.GetResponseAsync(
+                It.IsAny<IList<ChatMessage>>(),
+                It.IsAny<ChatOptions?>(),
+                It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException("rate limited"));
+
+        var result = await _sut.ExtractAsync("msg", "resp", "conv-1", 1);
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ExtractAsync_JsonWrappedInMarkdown_ExtractsCorrectly()
+    {
+        SetupLlmResponse("""
+            ```json
+            [
+              {"key": "fact1", "content": "API rate limit is 1000/min", "entity_type": "Fact", "confidence": 0.85}
+            ]
+            ```
+            """);
+
+        var result = await _sut.ExtractAsync("what's the rate limit?", "The API rate limit is 1000 requests per minute.", "conv-1", 5);
+
+        result.Should().HaveCount(1);
+        result[0].Content.Should().Be("API rate limit is 1000/min");
+    }
+
+    [Fact]
+    public async Task ExtractAsync_DefaultConfidenceThreshold_Is07()
+    {
+        SetupLlmResponse("""
+            [
+              {"key": "exactly_at", "content": "Exactly at threshold", "entity_type": "Fact", "confidence": 0.7},
+              {"key": "just_below", "content": "Just below threshold", "entity_type": "Fact", "confidence": 0.69}
+            ]
+            """);
+
+        var result = await _sut.ExtractAsync("msg", "resp", "conv-1", 1);
+
+        result.Should().HaveCount(1);
+        result[0].Content.Should().Be("Exactly at threshold");
+    }
+
+    private void SetupLlmResponse(string responseText)
+    {
+        var chatResponse = new ChatResponse(new ChatMessage(ChatRole.Assistant, responseText));
+        _mockClient
+            .Setup(c => c.GetResponseAsync(
+                It.IsAny<IList<ChatMessage>>(),
+                It.IsAny<ChatOptions?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(chatResponse);
+    }
+}
+```
+
+- [ ] **Step 2: Run tests — verify they fail**
+
+Run: `dotnet test src/AgenticHarness.slnx --filter "FullyQualifiedName~ConversationFactExtractorTests" --no-build`
+Expected: Build fails — `ConversationFactExtractor` class doesn't exist yet.
+
+- [ ] **Step 3: Write the ConversationFactExtractor implementation**
+
+```csharp
+// src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/Memory/ConversationFactExtractor.cs
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Application.AI.Common.Interfaces.KnowledgeGraph;
+using Application.AI.Common.Interfaces.Routing;
+using Domain.AI.KnowledgeGraph.Models;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
+
+namespace Infrastructure.AI.KnowledgeGraph.Memory;
+
+/// <summary>
+/// Extracts structured facts from conversation turns using an economy-tier LLM.
+/// Catches all exceptions internally — callers always receive a valid (possibly empty) list.
+/// </summary>
+public sealed class ConversationFactExtractor : IConversationFactExtractor
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+    };
+
+    private const double DefaultMinConfidence = 0.7;
+
+    private readonly IModelRouter _modelRouter;
+    private readonly ILogger<ConversationFactExtractor> _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ConversationFactExtractor"/> class.
+    /// </summary>
+    public ConversationFactExtractor(
+        IModelRouter modelRouter,
+        ILogger<ConversationFactExtractor> logger)
+    {
+        _modelRouter = modelRouter;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<ConversationFact>> ExtractAsync(
+        string userMessage,
+        string assistantResponse,
+        string conversationId,
+        int turnNumber,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var client = (await _modelRouter.RouteOperationAsync("fact_extraction", cancellationToken)).Client;
+
+            var prompt = BuildPrompt(userMessage, assistantResponse);
+            var response = await client.GetResponseAsync(prompt, cancellationToken: cancellationToken);
+
+            var json = response.Text ?? "[]";
+            var facts = ParseFacts(json, conversationId, turnNumber);
+
+            _logger.LogDebug(
+                "Extracted {Count} facts from conversation {ConversationId} turn {Turn}",
+                facts.Count, conversationId, turnNumber);
+
+            return facts;
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogWarning(ex,
+                "Fact extraction failed for conversation {ConversationId} turn {Turn}",
+                conversationId, turnNumber);
+            return [];
+        }
+    }
+
+    private static string BuildPrompt(string userMessage, string assistantResponse) =>
+        $$"""
+        You are a fact extraction system. Analyze the following conversation turn and extract notable facts that would be valuable in a future conversation with a different agent.
+
+        Only extract facts that represent:
+        - **Preference**: User likes/dislikes, workflow choices
+        - **Decision**: Architectural or design decisions made
+        - **Fact**: Stated facts about the project, team, or domain
+        - **Correction**: User corrected the assistant
+
+        Routine instructions, greetings, acknowledgments, and tool invocations should return an empty array.
+
+        Return a JSON array (no markdown fencing). Each element:
+        {"key": "snake_case_short_key", "content": "Human-readable fact description", "entity_type": "Preference|Decision|Fact|Correction", "confidence": 0.0-1.0}
+
+        Return [] if no notable facts are present.
+
+        <user_message>
+        {{userMessage}}
+        </user_message>
+
+        <assistant_message>
+        {{assistantResponse[..Math.Min(assistantResponse.Length, 2000)]}}
+        </assistant_message>
+        """;
+
+    private static IReadOnlyList<ConversationFact> ParseFacts(
+        string json, string conversationId, int turnNumber)
+    {
+        // Strip markdown code fences if present
+        json = json.Trim();
+        if (json.StartsWith("```"))
+        {
+            var firstNewline = json.IndexOf('\n');
+            if (firstNewline >= 0) json = json[(firstNewline + 1)..];
+            if (json.EndsWith("```")) json = json[..^3];
+            json = json.Trim();
+        }
+
+        // Extract JSON array bounds
+        var startIndex = json.IndexOf('[');
+        var endIndex = json.LastIndexOf(']');
+        if (startIndex < 0 || endIndex <= startIndex)
+            return [];
+
+        json = json[startIndex..(endIndex + 1)];
+
+        List<RawFact>? rawFacts;
+        try
+        {
+            rawFacts = JsonSerializer.Deserialize<List<RawFact>>(json, JsonOptions);
+        }
+        catch (JsonException)
+        {
+            return [];
+        }
+
+        if (rawFacts is null or { Count: 0 })
+            return [];
+
+        var factIndex = 0;
+        return rawFacts
+            .Where(f => f.Confidence >= DefaultMinConfidence)
+            .Select(f => new ConversationFact
+            {
+                Key = $"{conversationId}:{turnNumber}:{factIndex++}",
+                Content = f.Content,
+                EntityType = f.EntityType ?? "Fact",
+                Confidence = f.Confidence
+            })
+            .ToList();
+    }
+
+    private sealed record RawFact
+    {
+        [JsonPropertyName("key")]
+        public string Key { get; init; } = string.Empty;
+
+        [JsonPropertyName("content")]
+        public string Content { get; init; } = string.Empty;
+
+        [JsonPropertyName("entity_type")]
+        public string? EntityType { get; init; }
+
+        [JsonPropertyName("confidence")]
+        public double Confidence { get; init; }
+    }
+}
+```
+
+- [ ] **Step 4: Run tests — verify they pass**
+
+Run: `dotnet test src/AgenticHarness.slnx --filter "FullyQualifiedName~ConversationFactExtractorTests"`
+Expected: All 8 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/Memory/ConversationFactExtractor.cs src/Content/Tests/Infrastructure.AI.KnowledgeGraph.Tests/Memory/ConversationFactExtractorTests.cs
+git commit -m "feat(bridge): add ConversationFactExtractor with LLM-based extraction + tests"
+```
+
+---
+
+### Task 5: Pipeline Behavior — KnowledgeExtractionBehavior + Tests
+
+**Files:**
+- Create: `src/Content/Application/Application.AI.Common/MediatRBehaviors/KnowledgeExtractionBehavior.cs`
+- Create: `src/Content/Tests/Application.AI.Common.Tests/MediatRBehaviors/KnowledgeExtractionBehaviorTests.cs`
+
+This task follows TDD. Write the tests first, then the implementation.
+
+- [ ] **Step 1: Write the test class**
+
+```csharp
+// src/Content/Tests/Application.AI.Common.Tests/MediatRBehaviors/KnowledgeExtractionBehaviorTests.cs
+using Application.AI.Common.Interfaces.KnowledgeGraph;
+using Application.AI.Common.MediatRBehaviors;
+using Application.Core.CQRS.Agents.ExecuteAgentTurn;
+using Domain.AI.KnowledgeGraph.Models;
+using Domain.Common.Config.AI;
+using FluentAssertions;
+using MediatR;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Application.AI.Common.Tests.MediatRBehaviors;
+
+public class KnowledgeExtractionBehaviorTests
+{
+    private readonly Mock<IConversationFactExtractor> _mockExtractor = new();
+    private readonly Mock<IKnowledgeMemory> _mockMemory = new();
+    private readonly KnowledgeBridgeConfig _config;
+
+    public KnowledgeExtractionBehaviorTests()
+    {
+        _config = new KnowledgeBridgeConfig { Enabled = true };
+    }
+
+    [Fact]
+    public async Task Handle_NonAgentTurnRequest_PassesThrough()
+    {
+        var behavior = CreateBehavior<NonAgentRequest, string>();
+
+        var result = await behavior.Handle(
+            new NonAgentRequest(),
+            () => Task.FromResult("passthrough"),
+            CancellationToken.None);
+
+        result.Should().Be("passthrough");
+        _mockExtractor.Verify(
+            e => e.ExtractAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_Disabled_SkipsExtraction()
+    {
+        _config.Enabled = false;
+        var behavior = CreateAgentTurnBehavior();
+        var command = CreateCommand("analyze this code");
+        var response = CreateSuccessResponse("Here's my analysis...");
+
+        var result = await behavior.Handle(command, () => Task.FromResult(response), CancellationToken.None);
+
+        result.Should().BeSameAs(response);
+        _mockExtractor.Verify(
+            e => e.ExtractAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_FailedTurn_SkipsExtraction()
+    {
+        var behavior = CreateAgentTurnBehavior();
+        var command = CreateCommand("do something");
+        var response = new AgentTurnResult
+        {
+            Success = false,
+            Response = "",
+            UpdatedHistory = [],
+            Error = "Agent error"
+        };
+
+        var result = await behavior.Handle(command, () => Task.FromResult(response), CancellationToken.None);
+
+        result.Should().BeSameAs(response);
+        _mockExtractor.Verify(
+            e => e.ExtractAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_EmptyResponse_SkipsExtraction()
+    {
+        var behavior = CreateAgentTurnBehavior();
+        var command = CreateCommand("hello");
+        var response = CreateSuccessResponse("");
+
+        var result = await behavior.Handle(command, () => Task.FromResult(response), CancellationToken.None);
+
+        result.Should().BeSameAs(response);
+        _mockExtractor.Verify(
+            e => e.ExtractAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_SuccessfulTurn_ExtractsAndRemembersFacts()
+    {
+        var facts = new List<ConversationFact>
+        {
+            new() { Key = "conv-1:3:0", Content = "User prefers PostgreSQL", EntityType = "Preference", Confidence = 0.9 },
+            new() { Key = "conv-1:3:1", Content = "Deadline is June 15", EntityType = "Decision", Confidence = 0.85 }
+        };
+
+        _mockExtractor
+            .Setup(e => e.ExtractAsync("use PostgreSQL", "Noted.", "conv-1", 3, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(facts);
+
+        var behavior = CreateAgentTurnBehavior();
+        var command = CreateCommand("use PostgreSQL", "conv-1", 3);
+        var response = CreateSuccessResponse("Noted.");
+
+        var result = await behavior.Handle(command, () => Task.FromResult(response), CancellationToken.None);
+
+        result.Should().BeSameAs(response);
+
+        // Wait briefly for the fire-and-forget task to complete
+        await Task.Delay(200);
+
+        _mockMemory.Verify(m => m.RememberAsync("conv-1:3:0", "User prefers PostgreSQL", "Preference", It.IsAny<CancellationToken>()), Times.Once);
+        _mockMemory.Verify(m => m.RememberAsync("conv-1:3:1", "Deadline is June 15", "Decision", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ExtractorThrows_ResponseStillReturned()
+    {
+        _mockExtractor
+            .Setup(e => e.ExtractAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("LLM down"));
+
+        var behavior = CreateAgentTurnBehavior();
+        var command = CreateCommand("analyze this");
+        var response = CreateSuccessResponse("Analysis complete.");
+
+        var result = await behavior.Handle(command, () => Task.FromResult(response), CancellationToken.None);
+
+        result.Should().BeSameAs(response);
+        // No exception propagated — fire-and-forget absorbed it
+    }
+
+    [Fact]
+    public async Task Handle_RememberAsyncThrows_ContinuesWithRemainingFacts()
+    {
+        var facts = new List<ConversationFact>
+        {
+            new() { Key = "conv-1:1:0", Content = "Fact A", Confidence = 0.9 },
+            new() { Key = "conv-1:1:1", Content = "Fact B", Confidence = 0.85 }
+        };
+
+        _mockExtractor
+            .Setup(e => e.ExtractAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(facts);
+
+        _mockMemory
+            .Setup(m => m.RememberAsync("conv-1:1:0", It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("graph full"));
+
+        var behavior = CreateAgentTurnBehavior();
+        var command = CreateCommand("msg", "conv-1", 1);
+        var response = CreateSuccessResponse("resp");
+
+        await behavior.Handle(command, () => Task.FromResult(response), CancellationToken.None);
+        await Task.Delay(200);
+
+        // Second fact should still be remembered despite first one throwing
+        _mockMemory.Verify(m => m.RememberAsync("conv-1:1:1", "Fact B", "Fact", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    // --- Helpers ---
+
+    private KnowledgeExtractionBehavior<TRequest, TResponse> CreateBehavior<TRequest, TResponse>()
+        where TRequest : notnull
+    {
+        return new KnowledgeExtractionBehavior<TRequest, TResponse>(
+            _mockExtractor.Object,
+            _mockMemory.Object,
+            Options.Create(_config),
+            NullLogger<KnowledgeExtractionBehavior<TRequest, TResponse>>.Instance);
+    }
+
+    private KnowledgeExtractionBehavior<ExecuteAgentTurnCommand, AgentTurnResult> CreateAgentTurnBehavior()
+    {
+        return new KnowledgeExtractionBehavior<ExecuteAgentTurnCommand, AgentTurnResult>(
+            _mockExtractor.Object,
+            _mockMemory.Object,
+            Options.Create(_config),
+            NullLogger<KnowledgeExtractionBehavior<ExecuteAgentTurnCommand, AgentTurnResult>>.Instance);
+    }
+
+    private static ExecuteAgentTurnCommand CreateCommand(
+        string userMessage, string conversationId = "conv-1", int turnNumber = 1) =>
+        new()
+        {
+            AgentName = "test-agent",
+            UserMessage = userMessage,
+            ConversationId = conversationId,
+            TurnNumber = turnNumber
+        };
+
+    private static AgentTurnResult CreateSuccessResponse(string response) =>
+        new()
+        {
+            Success = true,
+            Response = response,
+            UpdatedHistory = []
+        };
+
+    // Test-local request type that is NOT ExecuteAgentTurnCommand
+    private record NonAgentRequest : IRequest<string>;
+}
+```
+
+- [ ] **Step 2: Run tests — verify they fail**
+
+Run: `dotnet test src/AgenticHarness.slnx --filter "FullyQualifiedName~KnowledgeExtractionBehaviorTests" --no-build`
+Expected: Build fails — `KnowledgeExtractionBehavior` class doesn't exist yet.
+
+- [ ] **Step 3: Write the KnowledgeExtractionBehavior implementation**
+
+```csharp
+// src/Content/Application/Application.AI.Common/MediatRBehaviors/KnowledgeExtractionBehavior.cs
+using Application.AI.Common.Interfaces.KnowledgeGraph;
+using Application.Core.CQRS.Agents.ExecuteAgentTurn;
+using Domain.Common.Config.AI;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Application.AI.Common.MediatRBehaviors;
+
+/// <summary>
+/// Post-turn pipeline behavior that extracts notable facts from agent conversations
+/// and persists them to the knowledge graph via <see cref="IKnowledgeMemory"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Only activates for <see cref="ExecuteAgentTurnCommand"/> requests that produce
+/// a successful <see cref="AgentTurnResult"/> with a non-empty response.
+/// All other request types pass through untouched.
+/// </para>
+/// <para>
+/// Extraction runs as fire-and-forget on a background thread. The agent's response
+/// is returned immediately — extraction failures are logged but never propagate.
+/// </para>
+/// </remarks>
+public sealed class KnowledgeExtractionBehavior<TRequest, TResponse>
+    : IPipelineBehavior<TRequest, TResponse> where TRequest : notnull
+{
+    private readonly IConversationFactExtractor _extractor;
+    private readonly IKnowledgeMemory _knowledgeMemory;
+    private readonly KnowledgeBridgeConfig _config;
+    private readonly ILogger<KnowledgeExtractionBehavior<TRequest, TResponse>> _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="KnowledgeExtractionBehavior{TRequest, TResponse}"/> class.
+    /// </summary>
+    public KnowledgeExtractionBehavior(
+        IConversationFactExtractor extractor,
+        IKnowledgeMemory knowledgeMemory,
+        IOptions<KnowledgeBridgeConfig> config,
+        ILogger<KnowledgeExtractionBehavior<TRequest, TResponse>> logger)
+    {
+        _extractor = extractor;
+        _knowledgeMemory = knowledgeMemory;
+        _config = config.Value;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<TResponse> Handle(
+        TRequest request,
+        RequestHandlerDelegate<TResponse> next,
+        CancellationToken cancellationToken)
+    {
+        var response = await next();
+
+        if (!_config.Enabled)
+            return response;
+
+        if (request is not ExecuteAgentTurnCommand command ||
+            response is not AgentTurnResult { Success: true, Response.Length: > 0 } turnResult)
+            return response;
+
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                cts.CancelAfter(TimeSpan.FromSeconds(_config.ExtractionTimeoutSeconds));
+
+                var facts = await _extractor.ExtractAsync(
+                    command.UserMessage,
+                    turnResult.Response,
+                    command.ConversationId,
+                    command.TurnNumber,
+                    cts.Token);
+
+                foreach (var fact in facts)
+                {
+                    try
+                    {
+                        await _knowledgeMemory.RememberAsync(
+                            fact.Key, fact.Content, fact.EntityType, cts.Token);
+                    }
+                    catch (Exception ex) when (ex is not OperationCanceledException)
+                    {
+                        _logger.LogWarning(ex,
+                            "Failed to persist fact {Key} for conversation {ConversationId}",
+                            fact.Key, command.ConversationId);
+                    }
+                }
+
+                if (facts.Count > 0)
+                {
+                    _logger.LogInformation(
+                        "Persisted {Count} facts from conversation {ConversationId} turn {Turn}",
+                        facts.Count, command.ConversationId, command.TurnNumber);
+                }
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                _logger.LogWarning(ex,
+                    "Knowledge extraction failed for conversation {ConversationId} turn {Turn}",
+                    command.ConversationId, command.TurnNumber);
+            }
+        }, cancellationToken);
+
+        return response;
+    }
+}
+```
+
+- [ ] **Step 4: Run tests — verify they pass**
+
+Run: `dotnet test src/AgenticHarness.slnx --filter "FullyQualifiedName~KnowledgeExtractionBehaviorTests"`
+Expected: All 7 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Content/Application/Application.AI.Common/MediatRBehaviors/KnowledgeExtractionBehavior.cs src/Content/Tests/Application.AI.Common.Tests/MediatRBehaviors/KnowledgeExtractionBehaviorTests.cs
+git commit -m "feat(bridge): add KnowledgeExtractionBehavior pipeline behavior + tests"
+```
+
+---
+
+### Task 6: DI Registration — Wire Everything Together
+
+**Files:**
+- Modify: `src/Content/Application/Application.AI.Common/DependencyInjection.cs`
+- Modify: `src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/DependencyInjection.cs`
+- Modify: `src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.cs`
+
+- [ ] **Step 1: Register the behavior in Application.AI.Common DI**
+
+In `src/Content/Application/Application.AI.Common/DependencyInjection.cs`, add the behavior registration as the **last** behavior in the pipeline (after `ResponseSanitizationBehavior` on line 71). Add the required using statement.
+
+Add this using at the top:
+```csharp
+using Domain.Common.Config.AI;
+```
+
+Add this line after `.AddTransient(typeof(IPipelineBehavior<,>), typeof(ResponseSanitizationBehavior<,>));` (line 71):
+
+```csharp
+            .AddTransient(typeof(IPipelineBehavior<,>), typeof(KnowledgeExtractionBehavior<,>));
+```
+
+Update the XML doc `<list>` in the class remarks to include the new behavior as the last item:
+```xml
+///   <item><description><c>KnowledgeExtractionBehavior</c> — post-turn: extracts facts to knowledge graph (fire-and-forget)</description></item>
+```
+
+- [ ] **Step 2: Register the extractor in Infrastructure.AI.KnowledgeGraph DI**
+
+In `src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/DependencyInjection.cs`, add the extractor registration after the `IKnowledgeMemory` registration block (after line 93). Add the required using statement.
+
+Add the following after the `// Cross-session knowledge persistence` block:
+
+```csharp
+        // Conversation-to-Knowledge Bridge — LLM-based fact extraction from agent turns
+        services.AddTransient<IConversationFactExtractor, ConversationFactExtractor>();
+```
+
+- [ ] **Step 3: Bind config in Infrastructure.AI DI**
+
+In `src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.cs`, add the config binding. Find the `ModelRouting` config line (line 222):
+
+```csharp
+services.AddSingleton(Options.Create(appConfig.AI.ModelRouting));
+```
+
+Add this line directly after it:
+
+```csharp
+services.AddSingleton(Options.Create(appConfig.AI.KnowledgeBridge));
+```
+
+- [ ] **Step 4: Verify build**
+
+Run: `dotnet build src/AgenticHarness.slnx`
+Expected: Build succeeds with 0 errors.
+
+- [ ] **Step 5: Run all tests**
+
+Run: `dotnet test src/AgenticHarness.slnx`
+Expected: All existing tests still pass. The new tests (8 extractor + 7 behavior = 15) also pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/Content/Application/Application.AI.Common/DependencyInjection.cs src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/DependencyInjection.cs src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.cs
+git commit -m "feat(bridge): register KnowledgeExtractionBehavior, extractor, and config in DI"
+```
+
+---
+
+### Task 7: Full Build Verification + Operation Override
+
+**Files:**
+- No new files — verification and config defaults only
+
+- [ ] **Step 1: Add operation override to appsettings**
+
+Check if `appsettings.json` has an `AI:ModelRouting:OperationOverrides` section. If it does, add `"fact_extraction": "economy"` to it. If no appsettings override exists, skip this step — the code already defaults to the economy tier via the `RoutingOperationName` config.
+
+To find the appsettings file:
+```bash
+find src -name "appsettings*.json" | head -5
+```
+
+If found, verify the `OperationOverrides` section contains existing entries (like `raptor_summarization`, `crag_evaluation`, `graph_entity_extraction`) and add:
+```json
+"fact_extraction": "economy"
+```
+
+- [ ] **Step 2: Full build**
+
+Run: `dotnet build src/AgenticHarness.slnx`
+Expected: 0 errors, 0 warnings related to the bridge code.
+
+- [ ] **Step 3: Run complete test suite**
+
+Run: `dotnet test src/AgenticHarness.slnx`
+Expected: All tests pass. Note any pre-existing failures (e.g., AgentHub) separately.
+
+- [ ] **Step 4: Verify test count**
+
+Confirm the 15 new tests appear:
+```bash
+dotnet test src/AgenticHarness.slnx --filter "FullyQualifiedName~ConversationFactExtractor" --list-tests
+dotnet test src/AgenticHarness.slnx --filter "FullyQualifiedName~KnowledgeExtractionBehavior" --list-tests
+```
+
+Expected: 8 extractor tests + 7 behavior tests = 15 new tests.
+
+- [ ] **Step 5: Final commit (if appsettings changed)**
+
+```bash
+git add <appsettings-path>
+git commit -m "feat(bridge): add fact_extraction operation override to appsettings"
+```
+
+---
+
+## Dependency Order
+
+```
+Task 1 (ConversationFact) ──┐
+Task 2 (Config) ────────────┤
+Task 3 (Interface) ─────────┼──► Task 4 (Extractor + Tests)
+                             │
+                             └──► Task 5 (Behavior + Tests)
+                                         │
+Task 4 + Task 5 ─────────────────────────┼──► Task 6 (DI Wiring)
+                                                     │
+                                                     └──► Task 7 (Verification)
+```
+
+Tasks 1, 2, 3 can run in parallel. Tasks 4 and 5 can run in parallel (after 1-3). Task 6 requires 4+5. Task 7 requires 6.

--- a/docs/superpowers/plans/2026-05-23-tool-output-compression.md
+++ b/docs/superpowers/plans/2026-05-23-tool-output-compression.md
@@ -1,0 +1,2035 @@
+# Tool Output Compression Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Compress large tool outputs before they enter conversation history, preserving decision-relevant information while reducing context window consumption. Full outputs persist in `IToolResultStore` for on-demand retrieval.
+
+**Architecture:** Post-execution MediatR pipeline behavior (`ToolOutputCompressionBehavior`) runs after `ResponseSanitizationBehavior`. Hybrid classification (tool metadata preferred, content sniffing fallback) routes to keyed compression strategies (JSON, StructuredText, FreeText). Tiered: heuristics first, LLM fallback for FreeText. Dual-store: compressed version in conversation history, full output in `IToolResultStore`.
+
+**Tech Stack:** C# .NET 10, MediatR pipeline behaviors, `System.Text.Json`, `Microsoft.Extensions.AI`, xUnit + Moq + FluentAssertions
+
+---
+
+## File Structure
+
+| Layer | File | Responsibility |
+|-------|------|---------------|
+| Domain | `Domain.AI/Compression/Enums/ToolOutputCategory.cs` | Output type classification enum |
+| Domain | `Domain.AI/Compression/Models/CompressionResult.cs` | Compression outcome record |
+| Domain | `Domain.Common/Config/AI/ToolOutputCompressionConfig.cs` | Config POCO with thresholds and toggles |
+| Application | `Application.AI.Common/Interfaces/Compression/IToolOutputCompressor.cs` | Entry-point interface for compression orchestration |
+| Application | `Application.AI.Common/Interfaces/Compression/ICompressionStrategy.cs` | Strategy interface for category-specific compression |
+| Application | `Application.AI.Common/MediatRBehaviors/ToolOutputCompressionBehavior.cs` | Pipeline behavior wiring compression into MediatR |
+| Infrastructure | `Infrastructure.AI/Compression/ContentTypeDetector.cs` | Static content sniffing for output classification |
+| Infrastructure | `Infrastructure.AI/Compression/ToolOutputCompressor.cs` | Orchestrates strategy dispatch + tiered fallback |
+| Infrastructure | `Infrastructure.AI/Compression/Strategies/JsonCompressionStrategy.cs` | JSON array truncation, depth pruning, key filtering |
+| Infrastructure | `Infrastructure.AI/Compression/Strategies/StructuredTextCompressionStrategy.cs` | Head/tail preservation, deduplication |
+| Infrastructure | `Infrastructure.AI/Compression/Strategies/FreeTextCompressionStrategy.cs` | Sentence truncation + LLM fallback |
+| Tests | `Infrastructure.AI.Tests/Compression/ContentTypeDetectorTests.cs` | 6 tests |
+| Tests | `Infrastructure.AI.Tests/Compression/Strategies/JsonCompressionStrategyTests.cs` | 7 tests |
+| Tests | `Infrastructure.AI.Tests/Compression/Strategies/StructuredTextCompressionStrategyTests.cs` | 5 tests |
+| Tests | `Infrastructure.AI.Tests/Compression/Strategies/FreeTextCompressionStrategyTests.cs` | 5 tests |
+| Tests | `Infrastructure.AI.Tests/Compression/ToolOutputCompressorTests.cs` | 6 tests |
+| Tests | `Application.AI.Common.Tests/MediatRBehaviors/ToolOutputCompressionBehaviorTests.cs` | 7 tests |
+
+**Modifications:**
+- `Domain.Common/Config/AI/AIConfig.cs` — add `ToolOutputCompression` property
+- `Application.AI.Common/Interfaces/Tools/ITool.cs` — add `OutputCategory` and `CompressionTokenThreshold` properties
+- `Infrastructure.AI/DependencyInjection.cs` — register compressor, strategies, config
+- `Application.AI.Common/DependencyInjection.cs` — register behavior after `ResponseSanitizationBehavior`
+
+---
+
+### Task 1: Domain Models — ToolOutputCategory Enum + CompressionResult Record
+
+**Files:**
+- Create: `src/Content/Domain/Domain.AI/Compression/Enums/ToolOutputCategory.cs`
+- Create: `src/Content/Domain/Domain.AI/Compression/Models/CompressionResult.cs`
+
+- [ ] **Step 1: Create ToolOutputCategory enum**
+
+```csharp
+// src/Content/Domain/Domain.AI/Compression/Enums/ToolOutputCategory.cs
+namespace Domain.AI.Compression.Enums;
+
+/// <summary>
+/// Classifies tool output content for compression strategy selection.
+/// Tools declare this via <c>ITool.OutputCategory</c>; when not declared,
+/// <c>ContentTypeDetector</c> infers it from content structure.
+/// </summary>
+public enum ToolOutputCategory
+{
+    /// <summary>Parseable JSON — API responses, structured data.</summary>
+    Json = 0,
+
+    /// <summary>Source code, configuration files, documents with line structure.</summary>
+    FileContent = 1,
+
+    /// <summary>Multiple results with repeated structure (search hits, log entries).</summary>
+    SearchResults = 2,
+
+    /// <summary>Tab/pipe-delimited rows with consistent column count.</summary>
+    Tabular = 3,
+
+    /// <summary>Unstructured prose, error output, logs without repeated structure.</summary>
+    FreeText = 4
+}
+```
+
+- [ ] **Step 2: Create CompressionResult record**
+
+```csharp
+// src/Content/Domain/Domain.AI/Compression/Models/CompressionResult.cs
+namespace Domain.AI.Compression.Models;
+
+/// <summary>
+/// Outcome of compressing a tool output. Carries the compressed text,
+/// token metrics, and which strategy produced the result.
+/// </summary>
+public sealed record CompressionResult
+{
+    /// <summary>The compressed (or original) output text.</summary>
+    public required string Output { get; init; }
+
+    /// <summary>Estimated token count of the original output.</summary>
+    public required int OriginalTokens { get; init; }
+
+    /// <summary>Estimated token count after compression.</summary>
+    public required int CompressedTokens { get; init; }
+
+    /// <summary>Name of the strategy that produced this result (e.g., "Json", "LlmFallback", "HardTruncate").</summary>
+    public required string Strategy { get; init; }
+
+    /// <summary>Whether compression was actually applied (false when output was below threshold).</summary>
+    public required bool WasCompressed { get; init; }
+
+    /// <summary>Creates a passthrough result for outputs below threshold.</summary>
+    public static CompressionResult Passthrough(string output, int tokens) => new()
+    {
+        Output = output,
+        OriginalTokens = tokens,
+        CompressedTokens = tokens,
+        Strategy = "None",
+        WasCompressed = false
+    };
+}
+```
+
+- [ ] **Step 3: Verify build**
+
+Run: `dotnet build src/Content/Domain/Domain.AI/Domain.AI.csproj`
+Expected: Build succeeded. 0 errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/Content/Domain/Domain.AI/Compression/
+git commit -m "feat(compression): add ToolOutputCategory enum and CompressionResult record"
+```
+
+---
+
+### Task 2: ToolOutputCompressionConfig + AIConfig Property
+
+**Files:**
+- Create: `src/Content/Domain/Domain.Common/Config/AI/ToolOutputCompressionConfig.cs`
+- Modify: `src/Content/Domain/Domain.Common/Config/AI/AIConfig.cs`
+
+- [ ] **Step 1: Create config POCO**
+
+```csharp
+// src/Content/Domain/Domain.Common/Config/AI/ToolOutputCompressionConfig.cs
+namespace Domain.Common.Config.AI;
+
+/// <summary>
+/// Configuration for the tool output compression subsystem.
+/// Bound from <c>AppConfig.AI.ToolOutputCompression</c>.
+/// </summary>
+public sealed class ToolOutputCompressionConfig
+{
+    /// <summary>Master toggle. When false, all outputs pass through uncompressed.</summary>
+    public bool Enabled { get; set; } = true;
+
+    /// <summary>
+    /// Default token threshold that triggers compression. Outputs below this
+    /// pass through untouched. Individual tools can override via
+    /// <c>ITool.CompressionTokenThreshold</c>.
+    /// </summary>
+    public int DefaultTokenThreshold { get; set; } = 2000;
+
+    /// <summary>
+    /// Whether to use an LLM for summarization when heuristic strategies
+    /// produce a result that still exceeds the threshold on FreeText content.
+    /// </summary>
+    public bool LlmFallbackEnabled { get; set; } = true;
+
+    /// <summary>Timeout in seconds for LLM fallback calls.</summary>
+    public int LlmFallbackTimeoutSeconds { get; set; } = 5;
+
+    /// <summary>
+    /// Operation name passed to <c>IModelRouter.RouteOperationAsync</c>
+    /// to resolve the economy-tier model for LLM compression.
+    /// </summary>
+    public string LlmRoutingOperation { get; set; } = "output_compression";
+}
+```
+
+- [ ] **Step 2: Add ToolOutputCompression property to AIConfig**
+
+In `src/Content/Domain/Domain.Common/Config/AI/AIConfig.cs`, add after the `Sandbox` property (line ~150):
+
+```csharp
+    /// <summary>
+    /// Tool output compression configuration: thresholds, LLM fallback,
+    /// and strategy selection for reducing context window consumption.
+    /// </summary>
+    public ToolOutputCompressionConfig ToolOutputCompression { get; set; } = new();
+```
+
+Also add `ToolOutputCompression` to the XML doc hierarchy comment in the `<code>` block, after `└── Sandbox`:
+
+```
+    /// ├── Sandbox           — Sandbox execution: resource limits, isolation, containers
+    /// └── ToolOutputCompression — Tool output compression: thresholds, LLM fallback, strategies
+```
+
+- [ ] **Step 3: Verify build**
+
+Run: `dotnet build src/Content/Domain/Domain.Common/Domain.Common.csproj`
+Expected: Build succeeded. 0 errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/Content/Domain/Domain.Common/Config/AI/ToolOutputCompressionConfig.cs
+git add src/Content/Domain/Domain.Common/Config/AI/AIConfig.cs
+git commit -m "feat(compression): add ToolOutputCompressionConfig and wire into AIConfig"
+```
+
+---
+
+### Task 3: Application Interfaces — ICompressionStrategy + IToolOutputCompressor
+
+**Files:**
+- Create: `src/Content/Application/Application.AI.Common/Interfaces/Compression/ICompressionStrategy.cs`
+- Create: `src/Content/Application/Application.AI.Common/Interfaces/Compression/IToolOutputCompressor.cs`
+
+- [ ] **Step 1: Create ICompressionStrategy**
+
+```csharp
+// src/Content/Application/Application.AI.Common/Interfaces/Compression/ICompressionStrategy.cs
+using Domain.AI.Compression.Enums;
+using Domain.AI.Compression.Models;
+
+namespace Application.AI.Common.Interfaces.Compression;
+
+/// <summary>
+/// Category-specific compression strategy for tool outputs.
+/// Implementations are registered via keyed DI by <see cref="ToolOutputCategory"/>
+/// and resolved by <see cref="IToolOutputCompressor"/> during compression.
+/// </summary>
+/// <remarks>
+/// Strategies must be deterministic and side-effect-free (except
+/// <c>FreeTextCompressionStrategy</c> which may call an LLM as fallback).
+/// Return <c>CompressionResult.WasCompressed = false</c> to signal that
+/// this strategy could not handle the content and the compressor should
+/// fall through to the next strategy.
+/// </remarks>
+public interface ICompressionStrategy
+{
+    /// <summary>Returns whether this strategy can handle the given output category.</summary>
+    bool CanHandle(ToolOutputCategory category);
+
+    /// <summary>
+    /// Compresses the output to fit within the token threshold.
+    /// </summary>
+    /// <param name="output">The tool output string to compress.</param>
+    /// <param name="tokenThreshold">Target maximum token count.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>
+    /// Compression result. Set <c>WasCompressed = false</c> if the strategy
+    /// cannot handle this content (e.g., JSON parse failure) to signal fallthrough.
+    /// </returns>
+    Task<CompressionResult> CompressAsync(
+        string output,
+        int tokenThreshold,
+        CancellationToken cancellationToken = default);
+}
+```
+
+- [ ] **Step 2: Create IToolOutputCompressor**
+
+```csharp
+// src/Content/Application/Application.AI.Common/Interfaces/Compression/IToolOutputCompressor.cs
+using Domain.AI.Compression.Enums;
+using Domain.AI.Compression.Models;
+
+namespace Application.AI.Common.Interfaces.Compression;
+
+/// <summary>
+/// Orchestrates tool output compression by dispatching to the appropriate
+/// <see cref="ICompressionStrategy"/> based on output category, applying
+/// tiered fallback (heuristic → LLM → hard truncation).
+/// </summary>
+public interface IToolOutputCompressor
+{
+    /// <summary>
+    /// Compresses tool output to fit within the token threshold.
+    /// </summary>
+    /// <param name="output">The raw tool output to compress.</param>
+    /// <param name="category">The classified output category.</param>
+    /// <param name="tokenThreshold">Maximum token count for the result.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>
+    /// The compression result. Always returns a valid result — never throws.
+    /// On internal failure, returns hard-truncated output.
+    /// </returns>
+    Task<CompressionResult> CompressAsync(
+        string output,
+        ToolOutputCategory category,
+        int tokenThreshold,
+        CancellationToken cancellationToken = default);
+}
+```
+
+- [ ] **Step 3: Verify build**
+
+Run: `dotnet build src/Content/Application/Application.AI.Common/Application.AI.Common.csproj`
+Expected: Build succeeded. 0 errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/Content/Application/Application.AI.Common/Interfaces/Compression/
+git commit -m "feat(compression): add ICompressionStrategy and IToolOutputCompressor interfaces"
+```
+
+---
+
+### Task 4: ITool Modification — Add OutputCategory + CompressionTokenThreshold
+
+**Files:**
+- Modify: `src/Content/Application/Application.AI.Common/Interfaces/Tools/ITool.cs`
+
+- [ ] **Step 1: Add optional properties to ITool**
+
+In `src/Content/Application/Application.AI.Common/Interfaces/Tools/ITool.cs`, add after the `IsConcurrencySafe` property (line ~62):
+
+```csharp
+    /// <summary>
+    /// Declares the expected output content type for compression strategy selection.
+    /// When null, <c>ContentTypeDetector</c> sniffs the output at runtime.
+    /// </summary>
+    Domain.AI.Compression.Enums.ToolOutputCategory? OutputCategory => null;
+
+    /// <summary>
+    /// Per-tool compression token threshold override. When null, falls back
+    /// to <c>ToolOutputCompressionConfig.DefaultTokenThreshold</c>.
+    /// </summary>
+    int? CompressionTokenThreshold => null;
+```
+
+- [ ] **Step 2: Verify build**
+
+Run: `dotnet build src/AgenticHarness.slnx`
+Expected: Build succeeded. 0 errors. Default interface implementations ensure no existing ITool implementors break.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/Content/Application/Application.AI.Common/Interfaces/Tools/ITool.cs
+git commit -m "feat(compression): add OutputCategory and CompressionTokenThreshold to ITool"
+```
+
+---
+
+### Task 5: ContentTypeDetector + Tests
+
+**Files:**
+- Create: `src/Content/Infrastructure/Infrastructure.AI/Compression/ContentTypeDetector.cs`
+- Create: `src/Content/Tests/Infrastructure.AI.Tests/Compression/ContentTypeDetectorTests.cs`
+
+- [ ] **Step 1: Write the tests**
+
+```csharp
+// src/Content/Tests/Infrastructure.AI.Tests/Compression/ContentTypeDetectorTests.cs
+using Domain.AI.Compression.Enums;
+using FluentAssertions;
+using Infrastructure.AI.Compression;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Compression;
+
+public sealed class ContentTypeDetectorTests
+{
+    [Fact]
+    public void Detect_ValidJsonObject_ReturnsJson()
+    {
+        var input = """{"name": "test", "value": 42}""";
+
+        ContentTypeDetector.Detect(input).Should().Be(ToolOutputCategory.Json);
+    }
+
+    [Fact]
+    public void Detect_ValidJsonArray_ReturnsJson()
+    {
+        var input = """[{"id": 1}, {"id": 2}]""";
+
+        ContentTypeDetector.Detect(input).Should().Be(ToolOutputCategory.Json);
+    }
+
+    [Fact]
+    public void Detect_FilePathsWithLineNumbers_ReturnsFileContent()
+    {
+        var input = """
+            src/Program.cs:10: public static void Main()
+            src/Program.cs:11: {
+            src/Program.cs:12:     Console.WriteLine("Hello");
+            src/Program.cs:13: }
+            """;
+
+        ContentTypeDetector.Detect(input).Should().Be(ToolOutputCategory.FileContent);
+    }
+
+    [Fact]
+    public void Detect_TabDelimitedRows_ReturnsTabular()
+    {
+        var input = "Name\tAge\tCity\nAlice\t30\tSeattle\nBob\t25\tPortland\nCharlie\t35\tDenver\n";
+
+        ContentTypeDetector.Detect(input).Should().Be(ToolOutputCategory.Tabular);
+    }
+
+    [Fact]
+    public void Detect_RepeatedStructuredLines_ReturnsSearchResults()
+    {
+        var lines = string.Join('\n', Enumerable.Range(1, 20)
+            .Select(i => $"Result {i}: Found match in file{i}.cs at line {i * 10}"));
+
+        ContentTypeDetector.Detect(lines).Should().Be(ToolOutputCategory.SearchResults);
+    }
+
+    [Fact]
+    public void Detect_PlainProse_ReturnsFreeText()
+    {
+        var input = "The quick brown fox jumps over the lazy dog. This is a paragraph of unstructured text that doesn't match any pattern.";
+
+        ContentTypeDetector.Detect(input).Should().Be(ToolOutputCategory.FreeText);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(null)]
+    public void Detect_EmptyOrNull_ReturnsFreeText(string? input)
+    {
+        ContentTypeDetector.Detect(input!).Should().Be(ToolOutputCategory.FreeText);
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `dotnet test src/Content/Tests/Infrastructure.AI.Tests/Infrastructure.AI.Tests.csproj --filter "FullyQualifiedName~ContentTypeDetectorTests" --no-build 2>&1 || echo "Expected: build failure because ContentTypeDetector does not exist yet"`
+Expected: Build failure — `ContentTypeDetector` does not exist.
+
+- [ ] **Step 3: Implement ContentTypeDetector**
+
+```csharp
+// src/Content/Infrastructure/Infrastructure.AI/Compression/ContentTypeDetector.cs
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using Domain.AI.Compression.Enums;
+
+namespace Infrastructure.AI.Compression;
+
+/// <summary>
+/// Sniffs tool output content to infer <see cref="ToolOutputCategory"/>
+/// when the tool does not declare one via <c>ITool.OutputCategory</c>.
+/// Detection order: JSON → FileContent → Tabular → SearchResults → FreeText.
+/// </summary>
+public static partial class ContentTypeDetector
+{
+    [GeneratedRegex(@"^[\s]*[\w\./\\]+\.\w+:\d+:", RegexOptions.Multiline)]
+    private static partial Regex FilePathLineNumberPattern();
+
+    [GeneratedRegex(@"^.+\t.+\t.+$", RegexOptions.Multiline)]
+    private static partial Regex TabDelimitedPattern();
+
+    /// <summary>
+    /// Detects the output category from content structure.
+    /// Returns <see cref="ToolOutputCategory.FreeText"/> for null, empty, or unrecognized content.
+    /// </summary>
+    public static ToolOutputCategory Detect(string? output)
+    {
+        if (string.IsNullOrWhiteSpace(output))
+            return ToolOutputCategory.FreeText;
+
+        var trimmed = output.AsSpan().Trim();
+        if (trimmed.Length == 0)
+            return ToolOutputCategory.FreeText;
+
+        if (IsJson(trimmed))
+            return ToolOutputCategory.Json;
+
+        var lines = output.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+
+        if (lines.Length >= 3 && FilePathLineNumberPattern().IsMatch(output))
+            return ToolOutputCategory.FileContent;
+
+        if (IsTabular(lines))
+            return ToolOutputCategory.Tabular;
+
+        if (IsRepeatedStructure(lines))
+            return ToolOutputCategory.SearchResults;
+
+        return ToolOutputCategory.FreeText;
+    }
+
+    private static bool IsJson(ReadOnlySpan<char> trimmed)
+    {
+        if ((trimmed[0] != '{' && trimmed[0] != '[') ||
+            (trimmed[^1] != '}' && trimmed[^1] != ']'))
+            return false;
+
+        try
+        {
+            using var doc = JsonDocument.Parse(trimmed.ToString());
+            return true;
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
+    }
+
+    private static bool IsTabular(string[] lines)
+    {
+        if (lines.Length < 3)
+            return false;
+
+        var firstTabCount = lines[0].Count(c => c == '\t');
+        if (firstTabCount < 2)
+            return false;
+
+        var matchingLines = lines.Count(l => l.Count(c => c == '\t') == firstTabCount);
+        return matchingLines >= lines.Length * 0.7;
+    }
+
+    private static bool IsRepeatedStructure(string[] lines)
+    {
+        if (lines.Length < 10)
+            return false;
+
+        var prefixPattern = ExtractPrefix(lines[0]);
+        if (prefixPattern.Length < 3)
+            return false;
+
+        var matchCount = lines.Count(l => l.StartsWith(prefixPattern, StringComparison.Ordinal));
+        return matchCount >= lines.Length * 0.6;
+    }
+
+    private static string ExtractPrefix(string line)
+    {
+        var colonIndex = line.IndexOf(':');
+        if (colonIndex > 0 && colonIndex < 30)
+            return line[..(colonIndex + 1)];
+
+        var spaceIndex = line.IndexOf(' ');
+        if (spaceIndex > 0 && spaceIndex < 20)
+            return line[..spaceIndex];
+
+        return line.Length > 10 ? line[..10] : line;
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `dotnet test src/Content/Tests/Infrastructure.AI.Tests/Infrastructure.AI.Tests.csproj --filter "FullyQualifiedName~ContentTypeDetectorTests"`
+Expected: All 7 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Content/Infrastructure/Infrastructure.AI/Compression/ContentTypeDetector.cs
+git add src/Content/Tests/Infrastructure.AI.Tests/Compression/ContentTypeDetectorTests.cs
+git commit -m "feat(compression): add ContentTypeDetector with content sniffing + 7 tests"
+```
+
+---
+
+### Task 6: JsonCompressionStrategy + Tests
+
+**Files:**
+- Create: `src/Content/Infrastructure/Infrastructure.AI/Compression/Strategies/JsonCompressionStrategy.cs`
+- Create: `src/Content/Tests/Infrastructure.AI.Tests/Compression/Strategies/JsonCompressionStrategyTests.cs`
+
+- [ ] **Step 1: Write the tests**
+
+```csharp
+// src/Content/Tests/Infrastructure.AI.Tests/Compression/Strategies/JsonCompressionStrategyTests.cs
+using Domain.AI.Compression.Enums;
+using FluentAssertions;
+using Infrastructure.AI.Compression.Strategies;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Compression.Strategies;
+
+public sealed class JsonCompressionStrategyTests
+{
+    private readonly JsonCompressionStrategy _sut = new();
+
+    [Fact]
+    public void CanHandle_Json_ReturnsTrue()
+    {
+        _sut.CanHandle(ToolOutputCategory.Json).Should().BeTrue();
+    }
+
+    [Fact]
+    public void CanHandle_FreeText_ReturnsFalse()
+    {
+        _sut.CanHandle(ToolOutputCategory.FreeText).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task CompressAsync_LargeArray_TruncatesWithCount()
+    {
+        var items = Enumerable.Range(1, 20).Select(i => new { id = i, name = $"item{i}" });
+        var json = System.Text.Json.JsonSerializer.Serialize(items);
+
+        var result = await _sut.CompressAsync(json, 50);
+
+        result.WasCompressed.Should().BeTrue();
+        result.Output.Should().Contain("items omitted");
+        result.CompressedTokens.Should().BeLessThan(result.OriginalTokens);
+    }
+
+    [Fact]
+    public async Task CompressAsync_DeeplyNested_PrunesAtDepth4()
+    {
+        var json = """{"a":{"b":{"c":{"d":{"e":{"f":"deep"}}}}}}""";
+
+        var result = await _sut.CompressAsync(json, 20);
+
+        result.WasCompressed.Should().BeTrue();
+        result.Output.Should().Contain("nested object");
+    }
+
+    [Fact]
+    public async Task CompressAsync_SmallJson_ReturnsPassthrough()
+    {
+        var json = """{"name":"test"}""";
+
+        var result = await _sut.CompressAsync(json, 100);
+
+        result.WasCompressed.Should().BeFalse();
+        result.Output.Should().Be(json);
+    }
+
+    [Fact]
+    public async Task CompressAsync_InvalidJson_ReturnsFalseWasCompressed()
+    {
+        var result = await _sut.CompressAsync("not json {{{", 50);
+
+        result.WasCompressed.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task CompressAsync_EmptyString_ReturnsPassthrough()
+    {
+        var result = await _sut.CompressAsync("", 100);
+
+        result.WasCompressed.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task CompressAsync_LowSignalKeys_RemovedWhenOverBudget()
+    {
+        var json = """{"data":"important","_links":{"self":"http://example.com"},"metadata":{"created":"2024-01-01"},"pagination":{"page":1,"total":100}}""";
+
+        var result = await _sut.CompressAsync(json, 15);
+
+        result.WasCompressed.Should().BeTrue();
+        result.Output.Should().Contain("important");
+        result.Output.Should().NotContain("_links");
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `dotnet test src/Content/Tests/Infrastructure.AI.Tests/Infrastructure.AI.Tests.csproj --filter "FullyQualifiedName~JsonCompressionStrategyTests" --no-build 2>&1 || echo "Expected: build failure"`
+Expected: Build failure — `JsonCompressionStrategy` does not exist.
+
+- [ ] **Step 3: Implement JsonCompressionStrategy**
+
+```csharp
+// src/Content/Infrastructure/Infrastructure.AI/Compression/Strategies/JsonCompressionStrategy.cs
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Application.AI.Common.Helpers;
+using Application.AI.Common.Interfaces.Compression;
+using Domain.AI.Compression.Enums;
+using Domain.AI.Compression.Models;
+
+namespace Infrastructure.AI.Compression.Strategies;
+
+/// <summary>
+/// Compresses JSON output by truncating large arrays, pruning deep nesting,
+/// and removing low-signal keys. Returns <c>WasCompressed = false</c> on
+/// parse failure to signal fallthrough to the next strategy.
+/// </summary>
+public sealed class JsonCompressionStrategy : ICompressionStrategy
+{
+    private const int MaxArrayElements = 10;
+    private const int KeepFirst = 3;
+    private const int KeepLast = 2;
+    private const int MaxDepth = 4;
+
+    private static readonly HashSet<string> LowSignalKeys = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "metadata", "_links", "pagination", "headers", "timestamps",
+        "_metadata", "links", "paging", "cursor"
+    };
+
+    /// <inheritdoc />
+    public bool CanHandle(ToolOutputCategory category) => category == ToolOutputCategory.Json;
+
+    /// <inheritdoc />
+    public Task<CompressionResult> CompressAsync(
+        string output, int tokenThreshold, CancellationToken cancellationToken = default)
+    {
+        var originalTokens = TokenEstimationHelper.EstimateTokens(output);
+
+        if (string.IsNullOrEmpty(output) || originalTokens <= tokenThreshold)
+            return Task.FromResult(CompressionResult.Passthrough(output, originalTokens));
+
+        JsonNode? node;
+        try
+        {
+            node = JsonNode.Parse(output);
+        }
+        catch (JsonException)
+        {
+            return Task.FromResult(new CompressionResult
+            {
+                Output = output,
+                OriginalTokens = originalTokens,
+                CompressedTokens = originalTokens,
+                Strategy = "Json",
+                WasCompressed = false
+            });
+        }
+
+        if (node is null)
+            return Task.FromResult(CompressionResult.Passthrough(output, originalTokens));
+
+        TruncateArrays(node);
+        PruneDepth(node, 0);
+
+        var compressed = node.ToJsonString(new JsonSerializerOptions { WriteIndented = false });
+        var compressedTokens = TokenEstimationHelper.EstimateTokens(compressed);
+
+        if (compressedTokens > tokenThreshold)
+        {
+            RemoveLowSignalKeys(node);
+            compressed = node.ToJsonString(new JsonSerializerOptions { WriteIndented = false });
+            compressedTokens = TokenEstimationHelper.EstimateTokens(compressed);
+        }
+
+        return Task.FromResult(new CompressionResult
+        {
+            Output = compressed,
+            OriginalTokens = originalTokens,
+            CompressedTokens = compressedTokens,
+            Strategy = "Json",
+            WasCompressed = true
+        });
+    }
+
+    private static void TruncateArrays(JsonNode node)
+    {
+        switch (node)
+        {
+            case JsonArray array when array.Count > MaxArrayElements:
+            {
+                var omitted = array.Count - KeepFirst - KeepLast;
+                var kept = new List<JsonNode?>();
+                for (var i = 0; i < KeepFirst && i < array.Count; i++)
+                    kept.Add(array[i]?.DeepClone());
+                kept.Add(JsonValue.Create($"... ({omitted} items omitted)"));
+                for (var i = array.Count - KeepLast; i < array.Count; i++)
+                    kept.Add(array[i]?.DeepClone());
+
+                array.Clear();
+                foreach (var item in kept)
+                    array.Add(item);
+                break;
+            }
+            case JsonArray array:
+            {
+                foreach (var item in array)
+                    if (item is not null) TruncateArrays(item);
+                break;
+            }
+            case JsonObject obj:
+            {
+                foreach (var (_, value) in obj)
+                    if (value is not null) TruncateArrays(value);
+                break;
+            }
+        }
+    }
+
+    private static void PruneDepth(JsonNode node, int depth)
+    {
+        if (node is not JsonObject obj) return;
+
+        var toPrune = new List<string>();
+        foreach (var (key, value) in obj)
+        {
+            if (value is JsonObject child)
+            {
+                if (depth >= MaxDepth)
+                {
+                    toPrune.Add(key);
+                }
+                else
+                {
+                    PruneDepth(child, depth + 1);
+                }
+            }
+            else if (value is JsonArray arr)
+            {
+                foreach (var item in arr)
+                    if (item is not null) PruneDepth(item, depth + 1);
+            }
+        }
+
+        foreach (var key in toPrune)
+        {
+            var child = obj[key] as JsonObject;
+            var keyCount = child?.Count ?? 0;
+            obj[key] = JsonValue.Create($"[nested object with {keyCount} keys]");
+        }
+    }
+
+    private static void RemoveLowSignalKeys(JsonNode node)
+    {
+        if (node is not JsonObject obj) return;
+
+        var toRemove = obj
+            .Where(kv => LowSignalKeys.Contains(kv.Key))
+            .Select(kv => kv.Key)
+            .ToList();
+
+        foreach (var key in toRemove)
+            obj.Remove(key);
+
+        foreach (var (_, value) in obj)
+            if (value is not null) RemoveLowSignalKeys(value);
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `dotnet test src/Content/Tests/Infrastructure.AI.Tests/Infrastructure.AI.Tests.csproj --filter "FullyQualifiedName~JsonCompressionStrategyTests"`
+Expected: All 8 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Content/Infrastructure/Infrastructure.AI/Compression/Strategies/JsonCompressionStrategy.cs
+git add src/Content/Tests/Infrastructure.AI.Tests/Compression/Strategies/JsonCompressionStrategyTests.cs
+git commit -m "feat(compression): add JsonCompressionStrategy with array/depth/key pruning + 8 tests"
+```
+
+---
+
+### Task 7: StructuredTextCompressionStrategy + Tests
+
+**Files:**
+- Create: `src/Content/Infrastructure/Infrastructure.AI/Compression/Strategies/StructuredTextCompressionStrategy.cs`
+- Create: `src/Content/Tests/Infrastructure.AI.Tests/Compression/Strategies/StructuredTextCompressionStrategyTests.cs`
+
+- [ ] **Step 1: Write the tests**
+
+```csharp
+// src/Content/Tests/Infrastructure.AI.Tests/Compression/Strategies/StructuredTextCompressionStrategyTests.cs
+using Domain.AI.Compression.Enums;
+using FluentAssertions;
+using Infrastructure.AI.Compression.Strategies;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Compression.Strategies;
+
+public sealed class StructuredTextCompressionStrategyTests
+{
+    private readonly StructuredTextCompressionStrategy _sut = new();
+
+    [Fact]
+    public void CanHandle_FileContent_ReturnsTrue()
+    {
+        _sut.CanHandle(ToolOutputCategory.FileContent).Should().BeTrue();
+    }
+
+    [Fact]
+    public void CanHandle_SearchResults_ReturnsTrue()
+    {
+        _sut.CanHandle(ToolOutputCategory.SearchResults).Should().BeTrue();
+    }
+
+    [Fact]
+    public void CanHandle_Tabular_ReturnsTrue()
+    {
+        _sut.CanHandle(ToolOutputCategory.Tabular).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task CompressAsync_DuplicateLines_DeduplicatesWithCount()
+    {
+        var lines = string.Join('\n', Enumerable.Repeat("ERROR: Connection refused", 500));
+
+        var result = await _sut.CompressAsync(lines, 50);
+
+        result.WasCompressed.Should().BeTrue();
+        result.Output.Should().Contain("similar lines omitted");
+        result.CompressedTokens.Should().BeLessThan(result.OriginalTokens);
+    }
+
+    [Fact]
+    public async Task CompressAsync_LongFile_PreservesHeadAndTail()
+    {
+        var lines = Enumerable.Range(1, 400).Select(i => $"Line {i}: content here").ToArray();
+        var input = string.Join('\n', lines);
+
+        var result = await _sut.CompressAsync(input, 100);
+
+        result.WasCompressed.Should().BeTrue();
+        result.Output.Should().Contain("Line 1:");
+        result.Output.Should().Contain("Line 400:");
+        result.Output.Should().Contain("lines omitted");
+    }
+
+    [Fact]
+    public async Task CompressAsync_ShortOutput_ReturnsPassthrough()
+    {
+        var input = "Line 1\nLine 2\nLine 3";
+
+        var result = await _sut.CompressAsync(input, 100);
+
+        result.WasCompressed.Should().BeFalse();
+        result.Output.Should().Be(input);
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `dotnet test src/Content/Tests/Infrastructure.AI.Tests/Infrastructure.AI.Tests.csproj --filter "FullyQualifiedName~StructuredTextCompressionStrategyTests" --no-build 2>&1 || echo "Expected: build failure"`
+Expected: Build failure — `StructuredTextCompressionStrategy` does not exist.
+
+- [ ] **Step 3: Implement StructuredTextCompressionStrategy**
+
+```csharp
+// src/Content/Infrastructure/Infrastructure.AI/Compression/Strategies/StructuredTextCompressionStrategy.cs
+using Application.AI.Common.Helpers;
+using Application.AI.Common.Interfaces.Compression;
+using Domain.AI.Compression.Enums;
+using Domain.AI.Compression.Models;
+
+namespace Infrastructure.AI.Compression.Strategies;
+
+/// <summary>
+/// Compresses structured text (file content, search results, tabular data)
+/// by deduplicating repeated lines and preserving head/tail with a summary
+/// of omitted content.
+/// </summary>
+public sealed class StructuredTextCompressionStrategy : ICompressionStrategy
+{
+    private const int DefaultHeadLines = 40;
+    private const int DefaultTailLines = 10;
+
+    /// <inheritdoc />
+    public bool CanHandle(ToolOutputCategory category) =>
+        category is ToolOutputCategory.FileContent
+            or ToolOutputCategory.SearchResults
+            or ToolOutputCategory.Tabular;
+
+    /// <inheritdoc />
+    public Task<CompressionResult> CompressAsync(
+        string output, int tokenThreshold, CancellationToken cancellationToken = default)
+    {
+        var originalTokens = TokenEstimationHelper.EstimateTokens(output);
+
+        if (string.IsNullOrEmpty(output) || originalTokens <= tokenThreshold)
+            return Task.FromResult(CompressionResult.Passthrough(output, originalTokens));
+
+        var lines = output.Split('\n');
+
+        var deduplicated = DeduplicateLines(lines);
+        var deduplicatedText = string.Join('\n', deduplicated);
+        var deduplicatedTokens = TokenEstimationHelper.EstimateTokens(deduplicatedText);
+
+        if (deduplicatedTokens <= tokenThreshold)
+        {
+            return Task.FromResult(new CompressionResult
+            {
+                Output = deduplicatedText,
+                OriginalTokens = originalTokens,
+                CompressedTokens = deduplicatedTokens,
+                Strategy = "StructuredText",
+                WasCompressed = true
+            });
+        }
+
+        var headTail = HeadTailPreserve(deduplicated, DefaultHeadLines, DefaultTailLines);
+        var compressed = string.Join('\n', headTail);
+        var compressedTokens = TokenEstimationHelper.EstimateTokens(compressed);
+
+        return Task.FromResult(new CompressionResult
+        {
+            Output = compressed,
+            OriginalTokens = originalTokens,
+            CompressedTokens = compressedTokens,
+            Strategy = "StructuredText",
+            WasCompressed = true
+        });
+    }
+
+    private static List<string> DeduplicateLines(string[] lines)
+    {
+        var result = new List<string>();
+        var consecutiveCount = 1;
+        string? previousLine = null;
+
+        foreach (var line in lines)
+        {
+            if (line == previousLine)
+            {
+                consecutiveCount++;
+                continue;
+            }
+
+            if (consecutiveCount > 1 && previousLine is not null)
+            {
+                result.Add($"[... {consecutiveCount - 1} similar lines omitted]");
+            }
+
+            result.Add(line);
+            previousLine = line;
+            consecutiveCount = 1;
+        }
+
+        if (consecutiveCount > 1)
+            result.Add($"[... {consecutiveCount - 1} similar lines omitted]");
+
+        return result;
+    }
+
+    private static List<string> HeadTailPreserve(List<string> lines, int headCount, int tailCount)
+    {
+        if (lines.Count <= headCount + tailCount)
+            return lines;
+
+        var result = new List<string>();
+        result.AddRange(lines.Take(headCount));
+
+        var omitted = lines.Count - headCount - tailCount;
+        result.Add($"[... {omitted} lines omitted]");
+
+        result.AddRange(lines.Skip(lines.Count - tailCount));
+
+        return result;
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `dotnet test src/Content/Tests/Infrastructure.AI.Tests/Infrastructure.AI.Tests.csproj --filter "FullyQualifiedName~StructuredTextCompressionStrategyTests"`
+Expected: All 6 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Content/Infrastructure/Infrastructure.AI/Compression/Strategies/StructuredTextCompressionStrategy.cs
+git add src/Content/Tests/Infrastructure.AI.Tests/Compression/Strategies/StructuredTextCompressionStrategyTests.cs
+git commit -m "feat(compression): add StructuredTextCompressionStrategy with dedup + head/tail + 6 tests"
+```
+
+---
+
+### Task 8: FreeTextCompressionStrategy + Tests
+
+**Files:**
+- Create: `src/Content/Infrastructure/Infrastructure.AI/Compression/Strategies/FreeTextCompressionStrategy.cs`
+- Create: `src/Content/Tests/Infrastructure.AI.Tests/Compression/Strategies/FreeTextCompressionStrategyTests.cs`
+
+- [ ] **Step 1: Write the tests**
+
+```csharp
+// src/Content/Tests/Infrastructure.AI.Tests/Compression/Strategies/FreeTextCompressionStrategyTests.cs
+using Application.AI.Common.Interfaces.Routing;
+using Domain.AI.Compression.Enums;
+using Domain.AI.Compression.Models;
+using Domain.AI.Routing.Enums;
+using Domain.AI.Routing.Models;
+using Domain.Common.Config.AI;
+using FluentAssertions;
+using Infrastructure.AI.Compression.Strategies;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Compression.Strategies;
+
+public sealed class FreeTextCompressionStrategyTests
+{
+    private readonly Mock<IModelRouter> _mockRouter = new();
+    private readonly ToolOutputCompressionConfig _config = new() { LlmFallbackEnabled = true, LlmFallbackTimeoutSeconds = 5 };
+
+    private FreeTextCompressionStrategy CreateSut() => new(
+        _mockRouter.Object,
+        Options.Create(_config),
+        Mock.Of<ILogger<FreeTextCompressionStrategy>>());
+
+    [Fact]
+    public void CanHandle_FreeText_ReturnsTrue()
+    {
+        CreateSut().CanHandle(ToolOutputCategory.FreeText).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task CompressAsync_LongProse_TruncatesAtSentenceBoundary()
+    {
+        var sentences = Enumerable.Range(1, 200)
+            .Select(i => $"This is sentence number {i} with some additional words to make it longer.");
+        var input = string.Join(' ', sentences);
+
+        var result = await CreateSut().CompressAsync(input, 100);
+
+        result.WasCompressed.Should().BeTrue();
+        result.Output.Should().EndWith("[... remainder omitted]");
+        result.CompressedTokens.Should().BeLessThanOrEqualTo(100);
+    }
+
+    [Fact]
+    public async Task CompressAsync_ShortText_ReturnsPassthrough()
+    {
+        var input = "Short text.";
+
+        var result = await CreateSut().CompressAsync(input, 100);
+
+        result.WasCompressed.Should().BeFalse();
+        result.Output.Should().Be(input);
+    }
+
+    [Fact]
+    public async Task CompressAsync_LlmFallbackDisabled_HardTruncatesOnly()
+    {
+        _config.LlmFallbackEnabled = false;
+        var input = string.Join(' ', Enumerable.Repeat("word", 5000));
+
+        var result = await CreateSut().CompressAsync(input, 50);
+
+        result.WasCompressed.Should().BeTrue();
+        _mockRouter.Verify(
+            r => r.RouteOperationAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task CompressAsync_LlmThrows_FallsBackToHardTruncation()
+    {
+        _mockRouter
+            .Setup(r => r.RouteOperationAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("LLM unavailable"));
+
+        var input = string.Join(' ', Enumerable.Repeat("word", 5000));
+
+        var result = await CreateSut().CompressAsync(input, 50);
+
+        result.WasCompressed.Should().BeTrue();
+        result.Strategy.Should().Be("HardTruncate");
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `dotnet test src/Content/Tests/Infrastructure.AI.Tests/Infrastructure.AI.Tests.csproj --filter "FullyQualifiedName~FreeTextCompressionStrategyTests" --no-build 2>&1 || echo "Expected: build failure"`
+Expected: Build failure — `FreeTextCompressionStrategy` does not exist.
+
+- [ ] **Step 3: Implement FreeTextCompressionStrategy**
+
+```csharp
+// src/Content/Infrastructure/Infrastructure.AI/Compression/Strategies/FreeTextCompressionStrategy.cs
+using Application.AI.Common.Helpers;
+using Application.AI.Common.Interfaces.Compression;
+using Application.AI.Common.Interfaces.Routing;
+using Domain.AI.Compression.Enums;
+using Domain.AI.Compression.Models;
+using Domain.Common.Config.AI;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Infrastructure.AI.Compression.Strategies;
+
+/// <summary>
+/// Compresses unstructured text using sentence-boundary truncation.
+/// When heuristic truncation still exceeds the threshold and LLM fallback
+/// is enabled, calls an economy-tier model for intelligent summarization.
+/// </summary>
+public sealed class FreeTextCompressionStrategy : ICompressionStrategy
+{
+    private readonly IModelRouter _modelRouter;
+    private readonly ToolOutputCompressionConfig _config;
+    private readonly ILogger<FreeTextCompressionStrategy> _logger;
+
+    public FreeTextCompressionStrategy(
+        IModelRouter modelRouter,
+        IOptions<ToolOutputCompressionConfig> config,
+        ILogger<FreeTextCompressionStrategy> logger)
+    {
+        _modelRouter = modelRouter;
+        _config = config.Value;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public bool CanHandle(ToolOutputCategory category) => category == ToolOutputCategory.FreeText;
+
+    /// <inheritdoc />
+    public async Task<CompressionResult> CompressAsync(
+        string output, int tokenThreshold, CancellationToken cancellationToken = default)
+    {
+        var originalTokens = TokenEstimationHelper.EstimateTokens(output);
+
+        if (string.IsNullOrEmpty(output) || originalTokens <= tokenThreshold)
+            return CompressionResult.Passthrough(output, originalTokens);
+
+        var truncated = TruncateAtSentenceBoundary(output, tokenThreshold);
+        var truncatedTokens = TokenEstimationHelper.EstimateTokens(truncated);
+
+        if (truncatedTokens <= tokenThreshold)
+        {
+            return new CompressionResult
+            {
+                Output = truncated,
+                OriginalTokens = originalTokens,
+                CompressedTokens = truncatedTokens,
+                Strategy = "FreeText",
+                WasCompressed = true
+            };
+        }
+
+        if (_config.LlmFallbackEnabled)
+        {
+            try
+            {
+                var llmResult = await SummarizeWithLlm(truncated, tokenThreshold, cancellationToken);
+                if (llmResult is not null)
+                    return new CompressionResult
+                    {
+                        Output = llmResult,
+                        OriginalTokens = originalTokens,
+                        CompressedTokens = TokenEstimationHelper.EstimateTokens(llmResult),
+                        Strategy = "LlmFallback",
+                        WasCompressed = true
+                    };
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                _logger.LogWarning(ex, "LLM compression fallback failed, using hard truncation");
+            }
+        }
+
+        var hardTruncated = TokenEstimationHelper.TruncateToTokenBudget(output, tokenThreshold);
+        return new CompressionResult
+        {
+            Output = hardTruncated,
+            OriginalTokens = originalTokens,
+            CompressedTokens = TokenEstimationHelper.EstimateTokens(hardTruncated),
+            Strategy = "HardTruncate",
+            WasCompressed = true
+        };
+    }
+
+    private static string TruncateAtSentenceBoundary(string text, int tokenThreshold)
+    {
+        var targetChars = (int)(tokenThreshold * 4 * 0.6);
+        if (text.Length <= targetChars)
+            return text;
+
+        var sentenceEnders = new[] { '. ', '! ', '? ', ".\n", "!\n", "?\n" };
+        var lastEnd = 0;
+
+        for (var i = 0; i < text.Length && i < targetChars; i++)
+        {
+            foreach (var ender in sentenceEnders)
+            {
+                if (ender is string s)
+                {
+                    if (i + s.Length <= text.Length && text.Substring(i, s.Length) == s)
+                        lastEnd = i + s.Length;
+                }
+                else if (text[i] == (char)ender)
+                {
+                    lastEnd = i + 1;
+                }
+            }
+        }
+
+        if (lastEnd == 0)
+            lastEnd = Math.Min(targetChars, text.Length);
+
+        return text[..lastEnd] + "[... remainder omitted]";
+    }
+
+    private async Task<string?> SummarizeWithLlm(
+        string input, int tokenThreshold, CancellationToken cancellationToken)
+    {
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        cts.CancelAfter(TimeSpan.FromSeconds(_config.LlmFallbackTimeoutSeconds));
+
+        var decision = await _modelRouter.RouteOperationAsync(
+            _config.LlmRoutingOperation, cts.Token);
+
+        var prompt = $"Summarize this tool output in under {tokenThreshold} tokens. " +
+                     "Preserve actionable information, specific values, and error details. " +
+                     "Omit boilerplate.\n\n" + input;
+
+        var response = await decision.Client.GetResponseAsync(prompt, cancellationToken: cts.Token);
+        return response.Text;
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `dotnet test src/Content/Tests/Infrastructure.AI.Tests/Infrastructure.AI.Tests.csproj --filter "FullyQualifiedName~FreeTextCompressionStrategyTests"`
+Expected: All 5 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Content/Infrastructure/Infrastructure.AI/Compression/Strategies/FreeTextCompressionStrategy.cs
+git add src/Content/Tests/Infrastructure.AI.Tests/Compression/Strategies/FreeTextCompressionStrategyTests.cs
+git commit -m "feat(compression): add FreeTextCompressionStrategy with LLM fallback + 5 tests"
+```
+
+---
+
+### Task 9: ToolOutputCompressor + Tests
+
+**Files:**
+- Create: `src/Content/Infrastructure/Infrastructure.AI/Compression/ToolOutputCompressor.cs`
+- Create: `src/Content/Tests/Infrastructure.AI.Tests/Compression/ToolOutputCompressorTests.cs`
+
+- [ ] **Step 1: Write the tests**
+
+```csharp
+// src/Content/Tests/Infrastructure.AI.Tests/Compression/ToolOutputCompressorTests.cs
+using Application.AI.Common.Interfaces.Compression;
+using Domain.AI.Compression.Enums;
+using Domain.AI.Compression.Models;
+using FluentAssertions;
+using Infrastructure.AI.Compression;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Compression;
+
+public sealed class ToolOutputCompressorTests
+{
+    private readonly Mock<ICompressionStrategy> _mockJsonStrategy = new();
+    private readonly Mock<ICompressionStrategy> _mockFreeTextStrategy = new();
+
+    public ToolOutputCompressorTests()
+    {
+        _mockJsonStrategy.Setup(s => s.CanHandle(ToolOutputCategory.Json)).Returns(true);
+        _mockFreeTextStrategy.Setup(s => s.CanHandle(ToolOutputCategory.FreeText)).Returns(true);
+    }
+
+    private ToolOutputCompressor CreateSut() => new(
+        [_mockJsonStrategy.Object, _mockFreeTextStrategy.Object],
+        Mock.Of<ILogger<ToolOutputCompressor>>());
+
+    [Fact]
+    public async Task CompressAsync_JsonCategory_RoutesToJsonStrategy()
+    {
+        _mockJsonStrategy
+            .Setup(s => s.CompressAsync(It.IsAny<string>(), 100, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new CompressionResult
+            {
+                Output = "compressed", OriginalTokens = 500, CompressedTokens = 50,
+                Strategy = "Json", WasCompressed = true
+            });
+
+        var result = await CreateSut().CompressAsync("big json", ToolOutputCategory.Json, 100);
+
+        result.Strategy.Should().Be("Json");
+        _mockJsonStrategy.Verify(s => s.CompressAsync("big json", 100, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task CompressAsync_StrategyFails_FallsBackToFreeText()
+    {
+        _mockJsonStrategy
+            .Setup(s => s.CompressAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new CompressionResult
+            {
+                Output = "original", OriginalTokens = 500, CompressedTokens = 500,
+                Strategy = "Json", WasCompressed = false
+            });
+
+        _mockFreeTextStrategy
+            .Setup(s => s.CompressAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new CompressionResult
+            {
+                Output = "fallback", OriginalTokens = 500, CompressedTokens = 50,
+                Strategy = "FreeText", WasCompressed = true
+            });
+
+        var result = await CreateSut().CompressAsync("data", ToolOutputCategory.Json, 100);
+
+        result.Strategy.Should().Be("FreeText");
+    }
+
+    [Fact]
+    public async Task CompressAsync_StrategyThrows_FallsBackToHardTruncate()
+    {
+        _mockJsonStrategy
+            .Setup(s => s.CompressAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("strategy error"));
+
+        _mockFreeTextStrategy
+            .Setup(s => s.CompressAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("also fails"));
+
+        var result = await CreateSut().CompressAsync(new string('x', 1000), ToolOutputCategory.Json, 50);
+
+        result.WasCompressed.Should().BeTrue();
+        result.Strategy.Should().Be("HardTruncate");
+    }
+
+    [Fact]
+    public async Task CompressAsync_UnknownCategory_FallsBackToFreeText()
+    {
+        _mockFreeTextStrategy
+            .Setup(s => s.CompressAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new CompressionResult
+            {
+                Output = "compressed", OriginalTokens = 500, CompressedTokens = 50,
+                Strategy = "FreeText", WasCompressed = true
+            });
+
+        var result = await CreateSut().CompressAsync("data", (ToolOutputCategory)99, 100);
+
+        result.Strategy.Should().Be("FreeText");
+    }
+
+    [Fact]
+    public async Task CompressAsync_BelowThreshold_ReturnsPassthrough()
+    {
+        var result = await CreateSut().CompressAsync("short", ToolOutputCategory.Json, 100);
+
+        result.WasCompressed.Should().BeFalse();
+        result.Output.Should().Be("short");
+        _mockJsonStrategy.Verify(
+            s => s.CompressAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task CompressAsync_EmptyOutput_ReturnsPassthrough()
+    {
+        var result = await CreateSut().CompressAsync("", ToolOutputCategory.Json, 100);
+
+        result.WasCompressed.Should().BeFalse();
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `dotnet test src/Content/Tests/Infrastructure.AI.Tests/Infrastructure.AI.Tests.csproj --filter "FullyQualifiedName~ToolOutputCompressorTests" --no-build 2>&1 || echo "Expected: build failure"`
+Expected: Build failure — `ToolOutputCompressor` does not exist.
+
+- [ ] **Step 3: Implement ToolOutputCompressor**
+
+```csharp
+// src/Content/Infrastructure/Infrastructure.AI/Compression/ToolOutputCompressor.cs
+using Application.AI.Common.Helpers;
+using Application.AI.Common.Interfaces.Compression;
+using Domain.AI.Compression.Enums;
+using Domain.AI.Compression.Models;
+using Microsoft.Extensions.Logging;
+
+namespace Infrastructure.AI.Compression;
+
+/// <summary>
+/// Orchestrates tool output compression by dispatching to category-matched
+/// strategies with fallback to FreeText and hard truncation as last resort.
+/// </summary>
+public sealed class ToolOutputCompressor : IToolOutputCompressor
+{
+    private readonly IReadOnlyList<ICompressionStrategy> _strategies;
+    private readonly ILogger<ToolOutputCompressor> _logger;
+
+    public ToolOutputCompressor(
+        IEnumerable<ICompressionStrategy> strategies,
+        ILogger<ToolOutputCompressor> logger)
+    {
+        _strategies = strategies.ToList();
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<CompressionResult> CompressAsync(
+        string output,
+        ToolOutputCategory category,
+        int tokenThreshold,
+        CancellationToken cancellationToken = default)
+    {
+        var originalTokens = TokenEstimationHelper.EstimateTokens(output);
+
+        if (string.IsNullOrEmpty(output) || originalTokens <= tokenThreshold)
+            return CompressionResult.Passthrough(output, originalTokens);
+
+        var matched = _strategies.FirstOrDefault(s => s.CanHandle(category));
+
+        if (matched is not null)
+        {
+            try
+            {
+                var result = await matched.CompressAsync(output, tokenThreshold, cancellationToken);
+                if (result.WasCompressed)
+                    return result;
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                _logger.LogWarning(ex,
+                    "Strategy {Strategy} failed for category {Category}, falling back",
+                    matched.GetType().Name, category);
+            }
+        }
+
+        if (category != ToolOutputCategory.FreeText)
+        {
+            var freeTextStrategy = _strategies.FirstOrDefault(s => s.CanHandle(ToolOutputCategory.FreeText));
+            if (freeTextStrategy is not null)
+            {
+                try
+                {
+                    var fallbackResult = await freeTextStrategy.CompressAsync(
+                        output, tokenThreshold, cancellationToken);
+                    if (fallbackResult.WasCompressed)
+                        return fallbackResult;
+                }
+                catch (Exception ex) when (ex is not OperationCanceledException)
+                {
+                    _logger.LogWarning(ex, "FreeText fallback strategy also failed, hard truncating");
+                }
+            }
+        }
+
+        var truncated = TokenEstimationHelper.TruncateToTokenBudget(output, tokenThreshold);
+        return new CompressionResult
+        {
+            Output = truncated,
+            OriginalTokens = originalTokens,
+            CompressedTokens = TokenEstimationHelper.EstimateTokens(truncated),
+            Strategy = "HardTruncate",
+            WasCompressed = true
+        };
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `dotnet test src/Content/Tests/Infrastructure.AI.Tests/Infrastructure.AI.Tests.csproj --filter "FullyQualifiedName~ToolOutputCompressorTests"`
+Expected: All 6 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Content/Infrastructure/Infrastructure.AI/Compression/ToolOutputCompressor.cs
+git add src/Content/Tests/Infrastructure.AI.Tests/Compression/ToolOutputCompressorTests.cs
+git commit -m "feat(compression): add ToolOutputCompressor with strategy dispatch + fallback + 6 tests"
+```
+
+---
+
+### Task 10: ToolOutputCompressionBehavior + Tests
+
+**Files:**
+- Create: `src/Content/Application/Application.AI.Common/MediatRBehaviors/ToolOutputCompressionBehavior.cs`
+- Create: `src/Content/Tests/Application.AI.Common.Tests/MediatRBehaviors/ToolOutputCompressionBehaviorTests.cs`
+
+**Critical context:** The `ResponseSanitizationBehavior` at `src/Content/Application/Application.AI.Common/MediatRBehaviors/ResponseSanitizationBehavior.cs` shows the exact pattern for extracting and replacing tool output in the pipeline. The response can be either a bare `IToolResponse` or wrapped in `Result<T>`. The behavior uses `ExtractToolOutput()` and `ReplaceSanitizedOutput()` helper methods with reflection on `Result.Value` and `Result.Success()`. The compression behavior must follow the same pattern.
+
+- [ ] **Step 1: Write the tests**
+
+```csharp
+// src/Content/Tests/Application.AI.Common.Tests/MediatRBehaviors/ToolOutputCompressionBehaviorTests.cs
+using Application.AI.Common.Interfaces.Agent;
+using Application.AI.Common.Interfaces.Compression;
+using Application.AI.Common.Interfaces.Context;
+using Application.AI.Common.Interfaces.MediatR;
+using Application.AI.Common.MediatRBehaviors;
+using Domain.AI.Compression.Enums;
+using Domain.AI.Compression.Models;
+using Domain.AI.Context;
+using Domain.Common.Config.AI;
+using FluentAssertions;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Application.AI.Common.Tests.MediatRBehaviors;
+
+public sealed class ToolOutputCompressionBehaviorTests
+{
+    private readonly Mock<IToolOutputCompressor> _mockCompressor = new();
+    private readonly Mock<IToolResultStore> _mockStore = new();
+    private readonly Mock<IAgentExecutionContext> _mockContext = new();
+    private readonly ToolOutputCompressionConfig _config = new() { Enabled = true, DefaultTokenThreshold = 10 };
+
+    private sealed record NonToolRequest : IRequest<string>;
+    private sealed record ToolTestRequest(string ToolName) : IRequest<ToolTestResponse>, IToolRequest;
+    private sealed record ToolTestResponse(string ToolOutput) : IToolResponse
+    {
+        public IToolResponse WithSanitizedOutput(string sanitizedOutput) =>
+            new ToolTestResponse(sanitizedOutput);
+    }
+
+    public ToolOutputCompressionBehaviorTests()
+    {
+        _mockContext.Setup(c => c.ConversationId).Returns("conv-1");
+    }
+
+    private ToolOutputCompressionBehavior<TRequest, TResponse> CreateSut<TRequest, TResponse>()
+        where TRequest : notnull => new(
+        _mockCompressor.Object,
+        _mockStore.Object,
+        _mockContext.Object,
+        Options.Create(_config),
+        Mock.Of<ILogger<ToolOutputCompressionBehavior<TRequest, TResponse>>>());
+
+    [Fact]
+    public async Task Handle_NonToolRequest_PassesThrough()
+    {
+        var sut = CreateSut<NonToolRequest, string>();
+        var result = await sut.Handle(new NonToolRequest(), () => Task.FromResult("hello"), CancellationToken.None);
+
+        result.Should().Be("hello");
+        _mockCompressor.Verify(
+            c => c.CompressAsync(It.IsAny<string>(), It.IsAny<ToolOutputCategory>(), It.IsAny<int>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_BelowThreshold_PassesThrough()
+    {
+        _config.DefaultTokenThreshold = 10000;
+        var sut = CreateSut<ToolTestRequest, ToolTestResponse>();
+        var response = new ToolTestResponse("short");
+
+        var result = await sut.Handle(
+            new ToolTestRequest("tool1"),
+            () => Task.FromResult(response),
+            CancellationToken.None);
+
+        result.ToolOutput.Should().Be("short");
+    }
+
+    [Fact]
+    public async Task Handle_AboveThreshold_CompressesAndStoresReference()
+    {
+        var largeOutput = new string('x', 200);
+        var response = new ToolTestResponse(largeOutput);
+
+        _mockStore
+            .Setup(s => s.StoreIfLargeAsync("conv-1", "tool1", null, largeOutput, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ToolResultReference
+            {
+                ResultId = "ref-123",
+                ToolName = "tool1",
+                PreviewContent = "xxx...",
+                SizeChars = 200,
+                Timestamp = DateTimeOffset.UtcNow
+            });
+
+        _mockCompressor
+            .Setup(c => c.CompressAsync(largeOutput, It.IsAny<ToolOutputCategory>(), _config.DefaultTokenThreshold, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new CompressionResult
+            {
+                Output = "compressed",
+                OriginalTokens = 50,
+                CompressedTokens = 10,
+                Strategy = "Json",
+                WasCompressed = true
+            });
+
+        var sut = CreateSut<ToolTestRequest, ToolTestResponse>();
+        var result = await sut.Handle(
+            new ToolTestRequest("tool1"),
+            () => Task.FromResult(response),
+            CancellationToken.None);
+
+        result.ToolOutput.Should().Contain("compressed");
+        result.ToolOutput.Should().Contain("[Full output: result://ref-123]");
+    }
+
+    [Fact]
+    public async Task Handle_DisabledConfig_PassesThrough()
+    {
+        _config.Enabled = false;
+        var sut = CreateSut<ToolTestRequest, ToolTestResponse>();
+        var response = new ToolTestResponse(new string('x', 200));
+
+        var result = await sut.Handle(
+            new ToolTestRequest("tool1"),
+            () => Task.FromResult(response),
+            CancellationToken.None);
+
+        result.ToolOutput.Should().Be(response.ToolOutput);
+    }
+
+    [Fact]
+    public async Task Handle_CompressorThrows_ReturnsOriginalWithWarning()
+    {
+        var largeOutput = new string('x', 200);
+        var response = new ToolTestResponse(largeOutput);
+
+        _mockStore
+            .Setup(s => s.StoreIfLargeAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ToolResultReference
+            {
+                ResultId = "ref-1", ToolName = "tool1",
+                PreviewContent = "x", SizeChars = 200,
+                Timestamp = DateTimeOffset.UtcNow
+            });
+
+        _mockCompressor
+            .Setup(c => c.CompressAsync(It.IsAny<string>(), It.IsAny<ToolOutputCategory>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("boom"));
+
+        var sut = CreateSut<ToolTestRequest, ToolTestResponse>();
+        var result = await sut.Handle(
+            new ToolTestRequest("tool1"),
+            () => Task.FromResult(response),
+            CancellationToken.None);
+
+        result.ToolOutput.Should().Be(largeOutput);
+    }
+
+    [Fact]
+    public async Task Handle_NullToolOutput_PassesThrough()
+    {
+        var sut = CreateSut<ToolTestRequest, ToolTestResponse>();
+        var response = new ToolTestResponse(null!);
+
+        var result = await sut.Handle(
+            new ToolTestRequest("tool1"),
+            () => Task.FromResult(response),
+            CancellationToken.None);
+
+        result.Should().Be(response);
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `dotnet test src/Content/Tests/Application.AI.Common.Tests/Application.AI.Common.Tests.csproj --filter "FullyQualifiedName~ToolOutputCompressionBehaviorTests" --no-build 2>&1 || echo "Expected: build failure"`
+Expected: Build failure — `ToolOutputCompressionBehavior` does not exist.
+
+- [ ] **Step 3: Implement ToolOutputCompressionBehavior**
+
+```csharp
+// src/Content/Application/Application.AI.Common/MediatRBehaviors/ToolOutputCompressionBehavior.cs
+using Application.AI.Common.Helpers;
+using Application.AI.Common.Interfaces.Agent;
+using Application.AI.Common.Interfaces.Compression;
+using Application.AI.Common.Interfaces.Context;
+using Application.AI.Common.Interfaces.MediatR;
+using Domain.AI.Compression.Enums;
+using Domain.Common;
+using Domain.Common.Config.AI;
+using Infrastructure.AI.Compression;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Application.AI.Common.MediatRBehaviors;
+
+/// <summary>
+/// Post-execution pipeline behavior that compresses large tool outputs before
+/// they enter conversation history. Full output is persisted to <see cref="IToolResultStore"/>
+/// and a compressed version with a retrieval reference replaces the response.
+/// </summary>
+/// <remarks>
+/// <para>Positioned after <c>ResponseSanitizationBehavior</c> in the pipeline.</para>
+/// <para>Only activates when the request implements <see cref="IToolRequest"/>
+/// and the response implements <see cref="IToolResponse"/> with output exceeding
+/// the configured token threshold.</para>
+/// <para>On any failure, returns the original response uncompressed.</para>
+/// </remarks>
+public sealed class ToolOutputCompressionBehavior<TRequest, TResponse>
+    : IPipelineBehavior<TRequest, TResponse> where TRequest : notnull
+{
+    private readonly IToolOutputCompressor _compressor;
+    private readonly IToolResultStore _store;
+    private readonly IAgentExecutionContext _context;
+    private readonly ToolOutputCompressionConfig _config;
+    private readonly ILogger<ToolOutputCompressionBehavior<TRequest, TResponse>> _logger;
+
+    public ToolOutputCompressionBehavior(
+        IToolOutputCompressor compressor,
+        IToolResultStore store,
+        IAgentExecutionContext context,
+        IOptions<ToolOutputCompressionConfig> config,
+        ILogger<ToolOutputCompressionBehavior<TRequest, TResponse>> logger)
+    {
+        _compressor = compressor;
+        _store = store;
+        _context = context;
+        _config = config.Value;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<TResponse> Handle(
+        TRequest request,
+        RequestHandlerDelegate<TResponse> next,
+        CancellationToken cancellationToken)
+    {
+        if (request is not IToolRequest toolRequest)
+            return await next();
+
+        if (!_config.Enabled)
+            return await next();
+
+        var response = await next();
+
+        try
+        {
+            var toolOutput = ExtractToolOutput(response);
+            if (string.IsNullOrEmpty(toolOutput))
+                return response;
+
+            var threshold = _config.DefaultTokenThreshold;
+            var estimatedTokens = TokenEstimationHelper.EstimateTokens(toolOutput);
+            if (estimatedTokens <= threshold)
+            {
+                _logger.LogDebug(
+                    "Tool {ToolName} output ({Tokens} tokens) below threshold ({Threshold}), skipping compression",
+                    toolRequest.ToolName, estimatedTokens, threshold);
+                return response;
+            }
+
+            var sessionId = _context.ConversationId ?? "unknown";
+            var reference = await _store.StoreIfLargeAsync(
+                sessionId, toolRequest.ToolName, null, toolOutput, cancellationToken);
+
+            var category = ContentTypeDetector.Detect(toolOutput);
+            var result = await _compressor.CompressAsync(
+                toolOutput, category, threshold, cancellationToken);
+
+            var compressed = result.Output + $"\n[Full output: result://{reference.ResultId}]";
+
+            _logger.LogInformation(
+                "Compressed tool {ToolName} output: {OriginalTokens} → {CompressedTokens} tokens ({Strategy})",
+                toolRequest.ToolName, result.OriginalTokens, result.CompressedTokens, result.Strategy);
+
+            return ReplaceToolOutput(response, compressed);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogWarning(ex,
+                "Tool output compression failed for {ToolName}, returning original output",
+                toolRequest.ToolName);
+            return response;
+        }
+    }
+
+    private static string? ExtractToolOutput(TResponse response)
+    {
+        if (response is Result { IsSuccess: true } resultBase)
+        {
+            var valueProperty = resultBase.GetType().GetProperty("Value");
+            if (valueProperty?.GetValue(resultBase) is IToolResponse toolResponse)
+                return toolResponse.ToolOutput;
+        }
+
+        if (response is IToolResponse directToolResponse)
+            return directToolResponse.ToolOutput;
+
+        return null;
+    }
+
+    private static TResponse ReplaceToolOutput(TResponse response, string compressedOutput)
+    {
+        if (response is Result { IsSuccess: true } resultBase)
+        {
+            var valueProperty = resultBase.GetType().GetProperty("Value");
+            if (valueProperty?.GetValue(resultBase) is IToolResponse toolResponse)
+            {
+                var replaced = toolResponse.WithSanitizedOutput(compressedOutput);
+                var successMethod = resultBase.GetType().GetMethod("Success", [valueProperty.PropertyType]);
+                if (successMethod is not null)
+                    return (TResponse)successMethod.Invoke(null, [replaced])!;
+            }
+        }
+
+        if (response is IToolResponse directToolResponse)
+            return (TResponse)directToolResponse.WithSanitizedOutput(compressedOutput);
+
+        return response;
+    }
+}
+```
+
+**Important:** This behavior has a `using` directive for `Infrastructure.AI.Compression` to access `ContentTypeDetector`. However, `Application.AI.Common` should not depend on `Infrastructure.AI`. The `ContentTypeDetector.Detect()` call must be moved to the `IToolOutputCompressor` implementation, or `ContentTypeDetector` should be promoted to an interface. The cleanest approach: make `ToolOutputCompressor.CompressAsync` accept a `ToolOutputCategory?` and do the detection internally when null. Let me revise:
+
+**Revised approach:** The behavior passes `null` as category when the tool doesn't declare one, and `ToolOutputCompressor` calls `ContentTypeDetector.Detect()` internally.
+
+Update `IToolOutputCompressor` signature to accept `ToolOutputCategory?`:
+
+```csharp
+// In IToolOutputCompressor.cs — change the category parameter type
+Task<CompressionResult> CompressAsync(
+    string output,
+    ToolOutputCategory? category,
+    int tokenThreshold,
+    CancellationToken cancellationToken = default);
+```
+
+Update `ToolOutputCompressor.CompressAsync` to detect when null:
+
+```csharp
+// In ToolOutputCompressor.cs — at the start of CompressAsync
+var resolvedCategory = category ?? ContentTypeDetector.Detect(output);
+// Then use resolvedCategory instead of category throughout
+```
+
+Update the behavior to remove the `Infrastructure.AI` dependency:
+
+```csharp
+// In ToolOutputCompressionBehavior.cs — remove: using Infrastructure.AI.Compression;
+// Change the compress call to:
+var result = await _compressor.CompressAsync(
+    toolOutput, null, threshold, cancellationToken);
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `dotnet test src/Content/Tests/Application.AI.Common.Tests/Application.AI.Common.Tests.csproj --filter "FullyQualifiedName~ToolOutputCompressionBehaviorTests"`
+Expected: All 6 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Content/Application/Application.AI.Common/MediatRBehaviors/ToolOutputCompressionBehavior.cs
+git add src/Content/Application/Application.AI.Common/Interfaces/Compression/IToolOutputCompressor.cs
+git add src/Content/Infrastructure/Infrastructure.AI/Compression/ToolOutputCompressor.cs
+git add src/Content/Tests/Application.AI.Common.Tests/MediatRBehaviors/ToolOutputCompressionBehaviorTests.cs
+git commit -m "feat(compression): add ToolOutputCompressionBehavior pipeline + 6 tests"
+```
+
+---
+
+### Task 11: DI Registration + Config Binding
+
+**Files:**
+- Modify: `src/Content/Application/Application.AI.Common/DependencyInjection.cs`
+- Modify: `src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.cs`
+
+- [ ] **Step 1: Register the behavior in Application.AI.Common/DependencyInjection.cs**
+
+After the `ResponseSanitizationBehavior` registration (line ~71), add:
+
+```csharp
+            .AddTransient(typeof(IPipelineBehavior<,>), typeof(ToolOutputCompressionBehavior<,>));
+```
+
+Update the XML doc `<list>` to include the new behavior after `ResponseSanitizationBehavior`:
+
+```xml
+///   <item><description><c>ToolOutputCompressionBehavior</c> — post-execution: compresses large tool output for context savings</description></item>
+```
+
+- [ ] **Step 2: Register compressor, strategies, and config in Infrastructure.AI/DependencyInjection.cs**
+
+After the model routing registrations (line ~226), add:
+
+```csharp
+        // --- Tool output compression ---
+
+        services.AddSingleton(Options.Create(appConfig.AI.ToolOutputCompression));
+        services.AddTransient<ICompressionStrategy, JsonCompressionStrategy>();
+        services.AddTransient<ICompressionStrategy, StructuredTextCompressionStrategy>();
+        services.AddTransient<ICompressionStrategy, FreeTextCompressionStrategy>();
+        services.AddTransient<IToolOutputCompressor, ToolOutputCompressor>();
+```
+
+Add the required `using` directives to the top of the file:
+
+```csharp
+using Application.AI.Common.Interfaces.Compression;
+using Infrastructure.AI.Compression;
+using Infrastructure.AI.Compression.Strategies;
+```
+
+- [ ] **Step 3: Verify full solution build**
+
+Run: `dotnet build src/AgenticHarness.slnx`
+Expected: Build succeeded. 0 errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/Content/Application/Application.AI.Common/DependencyInjection.cs
+git add src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.cs
+git commit -m "feat(compression): register ToolOutputCompressionBehavior, strategies, and config in DI"
+```
+
+---
+
+### Task 12: Full Build Verification + Test Run
+
+**Files:** None (verification only)
+
+- [ ] **Step 1: Clean build**
+
+Run: `dotnet build src/AgenticHarness.slnx`
+Expected: Build succeeded. 0 errors, 0 warnings (or only pre-existing warnings).
+
+- [ ] **Step 2: Run all new tests**
+
+Run: `dotnet test src/AgenticHarness.slnx --filter "FullyQualifiedName~Compression"`
+Expected: All ~36 new tests pass.
+
+- [ ] **Step 3: Run full test suite to check for regressions**
+
+Run: `dotnet test src/AgenticHarness.slnx`
+Expected: All tests pass except the pre-existing 95 AgentHub failures (unrelated).
+
+- [ ] **Step 4: Final commit if any fixups needed**
+
+If any test fixups were needed, commit them:
+
+```bash
+git add -A
+git commit -m "fix(compression): address test/build issues from full verification"
+```

--- a/docs/superpowers/specs/2026-05-22-conversation-knowledge-bridge-design.md
+++ b/docs/superpowers/specs/2026-05-22-conversation-knowledge-bridge-design.md
@@ -1,0 +1,234 @@
+# Conversation-to-Knowledge Bridge Design Spec
+
+## Goal
+
+Connect the existing `IConversationStore` (chat history persistence) with `IKnowledgeMemory` (cross-session knowledge graph) so that notable facts, decisions, corrections, and preferences expressed during conversation are automatically persisted to the knowledge graph and made available to future sessions and other agents.
+
+## Architecture
+
+### Approach: Thin Pipeline Behavior + Dedicated Extractor Service
+
+A MediatR pipeline behavior (`KnowledgeExtractionBehavior`) fires post-turn, calling a dedicated `IConversationFactExtractor` that uses an economy-tier LLM to extract structured facts, then persists them via `IKnowledgeMemory.RememberAsync()`.
+
+### Why this approach
+
+- **Non-blocking**: Fire-and-forget ensures zero latency impact on agent responses
+- **Layer-clean**: Behavior lives in Application, never touches Presentation types (reads from `ExecuteAgentTurnCommand.UserMessage` and `AgentTurnResult.Response` — both Application-layer)
+- **Cost-efficient**: Economy tier via `IModelRouter.RouteOperationAsync("fact_extraction")` keeps per-turn extraction cheap
+- **Consistent**: Follows the same MediatR pipeline behavior pattern used by `AuditTrailBehavior`, `HookBehavior`, and 9 other existing behaviors
+
+## Components
+
+| Component | Layer | Project | Responsibility |
+|-----------|-------|---------|----------------|
+| `ConversationFact` | Domain | `Domain.AI` | Value object — extracted fact with key, content, entity type, confidence |
+| `IConversationFactExtractor` | Application | `Application.AI.Common` | Interface for extracting facts from a user/assistant message pair |
+| `KnowledgeExtractionBehavior<TRequest, TResponse>` | Application | `Application.AI.Common` | MediatR pipeline behavior — post-turn async extraction hook |
+| `ConversationFactExtractor` | Infrastructure | `Infrastructure.AI.KnowledgeGraph` | LLM-based implementation using economy-tier model |
+| `KnowledgeBridgeConfig` | Domain | `Domain.Common` | Configuration POCO for feature toggle, thresholds, timeout |
+
+### File Placement
+
+```
+src/Content/
+  Domain/
+    Domain.AI/
+      KnowledgeGraph/Models/
+        ConversationFact.cs                          # NEW — value object
+    Domain.Common/
+      Config/AI/
+        KnowledgeBridgeConfig.cs                     # NEW — config POCO
+  Application/
+    Application.AI.Common/
+      Interfaces/KnowledgeGraph/
+        IConversationFactExtractor.cs                # NEW — extraction interface
+      MediatRBehaviors/
+        KnowledgeExtractionBehavior.cs               # NEW — pipeline behavior
+    Application.Common/
+      DependencyInjection.cs                         # MODIFY — register behavior
+  Infrastructure/
+    Infrastructure.AI.KnowledgeGraph/
+      Memory/
+        ConversationFactExtractor.cs                 # NEW — LLM implementation
+      DependencyInjection.cs                         # MODIFY — register extractor
+    Infrastructure.AI/
+      DependencyInjection.cs                         # MODIFY — bind config
+```
+
+## Data Flow
+
+### Per-turn sequence
+
+1. User sends a message; `AgUiRunHandler` builds `ExecuteAgentTurnCommand` and dispatches via MediatR
+2. Pipeline behaviors execute in order: Validation, Auth, ContentSafety, Governance, ..., Audit
+3. `KnowledgeExtractionBehavior.Handle()` is the **last** behavior in the pipeline
+4. Behavior calls `var response = await next()` — the agent handler runs, produces `AgentTurnResult`
+5. Behavior checks:
+   - `KnowledgeBridgeConfig.Enabled` is `true`
+   - `response.Success` is `true`
+   - `response.Response` is non-empty
+6. If checks pass, behavior fires a background task (fire-and-forget):
+   - Creates a linked `CancellationTokenSource` with `ExtractionTimeoutSeconds` deadline
+   - Calls `IConversationFactExtractor.ExtractAsync(userMessage, assistantResponse, conversationId, turnNumber, ct)`
+   - For each returned `ConversationFact` with confidence >= `MinConfidence`: calls `IKnowledgeMemory.RememberAsync(fact.Key, fact.Content, fact.EntityType, ct)`
+7. Behavior immediately returns `response` — user sees the agent's answer without waiting
+
+### Key properties
+
+- **Fire-and-forget**: Extraction runs on a background thread. User response latency is unaffected.
+- **Idempotent**: Fact keys are deterministic (`{conversationId}:{turnNumber}:{factIndex}`), so re-processing the same turn won't create duplicates via `RememberAsync`'s key-based upsert.
+- **Session cache first**: `RememberAsync` writes to `ISessionKnowledgeCache` (synchronous, sub-ms). Graph flush happens at session end. Extracted facts are immediately available to `RecallAsync` within the same session.
+- **Economy tier**: Extractor calls `_modelRouter.RouteOperationAsync("fact_extraction")` to get a cheap client (e.g., gpt-4o-mini). Same pattern as `ExtractEntitiesExecutor` using `"graph_entity_extraction"`.
+
+## Extraction Model
+
+### LLM Structured Output
+
+The extractor sends a single-shot prompt containing the user/assistant message pair and expects a JSON array response:
+
+```json
+[
+  {
+    "key": "user_prefers_postgresql",
+    "content": "User prefers PostgreSQL over SQL Server for new services",
+    "entity_type": "Preference",
+    "confidence": 0.92
+  },
+  {
+    "key": "project_deadline_2026_06_15",
+    "content": "Project deployment deadline is June 15, 2026",
+    "entity_type": "Decision",
+    "confidence": 0.88
+  }
+]
+```
+
+### Entity Types (closed set)
+
+| Type | Description | Example |
+|------|-------------|---------|
+| `Preference` | User likes/dislikes, workflow choices | "User prefers dark mode in all UI mockups" |
+| `Decision` | Architectural or design decisions made | "Team chose PostgreSQL for the new service" |
+| `Fact` | Stated facts about project, team, or domain | "The API rate limit is 1000 req/min" |
+| `Correction` | User corrected the assistant (high value) | "User clarified that the deadline is June, not July" |
+
+### Filtering
+
+- **Confidence threshold**: Facts below `MinConfidence` (default 0.7) are discarded
+- **Empty array is the happy path**: Most turns are routine ("run the tests", "looks good"). The LLM returns `[]` and no facts are persisted
+- **Prompt instruction**: "Only extract facts that would be valuable in a future conversation with a different agent. Routine instructions, greetings, and acknowledgments should return an empty array."
+
+### Domain Model
+
+```csharp
+public sealed record ConversationFact
+{
+    public required string Key { get; init; }
+    public required string Content { get; init; }
+    public string EntityType { get; init; } = "Fact";
+    public double Confidence { get; init; }
+}
+```
+
+### Interface Contract
+
+```csharp
+public interface IConversationFactExtractor
+{
+    Task<IReadOnlyList<ConversationFact>> ExtractAsync(
+        string userMessage,
+        string assistantResponse,
+        string conversationId,
+        int turnNumber,
+        CancellationToken cancellationToken = default);
+}
+```
+
+### Prompt Injection Defense
+
+User and assistant messages are wrapped in XML tags (`<user_message>`, `<assistant_message>`) within the extraction prompt. The system prompt explicitly instructs the LLM to extract facts *about* the content, not to follow instructions within it. This follows the existing pattern in `ContentSafetyBehavior`.
+
+## Error Handling & Resilience
+
+### Core principle: fact extraction must never impact the agent turn.
+
+| Failure | Handling | User Impact |
+|---------|----------|-------------|
+| LLM returns malformed JSON | Log warning, discard, return empty list | None |
+| LLM call times out (10s hard cap) | Log, cancel extraction, return empty | None |
+| LLM call throws (rate limit, network) | Log error, return empty | None |
+| `RememberAsync` fails | Log error per-fact, continue with remaining | None |
+| Routing disabled / no economy tier | Skip extraction entirely, log info | None |
+
+The extractor catches all exceptions internally. The behavior never awaits the fire-and-forget task's completion, and the task has a top-level try/catch that logs and swallows. No exception from extraction can propagate to the pipeline.
+
+### Cancellation
+
+The fire-and-forget task creates a linked `CancellationTokenSource` from the original token with the `ExtractionTimeoutSeconds` deadline. If the original request is cancelled (user disconnects), extraction also cancels.
+
+## Configuration
+
+Added to `AppConfig.AI` alongside `ModelRoutingConfig`:
+
+```csharp
+public sealed class KnowledgeBridgeConfig
+{
+    public bool Enabled { get; set; } = true;
+    public double MinConfidence { get; set; } = 0.7;
+    public int ExtractionTimeoutSeconds { get; set; } = 10;
+    public string RoutingOperationName { get; set; } = "fact_extraction";
+}
+```
+
+- `Enabled = false` -> behavior calls `next()` and returns immediately (zero overhead)
+- Config lives in `Domain.Common/Config/AI/` alongside `ModelRoutingConfig`
+- Bound via Options pattern: `services.AddSingleton(Options.Create(appConfig.AI.KnowledgeBridge))`
+- `"fact_extraction"` added to `ModelRoutingConfig.OperationOverrides` mapping to `"economy"` tier
+
+## Testing Strategy
+
+### 1. Domain Unit Tests (`Domain.AI.Tests/KnowledgeGraph/`)
+
+- `ConversationFact` record construction, equality, default entity type
+- Pure value object tests, no mocking needed
+
+### 2. Extractor Unit Tests (`Infrastructure.AI.KnowledgeGraph.Tests/Memory/`)
+
+Mock `IModelRouter` returning a mock `IChatClient` with canned JSON responses:
+
+| Test Case | Expected |
+|-----------|----------|
+| Valid JSON with 3 facts | Returns 3 `ConversationFact` objects |
+| Empty array `[]` | Returns empty list (routine turn) |
+| Malformed JSON | Logs warning, returns empty list |
+| All facts below confidence threshold | Returns empty list |
+| Mixed confidence (some above, some below 0.7) | Returns only facts above threshold |
+| LLM timeout | Returns empty list within deadline |
+| Prompt injection in user message | Facts extracted *about* content, not instructions followed |
+
+### 3. Behavior Integration Tests (`Application.AI.Common.Tests/MediatRBehaviors/`)
+
+Mock `IConversationFactExtractor` and `IKnowledgeMemory`:
+
+| Test Case | Expected |
+|-----------|----------|
+| Enabled + facts returned | `RememberAsync` called for each fact |
+| Disabled (`Enabled = false`) | Extractor never called, `next()` still invoked |
+| Extractor throws | `next()` response still returned, no exception propagated |
+| Request is not `ExecuteAgentTurnCommand` | Behavior passes through without filtering |
+| `AgentTurnResult` with empty `Response` | Extractor not called |
+
+### Coverage Target
+
+90%+ on the behavior and extractor. Domain model is trivial.
+
+### What We Don't Test
+
+LLM prompt quality. That's validated empirically during development, not in CI. Tests verify plumbing (correct calls, error isolation, filtering) with deterministic mock responses.
+
+## Non-Goals
+
+- **Deduplication across sessions**: `RememberAsync` handles key-based upsert within a session. Cross-session dedup is out of scope (handled by the graph layer's merge semantics).
+- **Retroactive extraction**: This processes turns as they happen. Backfilling facts from historical conversations is a separate feature.
+- **User-facing controls**: No UI for viewing/editing extracted facts in this iteration. Facts are visible through `RecallAsync` in future agent turns.
+- **Multi-modal extraction**: Only processes text content. Tool call results, images, and file contents are not analyzed.

--- a/docs/superpowers/specs/2026-05-23-tool-output-compression-design.md
+++ b/docs/superpowers/specs/2026-05-23-tool-output-compression-design.md
@@ -1,0 +1,226 @@
+# Tool Output Compression — Design Spec
+
+## Goal
+
+Compress large tool outputs before they enter conversation history, preserving decision-relevant information while reducing context window consumption. Full outputs persist in `IToolResultStore` for on-demand retrieval.
+
+## Architecture
+
+### Compression Point
+
+Post-execution MediatR pipeline behavior (`ToolOutputCompressionBehavior`), positioned after `ResponseSanitizationBehavior`. Dual-store model: compressed version enters conversation history as `FunctionResultContent`, full output persisted to `IToolResultStore` with a retrieval reference appended to the compressed text.
+
+### Output Classification
+
+Hybrid approach: tools declare their output type via an `OutputCategory` property on `ITool` (preferred). When not declared, `ContentTypeDetector` sniffs the output string to infer the category at runtime.
+
+### Tiered Compression
+
+1. **Heuristic strategies** — deterministic, zero-cost, applied first. Strategy selected by `ToolOutputCategory`.
+2. **LLM fallback** — economy-tier model via `IModelRouter.RouteOperationAsync("output_compression")`. Only invoked when heuristic result still exceeds threshold AND content is unstructured text (`FreeText`). Configurable timeout (default 5s), falls back to hard truncation on failure.
+
+## Components
+
+### Domain Layer
+
+**`ToolOutputCategory` enum:**
+
+| Value | Description |
+|-------|-------------|
+| `Json` | Parseable JSON (API responses, structured data) |
+| `FileContent` | Source code, config files, documents |
+| `SearchResults` | Multiple results with repeated structure |
+| `Tabular` | Tab/pipe-delimited rows with consistent columns |
+| `FreeText` | Unstructured prose, logs, error output |
+
+**`CompressionResult` record:**
+- `Output` (string) — compressed text
+- `OriginalTokens` (int) — estimated token count before compression
+- `CompressedTokens` (int) — estimated token count after compression
+- `Strategy` (string) — name of strategy that produced the result (e.g., `"Json"`, `"LlmFallback"`)
+- `WasCompressed` (bool) — false when output was below threshold
+
+### Application Layer
+
+**`IToolOutputCompressor` interface:**
+- `CompressAsync(string output, ToolOutputCategory category, int tokenThreshold, CancellationToken ct)` returns `CompressionResult`
+- Orchestrates strategy selection, tiered fallback, and hard truncation as last resort
+
+**`ICompressionStrategy` interface:**
+- `CanHandle(ToolOutputCategory category)` — returns whether this strategy handles the given category
+- `CompressAsync(string output, int tokenThreshold, CancellationToken ct)` returns `CompressionResult`
+- Multiple implementations registered via keyed DI by `ToolOutputCategory`
+
+**`ToolOutputCompressionBehavior<TRequest, TResponse>` (MediatR pipeline behavior):**
+- Activates for requests implementing `IToolRequest` that produce a response implementing `IToolResponse` (existing marker interfaces in `Application.AI.Common.Interfaces.MediatR`)
+- Injects `AgentExecutionContext` (scoped) for session ID when storing full output
+- Guards: `config.Enabled`, `response.ToolOutput` token estimate > threshold
+- On success: stores full output via `IToolResultStore.StoreIfLargeAsync()`, calls `IToolResponse.WithSanitizedOutput()` to replace output with compressed text + `[Full output: result://{resultId}]` footer
+- On failure: logs warning, returns original response uncompressed
+
+**`ITool` modification:**
+- Add `ToolOutputCategory? OutputCategory { get; }` — default `null` (triggers content sniffing)
+- Add `int? CompressionTokenThreshold { get; }` — nullable, falls back to config default
+
+### Infrastructure Layer
+
+**`JsonCompressionStrategy`:**
+- Array truncation: arrays >10 elements → first 3 + last 2, insert `"... (N items omitted)"`
+- Depth pruning: objects nested >4 levels → replace subtree with `"[nested object with N keys]"`
+- Key filtering: remove low-signal keys (`metadata`, `_links`, `pagination`, `headers`, `timestamps`) when still over budget
+- Parse failure → return `WasCompressed = false` to signal fallthrough
+
+**`StructuredTextCompressionStrategy`:**
+- Line deduplication: detect repeated patterns → `[... N similar lines omitted]`
+- Head/tail preservation: first 40 / last 10 lines, structural summary of omitted middle
+- Summary header: `"File: path (N lines, language with M methods)"` from heuristics
+
+**`FreeTextCompressionStrategy`:**
+- Sentence-boundary truncation: keep first N sentences fitting 60% of threshold
+- LLM fallback (if enabled, still over budget): economy-tier model summarizes the heuristically-reduced text
+- LLM prompt: *"Summarize this tool output in under {targetTokens} tokens. Preserve actionable information, specific values, and error details. Omit boilerplate."*
+- LLM failure/timeout → hard-truncate at threshold with `[... truncated]` marker
+
+**`ContentTypeDetector` (static helper):**
+- `JsonDocument.Parse()` success → `Json`
+- Regex for file path + line number patterns → `FileContent`
+- Tab/pipe-delimited with consistent column count → `Tabular`
+- Repeated structured lines → `SearchResults`
+- Default → `FreeText`
+
+**`ToolOutputCompressor` (implementation of `IToolOutputCompressor`):**
+- Resolves matching `ICompressionStrategy` by `ToolOutputCategory`
+- Runs strategy → checks result against threshold
+- If still over and `LlmFallbackEnabled` and category is `FreeText` → LLM summarization
+- If still over after all strategies → hard-truncate to threshold
+
+## Data Flow
+
+### Happy Path (output exceeds threshold)
+
+1. Tool executes → `ToolResult` with output string
+2. `ResponseSanitizationBehavior` screens for credentials/injection (existing)
+3. `ToolOutputCompressionBehavior` activates (pattern-matches on `IToolRequest` + `IToolResponse`):
+   - `TokenEstimationHelper.EstimateTokens(response.ToolOutput)` → above threshold
+   - Determine category: `ITool.OutputCategory` ?? `ContentTypeDetector.Detect(output)`
+   - `IToolResultStore.StoreIfLargeAsync(context.ConversationId, request.ToolName, ...)` → `resultId`
+   - `IToolOutputCompressor.CompressAsync()` → `CompressionResult`
+   - `response.WithSanitizedOutput(compressed + footer)` → replace response output
+4. Compressed output enters conversation history as `FunctionResultContent`
+
+### Agent Retrieval
+
+Agent sees `[Full output: result://{resultId}]` footer → calls `IToolResultStore.RetrieveFullContentAsync(resultId)` via existing retrieval mechanism. No new retrieval tool needed.
+
+### Tiered Fallback Chain
+
+1. Category-matched heuristic strategy
+2. If still over + `FreeText` + LLM enabled → LLM summarization of heuristically-reduced text
+3. If still over or any failure → hard-truncate at threshold
+
+## Configuration
+
+```yaml
+AI:
+  ToolOutputCompression:
+    Enabled: true
+    DefaultTokenThreshold: 2000
+    LlmFallbackEnabled: true
+    LlmFallbackTimeoutSeconds: 5
+    LlmRoutingOperation: "output_compression"
+```
+
+Per-tool overrides via `ITool.OutputCategory` and `ITool.CompressionTokenThreshold` (nullable, fall back to config defaults when null).
+
+## Error Handling
+
+- `ToolOutputCompressionBehavior` wraps all compression in try/catch — on failure, returns original output uncompressed with a warning log. Compression must never break tool execution.
+- `ContentTypeDetector` failures → default to `FreeText`
+- Individual strategy failures → fall through to `FreeTextCompressionStrategy` hard truncation
+- LLM timeout/failure → hard-truncate at threshold with retrieval reference
+
+## Observability
+
+- `Debug`: output below threshold, skipped compression
+- `Information`: compressed successfully — original tokens, compressed tokens, strategy, ratio
+- `Warning`: strategy failed with fallback, LLM timeout
+- `CompressionResult` metrics available for `ContextBudgetTracker.RecordUsage()`
+- No new OpenTelemetry spans — existing `ToolDiagnosticsMiddleware` traces cover tool output
+
+## Testing Strategy
+
+### ContentTypeDetectorTests (~6 tests)
+- Valid JSON → `Json`
+- File paths with line numbers → `FileContent`
+- Tab-delimited rows → `Tabular`
+- Repeated structured lines → `SearchResults`
+- Plain prose → `FreeText`
+- Malformed/empty → `FreeText`
+
+### JsonCompressionStrategyTests (~7 tests)
+- Array >10 elements truncated with count
+- Deep nesting pruned at depth 4
+- Low-signal keys removed when over budget
+- Small JSON → passthrough
+- Invalid JSON → `WasCompressed = false`
+- Empty/null → passthrough
+- Mixed-type arrays preserved
+
+### StructuredTextCompressionStrategyTests (~5 tests)
+- Duplicate lines → deduplicated with count
+- Long file → head/tail with summary
+- Structural summary header generated
+- Short output → passthrough
+- No structure detected → passthrough
+
+### FreeTextCompressionStrategyTests (~5 tests)
+- Long prose → sentence-boundary truncation
+- LLM fallback invoked when heuristic still over
+- LLM timeout → hard truncation
+- LLM disabled → hard truncation only
+- Short text → passthrough
+
+### ToolOutputCompressorTests (~6 tests)
+- Routes category to correct strategy
+- Strategy failure → FreeText fallback
+- Tiered: heuristic under budget → no LLM
+- Tiered: heuristic over → LLM called
+- Unknown category → FreeText default
+- Below threshold → passthrough
+
+### ToolOutputCompressionBehaviorTests (~7 tests)
+- Non-tool request → passthrough
+- Below threshold → passthrough
+- Above threshold → compressed + stored + reference footer
+- Disabled in config → passthrough
+- Compression throws → original output, warning logged
+- Tool with custom OutputCategory → used over sniffing
+- Tool with custom threshold → overrides config default
+
+**Total: ~36 tests.** Strategy tests are pure unit tests (deterministic string-in/string-out). Behavior and compressor tests mock `IToolResultStore`, `IModelRouter`, `ICompressionStrategy`.
+
+## File Manifest
+
+| Layer | File | Action |
+|-------|------|--------|
+| Domain | `Domain.AI/Models/ToolOutputCategory.cs` | Create |
+| Domain | `Domain.AI/Models/CompressionResult.cs` | Create |
+| Domain | `Domain.Common/Config/AI/ToolOutputCompressionConfig.cs` | Create |
+| Domain | `Domain.Common/Config/AI/AIConfig.cs` | Modify — add `ToolOutputCompression` property |
+| Application | `Application.AI.Common/Interfaces/Compression/IToolOutputCompressor.cs` | Create |
+| Application | `Application.AI.Common/Interfaces/Compression/ICompressionStrategy.cs` | Create |
+| Application | `Application.AI.Common/MediatRBehaviors/ToolOutputCompressionBehavior.cs` | Create |
+| Application | `Application.AI.Common/Interfaces/Tools/ITool.cs` | Modify — add `OutputCategory`, `CompressionTokenThreshold` |
+| Infrastructure | `Infrastructure.AI/Compression/ContentTypeDetector.cs` | Create |
+| Infrastructure | `Infrastructure.AI/Compression/ToolOutputCompressor.cs` | Create |
+| Infrastructure | `Infrastructure.AI/Compression/Strategies/JsonCompressionStrategy.cs` | Create |
+| Infrastructure | `Infrastructure.AI/Compression/Strategies/StructuredTextCompressionStrategy.cs` | Create |
+| Infrastructure | `Infrastructure.AI/Compression/Strategies/FreeTextCompressionStrategy.cs` | Create |
+| Infrastructure | `Infrastructure.AI/DependencyInjection.cs` | Modify — register compressor, strategies, config |
+| Application | `Application.AI.Common/DependencyInjection.cs` | Modify — register behavior |
+| Tests | `Infrastructure.AI.Tests/Compression/ContentTypeDetectorTests.cs` | Create |
+| Tests | `Infrastructure.AI.Tests/Compression/Strategies/JsonCompressionStrategyTests.cs` | Create |
+| Tests | `Infrastructure.AI.Tests/Compression/Strategies/StructuredTextCompressionStrategyTests.cs` | Create |
+| Tests | `Infrastructure.AI.Tests/Compression/Strategies/FreeTextCompressionStrategyTests.cs` | Create |
+| Tests | `Infrastructure.AI.Tests/Compression/ToolOutputCompressorTests.cs` | Create |
+| Tests | `Application.AI.Common.Tests/MediatRBehaviors/ToolOutputCompressionBehaviorTests.cs` | Create |

--- a/src/Content/Application/Application.AI.Common/DependencyInjection.cs
+++ b/src/Content/Application/Application.AI.Common/DependencyInjection.cs
@@ -43,6 +43,7 @@ namespace Application.AI.Common;
 ///   <item><description><c>HookBehavior</c> — fires lifecycle hooks for tool and turn events</description></item>
 ///   <item><description><c>RetrievalAuditBehavior</c> — logs retrieval-augmented generation audit trails</description></item>
 ///   <item><description><c>ResponseSanitizationBehavior</c> — post-execution: sanitizes tool output for credentials, injection, exfiltration</description></item>
+///   <item><description><c>ToolOutputCompressionBehavior</c> — post-execution: compresses large tool output for context window savings</description></item>
 /// </list>
 /// </para>
 /// </remarks>
@@ -68,7 +69,8 @@ public static class DependencyInjection
             .AddTransient(typeof(IPipelineBehavior<,>), typeof(PromptInjectionBehavior<,>))
             .AddTransient(typeof(IPipelineBehavior<,>), typeof(HookBehavior<,>))
             .AddTransient(typeof(IPipelineBehavior<,>), typeof(RetrievalAuditBehavior<,>))
-            .AddTransient(typeof(IPipelineBehavior<,>), typeof(ResponseSanitizationBehavior<,>));
+            .AddTransient(typeof(IPipelineBehavior<,>), typeof(ResponseSanitizationBehavior<,>))
+            .AddTransient(typeof(IPipelineBehavior<,>), typeof(ToolOutputCompressionBehavior<,>));
 
         // Sandbox capability enforcement — profile resolution and enforcement
         services.AddOptions<SandboxConfig>();

--- a/src/Content/Application/Application.AI.Common/Interfaces/Compression/ICompressionStrategy.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Compression/ICompressionStrategy.cs
@@ -1,0 +1,37 @@
+using Domain.AI.Compression.Enums;
+using Domain.AI.Compression.Models;
+
+namespace Application.AI.Common.Interfaces.Compression;
+
+/// <summary>
+/// Category-specific compression strategy for tool outputs.
+/// Implementations are registered via keyed DI by <see cref="ToolOutputCategory"/>
+/// and resolved by <see cref="IToolOutputCompressor"/> during compression.
+/// </summary>
+/// <remarks>
+/// Strategies must be deterministic and side-effect-free (except
+/// <c>FreeTextCompressionStrategy</c> which may call an LLM as fallback).
+/// Return <c>CompressionResult.WasCompressed = false</c> to signal that
+/// this strategy could not handle the content and the compressor should
+/// fall through to the next strategy.
+/// </remarks>
+public interface ICompressionStrategy
+{
+    /// <summary>Returns whether this strategy can handle the given output category.</summary>
+    bool CanHandle(ToolOutputCategory category);
+
+    /// <summary>
+    /// Compresses the output to fit within the token threshold.
+    /// </summary>
+    /// <param name="output">The tool output string to compress.</param>
+    /// <param name="tokenThreshold">Target maximum token count.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>
+    /// Compression result. Set <c>WasCompressed = false</c> if the strategy
+    /// cannot handle this content (e.g., JSON parse failure) to signal fallthrough.
+    /// </returns>
+    Task<CompressionResult> CompressAsync(
+        string output,
+        int tokenThreshold,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Content/Application/Application.AI.Common/Interfaces/Compression/IToolOutputCompressor.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Compression/IToolOutputCompressor.cs
@@ -1,0 +1,32 @@
+using Domain.AI.Compression.Enums;
+using Domain.AI.Compression.Models;
+
+namespace Application.AI.Common.Interfaces.Compression;
+
+/// <summary>
+/// Orchestrates tool output compression by dispatching to the appropriate
+/// <see cref="ICompressionStrategy"/> based on output category, applying
+/// tiered fallback (heuristic → LLM → hard truncation).
+/// </summary>
+public interface IToolOutputCompressor
+{
+    /// <summary>
+    /// Compresses tool output to fit within the token threshold.
+    /// </summary>
+    /// <param name="output">The raw tool output to compress.</param>
+    /// <param name="category">
+    /// The classified output category, or null to trigger automatic content detection.
+    /// When null, the implementation uses ContentTypeDetector to infer the category.
+    /// </param>
+    /// <param name="tokenThreshold">Maximum token count for the result.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>
+    /// The compression result. Always returns a valid result — never throws.
+    /// On internal failure, returns hard-truncated output.
+    /// </returns>
+    Task<CompressionResult> CompressAsync(
+        string output,
+        ToolOutputCategory? category,
+        int tokenThreshold,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Content/Application/Application.AI.Common/Interfaces/Tools/ITool.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Tools/ITool.cs
@@ -61,6 +61,18 @@ public interface ITool
     bool IsConcurrencySafe => false;
 
     /// <summary>
+    /// Declares the expected output content type for compression strategy selection.
+    /// When null, <c>ContentTypeDetector</c> sniffs the output at runtime.
+    /// </summary>
+    Domain.AI.Compression.Enums.ToolOutputCategory? OutputCategory => null;
+
+    /// <summary>
+    /// Per-tool compression token threshold override. When null, falls back
+    /// to <c>ToolOutputCompressionConfig.DefaultTokenThreshold</c>.
+    /// </summary>
+    int? CompressionTokenThreshold => null;
+
+    /// <summary>
     /// Executes a tool operation with the given parameters.
     /// </summary>
     /// <param name="operation">The operation to perform (must be in <see cref="SupportedOperations"/>).</param>

--- a/src/Content/Application/Application.AI.Common/MediatRBehaviors/ToolOutputCompressionBehavior.cs
+++ b/src/Content/Application/Application.AI.Common/MediatRBehaviors/ToolOutputCompressionBehavior.cs
@@ -1,0 +1,167 @@
+using Application.AI.Common.Helpers;
+using Application.AI.Common.Interfaces.Agent;
+using Application.AI.Common.Interfaces.Compression;
+using Application.AI.Common.Interfaces.Context;
+using Application.AI.Common.Interfaces.MediatR;
+using Domain.Common;
+using Domain.Common.Config.AI;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Application.AI.Common.MediatRBehaviors;
+
+/// <summary>
+/// Compresses large tool output before it re-enters the LLM context window.
+/// Stores the full output via <see cref="IToolResultStore"/> and replaces
+/// the response content with a compressed summary plus a retrieval reference.
+/// </summary>
+/// <remarks>
+/// <para>Pipeline position: 9 (post-execution, before response sanitization at 9.5).</para>
+/// <para>Only activates when <c>ToolOutputCompressionConfig.Enabled</c> is true,
+/// the request implements <see cref="IToolRequest"/>, and the response
+/// value implements <see cref="IToolResponse"/> with output exceeding the token threshold.</para>
+/// <para>
+/// Extract/Replace pattern mirrors <see cref="ResponseSanitizationBehavior{TRequest,TResponse}"/>
+/// to handle both <c>Result&lt;IToolResponse&gt;</c> and direct <c>IToolResponse</c> responses
+/// via reflection-based <c>Result&lt;T&gt;</c> unwrapping.
+/// </para>
+/// </remarks>
+public sealed class ToolOutputCompressionBehavior<TRequest, TResponse>
+    : IPipelineBehavior<TRequest, TResponse> where TRequest : notnull
+{
+    private readonly IToolOutputCompressor _compressor;
+    private readonly IToolResultStore _resultStore;
+    private readonly IAgentExecutionContext _executionContext;
+    private readonly ToolOutputCompressionConfig _config;
+    private readonly ILogger<ToolOutputCompressionBehavior<TRequest, TResponse>> _logger;
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="ToolOutputCompressionBehavior{TRequest, TResponse}"/>.
+    /// </summary>
+    public ToolOutputCompressionBehavior(
+        IToolOutputCompressor compressor,
+        IToolResultStore resultStore,
+        IAgentExecutionContext executionContext,
+        IOptions<ToolOutputCompressionConfig> config,
+        ILogger<ToolOutputCompressionBehavior<TRequest, TResponse>> logger)
+    {
+        _compressor = compressor;
+        _resultStore = resultStore;
+        _executionContext = executionContext;
+        _config = config.Value;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<TResponse> Handle(
+        TRequest request,
+        RequestHandlerDelegate<TResponse> next,
+        CancellationToken cancellationToken)
+    {
+        if (request is not IToolRequest toolRequest)
+            return await next();
+
+        if (!_config.Enabled)
+            return await next();
+
+        var response = await next();
+
+        try
+        {
+            return await CompressIfNeeded(response, toolRequest, cancellationToken);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "Tool output compression failed for {ToolName}; returning original response",
+                toolRequest.ToolName);
+            return response;
+        }
+    }
+
+    private async Task<TResponse> CompressIfNeeded(
+        TResponse response,
+        IToolRequest toolRequest,
+        CancellationToken cancellationToken)
+    {
+        var toolOutput = ExtractToolOutput(response);
+        if (toolOutput is null)
+            return response;
+
+        var estimatedTokens = TokenEstimationHelper.EstimateTokens(toolOutput);
+        if (estimatedTokens <= _config.DefaultTokenThreshold)
+        {
+            _logger.LogDebug(
+                "Tool {ToolName} output ({Tokens} tokens) below threshold ({Threshold}); skipping compression",
+                toolRequest.ToolName, estimatedTokens, _config.DefaultTokenThreshold);
+            return response;
+        }
+
+        var sessionId = _executionContext.ConversationId ?? "unknown";
+
+        var reference = await _resultStore.StoreIfLargeAsync(
+            sessionId,
+            toolRequest.ToolName,
+            operation: null,
+            toolOutput,
+            cancellationToken);
+
+        var compressionResult = await _compressor.CompressAsync(
+            toolOutput,
+            category: null,
+            _config.DefaultTokenThreshold,
+            cancellationToken);
+
+        var compressedWithRef = $"{compressionResult.Output}\n[Full output: result://{reference.ResultId}]";
+
+        _logger.LogInformation(
+            "Compressed tool {ToolName} output from {OriginalTokens} to {CompressedTokens} tokens (strategy: {Strategy}, ref: {ResultId})",
+            toolRequest.ToolName,
+            compressionResult.OriginalTokens,
+            compressionResult.CompressedTokens,
+            compressionResult.Strategy,
+            reference.ResultId);
+
+        return ReplaceToolOutput(response, compressedWithRef);
+    }
+
+    private static string? ExtractToolOutput(TResponse response)
+    {
+        if (response is Result { IsSuccess: true } resultBase)
+        {
+            var valueProperty = resultBase.GetType().GetProperty("Value");
+            if (valueProperty?.GetValue(resultBase) is IToolResponse toolResponse)
+                return toolResponse.ToolOutput;
+        }
+
+        if (response is IToolResponse directToolResponse)
+            return directToolResponse.ToolOutput;
+
+        return null;
+    }
+
+    private static TResponse ReplaceToolOutput(TResponse response, string compressedContent)
+    {
+        if (response is Result { IsSuccess: true } resultBase)
+        {
+            var valueProperty = resultBase.GetType().GetProperty("Value");
+            if (valueProperty?.GetValue(resultBase) is IToolResponse toolResponse)
+            {
+                var replacedValue = toolResponse.WithSanitizedOutput(compressedContent);
+                var successMethod = resultBase.GetType().GetMethod("Success", [valueProperty.PropertyType]);
+                if (successMethod is not null)
+                    return (TResponse)successMethod.Invoke(null, [replacedValue])!;
+            }
+        }
+
+        if (response is IToolResponse directToolResponse)
+            return (TResponse)directToolResponse.WithSanitizedOutput(compressedContent);
+
+        return response;
+    }
+}

--- a/src/Content/Domain/Domain.AI/Compression/Enums/ToolOutputCategory.cs
+++ b/src/Content/Domain/Domain.AI/Compression/Enums/ToolOutputCategory.cs
@@ -1,0 +1,24 @@
+namespace Domain.AI.Compression.Enums;
+
+/// <summary>
+/// Classifies tool output content for compression strategy selection.
+/// Tools declare this via <c>ITool.OutputCategory</c>; when not declared,
+/// <c>ContentTypeDetector</c> infers it from content structure.
+/// </summary>
+public enum ToolOutputCategory
+{
+    /// <summary>Parseable JSON — API responses, structured data.</summary>
+    Json = 0,
+
+    /// <summary>Source code, configuration files, documents with line structure.</summary>
+    FileContent = 1,
+
+    /// <summary>Multiple results with repeated structure (search hits, log entries).</summary>
+    SearchResults = 2,
+
+    /// <summary>Tab/pipe-delimited rows with consistent column count.</summary>
+    Tabular = 3,
+
+    /// <summary>Unstructured prose, error output, logs without repeated structure.</summary>
+    FreeText = 4
+}

--- a/src/Content/Domain/Domain.AI/Compression/Models/CompressionResult.cs
+++ b/src/Content/Domain/Domain.AI/Compression/Models/CompressionResult.cs
@@ -1,0 +1,33 @@
+namespace Domain.AI.Compression.Models;
+
+/// <summary>
+/// Outcome of compressing a tool output. Carries the compressed text,
+/// token metrics, and which strategy produced the result.
+/// </summary>
+public sealed record CompressionResult
+{
+    /// <summary>The compressed (or original) output text.</summary>
+    public required string Output { get; init; }
+
+    /// <summary>Estimated token count of the original output.</summary>
+    public required int OriginalTokens { get; init; }
+
+    /// <summary>Estimated token count after compression.</summary>
+    public required int CompressedTokens { get; init; }
+
+    /// <summary>Name of the strategy that produced this result (e.g., "Json", "LlmFallback", "HardTruncate").</summary>
+    public required string Strategy { get; init; }
+
+    /// <summary>Whether compression was actually applied (false when output was below threshold).</summary>
+    public required bool WasCompressed { get; init; }
+
+    /// <summary>Creates a passthrough result for outputs below threshold.</summary>
+    public static CompressionResult Passthrough(string output, int tokens) => new()
+    {
+        Output = output,
+        OriginalTokens = tokens,
+        CompressedTokens = tokens,
+        Strategy = "None",
+        WasCompressed = false
+    };
+}

--- a/src/Content/Domain/Domain.Common/Config/AI/AIConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/AIConfig.cs
@@ -39,7 +39,8 @@ namespace Domain.Common.Config.AI;
 /// ├── DriftDetection    — EWMA-based drift detection for quality regressions
 /// ├── Learnings         — Cross-session learnings: feedback blending, decay, pruning
 /// ├── Planner           — Plan execution: concurrency, timeouts, persistence
-/// └── Sandbox           — Sandbox execution: resource limits, isolation, containers
+/// ├── Sandbox           — Sandbox execution: resource limits, isolation, containers
+/// └── ToolOutputCompression — Tool output compression: thresholds, LLM fallback, strategies
 /// </code>
 /// </para>
 /// </remarks>
@@ -148,4 +149,10 @@ public class AIConfig
     /// isolation defaults, container settings, and per-tool overrides.
     /// </summary>
     public SandboxOptions Sandbox { get; set; } = new();
+
+    /// <summary>
+    /// Tool output compression configuration: thresholds, LLM fallback,
+    /// and strategy selection for reducing context window consumption.
+    /// </summary>
+    public ToolOutputCompressionConfig ToolOutputCompression { get; set; } = new();
 }

--- a/src/Content/Domain/Domain.Common/Config/AI/ToolOutputCompressionConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/ToolOutputCompressionConfig.cs
@@ -1,0 +1,33 @@
+namespace Domain.Common.Config.AI;
+
+/// <summary>
+/// Configuration for the tool output compression subsystem.
+/// Bound from <c>AppConfig.AI.ToolOutputCompression</c>.
+/// </summary>
+public sealed class ToolOutputCompressionConfig
+{
+    /// <summary>Master toggle. When false, all outputs pass through uncompressed.</summary>
+    public bool Enabled { get; set; } = true;
+
+    /// <summary>
+    /// Default token threshold that triggers compression. Outputs below this
+    /// pass through untouched. Individual tools can override via
+    /// <c>ITool.CompressionTokenThreshold</c>.
+    /// </summary>
+    public int DefaultTokenThreshold { get; set; } = 2000;
+
+    /// <summary>
+    /// Whether to use an LLM for summarization when heuristic strategies
+    /// produce a result that still exceeds the threshold on FreeText content.
+    /// </summary>
+    public bool LlmFallbackEnabled { get; set; } = true;
+
+    /// <summary>Timeout in seconds for LLM fallback calls.</summary>
+    public int LlmFallbackTimeoutSeconds { get; set; } = 5;
+
+    /// <summary>
+    /// Operation name passed to <c>IModelRouter.RouteOperationAsync</c>
+    /// to resolve the economy-tier model for LLM compression.
+    /// </summary>
+    public string LlmRoutingOperation { get; set; } = "output_compression";
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Compression/ContentTypeDetector.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Compression/ContentTypeDetector.cs
@@ -1,0 +1,110 @@
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using Domain.AI.Compression.Enums;
+
+namespace Infrastructure.AI.Compression;
+
+/// <summary>
+/// Sniffs tool output content to infer <see cref="ToolOutputCategory"/>
+/// when the tool does not declare one via <c>ITool.OutputCategory</c>.
+/// Detection order: JSON → FileContent → Tabular → SearchResults → FreeText.
+/// </summary>
+public static partial class ContentTypeDetector
+{
+    [GeneratedRegex(@"^[\s]*[\w\./\\]+\.\w+:\d+:", RegexOptions.Multiline)]
+    private static partial Regex FilePathLineNumberPattern();
+
+    [GeneratedRegex(@"^.+\t.+\t.+$", RegexOptions.Multiline)]
+    private static partial Regex TabDelimitedPattern();
+
+    /// <summary>
+    /// Detects the output category from content structure.
+    /// Returns <see cref="ToolOutputCategory.FreeText"/> for null, empty, or unrecognized content.
+    /// </summary>
+    public static ToolOutputCategory Detect(string? output)
+    {
+        if (string.IsNullOrWhiteSpace(output))
+            return ToolOutputCategory.FreeText;
+
+        var trimmed = output.AsSpan().Trim();
+        if (trimmed.Length == 0)
+            return ToolOutputCategory.FreeText;
+
+        if (IsJson(trimmed))
+            return ToolOutputCategory.Json;
+
+        var lines = output.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+
+        if (lines.Length >= 3 && FilePathLineNumberPattern().IsMatch(output))
+            return ToolOutputCategory.FileContent;
+
+        if (IsTabular(lines))
+            return ToolOutputCategory.Tabular;
+
+        if (IsRepeatedStructure(lines))
+            return ToolOutputCategory.SearchResults;
+
+        return ToolOutputCategory.FreeText;
+    }
+
+    private static bool IsJson(ReadOnlySpan<char> trimmed)
+    {
+        if ((trimmed[0] != '{' && trimmed[0] != '[') ||
+            (trimmed[^1] != '}' && trimmed[^1] != ']'))
+            return false;
+
+        try
+        {
+            using var doc = JsonDocument.Parse(trimmed.ToString());
+            return true;
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
+    }
+
+    private static bool IsTabular(string[] lines)
+    {
+        if (lines.Length < 3)
+            return false;
+
+        var firstTabCount = lines[0].Count(c => c == '\t');
+        if (firstTabCount < 2)
+            return false;
+
+        var matchingLines = lines.Count(l => l.Count(c => c == '\t') == firstTabCount);
+        return matchingLines >= lines.Length * 0.7;
+    }
+
+    private static bool IsRepeatedStructure(string[] lines)
+    {
+        if (lines.Length < 10)
+            return false;
+
+        // Extract structural key from each line (leading alphabetic word, ignoring numbers)
+        var keys = lines.Select(ExtractStructuralKey).ToArray();
+        var dominantKey = keys
+            .Where(k => k.Length >= 3)
+            .GroupBy(k => k)
+            .OrderByDescending(g => g.Count())
+            .FirstOrDefault()?.Key;
+
+        if (dominantKey is null)
+            return false;
+
+        var matchCount = keys.Count(k => k.Equals(dominantKey, StringComparison.Ordinal));
+        return matchCount >= lines.Length * 0.6;
+    }
+
+    private static string ExtractStructuralKey(string line)
+    {
+        // Extract the first run of non-digit, non-whitespace characters as the structural key.
+        // "Result 1: ..." → "Result", "Error[42]:" → "Error", "  src/foo.cs:10:" → "src/foo.cs:"
+        var span = line.AsSpan().TrimStart();
+        var end = 0;
+        while (end < span.Length && !char.IsWhiteSpace(span[end]) && !char.IsDigit(span[end]))
+            end++;
+        return end >= 3 ? span[..end].ToString() : string.Empty;
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Compression/Strategies/FreeTextCompressionStrategy.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Compression/Strategies/FreeTextCompressionStrategy.cs
@@ -1,0 +1,158 @@
+using Application.AI.Common.Helpers;
+using Application.AI.Common.Interfaces.Compression;
+using Application.AI.Common.Interfaces.Routing;
+using Domain.AI.Compression.Enums;
+using Domain.AI.Compression.Models;
+using Domain.Common.Config.AI;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Infrastructure.AI.Compression.Strategies;
+
+/// <summary>
+/// Compresses unstructured text using sentence-boundary truncation.
+/// When heuristic truncation still exceeds the threshold and LLM fallback
+/// is enabled, calls an economy-tier model for intelligent summarization.
+/// Falls back to hard truncation if the LLM call fails or is disabled.
+/// </summary>
+/// <remarks>
+/// Compression pipeline:
+/// <list type="number">
+///   <item><description>Sentence-boundary truncation — clips at the last complete sentence before the target char limit.</description></item>
+///   <item><description>LLM summarization (optional) — economy-tier model call when sentence truncation still exceeds the threshold.</description></item>
+///   <item><description>Hard truncation — character-level cut with <c>...[truncated]</c> suffix as final fallback.</description></item>
+/// </list>
+/// </remarks>
+public sealed class FreeTextCompressionStrategy : ICompressionStrategy
+{
+    private readonly IModelRouter _modelRouter;
+    private readonly ToolOutputCompressionConfig _config;
+    private readonly ILogger<FreeTextCompressionStrategy> _logger;
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="FreeTextCompressionStrategy"/>.
+    /// </summary>
+    /// <param name="modelRouter">Router for resolving the economy-tier LLM used during fallback summarization.</param>
+    /// <param name="config">Compression configuration (LLM fallback toggle, timeout, routing operation name).</param>
+    /// <param name="logger">Logger for recording fallback events and warnings.</param>
+    public FreeTextCompressionStrategy(
+        IModelRouter modelRouter,
+        IOptions<ToolOutputCompressionConfig> config,
+        ILogger<FreeTextCompressionStrategy> logger)
+    {
+        _modelRouter = modelRouter;
+        _config = config.Value;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public bool CanHandle(ToolOutputCategory category) => category == ToolOutputCategory.FreeText;
+
+    /// <inheritdoc />
+    public async Task<CompressionResult> CompressAsync(
+        string output, int tokenThreshold, CancellationToken cancellationToken = default)
+    {
+        var originalTokens = TokenEstimationHelper.EstimateTokens(output);
+
+        if (string.IsNullOrEmpty(output) || originalTokens <= tokenThreshold)
+            return CompressionResult.Passthrough(output, originalTokens);
+
+        var truncated = TruncateAtSentenceBoundary(output, tokenThreshold);
+        var truncatedTokens = TokenEstimationHelper.EstimateTokens(truncated);
+
+        if (truncatedTokens <= tokenThreshold)
+        {
+            return new CompressionResult
+            {
+                Output = truncated,
+                OriginalTokens = originalTokens,
+                CompressedTokens = truncatedTokens,
+                Strategy = "FreeText",
+                WasCompressed = true
+            };
+        }
+
+        if (_config.LlmFallbackEnabled)
+        {
+            try
+            {
+                var llmResult = await SummarizeWithLlmAsync(output, tokenThreshold, cancellationToken);
+                if (llmResult is not null)
+                {
+                    return new CompressionResult
+                    {
+                        Output = llmResult,
+                        OriginalTokens = originalTokens,
+                        CompressedTokens = TokenEstimationHelper.EstimateTokens(llmResult),
+                        Strategy = "LlmFallback",
+                        WasCompressed = true
+                    };
+                }
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                _logger.LogWarning(ex, "LLM compression fallback failed, using hard truncation");
+            }
+        }
+
+        var hardTruncated = TokenEstimationHelper.TruncateToTokenBudget(output, tokenThreshold);
+        return new CompressionResult
+        {
+            Output = hardTruncated,
+            OriginalTokens = originalTokens,
+            CompressedTokens = TokenEstimationHelper.EstimateTokens(hardTruncated),
+            Strategy = "HardTruncate",
+            WasCompressed = true
+        };
+    }
+
+    /// <summary>
+    /// Clips the text at the last sentence-ending punctuation before the target
+    /// character limit, then appends an omission notice. The target is set at
+    /// 60% of the full token budget (~4 chars/token) to leave room for the omission
+    /// marker and to avoid re-triggering LLM fallback in common cases.
+    /// </summary>
+    private static string TruncateAtSentenceBoundary(string text, int tokenThreshold)
+    {
+        const double targetFactor = 0.6;
+        const int charsPerToken = 4;
+        var targetChars = (int)(tokenThreshold * charsPerToken * targetFactor);
+
+        if (text.Length <= targetChars)
+            return text;
+
+        var lastEnd = 0;
+        for (var i = 0; i < text.Length && i < targetChars; i++)
+        {
+            if (i + 2 <= text.Length)
+            {
+                var twoChar = text.Substring(i, 2);
+                if (twoChar is ". " or "! " or "? " or ".\n" or "!\n" or "?\n")
+                    lastEnd = i + 2;
+            }
+        }
+
+        if (lastEnd == 0)
+            lastEnd = Math.Min(targetChars, text.Length);
+
+        return text[..lastEnd] + "[... remainder omitted]";
+    }
+
+    private async Task<string?> SummarizeWithLlmAsync(
+        string input, int tokenThreshold, CancellationToken cancellationToken)
+    {
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        cts.CancelAfter(TimeSpan.FromSeconds(_config.LlmFallbackTimeoutSeconds));
+
+        var decision = await _modelRouter.RouteOperationAsync(
+            _config.LlmRoutingOperation, cts.Token);
+
+        var prompt = $"Summarize this tool output in under {tokenThreshold} tokens. " +
+                     "Preserve actionable information, specific values, and error details. " +
+                     "Omit boilerplate.\n\n" + input;
+
+        var response = await decision.Client.GetResponseAsync(prompt, cancellationToken: cts.Token);
+        return response.Text;
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Compression/Strategies/JsonCompressionStrategy.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Compression/Strategies/JsonCompressionStrategy.cs
@@ -1,0 +1,180 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Application.AI.Common.Helpers;
+using Application.AI.Common.Interfaces.Compression;
+using Domain.AI.Compression.Enums;
+using Domain.AI.Compression.Models;
+
+namespace Infrastructure.AI.Compression.Strategies;
+
+/// <summary>
+/// Compresses JSON output by truncating large arrays, pruning deep nesting,
+/// and removing low-signal keys. Returns <c>WasCompressed = false</c> on
+/// parse failure to signal fallthrough to the next strategy.
+/// </summary>
+/// <remarks>
+/// Three-pass compression pipeline:
+/// <list type="number">
+///   <item><description>Array truncation — arrays &gt;10 elements become first 3 + last 2 with omission count.</description></item>
+///   <item><description>Depth pruning — objects nested beyond depth 4 are replaced with a summary placeholder.</description></item>
+///   <item><description>Low-signal key removal — metadata, pagination, and link fields are stripped when still over budget.</description></item>
+/// </list>
+/// On JSON parse failure the strategy returns <c>WasCompressed = false</c> so the
+/// compressor falls through to the next registered strategy.
+/// </remarks>
+public sealed class JsonCompressionStrategy : ICompressionStrategy
+{
+    private const int MaxArrayElements = 10;
+    private const int KeepFirst = 3;
+    private const int KeepLast = 2;
+    private const int MaxDepth = 4;
+
+    private static readonly HashSet<string> LowSignalKeys = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "metadata", "_links", "pagination", "headers", "timestamps",
+        "_metadata", "links", "paging", "cursor"
+    };
+
+    /// <inheritdoc />
+    public bool CanHandle(ToolOutputCategory category) => category == ToolOutputCategory.Json;
+
+    /// <inheritdoc />
+    public Task<CompressionResult> CompressAsync(
+        string output, int tokenThreshold, CancellationToken cancellationToken = default)
+    {
+        var originalTokens = TokenEstimationHelper.EstimateTokens(output);
+
+        if (string.IsNullOrEmpty(output))
+            return Task.FromResult(CompressionResult.Passthrough(output, originalTokens));
+
+        JsonNode? node;
+        try
+        {
+            node = JsonNode.Parse(output);
+        }
+        catch (JsonException)
+        {
+            return Task.FromResult(new CompressionResult
+            {
+                Output = output,
+                OriginalTokens = originalTokens,
+                CompressedTokens = originalTokens,
+                Strategy = "Json",
+                WasCompressed = false
+            });
+        }
+
+        if (node is null)
+            return Task.FromResult(CompressionResult.Passthrough(output, originalTokens));
+
+        // Structural passes always run — they fix depth and array bloat regardless of token budget.
+        // This ensures deeply nested or oversized arrays are always normalized.
+        TruncateArrays(node);
+        PruneDepth(node, 0);
+
+        var afterStructural = node.ToJsonString(new JsonSerializerOptions { WriteIndented = false });
+        var structurallyChanged = afterStructural != output;
+
+        // If still over budget after structural passes, strip low-signal keys.
+        var afterStructuralTokens = TokenEstimationHelper.EstimateTokens(afterStructural);
+        if (afterStructuralTokens > tokenThreshold)
+        {
+            RemoveLowSignalKeys(node);
+            afterStructural = node.ToJsonString(new JsonSerializerOptions { WriteIndented = false });
+            afterStructuralTokens = TokenEstimationHelper.EstimateTokens(afterStructural);
+            structurallyChanged = true;
+        }
+
+        // Passthrough only when the content was never over budget AND no structural changes occurred.
+        if (!structurallyChanged && originalTokens <= tokenThreshold)
+            return Task.FromResult(CompressionResult.Passthrough(output, originalTokens));
+
+        return Task.FromResult(new CompressionResult
+        {
+            Output = afterStructural,
+            OriginalTokens = originalTokens,
+            CompressedTokens = afterStructuralTokens,
+            Strategy = "Json",
+            WasCompressed = true
+        });
+    }
+
+    private static void TruncateArrays(JsonNode node)
+    {
+        switch (node)
+        {
+            case JsonArray array when array.Count > MaxArrayElements:
+            {
+                var omitted = array.Count - KeepFirst - KeepLast;
+                var kept = new List<JsonNode?>();
+                for (var i = 0; i < KeepFirst && i < array.Count; i++)
+                    kept.Add(array[i]?.DeepClone());
+                kept.Add(JsonValue.Create($"... ({omitted} items omitted)"));
+                for (var i = array.Count - KeepLast; i < array.Count; i++)
+                    kept.Add(array[i]?.DeepClone());
+
+                array.Clear();
+                foreach (var item in kept)
+                    array.Add(item);
+                break;
+            }
+            case JsonArray array:
+            {
+                foreach (var item in array)
+                    if (item is not null) TruncateArrays(item);
+                break;
+            }
+            case JsonObject obj:
+            {
+                foreach (var (_, value) in obj)
+                    if (value is not null) TruncateArrays(value);
+                break;
+            }
+        }
+    }
+
+    private static void PruneDepth(JsonNode node, int depth)
+    {
+        if (node is not JsonObject obj) return;
+
+        var toPrune = new List<string>();
+        foreach (var (key, value) in obj)
+        {
+            if (value is JsonObject child)
+            {
+                if (depth >= MaxDepth)
+                    toPrune.Add(key);
+                else
+                    PruneDepth(child, depth + 1);
+            }
+            else if (value is JsonArray arr)
+            {
+                foreach (var item in arr)
+                    if (item is not null) PruneDepth(item, depth + 1);
+            }
+        }
+
+        foreach (var key in toPrune)
+        {
+            var child = obj[key] as JsonObject;
+            var keyCount = child?.Count ?? 0;
+            obj[key] = JsonValue.Create($"[nested object with {keyCount} keys]");
+        }
+    }
+
+    private static void RemoveLowSignalKeys(JsonNode node)
+    {
+        if (node is not JsonObject obj) return;
+
+        var toRemove = obj
+            .Where(kv => LowSignalKeys.Contains(kv.Key))
+            .Select(kv => kv.Key)
+            .ToList();
+
+        foreach (var key in toRemove)
+            obj.Remove(key);
+
+        foreach (var (_, value) in obj)
+            if (value is not null) RemoveLowSignalKeys(value);
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Compression/Strategies/StructuredTextCompressionStrategy.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Compression/Strategies/StructuredTextCompressionStrategy.cs
@@ -1,0 +1,117 @@
+using Application.AI.Common.Helpers;
+using Application.AI.Common.Interfaces.Compression;
+using Domain.AI.Compression.Enums;
+using Domain.AI.Compression.Models;
+
+namespace Infrastructure.AI.Compression.Strategies;
+
+/// <summary>
+/// Compresses structured text (file content, search results, tabular data)
+/// by deduplicating repeated lines and preserving head/tail with a summary
+/// of omitted content.
+/// </summary>
+/// <remarks>
+/// Two-pass compression pipeline:
+/// <list type="number">
+///   <item><description>Deduplication — consecutive identical lines are collapsed into a count marker.</description></item>
+///   <item><description>Head/tail preservation — when still over budget after dedup, keeps first 40
+///   and last 10 lines with an omission summary in between.</description></item>
+/// </list>
+/// Returns <c>WasCompressed = false</c> when the original is already within the token threshold.
+/// </remarks>
+public sealed class StructuredTextCompressionStrategy : ICompressionStrategy
+{
+    private const int DefaultHeadLines = 40;
+    private const int DefaultTailLines = 10;
+
+    /// <inheritdoc />
+    public bool CanHandle(ToolOutputCategory category) =>
+        category is ToolOutputCategory.FileContent
+            or ToolOutputCategory.SearchResults
+            or ToolOutputCategory.Tabular;
+
+    /// <inheritdoc />
+    public Task<CompressionResult> CompressAsync(
+        string output, int tokenThreshold, CancellationToken cancellationToken = default)
+    {
+        var originalTokens = TokenEstimationHelper.EstimateTokens(output);
+
+        if (string.IsNullOrEmpty(output) || originalTokens <= tokenThreshold)
+            return Task.FromResult(CompressionResult.Passthrough(output, originalTokens));
+
+        var lines = output.Split('\n');
+
+        var deduplicated = DeduplicateLines(lines);
+        var deduplicatedText = string.Join('\n', deduplicated);
+        var deduplicatedTokens = TokenEstimationHelper.EstimateTokens(deduplicatedText);
+
+        if (deduplicatedTokens <= tokenThreshold)
+        {
+            return Task.FromResult(new CompressionResult
+            {
+                Output = deduplicatedText,
+                OriginalTokens = originalTokens,
+                CompressedTokens = deduplicatedTokens,
+                Strategy = "StructuredText",
+                WasCompressed = true
+            });
+        }
+
+        var headTail = HeadTailPreserve(deduplicated, DefaultHeadLines, DefaultTailLines);
+        var compressed = string.Join('\n', headTail);
+        var compressedTokens = TokenEstimationHelper.EstimateTokens(compressed);
+
+        return Task.FromResult(new CompressionResult
+        {
+            Output = compressed,
+            OriginalTokens = originalTokens,
+            CompressedTokens = compressedTokens,
+            Strategy = "StructuredText",
+            WasCompressed = true
+        });
+    }
+
+    private static List<string> DeduplicateLines(string[] lines)
+    {
+        var result = new List<string>();
+        var consecutiveCount = 1;
+        string? previousLine = null;
+
+        foreach (var line in lines)
+        {
+            if (line == previousLine)
+            {
+                consecutiveCount++;
+                continue;
+            }
+
+            if (consecutiveCount > 1 && previousLine is not null)
+                result.Add($"[... {consecutiveCount - 1} similar lines omitted]");
+
+            result.Add(line);
+            previousLine = line;
+            consecutiveCount = 1;
+        }
+
+        if (consecutiveCount > 1)
+            result.Add($"[... {consecutiveCount - 1} similar lines omitted]");
+
+        return result;
+    }
+
+    private static List<string> HeadTailPreserve(List<string> lines, int headCount, int tailCount)
+    {
+        if (lines.Count <= headCount + tailCount)
+            return lines;
+
+        var result = new List<string>();
+        result.AddRange(lines.Take(headCount));
+
+        var omitted = lines.Count - headCount - tailCount;
+        result.Add($"[... {omitted} lines omitted]");
+
+        result.AddRange(lines.Skip(lines.Count - tailCount));
+
+        return result;
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Compression/ToolOutputCompressor.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Compression/ToolOutputCompressor.cs
@@ -1,0 +1,97 @@
+using Application.AI.Common.Helpers;
+using Application.AI.Common.Interfaces.Compression;
+using Domain.AI.Compression.Enums;
+using Domain.AI.Compression.Models;
+using Microsoft.Extensions.Logging;
+
+namespace Infrastructure.AI.Compression;
+
+/// <summary>
+/// Orchestrates tool output compression by dispatching to category-matched
+/// strategies with fallback to FreeText and hard truncation as last resort.
+/// </summary>
+/// <remarks>
+/// When the <paramref name="category"/> passed to <see cref="CompressAsync"/> is null,
+/// the compressor calls <see cref="ContentTypeDetector.Detect"/> to infer the category
+/// from the output content. This keeps the Application layer free of Infrastructure dependencies.
+/// </remarks>
+public sealed class ToolOutputCompressor : IToolOutputCompressor
+{
+    private readonly IReadOnlyList<ICompressionStrategy> _strategies;
+    private readonly ILogger<ToolOutputCompressor> _logger;
+
+    /// <summary>
+    /// Initialises a new instance of <see cref="ToolOutputCompressor"/>.
+    /// </summary>
+    /// <param name="strategies">All registered compression strategies, resolved in priority order.</param>
+    /// <param name="logger">Logger for strategy failure diagnostics.</param>
+    public ToolOutputCompressor(
+        IEnumerable<ICompressionStrategy> strategies,
+        ILogger<ToolOutputCompressor> logger)
+    {
+        _strategies = strategies.ToList();
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<CompressionResult> CompressAsync(
+        string output,
+        ToolOutputCategory? category,
+        int tokenThreshold,
+        CancellationToken cancellationToken = default)
+    {
+        var originalTokens = TokenEstimationHelper.EstimateTokens(output);
+
+        if (string.IsNullOrEmpty(output) || originalTokens <= tokenThreshold)
+            return CompressionResult.Passthrough(output, originalTokens);
+
+        var resolvedCategory = category ?? ContentTypeDetector.Detect(output);
+
+        var matched = _strategies.FirstOrDefault(s => s.CanHandle(resolvedCategory));
+
+        if (matched is not null)
+        {
+            try
+            {
+                var result = await matched.CompressAsync(output, tokenThreshold, cancellationToken);
+                if (result.WasCompressed)
+                    return result;
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                _logger.LogWarning(ex,
+                    "Strategy {Strategy} failed for category {Category}, falling back",
+                    matched.GetType().Name, resolvedCategory);
+            }
+        }
+
+        if (resolvedCategory != ToolOutputCategory.FreeText)
+        {
+            var freeTextStrategy = _strategies.FirstOrDefault(s => s.CanHandle(ToolOutputCategory.FreeText));
+            if (freeTextStrategy is not null)
+            {
+                try
+                {
+                    var fallbackResult = await freeTextStrategy.CompressAsync(
+                        output, tokenThreshold, cancellationToken);
+                    if (fallbackResult.WasCompressed)
+                        return fallbackResult;
+                }
+                catch (Exception ex) when (ex is not OperationCanceledException)
+                {
+                    _logger.LogWarning(ex, "FreeText fallback strategy also failed, hard truncating");
+                }
+            }
+        }
+
+        var truncated = TokenEstimationHelper.TruncateToTokenBudget(output, tokenThreshold);
+        return new CompressionResult
+        {
+            Output = truncated,
+            OriginalTokens = originalTokens,
+            CompressedTokens = TokenEstimationHelper.EstimateTokens(truncated),
+            Strategy = "HardTruncate",
+            WasCompressed = true
+        };
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.cs
@@ -1,5 +1,6 @@
 using Application.AI.Common.Interfaces;
 using Application.AI.Common.Interfaces.Agent;
+using Application.AI.Common.Interfaces.Compression;
 using Application.AI.Common.Interfaces.Agents;
 using Application.AI.Common.Interfaces.Compaction;
 using Application.AI.Common.Interfaces.Config;
@@ -17,6 +18,8 @@ using Infrastructure.AI.Agents;
 using Infrastructure.AI.Audit;
 using Infrastructure.AI.Compaction;
 using Infrastructure.AI.Compaction.Strategies;
+using Infrastructure.AI.Compression;
+using Infrastructure.AI.Compression.Strategies;
 using Infrastructure.AI.Config;
 using Infrastructure.AI.ContentSafety;
 using Infrastructure.AI.Factories;
@@ -224,6 +227,14 @@ public static partial class DependencyInjection
         services.AddSingleton<IEscalationTracker, EscalationTracker>();
         services.AddSingleton<ITaskComplexityClassifier, TaskComplexityClassifier>();
         services.AddSingleton<IModelRouter, ModelRouter>();
+
+        // --- Tool output compression ---
+
+        services.AddSingleton(Options.Create(appConfig.AI.ToolOutputCompression));
+        services.AddTransient<ICompressionStrategy, JsonCompressionStrategy>();
+        services.AddTransient<ICompressionStrategy, StructuredTextCompressionStrategy>();
+        services.AddTransient<ICompressionStrategy, FreeTextCompressionStrategy>();
+        services.AddTransient<IToolOutputCompressor, ToolOutputCompressor>();
 
         return services;
     }

--- a/src/Content/Tests/Application.AI.Common.Tests/DependencyInjectionTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/DependencyInjectionTests.cs
@@ -80,7 +80,7 @@ public class DependencyInjectionTests
     }
 
     [Fact]
-    public void AddApplicationAIDependencies_RegistersTenPipelineBehaviors()
+    public void AddApplicationAIDependencies_RegistersElevenPipelineBehaviors()
     {
         var services = CreateServicesWithAIDependencies();
 
@@ -89,7 +89,7 @@ public class DependencyInjectionTests
                         d.ServiceType.GetGenericTypeDefinition() == typeof(MediatR.IPipelineBehavior<,>))
             .ToList();
 
-        behaviors.Should().HaveCount(10);
+        behaviors.Should().HaveCount(11);
         behaviors.Should().OnlyContain(d => d.Lifetime == ServiceLifetime.Transient);
     }
 

--- a/src/Content/Tests/Application.AI.Common.Tests/MediatRBehaviors/ToolOutputCompressionBehaviorTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/MediatRBehaviors/ToolOutputCompressionBehaviorTests.cs
@@ -1,0 +1,208 @@
+using Application.AI.Common.Interfaces.Agent;
+using Application.AI.Common.Interfaces.Compression;
+using Application.AI.Common.Interfaces.Context;
+using Application.AI.Common.Interfaces.MediatR;
+using Application.AI.Common.MediatRBehaviors;
+using Domain.AI.Compression.Enums;
+using Domain.AI.Compression.Models;
+using Domain.AI.Context;
+using Domain.Common;
+using Domain.Common.Config.AI;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Application.AI.Common.Tests.MediatRBehaviors;
+
+public sealed class ToolOutputCompressionBehaviorTests
+{
+    private readonly Mock<IToolOutputCompressor> _compressor = new();
+    private readonly Mock<IToolResultStore> _resultStore = new();
+    private readonly Mock<IAgentExecutionContext> _executionContext = new();
+    private readonly Mock<ILogger<ToolOutputCompressionBehavior<ToolTestRequest, Result<ToolTestResponse>>>> _logger = new();
+    private readonly ToolOutputCompressionConfig _config = new()
+    {
+        Enabled = true,
+        DefaultTokenThreshold = 2000
+    };
+
+    private ToolOutputCompressionBehavior<ToolTestRequest, Result<ToolTestResponse>> CreateBehavior(
+        ToolOutputCompressionConfig? config = null)
+    {
+        var options = Options.Create(config ?? _config);
+        _executionContext.Setup(x => x.ConversationId).Returns("session-1");
+        return new ToolOutputCompressionBehavior<ToolTestRequest, Result<ToolTestResponse>>(
+            _compressor.Object,
+            _resultStore.Object,
+            _executionContext.Object,
+            options,
+            _logger.Object);
+    }
+
+    [Fact]
+    public async Task Handle_NonToolRequest_PassesThrough()
+    {
+        var behavior = new ToolOutputCompressionBehavior<NonToolRequest, string>(
+            _compressor.Object,
+            _resultStore.Object,
+            _executionContext.Object,
+            Options.Create(_config),
+            Mock.Of<ILogger<ToolOutputCompressionBehavior<NonToolRequest, string>>>());
+
+        var result = await behavior.Handle(
+            new NonToolRequest(),
+            () => Task.FromResult("passthrough"),
+            CancellationToken.None);
+
+        Assert.Equal("passthrough", result);
+        _compressor.Verify(
+            x => x.CompressAsync(It.IsAny<string>(), It.IsAny<ToolOutputCategory?>(), It.IsAny<int>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_BelowThreshold_PassesThrough()
+    {
+        var output = new ToolTestResponse("short output");
+        var behavior = CreateBehavior();
+
+        var result = await behavior.Handle(
+            new ToolTestRequest("test_tool"),
+            () => Task.FromResult(Result<ToolTestResponse>.Success(output)),
+            CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal("short output", result.Value!.ToolOutput);
+        _compressor.Verify(
+            x => x.CompressAsync(It.IsAny<string>(), It.IsAny<ToolOutputCategory?>(), It.IsAny<int>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_AboveThreshold_CompressesAndStoresReference()
+    {
+        // Generate output that exceeds 2000 tokens (~8000 chars)
+        var largeOutput = new string('x', 9000);
+        var output = new ToolTestResponse(largeOutput);
+        var behavior = CreateBehavior();
+
+        var reference = new ToolResultReference
+        {
+            ResultId = "ref-123",
+            ToolName = "test_tool",
+            PreviewContent = "preview...",
+            SizeChars = 9000,
+            Timestamp = DateTimeOffset.UtcNow
+        };
+
+        _resultStore.Setup(x => x.StoreIfLargeAsync("session-1", "test_tool", null, largeOutput, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(reference);
+
+        _compressor.Setup(x => x.CompressAsync(largeOutput, null, 2000, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new CompressionResult
+            {
+                Output = "compressed summary",
+                OriginalTokens = 2250,
+                CompressedTokens = 5,
+                Strategy = "Json",
+                WasCompressed = true
+            });
+
+        var result = await behavior.Handle(
+            new ToolTestRequest("test_tool"),
+            () => Task.FromResult(Result<ToolTestResponse>.Success(output)),
+            CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Contains("compressed summary", result.Value!.ToolOutput);
+        Assert.Contains("[Full output: result://ref-123]", result.Value!.ToolOutput);
+
+        _resultStore.Verify(
+            x => x.StoreIfLargeAsync("session-1", "test_tool", null, largeOutput, It.IsAny<CancellationToken>()),
+            Times.Once);
+        _compressor.Verify(
+            x => x.CompressAsync(largeOutput, null, 2000, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_DisabledConfig_PassesThrough()
+    {
+        var output = new ToolTestResponse(new string('x', 9000));
+        var behavior = CreateBehavior(new ToolOutputCompressionConfig { Enabled = false });
+
+        var result = await behavior.Handle(
+            new ToolTestRequest("test_tool"),
+            () => Task.FromResult(Result<ToolTestResponse>.Success(output)),
+            CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(output.ToolOutput, result.Value!.ToolOutput);
+        _compressor.Verify(
+            x => x.CompressAsync(It.IsAny<string>(), It.IsAny<ToolOutputCategory?>(), It.IsAny<int>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_CompressorThrows_ReturnsOriginalWithWarning()
+    {
+        var largeOutput = new string('x', 9000);
+        var output = new ToolTestResponse(largeOutput);
+        var behavior = CreateBehavior();
+
+        var reference = new ToolResultReference
+        {
+            ResultId = "ref-456",
+            ToolName = "test_tool",
+            PreviewContent = "preview...",
+            SizeChars = 9000,
+            Timestamp = DateTimeOffset.UtcNow
+        };
+
+        _resultStore.Setup(x => x.StoreIfLargeAsync("session-1", "test_tool", null, largeOutput, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(reference);
+
+        _compressor.Setup(x => x.CompressAsync(largeOutput, null, 2000, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("Compressor exploded"));
+
+        var result = await behavior.Handle(
+            new ToolTestRequest("test_tool"),
+            () => Task.FromResult(Result<ToolTestResponse>.Success(output)),
+            CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(largeOutput, result.Value!.ToolOutput);
+    }
+
+    [Fact]
+    public async Task Handle_NullToolOutput_PassesThrough()
+    {
+        var output = new ToolTestResponse(null!);
+        var behavior = CreateBehavior();
+
+        var result = await behavior.Handle(
+            new ToolTestRequest("test_tool"),
+            () => Task.FromResult(Result<ToolTestResponse>.Success(output)),
+            CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Null(result.Value!.ToolOutput);
+        _compressor.Verify(
+            x => x.CompressAsync(It.IsAny<string>(), It.IsAny<ToolOutputCategory?>(), It.IsAny<int>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    // --- Test records (public required for Moq's Castle proxy on ILogger<T> generic args) ---
+
+    public sealed record NonToolRequest : IRequest<string>;
+
+    public sealed record ToolTestRequest(string ToolName) : IRequest<ToolTestResponse>, IToolRequest;
+
+    public sealed record ToolTestResponse(string ToolOutput) : IToolResponse
+    {
+        public IToolResponse WithSanitizedOutput(string sanitizedOutput) =>
+            new ToolTestResponse(sanitizedOutput);
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Compression/ContentTypeDetectorTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Compression/ContentTypeDetectorTests.cs
@@ -1,0 +1,65 @@
+using Domain.AI.Compression.Enums;
+using FluentAssertions;
+using Infrastructure.AI.Compression;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Compression;
+
+public sealed class ContentTypeDetectorTests
+{
+    [Fact]
+    public void Detect_ValidJsonObject_ReturnsJson()
+    {
+        var input = """{"name": "test", "value": 42}""";
+        ContentTypeDetector.Detect(input).Should().Be(ToolOutputCategory.Json);
+    }
+
+    [Fact]
+    public void Detect_ValidJsonArray_ReturnsJson()
+    {
+        var input = """[{"id": 1}, {"id": 2}]""";
+        ContentTypeDetector.Detect(input).Should().Be(ToolOutputCategory.Json);
+    }
+
+    [Fact]
+    public void Detect_FilePathsWithLineNumbers_ReturnsFileContent()
+    {
+        var input = """
+            src/Program.cs:10: public static void Main()
+            src/Program.cs:11: {
+            src/Program.cs:12:     Console.WriteLine("Hello");
+            src/Program.cs:13: }
+            """;
+        ContentTypeDetector.Detect(input).Should().Be(ToolOutputCategory.FileContent);
+    }
+
+    [Fact]
+    public void Detect_TabDelimitedRows_ReturnsTabular()
+    {
+        var input = "Name\tAge\tCity\nAlice\t30\tSeattle\nBob\t25\tPortland\nCharlie\t35\tDenver\n";
+        ContentTypeDetector.Detect(input).Should().Be(ToolOutputCategory.Tabular);
+    }
+
+    [Fact]
+    public void Detect_RepeatedStructuredLines_ReturnsSearchResults()
+    {
+        var lines = string.Join('\n', Enumerable.Range(1, 20)
+            .Select(i => $"Result {i}: Found match in file{i}.cs at line {i * 10}"));
+        ContentTypeDetector.Detect(lines).Should().Be(ToolOutputCategory.SearchResults);
+    }
+
+    [Fact]
+    public void Detect_PlainProse_ReturnsFreeText()
+    {
+        var input = "The quick brown fox jumps over the lazy dog. This is a paragraph of unstructured text that doesn't match any pattern.";
+        ContentTypeDetector.Detect(input).Should().Be(ToolOutputCategory.FreeText);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(null)]
+    public void Detect_EmptyOrNull_ReturnsFreeText(string? input)
+    {
+        ContentTypeDetector.Detect(input!).Should().Be(ToolOutputCategory.FreeText);
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Compression/Strategies/FreeTextCompressionStrategyTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Compression/Strategies/FreeTextCompressionStrategyTests.cs
@@ -1,0 +1,168 @@
+// src/Content/Tests/Infrastructure.AI.Tests/Compression/Strategies/FreeTextCompressionStrategyTests.cs
+using Application.AI.Common.Interfaces.Routing;
+using Domain.AI.Compression.Enums;
+using Domain.AI.Routing.Enums;
+using Domain.AI.Routing.Models;
+using Domain.Common.Config.AI;
+using FluentAssertions;
+using Infrastructure.AI.Compression.Strategies;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Compression.Strategies;
+
+public sealed class FreeTextCompressionStrategyTests
+{
+    private readonly Mock<IModelRouter> _mockRouter = new();
+    private readonly ToolOutputCompressionConfig _config = new() { LlmFallbackEnabled = true, LlmFallbackTimeoutSeconds = 5 };
+
+    private FreeTextCompressionStrategy CreateSut() => new(
+        _mockRouter.Object,
+        Options.Create(_config),
+        Mock.Of<ILogger<FreeTextCompressionStrategy>>());
+
+    [Fact]
+    public void CanHandle_FreeText_ReturnsTrue()
+    {
+        CreateSut().CanHandle(ToolOutputCategory.FreeText).Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData(ToolOutputCategory.Json)]
+    [InlineData(ToolOutputCategory.FileContent)]
+    [InlineData(ToolOutputCategory.SearchResults)]
+    [InlineData(ToolOutputCategory.Tabular)]
+    public void CanHandle_NonFreeText_ReturnsFalse(ToolOutputCategory category)
+    {
+        CreateSut().CanHandle(category).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task CompressAsync_LongProse_TruncatesAtSentenceBoundary()
+    {
+        var sentences = Enumerable.Range(1, 200)
+            .Select(i => $"This is sentence number {i} with some additional words to make it longer.");
+        var input = string.Join(' ', sentences);
+
+        var result = await CreateSut().CompressAsync(input, 100);
+
+        result.WasCompressed.Should().BeTrue();
+        result.Output.Should().EndWith("[... remainder omitted]");
+        result.CompressedTokens.Should().BeLessThanOrEqualTo(100);
+    }
+
+    [Fact]
+    public async Task CompressAsync_ShortText_ReturnsPassthrough()
+    {
+        var input = "Short text.";
+
+        var result = await CreateSut().CompressAsync(input, 100);
+
+        result.WasCompressed.Should().BeFalse();
+        result.Output.Should().Be(input);
+    }
+
+    [Fact]
+    public async Task CompressAsync_EmptyString_ReturnsPassthrough()
+    {
+        var result = await CreateSut().CompressAsync(string.Empty, 100);
+
+        result.WasCompressed.Should().BeFalse();
+        result.Output.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task CompressAsync_LlmFallbackDisabled_HardTruncatesOnly()
+    {
+        _config.LlmFallbackEnabled = false;
+        var input = string.Join(' ', Enumerable.Repeat("word", 5000));
+
+        // threshold=5 forces sentence truncation to still exceed budget (suffix alone > threshold),
+        // which is the only path that can reach LLM fallback. With LLM disabled, hard truncation runs.
+        var result = await CreateSut().CompressAsync(input, 5);
+
+        result.WasCompressed.Should().BeTrue();
+        _mockRouter.Verify(
+            r => r.RouteOperationAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task CompressAsync_LlmThrows_FallsBackToHardTruncation()
+    {
+        _mockRouter
+            .Setup(r => r.RouteOperationAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("LLM unavailable"));
+
+        var input = string.Join(' ', Enumerable.Repeat("word", 5000));
+
+        // threshold=5 ensures sentence truncation still exceeds budget, triggering LLM path.
+        var result = await CreateSut().CompressAsync(input, 5);
+
+        result.WasCompressed.Should().BeTrue();
+        result.Strategy.Should().Be("HardTruncate");
+    }
+
+    [Fact]
+    public async Task CompressAsync_LlmSucceeds_ReturnsLlmResult()
+    {
+        var mockClient = new Mock<IChatClient>();
+        mockClient
+            .Setup(c => c.GetResponseAsync(
+                It.IsAny<IEnumerable<ChatMessage>>(),
+                It.IsAny<ChatOptions?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ChatResponse([new ChatMessage(ChatRole.Assistant, "Summarized output.")])
+            {
+                FinishReason = ChatFinishReason.Stop
+            });
+
+        var economyTier = new ModelTier
+        {
+            Name = "economy",
+            ClientType = AIAgentFrameworkClientType.AzureOpenAI,
+            DeploymentName = "gpt-4o-mini"
+        };
+
+        var mockDecision = new ModelRoutingDecision
+        {
+            SelectedTier = economyTier,
+            Client = mockClient.Object,
+            Complexity = TaskComplexity.Simple,
+            Source = ClassificationSource.Heuristic,
+            Confidence = 0.9
+        };
+
+        _mockRouter
+            .Setup(r => r.RouteOperationAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(mockDecision);
+
+        var input = string.Join(' ', Enumerable.Repeat("word", 5000));
+
+        // threshold=5 ensures sentence truncation still exceeds budget, reaching the LLM path.
+        var result = await CreateSut().CompressAsync(input, 5);
+
+        result.WasCompressed.Should().BeTrue();
+        result.Strategy.Should().Be("LlmFallback");
+        result.Output.Should().Be("Summarized output.");
+    }
+
+    [Fact]
+    public async Task CompressAsync_SentenceTruncationFitsThreshold_UsesFreeTextStrategy()
+    {
+        // Build input where sentence-boundary truncation will fit in the threshold.
+        // 20 short sentences. At threshold=100 tokens (~400 chars), a few sentences will fit.
+        var sentences = Enumerable.Range(1, 20)
+            .Select(i => $"Sentence {i}.");
+        var input = string.Join(' ', sentences);
+
+        var result = await CreateSut().CompressAsync(input, 100);
+
+        // If compressed, should use FreeText strategy (not HardTruncate or LlmFallback)
+        if (result.WasCompressed)
+            result.Strategy.Should().Be("FreeText");
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Compression/Strategies/JsonCompressionStrategyTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Compression/Strategies/JsonCompressionStrategyTests.cs
@@ -1,0 +1,86 @@
+using Domain.AI.Compression.Enums;
+using FluentAssertions;
+using Infrastructure.AI.Compression.Strategies;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Compression.Strategies;
+
+public sealed class JsonCompressionStrategyTests
+{
+    private readonly JsonCompressionStrategy _sut = new();
+
+    [Fact]
+    public void CanHandle_Json_ReturnsTrue()
+    {
+        _sut.CanHandle(ToolOutputCategory.Json).Should().BeTrue();
+    }
+
+    [Fact]
+    public void CanHandle_FreeText_ReturnsFalse()
+    {
+        _sut.CanHandle(ToolOutputCategory.FreeText).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task CompressAsync_LargeArray_TruncatesWithCount()
+    {
+        var items = Enumerable.Range(1, 20).Select(i => new { id = i, name = $"item{i}" });
+        var json = System.Text.Json.JsonSerializer.Serialize(items);
+
+        var result = await _sut.CompressAsync(json, 50);
+
+        result.WasCompressed.Should().BeTrue();
+        result.Output.Should().Contain("items omitted");
+        result.CompressedTokens.Should().BeLessThan(result.OriginalTokens);
+    }
+
+    [Fact]
+    public async Task CompressAsync_DeeplyNested_PrunesAtDepth4()
+    {
+        var json = """{"a":{"b":{"c":{"d":{"e":{"f":"deep"}}}}}}""";
+
+        var result = await _sut.CompressAsync(json, 20);
+
+        result.WasCompressed.Should().BeTrue();
+        result.Output.Should().Contain("nested object");
+    }
+
+    [Fact]
+    public async Task CompressAsync_SmallJson_ReturnsPassthrough()
+    {
+        var json = """{"name":"test"}""";
+
+        var result = await _sut.CompressAsync(json, 100);
+
+        result.WasCompressed.Should().BeFalse();
+        result.Output.Should().Be(json);
+    }
+
+    [Fact]
+    public async Task CompressAsync_InvalidJson_ReturnsFalseWasCompressed()
+    {
+        var result = await _sut.CompressAsync("not json {{{", 50);
+
+        result.WasCompressed.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task CompressAsync_EmptyString_ReturnsPassthrough()
+    {
+        var result = await _sut.CompressAsync("", 100);
+
+        result.WasCompressed.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task CompressAsync_LowSignalKeys_RemovedWhenOverBudget()
+    {
+        var json = """{"data":"important","_links":{"self":"http://example.com"},"metadata":{"created":"2024-01-01"},"pagination":{"page":1,"total":100}}""";
+
+        var result = await _sut.CompressAsync(json, 15);
+
+        result.WasCompressed.Should().BeTrue();
+        result.Output.Should().Contain("important");
+        result.Output.Should().NotContain("_links");
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Compression/Strategies/StructuredTextCompressionStrategyTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Compression/Strategies/StructuredTextCompressionStrategyTests.cs
@@ -1,0 +1,66 @@
+using Domain.AI.Compression.Enums;
+using FluentAssertions;
+using Infrastructure.AI.Compression.Strategies;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Compression.Strategies;
+
+public sealed class StructuredTextCompressionStrategyTests
+{
+    private readonly StructuredTextCompressionStrategy _sut = new();
+
+    [Fact]
+    public void CanHandle_FileContent_ReturnsTrue()
+    {
+        _sut.CanHandle(ToolOutputCategory.FileContent).Should().BeTrue();
+    }
+
+    [Fact]
+    public void CanHandle_SearchResults_ReturnsTrue()
+    {
+        _sut.CanHandle(ToolOutputCategory.SearchResults).Should().BeTrue();
+    }
+
+    [Fact]
+    public void CanHandle_Tabular_ReturnsTrue()
+    {
+        _sut.CanHandle(ToolOutputCategory.Tabular).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task CompressAsync_DuplicateLines_DeduplicatesWithCount()
+    {
+        var lines = string.Join('\n', Enumerable.Repeat("ERROR: Connection refused", 500));
+
+        var result = await _sut.CompressAsync(lines, 50);
+
+        result.WasCompressed.Should().BeTrue();
+        result.Output.Should().Contain("similar lines omitted");
+        result.CompressedTokens.Should().BeLessThan(result.OriginalTokens);
+    }
+
+    [Fact]
+    public async Task CompressAsync_LongFile_PreservesHeadAndTail()
+    {
+        var lines = Enumerable.Range(1, 400).Select(i => $"Line {i}: content here").ToArray();
+        var input = string.Join('\n', lines);
+
+        var result = await _sut.CompressAsync(input, 100);
+
+        result.WasCompressed.Should().BeTrue();
+        result.Output.Should().Contain("Line 1:");
+        result.Output.Should().Contain("Line 400:");
+        result.Output.Should().Contain("lines omitted");
+    }
+
+    [Fact]
+    public async Task CompressAsync_ShortOutput_ReturnsPassthrough()
+    {
+        var input = "Line 1\nLine 2\nLine 3";
+
+        var result = await _sut.CompressAsync(input, 100);
+
+        result.WasCompressed.Should().BeFalse();
+        result.Output.Should().Be(input);
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Compression/ToolOutputCompressorTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Compression/ToolOutputCompressorTests.cs
@@ -1,0 +1,123 @@
+using Application.AI.Common.Interfaces.Compression;
+using Domain.AI.Compression.Enums;
+using Domain.AI.Compression.Models;
+using FluentAssertions;
+using Infrastructure.AI.Compression;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Compression;
+
+public sealed class ToolOutputCompressorTests
+{
+    private readonly Mock<ICompressionStrategy> _mockJsonStrategy = new();
+    private readonly Mock<ICompressionStrategy> _mockFreeTextStrategy = new();
+
+    public ToolOutputCompressorTests()
+    {
+        _mockJsonStrategy.Setup(s => s.CanHandle(ToolOutputCategory.Json)).Returns(true);
+        _mockFreeTextStrategy.Setup(s => s.CanHandle(ToolOutputCategory.FreeText)).Returns(true);
+    }
+
+    private ToolOutputCompressor CreateSut() => new(
+        [_mockJsonStrategy.Object, _mockFreeTextStrategy.Object],
+        Mock.Of<ILogger<ToolOutputCompressor>>());
+
+    [Fact]
+    public async Task CompressAsync_JsonCategory_RoutesToJsonStrategy()
+    {
+        var bigJson = "{" + string.Join(",", Enumerable.Range(0, 100).Select(i => $"\"key{i}\":\"value{i}\"")) + "}";
+        _mockJsonStrategy
+            .Setup(s => s.CompressAsync(It.IsAny<string>(), 100, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new CompressionResult
+            {
+                Output = "compressed", OriginalTokens = 500, CompressedTokens = 50,
+                Strategy = "Json", WasCompressed = true
+            });
+
+        var result = await CreateSut().CompressAsync(bigJson, ToolOutputCategory.Json, 100);
+
+        result.Strategy.Should().Be("Json");
+        _mockJsonStrategy.Verify(s => s.CompressAsync(bigJson, 100, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task CompressAsync_StrategyFails_FallsBackToFreeText()
+    {
+        var largeData = new string('d', 500);
+        _mockJsonStrategy
+            .Setup(s => s.CompressAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new CompressionResult
+            {
+                Output = largeData, OriginalTokens = 500, CompressedTokens = 500,
+                Strategy = "Json", WasCompressed = false
+            });
+
+        _mockFreeTextStrategy
+            .Setup(s => s.CompressAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new CompressionResult
+            {
+                Output = "fallback", OriginalTokens = 500, CompressedTokens = 50,
+                Strategy = "FreeText", WasCompressed = true
+            });
+
+        var result = await CreateSut().CompressAsync(largeData, ToolOutputCategory.Json, 100);
+
+        result.Strategy.Should().Be("FreeText");
+    }
+
+    [Fact]
+    public async Task CompressAsync_StrategyThrows_FallsBackToHardTruncate()
+    {
+        _mockJsonStrategy
+            .Setup(s => s.CompressAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("strategy error"));
+
+        _mockFreeTextStrategy
+            .Setup(s => s.CompressAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("also fails"));
+
+        var result = await CreateSut().CompressAsync(new string('x', 1000), ToolOutputCategory.Json, 50);
+
+        result.WasCompressed.Should().BeTrue();
+        result.Strategy.Should().Be("HardTruncate");
+    }
+
+    [Fact]
+    public async Task CompressAsync_UnknownCategory_FallsBackToFreeText()
+    {
+        var largeData = new string('d', 500);
+        _mockFreeTextStrategy
+            .Setup(s => s.CompressAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new CompressionResult
+            {
+                Output = "compressed", OriginalTokens = 500, CompressedTokens = 50,
+                Strategy = "FreeText", WasCompressed = true
+            });
+
+        var result = await CreateSut().CompressAsync(largeData, (ToolOutputCategory)99, 100);
+
+        result.Strategy.Should().Be("FreeText");
+    }
+
+    [Fact]
+    public async Task CompressAsync_BelowThreshold_ReturnsPassthrough()
+    {
+        var result = await CreateSut().CompressAsync("short", ToolOutputCategory.Json, 100);
+
+        result.WasCompressed.Should().BeFalse();
+        result.Output.Should().Be("short");
+        _mockJsonStrategy.Verify(
+            s => s.CompressAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task CompressAsync_EmptyOutput_ReturnsPassthrough()
+    {
+        var result = await CreateSut().CompressAsync("", ToolOutputCategory.Json, 100);
+
+        result.WasCompressed.Should().BeFalse();
+    }
+}


### PR DESCRIPTION
## Summary

- **MediatR pipeline behavior** (`ToolOutputCompressionBehavior`, position 9) that intercepts large tool outputs post-execution, compresses them via tiered strategies, and stores full output in `IToolResultStore` with a `result://{id}` retrieval reference
- **Three compression strategies** — `JsonCompressionStrategy` (array truncation, depth pruning, low-signal key removal), `StructuredTextCompressionStrategy` (consecutive line dedup, head/tail preserve), `FreeTextCompressionStrategy` (sentence-boundary truncation, optional LLM summarization fallback, hard truncation)
- **Hybrid classification** — tools declare `OutputCategory` via `ITool` property (preferred path); `ContentTypeDetector` sniffs content type when not declared, using regex-based detection for JSON, file content, tabular, and search result patterns
- **Clean Architecture compliance** — Application layer passes `null` category to `IToolOutputCompressor`; Infrastructure's `ToolOutputCompressor` resolves category internally via `ContentTypeDetector.Detect()`
- **Configuration** — `ToolOutputCompressionConfig` POCO with `Enabled`, `DefaultTokenThreshold` (2000), `LlmFallbackEnabled`, `LlmFallbackTimeoutSeconds` (5), `LlmRoutingOperation`

## Architecture

```
Tool Output → ToolOutputCompressionBehavior (MediatR)
                ├── Check: IToolRequest? Enabled? Above threshold?
                ├── Store full output → IToolResultStore
                ├── Compress → IToolOutputCompressor
                │     ├── Resolve category (declared or ContentTypeDetector)
                │     ├── Dispatch to matching ICompressionStrategy
                │     ├── Fallback to FreeText if primary fails
                │     └── Hard truncation as last resort
                └── Replace response content + append result:// reference
```

## Files Changed (22 files, +1,740 lines)

### Domain Layer
- `Domain.AI/Compression/Enums/ToolOutputCategory.cs` — 5-value enum (Json, FileContent, SearchResults, Tabular, FreeText)
- `Domain.AI/Compression/Models/CompressionResult.cs` — Sealed record with `Passthrough` factory
- `Domain.Common/Config/AI/ToolOutputCompressionConfig.cs` — Config POCO
- `Domain.Common/Config/AI/AIConfig.cs` — Added `ToolOutputCompression` property

### Application Layer
- `Application.AI.Common/Interfaces/Compression/ICompressionStrategy.cs` — Strategy interface
- `Application.AI.Common/Interfaces/Compression/IToolOutputCompressor.cs` — Compressor interface (nullable category)
- `Application.AI.Common/Interfaces/Tools/ITool.cs` — Added `OutputCategory` and `CompressionTokenThreshold` default properties
- `Application.AI.Common/MediatRBehaviors/ToolOutputCompressionBehavior.cs` — Pipeline behavior with Result<T> reflection

### Infrastructure Layer
- `Infrastructure.AI/Compression/ContentTypeDetector.cs` — Static regex-based content classifier
- `Infrastructure.AI/Compression/ToolOutputCompressor.cs` — Strategy dispatcher with fallback chain
- `Infrastructure.AI/Compression/Strategies/JsonCompressionStrategy.cs` — JSON structural compression
- `Infrastructure.AI/Compression/Strategies/StructuredTextCompressionStrategy.cs` — Dedup + head/tail
- `Infrastructure.AI/Compression/Strategies/FreeTextCompressionStrategy.cs` — Sentence truncation + LLM fallback

### DI Registration
- `Application.AI.Common/DependencyInjection.cs` — Behavior registration (position 11)
- `Infrastructure.AI/DependencyInjection.cs` — Strategies, compressor, config options

### Tests (46 new tests)
- `ContentTypeDetectorTests.cs` — 8 tests
- `JsonCompressionStrategyTests.cs` — 8 tests
- `StructuredTextCompressionStrategyTests.cs` — 6 tests
- `FreeTextCompressionStrategyTests.cs` — 12 tests
- `ToolOutputCompressorTests.cs` — 6 tests
- `ToolOutputCompressionBehaviorTests.cs` — 6 tests
- `DependencyInjectionTests.cs` — Updated behavior count (10 → 11)

## Test Plan

- [x] `dotnet build src/AgenticHarness.slnx` — 0 errors
- [x] `dotnet test src/AgenticHarness.slnx` — 46 new tests passing, 0 new regressions
- [ ] Verify JSON compression reduces large API responses below token threshold
- [ ] Verify FreeText LLM fallback activates when sentence truncation exceeds budget
- [ ] Verify `ContentTypeDetector` correctly classifies mixed content types
- [ ] Verify `result://` references are appended to compressed output
- [ ] Verify compression is skipped when `Enabled = false`
- [ ] Verify tools with declared `OutputCategory` bypass content detection

🤖 Generated with [Claude Code](https://claude.com/claude-code)