### PR TITLE
feat: Foundry hosted-runtime state profile (Phase 3)

### DIFF
--- a/src/Content/Presentation/Presentation.FoundryHost/FoundryHostBootstrap.cs
+++ b/src/Content/Presentation/Presentation.FoundryHost/FoundryHostBootstrap.cs
@@ -108,6 +108,20 @@ internal static class FoundryHostBootstrap
         overrides["AppConfig__AI__Changes__EvidenceStoragePath"] = $"{stateRoot}/changes/evidence";
         overrides["AppConfig__AI__Egress__AuditStoragePath"] = $"{stateRoot}/egress";
 
+        // Per-session agent working state that also defaults under .agent-sessions/: offloaded tool
+        // results (large outputs spilled to disk), subagent delegation records, and the inter-agent
+        // mailbox. StoragePath is the .agent-sessions root itself (the store appends
+        // {session}/tool-results/), so it maps to the state root directly. Mailbox has no writer
+        // today but is rooted now so the capability lands persistent when it ships.
+        overrides["AppConfig__AI__ContextManagement__ToolResultStorage__StoragePath"] = stateRoot;
+        overrides["AppConfig__AI__Orchestration__Subagent__DelegationStoragePath"] = $"{stateRoot}/delegations";
+        overrides["AppConfig__AI__Orchestration__Subagent__MailboxStoragePath"] = $"{stateRoot}/mailbox";
+
+        // Embedded graph database (Kuzu) — the default GraphDatabase.Provider, so it writes to local
+        // disk out of the box. (External Neo4j/PostgreSQL promotion targets a different subsystem,
+        // the GraphRag knowledge store, so this still applies when the embedded backend is in use.)
+        overrides["AppConfig__AI__Rag__GraphDatabase__DataDirectory"] = $"{stateRoot}/graph";
+
         // File logs.
         overrides["AppConfig__Logging__LogsBasePath"] = $"{stateRoot}/logs";
     }

--- a/src/Content/Presentation/Presentation.FoundryHost/FoundryHostBootstrap.cs
+++ b/src/Content/Presentation/Presentation.FoundryHost/FoundryHostBootstrap.cs
@@ -4,13 +4,20 @@ namespace Presentation.FoundryHost;
 
 /// <summary>
 /// Pure bootstrap logic for the Foundry hosted-agent container, factored out of
-/// <see cref="Program"/> so the bug-prone parts — environment-variable translation and
-/// agent/skill selection — are unit-testable without standing up the web host.
+/// <see cref="Program"/> so the bug-prone parts — environment-variable translation, state-path
+/// rooting, and agent/skill selection — are unit-testable without standing up the web host.
 /// </summary>
 internal static class FoundryHostBootstrap
 {
     /// <summary>Default agent id served when <c>FOUNDRY_AGENT_ID</c> is not set.</summary>
     internal const string DefaultAgentId = "default";
+
+    /// <summary>
+    /// Subdirectory under the persistent <c>$HOME</c> where the harness's per-session local state
+    /// lives. Foundry guarantees only <c>$HOME</c> (and <c>/files</c>) survive idle/resume, so all
+    /// local-disk writes are rooted here rather than in the container's (non-persistent) app dir.
+    /// </summary>
+    internal const string StateRootSubdirectory = "agent-state";
 
     /// <summary>
     /// Computes the harness configuration overrides implied by Foundry's runtime-injected
@@ -19,6 +26,27 @@ internal static class FoundryHostBootstrap
     /// </summary>
     /// <param name="readEnv">Reads an environment variable by name (returns <c>null</c> when unset).</param>
     /// <remarks>
+    /// <para>Three groups of overrides are produced:</para>
+    /// <list type="number">
+    ///   <item><description>
+    ///     <b>Inference + telemetry</b> — Foundry's injected <c>FOUNDRY_PROJECT_ENDPOINT</c>,
+    ///     <c>AZURE_AI_MODEL_DEPLOYMENT_NAME</c>, and <c>APPLICATIONINSIGHTS_CONNECTION_STRING</c>.
+    ///   </description></item>
+    ///   <item><description>
+    ///     <b>Per-session local state → <c>$HOME</c></b> — the planner database, audit trails, and
+    ///     logs are re-rooted under the persistent <c>$HOME</c> so they survive Foundry's
+    ///     idle/resume cycle (the container's publish directory is <i>not</i> persisted). This is the
+    ///     core of the hosted-runtime profile and requires no external services.
+    ///   </description></item>
+    ///   <item><description>
+    ///     <b>Optional external stores</b> — the graph/knowledge backend, RAG vector store, and
+    ///     distributed cache each promote themselves from their in-process default to an external
+    ///     managed service ONLY when the matching connection environment variable is supplied. With
+    ///     none supplied the container boots standalone (durable per-conversation memory via
+    ///     <c>$HOME</c>); external stores are needed only to share knowledge across conversations or
+    ///     beyond the session retention window.
+    ///   </description></item>
+    /// </list>
     /// Only non-empty source values produce overrides. A present
     /// <c>APPLICATIONINSIGHTS_CONNECTION_STRING</c> additionally enables the Azure Monitor exporter
     /// so harness traces and metrics flow to the injected sink.
@@ -39,7 +67,117 @@ internal static class FoundryHostBootstrap
             overrides["AppConfig__Observability__Exporters__AzureMonitor__Enabled"] = "true";
         }
 
