### PR TITLE
feat(governance): Graph/MIP sensitivity-label provider (Purview DLP PR2)

### DIFF
--- a/src/Content/Application/Application.Core/Validation/DataClassificationConfigValidator.cs
+++ b/src/Content/Application/Application.Core/Validation/DataClassificationConfigValidator.cs
@@ -30,6 +30,35 @@ public sealed class DataClassificationConfigValidator : AbstractValidator<DataCl
                 .WithMessage(
                     "LabelActions contains a blank label name. A blank key can never match a Purview " +
                     "sensitivity label, so the rule would never fire — remove it or supply the label name.");
+
+            RuleFor(x => x.ResultCacheTtl)
+                .GreaterThanOrEqualTo(TimeSpan.Zero)
+                .WithMessage("ResultCacheTtl cannot be negative; use TimeSpan.Zero to disable result caching.");
+        });
+
+        // Information Protection provider rules apply only once it is switched on, independent of Mode:
+        // an operator may stage the provider's connection settings before flipping the gate.
+        When(x => x.InformationProtection.Enabled, () =>
+        {
+            RuleFor(x => x.InformationProtection.GraphBaseUrl)
+                .Must(BeValidHttpUrl)
+                .WithMessage("InformationProtection.GraphBaseUrl must be a valid absolute http(s) URL.");
+
+            RuleFor(x => x.InformationProtection.Scopes)
+                .NotEmpty()
+                .WithMessage("InformationProtection.Scopes must contain at least one OAuth scope to mint a Graph token.");
+
+            RuleForEach(x => x.InformationProtection.Scopes)
+                .Must(scope => !string.IsNullOrWhiteSpace(scope))
+                .WithMessage("InformationProtection.Scopes contains a blank scope; remove it or supply a value.");
+
+            RuleFor(x => x.InformationProtection.LabelCatalogCacheTtl)
+                .GreaterThan(TimeSpan.Zero)
+                .WithMessage("InformationProtection.LabelCatalogCacheTtl must be positive so the label taxonomy is cached.");
         });
     }
+
+    private static bool BeValidHttpUrl(string url) =>
+        Uri.TryCreate(url, UriKind.Absolute, out var uri) &&
+        (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps);
 }

--- a/src/Content/Domain/Domain.Common/Config/AI/Governance/DataClassificationConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/Governance/DataClassificationConfig.cs
@@ -49,4 +49,20 @@ public sealed class DataClassificationConfig
     /// for fail-closed handling of anything Purview cannot vouch for.
     /// </summary>
     public ClassificationAction UnknownAssetAction { get; init; } = ClassificationAction.Allow;
+
+    /// <summary>
+    /// Configuration for the Microsoft Purview Information Protection (MIP) provider — the Microsoft
+    /// Graph-backed source of sensitivity labels for documents and files. Opt-in via
+    /// <see cref="InformationProtectionProviderConfig.Enabled"/>; off by default.
+    /// </summary>
+    public InformationProtectionProviderConfig InformationProtection { get; init; } = new();
+
+    /// <summary>
+    /// How long a resolved <c>AssetLabelResult</c> is cached, keyed by the asset, before the provider is
+    /// consulted again. Caching is mandatory in practice — without it every gated tool call incurs a
+    /// Purview round trip. Defaults to five minutes; a non-positive value disables result caching.
+    /// Distinct from <see cref="InformationProtectionProviderConfig.LabelCatalogCacheTtl"/>, which caches
+    /// the label taxonomy rather than per-asset results.
+    /// </summary>
+    public TimeSpan ResultCacheTtl { get; init; } = TimeSpan.FromMinutes(5);
 }

--- a/src/Content/Domain/Domain.Common/Config/AI/Governance/InformationProtectionProviderConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/Governance/InformationProtectionProviderConfig.cs
@@ -1,0 +1,61 @@
+using Domain.Common.Config.Azure;
+
+namespace Domain.Common.Config.AI.Governance;
+
+/// <summary>
+/// Configuration for the Microsoft Purview Information Protection (MIP) classification provider — the
+/// Microsoft Graph-backed half of the data-classification gate. Bound from
+/// <c>AppConfig:AI:Governance:DataClassification:InformationProtection</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The provider resolves an asset's sensitivity by mapping the label identifier embedded in the asset
+/// against the organization's <em>label taxonomy</em>, which it fetches and caches from Microsoft Graph
+/// (<c>GET /security/dataSecurityAndGovernance/sensitivityLabels</c>). Graph supplies the label
+/// dictionary (id → name); it does not crack open a file to read the embedded label — that extraction
+/// (file → label id) is the asset resolver's job and requires the native MIP File SDK. An asset whose
+/// identifier carries no embedded label id therefore resolves to Unknown, which is the common case for
+/// ordinary local files.
+/// </para>
+/// <para>
+/// <strong>Opt-in.</strong> <see cref="Enabled"/> defaults to <c>false</c>, so even with classification
+/// enforcement switched on the harness only contacts Graph once an operator deliberately wires the MIP
+/// provider with a tenant and credentials.
+/// </para>
+/// </remarks>
+public sealed class InformationProtectionProviderConfig
+{
+    /// <summary>
+    /// Whether the Graph-backed Information Protection provider is active. When <c>false</c> (the
+    /// default) the harness does not register the provider and never contacts Microsoft Graph.
+    /// </summary>
+    public bool Enabled { get; init; }
+
+    /// <summary>
+    /// Base URL of the Microsoft Graph endpoint. Defaults to the global cloud v1.0 endpoint; override
+    /// for sovereign clouds (for example <c>https://graph.microsoft.us/v1.0</c> for US Government).
+    /// </summary>
+    public string GraphBaseUrl { get; init; } = "https://graph.microsoft.com/v1.0";
+
+    /// <summary>
+    /// OAuth scopes requested when minting the Graph access token. Defaults to the application-permission
+    /// resource scope (<c>.default</c>), which is correct for a managed identity or app registration
+    /// holding the <c>SensitivityLabels.Read.All</c> application role required to list tenant labels.
+    /// </summary>
+    public IReadOnlyList<string> Scopes { get; init; } = ["https://graph.microsoft.com/.default"];
+
+    /// <summary>
+    /// Entra credential used to authenticate to Graph. Leave the explicit fields unset to use the
+    /// ambient managed identity / default credential chain (the recommended production posture); supply
+    /// client-secret or certificate fields for non-managed-identity hosts. The secret, if any, must come
+    /// from User Secrets or Key Vault — never appsettings.json.
+    /// </summary>
+    public EntraCredentialConfig Auth { get; init; } = new();
+
+    /// <summary>
+    /// How long the fetched label taxonomy is cached before it is refreshed from Graph. The taxonomy
+    /// changes rarely (an admin edits the org's label set), so a long TTL avoids a Graph round trip on
+    /// every gated tool call. Defaults to one hour.
+    /// </summary>
+    public TimeSpan LabelCatalogCacheTtl { get; init; } = TimeSpan.FromHours(1);
+}

--- a/src/Content/Infrastructure/Infrastructure.AI.Governance/Classification/CachedDataClassificationProvider.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.Governance/Classification/CachedDataClassificationProvider.cs
@@ -22,9 +22,18 @@ namespace Infrastructure.AI.Governance.Classification;
 /// unreachable for an asset that carries a label id), the exception propagates and nothing is stored, so
 /// a transient failure is never frozen into the cache.
 /// </para>
+/// <para>
+/// Growth is bounded by opportunistic pruning: once the entry count crosses
+/// <see cref="PruneThreshold"/>, expired entries are swept on write, so a long-running agent that touches
+/// many distinct assets does not accumulate dead entries indefinitely. Memory is therefore bounded by the
+/// set of <em>live</em> (unexpired) assets within a TTL window, not by total assets ever seen.
+/// </para>
 /// </remarks>
 public sealed class CachedDataClassificationProvider : IDataClassificationProvider
 {
+    /// <summary>Entry count above which expired entries are pruned on the next write.</summary>
+    private const int PruneThreshold = 1024;
+
     private readonly IDataClassificationProvider _inner;
     private readonly TimeProvider _timeProvider;
     private readonly TimeSpan _ttl;
@@ -66,7 +75,20 @@ public sealed class CachedDataClassificationProvider : IDataClassificationProvid
 
         var result = await _inner.GetLabelAsync(asset, cancellationToken).ConfigureAwait(false);
         _cache[asset] = new CacheEntry(result, now + _ttl);
+
+        if (_cache.Count > PruneThreshold)
+            PruneExpired(now);
+
         return result;
+    }
+
+    private void PruneExpired(DateTimeOffset now)
+    {
+        foreach (var (asset, entry) in _cache)
+        {
+            if (now >= entry.ExpiresAt)
+                _cache.TryRemove(asset, out _);
+        }
     }
 
     private sealed record CacheEntry(AssetLabelResult Result, DateTimeOffset ExpiresAt);

