### PR TITLE
feat: tool risk tiers drive autonomy gate + escalation severity

### DIFF
--- a/documentation/design/tool-risk-tiers.md
+++ b/documentation/design/tool-risk-tiers.md
@@ -1,0 +1,50 @@
+# Tool Risk Tiers & Graded Autonomy
+
+> Date: 2026-06-18. Audience: harness engineers and template consumers configuring how tool blast radius drives approval. Phase 3 of the MCP/governance hardening line.
+
+## 1. Why
+
+Before this change, the governance pipeline treated every tool the same when deciding approval severity: a tool that deletes files and one that reads a document both escalated at a fixed `RiskLevel.Medium`. There was no signal connecting a tool's actual impact to the autonomy/approval machinery, even though the harness already had a graded-autonomy engine (`IAutonomyDecisionEvaluator`) that maps a `BlastRadius` to an auto-approve / require-approval decision per tier — it was only wired to the change-proposal pipeline.
+
+This phase gives each tool a declared blast radius and feeds it into both the approval **decision** and the escalation **severity**.
+
+## 2. The model
+
+A tool declares its intrinsic worst-case impact via `ITool.RiskTier`, reusing the existing `BlastRadius` scale (no new enum, no mapping layer to the evaluator):
+
+| Band | Meaning for a tool | Example tools (defaults shipped) |
+| --- | --- | --- |
+| `Trivial` | No real-world effect | `echo_lookup`, `echo_calculate` |
+| `Low` | Read-only / preview | `read_file`, `list_files`, `document_search`, `iac_scan`, `iac_plan`, `iac_generate`, `k8sgpt_analyze`, `detect_drift`, `cluster_health`, `run_lint` |
+| `Medium` | Bounded writes / sandboxed execution | `restricted_search`, `run_tests`, `document_ingest`, **and the default for any tool that does not override `RiskTier`** |
+| `High` | File mutation, GitOps proposals, subagent delegation | `write_file`, `file_system`, `propose_remediation`, `delegate_task` |
+| `Critical` | Production availability / security boundaries | (none shipped by default) |
+
+`RiskTier` is a default-implemented interface member (`=> BlastRadius.Medium`), so every existing and future tool compiles unchanged and is treated as Medium until it classifies itself. The rating is tool-level (worst-case across operations); per-operation refinement is a separate future concern.
+
+## 3. Two consumption points
+
+**Escalation severity (always on).** When a tool call is routed to approval, `GovernancePolicyBehavior` derives the escalation `RiskLevel` from the tool's blast radius (`BlastRadiusRiskMapping.ToRiskLevel`) instead of a fixed `Medium`. A `High` tool now gets the stricter approval strategy, shorter timeout, and wider notification its severity warrants. This only changes the *severity label* of an escalation that was already happening, so it is safe to enable unconditionally.
+
+**Approval decision (opt-in).** `ToolPermissionBehavior` layers a risk gate on top of the rule-based permission decision: it resolves the tool's risk (`IToolRiskClassifier`) and asks the existing `IAutonomyDecisionEvaluator` whether that blast radius may auto-approve under the active tier. The gate can only **tighten** — `Allow → Ask` (RequiresApproval) or `Allow → Deny` (Forbidden) — never loosen. A `Deny`/`Ask` from the rules is left untouched.
+
+### Safety: off by default
+
+The approval gate is active only when graded autonomy is explicitly enabled (`AI:Permissions:GradedAutonomy:Enabled = true`). With it off — the default — the gate is a no-op and the evaluator is never consulted, so **shipping tool risk ratings alone changes no runtime behavior**. A consumer turns the gate on deliberately and configures the per-tier `PerBlastRadius` table that decides which bands auto-approve.
+
+The evaluator already enforces two load-bearing invariants that now apply to tool calls for free: **Critical always requires approval** regardless of tier, and **state-changing tools** (`!ITool.IsReadOnly`) default to requiring approval unless explicitly opted in.
+
+## 4. Unknown tools
+
+`IToolRiskClassifier` resolves the registered `ITool` for a name and reads its `RiskTier` / `IsReadOnly`. A name that does not resolve — an external MCP tool, a typo — returns `ToolRiskProfile.Default` (`Medium`, treated as a state change). The default never classifies a tool as *lower* risk than reality, so an unrecognized tool is never silently waved through at a looser bar.
+
+## 5. Implementation map
+
+| Concern | Type | Project |
+| --- | --- | --- |
+| Per-tool blast radius | `ITool.RiskTier` (default `Medium`) | `Application.AI.Common` |
+| Risk resolution by name | `IToolRiskClassifier` / `ToolRiskClassifier` | `Application.AI.Common` |
+| Blast radius → escalation severity | `BlastRadiusRiskMapping.ToRiskLevel` | `Domain.AI` |
+| Escalation severity wiring | `GovernancePolicyBehavior` | `Application.AI.Common` |
+| Approval gate (opt-in) | `ToolPermissionBehavior` → `IAutonomyDecisionEvaluator` | `Application.AI.Common` |
+| Graded-autonomy decision table | `AutonomyTierPolicy.PerBlastRadius` (config) | `Domain.AI` / config |

--- a/src/Content/Application/Application.AI.Common/DependencyInjection.cs
+++ b/src/Content/Application/Application.AI.Common/DependencyInjection.cs
@@ -126,6 +126,10 @@ public static class DependencyInjection
         // Tool conversion — ITool to AITool bridge for keyed DI tools
         services.AddSingleton<IToolConverter, AIToolConverter>();
 
+        // Tool risk classification — resolves a tool's declared blast radius for the
+        // graded-autonomy gate and escalation-severity derivation.
+        services.AddSingleton<Interfaces.Tools.IToolRiskClassifier, Services.Tools.ToolRiskClassifier>();
+
         // Context budget tracking
         services.AddSingleton<IContextBudgetTracker, ContextBudgetTracker>();
 

--- a/src/Content/Application/Application.AI.Common/Interfaces/Tools/ITool.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Tools/ITool.cs
@@ -1,3 +1,4 @@
+using Domain.AI.Changes;
 using Domain.AI.Models;
 
 namespace Application.AI.Common.Interfaces.Tools;
@@ -59,6 +60,30 @@ public interface ITool
     /// Default is false (fail-closed — assumes not safe).
     /// </summary>
     bool IsConcurrencySafe => false;
+
+    /// <summary>
+    /// The intrinsic blast radius (impact band) of invoking this tool — how much damage
+    /// a single call can do. Feeds the graded-autonomy engine: higher tiers may
+    /// auto-approve low-radius tools while still requiring human approval for high-radius
+    /// ones, and the escalation severity is derived from it.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Default is <see cref="BlastRadius.Medium"/> — a neutral middle that preserves the
+    /// harness's prior fixed risk treatment for tools that do not classify themselves.
+    /// Tools should override this to declare their true impact: read-only lookups as
+    /// <see cref="BlastRadius.Trivial"/>/<see cref="BlastRadius.Low"/>; operations that
+    /// touch production state, run commands, or apply infrastructure as
+    /// <see cref="BlastRadius.High"/>/<see cref="BlastRadius.Critical"/>.
+    /// </para>
+    /// <para>
+    /// This is the tool-level (worst-case) rating across all <see cref="SupportedOperations"/>;
+    /// per-operation risk refinement is a separate concern. The reused
+    /// <see cref="BlastRadius"/> scale lets a tool's rating flow directly into the same
+    /// graded-autonomy evaluator that governs change proposals, with no mapping layer.
+    /// </para>
+    /// </remarks>
+    BlastRadius RiskTier => BlastRadius.Medium;
 
     /// <summary>
     /// Declares the expected output content type for compression strategy selection.

