### PR TITLE
feat(skill-training): editable-surface fence (Self-Harness Phase 1)

### DIFF
--- a/src/Content/Application/Application.AI.Common/CQRS/SkillTraining/TrainSkill/TrainSkillCommandHandler.cs
+++ b/src/Content/Application/Application.AI.Common/CQRS/SkillTraining/TrainSkill/TrainSkillCommandHandler.cs
@@ -1,5 +1,6 @@
 using System.Security.Cryptography;
 using System.Text;
+using Application.AI.Common.Interfaces.Governance;
 using Application.AI.Common.Interfaces.SkillTraining;
 using Application.AI.Common.Services.SkillTraining;
 using Application.AI.Common.Services.SkillTraining.Schedulers;
@@ -37,12 +38,21 @@ public sealed class TrainSkillCommandHandler
     private readonly IEditSelector _selector;
     private readonly PatchApplier _applier;
     private readonly IGateEvaluator _gate;
+    private readonly HarnessPatchValidator _fence;
     private readonly ISkillTrainingCheckpointStore _checkpointStore;
     private readonly IMediator _mediator;
     private readonly TimeProvider _time;
     private readonly ILogger<TrainSkillCommandHandler> _logger;
+    private readonly IGovernanceAuditService? _audit;
 
     /// <summary>Initializes a new instance of the <see cref="TrainSkillCommandHandler"/> class.</summary>
+    /// <remarks>
+    /// <paramref name="audit"/> is optional: when a tamper-evident governance audit service is
+    /// registered (the full-harness composition root), fence rejections are written to the hash-chain;
+    /// when it is absent (a consumer wiring only the skill-training subsystem), rejections are still
+    /// logged via <see cref="ILogger{TCategoryName}"/> and the patch is still blocked. The fence is the
+    /// security control; the audit is the record of it.
+    /// </remarks>
     public TrainSkillCommandHandler(
         IRolloutRunner rolloutRunner,
         IPatchProposer proposer,
@@ -50,10 +60,12 @@ public sealed class TrainSkillCommandHandler
         IEditSelector selector,
         PatchApplier applier,
         IGateEvaluator gate,
+        HarnessPatchValidator fence,
         ISkillTrainingCheckpointStore checkpointStore,
         IMediator mediator,
         TimeProvider time,
-        ILogger<TrainSkillCommandHandler> logger)
+        ILogger<TrainSkillCommandHandler> logger,
+        IGovernanceAuditService? audit = null)
     {
         ArgumentNullException.ThrowIfNull(rolloutRunner);
         ArgumentNullException.ThrowIfNull(proposer);
@@ -61,6 +73,7 @@ public sealed class TrainSkillCommandHandler
         ArgumentNullException.ThrowIfNull(selector);
         ArgumentNullException.ThrowIfNull(applier);
         ArgumentNullException.ThrowIfNull(gate);
+        ArgumentNullException.ThrowIfNull(fence);
         ArgumentNullException.ThrowIfNull(checkpointStore);
         ArgumentNullException.ThrowIfNull(mediator);
         ArgumentNullException.ThrowIfNull(time);
@@ -72,10 +85,12 @@ public sealed class TrainSkillCommandHandler
         _selector = selector;
         _applier = applier;
         _gate = gate;
+        _fence = fence;
         _checkpointStore = checkpointStore;
         _mediator = mediator;
         _time = time;
         _logger = logger;
+        _audit = audit;
     }
 
     /// <inheritdoc />
@@ -170,6 +185,42 @@ public sealed class TrainSkillCommandHandler
                     // No edits proposed — record as a Reject no-op and continue.
                     steps.Add(NewStepRecord(globalStep, epoch, GateAction.Reject,
                         candidateScore: 0.0, proposed.Edits.Count, 0));
+                    consecutiveRejects++;
+                    if (consecutiveRejects >= cfg.Patience) goto EarlyStop;
+                    continue;
+                }
+
+                // ── Governance fence (Self-Harness Phase 1) ───────────────────
+                // Hard-reject — below and independent of the gate — any patch whose edits target a
+                // harness surface the code-owned registry has not marked editable. Running beneath the
+                // gate is the whole point: a frozen-surface edit can never be accepted by improving the
+                // score. Today only SkillDocument is editable, so legitimate skill-prose patches pass
+                // untouched; this is the lock that must already exist before the edit target is ever
+                // widened to system prompt / tools / policies (Phase 2/3).
+                var fenceResult = _fence.Validate(selected);
+                if (!fenceResult.IsAllowed)
+                {
+                    var surfaces = string.Join(", ", fenceResult.Violations.Select(v => v.Surface));
+                    _logger.LogWarning(
+                        "Harness patch fence rejected step {Step}: {Count} edit(s) target frozen surface(s) [{Surfaces}]. Patch not applied or gated.",
+                        globalStep, fenceResult.Violations.Count, surfaces);
+                    // The fence — not the audit — is the control: an audit-write failure must not abort
+                    // the run or let a frozen-surface patch through. Record the rejection best-effort.
+                    try
+                    {
+                        _audit?.Log(
+                            request.SkillId,
+                            "skill_training.harness_patch_rejected",
+                            $"deny: frozen surface(s) [{surfaces}]");
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogError(ex,
+                            "Governance audit write failed for fence rejection at step {Step}; rejection still enforced.",
+                            globalStep);
+                    }
+                    steps.Add(NewStepRecord(globalStep, epoch, GateAction.Reject,
+                        candidateScore: 0.0, proposed.Edits.Count, applied: 0));
                     consecutiveRejects++;
                     if (consecutiveRejects >= cfg.Patience) goto EarlyStop;
                     continue;

--- a/src/Content/Application/Application.AI.Common/CQRS/SkillTraining/TrainSkill/TrainSkillCommandHandler.cs
+++ b/src/Content/Application/Application.AI.Common/CQRS/SkillTraining/TrainSkill/TrainSkillCommandHandler.cs
@@ -175,29 +175,18 @@ public sealed class TrainSkillCommandHandler
                     continue;
                 }
 
