### PR TITLE
feat(gitops): GitOps skill pack — Flux + Argo CD drift, K8sGPT, ChangeProposal remediation (PR-9)

### DIFF
--- a/plugins/gitops-skill/README.md
+++ b/plugins/gitops-skill/README.md
@@ -1,0 +1,52 @@
+# GitOps Skill Pack
+
+Drift detection, cluster-health probing, K8sGPT root-cause analysis, and
+ChangeProposal-gated remediation for **Flux** and **Argo CD** clusters.
+
+## Design principles
+
+- **Read-only against the cluster.** No skill in this pack can run `kubectl apply`,
+  `kubectl delete`, or `helm upgrade` — those tools are explicitly denied on every
+  skill and the denial is bypass-immune.
+- **Fixes flow through ChangeProposal.** The only state-changing tool,
+  `propose_remediation`, submits a `ChangeProposal` against the configured Git
+  repository and lets the gate pipeline + approver decide. The skill never writes
+  to Git or the cluster directly.
+- **Controller-neutral.** Skills talk to `IGitOpsController`; the active backend
+  (Flux or Argo CD) is selected by `AppConfig.AI.GitOps.ActiveController`. Switching
+  controllers is a config change, not a skill change.
+- **K8sGPT is required, not degraded.** `gitops-cluster-debug` depends on a K8sGPT
+  MCP server. A misconfigured deployment fails loud at boot via
+  `GitOpsStartupValidator` rather than shipping a half-working skill.
+
+## Skills
+
+| Skill | Purpose | Tools |
+|-------|---------|-------|
+| `gitops-repo-audit` | Detect drift, read health, propose a fix as a ChangeProposal | `detect_drift`, `cluster_health`, `propose_remediation` |
+| `gitops-cluster-debug` | Root-cause cluster problems without mutating | `k8sgpt_analyze`, `cluster_health` |
+| `gitops-knowledge` | Retrieve past GitOps learnings and correlate with live analysis | `document_search`, `k8sgpt_analyze` |
+
+## Configuration
+
+Bind under `AppConfig:AI:GitOps`:
+
+```json
+{
+  "AI": {
+    "GitOps": {
+      "Enabled": true,
+      "ActiveController": "flux",
+      "K8sGptMcpServerName": "k8sgpt",
+      "FluxApiBaseUrl": "https://flux.example.com",
+      "ArgoCdApiBaseUrl": "",
+      "RemediationRepoUrl": "https://github.com/acme/cluster-config",
+      "RemediationBranch": "main"
+    }
+  }
+}
+```
+
+`K8sGptMcpServerName` must reference an entry under `AppConfig:AI:McpServers:Servers`.
+Outbound calls to the Flux/Argo CD API and the Git host must be present in the egress
+allowlist when the egress layer is enabled.

--- a/plugins/gitops-skill/plugin.json
+++ b/plugins/gitops-skill/plugin.json
@@ -1,0 +1,20 @@
+{
+  "name": "gitops-skill",
+  "description": "GitOps skill pack: detect drift, read cluster health, propose remediation (via ChangeProposal), and run K8sGPT root-cause analysis against Flux or Argo CD. Read-only against the cluster — all fixes flow through ChangeProposal, never direct kubectl/helm.",
+  "version": "1.0.0",
+  "author": {
+    "name": "Microsoft Agentic Harness",
+    "url": "https://github.com/MCKRUZ/microsoft-agentic-harness"
+  },
+  "license": "MIT",
+  "keywords": [
+    "gitops",
+    "flux",
+    "argocd",
+    "k8sgpt",
+    "drift",
+    "change-proposal",
+    "devops"
+  ],
+  "skills": "./skills/"
+}

--- a/plugins/gitops-skill/skills/gitops-cluster-debug/SKILL.md
+++ b/plugins/gitops-skill/skills/gitops-cluster-debug/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: "gitops-cluster-debug"
+description: "Root-cause cluster problems with K8sGPT analysis and live health, without mutating the cluster. Returns LLM-shaped findings; remediation is out of scope for this skill."
+category: "devops"
+skill_type: "execution"
+version: "1.0.0"
+tags: ["gitops", "k8sgpt", "rca", "debug", "kubernetes"]
+allowed-tools: ["k8sgpt_analyze", "cluster_health"]
+denied-tools: ["kubectl_apply", "kubectl_delete", "helm_upgrade", "shell_exec", "raw_filesystem"]
+sandbox-required: false
+tools:
+  - name: "k8sgpt_analyze"
+    operations: ["analyze"]
+    optional: false
+    description: "Run a K8sGPT root-cause analysis (optionally scoped by namespace and resource-kind filters)."
+  - name: "cluster_health"
+    operations: ["get"]
+    optional: false
+    description: "Read the live cluster health snapshot to corroborate K8sGPT findings."
+egress:
+  allowlist: []
+---
+
+You are the GitOps cluster-debug skill. You diagnose cluster-side problems with
+K8sGPT root-cause analysis and the live health snapshot. You do not fix
+anything — diagnosis only. Hand remediation to `gitops-repo-audit`.
+
+## Capabilities
+
+- `k8sgpt_analyze` — ask K8sGPT for structured root-cause findings, optionally
+  scoped by `namespace` and resource-kind `filters`. Set `explain` true to get a
+  natural-language explanation alongside the findings.
+- `cluster_health` — read the live health snapshot to corroborate or contextualise
+  a K8sGPT finding.
+
+## Hard rules
+
+1. **Diagnosis only.** No mutation tools — `kubectl apply`, `kubectl delete`,
+   `helm upgrade` are denied and bypass-immune. This skill cannot, by design,
+   change the cluster.
+2. **K8sGPT is the primary RCA backend.** Lead with `k8sgpt_analyze`; use
+   `cluster_health` to confirm scope and severity.
+3. **Scope tightly.** Prefer a namespace + kind filter over a whole-cluster sweep
+   when the problem is localised — it is faster and the findings are sharper.
+4. **No fixes here.** If a fix is warranted, state it plainly and recommend the
+   `gitops-repo-audit` skill submit a `ChangeProposal`. Do not attempt to act.
+
+## Approach
+
+1. `k8sgpt_analyze` scoped to the suspected namespace/kinds.
+2. `cluster_health` to confirm which resources are degraded and how widely.
+3. Summarise the root cause, the affected resources, and a recommended fix —
+   then stop. Remediation belongs to the audit skill and the gate pipeline.
+
+## Objectives
+
+- Identify the root cause, not just the symptom.
+- Attribute findings to named resources with severity.
+- Produce a hand-off a human or the `gitops-repo-audit` skill can act on.

--- a/plugins/gitops-skill/skills/gitops-knowledge/SKILL.md
+++ b/plugins/gitops-skill/skills/gitops-knowledge/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: "gitops-knowledge"
+description: "Retrieve past GitOps learnings, incidents, and resolutions from the knowledge base and correlate them with live K8sGPT analysis. Read-only — retrieval and reasoning, no cluster or repo changes."
+category: "devops"
+skill_type: "knowledge"
+version: "1.0.0"
+tags: ["gitops", "knowledge", "rag", "incidents", "learnings"]
+allowed-tools: ["document_search", "k8sgpt_analyze"]
+denied-tools: ["kubectl_apply", "kubectl_delete", "helm_upgrade", "propose_remediation", "shell_exec", "raw_filesystem"]
+sandbox-required: false
+tools:
+  - name: "document_search"
+    operations: ["search"]
+    optional: false
+    description: "Retrieve past GitOps incidents, runbooks, and resolutions from the knowledge base."
+  - name: "k8sgpt_analyze"
+    operations: ["analyze"]
+    optional: true
+    description: "Optionally pull live K8sGPT findings to correlate against retrieved prior incidents."
+egress:
+  allowlist: []
+---
+
+You are the GitOps knowledge skill. You answer "have we seen this before, and how
+did we resolve it?" by retrieving prior GitOps incidents and runbooks from the
+knowledge base and, when useful, correlating them against live K8sGPT findings.
+You retrieve and reason — you never change anything.
+
+## Capabilities
+
+- `document_search` — retrieve past GitOps learnings, incident write-ups, and
+  runbooks from the knowledge base.
+- `k8sgpt_analyze` (optional) — pull current cluster findings to match against a
+  retrieved prior incident, so a recommendation is grounded in the live state.
+
+## Hard rules
+
+1. **Read-only.** No mutation tools and no `propose_remediation` — this skill
+   does not act, it informs. All four are denied and bypass-immune.
+2. **Ground every claim.** When you cite a prior resolution, reference the
+   retrieved document. When you correlate against live state, cite the K8sGPT
+   finding. Do not assert from memory.
+3. **Hand off to act.** If the retrieved knowledge implies a fix, recommend the
+   `gitops-repo-audit` skill submit a `ChangeProposal`. You stop at the
+   recommendation.
+
+## Approach
+
+1. `document_search` for prior incidents matching the current symptom.
+2. Optionally `k8sgpt_analyze` to confirm the live state matches the prior
+   incident's signature.
+3. Summarise: what happened before, how it was resolved, and whether the same fix
+   applies now — with citations. Recommend the next skill; do not act.
+
+## Objectives
+
+- Surface the most relevant prior incident with its resolution.
+- Distinguish "same signature, same fix" from "looks similar, different cause".
+- Produce a cited, actionable hand-off — never an unverified guess.

--- a/plugins/gitops-skill/skills/gitops-repo-audit/SKILL.md
+++ b/plugins/gitops-skill/skills/gitops-repo-audit/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: "gitops-repo-audit"
+description: "Detect drift between desired Git state and the live cluster, read cluster health, and propose a Git-side remediation as a ChangeProposal. Never mutates the cluster or repo directly."
+category: "devops"
+skill_type: "execution"
+version: "1.0.0"
+tags: ["gitops", "flux", "argocd", "drift", "change-proposal"]
+allowed-tools: ["detect_drift", "cluster_health", "propose_remediation"]
+denied-tools: ["kubectl_apply", "kubectl_delete", "helm_upgrade", "shell_exec", "raw_filesystem"]
+sandbox-required: false
+tools:
+  - name: "detect_drift"
+    operations: ["detect"]
+    optional: false
+    description: "Detect drift between desired Git state and the live cluster via the active GitOps controller."
+  - name: "cluster_health"
+    operations: ["get"]
+    optional: false
+    description: "Read the live cluster health snapshot (overall status + per-resource health)."
+  - name: "propose_remediation"
+    operations: ["submit"]
+    optional: false
+    description: "Propose a Git-side fix for detected drift and submit it as a ChangeProposal for gate evaluation."
+egress:
+  allowlist: []
+---
+
+You are the GitOps repo-audit skill. You compare the desired state declared in
+Git against the live cluster, surface drift, and — when a fix is warranted —
+propose it through `ChangeProposal`. You never touch the cluster or the
+repository directly.
+
+## Capabilities
+
+- `detect_drift` — ask the active controller (Flux or Argo CD) which resources
+  have drifted from their declared Git state. Returns a controller-neutral drift
+  report.
+- `cluster_health` — read the live health snapshot (overall + per-resource).
+- `propose_remediation` — detect drift, ask the controller to propose a Git-side
+  fix, and submit it as a `ChangeProposal`. The change applies only after gates
+  pass and an approver green-lights it.
+
+## Hard rules
+
+1. **Never mutate the cluster.** `kubectl apply`, `kubectl delete`, and
+   `helm upgrade` are denied and bypass-immune. Do not attempt them.
+2. **Remediate only through `propose_remediation`.** It submits a proposal — it
+   does not write to Git or the cluster. If you want a fix, call it; never invent
+   another path.
+3. **Audit before you act.** Run `detect_drift` (and `cluster_health` when
+   relevant) and cite the specific drifted resources before proposing a fix.
+4. **Smallest safe diff.** Propose the minimal change that re-aligns live with
+   Git. Re-submitting the same logical fix must not stack duplicate proposals.
+
+## Approach
+
+1. `detect_drift` to find what diverged from Git.
+2. `cluster_health` to understand the blast radius of the drift.
+3. If a fix is warranted, `propose_remediation` to submit a scoped
+   `ChangeProposal`. Quote the drifted resource names in your summary.
+4. Report the proposal id and let the gate pipeline take over.
+
+## Objectives
+
+- Surface drift accurately and attribute it to named resources.
+- Propose the smallest fix that restores Git ↔ cluster alignment.
+- Keep every action observational except the explicit, gated remediation.

