### PR TITLE
feat(dashboard): activate chat surface + tests (PR3)

### DIFF
--- a/src/Content/Presentation/Presentation.Dashboard/src/app/App.tsx
+++ b/src/Content/Presentation/Presentation.Dashboard/src/app/App.tsx
@@ -3,6 +3,7 @@ import { QueryClientProvider } from '@tanstack/react-query';
 import { RouterProvider } from 'react-router-dom';
 import { msalInstance } from '@/auth/authConfig';
 import { setMsalInstance } from '@/api/client';
+import { TooltipProvider } from '@/components/ui/tooltip';
 import { queryClient } from './queryClient';
 import { router } from './router';
 
@@ -12,7 +13,9 @@ export default function App() {
   return (
     <MsalProvider instance={msalInstance}>
       <QueryClientProvider client={queryClient}>
-        <RouterProvider router={router} />
+        <TooltipProvider>
+          <RouterProvider router={router} />
+        </TooltipProvider>
       </QueryClientProvider>
     </MsalProvider>
   );

--- a/src/Content/Presentation/Presentation.Dashboard/src/app/router.tsx
+++ b/src/Content/Presentation/Presentation.Dashboard/src/app/router.tsx
@@ -21,6 +21,16 @@ const GovernancePage = lazy(() => import('@/routes/Governance/GovernancePage'));
 const EvalsListPage = lazy(() => import('@/routes/Evals/EvalsListPage'));
 const EvalRunDetailPage = lazy(() => import('@/routes/Evals/EvalRunDetailPage'));
 
+// Agent-interaction surface (folded in from the former WebUI). Its own shell
+// mounts the SignalR conversation hub; the views use named exports, so each
+// lazy import maps the named member onto `default`.
+const ChatShell = lazy(() => import('@/components/layout/ChatShell'));
+const ChatView = lazy(() => import('@/views/ChatView').then((m) => ({ default: m.ChatView })));
+const AgentsView = lazy(() => import('@/views/AgentsView').then((m) => ({ default: m.AgentsView })));
+const ToolsView = lazy(() => import('@/views/ToolsView').then((m) => ({ default: m.ToolsView })));
+const ResourcesView = lazy(() => import('@/views/ResourcesView').then((m) => ({ default: m.ResourcesView })));
+const PromptsView = lazy(() => import('@/views/PromptsView').then((m) => ({ default: m.PromptsView })));
+
 // Dev-only sandbox. `import.meta.env.DEV` is statically replaced by Vite, so in
 // prod the ternary resolves to `null` at build time and the dynamic import() is
 // dropped from the bundle entirely — no DesignSystemPage chunk ships to users.
@@ -87,6 +97,22 @@ export const router = createBrowserRouter([
       { path: 'tools', element: <Navigate to="/quality/tools" replace /> },
       { path: 'safety', element: <Navigate to="/quality/safety" replace /> },
       { path: 'rag', element: <Navigate to="/quality/rag" replace /> },
+    ],
+  },
+
+  // Agent interaction (chat + MCP browsers) under its own shell, which mounts
+  // the SignalR conversation hub. Namespaced under /agent so 'tools' here does
+  // not collide with the legacy '/tools' → '/quality/tools' redirect above.
+  {
+    path: '/agent',
+    element: <LazyWrapper><ChatShell /></LazyWrapper>,
+    children: [
+      { index: true, element: <Navigate to="/agent/chat" replace /> },
+      { path: 'chat', element: <LazyWrapper><ChatView /></LazyWrapper> },
+      { path: 'agents', element: <LazyWrapper><AgentsView /></LazyWrapper> },
+      { path: 'tools', element: <LazyWrapper><ToolsView /></LazyWrapper> },
+      { path: 'resources', element: <LazyWrapper><ResourcesView /></LazyWrapper> },
+      { path: 'prompts', element: <LazyWrapper><PromptsView /></LazyWrapper> },
     ],
   },
 ]);

--- a/src/Content/Presentation/Presentation.Dashboard/src/components/layout/ChatShell.tsx
+++ b/src/Content/Presentation/Presentation.Dashboard/src/components/layout/ChatShell.tsx
@@ -1,0 +1,87 @@
+import { useEffect } from 'react';
+import { Outlet } from 'react-router-dom';
+import { Sidebar } from './Sidebar';
+import { ThemeToggle } from '@/components/theme/ThemeToggle';
+import { AgentHubProvider, useAgentHub, type ConnectionState } from '@/hooks/useAgentHub';
+import { useAgentsQuery } from '@/features/agents/useAgentsQuery';
+import { useAppStore } from '@/stores/appStore';
+import { cn } from '@/lib/utils';
+
+const CONNECTION_META: Record<ConnectionState, { label: string; dotClass: string }> = {
+  connected: { label: 'Connected', dotClass: 'bg-emerald-500' },
+  connecting: { label: 'Connecting', dotClass: 'bg-amber-500 animate-pulse' },
+  reconnecting: { label: 'Reconnecting', dotClass: 'bg-amber-500 animate-pulse' },
+  disconnected: { label: 'Disconnected', dotClass: 'bg-red-500' },
+};
+
+/** Live SignalR connection indicator for the chat surface. */
+function ConnectionBadge() {
+  const { connectionState } = useAgentHub();
+  const meta = CONNECTION_META[connectionState];
+  return (
+    <div className="flex items-center gap-1.5 px-2 py-1 rounded-md bg-muted/50 text-xs text-muted-foreground">
+      <span className={cn('size-1.5 rounded-full', meta.dotClass)} />
+      <span>{meta.label}</span>
+    </div>
+  );
+}
+
+/**
+ * Chat-surface top bar. Distinct from the observability {@link Topbar} (which
+ * carries the time-range picker, telemetry-LIVE pip, and refresh) because none
+ * of that applies to a conversation view.
+ */
+function ChatHeader() {
+  return (
+    <header className="flex items-center justify-between px-5 h-12 min-h-12 border-b border-border bg-background shrink-0">
+      <span className="text-sm font-semibold tracking-tight text-foreground">Agent Chat</span>
+      <div className="flex items-center gap-2">
+        <ConnectionBadge />
+        <ThemeToggle />
+      </div>
+    </header>
+  );
+}
+
+/**
+ * Default the active agent to the first available one when nothing is selected
+ * yet, so the chat opens ready-to-use instead of on the "pick an agent" empty
+ * state. Mirrors the bootstrap the standalone WebUI shell performed.
+ */
+function useDefaultAgentSelection(): void {
+  const selectedAgent = useAppStore((s) => s.selectedAgent);
+  const setSelectedAgent = useAppStore((s) => s.setSelectedAgent);
+  const agentsQuery = useAgentsQuery();
+
+  useEffect(() => {
+    const first = agentsQuery.data?.[0];
+    if (!selectedAgent && first) {
+      setSelectedAgent(first.id);
+    }
+  }, [selectedAgent, agentsQuery.data, setSelectedAgent]);
+}
+
+/**
+ * Layout for the agent-interaction routes (`/agent/*`). Shares the Dashboard
+ * {@link Sidebar} for navigation, but provides a chat-specific header and a
+ * full-bleed body (the chat/MCP views supply their own <main>). The SignalR
+ * conversation hub is mounted here — and only here — so observability-only
+ * pages never open an idle agent connection.
+ */
+export default function ChatShell() {
+  useDefaultAgentSelection();
+
+  return (
+    <div className="flex h-screen overflow-hidden">
+      <Sidebar />
+      <AgentHubProvider>
+        <div className="flex-1 flex flex-col overflow-hidden">
+          <ChatHeader />
+          <div className="flex flex-1 min-h-0 overflow-hidden">
+            <Outlet />
+          </div>
+        </div>
+      </AgentHubProvider>
+    </div>
+  );
+}

