### PR TITLE
feat(skill-training): bounded harness-change suggestions (Self-Harness Phase 2 Step 2)

### DIFF
--- a/src/Content/Application/Application.AI.Common/CQRS/SkillTraining/TrainSkill/TrainSkillCommandHandler.cs
+++ b/src/Content/Application/Application.AI.Common/CQRS/SkillTraining/TrainSkill/TrainSkillCommandHandler.cs
@@ -505,32 +505,47 @@ public sealed class TrainSkillCommandHandler
         var accepted = new List<HarnessChangeSuggestion>(proposed.Count);
         foreach (var suggestion in proposed)
         {
-            var validation = _suggestionValidator.Validate(suggestion);
-            if (validation.IsAllowed)
+            var surfaced = ValidateAndAuditSuggestion(suggestion, request.SkillId, finalStep);
+            if (surfaced is not null)
             {
-                accepted.Add(suggestion);
-                _logger.LogInformation(
-                    "Harness-change suggestion surfaced: {Surface}.{Field} = {Value} (advisory only, not applied).",
-                    suggestion.Surface, suggestion.Field, suggestion.ProposedValue);
-                // Safe to audit Field (validation passed → it is the allow-listed constant, not raw input)
-                // and NormalizedValue (the scrubbed canonical value), never the raw ProposedValue.
-                SafeAudit(request.SkillId, "skill_training.harness_change_suggested",
-                    $"suggest: {suggestion.Surface}.{suggestion.Field}={validation.NormalizedValue}", finalStep);
-            }
-            else
-            {
-                // Audit rejections too (audit-everything guardrail). The raw, unvalidated proposer Field
-                // and value are logged operationally below but kept OUT of the tamper-evident chain — only
-                // the enum surface and the stable reason category are recorded there.
-                _logger.LogWarning(
-                    "Harness-change suggestion rejected: {Surface}.{Field} — {Reason}.",
-                    suggestion.Surface, suggestion.Field, validation.RejectionReason);
-                SafeAudit(request.SkillId, "skill_training.harness_change_rejected",
-                    $"deny: {suggestion.Surface} reason {validation.RejectionReason}", finalStep);
+                accepted.Add(surfaced);
             }
         }
 
         return accepted;
+    }
+
+    /// <summary>
+    /// Validates one suggestion against the config-surface constraint and audits the outcome. Returns the
+    /// suggestion to surface — with its value replaced by the scrubbed canonical form — when allowed, or
+    /// <see langword="null"/> when rejected.
+    /// </summary>
+    private HarnessChangeSuggestion? ValidateAndAuditSuggestion(
+        HarnessChangeSuggestion suggestion, string skillId, int finalStep)
+    {
+        var validation = _suggestionValidator.Validate(suggestion);
+        if (validation.IsAllowed)
+        {
+            _logger.LogInformation(
+                "Harness-change suggestion surfaced: {Surface}.{Field} = {Value} (advisory only, not applied).",
+                suggestion.Surface, suggestion.Field, validation.NormalizedValue);
+            // Safe to audit Field (validation passed → it is the allow-listed constant, not raw input)
+            // and NormalizedValue (the scrubbed canonical value), never the raw ProposedValue.
+            SafeAudit(skillId, "skill_training.harness_change_suggested",
+                $"suggest: {suggestion.Surface}.{suggestion.Field}={validation.NormalizedValue}", finalStep);
+            // Surface the canonical value too, so consumers of the run result never see raw proposer text.
+            return suggestion with { ProposedValue = validation.NormalizedValue ?? suggestion.ProposedValue };
+        }
+
+        // Audit rejections too (audit-everything guardrail). The raw, unvalidated proposer Field and value
+        // are logged operationally below but kept OUT of the tamper-evident chain — only the enum surface
+        // and the stable reason category are recorded there.
+        _logger.LogWarning(
+            "Harness-change suggestion rejected: {Surface}.{Field} — {Reason}.",
+            suggestion.Surface, suggestion.Field, validation.RejectionReason);
+        SafeAudit(skillId, "skill_training.harness_change_rejected",
+            $"deny: {suggestion.Surface} reason {validation.RejectionReason}", finalStep);
+        return null;
     }
 
     private ILrScheduler ResolveScheduler(string key) => key.ToLowerInvariant() switch

--- a/src/Content/Application/Application.AI.Common/CQRS/SkillTraining/TrainSkill/TrainSkillCommandHandler.cs
+++ b/src/Content/Application/Application.AI.Common/CQRS/SkillTraining/TrainSkill/TrainSkillCommandHandler.cs
@@ -39,6 +39,8 @@ public sealed class TrainSkillCommandHandler
     private readonly PatchApplier _applier;
     private readonly IGateEvaluator _gate;
     private readonly HarnessPatchValidator _fence;
+    private readonly IHarnessChangeSuggester _suggester;
+    private readonly HarnessChangeSuggestionValidator _suggestionValidator;
     private readonly ISkillTrainingCheckpointStore _checkpointStore;
     private readonly IMediator _mediator;
     private readonly TimeProvider _time;
@@ -61,6 +63,8 @@ public sealed class TrainSkillCommandHandler
         PatchApplier applier,
         IGateEvaluator gate,
         HarnessPatchValidator fence,
+        IHarnessChangeSuggester suggester,
+        HarnessChangeSuggestionValidator suggestionValidator,
         ISkillTrainingCheckpointStore checkpointStore,
         IMediator mediator,
         TimeProvider time,
@@ -74,6 +78,8 @@ public sealed class TrainSkillCommandHandler
         ArgumentNullException.ThrowIfNull(applier);
         ArgumentNullException.ThrowIfNull(gate);
         ArgumentNullException.ThrowIfNull(fence);
+        ArgumentNullException.ThrowIfNull(suggester);
+        ArgumentNullException.ThrowIfNull(suggestionValidator);
         ArgumentNullException.ThrowIfNull(checkpointStore);
         ArgumentNullException.ThrowIfNull(mediator);
         ArgumentNullException.ThrowIfNull(time);
@@ -86,6 +92,8 @@ public sealed class TrainSkillCommandHandler
         _applier = applier;
         _gate = gate;
         _fence = fence;
+        _suggester = suggester;
+        _suggestionValidator = suggestionValidator;
         _checkpointStore = checkpointStore;
         _mediator = mediator;
         _time = time;
@@ -432,6 +440,13 @@ public sealed class TrainSkillCommandHandler
         }
 
     EarlyStop:
+        // Suggestion-only harness-change path (Self-Harness Phase 2 Step 2). Off by default; when a run
+        // opts in, the loop asks for advisory config-dial suggestions, bounds-checks each against the
+        // code-owned constraint, audits both outcomes, and surfaces the survivors. It NEVER mutates live
+        // config and runs after the optimization loop, so it cannot influence the gated result above.
+        var suggestions = await EmitHarnessChangeSuggestionsAsync(
+            request, cfg, lastValRollouts, globalStep, cancellationToken).ConfigureAwait(false);
+
         return Result<SkillTrainingRunResult>.Success(new SkillTrainingRunResult
         {
             RunId = request.RunId,
@@ -441,8 +456,81 @@ public sealed class TrainSkillCommandHandler
             StepsExecuted = globalStep,
             ConsecutiveRejects = consecutiveRejects,
             HasAcceptedAny = hasAcceptedAny,
-            Steps = steps
+            Steps = steps,
+            HarnessChangeSuggestions = suggestions
         });
