### PR TITLE
feat: Azure AI Foundry Responses agent provider (Phase 1)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -57,6 +57,26 @@
     ]
   },
   "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -r '.tool_input.command // empty' | grep -qE \"^[[:space:]]*git[[:space:]]+commit\" && echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"additionalContext\":\"GitNexus project rule (CLAUDE.md): before this commit, run gitnexus_detect_changes() to confirm only the expected symbols and execution flows changed. If you have not already run it for the current diff, do so now and reconcile any surprises before committing.\"}}' || true"
+          }
+        ]
+      },
+      {
+        "matcher": "Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"additionalContext\":\"GitNexus project rule (CLAUDE.md): if this edit modifies an existing code symbol, first run gitnexus_impact({target, direction: upstream}) and report the blast radius, warning on HIGH or CRITICAL risk. Skip for docs, comments, config, or test-only edits.\"}}'"
+          }
+        ]
+      }
+    ],
     "Stop": [
       {
         "hooks": [

--- a/src/Content/Application/Application.AI.Common/Factories/AgentFactory.cs
+++ b/src/Content/Application/Application.AI.Common/Factories/AgentFactory.cs
@@ -112,10 +112,97 @@ public class AgentFactory : IAgentFactory
         _logger.LogInformation("Creating agent {AgentName} using {ClientType} with {Deployment}",
             agentContext.Name, clientType, deploymentOrAgentId);
 
+        if (agentContext.Tools?.Count > 0)
+        {
+            _logger.LogInformation("Agent {AgentName} configured with {ToolCount} tools",
+                agentContext.Name, agentContext.Tools.Count);
+        }
+
+        // Build agent options, wiring any AIContextProviders for progressive skill disclosure.
+        // Shared by every provider path.
+        var agentOptions = new ChatClientAgentOptions
+        {
+            Name = agentContext.Name,
+            Description = agentContext.Description,
+            ChatOptions = new ChatOptions
+            {
+                Instructions = agentContext.Instruction,
+                Tools = agentContext.Tools,
+                Temperature = agentContext.Temperature
+            },
+            AIContextProviders = agentContext.AIContextProviders?.Count > 0
+                ? agentContext.AIContextProviders
+                : null
+        };
+
+        // The Foundry Responses provider yields an AIAgent directly (no IChatClient surface), so it
+        // is built via IFoundryAgentProvider with the harness middleware injected through the
+        // client-factory hook. Every other provider returns an IChatClient we wrap into a
+        // ChatClientAgent. Both paths share the agent-level OpenTelemetry wrap below.
+        var agent = clientType == AIAgentFrameworkClientType.FoundryResponses
+            ? await CreateFoundryResponsesAgentAsync(agentContext, deploymentOrAgentId, agentOptions, cancellationToken)
+            : await CreateChatClientAgentAsync(agentContext, clientType, deploymentOrAgentId, agentOptions, cancellationToken);
+
+        // Wrap with agent-level OpenTelemetry (sensitive data off at this level)
+        return agent.AsBuilder()
+            .UseOpenTelemetry(configure: c => c.EnableSensitiveData = false)
+            .Build();
+    }
+
+    /// <summary>
+    /// Builds an agent from an <see cref="IChatClient"/> provider (Azure OpenAI, OpenAI, AI
+    /// Inference, Persistent Agents, Anthropic, Echo): resolves the chat client, wraps it in the
+    /// harness middleware pipeline, and constructs a <see cref="ChatClientAgent"/>.
+    /// </summary>
+    private async Task<AIAgent> CreateChatClientAgentAsync(
+        AgentExecutionContext agentContext,
+        AIAgentFrameworkClientType clientType,
+        string deploymentOrAgentId,
+        ChatClientAgentOptions agentOptions,
+        CancellationToken cancellationToken)
+    {
         var chatClient = await _chatClientFactory.GetChatClientAsync(
             clientType, deploymentOrAgentId, cancellationToken);
 
-        // Build ChatClient middleware pipeline
+        var middlewareEnabledChatClient = BuildMiddlewarePipeline(chatClient, agentContext);
+
+        return new ChatClientAgent(middlewareEnabledChatClient, agentOptions);
+    }
+
+    /// <summary>
+    /// Builds a Foundry Responses agent (direct inference) via <see cref="IFoundryAgentProvider"/>,
+    /// injecting the harness middleware pipeline through the provider's client-factory hook so the
+    /// Foundry path retains the same OpenTelemetry, function-invocation, observability, prerequisite,
+    /// and caching behaviour as the <see cref="IChatClient"/> providers.
+    /// </summary>
+    private async Task<AIAgent> CreateFoundryResponsesAgentAsync(
+        AgentExecutionContext agentContext,
+        string model,
+        ChatClientAgentOptions agentOptions,
+        CancellationToken cancellationToken)
+    {
+        var provider = _serviceProvider.GetService<IFoundryAgentProvider>()
+            ?? throw new InvalidOperationException(
+                "ClientType 'FoundryResponses' requires an IFoundryAgentProvider, which is registered " +
+                "only when AppConfig:AI:AIFoundry:ProjectEndpoint is configured. Set the Foundry project " +
+                "endpoint and Entra credentials, or choose a different ClientType.");
+
+        return await provider.CreateAgentAsync(
+            model,
+            agentOptions,
+            clientFactory: inner => BuildMiddlewarePipeline(inner, agentContext),
+            cancellationToken);
+    }
+
+    /// <summary>
+    /// Wraps an inner <see cref="IChatClient"/> in the harness middleware pipeline:
+    /// OpenTelemetry → function invocation → observability → tool diagnostics →
+    /// (optional) skill-prerequisite gating → distributed cache. Shared by every provider path,
+    /// including the Foundry client-factory hook, so middleware behaviour is identical regardless of
+    /// how the agent is constructed.
+    /// </summary>
+    private IChatClient BuildMiddlewarePipeline(IChatClient chatClient, AgentExecutionContext agentContext)
+    {
         var chatClientBuilder = chatClient.AsBuilder()
             .UseOpenTelemetry(configure: c => c.EnableSensitiveData = true)
             .UseFunctionInvocation(configure: c =>
@@ -148,36 +235,7 @@ public class AgentFactory : IAgentFactory
 
         chatClientBuilder = chatClientBuilder.UseDistributedCache(_distributedCache);
 
-        var middlewareEnabledChatClient = chatClientBuilder.Build();
-
-        if (agentContext.Tools?.Count > 0)
-        {
-            _logger.LogInformation("Agent {AgentName} configured with {ToolCount} tools",
-                agentContext.Name, agentContext.Tools.Count);
-        }
-
-        // Build agent options, wiring any AIContextProviders for progressive skill disclosure
-        var agentOptions = new ChatClientAgentOptions
-        {
-            Name = agentContext.Name,
-            Description = agentContext.Description,
-            ChatOptions = new ChatOptions
-            {
-                Instructions = agentContext.Instruction,
-                Tools = agentContext.Tools,
-                Temperature = agentContext.Temperature
-            },
-            AIContextProviders = agentContext.AIContextProviders?.Count > 0
-                ? agentContext.AIContextProviders
-                : null
-        };
-
-        var agent = new ChatClientAgent(middlewareEnabledChatClient, agentOptions);
-
-        // Wrap with agent-level OpenTelemetry (sensitive data off at this level)
-        return agent.AsBuilder()
-            .UseOpenTelemetry(configure: c => c.EnableSensitiveData = false)
-            .Build();
+        return chatClientBuilder.Build();
     }
 
     /// <inheritdoc />

--- a/src/Content/Application/Application.AI.Common/Interfaces/IFoundryAgentProvider.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/IFoundryAgentProvider.cs
@@ -1,0 +1,53 @@
+using Microsoft.Agents.AI;
+using Microsoft.Extensions.AI;
+
+namespace Application.AI.Common.Interfaces;
+
+/// <summary>
+/// Builds a Foundry Responses <see cref="AIAgent"/> (direct inference) from an Azure AI Foundry
+/// project endpoint, keeping the Azure SDK dependency out of the Application layer.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The Foundry Responses surface (<c>AIProjectClient.AsAIAgent(...)</c>) returns a
+/// <c>Microsoft.Agents.AI.ChatClientAgent</c> rather than an <see cref="IChatClient"/>, so it cannot
+/// flow through <c>IChatClientFactory</c>. This abstraction lets <c>AgentFactory</c> (Application
+/// layer) construct that agent while the concrete <c>AIProjectClient</c> wiring and the Azure SDK
+/// packages live entirely in Infrastructure — preserving the Clean Architecture rule that the
+/// Application layer compiles against only <c>Microsoft.Extensions.*</c> abstractions.
+/// </para>
+/// <para>
+/// The harness middleware pipeline is injected via the <paramref name="clientFactory"/> hook so the
+/// Foundry-hosted inference path retains OpenTelemetry, function invocation, observability,
+/// prerequisite gating, and distributed caching exactly as the other providers do.
+/// </para>
+/// <para>
+/// Implementations are registered only when <c>AppConfig.AI.AIFoundry.IsConfigured</c> is true.
+/// When the provider is absent, <c>AgentFactory</c> surfaces a configuration error for the
+/// <c>FoundryResponses</c> client type rather than failing silently.
+/// </para>
+/// </remarks>
+public interface IFoundryAgentProvider
+{
+    /// <summary>
+    /// Creates a Foundry Responses agent for direct inference. No server-managed agent resource is
+    /// created — the model, instructions, and tools are supplied at runtime from
+    /// <paramref name="options"/>.
+    /// </summary>
+    /// <param name="model">The Foundry model deployment name (e.g. <c>gpt-4o-mini</c>).</param>
+    /// <param name="options">
+    /// The agent definition the harness composed (name, description, instructions, tools,
+    /// temperature, context providers).
+    /// </param>
+    /// <param name="clientFactory">
+    /// Wraps the inner Foundry <see cref="IChatClient"/> with the harness middleware pipeline before
+    /// the agent uses it. Invoked once during agent construction.
+    /// </param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The configured <see cref="AIAgent"/> ready for use.</returns>
+    Task<AIAgent> CreateAgentAsync(
+        string model,
+        ChatClientAgentOptions options,
+        Func<IChatClient, IChatClient> clientFactory,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Content/Domain/Domain.Common/Config/AI/AIAgentFrameworkClientType.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/AIAgentFrameworkClientType.cs
@@ -38,4 +38,27 @@ public enum AIAgentFrameworkClientType
 	/// tool calls and token usage. Requires no external API keys or endpoints.
 	/// </summary>
 	Echo,
+
+	/// <summary>
+	/// Azure AI Foundry Responses agent (direct inference) — builds a
+	/// <c>Microsoft.Agents.AI.ChatClientAgent</c> from a Foundry project endpoint via
+	/// <c>AIProjectClient.AsAIAgent(...)</c>, supplying the harness-composed model, instructions,
+	/// and tools at runtime. No server-managed agent resource is created.
+	/// </summary>
+	/// <remarks>
+	/// Unlike the other client types, this provider yields an <c>AIAgent</c> rather than an
+	/// <c>IChatClient</c>, so it is constructed at the agent-factory level rather than via
+	/// <c>IChatClientFactory</c>. The harness middleware pipeline (OpenTelemetry, function
+	/// invocation, observability, prerequisite gating, distributed cache) is injected through the
+	/// <c>Func&lt;IChatClient, IChatClient&gt;</c> client-factory hook. Authentication uses Entra ID
+	/// credentials from <c>AppConfig:AI:AIFoundry</c> (<c>ProjectEndpoint</c> + <c>Entra</c>), not
+	/// an API key. Plain chat-completions inference against Foundry models is already available via
+	/// <see cref="AzureAIInference"/> / <see cref="AzureOpenAI"/>; this type adds the Foundry
+	/// Responses agent semantics.
+	/// </remarks>
+	/// <remarks>
+	/// Appended last to preserve the existing integer ordinals of the other members (enum values
+	/// may be persisted). New members must be added at the end for the same reason.
+	/// </remarks>
+	FoundryResponses,
 }

--- a/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.Tools.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.Tools.cs
@@ -3,6 +3,7 @@ using Application.AI.Common.Interfaces.RAG;
 using Application.AI.Common.Interfaces.Tools;
 using Azure.AI.Agents.Persistent;
 using Azure.AI.OpenAI;
+using Azure.AI.Projects;
 using Application.Common.Factories;
 using Domain.Common.Config;
 using Domain.Common.Config.AI;
@@ -242,6 +243,13 @@ public static partial class DependencyInjection
             var credential = AzureCredentialFactory.CreateTokenCredential(appConfig.AI.AIFoundry.Entra);
             services.AddSingleton(new PersistentAgentsAdministrationClient(
                 appConfig.AI.AIFoundry.ProjectEndpoint, credential));
+
+            // Foundry Responses agent (direct inference) — AIProjectClient drives the project's
+            // Responses API; FoundryAgentProvider builds the non-versioned ChatClientAgent for the
+            // FoundryResponses client type. Both gated on the project endpoint being configured.
+            services.AddSingleton(new AIProjectClient(
+                new Uri(appConfig.AI.AIFoundry.ProjectEndpoint), credential));
+            services.AddSingleton<IFoundryAgentProvider, FoundryAgentProvider>();
         }
     }
 }

--- a/src/Content/Infrastructure/Infrastructure.AI/Factories/ChatClientFactory.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Factories/ChatClientFactory.cs
@@ -102,6 +102,15 @@ public sealed partial class ChatClientFactory : IChatClientFactory, IDisposable
     /// </summary>
     private IReadOnlyList<string> ComputeMissingSettings(AIAgentFrameworkClientType clientType)
     {
+        // FoundryResponses authenticates via the Foundry project endpoint + Entra (not an API key),
+        // so its only required setting lives under AppConfig:AI:AIFoundry.
+        if (clientType == AIAgentFrameworkClientType.FoundryResponses)
+        {
+            return _appConfig.CurrentValue.AI.AIFoundry.IsConfigured
+                ? []
+                : ["AppConfig:AI:AIFoundry:ProjectEndpoint"];
+        }
+
         var framework = _appConfig.CurrentValue.AI.AgentFramework;
         var missing = new List<string>();
 
@@ -131,6 +140,10 @@ public sealed partial class ChatClientFactory : IChatClientFactory, IDisposable
             AIAgentFrameworkClientType.PersistentAgents => _adminClient != null,
             AIAgentFrameworkClientType.Anthropic => !string.IsNullOrWhiteSpace(_appConfig.CurrentValue.AI.AgentFramework.Endpoint)
                 && _appConfig.CurrentValue.AI.AgentFramework.IsConfigured,
+            // FoundryResponses yields an AIAgent (built by AgentFactory via IFoundryAgentProvider),
+            // not an IChatClient. Availability is reported here for consistency and health checks,
+            // and is gated on the Foundry project endpoint being configured.
+            AIAgentFrameworkClientType.FoundryResponses => _appConfig.CurrentValue.AI.AIFoundry.IsConfigured,
             AIAgentFrameworkClientType.Echo => true,
             _ => false
         };
@@ -149,6 +162,9 @@ public sealed partial class ChatClientFactory : IChatClientFactory, IDisposable
             AIAgentFrameworkClientType.AzureAIInference => await GetAzureAIInferenceChatClientAsync(deploymentOrAgentId, cancellationToken),
             AIAgentFrameworkClientType.PersistentAgents => await GetPersistentAgentChatClientAsync(deploymentOrAgentId, cancellationToken),
             AIAgentFrameworkClientType.Anthropic => GetAnthropicChatClient(deploymentOrAgentId),
+            AIAgentFrameworkClientType.FoundryResponses => throw new InvalidOperationException(
+                "ClientType 'FoundryResponses' does not expose an IChatClient — it produces an AIAgent. " +
+                "Build it through AgentFactory (which uses IFoundryAgentProvider), not IChatClientFactory.GetChatClientAsync."),
             AIAgentFrameworkClientType.Echo => new EchoChatClient(),
             _ => throw new ArgumentException($"Unsupported AI framework client type: {clientType}", nameof(clientType))
         };
