### PR TITLE
Dashboard metric-emission harness + fix 3 broken tiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,7 @@ logs/
 ## AgentHub runtime artifacts
 src/Content/Presentation/Presentation.AgentHub/conversations/
 src/Content/Presentation/Presentation.AgentHub/traces/
+src/Content/Presentation/Presentation.AgentHub/data/
 coverage-final/
 coverage-out*/
 infra-cov*/

--- a/src/Content/Application/Application.AI.Common/Middleware/ObservabilityMiddleware.cs
+++ b/src/Content/Application/Application.AI.Common/Middleware/ObservabilityMiddleware.cs
@@ -108,7 +108,10 @@ public sealed class ObservabilityMiddleware : DelegatingChatClient
         var outputTokens = (int)Math.Min(usage.OutputTokenCount ?? 0, int.MaxValue);
         var cacheRead = GetAdditionalCount(usage, "cache_read_input_tokens");
         var cacheWrite = GetAdditionalCount(usage, "cache_creation_input_tokens");
-        var model = options?.ModelId;
+        // Prefer the model the provider actually reported on the response; the per-call
+        // ChatOptions.ModelId is usually null because the model is configured on the client.
+        // A still-null model is defaulted to a priced model downstream in LlmUsageCapture.
+        var model = response.ModelId ?? options?.ModelId;
 
         (_usageCapture ?? LlmUsageCapture.Current)?.Record(inputTokens, outputTokens, cacheRead, cacheWrite, model);
     }

--- a/src/Content/Application/Application.AI.Common/Services/LlmUsageCapture.cs
+++ b/src/Content/Application/Application.AI.Common/Services/LlmUsageCapture.cs
@@ -27,6 +27,7 @@ public sealed class LlmUsageCapture : ILlmUsageCapture
     }
 
     private readonly Dictionary<string, ModelPricingEntry> _pricing;
+    private readonly string _defaultModel;
     private readonly object _lock = new();
 
     private int _inputTokens;
@@ -59,6 +60,7 @@ public sealed class LlmUsageCapture : ILlmUsageCapture
         _pricing = new Dictionary<string, ModelPricingEntry>(StringComparer.OrdinalIgnoreCase);
         foreach (var entry in config.Models)
             _pricing[entry.Name] = entry;
+        _defaultModel = config.DefaultModel;
     }
 
     public void Record(int inputTokens, int outputTokens, int cacheRead, int cacheWrite, string? model)
