### PR TITLE
feat(autonomy): graded autonomy refinement — BlastRadius-aware tier policies (PR-4)

### DIFF
--- a/src/Content/Application/Application.AI.Common/CQRS/Changes/SubmitChangeProposal/SubmitChangeProposalCommand.cs
+++ b/src/Content/Application/Application.AI.Common/CQRS/Changes/SubmitChangeProposal/SubmitChangeProposalCommand.cs
@@ -49,4 +49,29 @@ public sealed record SubmitChangeProposalCommand : IRequest<Result<ChangeProposa
     /// reads <c>TimeProvider.GetUtcNow</c>. Used for tests and replay tooling.
     /// </summary>
     public DateTimeOffset? SubmittedAt { get; init; }
+
+    /// <summary>
+    /// Optional skill key for graded-autonomy resolution (PR-4). When provided the
+    /// <c>IAutonomyDecisionEvaluator</c> applies per-skill overrides and consults
+    /// <c>GradedAutonomyConfig.StateChangerOptIns</c> for the state-change dual-key
+    /// check. Null means the proposal is not skill-attributable — the evaluator
+    /// applies environment + tier rules only.
+    /// </summary>
+    public string? SkillKey { get; init; }
+
+    /// <summary>
+    /// True when the proposal mutates state (writes a file, applies a deployment,
+    /// runs a migration). Drives the graded-autonomy state-change safety default
+    /// — even an Autonomous tier configured to auto-approve at this blast radius
+    /// will be forced to <c>RequiresApproval</c> unless the skill is in
+    /// <c>StateChangerOptIns</c>.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <c>true</c> — the safe assumption is that any proposal is a
+    /// state change unless the caller explicitly says otherwise. Mistakenly
+    /// marking a non-state-change as a state-change costs a human approval
+    /// round-trip; the inverse silently bypasses the safety check, which is
+    /// strictly worse.
+    /// </remarks>
+    public bool IsStateChange { get; init; } = true;
 }

--- a/src/Content/Application/Application.AI.Common/CQRS/Changes/SubmitChangeProposal/SubmitChangeProposalCommandHandler.cs
+++ b/src/Content/Application/Application.AI.Common/CQRS/Changes/SubmitChangeProposal/SubmitChangeProposalCommandHandler.cs
@@ -1,6 +1,9 @@
 using Application.AI.Common.Interfaces.Agent;
 using Application.AI.Common.Interfaces.Changes;
+using Application.AI.Common.Interfaces.Governance;
+using Domain.AI.Agents;
 using Domain.AI.Changes;
+using Domain.AI.Governance;
 using Domain.Common;
 using Domain.Common.Config;
 using MediatR;
@@ -47,11 +50,20 @@ public sealed class SubmitChangeProposalCommandHandler
     private readonly IChangeProposalGateResolver _gateResolver;
     private readonly IChangeProposalDispatchQueue _dispatchQueue;
     private readonly IAgentExecutionContext _agentContext;
+    private readonly IAutonomyDecisionEvaluator? _autonomyEvaluator;
+    private readonly IAutonomyTierResolver? _tierResolver;
     private readonly IOptionsMonitor<AppConfig> _config;
     private readonly TimeProvider _time;
     private readonly ILogger<SubmitChangeProposalCommandHandler> _logger;
 
     /// <summary>Initializes a new <see cref="SubmitChangeProposalCommandHandler"/>.</summary>
+    /// <remarks>
+    /// <paramref name="autonomyEvaluator"/> and <paramref name="tierResolver"/> are
+    /// optional (PR-4 graded autonomy). When either is missing the handler skips
+    /// the per-blast-radius decision computation and falls back to the gate
+    /// resolver's pre-PR-4 behaviour — preserving PR-2's contract for consumers
+    /// who haven't wired the new evaluator.
+    /// </remarks>
     public SubmitChangeProposalCommandHandler(
         IChangeProposalStore store,
         IChangeProposalGateResolver gateResolver,
@@ -59,7 +71,9 @@ public sealed class SubmitChangeProposalCommandHandler
         IAgentExecutionContext agentContext,
         IOptionsMonitor<AppConfig> config,
         TimeProvider time,
-        ILogger<SubmitChangeProposalCommandHandler> logger)
+        ILogger<SubmitChangeProposalCommandHandler> logger,
+        IAutonomyDecisionEvaluator? autonomyEvaluator = null,
+        IAutonomyTierResolver? tierResolver = null)
     {
         ArgumentNullException.ThrowIfNull(store);
         ArgumentNullException.ThrowIfNull(gateResolver);
@@ -73,6 +87,8 @@ public sealed class SubmitChangeProposalCommandHandler
         _gateResolver = gateResolver;
         _dispatchQueue = dispatchQueue;
         _agentContext = agentContext;
+        _autonomyEvaluator = autonomyEvaluator;
+        _tierResolver = tierResolver;
         _config = config;
         _time = time;
         _logger = logger;
@@ -102,7 +118,39 @@ public sealed class SubmitChangeProposalCommandHandler
         }
 
         var submittedAt = request.SubmittedAt ?? _time.GetUtcNow();
-        var gates = request.RequiredGates ?? _gateResolver.Resolve(request.Target.Kind, request.BlastRadius);
+
+        // PR-4 graded autonomy: compute the per-blast-radius decision when the
+        // evaluator + tier resolver are wired and the caller hasn't supplied an
+        // explicit RequiredGates override. The decision flows into the resolver
+        // and decides whether the approval gate appears in the frozen gate list.
+        AutonomyDecisionResult? decision = null;
+        if (request.RequiredGates is null
+            && _autonomyEvaluator is not null
+            && _tierResolver is not null)
+        {
+            var tier = ResolveTier(identity);
+            decision = _autonomyEvaluator.Evaluate(
+                tier,
+                request.BlastRadius,
+                request.Target.Kind,
+                request.IsStateChange,
+                request.SkillKey);
+
+            if (decision.Decision == AutonomyDecision.Forbidden)
+            {
+                _logger.LogWarning(
+                    "ChangeProposal forbidden by graded-autonomy policy: tier={Tier} radius={Radius} " +
+                    "target={TargetKind} stateChange={StateChange} skill={Skill} reason={Reason}",
+                    decision.Tier, decision.BlastRadius, decision.TargetKind,
+                    decision.IsStateChange, decision.SkillKey ?? "<none>", decision.Reason);
+
+                return Result<ChangeProposal>.Forbidden(
+                    $"Graded autonomy policy forbids this proposal: {decision.Reason}");
+            }
+        }
+
+        var gates = request.RequiredGates
+            ?? _gateResolver.ResolveWithDecision(request.Target.Kind, request.BlastRadius, decision);
 
         if (gates.Count == 0)
         {
@@ -136,5 +184,36 @@ public sealed class SubmitChangeProposalCommandHandler
         // subscribes for the post-pipeline status.
         await _dispatchQueue.EnqueueAsync(proposal.Id, cancellationToken).ConfigureAwait(false);
         return Result<ChangeProposal>.Success(proposal);
+    }
+
+    /// <summary>
+    /// Best-effort tier resolution for graded autonomy. Tries to parse the agent
+    /// identity's id as a <see cref="SubagentType"/>; falls back to the configured
+    /// <c>PermissionsConfig.DefaultAutonomyLevel</c>; falls back finally to
+    /// <see cref="AutonomyLevel.Supervised"/> (the safe-middle default).
+    /// </summary>
+    private AutonomyLevel ResolveTier(Domain.AI.Identity.AgentIdentity identity)
+    {
+        if (_tierResolver is null)
+        {
+            return AutonomyLevel.Supervised;
+        }
+
+        if (Enum.TryParse<SubagentType>(identity.Id, ignoreCase: true, out var subagentType))
+        {
+            return _tierResolver.Resolve(subagentType);
+        }
+
+        var permissions = _config.CurrentValue.AI.Permissions;
+        if (Enum.TryParse<AutonomyLevel>(permissions.DefaultAutonomyLevel, ignoreCase: true, out var configured))
+        {
+            return configured;
+        }
+
+        _logger.LogWarning(
+            "Could not parse '{Id}' as SubagentType and PermissionsConfig.DefaultAutonomyLevel " +
+            "'{Default}' is invalid — falling back to Supervised for graded-autonomy evaluation.",
+            identity.Id, permissions.DefaultAutonomyLevel);
+        return AutonomyLevel.Supervised;
     }
 }

--- a/src/Content/Application/Application.AI.Common/Interfaces/Changes/IChangeProposalGateResolver.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Changes/IChangeProposalGateResolver.cs
@@ -1,4 +1,5 @@
 using Domain.AI.Changes;
+using Domain.AI.Governance;
 
 namespace Application.AI.Common.Interfaces.Changes;
 
@@ -27,10 +28,37 @@ public interface IChangeProposalGateResolver
 {
     /// <summary>
     /// Compute the ordered gate-key list for a proposal with the given target kind
-    /// and blast radius.
+    /// and blast radius. Pre-PR-4 entry point — equivalent to calling
+    /// <see cref="ResolveWithDecision"/> with a null decision, which forces the
+    /// resolver into its "no graded-autonomy input" fallback path.
     /// </summary>
     /// <param name="targetKind">The proposal's target kind.</param>
     /// <param name="blastRadius">The proposal's estimated blast radius.</param>
     /// <returns>An ordered list of gate keys to be assigned to <c>ChangeProposal.RequiredGates</c>. Must not be empty.</returns>
     IReadOnlyList<string> Resolve(ChangeTargetKind targetKind, BlastRadius blastRadius);
+
+    /// <summary>
+    /// PR-4 entry point: compute the ordered gate-key list with an attached
+    /// <see cref="AutonomyDecisionResult"/> the resolver may consult to decide
+    /// whether to include the approval gate.
+    /// </summary>
+    /// <param name="targetKind">The proposal's target kind.</param>
+    /// <param name="blastRadius">The proposal's estimated blast radius.</param>
+    /// <param name="decision">
+    /// Pre-computed graded-autonomy decision. May be null when the caller has
+    /// not (or could not) compute one — in that case the resolver behaves
+    /// exactly as if <see cref="Resolve(ChangeTargetKind, BlastRadius)"/> were
+    /// called.
+    /// </param>
+    /// <returns>An ordered list of gate keys. Must not be empty.</returns>
+    /// <remarks>
+    /// Default implementation forwards to the non-decision overload so existing
+    /// resolvers (including test stubs) keep working without modification. New
+    /// resolvers that want to honour the decision override this method.
+    /// </remarks>
+    IReadOnlyList<string> ResolveWithDecision(
+        ChangeTargetKind targetKind,
+        BlastRadius blastRadius,
+        AutonomyDecisionResult? decision)
+        => Resolve(targetKind, blastRadius);
 }

