### PR TITLE
feat(observability): wire Npgsql DB telemetry into OTel pipeline

### DIFF
--- a/src/Content/Infrastructure/Infrastructure.Observability/Exporters/ObservabilityTelemetryConfigurator.cs
+++ b/src/Content/Infrastructure/Infrastructure.Observability/Exporters/ObservabilityTelemetryConfigurator.cs
@@ -4,6 +4,7 @@ using Azure.Monitor.OpenTelemetry.Exporter;
 using Infrastructure.Observability.Processors;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Npgsql;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Trace;
 
@@ -64,6 +65,13 @@ public sealed class ObservabilityTelemetryConfigurator : ITelemetryConfigurator
     public void ConfigureTracing(TracerProviderBuilder builder)
     {
         var config = _appConfig.CurrentValue.Observability;
+
+        // Database-client instrumentation: surface Npgsql's own spans (command + connection
+        // activity) into the pipeline so DB time nests under the calling agent/HTTP span.
+        // No-op unless a Postgres-backed store is in use (e.g. PostgresObservabilityStore);
+        // Npgsql 10 emits OpenTelemetry-semconv span tags.
+        builder.AddNpgsql();
+        _logger.LogInformation("Npgsql tracing instrumentation registered");
 
         // Snapshot config for processors (they use IOptions, not IOptionsMonitor)
         var optionsSnapshot = Options.Create(_appConfig.CurrentValue);
@@ -139,6 +147,12 @@ public sealed class ObservabilityTelemetryConfigurator : ITelemetryConfigurator
     public void ConfigureMetrics(MeterProviderBuilder builder)
     {
         var config = _appConfig.CurrentValue.Observability;
+
+        // Database-client metrics: connection-pool occupancy/leaks, command duration,
+        // bytes read/written. Meter name "Npgsql"; Npgsql 10 renamed these counters to the
+        // OpenTelemetry db.client.* semantic conventions. No-op without a Postgres store.
+        builder.AddMeter("Npgsql");
+        _logger.LogInformation("Npgsql metrics instrumentation registered");
 
         // OTLP exporter is registered in OpenTelemetryServiceCollectionExtensions (pre-build phase)
 

--- a/src/Content/Infrastructure/Infrastructure.Observability/Infrastructure.Observability.csproj
+++ b/src/Content/Infrastructure/Infrastructure.Observability/Infrastructure.Observability.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Npgsql" />
+    <PackageReference Include="Npgsql.OpenTelemetry" />
     <PackageReference Include="OpenTelemetry" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
     <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -97,6 +97,7 @@
 
     <!-- Infrastructure.Observability -->
     <PackageVersion Include="Npgsql" Version="10.0.3" />
+    <PackageVersion Include="Npgsql.OpenTelemetry" Version="10.0.3" />
     <PackageVersion Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.4.0" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.11.2-beta.1" />


### PR DESCRIPTION
## Summary
Wires Npgsql's own OpenTelemetry instrumentation — DB command/connection **traces** and connection-pool/duration/throughput **metrics** — into the harness telemetry pipeline. Unlocked by the Npgsql 9→10 bump: v10 renamed its counters and span tags to the OpenTelemetry `db.client.*` semantic conventions, so the harness now emits standards-conforming DB telemetry.

## Why
Before this, **no Npgsql instrumentation was wired at all** (no `Npgsql.OpenTelemetry`, no `AddMeter("Npgsql")`). For an observability-focused template whose own audit store is Postgres (`PostgresObservabilityStore`), surfacing DB spans (nested under the calling agent/HTTP span) and pool/leak metrics is squarely on-mission. The earlier "v10 renames break dashboards" note was moot — there were no Npgsql dashboards because nothing was instrumented.

## What changed (16 lines, 3 files)
- **`Npgsql.OpenTelemetry` 10.0.3** added to CPM, referenced only by `Infrastructure.Observability` (the layer that owns Postgres).
- **Tracing:** `builder.AddNpgsql()` in `ObservabilityTelemetryConfigurator.ConfigureTracing`.
- **Metrics:** `builder.AddMeter("Npgsql")` in `ConfigureMetrics` (counters: `db.client.operation.duration`, `db.client.connection.count`, etc.).
- Wired through the existing `ITelemetryConfigurator` seam, **not** the generic Presentation OTel base pipeline — DB instrumentation lives with the layer that uses the DB (clean-architecture altitude).

## Design notes
- **No-op when no Postgres store is configured** — the source/meter simply emit nothing. Registered unconditionally, mirroring how ASP.NET/HTTP/Runtime instrumentation is always-on.
- API verified against the official Npgsql docs (tracing: `Npgsql.OpenTelemetry` + `AddNpgsql()`; metrics: meter name `"Npgsql"`, renamed to OTel semconv in v10).

## Test plan
- `dotnet build src/AgenticHarness.slnx` → clean.
- `dotnet test src/AgenticHarness.slnx` → **7354 passed, 0 failed** (telemetry pipeline is built at host start by the integration tests).
- GitNexus impact on `ObservabilityTelemetryConfigurator`: LOW (only the DI registration imports it).
- **Not asserted:** runtime span/metric emission needs a live Postgres, which is outside the test harness. A Grafana dashboard for the new `db.client.*` metrics is a sensible follow-up (none exists yet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)