### PR TITLE
chore(eval): cap YAML deserializer recursion depth

### DIFF
--- a/src/Content/Infrastructure/Infrastructure.AI.Evaluation/Loaders/YamlEvalDatasetLoader.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.Evaluation/Loaders/YamlEvalDatasetLoader.cs
@@ -25,6 +25,11 @@ public sealed class YamlEvalDatasetLoader : IEvalDatasetLoader
     private static readonly IDeserializer Deserializer = new DeserializerBuilder()
         .WithNamingConvention(UnderscoredNamingConvention.Instance)
         .IgnoreUnmatchedProperties()
+        // Depth cap (defense-in-depth): the dataset schema is shallow
+        // (dataset -> cases -> metrics), so 64 is far above any legitimate document.
+        // Bounds stack growth from maliciously deep YAML, complementing the
+        // no-arbitrary-type-construction stance above. Requires YamlDotNet >= 17.
+        .WithMaximumRecursion(64)
         .Build();
 
     /// <inheritdoc />


### PR DESCRIPTION
## Summary
Adds `WithMaximumRecursion(64)` to the `YamlEvalDatasetLoader` deserializer — a defense-in-depth hardening unlocked by the YamlDotNet 16→18 bump (the API exists since v17).

## Why
The loader's XML docs already state its security posture ("does not allow arbitrary type construction, mitigating deserialization attacks via crafted YAML tags"). A recursion-depth bound is the natural complement: it caps stack growth from maliciously deep YAML. Eval datasets may be authored outside the trust boundary, so bounding parse depth fits the existing threat model.

## Honest scope
This is **preventative**, not a fix for a live exploit path. The current schema is shallow (`dataset → cases → metrics`) and uses `IgnoreUnmatchedProperties`, so object-graph recursion is already bounded today. The cap guards against:
- future recursive/nested schema changes, and
- any deep internal parser recursion.

`64` is far above the documented schema depth, so no legitimate dataset is affected. A test that reliably trips depth-64 isn't constructible against the fixed shallow shape, so none was added; the change is config-only and the 205 existing Evaluation tests confirm no regression.

## Test plan
- `dotnet build Infrastructure.AI.Evaluation` → clean.
- `dotnet test Infrastructure.AI.Evaluation.Tests` → **205 passed, 0 failed**.
- GitNexus impact on `YamlEvalDatasetLoader`: LOW, 0 impacted symbols.

🤖 Generated with [Claude Code](https://claude.com/claude-code)