--- a/src/Content/Presentation/Presentation.Dashboard/src/components/layout/Sidebar.tsx
+++ b/src/Content/Presentation/Presentation.Dashboard/src/components/layout/Sidebar.tsx
@@ -2,6 +2,7 @@ import { NavLink, useLocation } from 'react-router-dom';
 import {
   Activity, Users, TrendingUp, Coins, DollarSign, Wallet,
   Wrench, ShieldCheck, Database, LayoutGrid, ChevronDown, Shield, FlaskConical,
+  MessageSquare, Bot, FolderOpen, FileText,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useState } from 'react';
@@ -20,6 +21,16 @@ interface NavItem {
 }
 
 const navGroups: NavGroup[] = [
+  {
+    label: 'Agent',
+    items: [
+      { to: '/agent/chat', label: 'Chat', icon: MessageSquare },
+      { to: '/agent/agents', label: 'Agents', icon: Bot },
+      { to: '/agent/tools', label: 'Tools', icon: Wrench },
+      { to: '/agent/resources', label: 'Resources', icon: FolderOpen },
+      { to: '/agent/prompts', label: 'Prompts', icon: FileText },
+    ],
+  },
   {
     label: 'Observe',
     items: [

--- a/src/Content/Presentation/Presentation.Dashboard/src/components/layout/__tests__/ChatShell.test.tsx
+++ b/src/Content/Presentation/Presentation.Dashboard/src/components/layout/__tests__/ChatShell.test.tsx
@@ -1,0 +1,40 @@
+import { waitFor } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import ChatShell from '../ChatShell';
+import { renderWithProviders } from '@/test/utils';
+import { useAppStore } from '@/stores/appStore';
+
+const mocks = vi.hoisted(() => ({
+  agentsData: [] as Array<{ id: string; name: string }>,
+}));
+
+// Passthrough provider + a stable connection state so ChatShell renders without
+// opening a real SignalR connection.
+vi.mock('@/hooks/useAgentHub', () => ({
+  useAgentHub: () => ({ connectionState: 'connected' }),
+  AgentHubProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@/features/agents/useAgentsQuery', () => ({
+  useAgentsQuery: () => ({ data: mocks.agentsData }),
+}));
+
+describe('ChatShell — default agent selection', () => {
+  beforeEach(() => {
+    useAppStore.setState({ selectedAgent: null, activeConversationId: null, showSidebar: true });
+    mocks.agentsData = [{ id: 'agent-1', name: 'First' }, { id: 'agent-2', name: 'Second' }];
+  });
+
+  it('defaults the active agent to the first available one when none is selected', async () => {
+    renderWithProviders(<ChatShell />);
+    await waitFor(() => expect(useAppStore.getState().selectedAgent).toBe('agent-1'));
+  });
+
+  it('does not override an already-selected agent', async () => {
+    useAppStore.setState({ selectedAgent: 'agent-2' });
+    renderWithProviders(<ChatShell />);
+    // Give the effect a chance to (wrongly) fire.
+    await new Promise((r) => setTimeout(r, 0));
+    expect(useAppStore.getState().selectedAgent).toBe('agent-2');
+  });
+});

--- a/src/Content/Presentation/Presentation.Dashboard/src/features/chat/__tests__/ChatInput.test.tsx
+++ b/src/Content/Presentation/Presentation.Dashboard/src/features/chat/__tests__/ChatInput.test.tsx
@@ -1,0 +1,130 @@
+import { screen, fireEvent, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { useChatStore } from '../useChatStore';
+import { ChatInput } from '../ChatInput';
+import { renderWithProviders } from '@/test/utils';
+
+vi.mock('@/features/mcp/useMcpQuery', () => ({
+  usePromptsQuery: () => ({
+    data: [
+      { name: 'summarize', description: 'Summarize text' },
+      { name: 'translate', description: 'Translate text' },
+    ],
+    isLoading: false,
+  }),
+  useToolsQuery: () => ({
+    data: [
+      { name: 'search', description: 'Web search' },
+      { name: 'calculator', description: 'Math' },
+    ],
+    isLoading: false,
+  }),
+}));
+
+const mockSendMessage = vi.fn().mockResolvedValue(undefined);
+
+function renderInput() {
+  return renderWithProviders(<ChatInput conversationId="test-conv" sendMessage={mockSendMessage} />);
+}
+
+function getSubmitButton(): HTMLButtonElement {
+  const btn = document.querySelector('button[type="submit"]');
+  if (!btn) throw new Error('Submit button not found');
+  return btn as HTMLButtonElement;
+}
+
+describe('ChatInput', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useChatStore.setState({ conversationId: null, messages: [], isStreaming: false, streamingContent: '' });
+  });
+
+  it('submit calls sendMessage with input value', async () => {
+    const user = userEvent.setup();
+    renderInput();
+    await user.type(screen.getByPlaceholderText(/message the agent/i), 'hello world');
+    await user.click(getSubmitButton());
+    expect(mockSendMessage).toHaveBeenCalledWith('test-conv', expect.any(String), 'hello world');
+  });
+
+  it('is disabled while isStreaming is true', () => {
+    useChatStore.setState({ isStreaming: true });
+    renderInput();
+    expect(screen.getByPlaceholderText(/message the agent/i)).toBeDisabled();
+    expect(getSubmitButton()).toBeDisabled();
+  });
+
+  it('clears after submit', async () => {
+    const user = userEvent.setup();
+    renderInput();
+    await user.type(screen.getByPlaceholderText(/message the agent/i), 'hello world');
+    await user.click(getSubmitButton());
+    expect(screen.getByPlaceholderText(/message the agent/i)).toHaveValue('');
+  });
+
+  it('rejects empty string (does not call sendMessage)', async () => {
+    const user = userEvent.setup();
+    renderInput();
+    await user.click(getSubmitButton());
+    expect(mockSendMessage).not.toHaveBeenCalled();
+  });
+
+  it('rejects messages over 40000 characters', async () => {
+    renderInput();
+    fireEvent.change(screen.getByPlaceholderText(/message the agent/i), {
+      target: { value: 'a'.repeat(40_001) },
+    });
+    fireEvent.click(getSubmitButton());
+    expect(await screen.findByText(/message too long/i)).toBeInTheDocument();
+    expect(mockSendMessage).not.toHaveBeenCalled();
+  });
+
+  it('shows prompt picker when user types @', async () => {
+    const user = userEvent.setup();
+    renderInput();
+    await user.type(screen.getByPlaceholderText(/message the agent/i), '@');
+    expect(await screen.findByRole('listbox', { name: /prompts/i })).toBeInTheDocument();
+    expect(screen.getByText('summarize')).toBeInTheDocument();
+    expect(screen.getByText('translate')).toBeInTheDocument();
+  });
+
+  it('shows tool picker when user types /', async () => {
+    const user = userEvent.setup();
+    renderInput();
+    await user.type(screen.getByPlaceholderText(/message the agent/i), '/');
+    expect(await screen.findByRole('listbox', { name: /tools/i })).toBeInTheDocument();
+    expect(screen.getByText('search')).toBeInTheDocument();
+    expect(screen.getByText('calculator')).toBeInTheDocument();
+  });
+
+  it('filters picker items as user types after @', async () => {
+    const user = userEvent.setup();
+    renderInput();
+    await user.type(screen.getByPlaceholderText(/message the agent/i), '@tra');
+    await waitFor(() => {
+      expect(screen.getByText('translate')).toBeInTheDocument();
+      expect(screen.queryByText('summarize')).not.toBeInTheDocument();
+    });
+  });
+
+  it('inserts selection on Enter and closes picker', async () => {
+    const user = userEvent.setup();
+    renderInput();
+    const input = screen.getByPlaceholderText(/message the agent/i);
+    await user.type(input, '@sum');
+    await user.keyboard('{Enter}');
+    expect(input).toHaveValue('@summarize ');
+    expect(screen.queryByRole('listbox', { name: /prompts/i })).not.toBeInTheDocument();
+  });
+
+  it('closes picker on Escape without inserting', async () => {
+    const user = userEvent.setup();
+    renderInput();
+    const input = screen.getByPlaceholderText(/message the agent/i);
+    await user.type(input, '@sum');
+    await user.keyboard('{Escape}');
+    expect(input).toHaveValue('@sum');
+    expect(screen.queryByRole('listbox', { name: /prompts/i })).not.toBeInTheDocument();
+  });
+});

--- a/src/Content/Presentation/Presentation.Dashboard/src/features/chat/__tests__/ChatPanel.test.tsx
+++ b/src/Content/Presentation/Presentation.Dashboard/src/features/chat/__tests__/ChatPanel.test.tsx
@@ -1,0 +1,158 @@
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { useChatStore } from '../useChatStore';
+import { useAppStore } from '@/stores/appStore';
+import { ChatPanel } from '../ChatPanel';
+import { renderWithProviders } from '@/test/utils';
+
+const mockSendMessage = vi.fn();
+const mockStartConversation = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('@/hooks/useAgentHub', () => ({
+  useAgentHub: () => ({
+    connectionState: 'connected',
+    startConversation: mockStartConversation,
+    invokeToolViaAgent: vi.fn().mockResolvedValue(undefined),
+    retryFromMessage: vi.fn().mockResolvedValue(undefined),
+    editAndResubmit: vi.fn().mockResolvedValue(undefined),
+    setConversationSettings: vi.fn().mockResolvedValue(undefined),
+  }),
+  AgentHubProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@/hooks/useAgentStream', () => ({
+  useAgentStream: () => ({
+    sendMessage: mockSendMessage,
+    abort: vi.fn(),
+  }),
+}));
+
+function getSubmitButton(): HTMLButtonElement {
+  const btn = document.querySelector('button[type="submit"]');
+  if (!btn) throw new Error('Submit button not found');
+  return btn as HTMLButtonElement;
+}
+
+function renderPanel() {
+  return renderWithProviders(<ChatPanel />);
+}
+
+describe('ChatPanel', () => {
+  beforeEach(() => {
+    useChatStore.setState({
+      conversationId: null,
+      messages: [],
+      isStreaming: false,
+      streamingContent: '',
+      error: null,
+    });
+    useAppStore.setState({ selectedAgent: 'test-agent' });
+    mockSendMessage.mockReset();
+    mockStartConversation.mockReset().mockResolvedValue(undefined);
+  });
+
+  // --- StartConversation race (regression guard) ---
+
+  describe('ChatInput gating', () => {
+    it('disables Send until startConversation resolves (prevents "Conversation not found")', async () => {
+      let resolveStart!: () => void;
+      const startPromise = new Promise<void>((resolve) => { resolveStart = resolve; });
+      mockStartConversation.mockReturnValueOnce(startPromise);
+
+      renderPanel();
+
+      // Submit button should be disabled while conversation is starting (disabled prop=true)
+      await waitFor(() => { expect(getSubmitButton()).toBeDisabled(); });
+
+      resolveStart();
+
+      // After start resolves, ChatInput disabled prop becomes false.
+      // The button is still disabled because there's no text typed yet,
+      // but the textarea should become enabled.
+      await waitFor(() => {
+        expect(screen.getByPlaceholderText(/message the agent/i)).not.toBeDisabled();
+      });
+    });
+
+    it('does not invoke sendMessage when user clicks Send before startConversation resolves', async () => {
+      const user = userEvent.setup();
+      let resolveStart!: () => void;
+      const startPromise = new Promise<void>((resolve) => { resolveStart = resolve; });
+      mockStartConversation.mockReturnValueOnce(startPromise);
+
+      renderPanel();
+
+      const textarea = await screen.findByPlaceholderText(/message the agent/i);
+      await user.type(textarea, 'hello');
+      await user.click(getSubmitButton());
+
+      expect(mockSendMessage).not.toHaveBeenCalled();
+
+      resolveStart();
+      await waitFor(() => {
+        expect(screen.getByPlaceholderText(/message the agent/i)).not.toBeDisabled();
+      });
+    });
+  });
+
+  // --- ErrorBanner ---
+
+  describe('ErrorBanner', () => {
+    it('renders nothing when error is null', async () => {
+      renderPanel();
+      // Wait for conversation to start so the full UI renders
+      await waitFor(() => { expect(screen.getByPlaceholderText(/message the agent/i)).toBeInTheDocument(); });
+      expect(screen.queryByRole('button', { name: /dismiss/i })).not.toBeInTheDocument();
+    });
+
+    it('renders error message string', async () => {
+      useChatStore.setState({ error: 'turn failed' });
+      renderPanel();
+      await waitFor(() => { expect(screen.getByText('turn failed')).toBeInTheDocument(); });
+    });
+
+    it('renders extracted .message not the raw [object Object]', async () => {
+      // Simulate what setError now receives after our fix — a clean string
+      useChatStore.setState({ error: 'turn failed' });
+      renderPanel();
+      await waitFor(() => {
+        expect(screen.queryByText('[object Object]')).not.toBeInTheDocument();
+        expect(screen.getByText('turn failed')).toBeInTheDocument();
+      });
+    });
+
+    it('dismiss button clears the error', async () => {
+      const user = userEvent.setup();
+      useChatStore.setState({ error: 'something went wrong' });
+      renderPanel();
+      await waitFor(() => { expect(screen.getByText('something went wrong')).toBeInTheDocument(); });
+      await user.click(screen.getByRole('button', { name: /dismiss/i }));
+      expect(useChatStore.getState().error).toBeNull();
+      expect(screen.queryByText('something went wrong')).not.toBeInTheDocument();
+    });
+  });
+
+  // --- ConversationHeader ---
+
+  describe('ConversationHeader', () => {
+    it('shows a truncated UUID (8 chars) after mount', async () => {
+      renderPanel();
+      await waitFor(() => {
+        // The component renders conversationId.slice(0, 8) — an 8 char hex substring
+        expect(screen.getByText(/^[0-9a-f]{8}$/i)).toBeInTheDocument();
+      });
+    });
+
+    it('Clear button resets messages', async () => {
+      const user = userEvent.setup();
+      useChatStore.setState({
+        messages: [{ id: '1', role: 'user', content: 'hello', timestamp: new Date() }],
+      });
+      renderPanel();
+      await waitFor(() => { expect(screen.getByRole('button', { name: /clear/i })).toBeInTheDocument(); });
+      await user.click(screen.getByRole('button', { name: /clear/i }));
+      expect(useChatStore.getState().messages).toHaveLength(0);
+    });
+  });
+});

--- a/src/Content/Presentation/Presentation.Dashboard/src/features/chat/__tests__/MessageItem.test.tsx
+++ b/src/Content/Presentation/Presentation.Dashboard/src/features/chat/__tests__/MessageItem.test.tsx
@@ -1,0 +1,86 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi, describe, it, expect } from 'vitest';
+import { MessageItem } from '../MessageItem';
+import type { ChatMessage } from '../useChatStore';
+
+const userMsg: ChatMessage = {
+  id: 'user-1',
+  role: 'user',
+  content: 'original text',
+  timestamp: new Date(),
+};
+
+const assistantMsg: ChatMessage = {
+  id: 'asst-1',
+  role: 'assistant',
+  content: 'agent reply',
+  timestamp: new Date(),
+};
+
+describe('MessageItem retry/edit actions', () => {
+  it('Retry button on assistant message invokes onRetry with message id', async () => {
+    const onRetry = vi.fn();
+    const user = userEvent.setup();
+    render(<MessageItem message={assistantMsg} onRetry={onRetry} />);
+    await user.click(screen.getByRole('button', { name: /regenerate response/i }));
+    expect(onRetry).toHaveBeenCalledWith('asst-1');
+  });
+
+  it('does not render Retry on user messages', () => {
+    render(<MessageItem message={userMsg} onRetry={vi.fn()} />);
+    expect(screen.queryByRole('button', { name: /regenerate response/i })).not.toBeInTheDocument();
+  });
+
+  it('Edit button on user message opens inline editor with current content', async () => {
+    const user = userEvent.setup();
+    render(<MessageItem message={userMsg} onEdit={vi.fn()} />);
+    await user.click(screen.getByRole('button', { name: /edit message/i }));
+    expect(screen.getByRole('textbox', { name: /edit message/i })).toHaveValue('original text');
+  });
+
+  it('Save in editor calls onEdit with id and new content', async () => {
+    const onEdit = vi.fn();
+    const user = userEvent.setup();
+    render(<MessageItem message={userMsg} onEdit={onEdit} />);
+    await user.click(screen.getByRole('button', { name: /edit message/i }));
+    const textarea = screen.getByRole('textbox', { name: /edit message/i });
+    await user.clear(textarea);
+    await user.type(textarea, 'revised text');
+    await user.click(screen.getByRole('button', { name: /save/i }));
+    expect(onEdit).toHaveBeenCalledWith('user-1', 'revised text');
+  });
+
+  it('Cancel in editor reverts draft and does not call onEdit', async () => {
+    const onEdit = vi.fn();
+    const user = userEvent.setup();
+    render(<MessageItem message={userMsg} onEdit={onEdit} />);
+    await user.click(screen.getByRole('button', { name: /edit message/i }));
+    const textarea = screen.getByRole('textbox', { name: /edit message/i });
+    await user.clear(textarea);
+    await user.type(textarea, 'scratch');
+    await user.click(screen.getByRole('button', { name: /cancel/i }));
+    expect(onEdit).not.toHaveBeenCalled();
+    expect(screen.getByText('original text')).toBeInTheDocument();
+  });
+
+  it('Save with unchanged content is a no-op (closes editor without invoking onEdit)', async () => {
+    const onEdit = vi.fn();
+    const user = userEvent.setup();
+    render(<MessageItem message={userMsg} onEdit={onEdit} />);
+    await user.click(screen.getByRole('button', { name: /edit message/i }));
+    await user.click(screen.getByRole('button', { name: /save/i }));
+    expect(onEdit).not.toHaveBeenCalled();
+    expect(screen.queryByRole('textbox', { name: /edit message/i })).not.toBeInTheDocument();
+  });
+
+  it('disabled hides the action row entirely', () => {
+    render(<MessageItem message={assistantMsg} onRetry={vi.fn()} disabled />);
+    expect(screen.queryByRole('button', { name: /regenerate response/i })).not.toBeInTheDocument();
+  });
+
+  it('isStreaming hides Retry (cannot retry an in-flight response)', () => {
+    render(<MessageItem message={assistantMsg} onRetry={vi.fn()} isStreaming />);
+    expect(screen.queryByRole('button', { name: /regenerate response/i })).not.toBeInTheDocument();
+  });
+});