--- a/src/Content/Infrastructure/Infrastructure.AI.Governance/Classification/CachedDataClassificationProvider.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.Governance/Classification/CachedDataClassificationProvider.cs
@@ -1,0 +1,73 @@
+using System.Collections.Concurrent;
+using Application.AI.Common.Interfaces.Governance;
+using Domain.AI.Governance;
+using Microsoft.Extensions.Logging;
+
+namespace Infrastructure.AI.Governance.Classification;
+
+/// <summary>
+/// Time-to-live caching decorator over an <see cref="IDataClassificationProvider"/>. Memoizes resolved
+/// <see cref="AssetLabelResult"/>s keyed by the <see cref="AssetReference"/> so repeated tool calls
+/// against the same asset within the TTL window do not each incur a Purview round trip.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Sensitivity labels change on the organization's scan/edit cadence, not per request, so a short result
+/// cache is safe and is what makes per-invocation gating affordable. The TTL is configured by
+/// <c>DataClassificationConfig.ResultCacheTtl</c>; a non-positive TTL disables caching and every call
+/// passes straight through to the inner provider.
+/// </para>
+/// <para>
+/// Only successful resolutions are cached. If the inner provider throws (for example, the backend is
+/// unreachable for an asset that carries a label id), the exception propagates and nothing is stored, so
+/// a transient failure is never frozen into the cache.
+/// </para>
+/// </remarks>
+public sealed class CachedDataClassificationProvider : IDataClassificationProvider
+{
+    private readonly IDataClassificationProvider _inner;
+    private readonly TimeProvider _timeProvider;
+    private readonly TimeSpan _ttl;
+    private readonly ILogger<CachedDataClassificationProvider> _logger;
+    private readonly ConcurrentDictionary<AssetReference, CacheEntry> _cache = new();
+
+    /// <summary>Initializes a new instance of the <see cref="CachedDataClassificationProvider"/> class.</summary>
+    /// <param name="inner">The provider whose results are cached.</param>
+    /// <param name="timeProvider">Clock used to evaluate entry expiry.</param>
+    /// <param name="ttl">How long a resolved result is reused; non-positive disables caching.</param>
+    /// <param name="logger">Logger for diagnostics.</param>
+    public CachedDataClassificationProvider(
+        IDataClassificationProvider inner,
+        TimeProvider timeProvider,
+        TimeSpan ttl,
+        ILogger<CachedDataClassificationProvider> logger)
+    {
+        ArgumentNullException.ThrowIfNull(inner);
+        ArgumentNullException.ThrowIfNull(timeProvider);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _inner = inner;
+        _timeProvider = timeProvider;
+        _ttl = ttl;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<AssetLabelResult> GetLabelAsync(AssetReference asset, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(asset);
+
+        if (_ttl <= TimeSpan.Zero)
+            return await _inner.GetLabelAsync(asset, cancellationToken).ConfigureAwait(false);
+
+        var now = _timeProvider.GetUtcNow();
+        if (_cache.TryGetValue(asset, out var entry) && now < entry.ExpiresAt)
+            return entry.Result;
+
+        var result = await _inner.GetLabelAsync(asset, cancellationToken).ConfigureAwait(false);
+        _cache[asset] = new CacheEntry(result, now + _ttl);
+        return result;
+    }
+
+    private sealed record CacheEntry(AssetLabelResult Result, DateTimeOffset ExpiresAt);
+}

--- a/src/Content/Infrastructure/Infrastructure.AI.Governance/Classification/GraphSensitivityLabelClient.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.Governance/Classification/GraphSensitivityLabelClient.cs
@@ -166,7 +166,7 @@ public sealed partial class GraphSensitivityLabelClient : IDataClassificationPro
                 labels[NormalizeLabelId(dto.Id)] = new SensitivityLabel(dto.Id, dto.Name);
             }
 
-            nextUrl = string.IsNullOrWhiteSpace(page.NextLink) ? null : new Uri(page.NextLink, UriKind.Absolute);
+            nextUrl = ResolveNextLink(page.NextLink);
         }
 
         _logger.LogInformation(
@@ -213,6 +213,29 @@ public sealed partial class GraphSensitivityLabelClient : IDataClassificationPro
     {
         var baseUrl = graphBaseUrl.EndsWith('/') ? graphBaseUrl : graphBaseUrl + "/";
         return new Uri(new Uri(baseUrl), LabelsPath);
+    }
+
+    /// <summary>
+    /// Parses and validates an <c>@odata.nextLink</c>, returning the next page URL or null on the final
+    /// page. The link comes from the response body, and each page request carries the access token, so the
+    /// host and scheme must match the configured Graph endpoint — otherwise a tampered or misrouted
+    /// response could trick the client into forwarding the bearer token to an attacker-controlled host.
+    /// </summary>
+    private Uri? ResolveNextLink(string? nextLink)
+    {
+        if (string.IsNullOrWhiteSpace(nextLink))
+            return null;
+
+        if (!Uri.TryCreate(nextLink, UriKind.Absolute, out var next) ||
+            next.Scheme != _labelsEndpoint.Scheme ||
+            !string.Equals(next.Host, _labelsEndpoint.Host, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException(
+                "The Microsoft Graph @odata.nextLink pointed to an unexpected or malformed host; refusing to " +
+                "forward the access token off the configured Graph endpoint.");
+        }
+
+        return next;
     }
 
     /// <summary>

--- a/src/Content/Infrastructure/Infrastructure.AI.Governance/Classification/GraphSensitivityLabelClient.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.Governance/Classification/GraphSensitivityLabelClient.cs
@@ -33,9 +33,15 @@ namespace Infrastructure.AI.Governance.Classification;
 /// silently treating an unreachable backend as "nothing to see".
 /// </para>
 /// </remarks>
-public sealed partial class GraphSensitivityLabelClient : IDataClassificationProvider
+public sealed partial class GraphSensitivityLabelClient : IDataClassificationProvider, IDisposable
 {
     private const string LabelsPath = "security/dataSecurityAndGovernance/sensitivityLabels";
+
+    /// <summary>
+    /// Hard cap on pagination follow-through, a guard against a malformed or looping
+    /// <c>@odata.nextLink</c> chain. A real tenant label taxonomy is far below this.
+    /// </summary>
+    private const int MaxCatalogPages = 100;
 
     /// <summary>
     /// Name of the <see cref="IHttpClientFactory"/> client this provider resolves on each fetch. Using
@@ -137,14 +143,47 @@ public sealed partial class GraphSensitivityLabelClient : IDataClassificationPro
 
     private async Task<IReadOnlyDictionary<string, SensitivityLabel>> FetchCatalogAsync(CancellationToken cancellationToken)
     {
-        using var request = new HttpRequestMessage(HttpMethod.Get, _labelsEndpoint);
+        var labels = new Dictionary<string, SensitivityLabel>(StringComparer.OrdinalIgnoreCase);
+
+        // Follow @odata.nextLink so a paginated taxonomy is read in full rather than silently truncated
+        // to the first page (which would degrade later labels to Unknown).
+        Uri? nextUrl = _labelsEndpoint;
+        var pages = 0;
+        while (nextUrl is not null)
+        {
+            if (++pages > MaxCatalogPages)
+            {
+                throw new InvalidOperationException(
+                    $"The Microsoft Graph sensitivity-label taxonomy exceeded the {MaxCatalogPages}-page cap; refusing to follow further pagination.");
+            }
+
+            var page = await GetPageAsync(nextUrl, cancellationToken).ConfigureAwait(false);
+            foreach (var dto in page.Value!)
+            {
+                if (string.IsNullOrWhiteSpace(dto.Id) || string.IsNullOrWhiteSpace(dto.Name))
+                    continue;
+
+                labels[NormalizeLabelId(dto.Id)] = new SensitivityLabel(dto.Id, dto.Name);
+            }
+
+            nextUrl = string.IsNullOrWhiteSpace(page.NextLink) ? null : new Uri(page.NextLink, UriKind.Absolute);
+        }
+
+        _logger.LogInformation(
+            "Loaded {LabelCount} Purview sensitivity labels from Graph across {PageCount} page(s).", labels.Count, pages);
+        return labels;
+    }
+
+    private async Task<GraphLabelListResponse> GetPageAsync(Uri url, CancellationToken cancellationToken)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Get, url);
         var token = await _credential
             .GetTokenAsync(new TokenRequestContext(_scopes), cancellationToken)
             .ConfigureAwait(false);
         request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token.Token);
 
-        // Resolved per fetch (not captured) so the factory can rotate the underlying handler.
-        var httpClient = _httpClientFactory.CreateClient(HttpClientName);
+        // Resolved (and disposed) per request so the factory can rotate the underlying handler.
+        using var httpClient = _httpClientFactory.CreateClient(HttpClientName);
         using var response = await httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
         if (!response.IsSuccessStatusCode)
         {
@@ -167,18 +206,7 @@ public sealed partial class GraphSensitivityLabelClient : IDataClassificationPro
                 "The Microsoft Graph sensitivity-label response did not contain a 'value' collection; the response shape was not understood.");
         }
 
