### PR TITLE
feat(work-memory): task-similarity recall at turn start (self-improving memory PR3)

### DIFF
--- a/src/Content/Application/Application.AI.Common/Factories/AgentExecutionContextFactory.cs
+++ b/src/Content/Application/Application.AI.Common/Factories/AgentExecutionContextFactory.cs
@@ -335,6 +335,24 @@ public class AgentExecutionContextFactory
             }
         }
 
+        // Task-similarity learnings recall. Like the memory provider above, it resolves the scoped,
+        // tenant-aware ILearningRecaller per invocation from the current request scope, so it is safe to
+        // attach to a singleton-cached agent. Injects the most task-relevant lessons (every source,
+        // including work-memory synthesis output) at turn start — the read half of the self-improving loop.
+        if (_appConfig.CurrentValue.AI?.LearningsRecall?.Enabled == true)
+        {
+            var ambientScope = _serviceProvider.GetService<IAmbientRequestScope>();
+            if (ambientScope is not null)
+            {
+                providers.Add(new Services.Agent.LearningsRecallContextProvider(
+                    ambientScope,
+                    _appConfig,
+                    _loggerFactory.CreateLogger<Services.Agent.LearningsRecallContextProvider>()));
+
+                _logger.LogDebug("Wired LearningsRecallContextProvider for task-similarity recall");
+            }
+        }
+
         // Governance wrapper — added LAST so it wraps the final, filtered tool set. When
         // tool-invocation enforcement is on, this guarantees the governor gates every tool the agent
         // can call, including framework progressive-disclosure tools that bypass ToolChainBuilder.

--- a/src/Content/Application/Application.AI.Common/Interfaces/Learnings/ILearningRecaller.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Learnings/ILearningRecaller.cs
@@ -1,0 +1,37 @@
+using Domain.AI.Learnings;
+
+namespace Application.AI.Common.Interfaces.Learnings;
+
+/// <summary>
+/// Recalls the learnings most relevant to a piece of context (e.g. the current task), ranked by the
+/// full relevance + feedback + freshness pipeline. This is a thin, layer-friendly seam over the
+/// <c>RecallQuery</c> CQRS path: it lets <c>Application.AI.Common</c> consumers (notably
+/// <c>LearningsRecallContextProvider</c>) recall learnings without depending on MediatR or
+/// <c>Application.Core</c>, mirroring how <c>IKnowledgeMemory</c> exposes fact recall.
+/// </summary>
+/// <remarks>
+/// Recall spans every learning source (human corrections, drift fixes, escalation resolutions, and
+/// agent self-improvement lessons) — the store is a single ranked recall surface, so the most relevant
+/// lesson wins regardless of how it was captured.
+/// </remarks>
+public interface ILearningRecaller
+{
+    /// <summary>
+    /// Recalls up to <paramref name="maxResults"/> learnings relevant to <paramref name="context"/>,
+    /// dropping any below <paramref name="minRelevance"/> semantic similarity.
+    /// </summary>
+    /// <param name="context">The natural-language context to match against (the current task / user message).</param>
+    /// <param name="maxResults">Maximum number of learnings to return.</param>
+    /// <param name="minRelevance">Minimum semantic relevance (0.0-1.0); learnings below this are excluded.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>
+    /// The ranked learnings (possibly empty). Implementations return an empty list rather than throwing
+    /// when the learnings subsystem is disabled or recall fails — recall is an enhancement, not a hard
+    /// dependency of a turn.
+    /// </returns>
+    Task<IReadOnlyList<WeightedLearning>> RecallAsync(
+        string context,
+        int maxResults,
+        double minRelevance,
+        CancellationToken ct);
+}

