### PR TITLE
PR-2 follow-ups (phase 3a): declarative GatePhase on IChangeProposalGate

### DIFF
--- a/src/Content/Application/Application.AI.Common/Interfaces/Changes/IChangeProposalGate.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Changes/IChangeProposalGate.cs
@@ -38,6 +38,17 @@ public interface IChangeProposalGate
     string Key { get; }
 
     /// <summary>
+    /// The orchestrator phase this gate runs in. The orchestrator partitions a
+    /// proposal's <c>RequiredGates</c> by querying each gate's <see cref="Phase"/>;
+    /// gate keys whose phase is <see cref="GatePhase.Validation"/> run in the
+    /// validation loop, <see cref="GatePhase.Approval"/> drives the
+    /// AwaitingApproval transition, and <see cref="GatePhase.Merge"/> runs in
+    /// the merge loop. Declared on the gate so a custom gate added by a skill
+    /// pack can never silently land in the wrong phase.
+    /// </summary>
+    GatePhase Phase { get; }
+
+    /// <summary>
     /// Evaluate the proposal against this gate's responsibility.
     /// </summary>
     /// <param name="proposal">The proposal under evaluation. Must not be mutated.</param>

--- a/src/Content/Domain/Domain.AI/Changes/GatePhase.cs
+++ b/src/Content/Domain/Domain.AI/Changes/GatePhase.cs
@@ -1,0 +1,47 @@
+namespace Domain.AI.Changes;
+
+/// <summary>
+/// The orchestrator phase a gate belongs to. Declared by each
+/// <c>IChangeProposalGate</c> so the orchestrator can partition a proposal's
+/// <c>RequiredGates</c> into validation vs. merge phase without string-matching
+/// on a hardcoded approval-gate key.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The pipeline runs phases in order: <see cref="Validation"/> →
+/// <see cref="Approval"/> (or auto-approve when no approval gate is present) →
+/// <see cref="Merge"/> (the only phase that mutates state outside the pipeline).
+/// Ordering inside a phase is taken from the order of <c>RequiredGates</c> —
+/// the phase only controls which phase loop runs the gate, not when it runs
+/// within that loop.
+/// </para>
+/// <para>
+/// Future phases (<c>PostMerge</c> for verification, <c>PreValidation</c> for
+/// shape checks) can be added when a concrete consumer needs them; deliberately
+/// kept to three values today to match what the orchestrator actually runs.
+/// </para>
+/// </remarks>
+public enum GatePhase
+{
+    /// <summary>
+    /// Pre-approval checks. Self-validation, policy, compliance, custom domain
+    /// validators. All must Pass before the approval phase runs.
+    /// </summary>
+    Validation = 0,
+
+    /// <summary>
+    /// The human-or-tier approval gate. At most one gate per proposal should
+    /// declare this phase; the orchestrator routes Defer here through the
+    /// <c>AwaitingApproval</c> status to wait for an out-of-band Approve / Reject
+    /// command.
+    /// </summary>
+    Approval = 1,
+
+    /// <summary>
+    /// Post-approval mutators. The built-in <c>MergeGate</c> is the only one in
+    /// the template; consumers may add post-merge verification gates here. A
+    /// Defer in this phase appends history without a status transition (the
+    /// state machine has no legal self-loop on <c>Merging</c>).
+    /// </summary>
+    Merge = 2
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Changes/ChangeProposalOrchestrator.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Changes/ChangeProposalOrchestrator.cs
@@ -157,8 +157,8 @@ public sealed class ChangeProposalOrchestrator : IChangeProposalOrchestrator
         int maxDefers,
         CancellationToken cancellationToken)
     {
-        var validationGates = ValidationGates(proposal.RequiredGates);
-        var hasApproval = proposal.RequiredGates.Contains(WellKnownGateKeys.Approval, StringComparer.Ordinal);
+        var validationGates = GatesForPhase(proposal.RequiredGates, GatePhase.Validation);
+        var approvalGateKey = FindApprovalGateKey(proposal.RequiredGates);
 
         var outcome = await RunGatesAsync(
             proposal,
@@ -175,7 +175,7 @@ public sealed class ChangeProposalOrchestrator : IChangeProposalOrchestrator
         proposal = outcome.Proposal;
 
         // Validation phase complete. The transition depends on whether the
-        // proposal carries an approval gate:
+        // proposal carries an approval-phase gate:
         //  - Has approval gate: invoke it; gate returns Pass / Fail / Defer.
         //    Defer → transition to AwaitingApproval (wait for human via the
         //    Approve/Reject CQRS commands). Pass → synthetic transit through
@@ -184,9 +184,9 @@ public sealed class ChangeProposalOrchestrator : IChangeProposalOrchestrator
         //  - No approval gate (e.g. Trivial blast radius): transit through
         //    AwaitingApproval to Approved with a synthetic "auto-approver"
         //    audit entry so the trail records exactly what happened.
-        if (hasApproval)
+        if (approvalGateKey is not null)
         {
-            var attempt = ConsecutiveDeferAttempts(proposal, WellKnownGateKeys.Approval) + 1;
+            var attempt = ConsecutiveDeferAttempts(proposal, approvalGateKey) + 1;
             if (attempt > maxDefers)
             {
                 return await TransitionAsync(
@@ -195,7 +195,7 @@ public sealed class ChangeProposalOrchestrator : IChangeProposalOrchestrator
                     new GateDecision
                     {
                         Timestamp = _time.GetUtcNow(),
-                        GateKey = WellKnownGateKeys.Approval,
+                        GateKey = approvalGateKey,
                         Action = GateAction.Fail,
                         Reason = $"approval defer budget exhausted ({maxDefers} consecutive Defers).",
                         DurationMs = 0
@@ -206,7 +206,7 @@ public sealed class ChangeProposalOrchestrator : IChangeProposalOrchestrator
             }
 
             var (approvalDecision, terminate) = await EvaluateGateAsync(
-                proposal, WellKnownGateKeys.Approval, mode, attempt, correlationId, cancellationToken)
+                proposal, approvalGateKey, mode, attempt, correlationId, cancellationToken)
                 .ConfigureAwait(false);
 
             if (terminate)
@@ -294,7 +294,7 @@ public sealed class ChangeProposalOrchestrator : IChangeProposalOrchestrator
         int maxDefers,
         CancellationToken cancellationToken)
     {
-        var mergeGates = MergeGates(proposal.RequiredGates);
+        var mergeGates = GatesForPhase(proposal.RequiredGates, GatePhase.Merge);
 
         // Merging does not legally self-loop in the state machine, so a Defer
         // records history without a status transition (selfLoopOnDefer: null).
@@ -526,24 +526,61 @@ public sealed class ChangeProposalOrchestrator : IChangeProposalOrchestrator
         return withHistory;
     }
 
-    private static IReadOnlyList<string> ValidationGates(IReadOnlyList<string> required) =>
-        required
-            .TakeWhile(k => !string.Equals(k, WellKnownGateKeys.Approval, StringComparison.Ordinal))
-            .ToList();
-
-    private static IReadOnlyList<string> MergeGates(IReadOnlyList<string> required)
+    /// <summary>
+    /// Filter <paramref name="required"/> to keys whose registered gate declares
+    /// <paramref name="phase"/>. Order is preserved from <paramref name="required"/>
+    /// so gates within a phase run in the order the proposal specified.
+    /// </summary>
+    /// <remarks>
+    /// A key with no registered gate is treated as <see cref="GatePhase.Validation"/>
+    /// so the "no gate registered for key" failure surfaces during validation rather
+    /// than after a synthetic auto-approval. The orchestrator's
+    /// <see cref="EvaluateGateAsync"/> Fail path then transitions the proposal to
+    /// Rejected with a directive message — same behaviour as before phase
+    /// metadata existed.
+    /// </remarks>
+    private IReadOnlyList<string> GatesForPhase(IReadOnlyList<string> required, GatePhase phase)
     {
-        var afterApproval = required
-            .SkipWhile(k => !string.Equals(k, WellKnownGateKeys.Approval, StringComparison.Ordinal))
-            .Skip(1)  // skip the approval gate itself
-            .ToList();
-        return afterApproval.Count > 0
-            ? afterApproval
-            // No approval gate in the pipeline → everything after validation gates is the merge phase.
-            : required
-                .SkipWhile(k => string.Equals(k, WellKnownGateKeys.SelfValidation, StringComparison.Ordinal)
-                             || string.Equals(k, WellKnownGateKeys.Policy, StringComparison.Ordinal))
-                .ToList();
+        var result = new List<string>(required.Count);
+        for (var i = 0; i < required.Count; i++)
+        {
+            var key = required[i];
+            if (ResolvePhase(key) == phase)
+            {
+                result.Add(key);
+            }
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// Return the first key in <paramref name="required"/> whose registered gate
+    /// declares <see cref="GatePhase.Approval"/>, or null if the proposal carries
+    /// no approval-phase gate. The orchestrator uses the null case to trigger
+    /// auto-approve-by-omission (typically for Trivial blast radius proposals).
+    /// </summary>
+    /// <remarks>
+    /// "First approval-phase gate" — a quorum-style multi-approval setup that
+    /// registered two approval-phase gates would have only the first one invoked.
+    /// Future work if a real consumer needs quorum: extend the orchestrator to
+    /// iterate all approval-phase gates and aggregate their results.
+    /// </remarks>
+    private string? FindApprovalGateKey(IReadOnlyList<string> required)
+    {
+        for (var i = 0; i < required.Count; i++)
+        {
+            if (ResolvePhase(required[i]) == GatePhase.Approval)
+            {
+                return required[i];
+            }
+        }
+        return null;
+    }
+
+    private GatePhase ResolvePhase(string gateKey)
+    {
+        var gate = _services.GetKeyedService<IChangeProposalGate>(gateKey);
+        return gate?.Phase ?? GatePhase.Validation;
     }
 
     /// <summary>

--- a/src/Content/Infrastructure/Infrastructure.AI/Changes/Gates/ApprovalGate.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Changes/Gates/ApprovalGate.cs
@@ -50,6 +50,9 @@ public sealed class ApprovalGate : IChangeProposalGate
     public string Key => WellKnownGateKeys.Approval;
 
     /// <inheritdoc />
+    public GatePhase Phase => GatePhase.Approval;
+
+    /// <inheritdoc />
     public async Task<GateResult> EvaluateAsync(
         ChangeProposal proposal,
         GateContext context,

--- a/src/Content/Infrastructure/Infrastructure.AI/Changes/Gates/MergeGate.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Changes/Gates/MergeGate.cs
@@ -53,6 +53,9 @@ public sealed class MergeGate : IChangeProposalGate
     public string Key => WellKnownGateKeys.Merge;
 
     /// <inheritdoc />
+    public GatePhase Phase => GatePhase.Merge;
+
+    /// <inheritdoc />
     public async Task<GateResult> EvaluateAsync(
         ChangeProposal proposal,
         GateContext context,

--- a/src/Content/Infrastructure/Infrastructure.AI/Changes/Gates/PolicyGate.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Changes/Gates/PolicyGate.cs
@@ -51,6 +51,9 @@ public sealed class PolicyGate : IChangeProposalGate
     public string Key => WellKnownGateKeys.Policy;
 
     /// <inheritdoc />
+    public GatePhase Phase => GatePhase.Validation;
+
+    /// <inheritdoc />
     public async Task<GateResult> EvaluateAsync(
         ChangeProposal proposal,
         GateContext context,

--- a/src/Content/Infrastructure/Infrastructure.AI/Changes/Gates/SelfValidationGate.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Changes/Gates/SelfValidationGate.cs
@@ -39,6 +39,9 @@ public sealed class SelfValidationGate : IChangeProposalGate
     public string Key => WellKnownGateKeys.SelfValidation;
 
     /// <inheritdoc />
+    public GatePhase Phase => GatePhase.Validation;
+
+    /// <inheritdoc />
     public async Task<GateResult> EvaluateAsync(
         ChangeProposal proposal,
         GateContext context,

--- a/src/Content/Tests/Application.AI.Common.Tests/CQRS/Changes/RunGateCommandHandlerTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/CQRS/Changes/RunGateCommandHandlerTests.cs
@@ -19,6 +19,7 @@ public sealed class RunGateCommandHandlerTests
     private sealed class StubGate(GateResult result) : IChangeProposalGate
     {
         public string Key => GateKey;
+        public GatePhase Phase => GatePhase.Validation;
         public Task<GateResult> EvaluateAsync(ChangeProposal proposal, GateContext context, CancellationToken cancellationToken)
             => Task.FromResult(result);
     }
@@ -26,6 +27,7 @@ public sealed class RunGateCommandHandlerTests
     private sealed class ThrowingGate : IChangeProposalGate
     {
         public string Key => GateKey;
+        public GatePhase Phase => GatePhase.Validation;
         public Task<GateResult> EvaluateAsync(ChangeProposal proposal, GateContext context, CancellationToken cancellationToken)
             => throw new InvalidOperationException("gate exploded");
     }
@@ -139,6 +141,7 @@ public sealed class RunGateCommandHandlerTests
     private sealed class CancellingGate : IChangeProposalGate
     {
         public string Key => GateKey;
+        public GatePhase Phase => GatePhase.Validation;
         public Task<GateResult> EvaluateAsync(ChangeProposal proposal, GateContext context, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();

--- a/src/Content/Tests/Infrastructure.AI.Tests/Changes/ChangeProposalOrchestratorPhasePartitionTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Changes/ChangeProposalOrchestratorPhasePartitionTests.cs
@@ -1,0 +1,167 @@
+using Application.AI.Common.Interfaces.Changes;
+using Domain.AI.Changes;
+using FluentAssertions;
+using Infrastructure.AI.Changes;
+using Infrastructure.AI.Tests.Changes.Support;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+using GateAction = Domain.AI.Changes.GateAction;
+
+namespace Infrastructure.AI.Tests.Changes;
+
+/// <summary>
+/// Regression tests for PR-2 follow-ups (6) + (8): the orchestrator partitions
+/// <c>RequiredGates</c> into validation / approval / merge phases by querying
+/// each registered gate's declared <see cref="GatePhase"/>, not by string-matching
+/// on the hardcoded <c>"approval"</c> key. These tests pin the behaviour that
+/// the old take-while/skip-while heuristic got wrong.
+/// </summary>
+public sealed class ChangeProposalOrchestratorPhasePartitionTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly InMemoryChangeProposalStore _store;
+    private readonly JsonlChangeAuditWriter _audit;
+    private readonly Microsoft.Extensions.Options.IOptionsMonitor<Domain.Common.Config.AppConfig> _monitor;
+
+    public ChangeProposalOrchestratorPhasePartitionTests()
+    {
+        var (monitor, dir) = TestConfig.NewMonitor();
+        _tempDir = dir;
+        _monitor = monitor;
+        _store = new InMemoryChangeProposalStore();
+        _audit = new JsonlChangeAuditWriter(monitor, NullLogger<JsonlChangeAuditWriter>.Instance);
+    }
+
+    public void Dispose()
+    {
+        _audit.Dispose();
+        try { Directory.Delete(_tempDir, recursive: true); }
+        catch { /* best effort */ }
+    }
+
+    private ChangeProposalOrchestrator BuildSut(params IChangeProposalGate[] gates)
+    {
+        var services = new ServiceCollection();
+        foreach (var gate in gates)
+        {
+            services.AddKeyedSingleton(gate.Key, gate);
+        }
+        return new ChangeProposalOrchestrator(
+            _store,
+            _audit,
+            services.BuildServiceProvider(),
+            TimeProvider.System,
+            _monitor,
+            NullLogger<ChangeProposalOrchestrator>.Instance);
+    }
+
+    [Fact]
+    public async Task ProcessAsync_CustomValidationGateWithoutApproval_RunsEachGateInCorrectPhaseExactlyOnce()
+    {
+        // Item (8) regression: previously
+        //   RequiredGates = ["self_validation", "compliance", "merge"] without approval
+        // produced:
+        //   - ValidationGates take-while-not-approval → [self_validation, compliance, merge]
+        //     (merge mis-runs in validation phase)
+        //   - MergeGates fallback → [compliance, merge]
+        //     (compliance mis-runs in merge phase too)
+        // Now: gates declare their phase; partition is correct.
+        var proposal = TestProposals.NewProposal(
+            gates: new[]
+            {
+                WellKnownGateKeys.SelfValidation,
+                "compliance",
+                WellKnownGateKeys.Merge
+            },
+            blastRadius: BlastRadius.Trivial); // auto-approve path
+        await _store.SaveAsync(proposal, CancellationToken.None);
+
+        var selfVal = new TestProposals.StubGate(WellKnownGateKeys.SelfValidation, GateResult.Pass());
+        var compliance = new TestProposals.StubGate("compliance", GateResult.Pass(), GatePhase.Validation);
+        var merge = new TestProposals.StubGate(WellKnownGateKeys.Merge, GateResult.Pass());
+
+        var sut = BuildSut(selfVal, compliance, merge);
+
+        var result = await sut.ProcessAsync(proposal.Id, OrchestratorMode.Live, CancellationToken.None);
+
+        result.Should().NotBeNull();
+        result!.Status.Should().Be(ChangeProposalStatus.Merged);
+
+        // Each gate invoked exactly once — neither compliance nor merge double-runs.
+        selfVal.InvocationCount.Should().Be(1);
+        compliance.InvocationCount.Should().Be(1);
+        merge.InvocationCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task ProcessAsync_CustomApprovalGateKey_IsRecognizedByPhaseNotByLiteralKey()
+    {
+        // A consumer that wires a "quorum_approval" gate with Phase.Approval
+        // should be routed through AwaitingApproval on Defer. The orchestrator
+        // must not depend on the literal string "approval" for that decision.
+        var proposal = TestProposals.NewProposal(
+            gates: new[]
+            {
+                WellKnownGateKeys.SelfValidation,
+                "quorum_approval",
+                WellKnownGateKeys.Merge
+            });
+        await _store.SaveAsync(proposal, CancellationToken.None);
+
+        var sut = BuildSut(
+            new TestProposals.StubGate(WellKnownGateKeys.SelfValidation, GateResult.Pass()),
+            new TestProposals.StubGate(
+                "quorum_approval",
+                GateResult.Defer("queued for quorum", TimeSpan.FromMinutes(5)),
+                GatePhase.Approval),
+            new TestProposals.StubGate(WellKnownGateKeys.Merge, GateResult.Pass()));
+
+        var result = await sut.ProcessAsync(proposal.Id, OrchestratorMode.Live, CancellationToken.None);
+
+        result.Should().NotBeNull();
+        result!.Status.Should().Be(ChangeProposalStatus.AwaitingApproval);
+        result.History.Should().Contain(h =>
+            h.GateKey == "quorum_approval" && h.Action == GateAction.Defer);
+    }
+
+    [Fact]
+    public async Task ProcessAsync_RequiredGatesNotInPhaseOrder_StillPartitionsByPhase()
+    {
+        // RequiredGates ordered merge → validation → approval. The orchestrator
+        // must still run validation first, approval second, merge last. Within
+        // a phase, order from RequiredGates is preserved (only matters when
+        // multiple gates share a phase).
+        var proposal = TestProposals.NewProposal(
+            gates: new[]
+            {
+                WellKnownGateKeys.Merge,           // merge phase, listed first
+                WellKnownGateKeys.SelfValidation,  // validation phase
+                WellKnownGateKeys.Approval         // approval phase, listed last
+            });
+        await _store.SaveAsync(proposal, CancellationToken.None);
+
+        var orderLog = new List<string>();
+        var selfVal = new RecordingGate(WellKnownGateKeys.SelfValidation, GatePhase.Validation, orderLog);
+        var approval = new RecordingGate(WellKnownGateKeys.Approval, GatePhase.Approval, orderLog);
+        var merge = new RecordingGate(WellKnownGateKeys.Merge, GatePhase.Merge, orderLog);
+
+        var sut = BuildSut(selfVal, approval, merge);
+
+        var result = await sut.ProcessAsync(proposal.Id, OrchestratorMode.Live, CancellationToken.None);
+
+        result!.Status.Should().Be(ChangeProposalStatus.Merged);
+        orderLog.Should().Equal("self_validation", "approval", "merge");
+    }
+
+    private sealed class RecordingGate(string key, GatePhase phase, List<string> log) : IChangeProposalGate
+    {
+        public string Key { get; } = key;
+        public GatePhase Phase { get; } = phase;
+        public Task<GateResult> EvaluateAsync(ChangeProposal proposal, GateContext context, CancellationToken cancellationToken)
+        {
+            log.Add(Key);
+            return Task.FromResult(GateResult.Pass());
+        }
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Changes/ChangeProposalOrchestratorTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Changes/ChangeProposalOrchestratorTests.cs
@@ -63,9 +63,14 @@ public sealed class ChangeProposalOrchestratorTests : IDisposable
         var proposal = TestProposals.NewProposal();
         await _store.SaveAsync(proposal, CancellationToken.None);
 
+        // Merge gate registered but never reached — approval defers before
+        // the merge phase runs. Required because phase-based partition reads
+        // each gate's declared Phase via DI; an unregistered key defaults to
+        // Validation, which would silently misclassify "merge" if omitted.
         var sut = BuildSut(
             new TestProposals.StubGate(WellKnownGateKeys.SelfValidation, GateResult.Pass()),
-            new TestProposals.StubGate(WellKnownGateKeys.Approval, GateResult.Defer("queued for human", TimeSpan.FromMinutes(5))));
+            new TestProposals.StubGate(WellKnownGateKeys.Approval, GateResult.Defer("queued for human", TimeSpan.FromMinutes(5))),
+            new TestProposals.StubGate(WellKnownGateKeys.Merge, GateResult.Pass()));
 
         var result = await sut.ProcessAsync(proposal.Id, OrchestratorMode.Live, CancellationToken.None);
 
@@ -97,13 +102,21 @@ public sealed class ChangeProposalOrchestratorTests : IDisposable
         var proposal = TestProposals.NewProposal();
         await _store.SaveAsync(proposal, CancellationToken.None);
 
+        // Merge gate registered but never reached — approval Fail terminates
+        // the pipeline before the merge phase. Required for the same partition
+        // reason as the approval-defer test above.
         var sut = BuildSut(
             new TestProposals.StubGate(WellKnownGateKeys.SelfValidation, GateResult.Pass()),
-            new TestProposals.StubGate(WellKnownGateKeys.Approval, GateResult.Fail("blocked by policy")));
+            new TestProposals.StubGate(WellKnownGateKeys.Approval, GateResult.Fail("blocked by policy")),
+            new TestProposals.StubGate(WellKnownGateKeys.Merge, GateResult.Pass()));
 
         var result = await sut.ProcessAsync(proposal.Id, OrchestratorMode.Live, CancellationToken.None);
 
         result!.Status.Should().Be(ChangeProposalStatus.Rejected);
+        // Assert the rejection came from the approval gate, not from a
+        // misclassified missing-merge-gate failure.
+        result.History.Last().GateKey.Should().Be(WellKnownGateKeys.Approval);
+        result.History.Last().Reason.Should().Contain("blocked by policy");
     }
 
     [Fact]

--- a/src/Content/Tests/Infrastructure.AI.Tests/Changes/Support/TestProposals.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Changes/Support/TestProposals.cs
@@ -34,17 +34,34 @@ internal static class TestProposals
             },
             submittedAt: DefaultTime);
 
+    /// <summary>
+    /// Infer the gate phase from a well-known key so existing tests that pass
+    /// <c>WellKnownGateKeys.Approval</c> or <c>WellKnownGateKeys.Merge</c> don't
+    /// have to pass the phase explicitly. Unknown keys default to
+    /// <see cref="GatePhase.Validation"/>, matching the orchestrator's
+    /// no-gate-registered fallback.
+    /// </summary>
+    internal static GatePhase InferPhase(string key) => key switch
+    {
+        WellKnownGateKeys.Approval => GatePhase.Approval,
+        WellKnownGateKeys.Merge => GatePhase.Merge,
+        _ => GatePhase.Validation,
+    };
+
     public sealed class StubGate : IChangeProposalGate
     {
         private readonly Queue<GateResult> _scripted;
-        public StubGate(string key, GateResult single) : this(key, new[] { single }) { }
-        public StubGate(string key, IEnumerable<GateResult> scripted)
+        public StubGate(string key, GateResult single, GatePhase? phase = null)
+            : this(key, new[] { single }, phase) { }
+        public StubGate(string key, IEnumerable<GateResult> scripted, GatePhase? phase = null)
         {
             Key = key;
+            Phase = phase ?? InferPhase(key);
             _scripted = new Queue<GateResult>(scripted);
         }
 
         public string Key { get; }
+        public GatePhase Phase { get; }
         public int InvocationCount { get; private set; }
 
         public Task<GateResult> EvaluateAsync(ChangeProposal proposal, GateContext context, CancellationToken cancellationToken)
@@ -55,9 +72,10 @@ internal static class TestProposals
         }
     }
 
-    public sealed class ThrowingGate(string key) : IChangeProposalGate
+    public sealed class ThrowingGate(string key, GatePhase? phase = null) : IChangeProposalGate
     {
         public string Key { get; } = key;
+        public GatePhase Phase { get; } = phase ?? InferPhase(key);
         public Task<GateResult> EvaluateAsync(ChangeProposal proposal, GateContext context, CancellationToken cancellationToken)
             => throw new InvalidOperationException("gate exploded");
     }


### PR DESCRIPTION
Stacked on top of #26 → #25 → #24 → main. Ships items **6** and **8** of the PR-2 deferred follow-ups. Item **2** (background-worker orchestrator) is intentionally deferred to a separate PR per pre-PR discussion.

## The bug being fixed (item 8)

`ChangeProposalOrchestrator` partitioned `RequiredGates` into validation/merge phases by string-matching on the literal `"approval"` key:

```csharp
ValidationGates(required) = required.TakeWhile(k => k != "approval")
MergeGates(required)      = required.SkipWhile(k => k != "approval").Skip(1)
                            ?? required.SkipWhile(k => k == "self_validation" || k == "policy")
```

A consumer who wired `RequiredGates = ["self_validation", "compliance", "merge"]` (custom validation gate, no approval — trivial blast radius auto-approves) hit two silent mis-classifications simultaneously:

- `ValidationGates` take-while-≠-approval → `[self_validation, compliance, merge]`. **Merge ran in the validation phase.**
- `MergeGates` fallback → `[compliance, merge]`. **Compliance ran in the merge phase too.**

Both `compliance` and `merge` got invoked twice. Tests didn't catch it because they all included `"approval"` in `RequiredGates`.

## The fix (item 6)

Each gate now declares its phase at construction:

```csharp
public interface IChangeProposalGate
{
    string Key { get; }
    GatePhase Phase { get; }    // NEW
    Task<GateResult> EvaluateAsync(ChangeProposal, GateContext, CancellationToken);
}

public enum GatePhase { Validation, Approval, Merge }
```

The orchestrator partitions by looking up each `RequiredGates` key's `Phase` via keyed DI:

```csharp
GatesForPhase(required, GatePhase.Validation) — runs in validation loop
FindApprovalGateKey(required)                   — returns first approval-phase gate or null
GatesForPhase(required, GatePhase.Merge)        — runs in merge loop
```

The `take-while/skip-while` heuristic and the `MergeGates` fallback are deleted entirely. Item 8 falls out for free.

## Commits

1. `384006d` — `GatePhase` enum + `Phase` on `IChangeProposalGate` + four built-in gates set their phase.
2. `dcbe8fc` — Orchestrator partition rewrite. Approval-gate audit decisions now record under the actual gate key, so a consumer who wires `"quorum_approval"` with `GatePhase.Approval` gets `quorum_approval` in the audit history (not the hardcoded `"approval"`).
3. `89e3085` — Stub-gate phase auto-inference (existing tests don't need to be touched) + three regression tests + two existing orchestrator tests fixed (they omitted a merge stub gate; phase-based partition treats unregistered keys as Validation, which the tests were silently relying on the old heuristic to skip).

## Deliberate design calls

- **Unknown gate keys default to `GatePhase.Validation`.** Consequence: the orchestrator's existing "no gate registered → Fail with directive message" path fires during the validation phase rather than after a synthetic auto-approval. Alternative (skip-if-not-registered) would silently drop unregistered keys, which is the failure mode we just eliminated.
- **`FindApprovalGateKey` returns the first approval-phase gate.** Multi-approval / quorum gates would need additional orchestrator work; documented inline. No real consumer needs it today.
- **The synthetic "auto-approver" entry** (no-approval-gate-in-pipeline branch) still records under `WellKnownGateKeys.Approval` as a marker for audit consumers — it's the "where the approval would have happened" trace, not an invocation.

## Item 2 (background-worker orchestrator) status

Per discussion, item 2 is its own PR. The synchronous Submit/Approve contract stays in this PR untouched. When item 2 lands it'll be on a new branch, possibly stacked on this one, with a focused discussion of the "Submit returns Draft, poll for outcome" return-contract change.

## Test plan

- [x] `dotnet build src/AgenticHarness.slnx` — 0 errors.
- [x] `dotnet test --filter "FullyQualifiedName~Changes"` — **293 passed** (was 289 on PR #26; +3 new regression tests in `ChangeProposalOrchestratorPhasePartitionTests` + 1 existing test fix that added an explicit history assertion).
- [x] Full suite green except pre-existing Postgres testcontainer cold-start flakes (excluded; unrelated).

## Merge order

`#24 → #25 → #26 → #27 (this)`. Auto-retargets as upstream PRs merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)