--- a/src/Content/Application/Application.AI.Common/Interfaces/Governance/IAutonomyDecisionEvaluator.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Governance/IAutonomyDecisionEvaluator.cs
@@ -1,0 +1,47 @@
+using Domain.AI.Changes;
+using Domain.AI.Governance;
+
+namespace Application.AI.Common.Interfaces.Governance;
+
+/// <summary>
+/// Evaluates the graded-autonomy decision for a single proposal context (PR-4).
+/// Layers the configured per-environment and per-skill overrides on top of the
+/// tier defaults registered in <c>PermissionsConfig.TierPolicies</c> and returns
+/// an <see cref="AutonomyDecisionResult"/> the gate resolver consumes.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The evaluator is the single source of truth for "is this proposal auto-approvable
+/// under the current tier, environment, and skill?". The gate resolver consults it
+/// when deciding whether to include the approval gate in a proposal's frozen gate
+/// list. The orchestrator's audit also records the result for forensic reconstruction.
+/// </para>
+/// <para>
+/// The decision is read-mostly — callers do not block on it, and a single evaluation
+/// is cheap (dictionary lookups + a few enum comparisons). The result is not cached;
+/// configuration hot-reload should propagate immediately.
+/// </para>
+/// <para>
+/// When <see cref="Domain.Common.Config.AI.Permissions.GradedAutonomyConfig.Enabled"/>
+/// is false the evaluator falls back to the PR-2 behavior: every non-<see cref="BlastRadius.Trivial"/>
+/// proposal returns <see cref="AutonomyDecision.RequiresApproval"/>.
+/// </para>
+/// </remarks>
+public interface IAutonomyDecisionEvaluator
+{
+    /// <summary>
+    /// Compute the graded-autonomy decision for the given proposal context.
+    /// </summary>
+    /// <param name="tier">The agent's effective autonomy tier (resolved by <see cref="IAutonomyTierResolver"/>).</param>
+    /// <param name="radius">The proposal's submitted blast radius.</param>
+    /// <param name="targetKind">The proposal's target kind. Reserved for future per-target rules.</param>
+    /// <param name="isStateChange">True when the proposal mutates state. Drives the safety-default lock.</param>
+    /// <param name="skillKey">The skill key that produced the proposal, or null when not skill-attributable.</param>
+    /// <returns>The decision result with the rule that produced it.</returns>
+    AutonomyDecisionResult Evaluate(
+        AutonomyLevel tier,
+        BlastRadius radius,
+        ChangeTargetKind targetKind,
+        bool isStateChange,
+        string? skillKey);
+}

--- a/src/Content/Application/Application.Core/DependencyInjection.cs
+++ b/src/Content/Application/Application.Core/DependencyInjection.cs
@@ -1,4 +1,5 @@
 using Application.AI.Common.Interfaces.Escalation;
+using Application.AI.Common.Interfaces.Governance;
 using Application.AI.Common.Interfaces.Permissions;
 using Application.Core.Escalation.Strategies;
 using Application.Core.Permissions;
@@ -47,6 +48,12 @@ public static class DependencyInjection
 
 		// Plugin-boundary rule provider — generates permission rules from plugin governance config
 		services.AddSingleton<IPermissionRuleProvider, PluginPermissionRuleProvider>();
+
+		// Graded autonomy decision evaluator (PR-4) — consulted by the ChangeProposal
+		// gate resolver to decide whether the approval gate is included in a proposal's
+		// frozen gate list. When AppConfig.AI.Permissions.GradedAutonomy.Enabled is false
+		// the evaluator returns the PR-2 fallback unchanged.
+		services.AddSingleton<IAutonomyDecisionEvaluator, AutonomyDecisionEvaluator>();
 
 		// Approval strategies — keyed by ApprovalStrategyType for IEscalationService to resolve
 		services.AddKeyedSingleton<IApprovalStrategy>(ApprovalStrategyType.AnyOf, (_, _) => new AnyOfApprovalStrategy());

--- a/src/Content/Application/Application.Core/Permissions/AutonomyDecisionEvaluator.cs
+++ b/src/Content/Application/Application.Core/Permissions/AutonomyDecisionEvaluator.cs
@@ -1,0 +1,266 @@
+using Application.AI.Common.Interfaces.Governance;
+using Domain.AI.Changes;
+using Domain.AI.Governance;
+using Domain.AI.Permissions;
+using Domain.Common.Config;
+using Domain.Common.Config.AI.Permissions;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Application.Core.Permissions;
+
+/// <summary>
+/// Default <see cref="IAutonomyDecisionEvaluator"/>: layers the configured
+/// <see cref="GradedAutonomyConfig"/> overrides on top of the tier defaults and
+/// returns the resulting <see cref="AutonomyDecisionResult"/>. Layering order:
+/// </summary>
+/// <list type="number">
+///   <item><description>Resolve effective tier (skill cannot loosen).</description></item>
+///   <item><description>Build the tier's <see cref="AutonomyTierPolicy"/> from per-environment, then per-skill rules.</description></item>
+///   <item><description>Call <see cref="AutonomyTierPolicy.EvaluateFor"/>.</description></item>
+///   <item><description>Apply the state-changer opt-in dual-key check at the end.</description></item>
+/// </list>
+/// <remarks>
+/// <para>
+/// When <see cref="GradedAutonomyConfig.Enabled"/> is false the evaluator returns
+/// the PR-2 fallback: <see cref="AutonomyDecision.AutoApprove"/> for
+/// <see cref="BlastRadius.Trivial"/>, <see cref="AutonomyDecision.RequiresApproval"/>
+/// for anything else. This preserves PR-2's existing tests without modification.
+/// </para>
+/// <para>
+/// Misconfig handling: invalid enum strings in config produce log warnings and the
+/// row is treated as <see cref="AutonomyDecision.RequiresApproval"/> — safer than
+/// throwing at evaluation time and stranding a proposal. Boot-time validation in
+/// <c>AutonomyConfigValidator</c> catches misconfigurations earlier and louder.
+/// </para>
+/// </remarks>
+public sealed class AutonomyDecisionEvaluator : IAutonomyDecisionEvaluator
+{
+    private readonly IOptionsMonitor<AppConfig> _options;
+    private readonly IHostEnvironment _hostEnvironment;
+    private readonly ILogger<AutonomyDecisionEvaluator> _logger;
+
+    /// <summary>Initializes a new <see cref="AutonomyDecisionEvaluator"/>.</summary>
+    /// <param name="options">Application config, read fresh on each call so hot-reload propagates immediately.</param>
+    /// <param name="hostEnvironment">Host environment used to pick the per-environment overlay.</param>
+    /// <param name="logger">Logger for misconfig warnings.</param>
+    public AutonomyDecisionEvaluator(
+        IOptionsMonitor<AppConfig> options,
+        IHostEnvironment hostEnvironment,
+        ILogger<AutonomyDecisionEvaluator> logger)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(hostEnvironment);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _options = options;
+        _hostEnvironment = hostEnvironment;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public AutonomyDecisionResult Evaluate(
+        AutonomyLevel tier,
+        BlastRadius radius,
+        ChangeTargetKind targetKind,
+        bool isStateChange,
+        string? skillKey)
+    {
+        var permissions = _options.CurrentValue.AI.Permissions;
+        var graded = permissions.GradedAutonomy;
+        var environmentName = _hostEnvironment.EnvironmentName ?? "Unknown";
+
+        // Fallback path — PR-2 behaviour preserved verbatim.
+        if (!graded.Enabled)
+        {
+            var fallbackDecision = radius == BlastRadius.Trivial
+                ? AutonomyDecision.AutoApprove
+                : AutonomyDecision.RequiresApproval;
+
+            // Even in fallback mode the state-changer invariant holds for non-Trivial.
+            // For Trivial state-changes the PR-2 resolver already auto-approves, so we
+            // preserve that exact behaviour for parity with the existing tests.
+            return new AutonomyDecisionResult(
+                fallbackDecision,
+                tier,
+                radius,
+                targetKind,
+                isStateChange,
+                environmentName,
+                skillKey,
+                "GradedAutonomy disabled — PR-2 fallback applied (Trivial → AutoApprove, else → RequiresApproval).");
+        }
+
+        // 1. Effective tier (skill cannot loosen the resolved tier).
+        var (effectiveTier, tierReason) = ResolveEffectiveTier(tier, skillKey, graded);
+
+        // 2. Build the policy: environment row → skill row → defaults.
+        var policy = BuildPolicy(effectiveTier, environmentName, skillKey, graded);
+
+        // 3. Apply policy.
+        var (decision, policyReason) = policy.EvaluateFor(radius, targetKind, isStateChange);
+
+        // 4. Dual-key state-change opt-in. If the policy says AutoApprove for a
+        //    state-change, the skill must ALSO be in StateChangerOptIns. The policy
+        //    has already checked the per-row flag; this is the second guard.
+        if (decision == AutonomyDecision.AutoApprove
+            && isStateChange
+            && (skillKey is null || !graded.StateChangerOptIns.Contains(skillKey)))
+        {
+            return new AutonomyDecisionResult(
+                AutonomyDecision.RequiresApproval,
+                effectiveTier,
+                radius,
+                targetKind,
+                isStateChange,
+                environmentName,
+                skillKey,
+                $"{policyReason} BUT state-change skill '{skillKey ?? "<none>"}' is not in StateChangerOptIns — " +
+                "the dual-key safety check forces RequiresApproval.");
+        }
+
+        return new AutonomyDecisionResult(
+            decision,
+            effectiveTier,
+            radius,
+            targetKind,
+            isStateChange,
+            environmentName,
+            skillKey,
+            $"{tierReason} {policyReason}");
+    }
+
+    private (AutonomyLevel Tier, string Reason) ResolveEffectiveTier(
+        AutonomyLevel baseline,
+        string? skillKey,
+        GradedAutonomyConfig graded)
+    {
+        if (skillKey is null
+            || !graded.PerSkill.TryGetValue(skillKey, out var skillConfig)
+            || skillConfig.Tier is null)
+        {
+            return (baseline, $"using baseline tier {baseline}.");
+        }
+
+        if (!Enum.TryParse<AutonomyLevel>(skillConfig.Tier, ignoreCase: true, out var skillTier))
+        {
+            _logger.LogWarning(
+                "Invalid PerSkill.Tier '{Tier}' for skill '{Skill}' — ignoring per-skill tier override.",
+                skillConfig.Tier, skillKey);
+            return (baseline, $"using baseline tier {baseline} (per-skill tier '{skillConfig.Tier}' was invalid).");
+        }
+
+        // Skill may only narrow — pick the lower numeric value (Restricted < Supervised < Autonomous).
+        if (skillTier >= baseline)
+        {
+            _logger.LogWarning(
+                "Per-skill tier '{SkillTier}' for skill '{Skill}' is not stricter than baseline '{Baseline}' — " +
+                "ignoring (skill cannot loosen).",
+                skillTier, skillKey, baseline);
+            return (baseline, $"using baseline tier {baseline} (per-skill '{skillTier}' would loosen — rejected).");
+        }
+
+        return (skillTier, $"per-skill tier override {skillTier} (narrowed from baseline {baseline}).");
+    }
+
+    private AutonomyTierPolicy BuildPolicy(
+        AutonomyLevel tier,
+        string environmentName,
+        string? skillKey,
+        GradedAutonomyConfig graded)
+    {
+        // Start with environment overlay; layer per-skill on top.
+        var radiusMap = new Dictionary<BlastRadius, BlastRadiusAutonomyRule>();
+
+        if (graded.PerEnvironment.TryGetValue(environmentName, out var envConfig))
+        {
+            foreach (var (radiusName, ruleConfig) in envConfig.PerBlastRadius)
+            {
+                if (TryParseRule(radiusName, ruleConfig, $"PerEnvironment[{environmentName}]", out var rule))
+                {
+                    radiusMap[rule.Radius] = rule;
+                }
+            }
+        }
+
+        if (skillKey is not null && graded.PerSkill.TryGetValue(skillKey, out var skillConfig))
+        {
+            foreach (var (radiusName, ruleConfig) in skillConfig.PerBlastRadius)
+            {
+                if (TryParseRule(radiusName, ruleConfig, $"PerSkill[{skillKey}]", out var rule))
+                {
+                    // Per-skill may only narrow: prefer existing env row if it is stricter (or equal).
+                    if (radiusMap.TryGetValue(rule.Radius, out var existing)
+                        && IsStricter(existing.Decision, rule.Decision))
+                    {
+                        _logger.LogWarning(
+                            "Per-skill rule for skill '{Skill}' radius '{Radius}' would loosen the resolved decision " +
+                            "from {Existing} to {Attempt} — ignoring.",
+                            skillKey, rule.Radius, existing.Decision, rule.Decision);
+                        continue;
+                    }
+
+                    radiusMap[rule.Radius] = rule;
+                }
+            }
+        }
+
+        return new AutonomyTierPolicy
+        {
+            Level = tier,
+            // DefaultBehavior is irrelevant for graded autonomy — it drives PermissionRule emission only.
+            // We pick a reasonable per-tier default so the record is constructible.
+            DefaultBehavior = tier == AutonomyLevel.Autonomous
+                ? PermissionBehaviorType.Allow
+                : PermissionBehaviorType.Ask,
+            PerBlastRadius = radiusMap.Count == 0 ? null : radiusMap
+        };
+    }
+
+    private bool TryParseRule(
+        string radiusName,
+        BlastRadiusRuleConfig ruleConfig,
+        string source,
+        out BlastRadiusAutonomyRule rule)
+    {
+        rule = default!;
+
+        if (!Enum.TryParse<BlastRadius>(radiusName, ignoreCase: true, out var radius))
+        {
+            _logger.LogWarning(
+                "Invalid BlastRadius name '{Radius}' in {Source} — skipping row.",
+                radiusName, source);
+            return false;
+        }
+
+        if (!Enum.TryParse<AutonomyDecision>(ruleConfig.Decision, ignoreCase: true, out var decision))
+        {
+            _logger.LogWarning(
+                "Invalid AutonomyDecision '{Decision}' in {Source}[{Radius}] — defaulting to RequiresApproval.",
+                ruleConfig.Decision, source, radiusName);
+            decision = AutonomyDecision.RequiresApproval;
+        }
+
+        rule = new BlastRadiusAutonomyRule(
+            radius,
+            decision,
+            ruleConfig.AllowAutoApproveForStateChange);
+        return true;
+    }
+
+    /// <summary>
+    /// True when <paramref name="a"/> is strictly more restrictive than <paramref name="b"/>.
+    /// Forbidden &gt; RequiresApproval &gt; AutoApprove.
+    /// </summary>
+    private static bool IsStricter(AutonomyDecision a, AutonomyDecision b)
+        => RestrictivenessRank(a) > RestrictivenessRank(b);
+
+    private static int RestrictivenessRank(AutonomyDecision d) => d switch
+    {
+        AutonomyDecision.AutoApprove => 0,
+        AutonomyDecision.RequiresApproval => 1,
+        AutonomyDecision.Forbidden => 2,
+        _ => 0
+    };
+}