+        AddHomeRootedStatePaths(overrides, readEnv);
+        AddExternalStorePromotions(overrides, readEnv);
+
         return overrides;
+    }
+
+    /// <summary>
+    /// Roots every local-disk store under the persistent <c>$HOME</c> so the harness's state
+    /// survives Foundry's idle/resume cycle. No-op when <c>HOME</c> is unset (non-Foundry runs),
+    /// where the harness's existing relative defaults apply.
+    /// </summary>
+    /// <remarks>
+    /// Each resolver in the harness already honors an absolute path (it either combines via
+    /// <see cref="Path.Combine(string, string)"/>, which discards the base when the second argument
+    /// is rooted, or uses the configured value verbatim) — none expand <c>$HOME</c>. Resolving the
+    /// absolute paths here is therefore the minimal, shared-code-free way to land them in the
+    /// persistent location. Paths are joined with <c>/</c> because the hosted runtime is Linux,
+    /// independent of the OS this code is built or unit-tested on.
+    /// </remarks>
+    private static void AddHomeRootedStatePaths(
+        IDictionary<string, string> overrides, Func<string, string?> readEnv)
+    {
+        var home = readEnv("HOME");
+        if (string.IsNullOrWhiteSpace(home))
+        {
+            return;
+        }
+
+        var stateRoot = $"{home.TrimEnd('/')}/{StateRootSubdirectory}";
+
+        // Planner checkpoint/resume database (SQLite).
+        overrides["AppConfig__AI__Planner__DatabasePath"] = $"{stateRoot}/planner/planner.db";
+
+        // JSONL audit trails — drift, governance escalations, change proposals (+ gate evidence),
+        // and egress decisions. Each is append-only forensic state worth preserving across resumes.
+        overrides["AppConfig__AI__DriftDetection__AuditPath"] = $"{stateRoot}/audit";
+        overrides["AppConfig__AI__Governance__Escalation__AuditStoragePath"] = $"{stateRoot}/escalations";
+        overrides["AppConfig__AI__Changes__AuditStoragePath"] = $"{stateRoot}/changes";
+        overrides["AppConfig__AI__Changes__EvidenceStoragePath"] = $"{stateRoot}/changes/evidence";
+        overrides["AppConfig__AI__Egress__AuditStoragePath"] = $"{stateRoot}/egress";
+
+        // File logs.
+        overrides["AppConfig__Logging__LogsBasePath"] = $"{stateRoot}/logs";
+    }
+
+    /// <summary>
+    /// Promotes the graph/knowledge backend, RAG vector store, and distributed cache from their
+    /// in-process defaults to external managed services — but only for each subsystem whose
+    /// connection environment variable is present. Subsystems with no env var keep their standalone
+    /// default, so the container always boots.
+    /// </summary>
+    /// <remarks>
+    /// A malformed connection still fails loudly at startup (correct: that is operator
+    /// misconfiguration, not a missing opt-in). Connection secrets are read from env here only so
+    /// Foundry/Key Vault can inject them; the harness never persists them to appsettings.
+    /// </remarks>
+    private static void AddExternalStorePromotions(
+        IDictionary<string, string> overrides, Func<string, string?> readEnv)
+    {
+        // Graph + cross-session knowledge store (Neo4j or PostgreSQL). GRAPH_PROVIDER selects the
+        // backend keyed in Infrastructure.AI.KnowledgeGraph DI; the connection string carries the
+        // endpoint/credentials. Promoting the backend also enables GraphRAG retrieval, which is
+        // off by default — an operator who wires a graph DB wants it actually used, not just
+        // connected.
+        var graphProvider = readEnv("GRAPH_PROVIDER");
+        var graphConnection = readEnv("GRAPH_CONNECTION_STRING");
+        if (!string.IsNullOrWhiteSpace(graphProvider) && !string.IsNullOrWhiteSpace(graphConnection))
+        {
+            var normalizedProvider = graphProvider.Trim().ToLowerInvariant();
+            if (normalizedProvider is not ("neo4j" or "postgresql"))
+            {
+                throw new InvalidOperationException(
+                    $"GRAPH_PROVIDER must be 'neo4j' or 'postgresql' (got '{graphProvider}'). " +
+                    "These are the external graph backends registered for hosted agents; leave " +
+                    "GRAPH_PROVIDER unset to use the in-process graph store.");
+            }
+
+            overrides["AppConfig__AI__Rag__GraphRag__GraphProvider"] = normalizedProvider;
+            overrides["AppConfig__AI__Rag__GraphRag__ConnectionString"] = graphConnection;
+            overrides["AppConfig__AI__Rag__GraphRag__Enabled"] = "true";
+        }
+
+        // RAG vector + BM25 store (Azure AI Search). Endpoint presence is the opt-in; the API key is
+        // optional because the agent's managed identity is the preferred auth path. With no
+        // endpoint, force the in-process FAISS/FTS5 store: the vector store's config default is
+        // Azure AI Search, which would fail without an endpoint, so this keeps the container
+        // bootable standalone (RAG state is per-session, rebuilt from ingested documents). The
+        // fallback defers to an operator who configured a vector store via the native AppConfig__
+        // keys, so we never silently override a hand-configured endpoint with FAISS.
+        var searchEndpoint = readEnv("AZURE_SEARCH_ENDPOINT");
+        if (!string.IsNullOrWhiteSpace(searchEndpoint))
+        {
+            overrides["AppConfig__AI__Rag__VectorStore__Provider"] = "azure_ai_search";
+            overrides["AppConfig__AI__Rag__VectorStore__Endpoint"] = searchEndpoint;
+            AddIfPresent(overrides, readEnv, "AZURE_SEARCH_API_KEY", "AppConfig__AI__Rag__VectorStore__ApiKey");
+            AddIfPresent(overrides, readEnv, "AZURE_SEARCH_INDEX", "AppConfig__AI__Rag__VectorStore__IndexName");
+        }
+        else if (string.IsNullOrWhiteSpace(readEnv("AppConfig__AI__Rag__VectorStore__Provider"))
+            && string.IsNullOrWhiteSpace(readEnv("AppConfig__AI__Rag__VectorStore__Endpoint")))
+        {
+            overrides["AppConfig__AI__Rag__VectorStore__Provider"] = "faiss";
+        }
+
+        // Distributed cache (Redis) — shared across sessions/replicas.
+        var redisEndpoint = readEnv("REDIS_ENDPOINT");
+        if (!string.IsNullOrWhiteSpace(redisEndpoint))
+        {
+            overrides["AppConfig__Cache__CacheType"] = "RedisCache";
+            overrides["AppConfig__Cache__RedisClient__Endpoint"] = redisEndpoint;
+            AddIfPresent(overrides, readEnv, "REDIS_SECRET", "AppConfig__Cache__RedisClient__Secret");
+        }
     }
 
     /// <summary>

