### PR TITLE
PR-2 follow-ups (phase 1): dedup helpers + NotFound on Process null

### DIFF
--- a/src/Content/Application/Application.AI.Common/CQRS/Changes/ApproveChangeProposal/ApproveChangeProposalCommandHandler.cs
+++ b/src/Content/Application/Application.AI.Common/CQRS/Changes/ApproveChangeProposal/ApproveChangeProposalCommandHandler.cs
@@ -57,37 +57,40 @@ public sealed class ApproveChangeProposalCommandHandler
                 "ChangeProposal pipeline is disabled. Set AppConfig.AI.Changes.Enabled = true to enable.");
         }
 
-        var proposal = await _store.GetAsync(request.ProposalId, cancellationToken).ConfigureAwait(false);
-        if (proposal is null)
-        {
-            return Result<ChangeProposal>.NotFound(
-                $"ChangeProposal '{request.ProposalId}' not found.");
-        }
-
-        if (proposal.Status != ChangeProposalStatus.AwaitingApproval)
-        {
-            return Result<ChangeProposal>.Fail(
-                $"Cannot approve proposal in status {proposal.Status} (must be AwaitingApproval).");
-        }
-
-        var decision = new GateDecision
-        {
-            Timestamp = _time.GetUtcNow(),
-            GateKey = ApprovalGateKey,
-            Action = GateAction.Pass,
-            Reason = string.IsNullOrEmpty(request.Reason) ? "approved" : request.Reason,
-            ReviewerId = request.ReviewerId,
-            DurationMs = 0
-        };
-
-        var approved = proposal.TransitionTo(ChangeProposalStatus.Approved, decision);
-        await _store.SaveAsync(approved, cancellationToken).ConfigureAwait(false);
-
-        // Drive the orchestrator inline so Approved → Merging → Merged (or
-        // Rejected on apply failure) happens before the command returns.
         var mode = ParseMode(changesConfig.DefaultMode);
-        var processed = await _orchestrator.ProcessAsync(approved.Id, mode, cancellationToken).ConfigureAwait(false);
-        return Result<ChangeProposal>.Success(processed ?? approved);
+
+        return await ChangeProposalCommandHelper.ApplyDecisionAsync(
+            _store,
+            request.ProposalId,
+            statusGuard: p => p.Status != ChangeProposalStatus.AwaitingApproval
+                ? Result<ChangeProposal>.Fail(
+                    $"Cannot approve proposal in status {p.Status} (must be AwaitingApproval).")
+                : null,
+            decisionFactory: () => new GateDecision
+            {
+                Timestamp = _time.GetUtcNow(),
+                GateKey = ApprovalGateKey,
+                Action = GateAction.Pass,
+                Reason = string.IsNullOrEmpty(request.Reason) ? "approved" : request.Reason,
+                ReviewerId = request.ReviewerId,
+                DurationMs = 0
+            },
+            targetStatus: ChangeProposalStatus.Approved,
+            postSave: async (approved, ct) =>
+            {
+                // Drive the orchestrator inline so Approved → Merging → Merged
+                // (or Rejected on apply failure) happens before the command
+                // returns. ProcessAsync returns null only when the store lost
+                // the proposal between our Save and its Get — surface as
+                // NotFound rather than returning the stale Approved snapshot,
+                // which would lie about the merge phase having completed.
+                var processed = await _orchestrator.ProcessAsync(approved.Id, mode, ct).ConfigureAwait(false);
+                return processed is null
+                    ? Result<ChangeProposal>.NotFound(
+                        $"ChangeProposal '{approved.Id}' was deleted before the orchestrator could process it.")
+                    : Result<ChangeProposal>.Success(processed);
+            },
+            cancellationToken: cancellationToken).ConfigureAwait(false);
     }
 
     private static OrchestratorMode ParseMode(string raw) =>

--- a/src/Content/Application/Application.AI.Common/CQRS/Changes/CancelChangeProposal/CancelChangeProposalCommandHandler.cs
+++ b/src/Content/Application/Application.AI.Common/CQRS/Changes/CancelChangeProposal/CancelChangeProposalCommandHandler.cs
@@ -37,39 +37,36 @@ public sealed class CancelChangeProposalCommandHandler
         ArgumentNullException.ThrowIfNull(request);
         cancellationToken.ThrowIfCancellationRequested();
 