--- a/src/Content/Presentation/Presentation.Dashboard/src/features/chat/__tests__/MessageList.test.tsx
+++ b/src/Content/Presentation/Presentation.Dashboard/src/features/chat/__tests__/MessageList.test.tsx
@@ -1,0 +1,73 @@
+import { render, screen, act } from '@testing-library/react';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useChatStore } from '../useChatStore';
+import { MessageList } from '../MessageList';
+import { TypingIndicator } from '../TypingIndicator';
+
+const seedMessages = () => {
+  useChatStore.getState().addMessage({ id: '1', role: 'user', content: 'Hello', timestamp: new Date() });
+  useChatStore.getState().addMessage({ id: '2', role: 'assistant', content: 'Hi there', timestamp: new Date() });
+  useChatStore.getState().addMessage({ id: '3', role: 'user', content: 'How are you?', timestamp: new Date() });
+};
+
+describe('MessageList', () => {
+  beforeEach(() => {
+    useChatStore.setState({
+      conversationId: null,
+      messages: [],
+      isStreaming: false,
+      streamingContent: '',
+      error: null,
+    });
+  });
+
+  it('renders all messages from the store', () => {
+    seedMessages();
+    render(<MessageList />);
+    expect(screen.getByText('Hello')).toBeInTheDocument();
+    expect(screen.getByText('Hi there')).toBeInTheDocument();
+    expect(screen.getByText('How are you?')).toBeInTheDocument();
+  });
+
+  it('renders user message right-aligned (flex-row-reverse)', () => {
+    useChatStore.getState().addMessage({ id: '1', role: 'user', content: 'User msg', timestamp: new Date() });
+    render(<MessageList />);
+    const msgEl = screen.getByText('User msg');
+    expect(msgEl.closest('[class*="flex-row-reverse"]')).toBeInTheDocument();
+  });
+
+  it('renders assistant message left-aligned (flex-row)', () => {
+    useChatStore.getState().addMessage({ id: '1', role: 'assistant', content: 'Agent msg', timestamp: new Date() });
+    render(<MessageList />);
+    const msgEl = screen.getByText('Agent msg');
+    const container = msgEl.closest('.group');
+    expect(container).toBeInTheDocument();
+    expect(container?.className).toMatch(/\bflex-row\b/);
+    expect(container?.className).not.toMatch(/flex-row-reverse/);
+  });
+
+  it('streaming: streamingContent updates visible text in DOM', () => {
+    useChatStore.setState({ isStreaming: true, streamingContent: 'partial response' });
+    render(<MessageList />);
+    expect(screen.getByText('partial response')).toBeInTheDocument();
+  });
+
+  it('TurnComplete: finalizeStream hides streaming content and shows final message', () => {
+    useChatStore.setState({ isStreaming: true, streamingContent: 'partial' });
+    render(
+      <>
+        <MessageList />
+        <TypingIndicator />
+      </>,
+    );
+    expect(screen.getByText('partial')).toBeInTheDocument();
+    expect(screen.getByLabelText('Agent is typing')).toBeInTheDocument();
+
+    act(() => {
+      useChatStore.getState().finalizeStream('Full response');
+    });
+
+    expect(screen.queryByLabelText('Agent is typing')).not.toBeInTheDocument();
+    expect(screen.getByText('Full response')).toBeInTheDocument();
+  });
+});

