### PR TITLE
feat(egress): sandbox egress preflight + attestation digest binding

### DIFF
--- a/src/Content/Application/Application.AI.Common/Interfaces/Attestation/IAttestationService.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Attestation/IAttestationService.cs
@@ -30,6 +30,34 @@ public interface IAttestationService
     Task<ToolExecutionAttestation> SignFailureAsync(string toolName, string input, string failureReason, CancellationToken ct);
 
     /// <summary>
+    /// Signs a successful tool execution and binds the egress digest into the
+    /// attestation payload, proving which outbound destinations the harness
+    /// permitted during sandbox preflight. Produces the extended payload shape;
+    /// baseline <see cref="SignAsync"/> attestations remain verifiable.
+    /// </summary>
+    /// <param name="toolName">Name of the tool that was executed.</param>
+    /// <param name="input">Serialized tool input.</param>
+    /// <param name="output">Serialized tool output.</param>
+    /// <param name="egressDigest">SHA-256 digest of the recorded egress decisions.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>A signed attestation carrying the egress digest.</returns>
+    Task<ToolExecutionAttestation> SignWithEgressAsync(string toolName, string input, string output, string egressDigest, CancellationToken ct);
+
+    /// <summary>
+    /// Signs a failed tool execution and binds the egress digest into the
+    /// failure attestation payload. Used when an egress preflight deny aborts
+    /// execution before output is produced, so the signed record proves the
+    /// destinations evaluated at the point of failure.
+    /// </summary>
+    /// <param name="toolName">Name of the tool that was executed.</param>
+    /// <param name="input">Serialized tool input.</param>
+    /// <param name="failureReason">Description of the failure.</param>
+    /// <param name="egressDigest">SHA-256 digest of the recorded egress decisions.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>A signed failure attestation carrying the egress digest.</returns>
+    Task<ToolExecutionAttestation> SignFailureWithEgressAsync(string toolName, string input, string failureReason, string egressDigest, CancellationToken ct);
+
+    /// <summary>
     /// Verifies the HMAC signature of an existing attestation.
     /// </summary>
     /// <param name="attestation">The attestation to verify.</param>

--- a/src/Content/Application/Application.AI.Common/Interfaces/Sandbox/ISandboxEgressPreflight.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Sandbox/ISandboxEgressPreflight.cs
@@ -1,0 +1,57 @@
+using Domain.AI.Egress;
+
+namespace Application.AI.Common.Interfaces.Sandbox;
+
+/// <summary>
+/// The sandbox-side gate that runs every URI a tool declares in
+/// <c>SandboxExecutionRequest.EgressPrecheckTargets</c> through the active
+/// per-skill <c>IEgressPolicy</c> BEFORE the process or container is spawned.
+/// Produces a digest of the decisions for inclusion in the HMAC-signed
+/// attestation.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The preflight is the sandbox's "cannot bypass policy" enforcement seam.
+/// In-process tools that respect the named <c>"egress"</c>
+/// <see cref="HttpClient"/> are already gated by the
+/// <c>EgressPolicyDelegatingHandler</c>; the preflight closes the gap for
+/// subprocess tools by surfacing the URIs the tool intends to reach so the
+/// policy can veto BEFORE the untrusted code runs. A tool that visits
+/// destinations it did not declare here is treated as a policy violation by
+/// the runtime egress audit — the audit captures actual decisions; preflight
+/// pre-stamps the ones the sandbox blessed up front.
+/// </para>
+/// <para>
+/// Implementations resolve the active <c>IEgressPolicy</c> from the ambient
+/// agent identity (set by <c>AgentFactory</c>) and the
+/// <c>IEgressPolicyResolver</c>. When no identity is bound — background work
+/// outside an agent turn — every decision is deny by default; consumers that
+/// need to bypass the gate must establish a system agent identity explicitly.
+/// </para>
+/// </remarks>
+public interface ISandboxEgressPreflight
+{
+    /// <summary>
+    /// Evaluate every URI in <paramref name="targets"/> against the active
+    /// per-skill egress policy. Returns the decisions in declaration order so
+    /// the digest is deterministic. Each decision is written to the egress
+    /// audit log; the executor decides whether a deny aborts the sandbox or
+    /// produces a signed failure attestation.
+    /// </summary>
+    /// <param name="targets">The URIs the tool intends to reach. Empty list returns an empty decision list.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>One <see cref="EgressDecision"/> per input URI, in input order.</returns>
+    Task<IReadOnlyList<EgressDecision>> EvaluateAsync(
+        IReadOnlyList<Uri> targets,
+        CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Compute the stable digest fed into the HMAC attestation payload. The
+    /// digest is a SHA-256 hex string over a deterministic encoding of the
+    /// decision list so the verifier can reconstruct it from the JSONL egress
+    /// audit and confirm the attestation matches.
+    /// </summary>
+    /// <param name="decisions">Decisions to digest. Empty list returns the digest of the empty string.</param>
+    /// <returns>The lowercase hex SHA-256 digest. Empty list returns an empty string (sentinel for "no decisions").</returns>
+    string ComputeDigest(IReadOnlyList<EgressDecision> decisions);
+}

--- a/src/Content/Domain/Domain.AI/Attestation/ToolExecutionAttestation.cs
+++ b/src/Content/Domain/Domain.AI/Attestation/ToolExecutionAttestation.cs
@@ -30,4 +30,13 @@ public sealed record ToolExecutionAttestation
 
     /// <summary>Reason for failure. Populated only when <see cref="IsFailureAttestation"/> is true.</summary>
     public string? FailureReason { get; init; }
+
+    /// <summary>
+    /// SHA-256 digest of the egress decisions recorded for this execution (the
+    /// destinations the harness permitted or denied during sandbox preflight).
+    /// Null for baseline attestations produced before egress enforcement; its
+    /// presence is the discriminator that selects the extended HMAC payload
+    /// shape during verification, so baseline attestations remain verifiable.
+    /// </summary>
+    public string? EgressDigest { get; init; }
 }

