### PR TITLE
feat: tamper-evident hash-chain for JSONL audit logs (PR 1/3)

### DIFF
--- a/.claude/plans/tamper-evident-audit-chain.md
+++ b/.claude/plans/tamper-evident-audit-chain.md
@@ -1,0 +1,175 @@
+# Plan: Tamper-Evident Audit Chain
+
+**Status:** Proposed — awaiting go-ahead
+**Date:** 2026-06-20
+**Source:** Gap analysis vs "AI Gateway Blueprint: Five Governance Functions" (Wasowski, 2026)
+**Related memory:** MCP Hardening (`project_mcp_hardening.md`), Multi-tenant isolation (`project_maf_native_adoption.md`)
+
+---
+
+## Why this exists (plain language)
+
+A court has already held a company liable for what its chatbot said. The regulatory
+defense against that is a log you can *prove* nobody altered after the fact — the "black
+box." The harness has an audit trail, but today it can only catch **accidental**
+corruption, not **deliberate** tampering. This plan closes that gap and nothing else.
+
+The article's other four functions (PII redaction, per-identity cost, virtual keys,
+observability) are either already present in the harness or deliberately deferred. The
+audit log is the **one genuine, on-brand gap** for a compliance-focused template.
+
+---
+
+## Current state (verified by reading the code, 2026-06-20)
+
+There is no single audit log. There are **four** append-only JSONL writers, with
+**inconsistent** integrity guarantees:
+
+| Writer | File | Integrity today |
+|---|---|---|
+| `JsonlDriftAuditStore` | `Infrastructure.AI/DriftDetection/` | Per-record SHA-256 (tab-appended), verified on read |
+| `JsonlEscalationAuditStore` | `Infrastructure.AI/Escalation/` | Per-record SHA-256, verified on read |
+| `JsonlChangeAuditWriter` | `Infrastructure.AI/Changes/` | **None** — raw JSON line, no hash |
+| `JsonlEgressAuditWriter` | `Infrastructure.AI/Egress/` | **None** (confirm during impl) |
+
+**Three problems, all confirmed in source:**
+
+1. **Hashes are standalone, not chained.** `JsonlDriftAuditStore.ComputeIntegrityHash`
+   (line 220) hashes *that record's JSON only*. An attacker who edits a record simply
+   recomputes its hash — the tamper is invisible. A chain (each record hashes the
+   previous one) makes any edit cascade-break every record after it.
+
+2. **No scheduled verification.** `VerifyIntegrity` runs only when a record is *read*.
+   The article's exact warning: without a periodic job that walks the whole chain,
+   "the cryptography exists only on paper."
+
+3. **No content/erasure story.** The harness already has erasure plumbing for the
+   knowledge graph (`DefaultErasureOrchestrator`, `ComplianceAwareGraphStore`,
+   `ErasureReceipt`) — but it is **not** wired to the audit logs. A WORM audit log that
+   contains prompts/responses collides head-on with the right to be forgotten.
+
+---
+
+## Design
+
+### Principle: build the primitive once, apply it everywhere
+
+The harness convention (per memory: "shared SQLite helpers extracted at N=2") is to
+factor shared behavior rather than copy-paste. We have N=4 writers. So: build **one**
+hash-chain primitive and route all four through it, replacing the two ad-hoc hash
+implementations and adding integrity to the two that have none.
+
+### Tier 1 — Hash-chain + nightly verifier (all four writers)
+
+These writers store **decisions, identity, and metadata** (gate actions, drift scores,
+escalation events, egress allow/deny) — not raw prompts. They need integrity, not
+erasure. Tier 1 covers them fully.
+
+**Line format** (replaces the current `{json}\t{hash}`):
+
+```
+{json}\t{recordHash}\t{prevHash}\t{seq}
+```
+
+- `recordHash = SHA-256(canonical(json) + prevHash)`
+- `prevHash` of record N is the `recordHash` of record N-1 across the **entire stream**
+  (not per-file — otherwise deleting a whole day's `.jsonl` is undetectable).
+- `seq` is a monotonic counter; gaps reveal a deleted record even at a file boundary.
+- Chain head (`{seq, recordHash}`) persists in a sidecar `.chainhead` file per stream,
+  read on first append after startup. The head is an *optimization* — the chain is
+  self-validating by full walk, so a tampered head is itself caught by the verifier.
+
+**New shared component:**
+- `Domain.AI/Audit/AuditChainRecord.cs` — value object: seq, prevHash, recordHash,
+  timestamp, payload-as-string.
+- `Application.AI.Common/Interfaces/Audit/IHashChainedAuditWriter.cs` — append +
+  `VerifyChainAsync` contract.
+- `Infrastructure.AI/Audit/HashChainedJsonlWriter.cs` — the one real implementation;
+  owns the SemaphoreSlim, FileShare.ReadWrite, snake_case JSON, sidecar head, and
+  cross-file chaining. The four existing writers delegate to it (composition, not
+  inheritance) and keep their typed public APIs.
+
+**Nightly verifier:**
+- `Infrastructure.AI/Audit/AuditChainVerificationService.cs` — a `BackgroundService`
+  (hosted) that, on a configurable cron (default daily), walks each stream end-to-end,
+  recomputes the chain, and:
+  - emits a metric via the existing `GovernanceMetrics` meter
+    (`audit.chain.verified` / `audit.chain.broken`),
+  - logs structured `Warning`/`Critical` on break with the first bad seq,
+  - writes a signed verification receipt (`audit-verify/{date}.jsonl`).
+- Config: `AppConfig.AI.Audit.VerificationCron`, `AppConfig.AI.Audit.Enabled`.
+
+### Tier 2 — Content/hash separation + erasure wiring (content-bearing sink only)
+
+**First task is investigation, not code:** confirm which sink actually persists raw
+prompt/response text. Candidates: the agent `IAuditSink` / `StructuredLogAuditSink`
+(`Infrastructure.AI/Audit/`) and any future turn-level audit. The four JSONL writers
+above store hashes/metadata, so they likely need **no** Tier 2 work. **Do not build
+Tier 2 against a sink that holds no PII.**
+
+Where content *is* stored:
+- **Chain store** (WORM, never deleted): seq, timestamp, identity, prevHash, recordHash,
+  and the **hash of the content** — never the content itself.
+- **Content store** (deletable, AES-256, key in Key Vault via existing `KeyVaultConfig`):
+  seq → encrypted prompt/response payload.
+- Deleting a subject's content removes content-store rows; the chain still verifies
+  because it holds only the content *hash*, which is unchanged. This is the article's
+  exact resolution of the WORM-vs-erasure conflict.
+- Wire `IErasureOrchestrator` to purge content-store rows for a subject and stamp an
+  `ErasureReceipt` (type already exists). The chain records the erasure as its own
+  appended event — the paper trail shows *that* data was erased, not the data.
+
+---
+
+## Phasing (one PR per phase)
+
+**PR 1 — Tier 1 primitive + migrate the two unhashed writers.**
+Build `HashChainedJsonlWriter` + chain record + verifier-less unit tests. Route
+`JsonlChangeAuditWriter` and `JsonlEgressAuditWriter` (currently hashless) through it.
+Net: integrity where there was none. Lowest risk, immediate value.
+
+**PR 2 — Migrate drift + escalation, add the nightly verifier.**
+Replace the two standalone-hash writers' integrity with the chain. Add
+`AuditChainVerificationService` hosted service + `GovernanceMetrics` counters + config.
+Includes a backfill note: existing un-chained files are treated as chain-genesis
+(verifier starts the chain from first record on/after rollout; documented, not silent).
+
+**PR 3 — Tier 2 (conditional on the investigation).**
+Only if a content-bearing sink exists. Content/hash split, encryption, erasure wiring,
+`ErasureReceipt` integration.
+
+---
+
+## Tests (TDD — failing test first, per `rules/testing.md`)
+
+- `HashChainedJsonlWriter`: append N records → tamper record K → verify fails at exactly
+  K (not K-1, not K+1). Delete a record → seq gap detected. Delete a whole day file →
+  cross-file prevHash mismatch detected.
+- Verifier: clean chain → `audit.chain.verified` metric, no warning. Broken chain →
+  `Critical` log + `audit.chain.broken` metric + receipt written.
+- Tier 2: erase subject → content rows gone, chain still verifies, `ErasureReceipt`
+  stamped, erasure event appended to chain.
+- Concurrency: parallel appends under the semaphore keep seq monotonic and chain intact.
+
+---
+
+## Scope discipline (what this plan does NOT do)
+
+- No NER/LLM PII redaction (regex layer is sufficient; out of scope).
+- No per-identity cost/virtual-key work (separate, lower-priority gap).
+- No new tool-description hashing (belongs to the MCP Hardening track, not here).
+- No change to the four writers' public APIs — callers are untouched.
+
+---
+
+## Open decisions for Matt
+
+1. **Scope of PR 1+2:** all four JSONL writers, or only the regulatory-critical
+   change-proposal + escalation ones? (Recommendation: all four — consistency, and the
+   primitive cost is already paid.)
+2. **Tier 2 at all?** Depends on whether any sink stores raw prompts/responses. The
+   investigation in PR 3 answers this; if nothing stores content, Tier 2 is dropped and
+   we're done after PR 2. (Recommendation: gate it on the finding — don't pre-build.)
+3. **Verifier cadence + alerting sink:** daily is the article's default. Where should a
+   broken-chain alert go — structured log only, or also escalation/AG-UI notification?
+   (Recommendation: log + `GovernanceMetrics` for PR 2; escalation hook as a follow-up.)

