### PR TITLE
feat: stream real model tokens instead of faking the typewriter

### DIFF
--- a/.claude/plans/real-token-streaming.md
+++ b/.claude/plans/real-token-streaming.md
@@ -1,0 +1,99 @@
+# Plan: Real Token Streaming (replace the fake typewriter)
+
+**Status:** Greenlit to draft — NOT built. Needs implementation go-ahead from Matt.
+**Owner decision pending:** approve approach (ambient sink vs callback-on-command) + the go/no-go spike result.
+**Origin:** Gap analysis of the "Streaming Responses from LLMs (SSE, Chunking, UX)" article, 2026-06-19. The article's central premise — show words as the model generates them so the user sees output in ~400ms instead of waiting for the whole response — is the one thing the harness does NOT do.
+
+---
+
+## Problem (plain language)
+
+Today the chat UI *looks* like it streams, but it doesn't. On every message the harness:
+
+1. Waits for the **entire** model response to finish generating (the full multi-second wait, nothing on screen but a thinking indicator).
+2. **Then** chops the finished text into 50-character pieces and replays them to the browser to fake a typewriter effect.
+
+So the user pays the full latency **and then** watches a cosmetic type-out. Perceived latency — the entire point of streaming — is not improved at all. This is the real gap; the markdown-flicker fix already shipped is cosmetic by comparison.
+
+## Current state (verified, with evidence)
+
+- **Fake streaming origin:** `ConversationOrchestrator.DispatchTurnAsync` calls `_mediator.Send(command, ct)` (blocking, full response) at `ConversationOrchestrator.cs:266`, then fake-streams the finished string at `:295-296` via `StreamChunksAsync` (`:380-389`, fixed 50-char chunks).
+- **Blocking model call:** `ExecuteAgentTurnCommandHandler.Handle` uses `agent.RunAsync(messages, cancellationToken: ct)` at `ExecuteAgentTurnCommandHandler.cs:115` — returns the complete response, then runs all observability/usage/snapshot work after it.
+- **Transport callback already exists:** the hub already passes a per-chunk callback down — `AgentTelemetryHub.cs:165-166` (`SendMessage`), `:191-192` (`RetryFromMessage`), `:220-221` (`EditAndResubmit`) → `IConversationOrchestrator.*Async(..., Func<string,CancellationToken,Task>? onChunk, ...)`. The plumbing to push chunks to the client is in place; only the *source* of the chunks is wrong.
+- **Cancellation already correct:** `Context.ConnectionAborted` → orchestrator → `_mediator.Send(ct)` → `RunAsync(ct)`. A blocking call aborts its HTTP request on cancel, so a user closing the tab does NOT burn tokens. This stays true with streaming (`RunStreamingAsync` takes the same token).
+
+## Feasibility (verified against Microsoft docs, Agent Framework RC2)
+
+- `AIAgent.RunStreamingAsync(IEnumerable<ChatMessage> messages, AgentSession? = null, AgentRunOptions? = null, CancellationToken = default)` returns `IAsyncEnumerable<AgentResponseUpdate>`. Each update is a portion of the response; concatenating `.Text` yields the full text. Source: learn.microsoft.com `microsoft.agents.ai.aiagent.runstreamingasync` (Microsoft.Agents.AI.Abstractions v1.0.0-rc2).
+- The cached agent is exactly this `AIAgent` type (`IAgentConversationCache.GetOrCreateAsync` → `Task<AIAgent>`).
+- **Verify at implement time:** the exact update type name (`AgentResponseUpdate` vs `AgentRunResponseUpdate`) against the *pinned* package version in this repo — RC1→RC2 renamed several `AgentRun*`/`Agent*` types. The existing handler already uses `AgentResponse`/`ChatResponse`, so confirm the streaming sibling name there first.
+
+## Frontend impact: essentially none (verified)
+
+The existing SignalR wire contract already supports real streaming with no UI change for the happy path:
+- `TokenReceived {token, isComplete:false}` → client appends to live `streamingContent` (`useChatStore.ts:64`).
+- `TokenReceived {isComplete:true}` is **ignored** by the client (`useAgentHub.tsx:72`) — so the hub's existing final full-text token is a harmless no-op (no doubling).
+- `TurnComplete {fullResponse}` → `finalizeStream` **replaces** the live buffer with the authoritative full message (`useChatStore.ts:68`).
+
+So real per-token deltas simply replace the fake 50-char slices on the same wire. The already-shipped `completeStreamingMarkdown` fix covers incomplete code fences during real streaming too.
+
+---
+
+## Approach
+
+### Recommended: ambient streaming sink (mirrors the existing `LlmUsageCapture.Current` pattern)
+
+The only real problem is getting per-token deltas *out* of the MediatR handler (where `RunStreamingAsync` must live, alongside usage capture + observability) and back to the orchestrator's `onChunk` callback — across the request/response MediatR boundary.
+
+Mirror the ambient pattern the handler already uses for usage capture (`ExecuteAgentTurnCommandHandler.cs:109` sets `LlmUsageCapture.Current = _usageCapture;`):
+
+1. **New seam** `IAgentTurnStreamSink` (Application interface) with an `AsyncLocal`-backed ambient `Current`, exposing `Task EmitAsync(string delta, CancellationToken ct)` and a `bool IsActive`. Place: `Application.AI.Common/Interfaces/` + a small default impl.
+2. **Orchestrator (Presentation)** sets the ambient sink to wrap the hub's `onChunk` before `_mediator.Send`, clears it in `finally`. The command record stays pure data.
+3. **Handler** branches: if `IAgentTurnStreamSink.Current?.IsActive == true`, run `RunStreamingAsync`, accumulate `update.Text` into a `StringBuilder`, and `await sink.EmitAsync(delta, ct)` per non-empty delta; else keep `RunAsync` (preserves the test path and non-interactive callers). After the loop, build the same `responseText` + take the usage snapshot exactly as today, so all downstream observability/snapshot/history code is unchanged.
+4. **Orchestrator** deletes `StreamChunksAsync` and the `if (onChunk is not null) await StreamChunksAsync(...)` block (`:295-296`); chunks now originate in the handler. `EmitTurnEventsAsync` stays as-is (final `TurnComplete` remains authoritative).
+
+Why this approach: keeps the MediatR command serialization-safe and cache-key-safe, keeps **all** observability/usage logic in one place (the handler), follows a convention already proven in this exact file, and degrades gracefully to blocking when no sink is set.
+
+### Alternative: callback on the command
+
+Add `Func<string,CancellationToken,Task>? OnTokenDelta` to `ExecuteAgentTurnCommand`. Simpler to read, but puts a delegate on a MediatR record that implements `IContentScreenable`/`IConsumesTokens` (breaks record value-equality; risks any cache-key/behavior that inspects the command). Documented as the fallback if the ambient seam is rejected.
+
+---
+
+## Key risks (in priority order)
+
+1. **GO/NO-GO SPIKE — RESOLVED 2026-06-19. Streaming path drops token/cost today, BUT the fix is bounded (not a blocker).**
+   - **Confirmed broken:** `ObservabilityMiddleware.GetStreamingResponseAsync` (`ObservabilityMiddleware.cs:84-103`) records NOTHING. Its own comment (`:100-102`) says: *"ChatResponseUpdate does not expose UsageDetails — token usage is not captured for streaming calls. When accurate usage tracking is required, prefer the non-streaming GetResponseAsync path."* The blocking path (`:53-81`) records usage from `response.Usage`. A naive switch to streaming = silently zeroed tokens/cost. **Naive switch is NO-GO.**
+   - **That comment is outdated.** Verified against Microsoft.Extensions.AI v10.7: streaming usage IS recoverable — it arrives as a `UsageContent : AIContent` item inside the final chunk's `Contents`. Two clean capture options inside the middleware `await foreach`: (a) detect `UsageContent` in `chunk.Contents` and `Record(...)` (same shape as the blocking block), or (b) accumulate updates and call `ChatResponseExtensions.ToChatResponse(updates)` after the loop, then read `.Usage` exactly like `GetResponseAsync` does today.
+   - **Net:** the usage-capture fix is ONE method in ONE file (`ObservabilityMiddleware.GetStreamingResponseAsync`), additive, mirroring existing code — not an architecture change. In-scope for this PR, done FIRST, with a test asserting a streamed turn records the same non-zero tokens/cost as the blocking turn.
+   - **Residual runtime validation (not a blocker):** streaming usage only arrives if the provider emits it. OpenAI/Azure OpenAI need a `StreamOptions.IncludeUsage`-equivalent; the harness's Azure AI Foundry Anthropic endpoint should surface usage in its stream-delta — confirm with one real streamed call that `UsageContent` is present. Fall back to `ToChatResponse().Usage` if a provider's per-chunk emission is absent. Decide per provider at implement time.
+2. **Tool-call turns:** `RunStreamingAsync` interleaves tool-call activity with text updates. Confirm `update.Text` yields only assistant text deltas (so tool-call chatter isn't streamed as visible text) and that tool names still surface via the ambient `LlmUsageCapture` exactly as in the blocking path. Multi-step tool chains must still produce a coherent streamed answer.
+3. **Mid-stream failure:** if the model errors after N tokens, the client holds partial text. Today `Error` clears the stream. Decide: keep current behavior (clear + generic error) or add a "response interrupted" affordance (optional follow-up, not blocking).
+4. **Ordering vs `SpanReceived`/`ToolCallStarted`:** those events come from the OTel bridge on a different path; confirm real streaming doesn't reorder them relative to text in a way the UI mishandles.
+
+## Files to touch
+
+- `Application.AI.Common/Interfaces/IAgentTurnStreamSink.cs` (new) + default impl.
+- `Application.AI.Common/DependencyInjection.cs` — register the sink.
+- `Application.Core/CQRS/Agents/ExecuteAgentTurn/ExecuteAgentTurnCommandHandler.cs` — streaming branch + accumulation.
+- `Presentation.AgentHub/Services/ConversationOrchestrator.cs` — set/clear ambient sink; delete `StreamChunksAsync`.
+- (Conditional) the LLM usage/observability middleware — only if the spike shows the streaming path isn't instrumented.
+- Tests (see below).
+
+## Testing plan
+
+- **Handler unit:** with an active fake sink, a stubbed agent that yields 3 updates emits 3 deltas in order and returns the concatenated text + unchanged usage snapshot. With no sink, falls back to `RunAsync` (existing tests stay green).
+- **Orchestrator:** real deltas flow to `onChunk`; `StreamChunksAsync` removal verified (no 50-char artifacts); `TurnComplete.fullResponse` equals the concatenation of streamed deltas.
+- **Usage capture:** a streamed turn records the same non-zero input/output tokens + cost as the equivalent blocking turn (guards risk #1 permanently).
+- **Cancellation:** cancelling mid-stream stops further deltas and does not append a partial assistant message (or appends a clearly-marked partial, per the risk #3 decision).
+- **Tool turn:** a turn that invokes a tool still streams a coherent final answer and records the tool.
+
+## Out of scope (separate optional follow-ups)
+
+- **Render pacing / typewriter queue** (article §Step 2) — smooths bursty deltas; marginal, only matters at very high token rates. Defer.
+- **"Response interrupted, continue" affordance** (article §Step 6) — nice UX, not required for the core win.
+- **Typed inline token events** (a `type` field on each token) — the harness already uses separate typed events; not needed.
+
+## Already shipped (related)
+
+- Markdown-flicker fix: `completeStreamingMarkdown.ts` + wiring in `Markdown.tsx`/`MessageItem.tsx` (9 tests). Helps both the current fake stream and future real streaming.

--- a/src/Content/Application/Application.AI.Common/Interfaces/IAgentTurnStreamSink.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/IAgentTurnStreamSink.cs
@@ -1,0 +1,26 @@
+namespace Application.AI.Common.Interfaces;
+
+/// <summary>
+/// Ambient seam that lets the agent-turn handler push assistant text deltas to the
+/// active transport (e.g. a SignalR connection) as the model generates them, without
+/// the Application layer taking a dependency on any transport.
+/// </summary>
+/// <remarks>
+/// The transport (the Presentation-layer orchestrator) attaches a sink before
+/// dispatching the turn; the handler reads the ambient sink to decide between
+/// streaming (<c>RunStreamingAsync</c>) and blocking (<c>RunAsync</c>) execution.
+/// When no sink is attached the handler runs blocking, so non-interactive callers
+/// (tests, batch jobs) keep their existing behaviour. Mirrors the ambient pattern of
+/// <see cref="Services.LlmUsageCapture.Current"/>.
+/// </remarks>
+public interface IAgentTurnStreamSink
+{
+    /// <summary>
+    /// Emits a single assistant text delta to the attached consumer. Empty deltas are
+    /// ignored. Honours <paramref name="cancellationToken"/> so a disconnected consumer
+    /// stops the stream promptly.
+    /// </summary>
+    /// <param name="delta">The newly generated assistant text fragment.</param>
+    /// <param name="cancellationToken">Cancels emission when the consumer goes away.</param>
+    Task EmitAsync(string delta, CancellationToken cancellationToken);
+}

--- a/src/Content/Application/Application.AI.Common/Middleware/ObservabilityMiddleware.cs
+++ b/src/Content/Application/Application.AI.Common/Middleware/ObservabilityMiddleware.cs
@@ -60,22 +60,7 @@ public sealed class ObservabilityMiddleware : DelegatingChatClient
 
         var response = await base.GetResponseAsync(messageList, options, cancellationToken);
 
-        if (response.Usage is { } usage)
-        {
-            _logger.LogInformation(
-                "Token usage — Input: {InputTokens}, Output: {OutputTokens}, Total: {TotalTokens}",
-                usage.InputTokenCount,
-                usage.OutputTokenCount,
-                usage.TotalTokenCount);
-
-            var inputTokens = (int)Math.Min(usage.InputTokenCount ?? 0, int.MaxValue);
-            var outputTokens = (int)Math.Min(usage.OutputTokenCount ?? 0, int.MaxValue);
-            var cacheRead = GetAdditionalCount(usage, "cache_read_input_tokens");
-            var cacheWrite = GetAdditionalCount(usage, "cache_creation_input_tokens");
-            var model = options?.ModelId;
-
-            (_usageCapture ?? LlmUsageCapture.Current)?.Record(inputTokens, outputTokens, cacheRead, cacheWrite, model);
-        }
+        RecordUsage(response, options);
 
         return response;
     }
@@ -89,17 +74,43 @@ public sealed class ObservabilityMiddleware : DelegatingChatClient
         var messageList = messages as ICollection<ChatMessage> ?? messages.ToList();
         _logger.LogInformation("Invoking streaming ChatClient with {MessageCount} messages", messageList.Count);
 
-        int chunkCount = 0;
+        // Accumulate updates so usage capture matches the non-streaming path exactly.
+        // Streaming providers emit token counts as a UsageContent item in the final
+        // chunk; ToChatResponse() coalesces the stream and surfaces it as Usage.
+        var updates = new List<ChatResponseUpdate>();
         await foreach (var chunk in base.GetStreamingResponseAsync(messageList, options, cancellationToken))
         {
-            chunkCount++;
+            updates.Add(chunk);
             _logger.LogDebug("Received chunk with {ContentCount} content item(s)", chunk.Contents?.Count ?? 0);
             yield return chunk;
         }
 
-        // ChatResponseUpdate does not expose UsageDetails — token usage is not captured for streaming calls.
-        // When accurate usage tracking is required, prefer the non-streaming GetResponseAsync path.
-        _logger.LogDebug("Streaming completed: {ChunkCount} chunks. Token usage unavailable for streaming path", chunkCount);
+        _logger.LogDebug("Streaming completed: {ChunkCount} chunks", updates.Count);
+        RecordUsage(updates.ToChatResponse(), options);
+    }
+
+    /// <summary>
+    /// Logs and records token usage from a (possibly stream-reconstructed) response.
+    /// Shared by the streaming and non-streaming paths so both capture identically.
+    /// </summary>
+    private void RecordUsage(ChatResponse response, ChatOptions? options)
+    {
+        if (response.Usage is not { } usage)
+            return;
+
+        _logger.LogInformation(
+            "Token usage — Input: {InputTokens}, Output: {OutputTokens}, Total: {TotalTokens}",
+            usage.InputTokenCount,
+            usage.OutputTokenCount,
+            usage.TotalTokenCount);
+
+        var inputTokens = (int)Math.Min(usage.InputTokenCount ?? 0, int.MaxValue);
+        var outputTokens = (int)Math.Min(usage.OutputTokenCount ?? 0, int.MaxValue);
+        var cacheRead = GetAdditionalCount(usage, "cache_read_input_tokens");
+        var cacheWrite = GetAdditionalCount(usage, "cache_creation_input_tokens");
+        var model = options?.ModelId;
+
+        (_usageCapture ?? LlmUsageCapture.Current)?.Record(inputTokens, outputTokens, cacheRead, cacheWrite, model);
     }
 
     private static int GetAdditionalCount(UsageDetails usage, string key)

--- a/src/Content/Application/Application.AI.Common/Middleware/ToolDiagnosticsMiddleware.cs
+++ b/src/Content/Application/Application.AI.Common/Middleware/ToolDiagnosticsMiddleware.cs
@@ -149,16 +149,24 @@ public sealed class ToolDiagnosticsMiddleware : DelegatingChatClient
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         options = DeduplicateTools(options);
+        var toolsWereConfigured = options?.Tools is { Count: > 0 };
         LogToolsInOptions(options, nameof(GetStreamingResponseAsync));
 
         // Unconditional: records tool stdout via LlmUsageCapture even when the trace
         // writer is null (the writer is null-checked inside the method).
         await AppendFunctionResultTracesAsync(messages, cancellationToken);
 
+        // Accumulate updates so tool-call capture (names, args, call ids) matches the
+        // non-streaming path. ToChatResponse() coalesces the stream into the same
+        // ChatResponse shape LogToolCallsInResponse already understands.
+        var updates = new List<ChatResponseUpdate>();
         await foreach (var chunk in base.GetStreamingResponseAsync(messages, options, cancellationToken))
         {
+            updates.Add(chunk);
             yield return chunk;
         }
+
+        LogToolCallsInResponse(updates.ToChatResponse(), toolsWereConfigured);
     }
 
     private void LogToolsInOptions(ChatOptions? options, string method)