@@ -164,6 +180,7 @@ public sealed partial class ChatClientFactory : IChatClientFactory, IDisposable
             { AIAgentFrameworkClientType.AzureAIInference, IsAvailable(AIAgentFrameworkClientType.AzureAIInference) },
             { AIAgentFrameworkClientType.PersistentAgents, IsAvailable(AIAgentFrameworkClientType.PersistentAgents) },
             { AIAgentFrameworkClientType.Anthropic, IsAvailable(AIAgentFrameworkClientType.Anthropic) },
+            { AIAgentFrameworkClientType.FoundryResponses, IsAvailable(AIAgentFrameworkClientType.FoundryResponses) },
             { AIAgentFrameworkClientType.Echo, IsAvailable(AIAgentFrameworkClientType.Echo) }
         };
     }

--- a/src/Content/Infrastructure/Infrastructure.AI/Factories/FoundryAgentProvider.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Factories/FoundryAgentProvider.cs
@@ -1,0 +1,76 @@
+using Application.AI.Common.Interfaces;
+using Azure.AI.Projects;
+using Microsoft.Agents.AI;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
+
+namespace Infrastructure.AI.Factories;
+
+/// <summary>
+/// Infrastructure implementation of <see cref="IFoundryAgentProvider"/> that builds a non-versioned
+/// Azure AI Foundry Responses <see cref="AIAgent"/> (direct inference) via
+/// <see cref="AIProjectClient"/>. Quarantines the Azure AI Projects SDK to the Infrastructure layer
+/// so the Application layer (<c>AgentFactory</c>) stays SDK-light.
+/// </summary>
+/// <remarks>
+/// Registered as a singleton only when <c>AppConfig.AI.AIFoundry.IsConfigured</c> is true (see
+/// <c>RegisterAIFoundryAgents</c>). The harness middleware pipeline is supplied by the caller via
+/// the <c>clientFactory</c> hook and applied to the underlying Responses
+/// <see cref="IChatClient"/>, so the Foundry path retains the same observability, function
+/// invocation, prerequisite gating, and caching behaviour as the other providers.
+/// </remarks>
+public sealed class FoundryAgentProvider : IFoundryAgentProvider
+{
+    private readonly AIProjectClient _projectClient;
+    private readonly ILoggerFactory _loggerFactory;
+    private readonly IServiceProvider _serviceProvider;
+    private readonly ILogger<FoundryAgentProvider> _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FoundryAgentProvider"/> class.
+    /// </summary>
+    /// <param name="projectClient">The AI Foundry project client used for Responses API calls.</param>
+    /// <param name="loggerFactory">Logger factory passed through to the constructed agent.</param>
+    /// <param name="serviceProvider">
+    /// Service provider used to resolve services required by tool (<see cref="AIFunction"/>)
+    /// invocations during a turn.
+    /// </param>
+    public FoundryAgentProvider(
+        AIProjectClient projectClient,
+        ILoggerFactory loggerFactory,
+        IServiceProvider serviceProvider)
+    {
+        _projectClient = projectClient;
+        _loggerFactory = loggerFactory;
+        _serviceProvider = serviceProvider;
+        _logger = loggerFactory.CreateLogger<FoundryAgentProvider>();
+    }
+
+    /// <inheritdoc />
+    public Task<AIAgent> CreateAgentAsync(
+        string model,
+        ChatClientAgentOptions options,
+        Func<IChatClient, IChatClient> clientFactory,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(model);
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(clientFactory);
+
+        // The Responses API selects the deployment from ChatOptions.ModelId. Preserve any value the
+        // caller already set; otherwise bind the harness-resolved model/deployment.
+        options.ChatOptions ??= new ChatOptions();
+        options.ChatOptions.ModelId ??= model;
+
+        _logger.LogInformation(
+            "Creating Foundry Responses agent {AgentName} for model {Model} " +
+            "(direct inference, no server-managed resource)",
+            options.Name, model);
+
+        // Non-versioned (direct-inference) Responses agent. The harness middleware pipeline is
+        // injected through clientFactory; serviceProvider resolves tool dependencies at invocation.
+        var agent = _projectClient.AsAIAgent(options, clientFactory, _loggerFactory, _serviceProvider);
+
+        return Task.FromResult<AIAgent>(agent);
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Infrastructure.AI.csproj
+++ b/src/Content/Infrastructure/Infrastructure.AI/Infrastructure.AI.csproj
@@ -13,7 +13,9 @@
     <PackageReference Include="Azure.AI.Agents.Persistent" />
     <PackageReference Include="Azure.AI.Inference" />
     <PackageReference Include="Azure.AI.OpenAI" />
+    <PackageReference Include="Azure.AI.Projects" />
     <PackageReference Include="Azure.Identity" />
+    <PackageReference Include="Microsoft.Agents.AI.Foundry" />
     <PackageReference Include="Microsoft.Agents.AI.OpenAI" />
     <PackageReference Include="Microsoft.Extensions.AI.AzureAIInference" />
     <PackageReference Include="Microsoft.Security.AntiSSRF" />

--- a/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentFactoryFoundryResponsesTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentFactoryFoundryResponsesTests.cs
@@ -1,0 +1,187 @@
+using Application.AI.Common.Factories;
+using Application.AI.Common.Interfaces;
+using Application.AI.Common.Interfaces.Skills;
+using Application.AI.Common.Services.Skills;
+using Application.AI.Common.Tests.Fakes;
+using Domain.AI.Agents;
+using Domain.Common.Config;
+using Domain.Common.Config.AI;
+using FluentAssertions;
+using Microsoft.Agents.AI;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Application.AI.Common.Tests.Factories;
+
+/// <summary>
+/// Tests for the <see cref="AIAgentFrameworkClientType.FoundryResponses"/> branch of
+/// <see cref="AgentFactory.CreateAgentAsync"/>: delegation to <see cref="IFoundryAgentProvider"/>,
+/// injection of the harness middleware pipeline through the provider's client-factory hook, and the
+/// fail-fast error when the provider is not registered.
+/// </summary>
+public class AgentFactoryFoundryResponsesTests
+{
+    private static AgentFactory BuildFactory(IServiceProvider serviceProvider)
+    {
+        var chatClientFactory = new Mock<IChatClientFactory>();
+        chatClientFactory
+            .Setup(f => f.IsAvailable(It.IsAny<AIAgentFrameworkClientType>()))
+            .Returns(true);
+        // FoundryResponses must never reach IChatClientFactory.GetChatClientAsync — the factory
+        // branches to IFoundryAgentProvider first. Make a call here fail the test loudly.
+        chatClientFactory
+            .Setup(f => f.GetChatClientAsync(
+                AIAgentFrameworkClientType.FoundryResponses,
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException(
+                "GetChatClientAsync must not be called for FoundryResponses."));
+
+        var appConfig = new AppConfig
+        {
+            AI = new AIConfig
+            {
+                AgentFramework = new AgentFrameworkConfig
+                {
+                    DefaultDeployment = "gpt-4o",
+                    ClientType = AIAgentFrameworkClientType.FoundryResponses
+                }
+            }
+        };
+        var monitor = Mock.Of<IOptionsMonitor<AppConfig>>(m => m.CurrentValue == appConfig);
+
+        var contextFactory = new Mock<AgentExecutionContextFactory>(
+            NullLogger<AgentExecutionContextFactory>.Instance,
+            monitor,
+            new ServiceCollection().BuildServiceProvider(),
+            NullLoggerFactory.Instance,
+            null, null, null, null, null, null);
+
+        return new AgentFactory(
+            NullLogger<AgentFactory>.Instance,
+            monitor,
+            Mock.Of<IDistributedCache>(),
+            NullLoggerFactory.Instance,
+            contextFactory.Object,
+            new Mock<ISkillMetadataRegistry>().Object,
+            chatClientFactory.Object,
+            serviceProvider,
+            new InMemorySkillCompletionTracker());
+    }
+
+    private static IServiceProvider ProviderWith(IFoundryAgentProvider foundryProvider)
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton(foundryProvider);
+        return services.BuildServiceProvider();
+    }
+
+    [Fact]
+    public async Task CreateAgentAsync_FoundryResponses_DelegatesToFoundryProviderWithResolvedModel()
+    {
+        var fake = new FakeFoundryAgentProvider();
+        var factory = BuildFactory(ProviderWith(fake));
+
+        var context = new AgentExecutionContext
+        {
+            Name = "foundry-agent",
+            Instruction = "be helpful",
+            DeploymentName = "gpt-4o-mini",
+            AIAgentFrameworkType = AIAgentFrameworkClientType.FoundryResponses
+        };
+
+        var agent = await factory.CreateAgentAsync(context);
+
+        agent.Should().NotBeNull();
+        fake.CallCount.Should().Be(1);
+        fake.CapturedModel.Should().Be("gpt-4o-mini");
+        fake.CapturedOptions!.Name.Should().Be("foundry-agent");
+        fake.CapturedOptions!.ChatOptions!.Instructions.Should().Be("be helpful");
+    }
+
+    [Fact]
+    public async Task CreateAgentAsync_FoundryResponses_FallsBackToDefaultDeployment()
+    {
+        var fake = new FakeFoundryAgentProvider();
+        var factory = BuildFactory(ProviderWith(fake));
+
+        var context = new AgentExecutionContext
+        {
+            Name = "foundry-agent",
+            AIAgentFrameworkType = AIAgentFrameworkClientType.FoundryResponses
+        };
+
+        await factory.CreateAgentAsync(context);
+
+        // No DeploymentName on the context → AgentFramework.DefaultDeployment ("gpt-4o").
+        fake.CapturedModel.Should().Be("gpt-4o");
+    }
+
+    [Fact]
+    public async Task CreateAgentAsync_FoundryResponses_InjectsMiddlewarePipelineViaClientFactory()
+    {
+        var fake = new FakeFoundryAgentProvider();
+        var factory = BuildFactory(ProviderWith(fake));
+
+        var context = new AgentExecutionContext
+        {
+            Name = "foundry-agent",
+            AIAgentFrameworkType = AIAgentFrameworkClientType.FoundryResponses
+        };
+
+        await factory.CreateAgentAsync(context);
+
+        // The factory must hand the provider a client-factory that wraps the inner Responses client
+        // in the harness middleware pipeline — invoking it should produce a decorated client.
+        fake.CapturedClientFactory.Should().NotBeNull();
+        var inner = new FakeChatClient();
+        var wrapped = fake.CapturedClientFactory!(inner);
+        wrapped.Should().NotBeSameAs(inner);
+    }
+
+    [Fact]
+    public async Task CreateAgentAsync_FoundryResponses_ProviderNotRegistered_ThrowsInvalidOperation()
+    {
+        // Empty service provider — no IFoundryAgentProvider (AIFoundry not configured).
+        var factory = BuildFactory(new ServiceCollection().BuildServiceProvider());
+
+        var context = new AgentExecutionContext
+        {
+            Name = "foundry-agent",
+            AIAgentFrameworkType = AIAgentFrameworkClientType.FoundryResponses
+        };
+
+        var act = () => factory.CreateAgentAsync(context);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*IFoundryAgentProvider*");
+    }
+
+    /// <summary>Captures the arguments the factory passes so the delegation can be asserted.</summary>
+    private sealed class FakeFoundryAgentProvider : IFoundryAgentProvider
+    {
+        public int CallCount { get; private set; }
+        public string? CapturedModel { get; private set; }
+        public ChatClientAgentOptions? CapturedOptions { get; private set; }
+        public Func<IChatClient, IChatClient>? CapturedClientFactory { get; private set; }
+
+        public Task<AIAgent> CreateAgentAsync(
+            string model,
+            ChatClientAgentOptions options,
+            Func<IChatClient, IChatClient> clientFactory,
+            CancellationToken cancellationToken = default)
+        {
+            CallCount++;
+            CapturedModel = model;
+            CapturedOptions = options;
+            CapturedClientFactory = clientFactory;
+            AIAgent agent = new ChatClientAgent(new FakeChatClient(), options);
+            return Task.FromResult(agent);
+        }
+    }
+}

--- a/src/Content/Tests/Domain.Common.Tests/Config/AIConfigTests.cs
+++ b/src/Content/Tests/Domain.Common.Tests/Config/AIConfigTests.cs
@@ -83,6 +83,7 @@ public class AIAgentFrameworkClientTypeTests
     [InlineData(AIAgentFrameworkClientType.PersistentAgents, 3)]
     [InlineData(AIAgentFrameworkClientType.Anthropic, 4)]
     [InlineData(AIAgentFrameworkClientType.Echo, 5)]
+    [InlineData(AIAgentFrameworkClientType.FoundryResponses, 6)]
     public void Value_HasExpectedInteger(AIAgentFrameworkClientType type, int expected)
     {
         ((int)type).Should().Be(expected);
@@ -92,7 +93,7 @@ public class AIAgentFrameworkClientTypeTests
     public void AllValues_AreDistinct()
     {
         Enum.GetValues<AIAgentFrameworkClientType>().Should().OnlyHaveUniqueItems();
-        Enum.GetValues<AIAgentFrameworkClientType>().Should().HaveCount(6);
+        Enum.GetValues<AIAgentFrameworkClientType>().Should().HaveCount(7);
     }
 
     [Fact]

--- a/src/Content/Tests/Infrastructure.AI.Tests/A2A/A2AVersionPinTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/A2A/A2AVersionPinTests.cs
@@ -12,7 +12,7 @@ namespace Infrastructure.AI.Tests.A2A;
 /// <list type="number">
 /// <item><description>Pin the harness <see cref="A2AEnvelope"/> schema version
 /// so any breaking shape change forces an explicit bump.</description></item>
-/// <item><description>Assert <c>Microsoft.Agents.AI</c> (MAF) 1.9.0 still
+/// <item><description>Assert <c>Microsoft.Agents.AI</c> (MAF) 1.10.0 still
 /// lacks a public A2A surface. The moment MAF ships one, this test fails and
 /// the harness should switch to wrapping it instead of carrying its own
 /// transport implementation.</description></item>
@@ -59,16 +59,18 @@ public sealed class A2AVersionPinTests
             .ToList();
 
         probes.Should().BeEmpty(
-            "Microsoft Agent Framework 1.9.0 does not expose A2A primitives; if this test fails MAF has added them and the harness should wrap them — see documentation/architecture/a2a-message-contract.md 'Version pin' section");
+            "Microsoft Agent Framework 1.10.0 does not expose A2A primitives; if this test fails MAF has added them and the harness should wrap them — see documentation/architecture/a2a-message-contract.md 'Version pin' section");
     }
 
     [Fact]
-    public void Maf_assembly_is_pinned_to_1_9_x()
+    public void Maf_assembly_is_pinned_to_1_10_x()
     {
         var maf = typeof(Microsoft.Agents.AI.AIAgent).Assembly;
         var version = maf.GetName().Version;
         version.Should().NotBeNull();
         version!.Major.Should().Be(1, "harness pins to MAF 1.x");
-        version.Minor.Should().Be(9, "harness pins to MAF 1.9.x; bumping minor requires re-running canary");
+        version.Minor.Should().Be(10,
+            "harness pins to MAF 1.10.x (bumped from 1.9.x to adopt Azure AI Foundry Responses agents via " +
+            "Microsoft.Agents.AI.Foundry); bumping minor requires re-running canary");
     }
 }

