### PR TITLE
Fix Context Inspector drawer stuck on Loading via shared hook

### DIFF
--- a/src/Content/Presentation/Presentation.Dashboard/src/routes/Sessions/ContextInspectorPage.test.tsx
+++ b/src/Content/Presentation/Presentation.Dashboard/src/routes/Sessions/ContextInspectorPage.test.tsx
@@ -1,10 +1,62 @@
 import { describe, it, expect, beforeEach } from 'vitest';
+import { http, HttpResponse } from 'msw';
 import { screen, waitFor, fireEvent } from '@testing-library/react';
 import { renderRoutedPage } from '@/test/helpers/renderPage';
 import ContextInspectorPage from './ContextInspectorPage';
 import { useSessionSnapshotsStore } from '@/stores/sessionSnapshotsStore';
+import { server } from '@/test/mocks/server';
 
 const testSessionId = '11111111-1111-1111-1111-111111111111';
+
+/**
+ * A session whose snapshot carries a single `system` loaded item. The registration
+ * categories (system / skills / tools / mcp / agents) resolve their body lazily via
+ * the loaded-body endpoint — exactly the path that was stuck on "Loading…" on this
+ * page before the shared resolver hook was wired in.
+ */
+const systemSnapshot = {
+  conversationId: 'conv-1',
+  turnIndex: 0,
+  turnId: 't-00',
+  ctxAfter: { system: 857, agents: 0, skills: 0, tools: 0, mcp: 0, messages: 0 },
+  loaded: [{ what: 'System prompt', tokens: 857, cat: 'system' }],
+  capturedAtUtc: new Date().toISOString(),
+};
+
+// Sentinel the test owns end-to-end: the snapshot exposes a system item, and the
+// loaded-body endpoint returns exactly this text. Asserting on a string this test
+// controls (rather than the global handler's wording) keeps the regression guard
+// from breaking on unrelated mock edits.
+const SYSTEM_PROMPT_BODY = 'You are the harness default agent. (inspector-test sentinel)';
+
+function respondWithSystemSnapshot() {
+  server.use(
+    http.get('/api/sessions/:id', ({ params }) =>
+      HttpResponse.json({
+        session: {
+          id: params['id'] as string,
+          conversationId: 'conv-1',
+          agentName: 'TestAgent',
+        },
+        messages: [],
+        tools: [],
+        safetyEvents: [],
+        snapshots: [systemSnapshot],
+        breakdown: systemSnapshot.ctxAfter,
+      }),
+    ),
+    http.get(
+      '/api/sessions/:id/turns/:turnIndex/loaded/:loadedIndex/body',
+      ({ params }) =>
+        HttpResponse.json({
+          conversationId: 'conv-1',
+          turnIndex: Number(params['turnIndex']),
+          loadedIndex: Number(params['loadedIndex']),
+          body: SYSTEM_PROMPT_BODY,
+        }),
+    ),
+  );
+}
 
 describe('ContextInspectorPage', () => {
   beforeEach(() => {
@@ -79,5 +131,39 @@ describe('ContextInspectorPage', () => {
     await waitFor(() => {
       expect(screen.getByTestId('context-drawer')).toBeInTheDocument();
     });
+  });
+
+  it('resolves the real system-prompt body in the drawer instead of a stuck "Loading…"', async () => {
+    respondWithSystemSnapshot();
+
+    renderRoutedPage(ContextInspectorPage, {
+      route: `/sessions/${testSessionId}/context`,
+      path: '/sessions/:sessionId/context',
+    });
+
+    await waitFor(
+      () => {
+        expect(screen.getByTestId('inspector-row-system-0')).toBeInTheDocument();
+      },
+      { timeout: 3000 },
+    );
+
+    fireEvent.click(screen.getByTestId('inspector-row-system-0'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('context-drawer')).toBeInTheDocument();
+    });
+
+    // The drawer must swap its "Loading…" placeholder for the body served by the
+    // loaded-body endpoint. Before the resolver hook was wired into this page the
+    // placeholder was the final state — this is the regression guard.
+    await waitFor(() => {
+      expect(screen.getByTestId('context-drawer-body')).toHaveTextContent(
+        SYSTEM_PROMPT_BODY,
+      );
+    });
+    expect(screen.getByTestId('context-drawer-body')).not.toHaveTextContent(
+      'Loading…',
+    );
   });
 });

--- a/src/Content/Presentation/Presentation.Dashboard/src/routes/Sessions/ContextInspectorPage.tsx
+++ b/src/Content/Presentation/Presentation.Dashboard/src/routes/Sessions/ContextInspectorPage.tsx
@@ -16,6 +16,7 @@ import {
 } from '@/lib/categories';
 import { aggregateLoadedItems, totalTokensInCategory } from '@/lib/loadedItems';
 import { useSessionGemState } from './gem/useSessionGemState';
+import { useResolvedDrawerBody } from './gem/useResolvedDrawerBody';
 import type { LoadedItem } from '@/api/types';
 
 /**
@@ -48,6 +49,12 @@ export default function ContextInspectorPage() {
     messages: data?.messages ?? [],
     tools: data?.tools ?? [],
   });
+
+  // Resolve the open drawer item's full body (composed system prompt, skill
+  // instructions, tool/MCP schema, sub-agent description) via the shared hook —
+  // the same resolution SessionDetailPage uses, so both surfaces behave
+  // identically instead of this page being stuck on the "Loading…" placeholder.
+  const drawerBody = useResolvedDrawerBody(sessionId, gem.drawerItem);
 
   const lanes = useMemo(() => aggregateLoadedItems(snapshots), [snapshots]);
   // Maintain a parallel { item, turnIndex } map so each row knows which
@@ -130,7 +137,7 @@ export default function ContextInspectorPage() {
         name={gem.drawerItem?.name ?? ''}
         path={gem.drawerItem?.path ?? ''}
         role={gem.drawerItem?.content.role}
-        body={gem.drawerItem?.content.body ?? ''}
+        body={drawerBody}
         lang={gem.drawerItem?.content.lang}
         onPrev={() => gem.walkDrawer(-1)}
         onNext={() => gem.walkDrawer(1)}

--- a/src/Content/Presentation/Presentation.Dashboard/src/routes/Sessions/SessionDetailPage.tsx
+++ b/src/Content/Presentation/Presentation.Dashboard/src/routes/Sessions/SessionDetailPage.tsx
@@ -1,12 +1,7 @@
 import { useEffect, useMemo } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
-import {
-  fetchSessionDetail,
-  fetchMessageBody,
-  fetchToolInvocation,
-  fetchLoadedBody,
-} from '@/api/sessions';
+import { fetchSessionDetail } from '@/api/sessions';
 import type { SessionRecord } from '@/api/types';
 import {
   subscribeToConversationSnapshots,
@@ -31,6 +26,7 @@ import {
 import { SessionHero } from './gem/SessionHero';
 import { SessionTimeline } from './gem/SessionTimeline';
 import { useSessionGemState } from './gem/useSessionGemState';
+import { useResolvedDrawerBody } from './gem/useResolvedDrawerBody';
 
 /* ------------------------------------------------------------------ */
 /*  Main page                                                         */
@@ -70,90 +66,11 @@ export default function SessionDetailPage() {
     tools: data?.tools ?? [],
   });
 
