### PR TITLE
feat(governance): enforce per-invocation tool governance on the live agent path

### DIFF
--- a/src/Content/Application/Application.AI.Common/DependencyInjection.cs
+++ b/src/Content/Application/Application.AI.Common/DependencyInjection.cs
@@ -110,6 +110,11 @@ public static class DependencyInjection
         // Scoped agent execution context — carries agent identity through the pipeline
         services.AddScoped<IAgentExecutionContext, AgentExecutionContext>();
 
+        // Per-invocation tool governor — runs the permission / graded-autonomy / capability / policy
+        // checks on the agent's live tool-call path (opt-in via GovernanceConfig.EnforceToolInvocation)
+        // and records the per-turn governance trace. Scoped: one per agent turn.
+        services.AddScoped<Interfaces.Governance.IToolInvocationGovernor, Services.Governance.ToolInvocationGovernor>();
+
         // AI telemetry configurator — registers AI SDK OTel sources and processors
         services.AddSingleton<ITelemetryConfigurator, AiTelemetryConfigurator>();
 

--- a/src/Content/Application/Application.AI.Common/Factories/AgentExecutionContextFactory.cs
+++ b/src/Content/Application/Application.AI.Common/Factories/AgentExecutionContextFactory.cs
@@ -335,6 +335,16 @@ public class AgentExecutionContextFactory
             }
         }
 
+        // Governance wrapper — added LAST so it wraps the final, filtered tool set. When
+        // tool-invocation enforcement is on, this guarantees the governor gates every tool the agent
+        // can call, including framework progressive-disclosure tools that bypass ToolChainBuilder.
+        // Inert (and skipped entirely) when enforcement is off, so default behaviour is unchanged.
+        if (_appConfig.CurrentValue.AI?.Governance?.EnforceToolInvocation == true)
+        {
+            providers.Add(new Services.Agent.GoverningToolContextProvider());
+            _logger.LogDebug("Wired GoverningToolContextProvider (tool-invocation enforcement enabled)");
+        }
+
         return providers.Count > 0 ? providers : null;
     }
 

--- a/src/Content/Application/Application.AI.Common/Interfaces/Governance/IToolInvocationGovernor.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Governance/IToolInvocationGovernor.cs
@@ -1,0 +1,56 @@
+using Domain.AI.Governance;
+
+namespace Application.AI.Common.Interfaces.Governance;
+
+/// <summary>
+/// Authorizes individual tool invocations on the agent's live tool-call path and records each
+/// decision for the turn's <see cref="GovernanceTrace"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This closes the gap where the harness's tool governance (permission ACLs, graded-autonomy risk
+/// gating, declarative policy, approval/escalation, capability enforcement) only ran on MediatR
+/// <c>IToolRequest</c> commands — which the agent's autonomous tool calls never produce. The governor
+/// runs that same logic at the one chokepoint every agent tool flows through (the converted
+/// <see cref="Microsoft.Extensions.AI.AITool"/> invocation), so a risk check actually precedes
+/// execution.
+/// </para>
+/// <para>
+/// Scoped to one agent turn. The implementation reads the ambient <c>IAgentExecutionContext</c> for
+/// the agent identity and accumulates a per-turn decision trace exposed via <see cref="GetTrace"/>.
+/// </para>
+/// </remarks>
+public interface IToolInvocationGovernor
+{
+    /// <summary>
+    /// Decides whether the named tool may execute. Records the decision on the turn trace.
+    /// </summary>
+    /// <param name="toolName">The tool the agent is attempting to invoke.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>
+    /// An allow decision, or a deny decision carrying a model-facing message to return in place of
+    /// the tool result. When enforcement is disabled the governor records the would-be decision but
+    /// always returns <see cref="ToolInvocationDecision.Allow"/>.
+    /// </returns>
+    ValueTask<ToolInvocationDecision> AuthorizeAsync(string toolName, CancellationToken cancellationToken);
+
+    /// <summary>Snapshots the governance decisions recorded so far for this turn.</summary>
+    GovernanceTrace GetTrace();
+}
+
+/// <summary>
+/// The result of authorizing a single tool invocation.
+/// </summary>
+/// <param name="IsAllowed">Whether the tool may execute.</param>
+/// <param name="DeniedMessage">
+/// When denied, the message returned to the model in place of the tool result (the same string-result
+/// shape the tool converter already uses for errors). Null when allowed.
+/// </param>
+public sealed record ToolInvocationDecision(bool IsAllowed, string? DeniedMessage = null)
+{
+    /// <summary>An allow decision.</summary>
+    public static ToolInvocationDecision Allow() => new(true);
+
+    /// <summary>A deny decision carrying the model-facing explanation.</summary>
+    public static ToolInvocationDecision Deny(string deniedMessage) => new(false, deniedMessage);
+}

--- a/src/Content/Application/Application.AI.Common/Interfaces/Governance/IToolInvocationGovernor.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Governance/IToolInvocationGovernor.cs
@@ -36,6 +36,15 @@ public interface IToolInvocationGovernor
 
     /// <summary>Snapshots the governance decisions recorded so far for this turn.</summary>
     GovernanceTrace GetTrace();
+
+    /// <summary>
+    /// Clears the recorded decisions so the next turn starts clean. The governor is registered
+    /// scoped, but nested MediatR sends within a conversation share one DI scope (and thus one
+    /// governor instance), so a multi-turn conversation must reset between turns — otherwise
+    /// <see cref="GetTrace"/> returns the cumulative list and per-turn traces double-count when
+    /// aggregated. Mirrors the per-turn reset of the adjacent scoped <c>ILlmUsageCapture</c>.
+    /// </summary>
+    void Reset();
 }
 
 /// <summary>

--- a/src/Content/Application/Application.AI.Common/Services/Agent/GoverningToolContextProvider.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Agent/GoverningToolContextProvider.cs
@@ -1,0 +1,76 @@
+using Application.AI.Common.Services.Tools;
+using Microsoft.Agents.AI;
+using Microsoft.Extensions.AI;
+
+namespace Application.AI.Common.Services.Agent;
+
+/// <summary>
+/// An <see cref="AIContextProvider"/> that wraps every callable tool in the accumulated
+/// <see cref="AIContext"/> in a <see cref="GovernedAIFunction"/> at invocation time, so the
+/// per-invocation governance check runs even for tools that never pass through
+/// <see cref="ToolChainBuilder"/> — notably framework tools surfaced by progressive skill disclosure.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Register this provider <em>last</em> in the <c>AIContextProviders</c> list (after the skills
+/// provider and <see cref="ToolPermissionFilter"/>) so it wraps the final, filtered tool set.
+/// Already-wrapped functions and non-function tools pass through unchanged, so it composes safely
+/// with the build-time wrapping in <see cref="ToolChainBuilder"/> (no double-wrapping).
+/// </para>
+/// <para>
+/// The wrapper is inert unless a governor is ambient for the turn (see
+/// <see cref="Governance.ToolGovernanceAccessor"/>), so this only adds enforcement, never changes
+/// which tools exist or their schemas.
+/// </para>
+/// </remarks>
+public sealed class GoverningToolContextProvider : AIContextProvider
+{
+    /// <summary>Initializes a new <see cref="GoverningToolContextProvider"/>.</summary>
+    public GoverningToolContextProvider()
+        : base(
+            provideInputMessageFilter: messages => messages,
+            storeInputRequestMessageFilter: messages => messages,
+            storeInputResponseMessageFilter: messages => messages)
+    {
+    }
+
+    /// <inheritdoc />
+    protected override ValueTask<AIContext> ProvideAIContextAsync(
+        InvokingContext context,
+        CancellationToken cancellationToken = default)
+    {
+        var tools = context.AIContext.Tools?.ToList();
+        if (tools is null or { Count: 0 })
+            return ValueTask.FromResult(context.AIContext);
+
+        var changed = false;
+        for (var i = 0; i < tools.Count; i++)
+        {
+            var governed = Govern(tools[i]);
+            if (!ReferenceEquals(governed, tools[i]))
+            {
+                tools[i] = governed;
+                changed = true;
+            }
+        }
+
+        // Nothing needed wrapping — avoid allocating a new AIContext.
+        if (!changed)
+            return ValueTask.FromResult(context.AIContext);
+
+        return ValueTask.FromResult(new AIContext
+        {
+            Instructions = context.AIContext.Instructions,
+            Messages = context.AIContext.Messages,
+            Tools = tools
+        });
+    }
+
+    /// <summary>
+    /// Returns <paramref name="tool"/> wrapped in a <see cref="GovernedAIFunction"/> when it is an
+    /// unwrapped callable function, or the tool unchanged when it is already governed or is not a
+    /// function. Extracted for unit testing of the wrapping decision.
+    /// </summary>
+    internal static AITool Govern(AITool tool)
+        => tool is AIFunction fn and not GovernedAIFunction ? new GovernedAIFunction(fn) : tool;
+}

