### PR TITLE
docs: relocate HANDOFF.md to documentation/design/foresight-dashboard-spec.md

### DIFF
--- a/documentation/design/foresight-dashboard-spec.md
+++ b/documentation/design/foresight-dashboard-spec.md
@@ -1,4 +1,4 @@
-# Foresight — Handoff
+# Foresight — Dashboard Design Spec
 
 A calm, readable dashboard for inspecting **what an agent actually loaded, said, and did** during a session. This document explains the design approach behind it and the data shape needed to power it.
 
@@ -131,7 +131,7 @@ project-root/
 ├── session.html              ← timeline + scrub + drawer (the gem)
 ├── context-inspector.html    ← all loaded files in category lanes
 ├── tool-drilldown.html       ← one tool invocation in depth
-├── HANDOFF.md                ← this document
+├── foresight-dashboard-spec.md  ← this document
 └── assets/
     ├── tokens.css            ← Neutral Modern design tokens + dark mode + category colors
     ├── app.css               ← shared component classes used across all four screens

--- a/src/Content/Domain/Domain.AI/Context/ContextSnapshot.cs
+++ b/src/Content/Domain/Domain.AI/Context/ContextSnapshot.cs
@@ -4,7 +4,7 @@ namespace Domain.AI.Context;
 /// The state of the model's context window immediately after turn
 /// <paramref name="TurnIndex"/> completes. <see cref="CtxAfter"/> is the
 /// per-category total at that moment; <see cref="Loaded"/> is the delta
-/// for this specific turn. Per HANDOFF.md §6.6 the invariant holds:
+/// for this specific turn. Per foresight-dashboard-spec.md §6.6 the invariant holds:
 /// <c>CtxAfter[N] = CtxAfter[N-1] + sum(Loaded[N] by category)</c>.
 /// </summary>
 /// <param name="ConversationId">Stable conversation identifier; matches the SignalR group name.</param>

--- a/src/Content/Domain/Domain.AI/Context/LoadedItem.cs
+++ b/src/Content/Domain/Domain.AI/Context/LoadedItem.cs
@@ -3,7 +3,7 @@ namespace Domain.AI.Context;
 /// <summary>
 /// One artifact that landed in the model's context this turn — a user message,
 /// an assistant response, a tool result, a freshly-loaded skill, etc.
-/// Powers the per-turn delta panel in the Foresight session view (HANDOFF §4.1).
+/// Powers the per-turn delta panel in the Foresight session view (foresight-dashboard-spec.md §4.1).
 /// </summary>
 /// <param name="What">Human label rendered in the timeline row (e.g. "User message", "Tool: Read · BillingPipeline.cs").</param>
 /// <param name="Tokens">Tokens this item added to the context window.</param>