-  // Lazy-fetch the full body for the open drawer item. The drawer renders the
-  // static preview/card from buildDrawerContent immediately; once the per-record
-  // detail lands, we override `body` with contentFull (messages) or the
-  // metadata card augmented with args + stdout (tools). Queries are gated on
-  // the drawerItem.idRef so they fire only when the item maps to a real
-  // backend record (messages / tools — not skills / agents / mcp / system).
-  const drawerIdRef = gem.drawerItem?.content.idRef;
-  const messageBodyQuery = useQuery({
-    queryKey: [
-      'session-message-body',
-      sessionId,
-      drawerIdRef?.kind === 'message' ? drawerIdRef.id : null,
-    ],
-    queryFn: () =>
-      fetchMessageBody(sessionId!, (drawerIdRef as { id: string }).id),
-    enabled: !!sessionId && drawerIdRef?.kind === 'message',
-    staleTime: 60_000,
-  });
-  const toolDetailQuery = useQuery({
-    queryKey: [
-      'session-tool-invocation',
-      sessionId,
-      drawerIdRef?.kind === 'tool' ? drawerIdRef.id : null,
-    ],
-    queryFn: () =>
-      fetchToolInvocation(sessionId!, (drawerIdRef as { id: string }).id),
-    enabled: !!sessionId && drawerIdRef?.kind === 'tool',
-    staleTime: 60_000,
-  });
-  const loadedBodyQuery = useQuery({
-    queryKey: [
-      'session-loaded-body',
-      sessionId,
-      drawerIdRef?.kind === 'loaded-body' ? drawerIdRef.turnIndex : null,
-      drawerIdRef?.kind === 'loaded-body' ? drawerIdRef.loadedIndex : null,
-    ],
-    queryFn: () => {
-      const ref = drawerIdRef as { turnIndex: number; loadedIndex: number };
-      return fetchLoadedBody(sessionId!, ref.turnIndex, ref.loadedIndex);
-    },
-    enabled: !!sessionId && drawerIdRef?.kind === 'loaded-body',
-    staleTime: 60_000,
-    // 404 is the expected response for rows that predate body capture — don't
-    // hammer the server retrying that.
-    retry: false,
-  });
-
-  const drawerBody = useMemo(() => {
-    const fallback = gem.drawerItem?.content.body ?? '';
-    if (!gem.drawerItem || !drawerIdRef) return fallback;
-
-    if (drawerIdRef.kind === 'message') {
-      const full = messageBodyQuery.data?.contentFull;
-      return typeof full === 'string' && full.length > 0 ? full : fallback;
-    }
-
-    if (drawerIdRef.kind === 'tool' && toolDetailQuery.data) {
-      // Re-serialise the JSON card with args + stdout so the drawer's `json`
-      // syntax styling continues to apply. The base card is already a JSON
-      // string in `fallback`; parse, augment, re-stringify.
-      try {
-        const card = JSON.parse(fallback) as Record<string, unknown>;
-        card['args'] = toolDetailQuery.data.args ?? null;
-        card['stdout'] = toolDetailQuery.data.stdout ?? null;
-        card['callId'] = toolDetailQuery.data.callId ?? null;
-        return JSON.stringify(card, null, 2);
-      } catch {
-        return fallback;
-      }
-    }
-
-    if (drawerIdRef.kind === 'loaded-body') {
-      const body = loadedBodyQuery.data?.body;
-      return typeof body === 'string' && body.length > 0 ? body : fallback;
-    }
-
-    return fallback;
-  }, [
-    gem.drawerItem,
-    drawerIdRef,
-    messageBodyQuery.data,
-    toolDetailQuery.data,
-    loadedBodyQuery.data,
-  ]);
+  // Lazy-resolve the open drawer item's full body (messages → contentFull,
+  // tools → card + args/stdout, registration categories → captured body) via the
+  // shared hook. ContextInspectorPage uses the identical hook so both surfaces
+  // resolve bodies the same way.
+  const drawerBody = useResolvedDrawerBody(sessionId, gem.drawerItem);
 
   if (isLoading) {
     return (

--- a/src/Content/Presentation/Presentation.Dashboard/src/routes/Sessions/gem/buildDrawerContent.ts
+++ b/src/Content/Presentation/Presentation.Dashboard/src/routes/Sessions/gem/buildDrawerContent.ts
@@ -73,9 +73,12 @@ const LOADING_BODY =
  * - `tools` → synthetic metadata card (name / status / duration / size)
  *   as JSON, plus an `idRef` so the drawer renderer can swap in the full
  *   args + stdout from `/api/sessions/:id/tools/:invocationId`.
- * - `skills` / `agents` / `mcp` / `system` → static "no body captured"
- *   note. The observability store does not currently record full bodies
- *   for these categories; the drawer shows the ref and label only.
+ * - `skills` / `agents` / `mcp` / `system` → a "Loading…" fallback plus a
+ *   `loaded-body` `idRef` (when a snapshotLoadedIndex is supplied) so the
+ *   drawer renderer fetches the captured body — composed system prompt, skill
+ *   instructions, tool/MCP schema, or sub-agent description — from
+ *   `/api/sessions/:id/turns/:turn/loaded/:idx/body` on open. The body itself
+ *   is resolved by `useResolvedDrawerBody`, shared by both drawer surfaces.
  *
  * Pure function — easy to test, easy to change content sources.
  */

--- a/src/Content/Presentation/Presentation.Dashboard/src/routes/Sessions/gem/useResolvedDrawerBody.ts
+++ b/src/Content/Presentation/Presentation.Dashboard/src/routes/Sessions/gem/useResolvedDrawerBody.ts
@@ -1,0 +1,115 @@
+import { useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import {
+  fetchMessageBody,
+  fetchToolInvocation,
+  fetchLoadedBody,
+} from '@/api/sessions';
+import type { DrawerTarget } from './useSessionGemState';
+
+/**
+ * Resolves the full body for the currently open {@link DrawerTarget}.
+ *
+ * The drawer renders the static preview/card from `buildDrawerContent`
+ * immediately (a short "Loading…" placeholder for the registration categories);
+ * this hook then lazily fetches the real body keyed off `drawerItem.content.idRef`
+ * and returns it so the caller can hand the resolved string to `ContextDrawer`.
+ *
+ *  - `message` → full `contentFull` from the message deep-link.
+ *  - `tool`    → the JSON metadata card augmented with args + stdout.
+ *  - `loaded-body` → the captured body (composed system prompt, skill
+ *    instructions, tool/MCP schema, sub-agent description) from the loaded-body
+ *    deep-link. This is the path the registration categories (system / skills /
+ *    tools / mcp / agents) take.
+ *
+ * Queries are gated on the idRef kind, so only the relevant fetch fires. When no
+ * idRef is present (e.g. a message with no backend record), the static fallback
+ * body is returned unchanged.
+ *
+ * Shared by SessionDetailPage and ContextInspectorPage so both surfaces resolve
+ * bodies identically — the two diverged once when this logic lived inline in
+ * SessionDetailPage only, leaving the Inspector stuck on "Loading…".
+ */
+export function useResolvedDrawerBody(
+  sessionId: string | undefined,
+  drawerItem: DrawerTarget | null,
+): string {
+  const idRef = drawerItem?.content.idRef;
+
+  // Narrow the discriminated union once, here, so the queries below read typed
+  // fields instead of casting past the union (a cast would let a future field
+  // rename compile and 404 at runtime).
+  const messageId = idRef?.kind === 'message' ? idRef.id : null;
+  const toolId = idRef?.kind === 'tool' ? idRef.id : null;
+  const loadedRef = idRef?.kind === 'loaded-body' ? idRef : null;
+
+  const messageBodyQuery = useQuery({
+    queryKey: ['session-message-body', sessionId, messageId],
+    queryFn: () => fetchMessageBody(sessionId!, messageId!),
+    enabled: !!sessionId && !!messageId,
+    staleTime: 60_000,
+  });
+
+  const toolDetailQuery = useQuery({
+    queryKey: ['session-tool-invocation', sessionId, toolId],
+    queryFn: () => fetchToolInvocation(sessionId!, toolId!),
+    enabled: !!sessionId && !!toolId,
+    staleTime: 60_000,
+  });
+
+  const loadedBodyQuery = useQuery({
+    queryKey: [
+      'session-loaded-body',
+      sessionId,
+      loadedRef?.turnIndex ?? null,
+      loadedRef?.loadedIndex ?? null,
+    ],
+    queryFn: () => fetchLoadedBody(sessionId!, loadedRef!.turnIndex, loadedRef!.loadedIndex),
+    enabled: !!sessionId && !!loadedRef,
+    staleTime: 60_000,
+    // 404 is the expected response for rows that predate body capture — don't
+    // hammer the server retrying that.
+    retry: false,
+  });
+
+  return useMemo(() => {
+    const fallback = drawerItem?.content.body ?? '';
+    if (!drawerItem || !idRef) return fallback;
+
+    if (idRef.kind === 'message') {
+      const full = messageBodyQuery.data?.contentFull;
+      return typeof full === 'string' && full.length > 0 ? full : fallback;
+    }
+
+    if (idRef.kind === 'tool' && toolDetailQuery.data) {
+      // Re-serialise the JSON card with args + stdout so the drawer's `json`
+      // syntax styling continues to apply. The base card is already a JSON
+      // string in `fallback`; parse, augment (immutably), re-stringify.
+      try {
+        const card = JSON.parse(fallback) as Record<string, unknown>;
+        const augmented = {
+          ...card,
+          args: toolDetailQuery.data.args ?? null,
+          stdout: toolDetailQuery.data.stdout ?? null,
+          callId: toolDetailQuery.data.callId ?? null,
+        };
+        return JSON.stringify(augmented, null, 2);
+      } catch {
+        return fallback;
+      }
+    }
+
+    if (idRef.kind === 'loaded-body') {
+      const body = loadedBodyQuery.data?.body;
+      return typeof body === 'string' && body.length > 0 ? body : fallback;
+    }
+
+    return fallback;
+  }, [
+    drawerItem,
+    idRef,
+    messageBodyQuery.data,
+    toolDetailQuery.data,
+    loadedBodyQuery.data,
+  ]);
+}


### PR DESCRIPTION
## What

The Context Inspector's detail drawer was stuck on **"Loading…" forever** — it rendered the placeholder but never fetched the real artifact body (system prompt, skill instructions, tool/MCP schema, sub-agent description).

Root cause: the lazy body-fetch logic lived **inline** in `SessionDetailPage` only and was never copied to `ContextInspectorPage`. The two drawer surfaces diverged.

## Fix

Extracted the fetch logic into one shared hook, `useResolvedDrawerBody`, now consumed by **both** pages — so they can't diverge again (that divergence was the root cause). The drawer itself is purely presentational; the hook resolves message / tool / loaded-body content and hands the drawer the final string.

## Review fixes applied
`/code-review` (8 finder angles + adversarial verify) surfaced 3 issues, all fixed before commit:
- Immutability — build the augmented tool card via spread instead of mutating it.
- Type safety — narrow the `DrawerIdRef` union by `kind` instead of unsafe casts.
- Test quality — the regression test owns its own sentinel body instead of asserting on a global mock's wording.

## Tests
Test-first: a failing test reproduced the stuck "Loading…" on a system item, then green after the fix. 353 Dashboard tests pass; typecheck + lint clean.

## Follow-up (not in this PR)
The drawer's JSX render block is still duplicated across both pages (lower-risk than the body logic, which is now shared).

🤖 Generated with [Claude Code](https://claude.com/claude-code)