--- a/src/Content/Domain/Domain.AI/Audit/AuditChainVerificationResult.cs
+++ b/src/Content/Domain/Domain.AI/Audit/AuditChainVerificationResult.cs
@@ -1,0 +1,58 @@
+namespace Domain.AI.Audit;
+
+/// <summary>
+/// The outcome of verifying the integrity of a hash-chained audit log.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A tamper-evident audit log links every record to its predecessor via a cryptographic
+/// hash. Verification walks the chain from genesis and recomputes each link; any retroactive
+/// edit, deletion, or reordering breaks the chain at the first affected record. This type
+/// reports whether the chain held and, when it did not, exactly where it broke.
+/// </para>
+/// <para>
+/// <see cref="VerifiedCount"/> counts the records that verified cleanly before any break,
+/// so an operator can see how much of the log is still trustworthy. <see cref="FirstBrokenSequence"/>
+/// pinpoints the first record whose hash, previous-hash link, or sequence number did not match,
+/// which is the record that was tampered with or the gap left by a deleted record.
+/// </para>
+/// </remarks>
+public sealed record AuditChainVerificationResult
+{
+    /// <summary>Gets whether the entire chain verified without a break.</summary>
+    public required bool IsValid { get; init; }
+
+    /// <summary>Gets the number of records that verified cleanly from genesis before any break.</summary>
+    public required long VerifiedCount { get; init; }
+
+    /// <summary>
+    /// Gets the sequence number of the first record where the chain broke, or <c>null</c>
+    /// when the chain is valid.
+    /// </summary>
+    public long? FirstBrokenSequence { get; init; }
+
+    /// <summary>
+    /// Gets a human-readable explanation of the break (hash mismatch, sequence gap, or
+    /// malformed line), or <c>null</c> when the chain is valid.
+    /// </summary>
+    public string? FailureReason { get; init; }
+
+    /// <summary>Creates a result indicating the chain verified cleanly.</summary>
+    /// <param name="verifiedCount">The number of records verified.</param>
+    public static AuditChainVerificationResult Valid(long verifiedCount) =>
+        new() { IsValid = true, VerifiedCount = verifiedCount };
+
+    /// <summary>Creates a result indicating the chain broke.</summary>
+    /// <param name="verifiedCount">The number of records that verified before the break.</param>
+    /// <param name="firstBrokenSequence">The sequence number where the break was detected.</param>
+    /// <param name="failureReason">A human-readable explanation of the break.</param>
+    public static AuditChainVerificationResult Broken(
+        long verifiedCount, long firstBrokenSequence, string failureReason) =>
+        new()
+        {
+            IsValid = false,
+            VerifiedCount = verifiedCount,
+            FirstBrokenSequence = firstBrokenSequence,
+            FailureReason = failureReason
+        };
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Audit/HashChainedJsonlWriter.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Audit/HashChainedJsonlWriter.cs
@@ -1,0 +1,307 @@
+using System.Buffers;
+using System.Globalization;
+using System.Security.Cryptography;
+using System.Text;
+using Domain.AI.Audit;
+using Domain.Common;
+using Microsoft.Extensions.Logging;
+
+namespace Infrastructure.AI.Audit;
+
+/// <summary>
+/// Append-only JSONL writer that links every record into a cryptographic hash-chain,
+/// making the log tamper-evident: any retroactive edit, deletion, or reordering of a
+/// record breaks the chain at the first affected record and is detected by
+/// <see cref="VerifyChainAsync"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is the shared integrity primitive for the harness's JSONL audit sinks. A sink
+/// serializes its own typed record to JSON and hands the string here; this writer owns the
+/// framing, the chain links, and thread-safe file access. Each persisted line has the form
+/// <c>{json}\t{recordHash}\t{previousHash}\t{sequence}</c>, where
+/// <c>recordHash = SHA-256(sequence + "\n" + previousHash + "\n" + json)</c>. Binding the
+/// sequence number and the previous record's hash into each hash means a record cannot be
+/// altered, removed, or moved without invalidating every record that follows it.
+/// </para>
+/// <para>
+/// <b>Framing safety.</b> The framing is line- and tab-delimited. <c>System.Text.Json</c>
+/// escapes control characters inside string values (tab/newline become <c>\t</c>/<c>\n</c>),
+/// so a serialized JSON payload never contains a raw framing byte. The writer rejects any
+/// payload that does contain a raw tab, carriage-return, or newline rather than corrupt the
+/// chain by splitting one logical record across physical lines.
+/// </para>
+/// <para>
+/// <b>Trusted head recovery.</b> On first append after a restart the writer rebuilds its
+/// in-memory head by scanning the file and validating the chain — the head is set to the last
+/// <i>cryptographically valid</i> record, never to an unverified tail. A forged or torn line
+/// appended out of band therefore cannot seed the live head; legitimate records continue to
+/// chain onto verified state, and the forged/torn line is still surfaced by
+/// <see cref="VerifyChainAsync"/>.
+/// </para>
+/// <para>
+/// <b>Brownfield rollout.</b> When pointed at a file that already contains un-chained lines
+/// written before this primitive was introduced, those legacy lines are treated as predating
+/// the chain: the scan skips them, the chain genesis is the first chained record written after
+/// rollout, and verification ignores the leading legacy lines. No silent rewrite of existing
+/// history occurs.
+/// </para>
+/// <para>
+/// <b>Out of scope (handled by the verification layer).</b> A torn trailing line from a crash
+/// mid-write, or wholesale deletion of the file, are not concealable by this primitive but are
+/// not <i>repaired</i> by it either — those are the province of WORM storage and the scheduled
+/// chain-verification job. This primitive guarantees detection, not crash-safe truncation.
+/// </para>
+/// <para>
+/// <b>Cost note.</b> Head recovery scans the file once per process lifetime (on first append);
+/// verification scans it in full. Both are O(records). For the append-only audit volumes this
+/// primitive targets, that cost is paid rarely and is acceptable.
+/// </para>
+/// </remarks>
+public sealed class HashChainedJsonlWriter : IDisposable
+{
+    /// <summary>The 64-character all-zero hash that precedes the first record in a chain.</summary>
+    public const string GenesisHash =
+        "0000000000000000000000000000000000000000000000000000000000000000";
+
+    private const char FieldSeparator = '\t';
+
+    /// <summary>Characters that would break the line/tab framing if present in a payload.</summary>
+    private static readonly SearchValues<char> FramingChars = SearchValues.Create("\t\n\r");
+
+    private readonly string _filePath;
+    private readonly ILogger _logger;
+    private readonly SemaphoreSlim _semaphore = new(1, 1);
+
+    private bool _headInitialized;
+    private long _headSequence = -1;
+    private string _headHash = GenesisHash;
+
+    /// <summary>Initializes a new <see cref="HashChainedJsonlWriter"/>.</summary>
+    /// <param name="filePath">Absolute path to the JSONL file backing this chain.</param>
+    /// <param name="logger">Logger for operational diagnostics.</param>
+    public HashChainedJsonlWriter(string filePath, ILogger logger)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(filePath);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _filePath = filePath;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Appends a serialized record to the chain, computing and persisting its hash links.
+    /// </summary>
+    /// <param name="payloadJson">The caller's already-serialized record as a single-line JSON string.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>
+    /// <see cref="Result.Success()"/> when the record was persisted; a failure result when the
+    /// payload contains a raw framing character or the file could not be written.
+    /// </returns>
+    public async Task<Result> AppendAsync(string payloadJson, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(payloadJson);
+
+        if (payloadJson.AsSpan().IndexOfAny(FramingChars) >= 0)
+            return Result.Fail(
+                "Audit payload must not contain raw tab, carriage-return, or newline characters; chain framing is line- and tab-delimited.");
+
+        await _semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            await EnsureHeadInitializedAsync(cancellationToken).ConfigureAwait(false);
+
+            var sequence = _headSequence + 1;
+            var previousHash = _headHash;
+            var recordHash = ComputeRecordHash(sequence, previousHash, payloadJson);
+            var line = string.Concat(
+                payloadJson, FieldSeparator,
+                recordHash, FieldSeparator,
+                previousHash, FieldSeparator,
+                sequence.ToString(CultureInfo.InvariantCulture), "\n");
+
+            Directory.CreateDirectory(Path.GetDirectoryName(_filePath)!);
+
+            await using (var stream = new FileStream(
+                _filePath, FileMode.Append, FileAccess.Write, FileShare.ReadWrite))
+            await using (var writer = new StreamWriter(stream))
+            {
+                await writer.WriteAsync(line.AsMemory(), cancellationToken).ConfigureAwait(false);
+            }
+
+            _headSequence = sequence;
+            _headHash = recordHash;
+            return Result.Success();
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            _logger.LogError(ex, "Failed to append audit record to {FilePath}", _filePath);
+            return Result.Fail($"Failed to persist audit record: {ex.Message}");
+        }
+        finally
+        {
+            _semaphore.Release();
+        }
+    }
+
+    /// <summary>
+    /// Walks the chain from genesis and recomputes every link, reporting whether the log is
+    /// intact and, if not, the first record where it broke.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A verification result describing the chain's integrity.</returns>
+    public async Task<AuditChainVerificationResult> VerifyChainAsync(CancellationToken cancellationToken)
+    {
+        await _semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            var scan = await ScanChainAsync(cancellationToken).ConfigureAwait(false);
+            return scan.BreakSequence is { } brokenSequence
+                ? AuditChainVerificationResult.Broken(scan.VerifiedCount, brokenSequence, scan.BreakReason!)
+                : AuditChainVerificationResult.Valid(scan.VerifiedCount);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            _logger.LogError(ex, "Failed to read audit chain at {FilePath}", _filePath);
+            return AuditChainVerificationResult.Broken(0, 0, $"Failed to read audit chain: {ex.Message}");
+        }
+        finally
+        {
+            _semaphore.Release();
+        }
+    }
+
+    /// <inheritdoc cref="IDisposable.Dispose" />
+    public void Dispose() => _semaphore.Dispose();
+
+    /// <summary>
+    /// Recovers the chain head (last valid sequence and hash) by scanning and validating the
+    /// file once. The head is the tail of the longest valid prefix, so appends always continue
+    /// from cryptographically verified state. Runs once per process under the append semaphore.
+    /// </summary>
+    private async Task EnsureHeadInitializedAsync(CancellationToken cancellationToken)
+    {
+        if (_headInitialized)
+            return;
+
+        var scan = await ScanChainAsync(cancellationToken).ConfigureAwait(false);
+        _headSequence = scan.LastValidSequence;
+        _headHash = scan.LastValidHash;
+        _headInitialized = true;
+    }
+
+    /// <summary>
+    /// Single forward pass over the file shared by verification and head recovery. Validates
+    /// sequence continuity, previous-hash links, and record hashes from genesis, tolerating
+    /// only the leading legacy (pre-chain) lines.
+    /// </summary>
+    private async Task<ChainScan> ScanChainAsync(CancellationToken cancellationToken)
+    {
+        if (!File.Exists(_filePath))
+            return ChainScan.Empty;
+
+        long expectedSequence = 0;
+        var expectedPreviousHash = GenesisHash;
+        long verifiedCount = 0;
+        long lastValidSequence = -1;
+        var lastValidHash = GenesisHash;
+        var chainStarted = false;
+        var lineNumber = 0;
+
+        await using var stream = new FileStream(
+            _filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+        using var reader = new StreamReader(stream);
+
+        while (await reader.ReadLineAsync(cancellationToken).ConfigureAwait(false) is { } line)
+        {
+            lineNumber++;
+            if (string.IsNullOrWhiteSpace(line))
+                continue;
+
+            if (!TryParseLine(line, out var sequence, out var recordHash, out var previousHash, out var payloadJson))
+            {
+                // Legacy lines that predate the chain are tolerated only before it starts.
+                if (chainStarted)
+                    return ChainScan.Break(verifiedCount, expectedSequence, lastValidSequence, lastValidHash,
+                        $"Malformed chain line at line {lineNumber}.");
+                continue;
+            }
+
+            chainStarted = true;
+
+            if (sequence != expectedSequence)
+                return ChainScan.Break(verifiedCount, expectedSequence, lastValidSequence, lastValidHash,
+                    $"Sequence gap: expected {expectedSequence} but found {sequence} at line {lineNumber} (record deleted or reordered).");
+
+            if (!string.Equals(previousHash, expectedPreviousHash, StringComparison.Ordinal))
+                return ChainScan.Break(verifiedCount, sequence, lastValidSequence, lastValidHash,
+                    $"Previous-hash mismatch at sequence {sequence} (chain link altered).");
+
+            var computedHash = ComputeRecordHash(sequence, previousHash, payloadJson);
+            if (!string.Equals(computedHash, recordHash, StringComparison.Ordinal))
+                return ChainScan.Break(verifiedCount, sequence, lastValidSequence, lastValidHash,
+                    $"Record-hash mismatch at sequence {sequence} (record content altered).");
+
+            verifiedCount++;
+            lastValidSequence = sequence;
+            lastValidHash = recordHash;
+            expectedSequence = sequence + 1;
+            expectedPreviousHash = recordHash;
+        }
+
+        return ChainScan.Valid(verifiedCount, lastValidSequence, lastValidHash);
+    }
+
+    private static string ComputeRecordHash(long sequence, string previousHash, string payloadJson)
+    {
+        var material = string.Concat(
+            sequence.ToString(CultureInfo.InvariantCulture), "\n", previousHash, "\n", payloadJson);
+        return Convert.ToHexStringLower(SHA256.HashData(Encoding.UTF8.GetBytes(material)));
+    }
+
+    private static bool TryParseLine(
+        string line, out long sequence, out string recordHash, out string previousHash, out string payloadJson)
+    {
+        sequence = -1;
+        recordHash = string.Empty;
+        previousHash = string.Empty;
+        payloadJson = string.Empty;
+
+        var parts = line.Split(FieldSeparator);
+        if (parts.Length != 4)
+            return false;
+
+        // The writer only ever emits a plain invariant-culture integer, so reject anything
+        // looser (leading sign, surrounding whitespace) to shrink the false-positive surface.
+        if (!long.TryParse(parts[3], NumberStyles.None, CultureInfo.InvariantCulture, out sequence))
+            return false;
+
+        payloadJson = parts[0];
+        recordHash = parts[1];
+        previousHash = parts[2];
+        return true;
+    }
+
+    /// <summary>Outcome of a single forward pass over the chain file.</summary>
+    /// <param name="VerifiedCount">Records that verified cleanly from genesis before any break.</param>
+    /// <param name="LastValidSequence">Sequence of the last valid record, or -1 if none.</param>
+    /// <param name="LastValidHash">Record hash of the last valid record, or the genesis hash if none.</param>
+    /// <param name="BreakSequence">Sequence where the chain broke, or null when intact.</param>
+    /// <param name="BreakReason">Explanation of the break, or null when intact.</param>
+    private readonly record struct ChainScan(
+        long VerifiedCount,
+        long LastValidSequence,
+        string LastValidHash,
+        long? BreakSequence,
+        string? BreakReason)
+    {
+        public static ChainScan Empty { get; } = Valid(0, -1, GenesisHash);
+
+        public static ChainScan Valid(long verifiedCount, long lastValidSequence, string lastValidHash) =>
+            new(verifiedCount, lastValidSequence, lastValidHash, null, null);
+
+        public static ChainScan Break(
+            long verifiedCount, long breakSequence, long lastValidSequence, string lastValidHash, string reason) =>
+            new(verifiedCount, lastValidSequence, lastValidHash, breakSequence, reason);
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Changes/JsonlChangeAuditWriter.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Changes/JsonlChangeAuditWriter.cs
@@ -4,6 +4,7 @@ using Application.AI.Common.Interfaces.Changes;
 using Domain.AI.Changes;
 using Domain.AI.Identity;
 using Domain.Common.Config;
+using Infrastructure.AI.Audit;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -13,8 +14,9 @@ namespace Infrastructure.AI.Changes;
 /// Append-only JSONL audit writer for change-proposal gate decisions. Mirrors
 /// the shape established by <c>JsonlEscalationAuditStore</c> and
 /// <c>JsonlDriftAuditStore</c>: one line per record, snake_case JSON,
-/// enums-as-strings, written under a <see cref="SemaphoreSlim"/> for thread
-/// safety, file opened with <c>FileShare.ReadWrite</c> for concurrent reads.
+/// enums-as-strings. Records are linked into a tamper-evident hash-chain via
+/// <see cref="HashChainedJsonlWriter"/> so a retroactively altered or deleted
+/// decision is detectable.
 /// </summary>
 public sealed class JsonlChangeAuditWriter : IChangeAuditWriter, IDisposable
 {
@@ -25,9 +27,8 @@ public sealed class JsonlChangeAuditWriter : IChangeAuditWriter, IDisposable
         Converters = { new JsonStringEnumConverter() }
     };
 
-    private readonly string _filePath;
+    private readonly HashChainedJsonlWriter _chain;
     private readonly ILogger<JsonlChangeAuditWriter> _logger;
-    private readonly SemaphoreSlim _semaphore = new(1, 1);
 
     /// <summary>Initializes a new <see cref="JsonlChangeAuditWriter"/>.</summary>
     public JsonlChangeAuditWriter(
@@ -38,7 +39,7 @@ public sealed class JsonlChangeAuditWriter : IChangeAuditWriter, IDisposable
         ArgumentNullException.ThrowIfNull(logger);
 
         var dir = config.CurrentValue.AI.Changes.AuditStoragePath;
-        _filePath = Path.Combine(dir, "changes.jsonl");
+        _chain = new HashChainedJsonlWriter(Path.Combine(dir, "changes.jsonl"), logger);
         _logger = logger;
     }
 
@@ -77,37 +78,23 @@ public sealed class JsonlChangeAuditWriter : IChangeAuditWriter, IDisposable
             DurationMs = decision.DurationMs
         };
 
-        Directory.CreateDirectory(Path.GetDirectoryName(_filePath)!);
-
-        await _semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
-        try
+        var json = JsonSerializer.Serialize(record, SerializeOptions);
+        var result = await _chain.AppendAsync(json, cancellationToken).ConfigureAwait(false);
+        if (!result.IsSuccess)
         {
-            await using var stream = new FileStream(
-                _filePath,
-                FileMode.Append,
-                FileAccess.Write,
-                FileShare.ReadWrite);
-            await using var writer = new StreamWriter(stream);
-            var json = JsonSerializer.Serialize(record, SerializeOptions);
-            await writer.WriteLineAsync(json).ConfigureAwait(false);
-        }
-        catch (Exception ex)
-        {
+            var reason = string.Join("; ", result.Errors);
             _logger.LogError(
-                ex,
-                "Failed to append ChangeProposal audit line for proposal {ProposalId} gate {GateKey}.",
+                "Failed to append ChangeProposal audit line for proposal {ProposalId} gate {GateKey}: {Reason}",
                 proposal.Id,
-                decision.GateKey);
-            throw;
-        }
-        finally
-        {
-            _semaphore.Release();
+                decision.GateKey,
+                reason);
+            throw new IOException(
+                $"Failed to append change audit record for proposal {proposal.Id}: {reason}");
         }
     }
 
     /// <inheritdoc />