--- a/src/Content/Domain/Domain.AI/Sandbox/SandboxExecutionRequest.cs
+++ b/src/Content/Domain/Domain.AI/Sandbox/SandboxExecutionRequest.cs
@@ -36,4 +36,28 @@ public sealed record SandboxExecutionRequest
     /// </summary>
     [Obsolete("Use ArgumentList to avoid command injection. This property is no longer consumed.", error: true)]
     public string? Arguments { get; init; }
+
+    /// <summary>
+    /// Optional list of outbound URIs the sandboxed tool intends to reach. When
+    /// non-empty, the executor consults the active <c>IEgressPolicy</c> for each
+    /// URI BEFORE spawning the process or container; a single deny aborts
+    /// execution with a signed failure attestation. Allowed decisions are
+    /// recorded into the signed attestation payload so the HMAC manifest
+    /// proves which destinations the harness permitted.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The preflight surface is the sandbox's enforcement seam against egress
+    /// policy. An in-process tool that respects the named <c>"egress"</c>
+    /// <see cref="HttpClient"/> is already gated by the delegating handler; the
+    /// preflight catches subprocess tools that bypass the in-process client by
+    /// surfacing the URIs they will visit so the policy can veto BEFORE the
+    /// untrusted code runs. A tool that intends to reach destinations it does
+    /// not declare here is treated as a policy violation by the egress audit —
+    /// the audit captures actual decisions; preflight tags them as
+    /// "sandbox.preflight" so dashboards can distinguish them from runtime
+    /// allowlist hits.
+    /// </para>
+    /// </remarks>
+    public IReadOnlyList<Uri>? EgressPrecheckTargets { get; init; }
 }

--- a/src/Content/Domain/Domain.AI/Skills/EgressManifestSection.cs
+++ b/src/Content/Domain/Domain.AI/Skills/EgressManifestSection.cs
@@ -1,0 +1,43 @@
+namespace Domain.AI.Skills;
+
+/// <summary>
+/// YAML-shape mirror of <see cref="EgressManifest"/> produced by the SKILL.md
+/// frontmatter parser. Holds the raw deserialized shape — mutable lists,
+/// nullable fields, no invariants enforced — so the parser can populate it
+/// incrementally before <see cref="EgressManifestSectionMapper.Map"/> projects
+/// it onto the immutable domain record.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The split mirrors the same boundary established by the egress configuration
+/// layer (<c>EgressAllowlistConfigEntry</c> → <c>EgressAllowlistEntry</c>): the
+/// parse-shape type accepts what the YAML loader hands it, and the mapper
+/// produces the immutable domain shape that the validator and policy operate
+/// on. The two-step keeps the domain free of mutable, nullable parse-state.
+/// </para>
+/// </remarks>
+public sealed class EgressManifestSection
+{
+    /// <summary>Raw allowlist entries deserialized from the YAML <c>allowlist:</c> sequence.</summary>
+    public List<EgressAllowlistEntrySection> Allowlist { get; set; } = [];
+}
+
+/// <summary>
+/// YAML-shape mirror of <see cref="Domain.AI.Egress.EgressAllowlistEntry"/>.
+/// Mutable, nullable, no invariants — populated by the parser, projected onto
+/// the immutable domain record at the boundary.
+/// </summary>
+public sealed class EgressAllowlistEntrySection
+{
+    /// <summary>The exact host declared by the <c>host:</c> YAML field. Null when <see cref="HostPattern"/> is set.</summary>
+    public string? Host { get; set; }
+
+    /// <summary>The leftmost-label wildcard declared by the <c>hostPattern:</c> YAML field. Null when <see cref="Host"/> is set.</summary>
+    public string? HostPattern { get; set; }
+
+    /// <summary>The schemes declared by the <c>schemes:</c> YAML sequence.</summary>
+    public List<string> Schemes { get; set; } = [];
+
+    /// <summary>The ports declared by the <c>ports:</c> YAML sequence.</summary>
+    public List<int> Ports { get; set; } = [];
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Attestation/HmacAttestationService.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Attestation/HmacAttestationService.cs
@@ -96,6 +96,93 @@ public sealed class HmacAttestationService : IAttestationService
     }
 
     /// <inheritdoc />
