### PR TITLE
feat: harden MCP outbound auth with managed identity + fail-loud (Phase 2)

### DIFF
--- a/documentation/security/mcp-outbound-authentication.md
+++ b/documentation/security/mcp-outbound-authentication.md
@@ -1,0 +1,92 @@
+# MCP Outbound Authentication
+
+> Date: 2026-06-18. Target: .NET 10 (Microsoft Agentic Harness). Audience: harness engineers and template consumers configuring how the harness authenticates to **external** MCP servers it consumes as a client.
+
+## 1. Executive summary
+
+When the harness acts as an MCP **client** — connecting out to a third-party tool server — it authenticates with **its own workload identity**, never by forwarding a caller's token. The recommended, secure-by-default credential is **managed identity**: the harness mints a short-lived, auto-rotating access token per request, so there is no standing secret on the wire and nothing to rotate by hand. Static API keys and bearer tokens remain supported for servers that require them, and a client secret or certificate is available as an explicit Entra fallback. A server whose auth block is configured but incomplete now **fails the connection loudly** instead of silently connecting with no credential.
+
+This is the client-side counterpart to [`ssrf-defense.md`](./ssrf-defense.md): every outbound MCP request passes through both the SSRF guard (connect-time IP filtering) **and**, for Entra, the token injector.
+
+## 2. Why no token passthrough
+
+The MCP security guidance forbids a client from forwarding the end user's credential to a downstream server. The harness satisfies this **by construction**: outbound auth is built only from the server's own `McpServerAuthConfig` (admin-configured), never from the inbound caller's `ClaimsPrincipal`. There is no code path on the outbound transport that reads the user's token. The improvement in this phase is not closing a passthrough hole (there was none) — it is making the harness's *own* credential rotating and secret-free by default, and refusing to connect when auth is half-configured.
+
+## 3. The four auth types
+
+Configured per server under `AI:McpServers:Servers:<name>:Auth` (`McpServerAuthConfig`):
+
+| Type | What goes on the wire | When to use |
+| --- | --- | --- |
+| `None` | No auth header | Local stdio servers, trusted unauthenticated endpoints |
+| `ApiKey` | `<ApiKeyHeader>: <ApiKey>` (default header `X-API-Key`) | Servers that gate on a static API key |
+| `Bearer` | `Authorization: Bearer <BearerToken>` | Servers expecting a static, externally-issued token |
+| `Entra` | `Authorization: Bearer <minted-token>`, refreshed per request | **Preferred.** Microsoft Entra–protected servers |
+
+`ApiKey` and `Bearer` carry a **static** secret from configuration. They work, but the secret is long-lived and must be rotated manually; persist it via user-secrets (development) or Key Vault (production), never `appsettings.json`.
+
+## 4. Entra credential shapes
+
+For `Type = Entra`, the harness selects one of three shapes from the config fields (via `AzureCredentialFactory`). **`Scopes` is required in all three** — it names the resource the token is minted for (typically `api://<app-id>/.default`). Without a scope there is no resource to request a token for, so the config is treated as invalid.
+
+| Shape | Fields set | Notes |
+| --- | --- | --- |
+| **Managed identity** (preferred) | `Scopes` only — or `Scopes` + `ClientId` for a user-assigned identity | No stored secret. Azure rotates the credential; the harness never sees it. Best on App Service, Container Apps, AKS, or a VM. |
+| Client secret | `TenantId` + `ClientId` + `ClientSecret` + `Scopes` | Explicit fallback. Long-lived secret — rotate on a tight schedule, store in Key Vault. |
+| Certificate | `TenantId` + `ClientId` + `CertificatePath` + `Scopes` | Explicit fallback. Stronger than a secret, still operator-managed. |
+
+When neither `ClientSecret` nor `CertificatePath` is set, the harness falls back to `DefaultAzureCredential` (managed identity, then developer credentials such as Visual Studio / Azure CLI), so the same config works in production and on a developer machine.
+
+> **Dev-machine caveat.** `DefaultAzureCredential` walks the full credential chain. On a developer's machine that means a managed-identity-shape Entra server mints a token from **whatever identity the developer is signed into** (`az login` / Visual Studio account) and sends it to the configured server URL. The SSRF guard blocks internal addresses, but an admin-configured *external* URL is allowed — so a developer's personal Entra token can reach a third-party MCP server. For production, prefer a pinned `ManagedIdentityCredential` (set `ClientId` for a user-assigned identity) over the ambient chain, and only point Entra servers at endpoints you trust with the harness's identity. A lone `TenantId` with no secret or certificate is rejected as a half-configured fallback, so a forgotten credential fails loudly instead of silently using the ambient identity.
+
+### Example — managed identity (recommended)
+
+```json
+"Auth": {
+  "Type": "Entra",
+  "Scopes": [ "api://contoso-tools-server/.default" ]
+}
+```
+
+### Example — client-secret fallback
+
+```json
+"Auth": {
+  "Type": "Entra",
+  "TenantId": "<tenant-guid>",
+  "ClientId": "<app-guid>",
+  "ClientSecret": "<from Key Vault / user-secrets>",
+  "Scopes": [ "api://contoso-tools-server/.default" ]
+}
+```
+
+## 5. How rotation works
+
+For an Entra server, the connection uses a per-server `HttpClient` whose handler chain is:
+
+```
+EntraTokenAuthHandler  →  AntiSSRF handler (shared, connect-time IP filter)  →  socket
+```
+
+`EntraTokenAuthHandler.SendAsync` calls `TokenCredential.GetTokenAsync` on **every** request. Azure.Identity caches the token in-process and refreshes it shortly before expiry, so:
+
+- the per-request call is near-instant on the hot path (served from cache), and
+- a long-lived, cached MCP connection never sends an expired token — the next request after expiry transparently mints a fresh one.
+
+There is no static `Authorization` header captured once at connection time, which is what previously made a cached Entra connection impossible to keep authenticated.
+
+The token handler sits **in front of** the shared SSRF guard, so Entra traffic still receives the full connect-time IP filtering (RFC 1918 / loopback / link-local / IMDS / IPv6 ULA) and redirect re-validation described in `ssrf-defense.md`.
+
+## 6. Fail-loud on incomplete configuration
+
+Previously, an auth block that was selected but incomplete (e.g. `Type = Entra` with no scope, or `Type = Bearer` with an empty token) silently connected **with no credential**. That class of misconfiguration now throws `McpConnectionException` at connection time with a message naming the server and instructing the operator to complete the fields or set `Type = None`. Validity is defined by `McpServerAuthConfig.IsValid`; the connection manager rejects any server that is configured-but-invalid rather than degrading to anonymous access.
+
+## 7. Implementation map
+
+| Concern | Type | Project |
+| --- | --- | --- |
+| Auth config + validity rules | `McpServerAuthConfig`, `McpServerAuthType` | `Domain.Common` |
+| Credential shape selection | `AzureCredentialFactory` | `Application.Common` |
+| Per-request token injection (rotation) | `EntraTokenAuthHandler` | `Infrastructure.AI` |
+| Transport wiring, client selection, fail-loud | `McpConnectionManager` | `Infrastructure.AI.MCP` |
+| SSRF guard composed under every client | `AntiSsrfHandlerFactory` | `Infrastructure.AI` |

