### PR TITLE
feat(governance): Purview Data Map classification provider + routing (DLP PR3)

### DIFF
--- a/src/Content/Application/Application.Core/Validation/DataClassificationConfigValidator.cs
+++ b/src/Content/Application/Application.Core/Validation/DataClassificationConfigValidator.cs
@@ -56,6 +56,27 @@ public sealed class DataClassificationConfigValidator : AbstractValidator<DataCl
                 .GreaterThan(TimeSpan.Zero)
                 .WithMessage("InformationProtection.LabelCatalogCacheTtl must be positive so the label taxonomy is cached.");
         });
+
+        // Data Map provider rules apply only once it is switched on, independent of Mode: an operator may
+        // stage the provider's connection settings before flipping the gate.
+        When(x => x.DataMap.Enabled, () =>
+        {
+            RuleFor(x => x.DataMap.AccountEndpoint)
+                .Must(BeValidHttpUrl)
+                .WithMessage("DataMap.AccountEndpoint must be a valid absolute http(s) URL (e.g. https://your-account.purview.azure.com).");
+
+            RuleFor(x => x.DataMap.Scopes)
+                .NotEmpty()
+                .WithMessage("DataMap.Scopes must contain at least one OAuth scope to mint a Data Map token.");
+
+            RuleForEach(x => x.DataMap.Scopes)
+                .Must(scope => !string.IsNullOrWhiteSpace(scope))
+                .WithMessage("DataMap.Scopes contains a blank scope; remove it or supply a value.");
+
+            RuleFor(x => x.DataMap.StalenessThreshold)
+                .GreaterThan(TimeSpan.Zero)
+                .WithMessage("DataMap.StalenessThreshold must be positive so scan freshness can be judged.");
+        });
     }
 
     private static bool BeValidHttpUrl(string url) =>

--- a/src/Content/Domain/Domain.Common/Config/AI/Governance/DataClassificationConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/Governance/DataClassificationConfig.cs
@@ -58,6 +58,14 @@ public sealed class DataClassificationConfig
     public InformationProtectionProviderConfig InformationProtection { get; init; } = new();
 
     /// <summary>
+    /// Configuration for the Microsoft Purview Data Map provider — the data-estate source of sensitivity
+    /// labels and classifications for cloud assets (Azure Blob, ADLS Gen2, Azure SQL, Cosmos DB). Opt-in
+    /// via <see cref="DataMapProviderConfig.Enabled"/>; off by default. The classification gate routes an
+    /// asset to this provider or to <see cref="InformationProtection"/> by the asset's kind.
+    /// </summary>
+    public DataMapProviderConfig DataMap { get; init; } = new();
+
+    /// <summary>
     /// How long a resolved <c>AssetLabelResult</c> is cached, keyed by the asset, before the provider is
     /// consulted again. Caching is mandatory in practice — without it every gated tool call incurs a
     /// Purview round trip. Defaults to five minutes; a non-positive value disables result caching.

--- a/src/Content/Domain/Domain.Common/Config/AI/Governance/DataMapProviderConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/Governance/DataMapProviderConfig.cs
@@ -1,0 +1,82 @@
+using Domain.Common.Config.Azure;
+
+namespace Domain.Common.Config.AI.Governance;
+
+/// <summary>
+/// Configuration for the Microsoft Purview Data Map classification provider — the data-estate half of the
+/// data-classification gate. Bound from
+/// <c>AppConfig:AI:Governance:DataClassification:DataMap</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The Data Map provider resolves a cloud data asset's sensitivity by reading the scanned catalog entry
+/// for that asset from the Purview Data Map (the Apache Atlas-based catalog), keyed by the asset's
+/// fully-qualified name. It surfaces the asset's applied sensitivity label and the classification findings
+/// a scan attached to it (for example "Credit Card Number"). This covers Azure Blob, ADLS Gen2, Azure SQL,
+/// and Cosmos DB — the asset kinds the Data Map can scan — whereas the Information Protection provider
+/// covers documents/files with embedded labels.
+/// </para>
+/// <para>
+/// <strong>Scan-time metadata.</strong> Data Map labels and classifications reflect the asset's last scan,
+/// not its live state, so a result can be stale between scans. The provider flags this on
+/// <c>AssetLabelResult.IsStale</c> using <see cref="StalenessThreshold"/> so a policy or audit can
+/// distinguish "recently verified" from "no recent scan".
+/// </para>
+/// <para>
+/// <strong>Opt-in.</strong> <see cref="Enabled"/> defaults to <c>false</c>, so even with classification
+/// enforcement switched on the harness only contacts the Purview Data Map once an operator deliberately
+/// wires it with an account endpoint and credentials.
+/// </para>
+/// </remarks>
+public sealed class DataMapProviderConfig
+{
+    /// <summary>
+    /// Whether the Purview Data Map provider is active. When <c>false</c> (the default) the harness does
+    /// not register the provider and never contacts the Data Map.
+    /// </summary>
+    public bool Enabled { get; init; }
+
+    /// <summary>
+    /// Base data-plane endpoint of the Purview account's catalog — the host the Atlas REST calls target,
+    /// for example <c>https://my-account.purview.azure.com</c>. The Atlas catalog path
+    /// (<c>/catalog/api/atlas/v2/…</c>) is appended by the provider. For the new Microsoft Purview portal
+    /// the shared endpoint is <c>https://api.purview-service.microsoft.com</c>.
+    /// </summary>
+    public string AccountEndpoint { get; init; } = string.Empty;
+
+    /// <summary>
+    /// OAuth scopes requested when minting the Data Map access token. Defaults to the Purview data-plane
+    /// resource scope (<c>https://purview.azure.net/.default</c>), which is correct for a managed identity
+    /// or app registration assigned a Purview data-reader role.
+    /// </summary>
+    public IReadOnlyList<string> Scopes { get; init; } = ["https://purview.azure.net/.default"];
+
+    /// <summary>
+    /// Entra credential used to authenticate to the Purview Data Map. Leave the explicit fields unset to
+    /// use the ambient managed identity / default credential chain (the recommended production posture);
+    /// supply client-secret or certificate fields for non-managed-identity hosts. A secret, if any, must
+    /// come from User Secrets or Key Vault — never appsettings.json.
+    /// </summary>
+    public EntraCredentialConfig Auth { get; init; } = new();
+
+    /// <summary>
+    /// Optional prefix that marks which of an asset's free-text label tags is its applied sensitivity
+    /// label. The Purview Data Map returns an asset's labels as a free-text tag set that mixes the applied
+    /// sensitivity label with arbitrary operational tags, and does not flag which is which. When this
+    /// prefix is set (matched case-insensitively), only tags beginning with it are treated as the
+    /// sensitivity label, and the prefix is stripped from the resolved label name — so an organization that
+    /// tags sensitivity as <c>MIP_Confidential</c> sets the prefix to <c>MIP_</c> and authors policy
+    /// against <c>Confidential</c>. When empty (the default), every tag is a candidate and the first by
+    /// ordinal order is used; deployments whose assets also carry non-sensitivity tags should set a prefix
+    /// so the gate does not key its decision on the wrong tag.
+    /// </summary>
+    public string SensitivityLabelTagPrefix { get; init; } = string.Empty;
+
+    /// <summary>
+    /// How old a scanned asset's metadata may be before its result is flagged as stale on
+    /// <c>AssetLabelResult.IsStale</c>. Compared against the catalog entry's last-update time. An asset
+    /// whose update time is unknown is always treated as stale, since freshness cannot be verified.
+    /// Defaults to seven days, a typical Data Map scan cadence.
+    /// </summary>
+    public TimeSpan StalenessThreshold { get; init; } = TimeSpan.FromDays(7);
+}

