### PR TITLE
feat(governance): Purview data-classification seam (DLP PR1)

### DIFF
--- a/.claude/plans/purview-data-classification-dlp.md
+++ b/.claude/plans/purview-data-classification-dlp.md
@@ -1,0 +1,134 @@
+# Purview-Backed Data Classification (Real DLP) — PR Plan
+
+**Status:** Greenlit-pending (Matt to approve). Scoping only — no code until approval.
+**Decisions captured:** (1) Target **both** Purview worlds — Information Protection *and* Data Map. (2) Cover **all** tool/asset types — with an explicit Unknown-asset policy for what Purview cannot classify.
+
+---
+
+## Goal
+
+Add classification-aware Data Loss Prevention to the agent: before a tool reads/writes an external
+asset, resolve that asset's **Purview sensitivity label / classification**, evaluate it against a
+policy, and **allow / redact / block** the call — with audit + OTel metrics, fail-closed.
+
+This is fundamentally different from the existing `IResponseSanitizer` controls
+(`ExfiltrationUrlDetector`, `CredentialRedactor`, …). Those scan *output text content* for dangerous
+*patterns*. This asks *"is the asset I'm about to touch classified, per the org's Purview policy?"* —
+**pre-execution access control**, not post-execution content scrubbing.
+
+## Why it does NOT fit the existing sanitizer seam
+
+`IResponseSanitizer.Sanitize(string content, string? toolName)` is **synchronous** and **content-only**.
+A Purview check is **async** (network) and needs the **asset identity** (file path / blob URI / table
+qualified name) — which lives in the tool's **input arguments**, not its output. Wrong shape. Do not
+extend `IResponseSanitizer`.
+
+## Integration point (confirmed in code)
+
+`IToolInvocationGovernor` is the live, fail-closed, pre-execution tool path, gated by
+`GovernanceConfig.EnforceToolInvocation` (`GovernanceConfig.cs:27`). The classification gate becomes
+one more check the governor runs. This avoids the dead-`IToolRequest`-MediatR trap (the Loop
+Engineering work found `ResponseSanitizationBehavior` never fires on the agent path because nothing
+live implements `IToolRequest`).
+
+---
+
+## The two Purview worlds (both in scope)
+
+| | Information Protection (MIP) | Data Map / Unified Catalog |
+|---|---|---|
+| Labels | Documents/emails/files, incl. **embedded** label on a file | Data-estate **assets** (blob, ADLS, Azure SQL columns) as metadata |
+| API | Microsoft Graph `informationProtection` / `sensitivityLabel` (GA) + MIP file API for embedded labels | Data Map REST (Atlas-based) |
+| Auth | Entra app reg, Graph scope `InformationProtectionPolicy.Read` | Purview account + managed identity, data-reader role |
+| Caveats | `evaluateClassificationResults` computes a label from classification results *you supply* — it does **not** scan a file for you | Labels/classifications are **scan-time metadata** (stale between scans); DB-column labels are **preview** and source-dependent |
+
+## The "all assets" reality (honest coverage matrix)
+
+Purview is **not** omniscient. "All tools" is handled by a resolver + Unknown-policy, not by pretending
+every asset is classifiable.
+
+| Tool / asset | Resolvable label source | Result |
+|---|---|---|
+| Local file (`file_system`) | Embedded MIP label via MIP file API only | Often **Unknown** (most local files carry no embedded label) |
+| Azure Blob / ADLS Gen2 | Data Map (if scanned) | Covered |
+| Azure SQL table/column | Data Map (preview) | Partially covered |
+| PostgreSQL / MySQL / Mongo / most others | — | **Unknown** (no Purview classification support) |
+| Arbitrary MCP server output | — | **Unknown** (no asset identity Purview knows) |
+
+**Design consequence:** an `IAssetReferenceResolver` per tool maps tool input → `AssetReference`,
+routes to the right provider, and everything Purview can't classify falls to a configurable
+**`UnknownAssetAction`** (Audit / Allow / Block). High-security consumers set Block-Unknown.
+
+---
+
+## Architecture (Clean Architecture, follows existing harness conventions)
+
+### Domain.AI / Governance
+- `AssetReference` (record): `AssetType` enum {LocalFile, AzureBlob, AdlsGen2, AzureSql, CosmosDb, Unknown}, `Identifier`, optional `TenantId`
+- `SensitivityLabel` (Id, Name, Priority, protection flags)
+- `DataClassification` (system/custom name, confidence)
+- `AssetLabelResult` (label?, classifications, `LabelSource` {InformationProtection, DataMap, None}, `RetrievedAtUtc`, `IsStale`)
+- `ClassificationPolicyDecision` (Allow / Redact / Block, matched rule, reason)
+- `ClassificationEnforcementMode` enum {Off, Audit, Enforce}
+
+### Application.AI.Common / Interfaces / Governance
+- `IDataClassificationProvider` — `Task<AssetLabelResult> GetLabelAsync(AssetReference, CancellationToken)`
+- `IAssetReferenceResolver` — keyed by tool; `bool TryResolve(toolName, toolInput, out AssetReference)`
+- `IClassificationPolicyEvaluator` — `ClassificationPolicyDecision Evaluate(AssetLabelResult, ctx)`
+
+### Config — `DataClassificationConfig` under `AppConfig:AI:Governance`
+- `Mode` (Off/Audit/Enforce), `UnknownAssetAction`, `CacheTtl`
+- `LabelActions` map (label name → Allow/Redact/Block)
+- per-provider enable flags + auth (managed identity), Purview account endpoint, Graph tenant
+- FluentValidation validator
+
+### Infrastructure.AI.Governance
+- `GraphSensitivityLabelClient : IDataClassificationProvider` (MIP / Graph world)
+- `PurviewDataMapClient : IDataClassificationProvider` (Data Map world)
+- `RoutingDataClassificationProvider` — picks provider by `AssetType`
+- `CachedDataClassificationProvider` — TTL cache decorator (labels change on scan cadence, not per call; caching is mandatory for latency)
+- `NotConfiguredDataClassificationProvider` — fail-fast default (matches harness `NotConfigured*` pattern); `NoOp` variant for `Mode=Off`
+
+---
+
+## PR breakdown (4 PRs, one concern each)
+
+**PR1 — Domain + Application seam + policy (no network). ✅ BUILT (uncommitted, awaiting approval to PR).**
+Domain models, **two** interfaces (`IDataClassificationProvider`, `IClassificationPolicyEvaluator`),
+`DataClassificationConfig` + validator, `DefaultClassificationPolicyEvaluator` (pure),
+`NotConfigured`/`NoOp` providers, DI wiring in both governance paths. 20 unit tests green; solution builds 0 errors.
+- **Change vs plan:** `IAssetReferenceResolver` **deferred to PR4** — its signature depends on the
+  governor's tool-argument shape (unverified), so defining it now risks a throwaway contract.
+- **Architecture note:** the two shared enums (`ClassificationAction`, `ClassificationEnforcementMode`)
+  live in **Domain.Common** (not Domain.AI) to satisfy dependency direction — same as `ThreatLevel`.
+- **Robustness note:** `DefaultClassificationPolicyEvaluator` does explicit case-insensitive label
+  matching rather than trusting the dictionary comparer (IConfiguration binding drops it).
+
+**PR2 — Graph / MIP provider (Information Protection world).**
+`GraphSensitivityLabelClient` (list label defs + resolve a file's embedded label), Entra auth via managed
+identity, `CachedDataClassificationProvider`, DI + config wiring. Tests against mocked Graph HTTP.
+
+**PR3 — Purview Data Map provider (data-estate world).**
+`PurviewDataMapClient` (query asset by qualified name → classifications + labels), `RoutingDataClassificationProvider`
+to select MIP vs Data Map by `AssetType`, managed-identity auth. Tests mocked.
+
+**PR4 — Asset resolvers + governor enforcement (the live path).**
+`IAssetReferenceResolver` impls keyed by tool (file_system → LocalFile; cloud-data tools → blob/sql/adls;
+default → Unknown). Integrate the gate into `IToolInvocationGovernor`: resolve → GetLabel → Evaluate →
+allow/redact/block + audit + OTel metric, honoring `Mode` (Audit observes, Enforce blocks). Integration
+tests proving block/audit/allow on the live governor path.
+
+---
+
+## Risks / caveats (must stay visible to consumers)
+
+1. **Coverage is patchy + partly preview.** DB-column labels: Azure SQL yes (preview); Postgres/MySQL/Mongo no. Document in config + README.
+2. **Labels are stale by design.** Data Map tags reflect the last scan, not live state. `IsStale` surfaced on `AssetLabelResult`.
+3. **Value depends on the consumer's Purview deployment.** Only useful if they run Purview with labels populated. Template ships the seam + reference clients + fail-safe default (consumer wires their tenant).
+4. **Latency.** Each gated tool call → a Graph/Purview round trip. Caching mandatory; default `Mode=Audit` so it observes before it blocks.
+5. **Unknown is the common case for local files + MCP.** `UnknownAssetAction` must be a deliberate, documented choice.
+
+## Open decisions for Matt
+- Default `UnknownAssetAction` for the template (lean **Audit** — observe, don't break consumers).
+- Default `Mode` (lean **Off**, opt-in like `EnforceToolInvocation`).
+- Whether PR2/PR3 order should flip (which world first) — currently MIP first (broadest, file-oriented).

--- a/src/Content/Application/Application.AI.Common/Interfaces/Governance/IClassificationPolicyEvaluator.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Governance/IClassificationPolicyEvaluator.cs
@@ -1,0 +1,25 @@
+using Domain.AI.Governance;
+using Domain.Common.Config.AI.Governance;
+
+namespace Application.AI.Common.Interfaces.Governance;
+
+/// <summary>
+/// Maps a resolved <see cref="AssetLabelResult"/> to a <see cref="ClassificationPolicyDecision"/> using
+/// the operator's <see cref="DataClassificationConfig"/>. Pure and deterministic — no I/O, no model.
+/// </summary>
+/// <remarks>
+/// The evaluator computes the <em>decision</em> (allow / redact / block) from the label and the policy
+/// map. It deliberately does not consider <see cref="DataClassificationConfig.Mode"/>: whether a block
+/// decision is actually enforced or merely observed is the enforcement point's responsibility, keeping
+/// this component a pure projection that is trivial to test.
+/// </remarks>
+public interface IClassificationPolicyEvaluator
+{
+    /// <summary>
+    /// Evaluates the policy against a resolved classification result.
+    /// </summary>
+    /// <param name="result">The label/classifications resolved for the asset.</param>
+    /// <param name="config">The classification policy to apply.</param>
+    /// <returns>The action to take, with the matched rule and a human-readable reason.</returns>
+    ClassificationPolicyDecision Evaluate(AssetLabelResult result, DataClassificationConfig config);
+}

--- a/src/Content/Application/Application.AI.Common/Interfaces/Governance/IDataClassificationProvider.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Governance/IDataClassificationProvider.cs
@@ -1,0 +1,36 @@
+using Domain.AI.Governance;
+
+namespace Application.AI.Common.Interfaces.Governance;
+
+/// <summary>
+/// Resolves the Purview sensitivity classification of an external asset so the classification gate can
+/// decide whether the agent may touch it. The seam between the harness and a Purview backend
+/// (Information Protection or the Data Map).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Implementations call out to Purview and should be wrapped in a caching decorator — labels change on
+/// scan cadence, not per request, and an uncached lookup on every gated tool call would dominate
+/// latency. The default registration is a fail-fast placeholder; real providers are supplied by the
+/// Infrastructure layer.
+/// </para>
+/// <para>
+/// Asynchronous and asset-aware by design — unlike the synchronous, content-only
+/// <see cref="IResponseSanitizer"/>, a classification lookup is a network call keyed on the asset's
+/// identity, not its output text.
+/// </para>
+/// </remarks>
+public interface IDataClassificationProvider
+{
+    /// <summary>
+    /// Resolves the sensitivity label and classifications for an asset.
+    /// </summary>
+    /// <param name="asset">The asset the agent is about to read from or write to.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>
+    /// The resolved label/classifications, or <see cref="AssetLabelResult.Unknown"/> when the asset
+    /// cannot be classified (unknown kind, unscanned, or unlabelled). Implementations should return an
+    /// unknown result rather than throw when Purview simply has nothing for the asset.
+    /// </returns>
+    Task<AssetLabelResult> GetLabelAsync(AssetReference asset, CancellationToken cancellationToken);
+}

--- a/src/Content/Application/Application.AI.Common/Services/Governance/DefaultClassificationPolicyEvaluator.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Governance/DefaultClassificationPolicyEvaluator.cs
@@ -1,0 +1,68 @@
+using Application.AI.Common.Interfaces.Governance;
+using Domain.AI.Governance;
+using Domain.Common.Config.AI.Governance;
+
+namespace Application.AI.Common.Services.Governance;
+
+/// <summary>
+/// Default <see cref="IClassificationPolicyEvaluator"/>: a pure projection of a resolved
+/// <see cref="AssetLabelResult"/> onto a <see cref="ClassificationPolicyDecision"/> using the
+/// label→action map in <see cref="DataClassificationConfig"/>.
+/// </summary>
+/// <remarks>
+/// Decision precedence:
+/// <list type="number">
+/// <item>No sensitivity label resolved → <see cref="DataClassificationConfig.UnknownAssetAction"/>.</item>
+/// <item>Label present and named in <see cref="DataClassificationConfig.LabelActions"/> → that action.</item>
+/// <item>Label present but unmapped → <see cref="DataClassificationConfig.DefaultAction"/>.</item>
+/// </list>
+/// Classifications are carried for audit but do not drive the action in this evaluator — the decision is
+/// sensitivity-label driven.
+/// </remarks>
+public sealed class DefaultClassificationPolicyEvaluator : IClassificationPolicyEvaluator
+{
+    /// <inheritdoc />
+    public ClassificationPolicyDecision Evaluate(AssetLabelResult result, DataClassificationConfig config)
+    {
+        ArgumentNullException.ThrowIfNull(result);
+        ArgumentNullException.ThrowIfNull(config);
+
+        if (result.Label is null)
+        {
+            var reason = result.Source == LabelSource.None
+                ? "No classification could be resolved for the asset; applying the unknown-asset policy."
+                : "Asset was classified but carries no sensitivity label; applying the unknown-asset policy.";
+            return Decide(config.UnknownAssetAction, reason, matchedLabel: null, matchedRule: nameof(config.UnknownAssetAction));
+        }
+
+        var labelName = result.Label.Name;
+
+        // Explicit case-insensitive match rather than relying on the dictionary's comparer: IConfiguration
+        // binding rebuilds LabelActions with the default ordinal comparer, dropping the POCO's
+        // case-insensitive default, so a TryGetValue here would miss "confidential" vs "Confidential".
+        foreach (var (ruleLabel, action) in config.LabelActions)
+        {
+            if (string.Equals(ruleLabel, labelName, StringComparison.OrdinalIgnoreCase))
+            {
+                return Decide(action,
+                    $"Sensitivity label '{labelName}' maps to {action} by policy.",
+                    matchedLabel: labelName,
+                    matchedRule: $"{nameof(config.LabelActions)}[{ruleLabel}]");
+            }
+        }
+
+        return Decide(config.DefaultAction,
+            $"Sensitivity label '{labelName}' has no explicit rule; applying the default action.",
+            matchedLabel: labelName,
+            matchedRule: nameof(config.DefaultAction));
+    }
+
+    private static ClassificationPolicyDecision Decide(
+        ClassificationAction action, string reason, string? matchedLabel, string matchedRule) =>
+        action switch
+        {
+            ClassificationAction.Block => ClassificationPolicyDecision.Block(reason, matchedLabel, matchedRule),
+            ClassificationAction.Redact => ClassificationPolicyDecision.Redact(reason, matchedLabel, matchedRule),
+            _ => ClassificationPolicyDecision.Allow(reason, matchedLabel, matchedRule)
+        };
+}

--- a/src/Content/Application/Application.AI.Common/Services/Governance/NoOpDataClassificationProvider.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Governance/NoOpDataClassificationProvider.cs
@@ -1,0 +1,29 @@
+using Application.AI.Common.Interfaces.Governance;
+using Domain.AI.Governance;
+
+namespace Application.AI.Common.Services.Governance;
+
+/// <summary>
+/// No-op <see cref="IDataClassificationProvider"/> that classifies every asset as
+/// <see cref="AssetLabelResult.Unknown"/>. Registered when governance is disabled so the seam resolves
+/// without throwing and without contacting Purview.
+/// </summary>
+/// <remarks>
+/// Distinct from <see cref="NotConfiguredDataClassificationProvider"/>: that one throws to signal a
+/// misconfiguration (gate on, provider missing); this one returns a benign unknown result so a
+/// governance-disabled deployment can resolve the dependency harmlessly. Time is taken from the injected
+/// <see cref="TimeProvider"/> so results are deterministic under test.
+/// </remarks>
+public sealed class NoOpDataClassificationProvider : IDataClassificationProvider
+{
+    private readonly TimeProvider _timeProvider;
+
+    /// <summary>Initializes a new instance of the <see cref="NoOpDataClassificationProvider"/> class.</summary>
+    /// <param name="timeProvider">Clock used to stamp the unknown result.</param>
+    public NoOpDataClassificationProvider(TimeProvider timeProvider) =>
+        _timeProvider = timeProvider;
+
+    /// <inheritdoc />
+    public Task<AssetLabelResult> GetLabelAsync(AssetReference asset, CancellationToken cancellationToken) =>
+        Task.FromResult(AssetLabelResult.Unknown(asset, _timeProvider.GetUtcNow()));
+}

--- a/src/Content/Application/Application.AI.Common/Services/Governance/NotConfiguredDataClassificationProvider.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Governance/NotConfiguredDataClassificationProvider.cs
@@ -1,0 +1,28 @@
+using Application.AI.Common.Interfaces.Governance;
+using Domain.AI.Governance;
+
+namespace Application.AI.Common.Services.Governance;
+
+/// <summary>
+/// Fail-fast placeholder <see cref="IDataClassificationProvider"/>. Throws with explicit guidance when
+/// invoked — the classification seam ships with this default so DI can resolve the provider, but a real
+/// Purview-backed implementation is wiring the consumer owns.
+/// </summary>
+/// <remarks>
+/// Registered as the default when governance is enabled. It is only ever invoked when classification
+/// enforcement is switched on (<c>DataClassificationConfig.Mode</c> is not <c>Off</c>) yet no real
+/// provider has been registered — exactly the "you enabled the gate but forgot to wire Purview" case,
+/// where a loud failure is correct. With the default <c>Mode = Off</c> the gate never consults the
+/// provider, so this never throws. Replace via a replacement registration (e.g. the Graph or Data Map
+/// client in Infrastructure) before enabling classification.
+/// </remarks>
+public sealed class NotConfiguredDataClassificationProvider : IDataClassificationProvider
+{
+    /// <inheritdoc />
+    public Task<AssetLabelResult> GetLabelAsync(AssetReference asset, CancellationToken cancellationToken) =>
+        throw new InvalidOperationException(
+            "Data classification is enabled (DataClassificationConfig.Mode is not Off) but no " +
+            "IDataClassificationProvider is configured. Register a Purview-backed provider " +
+            "(e.g. GraphSensitivityLabelClient or PurviewDataMapClient in Infrastructure.AI.Governance) " +
+            "before enabling classification enforcement.");
+}

--- a/src/Content/Application/Application.Core/Validation/DataClassificationConfigValidator.cs
+++ b/src/Content/Application/Application.Core/Validation/DataClassificationConfigValidator.cs
@@ -1,0 +1,35 @@
+using Domain.Common.Config.AI.Governance;
+using FluentValidation;
+
+namespace Application.Core.Validation;
+
+/// <summary>
+/// Validates <see cref="DataClassificationConfig"/>. All rules are conditional on classification being
+/// enabled (<see cref="DataClassificationConfig.Mode"/> not <see cref="ClassificationEnforcementMode.Off"/>) —
+/// the gate is off by default and a disabled section imposes no constraints, so the template runs out of
+/// the box. When enabled the rules ensure the label→action map is coherent: a blank label key can never
+/// match a real Purview label and signals a config typo that would silently never fire.
+/// </summary>
+/// <remarks>
+/// Auto-discovered via <c>AddValidatorsFromAssembly</c> on the Application.Core assembly — no manual
+/// registration required.
+/// </remarks>
+public sealed class DataClassificationConfigValidator : AbstractValidator<DataClassificationConfig>
+{
+    /// <summary>Initializes a new instance of the <see cref="DataClassificationConfigValidator"/> class.</summary>
+    public DataClassificationConfigValidator()
+    {
+        When(x => x.Mode != ClassificationEnforcementMode.Off, () =>
+        {
+            RuleFor(x => x.LabelActions)
+                .NotNull()
+                .WithMessage("LabelActions must not be null when classification is enabled.");
+
+            RuleForEach(x => x.LabelActions)
+                .Must(kvp => !string.IsNullOrWhiteSpace(kvp.Key))
+                .WithMessage(
+                    "LabelActions contains a blank label name. A blank key can never match a Purview " +
+                    "sensitivity label, so the rule would never fire — remove it or supply the label name.");
+        });
+    }
+}

--- a/src/Content/Domain/Domain.AI/Governance/AssetLabelResult.cs
+++ b/src/Content/Domain/Domain.AI/Governance/AssetLabelResult.cs
@@ -1,0 +1,53 @@
+namespace Domain.AI.Governance;
+
+/// <summary>
+/// The outcome of resolving an asset's sensitivity from Purview: the label and classifications found
+/// (if any), which surface produced them, and how fresh they are. Immutable value object returned by
+/// <c>IDataClassificationProvider</c>.
+/// </summary>
+/// <param name="Asset">The asset that was looked up.</param>
+/// <param name="Label">
+/// The resolved sensitivity label, or null when none applies (unlabelled or unknown asset).
+/// </param>
+/// <param name="Classifications">
+/// The classification findings on the asset. Empty when none were found or the asset is unknown.
+/// </param>
+/// <param name="Source">Which Purview surface produced this result, or <see cref="LabelSource.None"/>.</param>
+/// <param name="RetrievedAtUtc">
+/// When this result was produced. For Data Map results this reflects the lookup time, not the
+/// underlying scan time — see <paramref name="IsStale"/>.
+/// </param>
+/// <param name="IsStale">
+/// Whether the classification metadata is known to be stale. Purview Data Map labels are applied by
+/// scheduled scans, so they reflect the last scan rather than live state; a provider sets this when it
+/// can determine the backing scan is older than the freshness window. Surfaced so policies and audit
+/// can distinguish "verified clean" from "no recent scan".
+/// </param>
+public sealed record AssetLabelResult(
+    AssetReference Asset,
+    SensitivityLabel? Label,
+    IReadOnlyList<DataClassification> Classifications,
+    LabelSource Source,
+    DateTimeOffset RetrievedAtUtc,
+    bool IsStale = false)
+{
+    /// <summary>
+    /// The classification findings on the asset, never null. A null argument from a provider or binder
+    /// is normalized to an empty list so <see cref="HasClassification"/> and downstream readers are safe.
+    /// </summary>
+    public IReadOnlyList<DataClassification> Classifications { get; init; } = Classifications ?? [];
+
+    /// <summary>
+    /// Whether any classification signal (a label or at least one classification) was resolved.
+    /// </summary>
+    public bool HasClassification => Label is not null || Classifications.Count > 0;
+
+    /// <summary>
+    /// Creates a result for an asset Purview could not classify (unknown kind, unscanned, or
+    /// unlabelled). Carries <see cref="LabelSource.None"/> and no label.
+    /// </summary>
+    /// <param name="asset">The asset that was looked up.</param>
+    /// <param name="retrievedAtUtc">When the lookup occurred.</param>
+    public static AssetLabelResult Unknown(AssetReference asset, DateTimeOffset retrievedAtUtc) =>
+        new(asset, null, [], LabelSource.None, retrievedAtUtc);
+}

--- a/src/Content/Domain/Domain.AI/Governance/AssetReference.cs
+++ b/src/Content/Domain/Domain.AI/Governance/AssetReference.cs
@@ -1,0 +1,32 @@
+namespace Domain.AI.Governance;
+
+/// <summary>
+/// Identifies the external asset a tool invocation reads from or writes to, so its sensitivity label
+/// can be resolved before the tool runs. This is the <em>subject</em> of a data-classification lookup.
+/// </summary>
+/// <param name="Type">
+/// The kind of asset, which selects the classification backend (or <see cref="AssetType.Unknown"/>
+/// when none can answer).
+/// </param>
+/// <param name="Identifier">
+/// The provider-specific identity of the asset — a local file path, a blob/ADLS URI, or a Data Map
+/// fully-qualified name. Opaque to the policy layer; meaningful only to the resolving provider.
+/// </param>
+/// <param name="TenantId">
+/// Optional Entra/Purview tenant the asset belongs to, when the deployment spans more than one tenant.
+/// Null uses the provider's configured default tenant.
+/// </param>
+public sealed record AssetReference(
+    AssetType Type,
+    string Identifier,
+    string? TenantId = null)
+{
+    /// <summary>
+    /// Creates an unidentifiable reference — used when a tool's target cannot be mapped to a known
+    /// asset kind (arbitrary MCP output, an unsupported data source). Resolves to the configured
+    /// unknown-asset policy rather than a real lookup.
+    /// </summary>
+    /// <param name="identifier">A best-effort identity for audit/trace purposes (may be empty).</param>
+    public static AssetReference Unknown(string identifier = "") =>
+        new(AssetType.Unknown, identifier);
+}

--- a/src/Content/Domain/Domain.AI/Governance/AssetType.cs
+++ b/src/Content/Domain/Domain.AI/Governance/AssetType.cs
@@ -1,0 +1,43 @@
+namespace Domain.AI.Governance;
+
+/// <summary>
+/// The kind of external asset a tool invocation touches, used to route a
+/// <see cref="AssetReference"/> to the data-classification provider that can resolve its
+/// sensitivity label.
+/// </summary>
+/// <remarks>
+/// Purview is not omniscient: only a subset of asset kinds can be classified, and the rest resolve to
+/// <see cref="Unknown"/> and fall to the configured unknown-asset policy. The classification provider
+/// uses this enum to decide which backend (Microsoft Purview Information Protection vs the Purview Data
+/// Map) — if any — can answer for the asset.
+/// </remarks>
+public enum AssetType
+{
+    /// <summary>
+    /// The asset could not be identified, or is a kind Purview cannot classify (a local file with no
+    /// embedded label, an unsupported database engine, arbitrary MCP server output). Resolves to the
+    /// configured unknown-asset action rather than a real label lookup.
+    /// </summary>
+    Unknown,
+
+    /// <summary>
+    /// A file on the local filesystem. Classifiable only via an embedded Microsoft Purview Information
+    /// Protection label read from the file itself; the Purview Data Map does not track local files.
+    /// </summary>
+    LocalFile,
+
+    /// <summary>An Azure Blob Storage blob, classifiable via the Purview Data Map when scanned.</summary>
+    AzureBlob,
+
+    /// <summary>An Azure Data Lake Storage Gen2 path, classifiable via the Purview Data Map when scanned.</summary>
+    AdlsGen2,
+
+    /// <summary>
+    /// An Azure SQL table or column. Column-level sensitivity labels are available through the Purview
+    /// Data Map in preview, and are source-dependent.
+    /// </summary>
+    AzureSql,
+
+    /// <summary>An Azure Cosmos DB container or item, classifiable via the Purview Data Map when scanned.</summary>
+    CosmosDb
+}

--- a/src/Content/Domain/Domain.AI/Governance/ClassificationPolicyDecision.cs
+++ b/src/Content/Domain/Domain.AI/Governance/ClassificationPolicyDecision.cs
@@ -1,0 +1,37 @@
+using Domain.Common.Config.AI.Governance;
+
+namespace Domain.AI.Governance;
+
+/// <summary>
+/// The outcome of evaluating a data-classification policy against an
+/// <see cref="AssetLabelResult"/>: the action to take and why. Immutable value object returned by
+/// <c>IClassificationPolicyEvaluator</c>.
+/// </summary>
+/// <param name="Action">The enforcement action the policy assigned.</param>
+/// <param name="Reason">A human-readable explanation, suitable for audit logs and model-facing denials.</param>
+/// <param name="MatchedLabel">
+/// The sensitivity label that drove the decision, or null when the decision came from the unknown-asset
+/// rule (no label resolved).
+/// </param>
+/// <param name="MatchedRule">
+/// The policy rule that produced the action — for example <c>LabelActions[Confidential]</c>,
+/// <c>DefaultAction</c>, or <c>UnknownAssetAction</c> — so audit can trace which rule fired.
+/// </param>
+public sealed record ClassificationPolicyDecision(
+    ClassificationAction Action,
+    string Reason,
+    string? MatchedLabel = null,
+    string? MatchedRule = null)
+{
+    /// <summary>Creates an allow decision.</summary>
+    public static ClassificationPolicyDecision Allow(string reason, string? matchedLabel = null, string? matchedRule = null) =>
+        new(ClassificationAction.Allow, reason, matchedLabel, matchedRule);
+
+    /// <summary>Creates a redact decision.</summary>
+    public static ClassificationPolicyDecision Redact(string reason, string? matchedLabel = null, string? matchedRule = null) =>
+        new(ClassificationAction.Redact, reason, matchedLabel, matchedRule);
+
+    /// <summary>Creates a block decision.</summary>
+    public static ClassificationPolicyDecision Block(string reason, string? matchedLabel = null, string? matchedRule = null) =>
+        new(ClassificationAction.Block, reason, matchedLabel, matchedRule);
+}

--- a/src/Content/Domain/Domain.AI/Governance/DataClassification.cs
+++ b/src/Content/Domain/Domain.AI/Governance/DataClassification.cs
@@ -1,0 +1,20 @@
+namespace Domain.AI.Governance;
+
+/// <summary>
+/// A single classification finding on an asset — a logical category of sensitive data Purview detected
+/// (for example "Credit Card Number" or "Person's Name"). Distinct from a
+/// <see cref="SensitivityLabel"/>: classifications describe <em>what kinds of data</em> an asset
+/// contains, while a label is the overall sensitivity tag (often derived from classifications).
+/// </summary>
+/// <param name="Name">The classification name, system-defined or custom.</param>
+/// <param name="Confidence">
+/// The provider's confidence in the finding, 0.0 to 1.0. Data Map scans report a 0–100 confidence which
+/// callers normalize into this range.
+/// </param>
+/// <param name="IsCustom">
+/// Whether this is a custom (organization-defined) classification rather than a Microsoft built-in.
+/// </param>
+public sealed record DataClassification(
+    string Name,
+    double Confidence = 1.0,
+    bool IsCustom = false);

--- a/src/Content/Domain/Domain.AI/Governance/LabelSource.cs
+++ b/src/Content/Domain/Domain.AI/Governance/LabelSource.cs
@@ -1,0 +1,26 @@
+namespace Domain.AI.Governance;
+
+/// <summary>
+/// Identifies which Purview surface produced an <see cref="AssetLabelResult"/>, or that no
+/// classification was available.
+/// </summary>
+public enum LabelSource
+{
+    /// <summary>
+    /// No classification was resolved — the asset is unknown to Purview, unscanned, or of a kind that
+    /// cannot be classified. Consumers apply the configured unknown-asset policy.
+    /// </summary>
+    None,
+
+    /// <summary>
+    /// The label came from Microsoft Purview Information Protection (Microsoft Graph
+    /// <c>informationProtection</c> / an embedded file label) — the document/file labelling world.
+    /// </summary>
+    InformationProtection,
+
+    /// <summary>
+    /// The label/classification came from the Microsoft Purview Data Map — the data-estate world (blob,
+    /// ADLS, database columns). These are scan-time metadata and may be stale between scans.
+    /// </summary>
+    DataMap
+}

--- a/src/Content/Domain/Domain.AI/Governance/SensitivityLabel.cs
+++ b/src/Content/Domain/Domain.AI/Governance/SensitivityLabel.cs
@@ -1,0 +1,13 @@
+namespace Domain.AI.Governance;
+
+/// <summary>
+/// A Microsoft Purview sensitivity label resolved for an asset (for example "Confidential" or "Highly
+/// Confidential\Internal"). Immutable value object.
+/// </summary>
+/// <param name="Id">The label's stable GUID, as defined in the organization's Purview label taxonomy.</param>
+/// <param name="Name">
+/// The human-readable label name used to match against the policy's label→action map.
+/// </param>
+public sealed record SensitivityLabel(
+    string Id,
+    string Name);

--- a/src/Content/Domain/Domain.Common/Config/AI/Governance/ClassificationAction.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/Governance/ClassificationAction.cs
@@ -1,0 +1,30 @@
+namespace Domain.Common.Config.AI.Governance;
+
+/// <summary>
+/// The enforcement action a data-classification policy assigns to a tool invocation based on the
+/// resolved sensitivity of the asset it touches.
+/// </summary>
+/// <remarks>
+/// Lives in Domain.Common (alongside <c>ThreatLevel</c>) because it is shared by both the
+/// configuration layer (<see cref="DataClassificationConfig"/>) and the Domain.AI policy decision.
+/// This is the <em>decision</em> the policy computes; whether a <see cref="Block"/> or
+/// <see cref="Redact"/> decision is actually applied (versus merely observed and logged) is governed
+/// separately by <see cref="ClassificationEnforcementMode"/> at the enforcement point.
+/// </remarks>
+public enum ClassificationAction
+{
+    /// <summary>Permit the tool invocation; the asset's sensitivity does not warrant intervention.</summary>
+    Allow,
+
+    /// <summary>
+    /// Permit the invocation but redact the sensitive content from the result before it re-enters the
+    /// model context. Used for labels that are restricted but not prohibited.
+    /// </summary>
+    Redact,
+
+    /// <summary>
+    /// Deny the invocation; the asset's sensitivity prohibits the agent from accessing it. The model
+    /// receives a denial message in place of the tool result.
+    /// </summary>
+    Block
+}

--- a/src/Content/Domain/Domain.Common/Config/AI/Governance/ClassificationEnforcementMode.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/Governance/ClassificationEnforcementMode.cs
@@ -1,0 +1,32 @@
+namespace Domain.Common.Config.AI.Governance;
+
+/// <summary>
+/// Governs how strongly resolved data-classification decisions are applied on the agent's live
+/// tool-call path. Separate from the per-asset <see cref="ClassificationAction"/>: the action is
+/// <em>what</em> the policy decided, the mode is <em>how forcefully</em> that decision is enforced.
+/// </summary>
+/// <remarks>
+/// Defaults to <see cref="Off"/> so cloning the template never requires a configured Purview tenant —
+/// classification enforcement is strictly opt-in, mirroring <c>GovernanceConfig.EnforceToolInvocation</c>.
+/// </remarks>
+public enum ClassificationEnforcementMode
+{
+    /// <summary>
+    /// Classification is disabled. No provider is consulted and no per-invocation cost is incurred.
+    /// The default.
+    /// </summary>
+    Off,
+
+    /// <summary>
+    /// Classification runs and every decision is recorded (audit log + metrics), but execution is never
+    /// blocked or redacted — the gate observes only. The safe first step for a new deployment: it
+    /// surfaces what <em>would</em> be blocked without breaking the agent.
+    /// </summary>
+    Audit,
+
+    /// <summary>
+    /// Classification runs and decisions are enforced — a <see cref="ClassificationAction.Block"/>
+    /// denies the tool call and a <see cref="ClassificationAction.Redact"/> strips the content.
+    /// </summary>
+    Enforce
+}

--- a/src/Content/Domain/Domain.Common/Config/AI/Governance/DataClassificationConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/Governance/DataClassificationConfig.cs
@@ -1,0 +1,52 @@
+namespace Domain.Common.Config.AI.Governance;
+
+/// <summary>
+/// Configuration for Purview-backed data classification (classification-aware DLP) on the agent's live
+/// tool-call path. Bound from <c>AppConfig:AI:Governance:DataClassification</c> in appsettings.json.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Before a tool reads or writes an external asset, the classification gate resolves the asset's
+/// Purview sensitivity label and applies the policy expressed here, mapping a label to an
+/// <see cref="ClassificationAction"/>. Unlike the content-pattern sanitizers, this is access control
+/// driven by the organization's classification metadata, not by scanning output text.
+/// </para>
+/// <para>
+/// <strong>Opt-in.</strong> <see cref="Mode"/> defaults to <see cref="ClassificationEnforcementMode.Off"/>,
+/// so a freshly cloned template requires no Purview tenant and incurs no per-invocation cost. The
+/// recommended first step for a real deployment is <see cref="ClassificationEnforcementMode.Audit"/>,
+/// which records what would be blocked without breaking the agent.
+/// </para>
+/// </remarks>
+public sealed class DataClassificationConfig
+{
+    /// <summary>
+    /// How strongly classification decisions are enforced. <see cref="ClassificationEnforcementMode.Off"/>
+    /// (the default) disables the gate entirely.
+    /// </summary>
+    public ClassificationEnforcementMode Mode { get; init; } = ClassificationEnforcementMode.Off;
+
+    /// <summary>
+    /// Maps a Purview sensitivity-label name (case-insensitive) to the action taken when an asset
+    /// carries that label. Labels absent from this map fall to <see cref="DefaultAction"/>. Empty by
+    /// default, meaning every resolved label uses <see cref="DefaultAction"/> until the operator
+    /// authors rules.
+    /// </summary>
+    public Dictionary<string, ClassificationAction> LabelActions { get; init; } = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// The action applied when an asset carries a resolved label that has no explicit entry in
+    /// <see cref="LabelActions"/>. Defaults to <see cref="ClassificationAction.Allow"/> so an
+    /// unmapped-but-known label does not block the agent until the operator opts in to stricter rules.
+    /// </summary>
+    public ClassificationAction DefaultAction { get; init; } = ClassificationAction.Allow;
+
+    /// <summary>
+    /// The action applied when no classification could be resolved — an unknown asset kind (local file
+    /// with no embedded label, arbitrary MCP output) or one Purview has not scanned. Defaults to
+    /// <see cref="ClassificationAction.Allow"/> (observe, do not break), matching the template's
+    /// opt-in posture. High-security deployments set this to <see cref="ClassificationAction.Block"/>
+    /// for fail-closed handling of anything Purview cannot vouch for.
+    /// </summary>
+    public ClassificationAction UnknownAssetAction { get; init; } = ClassificationAction.Allow;
+}

--- a/src/Content/Domain/Domain.Common/Config/AI/GovernanceConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/GovernanceConfig.cs
@@ -74,4 +74,13 @@ public sealed class GovernanceConfig
     /// "may this tool run?".
     /// </summary>
     public ProgressGuardConfig ProgressGuard { get; init; } = new();
+
+    /// <summary>
+    /// Purview-backed data classification (classification-aware DLP) for the agent's live tool-call
+    /// path. Opt-in via <see cref="Governance.DataClassificationConfig.Mode"/>; off by default. Resolves
+    /// the Purview sensitivity label of the asset a tool is about to touch and allows / redacts / blocks
+    /// the call accordingly — access control driven by classification metadata, distinct from the
+    /// content-pattern response sanitizers.
+    /// </summary>
+    public DataClassificationConfig DataClassification { get; init; } = new();
 }

--- a/src/Content/Infrastructure/Infrastructure.AI.Governance/DependencyInjection.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.Governance/DependencyInjection.cs
@@ -3,6 +3,7 @@ using AgentGovernance.Audit;
 using AgentGovernance.Policy;
 using AgentGovernance.Security;
 using Application.AI.Common.Interfaces.Governance;
+using Application.AI.Common.Services.Governance;
 using Domain.Common.Config.AI;
 using Infrastructure.AI.Governance.Adapters;
 using Microsoft.Extensions.DependencyInjection;
@@ -58,6 +59,12 @@ public static class DependencyInjection
         services.AddSingleton<IResponseSanitizer, ExfiltrationUrlDetector>();
         services.AddSingleton<ICompositeResponseSanitizer, CompositeResponseSanitizer>();
 
+        // Data-classification seam. The policy evaluator is pure; the provider default is fail-fast and
+        // is only consulted when DataClassificationConfig.Mode is not Off — a real Purview-backed
+        // provider (Graph / Data Map) replaces it before classification enforcement is switched on.
+        services.AddSingleton<IClassificationPolicyEvaluator, DefaultClassificationPolicyEvaluator>();
+        services.AddSingleton<IDataClassificationProvider, NotConfiguredDataClassificationProvider>();
+
         return services;
     }
 