--- a/src/Content/Application/Application.AI.Common/Interfaces/Tools/IToolRiskClassifier.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Tools/IToolRiskClassifier.cs
@@ -1,0 +1,43 @@
+using Domain.AI.Changes;
+
+namespace Application.AI.Common.Interfaces.Tools;
+
+/// <summary>
+/// The risk profile of a tool: its blast radius and whether it is read-only. Together these
+/// are the inputs the graded-autonomy evaluator needs to decide whether a tool call may
+/// auto-approve under the active tier.
+/// </summary>
+/// <param name="Radius">The tool's declared <see cref="ITool.RiskTier"/> blast radius.</param>
+/// <param name="IsReadOnly">The tool's <see cref="ITool.IsReadOnly"/> flag — the inverse of
+/// "is a state change" for the evaluator's state-changer safety rule.</param>
+public readonly record struct ToolRiskProfile(BlastRadius Radius, bool IsReadOnly)
+{
+    /// <summary>
+    /// The fail-safe profile for a tool that cannot be classified (e.g. an external MCP tool
+    /// with no local registration): <see cref="BlastRadius.Medium"/> and treated as a state
+    /// change (not read-only). Neither loosens governance.
+    /// </summary>
+    public static ToolRiskProfile Default => new(BlastRadius.Medium, IsReadOnly: false);
+}
+
+/// <summary>
+/// Resolves a tool's <see cref="ToolRiskProfile"/> from its name. Lets governance behaviors
+/// reason about a tool's blast radius without depending on how tools are registered or
+/// resolved.
+/// </summary>
+/// <remarks>
+/// Implementations resolve the registered <see cref="ITool"/> for the name and read its
+/// <see cref="ITool.RiskTier"/> / <see cref="ITool.IsReadOnly"/>. Unknown names (external
+/// MCP tools, typos) return <see cref="ToolRiskProfile.Default"/> — fail-safe, never
+/// fail-open.
+/// </remarks>
+public interface IToolRiskClassifier
+{
+    /// <summary>
+    /// Classifies the named tool. Returns <see cref="ToolRiskProfile.Default"/> when the
+    /// name does not resolve to a registered tool.
+    /// </summary>
+    /// <param name="toolName">The tool name / keyed-DI registration key.</param>
+    /// <returns>The tool's risk profile, or the fail-safe default.</returns>
+    ToolRiskProfile Classify(string toolName);
+}

--- a/src/Content/Application/Application.AI.Common/MediatRBehaviors/GovernancePolicyBehavior.cs
+++ b/src/Content/Application/Application.AI.Common/MediatRBehaviors/GovernancePolicyBehavior.cs
@@ -2,6 +2,7 @@ using Application.AI.Common.Interfaces.Agent;
 using Application.AI.Common.Interfaces.Escalation;
 using Application.AI.Common.Interfaces.Governance;
 using Application.AI.Common.Interfaces.MediatR;
+using Application.AI.Common.Interfaces.Tools;
 using Domain.AI.Escalation;
 using Domain.AI.Governance;
 using Domain.Common;
@@ -31,6 +32,7 @@ public sealed class GovernancePolicyBehavior<TRequest, TResponse>
     private readonly IAgentExecutionContext _executionContext;
     private readonly IOptionsMonitor<GovernanceConfig> _config;
     private readonly IOptionsMonitor<PermissionsConfig> _permissionsConfig;
+    private readonly IToolRiskClassifier _toolRiskClassifier;
     private readonly ILogger<GovernancePolicyBehavior<TRequest, TResponse>> _logger;
     private readonly IEscalationService? _escalationService;
 
@@ -40,6 +42,7 @@ public sealed class GovernancePolicyBehavior<TRequest, TResponse>
         IAgentExecutionContext executionContext,
         IOptionsMonitor<GovernanceConfig> config,
         IOptionsMonitor<PermissionsConfig> permissionsConfig,
+        IToolRiskClassifier toolRiskClassifier,
         ILogger<GovernancePolicyBehavior<TRequest, TResponse>> logger,
         IEscalationService? escalationService = null)
     {
@@ -48,6 +51,7 @@ public sealed class GovernancePolicyBehavior<TRequest, TResponse>
         _executionContext = executionContext;
         _config = config;
         _permissionsConfig = permissionsConfig;
+        _toolRiskClassifier = toolRiskClassifier;
         _logger = logger;
         _escalationService = escalationService;
     }
@@ -107,6 +111,12 @@ public sealed class GovernancePolicyBehavior<TRequest, TResponse>
             throw new InvalidOperationException($"Governance policy denied: {decision.Reason}");
         }
 
