### PR TITLE
chore: mechanical review gate (code-review + simplify before push)

### DIFF
--- a/.claude/hooks/review-gate.ps1
+++ b/.claude/hooks/review-gate.ps1
@@ -1,0 +1,142 @@
+#!/usr/bin/env pwsh
+#
+# review-gate.ps1 — the methodology's "review gate" (companion to review-cadence.md).
+#
+# Fires on the Claude Code `PreToolUse` event for Bash. Before the agent is allowed
+# to `git push` or `gh pr create` a change that touches compilable source, this proves
+# that `/code-review` AND `/simplify` were actually run against the EXACT commit being
+# pushed — not the agent's recollection that it did them. A missing receipt blocks the
+# push and tells the agent to run the reviews.
+#
+# Why a gate and not a reminder: a written instruction to "run code-review before
+# pushing" is the same class of thing the agent forgets. The only reliable enforcement
+# is mechanical — the push refuses until per-commit review evidence exists. This mirrors
+# the borrowed principle: don't trust the agent to behave, force it with plain machinery.
+#
+# Scope decisions (deliberate, documented):
+#   * Only gates pushes/PRs whose branch diff vs the base touches compilable source
+#     (src/**). Docs-, memory-, and config-only pushes pass without review receipts.
+#   * Receipts are bound to the current HEAD short-SHA, so a review of older code does
+#     not satisfy a later commit. The working tree must be clean under src/ so HEAD is
+#     what actually gets pushed.
+#   * Skill-agnostic: it checks for review RECEIPTS, not for a specific tool. Receipts
+#     are written by save-review-receipt.ps1 when /code-review and /simplify complete.
+#   * Honors RAILS_SKIP_REVIEW_GATE=1 as a documented, auditable escape hatch.
+#   * Never wedges the session on missing tooling or an unresolvable base: it fails OPEN
+#     (allows) only when it genuinely cannot compute the diff, and fails CLOSED (blocks)
+#     whenever it can prove review evidence is missing.
+#
+# IMPORTANT — coverage boundary: a Claude Code hook only fires for actions taken THROUGH
+# Claude Code. A human running `git push` in their own terminal is NOT gated by this; the
+# server-side equivalent is a required CI check. This gate stops the agent from skipping
+# review, not every possible push.
+#
+# Contract: emit a PreToolUse hookSpecificOutput with permissionDecision "deny" to block;
+# emit nothing (exit 0) to allow.
+
+$ErrorActionPreference = 'Stop'
+# Read native command exit codes explicitly so a non-zero git call never throws before
+# we can decide — this gate must fail closed on "evidence missing", open on "can't tell".
+$PSNativeCommandUseErrorActionPreference = $false
+
+function Allow { exit 0 }
+function Deny([string]$reason) {
+  @{
+    hookSpecificOutput = @{
+      hookEventName          = 'PreToolUse'
+      permissionDecision     = 'deny'
+      permissionDecisionReason = $reason
+    }
+  } | ConvertTo-Json -Compress -Depth 5
+  exit 0
+}
+
+# --- Read the PreToolUse payload from stdin.
+$raw = [Console]::In.ReadToEnd()
+$payload = $null
+if ($raw) { try { $payload = $raw | ConvertFrom-Json } catch { } }
+if (-not $payload) { Allow }
+
+# --- Only gate Bash commands that actually INVOKE git push / gh pr create. Match the
+#     start of each shell segment (split on ; && || | &) so the words appearing inside a
+#     quoted string, an echo, or `--help` text don't trip the gate. `git -C <path> push`
+#     is recognized.
+if ($payload.tool_name -ne 'Bash') { Allow }
+$cmd = [string]$payload.tool_input.command
+if (-not $cmd) { Allow }
+$gates = $false
+foreach ($seg in ($cmd -split '\|\||&&|[;|&]')) {
+  $s = $seg.Trim()
+  if ($s -match '^git\s+(-C\s+\S+\s+)?push(\s|$)' -or $s -match '^gh\s+pr\s+create(\s|$)') {
+    $gates = $true; break
+  }
+}
+if (-not $gates) { Allow }
+
+# --- Documented escape hatch.
+if ($env:RAILS_SKIP_REVIEW_GATE -eq '1') {
+  [Console]::Error.WriteLine('review-gate: RAILS_SKIP_REVIEW_GATE=1 set; skipping review gate.')
+  Allow
+}
+
+$projectDir = $env:CLAUDE_PROJECT_DIR
+if (-not $projectDir) { $projectDir = (Get-Location).Path }
+Set-Location $projectDir
+
+# --- Tooling guard: don't trap the agent if git isn't available.
+if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
+  [Console]::Error.WriteLine('review-gate: git not found; skipping review gate.')
+  Allow
+}
+
+# --- Resolve the base to diff against. Prefer origin/main, then main. If neither
+#     resolves (unusual), fall back to the last commit so we can still scope on src/.
+$base = $null
+foreach ($ref in @('origin/main', 'main')) {
+  $resolved = & git rev-parse --verify --quiet "$ref" 2>$null
+  if ($LASTEXITCODE -eq 0 -and $resolved) { $base = $ref; break }
+}
+
+if ($base) {
+  $changed = & git diff --name-only "$base...HEAD" 2>$null
+} else {
+  $changed = & git show --name-only --pretty=format: HEAD 2>$null
+}
+
+# Can't compute a diff at all — fail open rather than wedge the session.
+if ($LASTEXITCODE -ne 0) {
+  [Console]::Error.WriteLine('review-gate: could not compute branch diff; skipping.')
+  Allow
+}
+
+# --- Scope: only compilable source under src/ triggers the gate.
+$srcChanged = $changed | Where-Object { $_ -match '^src/.*\.(cs|csproj|slnx|props|targets|razor|cshtml|ts|html)$' }
+if (-not $srcChanged) { Allow }
+
+# --- The committed code under review must equal what gets pushed.
+$dirtySrc = & git status --porcelain -- 'src' 2>$null
+if ($dirtySrc) {
+  Deny("Review gate: you have uncommitted changes under src/. Commit them first so the " +
+       "review covers exactly what you push, then run /code-review and /simplify on the final commit.")
+}
+
+# --- Require a receipt for each review, bound to the exact commit being pushed.
+$sha = (& git rev-parse --short HEAD 2>$null)
+if ($LASTEXITCODE -ne 0 -or -not $sha) { Allow }   # detached/unborn — can't bind; don't wedge.
+$sha = $sha.Trim()
+
+$receiptDir = Join-Path $projectDir '.claude/.review-receipts'
+$missing = @()
+if (-not (Test-Path (Join-Path $receiptDir "$sha.code-review"))) { $missing += '/code-review' }
+if (-not (Test-Path (Join-Path $receiptDir "$sha.simplify")))    { $missing += '/simplify' }
+
+if ($missing.Count -gt 0) {
+  Deny("Review gate: src/ changed but [$($missing -join ', ')] " +
+       "$(if ($missing.Count -eq 1) {'has'} else {'have'}) not been run against commit $sha. " +
+       "Run the missing review(s), then record each by piping its summary to " +
+       ".claude/hooks/save-review-receipt.ps1 (e.g. `'...summary...' | pwsh -NoProfile -File " +
+       ".claude/hooks/save-review-receipt.ps1 -Kind code-review`). Re-run after re-committing any " +
+       "fixes the reviews produce. Emergency bypass: set RAILS_SKIP_REVIEW_GATE=1.")
+}
+
+Allow