+    }
+
+    /// <summary>
+    /// Emits bounded, never-applied harness-change suggestions at end of run when the config opts in.
+    /// Returns the suggestions that passed the code-owned <see cref="ConfigSurfaceConstraint"/>; rejects
+    /// and a thrown suggester are isolated so the suggestion path can never fail the run.
+    /// </summary>
+    private async Task<IReadOnlyList<HarnessChangeSuggestion>> EmitHarnessChangeSuggestionsAsync(
+        TrainSkillCommand request,
+        TrainSkillConfig cfg,
+        IReadOnlyList<RolloutResult> rollouts,
+        int finalStep,
+        CancellationToken cancellationToken)
+    {
+        if (!cfg.EmitHarnessChangeSuggestions)
+        {
+            return [];
+        }
+
+        IReadOnlyList<HarnessChangeSuggestion> proposed;
+        try
+        {
+            proposed = await _suggester.SuggestAsync(
+                new HarnessSuggestionInput { SkillId = request.SkillId, Rollouts = rollouts },
+                cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            // Advisory by design: a faulty suggester must never fail an already-completed run.
+            _logger.LogError(ex,
+                "Harness-change suggester threw; no suggestions surfaced. The optimization result is unaffected.");
+            return [];
+        }
+
+        if (proposed is null || proposed.Count == 0)
+        {
+            return [];
+        }
+
+        var accepted = new List<HarnessChangeSuggestion>(proposed.Count);
+        foreach (var suggestion in proposed)
+        {
+            var validation = _suggestionValidator.Validate(suggestion);
+            if (validation.IsAllowed)
+            {
+                accepted.Add(suggestion);
+                _logger.LogInformation(
+                    "Harness-change suggestion surfaced: {Surface}.{Field} = {Value} (advisory only, not applied).",
+                    suggestion.Surface, suggestion.Field, suggestion.ProposedValue);
+                // Safe to audit Field (validation passed → it is the allow-listed constant, not raw input)
+                // and NormalizedValue (the scrubbed canonical value), never the raw ProposedValue.
+                SafeAudit(request.SkillId, "skill_training.harness_change_suggested",
+                    $"suggest: {suggestion.Surface}.{suggestion.Field}={validation.NormalizedValue}", finalStep);
+            }
+            else
+            {
+                // Audit rejections too (audit-everything guardrail). The raw, unvalidated proposer Field
+                // and value are logged operationally below but kept OUT of the tamper-evident chain — only
+                // the enum surface and the stable reason category are recorded there.
+                _logger.LogWarning(
+                    "Harness-change suggestion rejected: {Surface}.{Field} — {Reason}.",
+                    suggestion.Surface, suggestion.Field, validation.RejectionReason);
+                SafeAudit(request.SkillId, "skill_training.harness_change_rejected",
+                    $"deny: {suggestion.Surface} reason {validation.RejectionReason}", finalStep);
+            }
+        }
+
+        return accepted;
     }
 
     private ILrScheduler ResolveScheduler(string key) => key.ToLowerInvariant() switch

--- a/src/Content/Application/Application.AI.Common/Extensions/SkillTrainingDependencyInjection.cs
+++ b/src/Content/Application/Application.AI.Common/Extensions/SkillTrainingDependencyInjection.cs
@@ -21,6 +21,9 @@ namespace Application.AI.Common.Extensions;
 /// <item><see cref="IEditSelector"/> → <see cref="TopKEditSelector"/>.</item>
 /// <item><see cref="EditableSurfaceRegistry"/> — code-owned editable-surface fence allowlist.</item>
 /// <item><see cref="HarnessPatchValidator"/> — concrete fence (no interface seam, by design).</item>
+/// <item><see cref="ConfigSurfaceConstraint"/> — code-owned config-surface bounds (Phase 2 Step 2).</item>
+/// <item><see cref="HarnessChangeSuggestionValidator"/> — concrete config-surface fence (no interface seam).</item>
+/// <item><see cref="IHarnessChangeSuggester"/> → <see cref="NoHarnessChangeSuggester"/> (inert advisory default).</item>
 /// <item><see cref="ISkillTrainingCheckpointStore"/> → <see cref="InMemorySkillTrainingCheckpointStore"/>.</item>
 /// <item><see cref="IPatchProposer"/> → <see cref="NotConfiguredPatchProposer"/> (fail-fast default).</item>
 /// <item><see cref="IRolloutRunner"/> → <see cref="NotConfiguredRolloutRunner"/> (fail-fast default).</item>
@@ -72,6 +75,15 @@ public static class SkillTrainingDependencyInjection
         // locks every surface — including SkillDocument — and silently breaking the loop's own edits.
         services.TryAddSingleton(_ => new EditableSurfaceRegistry());
         services.TryAddSingleton<HarnessPatchValidator>();
+
+        // Phase 2 Step 2 — suggestion-only harness-change path. The constraint + validator are the
+        // code-owned config-surface fence (bounded fields, fixed ranges); the suggester is the optional
+        // producer seam. Its default returns nothing, so the path stays inert until a consumer plugs in
+        // a real suggester AND a run opts in via TrainSkillConfig.EmitHarnessChangeSuggestions.
+        services.TryAddSingleton<ConfigSurfaceConstraint>();
+        services.TryAddSingleton<HarnessChangeSuggestionValidator>();
+        services.TryAddSingleton<IHarnessChangeSuggester, NoHarnessChangeSuggester>();
+
         services.TryAddSingleton<ISkillTrainingCheckpointStore, InMemorySkillTrainingCheckpointStore>();
         services.TryAddSingleton<IPatchProposer, NotConfiguredPatchProposer>();
         services.TryAddSingleton<IRolloutRunner, NotConfiguredRolloutRunner>();

--- a/src/Content/Application/Application.AI.Common/Interfaces/SkillTraining/IHarnessChangeSuggester.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/SkillTraining/IHarnessChangeSuggester.cs
@@ -1,0 +1,43 @@
+using Domain.AI.SkillTraining;
+
+namespace Application.AI.Common.Interfaces.SkillTraining;
+
+/// <summary>
+/// The optional "harness-change advisor" role of the skill-training loop: reflects on a run's rollout
+/// signal and proposes bounded, never-applied <see cref="HarnessChangeSuggestion"/>s for non-prose
+/// harness settings (Self-Harness Phase 2 Step 2).
+/// </summary>
+/// <remarks>
+/// <para>
+/// This seam exists because some harness knobs are scalar configuration, not prose — the retry dial
+/// (<c>RetryConfig.MaxAttempts</c>) being the canonical case. A scalar change cannot flow through the
+/// rollout-scoring accept-gate, and Phase 2 deliberately refuses to auto-mutate live resilience config,
+/// so the loop's only sanctioned move is to <em>suggest</em>. The loop bounds-checks every returned
+/// suggestion against a code-owned <c>ConfigSurfaceConstraint</c>, audits it, and surfaces the survivors
+/// on the run result. Nothing a suggester returns ever mutates running configuration.
+/// </para>
+/// <para>
+/// Unlike <see cref="IPatchProposer"/> and <see cref="IRolloutRunner"/> — which are <em>required</em>
+/// for the loop to function and whose defaults throw — this seam is <em>optional and advisory</em>. Its
+/// default implementation (<c>NoHarnessChangeSuggester</c>) returns no suggestions, and the loop only
+/// calls it at all when a run opts in via <c>TrainSkillConfig.EmitHarnessChangeSuggestions</c>. A real
+/// implementation (typically agent-backed, reading current config from its own injected options) is a
+/// template consumer's concern.
+/// </para>
+/// </remarks>
+public interface IHarnessChangeSuggester
+{
+    /// <summary>
+    /// Reflects on the run's rollout signal and returns zero or more bounded harness-change suggestions.
+    /// </summary>
+    /// <param name="input">The run's rollout outcomes and provenance context.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>
+    /// Candidate suggestions — possibly empty. The loop validates each against the code-owned constraint
+    /// before auditing or surfacing it; an implementation need not pre-filter, though it should only
+    /// propose changes it believes are warranted.
+    /// </returns>
+    Task<IReadOnlyList<HarnessChangeSuggestion>> SuggestAsync(
+        HarnessSuggestionInput input,
+        CancellationToken cancellationToken);
+}

--- a/src/Content/Application/Application.AI.Common/Services/SkillTraining/ConfigSurfaceConstraint.cs
+++ b/src/Content/Application/Application.AI.Common/Services/SkillTraining/ConfigSurfaceConstraint.cs
@@ -1,0 +1,67 @@
+using Domain.AI.SkillTraining;
+
+namespace Application.AI.Common.Services.SkillTraining;
+
+/// <summary>
+/// The code-owned policy declaring which harness <em>configuration</em> fields a Phase 2 Step 2
+/// suggestion may target, and the bounds each must stay within — the config-surface analog of the
+/// <see cref="EditableSurfaceRegistry"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Where the registry governs which prose <em>surfaces</em> the loop may <em>edit</em>, this constraint
+/// governs which scalar config fields the loop may <em>suggest</em> changing — and within what range.
+/// Today it admits exactly one field: <see cref="HarnessSurface.ToolErrorRetryLimit"/> →
+/// <see cref="MaxAttemptsField"/>, bounded to <c>[<see cref="MinMaxAttempts"/>, <see cref="MaxMaxAttempts"/>]</c>.
+/// The retry config's other fields (base delay, backoff type) are <em>frozen</em> simply by not being
+/// admitted here.
+/// </para>
+/// <para>
+/// Like the registry, this is owned by code, not configuration: the bounds and allowed-field set are
+/// compile-time constants the loop cannot widen. There is intentionally no DI-time widening hook (unlike
+/// the registry's opt-in constructor) — a single, fixed, minimal allowlist is the whole point of a
+/// suggestion-only path, and broadening it is a deliberate code change a human reviews.
+/// </para>
+/// </remarks>
+public sealed class ConfigSurfaceConstraint
+{
+    /// <summary>The only config field admitted today: the transient-failure retry-attempt count.</summary>
+    public const string MaxAttemptsField = "MaxAttempts";
+
+    /// <summary>Inclusive lower bound for a suggested <see cref="MaxAttemptsField"/> value.</summary>
+    public const int MinMaxAttempts = 2;
+
+    /// <summary>Inclusive upper bound for a suggested <see cref="MaxAttemptsField"/> value.</summary>
+    public const int MaxMaxAttempts = 5;
+
+    // Ordinal (case-sensitive): field names are exact config property names. A casing variant is
+    // rejected as FieldNotAllowed — the safe direction for a governance boundary (reject, never widen).
+    private static readonly IReadOnlySet<string> AllowedFields =
+        new HashSet<string>(StringComparer.Ordinal) { MaxAttemptsField };
+
+    /// <summary>The single config surface this constraint governs.</summary>
+    public HarnessSurface GovernedSurface => HarnessSurface.ToolErrorRetryLimit;
+
+    /// <summary>Returns <see langword="true"/> iff this constraint governs <paramref name="surface"/>.</summary>
+    /// <param name="surface">The surface a suggestion targets.</param>
+    public bool GovernsSurface(HarnessSurface surface) => surface == GovernedSurface;
+
+    /// <summary>
+    /// Returns <see langword="true"/> iff <paramref name="field"/> is one this constraint admits (an
+    /// exact, case-sensitive match). Frozen fields return <see langword="false"/>.
+    /// </summary>
+    /// <param name="field">The config field name a suggestion targets.</param>
+    public bool IsFieldAllowed(string field) => field is not null && AllowedFields.Contains(field);
+
+    /// <summary>
+    /// Returns <see langword="true"/> iff <paramref name="value"/> is within the inclusive bounds for
+    /// <paramref name="field"/>. All currently-admitted fields are integer-valued.
+    /// </summary>
+    /// <param name="field">The admitted config field (must satisfy <see cref="IsFieldAllowed"/>).</param>
+    /// <param name="value">The proposed integer value.</param>
+    public bool IsWithinBounds(string field, int value) => field switch
+    {
+        MaxAttemptsField => value >= MinMaxAttempts && value <= MaxMaxAttempts,
+        _ => false
+    };
+}

--- a/src/Content/Application/Application.AI.Common/Services/SkillTraining/HarnessChangeSuggestionValidator.cs
+++ b/src/Content/Application/Application.AI.Common/Services/SkillTraining/HarnessChangeSuggestionValidator.cs
@@ -1,0 +1,69 @@
+using System.Globalization;
+using Domain.AI.SkillTraining;
+
+namespace Application.AI.Common.Services.SkillTraining;
+
+/// <summary>
+/// The config-surface fence: bounds-checks every <see cref="HarnessChangeSuggestion"/> against the
+/// code-owned <see cref="ConfigSurfaceConstraint"/> before the loop audits or surfaces it.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Like <c>HarnessPatchValidator</c>, this is intentionally a concrete sealed class with no interface
+/// seam: a validator a consumer could swap for a permissive no-op would not be a fence. The only
+/// configurable part of the policy is the <see cref="ConfigSurfaceConstraint"/> it reads — and that
+/// constraint's allowlist and bounds are compile-time constants.
+/// </para>
+/// <para>
+/// <see cref="Validate"/> is pure and side-effect free. Auditing a rejection or an acceptance, and
+/// surfacing survivors on the run result, are the caller's responsibility (the training loop), which
+/// keeps this component deterministically testable.
+/// </para>
+/// </remarks>
+public sealed class HarnessChangeSuggestionValidator
+{
+    private readonly ConfigSurfaceConstraint _constraint;
+
+    /// <summary>Initializes a new instance of the <see cref="HarnessChangeSuggestionValidator"/> class.</summary>
+    /// <param name="constraint">The code-owned config-surface constraint to enforce.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="constraint"/> is <see langword="null"/>.</exception>
+    public HarnessChangeSuggestionValidator(ConfigSurfaceConstraint constraint)
+    {
+        ArgumentNullException.ThrowIfNull(constraint);
+        _constraint = constraint;
+    }
+
+    /// <summary>
+    /// Validates that <paramref name="suggestion"/> targets the governed surface, names an allowed field,
+    /// and proposes an in-bounds value.
+    /// </summary>
+    /// <param name="suggestion">The suggestion to check.</param>
+    /// <returns>
+    /// <see cref="HarnessChangeSuggestionValidation.Allowed"/> when all checks pass; otherwise a
+    /// rejection carrying the first failing <see cref="HarnessChangeRejectionReason"/>.
+    /// </returns>
+    /// <exception cref="ArgumentNullException"><paramref name="suggestion"/> is <see langword="null"/>.</exception>
+    public HarnessChangeSuggestionValidation Validate(HarnessChangeSuggestion suggestion)
+    {
+        ArgumentNullException.ThrowIfNull(suggestion);
+
+        if (!_constraint.GovernsSurface(suggestion.Surface))
+        {
+            return HarnessChangeSuggestionValidation.Rejected(HarnessChangeRejectionReason.UngovernedSurface);
+        }
+
+        if (!_constraint.IsFieldAllowed(suggestion.Field))
+        {
+            return HarnessChangeSuggestionValidation.Rejected(HarnessChangeRejectionReason.FieldNotAllowed);
+        }
+
+        if (!int.TryParse(suggestion.ProposedValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out var value))
+        {
+            return HarnessChangeSuggestionValidation.Rejected(HarnessChangeRejectionReason.ValueUnparsable);
+        }
+
+        return _constraint.IsWithinBounds(suggestion.Field, value)
+            ? HarnessChangeSuggestionValidation.AllowedWith(value.ToString(CultureInfo.InvariantCulture))
+            : HarnessChangeSuggestionValidation.Rejected(HarnessChangeRejectionReason.ValueOutOfBounds);
+    }
+}

--- a/src/Content/Application/Application.AI.Common/Services/SkillTraining/HarnessChangeSuggestionValidator.cs
+++ b/src/Content/Application/Application.AI.Common/Services/SkillTraining/HarnessChangeSuggestionValidator.cs
@@ -39,8 +39,9 @@ public sealed class HarnessChangeSuggestionValidator
     /// </summary>
     /// <param name="suggestion">The suggestion to check.</param>
     /// <returns>
-    /// <see cref="HarnessChangeSuggestionValidation.Allowed"/> when all checks pass; otherwise a
-    /// rejection carrying the first failing <see cref="HarnessChangeRejectionReason"/>.
+    /// An allowed result (<see cref="HarnessChangeSuggestionValidation.AllowedWith(string)"/>) carrying
+    /// the scrubbed canonical value when all checks pass; otherwise a rejection carrying the first failing
+    /// <see cref="HarnessChangeRejectionReason"/>.
     /// </returns>
     /// <exception cref="ArgumentNullException"><paramref name="suggestion"/> is <see langword="null"/>.</exception>
     public HarnessChangeSuggestionValidation Validate(HarnessChangeSuggestion suggestion)

--- a/src/Content/Application/Application.AI.Common/Services/SkillTraining/NoHarnessChangeSuggester.cs
+++ b/src/Content/Application/Application.AI.Common/Services/SkillTraining/NoHarnessChangeSuggester.cs
@@ -1,0 +1,27 @@
+using Application.AI.Common.Interfaces.SkillTraining;
+using Domain.AI.SkillTraining;
+
+namespace Application.AI.Common.Services.SkillTraining;
+
+/// <summary>
+/// The inert default <see cref="IHarnessChangeSuggester"/>: proposes nothing. With this registered (the
+/// out-of-the-box state), the Phase 2 Step 2 suggestion path produces no suggestions even if a run opts
+/// in via <c>TrainSkillConfig.EmitHarnessChangeSuggestions</c> — the feature is off until a consumer
+/// plugs in a real suggester.
+/// </summary>
+/// <remarks>
+/// This default <em>returns empty</em> rather than throwing, unlike <c>NotConfiguredPatchProposer</c> /
+/// <c>NotConfiguredRolloutRunner</c>. Those seams are required for the loop to function at all, so a
+/// missing implementation is a misconfiguration worth failing loudly on. The suggester is optional and
+/// advisory: a run must complete normally whether or not a suggester is wired, so the safe default is
+/// silence, not an exception.
+/// </remarks>
+public sealed class NoHarnessChangeSuggester : IHarnessChangeSuggester
+{
+    private static readonly IReadOnlyList<HarnessChangeSuggestion> None = [];
+
+    /// <inheritdoc />
+    public Task<IReadOnlyList<HarnessChangeSuggestion>> SuggestAsync(
+        HarnessSuggestionInput input,
+        CancellationToken cancellationToken) => Task.FromResult(None);
+}

--- a/src/Content/Domain/Domain.AI/SkillTraining/HarnessChangeSuggestion.cs
+++ b/src/Content/Domain/Domain.AI/SkillTraining/HarnessChangeSuggestion.cs
@@ -1,0 +1,54 @@
+namespace Domain.AI.SkillTraining;
+
+/// <summary>
+/// An advisory, never-applied proposal to change one bounded harness configuration field — the
+/// suggestion-only path of Self-Harness Phase 2 Step 2.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Step 1 widened the loop to edit prose <em>surfaces</em> (skill text, recovery guidance) and prove
+/// each edit through the accept-gate. Some harness knobs, though, are not prose but plain settings —
+/// the canonical example is the transient-failure retry dial (<c>RetryConfig.MaxAttempts</c>). A scalar
+/// config change cannot flow through the rollout-scoring gate (there is no trajectory whose score moves
+/// because an <c>int</c> changed), and even if it could, mutating live resilience configuration from a
+/// self-optimization loop is exactly the kind of self-modification Phase 2 deliberately refuses to
+/// automate.
+/// </para>
+/// <para>
+/// So this type is a <em>note to a human</em>, not a hand on the dial. The loop may emit one; a
+/// code-owned <c>ConfigSurfaceConstraint</c> + <c>HarnessChangeSuggestionValidator</c> bounds-check it;
+/// valid suggestions are written to the tamper-evident governance audit and surfaced on the run result.
+/// Nothing here ever mutates running configuration. All values are carried as strings so the Domain
+/// stays decoupled from the concrete config POCOs (which live in <c>Domain.Common.Config</c>) — the
+/// suggestion is advisory text, not a typed assignment.
+/// </para>
+/// </remarks>
+public sealed record HarnessChangeSuggestion
+{
+    /// <summary>
+    /// The harness surface the suggestion concerns — e.g. <see cref="HarnessSurface.ToolErrorRetryLimit"/>
+    /// for the retry dial. The constraint rejects any surface it does not govern.
+    /// </summary>
+    public required HarnessSurface Surface { get; init; }
+
+    /// <summary>
+    /// The configuration field the suggestion targets (e.g. <c>"MaxAttempts"</c>). Must be one of the
+    /// constraint's allowed fields; frozen fields (delay, backoff type) are rejected.
+    /// </summary>
+    public required string Field { get; init; }
+
+    /// <summary>The field's current value, as observed by the loop. Advisory context only.</summary>
+    public required string CurrentValue { get; init; }
+
+    /// <summary>
+    /// The proposed new value. Bounds-checked by the constraint (e.g. an integer within
+    /// <c>[2, 5]</c> for <c>MaxAttempts</c>); out-of-range or non-parsable values are rejected.
+    /// </summary>
+    public required string ProposedValue { get; init; }
+
+    /// <summary>
+    /// Why the loop is proposing this change — the rollout signal that motivated it (e.g. "12 of 16
+    /// rollouts failed on transient tool errors"). Surfaced verbatim to the human reviewer.
+    /// </summary>
+    public string Rationale { get; init; } = string.Empty;
+}

--- a/src/Content/Domain/Domain.AI/SkillTraining/HarnessChangeSuggestionValidation.cs
+++ b/src/Content/Domain/Domain.AI/SkillTraining/HarnessChangeSuggestionValidation.cs
@@ -1,0 +1,67 @@
+namespace Domain.AI.SkillTraining;
+
+/// <summary>
+/// The result of checking a <see cref="HarnessChangeSuggestion"/> against the code-owned
+/// <c>ConfigSurfaceConstraint</c> before it is audited or surfaced on a run result.
+/// </summary>
+/// <remarks>
+/// A suggestion is allowed only when it targets the constrained surface, names an allowed field, and
+/// proposes a value within that field's bounds. Anything else is rejected with a stable, scrubbed
+/// <see cref="RejectionReason"/> so the audit trail distinguishes <em>why</em> a suggestion was refused
+/// without leaking proposer internals.
+/// </remarks>
+public sealed record HarnessChangeSuggestionValidation
+{
+    /// <summary>True iff the suggestion targets an allowed field with an in-bounds value.</summary>
+    public required bool IsAllowed { get; init; }
+
+    /// <summary>
+    /// The reason category when <see cref="IsAllowed"/> is false; <see cref="HarnessChangeRejectionReason.None"/>
+    /// when allowed.
+    /// </summary>
+    public HarnessChangeRejectionReason RejectionReason { get; init; } = HarnessChangeRejectionReason.None;
+
+    /// <summary>
+    /// The canonical, parsed form of the validated value when <see cref="IsAllowed"/> is
+    /// <see langword="true"/>; <see langword="null"/> when rejected. The loop audits <em>this</em> — not
+    /// the raw proposer-supplied <c>ProposedValue</c> — so the tamper-evident trail records a scrubbed
+    /// canonical value (e.g. <c>"3"</c>), never arbitrary proposer text such as <c>" +0003 "</c>.
+    /// </summary>
+    public string? NormalizedValue { get; init; }
+
+    /// <summary>A shared allowed result carrying no normalized value.</summary>
+    public static HarnessChangeSuggestionValidation Allowed { get; } = new() { IsAllowed = true };
+
+    /// <summary>Builds an allowed result carrying the scrubbed canonical <paramref name="normalizedValue"/>.</summary>
+    /// <param name="normalizedValue">The validated value in canonical form, safe to audit.</param>
+    public static HarnessChangeSuggestionValidation AllowedWith(string normalizedValue) =>
+        new() { IsAllowed = true, NormalizedValue = normalizedValue };
+
+    /// <summary>Builds a rejection result with the given <paramref name="reason"/>.</summary>
+    /// <param name="reason">Why the suggestion was rejected.</param>
+    public static HarnessChangeSuggestionValidation Rejected(HarnessChangeRejectionReason reason) =>
+        new() { IsAllowed = false, RejectionReason = reason };
+}
+
+/// <summary>
+/// Why a <see cref="HarnessChangeSuggestion"/> was rejected by the constraint. A closed set of stable
+/// categories — not free text — so the governance audit records the failure mode without echoing any
+/// proposer-supplied content.
+/// </summary>
+public enum HarnessChangeRejectionReason
+{
+    /// <summary>The suggestion was allowed (no rejection).</summary>
+    None,
+
+    /// <summary>The suggestion targets a surface the constraint does not govern.</summary>
+    UngovernedSurface,
+
+    /// <summary>The named field is not in the constraint's allowed-field set (it is frozen).</summary>
+    FieldNotAllowed,
+
+    /// <summary>The proposed value could not be parsed as the field's expected type.</summary>
+    ValueUnparsable,
+
+    /// <summary>The proposed value parsed but fell outside the field's allowed bounds.</summary>
+    ValueOutOfBounds
+}

--- a/src/Content/Domain/Domain.AI/SkillTraining/HarnessChangeSuggestionValidation.cs
+++ b/src/Content/Domain/Domain.AI/SkillTraining/HarnessChangeSuggestionValidation.cs
@@ -29,9 +29,6 @@ public sealed record HarnessChangeSuggestionValidation
     /// </summary>
     public string? NormalizedValue { get; init; }
 
-    /// <summary>A shared allowed result carrying no normalized value.</summary>
-    public static HarnessChangeSuggestionValidation Allowed { get; } = new() { IsAllowed = true };
-
     /// <summary>Builds an allowed result carrying the scrubbed canonical <paramref name="normalizedValue"/>.</summary>
     /// <param name="normalizedValue">The validated value in canonical form, safe to audit.</param>
     public static HarnessChangeSuggestionValidation AllowedWith(string normalizedValue) =>

--- a/src/Content/Domain/Domain.AI/SkillTraining/HarnessSuggestionInput.cs
+++ b/src/Content/Domain/Domain.AI/SkillTraining/HarnessSuggestionInput.cs
@@ -1,0 +1,24 @@
+namespace Domain.AI.SkillTraining;
+
+/// <summary>
+/// The signal a <c>IHarnessChangeSuggester</c> reflects on when deciding whether to propose a bounded
+/// harness configuration change at the end of a training run.
+/// </summary>
+/// <remarks>
+/// The loop hands the suggester the run's rollout outcomes — the evidence a config-dial suggestion is
+/// grounded in (e.g. a high proportion of rollouts that failed on transient tool errors motivates
+/// suggesting a higher retry count). The suggester reads any current configuration values it needs
+/// directly from its own injected options; the loop does not pass live config through, keeping this
+/// input free of any dependency on the concrete config POCOs.
+/// </remarks>
+public sealed record HarnessSuggestionInput
+{
+    /// <summary>Identifier of the skill whose run produced these rollouts. Provenance / audit context.</summary>
+    public required string SkillId { get; init; }
+
+    /// <summary>
+    /// The run's rollout outcomes — the failure/success signal a suggestion is reasoned from. The
+    /// orchestrator passes the last evaluated (val) rollouts; may be empty if the run produced none.
+    /// </summary>
+    public required IReadOnlyList<RolloutResult> Rollouts { get; init; }
+}

--- a/src/Content/Domain/Domain.AI/SkillTraining/SkillTrainingRunResult.cs
+++ b/src/Content/Domain/Domain.AI/SkillTraining/SkillTrainingRunResult.cs
@@ -33,6 +33,15 @@ public sealed record SkillTrainingRunResult
 
     /// <summary>Per-step audit trail in chronological order.</summary>
     public IReadOnlyList<SkillTrainingStepRecord> Steps { get; init; } = [];
+
+    /// <summary>
+    /// Bounded, never-applied harness-change suggestions surfaced by the run (Self-Harness Phase 2
+    /// Step 2). Empty unless the run opted in via <c>TrainSkillConfig.EmitHarnessChangeSuggestions</c>
+    /// and a registered <c>IHarnessChangeSuggester</c> proposed at least one suggestion that passed the
+    /// code-owned <c>ConfigSurfaceConstraint</c>. These are advisory notes for a human — the loop never
+    /// applies them.
+    /// </summary>
+    public IReadOnlyList<HarnessChangeSuggestion> HarnessChangeSuggestions { get; init; } = [];
 }
 
 /// <summary>