--- a/src/Content/Presentation/Presentation.FoundryHost/README.md
+++ b/src/Content/Presentation/Presentation.FoundryHost/README.md
@@ -23,7 +23,11 @@ Foundry runs each conversation in its own **session** — a VM-isolated sandbox 
 - Conversation history is stored **durably in Foundry**, independently of compute. The host sets
   the harness to *not* re-persist it, so Foundry remains the single source of truth.
 - **Only `$HOME`/`/files` are guaranteed to persist** — *not* the container's app/publish
-  directory. So the host re-roots every local-disk write under `$HOME` (see below).
+  directory. So the host re-roots the harness's per-session disk stores under `$HOME/agent-state`:
+  the planner database, the JSONL audit trails (drift, escalation, change proposals + evidence,
+  egress), offloaded tool results, subagent delegation records and mailbox, the embedded (Kuzu)
+  graph database, and file logs. (RAG's FAISS vector index and FTS5 BM25 store are in-memory only —
+  there is no on-disk index to root; they rebuild from ingested documents.)
 
 **Net effect:** out of the box, every conversation gets durable, idle-surviving memory with **zero
 external services**. External managed stores are needed *only* to share knowledge **across different
@@ -60,6 +64,12 @@ per-conversation memory via `$HOME`); supply a variable and that subsystem goes 
 
 Any of the above can also be set directly via the native `AppConfig__...` env key, which the host
 never overwrites.
