### PR TITLE
fix(observability): stamp short 'model' label on agent token/cost metrics

### DIFF
--- a/src/Content/Application/Application.AI.Common/Middleware/CacheStatsEnrichingChatClient.cs
+++ b/src/Content/Application/Application.AI.Common/Middleware/CacheStatsEnrichingChatClient.cs
@@ -153,9 +153,12 @@ public sealed class CacheStatsEnrichingChatClient : DelegatingChatClient
     private void EmitMetrics(GenerationStats? stats, string? fallbackModel, TokenCounts tokens)
     {
         var model = stats?.Model ?? fallbackModel;
+        // Stamp the harness-short `model` label (not the dotted semconv key) so the dashboards'
+        // `sum by (model)` cost/cache breakdowns resolve — must match LlmTokenTrackingProcessor,
+        // which emits the same instruments. See TokenConventions.Model.
         var tags = new TagList
         {
-            { TokenConventions.GenAiRequestModel, model ?? "unknown" },
+            { TokenConventions.Model, model ?? "unknown" },
             { AgentConventions.Name, _agentName }
         };
 
@@ -174,7 +177,7 @@ public sealed class CacheStatsEnrichingChatClient : DelegatingChatClient
             {
                 var hitRate = (double)stats.CacheReadTokens / stats.PromptTokens;
                 LlmUsageMetrics.CacheHitRate.Record(
-                    hitRate, new TagList { { TokenConventions.GenAiRequestModel, model ?? "unknown" } });
+                    hitRate, new TagList { { TokenConventions.Model, model ?? "unknown" } });
             }
         }
 

--- a/src/Content/Domain/Domain.AI/Telemetry/Conventions/TokenConventions.cs
+++ b/src/Content/Domain/Domain.AI/Telemetry/Conventions/TokenConventions.cs
@@ -42,4 +42,18 @@ public static class TokenConventions
     public const string GenAiCacheWriteTokens = "gen_ai.usage.cache_creation_input_tokens";
     /// <summary>Gen AI semantic convention: requested model identifier.</summary>
     public const string GenAiRequestModel = "gen_ai.request.model";
+
+    /// <summary>
+    /// Harness-owned short model label stamped on the harness's own token and cost metrics
+    /// (<c>agent.tokens.*</c>). The dashboards break down spend and volume with
+    /// <c>sum by (model)</c>, so the emitted metric label must be the bare <c>model</c>.
+    /// </summary>
+    /// <remarks>
+    /// The model value itself is read from the span's <see cref="GenAiRequestModel"/> attribute,
+    /// but that dotted semantic-convention key normalizes to the Prometheus label
+    /// <c>gen_ai_request_model</c> — which no dashboard query references. This mirrors how the
+    /// harness labels agents with the short <c>agent.name</c> (→ <c>agent_name</c>) rather than a
+    /// dotted semconv key, keeping the metric label aligned with the dashboard and demo data.
+    /// </remarks>
+    public const string Model = "model";
 }

--- a/src/Content/Infrastructure/Infrastructure.Observability/Processors/LlmTokenTrackingProcessor.cs
+++ b/src/Content/Infrastructure/Infrastructure.Observability/Processors/LlmTokenTrackingProcessor.cs
@@ -79,9 +79,11 @@ public sealed class LlmTokenTrackingProcessor : BaseProcessor<Activity>
             ?? data.GetBaggageItem(AgentConventions.Name)
             ?? "unknown";
 
+        // Stamp the harness-short `model` label (not the dotted semconv key) so the
+        // dashboards' `sum by (model)` breakdowns resolve — see TokenConventions.Model.
         var tags = new TagList
         {
-            { TokenConventions.GenAiRequestModel, model },
+            { TokenConventions.Model, model },
             { AgentConventions.Name, agentName }
         };
 
@@ -131,7 +133,7 @@ public sealed class LlmTokenTrackingProcessor : BaseProcessor<Activity>
         if (hasCacheAttributes && totalInput > 0)
         {
             var hitRate = (double)cacheReadTokens / totalInput;
-            LlmUsageMetrics.CacheHitRate.Record(hitRate, new TagList { { TokenConventions.GenAiRequestModel, model } });
+            LlmUsageMetrics.CacheHitRate.Record(hitRate, new TagList { { TokenConventions.Model, model } });
         }
 
         // Per-turn metrics

--- a/src/Content/Tests/Application.AI.Common.Tests/Middleware/CacheStatsEnrichingChatClientTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Middleware/CacheStatsEnrichingChatClientTests.cs
@@ -49,6 +49,34 @@ public sealed class CacheStatsEnrichingChatClientTests
     }
 
     [Fact]
