### PR TITLE
feat(iac): IaC skill pack — Terraform + Bicep parity, sandboxed plan/scan, gate integration (PR-10)

### DIFF
--- a/plugins/iac-skill/README.md
+++ b/plugins/iac-skill/README.md
@@ -1,0 +1,59 @@
+# IaC Skill Pack
+
+Scaffold, validate, plan, and security-scan **Terraform** and **Bicep**
+infrastructure-as-code — without ever deploying.
+
+## Design principles
+
+- **Plan and scan only — never deploy.** No skill in this pack can run
+  `terraform apply`, `az deployment create`, or `kubectl apply`. Those tools are
+  explicitly denied on every skill and the denial is bypass-immune. The skill
+  produces a plan + a scan verdict; applying the change is the gate pipeline's job.
+- **Fixes flow through ChangeProposal.** The generator scaffolds files and the
+  agent submits them as a `ChangeProposal` against the configured Git repository.
+  The IaC validator (`iac_plan_scan`) runs inside the `SelfValidationGate` and
+  blocks any proposal whose plan errors, shows unexpected destructive changes, or
+  fails the security scan.
+- **Backend-neutral.** Skills talk to `IIacGenerator`; Terraform and Bicep ship
+  with parity so the template does not cloud-lock by shipping Bicep alone. A third
+  backend (Pulumi, CloudFormation) is added by implementing `IIacGenerator` and
+  registering it under a new keyed-DI key.
+- **Sandboxed CLIs.** Every CLI run — `terraform`, `bicep`, `checkov`, `tfsec`,
+  `arm-ttk` — executes inside the PR-3 sandbox with the egress allowlist scoped to
+  the provider/module registries. The generator never spawns a process on the host.
+
+## Skills
+
+| Skill | Purpose | Tools |
+|-------|---------|-------|
+| `iac-authoring` | Scaffold a module, plan it, and security-scan it before proposing | `iac_generate`, `iac_plan`, `iac_scan` |
+
+## Configuration
+
+Bind under `AppConfig:AI:Iac`:
+
+```json
+{
+  "AI": {
+    "Iac": {
+      "Enabled": true,
+      "EnabledBackends": ["terraform", "bicep"],
+      "TerraformVersion": "1.9.5",
+      "BicepVersion": "0.30.23",
+      "CheckovVersion": "3.2.0",
+      "TfsecVersion": "1.28.11",
+      "ArmTtkVersion": "0.24",
+      "BlockingSeverity": "High",
+      "RegistryAllowlist": [
+        "registry.terraform.io",
+        "releases.hashicorp.com",
+        "mcr.microsoft.com"
+      ]
+    }
+  }
+}
+```
+
+When enabled, `IacStartupValidator` requires each enabled backend to carry a pinned
+CLI version, a valid `BlockingSeverity`, and a non-empty `RegistryAllowlist`.
+Misconfiguration fails loud at boot rather than shipping a half-working skill.

--- a/plugins/iac-skill/plugin.json
+++ b/plugins/iac-skill/plugin.json
@@ -1,0 +1,21 @@
+{
+  "name": "iac-skill",
+  "description": "Infrastructure-as-code skill pack: scaffold Terraform/Bicep modules, validate and plan them, and security-scan with Checkov, tfsec, and ARM-TTK. Plan/scan only — the skill never deploys; all fixes flow through ChangeProposal and the gate pipeline.",
+  "version": "1.0.0",
+  "author": {
+    "name": "Microsoft Agentic Harness",
+    "url": "https://github.com/MCKRUZ/microsoft-agentic-harness"
+  },
+  "license": "MIT",
+  "keywords": [
+    "iac",
+    "terraform",
+    "bicep",
+    "checkov",
+    "tfsec",
+    "arm-ttk",
+    "change-proposal",
+    "devops"
+  ],
+  "skills": "./skills/"
+}

--- a/plugins/iac-skill/skills/iac-authoring/SKILL.md
+++ b/plugins/iac-skill/skills/iac-authoring/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: "iac-authoring"
+description: "Scaffold a Terraform or Bicep module, validate and plan it, and security-scan it before proposing the change. Plan and scan only — this skill never deploys."
+category: "devops"
+skill_type: "execution"
+version: "1.0.0"
+tags: ["iac", "terraform", "bicep", "checkov", "tfsec", "arm-ttk"]
+allowed-tools: ["iac_generate", "iac_plan", "iac_scan"]
+denied-tools: ["terraform_apply", "az_deployment_create", "kubectl_apply", "shell_exec", "raw_filesystem"]
+sandbox-required: true
+tools:
+  - name: "iac_generate"
+    operations: ["generate"]
+    optional: false
+    description: "Scaffold a starter module (main.tf/variables.tf for Terraform, main.bicep for Bicep) for a resource type and name."
+  - name: "iac_plan"
+    operations: ["plan"]
+    optional: false
+    description: "Validate and plan the module inside the sandbox; reports success, changes, and any destructive changes."
+  - name: "iac_scan"
+    operations: ["scan"]
+    optional: false
+    description: "Security-scan the module (Checkov + tfsec / ARM-TTK + Checkov); reports normalised findings and a pass/fail verdict."
+egress:
+  allowlist:
+    - "registry.terraform.io"
+    - "releases.hashicorp.com"
+    - "mcr.microsoft.com"
+---
+
+You are the IaC authoring skill. You scaffold infrastructure-as-code modules,
+validate and plan them, and security-scan them — then hand the result to the
+change pipeline. You do not deploy anything.
+
+## Capabilities
+
+- `iac_generate` — scaffold a starter module for a `resource_type` and
+  `resource_name`. Pass `backend` (`terraform` / `bicep`) to override the default,
+  `environment` to drive tags, and `parameters` for backend-specific attributes.
+- `iac_plan` — validate and plan the module at `module_directory`. Returns whether
+  the plan succeeded, whether it has changes, and whether it has destructive
+  changes (resource replacement / deletion).
+- `iac_scan` — security-scan the module at `module_directory`. Returns the
+  normalised findings and whether the scan passed the configured blocking severity.
+
+## Hard rules
+
+1. **Plan and scan only.** No deploy tools — `terraform apply`,
+   `az deployment create`, `kubectl apply` are denied and bypass-immune. This skill
+   cannot, by design, change real infrastructure.
+2. **Scan before you propose.** Always run `iac_scan` after `iac_plan`. A clean
+   plan with a failing scan is not a safe change.
+3. **Treat destructive plans as a stop sign.** If `iac_plan` reports destructive
+   changes, surface them plainly and do not propose the change without explicit
+   human direction — the gate will refuse it anyway.
+4. **Fixes flow through ChangeProposal.** Submit the scaffolded + reviewed module as
+   a `ChangeProposal`; let the `iac_plan_scan` validator and the gate pipeline
+   decide. Never write to the cloud directly.
+
+## Approach
+
+1. `iac_generate` the starter module for the requested resource.
+2. Refine the module to satisfy the requirement and the security baseline.
+3. `iac_plan` to confirm it validates and to inspect the change set.
+4. `iac_scan` to confirm it clears the blocking severity.
+5. Submit the result as a `ChangeProposal` — then stop. Applying is out of scope.
+
+## Objectives
+
+- Produce a module that validates and plans cleanly.
+- Clear the configured blocking severity in the scan.
+- Flag destructive changes for human review rather than papering over them.

