### PR TITLE
feat(work-memory): per-turn work episode capture (self-improving memory PR1)

### DIFF
--- a/.claude/plans/self-improving-work-memory.md
+++ b/.claude/plans/self-improving-work-memory.md
@@ -1,0 +1,77 @@
+# Self-Improving Work Memory (Perplexity "Brain" parity)
+
+## Origin
+Research project: Perplexity **Brain** (launched 2026-06-18) — a *self-improving work memory*
+for agents. Distinct from user-preference memory: it remembers **what the agent did** (what
+worked, what failed, what the user corrected), runs an **overnight synthesis** pass that distills
+raw session logs into reusable lessons stored in an auto-loaded "LLM wiki" / context graph, so
+each new task **starts with better context**. Claimed: +25% correctness, +16% recall, −13% cost
+on previously-seen tasks. (Numbers are Perplexity's own research-preview measurement — directional,
+not independently verified.)
+
+## Gap analysis vs. this harness
+The harness already has ~80% of the primitives and **exceeds** Brain on provenance, right-to-erasure,
+and multi-tenant isolation. Existing pieces:
+- Knowledge graph (Neo4j/Kuzu/Postgres) + entity extraction
+- `Learnings` subsystem (`LearningEntry`, `ILearningsStore`, `GraphLearningsStore`, EMA feedback,
+  decay/pruning) — but stores **isolated facts**, not **work trajectories**
+- Cross-session memory (`IKnowledgeMemory` Remember/Recall/Forget/Improve) — **user/domain facts**
+- Feedback (`LlmFeedbackDetector`, `GraphFeedbackStore`), provenance (`DefaultProvenanceStamper`)
+- `KnowledgeMemoryContextProvider` injects recalled facts each turn
+- SkillOpt 6-stage loop (self-improvement) — but trains on **synthetic rollouts**, not real sessions
+
+### The three real gaps
+1. **No work-episode capture** — nothing records what the agent *did* on a task (outcome, cost,
+   correction). Memory stores facts, not trajectories. *Foundational.*
+2. **No synthesis/consolidation job** — the background service only prunes/decays; nothing distills
+   raw sessions into higher-level lessons.
+3. **Self-improvement runs on synthetic data** — SkillOpt never sees real production sessions; the
+   loop "real work → lessons → better next task" is open.
+
+## Plan — three PRs, dependency order
+
+### PR1 — Work-episode capture (foundation) — `feat/work-memory-pr1-episode-capture`
+Record each agent turn as a cheap, structural **work episode** (no LLM in the hot path).
+- **Domain** (`Domain.AI/WorkMemory/`): `WorkEpisode` record, `EpisodeOutcome` enum.
+- **Application** (`Application.AI.Common/Interfaces/WorkMemory/`): `IWorkEpisodeStore`
+  (Save/Get/Search), `WorkEpisodeSearchCriteria`.
+- **Application**: `WorkEpisodeCaptureBehavior` — mirrors `KnowledgeExtractionBehavior`
+  (fire-and-forget, fresh DI scope, ambient-scope re-establishment so tenant isolation resolves).
+  Builds an episode from `IAgentTurnRequest`/`IAgentTurnResult` and persists it.
+- **Config**: `WorkMemoryConfig` under `AppConfig:AI:WorkMemory` (Enabled, StoreProvider,
+  ResponseSummaryMaxChars). Master toggle **off-by-default** until PR2/PR3 consume it.
+- **Infrastructure** (`Infrastructure.AI.KnowledgeGraph/WorkMemory/`): `GraphWorkEpisodeStore`
+  (keyed `"graph"`, mirrors `GraphLearningsStore`, indexed by conversation), `InMemoryWorkEpisodeStore`
+  (keyed `"in_memory"`). Tenant/owner isolation inherited from the decorated `IKnowledgeGraphStore`.
+- **Tests**: domain defaults, behavior gating + fire-and-forget, in-memory store, graph round-trip.
+- **Deliberately NOT in PR1** (YAGNI): per-tool step granularity (no reliable source at the turn
+  seam — needs a deeper function-invocation hook; revisit only if a consumer needs it).
+
+### PR2 — Overnight synthesis (consolidation) — depends on PR1
+Scheduled `BackgroundService` (mirrors `LearningsPruningBackgroundService`) that reads recent
+`WorkEpisode`s and distills them into `LearningEntry`s via an LLM synthesizer:
+- Detect corrections / dead-ends / repeated-success patterns across episodes.
+- Write lessons through the **existing** `Learnings` store with `LearningSourceType.AgentSelfImprovement`.
+- Reuse the RAPTOR hierarchical-summarization pattern for cross-episode clustering.
+- **Security prerequisite:** synthesized lessons are model-generated from session content → the
+  [[guarding-ai-memory]] write-path injection scan + trust marker must gate this write. Fold that
+  gate into PR2 (it becomes a hard requirement, not a nice-to-have, the moment we ingest sessions).
+
+### PR3 — Task-similarity recall at task start — depends on PR1+PR2
+Extend `KnowledgeMemoryContextProvider` (or a sibling provider) to recall **"this task resembles
+past task Y; here's what worked"** from synthesized lessons + episode outcomes, injected at turn
+start. Closes the loop; enables the correctness/recall/cost measurement.
+
+## Deferred cleanup (surfaced in PR1 review, intentionally not done)
+- **Shared graph-keyed-store base:** `GraphWorkEpisodeStore` duplicates ~80% of
+  `GraphLearningsStore` (const node/index keys, `ToNodeId`/`Extract*`, `CollectIndexNeighborsAsync`,
+  full-scan fallback). Only two instances exist (rule of three not met) and abstracting touches
+  working code. Revisit when a third graph-keyed store appears — then extract a base in its own PR.
+- **Fire-and-forget backpressure:** both `WorkEpisodeCaptureBehavior` and the reference
+  `KnowledgeExtractionBehavior` use unbounded `Task.Run` per turn. If this becomes a load concern,
+  bound it cross-cuttingly for both behaviors, not just this one.
+
+## Status
+- PR1: complete — build green, 27 new tests pass, `/code-review` + `/simplify` run
+  (validator + surrogate-pair fixes applied; duplication/backpressure deferred above).
+- PR2, PR3: not started.

--- a/src/Content/Application/Application.AI.Common/DependencyInjection.cs
+++ b/src/Content/Application/Application.AI.Common/DependencyInjection.cs
@@ -53,6 +53,7 @@ namespace Application.AI.Common;
 ///   <item><description><c>ResponseSanitizationBehavior</c> — post-execution: sanitizes tool output for credentials, injection, exfiltration</description></item>
 ///   <item><description><c>ToolOutputCompressionBehavior</c> — post-execution: compresses large tool output for context window savings</description></item>
 ///   <item><description><c>KnowledgeExtractionBehavior</c> — post-turn: extracts facts to knowledge graph (fire-and-forget)</description></item>
+///   <item><description><c>WorkEpisodeCaptureBehavior</c> — post-turn: records what the agent did as a WorkEpisode (fire-and-forget)</description></item>
 /// </list>
 /// </para>
 /// </remarks>
@@ -103,6 +104,7 @@ public static class DependencyInjection
             .AddTransient(typeof(IPipelineBehavior<,>), typeof(ResponseSanitizationBehavior<,>))
             .AddTransient(typeof(IPipelineBehavior<,>), typeof(ToolOutputCompressionBehavior<,>))
             .AddTransient(typeof(IPipelineBehavior<,>), typeof(KnowledgeExtractionBehavior<,>))
+            .AddTransient(typeof(IPipelineBehavior<,>), typeof(WorkEpisodeCaptureBehavior<,>))
             .AddTransient(typeof(IPipelineBehavior<,>), typeof(PromptUsageTrackingBehavior<,>));
 
         // Sandbox capability enforcement — profile resolution and enforcement

--- a/src/Content/Application/Application.AI.Common/Interfaces/WorkMemory/IWorkEpisodeStore.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/WorkMemory/IWorkEpisodeStore.cs
@@ -1,0 +1,26 @@
+using Domain.AI.WorkMemory;
+using Domain.Common;
+
+namespace Application.AI.Common.Interfaces.WorkMemory;
+
+/// <summary>
+/// Persistence contract for <see cref="WorkEpisode"/> records — the agent's structured log of what
+/// it did, turn by turn. The write half is driven by <c>WorkEpisodeCaptureBehavior</c>; the read half
+/// is consumed by the overnight synthesis pass (PR2) and task-similarity recall (PR3).
+/// </summary>
+/// <remarks>
+/// Keyed DI: <c>"graph"</c> (default, <c>GraphWorkEpisodeStore</c>) and <c>"in_memory"</c>
+/// (<c>InMemoryWorkEpisodeStore</c>, for tests and ephemeral hosts). The provider is selected by
+/// <c>WorkMemoryConfig.StoreProvider</c>.
+/// </remarks>
+public interface IWorkEpisodeStore
+{
+    /// <summary>Persists a work episode. Episode IDs are unique; saving an existing ID overwrites it.</summary>
+    Task<Result> SaveAsync(WorkEpisode episode, CancellationToken ct);
+
+    /// <summary>Retrieves an episode by ID. Returns a success result with a null value when not found.</summary>
+    Task<Result<WorkEpisode?>> GetAsync(Guid episodeId, CancellationToken ct);
+
+    /// <summary>Searches episodes matching the supplied <paramref name="criteria"/>.</summary>
+    Task<Result<IReadOnlyList<WorkEpisode>>> SearchAsync(WorkEpisodeSearchCriteria criteria, CancellationToken ct);
+}

