### PR TITLE
feat(rag): opt-in Azure AI Search agentic-retrieval backend [DRAFT]

### DIFF
--- a/src/Content/Domain/Domain.Common/Config/AI/RAG/AgenticRetrievalConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/RAG/AgenticRetrievalConfig.cs
@@ -1,0 +1,57 @@
+namespace Domain.Common.Config.AI.RAG;
+
+/// <summary>
+/// Configuration for the optional Azure AI Search <em>agentic retrieval</em> backend, which
+/// delegates the entire query → ranked-results step to an Azure AI Search knowledge base
+/// (server-side query execution and semantic ranking) instead of the harness's local
+/// dense + sparse + RRF hybrid pipeline. Bound from <c>AppConfig:AI:Rag:AgenticRetrieval</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>Opt-in and off by default.</strong> When <see cref="Enabled"/> is <c>false</c> the
+/// harness uses its portable local hybrid retriever. When <c>true</c>, the
+/// <c>IHybridRetriever</c> resolves to the Azure knowledge-base implementation instead.
+/// </para>
+/// <para>
+/// This targets the <strong>stable</strong> <c>Azure.Search.Documents</c> GA surface
+/// (<c>KnowledgeBaseRetrievalClient</c>, API version 2026-04-01), which performs parallel
+/// extractive retrieval with semantic ranking. The LLM query-planning and answer-synthesis
+/// features of agentic retrieval are preview-only and intentionally NOT used here, so no
+/// preview dependency is introduced. The referenced knowledge base must already exist on the
+/// Azure AI Search service (provisioning is an Azure-side / infrastructure concern).
+/// </para>
+/// </remarks>
+public class AgenticRetrievalConfig
+{
+    /// <summary>
+    /// Gets or sets a value indicating whether the Azure AI Search agentic-retrieval backend
+    /// is active. When <c>true</c>, <c>IHybridRetriever</c> resolves to the knowledge-base
+    /// implementation; when <c>false</c> (default), the local hybrid retriever is used.
+    /// </summary>
+    public bool Enabled { get; set; }
+
+    /// <summary>
+    /// Gets or sets the Azure AI Search service endpoint URL
+    /// (e.g., <c>https://myservice.search.windows.net</c>).
+    /// </summary>
+    public string? Endpoint { get; set; }
+
+    /// <summary>
+    /// Gets or sets the name of the knowledge base to query. The knowledge base, its knowledge
+    /// sources, and the underlying index must already be provisioned on the service.
+    /// </summary>
+    public string KnowledgeBaseName { get; set; } = "agentic-kb";
+
+    /// <summary>
+    /// Gets or sets the API key (admin or query key) for the Azure AI Search service. Should be
+    /// stored in User Secrets (dev) or Azure Key Vault (prod), never in appsettings.
+    /// </summary>
+    public string? ApiKey { get; set; }
+
+    /// <summary>
+    /// Gets a value indicating whether the backend is both enabled and pointed at a
+    /// non-empty endpoint. Used to fail soft (return no results) rather than attempt a
+    /// doomed network call when enabled but mis-configured.
+    /// </summary>
+    public bool IsConfigured => Enabled && !string.IsNullOrWhiteSpace(Endpoint);
+}

--- a/src/Content/Domain/Domain.Common/Config/AI/RAG/RagConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/RAG/RagConfig.cs
@@ -53,6 +53,13 @@ public class RagConfig
     public VectorStoreConfig VectorStore { get; set; } = new();
 
     /// <summary>
+    /// Gets or sets the optional Azure AI Search agentic-retrieval backend configuration.
+    /// Off by default; when enabled, <c>IHybridRetriever</c> resolves to the server-side
+    /// knowledge-base retriever instead of the local hybrid pipeline.
+    /// </summary>
+    public AgenticRetrievalConfig AgenticRetrieval { get; set; } = new();
+
+    /// <summary>
     /// Gets or sets the GraphRAG configuration for graph-based retrieval
     /// using community summaries and entity relationships.
     /// </summary>

--- a/src/Content/Domain/Domain.Common/Config/AI/RAG/RagConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/RAG/RagConfig.cs
@@ -13,6 +13,7 @@ namespace Domain.Common.Config.AI.RAG;
 /// ├── Ingestion          — Chunking strategy, token targets, RAPTOR summaries
 /// ├── Retrieval          — Top-K, RRF constant, hybrid search toggle
 /// ├── VectorStore        — Provider, endpoint, embedding model, dimensions