-    public void Dispose() => _semaphore.Dispose();
+    public void Dispose() => _chain.Dispose();
 
     private sealed record ChangeAuditRecord
     {

--- a/src/Content/Infrastructure/Infrastructure.AI/Egress/JsonlEgressAuditWriter.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Egress/JsonlEgressAuditWriter.cs
@@ -4,6 +4,7 @@ using Application.AI.Common.Interfaces.Egress;
 using Domain.AI.Egress;
 using Domain.AI.Identity;
 using Domain.Common.Config;
+using Infrastructure.AI.Audit;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -12,9 +13,9 @@ namespace Infrastructure.AI.Egress;
 /// <summary>
 /// Append-only JSONL audit writer for egress decisions. Mirrors the shape
 /// established by <c>JsonlChangeAuditWriter</c>: one line per record,
-/// snake_case JSON, enums-as-strings, written under a <see cref="SemaphoreSlim"/>
-/// for thread safety, file opened with <c>FileShare.ReadWrite</c> for
-/// concurrent reads.
+/// snake_case JSON, enums-as-strings. Records are linked into a tamper-evident
+/// hash-chain via <see cref="HashChainedJsonlWriter"/> so a retroactively
+/// altered or deleted egress decision is detectable.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -33,9 +34,8 @@ public sealed class JsonlEgressAuditWriter : IEgressAuditWriter, IDisposable
         Converters = { new JsonStringEnumConverter() }
     };
 