+
+> **Vector store note:** with no `AZURE_SEARCH_ENDPOINT`, the host applies an in-process FAISS
+> default *via an environment override*, which takes precedence over an `appsettings`-only
+> `VectorStore` section. To run against Azure AI Search, set `AZURE_SEARCH_ENDPOINT` (or the native
+> `AppConfig__AI__Rag__VectorStore__Endpoint` env key) — do not rely on an `appsettings`-only
+> endpoint, which the FAISS default would shadow.
 
 ### Capability note: sandbox
 

--- a/src/Content/Presentation/Presentation.FoundryHost/README.md
+++ b/src/Content/Presentation/Presentation.FoundryHost/README.md
@@ -1,0 +1,79 @@
+# Presentation.FoundryHost
+
+Packages the full agentic harness as an **Azure AI Foundry hosted agent** — a container Foundry
+Agent Service starts, scales, and exposes over the OpenAI-compatible `/responses` protocol. Unlike a
+Foundry *prompt agent* (where the platform owns the loop), a hosted agent runs *your* code, so the
+harness's in-process pipeline — skills, governance, tool-output compression, prerequisite gating,
+telemetry — survives intact.
+
+The host reuses the same composition root every other host uses (`GetServices`), builds the agent
+through `IAgentFactory` exactly as the desktop and web hosts do, and hands it to the Foundry hosting
+library. **There is no new agent-type concept**: which agent this deployment exposes is selected by
+id (`FOUNDRY_AGENT_ID`, default `default`), resolved against the same `AGENT.md` manifests the rest
+of the harness discovers.
+
+## Runtime persistence model
+
+Foundry runs each conversation in its own **session** — a VM-isolated sandbox with a **persistent
+`$HOME`**. Key facts (verified against Microsoft Learn, *What are hosted agents?*):
+
+- `$HOME` (and the `/files` upload area) **survive idle/resume**: when a session is idle for 15
+  minutes the compute is deprovisioned, but `$HOME` is preserved and **restored on resume**.
+- A session — and its `$HOME` — is **permanently deleted after 30 days of inactivity**.
+- Conversation history is stored **durably in Foundry**, independently of compute. The host sets
+  the harness to *not* re-persist it, so Foundry remains the single source of truth.
+- **Only `$HOME`/`/files` are guaranteed to persist** — *not* the container's app/publish
+  directory. So the host re-roots every local-disk write under `$HOME` (see below).
+
+**Net effect:** out of the box, every conversation gets durable, idle-surviving memory with **zero
+external services**. External managed stores are needed *only* to share knowledge **across different
+conversations or users**, or beyond the 30-day window.
+
+## Environment variables
+
+### Injected by Foundry at deploy time
+
+| Variable | Purpose |
+|---|---|
+| `FOUNDRY_PROJECT_ENDPOINT` | Foundry project endpoint used for model inference. |
+| `AZURE_AI_MODEL_DEPLOYMENT_NAME` | Model deployment the agent runs against. |
+| `APPLICATIONINSIGHTS_CONNECTION_STRING` | Telemetry sink; presence auto-enables the Azure Monitor exporter. |
+| `FOUNDRY_AGENT_ID` | (Optional) which discovered `AGENT.md` to expose. Defaults to `default`. |
+| `HOME` | Persistent session storage root. The host roots all local state under `$HOME/agent-state`. |
+
+### Optional — external stores for cross-conversation / cross-user persistence
+
+Each subsystem promotes itself from its in-process default to an external managed service **only when
+its connection variable is supplied**. Supply none and the container still boots (durable
+per-conversation memory via `$HOME`); supply a variable and that subsystem goes external. A
+*malformed* connection still fails loudly at startup. Add the ones you need to `agent.yaml`'s
+`environment_variables`.
+
+| Variable(s) | Promotes | Notes |
+|---|---|---|
+| `GRAPH_PROVIDER` (`neo4j`\|`postgresql`) **and** `GRAPH_CONNECTION_STRING` | Knowledge graph + cross-session memory; also enables GraphRAG retrieval | Both required. `GRAPH_PROVIDER` is validated (a value other than `neo4j`/`postgresql` fails at startup with a clear message rather than an opaque DI error). |
+| `AZURE_SEARCH_ENDPOINT` | RAG vector + BM25 store → Azure AI Search | Without it, RAG uses the in-process FAISS/FTS5 store (per-session, rebuilt from ingested docs). |
+| `AZURE_SEARCH_API_KEY` | — | Optional; omit to use the agent's managed identity (preferred). |
+| `AZURE_SEARCH_INDEX` | — | Optional; defaults to the harness's configured index name. |
+| `REDIS_ENDPOINT` | `IDistributedCache` → Redis | Shared cache across sessions/replicas. |
+| `REDIS_SECRET` | — | Optional Redis password. |
+
+Any of the above can also be set directly via the native `AppConfig__...` env key, which the host
+never overwrites.
+
+### Capability note: sandbox
+
+The `Foundry` profile sets `Sandbox:Enabled=false`. Docker-in-Micro-VM is unavailable and the
+process sandbox's Windows Job-Object limits don't apply on the Linux runtime, so sandboxed tool
+execution is the one harness capability degraded under hosted agents. The closed-by-default model
+means such tools are refused with a clear capability message rather than running unsandboxed.
+
+## Deploy
+
+```bash
+azd provision   # Foundry project, model deployment, App Insights, container registry
+azd deploy      # builds the Dockerfile, pushes to ACR, registers the hosted agent
+```
+
+The translation from these environment variables to harness config keys lives in
+`FoundryHostBootstrap.BuildConfigOverrides` (pure and unit-tested in `Presentation.FoundryHost.Tests`).