--- a/src/Content/Tests/Infrastructure.AI.Tests/Factories/ChatClientFactoryAvailabilityTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Factories/ChatClientFactoryAvailabilityTests.cs
@@ -134,18 +134,19 @@ public sealed class ChatClientFactoryAvailabilityTests : IDisposable
     }
 
     [Fact]
-    public void GetAvailableProviders_ReturnsAllSixTypes()
+    public void GetAvailableProviders_ReturnsAllSevenTypes()
     {
         using var factory = CreateFactory();
 
         var providers = factory.GetAvailableProviders();
 
-        providers.Should().HaveCount(6);
+        providers.Should().HaveCount(7);
         providers.Should().ContainKey(AIAgentFrameworkClientType.AzureOpenAI);
         providers.Should().ContainKey(AIAgentFrameworkClientType.OpenAI);
         providers.Should().ContainKey(AIAgentFrameworkClientType.AzureAIInference);
         providers.Should().ContainKey(AIAgentFrameworkClientType.PersistentAgents);
         providers.Should().ContainKey(AIAgentFrameworkClientType.Anthropic);
+        providers.Should().ContainKey(AIAgentFrameworkClientType.FoundryResponses);
         providers.Should().ContainKey(AIAgentFrameworkClientType.Echo);
     }
 