-                // ── Aggregate + select ────────────────────────────────────────
-                var aggregated = _aggregator.Aggregate([proposed]);
-                var lr = scheduler.GetLearningRate(globalStep - 1, totalSteps, cfg.LrStart, cfg.LrMin);
-                var selected = _selector.SelectTopK(aggregated, lr);
-
-                if (selected.Edits.Count == 0)
-                {
-                    // No edits proposed — record as a Reject no-op and continue.
-                    steps.Add(NewStepRecord(globalStep, epoch, GateAction.Reject,
-                        candidateScore: 0.0, proposed.Edits.Count, 0));
-                    consecutiveRejects++;
-                    if (consecutiveRejects >= cfg.Patience) goto EarlyStop;
-                    continue;
-                }
-
                 // ── Governance fence (Self-Harness Phase 1) ───────────────────
-                // Hard-reject — below and independent of the gate — any patch whose edits target a
-                // harness surface the code-owned registry has not marked editable. Running beneath the
-                // gate is the whole point: a frozen-surface edit can never be accepted by improving the
-                // score. Today only SkillDocument is editable, so legitimate skill-prose patches pass
+                // Hard-reject — at intake, below and independent of the gate — any proposed patch whose
+                // edits target a harness surface the code-owned registry has not marked editable.
+                // Validating the PROPOSED patch (before aggregate/select) keeps the audit trail complete:
+                // every frozen-surface attempt is recorded, including ones selection would later drop.
+                // Aggregate/select only filter and merge existing edits (preserving Edit.Surface), so
+                // they cannot introduce a frozen surface that intake did not already see. Running beneath
+                // the gate is the whole point: a frozen-surface edit can never be accepted by improving
+                // the score. Today only SkillDocument is editable, so legitimate skill-prose patches pass
                 // untouched; this is the lock that must already exist before the edit target is ever
                 // widened to system prompt / tools / policies (Phase 2/3).
-                var fenceResult = _fence.Validate(selected);
+                var fenceResult = _fence.Validate(proposed);
                 if (!fenceResult.IsAllowed)
                 {
                     var surfaces = string.Join(", ", fenceResult.Violations.Select(v => v.Surface));
@@ -221,6 +210,21 @@ public sealed class TrainSkillCommandHandler
                     }
                     steps.Add(NewStepRecord(globalStep, epoch, GateAction.Reject,
                         candidateScore: 0.0, proposed.Edits.Count, applied: 0));