--- a/src/Content/Domain/Domain.AI/Governance/AutonomyDecision.cs
+++ b/src/Content/Domain/Domain.AI/Governance/AutonomyDecision.cs
@@ -1,0 +1,46 @@
+namespace Domain.AI.Governance;
+
+/// <summary>
+/// The graded-autonomy decision for a single proposal context. Independent of the
+/// agent's <see cref="AutonomyLevel"/> tier — the tier sets the baseline; the
+/// decision narrows it per <see cref="Domain.AI.Changes.BlastRadius"/>,
+/// <see cref="Domain.AI.Changes.ChangeTargetKind"/>, and the state-change flag.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Three values intentionally — the autonomy tier enum already covers "Restricted"
+/// (everything asks). What an evaluator returns is the outcome for one proposal:
+/// auto-approve, route through human review, or reject outright (the latter is
+/// reserved for misconfig-or-policy-overlap cases where the evaluator wants to
+/// stop the proposal cold without involving the approval router).
+/// </para>
+/// <para>
+/// The decision is consulted by <c>IChangeProposalGateResolver</c> when deciding
+/// whether to include the approval gate in a proposal's frozen gate list; it is
+/// also surfaced via <see cref="AutonomyDecisionResult"/> for audit.
+/// </para>
+/// </remarks>
+public enum AutonomyDecision
+{
+    /// <summary>
+    /// The proposal may proceed without an approval gate. The <c>ApprovalGate</c>
+    /// is omitted from the frozen gate list. Reserved for low-risk, non-state-changing
+    /// proposals under a permissive tier in a permissive environment.
+    /// </summary>
+    AutoApprove = 0,
+
+    /// <summary>
+    /// The proposal must be routed through the approval gate. Default for anything
+    /// that touches state, anything above <see cref="Domain.AI.Changes.BlastRadius.Low"/>
+    /// blast radius unless explicitly overridden, and everything in stricter environments.
+    /// </summary>
+    RequiresApproval = 1,
+
+    /// <summary>
+    /// The configuration explicitly forbids the proposal. The orchestrator transitions
+    /// the proposal to Rejected without invoking gates. Useful for hard-coded
+    /// "Critical in Production by this skill is always rejected" policies that pre-empt
+    /// the approval router entirely.
+    /// </summary>
+    Forbidden = 2
+}

--- a/src/Content/Domain/Domain.AI/Governance/AutonomyDecisionResult.cs
+++ b/src/Content/Domain/Domain.AI/Governance/AutonomyDecisionResult.cs
@@ -1,0 +1,27 @@
+using Domain.AI.Changes;
+
+namespace Domain.AI.Governance;
+
+/// <summary>
+/// Carries the outcome of a graded-autonomy evaluation along with the inputs that
+/// produced it. The orchestrator records the result on the proposal's audit history
+/// so a reviewer can reconstruct why a given proposal was (or was not) routed
+/// through the approval gate.
+/// </summary>
+/// <param name="Decision">The chosen action.</param>
+/// <param name="Tier">The agent's effective autonomy tier at evaluation time.</param>
+/// <param name="BlastRadius">The proposal's submitted blast radius.</param>
+/// <param name="TargetKind">The proposal's target kind.</param>
+/// <param name="IsStateChange">True when the proposal mutates state (writes a file, applies a deployment, runs a migration).</param>
+/// <param name="Environment">The host environment name (Development / Staging / Production / etc.) at evaluation time.</param>
+/// <param name="SkillKey">The skill key that produced the proposal, or null when not skill-attributable.</param>
+/// <param name="Reason">A human-readable explanation pinning the rule that drove the decision. Surfaces in audit lines.</param>
+public sealed record AutonomyDecisionResult(
+    AutonomyDecision Decision,
+    AutonomyLevel Tier,
+    BlastRadius BlastRadius,
+    ChangeTargetKind TargetKind,
+    bool IsStateChange,
+    string Environment,
+    string? SkillKey,
+    string Reason);

--- a/src/Content/Domain/Domain.AI/Governance/AutonomyTierPolicy.cs
+++ b/src/Content/Domain/Domain.AI/Governance/AutonomyTierPolicy.cs
@@ -1,11 +1,45 @@
+using Domain.AI.Changes;
 using Domain.AI.Permissions;
 
 namespace Domain.AI.Governance;
 
 /// <summary>
-/// Maps an autonomy level to its permission behavior and per-tool overrides.
-/// Pure value object with no behavior.
+/// Maps an autonomy level to its baseline permission behavior, its per-tool overrides,
+/// and (PR-4) its per-<see cref="BlastRadius"/> decision table for the
+/// <c>ChangeProposal</c> pipeline. Pure value object with no behavior beyond
+/// <see cref="EvaluateFor"/> — a deterministic projection of its inputs.
 /// </summary>
+/// <remarks>
+/// <para>
+/// Two orthogonal jobs live on this record:
+/// </para>
+/// <list type="number">
+///   <item><description>
+///     <b>Tool permission baseline</b> — <see cref="DefaultBehavior"/> and
+///     <see cref="ToolOverrides"/> are consumed by <c>AutonomyTierRuleProvider</c>
+///     to emit <c>ToolPermissionRule</c> entries for runtime tool-invocation gating.
+///   </description></item>
+///   <item><description>
+///     <b>Graded autonomy decision</b> — <see cref="PerBlastRadius"/> and
+///     <see cref="EvaluateFor"/> are consumed by the gate resolver / autonomy
+///     evaluator to decide whether a <see cref="ChangeProposal"/> at a given
+///     <see cref="BlastRadius"/> may auto-approve under this tier.
+///   </description></item>
+/// </list>
+/// <para>
+/// The two surfaces are kept on the same record because they share an input
+/// (the tier) and consumers configuring autonomy think of them together. They do
+/// not interact: setting tool overrides does not change blast-radius decisions
+/// and vice versa.
+/// </para>
+/// <para>
+/// <b>Naming note.</b> The plan documents the trust tiers as
+/// "Manual / Supervised / Autonomous"; the harness's <see cref="AutonomyLevel"/>
+/// enum uses <see cref="AutonomyLevel.Restricted"/> in place of "Manual"
+/// (numeric ordering and "ask for everything" semantics match). All API surfaces
+/// here use the <see cref="AutonomyLevel"/> names.
+/// </para>
+/// </remarks>
 public sealed record AutonomyTierPolicy
 {
     /// <summary>Which tier this policy applies to.</summary>
@@ -22,4 +56,77 @@ public sealed record AutonomyTierPolicy
     /// might still Allow <c>"query_knowledge_graph"</c>. Null means no overrides.
     /// </summary>
     public IReadOnlyDictionary<string, PermissionBehaviorType>? ToolOverrides { get; init; }
+
+    /// <summary>
+    /// Per-<see cref="BlastRadius"/> autonomy decision table consumed by the
+    /// <c>ChangeProposal</c> pipeline. Null means "no graded rules" — the evaluator
+    /// falls back to its environment-wide defaults
+    /// (<see cref="AutonomyDecision.RequiresApproval"/> for everything above
+    /// <see cref="BlastRadius.Trivial"/>).
+    /// </summary>
+    /// <remarks>
+    /// The dictionary is keyed by <see cref="BlastRadius"/> so the consumer can
+    /// declare e.g. <c>Trivial =&gt; AutoApprove</c> and <c>Low =&gt; AutoApprove</c>
+    /// without having to enumerate every radius. Radii not present in the map fall
+    /// back to <see cref="AutonomyDecision.RequiresApproval"/>.
+    /// </remarks>
+    public IReadOnlyDictionary<BlastRadius, BlastRadiusAutonomyRule>? PerBlastRadius { get; init; }
+
+    /// <summary>
+    /// Evaluate the autonomy decision for a single proposal context against this
+    /// tier policy. Pure function: returns the same answer for the same inputs and
+    /// never mutates state. Does not consider environment or skill — those are
+    /// resolved by <c>IAutonomyDecisionEvaluator</c> before it picks which policy
+    /// to evaluate against.
+    /// </summary>
+    /// <param name="radius">The proposal's blast radius.</param>
+    /// <param name="targetKind">The proposal's target kind. Reserved for future per-target rules; currently unused but accepted so callers thread it through ready for PR-9/10.</param>
+    /// <param name="isStateChange">True when the proposal mutates state (writes a file, applies a deployment, etc.). The hard invariant: state-changers default to <see cref="AutonomyDecision.RequiresApproval"/> regardless of tier, unless the matching <see cref="BlastRadiusAutonomyRule.AllowAutoApproveForStateChange"/> is true.</param>
+    /// <returns>The decision and the rule that produced it.</returns>
+    public (AutonomyDecision Decision, string Reason) EvaluateFor(
+        BlastRadius radius,
+        ChangeTargetKind targetKind,
+        bool isStateChange)
+    {
+        _ = targetKind; // reserved for future per-target rules; consumed by evaluator caller.
+
+        // Critical blast radius is special-cased at the tier level: even an
+        // Autonomous tier that lists Critical => AutoApprove must still route
+        // through approval. This is the load-bearing safety rule and lives on
+        // the policy itself so a misconfigured rule table cannot circumvent it.
+        if (radius == BlastRadius.Critical)
+        {
+            return (
+                AutonomyDecision.RequiresApproval,
+                "blast radius Critical always requires approval regardless of tier configuration.");
+        }
+
+        if (PerBlastRadius is not null && PerBlastRadius.TryGetValue(radius, out var rule))
+        {
+            // The hard invariant: state-changers default to RequiresApproval.
+            if (rule.Decision == AutonomyDecision.AutoApprove
+                && isStateChange
+                && !rule.AllowAutoApproveForStateChange)
+            {
+                return (
+                    AutonomyDecision.RequiresApproval,
+                    $"tier {Level} at blast radius {radius} would auto-approve, but the proposal is a state-change " +
+                    "and AllowAutoApproveForStateChange is false (the safety-default).");
+            }
+
+            return (
+                rule.Decision,
+                $"tier {Level} rule for blast radius {radius} → {rule.Decision} " +
+                $"(state-change opt-in: {rule.AllowAutoApproveForStateChange}).");
+        }
+
+        // No explicit rule: default to requiring approval. Anything that needs to
+        // auto-approve must declare it explicitly. The state-change default is
+        // separately enforced because Trivial-non-state-change is the only case
+        // where this default could plausibly be loosened to AutoApprove by a
+        // consumer — and they have to do that explicitly via a rule.
+        return (
+            AutonomyDecision.RequiresApproval,
+            $"tier {Level} has no rule for blast radius {radius} — defaulting to RequiresApproval.");
+    }
 }