--- a/src/Content/Application/Application.AI.Common/Interfaces/Iac/IIacGenerator.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Iac/IIacGenerator.cs
@@ -1,0 +1,61 @@
+using Domain.AI.Iac;
+using Domain.Common;
+
+namespace Application.AI.Common.Interfaces.Iac;
+
+/// <summary>
+/// Backend-neutral infrastructure-as-code surface: scaffold a module, validate +
+/// plan it, and security-scan it. The load-bearing abstraction behind the IaC
+/// skill pack (PR-10) — Terraform and Bicep ship with parity, and consumers add
+/// a third backend by implementing this interface and registering it under a new
+/// keyed-DI key.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Implementations are registered as keyed singletons under the backend's
+/// canonical key (<see cref="IacBackendKeys"/>: <c>"terraform"</c> / <c>"bicep"</c>),
+/// so the validator and tools resolve the right backend by the
+/// <c>IacDeploymentTarget.Backend</c> string.
+/// </para>
+/// <para>
+/// <see cref="PlanAsync"/> and <see cref="ScanAsync"/> shell out to the backend
+/// CLIs (terraform / bicep / checkov / tfsec / arm-ttk) <b>inside the PR-3
+/// sandbox</b> with the egress allowlist scoped to the relevant registries — the
+/// implementation never spawns processes on the host directly. The skill never
+/// deploys: there is intentionally no <c>ApplyAsync</c> on this surface.
+/// </para>
+/// </remarks>
+public interface IIacGenerator
+{
+    /// <summary>The backend this generator implements. Matches its keyed-DI registration key.</summary>
+    IacBackend Backend { get; }
+
+    /// <summary>
+    /// Scaffolds a starter module for the requested resource. Deterministic
+    /// templating — not an LLM call. The caller submits the result as a
+    /// <c>ChangeProposal</c>.
+    /// </summary>
+    /// <param name="request">The typed scaffold request.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns><see cref="Result{T}.Success"/> with the generated files, or <see cref="Result{T}.Fail(string[])"/> with a stable <c>iac.*</c> code.</returns>
+    Task<Result<IacGenerationResult>> GenerateAsync(IacGenerationRequest request, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Validates and plans the module at <paramref name="moduleDirectory"/> by
+    /// running the backend's validate/plan CLI inside the sandbox.
+    /// </summary>
+    /// <param name="moduleDirectory">The sandbox-rooted directory containing the module.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns><see cref="Result{T}.Success"/> with the plan outcome, or <see cref="Result{T}.Fail(string[])"/> with a stable <c>iac.*</c> code.</returns>
+    Task<Result<IacPlanResult>> PlanAsync(string moduleDirectory, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Security-scans the module at <paramref name="moduleDirectory"/> by running
+    /// the backend's scanners (Checkov + tfsec / ARM-TTK + Checkov) inside the
+    /// sandbox and normalising their findings.
+    /// </summary>
+    /// <param name="moduleDirectory">The sandbox-rooted directory containing the module.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns><see cref="Result{T}.Success"/> with the scan outcome, or <see cref="Result{T}.Fail(string[])"/> with a stable <c>iac.*</c> code.</returns>
+    Task<Result<IacScanResult>> ScanAsync(string moduleDirectory, CancellationToken cancellationToken);
+}

--- a/src/Content/Application/Application.Core/Validation/IacConfigValidator.cs
+++ b/src/Content/Application/Application.Core/Validation/IacConfigValidator.cs
@@ -1,0 +1,66 @@
+using Domain.AI.Iac;
+using Domain.Common.Config.AI.Iac;
+using FluentValidation;
+
+namespace Application.Core.Validation;
+
+/// <summary>
+/// Validates <see cref="IacConfig"/>. All rules are conditional on
+/// <see cref="IacConfig.Enabled"/> — a disabled skill pack imposes no constraints so
+/// the template runs out of the box. When enabled the rules mirror
+/// <c>IacStartupValidator</c> so a misconfiguration is caught both by the
+/// options-validation pipeline and at host boot.
+/// </summary>
+public sealed class IacConfigValidator : AbstractValidator<IacConfig>
+{
+    private static readonly string[] KnownBackends = [IacBackendKeys.Terraform, IacBackendKeys.Bicep];
+
+    /// <summary>Initializes a new instance of the <see cref="IacConfigValidator"/> class.</summary>
+    public IacConfigValidator()
+    {
+        When(x => x.Enabled, () =>
+        {
+            RuleFor(x => x.EnabledBackends)
+                .NotEmpty()
+                .WithMessage("EnabledBackends must contain at least one backend when IaC is enabled.")
+                .Must(AllKnown)
+                .WithMessage("EnabledBackends may only contain \"terraform\" or \"bicep\" when IaC is enabled.");
+
+            RuleFor(x => x.BlockingSeverity)
+                .Must(s => IacScanSeverityParser.TryParse(s, out _))
+                .WithMessage("BlockingSeverity must be one of Low, Medium, High, Critical when IaC is enabled.");
+
+            RuleFor(x => x.RegistryAllowlist)
+                .NotEmpty()
+                .WithMessage("RegistryAllowlist must be non-empty when IaC is enabled (plan/scan need registry egress).");
+
+            When(BackendEnabled(IacBackendKeys.Terraform), () =>
+            {
+                RuleFor(x => x.TerraformVersion).NotEmpty()
+                    .WithMessage("TerraformVersion is required when terraform is enabled.");
+                RuleFor(x => x.CheckovVersion).NotEmpty()
+                    .WithMessage("CheckovVersion is required when terraform is enabled.");
+                RuleFor(x => x.TfsecVersion).NotEmpty()
+                    .WithMessage("TfsecVersion is required when terraform is enabled.");
+            });
+
+            When(BackendEnabled(IacBackendKeys.Bicep), () =>
+            {
+                RuleFor(x => x.BicepVersion).NotEmpty()
+                    .WithMessage("BicepVersion is required when bicep is enabled.");
+                RuleFor(x => x.ArmTtkVersion).NotEmpty()
+                    .WithMessage("ArmTtkVersion is required when bicep is enabled.");
+                RuleFor(x => x.CheckovVersion).NotEmpty()
+                    .WithMessage("CheckovVersion is required when bicep is enabled.");
+            });
+        });
+    }
+
+    private static bool AllKnown(List<string> backends)
+        => backends is { Count: > 0 }
+           && backends.All(b => KnownBackends.Contains(b?.Trim().ToLowerInvariant()));
+
+    private static Func<IacConfig, bool> BackendEnabled(string key)
+        => config => config.EnabledBackends is { Count: > 0 }
+                     && config.EnabledBackends.Any(b => string.Equals(b?.Trim(), key, StringComparison.OrdinalIgnoreCase));
+}

--- a/src/Content/Domain/Domain.AI/Iac/IacBackend.cs
+++ b/src/Content/Domain/Domain.AI/Iac/IacBackend.cs
@@ -1,0 +1,68 @@
+namespace Domain.AI.Iac;
+
+/// <summary>
+/// The infrastructure-as-code backend a generation / plan / scan operation
+/// targets. Each value maps to a keyed <c>IIacGenerator</c> registration and to
+/// the <c>backend</c> string carried on an <c>IacDeploymentTarget</c>.
+/// </summary>
+/// <remarks>
+/// The harness ships Terraform and Bicep with parity per the PR-10 plan — the
+/// template must not implicitly cloud-lock by shipping Bicep alone. Consumers add
+/// a third backend (e.g. Pulumi, CloudFormation) by implementing
+/// <c>IIacGenerator</c> and registering it under a new key; this enum is the
+/// first-party set, not a closed universe.
+/// </remarks>
+public enum IacBackend
+{
+    /// <summary>HashiCorp Terraform (<c>terraform validate</c> / <c>plan</c>; Checkov + tfsec scanners).</summary>
+    Terraform = 0,
+
+    /// <summary>Azure Bicep (<c>bicep build</c>; ARM-TTK + Checkov scanners).</summary>
+    Bicep = 1
+}
+
+/// <summary>
+/// Maps <see cref="IacBackend"/> values to and from their canonical lowercase
+/// string keys — the keys used for keyed-DI resolution and on
+/// <c>IacDeploymentTarget.Backend</c>.
+/// </summary>
+public static class IacBackendKeys
+{
+    /// <summary>Canonical key for <see cref="IacBackend.Terraform"/>.</summary>
+    public const string Terraform = "terraform";
+
+    /// <summary>Canonical key for <see cref="IacBackend.Bicep"/>.</summary>
+    public const string Bicep = "bicep";
+
+    /// <summary>Returns the canonical lowercase key for a backend value.</summary>
+    /// <param name="backend">The backend to convert.</param>
+    /// <returns>The canonical key string.</returns>
+    public static string ToKey(this IacBackend backend) => backend switch
+    {
+        IacBackend.Terraform => Terraform,
+        IacBackend.Bicep => Bicep,
+        _ => backend.ToString().ToLowerInvariant()
+    };
+
+    /// <summary>
+    /// Parses a backend key (case-insensitive) to an <see cref="IacBackend"/>.
+    /// </summary>
+    /// <param name="key">The backend key, e.g. <c>"terraform"</c> or <c>"bicep"</c>.</param>
+    /// <param name="backend">The parsed backend when the key is recognised.</param>
+    /// <returns><see langword="true"/> when the key maps to a known backend; otherwise <see langword="false"/>.</returns>
+    public static bool TryParse(string? key, out IacBackend backend)
+    {
+        switch (key?.Trim().ToLowerInvariant())
+        {
+            case Terraform:
+                backend = IacBackend.Terraform;
+                return true;
+            case Bicep:
+                backend = IacBackend.Bicep;
+                return true;
+            default:
+                backend = default;
+                return false;
+        }
+    }
+}

--- a/src/Content/Domain/Domain.AI/Iac/IacGenerationRequest.cs
+++ b/src/Content/Domain/Domain.AI/Iac/IacGenerationRequest.cs
@@ -1,0 +1,34 @@
+namespace Domain.AI.Iac;
+
+/// <summary>
+/// A typed request to scaffold an infrastructure-as-code module. Deterministic —
+/// the generator templates a starter module from these fields; it is NOT an LLM
+/// call. The agent refines the scaffold afterwards and submits the result as a
+/// <c>ChangeProposal</c>.
+/// </summary>
+public sealed record IacGenerationRequest
+{
+    /// <summary>The IaC backend to scaffold for (Terraform or Bicep).</summary>
+    public required IacBackend Backend { get; init; }
+
+    /// <summary>
+    /// The cloud resource type to scaffold, in the backend's own vocabulary
+    /// (e.g. <c>azurerm_storage_account</c> for Terraform, <c>Microsoft.Storage/storageAccounts</c>
+    /// for Bicep). Required.
+    /// </summary>
+    public required string ResourceType { get; init; }
+
+    /// <summary>The logical name for the scaffolded resource (e.g. <c>primary</c>, <c>app_data</c>). Required.</summary>
+    public required string ResourceName { get; init; }
+
+    /// <summary>The target environment (<c>dev</c>, <c>staging</c>, <c>prod</c>). Drives default tags and naming.</summary>
+    public string Environment { get; init; } = "dev";
+
+    /// <summary>
+    /// Optional backend-specific parameters folded into the scaffold (e.g.
+    /// <c>location=eastus</c>, <c>sku=Standard_LRS</c>). Keys/values are emitted
+    /// verbatim into the templated module.
+    /// </summary>
+    public IReadOnlyDictionary<string, string> Parameters { get; init; } =
+        new Dictionary<string, string>();
+}

--- a/src/Content/Domain/Domain.AI/Iac/IacGenerationResult.cs
+++ b/src/Content/Domain/Domain.AI/Iac/IacGenerationResult.cs
@@ -1,0 +1,19 @@
+namespace Domain.AI.Iac;
+
+/// <summary>
+/// The output of scaffolding an IaC module — the generated files keyed by their
+/// relative path. The agent typically submits these as the edits of a
+/// <c>ChangeProposal</c> (a <c>GitRepoTarget</c>); the scaffold never writes to
+/// disk or the cluster itself.
+/// </summary>
+public sealed record IacGenerationResult
+{
+    /// <summary>The backend the files were scaffolded for.</summary>
+    public required IacBackend Backend { get; init; }
+
+    /// <summary>
+    /// The generated files, keyed by relative path (e.g. <c>main.tf</c>,
+    /// <c>variables.tf</c>, <c>main.bicep</c>) to file content.
+    /// </summary>
+    public required IReadOnlyDictionary<string, string> Files { get; init; }
+}

--- a/src/Content/Domain/Domain.AI/Iac/IacPlanResult.cs
+++ b/src/Content/Domain/Domain.AI/Iac/IacPlanResult.cs
@@ -1,0 +1,34 @@
+namespace Domain.AI.Iac;
+
+/// <summary>
+/// The outcome of validating and planning an IaC module — <c>terraform validate</c>
+/// + <c>terraform plan</c> for Terraform, <c>bicep build</c> for Bicep. Carries
+/// enough signal for a gate to decide whether the change is safe to advance.
+/// </summary>
+public sealed record IacPlanResult
+{
+    /// <summary>The backend that produced the plan.</summary>
+    public required IacBackend Backend { get; init; }
+
+    /// <summary>The module path that was planned (relative to the sandbox working copy).</summary>
+    public required string ModulePath { get; init; }
+
+    /// <summary>Whether validation + plan succeeded (the module is syntactically and semantically valid).</summary>
+    public required bool Succeeded { get; init; }
+
+    /// <summary>Whether the plan reports any changes to apply. False means the module is already in the desired state.</summary>
+    public bool HasChanges { get; init; }
+
+    /// <summary>
+    /// Whether the plan includes destructive changes — resource replacement or
+    /// deletion. A merge gate must refuse to auto-advance a plan with destructive
+    /// changes outside the diff's declared scope.
+    /// </summary>
+    public bool HasDestructiveChanges { get; init; }
+
+    /// <summary>The raw CLI output of the validate/plan run, retained as gate evidence.</summary>
+    public string RawOutput { get; init; } = string.Empty;
+
+    /// <summary>A short human-readable summary of the plan (e.g. "3 to add, 1 to change, 0 to destroy").</summary>
+    public string Summary { get; init; } = string.Empty;
+}

--- a/src/Content/Domain/Domain.AI/Iac/IacScanFinding.cs
+++ b/src/Content/Domain/Domain.AI/Iac/IacScanFinding.cs
@@ -1,0 +1,23 @@
+namespace Domain.AI.Iac;
+
+/// <summary>
+/// A single IaC security-scan finding, normalised from a backend scanner
+/// (Checkov, tfsec, or ARM-TTK) into a scanner-neutral shape.
+/// </summary>
+public sealed record IacScanFinding
+{
+    /// <summary>The scanner that produced the finding (<c>checkov</c>, <c>tfsec</c>, <c>arm-ttk</c>).</summary>
+    public required string Scanner { get; init; }
+
+    /// <summary>The scanner's rule / check identifier (e.g. <c>CKV_AZURE_33</c>, <c>azure-storage-default-action-deny</c>).</summary>
+    public required string RuleId { get; init; }
+
+    /// <summary>The finding severity, normalised to the shared scale.</summary>
+    public required IacScanSeverity Severity { get; init; }
+
+    /// <summary>The resource / template element the finding relates to (e.g. <c>azurerm_storage_account.primary</c>).</summary>
+    public string Resource { get; init; } = string.Empty;
+
+    /// <summary>Short, human-readable description of the finding.</summary>
+    public string Message { get; init; } = string.Empty;
+}

--- a/src/Content/Domain/Domain.AI/Iac/IacScanResult.cs
+++ b/src/Content/Domain/Domain.AI/Iac/IacScanResult.cs
@@ -1,0 +1,26 @@
+namespace Domain.AI.Iac;
+
+/// <summary>
+/// The aggregated outcome of running the backend's security scanners over an IaC
+/// module — Checkov + tfsec for Terraform, ARM-TTK + Checkov for Bicep.
+/// </summary>
+public sealed record IacScanResult
+{
+    /// <summary>The backend whose module was scanned.</summary>
+    public required IacBackend Backend { get; init; }
+
+    /// <summary>The module path that was scanned (relative to the sandbox working copy).</summary>
+    public required string ModulePath { get; init; }
+
+    /// <summary>
+    /// Whether the scan passed the gate's policy. Convention: pass when there are
+    /// no findings at or above the configured blocking severity (default High).
+    /// </summary>
+    public required bool Passed { get; init; }
+
+    /// <summary>The scanners that ran (e.g. <c>["checkov", "tfsec"]</c>). Empty means no scanner produced output.</summary>
+    public IReadOnlyList<string> ScannersRun { get; init; } = [];
+
+    /// <summary>All normalised findings across the scanners that ran.</summary>
+    public IReadOnlyList<IacScanFinding> Findings { get; init; } = [];
+}

--- a/src/Content/Domain/Domain.AI/Iac/IacScanSeverity.cs
+++ b/src/Content/Domain/Domain.AI/Iac/IacScanSeverity.cs
@@ -1,0 +1,20 @@
+namespace Domain.AI.Iac;
+
+/// <summary>
+/// Severity classification of an IaC security-scan finding, normalised across
+/// the backend scanners (Checkov, tfsec, ARM-TTK) into one ordered scale.
+/// </summary>
+public enum IacScanSeverity
+{
+    /// <summary>Informational / style — no security impact.</summary>
+    Low = 0,
+
+    /// <summary>A weak default or missing hardening that should be addressed.</summary>
+    Medium = 1,
+
+    /// <summary>A misconfiguration with real exposure (e.g. public storage, open security group).</summary>
+    High = 2,
+
+    /// <summary>A critical exposure (e.g. plaintext secret, world-writable resource) — must block.</summary>
+    Critical = 3
+}

--- a/src/Content/Domain/Domain.AI/Iac/IacScanSeverityParser.cs
+++ b/src/Content/Domain/Domain.AI/Iac/IacScanSeverityParser.cs
@@ -1,0 +1,35 @@
+namespace Domain.AI.Iac;
+
+/// <summary>
+/// Parses the configured <c>BlockingSeverity</c> string into the shared
+/// <see cref="IacScanSeverity"/> scale, and decides scan pass/fail against it.
+/// Lives in the Domain so both the Application-layer config validator and the
+/// Infrastructure-layer generators/startup validator agree on what counts as a
+/// valid severity and what blocks a proposal.
+/// </summary>
+public static class IacScanSeverityParser
+{
+    /// <summary>
+    /// Parses a blocking-severity string (case-insensitive) into an
+    /// <see cref="IacScanSeverity"/>.
+    /// </summary>
+    /// <param name="value">The configured severity, e.g. <c>"High"</c>.</param>
+    /// <param name="severity">The parsed severity when recognised.</param>
+    /// <returns><see langword="true"/> when the value maps to a known severity; otherwise <see langword="false"/>.</returns>
+    public static bool TryParse(string? value, out IacScanSeverity severity)
+        => Enum.TryParse(value?.Trim(), ignoreCase: true, out severity)
+           && Enum.IsDefined(severity);
+
+    /// <summary>
+    /// Decides whether a scan passes the gate: it passes when no finding is at or
+    /// above the configured blocking severity.
+    /// </summary>
+    /// <param name="findings">The normalised findings across the scanners that ran.</param>
+    /// <param name="blocking">The minimum severity that blocks a proposal.</param>
+    /// <returns><see langword="true"/> when no finding meets or exceeds <paramref name="blocking"/>.</returns>
+    public static bool Passes(IEnumerable<IacScanFinding> findings, IacScanSeverity blocking)
+    {
+        ArgumentNullException.ThrowIfNull(findings);
+        return !findings.Any(f => f.Severity >= blocking);
+    }
+}

--- a/src/Content/Domain/Domain.Common/Config/AI/AIConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/AIConfig.cs
@@ -4,6 +4,7 @@ using Domain.Common.Config.AI.ContextManagement;
 using Domain.Common.Config.AI.DriftDetection;
 using Domain.Common.Config.AI.GitOps;
 using Domain.Common.Config.AI.Hooks;
+using Domain.Common.Config.AI.Iac;
 using Domain.Common.Config.AI.Identity;
 using Domain.Common.Config.AI.IncidentResponse;
 using Domain.Common.Config.AI.Learnings;
@@ -235,6 +236,14 @@ public class AIConfig
     /// skill at runtime.
     /// </summary>
     public GitOpsConfig GitOps { get; set; } = new();
+
+    /// <summary>
+    /// IaC skill pack configuration (PR-10). Off by default — when enabled, the
+    /// startup validator requires each enabled backend (terraform/bicep) to carry
+    /// a pinned CLI version and a valid blocking-severity. Generation/plan/scan
+    /// run inside the PR-3 sandbox; the skill never deploys.
+    /// </summary>
+    public IacConfig Iac { get; set; } = new();
 
     /// <summary>
     /// Telemetry-layer configuration (PR-11). Wraps the OTel GenAI

--- a/src/Content/Domain/Domain.Common/Config/AI/Iac/IacConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/Iac/IacConfig.cs
@@ -1,0 +1,65 @@
+namespace Domain.Common.Config.AI.Iac;
+
+/// <summary>
+/// Configuration for the IaC skill pack (PR-10). Bound from <c>AppConfig:AI:Iac</c>.
+/// Off by default — the skill pack and its tools are inert until <see cref="Enabled"/>
+/// is true.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The five backend CLIs (terraform, bicep, checkov, tfsec, arm-ttk) run inside
+/// the PR-3 sandbox and are pinned to verified versions baked into the sandbox
+/// image. The version pins below are advisory metadata surfaced to the runners and
+/// validated at boot; they do not install anything.
+/// </para>
+/// <para>
+/// Generation, plan, and scan need outbound access only to the provider/module
+/// registries. <see cref="RegistryAllowlist"/> seeds the sandbox egress allowlist
+/// for IaC runs; it defaults to the HashiCorp and Microsoft registries.
+/// </para>
+/// </remarks>
+public sealed class IacConfig
+{
+    /// <summary>Master toggle. When false the skill pack and all IaC tools are inert. Default false.</summary>
+    public bool Enabled { get; set; }
+
+    /// <summary>
+    /// The backends to enable, by key (<c>"terraform"</c>, <c>"bicep"</c>).
+    /// Defaults to both — parity. The startup validator refuses to boot when
+    /// enabled with an empty or unknown entry.
+    /// </summary>
+    public List<string> EnabledBackends { get; set; } = ["terraform", "bicep"];
+
+    /// <summary>Pinned Terraform CLI version (baked into the sandbox image). Validated for non-empty when terraform is enabled.</summary>
+    public string TerraformVersion { get; set; } = "1.9.5";
+
+    /// <summary>Pinned Bicep CLI version.</summary>
+    public string BicepVersion { get; set; } = "0.30.23";
+
+    /// <summary>Pinned Checkov version (shared by both backends).</summary>
+    public string CheckovVersion { get; set; } = "3.2.0";
+
+    /// <summary>Pinned tfsec version (Terraform scanner).</summary>
+    public string TfsecVersion { get; set; } = "1.28.11";
+
+    /// <summary>Pinned ARM-TTK version (Bicep scanner).</summary>
+    public string ArmTtkVersion { get; set; } = "0.24";
+
+    /// <summary>
+    /// The minimum scan-finding severity that blocks a proposal. Findings below
+    /// this are reported but do not fail the gate. One of <c>Low</c>, <c>Medium</c>,
+    /// <c>High</c>, <c>Critical</c>. Default <c>High</c>.
+    /// </summary>
+    public string BlockingSeverity { get; set; } = "High";
+
+    /// <summary>
+    /// Hosts the IaC sandbox runs may reach (provider/module registries). Seeds the
+    /// sandbox egress allowlist for plan/scan runs.
+    /// </summary>
+    public List<string> RegistryAllowlist { get; set; } =
+    [
+        "registry.terraform.io",
+        "releases.hashicorp.com",
+        "mcr.microsoft.com"
+    ];
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.Iac.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.Iac.cs
@@ -1,0 +1,53 @@
+using Application.AI.Common.Interfaces.Changes;
+using Domain.AI.Changes;
+using Infrastructure.AI.Iac;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Infrastructure.AI;
+
+public static partial class DependencyInjection
+{
+    /// <summary>
+    /// Swaps the fail-loud <c>NotConfiguredValidator</c> placeholder registered for
+    /// <see cref="ChangeTargetKind.IacDeployment"/> (inside
+    /// <see cref="RegisterChangesServices"/>) for the real
+    /// <see cref="IacChangeProposalValidator"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The placeholder is registered later in the composition order than the IaC
+    /// skill tools, so this swap MUST run after <see cref="RegisterChangesServices"/>.
+    /// It removes every keyed <see cref="IChangeProposalValidator"/> descriptor for
+    /// the IaC target kind (there is exactly one — the placeholder — but the loop is
+    /// defensive against future additions) and registers the real validator under the
+    /// same key. The <c>SelfValidationGate</c> then enumerates only the real validator
+    /// for IaC proposals.
+    /// </para>
+    /// <para>
+    /// Registered as a keyed singleton resolving <see cref="IServiceProvider"/> so the
+    /// validator can look up the backend <c>IIacGenerator</c> by the target's backend
+    /// string at evaluation time.
+    /// </para>
+    /// </remarks>
+    /// <param name="services">The service collection to mutate.</param>
+    private static void RegisterIacValidator(IServiceCollection services)
+    {
+        var placeholders = services
+            .Where(d => d.ServiceType == typeof(IChangeProposalValidator)
+                        && d.IsKeyedService
+                        && Equals(d.ServiceKey, ChangeTargetKind.IacDeployment))
+            .ToList();
+
+        foreach (var descriptor in placeholders)
+        {
+            services.Remove(descriptor);
+        }
+
+        services.AddKeyedSingleton<IChangeProposalValidator>(
+            ChangeTargetKind.IacDeployment,
+            static (sp, _) => new IacChangeProposalValidator(
+                sp,
+                sp.GetRequiredService<ILogger<IacChangeProposalValidator>>()));
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.cs
@@ -19,6 +19,7 @@ using Infrastructure.AI.Audit;
 using Infrastructure.AI.Compaction;
 using Infrastructure.AI.Compaction.Strategies;
 using Infrastructure.AI.Tools.GitOps;
+using Infrastructure.AI.Tools.Iac;
 using Infrastructure.AI.Tools.Workspace;
 using Infrastructure.AI.Compression;
 using Infrastructure.AI.Compression.Strategies;
@@ -133,6 +134,12 @@ public static partial class DependencyInjection
         // unconditionally; GitOpsStartupValidator fails the host loud when Enabled with bad config.
         services.AddGitOpsSkillTools();
 
+        // IaC skill pack — iac_generate (scaffold), iac_plan (validate+plan), iac_scan (Checkov/tfsec/ARM-TTK).
+        // Terraform + Bicep generators behind IIacGenerator, keyed by backend. All CLI work runs inside the
+        // PR-3 sandbox; the skill never deploys. Registered unconditionally; IacStartupValidator fails the host
+        // loud when Enabled with bad config. The IaC validator swap happens after RegisterChangesServices below.
+        services.AddIacSkillTools();
+
         // Chat client factory — creates IChatClient from Azure OpenAI / OpenAI / AI Inference / Persistent Agents
         services.AddSingleton<IChatClientFactory, ChatClientFactory>();
 
@@ -218,6 +225,13 @@ public static partial class DependencyInjection
         //     NotConfigured defaults). Inert until AppConfig.AI.Changes.Enabled. ---
 
         RegisterChangesServices(services);
+
+        // --- Swap the IaC NotConfiguredValidator placeholder (registered inside
+        //     RegisterChangesServices, keyed by ChangeTargetKind.IacDeployment) for
+        //     the real IacChangeProposalValidator. Must run AFTER RegisterChangesServices
+        //     so the placeholder exists to remove. See RegisterIacValidator. ---
+
+        RegisterIacValidator(services);
 
         // --- Egress layer (per-skill allowlist policy + AntiSSRF terminal
         //     handler + JSONL audit + named HttpClient "egress"). Inert until

--- a/src/Content/Infrastructure/Infrastructure.AI/Iac/ArmTtkParser.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Iac/ArmTtkParser.cs
@@ -1,0 +1,101 @@
+using System.Text.RegularExpressions;
+using Domain.AI.Iac;
+
+namespace Infrastructure.AI.Iac;
+
+/// <summary>
+/// Parses ARM-TTK (Azure Resource Manager Template Toolkit) text output into the
+/// scanner-neutral <see cref="IacScanFinding"/> shape. Only failed tests become
+/// findings.
+/// </summary>
+/// <remarks>
+/// ARM-TTK marks each test with a leading status glyph; a failure is rendered as
+/// <c>[-]</c> and a pass as <c>[+]</c>:
+/// <code>
+/// [-] Secure-Params-No-Hardcoded-Default (12 ms)
+///         Parameter 'adminPassword' must not have a hardcoded default. Severity: High
+/// [+] DeploymentTemplate-Schema-Is-Correct (3 ms)
+/// </code>
+/// ARM-TTK does not assign a severity per test; the parser reads an explicit
+/// <c>Severity:</c> token on the detail line when present and otherwise treats a
+/// failed test as <see cref="IacScanSeverity.Medium"/>.
+/// </remarks>
+public static partial class ArmTtkParser
+{
+    private const string Scanner = "arm-ttk";
+
+    [GeneratedRegex(@"^\[-\]\s+(?<rule>[^\(]+?)(?:\s+\(\d+\s*ms\))?$", RegexOptions.Compiled)]
+    private static partial Regex FailedTestLine();
+
+    [GeneratedRegex(@"Severity:\s*(?<sev>\w+)", RegexOptions.Compiled | RegexOptions.IgnoreCase)]
+    private static partial Regex SeverityToken();
+
+    /// <summary>Parses ARM-TTK text output into failed-test findings.</summary>
+    /// <param name="output">The raw ARM-TTK stdout.</param>
+    /// <returns>One finding per failed test.</returns>
+    public static IReadOnlyList<IacScanFinding> Parse(string output)
+    {
+        if (string.IsNullOrWhiteSpace(output))
+        {
+            return [];
+        }
+
+        var findings = new List<IacScanFinding>();
+        string? rule = null;
+        var detail = new List<string>();
+
+        void Flush()
+        {
+            if (string.IsNullOrEmpty(rule))
+            {
+                return;
+            }
+
+            var joined = string.Join(" ", detail).Trim();
+            var severity = IacScanSeverity.Medium;
+            var sevMatch = SeverityToken().Match(joined);
+            if (sevMatch.Success && IacScanSeverityParser.TryParse(sevMatch.Groups["sev"].Value, out var parsed))
+            {
+                severity = parsed;
+            }
+
+            findings.Add(new IacScanFinding
+            {
+                Scanner = Scanner,
+                RuleId = rule.Trim(),
+                Severity = severity,
+                Resource = string.Empty,
+                Message = joined
+            });
+        }
+
+        foreach (var raw in output.Split('\n'))
+        {
+            var line = raw.Trim();
+            var failed = FailedTestLine().Match(line);
+            if (failed.Success)
+            {
+                Flush();
+                rule = failed.Groups["rule"].Value;
+                detail = [];
+                continue;
+            }
+
+            if (line.StartsWith("[+]", StringComparison.Ordinal))
+            {
+                Flush();
+                rule = null;
+                detail = [];
+                continue;
+            }
+
+            if (rule is not null && line.Length > 0)
+            {
+                detail.Add(line);
+            }
+        }
+
+        Flush();
+        return findings;
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Iac/BicepGenerator.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Iac/BicepGenerator.cs
@@ -1,0 +1,205 @@
+using Application.AI.Common.Interfaces.Iac;
+using Application.AI.Common.Interfaces.Sandbox;
+using Domain.AI.Iac;
+using Domain.AI.Sandbox;
+using Domain.Common;
+using Domain.Common.Config;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Infrastructure.AI.Iac;
+
+/// <summary>
+/// Bicep <see cref="IIacGenerator"/>. Scaffolds a starter <c>main.bicep</c>
+/// deterministically, validates it with <c>bicep build</c>, and security-scans it
+/// with ARM-TTK + Checkov — all CLI work runs inside the PR-3 sandbox via
+/// <see cref="IacSandboxRunner"/>. Never deploys: there is no apply.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>bicep build</c> compiles the template to ARM JSON; it surfaces syntax and
+/// semantic errors but does not compute a resource diff, so a successful build is
+/// reported as <see cref="IacPlanResult.Succeeded"/> with no change / destruction
+/// signal. The real what-if diff happens at apply time, which this skill never
+/// performs.
+/// </para>
+/// <para>
+/// Stable failure codes (<c>iac.*</c>): raw CLI stderr is logged via structured
+/// logging and never returned in a <see cref="Result"/> error, so a credential in
+/// a provider error can never leak into LLM context.
+/// </para>
+/// </remarks>
+public sealed class BicepGenerator : IIacGenerator
+{
+    private const string CliProgram = "bicep";
+    private const string ArmTtkProgram = "arm-ttk";
+    private const string CheckovProgram = "checkov";
+    private const string MainFile = "main.bicep";
+
+    private readonly IOptionsMonitor<AppConfig> _config;
+    private readonly ISandboxExecutor _sandbox;
+    private readonly ILogger<BicepGenerator> _logger;
+    private readonly TimeProvider _timeProvider;
+
+    /// <summary>Initialises a new <see cref="BicepGenerator"/>.</summary>
+    /// <param name="config">Application configuration monitor — supplies version pins, registry allowlist, and blocking severity.</param>
+    /// <param name="sandbox">The Process-isolation sandbox executor the CLIs run inside.</param>
+    /// <param name="logger">Structured logger.</param>
+    /// <param name="timeProvider">Clock abstraction (injected for parity and future use).</param>
+    public BicepGenerator(
+        IOptionsMonitor<AppConfig> config,
+        ISandboxExecutor sandbox,
+        ILogger<BicepGenerator> logger,
+        TimeProvider timeProvider)
+    {
+        ArgumentNullException.ThrowIfNull(config);
+        ArgumentNullException.ThrowIfNull(sandbox);
+        ArgumentNullException.ThrowIfNull(logger);
+        ArgumentNullException.ThrowIfNull(timeProvider);
+        _config = config;
+        _sandbox = sandbox;
+        _logger = logger;
+        _timeProvider = timeProvider;
+    }
+
+    /// <inheritdoc />
+    public IacBackend Backend => IacBackend.Bicep;
+
+    /// <inheritdoc />
+    public Task<Result<IacGenerationResult>> GenerateAsync(
+        IacGenerationRequest request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        if (string.IsNullOrWhiteSpace(request.ResourceType) || string.IsNullOrWhiteSpace(request.ResourceName))
+        {
+            return Task.FromResult(Result<IacGenerationResult>.Fail("iac.generate.invalid_request"));
+        }
+
+        var files = new Dictionary<string, string>
+        {
+            [MainFile] = BuildMainBicep(request)
+        };
+
+        return Task.FromResult(Result<IacGenerationResult>.Success(new IacGenerationResult
+        {
+            Backend = IacBackend.Bicep,
+            Files = files
+        }));
+    }
+
+    /// <inheritdoc />
+    public async Task<Result<IacPlanResult>> PlanAsync(string moduleDirectory, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(moduleDirectory))
+        {
+            return Result<IacPlanResult>.Fail("iac.plan.invalid_module_directory");
+        }
+
+        var allowlist = _config.CurrentValue.AI.Iac.RegistryAllowlist;
+
+        var build = await Run(CliProgram, [ "build", MainFile, "--stdout" ], moduleDirectory, allowlist, "iac_plan", cancellationToken);
+        if (build is null)
+        {
+            return Result<IacPlanResult>.Fail("iac.plan.sandbox_error");
+        }
+
+        if (!build.Success)
+        {
+            _logger.LogWarning("Bicep build failed in {Module}: exit={Exit}", moduleDirectory, build.ExitCode);
+        }
+
+        return Result<IacPlanResult>.Success(new IacPlanResult
+        {
+            Backend = IacBackend.Bicep,
+            ModulePath = moduleDirectory,
+            Succeeded = build.Success,
+            HasChanges = false,
+            HasDestructiveChanges = false,
+            RawOutput = build.Output ?? string.Empty,
+            Summary = build.Success ? "bicep build succeeded" : "bicep build failed"
+        });
+    }
+
+    /// <inheritdoc />
+    public async Task<Result<IacScanResult>> ScanAsync(string moduleDirectory, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(moduleDirectory))
+        {
+            return Result<IacScanResult>.Fail("iac.scan.invalid_module_directory");
+        }
+
+        var iac = _config.CurrentValue.AI.Iac;
+        if (!IacScanSeverityParser.TryParse(iac.BlockingSeverity, out var blocking))
+        {
+            return Result<IacScanResult>.Fail("iac.scan.invalid_blocking_severity");
+        }
+
+        var armTtk = await Run(ArmTtkProgram, [ "-TemplatePath", "." ], moduleDirectory, iac.RegistryAllowlist, "iac_scan", cancellationToken);
+        var checkov = await Run(CheckovProgram, [ "-d", ".", "--compact", "--quiet" ], moduleDirectory, iac.RegistryAllowlist, "iac_scan", cancellationToken);
+        if (armTtk is null || checkov is null)
+        {
+            return Result<IacScanResult>.Fail("iac.scan.sandbox_error");
+        }
+
+        var findings = new List<IacScanFinding>();
+        findings.AddRange(ArmTtkParser.Parse(armTtk.Output ?? string.Empty));
+        findings.AddRange(CheckovParser.Parse(checkov.Output ?? string.Empty));
+
+        return Result<IacScanResult>.Success(new IacScanResult
+        {
+            Backend = IacBackend.Bicep,
+            ModulePath = moduleDirectory,
+            Passed = IacScanSeverityParser.Passes(findings, blocking),
+            ScannersRun = [ArmTtkProgram, CheckovProgram],
+            Findings = findings
+        });
+    }
+
+    private async Task<SandboxExecutionResult?> Run(
+        string program,
+        IReadOnlyList<string> args,
+        string moduleDirectory,
+        IReadOnlyList<string> allowlist,
+        string toolName,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            return await IacSandboxRunner.RunAsync(program, args, moduleDirectory, allowlist, _sandbox, toolName, cancellationToken: cancellationToken);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Bicep sandbox run failed for {Program} in {Module}.", program, moduleDirectory);
+            return null;
+        }
+    }
+
+    private static string BuildMainBicep(IacGenerationRequest request)
+    {
+        var properties = string.Join(
+            "\n",
+            request.Parameters.Select(p => $"    {p.Key}: '{p.Value}'"));
+        var body = string.IsNullOrEmpty(properties) ? string.Empty : properties + "\n";
+
+        return $$"""
+            // Scaffolded by the Microsoft Agentic Harness IaC skill (Bicep).
+            param environment string = '{{request.Environment}}'
+
+            resource {{request.ResourceName}} '{{request.ResourceType}}@2023-01-01' = {
+              name: '{{request.ResourceName}}'
+              tags: {
+                environment: environment
+                managedBy: 'agentic-harness'
+              }
+              properties: {
+            {{body}}  }
+            }
+            """;
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Iac/CheckovParser.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Iac/CheckovParser.cs
@@ -1,0 +1,109 @@
+using System.Text.RegularExpressions;
+using Domain.AI.Iac;
+
+namespace Infrastructure.AI.Iac;
+
+/// <summary>
+/// Parses Checkov's compact text output (<c>checkov -d . --compact</c>) into the
+/// scanner-neutral <see cref="IacScanFinding"/> shape. Only failed checks become
+/// findings — passed checks are not security issues.
+/// </summary>
+/// <remarks>
+/// Checkov's compact output emits one block per check; a failed check looks like:
+/// <code>
+/// Check: CKV_AZURE_33: "Ensure Storage logging is enabled for Queue service"
+///         FAILED for resource: azurerm_storage_account.primary
+///         Severity: HIGH
+/// </code>
+/// The parser is line-oriented and tolerant: a check with no explicit severity
+/// line is treated as <see cref="IacScanSeverity.Medium"/> (Checkov's default
+/// weighting for an unscored policy).
+/// </remarks>
+public static partial class CheckovParser
+{
+    private const string Scanner = "checkov";
+
+    [GeneratedRegex(@"^Check:\s+(?<rule>[A-Z0-9_]+):\s*""?(?<msg>[^""]*)""?", RegexOptions.Compiled)]
+    private static partial Regex CheckLine();
+
+    [GeneratedRegex(@"FAILED\s+for\s+resource:\s*(?<res>\S+)", RegexOptions.Compiled)]
+    private static partial Regex FailedLine();
+
+    [GeneratedRegex(@"Severity:\s*(?<sev>\w+)", RegexOptions.Compiled | RegexOptions.IgnoreCase)]
+    private static partial Regex SeverityLine();
+
+    /// <summary>Parses Checkov compact output into failed-check findings.</summary>
+    /// <param name="output">The raw Checkov stdout.</param>
+    /// <returns>One finding per failed check.</returns>
+    public static IReadOnlyList<IacScanFinding> Parse(string output)
+    {
+        if (string.IsNullOrWhiteSpace(output))
+        {
+            return [];
+        }
+
+        var findings = new List<IacScanFinding>();
+        string? rule = null;
+        string? message = null;
+        string? resource = null;
+        var failed = false;
+        var severity = IacScanSeverity.Medium;
+
+        foreach (var raw in output.Split('\n'))
+        {
+            var line = raw.Trim();
+
+            var check = CheckLine().Match(line);
+            if (check.Success)
+            {
+                Flush(findings, rule, message, resource, failed, severity);
+                rule = check.Groups["rule"].Value;
+                message = check.Groups["msg"].Value.Trim();
+                resource = null;
+                failed = false;
+                severity = IacScanSeverity.Medium;
+                continue;
+            }
+
+            var failedMatch = FailedLine().Match(line);
+            if (failedMatch.Success)
+            {
+                failed = true;
+                resource = failedMatch.Groups["res"].Value;
+                continue;
+            }
+
+            var sevMatch = SeverityLine().Match(line);
+            if (sevMatch.Success && IacScanSeverityParser.TryParse(sevMatch.Groups["sev"].Value, out var parsed))
+            {
+                severity = parsed;
+            }
+        }
+
+        Flush(findings, rule, message, resource, failed, severity);
+        return findings;
+    }
+
+    private static void Flush(
+        List<IacScanFinding> findings,
+        string? rule,
+        string? message,
+        string? resource,
+        bool failed,
+        IacScanSeverity severity)
+    {
+        if (!failed || string.IsNullOrEmpty(rule))
+        {
+            return;
+        }
+
+        findings.Add(new IacScanFinding
+        {
+            Scanner = Scanner,
+            RuleId = rule,
+            Severity = severity,
+            Resource = resource ?? string.Empty,
+            Message = message ?? string.Empty
+        });
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Iac/IacChangeProposalValidator.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Iac/IacChangeProposalValidator.cs
@@ -1,0 +1,125 @@
+using Application.AI.Common.Interfaces.Changes;
+using Application.AI.Common.Interfaces.Iac;
+using Domain.AI.Changes;
+using Domain.AI.Iac;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Infrastructure.AI.Iac;
+
+/// <summary>
+/// The IaC <see cref="IChangeProposalValidator"/> run by the <c>SelfValidationGate</c>
+/// for <see cref="ChangeTargetKind.IacDeployment"/> proposals (PR-10). Validates +
+/// plans the module and security-scans it via the backend's <see cref="IIacGenerator"/>,
+/// failing the proposal when the plan errors, when the plan shows destructive
+/// changes (the deploy guard refuses unexpected resource replacement/deletion), or
+/// when the scan does not pass policy.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Registered under the <see cref="ChangeTargetKind.IacDeployment"/> keyed-DI key,
+/// replacing the fail-loud <c>NotConfiguredValidator</c> placeholder. A proposal
+/// whose target is not an <see cref="IacDeploymentTarget"/> is not this validator's
+/// concern — it returns <see cref="GateResult.Pass"/> so a mis-routed proposal is
+/// neither blocked nor silently approved by IaC logic.
+/// </para>
+/// <para>
+/// The backend is resolved by <see cref="IacDeploymentTarget.Backend"/> via
+/// <see cref="ServiceProviderKeyedServiceExtensions.GetKeyedService{T}"/>; an
+/// unknown or unregistered backend fails the proposal with <c>iac.backend_not_registered</c>
+/// rather than throwing — a typo in a target's backend string must not crash the
+/// gate pipeline.
+/// </para>
+/// </remarks>
+public sealed class IacChangeProposalValidator : IChangeProposalValidator
+{
+    /// <summary>The keyed-DI key this validator registers under for the IaC target kind.</summary>
+    public const string ValidatorKey = "iac_plan_scan";
+
+    private readonly IServiceProvider _services;
+    private readonly ILogger<IacChangeProposalValidator> _logger;
+
+    /// <summary>Initialises a new <see cref="IacChangeProposalValidator"/>.</summary>
+    /// <param name="services">The service provider used to resolve the backend <see cref="IIacGenerator"/> by key.</param>
+    /// <param name="logger">Structured logger.</param>
+    public IacChangeProposalValidator(IServiceProvider services, ILogger<IacChangeProposalValidator> logger)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(logger);
+        _services = services;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public string Key => ValidatorKey;
+
+    /// <inheritdoc />
+    public async Task<GateResult> ValidateAsync(
+        ChangeProposal proposal,
+        GateContext context,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(proposal);
+
+        if (proposal.Target is not IacDeploymentTarget target)
+        {
+            return GateResult.Pass("Not an IaC deployment target; iac_plan_scan does not apply.");
+        }
+
+        var generator = _services.GetKeyedService<IIacGenerator>(target.Backend);
+        if (generator is null)
+        {
+            _logger.LogWarning(
+                "No IIacGenerator registered for backend '{Backend}' (proposal {Proposal}).",
+                target.Backend, proposal.Id);
+            return GateResult.Fail($"iac.backend_not_registered: no IIacGenerator for backend '{target.Backend}'.");
+        }
+
+        var moduleDirectory = ResolveModuleDirectory(target.ModulePath);
+
+        var planResult = await generator.PlanAsync(moduleDirectory, cancellationToken).ConfigureAwait(false);
+        if (!planResult.IsSuccess || planResult.Value is null)
+        {
+            return GateResult.Fail($"iac.plan_failed: {string.Join("; ", planResult.Errors)}");
+        }
+
+        var plan = planResult.Value;
+        if (!plan.Succeeded)
+        {
+            return GateResult.Fail($"iac.plan_invalid: {plan.Summary}");
+        }
+
+        if (plan.HasDestructiveChanges)
+        {
+            return GateResult.Fail($"iac.plan_destructive: plan includes destructive changes ({plan.Summary}).");
+        }
+
+        var scanResult = await generator.ScanAsync(moduleDirectory, cancellationToken).ConfigureAwait(false);
+        if (!scanResult.IsSuccess || scanResult.Value is null)
+        {
+            return GateResult.Fail($"iac.scan_failed: {string.Join("; ", scanResult.Errors)}");
+        }
+
+        var scan = scanResult.Value;
+        if (!scan.Passed)
+        {
+            return GateResult.Fail(
+                $"iac.scan_blocked: {scan.Findings.Count} finding(s) at or above the blocking severity " +
+                $"from {string.Join(", ", scan.ScannersRun)}.");
+        }
+
+        return GateResult.Pass(
+            $"iac plan clean ({plan.Summary}); scan passed ({scan.Findings.Count} sub-blocking finding(s)).");
+    }
+
+    private static string ResolveModuleDirectory(string modulePath)
+    {
+        if (string.IsNullOrWhiteSpace(modulePath))
+        {
+            return ".";
+        }
+
+        var directory = Path.GetDirectoryName(modulePath);
+        return string.IsNullOrEmpty(directory) ? "." : directory;
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Iac/IacSandboxRunner.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Iac/IacSandboxRunner.cs
@@ -1,0 +1,89 @@
+using Application.AI.Common.Interfaces.Sandbox;
+using Domain.AI.Sandbox;
+
+namespace Infrastructure.AI.Iac;
+
+/// <summary>
+/// Shared dispatch helper for the IaC generators. Builds a
+/// <see cref="SandboxExecutionRequest"/> for an infrastructure-as-code CLI
+/// (terraform / bicep / checkov / tfsec / arm-ttk), runs it through the supplied
+/// <see cref="ISandboxExecutor"/>, and returns the raw
+/// <see cref="SandboxExecutionResult"/> for the caller to parse.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Mirrors <c>WorkspaceCommandRunner</c>: the program and arguments are passed as
+/// discrete <c>ArgumentList</c> entries — never a single shell string — so a CLI
+/// argument can never smuggle a shell metacharacter through the sandbox boundary.
+/// </para>
+/// <para>
+/// The permission profile grants <see cref="ToolCapability.FileRead"/>,
+/// <see cref="ToolCapability.FileWrite"/> (terraform writes a <c>.terraform</c>
+/// cache and a plan file; bicep emits an ARM template), <see cref="ToolCapability.Subprocess"/>
+/// (the CLIs spawn provider plugins / language servers), and
+/// <see cref="ToolCapability.NetworkAccess"/> scoped to the provider/module
+/// registries via <see cref="ToolPermissionProfile.AllowedHosts"/>. The egress is
+/// the registry allowlist from <c>AppConfig.AI.Iac.RegistryAllowlist</c>; the
+/// filesystem scope is the single module directory.
+/// </para>
+/// </remarks>
+public static class IacSandboxRunner
+{
+    /// <summary>
+    /// Runs an IaC CLI inside the sandbox rooted at <paramref name="moduleDirectory"/>.
+    /// </summary>
+    /// <param name="program">The CLI program to launch (e.g. <c>terraform</c>, <c>bicep</c>, <c>checkov</c>).</param>
+    /// <param name="arguments">The discrete CLI arguments — each entry is passed verbatim, never shell-interpreted.</param>
+    /// <param name="moduleDirectory">The sandbox-rooted directory the CLI runs against; the sole allowed filesystem path.</param>
+    /// <param name="registryAllowlist">The provider/module-registry hosts the run may reach. Seeds the sandbox egress allowlist.</param>
+    /// <param name="executor">The sandbox executor to dispatch through.</param>
+    /// <param name="toolName">Tool name for diagnostic attribution in the sandbox request.</param>
+    /// <param name="timeout">Optional wall-clock timeout. Defaults to 5 minutes — terraform init/plan can be slow.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The raw <see cref="SandboxExecutionResult"/> for the caller to parse.</returns>
+    public static async Task<SandboxExecutionResult> RunAsync(
+        string program,
+        IReadOnlyList<string> arguments,
+        string moduleDirectory,
+        IReadOnlyList<string> registryAllowlist,
+        ISandboxExecutor executor,
+        string toolName,
+        TimeSpan? timeout = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(program);
+        ArgumentNullException.ThrowIfNull(arguments);
+        ArgumentException.ThrowIfNullOrWhiteSpace(moduleDirectory);
+        ArgumentNullException.ThrowIfNull(registryAllowlist);
+        ArgumentNullException.ThrowIfNull(executor);
+        ArgumentException.ThrowIfNullOrWhiteSpace(toolName);
+
+        var profile = new ToolPermissionProfile
+        {
+            RequiredCapabilities =
+                ToolCapability.FileRead
+                | ToolCapability.FileWrite
+                | ToolCapability.Subprocess
+                | ToolCapability.NetworkAccess,
+            AllowedPaths = [moduleDirectory],
+            AllowedPrograms = [program],
+            AllowedHosts = registryAllowlist,
+            DeniedHosts = [],
+            DeniedPaths = [],
+            MinimumIsolation = SandboxIsolationLevel.Process
+        };
+
+        var request = new SandboxExecutionRequest
+        {
+            ToolName = toolName,
+            Input = string.Empty,
+            Command = program,
+            ArgumentList = arguments,
+            Limits = new ResourceLimits(),
+            PermissionProfile = profile,
+            Timeout = timeout ?? TimeSpan.FromMinutes(5)
+        };
+
+        return await executor.ExecuteAsync(request, cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Iac/IacStartupValidator.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Iac/IacStartupValidator.cs
@@ -1,0 +1,146 @@
+using Domain.AI.Iac;
+using Domain.Common.Config;
+using Domain.Common.Config.AI.Iac;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Infrastructure.AI.Iac;
+
+/// <summary>
+/// One-shot startup validator for the IaC skill pack (PR-10). Runs via
+/// <see cref="IHostedService.StartAsync"/> and refuses to boot the host when the
+/// skill pack is enabled but its configuration is impossible.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Checks performed (only when <c>AppConfig.AI.Iac.Enabled</c> is true):
+/// </para>
+/// <list type="number">
+///   <item><description><b>Enabled backends</b> — non-empty, and every entry is a known backend (<c>terraform</c> / <c>bicep</c>).</description></item>
+///   <item><description><b>Version pins</b> — each enabled backend (and its scanners) carries a non-empty pinned version.</description></item>
+///   <item><description><b>Blocking severity</b> — parses to a defined <see cref="IacScanSeverity"/>.</description></item>
+///   <item><description><b>Registry allowlist</b> — non-empty; the sandbox egress allowlist for plan/scan must seed from something.</description></item>
+/// </list>
+/// <para>
+/// When the skill pack is disabled the validator no-ops — the tools are inert and a
+/// consumer exploring the template should not be blocked from running the host.
+/// </para>
+/// </remarks>
+public sealed class IacStartupValidator : IHostedService
+{
+    private readonly IOptionsMonitor<AppConfig> _config;
+    private readonly ILogger<IacStartupValidator> _logger;
+
+    /// <summary>Initialises a new <see cref="IacStartupValidator"/>.</summary>
+    /// <param name="config">Application configuration monitor.</param>
+    /// <param name="logger">Structured logger.</param>
+    public IacStartupValidator(IOptionsMonitor<AppConfig> config, ILogger<IacStartupValidator> logger)
+    {
+        ArgumentNullException.ThrowIfNull(config);
+        ArgumentNullException.ThrowIfNull(logger);
+        _config = config;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        var iac = _config.CurrentValue.AI.Iac;
+        if (!iac.Enabled)
+        {
+            return Task.CompletedTask;
+        }
+
+        var backends = ValidateEnabledBackends(iac);
+        ValidateVersionPins(iac, backends);
+        ValidateBlockingSeverity(iac);
+        ValidateRegistryAllowlist(iac);
+
+        _logger.LogInformation(
+            "IaC skill pack enabled. Backends={Backends}, BlockingSeverity={Severity}, Registries={Registries}.",
+            string.Join(",", backends),
+            iac.BlockingSeverity,
+            iac.RegistryAllowlist.Count);
+
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    private static IReadOnlyList<IacBackend> ValidateEnabledBackends(IacConfig iac)
+    {
+        if (iac.EnabledBackends is null || iac.EnabledBackends.Count == 0)
+        {
+            throw new InvalidOperationException(
+                "IaC skill pack is Enabled but AppConfig.AI.Iac.EnabledBackends is empty. " +
+                "Enable at least one of: \"terraform\", \"bicep\".");
+        }
+
+        var backends = new List<IacBackend>(iac.EnabledBackends.Count);
+        foreach (var entry in iac.EnabledBackends)
+        {
+            if (!IacBackendKeys.TryParse(entry, out var backend))
+            {
+                throw new InvalidOperationException(
+                    $"IaC skill pack is Enabled but AppConfig.AI.Iac.EnabledBackends contains an unknown backend '{entry}'. " +
+                    "Known backends: \"terraform\", \"bicep\".");
+            }
+
+            backends.Add(backend);
+        }
+
+        return backends;
+    }
+
+    private static void ValidateVersionPins(IacConfig iac, IReadOnlyList<IacBackend> backends)
+    {
+        foreach (var backend in backends)
+        {
+            switch (backend)
+            {
+                case IacBackend.Terraform:
+                    RequirePin(iac.TerraformVersion, nameof(IacConfig.TerraformVersion));
+                    RequirePin(iac.CheckovVersion, nameof(IacConfig.CheckovVersion));
+                    RequirePin(iac.TfsecVersion, nameof(IacConfig.TfsecVersion));
+                    break;
+                case IacBackend.Bicep:
+                    RequirePin(iac.BicepVersion, nameof(IacConfig.BicepVersion));
+                    RequirePin(iac.ArmTtkVersion, nameof(IacConfig.ArmTtkVersion));
+                    RequirePin(iac.CheckovVersion, nameof(IacConfig.CheckovVersion));
+                    break;
+            }
+        }
+    }
+
+    private static void RequirePin(string version, string propertyName)
+    {
+        if (string.IsNullOrWhiteSpace(version))
+        {
+            throw new InvalidOperationException(
+                $"IaC skill pack is Enabled but AppConfig.AI.Iac.{propertyName} is empty. " +
+                "Every enabled backend's CLI must carry a pinned version baked into the sandbox image.");
+        }
+    }
+
+    private static void ValidateBlockingSeverity(IacConfig iac)
+    {
+        if (!IacScanSeverityParser.TryParse(iac.BlockingSeverity, out _))
+        {
+            throw new InvalidOperationException(
+                $"IaC skill pack is Enabled but AppConfig.AI.Iac.BlockingSeverity is '{iac.BlockingSeverity}'. " +
+                "It must be one of: Low, Medium, High, Critical.");
+        }
+    }
+
+    private static void ValidateRegistryAllowlist(IacConfig iac)
+    {
+        if (iac.RegistryAllowlist is null || iac.RegistryAllowlist.Count == 0)
+        {
+            throw new InvalidOperationException(
+                "IaC skill pack is Enabled but AppConfig.AI.Iac.RegistryAllowlist is empty. " +
+                "Plan/scan runs need outbound access to the provider/module registries.");
+        }
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Iac/TerraformGenerator.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Iac/TerraformGenerator.cs
@@ -1,0 +1,248 @@
+using Application.AI.Common.Interfaces.Iac;
+using Application.AI.Common.Interfaces.Sandbox;
+using Domain.AI.Iac;
+using Domain.AI.Sandbox;
+using Domain.Common;
+using Domain.Common.Config;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Infrastructure.AI.Iac;
+
+/// <summary>
+/// Terraform <see cref="IIacGenerator"/>. Scaffolds a starter module
+/// deterministically, validates + plans it with the <c>terraform</c> CLI, and
+/// security-scans it with Checkov + tfsec — all CLI work runs inside the PR-3
+/// sandbox via <see cref="IacSandboxRunner"/>. Never deploys: there is no apply.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Stable failure codes (<c>iac.*</c>): the implementation never surfaces raw CLI
+/// stderr in a <see cref="Result"/> error — it logs the full output via structured
+/// logging and returns a scrubbed code so a SAS token or registry credential in a
+/// provider error can never leak into LLM context or an audit line.
+/// </para>
+/// </remarks>
+public sealed class TerraformGenerator : IIacGenerator
+{
+    private const string CliProgram = "terraform";
+    private const string CheckovProgram = "checkov";
+    private const string TfsecProgram = "tfsec";
+
+    private readonly IOptionsMonitor<AppConfig> _config;
+    private readonly ISandboxExecutor _sandbox;
+    private readonly ILogger<TerraformGenerator> _logger;
+    private readonly TimeProvider _timeProvider;
+
+    /// <summary>Initialises a new <see cref="TerraformGenerator"/>.</summary>
+    /// <param name="config">Application configuration monitor — supplies version pins, registry allowlist, and blocking severity.</param>
+    /// <param name="sandbox">The Process-isolation sandbox executor the CLIs run inside.</param>
+    /// <param name="logger">Structured logger.</param>
+    /// <param name="timeProvider">Clock abstraction (unused for timing here but injected for parity and future use).</param>
+    public TerraformGenerator(
+        IOptionsMonitor<AppConfig> config,
+        ISandboxExecutor sandbox,
+        ILogger<TerraformGenerator> logger,
+        TimeProvider timeProvider)
+    {
+        ArgumentNullException.ThrowIfNull(config);
+        ArgumentNullException.ThrowIfNull(sandbox);
+        ArgumentNullException.ThrowIfNull(logger);
+        ArgumentNullException.ThrowIfNull(timeProvider);
+        _config = config;
+        _sandbox = sandbox;
+        _logger = logger;
+        _timeProvider = timeProvider;
+    }
+
+    /// <inheritdoc />
+    public IacBackend Backend => IacBackend.Terraform;
+
+    /// <inheritdoc />
+    public Task<Result<IacGenerationResult>> GenerateAsync(
+        IacGenerationRequest request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        if (string.IsNullOrWhiteSpace(request.ResourceType) || string.IsNullOrWhiteSpace(request.ResourceName))
+        {
+            return Task.FromResult(Result<IacGenerationResult>.Fail("iac.generate.invalid_request"));
+        }
+
+        var files = new Dictionary<string, string>
+        {
+            ["main.tf"] = BuildMainTf(request),
+            ["variables.tf"] = BuildVariablesTf(request)
+        };
+
+        return Task.FromResult(Result<IacGenerationResult>.Success(new IacGenerationResult
+        {
+            Backend = IacBackend.Terraform,
+            Files = files
+        }));
+    }
+
+    /// <inheritdoc />
+    public async Task<Result<IacPlanResult>> PlanAsync(string moduleDirectory, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(moduleDirectory))
+        {
+            return Result<IacPlanResult>.Fail("iac.plan.invalid_module_directory");
+        }
+
+        var allowlist = _config.CurrentValue.AI.Iac.RegistryAllowlist;
+
+        var validate = await Run([ "validate", "-no-color" ], moduleDirectory, allowlist, "iac_plan", cancellationToken);
+        if (validate is null)
+        {
+            return Result<IacPlanResult>.Fail("iac.plan.sandbox_error");
+        }
+
+        if (!validate.Success)
+        {
+            _logger.LogWarning("Terraform validate failed in {Module}: exit={Exit}", moduleDirectory, validate.ExitCode);
+            return Result<IacPlanResult>.Success(FailedPlan(moduleDirectory, validate.Output ?? string.Empty, "validate failed"));
+        }
+
+        var plan = await Run([ "plan", "-no-color", "-detailed-exitcode" ], moduleDirectory, allowlist, "iac_plan", cancellationToken);
+        if (plan is null)
+        {
+            return Result<IacPlanResult>.Fail("iac.plan.sandbox_error");
+        }
+
+        return Result<IacPlanResult>.Success(ParsePlan(moduleDirectory, plan));
+    }
+
+    /// <inheritdoc />
+    public async Task<Result<IacScanResult>> ScanAsync(string moduleDirectory, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(moduleDirectory))
+        {
+            return Result<IacScanResult>.Fail("iac.scan.invalid_module_directory");
+        }
+
+        var iac = _config.CurrentValue.AI.Iac;
+        if (!IacScanSeverityParser.TryParse(iac.BlockingSeverity, out var blocking))
+        {
+            return Result<IacScanResult>.Fail("iac.scan.invalid_blocking_severity");
+        }
+
+        var checkov = await Run([ "-d", ".", "--compact", "--quiet" ], moduleDirectory, iac.RegistryAllowlist, "iac_scan", cancellationToken, CheckovProgram);
+        var tfsec = await Run([ ".", "--no-colour" ], moduleDirectory, iac.RegistryAllowlist, "iac_scan", cancellationToken, TfsecProgram);
+        if (checkov is null || tfsec is null)
+        {
+            return Result<IacScanResult>.Fail("iac.scan.sandbox_error");
+        }
+
+        var findings = new List<IacScanFinding>();
+        findings.AddRange(CheckovParser.Parse(checkov.Output ?? string.Empty));
+        findings.AddRange(TfsecParser.Parse(tfsec.Output ?? string.Empty));
+
+        return Result<IacScanResult>.Success(new IacScanResult
+        {
+            Backend = IacBackend.Terraform,
+            ModulePath = moduleDirectory,
+            Passed = IacScanSeverityParser.Passes(findings, blocking),
+            ScannersRun = [CheckovProgram, TfsecProgram],
+            Findings = findings
+        });
+    }
+
+    private Task<SandboxExecutionResult?> Run(
+        IReadOnlyList<string> args,
+        string moduleDirectory,
+        IReadOnlyList<string> allowlist,
+        string toolName,
+        CancellationToken cancellationToken,
+        string program = CliProgram)
+        => RunGuarded(program, args, moduleDirectory, allowlist, toolName, cancellationToken);
+
+    private async Task<SandboxExecutionResult?> RunGuarded(
+        string program,
+        IReadOnlyList<string> args,
+        string moduleDirectory,
+        IReadOnlyList<string> allowlist,
+        string toolName,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            return await IacSandboxRunner.RunAsync(program, args, moduleDirectory, allowlist, _sandbox, toolName, cancellationToken: cancellationToken);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Terraform sandbox run failed for {Program} in {Module}.", program, moduleDirectory);
+            return null;
+        }
+    }
+
+    private static IacPlanResult ParsePlan(string moduleDirectory, SandboxExecutionResult plan)
+    {
+        // terraform plan -detailed-exitcode: 0 = no changes, 2 = changes present, 1 = error.
+        var output = plan.Output ?? string.Empty;
+        var hasChanges = plan.ExitCode == 2 || output.Contains("to add", StringComparison.OrdinalIgnoreCase);
+        var destructive = output.Contains("to destroy", StringComparison.OrdinalIgnoreCase)
+            && !output.Contains("0 to destroy", StringComparison.OrdinalIgnoreCase);
+        var succeeded = plan.ExitCode is 0 or 2;
+
+        return new IacPlanResult
+        {
+            Backend = IacBackend.Terraform,
+            ModulePath = moduleDirectory,
+            Succeeded = succeeded,
+            HasChanges = hasChanges,
+            HasDestructiveChanges = destructive,
+            RawOutput = output,
+            Summary = succeeded ? PlanSummaryLine(output) : "plan errored"
+        };
+    }
+
+    private static IacPlanResult FailedPlan(string moduleDirectory, string output, string summary) => new()
+    {
+        Backend = IacBackend.Terraform,
+        ModulePath = moduleDirectory,
+        Succeeded = false,
+        HasChanges = false,
+        HasDestructiveChanges = false,
+        RawOutput = output,
+        Summary = summary
+    };
+
+    private static string PlanSummaryLine(string output)
+    {
+        var line = output.Split('\n').LastOrDefault(l => l.Contains("to add", StringComparison.OrdinalIgnoreCase));
+        return string.IsNullOrWhiteSpace(line) ? "no changes" : line.Trim();
+    }
+
+    private static string BuildMainTf(IacGenerationRequest request)
+    {
+        var attributes = string.Join(
+            "\n",
+            request.Parameters.Select(p => $"  {p.Key} = \"{p.Value}\""));
+        var body = string.IsNullOrEmpty(attributes) ? string.Empty : attributes + "\n";
+
+        return $$"""
+            # Scaffolded by the Microsoft Agentic Harness IaC skill (Terraform).
+            # Environment: {{request.Environment}}
+            resource "{{request.ResourceType}}" "{{request.ResourceName}}" {
+            {{body}}  tags = {
+                environment = var.environment
+                managed_by  = "agentic-harness"
+              }
+            }
+            """;
+    }
+
+    private static string BuildVariablesTf(IacGenerationRequest request) => $$"""
+        variable "environment" {
+          description = "Target environment for the {{request.ResourceName}} resource."
+          type        = string
+          default     = "{{request.Environment}}"
+        }
+        """;
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Iac/TfsecParser.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Iac/TfsecParser.cs
@@ -1,0 +1,115 @@
+using System.Text.RegularExpressions;
+using Domain.AI.Iac;
+
+namespace Infrastructure.AI.Iac;
+
+/// <summary>
+/// Parses tfsec's default text output into the scanner-neutral
+/// <see cref="IacScanFinding"/> shape.
+/// </summary>
+/// <remarks>
+/// tfsec's text output emits one block per result; each carries an ID, a severity,
+/// and the offending resource, e.g.:
+/// <code>
+/// Result #1 CRITICAL Storage account uses an insecure TLS version
+///   ID      azure-storage-use-secure-tls-policy
+///   Severity CRITICAL
+///   Resource azurerm_storage_account.primary
+/// </code>
+/// The parser is line-oriented: it keys off the <c>ID</c>, <c>Severity</c>, and
+/// <c>Resource</c> lines and emits a finding when an ID and severity are both seen.
+/// </remarks>
+public static partial class TfsecParser
+{
+    private const string Scanner = "tfsec";
+
+    [GeneratedRegex(@"^ID\s+(?<id>[A-Za-z0-9\-]+)", RegexOptions.Compiled)]
+    private static partial Regex IdLine();
+
+    [GeneratedRegex(@"^Severity\s+(?<sev>\w+)", RegexOptions.Compiled | RegexOptions.IgnoreCase)]
+    private static partial Regex SeverityLine();
+
+    [GeneratedRegex(@"^Resource\s+(?<res>\S+)", RegexOptions.Compiled)]
+    private static partial Regex ResourceLine();
+
+    [GeneratedRegex(@"^Result\s+#\d+\s+\w+\s+(?<msg>.+)$", RegexOptions.Compiled)]
+    private static partial Regex ResultLine();
+
+    /// <summary>Parses tfsec text output into findings.</summary>
+    /// <param name="output">The raw tfsec stdout.</param>
+    /// <returns>One finding per result block carrying an ID + severity.</returns>
+    public static IReadOnlyList<IacScanFinding> Parse(string output)
+    {
+        if (string.IsNullOrWhiteSpace(output))
+        {
+            return [];
+        }
+
+        var findings = new List<IacScanFinding>();
+        string? id = null;
+        string? message = null;
+        string? resource = null;
+        IacScanSeverity? severity = null;
+
+        foreach (var raw in output.Split('\n'))
+        {
+            var line = raw.Trim();
+
+            var result = ResultLine().Match(line);
+            if (result.Success)
+            {
+                Flush(findings, id, message, resource, severity);
+                id = null;
+                resource = null;
+                severity = null;
+                message = result.Groups["msg"].Value.Trim();
+                continue;
+            }
+
+            var idMatch = IdLine().Match(line);
+            if (idMatch.Success)
+            {
+                id = idMatch.Groups["id"].Value;
+                continue;
+            }
+
+            var sevMatch = SeverityLine().Match(line);
+            if (sevMatch.Success && IacScanSeverityParser.TryParse(sevMatch.Groups["sev"].Value, out var parsed))
+            {
+                severity = parsed;
+                continue;
+            }
+
+            var resMatch = ResourceLine().Match(line);
+            if (resMatch.Success)
+            {
+                resource = resMatch.Groups["res"].Value;
+            }
+        }
+
+        Flush(findings, id, message, resource, severity);
+        return findings;
+    }
+
+    private static void Flush(
+        List<IacScanFinding> findings,
+        string? id,
+        string? message,
+        string? resource,
+        IacScanSeverity? severity)
+    {
+        if (string.IsNullOrEmpty(id) || severity is null)
+        {
+            return;
+        }
+
+        findings.Add(new IacScanFinding
+        {
+            Scanner = Scanner,
+            RuleId = id,
+            Severity = severity.Value,
+            Resource = resource ?? string.Empty,
+            Message = message ?? string.Empty
+        });
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/Iac/DependencyInjection.Iac.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/Iac/DependencyInjection.Iac.cs
@@ -1,0 +1,82 @@
+using Application.AI.Common.Interfaces.Iac;
+using Application.AI.Common.Interfaces.Sandbox;
+using Application.AI.Common.Interfaces.Tools;
+using Domain.AI.Iac;
+using Domain.AI.Sandbox;
+using Domain.Common.Config;
+using Infrastructure.AI.Iac;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Infrastructure.AI.Tools.Iac;
+
+/// <summary>
+/// DI registration for the IaC skill pack (PR-10): the Terraform and Bicep
+/// <see cref="IIacGenerator"/> implementations keyed by backend, the three
+/// agent-facing tools keyed by tool name, and the fail-loud startup validator.
+/// Composition-root opt-in — callers invoke <see cref="AddIacSkillTools"/> from
+/// their <c>Add*Dependencies</c> chain so the skill pack is bolted on only when
+/// wanted.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Registers, by keyed-DI name:
+/// <list type="bullet">
+///   <item><c>terraform</c> / <c>bicep</c> — <see cref="IIacGenerator"/> implementations</item>
+///   <item><c>iac_generate</c> — <see cref="IacGenerateTool"/></item>
+///   <item><c>iac_plan</c>     — <see cref="IacPlanTool"/></item>
+///   <item><c>iac_scan</c>     — <see cref="IacScanTool"/></item>
+/// </list>
+/// </para>
+/// <para>
+/// The generators are keyed singletons that resolve the <c>Process</c>-isolation
+/// <see cref="ISandboxExecutor"/> at construction — the same pattern the workspace
+/// skill pack uses for its verifier tools. Registrations are unconditional (the
+/// tools are inert until a skill resolves them); <see cref="IacStartupValidator"/>
+/// turns a bad config into a fail-loud boot error whenever the skill pack is enabled.
+/// </para>
+/// </remarks>
+public static class IacDependencyInjection
+{
+    /// <summary>
+    /// Registers the IaC skill pack's generators, agent-facing tools, and startup
+    /// validator on the supplied <see cref="IServiceCollection"/>.
+    /// </summary>
+    /// <param name="services">The service collection to register into.</param>
+    /// <returns>The same collection, for fluent chaining.</returns>
+    public static IServiceCollection AddIacSkillTools(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        // --- Generators, keyed by backend canonical key ---
+        services.AddKeyedSingleton<IIacGenerator>(IacBackendKeys.Terraform, static (sp, _) =>
+            new TerraformGenerator(
+                sp.GetRequiredService<IOptionsMonitor<AppConfig>>(),
+                sp.GetRequiredKeyedService<ISandboxExecutor>(SandboxIsolationLevel.Process),
+                sp.GetRequiredService<ILogger<TerraformGenerator>>(),
+                sp.GetRequiredService<TimeProvider>()));
+
+        services.AddKeyedSingleton<IIacGenerator>(IacBackendKeys.Bicep, static (sp, _) =>
+            new BicepGenerator(
+                sp.GetRequiredService<IOptionsMonitor<AppConfig>>(),
+                sp.GetRequiredKeyedService<ISandboxExecutor>(SandboxIsolationLevel.Process),
+                sp.GetRequiredService<ILogger<BicepGenerator>>(),
+                sp.GetRequiredService<TimeProvider>()));
+
+        // --- Agent-facing tools (keyed by ToolName) ---
+        services.AddKeyedSingleton<ITool>(IacGenerateTool.ToolName, static (sp, _) =>
+            new IacGenerateTool(sp, sp.GetRequiredService<IOptionsMonitor<AppConfig>>()));
+
+        services.AddKeyedSingleton<ITool>(IacPlanTool.ToolName, static (sp, _) =>
+            new IacPlanTool(sp, sp.GetRequiredService<IOptionsMonitor<AppConfig>>()));
+
+        services.AddKeyedSingleton<ITool>(IacScanTool.ToolName, static (sp, _) =>
+            new IacScanTool(sp, sp.GetRequiredService<IOptionsMonitor<AppConfig>>()));
+
+        // --- Fail-loud startup validation when the skill pack is enabled ---
+        services.AddHostedService<IacStartupValidator>();
+
+        return services;
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/Iac/IacGenerateTool.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/Iac/IacGenerateTool.cs
@@ -1,0 +1,117 @@
+using System.Text.Json;
+using Application.AI.Common.Interfaces.Tools;
+using Domain.AI.Iac;
+using Domain.AI.Models;
+using Domain.Common.Config;
+using Microsoft.Extensions.Options;
+
+namespace Infrastructure.AI.Tools.Iac;
+
+/// <summary>
+/// Scaffolds a starter IaC module via the backend's <c>IIacGenerator</c> and
+/// returns the generated files as JSON. The agent refines the scaffold and submits
+/// it as a <c>ChangeProposal</c>; this tool only produces files — it never writes
+/// to disk or the cluster, so it is treated as read-only.
+/// </summary>
+public sealed class IacGenerateTool : ITool
+{
+    /// <summary>Tool key — matches the keyed-DI registration and the SKILL.md allowed-tools entry.</summary>
+    public const string ToolName = "iac_generate";
+
+    private static readonly IReadOnlyList<string> Operations = ["generate"];
+    private static readonly JsonSerializerOptions SerializerOptions = new() { WriteIndented = false };
+
+    private readonly IServiceProvider _services;
+    private readonly IOptionsMonitor<AppConfig> _config;
+
+    /// <summary>Initialises a new <see cref="IacGenerateTool"/>.</summary>
+    /// <param name="services">Service provider for keyed backend resolution.</param>
+    /// <param name="config">Application configuration monitor — supplies the default backend.</param>
+    public IacGenerateTool(IServiceProvider services, IOptionsMonitor<AppConfig> config)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(config);
+        _services = services;
+        _config = config;
+    }
+
+    /// <inheritdoc />
+    public string Name => ToolName;
+
+    /// <inheritdoc />
+    public string Description =>
+        "Scaffolds a starter IaC module (Terraform or Bicep) for a resource type and name. Returns the generated files as JSON; does not write to disk or deploy.";
+
+    /// <inheritdoc />
+    public IReadOnlyList<string> SupportedOperations => Operations;
+
+    /// <inheritdoc />
+    public bool IsReadOnly => true;
+
+    /// <inheritdoc />
+    public bool IsConcurrencySafe => true;
+
+    /// <inheritdoc />
+    public async Task<ToolResult> ExecuteAsync(
+        string operation,
+        IReadOnlyDictionary<string, object?> parameters,
+        CancellationToken cancellationToken = default)
+    {
+        if (!string.Equals(operation, "generate", StringComparison.OrdinalIgnoreCase))
+            return ToolResult.Fail($"Unknown operation: {operation}. Supported: generate.");
+
+        var resolved = IacToolBackendResolver.Resolve(_services, _config, parameters);
+        if (!resolved.IsSuccess || resolved.Value is null)
+            return ToolResult.Fail(string.Join("; ", resolved.Errors));
+
+        if (!TryReadRequired(parameters, "resource_type", out var resourceType))
+            return ToolResult.Fail("Required parameter 'resource_type' is missing or empty.");
+        if (!TryReadRequired(parameters, "resource_name", out var resourceName))
+            return ToolResult.Fail("Required parameter 'resource_name' is missing or empty.");
+
+        var request = new IacGenerationRequest
+        {
+            Backend = resolved.Value.Backend,
+            ResourceType = resourceType,
+            ResourceName = resourceName,
+            Environment = ReadOptional(parameters, "environment", "dev"),
+            Parameters = ReadParameterMap(parameters)
+        };
+
+        var result = await resolved.Value.GenerateAsync(request, cancellationToken).ConfigureAwait(false);
+        if (!result.IsSuccess || result.Value is null)
+            return ToolResult.Fail(string.Join("; ", result.Errors));
+
+        return ToolResult.Ok(JsonSerializer.Serialize(result.Value, SerializerOptions));
+    }
+
+    private static bool TryReadRequired(IReadOnlyDictionary<string, object?> parameters, string key, out string value)
+    {
+        value = string.Empty;
+        if (parameters.TryGetValue(key, out var raw) && raw is string s && !string.IsNullOrWhiteSpace(s))
+        {
+            value = s.Trim();
+            return true;
+        }
+
+        return false;
+    }
+
+    private static string ReadOptional(IReadOnlyDictionary<string, object?> parameters, string key, string fallback)
+        => parameters.TryGetValue(key, out var raw) && raw is string s && !string.IsNullOrWhiteSpace(s)
+            ? s.Trim()
+            : fallback;
+
+    private static IReadOnlyDictionary<string, string> ReadParameterMap(IReadOnlyDictionary<string, object?> parameters)
+    {
+        if (parameters.TryGetValue("parameters", out var raw)
+            && raw is IReadOnlyDictionary<string, object?> map)
+        {
+            return map
+                .Where(kvp => kvp.Value is not null)
+                .ToDictionary(kvp => kvp.Key, kvp => kvp.Value!.ToString() ?? string.Empty);
+        }
+
+        return new Dictionary<string, string>();
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/Iac/IacPlanTool.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/Iac/IacPlanTool.cs
@@ -1,0 +1,75 @@
+using System.Text.Json;
+using Application.AI.Common.Interfaces.Tools;
+using Domain.AI.Models;
+using Domain.Common.Config;
+using Microsoft.Extensions.Options;
+
+namespace Infrastructure.AI.Tools.Iac;
+
+/// <summary>
+/// Validates and plans an IaC module via the backend's <c>IIacGenerator</c>,
+/// returning the plan outcome (success, changes, destructive flag, summary) as
+/// JSON. Read-only and concurrency-safe — planning never mutates infrastructure.
+/// </summary>
+public sealed class IacPlanTool : ITool
+{
+    /// <summary>Tool key — matches the keyed-DI registration and the SKILL.md allowed-tools entry.</summary>
+    public const string ToolName = "iac_plan";
+
+    private static readonly IReadOnlyList<string> Operations = ["plan"];
+    private static readonly JsonSerializerOptions SerializerOptions = new() { WriteIndented = false };
+
+    private readonly IServiceProvider _services;
+    private readonly IOptionsMonitor<AppConfig> _config;
+
+    /// <summary>Initialises a new <see cref="IacPlanTool"/>.</summary>
+    /// <param name="services">Service provider for keyed backend resolution.</param>
+    /// <param name="config">Application configuration monitor — supplies the default backend.</param>
+    public IacPlanTool(IServiceProvider services, IOptionsMonitor<AppConfig> config)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(config);
+        _services = services;
+        _config = config;
+    }
+
+    /// <inheritdoc />
+    public string Name => ToolName;
+
+    /// <inheritdoc />
+    public string Description =>
+        "Validates and plans an IaC module (terraform validate+plan / bicep build) inside the sandbox. Returns the plan outcome as JSON. Read-only; never deploys.";
+
+    /// <inheritdoc />
+    public IReadOnlyList<string> SupportedOperations => Operations;
+
+    /// <inheritdoc />
+    public bool IsReadOnly => true;
+
+    /// <inheritdoc />
+    public bool IsConcurrencySafe => true;
+
+    /// <inheritdoc />
+    public async Task<ToolResult> ExecuteAsync(
+        string operation,
+        IReadOnlyDictionary<string, object?> parameters,
+        CancellationToken cancellationToken = default)
+    {
+        if (!string.Equals(operation, "plan", StringComparison.OrdinalIgnoreCase))
+            return ToolResult.Fail($"Unknown operation: {operation}. Supported: plan.");
+
+        var resolved = IacToolBackendResolver.Resolve(_services, _config, parameters);
+        if (!resolved.IsSuccess || resolved.Value is null)
+            return ToolResult.Fail(string.Join("; ", resolved.Errors));
+
+        if (!parameters.TryGetValue("module_directory", out var dirRaw)
+            || dirRaw is not string moduleDirectory || string.IsNullOrWhiteSpace(moduleDirectory))
+            return ToolResult.Fail("Required parameter 'module_directory' is missing or empty.");
+
+        var result = await resolved.Value.PlanAsync(moduleDirectory.Trim(), cancellationToken).ConfigureAwait(false);
+        if (!result.IsSuccess || result.Value is null)
+            return ToolResult.Fail(string.Join("; ", result.Errors));
+
+        return ToolResult.Ok(JsonSerializer.Serialize(result.Value, SerializerOptions));
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/Iac/IacScanTool.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/Iac/IacScanTool.cs
@@ -1,0 +1,75 @@
+using System.Text.Json;
+using Application.AI.Common.Interfaces.Tools;
+using Domain.AI.Models;
+using Domain.Common.Config;
+using Microsoft.Extensions.Options;
+
+namespace Infrastructure.AI.Tools.Iac;
+
+/// <summary>
+/// Security-scans an IaC module via the backend's <c>IIacGenerator</c> (Checkov +
+/// tfsec for Terraform, ARM-TTK + Checkov for Bicep), returning normalised findings
+/// and the pass/fail verdict as JSON. Read-only and concurrency-safe.
+/// </summary>
+public sealed class IacScanTool : ITool
+{
+    /// <summary>Tool key — matches the keyed-DI registration and the SKILL.md allowed-tools entry.</summary>
+    public const string ToolName = "iac_scan";
+
+    private static readonly IReadOnlyList<string> Operations = ["scan"];
+    private static readonly JsonSerializerOptions SerializerOptions = new() { WriteIndented = false };
+
+    private readonly IServiceProvider _services;
+    private readonly IOptionsMonitor<AppConfig> _config;
+
+    /// <summary>Initialises a new <see cref="IacScanTool"/>.</summary>
+    /// <param name="services">Service provider for keyed backend resolution.</param>
+    /// <param name="config">Application configuration monitor — supplies the default backend.</param>
+    public IacScanTool(IServiceProvider services, IOptionsMonitor<AppConfig> config)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(config);
+        _services = services;
+        _config = config;
+    }
+
+    /// <inheritdoc />
+    public string Name => ToolName;
+
+    /// <inheritdoc />
+    public string Description =>
+        "Security-scans an IaC module (Checkov + tfsec / ARM-TTK + Checkov) inside the sandbox. Returns normalised findings and a pass/fail verdict as JSON. Read-only.";
+
+    /// <inheritdoc />
+    public IReadOnlyList<string> SupportedOperations => Operations;
+
+    /// <inheritdoc />
+    public bool IsReadOnly => true;
+
+    /// <inheritdoc />
+    public bool IsConcurrencySafe => true;
+
+    /// <inheritdoc />
+    public async Task<ToolResult> ExecuteAsync(
+        string operation,
+        IReadOnlyDictionary<string, object?> parameters,
+        CancellationToken cancellationToken = default)
+    {
+        if (!string.Equals(operation, "scan", StringComparison.OrdinalIgnoreCase))
+            return ToolResult.Fail($"Unknown operation: {operation}. Supported: scan.");
+
+        var resolved = IacToolBackendResolver.Resolve(_services, _config, parameters);
+        if (!resolved.IsSuccess || resolved.Value is null)
+            return ToolResult.Fail(string.Join("; ", resolved.Errors));
+
+        if (!parameters.TryGetValue("module_directory", out var dirRaw)
+            || dirRaw is not string moduleDirectory || string.IsNullOrWhiteSpace(moduleDirectory))
+            return ToolResult.Fail("Required parameter 'module_directory' is missing or empty.");
+
+        var result = await resolved.Value.ScanAsync(moduleDirectory.Trim(), cancellationToken).ConfigureAwait(false);
+        if (!result.IsSuccess || result.Value is null)
+            return ToolResult.Fail(string.Join("; ", result.Errors));
+
+        return ToolResult.Ok(JsonSerializer.Serialize(result.Value, SerializerOptions));
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/Iac/IacToolBackendResolver.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/Iac/IacToolBackendResolver.cs
@@ -1,0 +1,55 @@
+using Application.AI.Common.Interfaces.Iac;
+using Domain.Common;
+using Domain.Common.Config;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace Infrastructure.AI.Tools.Iac;
+
+/// <summary>
+/// Shared backend-selection helper for the three IaC tools. Reads the optional
+/// <c>backend</c> parameter, falls back to the first <c>EnabledBackends</c> entry
+/// in <c>AppConfig.AI.Iac</c>, and resolves the matching keyed
+/// <see cref="IIacGenerator"/>.
+/// </summary>
+public static class IacToolBackendResolver
+{
+    /// <summary>
+    /// Resolves the <see cref="IIacGenerator"/> a tool call targets.
+    /// </summary>
+    /// <param name="services">Service provider for keyed-DI resolution.</param>
+    /// <param name="config">Application configuration monitor — supplies the default backend.</param>
+    /// <param name="parameters">The tool parameters; an optional <c>backend</c> entry overrides the default.</param>
+    /// <returns><see cref="Result{T}.Success"/> with the resolved generator, or <see cref="Result{T}.Fail(string[])"/> with a stable code.</returns>
+    public static Result<IIacGenerator> Resolve(
+        IServiceProvider services,
+        IOptionsMonitor<AppConfig> config,
+        IReadOnlyDictionary<string, object?> parameters)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(config);
+        ArgumentNullException.ThrowIfNull(parameters);
+
+        var backendKey = ReadBackendKey(parameters, config);
+        if (string.IsNullOrWhiteSpace(backendKey))
+        {
+            return Result<IIacGenerator>.Fail("iac.no_backend_configured");
+        }
+
+        var generator = services.GetKeyedService<IIacGenerator>(backendKey);
+        return generator is null
+            ? Result<IIacGenerator>.Fail($"iac.backend_not_registered: '{backendKey}'")
+            : Result<IIacGenerator>.Success(generator);
+    }
+
+    private static string ReadBackendKey(IReadOnlyDictionary<string, object?> parameters, IOptionsMonitor<AppConfig> config)
+    {
+        if (parameters.TryGetValue("backend", out var value) && value is string s && !string.IsNullOrWhiteSpace(s))
+        {
+            return s.Trim().ToLowerInvariant();
+        }
+
+        var enabled = config.CurrentValue.AI.Iac.EnabledBackends;
+        return enabled is { Count: > 0 } ? enabled[0].Trim().ToLowerInvariant() : string.Empty;
+    }
+}

--- a/src/Content/Tests/Application.Core.Tests/Validation/IacConfigValidatorTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/Validation/IacConfigValidatorTests.cs
@@ -1,0 +1,170 @@
+using Application.Core.Validation;
+using Domain.Common.Config.AI.Iac;
+using FluentAssertions;
+using Xunit;
+
+namespace Application.Core.Tests.Validation;
+
+/// <summary>
+/// Tests for <see cref="IacConfigValidator"/>. All rules are conditional on
+/// <see cref="IacConfig.Enabled"/>: a disabled skill pack is always valid; an
+/// enabled one mirrors the boot-time checks in <c>IacStartupValidator</c>.
+/// Pattern: CreateValidConfig() baseline, mutate one field per test.
+/// </summary>
+public class IacConfigValidatorTests
+{
+    private readonly IacConfigValidator _validator = new();
+
+    [Fact]
+    public void DefaultValues_MatchSpec()
+    {
+        var config = new IacConfig();
+
+        config.Enabled.Should().BeFalse();
+        config.EnabledBackends.Should().Equal("terraform", "bicep");
+        config.BlockingSeverity.Should().Be("High");
+        config.RegistryAllowlist.Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public async Task Validate_Disabled_AlwaysValid()
+    {
+        var config = new IacConfig
+        {
+            Enabled = false,
+            EnabledBackends = [],
+            BlockingSeverity = "nonsense",
+            RegistryAllowlist = [],
+            TerraformVersion = ""
+        };
+
+        var result = await _validator.ValidateAsync(config);
+
+        result.IsValid.Should().BeTrue();
+        result.Errors.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Validate_ValidConfig_NoErrors()
+    {
+        var result = await _validator.ValidateAsync(CreateValidConfig());
+
+        result.IsValid.Should().BeTrue();
+        result.Errors.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Validate_EmptyBackends_HasError()
+    {
+        var config = CreateValidConfig();
+        config.EnabledBackends = [];
+
+        var result = await _validator.ValidateAsync(config);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == "EnabledBackends");
+    }
+
+    [Fact]
+    public async Task Validate_UnknownBackend_HasError()
+    {
+        var config = CreateValidConfig();
+        config.EnabledBackends = ["terraform", "pulumi"];
+
+        var result = await _validator.ValidateAsync(config);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == "EnabledBackends");
+    }
+
+    [Theory]
+    [InlineData("nonsense")]
+    [InlineData("")]
+    public async Task Validate_InvalidBlockingSeverity_HasError(string severity)
+    {
+        var config = CreateValidConfig();
+        config.BlockingSeverity = severity;
+
+        var result = await _validator.ValidateAsync(config);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == "BlockingSeverity");
+    }
+
+    [Theory]
+    [InlineData("Low")]
+    [InlineData("medium")]
+    [InlineData("HIGH")]
+    [InlineData("Critical")]
+    public async Task Validate_ValidBlockingSeverityCaseInsensitive_NoSeverityError(string severity)
+    {
+        var config = CreateValidConfig();
+        config.BlockingSeverity = severity;
+
+        var result = await _validator.ValidateAsync(config);
+
+        result.Errors.Should().NotContain(e => e.PropertyName == "BlockingSeverity");
+    }
+
+    [Fact]
+    public async Task Validate_EmptyRegistryAllowlist_HasError()
+    {
+        var config = CreateValidConfig();
+        config.RegistryAllowlist = [];
+
+        var result = await _validator.ValidateAsync(config);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == "RegistryAllowlist");
+    }
+
+    [Fact]
+    public async Task Validate_TerraformEnabledButTerraformVersionEmpty_HasError()
+    {
+        var config = CreateValidConfig();
+        config.TerraformVersion = "";
+
+        var result = await _validator.ValidateAsync(config);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == "TerraformVersion");
+    }
+
+    [Fact]
+    public async Task Validate_BicepEnabledButArmTtkVersionEmpty_HasError()
+    {
+        var config = CreateValidConfig();
+        config.ArmTtkVersion = "";
+
+        var result = await _validator.ValidateAsync(config);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == "ArmTtkVersion");
+    }
+
+    [Fact]
+    public async Task Validate_OnlyTerraformEnabled_DoesNotRequireBicepVersion()
+    {
+        var config = CreateValidConfig();
+        config.EnabledBackends = ["terraform"];
+        config.BicepVersion = "";
+        config.ArmTtkVersion = "";
+
+        var result = await _validator.ValidateAsync(config);
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    private static IacConfig CreateValidConfig() => new()
+    {
+        Enabled = true,
+        EnabledBackends = ["terraform", "bicep"],
+        TerraformVersion = "1.9.5",
+        BicepVersion = "0.30.23",
+        CheckovVersion = "3.2.0",
+        TfsecVersion = "1.28.11",
+        ArmTtkVersion = "0.24",
+        BlockingSeverity = "High",
+        RegistryAllowlist = ["registry.terraform.io"]
+    };
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Iac/BicepGeneratorTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Iac/BicepGeneratorTests.cs
@@ -1,0 +1,194 @@
+using Domain.AI.Iac;
+using FluentAssertions;
+using Infrastructure.AI.Iac;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Iac;
+
+/// <summary>
+/// Unit tests for <see cref="BicepGenerator"/>. Scaffold output is asserted
+/// directly; plan (<c>bicep build</c>) and scan (ARM-TTK + Checkov) are exercised
+/// against a recording sandbox so the exact CLI program + arguments are verified
+/// and canned output is parsed into the domain result shapes. Never invokes a real CLI.
+/// </summary>
+public sealed class BicepGeneratorTests
+{
+    private static BicepGenerator Create(Application.AI.Common.Interfaces.Sandbox.ISandboxExecutor sandbox, string blockingSeverity = "High")
+        => new(
+            IacTestConfig.ValidMonitor(blockingSeverity),
+            sandbox,
+            NullLogger<BicepGenerator>.Instance,
+            TimeProvider.System);
+
+    private static IacGenerationRequest Request() => new()
+    {
+        Backend = IacBackend.Bicep,
+        ResourceType = "Microsoft.Storage/storageAccounts",
+        ResourceName = "primary",
+        Environment = "prod",
+        Parameters = new Dictionary<string, string> { ["sku"] = "Standard_LRS" }
+    };
+
+    // ---------- GenerateAsync ----------
+
+    [Fact]
+    public async Task GenerateAsync_ProducesMainBicep()
+    {
+        var sut = Create(new RecordingIacSandbox());
+
+        var result = await sut.GenerateAsync(Request(), CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.Backend.Should().Be(IacBackend.Bicep);
+        result.Value.Files.Should().ContainKey("main.bicep");
+        result.Value.Files["main.bicep"].Should().Contain("Microsoft.Storage/storageAccounts");
+        result.Value.Files["main.bicep"].Should().Contain("sku: 'Standard_LRS'");
+    }
+
+    [Fact]
+    public async Task GenerateAsync_BlankResourceName_Fails()
+    {
+        var sut = Create(new RecordingIacSandbox());
+        var request = Request() with { ResourceName = "" };
+
+        var result = await sut.GenerateAsync(request, CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Errors.Should().Contain("iac.generate.invalid_request");
+    }
+
+    // ---------- PlanAsync ----------
+
+    [Fact]
+    public async Task PlanAsync_BuildsBicepBuildCommand()
+    {
+        var sandbox = new RecordingIacSandbox()
+            .ForProgram("bicep", success: true, exitCode: 0, output: "{ }");
+        var sut = Create(sandbox);
+
+        await sut.PlanAsync("infra", CancellationToken.None);
+
+        sandbox.Requests.Should().ContainSingle();
+        sandbox.Requests[0].Command.Should().Be("bicep");
+        sandbox.Requests[0].ArgumentList.Should().Equal("build", "main.bicep", "--stdout");
+    }
+
+    [Fact]
+    public async Task PlanAsync_BuildSucceeds_Succeeded()
+    {
+        var sandbox = new RecordingIacSandbox()
+            .ForProgram("bicep", success: true, exitCode: 0, output: "{ }");
+        var sut = Create(sandbox);
+
+        var result = await sut.PlanAsync("infra", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.Succeeded.Should().BeTrue();
+        result.Value.HasChanges.Should().BeFalse();
+        result.Value.HasDestructiveChanges.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task PlanAsync_BuildFails_NotSucceeded()
+    {
+        var sandbox = new RecordingIacSandbox()
+            .ForProgram("bicep", success: false, exitCode: 1, output: "Error BCP028");
+        var sut = Create(sandbox);
+
+        var result = await sut.PlanAsync("infra", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.Succeeded.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task PlanAsync_SandboxThrows_ReturnsStableFailureCode()
+    {
+        var sut = Create(new ThrowingSandbox());
+
+        var result = await sut.PlanAsync("infra", CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Errors.Should().Contain("iac.plan.sandbox_error");
+    }
+
+    // ---------- ScanAsync ----------
+
+    [Fact]
+    public async Task ScanAsync_BuildsArmTtkAndCheckovCommands()
+    {
+        var sandbox = new RecordingIacSandbox().WithDefault(true, 0, string.Empty);
+        var sut = Create(sandbox);
+
+        await sut.ScanAsync("infra", CancellationToken.None);
+
+        sandbox.Programs.Should().Contain("arm-ttk");
+        sandbox.Programs.Should().Contain("checkov");
+        sandbox.RequestFor("arm-ttk").ArgumentList.Should().Equal("-TemplatePath", ".");
+        sandbox.RequestFor("checkov").ArgumentList.Should().Equal("-d", ".", "--compact", "--quiet");
+    }
+
+    [Fact]
+    public async Task ScanAsync_CleanScan_Passes()
+    {
+        var sandbox = new RecordingIacSandbox().WithDefault(true, 0, string.Empty);
+        var sut = Create(sandbox);
+
+        var result = await sut.ScanAsync("infra", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.Passed.Should().BeTrue();
+        result.Value.ScannersRun.Should().Equal("arm-ttk", "checkov");
+    }
+
+    [Fact]
+    public async Task ScanAsync_ParsesArmTtkFailureAsFinding()
+    {
+        var armttk = """
+            [-] Secure-Params-No-Hardcoded-Default (12 ms)
+                    Parameter 'adminPassword' must not have a hardcoded default. Severity: High
+            [+] DeploymentTemplate-Schema-Is-Correct (3 ms)
+            """;
+        var sandbox = new RecordingIacSandbox()
+            .ForProgram("arm-ttk", true, 1, armttk)
+            .ForProgram("checkov", true, 0, string.Empty);
+        var sut = Create(sandbox, blockingSeverity: "High");
+
+        var result = await sut.ScanAsync("infra", CancellationToken.None);
+
+        result.Value!.Findings.Should().ContainSingle();
+        result.Value.Findings[0].Scanner.Should().Be("arm-ttk");
+        result.Value.Findings[0].RuleId.Should().Be("Secure-Params-No-Hardcoded-Default");
+        result.Value.Findings[0].Severity.Should().Be(IacScanSeverity.High);
+        result.Value.Passed.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ScanAsync_CombinesArmTtkAndCheckovFindings()
+    {
+        var armttk = "[-] Some-Rule (1 ms)\n        Detail. Severity: Medium";
+        var checkov = """
+            Check: CKV_AZURE_1: "Ensure foo"
+                    FAILED for resource: r.x
+                    Severity: LOW
+            """;
+        var sandbox = new RecordingIacSandbox()
+            .ForProgram("arm-ttk", true, 1, armttk)
+            .ForProgram("checkov", true, 1, checkov);
+        var sut = Create(sandbox, blockingSeverity: "High");
+
+        var result = await sut.ScanAsync("infra", CancellationToken.None);
+
+        result.Value!.Findings.Should().HaveCount(2);
+        // Both are below High -> passes.
+        result.Value.Passed.Should().BeTrue();
+    }
+
+    private sealed class ThrowingSandbox : Application.AI.Common.Interfaces.Sandbox.ISandboxExecutor
+    {
+        public Task<Domain.AI.Sandbox.SandboxExecutionResult> ExecuteAsync(
+            Domain.AI.Sandbox.SandboxExecutionRequest request, CancellationToken ct)
+            => throw new InvalidOperationException("boom");
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Iac/IacChangeProposalValidatorTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Iac/IacChangeProposalValidatorTests.cs
@@ -1,0 +1,210 @@
+using Application.AI.Common.Interfaces.Changes;
+using Application.AI.Common.Interfaces.Iac;
+using Domain.AI.Changes;
+using Domain.AI.Iac;
+using Domain.AI.Identity;
+using Domain.AI.SkillTraining;
+using Domain.Common;
+using FluentAssertions;
+using Infrastructure.AI.Iac;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+using GateAction = Domain.AI.Changes.GateAction;
+
+namespace Infrastructure.AI.Tests.Iac;
+
+/// <summary>
+/// Unit tests for <see cref="IacChangeProposalValidator"/>. Each scenario builds a
+/// service provider with (or without) a keyed <see cref="IIacGenerator"/> and a
+/// proposal whose target is (or is not) an <see cref="IacDeploymentTarget"/>, then
+/// asserts the resulting <see cref="GateResult"/>.
+/// </summary>
+public sealed class IacChangeProposalValidatorTests
+{
+    private static readonly DateTimeOffset Now = DateTimeOffset.Parse("2026-06-08T12:00:00Z");
+
+    private static GateContext Context() => new()
+    {
+        Mode = OrchestratorMode.Shadow,
+        AttemptCount = 1,
+        EvaluatedAt = Now,
+        CorrelationId = "corr-1"
+    };
+
+    private static ChangeProposal IacProposal(string backend = "terraform", string modulePath = "modules/network/main.tf")
+        => new()
+        {
+            Id = "cp-iac-1",
+            Target = new IacDeploymentTarget(backend, "net", modulePath, "prod"),
+            Diff = [new ChangeEdit { Op = EditOp.Replace, Target = modulePath, Content = "# x" }],
+            BlastRadius = BlastRadius.Medium,
+            RequiredGates = [],
+            Status = ChangeProposalStatus.Draft,
+            SubmittedBy = new AgentIdentity { Id = "a-1", Kind = AgentIdentityKind.Development },
+            SubmittedAt = Now
+        };
+
+    private static ChangeProposal GitProposal() => new()
+    {
+        Id = "cp-git-1",
+        Target = new GitRepoTarget("https://github.com/example/x.git", "main"),
+        Diff = [new ChangeEdit { Op = EditOp.Replace, Target = "a.cs", Content = "// x" }],
+        BlastRadius = BlastRadius.Low,
+        RequiredGates = [],
+        Status = ChangeProposalStatus.Draft,
+        SubmittedBy = new AgentIdentity { Id = "a-1", Kind = AgentIdentityKind.Development },
+        SubmittedAt = Now
+    };
+
+    private static IServiceProvider ProviderWith(string backendKey, IIacGenerator generator)
+    {
+        var services = new ServiceCollection();
+        services.AddKeyedSingleton(backendKey, generator);
+        return services.BuildServiceProvider();
+    }
+
+    private static IacChangeProposalValidator Validator(IServiceProvider sp)
+        => new(sp, NullLogger<IacChangeProposalValidator>.Instance);
+
+    private static Mock<IIacGenerator> GeneratorReturning(IacPlanResult plan, IacScanResult? scan = null)
+    {
+        var mock = new Mock<IIacGenerator>();
+        mock.SetupGet(g => g.Backend).Returns(IacBackend.Terraform);
+        mock.Setup(g => g.PlanAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<IacPlanResult>.Success(plan));
+        if (scan is not null)
+        {
+            mock.Setup(g => g.ScanAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(Result<IacScanResult>.Success(scan));
+        }
+
+        return mock;
+    }
+
+    private static IacPlanResult Plan(bool succeeded, bool destructive = false) => new()
+    {
+        Backend = IacBackend.Terraform,
+        ModulePath = "modules/network",
+        Succeeded = succeeded,
+        HasDestructiveChanges = destructive,
+        Summary = "1 to add"
+    };
+
+    private static IacScanResult Scan(bool passed) => new()
+    {
+        Backend = IacBackend.Terraform,
+        ModulePath = "modules/network",
+        Passed = passed,
+        ScannersRun = ["checkov", "tfsec"],
+        Findings = passed ? [] : [new IacScanFinding { Scanner = "checkov", RuleId = "CKV_X", Severity = IacScanSeverity.High }]
+    };
+
+    [Fact]
+    public void Key_IsIacPlanScan()
+    {
+        Validator(new ServiceCollection().BuildServiceProvider()).Key.Should().Be("iac_plan_scan");
+    }
+
+    [Fact]
+    public async Task ValidateAsync_NonIacTarget_Passes()
+    {
+        var sut = Validator(new ServiceCollection().BuildServiceProvider());
+
+        var result = await sut.ValidateAsync(GitProposal(), Context(), CancellationToken.None);
+
+        result.Action.Should().Be(GateAction.Pass);
+    }
+
+    [Fact]
+    public async Task ValidateAsync_NoGeneratorForBackend_Fails()
+    {
+        var sp = new ServiceCollection().BuildServiceProvider();
+        var sut = Validator(sp);
+
+        var result = await sut.ValidateAsync(IacProposal("pulumi"), Context(), CancellationToken.None);
+
+        result.Action.Should().Be(GateAction.Fail);
+        result.Reason.Should().Contain("iac.backend_not_registered");
+    }
+
+    [Fact]
+    public async Task ValidateAsync_PlanFails_Fails()
+    {
+        var generator = new Mock<IIacGenerator>();
+        generator.SetupGet(g => g.Backend).Returns(IacBackend.Terraform);
+        generator.Setup(g => g.PlanAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<IacPlanResult>.Fail("iac.plan.sandbox_error"));
+        var sut = Validator(ProviderWith("terraform", generator.Object));
+
+        var result = await sut.ValidateAsync(IacProposal(), Context(), CancellationToken.None);
+
+        result.Action.Should().Be(GateAction.Fail);
+        result.Reason.Should().Contain("iac.plan_failed");
+    }
+
+    [Fact]
+    public async Task ValidateAsync_PlanInvalid_Fails()
+    {
+        var generator = GeneratorReturning(Plan(succeeded: false));
+        var sut = Validator(ProviderWith("terraform", generator.Object));
+
+        var result = await sut.ValidateAsync(IacProposal(), Context(), CancellationToken.None);
+
+        result.Action.Should().Be(GateAction.Fail);
+        result.Reason.Should().Contain("iac.plan_invalid");
+    }
+
+    [Fact]
+    public async Task ValidateAsync_DestructivePlan_Fails()
+    {
+        var generator = GeneratorReturning(Plan(succeeded: true, destructive: true));
+        var sut = Validator(ProviderWith("terraform", generator.Object));
+
+        var result = await sut.ValidateAsync(IacProposal(), Context(), CancellationToken.None);
+
+        result.Action.Should().Be(GateAction.Fail);
+        result.Reason.Should().Contain("iac.plan_destructive");
+    }
+
+    [Fact]
+    public async Task ValidateAsync_ScanBlocked_Fails()
+    {
+        var generator = GeneratorReturning(Plan(succeeded: true), Scan(passed: false));
+        var sut = Validator(ProviderWith("terraform", generator.Object));
+
+        var result = await sut.ValidateAsync(IacProposal(), Context(), CancellationToken.None);
+
+        result.Action.Should().Be(GateAction.Fail);
+        result.Reason.Should().Contain("iac.scan_blocked");
+    }
+
+    [Fact]
+    public async Task ValidateAsync_CleanPlanAndScan_Passes()
+    {
+        var generator = GeneratorReturning(Plan(succeeded: true), Scan(passed: true));
+        var sut = Validator(ProviderWith("terraform", generator.Object));
+
+        var result = await sut.ValidateAsync(IacProposal(), Context(), CancellationToken.None);
+
+        result.Action.Should().Be(GateAction.Pass);
+    }
+
+    [Fact]
+    public async Task ValidateAsync_ScanFails_Fails()
+    {
+        var generator = new Mock<IIacGenerator>();
+        generator.SetupGet(g => g.Backend).Returns(IacBackend.Terraform);
+        generator.Setup(g => g.PlanAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<IacPlanResult>.Success(Plan(succeeded: true)));
+        generator.Setup(g => g.ScanAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<IacScanResult>.Fail("iac.scan.sandbox_error"));
+        var sut = Validator(ProviderWith("terraform", generator.Object));
+
+        var result = await sut.ValidateAsync(IacProposal(), Context(), CancellationToken.None);
+
+        result.Action.Should().Be(GateAction.Fail);
+        result.Reason.Should().Contain("iac.scan_failed");
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Iac/IacDependencyInjectionTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Iac/IacDependencyInjectionTests.cs
@@ -1,0 +1,162 @@
+using System.Reflection;
+using Application.AI.Common.Interfaces.Changes;
+using Application.AI.Common.Interfaces.Iac;
+using Application.AI.Common.Interfaces.Sandbox;
+using Application.AI.Common.Interfaces.Tools;
+using Domain.AI.Changes;
+using Domain.AI.Iac;
+using Domain.AI.Sandbox;
+using FluentAssertions;
+using Infrastructure.AI.Changes.Gates;
+using Infrastructure.AI.Iac;
+using Infrastructure.AI.Tools.Iac;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Moq;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Iac;
+
+/// <summary>
+/// Verifies <see cref="IacDependencyInjection.AddIacSkillTools"/> registers the
+/// three tools and both generators by keyed name, and — crucially — that the
+/// private <c>RegisterIacValidator</c> swap replaces the fail-loud
+/// <c>NotConfiguredValidator</c> placeholder (registered by
+/// <c>RegisterChangesServices</c>) with the real
+/// <see cref="IacChangeProposalValidator"/> under the
+/// <see cref="ChangeTargetKind.IacDeployment"/> key.
+/// </summary>
+public sealed class IacDependencyInjectionTests
+{
+    private static readonly MethodInfo RegisterChangesMethod =
+        typeof(Infrastructure.AI.DependencyInjection)
+            .GetMethod("RegisterChangesServices", BindingFlags.NonPublic | BindingFlags.Static)!;
+
+    private static readonly MethodInfo RegisterIacValidatorMethod =
+        typeof(Infrastructure.AI.DependencyInjection)
+            .GetMethod("RegisterIacValidator", BindingFlags.NonPublic | BindingFlags.Static)!;
+
+    private static void RegisterChanges(IServiceCollection services) => RegisterChangesMethod.Invoke(null, [services]);
+    private static void RegisterIacValidator(IServiceCollection services) => RegisterIacValidatorMethod.Invoke(null, [services]);
+
+    private static IServiceCollection BaseServices()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton(IacTestConfig.ValidMonitor());
+        services.AddSingleton(TimeProvider.System);
+        // The generators resolve the keyed Process sandbox executor at construction.
+        services.AddKeyedSingleton<ISandboxExecutor>(SandboxIsolationLevel.Process, Mock.Of<ISandboxExecutor>());
+        return services;
+    }
+
+    [Fact]
+    public void AddIacSkillTools_RegistersAllThreeToolsByKeyedName()
+    {
+        var services = BaseServices();
+
+        services.AddIacSkillTools();
+        var sp = services.BuildServiceProvider();
+
+        sp.GetRequiredKeyedService<ITool>(IacGenerateTool.ToolName).Should().BeOfType<IacGenerateTool>();
+        sp.GetRequiredKeyedService<ITool>(IacPlanTool.ToolName).Should().BeOfType<IacPlanTool>();
+        sp.GetRequiredKeyedService<ITool>(IacScanTool.ToolName).Should().BeOfType<IacScanTool>();
+    }
+
+    [Fact]
+    public void AddIacSkillTools_RegistersBothGeneratorsByBackendKey()
+    {
+        var services = BaseServices();
+
+        services.AddIacSkillTools();
+        var sp = services.BuildServiceProvider();
+
+        sp.GetRequiredKeyedService<IIacGenerator>("terraform").Should().BeOfType<TerraformGenerator>();
+        sp.GetRequiredKeyedService<IIacGenerator>("bicep").Should().BeOfType<BicepGenerator>();
+    }
+
+    [Fact]
+    public void AddIacSkillTools_GeneratorsExposeMatchingBackend()
+    {
+        var services = BaseServices();
+
+        services.AddIacSkillTools();
+        var sp = services.BuildServiceProvider();
+
+        sp.GetRequiredKeyedService<IIacGenerator>("terraform").Backend.Should().Be(IacBackend.Terraform);
+        sp.GetRequiredKeyedService<IIacGenerator>("bicep").Backend.Should().Be(IacBackend.Bicep);
+    }
+
+    [Fact]
+    public void AddIacSkillTools_RegistersStartupValidatorAsHostedService()
+    {
+        var services = BaseServices();
+
+        services.AddIacSkillTools();
+        var sp = services.BuildServiceProvider();
+
+        sp.GetServices<IHostedService>().Should().ContainSingle(h => h is IacStartupValidator);
+    }
+
+    // ---------- The validator swap (proves the placeholder is replaced) ----------
+
+    [Fact]
+    public void RegisterChangesServices_SeedsNotConfiguredPlaceholderForIacDeployment()
+    {
+        var services = BaseServices();
+
+        RegisterChanges(services);
+        var sp = services.BuildServiceProvider();
+
+        // Before the swap, the IaC validator key resolves to the fail-loud placeholder.
+        sp.GetRequiredKeyedService<IChangeProposalValidator>(ChangeTargetKind.IacDeployment)
+            .Should().BeOfType<NotConfiguredValidator>();
+    }
+
+    [Fact]
+    public void RegisterIacValidator_ReplacesPlaceholderWithRealValidator()
+    {
+        var services = BaseServices();
+
+        // Compose the root in the same order the production entry point does:
+        // RegisterChangesServices seeds the placeholder, then RegisterIacValidator swaps it.
+        RegisterChanges(services);
+        RegisterIacValidator(services);
+        var sp = services.BuildServiceProvider();
+
+        var validators = sp.GetKeyedServices<IChangeProposalValidator>(ChangeTargetKind.IacDeployment).ToList();
+
+        validators.Should().ContainSingle();
+        validators[0].Should().BeOfType<IacChangeProposalValidator>();
+        validators.Should().NotContain(v => v is NotConfiguredValidator);
+    }
+
+    [Fact]
+    public void RegisterIacValidator_RealValidatorHasIacPlanScanKey()
+    {
+        var services = BaseServices();
+
+        RegisterChanges(services);
+        RegisterIacValidator(services);
+        var sp = services.BuildServiceProvider();
+
+        sp.GetRequiredKeyedService<IChangeProposalValidator>(ChangeTargetKind.IacDeployment)
+            .Key.Should().Be("iac_plan_scan");
+    }
+
+    [Fact]
+    public void RegisterIacValidator_LeavesOtherTargetKindPlaceholdersIntact()
+    {
+        var services = BaseServices();
+
+        RegisterChanges(services);
+        RegisterIacValidator(services);
+        var sp = services.BuildServiceProvider();
+
+        // GitRepo + KubernetesResource placeholders must not be disturbed by the IaC swap.
+        sp.GetRequiredKeyedService<IChangeProposalValidator>(ChangeTargetKind.GitRepo)
+            .Should().BeOfType<NotConfiguredValidator>();
+        sp.GetRequiredKeyedService<IChangeProposalValidator>(ChangeTargetKind.KubernetesResource)
+            .Should().BeOfType<NotConfiguredValidator>();
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Iac/IacStartupValidatorTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Iac/IacStartupValidatorTests.cs
@@ -1,0 +1,147 @@
+using Domain.Common.Config;
+using Domain.Common.Config.AI;
+using Domain.Common.Config.AI.Iac;
+using FluentAssertions;
+using Infrastructure.AI.Iac;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Iac;
+
+/// <summary>
+/// Tests for <see cref="IacStartupValidator"/>. Disabled is always a no-op; each
+/// misconfiguration throws <see cref="InvalidOperationException"/> at boot; a valid
+/// config passes.
+/// </summary>
+public sealed class IacStartupValidatorTests
+{
+    private static IacStartupValidator Create(IacConfig iac)
+    {
+        var appConfig = new AppConfig { AI = new AIConfig { Iac = iac } };
+        var monitor = Mock.Of<IOptionsMonitor<AppConfig>>(o => o.CurrentValue == appConfig);
+        return new IacStartupValidator(monitor, NullLogger<IacStartupValidator>.Instance);
+    }
+
+    private static IacConfig ValidConfig() => new()
+    {
+        Enabled = true,
+        EnabledBackends = ["terraform", "bicep"],
+        TerraformVersion = "1.9.5",
+        BicepVersion = "0.30.23",
+        CheckovVersion = "3.2.0",
+        TfsecVersion = "1.28.11",
+        ArmTtkVersion = "0.24",
+        BlockingSeverity = "High",
+        RegistryAllowlist = ["registry.terraform.io"]
+    };
+
+    [Fact]
+    public async Task StartAsync_Disabled_NoOp()
+    {
+        var config = ValidConfig();
+        config.Enabled = false;
+        config.EnabledBackends = []; // would be invalid if enabled
+        var sut = Create(config);
+
+        var act = () => sut.StartAsync(CancellationToken.None);
+
+        await act.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task StartAsync_Valid_Passes()
+    {
+        var sut = Create(ValidConfig());
+
+        var act = () => sut.StartAsync(CancellationToken.None);
+
+        await act.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task StartAsync_EmptyBackends_Throws()
+    {
+        var config = ValidConfig();
+        config.EnabledBackends = [];
+        var sut = Create(config);
+
+        var act = () => sut.StartAsync(CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("*EnabledBackends*");
+    }
+
+    [Fact]
+    public async Task StartAsync_UnknownBackend_Throws()
+    {
+        var config = ValidConfig();
+        config.EnabledBackends = ["terraform", "pulumi"];
+        var sut = Create(config);
+
+        var act = () => sut.StartAsync(CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("*unknown backend*");
+    }
+
+    [Fact]
+    public async Task StartAsync_TerraformEnabledButTerraformVersionBlank_Throws()
+    {
+        var config = ValidConfig();
+        config.TerraformVersion = "";
+        var sut = Create(config);
+
+        var act = () => sut.StartAsync(CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("*TerraformVersion*");
+    }
+
+    [Fact]
+    public async Task StartAsync_BicepEnabledButArmTtkVersionBlank_Throws()
+    {
+        var config = ValidConfig();
+        config.ArmTtkVersion = "";
+        var sut = Create(config);
+
+        var act = () => sut.StartAsync(CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("*ArmTtkVersion*");
+    }
+
+    [Fact]
+    public async Task StartAsync_OnlyBicepEnabled_DoesNotRequireTerraformVersion()
+    {
+        var config = ValidConfig();
+        config.EnabledBackends = ["bicep"];
+        config.TerraformVersion = ""; // not needed when terraform is not enabled
+        var sut = Create(config);
+
+        var act = () => sut.StartAsync(CancellationToken.None);
+
+        await act.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task StartAsync_InvalidBlockingSeverity_Throws()
+    {
+        var config = ValidConfig();
+        config.BlockingSeverity = "nonsense";
+        var sut = Create(config);
+
+        var act = () => sut.StartAsync(CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("*BlockingSeverity*");
+    }
+
+    [Fact]
+    public async Task StartAsync_EmptyRegistryAllowlist_Throws()
+    {
+        var config = ValidConfig();
+        config.RegistryAllowlist = [];
+        var sut = Create(config);
+
+        var act = () => sut.StartAsync(CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("*RegistryAllowlist*");
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Iac/IacTestSupport.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Iac/IacTestSupport.cs
@@ -1,0 +1,102 @@
+using Application.AI.Common.Interfaces.Sandbox;
+using Domain.AI.Sandbox;
+using Domain.Common.Config;
+using Domain.Common.Config.AI;
+using Domain.Common.Config.AI.Iac;
+using Microsoft.Extensions.Options;
+using Moq;
+
+namespace Infrastructure.AI.Tests.Iac;
+
+/// <summary>
+/// Shared builders for the IaC test suite: an <see cref="IOptionsMonitor{AppConfig}"/>
+/// whose <c>AI.Iac</c> section is configured per scenario, and a programmable
+/// recording sandbox that returns canned CLI output keyed by the program invoked.
+/// </summary>
+internal static class IacTestConfig
+{
+    /// <summary>Builds an <see cref="AppConfig"/> with a fully-valid IaC section.</summary>
+    public static AppConfig ValidAppConfig(
+        string blockingSeverity = "High",
+        IEnumerable<string>? enabledBackends = null,
+        IEnumerable<string>? registryAllowlist = null)
+    {
+        return new AppConfig
+        {
+            AI = new AIConfig
+            {
+                Iac = new IacConfig
+                {
+                    Enabled = true,
+                    EnabledBackends = (enabledBackends ?? ["terraform", "bicep"]).ToList(),
+                    BlockingSeverity = blockingSeverity,
+                    RegistryAllowlist = (registryAllowlist ?? ["registry.terraform.io", "mcr.microsoft.com"]).ToList()
+                }
+            }
+        };
+    }
+
+    /// <summary>Wraps an <see cref="AppConfig"/> in a Moq-backed monitor.</summary>
+    public static IOptionsMonitor<AppConfig> Monitor(AppConfig appConfig)
+        => Mock.Of<IOptionsMonitor<AppConfig>>(o => o.CurrentValue == appConfig);
+
+    /// <summary>Convenience: a monitor over a valid config with the given blocking severity.</summary>
+    public static IOptionsMonitor<AppConfig> ValidMonitor(string blockingSeverity = "High")
+        => Monitor(ValidAppConfig(blockingSeverity));
+}
+
+/// <summary>
+/// Recording <see cref="ISandboxExecutor"/> fake that returns canned results keyed
+/// by the CLI program (<c>terraform</c>, <c>bicep</c>, <c>checkov</c>, <c>tfsec</c>,
+/// <c>arm-ttk</c>). Records every request so tests can assert the exact program +
+/// argument list the generator built.
+/// </summary>
+internal sealed class RecordingIacSandbox : ISandboxExecutor
+{
+    private readonly Dictionary<string, SandboxExecutionResult> _byProgram = new(StringComparer.OrdinalIgnoreCase);
+    private SandboxExecutionResult _default = new() { Success = true, ExitCode = 0, Output = string.Empty };
+
+    /// <summary>Every request the generator dispatched, in order.</summary>
+    public List<SandboxExecutionRequest> Requests { get; } = [];
+
+    /// <summary>Programs invoked, in order — convenience accessor for assertions.</summary>
+    public IReadOnlyList<string?> Programs => Requests.Select(r => r.Command).ToList();
+
+    /// <summary>Sets the canned result for a given program (matched case-insensitively).</summary>
+    public RecordingIacSandbox ForProgram(string program, bool success, int exitCode, string output)
+    {
+        _byProgram[program] = new SandboxExecutionResult
+        {
+            Success = success,
+            ExitCode = exitCode,
+            Output = output,
+            ErrorMessage = success ? null : output
+        };
+        return this;
+    }
+
+    /// <summary>Sets the fallback result for any program with no explicit mapping.</summary>
+    public RecordingIacSandbox WithDefault(bool success, int exitCode, string output)
+    {
+        _default = new SandboxExecutionResult
+        {
+            Success = success,
+            ExitCode = exitCode,
+            Output = output,
+            ErrorMessage = success ? null : output
+        };
+        return this;
+    }
+
+    /// <summary>The single request whose program matches <paramref name="program"/>.</summary>
+    public SandboxExecutionRequest RequestFor(string program)
+        => Requests.Single(r => string.Equals(r.Command, program, StringComparison.OrdinalIgnoreCase));
+
+    /// <inheritdoc />
+    public Task<SandboxExecutionResult> ExecuteAsync(SandboxExecutionRequest request, CancellationToken ct)
+    {
+        Requests.Add(request);
+        var result = _byProgram.TryGetValue(request.Command ?? string.Empty, out var mapped) ? mapped : _default;
+        return Task.FromResult(result);
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Iac/IacToolsTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Iac/IacToolsTests.cs
@@ -1,0 +1,271 @@
+using Application.AI.Common.Interfaces.Iac;
+using Domain.AI.Iac;
+using Domain.Common;
+using FluentAssertions;
+using Infrastructure.AI.Tools.Iac;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Iac;
+
+/// <summary>
+/// Tests the three agent-facing IaC tools against a mocked
+/// <see cref="IIacGenerator"/> resolved by backend key. Each tool is asserted on its
+/// happy path (JSON returned), its failure pass-through, and its unknown-operation
+/// rejection. The default backend is resolved from <c>AppConfig.AI.Iac.EnabledBackends</c>.
+/// </summary>
+public sealed class IacToolsTests
+{
+    private static (IServiceProvider sp, Mock<IIacGenerator> gen) ProviderWith(string backendKey = "terraform")
+    {
+        var gen = new Mock<IIacGenerator>();
+        gen.SetupGet(g => g.Backend).Returns(IacBackend.Terraform);
+        var services = new ServiceCollection();
+        services.AddKeyedSingleton(backendKey, gen.Object);
+        return (services.BuildServiceProvider(), gen);
+    }
+
+    private static IReadOnlyDictionary<string, object?> Params(params (string, object?)[] kv)
+        => kv.ToDictionary(p => p.Item1, p => p.Item2);
+
+    // ---------- IacGenerateTool ----------
+
+    [Fact]
+    public async Task GenerateTool_HappyPath_ReturnsOkWithJson()
+    {
+        var (sp, gen) = ProviderWith();
+        gen.Setup(g => g.GenerateAsync(It.IsAny<IacGenerationRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<IacGenerationResult>.Success(new IacGenerationResult
+            {
+                Backend = IacBackend.Terraform,
+                Files = new Dictionary<string, string> { ["main.tf"] = "resource {}" }
+            }));
+        var tool = new IacGenerateTool(sp, IacTestConfig.ValidMonitor());
+
+        var result = await tool.ExecuteAsync("generate", Params(
+            ("resource_type", "azurerm_storage_account"),
+            ("resource_name", "primary")));
+
+        result.Success.Should().BeTrue();
+        result.Output.Should().Contain("main.tf");
+    }
+
+    [Fact]
+    public async Task GenerateTool_MissingResourceType_ReturnsFail()
+    {
+        var (sp, _) = ProviderWith();
+        var tool = new IacGenerateTool(sp, IacTestConfig.ValidMonitor());
+
+        var result = await tool.ExecuteAsync("generate", Params(("resource_name", "primary")));
+
+        result.Success.Should().BeFalse();
+        result.Error.Should().Contain("resource_type");
+    }
+
+    [Fact]
+    public async Task GenerateTool_GeneratorFails_ReturnsFail()
+    {
+        var (sp, gen) = ProviderWith();
+        gen.Setup(g => g.GenerateAsync(It.IsAny<IacGenerationRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<IacGenerationResult>.Fail("iac.generate.invalid_request"));
+        var tool = new IacGenerateTool(sp, IacTestConfig.ValidMonitor());
+
+        var result = await tool.ExecuteAsync("generate", Params(
+            ("resource_type", "x"), ("resource_name", "y")));
+
+        result.Success.Should().BeFalse();
+        result.Error.Should().Contain("iac.generate.invalid_request");
+    }
+
+    [Fact]
+    public async Task GenerateTool_UnknownOperation_ReturnsFail()
+    {
+        var (sp, _) = ProviderWith();
+        var tool = new IacGenerateTool(sp, IacTestConfig.ValidMonitor());
+
+        var result = await tool.ExecuteAsync("destroy", Params());
+
+        result.Success.Should().BeFalse();
+        result.Error.Should().Contain("Unknown operation");
+    }
+
+    [Fact]
+    public async Task GenerateTool_UnknownBackend_ReturnsFail()
+    {
+        var (sp, _) = ProviderWith();
+        var tool = new IacGenerateTool(sp, IacTestConfig.ValidMonitor());
+
+        var result = await tool.ExecuteAsync("generate", Params(
+            ("backend", "pulumi"), ("resource_type", "x"), ("resource_name", "y")));
+
+        result.Success.Should().BeFalse();
+        result.Error.Should().Contain("iac.backend_not_registered");
+    }
+
+    [Fact]
+    public void GenerateTool_IsReadOnly()
+    {
+        var (sp, _) = ProviderWith();
+        var tool = new IacGenerateTool(sp, IacTestConfig.ValidMonitor());
+
+        tool.Name.Should().Be("iac_generate");
+        tool.IsReadOnly.Should().BeTrue();
+    }
+
+    // ---------- IacPlanTool ----------
+
+    [Fact]
+    public async Task PlanTool_HappyPath_ReturnsOkWithJson()
+    {
+        var (sp, gen) = ProviderWith();
+        gen.Setup(g => g.PlanAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<IacPlanResult>.Success(new IacPlanResult
+            {
+                Backend = IacBackend.Terraform,
+                ModulePath = "modules/net",
+                Succeeded = true,
+                Summary = "1 to add"
+            }));
+        var tool = new IacPlanTool(sp, IacTestConfig.ValidMonitor());
+
+        var result = await tool.ExecuteAsync("plan", Params(("module_directory", "modules/net")));
+
+        result.Success.Should().BeTrue();
+        result.Output.Should().Contain("1 to add");
+    }
+
+    [Fact]
+    public async Task PlanTool_MissingDirectory_ReturnsFail()
+    {
+        var (sp, _) = ProviderWith();
+        var tool = new IacPlanTool(sp, IacTestConfig.ValidMonitor());
+
+        var result = await tool.ExecuteAsync("plan", Params());
+
+        result.Success.Should().BeFalse();
+        result.Error.Should().Contain("module_directory");
+    }
+
+    [Fact]
+    public async Task PlanTool_GeneratorFails_ReturnsFail()
+    {
+        var (sp, gen) = ProviderWith();
+        gen.Setup(g => g.PlanAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<IacPlanResult>.Fail("iac.plan.sandbox_error"));
+        var tool = new IacPlanTool(sp, IacTestConfig.ValidMonitor());
+
+        var result = await tool.ExecuteAsync("plan", Params(("module_directory", "modules/net")));
+
+        result.Success.Should().BeFalse();
+        result.Error.Should().Contain("iac.plan.sandbox_error");
+    }
+
+    [Fact]
+    public async Task PlanTool_UnknownOperation_ReturnsFail()
+    {
+        var (sp, _) = ProviderWith();
+        var tool = new IacPlanTool(sp, IacTestConfig.ValidMonitor());
+
+        var result = await tool.ExecuteAsync("apply", Params());
+
+        result.Success.Should().BeFalse();
+        result.Error.Should().Contain("Unknown operation");
+    }
+
+    [Fact]
+    public void PlanTool_IsReadOnlyAndConcurrencySafe()
+    {
+        var (sp, _) = ProviderWith();
+        var tool = new IacPlanTool(sp, IacTestConfig.ValidMonitor());
+
+        tool.Name.Should().Be("iac_plan");
+        tool.IsReadOnly.Should().BeTrue();
+        tool.IsConcurrencySafe.Should().BeTrue();
+    }
+
+    // ---------- IacScanTool ----------
+
+    [Fact]
+    public async Task ScanTool_HappyPath_ReturnsOkWithJson()
+    {
+        var (sp, gen) = ProviderWith();
+        gen.Setup(g => g.ScanAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<IacScanResult>.Success(new IacScanResult
+            {
+                Backend = IacBackend.Terraform,
+                ModulePath = "modules/net",
+                Passed = true,
+                ScannersRun = ["checkov", "tfsec"]
+            }));
+        var tool = new IacScanTool(sp, IacTestConfig.ValidMonitor());
+
+        var result = await tool.ExecuteAsync("scan", Params(("module_directory", "modules/net")));
+
+        result.Success.Should().BeTrue();
+        result.Output.Should().Contain("checkov");
+    }
+
+    [Fact]
+    public async Task ScanTool_MissingDirectory_ReturnsFail()
+    {
+        var (sp, _) = ProviderWith();
+        var tool = new IacScanTool(sp, IacTestConfig.ValidMonitor());
+
+        var result = await tool.ExecuteAsync("scan", Params());
+
+        result.Success.Should().BeFalse();
+        result.Error.Should().Contain("module_directory");
+    }
+
+    [Fact]
+    public async Task ScanTool_GeneratorFails_ReturnsFail()
+    {
+        var (sp, gen) = ProviderWith();
+        gen.Setup(g => g.ScanAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<IacScanResult>.Fail("iac.scan.sandbox_error"));
+        var tool = new IacScanTool(sp, IacTestConfig.ValidMonitor());
+
+        var result = await tool.ExecuteAsync("scan", Params(("module_directory", "modules/net")));
+
+        result.Success.Should().BeFalse();
+        result.Error.Should().Contain("iac.scan.sandbox_error");
+    }
+
+    [Fact]
+    public async Task ScanTool_UnknownOperation_ReturnsFail()
+    {
+        var (sp, _) = ProviderWith();
+        var tool = new IacScanTool(sp, IacTestConfig.ValidMonitor());
+
+        var result = await tool.ExecuteAsync("fix", Params());
+
+        result.Success.Should().BeFalse();
+        result.Error.Should().Contain("Unknown operation");
+    }
+
+    [Fact]
+    public async Task ScanTool_BackendParameterSelectsBicep()
+    {
+        var bicep = new Mock<IIacGenerator>();
+        bicep.SetupGet(g => g.Backend).Returns(IacBackend.Bicep);
+        bicep.Setup(g => g.ScanAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<IacScanResult>.Success(new IacScanResult
+            {
+                Backend = IacBackend.Bicep,
+                ModulePath = "infra",
+                Passed = true,
+                ScannersRun = ["arm-ttk", "checkov"]
+            }));
+        var services = new ServiceCollection();
+        services.AddKeyedSingleton("bicep", bicep.Object);
+        var sp = services.BuildServiceProvider();
+        var tool = new IacScanTool(sp, IacTestConfig.ValidMonitor());
+
+        var result = await tool.ExecuteAsync("scan", Params(
+            ("backend", "bicep"), ("module_directory", "infra")));
+
+        result.Success.Should().BeTrue();
+        result.Output.Should().Contain("arm-ttk");
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Iac/TerraformGeneratorTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Iac/TerraformGeneratorTests.cs
@@ -1,0 +1,257 @@
+using Domain.AI.Iac;
+using FluentAssertions;
+using Infrastructure.AI.Iac;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Iac;
+
+/// <summary>
+/// Unit tests for <see cref="TerraformGenerator"/>. Scaffold output is asserted
+/// directly; plan/scan are exercised against a recording sandbox so the exact CLI
+/// program + arguments are verified and canned CLI output is parsed into the
+/// domain result shapes. Never invokes a real CLI.
+/// </summary>
+public sealed class TerraformGeneratorTests
+{
+    private static TerraformGenerator Create(Application.AI.Common.Interfaces.Sandbox.ISandboxExecutor sandbox, string blockingSeverity = "High")
+        => new(
+            IacTestConfig.ValidMonitor(blockingSeverity),
+            sandbox,
+            NullLogger<TerraformGenerator>.Instance,
+            TimeProvider.System);
+
+    private static IacGenerationRequest Request() => new()
+    {
+        Backend = IacBackend.Terraform,
+        ResourceType = "azurerm_storage_account",
+        ResourceName = "primary",
+        Environment = "prod",
+        Parameters = new Dictionary<string, string> { ["location"] = "eastus" }
+    };
+
+    // ---------- GenerateAsync ----------
+
+    [Fact]
+    public async Task GenerateAsync_ProducesMainAndVariablesTf()
+    {
+        var sut = Create(new RecordingIacSandbox());
+
+        var result = await sut.GenerateAsync(Request(), CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.Backend.Should().Be(IacBackend.Terraform);
+        result.Value.Files.Should().ContainKey("main.tf");
+        result.Value.Files.Should().ContainKey("variables.tf");
+        result.Value.Files["main.tf"].Should().Contain("resource \"azurerm_storage_account\" \"primary\"");
+        result.Value.Files["main.tf"].Should().Contain("location = \"eastus\"");
+    }
+
+    [Fact]
+    public async Task GenerateAsync_BlankResourceType_Fails()
+    {
+        var sut = Create(new RecordingIacSandbox());
+        var request = Request() with { ResourceType = "" };
+
+        var result = await sut.GenerateAsync(request, CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Errors.Should().Contain("iac.generate.invalid_request");
+    }
+
+    // ---------- PlanAsync ----------
+
+    [Fact]
+    public async Task PlanAsync_BuildsValidateThenPlanCommands()
+    {
+        var sandbox = new RecordingIacSandbox()
+            .ForProgram("terraform", success: true, exitCode: 0, output: "Success! No changes.");
+        var sut = Create(sandbox);
+
+        await sut.PlanAsync("modules/network", CancellationToken.None);
+
+        sandbox.Requests.Should().HaveCount(2);
+        sandbox.Requests[0].Command.Should().Be("terraform");
+        sandbox.Requests[0].ArgumentList.Should().Equal("validate", "-no-color");
+        sandbox.Requests[1].ArgumentList.Should().Equal("plan", "-no-color", "-detailed-exitcode");
+    }
+
+    [Fact]
+    public async Task PlanAsync_ValidateFails_ReturnsFailedPlanWithoutRunningPlan()
+    {
+        var sandbox = new RecordingIacSandbox()
+            .ForProgram("terraform", success: false, exitCode: 1, output: "Error: invalid HCL");
+        var sut = Create(sandbox);
+
+        var result = await sut.PlanAsync("modules/network", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.Succeeded.Should().BeFalse();
+        // Only validate ran; plan was skipped.
+        sandbox.Requests.Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task PlanAsync_PlanWithChanges_SetsHasChanges()
+    {
+        var sandbox = new RecordingIacSandbox()
+            .ForProgram("terraform", success: true, exitCode: 2,
+                output: "Plan: 3 to add, 1 to change, 0 to destroy.");
+        var sut = Create(sandbox);
+
+        var result = await sut.PlanAsync("modules/network", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.Succeeded.Should().BeTrue();
+        result.Value.HasChanges.Should().BeTrue();
+        result.Value.HasDestructiveChanges.Should().BeFalse();
+        result.Value.Summary.Should().Contain("to add");
+    }
+
+    [Fact]
+    public async Task PlanAsync_DestructivePlan_SetsHasDestructiveChanges()
+    {
+        var sandbox = new RecordingIacSandbox()
+            .ForProgram("terraform", success: true, exitCode: 2,
+                output: "Plan: 1 to add, 0 to change, 2 to destroy.");
+        var sut = Create(sandbox);
+
+        var result = await sut.PlanAsync("modules/network", CancellationToken.None);
+
+        result.Value!.HasDestructiveChanges.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task PlanAsync_SandboxThrows_ReturnsStableFailureCode()
+    {
+        var sut = Create(new ThrowingSandbox());
+
+        var result = await sut.PlanAsync("modules/network", CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Errors.Should().Contain("iac.plan.sandbox_error");
+    }
+
+    [Fact]
+    public async Task PlanAsync_BlankDirectory_Fails()
+    {
+        var sut = Create(new RecordingIacSandbox());
+
+        var result = await sut.PlanAsync("  ", CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Errors.Should().Contain("iac.plan.invalid_module_directory");
+    }
+
+    // ---------- ScanAsync ----------
+
+    [Fact]
+    public async Task ScanAsync_BuildsCheckovAndTfsecCommands()
+    {
+        var sandbox = new RecordingIacSandbox().WithDefault(true, 0, string.Empty);
+        var sut = Create(sandbox);
+
+        await sut.ScanAsync("modules/network", CancellationToken.None);
+
+        sandbox.Programs.Should().Contain("checkov");
+        sandbox.Programs.Should().Contain("tfsec");
+        sandbox.RequestFor("checkov").ArgumentList.Should().Equal("-d", ".", "--compact", "--quiet");
+        sandbox.RequestFor("tfsec").ArgumentList.Should().Equal(".", "--no-colour");
+    }
+
+    [Fact]
+    public async Task ScanAsync_CleanScan_Passes()
+    {
+        var sandbox = new RecordingIacSandbox().WithDefault(true, 0, string.Empty);
+        var sut = Create(sandbox);
+
+        var result = await sut.ScanAsync("modules/network", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.Passed.Should().BeTrue();
+        result.Value.Findings.Should().BeEmpty();
+        result.Value.ScannersRun.Should().Equal("checkov", "tfsec");
+    }
+
+    [Fact]
+    public async Task ScanAsync_HighFindingWithHighBlocking_Fails()
+    {
+        var checkov = """
+            Check: CKV_AZURE_33: "Ensure Storage logging is enabled for Queue service"
+                    FAILED for resource: azurerm_storage_account.primary
+                    Severity: HIGH
+            """;
+        var sandbox = new RecordingIacSandbox()
+            .ForProgram("checkov", true, 1, checkov)
+            .ForProgram("tfsec", true, 0, string.Empty);
+        var sut = Create(sandbox, blockingSeverity: "High");
+
+        var result = await sut.ScanAsync("modules/network", CancellationToken.None);
+
+        result.Value!.Passed.Should().BeFalse();
+        result.Value.Findings.Should().ContainSingle();
+        result.Value.Findings[0].Scanner.Should().Be("checkov");
+        result.Value.Findings[0].RuleId.Should().Be("CKV_AZURE_33");
+        result.Value.Findings[0].Severity.Should().Be(IacScanSeverity.High);
+    }
+
+    [Fact]
+    public async Task ScanAsync_HighFindingWithCriticalBlocking_PassesBecauseBelowThreshold()
+    {
+        var checkov = """
+            Check: CKV_AZURE_33: "Ensure Storage logging is enabled"
+                    FAILED for resource: azurerm_storage_account.primary
+                    Severity: HIGH
+            """;
+        var sandbox = new RecordingIacSandbox()
+            .ForProgram("checkov", true, 1, checkov)
+            .ForProgram("tfsec", true, 0, string.Empty);
+        var sut = Create(sandbox, blockingSeverity: "Critical");
+
+        var result = await sut.ScanAsync("modules/network", CancellationToken.None);
+
+        result.Value!.Passed.Should().BeTrue();
+        result.Value.Findings.Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task ScanAsync_ParsesTfsecFindings()
+    {
+        var tfsec = """
+            Result #1 CRITICAL Storage account uses an insecure TLS version
+              ID       azure-storage-use-secure-tls-policy
+              Severity CRITICAL
+              Resource azurerm_storage_account.primary
+            """;
+        var sandbox = new RecordingIacSandbox()
+            .ForProgram("checkov", true, 0, string.Empty)
+            .ForProgram("tfsec", true, 1, tfsec);
+        var sut = Create(sandbox);
+
+        var result = await sut.ScanAsync("modules/network", CancellationToken.None);
+
+        result.Value!.Findings.Should().ContainSingle();
+        result.Value.Findings[0].Scanner.Should().Be("tfsec");
+        result.Value.Findings[0].RuleId.Should().Be("azure-storage-use-secure-tls-policy");
+        result.Value.Findings[0].Severity.Should().Be(IacScanSeverity.Critical);
+        result.Value.Passed.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ScanAsync_InvalidBlockingSeverity_Fails()
+    {
+        var sut = Create(new RecordingIacSandbox(), blockingSeverity: "nonsense");
+
+        var result = await sut.ScanAsync("modules/network", CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Errors.Should().Contain("iac.scan.invalid_blocking_severity");
+    }
+
+    private sealed class ThrowingSandbox : Application.AI.Common.Interfaces.Sandbox.ISandboxExecutor
+    {
+        public Task<Domain.AI.Sandbox.SandboxExecutionResult> ExecuteAsync(
+            Domain.AI.Sandbox.SandboxExecutionRequest request, CancellationToken ct)
+            => throw new InvalidOperationException("boom");
+    }
+}


### PR DESCRIPTION
## Summary
Completes **PR-10**: an infrastructure-as-code skill pack with **Terraform + Bicep parity**, behind the load-bearing `IIacGenerator` abstraction. Scaffolds modules, validates/plans, and security-scans — all inside the PR-3 sandbox with egress allowlisted to provider registries. **The skill never deploys**: deploy stays a separate `BlastRadius=Critical` proposal needing human approval.

## Layers (4 commits)
1. Domain types (`IacBackend`, generation/plan/scan results) + `IIacGenerator` interface + `IacConfig`
3. `TerraformGenerator` + `BicepGenerator`, `IacSandboxRunner` (egress-allowlisted CLI dispatch), Checkov/tfsec/ARM-TTK parsers, `IacChangeProposalValidator`, `IacStartupValidator`
4–5. 3 tools (`iac_generate`/`iac_plan`/`iac_scan`) + DI; `IacConfigValidator`; `plugins/iac-skill/` manifest (denies every deploy/apply tool)
6. 81-test suite

## Design decisions
- **Gate integration via `IChangeProposalValidator`** (keyed by `ChangeTargetKind.IacDeployment`, run by the existing `SelfValidationGate`) — matches the *implemented* PR-2 pipeline, not the plan's pre-implementation wording. The consumer's only gate surface stays `IChangeProposalGate`, which satisfies the plan's 'one surface' acceptance criterion better than parallel gate types.
- **Validator swap**: PR-10 is the first real validator wiring. `RegisterIacValidator` runs *after* `RegisterChangesServices` and replaces the `IacDeployment` `NotConfiguredValidator` placeholder with the real validator — proven by a reflection-driven composition-root test.
- **Deploy guard**: the validator fails on plan error/invalid, **destructive plan changes**, or blocking scan findings.
- CLIs (terraform/bicep/checkov/tfsec/arm-ttk) run in the sandbox (versions pinned in the baked image); tests are unit-level with a mocked `ISandboxExecutor`.

## Test plan
- `dotnet build src/AgenticHarness.slnx` → 0 errors
- **81 new Iac tests green**; full suite green except pre-existing flaky KnowledgeGraph Docker-Testcontainers E2E (unrelated — PR-10 touches no KG code)
- Changes pipeline unregressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)