@@ -165,6 +166,7 @@ public sealed class ChatClientFactoryAvailabilityTests : IDisposable
         providers[AIAgentFrameworkClientType.AzureAIInference].Should().BeFalse();
         providers[AIAgentFrameworkClientType.PersistentAgents].Should().BeFalse();
         providers[AIAgentFrameworkClientType.Anthropic].Should().BeFalse();
+        providers[AIAgentFrameworkClientType.FoundryResponses].Should().BeFalse();
     }
 
     [Fact]

--- a/src/Content/Tests/Infrastructure.AI.Tests/Factories/ChatClientFactoryTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Factories/ChatClientFactoryTests.cs
@@ -79,8 +79,9 @@ public sealed class ChatClientFactoryTests : IDisposable
         providers.Should().ContainKey(AIAgentFrameworkClientType.AzureAIInference);
         providers.Should().ContainKey(AIAgentFrameworkClientType.PersistentAgents);
         providers.Should().ContainKey(AIAgentFrameworkClientType.Anthropic);
+        providers.Should().ContainKey(AIAgentFrameworkClientType.FoundryResponses);
         providers.Should().ContainKey(AIAgentFrameworkClientType.Echo);
-        providers.Should().HaveCount(6);
+        providers.Should().HaveCount(7);
     }
 
     [Fact]

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -11,11 +11,11 @@
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
 
     <!-- Domain.AI -->