-        var proposal = await _store.GetAsync(request.ProposalId, cancellationToken).ConfigureAwait(false);
-        if (proposal is null)
-        {
-            return Result<ChangeProposal>.NotFound(
-                $"ChangeProposal '{request.ProposalId}' not found.");
-        }
-
-        if (proposal.IsTerminal)
-        {
-            return Result<ChangeProposal>.Fail(
-                $"Cannot cancel proposal in terminal status {proposal.Status}.");
-        }
-
-        if (proposal.Status == ChangeProposalStatus.Merging)
-        {
-            return Result<ChangeProposal>.Fail(
-                "Cannot cancel proposal while merge is in progress.");
-        }
-
-        var decision = new GateDecision
-        {
-            Timestamp = _time.GetUtcNow(),
-            GateKey = CancellationGateKey,
-            Action = GateAction.Fail,
-            Reason = string.IsNullOrEmpty(request.Reason)
-                ? $"cancelled by {request.CancelledBy}"
-                : request.Reason,
-            ReviewerId = request.CancelledBy,
-            DurationMs = 0
-        };
-
-        var cancelled = proposal.TransitionTo(ChangeProposalStatus.Cancelled, decision);
-        await _store.SaveAsync(cancelled, cancellationToken).ConfigureAwait(false);
-        return Result<ChangeProposal>.Success(cancelled);
+        return await ChangeProposalCommandHelper.ApplyDecisionAsync(
+            _store,
+            request.ProposalId,
+            statusGuard: p =>
+            {
+                if (p.IsTerminal)
+                {
+                    return Result<ChangeProposal>.Fail(
+                        $"Cannot cancel proposal in terminal status {p.Status}.");
+                }
+                if (p.Status == ChangeProposalStatus.Merging)
+                {
+                    return Result<ChangeProposal>.Fail(
+                        "Cannot cancel proposal while merge is in progress.");
+                }
+                return null;
+            },
+            decisionFactory: () => new GateDecision
+            {
+                Timestamp = _time.GetUtcNow(),
+                GateKey = CancellationGateKey,
+                Action = GateAction.Fail,
+                Reason = string.IsNullOrEmpty(request.Reason)
+                    ? $"cancelled by {request.CancelledBy}"
+                    : request.Reason,
+                ReviewerId = request.CancelledBy,
+                DurationMs = 0
+            },
+            targetStatus: ChangeProposalStatus.Cancelled,
+            postSave: null,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/Content/Application/Application.AI.Common/CQRS/Changes/ChangeProposalCommandHelper.cs
+++ b/src/Content/Application/Application.AI.Common/CQRS/Changes/ChangeProposalCommandHelper.cs
@@ -1,0 +1,75 @@
+using Application.AI.Common.Interfaces.Changes;
+using Domain.AI.Changes;
+using Domain.Common;
+
+namespace Application.AI.Common.CQRS.Changes;
+
+/// <summary>
+/// Shared <c>load → status guard → transition + save → optional post-save</c>
+/// skeleton for the <c>Approve</c>, <c>Reject</c>, and <c>Cancel</c> command
+/// handlers. Each handler injects its handler-specific guard predicate,
+/// <see cref="GateDecision"/> factory, target status, and an optional post-save
+/// hook (Approve uses it to drive the orchestrator inline so the merge phase
+/// runs before the command returns).
+/// </summary>
+/// <remarks>
+/// Lives in <c>Application.AI.Common.CQRS.Changes</c> rather than inside any
+/// single handler's folder because all three handlers consume it. Kept as an
+/// internal static helper instead of an abstract base because the handlers have
+/// divergent dependencies (Approve takes an orchestrator + config; the others
+/// take only the store + clock) and base-class ceremony would obscure that.
+/// </remarks>
+internal static class ChangeProposalCommandHelper
+{
+    /// <summary>
+    /// Run the shared decision pipeline against an existing proposal.
+    /// </summary>
+    /// <param name="store">The proposal store to load + save from.</param>
+    /// <param name="proposalId">The id of the proposal to act on.</param>
+    /// <param name="statusGuard">
+    /// Returns a non-null <see cref="Result{T}"/> to short-circuit the pipeline
+    /// (typically <c>Fail</c> when the current status doesn't permit the
+    /// decision), or <c>null</c> to proceed. The proposal is passed in so the
+    /// guard can include its actual current status in the failure message.
+    /// </param>
+    /// <param name="decisionFactory">Builds the <see cref="GateDecision"/> to record on the transition.</param>
+    /// <param name="targetStatus">The status to transition the proposal into.</param>
+    /// <param name="postSave">
+    /// Optional follow-up after the transition is persisted. When non-null its
+    /// result replaces the default <c>Success(transitioned)</c> return — used by
+    /// Approve to drive the orchestrator forward and return the post-merge
+    /// proposal snapshot.
+    /// </param>
+    /// <param name="cancellationToken">Cancellation token forwarded to the store + post-save hook.</param>
+    public static async Task<Result<ChangeProposal>> ApplyDecisionAsync(
+        IChangeProposalStore store,
+        string proposalId,
+        Func<ChangeProposal, Result<ChangeProposal>?> statusGuard,
+        Func<GateDecision> decisionFactory,
+        ChangeProposalStatus targetStatus,
+        Func<ChangeProposal, CancellationToken, Task<Result<ChangeProposal>>>? postSave,
+        CancellationToken cancellationToken)
+    {
+        var proposal = await store.GetAsync(proposalId, cancellationToken).ConfigureAwait(false);
+        if (proposal is null)
+        {
+            return Result<ChangeProposal>.NotFound($"ChangeProposal '{proposalId}' not found.");
+        }
+
+        var guard = statusGuard(proposal);
+        if (guard is not null)
+        {
+            return guard;
+        }
+
+        var decision = decisionFactory();
+        var transitioned = proposal.TransitionTo(targetStatus, decision);
+        await store.SaveAsync(transitioned, cancellationToken).ConfigureAwait(false);
+
+        if (postSave is not null)
+        {
+            return await postSave(transitioned, cancellationToken).ConfigureAwait(false);
+        }
+        return Result<ChangeProposal>.Success(transitioned);
+    }
+}

--- a/src/Content/Application/Application.AI.Common/CQRS/Changes/RejectChangeProposal/RejectChangeProposalCommandHandler.cs
+++ b/src/Content/Application/Application.AI.Common/CQRS/Changes/RejectChangeProposal/RejectChangeProposalCommandHandler.cs
@@ -36,31 +36,24 @@ public sealed class RejectChangeProposalCommandHandler
         ArgumentNullException.ThrowIfNull(request);
         cancellationToken.ThrowIfCancellationRequested();
 
-        var proposal = await _store.GetAsync(request.ProposalId, cancellationToken).ConfigureAwait(false);
-        if (proposal is null)
-        {
-            return Result<ChangeProposal>.NotFound(
-                $"ChangeProposal '{request.ProposalId}' not found.");
-        }
-
-        if (proposal.Status != ChangeProposalStatus.AwaitingApproval)
-        {
-            return Result<ChangeProposal>.Fail(
-                $"Cannot reject proposal in status {proposal.Status} (must be AwaitingApproval).");
-        }
-
-        var decision = new GateDecision
-        {
-            Timestamp = _time.GetUtcNow(),
-            GateKey = ApproveChangeProposalCommandHandler.ApprovalGateKey,
-            Action = GateAction.Fail,
-            Reason = request.Reason,
-            ReviewerId = request.ReviewerId,
-            DurationMs = 0
-        };
-
-        var rejected = proposal.TransitionTo(ChangeProposalStatus.Rejected, decision);
-        await _store.SaveAsync(rejected, cancellationToken).ConfigureAwait(false);
-        return Result<ChangeProposal>.Success(rejected);
+        return await ChangeProposalCommandHelper.ApplyDecisionAsync(
+            _store,
+            request.ProposalId,
+            statusGuard: p => p.Status != ChangeProposalStatus.AwaitingApproval
+                ? Result<ChangeProposal>.Fail(
+                    $"Cannot reject proposal in status {p.Status} (must be AwaitingApproval).")
+                : null,
+            decisionFactory: () => new GateDecision
+            {
+                Timestamp = _time.GetUtcNow(),
+                GateKey = ApproveChangeProposalCommandHandler.ApprovalGateKey,
+                Action = GateAction.Fail,
+                Reason = request.Reason,
+                ReviewerId = request.ReviewerId,
+                DurationMs = 0
+            },
+            targetStatus: ChangeProposalStatus.Rejected,
+            postSave: null,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/Content/Application/Application.AI.Common/CQRS/Changes/SubmitChangeProposal/SubmitChangeProposalCommandHandler.cs
+++ b/src/Content/Application/Application.AI.Common/CQRS/Changes/SubmitChangeProposal/SubmitChangeProposalCommandHandler.cs
@@ -113,7 +113,19 @@ public sealed class SubmitChangeProposalCommandHandler
         // Merged, or Rejected depending on what the gates decide).
         var mode = ParseMode(changesConfig.DefaultMode);
         var processed = await _orchestrator.ProcessAsync(proposal.Id, mode, cancellationToken).ConfigureAwait(false);
-        return Result<ChangeProposal>.Success(processed ?? proposal);
+        if (processed is null)
+        {
+            // ProcessAsync returns null only when the store lost the proposal
+            // between our Save and its Get — a tiny race window with an external
+            // deletion. Surface as NotFound rather than returning the stale Draft
+            // snapshot, which would lie about the pipeline having advanced.
+            _logger.LogWarning(
+                "Orchestrator returned null for just-saved ChangeProposal {ProposalId}; treating as NotFound.",
+                proposal.Id);
+            return Result<ChangeProposal>.NotFound(
+                $"ChangeProposal '{proposal.Id}' was deleted before the orchestrator could process it.");
+        }
+        return Result<ChangeProposal>.Success(processed);
     }
 
     private static OrchestratorMode ParseMode(string raw) =>

--- a/src/Content/Domain/Domain.AI/Changes/ChangeProposalIdDeriver.cs
+++ b/src/Content/Domain/Domain.AI/Changes/ChangeProposalIdDeriver.cs
@@ -1,6 +1,7 @@
 using System.Security.Cryptography;
 using System.Text;
 using Domain.AI.Identity;
+using Domain.Common.Helpers;
 
 namespace Domain.AI.Changes;
 
@@ -56,7 +57,7 @@ public static class ChangeProposalIdDeriver
 
         var canonical = Canonicalize(target, diff, submittedBy, submittedAt);
         var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(canonical));
