### PR TITLE
feat(skill-training): two-split non-regression gate (Self-Harness)

### DIFF
--- a/src/Content/Application/Application.AI.Common/CQRS/SkillTraining/GateCandidateSkill/GateCandidateSkillCommand.cs
+++ b/src/Content/Application/Application.AI.Common/CQRS/SkillTraining/GateCandidateSkill/GateCandidateSkillCommand.cs
@@ -64,4 +64,36 @@ public sealed record GateCandidateSkillCommand : IRequest<Result<GateResult>>
     /// Ignored otherwise. Defaults to 0.5.
     /// </summary>
     public double MixedWeight { get; init; } = 0.5;
+
+    /// <summary>
+    /// Gate acceptance policy. Defaults to single-split <see cref="GateMode.StrictImprovementHeldOut"/>
+    /// — the mode needing the fewest inputs. Set to <see cref="GateMode.TwoSplitNonRegression"/> to
+    /// also require non-regression on the held-in split, in which case
+    /// <see cref="CandidateHeldInHard"/>, <see cref="CandidateHeldInSoft"/>, and
+    /// <see cref="CurrentHeldInScore"/> must be supplied.
+    /// <para>
+    /// Note: this default differs from <c>TrainSkillConfig.GateMode</c> (which defaults to the safer
+    /// two-split mode). The orchestrated training loop computes held-in scores itself, whereas this
+    /// command's caller cannot be assumed to have them — hence the strict default here.
+    /// </para>
+    /// </summary>
+    public GateMode Mode { get; init; } = GateMode.StrictImprovementHeldOut;
+
+    /// <summary>
+    /// Candidate's aggregate hard score on the held-in (proposer-visible) split in [0, 1].
+    /// Consulted only when <see cref="Mode"/> is <see cref="GateMode.TwoSplitNonRegression"/>.
+    /// </summary>
+    public double CandidateHeldInHard { get; init; }
+
+    /// <summary>
+    /// Candidate's aggregate soft score on the held-in split in [0, 1]. Consulted only in
+    /// two-split mode.
+    /// </summary>
+    public double CandidateHeldInSoft { get; init; }
+
+    /// <summary>
+    /// Metric-projected held-in score of <see cref="CurrentSkill"/> in [0, 1] — the baseline the
+    /// candidate's held-in score is compared against. Consulted only in two-split mode.
+    /// </summary>
+    public double CurrentHeldInScore { get; init; }
 }

--- a/src/Content/Application/Application.AI.Common/CQRS/SkillTraining/GateCandidateSkill/GateCandidateSkillCommandHandler.cs
+++ b/src/Content/Application/Application.AI.Common/CQRS/SkillTraining/GateCandidateSkill/GateCandidateSkillCommandHandler.cs
@@ -34,18 +34,36 @@ public sealed class GateCandidateSkillCommandHandler
         ArgumentNullException.ThrowIfNull(request);
         cancellationToken.ThrowIfCancellationRequested();
 
-        var result = _gate.Evaluate(
-            candidateSkill: request.CandidateSkill,
-            candidateHard: request.CandidateHard,
-            candidateSoft: request.CandidateSoft,
-            currentSkill: request.CurrentSkill,
-            currentScore: request.CurrentScore,
-            bestSkill: request.BestSkill,
-            bestScore: request.BestScore,
-            bestStep: request.BestStep,
-            globalStep: request.GlobalStep,
-            metric: request.Metric,
-            mixedWeight: request.MixedWeight);
+        var result = request.Mode == GateMode.TwoSplitNonRegression
+            ? _gate.EvaluateTwoSplit(new GateEvaluation
+            {
+                CandidateSkill = request.CandidateSkill,
+                CandidateHard = request.CandidateHard,
+                CandidateSoft = request.CandidateSoft,
+                CandidateHeldInHard = request.CandidateHeldInHard,
+                CandidateHeldInSoft = request.CandidateHeldInSoft,
+                CurrentSkill = request.CurrentSkill,
+                CurrentScore = request.CurrentScore,
+                CurrentHeldInScore = request.CurrentHeldInScore,
+                BestSkill = request.BestSkill,
+                BestScore = request.BestScore,
+                BestStep = request.BestStep,
+                GlobalStep = request.GlobalStep,
+                Metric = request.Metric,
+                MixedWeight = request.MixedWeight
+            })
+            : _gate.Evaluate(
+                candidateSkill: request.CandidateSkill,
+                candidateHard: request.CandidateHard,
+                candidateSoft: request.CandidateSoft,
+                currentSkill: request.CurrentSkill,
+                currentScore: request.CurrentScore,
+                bestSkill: request.BestSkill,
+                bestScore: request.BestScore,
+                bestStep: request.BestStep,
+                globalStep: request.GlobalStep,
+                metric: request.Metric,
+                mixedWeight: request.MixedWeight);
 
         return Task.FromResult(Result<GateResult>.Success(result));
     }

--- a/src/Content/Application/Application.AI.Common/CQRS/SkillTraining/GateCandidateSkill/GateCandidateSkillCommandValidator.cs
+++ b/src/Content/Application/Application.AI.Common/CQRS/SkillTraining/GateCandidateSkill/GateCandidateSkillCommandValidator.cs
@@ -53,6 +53,15 @@ public sealed class GateCandidateSkillCommandValidator : AbstractValidator<GateC
         RuleFor(x => x.MixedWeight)
             .InclusiveBetween(0.0, 1.0).WithMessage("MixedWeight must be in [0, 1].");
 