+    public Task<ToolExecutionAttestation> SignWithEgressAsync(
+        string toolName,
+        string input,
+        string output,
+        string egressDigest,
+        CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(egressDigest);
+
+        var options = _optionsMonitor.CurrentValue;
+        var currentKey = GetKey(options, options.CurrentKeyVersion);
+        try
+        {
+            var timestamp = _timeProvider.GetUtcNow();
+            var inputHash = ComputeSha256Hex(input);
+            var outputHash = ComputeSha256Hex(output);
+            // Payload schema extended (egress trailing field). Algorithm and
+            // key derivation unchanged — HMAC-SHA256 over UTF-8 of the payload
+            // string. PR-3a's existing payload shape is preserved by the
+            // SignAsync overload; new callers opt in to the extended shape
+            // explicitly.
+            var payload = $"{toolName}|{inputHash}|{outputHash}|{timestamp:O}|egress:{egressDigest}";
+            var signature = ComputeHmac(currentKey, payload);
+
+            var attestation = new ToolExecutionAttestation
+            {
+                ToolName = toolName,
+                InputHash = inputHash,
+                OutputHash = outputHash,
+                Timestamp = timestamp,
+                Signature = signature,
+                KeyVersion = options.CurrentKeyVersion,
+                IsFailureAttestation = false,
+                FailureReason = null,
+                EgressDigest = egressDigest
+            };
+
+            return Task.FromResult(attestation);
+        }
+        finally
+        {
+            CryptographicOperations.ZeroMemory(currentKey);
+        }
+    }
+
+    /// <inheritdoc />
+    public Task<ToolExecutionAttestation> SignFailureWithEgressAsync(
+        string toolName,
+        string input,
+        string failureReason,
+        string egressDigest,
+        CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(egressDigest);
+
+        var options = _optionsMonitor.CurrentValue;
+        var currentKey = GetKey(options, options.CurrentKeyVersion);
+        try
+        {
+            var timestamp = _timeProvider.GetUtcNow();
+            var inputHash = ComputeSha256Hex(input);
+            var failureHash = ComputeSha256Hex(failureReason);
+            var payload = $"{toolName}|{inputHash}|null|{failureHash}|{timestamp:O}|egress:{egressDigest}";
+            var signature = ComputeHmac(currentKey, payload);
+
+            var attestation = new ToolExecutionAttestation
+            {
+                ToolName = toolName,
+                InputHash = inputHash,
+                OutputHash = null,
+                Timestamp = timestamp,
+                Signature = signature,
+                KeyVersion = options.CurrentKeyVersion,
+                IsFailureAttestation = true,
+                FailureReason = failureReason,
+                EgressDigest = egressDigest
+            };
+
+            return Task.FromResult(attestation);
+        }
+        finally
+        {
+            CryptographicOperations.ZeroMemory(currentKey);
+        }
+    }
+
+    /// <inheritdoc />
     public Task<bool> VerifyAsync(ToolExecutionAttestation attestation, CancellationToken ct)
     {
         var options = _optionsMonitor.CurrentValue;
@@ -137,15 +224,26 @@ public sealed class HmacAttestationService : IAttestationService
 
     private static string BuildVerificationPayload(ToolExecutionAttestation attestation)
     {
+        // Two payload shapes coexist: the PR-3a baseline (no egress digest) and
+        // the PR-3c extended shape (egress digest trailing). The discriminator
+        // is the presence of EgressDigest on the record. The baseline shape
+        // is preserved verbatim so PR-3a attestations remain verifiable after
+        // the PR-3c upgrade.
         if (attestation.IsFailureAttestation)
         {
             var failureHash = attestation.FailureReason is not null
                 ? ComputeSha256Hex(attestation.FailureReason)
                 : ComputeSha256Hex(string.Empty);
-            return $"{attestation.ToolName}|{attestation.InputHash}|null|{failureHash}|{attestation.Timestamp:O}";
+            var baselineFailure = $"{attestation.ToolName}|{attestation.InputHash}|null|{failureHash}|{attestation.Timestamp:O}";
+            return attestation.EgressDigest is null
+                ? baselineFailure
+                : $"{baselineFailure}|egress:{attestation.EgressDigest}";
         }
 
-        return $"{attestation.ToolName}|{attestation.InputHash}|{attestation.OutputHash}|{attestation.Timestamp:O}";
+        var baselineSuccess = $"{attestation.ToolName}|{attestation.InputHash}|{attestation.OutputHash}|{attestation.Timestamp:O}";
+        return attestation.EgressDigest is null
+            ? baselineSuccess
+            : $"{baselineSuccess}|egress:{attestation.EgressDigest}";
     }
 
     private void ValidateOptions(AttestationKeyOptions options)

--- a/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.Planner.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.Planner.cs
@@ -79,6 +79,12 @@ public static partial class DependencyInjection
         services.AddScoped<ProcessSandboxExecutor>();
         services.AddScoped<DockerSandboxExecutor>();
 
+        // PR-3c: sandbox-side egress preflight gate. Optional injection on the
+        // executors; the executor falls back to legacy attestation when no
+        // preflight is registered. Activated unconditionally here so the
+        // sandbox cannot bypass policy by default in any composed host.
+        services.AddScoped<Application.AI.Common.Interfaces.Sandbox.ISandboxEgressPreflight, Infrastructure.AI.Sandbox.SandboxEgressPreflight>();
+
         services.AddSingleton<Docker.DotNet.IDockerClient>(_ =>
             new Docker.DotNet.DockerClientConfiguration().CreateClient());
 

--- a/src/Content/Infrastructure/Infrastructure.AI/Sandbox/DockerSandboxExecutor.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Sandbox/DockerSandboxExecutor.cs
@@ -21,22 +21,29 @@ public sealed class DockerSandboxExecutor : ISandboxExecutor
     private readonly IAttestationService _attestationService;
     private readonly IOptionsMonitor<SandboxExecutionOptions> _options;
     private readonly ILogger<DockerSandboxExecutor> _logger;
+    private readonly ISandboxEgressPreflight? _egressPreflight;
 
     public DockerSandboxExecutor(
         IDockerClient dockerClient,
         IAttestationService attestationService,
         IOptionsMonitor<SandboxExecutionOptions> options,
-        ILogger<DockerSandboxExecutor> logger)
+        ILogger<DockerSandboxExecutor> logger,
+        ISandboxEgressPreflight? egressPreflight = null)
     {
         _dockerClient = dockerClient;
         _attestationService = attestationService;
         _options = options;
         _logger = logger;
+        _egressPreflight = egressPreflight;
     }
 
     public async Task<SandboxExecutionResult> ExecuteAsync(
         SandboxExecutionRequest request, CancellationToken ct)
     {
+        var egress = await RunEgressPreflightAsync(request, ct);
+        if (egress.Blocked is { } block)
+            return block;
+
         if (!await IsDockerAvailableAsync(ct))
             return await HandleDockerUnavailableAsync(request, ct);
 
@@ -70,22 +77,22 @@ public sealed class DockerSandboxExecutor : ISandboxExecutor
             }
             catch (OperationCanceledException) when (!ct.IsCancellationRequested)
             {
-                return await HandleTimeoutAsync(containerId, request, ct);
+                return await HandleTimeoutAsync(containerId, request, egress.Digest, ct);
             }
 
             var logs = await GetContainerLogsAsync(containerId, ct);
             var output = await ReadWorkspaceOutputAsync(workspaceDir, ct);
 
             if (waitResponse.StatusCode != 0)