+    public async Task GetResponseAsync_TagsCacheMetricsWithShortModelLabel()
+    {
+        // The dashboards group cache/cost by the short `model` label (sum by (model)). Emitting the
+        // dotted gen_ai.request.model key here would leave these metrics — including cost_actual,
+        // the preferred cost source — invisible to those tiles, and disagree with
+        // LlmTokenTrackingProcessor, which emits the same instruments. See TokenConventions.Model.
+        var agent = $"agent-{Guid.NewGuid():N}";
+        var stats = new GenerationStats(Model, CacheReadTokens: 100, PromptTokens: 200,
+            TotalCost: 0.01m, CacheDiscount: 0.02m);
+        var statsClient = new FakeStatsClient(stats);
+        var inner = new TestChatClient(new ChatResponse(new ChatMessage(ChatRole.Assistant, "hi"))
+        {
+            ResponseId = "gen-model",
+            ModelId = Model
+        });
+        var sut = Create(inner, statsClient, agent);
+
+        var models = CaptureModelTag(TokenConventions.CacheRead, agent);
+
+        await sut.GetResponseAsync([new ChatMessage(ChatRole.User, "hello")]);
+        await sut.EnrichmentCompletion;
+
+        models.Should().ContainSingle(
+            "the cache metric must carry the short `model` label, not the dotted gen_ai.request.model key")
+            .Which.Should().Be(Model);
+    }
+
+    [Fact]
     public async Task GetResponseAsync_NoResponseId_DoesNotCallStatsClient()
     {
         var statsClient = new FakeStatsClient(null);
@@ -215,6 +243,30 @@ public sealed class CacheStatsEnrichingChatClientTests
         });
         listener.Start();
         return values;
+    }
+
+    /// <summary>Captures the value of the short <c>model</c> tag on long-counter measurements for an agent.</summary>
+    private static List<string> CaptureModelTag(string instrumentName, string agent)
+    {
+        var models = new List<string>();
+        var listener = new MeterListener
+        {
+            InstrumentPublished = (instrument, l) =>
+            {
+                if (instrument.Name == instrumentName)
+                    l.EnableMeasurementEvents(instrument);
+            }
+        };
+        listener.SetMeasurementEventCallback<long>((_, _, tags, _) =>
+        {
+            if (!HasAgentTag(tags, agent))
+                return;
+            foreach (var tag in tags)
+                if (tag.Key == TokenConventions.Model && tag.Value is string model)
+                    models.Add(model);
+        });
+        listener.Start();
+        return models;
     }
 
     private static bool HasAgentTag(ReadOnlySpan<KeyValuePair<string, object?>> tags, string agent)

--- a/src/Content/Tests/Domain.AI.Tests/Telemetry/TokenAndToolConventionsTests.cs
+++ b/src/Content/Tests/Domain.AI.Tests/Telemetry/TokenAndToolConventionsTests.cs
@@ -21,6 +21,7 @@ public sealed class TokenAndToolConventionsTests
     [InlineData(TokenConventions.CostEstimated, "agent.tokens.cost_estimated")]
     [InlineData(TokenConventions.CostActual, "agent.tokens.cost_actual")]
     [InlineData(TokenConventions.CacheHitRate, "agent.tokens.cache_hit_rate")]
+    [InlineData(TokenConventions.Model, "model")]
     public void TokenConventions_HaveExpectedValues(string actual, string expected)
     {
         actual.Should().Be(expected);

--- a/src/Content/Tests/Infrastructure.Observability.Tests/Processors/LlmTokenTrackingProcessorTests.cs
+++ b/src/Content/Tests/Infrastructure.Observability.Tests/Processors/LlmTokenTrackingProcessorTests.cs
@@ -166,7 +166,7 @@ public sealed class LlmTokenTrackingProcessorTests : IDisposable
         listener.SetMeasurementEventCallback<double>((_, value, tags, _) =>
         {
             foreach (var tag in tags)
-                if (tag.Key == TokenConventions.GenAiRequestModel && tag.Value as string == "with-cache-attrs-model")
+                if (tag.Key == TokenConventions.Model && tag.Value as string == "with-cache-attrs-model")
                     hitRates.Add(value);
         });
         listener.Start();
@@ -271,5 +271,64 @@ public sealed class LlmTokenTrackingProcessorTests : IDisposable
             "a non-null unpriced model must still emit cost via the default-model pricing fallback");
         costs.Sum().Should().BeApproximately(3.00, 0.0001,
             "1,000,000 input tokens priced at the default model's $3.00/M rate");