--- a/src/Content/Infrastructure/Infrastructure.AI.Governance/Classification/PurviewDataMapClient.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.Governance/Classification/PurviewDataMapClient.cs
@@ -1,0 +1,262 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Application.AI.Common.Interfaces.Governance;
+using Azure.Core;
+using Domain.AI.Governance;
+using Domain.Common.Config.AI.Governance;
+using Microsoft.Extensions.Logging;
+
+namespace Infrastructure.AI.Governance.Classification;
+
+/// <summary>
+/// Microsoft Purview Data Map classification provider. Resolves a cloud data asset's sensitivity by
+/// reading its scanned catalog entry from the Purview Data Map (the Apache Atlas-based catalog), keyed by
+/// the asset's fully-qualified name.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>What the Data Map can and cannot do.</strong> The Data Map answers for asset kinds it has
+/// scanned — Azure Blob, ADLS Gen2, Azure SQL, Cosmos DB — and returns the applied sensitivity label plus
+/// the classification findings a scan attached to the asset. It does not track local files (that is the
+/// Information Protection provider's world), and its labels are <em>scan-time metadata</em>: they reflect
+/// the last scan, not live state, so a result can be stale between scans. The provider flags this on
+/// <see cref="AssetLabelResult.IsStale"/>.
+/// </para>
+/// <para>
+/// <strong>How the sensitivity label is resolved.</strong> The default policy evaluator is
+/// sensitivity-label driven — it keys its allow/redact/block decision on the label <em>name</em>, with
+/// scan classifications carried only for audit. The Data Map surfaces an asset's applied sensitivity label
+/// among the catalog entry's free-text label tags but does not flag which tag it is, so this provider
+/// selects the sensitivity-label tag deterministically: when
+/// <see cref="DataMapProviderConfig.SensitivityLabelTagPrefix"/> is set, the first (by ordinal order) tag
+/// carrying that prefix wins and the prefix is stripped from the resolved name; otherwise the first tag by
+/// ordinal order is used. The resolved name doubles as the label id (Atlas label tags carry no GUID), and
+/// the scan classifications map to <see cref="DataClassification"/> findings. This surfacing is
+/// source-dependent — an asset whose scan propagated no matching label tag resolves with no label and
+/// falls to the unknown-asset policy, even when it carries classifications.
+/// </para>
+/// <para>
+/// <strong>Failure handling.</strong> An asset the Data Map has never scanned returns
+/// <see cref="HttpStatusCode.NotFound"/>, which the provider maps to a benign Unknown result (there is
+/// genuinely nothing to enforce on). Any other non-success status surfaces as an exception rather than a
+/// silent Unknown, so the enforcement point can apply its fail-closed policy instead of treating an
+/// unreachable backend as "nothing to see". The fully-qualified name is the only request input and the
+/// account endpoint is operator-configured, so there is no response-driven URL to follow and no bearer
+/// token to leak off-host.
+/// </para>
+/// </remarks>
+public sealed class PurviewDataMapClient : IDataClassificationProvider
+{
+    /// <summary>
+    /// Name of the <see cref="IHttpClientFactory"/> client this provider resolves on each lookup. Using
+    /// the factory per call lets it pool and rotate the underlying handler instead of pinning one handler
+    /// for the lifetime of this singleton provider (which would leave DNS and sockets stale).
+    /// </summary>
+    public const string HttpClientName = "purview-data-map";
+
+    /// <summary>
+    /// Maps each Data Map-classifiable <see cref="AssetType"/> to its Apache Atlas entity type name, which
+    /// the Atlas <c>get entity by unique attribute</c> call needs alongside the qualified name. Azure SQL
+    /// maps to the table type; column-level labels are a source-dependent preview and are out of scope.
+    /// Asset kinds absent from this map are not answerable by the Data Map and resolve to Unknown.
+    /// </summary>
+    private static readonly IReadOnlyDictionary<AssetType, string> AtlasTypeNames =
+        new Dictionary<AssetType, string>
+        {
+            [AssetType.AzureBlob] = "azure_blob_path",
+            [AssetType.AdlsGen2] = "azure_datalake_gen2_path",
+            [AssetType.AzureSql] = "azure_sql_table",
+            [AssetType.CosmosDb] = "azure_cosmosdb_sqlapi_collection",
+        };
+
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly TokenCredential _credential;
+    private readonly TimeProvider _timeProvider;
+    private readonly ILogger<PurviewDataMapClient> _logger;
+
+    private readonly Uri _catalogBase;
+    private readonly string[] _scopes;
+    private readonly TimeSpan _stalenessThreshold;
+    private readonly string _sensitivityLabelTagPrefix;
+
+    /// <summary>Initializes a new instance of the <see cref="PurviewDataMapClient"/> class.</summary>
+    /// <param name="httpClientFactory">Factory used to resolve a fresh, handler-rotated client per lookup.</param>
+    /// <param name="credential">Entra credential used to mint Purview data-plane access tokens.</param>
+    /// <param name="config">The Data Map provider configuration this client binds to.</param>
+    /// <param name="timeProvider">Clock used for result timestamps and staleness evaluation.</param>
+    /// <param name="logger">Logger for diagnostics.</param>
+    public PurviewDataMapClient(
+        IHttpClientFactory httpClientFactory,
+        TokenCredential credential,
+        DataMapProviderConfig config,
+        TimeProvider timeProvider,
+        ILogger<PurviewDataMapClient> logger)
+    {
+        ArgumentNullException.ThrowIfNull(httpClientFactory);
+        ArgumentNullException.ThrowIfNull(credential);
+        ArgumentNullException.ThrowIfNull(config);
+        ArgumentNullException.ThrowIfNull(timeProvider);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _httpClientFactory = httpClientFactory;
+        _credential = credential;
+        _timeProvider = timeProvider;
+        _logger = logger;
+        _scopes = [.. config.Scopes];
+        _stalenessThreshold = config.StalenessThreshold;
+        _sensitivityLabelTagPrefix = config.SensitivityLabelTagPrefix ?? string.Empty;
+        _catalogBase = BuildCatalogBase(config.AccountEndpoint);
+    }
+
+    /// <inheritdoc />
+    public async Task<AssetLabelResult> GetLabelAsync(AssetReference asset, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(asset);
+
+        // The Data Map can only answer for scanned cloud asset kinds, and only when given a qualified name
+        // to key on. Anything else has nothing to look up — return Unknown without a network call so the
+        // unknown-asset policy applies.
+        if (!AtlasTypeNames.TryGetValue(asset.Type, out var typeName) ||
+            string.IsNullOrWhiteSpace(asset.Identifier))
+        {
+            return AssetLabelResult.Unknown(asset, _timeProvider.GetUtcNow());
+        }
+
+        var requestUri = BuildEntityUri(typeName, asset.Identifier);
+        var entity = await GetEntityAsync(requestUri, cancellationToken).ConfigureAwait(false);
+        var now = _timeProvider.GetUtcNow();
+
+        // A NotFound asset is genuinely unscanned — there is nothing to enforce on, so treat it as Unknown
+        // rather than a failure.
+        if (entity is null)
+            return AssetLabelResult.Unknown(asset, now);
+
+        var label = ResolveLabel(entity.Labels);
+        var classifications = ResolveClassifications(entity.Classifications);
+        var isStale = IsStale(entity.UpdateTime, now);
+
+        return new AssetLabelResult(asset, label, classifications, LabelSource.DataMap, now, isStale);
+    }
+
+    /// <summary>
+    /// Reads the catalog entity, returning null when the asset is unscanned (<see cref="HttpStatusCode.NotFound"/>)
+    /// and throwing on any other non-success status so the gate can fail closed.
+    /// </summary>
+    private async Task<AtlasEntity?> GetEntityAsync(Uri requestUri, CancellationToken cancellationToken)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+        var token = await _credential
+            .GetTokenAsync(new TokenRequestContext(_scopes), cancellationToken)
+            .ConfigureAwait(false);
+        request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token.Token);
+
+        // Resolved (and disposed) per request so the factory can rotate the underlying handler.
+        using var httpClient = _httpClientFactory.CreateClient(HttpClientName);
+        using var response = await httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+
+        if (response.StatusCode == HttpStatusCode.NotFound)
+        {
+            _logger.LogDebug("Purview Data Map has no scanned entry for the requested asset; treating it as unclassified.");
+            return null;
+        }
+
+        if (!response.IsSuccessStatusCode)
+        {
+            // Status only — never echo the response body or token, which can carry tenant detail.
+            throw new InvalidOperationException(
+                $"Failed to read the asset's entry from the Microsoft Purview Data Map (HTTP {(int)response.StatusCode}).");
+        }
+
+        var payload = await response.Content
+            .ReadFromJsonAsync<AtlasEntityWithExtInfo>(JsonOptions, cancellationToken)
+            .ConfigureAwait(false);
+
+        // A 2xx whose body carries no entity is an unrecognized shape — fail closed rather than silently
+        // degrading a real asset to Unknown.
+        if (payload?.Entity is null)
+        {
+            throw new InvalidOperationException(
+                "The Microsoft Purview Data Map response did not contain an 'entity'; the response shape was not understood.");
+        }
+
+        return payload.Entity;
+    }
+
+    /// <summary>
+    /// Resolves the asset's sensitivity label from its Atlas label tags. Tags are considered in ordinal
+    /// order so the same asset always resolves to the same label regardless of the order the Data Map
+    /// returns them in. When a prefix is configured, only tags carrying it qualify and the prefix is
+    /// stripped from the resolved name; otherwise the first tag is used. The resolved name doubles as the
+    /// id, since Data Map label tags carry no GUID. Returns null when no qualifying tag is present, which
+    /// the evaluator treats via the unknown-asset policy.
+    /// </summary>
+    private SensitivityLabel? ResolveLabel(IReadOnlyList<string>? labels)
+    {
+        if (labels is null)
+            return null;
+
+        var candidates = labels
+            .Where(tag => !string.IsNullOrWhiteSpace(tag))
+            .Select(tag => tag.Trim());
+
+        // No prefix: the first tag by ordinal order is the label. With a prefix: only prefix-carrying tags
+        // qualify and the prefix is stripped. Ordinal ordering keeps the choice stable across scans.
+        var name = _sensitivityLabelTagPrefix.Length == 0
+            ? candidates.OrderBy(tag => tag, StringComparer.Ordinal).FirstOrDefault()
+            : candidates
+                .Where(tag => tag.StartsWith(_sensitivityLabelTagPrefix, StringComparison.OrdinalIgnoreCase))
+                .Select(tag => tag[_sensitivityLabelTagPrefix.Length..].Trim())
+                .Where(stripped => stripped.Length > 0)
+                .OrderBy(stripped => stripped, StringComparer.Ordinal)
+                .FirstOrDefault();
+
+        return string.IsNullOrEmpty(name) ? null : new SensitivityLabel(name, name);
+    }
+
+    /// <summary>
+    /// Projects the scan classifications onto <see cref="DataClassification"/> findings, dropping blanks.
+    /// Atlas reports no confidence on the entity classification, so the default full confidence is used.
+    /// </summary>
+    private static IReadOnlyList<DataClassification> ResolveClassifications(IReadOnlyList<AtlasClassification>? classifications)
+    {
+        if (classifications is null || classifications.Count == 0)
+            return [];
+
+        var findings = new List<DataClassification>(classifications.Count);
+        foreach (var classification in classifications)
+        {
+            if (!string.IsNullOrWhiteSpace(classification.TypeName))
+                findings.Add(new DataClassification(classification.TypeName.Trim()));
+        }
+
+        return findings;
+    }
+
+    /// <summary>
+    /// Judges staleness from the catalog entry's last-update time. An asset whose update time is unknown
+    /// (null or non-positive) or implausibly in the future (clock skew, corrupt scan metadata) is treated
+    /// as stale, since in neither case can freshness be trusted; otherwise it is stale once its age exceeds
+    /// the configured threshold.
+    /// </summary>
+    private bool IsStale(long? updateTimeEpochMs, DateTimeOffset now)
+    {
+        if (updateTimeEpochMs is null or <= 0)
+            return true;
+
+        var age = now - DateTimeOffset.FromUnixTimeMilliseconds(updateTimeEpochMs.Value);
+        return age < TimeSpan.Zero || age > _stalenessThreshold;
+    }
+
+    private static Uri BuildCatalogBase(string accountEndpoint)
+    {
+        var baseUrl = accountEndpoint.EndsWith('/') ? accountEndpoint : accountEndpoint + "/";
+        return new Uri(new Uri(baseUrl), "catalog/api/atlas/v2/entity/uniqueAttribute/type/");
+    }
+
+    private Uri BuildEntityUri(string typeName, string qualifiedName) =>
+        new(_catalogBase,
+            $"{Uri.EscapeDataString(typeName)}?attr:qualifiedName={Uri.EscapeDataString(qualifiedName)}");
+}