--- a/src/Content/Tests/Presentation.FoundryHost.Tests/FoundryHostBootstrapTests.cs
+++ b/src/Content/Tests/Presentation.FoundryHost.Tests/FoundryHostBootstrapTests.cs
@@ -46,11 +46,15 @@ public sealed class FoundryHostBootstrapTests
     }
 
     [Fact]
-    public void BuildConfigOverrides_WithNoFoundryEnvironment_ReturnsEmpty()
+    public void BuildConfigOverrides_WithNoEnvironment_AppliesOnlyStandaloneRagDefault()
     {
         var overrides = FoundryHostBootstrap.BuildConfigOverrides(Env());
 
-        overrides.Should().BeEmpty();
+        // No HOME, no Foundry inference vars, no external-store connections: the only override is
+        // the in-process RAG fallback that keeps the container bootable without Azure AI Search.
+        overrides.Should().ContainSingle()
+            .Which.Should().BeEquivalentTo(
+                new KeyValuePair<string, string>("AppConfig__AI__Rag__VectorStore__Provider", "faiss"));
     }
 
     [Theory]
@@ -60,9 +64,146 @@ public sealed class FoundryHostBootstrapTests
     {
         var overrides = FoundryHostBootstrap.BuildConfigOverrides(Env(
             ("FOUNDRY_PROJECT_ENDPOINT", blank),
-            ("APPLICATIONINSIGHTS_CONNECTION_STRING", blank)));
+            ("APPLICATIONINSIGHTS_CONNECTION_STRING", blank),
+            ("HOME", blank),
+            ("GRAPH_PROVIDER", blank),
+            ("AZURE_SEARCH_ENDPOINT", blank),
+            ("REDIS_ENDPOINT", blank)));
 