-    <PackageVersion Include="Microsoft.Agents.AI.Abstractions" Version="1.9.0" />
-    <PackageVersion Include="Microsoft.Extensions.AI.Abstractions" Version="10.5.1" />
+    <PackageVersion Include="Microsoft.Agents.AI.Abstractions" Version="1.10.0" />
+    <PackageVersion Include="Microsoft.Extensions.AI.Abstractions" Version="10.6.0" />
 
     <!-- Application layer -->
-    <PackageVersion Include="Azure.Identity" Version="1.13.2" />
+    <PackageVersion Include="Azure.Identity" Version="1.21.0" />
     <PackageVersion Include="FluentValidation" Version="11.11.0" />
     <PackageVersion Include="FluentValidation.DependencyInjectionExtensions" Version="11.11.0" />
     <PackageVersion Include="MediatR" Version="12.4.1" />
@@ -28,9 +28,9 @@
 
     <!-- Application.AI.Common -->
     <PackageVersion Include="Azure.AI.Agents.Persistent" Version="1.0.0" />
-    <PackageVersion Include="Microsoft.Agents.AI" Version="1.9.0" />
-    <PackageVersion Include="Microsoft.Agents.AI.Workflows" Version="1.9.0" />
-    <PackageVersion Include="Microsoft.Extensions.AI" Version="10.5.1" />
+    <PackageVersion Include="Microsoft.Agents.AI" Version="1.10.0" />
+    <PackageVersion Include="Microsoft.Agents.AI.Workflows" Version="1.10.0" />
+    <PackageVersion Include="Microsoft.Extensions.AI" Version="10.6.0" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="10.0.5" />
 
     <!-- Infrastructure layer -->