@@ -73,6 +80,12 @@ public static class DependencyInjection
         services.AddSingleton<IGovernanceAuditService, NoOpAuditService>();
         services.AddSingleton<IMcpSecurityScanner, NoOpMcpScanner>();
         services.AddSingleton<ICompositeResponseSanitizer, NoOpResponseSanitizer>();
+
+        // Data-classification seam (governance disabled): the pure evaluator plus a benign no-op
+        // provider that classifies every asset as Unknown, so the dependency resolves without
+        // contacting Purview or throwing.
+        services.AddSingleton<IClassificationPolicyEvaluator, DefaultClassificationPolicyEvaluator>();
+        services.AddSingleton<IDataClassificationProvider, NoOpDataClassificationProvider>();
 
         return services;
     }

--- a/src/Content/Tests/Application.AI.Common.Tests/Governance/DataClassificationProviderDefaultsTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Governance/DataClassificationProviderDefaultsTests.cs
@@ -1,0 +1,49 @@
+using Application.AI.Common.Services.Governance;
+using Domain.AI.Governance;
+using FluentAssertions;
+using Xunit;
+
+namespace Application.AI.Common.Tests.Governance;
+
+/// <summary>
+/// Tests for the two fail-safe <c>IDataClassificationProvider</c> defaults: the no-op provider that
+/// classifies everything as Unknown (governance-disabled path), and the not-configured provider that
+/// throws to flag a "gate enabled, Purview not wired" misconfiguration.
+/// </summary>
+public class DataClassificationProviderDefaultsTests
+{
+    private static readonly AssetReference SampleAsset = new(AssetType.LocalFile, "/tmp/x.txt");
+
+    [Fact]
+    public async Task NoOp_ReturnsUnknownStampedWithProviderClock()
+    {
+        var now = new DateTimeOffset(2026, 6, 25, 9, 0, 0, TimeSpan.Zero);
+        var provider = new NoOpDataClassificationProvider(new FixedTimeProvider(now));
+
+        var result = await provider.GetLabelAsync(SampleAsset, CancellationToken.None);
+
+        result.Source.Should().Be(LabelSource.None);
+        result.HasClassification.Should().BeFalse();
+        result.RetrievedAtUtc.Should().Be(now);
+    }
+
+    [Fact]
+    public async Task NotConfigured_ThrowsWithGuidance()
+    {
+        var provider = new NotConfiguredDataClassificationProvider();
+
+        var act = () => provider.GetLabelAsync(SampleAsset, CancellationToken.None);
+
+        (await act.Should().ThrowAsync<InvalidOperationException>())
+            .Which.Message.Should().Contain("IDataClassificationProvider");
+    }
+
+    /// <summary>
+    /// Minimal <see cref="TimeProvider"/> shim returning a fixed UTC time. Mirrors the project
+    /// convention of a local shim rather than referencing Microsoft.Extensions.TimeProvider.Testing.
+    /// </summary>
+    private sealed class FixedTimeProvider(DateTimeOffset now) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => now;
+    }
+}

