### PR TITLE
feat(memory): tenant-level isolation across all graph backends (task #6 PR 3)

### DIFF
--- a/.claude/plans/task6-pr3-tenant-level-isolation.md
+++ b/.claude/plans/task6-pr3-tenant-level-isolation.md
@@ -4,6 +4,8 @@
 **Date:** 2026-06-05
 **Scope chosen by user:** Option B — fix everything now. Tenant isolation must actually work on all three backends, not just in-memory.
 
+**STATUS: COMPLETE (2026-06-05).** Commits on `feat/task6-tenant-level-isolation`: `34f76e3` (model + default backend), `77355cb` (Neo4j), `aee659a` (Postgres), + docs. All 5 steps done; full suite green incl. 8 Docker-backed Neo4j/Postgres integration tests (179 KG tests total). Verified against real neo4j:5.20 + postgres:16 containers.
+
 ## Why this is bigger than "add a field"
 
 The default backend (`managed_code` → in-memory) is lossless, so PR 2's owner isolation works there. But the opt-in **Neo4j** and **PostgreSQL** backends are incomplete (pre-existing TODOs):

--- a/.claude/plans/task6-pr3-tenant-level-isolation.md
+++ b/.claude/plans/task6-pr3-tenant-level-isolation.md
@@ -1,0 +1,84 @@
+# Task #6 — PR 3: Tenant-Level Isolation (all backends)
+
+**Branch:** `feat/task6-tenant-level-isolation` (stacked on PR 2 / `feat/task6-multitenant-memory-isolation`)
+**Date:** 2026-06-05
+**Scope chosen by user:** Option B — fix everything now. Tenant isolation must actually work on all three backends, not just in-memory.
+
+## Why this is bigger than "add a field"
+
+The default backend (`managed_code` → in-memory) is lossless, so PR 2's owner isolation works there. But the opt-in **Neo4j** and **PostgreSQL** backends are incomplete (pre-existing TODOs):
+- `AddNodesAsync`/`AddEdgesAsync` **drop** `OwnerId`, `CreatedAt`, `ExpiresAt` (Neo4j also drops `Provenance`).
+- `GetAllNodesAsync` and `GetNodesByOwnerAsync` are **stubs returning `[]`**.
+- There is **no schema-creation code** for Postgres (tables assumed to pre-exist).
+- Neither backend has **any tests**.
+
+Consequence: on those backends every node reads back with `OwnerId == null`, so PR 2's decorator treats everything as shared → the owner/tenant filter is a silent no-op, and retention/erase-by-owner don't function. Adding `TenantId` only to the model would inherit the same silent no-op. So PR 3 must complete the backend persistence too.
+
+Verification is feasible: **Docker is available** and Testcontainers is already used (`Presentation.AgentHub.Tests`), so Neo4j/Postgres code can be tested against real containers.
+
+## Design
+
+### Isolation model (the rule every read enforces)
+A record is visible to a caller iff **tenant matches AND owner matches**:
+- **tenantOk** = `node.TenantId is null` (global/shared-across-tenants) OR `validator.ValidateAccess(scope, node.TenantId)` (same tenant).
+- **ownerOk** = `node.OwnerId is null` (shared within the tenant — corpus/learnings) OR `validator.CanAccessDataset(scope, node.OwnerId)` (caller owns it — memory).
+- No ambient scope (background/system) = full access (unchanged).
+
+This yields: a tenant's ingested corpus is shared among that tenant's users but invisible to other tenants; a user's memory is private to them within their tenant; truly global reference data (null tenant) is visible to all.
+
+### 1. Domain model
+- `GraphNode` + `public string? TenantId { get; init; }` (XML: "tenant that owns this node; null = global, visible across all tenants").
+- `GraphEdge` + same.
+
+### 2. Tenant stamping — `ComplianceAwareGraphStore`
+Symmetric with temporal stamping, and the deliberate **opposite** of the owner decision: stamp `TenantId = node.TenantId ?? CurrentTenantId` on `AddNodesAsync`/`AddEdgesAsync` (CurrentTenantId = ambient `scope.TenantId`).
+- Owner is *not* defaulted (null owner = shared within tenant). Tenant *is* defaulted to the writer's tenant, because that is what makes corpus tenant-gated; a write with no tenant context (null ambient = system) stays null = global.
+- Add a `CurrentTenantId` helper mirroring the existing `CurrentUserId`.
+
+### 3. Memory path — `KnowledgeMemoryService`
+`RememberAsync` sets `TenantId = scope.TenantId` on the node explicitly (alongside the existing `OwnerId = scope.UserId`), so memory nodes are self-describing.
+
+### 4. Decorator — `TenantIsolatedGraphStore`
+Change `CanAccess(string? ownerId, scope)` → `CanAccess(string? tenantId, string? ownerId, scope)` implementing tenantOk && ownerOk above. Update every call site (GetNode, GetNeighbors seed + results, GetTriplets endpoints, GetAllNodes, GetNodesByOwner, GetNodeCount, AddNodes/AddEdges write filter, DeleteNode) to pass `n.TenantId, n.OwnerId`. System-scope full-access path unchanged.
+
+### 5. Validator — `KnowledgeScopeValidator`
+Reuse existing `ValidateAccess(scope, targetTenantId)` for the tenant check (already `scope.TenantId == targetTenantId`, denies on either null). Decorator handles the null-tenant=global case before calling it. No new method. Owner check (`CanAccessDataset`) unchanged.
+
+### 6. Backends — round-trip owner/tenant/temporal + implement stub queries
+- **InMemory:** round-trips `TenantId` automatically (full-record storage); `GetAllNodes`/`GetNodesByOwner` already work. No production change; add tenant assertions in tests.
+- **Neo4j:**
+  - `AddNodesAsync` SET: add `owner_id`, `tenant_id`, `created_at` (ISO-8601 string), `expires_at` (ISO-8601 string), `provenance` (JSON). Same for `AddEdgesAsync`.
+  - `MapNode`/`MapEdge`: rehydrate those fields (parse ISO timestamps, deserialize provenance).
+  - Implement `GetAllNodesAsync` (`MATCH (n:Entity) RETURN n`) and `GetNodesByOwnerAsync` (`... WHERE n.owner_id = $ownerId`).
+- **PostgreSQL:**
+  - Add idempotent `EnsureSchemaAsync` (`CREATE TABLE IF NOT EXISTS kg_nodes/kg_edges (... full columns incl owner_id, tenant_id, created_at, expires_at ...)`), invoked once per store (guarded flag) on first connection — makes the backend self-contained.
+  - `AddNodesAsync`/`AddEdgesAsync` INSERT: add the 4 columns + params.
+  - All SELECTs (GetNode, GetNeighbors, GetTriplets): add the 4 columns; update `ReadNode` + triplet reconstruction column indices.
+  - Implement `GetAllNodesAsync` and `GetNodesByOwnerAsync`.
+
+### 7. Tests
+- **Domain:** TenantId on both records (with-expression, default null).
+- **Decorator (in-memory — runs locally):** cross-tenant hidden; same-tenant shared corpus visible; same-tenant other-user memory hidden; null-tenant global visible to all; system full access. Extend `TenantIsolatedGraphStoreTests`.
+- **Compliance:** TenantId stamped from ambient tenant; explicit preserved; null ambient → null tenant.
+- **Neo4j (Testcontainers/Docker):** new `Neo4jGraphStoreTests` — owner/tenant/temporal round-trip, GetAllNodes, GetNodesByOwner. Docker-gated (skip if unavailable).
+- **PostgreSQL (Testcontainers/Docker):** new `PostgreSqlGraphStoreTests` — schema init, round-trip, GetAllNodes, GetNodesByOwner, retention purge of expired.
+
+### 8. Retention / erasure
+With the stub query methods implemented, `RetentionEnforcementService` and `EraseByOwnerAsync` now function on Neo4j/Postgres for free; covered by a Postgres Testcontainers test.
+
+### 9. Docs
+Update `CLAUDE.md` (Multi-Tenant Knowledge Isolation bullet) + the task6 plan: tenant isolation enforced across all 3 backends; corpus is now tenant-gated (drop the "globally shared until PR 3" caveat); backend persistence of owner/tenant/temporal completed; Postgres schema is now self-initializing.
+
+## Phasing (single PR, logical commits)
+1. Domain model (TenantId) + in-memory tests.
+2. Decorator + validator tenant filter + Compliance tenant stamping + memory path + tests (runs locally — proves the model on the default backend).
+3. Neo4j backend completion + Testcontainers tests.
+4. PostgreSQL backend completion (incl. schema init) + Testcontainers tests.
+5. Docs.
+
+Each phase: `dotnet build` + `dotnet test` green before the next. `/code-review` at the end. Verification uses Docker-backed integration tests for the DB backends.
+
+## Risk / verification notes
+- Postgres `GetTripletsAsync` column-index shifts (adding 4 cols × source/target/edge) are fiddly — the Testcontainers test is the guard.
+- Estimated ~20-25 files. Largest blast radius of the three PRs.
+- New test-project dependencies: `Testcontainers.PostgreSql`, `Testcontainers.Neo4j` (mirror the existing Testcontainers usage).

--- a/.claude/plans/task6-pr3-tenant-level-isolation.md
+++ b/.claude/plans/task6-pr3-tenant-level-isolation.md
@@ -6,15 +6,17 @@
 
 **STATUS: COMPLETE (2026-06-05).** Commits on `feat/task6-tenant-level-isolation`: `34f76e3` (model + default backend), `77355cb` (Neo4j), `aee659a` (Postgres), `04de890` (docs), `3c3555e` (code-review hardening). All 5 steps done; full suite green incl. 9 Docker-backed Neo4j/Postgres integration tests (180 KG tests total). Verified against real neo4j:5.20 + postgres:16 containers.
 
-## Follow-up findings (from PR 3 code review — NOT blocking; memory isolation is airtight)
+## Follow-up findings (from PR 3 code review) — RESOLVED 2026-06-05
 
-These concern the **corpus/entity dimension** only. Conversation-memory isolation is complete and unaffected (memory ids are `memory:{tenant}:{user}:{key}`-namespaced + owner+tenant stamped). Captured here as deliberate follow-ups:
+These concerned the **corpus/entity dimension** only. Conversation-memory isolation was complete and unaffected throughout (memory ids are `memory:{tenant}:{user}:{key}`-namespaced + owner+tenant stamped).
 
-1. **Shared entity ids across tenants (design).** Corpus entity nodes use content-derived ids (hash of name+type), so two tenants ingesting the same entity collide on one physical node; an upsert can merge properties or reassign the tenant. True per-tenant corpus needs tenant-namespaced entity ids at ingestion (RAG pipeline) + tenant-aware edge references, OR an explicit "shared global entity" model. Documented as a known limitation in `TenantIsolatedGraphStore` remarks. **Decision needed:** namespace corpus by tenant vs. accept shared global entities.
-2. **Null-tenant = global is fail-open.** A node that ends up untenanted (background ingestion that loses ambient scope, or a future writer that forgets to stamp) is readable by every tenant. Memory is hardened (explicit `TenantId` on the writer). **Decision needed:** keep fail-open (global reference data is a feature) or move to fail-closed (untenanted ⇒ system/null-scope only) + an explicit global marker.
-3. **Misconfig lockout (DX).** With `MultiTenantIsolation` ON but a caller's `IKnowledgeScope.TenantId` unpopulated (partial auth wiring), the caller keeps their own owner-stamped memory but silently loses their tenant's shared corpus on recall. **Suggested:** fail-fast / loud-log when isolation is on and a non-system caller has a null `TenantId`.
+1. **Shared entity ids across tenants — RESOLVED (decision: shared global entity graph).** User chose the standard RAG posture: entities are intentionally shared/global across tenants (dedup, no per-tenant bloat); only memory + documents are tenant-isolated. So `null-tenant = global` is *correct* for entities, and no id-namespacing is needed. Documented as a deliberate design choice in `TenantIsolatedGraphStore` remarks. Per-tenant entity graphs (namespacing) remain an option only if entity *names* are confidential — a separate change.
+2. **Null-tenant = global — RESOLVED (kept, by design).** Follows from #1: global reference/entity data is a feature, not a leak (entity names are non-sensitive). No fail-closed change.
+3. **Misconfig lockout — FIXED (`32d2980`).** `TenantIsolatedGraphStore` now logs a loud warning when isolation is on and a non-system caller (UserId present) has a null `TenantId`, instead of silently hiding their tenant's corpus.
 
-Lower-severity notes: Postgres `GetNeighborsAsync` recursive CTE filters tenant/owner only in the final projection, not inside the walk (defense-in-depth/perf — push predicates into the CTE); `DeleteEdgeAsync` remains unfiltered (no get-edge-by-id primitive).
+**Also fixed (pre-existing bug found during recon):** corpus extraction wrote edge endpoints as `{name}:entity` while nodes are `{name}:{type}`, so ingested-corpus edges never joined their nodes (triplet/neighbor traversal returned empty for corpus). Fixed in `ExtractEntitiesExecutor` + `ManagedCodeGraphRagService` by resolving edge endpoints to real node ids via a name→id map.
+
+Remaining lower-severity notes (not scheduled): Postgres `GetNeighborsAsync` recursive CTE filters tenant/owner only in the final projection (defense-in-depth/perf — could push predicates into the CTE); `DeleteEdgeAsync` unfiltered (no get-edge-by-id primitive).
 
 ## Why this is bigger than "add a field"
 

--- a/.claude/plans/task6-pr3-tenant-level-isolation.md
+++ b/.claude/plans/task6-pr3-tenant-level-isolation.md
@@ -4,7 +4,17 @@
 **Date:** 2026-06-05
 **Scope chosen by user:** Option B — fix everything now. Tenant isolation must actually work on all three backends, not just in-memory.
 
-**STATUS: COMPLETE (2026-06-05).** Commits on `feat/task6-tenant-level-isolation`: `34f76e3` (model + default backend), `77355cb` (Neo4j), `aee659a` (Postgres), + docs. All 5 steps done; full suite green incl. 8 Docker-backed Neo4j/Postgres integration tests (179 KG tests total). Verified against real neo4j:5.20 + postgres:16 containers.
+**STATUS: COMPLETE (2026-06-05).** Commits on `feat/task6-tenant-level-isolation`: `34f76e3` (model + default backend), `77355cb` (Neo4j), `aee659a` (Postgres), `04de890` (docs), `3c3555e` (code-review hardening). All 5 steps done; full suite green incl. 9 Docker-backed Neo4j/Postgres integration tests (180 KG tests total). Verified against real neo4j:5.20 + postgres:16 containers.
+
+## Follow-up findings (from PR 3 code review — NOT blocking; memory isolation is airtight)
+
+These concern the **corpus/entity dimension** only. Conversation-memory isolation is complete and unaffected (memory ids are `memory:{tenant}:{user}:{key}`-namespaced + owner+tenant stamped). Captured here as deliberate follow-ups:
+
+1. **Shared entity ids across tenants (design).** Corpus entity nodes use content-derived ids (hash of name+type), so two tenants ingesting the same entity collide on one physical node; an upsert can merge properties or reassign the tenant. True per-tenant corpus needs tenant-namespaced entity ids at ingestion (RAG pipeline) + tenant-aware edge references, OR an explicit "shared global entity" model. Documented as a known limitation in `TenantIsolatedGraphStore` remarks. **Decision needed:** namespace corpus by tenant vs. accept shared global entities.
+2. **Null-tenant = global is fail-open.** A node that ends up untenanted (background ingestion that loses ambient scope, or a future writer that forgets to stamp) is readable by every tenant. Memory is hardened (explicit `TenantId` on the writer). **Decision needed:** keep fail-open (global reference data is a feature) or move to fail-closed (untenanted ⇒ system/null-scope only) + an explicit global marker.
+3. **Misconfig lockout (DX).** With `MultiTenantIsolation` ON but a caller's `IKnowledgeScope.TenantId` unpopulated (partial auth wiring), the caller keeps their own owner-stamped memory but silently loses their tenant's shared corpus on recall. **Suggested:** fail-fast / loud-log when isolation is on and a non-system caller has a null `TenantId`.
+
+Lower-severity notes: Postgres `GetNeighborsAsync` recursive CTE filters tenant/owner only in the final projection, not inside the walk (defense-in-depth/perf — push predicates into the CTE); `DeleteEdgeAsync` remains unfiltered (no get-edge-by-id primitive).
 
 ## Why this is bigger than "add a field"
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ The harness includes a full RAG pipeline (`Infrastructure.AI.RAG`) and a product
 2. **Feedback-Weighted Search** — `GraphFeedbackStore` + `LlmFeedbackDetector` track retrieval quality on graph nodes/edges. Future retrievals blend semantic relevance with historical feedback weights
 3. **Cross-Session Knowledge Persistence** — `Remember()`/`Recall()`/`Forget()`/`Improve()` via `IKnowledgeMemory`. `InMemorySessionCache` for fast reads with background sync to `ICrossSessionMemoryStore`. `MemoryDecayService` handles configurable decay tiers (CRITICAL/STANDARD/EPHEMERAL)
 4. **Entity-Level Provenance** — `DefaultProvenanceStamper` stamps every node/edge with source pipeline, task, and timestamp. `ComplianceAwareGraphStore` enforces retention policies. `DefaultErasureOrchestrator` handles right-to-erasure with `ErasureReceipt` records
-5. **Multi-Tenant Knowledge Isolation** — `TenantIsolatedGraphStore` enforces scope boundaries (user → dataset → owner) via `IKnowledgeScopeValidator`. Multiple agents/users share infrastructure with strict data isolation
+5. **Multi-Tenant Knowledge Isolation** — `TenantIsolatedGraphStore` enforces per-record boundaries by **tenant AND owner** via `IKnowledgeScopeValidator`: a record is visible only when its tenant matches (or is global/null) and its owner matches (or is shared-in-tenant/null). Identity is captured at the entry point (`KnowledgeScopeMiddleware`/`KnowledgeScopeHubFilter`) and flows ambiently (`AsyncLocal`) into child scopes + post-turn background writes; `ComplianceAwareGraphStore` stamps `TenantId` on write (owner stays writer-authoritative). Memory is scope-namespaced (`memory:{tenant}:{user}:{key}`). Enforced across **all three backends** — in-memory, Neo4j, and PostgreSQL all persist and filter `OwnerId`/`TenantId` (Postgres self-initializes its schema)
 
 ### Governance Subsystems
 - **Drift Detection**: EWMA-based quality monitoring against baselines, three severity levels, DriftEscalationBridge
@@ -93,6 +93,14 @@ After changes: `dotnet build src/AgenticHarness.slnx && dotnet test src/AgenticH
 3. Implement in layers: Domain models first, Application interfaces, Infrastructure implementations, Presentation last
 4. Run build + tests after each meaningful change
 5. Flag anything that diverges from the ApplicationTemplate patterns
+
+## Quality Bar
+
+This is a production template that enterprise consumers will clone. Corners cut now propagate to every downstream consumer. The global "Optimize for Best Outcome, Not Speed" rule applies with extra weight here:
+
+- Match or exceed the reference implementation (`C:\CodeRepos\ApplicationTemplate`) on patterns, abstractions, and rigor. Never ship something here that you'd reject when reviewing the reference.
+- When the reference is silent on a problem, design the best answer; do not invent a smaller answer just because the reference didn't address it.
+- Every public type ships with full XML docs (already a rule) — same reasoning. Consumers are reading this as teaching material.
 
 ## Common Mistakes
 - Creating new abstractions when ApplicationTemplate already has one: check `Application.AI.Common/Interfaces/` first

--- a/src/Content/Application/Application.Core/Workflows/KnowledgeGraph/ExtractEntitiesExecutor.cs
+++ b/src/Content/Application/Application.Core/Workflows/KnowledgeGraph/ExtractEntitiesExecutor.cs
@@ -130,11 +130,21 @@ public sealed class ExtractEntitiesExecutor : Executor<KgIngestionInput, Extract
                 })
                 .ToList();
 
+            // Node ids encode the entity type ("{name}:{type}"), but relationships reference entities
+            // by name only. Resolve each endpoint to its actual node id via a name->id map so edges
+            // join to their nodes; fall back to "{name}:entity" only for names not in this chunk's
+            // extracted entity set (orphan references).
+            var nodeIdByName = nodes
+                .GroupBy(n => n.Name.ToLowerInvariant())
+                .ToDictionary(g => g.Key, g => g.First().Id);
+
             var edges = (parsed?.Relationships ?? [])
                 .Select(r =>
                 {
-                    var source = $"{(r.Source ?? "unknown").ToLowerInvariant()}:entity";
-                    var target = $"{(r.Target ?? "unknown").ToLowerInvariant()}:entity";
+                    var sourceName = (r.Source ?? "unknown").ToLowerInvariant();
+                    var targetName = (r.Target ?? "unknown").ToLowerInvariant();
+                    var source = nodeIdByName.GetValueOrDefault(sourceName, $"{sourceName}:entity");
+                    var target = nodeIdByName.GetValueOrDefault(targetName, $"{targetName}:entity");
                     var predicate = r.Predicate ?? "related_to";
                     return new GraphEdge
                     {

--- a/src/Content/Domain/Domain.AI/KnowledgeGraph/Models/GraphEdge.cs
+++ b/src/Content/Domain/Domain.AI/KnowledgeGraph/Models/GraphEdge.cs
@@ -79,4 +79,12 @@ public record GraphEdge
     /// Used for right-to-erasure cascading: erasing an owner deletes all their edges.
     /// </summary>
     public string? OwnerId { get; init; }
+
+    /// <summary>
+    /// The tenant that owns this edge, enforced by <c>TenantIsolatedGraphStore</c> for
+    /// multi-tenant isolation. <see langword="null"/> means the edge is global — visible
+    /// across all tenants. A non-null value scopes the edge to that tenant. Stamped on write
+    /// from the caller's <c>IKnowledgeScope.TenantId</c> by <c>ComplianceAwareGraphStore</c>.
+    /// </summary>
+    public string? TenantId { get; init; }
 }

--- a/src/Content/Domain/Domain.AI/KnowledgeGraph/Models/GraphNode.cs
+++ b/src/Content/Domain/Domain.AI/KnowledgeGraph/Models/GraphNode.cs
@@ -77,4 +77,14 @@ public record GraphNode
     /// Used for right-to-erasure cascading: erasing an owner deletes all their nodes.
     /// </summary>
     public string? OwnerId { get; init; }
+
+    /// <summary>
+    /// The tenant that owns this node, enforced by <c>TenantIsolatedGraphStore</c> for
+    /// multi-tenant isolation. <see langword="null"/> means the node is global — visible
+    /// across all tenants (e.g. shared reference data ingested by system/background work).
+    /// A non-null value scopes the node to that tenant: only callers in the same tenant can
+    /// read it. Stamped on write from the caller's <c>IKnowledgeScope.TenantId</c> by
+    /// <c>ComplianceAwareGraphStore</c> (or set explicitly by the writer, e.g. memory).
+    /// </summary>
+    public string? TenantId { get; init; }
 }

--- a/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/Compliance/ComplianceAwareGraphStore.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/Compliance/ComplianceAwareGraphStore.cs
@@ -61,6 +61,13 @@ public sealed class ComplianceAwareGraphStore : IKnowledgeGraphStore
     private string? CurrentUserId =>
         _ambientScope.Current?.GetService<IKnowledgeScope>()?.UserId;
 
+    /// <summary>
+    /// The tenant of the caller in flight on the current async context, or <see langword="null"/>
+    /// for background/system work outside any request scope (such writes stay global/untenanted).
+    /// </summary>
+    private string? CurrentTenantId =>
+        _ambientScope.Current?.GetService<IKnowledgeScope>()?.TenantId;
+
     /// <inheritdoc />
     public async Task AddNodesAsync(
         IReadOnlyList<GraphNode> nodes,
@@ -68,7 +75,8 @@ public sealed class ComplianceAwareGraphStore : IKnowledgeGraphStore
     {
         var now = _timeProvider.GetUtcNow();
         var ownerId = CurrentUserId;
-        var stamped = nodes.Select(n => StampNode(n, now)).ToList();
+        var tenantId = CurrentTenantId;
+        var stamped = nodes.Select(n => StampNode(n, now, tenantId)).ToList();
 
         await _inner.AddNodesAsync(stamped, cancellationToken);
 
@@ -89,9 +97,11 @@ public sealed class ComplianceAwareGraphStore : IKnowledgeGraphStore
         CancellationToken cancellationToken = default)
     {
         var now = _timeProvider.GetUtcNow();
+        var tenantId = CurrentTenantId;
         var stamped = edges.Select(e => e with
         {
-            CreatedAt = e.CreatedAt ?? now
+            CreatedAt = e.CreatedAt ?? now,
+            TenantId = e.TenantId ?? tenantId
         }).ToList();
 
         await _inner.AddEdgesAsync(stamped, cancellationToken);
@@ -192,18 +202,20 @@ public sealed class ComplianceAwareGraphStore : IKnowledgeGraphStore
         CancellationToken cancellationToken = default)
         => _inner.GetAllNodesAsync(cancellationToken);
 
-    // Stamps temporal metadata only. OwnerId is intentionally NOT defaulted here: ownership is
+    // Stamps temporal metadata and the tenant. OwnerId is intentionally NOT defaulted: ownership is
     // authoritative from the writer (KnowledgeMemoryService sets OwnerId = the user; shared
-    // subsystems — corpus ingestion, learnings, skill memory — leave it null on purpose so the
-    // records stay globally visible). Defaulting a null owner to the current user would silently
-    // privatize shared knowledge once TenantIsolatedGraphStore is active.
-    private GraphNode StampNode(GraphNode node, DateTimeOffset now)
+    // subsystems — corpus ingestion, learnings, skill memory — leave it null on purpose so records
+    // stay shared WITHIN their tenant). TenantId, by contrast, IS defaulted to the caller's tenant:
+    // that is what scopes a tenant's ingested corpus to that tenant. A write with no tenant context
+    // (background/system, CurrentTenantId == null) stays global, visible across all tenants.
+    private GraphNode StampNode(GraphNode node, DateTimeOffset now, string? tenantId)
     {
         var policy = _retentionProvider.GetPolicy(node.Type);
         return node with
         {
             CreatedAt = node.CreatedAt ?? now,
-            ExpiresAt = node.ExpiresAt ?? (policy.AllowIndefinite ? null : now + policy.RetentionPeriod)
+            ExpiresAt = node.ExpiresAt ?? (policy.AllowIndefinite ? null : now + policy.RetentionPeriod),
+            TenantId = node.TenantId ?? tenantId
         };
     }
 

--- a/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/Memory/KnowledgeMemoryService.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/Memory/KnowledgeMemoryService.cs
@@ -75,7 +75,8 @@ public sealed class KnowledgeMemoryService : IKnowledgeMemory
             Type = entityType,
             Properties = new Dictionary<string, string> { ["content"] = content },
             ChunkIds = [],
-            OwnerId = _scope.UserId
+            OwnerId = _scope.UserId,
+            TenantId = _scope.TenantId
         };
 
         // Fast path for any same-scope recall within this request.

--- a/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/Neo4j/Neo4jGraphStore.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/Neo4j/Neo4jGraphStore.cs
@@ -46,8 +46,10 @@ public sealed class Neo4jGraphStore : IKnowledgeGraphStore, IAsyncDisposable
         var uri = new Uri(connString);
         var userInfo = uri.UserInfo.Split(':');
         // The Bolt driver rejects a URI that carries a userinfo component, so pass a clean
-        // scheme://host:port and supply credentials separately as an auth token.
-        var boltUri = $"{uri.Scheme}://{uri.Host}:{uri.Port}";
+        // scheme://host:port and supply credentials separately as an auth token. Fall back to the
+        // default Bolt port when the connection string omits one (Uri.Port is -1 in that case).
+        var port = uri.Port == -1 ? 7687 : uri.Port;
+        var boltUri = $"{uri.Scheme}://{uri.Host}:{port}";
         _driver = userInfo.Length == 2
             ? GraphDatabase.Driver(boltUri, AuthTokens.Basic(userInfo[0], userInfo[1]))
             : GraphDatabase.Driver(boltUri);
@@ -70,8 +72,11 @@ public sealed class Neo4jGraphStore : IKnowledgeGraphStore, IAsyncDisposable
                 await tx.RunAsync("""
                     MERGE (n:Entity {id: $id})
                     SET n.name = $name, n.type = $type, n.properties = $props,
-                        n.owner_id = $owner_id, n.tenant_id = $tenant_id,
-                        n.created_at = $created_at, n.expires_at = $expires_at, n.provenance = $prov
+                        n.owner_id = coalesce($owner_id, n.owner_id),
+                        n.tenant_id = coalesce($tenant_id, n.tenant_id),
+                        n.created_at = coalesce(n.created_at, $created_at),
+                        n.expires_at = $expires_at,
+                        n.provenance = coalesce($prov, n.provenance)
                     WITH n
                     UNWIND $chunks AS chunkId
                     WITH n, collect(DISTINCT chunkId) + coalesce(n.chunk_ids, []) AS allChunks
@@ -114,8 +119,11 @@ public sealed class Neo4jGraphStore : IKnowledgeGraphStore, IAsyncDisposable
                     MERGE (s)-[r:RELATES {id: $id}]->(t)
                     SET r.predicate = $pred, r.properties = $props, r.chunk_id = $chunk,
                         r.source = $source, r.target = $target,
-                        r.owner_id = $owner_id, r.tenant_id = $tenant_id,
-                        r.created_at = $created_at, r.expires_at = $expires_at, r.provenance = $prov
+                        r.owner_id = coalesce($owner_id, r.owner_id),
+                        r.tenant_id = coalesce($tenant_id, r.tenant_id),
+                        r.created_at = coalesce(r.created_at, $created_at),
+                        r.expires_at = $expires_at,
+                        r.provenance = coalesce($prov, r.provenance)
                     """,
                     new
                     {

--- a/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/Neo4j/Neo4jGraphStore.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/Neo4j/Neo4jGraphStore.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Globalization;
 using System.Text.Json;
 using Application.AI.Common.Interfaces.KnowledgeGraph;
 using Domain.AI.KnowledgeGraph.Models;
@@ -44,9 +45,12 @@ public sealed class Neo4jGraphStore : IKnowledgeGraphStore, IAsyncDisposable
 
         var uri = new Uri(connString);
         var userInfo = uri.UserInfo.Split(':');
+        // The Bolt driver rejects a URI that carries a userinfo component, so pass a clean
+        // scheme://host:port and supply credentials separately as an auth token.
+        var boltUri = $"{uri.Scheme}://{uri.Host}:{uri.Port}";
         _driver = userInfo.Length == 2
-            ? GraphDatabase.Driver(connString, AuthTokens.Basic(userInfo[0], userInfo[1]))
-            : GraphDatabase.Driver(connString);
+            ? GraphDatabase.Driver(boltUri, AuthTokens.Basic(userInfo[0], userInfo[1]))
+            : GraphDatabase.Driver(boltUri);
         _logger = logger;
     }
 
@@ -65,7 +69,9 @@ public sealed class Neo4jGraphStore : IKnowledgeGraphStore, IAsyncDisposable
             {
                 await tx.RunAsync("""
                     MERGE (n:Entity {id: $id})
-                    SET n.name = $name, n.type = $type, n.properties = $props
+                    SET n.name = $name, n.type = $type, n.properties = $props,
+                        n.owner_id = $owner_id, n.tenant_id = $tenant_id,
+                        n.created_at = $created_at, n.expires_at = $expires_at, n.provenance = $prov
                     WITH n
                     UNWIND $chunks AS chunkId
                     WITH n, collect(DISTINCT chunkId) + coalesce(n.chunk_ids, []) AS allChunks
@@ -75,7 +81,14 @@ public sealed class Neo4jGraphStore : IKnowledgeGraphStore, IAsyncDisposable
                     {
                         id = node.Id, name = node.Name, type = node.Type,
                         props = JsonSerializer.Serialize(node.Properties, JsonOptions),
-                        chunks = node.ChunkIds.ToList()
+                        chunks = node.ChunkIds.ToList(),
+                        owner_id = node.OwnerId,
+                        tenant_id = node.TenantId,
+                        created_at = node.CreatedAt?.ToString("O"),
+                        expires_at = node.ExpiresAt?.ToString("O"),
+                        prov = node.Provenance is not null
+                            ? JsonSerializer.Serialize(node.Provenance, JsonOptions)
+                            : null
                     });
             }, x => x.WithMetadata(new Dictionary<string, object?>()));
         }
@@ -99,14 +112,24 @@ public sealed class Neo4jGraphStore : IKnowledgeGraphStore, IAsyncDisposable
                 await tx.RunAsync("""
                     MATCH (s:Entity {id: $source}), (t:Entity {id: $target})
                     MERGE (s)-[r:RELATES {id: $id}]->(t)
-                    SET r.predicate = $pred, r.properties = $props, r.chunk_id = $chunk
+                    SET r.predicate = $pred, r.properties = $props, r.chunk_id = $chunk,
+                        r.source = $source, r.target = $target,
+                        r.owner_id = $owner_id, r.tenant_id = $tenant_id,
+                        r.created_at = $created_at, r.expires_at = $expires_at, r.provenance = $prov
                     """,
                     new
                     {
                         id = edge.Id, source = edge.SourceNodeId,
                         target = edge.TargetNodeId, pred = edge.Predicate,
                         props = JsonSerializer.Serialize(edge.Properties, JsonOptions),
-                        chunk = edge.ChunkId
+                        chunk = edge.ChunkId,
+                        owner_id = edge.OwnerId,
+                        tenant_id = edge.TenantId,
+                        created_at = edge.CreatedAt?.ToString("O"),
+                        expires_at = edge.ExpiresAt?.ToString("O"),
+                        prov = edge.Provenance is not null
+                            ? JsonSerializer.Serialize(edge.Provenance, JsonOptions)
+                            : null
                     });
             }, x => x.WithMetadata(new Dictionary<string, object?>()));
         }
@@ -249,24 +272,38 @@ public sealed class Neo4jGraphStore : IKnowledgeGraphStore, IAsyncDisposable
     }
 
     /// <inheritdoc />
-    public Task<IReadOnlyList<GraphNode>> GetNodesByOwnerAsync(
+    public async Task<IReadOnlyList<GraphNode>> GetNodesByOwnerAsync(
         string ownerId,
         CancellationToken cancellationToken = default)
     {
-        // TODO: When Neo4j driver is wired, use Cypher:
-        // MATCH (n) WHERE n.ownerId = $ownerId RETURN n
-        _logger.LogWarning("GetNodesByOwnerAsync not yet implemented for Neo4j backend");
-        return Task.FromResult<IReadOnlyList<GraphNode>>([]);
+        await using var session = _driver.AsyncSession();
+        return await session.ExecuteReadAsync(async tx =>
+        {
+            var cursor = await tx.RunAsync(
+                "MATCH (n:Entity) WHERE n.owner_id = $ownerId RETURN n",
+                new { ownerId });
+
+            var results = new List<GraphNode>();
+            while (await cursor.FetchAsync())
+                results.Add(MapNode(cursor.Current["n"].As<INode>()));
+            return (IReadOnlyList<GraphNode>)results;
+        });
     }
 
     /// <inheritdoc />
-    public Task<IReadOnlyList<GraphNode>> GetAllNodesAsync(
+    public async Task<IReadOnlyList<GraphNode>> GetAllNodesAsync(
         CancellationToken cancellationToken = default)
     {
-        // TODO: When Neo4j driver is wired, use Cypher:
-        // MATCH (n:Entity) RETURN n
-        _logger.LogWarning("GetAllNodesAsync not yet implemented for Neo4j backend");
-        return Task.FromResult<IReadOnlyList<GraphNode>>([]);
+        await using var session = _driver.AsyncSession();
+        return await session.ExecuteReadAsync(async tx =>
+        {
+            var cursor = await tx.RunAsync("MATCH (n:Entity) RETURN n");
+
+            var results = new List<GraphNode>();
+            while (await cursor.FetchAsync())
+                results.Add(MapNode(cursor.Current["n"].As<INode>()));
+            return (IReadOnlyList<GraphNode>)results;
+        });
     }
 
     /// <inheritdoc cref="IAsyncDisposable.DisposeAsync"/>
@@ -292,7 +329,12 @@ public sealed class Neo4jGraphStore : IKnowledgeGraphStore, IAsyncDisposable
             Name = neo4jNode.Properties["name"].As<string>(),
             Type = neo4jNode.Properties["type"].As<string>(),
             Properties = props,
-            ChunkIds = chunks
+            ChunkIds = chunks,
+            OwnerId = ReadString(neo4jNode.Properties, "owner_id"),
+            TenantId = ReadString(neo4jNode.Properties, "tenant_id"),
+            CreatedAt = ReadDate(neo4jNode.Properties, "created_at"),
+            ExpiresAt = ReadDate(neo4jNode.Properties, "expires_at"),
+            Provenance = ReadProvenance(neo4jNode.Properties)
         };
     }
 
@@ -310,7 +352,29 @@ public sealed class Neo4jGraphStore : IKnowledgeGraphStore, IAsyncDisposable
             TargetNodeId = rel.Properties.TryGetValue("target", out var t) ? t.As<string>() : "",
             Predicate = rel.Properties["predicate"].As<string>(),
             Properties = props,
-            ChunkId = rel.Properties["chunk_id"].As<string>()
+            ChunkId = rel.Properties["chunk_id"].As<string>(),
+            OwnerId = ReadString(rel.Properties, "owner_id"),
+            TenantId = ReadString(rel.Properties, "tenant_id"),
+            CreatedAt = ReadDate(rel.Properties, "created_at"),
+            ExpiresAt = ReadDate(rel.Properties, "expires_at"),
+            Provenance = ReadProvenance(rel.Properties)
         };
+    }
+
+    private static string? ReadString(IReadOnlyDictionary<string, object> props, string key)
+        => props.TryGetValue(key, out var v) && v is not null ? v.As<string>() : null;
+
+    private static DateTimeOffset? ReadDate(IReadOnlyDictionary<string, object> props, string key)
+    {
+        var s = ReadString(props, key);
+        return s is null
+            ? null
+            : DateTimeOffset.Parse(s, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind);
+    }
+
+    private static ProvenanceStamp? ReadProvenance(IReadOnlyDictionary<string, object> props)
+    {
+        var s = ReadString(props, "provenance");
+        return s is null ? null : JsonSerializer.Deserialize<ProvenanceStamp>(s, JsonOptions);
     }
 }

--- a/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/PostgreSql/PostgreSqlGraphStore.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/PostgreSql/PostgreSqlGraphStore.cs
@@ -376,8 +376,22 @@ public sealed class PostgreSqlGraphStore : IKnowledgeGraphStore
         try
         {
             if (_schemaReady) return;
-            await using var cmd = new NpgsqlCommand(SchemaDdl, conn);
-            await cmd.ExecuteNonQueryAsync(ct);
+
+            // Serialize DDL across processes/replicas: concurrent CREATE TABLE/INDEX IF NOT EXISTS
+            // on a fresh database can race and throw ("tuple concurrently updated" / duplicate
+            // object). A transaction-scoped advisory lock (auto-released on commit) makes first-use
+            // safe in a scaled-out deployment; the in-process semaphore + flag handle the common case.
+            await using var tx = await conn.BeginTransactionAsync(ct);
+            await using (var lockCmd = new NpgsqlCommand("SELECT pg_advisory_xact_lock(@key)", conn, tx))
+            {
+                lockCmd.Parameters.AddWithValue("key", 0x6B675F736368656DL); // "kg_schem"
+                await lockCmd.ExecuteNonQueryAsync(ct);
+            }
+            await using (var cmd = new NpgsqlCommand(SchemaDdl, conn, tx))
+            {
+                await cmd.ExecuteNonQueryAsync(ct);
+            }
+            await tx.CommitAsync(ct);
             _schemaReady = true;
         }
         finally

--- a/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/PostgreSql/PostgreSqlGraphStore.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/PostgreSql/PostgreSqlGraphStore.cs
@@ -31,8 +31,40 @@ public sealed class PostgreSqlGraphStore : IKnowledgeGraphStore
     private static readonly ActivitySource ActivitySource = new("Infrastructure.AI.KnowledgeGraph.PostgreSql");
     private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
 
+    private const string SchemaDdl = """
+        CREATE TABLE IF NOT EXISTS kg_nodes (
+            id          TEXT PRIMARY KEY,
+            name        TEXT NOT NULL,
+            type        TEXT NOT NULL,
+            properties  JSONB,
+            chunk_ids   TEXT[],
+            provenance  JSONB,
+            owner_id    TEXT,
+            tenant_id   TEXT,
+            created_at  TIMESTAMPTZ,
+            expires_at  TIMESTAMPTZ
+        );
+        CREATE TABLE IF NOT EXISTS kg_edges (
+            id              TEXT PRIMARY KEY,
+            source_node_id  TEXT NOT NULL,
+            target_node_id  TEXT NOT NULL,
+            predicate       TEXT NOT NULL,
+            properties      JSONB,
+            chunk_id        TEXT,
+            provenance      JSONB,
+            owner_id        TEXT,
+            tenant_id       TEXT,
+            created_at      TIMESTAMPTZ,
+            expires_at      TIMESTAMPTZ
+        );
+        CREATE INDEX IF NOT EXISTS idx_kg_nodes_owner ON kg_nodes (owner_id);
+        CREATE INDEX IF NOT EXISTS idx_kg_nodes_tenant ON kg_nodes (tenant_id);
+        """;
+
     private readonly string _connectionString;
     private readonly ILogger<PostgreSqlGraphStore> _logger;
+    private readonly SemaphoreSlim _schemaLock = new(1, 1);
+    private volatile bool _schemaReady;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="PostgreSqlGraphStore"/> class.
@@ -64,12 +96,18 @@ public sealed class PostgreSqlGraphStore : IKnowledgeGraphStore
         {
             cancellationToken.ThrowIfCancellationRequested();
             await using var cmd = new NpgsqlCommand("""
-                INSERT INTO kg_nodes (id, name, type, properties, chunk_ids, provenance)
-                VALUES (@id, @name, @type, @props::jsonb, @chunks, @prov::jsonb)
+                INSERT INTO kg_nodes
+                    (id, name, type, properties, chunk_ids, provenance, owner_id, tenant_id, created_at, expires_at)
+                VALUES
+                    (@id, @name, @type, @props::jsonb, @chunks, @prov::jsonb, @owner_id, @tenant_id, @created_at, @expires_at)
                 ON CONFLICT (id) DO UPDATE SET
                     properties = kg_nodes.properties || @props::jsonb,
                     chunk_ids = ARRAY(SELECT DISTINCT unnest(kg_nodes.chunk_ids || @chunks)),
-                    provenance = COALESCE(@prov::jsonb, kg_nodes.provenance)
+                    provenance = COALESCE(@prov::jsonb, kg_nodes.provenance),
+                    owner_id = COALESCE(@owner_id, kg_nodes.owner_id),
+                    tenant_id = COALESCE(@tenant_id, kg_nodes.tenant_id),
+                    created_at = COALESCE(kg_nodes.created_at, @created_at),
+                    expires_at = @expires_at
                 """, conn);
 
             cmd.Parameters.AddWithValue("id", node.Id);
@@ -81,6 +119,10 @@ public sealed class PostgreSqlGraphStore : IKnowledgeGraphStore
                 node.Provenance is not null
                     ? JsonSerializer.Serialize(node.Provenance, JsonOptions)
                     : (object)DBNull.Value);
+            cmd.Parameters.AddWithValue("owner_id", (object?)node.OwnerId ?? DBNull.Value);
+            cmd.Parameters.AddWithValue("tenant_id", (object?)node.TenantId ?? DBNull.Value);
+            cmd.Parameters.AddWithValue("created_at", (object?)node.CreatedAt ?? DBNull.Value);
+            cmd.Parameters.AddWithValue("expires_at", (object?)node.ExpiresAt ?? DBNull.Value);
             await cmd.ExecuteNonQueryAsync(cancellationToken);
         }
 
@@ -99,8 +141,10 @@ public sealed class PostgreSqlGraphStore : IKnowledgeGraphStore
         {
             cancellationToken.ThrowIfCancellationRequested();
             await using var cmd = new NpgsqlCommand("""
-                INSERT INTO kg_edges (id, source_node_id, target_node_id, predicate, properties, chunk_id, provenance)
-                VALUES (@id, @source, @target, @pred, @props::jsonb, @chunk, @prov::jsonb)
+                INSERT INTO kg_edges
+                    (id, source_node_id, target_node_id, predicate, properties, chunk_id, provenance, owner_id, tenant_id, created_at, expires_at)
+                VALUES
+                    (@id, @source, @target, @pred, @props::jsonb, @chunk, @prov::jsonb, @owner_id, @tenant_id, @created_at, @expires_at)
                 ON CONFLICT (id) DO NOTHING
                 """, conn);
 
@@ -114,6 +158,10 @@ public sealed class PostgreSqlGraphStore : IKnowledgeGraphStore
                 edge.Provenance is not null
                     ? JsonSerializer.Serialize(edge.Provenance, JsonOptions)
                     : (object)DBNull.Value);
+            cmd.Parameters.AddWithValue("owner_id", (object?)edge.OwnerId ?? DBNull.Value);
+            cmd.Parameters.AddWithValue("tenant_id", (object?)edge.TenantId ?? DBNull.Value);
+            cmd.Parameters.AddWithValue("created_at", (object?)edge.CreatedAt ?? DBNull.Value);
+            cmd.Parameters.AddWithValue("expires_at", (object?)edge.ExpiresAt ?? DBNull.Value);
             await cmd.ExecuteNonQueryAsync(cancellationToken);
         }
 
@@ -127,7 +175,8 @@ public sealed class PostgreSqlGraphStore : IKnowledgeGraphStore
     {
         await using var conn = await OpenConnectionAsync(cancellationToken);
         await using var cmd = new NpgsqlCommand(
-            "SELECT id, name, type, properties, chunk_ids, provenance FROM kg_nodes WHERE id = @id", conn);
+            "SELECT id, name, type, properties, chunk_ids, provenance, owner_id, tenant_id, created_at, expires_at " +
+            "FROM kg_nodes WHERE id = @id", conn);
         cmd.Parameters.AddWithValue("id", nodeId);
 
         await using var reader = await cmd.ExecuteReaderAsync(cancellationToken);
@@ -155,7 +204,8 @@ public sealed class PostgreSqlGraphStore : IKnowledgeGraphStore
                 WHERE n.depth < @maxDepth
                   AND CASE WHEN e.source_node_id = n.neighbor_id THEN e.target_node_id ELSE e.source_node_id END != @id
             )
-            SELECT DISTINCT nd.id, nd.name, nd.type, nd.properties, nd.chunk_ids, nd.provenance
+            SELECT DISTINCT nd.id, nd.name, nd.type, nd.properties, nd.chunk_ids, nd.provenance,
+                   nd.owner_id, nd.tenant_id, nd.created_at, nd.expires_at
             FROM neighbors nb
             JOIN kg_nodes nd ON nd.id = nb.neighbor_id
             """, conn);
@@ -179,10 +229,15 @@ public sealed class PostgreSqlGraphStore : IKnowledgeGraphStore
         if (nodeIds.Count == 0) return [];
 
         await using var conn = await OpenConnectionAsync(cancellationToken);
+        // Column layout (offsets used by ReadEdgeAt/ReadNodeAt below):
+        //   edge   0-10  (11 cols), source 11-20 (10 cols), target 21-30 (10 cols)
         await using var cmd = new NpgsqlCommand("""
-            SELECT e.id AS eid, e.source_node_id, e.target_node_id, e.predicate, e.properties AS eprops, e.chunk_id, e.provenance AS eprov,
-                   s.id AS sid, s.name AS sname, s.type AS stype, s.properties AS sprops, s.chunk_ids AS schunks, s.provenance AS sprov,
-                   t.id AS tid, t.name AS tname, t.type AS ttype, t.properties AS tprops, t.chunk_ids AS tchunks, t.provenance AS tprov
+            SELECT e.id, e.source_node_id, e.target_node_id, e.predicate, e.properties, e.chunk_id, e.provenance,
+                   e.owner_id, e.tenant_id, e.created_at, e.expires_at,
+                   s.id, s.name, s.type, s.properties, s.chunk_ids, s.provenance,
+                   s.owner_id, s.tenant_id, s.created_at, s.expires_at,
+                   t.id, t.name, t.type, t.properties, t.chunk_ids, t.provenance,
+                   t.owner_id, t.tenant_id, t.created_at, t.expires_at
             FROM kg_edges e
             JOIN kg_nodes s ON s.id = e.source_node_id
             JOIN kg_nodes t ON t.id = e.target_node_id
@@ -197,36 +252,9 @@ public sealed class PostgreSqlGraphStore : IKnowledgeGraphStore
         {
             triplets.Add(new GraphTriplet
             {
-                Source = new GraphNode
-                {
-                    Id = reader.GetString(7), Name = reader.GetString(8),
-                    Type = reader.GetString(9),
-                    Properties = DeserializeProps(reader.GetString(10)),
-                    ChunkIds = (string[])reader.GetValue(11),
-                    Provenance = reader.IsDBNull(12)
-                        ? null
-                        : JsonSerializer.Deserialize<ProvenanceStamp>(reader.GetString(12), JsonOptions)
-                },
-                Edge = new GraphEdge
-                {
-                    Id = reader.GetString(0), SourceNodeId = reader.GetString(1),
-                    TargetNodeId = reader.GetString(2), Predicate = reader.GetString(3),
-                    Properties = DeserializeProps(reader.GetString(4)),
-                    ChunkId = reader.GetString(5),
-                    Provenance = reader.IsDBNull(6)
-                        ? null
-                        : JsonSerializer.Deserialize<ProvenanceStamp>(reader.GetString(6), JsonOptions)
-                },
-                Target = new GraphNode
-                {
-                    Id = reader.GetString(13), Name = reader.GetString(14),
-                    Type = reader.GetString(15),
-                    Properties = DeserializeProps(reader.GetString(16)),
-                    ChunkIds = (string[])reader.GetValue(17),
-                    Provenance = reader.IsDBNull(18)
-                        ? null
-                        : JsonSerializer.Deserialize<ProvenanceStamp>(reader.GetString(18), JsonOptions)
-                }
+                Edge = ReadEdgeAt(reader, 0),
+                Source = ReadNodeAt(reader, 11),
+                Target = ReadNodeAt(reader, 21)
             });
         }
 
@@ -293,45 +321,118 @@ public sealed class PostgreSqlGraphStore : IKnowledgeGraphStore
     }
 
     /// <inheritdoc />
-    public Task<IReadOnlyList<GraphNode>> GetNodesByOwnerAsync(
+    public async Task<IReadOnlyList<GraphNode>> GetNodesByOwnerAsync(
         string ownerId,
         CancellationToken cancellationToken = default)
     {
-        // TODO: When PostgreSQL is wired, use:
-        // SELECT * FROM graph_nodes WHERE owner_id = @ownerId
-        _logger.LogWarning("GetNodesByOwnerAsync not yet implemented for PostgreSQL backend");
-        return Task.FromResult<IReadOnlyList<GraphNode>>([]);
+        await using var conn = await OpenConnectionAsync(cancellationToken);
+        await using var cmd = new NpgsqlCommand(
+            "SELECT id, name, type, properties, chunk_ids, provenance, owner_id, tenant_id, created_at, expires_at " +
+            "FROM kg_nodes WHERE owner_id = @ownerId", conn);
+        cmd.Parameters.AddWithValue("ownerId", ownerId);
+
+        var results = new List<GraphNode>();
+        await using var reader = await cmd.ExecuteReaderAsync(cancellationToken);
+        while (await reader.ReadAsync(cancellationToken))
+            results.Add(ReadNode(reader));
+
+        return results;
     }
 
     /// <inheritdoc />
-    public Task<IReadOnlyList<GraphNode>> GetAllNodesAsync(
+    public async Task<IReadOnlyList<GraphNode>> GetAllNodesAsync(
         CancellationToken cancellationToken = default)
     {
-        // TODO: When PostgreSQL is wired, use:
-        // SELECT id, name, type, properties, chunk_ids, provenance FROM kg_nodes
-        _logger.LogWarning("GetAllNodesAsync not yet implemented for PostgreSQL backend");
-        return Task.FromResult<IReadOnlyList<GraphNode>>([]);
+        await using var conn = await OpenConnectionAsync(cancellationToken);
+        await using var cmd = new NpgsqlCommand(
+            "SELECT id, name, type, properties, chunk_ids, provenance, owner_id, tenant_id, created_at, expires_at " +
+            "FROM kg_nodes", conn);
+
+        var results = new List<GraphNode>();
+        await using var reader = await cmd.ExecuteReaderAsync(cancellationToken);
+        while (await reader.ReadAsync(cancellationToken))
+            results.Add(ReadNode(reader));
+
+        return results;
     }
 
     private async Task<NpgsqlConnection> OpenConnectionAsync(CancellationToken ct)
     {
         var conn = new NpgsqlConnection(_connectionString);
         await conn.OpenAsync(ct);
+        await EnsureSchemaAsync(conn, ct);
         return conn;
     }
 
-    private static GraphNode ReadNode(NpgsqlDataReader reader)
+    /// <summary>
+    /// Creates the <c>kg_nodes</c>/<c>kg_edges</c> tables (with the full isolation/temporal column
+    /// set) if they do not already exist. Runs once per store instance — the backend is a singleton —
+    /// guarded so concurrent callers initialize the schema exactly once.
+    /// </summary>
+    private async Task EnsureSchemaAsync(NpgsqlConnection conn, CancellationToken ct)
+    {
+        if (_schemaReady) return;
+        await _schemaLock.WaitAsync(ct);
+        try
+        {
+            if (_schemaReady) return;
+            await using var cmd = new NpgsqlCommand(SchemaDdl, conn);
+            await cmd.ExecuteNonQueryAsync(ct);
+            _schemaReady = true;
+        }
+        finally
+        {
+            _schemaLock.Release();
+        }
+    }
+
+    private static GraphNode ReadNode(NpgsqlDataReader reader) => ReadNodeAt(reader, 0);
+
+    /// <summary>
+    /// Reads a node from 10 consecutive columns starting at <paramref name="o"/>, in the order
+    /// id, name, type, properties, chunk_ids, provenance, owner_id, tenant_id, created_at, expires_at.
+    /// </summary>
+    private static GraphNode ReadNodeAt(NpgsqlDataReader r, int o)
     {
         return new GraphNode
         {
-            Id = reader.GetString(0),
-            Name = reader.GetString(1),
-            Type = reader.GetString(2),
-            Properties = DeserializeProps(reader.GetString(3)),
-            ChunkIds = (string[])reader.GetValue(4),
-            Provenance = reader.IsDBNull(5)
+            Id = r.GetString(o),
+            Name = r.GetString(o + 1),
+            Type = r.GetString(o + 2),
+            Properties = DeserializeProps(r.GetString(o + 3)),
+            ChunkIds = (string[])r.GetValue(o + 4),
+            Provenance = r.IsDBNull(o + 5)
                 ? null
-                : JsonSerializer.Deserialize<ProvenanceStamp>(reader.GetString(5), JsonOptions)
+                : JsonSerializer.Deserialize<ProvenanceStamp>(r.GetString(o + 5), JsonOptions),
+            OwnerId = r.IsDBNull(o + 6) ? null : r.GetString(o + 6),
+            TenantId = r.IsDBNull(o + 7) ? null : r.GetString(o + 7),
+            CreatedAt = r.IsDBNull(o + 8) ? null : r.GetFieldValue<DateTimeOffset>(o + 8),
+            ExpiresAt = r.IsDBNull(o + 9) ? null : r.GetFieldValue<DateTimeOffset>(o + 9)
+        };
+    }
+
+    /// <summary>
+    /// Reads an edge from 11 consecutive columns starting at <paramref name="o"/>, in the order
+    /// id, source_node_id, target_node_id, predicate, properties, chunk_id, provenance, owner_id,
+    /// tenant_id, created_at, expires_at.
+    /// </summary>
+    private static GraphEdge ReadEdgeAt(NpgsqlDataReader r, int o)
+    {
+        return new GraphEdge
+        {
+            Id = r.GetString(o),
+            SourceNodeId = r.GetString(o + 1),
+            TargetNodeId = r.GetString(o + 2),
+            Predicate = r.GetString(o + 3),
+            Properties = DeserializeProps(r.GetString(o + 4)),
+            ChunkId = r.GetString(o + 5),
+            Provenance = r.IsDBNull(o + 6)
+                ? null
+                : JsonSerializer.Deserialize<ProvenanceStamp>(r.GetString(o + 6), JsonOptions),
+            OwnerId = r.IsDBNull(o + 7) ? null : r.GetString(o + 7),
+            TenantId = r.IsDBNull(o + 8) ? null : r.GetString(o + 8),
+            CreatedAt = r.IsDBNull(o + 9) ? null : r.GetFieldValue<DateTimeOffset>(o + 9),
+            ExpiresAt = r.IsDBNull(o + 10) ? null : r.GetFieldValue<DateTimeOffset>(o + 10)
         };
     }
 

--- a/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/Scoping/TenantIsolatedGraphStore.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/Scoping/TenantIsolatedGraphStore.cs
@@ -36,6 +36,16 @@ namespace Infrastructure.AI.KnowledgeGraph.Scoping;
 /// Registered conditionally: only when <c>GraphRagConfig.MultiTenantIsolation</c> is <c>true</c>.
 /// In single-tenant mode the inner store is used directly.
 /// </para>
+/// <para>
+/// <b>Scope &amp; known limitation.</b> Conversation <em>memory</em> isolation is airtight: memory
+/// node ids are scope-namespaced (<c>memory:{tenant}:{user}:{key}</c>) and stamped with owner+tenant,
+/// so they never collide across tenants. Ingested <em>corpus</em> entity nodes, however, use
+/// content-derived ids (a hash of name+type) that are <strong>shared across tenants</strong> — two
+/// tenants ingesting the same entity resolve to one physical node, and an upsert can merge or
+/// reassign its tenant. Tenant-gating ingested corpus therefore assumes either tenant-namespaced
+/// entity ids at ingestion time or intentionally-shared global entities; it is not enforced by this
+/// decorator alone. Backends preserve (never null-clobber) an existing owner/tenant on re-write.
+/// </para>
 /// </remarks>
 public sealed class TenantIsolatedGraphStore : IKnowledgeGraphStore
 {

--- a/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/Scoping/TenantIsolatedGraphStore.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/Scoping/TenantIsolatedGraphStore.cs
@@ -37,14 +37,17 @@ namespace Infrastructure.AI.KnowledgeGraph.Scoping;
 /// In single-tenant mode the inner store is used directly.
 /// </para>
 /// <para>
-/// <b>Scope &amp; known limitation.</b> Conversation <em>memory</em> isolation is airtight: memory
+/// <b>Scope of isolation (by design).</b> Conversation <em>memory</em> is strictly isolated: memory
 /// node ids are scope-namespaced (<c>memory:{tenant}:{user}:{key}</c>) and stamped with owner+tenant,
-/// so they never collide across tenants. Ingested <em>corpus</em> entity nodes, however, use
-/// content-derived ids (a hash of name+type) that are <strong>shared across tenants</strong> — two
-/// tenants ingesting the same entity resolve to one physical node, and an upsert can merge or
-/// reassign its tenant. Tenant-gating ingested corpus therefore assumes either tenant-namespaced
-/// entity ids at ingestion time or intentionally-shared global entities; it is not enforced by this
-/// decorator alone. Backends preserve (never null-clobber) an existing owner/tenant on re-write.
+/// so a user only ever recalls their own facts within their tenant. Ingested <em>corpus entities</em>
+/// (people, orgs, technologies) are <strong>intentionally shared/global</strong> across tenants: they
+/// use content-derived ids (name+type) and deduplicate into one physical node, giving a shared
+/// knowledge graph without per-tenant bloat. Entity nodes are therefore written without a tenant
+/// (<c>TenantId == null</c> = global, visible to all), which is the correct posture when entity
+/// <em>names</em> are non-sensitive shared knowledge. Per-tenant document/memory data carries an
+/// explicit tenant and is isolated as above. (If entity names themselves are confidential, corpus
+/// ingestion must tenant-namespace entity ids — that is a deliberate, separate change.) Backends
+/// preserve (never null-clobber) an existing owner/tenant on re-write.
 /// </para>
 /// </remarks>
 public sealed class TenantIsolatedGraphStore : IKnowledgeGraphStore

--- a/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/Scoping/TenantIsolatedGraphStore.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/Scoping/TenantIsolatedGraphStore.cs
@@ -14,13 +14,15 @@ namespace Infrastructure.AI.KnowledgeGraph.Scoping;
 /// </summary>
 /// <remarks>
 /// <para>
-/// Isolation is <strong>per record, by owner</strong> — not an all-or-nothing gate. A node is
-/// visible when it is unowned (<see cref="GraphNode.OwnerId"/> is <see langword="null"/>, i.e.
-/// shared/ingested corpus) or when the caller owns it
-/// (<see cref="IKnowledgeScopeValidator.CanAccessDataset"/>). A user therefore only ever sees
-/// their own remembered facts plus the shared corpus, never another user's memory — even within
-/// the same tenant. True tenant-level corpus partitioning requires a <c>TenantId</c> on the node
-/// model and is deferred to a later change; until then, unowned corpus is shared across tenants.
+/// Isolation is <strong>per record, by tenant and owner</strong> — not an all-or-nothing gate. A
+/// node is visible only when its tenant matches (<see cref="GraphNode.TenantId"/> is
+/// <see langword="null"/> = global, or equals the caller's tenant via
+/// <see cref="IKnowledgeScopeValidator.ValidateAccess"/>) AND its owner matches
+/// (<see cref="GraphNode.OwnerId"/> is <see langword="null"/> = shared within the tenant, or the
+/// caller owns it via <see cref="IKnowledgeScopeValidator.CanAccessDataset"/>). A user therefore
+/// sees their tenant's shared corpus plus their own remembered facts, never another tenant's data
+/// and never another user's memory within the tenant. Global (null-tenant) records — e.g. system
+/// reference data — remain visible to everyone.
 /// </para>
 /// <para>
 /// Registered as a <c>Singleton</c> wrapping the singleton backend, so it cannot capture the
@@ -81,9 +83,9 @@ public sealed class TenantIsolatedGraphStore : IKnowledgeGraphStore
         var scope = CurrentScope;
         if (scope is null) return _inner.AddNodesAsync(nodes, cancellationToken);
 
-        // Fresh nodes arrive unowned and are stamped with the owner by the inner
-        // ComplianceAwareGraphStore; only reject nodes that already carry a foreign owner.
-        var permitted = nodes.Where(n => CanAccess(n.OwnerId, scope)).ToList();
+        // Fresh nodes arrive unowned/untenanted and are stamped by the inner
+        // ComplianceAwareGraphStore; only reject nodes that already carry a foreign tenant/owner.
+        var permitted = nodes.Where(n => CanAccess(n.TenantId, n.OwnerId, scope)).ToList();
         if (permitted.Count != nodes.Count)
         {
             _logger.LogWarning(
@@ -104,7 +106,7 @@ public sealed class TenantIsolatedGraphStore : IKnowledgeGraphStore
         var scope = CurrentScope;
         if (scope is null) return _inner.AddEdgesAsync(edges, cancellationToken);
 
-        var permitted = edges.Where(e => CanAccess(e.OwnerId, scope)).ToList();
+        var permitted = edges.Where(e => CanAccess(e.TenantId, e.OwnerId, scope)).ToList();
         return permitted.Count == 0
             ? Task.CompletedTask
             : _inner.AddEdgesAsync(permitted, cancellationToken);
@@ -118,7 +120,7 @@ public sealed class TenantIsolatedGraphStore : IKnowledgeGraphStore
         var node = await _inner.GetNodeAsync(nodeId, cancellationToken);
         var scope = CurrentScope;
         if (node is null || scope is null) return node;
-        return CanAccess(node.OwnerId, scope) ? node : null;
+        return CanAccess(node.TenantId, node.OwnerId, scope) ? node : null;
     }
 
     /// <inheritdoc />
@@ -136,11 +138,11 @@ public sealed class TenantIsolatedGraphStore : IKnowledgeGraphStore
         // shared entities it connects to. (GetTripletsAsync needs no seed guard — the seed always
         // appears as a triplet endpoint and is dropped by the both-endpoints-visible filter.)
         var seed = await _inner.GetNodeAsync(nodeId, cancellationToken);
-        if (seed is null || !CanAccess(seed.OwnerId, scope))
+        if (seed is null || !CanAccess(seed.TenantId, seed.OwnerId, scope))
             return [];
 
         var neighbors = await _inner.GetNeighborsAsync(nodeId, maxDepth, cancellationToken);
-        return neighbors.Where(n => CanAccess(n.OwnerId, scope)).ToList();
+        return neighbors.Where(n => CanAccess(n.TenantId, n.OwnerId, scope)).ToList();
     }
 
     /// <inheritdoc />
@@ -154,7 +156,8 @@ public sealed class TenantIsolatedGraphStore : IKnowledgeGraphStore
 
         // A triplet is visible only when both endpoints are visible to the caller.
         return triplets
-            .Where(t => CanAccess(t.Source.OwnerId, scope) && CanAccess(t.Target.OwnerId, scope))
+            .Where(t => CanAccess(t.Source.TenantId, t.Source.OwnerId, scope)
+                     && CanAccess(t.Target.TenantId, t.Target.OwnerId, scope))
             .ToList();
     }
 
@@ -169,9 +172,9 @@ public sealed class TenantIsolatedGraphStore : IKnowledgeGraphStore
         // Existence must mirror visibility: a node the caller cannot read does not exist for them.
         // This trades the backend's cheap existence probe for a full node fetch to read OwnerId;
         // acceptable for typical use, but bulk ingestion dedup on a large backend would want an
-        // owner-aware NodeExists primitive on IKnowledgeGraphStore (deferred with the TenantId work).
+        // tenant/owner-aware NodeExists primitive on IKnowledgeGraphStore would avoid the full fetch.
         var node = await _inner.GetNodeAsync(nodeId, cancellationToken);
-        return node is not null && CanAccess(node.OwnerId, scope);
+        return node is not null && CanAccess(node.TenantId, node.OwnerId, scope);
     }
 
     /// <inheritdoc />
@@ -188,7 +191,7 @@ public sealed class TenantIsolatedGraphStore : IKnowledgeGraphStore
 
         var node = await _inner.GetNodeAsync(nodeId, cancellationToken);
         if (node is null) return;
-        if (!CanAccess(node.OwnerId, scope))
+        if (!CanAccess(node.TenantId, node.OwnerId, scope))
         {
             _logger.LogWarning(
                 "Tenant isolation: blocked delete of foreign node {NodeId} for User={UserId}",
@@ -203,8 +206,9 @@ public sealed class TenantIsolatedGraphStore : IKnowledgeGraphStore
     public Task DeleteEdgeAsync(
         string edgeId,
         CancellationToken cancellationToken = default)
-        // Edges expose no owner lookup; edge-level isolation is deferred with the TenantId model
-        // change. Edges carry no user-memory content, so this delegates unfiltered.
+        // The store exposes no get-edge-by-id, so an edge's tenant/owner can't be checked on delete.
+        // Edges carry no user-memory content (they connect entity nodes), so this delegates unfiltered;
+        // an edge-by-id lookup primitive would be needed to gate it.
         => _inner.DeleteEdgeAsync(edgeId, cancellationToken);
 
     /// <inheritdoc />
@@ -219,7 +223,7 @@ public sealed class TenantIsolatedGraphStore : IKnowledgeGraphStore
         // proper fix is an owner-scoped count primitive on IKnowledgeGraphStore (deferred with the
         // TenantId work); until then, prefer not to poll this on large multi-tenant graphs.
         var all = await _inner.GetAllNodesAsync(cancellationToken);
-        return all.Count(n => CanAccess(n.OwnerId, scope));
+        return all.Count(n => CanAccess(n.TenantId, n.OwnerId, scope));
     }
 
     /// <inheritdoc />
@@ -252,12 +256,25 @@ public sealed class TenantIsolatedGraphStore : IKnowledgeGraphStore
     {
         var scope = CurrentScope;
         if (scope is null) return nodes;
-        return nodes.Where(n => CanAccess(n.OwnerId, scope)).ToList();
+        return nodes.Where(n => CanAccess(n.TenantId, n.OwnerId, scope)).ToList();
     }
 
     /// <summary>
-    /// A record is accessible when it is unowned (shared corpus) or the caller owns it.
+    /// A record is accessible to the caller when BOTH hold:
+    /// <list type="bullet">
+    ///   <item><b>tenant</b>: the record is global (<paramref name="tenantId"/> is null) or belongs
+    ///   to the caller's tenant (<see cref="IKnowledgeScopeValidator.ValidateAccess"/>);</item>
+    ///   <item><b>owner</b>: the record is shared within the tenant (<paramref name="ownerId"/> is
+    ///   null — e.g. corpus/learnings) or the caller owns it
+    ///   (<see cref="IKnowledgeScopeValidator.CanAccessDataset"/> — e.g. their memory).</item>
+    /// </list>
+    /// So a user sees their tenant's shared corpus plus their own memory, never another tenant's
+    /// data and never another user's memory within the tenant.
     /// </summary>
-    private bool CanAccess(string? ownerId, IKnowledgeScope scope)
-        => ownerId is null || _validator.CanAccessDataset(scope, ownerId);
+    private bool CanAccess(string? tenantId, string? ownerId, IKnowledgeScope scope)
+    {
+        var tenantOk = tenantId is null || _validator.ValidateAccess(scope, tenantId);
+        var ownerOk = ownerId is null || _validator.CanAccessDataset(scope, ownerId);
+        return tenantOk && ownerOk;
+    }
 }

--- a/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/Scoping/TenantIsolatedGraphStore.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/Scoping/TenantIsolatedGraphStore.cs
@@ -283,6 +283,18 @@ public sealed class TenantIsolatedGraphStore : IKnowledgeGraphStore
     /// </summary>
     private bool CanAccess(string? tenantId, string? ownerId, IKnowledgeScope scope)
     {
+        // Misconfiguration guard: this decorator is only wired when MultiTenantIsolation is on, so a
+        // non-system caller (scope present) with no TenantId means auth populated UserId but not the
+        // tenant claim. Such a caller keeps their own owned memory (owner match) but silently loses
+        // their tenant's shared corpus on every read. Surface it loudly rather than failing silent.
+        if (tenantId is not null && scope.UserId is not null && scope.TenantId is null)
+        {
+            _logger.LogWarning(
+                "Tenant isolation: caller User={UserId} has no TenantId while isolation is enabled — " +
+                "tenant-scoped records are being hidden. Ensure the tenant claim is wired into IKnowledgeScope.",
+                scope.UserId);
+        }
+
         var tenantOk = tenantId is null || _validator.ValidateAccess(scope, tenantId);
         var ownerOk = ownerId is null || _validator.CanAccessDataset(scope, ownerId);
         return tenantOk && ownerOk;

--- a/src/Content/Infrastructure/Infrastructure.AI.RAG/GraphRag/ManagedCodeGraphRagService.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.RAG/GraphRag/ManagedCodeGraphRagService.cs
@@ -299,11 +299,20 @@ public sealed class ManagedCodeGraphRagService : IGraphRagService
                 })
                 .ToList();
 
+            // Resolve relationship endpoints (referenced by name) to the actual node ids, which encode
+            // the entity type — otherwise edges would reference "{name}:entity" and never join to the
+            // "{name}:{type}" nodes. Fall back to "{name}:entity" only for names not extracted here.
+            var nodeIdByName = nodes
+                .GroupBy(n => n.Name.ToLowerInvariant())
+                .ToDictionary(g => g.Key, g => g.First().Id);
+
             var edges = (parsed?.Relationships ?? [])
                 .Select(r =>
                 {
-                    var source = $"{(r.Source ?? "unknown").ToLowerInvariant()}:entity";
-                    var target = $"{(r.Target ?? "unknown").ToLowerInvariant()}:entity";
+                    var sourceName = (r.Source ?? "unknown").ToLowerInvariant();
+                    var targetName = (r.Target ?? "unknown").ToLowerInvariant();
+                    var source = nodeIdByName.GetValueOrDefault(sourceName, $"{sourceName}:entity");
+                    var target = nodeIdByName.GetValueOrDefault(targetName, $"{targetName}:entity");
                     var predicate = r.Predicate ?? "related_to";
                     return new GraphEdge
                     {

--- a/src/Content/Tests/Domain.AI.Tests/KnowledgeGraph/GraphNodeTests.cs
+++ b/src/Content/Tests/Domain.AI.Tests/KnowledgeGraph/GraphNodeTests.cs
@@ -90,6 +90,28 @@ public sealed class GraphNodeTests
     }
 
     [Fact]
+    public void Defaults_OwnerAndTenant_AreNull()
+    {
+        var node = new GraphNode { Id = "test", Name = "Test", Type = "Entity" };
+
+        node.OwnerId.Should().BeNull();
+        node.TenantId.Should().BeNull();
+    }
+
+    [Fact]
+    public void TenantId_WhenSet_RoundTripsAndPreservesOnWith()
+    {
+        var node = new GraphNode
+        {
+            Id = "n1", Name = "Test", Type = "Entity",
+            OwnerId = "user-1", TenantId = "tenant-acme"
+        };
+
+        node.TenantId.Should().Be("tenant-acme");
+        (node with { Name = "Renamed" }).TenantId.Should().Be("tenant-acme");
+    }
+
+    [Fact]
     public void ChunkIds_MultipleChunks_PreservesAll()
     {
         var node = new GraphNode
@@ -159,6 +181,19 @@ public sealed class GraphEdgeTests
         };
 
         edge1.Should().BeEquivalentTo(edge2);
+    }
+
+    [Fact]
+    public void TenantId_WhenSet_RoundTrips()
+    {
+        var edge = new GraphEdge
+        {
+            Id = "e1", SourceNodeId = "n1", TargetNodeId = "n2",
+            Predicate = "uses", ChunkId = "c1", TenantId = "tenant-acme"
+        };
+
+        edge.TenantId.Should().Be("tenant-acme");
+        edge.OwnerId.Should().BeNull();
     }
 }
 

--- a/src/Content/Tests/Infrastructure.AI.KnowledgeGraph.Tests/Compliance/ComplianceAwareGraphStoreTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.KnowledgeGraph.Tests/Compliance/ComplianceAwareGraphStoreTests.cs
@@ -28,6 +28,7 @@ public sealed class ComplianceAwareGraphStoreTests
         _auditSink = new Mock<IMemoryAuditSink>();
         _scope = new Mock<IKnowledgeScope>();
         _scope.Setup(s => s.UserId).Returns("user-1");
+        _scope.Setup(s => s.TenantId).Returns("tenant-1");
         _retentionProvider = new Mock<IRetentionPolicyProvider>();
         _retentionProvider.Setup(r => r.GetPolicy(It.IsAny<string>()))
             .Returns(new RetentionPolicy
@@ -65,6 +66,28 @@ public sealed class ComplianceAwareGraphStoreTests
         stored!.CreatedAt.Should().Be(_timeProvider.GetUtcNow());
         stored.ExpiresAt.Should().Be(_timeProvider.GetUtcNow().AddDays(365));
         stored.OwnerId.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task AddNodes_StampsTenantFromScope()
+    {
+        // Unlike owner, tenant IS defaulted to the caller's tenant — this is what scopes a
+        // tenant's ingested corpus to that tenant.
+        var node = new GraphNode { Id = "n1", Name = "Test", Type = "Fact" };
+
+        await _store.AddNodesAsync([node]);
+
+        (await _innerStore.GetNodeAsync("n1"))!.TenantId.Should().Be("tenant-1");
+    }
+
+    [Fact]
+    public async Task AddNodes_PreservesExplicitTenantId()
+    {
+        var node = new GraphNode { Id = "n1", Name = "Test", Type = "Fact", TenantId = "tenant-explicit" };
+
+        await _store.AddNodesAsync([node]);
+
+        (await _innerStore.GetNodeAsync("n1"))!.TenantId.Should().Be("tenant-explicit");
     }
 
     [Fact]

--- a/src/Content/Tests/Infrastructure.AI.KnowledgeGraph.Tests/Infrastructure.AI.KnowledgeGraph.Tests.csproj
+++ b/src/Content/Tests/Infrastructure.AI.KnowledgeGraph.Tests/Infrastructure.AI.KnowledgeGraph.Tests.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Moq" />
+    <PackageReference Include="Testcontainers" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>

--- a/src/Content/Tests/Infrastructure.AI.KnowledgeGraph.Tests/Neo4j/Neo4jGraphStoreTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.KnowledgeGraph.Tests/Neo4j/Neo4jGraphStoreTests.cs
@@ -108,6 +108,25 @@ public sealed class Neo4jGraphStoreTests : IClassFixture<Neo4jStoreFixture>
     }
 
     [Fact]
+    public async Task AddNode_RewriteWithoutOwnerTenant_PreservesExisting()
+    {
+        // A later write that omits owner/tenant (e.g. a background/system re-ingest of an entity id
+        // that collides with an existing node) must NOT null-clobber the stored owner/tenant, or the
+        // node would silently become global and leak across tenants.
+        await _store.AddNodesAsync([new GraphNode
+        {
+            Id = "neo-pres", Name = "P", Type = "Entity",
+            OwnerId = "neo-owner-p", TenantId = "neo-tenant-p"
+        }]);
+        await _store.AddNodesAsync([new GraphNode { Id = "neo-pres", Name = "P2", Type = "Entity" }]);
+
+        var node = await _store.GetNodeAsync("neo-pres");
+
+        node!.OwnerId.Should().Be("neo-owner-p");
+        node.TenantId.Should().Be("neo-tenant-p");
+    }
+
+    [Fact]
     public async Task AddAndGetTriplet_RoundTripsEdgeTenantAndEndpoints()
     {
         await _store.AddNodesAsync([

--- a/src/Content/Tests/Infrastructure.AI.KnowledgeGraph.Tests/Neo4j/Neo4jGraphStoreTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.KnowledgeGraph.Tests/Neo4j/Neo4jGraphStoreTests.cs
@@ -1,0 +1,120 @@
+using Domain.AI.KnowledgeGraph.Models;
+using Domain.Common.Config;
+using DotNet.Testcontainers.Builders;
+using DotNet.Testcontainers.Containers;
+using FluentAssertions;
+using Infrastructure.AI.KnowledgeGraph.Neo4j;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Infrastructure.AI.KnowledgeGraph.Tests.Neo4j;
+
+/// <summary>
+/// Integration tests for <see cref="Neo4jGraphStore"/> against a real Neo4j container.
+/// Verifies that owner/tenant/temporal fields round-trip through Cypher (they were previously
+/// dropped on write) and that the formerly-stubbed <c>GetAllNodesAsync</c>/<c>GetNodesByOwnerAsync</c>
+/// now return data — the persistence prerequisites for tenant isolation on this backend.
+/// </summary>
+/// <remarks>Requires Docker. Gated with <c>[Trait("Category","E2E")]</c> so it can be filtered out.</remarks>
+[Trait("Category", "E2E")]
+public sealed class Neo4jGraphStoreTests : IAsyncLifetime
+{
+    private readonly IContainer _neo4j = new ContainerBuilder()
+        .WithImage("neo4j:5.20")
+        .WithEnvironment("NEO4J_AUTH", "neo4j/testpassword")
+        .WithPortBinding(7687, true)
+        .WithWaitStrategy(Wait.ForUnixContainer().UntilMessageIsLogged("Started."))
+        .Build();
+
+    private Neo4jGraphStore _store = null!;
+
+    public async Task InitializeAsync()
+    {
+        await _neo4j.StartAsync();
+
+        var connString = $"bolt://neo4j:testpassword@localhost:{_neo4j.GetMappedPublicPort(7687)}";
+        var config = new AppConfig();
+        config.AI.Rag.GraphRag.ConnectionString = connString;
+        var monitor = Mock.Of<IOptionsMonitor<AppConfig>>(m => m.CurrentValue == config);
+        _store = new Neo4jGraphStore(monitor, NullLogger<Neo4jGraphStore>.Instance);
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _store.DisposeAsync();
+        await _neo4j.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task AddAndGetNode_RoundTripsOwnerTenantAndTemporal()
+    {
+        var created = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        var expires = created.AddDays(365);
+        await _store.AddNodesAsync([new GraphNode
+        {
+            Id = "n1", Name = "Acme Corp", Type = "Organization",
+            OwnerId = "user-a", TenantId = "tenant-a",
+            CreatedAt = created, ExpiresAt = expires
+        }]);
+
+        var node = await _store.GetNodeAsync("n1");
+
+        node.Should().NotBeNull();
+        node!.OwnerId.Should().Be("user-a");
+        node.TenantId.Should().Be("tenant-a");
+        node.CreatedAt.Should().BeCloseTo(created, TimeSpan.FromSeconds(1));
+        node.ExpiresAt.Should().BeCloseTo(expires, TimeSpan.FromSeconds(1));
+    }
+
+    [Fact]
+    public async Task GetAllNodes_ReturnsInsertedNodes()
+    {
+        await _store.AddNodesAsync([
+            new GraphNode { Id = "a", Name = "A", Type = "Entity", TenantId = "t1" },
+            new GraphNode { Id = "b", Name = "B", Type = "Entity", TenantId = "t2" }
+        ]);
+
+        var all = await _store.GetAllNodesAsync();
+
+        all.Select(n => n.Id).Should().Contain(["a", "b"]);
+        all.Single(n => n.Id == "a").TenantId.Should().Be("t1");
+    }
+
+    [Fact]
+    public async Task GetNodesByOwner_ReturnsOnlyMatchingOwner()
+    {
+        await _store.AddNodesAsync([
+            new GraphNode { Id = "own", Name = "Own", Type = "Entity", OwnerId = "user-x" },
+            new GraphNode { Id = "other", Name = "Other", Type = "Entity", OwnerId = "user-y" }
+        ]);
+
+        var owned = await _store.GetNodesByOwnerAsync("user-x");
+
+        owned.Select(n => n.Id).Should().BeEquivalentTo(["own"]);
+    }
+
+    [Fact]
+    public async Task AddAndGetTriplet_RoundTripsEdgeTenantAndEndpoints()
+    {
+        await _store.AddNodesAsync([
+            new GraphNode { Id = "s", Name = "S", Type = "Entity", TenantId = "tenant-a" },
+            new GraphNode { Id = "t", Name = "T", Type = "Entity", TenantId = "tenant-a" }
+        ]);
+        await _store.AddEdgesAsync([new GraphEdge
+        {
+            Id = "e1", SourceNodeId = "s", TargetNodeId = "t",
+            Predicate = "relates_to", ChunkId = "c1", TenantId = "tenant-a"
+        }]);
+
+        var triplets = await _store.GetTripletsAsync(["s"]);
+
+        triplets.Should().ContainSingle();
+        var edge = triplets[0].Edge;
+        edge.SourceNodeId.Should().Be("s");
+        edge.TargetNodeId.Should().Be("t");
+        edge.TenantId.Should().Be("tenant-a");
+        triplets[0].Source.TenantId.Should().Be("tenant-a");
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.KnowledgeGraph.Tests/Neo4j/Neo4jGraphStoreTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.KnowledgeGraph.Tests/Neo4j/Neo4jGraphStoreTests.cs
@@ -12,14 +12,10 @@ using Xunit;
 namespace Infrastructure.AI.KnowledgeGraph.Tests.Neo4j;
 
 /// <summary>
-/// Integration tests for <see cref="Neo4jGraphStore"/> against a real Neo4j container.
-/// Verifies that owner/tenant/temporal fields round-trip through Cypher (they were previously
-/// dropped on write) and that the formerly-stubbed <c>GetAllNodesAsync</c>/<c>GetNodesByOwnerAsync</c>
-/// now return data — the persistence prerequisites for tenant isolation on this backend.
+/// Shared Neo4j container + store for the integration tests. One container per test class (via
+/// <see cref="IClassFixture{T}"/>) rather than one per method — faster and avoids container churn.
 /// </summary>
-/// <remarks>Requires Docker. Gated with <c>[Trait("Category","E2E")]</c> so it can be filtered out.</remarks>
-[Trait("Category", "E2E")]
-public sealed class Neo4jGraphStoreTests : IAsyncLifetime
+public sealed class Neo4jStoreFixture : IAsyncLifetime
 {
     private readonly IContainer _neo4j = new ContainerBuilder()
         .WithImage("neo4j:5.20")
@@ -28,7 +24,7 @@ public sealed class Neo4jGraphStoreTests : IAsyncLifetime
         .WithWaitStrategy(Wait.ForUnixContainer().UntilMessageIsLogged("Started."))
         .Build();
 
-    private Neo4jGraphStore _store = null!;
+    public Neo4jGraphStore Store { get; private set; } = null!;
 
     public async Task InitializeAsync()
     {
@@ -38,14 +34,30 @@ public sealed class Neo4jGraphStoreTests : IAsyncLifetime
         var config = new AppConfig();
         config.AI.Rag.GraphRag.ConnectionString = connString;
         var monitor = Mock.Of<IOptionsMonitor<AppConfig>>(m => m.CurrentValue == config);
-        _store = new Neo4jGraphStore(monitor, NullLogger<Neo4jGraphStore>.Instance);
+        Store = new Neo4jGraphStore(monitor, NullLogger<Neo4jGraphStore>.Instance);
     }
 
     public async Task DisposeAsync()
     {
-        await _store.DisposeAsync();
+        await Store.DisposeAsync();
         await _neo4j.DisposeAsync();
     }
+}
+
+/// <summary>
+/// Integration tests for <see cref="Neo4jGraphStore"/> against a real Neo4j container.
+/// Verifies that owner/tenant/temporal fields round-trip through Cypher (they were previously
+/// dropped on write) and that the formerly-stubbed <c>GetAllNodesAsync</c>/<c>GetNodesByOwnerAsync</c>
+/// now return data — the persistence prerequisites for tenant isolation on this backend. Each test
+/// uses unique ids so they remain correct against the shared container.
+/// </summary>
+/// <remarks>Requires Docker. Gated with <c>[Trait("Category","E2E")]</c> so it can be filtered out.</remarks>
+[Trait("Category", "E2E")]
+public sealed class Neo4jGraphStoreTests : IClassFixture<Neo4jStoreFixture>
+{
+    private readonly Neo4jGraphStore _store;
+
+    public Neo4jGraphStoreTests(Neo4jStoreFixture fixture) => _store = fixture.Store;
 
     [Fact]
     public async Task AddAndGetNode_RoundTripsOwnerTenantAndTemporal()
@@ -54,16 +66,16 @@ public sealed class Neo4jGraphStoreTests : IAsyncLifetime
         var expires = created.AddDays(365);
         await _store.AddNodesAsync([new GraphNode
         {
-            Id = "n1", Name = "Acme Corp", Type = "Organization",
-            OwnerId = "user-a", TenantId = "tenant-a",
+            Id = "neo-n1", Name = "Acme Corp", Type = "Organization",
+            OwnerId = "neo-user-a", TenantId = "neo-tenant-a",
             CreatedAt = created, ExpiresAt = expires
         }]);
 
-        var node = await _store.GetNodeAsync("n1");
+        var node = await _store.GetNodeAsync("neo-n1");
 
         node.Should().NotBeNull();
-        node!.OwnerId.Should().Be("user-a");
-        node.TenantId.Should().Be("tenant-a");
+        node!.OwnerId.Should().Be("neo-user-a");
+        node.TenantId.Should().Be("neo-tenant-a");
         node.CreatedAt.Should().BeCloseTo(created, TimeSpan.FromSeconds(1));
         node.ExpiresAt.Should().BeCloseTo(expires, TimeSpan.FromSeconds(1));
     }
@@ -72,49 +84,49 @@ public sealed class Neo4jGraphStoreTests : IAsyncLifetime
     public async Task GetAllNodes_ReturnsInsertedNodes()
     {
         await _store.AddNodesAsync([
-            new GraphNode { Id = "a", Name = "A", Type = "Entity", TenantId = "t1" },
-            new GraphNode { Id = "b", Name = "B", Type = "Entity", TenantId = "t2" }
+            new GraphNode { Id = "neo-all-a", Name = "A", Type = "Entity", TenantId = "t1" },
+            new GraphNode { Id = "neo-all-b", Name = "B", Type = "Entity", TenantId = "t2" }
         ]);
 
         var all = await _store.GetAllNodesAsync();
 
-        all.Select(n => n.Id).Should().Contain(["a", "b"]);
-        all.Single(n => n.Id == "a").TenantId.Should().Be("t1");
+        all.Select(n => n.Id).Should().Contain(["neo-all-a", "neo-all-b"]);
+        all.Single(n => n.Id == "neo-all-a").TenantId.Should().Be("t1");
     }
 
     [Fact]
     public async Task GetNodesByOwner_ReturnsOnlyMatchingOwner()
     {
         await _store.AddNodesAsync([
-            new GraphNode { Id = "own", Name = "Own", Type = "Entity", OwnerId = "user-x" },
-            new GraphNode { Id = "other", Name = "Other", Type = "Entity", OwnerId = "user-y" }
+            new GraphNode { Id = "neo-own", Name = "Own", Type = "Entity", OwnerId = "neo-owner-x" },
+            new GraphNode { Id = "neo-other", Name = "Other", Type = "Entity", OwnerId = "neo-owner-y" }
         ]);
 
-        var owned = await _store.GetNodesByOwnerAsync("user-x");
+        var owned = await _store.GetNodesByOwnerAsync("neo-owner-x");
 
-        owned.Select(n => n.Id).Should().BeEquivalentTo(["own"]);
+        owned.Select(n => n.Id).Should().BeEquivalentTo(["neo-own"]);
     }
 
     [Fact]
     public async Task AddAndGetTriplet_RoundTripsEdgeTenantAndEndpoints()
     {
         await _store.AddNodesAsync([
-            new GraphNode { Id = "s", Name = "S", Type = "Entity", TenantId = "tenant-a" },
-            new GraphNode { Id = "t", Name = "T", Type = "Entity", TenantId = "tenant-a" }
+            new GraphNode { Id = "neo-s", Name = "S", Type = "Entity", TenantId = "tenant-a" },
+            new GraphNode { Id = "neo-t", Name = "T", Type = "Entity", TenantId = "tenant-a" }
         ]);
         await _store.AddEdgesAsync([new GraphEdge
         {
-            Id = "e1", SourceNodeId = "s", TargetNodeId = "t",
+            Id = "neo-e1", SourceNodeId = "neo-s", TargetNodeId = "neo-t",
             Predicate = "relates_to", ChunkId = "c1", TenantId = "tenant-a"
         }]);
 
-        var triplets = await _store.GetTripletsAsync(["s"]);
+        var triplets = await _store.GetTripletsAsync(["neo-s"]);
 
-        triplets.Should().ContainSingle();
-        var edge = triplets[0].Edge;
-        edge.SourceNodeId.Should().Be("s");
-        edge.TargetNodeId.Should().Be("t");
-        edge.TenantId.Should().Be("tenant-a");
-        triplets[0].Source.TenantId.Should().Be("tenant-a");
+        triplets.Should().ContainSingle(t => t.Edge.Id == "neo-e1");
+        var triplet = triplets.Single(t => t.Edge.Id == "neo-e1");
+        triplet.Edge.SourceNodeId.Should().Be("neo-s");
+        triplet.Edge.TargetNodeId.Should().Be("neo-t");
+        triplet.Edge.TenantId.Should().Be("tenant-a");
+        triplet.Source.TenantId.Should().Be("tenant-a");
     }
 }

--- a/src/Content/Tests/Infrastructure.AI.KnowledgeGraph.Tests/PostgreSql/PostgreSqlGraphStoreTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.KnowledgeGraph.Tests/PostgreSql/PostgreSqlGraphStoreTests.cs
@@ -1,0 +1,131 @@
+using Domain.AI.KnowledgeGraph.Models;
+using Domain.Common.Config;
+using DotNet.Testcontainers.Builders;
+using DotNet.Testcontainers.Containers;
+using FluentAssertions;
+using Infrastructure.AI.KnowledgeGraph.PostgreSql;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Infrastructure.AI.KnowledgeGraph.Tests.PostgreSql;
+
+/// <summary>
+/// Shared PostgreSQL container + store for the integration tests. Using a single container per test
+/// class (via <see cref="IClassFixture{T}"/>) avoids spinning up one container per test method, which
+/// both speeds the suite up and sidesteps the postgres image's init-then-restart readiness race.
+/// </summary>
+public sealed class PostgreSqlStoreFixture : IAsyncLifetime
+{
+    private readonly IContainer _postgres = new ContainerBuilder()
+        .WithImage("postgres:16")
+        .WithEnvironment("POSTGRES_PASSWORD", "postgres")
+        .WithPortBinding(5432, true)
+        .WithWaitStrategy(Wait.ForUnixContainer()
+            .UntilCommandIsCompleted("pg_isready", "-U", "postgres"))
+        .Build();
+
+    public PostgreSqlGraphStore Store { get; private set; } = null!;
+
+    public async Task InitializeAsync()
+    {
+        await _postgres.StartAsync();
+
+        var connString =
+            $"Host=localhost;Port={_postgres.GetMappedPublicPort(5432)};" +
+            "Username=postgres;Password=postgres;Database=postgres";
+        var config = new AppConfig();
+        config.AI.Rag.GraphRag.ConnectionString = connString;
+        var monitor = Mock.Of<IOptionsMonitor<AppConfig>>(m => m.CurrentValue == config);
+        Store = new PostgreSqlGraphStore(monitor, NullLogger<PostgreSqlGraphStore>.Instance);
+    }
+
+    public Task DisposeAsync() => _postgres.DisposeAsync().AsTask();
+}
+
+/// <summary>
+/// Integration tests for <see cref="PostgreSqlGraphStore"/> against a real PostgreSQL container.
+/// Verifies the self-initializing schema, that owner/tenant/temporal fields round-trip (they were
+/// previously absent from INSERT/SELECT), and that the formerly-stubbed
+/// <c>GetAllNodesAsync</c>/<c>GetNodesByOwnerAsync</c> now return data. Each test uses unique ids so
+/// they remain correct against the shared container.
+/// </summary>
+/// <remarks>Requires Docker. Gated with <c>[Trait("Category","E2E")]</c> so it can be filtered out.</remarks>
+[Trait("Category", "E2E")]
+public sealed class PostgreSqlGraphStoreTests : IClassFixture<PostgreSqlStoreFixture>
+{
+    private readonly PostgreSqlGraphStore _store;
+
+    public PostgreSqlGraphStoreTests(PostgreSqlStoreFixture fixture) => _store = fixture.Store;
+
+    [Fact]
+    public async Task AddAndGetNode_CreatesSchemaAndRoundTripsOwnerTenantTemporal()
+    {
+        // The store creates kg_nodes/kg_edges on first use — no external migration needed.
+        var created = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        var expires = created.AddDays(365);
+        await _store.AddNodesAsync([new GraphNode
+        {
+            Id = "pg-n1", Name = "Acme Corp", Type = "Organization",
+            OwnerId = "pg-user-a", TenantId = "pg-tenant-a",
+            CreatedAt = created, ExpiresAt = expires
+        }]);
+
+        var node = await _store.GetNodeAsync("pg-n1");
+
+        node.Should().NotBeNull();
+        node!.OwnerId.Should().Be("pg-user-a");
+        node.TenantId.Should().Be("pg-tenant-a");
+        node.CreatedAt.Should().BeCloseTo(created, TimeSpan.FromSeconds(1));
+        node.ExpiresAt.Should().BeCloseTo(expires, TimeSpan.FromSeconds(1));
+    }
+
+    [Fact]
+    public async Task GetAllNodes_ReturnsInsertedNodesWithTenant()
+    {
+        await _store.AddNodesAsync([
+            new GraphNode { Id = "pg-all-a", Name = "A", Type = "Entity", TenantId = "t1" },
+            new GraphNode { Id = "pg-all-b", Name = "B", Type = "Entity", TenantId = "t2" }
+        ]);
+
+        var all = await _store.GetAllNodesAsync();
+
+        all.Select(n => n.Id).Should().Contain(["pg-all-a", "pg-all-b"]);
+        all.Single(n => n.Id == "pg-all-a").TenantId.Should().Be("t1");
+    }
+
+    [Fact]
+    public async Task GetNodesByOwner_ReturnsOnlyMatchingOwner()
+    {
+        await _store.AddNodesAsync([
+            new GraphNode { Id = "pg-own", Name = "Own", Type = "Entity", OwnerId = "pg-owner-x" },
+            new GraphNode { Id = "pg-other", Name = "Other", Type = "Entity", OwnerId = "pg-owner-y" }
+        ]);
+
+        var owned = await _store.GetNodesByOwnerAsync("pg-owner-x");
+
+        owned.Select(n => n.Id).Should().BeEquivalentTo(["pg-own"]);
+    }
+
+    [Fact]
+    public async Task AddAndGetTriplet_RoundTripsEdgeTenant()
+    {
+        await _store.AddNodesAsync([
+            new GraphNode { Id = "pg-s", Name = "S", Type = "Entity", TenantId = "tenant-a" },
+            new GraphNode { Id = "pg-t", Name = "T", Type = "Entity", TenantId = "tenant-a" }
+        ]);
+        await _store.AddEdgesAsync([new GraphEdge
+        {
+            Id = "pg-e1", SourceNodeId = "pg-s", TargetNodeId = "pg-t",
+            Predicate = "relates_to", ChunkId = "c1", TenantId = "tenant-a"
+        }]);
+
+        var triplets = await _store.GetTripletsAsync(["pg-s"]);
+
+        triplets.Should().ContainSingle();
+        triplets[0].Edge.TenantId.Should().Be("tenant-a");
+        triplets[0].Source.TenantId.Should().Be("tenant-a");
+        triplets[0].Target.Id.Should().Be("pg-t");
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.KnowledgeGraph.Tests/Scoping/TenantIsolatedGraphStoreTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.KnowledgeGraph.Tests/Scoping/TenantIsolatedGraphStoreTests.cs
@@ -25,6 +25,8 @@ public sealed class TenantIsolatedGraphStoreTests
 {
     private const string UserA = "user-a";
     private const string UserB = "user-b";
+    private const string TenantA = "tenant-a";
+    private const string TenantB = "tenant-b";
 
     private readonly InMemoryGraphStore _innerStore;
     private readonly KnowledgeScopeValidator _validator;
@@ -177,8 +179,79 @@ public sealed class TenantIsolatedGraphStoreTests
         (await store.GetNeighborsAsync("seed")).Select(n => n.Id).Should().Contain("nbr");
     }
 
+    // --- Tenant-level isolation ---
+
+    [Fact]
+    public async Task GetNode_DifferentTenant_SharedCorpus_ReturnsNull()
+    {
+        // A tenant's shared corpus (null owner) must be invisible to other tenants.
+        await SeedTenantNode("n1", tenant: TenantB, owner: null);
+        var store = StoreForTenant(UserA, TenantA);
+
+        (await store.GetNodeAsync("n1")).Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetNode_SameTenant_SharedCorpus_ReturnsNode()
+    {
+        await SeedTenantNode("n1", tenant: TenantA, owner: null);
+        var store = StoreForTenant(UserA, TenantA);
+
+        (await store.GetNodeAsync("n1")).Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task GetNode_SameTenant_OtherUsersMemory_ReturnsNull()
+    {
+        // Within one tenant, a user still cannot read another user's owned memory.
+        await SeedTenantNode("n1", tenant: TenantA, owner: UserB);
+        var store = StoreForTenant(UserA, TenantA);
+
+        (await store.GetNodeAsync("n1")).Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetNode_SameTenant_OwnMemory_ReturnsNode()
+    {
+        await SeedTenantNode("n1", tenant: TenantA, owner: UserA);
+        var store = StoreForTenant(UserA, TenantA);
+
+        (await store.GetNodeAsync("n1")).Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task GetNode_GlobalNullTenant_VisibleAcrossTenants()
+    {
+        // Global (null-tenant) reference data is visible to every tenant.
+        await SeedTenantNode("n1", tenant: null, owner: null);
+        var store = StoreForTenant(UserA, TenantA);
+
+        (await store.GetNodeAsync("n1")).Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task GetAllNodes_FiltersByTenantAndOwner()
+    {
+        await SeedTenantNode("mine", tenant: TenantA, owner: UserA);
+        await SeedTenantNode("tenantShared", tenant: TenantA, owner: null);
+        await SeedTenantNode("otherTenant", tenant: TenantB, owner: null);
+        await SeedTenantNode("otherUserSameTenant", tenant: TenantA, owner: UserB);
+        await SeedTenantNode("global", tenant: null, owner: null);
+        var store = StoreForTenant(UserA, TenantA);
+
+        var ids = (await store.GetAllNodesAsync()).Select(n => n.Id).ToList();
+
+        ids.Should().BeEquivalentTo(["mine", "tenantShared", "global"]);
+    }
+
     private Task SeedNode(string id, string? owner) =>
         _innerStore.AddNodesAsync([new GraphNode { Id = id, Name = id, Type = "Fact", OwnerId = owner }]);
+
+    private Task SeedTenantNode(string id, string? tenant, string? owner) =>
+        _innerStore.AddNodesAsync([new GraphNode
+        {
+            Id = id, Name = id, Type = "Fact", OwnerId = owner, TenantId = tenant
+        }]);
 
     private Task SeedEdge(string source, string target) =>
         _innerStore.AddEdgesAsync([new GraphEdge
@@ -187,9 +260,14 @@ public sealed class TenantIsolatedGraphStoreTests
             Predicate = "relates_to", ChunkId = "c1"
         }]);
 
-    private TenantIsolatedGraphStore StoreFor(string userId)
+    private TenantIsolatedGraphStore StoreFor(string userId) => StoreForScope(userId, tenantId: null);
+
+    private TenantIsolatedGraphStore StoreForTenant(string userId, string tenantId) =>
+        StoreForScope(userId, tenantId);
+
+    private TenantIsolatedGraphStore StoreForScope(string userId, string? tenantId)
     {
-        var scope = Mock.Of<IKnowledgeScope>(s => s.UserId == userId);
+        var scope = Mock.Of<IKnowledgeScope>(s => s.UserId == userId && s.TenantId == tenantId);
         var services = new ServiceCollection();
         services.AddSingleton(scope);
         var ambient = Mock.Of<IAmbientRequestScope>(a => a.Current == services.BuildServiceProvider());


### PR DESCRIPTION
## Summary

PR 3 of task #6 — **tenant-level knowledge isolation, enforced across all three graph backends**. Completes the multi-tenant memory work: a tenant's data is invisible to other tenants, and (the new part) ingested corpus can be tenant-gated rather than globally shared.

> **Stacked PR.** Based on `feat/task6-multitenant-memory-isolation` (PR #20, PR 1+2), which is not yet merged. Review/merge #20 first, or retarget this to `main` once it lands.

## What this adds

### Tenant dimension (model + default backend)
- `GraphNode`/`GraphEdge` gain a `TenantId` (`null` = global, visible across all tenants).
- `TenantIsolatedGraphStore` now filters every record by **tenant AND owner**: visible iff *(global or same-tenant)* **and** *(shared-in-tenant or caller-owned)*. A user sees their tenant's shared corpus plus their own memory — never another tenant's data, never another user's memory within the tenant.
- `ComplianceAwareGraphStore` stamps `TenantId` from the caller's scope on write (the deliberate opposite of `OwnerId`, which stays writer-authoritative — so a tenant's ingested corpus is scoped to that tenant, while system/background writes stay global).
- `KnowledgeMemoryService` stamps `TenantId` on remembered facts.

### Backend completion (the bulk of the work)
The opt-in **Neo4j** and **PostgreSQL** backends were incomplete (pre-existing): they silently **dropped** `OwnerId`/`CreatedAt`/`ExpiresAt` on write and **stubbed** `GetAllNodesAsync`/`GetNodesByOwnerAsync` (returned `[]`). That made *any* per-record isolation a silent no-op on those backends, and broke retention + erase-by-owner there. This PR completes them:
- **Neo4j** — persist owner/tenant/temporal (+ provenance, + the previously-missing edge source/target) in the MERGE Cypher; rehydrate in `MapNode`/`MapEdge`; implement the two query methods; fix driver init (the Bolt driver rejects a URI with embedded credentials).
- **PostgreSQL** — **self-initializing schema** (there was no table-creation code at all — tables were assumed to pre-exist); persist the four fields in INSERT/SELECT (incl. the 31-column triplet query via offset-based readers); implement the two query methods; serialize DDL with a `pg_advisory_xact_lock` for safe concurrent first-use.

## Test plan

- `dotnet build src/AgenticHarness.slnx` — clean.
- `dotnet test src/AgenticHarness.slnx` — **full suite green**.
- **180 KnowledgeGraph tests**, including **9 Docker-backed Testcontainers integration tests** that verify, against real `neo4j:5.20` and `postgres:16` containers: owner/tenant/temporal round-trip, schema self-init, `GetAllNodes`/`GetNodesByOwner`, triplet reconstruction, and a null-clobber regression. Gated `[Trait("Category","E2E")]` so they can be filtered where Docker is unavailable.
- Unit tests for the tenant filter (cross-tenant hidden, same-tenant shared corpus, same-tenant other-user memory hidden, global visibility, system full-access) and tenant stamping.

## Code review

Two adversarial review passes. Fixed in-PR: Neo4j null-clobber of owner/tenant on re-write (could globalize a private node) → `coalesce`-preserve + regression test; Neo4j malformed URI when port omitted → default 7687; Postgres concurrent-DDL race → advisory lock.

## Known limitation / follow-ups (not blocking — memory isolation is airtight)

Conversation-**memory** isolation is complete (memory ids are `memory:{tenant}:{user}:{key}`-namespaced + owner+tenant stamped). The following concern only the **corpus/entity** dimension and are tracked in `.claude/plans/task6-pr3-tenant-level-isolation.md`:
1. **Shared entity ids across tenants** — corpus entity nodes use content-derived ids, so two tenants ingesting the same entity collide on one node. True per-tenant corpus needs tenant-namespaced ids at ingestion. Documented in code.
2. **Null-tenant = global is fail-open** — deliberate (global reference data), but every stamping gap becomes a cross-tenant read; could move to fail-closed.
3. **Misconfig lockout** — isolation ON + a caller with unpopulated `TenantId` silently loses tenant corpus; suggest fail-fast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