--- a/src/Content/Domain/Domain.Common/Config/AI/MCP/McpServerAuthConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/MCP/McpServerAuthConfig.cs
@@ -64,22 +64,68 @@ public class McpServerAuthConfig
     public string? CertificatePath { get; set; }
 
     /// <summary>
-    /// Gets or sets the OAuth 2.0 scopes to request.
+    /// Gets or sets the OAuth 2.0 scopes to request when minting a token for
+    /// <see cref="McpServerAuthType.Entra"/> authentication.
     /// </summary>
+    /// <remarks>
+    /// <strong>Required for Entra.</strong> Identifies the resource the harness mints a
+    /// token for — typically the target server's application ID URI plus <c>/.default</c>
+    /// (e.g. <c>api://&lt;app-id&gt;/.default</c>). At least one scope must be supplied;
+    /// without it the harness cannot request a token, so an Entra server configured with
+    /// no scope is treated as invalid rather than connecting with no credential.
+    /// </remarks>
     public List<string> Scopes { get; set; } = [];
 
     /// <summary>Gets whether authentication is configured.</summary>
     public bool IsConfigured => Type != McpServerAuthType.None;
 
     /// <summary>Gets whether the configuration is valid for the selected type.</summary>
+    /// <remarks>
+    /// For <see cref="McpServerAuthType.Entra"/> the harness mints its own short-lived,
+    /// auto-rotating token rather than forwarding a caller's credential. The preferred,
+    /// secure-by-default shape is <em>managed identity</em>: supply only <see cref="Scopes"/>
+    /// (and optionally <see cref="ClientId"/> for a user-assigned identity) and leave
+    /// <see cref="ClientSecret"/> / <see cref="CertificatePath"/> unset — no standing secret
+    /// is stored. A client secret or certificate is supported as an explicit fallback but
+    /// requires both <see cref="TenantId"/> and <see cref="ClientId"/>. Setting
+    /// <see cref="TenantId"/> with no secret or certificate is rejected as a half-configured
+    /// fallback, so a forgotten credential fails loudly rather than silently minting a token
+    /// from an ambient identity.
+    /// </remarks>
     public bool IsValid => Type switch
     {
         McpServerAuthType.None => true,
         McpServerAuthType.ApiKey => !string.IsNullOrWhiteSpace(ApiKey),
         McpServerAuthType.Bearer => !string.IsNullOrWhiteSpace(BearerToken),
-        McpServerAuthType.Entra => !string.IsNullOrWhiteSpace(TenantId)
-            && !string.IsNullOrWhiteSpace(ClientId)
-            && (!string.IsNullOrWhiteSpace(ClientSecret) || !string.IsNullOrWhiteSpace(CertificatePath)),
+        McpServerAuthType.Entra => Scopes.Count > 0 && IsEntraCredentialShapeValid,
         _ => false
     };