+        RuleFor(x => x.CandidateHeldInHard)
+            .InclusiveBetween(0.0, 1.0).WithMessage("CandidateHeldInHard must be in [0, 1].");
+
+        RuleFor(x => x.CandidateHeldInSoft)
+            .InclusiveBetween(0.0, 1.0).WithMessage("CandidateHeldInSoft must be in [0, 1].");
+
+        RuleFor(x => x.CurrentHeldInScore)
+            .InclusiveBetween(0.0, 1.0).WithMessage("CurrentHeldInScore must be in [0, 1].");
+
         // Cross-field: a best snapshot taken at a future step is incoherent — it would
         // mean we accepted a best before it had been evaluated. Almost always signals
         // a checkpoint-resume bug that reset GlobalStep without resetting BestStep.

--- a/src/Content/Application/Application.AI.Common/CQRS/SkillTraining/TrainSkill/TrainSkillCommandHandler.cs
+++ b/src/Content/Application/Application.AI.Common/CQRS/SkillTraining/TrainSkill/TrainSkillCommandHandler.cs
@@ -205,13 +205,62 @@ public sealed class TrainSkillCommandHandler
                 var (candHard, candSoft) = RolloutBatchScorer.Score(valRollouts);
 
                 // ── Gate ─────────────────────────────────────────────────────
-                var gateResult = _gate.Evaluate(
-                    candidateSkill: applyReport.NewSkillContent,
-                    candidateHard: candHard, candidateSoft: candSoft,
-                    currentSkill: currentSkill, currentScore: currentScore,
-                    bestSkill: bestSkill, bestScore: bestScore, bestStep: bestStep,
-                    globalStep: globalStep,
-                    metric: cfg.GateMetric, mixedWeight: cfg.MixedWeight);
+                GateResult gateResult;
+                if (cfg.GateMode == GateMode.TwoSplitNonRegression)
+                {
+                    // Held-in non-regression guard: score the candidate on the EXACT items the
+                    // current skill was just scored on (pin trainRollouts' ids), then compare the two
+                    // means. Pairing by id — the same mechanism SlowUpdate uses for longitudinal
+                    // comparison — makes Δ_in a true paired delta instead of trusting the runner to
+                    // re-sample an identical batch. The current skill's held-in score reuses this
+                    // step's trainRollouts, so only the candidate needs a fresh rollout: the one
+                    // extra rollout per step this mode costs. (If trainRollouts is empty the id list
+                    // is empty and the runner falls back to sampling — handled by the 0-rollout warn.)
+                    var heldInItemIds = trainRollouts.Select(r => r.ItemId).ToArray();
+                    var candidateTrainBatch = trainBatch with { ItemIds = heldInItemIds };
+                    var candidateTrainRollouts = await _rolloutRunner
+                        .RunAsync(applyReport.NewSkillContent, candidateTrainBatch, cancellationToken).ConfigureAwait(false);
+                    if (candidateTrainRollouts.Count == 0)
+                    {
+                        _logger.LogWarning(
+                            "Candidate train split returned 0 rollouts at step {Step}. With GateMode=TwoSplitNonRegression this scores the candidate's held-in performance as 0 and will Reject. Check TrainBatchSize and IRolloutRunner configuration.",
+                            globalStep);
+                    }
+                    var (candHardIn, candSoftIn) = RolloutBatchScorer.Score(candidateTrainRollouts);
+                    var (curHardIn, curSoftIn) = RolloutBatchScorer.Score(trainRollouts);
+                    // Project held-in current the same way the gate projects everything, so the
+                    // delta is computed in a single consistent metric space.
+                    var currentHeldInScore = _gate.SelectGateScore(
+                        curHardIn, curSoftIn, cfg.GateMetric, cfg.MixedWeight);
+
+                    gateResult = _gate.EvaluateTwoSplit(new GateEvaluation
+                    {
+                        CandidateSkill = applyReport.NewSkillContent,
+                        CandidateHard = candHard,
+                        CandidateSoft = candSoft,
+                        CandidateHeldInHard = candHardIn,
+                        CandidateHeldInSoft = candSoftIn,
+                        CurrentSkill = currentSkill,
+                        CurrentScore = currentScore,
+                        CurrentHeldInScore = currentHeldInScore,
+                        BestSkill = bestSkill,
+                        BestScore = bestScore,
+                        BestStep = bestStep,
+                        GlobalStep = globalStep,
+                        Metric = cfg.GateMetric,
+                        MixedWeight = cfg.MixedWeight
+                    });
+                }
+                else
+                {
+                    gateResult = _gate.Evaluate(
+                        candidateSkill: applyReport.NewSkillContent,
+                        candidateHard: candHard, candidateSoft: candSoft,
+                        currentSkill: currentSkill, currentScore: currentScore,
+                        bestSkill: bestSkill, bestScore: bestScore, bestStep: bestStep,
+                        globalStep: globalStep,
+                        metric: cfg.GateMetric, mixedWeight: cfg.MixedWeight);
+                }
 
                 steps.Add(NewStepRecord(globalStep, epoch, gateResult.Action,
                     candidateScore: gateResult.CandidateScore,

--- a/src/Content/Application/Application.AI.Common/Interfaces/SkillTraining/IGateEvaluator.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/SkillTraining/IGateEvaluator.cs
@@ -61,4 +61,30 @@ public interface IGateEvaluator
         int globalStep,
         GateMetric metric,
         double mixedWeight = 0.5);
+
+    /// <summary>
+    /// Evaluates a candidate under the two-split non-regression policy (Self-Harness, arXiv
+    /// 2606.09498): accept only if the candidate does not regress on either the held-out or the
+    /// held-in split and strictly improves at least one.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Distinct from <see cref="Evaluate"/> (which maximizes the held-out score alone and ignores
+    /// held-in regression) so that the single-split path — and the exhaustive tests that pin its
+    /// behavior — stay untouched. The orchestrator selects between the two via
+    /// <see cref="GateMode"/>. Best-so-far is tracked on the held-out metric in both modes, so a
+    /// candidate is promoted to new best only when its held-out score strictly beats the running
+    /// best.
+    /// </para>
+    /// <para>
+    /// Accept rule, with <c>Δ_ho = candidate_ho − current_ho</c> and
+    /// <c>Δ_in = candidate_in − current_in</c> (both metric-projected):
+    /// <c>Δ_ho ≥ 0 ∧ Δ_in ≥ 0 ∧ max(Δ_ho, Δ_in) &gt; 0</c>. Anything else is
+    /// <see cref="GateAction.Reject"/>, including a candidate that improves one split while
+    /// regressing the other.
+    /// </para>
+    /// </remarks>
+    /// <param name="evaluation">The held-out and held-in score bundle plus lineage state.</param>
+    /// <returns>The gate decision plus the new (current, best) state, with held-in audit scores.</returns>
+    GateResult EvaluateTwoSplit(GateEvaluation evaluation);
 }