--- a/src/Content/Tests/Application.AI.Common.Tests/Governance/DefaultClassificationPolicyEvaluatorTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Governance/DefaultClassificationPolicyEvaluatorTests.cs
@@ -1,0 +1,123 @@
+using Application.AI.Common.Services.Governance;
+using Domain.AI.Governance;
+using Domain.Common.Config.AI.Governance;
+using FluentAssertions;
+using Xunit;
+
+namespace Application.AI.Common.Tests.Governance;
+
+/// <summary>
+/// Tests for <see cref="DefaultClassificationPolicyEvaluator"/> — the pure projection of a resolved
+/// <see cref="AssetLabelResult"/> onto a <see cref="ClassificationPolicyDecision"/>. Covers the three
+/// precedence branches (unknown → label-mapped → default), case-insensitive label matching, action
+/// fidelity, and rule/label provenance for audit.
+/// </summary>
+public class DefaultClassificationPolicyEvaluatorTests
+{
+    private static readonly DateTimeOffset Now = new(2026, 6, 25, 12, 0, 0, TimeSpan.Zero);
+    private readonly DefaultClassificationPolicyEvaluator _evaluator = new();
+
+    private static AssetReference Asset(AssetType type = AssetType.AzureBlob) =>
+        new(type, "https://acct.blob.core.windows.net/c/secret.csv");
+
+    private static AssetLabelResult Labelled(string labelName, LabelSource source = LabelSource.DataMap) =>
+        new(Asset(), new SensitivityLabel("id-1", labelName), [], source, Now);
+
+    [Fact]
+    public void Evaluate_NoLabelUnknownSource_AppliesUnknownAssetAction()
+    {
+        var result = AssetLabelResult.Unknown(Asset(AssetType.Unknown), Now);
+        var config = new DataClassificationConfig { UnknownAssetAction = ClassificationAction.Block };
+
+        var decision = _evaluator.Evaluate(result, config);
+
+        decision.Action.Should().Be(ClassificationAction.Block);
+        decision.MatchedLabel.Should().BeNull();
+        decision.MatchedRule.Should().Be(nameof(config.UnknownAssetAction));
+    }
+
+    [Fact]
+    public void Evaluate_NoLabelUnknownSource_DefaultUnknownActionAllows()
+    {
+        // The template default: unknown assets are allowed (observe, don't break the agent).
+        var result = AssetLabelResult.Unknown(Asset(AssetType.LocalFile), Now);
+
+        var decision = _evaluator.Evaluate(result, new DataClassificationConfig());
+
+        decision.Action.Should().Be(ClassificationAction.Allow);
+    }
+
+    [Fact]
+    public void Evaluate_ClassifiedButNoLabel_AppliesUnknownAssetActionWithDistinctReason()
+    {
+        // Source is DataMap and classifications exist, but no overall sensitivity label was assigned.
+        var result = new AssetLabelResult(
+            Asset(), Label: null, [new DataClassification("Credit Card Number", 0.9)], LabelSource.DataMap, Now);
+        var config = new DataClassificationConfig { UnknownAssetAction = ClassificationAction.Redact };
+
+        var decision = _evaluator.Evaluate(result, config);
+
+        decision.Action.Should().Be(ClassificationAction.Redact);
+        decision.MatchedRule.Should().Be(nameof(config.UnknownAssetAction));
+        decision.Reason.Should().Contain("no sensitivity label");
+    }
+
+    [Fact]
+    public void Evaluate_MappedLabel_AppliesMappedActionAndRecordsRule()
+    {
+        var config = new DataClassificationConfig
+        {
+            Mode = ClassificationEnforcementMode.Enforce,
+            LabelActions = new() { ["Confidential"] = ClassificationAction.Block },
+        };
+
+        var decision = _evaluator.Evaluate(Labelled("Confidential"), config);
+
+        decision.Action.Should().Be(ClassificationAction.Block);
+        decision.MatchedLabel.Should().Be("Confidential");
+        decision.MatchedRule.Should().Be("LabelActions[Confidential]");
+    }
+
+    [Fact]
+    public void Evaluate_UnmappedLabel_AppliesDefaultAction()
+    {
+        var config = new DataClassificationConfig
+        {
+            DefaultAction = ClassificationAction.Redact,
+            LabelActions = new() { ["Confidential"] = ClassificationAction.Block },
+        };
+
+        var decision = _evaluator.Evaluate(Labelled("Public"), config);
+
+        decision.Action.Should().Be(ClassificationAction.Redact);
+        decision.MatchedLabel.Should().Be("Public");
+        decision.MatchedRule.Should().Be(nameof(config.DefaultAction));
+    }
+
+    [Theory]
+    [InlineData("confidential")]
+    [InlineData("CONFIDENTIAL")]
+    [InlineData("Confidential")]
+    public void Evaluate_LabelMatch_IsCaseInsensitive(string ruleKey)
+    {
+        // Guards the IConfiguration-binding gotcha: matching must not depend on the dictionary comparer.
+        var config = new DataClassificationConfig
+        {
+            LabelActions = new(StringComparer.Ordinal) { [ruleKey] = ClassificationAction.Block },
+        };
+
+        var decision = _evaluator.Evaluate(Labelled("Confidential"), config);
+
+        decision.Action.Should().Be(ClassificationAction.Block);
+    }
+
+    [Fact]
+    public void Evaluate_NullArguments_Throw()
+    {
+        var config = new DataClassificationConfig();
+
+        _evaluator.Invoking(e => e.Evaluate(null!, config)).Should().Throw<ArgumentNullException>();
+        _evaluator.Invoking(e => e.Evaluate(AssetLabelResult.Unknown(Asset(), Now), null!))
+            .Should().Throw<ArgumentNullException>();
+    }
+}

