### PR TITLE
MCP hardening Phase 1: SSRF guard, tool-level auth, audit trail

### DIFF
--- a/src/Content/Infrastructure/Infrastructure.AI.MCP/DependencyInjection.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.MCP/DependencyInjection.cs
@@ -1,5 +1,6 @@
 using Application.AI.Common.Interfaces;
 using Domain.Common.Config.AI;
+using Infrastructure.AI.Egress;
 using Infrastructure.AI.MCP.Resources;
 using Infrastructure.AI.MCP.Services;
 using Microsoft.Extensions.DependencyInjection;
@@ -28,13 +29,17 @@ public static class DependencyInjection
     /// <returns>The service collection for chaining.</returns>
     public static IServiceCollection AddMcpClientDependencies(this IServiceCollection services)
     {
-        // Connection manager — singleton, manages MCP client lifecycles
+        // Connection manager — singleton, manages MCP client lifecycles.
+        // Resolving AntiSsrfHandlerFactory makes the SSRF guard a mandatory dependency:
+        // if the egress layer (Infrastructure.AI RegisterEgressServices) was not wired,
+        // this throws at startup rather than silently producing an unguarded client.
         services.AddSingleton<McpConnectionManager>(sp =>
         {
             var aiConfig = sp.GetRequiredService<IOptionsMonitor<AIConfig>>();
             var logger = sp.GetRequiredService<Microsoft.Extensions.Logging.ILogger<McpConnectionManager>>();
             var loggerFactory = sp.GetRequiredService<Microsoft.Extensions.Logging.ILoggerFactory>();
-            return new McpConnectionManager(logger, loggerFactory, aiConfig.CurrentValue.McpServers);
+            var antiSsrfHandlerFactory = sp.GetRequiredService<AntiSsrfHandlerFactory>();
+            return new McpConnectionManager(logger, loggerFactory, antiSsrfHandlerFactory, aiConfig.CurrentValue.McpServers);
         });
 
         // Tool provider — singleton wrapping connection manager

--- a/src/Content/Infrastructure/Infrastructure.AI.MCP/Infrastructure.AI.MCP.csproj
+++ b/src/Content/Infrastructure/Infrastructure.AI.MCP/Infrastructure.AI.MCP.csproj
@@ -16,6 +16,9 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\Application\Application.AI.Common\Application.AI.Common.csproj" />
+    <!-- Infrastructure.AI supplies AntiSsrfHandlerFactory — the SSRF guard the MCP
+         client is built on. Hard dependency so SSRF protection cannot be omitted. -->
+    <ProjectReference Include="..\Infrastructure.AI\Infrastructure.AI.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/McpConnectionManager.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/McpConnectionManager.cs
@@ -1,6 +1,7 @@
 using System.Collections.Concurrent;
 using Application.AI.Common.Exceptions;
 using Domain.Common.Config.AI.MCP;
+using Infrastructure.AI.Egress;
 using Microsoft.Extensions.Logging;
 using ModelContextProtocol.Client;
 
@@ -21,6 +22,7 @@ public sealed class McpConnectionManager : IAsyncDisposable
 {
     private readonly ILogger<McpConnectionManager> _logger;
     private readonly ILoggerFactory _loggerFactory;
+    private readonly HttpClient _httpClient;
     private readonly McpServersConfig _config;
     private readonly ConcurrentDictionary<string, McpClient> _clients = new();
     private readonly ConcurrentDictionary<string, SemaphoreSlim> _connectionLocks = new();
@@ -29,13 +31,34 @@ public sealed class McpConnectionManager : IAsyncDisposable
     /// <summary>
     /// Initializes a new instance of the <see cref="McpConnectionManager"/> class.
     /// </summary>
+    /// <remarks>
+    /// The SSRF defense is a hard dependency, not a configuration option: the single
+    /// shared <see cref="HttpClient"/> used for every HTTP/SSE transport is built on the
+    /// <c>AntiSSRFHandler</c> produced by <paramref name="antiSsrfHandlerFactory"/>, which
+    /// performs connect-time IP filtering (RFC 1918, loopback, link-local, IMDS, IPv6 ULA)
+    /// and redirect re-validation. There is no code path that constructs an unguarded
+    /// client, so SSRF protection cannot be silently omitted by misconfiguration.
+    /// <para>
+    /// This deliberately applies only the AntiSSRF ring, NOT the outer
+    /// <c>EgressPolicyDelegatingHandler</c> (per-skill hostname allowlist + JSONL audit)
+    /// that the general egress <see cref="HttpClient"/> composes. MCP servers are
+    /// explicitly admin-configured, and connections are established outside an agent turn
+    /// (e.g. startup tool discovery) where that handler's required agent identity is
+    /// absent — it would deny every connection. SSRF filtering, the security-critical
+    /// ring, applies unconditionally.
+    /// </para>
+    /// </remarks>
     public McpConnectionManager(
         ILogger<McpConnectionManager> logger,
         ILoggerFactory loggerFactory,
+        AntiSsrfHandlerFactory antiSsrfHandlerFactory,
         McpServersConfig config)
     {
         _logger = logger;
         _loggerFactory = loggerFactory;
+        // disposeHandler: false — the AntiSSRF handler is a shared singleton owned by
+        // the factory; this client must not dispose it.
+        _httpClient = new HttpClient(antiSsrfHandlerFactory.GetOrCreate(), disposeHandler: false);
         _config = config;
     }
 
@@ -136,7 +159,7 @@ public sealed class McpConnectionManager : IAsyncDisposable
         }
     }
 