--- a/src/Content/Application/Application.AI.Common/Services/AgentTurnStreamSink.cs
+++ b/src/Content/Application/Application.AI.Common/Services/AgentTurnStreamSink.cs
@@ -1,0 +1,42 @@
+using Application.AI.Common.Interfaces;
+
+namespace Application.AI.Common.Services;
+
+/// <summary>
+/// Ambient holder plus delegate-backed implementation of <see cref="IAgentTurnStreamSink"/>.
+/// Mirrors the <see cref="LlmUsageCapture.Current"/> <see cref="AsyncLocal{T}"/> pattern: the
+/// transport (orchestrator) sets <see cref="Current"/> to a sink wrapping its per-chunk
+/// callback before dispatching the turn, and the handler reads <see cref="Current"/> to choose
+/// streaming over blocking execution. Flowing the sink ambiently keeps the MediatR command a
+/// pure data record (no delegate that would break value-equality or cache keys).
+/// </summary>
+public sealed class AgentTurnStreamSink : IAgentTurnStreamSink
+{
+    private static readonly AsyncLocal<IAgentTurnStreamSink?> s_current = new();
+
+    /// <summary>
+    /// The sink attached to the current async flow, or <c>null</c> when the turn has no live
+    /// consumer (tests, batch jobs). Set by the transport before dispatch; cleared afterward.
+    /// </summary>
+    public static IAgentTurnStreamSink? Current
+    {
+        get => s_current.Value;
+        set => s_current.Value = value;
+    }
+
+    private readonly Func<string, CancellationToken, Task> _onDelta;
+
+    /// <summary>
+    /// Creates a sink that forwards each assistant text delta to <paramref name="onDelta"/>.
+    /// </summary>
+    /// <param name="onDelta">The transport callback invoked per text delta.</param>
+    public AgentTurnStreamSink(Func<string, CancellationToken, Task> onDelta)
+    {
+        ArgumentNullException.ThrowIfNull(onDelta);
+        _onDelta = onDelta;
+    }
+
+    /// <inheritdoc />
+    public Task EmitAsync(string delta, CancellationToken cancellationToken) =>
+        string.IsNullOrEmpty(delta) ? Task.CompletedTask : _onDelta(delta, cancellationToken);
+}