-    private readonly string _filePath;
+    private readonly HashChainedJsonlWriter _chain;
     private readonly ILogger<JsonlEgressAuditWriter> _logger;
-    private readonly SemaphoreSlim _semaphore = new(1, 1);
 
     /// <summary>Initializes a new <see cref="JsonlEgressAuditWriter"/>.</summary>
     public JsonlEgressAuditWriter(
@@ -46,7 +46,7 @@ public sealed class JsonlEgressAuditWriter : IEgressAuditWriter, IDisposable
         ArgumentNullException.ThrowIfNull(logger);
 
         var dir = config.CurrentValue.AI.Egress.AuditStoragePath;
-        _filePath = Path.Combine(dir, "egress.jsonl");
+        _chain = new HashChainedJsonlWriter(Path.Combine(dir, "egress.jsonl"), logger);
         _logger = logger;
     }
 
@@ -78,37 +78,23 @@ public sealed class JsonlEgressAuditWriter : IEgressAuditWriter, IDisposable
             }
         };
 
-        Directory.CreateDirectory(Path.GetDirectoryName(_filePath)!);
-
-        await _semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
-        try
+        var json = JsonSerializer.Serialize(record, SerializeOptions);
+        var result = await _chain.AppendAsync(json, cancellationToken).ConfigureAwait(false);
+        if (!result.IsSuccess)
         {
-            await using var stream = new FileStream(
-                _filePath,
-                FileMode.Append,
-                FileAccess.Write,
-                FileShare.ReadWrite);
-            await using var writer = new StreamWriter(stream);
-            var json = JsonSerializer.Serialize(record, SerializeOptions);
-            await writer.WriteLineAsync(json).ConfigureAwait(false);
-        }
-        catch (Exception ex)
-        {
+            var reason = string.Join("; ", result.Errors);
             _logger.LogError(
-                ex,
-                "Failed to append egress audit line for target {Host} ({Allowed}).",
+                "Failed to append egress audit line for target {Host} ({Allowed}): {Reason}",
                 decision.Target.Host,
-                decision.Allowed);
-            throw;
-        }
-        finally
-        {
-            _semaphore.Release();
+                decision.Allowed,
+                reason);
+            throw new IOException(
+                $"Failed to append egress audit record for target {decision.Target.Host}: {reason}");
         }
     }
 
     /// <inheritdoc />