--- a/src/Content/Domain/Domain.AI/Governance/BlastRadiusAutonomyRule.cs
+++ b/src/Content/Domain/Domain.AI/Governance/BlastRadiusAutonomyRule.cs
@@ -1,0 +1,26 @@
+using Domain.AI.Changes;
+
+namespace Domain.AI.Governance;
+
+/// <summary>
+/// A single row in a tier-policy's per-blast-radius rule table. Maps one
+/// <see cref="BlastRadius"/> to the <see cref="AutonomyDecision"/> the tier wants
+/// to apply by default; <see cref="AllowAutoApproveForStateChange"/> opens the
+/// state-changer escape hatch on a per-row basis.
+/// </summary>
+/// <param name="Radius">The blast radius this row applies to.</param>
+/// <param name="Decision">
+/// The decision for proposals at this radius. <see cref="AutonomyDecision.AutoApprove"/>
+/// is the only value that takes effect without the state-change opt-in below — the
+/// other two outcomes are always honoured.
+/// </param>
+/// <param name="AllowAutoApproveForStateChange">
+/// When true and <paramref name="Decision"/> is <see cref="AutonomyDecision.AutoApprove"/>,
+/// the tier permits auto-approval even when the proposal is a state-changer. False by
+/// default: the hard invariant is that state-changers default to
+/// <see cref="AutonomyDecision.RequiresApproval"/> regardless of tier, opt-in only.
+/// </param>
+public sealed record BlastRadiusAutonomyRule(
+    BlastRadius Radius,
+    AutonomyDecision Decision,
+    bool AllowAutoApproveForStateChange = false);

--- a/src/Content/Domain/Domain.Common/Config/AI/Permissions/GradedAutonomyConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/Permissions/GradedAutonomyConfig.cs
@@ -1,0 +1,130 @@
+namespace Domain.Common.Config.AI.Permissions;
+
+/// <summary>
+/// Configuration for graded autonomy (PR-4): per-environment, per-blast-radius,
+/// and per-skill rules layered over the tier defaults in
+/// <see cref="PermissionsConfig.TierPolicies"/>. Bound from
+/// <c>AppConfig:AI:Permissions:GradedAutonomy</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Layering order from coarsest to finest (each layer overrides the previous):
+/// </para>
+/// <list type="number">
+///   <item><description>Tier defaults — <see cref="PermissionsConfig.TierPolicies"/>.</description></item>
+///   <item><description>Per-environment overrides — <see cref="PerEnvironment"/> keyed by <c>IHostEnvironment.EnvironmentName</c>.</description></item>
+///   <item><description>Per-skill overrides — <see cref="PerSkill"/>, more restrictive only (cannot loosen the resolved tier).</description></item>
+/// </list>
+/// <para>
+/// State-changers default to "RequiresApproval" regardless of layer. To opt a
+/// specific (skill, blast radius) pair into auto-approval for state changes, add
+/// the skill key to <see cref="StateChangerOptIns"/> AND ensure the row's
+/// <c>AllowAutoApproveForStateChange</c> is true. Both are required so a single
+/// misconfig cannot weaken the safety default.
+/// </para>
+/// </remarks>
+public sealed class GradedAutonomyConfig
+{
+    /// <summary>
+    /// Master toggle. When false (the default), the gate resolver falls back to
+    /// the PR-2 behavior — Trivial proposals auto-approve, everything else routes
+    /// through approval. When true, the evaluator runs and per-environment,
+    /// per-skill, and per-blast-radius overrides take effect.
+    /// </summary>
+    public bool Enabled { get; set; }
+
+    /// <summary>
+    /// Per-environment overrides. Keys are environment names matched against
+    /// <c>IHostEnvironment.EnvironmentName</c> (case-insensitive). Values map a
+    /// per-environment <see cref="EnvironmentAutonomyConfig"/> that the
+    /// evaluator unions over the tier defaults.
+    /// </summary>
+    /// <remarks>
+    /// Typical map:
+    /// <code>
+    /// PerEnvironment:
+    ///   Development: { Permissive defaults }
+    ///   Staging:     { Mid defaults }
+    ///   Production:  { Strictest defaults }
+    /// </code>
+    /// Missing environment → no per-environment overlay (tier defaults rule).
+    /// </remarks>
+    public Dictionary<string, EnvironmentAutonomyConfig> PerEnvironment { get; set; } = new();
+
+    /// <summary>
+    /// Per-skill overrides. Key is the skill key (matches <c>SubagentDefinition.SkillKey</c>
+    /// or the agent's manifest skill name). Values map to <see cref="SkillAutonomyConfig"/>.
+    /// </summary>
+    /// <remarks>
+    /// Per-skill overrides may only narrow the resolved autonomy (declare a stricter
+    /// tier, raise a row to RequiresApproval). The evaluator silently ignores any
+    /// per-skill rule that would loosen the resolved tier — and logs a warning so
+    /// the misconfig surfaces.
+    /// </remarks>
+    public Dictionary<string, SkillAutonomyConfig> PerSkill { get; set; } = new();
+
+    /// <summary>
+    /// Skill keys that are explicitly opted into auto-approval for state-changing
+    /// proposals. Without an entry here, no skill can auto-approve a state change
+    /// regardless of any per-blast-radius rule's <c>AllowAutoApproveForStateChange</c>
+    /// flag. This is the second half of the dual-key safety check.
+    /// </summary>
+    public List<string> StateChangerOptIns { get; set; } = [];
+}
+
+/// <summary>
+/// Per-environment overlay applied on top of the tier defaults.
+/// </summary>
+public sealed class EnvironmentAutonomyConfig
+{
+    /// <summary>
+    /// Per-blast-radius rules for this environment. Each row maps a
+    /// <see cref="Domain.AI.Changes.BlastRadius"/> name
+    /// (<c>"Trivial"</c>, <c>"Low"</c>, <c>"Medium"</c>, <c>"High"</c>, <c>"Critical"</c>)
+    /// to a decision name (<c>"AutoApprove"</c>, <c>"RequiresApproval"</c>, <c>"Forbidden"</c>).
+    /// Missing rows fall back to tier defaults.
+    /// </summary>
+    public Dictionary<string, BlastRadiusRuleConfig> PerBlastRadius { get; set; } = new();
+}
+
+/// <summary>
+/// Per-skill overlay applied on top of the environment-resolved tier policy.
+/// </summary>
+public sealed class SkillAutonomyConfig
+{
+    /// <summary>
+    /// Optional autonomy-tier ceiling for this skill. When set, the evaluator
+    /// uses <c>min(resolved tier, this tier)</c> — the skill can only narrow the
+    /// resolved tier, never widen it. Valid values: <c>"Restricted"</c>,
+    /// <c>"Supervised"</c>, <c>"Autonomous"</c>.
+    /// </summary>
+    public string? Tier { get; set; }
+
+    /// <summary>
+    /// Per-blast-radius overrides for this specific skill. Same shape and rules as
+    /// <see cref="EnvironmentAutonomyConfig.PerBlastRadius"/> but only narrows.
+    /// </summary>
+    public Dictionary<string, BlastRadiusRuleConfig> PerBlastRadius { get; set; } = new();
+}
+
+/// <summary>
+/// One row in a per-blast-radius rule map. Mirrors
+/// <c>Domain.AI.Governance.BlastRadiusAutonomyRule</c> but with string-typed
+/// fields for configuration binding. The evaluator parses + validates these at
+/// load time.
+/// </summary>
+public sealed class BlastRadiusRuleConfig
+{
+    /// <summary>
+    /// Decision name. Valid values: <c>"AutoApprove"</c>, <c>"RequiresApproval"</c>,
+    /// <c>"Forbidden"</c>. Defaults to <c>"RequiresApproval"</c> — the safe default.
+    /// </summary>
+    public string Decision { get; set; } = "RequiresApproval";
+
+    /// <summary>
+    /// State-change escape hatch. When true, the row permits auto-approve even for
+    /// state-changing proposals (still gated by the skill's presence in
+    /// <see cref="GradedAutonomyConfig.StateChangerOptIns"/>). Defaults to false.
+    /// </summary>
+    public bool AllowAutoApproveForStateChange { get; set; }
+}

--- a/src/Content/Domain/Domain.Common/Config/AI/Permissions/PermissionsConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/Permissions/PermissionsConfig.cs
@@ -50,4 +50,12 @@ public class PermissionsConfig
     /// Each entry defines the default behavior and tool overrides for that tier.
     /// </summary>
     public Dictionary<string, AutonomyTierPolicyConfig> TierPolicies { get; set; } = new();
+
+    /// <summary>
+    /// Graded autonomy configuration (PR-4) layered on top of <see cref="TierPolicies"/>.
+    /// Off by default — when enabled, the gate resolver consults
+    /// <c>IAutonomyDecisionEvaluator</c> for per-environment and per-skill rules
+    /// instead of using the static PR-2 mapping.
+    /// </summary>
+    public GradedAutonomyConfig GradedAutonomy { get; set; } = new();
 }

--- a/src/Content/Infrastructure/Infrastructure.AI/Changes/DefaultChangeProposalGateResolver.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Changes/DefaultChangeProposalGateResolver.cs
@@ -1,5 +1,6 @@
 using Application.AI.Common.Interfaces.Changes;
 using Domain.AI.Changes;
+using Domain.AI.Governance;
 
 namespace Infrastructure.AI.Changes;
 
@@ -12,10 +13,24 @@ namespace Infrastructure.AI.Changes;
 /// the proposal at submission time and cannot be lowered later.
 /// </summary>
 /// <remarks>
+/// <para>
 /// Consumers needing stricter pipelines (an extra <c>compliance</c> gate for
 /// regulated environments, a <c>cost</c> gate for IaC at high blast radius)
 /// register their own <see cref="IChangeProposalGateResolver"/> implementation
 /// in place of this one.
+/// </para>
+/// <para>
+/// PR-4 wiring: <see cref="ResolveWithDecision"/> consults the supplied
+/// <see cref="AutonomyDecisionResult"/> to decide whether the approval gate is
+/// included. A null decision (the pre-PR-4 path) falls back to the static
+/// "Trivial auto-approves, everything else requires approval" rule. A non-null
+/// decision overrides that rule entirely:
+/// </para>
+/// <list type="bullet">
+///   <item><description><see cref="AutonomyDecision.AutoApprove"/> — approval gate omitted.</description></item>
+///   <item><description><see cref="AutonomyDecision.RequiresApproval"/> — approval gate included.</description></item>
+///   <item><description><see cref="AutonomyDecision.Forbidden"/> — approval gate included; the orchestrator's first-policy-gate rejection turns the proposal into Rejected without invoking the approval router.</description></item>
+/// </list>
 /// </remarks>
 public sealed class DefaultChangeProposalGateResolver : IChangeProposalGateResolver
 {
@@ -47,5 +62,31 @@ public sealed class DefaultChangeProposalGateResolver : IChangeProposalGateResol
         }
 
         return StandardPipeline;
