### PR TITLE
chore: add correctness-review CI rail + deterministic line-anchor scaffolding

### DIFF
--- a/.github/RAILS.md
+++ b/.github/RAILS.md
@@ -14,6 +14,7 @@ them live, and how to prove they actually catch things.
 | **build-and-test** | `workflows/ci.yml` | every PR | **Blocks** (hard gate) |
 | **OWASP Agentic Top-10 Gate** | `workflows/ci.yml` | every PR | **Blocks** (hard gate) |
 | **security-review** | `workflows/security-review.yml` | every PR; reviews on gated paths / `risk:high` | **Blocks on HIGH** |
+| **correctness-review** | `workflows/correctness-review.yml` | every PR; reviews when `src/` changed | **Blocks on a high-confidence defect** (not yet a required check — see go-live) |
 | **grader** | `workflows/grader.yml` | every PR | **Advises** — never blocks |
 | **docs-drift** | `workflows/docs-drift-check.yml` | push to main (code / CI / governance paths) | **Advises** — opens a doc-sync PR |
 | **Stop gate** | `../.claude/hooks/stop-build-gate.ps1` | agent tries to finish locally | **Blocks** a red build |
@@ -29,9 +30,10 @@ These are deliberate, outward-facing actions. Nothing in this PR performs them.
    Claude Code, or install from <https://github.com/apps/claude>. Needed for the
    grader, security-review, and docs-drift workflows. (Repo admin required.)
 2. **Add the `ANTHROPIC_API_KEY` repository secret** (Settings → Secrets and
-   variables → Actions). The grader and security-review steps call the Claude API;
-   there is a real per-PR token cost. Until this is set, the security-review gate
-   **fails closed on gated PRs** (by design) and the grader stays green/no-op.
+   variables → Actions). The grader, security-review, and correctness-review steps
+   call the Claude API; there is a real per-PR token cost. Until this is set, the
+   security-review and correctness-review gates **fail closed on the PRs they
+   review** (by design) and the grader stays green/no-op.
 3. **Apply branch protection** once you've read the desired ruleset:
    ```bash
    scripts/rails/apply-branch-protection.sh --dry-run   # review the plan
@@ -39,6 +41,12 @@ These are deliberate, outward-facing actions. Nothing in this PR performs them.
    ```
    This is the only sanctioned way to change branch protection — edit the JSON,
    re-run the script. Do not hand-edit rules in the GitHub UI.
+4. **(Optional) Promote correctness-review to a required check.** It ships wired
+   and fail-closed but is intentionally **not** in the ruleset, so merging it does
+   not wedge every source PR before steps 1–2 are done. Once the Claude App + key
+   are live and you've watched it run on a few PRs, add `correctness-review` to the
+   `required_status_checks` array in `rulesets/main-branch-protection.json` and
+   re-run the apply script. Until then it advises (its red X does not block).
 
 ## Required status checks
 
@@ -94,6 +102,11 @@ Before trusting these, force each one to fail and confirm it's caught:
 - **security-review** — open a throwaway PR touching a gated path (e.g. add a
   comment in a file under `**/Auth/`) with a planted HIGH issue. The check must
   go red. Close it unmerged.
+- **correctness-review** — open a throwaway PR with a planted high-confidence
+  defect under `src/` (e.g. an inverted null check or an off-by-one that drops a
+  row). The check must go red with `CORRECTNESS_VERDICT: BLOCK`; then apply the
+  `accepted-risk:correctness` label and confirm it goes green. Close it unmerged.
+  Do this before promoting it to a required check (go-live step 4).
 - **CI / OWASP** — already exercised by every real PR.
 
 ## Deferred (not built — no cloud deployment exists yet)