-        var labels = new Dictionary<string, SensitivityLabel>(StringComparer.OrdinalIgnoreCase);
-        foreach (var dto in payload.Value)
-        {
-            if (string.IsNullOrWhiteSpace(dto.Id) || string.IsNullOrWhiteSpace(dto.Name))
-                continue;
-
-            var key = NormalizeLabelId(dto.Id);
-            labels[key] = new SensitivityLabel(dto.Id, dto.Name);
-        }
-
-        _logger.LogInformation("Loaded {LabelCount} Purview sensitivity labels from Graph.", labels.Count);
-        return labels;
+        return payload;
     }
 
     private static Uri BuildLabelsEndpoint(string graphBaseUrl)
@@ -219,6 +247,9 @@ public sealed partial class GraphSensitivityLabelClient : IDataClassificationPro
     [GeneratedRegex(@"MSIP_Label_(?<id>[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})_",
         RegexOptions.IgnoreCase)]
     private static partial Regex MsipLabelMarker();
+
+    /// <summary>Disposes the catalog-refresh lock.</summary>
+    public void Dispose() => _refreshLock.Dispose();
 
     /// <summary>An immutable snapshot of the label taxonomy with its expiry.</summary>
     private sealed record CatalogSnapshot(

--- a/src/Content/Infrastructure/Infrastructure.AI.Governance/Classification/GraphSensitivityLabelClient.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.Governance/Classification/GraphSensitivityLabelClient.cs
@@ -218,8 +218,9 @@ public sealed partial class GraphSensitivityLabelClient : IDataClassificationPro
     /// <summary>
     /// Parses and validates an <c>@odata.nextLink</c>, returning the next page URL or null on the final
     /// page. The link comes from the response body, and each page request carries the access token, so the
-    /// host and scheme must match the configured Graph endpoint — otherwise a tampered or misrouted
-    /// response could trick the client into forwarding the bearer token to an attacker-controlled host.
+    /// scheme and authority (host and port) must match the configured Graph endpoint — otherwise a
+    /// tampered or misrouted response could trick the client into forwarding the bearer token to an
+    /// attacker-controlled host, a downgraded scheme, or a different port.
     /// </summary>
     private Uri? ResolveNextLink(string? nextLink)
     {
@@ -228,11 +229,11 @@ public sealed partial class GraphSensitivityLabelClient : IDataClassificationPro
 
         if (!Uri.TryCreate(nextLink, UriKind.Absolute, out var next) ||
             next.Scheme != _labelsEndpoint.Scheme ||
-            !string.Equals(next.Host, _labelsEndpoint.Host, StringComparison.OrdinalIgnoreCase))
+            !string.Equals(next.Authority, _labelsEndpoint.Authority, StringComparison.OrdinalIgnoreCase))
         {
             throw new InvalidOperationException(
-                "The Microsoft Graph @odata.nextLink pointed to an unexpected or malformed host; refusing to " +
-                "forward the access token off the configured Graph endpoint.");
+                "The Microsoft Graph @odata.nextLink pointed to an unexpected or malformed endpoint; refusing " +
+                "to forward the access token off the configured Graph scheme/host/port.");
         }
 
         return next;