--- a/src/Content/Domain/Domain.AI/SkillTraining/TrainSkillConfig.cs
+++ b/src/Content/Domain/Domain.AI/SkillTraining/TrainSkillConfig.cs
@@ -76,4 +76,19 @@ public sealed record TrainSkillConfig
     /// what it can and cannot alter" guardrail of Self-Harness Phase 2.
     /// </remarks>
     public HarnessSurface TargetSurface { get; init; } = HarnessSurface.SkillDocument;
+
+    /// <summary>
+    /// Whether this run may emit bounded, never-applied harness-change suggestions (Self-Harness Phase 2
+    /// Step 2). Defaults to <see langword="false"/> — off. When true, the loop asks the registered
+    /// <c>IHarnessChangeSuggester</c> once, at end of run, for advisory config-dial suggestions (e.g.
+    /// raising <c>RetryConfig.MaxAttempts</c>); each is bounds-checked by the code-owned
+    /// <c>ConfigSurfaceConstraint</c>, audited, and surfaced on <c>SkillTrainingRunResult</c>.
+    /// </summary>
+    /// <remarks>
+    /// This is a suggestion-only path: nothing it produces ever mutates running configuration. It is
+    /// inert twice over by default — this flag is off, and the default <c>NoHarnessChangeSuggester</c>
+    /// returns nothing even when it is on. Turning it on without registering a real suggester therefore
+    /// changes nothing.
+    /// </remarks>
+    public bool EmitHarnessChangeSuggestions { get; init; }
 }