-    private static IClientTransport CreateTransport(string serverName, McpServerDefinition definition)
+    private IClientTransport CreateTransport(string serverName, McpServerDefinition definition)
     {
         return definition.Type switch
         {
@@ -155,7 +178,7 @@ public sealed class McpConnectionManager : IAsyncDisposable
         };
     }
 
-    private static HttpClientTransport CreateHttpTransport(string serverName, McpServerDefinition definition)
+    private HttpClientTransport CreateHttpTransport(string serverName, McpServerDefinition definition)
     {
         var uri = new Uri(definition.Url ?? throw new McpConnectionException(
             $"MCP server '{serverName}' is configured as {definition.Type} but has no URL."));
@@ -185,7 +208,12 @@ public sealed class McpConnectionManager : IAsyncDisposable
             };
         }
 
-        return new HttpClientTransport(options);
+        // Route the transport through the SSRF-guarded client. Its handler performs
+        // connect-time IP filtering and redirect re-validation, so a server URL that
+        // resolves to an internal/metadata address is refused at the socket — including
+        // the DNS-rebinding case a pre-flight host check cannot catch. The transport
+        // does not own the shared client.
+        return new HttpClientTransport(options, _httpClient, _loggerFactory);
     }
 
     private static readonly HashSet<string> BlockedHosts = new(StringComparer.OrdinalIgnoreCase)
@@ -195,6 +223,10 @@ public sealed class McpConnectionManager : IAsyncDisposable
         "metadata.goog"
     };
 
+    // Cheap pre-flight check: reject non-http(s) schemes early and fail fast on
+    // well-known metadata hostnames. Comprehensive IP-range filtering (RFC 1918,
+    // loopback, link-local, IMDS, IPv6 ULA) and DNS-rebinding defense are handled
+    // at connect time by the AntiSSRF handler backing this manager's shared HTTP client.
     private static void ValidateMcpServerUrl(Uri uri, string serverName)
     {
         if (uri.Scheme is not ("http" or "https"))
@@ -225,5 +257,9 @@ public sealed class McpConnectionManager : IAsyncDisposable
         }
 
         _connectionLocks.Clear();
+
+        // disposeHandler:false at construction — disposes the client wrapper only,
+        // leaving the shared AntiSSRF handler intact for the factory to own.
+        _httpClient.Dispose();
     }
 }