+/// ├── AgenticRetrieval   — Opt-in Azure AI Search knowledge-base backend (off by default)
 /// ├── GraphRag           — Graph provider, community level, entity extraction
 /// ├── Reranker           — Reranking strategy and model selection
 /// ├── Crag               — Corrective RAG thresholds and web fallback

--- a/src/Content/Infrastructure/Infrastructure.AI.RAG/DependencyInjection.Retrieval.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.RAG/DependencyInjection.Retrieval.cs
@@ -4,6 +4,7 @@ using Application.AI.Common.Interfaces.Routing;
 using Application.Common.Interfaces.Data;
 using Azure;
 using Azure.Search.Documents;
+using Azure.Search.Documents.KnowledgeBases;
 using Domain.Common.Config;
 using Infrastructure.AI.RAG.Evaluation;
 using Infrastructure.AI.RAG.Orchestration;
@@ -61,8 +62,24 @@ public static partial class DependencyInjection
             return sp.GetRequiredKeyedService<IBm25Store>(key);
         });
 
-        // Hybrid retriever
-        services.AddSingleton<IHybridRetriever, HybridRetriever>();
+        // Hybrid retriever — keyed so an optional server-side backend (Azure AI Search
+        // agentic retrieval) can replace the local dense+sparse+RRF path without changing
+        // any consumer. The local hybrid path is the default.
+        services.AddKeyedSingleton<IHybridRetriever, HybridRetriever>("hybrid");
+
+        services.AddKeyedSingleton<IHybridRetriever>("azure_knowledge_base", (sp, _) =>
+            new AzureKnowledgeBaseRetriever(
+                BuildKnowledgeBaseRetrievalClient(sp),
+                sp.GetRequiredService<IOptionsMonitor<AppConfig>>(),
+                sp.GetRequiredService<ILogger<AzureKnowledgeBaseRetriever>>()));
+
+        // Default hybrid retriever from config — opt-in agentic backend, else local hybrid.
+        services.AddSingleton<IHybridRetriever>(sp =>
+        {
+            var config = sp.GetRequiredService<IOptionsMonitor<AppConfig>>().CurrentValue;
+            var key = config.AI.Rag.AgenticRetrieval.Enabled ? "azure_knowledge_base" : "hybrid";
+            return sp.GetRequiredKeyedService<IHybridRetriever>(key);
+        });
 
         // Rerankers — keyed by strategy name
         services.AddKeyedSingleton<IReranker>("azure_semantic", (sp, _) =>
@@ -264,5 +281,26 @@ public static partial class DependencyInjection
             : new AzureKeyCredential("not-configured");
 
         return new SearchClient(endpoint, vsConfig.IndexName, credential);
+    }
+
+    /// <summary>
+    /// Builds a <see cref="KnowledgeBaseRetrievalClient"/> from the agentic-retrieval
+    /// configuration. Falls back to a placeholder endpoint when not configured so DI
+    /// resolution always succeeds; the retriever short-circuits to no results in that case
+    /// rather than calling the placeholder.
+    /// </summary>
+    private static KnowledgeBaseRetrievalClient BuildKnowledgeBaseRetrievalClient(IServiceProvider sp)
+    {
+        var config = sp.GetRequiredService<IOptionsMonitor<AppConfig>>().CurrentValue.AI.Rag.AgenticRetrieval;
+
+        var endpoint = config.IsConfigured
+            ? new Uri(config.Endpoint!)
+            : new Uri("https://not-configured.search.windows.net");
+
+        var credential = !string.IsNullOrWhiteSpace(config.ApiKey)
+            ? new AzureKeyCredential(config.ApiKey)
+            : new AzureKeyCredential("not-configured");
+
+        return new KnowledgeBaseRetrievalClient(endpoint, config.KnowledgeBaseName, credential);
     }
 }

