### PR TITLE
feat(telemetry): OTel GenAI content-capture policy + redaction (PR-11)

### DIFF
--- a/documentation/blueprints/agentic-harness-observability.md
+++ b/documentation/blueprints/agentic-harness-observability.md
@@ -283,6 +283,82 @@ Adobe's locked sidecar: it must redact before emit, not after observe.
 - The dashboard subscription enforces tenant/user scope via the existing
   `IKnowledgeScopeValidator` chain. The exporter never bypasses it.
 
+#### Content Capture Policy (PR-11)
+
+The OTel GenAI conventions allow attaching full prompt / output / tool /
+orchestration content to spans for debugging and audit. This is **OFF by
+default** and gated behind a closed-by-default policy so a fresh
+`appsettings.json` never silently surfaces user content in traces.
+
+**Stability opt-in is mandatory when capture is on.** Content keys live in the
+experimental GenAI SemConv tier. When capture is enabled the
+`OTEL_SEMCONV_STABILITY_OPT_IN` environment variable **must** equal
+`gen_ai_latest_experimental`
+(`GenAiSemconvRegistry.SemconvStabilityOptInValue`). The hosted
+`ContentCaptureStartupValidator` reads this at boot and **fails the host**
+when capture is on but the variable is unset or wrong, and again if no
+`IContentRedactionFilter` is registered — content can only leave the domain
+through a redaction filter.
+
+**Two-level gate.** A master `Enabled` flag is the single operator decision;
+per-attribute toggles then opt individual attributes in. When the master flag
+is off, every `ShouldCapture*` check on `IContentCapturePolicy` returns false
+regardless of a stale per-attribute toggle. The `ContentCaptureConfigValidator`
+(FluentValidation, auto-discovered) enforces that, when enabled,
+`RedactionCategories` is non-empty and every entry maps to a known
+`RedactionCategory`.
+
+**Redaction before emit.** Every captured string passes through
+`DefaultContentRedactionFilter` (a fixed, over-redactive regex rule set) before
+it is attached. The eight `RedactionCategory` values:
+
+| Category | Masks |
+|---|---|
+| `Email` | Email addresses (RFC 5322 simplified) |
+| `Phone` | E.164 + North-American phone numbers |
+| `Ssn` | US Social Security Numbers |
+| `CreditCard` | Credit-card PANs (broad, Luhn-ish) |
+| `IpAddress` | IPv4 / IPv6 addresses |
+| `AwsKey` | AWS access-key ids (`AKIA…`, `ASIA…`, …) |
+| `JwtToken` | JWT tokens (`header.payload.signature`) |
+| `Generic` | Catch-all: `Bearer …`, `AccountKey=`, `api_key=`, … |
+
+The filter is intentionally noisy: a false positive that masks a benign string
+is acceptable; a false negative that leaks a credit-card number into a span is
+not.
+
+**Schema** — bind from `AppConfig.AI.Telemetry.ContentCapture`:
+
+```jsonc
+{
+  "AI": {
+    "Telemetry": {
+      "ContentCapture": {
+        "Enabled": false,                    // master toggle — OFF by default
+        "CapturePromptContent": false,       // gen_ai.input.messages
+        "CaptureOutputContent": false,       // gen_ai.output.messages
+        "CaptureToolCallArguments": false,   // gen_ai.tool.call.arguments
+        "CaptureToolCallResult": false,      // gen_ai.tool.call.result
+        "CaptureMagenticPlanContent": false, // ...magentic.plan.content
+        "CaptureMagenticReplanReason": false,// ...magentic.replan.reason
+        "CaptureMagenticProgressContent": false,
+        "CaptureMagenticPlanReviewFeedback": false,
+        "RedactionCategories": [
+          "Email", "Phone", "Ssn", "CreditCard",
+          "IpAddress", "AwsKey", "JwtToken", "Generic"
+        ]
+      }
+    }
+  }
+}
+```
+
+To turn capture on in an environment: set the env var
+(`OTEL_SEMCONV_STABILITY_OPT_IN=gen_ai_latest_experimental`), flip `Enabled`
+to `true`, and enable only the specific per-attribute toggles you need. Leave
+`RedactionCategories` at the full list unless you have a deliberate,
+reviewed reason to shrink it.
+
 ### G9 — Convention upgrades happen on a fixed cadence
 
 Skyscanner's biggest pain was 6-month upgrade gaps that batched breaking
@@ -455,6 +531,14 @@ Following the OTel pattern of explicit overlap / extends / relates-to:
 
 ## Change log
 
+- 2026-06-08 — v1.3. PR-11 content capture. Added the "Content Capture Policy
+  (PR-11)" subsection under G8: `OTEL_SEMCONV_STABILITY_OPT_IN` requirement,
+  the `AppConfig.AI.Telemetry.ContentCapture` schema (master `Enabled` +
+  per-attribute toggles + `RedactionCategories`), the eight redaction
+  categories, the OFF-by-default safety stance, and an appsettings.json
+  example. Backed by `ContentCaptureConfigValidator`,
+  `DefaultContentRedactionFilter`, `ContentCapturePolicy`, and
+  `ContentCaptureStartupValidator`.
 - 2026-06-03 — v1 draft. Initial blueprint, lessons-learned table from
   Adobe / Mastodon / Skyscanner reference implementations, mapping to
   existing harness code.

--- a/src/Content/Application/Application.AI.Common/Interfaces/Telemetry/IContentCapturePolicy.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Telemetry/IContentCapturePolicy.cs
@@ -1,0 +1,90 @@
+using Domain.AI.Telemetry.Redaction;
+
+namespace Application.AI.Common.Interfaces.Telemetry;
+
+/// <summary>
+/// Reads <c>AppConfig.AI.Telemetry.ContentCapture</c> and reports which
+/// content attributes the harness is currently allowed to attach to spans.
+/// Span emitters call the matching <c>ShouldCapture*</c> method before
+/// invoking <see cref="IContentRedactionFilter.Redact"/> and writing the
+/// attribute.
+/// </summary>
+/// <remarks>
+/// <para>
+/// All <c>ShouldCapture*</c> methods MUST return <see langword="false"/>
+/// when the master <c>ContentCaptureConfig.Enabled</c> flag is off,
+/// regardless of any per-attribute toggle. This ensures a single boot-time
+/// decision (capture on / off) cannot be undermined by a stale per-attribute
+/// flag left enabled in <c>appsettings.json</c>.
+/// </para>
+/// <para>
+/// The policy also exposes the active redaction categories so emitters can
+/// pass them straight into the filter without duplicating the lookup.
+/// </para>
+/// </remarks>
+public interface IContentCapturePolicy
+{
+    /// <summary>
+    /// Whether content-capture is currently enabled in any form. When this
+    /// returns <see langword="false"/> every <c>ShouldCapture*</c> method
+    /// also returns <see langword="false"/>.
+    /// </summary>
+    bool IsEnabled { get; }
+
+    /// <summary>
+    /// Categories the active configuration wants redacted from captured
+    /// content. Emitters MUST forward this list to
+    /// <see cref="IContentRedactionFilter.Redact"/>.
+    /// </summary>
+    IReadOnlyList<RedactionCategory> Categories { get; }
+
+    /// <summary>
+    /// Whether <c>gen_ai.input.messages</c> may be attached to a chat /
+    /// agent span.
+    /// </summary>
+    bool ShouldCapturePromptContent();
+
+    /// <summary>
+    /// Whether <c>gen_ai.output.messages</c> may be attached to a chat /
+    /// agent span.
+    /// </summary>
+    bool ShouldCaptureOutputContent();
+
+    /// <summary>
+    /// Whether <c>gen_ai.tool.call.arguments</c> may be attached to an
+    /// <c>execute_tool</c> span.
+    /// </summary>
+    bool ShouldCaptureToolCallArguments();
+
+    /// <summary>
+    /// Whether <c>gen_ai.tool.call.result</c> may be attached to an
+    /// <c>execute_tool</c> span.
+    /// </summary>
+    bool ShouldCaptureToolCallResult();
+
+    /// <summary>
+    /// Whether <c>gen_ai.orchestration.magentic.plan.content</c> may be
+    /// attached to a Magentic <c>plan_created</c> / <c>replanned</c> span
+    /// event.
+    /// </summary>
+    bool ShouldCaptureMagenticPlanContent();
+
+    /// <summary>
+    /// Whether <c>gen_ai.orchestration.magentic.replan.reason</c> may be
+    /// attached to a Magentic <c>magentic.reset</c> span.
+    /// </summary>
+    bool ShouldCaptureMagenticReplanReason();
+
+    /// <summary>
+    /// Whether <c>gen_ai.orchestration.magentic.progress.instruction_or_question</c>
+    /// may be attached to a Magentic <c>magentic.round</c> span.
+    /// </summary>
+    bool ShouldCaptureMagenticProgressContent();
+
+    /// <summary>
+    /// Whether <c>gen_ai.orchestration.magentic.plan_review.feedback</c> may
+    /// be attached to a Magentic <c>plan_review</c> span on a revised
+    /// outcome.
+    /// </summary>
+    bool ShouldCaptureMagenticPlanReviewFeedback();
+}

--- a/src/Content/Application/Application.AI.Common/Interfaces/Telemetry/IContentRedactionFilter.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Telemetry/IContentRedactionFilter.cs
@@ -1,0 +1,39 @@
+using Domain.AI.Telemetry.Redaction;
+
+namespace Application.AI.Common.Interfaces.Telemetry;
+
+/// <summary>
+/// Redacts PII / secret content from free-text before it is attached to a
+/// telemetry span attribute. Implementations are pure functions of their
+/// input and MUST be thread-safe — span emission runs on whatever thread
+/// happens to own the activity.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The harness applies the filter at the boundary between domain content and
+/// span emission. Callers pass the raw content string, the categories they
+/// want redacted (typically derived from <c>AppConfig.AI.Telemetry.ContentCapture</c>
+/// or fixed by policy), and receive the sanitised string ready for attribute
+/// assignment.
+/// </para>
+/// <para>
+/// Implementations SHOULD favour conservative (over-redacting) matches: a
+/// false positive that hides a string segment is acceptable, a false negative
+/// that lets a credit-card number into a span attribute is not.
+/// </para>
+/// </remarks>
+public interface IContentRedactionFilter
+{
+    /// <summary>
+    /// Returns <paramref name="content"/> with every match of every requested
+    /// category replaced by the category's configured placeholder. Returns
+    /// the input unchanged when it is null, empty, or contains no matches.
+    /// </summary>
+    /// <param name="content">Raw content captured from the domain.</param>
+    /// <param name="categories">
+    /// Categories to redact in this call. Pass an empty array to disable
+    /// every rule (the filter returns the input unchanged).
+    /// </param>
+    /// <returns>The redacted content string.</returns>
+    string Redact(string? content, IReadOnlyList<RedactionCategory> categories);
+}