--- a/src/Content/Infrastructure/Infrastructure.AI.MCPServer/Authorization/McpToolAuthorizationFilter.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.MCPServer/Authorization/McpToolAuthorizationFilter.cs
@@ -1,0 +1,54 @@
+using System.Security.Claims;
+using ModelContextProtocol.Protocol;
+
+namespace Infrastructure.AI.MCPServer.Authorization;
+
+/// <summary>
+/// Per-tool-call authorization gate for inbound MCP <c>tools/call</c> requests.
+/// Runs at the tool-dispatch layer as defense-in-depth behind the endpoint's
+/// <c>RequireAuthorization()</c> — so a misconfigured or bypassed transport
+/// guard does not leave tool execution unprotected.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is the baseline gate: when authentication is configured (all non-Development
+/// environments), every tool call must carry an authenticated principal. The logic is
+/// extracted from the server-builder wiring so it can be unit-tested in isolation.
+/// </para>
+/// <para>
+/// Finer-grained, per-tool restriction is layered on top via standard
+/// <see cref="Microsoft.AspNetCore.Authorization.AuthorizeAttribute"/> attributes on
+/// individual tool methods, enabled by <c>AddAuthorizationFilters()</c>. A high-risk
+/// tool is locked to a role with <c>[Authorize(Roles = "...")]</c> — no change to this
+/// gate required.
+/// </para>
+/// </remarks>
+internal static class McpToolAuthorizationFilter
+{
+    /// <summary>
+    /// Evaluates whether an inbound tool call is permitted to proceed.
+    /// </summary>
+    /// <param name="authenticationRequired">
+    /// True when the server has authentication configured (non-Development). When false
+    /// (Development with no configured auth) the gate is inert, matching the server's
+    /// existing unauthenticated-development posture.
+    /// </param>
+    /// <param name="user">The caller principal carried on the request, if any.</param>
+    /// <returns>
+    /// <c>null</c> when the call may proceed; otherwise an error <see cref="CallToolResult"/>
+    /// that short-circuits dispatch without invoking the tool.
+    /// </returns>
+    public static CallToolResult? Evaluate(bool authenticationRequired, ClaimsPrincipal? user)
+    {
+        if (authenticationRequired && user?.Identity?.IsAuthenticated != true)
+        {
+            return new CallToolResult
+            {
+                IsError = true,
+                Content = [new TextContentBlock { Text = "Authentication is required to invoke MCP tools." }]
+            };
+        }
+
+        return null;
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI.MCPServer/Extensions/McpServerExtensions.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.MCPServer/Extensions/McpServerExtensions.cs
@@ -1,9 +1,11 @@
 using System.Collections.Concurrent;
+using System.Diagnostics;
 using Domain.Common.Config;
 using Domain.Common.Config.AI.MCP;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.Extensions.Hosting;
+using Infrastructure.AI.MCPServer.Authorization;
 using ModelContextProtocol;
 using ModelContextProtocol.AspNetCore;
 using ModelContextProtocol.Protocol;
@@ -27,6 +29,12 @@ public static class McpServerExtensions
         var subscriptions = new ConcurrentDictionary<string, byte>();
         services.AddSingleton(subscriptions);
 
+        // Auth is configured in all non-Development environments (AddMcpAuthentication
+        // enforces this). When it is, every inbound tool call must carry an
+        // authenticated principal — re-checked at the tool-dispatch layer below as
+        // defense-in-depth behind the endpoint's RequireAuthorization().
+        var authenticationRequired = mcpConfig.Auth.IsConfigured;
+
         services
             .AddMcpServer(options =>
             {
@@ -39,6 +47,9 @@ public static class McpServerExtensions
                 options.InitializationTimeout = mcpConfig.InitializationTimeout;
             })
             .WithHttpTransport()
+            // Enable [Authorize]/[AllowAnonymous] attributes on individual tools so a
+            // high-risk tool can be locked to a role without touching the baseline gate.
+            .AddAuthorizationFilters()
             // Always load tools/prompts from this assembly (SkillTools, etc.)
             .WithToolsFromAssembly(typeof(McpServerExtensions).Assembly)
             // Load additional tools/prompts from externally configured assemblies
@@ -47,7 +58,35 @@ public static class McpServerExtensions
             .LoadResourcesFromAssemblies(mcpConfig)
             .WithSubscribeToResourcesHandler(CreateSubscribeHandler(subscriptions))
             .WithUnsubscribeFromResourcesHandler(CreateUnsubscribeHandler(subscriptions))
-            .WithSetLoggingLevelHandler(CreateSetLoggingLevelHandler());
+            .WithSetLoggingLevelHandler(CreateSetLoggingLevelHandler())
+            // Baseline per-tool-call authorization gate (defense-in-depth) + audit.
+            .WithRequestFilters(filters =>
+            {
+                filters.AddCallToolFilter(next => async (context, cancellationToken) =>
+                {
+                    var logger = context.Services?
+                        .GetService<ILoggerFactory>()?
+                        .CreateLogger("Mcp.ToolAudit");
+                    var toolName = context.Params?.Name ?? "(unknown)";
+                    var user = context.User?.Identity?.Name ?? "anonymous";
+                    // W3C trace id correlates this audit line with the request's spans.
+                    var correlationId = Activity.Current?.TraceId.ToString() ?? "none";
+
+                    var denied = McpToolAuthorizationFilter.Evaluate(authenticationRequired, context.User);
+                    if (denied is not null)
+                    {
+                        logger?.LogWarning(
+                            "MCP tool call denied. User={User} ToolName={ToolName} Reason=unauthenticated CorrelationId={CorrelationId}",
+                            user, toolName, correlationId);
+                        return denied;
+                    }
+
+                    logger?.LogInformation(
+                        "MCP tool call authorized. User={User} ToolName={ToolName} CorrelationId={CorrelationId}",
+                        user, toolName, correlationId);
+                    return await next(context, cancellationToken);
+                });
+            });
 
         return services;
     }

--- a/src/Content/Infrastructure/Infrastructure.AI.MCPServer/Extensions/McpServerExtensions.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.MCPServer/Extensions/McpServerExtensions.cs
@@ -84,7 +84,25 @@ public static class McpServerExtensions
                     logger?.LogInformation(
                         "MCP tool call authorized. User={User} ToolName={ToolName} CorrelationId={CorrelationId}",
                         user, toolName, correlationId);
-                    return await next(context, cancellationToken);
+
+                    // Guaranteed outcome line (mirrors the WebUI controller path): every
+                    // authorized call logs a terminal success/error/faulted record so the
+                    // audit trail is never left at "authorized" with no resolution.
+                    try
+                    {
+                        var result = await next(context, cancellationToken);
+                        logger?.LogInformation(
+                            "MCP tool call completed. User={User} ToolName={ToolName} Status={Status} CorrelationId={CorrelationId}",
+                            user, toolName, result?.IsError == true ? "error" : "success", correlationId);
+                        return result;
+                    }
+                    catch (Exception ex)
+                    {
+                        logger?.LogWarning(ex,
+                            "MCP tool call faulted. User={User} ToolName={ToolName} Status=faulted CorrelationId={CorrelationId}",
+                            user, toolName, correlationId);
+                        throw;
+                    }
                 });
             });
 

