### PR TITLE
PR-5: Incident-Response-Plan abstraction

### DIFF
--- a/src/Content/Application/Application.AI.Common/Interfaces/IncidentResponse/IIncidentContext.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/IncidentResponse/IIncidentContext.cs
@@ -1,0 +1,52 @@
+namespace Application.AI.Common.Interfaces.IncidentResponse;
+
+/// <summary>
+/// Ambient context exposing the currently active incident type, if any. Set
+/// once per request by the Presentation layer (typically a middleware or hub
+/// filter) when an incident-tracking system reports the host is operating
+/// under an active incident. Read by services that need to vary their
+/// behaviour while an incident is active — notably the
+/// <c>ChangeProposalOrchestrator</c>, which consults
+/// <see cref="IIncidentResponsePlanResolver"/> to overlay additional
+/// required-gates onto in-flight proposals.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Implementations flow the active incident type through async continuations
+/// and child DI scopes via <see cref="System.Threading.AsyncLocal{T}"/> — the
+/// same pattern the harness uses for its knowledge-scope identity. This is
+/// deliberate: the orchestrator dispatch and gate evaluations may run on a
+/// background <c>IHostedService</c> task after the originating request scope
+/// has been disposed, and ambient flow is the only way to carry the incident
+/// type into those continuations without threading it through every interface.
+/// </para>
+/// <para>
+/// The interface is intentionally minimal — set, read, clear. Higher-level
+/// concerns (mapping a Sentry / PagerDuty alert to an incident type, deciding
+/// when to clear the incident) live in consumer-supplied glue at the
+/// Presentation layer.
+/// </para>
+/// </remarks>
+public interface IIncidentContext
+{
+    /// <summary>
+    /// The active incident type, or <c>null</c> when no incident is active.
+    /// Reading is free — every consumer that cares about the incident state
+    /// reads this property and then consults
+    /// <see cref="IIncidentResponsePlanResolver"/>.
+    /// </summary>
+    string? CurrentIncidentType { get; }
+
+    /// <summary>
+    /// Set the active incident for the current async execution context. The
+    /// value flows into child scopes and background continuations through
+    /// <see cref="System.Threading.AsyncLocal{T}"/>. Passing <c>null</c> clears
+    /// the incident — equivalent to a follow-up "incident resolved" report.
+    /// </summary>
+    /// <param name="incidentType">
+    /// The incident type token, or <c>null</c> to clear. Whitespace is
+    /// normalised to <c>null</c> so empty strings don't accidentally activate
+    /// a non-existent plan.
+    /// </param>
+    void Set(string? incidentType);
+}

--- a/src/Content/Application/Application.AI.Common/Interfaces/IncidentResponse/IIncidentResponsePlanResolver.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/IncidentResponse/IIncidentResponsePlanResolver.cs
@@ -1,0 +1,52 @@
+using Domain.Common.Config.AI.IncidentResponse;
+
+namespace Application.AI.Common.Interfaces.IncidentResponse;
+
+/// <summary>
+/// Lookup service that maps an incident type token to the configured
+/// <see cref="IncidentResponsePlan"/>. Consulted by the
+/// <c>ChangeProposalOrchestrator</c> (and by skill / autonomy wiring) when the
+/// host reports an active incident.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Resolution semantics:
+/// </para>
+/// <list type="number">
+///   <item><description>
+///     Plans are matched by <see cref="IncidentResponsePlan.IncidentType"/>
+///     case-insensitively. The first matching plan wins; the boot validator
+///     refuses to start with duplicate incident-type entries so the
+///     "first match" rule is deterministic in well-configured hosts.
+///   </description></item>
+///   <item><description>
+///     If no plan matches and a fallback
+///     (<c>IncidentResponsePlanConfig.DefaultPlanName</c>) is configured, the
+///     resolver returns that plan.
+///   </description></item>
+///   <item><description>
+///     If neither a match nor a default exists, the resolver returns
+///     <c>null</c> — callers treat null as "no incident behaviour applies".
+///   </description></item>
+/// </list>
+/// <para>
+/// The resolver reads through <c>IOptionsMonitor&lt;AppConfig&gt;.CurrentValue</c>
+/// on every call so hot-reloaded config takes effect on the next lookup.
+/// </para>
+/// </remarks>
+public interface IIncidentResponsePlanResolver
+{
+    /// <summary>
+    /// Resolve the plan for an incident type token.
+    /// </summary>
+    /// <param name="incidentType">
+    /// The active incident type. May be null or whitespace — in that case the
+    /// resolver returns the default plan if one is configured, otherwise
+    /// <c>null</c>.
+    /// </param>
+    /// <returns>
+    /// The matching plan, the configured default plan, or <c>null</c> when
+    /// neither exists.
+    /// </returns>
+    IncidentResponsePlan? ResolveFor(string? incidentType);
+}

--- a/src/Content/Domain/Domain.Common/Config/AI/AIConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/AIConfig.cs
@@ -4,6 +4,7 @@ using Domain.Common.Config.AI.ContextManagement;
 using Domain.Common.Config.AI.DriftDetection;
 using Domain.Common.Config.AI.Hooks;
 using Domain.Common.Config.AI.Identity;
+using Domain.Common.Config.AI.IncidentResponse;
 using Domain.Common.Config.AI.Learnings;
 using Domain.Common.Config.AI.MCP;
 using Domain.Common.Config.AI.Orchestration;
@@ -46,7 +47,8 @@ namespace Domain.Common.Config.AI;
 /// ├── Sandbox           — Sandbox execution: resource limits, isolation, containers
 /// ├── ToolOutputCompression — Tool output compression: thresholds, LLM fallback, strategies
 /// ├── Plugins              — Local plugin declarations for external skill/MCP discovery
-/// └── Egress               — Per-skill outbound egress allowlist + SSRF defense
+/// ├── Egress               — Per-skill outbound egress allowlist + SSRF defense
+/// └── IncidentResponse     — Named incident-response plans (skill sets, autonomy overrides, gate overlays)
 /// </code>
 /// </para>
 /// </remarks>
@@ -214,4 +216,11 @@ public class AIConfig
     /// alongside the per-skill hostname allowlist.
     /// </summary>
     public EgressConfig Egress { get; set; } = new();
+
+    /// <summary>
+    /// Incident-response plan registry (PR-5). Empty by default — the resolver
+    /// returns <c>null</c> for every incident type so the orchestrator
+    /// behaves identically to a host with no incident concept at all.
+    /// </summary>
+    public IncidentResponsePlanConfig IncidentResponse { get; set; } = new();
 }