+    }
+
+    /// <summary>
+    /// Regression guard for the dashboard "Distribution by Model" tile showing a single
+    /// "unknown" bucket: the harness's own token metrics must carry the short <c>model</c>
+    /// label that every <c>sum by (model)</c> dashboard query groups on — NOT the dotted
+    /// semantic-convention key <c>gen_ai.request.model</c>, which Prometheus normalizes to
+    /// <c>gen_ai_request_model</c> and which no dashboard query references.
+    /// </summary>
+    [Fact]
+    public void OnEnd_EmitsTotalTokens_WithShortModelLabel()
+    {
+        const string uniqueAgent = "model-label-guard-agent";
+        const string expectedModel = "claude-opus-4-8";
+        var processor = CreateProcessor();
+
+        var modelTagValues = new List<string?>();
+        var sawDottedSemconvKey = false;
+        using var listener = new MeterListener
+        {
+            InstrumentPublished = (instrument, l) =>
+            {
+                if (instrument.Name == TokenConventions.Total)
+                    l.EnableMeasurementEvents(instrument);
+            }
+        };
+        listener.SetMeasurementEventCallback<long>((_, _, tags, _) =>
+        {
+            var isOurs = false;
+            string? model = null;
+            foreach (var tag in tags)
+            {
+                if (tag.Key == AgentConventions.Name && tag.Value as string == uniqueAgent)
+                    isOurs = true;
+                if (tag.Key == TokenConventions.Model)
+                    model = tag.Value as string;
+                if (tag.Key == TokenConventions.GenAiRequestModel)
+                    sawDottedSemconvKey = true;
+            }
+            if (isOurs)
+                modelTagValues.Add(model);
+        });
+        listener.Start();
+
+        using (var activity = _source.StartActivity("llm-call")!)
+        {
+            activity.SetTag(TokenConventions.GenAiInputTokens, 100);
+            activity.SetTag(TokenConventions.GenAiOutputTokens, 50);
+            activity.SetTag(TokenConventions.GenAiRequestModel, expectedModel);
+            activity.SetTag(AgentConventions.Name, uniqueAgent);
+            processor.OnEnd(activity);
+        }
+
+        modelTagValues.Should().ContainSingle(
+            "the total-tokens metric is emitted once per LLM call")
+            .Which.Should().Be(expectedModel,
+                "the dashboards group by the short `model` label, populated from the span's model attribute");
+        sawDottedSemconvKey.Should().BeFalse(
+            "the metric must not be labelled with the dotted gen_ai.request.model key");
     }
 }

--- a/src/Content/Tests/Presentation.AgentHub.Tests/Telemetry/TelemetryPipelineTests.cs
+++ b/src/Content/Tests/Presentation.AgentHub.Tests/Telemetry/TelemetryPipelineTests.cs
@@ -74,7 +74,7 @@ public class TelemetryPipelineTests : IClassFixture<TelemetryPipelineTests.Telem
         var tags = new KeyValuePair<string, object?>[]
         {
             new("agent.name", "test-agent"),
-            new("gen_ai.request.model", "gpt-4o"),
+            new("model", "gpt-4o"),
         };
 
         // Session metrics
@@ -286,8 +286,8 @@ public class TelemetryPipelineTests : IClassFixture<TelemetryPipelineTests.Telem
     {
         var metrics = await ScrapeMetrics();
 
-        metrics.Should().Contain("gen_ai_request_model=\"gpt-4o\"",
-            "dashboard cost-by-model queries group by gen_ai_request_model");
+        metrics.Should().Contain("model=\"gpt-4o\"",
+            "dashboard cost/token-by-model queries group by the short `model` label");
     }
 
     [Fact]


### PR DESCRIPTION
## Why

The harness-owned `agent.tokens.*` metrics (token volume, cost, cache hit rate) were tagged with the dotted semantic-convention key `gen_ai.request.model`, which Prometheus normalizes to `gen_ai_request_model`. Every dashboard breaks spend and volume down with `sum by (model)`, so the per-model tiles (Tokens-by-model, cost-by-model) resolved to **`unknown`**.

This completes the prompt-caching epic (PR #76): caching itself shipped, but the by-model dashboard breakdown was left mislabeled.

## What

- Add `TokenConventions.Model` (`"model"`) and stamp it on the emitted metrics — mirroring how the harness already labels agents with the short `agent.name` rather than a dotted semconv key. The model value is still read from the span's `gen_ai.request.model` attribute; only the metric tag changes.
- Repoint **both** emitters of these instruments:
  - `LlmTokenTrackingProcessor` — token volume, `cost_estimated`, cache metrics.
  - `CacheStatsEnrichingChatClient` — `cost_actual` (the dashboards' **preferred** cost source) plus the OpenRouter-path cache metrics.

Repointing only the processor (the original uncommitted fix) would have left `cost_actual` invisible to `sum by (model)` — silently falling back to the inflated estimate, defeating PR #76's cost correction — and split the cache metrics across two label keys.

## Tests

- New: assert the enriching client tags its metrics with the short `model` label.
- Fixed `TelemetryPipelineTests`, which emitted and asserted the old `gen_ai_request_model` key with a reason claiming the dashboards group by it — the opposite of the real contract (`costQueries.ts` uses `sum by (model)`). It bypassed production code, so it stayed green while documenting the wrong contract.
- Build: 0 errors. Affected projects green: Application.AI.Common.Tests 1207, Infrastructure.Observability.Tests 166, Domain.AI.Tests 792, Presentation.AgentHub.Tests 359.

## Out of scope (flagged)

`TokenUsageMetrics` and `LlmUsageMetrics` both register instruments with the same names (`agent.tokens.*`); the cache/cost instruments on `TokenUsageMetrics` are dead duplicates. Pre-existing; worth a follow-up cleanup.

## Manual verification still pending

A paid multi-turn smoke to watch the cache/cost tiles actually populate by model — can't run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)