--- a/src/Content/Application/Application.AI.Common/Interfaces/WorkMemory/WorkEpisodeSearchCriteria.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/WorkMemory/WorkEpisodeSearchCriteria.cs
@@ -1,0 +1,26 @@
+using Domain.AI.WorkMemory;
+
+namespace Application.AI.Common.Interfaces.WorkMemory;
+
+/// <summary>
+/// Filter criteria for querying <see cref="WorkEpisode"/> records. All properties are optional;
+/// a null property means "no filter on that dimension". The primary consumer is the overnight
+/// synthesis pass, which scans recent episodes (typically <see cref="CreatedAfter"/> = last 24h).
+/// </summary>
+public sealed record WorkEpisodeSearchCriteria
+{
+    /// <summary>Restrict to a single conversation. Null = all conversations in scope.</summary>
+    public string? ConversationId { get; init; }
+
+    /// <summary>Restrict to episodes with this outcome. Null = both successes and failures.</summary>
+    public EpisodeOutcome? Outcome { get; init; }
+
+    /// <summary>Only episodes created at or after this instant. Null = no lower bound.</summary>
+    public DateTimeOffset? CreatedAfter { get; init; }
+
+    /// <summary>Only episodes created at or before this instant. Null = no upper bound.</summary>
+    public DateTimeOffset? CreatedBefore { get; init; }
+
+    /// <summary>Maximum number of episodes to return. Null = no limit (caller is responsible for bounding).</summary>
+    public int? Limit { get; init; }
+}

--- a/src/Content/Application/Application.AI.Common/MediatRBehaviors/WorkEpisodeCaptureBehavior.cs
+++ b/src/Content/Application/Application.AI.Common/MediatRBehaviors/WorkEpisodeCaptureBehavior.cs
@@ -1,0 +1,161 @@
+using Application.AI.Common.Interfaces;
+using Application.AI.Common.Interfaces.MediatR;
+using Application.AI.Common.Interfaces.WorkMemory;
+using Domain.AI.WorkMemory;
+using Domain.Common.Config;
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Application.AI.Common.MediatRBehaviors;
+
+/// <summary>
+/// Post-turn pipeline behavior that records what the agent <em>did</em> on each turn as a
+/// <see cref="WorkEpisode"/> — the capture half of the self-improving work-memory loop. The expensive
+/// distillation of episodes into reusable lessons happens later, offline, in the overnight synthesis
+/// pass; this behavior only logs, cheaply and structurally, with <strong>no LLM call</strong>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Only activates for requests implementing <see cref="IAgentTurnRequest"/> that produce an
+/// <see cref="IAgentTurnResult"/>. Both success and failure are recorded — a failed turn is itself a
+/// signal worth learning from. All other request types pass through untouched.
+/// </para>
+/// <para>
+/// Capture runs as fire-and-forget on a background thread; the agent's response returns immediately
+/// and capture failures are logged but never propagate. Like <see cref="KnowledgeExtractionBehavior{TRequest, TResponse}"/>,
+/// the background task must not capture request-scoped services or the request
+/// <see cref="System.Threading.CancellationToken"/>: it injects <see cref="IServiceScopeFactory"/>,
+/// creates a fresh DI scope, and re-establishes it as the ambient request scope so the
+/// tenant/owner-aware graph store resolves its identity from a live provider.
+/// </para>
+/// </remarks>
+public sealed class WorkEpisodeCaptureBehavior<TRequest, TResponse>
+    : IPipelineBehavior<TRequest, TResponse> where TRequest : notnull
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly IAmbientRequestScope _ambientScope;
+    private readonly IOptionsMonitor<AppConfig> _appConfig;
+    private readonly TimeProvider _timeProvider;
+    private readonly ILogger<WorkEpisodeCaptureBehavior<TRequest, TResponse>> _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="WorkEpisodeCaptureBehavior{TRequest, TResponse}"/> class.
+    /// </summary>
+    public WorkEpisodeCaptureBehavior(
+        IServiceScopeFactory scopeFactory,
+        IAmbientRequestScope ambientScope,
+        IOptionsMonitor<AppConfig> appConfig,
+        TimeProvider timeProvider,
+        ILogger<WorkEpisodeCaptureBehavior<TRequest, TResponse>> logger)
+    {
+        ArgumentNullException.ThrowIfNull(scopeFactory);
+        ArgumentNullException.ThrowIfNull(ambientScope);
+        ArgumentNullException.ThrowIfNull(appConfig);
+        ArgumentNullException.ThrowIfNull(timeProvider);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _scopeFactory = scopeFactory;
+        _ambientScope = ambientScope;
+        _appConfig = appConfig;
+        _timeProvider = timeProvider;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<TResponse> Handle(
+        TRequest request,
+        RequestHandlerDelegate<TResponse> next,
+        CancellationToken cancellationToken)
+    {
+        var response = await next();
+
+        // Read live so a hot config change takes effect without evicting anything.
+        if (!_appConfig.CurrentValue.AI.WorkMemory.Enabled)
+            return response;
+
+        if (request is not IAgentTurnRequest agentRequest || response is not IAgentTurnResult turnResult)
+            return response;
+
+        // Snapshot the values the background task needs so the closure captures no request-scoped
+        // service and not the request CancellationToken — both are gone once the turn returns.
+        var episode = BuildEpisode(agentRequest, turnResult);
+
+        _ = Task.Run(() => PersistAsync(episode));
+
+        return response;
+    }
+
+    /// <summary>
+    /// Builds a <see cref="WorkEpisode"/> from the turn request and result. Pure and synchronous so it
+    /// runs on the request thread (before the closure escapes) and is trivially unit-testable.
+    /// </summary>
+    internal WorkEpisode BuildEpisode(IAgentTurnRequest request, IAgentTurnResult result)
+    {
+        var maxChars = _appConfig.CurrentValue.AI.WorkMemory.ResponseSummaryMaxChars;
+        var summary = Truncate(result.Response ?? string.Empty, maxChars);
+
+        return new WorkEpisode
+        {
+            EpisodeId = Guid.NewGuid(),
+            AgentId = request.AgentId,
+            ConversationId = request.ConversationId,
+            TurnNumber = request.TurnNumber,
+            UserMessage = request.UserMessage,
+            ResponseSummary = summary,
+            Outcome = result.Success ? EpisodeOutcome.Success : EpisodeOutcome.Failure,
+            InputTokens = result.InputTokens,
+            OutputTokens = result.OutputTokens,
+            CreatedAt = _timeProvider.GetUtcNow()
+        };
+    }
+
+    private static string Truncate(string value, int maxChars)
+    {
+        if (maxChars <= 0 || value.Length <= maxChars)
+            return value;
+
+        // Don't split a UTF-16 surrogate pair at the boundary — a lone surrogate can throw or become
+        // U+FFFD when the graph backend serializes the string to UTF-8. Back off one char if needed.
+        var cut = maxChars;
+        if (char.IsHighSurrogate(value[cut - 1]))
+            cut--;
+
+        return value[..cut];
+    }
+
+    /// <summary>
+    /// Persists the episode in a fresh DI scope. Failures are logged and swallowed — work-memory
+    /// capture is an enhancement, never a hard dependency of a turn.
+    /// </summary>
+    private async Task PersistAsync(WorkEpisode episode)
+    {
+        try
+        {
+            await using var scope = _scopeFactory.CreateAsyncScope();
+
+            // Re-establish the fresh, alive scope as the ambient request scope so the tenant/owner-aware
+            // graph store resolves identity from a live provider (mirrors KnowledgeExtractionBehavior).
+            using var _ = _ambientScope.BeginScope(scope.ServiceProvider);
+
+            var store = scope.ServiceProvider.GetRequiredService<IWorkEpisodeStore>();
+            var result = await store.SaveAsync(episode, CancellationToken.None);
+
+            if (result.IsSuccess)
+                _logger.LogDebug(
+                    "Captured work episode {EpisodeId} for conversation {ConversationId} turn {Turn} ({Outcome})",
+                    episode.EpisodeId, episode.ConversationId, episode.TurnNumber, episode.Outcome);
+            else
+                _logger.LogWarning(
+                    "Failed to persist work episode for conversation {ConversationId} turn {Turn}: {Errors}",
+                    episode.ConversationId, episode.TurnNumber, string.Join(", ", result.Errors));
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogWarning(ex,
+                "Work-episode capture failed for conversation {ConversationId} turn {Turn}",
+                episode.ConversationId, episode.TurnNumber);
+        }
+    }
+}

