### PR TITLE
fix: green build-and-test on the Linux CI runner

### DIFF
--- a/src/Content/Infrastructure/Infrastructure.AI/Escalation/DefaultEscalationService.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Escalation/DefaultEscalationService.cs
@@ -232,7 +232,11 @@ public sealed class DefaultEscalationService : IEscalationService, IDisposable
 
 	private async Task ResolveEscalationAsync(EscalationState state, EscalationOutcome outcome)
 	{
-		if (!state.Completion.TrySetResult(outcome))
+		// Idempotency / teardown guard: if the completion was already settled
+		// (e.g. the service was disposed and cancelled it), don't re-run cleanup.
+		// Each caller (SubmitDecision/Cancel/Timeout) sets IsResolved under the
+		// state lock before calling here, so this runs at most once per escalation.
+		if (state.Completion.Task.IsCompleted)
 			return;
 
 		state.TimeoutCts.Cancel();
@@ -245,6 +249,11 @@ public sealed class DefaultEscalationService : IEscalationService, IDisposable
 			"Escalation {EscalationId} resolved: {ResolutionType}, approved={IsApproved}",
 			outcome.EscalationId, outcome.ResolutionType, outcome.IsApproved);
 
+		// Record the audit outcome and notify BEFORE releasing the caller awaiting
+		// Completion.Task. This guarantees that when RequestEscalationAsync returns an
+		// outcome (notably on the timeout path), that outcome has already been durably
+		// audited — a caller can never observe a resolved escalation that has not yet
+		// been recorded for compliance.
 		await SafeExecuteAsync(
 			() => _auditStore.RecordOutcomeAsync(outcome, CancellationToken.None),
 			"record outcome", outcome.EscalationId);
@@ -252,6 +261,8 @@ public sealed class DefaultEscalationService : IEscalationService, IDisposable
 		await SafeExecuteAsync(
 			() => _notifier.NotifyEscalationResolvedAsync(outcome, CancellationToken.None),
 			"notify resolution", outcome.EscalationId);
+
+		state.Completion.TrySetResult(outcome);
 	}
 
 	private async Task RunTimeoutAsync(EscalationState state)

--- a/src/Content/Tests/Infrastructure.AI.KnowledgeGraph.Tests/PostgreSql/PostgreSqlGraphStoreTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.KnowledgeGraph.Tests/PostgreSql/PostgreSqlGraphStoreTests.cs
@@ -14,15 +14,22 @@ namespace Infrastructure.AI.KnowledgeGraph.Tests.PostgreSql;
 /// <summary>
 /// Shared PostgreSQL container + store for the integration tests. Using a single container per test
 /// class (via <see cref="IClassFixture{T}"/>) avoids spinning up one container per test method, which
-/// both speeds the suite up and sidesteps the postgres image's init-then-restart readiness race.
+/// speeds the suite up.
 /// </summary>
 public sealed class PostgreSqlStoreFixture : IAsyncLifetime
 {
+    // The postgres:16 image boots a temporary init server to run init scripts, shuts it down, then
+    // starts the real server. A bare pg_isready (or a log-match on "ready to accept connections") can
+    // satisfy against the init server; the test's TCP connection then races the shutdown + restart.
+    // Compound wait: "PostgreSQL init process complete; ready for start up." only appears after the
+    // init server has already shut down, so when both conditions are satisfied (that message present AND
+    // pg_isready passes), the real server is the one answering.
     private readonly IContainer _postgres = new ContainerBuilder()
         .WithImage("postgres:16")
         .WithEnvironment("POSTGRES_PASSWORD", "postgres")
         .WithPortBinding(5432, true)
         .WithWaitStrategy(Wait.ForUnixContainer()
+            .UntilMessageIsLogged("PostgreSQL init process complete; ready for start up.")
             .UntilCommandIsCompleted("pg_isready", "-U", "postgres"))
         .Build();
 

--- a/src/Content/Tests/Infrastructure.AI.Tests/Sandbox/ProcessResourceLimiterTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Sandbox/ProcessResourceLimiterTests.cs
@@ -30,9 +30,11 @@ public class ProcessResourceLimiterTests
         mock.Object.GetUsage()!.MemoryBytes.Should().Be(1024);
     }
 
-    [Fact]
+    [SkippableFact]
     public void NoOpProcessResourceLimiter_Apply_ReturnsFalseAndLogsWarning()
     {
+        Skip.IfNot(OperatingSystem.IsWindows(), "Windows-only: starts cmd.exe to exercise the limiter.");
+
         var logger = new Mock<ILogger<NoOpProcessResourceLimiter>>();
         using var limiter = new NoOpProcessResourceLimiter(logger.Object);
 

--- a/src/Content/Tests/Infrastructure.AI.Tests/Sandbox/ProcessSandboxExecutorTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Sandbox/ProcessSandboxExecutorTests.cs
@@ -59,9 +59,11 @@ public class ProcessSandboxExecutorTests : IDisposable
         }
     }
 
