### PR TITLE
feat(a2a): harness Agent-to-Agent surface — wire shape, identity, OTel, auth (PR-7)

### DIFF
--- a/documentation/architecture/a2a-message-contract.md
+++ b/documentation/architecture/a2a-message-contract.md
@@ -1,0 +1,236 @@
+# A2A Message Contract
+
+PR-7 ships the harness Agent-to-Agent (A2A) surface — the common dispatch
+shape every inter-skill call goes through, whether the callee is in the
+same process or a remote one. The shape is identical across transports
+so a consumer can split a skill into its own process later without
+touching call sites.
+
+## Why not a thin wrapper over MAF A2A?
+
+The plan calls for "thin wrapper over MAF" but Microsoft Agent
+Framework 1.9.0 (current pin — `Microsoft.Agents.AI`) does **not** ship
+an A2A client/server surface. The Linux Foundation A2A protocol is
+young (June 2025) and MAF has not yet published primitives that the
+harness could wrap. PR-7 therefore ships a harness-native A2A surface
+with the same goals — wire shape, identity propagation, OTel span
+linking, mutual-TLS-plus-JWT auth — and pins to MAF 1.9.0 via a
+canary test (`A2AVersionPinTests`) that fails the moment MAF adds an
+A2A surface, so the harness can switch to wrapping it.
+
+## Envelope
+
+Every A2A call carries an `A2AEnvelope` plus a payload. The envelope is
+JSON-serializable with explicit camelCase property names — no
+serializer-config drift between processes.
+
+```json
+{
+  "schemaVersion": 1,
+  "correlationId": "ec0b3a4d6e6f4b5a8e9f0c1d2e3f4a5b",
+  "callerAgentId": "sre-agent",
+  "callerKind": "FederatedCredential",
+  "calleeAgentId": "workspace-agent",
+  "calleeSkill": "search-tickets",
+  "traceparent": "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+  "extensions": { "tenantId": "contoso" }
+}
+```
+
+| Field | Required | Purpose |
+| --- | --- | --- |
+| `schemaVersion` | yes | Envelope version; current `1`. Bump on any breaking shape change. |
+| `correlationId` | yes | UUIDv4 (no hyphens). Shared across caller + callee spans. |
+| `callerAgentId` | yes | Caller agent id from `IAgentExecutionContext.AgentIdentity.Id`. |
+| `callerKind` | yes | Caller identity kind, e.g. `FederatedCredential`. |
+| `calleeAgentId` | yes | Target agent id; resolves DNS / DI key on the callee side. |
+| `calleeSkill` | no | Target skill name. Null → callee's default skill. |
+| `traceparent` | no | W3C trace-context header value, captured client-side. |
+| `extensions` | no | Vendor-extensible headers, bounded by `MaxExtensionHeaders`. |
+
+## Request / response
+
+```json
+// Request
+{
+  "envelope": { ... },
+  "taskDescription": "Find open SEV-2 tickets for tenant contoso",
+  "input": { "tenantId": "contoso", "severity": 2 }
+}
+
+// Success response
+{
+  "correlationId": "ec0b3a4d...",
+  "success": true,
+  "output": { "tickets": [ ... ] }
+}
+
+// Failure response
+{
+  "correlationId": "ec0b3a4d...",
+  "success": false,
+  "errorCode": "a2a.auth_rejected",
+  "errorMessage": null
+}
+```
+
+Stable failure codes:
+
+| Code | Meaning |
+| --- | --- |
+| `a2a.auth_rejected` | Auth provider rejected the inbound envelope (no JWT, bad signature, sub mismatch, etc). |
+| `a2a.unsupported_envelope_version` | `schemaVersion` does not match server's supported version. |
+| `a2a.too_many_extensions` | Extension dictionary exceeded `MaxExtensionHeaders`. |
+| `a2a.identity_conflict` | Server's execution scope was already bound to a different identity. |
+| `a2a.skill_not_found` | No keyed handler registered for `{calleeAgentId}` or `{calleeAgentId}:{calleeSkill}`. |
+| `a2a.skill_failed` | Handler threw or returned a `Result.Fail`. |
+| `a2a.cancelled` | Cooperative cancellation. |
+| `a2a.bad_response` | Cross-process callee returned an unparseable body. |
+| `a2a.transport_failure` | HTTP-level error (DNS, TLS, connection reset). |
+| `a2a.http_4xx` / `a2a.http_5xx` | HTTP error not covered above. |
+| `a2a.unknown_callee` | No `RemoteAgents` entry matches the envelope's `calleeAgentId`. |
+| `a2a.unknown_transport` | Configured `Transport` value is invalid. |
+| `a2a.auth_acquisition_failed` | Client-side JWT acquirer failed. |
+
+Server-side exceptions are logged via structured logging and never
+returned on the wire — error messages are nullable and used only for
+human-readable diagnostics when safe.
+
+## Identity propagation
+
+The caller stamps `callerAgentId` from
+`IAgentExecutionContext.AgentIdentity.Id`. The server reads it, runs the
+auth provider, and establishes the **authoritative** caller id on its
+own `IAgentExecutionContext` via `A2AIdentityPropagator`:
+
+- **In-process transport**: the envelope's declared caller id is
+  authoritative because both ends share the same trust boundary. The
+  auth provider also checks that the envelope's declared id matches the
+  ambient identity to catch scope-leak bugs.
+- **Cross-process transport**: the JWT `sub` claim is authoritative.
+  If the envelope's declared `callerAgentId` does not match the JWT
+  `sub`, the server returns `a2a.auth_rejected` — a holder of a token
+  for agent A cannot masquerade as agent B in the envelope.
+
+The propagator sets the caller's `AgentIdentity` on the server-side
+scope so all downstream tool calls in the handler are RBAC'd against
+the original caller, not a synthetic "callee" identity.
+
+## OpenTelemetry span linking
+
+Both sides emit spans on `ActivitySource = "AgenticHarness.A2A"`.
+
+| Attribute | Caller span | Callee span |
+| --- | --- | --- |
+| Span name | `a2a.client {calleeAgentId}` | `a2a.server {calleeSkill | calleeAgentId}` |
+| Kind | `Client` | `Server` |
+| `gen_ai.operation.name` | `invoke_a2a` | `invoke_a2a` |
+| `gen_ai.a2a.caller.id` | yes | yes |
+| `gen_ai.a2a.caller.kind` | yes | yes |
+| `gen_ai.a2a.callee.id` | yes | yes |
+| `gen_ai.a2a.callee.skill` | optional | optional |
+| `gen_ai.a2a.correlation_id` | yes | yes |
+| `gen_ai.a2a.transport` | `in_process` or `http` | `in_process` or `http` |
+| `gen_ai.a2a.auth.scheme` | `ambient` or `mtls+jwt` | `ambient` or `mtls+jwt` |
+| `gen_ai.a2a.envelope.version` | yes | yes |
+| `gen_ai.a2a.error.code` | on failure | on failure |
+| `error.type` | mirrors error code | mirrors error code |
+
+The correlation id appears on both spans so log search joins the two
+ends even when the W3C trace-context propagator is broken or stripped
+by an intermediary. For cross-process calls, the caller also stamps
+`traceparent` onto the envelope; the server extracts it onto the
+inbound span as a standard parent link.
+
+## Authentication
+
+### In-process (`A2ATransport.InProcess`)
+
+- Scheme name: `ambient`.
+- Trusts `IAgentExecutionContext.AgentIdentity` because the call never
+  leaves the process boundary.
+- Server-side: validates the envelope's declared caller matches the
+  ambient identity (when one is set). A mismatch is a scope-leak bug
+  and surfaces as `a2a.auth_rejected`.
+
+### Cross-process (`A2ATransport.Http`)
+
+- Scheme name: `mtls+jwt`.
+- **Layer 1 — mutual TLS**: Kestrel terminates the connection with peer
+  certificate authentication. Untrusted certs are rejected before any
+  harness code runs. The harness expects Kestrel to be configured per
+  the security playbook (cert thumbprint allowlist; revocation check
+  enabled).
+- **Layer 2 — workload identity JWT**: the client attaches
+  `Authorization: Bearer <jwt>` via the consumer-supplied
+  `IA2ATokenAcquirer`. The server validates via the
+  consumer-supplied `IA2ATokenValidator`:
+  - signature against the configured key material;
+  - `iss` against `A2ASurfaceConfig.ExpectedIssuer`;
+  - `aud` against `A2ASurfaceConfig.ExpectedAudience`;
+  - `exp` with clock skew = `A2ASurfaceConfig.ClockSkewSeconds`
+    (defaults to `0` — never widen without a recorded design decision);
+  - revocation status against any configured revocation list.
+- **Layer 3 — envelope match**: the JWT's `sub` claim must equal the
+  envelope's declared `callerAgentId`. JWT sub is authoritative.
+
+Why mTLS + JWT instead of JWT alone? mTLS pins the connection
+**workload** (which Kestrel can verify cryptographically) and JWT pins
+the **agent identity** running inside that workload (which the
+identity provider issues). Separately validated, separately revocable.
+The harness expresses this as two distinct trust layers rather than
+folding identity into the connection cert.
+
+## Transport selection
+
+`AppConfig.AI.A2A.Surface.Transport`:
+
+- `InProcess` (default): same-process dispatch via the in-process
+  bridge — no HTTP, no JWT acquisition. Example demos and unit tests
+  use this transport.
+- `Http`: cross-process dispatch. Requires the consumer to register an
+  `IA2ATokenAcquirer` and `IA2ATokenValidator` and to set
+  `ExpectedAudience` + `ExpectedIssuer`.
+
+`A2ASurfaceConfig.MaxExtensionHeaders` (default `16`) bounds the
+extension dictionary the server will deserialize — protects against
+malicious payload inflation.
+
+## Skill handler registration
+
+The server resolves a handler via keyed DI:
+
+```csharp
+// Default skill for the agent
+services.AddKeyedScoped<IA2ASkillHandler, MyAgentHandler>("sre-agent");
+
+// Named skill
+services.AddKeyedScoped<IA2ASkillHandler, MySearchHandler>("workspace-agent:search-tickets");
+```
+
+`HarnessA2AServer` looks up the keyed handler in this precedence:
+
+1. `{calleeAgentId}:{calleeSkill}` if `CalleeSkill` is non-null;
+2. `{calleeAgentId}` otherwise.
+
+Missing handlers surface as `a2a.skill_not_found`.
+
+## Version pin
+
+`Infrastructure.AI.Tests/A2A/A2AVersionPinTests` asserts:
+
+- `Microsoft.Agents.AI` 1.9.0 does **not** expose a public A2A surface
+  (canary: when MAF adds one, this test fails and the harness should
+  switch to wrapping it).
+- `A2AEnvelope.CurrentSchemaVersion == 1` — bumping requires updating
+  the test and writing a migration note.
+
+When MAF ships A2A primitives:
+
+1. Failing test makes the situation visible.
+2. Replace `HarnessA2AClient` / `HarnessA2AServer` with thin wrappers
+   over the MAF types, keeping the harness `IA2AClient` / `IA2AServer`
+   call-site shape unchanged.
+3. Keep the envelope conventions — they encode harness-specific
+   identity + correlation semantics that MAF's transport will not
+   replicate.