--- a/src/Content/Infrastructure/Infrastructure.AI.RAG/Retrieval/AzureKnowledgeBaseRetriever.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.RAG/Retrieval/AzureKnowledgeBaseRetriever.cs
@@ -1,0 +1,236 @@
+using System.Text.Json;
+using Application.AI.Common.Interfaces.RAG;
+using Azure;
+using Azure.Search.Documents.KnowledgeBases;
+using Azure.Search.Documents.KnowledgeBases.Models;
+using Domain.AI.RAG.Models;
+using Domain.Common.Config;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Infrastructure.AI.RAG.Retrieval;
+
+/// <summary>
+/// An <see cref="IHybridRetriever"/> backed by Azure AI Search <em>agentic retrieval</em>: it
+/// delegates the whole query → ranked-results step to a server-side knowledge base
+/// (<see cref="KnowledgeBaseRetrievalClient"/>) rather than running the local dense + sparse +
+/// RRF pipeline. Opt-in, selected by <c>AppConfig:AI:Rag:AgenticRetrieval:Enabled</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Targets the <strong>stable</strong> <c>Azure.Search.Documents</c> GA surface (API version
+/// 2026-04-01), which performs parallel extractive retrieval with built-in semantic ranking.
+/// The preview-only LLM query-planning and answer-synthesis modes are intentionally not used,
+/// so the template takes on no preview dependency.
+/// </para>
+/// <para>
+/// <strong>Impedance note.</strong> The knowledge base returns a ranked grounding payload, not
+/// the harness's native <see cref="DocumentChunk"/> shape, so the mapping is necessarily
+/// best-effort: the service ranks results server-side (list order is the authority), so a
+/// positional proxy score is assigned; <see cref="DocumentChunk.Tokens"/> is estimated; and
+/// <see cref="ChunkMetadata.SourceUri"/>/<see cref="ChunkMetadata.CreatedAt"/> are synthesized
+/// because the payload carries neither the original document URI nor its ingestion time.
+/// </para>
+/// <para>
+/// Fails soft: a missing configuration or an Azure request failure
+/// (<see cref="RequestFailedException"/>) returns no results — mirroring the local hybrid
+/// retriever's graceful-degradation contract — rather than throwing into the RAG pipeline.
+/// The result-mapping step is exception-safe (it constructs no host-segment URIs and parses
+/// JSON defensively), so it never throws regardless of payload or configured name.
+/// </para>
+/// </remarks>
+public sealed class AzureKnowledgeBaseRetriever : IHybridRetriever
+{
+    private readonly KnowledgeBaseRetrievalClient _client;
+    private readonly IOptionsMonitor<AppConfig> _appConfig;
+    private readonly ILogger<AzureKnowledgeBaseRetriever> _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AzureKnowledgeBaseRetriever"/> class.
+    /// </summary>
+    /// <param name="client">The Azure AI Search knowledge-base retrieval client.</param>
+    /// <param name="appConfig">The application configuration monitor.</param>
+    /// <param name="logger">The logger.</param>
+    public AzureKnowledgeBaseRetriever(
+        KnowledgeBaseRetrievalClient client,
+        IOptionsMonitor<AppConfig> appConfig,
+        ILogger<AzureKnowledgeBaseRetriever> logger)
+    {
+        _client = client;
+        _appConfig = appConfig;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<RetrievalResult>> RetrieveAsync(
+        string query,
+        int topK,
+        string? collectionName = null,
+        CancellationToken cancellationToken = default)
+    {
+        var config = _appConfig.CurrentValue.AI.Rag.AgenticRetrieval;
+        if (!config.IsConfigured)
+        {
+            _logger.LogWarning(
+                "Agentic retrieval is enabled but not configured (missing endpoint); returning no results.");
+            return [];
+        }
+
+        if (string.IsNullOrWhiteSpace(query) || topK <= 0)
+            return [];
+
+        KnowledgeBaseRetrievalResponse response;
+        try
+        {
+            var request = new KnowledgeBaseRetrievalRequest();
+            request.Intents.Add(new KnowledgeRetrievalSemanticIntent(query));
+
+            var raw = await _client.RetrieveAsync(request, cancellationToken: cancellationToken)
+                .ConfigureAwait(false);
+            response = raw.Value;
+        }
+        catch (RequestFailedException ex)
+        {
+            _logger.LogWarning(ex,
+                "Azure knowledge base '{KnowledgeBase}' retrieval failed (status {Status}); returning no results.",
+                config.KnowledgeBaseName, ex.Status);
+            return [];
+        }
+
+        // Extractive mode returns a single grounding message whose text content is a JSON array
+        // of ranked chunks. Take the first non-empty text payload and map it.
+        var groundingText = response.Response
+            .SelectMany(message => message.Content)
+            .OfType<KnowledgeBaseMessageTextContent>()
+            .Select(content => content.Text)
+            .FirstOrDefault(text => !string.IsNullOrWhiteSpace(text));
+
+        if (groundingText is null)
+        {
+            _logger.LogDebug("Agentic retrieval returned no grounding content for the query.");
+            return [];
+        }
+
+        var results = ParseGroundingPayload(groundingText, config.KnowledgeBaseName, topK, DateTimeOffset.UtcNow);
+        _logger.LogDebug("Agentic retrieval returned {Count} result(s) for the query.", results.Count);
+        return results;
+    }
+
+    /// <summary>
+    /// Parses an Azure AI Search agentic-retrieval grounding payload (a JSON array of ranked
+    /// chunks) into <see cref="RetrievalResult"/>s. Defensive against schema variation: field
+    /// names are resolved with fallbacks, malformed or content-less entries are skipped, and a
+    /// non-array or unparseable payload yields an empty list. Exposed <c>internal</c> for direct
+    /// unit testing because this mapping — not the thin client round-trip — is where the risk is.
+    /// </summary>
+    /// <param name="payload">The JSON grounding payload from the knowledge base response.</param>
+    /// <param name="knowledgeBaseName">Knowledge base name, used to synthesize a stable source URI.</param>
+    /// <param name="topK">Maximum number of results to emit.</param>
+    /// <param name="retrievedAt">Timestamp stamped as the chunk's <see cref="ChunkMetadata.CreatedAt"/>.</param>
+    /// <returns>Results in the server-provided rank order, with positional proxy scores.</returns>
+    internal static IReadOnlyList<RetrievalResult> ParseGroundingPayload(
+        string payload,
+        string knowledgeBaseName,
+        int topK,
+        DateTimeOffset retrievedAt)
+    {
+        if (string.IsNullOrWhiteSpace(payload) || topK <= 0)
+            return [];
+
+        JsonDocument document;
+        try
+        {
+            document = JsonDocument.Parse(payload);
+        }
+        catch (JsonException)
+        {
+            return [];
+        }
+
+        using (document)
+        {
+            if (document.RootElement.ValueKind != JsonValueKind.Array)
+                return [];
+
+            var results = new List<RetrievalResult>();
+            var rank = 0;
+            foreach (var element in document.RootElement.EnumerateArray())
+            {
+                if (results.Count >= topK)
+                    break;
+                if (element.ValueKind != JsonValueKind.Object)
+                    continue;
+
+                var content = GetString(element, "content", "text", "chunk");
+                if (string.IsNullOrWhiteSpace(content))
+                    continue;
+
+                var refId = GetString(element, "ref_id", "id", "doc_key") ?? $"kb-{rank}";
+                var title = GetString(element, "title", "section_path", "sectionPath");
+
+                // The service ranks results server-side, so list order is the relevance order.
+                // The extractive payload carries no per-chunk numeric score, so encode rank as
+                // a positional proxy: first = 1.0, decaying as 1/(1+rank).
+                var score = 1.0 / (1 + rank);
+
+                results.Add(new RetrievalResult
+                {
+                    Chunk = BuildChunk(refId, title, content!, knowledgeBaseName, retrievedAt),
+                    DenseScore = score,
+                    SparseScore = 0.0,
+                    FusedScore = score
+                });
+                rank++;
+            }
+
+            return results;
+        }
+    }
+
+    private static DocumentChunk BuildChunk(
+        string refId,
+        string? title,
+        string content,
+        string knowledgeBaseName,
+        DateTimeOffset retrievedAt) =>
+        new()
+        {
+            Id = refId,
+            DocumentId = refId,
+            SectionPath = title ?? string.Empty,
+            Content = content,
+            // ~4 chars/token proxy — the knowledge base does not return an authoritative count.
+            Tokens = Math.Max(1, content.Length / 4),
+            Metadata = new ChunkMetadata
+            {
+                // Synthetic, stable identifier — the grounding payload carries no original
+                // document URI. Fixed host on the reserved .invalid TLD (never resolves); the
+                // knowledge base name and ref id go in the PATH, where Uri.EscapeDataString is
+                // valid (escaping them into the HOST would throw for spaces/non-ASCII/long names).
+                SourceUri = new Uri(
+                    $"https://azure-knowledge-base.invalid/{Uri.EscapeDataString(knowledgeBaseName)}/{Uri.EscapeDataString(refId)}"),
+                // Retrieval time — the knowledge base does not return original ingestion time.
+                CreatedAt = retrievedAt,
+                SiblingChunkIds = []
+            },
+            Embedding = null
+        };
+
+    private static string? GetString(JsonElement element, params string[] propertyNames)
+    {
+        foreach (var name in propertyNames)
+        {
+            if (!element.TryGetProperty(name, out var value))
+                continue;
+
+            return value.ValueKind switch
+            {
+                JsonValueKind.String => value.GetString(),
+                JsonValueKind.Number => value.ToString(),
+                _ => null
+            };
+        }
+
+        return null;
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI.RAG/Retrieval/AzureKnowledgeBaseRetriever.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.RAG/Retrieval/AzureKnowledgeBaseRetriever.cs
@@ -38,6 +38,12 @@ namespace Infrastructure.AI.RAG.Retrieval;
 /// The result-mapping step is exception-safe (it constructs no host-segment URIs and parses
 /// JSON defensively), so it never throws regardless of payload or configured name.
 /// </para>
+/// <para>
+/// <strong>Single knowledge base.</strong> This backend always queries the one knowledge base
+/// named in configuration. The <c>IHybridRetriever.RetrieveAsync</c> <c>collectionName</c>
+/// override is therefore not supported — a non-null value that differs from the configured name
+/// is logged and ignored rather than silently retargeting (or wrongly querying) another base.
+/// </para>
 /// </remarks>
 public sealed class AzureKnowledgeBaseRetriever : IHybridRetriever
 {
@@ -79,6 +85,13 @@ public sealed class AzureKnowledgeBaseRetriever : IHybridRetriever
         if (string.IsNullOrWhiteSpace(query) || topK <= 0)
             return [];
 
+        if (collectionName is not null && collectionName != config.KnowledgeBaseName)
+        {
+            _logger.LogWarning(
+                "Agentic retrieval ignores collectionName '{Requested}'; it always queries the configured knowledge base '{KnowledgeBase}'.",
+                collectionName, config.KnowledgeBaseName);
+        }
+
         KnowledgeBaseRetrievalResponse response;
         try
         {
@@ -97,14 +110,7 @@ public sealed class AzureKnowledgeBaseRetriever : IHybridRetriever
             return [];
         }
 
-        // Extractive mode returns a single grounding message whose text content is a JSON array
-        // of ranked chunks. Take the first non-empty text payload and map it.
-        var groundingText = response.Response
-            .SelectMany(message => message.Content)
-            .OfType<KnowledgeBaseMessageTextContent>()
-            .Select(content => content.Text)
-            .FirstOrDefault(text => !string.IsNullOrWhiteSpace(text));
-
+        var groundingText = ExtractGroundingText(response);
         if (groundingText is null)
         {
             _logger.LogDebug("Agentic retrieval returned no grounding content for the query.");
@@ -153,39 +159,66 @@ public sealed class AzureKnowledgeBaseRetriever : IHybridRetriever
                 return [];
 
             var results = new List<RetrievalResult>();
-            var rank = 0;
             foreach (var element in document.RootElement.EnumerateArray())
             {
                 if (results.Count >= topK)
                     break;
-                if (element.ValueKind != JsonValueKind.Object)
-                    continue;
 
-                var content = GetString(element, "content", "text", "chunk");
-                if (string.IsNullOrWhiteSpace(content))
-                    continue;
-
-                var refId = GetString(element, "ref_id", "id", "doc_key") ?? $"kb-{rank}";
-                var title = GetString(element, "title", "section_path", "sectionPath");
-
-                // The service ranks results server-side, so list order is the relevance order.
-                // The extractive payload carries no per-chunk numeric score, so encode rank as
-                // a positional proxy: first = 1.0, decaying as 1/(1+rank).
-                var score = 1.0 / (1 + rank);
-
-                results.Add(new RetrievalResult
-                {
-                    Chunk = BuildChunk(refId, title, content!, knowledgeBaseName, retrievedAt),
-                    DenseScore = score,
-                    SparseScore = 0.0,
-                    FusedScore = score
-                });
-                rank++;
+                // results.Count is the OUTPUT rank: skipped (content-less) entries don't consume
+                // a slot, so the top surviving chunk scores 1.0 rather than being demoted.
+                var mapped = TryMapElement(element, results.Count, knowledgeBaseName, retrievedAt);
+                if (mapped is not null)
+                    results.Add(mapped);
             }
 
             return results;
         }
     }
+
+    /// <summary>
+    /// Maps a single grounding-array element to a <see cref="RetrievalResult"/>, or returns
+    /// <see langword="null"/> when the element is not a content-bearing object (skipped).
+    /// </summary>
+    private static RetrievalResult? TryMapElement(
+        JsonElement element,
+        int rank,
+        string knowledgeBaseName,
+        DateTimeOffset retrievedAt)
+    {
+        if (element.ValueKind != JsonValueKind.Object)
+            return null;
+
+        var content = GetString(element, "content", "text", "chunk");
+        if (string.IsNullOrWhiteSpace(content))
+            return null;
+
+        var refId = GetString(element, "ref_id", "id", "doc_key") ?? $"kb-{rank}";
+        var title = GetString(element, "title", "section_path", "sectionPath");
+
+        // The service ranks results server-side, so list order is the relevance order. The
+        // extractive payload carries no per-chunk numeric score, so encode the output rank as a
+        // positional proxy: first = 1.0, decaying as 1/(1+rank).
+        var score = 1.0 / (1 + rank);
+
+        return new RetrievalResult
+        {
+            Chunk = BuildChunk(refId, title, content!, knowledgeBaseName, retrievedAt),
+            DenseScore = score,
+            SparseScore = 0.0,
+            FusedScore = score
+        };
+    }
+
+    /// <summary>
+    /// Returns the first non-empty text payload from the knowledge base response — in extractive
+    /// mode a single grounding message whose text content is the JSON array of ranked chunks.
+    /// </summary>
+    private static string? ExtractGroundingText(KnowledgeBaseRetrievalResponse response) =>
+        response.Response
+            .SelectMany(message => message.Content)
+            .OfType<KnowledgeBaseMessageTextContent>()
+            .Select(content => content.Text)
+            .FirstOrDefault(text => !string.IsNullOrWhiteSpace(text));
 
     private static DocumentChunk BuildChunk(
         string refId,

--- a/src/Content/Tests/Infrastructure.AI.RAG.Tests/Retrieval/AzureKnowledgeBaseRetrieverTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.RAG.Tests/Retrieval/AzureKnowledgeBaseRetrieverTests.cs
@@ -1,0 +1,151 @@
+using Azure;
+using Azure.Search.Documents.KnowledgeBases;
+using Domain.Common.Config;
+using FluentAssertions;
+using Infrastructure.AI.RAG.Retrieval;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Infrastructure.AI.RAG.Tests.Retrieval;
+
+/// <summary>
+/// Tests for <see cref="AzureKnowledgeBaseRetriever"/>. Coverage targets the grounding-payload
+/// parser (the real risk surface — mapping the knowledge base's JSON response to
+/// <c>RetrievalResult</c>) directly via the <c>internal</c> seam, plus the fail-soft path when
+/// the backend is enabled but not configured. The thin client round-trip is intentionally not
+/// mocked; the payload shape it produces is exercised by the parser tests.
+/// </summary>
+public sealed class AzureKnowledgeBaseRetrieverTests
+{
+    private static readonly DateTimeOffset RetrievedAt = new(2026, 6, 26, 12, 0, 0, TimeSpan.Zero);
+
+    [Fact]
+    public void ParseGroundingPayload_ValidArray_MapsContentTitleAndRankOrder()
+    {
+        const string payload = """
+        [
+          {"ref_id":"r1","title":"Intro","content":"first chunk"},
+          {"ref_id":"r2","title":"Body","content":"second chunk"}
+        ]
+        """;
+
+        var results = AzureKnowledgeBaseRetriever.ParseGroundingPayload(payload, "kb", topK: 10, RetrievedAt);
+
+        results.Should().HaveCount(2);
+        results[0].Chunk.Content.Should().Be("first chunk");
+        results[0].Chunk.Id.Should().Be("r1");
+        results[0].Chunk.SectionPath.Should().Be("Intro");
+        results[1].Chunk.Content.Should().Be("second chunk");
+
+        // Server rank order is authoritative; scores decay positionally (1/(1+rank)).
+        results[0].FusedScore.Should().Be(1.0);
+        results[0].DenseScore.Should().Be(1.0);
+        results[1].FusedScore.Should().Be(0.5);
+        results.Should().BeInDescendingOrder(r => r.FusedScore);
+    }
+
+    [Fact]
+    public void ParseGroundingPayload_RespectsTopK()
+    {
+        const string payload = """
+        [{"content":"a"},{"content":"b"},{"content":"c"}]
+        """;
+
+        var results = AzureKnowledgeBaseRetriever.ParseGroundingPayload(payload, "kb", topK: 2, RetrievedAt);
+
+        results.Should().HaveCount(2);
+        results.Select(r => r.Chunk.Content).Should().Equal("a", "b");
+    }
+
+    [Fact]
+    public void ParseGroundingPayload_SkipsEntriesWithoutContent_AndKeepsContiguousRank()
+    {
+        // First entry has no content and must be skipped without consuming a rank slot, so the
+        // surviving entry is ranked first (score 1.0) rather than demoted.
+        const string payload = """
+        [{"ref_id":"empty"},{"ref_id":"keep","content":"kept"}]
+        """;
+
+        var results = AzureKnowledgeBaseRetriever.ParseGroundingPayload(payload, "kb", topK: 10, RetrievedAt);
+
+        results.Should().ContainSingle();
+        results[0].Chunk.Content.Should().Be("kept");
+        results[0].FusedScore.Should().Be(1.0);
+    }
+
+    [Fact]
+    public void ParseGroundingPayload_MissingRefId_SynthesizesStableId()
+    {
+        const string payload = """
+        [{"content":"no id here"}]
+        """;
+
+        var results = AzureKnowledgeBaseRetriever.ParseGroundingPayload(payload, "kb", topK: 10, RetrievedAt);
+
+        results.Should().ContainSingle();
+        results[0].Chunk.Id.Should().Be("kb-0");
+        results[0].Chunk.SectionPath.Should().BeEmpty();
+        results[0].Chunk.Metadata.CreatedAt.Should().Be(RetrievedAt);
+    }
+
+    [Theory]
+    [InlineData("not valid json {")]
+    [InlineData("{\"content\":\"object-not-array\"}")]
+    [InlineData("\"a bare string\"")]
+    [InlineData("")]
+    public void ParseGroundingPayload_MalformedOrNonArray_ReturnsEmpty(string payload)
+    {
+        var results = AzureKnowledgeBaseRetriever.ParseGroundingPayload(payload, "kb", topK: 10, RetrievedAt);
+
+        results.Should().BeEmpty();
+    }
+
+    [Theory]
+    [InlineData("agentic-kb")]
+    [InlineData("my kb")]    // space — would break a host-segment URI
+    [InlineData("über-kb")]  // non-ASCII
+    [InlineData("a%b")]      // percent
+    [InlineData("")]         // empty
+    public void ParseGroundingPayload_ExoticKnowledgeBaseName_DoesNotThrowAndBuildsSourceUri(string knowledgeBaseName)
+    {
+        // Regression: the synthetic SourceUri must put the knowledge base name in the PATH,
+        // not the host — escaping an exotic name into the host segment throws UriFormatException
+        // and (since mapping runs outside the client try/catch) would break the fail-soft contract.
+        const string payload = """[{"ref_id":"r1","content":"c"}]""";
+
+        var act = () => AzureKnowledgeBaseRetriever.ParseGroundingPayload(payload, knowledgeBaseName, 10, RetrievedAt);
+
+        var results = act.Should().NotThrow().Which;
+        results.Should().ContainSingle();
+        results[0].Chunk.Metadata.SourceUri.Host.Should().Be("azure-knowledge-base.invalid");
+    }
+
+    [Fact]
+    public void ParseGroundingPayload_ZeroTopK_ReturnsEmpty()
+    {
+        const string payload = """[{"content":"a"}]""";
+
+        AzureKnowledgeBaseRetriever.ParseGroundingPayload(payload, "kb", topK: 0, RetrievedAt)
+            .Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task RetrieveAsync_EnabledButNotConfigured_ReturnsEmptyWithoutCallingService()
+    {
+        var config = new AppConfig();
+        config.AI.Rag.AgenticRetrieval.Enabled = true; // enabled but Endpoint left null -> not configured
+        var monitor = Mock.Of<IOptionsMonitor<AppConfig>>(m => m.CurrentValue == config);
+
+        // A real client that must never be called because IsConfigured short-circuits first.
+        var client = new KnowledgeBaseRetrievalClient(
+            new Uri("https://placeholder.search.windows.net"), "kb", new AzureKeyCredential("unused"));
+
+        var sut = new AzureKnowledgeBaseRetriever(client, monitor, NullLogger<AzureKnowledgeBaseRetriever>.Instance);
+
+        var results = await sut.RetrieveAsync("any query", topK: 5);
+
+        results.Should().BeEmpty();
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.RAG.Tests/Retrieval/AzureKnowledgeBaseRetrieverTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.RAG.Tests/Retrieval/AzureKnowledgeBaseRetrieverTests.cs
@@ -1,5 +1,6 @@
 using Azure;
 using Azure.Search.Documents.KnowledgeBases;
+using Azure.Search.Documents.KnowledgeBases.Models;
 using Domain.Common.Config;
 using FluentAssertions;
 using Infrastructure.AI.RAG.Retrieval;
@@ -129,6 +130,30 @@ public sealed class AzureKnowledgeBaseRetrieverTests
 
         AzureKnowledgeBaseRetriever.ParseGroundingPayload(payload, "kb", topK: 0, RetrievedAt)
             .Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task RetrieveAsync_BackendThrowsRequestFailed_FailsSoftToEmpty()
+    {
+        var config = new AppConfig();
+        config.AI.Rag.AgenticRetrieval.Enabled = true;
+        config.AI.Rag.AgenticRetrieval.Endpoint = "https://svc.search.windows.net";
+        var monitor = Mock.Of<IOptionsMonitor<AppConfig>>(m => m.CurrentValue == config);
+
+        // KnowledgeBaseRetrievalClient has a protected ctor + virtual RetrieveAsync, so it is
+        // mockable; simulate a backend outage and assert the fail-soft contract (no throw).
+        var client = new Mock<KnowledgeBaseRetrievalClient>();
+        client
+            .Setup(c => c.RetrieveAsync(
+                It.IsAny<KnowledgeBaseRetrievalRequest>(),
+                It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new RequestFailedException(503, "service unavailable"));
+
+        var sut = new AzureKnowledgeBaseRetriever(client.Object, monitor, NullLogger<AzureKnowledgeBaseRetriever>.Instance);
+
+        var results = await sut.RetrieveAsync("any query", topK: 5);
+
+        results.Should().BeEmpty();
     }
 
     [Fact]


### PR DESCRIPTION
> **Draft** — opened for your review per our discussion. Functional and fully tested, but adopting it for real needs (a) a provisioned Azure knowledge base and (b) a decision on the preview-vs-stable tradeoff below.

## Summary
Adds an **optional** `IHybridRetriever` backed by Azure AI Search **agentic retrieval** (server-side knowledge base) as an alternative to the local dense+sparse+RRF pipeline. **Off by default**; flip `AppConfig:AI:Rag:AgenticRetrieval:Enabled` to route retrieval through it. Mirrors the swappable-graph-backend philosophy: consumers can adopt it where Azure lock-in is acceptable, while the portable hybrid pipeline stays the default and the teaching centerpiece.

## The key decision baked into this draft: stable, not preview
Built against the **stable `Azure.Search.Documents` 12.0.0 GA** surface (`KnowledgeBaseRetrievalClient`, API 2026-04-01). **No preview dependency** — the package is already referenced, nothing new added.

The catch (worth your eyes): the **stable GA path is extractive-only** — it does parallel server-side retrieval + semantic ranking, but **no LLM query-planning or answer-synthesis**. Those marquee "agentic" features are **preview-only** (`12.1.0-beta.1`, no SLA, breaking changes each release). I deliberately did **not** pull that preview SDK into a template enterprises clone. Adopting the higher-value preview features is a **separate, explicit decision** — the seam here is built so that swap is localized to the request/response mapping.

## What's in it
- **`AgenticRetrievalConfig`** (`Enabled`/`Endpoint`/`KnowledgeBaseName`/`ApiKey` + `IsConfigured`), wired into `RagConfig`.
- **`AzureKnowledgeBaseRetriever : IHybridRetriever`** — sends the query as a `KnowledgeRetrievalSemanticIntent`, maps the ranked grounding payload to `RetrievalResult`.
- **DI**: `IHybridRetriever` is now keyed (`"hybrid"` default, `"azure_knowledge_base"` opt-in) with a config resolver — same pattern as `IVectorStore`/`IReranker`. **Default behavior is unchanged** (verified by full suite).

## Honest limitations (documented in code)
- **Best-effort mapping**: the KB returns a ranked grounding blob, not native `DocumentChunk`s. So scores are **positional proxies** (the service ranks server-side; the payload has no per-chunk score), `Tokens` is estimated, and `SourceUri`/`CreatedAt` are synthesized (the payload carries neither original document URI nor ingestion time).
- **Provisioning is Azure-side**: the knowledge base + sources + index must already exist.
- **Fails soft**: not-configured or `RequestFailedException` → no results (graceful degradation), never throws into the pipeline.

## Review / test
- Self-reviewed via `/code-review` (high effort): it caught a real bug — a `UriFormatException` when an exotic `KnowledgeBaseName` (space/non-ASCII/empty) was escaped into the URI **host** segment, thrown outside the fail-soft try/catch. **Fixed** (values moved to the URI path behind a fixed host) + a 5-case regression test added. DI-resolution change reviewed clean.
- The risky logic (`ParseGroundingPayload`) is `internal` and unit-tested directly: rank order, topK, malformed/non-array JSON, content-less skips, id synthesis, exotic names, plus the not-configured fail-soft path.
- **15 new tests green; full solution build clean; full suite 7367 green** before push (CI re-runs everything).

## Open questions for you
1. Ship the stable/extractive version as the opt-in backend, or hold until the preview agentic features (planning + synthesis) are worth taking the preview dependency?
2. If we keep it, do you want a follow-up that provisions the knowledge base from config (currently assumed pre-existing)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)