-        overrides.Should().BeEmpty();
+        overrides.Should().NotContainKey("AppConfig__AI__AIFoundry__ProjectEndpoint");
+        overrides.Should().NotContainKey("AppConfig__Observability__Exporters__AzureMonitor__ConnectionString");
+        overrides.Should().NotContainKey("AppConfig__AI__Planner__DatabasePath");
+        overrides.Should().NotContainKey("AppConfig__AI__Rag__GraphRag__GraphProvider");
+        overrides.Should().NotContainKey("AppConfig__Cache__CacheType");
+        // Blank search endpoint still yields the standalone in-process RAG default.
+        overrides["AppConfig__AI__Rag__VectorStore__Provider"].Should().Be("faiss");
+    }
+
+    [Fact]
+    public void BuildConfigOverrides_WithHome_RootsLocalStateUnderHome()
+    {
+        var overrides = FoundryHostBootstrap.BuildConfigOverrides(Env(("HOME", "/home/agent")));
+
+        const string root = "/home/agent/agent-state";
+        overrides["AppConfig__AI__Planner__DatabasePath"].Should().Be($"{root}/planner/planner.db");
+        overrides["AppConfig__AI__DriftDetection__AuditPath"].Should().Be($"{root}/audit");
+        overrides["AppConfig__AI__Governance__Escalation__AuditStoragePath"].Should().Be($"{root}/escalations");
+        overrides["AppConfig__AI__Changes__AuditStoragePath"].Should().Be($"{root}/changes");
+        overrides["AppConfig__AI__Changes__EvidenceStoragePath"].Should().Be($"{root}/changes/evidence");
+        overrides["AppConfig__AI__Egress__AuditStoragePath"].Should().Be($"{root}/egress");
+        overrides["AppConfig__Logging__LogsBasePath"].Should().Be($"{root}/logs");
+    }
+
+    [Fact]
+    public void BuildConfigOverrides_WithTrailingSlashHome_DoesNotDoubleSlash()
+    {
+        var overrides = FoundryHostBootstrap.BuildConfigOverrides(Env(("HOME", "/home/agent/")));
+
+        overrides["AppConfig__AI__Planner__DatabasePath"].Should().Be("/home/agent/agent-state/planner/planner.db");
+    }
+
+    [Fact]
+    public void BuildConfigOverrides_WithoutHome_DoesNotRootLocalState()
+    {
+        var overrides = FoundryHostBootstrap.BuildConfigOverrides(Env(
+            ("FOUNDRY_PROJECT_ENDPOINT", "https://proj")));
+
+        overrides.Should().NotContainKey("AppConfig__AI__Planner__DatabasePath");
+        overrides.Should().NotContainKey("AppConfig__Logging__LogsBasePath");
+    }
+
+    [Fact]
+    public void BuildConfigOverrides_WithGraphProviderAndConnection_PromotesAndEnablesGraphBackend()
+    {
+        var overrides = FoundryHostBootstrap.BuildConfigOverrides(Env(
+            ("GRAPH_PROVIDER", "Neo4j"),
+            ("GRAPH_CONNECTION_STRING", "bolt://user:pass@graph:7687")));
+
+        // Provider is normalized to the lowercase DI key, and GraphRAG retrieval is switched on so
+        // the wired backend is actually used (it defaults off).
+        overrides["AppConfig__AI__Rag__GraphRag__GraphProvider"].Should().Be("neo4j");
+        overrides["AppConfig__AI__Rag__GraphRag__ConnectionString"].Should().Be("bolt://user:pass@graph:7687");
+        overrides["AppConfig__AI__Rag__GraphRag__Enabled"].Should().Be("true");
+    }
+
+    [Fact]
+    public void BuildConfigOverrides_WithUnknownGraphProvider_ThrowsClearError()
+    {
+        var act = () => FoundryHostBootstrap.BuildConfigOverrides(Env(
+            ("GRAPH_PROVIDER", "cosmos_gremlin"),
+            ("GRAPH_CONNECTION_STRING", "AccountEndpoint=https://x")));
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*neo4j*postgresql*cosmos_gremlin*");
+    }
+
+    [Fact]
+    public void BuildConfigOverrides_WithNativeVectorStoreEndpoint_DoesNotForceFaissFallback()
+    {
+        // Operator configured Azure AI Search via the native key but not the Provider key; the
+        // standalone fallback must NOT clobber that endpoint with the in-process FAISS store.
+        var overrides = FoundryHostBootstrap.BuildConfigOverrides(Env(
+            ("AppConfig__AI__Rag__VectorStore__Endpoint", "https://svc.search.windows.net")));
+
+        overrides.Should().NotContainKey("AppConfig__AI__Rag__VectorStore__Provider");
+    }
+
+    [Theory]
+    [InlineData("neo4j", null)]
+    [InlineData(null, "bolt://graph:7687")]
+    public void BuildConfigOverrides_WithIncompleteGraphConfig_DoesNotPromote(string? provider, string? connection)
+    {
+        var overrides = FoundryHostBootstrap.BuildConfigOverrides(Env(
+            ("GRAPH_PROVIDER", provider),
+            ("GRAPH_CONNECTION_STRING", connection)));
+
+        overrides.Should().NotContainKey("AppConfig__AI__Rag__GraphRag__GraphProvider");
+        overrides.Should().NotContainKey("AppConfig__AI__Rag__GraphRag__ConnectionString");
+    }
+
+    [Fact]
+    public void BuildConfigOverrides_WithSearchEndpoint_PromotesVectorStoreWithOptionalCredentials()
+    {
+        var overrides = FoundryHostBootstrap.BuildConfigOverrides(Env(
+            ("AZURE_SEARCH_ENDPOINT", "https://svc.search.windows.net"),
+            ("AZURE_SEARCH_API_KEY", "secret"),
+            ("AZURE_SEARCH_INDEX", "harness-chunks")));
+
+        overrides["AppConfig__AI__Rag__VectorStore__Provider"].Should().Be("azure_ai_search");
+        overrides["AppConfig__AI__Rag__VectorStore__Endpoint"].Should().Be("https://svc.search.windows.net");
+        overrides["AppConfig__AI__Rag__VectorStore__ApiKey"].Should().Be("secret");
+        overrides["AppConfig__AI__Rag__VectorStore__IndexName"].Should().Be("harness-chunks");
+    }
+
+    [Fact]
+    public void BuildConfigOverrides_WithSearchEndpointOnly_OmitsCredentialKeysForManagedIdentity()
+    {
+        var overrides = FoundryHostBootstrap.BuildConfigOverrides(Env(
+            ("AZURE_SEARCH_ENDPOINT", "https://svc.search.windows.net")));
+
+        overrides["AppConfig__AI__Rag__VectorStore__Provider"].Should().Be("azure_ai_search");
+        overrides.Should().NotContainKey("AppConfig__AI__Rag__VectorStore__ApiKey");
+        overrides.Should().NotContainKey("AppConfig__AI__Rag__VectorStore__IndexName");
+    }
+
+    [Fact]
+    public void BuildConfigOverrides_WithRedisEndpoint_PromotesDistributedCache()
+    {
+        var overrides = FoundryHostBootstrap.BuildConfigOverrides(Env(
+            ("REDIS_ENDPOINT", "cache:6379"),
+            ("REDIS_SECRET", "pw")));
+
+        overrides["AppConfig__Cache__CacheType"].Should().Be("RedisCache");
+        overrides["AppConfig__Cache__RedisClient__Endpoint"].Should().Be("cache:6379");
+        overrides["AppConfig__Cache__RedisClient__Secret"].Should().Be("pw");
+    }
+
+    [Fact]
+    public void BuildConfigOverrides_WithoutRedisEndpoint_LeavesCacheDefault()
+    {
+        var overrides = FoundryHostBootstrap.BuildConfigOverrides(Env(("HOME", "/home/agent")));
+
+        overrides.Should().NotContainKey("AppConfig__Cache__CacheType");
     }
 
     [Fact]