+        // Derive escalation severity from the tool's declared blast radius rather than a
+        // fixed default, so a high-impact tool escalates harder (stricter approval strategy,
+        // shorter timeout, wider notification) than a low-impact one. Unknown tools fall back
+        // to the Medium-equivalent default via the classifier.
+        var toolRiskLevel = _toolRiskClassifier.Classify(toolRequest.ToolName).Radius.ToRiskLevel();
+
         var escalationRequest = new EscalationRequest
         {
             EscalationId = Guid.NewGuid(),
@@ -114,7 +124,7 @@ public sealed class GovernancePolicyBehavior<TRequest, TResponse>
             ToolName = toolRequest.ToolName,
             Arguments = new Dictionary<string, string>(),
             Description = $"Agent '{agentId}' requires approval to invoke '{toolRequest.ToolName}': {decision.Reason}",
-            RiskLevel = RiskLevel.Medium,
+            RiskLevel = toolRiskLevel,
             Priority = EscalationPriority.Blocking,
             ApprovalStrategy = Enum.TryParse<ApprovalStrategyType>(escalationConfig.DefaultApprovalStrategy, true, out var strategy)
                 ? strategy

--- a/src/Content/Application/Application.AI.Common/MediatRBehaviors/ToolPermissionBehavior.cs
+++ b/src/Content/Application/Application.AI.Common/MediatRBehaviors/ToolPermissionBehavior.cs
@@ -203,8 +203,11 @@ public sealed class ToolPermissionBehavior<TRequest, TResponse>
         var profile = _toolRiskClassifier.Classify(toolName);
 
         // The evaluator ignores targetKind (reserved); tool calls pass Unspecified. isStateChange
-        // is the inverse of the tool's read-only flag. skillKey is null here — tool-call risk uses
-        // the baseline tier, which can only be stricter than a per-skill narrowing.
+        // is the inverse of the tool's read-only flag. skillKey is null because the executing skill
+        // is not exposed on the tool-permission context, so tool-call risk is evaluated at the
+        // BASELINE tier. A per-skill tier *narrowing* is therefore not applied here — that only
+        // forgoes extra tightening, it cannot loosen: the gate still never relaxes the rule-based
+        // Allow, and the rule layer (which does see plugin/skill rules) has already run.
         var result = _autonomyEvaluator.Evaluate(
             tier, profile.Radius, ChangeTargetKind.Unspecified, isStateChange: !profile.IsReadOnly, skillKey: null);
 

--- a/src/Content/Application/Application.AI.Common/MediatRBehaviors/ToolPermissionBehavior.cs
+++ b/src/Content/Application/Application.AI.Common/MediatRBehaviors/ToolPermissionBehavior.cs
@@ -1,11 +1,16 @@
 using Application.AI.Common.Interfaces.Agent;
+using Application.AI.Common.Interfaces.Governance;
 using Application.AI.Common.Interfaces.MediatR;
 using Application.AI.Common.Interfaces.Permissions;
 using Application.AI.Common.Interfaces.Sandbox;
+using Application.AI.Common.Interfaces.Tools;
 using Application.Common.Exceptions.ExceptionTypes;
+using Domain.AI.Changes;
+using Domain.AI.Governance;
 using Domain.AI.Permissions;
 using Domain.AI.Sandbox;
 using Domain.Common;
+using Domain.Common.Config.AI.Permissions;
 using Domain.Common.Config.AI.Sandbox;
 using Domain.Common.Helpers;
 using MediatR;
@@ -38,7 +43,10 @@ public sealed class ToolPermissionBehavior<TRequest, TResponse>
     private readonly IToolPermissionService _toolPermissionService;
     private readonly IDenialTracker _denialTracker;
     private readonly ICapabilityEnforcer _capabilityEnforcer;
+    private readonly IToolRiskClassifier _toolRiskClassifier;
+    private readonly IAutonomyDecisionEvaluator _autonomyEvaluator;
     private readonly IOptionsMonitor<SandboxConfig> _sandboxConfig;
+    private readonly IOptionsMonitor<PermissionsConfig> _permissionsConfig;
     private readonly ILogger<ToolPermissionBehavior<TRequest, TResponse>> _logger;
 
     /// <summary>
@@ -48,21 +56,30 @@ public sealed class ToolPermissionBehavior<TRequest, TResponse>
     /// <param name="toolPermissionService">The permission resolution service.</param>
     /// <param name="denialTracker">Tracks repeated denials for rate-limiting auto-deny.</param>
     /// <param name="capabilityEnforcer">Capability-based enforcement for tool resource access.</param>
+    /// <param name="toolRiskClassifier">Resolves a tool's declared blast radius for the graded-autonomy gate.</param>
+    /// <param name="autonomyEvaluator">Graded-autonomy evaluator that decides whether a tool's risk requires approval under the active tier.</param>
     /// <param name="sandboxConfig">Sandbox configuration providing granted capabilities.</param>
+    /// <param name="permissionsConfig">Permission configuration providing the autonomy tier and graded-autonomy toggle.</param>
     /// <param name="logger">Logger for permission decision auditing.</param>
     public ToolPermissionBehavior(
         IAgentExecutionContext executionContext,
         IToolPermissionService toolPermissionService,
         IDenialTracker denialTracker,
         ICapabilityEnforcer capabilityEnforcer,
+        IToolRiskClassifier toolRiskClassifier,
+        IAutonomyDecisionEvaluator autonomyEvaluator,
         IOptionsMonitor<SandboxConfig> sandboxConfig,
+        IOptionsMonitor<PermissionsConfig> permissionsConfig,
         ILogger<ToolPermissionBehavior<TRequest, TResponse>> logger)
     {
         _executionContext = executionContext;
         _toolPermissionService = toolPermissionService;
         _denialTracker = denialTracker;
         _capabilityEnforcer = capabilityEnforcer;
+        _toolRiskClassifier = toolRiskClassifier;
+        _autonomyEvaluator = autonomyEvaluator;
         _sandboxConfig = sandboxConfig;
+        _permissionsConfig = permissionsConfig;
         _logger = logger;
     }
 
@@ -86,6 +103,11 @@ public sealed class ToolPermissionBehavior<TRequest, TResponse>
 
         var decision = await _toolPermissionService.ResolvePermissionAsync(
             agentId, toolRequest.ToolName, cancellationToken: cancellationToken);
+
+        // Layer the graded-autonomy risk gate on top of the rule-based decision. It can only
+        // tighten (Allow → Ask/Deny), never loosen, so a high-blast-radius tool the rules
+        // would allow can still be routed to approval under the active tier.
+        decision = ApplyRiskGate(decision, toolRequest.ToolName);
 
         switch (decision.Behavior)
         {
@@ -147,5 +169,53 @@ public sealed class ToolPermissionBehavior<TRequest, TResponse>
             default:
                 throw new InvalidOperationException($"Unexpected permission behavior: {decision.Behavior}");
         }
+    }
+
+    /// <summary>
+    /// Applies the graded-autonomy risk gate to an otherwise-<see cref="PermissionBehaviorType.Allow"/>
+    /// decision. When graded autonomy is enabled, a tool whose blast radius the active tier will not
+    /// auto-approve is tightened to <see cref="PermissionBehaviorType.Ask"/> (RequiresApproval) or
+    /// <see cref="PermissionBehaviorType.Deny"/> (Forbidden). Non-Allow decisions and the
+    /// graded-autonomy-disabled case pass through unchanged — the gate never loosens a decision.
+    /// </summary>
+    private PermissionDecision ApplyRiskGate(PermissionDecision decision, string toolName)
+    {
+        // Only an Allow can be tightened; Deny/Ask are already at least as strict.
+        if (decision.Behavior != PermissionBehaviorType.Allow)
+            return decision;
+
+        var permissions = _permissionsConfig.CurrentValue;
+
+        // Off by default: when graded autonomy is disabled the gate is a no-op, so enabling
+        // tool risk classification alone changes no behavior.
+        if (!permissions.GradedAutonomy.Enabled)
+            return decision;
+
+        if (!Enum.TryParse<AutonomyLevel>(permissions.DefaultAutonomyLevel, ignoreCase: true, out var tier))
+        {
+            _logger.LogWarning(
+                "Graded autonomy is enabled but DefaultAutonomyLevel '{Tier}' is not a valid AutonomyLevel — " +
+                "skipping the risk gate for tool {ToolName}.",
+                permissions.DefaultAutonomyLevel, toolName);
+            return decision;
+        }
+
+        var profile = _toolRiskClassifier.Classify(toolName);
+
+        // The evaluator ignores targetKind (reserved); tool calls pass Unspecified. isStateChange
+        // is the inverse of the tool's read-only flag. skillKey is null here — tool-call risk uses
+        // the baseline tier, which can only be stricter than a per-skill narrowing.
+        var result = _autonomyEvaluator.Evaluate(
+            tier, profile.Radius, ChangeTargetKind.Unspecified, isStateChange: !profile.IsReadOnly, skillKey: null);
+
+        return result.Decision switch
+        {
+            AutonomyDecision.AutoApprove => decision,
+            AutonomyDecision.RequiresApproval => PermissionDecision.Ask(
+                $"Graded autonomy: tool '{toolName}' (blast radius {profile.Radius}) requires approval under tier {tier}. {result.Reason}"),
+            AutonomyDecision.Forbidden => PermissionDecision.Deny(
+                $"Graded autonomy: tool '{toolName}' (blast radius {profile.Radius}) is forbidden under tier {tier}. {result.Reason}"),
+            _ => decision
+        };
     }
 }

--- a/src/Content/Application/Application.AI.Common/Services/Tools/ToolRiskClassifier.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/ToolRiskClassifier.cs
@@ -1,0 +1,38 @@
+using Application.AI.Common.Interfaces.Tools;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Application.AI.Common.Services.Tools;
+
+/// <summary>
+/// Default <see cref="IToolRiskClassifier"/>: resolves the registered <see cref="ITool"/> for
+/// a name from keyed DI and reads its declared risk. Returns
+/// <see cref="ToolRiskProfile.Default"/> for names that do not resolve (external MCP tools,
+/// unregistered names) so an unknown tool is never treated as lower-risk than it is.
+/// </summary>
+public sealed class ToolRiskClassifier : IToolRiskClassifier
+{
+    private readonly IServiceProvider _serviceProvider;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ToolRiskClassifier"/> class.
+    /// </summary>
+    /// <param name="serviceProvider">Provider used to resolve keyed <see cref="ITool"/> registrations.</param>
+    public ToolRiskClassifier(IServiceProvider serviceProvider)
+    {
+        ArgumentNullException.ThrowIfNull(serviceProvider);
+        _serviceProvider = serviceProvider;
+    }
+
+    /// <inheritdoc />
+    public ToolRiskProfile Classify(string toolName)
+    {
+        if (string.IsNullOrWhiteSpace(toolName))
+            return ToolRiskProfile.Default;
+
+        var tool = _serviceProvider.GetKeyedService<ITool>(toolName);
+
+        return tool is null
+            ? ToolRiskProfile.Default
+            : new ToolRiskProfile(tool.RiskTier, tool.IsReadOnly);
+    }
+}