--- a/src/Content/Application/Application.Core/CQRS/Agents/ExecuteAgentTurn/ExecuteAgentTurnCommandHandler.cs
+++ b/src/Content/Application/Application.Core/CQRS/Agents/ExecuteAgentTurn/ExecuteAgentTurnCommandHandler.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
+using System.Text;
 using System.Text.Json;
 using Application.AI.Common.Exceptions;
 using Application.AI.Common.Helpers;
@@ -112,7 +113,15 @@ public class ExecuteAgentTurnCommandHandler : IRequestHandler<ExecuteAgentTurnCo
 			var turnSw = Stopwatch.StartNew();
 			try
 			{
-				response = await agent.RunAsync(messages, cancellationToken: cancellationToken);
+				// When a transport has attached a streaming sink, stream assistant text
+				// deltas as the model generates them (real perceived-latency win). Usage
+				// and tool capture still flow through the chat-client middleware, so the
+				// post-turn accounting below is identical to the blocking path. With no
+				// sink (tests, batch callers) fall back to a single blocking call.
+				var streamSink = AgentTurnStreamSink.Current;
+				response = streamSink is not null
+					? await RunStreamingTurnAsync(agent, messages, streamSink, cancellationToken)
+					: await agent.RunAsync(messages, cancellationToken: cancellationToken);
 				turnSw.Stop();
 			}
 			finally
