### PR TITLE
feat(foundry): default hosted agent to autonomous tool execution

### DIFF
--- a/src/Content/Presentation/Presentation.FoundryHost/appsettings.json
+++ b/src/Content/Presentation/Presentation.FoundryHost/appsettings.json
@@ -87,8 +87,8 @@
         "DecayBiasAlpha": 0.25
       },
       "Permissions": {
-        "DefaultBehavior": "Ask",
-        "DefaultAutonomyLevel": "Supervised",
+        "DefaultBehavior": "Allow",
+        "DefaultAutonomyLevel": "Autonomous",
         "TierPolicies": {
           "Restricted": {
             "DefaultBehavior": "Ask",


### PR DESCRIPTION
## What

Flips the Foundry-hosted agent's default permission posture from `Ask`/`Supervised` to `Allow`/`Autonomous` in `Presentation.FoundryHost/appsettings.json`.

## Why

The hosted agent runs in a Foundry-managed container with **no human at a console**. The conservative `Ask`/`Supervised` value (a safe placeholder from the Phase 2 hardening pass, PR #51) produced human-approval prompts that nothing could ever answer in that environment — effectively stalling tool use. Autonomous is the correct end-state for a headless hosted agent.

## Safety — what is NOT weakened

Autonomy tier governs only the *default approval behavior*. The hard guardrails are independent and remain fully enforced regardless of tier:
- **`DeniedTools`** stay bypass-immune.
- **Content safety** wiring stays on (`Governance.EnablePromptInjectionDetection`, injection block threshold `High`).
- **Governance escalation** stays enabled (`Governance.Escalation`).
- The Foundry host's `/responses` endpoint is fronted by Foundry's own auth (trust boundary unchanged).

## Scope

Config-only: two lines in one `appsettings.json`. No code change, no test impact (no test pins these values).

🤖 Generated with [Claude Code](https://claude.com/claude-code)