--- a/src/Content/Infrastructure/Infrastructure.AI.Governance/Classification/PurviewDataMapDtos.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.Governance/Classification/PurviewDataMapDtos.cs
@@ -1,0 +1,45 @@
+using System.Text.Json.Serialization;
+
+namespace Infrastructure.AI.Governance.Classification;
+
+/// <summary>
+/// Wire-format envelope for an Apache Atlas <c>get entity by unique attribute</c> response from the
+/// Microsoft Purview Data Map — <c>GET /catalog/api/atlas/v2/entity/uniqueAttribute/type/{typeName}</c>.
+/// Only the single resolved <see cref="Entity"/> is bound; the response's <c>referredEntities</c> map is
+/// ignored. Internal to the Data Map provider.
+/// </summary>
+/// <param name="Entity">
+/// The resolved catalog entity, or null when the body did not carry one (an unrecognized shape).
+/// </param>
+internal sealed record AtlasEntityWithExtInfo(
+    [property: JsonPropertyName("entity")] AtlasEntity? Entity);
+
+/// <summary>
+/// Wire-format projection of an Apache Atlas entity as the Purview Data Map returns it. Only the fields
+/// the classification gate needs — the applied sensitivity labels, the scan classifications, and the
+/// last-update time used to judge staleness — are bound; the rest of the entity is ignored.
+/// </summary>
+/// <param name="Labels">
+/// The asset's applied label tags. In a Purview Data Map deployment the applied sensitivity label surfaces
+/// here; the provider treats the first as the asset's sensitivity label. Null when the asset carries none.
+/// </param>
+/// <param name="Classifications">
+/// The classification findings a scan attached to the asset (for example a credit-card or SSN
+/// classification). Carried as audit detail. Null when the asset carries none.
+/// </param>
+/// <param name="UpdateTime">
+/// The catalog entry's last-update time as Unix epoch milliseconds, used to judge whether the scanned
+/// metadata is stale. Null or zero when the Data Map did not report one.
+/// </param>
+internal sealed record AtlasEntity(
+    [property: JsonPropertyName("labels")] IReadOnlyList<string>? Labels,
+    [property: JsonPropertyName("classifications")] IReadOnlyList<AtlasClassification>? Classifications,
+    [property: JsonPropertyName("updateTime")] long? UpdateTime);
+
+/// <summary>
+/// Wire-format projection of a single Apache Atlas classification on an entity. Only the classification's
+/// type name — the human-readable finding name — is bound. Internal to the Data Map provider.
+/// </summary>
+/// <param name="TypeName">The classification's type name, surfaced as a <c>DataClassification</c> finding.</param>
+internal sealed record AtlasClassification(
+    [property: JsonPropertyName("typeName")] string? TypeName);