--- a/src/Content/Application/Application.AI.Common/Services/Governance/ToolGovernanceAccessor.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Governance/ToolGovernanceAccessor.cs
@@ -1,0 +1,28 @@
+using Application.AI.Common.Interfaces.Governance;
+
+namespace Application.AI.Common.Services.Governance;
+
+/// <summary>
+/// Ambient accessor that bridges the per-turn scoped <see cref="IToolInvocationGovernor"/> to the
+/// agent's converted tool functions.
+/// </summary>
+/// <remarks>
+/// Agents (and their captured tool-invocation lambdas) are cached across turns by
+/// <c>IAgentConversationCache</c>, so a tool function cannot capture a scoped governor at build time —
+/// it would go stale on later turns. This follows the existing <c>LlmUsageCapture.Current</c> /
+/// <c>AgentTurnStreamSink.Current</c> precedent: the turn handler sets <see cref="Current"/> to the
+/// live scoped governor at the start of each turn and clears it in a <c>finally</c>, and the governed
+/// tool wrapper reads it at invocation time. When unset (a tool invoked outside a governed turn), the
+/// wrapper passes through.
+/// </remarks>
+public static class ToolGovernanceAccessor
+{
+    private static readonly AsyncLocal<IToolInvocationGovernor?> s_current = new();
+
+    /// <summary>The governor for the current async flow, or null when not inside a governed turn.</summary>
+    public static IToolInvocationGovernor? Current
+    {
+        get => s_current.Value;
+        set => s_current.Value = value;
+    }
+}