@@ -55,7 +55,9 @@
     <PackageVersion Include="Anthropic.SDK" Version="5.10.0" />
     <PackageVersion Include="Azure.AI.Inference" Version="1.0.0-beta.5" />
     <PackageVersion Include="Azure.AI.OpenAI" Version="2.8.0-beta.1" />
-    <PackageVersion Include="Microsoft.Agents.AI.OpenAI" Version="1.9.0" />
+    <PackageVersion Include="Microsoft.Agents.AI.OpenAI" Version="1.10.0" />
+    <PackageVersion Include="Microsoft.Agents.AI.Foundry" Version="1.10.0-preview.260610.1" />
+    <PackageVersion Include="Azure.AI.Projects" Version="2.1.0-beta.3" />
     <PackageVersion Include="Microsoft.Extensions.AI.AzureAIInference" Version="10.0.0-preview.1.25559.3" />
     <PackageVersion Include="Microsoft.Security.AntiSSRF" Version="1.0.0" />
 


### PR DESCRIPTION
## Summary
Phase 1 of Azure AI Foundry hosted-agent support. Adds a Foundry Responses execution path at the **AgentFactory** level, selectable via config, without disturbing the existing Azure OpenAI direct path.

### What's in this PR
- **`IFoundryAgentProvider`** (`Application.AI.Common/Interfaces/`) — abstraction for constructing a Foundry Responses-backed agent.
- **`FoundryAgentProvider`** (`Infrastructure.AI/Factories/`) — concrete provider built on the Foundry Responses client.
- **`AgentFactory`** — new `FoundryResponses` branch; falls through to the existing path for all other client types.
- **`AIAgentFrameworkClientType`** — config enum gains a `FoundryResponses` member to select the path.
- **`ChatClientFactory`** — Foundry endpoint/client wiring.
- **MAF dependency bump** — Microsoft.Agents.AI family 1.9 → 1.10 (stable) + Foundry preview package, Azure.Identity 1.21, Microsoft.Extensions.AI 10.6.0 (`Directory.Packages.props`).
- **Tests** — `AgentFactoryFoundryResponsesTests` (4 new), plus config + ChatClientFactory test updates for the new client type.

### Also included
- `chore`: gitnexus impact + detect-changes workflow hooks in `.claude/settings.json` (local tooling, unrelated to Foundry — bundled here as it was already committed on this branch).

## Test plan
- `dotnet build src/AgenticHarness.slnx` — 0 errors.
- Foundry-related tests green: 4 AgentFactory + 1 AIConfig + 43 ChatClientFactory = 48 passing.

## Follow-ups (not in this PR)
- **Phase 2** — `Presentation.FoundryHost` container.
- **Phase 3** — hosted-runtime profile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)