--- a/src/Content/Infrastructure/Infrastructure.AI.Governance/Classification/RoutingDataClassificationProvider.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.Governance/Classification/RoutingDataClassificationProvider.cs
@@ -1,0 +1,78 @@
+using Application.AI.Common.Interfaces.Governance;
+using Domain.AI.Governance;
+using Microsoft.Extensions.Logging;
+
+namespace Infrastructure.AI.Governance.Classification;
+
+/// <summary>
+/// Routes a classification lookup to the Purview surface that can answer for the asset's kind: the
+/// Information Protection provider for local files (embedded document labels) and the Data Map provider for
+/// scanned cloud data assets (Azure Blob, ADLS Gen2, Azure SQL, Cosmos DB).
+/// </summary>
+/// <remarks>
+/// <para>
+/// The two Purview worlds answer for disjoint asset kinds, so a single provider cannot serve both. This
+/// router holds each world's provider and dispatches by <see cref="AssetReference.Type"/>. Each world is
+/// independently optional: when the matching provider is not wired (the operator enabled only one world,
+/// or none), or the asset kind is one Purview cannot classify, the lookup resolves to
+/// <see cref="AssetLabelResult.Unknown(AssetReference, DateTimeOffset)"/> without a network call, so the
+/// unknown-asset policy applies.
+/// </para>
+/// <para>
+/// Routing is by asset kind alone and incurs no I/O of its own; per-asset result caching is the
+/// surrounding <see cref="CachedDataClassificationProvider"/>'s job, so this router is wrapped by it.
+/// </para>
+/// </remarks>
+public sealed class RoutingDataClassificationProvider : IDataClassificationProvider
+{
+    private readonly IDataClassificationProvider? _informationProtection;
+    private readonly IDataClassificationProvider? _dataMap;
+    private readonly TimeProvider _timeProvider;
+    private readonly ILogger<RoutingDataClassificationProvider> _logger;
+
+    /// <summary>Initializes a new instance of the <see cref="RoutingDataClassificationProvider"/> class.</summary>
+    /// <param name="informationProtection">
+    /// The Information Protection provider for local-file labels, or null when that world is not wired.
+    /// </param>
+    /// <param name="dataMap">
+    /// The Data Map provider for scanned cloud assets, or null when that world is not wired.
+    /// </param>
+    /// <param name="timeProvider">Clock used to timestamp Unknown results produced without a provider call.</param>
+    /// <param name="logger">Logger for diagnostics.</param>
+    public RoutingDataClassificationProvider(
+        IDataClassificationProvider? informationProtection,
+        IDataClassificationProvider? dataMap,
+        TimeProvider timeProvider,
+        ILogger<RoutingDataClassificationProvider> logger)
+    {
+        ArgumentNullException.ThrowIfNull(timeProvider);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _informationProtection = informationProtection;
+        _dataMap = dataMap;
+        _timeProvider = timeProvider;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public Task<AssetLabelResult> GetLabelAsync(AssetReference asset, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(asset);
+
+        var provider = asset.Type switch
+        {
+            AssetType.LocalFile => _informationProtection,
+            AssetType.AzureBlob or AssetType.AdlsGen2 or AssetType.AzureSql or AssetType.CosmosDb => _dataMap,
+            _ => null,
+        };
+
+        if (provider is null)
+        {
+            _logger.LogDebug(
+                "No classification provider is wired for asset kind {AssetType}; resolving as Unknown.", asset.Type);
+            return Task.FromResult(AssetLabelResult.Unknown(asset, _timeProvider.GetUtcNow()));
+        }
+
+        return provider.GetLabelAsync(asset, cancellationToken);
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI.Governance/DependencyInjection.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.Governance/DependencyInjection.cs
@@ -71,42 +71,65 @@ public static class DependencyInjection
 
     /// <summary>
     /// Registers the data-classification policy evaluator and the appropriate
-    /// <see cref="IDataClassificationProvider"/>. Wires the real Graph-backed
-    /// <see cref="GraphSensitivityLabelClient"/> (behind a TTL cache) only when classification is enabled
-    /// and the Information Protection provider is switched on; otherwise keeps the fail-fast default so an
-    /// enabled-but-unconfigured gate fails loudly rather than silently allowing everything.
+    /// <see cref="IDataClassificationProvider"/>. When classification is enabled and at least one Purview
+    /// world is switched on, wires those worlds — the Graph-backed <see cref="GraphSensitivityLabelClient"/>
+    /// for documents/files and the <see cref="PurviewDataMapClient"/> for scanned cloud assets — behind a
+    /// <see cref="RoutingDataClassificationProvider"/> and a shared TTL cache. Otherwise keeps the
+    /// fail-fast default so an enabled-but-unconfigured gate fails loudly rather than silently allowing
+    /// everything.
     /// </summary>
     internal static void AddDataClassificationProvider(IServiceCollection services, DataClassificationConfig config)
     {
         services.AddSingleton<IClassificationPolicyEvaluator, DefaultClassificationPolicyEvaluator>();
 
         var ip = config.InformationProtection;
-        if (config.Mode == ClassificationEnforcementMode.Off || !ip.Enabled)
+        var dataMap = config.DataMap;
+        if (config.Mode == ClassificationEnforcementMode.Off || (!ip.Enabled && !dataMap.Enabled))
         {
             services.AddSingleton<IDataClassificationProvider, NotConfiguredDataClassificationProvider>();
             return;
         }
 
-        services.AddHttpClient(GraphSensitivityLabelClient.HttpClientName);
+        if (ip.Enabled)
+            services.AddHttpClient(GraphSensitivityLabelClient.HttpClientName);
+
+        if (dataMap.Enabled)
+            services.AddHttpClient(PurviewDataMapClient.HttpClientName);
 
         services.AddSingleton<IDataClassificationProvider>(sp =>
         {
             var timeProvider = sp.GetRequiredService<TimeProvider>();
+            var httpClientFactory = sp.GetRequiredService<IHttpClientFactory>();
 
-            // Azure.Identity caches and refreshes the token in-process, so building the credential once
-            // for the singleton is correct; it is created lazily here so a credential-config error
-            // surfaces when the provider is first resolved rather than during the DI graph build.
-            var credential = AzureCredentialFactory.CreateTokenCredential(ip.Auth);
+            // Azure.Identity caches and refreshes tokens in-process, so building each credential once for
+            // the singleton is correct; they are created lazily here so a credential-config error surfaces
+            // when the provider is first resolved rather than during the DI graph build.
+            IDataClassificationProvider? mip = ip.Enabled
+                ? new GraphSensitivityLabelClient(
+                    httpClientFactory,
+                    AzureCredentialFactory.CreateTokenCredential(ip.Auth),
+                    ip,
+                    timeProvider,
+                    sp.GetRequiredService<ILogger<GraphSensitivityLabelClient>>())
+                : null;
 
-            var inner = new GraphSensitivityLabelClient(
-                sp.GetRequiredService<IHttpClientFactory>(),
-                credential,
-                ip,
+            IDataClassificationProvider? dataMapProvider = dataMap.Enabled
+                ? new PurviewDataMapClient(
+                    httpClientFactory,
+                    AzureCredentialFactory.CreateTokenCredential(dataMap.Auth),
+                    dataMap,
+                    timeProvider,
+                    sp.GetRequiredService<ILogger<PurviewDataMapClient>>())
+                : null;
+
+            var router = new RoutingDataClassificationProvider(
+                mip,
+                dataMapProvider,
                 timeProvider,
-                sp.GetRequiredService<ILogger<GraphSensitivityLabelClient>>());
+                sp.GetRequiredService<ILogger<RoutingDataClassificationProvider>>());
 
             return new CachedDataClassificationProvider(
-                inner,
+                router,
                 timeProvider,
                 config.ResultCacheTtl,
                 sp.GetRequiredService<ILogger<CachedDataClassificationProvider>>());

--- a/src/Content/Infrastructure/Infrastructure.AI.Governance/DependencyInjection.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.Governance/DependencyInjection.cs
@@ -62,8 +62,8 @@ public static class DependencyInjection
         services.AddSingleton<IResponseSanitizer, ExfiltrationUrlDetector>();
         services.AddSingleton<ICompositeResponseSanitizer, CompositeResponseSanitizer>();
 
-        // Data-classification seam. The policy evaluator is pure; the provider is the real Graph-backed
-        // Information Protection client when wired, else the fail-fast default.
+        // Data-classification seam. The policy evaluator is pure; the provider routes to the Graph-backed
+        // Information Protection and Purview Data Map clients when wired, else the fail-fast default.
         AddDataClassificationProvider(services, config.DataClassification);
 
         return services;
@@ -101,30 +101,9 @@ public static class DependencyInjection
             var timeProvider = sp.GetRequiredService<TimeProvider>();
             var httpClientFactory = sp.GetRequiredService<IHttpClientFactory>();
 
-            // Azure.Identity caches and refreshes tokens in-process, so building each credential once for
-            // the singleton is correct; they are created lazily here so a credential-config error surfaces
-            // when the provider is first resolved rather than during the DI graph build.
-            IDataClassificationProvider? mip = ip.Enabled
-                ? new GraphSensitivityLabelClient(
-                    httpClientFactory,
-                    AzureCredentialFactory.CreateTokenCredential(ip.Auth),
-                    ip,
-                    timeProvider,
-                    sp.GetRequiredService<ILogger<GraphSensitivityLabelClient>>())
-                : null;
-
-            IDataClassificationProvider? dataMapProvider = dataMap.Enabled
-                ? new PurviewDataMapClient(
-                    httpClientFactory,
-                    AzureCredentialFactory.CreateTokenCredential(dataMap.Auth),
-                    dataMap,
-                    timeProvider,
-                    sp.GetRequiredService<ILogger<PurviewDataMapClient>>())
-                : null;
-
             var router = new RoutingDataClassificationProvider(
-                mip,
-                dataMapProvider,
+                BuildInformationProtectionProvider(sp, ip, timeProvider, httpClientFactory),
+                BuildDataMapProvider(sp, dataMap, timeProvider, httpClientFactory),
                 timeProvider,
                 sp.GetRequiredService<ILogger<RoutingDataClassificationProvider>>());
 
@@ -135,6 +114,46 @@ public static class DependencyInjection
                 sp.GetRequiredService<ILogger<CachedDataClassificationProvider>>());
         });
     }
+
+    /// <summary>
+    /// Builds the Graph-backed Information Protection provider when that world is enabled, else null. The
+    /// Entra credential is created lazily here (not at DI graph build) so a credential-config error
+    /// surfaces when the provider is first resolved; Azure.Identity then caches and refreshes the token
+    /// in-process for the lifetime of the singleton.
+    /// </summary>
+    private static IDataClassificationProvider? BuildInformationProtectionProvider(
+        IServiceProvider sp,
+        InformationProtectionProviderConfig ip,
+        TimeProvider timeProvider,
+        IHttpClientFactory httpClientFactory) =>
+        ip.Enabled
+            ? new GraphSensitivityLabelClient(
+                httpClientFactory,
+                AzureCredentialFactory.CreateTokenCredential(ip.Auth),
+                ip,
+                timeProvider,
+                sp.GetRequiredService<ILogger<GraphSensitivityLabelClient>>())
+            : null;
+
+    /// <summary>
+    /// Builds the Purview Data Map provider when that world is enabled, else null. The Entra credential is
+    /// created lazily here (not at DI graph build) so a credential-config error surfaces when the provider
+    /// is first resolved; Azure.Identity then caches and refreshes the token in-process for the lifetime of
+    /// the singleton.
+    /// </summary>
+    private static IDataClassificationProvider? BuildDataMapProvider(
+        IServiceProvider sp,
+        DataMapProviderConfig dataMap,
+        TimeProvider timeProvider,
+        IHttpClientFactory httpClientFactory) =>
+        dataMap.Enabled
+            ? new PurviewDataMapClient(
+                httpClientFactory,
+                AzureCredentialFactory.CreateTokenCredential(dataMap.Auth),
+                dataMap,
+                timeProvider,
+                sp.GetRequiredService<ILogger<PurviewDataMapClient>>())
+            : null;
 
     /// <summary>
     /// Adds no-op governance services that satisfy DI without AGT.

--- a/src/Content/Tests/Application.Core.Tests/Validation/DataClassificationConfigValidatorTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/Validation/DataClassificationConfigValidatorTests.cs
@@ -182,4 +182,93 @@ public class DataClassificationConfigValidatorTests
         result.IsValid.Should().BeFalse();
         result.Errors.Should().Contain(e => e.PropertyName.Contains(nameof(InformationProtectionProviderConfig.LabelCatalogCacheTtl)));
     }
+
+    [Fact]
+    public async Task Validate_DataMapDisabled_SkipsProviderRules()
+    {
+        // Even with incoherent provider settings, a disabled provider imposes no constraints.
+        var config = new DataClassificationConfig
+        {
+            DataMap = new DataMapProviderConfig
+            {
+                Enabled = false,
+                AccountEndpoint = "not-a-url",
+                Scopes = [],
+                StalenessThreshold = TimeSpan.Zero,
+            },
+        };
+
+        var result = await _validator.ValidateAsync(config);
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Validate_DataMapEnabledWithEndpointAndDefaults_IsValid()
+    {
+        var config = new DataClassificationConfig
+        {
+            DataMap = new DataMapProviderConfig { Enabled = true, AccountEndpoint = "https://acct.purview.azure.com" },
+        };
+
+        var result = await _validator.ValidateAsync(config);
+
+        result.IsValid.Should().BeTrue();
+        result.Errors.Should().BeEmpty();
+    }
+
+    [Theory]
+    [InlineData("not-a-url")]
+    [InlineData("ftp://acct.purview.azure.com")]
+    [InlineData("acct.purview.azure.com")]
+    public async Task Validate_DataMapEnabledWithInvalidEndpoint_HasError(string badUrl)
+    {
+        var config = new DataClassificationConfig
+        {
+            DataMap = new DataMapProviderConfig { Enabled = true, AccountEndpoint = badUrl },
+        };
+
+        var result = await _validator.ValidateAsync(config);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName.Contains(nameof(DataMapProviderConfig.AccountEndpoint)));
+    }
+
+    [Fact]
+    public async Task Validate_DataMapEnabledWithEmptyScopes_HasError()
+    {
+        var config = new DataClassificationConfig
+        {
+            DataMap = new DataMapProviderConfig
+            {
+                Enabled = true,
+                AccountEndpoint = "https://acct.purview.azure.com",
+                Scopes = [],
+            },
+        };
+
+        var result = await _validator.ValidateAsync(config);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName.Contains(nameof(DataMapProviderConfig.Scopes)));
+    }
+
+    [Fact]
+    public async Task Validate_DataMapEnabledWithNonPositiveStalenessThreshold_HasError()
+    {
+        var config = new DataClassificationConfig
+        {
+            DataMap = new DataMapProviderConfig
+            {
+                Enabled = true,
+                AccountEndpoint = "https://acct.purview.azure.com",
+                StalenessThreshold = TimeSpan.Zero,
+            },
+        };
+
+        var result = await _validator.ValidateAsync(config);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName.Contains(nameof(DataMapProviderConfig.StalenessThreshold)));
+    }
 }