--- a/src/Content/Application/Application.AI.Common/Interfaces/A2A/IA2AAuthenticationProvider.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/A2A/IA2AAuthenticationProvider.cs
@@ -1,0 +1,68 @@
+using Domain.AI.A2A;
+using Domain.Common;
+
+namespace Application.AI.Common.Interfaces.A2A;
+
+/// <summary>
+/// Abstracts the authentication strategy for A2A calls: in-process trust of
+/// the ambient identity context, or cross-process mutual TLS plus
+/// workload-identity JWT.
+/// </summary>
+/// <remarks>
+/// <para>
+/// One implementation per transport. Client-side:
+/// <see cref="StampOutboundCredentialsAsync"/> attaches transport-specific
+/// auth material (e.g. a JWT) before the request goes out. Server-side:
+/// <see cref="ValidateInboundAsync"/> verifies what arrived and returns the
+/// authenticated caller's <c>callerAgentId</c> string (or a failure code).
+/// </para>
+/// <para>
+/// The auth provider returns a <see cref="Result{T}"/> rather than throwing on
+/// rejection — the server treats rejection as a stable failure code
+/// (<c>a2a.auth_rejected</c>) rather than an exception, so observability
+/// dashboards can distinguish auth failures from skill failures cleanly.
+/// </para>
+/// </remarks>
+public interface IA2AAuthenticationProvider
+{
+    /// <summary>
+    /// Identifier of the auth scheme: one of
+    /// <c>A2AConventions.AuthSchemeInProcess</c> or
+    /// <c>A2AConventions.AuthSchemeMtlsJwt</c>. Stamped on both spans.
+    /// </summary>
+    string SchemeName { get; }
+
+    /// <summary>
+    /// Caller-side hook. Returns the transport-specific auth header(s) to
+    /// attach to the outbound request. For the in-process provider this is a
+    /// no-op (returns an empty dictionary); for the cross-process provider it
+    /// returns an <c>Authorization: Bearer &lt;jwt&gt;</c> header.
+    /// </summary>
+    /// <param name="envelope">The envelope being sent (caller id is required —
+    /// JWT subject claim is derived from it).</param>
+    /// <param name="cancellationToken">Cooperative cancellation token.</param>
+    /// <returns>A bounded set of transport headers to attach, or
+    /// <see cref="Result.Fail(string[])"/> with a stable code if credentials
+    /// cannot be acquired.</returns>
+    Task<Result<IReadOnlyDictionary<string, string>>> StampOutboundCredentialsAsync(
+        A2AEnvelope envelope,
+        CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Server-side hook. Validates the inbound envelope (and any
+    /// transport-attached credentials accumulated by the listener) and returns
+    /// the authoritative <c>callerAgentId</c> the call should be attributed to.
+    /// </summary>
+    /// <param name="envelope">The envelope as it arrived on the wire.</param>
+    /// <param name="transportHeaders">Transport-level headers the listener
+    /// observed (e.g. <c>Authorization</c>, peer cert subject). May be empty
+    /// for in-process calls.</param>
+    /// <param name="cancellationToken">Cooperative cancellation token.</param>
+    /// <returns>The authoritative caller agent id on success, or
+    /// <see cref="Result.Fail(string[])"/> with a stable
+    /// <c>a2a.auth_rejected</c> code on failure.</returns>
+    Task<Result<string>> ValidateInboundAsync(
+        A2AEnvelope envelope,
+        IReadOnlyDictionary<string, string> transportHeaders,
+        CancellationToken cancellationToken);
+}

--- a/src/Content/Application/Application.AI.Common/Interfaces/A2A/IA2AClient.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/A2A/IA2AClient.cs
@@ -1,0 +1,43 @@
+using Domain.AI.A2A;
+using Domain.Common;
+
+namespace Application.AI.Common.Interfaces.A2A;
+
+/// <summary>
+/// Caller-side A2A surface. Sends an <see cref="A2ARequest"/> to another agent
+/// (in-process or cross-process) and returns the resulting <see cref="A2AResponse"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The client is the harness-wide ingress point for every inter-agent call. It
+/// stamps caller identity onto the envelope from
+/// <c>IAgentExecutionContext.AgentIdentity</c>, generates a fresh correlation id,
+/// opens the <c>a2a.client</c> span, and delegates to the configured
+/// <see cref="IA2AAuthenticationProvider"/> for transport-specific auth.
+/// </para>
+/// <para>
+/// Both in-process and cross-process transports return a normalized
+/// <see cref="Result{T}"/> — never throw on remote-side failures. Cancellation
+/// (cooperative <see cref="CancellationToken"/>) is the only legitimate
+/// exception path.
+/// </para>
+/// </remarks>
+public interface IA2AClient
+{
+    /// <summary>
+    /// Dispatches an A2A request to the configured transport and returns the
+    /// callee's response.
+    /// </summary>
+    /// <param name="request">The request envelope and payload. The envelope's
+    /// <c>callerAgentId</c>, <c>callerKind</c>, and <c>correlationId</c> may be
+    /// pre-stamped by the caller; if absent, the client populates them from the
+    /// ambient <c>IAgentExecutionContext</c> and a fresh UUIDv4.</param>
+    /// <param name="cancellationToken">Cooperative cancellation token.</param>
+    /// <returns>The callee's response, wrapped in a <see cref="Result{T}"/>.
+    /// A successful HTTP-level call with a <c>success=false</c> body still
+    /// returns <see cref="Result{T}.Success"/> carrying the failure response —
+    /// the call itself succeeded. Transport / auth / serialization failures
+    /// surface as <see cref="Result.Fail(string[])"/> with stable <c>a2a.*</c>
+    /// codes.</returns>
+    Task<Result<A2AResponse>> CallAsync(A2ARequest request, CancellationToken cancellationToken);
+}

--- a/src/Content/Application/Application.AI.Common/Interfaces/A2A/IA2AServer.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/A2A/IA2AServer.cs
@@ -1,0 +1,44 @@
+using Domain.AI.A2A;
+using Domain.Common;
+
+namespace Application.AI.Common.Interfaces.A2A;
+
+/// <summary>
+/// Callee-side A2A surface. Dispatches an inbound <see cref="A2ARequest"/> to
+/// the registered local skill handler and returns its <see cref="A2AResponse"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Single dispatch entrypoint regardless of transport. The HTTP listener for
+/// cross-process calls and the in-process bridge for same-process calls both
+/// terminate at <see cref="DispatchAsync"/>, so authentication, identity
+/// re-establishment, OTel span emission, and skill lookup live in exactly one
+/// place.
+/// </para>
+/// <para>
+/// Server implementations MUST:
+/// <list type="number">
+/// <item><description>Validate the inbound envelope via the registered
+/// <see cref="IA2AAuthenticationProvider"/> before executing any skill code.</description></item>
+/// <item><description>Establish the calling agent's identity onto
+/// <c>IAgentExecutionContext</c> for the duration of the call, then restore the
+/// previous identity (if any) afterwards.</description></item>
+/// <item><description>Stamp the <see cref="A2AResponse.CorrelationId"/> echo
+/// from the request envelope.</description></item>
+/// </list>
+/// </para>
+/// </remarks>
+public interface IA2AServer
+{
+    /// <summary>
+    /// Dispatches a single inbound A2A request to the resolved local skill.
+    /// </summary>
+    /// <param name="request">The inbound request, with its envelope already
+    /// extracted by the transport layer. Authentication has NOT yet run.</param>
+    /// <param name="cancellationToken">Cooperative cancellation token.</param>
+    /// <returns>A success response with the skill's output, or a failure
+    /// response with a stable <c>a2a.*</c> error code. The outer
+    /// <see cref="Result{T}"/> wraps catastrophic dispatch failures (e.g. the
+    /// server is shutting down).</returns>
+    Task<Result<A2AResponse>> DispatchAsync(A2ARequest request, CancellationToken cancellationToken);
+}

--- a/src/Content/Application/Application.AI.Common/Interfaces/A2A/IA2ASkillHandler.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/A2A/IA2ASkillHandler.cs
@@ -1,0 +1,34 @@
+using Domain.AI.A2A;
+using Domain.Common;
+
+namespace Application.AI.Common.Interfaces.A2A;
+
+/// <summary>
+/// Server-side skill handler registered against an agent id (and optional skill
+/// name). Resolved by the A2A server when an inbound request arrives and
+/// dispatched once authentication has succeeded.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Implementations are registered via keyed DI keyed on the agent id (e.g.
+/// <c>"sre-agent"</c>) so the server's dispatch loop is a single keyed lookup.
+/// A null <see cref="A2AEnvelope.CalleeSkill"/> on the request resolves to the
+/// handler registered against the agent id alone; a non-null skill name
+/// resolves to the handler keyed on <c>"{agentId}:{skillName}"</c>.
+/// </para>
+/// </remarks>
+public interface IA2ASkillHandler
+{
+    /// <summary>
+    /// Handles an inbound A2A request after authentication has succeeded and
+    /// the calling agent's identity has been established on
+    /// <c>IAgentExecutionContext</c>.
+    /// </summary>
+    /// <param name="request">The validated inbound request.</param>
+    /// <param name="cancellationToken">Cooperative cancellation token.</param>
+    /// <returns>The skill's response. Implementations that throw cause the
+    /// server to translate the exception into an <c>a2a.skill_failed</c>
+    /// response and log the inner exception via structured logging — never on
+    /// the wire.</returns>
+    Task<Result<A2AResponse>> HandleAsync(A2ARequest request, CancellationToken cancellationToken);
+}

--- a/src/Content/Domain/Domain.AI/A2A/A2AEnvelope.cs
+++ b/src/Content/Domain/Domain.AI/A2A/A2AEnvelope.cs
@@ -1,0 +1,97 @@
+using System.Text.Json.Serialization;
+
+namespace Domain.AI.A2A;
+
+/// <summary>
+/// Wire-shape envelope carrying identity and correlation metadata for every
+/// A2A call. Used by both <c>IA2AClient</c> (stamps headers) and <c>IA2AServer</c>
+/// (reads + re-establishes context) so an in-process call and a cross-process
+/// call speak the same shape.
+/// </summary>
+/// <remarks>
+/// <para>
+/// All property names are explicitly camelCase via <see cref="JsonPropertyNameAttribute"/>
+/// — never rely on serializer naming-policy defaults, since the envelope crosses
+/// process boundaries and a serializer config drift on either side would silently
+/// drop fields. This is also why the type is a sealed record with init-only
+/// properties: post-deserialization mutation is a bug source for distributed
+/// protocols.
+/// </para>
+/// <para>
+/// <see cref="SchemaVersion"/> is fixed at <see cref="CurrentSchemaVersion"/> for
+/// PR-7. Any breaking shape change requires bumping the constant AND updating
+/// the version-pin test in <c>Infrastructure.AI.Tests/A2A</c>.
+/// </para>
+/// </remarks>
+public sealed record A2AEnvelope
+{
+    /// <summary>
+    /// Current envelope schema version. Increments on any breaking change to
+    /// the JSON shape (added optional fields do not bump).
+    /// </summary>
+    public const int CurrentSchemaVersion = 1;
+
+    /// <summary>
+    /// Envelope schema version stamped on each message. Required so a callee
+    /// running an older harness can reject an envelope it cannot interpret.
+    /// </summary>
+    [JsonPropertyName("schemaVersion")]
+    public required int SchemaVersion { get; init; }
+
+    /// <summary>
+    /// Correlation id shared by the caller and callee for this single A2A hop.
+    /// Stamped by the client (UUIDv4) and echoed unchanged by the server.
+    /// Surfaces as <c>gen_ai.a2a.correlation_id</c> on both spans.
+    /// </summary>
+    [JsonPropertyName("correlationId")]
+    public required string CorrelationId { get; init; }
+
+    /// <summary>
+    /// Caller agent identifier (the agent making the call). Sourced from
+    /// <c>IAgentExecutionContext.AgentIdentity.Id</c> at the call site. Required
+    /// on every envelope so the callee can attribute the work even when the
+    /// transport-level identity (cert SAN / JWT sub) is missing or generic.
+    /// </summary>
+    [JsonPropertyName("callerAgentId")]
+    public required string CallerAgentId { get; init; }
+
+    /// <summary>
+    /// Caller identity kind, as the string value of <c>AgentIdentityKind</c>.
+    /// Cross-process callees use this to decide whether to honor the caller's
+    /// declared identity or fall back to the JWT-asserted one.
+    /// </summary>
+    [JsonPropertyName("callerKind")]
+    public required string CallerKind { get; init; }
+
+    /// <summary>
+    /// Callee agent identifier (the agent being called). Stamped by the client
+    /// from its routing decision. Surfaces as <c>gen_ai.a2a.callee.id</c>.
+    /// </summary>
+    [JsonPropertyName("calleeAgentId")]
+    public required string CalleeAgentId { get; init; }
+
+    /// <summary>
+    /// Optional skill name on the callee side. Null when the call targets the
+    /// callee's default skill. Servers must treat null as "default skill".
+    /// </summary>
+    [JsonPropertyName("calleeSkill")]
+    public string? CalleeSkill { get; init; }
+
+    /// <summary>
+    /// W3C trace-context <c>traceparent</c> header value captured on the caller
+    /// side. Null for in-process calls (the local <c>Activity</c> parent links
+    /// the spans directly); set for cross-process calls so the callee can
+    /// extract the upstream context onto its server span.
+    /// </summary>
+    [JsonPropertyName("traceparent")]
+    public string? Traceparent { get; init; }
+
+    /// <summary>
+    /// Optional vendor-extensible headers — for example downstream tenant ids
+    /// or feature flags the caller wants the callee to honor. Bounded to a few
+    /// short string-string entries; transport implementations MAY refuse
+    /// envelopes whose extension dictionary exceeds a configured size.
+    /// </summary>
+    [JsonPropertyName("extensions")]
+    public IReadOnlyDictionary<string, string>? Extensions { get; init; }
+}

--- a/src/Content/Domain/Domain.AI/A2A/A2ARequest.cs
+++ b/src/Content/Domain/Domain.AI/A2A/A2ARequest.cs
@@ -1,0 +1,47 @@
+using System.Text.Json.Serialization;
+
+namespace Domain.AI.A2A;
+
+/// <summary>
+/// Wire-shape request for a single A2A call. Pairs an <see cref="A2AEnvelope"/>
+/// (identity + correlation metadata) with the call payload (task description
+/// and structured input).
+/// </summary>
+/// <remarks>
+/// <para>
+/// The shape is identical for in-process and cross-process calls — a consumer
+/// that wires an in-process server today can flip it to cross-process tomorrow
+/// without touching call sites. This is the core PR-7 invariant.
+/// </para>
+/// <para>
+/// <see cref="Input"/> is a single JSON node (rather than a strongly-typed
+/// payload) so the harness can route arbitrary skill inputs without adding a
+/// new request type per skill. Callees are responsible for binding it to the
+/// concrete shape their skill expects, and rejecting malformed payloads with
+/// an <c>a2a.bad_request</c> error.
+/// </para>
+/// </remarks>
+public sealed record A2ARequest
+{
+    /// <summary>
+    /// Identity / correlation envelope. Required on every request.
+    /// </summary>
+    [JsonPropertyName("envelope")]
+    public required A2AEnvelope Envelope { get; init; }
+
+    /// <summary>
+    /// Free-text task description for the callee. Mandatory: even
+    /// structured-input calls carry a human-readable summary so observability
+    /// dashboards can show what was asked without re-rendering the input
+    /// payload.
+    /// </summary>
+    [JsonPropertyName("taskDescription")]
+    public required string TaskDescription { get; init; }
+
+    /// <summary>
+    /// Optional structured input for the callee skill, serialized as a raw JSON
+    /// document. Null when the callee only needs <see cref="TaskDescription"/>.
+    /// </summary>
+    [JsonPropertyName("input")]
+    public System.Text.Json.JsonElement? Input { get; init; }
+}

--- a/src/Content/Domain/Domain.AI/A2A/A2AResponse.cs
+++ b/src/Content/Domain/Domain.AI/A2A/A2AResponse.cs
@@ -1,0 +1,81 @@
+using System.Text.Json.Serialization;
+
+namespace Domain.AI.A2A;
+
+/// <summary>
+/// Wire-shape response for a single A2A call. Carries a success-or-error
+/// discriminator plus the correlation id from the originating envelope.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The shape is intentionally narrow: a successful call returns an
+/// <see cref="Output"/> JSON document; a failed call returns an
+/// <see cref="ErrorCode"/> (stable <c>a2a.*</c> identifier) and a sanitized
+/// <see cref="ErrorMessage"/>. Detailed exception context is logged via
+/// structured logging on the server side and never sent over the wire — A2A
+/// errors are treated like CQRS <c>Result.Fail</c> codes.
+/// </para>
+/// </remarks>
+public sealed record A2AResponse
+{
+    /// <summary>
+    /// Correlation id echoed back from the request envelope. Required so the
+    /// caller can match an asynchronous response to its outbound call without
+    /// trusting the transport channel.
+    /// </summary>
+    [JsonPropertyName("correlationId")]
+    public required string CorrelationId { get; init; }
+
+    /// <summary>
+    /// Indicates whether the call succeeded. When <c>false</c>, the
+    /// <see cref="ErrorCode"/> field MUST be populated and <see cref="Output"/>
+    /// MUST be null. When <c>true</c>, <see cref="ErrorCode"/> MUST be null.
+    /// </summary>
+    [JsonPropertyName("success")]
+    public required bool Success { get; init; }
+
+    /// <summary>
+    /// Successful callee output as a raw JSON document. Null when
+    /// <see cref="Success"/> is <c>false</c>.
+    /// </summary>
+    [JsonPropertyName("output")]
+    public System.Text.Json.JsonElement? Output { get; init; }
+
+    /// <summary>
+    /// Stable error code such as <c>a2a.auth_rejected</c>, <c>a2a.timeout</c>,
+    /// <c>a2a.bad_request</c>, or <c>a2a.skill_failed</c>. Null on success.
+    /// Surfaces as <c>gen_ai.a2a.error.code</c> on the spans.
+    /// </summary>
+    [JsonPropertyName("errorCode")]
+    public string? ErrorCode { get; init; }
+
+    /// <summary>
+    /// Optional human-readable error message. Sanitized server-side: never
+    /// includes stack traces, secrets, or internal paths.
+    /// </summary>
+    [JsonPropertyName("errorMessage")]
+    public string? ErrorMessage { get; init; }
+
+    /// <summary>
+    /// Convenience factory for a successful response.
+    /// </summary>
+    /// <param name="correlationId">Correlation id from the request envelope.</param>
+    /// <param name="output">Successful output JSON document.</param>
+    public static A2AResponse Ok(string correlationId, System.Text.Json.JsonElement output) =>
+        new() { CorrelationId = correlationId, Success = true, Output = output };
+
+    /// <summary>
+    /// Convenience factory for a failed response.
+    /// </summary>
+    /// <param name="correlationId">Correlation id from the request envelope.</param>
+    /// <param name="errorCode">Stable <c>a2a.*</c> error code.</param>
+    /// <param name="errorMessage">Sanitized human-readable error message.</param>
+    public static A2AResponse Fail(string correlationId, string errorCode, string? errorMessage = null) =>
+        new()
+        {
+            CorrelationId = correlationId,
+            Success = false,
+            ErrorCode = errorCode,
+            ErrorMessage = errorMessage
+        };
+}

--- a/src/Content/Domain/Domain.AI/Telemetry/Conventions/A2AConventions.cs
+++ b/src/Content/Domain/Domain.AI/Telemetry/Conventions/A2AConventions.cs
@@ -1,0 +1,155 @@
+namespace Domain.AI.Telemetry.Conventions;
+
+/// <summary>
+/// OpenTelemetry semantic-convention attribute, span, and event names for the
+/// harness Agent-to-Agent (A2A) surface (PR-7).
+/// </summary>
+/// <remarks>
+/// <para>
+/// The OTel GenAI semconv (Experimental as of 2026-06) does not yet cover the
+/// A2A protocol. Harness extensions therefore live under
+/// <c>gen_ai.a2a.*</c> — outside the official reserved namespace — and re-export
+/// the spec-covered concepts (system, operation, conversation) from
+/// <see cref="GenAiSemconvRegistry"/>.
+/// </para>
+/// <para>
+/// Span tree:
+/// <list type="bullet">
+/// <item><description><c>a2a.client {callee_id}</c> — emitted by <c>IA2AClient.CallAsync</c> on the caller side, kind <c>Client</c>.</description></item>
+/// <item><description><c>a2a.server {callee_skill}</c> — emitted by <c>IA2AServer</c> dispatch on the callee side, kind <c>Server</c>.</description></item>
+/// </list>
+/// The two spans share <see cref="CorrelationId"/>; the callee span links to the
+/// caller span through standard W3C trace-context propagation, AND through the
+/// correlation id attribute so cross-process logs join even when the trace
+/// context propagator is misconfigured.
+/// </para>
+/// </remarks>
+public static class A2AConventions
+{
+    // ─────────────────────────────────────────────────────────────────────
+    // ActivitySource
+    // ─────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Name of the OTel <see cref="System.Diagnostics.ActivitySource"/> used by
+    /// the A2A client and server emitters. Single source per process; the
+    /// Presentation layer registers this name with the OTel tracer provider.
+    /// </summary>
+    public const string ActivitySourceName = "AgenticHarness.A2A";
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Span names
+    // ─────────────────────────────────────────────────────────────────────
+
+    /// <summary>Span name prefix for the caller-side span. Full name: <c>a2a.client {callee_agent_id}</c>.</summary>
+    public const string SpanNameClientPrefix = "a2a.client ";
+
+    /// <summary>Span name prefix for the callee-side span. Full name: <c>a2a.server {callee_skill}</c>.</summary>
+    public const string SpanNameServerPrefix = "a2a.server ";
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Operation
+    // ─────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Operation value used on both client and server A2A spans. Harness-vendored
+    /// because the OTel GenAI <c>gen_ai.operation.name</c> enum does not yet
+    /// include an A2A operation.
+    /// </summary>
+    public const string OperationInvokeA2A = "invoke_a2a";
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Caller / callee identity (harness-vendored)
+    // ─────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Caller agent identifier on both spans. Sourced from
+    /// <c>IAgentExecutionContext.AgentIdentity.Id</c> at the call site.
+    /// </summary>
+    public const string CallerId = "gen_ai.a2a.caller.id";
+
+    /// <summary>
+    /// Caller agent identity kind on both spans. Sourced from
+    /// <c>IAgentExecutionContext.AgentIdentity.Kind</c>; one of the
+    /// <c>AgentIdentityKind</c> string values.
+    /// </summary>
+    public const string CallerKind = "gen_ai.a2a.caller.kind";
+
+    /// <summary>
+    /// Callee agent identifier on both spans. Resolved by the client before the
+    /// call and confirmed by the server on dispatch.
+    /// </summary>
+    public const string CalleeId = "gen_ai.a2a.callee.id";
+
+    /// <summary>
+    /// Skill name the call is targeting on the callee side. Optional — null for
+    /// calls that target the callee's default skill.
+    /// </summary>
+    public const string CalleeSkill = "gen_ai.a2a.callee.skill";
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Correlation
+    // ─────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Correlation id shared by the caller and callee spans. Stamped by the
+    /// client (UUIDv4) and echoed by the server. Lets log search join the two
+    /// spans even when the W3C trace-context propagator is broken.
+    /// </summary>
+    public const string CorrelationId = "gen_ai.a2a.correlation_id";
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Transport
+    // ─────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Transport used for the call: <see cref="TransportInProcess"/> or
+    /// <see cref="TransportHttp"/>. Distinguishes a same-process A2A hop from
+    /// a cross-process hop so dashboards can filter cleanly.
+    /// </summary>
+    public const string Transport = "gen_ai.a2a.transport";
+
+    /// <summary>Transport value: same-process direct dispatch.</summary>
+    public const string TransportInProcess = "in_process";
+
+    /// <summary>Transport value: HTTP over (m)TLS between processes.</summary>
+    public const string TransportHttp = "http";
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Auth
+    // ─────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Authentication scheme used for the call: <see cref="AuthSchemeInProcess"/>,
+    /// <see cref="AuthSchemeMtlsJwt"/>, or a future scheme name. Allows dashboards
+    /// to alert on calls that fell back to a weaker scheme.
+    /// </summary>
+    public const string AuthScheme = "gen_ai.a2a.auth.scheme";
+
+    /// <summary>Auth-scheme value: ambient identity context trust (in-process only).</summary>
+    public const string AuthSchemeInProcess = "ambient";
+
+    /// <summary>Auth-scheme value: mutual TLS plus workload-identity JWT bearer.</summary>
+    public const string AuthSchemeMtlsJwt = "mtls+jwt";
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Error
+    // ─────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Error code on a failed call: a stable <c>a2a.*</c> identifier such as
+    /// <c>a2a.auth_rejected</c> or <c>a2a.timeout</c>. Server populates this on
+    /// failures; client mirrors the server-supplied code when present.
+    /// </summary>
+    public const string ErrorCode = "gen_ai.a2a.error.code";
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Envelope versioning
+    // ─────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Envelope schema version on both spans. Currently <c>1</c>; bumping the
+    /// envelope shape requires bumping this constant and the version-pin test.
+    /// </summary>
+    public const string EnvelopeVersion = "gen_ai.a2a.envelope.version";
+}

--- a/src/Content/Domain/Domain.AI/Telemetry/Conventions/GenAiSemconvRegistry.cs
+++ b/src/Content/Domain/Domain.AI/Telemetry/Conventions/GenAiSemconvRegistry.cs
@@ -293,4 +293,38 @@ public static class GenAiSemconvRegistry
     /// Re-exported from <see cref="MagenticConventions.ActivitySourceName"/>.
     /// </summary>
     public const string MagenticActivitySourceName = MagenticConventions.ActivitySourceName;
+
+    // ────────────────────────────────────────────────────────────────────
+    // A2A — Agent-to-Agent (re-exported from A2AConventions)
+    // ────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Operation value used on both client and server A2A spans.
+    /// Re-exported from <see cref="A2AConventions.OperationInvokeA2A"/>.
+    /// </summary>
+    public const string OperationInvokeA2A = A2AConventions.OperationInvokeA2A;
+
+    /// <summary>
+    /// Caller agent identifier on A2A spans.
+    /// Re-exported from <see cref="A2AConventions.CallerId"/>.
+    /// </summary>
+    public const string A2ACallerId = A2AConventions.CallerId;
+
+    /// <summary>
+    /// Callee agent identifier on A2A spans.
+    /// Re-exported from <see cref="A2AConventions.CalleeId"/>.
+    /// </summary>
+    public const string A2ACalleeId = A2AConventions.CalleeId;
+
+    /// <summary>
+    /// Correlation id shared by caller and callee A2A spans.
+    /// Re-exported from <see cref="A2AConventions.CorrelationId"/>.
+    /// </summary>
+    public const string A2ACorrelationId = A2AConventions.CorrelationId;
+
+    /// <summary>
+    /// Name of the OTel <c>ActivitySource</c> for A2A client/server spans.
+    /// Re-exported from <see cref="A2AConventions.ActivitySourceName"/>.
+    /// </summary>
+    public const string A2AActivitySourceName = A2AConventions.ActivitySourceName;
 }

--- a/src/Content/Domain/Domain.Common/Config/AI/A2A/A2AConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/A2A/A2AConfig.cs
@@ -22,6 +22,66 @@ public class A2AConfig
 
     /// <summary>Whether A2A is configured with at least one remote agent.</summary>
     public bool HasRemoteAgents => RemoteAgents.Count > 0;
+
+    /// <summary>
+    /// PR-7 surface configuration. Controls which transport
+    /// (in-process vs cross-process) the harness A2A client/server use, and
+    /// the auth settings for the cross-process transport.
+    /// </summary>
+    public A2ASurfaceConfig Surface { get; set; } = new();
+}
+
+/// <summary>
+/// PR-7 A2A surface configuration. Bound from <c>AppConfig:AI:A2A:Surface</c>.
+/// </summary>
+public class A2ASurfaceConfig
+{
+    /// <summary>
+    /// Transport selector. <c>InProcess</c> routes calls through the in-process
+    /// bridge; <c>Http</c> routes calls over HTTP with mutual TLS and a workload
+    /// identity JWT bearer. Default is <c>InProcess</c> so the example demo
+    /// works out of the box without external setup.
+    /// </summary>
+    public A2ATransport Transport { get; set; } = A2ATransport.InProcess;
+
+    /// <summary>
+    /// Required audience claim ("aud") for inbound JWTs on the cross-process
+    /// server. Typically this agent's Entra application uri. Null when the
+    /// transport is <see cref="A2ATransport.InProcess"/>.
+    /// </summary>
+    public string? ExpectedAudience { get; set; }
+
+    /// <summary>
+    /// Expected issuer claim ("iss") for inbound JWTs. Typically the harness
+    /// identity provider's discovery endpoint. Null in the in-process transport.
+    /// </summary>
+    public string? ExpectedIssuer { get; set; }
+
+    /// <summary>
+    /// Clock skew tolerance in seconds when validating JWT expiry. Set to 0 on
+    /// the cross-process path per the security playbook — never widen this
+    /// without a recorded design decision.
+    /// </summary>
+    public int ClockSkewSeconds { get; set; }
+
+    /// <summary>
+    /// Maximum number of extension headers permitted on a single envelope. Caps
+    /// the server's deserialisation work and shields against malicious payload
+    /// inflation. Defaults to 16.
+    /// </summary>
+    public int MaxExtensionHeaders { get; set; } = 16;
+}
+
+/// <summary>
+/// Transport selector for the PR-7 A2A surface.
+/// </summary>
+public enum A2ATransport
+{
+    /// <summary>Same-process dispatch via the in-process bridge.</summary>
+    InProcess = 0,
+
+    /// <summary>Cross-process dispatch over HTTP with mTLS + workload-identity JWT.</summary>
+    Http = 1
 }
 
 /// <summary>