+                    consecutiveRejects++;
+                    if (consecutiveRejects >= cfg.Patience) goto EarlyStop;
+                    continue;
+                }
+
+                // ── Aggregate + select ────────────────────────────────────────
+                var aggregated = _aggregator.Aggregate([proposed]);
+                var lr = scheduler.GetLearningRate(globalStep - 1, totalSteps, cfg.LrStart, cfg.LrMin);
+                var selected = _selector.SelectTopK(aggregated, lr);
+
+                if (selected.Edits.Count == 0)
+                {
+                    // No edits proposed — record as a Reject no-op and continue.
+                    steps.Add(NewStepRecord(globalStep, epoch, GateAction.Reject,
+                        candidateScore: 0.0, proposed.Edits.Count, 0));
                     consecutiveRejects++;
                     if (consecutiveRejects >= cfg.Patience) goto EarlyStop;
                     continue;

--- a/src/Content/Application/Application.AI.Common/Extensions/SkillTrainingDependencyInjection.cs
+++ b/src/Content/Application/Application.AI.Common/Extensions/SkillTrainingDependencyInjection.cs
@@ -18,6 +18,8 @@ namespace Application.AI.Common.Extensions;
 /// <item><see cref="IGateEvaluator"/> → <see cref="GateEvaluator"/>.</item>
 /// <item><see cref="IPatchAggregator"/> → <see cref="PatchAggregator"/>.</item>
 /// <item><see cref="IEditSelector"/> → <see cref="TopKEditSelector"/>.</item>
+/// <item><see cref="EditableSurfaceRegistry"/> — code-owned editable-surface fence allowlist.</item>
+/// <item><see cref="HarnessPatchValidator"/> — concrete fence (no interface seam, by design).</item>
 /// <item><see cref="ISkillTrainingCheckpointStore"/> → <see cref="InMemorySkillTrainingCheckpointStore"/>.</item>
 /// <item><see cref="IPatchProposer"/> → <see cref="NotConfiguredPatchProposer"/> (fail-fast default).</item>
 /// <item><see cref="IRolloutRunner"/> → <see cref="NotConfiguredRolloutRunner"/> (fail-fast default).</item>
@@ -42,6 +44,8 @@ public static class SkillTrainingDependencyInjection
         services.TryAddSingleton<IGateEvaluator, GateEvaluator>();
         services.TryAddSingleton<IPatchAggregator, PatchAggregator>();
         services.TryAddSingleton<IEditSelector, TopKEditSelector>();
+        services.TryAddSingleton<EditableSurfaceRegistry>();
+        services.TryAddSingleton<HarnessPatchValidator>();
         services.TryAddSingleton<ISkillTrainingCheckpointStore, InMemorySkillTrainingCheckpointStore>();
         services.TryAddSingleton<IPatchProposer, NotConfiguredPatchProposer>();
         services.TryAddSingleton<IRolloutRunner, NotConfiguredRolloutRunner>();

--- a/src/Content/Application/Application.AI.Common/Services/SkillTraining/EditableSurfaceRegistry.cs
+++ b/src/Content/Application/Application.AI.Common/Services/SkillTraining/EditableSurfaceRegistry.cs
@@ -1,0 +1,85 @@
+using Domain.AI.SkillTraining;
+
+namespace Application.AI.Common.Services.SkillTraining;
+
+/// <summary>
+/// The code-owned allowlist of which <see cref="HarnessSurface"/>s the skill-training loop may edit —
+/// the fence at the heart of Self-Harness Phase 1.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The registry is <em>owned by code, not by the loop</em>: the optimizer can propose edits, but it
+/// can never change what this registry permits. Today only <see cref="HarnessSurface.SkillDocument"/>
+/// is editable; every other surface is frozen.
+/// </para>
+/// <para>
+/// A subset of surfaces is frozen <em>by construction</em> — <see cref="HarnessSurface.DeniedTools"/>,
+/// <see cref="HarnessSurface.AutonomyTier"/>, <see cref="HarnessSurface.ContentSafetyConfig"/>, and
+/// <see cref="HarnessSurface.EditableSurfaceRegistry"/>. These can never be made editable: the
+/// widening constructor throws if asked to include any of them. This is the analog, for
+/// self-modification, of the bypass-immune denied-tool rule — a guarantee enforced in the type system
+/// rather than in configuration that could be edited or misconfigured.
+/// </para>
+/// </remarks>
+public sealed class EditableSurfaceRegistry
+{
+    private static readonly IReadOnlySet<HarnessSurface> AlwaysFrozenSurfaces =
+        new HashSet<HarnessSurface>
+        {
+            HarnessSurface.DeniedTools,
+            HarnessSurface.AutonomyTier,
+            HarnessSurface.ContentSafetyConfig,
+            HarnessSurface.EditableSurfaceRegistry
+        };
+
+    private readonly IReadOnlySet<HarnessSurface> _editableSurfaces;
+
+    /// <summary>
+    /// Initializes the registry with the default policy: only
+    /// <see cref="HarnessSurface.SkillDocument"/> is editable. This is the parameterless constructor
+    /// dependency injection resolves.
+    /// </summary>
+    public EditableSurfaceRegistry()
+        : this([HarnessSurface.SkillDocument])
+    {
+    }
+
+    /// <summary>
+    /// Initializes the registry with an explicit set of editable surfaces. Reserved for a future phase
+    /// that widens the loop's edit target behind a product decision; today only the default set is
+    /// wired.
+    /// </summary>
+    /// <param name="editableSurfaces">The surfaces the loop may edit.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="editableSurfaces"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException">
+    /// Any requested surface is frozen by construction (<see cref="IsFrozenByConstruction"/>) and can
+    /// never be made editable.
+    /// </exception>
+    public EditableSurfaceRegistry(IEnumerable<HarnessSurface> editableSurfaces)
+    {
+        ArgumentNullException.ThrowIfNull(editableSurfaces);
+
+        var requested = new HashSet<HarnessSurface>(editableSurfaces);
+        var illegal = requested.Where(AlwaysFrozenSurfaces.Contains).ToArray();
+        if (illegal.Length > 0)
+        {
+            throw new ArgumentException(
+                $"Surface(s) [{string.Join(", ", illegal)}] are frozen by construction and can never be marked editable.",
+                nameof(editableSurfaces));
+        }
+
+        _editableSurfaces = requested;
+    }
+
+    /// <summary>Returns <see langword="true"/> iff the loop may edit <paramref name="surface"/>.</summary>
+    /// <param name="surface">The surface to test.</param>
+    public bool IsEditable(HarnessSurface surface) => _editableSurfaces.Contains(surface);
+
+    /// <summary>
+    /// Returns <see langword="true"/> iff <paramref name="surface"/> is frozen by construction — a hard
+    /// governance boundary (denied tools, autonomy tier, content safety, the registry itself) that no
+    /// configuration or widening can ever make editable.
+    /// </summary>
+    /// <param name="surface">The surface to test.</param>
+    public bool IsFrozenByConstruction(HarnessSurface surface) => AlwaysFrozenSurfaces.Contains(surface);
+}

--- a/src/Content/Application/Application.AI.Common/Services/SkillTraining/HarnessPatchValidator.cs
+++ b/src/Content/Application/Application.AI.Common/Services/SkillTraining/HarnessPatchValidator.cs
@@ -1,0 +1,69 @@
+using Domain.AI.SkillTraining;
+
+namespace Application.AI.Common.Services.SkillTraining;
+
+/// <summary>
+/// The editable-surface fence: hard-rejects, before the accept-gate, any skill-training patch whose
+/// edits target a harness surface the <see cref="EditableSurfaceRegistry"/> has not marked editable.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This type is intentionally a concrete sealed class with no interface seam. A fence a consumer could
+/// replace with a permissive no-op via dependency injection would not be a fence; the only
+/// configurable part of the policy is the <see cref="EditableSurfaceRegistry"/> it reads — and that
+/// registry refuses, by construction, to mark governance surfaces editable.
+/// </para>
+/// <para>
+/// <see cref="Validate"/> is pure and side-effect free, like <c>PatchApplier</c> and
+/// <c>GateEvaluator</c>. Auditing a rejection and recording the rejected step are the caller's
+/// responsibility (the training loop), which keeps this component deterministically testable.
+/// </para>
+/// </remarks>
+public sealed class HarnessPatchValidator
+{
+    private readonly EditableSurfaceRegistry _registry;
+
+    /// <summary>Initializes a new instance of the <see cref="HarnessPatchValidator"/> class.</summary>
+    /// <param name="registry">The code-owned editable-surface registry to enforce.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="registry"/> is <see langword="null"/>.</exception>
+    public HarnessPatchValidator(EditableSurfaceRegistry registry)
+    {
+        ArgumentNullException.ThrowIfNull(registry);
+        _registry = registry;
+    }
+
+    /// <summary>
+    /// Validates that every edit in <paramref name="patch"/> targets an editable surface.
+    /// </summary>
+    /// <param name="patch">The selected patch about to be applied.</param>
+    /// <returns>
+    /// <see cref="HarnessPatchValidation.Allowed"/> when every edit targets an editable surface;
+    /// otherwise a result listing each edit that targeted a frozen surface.
+    /// </returns>
+    /// <exception cref="ArgumentNullException"><paramref name="patch"/> is <see langword="null"/>.</exception>
+    public HarnessPatchValidation Validate(Patch patch)
+    {
+        ArgumentNullException.ThrowIfNull(patch);
+
+        List<FrozenSurfaceViolation>? violations = null;
+        for (var i = 0; i < patch.Edits.Count; i++)
+        {
+            var surface = patch.Edits[i].Surface;
+            if (_registry.IsEditable(surface))
+            {
+                continue;
+            }
+
+            (violations ??= []).Add(new FrozenSurfaceViolation
+            {
+                EditIndex = i,
+                Surface = surface,
+                FrozenByConstruction = _registry.IsFrozenByConstruction(surface)
+            });
+        }
+
+        return violations is null
+            ? HarnessPatchValidation.Allowed
+            : new HarnessPatchValidation { IsAllowed = false, Violations = violations };
+    }
+}

--- a/src/Content/Domain/Domain.AI/SkillTraining/Edit.cs
+++ b/src/Content/Domain/Domain.AI/SkillTraining/Edit.cs
@@ -23,6 +23,14 @@ public sealed record Edit
     public required EditOp Op { get; init; }
 
     /// <summary>
+    /// The harness surface this edit targets. Defaults to <see cref="HarnessSurface.SkillDocument"/> —
+    /// the only surface the loop edits today. The editable-surface fence
+    /// (<c>HarnessPatchValidator</c>) hard-rejects, before the gate, any patch whose edits target a
+    /// surface the code-owned registry has not marked editable.
+    /// </summary>
+    public HarnessSurface Surface { get; init; } = HarnessSurface.SkillDocument;
+
+    /// <summary>
     /// The content to insert or replace. Ignored for <see cref="EditOp.Delete"/>;
     /// appended/inserted/used-as-replacement for the other three ops.
     /// </summary>

--- a/src/Content/Domain/Domain.AI/SkillTraining/HarnessPatchValidation.cs
+++ b/src/Content/Domain/Domain.AI/SkillTraining/HarnessPatchValidation.cs
@@ -1,0 +1,45 @@
+namespace Domain.AI.SkillTraining;
+
+/// <summary>
+/// The result of checking a <see cref="Patch"/> against the editable-surface fence before it is
+/// applied or gated.
+/// </summary>
+/// <remarks>
+/// A patch is allowed only when every one of its edits targets a surface the
+/// <c>EditableSurfaceRegistry</c> marks editable. A single edit targeting a frozen surface fails the
+/// whole patch — the fence is all-or-nothing, mirroring the bypass-immune denied-tool rule it is
+/// modeled on.
+/// </remarks>
+public sealed record HarnessPatchValidation
+{
+    /// <summary>True iff no edit in the patch targets a frozen surface.</summary>
+    public required bool IsAllowed { get; init; }
+
+    /// <summary>
+    /// The edits that targeted a frozen surface; empty when <see cref="IsAllowed"/> is true.
+    /// </summary>
+    public IReadOnlyList<FrozenSurfaceViolation> Violations { get; init; } = [];
+
+    /// <summary>A shared allowed result carrying no violations.</summary>
+    public static HarnessPatchValidation Allowed { get; } = new() { IsAllowed = true };
+}
+
+/// <summary>
+/// A single edit the fence rejected because it targeted a frozen <see cref="HarnessSurface"/>.
+/// </summary>
+public sealed record FrozenSurfaceViolation
+{
+    /// <summary>The zero-based index of the offending edit within the patch's edit list.</summary>
+    public required int EditIndex { get; init; }
+
+    /// <summary>The frozen surface the edit attempted to target.</summary>
+    public required HarnessSurface Surface { get; init; }
+
+    /// <summary>
+    /// True when the surface is frozen <em>by construction</em> (denied tools, autonomy tier, content
+    /// safety, the registry itself) — a freeze no configuration or future widening can lift — versus
+    /// frozen merely by current policy. Recorded so the audit trail distinguishes a policy rejection
+    /// from an attempt to breach a hard governance boundary.
+    /// </summary>
+    public required bool FrozenByConstruction { get; init; }
+}

--- a/src/Content/Domain/Domain.AI/SkillTraining/HarnessSurface.cs
+++ b/src/Content/Domain/Domain.AI/SkillTraining/HarnessSurface.cs
@@ -1,0 +1,75 @@
+namespace Domain.AI.SkillTraining;
+
+/// <summary>
+/// A named, governable surface of the agent harness that a skill-training patch could target.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The self-optimization loop today edits exactly one surface — <see cref="SkillDocument"/> (a
+/// SKILL.md prose file). Self-Harness (arXiv 2606.09498) points the same propose → evaluate → accept
+/// loop at the <em>entire</em> harness. Before any such widening, every surface is named here so the
+/// <c>EditableSurfaceRegistry</c> fence can declare — in code, not configuration — which surfaces a
+/// patch may legally touch and which are frozen.
+/// </para>
+/// <para>
+/// Surfaces fall into three intent bands. First, the single editable surface today
+/// (<see cref="SkillDocument"/>). Second, low-stakes runtime-policy surfaces a future phase could
+/// safely unfreeze. Third, governance surfaces that must remain <em>frozen by construction</em> —
+/// <see cref="DeniedTools"/>, <see cref="AutonomyTier"/>, <see cref="ContentSafetyConfig"/>, and the
+/// registry itself — which can never be marked editable, because an optimizer able to edit them could
+/// weaken the very safety architecture it runs under.
+/// </para>
+/// </remarks>
+public enum HarnessSurface
+{
+    /// <summary>The skill instruction document (SKILL.md prose). The only editable surface today.</summary>
+    SkillDocument,
+
+    /// <summary>The agent system prompt. Frozen pending a product decision (Self-Harness Phase 2).</summary>
+    SystemPrompt,
+
+    /// <summary>Guidance on how the agent produces artifacts. Low-stakes; Phase 2 candidate. Frozen today.</summary>
+    ArtifactGuidance,
+
+    /// <summary>Failure-recovery instructions. Low-stakes; Phase 2 candidate. Frozen today.</summary>
+    FailureRecovery,
+
+    /// <summary>Verification / self-check prompts. Low-stakes; Phase 2 candidate. Frozen today.</summary>
+    VerificationPrompt,
+
+    /// <summary>Tool-error retry / limit runtime policy. Low-stakes; Phase 2 candidate. Frozen today.</summary>
+    ToolErrorRetryLimit,
+
+    /// <summary>
+    /// Tool availability — the agent's allowed tool set and tool declarations (AGENT.md). High-stakes;
+    /// only ever editable behind a human escalation gate (Phase 3). Frozen today.
+    /// </summary>
+    ToolAvailability,
+
+    /// <summary>Memory-scope and persistence rules. High-stakes; Phase 3 candidate. Frozen today.</summary>
+    MemoryScopeRules,
+
+    /// <summary>
+    /// The bypass-immune denied-tool list. Frozen <b>by construction</b> — never editable by the loop,
+    /// because re-enabling a denied tool is exactly what the denied-tool rule exists to prevent.
+    /// </summary>
+    DeniedTools,
+
+    /// <summary>
+    /// The agent autonomy tier (Restricted / Supervised / Autonomous). Frozen <b>by construction</b> —
+    /// self-improvement must never be able to escalate its own autonomy.
+    /// </summary>
+    AutonomyTier,
+
+    /// <summary>
+    /// Content-safety and response-sanitization wiring. Frozen <b>by construction</b> — the loop must
+    /// never be able to remove a safety filter to pass more tasks.
+    /// </summary>
+    ContentSafetyConfig,
+
+    /// <summary>
+    /// The editable-surface registry itself. Frozen <b>by construction</b> — the fence cannot be edited
+    /// by the thing it fences.
+    /// </summary>
+    EditableSurfaceRegistry
+}

--- a/src/Content/Presentation/Presentation.ConsoleUI/Examples/SkillTrainingExample.cs
+++ b/src/Content/Presentation/Presentation.ConsoleUI/Examples/SkillTrainingExample.cs
@@ -87,13 +87,14 @@ public sealed class SkillTrainingExample
         var selector = new TopKEditSelector();
         var applier = new PatchApplier();
         var gate = new GateEvaluator();
+        var fence = new HarnessPatchValidator(new EditableSurfaceRegistry());
         var store = new InMemorySkillTrainingCheckpointStore();
         var runner = new DeterministicRolloutRunner();
         var proposer = new DeterministicProposer();
         ILogger<TrainSkillCommandHandler> logger = NullLogger<TrainSkillCommandHandler>.Instance;
 
         return new TrainSkillCommandHandler(
-            runner, proposer, aggregator, selector, applier, gate, store,
+            runner, proposer, aggregator, selector, applier, gate, fence, store,
             new NoOpMediator(), TimeProvider.System, logger);
     }
 