+    }
+
+    /// <inheritdoc />
+    public IReadOnlyList<string> ResolveWithDecision(
+        ChangeTargetKind targetKind,
+        BlastRadius blastRadius,
+        AutonomyDecisionResult? decision)
+    {
+        // No decision supplied — fall back to the static PR-2 rule so existing
+        // call sites that don't compute a decision behave identically.
+        if (decision is null)
+        {
+            return Resolve(targetKind, blastRadius);
+        }
+
+        // Critical is already double-guarded in the policy itself, but the
+        // resolver re-asserts it here so a consumer-supplied IAutonomyDecisionEvaluator
+        // that bypassed the policy cannot drop approval at Critical.
+        if (blastRadius == BlastRadius.Critical)
+        {
+            return StandardPipeline;
+        }
+
+        return decision.Decision == AutonomyDecision.AutoApprove
+            ? AutoApprovePipeline
+            : StandardPipeline;
     }
 }

--- a/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.Governance.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.Governance.cs
@@ -37,6 +37,12 @@ public static partial class DependencyInjection
 
         // Autonomy tier resolution — reads tier from SubagentDefinition or falls back to config
         services.AddSingleton<IAutonomyTierResolver, DefaultAutonomyTierResolver>();
+
+        // PR-4: graded-autonomy startup validator — refuses to boot when
+        // GradedAutonomy.Enabled is true and the config is internally
+        // inconsistent (Critical→AutoApprove, Prod→High→AutoApprove, per-skill
+        // tier looser than baseline, etc.). No-ops when GradedAutonomy is off.
+        services.AddHostedService<AutonomyConfigValidator>();
     }
 
     /// <summary>

--- a/src/Content/Infrastructure/Infrastructure.AI/Governance/AutonomyConfigValidator.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Governance/AutonomyConfigValidator.cs
@@ -1,0 +1,246 @@
+using Domain.AI.Changes;
+using Domain.AI.Governance;
+using Domain.Common.Config;
+using Domain.Common.Config.AI.Permissions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Infrastructure.AI.Governance;
+
+/// <summary>
+/// One-shot startup validator for the PR-4 graded-autonomy configuration. Refuses
+/// to boot the host when <see cref="GradedAutonomyConfig.Enabled"/> is true and
+/// the config is internally inconsistent — e.g. a Production environment row
+/// declaring <see cref="BlastRadius.Critical"/> as <see cref="AutonomyDecision.AutoApprove"/>
+/// (which the Domain-level safety check would override at runtime but should never
+/// have been allowed to bind in the first place).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Checks performed (only when <c>GradedAutonomy.Enabled</c> is true):
+/// </para>
+/// <list type="number">
+///   <item><description>
+///     <b>Unknown decision or radius names</b> — every row's <c>Decision</c> and
+///     row key must parse to <see cref="AutonomyDecision"/> / <see cref="BlastRadius"/>.
+///     Typos in config would otherwise produce silent fallbacks to RequiresApproval,
+///     which is safe at runtime but indistinguishable from intent — louder at boot.
+///   </description></item>
+///   <item><description>
+///     <b>Critical-AutoApprove rows</b> — any row mapping <see cref="BlastRadius.Critical"/>
+///     to <see cref="AutonomyDecision.AutoApprove"/> at any scope (environment or skill)
+///     is rejected. The Domain policy double-guards this at runtime, but accepting it
+///     here would let a misconfig pass review.
+///   </description></item>
+///   <item><description>
+///     <b>Production permissive rows</b> — Production environment rows declaring
+///     <see cref="BlastRadius.High"/> as AutoApprove are rejected. The runtime
+///     policy still works without this guard, but Production at High blast radius
+///     is the canonical "load-bearing change" case where auto-approve is almost
+///     certainly a misconfiguration.
+///   </description></item>
+///   <item><description>
+///     <b>Per-skill tier widens baseline</b> — a per-skill <c>Tier</c> that is
+///     looser than the configured <see cref="PermissionsConfig.DefaultAutonomyLevel"/>
+///     is rejected. The evaluator silently downgrades these at runtime; rejecting at
+///     boot makes the intent explicit.
+///   </description></item>
+/// </list>
+/// <para>
+/// When graded autonomy is disabled the validator no-ops — the entire layer is
+/// inert anyway, and consumers exploring the template shouldn't be blocked from
+/// running the host.
+/// </para>
+/// </remarks>
+public sealed class AutonomyConfigValidator : IHostedService
+{
+    private readonly IServiceProvider _services;
+    private readonly IOptionsMonitor<AppConfig> _config;
+    private readonly ILogger<AutonomyConfigValidator> _logger;
+
+    /// <summary>Initializes a new <see cref="AutonomyConfigValidator"/>.</summary>
+    /// <remarks>
+    /// <see cref="IHostEnvironment"/> is resolved lazily from
+    /// <see cref="IServiceProvider"/> inside <see cref="StartAsync"/> rather than
+    /// required at construction so DI tests that enumerate
+    /// <c>GetServices&lt;IHostedService&gt;()</c> without a registered host
+    /// environment don't fail at materialization. Real hosts always register
+    /// <see cref="IHostEnvironment"/>.
+    /// </remarks>
+    public AutonomyConfigValidator(
+        IServiceProvider services,
+        IOptionsMonitor<AppConfig> config,
+        ILogger<AutonomyConfigValidator> logger)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(config);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _services = services;
+        _config = config;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        var permissions = _config.CurrentValue.AI.Permissions;
+        var graded = permissions.GradedAutonomy;
+        if (!graded.Enabled)
+        {
+            return Task.CompletedTask;
+        }
+
+        var environment = _services.GetService<IHostEnvironment>();
+        var environmentName = environment?.EnvironmentName ?? "Unknown";
+
+        var errors = new List<string>();
+
+        ValidatePerEnvironment(graded, environmentName, errors);
+        ValidatePerSkill(graded, permissions, errors);
+        ValidateStateChangerOptIns(graded, errors);
+
+        if (errors.Count == 0)
+        {
+            _logger.LogInformation(
+                "Graded autonomy configuration validated successfully ({EnvCount} environment rows, " +
+                "{SkillCount} skill rows, {OptInCount} state-changer opt-ins).",
+                graded.PerEnvironment.Count, graded.PerSkill.Count, graded.StateChangerOptIns.Count);
+            return Task.CompletedTask;
+        }
+
+        var message =
+            "Graded autonomy configuration is internally inconsistent and refuses to boot. " +
+            "Fix the following issues in AppConfig.AI.Permissions.GradedAutonomy then restart:\n - "
+            + string.Join("\n - ", errors);
+        throw new InvalidOperationException(message);
+    }
+
+    /// <inheritdoc />
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    private static void ValidatePerEnvironment(
+        GradedAutonomyConfig graded,
+        string currentEnvironmentName,
+        List<string> errors)
+    {
+        foreach (var (envName, envConfig) in graded.PerEnvironment)
+        {
+            foreach (var (radiusName, ruleConfig) in envConfig.PerBlastRadius)
+            {
+                if (!Enum.TryParse<BlastRadius>(radiusName, ignoreCase: true, out var radius))
+                {
+                    errors.Add(
+                        $"PerEnvironment[{envName}] declares unknown BlastRadius '{radiusName}'. " +
+                        "Valid values: Trivial, Low, Medium, High, Critical.");
+                    continue;
+                }
+
+                if (!Enum.TryParse<AutonomyDecision>(ruleConfig.Decision, ignoreCase: true, out var decision))
+                {
+                    errors.Add(
+                        $"PerEnvironment[{envName}][{radiusName}] declares unknown Decision '{ruleConfig.Decision}'. " +
+                        "Valid values: AutoApprove, RequiresApproval, Forbidden.");
+                    continue;
+                }
+
+                if (radius == BlastRadius.Critical && decision == AutonomyDecision.AutoApprove)
+                {
+                    errors.Add(
+                        $"PerEnvironment[{envName}] maps BlastRadius.Critical to AutoApprove — Critical " +
+                        "must always require human approval. Remove the row or change Decision to RequiresApproval.");
+                }
+
+                if (IsProductionLike(envName) && radius == BlastRadius.High
+                    && decision == AutonomyDecision.AutoApprove)
+                {
+                    errors.Add(
+                        $"PerEnvironment[{envName}] maps BlastRadius.High to AutoApprove in a Production-like " +
+                        "environment — High-blast-radius changes in Production are load-bearing and require " +
+                        "approval. Either lower the environment match or change Decision to RequiresApproval.");
+                }
+            }
+        }
+
+        _ = currentEnvironmentName; // Reserved for environment-conditional checks; not used today.
+    }
+
+    private static void ValidatePerSkill(
+        GradedAutonomyConfig graded,
+        PermissionsConfig permissions,
+        List<string> errors)
+    {
+        if (!Enum.TryParse<AutonomyLevel>(permissions.DefaultAutonomyLevel, ignoreCase: true, out var baseline))
+        {
+            baseline = AutonomyLevel.Supervised;
+        }
+
+        foreach (var (skillKey, skillConfig) in graded.PerSkill)
+        {
+            if (skillConfig.Tier is not null)
+            {
+                if (!Enum.TryParse<AutonomyLevel>(skillConfig.Tier, ignoreCase: true, out var skillTier))
+                {
+                    errors.Add(
+                        $"PerSkill[{skillKey}].Tier '{skillConfig.Tier}' is not a valid AutonomyLevel. " +
+                        "Valid values: Restricted, Supervised, Autonomous.");
+                }
+                else if (skillTier > baseline)
+                {
+                    errors.Add(
+                        $"PerSkill[{skillKey}].Tier '{skillTier}' is looser than the baseline " +
+                        $"DefaultAutonomyLevel '{baseline}'. Per-skill tiers may only narrow the baseline. " +
+                        "Either remove the per-skill tier or set it to Restricted/Supervised.");
+                }
+            }
+
+            foreach (var (radiusName, ruleConfig) in skillConfig.PerBlastRadius)
+            {
+                if (!Enum.TryParse<BlastRadius>(radiusName, ignoreCase: true, out var radius))
+                {
+                    errors.Add(
+                        $"PerSkill[{skillKey}] declares unknown BlastRadius '{radiusName}'. " +
+                        "Valid values: Trivial, Low, Medium, High, Critical.");
+                    continue;
+                }
+
+                if (!Enum.TryParse<AutonomyDecision>(ruleConfig.Decision, ignoreCase: true, out var decision))
+                {
+                    errors.Add(
+                        $"PerSkill[{skillKey}][{radiusName}] declares unknown Decision '{ruleConfig.Decision}'.");
+                    continue;
+                }
+
+                if (radius == BlastRadius.Critical && decision == AutonomyDecision.AutoApprove)
+                {
+                    errors.Add(
+                        $"PerSkill[{skillKey}] maps BlastRadius.Critical to AutoApprove — Critical must always " +
+                        "require human approval regardless of skill.");
+                }
+            }
+        }
+    }
+
+    private static void ValidateStateChangerOptIns(GradedAutonomyConfig graded, List<string> errors)
+    {
+        // A skill in StateChangerOptIns without a corresponding PerSkill rule that
+        // declares AllowAutoApproveForStateChange is harmless (the opt-in alone
+        // grants nothing). The inverse — a PerSkill rule with
+        // AllowAutoApproveForStateChange=true but no entry in StateChangerOptIns
+        // — is also harmless (the dual-key check denies it). Both are documented
+        // as "intentional config noise" rather than errors. The only thing worth
+        // flagging is empty-string entries.
+        var blanks = graded.StateChangerOptIns.Count(s => string.IsNullOrWhiteSpace(s));
+        if (blanks > 0)
+        {
+            errors.Add(
+                $"StateChangerOptIns contains {blanks} blank entry — every entry must be a non-empty skill key.");
+        }
+    }
+
+    private static bool IsProductionLike(string environmentName)
+        => environmentName.Equals("Production", StringComparison.OrdinalIgnoreCase)
+        || environmentName.Equals("Prod", StringComparison.OrdinalIgnoreCase);
+}