--- a/src/Content/Domain/Domain.AI/Governance/BlastRadiusRiskMapping.cs
+++ b/src/Content/Domain/Domain.AI/Governance/BlastRadiusRiskMapping.cs
@@ -1,0 +1,34 @@
+using Domain.AI.Changes;
+using Domain.AI.Escalation;
+
+namespace Domain.AI.Governance;
+
+/// <summary>
+/// Projects a <see cref="BlastRadius"/> impact band onto the <see cref="RiskLevel"/>
+/// scale used by the escalation subsystem. Lets a tool's declared blast radius drive the
+/// severity (and therefore the approval strategy, timeout, and notification fan-out) of an
+/// escalation it triggers, instead of a fixed default.
+/// </summary>
+/// <remarks>
+/// The two scales differ by one band: <see cref="BlastRadius"/> has a <see cref="BlastRadius.Trivial"/>
+/// floor below <see cref="BlastRadius.Low"/>, whereas <see cref="RiskLevel"/> bottoms out at
+/// <see cref="RiskLevel.Low"/>. Trivial therefore folds into <see cref="RiskLevel.Low"/>; the
+/// remaining bands map one-to-one.
+/// </remarks>
+public static class BlastRadiusRiskMapping
+{
+    /// <summary>
+    /// Maps a <see cref="BlastRadius"/> to the corresponding escalation <see cref="RiskLevel"/>.
+    /// </summary>
+    /// <param name="radius">The blast radius to project.</param>
+    /// <returns>The escalation risk level for the band.</returns>
+    public static RiskLevel ToRiskLevel(this BlastRadius radius) => radius switch
+    {
+        BlastRadius.Trivial => RiskLevel.Low,
+        BlastRadius.Low => RiskLevel.Low,
+        BlastRadius.Medium => RiskLevel.Medium,
+        BlastRadius.High => RiskLevel.High,
+        BlastRadius.Critical => RiskLevel.Critical,
+        _ => RiskLevel.Medium
+    };
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Governance/AutonomyConfigValidator.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Governance/AutonomyConfigValidator.cs
@@ -98,6 +98,7 @@ public sealed class AutonomyConfigValidator : IHostedService
 
         var errors = new List<string>();
 
+        ValidateDefaultAutonomyLevel(permissions, errors);
         ValidatePerEnvironment(graded, environmentName, errors);
         ValidatePerSkill(graded, permissions, errors);
         ValidateStateChangerOptIns(graded, errors);
@@ -120,6 +121,20 @@ public sealed class AutonomyConfigValidator : IHostedService
 
     /// <inheritdoc />
     public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    private static void ValidateDefaultAutonomyLevel(PermissionsConfig permissions, List<string> errors)
+    {
+        // The tool-risk gate (ToolPermissionBehavior) parses this value at runtime; an invalid
+        // tier would silently disable the gate. Fail fast at boot instead — but only when graded
+        // autonomy is enabled (this validator returns early otherwise), so a typo cannot quietly
+        // weaken governance.
+        if (!Enum.TryParse<AutonomyLevel>(permissions.DefaultAutonomyLevel, ignoreCase: true, out _))
+        {
+            errors.Add(
+                $"DefaultAutonomyLevel '{permissions.DefaultAutonomyLevel}' is not a valid AutonomyLevel. " +
+                "Valid values: Restricted, Supervised, Autonomous.");
+        }
+    }
 
     private static void ValidatePerEnvironment(
         GradedAutonomyConfig graded,

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/DelegateToSubagentTool.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/DelegateToSubagentTool.cs
@@ -1,5 +1,6 @@
 using Application.AI.Common.Interfaces.Agents;
 using Application.AI.Common.Interfaces.Tools;
+using Domain.AI.Changes;
 using Domain.AI.Governance;
 using Domain.AI.Models;
 using Microsoft.Extensions.Logging;
@@ -73,6 +74,9 @@ public sealed class DelegateToSubagentTool : ITool
 
     /// <inheritdoc />
     public bool IsReadOnly => false;
+
+    /// <inheritdoc />
+    public BlastRadius RiskTier => BlastRadius.High;
 
     /// <inheritdoc />
     public bool IsConcurrencySafe => false;

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/DocumentIngestTool.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/DocumentIngestTool.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using Application.AI.Common.Interfaces.Tools;
 using Application.Core.CQRS.RAG.IngestDocument;
+using Domain.AI.Changes;
 using Domain.AI.Models;
 using MediatR;
 
@@ -56,6 +57,9 @@ public sealed class DocumentIngestTool : ITool
 
     /// <inheritdoc />
     public bool IsReadOnly => false;
+
+    /// <inheritdoc />
+    public BlastRadius RiskTier => BlastRadius.Medium;
 
     /// <inheritdoc />
     public bool IsConcurrencySafe => false;

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/DocumentSearchTool.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/DocumentSearchTool.cs
@@ -2,6 +2,7 @@ using System.Text;
 using System.Text.Json;
 using Application.AI.Common.Interfaces.RAG;
 using Application.AI.Common.Interfaces.Tools;
+using Domain.AI.Changes;
 using Domain.AI.Models;
 using Domain.AI.RAG.Enums;
 
@@ -69,6 +70,9 @@ public sealed class DocumentSearchTool : ITool
 
     /// <inheritdoc />
     public bool IsReadOnly => true;
+
+    /// <inheritdoc />
+    public BlastRadius RiskTier => BlastRadius.Low;
 
     /// <inheritdoc />
     public bool IsConcurrencySafe => true;

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/EchoCalculateTool.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/EchoCalculateTool.cs
@@ -1,4 +1,5 @@
 using Application.AI.Common.Interfaces.Tools;
+using Domain.AI.Changes;
 using Domain.AI.Models;
 
 namespace Infrastructure.AI.Tools;
@@ -24,6 +25,9 @@ public sealed class EchoCalculateTool : ITool
 
 	/// <inheritdoc />
 	public bool IsReadOnly => true;
+
+	/// <inheritdoc />
+	public BlastRadius RiskTier => BlastRadius.Trivial;
 
 	/// <inheritdoc />
 	public bool IsConcurrencySafe => true;

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/EchoLookupTool.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/EchoLookupTool.cs
@@ -1,4 +1,5 @@
 using Application.AI.Common.Interfaces.Tools;
+using Domain.AI.Changes;
 using Domain.AI.Models;
 
 namespace Infrastructure.AI.Tools;
@@ -25,6 +26,9 @@ public sealed class EchoLookupTool : ITool
 
 	/// <inheritdoc />
 	public bool IsReadOnly => true;
+
+	/// <inheritdoc />
+	public BlastRadius RiskTier => BlastRadius.Trivial;
 
 	/// <inheritdoc />
 	public bool IsConcurrencySafe => true;

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/FileSystemTool.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/FileSystemTool.cs
@@ -1,4 +1,5 @@
 using Application.AI.Common.Interfaces.Tools;
+using Domain.AI.Changes;
 using Domain.AI.Models;
 
 namespace Infrastructure.AI.Tools;
@@ -43,6 +44,9 @@ public sealed class FileSystemTool : ITool
 
     /// <inheritdoc />
     public string Name => ToolName;
+
+    /// <inheritdoc />
+    public BlastRadius RiskTier => BlastRadius.High;
 
     /// <inheritdoc />
     public string Description => "Reads, writes, lists, and searches files within the project sandbox.";

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/GitOps/GitOpsClusterHealthTool.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/GitOps/GitOpsClusterHealthTool.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using Application.AI.Common.Interfaces.GitOps;
 using Application.AI.Common.Interfaces.Tools;
+using Domain.AI.Changes;
 using Domain.AI.Models;
 
 namespace Infrastructure.AI.Tools.GitOps;
@@ -45,6 +46,9 @@ public sealed class GitOpsClusterHealthTool : ITool
 
     /// <inheritdoc />
     public bool IsReadOnly => true;
+
+    /// <inheritdoc />
+    public BlastRadius RiskTier => BlastRadius.Low;
 
     /// <inheritdoc />
     public bool IsConcurrencySafe => true;

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/GitOps/GitOpsDetectDriftTool.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/GitOps/GitOpsDetectDriftTool.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using Application.AI.Common.Interfaces.GitOps;
 using Application.AI.Common.Interfaces.Tools;
+using Domain.AI.Changes;
 using Domain.AI.Models;
 
 namespace Infrastructure.AI.Tools.GitOps;
@@ -49,6 +50,9 @@ public sealed class GitOpsDetectDriftTool : ITool
 
     /// <inheritdoc />
     public bool IsReadOnly => true;
+
+    /// <inheritdoc />
+    public BlastRadius RiskTier => BlastRadius.Low;
 
     /// <inheritdoc />
     public bool IsConcurrencySafe => true;

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/GitOps/GitOpsProposeRemediationTool.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/GitOps/GitOpsProposeRemediationTool.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using Application.AI.Common.Interfaces.GitOps;
 using Application.AI.Common.Interfaces.Tools;
+using Domain.AI.Changes;
 using Domain.AI.Models;
 
 namespace Infrastructure.AI.Tools.GitOps;
@@ -59,6 +60,9 @@ public sealed class GitOpsProposeRemediationTool : ITool
 
     /// <inheritdoc />
     public bool IsReadOnly => false;
+
+    /// <inheritdoc />
+    public BlastRadius RiskTier => BlastRadius.High;
 
     /// <inheritdoc />
     public bool IsConcurrencySafe => false;

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/GitOps/K8sGptAnalyzeTool.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/GitOps/K8sGptAnalyzeTool.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using Application.AI.Common.Interfaces.GitOps;
 using Application.AI.Common.Interfaces.Tools;
+using Domain.AI.Changes;
 using Domain.AI.Models;
 
 namespace Infrastructure.AI.Tools.GitOps;
@@ -53,6 +54,9 @@ public sealed class K8sGptAnalyzeTool : ITool
 
     /// <inheritdoc />
     public bool IsReadOnly => true;
+
+    /// <inheritdoc />
+    public BlastRadius RiskTier => BlastRadius.Low;
 
     /// <inheritdoc />
     public bool IsConcurrencySafe => true;

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/Iac/IacGenerateTool.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/Iac/IacGenerateTool.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using Application.AI.Common.Interfaces.Tools;
+using Domain.AI.Changes;
 using Domain.AI.Iac;
 using Domain.AI.Models;
 using Domain.Common.Config;
@@ -47,6 +48,9 @@ public sealed class IacGenerateTool : ITool
 
     /// <inheritdoc />
     public bool IsReadOnly => true;
+
+    /// <inheritdoc />
+    public BlastRadius RiskTier => BlastRadius.Low;
 
     /// <inheritdoc />
     public bool IsConcurrencySafe => true;

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/Iac/IacPlanTool.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/Iac/IacPlanTool.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using Application.AI.Common.Interfaces.Tools;
+using Domain.AI.Changes;
 using Domain.AI.Models;
 using Domain.Common.Config;
 using Microsoft.Extensions.Options;
@@ -45,6 +46,9 @@ public sealed class IacPlanTool : ITool
 
     /// <inheritdoc />
     public bool IsReadOnly => true;
+
+    /// <inheritdoc />
+    public BlastRadius RiskTier => BlastRadius.Low;
 
     /// <inheritdoc />
     public bool IsConcurrencySafe => true;

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/Iac/IacScanTool.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/Iac/IacScanTool.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using Application.AI.Common.Interfaces.Tools;
+using Domain.AI.Changes;
 using Domain.AI.Models;
 using Domain.Common.Config;
 using Microsoft.Extensions.Options;
@@ -45,6 +46,9 @@ public sealed class IacScanTool : ITool
 
     /// <inheritdoc />
     public bool IsReadOnly => true;
+
+    /// <inheritdoc />
+    public BlastRadius RiskTier => BlastRadius.Low;
 
     /// <inheritdoc />
     public bool IsConcurrencySafe => true;

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/RestrictedSearchTool.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/RestrictedSearchTool.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using System.Text;
 using Application.AI.Common.Interfaces.Tools;
+using Domain.AI.Changes;
 using Domain.AI.Models;
 using Domain.Common.Config.MetaHarness;
 using Microsoft.Extensions.Logging;
@@ -92,6 +93,9 @@ public sealed class RestrictedSearchTool : ITool
 
     /// <inheritdoc />
     public bool IsReadOnly => true;
+
+    /// <inheritdoc />
+    public BlastRadius RiskTier => BlastRadius.Medium;
 
     /// <inheritdoc />
     public bool IsConcurrencySafe => true;

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/Workspace/WorkspaceListFilesTool.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/Workspace/WorkspaceListFilesTool.cs
@@ -1,5 +1,6 @@
 using Application.AI.Common.Interfaces.Tools;
 using Application.AI.Common.Interfaces.Workspace;
+using Domain.AI.Changes;
 using Domain.AI.Models;
 
 namespace Infrastructure.AI.Tools.Workspace;
@@ -52,6 +53,9 @@ public sealed class WorkspaceListFilesTool : ITool
 
     /// <inheritdoc />
     public bool IsReadOnly => true;
+
+    /// <inheritdoc />
+    public BlastRadius RiskTier => BlastRadius.Low;
 
     /// <inheritdoc />
     public bool IsConcurrencySafe => true;

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/Workspace/WorkspaceReadFileTool.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/Workspace/WorkspaceReadFileTool.cs
@@ -1,5 +1,6 @@
 using Application.AI.Common.Interfaces.Tools;
 using Application.AI.Common.Interfaces.Workspace;
+using Domain.AI.Changes;
 using Domain.AI.Models;
 
 namespace Infrastructure.AI.Tools.Workspace;
@@ -51,6 +52,9 @@ public sealed class WorkspaceReadFileTool : ITool
 
     /// <inheritdoc />
     public bool IsReadOnly => true;
+
+    /// <inheritdoc />
+    public BlastRadius RiskTier => BlastRadius.Low;
 
     /// <inheritdoc />
     public bool IsConcurrencySafe => true;

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/Workspace/WorkspaceRunLintTool.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/Workspace/WorkspaceRunLintTool.cs
@@ -1,6 +1,7 @@
 using Application.AI.Common.Interfaces.Sandbox;
 using Application.AI.Common.Interfaces.Tools;
 using Application.AI.Common.Interfaces.Workspace;
+using Domain.AI.Changes;
 using Domain.AI.Models;
 
 namespace Infrastructure.AI.Tools.Workspace;
@@ -42,6 +43,9 @@ public sealed class WorkspaceRunLintTool : ITool
 
     /// <inheritdoc />
     public string Name => ToolName;
+
+    /// <inheritdoc />
+    public BlastRadius RiskTier => BlastRadius.Low;
 
     /// <inheritdoc />
     public string Description =>

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/Workspace/WorkspaceRunTestsTool.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/Workspace/WorkspaceRunTestsTool.cs
@@ -1,6 +1,7 @@
 using Application.AI.Common.Interfaces.Sandbox;
 using Application.AI.Common.Interfaces.Tools;
 using Application.AI.Common.Interfaces.Workspace;
+using Domain.AI.Changes;
 using Domain.AI.Models;
 
 namespace Infrastructure.AI.Tools.Workspace;
@@ -44,6 +45,9 @@ public sealed class WorkspaceRunTestsTool : ITool
 
     /// <inheritdoc />
     public string Name => ToolName;
+
+    /// <inheritdoc />
+    public BlastRadius RiskTier => BlastRadius.Medium;
 
     /// <inheritdoc />
     public string Description =>

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/Workspace/WorkspaceWriteFileTool.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/Workspace/WorkspaceWriteFileTool.cs
@@ -67,6 +67,9 @@ public sealed class WorkspaceWriteFileTool : ITool
     public bool IsReadOnly => false;
 
     /// <inheritdoc />
+    public BlastRadius RiskTier => BlastRadius.High;
+
+    /// <inheritdoc />
     public bool IsConcurrencySafe => false;
 
     /// <inheritdoc />

--- a/src/Content/Tests/Application.AI.Common.Tests/Behaviors/ToolPermissionBehaviorTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Behaviors/ToolPermissionBehaviorTests.cs
@@ -1,11 +1,16 @@
 using Application.AI.Common.Interfaces.Agent;
+using Application.AI.Common.Interfaces.Governance;
 using Application.AI.Common.Interfaces.MediatR;
 using Application.AI.Common.Interfaces.Permissions;
 using Application.AI.Common.Interfaces.Sandbox;
+using Application.AI.Common.Interfaces.Tools;
 using Application.AI.Common.MediatRBehaviors;
+using Domain.AI.Changes;
+using Domain.AI.Governance;
 using Domain.AI.Permissions;
 using Domain.AI.Sandbox;
 using Domain.Common;
+using Domain.Common.Config.AI.Permissions;
 using Domain.Common.Config.AI.Sandbox;
 using FluentAssertions;
 using MediatR;
@@ -22,12 +27,18 @@ public sealed class ToolPermissionBehaviorTests
     private readonly Mock<IToolPermissionService> _permissionService = new();
     private readonly Mock<IDenialTracker> _denialTracker = new();
     private readonly Mock<ICapabilityEnforcer> _capabilityEnforcer = new();
+    private readonly Mock<IToolRiskClassifier> _toolRiskClassifier = new();
+    private readonly Mock<IAutonomyDecisionEvaluator> _autonomyEvaluator = new();
     private readonly Mock<IOptionsMonitor<SandboxConfig>> _sandboxConfig = new();
+    private readonly Mock<IOptionsMonitor<PermissionsConfig>> _permissionsConfig = new();
     private readonly Mock<ILogger<ToolPermissionBehavior<TestToolRequest, Result<string>>>> _logger = new();
 
     public ToolPermissionBehaviorTests()
     {
         _sandboxConfig.Setup(o => o.CurrentValue).Returns(new SandboxConfig());
+        // GradedAutonomy defaults to disabled, so the risk gate is a no-op for these tests.
+        _permissionsConfig.Setup(o => o.CurrentValue).Returns(new PermissionsConfig());
+        _toolRiskClassifier.Setup(c => c.Classify(It.IsAny<string>())).Returns(ToolRiskProfile.Default);
         _capabilityEnforcer
             .Setup(e => e.EnforceAsync(
                 It.IsAny<string>(), It.IsAny<ToolCapability>(),
@@ -38,7 +49,8 @@ public sealed class ToolPermissionBehaviorTests
 
     private ToolPermissionBehavior<TestToolRequest, Result<string>> CreateBehavior() =>
         new(_executionContext.Object, _permissionService.Object, _denialTracker.Object,
-            _capabilityEnforcer.Object, _sandboxConfig.Object, _logger.Object);
+            _capabilityEnforcer.Object, _toolRiskClassifier.Object, _autonomyEvaluator.Object,
+            _sandboxConfig.Object, _permissionsConfig.Object, _logger.Object);
 
     private static RequestHandlerDelegate<Result<string>> CreateNext(string value = "success") =>
         () => Task.FromResult(Result<string>.Success(value));
@@ -149,7 +161,8 @@ public sealed class ToolPermissionBehaviorTests
         var nonToolLogger = new Mock<ILogger<ToolPermissionBehavior<NonToolRequest, Result<string>>>>();
         var behavior = new ToolPermissionBehavior<NonToolRequest, Result<string>>(
             _executionContext.Object, _permissionService.Object, _denialTracker.Object,
-            _capabilityEnforcer.Object, _sandboxConfig.Object, nonToolLogger.Object);
+            _capabilityEnforcer.Object, _toolRiskClassifier.Object, _autonomyEvaluator.Object,
+            _sandboxConfig.Object, _permissionsConfig.Object, nonToolLogger.Object);
 
         RequestHandlerDelegate<Result<string>> next = () =>
             Task.FromResult(Result<string>.Success("passed"));
@@ -180,6 +193,77 @@ public sealed class ToolPermissionBehaviorTests
             s => s.ResolvePermissionAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<IReadOnlyDictionary<string, object?>?>(), It.IsAny<CancellationToken>()),
             Times.Never);
     }