@@ -137,7 +139,12 @@ public sealed class LlmUsageCapture : ILlmUsageCapture
     {
         lock (_lock)
         {
-            var cost = ComputeCost(_inputTokens, _outputTokens, _cacheRead, _cacheWrite, _model);
+            // A null per-call model (the chat client frequently doesn't surface ModelId
+            // per request — the model is configured on the client) must still price. Fall
+            // back to the configured DefaultModel so cost is computed and the stored model
+            // is meaningful instead of null — the cause of $0 cost on 216/217 prod messages.
+            var model = _model ?? _defaultModel;
+            var cost = ComputeCost(_inputTokens, _outputTokens, _cacheRead, _cacheWrite, model);
             var totalInput = _inputTokens + _cacheRead;
             var cacheHitPct = totalInput > 0 ? (decimal)_cacheRead / totalInput : 0m;
 
@@ -154,7 +161,7 @@ public sealed class LlmUsageCapture : ILlmUsageCapture
 
             var snapshot = new LlmUsageSnapshot(
                 _inputTokens, _outputTokens, _cacheRead, _cacheWrite,
-                _model, cost, Math.Round(cacheHitPct, 4), toolNames)
+                model, cost, Math.Round(cacheHitPct, 4), toolNames)
             {
                 ToolInvocations = invocations
             };

--- a/src/Content/Application/Application.Core/CQRS/RAG/IngestDocument/IngestDocumentCommandHandler.cs
+++ b/src/Content/Application/Application.Core/CQRS/RAG/IngestDocument/IngestDocumentCommandHandler.cs
@@ -106,6 +106,7 @@ public sealed class IngestDocumentCommandHandler
 
 			sw.Stop();
 
+			RagIngestionMetrics.Documents.Add(1);
 			RagIngestionMetrics.ChunksProduced.Add(chunks.Count);
 			RagIngestionMetrics.TokensEmbedded.Add(totalTokens);
 			RagIngestionMetrics.Duration.Record(sw.Elapsed.TotalMilliseconds);

--- a/src/Content/Infrastructure/Infrastructure.Observability/Processors/LlmTokenTrackingProcessor.cs
+++ b/src/Content/Infrastructure/Infrastructure.Observability/Processors/LlmTokenTrackingProcessor.cs
@@ -93,7 +93,13 @@ public sealed class LlmTokenTrackingProcessor : BaseProcessor<Activity>
         // Compute and record cost
         // Note: gen_ai.usage.input_tokens is the non-cached input portion.
         // Cache-read tokens are reported separately and priced at the lower cache rate.
-        if (_pricingLookup.TryGetValue(model, out var pricing))
+        // Fall back to the configured default model's pricing when the span's model isn't
+        // in the pricing table (e.g. a deployment alias or an unpriced model). The prior
+        // `?? _defaultModel` only covered a *null* model — a non-null unpriced model skipped
+        // cost entirely, the cause of the empty Prometheus cost tiles. Mirrors LlmUsageCapture.
+        if (!_pricingLookup.TryGetValue(model, out var pricing))
+            _pricingLookup.TryGetValue(_defaultModel, out pricing);
+        if (pricing is not null)
         {
             var cost = ComputeCost(inputTokens, outputTokens, cacheReadTokens, cacheWriteTokens, pricing);
             if (cost > 0)
@@ -137,9 +143,10 @@ public sealed class LlmTokenTrackingProcessor : BaseProcessor<Activity>
             var userAgentTag = new KeyValuePair<string, object?>(AgentConventions.Name, agentName);
             UserActivityMetrics.TokensConsumed.Add(totalTokens, userTag, userAgentTag);
 
-            if (_pricingLookup.TryGetValue(model, out var userPricing))
+            // Reuse the pricing resolved above (already includes the default-model fallback).
+            if (pricing is not null)
             {
-                var userCost = ComputeCost(inputTokens, outputTokens, cacheReadTokens, cacheWriteTokens, userPricing);
+                var userCost = ComputeCost(inputTokens, outputTokens, cacheReadTokens, cacheWriteTokens, pricing);
                 if (userCost > 0)
                     UserActivityMetrics.CostAccrued.Add(userCost, userTag, userAgentTag);
             }

--- a/src/Content/Presentation/Presentation.AgentHub/Controllers/MetricsController.cs
+++ b/src/Content/Presentation/Presentation.AgentHub/Controllers/MetricsController.cs
@@ -206,7 +206,7 @@ internal static class MetricCatalog
         new() { Id = "sessions_turns_avg", Title = "Avg Turns/Session", Description = "Average conversation turns per session", Query = "agentic_harness_agent_orchestration_turns_per_conversation_sum / agentic_harness_agent_orchestration_turns_per_conversation_count or vector(0)", ChartType = "stat", Unit = "turns", Category = "sessions" },
         new() { Id = "sessions_duration_avg", Title = "Avg Duration", Description = "Average session duration", Query = "agentic_harness_agent_orchestration_conversation_duration_sum / agentic_harness_agent_orchestration_conversation_duration_count or vector(0)", ChartType = "stat", Unit = "ms", Category = "sessions" },
         new() { Id = "sessions_active_ts", Title = "Active Sessions Over Time", Description = "Session concurrency over time", Query = "agentic_harness_agent_session_active or vector(0)", ChartType = "timeseries", Unit = "count", Category = "sessions" },
-        new() { Id = "sessions_turns_ts", Title = "Turns Over Time", Description = "Conversation turns per minute", Query = "rate(agentic_harness_agent_orchestration_turns_total_total[5m]) * 60", ChartType = "timeseries", Unit = "turns/min", Category = "sessions" },
+        new() { Id = "sessions_turns_ts", Title = "Turns Over Time", Description = "Conversation turns per minute", Query = "rate(agentic_harness_agent_orchestration_turns_total[5m]) * 60", ChartType = "timeseries", Unit = "turns/min", Category = "sessions" },
 
         // --- RAG ---
         new() { Id = "rag_ingestion_total", Title = "Documents Ingested", Description = "Total documents processed for RAG", Query = "sum(agentic_harness_rag_ingestion_documents_total) or vector(0)", ChartType = "stat", Unit = "count", Category = "rag" },

--- a/src/Content/Presentation/Presentation.FoundryHost/Properties/launchSettings.json
+++ b/src/Content/Presentation/Presentation.FoundryHost/Properties/launchSettings.json
@@ -1,0 +1,12 @@
+{
+  "profiles": {
+    "Presentation.FoundryHost": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "https://localhost:53883;http://localhost:53884"
+    }
+  }
+}

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/LlmUsageCaptureTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/LlmUsageCaptureTests.cs
@@ -156,4 +156,47 @@ public class LlmUsageCaptureTests
 
         snapshot.ToolNames.Should().BeEquivalentTo(new[] { "ReadFile", "WriteFile" });
     }