--- a/src/Content/Infrastructure/Infrastructure.AI.MCPServer/Infrastructure.AI.MCPServer.csproj
+++ b/src/Content/Infrastructure/Infrastructure.AI.MCPServer/Infrastructure.AI.MCPServer.csproj
@@ -13,6 +13,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Infrastructure.AI.MCPServer.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\Application\Application.AI.Common\Application.AI.Common.csproj" />
     <ProjectReference Include="..\..\Application\Application.Common\Application.Common.csproj" />
     <ProjectReference Include="..\..\Domain\Domain.Common\Domain.Common.csproj" />

--- a/src/Content/Presentation/Presentation.AgentHub/Controllers/McpController.cs
+++ b/src/Content/Presentation/Presentation.AgentHub/Controllers/McpController.cs
@@ -140,9 +140,13 @@ public sealed class McpController : ControllerBase
         var rawArgs = request.Arguments.GetRawText();
         var inputHash = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(rawArgs))).ToLowerInvariant();
 
+        // W3C trace id ties this audit entry to the rest of the request's spans across
+        // systems — the "who authorized that call?" thread an auditor follows.
+        var correlationId = Activity.Current?.TraceId.ToString() ?? "none";
+
         _logger.LogInformation(
-            "MCP tool invoked. UserId={UserId} ToolName={ToolName} InputHash={InputHash}",
-            userId, name, inputHash);
+            "MCP tool invoked. UserId={UserId} ToolName={ToolName} InputHash={InputHash} CorrelationId={CorrelationId}",
+            userId, name, inputHash, correlationId);
 
         _logger.LogDebug(
             "MCP tool raw arguments. ToolName={ToolName} Arguments={Arguments}",
@@ -165,6 +169,10 @@ public sealed class McpController : ControllerBase
                 ? je
                 : JsonSerializer.SerializeToElement(result);
 
+            _logger.LogInformation(
+                "MCP tool completed. UserId={UserId} ToolName={ToolName} Status=success DurationMs={DurationMs} CorrelationId={CorrelationId}",
+                userId, name, sw.ElapsedMilliseconds, correlationId);
+
             return Ok(new McpToolInvokeResponse
             {
                 Output = output,
@@ -175,7 +183,9 @@ public sealed class McpController : ControllerBase
         catch (Exception ex)
         {
             sw.Stop();
-            _logger.LogError(ex, "MCP tool {ToolName} threw during invocation.", name);
+            _logger.LogError(ex,
+                "MCP tool completed. UserId={UserId} ToolName={ToolName} Status=error DurationMs={DurationMs} CorrelationId={CorrelationId}",
+                userId, name, sw.ElapsedMilliseconds, correlationId);
             return Ok(new McpToolInvokeResponse
             {
                 DurationMs = sw.ElapsedMilliseconds,

--- a/src/Content/Tests/Infrastructure.AI.MCP.Tests/DependencyInjectionTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.MCP.Tests/DependencyInjectionTests.cs
@@ -27,6 +27,9 @@ public sealed class DependencyInjectionTests : IAsyncLifetime
         services.AddSingleton(typeof(ILogger<>), typeof(NullLogger<>));
         services.Configure<AIConfig>(_ => { });
         services.Configure<Domain.Common.Config.MetaHarness.MetaHarnessConfig>(_ => { });
+        // McpConnectionManager now has a hard dependency on the SSRF guard; the egress
+        // layer normally registers it. Provide it here so resolution succeeds.
+        services.AddSingleton(TestSsrf.HandlerFactory());
 
         services.AddMcpClientDependencies();
 

--- a/src/Content/Tests/Infrastructure.AI.MCP.Tests/Infrastructure.AI.MCP.Tests.csproj
+++ b/src/Content/Tests/Infrastructure.AI.MCP.Tests/Infrastructure.AI.MCP.Tests.csproj
@@ -20,6 +20,7 @@
 
   <ItemGroup>
     <ProjectReference Include="../../Infrastructure/Infrastructure.AI.MCP/Infrastructure.AI.MCP.csproj" />
+    <ProjectReference Include="../../Infrastructure/Infrastructure.AI/Infrastructure.AI.csproj" />
     <ProjectReference Include="../../Application/Application.AI.Common/Application.AI.Common.csproj" />
   </ItemGroup>
 

--- a/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/McpConnectionManagerExtendedTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/McpConnectionManagerExtendedTests.cs
@@ -18,6 +18,7 @@ public sealed class McpConnectionManagerExtendedTests
         return new McpConnectionManager(
             Mock.Of<ILogger<McpConnectionManager>>(),
             new Mock<ILoggerFactory>().Object,
+            TestSsrf.HandlerFactory(),
             config ?? new McpServersConfig());
     }
 

--- a/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/McpConnectionManagerTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/McpConnectionManagerTests.cs
@@ -14,6 +14,7 @@ public sealed class McpConnectionManagerTests
         return new McpConnectionManager(
             Mock.Of<ILogger<McpConnectionManager>>(),
             new Mock<ILoggerFactory>().Object,
+            TestSsrf.HandlerFactory(),
             config ?? new McpServersConfig());
     }
 

--- a/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/McpConnectionManagerTransportTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/McpConnectionManagerTransportTests.cs
@@ -19,6 +19,7 @@ public sealed class McpConnectionManagerTransportTests
         return new McpConnectionManager(
             Mock.Of<ILogger<McpConnectionManager>>(),
             new Mock<ILoggerFactory>().Object,
+            TestSsrf.HandlerFactory(),
             config ?? new McpServersConfig());
     }
 

--- a/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/McpToolProviderExtendedTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/McpToolProviderExtendedTests.cs
@@ -19,6 +19,7 @@ public sealed class McpToolProviderExtendedTests
         var manager = new McpConnectionManager(
             Mock.Of<ILogger<McpConnectionManager>>(),
             new Mock<ILoggerFactory>().Object,
+            TestSsrf.HandlerFactory(),
             config ?? new McpServersConfig());
 
         var provider = new McpToolProvider(

--- a/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/McpToolProviderIntegrationTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/McpToolProviderIntegrationTests.cs
@@ -19,6 +19,7 @@ public sealed class McpToolProviderIntegrationTests
         var manager = new McpConnectionManager(
             Mock.Of<ILogger<McpConnectionManager>>(),
             new Mock<ILoggerFactory>().Object,
+            TestSsrf.HandlerFactory(),
             config ?? new McpServersConfig());
 
         var provider = new McpToolProvider(

--- a/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/McpToolProviderTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/McpToolProviderTests.cs
@@ -86,6 +86,7 @@ public sealed class McpToolProviderTests
         return new McpConnectionManager(
             Mock.Of<ILogger<McpConnectionManager>>(),
             new Mock<ILoggerFactory>().Object,
+            TestSsrf.HandlerFactory(),
             new Domain.Common.Config.AI.MCP.McpServersConfig());
     }
 }

--- a/src/Content/Tests/Infrastructure.AI.MCP.Tests/TestSsrf.cs
+++ b/src/Content/Tests/Infrastructure.AI.MCP.Tests/TestSsrf.cs
@@ -1,0 +1,26 @@
+using Domain.Common.Config;
+using Infrastructure.AI.Egress;
+using Microsoft.Extensions.Options;
+
+namespace Infrastructure.AI.MCP.Tests;
+
+/// <summary>
+/// Builds a real <see cref="AntiSsrfHandlerFactory"/> for tests that construct an
+/// <see cref="Infrastructure.AI.MCP.Services.McpConnectionManager"/>. Non-HTTP transport
+/// tests (stdio, dispose, error paths) never invoke the handler; the SSRF-blocking
+/// behavior itself is proven end-to-end in <c>Infrastructure.AI.Tests</c>'
+/// <c>McpSsrfProtectionTests</c>.
+/// </summary>
+internal static class TestSsrf
+{
+    /// <summary>Creates an <see cref="AntiSsrfHandlerFactory"/> bound to a default config.</summary>
+    public static AntiSsrfHandlerFactory HandlerFactory()
+        => new(new StaticOptionsMonitor(new AppConfig()));
+
+    private sealed class StaticOptionsMonitor(AppConfig value) : IOptionsMonitor<AppConfig>
+    {
+        public AppConfig CurrentValue { get; } = value;
+        public AppConfig Get(string? name) => CurrentValue;
+        public IDisposable? OnChange(Action<AppConfig, string?> listener) => null;
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.MCPServer.Tests/Authorization/McpToolAuthorizationFilterTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.MCPServer.Tests/Authorization/McpToolAuthorizationFilterTests.cs
@@ -1,0 +1,56 @@
+using System.Security.Claims;
+using FluentAssertions;
+using Infrastructure.AI.MCPServer.Authorization;
+using Xunit;
+
+namespace Infrastructure.AI.MCPServer.Tests.Authorization;
+
+/// <summary>
+/// Tests the baseline per-tool-call authorization gate. Encodes the rule that
+/// matters: when authentication is configured, an inbound tool call without an
+/// authenticated principal must be refused at the dispatch layer — independent of
+/// the endpoint's transport-level guard.
+/// </summary>
+public sealed class McpToolAuthorizationFilterTests
+{
+    [Fact]
+    public void Evaluate_AuthRequired_NoPrincipal_Denies()
+    {
+        var result = McpToolAuthorizationFilter.Evaluate(authenticationRequired: true, user: null);
+
+        result.Should().NotBeNull();
+        result!.IsError.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Evaluate_AuthRequired_UnauthenticatedPrincipal_Denies()
+    {
+        // A ClaimsIdentity with no authentication type reports IsAuthenticated == false.
+        var anonymous = new ClaimsPrincipal(new ClaimsIdentity());
+
+        var result = McpToolAuthorizationFilter.Evaluate(authenticationRequired: true, user: anonymous);
+
+        result.Should().NotBeNull();
+        result!.IsError.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Evaluate_AuthRequired_AuthenticatedPrincipal_Allows()
+    {
+        var authenticated = new ClaimsPrincipal(new ClaimsIdentity(authenticationType: "Bearer"));
+
+        var result = McpToolAuthorizationFilter.Evaluate(authenticationRequired: true, user: authenticated);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void Evaluate_AuthNotConfigured_NoPrincipal_Allows()
+    {
+        // Development posture: no auth configured, so the gate is inert and matches
+        // the server's existing unauthenticated-development behavior.
+        var result = McpToolAuthorizationFilter.Evaluate(authenticationRequired: false, user: null);
+
+        result.Should().BeNull();
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Egress/McpSsrfProtectionTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Egress/McpSsrfProtectionTests.cs
@@ -1,0 +1,63 @@
+using Application.AI.Common.Exceptions;
+using Domain.Common.Config;
+using Domain.Common.Config.AI.MCP;
+using Infrastructure.AI.Egress;
+using Infrastructure.AI.MCP.Services;
+using Infrastructure.AI.Tests.Egress.Support;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Egress;
+
+/// <summary>
+/// End-to-end proof that outbound MCP server connections are SSRF-guarded by
+/// construction. <see cref="McpConnectionManager"/> builds its HTTP client on the
+/// <see cref="AntiSsrfHandlerFactory"/> handler, so a server URL that resolves to an
+/// internal, loopback, or cloud-metadata address is refused at connect time and
+/// surfaced as <see cref="McpConnectionException"/> — closing the gap where MCP
+/// connections previously bypassed SSRF defenses entirely.
+/// </summary>
+public sealed class McpSsrfProtectionTests
+{
+    [Theory]
+    [InlineData("http://169.254.169.254/mcp")]   // cloud metadata (IMDS)
+    [InlineData("http://10.0.0.1/mcp")]           // RFC 1918 private
+    [InlineData("http://127.0.0.1:9/mcp")]        // loopback
+    public async Task GetClientAsync_HttpServerTargetingInternalAddress_IsBlocked(string url)
+    {
+        var sut = BuildManager(url);
+
+        await Assert.ThrowsAsync<McpConnectionException>(
+            () => sut.GetClientAsync("internal"));
+    }
+
+    private static McpConnectionManager BuildManager(string url)
+    {
+        // AllowPlainTextHttp = true so the deny verdict provably comes from the
+        // IP-range filter, not the plain-text-HTTP rule.
+        var cfg = new AppConfig();
+        cfg.AI.Egress.AllowPlainTextHttp = true;
+
+        var antiSsrf = new AntiSsrfHandlerFactory(new TestConfig.StaticOptionsMonitor<AppConfig>(cfg));
+
+        var config = new McpServersConfig
+        {
+            Servers = new Dictionary<string, McpServerDefinition>
+            {
+                ["internal"] = new()
+                {
+                    Enabled = true,
+                    Type = McpServerType.Http,
+                    Url = url,
+                    StartupTimeoutSeconds = 3
+                }
+            }
+        };
+
+        return new McpConnectionManager(
+            NullLogger<McpConnectionManager>.Instance,
+            NullLoggerFactory.Instance,
+            antiSsrf,
+            config);
+    }
+}


### PR DESCRIPTION
## Summary

Phase 1 of three, aligning the harness's MCP server/client with the **MCP 2025-11-25 security best practices** and OWASP MCP guidance. Each fix reuses existing infrastructure rather than inventing new mechanisms.

The harness is itself both an MCP **server** (exposes tools) and an MCP **client** (consumes external servers), so the spec's per-server hardening applies directly to our code. This PR closes three verified gaps.

### 1. SSRF defense on outbound MCP connections (spec **MUST**)
Previously, outbound MCP client connections bypassed SSRF protection entirely. They now route through an SSRF-guarded `HttpClient` built on the existing `AntiSsrfHandlerFactory`: connect-time IP filtering (RFC 1918 / loopback / link-local / cloud-metadata / IPv6 ULA) and redirect re-validation — which defeats the DNS-rebinding case a pre-flight host check cannot catch.

**Fail-closed by construction:** `McpConnectionManager` takes the SSRF factory as a hard dependency and DI resolution throws loudly at startup if the security (egress) layer isn't wired — there is no code path that produces an unguarded client.

**Deliberate scoping** (documented in code): applies the AntiSSRF ring only, *not* the per-skill hostname-allowlist ring. MCP servers are explicitly admin-configured and connections happen outside an agent turn (e.g. startup tool discovery), where the allowlist's required agent identity is absent and would deny every connection. SSRF — the security-critical ring — applies unconditionally.

### 2. Tool-level authorization at the MCP server
Inbound `tools/call` requests are re-checked at the SDK dispatch layer (`WithRequestFilters`) as defense-in-depth behind the endpoint's `RequireAuthorization()`, and `AddAuthorizationFilters()` enables per-tool `[Authorize]` role-locking for high-risk tools. The gate is inert in Development (matches the existing unauthenticated-dev posture). Decision logic is a pure, unit-tested helper.

### 3. Audit trail with correlation IDs
Every inbound tool call — both the standalone MCP server and the WebUI controller — logs user, tool, decision, and the W3C trace id, with a guaranteed outcome line. This is the spec's "deep logging with correlation IDs," flowing to the existing OpenTelemetry sinks.

## Tests
- 3 end-to-end SSRF-block tests proving internal/private/loopback/metadata addresses are refused at connect time
- 4 authorization-gate tests (authenticated/unauthenticated/dev-inert)
- Updated DI + transport wiring tests
- Full solution builds clean; affected suites green (MCP 73, MCP-server 34, Infrastructure.AI 1875, WebUI MCP 10)

## Review
`/code-review` (high effort, two passes) + `/simplify` run; the one substantive finding (a fail-open if the security layer were unwired) drove the fail-closed rework. Verified against the MCP SDK source that per-server auth headers are applied per-request, so the shared client cannot leak credentials across servers.

## Follow-ups (not in scope)
- **Phase 2:** stop client-side token passthrough (mint scoped credentials); optional risk-tier/data-classification tool metadata
- **Phase 3:** full OAuth 2.1 + RFC 9728 discovery (posture decision)
- Minor: unify audit field names across the two inbound paths (`User` vs `UserId`); optional per-call DB persistence

🤖 Generated with [Claude Code](https://claude.com/claude-code)