--- a/src/Content/Tests/Application.Core.Tests/Validation/DataClassificationConfigValidatorTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/Validation/DataClassificationConfigValidatorTests.cs
@@ -253,6 +253,27 @@ public class DataClassificationConfigValidatorTests
         result.Errors.Should().Contain(e => e.PropertyName.Contains(nameof(DataMapProviderConfig.Scopes)));
     }
 
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task Validate_DataMapEnabledWithBlankScope_HasError(string blankScope)
+    {
+        var config = new DataClassificationConfig
+        {
+            DataMap = new DataMapProviderConfig
+            {
+                Enabled = true,
+                AccountEndpoint = "https://acct.purview.azure.com",
+                Scopes = [blankScope],
+            },
+        };
+
+        var result = await _validator.ValidateAsync(config);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName.Contains(nameof(DataMapProviderConfig.Scopes)));
+    }
+
     [Fact]
     public async Task Validate_DataMapEnabledWithNonPositiveStalenessThreshold_HasError()
     {

--- a/src/Content/Tests/Infrastructure.AI.Governance.Tests/Classification/DataClassificationDependencyInjectionTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Governance.Tests/Classification/DataClassificationDependencyInjectionTests.cs
@@ -34,13 +34,42 @@ public sealed class DataClassificationDependencyInjectionTests
     }
 
     [Fact]
-    public void AddDataClassificationProvider_GateOnButIpProviderDisabled_ResolvesNotConfiguredDefault()
+    public void AddDataClassificationProvider_GateOnButNoProviderEnabled_ResolvesNotConfiguredDefault()
     {
         var config = new DataClassificationConfig { Mode = ClassificationEnforcementMode.Enforce };
         using var sp = BuildProvider(config);
 
         sp.GetRequiredService<IDataClassificationProvider>()
             .Should().BeOfType<NotConfiguredDataClassificationProvider>();
+    }
+
+    [Fact]
+    public void AddDataClassificationProvider_DataMapProviderEnabled_ResolvesCachedRoutingProvider()
+    {
+        var config = new DataClassificationConfig
+        {
+            Mode = ClassificationEnforcementMode.Enforce,
+            DataMap = new DataMapProviderConfig { Enabled = true, AccountEndpoint = "https://acct.purview.azure.com" },
+        };
+        using var sp = BuildProvider(config);
+
+        sp.GetRequiredService<IDataClassificationProvider>()
+            .Should().BeOfType<CachedDataClassificationProvider>();
+    }
+
+    [Fact]
+    public void AddDataClassificationProvider_BothWorldsEnabled_ResolvesCachedRoutingProvider()
+    {
+        var config = new DataClassificationConfig
+        {
+            Mode = ClassificationEnforcementMode.Enforce,
+            InformationProtection = new InformationProtectionProviderConfig { Enabled = true },
+            DataMap = new DataMapProviderConfig { Enabled = true, AccountEndpoint = "https://acct.purview.azure.com" },
+        };
+        using var sp = BuildProvider(config);
+
+        sp.GetRequiredService<IDataClassificationProvider>()
+            .Should().BeOfType<CachedDataClassificationProvider>();
     }
 
     [Fact]