--- a/src/Content/Tests/Application.Core.Tests/Validation/DataClassificationConfigValidatorTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/Validation/DataClassificationConfigValidatorTests.cs
@@ -1,0 +1,87 @@
+using Application.Core.Validation;
+using Domain.Common.Config.AI.Governance;
+using FluentAssertions;
+using Xunit;
+
+namespace Application.Core.Tests.Validation;
+
+/// <summary>
+/// Tests for <see cref="DataClassificationConfigValidator"/>. All rules are conditional on
+/// <see cref="DataClassificationConfig.Mode"/> being non-<c>Off</c>: a disabled (off) section is always
+/// valid; an enabled one rejects blank label keys that could never match a real Purview label. Pattern:
+/// a valid baseline, mutate one field per test.
+/// </summary>
+public class DataClassificationConfigValidatorTests
+{
+    private readonly DataClassificationConfigValidator _validator = new();
+
+    [Fact]
+    public void DefaultValues_AreOffWithAllowDefaults()
+    {
+        var config = new DataClassificationConfig();
+
+        config.Mode.Should().Be(ClassificationEnforcementMode.Off);
+        config.DefaultAction.Should().Be(ClassificationAction.Allow);
+        config.UnknownAssetAction.Should().Be(ClassificationAction.Allow);
+        config.LabelActions.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Validate_OffWithBlankLabelKey_IsValid()
+    {
+        // Mode=Off short-circuits every rule, so even an incoherent map is accepted.
+        var config = new DataClassificationConfig
+        {
+            Mode = ClassificationEnforcementMode.Off,
+            LabelActions = new() { ["  "] = ClassificationAction.Block },
+        };
+
+        var result = await _validator.ValidateAsync(config);
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Validate_AuditWithEmptyLabelActions_IsValid()
+    {
+        // An empty map is coherent: every resolved label falls through to DefaultAction.
+        var config = new DataClassificationConfig { Mode = ClassificationEnforcementMode.Audit };
+
+        var result = await _validator.ValidateAsync(config);
+
+        result.IsValid.Should().BeTrue();
+        result.Errors.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Validate_EnforceWithNamedLabelAction_IsValid()
+    {
+        var config = new DataClassificationConfig
+        {
+            Mode = ClassificationEnforcementMode.Enforce,
+            LabelActions = new() { ["Confidential"] = ClassificationAction.Block },
+        };
+
+        var result = await _validator.ValidateAsync(config);
+
+        result.IsValid.Should().BeTrue();
+        result.Errors.Should().BeEmpty();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task Validate_EnforceWithBlankLabelKey_HasError(string blankKey)
+    {
+        var config = new DataClassificationConfig
+        {
+            Mode = ClassificationEnforcementMode.Enforce,
+            LabelActions = new() { [blankKey] = ClassificationAction.Block },
+        };
+
+        var result = await _validator.ValidateAsync(config);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName.StartsWith("LabelActions"));
+    }
+}

--- a/src/Content/Tests/Domain.AI.Tests/Governance/AssetLabelResultTests.cs
+++ b/src/Content/Tests/Domain.AI.Tests/Governance/AssetLabelResultTests.cs
@@ -1,0 +1,47 @@
+using Domain.AI.Governance;
+using FluentAssertions;
+using Xunit;
+
+namespace Domain.AI.Tests.Governance;
+
+/// <summary>
+/// Tests for <see cref="AssetLabelResult"/> — the <see cref="AssetLabelResult.Unknown"/> factory and the
+/// <see cref="AssetLabelResult.HasClassification"/> projection that distinguishes "classified" from
+/// "nothing resolved".
+/// </summary>
+public class AssetLabelResultTests
+{
+    private static readonly DateTimeOffset Now = new(2026, 6, 25, 12, 0, 0, TimeSpan.Zero);
+    private static readonly AssetReference SampleAsset = new(AssetType.AzureBlob, "blob://x");
+
+    [Fact]
+    public void Unknown_ProducesNoneSourceWithNoLabelOrClassifications()
+    {
+        var result = AssetLabelResult.Unknown(SampleAsset, Now);
+
+        result.Source.Should().Be(LabelSource.None);
+        result.Label.Should().BeNull();
+        result.Classifications.Should().BeEmpty();
+        result.RetrievedAtUtc.Should().Be(Now);
+        result.IsStale.Should().BeFalse();
+        result.HasClassification.Should().BeFalse();
+    }
+
+    [Fact]
+    public void HasClassification_IsTrue_WhenLabelPresent()
+    {
+        var result = new AssetLabelResult(
+            SampleAsset, new SensitivityLabel("id", "Confidential"), [], LabelSource.DataMap, Now);
+
+        result.HasClassification.Should().BeTrue();
+    }
+
+    [Fact]
+    public void HasClassification_IsTrue_WhenClassificationsPresentWithoutLabel()
+    {
+        var result = new AssetLabelResult(
+            SampleAsset, Label: null, [new DataClassification("Person's Name")], LabelSource.DataMap, Now);
+
+        result.HasClassification.Should().BeTrue();
+    }
+}


### PR DESCRIPTION
## What & why

First of four PRs adding **Purview-backed data classification** (classification-aware DLP) to the agent. This PR ships the **seam only** — no external calls. It resolves an asset's Purview sensitivity label before a tool touches it and maps that label to an allow/redact/block decision. This is access control driven by classification metadata, distinct from the existing content-pattern response sanitizers (`ExfiltrationUrlDetector`, etc.), which scan output text.

Plan: `.claude/plans/purview-data-classification-dlp.md`.

## What's in this PR

- **Domain models** (`Domain.AI/Governance`): `AssetReference`, `AssetType`, `SensitivityLabel`, `DataClassification`, `AssetLabelResult`, `LabelSource`, `ClassificationPolicyDecision` — immutable records following the existing `GovernanceDecision`/`SanitizationResult` factory idiom.
- **Shared enums** in `Domain.Common` (`ClassificationAction`, `ClassificationEnforcementMode`) — placed there (not Domain.AI) to satisfy dependency direction, mirroring `ThreatLevel`.
- **Contracts** (`Application.AI.Common/Interfaces/Governance`): `IDataClassificationProvider` (async, asset-aware) and `IClassificationPolicyEvaluator` (pure).
- **Pure policy engine**: `DefaultClassificationPolicyEvaluator` — label→action projection (unknown → `UnknownAssetAction`; mapped label → its action; unmapped → `DefaultAction`). Matches labels case-insensitively rather than trusting the dictionary comparer (IConfiguration binding drops it).
- **Config**: `DataClassificationConfig` under `AppConfig:AI:Governance`, **`Mode=Off` by default** (opt-in, like `EnforceToolInvocation`); `UnknownAssetAction` defaults to `Allow`. FluentValidation validator.
- **Fail-safe defaults**: `NotConfigured` (fail-fast when the gate is on but no Purview provider wired) and `NoOp` (benign Unknown when governance is off), registered in both DI paths — matches the skill-training `NotConfigured*` pattern.

## Deliberate scope decisions

- **`IAssetReferenceResolver` deferred to PR4** — its signature depends on the governor's tool-argument shape, unverified here; defining it now risks a throwaway contract.
- **Seam has no live consumer yet** — wired into `IToolInvocationGovernor` in PR4. Intentional phased build.

## Review

- `/code-review` (high): 2 findings fixed — `AssetLabelResult.HasClassification` null-guard; trimmed unused `SensitivityLabel` fields (YAGNI).
- `/simplify`: clean, no findings.
- Build: 0 errors. **20 new unit tests, all green** (evaluator, validator, providers, domain factory).

### Known gap (pre-existing, not in scope)
Config FluentValidation validators (including the sibling `ContentCaptureConfigValidator`) are registered via `AddValidatorsFromAssembly` but not wired to startup options-validation, so they run only under unit tests today. Repo-wide concern, tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)