+
+    // ── Cost: a null per-call model must still be priced ──
+    // Repro for the dashboard cost-tile bug. The chat client often does not surface
+    // a per-call ModelId, so the recorded model is null and cost silently computes
+    // to $0 — even though the configured DefaultModel (claude-sonnet-4-6) IS priced.
+    // Verified in prod: 216/217 session_messages had model=(null) and cost 0.0000,
+    // while the one row with a real model priced correctly.
+
+    [Fact]
+    public void TakeSnapshot_NullModel_FallsBackToConfiguredDefaultModel()
+    {
+        var sut = CreateSut(); // default config: DefaultModel = claude-sonnet-4-6
+
+        sut.Record(inputTokens: 1_000_000, outputTokens: 0, cacheRead: 0, cacheWrite: 0, model: null);
+        var snapshot = sut.TakeSnapshot();
+
+        snapshot.Model.Should().Be("claude-sonnet-4-6",
+            "a null per-call model must fall back to the configured DefaultModel so cost can be priced");
+    }
+
+    [Fact]
+    public void TakeSnapshot_NullModel_PricesCostAtDefaultModelRate()
+    {
+        var sut = CreateSut(); // claude-sonnet-4-6 input rate = $3.00 / 1M tokens
+
+        sut.Record(inputTokens: 1_000_000, outputTokens: 0, cacheRead: 0, cacheWrite: 0, model: null);
+        var snapshot = sut.TakeSnapshot();
+
+        snapshot.CostUsd.Should().Be(3.00m,
+            "1M input tokens at the default model's $3.00/M rate — was $0 because a null model skipped pricing");
+    }
+
+    [Fact]
+    public void TakeSnapshot_ExplicitModel_StillTakesPrecedenceOverDefault()
+    {
+        var sut = CreateSut(); // claude-haiku-4-5 input rate = $0.80 / 1M tokens
+
+        sut.Record(inputTokens: 1_000_000, outputTokens: 0, cacheRead: 0, cacheWrite: 0, model: "claude-haiku-4-5");
+        var snapshot = sut.TakeSnapshot();
+
+        snapshot.Model.Should().Be("claude-haiku-4-5", "an explicitly recorded model must not be overridden by the default");
+        snapshot.CostUsd.Should().Be(0.80m);
+    }
 }

--- a/src/Content/Tests/Infrastructure.Observability.Tests/Processors/LlmTokenTrackingProcessorTests.cs
+++ b/src/Content/Tests/Infrastructure.Observability.Tests/Processors/LlmTokenTrackingProcessorTests.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Diagnostics.Metrics;
 using Application.AI.Common.Interfaces;
 using Domain.AI.Telemetry.Conventions;
 using Domain.Common.Config;
@@ -129,5 +130,66 @@ public sealed class LlmTokenTrackingProcessorTests : IDisposable
 
         var act = () => processor.OnEnd(activity);
         act.Should().NotThrow();