--- a/.claude/hooks/save-review-receipt.ps1
+++ b/.claude/hooks/save-review-receipt.ps1
@@ -1,0 +1,53 @@
+#!/usr/bin/env pwsh
+#
+# save-review-receipt.ps1 — records that a review ran against the current commit, for the
+# review gate (review-gate.ps1) to verify before a push/PR.
+#
+# Usage (pipe the review summary on stdin so the receipt is real evidence, not a flag):
+#   "...code-review findings...""  | pwsh -NoProfile -File .claude/hooks/save-review-receipt.ps1 -Kind code-review
+#   "...simplify findings..."       | pwsh -NoProfile -File .claude/hooks/save-review-receipt.ps1 -Kind simplify
+#
+# The receipt is written to .claude/.review-receipts/<HEAD-short-sha>.<kind> so it is bound
+# to the exact commit. If you amend or add commits, the SHA changes and the gate re-arms,
+# forcing a fresh review of the final code. Receipts are gitignored (per-clone evidence).
+#
+# Honest scope: the receipt's CONTENT is whatever is piped in; this script binds it to the
+# commit and timestamps it, but it cannot verify the review was done well — that is on the
+# reviewer. Its value is mechanical: the push is blocked until a commit-bound receipt exists,
+# turning "might forget entirely" into "must produce per-commit, inspectable review evidence."
+
+[CmdletBinding()]
+param(
+  [Parameter(Mandatory = $true)]
+  [ValidateSet('code-review', 'simplify')]
+  [string]$Kind
+)
+
+$ErrorActionPreference = 'Stop'
+$PSNativeCommandUseErrorActionPreference = $false
+
+$projectDir = $env:CLAUDE_PROJECT_DIR
+if (-not $projectDir) { $projectDir = (Get-Location).Path }
+Set-Location $projectDir
+
+if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
+  [Console]::Error.WriteLine('save-review-receipt: git not found.'); exit 1
+}
+
+$sha = (& git rev-parse --short HEAD 2>$null)
+if ($LASTEXITCODE -ne 0 -or -not $sha) {
+  [Console]::Error.WriteLine('save-review-receipt: cannot resolve HEAD.'); exit 1
+}
+$sha = $sha.Trim()
+
+$receiptDir = Join-Path $projectDir '.claude/.review-receipts'
+New-Item -ItemType Directory -Force -Path $receiptDir | Out-Null
+
+$summary = [Console]::In.ReadToEnd()
+if (-not $summary) { $summary = "($Kind run; no summary piped)" }
+
+$header = "# $Kind receipt`ncommit: $sha`n`n"
+$path = Join-Path $receiptDir "$sha.$Kind"
+Set-Content -Path $path -Value ($header + $summary) -Encoding UTF8
+
+Write-Output "Saved $Kind receipt for commit $sha at .claude/.review-receipts/$sha.$Kind"