@@ -280,6 +289,34 @@ public class ExecuteAgentTurnCommandHandler : IRequestHandler<ExecuteAgentTurnCo
 				ErrorKind = AgentTurnErrorKind.Internal
 			};
 		}
+	}
+
+	/// <summary>
+	/// Runs the turn in streaming mode, emitting each assistant text delta to
+	/// <paramref name="sink"/> as it arrives and returning the concatenated full text.
+	/// Tool invocation, usage, and tool-call capture happen transparently in the
+	/// chat-client middleware pipeline (which instruments the streaming path), so the
+	/// caller's post-turn accounting is unchanged. The same <paramref name="cancellationToken"/>
+	/// flows to <c>RunStreamingAsync</c>, so a disconnected consumer aborts the model call.
+	/// </summary>
+	private static async Task<string> RunStreamingTurnAsync(
+		AIAgent agent,
+		IReadOnlyList<ChatMessage> messages,
+		IAgentTurnStreamSink sink,
+		CancellationToken cancellationToken)
+	{
+		var builder = new StringBuilder();
+		await foreach (var update in agent.RunStreamingAsync(messages, cancellationToken: cancellationToken))
+		{
+			var delta = update.Text;
+			if (string.IsNullOrEmpty(delta))
+				continue;
+
+			builder.Append(delta);
+			await sink.EmitAsync(delta, cancellationToken);
+		}
+
+		return builder.ToString();
 	}
 
 	private static void RecordTurnError(string agentName)

--- a/src/Content/Presentation/Presentation.AgentHub/Services/ConversationOrchestrator.cs
+++ b/src/Content/Presentation/Presentation.AgentHub/Services/ConversationOrchestrator.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using Application.AI.Common.Exceptions;
 using Application.AI.Common.Interfaces;
 using Application.AI.Common.OpenTelemetry.Metrics;
+using Application.AI.Common.Services;
 using Application.Core.CQRS.Agents.ExecuteAgentTurn;
 using Domain.AI.Telemetry.Conventions;
 using MediatR;
@@ -260,7 +261,14 @@ public sealed class ConversationOrchestrator : IConversationOrchestrator
             ObservabilitySessionId = obsSessionId,
         };
 
+        // Attach the streaming sink so the agent-turn handler streams real model token
+        // deltas to the caller as they arrive. Flowing it ambiently (AsyncLocal) keeps the
+        // MediatR command a pure data record. Restored in finally so nested/subsequent
+        // dispatches on this async flow are unaffected.
         AgentTurnResult result;
+        var previousSink = AgentTurnStreamSink.Current;
+        if (onChunk is not null)
+            AgentTurnStreamSink.Current = new AgentTurnStreamSink(onChunk);
         try
         {
             result = await _mediator.Send(command, ct);
@@ -270,6 +278,10 @@ public sealed class ConversationOrchestrator : IConversationOrchestrator
             _healthTracker.RecordError(agentName);
             var kind = ex is AiProviderNotConfiguredException ? AgentTurnErrorKind.Configuration : AgentTurnErrorKind.Internal;
             return await HandleTurnErrorAsync(conversationId, ex, kind, ct);
+        }
+        finally
+        {
+            AgentTurnStreamSink.Current = previousSink;
         }
 
         if (!result.Success)
@@ -292,9 +304,8 @@ public sealed class ConversationOrchestrator : IConversationOrchestrator
 
         await UpdateSessionMetricsAsync(sessionKey, result);
 
-        if (onChunk is not null)
-            await StreamChunksAsync(result.Response, onChunk, ct);
-
+        // Token deltas were already streamed to the caller during dispatch via the
+        // ambient AgentTurnStreamSink. The final authoritative text rides TurnComplete.
         var assistantMessageId = Guid.NewGuid();
         var assistantMsg = new ConversationMessage(
             assistantMessageId, MessageRole.Assistant, result.Response, DateTimeOffset.UtcNow);
@@ -374,17 +385,6 @@ public sealed class ConversationOrchestrator : IConversationOrchestrator
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
             _logger.LogWarning(ex, "Failed to persist session metrics for session {SessionId}", updated.ObservabilitySessionId);