--- a/src/Content/Application/Application.AI.Common/Services/SkillTraining/GateEvaluator.cs
+++ b/src/Content/Application/Application.AI.Common/Services/SkillTraining/GateEvaluator.cs
@@ -109,6 +109,67 @@ public sealed class GateEvaluator : IGateEvaluator
         };
     }
 
+    /// <inheritdoc />
+    public GateResult EvaluateTwoSplit(GateEvaluation evaluation)
+    {
+        ArgumentNullException.ThrowIfNull(evaluation);
+        ArgumentNullException.ThrowIfNull(evaluation.CandidateSkill);
+        ArgumentNullException.ThrowIfNull(evaluation.CurrentSkill);
+        ArgumentNullException.ThrowIfNull(evaluation.BestSkill);
+        EnsureFinite(evaluation.CurrentScore, nameof(evaluation.CurrentScore));
+        EnsureFinite(evaluation.CurrentHeldInScore, nameof(evaluation.CurrentHeldInScore));
+        EnsureFinite(evaluation.BestScore, nameof(evaluation.BestScore));
+
+        // Project both splits onto the comparison metric. SelectGateScore finite-checks each
+        // candidate (hard, soft) pair, so a corrupted aggregation throws here rather than silently
+        // skewing a delta.
+        var candidateHeldOut = SelectGateScore(
+            evaluation.CandidateHard, evaluation.CandidateSoft, evaluation.Metric, evaluation.MixedWeight);
+        var candidateHeldIn = SelectGateScore(
+            evaluation.CandidateHeldInHard, evaluation.CandidateHeldInSoft, evaluation.Metric, evaluation.MixedWeight);
+
+        var deltaHeldOut = candidateHeldOut - evaluation.CurrentScore;
+        var deltaHeldIn = candidateHeldIn - evaluation.CurrentHeldInScore;
+
+        // Non-regression rule (Self-Harness): no split may regress, and at least one must improve.
+        // A candidate that trades one split off against the other is rejected.
+        var accepts = deltaHeldOut >= 0.0 && deltaHeldIn >= 0.0
+            && Math.Max(deltaHeldOut, deltaHeldIn) > 0.0;
+
+        if (accepts)
+        {
+            // Best is tracked on the held-out metric, so promotion needs a strict held-out gain.
+            var newBest = candidateHeldOut > evaluation.BestScore;
+            return new GateResult
+            {
+                Action = newBest ? GateAction.AcceptNewBest : GateAction.Accept,
+                CurrentSkill = evaluation.CandidateSkill,
+                CurrentScore = candidateHeldOut,
+                BestSkill = newBest ? evaluation.CandidateSkill : evaluation.BestSkill,
+                BestScore = newBest ? candidateHeldOut : evaluation.BestScore,
+                BestStep = newBest ? evaluation.GlobalStep : evaluation.BestStep,
+                CandidateSkill = evaluation.CandidateSkill,
+                CandidateScore = candidateHeldOut,
+                CandidateHeldInScore = candidateHeldIn,
+                CurrentHeldInScore = evaluation.CurrentHeldInScore
+            };
+        }
+
+        return new GateResult
+        {
+            Action = GateAction.Reject,
+            CurrentSkill = evaluation.CurrentSkill,
+            CurrentScore = evaluation.CurrentScore,
+            BestSkill = evaluation.BestSkill,
+            BestScore = evaluation.BestScore,
+            BestStep = evaluation.BestStep,
+            CandidateSkill = evaluation.CandidateSkill,
+            CandidateScore = candidateHeldOut,
+            CandidateHeldInScore = candidateHeldIn,
+            CurrentHeldInScore = evaluation.CurrentHeldInScore
+        };
+    }
+
     private static void EnsureFinite(double value, string paramName)
     {
         if (double.IsNaN(value) || double.IsInfinity(value))

--- a/src/Content/Domain/Domain.AI/SkillTraining/GateEvaluation.cs
+++ b/src/Content/Domain/Domain.AI/SkillTraining/GateEvaluation.cs
@@ -1,0 +1,70 @@
+namespace Domain.AI.SkillTraining;
+
+/// <summary>
+/// Immutable input bundle for the two-split non-regression gate
+/// (<c>IGateEvaluator.EvaluateTwoSplit</c>). Carries both the held-out (validation) and held-in
+/// (proposer-visible) score signals the policy compares on, plus the projection metric and the
+/// running (current, best) lineage state.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The held-out fields mirror the single-split <c>Evaluate</c> contract exactly. The held-in fields
+/// (<see cref="CandidateHeldInHard"/>, <see cref="CandidateHeldInSoft"/>,
+/// <see cref="CurrentHeldInScore"/>) are the additional signal the two-split rule needs; they are
+/// the scores on the same task split the proposer reflected on.
+/// </para>
+/// <para>
+/// As with the single-split gate, candidate scores are supplied as raw (hard, soft) pairs and
+/// projected onto the comparison metric <em>inside</em> the evaluator, while the current/best scores
+/// are supplied pre-projected. Re-projecting on every call (rather than persisting projected values)
+/// keeps a candidate that ties an earlier accepted skill comparing bit-identically across checkpoint
+/// round-trips.
+/// </para>
+/// </remarks>
+public sealed record GateEvaluation
+{
+    /// <summary>The candidate skill document being evaluated.</summary>
+    public required string CandidateSkill { get; init; }
+
+    /// <summary>Candidate's aggregate hard (exact-match) score on the held-out split, in [0, 1].</summary>
+    public required double CandidateHard { get; init; }
+
+    /// <summary>Candidate's aggregate soft (graded) score on the held-out split, in [0, 1].</summary>
+    public required double CandidateSoft { get; init; }
+
+    /// <summary>Candidate's aggregate hard score on the held-in (proposer-visible) split, in [0, 1].</summary>
+    public required double CandidateHeldInHard { get; init; }
+
+    /// <summary>Candidate's aggregate soft score on the held-in split, in [0, 1].</summary>
+    public required double CandidateHeldInSoft { get; init; }
+
+    /// <summary>The currently-active skill at the moment of the comparison.</summary>
+    public required string CurrentSkill { get; init; }
+
+    /// <summary>Metric-projected held-out score of <see cref="CurrentSkill"/>, in [0, 1].</summary>
+    public required double CurrentScore { get; init; }
+
+    /// <summary>Metric-projected held-in score of <see cref="CurrentSkill"/>, in [0, 1].</summary>
+    public required double CurrentHeldInScore { get; init; }
+
+    /// <summary>The best-so-far skill across the run (tracked on the held-out metric).</summary>
+    public required string BestSkill { get; init; }
+
+    /// <summary>Metric-projected held-out score of <see cref="BestSkill"/>, in [0, 1].</summary>
+    public required double BestScore { get; init; }
+
+    /// <summary>Training step at which <see cref="BestSkill"/> was last updated.</summary>
+    public required int BestStep { get; init; }
+
+    /// <summary>Current training step (recorded when a new best is promoted).</summary>
+    public required int GlobalStep { get; init; }
+
+    /// <summary>Which metric both splits are projected onto. Defaults to <see cref="GateMetric.Hard"/>.</summary>
+    public GateMetric Metric { get; init; } = GateMetric.Hard;
+
+    /// <summary>
+    /// Soft-weight when <see cref="Metric"/> is <see cref="GateMetric.Mixed"/>. Must be in [0, 1].
+    /// Ignored otherwise. Defaults to 0.5.
+    /// </summary>
+    public double MixedWeight { get; init; } = 0.5;
+}

--- a/src/Content/Domain/Domain.AI/SkillTraining/GateMode.cs
+++ b/src/Content/Domain/Domain.AI/SkillTraining/GateMode.cs
@@ -1,0 +1,44 @@
+namespace Domain.AI.SkillTraining;
+
+/// <summary>
+/// Acceptance policy the skill-training gate applies when deciding whether to promote a
+/// candidate skill into the lineage.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The two modes encode genuinely different optimization objectives, not a cosmetic toggle over
+/// the same goal — which is why they are an explicit, configured choice rather than an inferred one:
+/// </para>
+/// <list type="bullet">
+/// <item>
+/// <description>
+/// <see cref="StrictImprovementHeldOut"/> maximizes the held-out (validation) score alone. A
+/// candidate is accepted whenever it strictly beats the current held-out score, even if it
+/// regresses on the held-in tasks the proposer reflected on. This is the original SkillOpt gate.
+/// </description>
+/// </item>
+/// <item>
+/// <description>
+/// <see cref="TwoSplitNonRegression"/> additionally requires non-regression on the held-in split,
+/// porting the acceptance rule from Self-Harness (arXiv 2606.09498). It rejects candidates that
+/// trade one split off against the other, guarding against edits that win on validation by chance
+/// while quietly breaking behavior that previously worked. This is the safer default.
+/// </description>
+/// </item>
+/// </list>
+/// </remarks>
+public enum GateMode
+{
+    /// <summary>
+    /// Accept iff the candidate strictly beats the current held-out score. Held-in scores are
+    /// ignored. Original single-split SkillOpt behavior.
+    /// </summary>
+    StrictImprovementHeldOut = 0,
+
+    /// <summary>
+    /// Accept iff the candidate does not regress on either split and strictly improves at least
+    /// one: <c>Δ_in ≥ 0 ∧ Δ_ho ≥ 0 ∧ max(Δ_in, Δ_ho) &gt; 0</c>. Safer default; rejects proposals
+    /// that only trade one split against the other.
+    /// </summary>
+    TwoSplitNonRegression = 1
+}

--- a/src/Content/Domain/Domain.AI/SkillTraining/GateResult.cs
+++ b/src/Content/Domain/Domain.AI/SkillTraining/GateResult.cs
@@ -41,4 +41,18 @@ public sealed record GateResult
 
     /// <summary>The gate-metric-projected score for the candidate.</summary>
     public required double CandidateScore { get; init; }
+
+    /// <summary>
+    /// The candidate's metric-projected score on the held-in (proposer-visible) split. Populated by
+    /// the two-split non-regression gate so the audit record shows the held-in evidence behind the
+    /// decision. Remains <c>0.0</c> for the single-split gate, which never consults a held-in split.
+    /// </summary>
+    public double CandidateHeldInScore { get; init; }
+
+    /// <summary>
+    /// The current skill's metric-projected held-in score at gate time, i.e. the baseline the
+    /// candidate's held-in score was compared against. Populated by the two-split gate; <c>0.0</c>
+    /// for the single-split gate.
+    /// </summary>
+    public double CurrentHeldInScore { get; init; }
 }