--- a/src/Content/Presentation/Presentation.ConsoleUI/Examples/SkillTrainingExample.cs
+++ b/src/Content/Presentation/Presentation.ConsoleUI/Examples/SkillTrainingExample.cs
@@ -88,13 +88,16 @@ public sealed class SkillTrainingExample
         var applier = new PatchApplier();
         var gate = new GateEvaluator();
         var fence = new HarnessPatchValidator(new EditableSurfaceRegistry());
+        var suggester = new NoHarnessChangeSuggester();
+        var suggestionValidator = new HarnessChangeSuggestionValidator(new ConfigSurfaceConstraint());
         var store = new InMemorySkillTrainingCheckpointStore();
         var runner = new DeterministicRolloutRunner();
         var proposer = new DeterministicProposer();
         ILogger<TrainSkillCommandHandler> logger = NullLogger<TrainSkillCommandHandler>.Instance;
 
         return new TrainSkillCommandHandler(
-            runner, proposer, aggregator, selector, applier, gate, fence, store,
+            runner, proposer, aggregator, selector, applier, gate, fence,
+            suggester, suggestionValidator, store,
             new NoOpMediator(), TimeProvider.System, logger);
     }
 

--- a/src/Content/Tests/Application.AI.Common.Tests/CQRS/SkillTraining/TrainSkillCommandHandlerTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/CQRS/SkillTraining/TrainSkillCommandHandlerTests.cs
@@ -620,6 +620,24 @@ public class TrainSkillCommandHandlerTests
     }
 
     [Fact]