+
+    /// <summary>
+    /// Gets whether the Entra credential fields form one of the three supported shapes:
+    /// managed identity (no secret and no certificate), client secret
+    /// (<see cref="TenantId"/> + <see cref="ClientId"/> + <see cref="ClientSecret"/>),
+    /// or certificate (<see cref="TenantId"/> + <see cref="ClientId"/> + <see cref="CertificatePath"/>).
+    /// </summary>
+    private bool IsEntraCredentialShapeValid
+    {
+        get
+        {
+            var hasSecret = !string.IsNullOrWhiteSpace(ClientSecret);
+            var hasCertificate = !string.IsNullOrWhiteSpace(CertificatePath);
+
+            if (!hasSecret && !hasCertificate)
+            {
+                // Managed identity / default credential chain — no standing secret to leak.
+                // A ClientId is allowed (user-assigned managed identity), but a TenantId with
+                // no secret or certificate signals a half-configured client-secret/certificate
+                // shape — reject it so the misconfiguration fails loudly rather than silently
+                // minting a token from a different (ambient) credential.
+                return string.IsNullOrWhiteSpace(TenantId);
+            }
+
+            // Client secret or certificate fallback — both require tenant + client id.
+            return !string.IsNullOrWhiteSpace(TenantId) && !string.IsNullOrWhiteSpace(ClientId);
+        }
+    }
 }

--- a/src/Content/Domain/Domain.Common/Config/AI/MCP/McpServerAuthType.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/MCP/McpServerAuthType.cs
@@ -23,8 +23,10 @@ public enum McpServerAuthType
     Bearer,
 
     /// <summary>
-    /// Microsoft Entra ID (Azure AD) authentication.
-    /// Uses OAuth 2.0 client credentials flow to obtain access tokens.
+    /// Microsoft Entra ID (Azure AD) authentication. The harness mints its own
+    /// short-lived, auto-rotating access token per outbound request and never forwards
+    /// a caller's credential. Secure-by-default shape is managed identity (no stored
+    /// secret); client secret and certificate are supported as explicit fallbacks.
     /// </summary>
     Entra
 }

--- a/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/McpConnectionManager.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/McpConnectionManager.cs
@@ -2,6 +2,7 @@ using System.Collections.Concurrent;
 using Application.AI.Common.Exceptions;
 using Domain.Common.Config.AI.MCP;
 using Infrastructure.AI.Egress;
+using Infrastructure.AI.Identity;
 using Microsoft.Extensions.Logging;
 using ModelContextProtocol.Client;
 
@@ -22,9 +23,11 @@ public sealed class McpConnectionManager : IAsyncDisposable
 {
     private readonly ILogger<McpConnectionManager> _logger;
     private readonly ILoggerFactory _loggerFactory;
+    private readonly HttpMessageHandler _antiSsrfHandler;
     private readonly HttpClient _httpClient;
     private readonly McpServersConfig _config;
     private readonly ConcurrentDictionary<string, McpClient> _clients = new();
+    private readonly ConcurrentDictionary<string, HttpClient> _entraClients = new();
     private readonly ConcurrentDictionary<string, SemaphoreSlim> _connectionLocks = new();
     private bool _disposed;
 
@@ -56,9 +59,13 @@ public sealed class McpConnectionManager : IAsyncDisposable
     {
         _logger = logger;
         _loggerFactory = loggerFactory;
+        // The shared SSRF-guard terminal handler. Captured so Entra connections can wrap
+        // it with a per-server token-injecting handler while still routing through the
+        // same connect-time IP filter.
+        _antiSsrfHandler = antiSsrfHandlerFactory.GetOrCreate();
         // disposeHandler: false — the AntiSSRF handler is a shared singleton owned by
         // the factory; this client must not dispose it.
-        _httpClient = new HttpClient(antiSsrfHandlerFactory.GetOrCreate(), disposeHandler: false);
+        _httpClient = new HttpClient(_antiSsrfHandler, disposeHandler: false);
         _config = config;
     }
 
@@ -111,6 +118,15 @@ public sealed class McpConnectionManager : IAsyncDisposable
         {
             await client.DisposeAsync();
             _logger.LogInformation("Disconnected from MCP server '{ServerName}'", serverName);
+        }
+
+        // Release the per-server Entra client (and its pooled sockets) on explicit
+        // disconnect, mirroring the cleanup of _clients above. disposeHandler:false leaves
+        // the shared AntiSSRF handler intact; a later reconnect recreates a fresh
+        // token-injecting client.
+        if (_entraClients.TryRemove(serverName, out var entraClient))
+        {
+            entraClient.Dispose();
         }
     }
 
@@ -191,29 +207,61 @@ public sealed class McpConnectionManager : IAsyncDisposable
             Endpoint = uri
         };
 