--- a/src/Content/Application/Application.Core/Validation/ContentCaptureConfigValidator.cs
+++ b/src/Content/Application/Application.Core/Validation/ContentCaptureConfigValidator.cs
@@ -1,0 +1,50 @@
+using Domain.AI.Telemetry.Redaction;
+using Domain.Common.Config.AI.Telemetry;
+using FluentValidation;
+
+namespace Application.Core.Validation;
+
+/// <summary>
+/// Validates <see cref="ContentCaptureConfig"/>. All rules are conditional on
+/// <see cref="ContentCaptureConfig.Enabled"/> — content-capture is OFF by
+/// default and a disabled section imposes no constraints, so the template runs
+/// out of the box. When enabled the rules ensure the redaction posture is
+/// coherent: at least one category must be requested and every requested name
+/// must map (case-insensitively) to a known
+/// <see cref="RedactionCategory"/>. This mirrors the parsing behaviour of the
+/// Infrastructure <c>ContentCapturePolicy</c>, so a config typo surfaces both
+/// in the options-validation pipeline and (as a debug log) at runtime.
+/// </summary>
+/// <remarks>
+/// Auto-discovered via <c>AddValidatorsFromAssembly</c> on the Application.Core
+/// assembly — no manual registration required.
+/// </remarks>
+public sealed class ContentCaptureConfigValidator : AbstractValidator<ContentCaptureConfig>
+{
+    private static readonly HashSet<string> KnownCategories =
+        new(Enum.GetNames<RedactionCategory>(), StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>Initializes a new instance of the <see cref="ContentCaptureConfigValidator"/> class.</summary>
+    public ContentCaptureConfigValidator()
+    {
+        When(x => x.Enabled, () =>
+        {
+            RuleFor(x => x.RedactionCategories)
+                .NotNull()
+                .Must(c => c is { Count: > 0 })
+                .WithMessage(
+                    "RedactionCategories must contain at least one category when content-capture is enabled. " +
+                    "Content can only leave the domain through a redaction rule; an empty list means raw content " +
+                    "would be emitted unredacted.");
+
+            RuleForEach(x => x.RedactionCategories)
+                .Must(BeKnownCategory)
+                .WithMessage(category =>
+                    $"RedactionCategories contains '{category}', which is not a known RedactionCategory. " +
+                    $"Valid values: {string.Join(", ", Enum.GetNames<RedactionCategory>())}.");
+        });
+    }
+
+    private static bool BeKnownCategory(string category)
+        => !string.IsNullOrWhiteSpace(category) && KnownCategories.Contains(category.Trim());
+}

--- a/src/Content/Domain/Domain.AI/Telemetry/Conventions/GenAiSemconvRegistry.cs
+++ b/src/Content/Domain/Domain.AI/Telemetry/Conventions/GenAiSemconvRegistry.cs
@@ -327,4 +327,72 @@ public static class GenAiSemconvRegistry
     /// Re-exported from <see cref="A2AConventions.ActivitySourceName"/>.
     /// </summary>
     public const string A2AActivitySourceName = A2AConventions.ActivitySourceName;
+
+    // ────────────────────────────────────────────────────────────────────
+    // Content capture (PR-11) — OFF by default. PR-6 declared the Magentic
+    // content keys on MagenticConventions; the standard OTel content keys
+    // and the global toggle are owned here.
+    // ────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Name of the OTel environment variable that pins the GenAI semantic-
+    /// convention stability tier the harness emits against. The harness emits
+    /// against the experimental GenAI conventions; consumers MUST set the
+    /// variable to <see cref="SemconvStabilityOptInValue"/> in any environment
+    /// where content-capture is enabled, otherwise upstream Collectors may
+    /// silently drop or rename attributes when a future SemConv release flips
+    /// stability.
+    /// </summary>
+    /// <remarks>
+    /// The <see cref="Infrastructure"/>'s content-capture startup validator
+    /// reads this env var and refuses to boot when content-capture is on but
+    /// the variable is unset or wrong.
+    /// </remarks>
+    public const string SemconvStabilityOptInEnvVar = "OTEL_SEMCONV_STABILITY_OPT_IN";
+
+    /// <summary>
+    /// Pinned value of <see cref="SemconvStabilityOptInEnvVar"/>. Matches the
+    /// OTel-GenAI experimental opt-in token. Update in lockstep with a
+    /// deliberate SDK + semconv NuGet bump (see blueprint G9).
+    /// </summary>
+    public const string SemconvStabilityOptInValue = "gen_ai_latest_experimental";
+
+    /// <summary>
+    /// Opt-in: full request prompt messages on the chat / agent span.
+    /// OFF by default per OTel GenAI content-capture guidance. PR-11 owns the
+    /// toggle (<see cref="Domain.Common.Config.AI.Telemetry.ContentCaptureConfig"/>).
+    /// </summary>
+    public const string InputMessages = "gen_ai.input.messages";
+
+    /// <summary>
+    /// Opt-in: full response message content on the chat / agent span.
+    /// OFF by default — PR-11 owns the toggle.
+    /// </summary>
+    public const string OutputMessages = "gen_ai.output.messages";
+
+    /// <summary>
+    /// Opt-in: full <c>gen_ai.orchestration.magentic.plan.content</c> attribute.
+    /// Re-exported from <see cref="MagenticConventions.PlanContent"/>.
+    /// OFF by default — PR-11 owns the toggle.
+    /// </summary>
+    public const string MagenticPlanContent = MagenticConventions.PlanContent;
+
+    /// <summary>
+    /// Opt-in: full Magentic replan reason. Re-exported from
+    /// <see cref="MagenticConventions.ReplanReason"/>. OFF by default.
+    /// </summary>
+    public const string MagenticReplanReason = MagenticConventions.ReplanReason;
+
+    /// <summary>
+    /// Opt-in: per-round instruction-or-question content. Re-exported from
+    /// <see cref="MagenticConventions.ProgressInstructionOrQuestion"/>.
+    /// OFF by default.
+    /// </summary>
+    public const string MagenticProgressInstructionOrQuestion = MagenticConventions.ProgressInstructionOrQuestion;
+
+    /// <summary>
+    /// Opt-in: Magentic plan-review revision feedback. Re-exported from
+    /// <see cref="MagenticConventions.PlanReviewFeedback"/>. OFF by default.
+    /// </summary>
+    public const string MagenticPlanReviewFeedback = MagenticConventions.PlanReviewFeedback;
 }

--- a/src/Content/Domain/Domain.AI/Telemetry/Redaction/RedactionCategory.cs
+++ b/src/Content/Domain/Domain.AI/Telemetry/Redaction/RedactionCategory.cs
@@ -1,0 +1,40 @@
+namespace Domain.AI.Telemetry.Redaction;
+
+/// <summary>
+/// PII / secret categories the harness recognises and can redact from
+/// telemetry content before it is attached to a span. Each value names a
+/// detection rule; <see cref="Generic"/> is the catch-all for harness-vendored
+/// patterns that do not map to a regulated PII class.
+/// </summary>
+/// <remarks>
+/// Order is not significant — the redactor applies all configured categories
+/// in a single pass. New categories are added at the end of the enum so the
+/// underlying integer values remain stable for any consumer that persists
+/// them.
+/// </remarks>
+public enum RedactionCategory
+{
+    /// <summary>Email addresses (RFC 5322 simplified).</summary>
+    Email = 0,
+
+    /// <summary>Phone numbers (E.164 + common North-American formats).</summary>
+    Phone = 1,
+
+    /// <summary>US Social Security Numbers.</summary>
+    Ssn = 2,
+
+    /// <summary>Credit-card primary account numbers (PAN) — broad Luhn-ish pattern.</summary>
+    CreditCard = 3,
+
+    /// <summary>IPv4 and IPv6 addresses.</summary>
+    IpAddress = 4,
+
+    /// <summary>AWS access-key identifiers (<c>AKIA…</c>, <c>ASIA…</c>) and similar.</summary>
+    AwsKey = 5,
+
+    /// <summary>JWT tokens (header.payload.signature with base64url segments).</summary>
+    JwtToken = 6,
+
+    /// <summary>Catch-all bucket for harness-vendored generic secret patterns.</summary>
+    Generic = 7,
+}

--- a/src/Content/Domain/Domain.AI/Telemetry/Redaction/RedactionRule.cs
+++ b/src/Content/Domain/Domain.AI/Telemetry/Redaction/RedactionRule.cs
@@ -1,0 +1,28 @@
+namespace Domain.AI.Telemetry.Redaction;
+
+/// <summary>
+/// A single regex-driven redaction rule. Rules are paired with a
+/// <see cref="RedactionCategory"/> so a content filter can opt in or out per
+/// category without rebuilding the whole pattern list.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="Pattern"/> is interpreted as a .NET regular expression. The
+/// content filter compiles each pattern once at construction and re-uses the
+/// compiled instance; runtime mutation is not supported.
+/// </para>
+/// <para>
+/// <see cref="Replacement"/> may include substitution groups (<c>$1</c>, etc.)
+/// when the rule wants to preserve a label (e.g. <c>"Bearer [REDACTED]"</c>).
+/// Conservative rules — favouring over-redaction — are correct here: false
+/// positives are acceptable, false negatives (PII leaking into a span) are
+/// not.
+/// </para>
+/// </remarks>
+/// <param name="Category">PII / secret category this rule belongs to.</param>
+/// <param name="Pattern">.NET regular-expression pattern matched against content.</param>
+/// <param name="Replacement">Replacement string applied to every match.</param>
+public sealed record RedactionRule(
+    RedactionCategory Category,
+    string Pattern,
+    string Replacement);

--- a/src/Content/Domain/Domain.Common/Config/AI/AIConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/AIConfig.cs
@@ -16,6 +16,7 @@ using Domain.Common.Config.AI.RAG;
 using Domain.Common.Config.AI.Resilience;
 using Domain.Common.Config.AI.Routing;
 using Domain.Common.Config.AI.Sandbox;
+using Domain.Common.Config.AI.Telemetry;
 
 namespace Domain.Common.Config.AI;
 
@@ -234,4 +235,12 @@ public class AIConfig
     /// skill at runtime.
     /// </summary>
     public GitOpsConfig GitOps { get; set; } = new();
+
+    /// <summary>
+    /// Telemetry-layer configuration (PR-11). Wraps the OTel GenAI
+    /// content-capture toggles; OFF by default so a fresh consumer never
+    /// silently emits prompt / tool / Magentic content into traces. See
+    /// <see cref="TelemetryConfig.ContentCapture"/>.
+    /// </summary>
+    public TelemetryConfig Telemetry { get; set; } = new();
 }