--- a/src/Content/Domain/Domain.AI/SkillTraining/TrainSkillConfig.cs
+++ b/src/Content/Domain/Domain.AI/SkillTraining/TrainSkillConfig.cs
@@ -31,6 +31,21 @@ public sealed record TrainSkillConfig
     /// <summary>Which metric the gate compares on.</summary>
     public GateMetric GateMetric { get; init; } = GateMetric.Hard;
 
+    /// <summary>
+    /// Gate acceptance policy. Defaults to <see cref="GateMode.TwoSplitNonRegression"/>, which
+    /// requires a candidate to avoid regressing on the held-in (train) split as well as improving
+    /// on the held-out (val) split. Set to <see cref="GateMode.StrictImprovementHeldOut"/> for the
+    /// original single-split behavior (maximize held-out score only). The two-split mode costs one
+    /// extra rollout per step (the candidate scored on the train split).
+    /// <para>
+    /// Note: this orchestrated loop defaults to the safer two-split mode because it can produce the
+    /// held-in scores itself. The lower-level <c>GateCandidateSkillCommand.Mode</c> intentionally
+    /// defaults to <see cref="GateMode.StrictImprovementHeldOut"/> instead — its caller must supply
+    /// held-in inputs explicitly, so it cannot assume they exist.
+    /// </para>
+    /// </summary>
+    public GateMode GateMode { get; init; } = GateMode.TwoSplitNonRegression;
+
     /// <summary>Soft weight when <see cref="GateMetric"/> is Mixed; [0, 1].</summary>
     public double MixedWeight { get; init; } = 0.5;
 