--- a/.github/correctness-review-rubric.md
+++ b/.github/correctness-review-rubric.md
@@ -1,0 +1,93 @@
+# Correctness-review rubric
+
+You are the **correctness-reviewer** running as a delivery rail (the-rails.md §3).
+You are a fresh agent that did **not** write this change. You hunt for **plain
+logic and correctness defects** in the diff — the bug class the other rails miss.
+`build-and-test` proves it compiles and the existing tests pass; `security-review`
+covers exploitability; the grader checks the change against its stated intent.
+None of them asks the one question you own: **is this code correct?**
+
+Unlike the grader, you **block** — but only on a defect you are genuinely sure of.
+A false red here costs a human a merge and erodes trust in every rail, so the bar
+to block is high confidence, not suspicion.
+
+## Scope — the anchor set is the law
+
+The workflow gives you a **changed-line anchor set** (from
+`scripts/rails/diff-anchors.sh`): a list of `path:Lstart-Lend` ranges that are the
+*only* lines this PR changed. Review **only** these lines and the code they
+directly touch.
+
+- Every finding **must** cite one anchor from that set, verbatim, as `path:line`
+  (a line inside one of the ranges). A finding you cannot anchor to a changed
+  line is **out of scope** — drop it.
+- Pre-existing bugs on unchanged lines are not yours to report. If a changed line
+  *depends on* a latent bug nearby, anchor to the changed line and explain the
+  interaction.
+- If the anchor set is empty (no in-scope source changed), pass trivially.
+
+## Review for — correctness defects only
+
+- **Null / undefined dereference** — a value that can be null reaching a member
+  access with no guard; `Result<T>` unwrapped without checking `IsSuccess`.
+- **Broken control flow** — inverted condition, wrong/missing `break`/`return`,
+  unreachable branch, a guard that no longer guards after the edit.
+- **Off-by-one / boundary** — loop or index bounds that drop or double-count, esp.
+  where data is written or deleted.
+- **Swapped or wrong arguments** — parameters passed in the wrong order, wrong
+  variable, wrong operator (`&&` vs `||`, `==` vs `!=`, `>=` vs `>`).
+- **Resource leak** — `IDisposable`/stream/connection/handle not disposed on every
+  path (incl. exception paths); missing `await using`/`using`.
+- **Async correctness** — un-awaited Task that should be awaited, `async void`
+  outside an event handler, `.Result`/`.Wait()` introducing deadlock risk, a
+  `CancellationToken` accepted but dropped.
+- **Mutation of shared/immutable state** — in-place mutation where this repo
+  requires a new object (records / `with` / `ImmutableList<T>`); a captured loop
+  variable; a mutable static.
+- **Data loss / corruption** — an overwrite, truncation, or silent catch that
+  swallows an error the caller needed.
+- **Contract drift** — a caller and callee that disagree after the edit (a renamed
+  field, a changed unit, a nullability change) that the compiler won't catch
+  (e.g. across JSON/serialization or DI boundaries).
+
+Not your job (hand to the grader or `/simplify`, do **not** block): style, naming,
+duplication, missing XML docs, "could be simpler," missing tests (note it as
+advisory, but a missing test is not itself a blocking correctness defect),
+performance that is merely suboptimal.
+
+## Severity — what blocks
+
+- **BLOCK** — a defect you are highly confident is real and reachable, that on
+  some input produces a wrong result, a crash, a leak, data loss, or a deadlock.
+  If you would bet money the code misbehaves, it blocks.
+- **ADVISE** — a likely-but-unproven concern, a smell, anything you cannot anchor
+  with confidence to a changed line. Note it in the comment; do **not** block.
+
+When unsure whether a finding is BLOCK or ADVISE, it is ADVISE. Reserve BLOCK for
+defects you can describe with a concrete failing input or execution path.
+
+## Output — do BOTH
+
+1. **Post a PR comment** (update the same comment on re-runs, don't stack):
+   - **Blocking defects** — a table: *Anchor* (`path:line`) · *Defect* · *Failing
+     case* (the concrete input/path that misbehaves) · *Fix*.
+   - **Advisory** — a short list, each anchored.
+   - **Bottom line** — `CORRECT` / `DEFECTS FOUND`, and the single most important
+     thing the human should look at.
+   - Cite anchors. No praise, no filler. Be precise and skeptical, not reassuring.
+
+2. **Write the machine verdict** to the absolute path the workflow gives you
+   (`${{ runner.temp }}/correctness-verdict.txt`). Its **first line must be exactly**:
+   - `CORRECTNESS_VERDICT: BLOCK` — one or more blocking defects, **or**
+   - `CORRECTNESS_VERDICT: PASS` — no blocking defects (advisories are fine).
+
+   Nothing else on the first line. A buried token or hedged prose
+   ("PASS, but…") fails closed.
+
+## Accepted-risk override
+
+A blocking defect can be consciously accepted: apply the
+`accepted-risk:correctness` label to the PR. The workflow honors the label to let
+this check pass; who applied it is recorded in the PR timeline (audited), and the
+branch ruleset's required non-author approval still gates the actual merge. The
+rail records the truth; the human owns the decision.

--- a/.github/grader-rubric.md
+++ b/.github/grader-rubric.md
@@ -17,12 +17,27 @@ as the spec, supplemented by any linked issue and the `CLAUDE.md` / `.claude/rul
 standards. If the PR description states no intent, say so plainly — an
 unspecified change cannot be graded against intent, and that itself is a finding.
 
+## The anchor set — pin your evidence to it
+
+The workflow gives you a **changed-line anchor set** (from
+`scripts/rails/diff-anchors.sh`): a list of `path:Lstart-Lend` ranges that are the
+*only* lines this PR changed. It is the authoritative answer to "what did this PR
+touch." Use it two ways:
+
+- **Evidence** for a met/partial check should cite a `path:line` from the anchor
+  set (or a test name) — not a vague "see the controller." Pinning to a changed
+  line makes the verdict reproducible and stops line-number drift.
+- **Scope** — a "hole" you raise must trace back to a changed line; the grader
+  judges *this change*, not pre-existing debt on untouched lines. (You may still
+  flag an omission — something the spec asked for that appears in *no* anchor — as
+  a not-met check; absence from the set is itself the evidence.)
+
 ## Produce, as a single PR comment
 
 1. **Intent** — one or two sentences: what this PR claims to do, in your words.
 2. **Check-by-check table** — one row per claim/acceptance-criterion you can
    extract from the spec. Columns: *Claim* · *Verdict* (✅ met / ⚠️ partial /
-   ❌ not met / ❓ can't tell) · *Evidence* (file:line or test name).
+   ❌ not met / ❓ can't tell) · *Evidence* (a `path:line` anchor or test name).
 3. **Holes** — anything the diff does that the spec did not ask for (scope
    creep), anything the spec asked for that the diff omits, and any risk the
    author may not have seen (missing tests, mutation of shared state, broken

--- a/.github/workflows/correctness-review.yml
+++ b/.github/workflows/correctness-review.yml
@@ -1,0 +1,156 @@
+name: Correctness Review
+
+# The correctness rail (the-rails.md §3): a fresh agent hunts the diff for plain
+# logic/correctness defects — the bug class the other rails miss. build-and-test
+# proves it compiles and existing tests pass; security-review covers
+# exploitability; the grader checks the change against its stated intent. None of
+# them asks "is this code correct?" — this rail does.
+#
+# Why this is a gate (like security-review, unlike the grader):
+# The local review-gate hook (.claude/hooks/review-gate.ps1) only fires for pushes
+# made *through Claude Code*; a human pushing from their own terminal gets no bug
+# review. This job is that server-side backstop. It runs on every PR but
+# short-circuits to success when no source under src/ changed, so it can be a
+# required status check without leaving the merge stuck "pending". When src/ IS
+# touched it runs the reviewer and FAILS on a high-confidence correctness defect
+# (CORRECTNESS_VERDICT: BLOCK) unless a named human records the
+# `accepted-risk:correctness` label.
+#
+# Fail-safe: a source change whose review cannot complete (e.g. missing
+# ANTHROPIC_API_KEY before go-live) BLOCKS rather than passes.
+#
+# NOT YET A REQUIRED CHECK: this ships wired and fail-closed, but is intentionally
+# left out of .github/rulesets/main-branch-protection.json so merging it does not
+# wedge every source PR before the Claude GitHub App + ANTHROPIC_API_KEY are live.
+# Flipping it on is a documented go-live step — see .github/RAILS.md.
+
+on:
+  pull_request:
+    # labeled/unlabeled are included so applying `accepted-risk:correctness` re-runs
+    # the gate and unblocks the merge promptly. The verdict lives in the runner's
+    # temp dir and does not survive across runs, so a label change re-reviews from
+    # scratch rather than re-reading a cached verdict — an accepted token cost for
+    # a responsive override (concurrency below cancels any in-flight run).
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+
+# Least privilege: read the code, write a PR comment. Nothing else.
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: correctness-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  correctness-review:
+    name: correctness-review
+    runs-on: ubuntu-latest
+    # Skip drafts; they aren't ready for a verdict.
+    if: github.event.pull_request.draft == false
+    steps:
+      - name: Checkout PR
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect source changes and compute anchors
+        id: detect
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          set -euo pipefail
+          # Full (non-shallow) fetch of the base so the merge-base exists; a
+          # --depth=1 fetch leaves no common ancestor and breaks the diff.
+          git fetch --no-tags origin "$BASE_REF"
+
+          # The anchor set IS the scope: compute the changed-line ranges under
+          # src/ once, with the same deterministic helper the grader uses. If it
+          # is empty, no compilable source changed and review is not required.
+          ANCHORS_FILE="${RUNNER_TEMP}/correctness-anchors.txt"
+          if ! scripts/rails/diff-anchors.sh --base "$BASE_REF" -- 'src/' > "$ANCHORS_FILE"; then
+            echo "::error::Correctness review could not compute the changed-line scope (diff-anchors.sh failed). Failing closed."
+            exit 1
+          fi
+          echo "anchors_file=${ANCHORS_FILE}" >> "$GITHUB_OUTPUT"
+
+          echo "Changed-line anchors under src/:"
+          cat "$ANCHORS_FILE" || true
+
+          if [ -s "$ANCHORS_FILE" ]; then
+            echo "review_required=true" >> "$GITHUB_OUTPUT"
+            echo "Correctness review REQUIRED ($(grep -c . "$ANCHORS_FILE") changed-line range(s) under src/)."
+          else
+            echo "review_required=false" >> "$GITHUB_OUTPUT"
+            echo "No source under src/ changed — correctness review not required."
+          fi
+
+      # Clear any verdict a PR may have COMMITTED into the tree. The verdict must
+      # come from this run, not from attacker-supplied content; we write/read it
+      # under the runner temp dir (outside the workspace) so a committed
+      # correctness-verdict.txt can never satisfy the gate.
+      - name: Reset verdict
+        if: steps.detect.outputs.review_required == 'true'
+        run: rm -f "${{ runner.temp }}/correctness-verdict.txt" correctness-verdict.txt
+
+      - name: Run correctness-reviewer
+        if: steps.detect.outputs.review_required == 'true'
+        continue-on-error: true
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          prompt: |
+            You are running as the correctness-reviewer for PR #${{ github.event.pull_request.number }}.
+            Read the rubric at .github/correctness-review-rubric.md and follow it exactly.
+            The changed-line anchor set is at ${{ steps.detect.outputs.anchors_file }} —
+            review ONLY those lines and the code they directly touch, and anchor every
+            finding to a line from that file. The diff base is origin/${{ github.base_ref }}.
+            POST your findings as a PR comment AND write the machine verdict to the
+            absolute path ${{ runner.temp }}/correctness-verdict.txt (its first line must be
+            exactly "CORRECTNESS_VERDICT: PASS" or "CORRECTNESS_VERDICT: BLOCK").
+          claude_args: |
+            --model opus
+            --max-turns 25
+            --allowedTools Bash,Read,Grep,Glob,Write
+
+      - name: Enforce verdict (block on high-confidence defect)
+        if: steps.detect.outputs.review_required == 'true'
+        env:
+          VERDICT_FILE: ${{ runner.temp }}/correctness-verdict.txt
+          # The label is an AUDITED manual override (who applied it is in the PR
+          # timeline), not an authorization check — this step cannot reliably tell
+          # the applier from the author across every trigger type. The "a non-author
+          # signs off" guarantee is enforced by the branch ruleset's required
+          # non-author approval, which still gates the merge after this passes.
+          HAS_ACCEPTED_RISK: ${{ contains(github.event.pull_request.labels.*.name, 'accepted-risk:correctness') }}
+        run: |
+          set -euo pipefail
+          if [ ! -f "$VERDICT_FILE" ]; then
+            echo "::error::Correctness review did not produce a verdict on a source change. Failing closed."
+            echo "If ANTHROPIC_API_KEY / the Claude GitHub App are not yet configured, see .github/RAILS.md."
+            exit 1
+          fi
+          echo "Verdict file:"; cat "$VERDICT_FILE"
+          # Exact prefix match on the first line — a model that buries the token in
+          # prose, or text like "PASS (1 BLOCK pending)", must not pass.
+          FIRST="$(head -n1 "$VERDICT_FILE" || true)"
+          case "$FIRST" in
+            "CORRECTNESS_VERDICT: BLOCK"*)
+              if [ "$HAS_ACCEPTED_RISK" = "true" ]; then
+                echo "::warning::Correctness review found a high-confidence defect, but the 'accepted-risk:correctness' label records an accepted-risk override (audited in the PR timeline). The branch ruleset's required non-author approval still gates the merge."
+                exit 0
+              fi
+              echo "::error::Correctness review found a high-confidence defect. Fix it, or apply the 'accepted-risk:correctness' label to record an accepted-risk override (audited; the merge still needs the ruleset's non-author approval)."
+              exit 1 ;;
+            "CORRECTNESS_VERDICT: PASS"*)
+              echo "Correctness review passed (no blocking defects)."
+              exit 0 ;;
+            *)
+              echo "::error::Unrecognized correctness verdict ('$FIRST'). Failing closed."
+              exit 1 ;;
+          esac
+
+      - name: No review required
+        if: steps.detect.outputs.review_required != 'true'
+        run: echo "No source under src/ changed — correctness-review check passes trivially."

--- a/.github/workflows/grader.yml
+++ b/.github/workflows/grader.yml
@@ -38,6 +38,25 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Compute changed-line anchors
+        id: anchors
+        # The grader NEVER adds red to a PR (it advises). Anchors are a best-effort
+        # aid: if the fetch hiccups or the helper exits non-zero, swallow it and let
+        # the grade step fall back to inspecting the diff directly.
+        continue-on-error: true
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          set -euo pipefail
+          # Full fetch of the base so the merge-base (and thus the diff) resolves.
+          git fetch --no-tags origin "$BASE_REF"
+          # Deterministic changed-line set, shared with the correctness rail, so
+          # the grader's evidence pins to exact lines instead of drifting prose.
+          ANCHORS_FILE="${RUNNER_TEMP}/grader-anchors.txt"
+          scripts/rails/diff-anchors.sh --base "$BASE_REF" > "$ANCHORS_FILE"
+          echo "anchors_file=${ANCHORS_FILE}" >> "$GITHUB_OUTPUT"
+          echo "Changed-line anchors:"; cat "$ANCHORS_FILE" || true
+
       - name: Grade the change against its spec
         id: grade
         continue-on-error: true
@@ -49,6 +68,9 @@ jobs:
             You are running as the grader for PR #${{ github.event.pull_request.number }}.
             Read the grading rubric at .github/grader-rubric.md and follow it exactly.
             The "spec" is this PR's description and any linked issue.
+            The changed-line anchor set is at ${{ steps.anchors.outputs.anchors_file }} —
+            cite a `path:line` from it as the evidence for each check, and treat it as
+            the authoritative list of what this PR changed.
             Inspect the PR diff (the base is origin/${{ github.base_ref }}) and the
             changed files, then POST your verdict as a single PR comment. Update the
             same comment on re-runs rather than stacking new ones.

--- a/scripts/rails/diff-anchors.sh
+++ b/scripts/rails/diff-anchors.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+#
+# diff-anchors.sh — emit the deterministic set of changed lines in a PR.
+#
+# Part of the delivery rails (see .github/RAILS.md). This is the line-anchor
+# scaffolding shared by the grader and correctness-review rails: it turns a PR
+# diff into a canonical, machine-readable list of changed-line ranges, one per
+# contiguous added/modified hunk:
+#
+#   src/Content/.../Foo.cs:120-145
+#   src/Content/.../Foo.cs:201-201
+#   src/Content/.../Bar.ts:5-5
+#
+# Why it exists: an LLM reviewer left to "inspect the diff" produces free-form,
+# non-reproducible findings that drift line numbers and wander outside the
+# change. Feeding it THIS list as the canonical anchor set forces every finding
+# to pin to a real changed line and keeps review scoped to the diff. Same input
+# in, same anchors out — the technique is borrowed from deterministic
+# code-review scaffolding (e.g. alibaba/open-code-review); only the technique,
+# not the tooling.
+#
+# Output is the anchor list on stdout (sorted, de-duplicated); a one-line count
+# summary goes to stderr so stdout stays pure and pipeable. Deleted files are
+# excluded (a finding cannot anchor to a line that no longer exists); pure
+# deletions inside a surviving file are likewise not emitted — review them via
+# the diff itself, anchored to the nearest surviving line.
+#
+# Requirements: git, awk, sort (all present on ubuntu-latest runners).
+#
+# Usage:
+#   scripts/rails/diff-anchors.sh                       # base = origin/main merge-base
+#   scripts/rails/diff-anchors.sh --base origin/develop # explicit base ref
+#   BASE_REF=main scripts/rails/diff-anchors.sh         # base ref via env
+#   scripts/rails/diff-anchors.sh -- 'src/**'           # restrict to pathspec(s)
+#
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-main}"
+PATHSPECS=()
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --base)
+      BASE_REF="${2:?--base requires a ref}"
+      shift 2
+      ;;
+    --)
+      shift
+      PATHSPECS=("$@")
+      break
+      ;;
+    *)
+      echo "diff-anchors.sh: unknown argument '$1'" >&2
+      exit 2
+      ;;
+  esac
+done
+
+# Resolve the merge-base so the diff is the PR's own changes, not everything that
+# landed on the base branch since the branch point. Try the ref as given, then
+# the origin/-prefixed form (CI checks out with a remote-tracking base).
+resolve_base() {
+  local ref="$1"
+  if git rev-parse --verify --quiet "$ref^{commit}" >/dev/null; then
+    git merge-base "$ref" HEAD && return 0
+  fi
+  if git rev-parse --verify --quiet "origin/$ref^{commit}" >/dev/null; then
+    git merge-base "origin/$ref" HEAD && return 0
+  fi
+  return 1
+}
+
+if ! BASE_SHA="$(resolve_base "$BASE_REF")"; then
+  echo "diff-anchors.sh: cannot resolve base ref '$BASE_REF' (tried '$BASE_REF' and 'origin/$BASE_REF')." >&2
+  exit 1
+fi
+
+# --unified=0 makes every hunk header's +start,len describe exactly the
+# added/modified new-file lines (no context lines to widen the range).
+# --diff-filter=d drops deleted files (their new-side path is /dev/null).
+# core.quotePath=false keeps non-ASCII paths literal (default would C-quote and
+# octal-escape them, e.g. "b/caf\303\251.txt", breaking the b/ strip below).
+anchors="$(
+  git -c core.quotePath=false diff --no-color --unified=0 --diff-filter=d "$BASE_SHA" HEAD -- "${PATHSPECS[@]}" \
+  | awk '
+      # Take everything after the "+++ " marker (substr from col 5), not $2, so a
+      # path containing spaces survives; strip the b/ prefix and any trailing tab
+      # git appends to delimit a space-bearing name.
+      /^\+\+\+ /            { file=substr($0, 5); sub(/^b\//, "", file); sub(/\t.*$/, "", file); next }
+      /^@@ /{
+        # Hunk header: @@ -oldStart,oldLen +newStart,newLen @@
+        if (match($0, /\+[0-9]+(,[0-9]+)?/)) {
+          spec = substr($0, RSTART + 1, RLENGTH - 1)   # drop leading "+"
+          n = split(spec, a, ",")
+          start = a[1] + 0
+          len   = (n > 1) ? a[2] + 0 : 1               # omitted length means 1
+          if (len > 0 && file != "" && file != "/dev/null")
+            print file ":" start "-" (start + len - 1)
+        }
+      }
+    ' \
+  | sort -u
+)"
+
+count="$(printf '%s' "$anchors" | grep -c . || true)"
+echo "diff-anchors.sh: ${count} changed-line range(s) vs ${BASE_SHA}" >&2
+
+# Pure output: nothing but the anchor list (empty when no in-scope changes).
+[ -n "$anchors" ] && printf '%s\n' "$anchors"
+exit 0


### PR DESCRIPTION
## What

Adds a new delivery rail — **correctness-review** — and the shared **line-anchor scaffolding** the review rails use to pin findings to exact changed lines.

### The gap this closes
CI today has `build-and-test`, `OWASP Agentic Top-10 Gate`, `security-review` (exploitability), and the spec-`grader` (change-vs-intent). **None hunts plain logic/correctness bugs.** The local review-gate hook only fires for pushes made *through Claude Code* — a human pushing from their own terminal gets no bug review. This rail is that server-side backstop.

## Changes

- **`scripts/rails/diff-anchors.sh`** (new, shared) — turns a PR diff into a deterministic, machine-readable set of changed-line ranges (`path:Lstart-Lend`), one per contiguous added/modified hunk. Feeding an LLM reviewer *this* as the canonical anchor set forces every finding to pin to a real changed line and keeps review scoped to the diff. Technique borrowed from deterministic code-review scaffolding (e.g. alibaba/open-code-review) — technique only, not the tool.
- **`.github/workflows/correctness-review.yml`** + **`.github/correctness-review-rubric.md`** (new) — mirrors the proven `security-review.yml` gate pattern: tamper-proof verdict file in `runner.temp`, exact-prefix enforce, fail-closed. **Blocks only on a high-confidence defect** (`CORRECTNESS_VERDICT: BLOCK`); everything uncertain is advisory. `accepted-risk:correctness` label records an audited override.
- **`.github/workflows/grader.yml`** + **`.github/grader-rubric.md`** — feed the same anchor set so the grader's evidence is line-pinned instead of drifting prose.
- **`.github/RAILS.md`** — gate table, go-live flip (step 4), and shakedown entry.

## Deliberate scoping
- **Not yet a required check.** It ships wired and fail-closed but is intentionally left out of `main-branch-protection.json`, so merging it does not wedge every source PR before the Claude App + `ANTHROPIC_API_KEY` are live. Promoting it is a documented go-live step.
- Scope = `src/`. PRs touching no source pass trivially (this PR does — `src/` anchor set is empty).

## Self-review applied
A high-effort `/code-review` (7-angle fan-out) ran on this diff. Fixes folded in:
- `diff-anchors.sh` now handles paths with **spaces** and **non-ASCII** names (`core.quotePath=false` + `substr` instead of awk `$2`).
- Grader's new anchors step is `continue-on-error` — preserves its documented **never-red** advisory guarantee.
- Accepted-risk override docs corrected: the label is an **audited manual override**; the *non-author* guarantee comes from the ruleset's required non-author approval, not the label check (which can't verify the applier across trigger types).
- Clear `::error::` fail-closed messaging when scope can't be computed.

## Verification
- `bash -n` + parser unit-checks (single-line edits, multi-line adds, new files, pure deletions, spaced/non-ASCII paths) all correct.
- Both workflows parse as valid YAML; structure mirrors the working `security-review.yml`.
- Script committed `100755` with LF (enforced by `.gitattributes`).
- **What this PR actually exercises:** the **grader's** anchor feed runs live here, and the correctness rail's **trivial-pass path** (empty `src/` set → reviewer correctly skipped). The correctness *reviewer's* BLOCK / fail-closed / label-override paths are **not** exercised by this PR — their first live exercise is the `RAILS.md` shakedown (plant a defect under `src/`), which must be run before promoting the rail to a required check (go-live step 4). (Thanks to the grader for catching the original overclaim here.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)