--- a/src/Content/Presentation/Presentation.Dashboard/src/features/chat/__tests__/TypingIndicator.test.tsx
+++ b/src/Content/Presentation/Presentation.Dashboard/src/features/chat/__tests__/TypingIndicator.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useChatStore } from '../useChatStore';
+import { TypingIndicator } from '../TypingIndicator';
+
+describe('TypingIndicator', () => {
+  beforeEach(() => {
+    useChatStore.setState({ isStreaming: false, messages: [], streamingContent: '', conversationId: null });
+  });
+
+  it('is visible when isStreaming is true', () => {
+    useChatStore.setState({ isStreaming: true });
+    render(<TypingIndicator />);
+    expect(screen.getByLabelText('Agent is typing')).toBeInTheDocument();
+  });
+
+  it('is not rendered when isStreaming is false', () => {
+    render(<TypingIndicator />);
+    expect(screen.queryByLabelText('Agent is typing')).not.toBeInTheDocument();
+  });
+});

--- a/src/Content/Presentation/Presentation.Dashboard/src/features/chat/__tests__/completeStreamingMarkdown.test.ts
+++ b/src/Content/Presentation/Presentation.Dashboard/src/features/chat/__tests__/completeStreamingMarkdown.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import { completeStreamingMarkdown } from '../completeStreamingMarkdown';
+
+describe('completeStreamingMarkdown', () => {
+  it('closes a dangling backtick code fence so it parses as a code block now', () => {
+    // The flicker case: opening fence has arrived, closing fence has not.
+    const partial = 'Here is some code:\n```ts\nconst x = 1;';
+    expect(completeStreamingMarkdown(partial)).toBe(
+      'Here is some code:\n```ts\nconst x = 1;\n```',
+    );
+  });
+
+  it('closes a dangling tilde fence with a tilde closer', () => {
+    const partial = '~~~\nplain block';
+    expect(completeStreamingMarkdown(partial)).toBe('~~~\nplain block\n~~~');
+  });
+
+  it('leaves a balanced code fence unchanged (no-op for completed content)', () => {
+    const complete = 'before\n```ts\nconst x = 1;\n```\nafter';
+    expect(completeStreamingMarkdown(complete)).toBe(complete);
+  });
+
+  it('does not append a separating newline when content already ends in one', () => {
+    const partial = '```\ncode\n';
+    expect(completeStreamingMarkdown(partial)).toBe('```\ncode\n```');
+  });
+
+  it('ignores triple backticks that appear mid-line in prose', () => {
+    // Not a fence — it is not at the start of a line, so nothing is opened.
+    const prose = 'Use the ``` syntax to start a block.';
+    expect(completeStreamingMarkdown(prose)).toBe(prose);
+  });
+
+  it('treats an indented fence as a fence (leading whitespace allowed)', () => {
+    const partial = '- item\n  ```\n  code';
+    expect(completeStreamingMarkdown(partial)).toBe('- item\n  ```\n  code\n```');
+  });
+
+  it('does not treat a tilde close as closing a backtick fence', () => {
+    // Different marker families do not pair — the backtick fence stays open.
+    const partial = '```\ncode\n~~~';
+    expect(completeStreamingMarkdown(partial)).toBe('```\ncode\n~~~\n```');
+  });
+
+  it('closes a 4-backtick fence with a 4-backtick closer (not a fixed 3)', () => {
+    // A 4-marker fence (used when the code itself contains triple backticks) must
+    // be closed by a run at least as long, or CommonMark would not close it.
+    const partial = '````md\n```\nnested\n```';
+    expect(completeStreamingMarkdown(partial)).toBe('````md\n```\nnested\n```\n````');
+  });
+
+  it('treats a shorter same-family fence inside a longer fence as content', () => {
+    // Opened with 4 backticks; the inner 3-backtick line is content, so the block
+    // stays open and is closed with 4 backticks.
+    const partial = '````\n```';
+    expect(completeStreamingMarkdown(partial)).toBe('````\n```\n````');
+  });
+
+  it('closes a longer fence opened after the standard three', () => {
+    const partial = '`````python\nprint(1)';
+    expect(completeStreamingMarkdown(partial)).toBe('`````python\nprint(1)\n`````');
+  });
+
+  it('returns empty string unchanged', () => {
+    expect(completeStreamingMarkdown('')).toBe('');
+  });
+
+  it('leaves plain prose with no fences unchanged', () => {
+    const text = 'Just a normal sentence with no code.';
+    expect(completeStreamingMarkdown(text)).toBe(text);
+  });
+});

