### PR TITLE
fix: console-host IHostEnvironment + cross-platform SPA launch (#19, #64)

### DIFF
--- a/src/Content/Presentation/Presentation.AgentHub/Presentation.AgentHub.csproj
+++ b/src/Content/Presentation/Presentation.AgentHub/Presentation.AgentHub.csproj
@@ -15,7 +15,11 @@
   <PropertyGroup Condition="'$(Configuration)' == 'Debug' or '$(Configuration)' == 'Debug-AgentHub-All'">
     <SpaRoot>.\</SpaRoot>
     <SpaProxyServerUrl>http://localhost:5173</SpaProxyServerUrl>
-    <SpaProxyLaunchCommand>cmd.exe /c start-all-spas.cmd</SpaProxyLaunchCommand>
+    <!-- Launch both SPAs. The Windows .cmd cannot run on macOS/Linux, so select a
+         shell launcher per OS — otherwise SpaProxy fails with "Couldn't start the SPA
+         development server with command 'cmd.exe /c start-all-spas.cmd'." -->
+    <SpaProxyLaunchCommand Condition="$([MSBuild]::IsOSPlatform('Windows'))">cmd.exe /c start-all-spas.cmd</SpaProxyLaunchCommand>
+    <SpaProxyLaunchCommand Condition="!$([MSBuild]::IsOSPlatform('Windows'))">bash start-all-spas.sh</SpaProxyLaunchCommand>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)' == 'Debug-AgentHub-WebUI'">

--- a/src/Content/Presentation/Presentation.AgentHub/start-all-spas.sh
+++ b/src/Content/Presentation/Presentation.AgentHub/start-all-spas.sh
@@ -25,5 +25,8 @@ trap cleanup EXIT INT TERM
 dashboard_pid=$!
 
 # WebUI Vite (:5173) in the foreground — keeps the process alive for SpaProxy.
+# Deliberately NOT `exec`: replacing the shell image would discard the EXIT/INT/TERM
+# trap above, orphaning the backgrounded Dashboard server. Running npm as a child keeps
+# the trap installed so the Dashboard is torn down when this script exits or is signalled.
 cd "$script_dir/../Presentation.WebUI"
-exec npm run dev
+npm run dev