--- a/src/Content/Application/Application.AI.Common/Services/Governance/ToolInvocationGovernor.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Governance/ToolInvocationGovernor.cs
@@ -164,9 +164,8 @@ public sealed class ToolInvocationGovernor : IToolInvocationGovernor
         {
             var decision = _policyEngine.EvaluateToolCall(agentId, toolName);
 
-            if (governance.EnableAudit)
-                _auditService.Log(agentId, toolName, decision.Action.ToString());
-
+            // The outcome is audited once below — by Blocked() on a deny/approval, or by the final
+            // Allowed audit on success — so the policy action is not logged separately here.
             if (!decision.IsAllowed)
             {
                 if (decision.Action == GovernancePolicyAction.RequireApproval)
@@ -255,6 +254,13 @@ public sealed class ToolInvocationGovernor : IToolInvocationGovernor
     {
         lock (_lock)
             _decisions.Add(record);
+    }
+
+    /// <inheritdoc />
+    public void Reset()
+    {
+        lock (_lock)
+            _decisions.Clear();
     }
 
     /// <inheritdoc />

--- a/src/Content/Application/Application.AI.Common/Services/Governance/ToolInvocationGovernor.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Governance/ToolInvocationGovernor.cs
@@ -1,0 +1,276 @@
+using Application.AI.Common.Interfaces.Agent;
+using Application.AI.Common.Interfaces.Governance;
+using Application.AI.Common.Interfaces.Permissions;
+using Application.AI.Common.Interfaces.Sandbox;
+using Application.AI.Common.Interfaces.Tools;
+using Domain.AI.Changes;
+using Domain.AI.Governance;
+using Domain.AI.Permissions;
+using Domain.AI.Sandbox;
+using Domain.Common.Config.AI;
+using Domain.Common.Config.AI.Permissions;
+using Domain.Common.Config.AI.Sandbox;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Application.AI.Common.Services.Governance;
+
+/// <summary>
+/// Scoped governor that authorizes the agent's autonomous tool calls on the live tool path,
+/// applying the same permission, graded-autonomy risk, capability, and policy logic the MediatR
+/// behaviours define — which never executed for agent tool calls because nothing produces
+/// <c>IToolRequest</c>. Records every decision into a per-turn <see cref="GovernanceTrace"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>Opt-in.</strong> Off unless <c>GovernanceConfig.EnforceToolInvocation</c> is true. When off,
+/// <see cref="AuthorizeAsync"/> is a pure pass-through (no evaluation, no recording) so default
+/// deployments are unchanged. When on, the gate is <em>fail-closed</em>.
+/// </para>
+/// <para>
+/// <strong>Approval handling (PR1a).</strong> A tool that resolves to "requires approval" is recorded
+/// as <see cref="ToolDecisionOutcome.PendingApproval"/> and blocked (fail-closed). Live human
+/// escalation routing mid-tool-call is intentionally deferred to a focused follow-up; this degrades
+/// safely to deny rather than silently allowing.
+/// </para>
+/// </remarks>
+public sealed class ToolInvocationGovernor : IToolInvocationGovernor
+{
+    private readonly IAgentExecutionContext _executionContext;
+    private readonly IToolPermissionService _toolPermissionService;
+    private readonly IToolRiskClassifier _toolRiskClassifier;
+    private readonly IAutonomyDecisionEvaluator _autonomyEvaluator;
+    private readonly IGovernancePolicyEngine _policyEngine;
+    private readonly IGovernanceAuditService _auditService;
+    private readonly IDenialTracker _denialTracker;
+    private readonly ICapabilityEnforcer _capabilityEnforcer;
+    private readonly IOptionsMonitor<GovernanceConfig> _governanceConfig;
+    private readonly IOptionsMonitor<PermissionsConfig> _permissionsConfig;
+    private readonly IOptionsMonitor<SandboxConfig> _sandboxConfig;
+    private readonly ILogger<ToolInvocationGovernor> _logger;
+
+    private readonly object _lock = new();
+    private readonly List<ToolDecisionRecord> _decisions = [];
+
+    public ToolInvocationGovernor(
+        IAgentExecutionContext executionContext,
+        IToolPermissionService toolPermissionService,
+        IToolRiskClassifier toolRiskClassifier,
+        IAutonomyDecisionEvaluator autonomyEvaluator,
+        IGovernancePolicyEngine policyEngine,
+        IGovernanceAuditService auditService,
+        IDenialTracker denialTracker,
+        ICapabilityEnforcer capabilityEnforcer,
+        IOptionsMonitor<GovernanceConfig> governanceConfig,
+        IOptionsMonitor<PermissionsConfig> permissionsConfig,
+        IOptionsMonitor<SandboxConfig> sandboxConfig,
+        ILogger<ToolInvocationGovernor> logger)
+    {
+        _executionContext = executionContext;
+        _toolPermissionService = toolPermissionService;
+        _toolRiskClassifier = toolRiskClassifier;
+        _autonomyEvaluator = autonomyEvaluator;
+        _policyEngine = policyEngine;
+        _auditService = auditService;
+        _denialTracker = denialTracker;
+        _capabilityEnforcer = capabilityEnforcer;
+        _governanceConfig = governanceConfig;
+        _permissionsConfig = permissionsConfig;
+        _sandboxConfig = sandboxConfig;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async ValueTask<ToolInvocationDecision> AuthorizeAsync(string toolName, CancellationToken cancellationToken)
+    {
+        // Opt-in: when enforcement is off the governor never engages — pure pass-through, no record,
+        // no behaviour change for existing deployments.
+        if (!_governanceConfig.CurrentValue.EnforceToolInvocation)
+            return ToolInvocationDecision.Allow();
+
+        var profile = _toolRiskClassifier.Classify(toolName);
+
+        // No agent identity means this isn't a fully-scoped agent turn (e.g. an execution path that
+        // did not initialize the context). Mirror ToolPermissionBehavior and pass through rather than
+        // guess an identity — but RECORD it as ungoverned (Enforced=false) so the trace surfaces the
+        // gap instead of it being invisible to an evaluator.
+        var agentId = _executionContext.AgentId;
+        if (string.IsNullOrEmpty(agentId))
+        {
+            _logger.LogWarning(
+                "Tool governance: no AgentId in execution context for {ToolName} — allowed ungoverned and recorded", toolName);
+            Record(new ToolDecisionRecord(toolName, ToolDecisionOutcome.Allowed,
+                "no agent identity in execution context", profile.Radius,
+                RequiredApproval: false, ApprovalGranted: false, Enforced: false));
+            return ToolInvocationDecision.Allow();
+        }
+
+        var permission = await _toolPermissionService
+            .ResolvePermissionAsync(agentId, toolName, cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+
+        // Graded-autonomy risk gate: can only tighten an Allow, never loosen (mirrors ToolPermissionBehavior).
+        permission = ApplyRiskGate(permission, toolName, profile);
+
+        switch (permission.Behavior)
+        {
+            case PermissionBehaviorType.Deny:
+                _denialTracker.RecordDenial(agentId, toolName);
+                return Blocked(toolName, ToolDecisionOutcome.Denied, permission.Reason, profile.Radius,
+                    requiredApproval: false, agentId);
+
+            case PermissionBehaviorType.Ask:
+                _denialTracker.RecordDenial(agentId, toolName);
+                return Blocked(toolName, ToolDecisionOutcome.PendingApproval,
+                    $"requires approval: {permission.Reason}", profile.Radius,
+                    requiredApproval: true, agentId);
+
+            case PermissionBehaviorType.Allow:
+                return await AuthorizeAllowedAsync(agentId, toolName, profile, cancellationToken)
+                    .ConfigureAwait(false);
+
+            default:
+                // Unknown behaviour: fail closed.
+                return Blocked(toolName, ToolDecisionOutcome.Denied,
+                    $"unrecognized permission behaviour '{permission.Behavior}'", profile.Radius,
+                    requiredApproval: false, agentId);
+        }
+    }
+
+    private async ValueTask<ToolInvocationDecision> AuthorizeAllowedAsync(
+        string agentId, string toolName, ToolRiskProfile profile, CancellationToken cancellationToken)
+    {
+        // Capability enforcement: the rule layer allowed the tool, now confirm the granted sandbox
+        // capabilities satisfy what the tool needs.
+        var grantedCapabilities = ToolCapability.None;
+        foreach (var name in _sandboxConfig.CurrentValue.DefaultGrantedCapabilities)
+            if (Enum.TryParse<ToolCapability>(name, ignoreCase: true, out var cap))
+                grantedCapabilities |= cap;
+
+        var capResult = await _capabilityEnforcer
+            .EnforceAsync(toolName, grantedCapabilities, ct: cancellationToken)
+            .ConfigureAwait(false);
+
+        if (!capResult.IsSuccess)
+        {
+            var reason = capResult.Errors.Count > 0 ? capResult.Errors[0] : "capability check failed";
+            return Blocked(toolName, ToolDecisionOutcome.Denied, $"capability violation: {reason}",
+                profile.Radius, requiredApproval: false, agentId);
+        }
+
+        // Declarative policy layer (YAML policies), only when configured.
+        var governance = _governanceConfig.CurrentValue;
+        if (governance.Enabled && _policyEngine.HasPolicies)
+        {
+            var decision = _policyEngine.EvaluateToolCall(agentId, toolName);
+
+            if (governance.EnableAudit)
+                _auditService.Log(agentId, toolName, decision.Action.ToString());
+
+            if (!decision.IsAllowed)
+            {
+                if (decision.Action == GovernancePolicyAction.RequireApproval)
+                {
+                    _denialTracker.RecordDenial(agentId, toolName);
+                    return Blocked(toolName, ToolDecisionOutcome.PendingApproval,
+                        $"requires approval: {decision.Reason}", profile.Radius,
+                        requiredApproval: true, agentId);
+                }
+
+                _denialTracker.RecordDenial(agentId, toolName);
+                return Blocked(toolName, ToolDecisionOutcome.Denied, decision.Reason, profile.Radius,
+                    requiredApproval: false, agentId);
+            }
+        }
+
+        Record(new ToolDecisionRecord(toolName, ToolDecisionOutcome.Allowed, "allowed",
+            profile.Radius, RequiredApproval: false, ApprovalGranted: false, Enforced: true));
+
+        if (governance.EnableAudit)
+            _auditService.Log(agentId, toolName, ToolDecisionOutcome.Allowed.ToString());
+
+        return ToolInvocationDecision.Allow();
+    }
+
+    /// <summary>
+    /// Records a blocking decision (audit + trace) and returns a deny carrying a model-facing message.
+    /// </summary>
+    private ToolInvocationDecision Blocked(
+        string toolName, ToolDecisionOutcome outcome, string reason, BlastRadius radius,
+        bool requiredApproval, string agentId)
+    {
+        Record(new ToolDecisionRecord(toolName, outcome, reason, radius,
+            RequiredApproval: requiredApproval, ApprovalGranted: false, Enforced: true));
+
+        if (_governanceConfig.CurrentValue.EnableAudit)
+            _auditService.Log(agentId, toolName, outcome.ToString());
+
+        _logger.LogWarning(
+            "Tool governance blocked agent {AgentId} tool {ToolName}: {Outcome} — {Reason}",
+            agentId, toolName, outcome, reason);
+
+        // Model-facing message is deliberately generic: the detailed reason (rule ids, paths,
+        // capability internals) stays in the structured log and the GovernanceTrace, never relayed
+        // to the LLM — avoids leaking operator-authored policy detail into model-visible content.
+        return ToolInvocationDecision.Deny($"Error: tool '{toolName}' is not permitted in the current context.");
+    }
+
+    /// <summary>
+    /// Applies the graded-autonomy risk gate to an Allow decision (a faithful copy of
+    /// <c>ToolPermissionBehavior.ApplyRiskGate</c>). Tightens Allow → Ask/Deny when the active tier
+    /// will not auto-approve the tool's blast radius; never loosens.
+    /// </summary>
+    private PermissionDecision ApplyRiskGate(PermissionDecision decision, string toolName, ToolRiskProfile profile)
+    {
+        if (decision.Behavior != PermissionBehaviorType.Allow)
+            return decision;
+
+        var permissions = _permissionsConfig.CurrentValue;
+        if (!permissions.GradedAutonomy.Enabled)
+            return decision;
+
+        if (!Enum.TryParse<AutonomyLevel>(permissions.DefaultAutonomyLevel, ignoreCase: true, out var tier))
+        {
+            _logger.LogWarning(
+                "Graded autonomy enabled but DefaultAutonomyLevel '{Tier}' is invalid — skipping risk gate for {ToolName}",
+                permissions.DefaultAutonomyLevel, toolName);
+            return decision;
+        }
+
+        var result = _autonomyEvaluator.Evaluate(
+            tier, profile.Radius, ChangeTargetKind.Unspecified, isStateChange: !profile.IsReadOnly, skillKey: null);
+
+        return result.Decision switch
+        {
+            AutonomyDecision.AutoApprove => decision,
+            AutonomyDecision.RequiresApproval => PermissionDecision.Ask(
+                $"graded autonomy: tool '{toolName}' (blast radius {profile.Radius}) requires approval under tier {tier}. {result.Reason}"),
+            AutonomyDecision.Forbidden => PermissionDecision.Deny(
+                $"graded autonomy: tool '{toolName}' (blast radius {profile.Radius}) is forbidden under tier {tier}. {result.Reason}"),
+            _ => decision
+        };
+    }
+
+    private void Record(ToolDecisionRecord record)
+    {
+        lock (_lock)
+            _decisions.Add(record);
+    }
+
+    /// <inheritdoc />
+    public GovernanceTrace GetTrace()
+    {
+        var enforced = _governanceConfig.CurrentValue.EnforceToolInvocation;
+        lock (_lock)
+        {
+            if (!enforced && _decisions.Count == 0)
+                return GovernanceTrace.Empty;
+
+            return new GovernanceTrace
+            {
+                EnforcementEnabled = enforced,
+                ToolDecisions = _decisions.ToList()
+            };
+        }
+    }
+}

--- a/src/Content/Application/Application.AI.Common/Services/Tools/GovernedAIFunction.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/GovernedAIFunction.cs
@@ -1,0 +1,44 @@
+using Application.AI.Common.Services.Governance;
+using Microsoft.Extensions.AI;
+
+namespace Application.AI.Common.Services.Tools;
+
+/// <summary>
+/// Wraps an agent tool function so a governance check runs immediately before the tool executes.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Derives from <see cref="DelegatingAIFunction"/> so the wrapped function's name, description, and
+/// JSON schema are preserved unchanged — only invocation is intercepted. On invoke it consults the
+/// ambient <c>IToolInvocationGovernor</c> (via <see cref="ToolGovernanceAccessor"/>); a denial returns
+/// the governor's model-facing message in place of the tool result (the same string-result shape the
+/// tool converter already uses for errors), and the inner function is never called. When no governor
+/// is ambient (a tool invoked outside a governed turn), the call passes straight through.
+/// </para>
+/// <para>
+/// This is the single invocation-time chokepoint for the agent's autonomous tool calls, applied to
+/// every converted tool regardless of source (keyed-DI, MCP, or skill-provided).
+/// </para>
+/// </remarks>
+internal sealed class GovernedAIFunction : DelegatingAIFunction
+{
+    public GovernedAIFunction(AIFunction innerFunction)
+        : base(innerFunction)
+    {
+    }
+
+    protected override async ValueTask<object?> InvokeCoreAsync(
+        AIFunctionArguments arguments,
+        CancellationToken cancellationToken)
+    {
+        var governor = ToolGovernanceAccessor.Current;
+        if (governor is not null)
+        {
+            var decision = await governor.AuthorizeAsync(Name, cancellationToken).ConfigureAwait(false);
+            if (!decision.IsAllowed)
+                return decision.DeniedMessage ?? $"Error: tool '{Name}' was blocked by governance policy.";
+        }
+
+        return await base.InvokeCoreAsync(arguments, cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/src/Content/Application/Application.AI.Common/Services/Tools/ToolChainBuilder.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/ToolChainBuilder.cs
@@ -74,7 +74,7 @@ public class ToolChainBuilder : IToolChainBuilder
                 skill.Id, skill.PluginSource, tools.Count);
 
             var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-            return tools.Where(t => seen.Add(t.Name)).ToList();
+            return WrapGoverned(tools.Where(t => seen.Add(t.Name)));
         }
 
         if (skill.Tools?.Count > 0)
@@ -105,8 +105,21 @@ public class ToolChainBuilder : IToolChainBuilder
             tools.AddRange(options.AdditionalTools);
 
         var seen2 = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        return tools.Where(t => seen2.Add(t.Name)).ToList();
+        return WrapGoverned(tools.Where(t => seen2.Add(t.Name)));
     }
+
+    /// <summary>
+    /// Wraps each callable tool function in a <see cref="GovernedAIFunction"/> so a per-invocation
+    /// governance check runs before the tool executes. Non-function tools and already-wrapped
+    /// functions pass through unchanged. The wrapper is inert unless tool-invocation enforcement is
+    /// enabled and a governor is ambient for the turn, so this adds no behaviour when governance is off.
+    /// Applied at this single shared builder so every agent-callable tool — keyed-DI, MCP, or
+    /// skill-provided — is governed exactly once.
+    /// </summary>
+    private static List<AITool> WrapGoverned(IEnumerable<AITool> tools)
+        => tools
+            .Select(t => t is AIFunction fn and not GovernedAIFunction ? new GovernedAIFunction(fn) : t)
+            .ToList();
 
     /// <inheritdoc />
     public async Task<List<AITool>> BuildMergedToolsAsync(

--- a/src/Content/Application/Application.Core/CQRS/Agents/ExecuteAgentTurn/ExecuteAgentTurnCommand.cs
+++ b/src/Content/Application/Application.Core/CQRS/Agents/ExecuteAgentTurn/ExecuteAgentTurnCommand.cs
@@ -101,6 +101,13 @@ public record AgentTurnResult : IAgentTurnResult
 	public int CacheWrite { get; init; }
 	public decimal CostUsd { get; init; }
 	public string? Model { get; init; }
+
+	/// <summary>
+	/// Snapshot of the per-invocation governance decisions the agent's tool calls passed through
+	/// this turn. Null when tool-invocation governance was not engaged. Lets evaluation grade the
+	/// agent's governance behaviour independently of task outcome.
+	/// </summary>
+	public Domain.AI.Governance.GovernanceTrace? Governance { get; init; }
 }
 
 /// <summary>

--- a/src/Content/Application/Application.Core/CQRS/Agents/ExecuteAgentTurn/ExecuteAgentTurnCommandHandler.cs
+++ b/src/Content/Application/Application.Core/CQRS/Agents/ExecuteAgentTurn/ExecuteAgentTurnCommandHandler.cs
@@ -6,8 +6,10 @@ using Application.AI.Common.Exceptions;
 using Application.AI.Common.Helpers;
 using Application.AI.Common.Interfaces;
 using Application.AI.Common.Interfaces.Context;
+using Application.AI.Common.Interfaces.Governance;
 using Application.AI.Common.OpenTelemetry.Metrics;
 using Application.AI.Common.Services;
+using Application.AI.Common.Services.Governance;
 using Domain.AI.Agents;
 using Domain.AI.Context;
 using Domain.AI.Skills;
@@ -27,6 +29,7 @@ namespace Application.Core.CQRS.Agents.ExecuteAgentTurn;
 public class ExecuteAgentTurnCommandHandler : IRequestHandler<ExecuteAgentTurnCommand, AgentTurnResult>
 {
 	private readonly IAgentConversationCache _agentCache;
+	private readonly IToolInvocationGovernor _governor;
 	private readonly IAgentMetadataRegistry _agentRegistry;
 	private readonly ISkillMetadataRegistry _skillRegistry;
 	private readonly IConversationRegistrationTracker _registrationTracker;
@@ -39,6 +42,7 @@ public class ExecuteAgentTurnCommandHandler : IRequestHandler<ExecuteAgentTurnCo
 
 	public ExecuteAgentTurnCommandHandler(
 		IAgentConversationCache agentCache,
+		IToolInvocationGovernor governor,
 		IAgentMetadataRegistry agentRegistry,
 		ISkillMetadataRegistry skillRegistry,
 		IConversationRegistrationTracker registrationTracker,
@@ -50,6 +54,7 @@ public class ExecuteAgentTurnCommandHandler : IRequestHandler<ExecuteAgentTurnCo
 		ILogger<ExecuteAgentTurnCommandHandler> logger)
 	{
 		_agentCache = agentCache;
+		_governor = governor;
 		_agentRegistry = agentRegistry;
 		_skillRegistry = skillRegistry;
 		_registrationTracker = registrationTracker;
@@ -109,6 +114,11 @@ public class ExecuteAgentTurnCommandHandler : IRequestHandler<ExecuteAgentTurnCo
 			// records to this handler's scoped ILlmUsageCapture instance.
 			LlmUsageCapture.Current = _usageCapture;
 
+			// Same bridge for tool governance: the agent (and its cached tool functions) outlive
+			// this scope, so expose this turn's scoped governor ambiently for the governed tool
+			// wrapper to consult at invocation time.
+			ToolGovernanceAccessor.Current = _governor;
+
 			object? response;
 			var turnSw = Stopwatch.StartNew();
 			try
@@ -127,6 +137,7 @@ public class ExecuteAgentTurnCommandHandler : IRequestHandler<ExecuteAgentTurnCo
 			finally
 			{
 				LlmUsageCapture.Current = null;
+				ToolGovernanceAccessor.Current = null;
 			}
 
 			// Capture accumulated token usage from all LLM calls during this turn
@@ -254,7 +265,8 @@ public class ExecuteAgentTurnCommandHandler : IRequestHandler<ExecuteAgentTurnCo
 				CacheRead = usage.CacheRead,
 				CacheWrite = usage.CacheWrite,
 				CostUsd = usage.CostUsd,
-				Model = usage.Model
+				Model = usage.Model,
+				Governance = _governor.GetTrace()
 			};
 		}
 		catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)

--- a/src/Content/Application/Application.Core/CQRS/Agents/ExecuteAgentTurn/ExecuteAgentTurnCommandHandler.cs
+++ b/src/Content/Application/Application.Core/CQRS/Agents/ExecuteAgentTurn/ExecuteAgentTurnCommandHandler.cs
@@ -116,7 +116,10 @@ public class ExecuteAgentTurnCommandHandler : IRequestHandler<ExecuteAgentTurnCo
 
 			// Same bridge for tool governance: the agent (and its cached tool functions) outlive
 			// this scope, so expose this turn's scoped governor ambiently for the governed tool
-			// wrapper to consult at invocation time.
+			// wrapper to consult at invocation time. Reset first: nested MediatR sends within a
+			// conversation share one scope (one governor), so clear prior turns' decisions so this
+			// turn's trace reflects only this turn — mirrors the _usageCapture clear above.
+			_governor.Reset();
 			ToolGovernanceAccessor.Current = _governor;
 
 			object? response;

--- a/src/Content/Application/Application.Core/CQRS/Agents/RunConversation/RunConversationCommand.cs
+++ b/src/Content/Application/Application.Core/CQRS/Agents/RunConversation/RunConversationCommand.cs
@@ -61,6 +61,12 @@ public record ConversationResult
 	public required string FinalResponse { get; init; }
 	public int TotalToolInvocations { get; init; }
 	public string? Error { get; init; }
+
+	/// <summary>
+	/// Aggregated snapshot of the per-invocation governance decisions across all turns of the
+	/// conversation. Null when tool-invocation governance was not engaged.
+	/// </summary>
+	public Domain.AI.Governance.GovernanceTrace? Governance { get; init; }
 }
 
 /// <summary>

--- a/src/Content/Application/Application.Core/CQRS/Agents/RunConversation/RunConversationCommandHandler.cs
+++ b/src/Content/Application/Application.Core/CQRS/Agents/RunConversation/RunConversationCommandHandler.cs
@@ -3,6 +3,7 @@ using System.Diagnostics.Metrics;
 using Application.AI.Common.Interfaces;
 using Application.AI.Common.OpenTelemetry.Metrics;
 using Application.Core.CQRS.Agents.ExecuteAgentTurn;
+using Domain.AI.Governance;
 using Domain.AI.Telemetry.Conventions;
 using MediatR;
 using Microsoft.Extensions.Logging;
@@ -40,6 +41,7 @@ public class RunConversationCommandHandler : IRequestHandler<RunConversationComm
 		var sw = Stopwatch.StartNew();
 		var turns = new List<TurnSummary>();
 		var totalToolInvocations = 0;
+		var governanceTraces = new List<GovernanceTrace>();
 		AgentTurnResult? lastResult = null;
 
 		// Running token/cost aggregates for session-level metrics
@@ -127,6 +129,9 @@ public class RunConversationCommandHandler : IRequestHandler<RunConversationComm
 
 				totalToolInvocations += lastResult.ToolsInvoked.Count;
 
+				if (lastResult.Governance is not null)
+					governanceTraces.Add(lastResult.Governance);
+
 				totalInputTokens += lastResult.InputTokens;
 				totalOutputTokens += lastResult.OutputTokens;
 				totalCacheRead += lastResult.CacheRead;
@@ -175,7 +180,8 @@ public class RunConversationCommandHandler : IRequestHandler<RunConversationComm
 				Success = true,
 				Turns = turns,
 				FinalResponse = lastResult?.Response ?? string.Empty,
-				TotalToolInvocations = totalToolInvocations
+				TotalToolInvocations = totalToolInvocations,
+				Governance = governanceTraces.Count > 0 ? GovernanceTrace.Merge(governanceTraces) : null
 			};
 		}
 		catch (OperationCanceledException)