--- a/src/Content/Presentation/Presentation.Dashboard/src/features/chat/__tests__/useChatStore.test.ts
+++ b/src/Content/Presentation/Presentation.Dashboard/src/features/chat/__tests__/useChatStore.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useChatStore } from '../useChatStore';
+
+describe('useChatStore', () => {
+  beforeEach(() => {
+    useChatStore.setState({
+      conversationId: null,
+      messages: [],
+      isStreaming: false,
+      streamingContent: '',
+      pendingEditMessage: null,
+    });
+  });
+
+  it('appendToken accumulates tokens in streamingContent', () => {
+    const { appendToken } = useChatStore.getState();
+    appendToken('hello ');
+    appendToken('world');
+    const state = useChatStore.getState();
+    expect(state.streamingContent).toBe('hello world');
+    expect(state.isStreaming).toBe(true);
+  });
+
+  it('finalizeStream clears streamingContent and adds message to messages array', () => {
+    const store = useChatStore.getState();
+    store.appendToken('hello ');
+    store.appendToken('world');
+    store.finalizeStream('hello world');
+    const state = useChatStore.getState();
+    expect(state.streamingContent).toBe('');
+    expect(state.isStreaming).toBe(false);
+    expect(state.messages).toHaveLength(1);
+    expect(state.messages[0]?.content).toBe('hello world');
+    expect(state.messages[0]?.role).toBe('assistant');
+  });
+
+  it('truncateAfter drops messages beyond keepCount', () => {
+    const store = useChatStore.getState();
+    store.setMessages([
+      { id: 'u1', role: 'user', content: 'first', timestamp: new Date() },
+      { id: 'a1', role: 'assistant', content: 'reply', timestamp: new Date() },
+      { id: 'u2', role: 'user', content: 'second', timestamp: new Date() },
+    ]);
+    store.truncateAfter(1);
+    const state = useChatStore.getState();
+    expect(state.messages).toHaveLength(1);
+    expect(state.messages[0]?.id).toBe('u1');
+  });
+
+  it('truncateAfter re-inserts the pending edit message after truncation', () => {
+    const store = useChatStore.getState();
+    store.setMessages([
+      { id: 'u1', role: 'user', content: 'old user', timestamp: new Date() },
+      { id: 'a1', role: 'assistant', content: 'old reply', timestamp: new Date() },
+    ]);
+    // Simulate EditAndResubmit: client stages the edited user message, server truncates to keepCount=0.
+    store.setPendingEditMessage({ id: 'u-new', role: 'user', content: 'edited user', timestamp: new Date() });
+    store.truncateAfter(0);
+
+    const state = useChatStore.getState();
+    expect(state.messages).toHaveLength(1);
+    expect(state.messages[0]?.id).toBe('u-new');
+    expect(state.messages[0]?.content).toBe('edited user');
+    expect(state.pendingEditMessage).toBeNull();
+  });
+
+  it('clearMessages resets all state', () => {
+    const store = useChatStore.getState();
+    store.addMessage({ id: '1', role: 'user', content: 'hi', timestamp: new Date() });
+    store.appendToken('token');
+    store.setConversationId('conv-1');
+    store.clearMessages();
+    const state = useChatStore.getState();
+    expect(state.messages).toHaveLength(0);
+    expect(state.isStreaming).toBe(false);
+    expect(state.streamingContent).toBe('');
+    expect(state.conversationId).toBe('conv-1');
+  });
+});

--- a/src/Content/Presentation/Presentation.Dashboard/src/features/conversations/ConversationSidebar.tsx
+++ b/src/Content/Presentation/Presentation.Dashboard/src/features/conversations/ConversationSidebar.tsx
@@ -4,6 +4,7 @@ import { useConversationsQuery } from './useConversationsQuery';
 import { useDeleteConversation } from './useDeleteConversation';
 import { useAppStore } from '@/stores/appStore';
 import { useChatStore } from '@/features/chat/useChatStore';
+import { useConversationSettingsStore } from '@/stores/conversationSettingsStore';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { ScrollArea } from '@/components/ui/scroll-area';
@@ -35,6 +36,7 @@ export function ConversationSidebar({ onSelect }: ConversationSidebarProps) {
   const selectedAgent = useAppStore((s) => s.selectedAgent);
   const setSelectedAgent = useAppStore((s) => s.setSelectedAgent);
   const clearMessages = useChatStore((s) => s.clearMessages);
+  const clearSettings = useConversationSettingsStore((s) => s.clear);
   const [search, setSearch] = useState('');
 
   const filtered = useMemo(() => {
@@ -71,6 +73,7 @@ export function ConversationSidebar({ onSelect }: ConversationSidebarProps) {
   const handleDelete = (e: React.MouseEvent, id: string): void => {
     e.stopPropagation();
     deleteMutation.mutate(id);
+    clearSettings(id);
     if (id === activeId) {
       clearMessages();
       const remaining = conversations?.filter((c) => c.id !== id) ?? [];

--- a/src/Content/Presentation/Presentation.Dashboard/src/features/conversations/__tests__/ConversationSidebar.test.tsx
+++ b/src/Content/Presentation/Presentation.Dashboard/src/features/conversations/__tests__/ConversationSidebar.test.tsx
@@ -1,0 +1,51 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { ConversationSidebar } from '../ConversationSidebar';
+import { renderWithProviders } from '@/test/utils';
+import { useConversationSettingsStore } from '@/stores/conversationSettingsStore';
+import { useAppStore } from '@/stores/appStore';
+
+const mocks = vi.hoisted(() => ({
+  mutate: vi.fn(),
+}));
+
+vi.mock('../useConversationsQuery', () => ({
+  useConversationsQuery: () => ({
+    data: [
+      { id: 'conv-1', title: 'First', agentName: 'agent-1', updatedAt: '2026-01-01T00:00:00Z' },
+    ],
+    isLoading: false,
+    error: null,
+  }),
+}));
+
+vi.mock('../useDeleteConversation', () => ({
+  useDeleteConversation: () => ({ mutate: mocks.mutate }),
+}));
+
+describe('ConversationSidebar', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useAppStore.setState({ selectedAgent: 'agent-1', activeConversationId: 'conv-1', showSidebar: true });
+    useConversationSettingsStore.setState({ byConversationId: {} });
+  });
+
+  it('clears the deleted conversation\'s per-conversation settings', async () => {
+    // Seed settings for the conversation that is about to be deleted.
+    useConversationSettingsStore.getState().setSettings('conv-1', {
+      deploymentName: 'gpt-x',
+      temperature: 0.5,
+      systemPromptOverride: null,
+    });
+    expect(useConversationSettingsStore.getState().byConversationId['conv-1']).toBeDefined();
+
+    renderWithProviders(<ConversationSidebar />);
+
+    await userEvent.click(screen.getByLabelText('Delete conversation First'));
+
+    expect(mocks.mutate).toHaveBeenCalledWith('conv-1');
+    // The settings entry for the deleted conversation must be gone (no leak).
+    expect(useConversationSettingsStore.getState().byConversationId['conv-1']).toBeUndefined();
+  });
+});

--- a/src/Content/Presentation/Presentation.Dashboard/src/hooks/__tests__/useAgentHub.conversationGuard.test.ts
+++ b/src/Content/Presentation/Presentation.Dashboard/src/hooks/__tests__/useAgentHub.conversationGuard.test.ts
@@ -1,0 +1,164 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { createElement, type ReactNode } from 'react';
+import { AgentHubProvider, useAgentHub } from '../useAgentHub';
+import { useChatStore } from '@/stores/chatStore';
+
+// Regression coverage for the solution-review finding: streaming handlers must
+// drop payloads whose conversationId does not match the store's active
+// conversation, so tokens from conversation A never render or finalize into
+// conversation B's transcript after a mid-stream conversation switch.
+
+const mocks = vi.hoisted(() => ({
+  connectionStart: vi.fn(),
+  connectionStop: vi.fn(),
+  connectionOn: vi.fn(),
+  connectionOff: vi.fn(),
+  connectionInvoke: vi.fn(),
+  onreconnecting: vi.fn(),
+  onreconnected: vi.fn(),
+  onclose: vi.fn(),
+  buildHubConnection: vi.fn(),
+  acquireTokenSilent: vi.fn(),
+}));
+
+const mockConnection = {
+  start: mocks.connectionStart,
+  stop: mocks.connectionStop,
+  on: mocks.connectionOn,
+  off: mocks.connectionOff,
+  invoke: mocks.connectionInvoke,
+  onreconnecting: mocks.onreconnecting,
+  onreconnected: mocks.onreconnected,
+  onclose: mocks.onclose,
+};
+
+vi.mock('@/realtime/signalrClient', () => ({
+  buildHubConnection: mocks.buildHubConnection,
+}));
+
+vi.mock('@azure/msal-react', () => ({
+  useMsal: () => ({
+    instance: {
+      acquireTokenSilent: mocks.acquireTokenSilent,
+      getAllAccounts: () => [{
+        username: 'test@example.com',
+        homeAccountId: '1',
+        environment: '',
+        tenantId: '',
+        localAccountId: '',
+        name: 'Test User',
+      }],
+    },
+    accounts: [{
+      username: 'test@example.com',
+      homeAccountId: '1',
+      environment: '',
+      tenantId: '',
+      localAccountId: '',
+    }],
+  }),
+}));
+
+vi.mock('@/auth/authConfig', () => ({
+  loginRequest: { scopes: ['api://test/access_as_user'] },
+}));
+
+vi.mock('@/auth/devAuth', () => ({
+  IS_AUTH_DISABLED: false,
+}));
+
+// Extract the callback registered for a named SignalR event.
+// Must be called after renderHook so the useEffect has run.
+function getHandler(eventName: string): (...args: unknown[]) => void {
+  const call = mocks.connectionOn.mock.calls.find(
+    ([name]: unknown[]) => name === eventName,
+  );
+  if (!call?.[1]) throw new Error(`No handler registered for '${eventName}'`);
+  return call[1] as (...args: unknown[]) => void;
+}
+
+const wrapper = ({ children }: { children: ReactNode }) =>
+  createElement(AgentHubProvider, null, children);
+
+async function mountConnected() {
+  const hook = renderHook(() => useAgentHub(), { wrapper });
+  await waitFor(() => expect(hook.result.current.connectionState).toBe('connected'));
+  return hook;
+}
+
+describe('useAgentHub conversation guard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.buildHubConnection.mockReturnValue(mockConnection);
+    mocks.connectionStart.mockResolvedValue(undefined);
+    mocks.connectionStop.mockResolvedValue(undefined);
+    mocks.acquireTokenSilent.mockResolvedValue({ accessToken: 'tok' });
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ authDisabled: false }), { status: 200 }),
+    );
+    useChatStore.setState({
+      conversationId: null,
+      messages: [],
+      isStreaming: false,
+      streamingContent: '',
+      error: null,
+    });
+  });
+
+  it('TokenReceived_ForeignConversation_DropsToken', async () => {
+    await mountConnected();
+    useChatStore.getState().setConversationId('conv-B');
+
+    act(() => {
+      getHandler('TokenReceived')({ conversationId: 'conv-A', token: 'leak', isComplete: false });
+    });
+
+    const state = useChatStore.getState();
+    expect(state.streamingContent).toBe('');
+    expect(state.isStreaming).toBe(false);
+  });
+
+  it('TokenReceived_ActiveConversation_AppendsToken', async () => {
+    await mountConnected();
+    useChatStore.getState().setConversationId('conv-B');
+
+    act(() => {
+      getHandler('TokenReceived')({ conversationId: 'conv-B', token: 'hi', isComplete: false });
+    });
+
+    expect(useChatStore.getState().streamingContent).toBe('hi');
+  });
+
+  it('TurnComplete_ForeignConversation_DoesNotFinalizeIntoActiveTranscript', async () => {
+    await mountConnected();
+    useChatStore.getState().setConversationId('conv-B');
+
+    act(() => {
+      getHandler('TurnComplete')({
+        conversationId: 'conv-A',
+        turnNumber: 1,
+        fullResponse: 'A full reply',
+      });
+    });
+
+    expect(useChatStore.getState().messages).toHaveLength(0);
+  });
+
+  it('HistoryTruncated_ForeignConversation_DoesNotTruncateActiveTranscript', async () => {
+    await mountConnected();
+    useChatStore.setState({
+      conversationId: 'conv-B',
+      messages: [
+        { id: 'm1', role: 'user', content: 'one', timestamp: new Date() },
+        { id: 'm2', role: 'assistant', content: 'two', timestamp: new Date() },
+      ],
+    });
+
+    act(() => {
+      getHandler('HistoryTruncated')({ conversationId: 'conv-A', keepCount: 0 });
+    });
+
+    expect(useChatStore.getState().messages).toHaveLength(2);
+  });
+});