-        // Apply auth headers from configuration
-        if (definition.Auth is { IsConfigured: true, IsValid: true } auth)
-        {
-            options.AdditionalHeaders = auth.Type switch
-            {
-                McpServerAuthType.ApiKey => new Dictionary<string, string>
-                {
-                    [auth.ApiKeyHeader] = auth.ApiKey!
-                },
-                McpServerAuthType.Bearer => new Dictionary<string, string>
-                {
-                    ["Authorization"] = $"Bearer {auth.BearerToken}"
-                },
-                _ => null
-            };
-        }
+        // Select the HTTP client carrying the right credential. Static schemes (ApiKey,
+        // Bearer) reuse the shared SSRF-guarded client with per-request headers; Entra
+        // gets a per-server client whose token-injecting handler mints a fresh, rotating
+        // token in front of the same SSRF guard. All paths still route through the
+        // connect-time IP filter, so a URL resolving to an internal/metadata address is
+        // refused at the socket. The transport does not own the supplied client.
+        var httpClient = ResolveTransportHttpClient(serverName, definition.Auth, options);
 
-        // Route the transport through the SSRF-guarded client. Its handler performs
-        // connect-time IP filtering and redirect re-validation, so a server URL that
-        // resolves to an internal/metadata address is refused at the socket — including
-        // the DNS-rebinding case a pre-flight host check cannot catch. The transport
-        // does not own the shared client.
-        return new HttpClientTransport(options, _httpClient, _loggerFactory);
+        return new HttpClientTransport(options, httpClient, _loggerFactory);
+    }
+
+    /// <summary>
+    /// Resolves the <see cref="HttpClient"/> for a server's transport and applies any
+    /// static auth headers to <paramref name="options"/>. Throws when auth is configured
+    /// but incomplete — a half-configured server must fail loudly rather than connect
+    /// with no credential.
+    /// </summary>
+    private HttpClient ResolveTransportHttpClient(
+        string serverName,
+        McpServerAuthConfig? auth,
+        HttpClientTransportOptions options)
+    {
+        if (auth is not { IsConfigured: true })
+            return _httpClient;
+
+        if (!auth.IsValid)
+            throw new McpConnectionException(
+                $"MCP server '{serverName}' has auth type {auth.Type} configured but its credential " +
+                "settings are incomplete. Provide the required fields for that auth type, or set the " +
+                "auth type to None.");
+
+        switch (auth.Type)
+        {
+            case McpServerAuthType.ApiKey:
+                options.AdditionalHeaders = new Dictionary<string, string> { [auth.ApiKeyHeader] = auth.ApiKey! };
+                return _httpClient;
+
+            case McpServerAuthType.Bearer:
+                options.AdditionalHeaders = new Dictionary<string, string> { ["Authorization"] = $"Bearer {auth.BearerToken}" };
+                return _httpClient;
+
+            case McpServerAuthType.Entra:
+                // Per-server client: EntraTokenAuthHandler mints a fresh, auto-rotating
+                // token per request and forwards to the shared SSRF-guard handler.
+                // disposeHandler:false (set in DisposeAsync's cleanup) keeps the shared
+                // terminal handler alive. Creation is serialized per server by the caller's
+                // connection lock, so GetOrAdd's factory runs at most once per server.
+                return _entraClients.GetOrAdd(
+                    serverName,
+                    _ => new HttpClient(EntraTokenAuthHandler.Create(auth, _antiSsrfHandler), disposeHandler: false));
+
+            default:
+                throw new McpConnectionException(
+                    $"MCP server '{serverName}' uses unsupported auth type '{auth.Type}'.");
+        }
     }
 
     private static readonly HashSet<string> BlockedHosts = new(StringComparer.OrdinalIgnoreCase)
@@ -250,6 +298,17 @@ public sealed class McpConnectionManager : IAsyncDisposable
         }
 
         _clients.Clear();