--- a/src/Content/Application/Application.Core/CQRS/Agents/RunOrchestratedTask/RunOrchestratedTaskCommandHandler.cs
+++ b/src/Content/Application/Application.Core/CQRS/Agents/RunOrchestratedTask/RunOrchestratedTaskCommandHandler.cs
@@ -1,5 +1,8 @@
 using Application.AI.Common.Interfaces;
+using Application.AI.Common.Interfaces.Agent;
+using Application.AI.Common.Interfaces.Governance;
 using Application.AI.Common.OpenTelemetry.Metrics;
+using Application.AI.Common.Services.Governance;
 using Application.Core.CQRS.Agents.RunConversation;
 using Domain.AI.Skills;
 using Domain.AI.Telemetry.Conventions;
@@ -22,15 +25,21 @@ public class RunOrchestratedTaskCommandHandler : IRequestHandler<RunOrchestrated
 {
 	private readonly IAgentFactory _agentFactory;
 	private readonly IServiceScopeFactory _scopeFactory;
+	private readonly IAgentExecutionContext _executionContext;
+	private readonly IToolInvocationGovernor _governor;
 	private readonly ILogger<RunOrchestratedTaskCommandHandler> _logger;
 
 	public RunOrchestratedTaskCommandHandler(
 		IAgentFactory agentFactory,
 		IServiceScopeFactory scopeFactory,
+		IAgentExecutionContext executionContext,
+		IToolInvocationGovernor governor,
 		ILogger<RunOrchestratedTaskCommandHandler> logger)
 	{
 		_agentFactory = agentFactory;
 		_scopeFactory = scopeFactory;
+		_executionContext = executionContext;
+		_governor = governor;
 		_logger = logger;
 	}
 
@@ -61,6 +70,12 @@ public class RunOrchestratedTaskCommandHandler : IRequestHandler<RunOrchestrated
 				},
 				cancellationToken);
 