-    public void Dispose() => _semaphore.Dispose();
+    public void Dispose() => _chain.Dispose();
 
     private sealed record EgressAuditRecord
     {

--- a/src/Content/Tests/Infrastructure.AI.Tests/Audit/HashChainedJsonlWriterTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Audit/HashChainedJsonlWriterTests.cs
@@ -1,0 +1,278 @@
+using FluentAssertions;
+using Infrastructure.AI.Audit;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Audit;
+
+public sealed class HashChainedJsonlWriterTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly string _filePath;
+
+    public HashChainedJsonlWriterTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"audit-chain-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+        _filePath = Path.Combine(_tempDir, "audit.jsonl");
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_tempDir, recursive: true); }
+        catch { /* best effort */ }
+    }
+
+    private HashChainedJsonlWriter NewWriter() =>
+        new(_filePath, NullLogger.Instance);
+
+    [Fact]
+    public async Task Append_PersistsOneFramedLinePerRecord()
+    {
+        using var sut = NewWriter();
+
+        (await sut.AppendAsync("{\"a\":1}", CancellationToken.None)).IsSuccess.Should().BeTrue();
+        (await sut.AppendAsync("{\"a\":2}", CancellationToken.None)).IsSuccess.Should().BeTrue();
+
+        var lines = await File.ReadAllLinesAsync(_filePath);
+        lines.Should().HaveCount(2);
+        // {json}\t{recordHash}\t{previousHash}\t{sequence}
+        lines[0].Split('\t').Should().HaveCount(4);
+        lines[0].Should().StartWith("{\"a\":1}\t");
+        lines[0].Should().EndWith("\t0");
+        lines[1].Should().EndWith("\t1");
+    }
+
+    [Fact]
+    public async Task FirstRecord_LinksToGenesisHash()
+    {
+        using var sut = NewWriter();
+        await sut.AppendAsync("{\"a\":1}", CancellationToken.None);
+
+        var parts = (await File.ReadAllLinesAsync(_filePath))[0].Split('\t');
+        parts[2].Should().Be(HashChainedJsonlWriter.GenesisHash);
+    }
+
+    [Fact]
+    public async Task EachRecord_LinksToPreviousRecordHash()
+    {
+        using var sut = NewWriter();
+        await sut.AppendAsync("{\"a\":1}", CancellationToken.None);
+        await sut.AppendAsync("{\"a\":2}", CancellationToken.None);
+
+        var lines = await File.ReadAllLinesAsync(_filePath);
+        var firstRecordHash = lines[0].Split('\t')[1];
+        var secondPreviousHash = lines[1].Split('\t')[2];
+        secondPreviousHash.Should().Be(firstRecordHash);
+    }
+
+    [Fact]
+    public async Task VerifyChain_OnUntamperedChain_ReturnsValid()
+    {
+        using var sut = NewWriter();
+        for (var i = 0; i < 5; i++)
+            await sut.AppendAsync($"{{\"a\":{i}}}", CancellationToken.None);
+
+        var result = await sut.VerifyChainAsync(CancellationToken.None);
+
+        result.IsValid.Should().BeTrue();
+        result.VerifiedCount.Should().Be(5);
+        result.FirstBrokenSequence.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task VerifyChain_OnEmptyOrMissingFile_ReturnsValidWithZeroCount()
+    {
+        using var sut = NewWriter();
+        var result = await sut.VerifyChainAsync(CancellationToken.None);
+
+        result.IsValid.Should().BeTrue();
+        result.VerifiedCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task VerifyChain_WhenRecordContentAltered_BreaksAtThatExactSequence()
+    {
+        using var sut = NewWriter();
+        for (var i = 0; i < 5; i++)
+            await sut.AppendAsync($"{{\"a\":{i}}}", CancellationToken.None);
+
+        // Tamper with record at sequence 2: change the payload but leave its stored hash.
+        var lines = await File.ReadAllLinesAsync(_filePath);
+        var parts = lines[2].Split('\t');
+        lines[2] = string.Join('\t', "{\"a\":99}", parts[1], parts[2], parts[3]);
+        await File.WriteAllLinesAsync(_filePath, lines);
+
+        var result = await sut.VerifyChainAsync(CancellationToken.None);
+
+        result.IsValid.Should().BeFalse();
+        result.FirstBrokenSequence.Should().Be(2);
+        result.VerifiedCount.Should().Be(2); // sequences 0 and 1 verified before the break
+        result.FailureReason.Should().Contain("altered");
+    }
+
+    [Fact]
+    public async Task VerifyChain_WhenRecordDeleted_DetectsSequenceGap()
+    {
+        using var sut = NewWriter();
+        for (var i = 0; i < 5; i++)
+            await sut.AppendAsync($"{{\"a\":{i}}}", CancellationToken.None);
+
+        // Remove the record at sequence 2 entirely.
+        var lines = (await File.ReadAllLinesAsync(_filePath)).ToList();
+        lines.RemoveAt(2);
+        await File.WriteAllLinesAsync(_filePath, lines);
+
+        var result = await sut.VerifyChainAsync(CancellationToken.None);
+
+        result.IsValid.Should().BeFalse();
+        result.FirstBrokenSequence.Should().Be(2);
+        result.FailureReason.Should().Contain("Sequence gap");
+    }
+
+    [Fact]
+    public async Task VerifyChain_WhenLinkRehashedButPreviousBroken_DetectsMismatch()
+    {
+        using var sut = NewWriter();
+        for (var i = 0; i < 4; i++)
+            await sut.AppendAsync($"{{\"a\":{i}}}", CancellationToken.None);
+
+        // Sophisticated tamper: change record 1's payload AND recompute its own hash so the
+        // record-hash check passes — but its hash no longer matches what record 2 points back to.
+        var lines = await File.ReadAllLinesAsync(_filePath);
+        var p = lines[1].Split('\t');
+        var altered = "{\"a\":777}";
+        // Recompute a self-consistent hash the same way the writer does.
+        var material = $"1\n{p[2]}\n{altered}";
+        var newHash = Convert.ToHexStringLower(
+            System.Security.Cryptography.SHA256.HashData(System.Text.Encoding.UTF8.GetBytes(material)));
+        lines[1] = string.Join('\t', altered, newHash, p[2], "1");
+        await File.WriteAllLinesAsync(_filePath, lines);
+
+        var result = await sut.VerifyChainAsync(CancellationToken.None);
+
+        result.IsValid.Should().BeFalse();
+        // Record 1 verifies (self-consistent), but record 2's previous-hash no longer matches.
+        result.FirstBrokenSequence.Should().Be(2);
+        result.FailureReason.Should().Contain("Previous-hash mismatch");
+    }
+
+    [Fact]
+    public async Task Append_AcrossWriterInstances_ContinuesTheSameChain()
+    {
+        using (var first = NewWriter())
+        {
+            await first.AppendAsync("{\"a\":0}", CancellationToken.None);
+            await first.AppendAsync("{\"a\":1}", CancellationToken.None);
+        }
+
+        // A fresh instance (simulating process restart) must recover the head and continue.
+        using var second = NewWriter();
+        await second.AppendAsync("{\"a\":2}", CancellationToken.None);
+
+        var lines = await File.ReadAllLinesAsync(_filePath);
+        lines.Should().HaveCount(3);
+        lines[2].Should().EndWith("\t2");
+
+        var result = await second.VerifyChainAsync(CancellationToken.None);
+        result.IsValid.Should().BeTrue();
+        result.VerifiedCount.Should().Be(3);
+    }
+
+    [Fact]
+    public async Task Append_OverLegacyUnchainedLines_StartsChainAndVerifies()
+    {
+        // Simulate a file written before the hash-chain primitive existed: raw JSON, no framing.
+        await File.WriteAllLinesAsync(_filePath, new[] { "{\"legacy\":1}", "{\"legacy\":2}" });
+
+        using var sut = NewWriter();
+        await sut.AppendAsync("{\"a\":0}", CancellationToken.None);
+        await sut.AppendAsync("{\"a\":1}", CancellationToken.None);
+
+        var lines = await File.ReadAllLinesAsync(_filePath);
+        lines.Should().HaveCount(4);
+        // The chain genesis is the first record written after rollout.
+        lines[2].Split('\t')[2].Should().Be(HashChainedJsonlWriter.GenesisHash);
+        lines[2].Should().EndWith("\t0");
+
+        var result = await sut.VerifyChainAsync(CancellationToken.None);
+        result.IsValid.Should().BeTrue();
+        result.VerifiedCount.Should().Be(2); // only the chained records count
+    }
+
+    [Fact]
+    public async Task Append_PayloadWithRawTab_IsRejected()
+    {
+        using var sut = NewWriter();
+        var result = await sut.AppendAsync("{\"a\":\"has\ttab\"}", CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Errors.Should().ContainSingle().Which.Should().Contain("tab");
+        File.Exists(_filePath).Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData("{\"a\":\"has\nnewline\"}")]
+    [InlineData("{\"a\":\"has\rcarriage\"}")]
+    public async Task Append_PayloadWithRawLineBreak_IsRejected(string payload)
+    {
+        using var sut = NewWriter();
+        var result = await sut.AppendAsync(payload, CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        File.Exists(_filePath).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Append_AfterForgedTailLine_ContinuesFromLastValidHeadNotTheForgedLine()
+    {
+        using (var first = NewWriter())
+        {
+            await first.AppendAsync("{\"a\":0}", CancellationToken.None);
+            await first.AppendAsync("{\"a\":1}", CancellationToken.None);
+            await first.AppendAsync("{\"a\":2}", CancellationToken.None);
+        }
+
+        var lines = (await File.ReadAllLinesAsync(_filePath)).ToList();
+        var lastValidHash = lines[2].Split('\t')[1]; // record hash of sequence 2
+
+        // An attacker appends a structurally-valid but forged line out of band.
+        var forged = string.Join('\t', "{\"x\":666}", new string('f', 64), new string('e', 64), "99");
+        await File.AppendAllTextAsync(_filePath, forged + "\n");
+
+        // A fresh instance recovers its head and must chain onto the last VALID record (seq 2),
+        // never onto the forged tail.
+        using var second = NewWriter();
+        (await second.AppendAsync("{\"a\":3}", CancellationToken.None)).IsSuccess.Should().BeTrue();
+
+        var newLine = (await File.ReadAllLinesAsync(_filePath)).Last();
+        newLine.Should().EndWith("\t3"); // sequence = lastValidSequence (2) + 1
+        newLine.Split('\t')[2].Should().Be(lastValidHash); // previousHash links to seq 2, not the forged line
+
+        // The forged line is still surfaced as a break by verification.
+        var verification = await second.VerifyChainAsync(CancellationToken.None);
+        verification.IsValid.Should().BeFalse();
+        verification.FirstBrokenSequence.Should().Be(3);
+    }
+
+    [Fact]
+    public async Task Append_ConcurrentWrites_KeepSequencesMonotonicAndChainIntact()
+    {
+        using var sut = NewWriter();
+
+        var tasks = Enumerable.Range(0, 50)
+            .Select(i => sut.AppendAsync($"{{\"a\":{i}}}", CancellationToken.None))
+            .ToArray();
+        await Task.WhenAll(tasks);
+
+        var result = await sut.VerifyChainAsync(CancellationToken.None);
+        result.IsValid.Should().BeTrue();
+        result.VerifiedCount.Should().Be(50);
+
+        var sequences = (await File.ReadAllLinesAsync(_filePath))
+            .Select(l => long.Parse(l.Split('\t')[3]))
+            .OrderBy(x => x)
+            .ToArray();
+        sequences.Should().Equal(Enumerable.Range(0, 50).Select(i => (long)i));
+    }
+}


### PR DESCRIPTION
## Why
Gap analysis vs the *AI Gateway Blueprint* article surfaced one genuine, on-brand gap for a compliance template: the audit logs are append-only but **not tamper-evident**. Two of the four JSONL writers (`changes`, `egress`) had **no integrity check at all**; the other two hash each record in isolation (catches accidents, not deliberate edits). None chain.

This is **PR 1 of 3** (plan: `.claude/plans/tamper-evident-audit-chain.md`).

## What
- New `HashChainedJsonlWriter` primitive: links every record to its predecessor via SHA-256. Line format `{json}\t{recordHash}\t{previousHash}\t{sequence}`. Any retroactive edit/delete/reorder breaks the chain at the first affected record.
- **Trusted head recovery**: on restart the head is rebuilt by *validating* the chain and seeding from the last cryptographically-valid record — a forged or torn tail cannot poison the live head.
- Framing-safe (rejects raw tab/CR/LF in payloads), strict sequence parsing, brownfield-safe (legacy un-chained lines tolerated).
- Migrated `JsonlChangeAuditWriter` + `JsonlEgressAuditWriter` (the two with zero integrity) onto the chain.
- New `AuditChainVerificationResult` domain value object.

## Not in this PR
- Drift + escalation stores onto the chain, plus the nightly chain-verification job → **PR 2**.
- Content/hash separation + right-to-erasure wiring (only if a sink stores raw prompts) → **PR 3**.

## Test plan
- 14 new unit tests for the primitive: clean-chain verify, exact-sequence tamper detection, deletion (sequence gap), sophisticated re-hash (previous-hash mismatch), cross-restart continuation, forged-tail recovery, brownfield legacy lines, framing-char rejection, 50-way concurrent append.
- Existing change/egress writer tests still green (JSON stays at line start).
- Full solution build clean (0 errors); 59 tests pass in Infrastructure.AI.Tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)