--- a/src/Content/Presentation/Presentation.Dashboard/src/hooks/__tests__/useAgentHub.test.ts
+++ b/src/Content/Presentation/Presentation.Dashboard/src/hooks/__tests__/useAgentHub.test.ts
@@ -1,0 +1,197 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { createElement, type ReactNode } from 'react';
+import { AgentHubProvider, useAgentHub } from '../useAgentHub';
+import { useChatStore } from '@/stores/chatStore';
+
+const mocks = vi.hoisted(() => ({
+  connectionStart: vi.fn(),
+  connectionStop: vi.fn(),
+  connectionOn: vi.fn(),
+  connectionOff: vi.fn(),
+  connectionInvoke: vi.fn(),
+  onreconnecting: vi.fn(),
+  onreconnected: vi.fn(),
+  onclose: vi.fn(),
+  buildHubConnection: vi.fn(),
+  acquireTokenSilent: vi.fn(),
+}));
+
+const mockConnection = {
+  start: mocks.connectionStart,
+  stop: mocks.connectionStop,
+  on: mocks.connectionOn,
+  off: mocks.connectionOff,
+  invoke: mocks.connectionInvoke,
+  onreconnecting: mocks.onreconnecting,
+  onreconnected: mocks.onreconnected,
+  onclose: mocks.onclose,
+};
+
+vi.mock('@/realtime/signalrClient', () => ({
+  buildHubConnection: mocks.buildHubConnection,
+}));
+
+vi.mock('@azure/msal-react', () => ({
+  useMsal: () => ({
+    instance: {
+      acquireTokenSilent: mocks.acquireTokenSilent,
+      getAllAccounts: () => [{
+        username: 'test@example.com',
+        homeAccountId: '1',
+        environment: '',
+        tenantId: '',
+        localAccountId: '',
+        name: 'Test User',
+      }],
+    },
+    accounts: [{
+      username: 'test@example.com',
+      homeAccountId: '1',
+      environment: '',
+      tenantId: '',
+      localAccountId: '',
+    }],
+  }),
+}));
+
+vi.mock('@/auth/authConfig', () => ({
+  loginRequest: { scopes: ['api://test/access_as_user'] },
+}));
+
+vi.mock('@/auth/devAuth', () => ({
+  IS_AUTH_DISABLED: false,
+}));
+
+// Extract the callback registered for a named SignalR event.
+// Must be called after renderHook so the useEffect has run.
+function getHandler(eventName: string): (...args: unknown[]) => void {
+  const call = mocks.connectionOn.mock.calls.find(
+    ([name]: unknown[]) => name === eventName,
+  );
+  if (!call?.[1]) throw new Error(`No handler registered for '${eventName}'`);
+  return call[1] as (...args: unknown[]) => void;
+}
+
+const wrapper = ({ children }: { children: ReactNode }) =>
+  createElement(AgentHubProvider, null, children);
+
+async function mountConnected() {
+  const hook = renderHook(() => useAgentHub(), { wrapper });
+  await waitFor(() => expect(hook.result.current.connectionState).toBe('connected'));
+  return hook;
+}
+
+describe('useAgentHub', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.buildHubConnection.mockReturnValue(mockConnection);
+    mocks.connectionStart.mockResolvedValue(undefined);
+    mocks.connectionStop.mockResolvedValue(undefined);
+    mocks.acquireTokenSilent.mockResolvedValue({ accessToken: 'tok' });
+    // Suppress the fetch('/api/config/auth') call made after connection starts
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(JSON.stringify({ authDisabled: false }), { status: 200 }));
+    useChatStore.setState({
+      conversationId: null,
+      messages: [],
+      isStreaming: false,
+      streamingContent: '',
+      error: null,
+    });
+  });
+
+  // --- connection lifecycle ---
+
+  it('starts in disconnected state', () => {
+    mocks.connectionStart.mockReturnValue(new Promise<void>(() => {}));
+    const { result } = renderHook(() => useAgentHub(), { wrapper });
+    expect(result.current.connectionState).not.toBe('connected');
+  });
+
+  it('transitions to connected state after start()', async () => {
+    const { result } = renderHook(() => useAgentHub(), { wrapper });
+    await waitFor(() => {
+      expect(result.current.connectionState).toBe('connected');
+    });
+  });
+
+  it('cleanup calls connection.stop() on unmount', async () => {
+    const { unmount } = renderHook(() => useAgentHub(), { wrapper });
+    await waitFor(() => expect(mocks.connectionStop).not.toHaveBeenCalled());
+    unmount();
+    // Cleanup waits for start() to settle before calling stop(), so the call is async.
+    await waitFor(() => { expect(mocks.connectionStop).toHaveBeenCalled(); });
+  });
+
+  it('sets chatStore error when connection.start() rejects', async () => {
+    mocks.connectionStart.mockRejectedValue(new Error('ECONNREFUSED'));
+    renderHook(() => useAgentHub(), { wrapper });
+    await waitFor(() => {
+      expect(useChatStore.getState().error).toBe('ECONNREFUSED');
+    });
+  });
+
+  // --- Error event (system boundary — server can send any shape) ---
+
+  describe('Error event', () => {
+    it('stores a plain string error', async () => {
+      await mountConnected();
+      act(() => { getHandler('Error')('something went wrong'); });
+      expect(useChatStore.getState().error).toBe('something went wrong');
+    });
+
+    it('extracts .message from {conversationId, message, code} object', async () => {
+      await mountConnected();
+      act(() => { getHandler('Error')({ conversationId: 'abc', message: 'turn failed', code: 500 }); });
+      expect(useChatStore.getState().error).toBe('turn failed');
+    });
+
+    it('JSON.stringifies unknown object shapes', async () => {
+      await mountConnected();
+      act(() => { getHandler('Error')({ unexpected: true }); });
+      expect(useChatStore.getState().error).toBe('{"unexpected":true}');
+    });
+
+    it('stores empty string for null payload', async () => {
+      await mountConnected();
+      act(() => { getHandler('Error')(null); });
+      expect(useChatStore.getState().error).toBe('null');
+    });
+  });
+
+  // --- TokenReceived event ---
+
+  describe('TokenReceived event', () => {
+    it('appends tokens and sets isStreaming', async () => {
+      await mountConnected();
+      act(() => { getHandler('TokenReceived')({ conversationId: 'c1', token: 'hello ', isComplete: false }); });
+      act(() => { getHandler('TokenReceived')({ conversationId: 'c1', token: 'world', isComplete: false }); });
+      const state = useChatStore.getState();
+      expect(state.streamingContent).toBe('hello world');
+      expect(state.isStreaming).toBe(true);
+    });
+
+    it('ignores the isComplete marker chunk', async () => {
+      await mountConnected();
+      act(() => { getHandler('TokenReceived')({ conversationId: 'c1', token: 'hi', isComplete: false }); });
+      act(() => { getHandler('TokenReceived')({ conversationId: 'c1', token: 'hi', isComplete: true }); });
+      expect(useChatStore.getState().streamingContent).toBe('hi');
+    });
+  });
+
+  // --- TurnComplete event ---
+
+  describe('TurnComplete event', () => {
+    it('finalizes stream and adds an assistant message', async () => {
+      await mountConnected();
+      act(() => { getHandler('TokenReceived')({ conversationId: 'c1', token: 'partial', isComplete: false }); });
+      act(() => { getHandler('TurnComplete')({ conversationId: 'c1', turnNumber: 2, fullResponse: 'full response' }); });
+      const state = useChatStore.getState();
+      expect(state.isStreaming).toBe(false);
+      expect(state.streamingContent).toBe('');
+      expect(state.messages).toHaveLength(1);
+      expect(state.messages[0]?.role).toBe('assistant');
+      expect(state.messages[0]?.content).toBe('full response');
+    });
+  });
+});