--- a/src/Content/Infrastructure/Infrastructure.AI.Governance/Classification/GraphSensitivityLabelClient.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.Governance/Classification/GraphSensitivityLabelClient.cs
@@ -1,0 +1,227 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using Application.AI.Common.Interfaces.Governance;
+using Azure.Core;
+using Domain.AI.Governance;
+using Domain.Common.Config.AI.Governance;
+using Microsoft.Extensions.Logging;
+
+namespace Infrastructure.AI.Governance.Classification;
+
+/// <summary>
+/// Microsoft Purview Information Protection (MIP) classification provider, backed by Microsoft Graph.
+/// Resolves an asset's sensitivity by mapping the label id embedded in the asset reference against the
+/// organization's label taxonomy, which it fetches and caches from Graph.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>What Graph can and cannot do.</strong> Graph supplies the tenant's label dictionary
+/// (<c>GET /security/dataSecurityAndGovernance/sensitivityLabels</c>, application permission
+/// <c>SensitivityLabels.Read.All</c>) — the id → name mapping. It does <em>not</em> open a file and read
+/// the label stamped inside it; that extraction requires the native MIP File SDK and is the asset
+/// resolver's responsibility. This client therefore resolves a real label only when the asset's
+/// identifier already carries an embedded label id (a bare GUID, or the MIP
+/// <c>MSIP_Label_{guid}_Enabled</c> marker). An ordinary local file path carries no such id and resolves
+/// to <see cref="AssetLabelResult.Unknown(AssetReference, DateTimeOffset)"/> — the documented common case.
+/// </para>
+/// <para>
+/// The taxonomy is cached in-process with a configurable TTL so the gate does not pay a Graph round trip
+/// per call. Per-asset results are cached separately by <see cref="CachedDataClassificationProvider"/>.
+/// A failure to reach Graph for an asset that <em>does</em> carry a label id surfaces as an exception
+/// rather than a benign Unknown, so the enforcement point can apply its fail-closed policy instead of
+/// silently treating an unreachable backend as "nothing to see".
+/// </para>
+/// </remarks>
+public sealed partial class GraphSensitivityLabelClient : IDataClassificationProvider
+{
+    private const string LabelsPath = "security/dataSecurityAndGovernance/sensitivityLabels";
+
+    /// <summary>
+    /// Name of the <see cref="IHttpClientFactory"/> client this provider resolves on each fetch. Using
+    /// the factory per call lets it pool and rotate the underlying handler instead of pinning one handler
+    /// for the lifetime of this singleton provider (which would leave DNS and sockets stale).
+    /// </summary>
+    public const string HttpClientName = "purview-information-protection";
+
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly TokenCredential _credential;
+    private readonly TimeProvider _timeProvider;
+    private readonly ILogger<GraphSensitivityLabelClient> _logger;
+
+    private readonly Uri _labelsEndpoint;
+    private readonly string[] _scopes;
+    private readonly TimeSpan _catalogTtl;
+
+    private readonly SemaphoreSlim _refreshLock = new(1, 1);
+    private volatile CatalogSnapshot? _catalog;
+
+    /// <summary>Initializes a new instance of the <see cref="GraphSensitivityLabelClient"/> class.</summary>
+    /// <param name="httpClientFactory">Factory used to resolve a fresh, handler-rotated client per Graph fetch.</param>
+    /// <param name="credential">Entra credential used to mint Graph access tokens.</param>
+    /// <param name="config">The Information Protection provider configuration this client binds to.</param>
+    /// <param name="timeProvider">Clock used for cache expiry and result timestamps.</param>
+    /// <param name="logger">Logger for diagnostics.</param>
+    public GraphSensitivityLabelClient(
+        IHttpClientFactory httpClientFactory,
+        TokenCredential credential,
+        InformationProtectionProviderConfig config,
+        TimeProvider timeProvider,
+        ILogger<GraphSensitivityLabelClient> logger)
+    {
+        ArgumentNullException.ThrowIfNull(httpClientFactory);
+        ArgumentNullException.ThrowIfNull(credential);
+        ArgumentNullException.ThrowIfNull(config);
+        ArgumentNullException.ThrowIfNull(timeProvider);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        var ip = config;
+        _httpClientFactory = httpClientFactory;
+        _credential = credential;
+        _timeProvider = timeProvider;
+        _logger = logger;
+        _scopes = [.. ip.Scopes];
+        _catalogTtl = ip.LabelCatalogCacheTtl;
+        _labelsEndpoint = BuildLabelsEndpoint(ip.GraphBaseUrl);
+    }
+
+    /// <inheritdoc />
+    public async Task<AssetLabelResult> GetLabelAsync(AssetReference asset, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(asset);
+
+        // No embedded label id means there is nothing for Graph to map — return Unknown without a network
+        // call. This is the common case for ordinary files and keeps the gate cheap when nothing is labelled.
+        if (!TryExtractLabelId(asset.Identifier, out var labelId))
+            return AssetLabelResult.Unknown(asset, _timeProvider.GetUtcNow());
+
+        var catalog = await EnsureCatalogAsync(cancellationToken).ConfigureAwait(false);
+        var now = _timeProvider.GetUtcNow();
+
+        if (catalog.ById.TryGetValue(labelId, out var label))
+            return new AssetLabelResult(asset, label, [], LabelSource.InformationProtection, now);
+
+        // The asset carries a label id the tenant taxonomy does not contain (a label deleted since the
+        // file was stamped, or a different tenant). Treat as Unknown so the unknown-asset policy applies.
+        _logger.LogWarning(
+            "Embedded sensitivity label id {LabelId} is not present in the tenant label taxonomy; treating asset as unclassified.",
+            labelId);
+        return AssetLabelResult.Unknown(asset, now);
+    }
+
+    private async Task<CatalogSnapshot> EnsureCatalogAsync(CancellationToken cancellationToken)
+    {
+        var snapshot = _catalog;
+        if (snapshot is not null && _timeProvider.GetUtcNow() < snapshot.ExpiresAt)
+            return snapshot;
+
+        await _refreshLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            snapshot = _catalog;
+            if (snapshot is not null && _timeProvider.GetUtcNow() < snapshot.ExpiresAt)
+                return snapshot;
+
+            var labels = await FetchCatalogAsync(cancellationToken).ConfigureAwait(false);
+            snapshot = new CatalogSnapshot(labels, _timeProvider.GetUtcNow() + _catalogTtl);
+            _catalog = snapshot;
+            return snapshot;
+        }
+        finally
+        {
+            _refreshLock.Release();
+        }
+    }
+
+    private async Task<IReadOnlyDictionary<string, SensitivityLabel>> FetchCatalogAsync(CancellationToken cancellationToken)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Get, _labelsEndpoint);
+        var token = await _credential
+            .GetTokenAsync(new TokenRequestContext(_scopes), cancellationToken)
+            .ConfigureAwait(false);
+        request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token.Token);
+
+        // Resolved per fetch (not captured) so the factory can rotate the underlying handler.
+        var httpClient = _httpClientFactory.CreateClient(HttpClientName);
+        using var response = await httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        if (!response.IsSuccessStatusCode)
+        {
+            // Status only — never echo the response body or token, which can carry tenant detail.
+            throw new InvalidOperationException(
+                $"Failed to retrieve the Microsoft Purview sensitivity-label taxonomy from Graph (HTTP {(int)response.StatusCode}).");
+        }
+
+        var payload = await response.Content
+            .ReadFromJsonAsync<GraphLabelListResponse>(JsonOptions, cancellationToken)
+            .ConfigureAwait(false);
+
+        // A well-formed Graph collection always carries a 'value' array — empty is legitimate (a tenant
+        // with no labels), but a missing 'value' means the response shape was not understood. Treat that
+        // as a failure rather than silently caching an empty taxonomy that would degrade labelled assets
+        // to Unknown for the whole TTL.
+        if (payload?.Value is null)
+        {
+            throw new InvalidOperationException(
+                "The Microsoft Graph sensitivity-label response did not contain a 'value' collection; the response shape was not understood.");
+        }
+
+        var labels = new Dictionary<string, SensitivityLabel>(StringComparer.OrdinalIgnoreCase);
+        foreach (var dto in payload.Value)
+        {
+            if (string.IsNullOrWhiteSpace(dto.Id) || string.IsNullOrWhiteSpace(dto.Name))
+                continue;
+
+            var key = NormalizeLabelId(dto.Id);
+            labels[key] = new SensitivityLabel(dto.Id, dto.Name);
+        }
+
+        _logger.LogInformation("Loaded {LabelCount} Purview sensitivity labels from Graph.", labels.Count);
+        return labels;
+    }
+
+    private static Uri BuildLabelsEndpoint(string graphBaseUrl)
+    {
+        var baseUrl = graphBaseUrl.EndsWith('/') ? graphBaseUrl : graphBaseUrl + "/";
+        return new Uri(new Uri(baseUrl), LabelsPath);
+    }
+
+    /// <summary>
+    /// Extracts an embedded sensitivity-label id from an asset identifier. Recognizes the MIP
+    /// <c>MSIP_Label_{guid}_…</c> marker and a bare GUID. Returns the id normalized to its canonical form.
+    /// </summary>
+    private static bool TryExtractLabelId(string identifier, out string labelId)
+    {
+        labelId = string.Empty;
+        if (string.IsNullOrWhiteSpace(identifier))
+            return false;
+
+        var marker = MsipLabelMarker().Match(identifier);
+        if (marker.Success)
+        {
+            labelId = NormalizeLabelId(marker.Groups["id"].Value);
+            return true;
+        }
+
+        if (Guid.TryParse(identifier.Trim(), out var guid))
+        {
+            labelId = guid.ToString("D");
+            return true;
+        }
+
+        return false;
+    }
+
+    private static string NormalizeLabelId(string id) =>
+        Guid.TryParse(id, out var guid) ? guid.ToString("D") : id.Trim();
+
+    [GeneratedRegex(@"MSIP_Label_(?<id>[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})_",
+        RegexOptions.IgnoreCase)]
+    private static partial Regex MsipLabelMarker();
+
+    /// <summary>An immutable snapshot of the label taxonomy with its expiry.</summary>
+    private sealed record CatalogSnapshot(
+        IReadOnlyDictionary<string, SensitivityLabel> ById,
+        DateTimeOffset ExpiresAt);
+}

--- a/src/Content/Infrastructure/Infrastructure.AI.Governance/Classification/GraphSensitivityLabelDtos.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.Governance/Classification/GraphSensitivityLabelDtos.cs
@@ -7,8 +7,13 @@ namespace Infrastructure.AI.Governance.Classification;
 /// <c>GET /security/dataSecurityAndGovernance/sensitivityLabels</c>. Internal to the MIP provider.
 /// </summary>
 /// <param name="Value">The sensitivity labels in the response, or null when the body is malformed.</param>
+/// <param name="NextLink">
+/// The <c>@odata.nextLink</c> URL for the next page of results, or null on the final page. Followed so a
+/// paginated taxonomy is read in full rather than silently truncated to the first page.
+/// </param>
 internal sealed record GraphLabelListResponse(
-    [property: JsonPropertyName("value")] IReadOnlyList<GraphSensitivityLabelDto>? Value);
+    [property: JsonPropertyName("value")] IReadOnlyList<GraphSensitivityLabelDto>? Value,
+    [property: JsonPropertyName("@odata.nextLink")] string? NextLink = null);
 
 /// <summary>
 /// Wire-format projection of a single Microsoft Graph <c>sensitivityLabel</c> resource. Only the fields

--- a/src/Content/Infrastructure/Infrastructure.AI.Governance/Classification/GraphSensitivityLabelDtos.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.Governance/Classification/GraphSensitivityLabelDtos.cs
@@ -1,0 +1,21 @@
+using System.Text.Json.Serialization;
+
+namespace Infrastructure.AI.Governance.Classification;
+
+/// <summary>
+/// Wire-format envelope for a Microsoft Graph collection response — the <c>value</c> array returned by
+/// <c>GET /security/dataSecurityAndGovernance/sensitivityLabels</c>. Internal to the MIP provider.
+/// </summary>
+/// <param name="Value">The sensitivity labels in the response, or null when the body is malformed.</param>
+internal sealed record GraphLabelListResponse(
+    [property: JsonPropertyName("value")] IReadOnlyList<GraphSensitivityLabelDto>? Value);
+
+/// <summary>
+/// Wire-format projection of a single Microsoft Graph <c>sensitivityLabel</c> resource. Only the fields
+/// the gate needs — the stable id and the display name — are bound; the rest of the resource is ignored.
+/// </summary>
+/// <param name="Id">The label's stable GUID, matched against the embedded label id on an asset.</param>
+/// <param name="Name">The plaintext label name surfaced to the policy's label→action map.</param>
+internal sealed record GraphSensitivityLabelDto(
+    [property: JsonPropertyName("id")] string? Id,
+    [property: JsonPropertyName("name")] string? Name);