--- a/src/Content/Tests/Presentation.FoundryHost.Tests/FoundryHostBootstrapTests.cs
+++ b/src/Content/Tests/Presentation.FoundryHost.Tests/FoundryHostBootstrapTests.cs
@@ -91,6 +91,10 @@ public sealed class FoundryHostBootstrapTests
         overrides["AppConfig__AI__Changes__AuditStoragePath"].Should().Be($"{root}/changes");
         overrides["AppConfig__AI__Changes__EvidenceStoragePath"].Should().Be($"{root}/changes/evidence");
         overrides["AppConfig__AI__Egress__AuditStoragePath"].Should().Be($"{root}/egress");
+        overrides["AppConfig__AI__ContextManagement__ToolResultStorage__StoragePath"].Should().Be(root);
+        overrides["AppConfig__AI__Orchestration__Subagent__DelegationStoragePath"].Should().Be($"{root}/delegations");
+        overrides["AppConfig__AI__Orchestration__Subagent__MailboxStoragePath"].Should().Be($"{root}/mailbox");
+        overrides["AppConfig__AI__Rag__GraphDatabase__DataDirectory"].Should().Be($"{root}/graph");
         overrides["AppConfig__Logging__LogsBasePath"].Should().Be($"{root}/logs");
     }
 


### PR DESCRIPTION
## Summary