-                return await BuildCrashResultAsync(waitResponse.StatusCode, output, logs, request, ct);
+                return await BuildCrashResultAsync(waitResponse.StatusCode, output, logs, request, egress.Digest, ct);
 
-            return await BuildSuccessResultAsync(output ?? logs, request, ct);
+            return await BuildSuccessResultAsync(output ?? logs, request, egress.Digest, ct);
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
             _logger.LogError(ex, "Docker execution failed for tool {ToolName}", request.ToolName);
-            var attestation = await _attestationService.SignFailureAsync(
-                request.ToolName, request.Input, $"Docker error: {ex.Message}", ct);
+            var attestation = await SignFailureAsync(
+                request.ToolName, request.Input, $"Docker error: {ex.Message}", egress.Digest, ct);
             return new SandboxExecutionResult
             {
                 Success = false,
@@ -230,7 +237,7 @@ public sealed class DockerSandboxExecutor : ISandboxExecutor
     }
 
     private async Task<SandboxExecutionResult> HandleTimeoutAsync(
-        string containerId, SandboxExecutionRequest request, CancellationToken ct)
+        string containerId, SandboxExecutionRequest request, string? egressDigest, CancellationToken ct)
     {
         var gracePeriod = _options.CurrentValue.Container.StopGracePeriodSeconds;
         _logger.LogWarning("Container {ContainerId} timed out, stopping with {GracePeriod}s grace period",
@@ -246,9 +253,9 @@ public sealed class DockerSandboxExecutor : ISandboxExecutor
             _logger.LogDebug(ex, "Stop container after timeout failed (may already be removed)");
         }
 
-        var attestation = await _attestationService.SignFailureAsync(
+        var attestation = await SignFailureAsync(
             request.ToolName, request.Input,
-            $"Container timed out after {request.Timeout}", ct);
+            $"Container timed out after {request.Timeout}", egressDigest, ct);
 
         return new SandboxExecutionResult
         {
@@ -288,13 +295,13 @@ public sealed class DockerSandboxExecutor : ISandboxExecutor
 
     private async Task<SandboxExecutionResult> BuildCrashResultAsync(
         long exitCode, string? output, string logs,
-        SandboxExecutionRequest request, CancellationToken ct)
+        SandboxExecutionRequest request, string? egressDigest, CancellationToken ct)
     {
         _logger.LogWarning("Container exited with code {ExitCode}", exitCode);
 
-        var attestation = await _attestationService.SignFailureAsync(
+        var attestation = await SignFailureAsync(
             request.ToolName, request.Input,
-            $"Container exited with code {exitCode}: {logs}", ct);
+            $"Container exited with code {exitCode}: {logs}", egressDigest, ct);
 
         return new SandboxExecutionResult
         {
@@ -307,10 +314,10 @@ public sealed class DockerSandboxExecutor : ISandboxExecutor
     }
 
     private async Task<SandboxExecutionResult> BuildSuccessResultAsync(
-        string output, SandboxExecutionRequest request, CancellationToken ct)
+        string output, SandboxExecutionRequest request, string? egressDigest, CancellationToken ct)
     {
-        var attestation = await _attestationService.SignAsync(
-            request.ToolName, request.Input, output, ct);
+        var attestation = await SignSuccessAsync(
+            request.ToolName, request.Input, output, egressDigest, ct);
 
         return new SandboxExecutionResult
         {
@@ -319,6 +326,58 @@ public sealed class DockerSandboxExecutor : ISandboxExecutor
             ExitCode = 0,
             Attestation = attestation
         };
+    }
+
+    private async Task<(SandboxExecutionResult? Blocked, string? Digest)> RunEgressPreflightAsync(
+        SandboxExecutionRequest request, CancellationToken ct)
+    {
+        if (_egressPreflight is null || request.EgressPrecheckTargets is not { Count: > 0 } targets)
+        {
+            return (null, null);
+        }
+
+        var decisions = await _egressPreflight.EvaluateAsync(targets, ct);
+        var digest = _egressPreflight.ComputeDigest(decisions);
+
+        var denied = decisions.FirstOrDefault(d => !d.Allowed);
+        if (denied is not null)
+        {
+            _logger.LogWarning(
+                "Docker sandbox refused to spawn container for tool {ToolName}: egress preflight denied '{Host}'",
+                request.ToolName, denied.Target.Host);
+
+            var attestation = await _attestationService.SignFailureWithEgressAsync(
+                request.ToolName,
+                request.Input,
+                $"Egress preflight denied: {denied.Target} ({denied.Reason})",
+                digest,
+                ct);
+
+            return (new SandboxExecutionResult
+            {
+                Success = false,
+                ErrorMessage = $"Egress preflight denied: {denied.Target}",
+                Attestation = attestation
+            }, digest);
+        }
+
+        return (null, digest);
+    }
+
+    private Task<Domain.AI.Attestation.ToolExecutionAttestation> SignFailureAsync(
+        string toolName, string input, string failureReason, string? egressDigest, CancellationToken ct)
+    {
+        return egressDigest is null
+            ? _attestationService.SignFailureAsync(toolName, input, failureReason, ct)
+            : _attestationService.SignFailureWithEgressAsync(toolName, input, failureReason, egressDigest, ct);
+    }
+
+    private Task<Domain.AI.Attestation.ToolExecutionAttestation> SignSuccessAsync(
+        string toolName, string input, string output, string? egressDigest, CancellationToken ct)
+    {
+        return egressDigest is null
+            ? _attestationService.SignAsync(toolName, input, output, ct)
+            : _attestationService.SignWithEgressAsync(toolName, input, output, egressDigest, ct);
     }
 
     private async Task RemoveContainerSafeAsync(string? containerId, CancellationToken ct)

--- a/src/Content/Infrastructure/Infrastructure.AI/Sandbox/ProcessSandboxExecutor.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Sandbox/ProcessSandboxExecutor.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using Application.AI.Common.Interfaces.Attestation;
 using Application.AI.Common.Interfaces.Sandbox;
+using Domain.AI.Egress;
 using Domain.AI.Sandbox;
 using Domain.Common.Config.AI.Sandbox;
 using Microsoft.Extensions.Logging;
@@ -21,19 +22,22 @@ public sealed class ProcessSandboxExecutor : ISandboxExecutor
     private readonly ILogger<ProcessSandboxExecutor> _logger;
     private readonly TimeProvider _timeProvider;
     private readonly IOptionsMonitor<SandboxConfig> _sandboxConfig;
+    private readonly ISandboxEgressPreflight? _egressPreflight;
 
     public ProcessSandboxExecutor(
         IProcessResourceLimiter resourceLimiter,
         IAttestationService attestationService,
         ILogger<ProcessSandboxExecutor> logger,
         TimeProvider timeProvider,
-        IOptionsMonitor<SandboxConfig> sandboxConfig)
+        IOptionsMonitor<SandboxConfig> sandboxConfig,
+        ISandboxEgressPreflight? egressPreflight = null)
     {
         _resourceLimiter = resourceLimiter;
         _attestationService = attestationService;
         _logger = logger;
         _timeProvider = timeProvider;
         _sandboxConfig = sandboxConfig;
+        _egressPreflight = egressPreflight;
         CreateWorkspaceDirectory = CreateDefaultWorkspace;
     }
 