+			// Govern the orchestrator's OWN tool calls (planning + synthesis). This command is not
+			// IAgentScopedRequest, so the pipeline doesn't initialize the execution context — set the
+			// orchestrator identity here so the governor can resolve it. Sub-agent delegation runs in
+			// its own child scope and governs itself per turn.
+			_executionContext.Initialize(request.OrchestratorName, request.ConversationId, 0);
+
 			await ReportProgress(request, "planning", request.OrchestratorName, "Decomposing task...");
 
 			var planMessages = new List<ChatMessage>
@@ -68,7 +83,7 @@ public class RunOrchestratedTaskCommandHandler : IRequestHandler<RunOrchestrated
 				new(ChatRole.User, $"Decompose and execute this task: {request.TaskDescription}")
 			};
 
-			var planResponse = await orchestrator.RunAsync(planMessages, cancellationToken: cancellationToken);
+			var planResponse = await RunOrchestratorGovernedAsync(orchestrator, planMessages, cancellationToken);
 			var planText = ExtractContent(planResponse);
 
 			await ReportProgress(request, "planning", request.OrchestratorName, "Plan created");
@@ -136,7 +151,7 @@ public class RunOrchestratedTaskCommandHandler : IRequestHandler<RunOrchestrated
 				new(ChatRole.User, synthesisPrompt)
 			};
 
-			var synthesisResponse = await orchestrator.RunAsync(synthesisMessages, cancellationToken: cancellationToken);
+			var synthesisResponse = await RunOrchestratorGovernedAsync(orchestrator, synthesisMessages, cancellationToken);
 			var finalSynthesis = ExtractContent(synthesisResponse);
 			totalTurns++;
 
@@ -164,6 +179,23 @@ public class RunOrchestratedTaskCommandHandler : IRequestHandler<RunOrchestrated
 				SubAgentResults = [],
 				Error = ex.Message
 			};
+		}
+	}
+
+	private async Task<object?> RunOrchestratorGovernedAsync(
+		AIAgent orchestrator, List<ChatMessage> messages, CancellationToken cancellationToken)
+	{
+		// Expose this scope's governor to the governed tool wrappers for the orchestrator's own
+		// RunAsync. Set/clear tightly around the call so interleaved sub-agent turns (which set their
+		// own ambient governor in their child scope) are unaffected.
+		ToolGovernanceAccessor.Current = _governor;
+		try
+		{
+			return await orchestrator.RunAsync(messages, cancellationToken: cancellationToken);
+		}
+		finally
+		{
+			ToolGovernanceAccessor.Current = null;
 		}
 	}
 

--- a/src/Content/Domain/Domain.AI/Governance/GovernanceTrace.cs
+++ b/src/Content/Domain/Domain.AI/Governance/GovernanceTrace.cs
@@ -1,0 +1,86 @@
+namespace Domain.AI.Governance;
+
+/// <summary>
+/// An immutable snapshot of the governance decisions an agent's tool calls passed through
+/// during a turn or conversation. Produced by <c>IToolInvocationGovernor</c> and surfaced on
+/// the agent-turn and conversation results so an evaluation can grade the agent's governance
+/// behaviour <em>independently of whether the task succeeded</em> — the core anti-"governance
+/// theater" instrument from Loop Engineering.
+/// </summary>
+/// <remarks>
+/// This is a read-only projection. The governor accumulates decisions in a mutable, thread-safe
+/// collector as the agent runs, then emits this snapshot at the boundary.
+/// </remarks>
+public sealed record GovernanceTrace
+{
+    /// <summary>An empty trace: enforcement off and no decisions recorded.</summary>
+    public static GovernanceTrace Empty { get; } = new();
+
+    /// <summary>
+    /// Whether per-invocation governance enforcement was active. When false the governor ran in
+    /// observe-only mode (or was not engaged) and denials were not blocking — an eval should treat
+    /// any "would-deny" decisions as ungoverned rather than enforced.
+    /// </summary>
+    public bool EnforcementEnabled { get; init; }
+
+    /// <summary>The individual per-tool decisions, in the order the agent attempted the calls.</summary>
+    public IReadOnlyList<ToolDecisionRecord> ToolDecisions { get; init; } = [];
+
+    /// <summary>Total number of tool invocations the governor evaluated.</summary>
+    public int ToolInvocationCount => ToolDecisions.Count;
+
+    /// <summary>Number of invocations that were allowed.</summary>
+    public int AllowedCount => ToolDecisions.Count(d => d.Outcome == ToolDecisionOutcome.Allowed);
+
+    /// <summary>Number of invocations that were denied (blocked when enforced).</summary>
+    public int DeniedCount => ToolDecisions.Count(d => d.Outcome == ToolDecisionOutcome.Denied);
+
+    /// <summary>True when at least one tool call hit a human approval gate.</summary>
+    public bool ApprovalGateEncountered => ToolDecisions.Any(d => d.RequiredApproval);
+
+    /// <summary>True when at least one approval gate was satisfied by a human.</summary>
+    public bool ApprovalGranted => ToolDecisions.Any(d => d.ApprovalGranted);
+
+    /// <summary>
+    /// True when a tool that required approval nonetheless executed without one — the governance
+    /// hole an outcome-blind eval must flag as a hard failure. With enforcement on this should
+    /// never be true; it surfaces config gaps and observe-only runs.
+    /// </summary>
+    public bool ApprovalBypassed =>
+        ToolDecisions.Any(d => d.RequiredApproval && !d.ApprovalGranted && !d.Enforced
+            && d.Outcome is ToolDecisionOutcome.Allowed);
+
+    /// <summary>Distinct escalation reason codes raised during the turn/conversation.</summary>
+    public IReadOnlyList<string> EscalationReasonCodes { get; init; } = [];
+
+    /// <summary>
+    /// Merges several traces (e.g. per-turn traces of a conversation) into one. Decisions are
+    /// concatenated in order; flags and reason codes are unioned; enforcement is true when any
+    /// component had it on.
+    /// </summary>
+    public static GovernanceTrace Merge(IEnumerable<GovernanceTrace> traces)
+    {
+        ArgumentNullException.ThrowIfNull(traces);
+
+        var decisions = new List<ToolDecisionRecord>();
+        var reasonCodes = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var enforcement = false;
+
+        foreach (var trace in traces)
+        {
+            if (trace is null)
+                continue;
+            decisions.AddRange(trace.ToolDecisions);
+            foreach (var code in trace.EscalationReasonCodes)
+                reasonCodes.Add(code);
+            enforcement |= trace.EnforcementEnabled;
+        }
+
+        return new GovernanceTrace
+        {
+            EnforcementEnabled = enforcement,
+            ToolDecisions = decisions,
+            EscalationReasonCodes = reasonCodes.Count > 0 ? reasonCodes.ToList() : []
+        };
+    }
+}

--- a/src/Content/Domain/Domain.AI/Governance/ToolDecisionOutcome.cs
+++ b/src/Content/Domain/Domain.AI/Governance/ToolDecisionOutcome.cs
@@ -1,0 +1,25 @@
+namespace Domain.AI.Governance;
+
+/// <summary>
+/// The outcome of a single per-invocation governance decision made when an agent
+/// attempts to call a tool during a turn. Recorded on the <see cref="GovernanceTrace"/>
+/// so loop behaviour can be observed and graded independently of task outcome.
+/// </summary>
+public enum ToolDecisionOutcome
+{
+    /// <summary>The tool call was permitted to execute.</summary>
+    Allowed = 0,
+
+    /// <summary>The tool call was blocked by permission, risk, policy, or capability checks.</summary>
+    Denied = 1,
+
+    /// <summary>
+    /// The tool call required human approval and was not (yet) granted. With escalation
+    /// disabled this is treated as a denial; with escalation enabled it reflects a
+    /// blocking approval request that was not approved.
+    /// </summary>
+    PendingApproval = 2,
+
+    /// <summary>The tool call triggered a human escalation that was resolved (approved or denied) before proceeding.</summary>
+    Escalated = 3
+}