+    }
+
+    /// <summary>
+    /// Regression guard for the empty Prometheus cost tiles: a span carrying a non-null model
+    /// that is NOT in the pricing table (e.g. a deployment alias) must still emit cost, priced
+    /// at the configured default model. Before the fix, only a *null* model fell back to the
+    /// default, so an unpriced non-null model skipped cost entirely.
+    /// </summary>
+    [Fact]
+    public void OnEnd_NonNullUnpricedModel_StillEmitsCostViaDefaultPricing()
+    {
+        const string uniqueAgent = "cost-fallback-guard-agent";
+        var config = new LlmPricingConfig
+        {
+            DefaultModel = "claude-sonnet-4-6",
+            Models =
+            [
+                new ModelPricingEntry
+                {
+                    Name = "claude-sonnet-4-6",
+                    InputPerMillion = 3.00m,
+                    OutputPerMillion = 15.00m,
+                    CacheReadPerMillion = 0.30m,
+                    CacheWritePerMillion = 3.75m
+                }
+            ]
+        };
+        var processor = CreateProcessor(config);
+
+        var costs = new List<double>();
+        using var listener = new MeterListener
+        {
+            InstrumentPublished = (instrument, l) =>
+            {
+                if (instrument.Name == TokenConventions.CostEstimated)
+                    l.EnableMeasurementEvents(instrument);
+            }
+        };
+        listener.SetMeasurementEventCallback<double>((_, value, tags, _) =>
+        {
+            // Filter by our unique agent so concurrent tests recording the same
+            // process-global instrument can't leak measurements into this assertion.
+            foreach (var tag in tags)
+                if (tag.Key == AgentConventions.Name && tag.Value as string == uniqueAgent)
+                    costs.Add(value);
+        });
+        listener.Start();
+
+        using (var activity = _source.StartActivity("llm-call")!)
+        {
+            activity.SetTag(TokenConventions.GenAiInputTokens, 1_000_000);
+            activity.SetTag(TokenConventions.GenAiOutputTokens, 0);
+            activity.SetTag(TokenConventions.GenAiRequestModel, "gpt-4o"); // non-null, NOT in the pricing table
+            activity.SetTag(AgentConventions.Name, uniqueAgent);
+            processor.OnEnd(activity);
+        }
+
+        costs.Should().NotBeEmpty(
+            "a non-null unpriced model must still emit cost via the default-model pricing fallback");
+        costs.Sum().Should().BeApproximately(3.00, 0.0001,
+            "1,000,000 input tokens priced at the default model's $3.00/M rate");
     }
 }