--- a/src/Content/Tests/Application.Core.Tests/Permissions/AutonomyDecisionEvaluatorTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/Permissions/AutonomyDecisionEvaluatorTests.cs
@@ -1,0 +1,329 @@
+using Application.Core.Permissions;
+using Domain.AI.Changes;
+using Domain.AI.Governance;
+using Domain.Common.Config;
+using Domain.Common.Config.AI.Permissions;
+using FluentAssertions;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Application.Core.Tests.Permissions;
+
+/// <summary>
+/// Tests for <see cref="AutonomyDecisionEvaluator"/> — the Application-side
+/// layered evaluator. Covers fallback path, environment overlay, per-skill
+/// narrowing, and the dual-key state-changer opt-in.
+/// </summary>
+public sealed class AutonomyDecisionEvaluatorTests
+{
+    private static AutonomyDecisionEvaluator Build(AppConfig config, string environmentName = "Development")
+    {
+        var monitor = Mock.Of<IOptionsMonitor<AppConfig>>(o => o.CurrentValue == config);
+
+        var env = new Mock<IHostEnvironment>();
+        env.SetupGet(e => e.EnvironmentName).Returns(environmentName);
+
+        return new AutonomyDecisionEvaluator(
+            monitor,
+            env.Object,
+            NullLogger<AutonomyDecisionEvaluator>.Instance);
+    }
+
+    private static AppConfig GradedDisabled() => new();
+
+    private static AppConfig GradedEnabled(Action<GradedAutonomyConfig>? configure = null)
+    {
+        var config = new AppConfig();
+        config.AI.Permissions.GradedAutonomy.Enabled = true;
+        configure?.Invoke(config.AI.Permissions.GradedAutonomy);
+        return config;
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // 1. Fallback path — Graded disabled preserves PR-2 behaviour exactly.
+    // ─────────────────────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData(BlastRadius.Trivial, AutonomyDecision.AutoApprove)]
+    [InlineData(BlastRadius.Low, AutonomyDecision.RequiresApproval)]
+    [InlineData(BlastRadius.Medium, AutonomyDecision.RequiresApproval)]
+    [InlineData(BlastRadius.High, AutonomyDecision.RequiresApproval)]
+    [InlineData(BlastRadius.Critical, AutonomyDecision.RequiresApproval)]
+    public void Evaluate_GradedDisabled_FallsBackToPR2Behavior(
+        BlastRadius radius, AutonomyDecision expected)
+    {
+        var sut = Build(GradedDisabled());
+
+        var result = sut.Evaluate(
+            AutonomyLevel.Autonomous,
+            radius,
+            ChangeTargetKind.GitRepo,
+            isStateChange: false,
+            skillKey: "any-skill");
+
+        result.Decision.Should().Be(expected);
+        result.Reason.Should().Contain("GradedAutonomy disabled");
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // 2. Per-environment override.
+    // ─────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Evaluate_DevelopmentPermissiveRule_AllowsAutoApprove()
+    {
+        var config = GradedEnabled(g =>
+        {
+            g.PerEnvironment["Development"] = new EnvironmentAutonomyConfig
+            {
+                PerBlastRadius =
+                {
+                    ["Medium"] = new BlastRadiusRuleConfig { Decision = "AutoApprove" }
+                }
+            };
+        });
+
+        var sut = Build(config, environmentName: "Development");
+
+        var result = sut.Evaluate(
+            AutonomyLevel.Autonomous,
+            BlastRadius.Medium,
+            ChangeTargetKind.GitRepo,
+            isStateChange: false,
+            skillKey: null);
+
+        result.Decision.Should().Be(AutonomyDecision.AutoApprove);
+        result.Environment.Should().Be("Development");
+    }
+
+    [Fact]
+    public void Evaluate_ProductionStrictRule_SameTier_StillRequiresApproval()
+    {
+        // Same tier (Autonomous), same radius (Medium) — but Production env has
+        // no rule, falls back to policy default (RequiresApproval).
+        var config = GradedEnabled(g =>
+        {
+            g.PerEnvironment["Development"] = new EnvironmentAutonomyConfig
+            {
+                PerBlastRadius =
+                {
+                    ["Medium"] = new BlastRadiusRuleConfig { Decision = "AutoApprove" }
+                }
+            };
+        });
+
+        var sut = Build(config, environmentName: "Production");
+
+        var result = sut.Evaluate(
+            AutonomyLevel.Autonomous,
+            BlastRadius.Medium,
+            ChangeTargetKind.GitRepo,
+            isStateChange: false,
+            skillKey: null);
+
+        result.Decision.Should().Be(AutonomyDecision.RequiresApproval);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // 3. Per-skill override is more restrictive only.
+    // ─────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Evaluate_PerSkillTierStricterThanBaseline_NarrowsTier()
+    {
+        var config = GradedEnabled(g =>
+        {
+            g.PerSkill["careful-skill"] = new SkillAutonomyConfig
+            {
+                Tier = "Restricted"
+            };
+
+            // Permissive env rule that the careful-skill tier narrowing should ignore
+            g.PerEnvironment["Development"] = new EnvironmentAutonomyConfig
+            {
+                PerBlastRadius =
+                {
+                    ["Low"] = new BlastRadiusRuleConfig { Decision = "AutoApprove" }
+                }
+            };
+        });
+
+        var sut = Build(config, environmentName: "Development");
+
+        // Skill narrows tier to Restricted; Restricted has no auto-approve rules
+        // → still RequiresApproval despite the env Auto-approve rule, because the
+        // policy is built off the narrowed tier whose rule table is the env one
+        // — but the SAFETY default still kicks in for state changes etc.
+        var result = sut.Evaluate(
+            AutonomyLevel.Autonomous,
+            BlastRadius.Low,
+            ChangeTargetKind.GitRepo,
+            isStateChange: false,
+            skillKey: "careful-skill");
+
+        result.Tier.Should().Be(AutonomyLevel.Restricted);
+    }
+
+    [Fact]
+    public void Evaluate_PerSkillTierLooserThanBaseline_IgnoredAndKeepsBaseline()
+    {
+        var config = GradedEnabled(g =>
+        {
+            g.PerSkill["bossy-skill"] = new SkillAutonomyConfig
+            {
+                Tier = "Autonomous"
+            };
+        });
+
+        var sut = Build(config);
+
+        var result = sut.Evaluate(
+            AutonomyLevel.Restricted,  // baseline is strict
+            BlastRadius.Low,
+            ChangeTargetKind.GitRepo,
+            isStateChange: false,
+            skillKey: "bossy-skill");
+
+        // Skill tried to widen Restricted → Autonomous, must be ignored.
+        result.Tier.Should().Be(AutonomyLevel.Restricted);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // 4. Per-environment vs Production — different decisions for same radius.
+    // ─────────────────────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("Development", AutonomyDecision.AutoApprove)]
+    [InlineData("Production", AutonomyDecision.RequiresApproval)]
+    public void Evaluate_SamePolicy_DifferentEnvironments_DifferentDecisions(
+        string environmentName, AutonomyDecision expected)
+    {
+        var config = GradedEnabled(g =>
+        {
+            g.PerEnvironment["Development"] = new EnvironmentAutonomyConfig
+            {
+                PerBlastRadius =
+                {
+                    ["Medium"] = new BlastRadiusRuleConfig { Decision = "AutoApprove" }
+                }
+            };
+            // Production gets no rule for Medium — falls back to RequiresApproval.
+        });
+
+        var sut = Build(config, environmentName);
+
+        var result = sut.Evaluate(
+            AutonomyLevel.Autonomous,
+            BlastRadius.Medium,
+            ChangeTargetKind.GitRepo,
+            isStateChange: false,
+            skillKey: null);
+
+        result.Decision.Should().Be(expected);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // 5. Dual-key state-change check.
+    // ─────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Evaluate_StateChange_RowOptInButSkillNotInOptIns_StillRequiresApproval()
+    {
+        var config = GradedEnabled(g =>
+        {
+            g.PerEnvironment["Development"] = new EnvironmentAutonomyConfig
+            {
+                PerBlastRadius =
+                {
+                    ["Low"] = new BlastRadiusRuleConfig
+                    {
+                        Decision = "AutoApprove",
+                        AllowAutoApproveForStateChange = true
+                    }
+                }
+            };
+            // Note: NO entry in g.StateChangerOptIns for "writer-skill"
+        });
+
+        var sut = Build(config);
+
+        var result = sut.Evaluate(
+            AutonomyLevel.Autonomous,
+            BlastRadius.Low,
+            ChangeTargetKind.GitRepo,
+            isStateChange: true,
+            skillKey: "writer-skill");
+
+        result.Decision.Should().Be(AutonomyDecision.RequiresApproval);
+        result.Reason.Should().Contain("dual-key");
+    }
+
+    [Fact]
+    public void Evaluate_StateChange_BothOptInsSet_AutoApproves()
+    {
+        var config = GradedEnabled(g =>
+        {
+            g.PerEnvironment["Development"] = new EnvironmentAutonomyConfig
+            {
+                PerBlastRadius =
+                {
+                    ["Low"] = new BlastRadiusRuleConfig
+                    {
+                        Decision = "AutoApprove",
+                        AllowAutoApproveForStateChange = true
+                    }
+                }
+            };
+            g.StateChangerOptIns.Add("writer-skill");
+        });
+
+        var sut = Build(config);
+
+        var result = sut.Evaluate(
+            AutonomyLevel.Autonomous,
+            BlastRadius.Low,
+            ChangeTargetKind.GitRepo,
+            isStateChange: true,
+            skillKey: "writer-skill");
+
+        result.Decision.Should().Be(AutonomyDecision.AutoApprove);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // 6. Critical always requires approval, even with permissive config.
+    // ─────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Evaluate_CriticalRadius_PermissiveProdConfig_StillRequiresApproval()
+    {
+        var config = GradedEnabled(g =>
+        {
+            g.PerEnvironment["Production"] = new EnvironmentAutonomyConfig
+            {
+                PerBlastRadius =
+                {
+                    ["Critical"] = new BlastRadiusRuleConfig
+                    {
+                        Decision = "AutoApprove",
+                        AllowAutoApproveForStateChange = true
+                    }
+                }
+            };
+            g.StateChangerOptIns.Add("any-skill");
+        });
+
+        var sut = Build(config, "Production");
+
+        var result = sut.Evaluate(
+            AutonomyLevel.Autonomous,
+            BlastRadius.Critical,
+            ChangeTargetKind.IacDeployment,
+            isStateChange: true,
+            skillKey: "any-skill");
+
+        result.Decision.Should().Be(AutonomyDecision.RequiresApproval);
+    }
+}

--- a/src/Content/Tests/Domain.AI.Tests/Governance/AutonomyTierPolicyTests.cs
+++ b/src/Content/Tests/Domain.AI.Tests/Governance/AutonomyTierPolicyTests.cs
@@ -1,0 +1,204 @@
+using Domain.AI.Changes;
+using Domain.AI.Governance;
+using Domain.AI.Permissions;
+using Xunit;
+
+namespace Domain.AI.Tests.Governance;
+
+/// <summary>
+/// Tests for <see cref="AutonomyTierPolicy.EvaluateFor"/> — the pure Domain
+/// projection used by the graded-autonomy evaluator. The matrix tests cover
+/// the full tier × blast-radius cross-product and lock in the load-bearing
+/// safety invariants (Critical always requires approval, state-changers
+/// default to RequiresApproval).
+/// </summary>
+public sealed class AutonomyTierPolicyTests
+{
+    private static AutonomyTierPolicy PolicyWith(
+        AutonomyLevel level,
+        params BlastRadiusAutonomyRule[] rules)
+        => new()
+        {
+            Level = level,
+            DefaultBehavior = level == AutonomyLevel.Autonomous
+                ? PermissionBehaviorType.Allow
+                : PermissionBehaviorType.Ask,
+            PerBlastRadius = rules.Length == 0
+                ? null
+                : rules.ToDictionary(r => r.Radius)
+        };
+
+    // ─────────────────────────────────────────────────────────────────────
+    // 1. Tier × blast-radius matrix — Restricted always RequiresApproval.
+    // ─────────────────────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData(BlastRadius.Trivial)]
+    [InlineData(BlastRadius.Low)]
+    [InlineData(BlastRadius.Medium)]
+    [InlineData(BlastRadius.High)]
+    [InlineData(BlastRadius.Critical)]
+    public void EvaluateFor_RestrictedTier_AnyRadius_AlwaysRequiresApproval(BlastRadius radius)
+    {
+        // Restricted tier has no auto-approve rules — every radius defaults
+        // to RequiresApproval per the safety-default rule on the policy.
+        var policy = PolicyWith(AutonomyLevel.Restricted);
+
+        var (decision, _) = policy.EvaluateFor(radius, ChangeTargetKind.GitRepo, isStateChange: false);
+
+        Assert.Equal(AutonomyDecision.RequiresApproval, decision);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // 2. Tier × blast-radius matrix — Supervised default behaviour.
+    // ─────────────────────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData(BlastRadius.Trivial)]
+    [InlineData(BlastRadius.Low)]
+    [InlineData(BlastRadius.Medium)]
+    [InlineData(BlastRadius.High)]
+    [InlineData(BlastRadius.Critical)]
+    public void EvaluateFor_SupervisedTier_NoRules_AnyRadius_RequiresApproval(BlastRadius radius)
+    {
+        var policy = PolicyWith(AutonomyLevel.Supervised);
+
+        var (decision, _) = policy.EvaluateFor(radius, ChangeTargetKind.GitRepo, isStateChange: false);
+
+        Assert.Equal(AutonomyDecision.RequiresApproval, decision);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // 3. Tier × blast-radius matrix — Autonomous with permissive rules.
+    // ─────────────────────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData(BlastRadius.Trivial, AutonomyDecision.AutoApprove)]
+    [InlineData(BlastRadius.Low, AutonomyDecision.AutoApprove)]
+    [InlineData(BlastRadius.Medium, AutonomyDecision.RequiresApproval)]
+    [InlineData(BlastRadius.High, AutonomyDecision.RequiresApproval)]
+    [InlineData(BlastRadius.Critical, AutonomyDecision.RequiresApproval)] // the invariant
+    public void EvaluateFor_AutonomousTier_PermissiveLowAndTrivial_RespectsCriticalGuard(
+        BlastRadius radius, AutonomyDecision expected)
+    {
+        var policy = PolicyWith(
+            AutonomyLevel.Autonomous,
+            new BlastRadiusAutonomyRule(BlastRadius.Trivial, AutonomyDecision.AutoApprove),
+            new BlastRadiusAutonomyRule(BlastRadius.Low, AutonomyDecision.AutoApprove));
+
+        var (decision, _) = policy.EvaluateFor(radius, ChangeTargetKind.GitRepo, isStateChange: false);
+
+        Assert.Equal(expected, decision);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // 4. Load-bearing safety invariant: state-changers default to Review.
+    // ─────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void EvaluateFor_AutoApproveRule_StateChange_NoOptIn_ForcesRequiresApproval()
+    {
+        // Tier=Autonomous, rule says AutoApprove for Low, but the proposal is a
+        // state change AND AllowAutoApproveForStateChange is false (the safety
+        // default). The policy must force RequiresApproval.
+        var policy = PolicyWith(
+            AutonomyLevel.Autonomous,
+            new BlastRadiusAutonomyRule(BlastRadius.Low, AutonomyDecision.AutoApprove, AllowAutoApproveForStateChange: false));
+
+        var (decision, reason) = policy.EvaluateFor(
+            BlastRadius.Low,
+            ChangeTargetKind.GitRepo,
+            isStateChange: true);
+
+        Assert.Equal(AutonomyDecision.RequiresApproval, decision);
+        Assert.Contains("state-change", reason);
+    }
+
+    [Fact]
+    public void EvaluateFor_AutoApproveRule_StateChange_WithOptIn_AllowsAutoApprove()
+    {
+        var policy = PolicyWith(
+            AutonomyLevel.Autonomous,
+            new BlastRadiusAutonomyRule(BlastRadius.Low, AutonomyDecision.AutoApprove, AllowAutoApproveForStateChange: true));
+
+        var (decision, _) = policy.EvaluateFor(
+            BlastRadius.Low,
+            ChangeTargetKind.GitRepo,
+            isStateChange: true);
+
+        Assert.Equal(AutonomyDecision.AutoApprove, decision);
+    }
+
+    [Fact]
+    public void EvaluateFor_AutoApproveRule_NonStateChange_AllowsAutoApprove()
+    {
+        // The opt-in is irrelevant for non-state-changes; the rule applies directly.
+        var policy = PolicyWith(
+            AutonomyLevel.Autonomous,
+            new BlastRadiusAutonomyRule(BlastRadius.Low, AutonomyDecision.AutoApprove, AllowAutoApproveForStateChange: false));
+
+        var (decision, _) = policy.EvaluateFor(
+            BlastRadius.Low,
+            ChangeTargetKind.GitRepo,
+            isStateChange: false);
+
+        Assert.Equal(AutonomyDecision.AutoApprove, decision);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // 5. Critical-always-requires-approval cannot be loosened by ANY rule.
+    // ─────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void EvaluateFor_CriticalBlastRadius_EvenWithAutoApproveRuleAndOptIn_RequiresApproval()
+    {
+        var policy = PolicyWith(
+            AutonomyLevel.Autonomous,
+            new BlastRadiusAutonomyRule(BlastRadius.Critical, AutonomyDecision.AutoApprove, AllowAutoApproveForStateChange: true));
+
+        var (decision, reason) = policy.EvaluateFor(
+            BlastRadius.Critical,
+            ChangeTargetKind.IacDeployment,
+            isStateChange: false);
+
+        Assert.Equal(AutonomyDecision.RequiresApproval, decision);
+        Assert.Contains("Critical", reason);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // 6. Forbidden decision is always honoured.
+    // ─────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void EvaluateFor_ForbiddenRule_ReturnsForbiddenRegardlessOfStateChange()
+    {
+        var policy = PolicyWith(
+            AutonomyLevel.Autonomous,
+            new BlastRadiusAutonomyRule(BlastRadius.High, AutonomyDecision.Forbidden));
+
+        var (decision, _) = policy.EvaluateFor(
+            BlastRadius.High,
+            ChangeTargetKind.IacDeployment,
+            isStateChange: true);
+
+        Assert.Equal(AutonomyDecision.Forbidden, decision);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // 7. Reason string includes useful diagnostics.
+    // ─────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void EvaluateFor_ReasonMentionsTierAndRadius()
+    {
+        var policy = PolicyWith(AutonomyLevel.Supervised);
+
+        var (_, reason) = policy.EvaluateFor(
+            BlastRadius.Medium,
+            ChangeTargetKind.GitRepo,
+            isStateChange: false);
+
+        Assert.Contains("Supervised", reason);
+        Assert.Contains("Medium", reason);
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Changes/DefaultChangeProposalGateResolverTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Changes/DefaultChangeProposalGateResolverTests.cs
@@ -1,5 +1,6 @@
 using Application.AI.Common.Interfaces.Changes;
 using Domain.AI.Changes;
+using Domain.AI.Governance;
 using FluentAssertions;
 using Infrastructure.AI.Changes;
 using Xunit;
@@ -47,5 +48,75 @@ public sealed class DefaultChangeProposalGateResolverTests
             WellKnownGateKeys.Policy,
             WellKnownGateKeys.Approval,
             WellKnownGateKeys.Merge);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // PR-4: ResolveWithDecision honours the graded-autonomy decision.
+    // ─────────────────────────────────────────────────────────────────────
+
+    private static AutonomyDecisionResult Decision(
+        AutonomyDecision decision,
+        BlastRadius radius = BlastRadius.Low,
+        ChangeTargetKind targetKind = ChangeTargetKind.GitRepo)
+        => new(
+            Decision: decision,
+            Tier: AutonomyLevel.Autonomous,
+            BlastRadius: radius,
+            TargetKind: targetKind,
+            IsStateChange: false,
+            Environment: "Test",
+            SkillKey: null,
+            Reason: "test");
+
+    [Fact]
+    public void ResolveWithDecision_NullDecision_FallsBackToStaticRule()
+    {
+        var sut = new DefaultChangeProposalGateResolver();
+
+        var gates = sut.ResolveWithDecision(ChangeTargetKind.GitRepo, BlastRadius.Medium, decision: null);
+
+        gates.Should().Contain(WellKnownGateKeys.Approval);
+    }
+
+    [Fact]
+    public void ResolveWithDecision_AutoApprove_OmitsApprovalGate()
+    {
+        var sut = new DefaultChangeProposalGateResolver();
+
+        var gates = sut.ResolveWithDecision(
+            ChangeTargetKind.GitRepo,
+            BlastRadius.Medium,
+            Decision(AutonomyDecision.AutoApprove, BlastRadius.Medium));
+
+        gates.Should().NotContain(WellKnownGateKeys.Approval);
+        gates.Should().Contain(WellKnownGateKeys.Merge);
+    }
+
+    [Fact]
+    public void ResolveWithDecision_RequiresApproval_IncludesApprovalGate()
+    {
+        var sut = new DefaultChangeProposalGateResolver();
+
+        var gates = sut.ResolveWithDecision(
+            ChangeTargetKind.GitRepo,
+            BlastRadius.Low,
+            Decision(AutonomyDecision.RequiresApproval, BlastRadius.Low));
+
+        gates.Should().Contain(WellKnownGateKeys.Approval);
+    }
+
+    [Fact]
+    public void ResolveWithDecision_CriticalRadius_AutoApprove_StillIncludesApproval()
+    {
+        // Even if the evaluator passes AutoApprove for Critical, the resolver
+        // re-asserts the safety invariant.
+        var sut = new DefaultChangeProposalGateResolver();
+
+        var gates = sut.ResolveWithDecision(
+            ChangeTargetKind.GitRepo,
+            BlastRadius.Critical,
+            Decision(AutonomyDecision.AutoApprove, BlastRadius.Critical));
+
+        gates.Should().Contain(WellKnownGateKeys.Approval);
     }
 }

--- a/src/Content/Tests/Infrastructure.AI.Tests/Governance/AutonomyConfigValidatorTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Governance/AutonomyConfigValidatorTests.cs
@@ -1,0 +1,236 @@
+using Domain.Common.Config;
+using Domain.Common.Config.AI.Permissions;
+using FluentAssertions;
+using Infrastructure.AI.Governance;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Governance;
+
+/// <summary>
+/// Boot-time validator tests for <see cref="AutonomyConfigValidator"/> (PR-4).
+/// </summary>
+public sealed class AutonomyConfigValidatorTests
+{
+    private sealed class StubEnv : IHostEnvironment
+    {
+        public string EnvironmentName { get; set; } = "Production";
+        public string ApplicationName { get; set; } = "TestApp";
+        public string ContentRootPath { get; set; } = ".";
+        public Microsoft.Extensions.FileProviders.IFileProvider ContentRootFileProvider { get; set; }
+            = new Microsoft.Extensions.FileProviders.NullFileProvider();
+    }
+
+    private static AutonomyConfigValidator Build(
+        AppConfig config,
+        string environmentName = "Development")
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<IHostEnvironment>(new StubEnv { EnvironmentName = environmentName });
+        var provider = services.BuildServiceProvider();
+
+        var monitor = new StaticOptionsMonitor<AppConfig>(config);
+
+        return new AutonomyConfigValidator(
+            provider,
+            monitor,
+            NullLogger<AutonomyConfigValidator>.Instance);
+    }
+
+    private static AppConfig GradedEnabled(Action<GradedAutonomyConfig> configure)
+    {
+        var cfg = new AppConfig();
+        cfg.AI.Permissions.GradedAutonomy.Enabled = true;
+        configure(cfg.AI.Permissions.GradedAutonomy);
+        return cfg;
+    }
+
+    [Fact]
+    public async Task StartAsync_GradedDisabled_NoOp()
+    {
+        var cfg = new AppConfig(); // GradedAutonomy.Enabled defaults to false
+        var sut = Build(cfg);
+
+        var act = async () => await sut.StartAsync(CancellationToken.None);
+
+        await act.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task StartAsync_GradedEnabled_NoRules_NoOp()
+    {
+        var cfg = GradedEnabled(_ => { });
+        var sut = Build(cfg);
+
+        var act = async () => await sut.StartAsync(CancellationToken.None);
+
+        await act.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task StartAsync_CriticalAutoApproveAnywhere_Throws()
+    {
+        var cfg = GradedEnabled(g =>
+        {
+            g.PerEnvironment["Development"] = new EnvironmentAutonomyConfig
+            {
+                PerBlastRadius =
+                {
+                    ["Critical"] = new BlastRadiusRuleConfig { Decision = "AutoApprove" }
+                }
+            };
+        });
+
+        var sut = Build(cfg);
+
+        var act = async () => await sut.StartAsync(CancellationToken.None);
+
+        var ex = await act.Should().ThrowAsync<InvalidOperationException>();
+        ex.Which.Message.Should().Contain("Critical");
+        ex.Which.Message.Should().Contain("AutoApprove");
+    }
+
+    [Fact]
+    public async Task StartAsync_ProductionHighAutoApprove_Throws()
+    {
+        var cfg = GradedEnabled(g =>
+        {
+            g.PerEnvironment["Production"] = new EnvironmentAutonomyConfig
+            {
+                PerBlastRadius =
+                {
+                    ["High"] = new BlastRadiusRuleConfig { Decision = "AutoApprove" }
+                }
+            };
+        });
+
+        var sut = Build(cfg);
+
+        var act = async () => await sut.StartAsync(CancellationToken.None);
+
+        var ex = await act.Should().ThrowAsync<InvalidOperationException>();
+        ex.Which.Message.Should().Contain("Production");
+        ex.Which.Message.Should().Contain("High");
+    }
+
+    [Fact]
+    public async Task StartAsync_InvalidEnumNames_Throws()
+    {
+        var cfg = GradedEnabled(g =>
+        {
+            g.PerEnvironment["Development"] = new EnvironmentAutonomyConfig
+            {
+                PerBlastRadius =
+                {
+                    ["Catastrophic"] = new BlastRadiusRuleConfig { Decision = "Maybe" }
+                }
+            };
+        });
+
+        var sut = Build(cfg);
+
+        var act = async () => await sut.StartAsync(CancellationToken.None);
+
+        var ex = await act.Should().ThrowAsync<InvalidOperationException>();
+        ex.Which.Message.Should().Contain("Catastrophic");
+    }
+
+    [Fact]
+    public async Task StartAsync_PerSkillTierLooserThanBaseline_Throws()
+    {
+        var cfg = GradedEnabled(g =>
+        {
+            g.PerSkill["bossy"] = new SkillAutonomyConfig
+            {
+                Tier = "Autonomous"
+            };
+        });
+        cfg.AI.Permissions.DefaultAutonomyLevel = "Restricted";
+
+        var sut = Build(cfg);
+
+        var act = async () => await sut.StartAsync(CancellationToken.None);
+
+        var ex = await act.Should().ThrowAsync<InvalidOperationException>();
+        ex.Which.Message.Should().Contain("bossy");
+        ex.Which.Message.Should().Contain("looser");
+    }
+
+    [Fact]
+    public async Task StartAsync_PerSkillCriticalAutoApprove_Throws()
+    {
+        var cfg = GradedEnabled(g =>
+        {
+            g.PerSkill["dangerous"] = new SkillAutonomyConfig
+            {
+                PerBlastRadius =
+                {
+                    ["Critical"] = new BlastRadiusRuleConfig { Decision = "AutoApprove" }
+                }
+            };
+        });
+
+        var sut = Build(cfg);
+
+        var act = async () => await sut.StartAsync(CancellationToken.None);
+
+        var ex = await act.Should().ThrowAsync<InvalidOperationException>();
+        ex.Which.Message.Should().Contain("dangerous");
+    }
+
+    [Fact]
+    public async Task StartAsync_BlankStateChangerOptIn_Throws()
+    {
+        var cfg = GradedEnabled(g =>
+        {
+            g.StateChangerOptIns.Add("   ");
+        });
+
+        var sut = Build(cfg);
+
+        var act = async () => await sut.StartAsync(CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+    }
+
+    [Fact]
+    public async Task StartAsync_ValidConfig_NoThrow()
+    {
+        var cfg = GradedEnabled(g =>
+        {
+            g.PerEnvironment["Development"] = new EnvironmentAutonomyConfig
+            {
+                PerBlastRadius =
+                {
+                    ["Trivial"] = new BlastRadiusRuleConfig { Decision = "AutoApprove" },
+                    ["Low"] = new BlastRadiusRuleConfig { Decision = "AutoApprove" }
+                }
+            };
+            g.PerEnvironment["Production"] = new EnvironmentAutonomyConfig
+            {
+                PerBlastRadius =
+                {
+                    ["Trivial"] = new BlastRadiusRuleConfig { Decision = "AutoApprove" }
+                }
+            };
+            g.StateChangerOptIns.Add("trusted-skill");
+        });
+
+        var sut = Build(cfg);
+
+        var act = async () => await sut.StartAsync(CancellationToken.None);
+
+        await act.Should().NotThrowAsync();
+    }
+
+    private sealed class StaticOptionsMonitor<T> : IOptionsMonitor<T>
+    {
+        public StaticOptionsMonitor(T value) { CurrentValue = value; }
+        public T CurrentValue { get; }
+        public T Get(string? name) => CurrentValue;
+        public IDisposable? OnChange(Action<T, string?> listener) => null;
+    }
+}


### PR DESCRIPTION
## Summary

PR-4 of the agentic-devops roadmap. Adds per-`BlastRadius`, per-environment, and per-skill decisions to `AutonomyTierPolicy`, wired into the `ChangeProposal` gate resolver. State-changers default to **RequiresApproval** even under Autonomous tier unless the skill is on the explicit `StateChangerOptIns` list AND the matching blast-radius row has `AllowAutoApproveForStateChange: true` (dual-key safety).

## What changed

**Domain** (`Domain.AI/Governance/`):
- `AutonomyDecision` enum (`AutoApprove`/`RequiresApproval`/`Forbidden`)
- `AutonomyDecisionResult` — decision + inputs + reason, for audit
- `BlastRadiusAutonomyRule` — one row in a tier's per-radius rule table
- `AutonomyTierPolicy.EvaluateFor(...)` — pure projection method enforcing the safety invariants (Critical always requires approval; state-changers default to Review)

**Config** (`Domain.Common/Config/AI/Permissions/`):
- `GradedAutonomyConfig` (off by default) with `PerEnvironment`, `PerSkill`, `StateChangerOptIns` maps
- `EnvironmentAutonomyConfig`, `SkillAutonomyConfig`, `BlastRadiusRuleConfig` overlay records
- Exposed as `PermissionsConfig.GradedAutonomy`; existing `TierPolicies` untouched

**Application** (`Application.AI.Common/`, `Application.Core/Permissions/`):
- `IAutonomyDecisionEvaluator` + `AutonomyDecisionEvaluator` impl with full layering: baseline tier → per-skill tier (narrow only) → per-environment rules → per-skill rules (narrow only) → policy.EvaluateFor → dual-key state-changer check
- `IChangeProposalGateResolver.ResolveWithDecision(...)` — new method with default-interface-impl forwarding to the existing `Resolve` for back-compat
- `SubmitChangeProposalCommand` adds optional `SkillKey` + `IsStateChange` (defaults to true — the safe assumption)
- `SubmitChangeProposalCommandHandler` optionally consumes the evaluator + tier resolver; falls back to PR-2 behavior when either is unwired

**Infrastructure** (`Infrastructure.AI/Changes/`, `Infrastructure.AI/Governance/`):
- `DefaultChangeProposalGateResolver` honours the decision (omits approval gate on `AutoApprove`); re-asserts the Critical-always-requires-approval invariant
- `AutonomyConfigValidator` — `IHostedService` refusing to boot when graded autonomy is enabled and config is internally inconsistent (Critical→AutoApprove anywhere, Production→High→AutoApprove, invalid enum names, per-skill tier looser than baseline)

## Safety invariants locked in by tests

1. **Critical always requires approval** — enforced in three places (Domain policy, evaluator, gate resolver). Even an Autonomous-tier `Critical→AutoApprove` rule with state-change opt-in is rejected at runtime.
2. **State-changers default to Review** — `AllowAutoApproveForStateChange` (per-row) AND `StateChangerOptIns` (per-skill list) both required; either one missing forces RequiresApproval.
3. **Skills can only narrow** — a per-skill `Tier` looser than the baseline is silently ignored at runtime AND rejected at boot by the validator.
4. **Per-environment overrides** — same policy in Development vs Production produces different decisions for the same Medium-blast-radius proposal (covered by Theory test).

## Test plan

- [x] `dotnet build src/AgenticHarness.slnx` — 0 errors
- [x] 21 new Domain tests (`AutonomyTierPolicyTests`) green
- [x] 11 new Application tests (`AutonomyDecisionEvaluatorTests`) green
- [x] 9 new Infrastructure validator tests (`AutonomyConfigValidatorTests`) green
- [x] 4 new resolver integration tests (extended `DefaultChangeProposalGateResolverTests`) green
- [x] All 163 existing Changes-namespace tests stay green (no PR-2 regression)
- [x] Full solution test suite: 6437 passed / 0 failed / 2 skipped

## Hard stops respected

- No changes to `BlastRadius` enum values, ordering, or namespace
- No breaking changes to `ApprovalGate` (default still defers via router; the autonomy decision is consulted upstream at gate-resolver time, which is the architecturally correct integration point — `ApprovalGate` documentation references this)
- Existing `AutonomyTierPolicy.DefaultBehavior` / `ToolOverrides` surface untouched; `PermissionRule` consumers unaffected
- `Result<T>` for expected failures; exceptions only for boot-time misconfig (matches PR-2 patterns)

🤖 Generated with [Claude Code](https://claude.com/claude-code)