+
+        // Per-server Entra clients were built with disposeHandler:false, so disposing them
+        // releases the client wrapper without touching the shared AntiSSRF handler their
+        // token handlers wrap. The token handlers hold only a managed TokenCredential and
+        // are reclaimed by the GC.
+        foreach (var kvp in _entraClients)
+        {
+            kvp.Value.Dispose();
+        }
+
+        _entraClients.Clear();
 
         foreach (var kvp in _connectionLocks)
         {

--- a/src/Content/Infrastructure/Infrastructure.AI/Identity/EntraTokenAuthHandler.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Identity/EntraTokenAuthHandler.cs
@@ -1,0 +1,97 @@
+using System.Net.Http.Headers;
+using Application.Common.Factories;
+using Azure.Core;
+using Domain.Common.Config.AI.MCP;
+using Domain.Common.Config.Azure;
+
+namespace Infrastructure.AI.Identity;
+
+/// <summary>
+/// Delegating handler that attaches a freshly-minted Microsoft Entra access token to
+/// every outbound request as an <c>Authorization: Bearer</c> header. Used to authenticate
+/// the harness to an external MCP server with the harness's <em>own</em> workload identity
+/// rather than forwarding a caller's credential.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The token is acquired per request from the supplied <see cref="TokenCredential"/>.
+/// Azure.Identity credentials cache the token in-process and refresh it shortly before
+/// expiry, so the per-request <see cref="TokenCredential.GetTokenAsync(TokenRequestContext, CancellationToken)"/>
+/// call is near-instant on the hot path while guaranteeing a long-lived, cached MCP
+/// connection never sends an expired token. There is no standing secret on the wire and
+/// nothing to rotate manually.
+/// </para>
+/// <para>
+/// The handler is designed to sit in front of the shared SSRF-guard terminal handler:
+/// construct it via <see cref="Create"/> with the egress <see cref="HttpMessageHandler"/>
+/// as its inner handler so token injection composes with connect-time IP filtering.
+/// </para>
+/// </remarks>
+public sealed class EntraTokenAuthHandler : DelegatingHandler
+{
+    private readonly TokenCredential _credential;
+    private readonly string[] _scopes;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EntraTokenAuthHandler"/> class.
+    /// </summary>
+    /// <param name="credential">The token credential used to mint access tokens.</param>
+    /// <param name="scopes">The OAuth scopes to request. Must contain at least one entry.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="credential"/> or
+    /// <paramref name="scopes"/> is null.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="scopes"/> is empty —
+    /// without a scope there is no resource to mint a token for.</exception>
+    public EntraTokenAuthHandler(TokenCredential credential, IReadOnlyList<string> scopes)
+    {
+        ArgumentNullException.ThrowIfNull(credential);
+        ArgumentNullException.ThrowIfNull(scopes);
+
+        if (scopes.Count == 0)
+            throw new ArgumentException("At least one scope is required to mint an Entra token.", nameof(scopes));
+
+        _credential = credential;
+        _scopes = [.. scopes];
+    }
+
+    /// <summary>
+    /// Builds an <see cref="EntraTokenAuthHandler"/> for the given MCP server auth
+    /// configuration, selecting the credential shape (managed identity, client secret,
+    /// or certificate) via <see cref="AzureCredentialFactory"/>.
+    /// </summary>
+    /// <param name="auth">The validated Entra auth configuration. Callers must ensure
+    /// <see cref="McpServerAuthConfig.IsValid"/> before calling.</param>
+    /// <param name="innerHandler">The inner handler the token-bearing request is forwarded
+    /// to — typically the shared SSRF-guard handler.</param>
+    /// <returns>A configured handler wired to <paramref name="innerHandler"/>.</returns>
+    public static EntraTokenAuthHandler Create(McpServerAuthConfig auth, HttpMessageHandler innerHandler)
+    {
+        ArgumentNullException.ThrowIfNull(auth);
+        ArgumentNullException.ThrowIfNull(innerHandler);
+
+        var credential = AzureCredentialFactory.CreateTokenCredential(new EntraCredentialConfig
+        {
+            TenantId = auth.TenantId,
+            ClientId = auth.ClientId,
+            ClientSecret = auth.ClientSecret,
+            CertificatePath = auth.CertificatePath
+        });
+
+        return new EntraTokenAuthHandler(credential, auth.Scopes) { InnerHandler = innerHandler };
+    }
+
+    /// <inheritdoc />
+    protected override async Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var token = await _credential
+            .GetTokenAsync(new TokenRequestContext(_scopes), cancellationToken)
+            .ConfigureAwait(false);
+
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token.Token);
+
+        return await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/src/Content/Tests/Domain.Common.Tests/Config/McpConfigTests.cs
+++ b/src/Content/Tests/Domain.Common.Tests/Config/McpConfigTests.cs
@@ -160,6 +160,33 @@ public class McpServerAuthConfigTests
     }
 
     [Fact]
+    public void IsValid_Entra_ManagedIdentity_ScopeOnly_ReturnsTrue()
+    {
+        // Secure-by-default shape: no stored secret or certificate, just the resource
+        // scope the harness mints a token for.
+        var auth = new McpServerAuthConfig
+        {
+            Type = McpServerAuthType.Entra,
+            Scopes = ["api://resource/.default"]
+        };
+
+        auth.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsValid_Entra_UserAssignedManagedIdentity_ReturnsTrue()
+    {
+        var auth = new McpServerAuthConfig
+        {
+            Type = McpServerAuthType.Entra,
+            ClientId = "user-assigned-mi",
+            Scopes = ["api://resource/.default"]
+        };
+
+        auth.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
     public void IsValid_Entra_WithClientSecret_ReturnsTrue()
     {
         var auth = new McpServerAuthConfig
@@ -167,7 +194,8 @@ public class McpServerAuthConfigTests
             Type = McpServerAuthType.Entra,
             TenantId = "tenant-1",
             ClientId = "client-1",
-            ClientSecret = "secret-1"
+            ClientSecret = "secret-1",
+            Scopes = ["api://resource/.default"]
         };
 
         auth.IsValid.Should().BeTrue();
@@ -181,18 +209,22 @@ public class McpServerAuthConfigTests
             Type = McpServerAuthType.Entra,
             TenantId = "tenant-1",
             ClientId = "client-1",
-            CertificatePath = "/certs/client.pfx"
+            CertificatePath = "/certs/client.pfx",
+            Scopes = ["api://resource/.default"]
         };
 
         auth.IsValid.Should().BeTrue();
     }
 
     [Fact]
