### PR TITLE
test: correctness-rail shakedown (DO NOT MERGE)

### DIFF
--- a/src/Content/Domain/Domain.Common/Extensions/ShakedownProbe.cs
+++ b/src/Content/Domain/Domain.Common/Extensions/ShakedownProbe.cs
@@ -1,0 +1,29 @@
+namespace Domain.Common.Extensions;
+
+/// <summary>
+/// TEMPORARY shakedown probe for the correctness-review CI rail
+/// (see <c>.github/RAILS.md</c> → "Prove the rails"). This file carries a deliberate,
+/// high-confidence correctness defect so the rail can be proven to BLOCK on a real bug.
+/// It is never merged: the shakedown PR is closed unmerged and the branch deleted.
+/// If you are seeing this on <c>main</c>, something went wrong — delete it.
+/// </summary>
+public static class ShakedownProbe
+{
+    /// <summary>
+    /// Returns the element at <paramref name="index"/>, or <c>null</c> when the index is
+    /// outside the bounds of <paramref name="items"/>.
+    /// </summary>
+    /// <typeparam name="T">Reference type of the list elements.</typeparam>
+    /// <param name="items">The list to read from.</param>
+    /// <param name="index">Zero-based position to read.</param>
+    /// <returns>The element at <paramref name="index"/>, or <c>null</c> if out of range.</returns>
+    public static T? ElementAtOrNull<T>(IReadOnlyList<T> items, int index)
+        where T : class
+    {
+        // Bounds guard before indexing.
+        if (index < 0 || index > items.Count)
+            return null;
+
+        return items[index];
+    }
+}


### PR DESCRIPTION
**Shakedown PR — not for merge.** Proves the `correctness-review` rail (added in #54) actually blocks on a real defect, per `.github/RAILS.md` → "Prove the rails".

Plants a deliberate high-confidence off-by-one under `src/`: `ShakedownProbe.ElementAtOrNull` guards with `index > items.Count`, which admits `index == items.Count` (one past the last valid index) → out-of-range read at `items[index]`. Should be `>=`.

Expected sequence:
1. `correctness-review` goes **red** with `CORRECTNESS_VERDICT: BLOCK`.
2. Apply the `accepted-risk:correctness` label → the gate re-runs and goes **green** (audited override).
3. Close unmerged, delete branch.