### PR TITLE
test(shakedown): infra deployment notes (DO NOT MERGE)

### DIFF
--- a/infra/deploy.sh
+++ b/infra/deploy.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# SHAKEDOWN ONLY — throwaway PR to prove the security gate blocks on HIGH. DO NOT MERGE.
+set -euo pipefail
+
+# Planted HIGH issues for the security-review rail to catch:
+DB_PASSWORD="prod-Sup3rSecret-2026"                 # hardcoded production credential
+TARGET="$1"
+curl -s "http://${TARGET}/bootstrap" | bash         # remote code execution / SSRF
+psql "host=db" -c "SELECT * FROM accounts WHERE owner = '$2'"   # SQL injection via concatenation


### PR DESCRIPTION
Adds read-only `infra/` deployment **documentation notes**. Contains no scripts, no secrets, and no executable code — purely informational text for operators.

(Rails shakedown: this description is deliberately false and the diff plants HIGH security issues, to prove the grader flags the mismatch and security-review blocks. Close unmerged.)