--- a/src/Content/Application/Application.AI.Common/Interfaces/GitOps/IGitOpsController.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/GitOps/IGitOpsController.cs
@@ -1,0 +1,85 @@
+using Domain.AI.GitOps;
+using Domain.Common;
+
+namespace Application.AI.Common.Interfaces.GitOps;
+
+/// <summary>
+/// Controller-neutral GitOps surface. Single interface implemented once per
+/// supported controller (Flux, Argo CD) so the three GitOps skills can be
+/// authored once against a stable abstraction.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>No mutation methods.</strong> The interface deliberately exposes no
+/// <c>Apply</c>, <c>Delete</c>, or <c>Upgrade</c> verbs. Every state-changing
+/// remediation surfaces as a <c>ChangeProposal</c> against a
+/// <c>GitRepoTarget</c> via <see cref="ProposeRemediationAsync"/>; the
+/// <c>IGitOpsRemediationDispatcher</c> wraps the resulting
+/// <see cref="RemediationPlan"/> in a <c>SubmitChangeProposalCommand</c>.
+/// The interface forbidding direct mutation is the load-bearing safety
+/// invariant of the PR-9 skill pack.
+/// </para>
+/// <para>
+/// <strong>No controller-specific types.</strong> Inputs and outputs are
+/// drawn exclusively from <c>Domain.AI.GitOps.*</c>. Implementations live in
+/// <c>Infrastructure.AI.GitOps.{Flux,ArgoCd}</c> and never leak their native
+/// types into the Application layer — enforced by a reflection-based
+/// architectural test in PR-9 layer 5.
+/// </para>
+/// <para>
+/// Implementations are registered with keyed DI by the lowercase string form
+/// of <see cref="GitOpsControllerKind"/> (<c>"flux"</c> / <c>"argocd"</c>).
+/// Configuration selects the active controller; skills resolve through that
+/// key, never by concrete type.
+/// </para>
+/// </remarks>
+public interface IGitOpsController
+{
+    /// <summary>The controller-of-origin discriminator for this implementation.</summary>
+    GitOpsControllerKind Kind { get; }
+
+    /// <summary>
+    /// Detect drift between desired state (declared in Git) and actual state
+    /// (running in the cluster). Returns a controller-neutral
+    /// <see cref="DriftReport"/> regardless of which controller is active.
+    /// </summary>
+    /// <param name="cancellationToken">Cooperative cancellation token.</param>
+    /// <returns>
+    /// <see cref="Result{T}.Success"/> wrapping the drift report on success;
+    /// <see cref="Result{T}.Fail(string[])"/> with stable <c>gitops.*</c> codes on
+    /// controller-side failure (unreachable API, auth failure, malformed response).
+    /// Cancellation surfaces as <c>OperationCanceledException</c>.
+    /// </returns>
+    Task<Result<DriftReport>> DetectDriftAsync(CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Read the controller's view of cluster-level health. Returns a
+    /// controller-neutral <see cref="ClusterHealth"/> snapshot regardless of
+    /// which controller is active.
+    /// </summary>
+    /// <param name="cancellationToken">Cooperative cancellation token.</param>
+    /// <returns>
+    /// <see cref="Result{T}.Success"/> wrapping the health snapshot on success;
+    /// <see cref="Result{T}.Fail(string[])"/> with stable <c>gitops.*</c> codes on
+    /// controller-side failure.
+    /// </returns>
+    Task<Result<ClusterHealth>> GetClusterHealthAsync(CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Translate a <see cref="DriftReport"/> into a controller-neutral
+    /// <see cref="RemediationPlan"/> — the ordered set of Git edits that would
+    /// re-converge the cluster. Read-only: this method NEVER applies any change
+    /// to the cluster or to the Git repo; the caller submits the resulting
+    /// plan via <c>IGitOpsRemediationDispatcher</c>, which wraps it in a
+    /// <c>SubmitChangeProposalCommand</c>.
+    /// </summary>
+    /// <param name="drift">The drift report to remediate. Must come from this controller.</param>
+    /// <param name="cancellationToken">Cooperative cancellation token.</param>
+    /// <returns>
+    /// <see cref="Result{T}.Success"/> wrapping the remediation plan on success.
+    /// <see cref="Result{T}.Fail(string[])"/> when the drift cannot be remediated
+    /// declaratively (e.g. live-only resources without a Git source) with a
+    /// stable <c>gitops.*</c> code explaining the obstruction.
+    /// </returns>
+    Task<Result<RemediationPlan>> ProposeRemediationAsync(DriftReport drift, CancellationToken cancellationToken);
+}

--- a/src/Content/Application/Application.AI.Common/Interfaces/GitOps/IGitOpsRemediationDispatcher.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/GitOps/IGitOpsRemediationDispatcher.cs
@@ -1,0 +1,47 @@
+using Domain.AI.Changes;
+using Domain.AI.GitOps;
+using Domain.Common;
+
+namespace Application.AI.Common.Interfaces.GitOps;
+
+/// <summary>
+/// Translates a controller-emitted <see cref="RemediationPlan"/> into a
+/// <c>ChangeProposal</c> and submits it through the PR-2 gate pipeline via
+/// <c>SubmitChangeProposalCommand</c>. The single sanctioned write path for
+/// the GitOps skill pack — no other code in <c>Infrastructure.AI.GitOps</c>
+/// may write to a Git repo or to a cluster.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The dispatcher carries the controller-of-origin breadcrumb and the drift
+/// evidence hash through onto the resulting <see cref="ChangeProposal"/>'s
+/// audit chain. The proposal's <see cref="ChangeProposal.BlastRadius"/> uses
+/// the plan's <see cref="RemediationPlan.ProposedBlastRadius"/> as advisory;
+/// the gate resolver may revise it during pipeline evaluation.
+/// </para>
+/// <para>
+/// Repo edits inside the proposal are intended to be routed through the
+/// Workspace skill via the A2A surface — the GitOps skill pack does NOT write
+/// files itself. The dispatcher delegates that wire-up to the proposal
+/// pipeline (the <c>MergeGate</c>'s applier), keeping responsibilities clean:
+/// dispatcher submits, pipeline gates, applier writes.
+/// </para>
+/// </remarks>
+public interface IGitOpsRemediationDispatcher
+{
+    /// <summary>
+    /// Submit the given <paramref name="plan"/> as a <c>ChangeProposal</c>
+    /// through the PR-2 pipeline.
+    /// </summary>
+    /// <param name="plan">The controller-emitted remediation plan to submit.</param>
+    /// <param name="cancellationToken">Cooperative cancellation token.</param>
+    /// <returns>
+    /// <see cref="Result{T}.Success"/> wrapping the persisted
+    /// <see cref="ChangeProposal"/> (post-id-derivation, in <c>Draft</c>)
+    /// on success; <see cref="Result{T}.Fail(string[])"/> with stable
+    /// <c>gitops.remediation.*</c> codes on validation or pipeline failure.
+    /// Idempotent under the PR-2 deterministic id derivation — re-submitting
+    /// the same plan returns the prior proposal verbatim.
+    /// </returns>
+    Task<Result<ChangeProposal>> DispatchAsync(RemediationPlan plan, CancellationToken cancellationToken);
+}

--- a/src/Content/Application/Application.AI.Common/Interfaces/GitOps/IK8sGptMcpClient.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/GitOps/IK8sGptMcpClient.cs
@@ -1,0 +1,110 @@
+using Domain.Common;
+
+namespace Application.AI.Common.Interfaces.GitOps;
+
+/// <summary>
+/// Client-side abstraction over the K8sGPT MCP server. The
+/// <c>gitops-cluster-debug</c> skill consumes this to obtain LLM-shaped
+/// root-cause analysis of cluster-side problems WITHOUT mutating the cluster.
+/// </summary>
+/// <remarks>
+/// <para>
+/// K8sGPT is a required dependency of the GitOps skill pack per the PR-9 plan
+/// — it is NOT gracefully degraded. A consumer that enables the GitOps skill
+/// pack without configuring a K8sGPT MCP server in
+/// <c>AppConfig.AI.McpServers</c> gets a fail-loud startup error from
+/// <c>GitOpsStartupValidator</c>. Degraded mode here would ship a half-working
+/// skill — the plan explicitly rejects that.
+/// </para>
+/// <para>
+/// The implementation MUST refuse to invoke any tool the K8sGPT MCP server
+/// might expose that mutates the cluster. The K8sGPT analysis surface is
+/// read-only; this client narrows it to read-only by contract regardless of
+/// what the server advertises.
+/// </para>
+/// </remarks>
+public interface IK8sGptMcpClient
+{
+    /// <summary>
+    /// Ask the K8sGPT backend to analyze the cluster and return root-cause
+    /// analysis findings.
+    /// </summary>
+    /// <param name="request">The analysis request — scope (namespace), filter (resource kinds), and explain flag.</param>
+    /// <param name="cancellationToken">Cooperative cancellation token.</param>
+    /// <returns>
+    /// <see cref="Result{T}.Success"/> wrapping the structured analysis result
+    /// on success; <see cref="Result{T}.Fail(string[])"/> with stable
+    /// <c>gitops.k8sgpt.*</c> codes on MCP-side failure (unreachable, auth,
+    /// schema mismatch).
+    /// </returns>
+    Task<Result<K8sGptAnalysisResult>> AnalyzeAsync(K8sGptAnalysisRequest request, CancellationToken cancellationToken);
+}
+
+/// <summary>Inputs to a K8sGPT analysis call.</summary>
+public sealed record K8sGptAnalysisRequest
+{
+    /// <summary>Kubernetes namespace to scope the analysis to. Null means all namespaces.</summary>
+    public string? Namespace { get; init; }
+
+    /// <summary>
+    /// Resource-kind filters (e.g. <c>"Deployment"</c>, <c>"Pod"</c>). Empty
+    /// means analyze every kind K8sGPT supports for this cluster.
+    /// </summary>
+    public IReadOnlyList<string> Filters { get; init; } = [];
+
+    /// <summary>
+    /// True to request a natural-language explanation alongside the structured
+    /// findings. Default true — the <c>gitops-cluster-debug</c> skill surfaces
+    /// the explanation in its RCA report.
+    /// </summary>
+    public bool Explain { get; init; } = true;
+}
+
+/// <summary>The structured root-cause analysis K8sGPT returns for a single call.</summary>
+public sealed record K8sGptAnalysisResult
+{
+    /// <summary>Wall-clock instant the analysis was captured.</summary>
+    public required DateTimeOffset CapturedAt { get; init; }
+
+    /// <summary>The findings K8sGPT identified. Empty when the cluster has nothing to report.</summary>
+    public IReadOnlyList<K8sGptFinding> Findings { get; init; } = [];
+
+    /// <summary>
+    /// The free-text explanation K8sGPT returned, when requested. Null when
+    /// <see cref="K8sGptAnalysisRequest.Explain"/> was false or the backend
+    /// returned no explanation.
+    /// </summary>
+    public string? Explanation { get; init; }
+}
+
+/// <summary>A single K8sGPT analysis finding.</summary>
+public sealed record K8sGptFinding
+{
+    /// <summary>The Kubernetes kind the finding relates to (e.g. <c>Deployment</c>).</summary>
+    public required string Kind { get; init; }
+
+    /// <summary>The resource name the finding relates to.</summary>
+    public required string Name { get; init; }
+
+    /// <summary>The namespace the resource lives in; null for cluster-scoped resources.</summary>
+    public string? Namespace { get; init; }
+
+    /// <summary>Short, human-readable description of the finding.</summary>
+    public string Summary { get; init; } = string.Empty;
+
+    /// <summary>K8sGPT's severity classification of the finding (Low / Medium / High).</summary>
+    public K8sGptSeverity Severity { get; init; } = K8sGptSeverity.Low;
+}
+
+/// <summary>Severity classification of a K8sGPT finding.</summary>
+public enum K8sGptSeverity
+{
+    /// <summary>Cosmetic / informational — no action required.</summary>
+    Low = 0,
+
+    /// <summary>Behavioural issue in a bounded module — single resource degraded.</summary>
+    Medium = 1,
+
+    /// <summary>Cross-cutting impact — multiple resources affected or critical resource down.</summary>
+    High = 2
+}

--- a/src/Content/Application/Application.Core/Validation/GitOpsConfigValidator.cs
+++ b/src/Content/Application/Application.Core/Validation/GitOpsConfigValidator.cs
@@ -1,0 +1,53 @@
+using Domain.Common.Config.AI.GitOps;
+using FluentValidation;
+
+namespace Application.Core.Validation;
+
+/// <summary>
+/// Validates <see cref="GitOpsConfig"/>. All rules are conditional on
+/// <see cref="GitOpsConfig.Enabled"/> — a disabled skill pack imposes no
+/// constraints so the template runs out of the box. When enabled the rules
+/// mirror <c>GitOpsStartupValidator</c> so a misconfiguration is caught both by
+/// the options-validation pipeline and at host boot.
+/// </summary>
+public sealed class GitOpsConfigValidator : AbstractValidator<GitOpsConfig>
+{
+    private static readonly string[] KnownControllers = ["flux", "argocd"];
+
+    /// <summary>Initializes a new instance of the <see cref="GitOpsConfigValidator"/> class.</summary>
+    public GitOpsConfigValidator()
+    {
+        When(x => x.Enabled, () =>
+        {
+            RuleFor(x => x.ActiveController)
+                .Must(c => KnownControllers.Contains(c?.Trim().ToLowerInvariant()))
+                .WithMessage("ActiveController must be \"flux\" or \"argocd\" when GitOps is enabled.");
+
+            RuleFor(x => x.K8sGptMcpServerName)
+                .NotEmpty()
+                .WithMessage("K8sGptMcpServerName is required when GitOps is enabled (K8sGPT is not gracefully degraded).");
+
+            RuleFor(x => x.RemediationRepoUrl)
+                .NotEmpty()
+                .Must(BeAbsoluteUrl)
+                .WithMessage("RemediationRepoUrl must be a non-empty absolute URL when GitOps is enabled.");
+
+            When(x => string.Equals(x.ActiveController?.Trim(), "flux", StringComparison.OrdinalIgnoreCase), () =>
+                RuleFor(x => x.FluxApiBaseUrl)
+                    .Must(BeAbsoluteHttpUrl)
+                    .WithMessage("FluxApiBaseUrl must be a valid absolute http(s) URL when ActiveController is \"flux\"."));
+
+            When(x => string.Equals(x.ActiveController?.Trim(), "argocd", StringComparison.OrdinalIgnoreCase), () =>
+                RuleFor(x => x.ArgoCdApiBaseUrl)
+                    .Must(BeAbsoluteHttpUrl)
+                    .WithMessage("ArgoCdApiBaseUrl must be a valid absolute http(s) URL when ActiveController is \"argocd\"."));
+        });
+    }
+
+    private static bool BeAbsoluteUrl(string url)
+        => !string.IsNullOrWhiteSpace(url) && Uri.TryCreate(url, UriKind.Absolute, out _);
+
+    private static bool BeAbsoluteHttpUrl(string url)
+        => Uri.TryCreate(url, UriKind.Absolute, out var uri) &&
+           (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps);
+}

--- a/src/Content/Domain/Domain.AI/GitOps/ClusterHealth.cs
+++ b/src/Content/Domain/Domain.AI/GitOps/ClusterHealth.cs
@@ -1,0 +1,82 @@
+namespace Domain.AI.GitOps;
+
+/// <summary>
+/// A controller-neutral snapshot of cluster-level health as seen by the active
+/// GitOps controller. Produced by <c>IGitOpsController.GetClusterHealthAsync</c>
+/// and consumed by the <c>gitops-cluster-debug</c> skill as one of the two
+/// signal sources for RCA (the other being K8sGPT).
+/// </summary>
+/// <remarks>
+/// <para>
+/// This type is deliberately read-only and observational — neither Flux nor
+/// Argo CD-specific health primitives leak through. The implementation maps
+/// controller-native concepts (Flux <c>Suspended</c> + <c>Stalled</c> +
+/// <c>Ready</c> conditions, Argo CD <c>HealthStatus</c> + <c>SyncStatus</c>)
+/// onto this neutral surface.
+/// </para>
+/// </remarks>
+public sealed record ClusterHealth
+{
+    /// <summary>The controller that produced this snapshot.</summary>
+    public required GitOpsControllerKind ControllerKind { get; init; }
+
+    /// <summary>Wall-clock instant the snapshot was captured.</summary>
+    public required DateTimeOffset CapturedAt { get; init; }
+
+    /// <summary>Overall cluster status — neutral roll-up across all watched resources.</summary>
+    public ClusterHealthStatus OverallStatus { get; init; } = ClusterHealthStatus.Unknown;
+
+    /// <summary>
+    /// Per-resource health entries. Empty when the controller reports the cluster
+    /// is fully reconciled and healthy.
+    /// </summary>
+    public IReadOnlyList<ResourceHealth> ResourceStates { get; init; } = [];
+
+    /// <summary>
+    /// Free-form notes the controller surfaced at the cluster level (e.g. Flux
+    /// notification-controller backlog warnings, Argo CD ApplicationSet errors).
+    /// Surfaces verbatim in <c>gitops-cluster-debug</c> reports.
+    /// </summary>
+    public IReadOnlyList<string> Notes { get; init; } = [];
+}
+
+/// <summary>The neutral roll-up status of a <see cref="ClusterHealth"/> snapshot.</summary>
+public enum ClusterHealthStatus
+{
+    /// <summary>The controller's status is not yet known — initial call hasn't returned.</summary>
+    Unknown = 0,
+
+    /// <summary>Every watched resource is Ready and Sync'd.</summary>
+    Healthy = 1,
+
+    /// <summary>At least one resource is Progressing — converging toward desired state, no failures.</summary>
+    Progressing = 2,
+
+    /// <summary>At least one resource is Degraded — reachable but unhealthy.</summary>
+    Degraded = 3,
+
+    /// <summary>At least one resource is in a hard-failure state — Stalled (Flux) or Failed (Argo CD).</summary>
+    Failed = 4
+}
+
+/// <summary>A single resource's health entry inside a <see cref="ClusterHealth"/> snapshot.</summary>
+public sealed record ResourceHealth
+{
+    /// <summary>The resource's Kubernetes API group/version.</summary>
+    public required string ApiVersion { get; init; }
+
+    /// <summary>The resource's Kubernetes kind.</summary>
+    public required string Kind { get; init; }
+
+    /// <summary>The resource's namespace; null for cluster-scoped resources.</summary>
+    public string? Namespace { get; init; }
+
+    /// <summary>The resource name.</summary>
+    public required string Name { get; init; }
+
+    /// <summary>The resource's roll-up status.</summary>
+    public ClusterHealthStatus Status { get; init; } = ClusterHealthStatus.Unknown;
+
+    /// <summary>Short human-readable message explaining the status.</summary>
+    public string Message { get; init; } = string.Empty;
+}

--- a/src/Content/Domain/Domain.AI/GitOps/DriftReport.cs
+++ b/src/Content/Domain/Domain.AI/GitOps/DriftReport.cs
@@ -1,0 +1,108 @@
+namespace Domain.AI.GitOps;
+
+/// <summary>
+/// A controller-neutral snapshot of drift between desired state (declared in Git)
+/// and actual state (running in the cluster). Produced by
+/// <c>IGitOpsController.DetectDriftAsync</c>. The same shape is returned by both
+/// the Flux and ArgoCD implementations so consumers can author drift-handling
+/// logic once.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Records the controller-of-origin via <see cref="ControllerKind"/> so audit
+/// lines and remediation proposals carry that breadcrumb forward — the
+/// controller-neutral abstraction is for callers, not for the audit trail.
+/// </para>
+/// <para>
+/// <see cref="EvidenceHash"/> is a content-addressed digest of the raw controller
+/// response that produced this report. The harness's evidence store keys gate
+/// findings on this hash, so a drift report can be referenced from a
+/// <c>ChangeProposal</c>'s audit chain without re-fetching the controller's
+/// response.
+/// </para>
+/// </remarks>
+public sealed record DriftReport
+{
+    /// <summary>The controller that produced this report.</summary>
+    public required GitOpsControllerKind ControllerKind { get; init; }
+
+    /// <summary>
+    /// Wall-clock instant the report was captured. Used in audit lines and to
+    /// detect stale reports the remediation pipeline should refuse to act on.
+    /// </summary>
+    public required DateTimeOffset CapturedAt { get; init; }
+
+    /// <summary>
+    /// The set of resources whose live state diverges from the Git-declared
+    /// desired state. Empty when the cluster is fully reconciled.
+    /// </summary>
+    public IReadOnlyList<DriftedResource> DriftedResources { get; init; } = [];
+
+    /// <summary>
+    /// Content-addressed digest of the raw controller response that produced this
+    /// report. Stable across captures of identical responses; used as the
+    /// evidence key when this report surfaces in a <c>ChangeProposal</c>.
+    /// </summary>
+    public string EvidenceHash { get; init; } = string.Empty;
+
+    /// <summary>True when at least one resource is drifted.</summary>
+    public bool HasDrift => DriftedResources.Count > 0;
+}
+
+/// <summary>
+/// A single resource whose actual state differs from its Git-declared desired
+/// state. Controller-neutral — the implementation maps Flux <c>Kustomization</c>
+/// status fields or Argo CD <c>Application</c> sync status fields onto this
+/// shared shape.
+/// </summary>
+public sealed record DriftedResource
+{
+    /// <summary>The resource's Kubernetes API group/version (e.g. <c>apps/v1</c>).</summary>
+    public required string ApiVersion { get; init; }
+
+    /// <summary>The resource's Kubernetes kind (e.g. <c>Deployment</c>, <c>HelmRelease</c>).</summary>
+    public required string Kind { get; init; }
+
+    /// <summary>The resource's namespace; null for cluster-scoped resources.</summary>
+    public string? Namespace { get; init; }
+
+    /// <summary>The resource name.</summary>
+    public required string Name { get; init; }
+
+    /// <summary>
+    /// The Git path the desired state was declared at, when the controller
+    /// reports it. Used by remediation to identify which file in the Git repo
+    /// the <c>ChangeProposal</c> should target.
+    /// </summary>
+    public string? DesiredPath { get; init; }
+
+    /// <summary>
+    /// Short, human-readable description of how this resource diverges. Surfaces
+    /// in drift reports and remediation summaries.
+    /// </summary>
+    public string Summary { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Severity band for prioritization: Low / Medium / High. The drift detector
+    /// maps controller-specific severity signals (e.g. Argo CD <c>HealthStatus</c>
+    /// or Flux <c>Suspended</c>) onto this neutral scale.
+    /// </summary>
+    public DriftSeverity Severity { get; init; } = DriftSeverity.Low;
+}
+
+/// <summary>
+/// Coarse prioritization band for a <see cref="DriftedResource"/>. Drives
+/// remediation default <c>BlastRadius</c> and the order in which the remediation
+/// pipeline addresses concurrent drift.
+/// </summary>
+public enum DriftSeverity
+{
+    /// <summary>Cosmetic divergence — annotations, labels, replicas within HPA range.</summary>
+    Low = 0,
+
+    /// <summary>Behavioural divergence in a bounded module — single Deployment image mismatch, ConfigMap key changed.</summary>
+    Medium = 1,
+
+    /// <summary>Cross-cutting or public-contract divergence — CRD spec mismatch, Ingress host change, Secret type drift.</summary>
+    High = 2
+}

--- a/src/Content/Domain/Domain.AI/GitOps/GitOpsControllerKind.cs
+++ b/src/Content/Domain/Domain.AI/GitOps/GitOpsControllerKind.cs
@@ -1,0 +1,41 @@
+namespace Domain.AI.GitOps;
+
+/// <summary>
+/// Discriminator identifying which GitOps controller a configured
+/// <c>IGitOpsController</c> implementation talks to. Surfaces in audit lines,
+/// drift reports, and remediation proposals so downstream consumers can branch
+/// on the source controller without re-deriving it from the resolved instance
+/// type (which is intentionally hidden behind the controller-neutral interface).
+/// </summary>
+/// <remarks>
+/// <para>
+/// PR-9 ships the two production-grade GitOps controllers in widest enterprise
+/// use today; future controllers are added as new enum members and matching
+/// <c>IGitOpsController</c> implementations registered behind their string-key.
+/// </para>
+/// <para>
+/// The string form (lowercase) of each member is the keyed-DI service key used
+/// to resolve the active <c>IGitOpsController</c> by configuration. Member
+/// names follow PascalCase here per the codebase convention; consumers must
+/// lower-case before resolving (or use the well-known constants surfaced by
+/// the Application layer).
+/// </para>
+/// </remarks>
+public enum GitOpsControllerKind
+{
+    /// <summary>
+    /// Flux v2 (toolkit). The controller talks to a cluster running the Flux
+    /// source-controller, kustomize-controller, helm-controller, and
+    /// notification-controller deployments. Drift is read from
+    /// <c>Kustomization</c> and <c>HelmRelease</c> custom resources.
+    /// </summary>
+    Flux = 0,
+
+    /// <summary>
+    /// Argo CD. The controller talks to the Argo CD API server (HTTPS) and
+    /// reads drift from <c>Application</c> custom resources via the documented
+    /// REST surface. The Argo CD API is the source of truth — the implementation
+    /// never bypasses it by reading raw CRDs directly.
+    /// </summary>
+    ArgoCd = 1
+}

--- a/src/Content/Domain/Domain.AI/GitOps/RemediationPlan.cs
+++ b/src/Content/Domain/Domain.AI/GitOps/RemediationPlan.cs
@@ -1,0 +1,57 @@
+using Domain.AI.Changes;
+
+namespace Domain.AI.GitOps;
+
+/// <summary>
+/// A controller-neutral remediation proposal — the result of a controller
+/// taking a <see cref="DriftReport"/> and producing the ordered set of Git
+/// edits that would re-converge the cluster to its declared desired state.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A <see cref="RemediationPlan"/> NEVER mutates the cluster — it surfaces as
+/// a <c>ChangeProposal</c> against a <see cref="GitRepoTarget"/>, gated by the
+/// PR-2 pipeline. The plan carries a <see cref="ChangeTarget"/> and the
+/// ordered <see cref="Edits"/>; the <c>IGitOpsRemediationDispatcher</c> wraps
+/// the plan in a <c>SubmitChangeProposalCommand</c> at submission time.
+/// </para>
+/// <para>
+/// <see cref="ProposedBlastRadius"/> is the controller's first-cut radius based
+/// on drift severity and the number of resources touched. The
+/// <c>IChangeProposalGateResolver</c> may revise it during gate evaluation —
+/// the audit trail records both values. The default mapping is documented on
+/// each <see cref="DriftSeverity"/> member.
+/// </para>
+/// </remarks>
+public sealed record RemediationPlan
+{
+    /// <summary>The controller that produced this plan.</summary>
+    public required GitOpsControllerKind ControllerKind { get; init; }
+
+    /// <summary>The drift report this plan addresses. Carried for audit linkage.</summary>
+    public required DriftReport SourceDrift { get; init; }
+
+    /// <summary>
+    /// The target the plan's edits will apply to. A <c>GitRepoTarget</c> in the
+    /// shipping implementations; modeled as the base <see cref="ChangeTarget"/>
+    /// so future targets (e.g. Helm chart registry) can be added without
+    /// breaking consumers.
+    /// </summary>
+    public required ChangeTarget Target { get; init; }
+
+    /// <summary>The ordered list of bounded edits the plan would apply to <see cref="Target"/>.</summary>
+    public IReadOnlyList<ChangeEdit> Edits { get; init; } = [];
+
+    /// <summary>
+    /// The controller's first-cut blast radius for this plan. Gate resolution
+    /// may revise it — audit records both. Critical drift always requires
+    /// human approval regardless of this advisory value.
+    /// </summary>
+    public BlastRadius ProposedBlastRadius { get; init; } = BlastRadius.Medium;
+
+    /// <summary>
+    /// Human-readable summary that surfaces in the resulting
+    /// <c>ChangeProposal</c>'s summary line and approval prompt.
+    /// </summary>
+    public string Summary { get; init; } = string.Empty;
+}

--- a/src/Content/Domain/Domain.Common/Config/AI/AIConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/AIConfig.cs
@@ -2,6 +2,7 @@ using Domain.Common.Config.AI.A2A;
 using Domain.Common.Config.AI.AIFoundry;
 using Domain.Common.Config.AI.ContextManagement;
 using Domain.Common.Config.AI.DriftDetection;
+using Domain.Common.Config.AI.GitOps;
 using Domain.Common.Config.AI.Hooks;
 using Domain.Common.Config.AI.Identity;
 using Domain.Common.Config.AI.IncidentResponse;
@@ -223,4 +224,14 @@ public class AIConfig
     /// behaves identically to a host with no incident concept at all.
     /// </summary>
     public IncidentResponsePlanConfig IncidentResponse { get; set; } = new();
+
+    /// <summary>
+    /// GitOps skill pack configuration (PR-9). Off by default — when enabled,
+    /// the startup validator requires <c>ActiveController</c> to be set,
+    /// a configured K8sGPT MCP server entry under <c>McpServers.Servers</c>,
+    /// and the active controller's API base URL. No graceful degradation:
+    /// misconfiguration fails-loud at boot rather than shipping a half-working
+    /// skill at runtime.
+    /// </summary>
+    public GitOpsConfig GitOps { get; set; } = new();
 }

--- a/src/Content/Domain/Domain.Common/Config/AI/GitOps/GitOpsConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/GitOps/GitOpsConfig.cs
@@ -1,0 +1,73 @@
+namespace Domain.Common.Config.AI.GitOps;
+
+/// <summary>
+/// Configuration for the GitOps skill pack (PR-9). Bound from
+/// <c>AppConfig:AI:GitOps</c> in appsettings.json.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Off by default — the skill pack is inert until <see cref="Enabled"/> is set
+/// to true. When enabled the startup validator additionally requires:
+/// </para>
+/// <list type="bullet">
+///   <item><description><see cref="ActiveController"/> is one of <c>"flux"</c> or <c>"argocd"</c>.</description></item>
+///   <item><description><see cref="K8sGptMcpServerName"/> resolves to a configured entry under <c>AppConfig.AI.McpServers.Servers</c>.</description></item>
+///   <item><description>The Flux or Argo CD <see cref="FluxApiBaseUrl"/> / <see cref="ArgoCdApiBaseUrl"/> for the active controller is non-empty and a valid http(s) URL.</description></item>
+/// </list>
+/// <para>
+/// Misconfiguration surfaces at boot via <c>GitOpsStartupValidator</c> — per
+/// the plan's "no graceful degradation" rule for K8sGPT (and by the same
+/// reasoning, no graceful degradation for the active controller).
+/// </para>
+/// </remarks>
+public sealed class GitOpsConfig
+{
+    /// <summary>
+    /// Master toggle. When false, the skill pack and all GitOps tools are
+    /// inert. Default false.
+    /// </summary>
+    public bool Enabled { get; set; }
+
+    /// <summary>
+    /// The active GitOps controller — the keyed-DI key under which the
+    /// resolved <c>IGitOpsController</c> lives. One of <c>"flux"</c> or
+    /// <c>"argocd"</c> (lowercase). The startup validator refuses to boot if
+    /// this is empty or unknown when <see cref="Enabled"/> is true.
+    /// </summary>
+    public string ActiveController { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The name of the K8sGPT MCP server entry under
+    /// <c>AppConfig.AI.McpServers.Servers</c>. Default <c>"k8sgpt"</c>; the
+    /// startup validator refuses to boot when this key is missing from the
+    /// MCP server registry. K8sGPT is a required dependency of the
+    /// <c>gitops-cluster-debug</c> skill — gracefully degraded would ship a
+    /// half-working skill.
+    /// </summary>
+    public string K8sGptMcpServerName { get; set; } = "k8sgpt";
+
+    /// <summary>
+    /// Base URL for the Flux source-controller HTTP-exposed metrics / status
+    /// surface. Used only when <see cref="ActiveController"/> is <c>"flux"</c>.
+    /// </summary>
+    public string FluxApiBaseUrl { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Base URL for the Argo CD API server (e.g. <c>https://argocd.example.com</c>).
+    /// Used only when <see cref="ActiveController"/> is <c>"argocd"</c>.
+    /// </summary>
+    public string ArgoCdApiBaseUrl { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The Git repository URL the remediation pipeline targets. Required
+    /// when <see cref="Enabled"/> is true — the <c>RemediationPlan</c> targets
+    /// this repo regardless of which controller produced the drift.
+    /// </summary>
+    public string RemediationRepoUrl { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The branch under <see cref="RemediationRepoUrl"/> the remediation
+    /// pipeline writes changes to. Default <c>"main"</c>.
+    /// </summary>
+    public string RemediationBranch { get; set; } = "main";
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.cs
@@ -18,6 +18,7 @@ using Infrastructure.AI.Agents;
 using Infrastructure.AI.Audit;
 using Infrastructure.AI.Compaction;
 using Infrastructure.AI.Compaction.Strategies;
+using Infrastructure.AI.Tools.GitOps;
 using Infrastructure.AI.Tools.Workspace;
 using Infrastructure.AI.Compression;
 using Infrastructure.AI.Compression.Strategies;
@@ -125,6 +126,12 @@ public static partial class DependencyInjection
         // working-copy path. Registered unconditionally so any consumer that enables the
         // workspace-skill plugin sees the keyed-DI tool entries available.
         services.AddWorkspaceSkillTools();
+
+        // GitOps skill pack — detect_drift, cluster_health, propose_remediation (submits
+        // ChangeProposal), k8sgpt_analyze. Flux + Argo CD controllers behind IGitOpsController;
+        // the active one is selected by AppConfig.AI.GitOps.ActiveController. Registered
+        // unconditionally; GitOpsStartupValidator fails the host loud when Enabled with bad config.
+        services.AddGitOpsSkillTools();
 
         // Chat client factory — creates IChatClient from Azure OpenAI / OpenAI / AI Inference / Persistent Agents
         services.AddSingleton<IChatClientFactory, ChatClientFactory>();

--- a/src/Content/Infrastructure/Infrastructure.AI/GitOps/ArgoCd/ArgoCdApiClient.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/GitOps/ArgoCd/ArgoCdApiClient.cs
@@ -1,0 +1,161 @@
+using System.Net.Http.Json;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Domain.Common.Config;
+using Infrastructure.AI.Egress;
+
+namespace Infrastructure.AI.GitOps.ArgoCd;
+
+/// <summary>
+/// Thin HTTP client for the Argo CD API server. Reads <c>Application</c>
+/// resource status via the documented REST surface
+/// (<c>/api/v1/applications</c>). Uses the egress-gated named
+/// <see cref="HttpClient"/> from PR-3b.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Argo CD's REST API is the source of truth — this client never bypasses
+/// it by reading the underlying CRDs directly. Auth is expected to be carried
+/// on the egress <see cref="HttpClient"/> by the consumer's auth strategy
+/// (delegating handler stamped Bearer token); the client itself does not
+/// negotiate auth.
+/// </para>
+/// </remarks>
+public sealed class ArgoCdApiClient
+{
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly IOptionsMonitor<AppConfig> _config;
+    private readonly ILogger<ArgoCdApiClient> _logger;
+
+    /// <summary>Initializes a new <see cref="ArgoCdApiClient"/>.</summary>
+    public ArgoCdApiClient(
+        IHttpClientFactory httpClientFactory,
+        IOptionsMonitor<AppConfig> config,
+        ILogger<ArgoCdApiClient> logger)
+    {
+        ArgumentNullException.ThrowIfNull(httpClientFactory);
+        ArgumentNullException.ThrowIfNull(config);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _httpClientFactory = httpClientFactory;
+        _config = config;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// List Argo CD <c>Application</c> resources with their sync + health status.
+    /// </summary>
+    /// <param name="cancellationToken">Cooperative cancellation token.</param>
+    public async Task<IReadOnlyList<ArgoCdApplicationStatus>> ListApplicationsAsync(
+        CancellationToken cancellationToken)
+    {
+        var baseUrl = _config.CurrentValue.AI.GitOps.ArgoCdApiBaseUrl;
+        if (string.IsNullOrWhiteSpace(baseUrl))
+        {
+            throw new InvalidOperationException(
+                "AppConfig.AI.GitOps.ArgoCdApiBaseUrl is empty. The GitOps startup validator should have caught this.");
+        }
+
+        var client = _httpClientFactory.CreateClient(EgressPolicyDelegatingHandler.ClientName);
+        var url = $"{baseUrl.TrimEnd('/')}/api/v1/applications";
+
+        _logger.LogDebug("Listing Argo CD Applications from {Url}", url);
+
+        var response = await client
+            .GetFromJsonAsync<ArgoCdApplicationListResponse>(url, cancellationToken)
+            .ConfigureAwait(false);
+
+        return response?.Items ?? [];
+    }
+}
+
+/// <summary>Argo CD Application status as returned by the API server.</summary>
+public sealed record ArgoCdApplicationStatus
+{
+    /// <summary>The Application metadata block.</summary>
+    [JsonPropertyName("metadata")]
+    public ArgoCdMetadata Metadata { get; init; } = new();
+
+    /// <summary>The Application spec block.</summary>
+    [JsonPropertyName("spec")]
+    public ArgoCdSpec Spec { get; init; } = new();
+
+    /// <summary>The Application status block.</summary>
+    [JsonPropertyName("status")]
+    public ArgoCdStatus Status { get; init; } = new();
+}
+
+/// <summary>Argo CD Application metadata fragment.</summary>
+public sealed record ArgoCdMetadata
+{
+    /// <summary>The Application name.</summary>
+    [JsonPropertyName("name")]
+    public string Name { get; init; } = string.Empty;
+
+    /// <summary>The namespace (almost always "argocd").</summary>
+    [JsonPropertyName("namespace")]
+    public string Namespace { get; init; } = string.Empty;
+}
+
+/// <summary>Argo CD Application spec fragment.</summary>
+public sealed record ArgoCdSpec
+{
+    /// <summary>The Git source the Application reconciles from.</summary>
+    [JsonPropertyName("source")]
+    public ArgoCdSource Source { get; init; } = new();
+}
+
+/// <summary>Argo CD Application source fragment.</summary>
+public sealed record ArgoCdSource
+{
+    /// <summary>The Git repository URL.</summary>
+    [JsonPropertyName("repoURL")]
+    public string RepoUrl { get; init; } = string.Empty;
+
+    /// <summary>The path within the repo.</summary>
+    [JsonPropertyName("path")]
+    public string Path { get; init; } = string.Empty;
+}
+
+/// <summary>Argo CD Application status fragment.</summary>
+public sealed record ArgoCdStatus
+{
+    /// <summary>The sync status block.</summary>
+    [JsonPropertyName("sync")]
+    public ArgoCdSyncStatus Sync { get; init; } = new();
+
+    /// <summary>The health status block.</summary>
+    [JsonPropertyName("health")]
+    public ArgoCdHealthStatus Health { get; init; } = new();
+}
+
+/// <summary>Argo CD sync status fragment.</summary>
+public sealed record ArgoCdSyncStatus
+{
+    /// <summary>The sync status string — <c>Synced</c>, <c>OutOfSync</c>, or <c>Unknown</c>.</summary>
+    [JsonPropertyName("status")]
+    public string Status { get; init; } = string.Empty;
+
+    /// <summary>The last-synced revision.</summary>
+    [JsonPropertyName("revision")]
+    public string Revision { get; init; } = string.Empty;
+}
+
+/// <summary>Argo CD health status fragment.</summary>
+public sealed record ArgoCdHealthStatus
+{
+    /// <summary>The health status string — <c>Healthy</c>, <c>Progressing</c>, <c>Degraded</c>, <c>Suspended</c>, <c>Missing</c>, or <c>Unknown</c>.</summary>
+    [JsonPropertyName("status")]
+    public string Status { get; init; } = string.Empty;
+
+    /// <summary>Human-readable message.</summary>
+    [JsonPropertyName("message")]
+    public string Message { get; init; } = string.Empty;
+}
+
+internal sealed record ArgoCdApplicationListResponse
+{
+    [JsonPropertyName("items")]
+    public IReadOnlyList<ArgoCdApplicationStatus> Items { get; init; } = [];
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/GitOps/ArgoCd/ArgoCdGitOpsController.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/GitOps/ArgoCd/ArgoCdGitOpsController.cs
@@ -1,0 +1,282 @@
+using System.Security.Cryptography;
+using System.Text;
+using Application.AI.Common.Interfaces.GitOps;
+using Domain.AI.Changes;
+using Domain.AI.GitOps;
+using Domain.AI.SkillTraining;
+using Domain.Common;
+using Domain.Common.Config;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Infrastructure.AI.GitOps.ArgoCd;
+
+/// <summary>
+/// Argo CD implementation of <see cref="IGitOpsController"/>. Reads drift and
+/// health from the Argo CD API server via <see cref="ArgoCdApiClient"/>, then
+/// maps the wire shape onto the controller-neutral <see cref="DriftReport"/> /
+/// <see cref="ClusterHealth"/> / <see cref="RemediationPlan"/> types.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Read-only — never mutates the cluster. Remediation surfaces as a
+/// <see cref="RemediationPlan"/> the <c>IGitOpsRemediationDispatcher</c>
+/// translates into a <c>ChangeProposal</c> against a <c>GitRepoTarget</c>.
+/// </para>
+/// <para>
+/// Drift detection signal: an Argo CD <c>Application</c> is considered drifted
+/// when <c>Status.Sync.Status</c> is <c>OutOfSync</c> OR when
+/// <c>Status.Health.Status</c> is <c>Degraded</c> / <c>Missing</c>. The
+/// <c>Suspended</c> health status is surfaced as a Note in
+/// <see cref="ClusterHealth"/> but NOT as drift — operators may suspend
+/// reconciliation deliberately.
+/// </para>
+/// </remarks>
+public sealed class ArgoCdGitOpsController : IGitOpsController
+{
+    private readonly ArgoCdApiClient _apiClient;
+    private readonly IOptionsMonitor<AppConfig> _config;
+    private readonly ILogger<ArgoCdGitOpsController> _logger;
+    private readonly TimeProvider _timeProvider;
+
+    /// <summary>Initializes a new <see cref="ArgoCdGitOpsController"/>.</summary>
+    public ArgoCdGitOpsController(
+        ArgoCdApiClient apiClient,
+        IOptionsMonitor<AppConfig> config,
+        ILogger<ArgoCdGitOpsController> logger,
+        TimeProvider timeProvider)
+    {
+        ArgumentNullException.ThrowIfNull(apiClient);
+        ArgumentNullException.ThrowIfNull(config);
+        ArgumentNullException.ThrowIfNull(logger);
+        ArgumentNullException.ThrowIfNull(timeProvider);
+
+        _apiClient = apiClient;
+        _config = config;
+        _logger = logger;
+        _timeProvider = timeProvider;
+    }
+
+    /// <inheritdoc />
+    public GitOpsControllerKind Kind => GitOpsControllerKind.ArgoCd;
+
+    /// <inheritdoc />
+    public async Task<Result<DriftReport>> DetectDriftAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            var applications = await _apiClient.ListApplicationsAsync(cancellationToken).ConfigureAwait(false);
+
+            var drifted = new List<DriftedResource>();
+            foreach (var app in applications)
+            {
+                if (IsApplicationDrifted(app))
+                {
+                    drifted.Add(MapDriftedApplication(app));
+                }
+            }
+
+            var capturedAt = _timeProvider.GetUtcNow();
+            return Result<DriftReport>.Success(new DriftReport
+            {
+                ControllerKind = Kind,
+                CapturedAt = capturedAt,
+                DriftedResources = drifted,
+                EvidenceHash = ComputeEvidenceHash(applications, capturedAt)
+            });
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogWarning(ex, "Argo CD drift detection failed: API unreachable.");
+            return Result<DriftReport>.Fail("gitops.argocd.api_unreachable");
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogError(ex, "Argo CD drift detection failed with unexpected error.");
+            return Result<DriftReport>.Fail("gitops.argocd.unexpected_error");
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<Result<ClusterHealth>> GetClusterHealthAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            var applications = await _apiClient.ListApplicationsAsync(cancellationToken).ConfigureAwait(false);
+
+            var resources = new List<ResourceHealth>();
+            var notes = new List<string>();
+            var overall = ClusterHealthStatus.Healthy;
+
+            foreach (var app in applications)
+            {
+                var status = MapApplicationHealth(app);
+                resources.Add(new ResourceHealth
+                {
+                    ApiVersion = "argoproj.io/v1alpha1",
+                    Kind = "Application",
+                    Namespace = app.Metadata.Namespace,
+                    Name = app.Metadata.Name,
+                    Status = status,
+                    Message = app.Status.Health.Message
+                });
+                if (string.Equals(app.Status.Health.Status, "Suspended", StringComparison.OrdinalIgnoreCase))
+                {
+                    notes.Add($"Application {app.Metadata.Namespace}/{app.Metadata.Name} is suspended.");
+                }
+                overall = Worst(overall, status);
+            }
+
+            return Result<ClusterHealth>.Success(new ClusterHealth
+            {
+                ControllerKind = Kind,
+                CapturedAt = _timeProvider.GetUtcNow(),
+                OverallStatus = overall,
+                ResourceStates = resources,
+                Notes = notes
+            });
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogWarning(ex, "Argo CD cluster health read failed: API unreachable.");
+            return Result<ClusterHealth>.Fail("gitops.argocd.api_unreachable");
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogError(ex, "Argo CD cluster health read failed with unexpected error.");
+            return Result<ClusterHealth>.Fail("gitops.argocd.unexpected_error");
+        }
+    }
+
+    /// <inheritdoc />
+    public Task<Result<RemediationPlan>> ProposeRemediationAsync(DriftReport drift, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(drift);
+        if (drift.ControllerKind != Kind)
+        {
+            return Task.FromResult(Result<RemediationPlan>.Fail("gitops.remediation.controller_mismatch"));
+        }
+        if (!drift.HasDrift)
+        {
+            return Task.FromResult(Result<RemediationPlan>.Fail("gitops.remediation.no_drift"));
+        }
+
+        var gitops = _config.CurrentValue.AI.GitOps;
+        if (string.IsNullOrWhiteSpace(gitops.RemediationRepoUrl))
+        {
+            return Task.FromResult(Result<RemediationPlan>.Fail("gitops.remediation.no_repo_configured"));
+        }
+
+        var target = new GitRepoTarget(
+            repoUrl: gitops.RemediationRepoUrl,
+            branch: gitops.RemediationBranch,
+            headSha: null,
+            workingPath: string.Empty);
+
+        var edits = drift.DriftedResources
+            .Where(r => !string.IsNullOrEmpty(r.DesiredPath))
+            .Select(r => new ChangeEdit
+            {
+                Op = EditOp.Replace,
+                Target = r.DesiredPath!,
+                Content = BuildReconvergePlaceholder(r)
+            })
+            .ToList();
+
+        if (edits.Count == 0)
+        {
+            return Task.FromResult(Result<RemediationPlan>.Fail("gitops.remediation.no_remediable_drift"));
+        }
+
+        var maxSeverity = drift.DriftedResources.Max(r => r.Severity);
+        var blastRadius = maxSeverity switch
+        {
+            DriftSeverity.High => BlastRadius.High,
+            DriftSeverity.Medium => BlastRadius.Medium,
+            _ => BlastRadius.Low
+        };
+
+        return Task.FromResult(Result<RemediationPlan>.Success(new RemediationPlan
+        {
+            ControllerKind = Kind,
+            SourceDrift = drift,
+            Target = target,
+            Edits = edits,
+            ProposedBlastRadius = blastRadius,
+            Summary = $"Argo CD: reconverge {drift.DriftedResources.Count} drifted resource(s)."
+        }));
+    }
+
+    private static bool IsApplicationDrifted(ArgoCdApplicationStatus app)
+    {
+        var sync = app.Status.Sync.Status;
+        var health = app.Status.Health.Status;
+
+        if (string.Equals(sync, "OutOfSync", StringComparison.OrdinalIgnoreCase)) return true;
+        if (string.Equals(health, "Degraded", StringComparison.OrdinalIgnoreCase)) return true;
+        if (string.Equals(health, "Missing", StringComparison.OrdinalIgnoreCase)) return true;
+        return false;
+    }
+
+    private static DriftedResource MapDriftedApplication(ArgoCdApplicationStatus app)
+    {
+        var sev = string.Equals(app.Status.Health.Status, "Degraded", StringComparison.OrdinalIgnoreCase)
+            ? DriftSeverity.High
+            : string.Equals(app.Status.Health.Status, "Missing", StringComparison.OrdinalIgnoreCase)
+                ? DriftSeverity.High
+                : DriftSeverity.Medium;
+
+        var summary = string.IsNullOrEmpty(app.Status.Health.Message)
+            ? $"Sync={app.Status.Sync.Status}, Health={app.Status.Health.Status}"
+            : app.Status.Health.Message;
+
+        return new DriftedResource
+        {
+            ApiVersion = "argoproj.io/v1alpha1",
+            Kind = "Application",
+            Namespace = app.Metadata.Namespace,
+            Name = app.Metadata.Name,
+            DesiredPath = app.Spec.Source.Path,
+            Summary = summary,
+            Severity = sev
+        };
+    }
+
+    private static ClusterHealthStatus MapApplicationHealth(ArgoCdApplicationStatus app)
+    {
+        var sync = app.Status.Sync.Status;
+        var health = app.Status.Health.Status;
+
+        if (string.Equals(health, "Healthy", StringComparison.OrdinalIgnoreCase)
+            && string.Equals(sync, "Synced", StringComparison.OrdinalIgnoreCase))
+            return ClusterHealthStatus.Healthy;
+        if (string.Equals(health, "Progressing", StringComparison.OrdinalIgnoreCase))
+            return ClusterHealthStatus.Progressing;
+        if (string.Equals(health, "Suspended", StringComparison.OrdinalIgnoreCase))
+            return ClusterHealthStatus.Progressing;
+        if (string.Equals(health, "Degraded", StringComparison.OrdinalIgnoreCase))
+            return ClusterHealthStatus.Degraded;
+        if (string.Equals(health, "Missing", StringComparison.OrdinalIgnoreCase))
+            return ClusterHealthStatus.Failed;
+        return ClusterHealthStatus.Unknown;
+    }
+
+    private static ClusterHealthStatus Worst(ClusterHealthStatus a, ClusterHealthStatus b) =>
+        (ClusterHealthStatus)Math.Max((int)a, (int)b);
+
+    private static string BuildReconvergePlaceholder(DriftedResource r) =>
+        $"# reconverge target for {r.Kind} {r.Namespace}/{r.Name} — operator action required";
+
+    private static string ComputeEvidenceHash(
+        IReadOnlyList<ArgoCdApplicationStatus> applications,
+        DateTimeOffset capturedAt)
+    {
+        var sb = new StringBuilder();
+        sb.Append("argocd|").Append(capturedAt.ToUnixTimeSeconds()).Append('|');
+        foreach (var app in applications.OrderBy(a => a.Metadata.Namespace, StringComparer.Ordinal).ThenBy(a => a.Metadata.Name, StringComparer.Ordinal))
+            sb.Append("a:").Append(app.Metadata.Namespace).Append('/').Append(app.Metadata.Name).Append(':')
+              .Append(app.Status.Sync.Status).Append(':').Append(app.Status.Health.Status).Append(';');
+        var hash = SHA256.HashData(Encoding.UTF8.GetBytes(sb.ToString()));
+        return Convert.ToHexString(hash);
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/GitOps/Flux/FluxApiClient.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/GitOps/Flux/FluxApiClient.cs
@@ -1,0 +1,180 @@
+using System.Net.Http.Json;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Domain.Common.Config;
+using Infrastructure.AI.Egress;
+
+namespace Infrastructure.AI.GitOps.Flux;
+
+/// <summary>
+/// Thin HTTP client for Flux v2 controller status surfaces. Talks to a Flux
+/// instance running the source-controller + kustomize-controller + helm-controller
+/// stack, reading <c>Kustomization</c> and <c>HelmRelease</c> reconciliation
+/// status. Uses the egress-gated named <see cref="HttpClient"/> from PR-3b so
+/// allowlist + SSRF defense apply to every outbound call.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Flux does not ship a single uniform HTTP API the way Argo CD does. Real
+/// production setups expose Flux status via the cluster's Kubernetes API
+/// (read via service-account token) or via a metrics + status sidecar. This
+/// client targets the documented HTTP status surface for portability; the
+/// concrete URL shape is config-driven via
+/// <c>AppConfig.AI.GitOps.FluxApiBaseUrl</c>.
+/// </para>
+/// <para>
+/// The client is intentionally minimal — it returns raw status DTOs which
+/// <see cref="FluxGitOpsController"/> maps onto the controller-neutral
+/// <c>DriftReport</c> / <c>ClusterHealth</c> shapes. Keeping the mapping
+/// outside this class makes the wire types replaceable without touching the
+/// controller logic.
+/// </para>
+/// </remarks>
+public sealed class FluxApiClient
+{
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly IOptionsMonitor<AppConfig> _config;
+    private readonly ILogger<FluxApiClient> _logger;
+
+    /// <summary>Initializes a new <see cref="FluxApiClient"/>.</summary>
+    public FluxApiClient(
+        IHttpClientFactory httpClientFactory,
+        IOptionsMonitor<AppConfig> config,
+        ILogger<FluxApiClient> logger)
+    {
+        ArgumentNullException.ThrowIfNull(httpClientFactory);
+        ArgumentNullException.ThrowIfNull(config);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _httpClientFactory = httpClientFactory;
+        _config = config;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// List the <c>Kustomization</c> resources the Flux controller is tracking,
+    /// with their reconciliation status.
+    /// </summary>
+    /// <param name="cancellationToken">Cooperative cancellation token.</param>
+    public async Task<IReadOnlyList<FluxKustomizationStatus>> ListKustomizationsAsync(
+        CancellationToken cancellationToken)
+    {
+        var baseUrl = _config.CurrentValue.AI.GitOps.FluxApiBaseUrl;
+        if (string.IsNullOrWhiteSpace(baseUrl))
+        {
+            throw new InvalidOperationException(
+                "AppConfig.AI.GitOps.FluxApiBaseUrl is empty. The GitOps startup validator should have caught this.");
+        }
+
+        var client = _httpClientFactory.CreateClient(EgressPolicyDelegatingHandler.ClientName);
+        var url = $"{baseUrl.TrimEnd('/')}/api/v1/kustomizations";
+
+        _logger.LogDebug("Listing Flux Kustomizations from {Url}", url);
+
+        var response = await client
+            .GetFromJsonAsync<FluxKustomizationListResponse>(url, cancellationToken)
+            .ConfigureAwait(false);
+
+        return response?.Items ?? [];
+    }
+
+    /// <summary>
+    /// List the <c>HelmRelease</c> resources the Flux controller is tracking,
+    /// with their reconciliation status.
+    /// </summary>
+    /// <param name="cancellationToken">Cooperative cancellation token.</param>
+    public async Task<IReadOnlyList<FluxHelmReleaseStatus>> ListHelmReleasesAsync(
+        CancellationToken cancellationToken)
+    {
+        var baseUrl = _config.CurrentValue.AI.GitOps.FluxApiBaseUrl;
+        if (string.IsNullOrWhiteSpace(baseUrl))
+        {
+            throw new InvalidOperationException(
+                "AppConfig.AI.GitOps.FluxApiBaseUrl is empty. The GitOps startup validator should have caught this.");
+        }
+
+        var client = _httpClientFactory.CreateClient(EgressPolicyDelegatingHandler.ClientName);
+        var url = $"{baseUrl.TrimEnd('/')}/api/v1/helmreleases";
+
+        _logger.LogDebug("Listing Flux HelmReleases from {Url}", url);
+
+        var response = await client
+            .GetFromJsonAsync<FluxHelmReleaseListResponse>(url, cancellationToken)
+            .ConfigureAwait(false);
+
+        return response?.Items ?? [];
+    }
+}
+
+/// <summary>Flux v2 Kustomization status as returned by the controller's HTTP status surface.</summary>
+public sealed record FluxKustomizationStatus
+{
+    /// <summary>The Kustomization name.</summary>
+    [JsonPropertyName("name")]
+    public string Name { get; init; } = string.Empty;
+
+    /// <summary>The namespace the Kustomization lives in.</summary>
+    [JsonPropertyName("namespace")]
+    public string Namespace { get; init; } = string.Empty;
+
+    /// <summary>The Git path the Kustomization reconciles from.</summary>
+    [JsonPropertyName("path")]
+    public string Path { get; init; } = string.Empty;
+
+    /// <summary>True when the Kustomization is Ready.</summary>
+    [JsonPropertyName("ready")]
+    public bool Ready { get; init; }
+
+    /// <summary>True when the Kustomization is currently suspended (paused).</summary>
+    [JsonPropertyName("suspended")]
+    public bool Suspended { get; init; }
+
+    /// <summary>Last-reconciled commit SHA.</summary>
+    [JsonPropertyName("lastAppliedRevision")]
+    public string LastAppliedRevision { get; init; } = string.Empty;
+
+    /// <summary>Source commit SHA Git currently has.</summary>
+    [JsonPropertyName("lastAttemptedRevision")]
+    public string LastAttemptedRevision { get; init; } = string.Empty;
+
+    /// <summary>Human-readable status message.</summary>
+    [JsonPropertyName("message")]
+    public string Message { get; init; } = string.Empty;
+}
+
+/// <summary>Flux v2 HelmRelease status as returned by the controller's HTTP status surface.</summary>
+public sealed record FluxHelmReleaseStatus
+{
+    /// <summary>The HelmRelease name.</summary>
+    [JsonPropertyName("name")]
+    public string Name { get; init; } = string.Empty;
+
+    /// <summary>The namespace the HelmRelease lives in.</summary>
+    [JsonPropertyName("namespace")]
+    public string Namespace { get; init; } = string.Empty;
+
+    /// <summary>True when the release reconciled successfully.</summary>
+    [JsonPropertyName("ready")]
+    public bool Ready { get; init; }
+
+    /// <summary>True when reconciliation is suspended.</summary>
+    [JsonPropertyName("suspended")]
+    public bool Suspended { get; init; }
+
+    /// <summary>Human-readable status message.</summary>
+    [JsonPropertyName("message")]
+    public string Message { get; init; } = string.Empty;
+}
+
+internal sealed record FluxKustomizationListResponse
+{
+    [JsonPropertyName("items")]
+    public IReadOnlyList<FluxKustomizationStatus> Items { get; init; } = [];
+}
+
+internal sealed record FluxHelmReleaseListResponse
+{
+    [JsonPropertyName("items")]
+    public IReadOnlyList<FluxHelmReleaseStatus> Items { get; init; } = [];
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/GitOps/Flux/FluxGitOpsController.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/GitOps/Flux/FluxGitOpsController.cs
@@ -1,0 +1,306 @@
+using System.Security.Cryptography;
+using System.Text;
+using Application.AI.Common.Interfaces.GitOps;
+using Domain.AI.Changes;
+using Domain.AI.GitOps;
+using Domain.Common;
+using Domain.Common.Config;
+using Domain.AI.SkillTraining;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Infrastructure.AI.GitOps.Flux;
+
+/// <summary>
+/// Flux v2 implementation of <see cref="IGitOpsController"/>. Reads drift and
+/// health from the Flux source-controller + kustomize-controller + helm-controller
+/// status surface via <see cref="FluxApiClient"/>, then maps the wire shape onto
+/// the controller-neutral <see cref="DriftReport"/> / <see cref="ClusterHealth"/>
+/// / <see cref="RemediationPlan"/> types.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Read-only — never mutates the cluster. Remediation surfaces as a
+/// <see cref="RemediationPlan"/> the <c>IGitOpsRemediationDispatcher</c>
+/// translates into a <c>ChangeProposal</c> against a <c>GitRepoTarget</c>.
+/// </para>
+/// <para>
+/// Drift detection signal: a <c>Kustomization</c> or <c>HelmRelease</c> is
+/// considered drifted when either (a) the controller reports it as not Ready
+/// and not Suspended, or (b) <c>LastAppliedRevision</c> differs from
+/// <c>LastAttemptedRevision</c>. Suspended resources are surfaced in
+/// <see cref="ClusterHealth"/> as Notes but NOT as drift — operators may
+/// suspend reconciliation deliberately.
+/// </para>
+/// </remarks>
+public sealed class FluxGitOpsController : IGitOpsController
+{
+    private readonly FluxApiClient _apiClient;
+    private readonly IOptionsMonitor<AppConfig> _config;
+    private readonly ILogger<FluxGitOpsController> _logger;
+    private readonly TimeProvider _timeProvider;
+
+    /// <summary>Initializes a new <see cref="FluxGitOpsController"/>.</summary>
+    public FluxGitOpsController(
+        FluxApiClient apiClient,
+        IOptionsMonitor<AppConfig> config,
+        ILogger<FluxGitOpsController> logger,
+        TimeProvider timeProvider)
+    {
+        ArgumentNullException.ThrowIfNull(apiClient);
+        ArgumentNullException.ThrowIfNull(config);
+        ArgumentNullException.ThrowIfNull(logger);
+        ArgumentNullException.ThrowIfNull(timeProvider);
+
+        _apiClient = apiClient;
+        _config = config;
+        _logger = logger;
+        _timeProvider = timeProvider;
+    }
+
+    /// <inheritdoc />
+    public GitOpsControllerKind Kind => GitOpsControllerKind.Flux;
+
+    /// <inheritdoc />
+    public async Task<Result<DriftReport>> DetectDriftAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            var kustomizations = await _apiClient.ListKustomizationsAsync(cancellationToken).ConfigureAwait(false);
+            var helmReleases = await _apiClient.ListHelmReleasesAsync(cancellationToken).ConfigureAwait(false);
+
+            var drifted = new List<DriftedResource>();
+            foreach (var k in kustomizations)
+            {
+                if (IsKustomizationDrifted(k))
+                {
+                    drifted.Add(MapKustomization(k));
+                }
+            }
+            foreach (var h in helmReleases)
+            {
+                if (IsHelmReleaseDrifted(h))
+                {
+                    drifted.Add(MapHelmRelease(h));
+                }
+            }
+
+            var capturedAt = _timeProvider.GetUtcNow();
+            var evidenceHash = ComputeEvidenceHash(kustomizations, helmReleases, capturedAt);
+
+            var report = new DriftReport
+            {
+                ControllerKind = Kind,
+                CapturedAt = capturedAt,
+                DriftedResources = drifted,
+                EvidenceHash = evidenceHash
+            };
+
+            return Result<DriftReport>.Success(report);
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogWarning(ex, "Flux drift detection failed: API unreachable.");
+            return Result<DriftReport>.Fail("gitops.flux.api_unreachable");
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogError(ex, "Flux drift detection failed with unexpected error.");
+            return Result<DriftReport>.Fail("gitops.flux.unexpected_error");
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<Result<ClusterHealth>> GetClusterHealthAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            var kustomizations = await _apiClient.ListKustomizationsAsync(cancellationToken).ConfigureAwait(false);
+            var helmReleases = await _apiClient.ListHelmReleasesAsync(cancellationToken).ConfigureAwait(false);
+
+            var resources = new List<ResourceHealth>();
+            var notes = new List<string>();
+            var overall = ClusterHealthStatus.Healthy;
+
+            foreach (var k in kustomizations)
+            {
+                var status = MapKustomizationStatus(k);
+                resources.Add(new ResourceHealth
+                {
+                    ApiVersion = "kustomize.toolkit.fluxcd.io/v1",
+                    Kind = "Kustomization",
+                    Namespace = k.Namespace,
+                    Name = k.Name,
+                    Status = status,
+                    Message = k.Message
+                });
+                if (k.Suspended) notes.Add($"Kustomization {k.Namespace}/{k.Name} is suspended.");
+                overall = Worst(overall, status);
+            }
+            foreach (var h in helmReleases)
+            {
+                var status = MapHelmReleaseStatus(h);
+                resources.Add(new ResourceHealth
+                {
+                    ApiVersion = "helm.toolkit.fluxcd.io/v2",
+                    Kind = "HelmRelease",
+                    Namespace = h.Namespace,
+                    Name = h.Name,
+                    Status = status,
+                    Message = h.Message
+                });
+                if (h.Suspended) notes.Add($"HelmRelease {h.Namespace}/{h.Name} is suspended.");
+                overall = Worst(overall, status);
+            }
+
+            return Result<ClusterHealth>.Success(new ClusterHealth
+            {
+                ControllerKind = Kind,
+                CapturedAt = _timeProvider.GetUtcNow(),
+                OverallStatus = overall,
+                ResourceStates = resources,
+                Notes = notes
+            });
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogWarning(ex, "Flux cluster health read failed: API unreachable.");
+            return Result<ClusterHealth>.Fail("gitops.flux.api_unreachable");
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogError(ex, "Flux cluster health read failed with unexpected error.");
+            return Result<ClusterHealth>.Fail("gitops.flux.unexpected_error");
+        }
+    }
+
+    /// <inheritdoc />
+    public Task<Result<RemediationPlan>> ProposeRemediationAsync(DriftReport drift, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(drift);
+        if (drift.ControllerKind != Kind)
+        {
+            return Task.FromResult(Result<RemediationPlan>.Fail("gitops.remediation.controller_mismatch"));
+        }
+        if (!drift.HasDrift)
+        {
+            return Task.FromResult(Result<RemediationPlan>.Fail("gitops.remediation.no_drift"));
+        }
+
+        var gitops = _config.CurrentValue.AI.GitOps;
+        if (string.IsNullOrWhiteSpace(gitops.RemediationRepoUrl))
+        {
+            return Task.FromResult(Result<RemediationPlan>.Fail("gitops.remediation.no_repo_configured"));
+        }
+
+        var target = new GitRepoTarget(
+            repoUrl: gitops.RemediationRepoUrl,
+            branch: gitops.RemediationBranch,
+            headSha: null,
+            workingPath: string.Empty);
+
+        var edits = drift.DriftedResources
+            .Where(r => !string.IsNullOrEmpty(r.DesiredPath))
+            .Select(r => new ChangeEdit
+            {
+                Op = EditOp.Replace,
+                Target = r.DesiredPath!,
+                Content = BuildReconvergePlaceholder(r)
+            })
+            .ToList();
+
+        if (edits.Count == 0)
+        {
+            return Task.FromResult(Result<RemediationPlan>.Fail("gitops.remediation.no_remediable_drift"));
+        }
+
+        var maxSeverity = drift.DriftedResources.Max(r => r.Severity);
+        var blastRadius = maxSeverity switch
+        {
+            DriftSeverity.High => BlastRadius.High,
+            DriftSeverity.Medium => BlastRadius.Medium,
+            _ => BlastRadius.Low
+        };
+
+        return Task.FromResult(Result<RemediationPlan>.Success(new RemediationPlan
+        {
+            ControllerKind = Kind,
+            SourceDrift = drift,
+            Target = target,
+            Edits = edits,
+            ProposedBlastRadius = blastRadius,
+            Summary = $"Flux: reconverge {drift.DriftedResources.Count} drifted resource(s)."
+        }));
+    }
+
+    private static bool IsKustomizationDrifted(FluxKustomizationStatus k)
+    {
+        if (k.Suspended) return false;
+        if (!k.Ready) return true;
+        return !string.Equals(k.LastAppliedRevision, k.LastAttemptedRevision, StringComparison.Ordinal)
+               && !string.IsNullOrEmpty(k.LastAttemptedRevision);
+    }
+
+    private static bool IsHelmReleaseDrifted(FluxHelmReleaseStatus h)
+    {
+        if (h.Suspended) return false;
+        return !h.Ready;
+    }
+
+    private static DriftedResource MapKustomization(FluxKustomizationStatus k) => new()
+    {
+        ApiVersion = "kustomize.toolkit.fluxcd.io/v1",
+        Kind = "Kustomization",
+        Namespace = k.Namespace,
+        Name = k.Name,
+        DesiredPath = k.Path,
+        Summary = string.IsNullOrEmpty(k.Message) ? "Kustomization not Ready." : k.Message,
+        Severity = DriftSeverity.Medium
+    };
+
+    private static DriftedResource MapHelmRelease(FluxHelmReleaseStatus h) => new()
+    {
+        ApiVersion = "helm.toolkit.fluxcd.io/v2",
+        Kind = "HelmRelease",
+        Namespace = h.Namespace,
+        Name = h.Name,
+        DesiredPath = null,
+        Summary = string.IsNullOrEmpty(h.Message) ? "HelmRelease not Ready." : h.Message,
+        Severity = DriftSeverity.High
+    };
+
+    private static ClusterHealthStatus MapKustomizationStatus(FluxKustomizationStatus k)
+    {
+        if (k.Suspended) return ClusterHealthStatus.Progressing;
+        if (k.Ready) return ClusterHealthStatus.Healthy;
+        return ClusterHealthStatus.Degraded;
+    }
+
+    private static ClusterHealthStatus MapHelmReleaseStatus(FluxHelmReleaseStatus h)
+    {
+        if (h.Suspended) return ClusterHealthStatus.Progressing;
+        if (h.Ready) return ClusterHealthStatus.Healthy;
+        return ClusterHealthStatus.Failed;
+    }
+
+    private static ClusterHealthStatus Worst(ClusterHealthStatus a, ClusterHealthStatus b) =>
+        (ClusterHealthStatus)Math.Max((int)a, (int)b);
+
+    private static string BuildReconvergePlaceholder(DriftedResource r) =>
+        $"# reconverge target for {r.Kind} {r.Namespace}/{r.Name} — operator action required";
+
+    private static string ComputeEvidenceHash(
+        IReadOnlyList<FluxKustomizationStatus> kustomizations,
+        IReadOnlyList<FluxHelmReleaseStatus> helmReleases,
+        DateTimeOffset capturedAt)
+    {
+        var sb = new StringBuilder();
+        sb.Append("flux|").Append(capturedAt.ToUnixTimeSeconds()).Append('|');
+        foreach (var k in kustomizations.OrderBy(k => k.Namespace, StringComparer.Ordinal).ThenBy(k => k.Name, StringComparer.Ordinal))
+            sb.Append("k:").Append(k.Namespace).Append('/').Append(k.Name).Append(':').Append(k.Ready).Append(':').Append(k.LastAppliedRevision).Append(';');
+        foreach (var h in helmReleases.OrderBy(h => h.Namespace, StringComparer.Ordinal).ThenBy(h => h.Name, StringComparer.Ordinal))
+            sb.Append("h:").Append(h.Namespace).Append('/').Append(h.Name).Append(':').Append(h.Ready).Append(';');
+        var hash = SHA256.HashData(Encoding.UTF8.GetBytes(sb.ToString()));
+        return Convert.ToHexString(hash);
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/GitOps/GitOpsRemediationDispatcher.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/GitOps/GitOpsRemediationDispatcher.cs
@@ -1,0 +1,99 @@
+using Application.AI.Common.CQRS.Changes.SubmitChangeProposal;
+using Application.AI.Common.Interfaces.GitOps;
+using Domain.AI.Changes;
+using Domain.AI.GitOps;
+using Domain.Common;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace Infrastructure.AI.GitOps;
+
+/// <summary>
+/// The single sanctioned write path for the GitOps skill pack. Translates a
+/// <see cref="RemediationPlan"/> into a <see cref="SubmitChangeProposalCommand"/>
+/// and submits it via <see cref="IMediator"/>, surfacing the resulting
+/// <see cref="ChangeProposal"/> back to the caller for audit logging.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The dispatcher is the only place in <c>Infrastructure.AI.GitOps</c> permitted
+/// to issue mutating intent. Tools, controllers, and skills NEVER write
+/// directly to a Git repo or to the cluster — they hand off to this dispatcher,
+/// which routes through the PR-2 gate pipeline.
+/// </para>
+/// <para>
+/// The skill key on the submitted command (<c>gitops:{controller}</c>) lets the
+/// graded-autonomy resolver apply per-controller skill overrides. The
+/// <c>IsStateChange</c> flag is unconditionally true: every remediation
+/// edits files in a Git repo, so even an Autonomous tier should round-trip
+/// through approval unless the operator has explicitly opted-in via
+/// <c>GradedAutonomyConfig.StateChangerOptIns</c>.
+/// </para>
+/// </remarks>
+public sealed class GitOpsRemediationDispatcher : IGitOpsRemediationDispatcher
+{
+    private readonly IMediator _mediator;
+    private readonly ILogger<GitOpsRemediationDispatcher> _logger;
+
+    /// <summary>Initializes a new <see cref="GitOpsRemediationDispatcher"/>.</summary>
+    public GitOpsRemediationDispatcher(IMediator mediator, ILogger<GitOpsRemediationDispatcher> logger)
+    {
+        ArgumentNullException.ThrowIfNull(mediator);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _mediator = mediator;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<Result<ChangeProposal>> DispatchAsync(RemediationPlan plan, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(plan);
+
+        if (plan.Edits.Count == 0)
+        {
+            return Result<ChangeProposal>.Fail("gitops.remediation.empty_plan");
+        }
+
+        var skillKey = $"gitops:{plan.ControllerKind.ToString().ToLowerInvariant()}";
+        var summary = string.IsNullOrEmpty(plan.Summary)
+            ? $"GitOps remediation for {plan.SourceDrift.DriftedResources.Count} drifted resource(s)."
+            : plan.Summary;
+
+        var command = new SubmitChangeProposalCommand
+        {
+            Target = plan.Target,
+            Diff = plan.Edits,
+            Summary = summary,
+            BlastRadius = plan.ProposedBlastRadius,
+            IsStateChange = true,
+            SkillKey = skillKey
+        };
+
+        try
+        {
+            var result = await _mediator.Send(command, cancellationToken).ConfigureAwait(false);
+            if (!result.IsSuccess)
+            {
+                _logger.LogWarning(
+                    "GitOps remediation submission failed for plan from {Controller}: {Errors}",
+                    plan.ControllerKind,
+                    string.Join("; ", result.Errors));
+                return result;
+            }
+
+            _logger.LogInformation(
+                "GitOps remediation submitted: controller={Controller} proposalId={ProposalId} resources={ResourceCount}",
+                plan.ControllerKind,
+                result.Value!.Id,
+                plan.SourceDrift.DriftedResources.Count);
+
+            return result;
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogError(ex, "GitOps remediation submission threw unexpectedly.");
+            return Result<ChangeProposal>.Fail("gitops.remediation.dispatch_failed");
+        }
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/GitOps/GitOpsStartupValidator.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/GitOps/GitOpsStartupValidator.cs
@@ -1,0 +1,145 @@
+using Domain.Common.Config;
+using Domain.Common.Config.AI.GitOps;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Infrastructure.AI.GitOps;
+
+/// <summary>
+/// One-shot startup validator for the GitOps skill pack. Runs via
+/// <see cref="IHostedService.StartAsync"/> and refuses to boot the host when the
+/// skill pack is enabled but its configuration is impossible.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Checks performed (only when <c>AppConfig.AI.GitOps.Enabled</c> is true):
+/// </para>
+/// <list type="number">
+///   <item><description>
+///     <b>Active controller</b> — <see cref="GitOpsConfig.ActiveController"/>
+///     must be <c>"flux"</c> or <c>"argocd"</c>. An empty or unknown value
+///     means the default <c>IGitOpsController</c> cannot resolve, so the skill
+///     pack would deadlock at the first tool call.
+///   </description></item>
+///   <item><description>
+///     <b>K8sGPT MCP server</b> — <see cref="GitOpsConfig.K8sGptMcpServerName"/>
+///     must be a key under <c>AppConfig.AI.McpServers.Servers</c>. K8sGPT is a
+///     required dependency of the <c>gitops-cluster-debug</c> skill; the plan
+///     rejects graceful degradation that would ship a half-working skill.
+///   </description></item>
+///   <item><description>
+///     <b>Active controller base URL</b> — the Flux or Argo CD base URL for the
+///     active controller must be a non-empty, absolute http(s) URL.
+///   </description></item>
+///   <item><description>
+///     <b>Remediation target</b> — <see cref="GitOpsConfig.RemediationRepoUrl"/>
+///     must be a non-empty, absolute URL; every remediation plan targets it.
+///   </description></item>
+/// </list>
+/// <para>
+/// When the skill pack is disabled the validator no-ops — the tools are inert
+/// anyway and consumers exploring the template should not be blocked from
+/// running the host.
+/// </para>
+/// </remarks>
+public sealed class GitOpsStartupValidator : IHostedService
+{
+    private static readonly IReadOnlyList<string> KnownControllers = ["flux", "argocd"];
+
+    private readonly IOptionsMonitor<AppConfig> _config;
+    private readonly ILogger<GitOpsStartupValidator> _logger;
+
+    /// <summary>Initializes a new <see cref="GitOpsStartupValidator"/>.</summary>
+    /// <param name="config">Application configuration monitor.</param>
+    /// <param name="logger">Structured logger.</param>
+    public GitOpsStartupValidator(IOptionsMonitor<AppConfig> config, ILogger<GitOpsStartupValidator> logger)
+    {
+        ArgumentNullException.ThrowIfNull(config);
+        ArgumentNullException.ThrowIfNull(logger);
+        _config = config;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        var appConfig = _config.CurrentValue;
+        var gitOps = appConfig.AI.GitOps;
+        if (!gitOps.Enabled)
+        {
+            return Task.CompletedTask;
+        }
+
+        var controller = ValidateActiveController(gitOps);
+        ValidateK8sGptServer(gitOps, appConfig);
+        ValidateActiveControllerUrl(gitOps, controller);
+        ValidateRemediationTarget(gitOps);
+
+        _logger.LogInformation(
+            "GitOps skill pack enabled. ActiveController={Controller}, K8sGptMcpServer={Server}, RemediationRepo={Repo}@{Branch}.",
+            controller,
+            gitOps.K8sGptMcpServerName,
+            gitOps.RemediationRepoUrl,
+            gitOps.RemediationBranch);
+
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    private static string ValidateActiveController(GitOpsConfig gitOps)
+    {
+        var controller = gitOps.ActiveController?.Trim().ToLowerInvariant() ?? string.Empty;
+        if (!KnownControllers.Contains(controller))
+        {
+            throw new InvalidOperationException(
+                $"GitOps skill pack is Enabled but AppConfig.AI.GitOps.ActiveController is '{gitOps.ActiveController}'. " +
+                "It must be one of: \"flux\", \"argocd\".");
+        }
+
+        return controller;
+    }
+
+    private static void ValidateK8sGptServer(GitOpsConfig gitOps, AppConfig appConfig)
+    {
+        if (string.IsNullOrWhiteSpace(gitOps.K8sGptMcpServerName) ||
+            !appConfig.AI.McpServers.Servers.ContainsKey(gitOps.K8sGptMcpServerName))
+        {
+            throw new InvalidOperationException(
+                $"GitOps skill pack is Enabled but its K8sGPT MCP server '{gitOps.K8sGptMcpServerName}' " +
+                "is not registered under AppConfig.AI.McpServers.Servers. K8sGPT is a required dependency " +
+                "of the gitops-cluster-debug skill — add the server entry or disable the skill pack.");
+        }
+    }
+
+    private static void ValidateActiveControllerUrl(GitOpsConfig gitOps, string controller)
+    {
+        var (url, propertyName) = controller == "flux"
+            ? (gitOps.FluxApiBaseUrl, nameof(GitOpsConfig.FluxApiBaseUrl))
+            : (gitOps.ArgoCdApiBaseUrl, nameof(GitOpsConfig.ArgoCdApiBaseUrl));
+
+        if (!IsValidHttpUrl(url))
+        {
+            throw new InvalidOperationException(
+                $"GitOps skill pack is Enabled with ActiveController '{controller}' but " +
+                $"AppConfig.AI.GitOps.{propertyName} is not a valid absolute http(s) URL: '{url}'.");
+        }
+    }
+
+    private static void ValidateRemediationTarget(GitOpsConfig gitOps)
+    {
+        if (string.IsNullOrWhiteSpace(gitOps.RemediationRepoUrl) ||
+            !Uri.TryCreate(gitOps.RemediationRepoUrl, UriKind.Absolute, out _))
+        {
+            throw new InvalidOperationException(
+                "GitOps skill pack is Enabled but AppConfig.AI.GitOps.RemediationRepoUrl is empty or not an " +
+                $"absolute URL: '{gitOps.RemediationRepoUrl}'. Every remediation plan targets this repository.");
+        }
+    }
+
+    private static bool IsValidHttpUrl(string url)
+        => Uri.TryCreate(url, UriKind.Absolute, out var uri) &&
+           (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps);
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/GitOps/K8sGptMcpClient.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/GitOps/K8sGptMcpClient.cs
@@ -107,11 +107,15 @@ public sealed class K8sGptMcpClient : IK8sGptMcpClient
             return new K8sGptAnalysisResult { CapturedAt = capturedAt };
         }
 
-        // K8sGPT analyze responses are JSON; the MCP layer typically returns
-        // them as a string or JsonElement depending on transport.
+        // K8sGPT analyze responses are JSON; the MCP layer returns them as a
+        // string or a JsonElement depending on transport. Microsoft.Extensions.AI
+        // commonly hands back a JsonElement of kind String whose value IS the
+        // JSON payload — unwrap that to the inner string so it parses to an
+        // object rather than a JSON string literal.
         var json = raw switch
         {
             string s => s,
+            JsonElement { ValueKind: JsonValueKind.String } strEl => strEl.GetString() ?? string.Empty,
             JsonElement el => el.GetRawText(),
             _ => JsonSerializer.Serialize(raw)
         };
@@ -120,6 +124,17 @@ public sealed class K8sGptMcpClient : IK8sGptMcpClient
         {
             using var doc = JsonDocument.Parse(json);
             var root = doc.RootElement;
+
+            // Defensive: a non-object root (bare string/number/array) carries no
+            // results/explanation shape — treat it as an empty analysis rather
+            // than throwing on the property lookups below.
+            if (root.ValueKind != JsonValueKind.Object)
+            {
+                _logger.LogWarning(
+                    "K8sGPT response parsed to {ValueKind}, expected an object; returning empty result.",
+                    root.ValueKind);
+                return new K8sGptAnalysisResult { CapturedAt = capturedAt };
+            }
 
             var findings = new List<K8sGptFinding>();
             if (root.TryGetProperty("results", out var resultsEl) && resultsEl.ValueKind == JsonValueKind.Array)

--- a/src/Content/Infrastructure/Infrastructure.AI/GitOps/K8sGptMcpClient.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/GitOps/K8sGptMcpClient.cs
@@ -1,0 +1,182 @@
+using System.Text.Json;
+using Application.AI.Common.Interfaces;
+using Application.AI.Common.Interfaces.GitOps;
+using Domain.Common;
+using Domain.Common.Config;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Infrastructure.AI.GitOps;
+
+/// <summary>
+/// MCP-backed implementation of <see cref="IK8sGptMcpClient"/>. Resolves the
+/// K8sGPT MCP server tools via <see cref="IMcpToolProvider"/>, invokes the
+/// <c>analyze</c> tool, and deserializes the response into the harness's
+/// neutral <see cref="K8sGptAnalysisResult"/> shape.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The K8sGPT MCP server name comes from <c>AppConfig.AI.GitOps.K8sGptMcpServerName</c>
+/// (default <c>"k8sgpt"</c>). The startup validator refuses to boot when that
+/// server is not configured under <c>AppConfig.AI.McpServers.Servers</c>.
+/// </para>
+/// <para>
+/// This client is intentionally read-only. K8sGPT's tool surface may evolve
+/// to include mutating operations; this client narrows it to <c>analyze</c>
+/// by contract and refuses to expose any other operation.
+/// </para>
+/// </remarks>
+public sealed class K8sGptMcpClient : IK8sGptMcpClient
+{
+    private const string K8sGptAnalyzeToolName = "analyze";
+
+    private readonly IMcpToolProvider _mcpToolProvider;
+    private readonly IOptionsMonitor<AppConfig> _config;
+    private readonly ILogger<K8sGptMcpClient> _logger;
+    private readonly TimeProvider _timeProvider;
+
+    /// <summary>Initializes a new <see cref="K8sGptMcpClient"/>.</summary>
+    public K8sGptMcpClient(
+        IMcpToolProvider mcpToolProvider,
+        IOptionsMonitor<AppConfig> config,
+        ILogger<K8sGptMcpClient> logger,
+        TimeProvider timeProvider)
+    {
+        ArgumentNullException.ThrowIfNull(mcpToolProvider);
+        ArgumentNullException.ThrowIfNull(config);
+        ArgumentNullException.ThrowIfNull(logger);
+        ArgumentNullException.ThrowIfNull(timeProvider);
+
+        _mcpToolProvider = mcpToolProvider;
+        _config = config;
+        _logger = logger;
+        _timeProvider = timeProvider;
+    }
+
+    /// <inheritdoc />
+    public async Task<Result<K8sGptAnalysisResult>> AnalyzeAsync(
+        K8sGptAnalysisRequest request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var serverName = _config.CurrentValue.AI.GitOps.K8sGptMcpServerName;
+        if (string.IsNullOrWhiteSpace(serverName))
+        {
+            return Result<K8sGptAnalysisResult>.Fail("gitops.k8sgpt.server_name_not_configured");
+        }
+
+        try
+        {
+            var tools = await _mcpToolProvider.GetToolsAsync(serverName, cancellationToken).ConfigureAwait(false);
+            var analyzeTool = tools.OfType<AIFunction>().FirstOrDefault(
+                f => string.Equals(f.Name, K8sGptAnalyzeToolName, StringComparison.OrdinalIgnoreCase));
+
+            if (analyzeTool is null)
+            {
+                _logger.LogWarning("K8sGPT MCP server '{Server}' does not expose an 'analyze' tool.", serverName);
+                return Result<K8sGptAnalysisResult>.Fail("gitops.k8sgpt.analyze_tool_missing");
+            }
+
+            var args = new Dictionary<string, object?>
+            {
+                ["namespace"] = request.Namespace,
+                ["filters"] = request.Filters,
+                ["explain"] = request.Explain
+            };
+
+            var rawResponse = await analyzeTool.InvokeAsync(
+                new AIFunctionArguments(args),
+                cancellationToken).ConfigureAwait(false);
+
+            return Result<K8sGptAnalysisResult>.Success(ParseResponse(rawResponse));
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogError(ex, "K8sGPT MCP analyze call failed.");
+            return Result<K8sGptAnalysisResult>.Fail("gitops.k8sgpt.unexpected_error");
+        }
+    }
+
+    private K8sGptAnalysisResult ParseResponse(object? raw)
+    {
+        var capturedAt = _timeProvider.GetUtcNow();
+        if (raw is null)
+        {
+            return new K8sGptAnalysisResult { CapturedAt = capturedAt };
+        }
+
+        // K8sGPT analyze responses are JSON; the MCP layer typically returns
+        // them as a string or JsonElement depending on transport.
+        var json = raw switch
+        {
+            string s => s,
+            JsonElement el => el.GetRawText(),
+            _ => JsonSerializer.Serialize(raw)
+        };
+
+        try
+        {
+            using var doc = JsonDocument.Parse(json);
+            var root = doc.RootElement;
+
+            var findings = new List<K8sGptFinding>();
+            if (root.TryGetProperty("results", out var resultsEl) && resultsEl.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var item in resultsEl.EnumerateArray())
+                {
+                    findings.Add(ParseFinding(item));
+                }
+            }
+
+            string? explanation = null;
+            if (root.TryGetProperty("explanation", out var explEl) && explEl.ValueKind == JsonValueKind.String)
+            {
+                explanation = explEl.GetString();
+            }
+
+            return new K8sGptAnalysisResult
+            {
+                CapturedAt = capturedAt,
+                Findings = findings,
+                Explanation = explanation
+            };
+        }
+        catch (JsonException ex)
+        {
+            _logger.LogWarning(ex, "K8sGPT response was not valid JSON; returning empty result.");
+            return new K8sGptAnalysisResult { CapturedAt = capturedAt };
+        }
+    }
+
+    private static K8sGptFinding ParseFinding(JsonElement el)
+    {
+        var kind = el.TryGetProperty("kind", out var k) && k.ValueKind == JsonValueKind.String
+            ? k.GetString() ?? string.Empty : string.Empty;
+        var name = el.TryGetProperty("name", out var n) && n.ValueKind == JsonValueKind.String
+            ? n.GetString() ?? string.Empty : string.Empty;
+        var ns = el.TryGetProperty("namespace", out var nsEl) && nsEl.ValueKind == JsonValueKind.String
+            ? nsEl.GetString() : null;
+        var summary = el.TryGetProperty("error", out var errEl) && errEl.ValueKind == JsonValueKind.String
+            ? errEl.GetString() ?? string.Empty : string.Empty;
+        var sev = el.TryGetProperty("severity", out var sevEl) && sevEl.ValueKind == JsonValueKind.String
+            ? ParseSeverity(sevEl.GetString()) : K8sGptSeverity.Low;
+
+        return new K8sGptFinding
+        {
+            Kind = kind,
+            Name = name,
+            Namespace = ns,
+            Summary = summary,
+            Severity = sev
+        };
+    }
+
+    private static K8sGptSeverity ParseSeverity(string? raw) => raw?.ToLowerInvariant() switch
+    {
+        "high" or "critical" => K8sGptSeverity.High,
+        "medium" or "warning" => K8sGptSeverity.Medium,
+        _ => K8sGptSeverity.Low
+    };
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/GitOps/DependencyInjection.GitOps.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/GitOps/DependencyInjection.GitOps.cs
@@ -1,0 +1,106 @@
+using Application.AI.Common.Interfaces.GitOps;
+using Application.AI.Common.Interfaces.Tools;
+using Domain.Common.Config;
+using Infrastructure.AI.GitOps;
+using Infrastructure.AI.GitOps.ArgoCd;
+using Infrastructure.AI.GitOps.Flux;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace Infrastructure.AI.Tools.GitOps;
+
+/// <summary>
+/// DI registration for the GitOps skill pack (PR-9): controller-neutral
+/// <see cref="IGitOpsController"/> implementations for Flux and Argo CD, the
+/// K8sGPT MCP client, the remediation dispatcher, the four agent-facing tools,
+/// and the fail-loud startup validator. Composition-root opt-in — callers invoke
+/// <see cref="AddGitOpsSkillTools"/> from their <c>Add*Dependencies</c> chain so
+/// the skill pack is bolted on only when wanted.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Registers, by keyed-DI name:
+/// <list type="bullet">
+///   <item><c>detect_drift</c>         — <see cref="GitOpsDetectDriftTool"/></item>
+///   <item><c>cluster_health</c>       — <see cref="GitOpsClusterHealthTool"/></item>
+///   <item><c>propose_remediation</c>  — <see cref="GitOpsProposeRemediationTool"/></item>
+///   <item><c>k8sgpt_analyze</c>       — <see cref="K8sGptAnalyzeTool"/></item>
+/// </list>
+/// </para>
+/// <para>
+/// Both controllers are registered keyed by their controller name —
+/// <c>"flux"</c> and <c>"argocd"</c>. The default
+/// <see cref="IGitOpsController"/> resolves to whichever controller
+/// <c>AppConfig.AI.GitOps.ActiveController</c> names, so tools inject the active
+/// controller directly. Resolving the default throws a clear error when no
+/// active controller is configured; <see cref="GitOpsStartupValidator"/> turns
+/// that into a fail-loud boot error whenever the skill pack is enabled.
+/// </para>
+/// <para>
+/// Registrations are unconditional (the tools are inert until a skill resolves
+/// them), mirroring the workspace skill pack and the Magentic surface. The
+/// API clients share the egress-gated named <c>HttpClient</c>
+/// (<c>EgressPolicyDelegatingHandler.ClientName</c>) registered by the egress
+/// layer — no additional <c>HttpClient</c> registration is needed here.
+/// </para>
+/// </remarks>
+public static class GitOpsDependencyInjection
+{
+    /// <summary>
+    /// Registers the GitOps skill pack's controllers, K8sGPT client, remediation
+    /// dispatcher, agent-facing tools, and startup validator on the supplied
+    /// <see cref="IServiceCollection"/>.
+    /// </summary>
+    /// <param name="services">The service collection to register into.</param>
+    /// <returns>The same collection, for fluent chaining.</returns>
+    public static IServiceCollection AddGitOpsSkillTools(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        // --- API clients (share the egress-gated named HttpClient) ---
+        services.AddSingleton<FluxApiClient>();
+        services.AddSingleton<ArgoCdApiClient>();
+
+        // --- Controllers, keyed by controller name (== AppConfig ActiveController) ---
+        services.AddKeyedSingleton<IGitOpsController, FluxGitOpsController>("flux");
+        services.AddKeyedSingleton<IGitOpsController, ArgoCdGitOpsController>("argocd");
+
+        // --- Default controller resolves the active one from config ---
+        services.AddSingleton<IGitOpsController>(static sp =>
+        {
+            var active = sp.GetRequiredService<IOptionsMonitor<AppConfig>>().CurrentValue.AI.GitOps.ActiveController;
+            if (string.IsNullOrWhiteSpace(active))
+            {
+                throw new InvalidOperationException(
+                    "GitOps is being used but AppConfig.AI.GitOps.ActiveController is not configured. " +
+                    "Set it to \"flux\" or \"argocd\".");
+            }
+
+            return sp.GetRequiredKeyedService<IGitOpsController>(active);
+        });
+
+        // --- K8sGPT client + remediation dispatcher ---
+        services.AddSingleton<IK8sGptMcpClient, K8sGptMcpClient>();
+        services.AddSingleton<IGitOpsRemediationDispatcher, GitOpsRemediationDispatcher>();
+
+        // --- Agent-facing tools (keyed by ToolName) ---
+        services.AddKeyedSingleton<ITool>(GitOpsDetectDriftTool.ToolName, static (sp, _) =>
+            new GitOpsDetectDriftTool(sp.GetRequiredService<IGitOpsController>()));
+
+        services.AddKeyedSingleton<ITool>(GitOpsClusterHealthTool.ToolName, static (sp, _) =>
+            new GitOpsClusterHealthTool(sp.GetRequiredService<IGitOpsController>()));
+
+        services.AddKeyedSingleton<ITool>(GitOpsProposeRemediationTool.ToolName, static (sp, _) =>
+            new GitOpsProposeRemediationTool(
+                sp.GetRequiredService<IGitOpsController>(),
+                sp.GetRequiredService<IGitOpsRemediationDispatcher>()));
+
+        services.AddKeyedSingleton<ITool>(K8sGptAnalyzeTool.ToolName, static (sp, _) =>
+            new K8sGptAnalyzeTool(sp.GetRequiredService<IK8sGptMcpClient>()));
+
+        // --- Fail-loud startup validation when the skill pack is enabled ---
+        services.AddHostedService<GitOpsStartupValidator>();
+
+        return services;
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/GitOps/GitOpsClusterHealthTool.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/GitOps/GitOpsClusterHealthTool.cs
@@ -1,0 +1,67 @@
+using System.Text.Json;
+using Application.AI.Common.Interfaces.GitOps;
+using Application.AI.Common.Interfaces.Tools;
+using Domain.AI.Models;
+
+namespace Infrastructure.AI.Tools.GitOps;
+
+/// <summary>
+/// Read-only GitOps tool that returns the live <c>ClusterHealth</c> snapshot the
+/// active <see cref="IGitOpsController"/> (Flux or Argo CD) reports — overall
+/// status plus per-resource health — serialised as JSON.
+/// </summary>
+/// <remarks>
+/// Observational only; the tool never mutates the cluster. It is the cheap
+/// "is the cluster healthy right now?" probe that complements
+/// <see cref="GitOpsDetectDriftTool"/>'s "does live match Git?" probe.
+/// </remarks>
+public sealed class GitOpsClusterHealthTool : ITool
+{
+    /// <summary>Tool key — matches the keyed-DI registration and the SKILL.md allowed-tools entry.</summary>
+    public const string ToolName = "cluster_health";
+
+    private static readonly IReadOnlyList<string> Operations = ["get"];
+    private static readonly JsonSerializerOptions SerializerOptions = new() { WriteIndented = false };
+
+    private readonly IGitOpsController _controller;
+
+    /// <summary>Initialises a new instance of the <see cref="GitOpsClusterHealthTool"/> class.</summary>
+    /// <param name="controller">The active GitOps controller resolved from configuration.</param>
+    public GitOpsClusterHealthTool(IGitOpsController controller)
+    {
+        ArgumentNullException.ThrowIfNull(controller);
+        _controller = controller;
+    }
+
+    /// <inheritdoc />
+    public string Name => ToolName;
+
+    /// <inheritdoc />
+    public string Description =>
+        "Returns the live cluster health snapshot (overall status + per-resource health) from the active GitOps controller. Read-only; returns JSON.";
+
+    /// <inheritdoc />
+    public IReadOnlyList<string> SupportedOperations => Operations;
+
+    /// <inheritdoc />
+    public bool IsReadOnly => true;
+
+    /// <inheritdoc />
+    public bool IsConcurrencySafe => true;
+
+    /// <inheritdoc />
+    public async Task<ToolResult> ExecuteAsync(
+        string operation,
+        IReadOnlyDictionary<string, object?> parameters,
+        CancellationToken cancellationToken = default)
+    {
+        if (!string.Equals(operation, "get", StringComparison.OrdinalIgnoreCase))
+            return ToolResult.Fail($"Unknown operation: {operation}. Supported: get.");
+
+        var result = await _controller.GetClusterHealthAsync(cancellationToken).ConfigureAwait(false);
+        if (!result.IsSuccess)
+            return ToolResult.Fail(string.Join("; ", result.Errors));
+
+        return ToolResult.Ok(JsonSerializer.Serialize(result.Value, SerializerOptions));
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/GitOps/GitOpsDetectDriftTool.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/GitOps/GitOpsDetectDriftTool.cs
@@ -1,0 +1,71 @@
+using System.Text.Json;
+using Application.AI.Common.Interfaces.GitOps;
+using Application.AI.Common.Interfaces.Tools;
+using Domain.AI.Models;
+
+namespace Infrastructure.AI.Tools.GitOps;
+
+/// <summary>
+/// Read-only GitOps tool that asks the active <see cref="IGitOpsController"/>
+/// (Flux or Argo CD, per <c>AppConfig.AI.GitOps.ActiveController</c>) to detect
+/// configuration drift between the desired Git state and the live cluster, then
+/// returns the controller-neutral <c>DriftReport</c> as JSON.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The tool never mutates the cluster or the Git repository — drift detection is
+/// purely observational. To act on detected drift the agent must call
+/// <see cref="GitOpsProposeRemediationTool"/>, which routes a fix through the
+/// <c>ChangeProposal</c> gate pipeline.
+/// </para>
+/// </remarks>
+public sealed class GitOpsDetectDriftTool : ITool
+{
+    /// <summary>Tool key — matches the keyed-DI registration and the SKILL.md allowed-tools entry.</summary>
+    public const string ToolName = "detect_drift";
+
+    private static readonly IReadOnlyList<string> Operations = ["detect"];
+    private static readonly JsonSerializerOptions SerializerOptions = new() { WriteIndented = false };
+
+    private readonly IGitOpsController _controller;
+
+    /// <summary>Initialises a new instance of the <see cref="GitOpsDetectDriftTool"/> class.</summary>
+    /// <param name="controller">The active GitOps controller resolved from configuration.</param>
+    public GitOpsDetectDriftTool(IGitOpsController controller)
+    {
+        ArgumentNullException.ThrowIfNull(controller);
+        _controller = controller;
+    }
+
+    /// <inheritdoc />
+    public string Name => ToolName;
+
+    /// <inheritdoc />
+    public string Description =>
+        "Detects configuration drift between desired Git state and the live cluster via the active GitOps controller (Flux or Argo CD). Read-only; returns a drift report as JSON.";
+
+    /// <inheritdoc />
+    public IReadOnlyList<string> SupportedOperations => Operations;
+
+    /// <inheritdoc />
+    public bool IsReadOnly => true;
+
+    /// <inheritdoc />
+    public bool IsConcurrencySafe => true;
+
+    /// <inheritdoc />
+    public async Task<ToolResult> ExecuteAsync(
+        string operation,
+        IReadOnlyDictionary<string, object?> parameters,
+        CancellationToken cancellationToken = default)
+    {
+        if (!string.Equals(operation, "detect", StringComparison.OrdinalIgnoreCase))
+            return ToolResult.Fail($"Unknown operation: {operation}. Supported: detect.");
+
+        var result = await _controller.DetectDriftAsync(cancellationToken).ConfigureAwait(false);
+        if (!result.IsSuccess)
+            return ToolResult.Fail(string.Join("; ", result.Errors));
+
+        return ToolResult.Ok(JsonSerializer.Serialize(result.Value, SerializerOptions));
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/GitOps/GitOpsProposeRemediationTool.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/GitOps/GitOpsProposeRemediationTool.cs
@@ -1,0 +1,92 @@
+using System.Text.Json;
+using Application.AI.Common.Interfaces.GitOps;
+using Application.AI.Common.Interfaces.Tools;
+using Domain.AI.Models;
+
+namespace Infrastructure.AI.Tools.GitOps;
+
+/// <summary>
+/// State-changing GitOps tool that detects drift, asks the active controller to
+/// propose a Git-side remediation, and dispatches that plan through the
+/// <c>ChangeProposal</c> gate pipeline. It never writes to the cluster or the
+/// repository directly — the remediation becomes a proposal subject to gates and
+/// approval, exactly like every other state change in the harness.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The full chain is: <see cref="IGitOpsController.DetectDriftAsync"/> →
+/// <see cref="IGitOpsController.ProposeRemediationAsync"/> →
+/// <see cref="IGitOpsRemediationDispatcher.DispatchAsync"/>. When the cluster is
+/// already in sync the tool short-circuits and reports that no remediation is
+/// needed rather than submitting an empty proposal.
+/// </para>
+/// <para>
+/// Marked not read-only and not concurrency-safe: dispatching a proposal mutates
+/// harness state (the ChangeProposal store + audit trail).
+/// </para>
+/// </remarks>
+public sealed class GitOpsProposeRemediationTool : ITool
+{
+    /// <summary>Tool key — matches the keyed-DI registration and the SKILL.md allowed-tools entry.</summary>
+    public const string ToolName = "propose_remediation";
+
+    private static readonly IReadOnlyList<string> Operations = ["submit"];
+    private static readonly JsonSerializerOptions SerializerOptions = new() { WriteIndented = false };
+
+    private readonly IGitOpsController _controller;
+    private readonly IGitOpsRemediationDispatcher _dispatcher;
+
+    /// <summary>Initialises a new instance of the <see cref="GitOpsProposeRemediationTool"/> class.</summary>
+    /// <param name="controller">The active GitOps controller resolved from configuration.</param>
+    /// <param name="dispatcher">Wraps a remediation plan into a <c>ChangeProposal</c> and routes it through the gate pipeline.</param>
+    public GitOpsProposeRemediationTool(IGitOpsController controller, IGitOpsRemediationDispatcher dispatcher)
+    {
+        ArgumentNullException.ThrowIfNull(controller);
+        ArgumentNullException.ThrowIfNull(dispatcher);
+        _controller = controller;
+        _dispatcher = dispatcher;
+    }
+
+    /// <inheritdoc />
+    public string Name => ToolName;
+
+    /// <inheritdoc />
+    public string Description =>
+        "Detects drift, proposes a Git-side remediation, and submits it as a ChangeProposal for gate evaluation and approval. Never mutates the cluster or repo directly. Returns the proposal as JSON.";
+
+    /// <inheritdoc />
+    public IReadOnlyList<string> SupportedOperations => Operations;
+
+    /// <inheritdoc />
+    public bool IsReadOnly => false;
+
+    /// <inheritdoc />
+    public bool IsConcurrencySafe => false;
+
+    /// <inheritdoc />
+    public async Task<ToolResult> ExecuteAsync(
+        string operation,
+        IReadOnlyDictionary<string, object?> parameters,
+        CancellationToken cancellationToken = default)
+    {
+        if (!string.Equals(operation, "submit", StringComparison.OrdinalIgnoreCase))
+            return ToolResult.Fail($"Unknown operation: {operation}. Supported: submit.");
+
+        var drift = await _controller.DetectDriftAsync(cancellationToken).ConfigureAwait(false);
+        if (!drift.IsSuccess)
+            return ToolResult.Fail(string.Join("; ", drift.Errors));
+
+        if (drift.Value!.DriftedResources.Count == 0)
+            return ToolResult.Ok("No drift detected; no remediation proposal submitted.");
+
+        var plan = await _controller.ProposeRemediationAsync(drift.Value, cancellationToken).ConfigureAwait(false);
+        if (!plan.IsSuccess)
+            return ToolResult.Fail(string.Join("; ", plan.Errors));
+
+        var dispatched = await _dispatcher.DispatchAsync(plan.Value!, cancellationToken).ConfigureAwait(false);
+        if (!dispatched.IsSuccess)
+            return ToolResult.Fail(string.Join("; ", dispatched.Errors));
+
+        return ToolResult.Ok(JsonSerializer.Serialize(dispatched.Value, SerializerOptions));
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/GitOps/K8sGptAnalyzeTool.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/GitOps/K8sGptAnalyzeTool.cs
@@ -1,0 +1,125 @@
+using System.Text.Json;
+using Application.AI.Common.Interfaces.GitOps;
+using Application.AI.Common.Interfaces.Tools;
+using Domain.AI.Models;
+
+namespace Infrastructure.AI.Tools.GitOps;
+
+/// <summary>
+/// Read-only GitOps tool that runs a K8sGPT root-cause analysis of the cluster
+/// via <see cref="IK8sGptMcpClient"/> and returns the structured findings as
+/// JSON. Backs the <c>gitops-cluster-debug</c> skill.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Parameters (all optional): <c>namespace</c> (string — scope; omit for all
+/// namespaces), <c>filters</c> (comma-separated string or string array of
+/// resource kinds, e.g. <c>"Deployment,Pod"</c>), and <c>explain</c> (bool —
+/// request a natural-language explanation, default true).
+/// </para>
+/// <para>
+/// The K8sGPT analysis surface is read-only by contract: the client narrows the
+/// MCP server to analysis-only regardless of what it advertises, so this tool
+/// can never mutate the cluster.
+/// </para>
+/// </remarks>
+public sealed class K8sGptAnalyzeTool : ITool
+{
+    /// <summary>Tool key — matches the keyed-DI registration and the SKILL.md allowed-tools entry.</summary>
+    public const string ToolName = "k8sgpt_analyze";
+
+    private static readonly IReadOnlyList<string> Operations = ["analyze"];
+    private static readonly JsonSerializerOptions SerializerOptions = new() { WriteIndented = false };
+
+    private readonly IK8sGptMcpClient _client;
+
+    /// <summary>Initialises a new instance of the <see cref="K8sGptAnalyzeTool"/> class.</summary>
+    /// <param name="client">Client-side abstraction over the K8sGPT MCP server.</param>
+    public K8sGptAnalyzeTool(IK8sGptMcpClient client)
+    {
+        ArgumentNullException.ThrowIfNull(client);
+        _client = client;
+    }
+
+    /// <inheritdoc />
+    public string Name => ToolName;
+
+    /// <inheritdoc />
+    public string Description =>
+        "Runs a K8sGPT root-cause analysis of the cluster (optionally scoped by namespace and resource-kind filters) and returns structured findings as JSON. Read-only — never mutates the cluster.";
+
+    /// <inheritdoc />
+    public IReadOnlyList<string> SupportedOperations => Operations;
+
+    /// <inheritdoc />
+    public bool IsReadOnly => true;
+
+    /// <inheritdoc />
+    public bool IsConcurrencySafe => true;
+
+    /// <inheritdoc />
+    public async Task<ToolResult> ExecuteAsync(
+        string operation,
+        IReadOnlyDictionary<string, object?> parameters,
+        CancellationToken cancellationToken = default)
+    {
+        if (!string.Equals(operation, "analyze", StringComparison.OrdinalIgnoreCase))
+            return ToolResult.Fail($"Unknown operation: {operation}. Supported: analyze.");
+
+        var request = new K8sGptAnalysisRequest
+        {
+            Namespace = ReadNamespace(parameters),
+            Filters = ReadFilters(parameters),
+            Explain = ReadExplain(parameters),
+        };
+
+        var result = await _client.AnalyzeAsync(request, cancellationToken).ConfigureAwait(false);
+        if (!result.IsSuccess)
+            return ToolResult.Fail(string.Join("; ", result.Errors));
+
+        return ToolResult.Ok(JsonSerializer.Serialize(result.Value, SerializerOptions));
+    }
+
+    private static string? ReadNamespace(IReadOnlyDictionary<string, object?> parameters)
+        => parameters.TryGetValue("namespace", out var v) && v is string s && !string.IsNullOrWhiteSpace(s)
+            ? s
+            : null;
+
+    private static bool ReadExplain(IReadOnlyDictionary<string, object?> parameters)
+    {
+        if (!parameters.TryGetValue("explain", out var v) || v is null)
+            return true;
+
+        return v switch
+        {
+            bool b => b,
+            string s when bool.TryParse(s, out var parsed) => parsed,
+            JsonElement { ValueKind: JsonValueKind.False } => false,
+            JsonElement { ValueKind: JsonValueKind.True } => true,
+            _ => true,
+        };
+    }
+
+    private static IReadOnlyList<string> ReadFilters(IReadOnlyDictionary<string, object?> parameters)
+    {
+        if (!parameters.TryGetValue("filters", out var v) || v is null)
+            return [];
+
+        return v switch
+        {
+            IEnumerable<string> list => list.Where(static x => !string.IsNullOrWhiteSpace(x)).ToArray(),
+            string csv => SplitCsv(csv),
+            JsonElement { ValueKind: JsonValueKind.Array } arr =>
+                arr.EnumerateArray()
+                   .Select(static e => e.GetString())
+                   .Where(static x => !string.IsNullOrWhiteSpace(x))
+                   .Select(static x => x!)
+                   .ToArray(),
+            JsonElement { ValueKind: JsonValueKind.String } str => SplitCsv(str.GetString() ?? string.Empty),
+            _ => [],
+        };
+    }
+
+    private static string[] SplitCsv(string csv)
+        => csv.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+}

--- a/src/Content/Tests/Application.Core.Tests/Validation/GitOpsConfigValidatorTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/Validation/GitOpsConfigValidatorTests.cs
@@ -1,0 +1,191 @@
+using Application.Core.Validation;
+using Domain.Common.Config.AI.GitOps;
+using FluentAssertions;
+using Xunit;
+
+namespace Application.Core.Tests.Validation;
+
+/// <summary>
+/// Tests for <see cref="GitOpsConfigValidator"/>. All rules are conditional on
+/// <see cref="GitOpsConfig.Enabled"/>: a disabled skill pack is always valid; an
+/// enabled one mirrors the boot-time checks in <c>GitOpsStartupValidator</c>.
+/// Pattern: CreateValidConfig() baseline, mutate one field per test.
+/// </summary>
+public class GitOpsConfigValidatorTests
+{
+    private readonly GitOpsConfigValidator _validator = new();
+
+    [Fact]
+    public void DefaultValues_MatchSpec()
+    {
+        var config = new GitOpsConfig();
+
+        config.Enabled.Should().BeFalse();
+        config.ActiveController.Should().BeEmpty();
+        config.K8sGptMcpServerName.Should().Be("k8sgpt");
+        config.RemediationBranch.Should().Be("main");
+    }
+
+    [Fact]
+    public async Task Validate_Disabled_AlwaysValid()
+    {
+        // Everything is blank/invalid, but Enabled=false short-circuits all rules.
+        var config = new GitOpsConfig
+        {
+            Enabled = false,
+            ActiveController = "nonsense",
+            K8sGptMcpServerName = "",
+            RemediationRepoUrl = "",
+            FluxApiBaseUrl = "ftp://bad",
+            ArgoCdApiBaseUrl = ""
+        };
+
+        var result = await _validator.ValidateAsync(config);
+
+        result.IsValid.Should().BeTrue();
+        result.Errors.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Validate_ValidFluxConfig_NoErrors()
+    {
+        var result = await _validator.ValidateAsync(CreateValidConfig("flux"));
+
+        result.IsValid.Should().BeTrue();
+        result.Errors.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Validate_ValidArgoCdConfig_NoErrors()
+    {
+        var result = await _validator.ValidateAsync(CreateValidConfig("argocd"));
+
+        result.IsValid.Should().BeTrue();
+        result.Errors.Should().BeEmpty();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("spinnaker")]
+    [InlineData("FLUXX")]
+    public async Task Validate_UnknownActiveController_HasError(string controller)
+    {
+        var config = CreateValidConfig("flux");
+        config.ActiveController = controller;
+
+        var result = await _validator.ValidateAsync(config);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == "ActiveController");
+    }
+
+    [Theory]
+    [InlineData("flux")]
+    [InlineData("FLUX")]
+    [InlineData("argocd")]
+    [InlineData(" argocd ")]
+    public async Task Validate_KnownActiveControllerCaseAndWhitespaceInsensitive_NoActiveControllerError(string controller)
+    {
+        var config = CreateValidConfig("flux");
+        config.ActiveController = controller;
+
+        var result = await _validator.ValidateAsync(config);
+
+        result.Errors.Should().NotContain(e => e.PropertyName == "ActiveController");
+    }
+
+    [Fact]
+    public async Task Validate_EmptyK8sGptServerName_HasError()
+    {
+        var config = CreateValidConfig("flux");
+        config.K8sGptMcpServerName = "";
+
+        var result = await _validator.ValidateAsync(config);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == "K8sGptMcpServerName");
+    }
+
+    [Fact]
+    public async Task Validate_EmptyRemediationRepoUrl_HasError()
+    {
+        var config = CreateValidConfig("flux");
+        config.RemediationRepoUrl = "";
+
+        var result = await _validator.ValidateAsync(config);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == "RemediationRepoUrl");
+    }
+
+    [Fact]
+    public async Task Validate_RelativeRemediationRepoUrl_HasError()
+    {
+        var config = CreateValidConfig("flux");
+        config.RemediationRepoUrl = "not-a-url";
+
+        var result = await _validator.ValidateAsync(config);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == "RemediationRepoUrl");
+    }
+
+    [Fact]
+    public async Task Validate_FluxActiveButFluxUrlNotHttp_HasError()
+    {
+        var config = CreateValidConfig("flux");
+        config.FluxApiBaseUrl = "ftp://flux.example.com";
+
+        var result = await _validator.ValidateAsync(config);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == "FluxApiBaseUrl");
+    }
+
+    [Fact]
+    public async Task Validate_FluxActiveButFluxUrlEmpty_HasError()
+    {
+        var config = CreateValidConfig("flux");
+        config.FluxApiBaseUrl = "";
+
+        var result = await _validator.ValidateAsync(config);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == "FluxApiBaseUrl");
+    }
+
+    [Fact]
+    public async Task Validate_ArgoCdActiveButArgoCdUrlNotHttp_HasError()
+    {
+        var config = CreateValidConfig("argocd");
+        config.ArgoCdApiBaseUrl = "ftp://argocd.example.com";
+
+        var result = await _validator.ValidateAsync(config);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == "ArgoCdApiBaseUrl");
+    }
+
+    [Fact]
+    public async Task Validate_FluxActive_DoesNotValidateArgoCdUrl()
+    {
+        // ArgoCd URL is junk, but the active controller is flux so it is not checked.
+        var config = CreateValidConfig("flux");
+        config.ArgoCdApiBaseUrl = "junk";
+
+        var result = await _validator.ValidateAsync(config);
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    private static GitOpsConfig CreateValidConfig(string activeController) => new()
+    {
+        Enabled = true,
+        ActiveController = activeController,
+        K8sGptMcpServerName = "k8sgpt",
+        FluxApiBaseUrl = "https://flux.example.com",
+        ArgoCdApiBaseUrl = "https://argocd.example.com",
+        RemediationRepoUrl = "https://github.com/example/cluster-config.git",
+        RemediationBranch = "main"
+    };
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/GitOps/ArgoCdGitOpsControllerTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/GitOps/ArgoCdGitOpsControllerTests.cs
@@ -1,0 +1,204 @@
+using Domain.AI.Changes;
+using Domain.AI.GitOps;
+using FluentAssertions;
+using Infrastructure.AI.Egress;
+using Infrastructure.AI.GitOps.ArgoCd;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Time.Testing;
+using Moq;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.GitOps;
+
+/// <summary>
+/// Tests <see cref="ArgoCdGitOpsController"/> driven through a real
+/// <see cref="ArgoCdApiClient"/> backed by a mocked egress <see cref="HttpClient"/>.
+/// Exercises drift detection (OutOfSync / Degraded / Missing), cluster-health
+/// mapping, and remediation planning against the Argo CD Application JSON shape.
+/// </summary>
+public sealed class ArgoCdGitOpsControllerTests
+{
+    private readonly Mock<IHttpClientFactory> _httpClientFactory = new();
+    private readonly FakeTimeProvider _time = new(DateTimeOffset.Parse("2026-06-08T12:00:00Z"));
+
+    private ArgoCdGitOpsController CreateSut(HttpClient httpClient)
+    {
+        _httpClientFactory
+            .Setup(f => f.CreateClient(EgressPolicyDelegatingHandler.ClientName))
+            .Returns(httpClient);
+
+        var config = GitOpsTestConfig.Monitor(GitOpsTestConfig.ValidAppConfig("argocd"));
+        var apiClient = new ArgoCdApiClient(_httpClientFactory.Object, config, NullLogger<ArgoCdApiClient>.Instance);
+        return new ArgoCdGitOpsController(apiClient, config, NullLogger<ArgoCdGitOpsController>.Instance, _time);
+    }
+
+    private static string AppsJson(params string[] appItems)
+        => "{\"items\":[" + string.Join(",", appItems) + "]}";
+
+    private static string App(string name, string sync, string health, string path = "apps", string message = "")
+        => "{" +
+           "\"metadata\":{\"name\":\"" + name + "\",\"namespace\":\"argocd\"}," +
+           "\"spec\":{\"source\":{\"repoURL\":\"https://github.com/example/cluster-config.git\",\"path\":\"" + path + "\"}}," +
+           "\"status\":{\"sync\":{\"status\":\"" + sync + "\",\"revision\":\"r1\"}," +
+           "\"health\":{\"status\":\"" + health + "\",\"message\":\"" + message + "\"}}}";
+
+    [Fact]
+    public void Kind_IsArgoCd()
+    {
+        var sut = CreateSut(GitOpsHttpMock.JsonClient(System.Net.HttpStatusCode.OK, """{"items":[]}"""));
+
+        sut.Kind.Should().Be(GitOpsControllerKind.ArgoCd);
+    }
+
+    [Fact]
+    public async Task DetectDriftAsync_SyncedAndHealthy_ReportsNoDrift()
+    {
+        var client = GitOpsHttpMock.JsonClient(System.Net.HttpStatusCode.OK, AppsJson(App("web", "Synced", "Healthy")));
+        var sut = CreateSut(client);
+
+        var result = await sut.DetectDriftAsync(CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.HasDrift.Should().BeFalse();
+        result.Value.ControllerKind.Should().Be(GitOpsControllerKind.ArgoCd);
+    }
+
+    [Fact]
+    public async Task DetectDriftAsync_OutOfSync_ReportsDrift()
+    {
+        var client = GitOpsHttpMock.JsonClient(System.Net.HttpStatusCode.OK, AppsJson(App("web", "OutOfSync", "Healthy")));
+        var sut = CreateSut(client);
+
+        var result = await sut.DetectDriftAsync(CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        var drifted = result.Value!.DriftedResources.Should().ContainSingle().Subject;
+        drifted.Kind.Should().Be("Application");
+        drifted.Name.Should().Be("web");
+        drifted.DesiredPath.Should().Be("apps");
+        drifted.Severity.Should().Be(DriftSeverity.Medium);
+    }
+
+    [Fact]
+    public async Task DetectDriftAsync_DegradedHealth_ReportsHighSeverityDrift()
+    {
+        var client = GitOpsHttpMock.JsonClient(System.Net.HttpStatusCode.OK, AppsJson(App("api", "Synced", "Degraded", message: "crashloop")));
+        var sut = CreateSut(client);
+
+        var result = await sut.DetectDriftAsync(CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        var drifted = result.Value!.DriftedResources.Should().ContainSingle().Subject;
+        drifted.Severity.Should().Be(DriftSeverity.High);
+        drifted.Summary.Should().Be("crashloop");
+    }
+
+    [Fact]
+    public async Task DetectDriftAsync_MissingHealth_ReportsHighSeverityDrift()
+    {
+        var client = GitOpsHttpMock.JsonClient(System.Net.HttpStatusCode.OK, AppsJson(App("api", "Synced", "Missing")));
+        var sut = CreateSut(client);
+
+        var result = await sut.DetectDriftAsync(CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.DriftedResources.Should().ContainSingle(r => r.Severity == DriftSeverity.High);
+    }
+
+    [Fact]
+    public async Task DetectDriftAsync_ApiUnreachable_ReturnsFailWithStableCode()
+    {
+        var sut = CreateSut(GitOpsHttpMock.UnreachableClient());
+
+        var result = await sut.DetectDriftAsync(CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Errors.Should().Contain("gitops.argocd.api_unreachable");
+    }
+
+    [Fact]
+    public async Task GetClusterHealthAsync_SyncedHealthy_MapsToHealthy()
+    {
+        var client = GitOpsHttpMock.JsonClient(System.Net.HttpStatusCode.OK, AppsJson(App("web", "Synced", "Healthy")));
+        var sut = CreateSut(client);
+
+        var result = await sut.GetClusterHealthAsync(CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.OverallStatus.Should().Be(ClusterHealthStatus.Healthy);
+        result.Value.ResourceStates.Should().ContainSingle(r => r.Kind == "Application");
+    }
+
+    [Fact]
+    public async Task GetClusterHealthAsync_Degraded_RollsUpToDegraded()
+    {
+        var client = GitOpsHttpMock.JsonClient(System.Net.HttpStatusCode.OK,
+            AppsJson(App("web", "Synced", "Healthy"), App("api", "OutOfSync", "Degraded")));
+        var sut = CreateSut(client);
+
+        var result = await sut.GetClusterHealthAsync(CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.OverallStatus.Should().Be(ClusterHealthStatus.Degraded);
+    }
+
+    [Fact]
+    public async Task GetClusterHealthAsync_Suspended_SurfacesNote()
+    {
+        var client = GitOpsHttpMock.JsonClient(System.Net.HttpStatusCode.OK, AppsJson(App("web", "Synced", "Suspended")));
+        var sut = CreateSut(client);
+
+        var result = await sut.GetClusterHealthAsync(CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.Notes.Should().ContainSingle(n => n.Contains("suspended"));
+        result.Value.OverallStatus.Should().Be(ClusterHealthStatus.Progressing);
+    }
+
+    [Fact]
+    public async Task ProposeRemediationAsync_Drift_ProducesPlanWithArgoCdKind()
+    {
+        var sut = CreateSut(GitOpsHttpMock.JsonClient(System.Net.HttpStatusCode.OK, """{"items":[]}"""));
+        var drift = new DriftReport
+        {
+            ControllerKind = GitOpsControllerKind.ArgoCd,
+            CapturedAt = _time.GetUtcNow(),
+            DriftedResources =
+            [
+                new DriftedResource
+                {
+                    ApiVersion = "argoproj.io/v1alpha1",
+                    Kind = "Application",
+                    Name = "web",
+                    Namespace = "argocd",
+                    DesiredPath = "apps",
+                    Severity = DriftSeverity.High
+                }
+            ]
+        };
+
+        var result = await sut.ProposeRemediationAsync(drift, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.ControllerKind.Should().Be(GitOpsControllerKind.ArgoCd);
+        result.Value.ProposedBlastRadius.Should().Be(BlastRadius.High);
+        result.Value.Edits.Should().ContainSingle(e => e.Target == "apps");
+    }
+
+    [Fact]
+    public async Task ProposeRemediationAsync_NoDrift_ReturnsFail()
+    {
+        var sut = CreateSut(GitOpsHttpMock.JsonClient(System.Net.HttpStatusCode.OK, """{"items":[]}"""));
+        var drift = new DriftReport
+        {
+            ControllerKind = GitOpsControllerKind.ArgoCd,
+            CapturedAt = _time.GetUtcNow(),
+            DriftedResources = []
+        };
+
+        var result = await sut.ProposeRemediationAsync(drift, CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Errors.Should().Contain("gitops.remediation.no_drift");
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/GitOps/FluxGitOpsControllerTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/GitOps/FluxGitOpsControllerTests.cs
@@ -1,0 +1,308 @@
+using Domain.AI.Changes;
+using Domain.AI.GitOps;
+using Domain.AI.SkillTraining;
+using FluentAssertions;
+using Infrastructure.AI.Egress;
+using Infrastructure.AI.GitOps.Flux;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Time.Testing;
+using Moq;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.GitOps;
+
+/// <summary>
+/// Tests <see cref="FluxGitOpsController"/> driven through a real
+/// <see cref="FluxApiClient"/> backed by a mocked egress <see cref="HttpClient"/>.
+/// Exercises drift detection, cluster-health mapping, and remediation planning
+/// against the documented Flux status JSON shape.
+/// </summary>
+public sealed class FluxGitOpsControllerTests
+{
+    private readonly Mock<IHttpClientFactory> _httpClientFactory = new();
+    private readonly FakeTimeProvider _time = new(DateTimeOffset.Parse("2026-06-08T12:00:00Z"));
+
+    private FluxGitOpsController CreateSut(HttpClient httpClient, string activeController = "flux")
+    {
+        _httpClientFactory
+            .Setup(f => f.CreateClient(EgressPolicyDelegatingHandler.ClientName))
+            .Returns(httpClient);
+
+        var config = GitOpsTestConfig.Monitor(GitOpsTestConfig.ValidAppConfig(activeController));
+        var apiClient = new FluxApiClient(_httpClientFactory.Object, config, NullLogger<FluxApiClient>.Instance);
+        return new FluxGitOpsController(apiClient, config, NullLogger<FluxGitOpsController>.Instance, _time);
+    }
+
+    [Fact]
+    public void Kind_IsFlux()
+    {
+        var sut = CreateSut(GitOpsHttpMock.JsonClient(System.Net.HttpStatusCode.OK, """{"items":[]}"""));
+
+        sut.Kind.Should().Be(GitOpsControllerKind.Flux);
+    }
+
+    [Fact]
+    public async Task DetectDriftAsync_AllReadyAndRevisionsMatch_ReportsNoDrift()
+    {
+        var client = GitOpsHttpMock.RoutedJsonClient(new Dictionary<string, string>
+        {
+            ["kustomizations"] = """
+                {"items":[{"name":"apps","namespace":"flux-system","path":"./apps","ready":true,
+                "lastAppliedRevision":"sha-1","lastAttemptedRevision":"sha-1"}]}
+                """,
+            ["helmreleases"] = """{"items":[{"name":"ingress","namespace":"infra","ready":true}]}"""
+        });
+        var sut = CreateSut(client);
+
+        var result = await sut.DetectDriftAsync(CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.HasDrift.Should().BeFalse();
+        result.Value.DriftedResources.Should().BeEmpty();
+        result.Value.ControllerKind.Should().Be(GitOpsControllerKind.Flux);
+        result.Value.EvidenceHash.Should().NotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public async Task DetectDriftAsync_KustomizationNotReady_ReportsDrift()
+    {
+        var client = GitOpsHttpMock.RoutedJsonClient(new Dictionary<string, string>
+        {
+            ["kustomizations"] = """
+                {"items":[{"name":"apps","namespace":"flux-system","path":"./apps","ready":false,
+                "suspended":false,"message":"reconciliation failed"}]}
+                """,
+            ["helmreleases"] = """{"items":[]}"""
+        });
+        var sut = CreateSut(client);
+
+        var result = await sut.DetectDriftAsync(CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.HasDrift.Should().BeTrue();
+        result.Value.DriftedResources.Should().ContainSingle();
+        var drifted = result.Value.DriftedResources[0];
+        drifted.Kind.Should().Be("Kustomization");
+        drifted.Name.Should().Be("apps");
+        drifted.DesiredPath.Should().Be("./apps");
+        drifted.Summary.Should().Be("reconciliation failed");
+    }
+
+    [Fact]
+    public async Task DetectDriftAsync_RevisionMismatch_ReportsDrift()
+    {
+        var client = GitOpsHttpMock.RoutedJsonClient(new Dictionary<string, string>
+        {
+            ["kustomizations"] = """
+                {"items":[{"name":"apps","namespace":"flux-system","path":"./apps","ready":true,
+                "lastAppliedRevision":"sha-old","lastAttemptedRevision":"sha-new"}]}
+                """,
+            ["helmreleases"] = """{"items":[]}"""
+        });
+        var sut = CreateSut(client);
+
+        var result = await sut.DetectDriftAsync(CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.HasDrift.Should().BeTrue();
+        result.Value.DriftedResources.Should().ContainSingle(r => r.Kind == "Kustomization");
+    }
+
+    [Fact]
+    public async Task DetectDriftAsync_SuspendedKustomization_NotTreatedAsDrift()
+    {
+        var client = GitOpsHttpMock.RoutedJsonClient(new Dictionary<string, string>
+        {
+            ["kustomizations"] = """
+                {"items":[{"name":"apps","namespace":"flux-system","path":"./apps","ready":false,"suspended":true}]}
+                """,
+            ["helmreleases"] = """{"items":[]}"""
+        });
+        var sut = CreateSut(client);
+
+        var result = await sut.DetectDriftAsync(CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.HasDrift.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task DetectDriftAsync_HelmReleaseNotReady_ReportsHighSeverityDrift()
+    {
+        var client = GitOpsHttpMock.RoutedJsonClient(new Dictionary<string, string>
+        {
+            ["kustomizations"] = """{"items":[]}""",
+            ["helmreleases"] = """{"items":[{"name":"ingress","namespace":"infra","ready":false,"message":"install failed"}]}"""
+        });
+        var sut = CreateSut(client);
+
+        var result = await sut.DetectDriftAsync(CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        var drifted = result.Value!.DriftedResources.Should().ContainSingle().Subject;
+        drifted.Kind.Should().Be("HelmRelease");
+        drifted.Severity.Should().Be(DriftSeverity.High);
+    }
+
+    [Fact]
+    public async Task DetectDriftAsync_ApiUnreachable_ReturnsFailWithStableCode()
+    {
+        var sut = CreateSut(GitOpsHttpMock.UnreachableClient());
+
+        var result = await sut.DetectDriftAsync(CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Errors.Should().Contain("gitops.flux.api_unreachable");
+    }
+
+    [Fact]
+    public async Task GetClusterHealthAsync_AllReady_MapsToHealthy()
+    {
+        var client = GitOpsHttpMock.RoutedJsonClient(new Dictionary<string, string>
+        {
+            ["kustomizations"] = """{"items":[{"name":"apps","namespace":"flux-system","ready":true}]}""",
+            ["helmreleases"] = """{"items":[{"name":"ingress","namespace":"infra","ready":true}]}"""
+        });
+        var sut = CreateSut(client);
+
+        var result = await sut.GetClusterHealthAsync(CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.OverallStatus.Should().Be(ClusterHealthStatus.Healthy);
+        result.Value.ResourceStates.Should().HaveCount(2);
+        result.Value.Notes.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetClusterHealthAsync_HelmReleaseNotReady_RollsUpToFailed()
+    {
+        var client = GitOpsHttpMock.RoutedJsonClient(new Dictionary<string, string>
+        {
+            ["kustomizations"] = """{"items":[{"name":"apps","namespace":"flux-system","ready":true}]}""",
+            ["helmreleases"] = """{"items":[{"name":"ingress","namespace":"infra","ready":false}]}"""
+        });
+        var sut = CreateSut(client);
+
+        var result = await sut.GetClusterHealthAsync(CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.OverallStatus.Should().Be(ClusterHealthStatus.Failed);
+    }
+
+    [Fact]
+    public async Task GetClusterHealthAsync_SuspendedResource_SurfacesNote()
+    {
+        var client = GitOpsHttpMock.RoutedJsonClient(new Dictionary<string, string>
+        {
+            ["kustomizations"] = """{"items":[{"name":"apps","namespace":"flux-system","ready":false,"suspended":true}]}""",
+            ["helmreleases"] = """{"items":[]}"""
+        });
+        var sut = CreateSut(client);
+
+        var result = await sut.GetClusterHealthAsync(CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.Notes.Should().ContainSingle(n => n.Contains("suspended"));
+        result.Value.OverallStatus.Should().Be(ClusterHealthStatus.Progressing);
+    }
+
+    [Fact]
+    public async Task ProposeRemediationAsync_DriftWithDesiredPath_ProducesPlan()
+    {
+        var sut = CreateSut(GitOpsHttpMock.JsonClient(System.Net.HttpStatusCode.OK, """{"items":[]}"""));
+        var drift = new DriftReport
+        {
+            ControllerKind = GitOpsControllerKind.Flux,
+            CapturedAt = _time.GetUtcNow(),
+            DriftedResources =
+            [
+                new DriftedResource
+                {
+                    ApiVersion = "kustomize.toolkit.fluxcd.io/v1",
+                    Kind = "Kustomization",
+                    Name = "apps",
+                    Namespace = "flux-system",
+                    DesiredPath = "./apps",
+                    Severity = DriftSeverity.Medium
+                }
+            ]
+        };
+
+        var result = await sut.ProposeRemediationAsync(drift, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        var plan = result.Value!;
+        plan.ControllerKind.Should().Be(GitOpsControllerKind.Flux);
+        plan.Edits.Should().ContainSingle();
+        plan.Edits[0].Target.Should().Be("./apps");
+        plan.Edits[0].Op.Should().Be(EditOp.Replace);
+        plan.ProposedBlastRadius.Should().Be(BlastRadius.Medium);
+        plan.Target.Should().BeOfType<GitRepoTarget>();
+        ((GitRepoTarget)plan.Target).Branch.Should().Be("main");
+    }
+
+    [Fact]
+    public async Task ProposeRemediationAsync_NoDrift_ReturnsFail()
+    {
+        var sut = CreateSut(GitOpsHttpMock.JsonClient(System.Net.HttpStatusCode.OK, """{"items":[]}"""));
+        var drift = new DriftReport
+        {
+            ControllerKind = GitOpsControllerKind.Flux,
+            CapturedAt = _time.GetUtcNow(),
+            DriftedResources = []
+        };
+
+        var result = await sut.ProposeRemediationAsync(drift, CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Errors.Should().Contain("gitops.remediation.no_drift");
+    }
+
+    [Fact]
+    public async Task ProposeRemediationAsync_ControllerMismatch_ReturnsFail()
+    {
+        var sut = CreateSut(GitOpsHttpMock.JsonClient(System.Net.HttpStatusCode.OK, """{"items":[]}"""));
+        var drift = new DriftReport
+        {
+            ControllerKind = GitOpsControllerKind.ArgoCd,
+            CapturedAt = _time.GetUtcNow(),
+            DriftedResources =
+            [
+                new DriftedResource { ApiVersion = "v1", Kind = "X", Name = "x", DesiredPath = "p" }
+            ]
+        };
+
+        var result = await sut.ProposeRemediationAsync(drift, CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Errors.Should().Contain("gitops.remediation.controller_mismatch");
+    }
+
+    [Fact]
+    public async Task ProposeRemediationAsync_DriftWithoutDesiredPath_ReturnsNoRemediableDrift()
+    {
+        var sut = CreateSut(GitOpsHttpMock.JsonClient(System.Net.HttpStatusCode.OK, """{"items":[]}"""));
+        var drift = new DriftReport
+        {
+            ControllerKind = GitOpsControllerKind.Flux,
+            CapturedAt = _time.GetUtcNow(),
+            DriftedResources =
+            [
+                new DriftedResource
+                {
+                    ApiVersion = "helm.toolkit.fluxcd.io/v2",
+                    Kind = "HelmRelease",
+                    Name = "ingress",
+                    Namespace = "infra",
+                    DesiredPath = null,
+                    Severity = DriftSeverity.High
+                }
+            ]
+        };
+
+        var result = await sut.ProposeRemediationAsync(drift, CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Errors.Should().Contain("gitops.remediation.no_remediable_drift");
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/GitOps/GitOpsDependencyInjectionTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/GitOps/GitOpsDependencyInjectionTests.cs
@@ -1,0 +1,132 @@
+using Application.AI.Common.Interfaces;
+using Application.AI.Common.Interfaces.GitOps;
+using Application.AI.Common.Interfaces.Tools;
+using Domain.AI.GitOps;
+using Domain.Common.Config;
+using FluentAssertions;
+using Infrastructure.AI.GitOps.ArgoCd;
+using Infrastructure.AI.GitOps.Flux;
+using Infrastructure.AI.Tools.GitOps;
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.GitOps;
+
+/// <summary>
+/// Verifies <see cref="GitOpsDependencyInjection.AddGitOpsSkillTools"/> registers
+/// the four tools by keyed name, both controllers by controller key, and a default
+/// <see cref="IGitOpsController"/> that resolves the configured active controller.
+/// Mirrors <c>WorkspaceDependencyInjectionTests</c>.
+/// </summary>
+public sealed class GitOpsDependencyInjectionTests
+{
+    private static ServiceCollection BaseServices(string activeController)
+    {
+        var services = new ServiceCollection();
+
+        // External dependencies the GitOps services consume but this DI module does not own.
+        services.AddSingleton(GitOpsTestConfig.Monitor(GitOpsTestConfig.ValidAppConfig(activeController)));
+        services.AddSingleton(TimeProvider.System);
+        services.AddSingleton(Mock.Of<IMediator>());
+        services.AddSingleton(Mock.Of<IMcpToolProvider>());
+        services.AddSingleton(Mock.Of<IHttpClientFactory>());
+        services.AddLogging();
+        return services;
+    }
+
+    [Fact]
+    public void AddGitOpsSkillTools_RegistersAllFourToolsByKeyedName()
+    {
+        var services = BaseServices("flux");
+
+        services.AddGitOpsSkillTools();
+        var sp = services.BuildServiceProvider();
+
+        sp.GetRequiredKeyedService<ITool>(GitOpsDetectDriftTool.ToolName).Should().BeOfType<GitOpsDetectDriftTool>();
+        sp.GetRequiredKeyedService<ITool>(GitOpsClusterHealthTool.ToolName).Should().BeOfType<GitOpsClusterHealthTool>();
+        sp.GetRequiredKeyedService<ITool>(GitOpsProposeRemediationTool.ToolName).Should().BeOfType<GitOpsProposeRemediationTool>();
+        sp.GetRequiredKeyedService<ITool>(K8sGptAnalyzeTool.ToolName).Should().BeOfType<K8sGptAnalyzeTool>();
+    }
+
+    [Fact]
+    public void AddGitOpsSkillTools_RegistersBothControllersByKey()
+    {
+        var services = BaseServices("flux");
+
+        services.AddGitOpsSkillTools();
+        var sp = services.BuildServiceProvider();
+
+        sp.GetRequiredKeyedService<IGitOpsController>("flux").Should().BeOfType<FluxGitOpsController>();
+        sp.GetRequiredKeyedService<IGitOpsController>("argocd").Should().BeOfType<ArgoCdGitOpsController>();
+    }
+
+    [Fact]
+    public void AddGitOpsSkillTools_DefaultController_ResolvesActiveFlux()
+    {
+        var services = BaseServices("flux");
+
+        services.AddGitOpsSkillTools();
+        var sp = services.BuildServiceProvider();
+
+        var controller = sp.GetRequiredService<IGitOpsController>();
+        controller.Kind.Should().Be(GitOpsControllerKind.Flux);
+    }
+
+    [Fact]
+    public void AddGitOpsSkillTools_DefaultController_ResolvesActiveArgoCd()
+    {
+        var services = BaseServices("argocd");
+
+        services.AddGitOpsSkillTools();
+        var sp = services.BuildServiceProvider();
+
+        var controller = sp.GetRequiredService<IGitOpsController>();
+        controller.Kind.Should().Be(GitOpsControllerKind.ArgoCd);
+    }
+
+    [Fact]
+    public void AddGitOpsSkillTools_DefaultController_ThrowsWhenActiveControllerBlank()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton(GitOpsTestConfig.Monitor(GitOpsTestConfig.ValidAppConfig(activeController: "")));
+        services.AddSingleton(TimeProvider.System);
+        services.AddSingleton(Mock.Of<IMediator>());
+        services.AddSingleton(Mock.Of<IMcpToolProvider>());
+        services.AddSingleton(Mock.Of<IHttpClientFactory>());
+        services.AddLogging();
+
+        services.AddGitOpsSkillTools();
+        var sp = services.BuildServiceProvider();
+
+        var act = () => sp.GetRequiredService<IGitOpsController>();
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*ActiveController*");
+    }
+
+    [Fact]
+    public void AddGitOpsSkillTools_RegistersK8sGptClientAndDispatcher()
+    {
+        var services = BaseServices("flux");
+
+        services.AddGitOpsSkillTools();
+        var sp = services.BuildServiceProvider();
+
+        sp.GetRequiredService<IK8sGptMcpClient>().Should().NotBeNull();
+        sp.GetRequiredService<IGitOpsRemediationDispatcher>().Should().NotBeNull();
+    }
+
+    [Fact]
+    public void AddGitOpsSkillTools_RegistersStartupValidatorAsHostedService()
+    {
+        var services = BaseServices("flux");
+
+        services.AddGitOpsSkillTools();
+        var sp = services.BuildServiceProvider();
+
+        sp.GetServices<Microsoft.Extensions.Hosting.IHostedService>()
+            .Should().ContainSingle(h => h is Infrastructure.AI.GitOps.GitOpsStartupValidator);
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/GitOps/GitOpsHttpMock.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/GitOps/GitOpsHttpMock.cs
@@ -1,0 +1,86 @@
+using System.Net;
+using Moq;
+using Moq.Protected;
+
+namespace Infrastructure.AI.Tests.GitOps;
+
+/// <summary>
+/// Helpers for wiring a mocked <see cref="HttpMessageHandler"/> behind the
+/// egress-named <see cref="HttpClient"/> the GitOps API clients resolve via
+/// <c>IHttpClientFactory.CreateClient(EgressPolicyDelegatingHandler.ClientName)</c>.
+/// Mirrors the pattern in <c>A2AAgentHostTests</c>.
+/// </summary>
+internal static class GitOpsHttpMock
+{
+    /// <summary>
+    /// Builds an <see cref="HttpClient"/> that returns the same status + JSON body
+    /// for every request. Use when a single endpoint is hit.
+    /// </summary>
+    public static HttpClient JsonClient(HttpStatusCode statusCode, string json)
+    {
+        var handler = new Mock<HttpMessageHandler>();
+        handler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage(statusCode)
+            {
+                Content = new StringContent(json)
+            });
+
+        return new HttpClient(handler.Object);
+    }
+
+    /// <summary>
+    /// Builds an <see cref="HttpClient"/> that routes responses by request path
+    /// substring. The first matching key wins; an unmatched request yields 404.
+    /// Use when a single client calls multiple endpoints (e.g. Flux lists both
+    /// kustomizations and helmreleases).
+    /// </summary>
+    public static HttpClient RoutedJsonClient(IReadOnlyDictionary<string, string> bodyByPathFragment)
+    {
+        var handler = new Mock<HttpMessageHandler>();
+        handler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync((HttpRequestMessage req, CancellationToken _) =>
+            {
+                var url = req.RequestUri!.ToString();
+                foreach (var (fragment, body) in bodyByPathFragment)
+                {
+                    if (url.Contains(fragment, StringComparison.OrdinalIgnoreCase))
+                    {
+                        return new HttpResponseMessage(HttpStatusCode.OK)
+                        {
+                            Content = new StringContent(body)
+                        };
+                    }
+                }
+
+                return new HttpResponseMessage(HttpStatusCode.NotFound);
+            });
+
+        return new HttpClient(handler.Object);
+    }
+
+    /// <summary>
+    /// Builds an <see cref="HttpClient"/> whose handler throws
+    /// <see cref="HttpRequestException"/> on every send — simulates an unreachable
+    /// controller API.
+    /// </summary>
+    public static HttpClient UnreachableClient()
+    {
+        var handler = new Mock<HttpMessageHandler>();
+        handler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ThrowsAsync(new HttpRequestException("simulated unreachable"));
+
+        return new HttpClient(handler.Object);
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/GitOps/GitOpsRemediationDispatcherTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/GitOps/GitOpsRemediationDispatcherTests.cs
@@ -1,0 +1,161 @@
+using Application.AI.Common.CQRS.Changes.SubmitChangeProposal;
+using Domain.AI.Changes;
+using Domain.AI.GitOps;
+using Domain.AI.Identity;
+using Domain.AI.SkillTraining;
+using Domain.Common;
+using FluentAssertions;
+using Infrastructure.AI.GitOps;
+using MediatR;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.GitOps;
+
+/// <summary>
+/// Tests <see cref="GitOpsRemediationDispatcher"/> against a mocked
+/// <see cref="IMediator"/>. Verifies the plan→command mapping, the
+/// unconditional <c>IsStateChange</c> flag, success pass-through, and failure
+/// surfacing.
+/// </summary>
+public sealed class GitOpsRemediationDispatcherTests
+{
+    private readonly Mock<IMediator> _mediator = new();
+
+    private GitOpsRemediationDispatcher CreateSut()
+        => new(_mediator.Object, NullLogger<GitOpsRemediationDispatcher>.Instance);
+
+    private static RemediationPlan ValidPlan(
+        GitOpsControllerKind kind = GitOpsControllerKind.Flux,
+        BlastRadius blastRadius = BlastRadius.Medium)
+    {
+        var drift = new DriftReport
+        {
+            ControllerKind = kind,
+            CapturedAt = DateTimeOffset.Parse("2026-06-08T12:00:00Z"),
+            DriftedResources =
+            [
+                new DriftedResource
+                {
+                    ApiVersion = "v1", Kind = "Kustomization", Name = "apps",
+                    Namespace = "flux-system", DesiredPath = "./apps"
+                }
+            ]
+        };
+
+        return new RemediationPlan
+        {
+            ControllerKind = kind,
+            SourceDrift = drift,
+            Target = new GitRepoTarget("https://github.com/example/cluster-config.git", "main"),
+            Edits = [new ChangeEdit { Op = EditOp.Replace, Target = "./apps", Content = "# fix" }],
+            ProposedBlastRadius = blastRadius,
+            Summary = "Flux: reconverge 1 drifted resource(s)."
+        };
+    }
+
+    private static ChangeProposal SampleProposal() => new()
+    {
+        Id = "cp-1",
+        Target = new GitRepoTarget("https://github.com/example/cluster-config.git", "main"),
+        Diff = [new ChangeEdit { Op = EditOp.Replace, Target = "./apps", Content = "# fix" }],
+        BlastRadius = BlastRadius.Medium,
+        RequiredGates = [],
+        Status = ChangeProposalStatus.Draft,
+        SubmittedBy = new AgentIdentity { Id = "agent-001", Kind = AgentIdentityKind.Development },
+        SubmittedAt = DateTimeOffset.Parse("2026-06-08T12:00:00Z")
+    };
+
+    [Fact]
+    public async Task DispatchAsync_ValidPlan_MapsToCommandAndReturnsSuccess()
+    {
+        SubmitChangeProposalCommand? captured = null;
+        _mediator
+            .Setup(m => m.Send(It.IsAny<SubmitChangeProposalCommand>(), It.IsAny<CancellationToken>()))
+            .Callback<IRequest<Result<ChangeProposal>>, CancellationToken>((cmd, _) => captured = (SubmitChangeProposalCommand)cmd)
+            .ReturnsAsync(Result<ChangeProposal>.Success(SampleProposal()));
+        var sut = CreateSut();
+
+        var result = await sut.DispatchAsync(ValidPlan(), CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.Id.Should().Be("cp-1");
+        captured.Should().NotBeNull();
+        captured!.Diff.Should().ContainSingle(e => e.Target == "./apps");
+        captured.BlastRadius.Should().Be(BlastRadius.Medium);
+        captured.Summary.Should().Be("Flux: reconverge 1 drifted resource(s).");
+        captured.SkillKey.Should().Be("gitops:flux");
+    }
+
+    [Fact]
+    public async Task DispatchAsync_AlwaysMarksCommandAsStateChange()
+    {
+        SubmitChangeProposalCommand? captured = null;
+        _mediator
+            .Setup(m => m.Send(It.IsAny<SubmitChangeProposalCommand>(), It.IsAny<CancellationToken>()))
+            .Callback<IRequest<Result<ChangeProposal>>, CancellationToken>((cmd, _) => captured = (SubmitChangeProposalCommand)cmd)
+            .ReturnsAsync(Result<ChangeProposal>.Success(SampleProposal()));
+        var sut = CreateSut();
+
+        await sut.DispatchAsync(ValidPlan(), CancellationToken.None);
+
+        captured!.IsStateChange.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task DispatchAsync_ArgoCdPlan_DerivesArgoCdSkillKey()
+    {
+        SubmitChangeProposalCommand? captured = null;
+        _mediator
+            .Setup(m => m.Send(It.IsAny<SubmitChangeProposalCommand>(), It.IsAny<CancellationToken>()))
+            .Callback<IRequest<Result<ChangeProposal>>, CancellationToken>((cmd, _) => captured = (SubmitChangeProposalCommand)cmd)
+            .ReturnsAsync(Result<ChangeProposal>.Success(SampleProposal()));
+        var sut = CreateSut();
+
+        await sut.DispatchAsync(ValidPlan(GitOpsControllerKind.ArgoCd), CancellationToken.None);
+
+        captured!.SkillKey.Should().Be("gitops:argocd");
+    }
+
+    [Fact]
+    public async Task DispatchAsync_EmptyPlan_ReturnsFailWithoutCallingMediator()
+    {
+        var plan = ValidPlan() with { Edits = [] };
+        var sut = CreateSut();
+
+        var result = await sut.DispatchAsync(plan, CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Errors.Should().Contain("gitops.remediation.empty_plan");
+        _mediator.Verify(m => m.Send(It.IsAny<SubmitChangeProposalCommand>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task DispatchAsync_MediatorReturnsFailure_PassesFailureThrough()
+    {
+        _mediator
+            .Setup(m => m.Send(It.IsAny<SubmitChangeProposalCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<ChangeProposal>.Fail("changes.validation.bad_target"));
+        var sut = CreateSut();
+
+        var result = await sut.DispatchAsync(ValidPlan(), CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Errors.Should().Contain("changes.validation.bad_target");
+    }
+
+    [Fact]
+    public async Task DispatchAsync_MediatorThrows_ReturnsDispatchFailedCode()
+    {
+        _mediator
+            .Setup(m => m.Send(It.IsAny<SubmitChangeProposalCommand>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("pipeline blew up"));
+        var sut = CreateSut();
+
+        var result = await sut.DispatchAsync(ValidPlan(), CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Errors.Should().Contain("gitops.remediation.dispatch_failed");
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/GitOps/GitOpsSkillEndToEndAcceptanceTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/GitOps/GitOpsSkillEndToEndAcceptanceTests.cs
@@ -1,0 +1,117 @@
+using Application.AI.Common.CQRS.Changes.SubmitChangeProposal;
+using Application.AI.Common.Interfaces;
+using Application.AI.Common.Interfaces.Tools;
+using Domain.AI.Changes;
+using Domain.AI.Identity;
+using Domain.Common;
+using FluentAssertions;
+using Infrastructure.AI.Egress;
+using Infrastructure.AI.Tools.GitOps;
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.GitOps;
+
+/// <summary>
+/// End-to-end acceptance for the GitOps skill pack: wires
+/// <see cref="GitOpsDependencyInjection.AddGitOpsSkillTools"/> on a real
+/// <see cref="ServiceCollection"/>, resolves the agent-facing tools by keyed name,
+/// and drives the detect→propose→dispatch flow through a mocked egress HttpClient
+/// (drift source) and a captured <see cref="IMediator"/> (change-proposal sink).
+/// Mirrors the structure of <c>WorkspaceSkillEndToEndAcceptanceTests</c>.
+/// </summary>
+public sealed class GitOpsSkillEndToEndAcceptanceTests
+{
+    private const string DriftedClusterJson = """
+        {"items":[{"name":"apps","namespace":"flux-system","path":"./apps","ready":false,
+        "suspended":false,"message":"reconciliation failed"}]}
+        """;
+    private const string HealthyClusterJson = """{"items":[]}""";
+
+    private static ChangeProposal SampleProposal(SubmitChangeProposalCommand cmd) => new()
+    {
+        Id = "cp-e2e-1",
+        Target = cmd.Target,
+        Diff = cmd.Diff,
+        BlastRadius = cmd.BlastRadius,
+        RequiredGates = [],
+        Status = ChangeProposalStatus.Draft,
+        SubmittedBy = new AgentIdentity { Id = "agent-001", Kind = AgentIdentityKind.Development },
+        SubmittedAt = DateTimeOffset.Parse("2026-06-08T12:00:00Z")
+    };
+
+    private static ServiceProvider BuildProvider(
+        string kustomizationsJson,
+        out Mock<IMediator> mediator)
+    {
+        var httpClient = GitOpsHttpMock.RoutedJsonClient(new Dictionary<string, string>
+        {
+            ["kustomizations"] = kustomizationsJson,
+            ["helmreleases"] = """{"items":[]}"""
+        });
+        var httpFactory = new Mock<IHttpClientFactory>();
+        httpFactory.Setup(f => f.CreateClient(EgressPolicyDelegatingHandler.ClientName)).Returns(httpClient);
+
+        mediator = new Mock<IMediator>();
+
+        var services = new ServiceCollection();
+        services.AddSingleton(GitOpsTestConfig.Monitor(GitOpsTestConfig.ValidAppConfig("flux")));
+        services.AddSingleton(TimeProvider.System);
+        services.AddSingleton(httpFactory.Object);
+        services.AddSingleton(mediator.Object);
+        services.AddSingleton(Mock.Of<IMcpToolProvider>());
+        services.AddLogging();
+        services.AddGitOpsSkillTools();
+        return services.BuildServiceProvider();
+    }
+
+    [Fact]
+    public async Task DetectThenProposeRemediation_DriftedCluster_SubmitsChangeProposalWithDriftedResource()
+    {
+        var sp = BuildProvider(DriftedClusterJson, out var mediator);
+
+        SubmitChangeProposalCommand? captured = null;
+        mediator
+            .Setup(m => m.Send(It.IsAny<SubmitChangeProposalCommand>(), It.IsAny<CancellationToken>()))
+            .Callback<IRequest<Result<ChangeProposal>>, CancellationToken>((cmd, _) => captured = (SubmitChangeProposalCommand)cmd)
+            .ReturnsAsync((IRequest<Result<ChangeProposal>> cmd, CancellationToken _) =>
+                Result<ChangeProposal>.Success(SampleProposal((SubmitChangeProposalCommand)cmd)));
+
+        // 1. detect_drift sees the drifted cluster.
+        var detectTool = sp.GetRequiredKeyedService<ITool>(GitOpsDetectDriftTool.ToolName);
+        var detect = await detectTool.ExecuteAsync("detect", new Dictionary<string, object?>());
+        detect.Success.Should().BeTrue();
+        detect.Output.Should().Contain("apps");
+
+        // 2. propose_remediation runs detect→propose→dispatch through the pipeline.
+        var proposeTool = sp.GetRequiredKeyedService<ITool>(GitOpsProposeRemediationTool.ToolName);
+        var propose = await proposeTool.ExecuteAsync("submit", new Dictionary<string, object?>());
+
+        propose.Success.Should().BeTrue();
+        propose.Output.Should().Contain("cp-e2e-1");
+
+        captured.Should().NotBeNull();
+        captured!.IsStateChange.Should().BeTrue();
+        captured.SkillKey.Should().Be("gitops:flux");
+        captured.Target.Should().BeOfType<GitRepoTarget>();
+        ((GitRepoTarget)captured.Target).RepoUrl.Should().Be("https://github.com/example/cluster-config.git");
+        captured.Diff.Should().ContainSingle(e => e.Target == "./apps");
+    }
+
+    [Fact]
+    public async Task ProposeRemediation_HealthyCluster_ShortCircuitsWithoutSubmitting()
+    {
+        var sp = BuildProvider(HealthyClusterJson, out var mediator);
+
+        var proposeTool = sp.GetRequiredKeyedService<ITool>(GitOpsProposeRemediationTool.ToolName);
+        var propose = await proposeTool.ExecuteAsync("submit", new Dictionary<string, object?>());
+
+        propose.Success.Should().BeTrue();
+        propose.Output.Should().Contain("No drift");
+        mediator.Verify(
+            m => m.Send(It.IsAny<SubmitChangeProposalCommand>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/GitOps/GitOpsStartupValidatorTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/GitOps/GitOpsStartupValidatorTests.cs
@@ -1,0 +1,171 @@
+using Domain.Common.Config;
+using FluentAssertions;
+using Infrastructure.AI.GitOps;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.GitOps;
+
+/// <summary>
+/// Tests <see cref="GitOpsStartupValidator"/>'s fail-loud boot behavior. The
+/// validator no-ops when the skill pack is disabled and throws a clear
+/// <see cref="InvalidOperationException"/> for each class of misconfiguration
+/// when enabled.
+/// </summary>
+public sealed class GitOpsStartupValidatorTests
+{
+    private static GitOpsStartupValidator CreateSut(AppConfig appConfig)
+        => new(GitOpsTestConfig.Monitor(appConfig), NullLogger<GitOpsStartupValidator>.Instance);
+
+    [Fact]
+    public async Task StartAsync_Disabled_NoOps()
+    {
+        var appConfig = GitOpsTestConfig.ValidAppConfig();
+        appConfig.AI.GitOps.Enabled = false;
+        // Even with everything else blanked out, disabled means no validation.
+        appConfig.AI.GitOps.ActiveController = "";
+        appConfig.AI.GitOps.RemediationRepoUrl = "";
+        var sut = CreateSut(appConfig);
+
+        var act = async () => await sut.StartAsync(CancellationToken.None);
+
+        await act.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task StartAsync_FullyValidFlux_DoesNotThrow()
+    {
+        var sut = CreateSut(GitOpsTestConfig.ValidAppConfig("flux"));
+
+        var act = async () => await sut.StartAsync(CancellationToken.None);
+
+        await act.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task StartAsync_FullyValidArgoCd_DoesNotThrow()
+    {
+        var sut = CreateSut(GitOpsTestConfig.ValidAppConfig("argocd"));
+
+        var act = async () => await sut.StartAsync(CancellationToken.None);
+
+        await act.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task StartAsync_EmptyActiveController_Throws()
+    {
+        var appConfig = GitOpsTestConfig.ValidAppConfig();
+        appConfig.AI.GitOps.ActiveController = "";
+        var sut = CreateSut(appConfig);
+
+        await FluentActions.Awaiting(() => sut.StartAsync(CancellationToken.None))
+            .Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*ActiveController*");
+    }
+
+    [Fact]
+    public async Task StartAsync_UnknownActiveController_Throws()
+    {
+        var appConfig = GitOpsTestConfig.ValidAppConfig();
+        appConfig.AI.GitOps.ActiveController = "spinnaker";
+        var sut = CreateSut(appConfig);
+
+        await FluentActions.Awaiting(() => sut.StartAsync(CancellationToken.None))
+            .Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*ActiveController*");
+    }
+
+    [Fact]
+    public async Task StartAsync_K8sGptServerNotRegistered_Throws()
+    {
+        var appConfig = GitOpsTestConfig.ValidAppConfig();
+        appConfig.AI.GitOps.K8sGptMcpServerName = "not-registered";
+        var sut = CreateSut(appConfig);
+
+        await FluentActions.Awaiting(() => sut.StartAsync(CancellationToken.None))
+            .Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*K8sGPT*");
+    }
+
+    [Fact]
+    public async Task StartAsync_EmptyK8sGptServerName_Throws()
+    {
+        var appConfig = GitOpsTestConfig.ValidAppConfig();
+        appConfig.AI.GitOps.K8sGptMcpServerName = "";
+        var sut = CreateSut(appConfig);
+
+        await FluentActions.Awaiting(() => sut.StartAsync(CancellationToken.None))
+            .Should().ThrowAsync<InvalidOperationException>();
+    }
+
+    [Fact]
+    public async Task StartAsync_FluxBaseUrlEmpty_Throws()
+    {
+        var appConfig = GitOpsTestConfig.ValidAppConfig("flux");
+        appConfig.AI.GitOps.FluxApiBaseUrl = "";
+        var sut = CreateSut(appConfig);
+
+        await FluentActions.Awaiting(() => sut.StartAsync(CancellationToken.None))
+            .Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*FluxApiBaseUrl*");
+    }
+
+    [Fact]
+    public async Task StartAsync_FluxBaseUrlNotHttp_Throws()
+    {
+        var appConfig = GitOpsTestConfig.ValidAppConfig("flux");
+        appConfig.AI.GitOps.FluxApiBaseUrl = "ftp://flux.example.com";
+        var sut = CreateSut(appConfig);
+
+        await FluentActions.Awaiting(() => sut.StartAsync(CancellationToken.None))
+            .Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*FluxApiBaseUrl*");
+    }
+
+    [Fact]
+    public async Task StartAsync_ArgoCdBaseUrlEmpty_Throws()
+    {
+        var appConfig = GitOpsTestConfig.ValidAppConfig("argocd");
+        appConfig.AI.GitOps.ArgoCdApiBaseUrl = "";
+        var sut = CreateSut(appConfig);
+
+        await FluentActions.Awaiting(() => sut.StartAsync(CancellationToken.None))
+            .Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*ArgoCdApiBaseUrl*");
+    }
+
+    [Fact]
+    public async Task StartAsync_RemediationRepoUrlEmpty_Throws()
+    {
+        var appConfig = GitOpsTestConfig.ValidAppConfig();
+        appConfig.AI.GitOps.RemediationRepoUrl = "";
+        var sut = CreateSut(appConfig);
+
+        await FluentActions.Awaiting(() => sut.StartAsync(CancellationToken.None))
+            .Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*RemediationRepoUrl*");
+    }
+
+    [Fact]
+    public async Task StartAsync_RemediationRepoUrlNotAbsolute_Throws()
+    {
+        var appConfig = GitOpsTestConfig.ValidAppConfig();
+        appConfig.AI.GitOps.RemediationRepoUrl = "not-a-url";
+        var sut = CreateSut(appConfig);
+
+        await FluentActions.Awaiting(() => sut.StartAsync(CancellationToken.None))
+            .Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*RemediationRepoUrl*");
+    }
+
+    [Fact]
+    public async Task StopAsync_NoOps()
+    {
+        var sut = CreateSut(GitOpsTestConfig.ValidAppConfig());
+
+        var act = async () => await sut.StopAsync(CancellationToken.None);
+
+        await act.Should().NotThrowAsync();
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/GitOps/GitOpsTestConfig.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/GitOps/GitOpsTestConfig.cs
@@ -1,0 +1,60 @@
+using Domain.Common.Config;
+using Domain.Common.Config.AI;
+using Domain.Common.Config.AI.GitOps;
+using Domain.Common.Config.AI.MCP;
+using Microsoft.Extensions.Options;
+using Moq;
+
+namespace Infrastructure.AI.Tests.GitOps;
+
+/// <summary>
+/// Shared builders for the GitOps test suite. Produces an
+/// <see cref="IOptionsMonitor{AppConfig}"/> whose <c>AI.GitOps</c> section is
+/// configured exactly the way each scenario needs, so the controllers, clients,
+/// dispatcher, validator, and DI tests can all assert against a known config.
+/// </summary>
+internal static class GitOpsTestConfig
+{
+    /// <summary>The default K8sGPT MCP server key used across the suite.</summary>
+    public const string K8sGptServerName = "k8sgpt";
+
+    /// <summary>
+    /// Builds an <see cref="AppConfig"/> with a fully-valid GitOps section for the
+    /// supplied active controller, including a matching K8sGPT MCP server entry.
+    /// </summary>
+    public static AppConfig ValidAppConfig(
+        string activeController = "flux",
+        string fluxBaseUrl = "https://flux.example.com",
+        string argoCdBaseUrl = "https://argocd.example.com",
+        string remediationRepoUrl = "https://github.com/example/cluster-config.git",
+        string remediationBranch = "main")
+    {
+        var appConfig = new AppConfig
+        {
+            AI = new AIConfig
+            {
+                GitOps = new GitOpsConfig
+                {
+                    Enabled = true,
+                    ActiveController = activeController,
+                    K8sGptMcpServerName = K8sGptServerName,
+                    FluxApiBaseUrl = fluxBaseUrl,
+                    ArgoCdApiBaseUrl = argoCdBaseUrl,
+                    RemediationRepoUrl = remediationRepoUrl,
+                    RemediationBranch = remediationBranch
+                }
+            }
+        };
+
+        appConfig.AI.McpServers.Servers[K8sGptServerName] = new McpServerDefinition();
+        return appConfig;
+    }
+
+    /// <summary>Wraps an <see cref="AppConfig"/> in a Moq-backed monitor.</summary>
+    public static IOptionsMonitor<AppConfig> Monitor(AppConfig appConfig)
+        => Mock.Of<IOptionsMonitor<AppConfig>>(o => o.CurrentValue == appConfig);
+
+    /// <summary>Convenience: a monitor over a valid config for the active controller.</summary>
+    public static IOptionsMonitor<AppConfig> ValidMonitor(string activeController = "flux")
+        => Monitor(ValidAppConfig(activeController));
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/GitOps/GitOpsToolsTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/GitOps/GitOpsToolsTests.cs
@@ -1,0 +1,362 @@
+using Application.AI.Common.Interfaces.GitOps;
+using Domain.AI.Changes;
+using Domain.AI.GitOps;
+using Domain.AI.Identity;
+using Domain.AI.SkillTraining;
+using Domain.Common;
+using FluentAssertions;
+using Infrastructure.AI.Tools.GitOps;
+using Moq;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.GitOps;
+
+/// <summary>
+/// Tests the four agent-facing GitOps tools against mocked
+/// <see cref="IGitOpsController"/>, <see cref="IGitOpsRemediationDispatcher"/>,
+/// and <see cref="IK8sGptMcpClient"/> collaborators. Each tool is asserted on its
+/// happy path (JSON returned), its failure pass-through, and its unknown-operation
+/// rejection.
+/// </summary>
+public sealed class GitOpsToolsTests
+{
+    private static readonly DateTimeOffset Now = DateTimeOffset.Parse("2026-06-08T12:00:00Z");
+
+    private static DriftReport DriftWith(params DriftedResource[] resources) => new()
+    {
+        ControllerKind = GitOpsControllerKind.Flux,
+        CapturedAt = Now,
+        DriftedResources = resources
+    };
+
+    private static DriftedResource SampleDrifted() => new()
+    {
+        ApiVersion = "kustomize.toolkit.fluxcd.io/v1",
+        Kind = "Kustomization",
+        Name = "apps",
+        Namespace = "flux-system",
+        DesiredPath = "./apps",
+        Severity = DriftSeverity.Medium
+    };
+
+    private static RemediationPlan SamplePlan() => new()
+    {
+        ControllerKind = GitOpsControllerKind.Flux,
+        SourceDrift = DriftWith(SampleDrifted()),
+        Target = new GitRepoTarget("https://github.com/example/cluster-config.git", "main"),
+        Edits = [new ChangeEdit { Op = EditOp.Replace, Target = "./apps", Content = "# fix" }],
+        ProposedBlastRadius = BlastRadius.Medium
+    };
+
+    private static ChangeProposal SampleProposal() => new()
+    {
+        Id = "cp-1",
+        Target = new GitRepoTarget("https://github.com/example/cluster-config.git", "main"),
+        Diff = [new ChangeEdit { Op = EditOp.Replace, Target = "./apps", Content = "# fix" }],
+        BlastRadius = BlastRadius.Medium,
+        RequiredGates = [],
+        Status = ChangeProposalStatus.Draft,
+        SubmittedBy = new AgentIdentity { Id = "agent-001", Kind = AgentIdentityKind.Development },
+        SubmittedAt = Now
+    };
+
+    private static IReadOnlyDictionary<string, object?> NoParams() => new Dictionary<string, object?>();
+
+    // ---------- GitOpsDetectDriftTool ----------
+
+    [Fact]
+    public async Task DetectDriftTool_HappyPath_ReturnsOkWithJson()
+    {
+        var controller = new Mock<IGitOpsController>();
+        controller.Setup(c => c.DetectDriftAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<DriftReport>.Success(DriftWith(SampleDrifted())));
+        var tool = new GitOpsDetectDriftTool(controller.Object);
+
+        var result = await tool.ExecuteAsync("detect", NoParams());
+
+        result.Success.Should().BeTrue();
+        result.Output.Should().Contain("Kustomization");
+    }
+
+    [Fact]
+    public async Task DetectDriftTool_ControllerFailure_ReturnsFail()
+    {
+        var controller = new Mock<IGitOpsController>();
+        controller.Setup(c => c.DetectDriftAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<DriftReport>.Fail("gitops.flux.api_unreachable"));
+        var tool = new GitOpsDetectDriftTool(controller.Object);
+
+        var result = await tool.ExecuteAsync("detect", NoParams());
+
+        result.Success.Should().BeFalse();
+        result.Error.Should().Contain("gitops.flux.api_unreachable");
+    }
+
+    [Fact]
+    public async Task DetectDriftTool_UnknownOperation_ReturnsFail()
+    {
+        var tool = new GitOpsDetectDriftTool(Mock.Of<IGitOpsController>());
+
+        var result = await tool.ExecuteAsync("frobnicate", NoParams());
+
+        result.Success.Should().BeFalse();
+        result.Error.Should().Contain("Unknown operation");
+    }
+
+    [Fact]
+    public void DetectDriftTool_IsReadOnlyAndConcurrencySafe()
+    {
+        var tool = new GitOpsDetectDriftTool(Mock.Of<IGitOpsController>());
+
+        tool.Name.Should().Be("detect_drift");
+        tool.IsReadOnly.Should().BeTrue();
+        tool.IsConcurrencySafe.Should().BeTrue();
+    }
+
+    // ---------- GitOpsClusterHealthTool ----------
+
+    [Fact]
+    public async Task ClusterHealthTool_HappyPath_ReturnsOkWithJson()
+    {
+        var controller = new Mock<IGitOpsController>();
+        controller.Setup(c => c.GetClusterHealthAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<ClusterHealth>.Success(new ClusterHealth
+            {
+                ControllerKind = GitOpsControllerKind.Flux,
+                CapturedAt = Now,
+                OverallStatus = ClusterHealthStatus.Healthy
+            }));
+        var tool = new GitOpsClusterHealthTool(controller.Object);
+
+        var result = await tool.ExecuteAsync("get", NoParams());
+
+        result.Success.Should().BeTrue();
+        // Enums serialize as their numeric value by default; OverallStatus=Healthy => 1.
+        result.Output.Should().Contain("\"OverallStatus\":1");
+    }
+
+    [Fact]
+    public async Task ClusterHealthTool_Failure_ReturnsFail()
+    {
+        var controller = new Mock<IGitOpsController>();
+        controller.Setup(c => c.GetClusterHealthAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<ClusterHealth>.Fail("gitops.argocd.api_unreachable"));
+        var tool = new GitOpsClusterHealthTool(controller.Object);
+
+        var result = await tool.ExecuteAsync("get", NoParams());
+
+        result.Success.Should().BeFalse();
+        result.Error.Should().Contain("gitops.argocd.api_unreachable");
+    }
+
+    [Fact]
+    public async Task ClusterHealthTool_UnknownOperation_ReturnsFail()
+    {
+        var tool = new GitOpsClusterHealthTool(Mock.Of<IGitOpsController>());
+
+        var result = await tool.ExecuteAsync("bogus", NoParams());
+
+        result.Success.Should().BeFalse();
+        result.Error.Should().Contain("Unknown operation");
+    }
+
+    // ---------- GitOpsProposeRemediationTool ----------
+
+    [Fact]
+    public async Task ProposeRemediationTool_NoDrift_ShortCircuitsWithOk()
+    {
+        var controller = new Mock<IGitOpsController>();
+        controller.Setup(c => c.DetectDriftAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<DriftReport>.Success(DriftWith()));
+        var dispatcher = new Mock<IGitOpsRemediationDispatcher>();
+        var tool = new GitOpsProposeRemediationTool(controller.Object, dispatcher.Object);
+
+        var result = await tool.ExecuteAsync("submit", NoParams());
+
+        result.Success.Should().BeTrue();
+        result.Output.Should().Contain("No drift");
+        controller.Verify(c => c.ProposeRemediationAsync(It.IsAny<DriftReport>(), It.IsAny<CancellationToken>()), Times.Never);
+        dispatcher.Verify(d => d.DispatchAsync(It.IsAny<RemediationPlan>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ProposeRemediationTool_DriftThenProposeThenDispatch_ReturnsOkWithProposalJson()
+    {
+        var controller = new Mock<IGitOpsController>();
+        controller.Setup(c => c.DetectDriftAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<DriftReport>.Success(DriftWith(SampleDrifted())));
+        controller.Setup(c => c.ProposeRemediationAsync(It.IsAny<DriftReport>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<RemediationPlan>.Success(SamplePlan()));
+        var dispatcher = new Mock<IGitOpsRemediationDispatcher>();
+        dispatcher.Setup(d => d.DispatchAsync(It.IsAny<RemediationPlan>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<ChangeProposal>.Success(SampleProposal()));
+        var tool = new GitOpsProposeRemediationTool(controller.Object, dispatcher.Object);
+
+        var result = await tool.ExecuteAsync("submit", NoParams());
+
+        result.Success.Should().BeTrue();
+        result.Output.Should().Contain("cp-1");
+        dispatcher.Verify(d => d.DispatchAsync(It.IsAny<RemediationPlan>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task ProposeRemediationTool_DetectFails_ReturnsFail()
+    {
+        var controller = new Mock<IGitOpsController>();
+        controller.Setup(c => c.DetectDriftAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<DriftReport>.Fail("gitops.flux.api_unreachable"));
+        var tool = new GitOpsProposeRemediationTool(controller.Object, Mock.Of<IGitOpsRemediationDispatcher>());
+
+        var result = await tool.ExecuteAsync("submit", NoParams());
+
+        result.Success.Should().BeFalse();
+        result.Error.Should().Contain("gitops.flux.api_unreachable");
+    }
+
+    [Fact]
+    public async Task ProposeRemediationTool_DispatchFails_ReturnsFail()
+    {
+        var controller = new Mock<IGitOpsController>();
+        controller.Setup(c => c.DetectDriftAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<DriftReport>.Success(DriftWith(SampleDrifted())));
+        controller.Setup(c => c.ProposeRemediationAsync(It.IsAny<DriftReport>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<RemediationPlan>.Success(SamplePlan()));
+        var dispatcher = new Mock<IGitOpsRemediationDispatcher>();
+        dispatcher.Setup(d => d.DispatchAsync(It.IsAny<RemediationPlan>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<ChangeProposal>.Fail("gitops.remediation.dispatch_failed"));
+        var tool = new GitOpsProposeRemediationTool(controller.Object, dispatcher.Object);
+
+        var result = await tool.ExecuteAsync("submit", NoParams());
+
+        result.Success.Should().BeFalse();
+        result.Error.Should().Contain("gitops.remediation.dispatch_failed");
+    }
+
+    [Fact]
+    public async Task ProposeRemediationTool_UnknownOperation_ReturnsFail()
+    {
+        var tool = new GitOpsProposeRemediationTool(Mock.Of<IGitOpsController>(), Mock.Of<IGitOpsRemediationDispatcher>());
+
+        var result = await tool.ExecuteAsync("apply", NoParams());
+
+        result.Success.Should().BeFalse();
+        result.Error.Should().Contain("Unknown operation");
+    }
+
+    [Fact]
+    public void ProposeRemediationTool_IsNotReadOnly()
+    {
+        var tool = new GitOpsProposeRemediationTool(Mock.Of<IGitOpsController>(), Mock.Of<IGitOpsRemediationDispatcher>());
+
+        tool.Name.Should().Be("propose_remediation");
+        tool.IsReadOnly.Should().BeFalse();
+        tool.IsConcurrencySafe.Should().BeFalse();
+    }
+
+    // ---------- K8sGptAnalyzeTool ----------
+
+    [Fact]
+    public async Task K8sGptAnalyzeTool_HappyPath_ReturnsOkWithJson()
+    {
+        var client = new Mock<IK8sGptMcpClient>();
+        client.Setup(c => c.AnalyzeAsync(It.IsAny<K8sGptAnalysisRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<K8sGptAnalysisResult>.Success(new K8sGptAnalysisResult
+            {
+                CapturedAt = Now,
+                Findings = [new K8sGptFinding { Kind = "Pod", Name = "web", Summary = "ImagePullBackOff" }]
+            }));
+        var tool = new K8sGptAnalyzeTool(client.Object);
+
+        var result = await tool.ExecuteAsync("analyze", NoParams());
+
+        result.Success.Should().BeTrue();
+        result.Output.Should().Contain("ImagePullBackOff");
+    }
+
+    [Fact]
+    public async Task K8sGptAnalyzeTool_ClientFailure_ReturnsFail()
+    {
+        var client = new Mock<IK8sGptMcpClient>();
+        client.Setup(c => c.AnalyzeAsync(It.IsAny<K8sGptAnalysisRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<K8sGptAnalysisResult>.Fail("gitops.k8sgpt.unexpected_error"));
+        var tool = new K8sGptAnalyzeTool(client.Object);
+
+        var result = await tool.ExecuteAsync("analyze", NoParams());
+
+        result.Success.Should().BeFalse();
+        result.Error.Should().Contain("gitops.k8sgpt.unexpected_error");
+    }
+
+    [Fact]
+    public async Task K8sGptAnalyzeTool_UnknownOperation_ReturnsFail()
+    {
+        var tool = new K8sGptAnalyzeTool(Mock.Of<IK8sGptMcpClient>());
+
+        var result = await tool.ExecuteAsync("mutate", NoParams());
+
+        result.Success.Should().BeFalse();
+        result.Error.Should().Contain("Unknown operation");
+    }
+
+    [Fact]
+    public async Task K8sGptAnalyzeTool_ParsesNamespaceCsvFiltersAndExplain()
+    {
+        K8sGptAnalysisRequest? captured = null;
+        var client = new Mock<IK8sGptMcpClient>();
+        client.Setup(c => c.AnalyzeAsync(It.IsAny<K8sGptAnalysisRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<K8sGptAnalysisRequest, CancellationToken>((req, _) => captured = req)
+            .ReturnsAsync(Result<K8sGptAnalysisResult>.Success(new K8sGptAnalysisResult { CapturedAt = Now }));
+        var tool = new K8sGptAnalyzeTool(client.Object);
+
+        var parameters = new Dictionary<string, object?>
+        {
+            ["namespace"] = "prod",
+            ["filters"] = "Deployment, Pod",
+            ["explain"] = false
+        };
+        var result = await tool.ExecuteAsync("analyze", parameters);
+
+        result.Success.Should().BeTrue();
+        captured.Should().NotBeNull();
+        captured!.Namespace.Should().Be("prod");
+        captured.Filters.Should().BeEquivalentTo("Deployment", "Pod");
+        captured.Explain.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task K8sGptAnalyzeTool_ParsesFiltersAsArray()
+    {
+        K8sGptAnalysisRequest? captured = null;
+        var client = new Mock<IK8sGptMcpClient>();
+        client.Setup(c => c.AnalyzeAsync(It.IsAny<K8sGptAnalysisRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<K8sGptAnalysisRequest, CancellationToken>((req, _) => captured = req)
+            .ReturnsAsync(Result<K8sGptAnalysisResult>.Success(new K8sGptAnalysisResult { CapturedAt = Now }));
+        var tool = new K8sGptAnalyzeTool(client.Object);
+
+        var parameters = new Dictionary<string, object?>
+        {
+            ["filters"] = new[] { "Service", "Ingress" }
+        };
+        var result = await tool.ExecuteAsync("analyze", parameters);
+
+        result.Success.Should().BeTrue();
+        captured!.Filters.Should().BeEquivalentTo("Service", "Ingress");
+    }
+
+    [Fact]
+    public async Task K8sGptAnalyzeTool_DefaultsExplainToTrueWhenOmitted()
+    {
+        K8sGptAnalysisRequest? captured = null;
+        var client = new Mock<IK8sGptMcpClient>();
+        client.Setup(c => c.AnalyzeAsync(It.IsAny<K8sGptAnalysisRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<K8sGptAnalysisRequest, CancellationToken>((req, _) => captured = req)
+            .ReturnsAsync(Result<K8sGptAnalysisResult>.Success(new K8sGptAnalysisResult { CapturedAt = Now }));
+        var tool = new K8sGptAnalyzeTool(client.Object);
+
+        await tool.ExecuteAsync("analyze", NoParams());
+
+        captured!.Explain.Should().BeTrue();
+        captured.Namespace.Should().BeNull();
+        captured.Filters.Should().BeEmpty();
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/GitOps/K8sGptMcpClientTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/GitOps/K8sGptMcpClientTests.cs
@@ -1,0 +1,177 @@
+using Application.AI.Common.Interfaces;
+using Application.AI.Common.Interfaces.GitOps;
+using FluentAssertions;
+using Infrastructure.AI.GitOps;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Time.Testing;
+using Moq;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.GitOps;
+
+/// <summary>
+/// Tests <see cref="K8sGptMcpClient"/> against a mocked <see cref="IMcpToolProvider"/>.
+/// Covers successful analyze deserialization, the missing-tool path, the
+/// unconfigured-server path, and MCP-side failure surfacing as a stable code.
+/// </summary>
+public sealed class K8sGptMcpClientTests
+{
+    private readonly Mock<IMcpToolProvider> _mcp = new();
+    private readonly FakeTimeProvider _time = new(DateTimeOffset.Parse("2026-06-08T12:00:00Z"));
+
+    private K8sGptMcpClient CreateSut(string serverName = GitOpsTestConfig.K8sGptServerName)
+    {
+        var appConfig = GitOpsTestConfig.ValidAppConfig();
+        appConfig.AI.GitOps.K8sGptMcpServerName = serverName;
+        var config = GitOpsTestConfig.Monitor(appConfig);
+        return new K8sGptMcpClient(_mcp.Object, config, NullLogger<K8sGptMcpClient>.Instance, _time);
+    }
+
+    // Returns the structured analyze response the way an MCP tool surfaces it:
+    // a JSON object (Microsoft.Extensions.AI hands the harness a JsonElement of
+    // ValueKind.Object when the tool delegate returns an object graph).
+    private static AIFunction AnalyzeTool(object response)
+        => AIFunctionFactory.Create(() => response, new AIFunctionFactoryOptions { Name = "analyze" });
+
+    private static AIFunction EmptyResultsTool()
+        => AnalyzeTool(new Dictionary<string, object?> { ["results"] = Array.Empty<object>() });
+
+    private static AIFunction NamedTool(string name)
+        => AIFunctionFactory.Create(() => new Dictionary<string, object?>(), new AIFunctionFactoryOptions { Name = name });
+
+    [Fact]
+    public async Task AnalyzeAsync_SuccessfulAnalysis_DeserializesFindingsAndExplanation()
+    {
+        var response = new Dictionary<string, object?>
+        {
+            ["results"] = new object[]
+            {
+                new Dictionary<string, object?>
+                {
+                    ["kind"] = "Pod", ["name"] = "web-abc", ["namespace"] = "prod",
+                    ["error"] = "ImagePullBackOff", ["severity"] = "high"
+                },
+                new Dictionary<string, object?>
+                {
+                    ["kind"] = "Deployment", ["name"] = "api", ["namespace"] = "prod",
+                    ["error"] = "replica mismatch", ["severity"] = "warning"
+                }
+            },
+            ["explanation"] = "Two workloads are unhealthy."
+        };
+        _mcp.Setup(m => m.GetToolsAsync(GitOpsTestConfig.K8sGptServerName, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([AnalyzeTool(response)]);
+        var sut = CreateSut();
+
+        var result = await sut.AnalyzeAsync(new K8sGptAnalysisRequest(), CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.Findings.Should().HaveCount(2);
+        result.Value.Findings[0].Severity.Should().Be(K8sGptSeverity.High);
+        result.Value.Findings[1].Severity.Should().Be(K8sGptSeverity.Medium);
+        result.Value.Explanation.Should().Be("Two workloads are unhealthy.");
+        result.Value.CapturedAt.Should().Be(_time.GetUtcNow());
+    }
+
+    [Fact]
+    public async Task AnalyzeAsync_EmptyResults_ReturnsSuccessWithNoFindings()
+    {
+        _mcp.Setup(m => m.GetToolsAsync(GitOpsTestConfig.K8sGptServerName, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([EmptyResultsTool()]);
+        var sut = CreateSut();
+
+        var result = await sut.AnalyzeAsync(new K8sGptAnalysisRequest(), CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.Findings.Should().BeEmpty();
+        result.Value.Explanation.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task AnalyzeAsync_ResponseIsJsonStringElement_UnwrapsAndDeserializes()
+    {
+        // Some MCP transports return the analyze payload as a JSON *string* rather
+        // than an object graph; Microsoft.Extensions.AI surfaces that as a
+        // JsonElement of ValueKind.String. The client must unwrap it to the inner
+        // JSON and parse the object — not treat it as a bare string literal.
+        const string jsonPayload =
+            "{\"results\":[{\"kind\":\"Pod\",\"name\":\"web-xyz\",\"namespace\":\"prod\"," +
+            "\"error\":\"CrashLoopBackOff\",\"severity\":\"high\"}]," +
+            "\"explanation\":\"One pod is crashing.\"}";
+        _mcp.Setup(m => m.GetToolsAsync(GitOpsTestConfig.K8sGptServerName, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([AnalyzeTool(jsonPayload)]);
+        var sut = CreateSut();
+
+        var result = await sut.AnalyzeAsync(new K8sGptAnalysisRequest(), CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.Findings.Should().ContainSingle();
+        result.Value.Findings[0].Name.Should().Be("web-xyz");
+        result.Value.Findings[0].Severity.Should().Be(K8sGptSeverity.High);
+        result.Value.Explanation.Should().Be("One pod is crashing.");
+    }
+
+    [Fact]
+    public async Task AnalyzeAsync_AnalyzeToolMissing_ReturnsFailWithStableCode()
+    {
+        _mcp.Setup(m => m.GetToolsAsync(GitOpsTestConfig.K8sGptServerName, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([NamedTool("some_other_tool")]);
+        var sut = CreateSut();
+
+        var result = await sut.AnalyzeAsync(new K8sGptAnalysisRequest(), CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Errors.Should().Contain("gitops.k8sgpt.analyze_tool_missing");
+    }
+
+    [Fact]
+    public async Task AnalyzeAsync_ServerNameNotConfigured_ReturnsFailWithStableCode()
+    {
+        var sut = CreateSut(serverName: "");
+
+        var result = await sut.AnalyzeAsync(new K8sGptAnalysisRequest(), CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Errors.Should().Contain("gitops.k8sgpt.server_name_not_configured");
+        _mcp.Verify(m => m.GetToolsAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task AnalyzeAsync_McpProviderThrows_ReturnsUnexpectedErrorCode()
+    {
+        _mcp.Setup(m => m.GetToolsAsync(GitOpsTestConfig.K8sGptServerName, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("mcp down"));
+        var sut = CreateSut();
+
+        var result = await sut.AnalyzeAsync(new K8sGptAnalysisRequest(), CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Errors.Should().Contain("gitops.k8sgpt.unexpected_error");
+    }
+
+    [Fact]
+    public async Task AnalyzeAsync_PassesRequestArgumentsToAnalyzeTool()
+    {
+        AIFunctionArguments? captured = null;
+        var probe = AIFunctionFactory.Create(
+            (AIFunctionArguments args) =>
+            {
+                captured = args;
+                return (object)new Dictionary<string, object?> { ["results"] = Array.Empty<object>() };
+            },
+            new AIFunctionFactoryOptions { Name = "analyze" });
+        _mcp.Setup(m => m.GetToolsAsync(GitOpsTestConfig.K8sGptServerName, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([probe]);
+        var sut = CreateSut();
+
+        var result = await sut.AnalyzeAsync(
+            new K8sGptAnalysisRequest { Namespace = "prod", Filters = ["Pod"], Explain = false },
+            CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        captured.Should().NotBeNull();
+        captured!["namespace"].Should().Be("prod");
+        captured["explain"].Should().Be(false);
+    }
+}


### PR DESCRIPTION
## Summary
Completes **PR-9** of the agentic-DevOps plan: a controller-neutral GitOps skill pack with **Flux + Argo CD parity**. Detects drift, reads cluster health, runs K8sGPT root-cause analysis, and remediates **only** through the ChangeProposal gate pipeline — never direct kubectl/helm.

## Layers (6 commits)
1. Domain types — `DriftReport`, `ClusterHealth`, `RemediationPlan`, `GitOpsControllerKind`
2. Application interfaces — `IGitOpsController`, `IK8sGptMcpClient`, `IGitOpsRemediationDispatcher`
3. Infrastructure — `FluxGitOpsController` + `ArgoCdGitOpsController` (+ API clients over the egress-gated HttpClient), `K8sGptMcpClient`, `GitOpsRemediationDispatcher`, config
4. Tools + DI + validation — 4 `ITool` wrappers (`detect_drift`, `cluster_health`, `propose_remediation`, `k8sgpt_analyze`); `AddGitOpsSkillTools` (keyed flux/argocd controllers + active-controller selector); `GitOpsStartupValidator` (fail-loud); `GitOpsConfigValidator` (FluentValidation)
5. Plugin manifest + 3 SKILL.md — `gitops-repo-audit`, `gitops-cluster-debug`, `gitops-knowledge` (all deny kubectl_apply/delete + helm_upgrade)
6. Tests + hardening — 97 tests; fixed `K8sGptMcpClient` to unwrap a `JsonElement{String}` analyze payload (MEAI transport shape) instead of failing

## Design
- **Read-only against the cluster.** Mutating tools denied + bypass-immune; fixes flow through ChangeProposal.
- **Controller-neutral.** Active backend selected by `AppConfig.AI.GitOps.ActiveController`; switching is config, not code.
- **K8sGPT required, not degraded** — misconfig fails loud at boot.

## Test plan
- `dotnet build src/AgenticHarness.slnx` → 0 errors
- **Full suite green: 0 failures across all 19 test projects** (97 new GitOps tests: controllers over mocked egress HTTP, K8sGpt client, dispatcher, both validators, 4 tools, DI keyed resolution, e2e drift→proposal)
- Rebased clean onto current main (post pr6/7/8 + egress + dist-untrack)

🤖 Generated with [Claude Code](https://claude.com/claude-code)