--- a/src/Content/Presentation/Presentation.Dashboard/e2e/sessions.spec.ts
+++ b/src/Content/Presentation/Presentation.Dashboard/e2e/sessions.spec.ts
@@ -193,7 +193,7 @@ test.describe('Session Detail Page', () => {
   });
 
   test('tools panel is a collapsible details with the tool count', async ({ page }) => {
-    // CostWaterfall was dropped intentionally (HANDOFF.md §4 pure gem). The
+    // CostWaterfall was dropped intentionally (foresight-dashboard-spec.md §4 pure gem). The
     // replacement surface for tool executions is the collapsible Tool
     // executions details below the timeline.
     const toolsPanel = page.locator('[data-testid="session-tools-panel"]');

--- a/src/Content/Presentation/Presentation.Dashboard/src/components/context/ContextBar.tsx
+++ b/src/Content/Presentation/Presentation.Dashboard/src/components/context/ContextBar.tsx
@@ -40,7 +40,7 @@ const HEIGHT_BY_SIZE: Record<ContextBarSize, string> = {
  * tiny mini-bar in a table row and the full-width hero rail on the session page.
  *
  * Order, color, and shape are identical at every scale by design — see
- * HANDOFF.md §3.1.
+ * foresight-dashboard-spec.md §3.1.
  */
 export function ContextBar({
   breakdown,

--- a/src/Content/Presentation/Presentation.Dashboard/src/components/context/ContextDrawer.tsx
+++ b/src/Content/Presentation/Presentation.Dashboard/src/components/context/ContextDrawer.tsx
@@ -39,7 +39,7 @@ const ROLE_LABEL: Record<DrawerRole, string> = {
  * Right-side drawer for drilling into any loaded artifact (file or message).
  * Sticky header (category mark + name + path), line-numbered body, sticky
  * footer (prev/next + keyboard hints). Esc closes; ← / → walk through the
- * current category. See HANDOFF.md §4.2.
+ * current category. See foresight-dashboard-spec.md §4.2.
  *
  * Built on Radix Dialog — focus trap, scroll lock, and overlay come for free.
  */

--- a/src/Content/Presentation/Presentation.Dashboard/src/components/context/ScrubStrip.tsx
+++ b/src/Content/Presentation/Presentation.Dashboard/src/components/context/ScrubStrip.tsx
@@ -32,7 +32,7 @@ const DOT_FILL_BY_ROLE: Record<TurnRole, string> = {
  * The active dot is haloed in cobalt; an optional sparkline above plots
  * cumulative tokens-in-context turn by turn.
  *
- * Used inside the hero of `session.html` per HANDOFF.md §4.3.
+ * Used inside the hero of `session.html` per foresight-dashboard-spec.md §4.3.
  */
 export function ScrubStrip({
   turns,

--- a/src/Content/Presentation/Presentation.Dashboard/src/components/metrics/MetricPanel.tsx
+++ b/src/Content/Presentation/Presentation.Dashboard/src/components/metrics/MetricPanel.tsx
@@ -51,7 +51,7 @@ const STATUS_ACCENT_BORDER: Record<MetricStatus, string> = {
  *
  * Pattern intentionally collapses the gauge axis — a 42% gauge says the same
  * thing as `42% used · ▁▂▃▅▇ +3.2%` but takes a fraction of the visual
- * budget. HANDOFF.md §3.4 restraint rule: no decorative arcs.
+ * budget. foresight-dashboard-spec.md §3.4 restraint rule: no decorative arcs.
  */
 export function MetricPanel({
   title,

--- a/src/Content/Presentation/Presentation.Dashboard/src/index.css
+++ b/src/Content/Presentation/Presentation.Dashboard/src/index.css
@@ -76,7 +76,7 @@
   --otel-panel-2: oklch(0.94 0 0);
 
   /* Foresight category colors (six segments of the context bar)
-     Order is load-bearing — see src/lib/categories.ts and HANDOFF.md §3.2 */
+     Order is load-bearing — see src/lib/categories.ts and foresight-dashboard-spec.md §3.2 */
   --cat-system:   #2F6FEB;
   --cat-agents:   #B45309;
   --cat-skills:   #17A34A;
@@ -84,7 +84,7 @@
   --cat-mcp:      #0284C7;
   --cat-messages: #4B5563;
 
-  /* Single accent (≤2 uses per screen per HANDOFF.md §3.2)
+  /* Single accent (≤2 uses per screen per foresight-dashboard-spec.md §3.2)
      Aliases --cat-system intentionally so the hero color reads as the accent */
   --cat-accent:   #2F6FEB;
 

--- a/src/Content/Presentation/Presentation.Dashboard/src/lib/categories.ts
+++ b/src/Content/Presentation/Presentation.Dashboard/src/lib/categories.ts
@@ -3,7 +3,7 @@
  *
  * Single source of truth for the six context-window segments. Every visualization
  * in the Foresight design language groups tokens by these keys. Order is
- * load-bearing — see HANDOFF.md §3.1 ("same color, same order, same shape everywhere").
+ * load-bearing — see foresight-dashboard-spec.md §3.1 ("same color, same order, same shape everywhere").
  *
  * If you change keys, labels, or order here, every Foresight component picks it up
  * automatically. CSS variables live in `src/index.css` under `--cat-*`.
@@ -76,7 +76,7 @@ export const CATEGORY_BORDER_CLASS: Record<CategoryKey, string> = {
 };
 
 /**
- * Tokens consumed by one category. Shape mirrors HANDOFF.md §6.3 `CategoryBreakdown`.
+ * Tokens consumed by one category. Shape mirrors foresight-dashboard-spec.md §6.3 `CategoryBreakdown`.
  * Every Foresight visualization (context bar, legend, table mini-bar, timeline node)
  * accepts this exact shape.
  */
@@ -101,5 +101,5 @@ export function breakdownTotal(b: CategoryBreakdown): number {
   return CATEGORY_ORDER.reduce((sum, k) => sum + b[k], 0);
 }
 
-/** Default context budget used when no per-model value is supplied. See HANDOFF.md §6.1. */
+/** Default context budget used when no per-model value is supplied. See foresight-dashboard-spec.md §6.1. */
 export const DEFAULT_CONTEXT_BUDGET = 200_000;

--- a/src/Content/Presentation/Presentation.Dashboard/src/routes/DesignSystem/DesignSystemPage.tsx
+++ b/src/Content/Presentation/Presentation.Dashboard/src/routes/DesignSystem/DesignSystemPage.tsx
@@ -68,7 +68,7 @@ export default function DesignSystemPage() {
         <h1 className="text-2xl font-bold text-foreground">Foresight Design System</h1>
         <p className="text-sm text-muted-foreground mt-1">
           Dev-only sandbox for the load-bearing Foresight primitives. See
-          <code className="font-mono text-xs ml-1">HANDOFF.md</code> for the full design spec.
+          <code className="font-mono text-xs ml-1">documentation/design/foresight-dashboard-spec.md</code> for the full design spec.
         </p>
       </header>
 

--- a/src/Content/Presentation/Presentation.Dashboard/src/routes/Sessions/ContextInspectorPage.tsx
+++ b/src/Content/Presentation/Presentation.Dashboard/src/routes/Sessions/ContextInspectorPage.tsx
@@ -19,7 +19,7 @@ import { useSessionGemState } from './gem/useSessionGemState';
 import type { LoadedItem } from '@/api/types';
 
 /**
- * Standalone Context Inspector — HANDOFF.md §9.3. Renders every loaded
+ * Standalone Context Inspector — foresight-dashboard-spec.md §9.3. Renders every loaded
  * artifact across the whole session, grouped into six category lanes.
  * Click any row → ContextDrawer opens with the (currently truncated)
  * preview body resolved by `buildDrawerContent` per category.

--- a/src/Content/Presentation/Presentation.Dashboard/src/routes/Sessions/gem/ContentsPanel.tsx
+++ b/src/Content/Presentation/Presentation.Dashboard/src/routes/Sessions/gem/ContentsPanel.tsx
@@ -47,7 +47,7 @@ function emptyLanes(): ContentsLanes {
  * renders one lane per category — or only the filtered lane when
  * `activeCategory` is set.
  *
- * Implements HANDOFF.md §4 ("CONTENTS panel — populated for active category").
+ * Implements foresight-dashboard-spec.md §4 ("CONTENTS panel — populated for active category").
  */
 export function ContentsPanel({
   snapshots,

--- a/src/Content/Presentation/Presentation.Dashboard/src/routes/Sessions/gem/SessionHero.tsx
+++ b/src/Content/Presentation/Presentation.Dashboard/src/routes/Sessions/gem/SessionHero.tsx
@@ -24,7 +24,7 @@ interface SessionHeroProps {
 
 /**
  * Composes the four Foresight hero primitives plus the contents panel into
- * the "gem" header that crowns the session page (HANDOFF.md §4). State is
+ * the "gem" header that crowns the session page (foresight-dashboard-spec.md §4). State is
  * owned externally by {@link useSessionGemState}; this component is a thin
  * presentational shell so the same composition can later be lifted to the
  * design-system sandbox or to an embedded preview.

--- a/src/Content/Presentation/Presentation.Dashboard/src/routes/Sessions/gem/SessionTimeline.tsx
+++ b/src/Content/Presentation/Presentation.Dashboard/src/routes/Sessions/gem/SessionTimeline.tsx
@@ -33,7 +33,7 @@ interface SessionTimelineProps {
 }
 
 /**
- * Per-turn rail under the hero. Each row mirrors HANDOFF.md §4: turn id +
+ * Per-turn rail under the hero. Each row mirrors foresight-dashboard-spec.md §4: turn id +
  * role pill + time + cumulative tokens, a body excerpt, a small ContextBar
  * snapshot, and the per-turn `loaded[]` items. Clicking the turn header
  * rewinds the hero; clicking any loaded item opens the drawer.


### PR DESCRIPTION
## What
The Foresight dashboard **design spec** sat at the repo root as `HANDOFF.md` — a generic, undiscoverable name — despite being cited by section number (`§3.1`, `§4.2`, `§6.3`…) in **14 source files** across `Domain.AI` and `Presentation.Dashboard`.

This moves it into `documentation/design/` (alongside the other design specs: `plugin-system-design.md`, `multi-skill-agent-execution.md`, etc.) as `foresight-dashboard-spec.md`, and updates all 17 references plus 2 in-doc self-references.

## Changes
- `git mv HANDOFF.md documentation/design/foresight-dashboard-spec.md` (rename — history preserved)
- Updated 17 `HANDOFF.md §X` / `HANDOFF §X` citations across 14 source files to `foresight-dashboard-spec.md §X`
- `DesignSystemPage.tsx` user-facing pointer now shows the full path `documentation/design/foresight-dashboard-spec.md`
- Doc title `Foresight — Handoff` → `Foresight — Dashboard Design Spec`; updated the tree-diagram self-reference

## Safety
Every source-file change is inside a comment, a CSS comment block, or inert JSX text — **zero code-logic changes** (verified: no added src line is anything but a comment/text). `git grep HANDOFF` returns nothing; all new references resolve to the moved file.

## Test plan
Docs/comment-only — no behavior change. CI build confirms compilation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)