--- a/src/Content/Domain/Domain.Common/Config/AI/IncidentResponse/IncidentResponsePlan.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/IncidentResponse/IncidentResponsePlan.cs
@@ -1,0 +1,79 @@
+namespace Domain.Common.Config.AI.IncidentResponse;
+
+/// <summary>
+/// A named bundle of incident-response policy. When the host reports an active
+/// incident whose <see cref="IncidentType"/> matches this plan, the harness:
+/// <list type="number">
+///   <item><description>Activates the declared <see cref="SkillSet"/> on the agent.</description></item>
+///   <item><description>Forces the agent's autonomy tier to <see cref="AutonomyTierOverride"/> for the duration of the incident (when non-null).</description></item>
+///   <item><description>Overlays <see cref="AdditionalRequiredGates"/> on any <c>ChangeProposal</c> submitted while the incident is active — without mutating the proposal's stored <c>RequiredGates</c>.</description></item>
+/// </list>
+/// </summary>
+/// <remarks>
+/// <para>
+/// The plan is pure configuration data — no behavior lives on it. Resolution is
+/// performed by <c>IIncidentResponsePlanResolver</c>; gate overlay is performed
+/// by the <c>ChangeProposalOrchestrator</c> at evaluation time so the audit
+/// trail captures both the original proposal shape and the incident-driven
+/// additions.
+/// </para>
+/// <para>
+/// <see cref="AutonomyTierOverride"/> uses the string name of the
+/// <c>Domain.AI.Governance.AutonomyLevel</c> enum (<c>Restricted</c>,
+/// <c>Supervised</c>, <c>Autonomous</c>). Storing the override as a string
+/// keeps Domain.Common free of a reference to Domain.AI; the validator parses
+/// and rejects unknown values at boot so consumers cannot silently typo a tier.
+/// </para>
+/// </remarks>
+public sealed record IncidentResponsePlan
+{
+    /// <summary>
+    /// Human-readable identifier for the plan. Must be unique across all plans
+    /// in <c>IncidentResponsePlanConfig.Plans</c>. Surfaces in audit lines as
+    /// the reason for any incident-driven gate overlay so reviewers see which
+    /// plan added the extra gates.
+    /// </summary>
+    public required string Name { get; init; }
+
+    /// <summary>
+    /// The incident type token this plan answers to. Matched
+    /// case-insensitively against <c>IIncidentContext.CurrentIncidentType</c>.
+    /// Empty / null means "this plan is the default" — see
+    /// <c>IncidentResponsePlanConfig.DefaultPlanName</c> for fallback semantics.
+    /// </summary>
+    public required string IncidentType { get; init; }
+
+    /// <summary>
+    /// Ordered list of skill ids to activate on the agent while the incident is
+    /// active. Empty list means no skill activation; the agent runs with its
+    /// existing skill set. The harness's skill-activation pipeline consumes
+    /// this surface — the plan itself enforces no ordering or prerequisite
+    /// invariants.
+    /// </summary>
+    public IReadOnlyList<string> SkillSet { get; init; } = [];
+
+    /// <summary>
+    /// Optional autonomy-tier override applied for the duration of the
+    /// incident. Must match an <c>AutonomyLevel</c> enum name
+    /// (<c>Restricted</c>, <c>Supervised</c>, <c>Autonomous</c>) when non-null.
+    /// Null means "do not override the agent's normal tier".
+    /// </summary>
+    /// <remarks>
+    /// Typical pattern: a tenant running an Autonomous agent under
+    /// <c>DataExfiltrationSuspected</c> forces the override to
+    /// <c>Restricted</c> so every action requires approval until the incident
+    /// clears. The validator rejects unknown values at boot.
+    /// </remarks>
+    public string? AutonomyTierOverride { get; init; }
+
+    /// <summary>
+    /// Additional required-gate keys overlaid on any <c>ChangeProposal</c>
+    /// submitted while this plan is active. The orchestrator overlays at
+    /// evaluation time only — the proposal's stored
+    /// <c>RequiredGates</c> is never mutated. Duplicates of gates already in
+    /// the proposal's required list are silently de-duplicated; ordering puts
+    /// existing required gates first, then incident-added gates in declared
+    /// order.
+    /// </summary>
+    public IReadOnlyList<string> AdditionalRequiredGates { get; init; } = [];
+}

--- a/src/Content/Domain/Domain.Common/Config/AI/IncidentResponse/IncidentResponsePlanConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/IncidentResponse/IncidentResponsePlanConfig.cs
@@ -1,0 +1,47 @@
+namespace Domain.Common.Config.AI.IncidentResponse;
+
+/// <summary>
+/// Root binding for incident-response policy. Sits under
+/// <c>AppConfig:AI:IncidentResponse</c>. Empty by default — the resolver
+/// returns <c>null</c> for every incident type so the host has zero behavioural
+/// change until a consumer declares plans.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Hot reload is supported: <c>IIncidentResponsePlanResolver</c> reads through
+/// <c>IOptionsMonitor&lt;AppConfig&gt;.CurrentValue</c> on every resolve, so
+/// config edits at runtime take effect on the next lookup without restarting
+/// the host.
+/// </para>
+/// </remarks>
+public sealed class IncidentResponsePlanConfig
+{
+    /// <summary>
+    /// Declared incident-response plans. Looked up by
+    /// <c>IncidentResponsePlan.IncidentType</c> (case-insensitive).
+    /// </summary>
+    /// <remarks>
+    /// The startup validator refuses to boot if two plans share the same
+    /// <c>Name</c> — duplicate names make the audit trail ambiguous about
+    /// which plan was actually applied. Two plans sharing the same
+    /// <c>IncidentType</c> are also rejected; the resolver picks the first
+    /// match deterministically but the duplicate is almost certainly a config
+    /// mistake.
+    /// </remarks>
+    public List<IncidentResponsePlan> Plans { get; set; } = [];
+
+    /// <summary>
+    /// Optional plan name used as fallback when the active incident type does
+    /// not match any declared plan. Null means "no fallback" — the resolver
+    /// returns <c>null</c> for unmatched incident types so the orchestrator
+    /// behaves as if no incident were active.
+    /// </summary>
+    /// <remarks>
+    /// Typical pattern: a consumer with a permissive "everything else" plan
+    /// (e.g. <c>StandardOps</c>) sets this to that plan's name so any
+    /// unrecognised incident still routes through the baseline gates. The
+    /// validator rejects a non-null value that does not match any declared
+    /// plan's <c>Name</c>.
+    /// </remarks>
+    public string? DefaultPlanName { get; set; }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Changes/ChangeProposalOrchestrator.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Changes/ChangeProposalOrchestrator.cs
@@ -1,7 +1,9 @@
 using System.Diagnostics;
 using Application.AI.Common.Interfaces.Changes;
+using Application.AI.Common.Interfaces.IncidentResponse;
 using Domain.AI.Changes;
 using Domain.Common.Config;
+using Domain.Common.Config.AI.IncidentResponse;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -36,15 +38,38 @@ public sealed class ChangeProposalOrchestrator : IChangeProposalOrchestrator
     private readonly TimeProvider _time;
     private readonly IOptionsMonitor<AppConfig> _config;
     private readonly ILogger<ChangeProposalOrchestrator> _logger;
+    private readonly IIncidentContext? _incidentContext;
+    private readonly IIncidentResponsePlanResolver? _incidentResolver;
 
     /// <summary>Initializes a new <see cref="ChangeProposalOrchestrator"/>.</summary>
+    /// <param name="store">Proposal persistence.</param>
+    /// <param name="audit">Append-only audit sink for gate decisions.</param>
+    /// <param name="services">Service provider used to resolve gates by key.</param>
+    /// <param name="time">Time provider for audit timestamps.</param>
+    /// <param name="config">Application configuration (defer budget, etc.).</param>
+    /// <param name="logger">Diagnostic logger.</param>
+    /// <param name="incidentContext">
+    /// Optional (PR-5) — when supplied alongside <paramref name="incidentResolver"/>,
+    /// the orchestrator overlays any active incident plan's
+    /// <see cref="IncidentResponsePlan.AdditionalRequiredGates"/> on every
+    /// proposal it processes. Null in tests that exercise the orchestrator in
+    /// isolation; non-null when registered through DI.
+    /// </param>
+    /// <param name="incidentResolver">
+    /// Optional (PR-5) — resolves the incident type carried by
+    /// <paramref name="incidentContext"/> to the active plan. Null in tests
+    /// that exercise the orchestrator in isolation; non-null when registered
+    /// through DI.
+    /// </param>
     public ChangeProposalOrchestrator(
         IChangeProposalStore store,
         IChangeAuditWriter audit,
         IServiceProvider services,
         TimeProvider time,
         IOptionsMonitor<AppConfig> config,
-        ILogger<ChangeProposalOrchestrator> logger)
+        ILogger<ChangeProposalOrchestrator> logger,
+        IIncidentContext? incidentContext = null,
+        IIncidentResponsePlanResolver? incidentResolver = null)
     {
         ArgumentNullException.ThrowIfNull(store);
         ArgumentNullException.ThrowIfNull(audit);
@@ -59,6 +84,8 @@ public sealed class ChangeProposalOrchestrator : IChangeProposalOrchestrator
         _time = time;
         _config = config;
         _logger = logger;
+        _incidentContext = incidentContext;
+        _incidentResolver = incidentResolver;
     }
 
     /// <inheritdoc />
@@ -84,13 +111,84 @@ public sealed class ChangeProposalOrchestrator : IChangeProposalOrchestrator
         var correlationId = Guid.NewGuid().ToString("N");
         var maxDefers = Math.Max(1, _config.CurrentValue.AI.Changes.MaxConsecutiveDefers);
 
-        proposal = await AdvanceFromCurrentStatusAsync(proposal, mode, correlationId, maxDefers, cancellationToken)
+        // PR-5: compute the effective required gates *once* per ProcessAsync
+        // invocation. The proposal's stored RequiredGates is never mutated;
+        // the orchestrator evaluates against the overlay at runtime so the
+        // audit trail records both the original shape and the incident-driven
+        // additions. The overlay marker is emitted before the first phase
+        // transition so reviewers see the augment alongside the orchestrator's
+        // "picked up Draft" line.
+        var (effectiveGates, activePlan) = ResolveEffectiveGates(proposal);
+        if (activePlan is not null && effectiveGates.Count != proposal.RequiredGates.Count)
+        {
+            proposal = await AppendHistoryAndSaveAsync(
+                proposal,
+                new GateDecision
+                {
+                    Timestamp = _time.GetUtcNow(),
+                    GateKey = "incident_overlay",
+                    Action = GateAction.Pass,
+                    Reason = $"incident plan '{activePlan.Name}' overlaid gates: " +
+                             string.Join(",", activePlan.AdditionalRequiredGates),
+                    DurationMs = 0
+                },
+                mode,
+                correlationId,
+                cancellationToken).ConfigureAwait(false);
+        }
+
+        proposal = await AdvanceFromCurrentStatusAsync(proposal, effectiveGates, mode, correlationId, maxDefers, cancellationToken)
             .ConfigureAwait(false);
         return proposal;
     }
 