-    public void IsValid_Entra_MissingTenantId_ReturnsFalse()
+    public void IsValid_Entra_NoScope_ReturnsFalse()
     {
+        // Without a scope there is no resource to mint a token for — reject rather than
+        // connect with no credential.
         var auth = new McpServerAuthConfig
         {
             Type = McpServerAuthType.Entra,
+            TenantId = "tenant-1",
             ClientId = "client-1",
             ClientSecret = "secret-1"
         };
@@ -201,13 +233,43 @@ public class McpServerAuthConfigTests
     }
 
     [Fact]
-    public void IsValid_Entra_MissingBothSecretAndCert_ReturnsFalse()
+    public void IsValid_Entra_SecretMissingTenantId_ReturnsFalse()
+    {
+        var auth = new McpServerAuthConfig
+        {
+            Type = McpServerAuthType.Entra,
+            ClientId = "client-1",
+            ClientSecret = "secret-1",
+            Scopes = ["api://resource/.default"]
+        };
+
+        auth.IsValid.Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsValid_Entra_SecretMissingClientId_ReturnsFalse()
     {
         var auth = new McpServerAuthConfig
         {
             Type = McpServerAuthType.Entra,
             TenantId = "tenant-1",
-            ClientId = "client-1"
+            ClientSecret = "secret-1",
+            Scopes = ["api://resource/.default"]
+        };
+
+        auth.IsValid.Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsValid_Entra_TenantIdWithoutSecretOrCert_ReturnsFalse()
+    {
+        // A TenantId with no secret/cert is a half-configured fallback (forgotten
+        // credential) — reject rather than silently fall back to an ambient identity.
+        var auth = new McpServerAuthConfig
+        {
+            Type = McpServerAuthType.Entra,
+            TenantId = "tenant-1",
+            Scopes = ["api://resource/.default"]
         };
 
         auth.IsValid.Should().BeFalse();

--- a/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/McpConnectionManagerTransportTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/McpConnectionManagerTransportTests.cs
@@ -1,3 +1,5 @@
+using System.Collections.Concurrent;
+using System.Reflection;
 using Application.AI.Common.Exceptions;
 using Domain.Common.Config.AI.MCP;
 using FluentAssertions;
@@ -169,6 +171,57 @@ public sealed class McpConnectionManagerTransportTests
 
         await act.Should().ThrowAsync<McpConnectionException>()
             .WithMessage("*incomplete*");
+    }
+
+    [Fact]
+    public async Task GetClientAsync_EntraServer_CachesPerServerClient_DisconnectRemovesIt()
+    {
+        // Drives the Entra happy-path branch at the manager level: a valid managed-identity
+        // Entra config builds and caches a per-server token-injecting client (this happens
+        // during transport construction, before any token call), and DisconnectAsync must
+        // release it. The connection itself fails (unreachable URL / SSRF) — we assert the
+        // lifecycle of the cached client, not a successful connect.
+        var config = new McpServersConfig
+        {
+            Servers = new Dictionary<string, McpServerDefinition>
+            {
+                ["entra-server"] = new()
+                {
+                    Enabled = true,
+                    Type = McpServerType.Http,
+                    Url = "http://localhost:19999/mcp",
+                    StartupTimeoutSeconds = 1,
+                    Auth = new McpServerAuthConfig
+                    {
+                        Type = McpServerAuthType.Entra,
+                        Scopes = ["api://resource/.default"]
+                    }
+                }
+            }
+        };
+        var sut = CreateManager(config);
+        var entraClients = GetEntraClients(sut);
+
+        using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15)))
+        {
+            var act = () => sut.GetClientAsync("entra-server", cts.Token);
+            await act.Should().ThrowAsync<McpConnectionException>();
+        }
+
+        // The per-server Entra client was created and cached even though the connect failed.
+        entraClients.Should().ContainKey("entra-server");
+
+        await sut.DisconnectAsync("entra-server");
+
+        // DisconnectAsync released it — the defended cleanup behavior, now guarded.
+        entraClients.Should().NotContainKey("entra-server");
+    }
+
+    private static ConcurrentDictionary<string, HttpClient> GetEntraClients(McpConnectionManager manager)
+    {
+        var field = typeof(McpConnectionManager)
+            .GetField("_entraClients", BindingFlags.NonPublic | BindingFlags.Instance);
+        return (ConcurrentDictionary<string, HttpClient>)field!.GetValue(manager)!;
     }
 
     // -- Concurrent GetClientAsync --