--- a/src/Content/Tests/Application.AI.Common.Tests/CQRS/SkillTraining/GateCandidateSkillCommandHandlerTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/CQRS/SkillTraining/GateCandidateSkillCommandHandlerTests.cs
@@ -62,4 +62,52 @@ public class GateCandidateSkillCommandHandlerTests
 
         await act.Should().ThrowAsync<ArgumentNullException>();
     }
+
+    [Fact]
+    public async Task Handle_TwoSplitMode_HeldInRegression_Rejects()
+    {
+        var sut = NewSut();
+        var cmd = new GateCandidateSkillCommand
+        {
+            Mode = GateMode.TwoSplitNonRegression,
+            CandidateSkill = "cand", CandidateHard = 0.9, CandidateSoft = 0.0,
+            CandidateHeldInHard = 0.4, CandidateHeldInSoft = 0.0,
+            CurrentSkill = "curr", CurrentScore = 0.5, CurrentHeldInScore = 0.6,
+            BestSkill = "best", BestScore = 0.8, BestStep = 3,
+            GlobalStep = 9,
+            Metric = GateMetric.Hard
+        };
+
+        var result = await sut.Handle(cmd, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.Action.Should().Be(
+            GateAction.Reject,
+            because: "held-out improved (0.5→0.9) but held-in regressed (0.6→0.4)");
+        result.Value.CandidateHeldInScore.Should().Be(0.4);
+        result.Value.CurrentHeldInScore.Should().Be(0.6);
+    }
+
+    [Fact]
+    public async Task Handle_TwoSplitMode_BothSplitsImprove_AcceptsNewBest()
+    {
+        var sut = NewSut();
+        var cmd = new GateCandidateSkillCommand
+        {
+            Mode = GateMode.TwoSplitNonRegression,
+            CandidateSkill = "cand", CandidateHard = 0.9, CandidateSoft = 0.0,
+            CandidateHeldInHard = 0.7, CandidateHeldInSoft = 0.0,
+            CurrentSkill = "curr", CurrentScore = 0.5, CurrentHeldInScore = 0.6,
+            BestSkill = "best", BestScore = 0.8, BestStep = 3,
+            GlobalStep = 9,
+            Metric = GateMetric.Hard
+        };
+
+        var result = await sut.Handle(cmd, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.Action.Should().Be(GateAction.AcceptNewBest);
+        result.Value.BestScore.Should().Be(0.9);
+        result.Value.CandidateHeldInScore.Should().Be(0.7);
+    }
 }

--- a/src/Content/Tests/Application.AI.Common.Tests/CQRS/SkillTraining/TrainSkillCommandHandlerTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/CQRS/SkillTraining/TrainSkillCommandHandlerTests.cs
@@ -170,6 +170,139 @@ public class TrainSkillCommandHandlerTests
         await act.Should().ThrowAsync<OperationCanceledException>();
     }
 