+
+    // -- Graded-autonomy risk gate --
+
+    [Fact]
+    public async Task RiskGate_Disabled_DoesNotTightenAllow_EvenForHighRiskTool()
+    {
+        // GradedAutonomy is off (default): a rules-Allow proceeds regardless of tool risk,
+        // and the evaluator is never consulted.
+        ArrangeAllow();
+        _toolRiskClassifier.Setup(c => c.Classify("test_tool"))
+            .Returns(new ToolRiskProfile(BlastRadius.High, IsReadOnly: false));
+
+        var result = await CreateBehavior().Handle(
+            new TestToolRequest("test_tool"), CreateNext("allowed"), CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        _autonomyEvaluator.Verify(
+            e => e.Evaluate(It.IsAny<AutonomyLevel>(), It.IsAny<BlastRadius>(), It.IsAny<ChangeTargetKind>(), It.IsAny<bool>(), It.IsAny<string?>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task RiskGate_Enabled_HighRiskTool_RequiresApproval_TightensAllowToAsk()
+    {
+        ArrangeAllow();
+        _permissionsConfig.Setup(o => o.CurrentValue).Returns(GradedConfig());
+        _toolRiskClassifier.Setup(c => c.Classify("test_tool"))
+            .Returns(new ToolRiskProfile(BlastRadius.High, IsReadOnly: false));
+        _autonomyEvaluator
+            .Setup(e => e.Evaluate(It.IsAny<AutonomyLevel>(), BlastRadius.High, It.IsAny<ChangeTargetKind>(), true, null))
+            .Returns(EvalResult(AutonomyDecision.RequiresApproval));
+
+        var result = await CreateBehavior().Handle(
+            new TestToolRequest("test_tool"), CreateNext("allowed"), CancellationToken.None);
+
+        // Allow was tightened to Ask → PermissionRequired failure, and the denial was recorded.
+        result.IsSuccess.Should().BeFalse();
+        _denialTracker.Verify(d => d.RecordDenial("agent-1", "test_tool"), Times.Once);
+    }
+
+    [Fact]
+    public async Task RiskGate_Enabled_AutoApprove_KeepsAllow()
+    {
+        ArrangeAllow();
+        _permissionsConfig.Setup(o => o.CurrentValue).Returns(GradedConfig());
+        _toolRiskClassifier.Setup(c => c.Classify("test_tool"))
+            .Returns(new ToolRiskProfile(BlastRadius.Low, IsReadOnly: true));
+        _autonomyEvaluator
+            .Setup(e => e.Evaluate(It.IsAny<AutonomyLevel>(), It.IsAny<BlastRadius>(), It.IsAny<ChangeTargetKind>(), It.IsAny<bool>(), It.IsAny<string?>()))
+            .Returns(EvalResult(AutonomyDecision.AutoApprove));
+
+        var result = await CreateBehavior().Handle(
+            new TestToolRequest("test_tool"), CreateNext("allowed"), CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    private void ArrangeAllow()
+    {
+        _executionContext.Setup(c => c.AgentId).Returns("agent-1");
+        _permissionService
+            .Setup(s => s.ResolvePermissionAsync("agent-1", "test_tool", null, null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(PermissionDecision.Allow("Allowed by rule."));
+    }
+
+    private static PermissionsConfig GradedConfig(string tier = "Autonomous") =>
+        new() { DefaultAutonomyLevel = tier, GradedAutonomy = new() { Enabled = true } };
+
+    private static AutonomyDecisionResult EvalResult(AutonomyDecision decision) =>
+        new(decision, AutonomyLevel.Autonomous, BlastRadius.High, ChangeTargetKind.Unspecified,
+            IsStateChange: true, "Test", SkillKey: null, "test reason");
 
     // Test request types
 

--- a/src/Content/Tests/Application.AI.Common.Tests/MediatRBehaviors/GovernancePolicyBehaviorCancellationSolutionReviewFixTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/MediatRBehaviors/GovernancePolicyBehaviorCancellationSolutionReviewFixTests.cs
@@ -68,6 +68,8 @@ public sealed class GovernancePolicyBehaviorCancellationSolutionReviewFixTests
             _executionContext.Object,
             Mock.Of<IOptionsMonitor<GovernanceConfig>>(m => m.CurrentValue == _config),
             Mock.Of<IOptionsMonitor<PermissionsConfig>>(m => m.CurrentValue == _permissionsConfig),
+            Mock.Of<Application.AI.Common.Interfaces.Tools.IToolRiskClassifier>(
+                c => c.Classify(It.IsAny<string>()) == Application.AI.Common.Interfaces.Tools.ToolRiskProfile.Default),
             _logger.Object,
             _escalationService.Object);
 

--- a/src/Content/Tests/Application.AI.Common.Tests/MediatRBehaviors/GovernancePolicyBehaviorEscalationTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/MediatRBehaviors/GovernancePolicyBehaviorEscalationTests.cs
@@ -2,7 +2,9 @@ using Application.AI.Common.Interfaces.Agent;
 using Application.AI.Common.Interfaces.Escalation;
 using Application.AI.Common.Interfaces.Governance;
 using Application.AI.Common.Interfaces.MediatR;
+using Application.AI.Common.Interfaces.Tools;
 using Application.AI.Common.MediatRBehaviors;
+using Domain.AI.Changes;
 using Domain.AI.Escalation;
 using Domain.AI.Governance;
 using Domain.Common;
@@ -31,6 +33,8 @@ public sealed class GovernancePolicyBehaviorEscalationTests
     private readonly Mock<ILogger<GovernancePolicyBehavior<TestToolRequest, Result<string>>>> _logger = new();
     private readonly GovernanceConfig _config;
     private readonly PermissionsConfig _permissionsConfig;
+    private IToolRiskClassifier _toolRiskClassifier =
+        Mock.Of<IToolRiskClassifier>(c => c.Classify(It.IsAny<string>()) == ToolRiskProfile.Default);
     private bool _nextCalled;
 
     public GovernancePolicyBehaviorEscalationTests()
@@ -72,6 +76,7 @@ public sealed class GovernancePolicyBehaviorEscalationTests
             _executionContext.Object,
             Mock.Of<IOptionsMonitor<GovernanceConfig>>(m => m.CurrentValue == cfg),
             Mock.Of<IOptionsMonitor<PermissionsConfig>>(m => m.CurrentValue == perm),
+            _toolRiskClassifier,
             _logger.Object,
             _escalationService.Object);
     }
@@ -117,6 +122,35 @@ public sealed class GovernancePolicyBehaviorEscalationTests
                     r.AgentId == "test-agent" &&
                     r.ToolName == "deploy" &&
                     r.Approvers.Contains("admin@test.com")),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_RequireApproval_DerivesEscalationRiskLevelFromToolBlastRadius()
+    {
+        // A High-blast-radius tool must escalate as High, not the previously-hardcoded Medium.
+        _toolRiskClassifier = Mock.Of<IToolRiskClassifier>(
+            c => c.Classify("deploy") == new ToolRiskProfile(BlastRadius.High, false));
+        _policyEngine.Setup(x => x.HasPolicies).Returns(true);
+        _policyEngine.Setup(x => x.EvaluateToolCall("test-agent", "deploy", null))
+            .Returns(RequireApprovalDecision());
+        _escalationService
+            .Setup(x => x.RequestEscalationAsync(It.IsAny<EscalationRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new EscalationOutcome
+            {
+                EscalationId = Guid.NewGuid(),
+                IsApproved = true,
+                Decisions = [],
+                ResolutionType = EscalationResolutionType.Approved,
+                ResolvedAt = DateTimeOffset.UtcNow
+            });
+
+        await CreateBehavior().Handle(new TestToolRequest("deploy"), Next, CancellationToken.None);
+
+        _escalationService.Verify(
+            x => x.RequestEscalationAsync(
+                It.Is<EscalationRequest>(r => r.RiskLevel == RiskLevel.High),
                 It.IsAny<CancellationToken>()),
             Times.Once);
     }

--- a/src/Content/Tests/Application.AI.Common.Tests/MediatRBehaviors/GovernancePolicyBehaviorTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/MediatRBehaviors/GovernancePolicyBehaviorTests.cs
@@ -1,6 +1,7 @@
 using Application.AI.Common.Interfaces.Agent;
 using Application.AI.Common.Interfaces.Governance;
 using Application.AI.Common.Interfaces.MediatR;
+using Application.AI.Common.Interfaces.Tools;
 using Application.AI.Common.MediatRBehaviors;
 using Domain.AI.Governance;
 using Domain.Common;
@@ -22,6 +23,8 @@ public sealed class GovernancePolicyBehaviorTests
     private readonly Mock<ILogger<GovernancePolicyBehavior<TestToolRequest, Result<string>>>> _logger = new();
     private readonly GovernanceConfig _config = new() { Enabled = true, EnableAudit = true };
     private readonly PermissionsConfig _permissionsConfig = new();
+    private readonly IToolRiskClassifier _toolRiskClassifier =
+        Mock.Of<IToolRiskClassifier>(c => c.Classify(It.IsAny<string>()) == ToolRiskProfile.Default);
     private readonly GovernancePolicyBehavior<TestToolRequest, Result<string>> _behavior;
     private bool _nextCalled;
 
@@ -37,6 +40,7 @@ public sealed class GovernancePolicyBehaviorTests
             _executionContext.Object,
             monitor,
             permMonitor,
+            _toolRiskClassifier,
             _logger.Object);
     }
 
@@ -55,6 +59,7 @@ public sealed class GovernancePolicyBehaviorTests
             _executionContext.Object,
             Mock.Of<IOptionsMonitor<GovernanceConfig>>(m => m.CurrentValue == _config),
             Mock.Of<IOptionsMonitor<PermissionsConfig>>(m => m.CurrentValue == _permissionsConfig),
+            _toolRiskClassifier,
             Mock.Of<ILogger<GovernancePolicyBehavior<NonToolRequest, Result<string>>>>());
 
         var result = await behavior.Handle(new NonToolRequest(), () => Task.FromResult(Result<string>.Success("ok")), CancellationToken.None);
@@ -70,6 +75,7 @@ public sealed class GovernancePolicyBehaviorTests
             _policyEngine.Object, _auditService.Object, _executionContext.Object,
             Mock.Of<IOptionsMonitor<GovernanceConfig>>(m => m.CurrentValue == disabledConfig),
             Mock.Of<IOptionsMonitor<PermissionsConfig>>(m => m.CurrentValue == _permissionsConfig),
+            _toolRiskClassifier,
             _logger.Object);
 
         var result = await behavior.Handle(new TestToolRequest("test"), Next, CancellationToken.None);

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/ToolRiskClassifierTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/ToolRiskClassifierTests.cs
@@ -1,0 +1,84 @@
+using Application.AI.Common.Interfaces.Tools;
+using Application.AI.Common.Services.Tools;
+using Domain.AI.Changes;
+using Domain.AI.Models;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Application.AI.Common.Tests.Services.Tools;
+
+/// <summary>
+/// Tests for <see cref="ToolRiskClassifier"/> — resolving a tool's declared risk from keyed DI,
+/// with a fail-safe default for names that do not resolve.
+/// </summary>
+public sealed class ToolRiskClassifierTests
+{
+    private static IToolRiskClassifier CreateClassifier(params ITool[] tools)
+    {
+        var services = new ServiceCollection();
+        foreach (var tool in tools)
+            services.AddKeyedSingleton<ITool>(tool.Name, tool);
+
+        return new ToolRiskClassifier(services.BuildServiceProvider());
+    }
+
+    [Fact]
+    public void Classify_KnownTool_ReturnsDeclaredRadiusAndReadOnly()
+    {
+        var sut = CreateClassifier(new FakeTool("deploy", BlastRadius.High, isReadOnly: false));
+
+        var profile = sut.Classify("deploy");
+
+        profile.Radius.Should().Be(BlastRadius.High);
+        profile.IsReadOnly.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Classify_ReadOnlyTool_ReflectsFlag()
+    {
+        var sut = CreateClassifier(new FakeTool("lookup", BlastRadius.Low, isReadOnly: true));
+
+        var profile = sut.Classify("lookup");
+
+        profile.Radius.Should().Be(BlastRadius.Low);
+        profile.IsReadOnly.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Classify_UnknownTool_ReturnsFailSafeDefault()
+    {
+        var sut = CreateClassifier(new FakeTool("known", BlastRadius.Trivial, isReadOnly: true));
+
+        var profile = sut.Classify("not-registered");
+
+        profile.Should().Be(ToolRiskProfile.Default);
+        profile.Radius.Should().Be(BlastRadius.Medium);
+        profile.IsReadOnly.Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Classify_BlankName_ReturnsDefault(string name)
+    {
+        var sut = CreateClassifier(new FakeTool("known", BlastRadius.High, isReadOnly: false));
+
+        sut.Classify(name).Should().Be(ToolRiskProfile.Default);
+    }
+
+    private sealed class FakeTool(string name, BlastRadius risk, bool isReadOnly) : ITool
+    {
+        public string Name => name;
+        public string Description => "fake tool";
+        public IReadOnlyList<string> SupportedOperations => [];
+        public bool IsReadOnly => isReadOnly;
+        public BlastRadius RiskTier => risk;
+
+        public Task<ToolResult> ExecuteAsync(
+            string operation,
+            IReadOnlyDictionary<string, object?> parameters,
+            CancellationToken cancellationToken = default)
+            => throw new NotSupportedException("Not used in classifier tests.");
+    }
+}

--- a/src/Content/Tests/Domain.AI.Tests/Governance/BlastRadiusRiskMappingTests.cs
+++ b/src/Content/Tests/Domain.AI.Tests/Governance/BlastRadiusRiskMappingTests.cs
@@ -1,0 +1,44 @@
+using Domain.AI.Changes;
+using Domain.AI.Escalation;
+using Domain.AI.Governance;
+using FluentAssertions;
+using Xunit;
+
+namespace Domain.AI.Tests.Governance;
+
+/// <summary>
+/// Tests for <see cref="BlastRadiusRiskMapping.ToRiskLevel"/> — the projection of a tool's
+/// blast radius onto the escalation risk scale.
+/// </summary>
+public sealed class BlastRadiusRiskMappingTests
+{
+    [Theory]
+    [InlineData(BlastRadius.Trivial, RiskLevel.Low)]
+    [InlineData(BlastRadius.Low, RiskLevel.Low)]
+    [InlineData(BlastRadius.Medium, RiskLevel.Medium)]
+    [InlineData(BlastRadius.High, RiskLevel.High)]
+    [InlineData(BlastRadius.Critical, RiskLevel.Critical)]
+    public void ToRiskLevel_MapsEachBand(BlastRadius radius, RiskLevel expected)
+    {
+        radius.ToRiskLevel().Should().Be(expected);
+    }
+
+    [Fact]
+    public void ToRiskLevel_FoldsTrivialAndLow_IntoLow()
+    {
+        // The escalation scale has no band below Low, so the two lowest blast radii collapse.
+        BlastRadius.Trivial.ToRiskLevel().Should().Be(BlastRadius.Low.ToRiskLevel());
+    }
+
+    [Fact]
+    public void ToRiskLevel_IsMonotonic_AcrossBands()
+    {
+        // Higher blast radius never maps to a lower escalation severity.
+        var ordered = new[] { BlastRadius.Trivial, BlastRadius.Low, BlastRadius.Medium, BlastRadius.High, BlastRadius.Critical };
+
+        for (var i = 1; i < ordered.Length; i++)
+        {
+            ((int)ordered[i].ToRiskLevel()).Should().BeGreaterThanOrEqualTo((int)ordered[i - 1].ToRiskLevel());
+        }
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Governance/AutonomyConfigValidatorTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Governance/AutonomyConfigValidatorTests.cs
@@ -160,6 +160,22 @@ public sealed class AutonomyConfigValidatorTests
     }
 
     [Fact]
+    public async Task StartAsync_InvalidDefaultAutonomyLevel_Throws()
+    {
+        // The tool-risk gate parses DefaultAutonomyLevel at runtime; a typo must fail boot
+        // (when graded autonomy is enabled) rather than silently disable the gate.
+        var cfg = GradedEnabled(_ => { });
+        cfg.AI.Permissions.DefaultAutonomyLevel = "NotATier";
+
+        var sut = Build(cfg);
+
+        var act = async () => await sut.StartAsync(CancellationToken.None);
+
+        var ex = await act.Should().ThrowAsync<InvalidOperationException>();
+        ex.Which.Message.Should().Contain("DefaultAutonomyLevel");
+    }
+
+    [Fact]
     public async Task StartAsync_PerSkillCriticalAutoApprove_Throws()
     {
         var cfg = GradedEnabled(g =>


### PR DESCRIPTION
## What & why
Phase 3 of the governance hardening line. Each tool now declares a **blast radius**, and that flows into the approval machinery — replacing a single hardcoded `RiskLevel.Medium` that treated every tool the same (a file-delete tool escalated identically to a document read).

The harness already had a graded-autonomy engine (`IAutonomyDecisionEvaluator`) that maps a `BlastRadius` to an auto-approve/require-approval decision per tier — it was only wired to change proposals. This connects tool calls to the same engine, reusing the existing scale with **no new enum and no mapping layer**.

## Changes
- **`ITool.RiskTier`** — new default-implemented member (default `Medium`), beside the existing `IsReadOnly`/`IsConcurrencySafe` flags. Non-breaking: every implementer inherits the default. The 19 first-party tools declare ratings (echo fixtures `Trivial`; reads `Low`; sandboxed exec / knowledge-writes `Medium`; file-writes, GitOps proposals, subagent delegation `High`).
- **`IToolRiskClassifier`** — resolves a tool's risk by name; fail-safe `Medium`/state-change default for unknown (external MCP) tools.
- **`GovernancePolicyBehavior`** — escalation `RiskLevel` derived from the tool's blast radius (`BlastRadiusRiskMapping`) instead of a fixed `Medium`.
- **`ToolPermissionBehavior`** — a graded-autonomy gate layered on the rule-based decision. **Can only tighten** (`Allow → Ask/Deny`), never loosen. State-changing tools can never auto-approve through it (evaluated with `skillKey: null`, which trips the evaluator's dual-key rule).
- **`AutonomyConfigValidator`** — fail-fast at boot on an invalid `DefaultAutonomyLevel` (when graded autonomy is on), backstopping the runtime gate.
- **Docs** — `documentation/design/tool-risk-tiers.md`.

## Safety: off by default
The approval gate activates only when `AI:Permissions:GradedAutonomy:Enabled = true`. With it off (default), the gate is a **no-op** and the evaluator is never consulted — so shipping ratings alone changes **no runtime behavior**. The escalation-severity change is always safe (it only relabels an escalation that was already happening; approval strategy/timeout/approvers come from config, not the label).

## Reviews
- **security-reviewer: APPROVE** (fail-open threat model). Gate only tightens; unknown tools resolve safe; no secret leakage; ratings correct. One follow-up (boot-validate `DefaultAutonomyLevel`) **fixed** in this PR.
- **High-effort /code-review** (correctness + cleanup + altitude): one efficiency fix applied; the rule-provider-vs-behavior altitude option was considered and rejected (keyed DI can't enumerate tools for a provider; the two-layer split mirrors the change-proposal path).

## Test plan
- Full solution build: 0 errors.
- New: `BlastRadiusRiskMapping` (7), `ToolRiskClassifier` (classifier + fail-safe default), the autonomy gate (tighten/keep/off), escalation-severity-from-risk, and invalid-`DefaultAutonomyLevel` boot rejection.
- Green: 1053 Application.AI.Common + 351 AgentHub (DI integration) + 1882 Infrastructure.AI + 7 Domain.AI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)