--- a/src/Content/Presentation/Presentation.AgentHub/start-all-spas.sh
+++ b/src/Content/Presentation/Presentation.AgentHub/start-all-spas.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Cross-platform companion to start-all-spas.cmd. Launches both Vite dev servers
+# (Dashboard on :5174, WebUI on :5173) for the SpaProxy on macOS/Linux, where the
+# Windows `cmd.exe /c start-all-spas.cmd` launch command cannot run.
+#
+# The SpaProxy invokes this with the AgentHub project directory as the working
+# directory, but resolve paths from the script's own location so it also works when
+# run by hand. The WebUI server runs in the foreground so this process stays alive
+# for as long as SpaProxy expects the dev server to be up; the Dashboard server is
+# backgrounded and torn down with it.
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Tear down the backgrounded Dashboard server when this script exits.
+cleanup() {
+  if [[ -n "${dashboard_pid:-}" ]]; then
+    kill "$dashboard_pid" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT INT TERM
+
+# Dashboard Vite (:5174) in the background.
+(cd "$script_dir/../Presentation.Dashboard" && npm run dev) &
+dashboard_pid=$!
+
+# WebUI Vite (:5173) in the foreground — keeps the process alive for SpaProxy.
+cd "$script_dir/../Presentation.WebUI"
+exec npm run dev

--- a/src/Content/Presentation/Presentation.Common/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Content/Presentation/Presentation.Common/Extensions/IServiceCollectionExtensions.cs
@@ -27,9 +27,12 @@ using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.Extensions.Caching.StackExchangeRedis;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Identity.Web;
 using Presentation.Common.Helpers;
+using Presentation.Common.Hosting;
 using Presentation.Common.Security;
 
 namespace Presentation.Common.Extensions;
@@ -160,6 +163,12 @@ public static class IServiceCollectionExtensions
         services.AddOptions();
         services.AddProblemDetails();
         services.AddHttpContextAccessor();
+
+        // Console-style hosts (ConsoleUI, EvalRunner, FoundryHost) compose a bare ServiceCollection
+        // with no IHost, so IHostEnvironment is never registered — yet services like
+        // AutonomyDecisionEvaluator hard-inject it and fail at first resolution. TryAdd fills the gap
+        // for those hosts while leaving a web host's real IHostEnvironment untouched.
+        services.TryAddSingleton<IHostEnvironment>(new HarnessHostEnvironment());
 
         services.AddCacheConfiguration(appConfig.Cache);
         services.AddCustomHealthChecks(appConfig, includeHealthChecksUI);

--- a/src/Content/Presentation/Presentation.Common/Hosting/HarnessHostEnvironment.cs
+++ b/src/Content/Presentation/Presentation.Common/Hosting/HarnessHostEnvironment.cs
@@ -1,0 +1,58 @@
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Hosting;
+using Presentation.Common.Helpers;
+using System.Reflection;
+
+namespace Presentation.Common.Hosting;
+
+/// <summary>
+/// Minimal <see cref="IHostEnvironment"/> for hosts that compose their container from a
+/// bare <see cref="Microsoft.Extensions.DependencyInjection.ServiceCollection"/> rather than
+/// a generic <c>IHost</c> / <c>WebApplication</c> builder — for example
+/// <c>Presentation.ConsoleUI</c>, <c>Presentation.EvalRunner</c>, and <c>Presentation.FoundryHost</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A web host registers <see cref="IHostEnvironment"/> automatically, so services that
+/// hard-inject it (such as <c>AutonomyDecisionEvaluator</c> and the Entra identity providers)
+/// resolve cleanly there. Console-style hosts have no such registration, so resolving those
+/// services throws <see cref="InvalidOperationException"/> at first use — surfacing only deep
+/// inside the MediatR pipeline as a sanitized "internal error during the agent turn". Registering
+/// this shim in <c>BuildGlobalSolutionServices</c> closes that gap for every non-web host at once.
+/// </para>
+/// <para>
+/// <see cref="EnvironmentName"/> is read from <see cref="AppConfigHelper.GetEnvironmentName"/> —
+/// the same <c>ASPNETCORE_ENVIRONMENT</c> source used to select <c>appsettings.{Environment}.json</c> —
+/// so the host environment and the loaded configuration always agree. The registration is done with
+/// <c>TryAddSingleton</c>, so a real web host's environment always wins and this shim only fills the gap.
+/// </para>
+/// <para>
+/// <see cref="ContentRootFileProvider"/> is a <see cref="NullFileProvider"/>: no consumer in the
+/// harness reads the content-root file provider, and a <see cref="PhysicalFileProvider"/> over a
+/// non-existent root would throw at construction. <see cref="ContentRootPath"/> still reports the
+/// process base directory for the rare diagnostic that inspects it.
+/// </para>
+/// </remarks>
+public sealed class HarnessHostEnvironment : IHostEnvironment
+{
+    /// <summary>Initializes a new <see cref="HarnessHostEnvironment"/> from the ambient environment.</summary>
+    public HarnessHostEnvironment()
+    {
+        EnvironmentName = AppConfigHelper.GetEnvironmentName();
+        ApplicationName = Assembly.GetEntryAssembly()?.GetName().Name ?? "AgenticHarness";
+        ContentRootPath = AppContext.BaseDirectory;
+        ContentRootFileProvider = new NullFileProvider();
+    }
+
+    /// <inheritdoc />
+    public string EnvironmentName { get; set; }
+
+    /// <inheritdoc />
+    public string ApplicationName { get; set; }
+
+    /// <inheritdoc />
+    public string ContentRootPath { get; set; }
+
+    /// <inheritdoc />
+    public IFileProvider ContentRootFileProvider { get; set; }
+}

--- a/src/Content/Presentation/Presentation.ConsoleUI/Examples/ResearchAgentExample.cs
+++ b/src/Content/Presentation/Presentation.ConsoleUI/Examples/ResearchAgentExample.cs
@@ -15,13 +15,11 @@ namespace Presentation.ConsoleUI.Examples;
 /// </summary>
 public class ResearchAgentExample
 {
-	private readonly ISender _sender;
 	private readonly IServiceScopeFactory _scopeFactory;
 	private readonly ILogger<ResearchAgentExample> _logger;
 
-	public ResearchAgentExample(ISender sender, IServiceScopeFactory scopeFactory, ILogger<ResearchAgentExample> logger)
+	public ResearchAgentExample(IServiceScopeFactory scopeFactory, ILogger<ResearchAgentExample> logger)
 	{
-		_sender = sender;
 		_scopeFactory = scopeFactory;
 		_logger = logger;
 	}
@@ -146,7 +144,14 @@ public class ResearchAgentExample
 			.SpinnerStyle(Style.Parse("cornflowerblue"))
 			.StartAsync("ResearchAgent is thinking...", async _ =>
 			{
-				var result = await _sender.Send(new ExecuteAgentTurnCommand
+				// Fresh DI scope per turn: IAgentExecutionContext is scoped and binds itself
+				// for the conversation. Reusing the root-injected sender would re-bind the
+				// same root-scope instance on the next run, throwing "AgentExecutionContext
+				// scope conflict". Mirrors RunHeadlessAsync.
+				await using var scope = _scopeFactory.CreateAsyncScope();
+				var scopedSender = scope.ServiceProvider.GetRequiredService<ISender>();
+
+				var result = await scopedSender.Send(new ExecuteAgentTurnCommand
 				{
 					AgentName = "research-agent",
 					UserMessage = question,
@@ -182,7 +187,12 @@ public class ResearchAgentExample
 
 		AnsiConsole.MarkupLine($"\n[bold]Running {messages.Count}-turn conversation...[/]\n");
 
-		var result = await _sender.Send(new RunConversationCommand
+		// Fresh DI scope per conversation so the scoped IAgentExecutionContext starts
+		// unbound — same reason as RunSingleTurnAsync / RunHeadlessAsync.
+		await using var scope = _scopeFactory.CreateAsyncScope();
+		var scopedSender = scope.ServiceProvider.GetRequiredService<ISender>();
+
+		var result = await scopedSender.Send(new RunConversationCommand
 		{
 			AgentName = "research-agent",
 			UserMessages = messages,

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/Agent/AgentExecutionContextTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/Agent/AgentExecutionContextTests.cs
@@ -1,6 +1,8 @@
+using Application.AI.Common.Interfaces.Agent;
 using Application.AI.Common.Services.Agent;
 using Domain.AI.Identity;
 using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
 namespace Application.AI.Common.Tests.Services.Agent;
@@ -340,5 +342,52 @@ public class AgentExecutionContextTests
         exceptions.Should().HaveCount(threadCount);
         exceptions.Should().AllSatisfy(e => e.Should().BeNull());
         context.AgentIdentity.Should().Be(identityTemplate);
+    }
+
+    // --- Per-run DI scoping contract (regression: GitHub #19) ---------------------
+    // ResearchAgentExample reused a root-scoped ISender across runs, so the scoped
+    // IAgentExecutionContext was bound on the first turn and collided on the second
+    // ("AgentExecutionContext scope conflict"), forcing an app restart. The fix runs
+    // each turn in a fresh DI scope. These two tests pin both halves of that contract.
+
+    [Fact]
+    public void ScopedContext_ReusedWithinOneScope_ThrowsScopeConflictOnSecondTurn()
+    {
+        // Reproduces the bug: a single scope hands back the same scoped instance, so the
+        // second turn's Initialize collides with the first turn's binding.
+        using var provider = new ServiceCollection()
+            .AddScoped<IAgentExecutionContext, AgentExecutionContext>()
+            .BuildServiceProvider();
+
+        var firstTurn = provider.GetRequiredService<IAgentExecutionContext>();
+        firstTurn.Initialize("research-agent", "conv-1", 1);
+
+        var reused = provider.GetRequiredService<IAgentExecutionContext>();
+        var act = () => reused.Initialize("research-agent", "conv-2", 1);
+
+        reused.Should().BeSameAs(firstTurn, "a single scope resolves the scoped context once");
+        act.Should().Throw<InvalidOperationException>().WithMessage("*scope conflict*");
+    }
+
+    [Fact]
+    public void ScopedContext_FreshScopePerTurn_NoConflict()
+    {
+        // Proves the fix: a new scope per turn yields a fresh, unbound context each time.
+        using var provider = new ServiceCollection()
+            .AddScoped<IAgentExecutionContext, AgentExecutionContext>()
+            .BuildServiceProvider();
+
+        using (var firstScope = provider.CreateScope())
+        {
+            firstScope.ServiceProvider.GetRequiredService<IAgentExecutionContext>()
+                .Initialize("research-agent", "conv-1", 1);
+        }
+
+        using var secondScope = provider.CreateScope();
+        var secondTurn = secondScope.ServiceProvider.GetRequiredService<IAgentExecutionContext>();
+        var act = () => secondTurn.Initialize("research-agent", "conv-2", 1);
+
+        act.Should().NotThrow();
+        secondTurn.ConversationId.Should().Be("conv-2");
     }
 }

--- a/src/Content/Tests/Presentation.Common.Tests/Hosting/HarnessHostEnvironmentTests.cs
+++ b/src/Content/Tests/Presentation.Common.Tests/Hosting/HarnessHostEnvironmentTests.cs
@@ -1,0 +1,65 @@
+using Domain.Common.Config;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Presentation.Common.Extensions;
+using Presentation.Common.Helpers;
+using Presentation.Common.Hosting;
+using Xunit;
+
+namespace Presentation.Common.Tests.Hosting;
+
+/// <summary>
+/// Regression tests for the <see cref="IHostEnvironment"/> registration in
+/// <see cref="IServiceCollectionExtensions.BuildGlobalSolutionServices"/>.
+/// </summary>
+/// <remarks>
+/// Reproduces GitHub issues #19 and #64: console-style hosts (ConsoleUI, EvalRunner,
+/// FoundryHost) compose a bare <see cref="ServiceCollection"/> with no <c>IHost</c>, so
+/// <see cref="IHostEnvironment"/> was never registered. Services that hard-inject it —
+/// notably <c>AutonomyDecisionEvaluator</c> in the MediatR tool-permission behavior — then
+/// failed to activate, surfacing only as a sanitized "internal error during the agent turn".
+/// </remarks>
+public sealed class HarnessHostEnvironmentTests
+{
+    [Fact]
+    public void BuildGlobalSolutionServices_RegistersHostEnvironment_ForConsoleStyleHosts()
+    {
+        // Mirrors the console composition: a bare ServiceCollection, no IHost.
+        var services = new ServiceCollection();
+
+        services.BuildGlobalSolutionServices(new AppConfig());
+
+        services.Any(d => d.ServiceType == typeof(IHostEnvironment))
+            .Should().BeTrue("services that hard-inject IHostEnvironment must resolve in console hosts");
+    }
+
+    [Fact]
+    public void BuildGlobalSolutionServices_DoesNotClobberExistingHostEnvironment()
+    {
+        // A web host registers its real IHostEnvironment before GetServices() runs.
+        var services = new ServiceCollection();
+        var webEnvironment = new HarnessHostEnvironment { EnvironmentName = "Staging" };
+        services.AddSingleton<IHostEnvironment>(webEnvironment);
+
+        services.BuildGlobalSolutionServices(new AppConfig());
+
+        services.Count(d => d.ServiceType == typeof(IHostEnvironment))
+            .Should().Be(1, "TryAddSingleton must not register a second IHostEnvironment");
+        using var provider = services.BuildServiceProvider();
+        provider.GetRequiredService<IHostEnvironment>()
+            .Should().BeSameAs(webEnvironment, "the host's real environment must win");
+    }
+
+    [Fact]
+    public void HarnessHostEnvironment_ReportsConfiguredEnvironmentName()
+    {
+        var environment = new HarnessHostEnvironment();
+
+        environment.EnvironmentName.Should().Be(AppConfigHelper.GetEnvironmentName());
+        environment.EnvironmentName.Should().NotBeNullOrEmpty();
+        environment.ApplicationName.Should().NotBeNullOrEmpty();
+        environment.ContentRootPath.Should().NotBeNullOrEmpty();
+        environment.ContentRootFileProvider.Should().NotBeNull();
+    }
+}


### PR DESCRIPTION
## Summary
Fixes the two runtime bugs reported in #64 and #19. (#59 is an enhancement, not a bug — left open.)

### 1. ConsoleUI research agent crash — *"internal error during the agent turn"* (#19, #64)
Console-style hosts (`ConsoleUI`, `EvalRunner`, `FoundryHost`) compose a bare `ServiceCollection` with no `IHost`, so `IHostEnvironment` was never registered. Services that hard-inject it — notably `AutonomyDecisionEvaluator` in the MediatR tool-permission behavior — failed to activate the moment the agent ran, surfacing only as a sanitized generic error.

**Fix:** register a minimal `HarnessHostEnvironment : IHostEnvironment` shim once in `BuildGlobalSolutionServices` via `TryAddSingleton`, so every non-web host is covered and a real web host's environment is never clobbered. `EnvironmentName` comes from `AppConfigHelper.GetEnvironmentName()` (the same `ASPNETCORE_ENVIRONMENT` source used for config), so host and config always agree.

### 2. *"AgentExecutionContext scope conflict"* forcing an app restart between runs (#19)
`RunSingleTurnAsync` / `RunMultiTurnAsync` reused the root-scoped sender, so the scoped `IAgentExecutionContext` got permanently bound on the first run and collided on the second.

**Fix:** each run gets its own DI scope (`CreateAsyncScope` + scoped `ISender`), matching the pattern `RunHeadlessAsync` already used. The now-dead `ISender` field/ctor param were removed.

### 3. AgentHub SPA proxy can't launch on macOS/Linux (#64)
`SpaProxyLaunchCommand` hardcoded `cmd.exe /c start-all-spas.cmd`, which cannot run off Windows.

**Fix:** add `start-all-spas.sh` (resolves its own dir via `BASH_SOURCE`, backgrounds Dashboard, foregrounds WebUI, traps cleanup) and select the launcher per OS in the csproj via `$([MSBuild]::IsOSPlatform('Windows'))`.

## Test plan
- New `HarnessHostEnvironmentTests` (3): registration present for console hosts, `TryAdd` doesn't clobber a real environment, shim reports configured environment.
- `dotnet build` clean (0 errors).
- `Presentation.Common.Tests` (98) and Permissions suite (22) green.
- AgentHub builds; Windows still resolves `cmd.exe`, non-Windows resolves `bash start-all-spas.sh`.

Closes #64
Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)