### PR TITLE
chore(deps): update 8 majors + patch SQLite CVE-2025-6965

### DIFF
--- a/src/Content/Infrastructure/Infrastructure.AI.Evaluation/Infrastructure.AI.Evaluation.csproj
+++ b/src/Content/Infrastructure/Infrastructure.AI.Evaluation/Infrastructure.AI.Evaluation.csproj
@@ -15,6 +15,10 @@
   <ItemGroup>
     <PackageReference Include="MediatR" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
+    <!-- Security pin: forces the transitively-pulled native SQLite up to a build carrying
+         SQLite >= 3.50.2, fixing CVE-2025-6965 (GHSA-2m69-gcr7-jv3q, High). Version is
+         centrally managed in Directory.Packages.props. -->
+    <PackageReference Include="SQLitePCLRaw.lib.e_sqlite3" />
     <PackageReference Include="Microsoft.Extensions.AI" />
     <PackageReference Include="Microsoft.Extensions.Logging" />
     <PackageReference Include="Microsoft.Extensions.Options" />

--- a/src/Content/Infrastructure/Infrastructure.AI.RAG/Infrastructure.AI.RAG.csproj
+++ b/src/Content/Infrastructure/Infrastructure.AI.RAG/Infrastructure.AI.RAG.csproj
@@ -14,6 +14,10 @@
   <ItemGroup>
     <PackageReference Include="Azure.Search.Documents" />
     <PackageReference Include="Microsoft.Data.Sqlite" />
+    <!-- Security pin: forces the transitively-pulled native SQLite up to a build carrying
+         SQLite >= 3.50.2, fixing CVE-2025-6965 (GHSA-2m69-gcr7-jv3q, High). Version is
+         centrally managed in Directory.Packages.props. -->
+    <PackageReference Include="SQLitePCLRaw.lib.e_sqlite3" />
     <PackageReference Include="Microsoft.Extensions.Http" />
     <PackageReference Include="Microsoft.Extensions.Logging" />
     <PackageReference Include="Microsoft.Extensions.Options" />

--- a/src/Content/Infrastructure/Infrastructure.AI/Infrastructure.AI.csproj
+++ b/src/Content/Infrastructure/Infrastructure.AI/Infrastructure.AI.csproj
@@ -21,6 +21,10 @@
     <PackageReference Include="Microsoft.Security.AntiSSRF" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" PrivateAssets="all" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
+    <!-- Security pin: forces the transitively-pulled native SQLite up to a build carrying
+         SQLite >= 3.50.2, fixing CVE-2025-6965 (GHSA-2m69-gcr7-jv3q, High). Version is
+         centrally managed in Directory.Packages.props. -->
+    <PackageReference Include="SQLitePCLRaw.lib.e_sqlite3" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" />
     <PackageReference Include="Microsoft.Extensions.Http" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />

--- a/src/Content/Tests/Application.AI.Common.Tests/CQRS/Evaluation/GetTopRegressedCasesQueryHandlerTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/CQRS/Evaluation/GetTopRegressedCasesQueryHandlerTests.cs
@@ -182,7 +182,7 @@ public sealed class GetTopRegressedCasesQueryValidatorTests
     [Fact]
     public void Same_run_ids_fails()
         => _sut.TestValidate(Valid() with { CurrentRunId = "x", BaselineRunId = "x" })
-            .ShouldHaveAnyValidationError();
+            .IsValid.Should().BeFalse();
 
     [Fact]
     public void Zero_Take_fails()

--- a/src/Content/Tests/Application.AI.Common.Tests/CQRS/SkillTraining/GateCandidateSkillCommandValidatorTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/CQRS/SkillTraining/GateCandidateSkillCommandValidatorTests.cs
@@ -74,7 +74,7 @@ public sealed class GateCandidateSkillCommandValidatorTests
     public void BestStep_Exceeds_GlobalStep_Fails()
     {
         var cmd = Valid() with { BestStep = 5, GlobalStep = 2 };
-        _sut.TestValidate(cmd).ShouldHaveAnyValidationError();
+        Assert.False(_sut.TestValidate(cmd).IsValid);
     }
 
     [Fact]

--- a/src/Content/Tests/Application.AI.Common.Tests/CQRS/SkillTraining/ReflectOnFailuresCommandValidatorTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/CQRS/SkillTraining/ReflectOnFailuresCommandValidatorTests.cs
@@ -56,8 +56,8 @@ public sealed class ReflectOnFailuresCommandValidatorTests
     public void Rollout_with_score_out_of_range_fails()
     {
         var bad = new RolloutResult { ItemId = "x", Hard = 1.5, Soft = 0.5 };
-        _sut.TestValidate(Valid() with { Rollouts = [bad] })
-            .ShouldHaveAnyValidationError();
+        var result = _sut.TestValidate(Valid() with { Rollouts = [bad] });
+        Assert.False(result.IsValid);
     }
 
     [Fact]