--- a/src/Content/Tests/Application.AI.Common.Tests/CQRS/SkillTraining/TrainSkillCommandHandlerTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/CQRS/SkillTraining/TrainSkillCommandHandlerTests.cs
@@ -1,4 +1,5 @@
 using Application.AI.Common.CQRS.SkillTraining.TrainSkill;
+using Application.AI.Common.Interfaces.Governance;
 using Application.AI.Common.Interfaces.SkillTraining;
 using Application.AI.Common.Services.SkillTraining;
 using Domain.AI.SkillTraining;
@@ -15,16 +16,18 @@ public class TrainSkillCommandHandlerTests
     private static readonly PatchAggregator Aggregator = new();
     private static readonly TopKEditSelector Selector = new();
     private static readonly GateEvaluator Gate = new();
+    private static readonly HarnessPatchValidator Fence = new(new EditableSurfaceRegistry());
 
     private static TrainSkillCommandHandler NewSut(
         IRolloutRunner runner,
         IPatchProposer proposer,
-        InMemorySkillTrainingCheckpointStore store)
+        InMemorySkillTrainingCheckpointStore store,
+        IGovernanceAuditService? audit = null)
     {
         return new TrainSkillCommandHandler(
-            runner, proposer, Aggregator, Selector, Applier, Gate,
+            runner, proposer, Aggregator, Selector, Applier, Gate, Fence,
             store, new NoOpMediator(), TimeProvider.System,
-            NullLogger<TrainSkillCommandHandler>.Instance);
+            NullLogger<TrainSkillCommandHandler>.Instance, audit);
     }
 
     private static TrainSkillCommand NewCommand(TrainSkillConfig config) => new()