--- a/src/Content/Application/Application.AI.Common/MediatRBehaviors/WorkEpisodeCaptureBehavior.cs
+++ b/src/Content/Application/Application.AI.Common/MediatRBehaviors/WorkEpisodeCaptureBehavior.cs
@@ -151,8 +151,10 @@ public sealed class WorkEpisodeCaptureBehavior<TRequest, TResponse>
                     "Failed to persist work episode for conversation {ConversationId} turn {Turn}: {Errors}",
                     episode.ConversationId, episode.TurnNumber, string.Join(", ", result.Errors));
         }
-        catch (Exception ex) when (ex is not OperationCanceledException)
+        catch (Exception ex)
         {
+            // Catch everything (incl. OperationCanceledException): this runs on a discarded Task.Run,
+            // so an unobserved exception would otherwise escape. Capture is best-effort, never fatal.
             _logger.LogWarning(ex,
                 "Work-episode capture failed for conversation {ConversationId} turn {Turn}",
                 episode.ConversationId, episode.TurnNumber);

--- a/src/Content/Application/Application.Core/Validation/WorkMemoryConfigValidator.cs
+++ b/src/Content/Application/Application.Core/Validation/WorkMemoryConfigValidator.cs
@@ -1,0 +1,27 @@
+using Domain.Common.Config.AI.WorkMemory;
+using FluentValidation;
+
+namespace Application.Core.Validation;
+
+/// <summary>
+/// Validates <see cref="WorkMemoryConfig"/>: the episode store provider must name a registered keyed
+/// implementation, and the response-summary cap must be positive. Validating the provider here turns a
+/// misconfigured key into a fail-loud startup error rather than a silent per-turn crash on the
+/// fire-and-forget capture path (where the exception would be swallowed).
+/// </summary>
+public sealed class WorkMemoryConfigValidator : AbstractValidator<WorkMemoryConfig>
+{
+    private static readonly string[] KnownStoreProviders = ["graph", "in_memory"];
+
+    /// <summary>Initializes a new instance of the <see cref="WorkMemoryConfigValidator"/> class.</summary>
+    public WorkMemoryConfigValidator()
+    {
+        RuleFor(x => x.StoreProvider)
+            .NotEmpty().WithMessage("StoreProvider must be configured ('graph' or 'in_memory').")
+            .Must(p => KnownStoreProviders.Contains(p))
+            .WithMessage("StoreProvider must be one of: 'graph', 'in_memory'.");
+
+        RuleFor(x => x.ResponseSummaryMaxChars)
+            .GreaterThan(0).WithMessage("ResponseSummaryMaxChars must be > 0.");
+    }
+}

--- a/src/Content/Application/Application.Core/Validation/WorkMemoryConfigValidator.cs
+++ b/src/Content/Application/Application.Core/Validation/WorkMemoryConfigValidator.cs
@@ -5,10 +5,16 @@ namespace Application.Core.Validation;
 
 /// <summary>
 /// Validates <see cref="WorkMemoryConfig"/>: the episode store provider must name a registered keyed
-/// implementation, and the response-summary cap must be positive. Validating the provider here turns a
-/// misconfigured key into a fail-loud startup error rather than a silent per-turn crash on the
-/// fire-and-forget capture path (where the exception would be swallowed).
+/// implementation, and the response-summary cap must be positive. Auto-discovered via
+/// <c>AddValidatorsFromAssembly</c>, consistent with the sibling config validators
+/// (<c>LearningsConfigValidator</c> et al.).
 /// </summary>
+/// <remarks>
+/// The hard fail-loud guarantee for a misconfigured <see cref="WorkMemoryConfig.StoreProvider"/> is
+/// enforced independently at DI registration time (<c>AddKnowledgeGraphDependencies</c>), which throws
+/// at startup before the app serves a turn. This validator additionally covers the numeric range and
+/// is available to any explicit config-validation pass.
+/// </remarks>
 public sealed class WorkMemoryConfigValidator : AbstractValidator<WorkMemoryConfig>
 {
     private static readonly string[] KnownStoreProviders = ["graph", "in_memory"];

--- a/src/Content/Domain/Domain.AI/WorkMemory/EpisodeOutcome.cs
+++ b/src/Content/Domain/Domain.AI/WorkMemory/EpisodeOutcome.cs
@@ -1,0 +1,15 @@
+namespace Domain.AI.WorkMemory;
+
+/// <summary>
+/// The terminal outcome of a single agent work episode (one conversation turn). Used by the
+/// overnight synthesis pass to separate successful trajectories worth reinforcing from failed
+/// or corrected ones worth learning from.
+/// </summary>
+public enum EpisodeOutcome
+{
+    /// <summary>The turn completed successfully and produced a response.</summary>
+    Success = 0,
+
+    /// <summary>The turn failed — the agent did not produce a usable response.</summary>
+    Failure = 1
+}

--- a/src/Content/Domain/Domain.AI/WorkMemory/WorkEpisode.cs
+++ b/src/Content/Domain/Domain.AI/WorkMemory/WorkEpisode.cs
@@ -1,0 +1,61 @@
+namespace Domain.AI.WorkMemory;
+
+/// <summary>
+/// A record of what the agent <em>did</em> on a single conversation turn — the unit of "work memory".
+/// Unlike a <see cref="Domain.AI.Learnings.LearningEntry"/> (an isolated fact) or a cross-session
+/// memory node (a user/domain fact), a work episode captures a <strong>trajectory</strong>: the task
+/// the user posed, the response produced, whether it succeeded, and what it cost.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Episodes are captured cheaply and structurally at the end of each turn by
+/// <c>WorkEpisodeCaptureBehavior</c> — there is deliberately <strong>no LLM call</strong> on the
+/// capture path. The expensive distillation of episodes into reusable lessons happens later, offline,
+/// in the overnight synthesis pass (mirroring Perplexity Brain's "log cheaply, synthesize overnight"
+/// design). This is the read corpus that synthesis consumes.
+/// </para>
+/// <para>
+/// <see cref="ConversationId"/> and <see cref="TurnNumber"/> form the provenance link back to the
+/// originating session — every episode is traceable to its source. Tenant/owner isolation is enforced
+/// by the underlying graph store (<c>ComplianceAwareGraphStore</c> stamps tenant on write,
+/// <c>TenantIsolatedGraphStore</c> filters on read); the episode itself carries no tenant field.
+/// </para>
+/// </remarks>
+public sealed record WorkEpisode
+{
+    /// <summary>Unique identifier for this episode.</summary>
+    public required Guid EpisodeId { get; init; }
+
+    /// <summary>The agent that performed the work — provenance for which agent's behaviour to improve.</summary>
+    public required string AgentId { get; init; }
+
+    /// <summary>The conversation this turn belonged to. Provenance link + grouping key for synthesis.</summary>
+    public required string ConversationId { get; init; }
+
+    /// <summary>The 1-based turn number within the conversation.</summary>
+    public required int TurnNumber { get; init; }
+
+    /// <summary>The user's message for this turn — i.e. the task the agent was asked to perform.</summary>
+    public required string UserMessage { get; init; }
+
+    /// <summary>
+    /// A (possibly truncated) summary of the assistant's response — what the agent produced.
+    /// Truncated to <c>WorkMemoryConfig.ResponseSummaryMaxChars</c> at capture time to bound storage.
+    /// </summary>
+    public required string ResponseSummary { get; init; }
+
+    /// <summary>Whether the turn succeeded or failed.</summary>
+    public required EpisodeOutcome Outcome { get; init; }
+
+    /// <summary>Prompt (input) tokens consumed across the LLM calls in this turn.</summary>
+    public required int InputTokens { get; init; }
+
+    /// <summary>Completion (output) tokens produced across the LLM calls in this turn.</summary>
+    public required int OutputTokens { get; init; }
+
+    /// <summary>When the episode was recorded (turn completion time).</summary>
+    public required DateTimeOffset CreatedAt { get; init; }
+
+    /// <summary>Total tokens consumed by the turn — the cost signal the synthesis pass trends over time.</summary>
+    public int TotalTokens => InputTokens + OutputTokens;
+}

--- a/src/Content/Domain/Domain.Common/Config/AI/AIConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/AIConfig.cs
@@ -19,6 +19,7 @@ using Domain.Common.Config.AI.Resilience;
 using Domain.Common.Config.AI.Routing;
 using Domain.Common.Config.AI.Sandbox;
 using Domain.Common.Config.AI.Telemetry;
+using Domain.Common.Config.AI.WorkMemory;
 
 namespace Domain.Common.Config.AI;
 
@@ -47,6 +48,7 @@ namespace Domain.Common.Config.AI;
 /// ├── KnowledgeBridge    — Conversation-to-Knowledge Bridge: fact extraction, confidence, timeout
 /// ├── DriftDetection    — EWMA-based drift detection for quality regressions
 /// ├── Learnings         — Cross-session learnings: feedback blending, decay, pruning
+/// ├── WorkMemory        — Self-improving work memory: per-turn episode capture for synthesis
 /// ├── Planner           — Plan execution: concurrency, timeouts, persistence
 /// ├── Sandbox           — Sandbox execution: resource limits, isolation, containers
 /// ├── ToolOutputCompression — Tool output compression: thresholds, LLM fallback, strategies
@@ -162,6 +164,16 @@ public class AIConfig
     /// temporal decay, pruning schedules, and drift baseline adjustment.
     /// </summary>
     public LearningsConfig Learnings { get; set; } = new();
+
+    /// <summary>
+    /// Self-improving work-memory configuration. Off by default — when enabled,
+    /// <c>WorkEpisodeCaptureBehavior</c> records what the agent did on each turn (a
+    /// <c>WorkEpisode</c>) so a later overnight synthesis pass can distill those trajectories
+    /// into reusable lessons. Distinct from <see cref="Learnings"/> (isolated facts) and
+    /// <see cref="KnowledgeBridge"/> (user/domain facts): work memory is about the agent's own
+    /// task executions — what worked, what failed, and what it cost.
+    /// </summary>
+    public WorkMemoryConfig WorkMemory { get; set; } = new();
 
     /// <summary>Agent Governance Toolkit configuration.</summary>
     public GovernanceConfig Governance { get; init; } = new();

--- a/src/Content/Domain/Domain.Common/Config/AI/WorkMemory/WorkMemoryConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/WorkMemory/WorkMemoryConfig.cs
@@ -1,0 +1,46 @@
+namespace Domain.Common.Config.AI.WorkMemory;
+
+/// <summary>
+/// Root configuration for the self-improving work-memory subsystem. Bound from
+/// <c>AppConfig:AI:WorkMemory</c> in appsettings.json.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Work memory records what the agent <em>did</em> on each turn (a <c>WorkEpisode</c>), so a later
+/// overnight synthesis pass can distill those trajectories into reusable lessons. This config governs
+/// the capture half (PR1).
+/// </para>
+/// <para>
+/// <strong>Off by default.</strong> Capturing episodes is pointless until the synthesis (PR2) and
+/// recall (PR3) consumers exist, so a fresh consumer pays no cost and stores nothing until they
+/// deliberately opt in.
+/// </para>
+/// <code>
+/// AppConfig.AI.WorkMemory
+/// ├── Enabled                 — Master toggle for episode capture (default false)
+/// ├── StoreProvider           — Keyed DI provider ("graph" or "in_memory")
+/// └── ResponseSummaryMaxChars — Cap on stored response length (bounds episode size)
+/// </code>
+/// </remarks>
+public class WorkMemoryConfig
+{
+    /// <summary>
+    /// Master toggle. When disabled (the default), <c>WorkEpisodeCaptureBehavior</c> is a pass-through
+    /// and no episodes are recorded.
+    /// </summary>
+    /// <value>Default: false</value>
+    public bool Enabled { get; set; }
+
+    /// <summary>
+    /// Keyed DI provider for <c>IWorkEpisodeStore</c> ("graph" or "in_memory").
+    /// </summary>
+    /// <value>Default: "graph"</value>
+    public string StoreProvider { get; set; } = "graph";
+
+    /// <summary>
+    /// Maximum number of characters of the assistant response stored on an episode. Responses longer
+    /// than this are truncated at capture time to bound per-episode storage. Must be positive.
+    /// </summary>
+    /// <value>Default: 2000</value>
+    public int ResponseSummaryMaxChars { get; set; } = 2000;
+}

--- a/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/DependencyInjection.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/DependencyInjection.cs
@@ -3,6 +3,7 @@ using Application.AI.Common.Interfaces.KnowledgeGraph;
 using Application.AI.Common.Interfaces.Learnings;
 using Application.AI.Common.Interfaces.RAG;
 using Application.AI.Common.Interfaces.Skills;
+using Application.AI.Common.Interfaces.WorkMemory;
 using Domain.Common.Config;
 using Infrastructure.AI.KnowledgeGraph.Audit;
 using Infrastructure.AI.KnowledgeGraph.Compliance;
@@ -255,6 +256,20 @@ public static class DependencyInjection
         var learningsProvider = appConfig.AI.Learnings.StoreProvider;
         services.AddSingleton<ILearningsStore>(sp =>
             sp.GetRequiredKeyedService<ILearningsStore>(learningsProvider));
+
+        // --- Work-Episode Store (keyed DI) ---
+
+        services.AddKeyedSingleton<IWorkEpisodeStore>("graph", (sp, _) =>
+            new WorkMemory.GraphWorkEpisodeStore(
+                sp.GetRequiredService<IKnowledgeGraphStore>(),
+                sp.GetRequiredService<ILogger<WorkMemory.GraphWorkEpisodeStore>>()));
+
+        services.AddKeyedSingleton<IWorkEpisodeStore>("in_memory", (_, _) =>
+            new WorkMemory.InMemoryWorkEpisodeStore());
+
+        var workMemoryProvider = appConfig.AI.WorkMemory.StoreProvider;
+        services.AddSingleton<IWorkEpisodeStore>(sp =>
+            sp.GetRequiredKeyedService<IWorkEpisodeStore>(workMemoryProvider));
 
         return services;
     }

--- a/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/DependencyInjection.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/DependencyInjection.cs
@@ -268,6 +268,17 @@ public static class DependencyInjection
             new WorkMemory.InMemoryWorkEpisodeStore());
 
         var workMemoryProvider = appConfig.AI.WorkMemory.StoreProvider;