--- a/src/Content/Infrastructure/Infrastructure.AI/A2A/A2AIdentityPropagator.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/A2A/A2AIdentityPropagator.cs
@@ -1,0 +1,77 @@
+using Application.AI.Common.Interfaces.Agent;
+using Domain.AI.A2A;
+using Domain.AI.Identity;
+
+namespace Infrastructure.AI.A2A;
+
+/// <summary>
+/// Bridges agent identity between the ambient
+/// <see cref="IAgentExecutionContext"/> and the wire-shape
+/// <see cref="A2AEnvelope"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Used by both client (caller) and server (callee) sides:
+/// </para>
+/// <list type="bullet">
+/// <item><description>Client: <see cref="StampOutboundIdentity"/> reads the
+/// ambient <see cref="AgentIdentity"/> and writes its id/kind onto a fresh
+/// envelope. Throws when no identity is set — outbound A2A without an
+/// identity is a contract violation; fail loud at the call site.</description></item>
+/// <item><description>Server: <see cref="EstablishInboundIdentity"/> wraps a
+/// <see cref="IAgentExecutionContext.SetIdentity"/> call so the inbound caller
+/// id becomes the ambient identity for the duration of the skill handler.
+/// The previous identity (if any) is preserved by the scoped DI lifetime.</description></item>
+/// </list>
+/// </remarks>
+public sealed class A2AIdentityPropagator
+{
+    private readonly IAgentExecutionContext _executionContext;
+
+    /// <summary>Creates a new propagator.</summary>
+    /// <param name="executionContext">Ambient agent execution context.</param>
+    public A2AIdentityPropagator(IAgentExecutionContext executionContext)
+    {
+        _executionContext = executionContext;
+    }
+
+    /// <summary>
+    /// Reads the ambient agent identity and returns its <c>(callerAgentId, callerKind)</c>
+    /// pair for inclusion in an outbound envelope.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">No ambient agent identity is set.</exception>
+    public (string CallerAgentId, string CallerKind) StampOutboundIdentity()
+    {
+        var identity = _executionContext.AgentIdentity
+            ?? throw new InvalidOperationException(
+                "A2A call attempted with no ambient agent identity. " +
+                "Calls must originate from within an agent execution scope established by AgentFactory.");
+
+        return (identity.Id, identity.Kind.ToString());
+    }
+
+    /// <summary>
+    /// Establishes the inbound caller's identity on the ambient execution
+    /// context for the duration of the call.
+    /// </summary>
+    /// <param name="authoritativeCallerId">The caller id confirmed by the auth provider.</param>
+    /// <param name="envelope">The envelope as received.</param>
+    public void EstablishInboundIdentity(string authoritativeCallerId, A2AEnvelope envelope)
+    {
+        if (envelope is null) throw new ArgumentNullException(nameof(envelope));
+        if (string.IsNullOrEmpty(authoritativeCallerId))
+            throw new ArgumentException("Caller id is required.", nameof(authoritativeCallerId));
+
+        var kind = Enum.TryParse<AgentIdentityKind>(envelope.CallerKind, out var parsed)
+            ? parsed
+            : AgentIdentityKind.Unspecified;
+
+        var identity = new AgentIdentity
+        {
+            Id = authoritativeCallerId,
+            Kind = kind
+        };
+
+        _executionContext.SetIdentity(identity);
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/A2A/A2ASpanEmitter.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/A2A/A2ASpanEmitter.cs
@@ -1,0 +1,115 @@
+using System.Diagnostics;
+using Domain.AI.A2A;
+using Domain.AI.Telemetry.Conventions;
+
+namespace Infrastructure.AI.A2A;
+
+/// <summary>
+/// Owns the OTel <see cref="ActivitySource"/> for the A2A surface and stamps
+/// caller/callee/correlation attributes on both the client-side
+/// (<c>a2a.client {callee}</c>) and server-side (<c>a2a.server {skill}</c>)
+/// spans.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Single source per process: <see cref="A2AConventions.ActivitySourceName"/>.
+/// Presentation registers this name with the OTel tracer provider.
+/// </para>
+/// <para>
+/// Span kind is <see cref="ActivityKind.Client"/> on the caller side and
+/// <see cref="ActivityKind.Server"/> on the callee side so downstream
+/// processors can tier-sample on the two surfaces independently.
+/// </para>
+/// </remarks>
+public sealed class A2ASpanEmitter : IDisposable
+{
+    private readonly ActivitySource _source;
+
+    /// <summary>
+    /// Creates an emitter with an <see cref="ActivitySource"/> named
+    /// <see cref="A2AConventions.ActivitySourceName"/>.
+    /// </summary>
+    public A2ASpanEmitter()
+    {
+        _source = new ActivitySource(A2AConventions.ActivitySourceName);
+    }
+
+    /// <summary>
+    /// Starts the caller-side <c>a2a.client {callee_agent_id}</c> span and
+    /// stamps caller/callee/correlation/transport/auth attributes.
+    /// </summary>
+    public Activity? StartClientSpan(
+        A2AEnvelope envelope,
+        string transport,
+        string authScheme)
+    {
+        if (envelope is null) throw new ArgumentNullException(nameof(envelope));
+
+        var activity = _source.StartActivity(
+            $"{A2AConventions.SpanNameClientPrefix}{envelope.CalleeAgentId}",
+            ActivityKind.Client);
+        if (activity is null) return null;
+
+        StampCommonAttributes(activity, envelope, transport, authScheme);
+        return activity;
+    }
+
+    /// <summary>
+    /// Starts the callee-side <c>a2a.server {callee_skill}</c> span as a child
+    /// of the propagated trace context.
+    /// </summary>
+    public Activity? StartServerSpan(
+        A2AEnvelope envelope,
+        string transport,
+        string authScheme)
+    {
+        if (envelope is null) throw new ArgumentNullException(nameof(envelope));
+
+        var spanName = envelope.CalleeSkill is null
+            ? $"{A2AConventions.SpanNameServerPrefix}{envelope.CalleeAgentId}"
+            : $"{A2AConventions.SpanNameServerPrefix}{envelope.CalleeSkill}";
+
+        var activity = _source.StartActivity(spanName, ActivityKind.Server);
+        if (activity is null) return null;
+
+        StampCommonAttributes(activity, envelope, transport, authScheme);
+        return activity;
+    }
+
+    /// <summary>
+    /// Closes a span with an error status when the call failed. The error code
+    /// is also stamped as <c>gen_ai.a2a.error.code</c> so dashboards can
+    /// alert on specific failure modes.
+    /// </summary>
+    public static void EndWithError(Activity? span, string errorCode, string? errorMessage)
+    {
+        if (span is null) return;
+        span.SetTag(A2AConventions.ErrorCode, errorCode);
+        span.SetTag(GenAiSemconvRegistry.ErrorType, errorCode);
+        span.SetStatus(ActivityStatusCode.Error, errorMessage);
+        span.Dispose();
+    }
+
+    /// <summary>Disposes the underlying <see cref="ActivitySource"/>.</summary>
+    public void Dispose() => _source.Dispose();
+
+    private static void StampCommonAttributes(
+        Activity activity,
+        A2AEnvelope envelope,
+        string transport,
+        string authScheme)
+    {
+        activity.SetTag(GenAiSemconvRegistry.OperationName, A2AConventions.OperationInvokeA2A);
+        activity.SetTag(A2AConventions.CorrelationId, envelope.CorrelationId);
+        activity.SetTag(A2AConventions.CallerId, envelope.CallerAgentId);
+        activity.SetTag(A2AConventions.CallerKind, envelope.CallerKind);
+        activity.SetTag(A2AConventions.CalleeId, envelope.CalleeAgentId);
+        if (envelope.CalleeSkill is not null)
+        {
+            activity.SetTag(A2AConventions.CalleeSkill, envelope.CalleeSkill);
+        }
+        activity.SetTag(A2AConventions.Transport, transport);
+        activity.SetTag(A2AConventions.AuthScheme, authScheme);
+        activity.SetTag(A2AConventions.EnvelopeVersion, envelope.SchemaVersion);
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/A2A/CrossProcessA2AAuthenticationProvider.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/A2A/CrossProcessA2AAuthenticationProvider.cs
@@ -1,0 +1,120 @@
+using Application.AI.Common.Interfaces.A2A;
+using Domain.AI.A2A;
+using Domain.AI.Telemetry.Conventions;
+using Domain.Common;
+using Microsoft.Extensions.Logging;
+
+namespace Infrastructure.AI.A2A;
+
+/// <summary>
+/// Cross-process implementation of <see cref="IA2AAuthenticationProvider"/>.
+/// Stamps an outbound <c>Authorization: Bearer &lt;jwt&gt;</c> header on the
+/// caller side and validates the inbound JWT on the server side via the
+/// registered <see cref="IA2ATokenAcquirer"/> / <see cref="IA2ATokenValidator"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The full validation chain on the server side runs in this order: (1) mTLS
+/// peer-cert acceptance happens at the Kestrel listener BEFORE the request
+/// reaches the harness — Kestrel hands us an already-authenticated client
+/// connection; (2) this provider validates the JWT signature, issuer,
+/// audience, expiry; (3) the JWT <c>sub</c> claim becomes the
+/// authoritative caller id (overriding whatever the envelope declared); (4)
+/// the server compares the JWT sub against the envelope's declared
+/// <c>callerAgentId</c> and rejects mismatches as <c>a2a.auth_rejected</c>.
+/// </para>
+/// <para>
+/// Authoritative caller id from JWT — not the envelope — protects against a
+/// caller that holds a valid token for agent A but tries to declare itself
+/// as agent B in the envelope payload.
+/// </para>
+/// </remarks>
+public sealed class CrossProcessA2AAuthenticationProvider : IA2AAuthenticationProvider
+{
+    private const string AuthorizationHeader = "Authorization";
+    private const string BearerScheme = "Bearer ";
+
+    private readonly IA2ATokenAcquirer _tokenAcquirer;
+    private readonly IA2ATokenValidator _tokenValidator;
+    private readonly ILogger<CrossProcessA2AAuthenticationProvider> _logger;
+
+    /// <summary>Creates a new cross-process auth provider.</summary>
+    /// <param name="tokenAcquirer">Consumer-supplied JWT acquisition strategy.</param>
+    /// <param name="tokenValidator">Consumer-supplied JWT validation strategy.</param>
+    /// <param name="logger">Logger for diagnostics. Exception text is logged here, never on the wire.</param>
+    public CrossProcessA2AAuthenticationProvider(
+        IA2ATokenAcquirer tokenAcquirer,
+        IA2ATokenValidator tokenValidator,
+        ILogger<CrossProcessA2AAuthenticationProvider> logger)
+    {
+        _tokenAcquirer = tokenAcquirer;
+        _tokenValidator = tokenValidator;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public string SchemeName => A2AConventions.AuthSchemeMtlsJwt;
+
+    /// <inheritdoc />
+    public async Task<Result<IReadOnlyDictionary<string, string>>> StampOutboundCredentialsAsync(
+        A2AEnvelope envelope,
+        CancellationToken cancellationToken)
+    {
+        if (envelope is null) throw new ArgumentNullException(nameof(envelope));
+
+        var tokenResult = await _tokenAcquirer.AcquireAsync(envelope, cancellationToken).ConfigureAwait(false);
+        if (!tokenResult.IsSuccess)
+        {
+            _logger.LogWarning(
+                "A2A token acquisition failed for caller {CallerId}: {Errors}",
+                envelope.CallerAgentId,
+                string.Join(',', tokenResult.Errors));
+            return Result<IReadOnlyDictionary<string, string>>.Fail(tokenResult.Errors.ToArray());
+        }
+
+        IReadOnlyDictionary<string, string> headers = new Dictionary<string, string>
+        {
+            [AuthorizationHeader] = BearerScheme + tokenResult.Value
+        };
+        return Result<IReadOnlyDictionary<string, string>>.Success(headers);
+    }
+
+    /// <inheritdoc />
+    public async Task<Result<string>> ValidateInboundAsync(
+        A2AEnvelope envelope,
+        IReadOnlyDictionary<string, string> transportHeaders,
+        CancellationToken cancellationToken)
+    {
+        if (envelope is null) throw new ArgumentNullException(nameof(envelope));
+        if (transportHeaders is null) throw new ArgumentNullException(nameof(transportHeaders));
+
+        if (!transportHeaders.TryGetValue(AuthorizationHeader, out var authHeader) ||
+            string.IsNullOrEmpty(authHeader) ||
+            !authHeader.StartsWith(BearerScheme, StringComparison.Ordinal))
+        {
+            return Result<string>.Fail("a2a.auth_rejected");
+        }
+
+        var jwt = authHeader[BearerScheme.Length..];
+        var validation = await _tokenValidator.ValidateAsync(jwt, cancellationToken).ConfigureAwait(false);
+        if (!validation.IsSuccess)
+        {
+            // Errors already scrubbed by the validator.
+            return Result<string>.Fail(validation.Errors.ToArray());
+        }
+
+        // JWT sub is authoritative — reject if the envelope declared a different
+        // caller. This prevents a holder of token-for-A from masquerading as
+        // agent B in the envelope payload.
+        if (!string.Equals(validation.Value, envelope.CallerAgentId, StringComparison.Ordinal))
+        {
+            _logger.LogWarning(
+                "A2A envelope caller {Declared} does not match JWT sub {Authoritative}",
+                envelope.CallerAgentId,
+                validation.Value);
+            return Result<string>.Fail("a2a.auth_rejected");
+        }
+
+        return Result<string>.Success(validation.Value!);
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/A2A/HarnessA2AClient.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/A2A/HarnessA2AClient.cs
@@ -1,0 +1,202 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using Application.AI.Common.Interfaces.A2A;
+using Domain.AI.A2A;
+using Domain.AI.Telemetry.Conventions;
+using Domain.Common;
+using Domain.Common.Config;
+using Domain.Common.Config.AI.A2A;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Infrastructure.AI.A2A;
+
+/// <summary>
+/// Production implementation of <see cref="IA2AClient"/>. Stamps caller
+/// identity + correlation id onto the envelope, opens the
+/// <c>a2a.client {callee}</c> span, and dispatches to either the in-process
+/// server bridge or the cross-process HTTP transport based on
+/// <see cref="A2ASurfaceConfig.Transport"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Same call-site shape for both transports — flipping
+/// <c>AppConfig.AI.A2A.Surface.Transport</c> from <c>InProcess</c> to
+/// <c>Http</c> moves the callee out of process without changing any handler
+/// code. This is the core PR-7 invariant.
+/// </para>
+/// </remarks>
+public sealed class HarnessA2AClient : IA2AClient
+{
+    /// <summary>HttpClient logical name used by the client.</summary>
+    public const string HttpClientName = "A2A.Harness";
+
+    private static readonly JsonSerializerOptions _jsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = false,
+        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull
+    };
+
+    private readonly IA2AServer _localServer;
+    private readonly IA2AAuthenticationProvider _authProvider;
+    private readonly A2ASpanEmitter _spanEmitter;
+    private readonly A2AIdentityPropagator _identityPropagator;
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly IOptionsMonitor<AppConfig> _appConfig;
+    private readonly ILogger<HarnessA2AClient> _logger;
+
+    /// <summary>Creates a new client.</summary>
+    public HarnessA2AClient(
+        IA2AServer localServer,
+        IA2AAuthenticationProvider authProvider,
+        A2ASpanEmitter spanEmitter,
+        A2AIdentityPropagator identityPropagator,
+        IHttpClientFactory httpClientFactory,
+        IOptionsMonitor<AppConfig> appConfig,
+        ILogger<HarnessA2AClient> logger)
+    {
+        _localServer = localServer;
+        _authProvider = authProvider;
+        _spanEmitter = spanEmitter;
+        _identityPropagator = identityPropagator;
+        _httpClientFactory = httpClientFactory;
+        _appConfig = appConfig;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<Result<A2AResponse>> CallAsync(A2ARequest request, CancellationToken cancellationToken)
+    {
+        if (request is null) throw new ArgumentNullException(nameof(request));
+
+        var envelope = EnsureEnvelopeStamped(request.Envelope);
+        var stampedRequest = request with { Envelope = envelope };
+
+        var surfaceConfig = _appConfig.CurrentValue.AI.A2A.Surface;
+        var transport = surfaceConfig.Transport == A2ATransport.InProcess
+            ? A2AConventions.TransportInProcess
+            : A2AConventions.TransportHttp;
+
+        using var clientSpan = _spanEmitter.StartClientSpan(envelope, transport, _authProvider.SchemeName);
+
+        var credentials = await _authProvider
+            .StampOutboundCredentialsAsync(envelope, cancellationToken)
+            .ConfigureAwait(false);
+        if (!credentials.IsSuccess)
+        {
+            var code = credentials.Errors.Count > 0 ? credentials.Errors[0] : "a2a.auth_acquisition_failed";
+            A2ASpanEmitter.EndWithError(clientSpan, code, null);
+            return Result<A2AResponse>.Fail(code);
+        }
+
+        return surfaceConfig.Transport switch
+        {
+            A2ATransport.InProcess => await DispatchInProcessAsync(stampedRequest, cancellationToken).ConfigureAwait(false),
+            A2ATransport.Http => await DispatchHttpAsync(stampedRequest, credentials.Value!, cancellationToken).ConfigureAwait(false),
+            _ => Result<A2AResponse>.Fail("a2a.unknown_transport")
+        };
+    }
+
+    private A2AEnvelope EnsureEnvelopeStamped(A2AEnvelope envelope)
+    {
+        var (callerId, callerKind) = string.IsNullOrEmpty(envelope.CallerAgentId)
+            ? _identityPropagator.StampOutboundIdentity()
+            : (envelope.CallerAgentId, envelope.CallerKind);
+
+        return envelope with
+        {
+            SchemaVersion = envelope.SchemaVersion == 0 ? A2AEnvelope.CurrentSchemaVersion : envelope.SchemaVersion,
+            CorrelationId = string.IsNullOrEmpty(envelope.CorrelationId)
+                ? Guid.NewGuid().ToString("N")
+                : envelope.CorrelationId,
+            CallerAgentId = callerId,
+            CallerKind = callerKind
+        };
+    }
+
+    private async Task<Result<A2AResponse>> DispatchInProcessAsync(
+        A2ARequest stampedRequest,
+        CancellationToken cancellationToken)
+    {
+        // In-process bridge: same JSON shape, no HTTP. The server side still
+        // runs through the full pipeline (auth provider, identity propagator,
+        // span emitter) so behaviour is identical to the HTTP path.
+        return await _localServer.DispatchAsync(stampedRequest, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<Result<A2AResponse>> DispatchHttpAsync(
+        A2ARequest stampedRequest,
+        IReadOnlyDictionary<string, string> credentialHeaders,
+        CancellationToken cancellationToken)
+    {
+        var remoteUrl = ResolveRemoteUrl(stampedRequest.Envelope.CalleeAgentId);
+        if (remoteUrl is null)
+        {
+            return Result<A2AResponse>.Fail("a2a.unknown_callee");
+        }
+
+        using var http = _httpClientFactory.CreateClient(HttpClientName);
+        using var content = JsonContent.Create(stampedRequest, options: _jsonOptions);
+        using var httpRequest = new HttpRequestMessage(HttpMethod.Post, $"{remoteUrl.TrimEnd('/')}/a2a/dispatch")
+        {
+            Content = content
+        };
+
+        foreach (var (header, value) in credentialHeaders)
+        {
+            httpRequest.Headers.TryAddWithoutValidation(header, value);
+        }
+
+        try
+        {
+            using var httpResponse = await http.SendAsync(httpRequest, cancellationToken).ConfigureAwait(false);
+
+            if (httpResponse.StatusCode == System.Net.HttpStatusCode.Unauthorized ||
+                httpResponse.StatusCode == System.Net.HttpStatusCode.Forbidden)
+            {
+                return Result<A2AResponse>.Success(A2AResponse.Fail(
+                    stampedRequest.Envelope.CorrelationId,
+                    "a2a.auth_rejected"));
+            }
+
+            if (!httpResponse.IsSuccessStatusCode)
+            {
+                return Result<A2AResponse>.Fail($"a2a.http_{(int)httpResponse.StatusCode}");
+            }
+
+            var body = await httpResponse.Content
+                .ReadFromJsonAsync<A2AResponse>(_jsonOptions, cancellationToken)
+                .ConfigureAwait(false);
+            if (body is null)
+            {
+                return Result<A2AResponse>.Fail("a2a.bad_response");
+            }
+
+            return Result<A2AResponse>.Success(body);
+        }
+        catch (OperationCanceledException)
+        {
+            return Result<A2AResponse>.Fail("a2a.cancelled");
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogWarning(ex,
+                "A2A HTTP dispatch to {Callee} failed",
+                stampedRequest.Envelope.CalleeAgentId);
+            return Result<A2AResponse>.Fail("a2a.transport_failure");
+        }
+    }
+
+    private string? ResolveRemoteUrl(string calleeAgentId)
+    {
+        var remotes = _appConfig.CurrentValue.AI.A2A.RemoteAgents;
+        for (var i = 0; i < remotes.Count; i++)
+        {
+            if (string.Equals(remotes[i].Name, calleeAgentId, StringComparison.Ordinal))
+            {
+                return remotes[i].Url;
+            }
+        }
+        return null;
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/A2A/HarnessA2AServer.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/A2A/HarnessA2AServer.cs
@@ -1,0 +1,179 @@
+using System.Collections.Generic;
+using Application.AI.Common.Interfaces.A2A;
+using Domain.AI.A2A;
+using Domain.AI.Telemetry.Conventions;
+using Domain.Common;
+using Domain.Common.Config;
+using Domain.Common.Config.AI.A2A;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Infrastructure.AI.A2A;
+
+/// <summary>
+/// Production implementation of <see cref="IA2AServer"/>. Authenticates the
+/// inbound envelope, establishes the caller's identity on the ambient
+/// execution context, resolves the local skill handler by keyed DI, runs it
+/// inside an <c>a2a.server</c> span, and returns the response.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The server is transport-neutral: the in-process bridge and the HTTP
+/// listener both terminate here with an already-parsed
+/// <see cref="A2ARequest"/> and a transport-headers dictionary. The auth
+/// provider is responsible for picking the right credential to validate.
+/// </para>
+/// <para>
+/// Skill handler lookup precedence: when
+/// <see cref="A2AEnvelope.CalleeSkill"/> is non-null, the server looks up the
+/// keyed service registered under <c>"{calleeAgentId}:{calleeSkill}"</c>;
+/// when null, it falls back to <c>"{calleeAgentId}"</c>. Missing handlers
+/// return a stable <c>a2a.skill_not_found</c> code.
+/// </para>
+/// </remarks>
+public sealed class HarnessA2AServer : IA2AServer
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly IA2AAuthenticationProvider _authProvider;
+    private readonly A2ASpanEmitter _spanEmitter;
+    private readonly A2AIdentityPropagator _identityPropagator;
+    private readonly IOptionsMonitor<AppConfig> _appConfig;
+    private readonly ILogger<HarnessA2AServer> _logger;
+
+    /// <summary>Creates a new server.</summary>
+    public HarnessA2AServer(
+        IServiceProvider serviceProvider,
+        IA2AAuthenticationProvider authProvider,
+        A2ASpanEmitter spanEmitter,
+        A2AIdentityPropagator identityPropagator,
+        IOptionsMonitor<AppConfig> appConfig,
+        ILogger<HarnessA2AServer> logger)
+    {
+        _serviceProvider = serviceProvider;
+        _authProvider = authProvider;
+        _spanEmitter = spanEmitter;
+        _identityPropagator = identityPropagator;
+        _appConfig = appConfig;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Convenience overload for transports that have no auxiliary header
+    /// dictionary (in-process bridge).
+    /// </summary>
+    public Task<Result<A2AResponse>> DispatchAsync(A2ARequest request, CancellationToken cancellationToken)
+        => DispatchAsync(request, EmptyHeaders, cancellationToken);
+
+    /// <summary>
+    /// Dispatches a single inbound A2A request, given a transport-headers
+    /// dictionary so cross-process transports can hand the auth provider what
+    /// it needs to validate.
+    /// </summary>
+    public async Task<Result<A2AResponse>> DispatchAsync(
+        A2ARequest request,
+        IReadOnlyDictionary<string, string> transportHeaders,
+        CancellationToken cancellationToken)
+    {
+        if (request is null) throw new ArgumentNullException(nameof(request));
+        if (transportHeaders is null) throw new ArgumentNullException(nameof(transportHeaders));
+
+        var envelope = request.Envelope;
+
+        if (envelope.SchemaVersion != A2AEnvelope.CurrentSchemaVersion)
+        {
+            return Result<A2AResponse>.Success(A2AResponse.Fail(
+                envelope.CorrelationId,
+                "a2a.unsupported_envelope_version",
+                $"server supports envelope version {A2AEnvelope.CurrentSchemaVersion}"));
+        }
+
+        var surfaceConfig = _appConfig.CurrentValue.AI.A2A.Surface;
+        if (envelope.Extensions is not null && envelope.Extensions.Count > surfaceConfig.MaxExtensionHeaders)
+        {
+            return Result<A2AResponse>.Success(A2AResponse.Fail(
+                envelope.CorrelationId,
+                "a2a.too_many_extensions"));
+        }
+
+        var transport = transportHeaders.Count == 0
+            ? A2AConventions.TransportInProcess
+            : A2AConventions.TransportHttp;
+
+        using var serverSpan = _spanEmitter.StartServerSpan(envelope, transport, _authProvider.SchemeName);
+
+        var authResult = await _authProvider
+            .ValidateInboundAsync(envelope, transportHeaders, cancellationToken)
+            .ConfigureAwait(false);
+        if (!authResult.IsSuccess)
+        {
+            var code = authResult.Errors.Count > 0 ? authResult.Errors[0] : "a2a.auth_rejected";
+            A2ASpanEmitter.EndWithError(serverSpan, code, null);
+            return Result<A2AResponse>.Success(A2AResponse.Fail(envelope.CorrelationId, code));
+        }
+
+        try
+        {
+            _identityPropagator.EstablishInboundIdentity(authResult.Value!, envelope);
+        }
+        catch (InvalidOperationException ex)
+        {
+            // Scope leak: someone routed the call into a scope that already
+            // has a different identity. This is a server-side bug — log and
+            // return a stable code.
+            _logger.LogError(ex, "A2A identity establishment failed (scope conflict).");
+            A2ASpanEmitter.EndWithError(serverSpan, "a2a.identity_conflict", null);
+            return Result<A2AResponse>.Success(A2AResponse.Fail(envelope.CorrelationId, "a2a.identity_conflict"));
+        }
+
+        var handler = ResolveHandler(envelope);
+        if (handler is null)
+        {
+            A2ASpanEmitter.EndWithError(serverSpan, "a2a.skill_not_found", null);
+            return Result<A2AResponse>.Success(A2AResponse.Fail(envelope.CorrelationId, "a2a.skill_not_found"));
+        }
+
+        try
+        {
+            var handlerResult = await handler.HandleAsync(request, cancellationToken).ConfigureAwait(false);
+            if (!handlerResult.IsSuccess)
+            {
+                var code = handlerResult.Errors.Count > 0 ? handlerResult.Errors[0] : "a2a.skill_failed";
+                A2ASpanEmitter.EndWithError(serverSpan, code, null);
+                return Result<A2AResponse>.Success(A2AResponse.Fail(envelope.CorrelationId, code));
+            }
+            return Result<A2AResponse>.Success(handlerResult.Value!);
+        }
+        catch (OperationCanceledException)
+        {
+            A2ASpanEmitter.EndWithError(serverSpan, "a2a.cancelled", null);
+            return Result<A2AResponse>.Fail("a2a.cancelled");
+        }
+        catch (Exception ex)
+        {
+            // NEVER return ex.Message — may carry sensitive context. Log via
+            // structured logging, return a stable code.
+            _logger.LogError(ex,
+                "A2A skill handler threw for caller {Caller} -> callee {Callee} / skill {Skill}",
+                envelope.CallerAgentId,
+                envelope.CalleeAgentId,
+                envelope.CalleeSkill);
+            A2ASpanEmitter.EndWithError(serverSpan, "a2a.skill_failed", null);
+            return Result<A2AResponse>.Success(A2AResponse.Fail(envelope.CorrelationId, "a2a.skill_failed"));
+        }
+    }
+
+    private IA2ASkillHandler? ResolveHandler(A2AEnvelope envelope)
+    {
+        if (envelope.CalleeSkill is not null)
+        {
+            var keyed = _serviceProvider.GetKeyedService<IA2ASkillHandler>(
+                $"{envelope.CalleeAgentId}:{envelope.CalleeSkill}");
+            if (keyed is not null) return keyed;
+        }
+        return _serviceProvider.GetKeyedService<IA2ASkillHandler>(envelope.CalleeAgentId);
+    }
+
+    private static readonly IReadOnlyDictionary<string, string> EmptyHeaders =
+        new Dictionary<string, string>();
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/A2A/IA2ATokenAcquirer.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/A2A/IA2ATokenAcquirer.cs
@@ -1,0 +1,32 @@
+using Domain.AI.A2A;
+using Domain.Common;
+
+namespace Infrastructure.AI.A2A;
+
+/// <summary>
+/// Acquires a workload-identity JWT for an outbound A2A call. Implemented by the
+/// consumer (e.g. via Azure.Identity DefaultAzureCredential for Entra-backed
+/// agents) so the harness does not lock the consumer into a specific token
+/// source.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The cross-process auth provider invokes this once per outbound call. The
+/// returned token MUST be a JWT whose "sub" claim names the calling agent and
+/// whose "aud" claim matches the callee's configured
+/// <c>A2ASurfaceConfig.ExpectedAudience</c>. Tokens that fail those checks on
+/// the server side surface as <c>a2a.auth_rejected</c>.
+/// </para>
+/// </remarks>
+public interface IA2ATokenAcquirer
+{
+    /// <summary>
+    /// Acquires a workload identity JWT for the given outbound envelope.
+    /// </summary>
+    /// <param name="envelope">The envelope being sent. Used to derive the
+    /// caller subject and target audience.</param>
+    /// <param name="cancellationToken">Cooperative cancellation token.</param>
+    /// <returns>The bearer JWT as a string, or a stable <c>a2a.*</c> failure
+    /// code on acquisition failure.</returns>
+    Task<Result<string>> AcquireAsync(A2AEnvelope envelope, CancellationToken cancellationToken);
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/A2A/IA2ATokenValidator.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/A2A/IA2ATokenValidator.cs
@@ -1,0 +1,38 @@
+using Domain.Common;
+
+namespace Infrastructure.AI.A2A;
+
+/// <summary>
+/// Validates an inbound workload-identity JWT on the server side. Consumer
+/// implements (e.g. via <c>Microsoft.IdentityModel.Tokens</c>) so the harness
+/// does not pin a specific JWT library.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Implementations MUST validate:
+/// </para>
+/// <list type="bullet">
+/// <item><description>signature against the configured key material;</description></item>
+/// <item><description><c>iss</c> against <c>A2ASurfaceConfig.ExpectedIssuer</c>;</description></item>
+/// <item><description><c>aud</c> against <c>A2ASurfaceConfig.ExpectedAudience</c>;</description></item>
+/// <item><description><c>exp</c> with clock skew = <c>A2ASurfaceConfig.ClockSkewSeconds</c>;</description></item>
+/// <item><description>token revocation status, if a revocation list is configured.</description></item>
+/// </list>
+/// <para>
+/// Returns the JWT's <c>sub</c> claim — the authenticated caller agent id —
+/// on success. Failures surface as stable <c>a2a.auth_rejected</c> codes; the
+/// underlying exception is logged via structured logging on the server side
+/// and never returned over the wire.
+/// </para>
+/// </remarks>
+public interface IA2ATokenValidator
+{
+    /// <summary>
+    /// Validates the bearer JWT and returns the authenticated caller agent id.
+    /// </summary>
+    /// <param name="jwt">The bearer JWT lifted from the <c>Authorization</c> header.</param>
+    /// <param name="cancellationToken">Cooperative cancellation token.</param>
+    /// <returns>The authenticated caller agent id (<c>sub</c> claim) on success,
+    /// or <see cref="Result.Fail(string[])"/> with a stable <c>a2a.*</c> code.</returns>
+    Task<Result<string>> ValidateAsync(string jwt, CancellationToken cancellationToken);
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/A2A/InProcessA2AAuthenticationProvider.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/A2A/InProcessA2AAuthenticationProvider.cs
@@ -1,0 +1,80 @@
+using Application.AI.Common.Interfaces.A2A;
+using Application.AI.Common.Interfaces.Agent;
+using Domain.AI.A2A;
+using Domain.AI.Telemetry.Conventions;
+using Domain.Common;
+
+namespace Infrastructure.AI.A2A;
+
+/// <summary>
+/// In-process implementation of <see cref="IA2AAuthenticationProvider"/>. Trusts
+/// the ambient <see cref="IAgentExecutionContext.AgentIdentity"/> — no transport
+/// credentials are stamped or verified because the call never leaves the
+/// process boundary.
+/// </summary>
+/// <remarks>
+/// <para>
+/// "Trust the ambient identity" is only safe inside the same process: the
+/// caller and callee share a memory-protected address space and the identity
+/// on the execution context was established by a trusted-path component
+/// (typically <c>AgentFactory</c>). The moment a call crosses a process
+/// boundary, <see cref="CrossProcessA2AAuthenticationProvider"/> takes over.
+/// </para>
+/// <para>
+/// The provider rejects calls where the envelope's <c>callerAgentId</c> does
+/// not match the ambient identity. Such a mismatch indicates either a coding
+/// bug (the caller forged the envelope) or a scope leak.
+/// </para>
+/// </remarks>
+public sealed class InProcessA2AAuthenticationProvider : IA2AAuthenticationProvider
+{
+    private static readonly IReadOnlyDictionary<string, string> _empty =
+        new Dictionary<string, string>();
+
+    private readonly IAgentExecutionContext _executionContext;
+
+    /// <summary>Creates a new in-process auth provider.</summary>
+    /// <param name="executionContext">Ambient agent execution context.</param>
+    public InProcessA2AAuthenticationProvider(IAgentExecutionContext executionContext)
+    {
+        _executionContext = executionContext;
+    }
+
+    /// <inheritdoc />
+    public string SchemeName => A2AConventions.AuthSchemeInProcess;
+
+    /// <inheritdoc />
+    public Task<Result<IReadOnlyDictionary<string, string>>> StampOutboundCredentialsAsync(
+        A2AEnvelope envelope,
+        CancellationToken cancellationToken)
+    {
+        // No credentials to stamp — the in-process bridge passes the envelope
+        // directly to the server side. The envelope's CallerAgentId is the
+        // sole identity proof.
+        if (envelope is null) throw new ArgumentNullException(nameof(envelope));
+
+        return Task.FromResult(Result<IReadOnlyDictionary<string, string>>.Success(_empty));
+    }
+
+    /// <inheritdoc />
+    public Task<Result<string>> ValidateInboundAsync(
+        A2AEnvelope envelope,
+        IReadOnlyDictionary<string, string> transportHeaders,
+        CancellationToken cancellationToken)
+    {
+        if (envelope is null) throw new ArgumentNullException(nameof(envelope));
+
+        // The ambient identity is the source of truth in-process. If it is
+        // missing the call was made from outside an agent execution scope —
+        // that is allowed (tools and CLI bootstraps), but the envelope's
+        // declared caller id is then the only identity we have. If it IS
+        // present, it MUST match the envelope.
+        var ambient = _executionContext.AgentIdentity;
+        if (ambient is not null && !string.Equals(ambient.Id, envelope.CallerAgentId, StringComparison.Ordinal))
+        {
+            return Task.FromResult(Result<string>.Fail("a2a.auth_rejected"));
+        }
+
+        return Task.FromResult(Result<string>.Success(envelope.CallerAgentId));
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.A2A.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.A2A.cs
@@ -1,0 +1,65 @@
+using Application.AI.Common.Interfaces.A2A;
+using Domain.Common.Config;
+using Domain.Common.Config.AI.A2A;
+using Infrastructure.AI.A2A;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace Infrastructure.AI;
+
+public static partial class DependencyInjection
+{
+    /// <summary>
+    /// Registers the PR-7 A2A surface: client, server, span emitter, identity
+    /// propagator, and the configured auth provider.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Auth provider selection runs at DI registration time, not per call: the
+    /// in-process provider has no transport credentials to stamp; the
+    /// cross-process provider acquires JWTs. Mixing them in a single process
+    /// would either leak credentials onto in-process calls (waste + audit
+    /// noise) or strip them from cross-process calls (auth failure). One
+    /// provider per process.
+    /// </para>
+    /// <para>
+    /// The cross-process provider depends on consumer-supplied
+    /// <see cref="IA2ATokenAcquirer"/> + <see cref="IA2ATokenValidator"/>
+    /// implementations. Consumers register those before calling this method,
+    /// or the cross-process transport will fail-loud on first call.
+    /// </para>
+    /// </remarks>
+    private static void RegisterA2AServices(IServiceCollection services)
+    {
+        // Span emitter owns the ActivitySource — single instance per process.
+        services.AddSingleton<A2ASpanEmitter>();
+
+        // Identity propagator is scoped — it reads ambient IAgentExecutionContext.
+        services.AddScoped<A2AIdentityPropagator>();
+
+        // Auth provider selection mirrors the configured transport. Scoped so
+        // the in-process variant can capture the scoped IAgentExecutionContext;
+        // the cross-process variant doesn't need scope but inherits the
+        // lifetime for consistency.
+        services.AddScoped<IA2AAuthenticationProvider>(sp =>
+        {
+            var transport = sp.GetRequiredService<IOptionsMonitor<AppConfig>>()
+                .CurrentValue.AI.A2A.Surface.Transport;
+
+            return transport switch
+            {
+                A2ATransport.Http => ActivatorUtilities
+                    .CreateInstance<CrossProcessA2AAuthenticationProvider>(sp),
+                _ => ActivatorUtilities
+                    .CreateInstance<InProcessA2AAuthenticationProvider>(sp)
+            };
+        });
+
+        // Server + client are scoped: they depend on scoped auth provider +
+        // identity propagator.
+        services.AddScoped<IA2AServer, HarnessA2AServer>();
+        services.AddScoped<IA2AClient, HarnessA2AClient>();
+
+        services.AddHttpClient(HarnessA2AClient.HttpClientName);
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.cs
@@ -222,6 +222,13 @@ public static partial class DependencyInjection
 
         RegisterMagenticServices(services);
 
+        // --- A2A surface (PR-7). Caller + callee dispatch, identity
+        //     propagation, OTel span linking, and pluggable auth
+        //     (in-process vs cross-process mTLS+JWT). Transport selected by
+        //     AppConfig.AI.A2A.Surface.Transport. ---
+
+        RegisterA2AServices(services);
+
         // --- Governance (permissions, escalation, resilience) ---
 
         RegisterGovernanceServices(services);

--- a/src/Content/Presentation/Presentation.ConsoleUI/Examples/A2ASreToWorkspaceExample.cs
+++ b/src/Content/Presentation/Presentation.ConsoleUI/Examples/A2ASreToWorkspaceExample.cs
@@ -1,0 +1,161 @@
+using System.Text.Json;
+using Application.AI.Common.Interfaces.A2A;
+using Application.AI.Common.Interfaces.Agent;
+using Domain.AI.A2A;
+using Domain.AI.Identity;
+using Domain.Common;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Presentation.ConsoleUI.Common.Helpers;
+using Spectre.Console;
+
+namespace Presentation.ConsoleUI.Examples;
+
+/// <summary>
+/// PR-7 demo: an SRE agent dispatches a search-tickets request to a Workspace
+/// agent through the harness A2A surface. Both run in the same process — the
+/// envelope shape is identical to the cross-process transport, so the demo
+/// proves the call-site shape without standing up a second process.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The example registers a stub <c>IA2ASkillHandler</c> as the Workspace
+/// agent's <c>search-tickets</c> skill, then drives a single call from the
+/// SRE side. Caller identity (<c>agent-sre</c>) propagates onto the server's
+/// ambient <see cref="IAgentExecutionContext"/>, and the handler reads it back
+/// to prove identity flowed through.
+/// </para>
+/// </remarks>
+public sealed class A2ASreToWorkspaceExample
+{
+    private readonly IServiceProvider _services;
+    private readonly ILogger<A2ASreToWorkspaceExample> _logger;
+
+    /// <summary>Creates a new example.</summary>
+    public A2ASreToWorkspaceExample(IServiceProvider services, ILogger<A2ASreToWorkspaceExample> logger)
+    {
+        _services = services;
+        _logger = logger;
+    }
+
+    /// <summary>Runs the SRE → Workspace A2A demo.</summary>
+    public async Task RunAsync(CancellationToken cancellationToken = default)
+    {
+        ConsoleHelper.DisplayHeader("A2A: SRE → Workspace (in-process)", Color.Green);
+
+        // Per-call DI scope so the scoped IA2AClient / Server / identity
+        // context all share the same lifetime.
+        using var scope = _services.CreateScope();
+        var sp = scope.ServiceProvider;
+
+        // Set the caller's ambient identity. In a real harness this is set by
+        // AgentFactory during agent construction; the demo establishes it
+        // directly so the example does not require a full agent bootstrap.
+        var executionContext = sp.GetRequiredService<IAgentExecutionContext>();
+        try
+        {
+            executionContext.SetIdentity(new AgentIdentity
+            {
+                Id = "agent-sre",
+                Kind = AgentIdentityKind.Development
+            });
+        }
+        catch (InvalidOperationException)
+        {
+            // Identity already set by a parent scope (e.g. running inside an
+            // agent turn); leave it as-is.
+        }
+
+        var client = sp.GetRequiredService<IA2AClient>();
+
+        var envelope = new A2AEnvelope
+        {
+            SchemaVersion = A2AEnvelope.CurrentSchemaVersion,
+            CorrelationId = Guid.NewGuid().ToString("N"),
+            CallerAgentId = "agent-sre",
+            CallerKind = AgentIdentityKind.Development.ToString(),
+            CalleeAgentId = "agent-workspace",
+            CalleeSkill = "search-tickets"
+        };
+
+        var request = new A2ARequest
+        {
+            Envelope = envelope,
+            TaskDescription = "Find open SEV-2 tickets for tenant contoso",
+            Input = JsonSerializer.SerializeToElement(new { tenantId = "contoso", severity = 2 })
+        };
+
+        AnsiConsole.MarkupLine($"[grey]Calling [yellow]agent-workspace[/] / [yellow]search-tickets[/] (correlation [yellow]{envelope.CorrelationId}[/])[/]");
+
+        var result = await client.CallAsync(request, cancellationToken);
+
+        if (!result.IsSuccess)
+        {
+            AnsiConsole.MarkupLine($"[red]Transport failed:[/] {string.Join(',', result.Errors)}");
+            return;
+        }
+
+        var response = result.Value!;
+        if (response.Success)
+        {
+            AnsiConsole.MarkupLine($"[green]OK[/] correlation=[yellow]{response.CorrelationId}[/]");
+            if (response.Output is { } output)
+            {
+                AnsiConsole.WriteLine(output.ToString());
+            }
+        }
+        else
+        {
+            AnsiConsole.MarkupLine($"[red]Callee returned failure[/] code=[yellow]{response.ErrorCode}[/]");
+            if (!string.IsNullOrEmpty(response.ErrorMessage))
+            {
+                AnsiConsole.WriteLine(response.ErrorMessage);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Demo handler for the workspace agent's search-tickets skill. Registered
+    /// via the demo composition root: <c>services.AddKeyedScoped&lt;IA2ASkillHandler, WorkspaceSearchTicketsHandler&gt;("agent-workspace:search-tickets")</c>.
+    /// </summary>
+    public sealed class WorkspaceSearchTicketsHandler : IA2ASkillHandler
+    {
+        private readonly IAgentExecutionContext _executionContext;
+        private readonly ILogger<WorkspaceSearchTicketsHandler> _logger;
+
+        /// <summary>Creates a new handler.</summary>
+        public WorkspaceSearchTicketsHandler(
+            IAgentExecutionContext executionContext,
+            ILogger<WorkspaceSearchTicketsHandler> logger)
+        {
+            _executionContext = executionContext;
+            _logger = logger;
+        }
+
+        /// <inheritdoc />
+        public Task<Result<A2AResponse>> HandleAsync(A2ARequest request, CancellationToken cancellationToken)
+        {
+            // The server's identity propagator stamped the caller's identity
+            // onto our ambient context. Reading it back proves identity flowed
+            // end-to-end.
+            var caller = _executionContext.AgentIdentity;
+            _logger.LogInformation(
+                "Workspace handler invoked by caller {Caller} for task: {Task}",
+                caller?.Id ?? "<unknown>",
+                request.TaskDescription);
+
+            var output = JsonSerializer.SerializeToElement(new
+            {
+                caller = caller?.Id ?? "<unknown>",
+                tickets = new[]
+                {
+                    new { id = "INC-1042", severity = 2, summary = "DB connection pool exhaustion" },
+                    new { id = "INC-1099", severity = 2, summary = "Auth latency spike" }
+                }
+            });
+
+            return Task.FromResult(Result<A2AResponse>.Success(
+                A2AResponse.Ok(request.Envelope.CorrelationId, output)));
+        }
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/A2A/A2ATestHelpers.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/A2A/A2ATestHelpers.cs
@@ -1,0 +1,160 @@
+using System.Diagnostics;
+using Application.AI.Common.Interfaces.A2A;
+using Application.AI.Common.Interfaces.Agent;
+using Application.AI.Common.Services.Agent;
+using Domain.AI.A2A;
+using Domain.AI.Identity;
+using Domain.AI.Telemetry.Conventions;
+using Domain.Common;
+using Domain.Common.Config;
+using Domain.Common.Config.AI;
+using Domain.Common.Config.AI.A2A;
+using Infrastructure.AI.A2A;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace Infrastructure.AI.Tests.A2A;
+
+/// <summary>
+/// Shared fixtures + helpers for the PR-7 A2A test suite. Provides span
+/// capture, in-process server construction, and stub handlers / auth providers
+/// without coupling tests to the full DI container.
+/// </summary>
+internal static class A2ATestHelpers
+{
+    /// <summary>Captures all activities emitted on the A2A activity source.</summary>
+    public sealed class CapturedSpans : IDisposable
+    {
+        private readonly ActivityListener _listener;
+        public List<Activity> Activities { get; } = new();
+
+        public CapturedSpans()
+        {
+            _listener = new ActivityListener
+            {
+                ShouldListenTo = s => s.Name == A2AConventions.ActivitySourceName,
+                Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+                ActivityStarted = a => Activities.Add(a)
+            };
+            ActivitySource.AddActivityListener(_listener);
+        }
+
+        public void Dispose() => _listener.Dispose();
+    }
+
+    public static AppConfig MakeConfig(A2ATransport transport = A2ATransport.InProcess) => new()
+    {
+        AI = new AIConfig
+        {
+            A2A = new A2AConfig
+            {
+                Enabled = true,
+                Surface = new A2ASurfaceConfig { Transport = transport, MaxExtensionHeaders = 16 }
+            }
+        }
+    };
+
+    public static IAgentExecutionContext MakeExecutionContext(string callerAgentId)
+    {
+        var ctx = new AgentExecutionContext();
+        ctx.SetIdentity(new AgentIdentity { Id = callerAgentId, Kind = AgentIdentityKind.Development });
+        return ctx;
+    }
+
+    public static A2AEnvelope MakeEnvelope(
+        string callerAgentId = "agent-a",
+        string calleeAgentId = "agent-b",
+        string? calleeSkill = null,
+        string? correlationId = null) => new()
+    {
+        SchemaVersion = A2AEnvelope.CurrentSchemaVersion,
+        CorrelationId = correlationId ?? Guid.NewGuid().ToString("N"),
+        CallerAgentId = callerAgentId,
+        CallerKind = AgentIdentityKind.Development.ToString(),
+        CalleeAgentId = calleeAgentId,
+        CalleeSkill = calleeSkill
+    };
+
+    public static A2ARequest MakeRequest(A2AEnvelope envelope, string task = "do the thing") =>
+        new() { Envelope = envelope, TaskDescription = task };
+
+    /// <summary>
+    /// Builds an in-process server backed by a single keyed handler. Returns a
+    /// scope-attached <see cref="HarnessA2AServer"/> plus the underlying execution
+    /// context the handler will see.
+    /// </summary>
+    public static (HarnessA2AServer Server, IAgentExecutionContext Context) BuildInProcessServer(
+        string calleeAgentId,
+        Func<A2ARequest, Task<Result<A2AResponse>>> handler,
+        AppConfig? appConfig = null,
+        string? calleeSkill = null)
+    {
+        var ctx = new AgentExecutionContext();
+        var executionContext = (IAgentExecutionContext)ctx;
+        var authProvider = new InProcessA2AAuthenticationProvider(executionContext);
+        var spanEmitter = new A2ASpanEmitter();
+        var propagator = new A2AIdentityPropagator(executionContext);
+        var monitor = new TestOptionsMonitor<AppConfig>(appConfig ?? MakeConfig());
+
+        var services = new ServiceCollection();
+        var key = calleeSkill is null ? calleeAgentId : $"{calleeAgentId}:{calleeSkill}";
+        services.AddKeyedSingleton<IA2ASkillHandler>(key, (_, _) => new DelegateHandler(handler));
+        var provider = services.BuildServiceProvider();
+
+        var server = new HarnessA2AServer(
+            provider,
+            authProvider,
+            spanEmitter,
+            propagator,
+            monitor,
+            NullLogger<HarnessA2AServer>.Instance);
+
+        return (server, executionContext);
+    }
+
+    /// <summary>
+    /// Builds an in-process client that dispatches into the supplied server.
+    /// </summary>
+    public static HarnessA2AClient BuildInProcessClient(
+        IA2AServer server,
+        IAgentExecutionContext executionContext,
+        AppConfig? appConfig = null)
+    {
+        var authProvider = new InProcessA2AAuthenticationProvider(executionContext);
+        var spanEmitter = new A2ASpanEmitter();
+        var propagator = new A2AIdentityPropagator(executionContext);
+        var monitor = new TestOptionsMonitor<AppConfig>(appConfig ?? MakeConfig());
+
+        return new HarnessA2AClient(
+            server,
+            authProvider,
+            spanEmitter,
+            propagator,
+            new StubHttpClientFactory(),
+            monitor,
+            NullLogger<HarnessA2AClient>.Instance);
+    }
+
+    private sealed class DelegateHandler : IA2ASkillHandler
+    {
+        private readonly Func<A2ARequest, Task<Result<A2AResponse>>> _impl;
+        public DelegateHandler(Func<A2ARequest, Task<Result<A2AResponse>>> impl) => _impl = impl;
+        public Task<Result<A2AResponse>> HandleAsync(A2ARequest request, CancellationToken cancellationToken)
+            => _impl(request);
+    }
+
+    private sealed class StubHttpClientFactory : IHttpClientFactory
+    {
+        public HttpClient CreateClient(string name) => new();
+    }
+}
+
+/// <summary>Minimal <see cref="IOptionsMonitor{T}"/> for tests.</summary>
+internal sealed class TestOptionsMonitor<T> : IOptionsMonitor<T>
+{
+    public TestOptionsMonitor(T value) => CurrentValue = value;
+    public T CurrentValue { get; }
+    public T Get(string? name) => CurrentValue;
+    public IDisposable? OnChange(Action<T, string?> listener) => null;
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/A2A/A2AVersionPinTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/A2A/A2AVersionPinTests.cs
@@ -1,0 +1,74 @@
+using System.Linq;
+using System.Reflection;
+using Domain.AI.A2A;
+using FluentAssertions;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.A2A;
+
+/// <summary>
+/// PR-7 canary tests. Two purposes:
+/// </summary>
+/// <list type="number">
+/// <item><description>Pin the harness <see cref="A2AEnvelope"/> schema version
+/// so any breaking shape change forces an explicit bump.</description></item>
+/// <item><description>Assert <c>Microsoft.Agents.AI</c> (MAF) 1.9.0 still
+/// lacks a public A2A surface. The moment MAF ships one, this test fails and
+/// the harness should switch to wrapping it instead of carrying its own
+/// transport implementation.</description></item>
+/// </list>
+public sealed class A2AVersionPinTests
+{
+    [Fact]
+    public void Envelope_schema_version_is_pinned_to_1()
+    {
+        A2AEnvelope.CurrentSchemaVersion
+            .Should().Be(1,
+                "PR-7 ships envelope schema v1; bumping requires updating the version-pin test and writing a migration note in documentation/architecture/a2a-message-contract.md");
+    }
+
+    [Fact]
+    public void Maf_does_not_yet_expose_a_public_A2A_surface()
+    {
+        // Force MAF assembly load — without a hard reference the test domain
+        // may not have it loaded yet and the canary would be vacuously true.
+        var mafProbe = typeof(Microsoft.Agents.AI.AIAgent).Assembly;
+        mafProbe.Should().NotBeNull();
+
+        // Canary: when MAF adds an A2A namespace / interface, this test fires
+        // and the harness should switch to wrapping the MAF surface. The
+        // probe is a heuristic — any public type under Microsoft.Agents.AI*
+        // whose name contains "A2A" or "AgentToAgent" trips it.
+        var mafAssemblies = AppDomain.CurrentDomain.GetAssemblies()
+            .Where(a => a.GetName().Name?.StartsWith("Microsoft.Agents.AI", StringComparison.Ordinal) == true)
+            .ToList();
+
+        mafAssemblies.Should().NotBeEmpty("the MAF assemblies must be loaded for the canary to be meaningful");
+
+        var probes = mafAssemblies
+            .SelectMany(a =>
+            {
+                try { return a.GetExportedTypes(); }
+                catch (ReflectionTypeLoadException ex) { return ex.Types.Where(t => t is not null)!; }
+            })
+            .Where(t => t is not null)
+            .Where(t =>
+                (t!.FullName?.Contains("A2A", StringComparison.OrdinalIgnoreCase) == true) ||
+                (t.FullName?.Contains("AgentToAgent", StringComparison.OrdinalIgnoreCase) == true))
+            .Select(t => t!.FullName)
+            .ToList();
+
+        probes.Should().BeEmpty(
+            "Microsoft Agent Framework 1.9.0 does not expose A2A primitives; if this test fails MAF has added them and the harness should wrap them — see documentation/architecture/a2a-message-contract.md 'Version pin' section");
+    }
+
+    [Fact]
+    public void Maf_assembly_is_pinned_to_1_9_x()
+    {
+        var maf = typeof(Microsoft.Agents.AI.AIAgent).Assembly;
+        var version = maf.GetName().Version;
+        version.Should().NotBeNull();
+        version!.Major.Should().Be(1, "harness pins to MAF 1.x");
+        version.Minor.Should().Be(9, "harness pins to MAF 1.9.x; bumping minor requires re-running canary");
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/A2A/CrossProcessA2AFlowTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/A2A/CrossProcessA2AFlowTests.cs
@@ -1,0 +1,124 @@
+using Application.AI.Common.Services.Agent;
+using Domain.AI.A2A;
+using Domain.Common;
+using FluentAssertions;
+using Infrastructure.AI.A2A;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.A2A;
+
+/// <summary>
+/// PR-7 acceptance tests for the cross-process A2A auth path. Covers tests 2
+/// and 3 of the PR plan: a valid JWT flows through and yields the
+/// authoritative caller id; an invalid JWT surfaces as
+/// <c>a2a.auth_rejected</c>.
+/// </summary>
+/// <remarks>
+/// We exercise the cross-process auth provider directly rather than spinning
+/// up a Kestrel mTLS listener — the listener side belongs to the consumer
+/// (Kestrel + IIS configuration), and the cross-process branch of
+/// <see cref="HarnessA2AServer"/> takes the same code path regardless of how
+/// the transport handed it the envelope + headers.
+/// </remarks>
+public sealed class CrossProcessA2AFlowTests
+{
+    [Fact]
+    public async Task Valid_JWT_yields_authoritative_caller_id()
+    {
+        var acquirer = new StubTokenAcquirer("valid-token-for-agent-a");
+        var validator = new StubTokenValidator(
+            jwt => jwt == "valid-token-for-agent-a"
+                ? Result<string>.Success("agent-a")
+                : Result<string>.Fail("a2a.auth_rejected"));
+
+        var provider = new CrossProcessA2AAuthenticationProvider(
+            acquirer,
+            validator,
+            NullLogger<CrossProcessA2AAuthenticationProvider>.Instance);
+
+        var envelope = A2ATestHelpers.MakeEnvelope(callerAgentId: "agent-a");
+        var outboundCreds = await provider.StampOutboundCredentialsAsync(envelope, default);
+        outboundCreds.IsSuccess.Should().BeTrue();
+        outboundCreds.Value!.Should().ContainKey("Authorization");
+        outboundCreds.Value["Authorization"].Should().Be("Bearer valid-token-for-agent-a");
+
+        var inbound = await provider.ValidateInboundAsync(envelope, outboundCreds.Value, default);
+        inbound.IsSuccess.Should().BeTrue();
+        inbound.Value.Should().Be("agent-a");
+    }
+
+    [Fact]
+    public async Task Invalid_JWT_returns_auth_rejected()
+    {
+        var validator = new StubTokenValidator(
+            _ => Result<string>.Fail("a2a.auth_rejected"));
+
+        var provider = new CrossProcessA2AAuthenticationProvider(
+            new StubTokenAcquirer("bad-jwt"),
+            validator,
+            NullLogger<CrossProcessA2AAuthenticationProvider>.Instance);
+
+        var envelope = A2ATestHelpers.MakeEnvelope(callerAgentId: "agent-a");
+        var headers = new Dictionary<string, string> { ["Authorization"] = "Bearer bad-jwt" };
+
+        var result = await provider.ValidateInboundAsync(envelope, headers, default);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Errors.Should().Contain("a2a.auth_rejected");
+    }
+
+    [Fact]
+    public async Task JWT_sub_mismatch_with_envelope_caller_rejects()
+    {
+        var validator = new StubTokenValidator(
+            // JWT sub says "agent-b" but envelope says "agent-a" — must reject.
+            _ => Result<string>.Success("agent-b"));
+
+        var provider = new CrossProcessA2AAuthenticationProvider(
+            new StubTokenAcquirer("token-for-agent-b"),
+            validator,
+            NullLogger<CrossProcessA2AAuthenticationProvider>.Instance);
+
+        var envelope = A2ATestHelpers.MakeEnvelope(callerAgentId: "agent-a");
+        var headers = new Dictionary<string, string> { ["Authorization"] = "Bearer token-for-agent-b" };
+
+        var result = await provider.ValidateInboundAsync(envelope, headers, default);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Errors.Should().Contain("a2a.auth_rejected");
+    }
+
+    [Fact]
+    public async Task Missing_authorization_header_rejects()
+    {
+        var provider = new CrossProcessA2AAuthenticationProvider(
+            new StubTokenAcquirer("ignored"),
+            new StubTokenValidator(_ => Result<string>.Success("agent-a")),
+            NullLogger<CrossProcessA2AAuthenticationProvider>.Instance);
+
+        var envelope = A2ATestHelpers.MakeEnvelope(callerAgentId: "agent-a");
+        var emptyHeaders = new Dictionary<string, string>();
+
+        var result = await provider.ValidateInboundAsync(envelope, emptyHeaders, default);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Errors.Should().Contain("a2a.auth_rejected");
+    }
+
+    private sealed class StubTokenAcquirer : IA2ATokenAcquirer
+    {
+        private readonly string _token;
+        public StubTokenAcquirer(string token) => _token = token;
+        public Task<Result<string>> AcquireAsync(A2AEnvelope envelope, CancellationToken ct)
+            => Task.FromResult(Result<string>.Success(_token));
+    }
+
+    private sealed class StubTokenValidator : IA2ATokenValidator
+    {
+        private readonly Func<string, Result<string>> _impl;
+        public StubTokenValidator(Func<string, Result<string>> impl) => _impl = impl;
+        public Task<Result<string>> ValidateAsync(string jwt, CancellationToken ct)
+            => Task.FromResult(_impl(jwt));
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/A2A/InProcessA2AFlowTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/A2A/InProcessA2AFlowTests.cs
@@ -1,0 +1,145 @@
+using System.Diagnostics;
+using System.Linq;
+using System.Text.Json;
+using Application.AI.Common.Interfaces.Agent;
+using Domain.AI.A2A;
+using Domain.AI.Identity;
+using Domain.AI.Telemetry.Conventions;
+using Domain.Common;
+using FluentAssertions;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.A2A;
+
+/// <summary>
+/// PR-7 acceptance tests for the in-process A2A flow. Covers tests 1, 4, 5
+/// of the PR plan: in-process call success, identity propagation end-to-end,
+/// and OTel span linking.
+/// </summary>
+public sealed class InProcessA2AFlowTests
+{
+    [Fact]
+    public async Task InProcess_call_returns_response_with_correlation_id()
+    {
+        using var spans = new A2ATestHelpers.CapturedSpans();
+        var envelope = A2ATestHelpers.MakeEnvelope();
+
+        var (server, ctx) = A2ATestHelpers.BuildInProcessServer(
+            calleeAgentId: "agent-b",
+            handler: req => Task.FromResult(Result<A2AResponse>.Success(
+                A2AResponse.Ok(
+                    req.Envelope.CorrelationId,
+                    JsonSerializer.SerializeToElement(new { ok = true })))));
+
+        var client = A2ATestHelpers.BuildInProcessClient(
+            server,
+            A2ATestHelpers.MakeExecutionContext("agent-a"));
+
+        var result = await client.CallAsync(A2ATestHelpers.MakeRequest(envelope), default);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.Success.Should().BeTrue();
+        result.Value.CorrelationId.Should().Be(envelope.CorrelationId);
+    }
+
+    [Fact]
+    public async Task Identity_propagates_end_to_end()
+    {
+        IAgentExecutionContext? serverCtxSeen = null;
+        var (server, _) = A2ATestHelpers.BuildInProcessServer(
+            calleeAgentId: "agent-b",
+            handler: req =>
+            {
+                // The handler runs inside the SAME execution context the
+                // server's identity propagator wrote to. We assert by
+                // capturing the context the test helper closed over.
+                return Task.FromResult(Result<A2AResponse>.Success(
+                    A2AResponse.Ok(req.Envelope.CorrelationId, JsonSerializer.SerializeToElement(new { })) ));
+            });
+
+        // The test helper exposes the server's execution context indirectly:
+        // BuildInProcessServer constructs the context internally and the
+        // server's propagator sets identity on it. We retrieve the context
+        // by reflecting against the server's auth provider.
+        var authField = typeof(Infrastructure.AI.A2A.HarnessA2AServer)
+            .GetField("_identityPropagator", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+        var propagator = authField!.GetValue(server);
+        var ctxField = propagator!.GetType()
+            .GetField("_executionContext", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+        serverCtxSeen = (IAgentExecutionContext)ctxField!.GetValue(propagator)!;
+
+        var client = A2ATestHelpers.BuildInProcessClient(
+            server,
+            A2ATestHelpers.MakeExecutionContext("agent-a"));
+
+        var envelope = A2ATestHelpers.MakeEnvelope(callerAgentId: "agent-a", calleeAgentId: "agent-b");
+        var result = await client.CallAsync(A2ATestHelpers.MakeRequest(envelope), default);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.Success.Should().BeTrue();
+        serverCtxSeen!.AgentIdentity.Should().NotBeNull();
+        serverCtxSeen.AgentIdentity!.Id.Should().Be("agent-a");
+    }
+
+    [Fact]
+    public async Task OTel_spans_share_correlation_id_and_link_caller_to_callee()
+    {
+        using var spans = new A2ATestHelpers.CapturedSpans();
+        var envelope = A2ATestHelpers.MakeEnvelope(
+            callerAgentId: "agent-a",
+            calleeAgentId: "agent-b",
+            calleeSkill: "search");
+
+        var (server, _) = A2ATestHelpers.BuildInProcessServer(
+            calleeAgentId: "agent-b",
+            calleeSkill: "search",
+            handler: req => Task.FromResult(Result<A2AResponse>.Success(
+                A2AResponse.Ok(req.Envelope.CorrelationId, JsonSerializer.SerializeToElement(new { })))));
+
+        var client = A2ATestHelpers.BuildInProcessClient(
+            server,
+            A2ATestHelpers.MakeExecutionContext("agent-a"));
+
+        await client.CallAsync(A2ATestHelpers.MakeRequest(envelope), default);
+
+        var clientSpan = spans.Activities
+            .FirstOrDefault(a => a.DisplayName.StartsWith(A2AConventions.SpanNameClientPrefix));
+        var serverSpan = spans.Activities
+            .FirstOrDefault(a => a.DisplayName.StartsWith(A2AConventions.SpanNameServerPrefix));
+
+        clientSpan.Should().NotBeNull();
+        serverSpan.Should().NotBeNull();
+
+        clientSpan!.Kind.Should().Be(ActivityKind.Client);
+        serverSpan!.Kind.Should().Be(ActivityKind.Server);
+
+        clientSpan.GetTagItem(A2AConventions.CalleeId).Should().Be("agent-b");
+        serverSpan.GetTagItem(A2AConventions.CallerId).Should().Be("agent-a");
+
+        clientSpan.GetTagItem(A2AConventions.CorrelationId)
+            .Should().Be(serverSpan.GetTagItem(A2AConventions.CorrelationId));
+
+        clientSpan.GetTagItem(A2AConventions.Transport).Should().Be(A2AConventions.TransportInProcess);
+        clientSpan.GetTagItem(A2AConventions.AuthScheme).Should().Be(A2AConventions.AuthSchemeInProcess);
+    }
+
+    [Fact]
+    public async Task Missing_skill_returns_skill_not_found()
+    {
+        var (server, _) = A2ATestHelpers.BuildInProcessServer(
+            calleeAgentId: "agent-b",
+            handler: req => Task.FromResult(Result<A2AResponse>.Success(
+                A2AResponse.Ok(req.Envelope.CorrelationId, JsonSerializer.SerializeToElement(new { })))));
+
+        var client = A2ATestHelpers.BuildInProcessClient(
+            server,
+            A2ATestHelpers.MakeExecutionContext("agent-a"));
+
+        var envelope = A2ATestHelpers.MakeEnvelope(calleeAgentId: "agent-c"); // no handler
+        var result = await client.CallAsync(A2ATestHelpers.MakeRequest(envelope), default);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.Success.Should().BeFalse();
+        result.Value.ErrorCode.Should().Be("a2a.skill_not_found");
+    }
+}


### PR DESCRIPTION
## Summary
- Ships the harness A2A surface from PR-7: a single wire shape (`A2AEnvelope` + `A2ARequest` + `A2AResponse`) used by both in-process and cross-process calls so consumers can split a skill into its own process later without touching call sites.
- Identity propagation: caller's `IAgentExecutionContext.AgentIdentity` stamps the envelope; server side establishes it on its own ambient context via `A2AIdentityPropagator`. JWT `sub` is authoritative on the cross-process path.
- OTel: caller emits `a2a.client {callee}` (Client kind), callee emits `a2a.server {skill}` (Server kind). Both share `gen_ai.a2a.correlation_id`; new attributes under `gen_ai.a2a.*` (caller/callee id+kind, transport, auth scheme, envelope version, error code).
- Auth: in-process trusts ambient identity; cross-process uses mTLS (Kestrel-terminated) plus workload-identity JWT validated against `ExpectedAudience` / `ExpectedIssuer` with ClockSkew=0 default. `IA2ATokenAcquirer` / `IA2ATokenValidator` are consumer-supplied so the harness does not pin a JWT library.
- Documentation: `documentation/architecture/a2a-message-contract.md` covers wire shape, error codes, identity semantics, OTel attribute table, mTLS+JWT design rationale, and version-pin escalation path.
- Demo: `Presentation.ConsoleUI/Examples/A2ASreToWorkspaceExample.cs` shows SRE → Workspace dispatch with identity flowing into the callee handler.

## Design call-outs
- **MAF 1.9.0 has no A2A surface** — the plan's "thin wrapper over MAF" is not yet possible. PR-7 ships a harness-native surface and pins MAF via `A2AVersionPinTests`: a canary asserts MAF still lacks A2A so any future MAF release that adds it surfaces as a failing test and we switch to wrapping it. Envelope conventions stay either way.
- **Layered auth, not folded**: mTLS pins the workload (cryptographically); JWT pins the agent identity inside it (revocable separately). Documented design.
- **JWT sub is authoritative**: on the cross-process path the JWT's `sub` claim overrides whatever the envelope declared — a holder of token-for-A cannot masquerade as B.
- **Stable failure codes** (`a2a.auth_rejected`, `a2a.skill_not_found`, `a2a.skill_failed`, …) returned through `A2AResponse`; raw exception text never crosses the wire.

## Test plan
- [x] `dotnet test --filter "FullyQualifiedName~A2A"` → 17/17 pass
- [x] Full Infrastructure.AI test suite still green (1607/1609, 2 pre-existing skips)
- [x] Full solution test suite green across 18 projects
- [x] `A2AVersionPinTests` canary passes (MAF 1.9.0 confirmed to lack A2A surface)
- [x] In-process happy-path, identity propagation, OTel span linking all green
- [x] Cross-process JWT validation covered (valid / invalid / sub-mismatch / missing header)

## Layer commits (per-layer push discipline)
1. `feat(a2a): wire-shape domain types + telemetry conventions (PR-7 step 1)`
2. `feat(a2a): application interfaces — client, server, auth provider, skill handler (PR-7 step 2)`
3. `feat(a2a): infrastructure impls — client, server, auth, identity, span emitter (PR-7 step 3)`
4. `test(a2a): in-process + cross-process flow tests, version pin, docs, example (PR-7 step 4)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)