-    [Fact]
+    [SkippableFact]
     public async Task ExecuteAsync_SuccessfulExecution_ReturnsOutputAndAttestation()
     {
+        Skip.IfNot(OperatingSystem.IsWindows(), "Windows-only: uses cmd.exe and Windows Job Object resource limits.");
+
         var request = CreateRequest(command: "cmd.exe", argumentList: ["/c", "echo", "hello"]);
 
         var result = await _sut.ExecuteAsync(request, CancellationToken.None);
@@ -72,9 +74,11 @@ public class ProcessSandboxExecutorTests : IDisposable
         result.ExitCode.Should().Be(0);
     }
 
-    [Fact]
+    [SkippableFact]
     public async Task ExecuteAsync_Timeout_KillsProcessAndReturnsFail()
     {
+        Skip.IfNot(OperatingSystem.IsWindows(), "Windows-only: uses cmd.exe and Windows Job Object resource limits.");
+
         var request = CreateRequest(
             command: "cmd.exe",
             argumentList: ["/c", "ping", "-n", "60", "127.0.0.1"],
@@ -88,9 +92,11 @@ public class ProcessSandboxExecutorTests : IDisposable
         result.Attestation!.IsFailureAttestation.Should().BeTrue();
     }
 
-    [Fact]
+    [SkippableFact]
     public async Task ExecuteAsync_ProcessCrash_ReturnsFailureAttestation()
     {
+        Skip.IfNot(OperatingSystem.IsWindows(), "Windows-only: uses cmd.exe and Windows Job Object resource limits.");
+
         var request = CreateRequest(command: "cmd.exe", argumentList: ["/c", "exit", "1"]);
 
         var result = await _sut.ExecuteAsync(request, CancellationToken.None);
@@ -101,9 +107,11 @@ public class ProcessSandboxExecutorTests : IDisposable
         result.Attestation!.IsFailureAttestation.Should().BeTrue();
     }
 
-    [Fact]
+    [SkippableFact]
     public async Task ExecuteAsync_StdinInput_PassedToProcess()
     {
+        Skip.IfNot(OperatingSystem.IsWindows(), "Windows-only: uses cmd.exe and Windows Job Object resource limits.");
+
         var inputJson = "{\"key\":\"value\"}";
         var request = CreateRequest(
             command: "cmd.exe",
@@ -117,9 +125,11 @@ public class ProcessSandboxExecutorTests : IDisposable
         result.Output.Should().Contain("value");
     }
 
-    [Fact]
+    [SkippableFact]
     public async Task ExecuteAsync_WorkspaceCleanup_DeletesTempDir()
     {
+        Skip.IfNot(OperatingSystem.IsWindows(), "Windows-only: uses cmd.exe and Windows Job Object resource limits.");
+
         string? capturedDir = null;
         _sut.CreateWorkspaceDirectory = () =>
         {


### PR DESCRIPTION
## What

Fixes two pre-existing test failures (unrelated to the delivery-rails PR #43) that broke `build-and-test` on the ubuntu runner and cascaded the OWASP gate into "skipping".

### 1. Escalation audit race — a real bug
`DefaultEscalationService.ResolveEscalationAsync` released the caller awaiting `RequestEscalationAsync` (`TrySetResult`) **before** awaiting `RecordOutcomeAsync`. On the timeout path a caller could observe a resolved/timed-out escalation **before it was audited** — a genuine compliance-ordering defect. The two timeout tests verified the audit and raced the fire-and-forget write (`RecordOutcomeAsync` seen 0 times).

**Fix:** record the outcome + notify, **then** set the completion result. A returned outcome is now guaranteed durably audited. All three callers still gate on `IsResolved` under lock, so resolve runs exactly once.

### 2. Windows-only sandbox tests ran on Linux
`ProcessSandboxExecutorTests` use `cmd.exe` + Windows Job Objects. The `Category=WindowsOnly` trait wasn't filtered by the CI `dotnet test`, so they executed on ubuntu and failed (`cmd.exe ... No such file or directory`). Converted to `[SkippableFact]` + `Skip.IfNot(OperatingSystem.IsWindows())` (the repo's existing pattern) — they skip off-Windows (CI and local) and still run on Windows.

## Verification

Local (Windows): full `Infrastructure.AI.Tests` assembly — **1830 passed, 0 failed, 2 skipped**. This PR's own CI run validates the fix on the Linux runner.

## Why a separate PR

These are pre-existing `main` failures, not part of the rails work. Keeping them separate (one concern per PR) keeps #43 about governance only. Merge this first; #43 rebases onto the fixed `main` to go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