@@ -69,7 +69,7 @@ public sealed class ReflectOnFailuresCommandValidatorTests
             Rollouts = [Success("s1"), Success("s2")]
         };
 
-        _sut.TestValidate(cmd).ShouldHaveAnyValidationError();
+        Assert.False(_sut.TestValidate(cmd).IsValid);
     }
 
     [Fact]

--- a/src/Content/Tests/Infrastructure.AI.Tests/Infrastructure.AI.Tests.csproj
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Infrastructure.AI.Tests.csproj
@@ -16,6 +16,10 @@
     <PackageReference Include="coverlet.collector" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
+    <!-- Security pin: forces the transitively-pulled native SQLite up to a build carrying
+         SQLite >= 3.50.2, fixing CVE-2025-6965 (GHSA-2m69-gcr7-jv3q, High). Version is
+         centrally managed in Directory.Packages.props. -->
+    <PackageReference Include="SQLitePCLRaw.lib.e_sqlite3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" />
     <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />

--- a/src/Content/Tests/Infrastructure.Common.Tests/Infrastructure.Common.Tests.csproj
+++ b/src/Content/Tests/Infrastructure.Common.Tests/Infrastructure.Common.Tests.csproj
@@ -13,6 +13,10 @@
     <PackageReference Include="coverlet.collector" />
     <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Microsoft.Data.Sqlite" />
+    <!-- Security pin: forces the transitively-pulled native SQLite up to a build carrying
+         SQLite >= 3.50.2, fixing CVE-2025-6965 (GHSA-2m69-gcr7-jv3q, High). Version is
+         centrally managed in Directory.Packages.props. -->
+    <PackageReference Include="SQLitePCLRaw.lib.e_sqlite3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Moq" />
     <PackageReference Include="xunit" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -16,8 +16,8 @@
 
     <!-- Application layer -->
     <PackageVersion Include="Azure.Identity" Version="1.21.0" />
-    <PackageVersion Include="FluentValidation" Version="11.11.0" />
-    <PackageVersion Include="FluentValidation.DependencyInjectionExtensions" Version="11.11.0" />
+    <PackageVersion Include="FluentValidation" Version="12.1.1" />
+    <PackageVersion Include="FluentValidation.DependencyInjectionExtensions" Version="12.1.1" />
     <PackageVersion Include="MediatR" Version="12.4.1" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Hybrid" Version="10.1.0" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.5" />
@@ -38,14 +38,25 @@
     <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.5" />
 
     <!-- Infrastructure.AI.Governance -->
+    <!-- Held at 3.0.2: AgentGovernance 4.0.0 makes PolicyEngine.Evaluate reject non-DID
+         agent identifiers (requires did:mesh: / did:agentmesh: prefix), throwing on the
+         live tool-path governance gate. 4.0 adds only SQL/K8s policy facets + redaction
+         this harness does not use, so the breaking identity-model change buys nothing.
+         Revisit when the harness adopts AgentMesh DIDs. -->
     <PackageVersion Include="Microsoft.AgentGovernance" Version="3.0.2" />
 
     <!-- Infrastructure.AI.KnowledgeGraph -->
-    <PackageVersion Include="Neo4j.Driver" Version="5.28.0" />
+    <PackageVersion Include="Neo4j.Driver" Version="6.2.1" />
 
     <!-- Infrastructure.AI.RAG -->
-    <PackageVersion Include="Azure.Search.Documents" Version="11.7.0" />
+    <PackageVersion Include="Azure.Search.Documents" Version="12.0.0" />
     <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.5" />
+    <!-- Transitive security pin: Microsoft.Data.Sqlite / EF Core Sqlite pull the native
+         SQLitePCLRaw.lib.e_sqlite3 2.1.11, whose embedded SQLite (< 3.50.2) is vulnerable
+         to CVE-2025-6965 (GHSA-2m69-gcr7-jv3q, High). The lib package re-versions to match
+         SQLite, so 3.50.3 is the patched native build (consumed alongside the existing
+         2.1.x core/provider/bundle — the C API surface is unchanged). -->
+    <PackageVersion Include="SQLitePCLRaw.lib.e_sqlite3" Version="3.50.3" />
 
     <!-- Infrastructure.AI -->
     <PackageVersion Include="Docker.DotNet" Version="3.125.15" />
@@ -63,7 +74,7 @@
     <PackageVersion Include="Microsoft.Security.AntiSSRF" Version="1.0.0" />
 
     <!-- Infrastructure.AI.Evaluation -->
-    <PackageVersion Include="YamlDotNet" Version="16.3.0" />
+    <PackageVersion Include="YamlDotNet" Version="18.0.0" />
 
     <!-- Infrastructure.AI Prompt Registry (Sub-phase 5.3) -->
     <!-- 7.0+ patches multiple critical/high CVEs (GHSA-5wr9-m6jw-xx44 etc). -->
