### PR TITLE
feat(skill-training): widen optimizer to prose surfaces, run-scoped (Self-Harness Phase 2 Step 1)

### DIFF
--- a/src/Content/Application/Application.AI.Common/CQRS/SkillTraining/TrainSkill/TrainSkillCommandHandler.cs
+++ b/src/Content/Application/Application.AI.Common/CQRS/SkillTraining/TrainSkill/TrainSkillCommandHandler.cs
@@ -113,6 +113,16 @@ public sealed class TrainSkillCommandHandler
                 ["TrainSkillConfig invariants violated; ensure RequestValidationBehavior is registered."]);
         }
 
+        // Fail fast when a run declares a TargetSurface the code-owned registry has not unlocked.
+        // Without this, every step's edits (which target this surface) would be fence-rejected one by
+        // one — correct, but opaque. Surfaces stay locked by default; widening is a deliberate,
+        // human-owned registration in the composition root, never something the loop can do itself.
+        if (!_fence.IsSurfaceEditable(cfg.TargetSurface))
+        {
+            return Result<SkillTrainingRunResult>.ValidationFailure(
+                [$"TargetSurface '{cfg.TargetSurface}' is not editable. The EditableSurfaceRegistry must be widened (in code) to unlock it before a run may target it."]);
+        }
+
         var scheduler = ResolveScheduler(cfg.LrScheduler);
         var totalSteps = cfg.Epochs * cfg.StepsPerEpoch;
 
@@ -193,21 +203,32 @@ public sealed class TrainSkillCommandHandler
                     _logger.LogWarning(
                         "Harness patch fence rejected step {Step}: {Count} edit(s) target frozen surface(s) [{Surfaces}]. Patch not applied or gated.",
                         globalStep, fenceResult.Violations.Count, surfaces);
-                    // The fence — not the audit — is the control: an audit-write failure must not abort
-                    // the run or let a frozen-surface patch through. Record the rejection best-effort.
-                    try
-                    {
-                        _audit?.Log(
-                            request.SkillId,
-                            "skill_training.harness_patch_rejected",
-                            $"deny: frozen surface(s) [{surfaces}]");
-                    }
-                    catch (Exception ex)
-                    {
-                        _logger.LogError(ex,
-                            "Governance audit write failed for fence rejection at step {Step}; rejection still enforced.",
-                            globalStep);
-                    }
+                    // The fence — not the audit — is the control: SafeAudit swallows write failures so a
+                    // frozen-surface patch can never slip through on a broken audit sink.
+                    SafeAudit(request.SkillId, "skill_training.harness_patch_rejected",
+                        $"deny: frozen surface(s) [{surfaces}]", globalStep);
+                    steps.Add(NewStepRecord(globalStep, epoch, GateAction.Reject,
+                        candidateScore: 0.0, proposed.Edits.Count, applied: 0));
+                    consecutiveRejects++;
+                    if (consecutiveRejects >= cfg.Patience) goto EarlyStop;
+                    continue;
+                }
+
+                // ── Run-scope guard (Self-Harness Phase 2) ────────────────────
+                // A run optimizes exactly one declared surface (cfg.TargetSurface). The fence above
+                // already guaranteed every edit targets an *editable* surface; this narrows further to
+                // the run's *declared* surface, so a failure-recovery run cannot also rewrite the skill
+                // body even though both may be unlocked. All-or-nothing, like the fence — and below the
+                // gate, so an out-of-scope edit can never be score-accepted.
+                var outOfScope = proposed.Edits.Where(e => e.Surface != cfg.TargetSurface).ToArray();
+                if (outOfScope.Length > 0)
+                {
+                    var surfaces = string.Join(", ", outOfScope.Select(e => e.Surface).Distinct());
+                    _logger.LogWarning(
+                        "Run-scope guard rejected step {Step}: {Count} edit(s) target surface(s) [{Surfaces}] outside the run's TargetSurface '{Target}'. Patch not applied or gated.",
+                        globalStep, outOfScope.Length, surfaces, cfg.TargetSurface);
+                    SafeAudit(request.SkillId, "skill_training.out_of_run_scope",
+                        $"deny: edit(s) on [{surfaces}] outside TargetSurface '{cfg.TargetSurface}'", globalStep);
                     steps.Add(NewStepRecord(globalStep, epoch, GateAction.Reject,
                         candidateScore: 0.0, proposed.Edits.Count, applied: 0));
                     consecutiveRejects++;
@@ -346,6 +367,17 @@ public sealed class TrainSkillCommandHandler
                         break;
                 }
 