--- a/src/Content/Application/Application.AI.Common/Services/Agent/LearningsRecallContextProvider.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Agent/LearningsRecallContextProvider.cs
@@ -1,0 +1,124 @@
+using Application.AI.Common.Interfaces;
+using Application.AI.Common.Interfaces.Learnings;
+using Domain.AI.Learnings;
+using Domain.Common.Config;
+using Microsoft.Agents.AI;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Application.AI.Common.Services.Agent;
+
+/// <summary>
+/// An <see cref="AIContextProvider"/> that recalls the learnings most relevant to the current task and
+/// injects them into the agent's instructions before the model is invoked — "this task resembles past
+/// work; here is what worked." This closes the self-improving loop: the lessons written by the
+/// work-memory synthesis pass (and every other learning source) are surfaced back at turn start.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Agents are cached as singletons, so this provider is long-lived and shared across requests and
+/// tenants. It therefore <strong>must not capture</strong> the scoped <see cref="ILearningRecaller"/>;
+/// instead it resolves it per invocation from the current request scope exposed by
+/// <see cref="IAmbientRequestScope"/>. When no request scope is established, recall is skipped.
+/// </para>
+/// <para>
+/// Mirrors <see cref="KnowledgeMemoryContextProvider"/> (the cross-session fact-recall provider).
+/// Recall failures are swallowed: recalled lessons are an enhancement, never a hard dependency of a turn.
+/// </para>
+/// </remarks>
+public sealed class LearningsRecallContextProvider : AIContextProvider
+{
+    private readonly IAmbientRequestScope _ambientScope;
+    private readonly IOptionsMonitor<AppConfig> _appConfig;
+    private readonly ILogger<LearningsRecallContextProvider> _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="LearningsRecallContextProvider"/> class.
+    /// </summary>
+    /// <param name="ambientScope">Bridge to the current request's service scope.</param>
+    /// <param name="appConfig">Application configuration; recall is gated live on
+    /// <c>AI.LearningsRecall.Enabled</c> so a hot config change takes effect without evicting cached agents.</param>
+    /// <param name="logger">Logger for recall diagnostics.</param>
+    public LearningsRecallContextProvider(
+        IAmbientRequestScope ambientScope,
+        IOptionsMonitor<AppConfig> appConfig,
+        ILogger<LearningsRecallContextProvider> logger)
+        : base(
+            provideInputMessageFilter: messages => messages,
+            storeInputRequestMessageFilter: messages => messages,
+            storeInputResponseMessageFilter: messages => messages)
+    {
+        _ambientScope = ambientScope;
+        _appConfig = appConfig;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    protected override ValueTask<AIContext> ProvideAIContextAsync(
+        InvokingContext context,
+        CancellationToken cancellationToken = default)
+        => RecallAndInjectAsync(context.AIContext, cancellationToken);
+
+    /// <summary>
+    /// Core recall logic, decoupled from <see cref="InvokingContext"/> for testability. Resolves the
+    /// scoped recaller from the current request scope, recalls learnings relevant to the latest user
+    /// message, and returns an <see cref="AIContext"/> with those lessons appended to the instructions.
+    /// Returns <paramref name="inputContext"/> unchanged when recall is disabled, unavailable, or empty.
+    /// </summary>
+    public async ValueTask<AIContext> RecallAndInjectAsync(
+        AIContext inputContext,
+        CancellationToken cancellationToken = default)
+    {
+        var config = _appConfig.CurrentValue.AI.LearningsRecall;
+        if (!config.Enabled)
+            return inputContext;
+
+        var query = ExtractQuery(inputContext);
+        if (string.IsNullOrWhiteSpace(query))
+            return inputContext;
+
+        IReadOnlyList<WeightedLearning> recalled;
+        try
+        {
+            // Resolve the recaller from the CURRENT request scope — never captured (see remarks).
+            // Resolution is inside the try so a disposed/absent scope degrades to "no recall" rather
+            // than crashing the turn (recall is an enhancement, never a hard dependency).
+            var recaller = _ambientScope.Current?.GetService<ILearningRecaller>();
+            if (recaller is null)
+                return inputContext;
+
+            recalled = await recaller.RecallAsync(query, config.MaxResults, config.MinRelevance, cancellationToken);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogWarning(ex, "Learning recall failed; proceeding without recalled lessons");
+            return inputContext;
+        }
+
+        if (recalled.Count == 0)
+            return inputContext;
+
+        var block = FormatRecalledLessons(recalled);
+        var instructions = string.IsNullOrWhiteSpace(inputContext.Instructions)
+            ? block
+            : inputContext.Instructions + "\n\n" + block;
+
+        _logger.LogDebug("Injected {Count} recalled lesson(s) into agent context", recalled.Count);
+
+        return new AIContext
+        {
+            Instructions = instructions,
+            Messages = inputContext.Messages,
+            Tools = inputContext.Tools
+        };
+    }
+
+    private static string? ExtractQuery(AIContext aiContext)
+        => aiContext.Messages?.LastOrDefault(m => m.Role == ChatRole.User)?.Text;
+
+    private static string FormatRecalledLessons(IReadOnlyList<WeightedLearning> lessons)
+        => "## Lessons from past work\n" +
+            string.Join("\n", lessons.Select(l => $"- {l.Learning.Content}"));
+}

--- a/src/Content/Application/Application.Core/DependencyInjection.cs
+++ b/src/Content/Application/Application.Core/DependencyInjection.cs
@@ -1,7 +1,9 @@
 using Application.AI.Common.Interfaces.Escalation;
 using Application.AI.Common.Interfaces.Governance;
+using Application.AI.Common.Interfaces.Learnings;
 using Application.AI.Common.Interfaces.Permissions;
 using Application.Core.Escalation.Strategies;
+using Application.Core.Learnings;
 using Application.Core.Permissions;
 using Application.Core.Workflows.Governance;
 using Application.Core.Workflows.KnowledgeGraph;
@@ -42,6 +44,11 @@ public static class DependencyInjection
 
 		// Auto-discover FluentValidation validators in this assembly
 		services.AddValidatorsFromAssembly(assembly);
+
+		// Learning recall seam — lets Application.AI.Common context providers recall learnings via the
+		// RecallQuery scoring pipeline without depending on MediatR. Scoped because it resolves the
+		// request-scoped IMediator.
+		services.AddScoped<ILearningRecaller, MediatorLearningRecaller>();
 
 		// Autonomy tier rule provider — generates baseline permission rules from agent tier
 		services.AddSingleton<IPermissionRuleProvider, AutonomyTierRuleProvider>();

--- a/src/Content/Application/Application.Core/Learnings/MediatorLearningRecaller.cs
+++ b/src/Content/Application/Application.Core/Learnings/MediatorLearningRecaller.cs
@@ -1,0 +1,64 @@
+using Application.AI.Common.Interfaces.Learnings;
+using Application.Core.CQRS.Learnings;
+using Domain.AI.Learnings;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace Application.Core.Learnings;
+
+/// <summary>
+/// <see cref="ILearningRecaller"/> implementation that dispatches the <see cref="RecallQuery"/> CQRS
+/// path via <see cref="IMediator"/>, so the recall scoring pipeline (relevance + feedback + freshness +
+/// diversity, in <c>RecallQueryHandler</c>) is reused rather than reimplemented. Lives in
+/// <c>Application.Core</c> because that is where MediatR and the query handler live; consumers depend
+/// only on the <see cref="ILearningRecaller"/> abstraction in <c>Application.AI.Common</c>.
+/// </summary>
+/// <remarks>
+/// Recall uses <see cref="LearningScope.IsGlobal"/> scope: it surfaces broadly-applicable learnings
+/// (which is what belongs in every agent turn), including the global self-improvement lessons written
+/// by the work-memory synthesis pass. Agent-/team-scoped recall would require flowing agent identity
+/// to this seam and is a deliberate future extension.
+/// </remarks>
+public sealed class MediatorLearningRecaller : ILearningRecaller
+{
+    private static readonly LearningScope GlobalScope = new() { IsGlobal = true };
+
+    private readonly IMediator _mediator;
+    private readonly ILogger<MediatorLearningRecaller> _logger;
+
+    /// <summary>Initializes a new instance of the <see cref="MediatorLearningRecaller"/> class.</summary>
+    public MediatorLearningRecaller(IMediator mediator, ILogger<MediatorLearningRecaller> logger)
+    {
+        ArgumentNullException.ThrowIfNull(mediator);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _mediator = mediator;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<WeightedLearning>> RecallAsync(
+        string context,
+        int maxResults,
+        double minRelevance,
+        CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(context))
+            return [];
+
+        var query = new RecallQuery
+        {
+            Context = context,
+            Scope = GlobalScope,
+            MaxResults = maxResults,
+            MinRelevance = minRelevance
+        };
+
+        var result = await _mediator.Send(query, ct);
+        if (result.IsSuccess)
+            return result.Value;
+
+        _logger.LogWarning("Learning recall failed: {Errors}", string.Join(", ", result.Errors));
+        return [];
+    }
+}

--- a/src/Content/Application/Application.Core/Validation/LearningsRecallConfigValidator.cs
+++ b/src/Content/Application/Application.Core/Validation/LearningsRecallConfigValidator.cs
@@ -1,0 +1,22 @@
+using Domain.Common.Config.AI;
+using FluentValidation;
+
+namespace Application.Core.Validation;
+
+/// <summary>
+/// Validates <see cref="LearningsRecallConfig"/>: the per-turn result cap must be positive and the
+/// relevance floor must be a probability. Auto-discovered via <c>AddValidatorsFromAssembly</c>,
+/// consistent with the sibling config validators (<c>WorkMemoryConfigValidator</c> et al.).
+/// </summary>
+public sealed class LearningsRecallConfigValidator : AbstractValidator<LearningsRecallConfig>
+{
+    /// <summary>Initializes a new instance of the <see cref="LearningsRecallConfigValidator"/> class.</summary>
+    public LearningsRecallConfigValidator()
+    {
+        RuleFor(x => x.MaxResults)
+            .GreaterThan(0).WithMessage("MaxResults must be > 0.");
+
+        RuleFor(x => x.MinRelevance)
+            .InclusiveBetween(0d, 1d).WithMessage("MinRelevance must be in [0, 1].");
+    }
+}

--- a/src/Content/Domain/Domain.Common/Config/AI/AIConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/AIConfig.cs
@@ -175,6 +175,14 @@ public class AIConfig
     /// </summary>
     public WorkMemoryConfig WorkMemory { get; set; } = new();
 
+    /// <summary>
+    /// Configuration for recalling relevant learnings into the agent's context at turn start (the read
+    /// half of the self-improving loop). Off by default; when enabled, the most task-relevant
+    /// learnings — across every source, including the work-memory synthesis lessons — are injected
+    /// before the model runs.
+    /// </summary>
+    public LearningsRecallConfig LearningsRecall { get; set; } = new();
+
     /// <summary>Agent Governance Toolkit configuration.</summary>
     public GovernanceConfig Governance { get; init; } = new();
 

--- a/src/Content/Domain/Domain.Common/Config/AI/LearningsRecallConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/LearningsRecallConfig.cs
@@ -1,0 +1,41 @@
+namespace Domain.Common.Config.AI;
+
+/// <summary>
+/// Configuration for recalling relevant learnings into the agent's context at turn start (the read
+/// half of the self-improving loop). Bound from <c>AppConfig:AI:LearningsRecall</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// When enabled, <c>LearningsRecallContextProvider</c> recalls the learnings most relevant to the
+/// current task — across every source, including the global self-improvement lessons written by the
+/// work-memory synthesis pass — and injects them into the agent's instructions before the model runs.
+/// </para>
+/// <para>
+/// <strong>Off by default.</strong> Recall runs the relevance scoring pipeline (which embeds the query
+/// and candidate learnings) on every turn, so a consumer opts in deliberately. Keep
+/// <see cref="MaxResults"/> small and <see cref="MinRelevance"/> meaningful so only genuinely similar
+/// past work is surfaced rather than diluting the prompt with weakly-related lessons.
+/// </para>
+/// </remarks>
+public sealed class LearningsRecallConfig
+{
+    /// <summary>
+    /// Master toggle. When disabled (the default), no recall provider is wired and nothing is injected.
+    /// </summary>
+    /// <value>Default: false</value>
+    public bool Enabled { get; set; }
+
+    /// <summary>
+    /// Maximum number of learnings injected per turn. Kept small to bound prompt budget. Must be positive.
+    /// </summary>
+    /// <value>Default: 3</value>
+    public int MaxResults { get; set; } = 3;
+
+    /// <summary>
+    /// Minimum semantic relevance (0.0-1.0) a learning must have to the current task to be injected.
+    /// A meaningful floor keeps recall to "this task resembles past work" rather than loosely-related
+    /// lessons. Must be in the range [0, 1].
+    /// </summary>
+    /// <value>Default: 0.3</value>
+    public double MinRelevance { get; set; } = 0.3;
+}

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/Agent/LearningsRecallContextProviderTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/Agent/LearningsRecallContextProviderTests.cs
@@ -1,0 +1,201 @@
+using Application.AI.Common.Interfaces;
+using Application.AI.Common.Interfaces.Learnings;
+using Application.AI.Common.Services.Agent;
+using Domain.AI.Learnings;
+using Domain.Common.Config;
+using Domain.Common.Config.AI;
+using FluentAssertions;
+using Microsoft.Agents.AI;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Application.AI.Common.Tests.Services.Agent;
+
+public class LearningsRecallContextProviderTests
+{
+    private static AIContext ContextWithUserMessage(string text, string? instructions = null) => new()
+    {
+        Instructions = instructions,
+        Messages = new List<ChatMessage> { new(ChatRole.User, text) }
+    };
+
+    private static WeightedLearning Lesson(string content) => new()
+    {
+        Learning = new LearningEntry
+        {
+            LearningId = Guid.NewGuid(),
+            Category = LearningCategory.ToolUsagePattern,
+            DecayClass = DecayClass.Stable,
+            Scope = new LearningScope { IsGlobal = true },
+            Content = content,
+            Source = new LearningSource
+            {
+                SourceType = LearningSourceType.AgentSelfImprovement,
+                SourceId = "run-1",
+                SourceDescription = "synthesis"
+            },
+            Provenance = new LearningProvenance
+            {
+                OriginPipeline = "work_memory_synthesis",
+                OriginTask = "overnight_synthesis",
+                OriginTimestamp = DateTimeOffset.UtcNow,
+                Confidence = 0.9
+            },
+            CreatedAt = DateTimeOffset.UtcNow
+        },
+        RelevanceScore = 0.8,
+        FeedbackScore = 1.0,
+        FreshnessScore = 1.0,
+        FinalScore = 0.85
+    };
+
+    private static LearningsRecallContextProvider Build(
+        ILearningRecaller? recaller,
+        bool enabled = true,
+        bool withScope = true,
+        int maxResults = 3,
+        double minRelevance = 0.3)
+    {
+        IServiceProvider? scopeProvider = null;
+        if (withScope)
+        {
+            var services = new ServiceCollection();
+            if (recaller is not null)
+                services.AddSingleton(recaller);
+            scopeProvider = services.BuildServiceProvider();
+        }
+
+        var ambient = Mock.Of<IAmbientRequestScope>(a => a.Current == scopeProvider);
+        var appConfig = new AppConfig
+        {
+            AI = new AIConfig
+            {
+                LearningsRecall = new LearningsRecallConfig
+                {
+                    Enabled = enabled,
+                    MaxResults = maxResults,
+                    MinRelevance = minRelevance
+                }
+            }
+        };
+        var monitor = Mock.Of<IOptionsMonitor<AppConfig>>(m => m.CurrentValue == appConfig);
+        return new LearningsRecallContextProvider(
+            ambient, monitor, NullLogger<LearningsRecallContextProvider>.Instance);
+    }
+
+    [Fact]
+    public async Task RecallAndInject_WithRelevantLessons_AppendsThemToInstructions()
+    {
+        var recaller = new Mock<ILearningRecaller>();
+        recaller.Setup(r => r.RecallAsync("how do I deploy?", 3, 0.3, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { Lesson("Build from the worktree path, not main root."), Lesson("Verify tests before reporting done.") });
+        var sut = Build(recaller.Object);
+        var input = ContextWithUserMessage("how do I deploy?", instructions: "You are helpful.");
+
+        var result = await sut.RecallAndInjectAsync(input);
+
+        result.Should().NotBeSameAs(input);
+        result.Instructions.Should().Contain("You are helpful.");
+        result.Instructions.Should().Contain("Lessons from past work");
+        result.Instructions.Should().Contain("Build from the worktree path, not main root.");
+        result.Instructions.Should().Contain("Verify tests before reporting done.");
+        result.Messages.Should().BeSameAs(input.Messages);
+    }
+
+    [Fact]
+    public async Task RecallAndInject_PassesConfiguredMaxResultsAndMinRelevance()
+    {
+        var recaller = new Mock<ILearningRecaller>();
+        recaller.Setup(r => r.RecallAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<double>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<WeightedLearning>());
+        var sut = Build(recaller.Object, maxResults: 7, minRelevance: 0.55);
+
+        await sut.RecallAndInjectAsync(ContextWithUserMessage("task"));
+
+        recaller.Verify(r => r.RecallAsync("task", 7, 0.55, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task RecallAndInject_Disabled_ReturnsInputUnchanged()
+    {
+        var recaller = new Mock<ILearningRecaller>(MockBehavior.Strict);
+        var sut = Build(recaller.Object, enabled: false);
+        var input = ContextWithUserMessage("anything");
+
+        var result = await sut.RecallAndInjectAsync(input);
+
+        result.Should().BeSameAs(input);
+        recaller.Verify(r => r.RecallAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<double>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task RecallAndInject_NoAmbientScope_ReturnsInputUnchanged()
+    {
+        var sut = Build(recaller: null, withScope: false);
+        var input = ContextWithUserMessage("anything");
+
+        var result = await sut.RecallAndInjectAsync(input);
+
+        result.Should().BeSameAs(input);
+    }
+
+    [Fact]
+    public async Task RecallAndInject_NoUserMessage_ReturnsInputUnchanged()
+    {
+        var recaller = new Mock<ILearningRecaller>(MockBehavior.Strict);
+        var sut = Build(recaller.Object);
+        var input = new AIContext { Messages = new List<ChatMessage> { new(ChatRole.System, "system only") } };
+
+        var result = await sut.RecallAndInjectAsync(input);
+
+        result.Should().BeSameAs(input);
+        recaller.Verify(r => r.RecallAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<double>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task RecallAndInject_NoRelevantLessons_ReturnsInputUnchanged()
+    {
+        var recaller = new Mock<ILearningRecaller>();
+        recaller.Setup(r => r.RecallAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<double>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<WeightedLearning>());
+        var sut = Build(recaller.Object);
+        var input = ContextWithUserMessage("anything", instructions: "keep me");
+
+        var result = await sut.RecallAndInjectAsync(input);
+
+        result.Should().BeSameAs(input);
+    }
+
+    [Fact]
+    public async Task RecallAndInject_RecallerThrows_ReturnsInputUnchanged()
+    {
+        var recaller = new Mock<ILearningRecaller>();
+        recaller.Setup(r => r.RecallAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<double>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("recall down"));
+        var sut = Build(recaller.Object);
+        var input = ContextWithUserMessage("anything", instructions: "keep me");
+
+        var result = await sut.RecallAndInjectAsync(input);
+
+        result.Should().BeSameAs(input);
+    }
+
+    [Fact]
+    public async Task RecallAndInject_NoExistingInstructions_UsesLessonsBlockAlone()
+    {
+        var recaller = new Mock<ILearningRecaller>();
+        recaller.Setup(r => r.RecallAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<double>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { Lesson("Prefer the worktree build.") });
+        var sut = Build(recaller.Object);
+        var input = ContextWithUserMessage("how?"); // no instructions
+
+        var result = await sut.RecallAndInjectAsync(input);
+
+        result.Instructions.Should().StartWith("## Lessons from past work");
+        result.Instructions.Should().Contain("Prefer the worktree build.");
+    }
+}

--- a/src/Content/Tests/Application.Core.Tests/Learnings/MediatorLearningRecallerTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/Learnings/MediatorLearningRecallerTests.cs
@@ -1,0 +1,105 @@
+using Application.Core.CQRS.Learnings;
+using Application.Core.Learnings;
+using Domain.AI.Learnings;
+using Domain.Common;
+using FluentAssertions;
+using MediatR;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Application.Core.Tests.Learnings;
+
+public sealed class MediatorLearningRecallerTests
+{
+    private readonly Mock<IMediator> _mediator = new();
+    private readonly MediatorLearningRecaller _sut;
+
+    public MediatorLearningRecallerTests()
+        => _sut = new MediatorLearningRecaller(_mediator.Object, NullLogger<MediatorLearningRecaller>.Instance);
+
+    [Fact]
+    public async Task RecallAsync_DispatchesRecallQuery_WithGlobalScopeAndParams()
+    {
+        RecallQuery? captured = null;
+        _mediator
+            .Setup(m => m.Send(It.IsAny<RecallQuery>(), It.IsAny<CancellationToken>()))
+            .Callback<IRequest<Result<IReadOnlyList<WeightedLearning>>>, CancellationToken>((q, _) => captured = (RecallQuery)q)
+            .ReturnsAsync(Result<IReadOnlyList<WeightedLearning>>.Success([]));
+
+        await _sut.RecallAsync("deploy the app", maxResults: 5, minRelevance: 0.4, CancellationToken.None);
+
+        captured.Should().NotBeNull();
+        captured!.Context.Should().Be("deploy the app");
+        captured.MaxResults.Should().Be(5);
+        captured.MinRelevance.Should().Be(0.4);
+        captured.Scope.IsGlobal.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task RecallAsync_Success_ReturnsLearnings()
+    {
+        var lessons = new[] { Weighted("lesson A"), Weighted("lesson B") };
+        _mediator
+            .Setup(m => m.Send(It.IsAny<RecallQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<IReadOnlyList<WeightedLearning>>.Success(lessons));
+
+        var result = await _sut.RecallAsync("ctx", 3, 0.3, CancellationToken.None);
+
+        result.Should().HaveCount(2);
+        result[0].Learning.Content.Should().Be("lesson A");
+    }
+
+    [Fact]
+    public async Task RecallAsync_Failure_ReturnsEmpty()
+    {
+        _mediator
+            .Setup(m => m.Send(It.IsAny<RecallQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<IReadOnlyList<WeightedLearning>>.Fail("recall offline"));
+
+        var result = await _sut.RecallAsync("ctx", 3, 0.3, CancellationToken.None);
+
+        result.Should().BeEmpty();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task RecallAsync_BlankContext_ReturnsEmptyWithoutDispatching(string context)
+    {
+        var result = await _sut.RecallAsync(context, 3, 0.3, CancellationToken.None);
+
+        result.Should().BeEmpty();
+        _mediator.Verify(m => m.Send(It.IsAny<RecallQuery>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    private static WeightedLearning Weighted(string content) => new()
+    {
+        Learning = new LearningEntry
+        {
+            LearningId = Guid.NewGuid(),
+            Category = LearningCategory.DomainKnowledge,
+            DecayClass = DecayClass.Stable,
+            Scope = new LearningScope { IsGlobal = true },
+            Content = content,
+            Source = new LearningSource
+            {
+                SourceType = LearningSourceType.AgentSelfImprovement,
+                SourceId = "run-1",
+                SourceDescription = "synthesis"
+            },
+            Provenance = new LearningProvenance
+            {
+                OriginPipeline = "p",
+                OriginTask = "t",
+                OriginTimestamp = DateTimeOffset.UtcNow,
+                Confidence = 0.9
+            },
+            CreatedAt = DateTimeOffset.UtcNow
+        },
+        RelevanceScore = 0.8,
+        FeedbackScore = 1.0,
+        FreshnessScore = 1.0,
+        FinalScore = 0.85
+    };
+}

--- a/src/Content/Tests/Application.Core.Tests/Validation/LearningsRecallConfigValidatorTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/Validation/LearningsRecallConfigValidatorTests.cs
@@ -1,0 +1,52 @@
+using Application.Core.Validation;
+using Domain.Common.Config.AI;
+using FluentAssertions;
+using Xunit;
+
+namespace Application.Core.Tests.Validation;
+
+public sealed class LearningsRecallConfigValidatorTests
+{
+    private readonly LearningsRecallConfigValidator _sut = new();
+
+    [Fact]
+    public void Validate_Defaults_Passes()
+    {
+        var result = _sut.Validate(new LearningsRecallConfig());
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void Validate_NonPositiveMaxResults_Fails(int max)
+    {
+        var result = _sut.Validate(new LearningsRecallConfig { MaxResults = max });
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(LearningsRecallConfig.MaxResults));
+    }
+
+    [Theory]
+    [InlineData(-0.1)]
+    [InlineData(1.1)]
+    public void Validate_MinRelevanceOutOfRange_Fails(double relevance)
+    {
+        var result = _sut.Validate(new LearningsRecallConfig { MinRelevance = relevance });
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(LearningsRecallConfig.MinRelevance));
+    }
+
+    [Theory]
+    [InlineData(0d)]
+    [InlineData(0.3)]
+    [InlineData(1d)]
+    public void Validate_MinRelevanceInRange_Passes(double relevance)
+    {
+        var result = _sut.Validate(new LearningsRecallConfig { MinRelevance = relevance });
+
+        result.IsValid.Should().BeTrue();
+    }
+}


### PR DESCRIPTION
## Summary
Final PR of the self-improving work-memory plan (`.claude/plans/self-improving-work-memory.md`), **closing the loop**. PR1 (#95) captured work episodes; PR2 (#97) synthesized them into lessons; PR3 recalls the most task-relevant lessons back into the agent's context at turn start — "this task resembles past work; here's what worked."

`LearningsRecallContextProvider` (an `AIContextProvider`, mirrors `KnowledgeMemoryContextProvider`) extracts the current user message, recalls the most relevant learnings, and appends them to the agent's instructions before the model runs.

**Off by default** behind `AppConfig:AI:LearningsRecall`.

## Recall scope (design decision)
Recalls **all** relevant learnings regardless of source — `AgentSelfImprovement` (PR2's synthesis) **plus** `HumanCorrection`, `DriftDetection`, `EscalationResolution`, `ManualEntry`. The Learnings store is a single ranked recall surface; filtering to one source would hide high-value human corrections. The synthesis lessons are global, so they participate automatically.

## Layering seam
The provider lives in `Application.AI.Common`, which must not depend on `Application.Core`/MediatR. So recall goes through a thin `ILearningRecaller` interface (Application.AI.Common) implemented by `MediatorLearningRecaller` (Application.Core), which dispatches the existing `RecallQuery` — reusing its relevance + feedback + freshness + diversity scoring rather than reimplementing it. This mirrors how the memory provider depends on `IKnowledgeMemory`, not a CQRS command.

## Key files
- `Application.AI.Common/Interfaces/Learnings/ILearningRecaller.cs` — seam
- `Application.Core/Learnings/MediatorLearningRecaller.cs` — `RecallQuery` impl (global scope), registered scoped
- `Application.AI.Common/Services/Agent/LearningsRecallContextProvider.cs` — the provider
- `LearningsRecallConfig` (Enabled/MaxResults/MinRelevance) + validator
- Wired in `AgentExecutionContextFactory` after the memory provider, before the governance wrapper

## Cost note
`RecallQuery` embeds the query + candidate learnings per call, so recall adds an embedding pass **per turn** when enabled. Mitigated by off-by-default, small `MaxResults` (3), and a `MinRelevance` floor (0.3). "Precompute/cache learning embeddings" is the scale optimization if turned on broadly — out of scope here (would touch `RecallQueryHandler`, used by all recall callers).

## Test plan
- `LearningsRecallContextProviderTests` (8): inject, passes MaxResults/MinRelevance, disabled, no ambient scope, no user message, no relevant lessons, recaller throws (swallowed), no-existing-instructions.
- `MediatorLearningRecallerTests` (5): dispatches RecallQuery with global scope + params, success returns lessons, failure → empty, blank context → empty without dispatch.
- `LearningsRecallConfigValidatorTests` (defaults + bounds).
- Build 0 errors; full Application.AI.Common (1285) + Application.Core (617) suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)