+    public async Task Handle_SuggestionsEnabled_NonCanonicalAcceptedValue_SurfacedAndAuditedCanonically()
+    {
+        // A lenient-but-in-bounds raw value (' +03 ') is accepted; both the surfaced run-result suggestion
+        // and the audit must carry the scrubbed canonical form ('3'), never the raw proposer string.
+        var suggester = new StubSuggester(_ => [RetrySuggestion(" +03 ")]);
+        var audit = new CapturingAudit();
+        var sut = NewSut(AcceptingRunner(), AppendProposer(), new InMemorySkillTrainingCheckpointStore(),
+            audit, suggester: suggester);
+
+        var result = await sut.Handle(NewCommand(SuggestConfig(emit: true)), CancellationToken.None);
+
+        result.Value!.HarnessChangeSuggestions.Should().ContainSingle()
+            .Which.ProposedValue.Should().Be("3", because: "the surfaced value is normalized, not the raw proposer string");
+        audit.Entries.Should().ContainSingle(e => e.Action == "skill_training.harness_change_suggested")
+            .Subject.Decision.Should().Contain("MaxAttempts=3").And.NotContain("+03");
+    }
+
+    [Fact]
     public async Task Handle_SuggestionsEnabled_OutOfBoundsSuggestion_RejectedNotSurfaced_AndAuditedWithoutRawValue()
     {
         // 99 exceeds ConfigSurfaceConstraint.MaxMaxAttempts. The suggestion must be dropped (not

--- a/src/Content/Tests/Application.AI.Common.Tests/CQRS/SkillTraining/TrainSkillCommandHandlerTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/CQRS/SkillTraining/TrainSkillCommandHandlerTests.cs
@@ -17,16 +17,19 @@ public class TrainSkillCommandHandlerTests
     private static readonly TopKEditSelector Selector = new();
     private static readonly GateEvaluator Gate = new();
     private static readonly HarnessPatchValidator Fence = new(new EditableSurfaceRegistry());
+    private static readonly HarnessChangeSuggestionValidator SuggestionValidator = new(new ConfigSurfaceConstraint());
 
     private static TrainSkillCommandHandler NewSut(
         IRolloutRunner runner,
         IPatchProposer proposer,
         InMemorySkillTrainingCheckpointStore store,
         IGovernanceAuditService? audit = null,
-        HarnessPatchValidator? fence = null)
+        HarnessPatchValidator? fence = null,
+        IHarnessChangeSuggester? suggester = null)
     {
         return new TrainSkillCommandHandler(
             runner, proposer, Aggregator, Selector, Applier, Gate, fence ?? Fence,
+            suggester ?? new NoHarnessChangeSuggester(), SuggestionValidator,
             store, new NoOpMediator(), TimeProvider.System,
             NullLogger<TrainSkillCommandHandler>.Instance, audit);
     }