+    [Fact]
+    public async Task Handle_TwoSplit_HeldOutUpHeldInDownCandidate_Rejects()
+    {
+        // Candidate improves held-out (val) but regresses held-in (train) vs the initial skill.
+        // The default GateMode (TwoSplitNonRegression) must reject it.
+        var runner = new StubRolloutRunner((skill, batch) => (batch.Split, regressed: skill.Contains("regressing")) switch
+        {
+            ("train", true) => [new RolloutResult { ItemId = "t", Hard = 0.0, Soft = 0.0 }],  // candidate worse on held-in
+            ("train", false) => [new RolloutResult { ItemId = "t", Hard = 0.5, Soft = 0.5 }], // current/initial baseline
+            ("val", _) => [new RolloutResult { ItemId = "v", Hard = 1.0, Soft = 1.0 }],       // candidate better on held-out
+            _ => []
+        });
+        var proposer = new StubProposer(_ => new Patch
+        {
+            Edits = [new Edit { Op = EditOp.Append, Content = "- regressing rule" }]
+        });
+        var sut = NewSut(runner, proposer, new InMemorySkillTrainingCheckpointStore());
+
+        var result = await sut.Handle(
+            NewCommand(new TrainSkillConfig
+            {
+                Epochs = 1, StepsPerEpoch = 1, LrStart = 4, LrMin = 1,
+                LrScheduler = "constant", Patience = 6,
+                UseSlowUpdate = false, UseMetaSkill = false
+                // GateMode defaults to TwoSplitNonRegression
+            }),
+            CancellationToken.None);
+
+        result.Value!.Steps[0].Action.Should().Be(GateAction.Reject);
+        result.Value.HasAcceptedAny.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Handle_StrictMode_SameHeldInRegressingCandidate_Accepts()
+    {
+        // Identical setup to the two-split reject test; StrictImprovementHeldOut ignores the held-in
+        // split and accepts on the val improvement alone — proving the two modes genuinely differ.
+        var runner = new StubRolloutRunner((skill, batch) => (batch.Split, regressed: skill.Contains("regressing")) switch
+        {
+            ("train", true) => [new RolloutResult { ItemId = "t", Hard = 0.0, Soft = 0.0 }],
+            ("train", false) => [new RolloutResult { ItemId = "t", Hard = 0.5, Soft = 0.5 }],
+            ("val", _) => [new RolloutResult { ItemId = "v", Hard = 1.0, Soft = 1.0 }],
+            _ => []
+        });
+        var proposer = new StubProposer(_ => new Patch
+        {
+            Edits = [new Edit { Op = EditOp.Append, Content = "- regressing rule" }]
+        });
+        var sut = NewSut(runner, proposer, new InMemorySkillTrainingCheckpointStore());
+
+        var result = await sut.Handle(
+            NewCommand(new TrainSkillConfig
+            {
+                Epochs = 1, StepsPerEpoch = 1, LrStart = 4, LrMin = 1,
+                LrScheduler = "constant", Patience = 6,
+                UseSlowUpdate = false, UseMetaSkill = false,
+                GateMode = GateMode.StrictImprovementHeldOut
+            }),
+            CancellationToken.None);
+
+        result.Value!.Steps[0].Action.Should().Be(GateAction.AcceptNewBest);
+    }
+
+    [Fact]
+    public async Task Handle_TwoSplit_ScoresCandidateOnTrainSplit_OneExtraRolloutPerStep()
+    {
+        var trainCalls = 0;
+        var valCalls = 0;
+        var runner = new StubRolloutRunner((skill, batch) =>
+        {
+            if (batch.Split == "train") trainCalls++;
+            else if (batch.Split == "val") valCalls++;
+            return batch.Split == "val"
+                ? [new RolloutResult { ItemId = "v", Hard = 1.0, Soft = 1.0 }]
+                : [new RolloutResult { ItemId = "t", Hard = 0.5, Soft = 0.5 }];
+        });
+        var proposer = new StubProposer(_ => new Patch
+        {
+            Edits = [new Edit { Op = EditOp.Append, Content = "- rule" }]
+        });
+        var sut = NewSut(runner, proposer, new InMemorySkillTrainingCheckpointStore());
+
+        await sut.Handle(
+            NewCommand(new TrainSkillConfig
+            {
+                Epochs = 1, StepsPerEpoch = 1, LrStart = 4, LrMin = 1,
+                LrScheduler = "constant", Patience = 6,
+                UseSlowUpdate = false, UseMetaSkill = false
+            }),
+            CancellationToken.None);
+
+        trainCalls.Should().Be(2, because: "the proposer's reflection rollout plus the candidate's held-in rollout");
+        valCalls.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Handle_TwoSplit_PinsCandidateHeldInRolloutToCurrentItems()
+    {
+        // The candidate's held-in rollout must be scored on the SAME items the current skill saw,
+        // so Δ_in is a true paired comparison rather than a mean over a re-sampled batch.
+        var trainBatches = new List<RolloutBatch>();
+        var runner = new StubRolloutRunner((skill, batch) =>
+        {
+            if (batch.Split == "train") trainBatches.Add(batch);
+            return batch.Split == "val"
+                ? [new RolloutResult { ItemId = "v", Hard = 1.0, Soft = 1.0 }]
+                :
+                [
+                    new RolloutResult { ItemId = "item-A", Hard = 0.5, Soft = 0.5 },
+                    new RolloutResult { ItemId = "item-B", Hard = 0.5, Soft = 0.5 }
+                ];
+        });
+        var proposer = new StubProposer(_ => new Patch
+        {
+            Edits = [new Edit { Op = EditOp.Append, Content = "- rule" }]
+        });
+        var sut = NewSut(runner, proposer, new InMemorySkillTrainingCheckpointStore());
+
+        await sut.Handle(
+            NewCommand(new TrainSkillConfig
+            {
+                Epochs = 1, StepsPerEpoch = 1, LrStart = 4, LrMin = 1,
+                LrScheduler = "constant", Patience = 6,
+                UseSlowUpdate = false, UseMetaSkill = false
+            }),
+            CancellationToken.None);
+
+        trainBatches.Should().HaveCount(2);
+        trainBatches[0].ItemIds.Should().BeEmpty(because: "the current skill's reflection rollout samples freely");
+        // The candidate is pinned to exactly the items the current skill was scored on.
+        trainBatches[1].ItemIds.Should().Equal(new[] { "item-A", "item-B" });
+    }
+
     // ── Stubs ────────────────────────────────────────────────────────────────────
 
     private sealed class StubRolloutRunner : IRolloutRunner

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/SkillTraining/GateEvaluatorTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/SkillTraining/GateEvaluatorTests.cs
@@ -194,4 +194,186 @@ public class GateEvaluatorTests
         var act = () => Sut.SelectGateScore(0, 0, (GateMetric)999);
         act.Should().Throw<ArgumentOutOfRangeException>();
     }
+
+    // ── EvaluateTwoSplit (non-regression) ────────────────────────────────────────
+    //
+    // Δ_ho = candidate_ho − current_ho,  Δ_in = candidate_in − current_in (metric-projected).
+    // Accept iff Δ_ho ≥ 0 ∧ Δ_in ≥ 0 ∧ max(Δ_ho, Δ_in) > 0. Best tracked on held-out.
+
+    /// <summary>Builds a Hard-metric evaluation where projected score == the supplied value
+    /// (hard == soft), so callers reason purely in projected-score space.</summary>
+    private static GateEvaluation Eval(
+        double candHo, double candIn, double curHo, double curIn,
+        double bestHo = 0.8, int bestStep = 3, int globalStep = 9) => new()
+    {
+        CandidateSkill = "cand",
+        CandidateHard = candHo,
+        CandidateSoft = candHo,
+        CandidateHeldInHard = candIn,
+        CandidateHeldInSoft = candIn,
+        CurrentSkill = "curr",
+        CurrentScore = curHo,
+        CurrentHeldInScore = curIn,
+        BestSkill = "best",
+        BestScore = bestHo,
+        BestStep = bestStep,
+        GlobalStep = globalStep,
+        Metric = GateMetric.Hard
+    };
+
+    [Fact]
+    public void EvaluateTwoSplit_BothSplitsImproveAndBeatsBest_PromotesToNewBest()
+    {
+        var result = Sut.EvaluateTwoSplit(Eval(candHo: 0.9, candIn: 0.7, curHo: 0.5, curIn: 0.6));
+
+        result.Action.Should().Be(GateAction.AcceptNewBest);
+        result.CurrentSkill.Should().Be("cand");
+        result.CurrentScore.Should().Be(0.9);
+        result.BestSkill.Should().Be("cand");
+        result.BestScore.Should().Be(0.9);
+        result.BestStep.Should().Be(9);
+        result.CandidateScore.Should().Be(0.9);
+        result.CandidateHeldInScore.Should().Be(0.7, because: "held-in evidence is recorded for audit");
+        result.CurrentHeldInScore.Should().Be(0.6);
+    }
+
+    [Fact]
+    public void EvaluateTwoSplit_HeldOutUpHeldInDown_Rejects()
+    {
+        // The core regression this gate exists to catch: a candidate that wins on the held-out
+        // split while quietly breaking the held-in tasks the proposer reflected on.
+        var result = Sut.EvaluateTwoSplit(Eval(candHo: 0.9, candIn: 0.4, curHo: 0.5, curIn: 0.6));
+
+        result.Action.Should().Be(GateAction.Reject);
+        result.CurrentSkill.Should().Be("curr", because: "reject preserves prior state");
+        result.CurrentScore.Should().Be(0.5);
+        result.BestSkill.Should().Be("best");
+        result.CandidateScore.Should().Be(0.9, because: "candidate scores are still recorded on reject");
+        result.CandidateHeldInScore.Should().Be(0.4);
+        result.CurrentHeldInScore.Should().Be(0.6);
+    }
+
+    [Fact]
+    public void EvaluateTwoSplit_HeldInUpHeldOutDown_Rejects()
+    {
+        var result = Sut.EvaluateTwoSplit(Eval(candHo: 0.4, candIn: 0.9, curHo: 0.5, curIn: 0.6));
+
+        result.Action.Should().Be(GateAction.Reject);
+    }
+
+    [Fact]
+    public void EvaluateTwoSplit_BothSplitsFlat_Rejects()
+    {
+        // No regression, but no improvement either: max(Δ) is not > 0.
+        var result = Sut.EvaluateTwoSplit(Eval(candHo: 0.5, candIn: 0.6, curHo: 0.5, curIn: 0.6));
+
+        result.Action.Should().Be(GateAction.Reject);
+    }
+
+    [Fact]
+    public void EvaluateTwoSplit_HeldOutFlatHeldInUp_AcceptsWithoutPromotion()
+    {
+        // Held-out unchanged (so never a new best), held-in strictly better → keep the candidate.
+        var result = Sut.EvaluateTwoSplit(
+            Eval(candHo: 0.5, candIn: 0.7, curHo: 0.5, curIn: 0.6, bestHo: 0.8));
+
+        result.Action.Should().Be(GateAction.Accept);
+        result.CurrentSkill.Should().Be("cand");
+        result.CurrentScore.Should().Be(0.5);
+        result.BestSkill.Should().Be("best", because: "held-out did not improve, so best is unchanged");
+        result.BestScore.Should().Be(0.8);
+        result.BestStep.Should().Be(3);
+        result.CandidateHeldInScore.Should().Be(0.7);
+    }
+
+    [Fact]
+    public void EvaluateTwoSplit_HeldInFlatHeldOutUp_PromotesToNewBest()
+    {
+        var result = Sut.EvaluateTwoSplit(
+            Eval(candHo: 0.9, candIn: 0.6, curHo: 0.5, curIn: 0.6, bestHo: 0.8));
+
+        result.Action.Should().Be(GateAction.AcceptNewBest);
+        result.BestScore.Should().Be(0.9);
+    }
+
+    [Fact]
+    public void EvaluateTwoSplit_BeatsCurrentButTiesBestOnHeldOut_AcceptsWithoutPromotion()
+    {
+        // candidate_ho 0.8 beats current 0.5 but only ties best 0.8 → Accept, not new best.
+        var result = Sut.EvaluateTwoSplit(
+            Eval(candHo: 0.8, candIn: 0.7, curHo: 0.5, curIn: 0.6, bestHo: 0.8));
+
+        result.Action.Should().Be(GateAction.Accept);
+        result.BestSkill.Should().Be("best", because: "a tie with best does not promote");
+        result.BestStep.Should().Be(3);
+    }
+
+    [Fact]
+    public void EvaluateTwoSplit_Soft_ProjectsBothSplitsOntoSoft()
+    {
+        // Hard scores would reject (candidate_in hard 0.1 < current_in 0.6); soft must drive Accept.
+        var evaluation = new GateEvaluation
+        {
+            CandidateSkill = "cand",
+            CandidateHard = 0.3, CandidateSoft = 0.9,
+            CandidateHeldInHard = 0.1, CandidateHeldInSoft = 0.7,
+            CurrentSkill = "curr", CurrentScore = 0.5, CurrentHeldInScore = 0.6,
+            BestSkill = "best", BestScore = 0.8, BestStep = 3, GlobalStep = 9,
+            Metric = GateMetric.Soft
+        };
+
+        var result = Sut.EvaluateTwoSplit(evaluation);
+
+        result.Action.Should().Be(GateAction.AcceptNewBest);
+        result.CandidateScore.Should().Be(0.9);
+        result.CandidateHeldInScore.Should().Be(0.7);
+    }
+
+    [Fact]
+    public void EvaluateTwoSplit_Mixed_ProjectsBothSplits_HeldInRegressionRejects()
+    {
+        // held-out projects to 0.6 (Δ +0.1), held-in projects to 0.5 (Δ −0.1) → Reject.
+        var evaluation = new GateEvaluation
+        {
+            CandidateSkill = "cand",
+            CandidateHard = 0.4, CandidateSoft = 0.8,        // → 0.6
+            CandidateHeldInHard = 0.5, CandidateHeldInSoft = 0.5, // → 0.5
+            CurrentSkill = "curr", CurrentScore = 0.5, CurrentHeldInScore = 0.6,
+            BestSkill = "best", BestScore = 0.55, BestStep = 3, GlobalStep = 9,
+            Metric = GateMetric.Mixed, MixedWeight = 0.5
+        };
+
+        var result = Sut.EvaluateTwoSplit(evaluation);
+
+        result.Action.Should().Be(GateAction.Reject);
+        result.CandidateScore.Should().BeApproximately(0.6, 1e-9);
+        result.CandidateHeldInScore.Should().BeApproximately(0.5, 1e-9);
+    }
+
+    [Fact]
+    public void EvaluateTwoSplit_NullEvaluation_Throws()
+    {
+        var act = () => Sut.EvaluateTwoSplit(null!);
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Theory]
+    [InlineData(double.NaN, 0.6)]
+    [InlineData(0.5, double.PositiveInfinity)]
+    public void EvaluateTwoSplit_NonFiniteCurrentScores_Throws(double curHo, double curIn)
+    {
+        var act = () => Sut.EvaluateTwoSplit(Eval(candHo: 0.9, candIn: 0.7, curHo: curHo, curIn: curIn));
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void EvaluateTwoSplit_NonFiniteCandidateHeldIn_Throws()
+    {
+        var evaluation = Eval(candHo: 0.9, candIn: 0.7, curHo: 0.5, curIn: 0.6) with
+        {
+            CandidateHeldInHard = double.NaN
+        };
+        var act = () => Sut.EvaluateTwoSplit(evaluation);
+        act.Should().Throw<ArgumentException>();
+    }
 }


### PR DESCRIPTION
## What

Ports the **Self-Harness** (arXiv 2606.09498) acceptance rule into our existing SkillOpt training loop (`TrainSkill`).

Today's gate accepts a candidate skill whenever its **held-out (val)** score beats the current score — it never checks whether the candidate **regressed on the held-in (train)** tasks the proposer reflected on. So an edit can win on validation by chance while quietly breaking behavior that previously worked, and we accept it.

The new policy requires non-regression on **both** splits:

```
Δ_ho ≥ 0  AND  Δ_in ≥ 0  AND  max(Δ_ho, Δ_in) > 0
```

## How

- **`GateMode` enum** (`StrictImprovementHeldOut` | `TwoSplitNonRegression`) selects the policy. `TrainSkillConfig.GateMode` **defaults to the safer `TwoSplitNonRegression`**.
- The original single-split `GateEvaluator.Evaluate` and its 23 tests are **left byte-identical** as a parity guard; the new policy lives in `GateEvaluator.EvaluateTwoSplit(GateEvaluation)`. Best-so-far is still tracked on the held-out metric in both modes.
- The training loop scores the candidate on the train split (**one extra rollout per step**) and reuses the current skill's existing train rollouts for its held-in baseline. The candidate's held-in rollout is **pinned to the exact item ids** the current skill was scored on (`RolloutBatch.ItemIds`), so `Δ_in` is a true paired comparison — the same mechanism `SlowUpdate` uses — not a mean over a re-sampled batch.
- The standalone `GateCandidateSkillCommand` gains **opt-in** two-split support (held-in fields + validator rules).

## ⚠️ Behavior change to note

`TrainSkillConfig.GateMode` now defaults to `TwoSplitNonRegression`. Consumers calling `TrainSkillCommand` with a default config will (a) pay one extra rollout per step and (b) get a stricter accept rule that rejects held-in regressions the old gate accepted. This is the intended, safer default. The lower-level `GateCandidateSkillCommand.Mode` intentionally defaults to `StrictImprovementHeldOut` (its caller must supply held-in inputs); both doc comments now cross-reference the difference.

## Review

- **Independent code-review agent:** found 1 MED — held-in delta compared two independently-sampled batches → **fixed** via item-id pinning (+ test). Accept/reject/new-best logic verified (`≥`/`>`, NaN/finite guards, best-on-held-out).
- **Independent simplifier agent:** no edits recommended; deliberate design choices (explicit branches, two methods, per-site dispatch) confirmed sound.

## Test plan

- TDD: 13 new `GateEvaluatorTests` (both-improve, held-out-up/held-in-down reject, trade-off rejects, both-flat reject, Soft/Mixed projection, NaN/finite, best-tracking).
- Loop: held-in-regressing candidate **rejected** under default mode but **accepted** under strict mode (proves the modes differ); extra-rollout count; item-id pinning assertion.
- Standalone command: two-split reject + accept-new-best.
- Full `Application.AI.Common` suite green: **1108 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)