--- a/src/Content/Presentation/Presentation.Dashboard/src/hooks/__tests__/useAgentStream.test.ts
+++ b/src/Content/Presentation/Presentation.Dashboard/src/hooks/__tests__/useAgentStream.test.ts
@@ -1,0 +1,67 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { useAgentStream } from '../useAgentStream';
+import { useChatStore } from '@/stores/chatStore';
+
+const mocks = vi.hoisted(() => ({
+  createAgent: vi.fn(),
+}));
+
+vi.mock('@/lib/agUiClient', () => ({
+  createAuthenticatedAgUiAgent: mocks.createAgent,
+}));
+
+vi.mock('@azure/msal-react', () => ({
+  useMsal: () => ({ instance: { getAllAccounts: () => [], acquireTokenSilent: vi.fn() } }),
+}));
+
+vi.mock('@/auth/authConfig', () => ({ loginRequest: { scopes: [] } }));
+vi.mock('@/auth/devAuth', () => ({ IS_AUTH_DISABLED: true }));
+
+describe('useAgentStream', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useChatStore.setState({
+      conversationId: null,
+      messages: [],
+      isStreaming: false,
+      streamingContent: '',
+      error: null,
+    });
+  });
+
+  it('clears the streaming flag and surfaces an error when agent construction fails', async () => {
+    mocks.createAgent.mockRejectedValue(new Error('boom'));
+    const { result } = renderHook(() => useAgentStream());
+
+    act(() => {
+      result.current.sendMessage('conv-1', 'msg-1', 'hello');
+    });
+
+    // Streaming is set optimistically before the async agent build.
+    expect(useChatStore.getState().isStreaming).toBe(true);
+
+    // The .catch must clear it once construction rejects (regression for the
+    // stuck-streaming footgun fixed in this PR).
+    await waitFor(() => expect(useChatStore.getState().isStreaming).toBe(false));
+    expect(useChatStore.getState().error).toBe('boom');
+  });
+
+  it('does not surface an error from a superseded run', async () => {
+    let rejectFirst!: (e: Error) => void;
+    mocks.createAgent
+      .mockImplementationOnce(() => new Promise((_, reject) => { rejectFirst = reject; }))
+      .mockImplementationOnce(() => new Promise(() => { /* second run stays pending */ }));
+
+    const { result } = renderHook(() => useAgentStream());
+
+    act(() => { result.current.sendMessage('conv-1', 'm1', 'first'); });
+    act(() => { result.current.sendMessage('conv-1', 'm2', 'second'); }); // bumps the run token
+
+    act(() => { rejectFirst(new Error('stale')); });
+    await act(async () => { await Promise.resolve(); });
+
+    // The first run was superseded, so its rejection must be swallowed.
+    expect(useChatStore.getState().error).not.toBe('stale');
+  });
+});

--- a/src/Content/Presentation/Presentation.Dashboard/src/hooks/__tests__/useAuth.test.ts
+++ b/src/Content/Presentation/Presentation.Dashboard/src/hooks/__tests__/useAuth.test.ts
@@ -1,0 +1,74 @@
+import { renderHook, act } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { InteractionRequiredAuthError } from '@azure/msal-browser';
+import { useAuth } from '../useAuth';
+
+const mocks = vi.hoisted(() => ({
+  acquireTokenSilent: vi.fn(),
+  acquireTokenPopup: vi.fn(),
+  logoutRedirect: vi.fn(),
+}));
+
+vi.mock('@azure/msal-react', () => ({
+  useMsal: () => ({
+    instance: {
+      acquireTokenSilent: mocks.acquireTokenSilent,
+      acquireTokenPopup: mocks.acquireTokenPopup,
+      logoutRedirect: mocks.logoutRedirect,
+    },
+    accounts: [{
+      username: 'test@example.com',
+      homeAccountId: '1',
+      environment: 'login.microsoftonline.com',
+      tenantId: 'tid',
+      localAccountId: 'lid',
+    }],
+  }),
+}));
+
+vi.mock('@/auth/authConfig', () => ({
+  loginRequest: { scopes: ['api://test-api/access_as_user'] },
+}));
+
+vi.mock('@/auth/devAuth', () => ({
+  IS_AUTH_DISABLED: false,
+  DEV_ACCOUNT: null,
+}));
+
+describe('useAuth', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('acquireToken returns token from acquireTokenSilent', async () => {
+    mocks.acquireTokenSilent.mockResolvedValue({ accessToken: 'silent-token' });
+
+    const { result } = renderHook(() => useAuth());
+
+    let token!: string;
+    await act(async () => {
+      token = await result.current.acquireToken();
+    });
+
+    expect(token).toBe('silent-token');
+    expect(mocks.acquireTokenSilent).toHaveBeenCalledOnce();
+    expect(mocks.acquireTokenPopup).not.toHaveBeenCalled();
+  });
+
+  it('acquireToken falls back to acquireTokenPopup on InteractionRequiredAuthError', async () => {
+    mocks.acquireTokenSilent.mockRejectedValue(
+      new InteractionRequiredAuthError('interaction_required'),
+    );
+    mocks.acquireTokenPopup.mockResolvedValue({ accessToken: 'popup-token' });
+
+    const { result } = renderHook(() => useAuth());
+
+    let token!: string;
+    await act(async () => {
+      token = await result.current.acquireToken();
+    });
+
+    expect(token).toBe('popup-token');
+    expect(mocks.acquireTokenPopup).toHaveBeenCalledOnce();
+  });
+});