--- a/src/Content/Tests/Infrastructure.AI.Governance.Tests/Classification/PurviewDataMapClientTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Governance.Tests/Classification/PurviewDataMapClientTests.cs
@@ -1,0 +1,354 @@
+using System.Net;
+using System.Text;
+using Azure.Core;
+using Domain.AI.Governance;
+using Domain.Common.Config.AI.Governance;
+using FluentAssertions;
+using Infrastructure.AI.Governance.Classification;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Infrastructure.AI.Governance.Tests.Classification;
+
+/// <summary>
+/// Tests for <see cref="PurviewDataMapClient"/> against a stubbed Apache Atlas catalog endpoint. They pin
+/// the honest contract of the Data Map provider: it reads a scanned cloud asset by qualified name, maps the
+/// applied label tag to a sensitivity label and the scan classifications to findings, judges staleness from
+/// the entry's update time, treats an unscanned asset (404) as a benign Unknown, and fails closed on any
+/// other backend error without leaking the access token.
+/// </summary>
+public sealed class PurviewDataMapClientTests
+{
+    private const string BlobQn = "https://acct.blob.core.windows.net/container/customers.csv";
+    private static readonly DateTimeOffset Now = new(2026, 6, 25, 12, 0, 0, TimeSpan.Zero);
+
+    private static DataMapProviderConfig Config(TimeSpan? staleness = null, string? labelPrefix = null) => new()
+    {
+        Enabled = true,
+        AccountEndpoint = "https://acct.purview.azure.com",
+        Scopes = ["https://purview.azure.net/.default"],
+        StalenessThreshold = staleness ?? TimeSpan.FromDays(7),
+        SensitivityLabelTagPrefix = labelPrefix ?? string.Empty,
+    };
+
+    private static PurviewDataMapClient CreateClient(
+        StubHandler handler, MutableTimeProvider time, TimeSpan? staleness = null, string? labelPrefix = null) =>
+        new(new StubHttpClientFactory(handler), new FakeCredential(), Config(staleness, labelPrefix), time,
+            NullLogger<PurviewDataMapClient>.Instance);
+
+    private static AssetReference Blob(string qn = BlobQn) => new(AssetType.AzureBlob, qn);
+
+    [Fact]
+    public async Task GetLabelAsync_ScannedAsset_MapsLabelAndClassifications()
+    {
+        // updateTime is "now", so well within the freshness window.
+        var entity = EntityJson(
+            labels: ["Confidential"],
+            classifications: ["MICROSOFT.GOVERNMENT.US.SOCIAL_SECURITY_NUMBER", "MICROSOFT.FINANCIAL.CREDIT_CARD_NUMBER"],
+            updateTimeMs: Now.ToUnixTimeMilliseconds());
+        var sut = CreateClient(new StubHandler(_ => Ok(entity)), new MutableTimeProvider(Now));
+
+        var result = await sut.GetLabelAsync(Blob(), CancellationToken.None);
+
+        result.Source.Should().Be(LabelSource.DataMap);
+        result.Label!.Name.Should().Be("Confidential");
+        result.Label.Id.Should().Be("Confidential", "Atlas label tags carry no GUID, so the name doubles as the id");
+        result.Classifications.Select(c => c.Name).Should().BeEquivalentTo(
+            "MICROSOFT.GOVERNMENT.US.SOCIAL_SECURITY_NUMBER", "MICROSOFT.FINANCIAL.CREDIT_CARD_NUMBER");
+        result.IsStale.Should().BeFalse("the asset was scanned within the staleness threshold");
+    }
+
+    [Fact]
+    public async Task GetLabelAsync_TargetsAtlasGetByUniqueAttribute_WithEncodedQualifiedName()
+    {
+        var handler = new StubHandler(_ => Ok(EntityJson(labels: ["Confidential"])));
+        var sut = CreateClient(handler, new MutableTimeProvider(Now));
+
+        await sut.GetLabelAsync(Blob(), CancellationToken.None);
+
+        var uri = handler.LastRequestUri!;
+        uri.AbsolutePath.Should().Be(
+            "/catalog/api/atlas/v2/entity/uniqueAttribute/type/azure_blob_path");
+        // The qualified name (a URL with ':' and '/') must be percent-encoded into the query.
+        uri.Query.Should().Contain("attr:qualifiedName=");
+        uri.Query.Should().Contain(Uri.EscapeDataString(BlobQn));
+        handler.LastAuthScheme.Should().Be("Bearer");
+        handler.LastAuthToken.Should().Be(FakeCredential.TokenValue);
+    }
+
+    [Theory]
+    [InlineData(AssetType.AzureBlob, "azure_blob_path")]
+    [InlineData(AssetType.AdlsGen2, "azure_datalake_gen2_path")]
+    [InlineData(AssetType.AzureSql, "azure_sql_table")]
+    [InlineData(AssetType.CosmosDb, "azure_cosmosdb_sqlapi_collection")]
+    public async Task GetLabelAsync_RoutesEachCloudKind_ToItsAtlasTypeName(AssetType type, string expectedType)
+    {
+        var handler = new StubHandler(_ => Ok(EntityJson(labels: ["Confidential"])));
+        var sut = CreateClient(handler, new MutableTimeProvider(Now));
+
+        await sut.GetLabelAsync(new AssetReference(type, "qn://asset"), CancellationToken.None);
+
+        handler.LastRequestUri!.AbsolutePath.Should().EndWith("/type/" + expectedType);
+    }
+
+    [Fact]
+    public async Task GetLabelAsync_StaleScan_FlagsIsStale()
+    {
+        // Last updated 30 days ago, past the 7-day threshold.
+        var entity = EntityJson(labels: ["Confidential"], updateTimeMs: Now.AddDays(-30).ToUnixTimeMilliseconds());
+        var sut = CreateClient(new StubHandler(_ => Ok(entity)), new MutableTimeProvider(Now));
+
+        var result = await sut.GetLabelAsync(Blob(), CancellationToken.None);
+
+        result.IsStale.Should().BeTrue("a scan older than the staleness threshold is not known to be current");
+    }
+
+    [Fact]
+    public async Task GetLabelAsync_FutureUpdateTime_TreatedAsStale()
+    {
+        // A timestamp ahead of now (clock skew or corrupt scan metadata) cannot be trusted, so the result
+        // is conservatively stale rather than reported as freshly verified.
+        var entity = EntityJson(labels: ["Confidential"], updateTimeMs: Now.AddHours(6).ToUnixTimeMilliseconds());
+        var sut = CreateClient(new StubHandler(_ => Ok(entity)), new MutableTimeProvider(Now));
+
+        var result = await sut.GetLabelAsync(Blob(), CancellationToken.None);
+
+        result.IsStale.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task GetLabelAsync_MissingUpdateTime_TreatedAsStale()
+    {
+        // No updateTime means freshness cannot be verified, so the result is conservatively stale.
+        var sut = CreateClient(new StubHandler(_ => Ok(EntityJson(labels: ["Confidential"]))), new MutableTimeProvider(Now));
+
+        var result = await sut.GetLabelAsync(Blob(), CancellationToken.None);
+
+        result.IsStale.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task GetLabelAsync_NoLabelTagButClassifications_ReturnsClassificationsWithNoLabel()
+    {
+        // An asset can be classified by a scan yet carry no applied sensitivity label tag. The label is
+        // null (so the unknown-asset policy applies), but the findings are still surfaced for audit.
+        var entity = EntityJson(labels: null, classifications: ["MICROSOFT.FINANCIAL.CREDIT_CARD_NUMBER"]);
+        var sut = CreateClient(new StubHandler(_ => Ok(entity)), new MutableTimeProvider(Now));
+
+        var result = await sut.GetLabelAsync(Blob(), CancellationToken.None);
+
+        result.Label.Should().BeNull();
+        result.Source.Should().Be(LabelSource.DataMap);
+        result.Classifications.Should().ContainSingle(c => c.Name == "MICROSOFT.FINANCIAL.CREDIT_CARD_NUMBER");
+    }
+
+    [Fact]
+    public async Task GetLabelAsync_BlankAndWhitespaceLabelTags_AreSkipped()
+    {
+        var entity = EntityJson(labels: ["  ", "", "Highly Confidential"]);
+        var sut = CreateClient(new StubHandler(_ => Ok(entity)), new MutableTimeProvider(Now));
+
+        var result = await sut.GetLabelAsync(Blob(), CancellationToken.None);
+
+        result.Label!.Name.Should().Be("Highly Confidential", "blank tags are skipped, the first real tag wins");
+    }
+
+    [Fact]
+    public async Task GetLabelAsync_MultipleTagsNoPrefix_PicksDeterministicallyByOrdinalOrder()
+    {
+        // The Data Map returns label tags as an unordered set. With no prefix configured the provider must
+        // still resolve the same tag every time, so ordinal order decides rather than response order.
+        var first = EntityJson(labels: ["Internal", "Confidential"]);
+        var second = EntityJson(labels: ["Confidential", "Internal"]);
+        var sutFirst = CreateClient(new StubHandler(_ => Ok(first)), new MutableTimeProvider(Now));
+        var sutSecond = CreateClient(new StubHandler(_ => Ok(second)), new MutableTimeProvider(Now));
+
+        var a = await sutFirst.GetLabelAsync(Blob(), CancellationToken.None);
+        var b = await sutSecond.GetLabelAsync(Blob(), CancellationToken.None);
+
+        a.Label!.Name.Should().Be("Confidential", "'Confidential' sorts before 'Internal' by ordinal order");
+        b.Label!.Name.Should().Be(a.Label.Name, "response order must not change the resolved label");
+    }
+
+    [Fact]
+    public async Task GetLabelAsync_PrefixConfigured_SelectsPrefixedTagAndStripsPrefix()
+    {
+        // Operational tags coexist with the sensitivity tag; the prefix disambiguates which is the label,
+        // and the prefix is stripped so policy is authored against the bare label name.
+        var entity = EntityJson(labels: ["project-phoenix", "archive", "MIP_Highly Confidential"]);
+        var sut = CreateClient(new StubHandler(_ => Ok(entity)), new MutableTimeProvider(Now), labelPrefix: "MIP_");
+
+        var result = await sut.GetLabelAsync(Blob(), CancellationToken.None);
+
+        result.Label!.Name.Should().Be("Highly Confidential");
+        result.Label.Id.Should().Be("Highly Confidential");
+    }
+
+    [Fact]
+    public async Task GetLabelAsync_PrefixConfiguredButNoTagMatches_ResolvesNoLabel()
+    {
+        // Without a prefixed tag the asset carries no recognizable sensitivity label, so it falls to the
+        // unknown-asset policy rather than keying the decision on an arbitrary operational tag.
+        var entity = EntityJson(labels: ["project-phoenix", "archive"]);
+        var sut = CreateClient(new StubHandler(_ => Ok(entity)), new MutableTimeProvider(Now), labelPrefix: "MIP_");
+
+        var result = await sut.GetLabelAsync(Blob(), CancellationToken.None);
+
+        result.Label.Should().BeNull();
+        result.Source.Should().Be(LabelSource.DataMap);
+    }
+
+    [Fact]
+    public async Task GetLabelAsync_UnscannedAsset_404_ReturnsUnknownWithoutThrowing()
+    {
+        var handler = new StubHandler(_ => new HttpResponseMessage(HttpStatusCode.NotFound));
+        var sut = CreateClient(handler, new MutableTimeProvider(Now));
+
+        var result = await sut.GetLabelAsync(Blob(), CancellationToken.None);
+
+        result.Source.Should().Be(LabelSource.None);
+        result.Label.Should().BeNull();
+        result.HasClassification.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task GetLabelAsync_BackendError_ThrowsWithoutLeakingToken()
+    {
+        var handler = new StubHandler(_ => new HttpResponseMessage(HttpStatusCode.InternalServerError));
+        var sut = CreateClient(handler, new MutableTimeProvider(Now));
+
+        var act = async () => await sut.GetLabelAsync(Blob(), CancellationToken.None);
+
+        var ex = await act.Should().ThrowAsync<InvalidOperationException>();
+        ex.Which.Message.Should().Contain("500");
+        ex.Which.Message.Should().NotContain(FakeCredential.TokenValue);
+    }
+
+    [Fact]
+    public async Task GetLabelAsync_200WithoutEntity_Throws()
+    {
+        // A 200 whose body carries no 'entity' is an unrecognized shape — fail closed rather than silently
+        // degrading a real asset to Unknown.
+        var sut = CreateClient(new StubHandler(_ => Ok("{}")), new MutableTimeProvider(Now));
+
+        var act = async () => await sut.GetLabelAsync(Blob(), CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+    }
+
+    [Fact]
+    public async Task GetLabelAsync_NonDataMapAssetKind_ReturnsUnknownWithoutCall()
+    {
+        var handler = new StubHandler(_ => Ok(EntityJson(labels: ["Confidential"])));
+        var sut = CreateClient(handler, new MutableTimeProvider(Now));
+
+        var result = await sut.GetLabelAsync(new AssetReference(AssetType.LocalFile, @"C:\x.txt"), CancellationToken.None);
+
+        result.Source.Should().Be(LabelSource.None);
+        handler.CallCount.Should().Be(0, "the Data Map does not track local files, so no round trip is made");
+    }
+
+    [Fact]
+    public async Task GetLabelAsync_BlankIdentifier_ReturnsUnknownWithoutCall()
+    {
+        var handler = new StubHandler(_ => Ok(EntityJson(labels: ["Confidential"])));
+        var sut = CreateClient(handler, new MutableTimeProvider(Now));
+
+        var result = await sut.GetLabelAsync(new AssetReference(AssetType.AzureBlob, "   "), CancellationToken.None);
+
+        result.Source.Should().Be(LabelSource.None);
+        handler.CallCount.Should().Be(0, "with no qualified name there is nothing to look up");
+    }
+
+    [Fact]
+    public async Task GetLabelAsync_RequestsConfiguredScopes()
+    {
+        var credential = new FakeCredential();
+        var sut = new PurviewDataMapClient(
+            new StubHttpClientFactory(new StubHandler(_ => Ok(EntityJson(labels: ["Confidential"])))),
+            credential, Config(), new MutableTimeProvider(Now), NullLogger<PurviewDataMapClient>.Instance);
+
+        await sut.GetLabelAsync(Blob(), CancellationToken.None);
+
+        credential.LastScopes.Should().Equal("https://purview.azure.net/.default");
+    }
+
+    [Fact]
+    public async Task GetLabelAsync_NullAsset_Throws()
+    {
+        var sut = CreateClient(new StubHandler(_ => Ok(EntityJson(labels: ["Confidential"]))), new MutableTimeProvider(Now));
+
+        var act = async () => await sut.GetLabelAsync(null!, CancellationToken.None);
+
+        await act.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    private static string EntityJson(
+        IReadOnlyList<string>? labels = null,
+        IReadOnlyList<string>? classifications = null,
+        long? updateTimeMs = null)
+    {
+        var labelJson = labels is null ? "null" : "[" + string.Join(",", labels.Select(l => $"\"{l}\"")) + "]";
+        var classJson = classifications is null
+            ? "null"
+            : "[" + string.Join(",", classifications.Select(c => $"{{ \"typeName\": \"{c}\" }}")) + "]";
+        var updateJson = updateTimeMs is null ? "null" : updateTimeMs.Value.ToString();
+        return $$"""
+            {
+              "entity": {
+                "labels": {{labelJson}},
+                "classifications": {{classJson}},
+                "updateTime": {{updateJson}}
+              }
+            }
+            """;
+    }
+
+    private static HttpResponseMessage Ok(string json) =>
+        new(HttpStatusCode.OK) { Content = new StringContent(json, Encoding.UTF8, "application/json") };
+
+    private sealed class StubHttpClientFactory(HttpMessageHandler handler) : IHttpClientFactory
+    {
+        public HttpClient CreateClient(string name) => new(handler, disposeHandler: false);
+    }
+
+    private sealed class StubHandler(Func<HttpRequestMessage, HttpResponseMessage> responder) : HttpMessageHandler
+    {
+        public int CallCount { get; private set; }
+        public Uri? LastRequestUri { get; private set; }
+        public string? LastAuthScheme { get; private set; }
+        public string? LastAuthToken { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            CallCount++;
+            LastRequestUri = request.RequestUri;
+            LastAuthScheme = request.Headers.Authorization?.Scheme;
+            LastAuthToken = request.Headers.Authorization?.Parameter;
+            return Task.FromResult(responder(request));
+        }
+    }
+
+    private sealed class FakeCredential : TokenCredential
+    {
+        public const string TokenValue = "fake-data-map-token";
+        public string[] LastScopes { get; private set; } = [];
+
+        public override AccessToken GetToken(TokenRequestContext requestContext, CancellationToken cancellationToken)
+        {
+            LastScopes = requestContext.Scopes;
+            return new AccessToken(TokenValue, Now.AddHours(1));
+        }
+
+        public override ValueTask<AccessToken> GetTokenAsync(TokenRequestContext requestContext, CancellationToken cancellationToken)
+            => new(GetToken(requestContext, cancellationToken));
+    }
+
+    private sealed class MutableTimeProvider(DateTimeOffset start) : TimeProvider
+    {
+        private DateTimeOffset _now = start;
+        public override DateTimeOffset GetUtcNow() => _now;
+        public void Advance(TimeSpan by) => _now += by;
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Governance.Tests/Classification/RoutingDataClassificationProviderTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Governance.Tests/Classification/RoutingDataClassificationProviderTests.cs
@@ -1,0 +1,121 @@
+using Application.AI.Common.Interfaces.Governance;
+using Domain.AI.Governance;
+using FluentAssertions;
+using Infrastructure.AI.Governance.Classification;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Infrastructure.AI.Governance.Tests.Classification;
+
+/// <summary>
+/// Tests for <see cref="RoutingDataClassificationProvider"/>. They prove the router dispatches each asset
+/// kind to the correct Purview world, resolves to Unknown without a provider call when the matching world
+/// is not wired or the kind is unclassifiable, and never crosses the streams (a cloud asset never reaches
+/// the Information Protection provider, and vice versa).
+/// </summary>
+public sealed class RoutingDataClassificationProviderTests
+{
+    private static readonly DateTimeOffset Now = new(2026, 6, 25, 12, 0, 0, TimeSpan.Zero);
+
+    [Theory]
+    [InlineData(AssetType.AzureBlob)]
+    [InlineData(AssetType.AdlsGen2)]
+    [InlineData(AssetType.AzureSql)]
+    [InlineData(AssetType.CosmosDb)]
+    public async Task GetLabelAsync_CloudAssetKinds_RouteToDataMap(AssetType type)
+    {
+        var ip = new SpyProvider(LabelSource.InformationProtection);
+        var dataMap = new SpyProvider(LabelSource.DataMap);
+        var sut = Create(ip, dataMap);
+
+        var result = await sut.GetLabelAsync(new AssetReference(type, "qn://asset"), CancellationToken.None);
+
+        result.Source.Should().Be(LabelSource.DataMap);
+        dataMap.Calls.Should().Be(1);
+        ip.Calls.Should().Be(0, "a cloud asset must never reach the Information Protection provider");
+    }
+
+    [Fact]
+    public async Task GetLabelAsync_LocalFile_RoutesToInformationProtection()
+    {
+        var ip = new SpyProvider(LabelSource.InformationProtection);
+        var dataMap = new SpyProvider(LabelSource.DataMap);
+        var sut = Create(ip, dataMap);
+
+        var result = await sut.GetLabelAsync(new AssetReference(AssetType.LocalFile, @"C:\x.txt"), CancellationToken.None);
+
+        result.Source.Should().Be(LabelSource.InformationProtection);
+        ip.Calls.Should().Be(1);
+        dataMap.Calls.Should().Be(0, "a local file must never reach the Data Map provider");
+    }
+
+    [Fact]
+    public async Task GetLabelAsync_UnknownKind_ReturnsUnknownWithoutCallingEitherProvider()
+    {
+        var ip = new SpyProvider(LabelSource.InformationProtection);
+        var dataMap = new SpyProvider(LabelSource.DataMap);
+        var sut = Create(ip, dataMap);
+
+        var result = await sut.GetLabelAsync(AssetReference.Unknown("mcp://output"), CancellationToken.None);
+
+        result.Source.Should().Be(LabelSource.None);
+        ip.Calls.Should().Be(0);
+        dataMap.Calls.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task GetLabelAsync_DataMapWorldNotWired_CloudAssetResolvesUnknown()
+    {
+        // Only the Information Protection world is enabled; a cloud asset has no provider and falls through.
+        var ip = new SpyProvider(LabelSource.InformationProtection);
+        var sut = Create(ip, dataMap: null);
+
+        var result = await sut.GetLabelAsync(new AssetReference(AssetType.AzureBlob, "qn://b"), CancellationToken.None);
+
+        result.Source.Should().Be(LabelSource.None);
+        ip.Calls.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task GetLabelAsync_InformationProtectionWorldNotWired_LocalFileResolvesUnknown()
+    {
+        var dataMap = new SpyProvider(LabelSource.DataMap);
+        var sut = Create(ip: null, dataMap);
+
+        var result = await sut.GetLabelAsync(new AssetReference(AssetType.LocalFile, @"C:\x.txt"), CancellationToken.None);
+
+        result.Source.Should().Be(LabelSource.None);
+        dataMap.Calls.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task GetLabelAsync_NullAsset_Throws()
+    {
+        var sut = Create(new SpyProvider(LabelSource.InformationProtection), new SpyProvider(LabelSource.DataMap));
+
+        var act = async () => await sut.GetLabelAsync(null!, CancellationToken.None);
+
+        await act.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    private static RoutingDataClassificationProvider Create(
+        IDataClassificationProvider? ip, IDataClassificationProvider? dataMap) =>
+        new(ip, dataMap, new FixedTimeProvider(Now), NullLogger<RoutingDataClassificationProvider>.Instance);
+
+    private sealed class SpyProvider(LabelSource source) : IDataClassificationProvider
+    {
+        public int Calls { get; private set; }
+
+        public Task<AssetLabelResult> GetLabelAsync(AssetReference asset, CancellationToken cancellationToken)
+        {
+            Calls++;
+            var label = new SensitivityLabel("id", "name");
+            return Task.FromResult(new AssetLabelResult(asset, label, [], source, Now));
+        }
+    }
+
+    private sealed class FixedTimeProvider(DateTimeOffset now) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => now;
+    }
+}


### PR DESCRIPTION
## Summary

PR3 of the Purview-backed data-classification DLP feature — the **data-estate** half of the gate. Adds a Purview Data Map provider and the router that selects between the two Purview worlds by asset kind. Builds on PR1 (#91, seam) and PR2 (#92, MIP/Graph provider).

- **`PurviewDataMapClient`** (`IDataClassificationProvider`) — reads a scanned cloud asset's catalog entry from the Purview Data Map via the Apache Atlas *get-entity-by-unique-attribute* call (`GET /catalog/api/atlas/v2/entity/uniqueAttribute/type/{typeName}?attr:qualifiedName=…`), keyed by the asset's fully-qualified name. Resolves the asset's sensitivity label + scan classifications.
- **`RoutingDataClassificationProvider`** — dispatches by `AssetType`: `LocalFile` → MIP/Graph world, `AzureBlob`/`AdlsGen2`/`AzureSql`/`CosmosDb` → Data Map. Each world is independently optional; unclassifiable kinds resolve to `Unknown` without a network call. Wrapped by the existing `CachedDataClassificationProvider` TTL cache.
- **`DataMapProviderConfig`** (+ FluentValidation rules) under `AppConfig:AI:Governance:DataClassification:DataMap`. DI restructured to wire MIP + Data Map behind the router behind the cache, preserving the fail-fast `NotConfigured` default when the gate is on but no provider is enabled.

## Verified API facts (microsoft_learn MCP)
- Atlas data-plane endpoint `https://{account}.purview.azure.com/catalog/api/atlas/v2`; token resource/scope `https://purview.azure.net/.default`.
- Single-entity read → **no pagination/nextLink**, so none of PR2's followed-URL credential-leak surface. `404` = unscanned/not-found.

## Key design decisions
- **Sensitivity label from free-text tags, made safe.** Data Map returns an asset's labels as a free-text tag set mixing the applied sensitivity label with arbitrary operational tags, and doesn't flag which is which. Selection is **deterministic (ordinal)** and disambiguable via a configurable **`SensitivityLabelTagPrefix`** (prefix-matched tag wins; prefix stripped so policy is authored against the bare name). Scan classifications are carried as **audit-only** `DataClassification` findings (the evaluator is label-driven, per PR1). *This was a reviewed decision — Matt chose the configurable-prefix approach over classifications-only.*
- **Staleness.** `IsStale` from the entry's `updateTime` vs a configurable `StalenessThreshold`; unknown or future (clock-skew) timestamps treated as stale.
- **Fail-closed.** `404` → `Unknown`; any other non-2xx → throw with status only (no token/body leakage).
- **Auth reuse declined (carried from PR2).** Inline bearer-attach kept rather than `EntraTokenAuthHandler`, which would force an `Infrastructure.AI.Governance → Infrastructure.AI` project dependency for ~4 lines.

## Honest scope / deferred to PR4 (per the 4-PR plan)
- Enforcement into `IToolInvocationGovernor` and the `file_system` asset resolver land in **PR4**; `IsStale` is surfaced for audit/future policy, not yet consumed by the label-driven evaluator.
- Azure SQL maps to the table type only (column-level labels are a source-dependent preview); the `AssetType→Atlas-typeName` map is a closed static (Atlas protocol constants).
- `appsettings.json` skeleton for the full config lands in PR4 (when the gate enforces).

## Test plan
- `dotnet build src/AgenticHarness.slnx` — 0 errors.
- `dotnet test src/AgenticHarness.slnx` — full suite green (0 failures).
- New: `PurviewDataMapClientTests` (routing per kind, label/prefix/deterministic selection, classifications, staleness incl. future/missing timestamp, 404→Unknown, fail-closed throw without token leak, scope plumbing), `RoutingDataClassificationProviderTests` (dispatch + unwired-world fallthrough), plus DI and validator tests for the Data Map branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)