--- a/src/Content/Infrastructure/Infrastructure.AI.Governance/DependencyInjection.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.Governance/DependencyInjection.cs
@@ -76,7 +76,7 @@ public static class DependencyInjection
     /// and the Information Protection provider is switched on; otherwise keeps the fail-fast default so an
     /// enabled-but-unconfigured gate fails loudly rather than silently allowing everything.
     /// </summary>
-    private static void AddDataClassificationProvider(IServiceCollection services, DataClassificationConfig config)
+    internal static void AddDataClassificationProvider(IServiceCollection services, DataClassificationConfig config)
     {
         services.AddSingleton<IClassificationPolicyEvaluator, DefaultClassificationPolicyEvaluator>();
 

--- a/src/Content/Infrastructure/Infrastructure.AI.Governance/DependencyInjection.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.Governance/DependencyInjection.cs
@@ -4,8 +4,11 @@ using AgentGovernance.Policy;
 using AgentGovernance.Security;
 using Application.AI.Common.Interfaces.Governance;
 using Application.AI.Common.Services.Governance;
+using Application.Common.Factories;
 using Domain.Common.Config.AI;
+using Domain.Common.Config.AI.Governance;
 using Infrastructure.AI.Governance.Adapters;
+using Infrastructure.AI.Governance.Classification;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
@@ -59,13 +62,55 @@ public static class DependencyInjection
         services.AddSingleton<IResponseSanitizer, ExfiltrationUrlDetector>();
         services.AddSingleton<ICompositeResponseSanitizer, CompositeResponseSanitizer>();
 
-        // Data-classification seam. The policy evaluator is pure; the provider default is fail-fast and
-        // is only consulted when DataClassificationConfig.Mode is not Off — a real Purview-backed
-        // provider (Graph / Data Map) replaces it before classification enforcement is switched on.
-        services.AddSingleton<IClassificationPolicyEvaluator, DefaultClassificationPolicyEvaluator>();
-        services.AddSingleton<IDataClassificationProvider, NotConfiguredDataClassificationProvider>();
+        // Data-classification seam. The policy evaluator is pure; the provider is the real Graph-backed
+        // Information Protection client when wired, else the fail-fast default.
+        AddDataClassificationProvider(services, config.DataClassification);
 
         return services;
+    }
+
+    /// <summary>
+    /// Registers the data-classification policy evaluator and the appropriate
+    /// <see cref="IDataClassificationProvider"/>. Wires the real Graph-backed
+    /// <see cref="GraphSensitivityLabelClient"/> (behind a TTL cache) only when classification is enabled
+    /// and the Information Protection provider is switched on; otherwise keeps the fail-fast default so an
+    /// enabled-but-unconfigured gate fails loudly rather than silently allowing everything.
+    /// </summary>
+    private static void AddDataClassificationProvider(IServiceCollection services, DataClassificationConfig config)
+    {
+        services.AddSingleton<IClassificationPolicyEvaluator, DefaultClassificationPolicyEvaluator>();
+
+        var ip = config.InformationProtection;
+        if (config.Mode == ClassificationEnforcementMode.Off || !ip.Enabled)
+        {
+            services.AddSingleton<IDataClassificationProvider, NotConfiguredDataClassificationProvider>();
+            return;
+        }
+
+        services.AddHttpClient(GraphSensitivityLabelClient.HttpClientName);
+
+        services.AddSingleton<IDataClassificationProvider>(sp =>
+        {
+            var timeProvider = sp.GetRequiredService<TimeProvider>();
+
+            // Azure.Identity caches and refreshes the token in-process, so building the credential once
+            // for the singleton is correct; it is created lazily here so a credential-config error
+            // surfaces when the provider is first resolved rather than during the DI graph build.
+            var credential = AzureCredentialFactory.CreateTokenCredential(ip.Auth);
+
+            var inner = new GraphSensitivityLabelClient(
+                sp.GetRequiredService<IHttpClientFactory>(),
+                credential,
+                ip,
+                timeProvider,
+                sp.GetRequiredService<ILogger<GraphSensitivityLabelClient>>());
+
+            return new CachedDataClassificationProvider(
+                inner,
+                timeProvider,
+                config.ResultCacheTtl,
+                sp.GetRequiredService<ILogger<CachedDataClassificationProvider>>());
+        });
     }
 
     /// <summary>

--- a/src/Content/Tests/Application.Core.Tests/Validation/DataClassificationConfigValidatorTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/Validation/DataClassificationConfigValidatorTests.cs
@@ -84,4 +84,102 @@ public class DataClassificationConfigValidatorTests
         result.IsValid.Should().BeFalse();
         result.Errors.Should().Contain(e => e.PropertyName.StartsWith("LabelActions"));
     }
+
+    [Fact]
+    public async Task Validate_EnforceWithNegativeResultCacheTtl_HasError()
+    {
+        var config = new DataClassificationConfig
+        {
+            Mode = ClassificationEnforcementMode.Enforce,
+            ResultCacheTtl = TimeSpan.FromSeconds(-1),
+        };
+
+        var result = await _validator.ValidateAsync(config);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(DataClassificationConfig.ResultCacheTtl));
+    }
+
+    [Fact]
+    public async Task Validate_InformationProtectionDisabled_SkipsProviderRules()
+    {
+        // Even with incoherent provider settings, a disabled provider imposes no constraints.
+        var config = new DataClassificationConfig
+        {
+            InformationProtection = new InformationProtectionProviderConfig
+            {
+                Enabled = false,
+                GraphBaseUrl = "not-a-url",
+                Scopes = [],
+                LabelCatalogCacheTtl = TimeSpan.Zero,
+            },
+        };
+
+        var result = await _validator.ValidateAsync(config);
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Validate_InformationProtectionEnabledWithDefaults_IsValid()
+    {
+        var config = new DataClassificationConfig
+        {
+            InformationProtection = new InformationProtectionProviderConfig { Enabled = true },
+        };
+
+        var result = await _validator.ValidateAsync(config);
+
+        result.IsValid.Should().BeTrue();
+        result.Errors.Should().BeEmpty();
+    }
+
+    [Theory]
+    [InlineData("not-a-url")]
+    [InlineData("ftp://graph.microsoft.com")]
+    [InlineData("graph.microsoft.com/v1.0")]
+    public async Task Validate_InformationProtectionEnabledWithInvalidGraphUrl_HasError(string badUrl)
+    {
+        var config = new DataClassificationConfig
+        {
+            InformationProtection = new InformationProtectionProviderConfig { Enabled = true, GraphBaseUrl = badUrl },
+        };
+
+        var result = await _validator.ValidateAsync(config);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName.Contains(nameof(InformationProtectionProviderConfig.GraphBaseUrl)));
+    }
+
+    [Fact]
+    public async Task Validate_InformationProtectionEnabledWithEmptyScopes_HasError()
+    {
+        var config = new DataClassificationConfig
+        {
+            InformationProtection = new InformationProtectionProviderConfig { Enabled = true, Scopes = [] },
+        };
+
+        var result = await _validator.ValidateAsync(config);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName.Contains(nameof(InformationProtectionProviderConfig.Scopes)));
+    }
+
+    [Fact]
+    public async Task Validate_InformationProtectionEnabledWithNonPositiveCatalogTtl_HasError()
+    {
+        var config = new DataClassificationConfig
+        {
+            InformationProtection = new InformationProtectionProviderConfig
+            {
+                Enabled = true,
+                LabelCatalogCacheTtl = TimeSpan.Zero,
+            },
+        };
+
+        var result = await _validator.ValidateAsync(config);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName.Contains(nameof(InformationProtectionProviderConfig.LabelCatalogCacheTtl)));
+    }
 }