--- a/src/Content/Domain/Domain.Common/Config/AI/Telemetry/ContentCaptureConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/Telemetry/ContentCaptureConfig.cs
@@ -1,0 +1,110 @@
+namespace Domain.Common.Config.AI.Telemetry;
+
+/// <summary>
+/// Per-attribute toggles for OpenTelemetry GenAI content capture. OFF by
+/// default — content capture is opt-in per the OTel GenAI semantic-convention
+/// guidance, and the harness defers to that posture so a fresh
+/// <c>appsettings.json</c> never silently surfaces prompt or tool content in
+/// traces.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The pipeline is off by default (<see cref="Enabled"/> is false). When the
+/// master flag is off every per-attribute toggle is also treated as off — the
+/// granular flags only become live once <see cref="Enabled"/> is set.
+/// </para>
+/// <para>
+/// When <see cref="Enabled"/> is true the harness ALSO requires the
+/// <c>OTEL_SEMCONV_STABILITY_OPT_IN</c> environment variable to be pinned to
+/// <see cref="Domain.AI.Telemetry.Conventions.GenAiSemconvRegistry.SemconvStabilityOptInValue"/>;
+/// the registered startup validator fails the host boot when the variable is
+/// unset or wrong.
+/// </para>
+/// </remarks>
+public sealed class ContentCaptureConfig
+{
+    /// <summary>
+    /// Master toggle. When false, every <c>Capture*</c> flag is treated as
+    /// false regardless of its stored value, and the redaction filter is not
+    /// invoked. Default: false.
+    /// </summary>
+    public bool Enabled { get; set; }
+
+    /// <summary>
+    /// Whether <c>gen_ai.input.messages</c> may be emitted on chat / agent
+    /// spans. Default: false.
+    /// </summary>
+    public bool CapturePromptContent { get; set; }
+
+    /// <summary>
+    /// Whether <c>gen_ai.output.messages</c> may be emitted on chat / agent
+    /// spans. Default: false.
+    /// </summary>
+    public bool CaptureOutputContent { get; set; }
+
+    /// <summary>
+    /// Whether <c>gen_ai.tool.call.arguments</c> may be emitted on
+    /// <c>execute_tool</c> spans. Default: false.
+    /// </summary>
+    public bool CaptureToolCallArguments { get; set; }
+
+    /// <summary>
+    /// Whether <c>gen_ai.tool.call.result</c> may be emitted on
+    /// <c>execute_tool</c> spans. Default: false.
+    /// </summary>
+    public bool CaptureToolCallResult { get; set; }
+
+    /// <summary>
+    /// Whether <c>gen_ai.orchestration.magentic.plan.content</c> may be
+    /// emitted on Magentic <c>plan_created</c> / <c>replanned</c> span events.
+    /// Default: false.
+    /// </summary>
+    public bool CaptureMagenticPlanContent { get; set; }
+
+    /// <summary>
+    /// Whether <c>gen_ai.orchestration.magentic.replan.reason</c> may be
+    /// emitted on Magentic <c>magentic.reset</c> spans. Default: false.
+    /// </summary>
+    public bool CaptureMagenticReplanReason { get; set; }
+
+    /// <summary>
+    /// Whether <c>gen_ai.orchestration.magentic.progress.instruction_or_question</c>
+    /// may be emitted on Magentic <c>magentic.round</c> spans. Default: false.
+    /// </summary>
+    public bool CaptureMagenticProgressContent { get; set; }
+
+    /// <summary>
+    /// Whether <c>gen_ai.orchestration.magentic.plan_review.feedback</c> may
+    /// be emitted on revised Magentic <c>plan_review</c> spans. Default: false.
+    /// </summary>
+    public bool CaptureMagenticPlanReviewFeedback { get; set; }
+
+    /// <summary>
+    /// Names of <see cref="Domain.AI.Telemetry.Redaction.RedactionCategory"/>
+    /// values the redaction filter should apply before emission. Unknown
+    /// names are ignored (with a startup log warning). Default: all categories
+    /// from the enum, so a consumer that flips <see cref="Enabled"/> on
+    /// without thinking about categories still gets the safest posture.
+    /// </summary>
+    /// <remarks>
+    /// Conservative-by-default: the harness errs toward over-redaction. A
+    /// consumer with a known-safe content stream can shrink this list, but
+    /// has to do so deliberately.
+    /// </remarks>
+    // Values mirror the members of Domain.AI.Telemetry.Redaction.RedactionCategory.
+    // They are literals (not nameof) because the AppConfig hierarchy lives in
+    // Domain.Common, which must not depend on Domain.AI. The Infrastructure
+    // ContentCapturePolicy parses these strings back to the enum and logs any
+    // value it does not recognise.
+    public List<string> RedactionCategories { get; set; } =
+    [
+        "Email",
+        "Phone",
+        "Ssn",
+        "CreditCard",
+        "IpAddress",
+        "AwsKey",
+        "JwtToken",
+        "Generic",
+    ];
+}

--- a/src/Content/Domain/Domain.Common/Config/AI/Telemetry/TelemetryConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/Telemetry/TelemetryConfig.cs
@@ -1,0 +1,21 @@
+namespace Domain.Common.Config.AI.Telemetry;
+
+/// <summary>
+/// Telemetry-layer configuration. Today this is a thin wrapper around
+/// <see cref="ContentCapture"/> (PR-11); future telemetry-only knobs live
+/// under here so the <c>AppConfig.AI</c> root does not accumulate a flat
+/// telemetry surface.
+/// </summary>
+/// <remarks>
+/// Bind from <c>AppConfig:AI:Telemetry</c> in appsettings.json. The whole
+/// section is optional — defaults yield content-capture OFF and no other
+/// behavioural change.
+/// </remarks>
+public sealed class TelemetryConfig
+{
+    /// <summary>
+    /// Per-attribute content-capture toggles. OFF by default — see
+    /// <see cref="ContentCaptureConfig"/>.
+    /// </summary>
+    public ContentCaptureConfig ContentCapture { get; set; } = new();
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.ContentCapture.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.ContentCapture.cs
@@ -1,0 +1,39 @@
+using Application.AI.Common.Interfaces.Telemetry;
+using Infrastructure.AI.Telemetry.Redaction;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Infrastructure.AI;
+
+public static partial class DependencyInjection
+{
+    /// <summary>
+    /// Registers the OTel GenAI content-capture pipeline (PR-11): the
+    /// per-attribute capture policy, the default regex-based redaction
+    /// filter, and the startup validator that fails-loud at boot when
+    /// content-capture is enabled but
+    /// <c>OTEL_SEMCONV_STABILITY_OPT_IN</c> is not pinned to
+    /// <see cref="Domain.AI.Telemetry.Conventions.GenAiSemconvRegistry.SemconvStabilityOptInValue"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// All registrations are unconditional. The pipeline is inert until the
+    /// consumer flips <c>AppConfig.AI.Telemetry.ContentCapture.Enabled</c>
+    /// and toggles individual attribute flags — the policy returns false for
+    /// every <c>ShouldCapture*</c> call until that happens, so span emitters
+    /// never invoke the filter and never attach content attributes.
+    /// </para>
+    /// <para>
+    /// <see cref="IContentRedactionFilter"/> is registered via
+    /// <c>TryAddSingleton</c> so a consumer can register a custom filter
+    /// before <c>AddInfrastructureAIDependencies</c> runs without colliding
+    /// with the built-in default.
+    /// </para>
+    /// </remarks>
+    private static void RegisterContentCaptureServices(IServiceCollection services)
+    {
+        services.TryAddSingleton<IContentRedactionFilter, DefaultContentRedactionFilter>();
+        services.TryAddSingleton<IContentCapturePolicy, ContentCapturePolicy>();
+        services.AddHostedService<ContentCaptureStartupValidator>();
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.cs
@@ -230,6 +230,12 @@ public static partial class DependencyInjection
 
         RegisterIncidentResponseServices(services);
 
+        // --- Content capture (PR-11). Per-attribute capture policy, default
+        //     regex redaction filter, startup validator. Inert until the
+        //     consumer flips AppConfig.AI.Telemetry.ContentCapture.Enabled. ---
+
+        RegisterContentCaptureServices(services);
+
         // --- Magentic orchestration (PR-6). Span emitter + HITL bridge +
         //     change-proposal router. Inert until IMagenticOrchestrator.RunAsync
         //     is invoked. ---

--- a/src/Content/Infrastructure/Infrastructure.AI/Orchestration/Magentic/MagenticEventSubscriber.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Orchestration/Magentic/MagenticEventSubscriber.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using Application.AI.Common.Interfaces.Orchestration.Magentic;
+using Application.AI.Common.Interfaces.Telemetry;
 using Domain.AI.Telemetry.Conventions;
 using Microsoft.Agents.AI.Workflows;
 using Microsoft.Agents.AI.Workflows.Specialized.Magentic;
@@ -38,6 +39,8 @@ public sealed class MagenticEventSubscriber : IDisposable
     private readonly MagenticSpanEmitter _emitter;
     private readonly IMagenticPlanReviewBridge _planReviewBridge;
     private readonly MagenticChangeProposalRouter _changeProposalRouter;
+    private readonly IContentCapturePolicy _contentCapturePolicy;
+    private readonly IContentRedactionFilter _contentRedactionFilter;
     private readonly ILogger<MagenticEventSubscriber> _logger;
 
     private Activity? _workflowSpan;
@@ -76,11 +79,15 @@ public sealed class MagenticEventSubscriber : IDisposable
         MagenticSpanEmitter emitter,
         IMagenticPlanReviewBridge planReviewBridge,
         MagenticChangeProposalRouter changeProposalRouter,
+        IContentCapturePolicy contentCapturePolicy,
+        IContentRedactionFilter contentRedactionFilter,
         ILogger<MagenticEventSubscriber> logger)
     {
         _emitter = emitter;
         _planReviewBridge = planReviewBridge;
         _changeProposalRouter = changeProposalRouter;
+        _contentCapturePolicy = contentCapturePolicy;
+        _contentRedactionFilter = contentRedactionFilter;
         _logger = logger;
     }
 

--- a/src/Content/Infrastructure/Infrastructure.AI/Orchestration/Magentic/MagenticOrchestrator.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Orchestration/Magentic/MagenticOrchestrator.cs
@@ -1,4 +1,5 @@
 using Application.AI.Common.Interfaces.Orchestration.Magentic;
+using Application.AI.Common.Interfaces.Telemetry;
 using Domain.AI.Telemetry.Conventions;
 using Domain.Common;
 using Microsoft.Agents.AI.Workflows;
@@ -33,6 +34,8 @@ public sealed class MagenticOrchestrator : IMagenticOrchestrator
     private readonly MagenticSpanEmitter _spanEmitter;
     private readonly IMagenticPlanReviewBridge _planReviewBridge;
     private readonly MagenticChangeProposalRouter _changeProposalRouter;
+    private readonly IContentCapturePolicy _contentCapturePolicy;
+    private readonly IContentRedactionFilter _contentRedactionFilter;
     private readonly ILoggerFactory _loggerFactory;
     private readonly ILogger<MagenticOrchestrator> _logger;
 
@@ -41,11 +44,15 @@ public sealed class MagenticOrchestrator : IMagenticOrchestrator
         MagenticSpanEmitter spanEmitter,
         IMagenticPlanReviewBridge planReviewBridge,
         MagenticChangeProposalRouter changeProposalRouter,
+        IContentCapturePolicy contentCapturePolicy,
+        IContentRedactionFilter contentRedactionFilter,
         ILoggerFactory loggerFactory)
     {
         _spanEmitter = spanEmitter;
         _planReviewBridge = planReviewBridge;
         _changeProposalRouter = changeProposalRouter;
+        _contentCapturePolicy = contentCapturePolicy;
+        _contentRedactionFilter = contentRedactionFilter;
         _loggerFactory = loggerFactory;
         _logger = loggerFactory.CreateLogger<MagenticOrchestrator>();
     }
@@ -64,6 +71,8 @@ public sealed class MagenticOrchestrator : IMagenticOrchestrator
             _spanEmitter,
             _planReviewBridge,
             _changeProposalRouter,
+            _contentCapturePolicy,
+            _contentRedactionFilter,
             _loggerFactory.CreateLogger<MagenticEventSubscriber>());
 
         subscriber.StartWorkflow(request, workflowName, workflowId);

--- a/src/Content/Infrastructure/Infrastructure.AI/Orchestration/Magentic/MagenticSpanEmitter.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Orchestration/Magentic/MagenticSpanEmitter.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using Application.AI.Common.Interfaces.Telemetry;
 using Domain.AI.Telemetry.Conventions;
 
 namespace Infrastructure.AI.Orchestration.Magentic;
@@ -222,6 +223,149 @@ public sealed class MagenticSpanEmitter : IDisposable
             workflowSpan.SetStatus(ActivityStatusCode.Error, errorMessage);
         }
         workflowSpan.Dispose();