@@ -537,6 +540,148 @@ public class TrainSkillCommandHandlerTests
             .Subject.Decision.Should().Contain("SkillDocument");
     }
 
+    // ── Harness-change suggestions (Phase 2 Step 2) ───────────────────────────────
+
+    private static StubRolloutRunner AcceptingRunner() => new((_, batch) => batch.Split == "val"
+        ? [new RolloutResult { ItemId = "v", Hard = 1.0, Soft = 1.0 }]
+        : [new RolloutResult { ItemId = "t", Hard = 0.5, Soft = 0.5 }]);
+
+    private static StubProposer AppendProposer() => new(_ => new Patch
+    {
+        Edits = [new Edit { Op = EditOp.Append, Content = "- new rule" }]
+    });
+
+    private static TrainSkillConfig SuggestConfig(bool emit) => new()
+    {
+        Epochs = 1, StepsPerEpoch = 1, LrStart = 4, LrMin = 1,
+        LrScheduler = "constant", Patience = 6,
+        UseSlowUpdate = false, UseMetaSkill = false,
+        EmitHarnessChangeSuggestions = emit
+    };
+
+    private static HarnessChangeSuggestion RetrySuggestion(string proposedValue) => new()
+    {
+        Surface = HarnessSurface.ToolErrorRetryLimit,
+        Field = ConfigSurfaceConstraint.MaxAttemptsField,
+        CurrentValue = "2",
+        ProposedValue = proposedValue,
+        Rationale = "many transient tool failures"
+    };
+
+    [Fact]
+    public async Task Handle_SuggestionsDisabledByDefault_NeverCallsSuggester_AndSurfacesNone()
+    {
+        // The default config leaves EmitHarnessChangeSuggestions false. The suggester must never be
+        // invoked (it throws if it is) and the result carries no suggestions.
+        var suggester = new StubSuggester(_ => throw new InvalidOperationException("must not be called when disabled"));
+        var sut = NewSut(AcceptingRunner(), AppendProposer(), new InMemorySkillTrainingCheckpointStore(),
+            suggester: suggester);
+
+        var result = await sut.Handle(NewCommand(SuggestConfig(emit: false)), CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.HarnessChangeSuggestions.Should().BeEmpty();
+        suggester.Calls.Should().Be(0, because: "the path is gated off by default");
+    }
+
+    [Fact]
+    public async Task Handle_SuggestionsEnabled_DefaultNoOpSuggester_SurfacesNothing()
+    {
+        // Enabled, but the registered suggester is the inert default — the path is still silent.
+        var sut = NewSut(AcceptingRunner(), AppendProposer(), new InMemorySkillTrainingCheckpointStore());
+
+        var result = await sut.Handle(NewCommand(SuggestConfig(emit: true)), CancellationToken.None);
+
+        result.Value!.HarnessChangeSuggestions.Should().BeEmpty(
+            because: "the default NoHarnessChangeSuggester proposes nothing even when the run opts in");
+    }
+
+    [Fact]
+    public async Task Handle_SuggestionsEnabled_ValidSuggestion_SurfacedAndAudited_FromRunRollouts()
+    {
+        var suggester = new StubSuggester(_ => [RetrySuggestion("3")]);
+        var audit = new CapturingAudit();
+        var sut = NewSut(AcceptingRunner(), AppendProposer(), new InMemorySkillTrainingCheckpointStore(),
+            audit, suggester: suggester);
+
+        var result = await sut.Handle(NewCommand(SuggestConfig(emit: true)), CancellationToken.None);
+
+        var run = result.Value!;
+        run.HarnessChangeSuggestions.Should().ContainSingle();
+        run.HarnessChangeSuggestions[0].Field.Should().Be(ConfigSurfaceConstraint.MaxAttemptsField);
+        run.HarnessChangeSuggestions[0].ProposedValue.Should().Be("3");
+
+        // The suggester reflects on the run's val rollouts.
+        suggester.LastInput!.SkillId.Should().Be("skill-X");
+        suggester.LastInput.Rollouts.Should().ContainSingle(r => r.ItemId == "v");
+
+        audit.Entries.Should().ContainSingle(e => e.Action == "skill_training.harness_change_suggested")
+            .Subject.Decision.Should().Contain("ToolErrorRetryLimit.MaxAttempts=3");
+    }
+
+    [Fact]
+    public async Task Handle_SuggestionsEnabled_OutOfBoundsSuggestion_RejectedNotSurfaced_AndAuditedWithoutRawValue()
+    {
+        // 99 exceeds ConfigSurfaceConstraint.MaxMaxAttempts. The suggestion must be dropped (not
+        // surfaced) and audited with the stable reason category only — never the raw proposer value.
+        var suggester = new StubSuggester(_ => [RetrySuggestion("99")]);
+        var audit = new CapturingAudit();
+        var sut = NewSut(AcceptingRunner(), AppendProposer(), new InMemorySkillTrainingCheckpointStore(),
+            audit, suggester: suggester);
+
+        var result = await sut.Handle(NewCommand(SuggestConfig(emit: true)), CancellationToken.None);
+
+        result.Value!.HarnessChangeSuggestions.Should().BeEmpty();
+        var rejected = audit.Entries.Should()
+            .ContainSingle(e => e.Action == "skill_training.harness_change_rejected").Subject;
+        rejected.Decision.Should().Contain(nameof(HarnessChangeRejectionReason.ValueOutOfBounds));
+        rejected.Decision.Should().NotContain("99", because: "the audit records the reason, not the rejected value");
+    }
+
+    [Fact]
+    public async Task Handle_SuggestionsEnabled_FrozenField_Rejected_AndNotSurfaced()
+    {
+        // A suggestion targeting a frozen field (BaseDelaySeconds) is refused by the constraint.
+        var suggester = new StubSuggester(_ =>
+        [
+            new HarnessChangeSuggestion
+            {
+                Surface = HarnessSurface.ToolErrorRetryLimit,
+                Field = "BaseDelaySeconds",
+                CurrentValue = "1.0",
+                ProposedValue = "3",
+                Rationale = "slow down"
+            }
+        ]);
+        var audit = new CapturingAudit();
+        var sut = NewSut(AcceptingRunner(), AppendProposer(), new InMemorySkillTrainingCheckpointStore(),
+            audit, suggester: suggester);
+
+        var result = await sut.Handle(NewCommand(SuggestConfig(emit: true)), CancellationToken.None);
+
+        result.Value!.HarnessChangeSuggestions.Should().BeEmpty();
+        var rejected = audit.Entries.Should()
+            .ContainSingle(e => e.Action == "skill_training.harness_change_rejected").Subject;
+        rejected.Decision.Should().Contain(nameof(HarnessChangeRejectionReason.FieldNotAllowed));
+        rejected.Decision.Should().NotContain("BaseDelaySeconds",
+            because: "the raw proposer-supplied field must never enter the tamper-evident audit chain");
+    }
+
+    [Fact]
+    public async Task Handle_SuggestionsEnabled_SuggesterThrows_RunStillSucceeds_NoSuggestions()
+    {
+        // The suggestion path is advisory: a faulty suggester must never fail an already-completed run.
+        var suggester = new StubSuggester(_ => throw new InvalidOperationException("suggester boom"));
+        var sut = NewSut(AcceptingRunner(), AppendProposer(), new InMemorySkillTrainingCheckpointStore(),
+            suggester: suggester);
+
+        var result = await sut.Handle(NewCommand(SuggestConfig(emit: true)), CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue(because: "the suggestion path must never fail a completed run");
+        result.Value!.HarnessChangeSuggestions.Should().BeEmpty();
+        result.Value.Steps.Should().ContainSingle(because: "the optimization loop ran to completion regardless");
+    }
+
     // ── Stubs ────────────────────────────────────────────────────────────────────
 
     private sealed class StubRolloutRunner : IRolloutRunner
@@ -553,6 +698,20 @@ public class TrainSkillCommandHandlerTests
         public StubProposer(Func<ReflectionInput, Patch> fn) => _fn = fn;
         public Task<Patch> ProposeAsync(ReflectionInput input, CancellationToken cancellationToken)
             => Task.FromResult(_fn(input));
+    }
+
+    private sealed class StubSuggester : IHarnessChangeSuggester
+    {
+        private readonly Func<HarnessSuggestionInput, IReadOnlyList<HarnessChangeSuggestion>> _fn;
+        public int Calls { get; private set; }
+        public HarnessSuggestionInput? LastInput { get; private set; }
+        public StubSuggester(Func<HarnessSuggestionInput, IReadOnlyList<HarnessChangeSuggestion>> fn) => _fn = fn;
+        public Task<IReadOnlyList<HarnessChangeSuggestion>> SuggestAsync(HarnessSuggestionInput input, CancellationToken cancellationToken)
+        {
+            Calls++;
+            LastInput = input;
+            return Task.FromResult(_fn(input));
+        }
     }
 
     private sealed class CapturingAudit : IGovernanceAuditService

--- a/src/Content/Tests/Application.AI.Common.Tests/Extensions/SkillTrainingDependencyInjectionTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Extensions/SkillTrainingDependencyInjectionTests.cs
@@ -1,4 +1,5 @@
 using Application.AI.Common.Extensions;
+using Application.AI.Common.Interfaces.SkillTraining;
 using Application.AI.Common.Services.SkillTraining;
 using Domain.AI.SkillTraining;
 using FluentAssertions;
@@ -50,5 +51,17 @@ public class SkillTrainingDependencyInjectionTests
 
         act.Should().Throw<ArgumentException>(
             because: "governance surfaces can never be unlocked, even by an explicit human opt-in");
+    }
+
+    [Fact]
+    public void Default_RegistersInertSuggestionPath()
+    {
+        // Phase 2 Step 2: the config-surface fence and an inert suggester are always wired, so the
+        // suggestion path resolves out of the box but produces nothing until a real suggester is added.
+        var provider = new ServiceCollection().AddSkillTrainingDependencies().BuildServiceProvider();
+
+        provider.GetRequiredService<ConfigSurfaceConstraint>().Should().NotBeNull();
+        provider.GetRequiredService<HarnessChangeSuggestionValidator>().Should().NotBeNull();
+        provider.GetRequiredService<IHarnessChangeSuggester>().Should().BeOfType<NoHarnessChangeSuggester>();
     }
 }

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/SkillTraining/ConfigSurfaceConstraintTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/SkillTraining/ConfigSurfaceConstraintTests.cs
@@ -1,0 +1,68 @@
+using Application.AI.Common.Services.SkillTraining;
+using Domain.AI.SkillTraining;
+using FluentAssertions;
+using Xunit;
+
+namespace Application.AI.Common.Tests.Services.SkillTraining;
+
+public class ConfigSurfaceConstraintTests
+{
+    private readonly ConfigSurfaceConstraint _sut = new();
+
+    [Fact]
+    public void GovernsSurface_ToolErrorRetryLimit_True()
+    {
+        _sut.GovernedSurface.Should().Be(HarnessSurface.ToolErrorRetryLimit);
+        _sut.GovernsSurface(HarnessSurface.ToolErrorRetryLimit).Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData(HarnessSurface.SkillDocument)]
+    [InlineData(HarnessSurface.FailureRecovery)]
+    [InlineData(HarnessSurface.AutonomyTier)]
+    [InlineData(HarnessSurface.DeniedTools)]
+    public void GovernsSurface_OtherSurfaces_False(HarnessSurface surface)
+        => _sut.GovernsSurface(surface).Should().BeFalse();
+
+    [Fact]
+    public void IsFieldAllowed_MaxAttempts_True()
+        => _sut.IsFieldAllowed(ConfigSurfaceConstraint.MaxAttemptsField).Should().BeTrue();
+
+    [Theory]
+    [InlineData("BaseDelaySeconds")]
+    [InlineData("BackoffType")]
+    [InlineData("maxattempts")]   // exact, case-sensitive — a casing variant is not admitted
+    [InlineData("")]
+    public void IsFieldAllowed_FrozenOrUnknownFields_False(string field)
+        => _sut.IsFieldAllowed(field).Should().BeFalse();
+
+    [Fact]
+    public void IsFieldAllowed_Null_FalseNotThrows()
+        => _sut.IsFieldAllowed(null!).Should().BeFalse();
+
+    [Theory]
+    [InlineData(ConfigSurfaceConstraint.MinMaxAttempts)]
+    [InlineData(3)]
+    [InlineData(ConfigSurfaceConstraint.MaxMaxAttempts)]
+    public void IsWithinBounds_MaxAttemptsInRange_True(int value)
+        => _sut.IsWithinBounds(ConfigSurfaceConstraint.MaxAttemptsField, value).Should().BeTrue();
+
+    [Theory]
+    [InlineData(ConfigSurfaceConstraint.MinMaxAttempts - 1)]
+    [InlineData(ConfigSurfaceConstraint.MaxMaxAttempts + 1)]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void IsWithinBounds_MaxAttemptsOutOfRange_False(int value)
+        => _sut.IsWithinBounds(ConfigSurfaceConstraint.MaxAttemptsField, value).Should().BeFalse();
+
+    [Fact]
+    public void IsWithinBounds_UnknownField_FalseRegardlessOfValue()
+        => _sut.IsWithinBounds("BaseDelaySeconds", 3).Should().BeFalse();
+
+    [Fact]
+    public void Bounds_AreSaneAndOrdered()
+    {
+        ConfigSurfaceConstraint.MinMaxAttempts.Should().BeLessThan(ConfigSurfaceConstraint.MaxMaxAttempts);
+        ConfigSurfaceConstraint.MinMaxAttempts.Should().BeGreaterThanOrEqualTo(1);
+    }
+}

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/SkillTraining/HarnessChangeSuggestionValidatorTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/SkillTraining/HarnessChangeSuggestionValidatorTests.cs
@@ -1,0 +1,122 @@
+using Application.AI.Common.Services.SkillTraining;
+using Domain.AI.SkillTraining;
+using FluentAssertions;
+using Xunit;
+
+namespace Application.AI.Common.Tests.Services.SkillTraining;
+
+public class HarnessChangeSuggestionValidatorTests
+{
+    private readonly HarnessChangeSuggestionValidator _sut = new(new ConfigSurfaceConstraint());
+
+    private static HarnessChangeSuggestion Suggestion(
+        HarnessSurface surface = HarnessSurface.ToolErrorRetryLimit,
+        string field = ConfigSurfaceConstraint.MaxAttemptsField,
+        string proposedValue = "3") => new()
+    {
+        Surface = surface,
+        Field = field,
+        CurrentValue = "2",
+        ProposedValue = proposedValue,
+        Rationale = "transient failures"
+    };
+
+    [Fact]
+    public void Ctor_NullConstraint_Throws()
+    {
+        var act = () => new HarnessChangeSuggestionValidator(null!);
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void Validate_NullSuggestion_Throws()
+    {
+        var act = () => _sut.Validate(null!);
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void Validate_AllowedFieldInBounds_Allowed()
+    {
+        var result = _sut.Validate(Suggestion(proposedValue: "4"));
+
+        result.IsAllowed.Should().BeTrue();
+        result.RejectionReason.Should().Be(HarnessChangeRejectionReason.None);
+        result.NormalizedValue.Should().Be("4");
+    }
+
+    [Theory]
+    [InlineData(" 3 ", "3")]
+    [InlineData("+3", "3")]
+    [InlineData("0003", "3")]
+    public void Validate_NonCanonicalButInBounds_AllowedWithScrubbedCanonicalValue(string raw, string canonical)
+    {
+        // Lenient parsing accepts surrounding whitespace / leading sign / leading zeros, but the
+        // validated result carries the canonical form so the audit never records the raw proposer string.
+        var result = _sut.Validate(Suggestion(proposedValue: raw));
+
+        result.IsAllowed.Should().BeTrue();
+        result.NormalizedValue.Should().Be(canonical);
+    }
+
+    [Fact]
+    public void Validate_Rejected_NormalizedValueIsNull()
+    {
+        _sut.Validate(Suggestion(proposedValue: "99")).NormalizedValue.Should().BeNull();
+    }
+
+    [Fact]
+    public void Validate_UngovernedSurface_RejectedWithReason()
+    {
+        var result = _sut.Validate(Suggestion(surface: HarnessSurface.SkillDocument));
+
+        result.IsAllowed.Should().BeFalse();
+        result.RejectionReason.Should().Be(HarnessChangeRejectionReason.UngovernedSurface);
+    }
+
+    [Theory]
+    [InlineData("BaseDelaySeconds")]
+    [InlineData("BackoffType")]
+    [InlineData("MaxAttempts ")]   // trailing space — not an exact match
+    public void Validate_FrozenOrMistypedField_RejectedFieldNotAllowed(string field)
+    {
+        var result = _sut.Validate(Suggestion(field: field));
+
+        result.IsAllowed.Should().BeFalse();
+        result.RejectionReason.Should().Be(HarnessChangeRejectionReason.FieldNotAllowed);
+    }
+
+    [Theory]
+    [InlineData("not-a-number")]
+    [InlineData("")]
+    [InlineData("3.5")]   // not an integer
+    public void Validate_UnparsableValue_RejectedValueUnparsable(string value)
+    {
+        var result = _sut.Validate(Suggestion(proposedValue: value));
+
+        result.IsAllowed.Should().BeFalse();
+        result.RejectionReason.Should().Be(HarnessChangeRejectionReason.ValueUnparsable);
+    }
+
+    [Theory]
+    [InlineData("1")]
+    [InlineData("6")]
+    [InlineData("100")]
+    [InlineData("-3")]
+    public void Validate_OutOfBoundsValue_RejectedValueOutOfBounds(string value)
+    {
+        var result = _sut.Validate(Suggestion(proposedValue: value));
+
+        result.IsAllowed.Should().BeFalse();
+        result.RejectionReason.Should().Be(HarnessChangeRejectionReason.ValueOutOfBounds);
+    }
+
+    [Fact]
+    public void Validate_ChecksSurfaceBeforeField()
+    {
+        // Wrong surface AND wrong field — surface is checked first, so the reason is UngovernedSurface.
+        var result = _sut.Validate(Suggestion(surface: HarnessSurface.SkillDocument, field: "BaseDelaySeconds"));
+
+        result.RejectionReason.Should().Be(HarnessChangeRejectionReason.UngovernedSurface);
+    }
+}


### PR DESCRIPTION
## What & why

Self-Harness Phase 2 **Step 2** (Step 1 = PR #81, merged). Step 1 widened the optimizer to edit prose *surfaces*. Some harness knobs, though, are scalar config — the canonical one being the transient-failure retry dial (`RetryConfig.MaxAttempts`). A scalar change can't flow through the rollout-scoring accept-gate, and Phase 2 deliberately refuses to auto-mutate live config. So the loop's only sanctioned move is to **suggest** — a note to a human, never a hand on the dial.

Per Matt's call (2026-06-23): **suggestion-by-design**, no config-apply engine (dropped as YAGNI). This builds only a bounded *suggestion-emission* path.

## Design

- **`HarnessChangeSuggestion` / `HarnessSuggestionInput` / `HarnessChangeSuggestionValidation`** (Domain.AI) — advisory, string-valued, decoupled from the concrete config POCOs (`Domain.Common.Config`).
- **`ConfigSurfaceConstraint`** — code-owned bounds (`MaxAttempts` only, `[2,5]`; delay/backoff frozen by omission). The config-surface analog of `EditableSurfaceRegistry`; no DI-widening hook (a fixed minimal allowlist is the point).
- **`HarnessChangeSuggestionValidator`** — concrete sealed fence, no interface seam (same reasoning as `HarnessPatchValidator` — a swappable fence is no fence).
- **`IHarnessChangeSuggester` + `NoHarnessChangeSuggester`** — optional producer seam. Default returns **nothing** (advisory ⇒ returns empty rather than throwing like the required `NotConfigured*` seams).
- **`TrainSkillConfig.EmitHarnessChangeSuggestions`** (default `false`) gates the path. The handler emits once at end-of-run, bounds-checks each suggestion, audits both outcomes (`skill_training.harness_change_suggested` / `_rejected`), and surfaces survivors on `SkillTrainingRunResult.HarnessChangeSuggestions`.

**Never mutates live config. Inert twice over by default** (flag off + no-op suggester). A thrown suggester is isolated — the advisory path can never fail a completed run.

## Governance / audit
The tamper-evident audit records only scrubbed content: the `HarnessSurface` enum, the stable rejection-reason category, the allow-listed field constant, and the validator's canonical `NormalizedValue` — never the raw proposer-supplied field name or value. (Two such leaks were caught in self-review and fixed with regression guards.)

## Review
- `/code-review` (high): 2 findings (raw proposer content entering the audit chain) — fixed + regression-tested. DI/cross-file tracer clean.
- `/simplify`: clean across all four angles.

## Tests
+42 tests (constraint, validator incl. canonicalization, handler: flag-off/on, valid/invalid/frozen-field/out-of-bounds, thrown-suggester isolation, DI defaults). **Application.AI.Common 1205 green, Domain.AI 791 green, 0 errors, 0 new warnings.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)