+                // Audit every accepted change to a harness surface (caveat: audit everything the loop
+                // alters). Rejections are recorded as step records; an accept mutates the surface, so it
+                // is written to the tamper-evident governance trail. Best-effort and isolated — an audit
+                // failure must not unwind an already-gated, already-applied accept.
+                if (gateResult.Action is GateAction.Accept or GateAction.AcceptNewBest)
+                {
+                    SafeAudit(request.SkillId, "skill_training.harness_patch_applied",
+                        $"accept: surface '{cfg.TargetSurface}', {applyReport.AppliedEdits.Count} edit(s), score {gateResult.CandidateScore:F4}",
+                        globalStep);
+                }
+
                 await _checkpointStore.SaveAsync(
                     new SkillTrainingCheckpoint
                     {
@@ -441,6 +473,25 @@ public sealed class TrainSkillCommandHandler
         };
         var result = await _mediator.Send(cmd, ct).ConfigureAwait(false);
         return result.IsSuccess ? result.Value! : priorMemory;
+    }
+
+    /// <summary>
+    /// Writes a governance-audit entry best-effort. The audit is the record, not the control: a failed
+    /// write is logged and swallowed so it can never unwind an already-enforced reject or an
+    /// already-applied accept. No-op when no <c>IGovernanceAuditService</c> is registered.
+    /// </summary>
+    private void SafeAudit(string skillId, string action, string decision, int step)
+    {
+        try
+        {
+            _audit?.Log(skillId, action, decision);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "Governance audit write failed for {Action} at step {Step}; the control was still enforced.",
+                action, step);
+        }
     }
 
     private static SkillTrainingStepRecord NewStepRecord(

--- a/src/Content/Application/Application.AI.Common/Extensions/SkillTrainingDependencyInjection.cs
+++ b/src/Content/Application/Application.AI.Common/Extensions/SkillTrainingDependencyInjection.cs
@@ -1,5 +1,6 @@
 using Application.AI.Common.Interfaces.SkillTraining;
 using Application.AI.Common.Services.SkillTraining;
+using Domain.AI.SkillTraining;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
@@ -35,8 +36,19 @@ public static class SkillTrainingDependencyInjection
 {
     /// <summary>Registers the skill-training subsystem's services.</summary>
     /// <param name="services">The service collection to configure.</param>
+    /// <param name="editableSurfaces">
+    /// Optional set of harness surfaces to <em>unlock</em> for the self-optimization loop, beyond the
+    /// always-editable <see cref="HarnessSurface.SkillDocument"/>. Defaults to <see langword="null"/> —
+    /// locked, skill-document-only. Passing surfaces here is the <em>deliberate, human-owned, code-level</em>
+    /// opt-in to Self-Harness Phase 2: it is the only way to widen the fence, the loop can never do it
+    /// itself, and the validating <see cref="EditableSurfaceRegistry"/> constructor throws if any
+    /// requested surface is frozen by construction (denied tools, autonomy tier, content safety, the
+    /// registry itself).
+    /// </param>
     /// <returns>The service collection for chaining.</returns>
-    public static IServiceCollection AddSkillTrainingDependencies(this IServiceCollection services)
+    public static IServiceCollection AddSkillTrainingDependencies(
+        this IServiceCollection services,
+        IReadOnlyCollection<HarnessSurface>? editableSurfaces = null)
     {
         ArgumentNullException.ThrowIfNull(services);
 
@@ -44,7 +56,21 @@ public static class SkillTrainingDependencyInjection
         services.TryAddSingleton<IGateEvaluator, GateEvaluator>();
         services.TryAddSingleton<IPatchAggregator, PatchAggregator>();
         services.TryAddSingleton<IEditSelector, TopKEditSelector>();
-        services.TryAddSingleton<EditableSurfaceRegistry>();
+
+        // Widen the fence only when a consumer explicitly opts in (code, not config). SkillDocument is
+        // always editable; the validating constructor throws on any frozen-by-construction surface.
+        // TryAddSingleton means the default-locked registration below is a no-op once this one lands.
+        if (editableSurfaces is { Count: > 0 })
+        {
+            var unlocked = new HashSet<HarnessSurface>(editableSurfaces) { HarnessSurface.SkillDocument };
+            services.TryAddSingleton(new EditableSurfaceRegistry(unlocked));
+        }
+
+        // Default-locked fallback. Registered via an explicit factory, NOT TryAddSingleton<T>(): the
+        // container's greedy constructor selection would otherwise activate the IEnumerable ctor with an
+        // empty sequence (unregistered IEnumerable<T> resolves to empty), producing a registry that
+        // locks every surface — including SkillDocument — and silently breaking the loop's own edits.
+        services.TryAddSingleton(_ => new EditableSurfaceRegistry());
         services.TryAddSingleton<HarnessPatchValidator>();
         services.TryAddSingleton<ISkillTrainingCheckpointStore, InMemorySkillTrainingCheckpointStore>();
         services.TryAddSingleton<IPatchProposer, NotConfiguredPatchProposer>();

--- a/src/Content/Application/Application.AI.Common/Services/SkillTraining/HarnessPatchValidator.cs
+++ b/src/Content/Application/Application.AI.Common/Services/SkillTraining/HarnessPatchValidator.cs
@@ -66,4 +66,12 @@ public sealed class HarnessPatchValidator
             ? HarnessPatchValidation.Allowed
             : new HarnessPatchValidation { IsAllowed = false, Violations = violations };
     }
+
+    /// <summary>
+    /// Returns <see langword="true"/> iff the code-owned registry marks <paramref name="surface"/>
+    /// editable. Exposed so the training loop can fail fast when a run declares a
+    /// <c>TargetSurface</c> the registry has not unlocked, instead of silently rejecting every step.
+    /// </summary>
+    /// <param name="surface">The surface to test.</param>
+    public bool IsSurfaceEditable(HarnessSurface surface) => _registry.IsEditable(surface);
 }

--- a/src/Content/Domain/Domain.AI/SkillTraining/TrainSkillConfig.cs
+++ b/src/Content/Domain/Domain.AI/SkillTraining/TrainSkillConfig.cs
@@ -63,4 +63,17 @@ public sealed record TrainSkillConfig
 
     /// <summary>Seed for sampling the train/val batches; 0 = nondeterministic.</summary>
     public int Seed { get; init; }
+
+    /// <summary>
+    /// The single harness surface this run is permitted to optimize. Defaults to
+    /// <see cref="HarnessSurface.SkillDocument"/> — the original, only-editable-today surface.
+    /// </summary>
+    /// <remarks>
+    /// This is the per-run scope, narrower than (and validated against) the code-owned
+    /// <c>EditableSurfaceRegistry</c>: the surface must be marked editable by the registry, and the
+    /// fence (<c>HarnessPatchValidator</c>) rejects, below the gate, any edit whose surface differs
+    /// from this value. A run therefore touches exactly one declared surface — the "get specific about
+    /// what it can and cannot alter" guardrail of Self-Harness Phase 2.
+    /// </remarks>
+    public HarnessSurface TargetSurface { get; init; } = HarnessSurface.SkillDocument;
 }