--- a/.claude/rules/review-cadence.md
+++ b/.claude/rules/review-cadence.md
@@ -8,6 +8,25 @@ Run these two skills in order:
 
 Do NOT skip these. Run them even when changes seem straightforward.
 
+## The review gate enforces this mechanically
+
+This cadence is not an honor system. A `PreToolUse` hook (`.claude/hooks/review-gate.ps1`, wired
+in `.claude/settings.json`) **blocks `git push` and `gh pr create`** when the branch's diff touches
+compilable source (`src/**`) unless `/code-review` **and** `/simplify` have been recorded against the
+exact `HEAD` commit being pushed.
+
+- **Recording a review:** pipe its summary to the helper, which binds the receipt to the current
+  commit:
+  `"<review summary>" | pwsh -NoProfile -File .claude/hooks/save-review-receipt.ps1 -Kind code-review`
+  (and again with `-Kind simplify`). Receipts live in the gitignored `.claude/.review-receipts/`.
+- **Re-arming:** amending or adding commits changes `HEAD`, so the gate demands a fresh review of the
+  final code. Run the reviews on the commit you actually push.
+- **Scope:** docs-, memory-, and config-only pushes pass without receipts.
+- **Coverage boundary:** the hook only fires for pushes made *through Claude Code* — a human pushing
+  from their own terminal is not gated (that is the server-side CI check's job). The hook stops the
+  *agent* from skipping review.
+- **Emergency bypass:** set `RAILS_SKIP_REVIEW_GATE=1` (auditable; use sparingly).
+
 ## After a Full Layer is Complete
 Run this additional skill:
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -75,6 +75,20 @@
             "command": "echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"additionalContext\":\"GitNexus project rule (CLAUDE.md): if this edit modifies an existing code symbol, first run gitnexus_impact({target, direction: upstream}) and report the blast radius, warning on HIGH or CRITICAL risk. Skip for docs, comments, config, or test-only edits.\"}}'"
           }
         ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "pwsh",
+            "args": [
+              "-NoProfile",
+              "-File",
+              "${CLAUDE_PROJECT_DIR}/.claude/hooks/review-gate.ps1"
+            ]
+          }
+        ]
       }
     ],
     "Stop": [

--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,4 @@ documentation/design/top-10-risks-executive.html
 documentation/design/top-10-risks-full-catalogue.html
 documentation/design/top-10-risks-mitigations.md
 .claude/reviews/
+.claude/.review-receipts/


### PR DESCRIPTION
## Summary

Adds a **mechanical review gate** so the review cadence (`.claude/rules/review-cadence.md`) is enforced by machinery instead of relying on the agent to remember it. This is the local/agent-side companion to the CI grader — same principle: *force the behavior, don't trust it.*

A `PreToolUse` hook blocks `git push` and `gh pr create` when the branch's diff touches compilable source (`src/**`) **unless** `/code-review` **and** `/simplify` were recorded against the exact `HEAD` commit being pushed.

## How it works

- **Block:** push/PR of `src/` changes with no per-commit review evidence → denied, with a message naming what's missing.
- **Record:** pipe each review's summary to `save-review-receipt.ps1`, which binds it to `HEAD`'s short-sha (receipts in the gitignored `.claude/.review-receipts/`).
- **Re-arm:** new/amended commits change `HEAD`, so stale reviews don't count.
- **Scope:** docs/memory/config-only pushes pass without receipts.
- **Escape hatch:** `RAILS_SKIP_REVIEW_GATE=1` (auditable).

Built in the project's existing fail-closed PowerShell hook style (mirrors `stop-build-gate.ps1`). Committed to `.claude/settings.json` so it ships with the template for every consumer.

## Honest coverage boundary

A Claude Code hook only fires for pushes made **through Claude Code**. A human running `git push` in their own terminal is not gated — that's the job of a required **server-side CI check** (separate follow-up). This gate stops the *agent* from skipping review; CI makes it universal.

## Verification

Tested the hook directly against fixture payloads:
- `git push` with `src/` changed, no receipts → **deny** ✅
- command merely mentioning "git push" inside a string → **allow** (no false positive) ✅
- `cd repo && gh pr create` → **deny** (segment-anchored detection) ✅
- push after both receipts recorded for `HEAD` → **allow** ✅

This PR itself touches no `src/`, so the gate correctly did not fire on its own push.

## Files
- `.claude/hooks/review-gate.ps1` — the gate
- `.claude/hooks/save-review-receipt.ps1` — receipt helper
- `.claude/settings.json` — wires the hook
- `.claude/rules/review-cadence.md` — documents it
- `.gitignore` — per-clone receipts dir

🤖 Generated with [Claude Code](https://claude.com/claude-code)