--- a/src/Content/Tests/Presentation.AgentHub.Tests/Telemetry/Contracts/InstrumentDefinition.cs
+++ b/src/Content/Tests/Presentation.AgentHub.Tests/Telemetry/Contracts/InstrumentDefinition.cs
@@ -15,11 +15,11 @@ public sealed record InstrumentDefinition(
 {
     public string ToPrometheusName(string @namespace)
     {
-        var baseName = Name.Replace('.', '_');
-        var unitSuffix = GetUnitSuffix();
-        var typeSuffix = GetTypeSuffix();
+        var core = Name.Replace('.', '_') + GetUnitSuffix();
 
-        return $"{@namespace}_{baseName}{unitSuffix}{typeSuffix}";
+        return Type == InstrumentType.Counter
+            ? $"{@namespace}_{WithCounterTotal(core)}"
+            : $"{@namespace}_{core}";
     }
 
     public IReadOnlyList<string> ToAllPrometheusNames(string @namespace)
@@ -37,7 +37,8 @@ public sealed record InstrumentDefinition(
             },
             InstrumentType.Counter => new[]
             {
-                $"{@namespace}_{baseName}{unitSuffix}_total"
+                // Exporter appends _total but does not double it when already present.
+                $"{@namespace}_{WithCounterTotal(baseName + unitSuffix)}"
             },
             InstrumentType.UpDownCounter => new[]
             {
@@ -68,12 +69,11 @@ public sealed record InstrumentDefinition(
         };
     }
 
-    private string GetTypeSuffix()
-    {
-        return Type switch
-        {
-            InstrumentType.Counter => "_total",
-            _ => string.Empty
-        };
-    }
+    /// <summary>
+    /// Appends the Prometheus counter <c>_total</c> suffix, matching the OTel Prometheus
+    /// exporter which does NOT double the suffix when the instrument name already ends in
+    /// <c>_total</c> (e.g. <c>agent.orchestration.turns_total</c> → <c>..._turns_total</c>).
+    /// </summary>
+    private static string WithCounterTotal(string core) =>
+        core.EndsWith("_total", StringComparison.Ordinal) ? core : $"{core}_total";
 }

--- a/src/Content/Tests/Presentation.AgentHub.Tests/Telemetry/DashboardMetricEmissionTests.cs
+++ b/src/Content/Tests/Presentation.AgentHub.Tests/Telemetry/DashboardMetricEmissionTests.cs
@@ -1,0 +1,275 @@
+using System.Reflection;
+using System.Text.RegularExpressions;
+using Application.Core.CQRS.Agents.RunConversation;
+using FluentAssertions;
+using FluentAssertions.Execution;
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+using OpenTelemetry.Metrics;
+using Presentation.AgentHub.Tests.Telemetry.Fixtures;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Presentation.AgentHub.Tests.Telemetry;
+
+/// <summary>
+/// Reconciles each dashboard tile against what a real agent turn actually EMITS — the gap
+/// that <see cref="DashboardContractTests"/> (names vs a declared contract) and the SPA
+/// component tests (rendered against mock data) both miss.
+///
+/// A tile is "broken" when its PromQL references a metric the running system never records.
+/// Because most catalog queries end in <c>or vector(0)</c>, such a tile renders <c>0</c> rather
+/// than blank — it looks healthy while showing nothing. This turns "which tiles actually have
+/// data?" into a test you run, instead of clicking every panel.
+///
+/// The <see cref="Tiles"/> table is the source of truth, classifying every catalog tile (by its
+/// catalog <c>Id</c>) as:
+/// <list type="bullet">
+///   <item><see cref="TileStatus.AlwaysOn"/> — its metric emits on any basic turn. Enforced by
+///   <see cref="AlwaysOnTiles_EmitOnABasicTurn"/>: a regression here means the working half of the
+///   dashboard went dark (e.g. the app stopped exporting to the collector).</item>
+///   <item><see cref="TileStatus.Conditional"/> — emits only when a specific thing happens (a tool
+///   call, a cache hit, a safety block, a configured budget, real LLM token usage). Legitimately
+///   blank on a no-op turn.</item>
+///   <item><see cref="TileStatus.KnownGap"/> — SHOULD have data but never will, because of a
+///   confirmed bug. Each carries the reason. Fixing the bug means moving the tile out of KnownGap,
+///   at which point the emission guard starts enforcing it.</item>
+/// </list>
+/// </summary>
+[Trait("Category", "Telemetry")]
+[Trait("Category", "Integration")]
+public sealed partial class DashboardMetricEmissionTests : IClassFixture<MetricsIntegrationFactory>
+{
+    private readonly MetricsIntegrationFactory _factory;
+    private readonly ITestOutputHelper _output;
+
+    public DashboardMetricEmissionTests(MetricsIntegrationFactory factory, ITestOutputHelper output)
+    {
+        _factory = factory;
+        _output = output;
+    }
+
+    /// <summary>Whether a dashboard tile has real data behind it.</summary>
+    public enum TileStatus
+    {
+        /// <summary>Metric emits on any basic turn; the emission guard enforces it.</summary>
+        AlwaysOn,
+
+        /// <summary>Emits only when a specific activity occurs; blank on a no-op turn is fine.</summary>
+        Conditional,
+
+        /// <summary>Should have data but never will, due to a confirmed bug.</summary>
+        KnownGap,
+    }
+
+    /// <summary>
+    /// Every dashboard tile, keyed by its catalog <c>Id</c>, with its data status and a reason.
+    /// Asserted complete by <see cref="EveryDashboardTile_IsClassified"/> — a new tile cannot be
+    /// added without recording whether it actually has data.
+    /// </summary>
+    private static readonly IReadOnlyDictionary<string, (TileStatus Status, string Note)> Tiles =
+        new Dictionary<string, (TileStatus, string)>
+        {
+            // ── Overview ──
+            ["tokens_per_minute"] = (TileStatus.Conditional, "needs real LLM token usage"),
+            ["active_sessions"] = (TileStatus.AlwaysOn, "agent_session_active toggles every session"),
+            ["cost_today"] = (TileStatus.Conditional, "needs real LLM token usage; cost now priced via the default-model fallback (fixed 2026-06-22)"),
+            ["cache_hit_rate"] = (TileStatus.Conditional, "needs real LLM token usage"),
+            ["safety_violations"] = (TileStatus.AlwaysOn, "ContentSafetyBehavior emits evaluations every turn"),
+            ["budget_status"] = (TileStatus.Conditional, "budget gauges only register when BudgetTracking.Enabled=true (dormant by default)"),
+
+            // ── Tokens ──
+            ["tokens_input_total"] = (TileStatus.Conditional, "needs real LLM token usage (works in prod, not with the stub)"),
+            ["tokens_output_total"] = (TileStatus.Conditional, "needs real LLM token usage"),
+            ["tokens_cache_read"] = (TileStatus.Conditional, "needs a prompt-cache read"),
+            ["tokens_cache_write"] = (TileStatus.Conditional, "needs a prompt-cache write"),
+            ["tokens_input_rate"] = (TileStatus.Conditional, "needs real LLM token usage"),
+            ["tokens_output_rate"] = (TileStatus.Conditional, "needs real LLM token usage"),
+            ["tokens_by_model"] = (TileStatus.Conditional, "needs real LLM token usage"),
+            ["tokens_cache_hit_rate_ts"] = (TileStatus.Conditional, "needs real LLM token usage"),
+
+            // ── Cost (fixed 2026-06-22: cost now prices via the default-model fallback in
+            //    LlmUsageCapture + LlmTokenTrackingProcessor; needs real token usage to be non-zero) ──
+            ["cost_total"] = (TileStatus.Conditional, "needs real LLM token usage (fixed: default-model pricing fallback)"),
+            ["cost_rate"] = (TileStatus.Conditional, "needs real LLM token usage (fixed)"),
+            ["cost_by_model"] = (TileStatus.Conditional, "needs real LLM token usage (fixed)"),
+            ["cost_cache_savings"] = (TileStatus.Conditional, "needs cache-read tokens (fixed: default-model pricing fallback)"),
+            ["cost_budget_remaining"] = (TileStatus.Conditional, "budget thresholds only register when BudgetTracking.Enabled=true"),
+
+            // ── Tools (counts work once a tool runs; quality metrics are a gap) ──
+            ["tools_calls_total"] = (TileStatus.Conditional, "needs a tool call (agent_tool_invocations works in prod)"),
+            ["tools_errors_total"] = (TileStatus.KnownGap, "tool_errors only records on an 'execute_tool' span the function-invocation middleware never emits"),
+            ["tools_avg_latency"] = (TileStatus.KnownGap, "tool_duration depends on the missing 'execute_tool' span"),
+            ["tools_result_size"] = (TileStatus.KnownGap, "tool_result_size depends on the missing 'execute_tool' span"),
+            ["tools_calls_by_tool"] = (TileStatus.Conditional, "needs a tool call"),
+            ["tools_latency_by_tool"] = (TileStatus.KnownGap, "tool_duration depends on the missing 'execute_tool' span"),
+            ["tools_error_rate"] = (TileStatus.KnownGap, "tool_errors depends on the missing 'execute_tool' span"),
+
+            // ── Safety ──
+            ["safety_total"] = (TileStatus.AlwaysOn, "evaluations emit every turn"),
+            ["safety_blocked"] = (TileStatus.Conditional, "needs content the safety filter blocks"),
+            ["safety_violations_ts"] = (TileStatus.AlwaysOn, "evaluations emit every turn"),
+            ["safety_by_category"] = (TileStatus.AlwaysOn, "evaluations emit every turn (category tag present)"),
+            ["safety_block_rate"] = (TileStatus.Conditional, "needs a block to be non-zero"),
+
+            // ── Sessions ──
+            ["sessions_total"] = (TileStatus.AlwaysOn, "session_started emits every conversation"),
+            ["sessions_active"] = (TileStatus.AlwaysOn, "session_active toggles every session"),
+            ["sessions_turns_avg"] = (TileStatus.AlwaysOn, "turns_per_conversation emits at conversation end"),
+            ["sessions_duration_avg"] = (TileStatus.AlwaysOn, "conversation_duration emits at conversation end"),
+            ["sessions_active_ts"] = (TileStatus.AlwaysOn, "session_active toggles every session"),
+            ["sessions_turns_ts"] = (TileStatus.AlwaysOn, "turns_total emits every turn (fixed 2026-06-22: removed the doubled _total suffix in the catalog query + the naming contract)"),
+
+            // ── RAG (only runs when the agent exercises retrieval/ingestion tools) ──
+            ["rag_ingestion_total"] = (TileStatus.Conditional, "needs a document ingestion (fixed 2026-06-22: Documents.Add now called in IngestDocumentCommandHandler)"),
+            ["rag_retrieval_total"] = (TileStatus.Conditional, "needs a RAG retrieval; also skipped on the routed-pipeline path"),
+            ["rag_avg_latency"] = (TileStatus.Conditional, "needs a RAG retrieval"),
+            ["rag_chunks_avg"] = (TileStatus.Conditional, "needs a RAG retrieval"),
+            ["rag_ingestion_rate"] = (TileStatus.Conditional, "needs a document ingestion (fixed: rag_ingestion_documents now incremented)"),
+            ["rag_retrieval_latency_ts"] = (TileStatus.Conditional, "needs a RAG retrieval"),
+
+            // ── Budget (dormant until a consumer enables + configures budgets) ──
+            ["budget_spent"] = (TileStatus.Conditional, "ObservableGauge dormant unless BudgetTracking.Enabled=true"),
+            ["budget_limit"] = (TileStatus.Conditional, "ObservableGauge dormant unless BudgetTracking.Enabled=true"),
+            ["budget_remaining"] = (TileStatus.Conditional, "ObservableGauge dormant unless BudgetTracking.Enabled=true"),
+            ["budget_utilization"] = (TileStatus.Conditional, "ObservableGauge dormant unless BudgetTracking.Enabled=true"),
+            ["budget_spend_rate"] = (TileStatus.Conditional, "session_cost needs real LLM token usage"),
+        };
+
+    [GeneratedRegex(@"agentic_harness_[a-z][a-z0-9_]+")]
+    private static partial Regex MetricNamePattern();
+
+    /// <summary>
+    /// Every tile in the catalog must appear in <see cref="Tiles"/>. Fails when a new dashboard
+    /// tile is added without recording whether it actually has data — the omission that let the
+    /// cost/tool/rag tiles ship silently broken.
+    /// </summary>
+    [Fact]
+    public void EveryDashboardTile_IsClassified()
+    {
+        var catalogIds = GetCatalogEntries().Select(e => e.Id).Distinct().ToList();
+        catalogIds.Should().NotBeEmpty("the catalog must define at least one tile");
+
+        using var _ = new AssertionScope();
+        foreach (var id in catalogIds.OrderBy(i => i))
+            Tiles.ContainsKey(id).Should().BeTrue(
+                $"dashboard tile '{id}' is not classified in {nameof(DashboardMetricEmissionTests)}." +
+                $"{nameof(Tiles)} — add it as AlwaysOn, Conditional, or KnownGap so its data status is tracked");
+    }
+
+    /// <summary>
+    /// Runs a real agent turn and asserts every <see cref="TileStatus.AlwaysOn"/> tile's metric
+    /// was actually emitted. This is the alarm that fires when the working half of the dashboard
+    /// goes dark — the failure a mock-based render test cannot see.
+    /// </summary>
+    [Fact]
+    public async Task AlwaysOnTiles_EmitOnABasicTurn()
+    {
+        await RunBasicTurnAsync();
+        var scrape = await ScrapeMetricsAsync();
+
+        // ToLookup (not ToDictionary) tolerates the catalog's duplicate tile Ids — e.g.
+        // "budget_status" is defined in both the Overview and Budget categories.
+        var byId = GetCatalogEntries().ToLookup(e => e.Id, e => e.Query);
+
+        var failures = new List<string>();
+        foreach (var (id, _) in Tiles.Where(t => t.Value.Status == TileStatus.AlwaysOn))
+        {
+            foreach (var query in byId[id]) // empty when the Id is absent; coverage test owns Id drift
+            foreach (var prefixed in MetricNamePattern().Matches(query).Select(m => m.Value).Distinct())
+            {
+                var unprefixed = prefixed["agentic_harness_".Length..];
+                if (!scrape.Contains(unprefixed, StringComparison.Ordinal))
+                    failures.Add($"tile '{id}' expects '{unprefixed}' but it was not emitted");
+            }
+        }
+
+        if (failures.Count > 0)
+            _output.WriteLine("Emitted agent/rag metrics:\n" + string.Join("\n", EmittedMetricNames(scrape)));
+
+        failures.Should().BeEmpty(
+            "every AlwaysOn tile's metric must be emitted by a basic turn — any miss means those " +
+            "dashboard tiles are dark for everyone:\n" + string.Join("\n", failures));
+    }
+
+    /// <summary>
+    /// Documents the confirmed broken tiles as a living record. Each KnownGap carries a reason;
+    /// the list is logged so the count of silently-broken tiles is visible at a glance.
+    /// </summary>
+    [Fact]
+    public void KnownGapTiles_AreDocumentedWithReasons()
+    {
+        var gaps = Tiles.Where(t => t.Value.Status == TileStatus.KnownGap).ToList();
+
+        using var _ = new AssertionScope();
+        foreach (var gap in gaps)
+            gap.Value.Note.Should().NotBeNullOrWhiteSpace($"KnownGap tile '{gap.Key}' must document why it has no data");
+
+        _output.WriteLine($"Dashboard KnownGap tiles ({gaps.Count}):\n" +
+            string.Join("\n", gaps.OrderBy(g => g.Key).Select(g => $"  {g.Key} — {g.Value.Note}")));
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Helpers
+    // ─────────────────────────────────────────────────────────────────────────
+
+    private async Task RunBasicTurnAsync()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+
+        var command = new RunConversationCommand
+        {
+            AgentName = "emission-test-agent",
+            UserMessages = ["Hello from the dashboard emission test"],
+            MaxTurns = 1,
+        };
+
+        var result = await mediator.Send(command, CancellationToken.None);
+        result.Success.Should().BeTrue("the stub agent factory should return a valid response");
+    }
+
+    private async Task<string> ScrapeMetricsAsync()
+    {
+        _factory.Services.GetService<MeterProvider>()?.ForceFlush();
+
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Add(TestAuthHandler.UserIdHeader, "dashboard-emission");
+
+        var response = await client.GetAsync("/metrics");
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadAsStringAsync();
+    }
+
+    private static IEnumerable<string> EmittedMetricNames(string scrape) =>
+        scrape.Split('\n')
+            .Where(l => l.StartsWith("# TYPE ", StringComparison.Ordinal))
+            .Select(l => l.Split(' ') is { Length: >= 4 } p ? p[2] : l)
+            .Where(n => n.StartsWith("agent_", StringComparison.Ordinal) || n.StartsWith("rag_", StringComparison.Ordinal))
+            .OrderBy(n => n);
+
+    /// <summary>Reads the internal <c>MetricCatalog.Entries</c> (Id, Query) pairs via reflection.</summary>
+    private static IReadOnlyList<(string Id, string Query)> GetCatalogEntries()
+    {
+        var hubAssembly = Assembly.GetAssembly(typeof(Program))
+            ?? throw new InvalidOperationException("Could not load Presentation.AgentHub assembly via typeof(Program)");
+
+        var catalogType = hubAssembly.GetTypes().SingleOrDefault(t => t.Name == "MetricCatalog")
+            ?? throw new InvalidOperationException("MetricCatalog type not found");
+
+        var entries = catalogType.GetField("Entries", BindingFlags.Public | BindingFlags.Static)?.GetValue(null)
+            as System.Collections.IEnumerable
+            ?? throw new InvalidOperationException("MetricCatalog.Entries not found or not enumerable");
+
+        var result = new List<(string, string)>();
+        foreach (var entry in entries)
+        {
+            var type = entry.GetType();
+            var id = type.GetProperty("Id")?.GetValue(entry) as string;
+            var query = type.GetProperty("Query")?.GetValue(entry) as string;
+            if (!string.IsNullOrWhiteSpace(id) && !string.IsNullOrWhiteSpace(query))
+                result.Add((id, query));
+        }
+        return result;
+    }
+}


### PR DESCRIPTION
## What

Adds a tile-by-tile **metric-emission test** (`DashboardMetricEmissionTests`) that runs a real agent turn and asserts each dashboard catalog tile's metric is actually emitted — the gap that the name-contract test (names only) and the SPA mock-render tests both miss. It classifies every tile **AlwaysOn / Conditional / KnownGap** and guards the working set against regression (e.g. the app silently not exporting metrics — which is how this whole investigation started).

Building the harness surfaced and fixed **three real instrumentation bugs**:

### 1. Cost — all cost tiles + budget spend
The model arrived **null/unpriced**, so cost computed to **$0** (verified in prod: 216/217 `session_messages` had a null model; the one with a priced model costed correctly). Fix: resolve a null model to the configured `DefaultModel` before pricing, in both `LlmUsageCapture` (Postgres/session cost) and `LlmTokenTrackingProcessor.OnEnd` (Prometheus metric + budget `RecordSpend`); also capture the real model from `response.ModelId` in `ObservabilityMiddleware`.

### 2. "Turns Over Time" tile
A doubled `_total` suffix queried a non-existent metric. Fixed the catalog query **and** the naming contract's `_total` dedup so both match the real exported name (`agent_orchestration_turns_total`).

### 3. "Documents Ingested" tile
`RagIngestionMetrics.Documents` was defined but never incremented; added the missing `Add` in the ingest success path.

## Tests
3 emission-harness + 3 `LlmUsageCapture` cost + 1 `MeterListener` cost-emission guard. Full build 0 errors; telemetry/contract (59), capture (12), processor (6), Application.AI.Common (351) all green.

## Known follow-ups (not in this PR)
- Tool-quality metrics (errors/latency/result_size) — needs the `execute_tool` span; the meaty remaining bug.
- Duplicate `budget_status` catalog tile Id — trivial cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)