@@ -303,6 +306,72 @@ public class TrainSkillCommandHandlerTests
         trainBatches[1].ItemIds.Should().Equal(new[] { "item-A", "item-B" });
     }
 
+    [Fact]
+    public async Task Handle_FrozenSurfaceEdit_RejectsBeforeApply_DoesNotChangeSkill_AndAudits()
+    {
+        // The proposer emits an edit targeting a frozen surface (tool availability). The fence must
+        // reject it before PatchApplier runs: the skill is never changed, the step is a Reject with
+        // zero applied edits, and the rejection is written to the governance audit.
+        var runner = new StubRolloutRunner((_, _) =>
+            [new RolloutResult { ItemId = "x", Hard = 1.0, Soft = 1.0 }]);
+        var proposer = new StubProposer(_ => new Patch
+        {
+            Edits = [new Edit { Op = EditOp.Append, Content = "- grant myself a new tool", Surface = HarnessSurface.ToolAvailability }]
+        });
+        var audit = new CapturingAudit();
+        var sut = NewSut(runner, proposer, new InMemorySkillTrainingCheckpointStore(), audit);
+
+        var result = await sut.Handle(
+            NewCommand(new TrainSkillConfig
+            {
+                Epochs = 1, StepsPerEpoch = 1, LrStart = 4, LrMin = 1,
+                LrScheduler = "constant", Patience = 6,
+                UseSlowUpdate = false, UseMetaSkill = false
+            }),
+            CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        var run = result.Value!;
+        run.Steps.Should().ContainSingle();
+        run.Steps[0].Action.Should().Be(GateAction.Reject);
+        run.Steps[0].AppliedEditCount.Should().Be(0, because: "the fence rejects before PatchApplier runs");
+        run.HasAcceptedAny.Should().BeFalse();
+        run.BestSkill.Should().Be("# initial\n- baseline rule", because: "a frozen-surface patch must never mutate the skill");
+
+        audit.Entries.Should().ContainSingle();
+        var (agentId, action, decision) = audit.Entries[0];
+        agentId.Should().Be("skill-X");
+        action.Should().Be("skill_training.harness_patch_rejected");
+        decision.Should().Contain("ToolAvailability");
+    }
+
+    [Fact]
+    public async Task Handle_FrozenSurfaceEveryStep_EarlyStopsOnPatience_WithoutAuditRegistered()
+    {
+        // No audit registered (the optional dependency is absent). The fence still blocks every patch,
+        // so consecutive rejects accumulate and patience trips — proving the block does not depend on
+        // the audit being wired.
+        var runner = new StubRolloutRunner((_, _) =>
+            [new RolloutResult { ItemId = "x", Hard = 1.0, Soft = 1.0 }]);
+        var proposer = new StubProposer(_ => new Patch
+        {
+            Edits = [new Edit { Op = EditOp.Append, Content = "- escalate autonomy", Surface = HarnessSurface.AutonomyTier }]
+        });
+        var sut = NewSut(runner, proposer, new InMemorySkillTrainingCheckpointStore());
+
+        var result = await sut.Handle(
+            NewCommand(new TrainSkillConfig
+            {
+                Epochs = 2, StepsPerEpoch = 5, LrStart = 4, LrMin = 1,
+                LrScheduler = "constant", Patience = 2,
+                UseSlowUpdate = false, UseMetaSkill = false
+            }),
+            CancellationToken.None);
+
+        result.Value!.StepsExecuted.Should().Be(2, because: "patience=2 stops after 2 fence rejects");
+        result.Value.Steps.Should().AllSatisfy(s => s.Action.Should().Be(GateAction.Reject));
+    }
+
     // ── Stubs ────────────────────────────────────────────────────────────────────
 
     private sealed class StubRolloutRunner : IRolloutRunner
@@ -319,6 +388,14 @@ public class TrainSkillCommandHandlerTests
         public StubProposer(Func<ReflectionInput, Patch> fn) => _fn = fn;
         public Task<Patch> ProposeAsync(ReflectionInput input, CancellationToken cancellationToken)
             => Task.FromResult(_fn(input));
+    }
+
+    private sealed class CapturingAudit : IGovernanceAuditService
+    {
+        public List<(string AgentId, string Action, string Decision)> Entries { get; } = [];
+        public void Log(string agentId, string action, string decision) => Entries.Add((agentId, action, decision));
+        public bool VerifyChainIntegrity() => true;
+        public int EntryCount => Entries.Count;
     }
 
     private sealed class NoOpMediator : IMediator