@@ -78,14 +89,14 @@
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.5" />
 
     <!-- Infrastructure.APIAccess -->
-    <PackageVersion Include="Asp.Versioning.Http" Version="8.1.1" />
-    <PackageVersion Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.1.1" />
+    <PackageVersion Include="Asp.Versioning.Http" Version="10.0.0" />
+    <PackageVersion Include="Asp.Versioning.Mvc.ApiExplorer" Version="10.0.0" />
     <PackageVersion Include="CorrelationId" Version="3.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.2.0" />
     <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerGen" Version="10.1.0" />
 
     <!-- Infrastructure.Observability -->
-    <PackageVersion Include="Npgsql" Version="9.0.3" />
+    <PackageVersion Include="Npgsql" Version="10.0.3" />
     <PackageVersion Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.4.0" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.11.2-beta.1" />
@@ -103,11 +114,11 @@
          17.0.14+ patches GHSA-w7r3-mgwf-4mqq. -->
     <PackageVersion Include="KubernetesClient" Version="19.0.2" />
     <PackageVersion Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.4.0" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="9.0.4" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.AzureAppConfiguration" Version="8.1.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.5" />
     <PackageVersion Include="Microsoft.AspNetCore.SpaProxy" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Identity.Web" Version="3.8.4" />
+    <PackageVersion Include="Microsoft.Identity.Web" Version="4.11.0" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />


### PR DESCRIPTION
## Summary
Applies the safe subset of the dependency-update report. **Build clean, 7354 tests pass, `dotnet list package --vulnerable` clean.** No application-code changes — only central package versions, a transitive security pin, and 4 test-helper call sites.

## Updated (8 majors, zero app-code change)
| Package | From | To | Notes |
|---|---|---|---|
| Asp.Versioning.Http / Mvc.ApiExplorer | 8.1.1 | 10.0.0 | aligns with the net10 LTS line |
| Azure.Search.Documents | 11.7.0 | 12.0.0 | nothing used by the RAG layer changed |
| FluentValidation (+DI ext) | 11.11.0 | 12.1.1 | ~90 rules untouched; 8 test-helper sites updated |
| Microsoft.Identity.Web | 3.8.4 | 4.11.0 | auth/JWT tests green |
| Neo4j.Driver | 5.28.0 | 6.2.1 | connection-pool leak fix |
| Npgsql | 9.0.3 | 10.0.3 | see dashboard note below |
| YamlDotNet | 16.3.0 | 18.0.0 | |
| Microsoft.Extensions.Caching.StackExchangeRedis | 9.0.4 | 10.0.9 | net10 alignment |

## Security fix (not in the original 10)
`dotnet list package --vulnerable` surfaced a **High** transitive vuln: **`SQLitePCLRaw.lib.e_sqlite3` 2.1.11** → **CVE-2025-6965** (GHSA-2m69-gcr7-jv3q), SQLite < 3.50.2 memory corruption, pulled in via Microsoft.Data.Sqlite / EF Core Sqlite across ~10 projects.

- Pinned the native lib to **3.50.3** (the package re-versions to match SQLite; it's the maintainer's intended drop-in native update, consumed alongside the existing 2.1.x core/provider).
- Added an explicit `PackageReference` to the 5 projects that directly reference SQLite; the patched native asset flows transitively to all dependents. Vuln scan is now clean end-to-end.

## Held back — breaking majors with no benefit to this template
- **MediatR 12.4.1** (not → 14.1.0): v13+ replaced the Apache license with a **paid commercial license**. Updating would force a license key on the template and every enterprise consumer who clones it, for no technical gain. Staying on the last Apache-licensed line (owner decision).
- **Microsoft.AgentGovernance 3.0.2** (not → 4.0.0): 4.0.0 makes `PolicyEngine.Evaluate` **reject non-DID agent ids** (requires `did:mesh:`/`did:agentmesh:`), which **throws on the live tool-path governance gate** (`ToolInvocationGovernor` → `EvaluateToolCall`). Caught by 3 failing governance tests — the report's "build-verified" badge missed this. 4.0 adds only SQL/K8s policy facets + redaction this harness doesn't use, so the breaking identity-model change buys nothing. Revisit if/when the harness adopts AgentMesh DIDs.

## Operational follow-up (no code change)
- **Npgsql 10** renamed its OpenTelemetry metric names / span tags to match the OTel DB semantic conventions. Any existing Grafana dashboard built on v9 Npgsql metric names needs reconfiguring. Tests pass; this is a dashboards check on the observability module.

## Test plan
- `dotnet build src/AgenticHarness.slnx` → 0 errors, no new warnings (the 2 CS0618 are pre-existing Azure.Identity, untouched).
- `dotnet test src/AgenticHarness.slnx` → **7354 passed, 0 failed**.
- `dotnet list package --vulnerable --include-transitive` → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)