-        return Base64Url(bytes);
+        return Base64UrlHelper.Encode(bytes);
     }
 
     /// <summary>
@@ -122,12 +123,5 @@ public static class ChangeProposalIdDeriver
             sb.Append(edit.Content.Length).Append(':').Append(edit.Content);
         }
         sb.Append(']');
-    }
-
-    private static string Base64Url(byte[] bytes)
-    {
-        var s = Convert.ToBase64String(bytes);
-        // Base64URL: + → -, / → _, drop = padding.
-        return s.Replace('+', '-').Replace('/', '_').TrimEnd('=');
     }
 }

--- a/src/Content/Domain/Domain.Common/Helpers/Base64UrlHelper.cs
+++ b/src/Content/Domain/Domain.Common/Helpers/Base64UrlHelper.cs
@@ -1,0 +1,41 @@
+namespace Domain.Common.Helpers;
+
+/// <summary>
+/// Base64URL (RFC 4648 §5) encoder. URL-safe alphabet (<c>+ → -</c>, <c>/ → _</c>)
+/// with padding stripped, so the output is filename-safe and shorter than hex.
+/// </summary>
+/// <remarks>
+/// Used for content-addressed identifiers where the encoded value flows through
+/// paths, URLs, or other contexts that disallow the standard Base64 alphabet.
+/// Encoding is one-way for the callers in this codebase (id derivation, evidence
+/// hashing) so no decoder is provided — add one only if a consumer actually needs
+/// it, to keep the surface honest.
+/// </remarks>
+public static class Base64UrlHelper
+{
+    /// <summary>
+    /// Encode <paramref name="bytes"/> as a Base64URL string with no padding.
+    /// </summary>
+    /// <param name="bytes">Raw bytes to encode.</param>
+    /// <returns>
+    /// Base64URL-encoded string. For a 32-byte SHA-256 hash this is 43 characters.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="bytes"/> is null.</exception>
+    public static string Encode(byte[] bytes)
+    {
+        ArgumentNullException.ThrowIfNull(bytes);
+        return Encode(bytes.AsSpan());
+    }
+
+    /// <summary>
+    /// Encode <paramref name="bytes"/> as a Base64URL string with no padding.
+    /// </summary>
+    /// <param name="bytes">Raw bytes to encode.</param>
+    /// <returns>Base64URL-encoded string, no padding.</returns>
+    public static string Encode(ReadOnlySpan<byte> bytes)
+    {
+        var standard = Convert.ToBase64String(bytes);
+        // Base64URL: + → -, / → _, drop = padding.
+        return standard.Replace('+', '-').Replace('/', '_').TrimEnd('=');
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Changes/ChangeProposalOrchestrator.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Changes/ChangeProposalOrchestrator.cs
@@ -160,60 +160,19 @@ public sealed class ChangeProposalOrchestrator : IChangeProposalOrchestrator
         var validationGates = ValidationGates(proposal.RequiredGates);
         var hasApproval = proposal.RequiredGates.Contains(WellKnownGateKeys.Approval, StringComparer.Ordinal);
 
-        // Skip gates already completed in this status (resumption after a Defer).
-        var startIndex = CompletedGateCount(proposal, validationGates);
-        for (var i = startIndex; i < validationGates.Count; i++)
+        var outcome = await RunGatesAsync(
+            proposal,
+            validationGates,
+            selfLoopOnDefer: ChangeProposalStatus.Validating,
+            mode,
+            correlationId,
+            maxDefers,
+            cancellationToken).ConfigureAwait(false);
+        if (outcome.Kind != PhaseOutcomeKind.Completed)
         {
-            var gateKey = validationGates[i];
-            var attempt = ConsecutiveDeferAttempts(proposal, gateKey) + 1;
-            if (attempt > maxDefers)
-            {
-                return await TransitionAsync(
-                    proposal,
-                    ChangeProposalStatus.Rejected,
-                    new GateDecision
-                    {
-                        Timestamp = _time.GetUtcNow(),
-                        GateKey = gateKey,
-                        Action = GateAction.Fail,
-                        Reason = $"defer budget exhausted ({maxDefers} consecutive Defers).",
-                        DurationMs = 0
-                    },
-                    mode,
-                    correlationId,
-                    cancellationToken).ConfigureAwait(false);
-            }
-
-            var (decision, terminate) = await EvaluateGateAsync(proposal, gateKey, mode, attempt, correlationId, cancellationToken)
-                .ConfigureAwait(false);
-
-            if (terminate)
-            {
-                return await TransitionAsync(
-                    proposal,
-                    ChangeProposalStatus.Rejected,
-                    decision,
-                    mode,
-                    correlationId,
-                    cancellationToken).ConfigureAwait(false);
-            }
-
-            if (decision.Action == GateAction.Defer)
-            {
-                return await TransitionAsync(
-                    proposal,
-                    ChangeProposalStatus.Validating,  // self-loop
-                    decision,
-                    mode,
-                    correlationId,
-                    cancellationToken).ConfigureAwait(false);
-            }
-
-            // Pass — record but don't transition yet; we batch the validation
-            // transition at the end of the phase.
-            proposal = await AppendHistoryAndSaveAsync(proposal, decision, mode, correlationId, cancellationToken)
-                .ConfigureAwait(false);
+            return outcome.Proposal;
         }
+        proposal = outcome.Proposal;
 
         // Validation phase complete. The transition depends on whether the
         // proposal carries an approval gate:
@@ -337,56 +296,21 @@ public sealed class ChangeProposalOrchestrator : IChangeProposalOrchestrator
     {
         var mergeGates = MergeGates(proposal.RequiredGates);
 
-        var startIndex = CompletedGateCount(proposal, mergeGates);
-        for (var i = startIndex; i < mergeGates.Count; i++)
+        // Merging does not legally self-loop in the state machine, so a Defer
+        // records history without a status transition (selfLoopOnDefer: null).
+        var outcome = await RunGatesAsync(
+            proposal,
+            mergeGates,
+            selfLoopOnDefer: null,
+            mode,
+            correlationId,
+            maxDefers,
+            cancellationToken).ConfigureAwait(false);
+        if (outcome.Kind != PhaseOutcomeKind.Completed)
         {
-            var gateKey = mergeGates[i];
-            var attempt = ConsecutiveDeferAttempts(proposal, gateKey) + 1;
-            if (attempt > maxDefers)
-            {
-                return await TransitionAsync(
-                    proposal,
-                    ChangeProposalStatus.Rejected,
-                    new GateDecision
-                    {
-                        Timestamp = _time.GetUtcNow(),
-                        GateKey = gateKey,
-                        Action = GateAction.Fail,
-                        Reason = $"defer budget exhausted ({maxDefers} consecutive Defers).",
-                        DurationMs = 0
-                    },
-                    mode,
-                    correlationId,
-                    cancellationToken).ConfigureAwait(false);
-            }
-
-            var (decision, terminate) = await EvaluateGateAsync(proposal, gateKey, mode, attempt, correlationId, cancellationToken)
-                .ConfigureAwait(false);
-
-            if (terminate)
-            {
-                return await TransitionAsync(
-                    proposal,
-                    ChangeProposalStatus.Rejected,
-                    decision,
-                    mode,
-                    correlationId,
-                    cancellationToken).ConfigureAwait(false);
-            }
-
-            if (decision.Action == GateAction.Defer)
-            {
-                // Note: Merging does not legally self-loop in the state machine;
-                // record the defer at the current status without transition by
-                // appending history only. Caller schedules retry.
-                proposal = await AppendHistoryAndSaveAsync(proposal, decision, mode, correlationId, cancellationToken)
-                    .ConfigureAwait(false);
-                return proposal;
-            }
-
-            proposal = await AppendHistoryAndSaveAsync(proposal, decision, mode, correlationId, cancellationToken)
-                .ConfigureAwait(false);
+            return outcome.Proposal;
         }
+        proposal = outcome.Proposal;
 
         return await TransitionAsync(
             proposal,
@@ -405,6 +329,96 @@ public sealed class ChangeProposalOrchestrator : IChangeProposalOrchestrator
             correlationId,
             cancellationToken).ConfigureAwait(false);
     }
+
+    /// <summary>
+    /// Iterate a sequence of gate keys, resuming from the first not-yet-passed
+    /// gate. Returns one of three outcomes:
+    /// <list type="bullet">
+    ///   <item><description><see cref="PhaseOutcomeKind.Completed"/> — all gates Passed; caller runs the phase-specific terminal transition.</description></item>
+    ///   <item><description><see cref="PhaseOutcomeKind.Paused"/> — a gate returned <c>Defer</c>; the proposal is saved (transitioned per <paramref name="selfLoopOnDefer"/> or history-only) and the caller returns it as-is for an upstream retry.</description></item>
+    ///   <item><description><see cref="PhaseOutcomeKind.Terminated"/> — a gate returned <c>Fail</c> or defer budget was exhausted; the proposal is transitioned to <c>Rejected</c>.</description></item>
+    /// </list>
+    /// </summary>
+    /// <param name="selfLoopOnDefer">
+    /// When non-null, a Defer causes a TransitionTo to this status (the validation
+    /// phase passes <see cref="ChangeProposalStatus.Validating"/> to record the
+    /// legal self-loop). When null, a Defer appends history without transition
+    /// (the merge phase has no legal self-loop on <see cref="ChangeProposalStatus.Merging"/>).
+    /// </param>
+    private async Task<PhaseOutcome> RunGatesAsync(
+        ChangeProposal proposal,
+        IReadOnlyList<string> gates,
+        ChangeProposalStatus? selfLoopOnDefer,
+        OrchestratorMode mode,
+        string correlationId,
+        int maxDefers,
+        CancellationToken cancellationToken)
+    {
+        var startIndex = CompletedGateCount(proposal, gates);
+        for (var i = startIndex; i < gates.Count; i++)
+        {
+            var gateKey = gates[i];
+            var attempt = ConsecutiveDeferAttempts(proposal, gateKey) + 1;
+            if (attempt > maxDefers)
+            {
+                var rejected = await TransitionAsync(
+                    proposal,
+                    ChangeProposalStatus.Rejected,
+                    new GateDecision
+                    {
+                        Timestamp = _time.GetUtcNow(),
+                        GateKey = gateKey,
+                        Action = GateAction.Fail,
+                        Reason = $"defer budget exhausted ({maxDefers} consecutive Defers).",
+                        DurationMs = 0
+                    },
+                    mode,
+                    correlationId,
+                    cancellationToken).ConfigureAwait(false);
+                return new PhaseOutcome(PhaseOutcomeKind.Terminated, rejected);
+            }
+
+            var (decision, terminate) = await EvaluateGateAsync(proposal, gateKey, mode, attempt, correlationId, cancellationToken)
+                .ConfigureAwait(false);
+
+            if (terminate)
+            {
+                var rejected = await TransitionAsync(
+                    proposal,
+                    ChangeProposalStatus.Rejected,
+                    decision,
+                    mode,
+                    correlationId,
+                    cancellationToken).ConfigureAwait(false);
+                return new PhaseOutcome(PhaseOutcomeKind.Terminated, rejected);
+            }
+
+            if (decision.Action == GateAction.Defer)
+            {
+                var deferred = selfLoopOnDefer.HasValue
+                    ? await TransitionAsync(proposal, selfLoopOnDefer.Value, decision, mode, correlationId, cancellationToken).ConfigureAwait(false)
+                    : await AppendHistoryAndSaveAsync(proposal, decision, mode, correlationId, cancellationToken).ConfigureAwait(false);
+                return new PhaseOutcome(PhaseOutcomeKind.Paused, deferred);
+            }
+
+            proposal = await AppendHistoryAndSaveAsync(proposal, decision, mode, correlationId, cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        return new PhaseOutcome(PhaseOutcomeKind.Completed, proposal);
+    }
+
+    private enum PhaseOutcomeKind
+    {
+        /// <summary>Every gate in the sequence returned Pass.</summary>
+        Completed,
+        /// <summary>A gate returned Defer; the proposal is paused for retry.</summary>
+        Paused,
+        /// <summary>A gate Failed or the defer budget was exhausted; the proposal was transitioned to Rejected.</summary>
+        Terminated
+    }
+
+    private readonly record struct PhaseOutcome(PhaseOutcomeKind Kind, ChangeProposal Proposal);
 
     private async Task<(GateDecision Decision, bool Terminate)> EvaluateGateAsync(
         ChangeProposal proposal,

--- a/src/Content/Infrastructure/Infrastructure.AI/Changes/FileSystemEvidenceStore.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Changes/FileSystemEvidenceStore.cs
@@ -1,6 +1,7 @@
 using System.Security.Cryptography;
 using Application.AI.Common.Interfaces.Changes;
 using Domain.Common.Config;
+using Domain.Common.Helpers;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -45,7 +46,7 @@ public sealed class FileSystemEvidenceStore : IEvidenceStore
         CancellationToken cancellationToken)
     {
         var hashBytes = SHA256.HashData(content.Span);
-        var hash = HashPrefix + Base64Url(hashBytes);
+        var hash = HashPrefix + Base64UrlHelper.Encode(hashBytes);
         var path = PathFor(hash);
 
         Directory.CreateDirectory(Path.GetDirectoryName(path)!);
@@ -147,10 +148,4 @@ public sealed class FileSystemEvidenceStore : IEvidenceStore
 
     /// <summary>32 raw bytes → 43 Base64URL chars (no padding). Constant for the format check.</summary>
     private const int Base64UrlSha256Length = 43;
-
-    private static string Base64Url(byte[] bytes)
-    {
-        var s = Convert.ToBase64String(bytes);
-        return s.Replace('+', '-').Replace('/', '_').TrimEnd('=');
-    }
 }

--- a/src/Content/Tests/Application.AI.Common.Tests/CQRS/Changes/ApproveChangeProposalCommandHandlerTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/CQRS/Changes/ApproveChangeProposalCommandHandlerTests.cs
@@ -77,4 +77,27 @@ public sealed class ApproveChangeProposalCommandHandlerTests
 
         result.IsSuccess.Should().BeFalse();
     }
+
+    [Fact]
+    public async Task Handle_OrchestratorReturnsNull_ReturnsNotFoundInsteadOfStaleApproved()
+    {
+        // Race: orchestrator returns null when the store lost the proposal
+        // between Approve's Save and the orchestrator's Get. Don't return the
+        // stale Approved snapshot — surface as NotFound.
+        var store = new InMemoryChangeProposalStore();
+        var pending = TestHelpers.NewProposal(ChangeProposalStatus.AwaitingApproval);
+        await store.SaveAsync(pending, CancellationToken.None);
+        var orchestrator = new TestHelpers.StubOrchestrator(storeForPassThrough: null);
+        var sut = new ApproveChangeProposalCommandHandler(
+            store, orchestrator, TestHelpers.EnabledConfigMonitor(), TimeProvider.System);
+
+        var result = await sut.Handle(
+            new ApproveChangeProposalCommand { ProposalId = pending.Id, ReviewerId = "user-42" },
+            CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.FailureType.Should().Be(ResultFailureType.NotFound);
+        result.Errors.Should().ContainSingle().Which.Should().Contain("deleted before");
+        orchestrator.InvocationCount.Should().Be(1);
+    }
 }

--- a/src/Content/Tests/Application.AI.Common.Tests/CQRS/Changes/SubmitChangeProposalCommandHandlerTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/CQRS/Changes/SubmitChangeProposalCommandHandlerTests.cs
@@ -108,4 +108,25 @@ public sealed class SubmitChangeProposalCommandHandlerTests
         result.IsSuccess.Should().BeTrue();
         result.Value!.RequiredGates.Should().Equal("custom_gate");
     }
+
+    [Fact]
+    public async Task Handle_OrchestratorReturnsNull_ReturnsNotFoundInsteadOfStaleDraft()
+    {
+        // Race window: the orchestrator returns null only when the store loses
+        // the proposal between our Save and its Get. Surface as NotFound so the
+        // caller doesn't get a stale Draft snapshot pretending the pipeline ran.
+        var store = new InMemoryChangeProposalStore();
+        var context = new TestHelpers.StubAgentContext(TestHelpers.DefaultIdentity);
+        // Orchestrator with no pass-through store → ProcessAsync returns null
+        // even though the handler successfully Saved.
+        var orchestrator = new TestHelpers.StubOrchestrator(storeForPassThrough: null);
+        var sut = NewSut(store, context, orchestrator: orchestrator);
+
+        var result = await sut.Handle(DefaultCommand(), CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.FailureType.Should().Be(ResultFailureType.NotFound);
+        result.Errors.Should().ContainSingle().Which.Should().Contain("deleted before");
+        orchestrator.InvocationCount.Should().Be(1);
+    }
 }


### PR DESCRIPTION
Stacked on top of #24. Knocks out four of the ten code-review follow-ups deferred from PR-2. Mechanical dedups + one small bug fix; no behavior change to the gate pipeline itself.

## Commits

1. `bba7f76` — **Follow-up (3)** consolidate `Base64Url` helper to `Domain.Common/Helpers/Base64UrlHelper.cs`. Removes the duplicated 5-line helper from `ChangeProposalIdDeriver` and `FileSystemEvidenceStore`.
2. `70b6df6` — **Follow-up (4)** collapse `RunValidationPhaseAsync` + `RunMergePhaseAsync` into a shared `RunGatesAsync(gates, selfLoopOnDefer)` in `ChangeProposalOrchestrator`. Phase-specific terminal logic (approval handling for validation; `Merged` transition for merge) stays in each phase method.
3. `fe64f97` — **Follow-up (5)** extract `ChangeProposalCommandHelper.ApplyDecisionAsync` covering the `load → status guard → GateDecision → TransitionTo + Save` skeleton. Migrates `RejectChangeProposalCommandHandler` and `CancelChangeProposalCommandHandler`.
4. `4512dad` — **Follow-up (9)** fix `SubmitChangeProposalCommandHandler` and `ApproveChangeProposalCommandHandler` returning a stale snapshot when the orchestrator returns null. Now returns `NotFound`. Migrates Approve to the shared helper in the same commit (the null-race fix and refactor sit on the same hunks).

## Why this scope

- **Pure dedup + one race fix.** No public contract change. No new dependencies. No new gates or new state-machine transitions.
- **The three architectural follow-ups stay deferred** (#2 background-worker orchestrator, #6 declarative `Gate.Phase` metadata, #8 `MergeGates` fallback edge case) — those each change a public shape and deserve their own discussion + PR.
- **Phase 2 follow-ups** (#1 store startup guard, #7 approver startup validation, #10 `Enabled=false` Forbidden test coverage) ship next, separately.

## Test plan

- [x] `dotnet build src/AgenticHarness.slnx` — 0 errors (118 pre-existing nullability warnings).
- [x] `dotnet test src/AgenticHarness.slnx --filter "FullyQualifiedName~Changes"` — **279 passed** (was 277 on PR #24; +2 new tests for the null-race fix on Submit and Approve).
- [x] Full suite green except 2 Postgres Testcontainer cold-start flakes (unrelated to this PR; `the database system is starting up` race during container init).

## Merge order

Merge `#24` first (the base). This PR auto-retargets to `main` once that happens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)