--- a/src/Content/Tests/Application.AI.Common.Tests/CQRS/SkillTraining/TrainSkillCommandHandlerTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/CQRS/SkillTraining/TrainSkillCommandHandlerTests.cs
@@ -22,13 +22,18 @@ public class TrainSkillCommandHandlerTests
         IRolloutRunner runner,
         IPatchProposer proposer,
         InMemorySkillTrainingCheckpointStore store,
-        IGovernanceAuditService? audit = null)
+        IGovernanceAuditService? audit = null,
+        HarnessPatchValidator? fence = null)
     {
         return new TrainSkillCommandHandler(
-            runner, proposer, Aggregator, Selector, Applier, Gate, Fence,
+            runner, proposer, Aggregator, Selector, Applier, Gate, fence ?? Fence,
             store, new NoOpMediator(), TimeProvider.System,
             NullLogger<TrainSkillCommandHandler>.Instance, audit);
     }
+
+    /// <summary>A fence whose registry has been widened to unlock the given prose surfaces (Phase 2).</summary>
+    private static HarnessPatchValidator WidenedFence(params HarnessSurface[] surfaces) =>
+        new(new EditableSurfaceRegistry([HarnessSurface.SkillDocument, .. surfaces]));
 
     private static TrainSkillCommand NewCommand(TrainSkillConfig config) => new()
     {
@@ -409,6 +414,127 @@ public class TrainSkillCommandHandlerTests
 
         result.Value!.StepsExecuted.Should().Be(2, because: "patience=2 stops after 2 fence rejects");
         result.Value.Steps.Should().AllSatisfy(s => s.Action.Should().Be(GateAction.Reject));
+    }
+
+    [Fact]
+    public async Task Handle_TargetSurfaceNotEditable_ReturnsValidationFailure_RunsNothing()
+    {
+        // The default registry locks every surface but SkillDocument. A run that declares a still-locked
+        // TargetSurface must fail fast at intake, not silently reject every step.
+        var runner = new StubRolloutRunner((_, _) => [new RolloutResult { ItemId = "x", Hard = 1.0, Soft = 1.0 }]);
+        var proposer = new StubProposer(_ => new Patch
+        {
+            Edits = [new Edit { Op = EditOp.Append, Content = "- x", Surface = HarnessSurface.FailureRecovery }]
+        });
+        var sut = NewSut(runner, proposer, new InMemorySkillTrainingCheckpointStore());
+
+        var result = await sut.Handle(
+            NewCommand(new TrainSkillConfig
+            {
+                Epochs = 1, StepsPerEpoch = 1, LrStart = 4, LrMin = 1,
+                LrScheduler = "constant", Patience = 6,
+                UseSlowUpdate = false, UseMetaSkill = false,
+                TargetSurface = HarnessSurface.FailureRecovery   // never unlocked in the default registry
+            }),
+            CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse(because: "a locked TargetSurface is rejected before the loop starts");
+    }
+
+    [Fact]
+    public async Task Handle_EditOutsideRunTargetSurface_RejectsAndAudits_EvenWhenSurfaceIsUnlocked()
+    {
+        // The registry unlocks both SkillDocument and FailureRecovery, but this run targets only
+        // FailureRecovery. An edit on SkillDocument passes the frozen-surface fence yet must be rejected
+        // by the run-scope guard — a run touches exactly its one declared surface.
+        var runner = new StubRolloutRunner((_, _) => [new RolloutResult { ItemId = "x", Hard = 1.0, Soft = 1.0 }]);
+        var proposer = new StubProposer(_ => new Patch
+        {
+            Edits = [new Edit { Op = EditOp.Append, Content = "- a skill-body rule", Surface = HarnessSurface.SkillDocument }]
+        });
+        var audit = new CapturingAudit();
+        var sut = NewSut(runner, proposer, new InMemorySkillTrainingCheckpointStore(),
+            audit, WidenedFence(HarnessSurface.FailureRecovery));
+
+        var result = await sut.Handle(
+            NewCommand(new TrainSkillConfig
+            {
+                Epochs = 1, StepsPerEpoch = 1, LrStart = 4, LrMin = 1,
+                LrScheduler = "constant", Patience = 6,
+                UseSlowUpdate = false, UseMetaSkill = false,
+                TargetSurface = HarnessSurface.FailureRecovery
+            }),
+            CancellationToken.None);
+
+        var run = result.Value!;
+        run.Steps[0].Action.Should().Be(GateAction.Reject);
+        run.Steps[0].AppliedEditCount.Should().Be(0, because: "the run-scope guard rejects before PatchApplier runs");
+        run.BestSkill.Should().Be("# initial\n- baseline rule");
+        run.HasAcceptedAny.Should().BeFalse();
+        audit.Entries.Should().ContainSingle();
+        audit.Entries[0].Action.Should().Be("skill_training.out_of_run_scope");
+        audit.Entries[0].Decision.Should().Contain("SkillDocument");
+    }
+
+    [Fact]
+    public async Task Handle_EditOnUnlockedTargetSurface_AppliesAndAuditsTheApply()
+    {
+        // A run targeting an unlocked prose surface, with an edit on that same surface, flows all the
+        // way through: fence passes, run-scope passes, candidate accepted — and the accepted apply is
+        // written to the governance audit (audit-everything-it-changes).
+        var runner = new StubRolloutRunner((_, batch) => batch.Split == "val"
+            ? [new RolloutResult { ItemId = "v", Hard = 1.0, Soft = 1.0 }]
+            : [new RolloutResult { ItemId = "t", Hard = 0.5, Soft = 0.5 }]);
+        var proposer = new StubProposer(_ => new Patch
+        {
+            Edits = [new Edit { Op = EditOp.Append, Content = "- retry once, then escalate", Surface = HarnessSurface.FailureRecovery }]
+        });
+        var audit = new CapturingAudit();
+        var sut = NewSut(runner, proposer, new InMemorySkillTrainingCheckpointStore(),
+            audit, WidenedFence(HarnessSurface.FailureRecovery));
+
+        var result = await sut.Handle(
+            NewCommand(new TrainSkillConfig
+            {
+                Epochs = 1, StepsPerEpoch = 1, LrStart = 4, LrMin = 1,
+                LrScheduler = "constant", Patience = 6,
+                UseSlowUpdate = false, UseMetaSkill = false,
+                TargetSurface = HarnessSurface.FailureRecovery
+            }),
+            CancellationToken.None);
+
+        result.Value!.Steps[0].Action.Should().Be(GateAction.AcceptNewBest);
+        result.Value.BestSkill.Should().Contain("retry once, then escalate");
+        var applied = audit.Entries.Should().ContainSingle(e => e.Action == "skill_training.harness_patch_applied").Subject;
+        applied.Decision.Should().Contain("FailureRecovery");
+    }
+
+    [Fact]
+    public async Task Handle_AcceptedSkillDocumentEdit_AuditsTheApply()
+    {
+        // The default skill-document path also audits accepted applies — the common case, not just
+        // widened prose surfaces.
+        var runner = new StubRolloutRunner((_, batch) => batch.Split == "val"
+            ? [new RolloutResult { ItemId = "v", Hard = 1.0, Soft = 1.0 }]
+            : [new RolloutResult { ItemId = "t", Hard = 0.5, Soft = 0.5 }]);
+        var proposer = new StubProposer(_ => new Patch
+        {
+            Edits = [new Edit { Op = EditOp.Append, Content = "- new rule" }]
+        });
+        var audit = new CapturingAudit();
+        var sut = NewSut(runner, proposer, new InMemorySkillTrainingCheckpointStore(), audit);
+
+        await sut.Handle(
+            NewCommand(new TrainSkillConfig
+            {
+                Epochs = 1, StepsPerEpoch = 1, LrStart = 4, LrMin = 1,
+                LrScheduler = "constant", Patience = 6,
+                UseSlowUpdate = false, UseMetaSkill = false
+            }),
+            CancellationToken.None);
+
+        audit.Entries.Should().ContainSingle(e => e.Action == "skill_training.harness_patch_applied")
+            .Subject.Decision.Should().Contain("SkillDocument");
     }
 
     // ── Stubs ────────────────────────────────────────────────────────────────────

--- a/src/Content/Tests/Application.AI.Common.Tests/Extensions/SkillTrainingDependencyInjectionTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Extensions/SkillTrainingDependencyInjectionTests.cs
@@ -1,0 +1,54 @@
+using Application.AI.Common.Extensions;
+using Application.AI.Common.Services.SkillTraining;
+using Domain.AI.SkillTraining;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Application.AI.Common.Tests.Extensions;
+
+/// <summary>
+/// Tests for the editable-surface opt-in on <see cref="SkillTrainingDependencyInjection.AddSkillTrainingDependencies"/> —
+/// the only sanctioned, code-level way to widen the Self-Harness fence (Phase 2).
+/// </summary>
+public class SkillTrainingDependencyInjectionTests
+{
+    private static EditableSurfaceRegistry ResolveRegistry(IServiceCollection services) =>
+        services.BuildServiceProvider().GetRequiredService<EditableSurfaceRegistry>();
+
+    [Fact]
+    public void Default_LocksEverythingButSkillDocument()
+    {
+        var registry = ResolveRegistry(new ServiceCollection().AddSkillTrainingDependencies());
+
+        registry.IsEditable(HarnessSurface.SkillDocument).Should().BeTrue();
+        registry.IsEditable(HarnessSurface.FailureRecovery).Should().BeFalse(
+            because: "surfaces stay locked by default; widening is an explicit opt-in");
+    }
+
+    [Fact]
+    public void Widening_UnlocksRequestedSurfaces_AndAlwaysKeepsSkillDocument()
+    {
+        var registry = ResolveRegistry(new ServiceCollection().AddSkillTrainingDependencies(
+            [HarnessSurface.ArtifactGuidance, HarnessSurface.FailureRecovery, HarnessSurface.VerificationPrompt]));
+
+        registry.IsEditable(HarnessSurface.ArtifactGuidance).Should().BeTrue();
+        registry.IsEditable(HarnessSurface.FailureRecovery).Should().BeTrue();
+        registry.IsEditable(HarnessSurface.VerificationPrompt).Should().BeTrue();
+        registry.IsEditable(HarnessSurface.SkillDocument).Should().BeTrue(
+            because: "SkillDocument is always editable, even when not explicitly listed");
+    }
+
+    [Theory]
+    [InlineData(HarnessSurface.DeniedTools)]
+    [InlineData(HarnessSurface.AutonomyTier)]
+    [InlineData(HarnessSurface.ContentSafetyConfig)]
+    [InlineData(HarnessSurface.EditableSurfaceRegistry)]
+    public void Widening_WithFrozenByConstructionSurface_ThrowsAtComposition(HarnessSurface frozen)
+    {
+        var act = () => new ServiceCollection().AddSkillTrainingDependencies([frozen]);
+
+        act.Should().Throw<ArgumentException>(
+            because: "governance surfaces can never be unlocked, even by an explicit human opt-in");
+    }
+}


### PR DESCRIPTION
## What

Self-Harness **Phase 2, Step 1 of 2**. Widens the self-optimization loop so it can target prose harness surfaces (artifact guidance, failure recovery, verification prompts) beyond the single skill document — behind a hard, code-owned fence. (Step 2, the locked suggestion-only retry dial, is a separate PR.)

Builds on the Phase 1 fence (PR #78). Plan: `.claude/plans/self-harness-phase2.md`.

## The four guardrails (as approved)

1. **Locked by default; humans only unlock.** No new surface is editable out of the box. `AddSkillTrainingDependencies(editableSurfaces: …)` is the *sole, deliberate, code-level* opt-in. The loop can never unlock a surface itself, and the validating registry constructor throws if asked to unlock a frozen-by-construction governance surface (denied tools, autonomy tier, content safety, the registry itself).
2. **Audit everything.** Accepted applies now write to the tamper-evident governance trail (previously only rejections did). Rejections (frozen-surface and out-of-scope) are audited too.
3. **Be specific about what it can alter (run-scope).** `TrainSkillConfig.TargetSurface` declares the *one* surface a run may edit. A run fails fast if that surface isn't unlocked, and the handler rejects — below the gate — any edit on a different surface, even an otherwise-editable one.
4. (Suggestion-only mode is a Step 2 concern — the prose surfaces here auto-apply, since they're low-stakes, fenced, two-split-gated, and audited.)

## Bug fixed along the way

A latent Phase 1 DI defect: `TryAddSingleton<EditableSurfaceRegistry>()` let the container pick the greedy `IEnumerable<HarnessSurface>` constructor and inject an **empty** sequence (MS DI resolves unregistered `IEnumerable<T>` to empty), producing a registry that locked **every** surface — including `SkillDocument`. In a composed app the loop's own skill edits would have been fence-rejected. Phase 1 tests missed it because they construct the fence directly, bypassing DI. Now registered via a parameterless factory; surfaced by a new DI-resolution test.

## Design note

No section "splicer" was built: the loop is text-agnostic (it optimizes a document string and scores it via rollouts), so the surface is a *governance scope + run-scope label*, not a physically isolated slice of text — isolating a section for scoring would break rollout semantics. Where the prose physically lives is consumer/proposer territory.

## Tests

189 skill-training tests green (1159 across the project). New: 4 handler tests (locked-surface guard, run-scope reject+audit, run-scope accept+apply-audit, default-path apply-audit) and 3 DI tests (default-locked, widening unlocks + always keeps SkillDocument, frozen-surface throws).

## Review

`/code-review` and `/simplify` run (inline — finder agents hit a transient 529 overload). `/simplify` collapsed three near-identical audit `try/catch` blocks into a `SafeAudit` helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)