@@ -65,6 +69,10 @@ public sealed class ProcessSandboxExecutor : ISandboxExecutor
     {
         if (!_sandboxConfig.CurrentValue.Enabled)
             throw new InvalidOperationException("Sandbox execution is disabled by configuration (Sandbox:Enabled=false).");
+
+        var egress = await RunEgressPreflightAsync(request, ct);
+        if (egress.Blocked is { } block)
+            return block;
 
         var workspaceDir = CreateWorkspaceDirectory();
         var startTimestamp = _timeProvider.GetTimestamp();
@@ -98,19 +106,19 @@ public sealed class ProcessSandboxExecutor : ISandboxExecutor
             var elapsed = _timeProvider.GetElapsedTime(startTimestamp);
 
             if (timedOut)
-                return await BuildTimeoutResultAsync(request, elapsed, ct);
+                return await BuildTimeoutResultAsync(request, elapsed, egress.Digest, ct);
 
             if (process.ExitCode != 0)
-                return await BuildCrashResultAsync(process.ExitCode, stdout, stderr, request, elapsed, ct);
+                return await BuildCrashResultAsync(process.ExitCode, stdout, stderr, request, elapsed, egress.Digest, ct);
 
-            return await BuildSuccessResultAsync(stdout, request, elapsed, ct);
+            return await BuildSuccessResultAsync(stdout, request, elapsed, egress.Digest, ct);
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
             _logger.LogError(ex, "Process sandbox execution failed for tool {ToolName}", request.ToolName);
 
-            var attestation = await _attestationService.SignFailureAsync(
-                request.ToolName, request.Input, $"Execution failed: {ex.Message}", ct);
+            var attestation = await SignFailureAsync(
+                request.ToolName, request.Input, $"Execution failed: {ex.Message}", egress.Digest, ct);
 
             return new SandboxExecutionResult
             {
@@ -123,6 +131,58 @@ public sealed class ProcessSandboxExecutor : ISandboxExecutor
         {
             CleanupWorkspace(workspaceDir);
         }
+    }
+
+    private async Task<(SandboxExecutionResult? Blocked, string? Digest)> RunEgressPreflightAsync(
+        SandboxExecutionRequest request, CancellationToken ct)
+    {
+        if (_egressPreflight is null || request.EgressPrecheckTargets is not { Count: > 0 } targets)
+        {
+            return (null, null);
+        }
+
+        var decisions = await _egressPreflight.EvaluateAsync(targets, ct);
+        var digest = _egressPreflight.ComputeDigest(decisions);
+
+        var denied = decisions.FirstOrDefault(d => !d.Allowed);
+        if (denied is not null)
+        {
+            _logger.LogWarning(
+                "Sandbox refused to spawn process for tool {ToolName}: egress preflight denied '{Host}'",
+                request.ToolName, denied.Target.Host);
+
+            var attestation = await _attestationService.SignFailureWithEgressAsync(
+                request.ToolName,
+                request.Input,
+                $"Egress preflight denied: {denied.Target} ({denied.Reason})",
+                digest,
+                ct);
+
+            return (new SandboxExecutionResult
+            {
+                Success = false,
+                ErrorMessage = $"Egress preflight denied: {denied.Target}",
+                Attestation = attestation
+            }, digest);
+        }
+
+        return (null, digest);
+    }
+
+    private Task<Domain.AI.Attestation.ToolExecutionAttestation> SignFailureAsync(
+        string toolName, string input, string failureReason, string? egressDigest, CancellationToken ct)
+    {
+        return egressDigest is null
+            ? _attestationService.SignFailureAsync(toolName, input, failureReason, ct)
+            : _attestationService.SignFailureWithEgressAsync(toolName, input, failureReason, egressDigest, ct);
+    }
+
+    private Task<Domain.AI.Attestation.ToolExecutionAttestation> SignSuccessAsync(
+        string toolName, string input, string output, string? egressDigest, CancellationToken ct)
+    {
+        return egressDigest is null
+            ? _attestationService.SignAsync(toolName, input, output, ct)
+            : _attestationService.SignWithEgressAsync(toolName, input, output, egressDigest, ct);
     }
 
     private static Process StartProcess(SandboxExecutionRequest request, string workspaceDir)
@@ -204,11 +264,11 @@ public sealed class ProcessSandboxExecutor : ISandboxExecutor
     }
 
     private async Task<SandboxExecutionResult> BuildTimeoutResultAsync(
-        SandboxExecutionRequest request, TimeSpan elapsed, CancellationToken ct)
+        SandboxExecutionRequest request, TimeSpan elapsed, string? egressDigest, CancellationToken ct)
     {
-        var attestation = await _attestationService.SignFailureAsync(
+        var attestation = await SignFailureAsync(
             request.ToolName, request.Input,
-            $"Process timed out after {request.Timeout}", ct);
+            $"Process timed out after {request.Timeout}", egressDigest, ct);
 
         return new SandboxExecutionResult
         {
@@ -221,13 +281,13 @@ public sealed class ProcessSandboxExecutor : ISandboxExecutor
 
     private async Task<SandboxExecutionResult> BuildCrashResultAsync(
         int exitCode, string stdout, string stderr,
-        SandboxExecutionRequest request, TimeSpan elapsed, CancellationToken ct)
+        SandboxExecutionRequest request, TimeSpan elapsed, string? egressDigest, CancellationToken ct)
     {
         _logger.LogWarning("Process exited with code {ExitCode}: {Stderr}", exitCode, stderr);
 
-        var attestation = await _attestationService.SignFailureAsync(
+        var attestation = await SignFailureAsync(
             request.ToolName, request.Input,
-            $"Process exited with code {exitCode}: {stderr}", ct);
+            $"Process exited with code {exitCode}: {stderr}", egressDigest, ct);
 
         return new SandboxExecutionResult
         {
@@ -242,10 +302,10 @@ public sealed class ProcessSandboxExecutor : ISandboxExecutor
 
     private async Task<SandboxExecutionResult> BuildSuccessResultAsync(
         string stdout, SandboxExecutionRequest request,
-        TimeSpan elapsed, CancellationToken ct)
+        TimeSpan elapsed, string? egressDigest, CancellationToken ct)
     {
-        var attestation = await _attestationService.SignAsync(
-            request.ToolName, request.Input, stdout, ct);
+        var attestation = await SignSuccessAsync(
+            request.ToolName, request.Input, stdout, egressDigest, ct);
 
         return new SandboxExecutionResult
         {

--- a/src/Content/Infrastructure/Infrastructure.AI/Sandbox/SandboxEgressPreflight.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Sandbox/SandboxEgressPreflight.cs
@@ -1,0 +1,154 @@
+using System.Security.Cryptography;
+using System.Text;
+using Application.AI.Common.Interfaces;
+using Application.AI.Common.Interfaces.Agent;
+using Application.AI.Common.Interfaces.Egress;
+using Application.AI.Common.Interfaces.Sandbox;
+using Domain.AI.Egress;
+using Domain.AI.Identity;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Infrastructure.AI.Sandbox;
+
+/// <summary>
+/// Default <see cref="ISandboxEgressPreflight"/> implementation. Resolves the
+/// active per-skill <see cref="IEgressPolicy"/> from the ambient agent
+/// identity and runs every URI in
+/// <c>SandboxExecutionRequest.EgressPrecheckTargets</c> through it before the
+/// process or container is spawned.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Each decision is written to the egress JSONL audit so dashboards can
+/// distinguish "sandbox preflight" hits from runtime allowlist hits — both
+/// land in the same audit. The digest is a stable SHA-256 over a canonical
+/// encoding of the decisions so the verifier can reconstruct it from the
+/// audit and confirm an attestation matches.
+/// </para>
+/// </remarks>
+public sealed class SandboxEgressPreflight : ISandboxEgressPreflight
+{
+    private readonly IServiceProvider _rootServices;
+    private readonly IAmbientRequestScope _ambientScope;
+    private readonly IEgressPolicyResolver _resolver;
+    private readonly IEgressAuditWriter _auditWriter;
+    private readonly ILogger<SandboxEgressPreflight> _logger;
+    private readonly TimeProvider _timeProvider;
+
+    private static readonly AgentIdentity UnattributedIdentity = new()
+    {
+        Id = "sandbox.unattributed",
+        Kind = AgentIdentityKind.Unspecified
+    };
+
+    /// <summary>Initializes a new <see cref="SandboxEgressPreflight"/>.</summary>
+    public SandboxEgressPreflight(
+        IServiceProvider rootServices,
+        IAmbientRequestScope ambientScope,
+        IEgressPolicyResolver resolver,
+        IEgressAuditWriter auditWriter,
+        ILogger<SandboxEgressPreflight> logger,
+        TimeProvider timeProvider)
+    {
+        ArgumentNullException.ThrowIfNull(rootServices);
+        ArgumentNullException.ThrowIfNull(ambientScope);
+        ArgumentNullException.ThrowIfNull(resolver);
+        ArgumentNullException.ThrowIfNull(auditWriter);
+        ArgumentNullException.ThrowIfNull(logger);
+        ArgumentNullException.ThrowIfNull(timeProvider);
+
+        _rootServices = rootServices;
+        _ambientScope = ambientScope;
+        _resolver = resolver;
+        _auditWriter = auditWriter;
+        _logger = logger;
+        _timeProvider = timeProvider;
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<EgressDecision>> EvaluateAsync(
+        IReadOnlyList<Uri> targets,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(targets);
+
+        if (targets.Count == 0)
+        {
+            return [];
+        }
+
+        var identity = ResolveIdentity();
+        var (effectiveIdentity, policy) = (identity, identity is not null ? _resolver.ResolveFor(identity) : null);
+
+        var decisions = new List<EgressDecision>(targets.Count);
+        foreach (var target in targets)
+        {
+            EgressDecision decision;
+            if (effectiveIdentity is null || policy is null)
+            {
+                decision = new EgressDecision
+                {
+                    Allowed = false,
+                    Reason = "Sandbox preflight blocked: no agent identity bound to the request scope.",
+                    Target = target,
+                    DecidedAt = _timeProvider.GetUtcNow()
+                };
+            }
+            else
+            {
+                decision = await policy.AllowAsync(target, effectiveIdentity, cancellationToken).ConfigureAwait(false);
+            }
+
+            await _auditWriter.AppendAsync(decision, effectiveIdentity ?? UnattributedIdentity, cancellationToken).ConfigureAwait(false);
+
+            if (!decision.Allowed)
+            {
+                _logger.LogWarning(
+                    "Sandbox preflight denied egress to '{Host}' for identity '{Identity}': {Reason}",
+                    target.Host,
+                    effectiveIdentity?.Id ?? UnattributedIdentity.Id,
+                    decision.Reason);
+            }
+
+            decisions.Add(decision);
+        }
+
+        return decisions;
+    }
+
+    /// <inheritdoc />
+    public string ComputeDigest(IReadOnlyList<EgressDecision> decisions)
+    {
+        ArgumentNullException.ThrowIfNull(decisions);
+
+        if (decisions.Count == 0)
+        {
+            return string.Empty;
+        }
+
+        var sb = new StringBuilder();
+        foreach (var d in decisions)
+        {
+            // Canonical encoding: target|allowed|matched-entry — does not
+            // include timestamp so the digest is deterministic across replays
+            // of the same decision sequence.
+            sb.Append(d.Target.AbsoluteUri);
+            sb.Append('|');
+            sb.Append(d.Allowed ? '1' : '0');
+            sb.Append('|');
+            sb.Append(d.MatchedAllowlistEntry ?? "none");
+            sb.Append('\n');
+        }
+
+        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(sb.ToString()));
+        return Convert.ToHexStringLower(bytes);
+    }
+
+    private AgentIdentity? ResolveIdentity()
+    {
+        var requestServices = _ambientScope.Current ?? _rootServices;
+        var context = requestServices.GetService<IAgentExecutionContext>();
+        return context?.AgentIdentity;
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Skills/EgressManifestSectionMapper.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Skills/EgressManifestSectionMapper.cs
@@ -1,0 +1,44 @@
+using Domain.AI.Egress;
+using Domain.AI.Skills;
+
+namespace Infrastructure.AI.Skills;
+
+/// <summary>
+/// Maps the parse-shape <see cref="EgressManifestSection"/> produced by the
+/// SKILL.md frontmatter reader onto the immutable <see cref="EgressManifest"/>
+/// domain record. Lives at the parser/domain boundary so the domain type does
+/// not depend on the parse intermediary and the parse type does not depend on
+/// immutability concerns.
+/// </summary>
+internal static class EgressManifestSectionMapper
+{
+    /// <summary>Map a parsed section to an immutable manifest.</summary>
+    /// <param name="section">The parsed section. May be null.</param>
+    /// <returns>The immutable manifest, or null when <paramref name="section"/> is null.</returns>
+    public static EgressManifest? Map(EgressManifestSection? section)
+    {
+        if (section is null)
+        {
+            return null;
+        }
+
+        return new EgressManifest
+        {
+            Allowlist = section.Allowlist
+                .Select(MapEntry)
+                .ToArray()
+        };
+    }
+
+    private static EgressAllowlistEntry MapEntry(EgressAllowlistEntrySection entry)
+    {
+        ArgumentNullException.ThrowIfNull(entry);
+        return new EgressAllowlistEntry
+        {
+            Host = string.IsNullOrWhiteSpace(entry.Host) ? null : entry.Host.Trim(),
+            HostPattern = string.IsNullOrWhiteSpace(entry.HostPattern) ? null : entry.HostPattern.Trim(),
+            Schemes = entry.Schemes.Select(s => s.Trim()).ToArray(),
+            Ports = entry.Ports.ToArray()
+        };
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Sandbox/SandboxEgressPreflightTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Sandbox/SandboxEgressPreflightTests.cs
@@ -1,0 +1,177 @@
+using Application.AI.Common.Interfaces.Egress;
+using Domain.AI.Egress;
+using Domain.AI.Identity;
+using FluentAssertions;
+using Infrastructure.AI.Egress;
+using Infrastructure.AI.Sandbox;
+using Infrastructure.AI.Tests.Egress.Support;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Sandbox;
+
+/// <summary>
+/// PR-3c tests 7 + 8 — sandbox preflight composed with the real egress policy:
+/// (7) an allowlisted target is approved and logged to the audit as an Allow;
+/// (8) a non-allowlisted target is denied and surfaces as a deny in the
+/// audit + a non-allowed decision in the returned list (which the executor
+/// translates into <c>EgressBlockedException</c>-style fail-fast on the
+/// sandbox boundary). The preflight does NOT throw — the executor decides
+/// whether to abort, which keeps the audit trail uniform.
+/// </summary>
+public sealed class SandboxEgressPreflightTests
+{
+    private static readonly AgentIdentity Identity = new()
+    {
+        Id = "sandbox-skill",
+        Kind = AgentIdentityKind.Development,
+        TenantId = "tenant-1"
+    };
+
+    private static DefaultEgressPolicy BuildPolicy(params EgressAllowlistEntry[] entries) =>
+        new(entries, NullLogger<DefaultEgressPolicy>.Instance, TimeProvider.System);
+
+    private sealed class StubResolver : IEgressPolicyResolver
+    {
+        private readonly Domain.AI.Egress.IEgressPolicy _policy;
+        public StubResolver(Domain.AI.Egress.IEgressPolicy policy) { _policy = policy; }
+        public Domain.AI.Egress.IEgressPolicy ResolveFor(AgentIdentity identity) => _policy;
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_AllowlistedTarget_AllowsAndAuditsAllow()
+    {
+        var policy = BuildPolicy(new EgressAllowlistEntry
+        {
+            Host = "api.github.com",
+            Schemes = ["https"],
+            Ports = [443]
+        });
+        var audit = new InMemoryEgressAuditWriter();
+        var preflight = new SandboxEgressPreflight(
+            new ServiceCollection().BuildServiceProvider(),
+            new FakeAmbientRequestScope(Identity),
+            new StubResolver(policy),
+            audit,
+            NullLogger<SandboxEgressPreflight>.Instance,
+            TimeProvider.System);
+
+        var decisions = await preflight.EvaluateAsync(
+            [new Uri("https://api.github.com/users/octocat")],
+            CancellationToken.None);
+
+        decisions.Should().HaveCount(1);
+        decisions[0].Allowed.Should().BeTrue();
+        decisions[0].MatchedAllowlistEntry.Should().Be("api.github.com");
+
+        audit.Entries.Should().HaveCount(1);
+        audit.Entries.TryDequeue(out var entry).Should().BeTrue();
+        entry.Decision.Allowed.Should().BeTrue();
+        entry.Identity.Id.Should().Be(Identity.Id);
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_NonAllowlistedTarget_DeniesAndAuditsDeny()
+    {
+        var policy = BuildPolicy(new EgressAllowlistEntry
+        {
+            Host = "api.github.com",
+            Schemes = ["https"],
+            Ports = [443]
+        });
+        var audit = new InMemoryEgressAuditWriter();
+        var preflight = new SandboxEgressPreflight(
+            new ServiceCollection().BuildServiceProvider(),
+            new FakeAmbientRequestScope(Identity),
+            new StubResolver(policy),
+            audit,
+            NullLogger<SandboxEgressPreflight>.Instance,
+            TimeProvider.System);
+
+        var decisions = await preflight.EvaluateAsync(
+            [new Uri("https://evil.example.com/exfil")],
+            CancellationToken.None);
+
+        decisions.Should().HaveCount(1);
+        decisions[0].Allowed.Should().BeFalse();
+
+        audit.Entries.Should().HaveCount(1);
+        audit.Entries.TryDequeue(out var entry).Should().BeTrue();
+        entry.Decision.Allowed.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_NoAgentIdentity_DeniesAll()
+    {
+        // Sandbox preflight without an attributable identity short-circuits to
+        // deny — the policy refuses to make a verdict without identity so the
+        // audit trail and per-skill allowlists remain meaningful.
+        var policy = BuildPolicy(new EgressAllowlistEntry
+        {
+            Host = "api.github.com",
+            Schemes = ["https"],
+            Ports = [443]
+        });
+        var audit = new InMemoryEgressAuditWriter();
+        var preflight = new SandboxEgressPreflight(
+            new ServiceCollection().BuildServiceProvider(),
+            new FakeAmbientRequestScope(identity: null),
+            new StubResolver(policy),
+            audit,
+            NullLogger<SandboxEgressPreflight>.Instance,
+            TimeProvider.System);
+
+        var decisions = await preflight.EvaluateAsync(
+            [new Uri("https://api.github.com/")],
+            CancellationToken.None);
+
+        decisions.Should().HaveCount(1);
+        decisions[0].Allowed.Should().BeFalse();
+        audit.Entries.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public void ComputeDigest_EmptyList_ReturnsEmptyString()
+    {
+        var preflight = new SandboxEgressPreflight(
+            new ServiceCollection().BuildServiceProvider(),
+            new FakeAmbientRequestScope(Identity),
+            new StubResolver(BuildPolicy()),
+            new InMemoryEgressAuditWriter(),
+            NullLogger<SandboxEgressPreflight>.Instance,
+            TimeProvider.System);
+
+        preflight.ComputeDigest([]).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ComputeDigest_NonEmptyDecisions_IsDeterministic()
+    {
+        var preflight = new SandboxEgressPreflight(
+            new ServiceCollection().BuildServiceProvider(),
+            new FakeAmbientRequestScope(Identity),
+            new StubResolver(BuildPolicy()),
+            new InMemoryEgressAuditWriter(),
+            NullLogger<SandboxEgressPreflight>.Instance,
+            TimeProvider.System);
+
+        var decisions = new EgressDecision[]
+        {
+            new()
+            {
+                Allowed = true,
+                Reason = "ok",
+                MatchedAllowlistEntry = "api.github.com",
+                Target = new Uri("https://api.github.com/"),
+                DecidedAt = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero)
+            }
+        };
+
+        var d1 = preflight.ComputeDigest(decisions);
+        var d2 = preflight.ComputeDigest(decisions);
+
+        d1.Should().Be(d2);
+        d1.Length.Should().Be(64); // SHA-256 hex
+    }
+}


### PR DESCRIPTION
## Summary
Rescues the sandbox-side **enforcement layer** for PR-3c egress policy that was stranded uncommitted on `main`. Merged #33 shipped the manifest types, validator, and resolver; this PR adds the teeth.

## What landed
- **`ISandboxEgressPreflight` + `SandboxEgressPreflight`** — consults the active egress policy for each declared outbound URI **before** spawning a process/container; a single deny aborts with a signed failure attestation.
- **`SandboxExecutionRequest.EgressPrecheckTargets`** — declared outbound URIs surfaced for preflight.
- **`IAttestationService.SignWithEgressAsync` / `SignFailureWithEgressAsync` + `ToolExecutionAttestation.EgressDigest`** — extended HMAC payload binding permitted/denied destinations into the signed record. Baseline (PR-3a) attestations remain verifiable via the `EgressDigest` null discriminator.
- **`EgressManifestSection` (+mapper)** — skill-manifest egress section.
- Both sandbox executors wired to preflight; registered in DI (`DependencyInjection.Planner`).

## Test plan
- `dotnet build src/AgenticHarness.slnx` → 0 errors
- Infrastructure.AI tests: 108 pass (incl. new `SandboxEgressPreflightTests` + attestation suite)
- Rebased clean onto current main (post pr6/7/8 merges + dist untrack)

🤖 Generated with [Claude Code](https://claude.com/claude-code)