+    /// <summary>
+    /// Compute the effective required-gate list for this orchestrator run by
+    /// overlaying any active incident plan's
+    /// <see cref="IncidentResponsePlan.AdditionalRequiredGates"/> on the
+    /// proposal's stored <c>RequiredGates</c>. Returns the proposal's original
+    /// list (and a null plan) when no incident is active, the resolver is not
+    /// registered, or the matching plan has no additional gates.
+    /// </summary>
+    /// <remarks>
+    /// Order preservation: the proposal's original gates come first in their
+    /// declared order; incident-added gates that are NOT already present in
+    /// the proposal's list are appended in the plan's declared order. Gates
+    /// already in the proposal are silently de-duplicated — the orchestrator
+    /// never runs the same gate twice in one phase.
+    /// </remarks>
+    private (IReadOnlyList<string> EffectiveGates, IncidentResponsePlan? Plan) ResolveEffectiveGates(
+        ChangeProposal proposal)
+    {
+        if (_incidentContext is null || _incidentResolver is null)
+        {
+            return (proposal.RequiredGates, null);
+        }
+
+        var incidentType = _incidentContext.CurrentIncidentType;
+        var plan = _incidentResolver.ResolveFor(incidentType);
+        if (plan is null || plan.AdditionalRequiredGates.Count == 0)
+        {
+            return (proposal.RequiredGates, plan);
+        }
+
+        var existing = new HashSet<string>(proposal.RequiredGates, StringComparer.Ordinal);
+        var effective = new List<string>(proposal.RequiredGates.Count + plan.AdditionalRequiredGates.Count);
+        effective.AddRange(proposal.RequiredGates);
+        for (var i = 0; i < plan.AdditionalRequiredGates.Count; i++)
+        {
+            var extra = plan.AdditionalRequiredGates[i];
+            if (existing.Add(extra))
+            {
+                effective.Add(extra);
+            }
+        }
+        return (effective, plan);
+    }
+
     private async Task<ChangeProposal> AdvanceFromCurrentStatusAsync(
         ChangeProposal proposal,
+        IReadOnlyList<string> effectiveGates,
         OrchestratorMode mode,
         string correlationId,
         int maxDefers,
@@ -118,7 +216,7 @@ public sealed class ChangeProposalOrchestrator : IChangeProposalOrchestrator
 
         if (proposal.Status == ChangeProposalStatus.Validating)
         {
-            proposal = await RunValidationPhaseAsync(proposal, mode, correlationId, maxDefers, cancellationToken)
+            proposal = await RunValidationPhaseAsync(proposal, effectiveGates, mode, correlationId, maxDefers, cancellationToken)
                 .ConfigureAwait(false);
         }
 
@@ -143,7 +241,7 @@ public sealed class ChangeProposalOrchestrator : IChangeProposalOrchestrator
 
         if (proposal.Status == ChangeProposalStatus.Merging)
         {
-            proposal = await RunMergePhaseAsync(proposal, mode, correlationId, maxDefers, cancellationToken)
+            proposal = await RunMergePhaseAsync(proposal, effectiveGates, mode, correlationId, maxDefers, cancellationToken)
                 .ConfigureAwait(false);
         }
 
@@ -152,13 +250,14 @@ public sealed class ChangeProposalOrchestrator : IChangeProposalOrchestrator
 
     private async Task<ChangeProposal> RunValidationPhaseAsync(
         ChangeProposal proposal,
+        IReadOnlyList<string> effectiveGates,
         OrchestratorMode mode,
         string correlationId,
         int maxDefers,
         CancellationToken cancellationToken)
     {
-        var validationGates = GatesForPhase(proposal.RequiredGates, GatePhase.Validation);
-        var approvalGateKey = FindApprovalGateKey(proposal.RequiredGates);
+        var validationGates = GatesForPhase(effectiveGates, GatePhase.Validation);
+        var approvalGateKey = FindApprovalGateKey(effectiveGates);
 
         var outcome = await RunGatesAsync(
             proposal,
@@ -289,12 +388,13 @@ public sealed class ChangeProposalOrchestrator : IChangeProposalOrchestrator
 
     private async Task<ChangeProposal> RunMergePhaseAsync(
         ChangeProposal proposal,
+        IReadOnlyList<string> effectiveGates,
         OrchestratorMode mode,
         string correlationId,
         int maxDefers,
         CancellationToken cancellationToken)
     {
-        var mergeGates = GatesForPhase(proposal.RequiredGates, GatePhase.Merge);
+        var mergeGates = GatesForPhase(effectiveGates, GatePhase.Merge);
 
         // Merging does not legally self-loop in the state machine, so a Defer
         // records history without a status transition (selfLoopOnDefer: null).

--- a/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.IncidentResponse.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.IncidentResponse.cs
@@ -1,0 +1,37 @@
+using Application.AI.Common.Interfaces.IncidentResponse;
+using Infrastructure.AI.IncidentResponse;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Infrastructure.AI;
+
+public static partial class DependencyInjection
+{
+    /// <summary>
+    /// Registers the incident-response plan subsystem (PR-5): the
+    /// <see cref="IIncidentContext"/> ambient holder, the
+    /// <see cref="IIncidentResponsePlanResolver"/> default implementation, and
+    /// the boot-time validator that refuses to start the host with internally
+    /// inconsistent plan config.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// All registrations are unconditional — the resolver returns <c>null</c>
+    /// and the orchestrator overlay does nothing when no plans are configured,
+    /// so the subsystem is inert until a consumer declares plans under
+    /// <c>AppConfig.AI.IncidentResponse</c>.
+    /// </para>
+    /// <para>
+    /// The ambient context is registered as a Singleton — its storage slot is
+    /// per <see cref="System.Threading.AsyncLocal{T}"/> context, so a shared
+    /// holder is correct and required (a Scoped holder would lose the value
+    /// when the orchestrator's background dispatch ran after the originating
+    /// request scope was disposed).
+    /// </para>
+    /// </remarks>
+    private static void RegisterIncidentResponseServices(IServiceCollection services)
+    {
+        services.AddSingleton<IIncidentContext, AsyncLocalIncidentContext>();
+        services.AddSingleton<IIncidentResponsePlanResolver, IncidentResponsePlanResolver>();
+        services.AddHostedService<IncidentResponsePlanValidator>();
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.cs
@@ -56,6 +56,7 @@ namespace Infrastructure.AI;
 ///   <item><description><c>DependencyInjection.Planner.cs</c> — planner DB, step executors, sandbox</description></item>
 ///   <item><description><c>DependencyInjection.Quality.cs</c> — drift detection and learnings</description></item>
 ///   <item><description><c>DependencyInjection.Egress.cs</c> — per-skill egress policy + AntiSSRF</description></item>
+///   <item><description><c>DependencyInjection.IncidentResponse.cs</c> — incident-response plan registry + ambient context</description></item>
 /// </list>
 /// </para>
 /// Called from the Presentation composition root after Application dependencies:
@@ -209,6 +210,11 @@ public static partial class DependencyInjection
         //     AppConfig.AI.Egress.Enabled. ---
 
         RegisterEgressServices(services);
+
+        // --- Incident-response plan registry (PR-5). Inert until a consumer
+        //     declares plans under AppConfig.AI.IncidentResponse. ---
+
+        RegisterIncidentResponseServices(services);
 
         // --- Governance (permissions, escalation, resilience) ---
 

--- a/src/Content/Infrastructure/Infrastructure.AI/IncidentResponse/AsyncLocalIncidentContext.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/IncidentResponse/AsyncLocalIncidentContext.cs
@@ -1,0 +1,37 @@
+using Application.AI.Common.Interfaces.IncidentResponse;
+
+namespace Infrastructure.AI.IncidentResponse;
+
+/// <summary>
+/// Default <see cref="IIncidentContext"/>: stores the active incident type in
+/// an <see cref="AsyncLocal{T}"/> so it flows into child scopes and background
+/// continuations without explicit plumbing.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Registered as a Singleton in DI even though the value it returns is per
+/// async context. This is the standard <see cref="AsyncLocal{T}"/> pattern —
+/// the holder is shared, the slot is per-context. Mirrors
+/// <c>KnowledgeScopeAccessor</c> for the same reason: the orchestrator's
+/// background dispatch runs after the originating request scope is gone, so a
+/// per-scope holder would lose the incident value.
+/// </para>
+/// <para>
+/// Whitespace-only inputs to <see cref="Set"/> are normalised to <c>null</c>
+/// so a caller that defensively passes <c>incidentType ?? string.Empty</c>
+/// can't accidentally activate a "default-by-empty" plan.
+/// </para>
+/// </remarks>
+public sealed class AsyncLocalIncidentContext : IIncidentContext
+{
+    private static readonly AsyncLocal<string?> s_incidentType = new();
+
+    /// <inheritdoc />
+    public string? CurrentIncidentType => s_incidentType.Value;
+
+    /// <inheritdoc />
+    public void Set(string? incidentType)
+    {
+        s_incidentType.Value = string.IsNullOrWhiteSpace(incidentType) ? null : incidentType;
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/IncidentResponse/IncidentResponsePlanResolver.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/IncidentResponse/IncidentResponsePlanResolver.cs
@@ -1,0 +1,69 @@
+using Application.AI.Common.Interfaces.IncidentResponse;
+using Domain.Common.Config;
+using Domain.Common.Config.AI.IncidentResponse;
+using Microsoft.Extensions.Options;
+
+namespace Infrastructure.AI.IncidentResponse;
+
+/// <summary>
+/// Default <see cref="IIncidentResponsePlanResolver"/> backed by
+/// <see cref="IOptionsMonitor{TOptions}"/> so hot-reloaded config takes effect
+/// on the next resolve.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Lookup walks
+/// <see cref="IncidentResponsePlanConfig.Plans"/> case-insensitively. If no
+/// plan matches and <see cref="IncidentResponsePlanConfig.DefaultPlanName"/>
+/// is set, the resolver returns the plan whose
+/// <see cref="IncidentResponsePlan.Name"/> matches the default; if the
+/// default name does not match any plan, the resolver returns <c>null</c> and
+/// the misconfigured-default case is surfaced by the boot validator instead.
+/// </para>
+/// </remarks>
+public sealed class IncidentResponsePlanResolver : IIncidentResponsePlanResolver
+{
+    private readonly IOptionsMonitor<AppConfig> _config;
+
+    /// <summary>
+    /// Initializes a new <see cref="IncidentResponsePlanResolver"/>.
+    /// </summary>
+    /// <param name="config">The application configuration monitor.</param>
+    public IncidentResponsePlanResolver(IOptionsMonitor<AppConfig> config)
+    {
+        ArgumentNullException.ThrowIfNull(config);
+        _config = config;
+    }
+
+    /// <inheritdoc />
+    public IncidentResponsePlan? ResolveFor(string? incidentType)
+    {
+        var cfg = _config.CurrentValue.AI.IncidentResponse;
+
+        if (!string.IsNullOrWhiteSpace(incidentType))
+        {
+            for (var i = 0; i < cfg.Plans.Count; i++)
+            {
+                var plan = cfg.Plans[i];
+                if (string.Equals(plan.IncidentType, incidentType, StringComparison.OrdinalIgnoreCase))
+                {
+                    return plan;
+                }
+            }
+        }
+
+        if (!string.IsNullOrWhiteSpace(cfg.DefaultPlanName))
+        {
+            for (var i = 0; i < cfg.Plans.Count; i++)
+            {
+                var plan = cfg.Plans[i];
+                if (string.Equals(plan.Name, cfg.DefaultPlanName, StringComparison.OrdinalIgnoreCase))
+                {
+                    return plan;
+                }
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/IncidentResponse/IncidentResponsePlanValidator.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/IncidentResponse/IncidentResponsePlanValidator.cs
@@ -1,0 +1,196 @@
+using Domain.AI.Governance;
+using Domain.Common.Config;
+using Domain.Common.Config.AI.IncidentResponse;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Infrastructure.AI.IncidentResponse;
+
+/// <summary>
+/// One-shot startup validator for the incident-response plan registry. Runs
+/// once via <see cref="IHostedService.StartAsync"/> and refuses to boot the
+/// host when the configured plans are internally inconsistent.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Validation rules (only when at least one plan is configured):
+/// </para>
+/// <list type="number">
+///   <item><description>
+///     <b>Required fields</b> — every plan must declare a non-empty
+///     <see cref="IncidentResponsePlan.Name"/> and
+///     <see cref="IncidentResponsePlan.IncidentType"/>. An unnamed plan can't
+///     be referenced from <see cref="IncidentResponsePlanConfig.DefaultPlanName"/>
+///     and can't appear in audit lines coherently.
+///   </description></item>
+///   <item><description>
+///     <b>Unique names</b> — two plans sharing the same
+///     <see cref="IncidentResponsePlan.Name"/> make audit lines ambiguous about
+///     which plan was applied.
+///   </description></item>
+///   <item><description>
+///     <b>Unique incident types</b> — two plans sharing the same
+///     <see cref="IncidentResponsePlan.IncidentType"/> mean only the first
+///     would ever fire; the second is dead config and almost certainly a
+///     mistake.
+///   </description></item>
+///   <item><description>
+///     <b>Known autonomy tier override</b> —
+///     <see cref="IncidentResponsePlan.AutonomyTierOverride"/>, when non-null,
+///     must parse to an <see cref="AutonomyLevel"/> enum value. A typo would
+///     otherwise silently fall back to "no override" at the consumption site.
+///   </description></item>
+///   <item><description>
+///     <b>Default plan exists</b> —
+///     <see cref="IncidentResponsePlanConfig.DefaultPlanName"/>, when non-null,
+///     must name an actually-declared plan. Otherwise the fallback path is
+///     dead.
+///   </description></item>
+/// </list>
+/// <para>
+/// When no plans are configured the validator no-ops — an empty registry is a
+/// legitimate "incident response not in use" deployment.
+/// </para>
+/// </remarks>
+public sealed class IncidentResponsePlanValidator : IHostedService
+{
+    private readonly IServiceProvider _services;
+    private readonly IOptionsMonitor<AppConfig> _config;
+    private readonly ILogger<IncidentResponsePlanValidator> _logger;
+
+    /// <summary>Initializes a new <see cref="IncidentResponsePlanValidator"/>.</summary>
+    /// <remarks>
+    /// <see cref="IHostEnvironment"/> is resolved lazily from
+    /// <see cref="IServiceProvider"/> inside <see cref="StartAsync"/> to match
+    /// the <c>ChangeProposalStartupValidator</c> pattern — DI tests that
+    /// enumerate hosted services without registering a host environment don't
+    /// fail at materialization. The incident-response validator does not vary
+    /// behaviour by environment today; the parameter is reserved for future
+    /// rules (e.g. "warn rather than throw under Development").
+    /// </remarks>
+    public IncidentResponsePlanValidator(
+        IServiceProvider services,
+        IOptionsMonitor<AppConfig> config,
+        ILogger<IncidentResponsePlanValidator> logger)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(config);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _services = services;
+        _config = config;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        var cfg = _config.CurrentValue.AI.IncidentResponse;
+        if (cfg.Plans.Count == 0)
+        {
+            // No plans configured — nothing to validate. A null DefaultPlanName
+            // is also a no-op; a non-null DefaultPlanName with zero plans is
+            // an error the consumer should see.
+            if (!string.IsNullOrWhiteSpace(cfg.DefaultPlanName))
+            {
+                throw new InvalidOperationException(
+                    "AppConfig.AI.IncidentResponse.DefaultPlanName is set to " +
+                    $"'{cfg.DefaultPlanName}' but no plans are configured. " +
+                    "Either remove the default name or declare at least one plan.");
+            }
+            return Task.CompletedTask;
+        }
+
+        // Probe IHostEnvironment so the lazy resolution exercises uniformly with
+        // the ChangeProposal validator; not currently used by any rule.
+        _ = _services.GetService<IHostEnvironment>();
+
+        ValidatePlans(cfg);
+        ValidateDefaultPlanName(cfg);
+
+        _logger.LogInformation(
+            "IncidentResponse plan registry validated: {PlanCount} plan(s); default='{DefaultPlanName}'.",
+            cfg.Plans.Count,
+            cfg.DefaultPlanName ?? "(none)");
+
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    private static void ValidatePlans(IncidentResponsePlanConfig cfg)
+    {
+        var seenNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var seenTypes = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        for (var i = 0; i < cfg.Plans.Count; i++)
+        {
+            var plan = cfg.Plans[i];
+
+            if (string.IsNullOrWhiteSpace(plan.Name))
+            {
+                throw new InvalidOperationException(
+                    $"AppConfig.AI.IncidentResponse.Plans[{i}].Name is required.");
+            }
+
+            if (string.IsNullOrWhiteSpace(plan.IncidentType))
+            {
+                throw new InvalidOperationException(
+                    $"AppConfig.AI.IncidentResponse.Plans[{i}].IncidentType is required " +
+                    $"(plan '{plan.Name}').");
+            }
+
+            if (!seenNames.Add(plan.Name))
+            {
+                throw new InvalidOperationException(
+                    "AppConfig.AI.IncidentResponse.Plans contains duplicate Name " +
+                    $"'{plan.Name}'. Plan names must be unique; the audit trail " +
+                    "records the name of the plan that drove a gate overlay, and " +
+                    "duplicates make the audit ambiguous.");
+            }
+
+            if (!seenTypes.Add(plan.IncidentType))
+            {
+                throw new InvalidOperationException(
+                    "AppConfig.AI.IncidentResponse.Plans contains duplicate IncidentType " +
+                    $"'{plan.IncidentType}' (plan '{plan.Name}'). The resolver picks the " +
+                    "first match deterministically, so the second plan would be dead " +
+                    "config; flagging at boot.");
+            }
+
+            if (plan.AutonomyTierOverride is not null
+                && !Enum.TryParse<AutonomyLevel>(plan.AutonomyTierOverride, ignoreCase: false, out _))
+            {
+                var known = string.Join(", ", Enum.GetNames<AutonomyLevel>());
+                throw new InvalidOperationException(
+                    $"AppConfig.AI.IncidentResponse.Plans[{i}].AutonomyTierOverride " +
+                    $"'{plan.AutonomyTierOverride}' (plan '{plan.Name}') does not match " +
+                    $"any known AutonomyLevel value. Allowed values: {known}.");
+            }
+        }
+    }
+
+    private static void ValidateDefaultPlanName(IncidentResponsePlanConfig cfg)
+    {
+        if (string.IsNullOrWhiteSpace(cfg.DefaultPlanName))
+        {
+            return;
+        }
+
+        for (var i = 0; i < cfg.Plans.Count; i++)
+        {
+            if (string.Equals(cfg.Plans[i].Name, cfg.DefaultPlanName, StringComparison.OrdinalIgnoreCase))
+            {
+                return;
+            }
+        }
+
+        throw new InvalidOperationException(
+            $"AppConfig.AI.IncidentResponse.DefaultPlanName '{cfg.DefaultPlanName}' " +
+            "does not match the Name of any declared plan. Either remove the default " +
+            "name or rename a plan to match it.");
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/IncidentResponse/AsyncLocalIncidentContextTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/IncidentResponse/AsyncLocalIncidentContextTests.cs
@@ -1,0 +1,109 @@
+using FluentAssertions;
+using Infrastructure.AI.IncidentResponse;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.IncidentResponse;
+
+/// <summary>
+/// Async-flow tests for <see cref="AsyncLocalIncidentContext"/>. Verifies the
+/// AsyncLocal slot flows through await boundaries and isolates between
+/// concurrent <c>Task.Run</c> branches.
+/// </summary>
+public sealed class AsyncLocalIncidentContextTests
+{
+    [Fact]
+    public void CurrentIncidentType_DefaultsToNull()
+    {
+        var sut = new AsyncLocalIncidentContext();
+
+        sut.CurrentIncidentType.Should().BeNull();
+    }
+
+    [Fact]
+    public void Set_NullOrWhitespace_NormalisesToNull()
+    {
+        var sut = new AsyncLocalIncidentContext();
+
+        sut.Set("DataExfiltrationSuspected");
+        sut.CurrentIncidentType.Should().Be("DataExfiltrationSuspected");
+
+        sut.Set("   ");
+        sut.CurrentIncidentType.Should().BeNull();
+
+        sut.Set("ProductionRollback");
+        sut.CurrentIncidentType.Should().Be("ProductionRollback");
+
+        sut.Set(null);
+        sut.CurrentIncidentType.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Set_FlowsThroughAsyncBoundary()
+    {
+        var sut = new AsyncLocalIncidentContext();
+        sut.Set("DataExfiltrationSuspected");
+
+        // Force an async boundary; AsyncLocal should carry the value.
+        await Task.Yield();
+
+        sut.CurrentIncidentType.Should().Be("DataExfiltrationSuspected");
+
+        await Task.Delay(1).ConfigureAwait(false);
+
+        sut.CurrentIncidentType.Should().Be("DataExfiltrationSuspected");
+    }
+
+    [Fact]
+    public async Task Set_ParallelTaskRunBranches_DoNotBleedIntoEachOther()
+    {
+        var sut = new AsyncLocalIncidentContext();
+        // The outer context starts clean; each Task.Run inherits a copy of the
+        // AsyncLocal slot at the moment of Task.Run, then mutates it locally.
+        // Outer must remain null and the two branches must each see only their
+        // own setting.
+
+        var leftReady = new TaskCompletionSource();
+        var rightReady = new TaskCompletionSource();
+        var release = new TaskCompletionSource();
+
+        var leftTask = Task.Run(async () =>
+        {
+            sut.Set("LeftIncident");
+            leftReady.SetResult();
+            await release.Task.ConfigureAwait(false);
+            return sut.CurrentIncidentType;
+        });
+
+        var rightTask = Task.Run(async () =>
+        {
+            sut.Set("RightIncident");
+            rightReady.SetResult();
+            await release.Task.ConfigureAwait(false);
+            return sut.CurrentIncidentType;
+        });
+
+        await leftReady.Task.ConfigureAwait(false);
+        await rightReady.Task.ConfigureAwait(false);
+        release.SetResult();
+
+        var leftValue = await leftTask.ConfigureAwait(false);
+        var rightValue = await rightTask.ConfigureAwait(false);
+
+        leftValue.Should().Be("LeftIncident");
+        rightValue.Should().Be("RightIncident");
+        sut.CurrentIncidentType.Should().BeNull(
+            because: "the outer async context was never written to; AsyncLocal copies down, not up");
+    }
+
+    [Fact]
+    public async Task Set_ChildAsyncScope_InheritsValueFromCaller()
+    {
+        var sut = new AsyncLocalIncidentContext();
+        sut.Set("OuterIncident");
+
+        var inner = await Task.Run(() => sut.CurrentIncidentType).ConfigureAwait(false);
+
+        inner.Should().Be("OuterIncident",
+            because: "Task.Run captures the AsyncLocal slot at the point of scheduling");
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/IncidentResponse/IncidentResponseOrchestratorOverlayTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/IncidentResponse/IncidentResponseOrchestratorOverlayTests.cs
@@ -1,0 +1,251 @@
+using Application.AI.Common.Interfaces.Changes;
+using Application.AI.Common.Interfaces.IncidentResponse;
+using Domain.AI.Changes;
+using Domain.Common.Config.AI.IncidentResponse;
+using FluentAssertions;
+using Infrastructure.AI.Changes;
+using Infrastructure.AI.IncidentResponse;
+using Infrastructure.AI.Tests.Changes.Support;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.IncidentResponse;
+
+/// <summary>
+/// Integration tests that wire <see cref="ChangeProposalOrchestrator"/> with
+/// the PR-5 incident overlay. Verifies that (a) when an incident is active
+/// with additional gates, the orchestrator runs those gates during the
+/// appropriate phase, (b) the proposal's stored <c>RequiredGates</c> is never
+/// mutated, and (c) the audit history records the overlay so a reviewer can
+/// see why extra gates ran.
+/// </summary>
+public sealed class IncidentResponseOrchestratorOverlayTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly InMemoryChangeProposalStore _store;
+    private readonly JsonlChangeAuditWriter _audit;
+    private readonly Microsoft.Extensions.Options.IOptionsMonitor<Domain.Common.Config.AppConfig> _monitor;
+
+    public IncidentResponseOrchestratorOverlayTests()
+    {
+        var (monitor, dir) = TestConfig.NewMonitor();
+        _tempDir = dir;
+        _store = new InMemoryChangeProposalStore();
+        _audit = new JsonlChangeAuditWriter(monitor, NullLogger<JsonlChangeAuditWriter>.Instance);
+        _monitor = monitor;
+    }
+
+    public void Dispose()
+    {
+        _audit.Dispose();
+        try { Directory.Delete(_tempDir, recursive: true); }
+        catch { /* best effort */ }
+    }
+
+    private sealed class StubIncidentContext : IIncidentContext
+    {
+        public StubIncidentContext(string? incidentType) { CurrentIncidentType = incidentType; }
+        public string? CurrentIncidentType { get; private set; }
+        public void Set(string? incidentType) { CurrentIncidentType = incidentType; }
+    }
+
+    private sealed class StubIncidentResolver : IIncidentResponsePlanResolver
+    {
+        private readonly IncidentResponsePlan? _plan;
+        public StubIncidentResolver(IncidentResponsePlan? plan) { _plan = plan; }
+        public IncidentResponsePlan? ResolveFor(string? incidentType) => _plan;
+    }
+
+    private ChangeProposalOrchestrator BuildSut(
+        IIncidentContext? incidentContext,
+        IIncidentResponsePlanResolver? incidentResolver,
+        params IChangeProposalGate[] gates)
+    {
+        var services = new ServiceCollection();
+        foreach (var gate in gates)
+        {
+            services.AddKeyedSingleton(gate.Key, gate);
+        }
+        return new ChangeProposalOrchestrator(
+            _store,
+            _audit,
+            services.BuildServiceProvider(),
+            TimeProvider.System,
+            _monitor,
+            NullLogger<ChangeProposalOrchestrator>.Instance,
+            incidentContext,
+            incidentResolver);
+    }
+
+    [Fact]
+    public async Task ProcessAsync_NoIncident_BehavesIdenticallyToPR2Path()
+    {
+        // No incident context wired — orchestrator runs only the proposal's stored gates.
+        var proposal = TestProposals.NewProposal(gates:
+        [
+            WellKnownGateKeys.SelfValidation,
+            WellKnownGateKeys.Approval,
+            WellKnownGateKeys.Merge
+        ]);
+        await _store.SaveAsync(proposal, CancellationToken.None);
+
+        var complianceGate = new TestProposals.StubGate("compliance", GateResult.Pass());
+
+        var sut = BuildSut(
+            incidentContext: null,
+            incidentResolver: null,
+            new TestProposals.StubGate(WellKnownGateKeys.SelfValidation, GateResult.Pass()),
+            new TestProposals.StubGate(WellKnownGateKeys.Approval, GateResult.Pass("auto")),
+            new TestProposals.StubGate(WellKnownGateKeys.Merge, GateResult.Pass()),
+            complianceGate);
+
+        var result = await sut.ProcessAsync(proposal.Id, OrchestratorMode.Live, CancellationToken.None);
+
+        result!.Status.Should().Be(ChangeProposalStatus.Merged);
+        complianceGate.InvocationCount.Should().Be(0,
+            because: "no incident is active so the incident-added compliance gate must not run");
+    }
+
+    [Fact]
+    public async Task ProcessAsync_IncidentActive_OverlaysAdditionalGatesAtRuntime()
+    {
+        var proposal = TestProposals.NewProposal(gates:
+        [
+            WellKnownGateKeys.SelfValidation,
+            WellKnownGateKeys.Approval,
+            WellKnownGateKeys.Merge
+        ]);
+        await _store.SaveAsync(proposal, CancellationToken.None);
+
+        var plan = new IncidentResponsePlan
+        {
+            Name = "DataExfil",
+            IncidentType = "DataExfiltrationSuspected",
+            AdditionalRequiredGates = ["compliance"]
+        };
+
+        var complianceGate = new TestProposals.StubGate("compliance", GateResult.Pass("policy ok"));
+
+        var sut = BuildSut(
+            incidentContext: new StubIncidentContext("DataExfiltrationSuspected"),
+            incidentResolver: new StubIncidentResolver(plan),
+            new TestProposals.StubGate(WellKnownGateKeys.SelfValidation, GateResult.Pass()),
+            new TestProposals.StubGate(WellKnownGateKeys.Approval, GateResult.Pass("auto")),
+            new TestProposals.StubGate(WellKnownGateKeys.Merge, GateResult.Pass()),
+            complianceGate);
+
+        var result = await sut.ProcessAsync(proposal.Id, OrchestratorMode.Live, CancellationToken.None);
+
+        result!.Status.Should().Be(ChangeProposalStatus.Merged);
+        complianceGate.InvocationCount.Should().Be(1,
+            because: "the active incident plan added the compliance gate to the validation phase");
+
+        // Stored RequiredGates MUST be untouched — the orchestrator overlays at
+        // evaluation time only. The audit trail records the overlay separately.
+        result.RequiredGates.Should().Equal(
+            WellKnownGateKeys.SelfValidation,
+            WellKnownGateKeys.Approval,
+            WellKnownGateKeys.Merge);
+    }
+
+    [Fact]
+    public async Task ProcessAsync_IncidentActive_AuditTrailRecordsOverlay()
+    {
+        var proposal = TestProposals.NewProposal(gates:
+        [
+            WellKnownGateKeys.SelfValidation,
+            WellKnownGateKeys.Approval,
+            WellKnownGateKeys.Merge
+        ]);
+        await _store.SaveAsync(proposal, CancellationToken.None);
+
+        var plan = new IncidentResponsePlan
+        {
+            Name = "DataExfil",
+            IncidentType = "DataExfiltrationSuspected",
+            AdditionalRequiredGates = ["compliance"]
+        };
+
+        var sut = BuildSut(
+            incidentContext: new StubIncidentContext("DataExfiltrationSuspected"),
+            incidentResolver: new StubIncidentResolver(plan),
+            new TestProposals.StubGate(WellKnownGateKeys.SelfValidation, GateResult.Pass()),
+            new TestProposals.StubGate(WellKnownGateKeys.Approval, GateResult.Pass("auto")),
+            new TestProposals.StubGate(WellKnownGateKeys.Merge, GateResult.Pass()),
+            new TestProposals.StubGate("compliance", GateResult.Pass()));
+
+        var result = await sut.ProcessAsync(proposal.Id, OrchestratorMode.Live, CancellationToken.None);
+
+        result!.History.Should().Contain(d =>
+            d.GateKey == "incident_overlay"
+            && d.Action == GateAction.Pass
+            && d.Reason.Contains("DataExfil", StringComparison.Ordinal)
+            && d.Reason.Contains("compliance", StringComparison.Ordinal),
+            because: "reviewers must be able to see which plan augmented the gate set and which gates it added");
+    }
+
+    [Fact]
+    public async Task ProcessAsync_IncidentGateAlreadyInProposal_DeduplicatesAndDoesNotDoubleRun()
+    {
+        // Proposal already lists "compliance" — the plan's same key must not
+        // run the gate twice or shift its position.
+        var proposal = TestProposals.NewProposal(gates:
+        [
+            WellKnownGateKeys.SelfValidation,
+            "compliance",
+            WellKnownGateKeys.Approval,
+            WellKnownGateKeys.Merge
+        ]);
+        await _store.SaveAsync(proposal, CancellationToken.None);
+
+        var plan = new IncidentResponsePlan
+        {
+            Name = "Dup",
+            IncidentType = "AnyIncident",
+            AdditionalRequiredGates = ["compliance"]
+        };
+
+        var complianceGate = new TestProposals.StubGate("compliance", GateResult.Pass());
+
+        var sut = BuildSut(
+            incidentContext: new StubIncidentContext("AnyIncident"),
+            incidentResolver: new StubIncidentResolver(plan),
+            new TestProposals.StubGate(WellKnownGateKeys.SelfValidation, GateResult.Pass()),
+            new TestProposals.StubGate(WellKnownGateKeys.Approval, GateResult.Pass("auto")),
+            new TestProposals.StubGate(WellKnownGateKeys.Merge, GateResult.Pass()),
+            complianceGate);
+
+        var result = await sut.ProcessAsync(proposal.Id, OrchestratorMode.Live, CancellationToken.None);
+
+        result!.Status.Should().Be(ChangeProposalStatus.Merged);
+        complianceGate.InvocationCount.Should().Be(1,
+            because: "the orchestrator de-duplicates incident-added gates already present in the proposal");
+    }
+
+    [Fact]
+    public async Task ProcessAsync_PlanWithNoAdditionalGates_SkipsOverlayMarker()
+    {
+        var proposal = TestProposals.NewProposal();
+        await _store.SaveAsync(proposal, CancellationToken.None);
+
+        var plan = new IncidentResponsePlan
+        {
+            Name = "NoExtraGates",
+            IncidentType = "AnyIncident"
+            // AdditionalRequiredGates default = []
+        };
+
+        var sut = BuildSut(
+            incidentContext: new StubIncidentContext("AnyIncident"),
+            incidentResolver: new StubIncidentResolver(plan),
+            new TestProposals.StubGate(WellKnownGateKeys.SelfValidation, GateResult.Pass()),
+            new TestProposals.StubGate(WellKnownGateKeys.Approval, GateResult.Pass("auto")),
+            new TestProposals.StubGate(WellKnownGateKeys.Merge, GateResult.Pass()));
+
+        var result = await sut.ProcessAsync(proposal.Id, OrchestratorMode.Live, CancellationToken.None);
+
+        result!.History.Should().NotContain(d => d.GateKey == "incident_overlay",
+            because: "no overlay was applied; the overlay marker would be noise");
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/IncidentResponse/IncidentResponsePlanResolverTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/IncidentResponse/IncidentResponsePlanResolverTests.cs
@@ -1,0 +1,151 @@
+using Domain.Common.Config;
+using Domain.Common.Config.AI.IncidentResponse;
+using FluentAssertions;
+using Infrastructure.AI.IncidentResponse;
+using Infrastructure.AI.Tests.Changes.Support;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.IncidentResponse;
+
+/// <summary>
+/// Unit tests for <see cref="IncidentResponsePlanResolver"/>. Covers match,
+/// case-insensitivity, default-fallback, miss, and hot-reload behaviour.
+/// </summary>
+public sealed class IncidentResponsePlanResolverTests
+{
+    private static AppConfig MakeConfig(
+        IReadOnlyList<IncidentResponsePlan> plans,
+        string? defaultPlanName = null)
+    {
+        var cfg = new AppConfig();
+        cfg.AI.IncidentResponse.Plans = [.. plans];
+        cfg.AI.IncidentResponse.DefaultPlanName = defaultPlanName;
+        return cfg;
+    }
+
+    private static IncidentResponsePlan Plan(
+        string name,
+        string incidentType,
+        string? autonomyTier = null,
+        params string[] additionalGates) =>
+        new()
+        {
+            Name = name,
+            IncidentType = incidentType,
+            AutonomyTierOverride = autonomyTier,
+            AdditionalRequiredGates = additionalGates
+        };
+
+    [Fact]
+    public void ResolveFor_MatchingIncidentType_ReturnsPlan()
+    {
+        var data = Plan("DataExfil", "DataExfiltrationSuspected", "Restricted", "compliance");
+        var cfg = MakeConfig([data, Plan("Rollback", "ProductionRollback")]);
+        var sut = new IncidentResponsePlanResolver(new TestConfig.StaticOptionsMonitor<AppConfig>(cfg));
+
+        sut.ResolveFor("DataExfiltrationSuspected").Should().BeSameAs(data);
+    }
+
+    [Fact]
+    public void ResolveFor_MatchingIncidentType_IsCaseInsensitive()
+    {
+        var data = Plan("DataExfil", "DataExfiltrationSuspected");
+        var cfg = MakeConfig([data]);
+        var sut = new IncidentResponsePlanResolver(new TestConfig.StaticOptionsMonitor<AppConfig>(cfg));
+
+        sut.ResolveFor("dataexfiltrationsuspected").Should().BeSameAs(data);
+    }
+
+    [Fact]
+    public void ResolveFor_NoMatchAndDefaultConfigured_ReturnsDefaultPlan()
+    {
+        var standardOps = Plan("StandardOps", "StandardOps");
+        var cfg = MakeConfig([standardOps], defaultPlanName: "StandardOps");
+        var sut = new IncidentResponsePlanResolver(new TestConfig.StaticOptionsMonitor<AppConfig>(cfg));
+
+        sut.ResolveFor("UnknownIncident").Should().BeSameAs(standardOps);
+    }
+
+    [Fact]
+    public void ResolveFor_NoMatchAndNoDefault_ReturnsNull()
+    {
+        var cfg = MakeConfig([Plan("DataExfil", "DataExfiltrationSuspected")]);
+        var sut = new IncidentResponsePlanResolver(new TestConfig.StaticOptionsMonitor<AppConfig>(cfg));
+
+        sut.ResolveFor("UnknownIncident").Should().BeNull();
+    }
+
+    [Fact]
+    public void ResolveFor_NullIncidentTypeAndNoDefault_ReturnsNull()
+    {
+        var cfg = MakeConfig([Plan("DataExfil", "DataExfiltrationSuspected")]);
+        var sut = new IncidentResponsePlanResolver(new TestConfig.StaticOptionsMonitor<AppConfig>(cfg));
+
+        sut.ResolveFor(null).Should().BeNull();
+        sut.ResolveFor("   ").Should().BeNull();
+    }
+
+    [Fact]
+    public void ResolveFor_NullIncidentTypeAndDefaultConfigured_ReturnsDefaultPlan()
+    {
+        var standardOps = Plan("StandardOps", "StandardOps");
+        var cfg = MakeConfig([standardOps], defaultPlanName: "StandardOps");
+        var sut = new IncidentResponsePlanResolver(new TestConfig.StaticOptionsMonitor<AppConfig>(cfg));
+
+        sut.ResolveFor(null).Should().BeSameAs(standardOps);
+    }
+
+    [Fact]
+    public void ResolveFor_EmptyRegistry_ReturnsNull()
+    {
+        var cfg = MakeConfig(plans: []);
+        var sut = new IncidentResponsePlanResolver(new TestConfig.StaticOptionsMonitor<AppConfig>(cfg));
+
+        sut.ResolveFor("DataExfiltrationSuspected").Should().BeNull();
+    }
+
+    [Fact]
+    public void ResolveFor_FirstMatchWins()
+    {
+        // Boot validator rejects duplicate types, but if a host runs without
+        // the validator (or hot-loads duplicates after start), the resolver
+        // returns the first declared. This documents that deterministic order.
+        var first = Plan("First", "Same");
+        var second = Plan("Second", "Same");
+        var cfg = MakeConfig([first, second]);
+        var sut = new IncidentResponsePlanResolver(new TestConfig.StaticOptionsMonitor<AppConfig>(cfg));
+
+        sut.ResolveFor("Same").Should().BeSameAs(first);
+    }
+
+    [Fact]
+    public void ResolveFor_HotReload_PicksUpNewPlanOnNextResolve()
+    {
+        var initial = MakeConfig([Plan("Old", "OldIncident")]);
+        var monitor = new MutableOptionsMonitor<AppConfig>(initial);
+        var sut = new IncidentResponsePlanResolver(monitor);
+
+        sut.ResolveFor("OldIncident").Should().NotBeNull();
+        sut.ResolveFor("NewIncident").Should().BeNull();
+
+        var swapped = MakeConfig([Plan("New", "NewIncident")]);
+        monitor.Set(swapped);
+
+        sut.ResolveFor("NewIncident").Should().NotBeNull();
+        sut.ResolveFor("OldIncident").Should().BeNull();
+    }
+
+    /// <summary>
+    /// Test double for hot-reload that lets a test push a new
+    /// <see cref="AppConfig"/> after the resolver has been constructed.
+    /// </summary>
+    private sealed class MutableOptionsMonitor<T> : Microsoft.Extensions.Options.IOptionsMonitor<T>
+    {
+        private T _current;
+        public MutableOptionsMonitor(T initial) { _current = initial; }
+        public T CurrentValue => _current;
+        public T Get(string? name) => _current;
+        public IDisposable? OnChange(Action<T, string?> listener) => null;
+        public void Set(T next) => _current = next;
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/IncidentResponse/IncidentResponsePlanValidatorTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/IncidentResponse/IncidentResponsePlanValidatorTests.cs
@@ -1,0 +1,154 @@
+using Domain.Common.Config;
+using Domain.Common.Config.AI.IncidentResponse;
+using FluentAssertions;
+using Infrastructure.AI.IncidentResponse;
+using Infrastructure.AI.Tests.Changes.Support;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.IncidentResponse;
+
+/// <summary>
+/// Boot-time validator tests for <see cref="IncidentResponsePlanValidator"/>.
+/// </summary>
+public sealed class IncidentResponsePlanValidatorTests
+{
+    private static IncidentResponsePlanValidator NewSut(AppConfig cfg)
+    {
+        var services = new ServiceCollection().BuildServiceProvider();
+        return new(
+            services,
+            new TestConfig.StaticOptionsMonitor<AppConfig>(cfg),
+            NullLogger<IncidentResponsePlanValidator>.Instance);
+    }
+
+    [Fact]
+    public async Task StartAsync_EmptyRegistry_NoOps()
+    {
+        var cfg = new AppConfig();
+        var sut = NewSut(cfg);
+
+        await sut.Invoking(s => s.StartAsync(CancellationToken.None))
+            .Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task StartAsync_ValidConfig_AllowsBoot()
+    {
+        var cfg = new AppConfig();
+        cfg.AI.IncidentResponse.Plans =
+        [
+            new() { Name = "DataExfil", IncidentType = "DataExfiltrationSuspected", AutonomyTierOverride = "Restricted", AdditionalRequiredGates = ["compliance"] },
+            new() { Name = "Rollback", IncidentType = "ProductionRollback", AutonomyTierOverride = "Supervised" }
+        ];
+        cfg.AI.IncidentResponse.DefaultPlanName = "DataExfil";
+        var sut = NewSut(cfg);
+
+        await sut.Invoking(s => s.StartAsync(CancellationToken.None))
+            .Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task StartAsync_UnknownAutonomyTier_Throws()
+    {
+        var cfg = new AppConfig();
+        cfg.AI.IncidentResponse.Plans =
+        [
+            new() { Name = "Bogus", IncidentType = "Whatever", AutonomyTierOverride = "Godmode" }
+        ];
+        var sut = NewSut(cfg);
+
+        var ex = await sut.Invoking(s => s.StartAsync(CancellationToken.None))
+            .Should().ThrowAsync<InvalidOperationException>();
+        ex.Which.Message.Should().Contain("AutonomyTierOverride");
+        ex.Which.Message.Should().Contain("Godmode");
+        ex.Which.Message.Should().Contain("Restricted"); // expected to list known tiers
+    }
+
+    [Fact]
+    public async Task StartAsync_DuplicatePlanNames_Throws()
+    {
+        var cfg = new AppConfig();
+        cfg.AI.IncidentResponse.Plans =
+        [
+            new() { Name = "Same", IncidentType = "TypeA" },
+            new() { Name = "same", IncidentType = "TypeB" } // case-insensitive duplicate
+        ];
+        var sut = NewSut(cfg);
+
+        var ex = await sut.Invoking(s => s.StartAsync(CancellationToken.None))
+            .Should().ThrowAsync<InvalidOperationException>();
+        ex.Which.Message.Should().Contain("duplicate");
+        ex.Which.Message.Should().Contain("Name");
+    }
+
+    [Fact]
+    public async Task StartAsync_DuplicateIncidentTypes_Throws()
+    {
+        var cfg = new AppConfig();
+        cfg.AI.IncidentResponse.Plans =
+        [
+            new() { Name = "First", IncidentType = "Same" },
+            new() { Name = "Second", IncidentType = "same" } // case-insensitive duplicate
+        ];
+        var sut = NewSut(cfg);
+
+        var ex = await sut.Invoking(s => s.StartAsync(CancellationToken.None))
+            .Should().ThrowAsync<InvalidOperationException>();
+        ex.Which.Message.Should().Contain("duplicate");
+        ex.Which.Message.Should().Contain("IncidentType");
+    }
+
+    [Fact]
+    public async Task StartAsync_DefaultPlanNameDoesNotMatchAnyPlan_Throws()
+    {
+        var cfg = new AppConfig();
+        cfg.AI.IncidentResponse.Plans = [new() { Name = "Plan1", IncidentType = "Type1" }];
+        cfg.AI.IncidentResponse.DefaultPlanName = "MissingPlan";
+        var sut = NewSut(cfg);
+
+        var ex = await sut.Invoking(s => s.StartAsync(CancellationToken.None))
+            .Should().ThrowAsync<InvalidOperationException>();
+        ex.Which.Message.Should().Contain("DefaultPlanName");
+        ex.Which.Message.Should().Contain("MissingPlan");
+    }
+
+    [Fact]
+    public async Task StartAsync_DefaultPlanNameWithEmptyRegistry_Throws()
+    {
+        var cfg = new AppConfig();
+        cfg.AI.IncidentResponse.DefaultPlanName = "SomePlan";
+        var sut = NewSut(cfg);
+
+        var ex = await sut.Invoking(s => s.StartAsync(CancellationToken.None))
+            .Should().ThrowAsync<InvalidOperationException>();
+        ex.Which.Message.Should().Contain("DefaultPlanName");
+        ex.Which.Message.Should().Contain("no plans");
+    }
+
+    [Fact]
+    public async Task StartAsync_MissingName_Throws()
+    {
+        var cfg = new AppConfig();
+        cfg.AI.IncidentResponse.Plans = [new() { Name = "  ", IncidentType = "Type1" }];
+        var sut = NewSut(cfg);
+
+        var ex = await sut.Invoking(s => s.StartAsync(CancellationToken.None))
+            .Should().ThrowAsync<InvalidOperationException>();
+        ex.Which.Message.Should().Contain("Name is required");
+    }
+
+    [Fact]
+    public async Task StartAsync_MissingIncidentType_Throws()
+    {
+        var cfg = new AppConfig();
+        cfg.AI.IncidentResponse.Plans = [new() { Name = "Plan1", IncidentType = "" }];
+        var sut = NewSut(cfg);
+
+        var ex = await sut.Invoking(s => s.StartAsync(CancellationToken.None))
+            .Should().ThrowAsync<InvalidOperationException>();
+        ex.Which.Message.Should().Contain("IncidentType is required");
+        ex.Which.Message.Should().Contain("Plan1");
+    }
+}


### PR DESCRIPTION
## Summary

Adds a config-driven incident-response abstraction. When the host reports an active incident (via an ambient `IIncidentContext` set by Presentation-layer middleware), the harness:

1. Looks up a matching `IncidentResponsePlan` via `IIncidentResponsePlanResolver`
2. Activates the plan's declared skill set on the agent (skill wiring is a consumer concern; the plan exposes the surface)
3. Forces the autonomy tier to `AutonomyTierOverride` for the duration (string-typed, validated at boot against `AutonomyLevel` enum names)
4. Overlays `AdditionalRequiredGates` on every in-flight `ChangeProposal` — non-mutatingly, with an `incident_overlay` audit entry so the trail captures the augment

## Files added

**Domain**
- `Domain.Common/Config/AI/IncidentResponse/IncidentResponsePlan.cs`
- `Domain.Common/Config/AI/IncidentResponse/IncidentResponsePlanConfig.cs`
- `AIConfig.IncidentResponse` property wired

**Application**
- `Application.AI.Common/Interfaces/IncidentResponse/IIncidentResponsePlanResolver.cs`
- `Application.AI.Common/Interfaces/IncidentResponse/IIncidentContext.cs`

**Infrastructure**
- `Infrastructure.AI/IncidentResponse/IncidentResponsePlanResolver.cs` (`IOptionsMonitor`-backed, hot-reload)
- `Infrastructure.AI/IncidentResponse/AsyncLocalIncidentContext.cs` (Singleton; AsyncLocal slot mirrors `KnowledgeScopeAccessor`)
- `Infrastructure.AI/IncidentResponse/IncidentResponsePlanValidator.cs` (`IHostedService`, fail-loud)
- `Infrastructure.AI/DependencyInjection.IncidentResponse.cs` (new DI partial)
- `Infrastructure.AI/Changes/ChangeProposalOrchestrator.cs` — gains 2 optional ctor deps; computes effective gates once per `ProcessAsync`; emits `incident_overlay` audit entry; **proposal's stored `RequiredGates` is never mutated**

**Tests** (28 new, all green)
- `Infrastructure.AI.Tests/IncidentResponse/IncidentResponsePlanResolverTests.cs` (9)
- `Infrastructure.AI.Tests/IncidentResponse/AsyncLocalIncidentContextTests.cs` (5)
- `Infrastructure.AI.Tests/IncidentResponse/IncidentResponsePlanValidatorTests.cs` (9)
- `Infrastructure.AI.Tests/IncidentResponse/IncidentResponseOrchestratorOverlayTests.cs` (5)

## Design decisions

- **Optional ctor deps on the orchestrator** instead of required. Keeps every PR-2 test compiling and prevents a constructor-shape break across consumer code that constructs the orchestrator directly. DI supplies the new deps in production paths.
- **String-typed `AutonomyTierOverride`** on the plan. Keeps `Domain.Common` free of a `Domain.AI` dependency; validator parses at boot and rejects typos.
- **Overlay is non-mutating.** Proposal's `RequiredGates` field stays exactly what was submitted; orchestrator unions in the plan's gates at evaluation time and audits the overlay separately. Reviewers see both the original shape and the incident-driven additions.
- **Default-plan-name fallback** when no incident-type match found (per acceptance criteria "missing plan → falls back to defaults").
- **De-duplication** when the incident plan re-declares a gate the proposal already has — orchestrator never runs the same gate twice in one phase.

## Verification

```
dotnet build src/AgenticHarness.slnx         # 0 errors
dotnet test src/AgenticHarness.slnx          # 6285 passed / 2 skipped / 0 failed
```

PR-2 Changes-namespace + PR-4 autonomy tests stay green. 28 new PR-5 tests added.

## Test plan

- [ ] Build clean on CI
- [ ] Full test suite green on CI
- [ ] Spot-check audit log shape includes `incident_overlay` line when a plan applies
- [ ] Confirm hot-reload picks up new plans (covered by unit test; manual smoke optional)

🤖 Generated with Claude Code