Phase 3 of Azure AI Foundry hosted-agent support: make the harness behave correctly under Foundry's per-session hosted runtime.

**Corrected runtime model** (verified against MS Learn *What are hosted agents?*): the runtime is **not** throwaway-per-turn. Each Foundry session (one per conversation under the Responses protocol) gets a VM-isolated sandbox with a **persistent `$HOME`/`/files`** — preserved on 15-min idle deprovision, restored on resume, retained for up to 30 days of inactivity. Conversation history is stored durably in Foundry independently (the host already sets `store=false`). The catch: Foundry guarantees persistence **only** for `$HOME`/`/files`, **not** the container's app/publish directory where the harness writes `data/`, `logs/`, and `.agent-sessions/`.

So the core of this PR is simply re-rooting those writes under `$HOME` — giving every conversation durable, idle-surviving memory with **zero external dependencies**. External managed stores are needed only to share knowledge across conversations/users or beyond the 30-day window, so they're kept **optional**.

## What changed

All three files live in the `Presentation.FoundryHost` project — no shared-code surgery (every local-disk resolver already honors an absolute path; none expand `$HOME`, so the host computes the absolute paths and injects them through the existing env→config override mechanism).

- **`FoundryHostBootstrap.BuildConfigOverrides`** (stays pure/`readEnv`-driven):
  - `AddHomeRootedStatePaths` — roots planner DB, JSONL audit trails (drift, escalation, changes + evidence, egress), and logs under `$HOME/agent-state`. No-op when `HOME` is unset.
  - `AddExternalStorePromotions` — conditional promotion: `GRAPH_PROVIDER` (`neo4j`/`postgresql`, validated + enables GraphRAG) + `GRAPH_CONNECTION_STRING`; `AZURE_SEARCH_ENDPOINT` (+ optional key/index) with a FAISS fallback that defers to native config; `REDIS_ENDPOINT` (+ optional secret).
- **`README.md`** — documents the runtime persistence model and the full env-var contract (injected + optional external).
- **Tests** — `FoundryHostBootstrapTests` 9 → 21: `$HOME` rooting, trailing-slash, graph promote/enable/validate, search promote + managed-identity, redis, FAISS fallback + native-key suppression.

## Review

High-effort `/code-review` run on the diff surfaced three issues, all fixed before commit:
1. FAISS fallback would clobber a vector store configured via the native `AppConfig__...` key — now defers to it.
2. `GRAPH_PROVIDER` was unvalidated → opaque DI crash-loop on a typo — now fails with a clear startup message.
3. Graph promotion didn't enable GraphRAG retrieval — now sets `Enabled=true`.

`gitnexus detect_changes`: low risk, purely additive (0 existing symbols affected).

## Test plan

- [x] `dotnet build src/AgenticHarness.slnx` — 0 errors
- [x] `dotnet test` (Presentation.FoundryHost.Tests) — 21/21 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)