--- a/src/Content/Tests/Application.AI.Common.Tests/CQRS/SkillTraining/TrainSkillCommandHandlerTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/CQRS/SkillTraining/TrainSkillCommandHandlerTests.cs
@@ -346,6 +346,45 @@ public class TrainSkillCommandHandlerTests
     }
 
     [Fact]
+    public async Task Handle_MixedPatchWithFrozenEdit_RejectsWholeStepAtIntake_ValidEditNotApplied_AndAudits()
+    {
+        // A patch bundling a valid skill-doc edit with a frozen-surface edit must be rejected as a whole
+        // at intake: the valid edit must NOT slip through, and the frozen attempt must be audited even
+        // though it never reaches selection/apply. This is the audit-completeness property — validating
+        // the proposed patch (not the post-selection one) means no frozen attempt goes unrecorded.
+        var runner = new StubRolloutRunner((_, _) =>
+            [new RolloutResult { ItemId = "x", Hard = 1.0, Soft = 1.0 }]);
+        var proposer = new StubProposer(_ => new Patch
+        {
+            Edits =
+            [
+                new Edit { Op = EditOp.Append, Content = "- a legitimate skill rule" },
+                new Edit { Op = EditOp.Append, Content = "- escalate autonomy", Surface = HarnessSurface.AutonomyTier }
+            ]
+        });
+        var audit = new CapturingAudit();
+        var sut = NewSut(runner, proposer, new InMemorySkillTrainingCheckpointStore(), audit);
+
+        var result = await sut.Handle(
+            NewCommand(new TrainSkillConfig
+            {
+                Epochs = 1, StepsPerEpoch = 1, LrStart = 4, LrMin = 1,
+                LrScheduler = "constant", Patience = 6,
+                UseSlowUpdate = false, UseMetaSkill = false
+            }),
+            CancellationToken.None);
+
+        var run = result.Value!;
+        run.Steps[0].Action.Should().Be(GateAction.Reject);
+        run.Steps[0].AppliedEditCount.Should().Be(0);
+        run.BestSkill.Should().Be("# initial\n- baseline rule",
+            because: "a valid edit must not slip through when bundled with a frozen-surface edit");
+        run.HasAcceptedAny.Should().BeFalse();
+        audit.Entries.Should().ContainSingle();
+        audit.Entries[0].Decision.Should().Contain("AutonomyTier");
+    }
+
+    [Fact]
     public async Task Handle_FrozenSurfaceEveryStep_EarlyStopsOnPatience_WithoutAuditRegistered()
     {
         // No audit registered (the optional dependency is absent). The fence still blocks every patch,

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/SkillTraining/EditableSurfaceRegistryTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/SkillTraining/EditableSurfaceRegistryTests.cs
@@ -1,0 +1,87 @@
+using Application.AI.Common.Services.SkillTraining;
+using Domain.AI.SkillTraining;
+using FluentAssertions;
+using Xunit;
+
+namespace Application.AI.Common.Tests.Services.SkillTraining;
+
+public class EditableSurfaceRegistryTests
+{
+    private static readonly EditableSurfaceRegistry Default = new();
+
+    [Fact]
+    public void Default_OnlySkillDocument_IsEditable()
+    {
+        Default.IsEditable(HarnessSurface.SkillDocument).Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData(HarnessSurface.SystemPrompt)]
+    [InlineData(HarnessSurface.ArtifactGuidance)]
+    [InlineData(HarnessSurface.FailureRecovery)]
+    [InlineData(HarnessSurface.VerificationPrompt)]
+    [InlineData(HarnessSurface.ToolErrorRetryLimit)]
+    [InlineData(HarnessSurface.ToolAvailability)]
+    [InlineData(HarnessSurface.MemoryScopeRules)]
+    [InlineData(HarnessSurface.DeniedTools)]
+    [InlineData(HarnessSurface.AutonomyTier)]
+    [InlineData(HarnessSurface.ContentSafetyConfig)]
+    [InlineData(HarnessSurface.EditableSurfaceRegistry)]
+    public void Default_EveryNonSkillSurface_IsFrozen(HarnessSurface surface)
+    {
+        Default.IsEditable(surface).Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData(HarnessSurface.DeniedTools)]
+    [InlineData(HarnessSurface.AutonomyTier)]
+    [InlineData(HarnessSurface.ContentSafetyConfig)]
+    [InlineData(HarnessSurface.EditableSurfaceRegistry)]
+    public void IsFrozenByConstruction_True_ForGovernanceSurfaces(HarnessSurface surface)
+    {
+        Default.IsFrozenByConstruction(surface).Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData(HarnessSurface.SkillDocument)]
+    [InlineData(HarnessSurface.SystemPrompt)]
+    [InlineData(HarnessSurface.ToolAvailability)]
+    [InlineData(HarnessSurface.MemoryScopeRules)]
+    public void IsFrozenByConstruction_False_ForNonGovernanceSurfaces(HarnessSurface surface)
+    {
+        // Note: ToolAvailability and MemoryScopeRules are frozen *today* but only by policy — a future
+        // phase could unfreeze them. The by-construction freeze is reserved for hard governance.
+        Default.IsFrozenByConstruction(surface).Should().BeFalse();
+    }
+
+    [Fact]
+    public void WideningCtor_CanMarkLowStakeSurfaceEditable()
+    {
+        var widened = new EditableSurfaceRegistry(
+            [HarnessSurface.SkillDocument, HarnessSurface.FailureRecovery]);
+
+        widened.IsEditable(HarnessSurface.SkillDocument).Should().BeTrue();
+        widened.IsEditable(HarnessSurface.FailureRecovery).Should().BeTrue();
+        widened.IsEditable(HarnessSurface.SystemPrompt).Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData(HarnessSurface.DeniedTools)]
+    [InlineData(HarnessSurface.AutonomyTier)]
+    [InlineData(HarnessSurface.ContentSafetyConfig)]
+    [InlineData(HarnessSurface.EditableSurfaceRegistry)]
+    public void WideningCtor_Throws_WhenAskedToUnfreezeByConstructionSurface(HarnessSurface frozen)
+    {
+        var act = () => new EditableSurfaceRegistry([HarnessSurface.SkillDocument, frozen]);
+
+        act.Should().Throw<ArgumentException>()
+            .WithMessage("*frozen by construction*");
+    }
+
+    [Fact]
+    public void WideningCtor_NullArgument_Throws()
+    {
+        var act = () => new EditableSurfaceRegistry(null!);
+        act.Should().Throw<ArgumentNullException>();
+    }
+}

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/SkillTraining/HarnessPatchValidatorTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/SkillTraining/HarnessPatchValidatorTests.cs
@@ -1,0 +1,142 @@
+using Application.AI.Common.Services.SkillTraining;
+using Domain.AI.SkillTraining;
+using FluentAssertions;
+using Xunit;
+
+namespace Application.AI.Common.Tests.Services.SkillTraining;
+
+public class HarnessPatchValidatorTests
+{
+    private static readonly HarnessPatchValidator Sut = new(new EditableSurfaceRegistry());
+
+    [Fact]
+    public void Validate_EmptyPatch_IsAllowed()
+    {
+        Sut.Validate(new Patch()).IsAllowed.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Validate_AllSkillDocumentEdits_IsAllowed()
+    {
+        var patch = new Patch
+        {
+            Edits =
+            [
+                new Edit { Op = EditOp.Append, Content = "- a" },                                  // defaults to SkillDocument
+                new Edit { Op = EditOp.Append, Content = "- b", Surface = HarnessSurface.SkillDocument }
+            ]
+        };
+
+        var result = Sut.Validate(patch);
+
+        result.IsAllowed.Should().BeTrue();
+        result.Violations.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Validate_SingleFrozenSurfaceEdit_IsRejected_WithViolationDetail()
+    {
+        var patch = new Patch
+        {
+            Edits = [new Edit { Op = EditOp.Append, Content = "x", Surface = HarnessSurface.ToolAvailability }]
+        };
+
+        var result = Sut.Validate(patch);
+
+        result.IsAllowed.Should().BeFalse();
+        result.Violations.Should().ContainSingle();
+        result.Violations[0].EditIndex.Should().Be(0);
+        result.Violations[0].Surface.Should().Be(HarnessSurface.ToolAvailability);
+        result.Violations[0].FrozenByConstruction.Should().BeFalse(
+            because: "tool availability is frozen by policy today, not by construction");
+    }
+
+    [Fact]
+    public void Validate_FrozenByConstructionEdit_FlagsByConstruction()
+    {
+        var patch = new Patch
+        {
+            Edits = [new Edit { Op = EditOp.Append, Content = "x", Surface = HarnessSurface.DeniedTools }]
+        };
+
+        var result = Sut.Validate(patch);
+
+        result.IsAllowed.Should().BeFalse();
+        result.Violations[0].FrozenByConstruction.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Validate_MixedEdits_ReportsOnlyTheFrozenOne_AtCorrectIndex()
+    {
+        var patch = new Patch
+        {
+            Edits =
+            [
+                new Edit { Op = EditOp.Append, Content = "ok" },                                       // index 0 — SkillDocument
+                new Edit { Op = EditOp.Append, Content = "bad", Surface = HarnessSurface.SystemPrompt } // index 1 — frozen
+            ]
+        };
+
+        var result = Sut.Validate(patch);
+
+        result.IsAllowed.Should().BeFalse();
+        result.Violations.Should().ContainSingle();
+        result.Violations[0].EditIndex.Should().Be(1);
+        result.Violations[0].Surface.Should().Be(HarnessSurface.SystemPrompt);
+    }
+
+    [Fact]
+    public void Validate_MultipleFrozenEdits_ReportsAllViolations()
+    {
+        var patch = new Patch
+        {
+            Edits =
+            [
+                new Edit { Op = EditOp.Append, Content = "a", Surface = HarnessSurface.SystemPrompt },
+                new Edit { Op = EditOp.Append, Content = "b" },                                         // SkillDocument — allowed
+                new Edit { Op = EditOp.Append, Content = "c", Surface = HarnessSurface.AutonomyTier }
+            ]
+        };
+
+        var result = Sut.Validate(patch);
+
+        result.IsAllowed.Should().BeFalse();
+        result.Violations.Should().HaveCount(2);
+        result.Violations.Select(v => v.EditIndex).Should().Equal(0, 2);
+    }
+
+    [Theory]
+    [InlineData(EditOp.Append)]
+    [InlineData(EditOp.InsertAfter)]
+    [InlineData(EditOp.Replace)]
+    [InlineData(EditOp.Delete)]
+    public void Validate_IsOpAgnostic_RejectsFrozenSurfaceRegardlessOfOp(EditOp op)
+    {
+        // The fence gates on the target surface, not the edit operation: a frozen surface is off-limits
+        // whether the loop wants to Append, InsertAfter, Replace, or Delete on it.
+        var patch = new Patch
+        {
+            Edits = [new Edit { Op = op, Target = "x", Content = "y", Surface = HarnessSurface.ContentSafetyConfig }]
+        };
+
+        var result = Sut.Validate(patch);
+
+        result.IsAllowed.Should().BeFalse();
+        result.Violations[0].Surface.Should().Be(HarnessSurface.ContentSafetyConfig);
+        result.Violations[0].FrozenByConstruction.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Validate_NullPatch_Throws()
+    {
+        var act = () => Sut.Validate(null!);
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void Ctor_NullRegistry_Throws()
+    {
+        var act = () => new HarnessPatchValidator(null!);
+        act.Should().Throw<ArgumentNullException>();
+    }
+}


### PR DESCRIPTION
## What

Builds **Phase 1** of the Self-Harness ([arXiv 2606.09498](https://arxiv.org/abs/2606.09498)) gap: a governance **fence** that decides — in code, not config — which harness surfaces the self-optimization loop (`TrainSkill`) may edit. Today the loop only edits one `SKILL.md`; Self-Harness points the same propose→evaluate→accept loop at the *whole* harness. Before that target is ever widened, this installs the lock.

**This PR widens nothing.** It only builds and proves the fence. Widening the edit target to system prompt / tools / policies is Phase 2/3 and is a separate, governance-gated product decision.

## Why it matters (plain terms)

An optimizer chasing a score could quietly edit the very safety rules it runs under — denied tools, autonomy tier, content safety. The fence runs **below and independent of the accept-gate**, so a frozen-surface patch can never be accepted by improving the score. A subset of surfaces is **frozen by construction**: the registry's widening constructor *throws* if asked to make them editable, so no config or future code path can flip a hard governance boundary.

## Changes

- **`EditableSurfaceRegistry`** — code-owned allowlist. Only `SkillDocument` editable today; `DeniedTools`/`AutonomyTier`/`ContentSafetyConfig`/the registry itself are frozen by construction.
- **`HarnessPatchValidator`** — concrete sealed, **no interface seam** (a fence you can DI-swap for a no-op is not a fence). Pure `Validate(Patch)`, mirroring `PatchApplier`/`GateEvaluator`.
- **`Edit.Surface`** — new field (default `SkillDocument`); lets a patch declare its target. Additive, back-compat.
- **`TrainSkillCommandHandler`** — runs the fence after select / before apply+gate. On violation: best-effort audit to the tamper-evident hash-chain (optional `IGovernanceAuditService`, isolated in try/catch — the fence is the control, the audit is only the record), record a `Reject` step, honor patience.
- DI registration; Console example call-site update.

## Tests

40 new tests: registry by-construction guarantees (widening-ctor throws on each frozen surface), validator violations (index, multi, op-agnostic, by-construction vs by-policy), and loop integration (frozen patch never applied, audited, blocked even with no audit registered).

- `dotnet build src/AgenticHarness.slnx` — 0 errors, 0 new warnings
- Application.AI.Common **1148** green · Domain.AI **791** green

## Review

Security + simplify reviews run; **no CRITICAL/HIGH**. Applied: audit-exception isolation (MED) and dropped an unused `SurfaceMutability` accessor (YAGNI). Receipts recorded against the pushed commit.

## Scope guard

Phase 1 only — the fence. No optimizer surface is widened. Plan: `.claude/plans/self-harness-full-harness-optimization.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)