+        // Fail loud at startup on a misconfigured provider key. Capture runs fire-and-forget, so a
+        // bad key would otherwise throw inside WorkEpisodeCaptureBehavior's swallowed catch on every
+        // turn — the subsystem would be silently dead with no surfaced error. Only enforced when the
+        // subsystem is enabled so a disabled (default) host with a stale value still boots.
+        if (appConfig.AI.WorkMemory.Enabled && workMemoryProvider is not ("graph" or "in_memory"))
+        {
+            throw new InvalidOperationException(
+                $"AppConfig:AI:WorkMemory:StoreProvider '{workMemoryProvider}' is not a registered " +
+                "work-episode store provider. Use 'graph' or 'in_memory'.");
+        }
+
         services.AddSingleton<IWorkEpisodeStore>(sp =>
             sp.GetRequiredKeyedService<IWorkEpisodeStore>(workMemoryProvider));
 

--- a/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/WorkMemory/GraphWorkEpisodeStore.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/WorkMemory/GraphWorkEpisodeStore.cs
@@ -1,0 +1,219 @@
+using System.Globalization;
+using Application.AI.Common.Interfaces.KnowledgeGraph;
+using Application.AI.Common.Interfaces.WorkMemory;
+using Domain.AI.KnowledgeGraph.Models;
+using Domain.AI.WorkMemory;
+using Domain.Common;
+using Microsoft.Extensions.Logging;
+
+namespace Infrastructure.AI.KnowledgeGraph.WorkMemory;
+
+/// <summary>
+/// Graph-backed implementation of <see cref="IWorkEpisodeStore"/> using deterministic node IDs and a
+/// per-conversation index node for efficient grouped retrieval. Registered with keyed DI key
+/// <c>"graph"</c>.
+/// </summary>
+/// <remarks>
+/// Tenant/owner isolation is <strong>not</strong> implemented here — it is inherited from the injected
+/// <see cref="IKnowledgeGraphStore"/>, which in production is the tenant-isolating / compliance-aware
+/// decorator chain (stamps tenant on write, filters on read). This mirrors <c>GraphLearningsStore</c>.
+/// </remarks>
+public sealed class GraphWorkEpisodeStore : IWorkEpisodeStore
+{
+    private readonly IKnowledgeGraphStore _graphStore;
+    private readonly ILogger<GraphWorkEpisodeStore> _logger;
+
+    private const string NodePrefix = "workepisode:";
+    private const string IndexPrefix = "workepisodeindex:conv:";
+    private const string NodeType = "WorkEpisode";
+    private const string IndexType = "WorkEpisodeIndex";
+    private const string EdgePredicate = "has_episode";
+    private const string ChunkId = "workepisodeindex";
+
+    /// <summary>Initializes a new instance of the <see cref="GraphWorkEpisodeStore"/> class.</summary>
+    public GraphWorkEpisodeStore(
+        IKnowledgeGraphStore graphStore,
+        ILogger<GraphWorkEpisodeStore> logger)
+    {
+        ArgumentNullException.ThrowIfNull(graphStore);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _graphStore = graphStore;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<Result> SaveAsync(WorkEpisode episode, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(episode);
+        try
+        {
+            var nodeId = ToNodeId(episode.EpisodeId);
+            var node = new GraphNode
+            {
+                Id = nodeId,
+                Name = $"Episode: {episode.ConversationId}#{episode.TurnNumber}",
+                Type = NodeType,
+                Properties = SerializeProperties(episode)
+            };
+
+            await _graphStore.AddNodesAsync([node], ct);
+            await CreateIndexEdgeAsync(nodeId, episode.ConversationId, ct);
+            return Result.Success();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to save work episode {EpisodeId}", episode.EpisodeId);
+            return Result.Fail($"Failed to save work episode: {ex.Message}");
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<Result<WorkEpisode?>> GetAsync(Guid episodeId, CancellationToken ct)
+    {
+        try
+        {
+            var node = await _graphStore.GetNodeAsync(ToNodeId(episodeId), ct);
+            if (node is null)
+                return Result<WorkEpisode?>.Success(null);
+
+            return Result<WorkEpisode?>.Success(Deserialize(episodeId, node));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to get work episode {EpisodeId}", episodeId);
+            return Result<WorkEpisode?>.Fail($"Failed to get work episode: {ex.Message}");
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<Result<IReadOnlyList<WorkEpisode>>> SearchAsync(WorkEpisodeSearchCriteria criteria, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(criteria);
+        try
+        {
+            var candidates = new Dictionary<string, GraphNode>();
+
+            if (criteria.ConversationId is not null)
+            {
+                await CollectIndexNeighborsAsync(ToIndexId(criteria.ConversationId), candidates, ct);
+            }
+            else
+            {
+                // No conversation filter = scan all episode nodes. O(N); acceptable for the overnight
+                // synthesis pass, which is the only cross-conversation caller.
+                var allNodes = await _graphStore.GetAllNodesAsync(ct);
+                foreach (var n in allNodes.Where(n => n.Type == NodeType))
+                    candidates.TryAdd(n.Id, n);
+            }
+
+            var episodes = new List<WorkEpisode>();
+            foreach (var node in candidates.Values)
+            {
+                var id = ExtractEpisodeId(node.Id);
+                if (id is null) continue;
+
+                var episode = Deserialize(id.Value, node);
+                if (episode is null) continue;
+
+                if (criteria.Outcome is not null && episode.Outcome != criteria.Outcome)
+                    continue;
+                if (criteria.CreatedAfter is not null && episode.CreatedAt < criteria.CreatedAfter)
+                    continue;
+                if (criteria.CreatedBefore is not null && episode.CreatedAt > criteria.CreatedBefore)
+                    continue;
+
+                episodes.Add(episode);
+            }
+
+            IEnumerable<WorkEpisode> ordered = episodes.OrderByDescending(e => e.CreatedAt);
+            if (criteria.Limit is { } limit)
+                ordered = ordered.Take(limit);
+
+            return Result<IReadOnlyList<WorkEpisode>>.Success(ordered.ToList());
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to search work episodes");
+            return Result<IReadOnlyList<WorkEpisode>>.Fail($"Failed to search work episodes: {ex.Message}");
+        }
+    }
+
+    private static string ToNodeId(Guid episodeId) => $"{NodePrefix}{episodeId}".ToLowerInvariant();
+
+    private static string ToIndexId(string conversationId) =>
+        $"{IndexPrefix}{conversationId}".ToLowerInvariant();
+
+    private static Guid? ExtractEpisodeId(string nodeId)
+    {
+        if (!nodeId.StartsWith(NodePrefix, StringComparison.OrdinalIgnoreCase))
+            return null;
+        return Guid.TryParse(nodeId[NodePrefix.Length..], out var id) ? id : null;
+    }
+
+    private async Task CreateIndexEdgeAsync(string nodeId, string conversationId, CancellationToken ct)
+    {
+        var indexId = ToIndexId(conversationId);
+        var indexNode = new GraphNode { Id = indexId, Name = $"Conversation:{conversationId}", Type = IndexType };
+
+        await _graphStore.AddNodesAsync([indexNode], ct);
+        await _graphStore.AddEdgesAsync(
+            [new GraphEdge
+            {
+                Id = $"edge:{indexId}:{nodeId}",
+                SourceNodeId = indexId,
+                TargetNodeId = nodeId,
+                Predicate = EdgePredicate,
+                ChunkId = ChunkId
+            }],
+            ct);
+    }
+
+    private async Task CollectIndexNeighborsAsync(string indexNodeId, Dictionary<string, GraphNode> candidates, CancellationToken ct)
+    {
+        if (!await _graphStore.NodeExistsAsync(indexNodeId, ct))
+            return;
+
+        var neighbors = await _graphStore.GetNeighborsAsync(indexNodeId, maxDepth: 1, ct);
+        foreach (var neighbor in neighbors.Where(n => n.Type == NodeType))
+            candidates.TryAdd(neighbor.Id, neighbor);
+    }
+
+    private static Dictionary<string, string> SerializeProperties(WorkEpisode episode) => new()
+    {
+        ["AgentId"] = episode.AgentId,
+        ["ConversationId"] = episode.ConversationId,
+        ["TurnNumber"] = episode.TurnNumber.ToString(CultureInfo.InvariantCulture),
+        ["UserMessage"] = episode.UserMessage,
+        ["ResponseSummary"] = episode.ResponseSummary,
+        ["Outcome"] = episode.Outcome.ToString(),
+        ["InputTokens"] = episode.InputTokens.ToString(CultureInfo.InvariantCulture),
+        ["OutputTokens"] = episode.OutputTokens.ToString(CultureInfo.InvariantCulture),
+        ["CreatedAt"] = episode.CreatedAt.ToString("O")
+    };
+
+    private WorkEpisode? Deserialize(Guid episodeId, GraphNode node)
+    {
+        var props = node.Properties;
+
+        if (!props.ContainsKey("ConversationId") || !props.ContainsKey("Outcome"))
+        {
+            _logger.LogWarning("Skipping graph node {NodeId}: missing required work-episode properties", node.Id);
+            return null;
+        }
+
+        return new WorkEpisode
+        {
+            EpisodeId = episodeId,
+            AgentId = props.GetValueOrDefault("AgentId", ""),
+            ConversationId = props.GetValueOrDefault("ConversationId", ""),
+            TurnNumber = int.TryParse(props.GetValueOrDefault("TurnNumber", "0"), NumberStyles.Integer, CultureInfo.InvariantCulture, out var tn) ? tn : 0,
+            UserMessage = props.GetValueOrDefault("UserMessage", ""),
+            ResponseSummary = props.GetValueOrDefault("ResponseSummary", ""),
+            Outcome = Enum.TryParse<EpisodeOutcome>(props.GetValueOrDefault("Outcome", ""), out var oc) ? oc : EpisodeOutcome.Success,
+            InputTokens = int.TryParse(props.GetValueOrDefault("InputTokens", "0"), NumberStyles.Integer, CultureInfo.InvariantCulture, out var it) ? it : 0,
+            OutputTokens = int.TryParse(props.GetValueOrDefault("OutputTokens", "0"), NumberStyles.Integer, CultureInfo.InvariantCulture, out var ot) ? ot : 0,
+            CreatedAt = DateTimeOffset.TryParse(props.GetValueOrDefault("CreatedAt", ""), CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var ca) ? ca : DateTimeOffset.UtcNow
+        };
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/WorkMemory/InMemoryWorkEpisodeStore.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/WorkMemory/InMemoryWorkEpisodeStore.cs
@@ -1,0 +1,56 @@
+using System.Collections.Concurrent;
+using Application.AI.Common.Interfaces.WorkMemory;
+using Domain.AI.WorkMemory;
+using Domain.Common;
+
+namespace Infrastructure.AI.KnowledgeGraph.WorkMemory;
+
+/// <summary>
+/// In-memory implementation of <see cref="IWorkEpisodeStore"/> for tests and ephemeral hosts.
+/// Registered with keyed DI key <c>"in_memory"</c>. Thread-safe; provides no tenant isolation —
+/// that is a property of the graph-backed store only.
+/// </summary>
+public sealed class InMemoryWorkEpisodeStore : IWorkEpisodeStore
+{
+    private readonly ConcurrentDictionary<Guid, WorkEpisode> _episodes = new();
+
+    /// <inheritdoc />
+    public Task<Result> SaveAsync(WorkEpisode episode, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(episode);
+        _episodes[episode.EpisodeId] = episode;
+        return Task.FromResult(Result.Success());
+    }
+
+    /// <inheritdoc />
+    public Task<Result<WorkEpisode?>> GetAsync(Guid episodeId, CancellationToken ct)
+    {
+        _episodes.TryGetValue(episodeId, out var episode);
+        return Task.FromResult(Result<WorkEpisode?>.Success(episode));
+    }
+
+    /// <inheritdoc />
+    public Task<Result<IReadOnlyList<WorkEpisode>>> SearchAsync(WorkEpisodeSearchCriteria criteria, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(criteria);
+
+        IEnumerable<WorkEpisode> query = _episodes.Values;
+
+        if (criteria.ConversationId is not null)
+            query = query.Where(e => e.ConversationId == criteria.ConversationId);
+        if (criteria.Outcome is not null)
+            query = query.Where(e => e.Outcome == criteria.Outcome);
+        if (criteria.CreatedAfter is not null)
+            query = query.Where(e => e.CreatedAt >= criteria.CreatedAfter);
+        if (criteria.CreatedBefore is not null)
+            query = query.Where(e => e.CreatedAt <= criteria.CreatedBefore);
+
+        // Newest first — synthesis cares about recent work; deterministic for tests.
+        query = query.OrderByDescending(e => e.CreatedAt);
+
+        if (criteria.Limit is { } limit)
+            query = query.Take(limit);
+
+        return Task.FromResult(Result<IReadOnlyList<WorkEpisode>>.Success(query.ToList()));
+    }
+}

--- a/src/Content/Tests/Application.AI.Common.Tests/DependencyInjectionTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/DependencyInjectionTests.cs
@@ -108,7 +108,7 @@ public class DependencyInjectionTests
     }
 
     [Fact]
-    public void AddApplicationAIDependencies_RegistersFourteenPipelineBehaviors()
+    public void AddApplicationAIDependencies_RegistersFifteenPipelineBehaviors()
     {
         var services = CreateServicesWithAIDependencies();
 
@@ -117,10 +117,11 @@ public class DependencyInjectionTests
                         d.ServiceType.GetGenericTypeDefinition() == typeof(MediatR.IPipelineBehavior<,>))
             .ToList();
 
-        // 14 = the prior 16 minus ToolPermissionBehavior + GovernancePolicyBehavior, which were
-        // removed once IToolInvocationGovernor took over tool authorization on the live tool path
-        // (nothing in production implements IToolRequest, so those behaviors never fired).
-        behaviors.Should().HaveCount(14);
+        // 15 = the prior 16 minus ToolPermissionBehavior + GovernancePolicyBehavior (removed once
+        // IToolInvocationGovernor took over tool authorization on the live tool path — nothing in
+        // production implements IToolRequest, so those behaviors never fired), plus the post-turn
+        // WorkEpisodeCaptureBehavior (self-improving work memory).
+        behaviors.Should().HaveCount(15);
         behaviors.Should().OnlyContain(d => d.Lifetime == ServiceLifetime.Transient);
     }
 

--- a/src/Content/Tests/Application.AI.Common.Tests/MediatRBehaviors/WorkEpisodeCaptureBehaviorTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/MediatRBehaviors/WorkEpisodeCaptureBehaviorTests.cs
@@ -65,6 +65,7 @@ public sealed class WorkEpisodeCaptureBehaviorTests
         await WaitForAsync(() => captured.Count == 1, TimeSpan.FromSeconds(2));
 
         var episode = captured.Single();
+        episode.AgentId.Should().Be("test-agent"); // ExecuteAgentTurnCommand.AgentId => AgentName
         episode.ConversationId.Should().Be("conv-9");
         episode.TurnNumber.Should().Be(4);
         episode.UserMessage.Should().Be("the task");

--- a/src/Content/Tests/Application.AI.Common.Tests/MediatRBehaviors/WorkEpisodeCaptureBehaviorTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/MediatRBehaviors/WorkEpisodeCaptureBehaviorTests.cs
@@ -1,0 +1,223 @@
+using Application.AI.Common.Interfaces;
+using Application.AI.Common.Interfaces.WorkMemory;
+using Application.AI.Common.MediatRBehaviors;
+using Application.Core.CQRS.Agents.ExecuteAgentTurn;
+using Domain.AI.WorkMemory;
+using Domain.Common;
+using Domain.Common.Config;
+using FluentAssertions;
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Application.AI.Common.Tests.MediatRBehaviors;
+
+public sealed class WorkEpisodeCaptureBehaviorTests
+{
+    private readonly Mock<IWorkEpisodeStore> _store = new();
+    private readonly AppConfig _appConfig = new();
+
+    public WorkEpisodeCaptureBehaviorTests()
+    {
+        _appConfig.AI.WorkMemory.Enabled = true;
+        _appConfig.AI.WorkMemory.ResponseSummaryMaxChars = 2000;
+    }
+
+    [Fact]
+    public async Task Handle_NonAgentTurnRequest_PassesThroughWithoutCapture()
+    {
+        var behavior = CreateBehavior<NonAgentRequest, string>();
+
+        var result = await behavior.Handle(
+            new NonAgentRequest(),
+            () => Task.FromResult("passthrough"),
+            CancellationToken.None);
+
+        result.Should().Be("passthrough");
+        _store.Verify(s => s.SaveAsync(It.IsAny<WorkEpisode>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_Disabled_SkipsCapture()
+    {
+        _appConfig.AI.WorkMemory.Enabled = false;
+        var behavior = CreateAgentTurnBehavior();
+        var response = CreateResult(success: true, response: "done");
+
+        var result = await behavior.Handle(CreateCommand("hi"), () => Task.FromResult(response), CancellationToken.None);
+
+        result.Should().BeSameAs(response);
+        _store.Verify(s => s.SaveAsync(It.IsAny<WorkEpisode>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_SuccessfulTurn_CapturesEpisodeWithOutcomeAndTokens()
+    {
+        var captured = SetupCapture();
+        var behavior = CreateAgentTurnBehavior();
+        var response = CreateResult(success: true, response: "the answer", inputTokens: 120, outputTokens: 45);
+
+        await behavior.Handle(CreateCommand("the task", "conv-9", 4), () => Task.FromResult(response), CancellationToken.None);
+
+        await WaitForAsync(() => captured.Count == 1, TimeSpan.FromSeconds(2));
+
+        var episode = captured.Single();
+        episode.ConversationId.Should().Be("conv-9");
+        episode.TurnNumber.Should().Be(4);
+        episode.UserMessage.Should().Be("the task");
+        episode.ResponseSummary.Should().Be("the answer");
+        episode.Outcome.Should().Be(EpisodeOutcome.Success);
+        episode.InputTokens.Should().Be(120);
+        episode.OutputTokens.Should().Be(45);
+        episode.TotalTokens.Should().Be(165);
+        episode.EpisodeId.Should().NotBe(Guid.Empty);
+    }
+
+    [Fact]
+    public async Task Handle_FailedTurn_CapturesEpisodeWithFailureOutcome()
+    {
+        var captured = SetupCapture();
+        var behavior = CreateAgentTurnBehavior();
+        var response = CreateResult(success: false, response: "");
+
+        await behavior.Handle(CreateCommand("do it"), () => Task.FromResult(response), CancellationToken.None);
+
+        await WaitForAsync(() => captured.Count == 1, TimeSpan.FromSeconds(2));
+        captured.Single().Outcome.Should().Be(EpisodeOutcome.Failure);
+    }
+
+    [Fact]
+    public async Task Handle_LongResponse_TruncatesSummaryToConfiguredCap()
+    {
+        _appConfig.AI.WorkMemory.ResponseSummaryMaxChars = 10;
+        var captured = SetupCapture();
+        var behavior = CreateAgentTurnBehavior();
+        var response = CreateResult(success: true, response: new string('x', 5000));
+
+        await behavior.Handle(CreateCommand("summarize"), () => Task.FromResult(response), CancellationToken.None);
+
+        await WaitForAsync(() => captured.Count == 1, TimeSpan.FromSeconds(2));
+        captured.Single().ResponseSummary.Should().HaveLength(10);
+    }
+
+    [Fact]
+    public async Task Handle_TruncationBoundaryOnSurrogatePair_DoesNotSplitThePair()
+    {
+        // Cap at 5 so the boundary lands exactly between the two halves of the 3rd emoji (each
+        // emoji is a surrogate pair = 2 chars). Naive value[..5] would leave a lone high surrogate.
+        _appConfig.AI.WorkMemory.ResponseSummaryMaxChars = 5;
+        var captured = SetupCapture();
+        var behavior = CreateAgentTurnBehavior();
+        var response = CreateResult(success: true, response: string.Concat(Enumerable.Repeat("😀", 4)));
+
+        await behavior.Handle(CreateCommand("emoji"), () => Task.FromResult(response), CancellationToken.None);
+
+        await WaitForAsync(() => captured.Count == 1, TimeSpan.FromSeconds(2));
+        var summary = captured.Single().ResponseSummary;
+        summary.Should().HaveLength(4); // backed off one char to keep whole pairs
+        char.IsHighSurrogate(summary[^1]).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Handle_StoreThrows_BackgroundFailureIsAbsorbed()
+    {
+        var attempts = 0;
+        _store
+            .Setup(s => s.SaveAsync(It.IsAny<WorkEpisode>(), It.IsAny<CancellationToken>()))
+            .Callback(() => Interlocked.Increment(ref attempts))
+            .ThrowsAsync(new InvalidOperationException("graph down"));
+
+        var behavior = CreateAgentTurnBehavior();
+        var response = CreateResult(success: true, response: "ok");
+
+        // Synchronous path returns immediately — capture is fire-and-forget.
+        var result = await behavior.Handle(CreateCommand("go"), () => Task.FromResult(response), CancellationToken.None);
+        result.Should().BeSameAs(response);
+
+        // Prove the background body ran (and threw) without faulting the test process.
+        await WaitForAsync(() => Volatile.Read(ref attempts) == 1, TimeSpan.FromSeconds(2));
+    }
+
+    // --- Helpers ---
+
+    private List<WorkEpisode> SetupCapture()
+    {
+        var captured = new List<WorkEpisode>();
+        _store
+            .Setup(s => s.SaveAsync(It.IsAny<WorkEpisode>(), It.IsAny<CancellationToken>()))
+            .Callback<WorkEpisode, CancellationToken>((e, _) =>
+            {
+                lock (captured) { captured.Add(e); }
+            })
+            .ReturnsAsync(Result.Success());
+        return captured;
+    }
+
+    private static async Task WaitForAsync(Func<bool> predicate, TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            if (predicate()) return;
+            await Task.Delay(10);
+        }
+        throw new TimeoutException($"Predicate did not become true within {timeout.TotalMilliseconds}ms.");
+    }
+
+    private IServiceScopeFactory BuildScopeFactory()
+    {
+        var provider = new Mock<IServiceProvider>();
+        provider.Setup(p => p.GetService(typeof(IWorkEpisodeStore))).Returns(_store.Object);
+
+        var scope = new Mock<IServiceScope>();
+        scope.SetupGet(s => s.ServiceProvider).Returns(provider.Object);
+
+        var factory = new Mock<IServiceScopeFactory>();
+        factory.Setup(f => f.CreateScope()).Returns(scope.Object);
+        return factory.Object;
+    }
+
+    private static IAmbientRequestScope BuildAmbientScope()
+    {
+        var ambient = new Mock<IAmbientRequestScope>();
+        ambient.Setup(a => a.BeginScope(It.IsAny<IServiceProvider>())).Returns(Mock.Of<IDisposable>());
+        return ambient.Object;
+    }
+
+    private WorkEpisodeCaptureBehavior<TRequest, TResponse> CreateBehavior<TRequest, TResponse>()
+        where TRequest : notnull =>
+        new(
+            BuildScopeFactory(),
+            BuildAmbientScope(),
+            Mock.Of<IOptionsMonitor<AppConfig>>(m => m.CurrentValue == _appConfig),
+            TimeProvider.System,
+            NullLogger<WorkEpisodeCaptureBehavior<TRequest, TResponse>>.Instance);
+
+    private WorkEpisodeCaptureBehavior<ExecuteAgentTurnCommand, AgentTurnResult> CreateAgentTurnBehavior() =>
+        CreateBehavior<ExecuteAgentTurnCommand, AgentTurnResult>();
+
+    private static ExecuteAgentTurnCommand CreateCommand(
+        string userMessage, string conversationId = "conv-1", int turnNumber = 1) =>
+        new()
+        {
+            AgentName = "test-agent",
+            UserMessage = userMessage,
+            ConversationId = conversationId,
+            TurnNumber = turnNumber
+        };
+
+    private static AgentTurnResult CreateResult(bool success, string response, int inputTokens = 0, int outputTokens = 0) =>
+        new()
+        {
+            Success = success,
+            Response = response,
+            UpdatedHistory = [],
+            InputTokens = inputTokens,
+            OutputTokens = outputTokens
+        };
+
+    private sealed record NonAgentRequest : IRequest<string>;
+}

--- a/src/Content/Tests/Application.Core.Tests/Validation/WorkMemoryConfigValidatorTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/Validation/WorkMemoryConfigValidatorTests.cs
@@ -1,0 +1,52 @@
+using Application.Core.Validation;
+using Domain.Common.Config.AI.WorkMemory;
+using FluentAssertions;
+using Xunit;
+
+namespace Application.Core.Tests.Validation;
+
+public sealed class WorkMemoryConfigValidatorTests
+{
+    private readonly WorkMemoryConfigValidator _sut = new();
+
+    [Fact]
+    public void Validate_Defaults_Passes()
+    {
+        var result = _sut.Validate(new WorkMemoryConfig());
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("graph")]
+    [InlineData("in_memory")]
+    public void Validate_KnownStoreProvider_Passes(string provider)
+    {
+        var result = _sut.Validate(new WorkMemoryConfig { StoreProvider = provider });
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("Graph")]
+    [InlineData("neo4j")]
+    public void Validate_UnknownStoreProvider_Fails(string provider)
+    {
+        var result = _sut.Validate(new WorkMemoryConfig { StoreProvider = provider });
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(WorkMemoryConfig.StoreProvider));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void Validate_NonPositiveResponseSummaryMaxChars_Fails(int max)
+    {
+        var result = _sut.Validate(new WorkMemoryConfig { ResponseSummaryMaxChars = max });
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(WorkMemoryConfig.ResponseSummaryMaxChars));
+    }
+}

--- a/src/Content/Tests/Domain.AI.Tests/WorkMemory/WorkEpisodeTests.cs
+++ b/src/Content/Tests/Domain.AI.Tests/WorkMemory/WorkEpisodeTests.cs
@@ -1,0 +1,28 @@
+using Domain.AI.WorkMemory;
+using FluentAssertions;
+using Xunit;
+
+namespace Domain.AI.Tests.WorkMemory;
+
+public sealed class WorkEpisodeTests
+{
+    [Fact]
+    public void TotalTokens_IsSumOfInputAndOutput()
+    {
+        var episode = new WorkEpisode
+        {
+            EpisodeId = Guid.NewGuid(),
+            AgentId = "agent-1",
+            ConversationId = "conv-1",
+            TurnNumber = 1,
+            UserMessage = "task",
+            ResponseSummary = "result",
+            Outcome = EpisodeOutcome.Success,
+            InputTokens = 100,
+            OutputTokens = 25,
+            CreatedAt = DateTimeOffset.UtcNow
+        };
+
+        episode.TotalTokens.Should().Be(125);
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.KnowledgeGraph.Tests/WorkMemory/GraphWorkEpisodeStoreTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.KnowledgeGraph.Tests/WorkMemory/GraphWorkEpisodeStoreTests.cs
@@ -1,0 +1,132 @@
+using Application.AI.Common.Interfaces.WorkMemory;
+using Domain.AI.WorkMemory;
+using FluentAssertions;
+using Infrastructure.AI.KnowledgeGraph.InMemory;
+using Infrastructure.AI.KnowledgeGraph.WorkMemory;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Infrastructure.AI.KnowledgeGraph.Tests.WorkMemory;
+
+public sealed class GraphWorkEpisodeStoreTests
+{
+    private readonly InMemoryGraphStore _graphStore;
+    private readonly GraphWorkEpisodeStore _sut;
+
+    public GraphWorkEpisodeStoreTests()
+    {
+        _graphStore = new InMemoryGraphStore(Mock.Of<ILogger<InMemoryGraphStore>>());
+        _sut = new GraphWorkEpisodeStore(_graphStore, Mock.Of<ILogger<GraphWorkEpisodeStore>>());
+    }
+
+    private static WorkEpisode BuildEpisode(
+        Guid? id = null,
+        string conversationId = "conv-1",
+        int turnNumber = 1,
+        EpisodeOutcome outcome = EpisodeOutcome.Success,
+        DateTimeOffset? createdAt = null) => new()
+    {
+        EpisodeId = id ?? Guid.NewGuid(),
+        AgentId = "agent-x",
+        ConversationId = conversationId,
+        TurnNumber = turnNumber,
+        UserMessage = "the task",
+        ResponseSummary = "the result",
+        Outcome = outcome,
+        InputTokens = 120,
+        OutputTokens = 45,
+        CreatedAt = createdAt ?? DateTimeOffset.UtcNow
+    };
+
+    [Fact]
+    public async Task SaveThenGet_RoundTripsAllFields()
+    {
+        var episode = BuildEpisode();
+
+        (await _sut.SaveAsync(episode, CancellationToken.None)).IsSuccess.Should().BeTrue();
+        var fetched = (await _sut.GetAsync(episode.EpisodeId, CancellationToken.None)).Value;
+
+        fetched.Should().NotBeNull();
+        fetched!.EpisodeId.Should().Be(episode.EpisodeId);
+        fetched.AgentId.Should().Be("agent-x");
+        fetched.ConversationId.Should().Be("conv-1");
+        fetched.TurnNumber.Should().Be(1);
+        fetched.UserMessage.Should().Be("the task");
+        fetched.ResponseSummary.Should().Be("the result");
+        fetched.Outcome.Should().Be(EpisodeOutcome.Success);
+        fetched.InputTokens.Should().Be(120);
+        fetched.OutputTokens.Should().Be(45);
+        fetched.CreatedAt.Should().Be(episode.CreatedAt);
+    }
+
+    [Fact]
+    public async Task Get_UnknownId_ReturnsSuccessWithNull()
+    {
+        var result = await _sut.GetAsync(Guid.NewGuid(), CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Search_ByConversation_ReturnsOnlyThatConversationViaIndex()
+    {
+        await _sut.SaveAsync(BuildEpisode(conversationId: "alpha", turnNumber: 1), CancellationToken.None);
+        await _sut.SaveAsync(BuildEpisode(conversationId: "alpha", turnNumber: 2), CancellationToken.None);
+        await _sut.SaveAsync(BuildEpisode(conversationId: "beta", turnNumber: 1), CancellationToken.None);
+
+        var result = await _sut.SearchAsync(new WorkEpisodeSearchCriteria { ConversationId = "alpha" }, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().HaveCount(2);
+        result.Value.Should().OnlyContain(e => e.ConversationId == "alpha");
+    }
+
+    [Fact]
+    public async Task Search_UnknownConversation_ReturnsEmpty()
+    {
+        await _sut.SaveAsync(BuildEpisode(conversationId: "alpha"), CancellationToken.None);
+
+        var result = await _sut.SearchAsync(new WorkEpisodeSearchCriteria { ConversationId = "missing" }, CancellationToken.None);
+
+        result.Value.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Search_NoConversation_ScansAllAndFiltersByOutcome()
+    {
+        await _sut.SaveAsync(BuildEpisode(conversationId: "a", outcome: EpisodeOutcome.Success), CancellationToken.None);
+        await _sut.SaveAsync(BuildEpisode(conversationId: "b", outcome: EpisodeOutcome.Failure), CancellationToken.None);
+
+        var failures = await _sut.SearchAsync(new WorkEpisodeSearchCriteria { Outcome = EpisodeOutcome.Failure }, CancellationToken.None);
+
+        failures.Value.Should().ContainSingle().Which.Outcome.Should().Be(EpisodeOutcome.Failure);
+    }
+
+    [Fact]
+    public async Task Search_OrdersNewestFirstAndHonorsLimit()
+    {
+        var baseTime = DateTimeOffset.UtcNow;
+        var older = BuildEpisode(conversationId: "c", createdAt: baseTime);
+        var newer = BuildEpisode(conversationId: "c", createdAt: baseTime.AddMinutes(5));
+        await _sut.SaveAsync(older, CancellationToken.None);
+        await _sut.SaveAsync(newer, CancellationToken.None);
+
+        var result = await _sut.SearchAsync(
+            new WorkEpisodeSearchCriteria { ConversationId = "c", Limit = 1 }, CancellationToken.None);
+
+        result.Value.Should().ContainSingle().Which.EpisodeId.Should().Be(newer.EpisodeId);
+    }
+
+    [Fact]
+    public async Task Save_UsesDeterministicLowercaseNodeId()
+    {
+        var id = Guid.NewGuid();
+        await _sut.SaveAsync(BuildEpisode(id: id), CancellationToken.None);
+
+        var node = await _graphStore.GetNodeAsync($"workepisode:{id}".ToLowerInvariant(), CancellationToken.None);
+        node.Should().NotBeNull();
+        node!.Type.Should().Be("WorkEpisode");
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.KnowledgeGraph.Tests/WorkMemory/InMemoryWorkEpisodeStoreTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.KnowledgeGraph.Tests/WorkMemory/InMemoryWorkEpisodeStoreTests.cs
@@ -1,0 +1,85 @@
+using Application.AI.Common.Interfaces.WorkMemory;
+using Domain.AI.WorkMemory;
+using FluentAssertions;
+using Infrastructure.AI.KnowledgeGraph.WorkMemory;
+using Xunit;
+
+namespace Infrastructure.AI.KnowledgeGraph.Tests.WorkMemory;
+
+public sealed class InMemoryWorkEpisodeStoreTests
+{
+    private readonly InMemoryWorkEpisodeStore _sut = new();
+
+    private static WorkEpisode BuildEpisode(
+        Guid? id = null,
+        string conversationId = "conv-1",
+        int turnNumber = 1,
+        EpisodeOutcome outcome = EpisodeOutcome.Success,
+        DateTimeOffset? createdAt = null) => new()
+    {
+        EpisodeId = id ?? Guid.NewGuid(),
+        AgentId = "agent-x",
+        ConversationId = conversationId,
+        TurnNumber = turnNumber,
+        UserMessage = "task",
+        ResponseSummary = "result",
+        Outcome = outcome,
+        InputTokens = 10,
+        OutputTokens = 5,
+        CreatedAt = createdAt ?? DateTimeOffset.UtcNow
+    };
+
+    [Fact]
+    public async Task SaveThenGet_RoundTripsEpisode()
+    {
+        var episode = BuildEpisode();
+
+        (await _sut.SaveAsync(episode, CancellationToken.None)).IsSuccess.Should().BeTrue();
+        var fetched = await _sut.GetAsync(episode.EpisodeId, CancellationToken.None);
+
+        fetched.IsSuccess.Should().BeTrue();
+        fetched.Value.Should().Be(episode);
+    }
+
+    [Fact]
+    public async Task Get_UnknownId_ReturnsSuccessWithNull()
+    {
+        var fetched = await _sut.GetAsync(Guid.NewGuid(), CancellationToken.None);
+
+        fetched.IsSuccess.Should().BeTrue();
+        fetched.Value.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Search_FiltersByConversationOutcomeAndTime()
+    {
+        var now = DateTimeOffset.UtcNow;
+        await _sut.SaveAsync(BuildEpisode(conversationId: "a", outcome: EpisodeOutcome.Success, createdAt: now), CancellationToken.None);
+        await _sut.SaveAsync(BuildEpisode(conversationId: "a", outcome: EpisodeOutcome.Failure, createdAt: now), CancellationToken.None);
+        await _sut.SaveAsync(BuildEpisode(conversationId: "b", outcome: EpisodeOutcome.Failure, createdAt: now), CancellationToken.None);
+
+        var byConversation = await _sut.SearchAsync(new WorkEpisodeSearchCriteria { ConversationId = "a" }, CancellationToken.None);
+        byConversation.Value.Should().HaveCount(2);
+
+        var failures = await _sut.SearchAsync(new WorkEpisodeSearchCriteria { Outcome = EpisodeOutcome.Failure }, CancellationToken.None);
+        failures.Value.Should().HaveCount(2);
+
+        var afterCutoff = await _sut.SearchAsync(
+            new WorkEpisodeSearchCriteria { CreatedAfter = now.AddMinutes(1) }, CancellationToken.None);
+        afterCutoff.Value.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Search_OrdersNewestFirstAndHonorsLimit()
+    {
+        var baseTime = DateTimeOffset.UtcNow;
+        var older = BuildEpisode(turnNumber: 1, createdAt: baseTime);
+        var newer = BuildEpisode(turnNumber: 2, createdAt: baseTime.AddMinutes(5));
+        await _sut.SaveAsync(older, CancellationToken.None);
+        await _sut.SaveAsync(newer, CancellationToken.None);
+
+        var result = await _sut.SearchAsync(new WorkEpisodeSearchCriteria { Limit = 1 }, CancellationToken.None);
+
+        result.Value.Should().ContainSingle().Which.EpisodeId.Should().Be(newer.EpisodeId);
+    }
+}


### PR DESCRIPTION
## What & why

Research project follow-up: Perplexity **Brain** is a *self-improving work memory* — it records what the agent **did** each turn (what worked, failed, was corrected), then synthesizes those logs overnight into reusable lessons that load at the start of the next task. Gap analysis showed this harness already has ~80% of the primitives (knowledge graph, learnings, provenance, feedback, context injection) but **no work-episode capture** — memory stores *facts*, never *trajectories*.

This is **PR1 of 3** — the foundation: cheap, structural, **no-LLM** capture of each turn as a `WorkEpisode`. PR2 adds the overnight synthesis pass; PR3 adds task-similarity recall at turn start. Plan: `.claude/plans/self-improving-work-memory.md`.

## Changes
- **Domain** (`Domain.AI/WorkMemory/`): `WorkEpisode` record + `EpisodeOutcome`.
- **Application**: `IWorkEpisodeStore` + `WorkEpisodeSearchCriteria`; `WorkEpisodeCaptureBehavior` — post-turn, fire-and-forget, mirrors `KnowledgeExtractionBehavior` (fresh DI scope + ambient-scope re-entry so tenant/owner isolation resolves). `WorkMemoryConfigValidator`.
- **Config**: `AppConfig.AI.WorkMemory` — **off by default** until PR2/PR3 consume it.
- **Infrastructure** (`Infrastructure.AI.KnowledgeGraph/WorkMemory/`): `GraphWorkEpisodeStore` (keyed `"graph"`, conversation-indexed; tenant isolation inherited from the decorated graph store) + `InMemoryWorkEpisodeStore` (keyed `"in_memory"`); keyed DI registration.

## Isolation & safety
- Tenant/owner isolation is inherited from the decorated `IKnowledgeGraphStore` (same model as `GraphLearningsStore`).
- Capture never blocks or fails a turn — failures are logged and swallowed.

## Tests (27 new, all green)
- Domain computed property; behavior gating / capture / failure-outcome / truncation / surrogate-pair boundary / fault absorption; both store impls (round-trip, search filters, ordering, limit, deterministic IDs); validator (known/unknown provider, non-positive cap).

## Review
`/code-review` (high) + `/simplify` run. Fixes applied: config validator (closes silent-dead-subsystem-on-`StoreProvider`-typo), surrogate-pair truncation guard. Deferred with rationale in the plan: graph-store duplication (rule of three), unbounded `Task.Run` (matches the reference behavior).

## Verification
`dotnet build src/AgenticHarness.slnx && dotnet test` — build clean (0 errors), new tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)