--- a/src/Content/Domain/Domain.AI/Governance/ToolDecisionRecord.cs
+++ b/src/Content/Domain/Domain.AI/Governance/ToolDecisionRecord.cs
@@ -1,0 +1,28 @@
+using Domain.AI.Changes;
+
+namespace Domain.AI.Governance;
+
+/// <summary>
+/// An immutable record of one governance decision taken when an agent attempted to
+/// invoke a tool during a turn. Captured by <c>IToolInvocationGovernor</c> as the agent
+/// runs and aggregated into a <see cref="GovernanceTrace"/>.
+/// </summary>
+/// <param name="ToolName">The tool the agent attempted to invoke.</param>
+/// <param name="Outcome">The governance outcome for this invocation.</param>
+/// <param name="Reason">Human-readable explanation of the decision (e.g. the matched rule or risk tier).</param>
+/// <param name="BlastRadius">The tool's classified blast radius at decision time.</param>
+/// <param name="RequiredApproval">True when the decision routed the call to a human approval gate.</param>
+/// <param name="ApprovalGranted">True when an approval gate was encountered and a human approved the call.</param>
+/// <param name="Enforced">
+/// True when the decision was actually enforced (a denial blocked execution). False when the
+/// governor ran in observe-only mode (enforcement disabled) and recorded the decision without
+/// blocking — the signal that lets an eval distinguish governance from "narration".
+/// </param>
+public sealed record ToolDecisionRecord(
+    string ToolName,
+    ToolDecisionOutcome Outcome,
+    string Reason,
+    BlastRadius BlastRadius,
+    bool RequiredApproval,
+    bool ApprovalGranted,
+    bool Enforced);

--- a/src/Content/Domain/Domain.Common/Config/AI/GovernanceConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/GovernanceConfig.cs
@@ -12,6 +12,21 @@ public sealed class GovernanceConfig
     public bool Enabled { get; init; }
 
     /// <summary>
+    /// Whether per-invocation governance runs on the agent's live tool-call path. When true, every
+    /// tool the agent calls during a turn passes through <c>IToolInvocationGovernor</c> (permission,
+    /// graded-autonomy risk, capability, and policy checks) before executing, fail-closed. When false
+    /// (the default) the governor is a pure pass-through and agent tool calls are not gated at
+    /// invocation time — preserving existing behaviour for consumers who have not opted in.
+    /// </summary>
+    /// <remarks>
+    /// This is the switch that connects the otherwise-dormant tool governance to the agent loop.
+    /// Enabling it without configured permission rules makes the default "Ask" behaviour block tools,
+    /// so operators should pair it with explicit allow rules. Independent of <see cref="Enabled"/>,
+    /// which only gates the declarative YAML policy layer.
+    /// </remarks>
+    public bool EnforceToolInvocation { get; init; }
+
+    /// <summary>
     /// Paths to YAML policy files. Relative paths resolve from the application base directory.
     /// </summary>
     public List<string> PolicyPaths { get; init; } = [];

--- a/src/Content/Tests/Application.AI.Common.Tests/Governance/GovernedAIFunctionTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Governance/GovernedAIFunctionTests.cs
@@ -1,0 +1,81 @@
+using Application.AI.Common.Interfaces.Governance;
+using Application.AI.Common.Services.Governance;
+using Application.AI.Common.Services.Tools;
+using Microsoft.Extensions.AI;
+using Moq;
+using Xunit;
+
+namespace Application.AI.Common.Tests.Governance;
+
+/// <summary>
+/// Verifies the governed tool-function wrapper consults the ambient governor before invoking the
+/// inner tool, blocks on denial without calling the tool, and passes through when ungoverned.
+/// </summary>
+public sealed class GovernedAIFunctionTests : IDisposable
+{
+    public void Dispose() => ToolGovernanceAccessor.Current = null;
+
+    private static (AIFunction inner, Func<bool> wasInvoked) MakeInner()
+    {
+        var invoked = false;
+        var inner = AIFunctionFactory.Create(
+            () => { invoked = true; return "inner-result"; },
+            new AIFunctionFactoryOptions { Name = "file_system", Description = "test tool" });
+        return (inner, () => invoked);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_GovernorDenies_ReturnsDeniedMessageAndSkipsInner()
+    {
+        var (inner, wasInvoked) = MakeInner();
+        var governor = new Mock<IToolInvocationGovernor>();
+        governor
+            .Setup(g => g.AuthorizeAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ToolInvocationDecision.Deny("Error: tool 'file_system' was blocked by governance — denied."));
+        ToolGovernanceAccessor.Current = governor.Object;
+
+        var governed = new GovernedAIFunction(inner);
+        var result = await governed.InvokeAsync(new AIFunctionArguments(), CancellationToken.None);
+
+        Assert.False(wasInvoked(), "inner tool must not run when governance denies");
+        Assert.Contains("blocked by governance", result?.ToString());
+    }
+
+    [Fact]
+    public async Task InvokeAsync_GovernorAllows_InvokesInner()
+    {
+        var (inner, wasInvoked) = MakeInner();
+        var governor = new Mock<IToolInvocationGovernor>();
+        governor
+            .Setup(g => g.AuthorizeAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ToolInvocationDecision.Allow());
+        ToolGovernanceAccessor.Current = governor.Object;
+
+        var governed = new GovernedAIFunction(inner);
+        await governed.InvokeAsync(new AIFunctionArguments(), CancellationToken.None);
+
+        Assert.True(wasInvoked(), "inner tool must run when governance allows");
+    }
+
+    [Fact]
+    public async Task InvokeAsync_NoAmbientGovernor_PassesThrough()
+    {
+        var (inner, wasInvoked) = MakeInner();
+        ToolGovernanceAccessor.Current = null;
+
+        var governed = new GovernedAIFunction(inner);
+        await governed.InvokeAsync(new AIFunctionArguments(), CancellationToken.None);
+
+        Assert.True(wasInvoked(), "inner tool must run when no governor is ambient");
+    }
+
+    [Fact]
+    public void Decorator_PreservesInnerNameAndSchema()
+    {
+        var (inner, _) = MakeInner();
+        var governed = new GovernedAIFunction(inner);
+
+        Assert.Equal(inner.Name, governed.Name);
+        Assert.Equal(inner.JsonSchema.ToString(), governed.JsonSchema.ToString());
+    }
+}

--- a/src/Content/Tests/Application.AI.Common.Tests/Governance/GoverningToolContextProviderTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Governance/GoverningToolContextProviderTests.cs
@@ -1,0 +1,38 @@
+using Application.AI.Common.Services.Agent;
+using Application.AI.Common.Services.Tools;
+using Microsoft.Extensions.AI;
+using Xunit;
+
+namespace Application.AI.Common.Tests.Governance;
+
+/// <summary>
+/// Verifies the invocation-time wrapping decision used by <see cref="GoverningToolContextProvider"/>
+/// to govern framework/progressive-disclosure tools that bypass the build-time wrap.
+/// </summary>
+public sealed class GoverningToolContextProviderTests
+{
+    private static AIFunction MakeFunction() => AIFunctionFactory.Create(
+        () => "ok", new AIFunctionFactoryOptions { Name = "file_system", Description = "t" });
+
+    [Fact]
+    public void Govern_UnwrappedFunction_WrapsInGovernedAIFunction()
+    {
+        var inner = MakeFunction();
+
+        var result = GoverningToolContextProvider.Govern(inner);
+
+        Assert.IsType<GovernedAIFunction>(result);
+        Assert.NotSame(inner, result);
+        Assert.Equal(inner.Name, result.Name); // schema/name preserved by the decorator
+    }
+
+    [Fact]
+    public void Govern_AlreadyGoverned_ReturnsSameInstance_NoDoubleWrap()
+    {
+        var alreadyGoverned = new GovernedAIFunction(MakeFunction());
+
+        var result = GoverningToolContextProvider.Govern(alreadyGoverned);
+
+        Assert.Same(alreadyGoverned, result);
+    }
+}

--- a/src/Content/Tests/Application.AI.Common.Tests/Governance/ToolInvocationGovernorTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Governance/ToolInvocationGovernorTests.cs
@@ -192,6 +192,27 @@ public sealed class ToolInvocationGovernorTests
     }
 
     [Fact]