--- a/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/McpConnectionManagerTransportTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/McpConnectionManagerTransportTests.cs
@@ -110,6 +110,67 @@ public sealed class McpConnectionManagerTransportTests
         await act.Should().ThrowAsync<McpConnectionException>();
     }
 
+    [Fact]
+    public async Task GetClientAsync_HttpWithIncompleteEntraAuth_ThrowsWithClearMessage()
+    {
+        // Entra type selected but no scope — previously this silently connected with no
+        // credential. It must now fail loudly at transport build before any send.
+        var config = new McpServersConfig
+        {
+            Servers = new Dictionary<string, McpServerDefinition>
+            {
+                ["entra-no-scope"] = new()
+                {
+                    Enabled = true,
+                    Type = McpServerType.Http,
+                    Url = "http://localhost:19999/mcp",
+                    StartupTimeoutSeconds = 1,
+                    Auth = new McpServerAuthConfig
+                    {
+                        Type = McpServerAuthType.Entra
+                    }
+                }
+            }
+        };
+        var sut = CreateManager(config);
+
+        var act = () => sut.GetClientAsync("entra-no-scope");
+
+        await act.Should().ThrowAsync<McpConnectionException>()
+            .WithMessage("*incomplete*");
+    }
+
+    [Fact]
+    public async Task GetClientAsync_HttpWithIncompleteBearerAuth_ThrowsWithClearMessage()
+    {
+        // A configured-but-empty static credential must also fail loudly rather than
+        // connecting with no Authorization header.
+        var config = new McpServersConfig
+        {
+            Servers = new Dictionary<string, McpServerDefinition>
+            {
+                ["bearer-empty"] = new()
+                {
+                    Enabled = true,
+                    Type = McpServerType.Http,
+                    Url = "http://localhost:19999/mcp",
+                    StartupTimeoutSeconds = 1,
+                    Auth = new McpServerAuthConfig
+                    {
+                        Type = McpServerAuthType.Bearer,
+                        BearerToken = ""
+                    }
+                }
+            }
+        };
+        var sut = CreateManager(config);
+
+        var act = () => sut.GetClientAsync("bearer-empty");
+
+        await act.Should().ThrowAsync<McpConnectionException>()
+            .WithMessage("*incomplete*");
+    }
+
     // -- Concurrent GetClientAsync --
 
     [Fact]

--- a/src/Content/Tests/Infrastructure.AI.Tests/Identity/EntraTokenAuthHandlerTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Identity/EntraTokenAuthHandlerTests.cs
@@ -1,0 +1,125 @@
+using System.Net;
+using Azure.Core;
+using Domain.Common.Config.AI.MCP;
+using FluentAssertions;
+using Infrastructure.AI.Identity;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Identity;
+
+/// <summary>
+/// Tests for <see cref="EntraTokenAuthHandler"/> covering per-request token injection,
+/// rotation (a fresh token acquired for every request), and construction guards.
+/// </summary>
+public sealed class EntraTokenAuthHandlerTests
+{
+    private static readonly string[] Scopes = ["api://test-resource/.default"];
+
+    [Fact]
+    public async Task SendAsync_AttachesBearerTokenFromCredential()
+    {
+        var credential = new CountingCredential();
+        using var capturing = new CapturingHandler();
+        using var sut = new EntraTokenAuthHandler(credential, Scopes) { InnerHandler = capturing };
+        using var invoker = new HttpMessageInvoker(sut);
+
+        await invoker.SendAsync(
+            new HttpRequestMessage(HttpMethod.Get, "https://server.test/mcp"),
+            CancellationToken.None);
+
+        capturing.SeenSchemes.Should().ContainSingle().Which.Should().Be("Bearer");
+        capturing.SeenTokens.Should().ContainSingle().Which.Should().Be("token-1");
+    }
+
+    [Fact]
+    public async Task SendAsync_AcquiresFreshTokenPerRequest()
+    {
+        // Proves the handler mints per request rather than capturing a token once at
+        // construction — the basis for auto-rotation, since the Azure credential refreshes
+        // the cached token near expiry on these same per-request calls.
+        var credential = new CountingCredential();
+        using var capturing = new CapturingHandler();
+        using var sut = new EntraTokenAuthHandler(credential, Scopes) { InnerHandler = capturing };
+        using var invoker = new HttpMessageInvoker(sut);
+
+        await invoker.SendAsync(new HttpRequestMessage(HttpMethod.Get, "https://server.test/a"), CancellationToken.None);
+        await invoker.SendAsync(new HttpRequestMessage(HttpMethod.Get, "https://server.test/b"), CancellationToken.None);
+
+        credential.CallCount.Should().Be(2);
+        capturing.SeenTokens.Should().Equal("token-1", "token-2");
+    }
+
+    [Fact]
+    public async Task SendAsync_PassesRequestedScopesToCredential()
+    {
+        var credential = new CountingCredential();
+        using var capturing = new CapturingHandler();
+        using var sut = new EntraTokenAuthHandler(credential, Scopes) { InnerHandler = capturing };
+        using var invoker = new HttpMessageInvoker(sut);
+
+        await invoker.SendAsync(new HttpRequestMessage(HttpMethod.Get, "https://server.test/mcp"), CancellationToken.None);
+
+        credential.LastScopes.Should().Equal("api://test-resource/.default");
+    }
+
+    [Fact]
+    public void Constructor_NullCredential_Throws()
+    {
+        var act = () => new EntraTokenAuthHandler(null!, Scopes);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void Constructor_EmptyScopes_Throws()
+    {
+        var act = () => new EntraTokenAuthHandler(new CountingCredential(), []);
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void Create_ManagedIdentityConfig_WiresInnerHandler()
+    {
+        var auth = new McpServerAuthConfig
+        {
+            Type = McpServerAuthType.Entra,
+            Scopes = ["api://test-resource/.default"]
+        };
+        using var inner = new CapturingHandler();
+
+        using var handler = EntraTokenAuthHandler.Create(auth, inner);
+
+        handler.InnerHandler.Should().BeSameAs(inner);
+    }
+
+    private sealed class CapturingHandler : HttpMessageHandler
+    {
+        public List<string?> SeenSchemes { get; } = [];
+        public List<string?> SeenTokens { get; } = [];
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            SeenSchemes.Add(request.Headers.Authorization?.Scheme);
+            SeenTokens.Add(request.Headers.Authorization?.Parameter);
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+        }
+    }
+
+    private sealed class CountingCredential : TokenCredential
+    {
+        public int CallCount { get; private set; }
+        public string[] LastScopes { get; private set; } = [];
+
+        public override AccessToken GetToken(TokenRequestContext requestContext, CancellationToken cancellationToken)
+        {
+            LastScopes = requestContext.Scopes;
+            return new AccessToken($"token-{++CallCount}", DateTimeOffset.MaxValue);
+        }
+
+        public override ValueTask<AccessToken> GetTokenAsync(TokenRequestContext requestContext, CancellationToken cancellationToken)
+            => new(GetToken(requestContext, cancellationToken));
+    }
+}


### PR DESCRIPTION
## What & why
Phase 2 of MCP hardening. The harness, acting as an MCP **client** to external tool servers, now authenticates with its **own short-lived, auto-rotating workload identity** and refuses to connect when an auth block is half-configured.

This is a **quality/completeness** pass, not an emergency: verified in code that the harness already never forwards the caller's token downstream (it builds outbound auth only from each server's admin config), so we already satisfy the MCP spec's no-passthrough MUST by construction. What this PR fixes is a latent bug and a posture gap:

1. **Latent bug — the Entra option was silently a no-op.** `McpServerAuthType.Entra` was declared but the outbound header switch only handled ApiKey/Bearer, so selecting Entra sent **no credential at all**. Now it mints a real token.
2. **Posture — managed identity is now the secure-by-default path.** Short-lived, auto-rotating token; no standing secret to leak or rotate by hand.
3. **Fail-loud.** A configured-but-incomplete auth block now throws a clear `McpConnectionException` instead of silently connecting unauthenticated.

## Changes
- **`McpServerAuthConfig.IsValid`** (Domain): Entra rule rewritten — requires a `Scope` and accepts three shapes: managed identity (no stored secret; preferred), client secret, or certificate. A `TenantId` with no secret/cert is rejected as a forgotten-credential misconfig.
- **`EntraTokenAuthHandler`** (new, Infrastructure.AI): `DelegatingHandler` that mints a fresh token per request via `TokenCredential.GetTokenAsync` (Azure.Identity caches + auto-rotates) and sets `Authorization: Bearer`. Built via the existing `AzureCredentialFactory`; sits **in front of** the shared SSRF guard so Entra traffic is still connect-time IP-filtered.
- **`McpConnectionManager`**: new `ResolveTransportHttpClient` — static schemes reuse the shared SSRF-guarded client with per-request headers; Entra gets a per-server token-injecting client; configured-but-invalid auth throws. Per-server clients are cleaned up on disconnect and dispose.
- **Docs**: `documentation/security/mcp-outbound-authentication.md` — credential model, no-passthrough-by-construction, rotation mechanics, dev-machine `DefaultAzureCredential` caveat.

## Behavior change (intentional)
An existing Entra server configured **without a scope** will now fail to connect. Those configs were previously connecting **unauthenticated** (no header sent), so this surfaces a latent misconfiguration rather than breaking working auth.

## Test plan
- New: Entra `IsValid` matrix (managed identity / user-assigned / secret / cert / no-scope / missing-tenant / missing-client / tenant-without-cred), `EntraTokenAuthHandler` (per-request header injection, rotation, scope passthrough, guards), and fail-loud transport cases (incomplete Entra, empty Bearer).
- Green: 18 IsValid + 6 handler + 75 full MCP project + 705 Domain.Common.
- **security-reviewer: APPROVE** (no CRITICAL/HIGH/MEDIUM; 2 LOW fixed).
- High-effort multi-agent /code-review: one real finding (DisconnectAsync cleanup) fixed; remainder refuted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)