### PR TITLE
ci: right-size review-agent models by gate criticality

### DIFF
--- a/.github/workflows/docs-drift-check.yml
+++ b/.github/workflows/docs-drift-check.yml
@@ -77,6 +77,6 @@ jobs:
             If you find NO drift, do not open a PR. Write a one-line "no drift" note to the
             job summary ($GITHUB_STEP_SUMMARY) and stop. Never open an empty PR.
           claude_args: |
-            --model opus
+            --model sonnet
             --max-turns 30
             --allowedTools Bash,Read,Grep,Glob,Write,Edit

--- a/.github/workflows/grader.yml
+++ b/.github/workflows/grader.yml
@@ -75,6 +75,6 @@ jobs:
             changed files, then POST your verdict as a single PR comment. Update the
             same comment on re-runs rather than stacking new ones.
           claude_args: |
-            --model opus
+            --model sonnet
             --max-turns 20
             --allowedTools Bash,Read,Grep,Glob


### PR DESCRIPTION
## What

Tunes the model each CI review agent runs on, matched to what the gate is actually for. Model is the only thing changed.

| Job | Blocks merge? | Model | Change |
|---|---|---|---|
| security-review | yes (gated paths, fail-closed) | opus | unchanged |
| correctness-review | yes (fail-closed) | opus | unchanged |
| grader | no (advisory comment) | opus → **sonnet** | downgraded |
| docs-drift | no (advisory doc PR, human-reviewed) | opus → **sonnet** | downgraded |
| eval-suite | off by default | n/a | untouched (judge model is harness-configured) |

## Why

The two blocking gates hunt the diff for logic/security defects — the failure mode there is a *merged* bug, so they stay on Opus where the reasoning edge has the most leverage. The two advisory jobs (a verdict comment; a human-reviewed doc PR) are lower-stakes comprehension/writing tasks that Sonnet 4.6 handles well at ~40% lower cost.

Effort flags are intentionally left untouched — `--model` is the verified `claude_args` lever; an unverified `--effort` flag could error a fail-closed gate and block merges.

## Test plan

- These workflows only run on PR / push; this PR exercises grader + (post-merge) docs-drift on their new model.
- No source under `src/` changes, so build-and-test, the OWASP gate, and security-review short-circuit to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)