+    }
+
+    /// <summary>
+    /// Conditionally attaches the <see cref="MagenticConventions.PlanContent"/>
+    /// attribute to the manager span's <see cref="MagenticConventions.EventPlanCreated"/>
+    /// event when the content-capture policy permits.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The plan text is recorded as a span event tag at observation time so
+    /// the captured content lands on the exact event the rest of the schema
+    /// docs anchor to. When <paramref name="policy"/> reports
+    /// <see cref="IContentCapturePolicy.ShouldCaptureMagenticPlanContent"/>
+    /// false this method records the bare event (matching the PR-6 default)
+    /// and skips the filter call entirely.
+    /// </para>
+    /// </remarks>
+    public static void RecordPlanCreatedWithContent(
+        Activity? managerSpan,
+        int planVersion,
+        string? planText,
+        IContentCapturePolicy policy,
+        IContentRedactionFilter filter)
+    {
+        ArgumentNullException.ThrowIfNull(policy);
+        ArgumentNullException.ThrowIfNull(filter);
+
+        managerSpan?.SetTag(MagenticConventions.PlanVersion, planVersion);
+        var evt = BuildPlanEvent(
+            MagenticConventions.EventPlanCreated,
+            planText,
+            policy,
+            filter);
+        managerSpan?.AddEvent(evt);
+    }
+
+    /// <summary>
+    /// Conditionally attaches the <see cref="MagenticConventions.PlanContent"/>
+    /// attribute to the manager span's <see cref="MagenticConventions.EventReplanned"/>
+    /// event when the content-capture policy permits.
+    /// </summary>
+    public static void RecordReplannedWithContent(
+        Activity? managerSpan,
+        int planVersion,
+        string? planText,
+        IContentCapturePolicy policy,
+        IContentRedactionFilter filter)
+    {
+        ArgumentNullException.ThrowIfNull(policy);
+        ArgumentNullException.ThrowIfNull(filter);
+
+        managerSpan?.SetTag(MagenticConventions.PlanVersion, planVersion);
+        var evt = BuildPlanEvent(
+            MagenticConventions.EventReplanned,
+            planText,
+            policy,
+            filter);
+        managerSpan?.AddEvent(evt);
+    }
+
+    /// <summary>
+    /// Conditionally stamps the
+    /// <see cref="MagenticConventions.ReplanReason"/> attribute on a reset
+    /// span when the content-capture policy permits.
+    /// </summary>
+    public static void RecordResetReason(
+        Activity? resetSpan,
+        string? replanReason,
+        IContentCapturePolicy policy,
+        IContentRedactionFilter filter)
+    {
+        ArgumentNullException.ThrowIfNull(policy);
+        ArgumentNullException.ThrowIfNull(filter);
+        if (resetSpan is null) return;
+        if (string.IsNullOrEmpty(replanReason)) return;
+        if (!policy.ShouldCaptureMagenticReplanReason()) return;
+
+        resetSpan.SetTag(
+            MagenticConventions.ReplanReason,
+            filter.Redact(replanReason, policy.Categories));
+    }
+
+    /// <summary>
+    /// Conditionally stamps the
+    /// <see cref="MagenticConventions.ProgressInstructionOrQuestion"/>
+    /// attribute on a round span when the content-capture policy permits.
+    /// </summary>
+    public static void RecordRoundInstruction(
+        Activity? roundSpan,
+        string? instructionOrQuestion,
+        IContentCapturePolicy policy,
+        IContentRedactionFilter filter)
+    {
+        ArgumentNullException.ThrowIfNull(policy);
+        ArgumentNullException.ThrowIfNull(filter);
+        if (roundSpan is null) return;
+        if (string.IsNullOrEmpty(instructionOrQuestion)) return;
+        if (!policy.ShouldCaptureMagenticProgressContent()) return;
+
+        roundSpan.SetTag(
+            MagenticConventions.ProgressInstructionOrQuestion,
+            filter.Redact(instructionOrQuestion, policy.Categories));
+    }
+
+    /// <summary>
+    /// Conditionally stamps the
+    /// <see cref="MagenticConventions.PlanReviewFeedback"/> attribute on a
+    /// plan-review span when the content-capture policy permits.
+    /// </summary>
+    public static void RecordPlanReviewFeedback(
+        Activity? planReviewSpan,
+        string? revisionFeedback,
+        IContentCapturePolicy policy,
+        IContentRedactionFilter filter)
+    {
+        ArgumentNullException.ThrowIfNull(policy);
+        ArgumentNullException.ThrowIfNull(filter);
+        if (planReviewSpan is null) return;
+        if (string.IsNullOrEmpty(revisionFeedback)) return;
+        if (!policy.ShouldCaptureMagenticPlanReviewFeedback()) return;
+
+        planReviewSpan.SetTag(
+            MagenticConventions.PlanReviewFeedback,
+            filter.Redact(revisionFeedback, policy.Categories));
+    }
+
+    private static ActivityEvent BuildPlanEvent(
+        string eventName,
+        string? planText,
+        IContentCapturePolicy policy,
+        IContentRedactionFilter filter)
+    {
+        if (string.IsNullOrEmpty(planText) || !policy.ShouldCaptureMagenticPlanContent())
+        {
+            return new ActivityEvent(eventName);
+        }
+
+        var redacted = filter.Redact(planText, policy.Categories);
+        var tags = new ActivityTagsCollection
+        {
+            { MagenticConventions.PlanContent, redacted },
+        };
+        return new ActivityEvent(eventName, tags: tags);
     }
 
     /// <summary>Disposes the underlying <see cref="ActivitySource"/>.</summary>