-        }
-    }
-
-    private static async Task StreamChunksAsync(
-        string response, Func<string, CancellationToken, Task> onChunk, CancellationToken ct)
-    {
-        const int chunkSize = 50;
-        for (var i = 0; i < response.Length; i += chunkSize)
-        {
-            var chunk = response.Substring(i, Math.Min(chunkSize, response.Length - i));
-            await onChunk(chunk, ct);
         }
     }
 

--- a/src/Content/Presentation/Presentation.WebUI/src/features/chat/Markdown.tsx
+++ b/src/Content/Presentation/Presentation.WebUI/src/features/chat/Markdown.tsx
@@ -4,6 +4,7 @@ import rehypeSanitize, { defaultSchema } from 'rehype-sanitize';
 import rehypeHighlight from 'rehype-highlight';
 import 'highlight.js/styles/github-dark.css';
 import { CodeBlock } from './CodeBlock';
+import { completeStreamingMarkdown } from './completeStreamingMarkdown';
 
 const sanitizeSchema = {
   ...defaultSchema,
@@ -16,9 +17,16 @@ const sanitizeSchema = {
 
 interface MarkdownProps {
   content: string;
+  /**
+   * When the message is still streaming, close any dangling code fence so an
+   * in-progress code block renders as a styled block instead of flickering as
+   * raw backticks until its closing fence arrives. No-op for finished messages.
+   */
+  isStreaming?: boolean;
 }
 
-export function Markdown({ content }: MarkdownProps) {
+export function Markdown({ content, isStreaming = false }: MarkdownProps) {
+  const source = isStreaming ? completeStreamingMarkdown(content) : content;
   return (
     <div className="markdown-body prose prose-sm prose-invert max-w-none break-words text-foreground">
       <ReactMarkdown
@@ -83,7 +91,7 @@ export function Markdown({ content }: MarkdownProps) {
           hr: () => <hr className="my-4 border-border/50" />,
         }}
       >
-        {content}
+        {source}
       </ReactMarkdown>
     </div>
   );

--- a/src/Content/Presentation/Presentation.WebUI/src/features/chat/MessageItem.tsx
+++ b/src/Content/Presentation/Presentation.WebUI/src/features/chat/MessageItem.tsx
@@ -204,7 +204,7 @@ export function MessageItem({
           ) : isUser ? (
             <p className="whitespace-pre-wrap">{message.content}</p>
           ) : (
-            <Markdown content={message.content} />
+            <Markdown content={message.content} isStreaming={isStreaming} />
           )}
 
           {isStreaming && (

--- a/src/Content/Presentation/Presentation.WebUI/src/features/chat/__tests__/completeStreamingMarkdown.test.ts
+++ b/src/Content/Presentation/Presentation.WebUI/src/features/chat/__tests__/completeStreamingMarkdown.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { completeStreamingMarkdown } from '../completeStreamingMarkdown';
+
+describe('completeStreamingMarkdown', () => {
+  it('closes a dangling backtick code fence so it parses as a code block now', () => {
+    // The flicker case: opening fence has arrived, closing fence has not.
+    const partial = 'Here is some code:\n```ts\nconst x = 1;';
+    expect(completeStreamingMarkdown(partial)).toBe(
+      'Here is some code:\n```ts\nconst x = 1;\n```',
+    );
+  });
+
+  it('closes a dangling tilde fence with a tilde closer', () => {
+    const partial = '~~~\nplain block';
+    expect(completeStreamingMarkdown(partial)).toBe('~~~\nplain block\n~~~');
+  });
+
+  it('leaves a balanced code fence unchanged (no-op for completed content)', () => {
+    const complete = 'before\n```ts\nconst x = 1;\n```\nafter';
+    expect(completeStreamingMarkdown(complete)).toBe(complete);
+  });
+
+  it('does not append a separating newline when content already ends in one', () => {
+    const partial = '```\ncode\n';
+    expect(completeStreamingMarkdown(partial)).toBe('```\ncode\n```');
+  });
+
+  it('ignores triple backticks that appear mid-line in prose', () => {
+    // Not a fence — it is not at the start of a line, so nothing is opened.
+    const prose = 'Use the ``` syntax to start a block.';
+    expect(completeStreamingMarkdown(prose)).toBe(prose);
+  });
+
+  it('treats an indented fence as a fence (leading whitespace allowed)', () => {
+    const partial = '- item\n  ```\n  code';
+    expect(completeStreamingMarkdown(partial)).toBe('- item\n  ```\n  code\n```');
+  });
+
+  it('does not treat a tilde close as closing a backtick fence', () => {
+    // Different marker families do not pair — the backtick fence stays open.
+    const partial = '```\ncode\n~~~';
+    expect(completeStreamingMarkdown(partial)).toBe('```\ncode\n~~~\n```');
+  });
+
+  it('returns empty string unchanged', () => {
+    expect(completeStreamingMarkdown('')).toBe('');
+  });
+
+  it('leaves plain prose with no fences unchanged', () => {
+    const text = 'Just a normal sentence with no code.';
+    expect(completeStreamingMarkdown(text)).toBe(text);
+  });
+});

--- a/src/Content/Presentation/Presentation.WebUI/src/features/chat/completeStreamingMarkdown.ts
+++ b/src/Content/Presentation/Presentation.WebUI/src/features/chat/completeStreamingMarkdown.ts
@@ -1,0 +1,53 @@
+/**
+ * Stabilises partially-streamed markdown so an in-progress fenced code block
+ * renders as a (growing) code block instead of flickering as raw ``` / ~~~
+ * delimiters until its closing fence finally arrives.
+ *
+ * While a response streams in, the markdown is re-parsed on every chunk. An
+ * opening code fence with no matching close parses as literal backticks, then
+ * snaps into a styled block once the close arrives — a visible flicker on any
+ * code-heavy answer. Closing the dangling fence ourselves makes the parser
+ * treat the in-progress text as a code block immediately.
+ *
+ * Only the unclosed-fence case is handled — that is the dominant visible
+ * offender during streaming. When all fences are balanced (well-formed or
+ * completed content) the input is returned unchanged, so this is a no-op for
+ * finished messages.
+ *
+ * Inline code spans (single backticks) are intentionally out of scope: they
+ * almost always open and close within a single streamed chunk, so they don't
+ * produce a sustained flicker.
+ *
+ * @param content The accumulated markdown received so far.
+ * @returns The content with any dangling code fence closed; unchanged when balanced.
+ */
+export function completeStreamingMarkdown(content: string): string {
+  if (!content) return content;
+
+  // A fence is a line whose first non-whitespace characters are ``` or ~~~.
+  // Counting line-anchored fences (rather than every ``` occurrence) avoids
+  // miscounting triple backticks that appear mid-line inside prose.
+  const fencePattern = /^[ \t]*(`{3,}|~{3,})/;
+
+  // Tracks the marker family (` or ~) of the currently open fence, or null when
+  // no fence is open. A fence only closes against the same family.
+  let openFence: string | null = null;
+
+  for (const line of content.split('\n')) {
+    const match = fencePattern.exec(line);
+    if (match === null) continue;
+
+    const marker = match[1][0]; // ` or ~
+    if (openFence === null) {
+      openFence = marker;
+    } else if (openFence === marker) {
+      openFence = null;
+    }
+  }
+
+  if (openFence === null) return content;
+
+  const closer = openFence === '`' ? '```' : '~~~';
+  const separator = content.endsWith('\n') ? '' : '\n';
+  return `${content}${separator}${closer}`;
+}

--- a/src/Content/Tests/Application.AI.Common.Tests/Fakes/FakeChatClient.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Fakes/FakeChatClient.cs
@@ -41,6 +41,19 @@ public sealed class FakeChatClient : IChatClient
         return this;
     }
 
+    /// <summary>
+    /// Enqueues a response whose assistant message carries a tool call, for tool-capture tests.
+    /// </summary>
+    public FakeChatClient EnqueueResponseWithToolCall(string toolName, string callId)
+    {
+        var message = new ChatMessage(ChatRole.Assistant, new List<AIContent>
+        {
+            new FunctionCallContent(callId, toolName, new Dictionary<string, object?>())
+        });
+        _responses.Enqueue(new ChatResponse(message));
+        return this;
+    }
+
     /// <inheritdoc />
     public Task<ChatResponse> GetResponseAsync(
         IEnumerable<ChatMessage> messages,
@@ -60,8 +73,16 @@ public sealed class FakeChatClient : IChatClient
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         var response = await GetResponseAsync(messages, options, cancellationToken);
-        var text = string.Join("", response.Messages.Select(m => m.Text));
-        yield return new ChatResponseUpdate(ChatRole.Assistant, text);
+
+        // Stream each content item (text, tool calls) as its own update so middleware
+        // reconstructing via ToChatResponse() sees the same shape as the blocking path.
+        foreach (var message in response.Messages)
+            foreach (var content in message.Contents)
+                yield return new ChatResponseUpdate(message.Role, new List<AIContent> { content });
+
+        // Mirror real providers: token usage arrives as a UsageContent item in a final chunk.
+        if (response.Usage is { } usage)
+            yield return new ChatResponseUpdate(ChatRole.Assistant, new List<AIContent> { new UsageContent(usage) });
     }
 
     /// <inheritdoc />

--- a/src/Content/Tests/Application.AI.Common.Tests/Integration/MiddlewarePipelineIntegrationTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Integration/MiddlewarePipelineIntegrationTests.cs
@@ -1,4 +1,6 @@
+using Application.AI.Common.Interfaces;
 using Application.AI.Common.Middleware;
+using Application.AI.Common.Services;
 using Application.AI.Common.Tests.Fakes;
 using FluentAssertions;
 using Microsoft.Extensions.AI;
@@ -63,6 +65,54 @@ public class MiddlewarePipelineIntegrationTests
         }
 
         chunks.Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public async Task ObservabilityMiddleware_StreamingResponse_CapturesTokenUsage()
+    {
+        // Guards the streaming usage-capture fix: a streamed response must record the
+        // same token usage the blocking path would, via the final UsageContent chunk.
+        var usageCapture = new Mock<ILlmUsageCapture>();
+        var fakeClient = new FakeChatClient();
+        fakeClient.EnqueueResponseWithUsage("streamed reply", inputTokens: 100, outputTokens: 50);
+
+        var middleware = new ObservabilityMiddleware(
+            fakeClient, NullLogger<ObservabilityMiddleware>.Instance, usageCapture.Object);
+
+        var messages = new List<ChatMessage> { new(ChatRole.User, "Stream this") };
+        await foreach (var _ in middleware.GetStreamingResponseAsync(messages)) { }
+
+        usageCapture.Verify(
+            c => c.Record(100, 50, 0, 0, It.IsAny<string?>()),
+            Times.Once,
+            "streaming path must record token usage like the blocking path");
+    }
+
+    [Fact]
+    public async Task ToolDiagnosticsMiddleware_StreamingResponse_CapturesToolCalls()
+    {
+        // Guards the streaming tool-capture fix: a tool call in a streamed response must
+        // be recorded (name + request) just as the blocking path records it.
+        var capture = new Mock<ILlmUsageCapture>();
+        LlmUsageCapture.Current = capture.Object;
+        try
+        {
+            var fakeClient = new FakeChatClient();
+            fakeClient.EnqueueResponseWithToolCall("test_tool", "call-1");
+
+            var middleware = new ToolDiagnosticsMiddleware(
+                fakeClient, NullLogger<ToolDiagnosticsMiddleware>.Instance);
+
+            var messages = new List<ChatMessage> { new(ChatRole.User, "Use a tool") };
+            await foreach (var _ in middleware.GetStreamingResponseAsync(messages)) { }
+
+            capture.Verify(c => c.RecordToolCall("test_tool"), Times.Once);
+            capture.Verify(c => c.RecordToolRequest("call-1", "test_tool", It.IsAny<string?>()), Times.Once);
+        }
+        finally
+        {
+            LlmUsageCapture.Current = null;
+        }
     }
 
     [Fact]

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/AgentTurnStreamSinkTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/AgentTurnStreamSinkTests.cs
@@ -1,0 +1,59 @@
+using Application.AI.Common.Services;
+using FluentAssertions;
+using Xunit;
+
+namespace Application.AI.Common.Tests.Services;
+
+/// <summary>
+/// Unit tests for <see cref="AgentTurnStreamSink"/> — the ambient, delegate-backed sink
+/// the orchestrator attaches so the agent-turn handler streams token deltas to the transport.
+/// </summary>
+public class AgentTurnStreamSinkTests
+{
+    [Fact]
+    public async Task EmitAsync_ForwardsDelta_ToTheCallback()
+    {
+        var received = new List<string>();
+        var sink = new AgentTurnStreamSink((delta, _) => { received.Add(delta); return Task.CompletedTask; });
+
+        await sink.EmitAsync("Hello ", CancellationToken.None);
+        await sink.EmitAsync("world", CancellationToken.None);
+
+        received.Should().Equal("Hello ", "world");
+    }
+
+    [Fact]
+    public async Task EmitAsync_IgnoresEmptyDelta_WithoutInvokingTheCallback()
+    {
+        var invoked = false;
+        var sink = new AgentTurnStreamSink((_, _) => { invoked = true; return Task.CompletedTask; });
+
+        await sink.EmitAsync("", CancellationToken.None);
+
+        invoked.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Constructor_NullCallback_Throws()
+    {
+        var act = () => new AgentTurnStreamSink(null!);
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void Current_IsNullByDefault_AndRoundTrips()
+    {
+        AgentTurnStreamSink.Current.Should().BeNull();
+
+        var sink = new AgentTurnStreamSink((_, _) => Task.CompletedTask);
+        AgentTurnStreamSink.Current = sink;
+        try
+        {
+            AgentTurnStreamSink.Current.Should().BeSameAs(sink);
+        }
+        finally
+        {
+            AgentTurnStreamSink.Current = null;
+        }
+    }
+}

--- a/src/Content/Tests/Application.Core.Tests/CQRS/ExecuteAgentTurnCommandHandlerTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/CQRS/ExecuteAgentTurnCommandHandlerTests.cs
@@ -84,6 +84,63 @@ public class ExecuteAgentTurnCommandHandlerTests
     }
 
     [Fact]
+    public async Task Handle_ActiveStreamSink_StreamsDeltasAndReturnsConcatenatedText()
+    {
+        // Arrange — multi-chunk streaming agent + an attached sink.
+        var agent = TestableAIAgent.Streaming("Hello ", "from ", "the agent");
+        _agentCache
+            .Setup(c => c.GetOrCreateAsync(
+                It.IsAny<string>(),
+                It.IsAny<IReadOnlyList<string>>(),
+                It.IsAny<SkillAgentOptions>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(agent);
+
+        var deltas = new List<string>();
+        Application.AI.Common.Services.AgentTurnStreamSink.Current =
+            new Application.AI.Common.Services.AgentTurnStreamSink(
+                (delta, _) => { deltas.Add(delta); return Task.CompletedTask; });
+
+        try
+        {
+            // Act
+            var result = await _handler.Handle(CreateCommand(), CancellationToken.None);
+
+            // Assert — each delta streamed in order; full text is their concatenation.
+            deltas.Should().Equal("Hello ", "from ", "the agent");
+            result.Success.Should().BeTrue();
+            result.Response.Should().Be("Hello from the agent");
+        }
+        finally
+        {
+            Application.AI.Common.Services.AgentTurnStreamSink.Current = null;
+        }
+    }
+
+    [Fact]
+    public async Task Handle_NoStreamSink_DoesNotStream_AndStillReturnsResponse()
+    {
+        // Arrange — sink is null (default), so the handler uses the blocking path.
+        var agent = TestableAIAgent.Streaming("A", "B");
+        _agentCache
+            .Setup(c => c.GetOrCreateAsync(
+                It.IsAny<string>(),
+                It.IsAny<IReadOnlyList<string>>(),
+                It.IsAny<SkillAgentOptions>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(agent);
+
+        Application.AI.Common.Services.AgentTurnStreamSink.Current.Should().BeNull();
+
+        // Act
+        var result = await _handler.Handle(CreateCommand(), CancellationToken.None);
+
+        // Assert — blocking path returns the full text without a sink.
+        result.Success.Should().BeTrue();
+        result.Response.Should().Be("AB");
+    }
+
+    [Fact]
     public async Task Handle_ValidRequest_UpdatedHistoryContainsUserAndAssistantMessages()
     {
         // Arrange

--- a/src/Content/Tests/Application.Core.Tests/Helpers/TestableAIAgent.cs
+++ b/src/Content/Tests/Application.Core.Tests/Helpers/TestableAIAgent.cs
@@ -12,6 +12,7 @@ namespace Application.Core.Tests.Helpers;
 public sealed class TestableAIAgent : AIAgent
 {
     private readonly Func<IEnumerable<ChatMessage>, CancellationToken, Task<AgentResponse>> _runHandler;
+    private readonly IReadOnlyList<string>? _streamingChunks;
 
     public TestableAIAgent(string responseText)
         : this(_ => new AgentResponse(new ChatMessage(ChatRole.Assistant, responseText)))
@@ -24,8 +25,29 @@ public sealed class TestableAIAgent : AIAgent
     }
 
     public TestableAIAgent(Func<IEnumerable<ChatMessage>, CancellationToken, Task<AgentResponse>> handler)
+        : this(handler, streamingChunks: null)
+    {
+    }
+
+    private TestableAIAgent(
+        Func<IEnumerable<ChatMessage>, CancellationToken, Task<AgentResponse>> handler,
+        IReadOnlyList<string>? streamingChunks)
     {
         _runHandler = handler;
+        _streamingChunks = streamingChunks;
+    }
+
+    /// <summary>
+    /// Creates a TestableAIAgent that emits the given <paramref name="chunks"/> as distinct
+    /// streaming updates (and their concatenation for the blocking path), so streaming
+    /// callers can assert per-delta emission.
+    /// </summary>
+    public static TestableAIAgent Streaming(params string[] chunks)
+    {
+        var full = string.Concat(chunks);
+        return new TestableAIAgent(
+            (_, _) => Task.FromResult(new AgentResponse(new ChatMessage(ChatRole.Assistant, full))),
+            chunks);
     }
 
     /// <summary>
@@ -51,6 +73,15 @@ public sealed class TestableAIAgent : AIAgent
         AgentRunOptions? options,
         [EnumeratorCancellation] CancellationToken cancellationToken)
     {
+        if (_streamingChunks is not null)
+        {
+            // Surface configured failures (e.g. Throwing) on the streaming path too.
+            await _runHandler(messages, cancellationToken);
+            foreach (var chunk in _streamingChunks)
+                yield return new AgentResponseUpdate(ChatRole.Assistant, chunk);
+            yield break;
+        }
+
         var response = await _runHandler(messages, cancellationToken);
         yield return new AgentResponseUpdate(ChatRole.Assistant, response.Text ?? string.Empty);
     }

--- a/src/Content/Tests/Presentation.AgentHub.Tests/Services/ConversationOrchestratorTests.cs
+++ b/src/Content/Tests/Presentation.AgentHub.Tests/Services/ConversationOrchestratorTests.cs
@@ -1,4 +1,5 @@
 using Application.AI.Common.Interfaces;
+using Application.AI.Common.Services;
 using Application.Core.CQRS.Agents.ExecuteAgentTurn;
 using FluentAssertions;
 using MediatR;
@@ -135,12 +136,23 @@ public class ConversationOrchestratorTests
         _obsStore.Setup(s => s.StartSessionAsync("c1", "agent", null, It.IsAny<CancellationToken>()))
             .ReturnsAsync(Guid.NewGuid());
 
+        // Simulate the handler streaming deltas through the ambient sink the orchestrator
+        // attaches for the duration of the dispatch.
         _mediator.Setup(m => m.Send(It.IsAny<ExecuteAgentTurnCommand>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new AgentTurnResult
+            .Returns(async () =>
             {
-                Success = true,
-                Response = "Hello from agent",
-                UpdatedHistory = [],
+                var sink = AgentTurnStreamSink.Current;
+                if (sink is not null)
+                {
+                    await sink.EmitAsync("Hello ", CancellationToken.None);
+                    await sink.EmitAsync("from agent", CancellationToken.None);
+                }
+                return new AgentTurnResult
+                {
+                    Success = true,
+                    Response = "Hello from agent",
+                    UpdatedHistory = [],
+                };
             });
 
         var orchestrator = CreateOrchestrator();
@@ -154,7 +166,7 @@ public class ConversationOrchestratorTests
         outcome.Success.Should().BeTrue();
         outcome.Response.Should().Be("Hello from agent");
         outcome.AssistantMessageId.Should().NotBeEmpty();
-        chunks.Should().NotBeEmpty();
+        chunks.Should().Equal("Hello ", "from agent");
     }
 
     [Fact]
@@ -479,7 +491,7 @@ public class ConversationOrchestratorTests
     // ── Streaming ────────────────────────────────────────────────────────
 
     [Fact]
-    public async Task SendMessage_LongResponse_StreamsMultipleChunks()
+    public async Task SendMessage_ForwardsHandlerDeltasVerbatim_WithoutRechunking()
     {
         var record = new ConversationRecord("c1", "agent", "user1", DateTimeOffset.UtcNow, DateTimeOffset.UtcNow, []);
         _store.Setup(s => s.GetAsync("c1", It.IsAny<CancellationToken>())).ReturnsAsync(record);
@@ -489,9 +501,17 @@ public class ConversationOrchestratorTests
         _obsStore.Setup(s => s.StartSessionAsync("c1", "agent", null, It.IsAny<CancellationToken>()))
             .ReturnsAsync(Guid.NewGuid());
 
-        var longResponse = new string('x', 120);
+        // A single long delta from the handler must reach the client as one chunk — the
+        // old 50-char re-chunker is gone; the orchestrator no longer reshapes the stream.
+        var longDelta = new string('x', 120);
         _mediator.Setup(m => m.Send(It.IsAny<ExecuteAgentTurnCommand>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new AgentTurnResult { Success = true, Response = longResponse, UpdatedHistory = [] });
+            .Returns(async () =>
+            {
+                var sink = AgentTurnStreamSink.Current;
+                if (sink is not null)
+                    await sink.EmitAsync(longDelta, CancellationToken.None);
+                return new AgentTurnResult { Success = true, Response = longDelta, UpdatedHistory = [] };
+            });
 
         var chunks = new List<string>();
         var orchestrator = CreateOrchestrator();
@@ -500,7 +520,7 @@ public class ConversationOrchestratorTests
             (chunk, _) => { chunks.Add(chunk); return Task.CompletedTask; },
             CancellationToken.None);
 
-        chunks.Should().HaveCount(3, "120 chars / 50 chars per chunk = 3 chunks (50+50+20)");
-        string.Concat(chunks).Should().Be(longResponse);
+        chunks.Should().ContainSingle("the orchestrator forwards handler deltas without re-chunking");
+        chunks[0].Should().Be(longDelta);
     }
 }


### PR DESCRIPTION
## Why

The chat *looked* like it streamed, but it didn't. `ConversationOrchestrator.DispatchTurnAsync` waited for the **entire** model response (blocking `agent.RunAsync`), then chopped the finished text into 50-char slices (`StreamChunksAsync`) to fake a typewriter. The user paid full latency **and then** watched a cosmetic type-out — the whole point of streaming (perceived latency) was zero.

This ships real token streaming: deltas flow to the client as the model generates them.

## What changed

**Streaming path**
- Handler streams via `AIAgent.RunStreamingAsync` through a new ambient `IAgentTurnStreamSink` (`AsyncLocal`, mirroring the existing `LlmUsageCapture.Current` pattern). Flowing the sink ambiently keeps the MediatR command a pure data record. No sink attached → falls back to blocking `RunAsync` (tests, batch callers).
- Orchestrator attaches/restores the sink around dispatch; the 50-char `StreamChunksAsync` re-chunker is deleted.

**Accounting fix (the precondition — verified via spike before building)**
The chat-client middleware only captured token usage / tool calls on the **blocking** path. A naive switch to streaming would have silently zeroed token + cost accounting and dropped tool logging. Both middleware streaming paths now capture, via `updates.ToChatResponse()`:
- `ObservabilityMiddleware.GetStreamingResponseAsync` → records token usage (streamed usage rides a `UsageContent` in the final chunk).
- `ToolDiagnosticsMiddleware.GetStreamingResponseAsync` → records tool calls. `ToChatResponse()` is also required to coalesce function-call arguments split across chunks.

**Markdown polish**
- `completeStreamingMarkdown` closes a dangling code fence during streaming so an in-progress code block renders as a growing block instead of flickering as raw backticks until its close arrives. No-op once the message completes.

**Frontend:** wire contract unchanged — real deltas replace the fake slices on the existing `TokenReceived`/`TurnComplete` events (the client ignores the redundant final token and finalizes from the authoritative `TurnComplete.fullResponse`).

## Test plan

- **New (.NET):** streaming usage-capture + streaming tool-capture guards (prove accounting survives streaming); ambient sink unit tests; handler streaming branch (multi-delta in order + concatenation) and blocking-fallback; orchestrator sink wiring + no-rechunking. Updated 2 orchestrator tests that asserted the deleted fake-chunking.
- **New (WebUI):** 9 `completeStreamingMarkdown` unit tests.
- **Result:** `dotnet build` 0 errors; full suite green (one pre-existing flaky test in `Infrastructure.AI.Tests`, untouched here); WebUI `vitest` + `tsc` green.

## Reviewed

`/code-review` (high) + `/simplify` run; one fix applied (removed a degenerate `IsActive` flag). Notable dismissal: a "disconnect → phantom error" finding is **pre-existing** (the old blocking `RunAsync(ct)` had the same cancellation window) — logged as a follow-up, not a regression from this PR.

## Known follow-up (pre-existing, out of scope)
A client disconnect mid-generation surfaces `OperationCanceledException` that the handler classifies as an internal error and the orchestrator persists as `[Error]` + a health-error metric. Fixing it correctly needs distinguishing a disconnect from the 5-min turn timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)