--- a/src/Content/Tests/Infrastructure.AI.Governance.Tests/Classification/CachedDataClassificationProviderTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Governance.Tests/Classification/CachedDataClassificationProviderTests.cs
@@ -1,0 +1,125 @@
+using Application.AI.Common.Interfaces.Governance;
+using Domain.AI.Governance;
+using FluentAssertions;
+using Infrastructure.AI.Governance.Classification;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Infrastructure.AI.Governance.Tests.Classification;
+
+/// <summary>
+/// Tests for <see cref="CachedDataClassificationProvider"/>: it memoizes results per asset within the
+/// TTL, refreshes after expiry, keys distinct assets separately, can be disabled by a non-positive TTL,
+/// and never caches a failure.
+/// </summary>
+public sealed class CachedDataClassificationProviderTests
+{
+    private static readonly DateTimeOffset Now = new(2026, 6, 25, 12, 0, 0, TimeSpan.Zero);
+    private static readonly AssetReference Asset = new(AssetType.AzureBlob, "https://acct.blob/c/f");
+    private static readonly AssetReference OtherAsset = new(AssetType.AzureBlob, "https://acct.blob/c/g");
+
+    [Fact]
+    public async Task GetLabelAsync_WithinTtl_ReturnsCachedResultWithoutCallingInner()
+    {
+        var inner = new CountingProvider();
+        var sut = Create(inner, TimeSpan.FromMinutes(5), new MutableTimeProvider(Now));
+
+        await sut.GetLabelAsync(Asset, CancellationToken.None);
+        await sut.GetLabelAsync(Asset, CancellationToken.None);
+
+        inner.CallCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task GetLabelAsync_AfterTtlExpiry_CallsInnerAgain()
+    {
+        var inner = new CountingProvider();
+        var time = new MutableTimeProvider(Now);
+        var sut = Create(inner, TimeSpan.FromMinutes(5), time);
+
+        await sut.GetLabelAsync(Asset, CancellationToken.None);
+        time.Advance(TimeSpan.FromMinutes(6));
+        await sut.GetLabelAsync(Asset, CancellationToken.None);
+
+        inner.CallCount.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task GetLabelAsync_DistinctAssets_AreCachedSeparately()
+    {
+        var inner = new CountingProvider();
+        var sut = Create(inner, TimeSpan.FromMinutes(5), new MutableTimeProvider(Now));
+
+        await sut.GetLabelAsync(Asset, CancellationToken.None);
+        await sut.GetLabelAsync(OtherAsset, CancellationToken.None);
+        await sut.GetLabelAsync(Asset, CancellationToken.None);
+
+        inner.CallCount.Should().Be(2, "each distinct asset is resolved once, then served from cache");
+    }
+
+    [Fact]
+    public async Task GetLabelAsync_NonPositiveTtl_DisablesCaching()
+    {
+        var inner = new CountingProvider();
+        var sut = Create(inner, TimeSpan.Zero, new MutableTimeProvider(Now));
+
+        await sut.GetLabelAsync(Asset, CancellationToken.None);
+        await sut.GetLabelAsync(Asset, CancellationToken.None);
+
+        inner.CallCount.Should().Be(2, "a non-positive TTL bypasses the cache entirely");
+    }
+
+    [Fact]
+    public async Task GetLabelAsync_InnerThrows_DoesNotCacheTheFailure()
+    {
+        var inner = new CountingProvider { ThrowNext = true };
+        var sut = Create(inner, TimeSpan.FromMinutes(5), new MutableTimeProvider(Now));
+
+        var act = async () => await sut.GetLabelAsync(Asset, CancellationToken.None);
+        await act.Should().ThrowAsync<InvalidOperationException>();
+
+        // A transient failure must not be frozen into the cache; the next call retries the inner provider.
+        var result = await sut.GetLabelAsync(Asset, CancellationToken.None);
+        result.Should().NotBeNull();
+        inner.CallCount.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task GetLabelAsync_NullAsset_Throws()
+    {
+        var sut = Create(new CountingProvider(), TimeSpan.FromMinutes(5), new MutableTimeProvider(Now));
+
+        var act = async () => await sut.GetLabelAsync(null!, CancellationToken.None);
+
+        await act.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    private static CachedDataClassificationProvider Create(
+        IDataClassificationProvider inner, TimeSpan ttl, TimeProvider time) =>
+        new(inner, time, ttl, NullLogger<CachedDataClassificationProvider>.Instance);
+
+    private sealed class CountingProvider : IDataClassificationProvider
+    {
+        public int CallCount { get; private set; }
+        public bool ThrowNext { get; set; }
+
+        public Task<AssetLabelResult> GetLabelAsync(AssetReference asset, CancellationToken cancellationToken)
+        {
+            CallCount++;
+            if (ThrowNext)
+            {
+                ThrowNext = false;
+                throw new InvalidOperationException("backend unreachable");
+            }
+
+            return Task.FromResult(AssetLabelResult.Unknown(asset, Now));
+        }
+    }
+
+    private sealed class MutableTimeProvider(DateTimeOffset start) : TimeProvider
+    {
+        private DateTimeOffset _now = start;
+        public override DateTimeOffset GetUtcNow() => _now;
+        public void Advance(TimeSpan by) => _now += by;
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Governance.Tests/Classification/DataClassificationDependencyInjectionTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Governance.Tests/Classification/DataClassificationDependencyInjectionTests.cs
@@ -1,0 +1,68 @@
+using Application.AI.Common.Interfaces.Governance;
+using Application.AI.Common.Services.Governance;
+using Domain.Common.Config.AI.Governance;
+using FluentAssertions;
+using Infrastructure.AI.Governance.Classification;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Infrastructure.AI.Governance.Tests.Classification;
+
+/// <summary>
+/// DI composition tests for the data-classification provider wiring in
+/// <see cref="DependencyInjection.AddDataClassificationProvider"/>. They prove the three resolution
+/// branches actually build: the enabled Information Protection path yields the cached Graph provider, and
+/// both not-wired paths keep the fail-fast default. Resolving the service exercises the factory lambda,
+/// which a pure registration test would not. The internal registration method is tested directly rather
+/// than through <see cref="DependencyInjection.AddGovernanceDependencies"/>, which additionally stands up
+/// a live Agent Governance Toolkit kernel that requires policy configuration unavailable to a unit test.
+/// </summary>
+public sealed class DataClassificationDependencyInjectionTests
+{
+    [Fact]
+    public void AddDataClassificationProvider_IpProviderEnabled_ResolvesCachedGraphProvider()
+    {
+        var config = new DataClassificationConfig
+        {
+            Mode = ClassificationEnforcementMode.Enforce,
+            InformationProtection = new InformationProtectionProviderConfig { Enabled = true },
+        };
+        using var sp = BuildProvider(config);
+
+        sp.GetRequiredService<IDataClassificationProvider>()
+            .Should().BeOfType<CachedDataClassificationProvider>();
+    }
+
+    [Fact]
+    public void AddDataClassificationProvider_GateOnButIpProviderDisabled_ResolvesNotConfiguredDefault()
+    {
+        var config = new DataClassificationConfig { Mode = ClassificationEnforcementMode.Enforce };
+        using var sp = BuildProvider(config);
+
+        sp.GetRequiredService<IDataClassificationProvider>()
+            .Should().BeOfType<NotConfiguredDataClassificationProvider>();
+    }
+
+    [Fact]
+    public void AddDataClassificationProvider_GateOff_ResolvesNotConfiguredDefault()
+    {
+        var config = new DataClassificationConfig
+        {
+            Mode = ClassificationEnforcementMode.Off,
+            InformationProtection = new InformationProtectionProviderConfig { Enabled = true },
+        };
+        using var sp = BuildProvider(config);
+
+        sp.GetRequiredService<IDataClassificationProvider>()
+            .Should().BeOfType<NotConfiguredDataClassificationProvider>();
+    }
+
+    private static ServiceProvider BuildProvider(DataClassificationConfig config)
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton(TimeProvider.System);
+        DependencyInjection.AddDataClassificationProvider(services, config);
+        return services.BuildServiceProvider();
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Governance.Tests/Classification/GraphSensitivityLabelClientTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Governance.Tests/Classification/GraphSensitivityLabelClientTests.cs
@@ -148,6 +148,26 @@ public sealed class GraphSensitivityLabelClientTests
     }
 
     [Fact]
+    public async Task GetLabelAsync_NextLinkToForeignHost_ThrowsWithoutForwardingToken()
+    {
+        // A nextLink pointing off the configured Graph host must be rejected so the bearer token is never
+        // forwarded to an attacker-controlled endpoint — the second (foreign) request must never be made.
+        var handler = new StubHandler(_ => Ok($$"""
+            {
+              "value": [ { "id": "{{ConfidentialId}}", "name": "Confidential" } ],
+              "@odata.nextLink": "https://evil.example/steal?$skiptoken=P2"
+            }
+            """));
+        var sut = CreateClient(handler, new MutableTimeProvider(Now));
+
+        var act = async () => await sut.GetLabelAsync(
+            new AssetReference(AssetType.LocalFile, ConfidentialId), CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+        handler.CallCount.Should().Be(1, "the foreign nextLink must not be followed with the token attached");
+    }
+
+    [Fact]
     public async Task GetLabelAsync_GraphReturns200WithoutValueCollection_Throws()
     {
         // A 200 whose body lacks the 'value' array is an unrecognized shape — it must fail closed rather

--- a/src/Content/Tests/Infrastructure.AI.Governance.Tests/Classification/GraphSensitivityLabelClientTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Governance.Tests/Classification/GraphSensitivityLabelClientTests.cs
@@ -124,6 +124,30 @@ public sealed class GraphSensitivityLabelClientTests
     }
 
     [Fact]
+    public async Task GetLabelAsync_FollowsODataNextLink_AcrossPages()
+    {
+        // Page 1 carries only "Confidential" plus a nextLink; page 2 carries "Highly Confidential".
+        const string page2Url = "https://graph.test/v1.0/security/dataSecurityAndGovernance/sensitivityLabels?$skiptoken=P2";
+        var handler = new StubHandler(request =>
+            request.RequestUri!.Query.Contains("skiptoken")
+                ? Ok($$"""{ "value": [ { "id": "{{HighlyConfidentialId}}", "name": "Highly Confidential" } ] }""")
+                : Ok($$"""
+                    {
+                      "value": [ { "id": "{{ConfidentialId}}", "name": "Confidential" } ],
+                      "@odata.nextLink": "{{page2Url}}"
+                    }
+                    """));
+        var sut = CreateClient(handler, new MutableTimeProvider(Now));
+
+        var first = await sut.GetLabelAsync(new AssetReference(AssetType.LocalFile, ConfidentialId), CancellationToken.None);
+        var second = await sut.GetLabelAsync(new AssetReference(AssetType.LocalFile, HighlyConfidentialId), CancellationToken.None);
+
+        first.Label!.Name.Should().Be("Confidential");
+        second.Label!.Name.Should().Be("Highly Confidential", "the second page's labels must be merged into the taxonomy");
+        handler.CallCount.Should().Be(2, "both pages are fetched once, then the merged catalog is cached");
+    }
+
+    [Fact]
     public async Task GetLabelAsync_GraphReturns200WithoutValueCollection_Throws()
     {
         // A 200 whose body lacks the 'value' array is an unrecognized shape — it must fail closed rather

--- a/src/Content/Tests/Infrastructure.AI.Governance.Tests/Classification/GraphSensitivityLabelClientTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Governance.Tests/Classification/GraphSensitivityLabelClientTests.cs
@@ -168,6 +168,26 @@ public sealed class GraphSensitivityLabelClientTests
     }
 
     [Fact]
+    public async Task GetLabelAsync_NextLinkWithDowngradedScheme_ThrowsWithoutForwardingToken()
+    {
+        // Same host but http instead of the configured https — a scheme downgrade must be rejected so the
+        // token is never sent over an unencrypted channel.
+        var handler = new StubHandler(_ => Ok($$"""
+            {
+              "value": [ { "id": "{{ConfidentialId}}", "name": "Confidential" } ],
+              "@odata.nextLink": "http://graph.test/v1.0/security/dataSecurityAndGovernance/sensitivityLabels?$skiptoken=P2"
+            }
+            """));
+        var sut = CreateClient(handler, new MutableTimeProvider(Now));
+
+        var act = async () => await sut.GetLabelAsync(
+            new AssetReference(AssetType.LocalFile, ConfidentialId), CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+        handler.CallCount.Should().Be(1, "a scheme-downgraded nextLink must not be followed with the token attached");
+    }
+
+    [Fact]
     public async Task GetLabelAsync_GraphReturns200WithoutValueCollection_Throws()
     {
         // A 200 whose body lacks the 'value' array is an unrecognized shape — it must fail closed rather

--- a/src/Content/Tests/Infrastructure.AI.Governance.Tests/Classification/GraphSensitivityLabelClientTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Governance.Tests/Classification/GraphSensitivityLabelClientTests.cs
@@ -1,0 +1,242 @@
+using System.Net;
+using System.Text;
+using Azure.Core;
+using Domain.AI.Governance;
+using Domain.Common.Config.AI.Governance;
+using FluentAssertions;
+using Infrastructure.AI.Governance.Classification;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Infrastructure.AI.Governance.Tests.Classification;
+
+/// <summary>
+/// Tests for <see cref="GraphSensitivityLabelClient"/> against a stubbed Microsoft Graph endpoint.
+/// They pin the honest contract of the MIP provider: it maps an embedded label id to the tenant label
+/// taxonomy, returns Unknown (without a network call) when no id is present, caches the taxonomy, and
+/// surfaces a backend failure as an exception rather than a silent Unknown.
+/// </summary>
+public sealed class GraphSensitivityLabelClientTests
+{
+    private const string ConfidentialId = "11111111-1111-1111-1111-111111111111";
+    private const string HighlyConfidentialId = "22222222-2222-2222-2222-222222222222";
+
+    private static readonly DateTimeOffset Now = new(2026, 6, 25, 12, 0, 0, TimeSpan.Zero);
+
+    private static string CatalogJson() =>
+        $$"""
+        {
+          "value": [
+            { "id": "{{ConfidentialId}}", "name": "Confidential" },
+            { "id": "{{HighlyConfidentialId}}", "name": "Highly Confidential" }
+          ]
+        }
+        """;
+
+    private static DataClassificationConfig Config(TimeSpan? catalogTtl = null) => new()
+    {
+        Mode = ClassificationEnforcementMode.Enforce,
+        InformationProtection = new InformationProtectionProviderConfig
+        {
+            Enabled = true,
+            GraphBaseUrl = "https://graph.test/v1.0",
+            Scopes = ["https://graph.test/.default"],
+            LabelCatalogCacheTtl = catalogTtl ?? TimeSpan.FromHours(1),
+        },
+    };
+
+    private static GraphSensitivityLabelClient CreateClient(
+        StubHandler handler, MutableTimeProvider time, TimeSpan? catalogTtl = null) =>
+        new(new StubHttpClientFactory(handler), new FakeCredential(), Config(catalogTtl).InformationProtection, time,
+            NullLogger<GraphSensitivityLabelClient>.Instance);
+
+    [Fact]
+    public async Task GetLabelAsync_NoEmbeddedLabelId_ReturnsUnknownWithoutCallingGraph()
+    {
+        var handler = new StubHandler(_ => Ok(CatalogJson()));
+        var sut = CreateClient(handler, new MutableTimeProvider(Now));
+
+        var result = await sut.GetLabelAsync(
+            new AssetReference(AssetType.LocalFile, @"C:\notes\plain.txt"), CancellationToken.None);
+
+        result.Source.Should().Be(LabelSource.None);
+        result.Label.Should().BeNull();
+        result.HasClassification.Should().BeFalse();
+        handler.CallCount.Should().Be(0, "a plain path carries no label id, so no Graph round trip is needed");
+    }
+
+    [Fact]
+    public async Task GetLabelAsync_BareGuidMatchingCatalog_ResolvesLabel()
+    {
+        var handler = new StubHandler(_ => Ok(CatalogJson()));
+        var sut = CreateClient(handler, new MutableTimeProvider(Now));
+
+        var result = await sut.GetLabelAsync(
+            new AssetReference(AssetType.LocalFile, ConfidentialId), CancellationToken.None);
+
+        result.Source.Should().Be(LabelSource.InformationProtection);
+        result.Label!.Name.Should().Be("Confidential");
+        result.Label.Id.Should().Be(ConfidentialId);
+        result.IsStale.Should().BeFalse("Information Protection labels are embedded, not scan-derived");
+    }
+
+    [Fact]
+    public async Task GetLabelAsync_MsipMarkerMatchingCatalog_ResolvesLabel()
+    {
+        var handler = new StubHandler(_ => Ok(CatalogJson()));
+        var sut = CreateClient(handler, new MutableTimeProvider(Now));
+
+        // The marker form MIP writes into a file's custom properties.
+        var identifier = $"MSIP_Label_{HighlyConfidentialId}_Enabled=True";
+        var result = await sut.GetLabelAsync(
+            new AssetReference(AssetType.LocalFile, identifier), CancellationToken.None);
+
+        result.Source.Should().Be(LabelSource.InformationProtection);
+        result.Label!.Name.Should().Be("Highly Confidential");
+    }
+
+    [Fact]
+    public async Task GetLabelAsync_LabelIdNotInCatalog_ReturnsUnknown()
+    {
+        var handler = new StubHandler(_ => Ok(CatalogJson()));
+        var sut = CreateClient(handler, new MutableTimeProvider(Now));
+
+        var result = await sut.GetLabelAsync(
+            new AssetReference(AssetType.LocalFile, "99999999-9999-9999-9999-999999999999"),
+            CancellationToken.None);
+
+        result.Source.Should().Be(LabelSource.None);
+        result.Label.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetLabelAsync_GraphReturnsError_ThrowsWithoutLeakingToken()
+    {
+        var handler = new StubHandler(_ => new HttpResponseMessage(HttpStatusCode.InternalServerError));
+        var sut = CreateClient(handler, new MutableTimeProvider(Now));
+
+        var act = async () => await sut.GetLabelAsync(
+            new AssetReference(AssetType.LocalFile, ConfidentialId), CancellationToken.None);
+
+        var ex = await act.Should().ThrowAsync<InvalidOperationException>();
+        ex.Which.Message.Should().Contain("500");
+        ex.Which.Message.Should().NotContain(FakeCredential.TokenValue);
+    }
+
+    [Fact]
+    public async Task GetLabelAsync_GraphReturns200WithoutValueCollection_Throws()
+    {
+        // A 200 whose body lacks the 'value' array is an unrecognized shape — it must fail closed rather
+        // than caching an empty taxonomy that silently degrades labelled assets to Unknown for the TTL.
+        var handler = new StubHandler(_ => Ok("{}"));
+        var sut = CreateClient(handler, new MutableTimeProvider(Now));
+
+        var act = async () => await sut.GetLabelAsync(
+            new AssetReference(AssetType.LocalFile, ConfidentialId), CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+    }
+
+    [Fact]
+    public async Task GetLabelAsync_CachesCatalog_AcrossCallsWithinTtl()
+    {
+        var handler = new StubHandler(_ => Ok(CatalogJson()));
+        var sut = CreateClient(handler, new MutableTimeProvider(Now));
+
+        await sut.GetLabelAsync(new AssetReference(AssetType.LocalFile, ConfidentialId), CancellationToken.None);
+        await sut.GetLabelAsync(new AssetReference(AssetType.LocalFile, HighlyConfidentialId), CancellationToken.None);
+
+        handler.CallCount.Should().Be(1, "the taxonomy is fetched once and reused within the TTL");
+    }
+
+    [Fact]
+    public async Task GetLabelAsync_RefetchesCatalog_AfterTtlExpires()
+    {
+        var handler = new StubHandler(_ => Ok(CatalogJson()));
+        var time = new MutableTimeProvider(Now);
+        var sut = CreateClient(handler, time, catalogTtl: TimeSpan.FromMinutes(30));
+
+        await sut.GetLabelAsync(new AssetReference(AssetType.LocalFile, ConfidentialId), CancellationToken.None);
+        time.Advance(TimeSpan.FromMinutes(31));
+        await sut.GetLabelAsync(new AssetReference(AssetType.LocalFile, ConfidentialId), CancellationToken.None);
+
+        handler.CallCount.Should().Be(2, "an expired taxonomy must be refreshed from Graph");
+    }
+
+    [Fact]
+    public async Task GetLabelAsync_AttachesBearerTokenAndRequestsConfiguredScopes()
+    {
+        var handler = new StubHandler(_ => Ok(CatalogJson()));
+        var credential = new FakeCredential();
+        var sut = new GraphSensitivityLabelClient(
+            new StubHttpClientFactory(handler), credential, Config().InformationProtection, new MutableTimeProvider(Now),
+            NullLogger<GraphSensitivityLabelClient>.Instance);
+
+        await sut.GetLabelAsync(new AssetReference(AssetType.LocalFile, ConfidentialId), CancellationToken.None);
+
+        handler.LastAuthScheme.Should().Be("Bearer");
+        handler.LastAuthToken.Should().Be(FakeCredential.TokenValue);
+        credential.LastScopes.Should().Equal("https://graph.test/.default");
+        handler.LastRequestUri!.AbsoluteUri.Should()
+            .Be("https://graph.test/v1.0/security/dataSecurityAndGovernance/sensitivityLabels");
+    }
+
+    [Fact]
+    public async Task GetLabelAsync_NullAsset_Throws()
+    {
+        var sut = CreateClient(new StubHandler(_ => Ok(CatalogJson())), new MutableTimeProvider(Now));
+
+        var act = async () => await sut.GetLabelAsync(null!, CancellationToken.None);
+
+        await act.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    private static HttpResponseMessage Ok(string json) =>
+        new(HttpStatusCode.OK) { Content = new StringContent(json, Encoding.UTF8, "application/json") };
+
+    private sealed class StubHttpClientFactory(HttpMessageHandler handler) : IHttpClientFactory
+    {
+        // disposeHandler: false so the shared stub survives disposal of the per-fetch client.
+        public HttpClient CreateClient(string name) => new(handler, disposeHandler: false);
+    }
+
+    private sealed class StubHandler(Func<HttpRequestMessage, HttpResponseMessage> responder) : HttpMessageHandler
+    {
+        public int CallCount { get; private set; }
+        public Uri? LastRequestUri { get; private set; }
+        public string? LastAuthScheme { get; private set; }
+        public string? LastAuthToken { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            CallCount++;
+            LastRequestUri = request.RequestUri;
+            LastAuthScheme = request.Headers.Authorization?.Scheme;
+            LastAuthToken = request.Headers.Authorization?.Parameter;
+            return Task.FromResult(responder(request));
+        }
+    }
+
+    private sealed class FakeCredential : TokenCredential
+    {
+        public const string TokenValue = "fake-access-token";
+        public string[] LastScopes { get; private set; } = [];
+
+        public override AccessToken GetToken(TokenRequestContext requestContext, CancellationToken cancellationToken)
+        {
+            LastScopes = requestContext.Scopes;
+            return new AccessToken(TokenValue, Now.AddHours(1));
+        }
+
+        public override ValueTask<AccessToken> GetTokenAsync(TokenRequestContext requestContext, CancellationToken cancellationToken)
+            => new(GetToken(requestContext, cancellationToken));
+    }
+
+    private sealed class MutableTimeProvider(DateTimeOffset start) : TimeProvider
+    {
+        private DateTimeOffset _now = start;
+        public override DateTimeOffset GetUtcNow() => _now;
+        public void Advance(TimeSpan by) => _now += by;
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Governance.Tests/Infrastructure.AI.Governance.Tests.csproj
+++ b/src/Content/Tests/Infrastructure.AI.Governance.Tests/Infrastructure.AI.Governance.Tests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Moq" />
     <PackageReference Include="xunit" />


### PR DESCRIPTION
## Summary
PR2 of the Purview data-classification DLP feature (PR1 = the seam, merged #91). Adds the **Information Protection (MIP)** classification provider — the Microsoft Graph-backed source of sensitivity labels — behind the `IDataClassificationProvider` seam.

## What's in it
- **`GraphSensitivityLabelClient : IDataClassificationProvider`** — fetches and TTL-caches the tenant's sensitivity-label taxonomy from Microsoft Graph (`GET /security/dataSecurityAndGovernance/sensitivityLabels`, app permission `SensitivityLabels.Read.All`), then maps an embedded label id parsed from the asset (a bare GUID or the MIP `MSIP_Label_{guid}_` marker) to a `SensitivityLabel`. No embedded id ⇒ `Unknown` **with no network call** (the common case for ordinary files). Fails **closed** (throws) when Graph is unreachable, returns a non-success status, or returns a `200` whose body lacks a `value` collection — so the enforcement point applies its fail-closed policy rather than silently allowing.
- **`CachedDataClassificationProvider`** — TTL cache decorator keyed by `AssetReference`; never caches a failure.
- **Config** — new `InformationProtectionProviderConfig` (enabled flag, Graph base URL, scopes, Entra `Auth`, label-catalog TTL) + `DataClassificationConfig.ResultCacheTtl`, with FluentValidation rules (valid absolute http(s) URL, non-empty scopes, positive TTLs), all conditional on the provider being enabled.
- **DI** — wires the real provider (behind the cache) only when `Mode != Off` **and** the IP provider is enabled; otherwise keeps the fail-fast `NotConfigured` default. Uses `IHttpClientFactory` per fetch for handler rotation; credential built lazily in the singleton factory.

## Honest scope (verified against the Graph API)
Graph supplies the label **dictionary** (id → name); it does **not** read a local file's embedded label — that requires the native MIP File SDK. So file → label-id extraction lands in **PR4's** asset resolver. This matches the plan's documented "local files are usually Unknown" reality. (SharePoint/OneDrive `extractSensitivityLabels` was considered and deferred — it needs a new asset type and is PR3+ scope.)

## Tests
16 new tests (Graph client + cache decorator + validator). Full solution suite green, build 0 errors.

## Defaults unchanged
`Mode = Off`, `UnknownAssetAction = Allow`, IP provider `Enabled = false` — a freshly cloned template still contacts nothing and behaves exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)