--- a/src/Content/Infrastructure/Infrastructure.AI/Telemetry/Redaction/ContentCapturePolicy.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Telemetry/Redaction/ContentCapturePolicy.cs
@@ -1,0 +1,102 @@
+using Application.AI.Common.Interfaces.Telemetry;
+using Domain.AI.Telemetry.Redaction;
+using Domain.Common.Config;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Infrastructure.AI.Telemetry.Redaction;
+
+/// <summary>
+/// Default <see cref="IContentCapturePolicy"/>. Reads
+/// <c>AppConfig.AI.Telemetry.ContentCapture</c> on each call so a runtime
+/// <c>IOptionsMonitor</c> update flips the toggles without a host restart.
+/// </summary>
+/// <remarks>
+/// <para>
+/// When <c>ContentCapture.Enabled</c> is false every <c>ShouldCapture*</c>
+/// method returns false regardless of the per-attribute flags. The master
+/// flag is the single decision the operator has to flip to turn capture on;
+/// individual attributes then opt in.
+/// </para>
+/// <para>
+/// <see cref="Categories"/> is recomputed on each read. Unknown category
+/// names in <c>ContentCapture.RedactionCategories</c> are skipped with a
+/// debug log so a config typo is loud during development without bringing
+/// the host down.
+/// </para>
+/// </remarks>
+public sealed class ContentCapturePolicy : IContentCapturePolicy
+{
+    private readonly IOptionsMonitor<AppConfig> _config;
+    private readonly ILogger<ContentCapturePolicy> _logger;
+
+    /// <summary>Initializes the policy.</summary>
+    public ContentCapturePolicy(
+        IOptionsMonitor<AppConfig> config,
+        ILogger<ContentCapturePolicy> logger)
+    {
+        ArgumentNullException.ThrowIfNull(config);
+        ArgumentNullException.ThrowIfNull(logger);
+        _config = config;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public bool IsEnabled => _config.CurrentValue.AI.Telemetry.ContentCapture.Enabled;
+
+    /// <inheritdoc />
+    public IReadOnlyList<RedactionCategory> Categories
+    {
+        get
+        {
+            var capture = _config.CurrentValue.AI.Telemetry.ContentCapture;
+            var result = new List<RedactionCategory>(capture.RedactionCategories.Count);
+            foreach (var name in capture.RedactionCategories)
+            {
+                if (Enum.TryParse<RedactionCategory>(name, ignoreCase: true, out var category))
+                {
+                    result.Add(category);
+                }
+                else
+                {
+                    _logger.LogDebug(
+                        "Unknown content-capture redaction category '{Category}' — ignored.",
+                        name);
+                }
+            }
+            return result;
+        }
+    }
+
+    /// <inheritdoc />
+    public bool ShouldCapturePromptContent()
+        => IsEnabled && _config.CurrentValue.AI.Telemetry.ContentCapture.CapturePromptContent;
+
+    /// <inheritdoc />
+    public bool ShouldCaptureOutputContent()
+        => IsEnabled && _config.CurrentValue.AI.Telemetry.ContentCapture.CaptureOutputContent;
+
+    /// <inheritdoc />
+    public bool ShouldCaptureToolCallArguments()
+        => IsEnabled && _config.CurrentValue.AI.Telemetry.ContentCapture.CaptureToolCallArguments;
+
+    /// <inheritdoc />
+    public bool ShouldCaptureToolCallResult()
+        => IsEnabled && _config.CurrentValue.AI.Telemetry.ContentCapture.CaptureToolCallResult;
+
+    /// <inheritdoc />
+    public bool ShouldCaptureMagenticPlanContent()
+        => IsEnabled && _config.CurrentValue.AI.Telemetry.ContentCapture.CaptureMagenticPlanContent;
+
+    /// <inheritdoc />
+    public bool ShouldCaptureMagenticReplanReason()
+        => IsEnabled && _config.CurrentValue.AI.Telemetry.ContentCapture.CaptureMagenticReplanReason;
+
+    /// <inheritdoc />
+    public bool ShouldCaptureMagenticProgressContent()
+        => IsEnabled && _config.CurrentValue.AI.Telemetry.ContentCapture.CaptureMagenticProgressContent;
+
+    /// <inheritdoc />
+    public bool ShouldCaptureMagenticPlanReviewFeedback()
+        => IsEnabled && _config.CurrentValue.AI.Telemetry.ContentCapture.CaptureMagenticPlanReviewFeedback;
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Telemetry/Redaction/ContentCaptureStartupValidator.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Telemetry/Redaction/ContentCaptureStartupValidator.cs
@@ -1,0 +1,129 @@
+using Application.AI.Common.Interfaces.Telemetry;
+using Domain.AI.Telemetry.Conventions;
+using Domain.Common.Config;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Infrastructure.AI.Telemetry.Redaction;
+
+/// <summary>
+/// One-shot startup validator for the content-capture pipeline. Runs once via
+/// <see cref="IHostedService.StartAsync"/> and refuses to boot the host when
+/// content-capture is enabled but the surrounding configuration is unsafe.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Checks performed (only when <c>AppConfig.AI.Telemetry.ContentCapture.Enabled</c>
+/// is true):
+/// </para>
+/// <list type="number">
+///   <item><description>
+///     <b>SemConv stability env var pinned</b> — the harness emits against the
+///     experimental OTel GenAI conventions. When content-capture is on the
+///     <see cref="GenAiSemconvRegistry.SemconvStabilityOptInEnvVar"/>
+///     environment variable MUST equal
+///     <see cref="GenAiSemconvRegistry.SemconvStabilityOptInValue"/>; absent
+///     or wrong values mean a Collector running a stable-only filter could
+///     drop the content attributes silently, defeating the audit purpose.
+///   </description></item>
+///   <item><description>
+///     <b>Redaction filter registered</b> — at least one
+///     <see cref="IContentRedactionFilter"/> must be in the container. Content
+///     can leave the domain only through a filter; a missing filter would
+///     emit raw content the next time a toggle is flipped.
+///   </description></item>
+/// </list>
+/// <para>
+/// When content-capture is disabled the validator no-ops — the rest of the
+/// graph stays inert and the env var is irrelevant to the host.
+/// </para>
+/// </remarks>
+public sealed class ContentCaptureStartupValidator : IHostedService
+{
+    private readonly IServiceProvider _services;
+    private readonly IOptionsMonitor<AppConfig> _config;
+    private readonly ILogger<ContentCaptureStartupValidator> _logger;
+
+    /// <summary>Initializes a new <see cref="ContentCaptureStartupValidator"/>.</summary>
+    /// <remarks>
+    /// <see cref="IHostEnvironment"/> is resolved lazily from the service
+    /// provider inside <see cref="StartAsync"/> rather than required at
+    /// construction so DI tests that enumerate
+    /// <c>GetServices&lt;IHostedService&gt;()</c> without a host environment
+    /// don't fail at materialisation.
+    /// </remarks>
+    public ContentCaptureStartupValidator(
+        IServiceProvider services,
+        IOptionsMonitor<AppConfig> config,
+        ILogger<ContentCaptureStartupValidator> logger)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(config);
+        ArgumentNullException.ThrowIfNull(logger);
+        _services = services;
+        _config = config;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        var capture = _config.CurrentValue.AI.Telemetry.ContentCapture;
+        if (!capture.Enabled)
+        {
+            return Task.CompletedTask;
+        }
+
+        ValidateSemconvStabilityEnvVar();
+        ValidateRedactionFilterRegistered();
+
+        _logger.LogInformation(
+            "Content-capture enabled. Redaction categories: {Categories}; prompt={Prompt}, output={Output}, " +
+            "tool.args={ToolArgs}, tool.result={ToolResult}, magentic.plan={Plan}, magentic.replan_reason={Reason}.",
+            string.Join(',', capture.RedactionCategories),
+            capture.CapturePromptContent,
+            capture.CaptureOutputContent,
+            capture.CaptureToolCallArguments,
+            capture.CaptureToolCallResult,
+            capture.CaptureMagenticPlanContent,
+            capture.CaptureMagenticReplanReason);
+
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    private static void ValidateSemconvStabilityEnvVar()
+    {
+        var value = Environment.GetEnvironmentVariable(GenAiSemconvRegistry.SemconvStabilityOptInEnvVar);
+        if (string.Equals(value, GenAiSemconvRegistry.SemconvStabilityOptInValue, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        throw new InvalidOperationException(
+            $"Content-capture is enabled (AppConfig.AI.Telemetry.ContentCapture.Enabled = true) but the " +
+            $"'{GenAiSemconvRegistry.SemconvStabilityOptInEnvVar}' environment variable is not pinned to " +
+            $"'{GenAiSemconvRegistry.SemconvStabilityOptInValue}'. The harness emits against the " +
+            "experimental OTel GenAI conventions; without the opt-in env var, upstream Collectors may drop " +
+            "content attributes silently. Set the environment variable to the expected value, or disable " +
+            "AppConfig.AI.Telemetry.ContentCapture.Enabled.");
+    }
+
+    private void ValidateRedactionFilterRegistered()
+    {
+        var filter = _services.GetService<IContentRedactionFilter>();
+        if (filter is not null)
+        {
+            return;
+        }
+
+        throw new InvalidOperationException(
+            "Content-capture is enabled but no IContentRedactionFilter is registered in the service " +
+            "container. Register DefaultContentRedactionFilter (or a custom filter) before enabling " +
+            "AppConfig.AI.Telemetry.ContentCapture.Enabled.");
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Telemetry/Redaction/DefaultContentRedactionFilter.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Telemetry/Redaction/DefaultContentRedactionFilter.cs
@@ -1,0 +1,129 @@
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Text.RegularExpressions;
+using Application.AI.Common.Interfaces.Telemetry;
+using Domain.AI.Telemetry.Redaction;
+
+namespace Infrastructure.AI.Telemetry.Redaction;
+
+/// <summary>
+/// Built-in <see cref="IContentRedactionFilter"/> that ships with a fixed,
+/// conservative rule set covering email addresses, phone numbers, US SSNs,
+/// credit-card PANs, IPv4/IPv6 addresses, AWS access keys, JWT tokens, and a
+/// generic <c>Bearer</c> / <c>AccountKey</c> / <c>api_key</c> bucket.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Rules are compiled once at construction. The filter is thread-safe — the
+/// compiled <see cref="Regex"/> instances are stateless after construction
+/// and the rule list is held as an immutable snapshot.
+/// </para>
+/// <para>
+/// The rule set is intentionally over-redactive: false positives (e.g. a
+/// random 9-digit string flagged as an SSN, an internal-only IP getting
+/// masked) are acceptable; false negatives that leak PII into a span are
+/// not.
+/// </para>
+/// </remarks>
+public sealed class DefaultContentRedactionFilter : IContentRedactionFilter
+{
+    private readonly ImmutableArray<CompiledRule> _rules;
+
+    /// <summary>
+    /// Initializes the filter with the harness's built-in rule set.
+    /// </summary>
+    public DefaultContentRedactionFilter()
+    {
+        _rules = BuildBuiltInRules();
+    }
+
+    /// <inheritdoc />
+    public string Redact(string? content, IReadOnlyList<RedactionCategory> categories)
+    {
+        if (string.IsNullOrEmpty(content) || categories is null || categories.Count == 0)
+        {
+            return content ?? string.Empty;
+        }
+
+        var enabled = new HashSet<RedactionCategory>(categories);
+        var result = content;
+        foreach (var rule in _rules)
+        {
+            if (!enabled.Contains(rule.Category))
+            {
+                continue;
+            }
+            result = rule.Pattern.Replace(result, rule.Replacement);
+        }
+        return result;
+    }
+
+    private static ImmutableArray<CompiledRule> BuildBuiltInRules()
+    {
+        var b = ImmutableArray.CreateBuilder<CompiledRule>();
+
+        // JWT must run before generic Bearer/api-key sweeps so the token body
+        // is captured as the JWT category rather than a generic credential.
+        b.Add(Compile(RedactionCategory.JwtToken,
+            @"eyJ[A-Za-z0-9_\-]+\.[A-Za-z0-9_\-]+\.[A-Za-z0-9_\-]+",
+            "[REDACTED:JwtToken]"));
+
+        // AWS access-key ids (AKIA…, ASIA…, AGPA…, AIDA…, AROA…).
+        b.Add(Compile(RedactionCategory.AwsKey,
+            @"\b(?:AKIA|ASIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASCA)[A-Z0-9]{16}\b",
+            "[REDACTED:AwsKey]"));
+
+        // Emails — RFC 5322 simplified.
+        b.Add(Compile(RedactionCategory.Email,
+            @"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b",
+            "[REDACTED:Email]"));
+
+        // US SSN — 3-2-4 with optional separator.
+        b.Add(Compile(RedactionCategory.Ssn,
+            @"\b\d{3}[-\s]?\d{2}[-\s]?\d{4}\b",
+            "[REDACTED:Ssn]"));
+
+        // Credit-card PAN — 13–19 digits with optional separators. Broad and
+        // intentionally noisy; the trade-off is documented above.
+        b.Add(Compile(RedactionCategory.CreditCard,
+            @"\b(?:\d[ -]?){13,19}\b",
+            "[REDACTED:CreditCard]"));
+
+        // Phone numbers — E.164 + North-American shapes.
+        b.Add(Compile(RedactionCategory.Phone,
+            @"\+?\d{1,3}[-.\s]?\(?\d{1,4}\)?[-.\s]?\d{1,4}[-.\s]?\d{1,9}",
+            "[REDACTED:Phone]"));
+
+        // IPv4.
+        b.Add(Compile(RedactionCategory.IpAddress,
+            @"\b(?:\d{1,3}\.){3}\d{1,3}\b",
+            "[REDACTED:IpAddress]"));
+
+        // IPv6 — simplified colon-hex with optional ::.
+        b.Add(Compile(RedactionCategory.IpAddress,
+            @"\b(?:[A-Fa-f0-9]{1,4}:){2,7}[A-Fa-f0-9]{1,4}\b",
+            "[REDACTED:IpAddress]"));
+
+        // Generic credential patterns.
+        b.Add(Compile(RedactionCategory.Generic,
+            @"Bearer\s+[A-Za-z0-9\-._~+/]+=*",
+            "Bearer [REDACTED]"));
+
+        b.Add(Compile(RedactionCategory.Generic,
+            @"(?i)(AccountKey|Password|pwd|SharedAccessKey)\s*=\s*(?!\[REDACTED\])[^;""'\s]+",
+            "$1=[REDACTED]"));
+
+        b.Add(Compile(RedactionCategory.Generic,
+            @"(?i)(api[_-]?key|access[_-]?token|secret[_-]?key)\s*[=:]\s*(?!\[REDACTED\])\S+",
+            "$1=[REDACTED]"));
+
+        return b.ToImmutable();
+    }
+
+    private static CompiledRule Compile(RedactionCategory category, string pattern, string replacement)
+        => new(category,
+            new Regex(pattern, RegexOptions.Compiled | RegexOptions.CultureInvariant),
+            replacement);
+
+    private sealed record CompiledRule(RedactionCategory Category, Regex Pattern, string Replacement);
+}

--- a/src/Content/Tests/Application.Core.Tests/Validation/ContentCaptureConfigValidatorTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/Validation/ContentCaptureConfigValidatorTests.cs
@@ -1,0 +1,147 @@
+using Application.Core.Validation;
+using Domain.Common.Config.AI.Telemetry;
+using FluentAssertions;
+using Xunit;
+
+namespace Application.Core.Tests.Validation;
+
+/// <summary>
+/// Tests for <see cref="ContentCaptureConfigValidator"/>. All rules are
+/// conditional on <see cref="ContentCaptureConfig.Enabled"/>: a disabled section
+/// is always valid; an enabled one requires a non-empty list of known
+/// <c>RedactionCategory</c> names. Pattern: a valid baseline, mutate one field
+/// per test.
+/// </summary>
+public class ContentCaptureConfigValidatorTests
+{
+    private readonly ContentCaptureConfigValidator _validator = new();
+
+    [Fact]
+    public void DefaultValues_AreCaptureOffWithAllCategories()
+    {
+        var config = new ContentCaptureConfig();
+
+        config.Enabled.Should().BeFalse();
+        config.RedactionCategories.Should()
+            .BeEquivalentTo("Email", "Phone", "Ssn", "CreditCard", "IpAddress", "AwsKey", "JwtToken", "Generic");
+    }
+
+    [Fact]
+    public async Task Validate_DisabledWithEmptyCategories_IsValid()
+    {
+        // Categories are empty, but Enabled=false short-circuits every rule.
+        var config = new ContentCaptureConfig
+        {
+            Enabled = false,
+            RedactionCategories = [],
+        };
+
+        var result = await _validator.ValidateAsync(config);
+
+        result.IsValid.Should().BeTrue();
+        result.Errors.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Validate_DisabledWithUnknownCategory_IsValid()
+    {
+        var config = new ContentCaptureConfig
+        {
+            Enabled = false,
+            RedactionCategories = ["NotARealCategory"],
+        };
+
+        var result = await _validator.ValidateAsync(config);
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Validate_EnabledWithDefaultCategories_IsValid()
+    {
+        var config = new ContentCaptureConfig { Enabled = true };
+
+        var result = await _validator.ValidateAsync(config);
+
+        result.IsValid.Should().BeTrue();
+        result.Errors.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Validate_EnabledWithEmptyCategories_HasError()
+    {
+        var config = new ContentCaptureConfig
+        {
+            Enabled = true,
+            RedactionCategories = [],
+        };
+
+        var result = await _validator.ValidateAsync(config);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == "RedactionCategories");
+    }
+
+    [Fact]
+    public async Task Validate_EnabledWithUnknownCategory_HasError()
+    {
+        var config = new ContentCaptureConfig
+        {
+            Enabled = true,
+            RedactionCategories = ["Email", "Bogus"],
+        };
+
+        var result = await _validator.ValidateAsync(config);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName.StartsWith("RedactionCategories"));
+    }
+
+    [Theory]
+    [InlineData("email")]
+    [InlineData("EMAIL")]
+    [InlineData("Email")]
+    [InlineData("jwttoken")]
+    public async Task Validate_EnabledWithKnownCategoryCaseInsensitive_NoCategoryError(string category)
+    {
+        var config = new ContentCaptureConfig
+        {
+            Enabled = true,
+            RedactionCategories = [category],
+        };
+
+        var result = await _validator.ValidateAsync(config);
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Validate_EnabledWithWhitespacePaddedKnownCategory_IsValid()
+    {
+        var config = new ContentCaptureConfig
+        {
+            Enabled = true,
+            RedactionCategories = [" Email "],
+        };
+
+        var result = await _validator.ValidateAsync(config);
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Validate_EnabledWithAllKnownCategories_IsValid()
+    {
+        var config = new ContentCaptureConfig
+        {
+            Enabled = true,
+            RedactionCategories =
+                ["Email", "Phone", "Ssn", "CreditCard", "IpAddress", "AwsKey", "JwtToken", "Generic"],
+        };
+
+        var result = await _validator.ValidateAsync(config);
+
+        result.IsValid.Should().BeTrue();
+        result.Errors.Should().BeEmpty();
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Orchestration/Magentic/MagenticTestHelpers.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Orchestration/Magentic/MagenticTestHelpers.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using Application.AI.Common.Interfaces.Orchestration.Magentic;
+using Application.AI.Common.Interfaces.Telemetry;
 using Domain.AI.Telemetry.Conventions;
 using Infrastructure.AI.Orchestration.Magentic;
 using MediatR;
@@ -83,7 +84,9 @@ internal static class MagenticTestHelpers
     public static MagenticEventSubscriber BuildSubscriber(
         out Mock<IMagenticPlanReviewBridge> bridge,
         out Mock<IMediator> mediator,
-        MagenticSpanEmitter? emitter = null)
+        MagenticSpanEmitter? emitter = null,
+        IContentCapturePolicy? capturePolicy = null,
+        IContentRedactionFilter? redactionFilter = null)
     {
         bridge = new Mock<IMagenticPlanReviewBridge>();
         mediator = new Mock<IMediator>();
@@ -92,6 +95,10 @@ internal static class MagenticTestHelpers
             emitter ?? new MagenticSpanEmitter(),
             bridge.Object,
             router,
+            // Default to capture-off mocks so pre-content-capture tests are
+            // unaffected; ShouldCapture* on a bare mock returns false.
+            capturePolicy ?? Mock.Of<IContentCapturePolicy>(),
+            redactionFilter ?? Mock.Of<IContentRedactionFilter>(),
             NullLogger<MagenticEventSubscriber>.Instance);
     }
 

--- a/src/Content/Tests/Infrastructure.AI.Tests/Telemetry/ContentCaptureDependencyInjectionTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Telemetry/ContentCaptureDependencyInjectionTests.cs
@@ -1,0 +1,81 @@
+using System.Reflection;
+using Application.AI.Common.Interfaces.Telemetry;
+using Domain.Common.Config;
+using FluentAssertions;
+using Infrastructure.AI.Telemetry.Redaction;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Telemetry;
+
+/// <summary>
+/// Verifies <c>DependencyInjection.RegisterContentCaptureServices</c> wires the
+/// content-capture pipeline: the default redaction filter, the capture policy,
+/// and the startup validator hosted service. The filter and policy use
+/// <c>TryAdd</c> semantics so a consumer can register custom implementations
+/// before <c>AddInfrastructureAIDependencies</c> runs. The helper is private, so
+/// it is invoked via reflection — the public entry point pulls in the full
+/// Infrastructure.AI graph, which is heavier than this unit needs.
+/// </summary>
+public sealed class ContentCaptureDependencyInjectionTests
+{
+    private static readonly MethodInfo RegisterMethod =
+        typeof(Infrastructure.AI.DependencyInjection)
+            .GetMethod("RegisterContentCaptureServices", BindingFlags.NonPublic | BindingFlags.Static)!;
+
+    private static void Register(IServiceCollection services)
+        => RegisterMethod.Invoke(null, [services]);
+
+    private static IServiceCollection BaseServices()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton(ContentCaptureTestConfig.Monitor(ContentCaptureTestConfig.AllOn()));
+        return services;
+    }
+
+    [Fact]
+    public void Register_ResolvesRedactionFilterAndPolicy()
+    {
+        var services = BaseServices();
+
+        Register(services);
+        var sp = services.BuildServiceProvider();
+
+        sp.GetRequiredService<IContentRedactionFilter>().Should().BeOfType<DefaultContentRedactionFilter>();
+        sp.GetRequiredService<IContentCapturePolicy>().Should().BeOfType<ContentCapturePolicy>();
+    }
+
+    [Fact]
+    public void Register_RegistersStartupValidatorAsHostedService()
+    {
+        var services = BaseServices();
+
+        Register(services);
+        var sp = services.BuildServiceProvider();
+
+        sp.GetServices<IHostedService>()
+            .Should().ContainSingle(h => h is ContentCaptureStartupValidator);
+    }
+
+    [Fact]
+    public void Register_TryAddSemantics_HonoursConsumerFilterOverride()
+    {
+        var services = BaseServices();
+        var custom = new CustomFilter();
+        services.AddSingleton<IContentRedactionFilter>(custom);
+
+        Register(services);
+        var sp = services.BuildServiceProvider();
+
+        // TryAddSingleton must not clobber the consumer-registered filter.
+        sp.GetRequiredService<IContentRedactionFilter>().Should().BeSameAs(custom);
+    }
+
+    private sealed class CustomFilter : IContentRedactionFilter
+    {
+        public string Redact(string? content, IReadOnlyList<Domain.AI.Telemetry.Redaction.RedactionCategory> categories)
+            => content ?? string.Empty;
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Telemetry/ContentCapturePolicyTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Telemetry/ContentCapturePolicyTests.cs
@@ -1,0 +1,172 @@
+using Domain.AI.Telemetry.Redaction;
+using Domain.Common.Config.AI.Telemetry;
+using FluentAssertions;
+using Infrastructure.AI.Telemetry.Redaction;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Telemetry;
+
+/// <summary>
+/// Tests for <see cref="ContentCapturePolicy"/>. The policy reads
+/// <c>AppConfig.AI.Telemetry.ContentCapture</c> through an
+/// <c>IOptionsMonitor&lt;AppConfig&gt;</c> on every call. The contract under test:
+/// the master <see cref="ContentCaptureConfig.Enabled"/> flag gates every
+/// <c>ShouldCapture*</c> method, each per-attribute toggle gates its own method,
+/// and <see cref="ContentCapturePolicy.Categories"/> parses the config string
+/// list to the enum, silently skipping unknown names.
+/// </summary>
+public sealed class ContentCapturePolicyTests
+{
+    private static ContentCapturePolicy Build(ContentCaptureConfig capture)
+        => new(ContentCaptureTestConfig.Monitor(capture), NullLogger<ContentCapturePolicy>.Instance);
+
+    [Fact]
+    public void IsEnabled_ReflectsMasterFlag()
+    {
+        Build(new ContentCaptureConfig { Enabled = false }).IsEnabled.Should().BeFalse();
+        Build(new ContentCaptureConfig { Enabled = true }).IsEnabled.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ShouldCapture_MasterDisabled_AllFalseEvenWhenTogglesOn()
+    {
+        var capture = ContentCaptureTestConfig.AllOn();
+        capture.Enabled = false; // master off overrides every per-attribute toggle
+
+        var policy = Build(capture);
+
+        policy.ShouldCapturePromptContent().Should().BeFalse();
+        policy.ShouldCaptureOutputContent().Should().BeFalse();
+        policy.ShouldCaptureToolCallArguments().Should().BeFalse();
+        policy.ShouldCaptureToolCallResult().Should().BeFalse();
+        policy.ShouldCaptureMagenticPlanContent().Should().BeFalse();
+        policy.ShouldCaptureMagenticReplanReason().Should().BeFalse();
+        policy.ShouldCaptureMagenticProgressContent().Should().BeFalse();
+        policy.ShouldCaptureMagenticPlanReviewFeedback().Should().BeFalse();
+    }
+
+    [Fact]
+    public void ShouldCapture_MasterEnabledAllTogglesOn_AllTrue()
+    {
+        var policy = Build(ContentCaptureTestConfig.AllOn());
+
+        policy.ShouldCapturePromptContent().Should().BeTrue();
+        policy.ShouldCaptureOutputContent().Should().BeTrue();
+        policy.ShouldCaptureToolCallArguments().Should().BeTrue();
+        policy.ShouldCaptureToolCallResult().Should().BeTrue();
+        policy.ShouldCaptureMagenticPlanContent().Should().BeTrue();
+        policy.ShouldCaptureMagenticReplanReason().Should().BeTrue();
+        policy.ShouldCaptureMagenticProgressContent().Should().BeTrue();
+        policy.ShouldCaptureMagenticPlanReviewFeedback().Should().BeTrue();
+    }
+
+    [Fact]
+    public void ShouldCapturePromptContent_GatedByItsOwnToggle()
+    {
+        var capture = ContentCaptureTestConfig.AllOn();
+        capture.CapturePromptContent = false;
+
+        var policy = Build(capture);
+
+        policy.ShouldCapturePromptContent().Should().BeFalse();
+        // A sibling toggle is unaffected.
+        policy.ShouldCaptureOutputContent().Should().BeTrue();
+    }
+
+    [Fact]
+    public void ShouldCaptureToolCallArguments_GatedByItsOwnToggle()
+    {
+        var capture = ContentCaptureTestConfig.AllOn();
+        capture.CaptureToolCallArguments = false;
+
+        var policy = Build(capture);
+
+        policy.ShouldCaptureToolCallArguments().Should().BeFalse();
+        policy.ShouldCaptureToolCallResult().Should().BeTrue();
+    }
+
+    [Fact]
+    public void ShouldCaptureMagenticReplanReason_GatedByItsOwnToggle()
+    {
+        var capture = ContentCaptureTestConfig.AllOn();
+        capture.CaptureMagenticReplanReason = false;
+
+        var policy = Build(capture);
+
+        policy.ShouldCaptureMagenticReplanReason().Should().BeFalse();
+        policy.ShouldCaptureMagenticPlanContent().Should().BeTrue();
+    }
+
+    [Fact]
+    public void Categories_ParsesConfigListToEnum()
+    {
+        var capture = new ContentCaptureConfig
+        {
+            Enabled = true,
+            RedactionCategories = ["Email", "Ssn", "JwtToken"],
+        };
+
+        var policy = Build(capture);
+
+        policy.Categories.Should().BeEquivalentTo(new[]
+        {
+            RedactionCategory.Email,
+            RedactionCategory.Ssn,
+            RedactionCategory.JwtToken,
+        });
+    }
+
+    [Fact]
+    public void Categories_IsCaseInsensitive()
+    {
+        var capture = new ContentCaptureConfig
+        {
+            Enabled = true,
+            RedactionCategories = ["email", "SSN"],
+        };
+
+        var policy = Build(capture);
+
+        policy.Categories.Should().BeEquivalentTo(new[]
+        {
+            RedactionCategory.Email,
+            RedactionCategory.Ssn,
+        });
+    }
+
+    [Fact]
+    public void Categories_SkipsUnknownNameWithoutThrowing()
+    {
+        var capture = new ContentCaptureConfig
+        {
+            Enabled = true,
+            RedactionCategories = ["Email", "NotARealCategory", "Generic"],
+        };
+
+        var policy = Build(capture);
+
+        var act = () => policy.Categories;
+
+        act.Should().NotThrow();
+        policy.Categories.Should().BeEquivalentTo(new[]
+        {
+            RedactionCategory.Email,
+            RedactionCategory.Generic,
+        });
+    }
+
+    [Fact]
+    public void Categories_EmptyList_ReturnsEmpty()
+    {
+        var capture = new ContentCaptureConfig
+        {
+            Enabled = true,
+            RedactionCategories = [],
+        };
+
+        var policy = Build(capture);
+
+        policy.Categories.Should().BeEmpty();
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Telemetry/ContentCaptureStartupValidatorTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Telemetry/ContentCaptureStartupValidatorTests.cs
@@ -1,0 +1,138 @@
+using Application.AI.Common.Interfaces.Telemetry;
+using Domain.AI.Telemetry.Conventions;
+using Domain.Common.Config.AI.Telemetry;
+using FluentAssertions;
+using Infrastructure.AI.Telemetry.Redaction;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Telemetry;
+
+/// <summary>
+/// Tests for <see cref="ContentCaptureStartupValidator"/>. The hosted service
+/// no-ops when content-capture is off; when on it fails-loud unless the OTel
+/// semconv-stability env var is pinned to the expected value AND an
+/// <see cref="IContentRedactionFilter"/> is registered. The env var is global
+/// process state, so each test that touches it restores the prior value in a
+/// <c>finally</c>.
+/// </summary>
+[Collection("ContentCaptureEnvVar")]
+public sealed class ContentCaptureStartupValidatorTests
+{
+    private static ContentCaptureStartupValidator Build(
+        ContentCaptureConfig capture,
+        bool registerFilter)
+    {
+        var services = new ServiceCollection();
+        if (registerFilter)
+        {
+            services.AddSingleton<IContentRedactionFilter, DefaultContentRedactionFilter>();
+        }
+        var sp = services.BuildServiceProvider();
+
+        return new ContentCaptureStartupValidator(
+            sp,
+            ContentCaptureTestConfig.Monitor(capture),
+            NullLogger<ContentCaptureStartupValidator>.Instance);
+    }
+
+    private static async Task WithEnvVar(string? value, Func<Task> body)
+    {
+        var prior = Environment.GetEnvironmentVariable(GenAiSemconvRegistry.SemconvStabilityOptInEnvVar);
+        try
+        {
+            Environment.SetEnvironmentVariable(GenAiSemconvRegistry.SemconvStabilityOptInEnvVar, value);
+            await body();
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(GenAiSemconvRegistry.SemconvStabilityOptInEnvVar, prior);
+        }
+    }
+
+    [Fact]
+    public async Task StartAsync_Disabled_NoOpEvenWithoutEnvVarOrFilter()
+    {
+        var validator = Build(new ContentCaptureConfig { Enabled = false }, registerFilter: false);
+
+        await WithEnvVar(null, async () =>
+        {
+            var act = async () => await validator.StartAsync(CancellationToken.None);
+
+            await act.Should().NotThrowAsync();
+        });
+    }
+
+    [Fact]
+    public async Task StartAsync_EnabledButEnvVarUnset_Throws()
+    {
+        var validator = Build(ContentCaptureTestConfig.AllOn(), registerFilter: true);
+
+        await WithEnvVar(null, async () =>
+        {
+            var act = async () => await validator.StartAsync(CancellationToken.None);
+
+            (await act.Should().ThrowAsync<InvalidOperationException>())
+                .WithMessage($"*{GenAiSemconvRegistry.SemconvStabilityOptInEnvVar}*");
+        });
+    }
+
+    [Fact]
+    public async Task StartAsync_EnabledButEnvVarWrongValue_Throws()
+    {
+        var validator = Build(ContentCaptureTestConfig.AllOn(), registerFilter: true);
+
+        await WithEnvVar("stable", async () =>
+        {
+            var act = async () => await validator.StartAsync(CancellationToken.None);
+
+            await act.Should().ThrowAsync<InvalidOperationException>();
+        });
+    }
+
+    [Fact]
+    public async Task StartAsync_EnabledAndEnvVarPinnedButNoFilter_Throws()
+    {
+        var validator = Build(ContentCaptureTestConfig.AllOn(), registerFilter: false);
+
+        await WithEnvVar(GenAiSemconvRegistry.SemconvStabilityOptInValue, async () =>
+        {
+            var act = async () => await validator.StartAsync(CancellationToken.None);
+
+            (await act.Should().ThrowAsync<InvalidOperationException>())
+                .WithMessage("*IContentRedactionFilter*");
+        });
+    }
+
+    [Fact]
+    public async Task StartAsync_EnabledAndEnvVarPinnedAndFilterRegistered_DoesNotThrow()
+    {
+        var validator = Build(ContentCaptureTestConfig.AllOn(), registerFilter: true);
+
+        await WithEnvVar(GenAiSemconvRegistry.SemconvStabilityOptInValue, async () =>
+        {
+            var act = async () => await validator.StartAsync(CancellationToken.None);
+
+            await act.Should().NotThrowAsync();
+        });
+    }
+
+    [Fact]
+    public async Task StopAsync_IsNoOp()
+    {
+        var validator = Build(new ContentCaptureConfig { Enabled = false }, registerFilter: false);
+
+        var act = async () => await validator.StopAsync(CancellationToken.None);
+
+        await act.Should().NotThrowAsync();
+    }
+}
+
+/// <summary>
+/// Serializes tests that mutate the process-global
+/// <c>OTEL_SEMCONV_STABILITY_OPT_IN</c> environment variable so they do not
+/// interfere with one another when xUnit runs collections in parallel.
+/// </summary>
+[CollectionDefinition("ContentCaptureEnvVar", DisableParallelization = true)]
+public sealed class ContentCaptureEnvVarCollection;

--- a/src/Content/Tests/Infrastructure.AI.Tests/Telemetry/ContentCaptureTestConfig.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Telemetry/ContentCaptureTestConfig.cs
@@ -1,0 +1,56 @@
+using Domain.Common.Config;
+using Domain.Common.Config.AI;
+using Domain.Common.Config.AI.Telemetry;
+using Microsoft.Extensions.Options;
+using Moq;
+
+namespace Infrastructure.AI.Tests.Telemetry;
+
+/// <summary>
+/// Shared builders for the content-capture test suite. Produces an
+/// <see cref="IOptionsMonitor{AppConfig}"/> whose
+/// <c>AI.Telemetry.ContentCapture</c> section is configured exactly the way each
+/// scenario needs, so the policy, startup validator, and DI tests can assert
+/// against a known config. Mirrors <c>GitOpsTestConfig</c>.
+/// </summary>
+internal static class ContentCaptureTestConfig
+{
+    /// <summary>
+    /// Builds an <see cref="AppConfig"/> with the supplied content-capture
+    /// section. Defaults yield the production posture: master enabled, all
+    /// per-attribute toggles on, and the full category list — so a test that
+    /// only cares about one toggle can flip just that toggle.
+    /// </summary>
+    public static AppConfig AppConfig(ContentCaptureConfig capture) => new()
+    {
+        AI = new AIConfig
+        {
+            Telemetry = new TelemetryConfig { ContentCapture = capture },
+        },
+    };
+
+    /// <summary>
+    /// A content-capture section with the master flag and every per-attribute
+    /// toggle on, ready to be narrowed per test.
+    /// </summary>
+    public static ContentCaptureConfig AllOn() => new()
+    {
+        Enabled = true,
+        CapturePromptContent = true,
+        CaptureOutputContent = true,
+        CaptureToolCallArguments = true,
+        CaptureToolCallResult = true,
+        CaptureMagenticPlanContent = true,
+        CaptureMagenticReplanReason = true,
+        CaptureMagenticProgressContent = true,
+        CaptureMagenticPlanReviewFeedback = true,
+    };
+
+    /// <summary>Wraps an <see cref="AppConfig"/> in a Moq-backed monitor.</summary>
+    public static IOptionsMonitor<AppConfig> Monitor(AppConfig appConfig)
+        => Mock.Of<IOptionsMonitor<AppConfig>>(o => o.CurrentValue == appConfig);
+
+    /// <summary>Convenience: a monitor over the supplied content-capture section.</summary>
+    public static IOptionsMonitor<AppConfig> Monitor(ContentCaptureConfig capture)
+        => Monitor(AppConfig(capture));
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Telemetry/DefaultContentRedactionFilterTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Telemetry/DefaultContentRedactionFilterTests.cs
@@ -1,0 +1,159 @@
+using Domain.AI.Telemetry.Redaction;
+using FluentAssertions;
+using Infrastructure.AI.Telemetry.Redaction;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Telemetry;
+
+/// <summary>
+/// Tests for <see cref="DefaultContentRedactionFilter"/>. Each of the eight
+/// built-in <see cref="RedactionCategory"/> rules must mask a representative
+/// sample of its target, leave content alone when its category is not requested,
+/// pass null/empty through unchanged, and handle multiple categories in one
+/// string. The rule set is intentionally over-redactive (false positives
+/// acceptable, false negatives not), so assertions check that the secret is gone
+/// rather than that surrounding text is byte-identical.
+/// </summary>
+public sealed class DefaultContentRedactionFilterTests
+{
+    private readonly DefaultContentRedactionFilter _filter = new();
+
+    private static readonly IReadOnlyList<RedactionCategory> AllCategories =
+        Enum.GetValues<RedactionCategory>();
+
+    [Fact]
+    public void Redact_Email_MasksAddress()
+    {
+        var result = _filter.Redact("contact me at alice@example.com please", [RedactionCategory.Email]);
+
+        result.Should().NotContain("alice@example.com");
+        result.Should().Contain("[REDACTED:Email]");
+    }
+
+    [Fact]
+    public void Redact_Phone_MasksNumber()
+    {
+        var result = _filter.Redact("call +1 415-555-0132 now", [RedactionCategory.Phone]);
+
+        result.Should().NotContain("415-555-0132");
+        result.Should().Contain("[REDACTED:Phone]");
+    }
+
+    [Fact]
+    public void Redact_Ssn_MasksNumber()
+    {
+        var result = _filter.Redact("ssn 123-45-6789 end", [RedactionCategory.Ssn]);
+
+        result.Should().NotContain("123-45-6789");
+        result.Should().Contain("[REDACTED:Ssn]");
+    }
+
+    [Fact]
+    public void Redact_CreditCard_MasksPan()
+    {
+        var result = _filter.Redact("card 4111 1111 1111 1111 ok", [RedactionCategory.CreditCard]);
+
+        result.Should().NotContain("4111 1111 1111 1111");
+        result.Should().Contain("[REDACTED:CreditCard]");
+    }
+
+    [Fact]
+    public void Redact_IpAddress_MasksIpv4()
+    {
+        var result = _filter.Redact("host at 192.168.1.10 down", [RedactionCategory.IpAddress]);
+
+        result.Should().NotContain("192.168.1.10");
+        result.Should().Contain("[REDACTED:IpAddress]");
+    }
+
+    [Fact]
+    public void Redact_AwsKey_MasksAccessKeyId()
+    {
+        var result = _filter.Redact("key AKIAIOSFODNN7EXAMPLE here", [RedactionCategory.AwsKey]);
+
+        result.Should().NotContain("AKIAIOSFODNN7EXAMPLE");
+        result.Should().Contain("[REDACTED:AwsKey]");
+    }
+
+    [Fact]
+    public void Redact_JwtToken_MasksToken()
+    {
+        // Built from parts so no literal token string sits in source (the shape
+        // is header.payload.signature with base64url segments, which is all the
+        // JWT regex keys on).
+        var jwt = string.Join('.', "eyJ" + "hbGciOiJIUzI1NiJ9", "eyJ" + "zdWIiOiIxMjM0In0", "Sig-abc_DEF123");
+        var result = _filter.Redact($"auth {jwt} done", [RedactionCategory.JwtToken]);
+
+        result.Should().NotContain(jwt);
+        result.Should().Contain("[REDACTED:JwtToken]");
+    }
+
+    [Fact]
+    public void Redact_Generic_MasksApiKeyAssignment()
+    {
+        var result = _filter.Redact("api_key=sk-supersecretvalue123", [RedactionCategory.Generic]);
+
+        result.Should().NotContain("sk-supersecretvalue123");
+        result.Should().Contain("[REDACTED]");
+    }
+
+    [Fact]
+    public void Redact_CategoryNotRequested_LeavesContentUnchanged()
+    {
+        // Only Email requested; the email stays intact because Email is excluded.
+        const string input = "email alice@example.com";
+        var result = _filter.Redact(input, [RedactionCategory.Phone]);
+
+        result.Should().Be(input);
+    }
+
+    [Fact]
+    public void Redact_MultipleCategories_MasksEachInOneString()
+    {
+        const string input = "mail bob@example.com ip 10.0.0.5 ssn 987-65-4321";
+        var result = _filter.Redact(
+            input,
+            [RedactionCategory.Email, RedactionCategory.IpAddress, RedactionCategory.Ssn]);
+
+        result.Should().NotContain("bob@example.com");
+        result.Should().NotContain("10.0.0.5");
+        result.Should().NotContain("987-65-4321");
+        result.Should().Contain("[REDACTED:Email]");
+        result.Should().Contain("[REDACTED:IpAddress]");
+        result.Should().Contain("[REDACTED:Ssn]");
+    }
+
+    [Fact]
+    public void Redact_Null_ReturnsEmptyString()
+    {
+        var result = _filter.Redact(null, AllCategories);
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Redact_Empty_ReturnsEmptyString()
+    {
+        var result = _filter.Redact(string.Empty, AllCategories);
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Redact_EmptyCategoryList_ReturnsInputUnchanged()
+    {
+        const string input = "email alice@example.com ip 10.0.0.5";
+        var result = _filter.Redact(input, []);
+
+        result.Should().Be(input);
+    }
+
+    [Fact]
+    public void Redact_NoMatches_ReturnsInputUnchanged()
+    {
+        const string input = "nothing sensitive here at all";
+        var result = _filter.Redact(input, AllCategories);
+
+        result.Should().Be(input);
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Telemetry/MagenticContentCaptureIntegrationTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Telemetry/MagenticContentCaptureIntegrationTests.cs
@@ -1,0 +1,165 @@
+using System.Diagnostics;
+using Application.AI.Common.Interfaces.Telemetry;
+using Domain.AI.Telemetry.Conventions;
+using Domain.Common.Config.AI.Telemetry;
+using FluentAssertions;
+using Infrastructure.AI.Orchestration.Magentic;
+using Infrastructure.AI.Telemetry.Redaction;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Telemetry;
+
+/// <summary>
+/// End-to-end content-capture integration tests for the Magentic span emitter.
+/// This closes the PR-1 (PR-6) deferral: the
+/// <see cref="MagenticSpanEmitter"/> content methods, wired to the real
+/// <see cref="DefaultContentRedactionFilter"/> and a real
+/// <see cref="ContentCapturePolicy"/>, must attach REDACTED content under the
+/// semconv attribute keys when capture is ON, and attach NO content attribute
+/// when capture is OFF. Spans/events are captured via an
+/// <see cref="ActivityListener"/>, matching the established
+/// <c>MagenticSpanEmitterTests</c> pattern. Attribute key names are asserted
+/// from <see cref="MagenticConventions"/> (never hardcoded strings).
+/// </summary>
+public sealed class MagenticContentCaptureIntegrationTests
+{
+    private sealed class CapturedSpans : IDisposable
+    {
+        private readonly ActivityListener _listener;
+        public List<Activity> Activities { get; } = [];
+
+        public CapturedSpans()
+        {
+            _listener = new ActivityListener
+            {
+                ShouldListenTo = s => s.Name == MagenticConventions.ActivitySourceName,
+                Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+                ActivityStarted = a => Activities.Add(a),
+            };
+            ActivitySource.AddActivityListener(_listener);
+        }
+
+        public void Dispose() => _listener.Dispose();
+    }
+
+    private static IContentCapturePolicy Policy(ContentCaptureConfig capture)
+        => new ContentCapturePolicy(
+            ContentCaptureTestConfig.Monitor(capture),
+            NullLogger<ContentCapturePolicy>.Instance);
+
+    private static readonly DefaultContentRedactionFilter Filter = new();
+
+    private const string PlanWithEmail = "Step 1: email the owner alice@example.com about the plan.";
+
+    [Fact]
+    public void RecordPlanCreatedWithContent_CaptureOn_AttachesRedactedPlanContent()
+    {
+        using var captured = new CapturedSpans();
+        using var emitter = new MagenticSpanEmitter();
+        var workflow = emitter.StartWorkflowSpan("wf", null, 3, null, false, ["p"]);
+        var manager = emitter.StartManagerSpan(workflow);
+
+        MagenticSpanEmitter.RecordPlanCreatedWithContent(
+            manager, planVersion: 1, planText: PlanWithEmail,
+            Policy(ContentCaptureTestConfig.AllOn()), Filter);
+
+        var evt = manager!.Events.Single(e => e.Name == MagenticConventions.EventPlanCreated);
+        var content = evt.Tags.Single(t => t.Key == MagenticConventions.PlanContent).Value as string;
+
+        content.Should().NotBeNull();
+        content!.Should().NotContain("alice@example.com");
+        content.Should().Contain("[REDACTED:Email]");
+    }
+
+    [Fact]
+    public void RecordPlanCreatedWithContent_CaptureOff_AttachesNoContent()
+    {
+        using var captured = new CapturedSpans();
+        using var emitter = new MagenticSpanEmitter();
+        var workflow = emitter.StartWorkflowSpan("wf", null, 3, null, false, ["p"]);
+        var manager = emitter.StartManagerSpan(workflow);
+
+        var off = ContentCaptureTestConfig.AllOn();
+        off.Enabled = false;
+        MagenticSpanEmitter.RecordPlanCreatedWithContent(
+            manager, planVersion: 1, planText: PlanWithEmail, Policy(off), Filter);
+
+        var evt = manager!.Events.Single(e => e.Name == MagenticConventions.EventPlanCreated);
+        evt.Tags.Should().NotContain(t => t.Key == MagenticConventions.PlanContent);
+    }
+
+    [Fact]
+    public void RecordPlanCreatedWithContent_PerAttributeToggleOff_AttachesNoContent()
+    {
+        using var captured = new CapturedSpans();
+        using var emitter = new MagenticSpanEmitter();
+        var workflow = emitter.StartWorkflowSpan("wf", null, 3, null, false, ["p"]);
+        var manager = emitter.StartManagerSpan(workflow);
+
+        // Master on, but the specific plan-content toggle off → no content.
+        var capture = ContentCaptureTestConfig.AllOn();
+        capture.CaptureMagenticPlanContent = false;
+        MagenticSpanEmitter.RecordPlanCreatedWithContent(
+            manager, planVersion: 1, planText: PlanWithEmail, Policy(capture), Filter);
+
+        var evt = manager!.Events.Single(e => e.Name == MagenticConventions.EventPlanCreated);
+        evt.Tags.Should().NotContain(t => t.Key == MagenticConventions.PlanContent);
+    }
+
+    [Fact]
+    public void RecordReplannedWithContent_CaptureOn_AttachesRedactedPlanContent()
+    {
+        using var captured = new CapturedSpans();
+        using var emitter = new MagenticSpanEmitter();
+        var workflow = emitter.StartWorkflowSpan("wf", null, 3, null, false, ["p"]);
+        var manager = emitter.StartManagerSpan(workflow);
+
+        MagenticSpanEmitter.RecordReplannedWithContent(
+            manager, planVersion: 2, planText: PlanWithEmail,
+            Policy(ContentCaptureTestConfig.AllOn()), Filter);
+
+        var evt = manager!.Events.Single(e => e.Name == MagenticConventions.EventReplanned);
+        var content = evt.Tags.Single(t => t.Key == MagenticConventions.PlanContent).Value as string;
+
+        content!.Should().NotContain("alice@example.com");
+        content.Should().Contain("[REDACTED:Email]");
+        manager.GetTagItem(MagenticConventions.PlanVersion).Should().Be(2);
+    }
+
+    [Fact]
+    public void RecordResetReason_CaptureOn_AttachesRedactedReason()
+    {
+        using var captured = new CapturedSpans();
+        using var emitter = new MagenticSpanEmitter();
+        var workflow = emitter.StartWorkflowSpan("wf", null, 3, null, false, ["p"]);
+        var manager = emitter.StartManagerSpan(workflow);
+        var reset = emitter.StartResetSpan(manager, 1, MagenticConventions.ResetTriggerStall, true);
+
+        MagenticSpanEmitter.RecordResetReason(
+            reset, "Reset because user bob@example.com reported a stall.",
+            Policy(ContentCaptureTestConfig.AllOn()), Filter);
+
+        var reason = reset!.GetTagItem(MagenticConventions.ReplanReason) as string;
+        reason.Should().NotBeNull();
+        reason!.Should().NotContain("bob@example.com");
+        reason.Should().Contain("[REDACTED:Email]");
+    }
+
+    [Fact]
+    public void RecordResetReason_CaptureOff_AttachesNoReason()
+    {
+        using var captured = new CapturedSpans();
+        using var emitter = new MagenticSpanEmitter();
+        var workflow = emitter.StartWorkflowSpan("wf", null, 3, null, false, ["p"]);
+        var manager = emitter.StartManagerSpan(workflow);
+        var reset = emitter.StartResetSpan(manager, 1, MagenticConventions.ResetTriggerStall, true);
+
+        var off = ContentCaptureTestConfig.AllOn();
+        off.Enabled = false;
+        MagenticSpanEmitter.RecordResetReason(
+            reset, "Reset because user bob@example.com reported a stall.", Policy(off), Filter);
+
+        reset!.GetTagItem(MagenticConventions.ReplanReason).Should().BeNull();
+    }
+}


### PR DESCRIPTION
## Summary
Completes **PR-11** of the agentic-DevOps plan: an opt-in OpenTelemetry GenAI **content-capture policy** with PII/secret **redaction**, wired into the Magentic orchestration spans. OFF by default — a fresh consumer never silently emits prompt / tool / plan content into traces. Closes PR-1's deferred '7f' OTel-attributes integration test.

## Layers (4 commits)
1. Attribute keys + redaction primitives (`RedactionCategory`)
2. Application interfaces — `IContentRedactionFilter`, `IContentCapturePolicy`
3. Infrastructure — `DefaultContentRedactionFilter` (8 regex categories), `ContentCapturePolicy` (IOptionsMonitor-gated), `ContentCaptureStartupValidator` (fail-loud on missing OTEL_SEMCONV_STABILITY_OPT_IN), DI, + Magentic span hooks (`RecordPlanCreatedWithContent`/`RecordReplannedWithContent`/`RecordResetReason`)
4. `ContentCaptureConfigValidator` (FluentValidation), 63-test suite, observability blueprint docs

## Design
- **OFF by default** — master `Enabled` + per-attribute toggles, all false. Requires the GenAi semconv opt-in env var; misconfig fails loud at boot.
- **Redaction-first** — content is filtered through `DefaultContentRedactionFilter` before it ever reaches a span; conservative (over-redacts) by default.
- **Two-level gate** — `IContentCapturePolicy` gates each attribute; the master flag short-circuits all.

## Rebase notes
Rebased onto current main (post PR-9). Resolved `AIConfig` (GitOps + Telemetry coexist), wired the two new `MagenticEventSubscriber` deps through `MagenticOrchestrator`, and fixed a Domain.Common→Domain.AI layering leak in `ContentCaptureConfig` (literal category names instead of cross-layer `nameof`).

## Test plan
- `dotnet build src/AgenticHarness.slnx` → 0 errors
- 63 new tests green (filter, policy, startup validator, DI, config validator, + the '7f' ActivityListener integration test asserting redacted content on Magentic spans and none when off). Full Magentic regression green.
- Full suite green except pre-existing flaky KnowledgeGraph Docker-Testcontainers E2E (unrelated; PR-11 touches no KnowledgeGraph code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)