+    public async Task Reset_ClearsPriorTurnDecisions_NoCrossTurnDoubleCount()
+    {
+        // The governor is scoped but shared across turns of a conversation (nested MediatR sends
+        // share one DI scope), so each turn must Reset() or the trace accumulates and the merged
+        // conversation trace double-counts. This guards that regression.
+        var governor = Build();
+
+        // Turn 1
+        await governor.AuthorizeAsync(Tool, CancellationToken.None);
+        Assert.Equal(1, governor.GetTrace().ToolInvocationCount);
+
+        // Turn 2 begins
+        governor.Reset();
+        await governor.AuthorizeAsync(Tool, CancellationToken.None);
+
+        var trace = governor.GetTrace();
+        Assert.Equal(1, trace.ToolInvocationCount); // this turn only, not cumulative
+        Assert.Equal(1, trace.AllowedCount);
+    }
+
+    [Fact]
     public async Task AuthorizeAsync_PolicyEngineDenies_Blocks()
     {
         // GovernanceConfig is init-only — build one with the policy layer enabled.

--- a/src/Content/Tests/Application.AI.Common.Tests/Governance/ToolInvocationGovernorTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Governance/ToolInvocationGovernorTests.cs
@@ -1,0 +1,217 @@
+using Application.AI.Common.Interfaces.Agent;
+using Application.AI.Common.Interfaces.Governance;
+using Application.AI.Common.Interfaces.Permissions;
+using Application.AI.Common.Interfaces.Sandbox;
+using Application.AI.Common.Interfaces.Tools;
+using Application.AI.Common.Services.Governance;
+using Domain.AI.Changes;
+using Domain.AI.Governance;
+using Domain.AI.Permissions;
+using Domain.Common;
+using Domain.Common.Config.AI;
+using Domain.Common.Config.AI.Permissions;
+using Domain.Common.Config.AI.Sandbox;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Application.AI.Common.Tests.Governance;
+
+/// <summary>
+/// Verifies the per-invocation tool governor enforces the permission / graded-autonomy /
+/// capability / policy gate on the live tool path and records an accurate governance trace.
+/// </summary>
+public sealed class ToolInvocationGovernorTests
+{
+    private const string Agent = "test-agent";
+    private const string Tool = "file_system";
+
+    private readonly Mock<IAgentExecutionContext> _context = new();
+    private readonly Mock<IToolPermissionService> _permissions = new();
+    private readonly Mock<IAutonomyDecisionEvaluator> _autonomy = new();
+    private readonly Mock<IGovernancePolicyEngine> _policyEngine = new();
+    private readonly Mock<IDenialTracker> _denialTracker = new();
+    private readonly Mock<ICapabilityEnforcer> _capabilities = new();
+    private readonly IToolRiskClassifier _riskClassifier =
+        Mock.Of<IToolRiskClassifier>(c => c.Classify(It.IsAny<string>()) == new ToolRiskProfile(BlastRadius.Low, true));
+
+    private readonly GovernanceConfig _governance = new() { EnforceToolInvocation = true, Enabled = false, EnableAudit = true };
+    private readonly PermissionsConfig _permissionsConfig = new();
+    private readonly SandboxConfig _sandbox = new();
+
+    public ToolInvocationGovernorTests()
+    {
+        _context.Setup(x => x.AgentId).Returns(Agent);
+        _permissions
+            .Setup(x => x.ResolvePermissionAsync(It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<string?>(), It.IsAny<IReadOnlyDictionary<string, object?>?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(PermissionDecision.Allow("allowed by default"));
+        _capabilities
+            .Setup(x => x.EnforceAsync(It.IsAny<string>(), It.IsAny<Domain.AI.Sandbox.ToolCapability>(),
+                It.IsAny<IReadOnlyList<string>?>(), It.IsAny<IReadOnlyList<string>?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Success());
+        _policyEngine.SetupGet(x => x.HasPolicies).Returns(false);
+    }
+
+    private ToolInvocationGovernor Build() => new(
+        _context.Object,
+        _permissions.Object,
+        _riskClassifier,
+        _autonomy.Object,
+        _policyEngine.Object,
+        Mock.Of<IGovernanceAuditService>(),
+        _denialTracker.Object,
+        _capabilities.Object,
+        Mock.Of<IOptionsMonitor<GovernanceConfig>>(m => m.CurrentValue == _governance),
+        Mock.Of<IOptionsMonitor<PermissionsConfig>>(m => m.CurrentValue == _permissionsConfig),
+        Mock.Of<IOptionsMonitor<SandboxConfig>>(m => m.CurrentValue == _sandbox),
+        NullLogger<ToolInvocationGovernor>.Instance);
+
+    [Fact]
+    public async Task AuthorizeAsync_EnforcementDisabled_AllowsAndDoesNotEvaluate()
+    {
+        var governance = new GovernanceConfig { EnforceToolInvocation = false };
+        var governor = new ToolInvocationGovernor(
+            _context.Object, _permissions.Object, _riskClassifier, _autonomy.Object, _policyEngine.Object,
+            Mock.Of<IGovernanceAuditService>(), _denialTracker.Object, _capabilities.Object,
+            Mock.Of<IOptionsMonitor<GovernanceConfig>>(m => m.CurrentValue == governance),
+            Mock.Of<IOptionsMonitor<PermissionsConfig>>(m => m.CurrentValue == _permissionsConfig),
+            Mock.Of<IOptionsMonitor<SandboxConfig>>(m => m.CurrentValue == _sandbox),
+            NullLogger<ToolInvocationGovernor>.Instance);
+
+        var decision = await governor.AuthorizeAsync(Tool, CancellationToken.None);
+
+        Assert.True(decision.IsAllowed);
+        Assert.Same(GovernanceTrace.Empty, governor.GetTrace());
+        _permissions.Verify(x => x.ResolvePermissionAsync(It.IsAny<string>(), It.IsAny<string>(),
+            It.IsAny<string?>(), It.IsAny<IReadOnlyDictionary<string, object?>?>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task AuthorizeAsync_NoAgentId_Allows()
+    {
+        _context.Setup(x => x.AgentId).Returns((string?)null);
+        var governor = Build();
+
+        var decision = await governor.AuthorizeAsync(Tool, CancellationToken.None);
+
+        Assert.True(decision.IsAllowed);
+    }
+
+    [Fact]
+    public async Task AuthorizeAsync_PermissionAllow_AllowsAndRecordsAllowed()
+    {
+        var governor = Build();
+
+        var decision = await governor.AuthorizeAsync(Tool, CancellationToken.None);
+
+        Assert.True(decision.IsAllowed);
+        var trace = governor.GetTrace();
+        Assert.True(trace.EnforcementEnabled);
+        var record = Assert.Single(trace.ToolDecisions);
+        Assert.Equal(ToolDecisionOutcome.Allowed, record.Outcome);
+        Assert.Equal(1, trace.AllowedCount);
+    }
+
+    [Fact]
+    public async Task AuthorizeAsync_PermissionDeny_BlocksAndRecordsDenial()
+    {
+        _permissions
+            .Setup(x => x.ResolvePermissionAsync(It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<string?>(), It.IsAny<IReadOnlyDictionary<string, object?>?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(PermissionDecision.Deny("not allowed for this agent"));
+        var governor = Build();
+
+        var decision = await governor.AuthorizeAsync(Tool, CancellationToken.None);
+
+        Assert.False(decision.IsAllowed);
+        Assert.NotNull(decision.DeniedMessage);
+        var record = Assert.Single(governor.GetTrace().ToolDecisions);
+        Assert.Equal(ToolDecisionOutcome.Denied, record.Outcome);
+        Assert.True(record.Enforced);
+        _denialTracker.Verify(x => x.RecordDenial(Agent, Tool, null), Times.Once);
+    }
+
+    [Fact]
+    public async Task AuthorizeAsync_PermissionAsk_BlocksAndRecordsPendingApproval()
+    {
+        _permissions
+            .Setup(x => x.ResolvePermissionAsync(It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<string?>(), It.IsAny<IReadOnlyDictionary<string, object?>?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(PermissionDecision.Ask("needs human sign-off"));
+        var governor = Build();
+
+        var decision = await governor.AuthorizeAsync(Tool, CancellationToken.None);
+
+        Assert.False(decision.IsAllowed);
+        var trace = governor.GetTrace();
+        var record = Assert.Single(trace.ToolDecisions);
+        Assert.Equal(ToolDecisionOutcome.PendingApproval, record.Outcome);
+        Assert.True(record.RequiredApproval);
+        Assert.True(trace.ApprovalGateEncountered);
+        Assert.False(trace.ApprovalBypassed); // gate enforced — not bypassed
+    }
+
+    [Fact]
+    public async Task AuthorizeAsync_GradedAutonomyTightensAllowToApproval_Blocks()
+    {
+        _permissionsConfig.GradedAutonomy.Enabled = true;
+        _permissionsConfig.DefaultAutonomyLevel = "Supervised";
+        _autonomy
+            .Setup(x => x.Evaluate(It.IsAny<AutonomyLevel>(), It.IsAny<BlastRadius>(),
+                It.IsAny<ChangeTargetKind>(), It.IsAny<bool>(), It.IsAny<string?>()))
+            .Returns(new AutonomyDecisionResult(
+                AutonomyDecision.RequiresApproval, AutonomyLevel.Supervised, BlastRadius.Low,
+                ChangeTargetKind.Unspecified, IsStateChange: true, "Development", null, "tier requires approval"));
+        var governor = Build();
+
+        var decision = await governor.AuthorizeAsync(Tool, CancellationToken.None);
+
+        Assert.False(decision.IsAllowed);
+        var record = Assert.Single(governor.GetTrace().ToolDecisions);
+        Assert.Equal(ToolDecisionOutcome.PendingApproval, record.Outcome);
+        Assert.True(record.RequiredApproval);
+    }
+
+    [Fact]
+    public async Task AuthorizeAsync_CapabilityViolation_Blocks()
+    {
+        _capabilities
+            .Setup(x => x.EnforceAsync(It.IsAny<string>(), It.IsAny<Domain.AI.Sandbox.ToolCapability>(),
+                It.IsAny<IReadOnlyList<string>?>(), It.IsAny<IReadOnlyList<string>?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Fail("filesystem capability not granted"));
+        var governor = Build();
+
+        var decision = await governor.AuthorizeAsync(Tool, CancellationToken.None);
+
+        Assert.False(decision.IsAllowed);
+        var record = Assert.Single(governor.GetTrace().ToolDecisions);
+        Assert.Equal(ToolDecisionOutcome.Denied, record.Outcome);
+        Assert.Contains("capability", record.Reason, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task AuthorizeAsync_PolicyEngineDenies_Blocks()
+    {
+        // GovernanceConfig is init-only — build one with the policy layer enabled.
+        var governance = new GovernanceConfig { EnforceToolInvocation = true, Enabled = true, EnableAudit = true };
+        _policyEngine.SetupGet(x => x.HasPolicies).Returns(true);
+        _policyEngine
+            .Setup(x => x.EvaluateToolCall(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IReadOnlyDictionary<string, object>?>()))
+            .Returns(GovernanceDecision.Denied("rule-7", "default-policy", "blocked by policy"));
+
+        var governor = new ToolInvocationGovernor(
+            _context.Object, _permissions.Object, _riskClassifier, _autonomy.Object, _policyEngine.Object,
+            Mock.Of<IGovernanceAuditService>(), _denialTracker.Object, _capabilities.Object,
+            Mock.Of<IOptionsMonitor<GovernanceConfig>>(m => m.CurrentValue == governance),
+            Mock.Of<IOptionsMonitor<PermissionsConfig>>(m => m.CurrentValue == _permissionsConfig),
+            Mock.Of<IOptionsMonitor<SandboxConfig>>(m => m.CurrentValue == _sandbox),
+            NullLogger<ToolInvocationGovernor>.Instance);
+
+        var decision = await governor.AuthorizeAsync(Tool, CancellationToken.None);
+
+        Assert.False(decision.IsAllowed);
+        Assert.Equal(ToolDecisionOutcome.Denied, Assert.Single(governor.GetTrace().ToolDecisions).Outcome);
+    }
+}

--- a/src/Content/Tests/Application.Core.Tests/CQRS/AgentPipelineIntegrationTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/CQRS/AgentPipelineIntegrationTests.cs
@@ -49,6 +49,13 @@ public class AgentPipelineIntegrationTests
         // Scoped agent execution context — real implementation, not mock
         services.AddScoped<IAgentExecutionContext, AgentExecutionContext>();
 
+        // Tool-invocation governor — not under test here; permissive mock so the handler resolves.
+        var governorMock = new Mock<Application.AI.Common.Interfaces.Governance.IToolInvocationGovernor>();
+        governorMock
+            .Setup(g => g.AuthorizeAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Application.AI.Common.Interfaces.Governance.ToolInvocationDecision.Allow());
+        services.AddScoped(_ => governorMock.Object);
+
         // Agent conversation cache — mock returns testable agents
         services.AddSingleton(cacheMock.Object);
 

--- a/src/Content/Tests/Application.Core.Tests/CQRS/ExecuteAgentTurnCommandHandlerTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/CQRS/ExecuteAgentTurnCommandHandlerTests.cs
@@ -34,6 +34,7 @@ public class ExecuteAgentTurnCommandHandlerTests
 
         _handler = new ExecuteAgentTurnCommandHandler(
             _agentCache.Object,
+            new Mock<Application.AI.Common.Interfaces.Governance.IToolInvocationGovernor>().Object,
             _agentRegistry.Object,
             new Mock<ISkillMetadataRegistry>().Object,
             new Application.AI.Common.Services.Context.ConversationRegistrationTracker(),

--- a/src/Content/Tests/Application.Core.Tests/CQRS/ExecuteAgentTurnCommandHandler_ExtractContentTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/CQRS/ExecuteAgentTurnCommandHandler_ExtractContentTests.cs
@@ -37,6 +37,7 @@ public class ExecuteAgentTurnCommandHandler_ExtractContentTests
 
         _handler = new ExecuteAgentTurnCommandHandler(
             _agentCache.Object,
+            new Mock<Application.AI.Common.Interfaces.Governance.IToolInvocationGovernor>().Object,
             _agentRegistry.Object,
             new Mock<ISkillMetadataRegistry>().Object,
             new Application.AI.Common.Services.Context.ConversationRegistrationTracker(),

--- a/src/Content/Tests/Application.Core.Tests/CQRS/ExecuteAgentTurnCommandHandler_RegistryTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/CQRS/ExecuteAgentTurnCommandHandler_RegistryTests.cs
@@ -32,6 +32,7 @@ public class ExecuteAgentTurnCommandHandler_RegistryTests
 
         _handler = new ExecuteAgentTurnCommandHandler(
             _agentCache.Object,
+            new Mock<Application.AI.Common.Interfaces.Governance.IToolInvocationGovernor>().Object,
             _agentRegistry.Object,
             new Mock<ISkillMetadataRegistry>().Object,
             new Application.AI.Common.Services.Context.ConversationRegistrationTracker(),

--- a/src/Content/Tests/Application.Core.Tests/CQRS/ExecuteAgentTurnCommandHandler_SnapshotTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/CQRS/ExecuteAgentTurnCommandHandler_SnapshotTests.cs
@@ -47,6 +47,7 @@ public class ExecuteAgentTurnCommandHandler_SnapshotTests
 
         return new ExecuteAgentTurnCommandHandler(
             _agentCache.Object,
+            new Mock<Application.AI.Common.Interfaces.Governance.IToolInvocationGovernor>().Object,
             _agentRegistry.Object,
             new Mock<ISkillMetadataRegistry>().Object,
             new Application.AI.Common.Services.Context.ConversationRegistrationTracker(),

--- a/src/Content/Tests/Application.Core.Tests/CQRS/RunOrchestratedTaskCommandHandlerTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/CQRS/RunOrchestratedTaskCommandHandlerTests.cs
@@ -37,6 +37,8 @@ public class RunOrchestratedTaskCommandHandlerTests
         _handler = new RunOrchestratedTaskCommandHandler(
             _agentFactory.Object,
             _scopeFactory.Object,
+            new Application.AI.Common.Services.Agent.AgentExecutionContext(),
+            new Mock<Application.AI.Common.Interfaces.Governance.IToolInvocationGovernor>().Object,
             NullLogger<RunOrchestratedTaskCommandHandler>.Instance);
     }
 

--- a/src/Content/Tests/Application.Core.Tests/CQRS/RunOrchestratedTaskCommandHandler_ExtractContentTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/CQRS/RunOrchestratedTaskCommandHandler_ExtractContentTests.cs
@@ -40,6 +40,8 @@ public class RunOrchestratedTaskCommandHandler_EdgeCaseTests
         _handler = new RunOrchestratedTaskCommandHandler(
             _agentFactory.Object,
             _scopeFactory.Object,
+            new Application.AI.Common.Services.Agent.AgentExecutionContext(),
+            new Mock<Application.AI.Common.Interfaces.Governance.IToolInvocationGovernor>().Object,
             NullLogger<RunOrchestratedTaskCommandHandler>.Instance);
     }
 


### PR DESCRIPTION
## Why

Gap analysis of the *Loop Engineering* article against the harness, then code verification, surfaced a real hole: the harness has a full tool **permission / graded-autonomy / approval / capability** system, but it only ran on MediatR requests implementing `IToolRequest` — and **nothing in production implements `IToolRequest`**. The agent's autonomous tool calls go straight through `AIToolConverter → ITool.ExecuteAsync`, bypassing MediatR. So during a normal conversation turn, that governance machinery was effectively dead code; only content-safety and the per-turn token budget applied.

This is the article's **Action Executor** ("every action passes a risk check before execution") — missing on the live path. This PR wires it in.

## What

- **`IToolInvocationGovernor`** (scoped) — consolidates the permission resolution, graded-autonomy risk gate, capability enforcement, and declarative-policy checks (the same logic the dead `ToolPermissionBehavior` / `GovernancePolicyBehavior` define) and runs them per tool call. Records each decision into a per-turn **`GovernanceTrace`** (the data source for the upcoming governance-behavior eval, PR1b).
- **`GovernedAIFunction`** — a `DelegatingAIFunction` wrapper that runs the gate before the tool; on denial it returns a model-facing error and never calls the tool (schema/name preserved).
- **`ToolGovernanceAccessor`** — AsyncLocal bridge from the scoped governor to cached agents, mirroring the existing `LlmUsageCapture.Current` pattern.
- Defense in depth: tools wrapped at **build time** (`ToolChainBuilder`) and at **invocation time** (`GoverningToolContextProvider`, an `AIContextProvider`) so every source is covered — including framework progressive-disclosure tools that bypass `ToolChainBuilder`. Double-wrap-safe.
- The orchestrator's own planning/synthesis calls are governed too.

**Opt-in and safe by default:** off unless `GovernanceConfig.EnforceToolInvocation = true`. When off, the governor is a pure pass-through — zero behavior change for existing consumers. When on, it is **fail-closed**.

## Security review

A `security-reviewer` pass caught and this PR fixes: orchestrator-path bypass, framework-tool bypass, denial messages leaking operator policy detail to the model (now generic; detail stays in logs/trace), and the no-identity edge now recorded in the trace instead of silently allowed.

## Tests

14 new unit tests (governor decision matrix, decorator block-on-deny / pass-through, wrapping decision). **Full suite green** — all projects, 0 failures (2 pre-existing Azure-creds skips).

## Follow-up (not in this PR)

Consolidate or delete the now-redundant `IToolRequest` MediatR behaviors whose logic this gate copies (replace-don't-deprecate). Next in this series: **PR1b** — a governance-behavior eval that grades the `GovernanceTrace` independently of task outcome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)