--- a/src/Content/Presentation/Presentation.Dashboard/src/hooks/useAgentStream.ts
+++ b/src/Content/Presentation/Presentation.Dashboard/src/hooks/useAgentStream.ts
@@ -16,6 +16,10 @@ export interface UseAgentStreamReturn {
 export function useAgentStream(): UseAgentStreamReturn {
   const { instance } = useMsal();
   const subscriptionRef = useRef<Subscription | null>(null);
+  // Monotonic run token: a newer sendMessage() (or abort()) bumps it, so an
+  // older in-flight agent-construction promise sees it was superseded and tears
+  // its subscription down instead of leaking it.
+  const runIdRef = useRef(0);
 
   const getAccessToken = async (): Promise<string> => {
     if (IS_AUTH_DISABLED) return '';
@@ -26,12 +30,14 @@ export function useAgentStream(): UseAgentStreamReturn {
   };
 
   const abort = (): void => {
+    runIdRef.current += 1;
     subscriptionRef.current?.unsubscribe();
     subscriptionRef.current = null;
   };
 
   const sendMessage = (conversationId: string, userMessageId: string, message: string): void => {
     abort();
+    const myRun = runIdRef.current;
 
     const chatStore = useChatStore.getState();
     chatStore.startStreaming();
@@ -39,6 +45,8 @@ export function useAgentStream(): UseAgentStreamReturn {
     let currentMessageId: string | null = null;
 
     void createAuthenticatedAgUiAgent(getAccessToken).then((agent) => {
+      if (myRun !== runIdRef.current) return; // superseded before the agent was ready
+
       const obs$ = agent.run({
         threadId: conversationId,
         runId: crypto.randomUUID(),
@@ -54,7 +62,7 @@ export function useAgentStream(): UseAgentStreamReturn {
         forwardedProps: {},
       });
 
-      subscriptionRef.current = obs$.subscribe({
+      const sub = obs$.subscribe({
         next: (event: BaseEvent) => {
           switch (event.type) {
             case EventType.TEXT_MESSAGE_START: {
@@ -91,6 +99,14 @@ export function useAgentStream(): UseAgentStreamReturn {
           subscriptionRef.current = null;
         },
       });
+
+      // A newer send (or abort) ran while we awaited agent construction —
+      // discard this subscription so it cannot leak past its successor.
+      if (myRun !== runIdRef.current) {
+        sub.unsubscribe();
+        return;
+      }
+      subscriptionRef.current = sub;
     });
   };
 

--- a/src/Content/Presentation/Presentation.Dashboard/src/hooks/useAgentStream.ts
+++ b/src/Content/Presentation/Presentation.Dashboard/src/hooks/useAgentStream.ts
@@ -107,6 +107,13 @@ export function useAgentStream(): UseAgentStreamReturn {
         return;
       }
       subscriptionRef.current = sub;
+    }).catch((err: unknown) => {
+      // Agent construction (or a synchronous throw in agent.run) failed — clear
+      // the streaming flag the current run optimistically set, so the UI does
+      // not stick in a "streaming" state. Ignore if already superseded.
+      if (myRun !== runIdRef.current) return;
+      const message = err instanceof Error ? err.message : 'Failed to start the agent stream';
+      useChatStore.getState().setError(message);
     });
   };
 

--- a/src/Content/Presentation/Presentation.Dashboard/src/test/setup.ts
+++ b/src/Content/Presentation/Presentation.Dashboard/src/test/setup.ts
@@ -20,6 +20,9 @@ if (typeof window !== 'undefined') {
     unobserve() {}
     disconnect() {}
   };
+
+  // jsdom does not implement scrollIntoView; the chat message list calls it.
+  Element.prototype.scrollIntoView ??= () => {};
 }
 
 beforeAll(() => server.listen({ onUnhandledRequest: 'bypass' }));

--- a/src/Content/Presentation/Presentation.Dashboard/src/test/setup.ts
+++ b/src/Content/Presentation/Presentation.Dashboard/src/test/setup.ts
@@ -23,6 +23,9 @@ if (typeof window !== 'undefined') {
 
   // jsdom does not implement scrollIntoView; the chat message list calls it.
   Element.prototype.scrollIntoView ??= () => {};
+
+  // jsdom lacks the Web Animations API that Radix (ScrollArea/Tooltip) probes.
+  Element.prototype.getAnimations ??= () => [];
 }
 
 beforeAll(() => server.listen({ onUnhandledRequest: 'bypass' }));

--- a/src/Content/Presentation/Presentation.Dashboard/src/test/utils.tsx
+++ b/src/Content/Presentation/Presentation.Dashboard/src/test/utils.tsx
@@ -1,0 +1,43 @@
+import { render, type RenderOptions } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
+import type { ReactElement, ReactNode } from 'react';
+import { TooltipProvider } from '@/components/ui/tooltip';
+
+function createTestQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+}
+
+interface RenderWithProvidersOptions extends Omit<RenderOptions, 'wrapper'> {
+  route?: string;
+}
+
+/**
+ * Renders a component inside the providers the chat surface needs at test time:
+ * an in-memory router, a no-retry QueryClient, and the tooltip provider. Theme
+ * is applied imperatively via the Dashboard's `themeStore` (no context
+ * provider), so none is wrapped here.
+ */
+export function renderWithProviders(
+  ui: ReactElement,
+  { route = '/', ...renderOptions }: RenderWithProvidersOptions = {},
+) {
+  const testQueryClient = createTestQueryClient();
+
+  function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <MemoryRouter initialEntries={[route]}>
+        <QueryClientProvider client={testQueryClient}>
+          <TooltipProvider>{children}</TooltipProvider>
+        </QueryClientProvider>
+      </MemoryRouter>
+    );
+  }
+
+  return render(ui, { wrapper: Wrapper, ...renderOptions });
+}


### PR DESCRIPTION
## What & why

Activates the chat surface ported (inert) in #104, so the Dashboard is now the
single frontend for **both** observability and agent interaction. This is the
behavioral half of the WebUI→Dashboard merge.

No backend changes — uses the existing `/ag-ui/run` SSE endpoint, `/hubs/agent`
SignalR hub, and REST API.

Plan: `.claude/plans/sprightly-gliding-rabbit.md`.

## Changes

**Activation (`284b748d`)**
- New `ChatShell` layout for `/agent/*`: shares the Dashboard `Sidebar`, adds a
  chat-specific header (SignalR connection badge + theme toggle), mounts
  `AgentHubProvider` **only here** (observability pages keep no idle agent
  connection), and defaults the active agent to the first available one.
- `router`: `/agent` group (chat, agents, tools, resources, prompts), namespaced
  to avoid the legacy `/tools → /quality/tools` redirect; named-export views via
  `.then(m => ({ default: m.X }))`.
- `App`: `TooltipProvider` hoisted to the root.
- `Sidebar`: new **Agent** nav group.

**PR #104 review follow-ups (in `284b748d`)**
- `ConversationSidebar.handleDelete` → `conversationSettingsStore.clear(id)` (no
  more orphaned per-conversation settings).
- `useAgentStream`: monotonic run-token guard so a rapid re-send can't leak the
  first stream.

**Tests (`22fa610d`)** — +67, all green
- Reconciled `renderWithProviders` (Router + no-retry QueryClient + Tooltip; no
  ThemeProvider — Dashboard themes via store), `scrollIntoView` stub.
- 7 chat component/store/util tests + 3 hub/auth tests (mock paths rewritten to
  canonical Dashboard modules).

**Review fix (`bdcb0762`)**
- `useAgentStream`: guarded `.catch` so a failed agent-stream start clears the
  streaming flag instead of sticking the UI.

## Verification

- `npm run build` (tsc + vite) — green
- `npm run lint` — 0 errors (1 benign react-hook-form `watch()` warning)
- `npm run test` — **420/420 pass**
- `gitnexus detect_changes` — 4 touched symbols (App, router consts, navGroups), 0 affected processes
- `/code-review` (high) + `/simplify` on the final commit: one real finding (the `.catch`), fixed; no quality findings.

**Manual E2E (recommended before merge):** start AgentHub + `npm run dev`, open `/agent/chat`, pick an agent, send a turn → confirm `/ag-ui/run` SSE streams and `/hubs/agent` connects; confirm telemetry pages still work and theme toggle restyles both surfaces.

## Follow-ups (deferred)
- PR4: retire `Presentation.WebUI` (slnx/esproj/scripts, delete project).
- Optional chat chrome not ported: command palette (Cmd+K), AI-provider banner, `s` sidebar shortcut. The unwired `CommandPalette` carries a known group-ordering bug to fix if/when it's mounted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)