### PR TITLE
feat: embedded dashboard agent that acts + generative charts

### DIFF
--- a/agents/dashboard-agent/AGENT.md
+++ b/agents/dashboard-agent/AGENT.md
@@ -1,7 +1,7 @@
 ---
 id: dashboard-agent
 name: Dashboard Agent
-description: Conversational agent embedded in the observability dashboard that reads the current view and acts on it (time range, navigation, refresh) and can list available metrics.
+description: Conversational agent embedded in the observability dashboard that reads the current view and acts on it (time range, navigation, refresh), lists available metrics, and renders charts inline in its answers.
 domain: observability
 category: observability
 version: 1.0.0
@@ -14,8 +14,8 @@ skill: dashboard-agent
 
 The agent behind the embedded dashboard chat panel. It answers questions about the observability
 dashboard and acts on it for the user — changing the time range, navigating between pages, and
-refreshing data — using the `dashboard_control` tool, and can enumerate the available metrics with
-`list_metrics`.
+refreshing data — using the `dashboard_control` tool, enumerates the available metrics with
+`list_metrics`, and renders charts inline in its answers with `render_chart`.
 
 ## When to use
 

--- a/agents/dashboard-agent/AGENT.md
+++ b/agents/dashboard-agent/AGENT.md
@@ -1,0 +1,26 @@
+---
+id: dashboard-agent
+name: Dashboard Agent
+description: Conversational agent embedded in the observability dashboard that reads the current view and acts on it (time range, navigation, refresh) and can list available metrics.
+domain: observability
+category: observability
+version: 1.0.0
+author: Microsoft Agentic Harness
+tags: ["dashboard", "observability", "agui", "interactive"]
+skill: dashboard-agent
+---
+
+# Dashboard Agent
+
+The agent behind the embedded dashboard chat panel. It answers questions about the observability
+dashboard and acts on it for the user — changing the time range, navigating between pages, and
+refreshing data — using the `dashboard_control` tool, and can enumerate the available metrics with
+`list_metrics`.
+
+## When to use
+
+- As the agent bound to conversations created by the dashboard's agent panel.
+- Anywhere a chat surface needs to both read and manipulate the live dashboard view via AG-UI
+  client round-trip tool calls.
+
+The companion skill (`skills/dashboard-agent/SKILL.md`) defines the tool contracts and usage patterns.

--- a/skills/dashboard-agent/SKILL.md
+++ b/skills/dashboard-agent/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: "dashboard-agent"
+description: "Conversational agent embedded in the observability dashboard. Reads the current view and acts on it — changes the time range, navigates between pages, and refreshes data — and can list the available metrics."
+category: "observability"
+skill_type: "agent"
+version: "1.0.0"
+tags: ["dashboard", "observability", "agui", "interactive"]
+allowed-tools: ["dashboard_control", "list_metrics"]
+tools:
+  - name: "dashboard_control"
+    operations: ["get_state", "set_time_range", "navigate", "refresh_data"]
+    optional: false
+    description: "Read and act on the user's live dashboard view"
+  - name: "list_metrics"
+    operations: ["list"]
+    optional: false
+    description: "Enumerate the available dashboard metrics"
+---
+
+You are the Dashboard Agent, embedded directly in the user's observability dashboard. You help the
+user understand and operate the dashboard by answering questions about what they're looking at and by
+acting on the view on their behalf.
+
+## Tools
+
+### `dashboard_control` — read and act on the live view
+The action runs in the user's browser and returns a short result. Operations:
+
+- `get_state` — read the current page, selected time range, and theme. **Call this first** whenever
+  the user's request depends on where they are or what range is selected (e.g. "what am I looking at?",
+  "show me the last day" — you need to know the current page).
+- `set_time_range` — change the dashboard time range. Pass either a `preset` (e.g. `"24h"`, `"7d"`,
+  `"1h"`, `"30d"`) or a custom `from`/`to` (ISO-8601 timestamps).
+- `navigate` — go to a dashboard page. Pass a `path` (e.g. `"/spend"`, `"/tokens"`, `"/overview"`).
+- `refresh_data` — re-fetch the data for the current view.
+
+### `list_metrics` — discover available metrics
+Returns the catalog of metrics (id, title, description, chart type, unit, category). Use it to ground
+your answers in metrics that actually exist before describing or charting them. You may pass an optional
+`category` (e.g. `"cost"`, `"tokens"`, `"tools"`) to filter.
+
+## How to work
+
+1. If the request depends on the current view, call `get_state` before acting.
+2. Take the smallest set of actions that satisfies the request. For "show me the last 24 hours on the
+   spend page," that is `navigate` to the spend page **and** `set_time_range` to `24h`.
+3. After acting, briefly confirm what you did in plain language ("Switched to the Spend page and set the
+   range to the last 24 hours.").
+4. If an action fails (for example, no dashboard is connected), say so plainly and do not pretend it
+   succeeded.
+
+Be concise. The user is looking at the dashboard while talking to you — short, direct confirmations are
+better than long explanations.

--- a/skills/dashboard-agent/SKILL.md
+++ b/skills/dashboard-agent/SKILL.md
@@ -5,7 +5,7 @@ category: "observability"
 skill_type: "agent"
 version: "1.0.0"
 tags: ["dashboard", "observability", "agui", "interactive"]
-allowed-tools: ["dashboard_control", "list_metrics"]
+allowed-tools: ["dashboard_control", "list_metrics", "render_chart"]
 tools:
   - name: "dashboard_control"
     operations: ["get_state", "set_time_range", "navigate", "refresh_data"]
@@ -15,6 +15,10 @@ tools:
     operations: ["list"]
     optional: false
     description: "Enumerate the available dashboard metrics"
+  - name: "render_chart"
+    operations: ["render"]
+    optional: false
+    description: "Render a chart inline in the answer from a metric"
 ---
 
 You are the Dashboard Agent, embedded directly in the user's observability dashboard. You help the
@@ -38,6 +42,13 @@ The action runs in the user's browser and returns a short result. Operations:
 Returns the catalog of metrics (id, title, description, chart type, unit, category). Use it to ground
 your answers in metrics that actually exist before describing or charting them. You may pass an optional
 `category` (e.g. `"cost"`, `"tokens"`, `"tools"`) to filter.
+
+### `render_chart` — draw a chart inline in your answer
+Renders a chart directly in the chat from a metric. Provide a `metricId` from `list_metrics` (preferred)
+or a raw `promQL` query, optionally a `chartType` (`"timeseries"`, `"bar"`, `"pie"`) and a `title`. It
+returns a short data summary you can narrate. The chart uses the dashboard's current time range — call
+`set_time_range` first if the user wants a different window. Prefer this over describing numbers in prose
+when the user asks to "show", "chart", "graph", or "plot" a metric.
 
 ## How to work
 

--- a/src/Content/Application/Application.AI.Common/Interfaces/Observability/IMetricCatalog.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Observability/IMetricCatalog.cs
@@ -1,0 +1,38 @@
+namespace Application.AI.Common.Interfaces.Observability;
+
+/// <summary>
+/// Read-only access to the curated catalog of dashboard metric panels, exposed as a
+/// framework-independent seam so tools and services in any layer can enumerate the valid
+/// metrics without depending on the Presentation-layer dashboard DTOs.
+/// </summary>
+/// <remarks>
+/// The authoritative catalog data lives with the dashboard it drives (Presentation layer); this
+/// interface projects it to a neutral <see cref="MetricDescriptor"/> shape. There is a single
+/// source of truth — the implementation reads the same catalog the dashboard renders, so a tool
+/// that lists metrics and the dashboard that displays them can never drift apart.
+/// </remarks>
+public interface IMetricCatalog
+{
+    /// <summary>Gets all curated metric panel descriptors, ordered as the dashboard groups them.</summary>
+    IReadOnlyList<MetricDescriptor> Entries { get; }
+}
+
+/// <summary>
+/// A neutral description of one curated metric panel: enough for an agent to choose a metric and
+/// reason about it, without the Presentation-specific rendering fields.
+/// </summary>
+/// <param name="Id">Unique identifier (e.g. <c>"tokens_by_model"</c>).</param>
+/// <param name="Title">Human-readable panel title.</param>
+/// <param name="Description">Brief description of what the metric shows.</param>
+/// <param name="Query">The PromQL query backing the metric.</param>
+/// <param name="ChartType">Recommended chart type (e.g. <c>"stat"</c>, <c>"timeseries"</c>, <c>"pie"</c>).</param>
+/// <param name="Unit">Display unit (e.g. <c>"tokens"</c>, <c>"usd"</c>, <c>"ms"</c>, <c>"percent"</c>).</param>
+/// <param name="Category">Dashboard grouping (e.g. <c>"overview"</c>, <c>"tokens"</c>, <c>"cost"</c>).</param>
+public sealed record MetricDescriptor(
+    string Id,
+    string Title,
+    string Description,
+    string Query,
+    string ChartType,
+    string Unit,
+    string Category);

--- a/src/Content/Application/Application.AI.Common/Interfaces/Tools/IClientToolBridge.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Tools/IClientToolBridge.cs
@@ -1,0 +1,42 @@
+namespace Application.AI.Common.Interfaces.Tools;
+
+/// <summary>
+/// A bidirectional channel that lets a server-side tool delegate an action to the connected
+/// client UI mid-run and block until the client returns a result.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is the framework-independent seam behind the AG-UI "blocking proxy" pattern: a tool such
+/// as <c>dashboard_control</c> calls <see cref="InvokeAsync"/>, the transport implementation emits
+/// the appropriate client-tool-call protocol events on the live run, parks awaiting the client's
+/// out-of-band reply, and resumes the same run with the result. The tool stays in the Infrastructure
+/// layer and depends only on this abstraction — it never references the AG-UI/SSE transport types,
+/// preserving Clean Architecture's dependency direction.
+/// </para>
+/// <para>
+/// When no client is attached (<see cref="IsClientAttached"/> is <c>false</c>), <see cref="InvokeAsync"/>
+/// throws <see cref="InvalidOperationException"/>; tools should surface that as a tool failure rather
+/// than letting it bubble. Implementations are expected to enforce a bounded timeout and to honor the
+/// supplied <see cref="System.Threading.CancellationToken"/> so a disconnected client never parks a run.
+/// </para>
+/// </remarks>
+public interface IClientToolBridge
+{
+    /// <summary>
+    /// Gets whether a client UI is currently attached to the active run and able to service a
+    /// round-trip tool call. <c>false</c> when the tool is invoked outside an interactive client run.
+    /// </summary>
+    bool IsClientAttached { get; }
+
+    /// <summary>
+    /// Delegates a tool invocation to the connected client and awaits its result.
+    /// </summary>
+    /// <param name="toolName">The client-facing tool name (e.g. <c>dashboard_control</c>).</param>
+    /// <param name="argumentsJson">The tool arguments serialized as a JSON object.</param>
+    /// <param name="cancellationToken">Cancelled when the owning run is cancelled.</param>
+    /// <returns>The client-supplied result payload (typically a short JSON or text summary).</returns>
+    /// <exception cref="InvalidOperationException">No client is attached to the active run.</exception>
+    /// <exception cref="TimeoutException">The client did not respond within the bounded timeout.</exception>
+    /// <exception cref="OperationCanceledException">The run was cancelled before a result arrived.</exception>
+    Task<string> InvokeAsync(string toolName, string argumentsJson, CancellationToken cancellationToken = default);
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.Tools.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.Tools.cs
@@ -1,4 +1,5 @@
 using Application.AI.Common.Interfaces;
+using Application.AI.Common.Interfaces.Observability;
 using Application.AI.Common.Interfaces.RAG;
 using Application.AI.Common.Interfaces.Tools;
 using Azure.AI.Agents.Persistent;
@@ -68,6 +69,18 @@ public static partial class DependencyInjection
             new DelegateToSubagentTool(
                 sp.GetRequiredService<Application.AI.Common.Interfaces.Agents.ISupervisor>(),
                 sp.GetRequiredService<ILogger<DelegateToSubagentTool>>()));
+
+        // Dashboard control tool — acts on the connected dashboard UI (read view, set time range,
+        // navigate, refresh) via a mid-run client round-trip through IClientToolBridge. The bridge
+        // implementation is supplied by the Presentation host (AG-UI); absent it, the tool fails
+        // gracefully ("no client attached"). Opt-in per skill via SKILL.md allowed-tools.
+        services.AddKeyedSingleton<ITool>(DashboardControlTool.ToolName, (sp, _) =>
+            new DashboardControlTool(sp.GetRequiredService<IClientToolBridge>()));
+
+        // List-metrics tool — enumerates the curated dashboard metric catalog (shared source) so the
+        // agent can pick a valid metric. Read-only, non-blocking. Opt-in per skill via allowed-tools.
+        services.AddKeyedSingleton<ITool>(ListMetricsTool.ToolName, (sp, _) =>
+            new ListMetricsTool(sp.GetRequiredService<IMetricCatalog>()));
     }
 
     /// <summary>

--- a/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.Tools.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.Tools.cs
@@ -81,6 +81,12 @@ public static partial class DependencyInjection
         // agent can pick a valid metric. Read-only, non-blocking. Opt-in per skill via allowed-tools.
         services.AddKeyedSingleton<ITool>(ListMetricsTool.ToolName, (sp, _) =>
             new ListMetricsTool(sp.GetRequiredService<IMetricCatalog>()));
+
+        // Render-chart tool — generative UI: the agent renders a chart inline in its answer via the
+        // same client round-trip bridge as dashboard_control. The browser draws an existing chart
+        // component from a metric and returns a short summary. Opt-in per skill via allowed-tools.
+        services.AddKeyedSingleton<ITool>(RenderChartTool.ToolName, (sp, _) =>
+            new RenderChartTool(sp.GetRequiredService<IClientToolBridge>()));
     }
 
     /// <summary>

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/BlockingProxyTool.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/BlockingProxyTool.cs
@@ -49,6 +49,11 @@ public abstract class BlockingProxyTool : ITool
     /// <summary>Client round-trip tools read/act on the live view; low intrinsic blast radius.</summary>
     public virtual BlastRadius RiskTier => BlastRadius.Low;
 
+    // IsReadOnly / IsConcurrencySafe intentionally keep the fail-closed defaults (false): the
+    // concurrency classifier then serializes these view-mutating proxy calls, which is the desired
+    // behaviour (two simultaneous navigations would race). AgUiEventWriter additionally serializes
+    // frame writes to defend against the framework's own concurrent function invocation.
+
     /// <summary>Whether a client is currently attached and able to service the round-trip.</summary>
     protected bool IsClientAttached => _bridge.IsClientAttached;
 

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/BlockingProxyTool.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/BlockingProxyTool.cs
@@ -1,0 +1,86 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Application.AI.Common.Interfaces.Tools;
+using Domain.AI.Changes;
+using Domain.AI.Models;
+
+namespace Infrastructure.AI.Tools;
+
+/// <summary>
+/// Base class for "blocking proxy" tools — server-side tools whose effect is carried out by the
+/// connected client mid-run. A subclass validates its operation and shapes a JSON argument payload;
+/// this base owns the shared round-trip plumbing: the client-attached check, JSON options, and the
+/// mapping of an <see cref="IClientToolBridge"/> call to a <see cref="ToolResult"/>.
+/// </summary>
+/// <remarks>
+/// The bridge emits the AG-UI <c>TOOL_CALL_*</c> events, blocks awaiting the browser's reply, and
+/// resumes the same run with it (see <c>AgUiClientToolBridge</c>). Subclasses such as
+/// <c>DashboardControlTool</c> and <c>RenderChartTool</c> differ only in their operation set and the
+/// shape of the payload they send.
+/// </remarks>
+public abstract class BlockingProxyTool : ITool
+{
+    /// <summary>Shared serializer options for the argument payload sent to the client.</summary>
+    protected static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    private readonly IClientToolBridge _bridge;
+
+    /// <summary>Initializes the base with the client round-trip bridge.</summary>
+    /// <param name="bridge">The bridge used to delegate the operation to the browser.</param>
+    protected BlockingProxyTool(IClientToolBridge bridge)
+    {
+        ArgumentNullException.ThrowIfNull(bridge);
+        _bridge = bridge;
+    }
+
+    /// <inheritdoc />
+    public abstract string Name { get; }
+
+    /// <inheritdoc />
+    public abstract string Description { get; }
+
+    /// <inheritdoc />
+    public abstract IReadOnlyList<string> SupportedOperations { get; }
+
+    /// <summary>Client round-trip tools read/act on the live view; low intrinsic blast radius.</summary>
+    public virtual BlastRadius RiskTier => BlastRadius.Low;
+
+    /// <summary>Whether a client is currently attached and able to service the round-trip.</summary>
+    protected bool IsClientAttached => _bridge.IsClientAttached;
+
+    /// <summary>
+    /// Delegates <paramref name="argumentsJson"/> to the connected client and maps the outcome to a
+    /// <see cref="ToolResult"/>: success → <see cref="ToolResult.Ok"/>; a bounded-timeout → a failure
+    /// carrying <paramref name="timeoutMessage"/>; a no-client race (the bridge throwing
+    /// <see cref="InvalidOperationException"/>) → a failure carrying that message.
+    /// <see cref="OperationCanceledException"/> is intentionally allowed to propagate so a cancelled
+    /// run unwinds rather than being reported as a benign tool failure.
+    /// </summary>
+    protected async Task<ToolResult> InvokeClientAsync(
+        string argumentsJson, string timeoutMessage, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var result = await _bridge.InvokeAsync(Name, argumentsJson, cancellationToken);
+            return ToolResult.Ok(result);
+        }
+        catch (TimeoutException)
+        {
+            return ToolResult.Fail(timeoutMessage);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return ToolResult.Fail(ex.Message);
+        }
+    }
+
+    /// <inheritdoc />
+    public abstract Task<ToolResult> ExecuteAsync(
+        string operation,
+        IReadOnlyDictionary<string, object?> parameters,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/DashboardControlTool.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/DashboardControlTool.cs
@@ -1,0 +1,110 @@
+using System.Text.Json;
+using Application.AI.Common.Interfaces.Tools;
+using Domain.AI.Changes;
+using Domain.AI.Models;
+
+namespace Infrastructure.AI.Tools;
+
+/// <summary>
+/// Lets an agent act on the connected dashboard UI — read the current view, change the time range,
+/// navigate, or refresh data — by delegating each operation to the browser through an
+/// <see cref="IClientToolBridge"/> round-trip and returning the browser's result to the model.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is a server-defined, governed action set (deliberately not a browser-advertised dynamic tool):
+/// the operations are fixed and validated here, while the actual effect is carried out by the client
+/// that owns the dashboard state. The tool blocks for the duration of one client round-trip; the
+/// <see cref="IClientToolBridge"/> enforces the bounded timeout and honors run cancellation.
+/// </para>
+/// <para>
+/// Register via keyed DI:
+/// <code>
+/// services.AddKeyedSingleton&lt;ITool&gt;(DashboardControlTool.ToolName, (sp, _) =&gt;
+///     new DashboardControlTool(sp.GetRequiredService&lt;IClientToolBridge&gt;()));
+/// </code>
+/// </para>
+/// </remarks>
+public sealed class DashboardControlTool : ITool
+{
+    /// <summary>The tool name matching keyed DI registration and SKILL.md declarations.</summary>
+    public const string ToolName = "dashboard_control";
+
+    private const string GetState = "get_state";
+    private const string SetTimeRange = "set_time_range";
+    private const string Navigate = "navigate";
+    private const string RefreshData = "refresh_data";
+
+    private static readonly IReadOnlyList<string> Operations =
+        [GetState, SetTimeRange, Navigate, RefreshData];
+
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    private readonly IClientToolBridge _bridge;
+
+    /// <summary>Initializes a new instance of the <see cref="DashboardControlTool"/> class.</summary>
+    /// <param name="bridge">The client round-trip bridge used to delegate operations to the browser.</param>
+    public DashboardControlTool(IClientToolBridge bridge)
+    {
+        ArgumentNullException.ThrowIfNull(bridge);
+        _bridge = bridge;
+    }
+
+    /// <inheritdoc />
+    public string Name => ToolName;
+
+    /// <inheritdoc />
+    public string Description =>
+        "Acts on the user's live dashboard: read the current view (get_state), change the time range " +
+        "(set_time_range with a preset like '24h'/'7d' or a custom from/to), navigate to a page " +
+        "(navigate with a path), or refresh the current data (refresh_data). The action runs in the " +
+        "user's browser and returns a short result.";
+
+    /// <inheritdoc />
+    public IReadOnlyList<string> SupportedOperations => Operations;
+
+    /// <summary><c>get_state</c> only reads; the tool as a whole can change the view, so it is not globally read-only.</summary>
+    public BlastRadius RiskTier => BlastRadius.Low;
+
+    /// <inheritdoc />
+    public async Task<ToolResult> ExecuteAsync(
+        string operation,
+        IReadOnlyDictionary<string, object?> parameters,
+        CancellationToken cancellationToken = default)
+    {
+        var op = operation?.ToLowerInvariant();
+        if (op is null || !Operations.Contains(op))
+            return ToolResult.Fail($"Unknown operation: {operation}. Supported: {string.Join(", ", Operations)}");
+
+        if (!_bridge.IsClientAttached)
+            return ToolResult.Fail("No dashboard client is connected to this conversation, so the view cannot be controlled.");
+
+        var argumentsJson = JsonSerializer.Serialize(
+            new DashboardControlPayload(op, parameters), SerializerOptions);
+
+        try
+        {
+            var result = await _bridge.InvokeAsync(ToolName, argumentsJson, cancellationToken);
+            return ToolResult.Ok(result);
+        }
+        catch (TimeoutException)
+        {
+            return ToolResult.Fail("The dashboard did not respond in time; the action may not have been applied.");
+        }
+        catch (InvalidOperationException ex)
+        {
+            // Raised by the bridge when no client is attached (race after the IsClientAttached check).
+            return ToolResult.Fail(ex.Message);
+        }
+        // OperationCanceledException is intentionally NOT caught: a cancelled run must unwind.
+    }
+
+    /// <summary>The wire payload posted to the browser: the operation plus its raw parameters.</summary>
+    private sealed record DashboardControlPayload(
+        string Operation,
+        IReadOnlyDictionary<string, object?> Parameters);
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/DashboardControlTool.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/DashboardControlTool.cs
@@ -1,6 +1,5 @@
 using System.Text.Json;
 using Application.AI.Common.Interfaces.Tools;
-using Domain.AI.Changes;
 using Domain.AI.Models;
 
 namespace Infrastructure.AI.Tools;
@@ -25,7 +24,7 @@ namespace Infrastructure.AI.Tools;
 /// </code>
 /// </para>
 /// </remarks>
-public sealed class DashboardControlTool : ITool
+public sealed class DashboardControlTool : BlockingProxyTool
 {
     /// <summary>The tool name matching keyed DI registration and SKILL.md declarations.</summary>
     public const string ToolName = "dashboard_control";
@@ -38,69 +37,44 @@ public sealed class DashboardControlTool : ITool
     private static readonly IReadOnlyList<string> Operations =
         [GetState, SetTimeRange, Navigate, RefreshData];
 
-    private static readonly JsonSerializerOptions SerializerOptions = new()
-    {
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
-    };
-
-    private readonly IClientToolBridge _bridge;
-
     /// <summary>Initializes a new instance of the <see cref="DashboardControlTool"/> class.</summary>
     /// <param name="bridge">The client round-trip bridge used to delegate operations to the browser.</param>
-    public DashboardControlTool(IClientToolBridge bridge)
+    public DashboardControlTool(IClientToolBridge bridge) : base(bridge)
     {
-        ArgumentNullException.ThrowIfNull(bridge);
-        _bridge = bridge;
     }
 
     /// <inheritdoc />
-    public string Name => ToolName;
+    public override string Name => ToolName;
 
     /// <inheritdoc />
-    public string Description =>
+    public override string Description =>
         "Acts on the user's live dashboard: read the current view (get_state), change the time range " +
         "(set_time_range with a preset like '24h'/'7d' or a custom from/to), navigate to a page " +
         "(navigate with a path), or refresh the current data (refresh_data). The action runs in the " +
         "user's browser and returns a short result.";
 
     /// <inheritdoc />
-    public IReadOnlyList<string> SupportedOperations => Operations;
-
-    /// <summary><c>get_state</c> only reads; the tool as a whole can change the view, so it is not globally read-only.</summary>
-    public BlastRadius RiskTier => BlastRadius.Low;
+    public override IReadOnlyList<string> SupportedOperations => Operations;
 
     /// <inheritdoc />
-    public async Task<ToolResult> ExecuteAsync(
+    public override Task<ToolResult> ExecuteAsync(
         string operation,
         IReadOnlyDictionary<string, object?> parameters,
         CancellationToken cancellationToken = default)
     {
         var op = operation?.ToLowerInvariant();
         if (op is null || !Operations.Contains(op))
-            return ToolResult.Fail($"Unknown operation: {operation}. Supported: {string.Join(", ", Operations)}");
+            return Task.FromResult(ToolResult.Fail($"Unknown operation: {operation}. Supported: {string.Join(", ", Operations)}"));
 
-        if (!_bridge.IsClientAttached)
-            return ToolResult.Fail("No dashboard client is connected to this conversation, so the view cannot be controlled.");
+        if (!IsClientAttached)
+            return Task.FromResult(ToolResult.Fail("No dashboard client is connected to this conversation, so the view cannot be controlled."));
 
-        var argumentsJson = JsonSerializer.Serialize(
-            new DashboardControlPayload(op, parameters), SerializerOptions);
+        var argumentsJson = JsonSerializer.Serialize(new DashboardControlPayload(op, parameters), SerializerOptions);
 
-        try
-        {
-            var result = await _bridge.InvokeAsync(ToolName, argumentsJson, cancellationToken);
-            return ToolResult.Ok(result);
-        }
-        catch (TimeoutException)
-        {
-            return ToolResult.Fail("The dashboard did not respond in time; the action may not have been applied.");
-        }
-        catch (InvalidOperationException ex)
-        {
-            // Raised by the bridge when no client is attached (race after the IsClientAttached check).
-            return ToolResult.Fail(ex.Message);
-        }
-        // OperationCanceledException is intentionally NOT caught: a cancelled run must unwind.
+        return InvokeClientAsync(
+            argumentsJson,
+            "The dashboard did not respond in time; the action may not have been applied.",
+            cancellationToken);
     }
 
     /// <summary>The wire payload posted to the browser: the operation plus its raw parameters.</summary>

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/ListMetricsTool.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/ListMetricsTool.cs
@@ -1,0 +1,91 @@
+using System.Text.Json;
+using Application.AI.Common.Interfaces.Observability;
+using Application.AI.Common.Interfaces.Tools;
+using Domain.AI.Changes;
+using Domain.AI.Models;
+
+namespace Infrastructure.AI.Tools;
+
+/// <summary>
+/// Returns the catalog of dashboard metrics (id, title, description, PromQL, chart type, unit,
+/// category) as JSON so an agent can choose a valid metric before charting or reasoning about it.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A read-only, non-blocking server-side tool. It reads the same curated catalog the dashboard
+/// renders via the <see cref="IMetricCatalog"/> seam, so the agent's notion of "available metrics"
+/// and the dashboard's panels share one source of truth.
+/// </para>
+/// <para>
+/// Register via keyed DI:
+/// <code>
+/// services.AddKeyedSingleton&lt;ITool&gt;(ListMetricsTool.ToolName, (sp, _) =&gt;
+///     new ListMetricsTool(sp.GetRequiredService&lt;IMetricCatalog&gt;()));
+/// </code>
+/// </para>
+/// </remarks>
+public sealed class ListMetricsTool : ITool
+{
+    /// <summary>The tool name matching keyed DI registration and SKILL.md declarations.</summary>
+    public const string ToolName = "list_metrics";
+
+    private const string List = "list";
+
+    private static readonly IReadOnlyList<string> Operations = [List];
+
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+    };
+
+    private readonly IMetricCatalog _catalog;
+
+    /// <summary>Initializes a new instance of the <see cref="ListMetricsTool"/> class.</summary>
+    /// <param name="catalog">The shared dashboard metric catalog.</param>
+    public ListMetricsTool(IMetricCatalog catalog)
+    {
+        ArgumentNullException.ThrowIfNull(catalog);
+        _catalog = catalog;
+    }
+
+    /// <inheritdoc />
+    public string Name => ToolName;
+
+    /// <inheritdoc />
+    public string Description =>
+        "Lists the available dashboard metrics (id, title, description, chart type, unit, category) " +
+        "so you can pick a valid metric to chart or discuss. Optionally filter by category.";
+
+    /// <inheritdoc />
+    public IReadOnlyList<string> SupportedOperations => Operations;
+
+    /// <inheritdoc />
+    public bool IsReadOnly => true;
+
+    /// <inheritdoc />
+    public bool IsConcurrencySafe => true;
+
+    /// <inheritdoc />
+    public BlastRadius RiskTier => BlastRadius.Trivial;
+
+    /// <inheritdoc />
+    public Task<ToolResult> ExecuteAsync(
+        string operation,
+        IReadOnlyDictionary<string, object?> parameters,
+        CancellationToken cancellationToken = default)
+    {
+        if (!string.Equals(operation, List, StringComparison.OrdinalIgnoreCase))
+            return Task.FromResult(ToolResult.Fail($"Unknown operation: {operation}. Supported: {List}"));
+
+        var category = parameters.TryGetValue("category", out var value) && value is string s && !string.IsNullOrWhiteSpace(s)
+            ? s
+            : null;
+
+        var entries = category is null
+            ? _catalog.Entries
+            : _catalog.Entries.Where(e => string.Equals(e.Category, category, StringComparison.OrdinalIgnoreCase)).ToList();
+
+        var json = JsonSerializer.Serialize(entries, SerializerOptions);
+        return Task.FromResult(ToolResult.Ok(json));
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/RenderChartTool.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/RenderChartTool.cs
@@ -1,6 +1,5 @@
 using System.Text.Json;
 using Application.AI.Common.Interfaces.Tools;
-using Domain.AI.Changes;
 using Domain.AI.Models;
 
 namespace Infrastructure.AI.Tools;
@@ -26,7 +25,7 @@ namespace Infrastructure.AI.Tools;
 /// </code>
 /// </para>
 /// </remarks>
-public sealed class RenderChartTool : ITool
+public sealed class RenderChartTool : BlockingProxyTool
 {
     /// <summary>The tool name matching keyed DI registration and SKILL.md declarations.</summary>
     public const string ToolName = "render_chart";
@@ -35,27 +34,17 @@ public sealed class RenderChartTool : ITool
 
     private static readonly IReadOnlyList<string> Operations = [Render];
 
-    private static readonly JsonSerializerOptions SerializerOptions = new()
-    {
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
-    };
-
-    private readonly IClientToolBridge _bridge;
-
     /// <summary>Initializes a new instance of the <see cref="RenderChartTool"/> class.</summary>
     /// <param name="bridge">The client round-trip bridge used to delegate rendering to the browser.</param>
-    public RenderChartTool(IClientToolBridge bridge)
+    public RenderChartTool(IClientToolBridge bridge) : base(bridge)
     {
-        ArgumentNullException.ThrowIfNull(bridge);
-        _bridge = bridge;
     }
 
     /// <inheritdoc />
-    public string Name => ToolName;
+    public override string Name => ToolName;
 
     /// <inheritdoc />
-    public string Description =>
+    public override string Description =>
         "Renders a chart inline in your answer from the dashboard's metrics. Operation: render. " +
         "Provide either a metricId from list_metrics (preferred) or a raw promQL query. " +
         "Parameters: metricId (string, optional — a metric id such as 'tokens_by_model'); " +
@@ -65,42 +54,26 @@ public sealed class RenderChartTool : ITool
         "time range, so call set_time_range first if a different window is needed.";
 
     /// <inheritdoc />
-    public IReadOnlyList<string> SupportedOperations => Operations;
-
-    /// <summary>Reads metric data and renders UI; low blast radius (no state mutation).</summary>
-    public BlastRadius RiskTier => BlastRadius.Low;
+    public override IReadOnlyList<string> SupportedOperations => Operations;
 
     /// <inheritdoc />
-    public async Task<ToolResult> ExecuteAsync(
+    public override Task<ToolResult> ExecuteAsync(
         string operation,
         IReadOnlyDictionary<string, object?> parameters,
         CancellationToken cancellationToken = default)
     {
         if (!string.Equals(operation, Render, StringComparison.OrdinalIgnoreCase))
-            return ToolResult.Fail($"Unknown operation: {operation}. Supported: {Render}");
+            return Task.FromResult(ToolResult.Fail($"Unknown operation: {operation}. Supported: {Render}"));
 
-        if (!_bridge.IsClientAttached)
-            return ToolResult.Fail("No dashboard client is connected to this conversation, so a chart cannot be rendered.");
+        if (!IsClientAttached)
+            return Task.FromResult(ToolResult.Fail("No dashboard client is connected to this conversation, so a chart cannot be rendered."));
 
         var hasMetric = parameters.ContainsKey("metricId") || parameters.ContainsKey("promQL");
         if (!hasMetric)
-            return ToolResult.Fail("Provide a metricId (from list_metrics) or a promQL query to chart.");
+            return Task.FromResult(ToolResult.Fail("Provide a metricId (from list_metrics) or a promQL query to chart."));
 
         var argumentsJson = JsonSerializer.Serialize(parameters, SerializerOptions);
 
-        try
-        {
-            var result = await _bridge.InvokeAsync(ToolName, argumentsJson, cancellationToken);
-            return ToolResult.Ok(result);
-        }
-        catch (TimeoutException)
-        {
-            return ToolResult.Fail("The dashboard did not render the chart in time.");
-        }
-        catch (InvalidOperationException ex)
-        {
-            return ToolResult.Fail(ex.Message);
-        }
-        // OperationCanceledException intentionally propagates so a cancelled run unwinds.
+        return InvokeClientAsync(argumentsJson, "The dashboard did not render the chart in time.", cancellationToken);
     }
 }

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/RenderChartTool.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/RenderChartTool.cs
@@ -1,0 +1,106 @@
+using System.Text.Json;
+using Application.AI.Common.Interfaces.Tools;
+using Domain.AI.Changes;
+using Domain.AI.Models;
+
+namespace Infrastructure.AI.Tools;
+
+/// <summary>
+/// Renders a chart inline in the agent's chat answer ("generative UI"): the agent picks <em>what</em>
+/// to chart, and the browser renders one of the dashboard's existing chart components populated via
+/// the existing Prometheus query path. The browser returns a short textual data summary so the agent
+/// can narrate what it drew.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A client round-trip tool using the same blocking-proxy mechanism as <see cref="DashboardControlTool"/>:
+/// it delegates the render to the connected browser via <see cref="IClientToolBridge"/> and returns the
+/// browser's summary. The chart itself never leaves the client; only the summary flows back to the model.
+/// Use <c>list_metrics</c> first to discover valid metric ids.
+/// </para>
+/// <para>
+/// Register via keyed DI:
+/// <code>
+/// services.AddKeyedSingleton&lt;ITool&gt;(RenderChartTool.ToolName, (sp, _) =&gt;
+///     new RenderChartTool(sp.GetRequiredService&lt;IClientToolBridge&gt;()));
+/// </code>
+/// </para>
+/// </remarks>
+public sealed class RenderChartTool : ITool
+{
+    /// <summary>The tool name matching keyed DI registration and SKILL.md declarations.</summary>
+    public const string ToolName = "render_chart";
+
+    private const string Render = "render";
+
+    private static readonly IReadOnlyList<string> Operations = [Render];
+
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    private readonly IClientToolBridge _bridge;
+
+    /// <summary>Initializes a new instance of the <see cref="RenderChartTool"/> class.</summary>
+    /// <param name="bridge">The client round-trip bridge used to delegate rendering to the browser.</param>
+    public RenderChartTool(IClientToolBridge bridge)
+    {
+        ArgumentNullException.ThrowIfNull(bridge);
+        _bridge = bridge;
+    }
+
+    /// <inheritdoc />
+    public string Name => ToolName;
+
+    /// <inheritdoc />
+    public string Description =>
+        "Renders a chart inline in your answer from the dashboard's metrics. Operation: render. " +
+        "Provide either a metricId from list_metrics (preferred) or a raw promQL query. " +
+        "Parameters: metricId (string, optional — a metric id such as 'tokens_by_model'); " +
+        "promQL (string, optional — a Prometheus query, used when no metricId is given); " +
+        "chartType (string, optional — 'timeseries', 'bar', or 'pie'; defaults to the metric's type); " +
+        "title (string, optional — a heading for the chart). The chart uses the dashboard's current " +
+        "time range, so call set_time_range first if a different window is needed.";
+
+    /// <inheritdoc />
+    public IReadOnlyList<string> SupportedOperations => Operations;
+
+    /// <summary>Reads metric data and renders UI; low blast radius (no state mutation).</summary>
+    public BlastRadius RiskTier => BlastRadius.Low;
+
+    /// <inheritdoc />
+    public async Task<ToolResult> ExecuteAsync(
+        string operation,
+        IReadOnlyDictionary<string, object?> parameters,
+        CancellationToken cancellationToken = default)
+    {
+        if (!string.Equals(operation, Render, StringComparison.OrdinalIgnoreCase))
+            return ToolResult.Fail($"Unknown operation: {operation}. Supported: {Render}");
+
+        if (!_bridge.IsClientAttached)
+            return ToolResult.Fail("No dashboard client is connected to this conversation, so a chart cannot be rendered.");
+
+        var hasMetric = parameters.ContainsKey("metricId") || parameters.ContainsKey("promQL");
+        if (!hasMetric)
+            return ToolResult.Fail("Provide a metricId (from list_metrics) or a promQL query to chart.");
+
+        var argumentsJson = JsonSerializer.Serialize(parameters, SerializerOptions);
+
+        try
+        {
+            var result = await _bridge.InvokeAsync(ToolName, argumentsJson, cancellationToken);
+            return ToolResult.Ok(result);
+        }
+        catch (TimeoutException)
+        {
+            return ToolResult.Fail("The dashboard did not render the chart in time.");
+        }
+        catch (InvalidOperationException ex)
+        {
+            return ToolResult.Fail(ex.Message);
+        }
+        // OperationCanceledException intentionally propagates so a cancelled run unwinds.
+    }
+}

--- a/src/Content/Presentation/Presentation.AgentHub/AgUi/AgUiClientToolBridge.cs
+++ b/src/Content/Presentation/Presentation.AgentHub/AgUi/AgUiClientToolBridge.cs
@@ -51,12 +51,16 @@ public sealed class AgUiClientToolBridge : IClientToolBridge
         var writer = _writerAccessor.Writer
             ?? throw new InvalidOperationException(
                 "No AG-UI client is attached to the current run; a client round-trip tool cannot be used here.");
+        var threadId = _writerAccessor.ThreadId
+            ?? throw new InvalidOperationException(
+                "The active AG-UI run has no thread id; a client round-trip tool cannot be used here.");
 
         var callId = Guid.NewGuid().ToString("N");
         var timeout = TimeSpan.FromSeconds(Math.Max(1, _config.CurrentValue.ClientToolTimeoutSeconds));
 
-        // Register before emitting events so a result can never race ahead of the pending entry.
-        var resultTask = _registry.RegisterAsync(callId, timeout, cancellationToken);
+        // Register (bound to the owning thread) before emitting events so a result can never race
+        // ahead of the pending entry, and so only a caller who owns this thread can complete it.
+        var resultTask = _registry.RegisterAsync(callId, threadId, timeout, cancellationToken);
 
         await writer.WriteAsync(new ToolCallStartEvent(callId, toolName), cancellationToken).ConfigureAwait(false);
         await writer.WriteAsync(new ToolCallArgsEvent(callId, argumentsJson ?? "{}"), cancellationToken).ConfigureAwait(false);

--- a/src/Content/Presentation/Presentation.AgentHub/AgUi/AgUiClientToolBridge.cs
+++ b/src/Content/Presentation/Presentation.AgentHub/AgUi/AgUiClientToolBridge.cs
@@ -1,0 +1,67 @@
+using Application.AI.Common.Interfaces.Tools;
+using Microsoft.Extensions.Options;
+using Presentation.AgentHub.Config;
+
+namespace Presentation.AgentHub.AgUi;
+
+/// <summary>
+/// AG-UI implementation of <see cref="IClientToolBridge"/>: the "blocking proxy" that turns a
+/// server-side tool invocation into a mid-run client round-trip over the live SSE stream.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The owning <see cref="AgUiRunHandler"/> stores the run's <see cref="IAgUiEventWriter"/> in an
+/// <see cref="IAgUiEventWriterAccessor"/> (an <c>AsyncLocal</c>) before dispatching the agent turn.
+/// Because the tool executes deep inside that same async context, this bridge reads the ambient
+/// writer to emit <see cref="ToolCallStartEvent"/>/<see cref="ToolCallArgsEvent"/>/<see cref="ToolCallEndEvent"/>
+/// frames, then parks on the <see cref="PendingToolCallRegistry"/> until the browser posts the result
+/// to <c>POST /ag-ui/tool-result</c> — all within the one run.
+/// </para>
+/// <para>
+/// Registered as a singleton: it holds no per-run state of its own (the writer is ambient and the
+/// pending map lives in the singleton registry), so a single instance safely serves concurrent runs.
+/// </para>
+/// </remarks>
+public sealed class AgUiClientToolBridge : IClientToolBridge
+{
+    private readonly IAgUiEventWriterAccessor _writerAccessor;
+    private readonly PendingToolCallRegistry _registry;
+    private readonly IOptionsMonitor<AgentHubConfig> _config;
+
+    /// <summary>Initializes a new <see cref="AgUiClientToolBridge"/>.</summary>
+    public AgUiClientToolBridge(
+        IAgUiEventWriterAccessor writerAccessor,
+        PendingToolCallRegistry registry,
+        IOptionsMonitor<AgentHubConfig> config)
+    {
+        _writerAccessor = writerAccessor;
+        _registry = registry;
+        _config = config;
+    }
+
+    /// <inheritdoc />
+    public bool IsClientAttached => _writerAccessor.Writer is not null;
+
+    /// <inheritdoc />
+    public async Task<string> InvokeAsync(
+        string toolName, string argumentsJson, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(toolName);
+
+        var writer = _writerAccessor.Writer
+            ?? throw new InvalidOperationException(
+                "No AG-UI client is attached to the current run; a client round-trip tool cannot be used here.");
+
+        var callId = Guid.NewGuid().ToString("N");
+        var timeout = TimeSpan.FromSeconds(Math.Max(1, _config.CurrentValue.ClientToolTimeoutSeconds));
+
+        // Register before emitting events so a result can never race ahead of the pending entry.
+        var resultTask = _registry.RegisterAsync(callId, timeout, cancellationToken);
+
+        await writer.WriteAsync(new ToolCallStartEvent(callId, toolName), cancellationToken).ConfigureAwait(false);
+        await writer.WriteAsync(new ToolCallArgsEvent(callId, argumentsJson ?? "{}"), cancellationToken).ConfigureAwait(false);
+        await writer.WriteAsync(new ToolCallEndEvent(callId), cancellationToken).ConfigureAwait(false);
+
+        return await resultTask.ConfigureAwait(false);
+    }
+}

--- a/src/Content/Presentation/Presentation.AgentHub/AgUi/AgUiEndpoints.cs
+++ b/src/Content/Presentation/Presentation.AgentHub/AgUi/AgUiEndpoints.cs
@@ -1,13 +1,17 @@
+using Presentation.AgentHub.Extensions;
+using Presentation.AgentHub.Interfaces;
+
 namespace Presentation.AgentHub.AgUi;
 
 /// <summary>
-/// Maps the AG-UI protocol SSE endpoint. Accepts a <see cref="RunAgentInput"/>
-/// via HTTP POST and streams the agent response as Server-Sent Events.
+/// Maps the AG-UI protocol SSE endpoints: the streaming run endpoint and the out-of-band
+/// tool-result resume endpoint that completes a mid-run client round-trip.
 /// </summary>
 public static class AgUiEndpoints
 {
     /// <summary>
-    /// Maps <c>POST /ag-ui/run</c> with authorization required.
+    /// Maps <c>POST /ag-ui/run</c> (streaming) and <c>POST /ag-ui/tool-result</c> (resume),
+    /// both with authorization required.
     /// </summary>
     public static IEndpointRouteBuilder MapAgUiEndpoints(this IEndpointRouteBuilder endpoints)
     {
@@ -16,6 +20,12 @@ public static class AgUiEndpoints
             .Accepts<RunAgentInput>("application/json")
             .WithName("AgUiRun")
             .WithDescription("AG-UI protocol streaming endpoint");
+
+        endpoints.MapPost("/ag-ui/tool-result", HandleToolResultAsync)
+            .RequireAuthorization()
+            .Accepts<ToolResultInput>("application/json")
+            .WithName("AgUiToolResult")
+            .WithDescription("Completes a mid-run AG-UI client round-trip tool call");
 
         return endpoints;
     }
@@ -44,4 +54,54 @@ public static class AgUiEndpoints
         var writer = new AgUiEventWriter(httpContext.Response.Body);
         await handler.HandleRunAsync(input, writer, httpContext.User, ct);
     }
+
+    /// <summary>
+    /// Completes a pending client round-trip tool call. The browser POSTs the result of an action it
+    /// performed in response to a <c>TOOL_CALL_*</c> sequence; this unblocks the server-side proxy
+    /// tool awaiting on the <see cref="PendingToolCallRegistry"/> and the agent run resumes.
+    /// </summary>
+    /// <remarks>
+    /// Ownership is enforced identically to the run endpoint: the caller must own the conversation
+    /// named by <see cref="ToolResultInput.ThreadId"/>. This prevents a user from completing — and
+    /// thereby injecting a tool result into — another user's in-flight run.
+    /// </remarks>
+    private static async Task<IResult> HandleToolResultAsync(
+        HttpContext httpContext,
+        ToolResultInput input,
+        IConversationStore conversationStore,
+        PendingToolCallRegistry registry,
+        CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(input.ThreadId) ||
+            string.IsNullOrWhiteSpace(input.CallId) ||
+            input.Result is null)
+        {
+            return Results.BadRequest(new { error = "threadId, callId, and result are required" });
+        }
+
+        var callerId = httpContext.User.GetUserIdOrNull();
+        if (callerId is null)
+            return Results.Unauthorized();
+
+        var record = await conversationStore.GetAsync(input.ThreadId, ct);
+        if (record is null)
+            return Results.NotFound(new { error = "Conversation not found." });
+
+        if (record.UserId != callerId)
+            return Results.Forbid();
+
+        // false ⇒ no call with this id is pending (already completed, timed out, or never existed).
+        return registry.TryComplete(input.CallId, input.Result)
+            ? Results.Ok()
+            : Results.NotFound(new { error = "No pending tool call with the supplied callId." });
+    }
 }
+
+/// <summary>
+/// Request body for <c>POST /ag-ui/tool-result</c>: the browser's result for a mid-run client
+/// round-trip tool call.
+/// </summary>
+/// <param name="ThreadId">The conversation the call belongs to (ownership is verified against it).</param>
+/// <param name="CallId">The <c>toolCallId</c> echoed from the <c>TOOL_CALL_START</c> event.</param>
+/// <param name="Result">The result payload the agent should observe (typically a short JSON/text summary).</param>
+public sealed record ToolResultInput(string ThreadId, string CallId, string Result);

--- a/src/Content/Presentation/Presentation.AgentHub/AgUi/AgUiEndpoints.cs
+++ b/src/Content/Presentation/Presentation.AgentHub/AgUi/AgUiEndpoints.cs
@@ -51,7 +51,7 @@ public static class AgUiEndpoints
         httpContext.Response.Headers.Connection = "keep-alive";
         httpContext.Response.Headers["X-Accel-Buffering"] = "no";
 
-        var writer = new AgUiEventWriter(httpContext.Response.Body);
+        using var writer = new AgUiEventWriter(httpContext.Response.Body);
         await handler.HandleRunAsync(input, writer, httpContext.User, ct);
     }
 
@@ -61,9 +61,11 @@ public static class AgUiEndpoints
     /// tool awaiting on the <see cref="PendingToolCallRegistry"/> and the agent run resumes.
     /// </summary>
     /// <remarks>
-    /// Ownership is enforced identically to the run endpoint: the caller must own the conversation
-    /// named by <see cref="ToolResultInput.ThreadId"/>. This prevents a user from completing — and
-    /// thereby injecting a tool result into — another user's in-flight run.
+    /// Ownership is enforced in depth: the caller must own the conversation named by
+    /// <see cref="ToolResultInput.ThreadId"/> (checked here), and the pending call must itself be bound
+    /// to that same thread (checked in <see cref="PendingToolCallRegistry.TryComplete"/>). Both must
+    /// hold, so a caller cannot inject a result into another user's in-flight run even if they learn its
+    /// <see cref="ToolResultInput.CallId"/>.
     /// </remarks>
     private static async Task<IResult> HandleToolResultAsync(
         HttpContext httpContext,
@@ -90,8 +92,9 @@ public static class AgUiEndpoints
         if (record.UserId != callerId)
             return Results.Forbid();
 
-        // false ⇒ no call with this id is pending (already completed, timed out, or never existed).
-        return registry.TryComplete(input.CallId, input.Result)
+        // false ⇒ no call with this id is pending for this thread (already completed, timed out, never
+        // existed, or registered under a different conversation).
+        return registry.TryComplete(input.CallId, input.ThreadId, input.Result)
             ? Results.Ok()
             : Results.NotFound(new { error = "No pending tool call with the supplied callId." });
     }

--- a/src/Content/Presentation/Presentation.AgentHub/AgUi/AgUiEventWriter.cs
+++ b/src/Content/Presentation/Presentation.AgentHub/AgUi/AgUiEventWriter.cs
@@ -35,7 +35,7 @@ public interface IAgUiEventWriter
 /// transfer delivers frames to the client without buffering.
 /// </para>
 /// </remarks>
-public sealed class AgUiEventWriter : IAgUiEventWriter
+public sealed class AgUiEventWriter : IAgUiEventWriter, IDisposable
 {
     private static readonly JsonSerializerOptions SerializerOptions = new()
     {
@@ -83,4 +83,7 @@ public sealed class AgUiEventWriter : IAgUiEventWriter
             _writeLock.Release();
         }
     }
+
+    /// <summary>Releases the write-serialization semaphore. The response stream is owned by the host.</summary>
+    public void Dispose() => _writeLock.Dispose();
 }

--- a/src/Content/Presentation/Presentation.AgentHub/AgUi/AgUiEventWriter.cs
+++ b/src/Content/Presentation/Presentation.AgentHub/AgUi/AgUiEventWriter.cs
@@ -45,6 +45,15 @@ public sealed class AgUiEventWriter : IAgUiEventWriter
 
     private readonly Stream _stream;
 
+    // Serializes frame writes. The agent runs tool calls concurrently
+    // (AgentFactory sets AllowConcurrentInvocation = true), and blocking-proxy tools emit
+    // TOOL_CALL_* frames from those concurrent invocations onto this same response body. Kestrel
+    // forbids concurrent response writes, so without this gate two in-flight tool calls would either
+    // throw or interleave bytes into an unparseable SSE frame. Each frame is written atomically;
+    // frames from different tool calls may still arrive in any order, which is fine because the client
+    // reassembles them by toolCallId.
+    private readonly SemaphoreSlim _writeLock = new(1, 1);
+
     /// <summary>
     /// Initializes a new <see cref="AgUiEventWriter"/> that writes to <paramref name="responseBody"/>.
     /// </summary>
@@ -62,7 +71,16 @@ public sealed class AgUiEventWriter : IAgUiEventWriter
         // Serialize as the base AgUiEvent type so JsonPolymorphic emits the "type" discriminator.
         var json = JsonSerializer.Serialize(evt, typeof(AgUiEvent), SerializerOptions);
         var frame = Encoding.UTF8.GetBytes($"data: {json}\n\n");
-        await _stream.WriteAsync(frame, ct);
-        await _stream.FlushAsync(ct);
+
+        await _writeLock.WaitAsync(ct);
+        try
+        {
+            await _stream.WriteAsync(frame, ct);
+            await _stream.FlushAsync(ct);
+        }
+        finally
+        {
+            _writeLock.Release();
+        }
     }
 }

--- a/src/Content/Presentation/Presentation.AgentHub/AgUi/AgUiEvents.cs
+++ b/src/Content/Presentation/Presentation.AgentHub/AgUi/AgUiEvents.cs
@@ -29,6 +29,10 @@ namespace Presentation.AgentHub.AgUi;
 [JsonDerivedType(typeof(TextMessageStartEvent), AgUiEventType.TextMessageStart)]
 [JsonDerivedType(typeof(TextMessageContentEvent), AgUiEventType.TextMessageContent)]
 [JsonDerivedType(typeof(TextMessageEndEvent), AgUiEventType.TextMessageEnd)]
+// Client round-trip tool calls (mid-run blocking proxy)
+[JsonDerivedType(typeof(ToolCallStartEvent), AgUiEventType.ToolCallStart)]
+[JsonDerivedType(typeof(ToolCallArgsEvent), AgUiEventType.ToolCallArgs)]
+[JsonDerivedType(typeof(ToolCallEndEvent), AgUiEventType.ToolCallEnd)]
 // Escalation
 [JsonDerivedType(typeof(EscalationRequestedEvent), AgUiEventType.EscalationRequested)]
 [JsonDerivedType(typeof(EscalationResolvedEvent), AgUiEventType.EscalationResolved)]

--- a/src/Content/Presentation/Presentation.AgentHub/AgUi/AgUiRunHandler.cs
+++ b/src/Content/Presentation/Presentation.AgentHub/AgUi/AgUiRunHandler.cs
@@ -151,6 +151,7 @@ public sealed class AgUiRunHandler
         try
         {
             _writerAccessor.Writer = writer;
+            _writerAccessor.ThreadId = input.ThreadId;
             await ExecuteRunAsync(input, writer, record, userMessage, callerId, observabilitySessionId, ct);
         }
         catch (OperationCanceledException)
@@ -165,6 +166,7 @@ public sealed class AgUiRunHandler
         finally
         {
             _writerAccessor.Writer = null;
+            _writerAccessor.ThreadId = null;
             semaphore.Release();
         }
     }

--- a/src/Content/Presentation/Presentation.AgentHub/AgUi/AgUiToolCallEvents.cs
+++ b/src/Content/Presentation/Presentation.AgentHub/AgUi/AgUiToolCallEvents.cs
@@ -1,0 +1,45 @@
+using System.Text.Json.Serialization;
+
+namespace Presentation.AgentHub.AgUi;
+
+/// <summary>
+/// Signals that the agent has begun a tool call whose execution is delegated to the
+/// connected client (a "client-side" or round-trip tool). Followed by one or more
+/// <see cref="ToolCallArgsEvent"/> frames carrying the serialized arguments and
+/// terminated by a <see cref="ToolCallEndEvent"/>.
+/// </summary>
+/// <remarks>
+/// Unlike the standard AG-UI client-tool flow (which terminates the run and expects the
+/// client to start a follow-up run), these events are emitted <em>mid-run</em> by the
+/// server-side blocking proxy tool. The server pauses the same run awaiting the client's
+/// result via <c>POST /ag-ui/tool-result</c>, then resumes. The <see cref="ToolCallId"/>
+/// is globally unique per run and is echoed by the client when it posts the result.
+/// </remarks>
+public sealed record ToolCallStartEvent(
+    /// <summary>Globally-unique identifier for this tool call, echoed by the client's result post.</summary>
+    [property: JsonPropertyName("toolCallId")] string ToolCallId,
+    /// <summary>The name of the tool being invoked (e.g. <c>dashboard_control</c>).</summary>
+    [property: JsonPropertyName("toolCallName")] string ToolCallName
+) : AgUiEvent;
+
+/// <summary>
+/// A streaming arguments chunk (delta) for an in-progress tool call. The full argument
+/// payload is assembled by concatenating all <see cref="Delta"/> values for the same
+/// <see cref="ToolCallId"/>. The blocking proxy emits the arguments as a single JSON delta.
+/// </summary>
+public sealed record ToolCallArgsEvent(
+    /// <summary>The tool call these arguments belong to.</summary>
+    [property: JsonPropertyName("toolCallId")] string ToolCallId,
+    /// <summary>The incremental arguments text (JSON) to append to the call's argument buffer.</summary>
+    [property: JsonPropertyName("delta")] string Delta
+) : AgUiEvent;
+
+/// <summary>
+/// Signals that a tool call's arguments have been fully streamed. After this frame the
+/// client should execute the requested action and post the result back to
+/// <c>POST /ag-ui/tool-result</c> with the matching <see cref="ToolCallId"/>.
+/// </summary>
+public sealed record ToolCallEndEvent(
+    /// <summary>The tool call that has finished streaming arguments.</summary>
+    [property: JsonPropertyName("toolCallId")] string ToolCallId
+) : AgUiEvent;

--- a/src/Content/Presentation/Presentation.AgentHub/AgUi/IAgUiEventWriterAccessor.cs
+++ b/src/Content/Presentation/Presentation.AgentHub/AgUi/IAgUiEventWriterAccessor.cs
@@ -1,14 +1,21 @@
 namespace Presentation.AgentHub.AgUi;
 
 /// <summary>
-/// Provides access to the current AG-UI event writer for the active run.
-/// Uses <see cref="AsyncLocal{T}"/> storage so the writer is scoped to the
-/// async execution context of the AG-UI run handler.
+/// Provides ambient access to the active AG-UI run's output context — the event writer and the id of
+/// the conversation thread that owns the run. Uses <see cref="AsyncLocal{T}"/> storage so the context
+/// is scoped to the async execution context of the AG-UI run handler and flows into the tools it invokes.
 /// </summary>
 public interface IAgUiEventWriterAccessor
 {
     /// <summary>Gets or sets the current AG-UI event writer. Null when no run is active.</summary>
     IAgUiEventWriter? Writer { get; set; }
+
+    /// <summary>
+    /// Gets or sets the conversation thread id of the active run. Null when no run is active. A
+    /// blocking-proxy tool reads this to bind its pending call to the owning thread, so a tool result
+    /// can only be completed by a caller who owns that same thread.
+    /// </summary>
+    string? ThreadId { get; set; }
 }
 
 /// <summary>
@@ -17,11 +24,19 @@ public interface IAgUiEventWriterAccessor
 public sealed class AgUiEventWriterAccessor : IAgUiEventWriterAccessor
 {
     private static readonly AsyncLocal<IAgUiEventWriter?> _current = new();
+    private static readonly AsyncLocal<string?> _threadId = new();
 
     /// <inheritdoc />
     public IAgUiEventWriter? Writer
     {
         get => _current.Value;
         set => _current.Value = value;
+    }
+
+    /// <inheritdoc />
+    public string? ThreadId
+    {
+        get => _threadId.Value;
+        set => _threadId.Value = value;
     }
 }

--- a/src/Content/Presentation/Presentation.AgentHub/AgUi/MetricCatalogProvider.cs
+++ b/src/Content/Presentation/Presentation.AgentHub/AgUi/MetricCatalogProvider.cs
@@ -1,0 +1,23 @@
+using Application.AI.Common.Interfaces.Observability;
+using Presentation.AgentHub.Controllers;
+
+namespace Presentation.AgentHub.AgUi;
+
+/// <summary>
+/// Presentation-layer implementation of <see cref="IMetricCatalog"/> that projects the dashboard's
+/// own curated <see cref="MetricCatalog"/> entries to the neutral <see cref="MetricDescriptor"/> shape.
+/// </summary>
+/// <remarks>
+/// This keeps a single source of truth: the dashboard renders <see cref="MetricCatalog.Entries"/> and
+/// the agent's <c>list_metrics</c> tool reads the very same list through this provider, so the two can
+/// never drift. The projection is computed once and cached for the provider's singleton lifetime.
+/// </remarks>
+public sealed class MetricCatalogProvider : IMetricCatalog
+{
+    /// <inheritdoc />
+    public IReadOnlyList<MetricDescriptor> Entries { get; } =
+        MetricCatalog.Entries
+            .Select(e => new MetricDescriptor(
+                e.Id, e.Title, e.Description, e.Query, e.ChartType, e.Unit, e.Category))
+            .ToList();
+}

--- a/src/Content/Presentation/Presentation.AgentHub/AgUi/PendingToolCallRegistry.cs
+++ b/src/Content/Presentation/Presentation.AgentHub/AgUi/PendingToolCallRegistry.cs
@@ -1,0 +1,94 @@
+using System.Collections.Concurrent;
+
+namespace Presentation.AgentHub.AgUi;
+
+/// <summary>
+/// Tracks in-flight client round-trip tool calls so a server-side blocking proxy tool can
+/// park mid-run awaiting a result that arrives out-of-band via <c>POST /ag-ui/tool-result</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Each pending call is keyed by a globally-unique <c>callId</c> and backed by a
+/// <see cref="TaskCompletionSource{TResult}"/>. The proxy tool calls <see cref="RegisterAsync"/>
+/// and awaits the returned task; the resume endpoint calls <see cref="TryComplete"/> with the
+/// browser-supplied result, which unblocks the awaiting tool and resumes the same agent run.
+/// </para>
+/// <para>
+/// <strong>Lifetime safety:</strong> every registration self-removes from the backing map on
+/// completion, timeout, or cancellation, so no <see cref="TaskCompletionSource{TResult}"/> is
+/// leaked when a client disconnects or never responds. Registered as a singleton — the resume
+/// endpoint (a different HTTP request) and the tool (running inside the run) must share one map.
+/// </para>
+/// </remarks>
+public sealed class PendingToolCallRegistry
+{
+    private readonly ConcurrentDictionary<string, TaskCompletionSource<string>> _pending = new(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Registers a pending tool call and returns a task that completes when the client posts a
+    /// result (<see cref="TryComplete"/>), faults when the client reports a failure
+    /// (<see cref="TryFail"/>), or throws when the <paramref name="timeout"/> elapses or
+    /// <paramref name="cancellationToken"/> is cancelled. The registration is removed from the
+    /// backing map in all cases.
+    /// </summary>
+    /// <param name="callId">Globally-unique identifier for the call. Must not already be pending.</param>
+    /// <param name="timeout">Maximum time to await the client result before giving up.</param>
+    /// <param name="cancellationToken">Cancelled when the owning run is cancelled (client disconnect).</param>
+    /// <returns>The client-supplied result string.</returns>
+    /// <exception cref="InvalidOperationException">A call with <paramref name="callId"/> is already pending.</exception>
+    /// <exception cref="TimeoutException">The timeout elapsed before a result arrived.</exception>
+    /// <exception cref="OperationCanceledException">The run was cancelled before a result arrived.</exception>
+    public Task<string> RegisterAsync(string callId, TimeSpan timeout, CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(callId);
+
+        // RunContinuationsAsynchronously prevents the resume endpoint's thread from inlining the
+        // (potentially long) agent-run continuation when it calls TrySetResult.
+        var tcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+        if (!_pending.TryAdd(callId, tcs))
+            throw new InvalidOperationException($"A tool call with id '{callId}' is already pending.");
+
+        return AwaitWithCleanupAsync(callId, tcs.Task, timeout, cancellationToken);
+    }
+
+    /// <summary>
+    /// Completes a pending call with the client-supplied <paramref name="result"/>, unblocking the
+    /// awaiting tool. Returns <c>false</c> when no call with <paramref name="callId"/> is pending
+    /// (already completed, timed out, or never registered) so the caller can report "unknown call".
+    /// </summary>
+    public bool TryComplete(string callId, string result)
+    {
+        if (_pending.TryRemove(callId, out var tcs))
+            return tcs.TrySetResult(result);
+        return false;
+    }
+
+    /// <summary>
+    /// Faults a pending call so the awaiting tool observes a failure rather than a result.
+    /// Returns <c>false</c> when no call with <paramref name="callId"/> is pending.
+    /// </summary>
+    public bool TryFail(string callId, string error)
+    {
+        if (_pending.TryRemove(callId, out var tcs))
+            return tcs.TrySetException(new InvalidOperationException(error));
+        return false;
+    }
+
+    /// <summary>Gets the number of currently-pending calls. Exposed for diagnostics and leak assertions in tests.</summary>
+    public int PendingCount => _pending.Count;
+
+    private async Task<string> AwaitWithCleanupAsync(
+        string callId, Task<string> task, TimeSpan timeout, CancellationToken cancellationToken)
+    {
+        try
+        {
+            return await task.WaitAsync(timeout, cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            // Idempotent: TryComplete/TryFail may have already removed it; this covers the
+            // timeout and cancellation paths where no result ever arrived.
+            _pending.TryRemove(callId, out _);
+        }
+    }
+}

--- a/src/Content/Presentation/Presentation.AgentHub/AgUi/PendingToolCallRegistry.cs
+++ b/src/Content/Presentation/Presentation.AgentHub/AgUi/PendingToolCallRegistry.cs
@@ -22,30 +22,35 @@ namespace Presentation.AgentHub.AgUi;
 /// </remarks>
 public sealed class PendingToolCallRegistry
 {
-    private readonly ConcurrentDictionary<string, TaskCompletionSource<string>> _pending = new(StringComparer.Ordinal);
+    private readonly ConcurrentDictionary<string, PendingCall> _pending = new(StringComparer.Ordinal);
+
+    /// <summary>A pending call's owning thread and its completion source.</summary>
+    private readonly record struct PendingCall(string ThreadId, TaskCompletionSource<string> Tcs);
 
     /// <summary>
-    /// Registers a pending tool call and returns a task that completes when the client posts a
-    /// result (<see cref="TryComplete"/>), faults when the client reports a failure
-    /// (<see cref="TryFail"/>), or throws when the <paramref name="timeout"/> elapses or
-    /// <paramref name="cancellationToken"/> is cancelled. The registration is removed from the
+    /// Registers a pending tool call bound to <paramref name="threadId"/> and returns a task that
+    /// completes when the client posts a result (<see cref="TryComplete"/>), faults when the client
+    /// reports a failure (<see cref="TryFail"/>), or throws when the <paramref name="timeout"/> elapses
+    /// or <paramref name="cancellationToken"/> is cancelled. The registration is removed from the
     /// backing map in all cases.
     /// </summary>
     /// <param name="callId">Globally-unique identifier for the call. Must not already be pending.</param>
+    /// <param name="threadId">The conversation thread that owns the call; a completer must match it.</param>
     /// <param name="timeout">Maximum time to await the client result before giving up.</param>
     /// <param name="cancellationToken">Cancelled when the owning run is cancelled (client disconnect).</param>
     /// <returns>The client-supplied result string.</returns>
     /// <exception cref="InvalidOperationException">A call with <paramref name="callId"/> is already pending.</exception>
     /// <exception cref="TimeoutException">The timeout elapsed before a result arrived.</exception>
     /// <exception cref="OperationCanceledException">The run was cancelled before a result arrived.</exception>
-    public Task<string> RegisterAsync(string callId, TimeSpan timeout, CancellationToken cancellationToken)
+    public Task<string> RegisterAsync(string callId, string threadId, TimeSpan timeout, CancellationToken cancellationToken)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(callId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(threadId);
 
         // RunContinuationsAsynchronously prevents the resume endpoint's thread from inlining the
         // (potentially long) agent-run continuation when it calls TrySetResult.
         var tcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
-        if (!_pending.TryAdd(callId, tcs))
+        if (!_pending.TryAdd(callId, new PendingCall(threadId, tcs)))
             throw new InvalidOperationException($"A tool call with id '{callId}' is already pending.");
 
         return AwaitWithCleanupAsync(callId, tcs.Task, timeout, cancellationToken);
@@ -53,24 +58,48 @@ public sealed class PendingToolCallRegistry
 
     /// <summary>
     /// Completes a pending call with the client-supplied <paramref name="result"/>, unblocking the
-    /// awaiting tool. Returns <c>false</c> when no call with <paramref name="callId"/> is pending
-    /// (already completed, timed out, or never registered) so the caller can report "unknown call".
+    /// awaiting tool. Returns <c>false</c> when no call with <paramref name="callId"/> is pending for
+    /// <paramref name="threadId"/> — whether it never existed, already completed/timed out, or belongs
+    /// to a different thread — so the caller can reject it as an unknown call.
     /// </summary>
-    public bool TryComplete(string callId, string result)
+    public bool TryComplete(string callId, string threadId, string result)
     {
-        if (_pending.TryRemove(callId, out var tcs))
+        if (TryRemoveOwned(callId, threadId, out var tcs))
             return tcs.TrySetResult(result);
         return false;
     }
 
     /// <summary>
     /// Faults a pending call so the awaiting tool observes a failure rather than a result.
-    /// Returns <c>false</c> when no call with <paramref name="callId"/> is pending.
+    /// Returns <c>false</c> when no call with <paramref name="callId"/> is pending for <paramref name="threadId"/>.
     /// </summary>
-    public bool TryFail(string callId, string error)
+    /// <remarks>
+    /// The current resume endpoint only ever calls <see cref="TryComplete"/> (a client encodes a failure
+    /// as a normal result string). This is the failure counterpart, kept so a future <c>/ag-ui/tool-error</c>
+    /// endpoint can surface a hard client error as a faulted tool call rather than a success.
+    /// </remarks>
+    public bool TryFail(string callId, string threadId, string error)
     {
-        if (_pending.TryRemove(callId, out var tcs))
+        if (TryRemoveOwned(callId, threadId, out var tcs))
             return tcs.TrySetException(new InvalidOperationException(error));
+        return false;
+    }
+
+    /// <summary>
+    /// Removes the pending call only when it exists AND belongs to <paramref name="threadId"/>. A
+    /// thread mismatch is treated as "not found" (and the entry is left intact for its real owner),
+    /// so a caller can never complete a call registered under a different conversation.
+    /// </summary>
+    private bool TryRemoveOwned(string callId, string threadId, out TaskCompletionSource<string> tcs)
+    {
+        if (_pending.TryGetValue(callId, out var pending) &&
+            string.Equals(pending.ThreadId, threadId, StringComparison.Ordinal) &&
+            _pending.TryRemove(new KeyValuePair<string, PendingCall>(callId, pending)))
+        {
+            tcs = pending.Tcs;
+            return true;
+        }
+        tcs = null!;
         return false;
     }
 

--- a/src/Content/Presentation/Presentation.AgentHub/Config/AgentHubConfig.cs
+++ b/src/Content/Presentation/Presentation.AgentHub/Config/AgentHubConfig.cs
@@ -20,6 +20,14 @@ public sealed record AgentHubConfig
     /// </summary>
     public int SessionIdleTimeoutMinutes { get; init; } = 5;
 
+    /// <summary>
+    /// Seconds a server-side client round-trip tool (e.g. <c>dashboard_control</c>) will block
+    /// awaiting the browser's result before failing the call. Bounds the AG-UI blocking-proxy
+    /// pattern so a disconnected or unresponsive client never parks an agent run. Must stay below
+    /// the agent turn timeout so the tool fails gracefully rather than the whole turn timing out.
+    /// </summary>
+    public int ClientToolTimeoutSeconds { get; init; } = 120;
+
     /// <summary>CORS configuration for this host.</summary>
     public AgentHubCorsConfig Cors { get; init; } = new();
 }

--- a/src/Content/Presentation/Presentation.AgentHub/Controllers/AgentsController.cs
+++ b/src/Content/Presentation/Presentation.AgentHub/Controllers/AgentsController.cs
@@ -1,6 +1,8 @@
 using Application.AI.Common.Interfaces;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+using Presentation.AgentHub.Config;
 using Presentation.AgentHub.Extensions;
 using Presentation.AgentHub.Interfaces;
 using Presentation.AgentHub.DTOs;
@@ -27,16 +29,19 @@ public sealed class AgentsController : ControllerBase
 
     private readonly IConversationStore _store;
     private readonly IAgentMetadataRegistry _agentRegistry;
+    private readonly IOptionsMonitor<AgentHubConfig> _config;
     private readonly ILogger<AgentsController> _logger;
 
     /// <summary>Initialises the controller with its dependencies.</summary>
     public AgentsController(
         IConversationStore store,
         IAgentMetadataRegistry agentRegistry,
+        IOptionsMonitor<AgentHubConfig> config,
         ILogger<AgentsController> logger)
     {
         _store = store;
         _agentRegistry = agentRegistry;
+        _config = config;
         _logger = logger;
     }
 
@@ -113,4 +118,46 @@ public sealed class AgentsController : ControllerBase
         await _store.DeleteAsync(id, ct);
         return NoContent();
     }
+
+    /// <summary>
+    /// Creates a new conversation owned by the caller and returns its thread id. The dashboard agent
+    /// panel calls this to obtain a thread before opening the AG-UI run stream.
+    /// </summary>
+    /// <remarks>
+    /// The agent is taken from the request body, falling back to
+    /// <see cref="AgentHubConfig.DefaultAgentName"/> when omitted. A 400 is returned when neither
+    /// supplies an agent name, so a conversation is never created against an unspecified agent.
+    /// </remarks>
+    [HttpPost("conversations")]
+    public async Task<IActionResult> CreateConversation(
+        [FromBody] CreateConversationRequest? request, CancellationToken ct)
+    {
+        var agentName = !string.IsNullOrWhiteSpace(request?.AgentName)
+            ? request!.AgentName!.Trim()
+            : _config.CurrentValue.DefaultAgentName;
+
+        if (string.IsNullOrWhiteSpace(agentName))
+            return BadRequest(new { error = "An agent name is required (none supplied and no default configured)." });
+
+        var userId = User.GetUserId();
+        var record = await _store.CreateAsync(agentName, userId, conversationId: null, ct);
+
+        _logger.LogInformation(
+            "Created conversation {ConversationId} for user {UserId} bound to agent {AgentName}.",
+            record.Id, userId, agentName);
+
+        return CreatedAtAction(nameof(GetConversation), new { id = record.Id },
+            new CreateConversationResponse(record.Id, record.AgentName));
+    }
 }
+
+/// <summary>Request body for <see cref="AgentsController.CreateConversation"/>.</summary>
+/// <param name="AgentName">
+/// The agent to bind the conversation to. Optional — falls back to the configured default agent.
+/// </param>
+public sealed record CreateConversationRequest(string? AgentName);
+
+/// <summary>Response for <see cref="AgentsController.CreateConversation"/>.</summary>
+/// <param name="ThreadId">The new conversation's id, used as the AG-UI <c>threadId</c>.</param>
+/// <param name="AgentName">The agent the conversation was bound to.</param>
+public sealed record CreateConversationResponse(string ThreadId, string AgentName);

--- a/src/Content/Presentation/Presentation.AgentHub/DependencyInjection.cs
+++ b/src/Content/Presentation/Presentation.AgentHub/DependencyInjection.cs
@@ -229,6 +229,14 @@ public static class DependencyInjection
         services.AddScoped<IConversationOrchestrator, ConversationOrchestrator>();
 
         services.AddSingleton<IAgUiEventWriterAccessor, AgUiEventWriterAccessor>();
+
+        // AG-UI client round-trip ("blocking proxy") wiring. The registry is the shared rendezvous
+        // between the tool (awaiting, inside a run) and the resume endpoint (a separate request), so
+        // it MUST be a singleton. The bridge holds no per-run state (writer is ambient, pending map
+        // lives in the registry) and the catalog provider is immutable — both safe as singletons.
+        services.AddSingleton<AgUi.PendingToolCallRegistry>();
+        services.AddSingleton<Application.AI.Common.Interfaces.Tools.IClientToolBridge, AgUi.AgUiClientToolBridge>();
+        services.AddSingleton<Application.AI.Common.Interfaces.Observability.IMetricCatalog, AgUi.MetricCatalogProvider>();
         services.AddSingleton<IEscalationNotificationChannel, AgUiEscalationNotifier>();
         services.AddSingleton<IDriftNotificationChannel, AgUiDriftNotifier>();
         services.AddSingleton<ILearningNotificationChannel, AgUiLearningNotifier>();

--- a/src/Content/Presentation/Presentation.Dashboard/package-lock.json
+++ b/src/Content/Presentation/Presentation.Dashboard/package-lock.json
@@ -8,6 +8,8 @@
       "name": "presentation-dashboard",
       "version": "0.0.0",
       "dependencies": {
+        "@ag-ui/client": "^0.0.57",
+        "@ag-ui/core": "^0.0.57",
         "@azure/msal-browser": "^5.6.3",
         "@azure/msal-react": "^5.2.1",
         "@fontsource-variable/geist": "^5.2.8",
@@ -26,6 +28,7 @@
         "react-dom": "^19.2.4",
         "react-router-dom": "^7.14.1",
         "recharts": "^2.15.3",
+        "rxjs": "^7.8.1",
         "tailwind-merge": "^3.5.0",
         "tailwindcss": "^4.2.2",
         "tw-animate-css": "^1.4.0",
@@ -62,6 +65,68 @@
       "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@ag-ui/client": {
+      "version": "0.0.57",
+      "resolved": "https://registry.npmjs.org/@ag-ui/client/-/client-0.0.57.tgz",
+      "integrity": "sha512-Xap2alG9Z0/j5kb3x4D7oTpe2sw1dfrC9rgJJr2NZu5vKcm8dzIPNd31mF2B4zS3BKqYIu245yxKPhEtT30MHw==",
+      "dependencies": {
+        "@ag-ui/core": "0.0.57",
+        "@ag-ui/encoder": "0.0.57",
+        "@ag-ui/proto": "0.0.57",
+        "@types/uuid": "^10.0.0",
+        "compare-versions": "^6.1.1",
+        "fast-json-patch": "^3.1.1",
+        "rxjs": "7.8.1",
+        "untruncate-json": "^0.0.1",
+        "uuid": "^11.1.0",
+        "zod": "^3.22.4"
+      }
+    },
+    "node_modules/@ag-ui/client/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@ag-ui/core": {
+      "version": "0.0.57",
+      "resolved": "https://registry.npmjs.org/@ag-ui/core/-/core-0.0.57.tgz",
+      "integrity": "sha512-gho1OWjNE6E3Rl7ZEZ1wr2CEpUHjLFU0FqzCZZk439TicLu+BfLCMkMokB07bMGlRmbJ60hM6LW60iOVauCx+Q==",
+      "dependencies": {
+        "zod": "^3.22.4"
+      }
+    },
+    "node_modules/@ag-ui/core/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@ag-ui/encoder": {
+      "version": "0.0.57",
+      "resolved": "https://registry.npmjs.org/@ag-ui/encoder/-/encoder-0.0.57.tgz",
+      "integrity": "sha512-ifD9NctR4xyPDR58xF9GK1bj/S8oECFkTeDfuYD8tXdbcOstIJ2TOqU2zhiCKnw7Vw+zR9Qv3TbsM9E7Gi9X3Q==",
+      "dependencies": {
+        "@ag-ui/core": "0.0.57",
+        "@ag-ui/proto": "0.0.57"
+      }
+    },
+    "node_modules/@ag-ui/proto": {
+      "version": "0.0.57",
+      "resolved": "https://registry.npmjs.org/@ag-ui/proto/-/proto-0.0.57.tgz",
+      "integrity": "sha512-pPENOZt0P6ibH8sCTgq05wLYXi5t3P9B5r/1bWYehXjUxtyOdnukSlWM++SsCIwUXsQdm/b3aBgGjEeTF7RenA==",
+      "dependencies": {
+        "@ag-ui/core": "0.0.57",
+        "@bufbuild/protobuf": "^2.2.5",
+        "@protobuf-ts/protoc": "^2.11.1"
+      }
     },
     "node_modules/@asamuzakjp/css-color": {
       "version": "5.1.11",
@@ -612,6 +677,12 @@
       "bin": {
         "specificity": "bin/cli.js"
       }
+    },
+    "node_modules/@bufbuild/protobuf": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.12.1.tgz",
+      "integrity": "sha512-BvAMfS6LrgZiryOAZ4pBYucu4wG/Ei/9o9DZ9akbREnMLbPJiom2i8b9C8IsKErQoiKqVhrerzt3kOT/RrzLHg==",
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/@csstools/color-helpers": {
       "version": "6.0.2",
@@ -1670,6 +1741,15 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@protobuf-ts/protoc": {
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/@protobuf-ts/protoc/-/protoc-2.11.1.tgz",
+      "integrity": "sha512-mUZJaV0daGO6HUX90o/atzQ6A7bbN2RSuHtdwo8SSF2Qoe3zHwa4IHyCN1evftTeHfLmdz+45qo47sL+5P8nyg==",
+      "license": "Apache-2.0",
+      "bin": {
+        "protoc": "protoc.js"
       }
     },
     "node_modules/@radix-ui/number": {
@@ -3088,6 +3168,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
+      "license": "MIT"
+    },
     "node_modules/@types/validate-npm-package-name": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/validate-npm-package-name/-/validate-npm-package-name-4.0.2.tgz",
@@ -4244,6 +4330,12 @@
         "node": ">=20"
       }
     },
+    "node_modules/compare-versions": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-6.1.1.tgz",
+      "integrity": "sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==",
+      "license": "MIT"
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -4274,6 +4366,16 @@
       },
       "funding": {
         "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
+      }
+    },
+    "node_modules/concurrently/node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
       }
     },
     "node_modules/content-disposition": {
@@ -5400,6 +5502,12 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/fast-json-patch": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-3.1.1.tgz",
+      "integrity": "sha512-vf6IHUX2SBcA+5/+4883dsIjpBTqmfBjmYiWK1savxQmFk4JfBMLa7ynTYOs1Rolp/T1betJxHiGD3g1Mn8lUQ==",
+      "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
@@ -8487,10 +8595,9 @@
       }
     },
     "node_modules/rxjs": {
-      "version": "7.8.2",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
-      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
-      "dev": true,
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"
@@ -9437,6 +9544,12 @@
         "url": "https://github.com/sponsors/kettanaito"
       }
     },
+    "node_modules/untruncate-json": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/untruncate-json/-/untruncate-json-0.0.1.tgz",
+      "integrity": "sha512-4W9enDK4X1y1s2S/Rz7ysw6kDuMS3VmRjMFg7GZrNO+98OSe+x5Lh7PKYoVjy3lW/1wmhs6HW0lusnQRHgMarA==",
+      "license": "MIT"
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
@@ -9537,6 +9650,19 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
     },
     "node_modules/validate-npm-package-name": {
       "version": "7.0.2",

--- a/src/Content/Presentation/Presentation.Dashboard/package.json
+++ b/src/Content/Presentation/Presentation.Dashboard/package.json
@@ -18,6 +18,8 @@
     "test:e2e:debug": "npx playwright test --debug"
   },
   "dependencies": {
+    "@ag-ui/client": "^0.0.57",
+    "@ag-ui/core": "^0.0.57",
     "@azure/msal-browser": "^5.6.3",
     "@azure/msal-react": "^5.2.1",
     "@fontsource-variable/geist": "^5.2.8",
@@ -36,6 +38,7 @@
     "react-dom": "^19.2.4",
     "react-router-dom": "^7.14.1",
     "recharts": "^2.15.3",
+    "rxjs": "^7.8.1",
     "tailwind-merge": "^3.5.0",
     "tailwindcss": "^4.2.2",
     "tw-animate-css": "^1.4.0",

--- a/src/Content/Presentation/Presentation.Dashboard/src/components/agent/AgentPanel.test.tsx
+++ b/src/Content/Presentation/Presentation.Dashboard/src/components/agent/AgentPanel.test.tsx
@@ -1,0 +1,60 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+const sendMessage = vi.fn(async () => {});
+vi.mock('@/hooks/useDashboardAgent', () => ({
+  useDashboardAgent: () => ({ sendMessage }),
+}));
+
+import { AgentPanel } from './AgentPanel';
+import { useChatStore } from '@/stores/chatStore';
+
+describe('AgentPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useChatStore.setState({ open: false, threadId: null, messages: [], status: 'idle', error: null, toolActivity: null });
+  });
+
+  it('is not rendered when the store is closed', () => {
+    render(<AgentPanel />);
+    expect(screen.queryByTestId('agent-panel')).not.toBeInTheDocument();
+  });
+
+  it('renders the transcript when open', () => {
+    useChatStore.setState({
+      open: true,
+      messages: [
+        { id: 'u1', role: 'user', content: 'show spend' },
+        { id: 'a1', role: 'assistant', content: 'On it.' },
+      ],
+    });
+    render(<AgentPanel />);
+    expect(screen.getByTestId('agent-panel')).toBeInTheDocument();
+    expect(screen.getByText('show spend')).toBeInTheDocument();
+    expect(screen.getByText('On it.')).toBeInTheDocument();
+  });
+
+  it('submits the input via the hook and clears the field', () => {
+    useChatStore.setState({ open: true });
+    render(<AgentPanel />);
+
+    const input = screen.getByTestId('agent-panel-input') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'refresh the data' } });
+    fireEvent.submit(input.closest('form')!);
+
+    expect(sendMessage).toHaveBeenCalledWith('refresh the data');
+    expect(input.value).toBe('');
+  });
+
+  it('disables send while a run is in progress', () => {
+    useChatStore.setState({ open: true, status: 'running' });
+    render(<AgentPanel />);
+    expect(screen.getByTestId('agent-panel-send')).toBeDisabled();
+  });
+
+  it('shows the error banner when the run failed', () => {
+    useChatStore.setState({ open: true, status: 'error', error: 'Access denied.' });
+    render(<AgentPanel />);
+    expect(screen.getByTestId('agent-panel-error')).toHaveTextContent('Access denied.');
+  });
+});

--- a/src/Content/Presentation/Presentation.Dashboard/src/components/agent/AgentPanel.test.tsx
+++ b/src/Content/Presentation/Presentation.Dashboard/src/components/agent/AgentPanel.test.tsx
@@ -6,6 +6,14 @@ vi.mock('@/hooks/useDashboardAgent', () => ({
   useDashboardAgent: () => ({ sendMessage }),
 }));
 
+// Stub the recharts-backed chart components — jsdom has no layout, so render simple markers.
+vi.mock('@/components/charts/TimeSeriesChart', () => ({
+  TimeSeriesChart: () => <div data-testid="timeseries-chart" />,
+}));
+vi.mock('@/components/charts/BarChart', () => ({
+  MetricBarChart: () => <div data-testid="bar-chart" />,
+}));
+
 import { AgentPanel } from './AgentPanel';
 import { useChatStore } from '@/stores/chatStore';
 
@@ -50,6 +58,24 @@ describe('AgentPanel', () => {
     useChatStore.setState({ open: true, status: 'running' });
     render(<AgentPanel />);
     expect(screen.getByTestId('agent-panel-send')).toBeDisabled();
+  });
+
+  it('renders an inline chart message with its title and a pie/bar chart', () => {
+    useChatStore.setState({
+      open: true,
+      messages: [
+        {
+          id: 'c1',
+          role: 'assistant',
+          content: 'Rendered a pie chart.',
+          chart: { title: 'Tokens by Model', chartType: 'pie', unit: 'tokens', series: [{ labels: {}, dataPoints: [{ timestamp: 1, value: '5' }] }] },
+        },
+      ],
+    });
+    render(<AgentPanel />);
+    expect(screen.getByTestId('agent-message-chart')).toBeInTheDocument();
+    expect(screen.getByText('Tokens by Model')).toBeInTheDocument();
+    expect(screen.getByTestId('bar-chart')).toBeInTheDocument();
   });
 
   it('shows the error banner when the run failed', () => {

--- a/src/Content/Presentation/Presentation.Dashboard/src/components/agent/AgentPanel.tsx
+++ b/src/Content/Presentation/Presentation.Dashboard/src/components/agent/AgentPanel.tsx
@@ -1,0 +1,132 @@
+import { useEffect, useRef, useState, type FormEvent } from 'react';
+import * as Dialog from '@radix-ui/react-dialog';
+import { Loader2, Send, Sparkles, X } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { useChatStore, type ChatMessage } from '@/stores/chatStore';
+import { useDashboardAgent } from '@/hooks/useDashboardAgent';
+
+/**
+ * Embedded dashboard agent panel — a right-side slide-over (Radix Dialog, mirroring
+ * {@link ContextDrawer}) holding a chat transcript and input. The agent can both answer questions
+ * and act on the dashboard (change the time range, navigate, refresh) via AG-UI tool calls handled
+ * by {@link useDashboardAgent}. Mounted once in the shell so it is available on every page.
+ */
+export function AgentPanel() {
+  const open = useChatStore((s) => s.open);
+  const setOpen = useChatStore((s) => s.setOpen);
+  const messages = useChatStore((s) => s.messages);
+  const status = useChatStore((s) => s.status);
+  const error = useChatStore((s) => s.error);
+  const toolActivity = useChatStore((s) => s.toolActivity);
+  const { sendMessage } = useDashboardAgent();
+
+  const [draft, setDraft] = useState('');
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  // Keep the newest message in view as the transcript grows or streams.
+  useEffect(() => {
+    scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight });
+  }, [messages, toolActivity]);
+
+  const running = status === 'running';
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    const text = draft.trim();
+    if (!text || running) return;
+    setDraft('');
+    void sendMessage(text);
+  };
+
+  return (
+    <Dialog.Root open={open} onOpenChange={setOpen}>
+      <Dialog.Portal>
+        <Dialog.Overlay
+          data-testid="agent-panel-overlay"
+          className="fixed inset-0 z-40 bg-foreground/30 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=open]:fade-in-0 data-[state=closed]:fade-out-0"
+        />
+        <Dialog.Content
+          data-testid="agent-panel"
+          className="fixed right-0 top-0 z-50 h-full w-full max-w-md bg-card border-l border-border shadow-2xl flex flex-col focus:outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=open]:slide-in-from-right data-[state=closed]:slide-out-to-right"
+        >
+          <header className="flex items-center gap-2 border-b border-border bg-card px-5 py-4">
+            <Sparkles className="h-4 w-4 text-cat-accent" />
+            <div className="flex-1 min-w-0">
+              <Dialog.Title className="text-sm font-semibold text-foreground">Dashboard Agent</Dialog.Title>
+              <Dialog.Description className="text-xs text-muted-foreground">
+                Ask about the dashboard or tell it what to show.
+              </Dialog.Description>
+            </div>
+            <Dialog.Close
+              data-testid="agent-panel-close"
+              className="rounded-md p-1 text-muted-foreground hover:bg-accent hover:text-foreground"
+              aria-label="Close agent panel"
+            >
+              <X className="h-4 w-4" />
+            </Dialog.Close>
+          </header>
+
+          <div ref={scrollRef} data-testid="agent-panel-transcript" className="flex-1 overflow-auto px-5 py-4 space-y-3">
+            {messages.length === 0 && !running && (
+              <p className="text-xs text-muted-foreground">
+                Try: “show me the last 24 hours on the spend page”, “what am I looking at?”, or “refresh the data”.
+              </p>
+            )}
+            {messages.map((m) => (
+              <MessageBubble key={m.id} message={m} />
+            ))}
+            {toolActivity && (
+              <div data-testid="agent-panel-activity" className="flex items-center gap-2 text-xs text-muted-foreground">
+                <Loader2 className="h-3 w-3 animate-spin" />
+                <span>{toolActivity}…</span>
+              </div>
+            )}
+            {error && (
+              <div data-testid="agent-panel-error" className="rounded-md border border-otel-negative/40 bg-otel-negative/10 px-3 py-2 text-xs text-otel-negative">
+                {error}
+              </div>
+            )}
+          </div>
+
+          <form onSubmit={handleSubmit} className="border-t border-border bg-card px-3 py-3">
+            <div className="flex items-end gap-2">
+              <input
+                data-testid="agent-panel-input"
+                value={draft}
+                onChange={(e) => setDraft(e.target.value)}
+                placeholder="Message the dashboard agent…"
+                aria-label="Message the dashboard agent"
+                className="flex-1 rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+              />
+              <button
+                type="submit"
+                data-testid="agent-panel-send"
+                disabled={running || draft.trim().length === 0}
+                aria-label="Send message"
+                className="flex h-9 w-9 items-center justify-center rounded-md bg-primary text-primary-foreground hover:opacity-90 disabled:opacity-40"
+              >
+                {running ? <Loader2 className="h-4 w-4 animate-spin" /> : <Send className="h-4 w-4" />}
+              </button>
+            </div>
+          </form>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}
+
+function MessageBubble({ message }: { message: ChatMessage }) {
+  const isUser = message.role === 'user';
+  return (
+    <div data-testid={`agent-message-${message.role}`} className={cn('flex', isUser ? 'justify-end' : 'justify-start')}>
+      <div
+        className={cn(
+          'max-w-[85%] rounded-lg px-3 py-2 text-sm whitespace-pre-wrap break-words',
+          isUser ? 'bg-primary text-primary-foreground' : 'bg-muted text-foreground',
+        )}
+      >
+        {message.content || <span className="text-muted-foreground">…</span>}
+      </div>
+    </div>
+  );
+}

--- a/src/Content/Presentation/Presentation.Dashboard/src/components/agent/AgentPanel.tsx
+++ b/src/Content/Presentation/Presentation.Dashboard/src/components/agent/AgentPanel.tsx
@@ -4,6 +4,8 @@ import { Loader2, Send, Sparkles, X } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useChatStore, type ChatMessage } from '@/stores/chatStore';
 import { useDashboardAgent } from '@/hooks/useDashboardAgent';
+import { TimeSeriesChart } from '@/components/charts/TimeSeriesChart';
+import { MetricBarChart } from '@/components/charts/BarChart';
 
 /**
  * Embedded dashboard agent panel — a right-side slide-over (Radix Dialog, mirroring
@@ -116,6 +118,8 @@ export function AgentPanel() {
 }
 
 function MessageBubble({ message }: { message: ChatMessage }) {
+  if (message.chart) return <ChartCard message={message} />;
+
   const isUser = message.role === 'user';
   return (
     <div data-testid={`agent-message-${message.role}`} className={cn('flex', isUser ? 'justify-end' : 'justify-start')}>
@@ -127,6 +131,30 @@ function MessageBubble({ message }: { message: ChatMessage }) {
       >
         {message.content || <span className="text-muted-foreground">…</span>}
       </div>
+    </div>
+  );
+}
+
+/**
+ * Renders a chart the agent generated inline, reusing the dashboard's existing chart components
+ * (bar/pie → {@link MetricBarChart}, otherwise → {@link TimeSeriesChart}) populated from real metric data.
+ */
+function ChartCard({ message }: { message: ChatMessage }) {
+  const chart = message.chart!;
+  const isBar = chart.chartType === 'bar' || chart.chartType === 'pie';
+  return (
+    <div data-testid="agent-message-chart" className="rounded-lg border border-border bg-muted/40 p-3">
+      <div className="mb-2 text-xs font-medium text-foreground">{chart.title}</div>
+      <div className="h-48">
+        {chart.series.length === 0 ? (
+          <p className="text-xs text-muted-foreground">No data for the current time range.</p>
+        ) : isBar ? (
+          <MetricBarChart series={chart.series} unit={chart.unit} />
+        ) : (
+          <TimeSeriesChart series={chart.series} unit={chart.unit} />
+        )}
+      </div>
+      {message.content && <p className="mt-2 text-xs text-muted-foreground">{message.content}</p>}
     </div>
   );
 }

--- a/src/Content/Presentation/Presentation.Dashboard/src/components/layout/DashboardShell.tsx
+++ b/src/Content/Presentation/Presentation.Dashboard/src/components/layout/DashboardShell.tsx
@@ -1,6 +1,7 @@
 import { Outlet } from 'react-router-dom';
 import { Sidebar } from './Sidebar';
 import { Topbar } from './Topbar';
+import { AgentPanel } from '@/components/agent/AgentPanel';
 import { useTelemetryStream } from '@/realtime/useTelemetryStream';
 
 export default function DashboardShell() {
@@ -15,6 +16,8 @@ export default function DashboardShell() {
           <Outlet />
         </main>
       </div>
+      {/* Mounted once at the shell level so the agent panel overlays every page. */}
+      <AgentPanel />
     </div>
   );
 }

--- a/src/Content/Presentation/Presentation.Dashboard/src/components/layout/Topbar.tsx
+++ b/src/Content/Presentation/Presentation.Dashboard/src/components/layout/Topbar.tsx
@@ -1,8 +1,9 @@
-import { RefreshCw } from 'lucide-react';
+import { RefreshCw, Sparkles } from 'lucide-react';
 import { TimeRangePicker } from './TimeRangePicker';
 import { ThemeToggle } from '@/components/theme/ThemeToggle';
 import { useTelemetryStore } from '@/stores/telemetryStore';
 import { useTimeRangeStore } from '@/stores/timeRangeStore';
+import { useChatStore } from '@/stores/chatStore';
 import { useQueryClient } from '@tanstack/react-query';
 import { useLocation } from 'react-router-dom';
 
@@ -43,6 +44,7 @@ function ConnectionPip({ connected }: { connected: boolean }) {
 export function Topbar() {
   const connected = useTelemetryStore((s) => s.connected);
   const refreshInterval = useTimeRangeStore((s) => s.refreshIntervalSeconds);
+  const toggleAgent = useChatStore((s) => s.toggle);
   const queryClient = useQueryClient();
   const location = useLocation();
 
@@ -62,6 +64,14 @@ export function Topbar() {
         </div>
       </div>
       <div className="flex items-center gap-2">
+        <button
+          onClick={toggleAgent}
+          className="p-1.5 rounded-md hover:bg-accent text-muted-foreground hover:text-foreground transition-colors"
+          aria-label="Open dashboard agent"
+          data-testid="agent-launcher"
+        >
+          <Sparkles className="h-3.5 w-3.5" />
+        </button>
         <button
           onClick={() => queryClient.invalidateQueries()}
           className="p-1.5 rounded-md hover:bg-accent text-muted-foreground hover:text-foreground transition-colors"

--- a/src/Content/Presentation/Presentation.Dashboard/src/hooks/useDashboardAgent.test.tsx
+++ b/src/Content/Presentation/Presentation.Dashboard/src/hooks/useDashboardAgent.test.tsx
@@ -104,6 +104,39 @@ describe('useDashboardAgent', () => {
     expect(createConversation).not.toHaveBeenCalled();
   });
 
+  it('recovers to error status when posting the tool result fails (does not hang on running)', async () => {
+    postToolResult.mockRejectedValueOnce(new Error('network down'));
+    runWith([
+      { type: EventType.TOOL_CALL_START, toolCallId: 'call-1', toolCallName: 'dashboard_control' },
+      { type: EventType.TOOL_CALL_ARGS, toolCallId: 'call-1', delta: JSON.stringify({ operation: 'refresh_data', parameters: {} }) },
+      { type: EventType.TOOL_CALL_END, toolCallId: 'call-1' },
+    ]);
+
+    const { result } = renderHook(() => useDashboardAgent());
+    await act(async () => {
+      await result.current.sendMessage('refresh');
+    });
+
+    await waitFor(() => expect(useChatStore.getState().status).toBe('error'));
+    expect(useChatStore.getState().error).toContain('network down');
+  });
+
+  it('still posts a result for a TOOL_CALL_END with no matching START (never hangs the server)', async () => {
+    runWith([
+      { type: EventType.TOOL_CALL_END, toolCallId: 'ghost' },
+      { type: EventType.RUN_FINISHED, threadId: 'thread-1', runId: 'r1' },
+    ]);
+
+    const { result } = renderHook(() => useDashboardAgent());
+    await act(async () => {
+      await result.current.sendMessage('go');
+    });
+
+    await waitFor(() =>
+      expect(postToolResult).toHaveBeenCalledWith('thread-1', 'ghost', expect.stringContaining('No client handler')),
+    );
+  });
+
   it('surfaces a RUN_ERROR as an error status', async () => {
     runWith([{ type: EventType.RUN_ERROR, message: 'boom' }]);
 

--- a/src/Content/Presentation/Presentation.Dashboard/src/hooks/useDashboardAgent.test.tsx
+++ b/src/Content/Presentation/Presentation.Dashboard/src/hooks/useDashboardAgent.test.tsx
@@ -1,0 +1,97 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { of } from 'rxjs';
+import { EventType } from '@ag-ui/core';
+
+const createConversation = vi.fn(async () => 'thread-1');
+const postToolResult = vi.fn(async () => {});
+const runMock = vi.fn();
+const createAuthenticatedAgUiAgent = vi.fn(async () => ({ run: runMock }));
+
+vi.mock('@/lib/agUiClient', () => ({
+  createConversation: (...args: unknown[]) => createConversation(...(args as [])),
+  postToolResult: (...args: unknown[]) => postToolResult(...(args as [])),
+  createAuthenticatedAgUiAgent: () => createAuthenticatedAgUiAgent(),
+}));
+
+const dispatchDashboardAction = vi.fn(async () => 'navigated to /spend');
+vi.mock('@/lib/dashboardActions', () => ({
+  dispatchDashboardAction: (...args: unknown[]) => dispatchDashboardAction(...(args as [])),
+  describeAction: () => 'Navigating',
+}));
+
+import { useDashboardAgent } from './useDashboardAgent';
+import { useChatStore } from '@/stores/chatStore';
+
+function runWith(events: unknown[]) {
+  runMock.mockReturnValue(of(...events));
+}
+
+describe('useDashboardAgent', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useChatStore.setState({ open: true, threadId: null, messages: [], status: 'idle', error: null, toolActivity: null });
+  });
+
+  it('creates a conversation, dispatches a dashboard_control call, posts the result, and streams text', async () => {
+    runWith([
+      { type: EventType.RUN_STARTED, threadId: 'thread-1', runId: 'r1' },
+      { type: EventType.TOOL_CALL_START, toolCallId: 'call-1', toolCallName: 'dashboard_control' },
+      { type: EventType.TOOL_CALL_ARGS, toolCallId: 'call-1', delta: JSON.stringify({ operation: 'navigate', parameters: { path: '/spend' } }) },
+      { type: EventType.TOOL_CALL_END, toolCallId: 'call-1' },
+      { type: EventType.TEXT_MESSAGE_START, messageId: 'm1', role: 'assistant' },
+      { type: EventType.TEXT_MESSAGE_CONTENT, messageId: 'm1', delta: 'Done.' },
+      { type: EventType.TEXT_MESSAGE_END, messageId: 'm1' },
+      { type: EventType.RUN_FINISHED, threadId: 'thread-1', runId: 'r1' },
+    ]);
+
+    const { result } = renderHook(() => useDashboardAgent());
+    await act(async () => {
+      await result.current.sendMessage('show spend');
+    });
+
+    expect(createConversation).toHaveBeenCalledTimes(1);
+    expect(useChatStore.getState().threadId).toBe('thread-1');
+
+    await waitFor(() => expect(dispatchDashboardAction).toHaveBeenCalledWith('navigate', { path: '/spend' }));
+    await waitFor(() => expect(postToolResult).toHaveBeenCalledWith('thread-1', 'call-1', 'navigated to /spend'));
+
+    const messages = useChatStore.getState().messages;
+    expect(messages[0]).toMatchObject({ role: 'user', content: 'show spend' });
+    expect(messages.some((m) => m.role === 'assistant' && m.content === 'Done.')).toBe(true);
+    expect(useChatStore.getState().status).toBe('idle');
+  });
+
+  it('reuses an existing threadId on a second turn', async () => {
+    useChatStore.setState({ threadId: 'existing' });
+    runWith([{ type: EventType.RUN_FINISHED, threadId: 'existing', runId: 'r1' }]);
+
+    const { result } = renderHook(() => useDashboardAgent());
+    await act(async () => {
+      await result.current.sendMessage('hello');
+    });
+
+    expect(createConversation).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a RUN_ERROR as an error status', async () => {
+    runWith([{ type: EventType.RUN_ERROR, message: 'boom' }]);
+
+    const { result } = renderHook(() => useDashboardAgent());
+    await act(async () => {
+      await result.current.sendMessage('go');
+    });
+
+    await waitFor(() => expect(useChatStore.getState().status).toBe('error'));
+    expect(useChatStore.getState().error).toBe('boom');
+  });
+
+  it('ignores empty input and does not start a run', async () => {
+    const { result } = renderHook(() => useDashboardAgent());
+    await act(async () => {
+      await result.current.sendMessage('   ');
+    });
+    expect(createAuthenticatedAgUiAgent).not.toHaveBeenCalled();
+    expect(useChatStore.getState().messages).toHaveLength(0);
+  });
+});

--- a/src/Content/Presentation/Presentation.Dashboard/src/hooks/useDashboardAgent.test.tsx
+++ b/src/Content/Presentation/Presentation.Dashboard/src/hooks/useDashboardAgent.test.tsx
@@ -20,6 +20,14 @@ vi.mock('@/lib/dashboardActions', () => ({
   describeAction: () => 'Navigating',
 }));
 
+const buildChart = vi.fn(async () => ({
+  chart: { title: 'Tokens by Model', chartType: 'pie', unit: 'tokens', series: [{ labels: {}, dataPoints: [] }] },
+  summary: 'Rendered a pie chart of "Tokens by Model" (1 series).',
+}));
+vi.mock('@/lib/chartRendering', () => ({
+  buildChart: (...args: unknown[]) => buildChart(...(args as [])),
+}));
+
 import { useDashboardAgent } from './useDashboardAgent';
 import { useChatStore } from '@/stores/chatStore';
 
@@ -60,6 +68,28 @@ describe('useDashboardAgent', () => {
     expect(messages[0]).toMatchObject({ role: 'user', content: 'show spend' });
     expect(messages.some((m) => m.role === 'assistant' && m.content === 'Done.')).toBe(true);
     expect(useChatStore.getState().status).toBe('idle');
+  });
+
+  it('renders a chart on a render_chart call and appends a chart message', async () => {
+    runWith([
+      { type: EventType.TOOL_CALL_START, toolCallId: 'c2', toolCallName: 'render_chart' },
+      { type: EventType.TOOL_CALL_ARGS, toolCallId: 'c2', delta: JSON.stringify({ metricId: 'tokens_by_model', chartType: 'pie' }) },
+      { type: EventType.TOOL_CALL_END, toolCallId: 'c2' },
+      { type: EventType.RUN_FINISHED, threadId: 'thread-1', runId: 'r1' },
+    ]);
+
+    const { result } = renderHook(() => useDashboardAgent());
+    await act(async () => {
+      await result.current.sendMessage('chart tokens by model');
+    });
+
+    await waitFor(() => expect(buildChart).toHaveBeenCalledWith({ metricId: 'tokens_by_model', chartType: 'pie' }));
+    await waitFor(() =>
+      expect(postToolResult).toHaveBeenCalledWith('thread-1', 'c2', 'Rendered a pie chart of "Tokens by Model" (1 series).'),
+    );
+
+    const chartMessage = useChatStore.getState().messages.find((m) => m.chart);
+    expect(chartMessage?.chart?.chartType).toBe('pie');
   });
 
   it('reuses an existing threadId on a second turn', async () => {

--- a/src/Content/Presentation/Presentation.Dashboard/src/hooks/useDashboardAgent.ts
+++ b/src/Content/Presentation/Presentation.Dashboard/src/hooks/useDashboardAgent.ts
@@ -1,0 +1,165 @@
+import { useCallback, useEffect, useRef } from 'react';
+import type { Subscription } from 'rxjs';
+import type { BaseEvent } from '@ag-ui/core';
+import { EventType } from '@ag-ui/core';
+import {
+  createAuthenticatedAgUiAgent,
+  createConversation,
+  postToolResult,
+} from '@/lib/agUiClient';
+import { describeAction, dispatchDashboardAction } from '@/lib/dashboardActions';
+import { useChatStore } from '@/stores/chatStore';
+
+/** The client round-trip tool the agent uses to act on the dashboard. */
+const DASHBOARD_CONTROL = 'dashboard_control';
+
+/** Accumulator for an in-flight tool call as its name and argument deltas stream in. */
+interface PendingCall {
+  name: string;
+  args: string;
+}
+
+/**
+ * Drives an embedded dashboard-agent conversation over AG-UI. Exposes {@link sendMessage}; all
+ * transcript and status state lives in the {@link useChatStore} so the panel can render it.
+ *
+ * The run uses the low-level {@link HttpAgent.run} observable (pure event transport) rather than the
+ * managed loop, so the non-standard mid-run blocking proxy works cleanly: on `TOOL_CALL_END` the hook
+ * executes the dashboard action locally and POSTs the result, which unblocks the server-side tool and
+ * resumes the same run with the agent's text response.
+ */
+export function useDashboardAgent() {
+  const subscriptionRef = useRef<Subscription | null>(null);
+  const pendingCallsRef = useRef<Map<string, PendingCall>>(new Map());
+
+  // Tear down any live run when the consuming component unmounts.
+  useEffect(() => () => subscriptionRef.current?.unsubscribe(), []);
+
+  const handleToolCallEnd = useCallback(async (threadId: string, callId: string) => {
+    const pending = pendingCallsRef.current.get(callId);
+    pendingCallsRef.current.delete(callId);
+    if (!pending) return;
+
+    // Only dashboard_control is a client round-trip tool; ignore any others defensively.
+    if (pending.name !== DASHBOARD_CONTROL) {
+      await postToolResult(threadId, callId, `Unsupported client tool "${pending.name}".`);
+      return;
+    }
+
+    let result: string;
+    try {
+      const { operation, parameters } = JSON.parse(pending.args || '{}') as {
+        operation?: string;
+        parameters?: Record<string, unknown>;
+      };
+      useChatStore.getState().setToolActivity(describeAction(operation ?? '', parameters ?? {}));
+      result = await dispatchDashboardAction(operation ?? '', parameters ?? {});
+    } catch {
+      result = 'The dashboard could not interpret the requested action.';
+    }
+
+    // Always post a result — even on failure — so the awaiting server-side tool never hangs.
+    await postToolResult(threadId, callId, result);
+  }, []);
+
+  const handleEvent = useCallback(
+    (threadId: string, event: BaseEvent) => {
+      const store = useChatStore.getState();
+      switch (event.type) {
+        case EventType.TEXT_MESSAGE_START: {
+          const e = event as BaseEvent & { messageId: string };
+          store.setToolActivity(null);
+          store.addMessage({ id: e.messageId, role: 'assistant', content: '' });
+          break;
+        }
+        case EventType.TEXT_MESSAGE_CONTENT: {
+          const e = event as BaseEvent & { messageId: string; delta: string };
+          store.appendToMessage(e.messageId, e.delta);
+          break;
+        }
+        case EventType.TOOL_CALL_START: {
+          const e = event as BaseEvent & { toolCallId: string; toolCallName: string };
+          pendingCallsRef.current.set(e.toolCallId, { name: e.toolCallName, args: '' });
+          break;
+        }
+        case EventType.TOOL_CALL_ARGS: {
+          const e = event as BaseEvent & { toolCallId: string; delta: string };
+          const pending = pendingCallsRef.current.get(e.toolCallId);
+          if (pending) pending.args += e.delta;
+          break;
+        }
+        case EventType.TOOL_CALL_END: {
+          const e = event as BaseEvent & { toolCallId: string };
+          void handleToolCallEnd(threadId, e.toolCallId);
+          break;
+        }
+        case EventType.RUN_ERROR: {
+          const e = event as BaseEvent & { message?: string };
+          store.setToolActivity(null);
+          store.setError(e.message ?? 'The agent run failed.');
+          store.setStatus('error');
+          break;
+        }
+        default:
+          break;
+      }
+    },
+    [handleToolCallEnd],
+  );
+
+  const sendMessage = useCallback(
+    async (text: string) => {
+      const trimmed = text.trim();
+      const store = useChatStore.getState();
+      if (!trimmed || store.status === 'running') return;
+
+      store.setError(null);
+      store.setStatus('running');
+      store.addMessage({ id: crypto.randomUUID(), role: 'user', content: trimmed });
+
+      try {
+        let threadId = store.threadId;
+        if (!threadId) {
+          threadId = await createConversation();
+          store.setThreadId(threadId);
+        }
+
+        const agent = await createAuthenticatedAgUiAgent();
+        subscriptionRef.current?.unsubscribe();
+        pendingCallsRef.current.clear();
+
+        subscriptionRef.current = agent
+          .run({
+            threadId,
+            runId: crypto.randomUUID(),
+            state: {},
+            messages: [{ id: crypto.randomUUID(), role: 'user', content: trimmed }],
+            tools: [],
+            context: [],
+            forwardedProps: {},
+          })
+          .subscribe({
+            next: (event) => handleEvent(threadId!, event),
+            error: (err: unknown) => {
+              const message = err instanceof Error ? err.message : 'The agent run failed.';
+              useChatStore.getState().setToolActivity(null);
+              useChatStore.getState().setError(message);
+              useChatStore.getState().setStatus('error');
+            },
+            complete: () => {
+              const s = useChatStore.getState();
+              s.setToolActivity(null);
+              if (s.status === 'running') s.setStatus('idle');
+            },
+          });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : 'Could not start the agent.';
+        store.setError(message);
+        store.setStatus('error');
+      }
+    },
+    [handleEvent],
+  );
+
+  return { sendMessage };
+}

--- a/src/Content/Presentation/Presentation.Dashboard/src/hooks/useDashboardAgent.ts
+++ b/src/Content/Presentation/Presentation.Dashboard/src/hooks/useDashboardAgent.ts
@@ -67,23 +67,37 @@ export function useDashboardAgent() {
   const handleToolCallEnd = useCallback(async (threadId: string, callId: string) => {
     const pending = pendingCallsRef.current.get(callId);
     pendingCallsRef.current.delete(callId);
-    if (!pending) return;
 
+    // Compute a result for every callId — including one we never saw a START for — so the awaiting
+    // server-side tool always gets a reply. The action runners already catch their own errors and
+    // return a string, so the only thing that can throw here is the POST itself.
     let result: string;
-    switch (pending.name) {
-      case DASHBOARD_CONTROL:
-        result = await runDashboardControl(pending.args);
-        break;
-      case RENDER_CHART:
-        result = await runRenderChart(pending.args);
-        break;
-      default:
-        result = `Unsupported client tool "${pending.name}".`;
-        break;
+    if (!pending) {
+      result = `No client handler matched tool call ${callId}.`;
+    } else {
+      switch (pending.name) {
+        case DASHBOARD_CONTROL:
+          result = await runDashboardControl(pending.args);
+          break;
+        case RENDER_CHART:
+          result = await runRenderChart(pending.args);
+          break;
+        default:
+          result = `Unsupported client tool "${pending.name}".`;
+          break;
+      }
     }
 
-    // Always post a result — even on failure — so the awaiting server-side tool never hangs.
-    await postToolResult(threadId, callId, result);
+    try {
+      await postToolResult(threadId, callId, result);
+    } catch (err) {
+      // The server tool is blocked on this POST; if delivery fails the run can never resume. Surface
+      // an error and stop the spinner so the panel recovers instead of hanging on 'running' forever.
+      const store = useChatStore.getState();
+      store.setToolActivity(null);
+      store.setError(err instanceof Error ? err.message : 'Could not deliver the tool result to the agent.');
+      store.setStatus('error');
+    }
   }, []);
 
   const handleEvent = useCallback(

--- a/src/Content/Presentation/Presentation.Dashboard/src/hooks/useDashboardAgent.ts
+++ b/src/Content/Presentation/Presentation.Dashboard/src/hooks/useDashboardAgent.ts
@@ -8,15 +8,44 @@ import {
   postToolResult,
 } from '@/lib/agUiClient';
 import { describeAction, dispatchDashboardAction } from '@/lib/dashboardActions';
+import { buildChart, type RenderChartParams } from '@/lib/chartRendering';
 import { useChatStore } from '@/stores/chatStore';
 
-/** The client round-trip tool the agent uses to act on the dashboard. */
+/** Client round-trip tools the agent uses to act on the dashboard. */
 const DASHBOARD_CONTROL = 'dashboard_control';
+const RENDER_CHART = 'render_chart';
 
 /** Accumulator for an in-flight tool call as its name and argument deltas stream in. */
 interface PendingCall {
   name: string;
   args: string;
+}
+
+/** Executes a `dashboard_control` call and returns the result string the agent should observe. */
+async function runDashboardControl(args: string): Promise<string> {
+  try {
+    const { operation, parameters } = JSON.parse(args || '{}') as {
+      operation?: string;
+      parameters?: Record<string, unknown>;
+    };
+    useChatStore.getState().setToolActivity(describeAction(operation ?? '', parameters ?? {}));
+    return await dispatchDashboardAction(operation ?? '', parameters ?? {});
+  } catch {
+    return 'The dashboard could not interpret the requested action.';
+  }
+}
+
+/** Executes a `render_chart` call: fetches the data, appends a chart message, and returns a summary. */
+async function runRenderChart(args: string): Promise<string> {
+  try {
+    const params = JSON.parse(args || '{}') as RenderChartParams;
+    useChatStore.getState().setToolActivity('Rendering chart');
+    const { chart, summary } = await buildChart(params);
+    useChatStore.getState().addMessage({ id: crypto.randomUUID(), role: 'assistant', content: summary, chart });
+    return summary;
+  } catch (e) {
+    return e instanceof Error ? e.message : 'Could not render the chart.';
+  }
 }
 
 /**
@@ -40,22 +69,17 @@ export function useDashboardAgent() {
     pendingCallsRef.current.delete(callId);
     if (!pending) return;
 
-    // Only dashboard_control is a client round-trip tool; ignore any others defensively.
-    if (pending.name !== DASHBOARD_CONTROL) {
-      await postToolResult(threadId, callId, `Unsupported client tool "${pending.name}".`);
-      return;
-    }
-
     let result: string;
-    try {
-      const { operation, parameters } = JSON.parse(pending.args || '{}') as {
-        operation?: string;
-        parameters?: Record<string, unknown>;
-      };
-      useChatStore.getState().setToolActivity(describeAction(operation ?? '', parameters ?? {}));
-      result = await dispatchDashboardAction(operation ?? '', parameters ?? {});
-    } catch {
-      result = 'The dashboard could not interpret the requested action.';
+    switch (pending.name) {
+      case DASHBOARD_CONTROL:
+        result = await runDashboardControl(pending.args);
+        break;
+      case RENDER_CHART:
+        result = await runRenderChart(pending.args);
+        break;
+      default:
+        result = `Unsupported client tool "${pending.name}".`;
+        break;
     }
 
     // Always post a result — even on failure — so the awaiting server-side tool never hangs.

--- a/src/Content/Presentation/Presentation.Dashboard/src/hooks/useDashboardAgent.ts
+++ b/src/Content/Presentation/Presentation.Dashboard/src/hooks/useDashboardAgent.ts
@@ -35,6 +35,14 @@ async function runDashboardControl(args: string): Promise<string> {
   }
 }
 
+/** Marks the current run as failed: clears the activity spinner, records the message, sets error status. */
+function failRun(message: string): void {
+  const store = useChatStore.getState();
+  store.setToolActivity(null);
+  store.setError(message);
+  store.setStatus('error');
+}
+
 /** Executes a `render_chart` call: fetches the data, appends a chart message, and returns a summary. */
 async function runRenderChart(args: string): Promise<string> {
   try {
@@ -93,10 +101,7 @@ export function useDashboardAgent() {
     } catch (err) {
       // The server tool is blocked on this POST; if delivery fails the run can never resume. Surface
       // an error and stop the spinner so the panel recovers instead of hanging on 'running' forever.
-      const store = useChatStore.getState();
-      store.setToolActivity(null);
-      store.setError(err instanceof Error ? err.message : 'Could not deliver the tool result to the agent.');
-      store.setStatus('error');
+      failRun(err instanceof Error ? err.message : 'Could not deliver the tool result to the agent.');
     }
   }, []);
 
@@ -133,9 +138,7 @@ export function useDashboardAgent() {
         }
         case EventType.RUN_ERROR: {
           const e = event as BaseEvent & { message?: string };
-          store.setToolActivity(null);
-          store.setError(e.message ?? 'The agent run failed.');
-          store.setStatus('error');
+          failRun(e.message ?? 'The agent run failed.');
           break;
         }
         default:
@@ -178,12 +181,7 @@ export function useDashboardAgent() {
           })
           .subscribe({
             next: (event) => handleEvent(threadId!, event),
-            error: (err: unknown) => {
-              const message = err instanceof Error ? err.message : 'The agent run failed.';
-              useChatStore.getState().setToolActivity(null);
-              useChatStore.getState().setError(message);
-              useChatStore.getState().setStatus('error');
-            },
+            error: (err: unknown) => failRun(err instanceof Error ? err.message : 'The agent run failed.'),
             complete: () => {
               const s = useChatStore.getState();
               s.setToolActivity(null);
@@ -191,9 +189,7 @@ export function useDashboardAgent() {
             },
           });
       } catch (err) {
-        const message = err instanceof Error ? err.message : 'Could not start the agent.';
-        store.setError(message);
-        store.setStatus('error');
+        failRun(err instanceof Error ? err.message : 'Could not start the agent.');
       }
     },
     [handleEvent],

--- a/src/Content/Presentation/Presentation.Dashboard/src/lib/agUiClient.ts
+++ b/src/Content/Presentation/Presentation.Dashboard/src/lib/agUiClient.ts
@@ -1,0 +1,70 @@
+import { HttpAgent } from '@ag-ui/client';
+import { apiClient } from '@/api/client';
+import { loginRequest, msalInstance } from '@/auth/authConfig';
+import { IS_AUTH_DISABLED } from '@/auth/devAuth';
+
+/** Path of the AG-UI streaming run endpoint (proxied to the AgentHub backend in dev). */
+const AG_UI_RUN_URL = '/ag-ui/run';
+
+/**
+ * Resolves the bearer token for the AG-UI endpoint, mirroring the axios request interceptor
+ * in {@link apiClient}. Returns an empty string when auth is disabled (dev mode) or no account
+ * is signed in, in which case no Authorization header is sent and the backend's dev auth applies.
+ */
+export async function getAccessToken(): Promise<string> {
+  if (IS_AUTH_DISABLED) return '';
+
+  const account = msalInstance.getAllAccounts()[0];
+  if (!account) return '';
+
+  const result = await msalInstance.acquireTokenSilent({ account, scopes: loginRequest.scopes });
+  return result.accessToken;
+}
+
+/**
+ * Builds the request headers for the AG-UI agent. Tokens expire, so callers should construct a
+ * fresh agent (and thus fresh headers) per run rather than caching one long-term.
+ */
+async function buildAgUiHeaders(): Promise<Record<string, string>> {
+  try {
+    const token = await getAccessToken();
+    if (token) return { Authorization: `Bearer ${token}` };
+  } catch {
+    // Token acquisition failed (e.g. auth disabled mid-session) — fall through to no header.
+  }
+  return {};
+}
+
+/**
+ * Creates an {@link HttpAgent} pointed at the AG-UI run endpoint with a freshly-resolved auth
+ * header. Use `agent.run(input)` to obtain the raw event observable for a run.
+ */
+export async function createAuthenticatedAgUiAgent(): Promise<HttpAgent> {
+  const headers = await buildAgUiHeaders();
+  return new HttpAgent({ url: AG_UI_RUN_URL, headers });
+}
+
+/**
+ * Completes a mid-run client round-trip by posting the browser's result for a tool call back to the
+ * backend, which unblocks the awaiting server-side tool and resumes the same run. Auth is applied by
+ * the shared {@link apiClient} interceptor.
+ */
+export async function postToolResult(
+  threadId: string,
+  callId: string,
+  result: string,
+): Promise<void> {
+  await apiClient.post('/ag-ui/tool-result', { threadId, callId, result });
+}
+
+/**
+ * Creates a new conversation owned by the caller and returns its thread id. The panel calls this
+ * once per chat session before starting the first run.
+ */
+export async function createConversation(agentName = 'dashboard-agent'): Promise<string> {
+  const { data } = await apiClient.post<{ threadId: string; agentName: string }>(
+    '/api/conversations',
+    { agentName },
+  );
+  return data.threadId;
+}

--- a/src/Content/Presentation/Presentation.Dashboard/src/lib/chartRendering.test.ts
+++ b/src/Content/Presentation/Presentation.Dashboard/src/lib/chartRendering.test.ts
@@ -7,6 +7,11 @@ const { getCatalog, queryRange } = vi.hoisted(() => ({
 
 vi.mock('@/api/metrics', () => ({ getCatalog, queryRange }));
 
+// Bypass the real query cache so each test sees its own getCatalog mock (no cross-test caching).
+vi.mock('@/app/queryClient', () => ({
+  queryClient: { fetchQuery: ({ queryFn }: { queryFn: () => unknown }) => queryFn() },
+}));
+
 import { buildChart } from './chartRendering';
 
 const CATALOG = [

--- a/src/Content/Presentation/Presentation.Dashboard/src/lib/chartRendering.test.ts
+++ b/src/Content/Presentation/Presentation.Dashboard/src/lib/chartRendering.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const { getCatalog, queryRange } = vi.hoisted(() => ({
+  getCatalog: vi.fn(),
+  queryRange: vi.fn(),
+}));
+
+vi.mock('@/api/metrics', () => ({ getCatalog, queryRange }));
+
+import { buildChart } from './chartRendering';
+
+const CATALOG = [
+  { id: 'tokens_by_model', title: 'Tokens by Model', description: '', query: 'sum by (model) (tokens)', chartType: 'pie', unit: 'tokens', category: 'tokens' },
+];
+
+const ONE_SERIES = {
+  success: true,
+  resultType: 'matrix',
+  series: [{ labels: { model: 'gpt-4o' }, dataPoints: [{ timestamp: 1, value: '5' }] }],
+};
+
+describe('buildChart', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getCatalog.mockResolvedValue(CATALOG);
+    queryRange.mockResolvedValue(ONE_SERIES);
+  });
+
+  it('resolves a metricId via the catalog and queries its PromQL', async () => {
+    const { chart, summary } = await buildChart({ metricId: 'tokens_by_model' });
+    expect(queryRange).toHaveBeenCalledWith('sum by (model) (tokens)', expect.any(String), expect.any(String), expect.any(String));
+    expect(chart.title).toBe('Tokens by Model');
+    expect(chart.chartType).toBe('pie');
+    expect(chart.unit).toBe('tokens');
+    expect(chart.series).toHaveLength(1);
+    expect(summary).toContain('pie');
+  });
+
+  it('lets the agent override the chart type', async () => {
+    const { chart } = await buildChart({ metricId: 'tokens_by_model', chartType: 'bar' });
+    expect(chart.chartType).toBe('bar');
+  });
+
+  it('uses a raw promQL query when no metricId is given', async () => {
+    const { chart } = await buildChart({ promQL: 'up', title: 'Up' });
+    expect(queryRange).toHaveBeenCalledWith('up', expect.any(String), expect.any(String), expect.any(String));
+    expect(chart.title).toBe('Up');
+    expect(chart.chartType).toBe('timeseries');
+  });
+
+  it('rejects an unknown metricId', async () => {
+    await expect(buildChart({ metricId: 'does-not-exist' })).rejects.toThrow(/unknown metric/i);
+  });
+
+  it('rejects when neither metricId nor promQL is supplied', async () => {
+    await expect(buildChart({})).rejects.toThrow();
+  });
+
+  it('summarizes an empty result as no data', async () => {
+    queryRange.mockResolvedValue({ success: true, resultType: 'matrix', series: [] });
+    const { chart, summary } = await buildChart({ promQL: 'up' });
+    expect(chart.series).toHaveLength(0);
+    expect(summary.toLowerCase()).toContain('no data');
+  });
+});

--- a/src/Content/Presentation/Presentation.Dashboard/src/lib/chartRendering.ts
+++ b/src/Content/Presentation/Presentation.Dashboard/src/lib/chartRendering.ts
@@ -1,0 +1,75 @@
+import { getCatalog, queryRange } from '@/api/metrics';
+import { useTimeRangeStore } from '@/stores/timeRangeStore';
+import type { ChartSpec } from '@/stores/chatStore';
+
+/** Parameters the agent supplies to `render_chart`. */
+export interface RenderChartParams {
+  metricId?: string;
+  promQL?: string;
+  chartType?: string;
+  title?: string;
+}
+
+/** Normalizes a catalog/agent chart type to one the panel can render. */
+function normalizeChartType(raw: string | undefined): 'timeseries' | 'bar' | 'pie' {
+  switch ((raw ?? '').toLowerCase()) {
+    case 'bar':
+      return 'bar';
+    case 'pie':
+      return 'pie';
+    default:
+      // stat / gauge / line / area / timeseries all render as a time series.
+      return 'timeseries';
+  }
+}
+
+function asString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : null;
+}
+
+/**
+ * Resolves a `render_chart` request to a concrete {@link ChartSpec} plus a short textual summary the
+ * agent can narrate. A `metricId` is looked up in the dashboard's metric catalog (single source of
+ * truth); otherwise a raw `promQL` query is used. Data is fetched over the dashboard's current time
+ * range via the existing metrics API, so the chart matches what the dashboard would show.
+ */
+export async function buildChart(
+  params: RenderChartParams,
+): Promise<{ chart: ChartSpec; summary: string }> {
+  const metricId = asString(params.metricId);
+  const promQL = asString(params.promQL);
+
+  let query: string;
+  let title: string;
+  let unit: string | undefined;
+  let chartType: string | undefined = asString(params.chartType) ?? undefined;
+
+  if (metricId) {
+    const entry = (await getCatalog()).find((e) => e.id === metricId);
+    if (!entry) {
+      throw new Error(`Unknown metric "${metricId}".`);
+    }
+    query = entry.query;
+    title = asString(params.title) ?? entry.title;
+    unit = entry.unit;
+    chartType = chartType ?? entry.chartType;
+  } else if (promQL) {
+    query = promQL;
+    title = asString(params.title) ?? 'Chart';
+  } else {
+    throw new Error('Provide a metricId or a promQL query.');
+  }
+
+  const { start, end, step } = useTimeRangeStore.getState().getRange();
+  const response = await queryRange(query, start, end, step);
+  const series = response.series ?? [];
+  const renderType = normalizeChartType(chartType);
+
+  const chart: ChartSpec = { title, chartType: renderType, unit, series };
+  const summary =
+    series.length === 0
+      ? `No data available for "${title}" over the current time range.`
+      : `Rendered a ${renderType} chart of "${title}" (${series.length} series).`;
+
+  return { chart, summary };
+}

--- a/src/Content/Presentation/Presentation.Dashboard/src/lib/chartRendering.ts
+++ b/src/Content/Presentation/Presentation.Dashboard/src/lib/chartRendering.ts
@@ -1,5 +1,8 @@
 import { getCatalog, queryRange } from '@/api/metrics';
+import { queryClient } from '@/app/queryClient';
+import { asString } from '@/lib/utils';
 import { useTimeRangeStore } from '@/stores/timeRangeStore';
+import type { MetricCatalogEntry } from '@/api/types';
 import type { ChartSpec } from '@/stores/chatStore';
 
 /** Parameters the agent supplies to `render_chart`. */
@@ -11,7 +14,7 @@ export interface RenderChartParams {
 }
 
 /** Normalizes a catalog/agent chart type to one the panel can render. */
-function normalizeChartType(raw: string | undefined): 'timeseries' | 'bar' | 'pie' {
+function normalizeChartType(raw: string | null | undefined): 'timeseries' | 'bar' | 'pie' {
   switch ((raw ?? '').toLowerCase()) {
     case 'bar':
       return 'bar';
@@ -23,8 +26,17 @@ function normalizeChartType(raw: string | undefined): 'timeseries' | 'bar' | 'pi
   }
 }
 
-function asString(value: unknown): string | null {
-  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : null;
+/**
+ * Loads the dashboard metric catalog, cached for the session. Uses the same server catalog the agent's
+ * `list_metrics` tool exposes (so a metricId the agent picked always resolves), routed through the
+ * shared query cache so repeated chart requests don't re-fetch it. The catalog is static at runtime.
+ */
+function loadCatalog(): Promise<MetricCatalogEntry[]> {
+  return queryClient.fetchQuery({
+    queryKey: ['metricsCatalog'],
+    queryFn: getCatalog,
+    staleTime: Infinity,
+  });
 }
 
 /**
@@ -42,10 +54,10 @@ export async function buildChart(
   let query: string;
   let title: string;
   let unit: string | undefined;
-  let chartType: string | undefined = asString(params.chartType) ?? undefined;
+  let chartType = asString(params.chartType);
 
   if (metricId) {
-    const entry = (await getCatalog()).find((e) => e.id === metricId);
+    const entry = (await loadCatalog()).find((e) => e.id === metricId);
     if (!entry) {
       throw new Error(`Unknown metric "${metricId}".`);
     }

--- a/src/Content/Presentation/Presentation.Dashboard/src/lib/dashboardActions.test.ts
+++ b/src/Content/Presentation/Presentation.Dashboard/src/lib/dashboardActions.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// vi.hoisted runs before the hoisted vi.mock factories, so these spies exist when the
+// factory objects are constructed (a plain top-level const would not yet be initialized).
+const { navigateMock, invalidateMock } = vi.hoisted(() => ({
+  navigateMock: vi.fn(),
+  invalidateMock: vi.fn(),
+}));
+
+vi.mock('@/app/router', () => ({
+  router: { navigate: navigateMock, state: { location: { pathname: '/spend/tokens' } } },
+}));
+vi.mock('@/app/queryClient', () => ({
+  queryClient: { invalidateQueries: invalidateMock },
+}));
+
+import { dispatchDashboardAction, describeAction } from './dashboardActions';
+import { useTimeRangeStore } from '@/stores/timeRangeStore';
+import { useThemeStore } from '@/stores/themeStore';
+
+describe('dispatchDashboardAction', () => {
+  beforeEach(() => {
+    navigateMock.mockClear();
+    invalidateMock.mockClear();
+    useTimeRangeStore.setState({ preset: '1h', customStart: null, customEnd: null });
+    useThemeStore.setState({ theme: 'dark' });
+  });
+
+  it('get_state returns the current page, preset and theme as JSON', async () => {
+    const result = await dispatchDashboardAction('get_state', {});
+    const parsed = JSON.parse(result);
+    expect(parsed.page).toBe('/spend/tokens');
+    expect(parsed.preset).toBe('1h');
+    expect(parsed.theme).toBe('dark');
+  });
+
+  it('set_time_range applies a valid preset to the store', async () => {
+    const result = await dispatchDashboardAction('set_time_range', { preset: '24h' });
+    expect(useTimeRangeStore.getState().preset).toBe('24h');
+    expect(result).toContain('24h');
+  });
+
+  it('set_time_range rejects an unsupported preset without changing state', async () => {
+    const result = await dispatchDashboardAction('set_time_range', { preset: '90d' });
+    expect(useTimeRangeStore.getState().preset).toBe('1h');
+    expect(result.toLowerCase()).toContain('unsupported');
+  });
+
+  it('set_time_range applies a custom from/to window', async () => {
+    await dispatchDashboardAction('set_time_range', { from: '2026-06-01T00:00:00Z', to: '2026-06-02T00:00:00Z' });
+    const tr = useTimeRangeStore.getState();
+    expect(tr.preset).toBe('custom');
+    expect(tr.customStart).toBe('2026-06-01T00:00:00Z');
+    expect(tr.customEnd).toBe('2026-06-02T00:00:00Z');
+  });
+
+  it('navigate routes to the supplied path', async () => {
+    const result = await dispatchDashboardAction('navigate', { path: '/spend/cost' });
+    expect(navigateMock).toHaveBeenCalledWith('/spend/cost');
+    expect(result).toContain('/spend/cost');
+  });
+
+  it('navigate rejects a non-path argument', async () => {
+    const result = await dispatchDashboardAction('navigate', { path: 'spend' });
+    expect(navigateMock).not.toHaveBeenCalled();
+    expect(result.toLowerCase()).toContain('no valid path');
+  });
+
+  it('refresh_data invalidates queries', async () => {
+    await dispatchDashboardAction('refresh_data', {});
+    expect(invalidateMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('unknown operation returns an explanatory message and does not throw', async () => {
+    const result = await dispatchDashboardAction('self_destruct', {});
+    expect(result.toLowerCase()).toContain('unknown');
+  });
+
+  it('describeAction summarizes navigation with the path', () => {
+    expect(describeAction('navigate', { path: '/spend' })).toContain('/spend');
+  });
+});

--- a/src/Content/Presentation/Presentation.Dashboard/src/lib/dashboardActions.ts
+++ b/src/Content/Presentation/Presentation.Dashboard/src/lib/dashboardActions.ts
@@ -60,10 +60,10 @@ function navigate(params: ActionParams): string {
   return `Navigated to ${path}.`;
 }
 
-/** Refreshes all data for the current view by invalidating cached queries. */
+/** Refreshes dashboard data by invalidating cached queries (matches the Topbar refresh button). */
 function refreshData(): string {
   void queryClient.invalidateQueries();
-  return 'Refreshed the current view data.';
+  return 'Refreshed the dashboard data.';
 }
 
 /**

--- a/src/Content/Presentation/Presentation.Dashboard/src/lib/dashboardActions.ts
+++ b/src/Content/Presentation/Presentation.Dashboard/src/lib/dashboardActions.ts
@@ -1,0 +1,106 @@
+import { router } from '@/app/router';
+import { queryClient } from '@/app/queryClient';
+import { useTimeRangeStore, type TimeRangePreset } from '@/stores/timeRangeStore';
+import { useThemeStore } from '@/stores/themeStore';
+
+/** Parameters supplied by the agent for a `dashboard_control` operation. */
+export type ActionParams = Record<string, unknown>;
+
+/** Presets the agent may select via `set_time_range` (excludes the custom sentinel). */
+const SELECTABLE_PRESETS: readonly TimeRangePreset[] = ['1h', '6h', '24h', '7d'];
+
+function asString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : null;
+}
+
+/** Reads the current view state so the agent can reason about what the user is looking at. */
+function getState(): string {
+  const tr = useTimeRangeStore.getState();
+  const theme = useThemeStore.getState().theme;
+  return JSON.stringify({
+    page: router.state.location.pathname,
+    preset: tr.preset,
+    customStart: tr.customStart,
+    customEnd: tr.customEnd,
+    refreshIntervalSeconds: tr.refreshIntervalSeconds,
+    theme,
+  });
+}
+
+/** Changes the dashboard time range via a preset or an explicit custom from/to window. */
+function setTimeRange(params: ActionParams): string {
+  const tr = useTimeRangeStore.getState();
+
+  const preset = asString(params['preset']);
+  if (preset) {
+    if (!SELECTABLE_PRESETS.includes(preset as TimeRangePreset)) {
+      return `Unsupported preset "${preset}". Valid presets: ${SELECTABLE_PRESETS.join(', ')}.`;
+    }
+    tr.setPreset(preset as TimeRangePreset);
+    return `Time range set to ${preset}.`;
+  }
+
+  const from = asString(params['from']);
+  const to = asString(params['to']);
+  if (from && to) {
+    tr.setCustomRange(from, to);
+    return `Time range set to custom window ${from} → ${to}.`;
+  }
+
+  return 'No valid time range supplied. Provide a preset (1h, 6h, 24h, 7d) or both from and to.';
+}
+
+/** Navigates the dashboard to the given route path. */
+function navigate(params: ActionParams): string {
+  const path = asString(params['path']);
+  if (!path || !path.startsWith('/')) {
+    return 'No valid path supplied. Provide a path beginning with "/", e.g. /spend/tokens.';
+  }
+  void router.navigate(path);
+  return `Navigated to ${path}.`;
+}
+
+/** Refreshes all data for the current view by invalidating cached queries. */
+function refreshData(): string {
+  void queryClient.invalidateQueries();
+  return 'Refreshed the current view data.';
+}
+
+/**
+ * Maps a `dashboard_control` operation to a concrete dashboard effect and returns a short result
+ * string for the agent to observe. Unknown operations return an explanatory message rather than
+ * throwing, so a misbehaving agent never breaks the run.
+ */
+export async function dispatchDashboardAction(
+  operation: string,
+  params: ActionParams,
+): Promise<string> {
+  switch (operation) {
+    case 'get_state':
+      return getState();
+    case 'set_time_range':
+      return setTimeRange(params);
+    case 'navigate':
+      return navigate(params);
+    case 'refresh_data':
+      return refreshData();
+    default:
+      return `Unknown dashboard operation "${operation}".`;
+  }
+}
+
+/** A short, human-readable label for the activity indicator while an action runs. */
+export function describeAction(operation: string, params: ActionParams): string {
+  switch (operation) {
+    case 'get_state':
+      return 'Reading the current view';
+    case 'set_time_range':
+      return `Setting time range${asString(params['preset']) ? ` → ${asString(params['preset'])}` : ''}`;
+    case 'navigate':
+      return `Navigating${asString(params['path']) ? ` → ${asString(params['path'])}` : ''}`;
+    case 'refresh_data':
+      return 'Refreshing data';
+    default:
+      return operation;
+  }
+}

--- a/src/Content/Presentation/Presentation.Dashboard/src/lib/dashboardActions.ts
+++ b/src/Content/Presentation/Presentation.Dashboard/src/lib/dashboardActions.ts
@@ -1,5 +1,6 @@
 import { router } from '@/app/router';
 import { queryClient } from '@/app/queryClient';
+import { asString } from '@/lib/utils';
 import { useTimeRangeStore, type TimeRangePreset } from '@/stores/timeRangeStore';
 import { useThemeStore } from '@/stores/themeStore';
 
@@ -8,10 +9,6 @@ export type ActionParams = Record<string, unknown>;
 
 /** Presets the agent may select via `set_time_range` (excludes the custom sentinel). */
 const SELECTABLE_PRESETS: readonly TimeRangePreset[] = ['1h', '6h', '24h', '7d'];
-
-function asString(value: unknown): string | null {
-  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : null;
-}
 
 /** Reads the current view state so the agent can reason about what the user is looking at. */
 function getState(): string {

--- a/src/Content/Presentation/Presentation.Dashboard/src/lib/utils.ts
+++ b/src/Content/Presentation/Presentation.Dashboard/src/lib/utils.ts
@@ -4,3 +4,8 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+/** Returns a trimmed non-empty string, or null when the value is missing/blank/not a string. */
+export function asString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : null
+}

--- a/src/Content/Presentation/Presentation.Dashboard/src/stores/chatStore.test.ts
+++ b/src/Content/Presentation/Presentation.Dashboard/src/stores/chatStore.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useChatStore } from './chatStore';
+
+describe('chatStore', () => {
+  beforeEach(() => {
+    useChatStore.setState({
+      open: false,
+      threadId: null,
+      messages: [],
+      status: 'idle',
+      error: null,
+      toolActivity: null,
+    });
+  });
+
+  it('toggles and sets the open flag', () => {
+    useChatStore.getState().toggle();
+    expect(useChatStore.getState().open).toBe(true);
+    useChatStore.getState().setOpen(false);
+    expect(useChatStore.getState().open).toBe(false);
+  });
+
+  it('adds messages in order', () => {
+    const s = useChatStore.getState();
+    s.addMessage({ id: 'a', role: 'user', content: 'hi' });
+    s.addMessage({ id: 'b', role: 'assistant', content: '' });
+    expect(useChatStore.getState().messages.map((m) => m.id)).toEqual(['a', 'b']);
+  });
+
+  it('appends streaming deltas to the matching message only', () => {
+    const s = useChatStore.getState();
+    s.addMessage({ id: 'b', role: 'assistant', content: '' });
+    s.appendToMessage('b', 'Hello ');
+    s.appendToMessage('b', 'world');
+    s.appendToMessage('missing', 'ignored');
+    expect(useChatStore.getState().messages).toEqual([{ id: 'b', role: 'assistant', content: 'Hello world' }]);
+  });
+
+  it('reset clears transcript and run state but keeps open and threadId', () => {
+    useChatStore.setState({ open: true, threadId: 't1' });
+    const s = useChatStore.getState();
+    s.addMessage({ id: 'a', role: 'user', content: 'hi' });
+    s.setStatus('error');
+    s.setError('boom');
+    s.setToolActivity('navigating');
+
+    s.reset();
+
+    const after = useChatStore.getState();
+    expect(after.messages).toEqual([]);
+    expect(after.status).toBe('idle');
+    expect(after.error).toBeNull();
+    expect(after.toolActivity).toBeNull();
+    expect(after.open).toBe(true);
+    expect(after.threadId).toBe('t1');
+  });
+});

--- a/src/Content/Presentation/Presentation.Dashboard/src/stores/chatStore.ts
+++ b/src/Content/Presentation/Presentation.Dashboard/src/stores/chatStore.ts
@@ -1,0 +1,69 @@
+import { create } from 'zustand';
+
+/** Role of a message shown in the agent chat transcript. */
+export type ChatRole = 'user' | 'assistant';
+
+/** A single message in the agent chat transcript. */
+export interface ChatMessage {
+  id: string;
+  role: ChatRole;
+  content: string;
+}
+
+/** Lifecycle of the current agent run, used to gate input and show status. */
+export type ChatStatus = 'idle' | 'running' | 'error';
+
+interface ChatState {
+  /** Whether the agent panel is open. */
+  open: boolean;
+  /** The conversation thread id, created once per session and reused across turns. */
+  threadId: string | null;
+  /** The chat transcript, oldest first. */
+  messages: ChatMessage[];
+  /** Current run status. */
+  status: ChatStatus;
+  /** Last error message, when {@link status} is `error`. */
+  error: string | null;
+  /** A short, transient note describing the action the agent is performing (e.g. "navigate → /spend"). */
+  toolActivity: string | null;
+
+  setOpen: (open: boolean) => void;
+  toggle: () => void;
+  setThreadId: (id: string | null) => void;
+  setStatus: (status: ChatStatus) => void;
+  setError: (message: string | null) => void;
+  setToolActivity: (activity: string | null) => void;
+  /** Appends a new message to the transcript. */
+  addMessage: (message: ChatMessage) => void;
+  /** Appends a text delta to the message with the given id (no-op if it does not exist). */
+  appendToMessage: (id: string, delta: string) => void;
+  /** Clears the transcript and run state. Does not change {@link open} or {@link threadId}. */
+  reset: () => void;
+}
+
+export const useChatStore = create<ChatState>((set) => ({
+  open: false,
+  threadId: null,
+  messages: [],
+  status: 'idle',
+  error: null,
+  toolActivity: null,
+
+  setOpen: (open) => set({ open }),
+  toggle: () => set((state) => ({ open: !state.open })),
+  setThreadId: (threadId) => set({ threadId }),
+  setStatus: (status) => set({ status }),
+  setError: (error) => set({ error }),
+  setToolActivity: (toolActivity) => set({ toolActivity }),
+
+  addMessage: (message) => set((state) => ({ messages: [...state.messages, message] })),
+
+  appendToMessage: (id, delta) =>
+    set((state) => ({
+      messages: state.messages.map((m) =>
+        m.id === id ? { ...m, content: m.content + delta } : m,
+      ),
+    })),
+
+  reset: () => set({ messages: [], status: 'idle', error: null, toolActivity: null }),
+}));

--- a/src/Content/Presentation/Presentation.Dashboard/src/stores/chatStore.ts
+++ b/src/Content/Presentation/Presentation.Dashboard/src/stores/chatStore.ts
@@ -1,13 +1,30 @@
 import { create } from 'zustand';
+import type { MetricSeries } from '@/api/types';
 
 /** Role of a message shown in the agent chat transcript. */
 export type ChatRole = 'user' | 'assistant';
 
-/** A single message in the agent chat transcript. */
+/** A chart the agent rendered inline, populated from the dashboard's existing metric data. */
+export interface ChartSpec {
+  /** Heading shown above the chart. */
+  title: string;
+  /** Which chart component to render: `timeseries`, `bar`, or `pie`. */
+  chartType: string;
+  /** Optional display unit (e.g. `tokens`, `usd`). */
+  unit?: string;
+  /** The metric series to plot, in the dashboard's standard shape. */
+  series: MetricSeries[];
+}
+
+/**
+ * A single message in the agent chat transcript. A message is plain text unless {@link chart} is set,
+ * in which case the panel renders the chart inline and uses {@link content} as its caption/summary.
+ */
 export interface ChatMessage {
   id: string;
   role: ChatRole;
   content: string;
+  chart?: ChartSpec;
 }
 
 /** Lifecycle of the current agent run, used to gate input and show status. */

--- a/src/Content/Presentation/Presentation.Dashboard/vite.config.ts
+++ b/src/Content/Presentation/Presentation.Dashboard/vite.config.ts
@@ -13,6 +13,10 @@ export default defineConfig({
     proxy: {
       '/api': { target: 'http://localhost:52000', changeOrigin: true },
       '/hubs': { target: 'http://localhost:52000', ws: true, changeOrigin: true },
+      // AG-UI streaming endpoint. The agent panel POSTs to /ag-ui/run and reads an SSE
+      // response; the proxy must not buffer it (the backend sets X-Accel-Buffering: no
+      // and flushes each frame), so streamed tool-call and text events arrive live.
+      '/ag-ui': { target: 'http://localhost:52000', changeOrigin: true },
     },
   },
   test: {

--- a/src/Content/Tests/Application.AI.Common.Tests/FunctionInvocation/BlockingToolRoundTripTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/FunctionInvocation/BlockingToolRoundTripTests.cs
@@ -3,25 +3,28 @@ using FluentAssertions;
 using Microsoft.Extensions.AI;
 using Xunit;
 
-namespace Application.AI.Common.Tests.Spikes;
+namespace Application.AI.Common.Tests.FunctionInvocation;
 
 /// <summary>
-/// SPIKE (throwaway feasibility probe — not a production feature).
+/// Feasibility guard for the AG-UI "blocking proxy" pattern: a model-invoked tool blocks mid-run while
+/// it awaits a result supplied OUT OF BAND (a browser executing a client tool call and POSTing the
+/// result back to <c>POST /ag-ui/tool-result</c>), and the run then resumes with that result.
 ///
-/// Question: can a model-invoked tool block mid-run while it awaits a result supplied OUT OF BAND
-/// (e.g. a browser executing an AG-UI tool call and POSTing the result back), and then have the run
-/// resume with that result? This is the load-bearing unknown for an AG-UI client-tool round-trip.
+/// This is the load-bearing assumption behind <c>DashboardControlTool</c> + <c>AgUiClientToolBridge</c>
+/// + <c>PendingToolCallRegistry</c>. If a future framework upgrade breaks the function-invocation
+/// middleware's tolerance for a tool that parks on a <see cref="TaskCompletionSource{TResult}"/>, these
+/// tests fail loudly before the whole feature silently regresses.
 ///
-/// The existing <see cref="Infrastructure.AI.Tests.Pipeline.MeAiPipelineCompatibilityTests"/> already
-/// proves the basic tool round-trip (UseFunctionInvocation invokes a registered tool, then the model
-/// produces a final answer). What is unproven — and probed here — is whether the function-invocation
-/// middleware tolerates a tool that does NOT return promptly but instead parks on a
-/// <see cref="TaskCompletionSource{TResult}"/> completed by a separate caller.
+/// The existing <see cref="Infrastructure.AI.Tests.Pipeline.MeAiPipelineCompatibilityTests"/> proves the
+/// basic tool round-trip (UseFunctionInvocation invokes a registered tool, then the model produces a
+/// final answer). These tests add the missing property: the middleware tolerates a tool that does NOT
+/// return promptly but instead blocks until completed by a separate caller, and that cancellation of a
+/// blocked tool unwinds the run instead of hanging.
 ///
-/// We drive the SAME middleware the harness uses in production (<c>AgentFactory.BuildMiddlewarePipeline</c>
+/// They drive the SAME middleware the harness uses in production (<c>AgentFactory.BuildMiddlewarePipeline</c>
 /// → <c>.UseFunctionInvocation()</c>) over a deterministic fake chat client, so no live LLM is needed.
 /// </summary>
-public class BlockingToolRoundTripSpikeTests
+public class BlockingToolRoundTripTests
 {
     [Fact]
     public async Task BlockingTool_SuspendsRunUntilExternallyCompleted_ThenResumes()

--- a/src/Content/Tests/Application.AI.Common.Tests/Spikes/BlockingToolRoundTripSpikeTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Spikes/BlockingToolRoundTripSpikeTests.cs
@@ -1,0 +1,109 @@
+using Application.AI.Common.Tests.Fakes;
+using FluentAssertions;
+using Microsoft.Extensions.AI;
+using Xunit;
+
+namespace Application.AI.Common.Tests.Spikes;
+
+/// <summary>
+/// SPIKE (throwaway feasibility probe — not a production feature).
+///
+/// Question: can a model-invoked tool block mid-run while it awaits a result supplied OUT OF BAND
+/// (e.g. a browser executing an AG-UI tool call and POSTing the result back), and then have the run
+/// resume with that result? This is the load-bearing unknown for an AG-UI client-tool round-trip.
+///
+/// The existing <see cref="Infrastructure.AI.Tests.Pipeline.MeAiPipelineCompatibilityTests"/> already
+/// proves the basic tool round-trip (UseFunctionInvocation invokes a registered tool, then the model
+/// produces a final answer). What is unproven — and probed here — is whether the function-invocation
+/// middleware tolerates a tool that does NOT return promptly but instead parks on a
+/// <see cref="TaskCompletionSource{TResult}"/> completed by a separate caller.
+///
+/// We drive the SAME middleware the harness uses in production (<c>AgentFactory.BuildMiddlewarePipeline</c>
+/// → <c>.UseFunctionInvocation()</c>) over a deterministic fake chat client, so no live LLM is needed.
+/// </summary>
+public class BlockingToolRoundTripSpikeTests
+{
+    [Fact]
+    public async Task BlockingTool_SuspendsRunUntilExternallyCompleted_ThenResumes()
+    {
+        // A signal that the tool has begun executing (and is about to block), plus the out-of-band
+        // channel a "browser" would complete with the tool result.
+        var toolEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var blockingTool = AIFunctionFactory.Create(
+            async () =>
+            {
+                toolEntered.TrySetResult();
+                return await release.Task; // parks here until completed from outside the run
+            },
+            "block_tool",
+            "Blocks until an external caller supplies the result.");
+
+        // First model turn calls the tool; second turn (after the tool result is fed back) answers.
+        var pipeline = new FakeChatClient()
+            .EnqueueResponseWithToolCall("block_tool", "call-1")
+            .EnqueueResponse("done after tool")
+            .AsBuilder()
+            .UseFunctionInvocation()
+            .Build();
+
+        var runTask = pipeline.GetResponseAsync(
+            [new ChatMessage(ChatRole.User, "go")],
+            new ChatOptions { Tools = [blockingTool] });
+
+        // The model issued the tool call and the tool is now parked awaiting the external result.
+        await toolEntered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        runTask.IsCompleted.Should().BeFalse("the run must stay suspended while the tool blocks");
+
+        // Resume from outside the run — exactly like a browser POSTing back its tool result.
+        release.SetResult("tool-result-payload");
+
+        var response = await runTask.WaitAsync(TimeSpan.FromSeconds(5));
+        response.Text.Should().Be("done after tool",
+            "the run must resume and complete once the blocking tool is externally satisfied");
+    }
+
+    [Fact]
+    public async Task BlockingTool_Cancellation_UnwindsWithoutHanging()
+    {
+        var toolEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var cts = new CancellationTokenSource();
+
+        var blockingTool = AIFunctionFactory.Create(
+            async (CancellationToken ct) =>
+            {
+                toolEntered.TrySetResult();
+                using var reg = ct.Register(() => release.TrySetCanceled(ct));
+                return await release.Task;
+            },
+            "block_tool",
+            "Blocks until released or cancelled.");
+
+        var pipeline = new FakeChatClient()
+            .EnqueueResponseWithToolCall("block_tool", "call-1")
+            .EnqueueResponse("unreachable")
+            .AsBuilder()
+            .UseFunctionInvocation()
+            .Build();
+
+        var runTask = pipeline.GetResponseAsync(
+            [new ChatMessage(ChatRole.User, "go")],
+            new ChatOptions { Tools = [blockingTool] },
+            cts.Token);
+
+        await toolEntered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        cts.Cancel();
+
+        // The key property: cancelling a blocked tool unwinds the run promptly rather than hanging.
+        // Whether the framework propagates the cancellation or finishes some other way is acceptable;
+        // a TimeoutException (a hung run) is not.
+        var unwind = async () =>
+        {
+            try { await runTask.WaitAsync(TimeSpan.FromSeconds(5)); }
+            catch (OperationCanceledException) { /* acceptable: cancellation propagated */ }
+        };
+        await unwind.Should().NotThrowAsync<TimeoutException>();
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Tools/DashboardControlToolTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Tools/DashboardControlToolTests.cs
@@ -1,0 +1,105 @@
+using Application.AI.Common.Interfaces.Tools;
+using FluentAssertions;
+using Infrastructure.AI.Tools;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Tools;
+
+/// <summary>
+/// Tests for <see cref="DashboardControlTool"/> — the blocking proxy that delegates dashboard actions
+/// to the connected client via <see cref="IClientToolBridge"/>. Covers operation validation, the
+/// no-client failure, the serialized payload handed to the bridge, and timeout/cancellation handling.
+/// </summary>
+public sealed class DashboardControlToolTests
+{
+    [Fact]
+    public void Metadata_IsCorrect()
+    {
+        var sut = new DashboardControlTool(new FakeBridge());
+        sut.Name.Should().Be("dashboard_control");
+        sut.Description.Should().NotBeNullOrWhiteSpace();
+        sut.SupportedOperations.Should().BeEquivalentTo(["get_state", "set_time_range", "navigate", "refresh_data"]);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_UnknownOperation_Fails_WithoutCallingBridge()
+    {
+        var bridge = new FakeBridge();
+        var sut = new DashboardControlTool(bridge);
+
+        var result = await sut.ExecuteAsync("explode", new Dictionary<string, object?>());
+
+        result.Success.Should().BeFalse();
+        bridge.InvokeCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_NoClientAttached_Fails()
+    {
+        var sut = new DashboardControlTool(new FakeBridge { ClientAttached = false });
+
+        var result = await sut.ExecuteAsync("get_state", new Dictionary<string, object?>());
+
+        result.Success.Should().BeFalse();
+        result.Error.Should().Contain("client");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_HappyPath_PassesSerializedPayload_AndReturnsBridgeResult()
+    {
+        var bridge = new FakeBridge { Result = "navigated to /spend" };
+        var sut = new DashboardControlTool(bridge);
+
+        var result = await sut.ExecuteAsync("navigate",
+            new Dictionary<string, object?> { ["path"] = "/spend" });
+
+        result.Success.Should().BeTrue();
+        result.Output.Should().Be("navigated to /spend");
+        bridge.LastToolName.Should().Be("dashboard_control");
+        bridge.LastArgsJson.Should().Contain("navigate").And.Contain("/spend");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_BridgeTimeout_FailsGracefully()
+    {
+        var sut = new DashboardControlTool(new FakeBridge { Throw = new TimeoutException() });
+
+        var result = await sut.ExecuteAsync("refresh_data", new Dictionary<string, object?>());
+
+        result.Success.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Cancellation_Propagates()
+    {
+        var sut = new DashboardControlTool(new FakeBridge { Throw = new OperationCanceledException() });
+
+        var act = async () => await sut.ExecuteAsync("get_state", new Dictionary<string, object?>());
+
+        await act.Should().ThrowAsync<OperationCanceledException>(
+            "a cancelled run must unwind rather than being swallowed as a tool failure");
+    }
+
+    private sealed class FakeBridge : IClientToolBridge
+    {
+        public bool ClientAttached { get; init; } = true;
+        public string Result { get; init; } = "ok";
+        public Exception? Throw { get; init; }
+
+        public int InvokeCount { get; private set; }
+        public string? LastToolName { get; private set; }
+        public string? LastArgsJson { get; private set; }
+
+        public bool IsClientAttached => ClientAttached;
+
+        public Task<string> InvokeAsync(string toolName, string argumentsJson, CancellationToken cancellationToken = default)
+        {
+            InvokeCount++;
+            LastToolName = toolName;
+            LastArgsJson = argumentsJson;
+            if (Throw is not null)
+                return Task.FromException<string>(Throw);
+            return Task.FromResult(Result);
+        }
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Tools/ListMetricsToolTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Tools/ListMetricsToolTests.cs
@@ -1,0 +1,72 @@
+using System.Text.Json;
+using Application.AI.Common.Interfaces.Observability;
+using FluentAssertions;
+using Infrastructure.AI.Tools;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Tools;
+
+/// <summary>
+/// Tests for <see cref="ListMetricsTool"/> — the read-only tool that surfaces the shared metric catalog
+/// to the agent as JSON. Covers full listing, category filtering, and operation validation.
+/// </summary>
+public sealed class ListMetricsToolTests
+{
+    private static readonly IMetricCatalog Catalog = new FakeCatalog(
+    [
+        new MetricDescriptor("tokens_by_model", "Tokens by Model", "d1", "q1", "pie", "tokens", "tokens"),
+        new MetricDescriptor("cost_total", "Total Cost", "d2", "q2", "stat", "usd", "cost"),
+    ]);
+
+    [Fact]
+    public void Metadata_IsReadOnlyAndConcurrencySafe()
+    {
+        var sut = new ListMetricsTool(Catalog);
+        sut.Name.Should().Be("list_metrics");
+        sut.IsReadOnly.Should().BeTrue();
+        sut.IsConcurrencySafe.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_List_ReturnsAllEntriesAsJson()
+    {
+        var sut = new ListMetricsTool(Catalog);
+
+        var result = await sut.ExecuteAsync("list", new Dictionary<string, object?>());
+
+        result.Success.Should().BeTrue();
+        var entries = JsonSerializer.Deserialize<List<MetricDescriptor>>(result.Output!,
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        entries.Should().HaveCount(2);
+        entries!.Select(e => e.Id).Should().Contain(["tokens_by_model", "cost_total"]);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_List_FiltersByCategory()
+    {
+        var sut = new ListMetricsTool(Catalog);
+
+        var result = await sut.ExecuteAsync("list",
+            new Dictionary<string, object?> { ["category"] = "cost" });
+
+        result.Success.Should().BeTrue();
+        var entries = JsonSerializer.Deserialize<List<MetricDescriptor>>(result.Output!,
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        entries.Should().ContainSingle().Which.Id.Should().Be("cost_total");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_UnknownOperation_Fails()
+    {
+        var sut = new ListMetricsTool(Catalog);
+
+        var result = await sut.ExecuteAsync("delete", new Dictionary<string, object?>());
+
+        result.Success.Should().BeFalse();
+    }
+
+    private sealed class FakeCatalog(IReadOnlyList<MetricDescriptor> entries) : IMetricCatalog
+    {
+        public IReadOnlyList<MetricDescriptor> Entries { get; } = entries;
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Tools/RenderChartToolTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Tools/RenderChartToolTests.cs
@@ -1,0 +1,108 @@
+using Application.AI.Common.Interfaces.Tools;
+using FluentAssertions;
+using Infrastructure.AI.Tools;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Tools;
+
+/// <summary>
+/// Tests for <see cref="RenderChartTool"/> — the generative-UI tool that delegates chart rendering to
+/// the connected client via <see cref="IClientToolBridge"/>. Covers operation validation, the no-client
+/// and missing-metric failures, the serialized payload, and timeout/cancellation handling.
+/// </summary>
+public sealed class RenderChartToolTests
+{
+    private static Dictionary<string, object?> Args(params (string Key, object? Value)[] pairs)
+    {
+        var d = new Dictionary<string, object?>();
+        foreach (var (k, v) in pairs) d[k] = v;
+        return d;
+    }
+
+    [Fact]
+    public void Metadata_IsCorrect()
+    {
+        var sut = new RenderChartTool(new FakeBridge());
+        sut.Name.Should().Be("render_chart");
+        sut.SupportedOperations.Should().BeEquivalentTo(["render"]);
+        sut.Description.Should().Contain("metricId");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_UnknownOperation_Fails()
+    {
+        var bridge = new FakeBridge();
+        var result = await new RenderChartTool(bridge).ExecuteAsync("explode", Args(("metricId", "x")));
+        result.Success.Should().BeFalse();
+        bridge.InvokeCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_NoClientAttached_Fails()
+    {
+        var sut = new RenderChartTool(new FakeBridge { ClientAttached = false });
+        var result = await sut.ExecuteAsync("render", Args(("metricId", "tokens_by_model")));
+        result.Success.Should().BeFalse();
+        result.Error.Should().Contain("client");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_NoMetricOrQuery_Fails()
+    {
+        var bridge = new FakeBridge();
+        var result = await new RenderChartTool(bridge).ExecuteAsync("render", Args(("chartType", "bar")));
+        result.Success.Should().BeFalse();
+        bridge.InvokeCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_HappyPath_PassesSerializedArgs_AndReturnsSummary()
+    {
+        var bridge = new FakeBridge { Result = "Rendered pie chart of tokens by model." };
+        var result = await new RenderChartTool(bridge).ExecuteAsync(
+            "render", Args(("metricId", "tokens_by_model"), ("chartType", "pie")));
+
+        result.Success.Should().BeTrue();
+        result.Output.Should().Be("Rendered pie chart of tokens by model.");
+        bridge.LastToolName.Should().Be("render_chart");
+        bridge.LastArgsJson.Should().Contain("tokens_by_model").And.Contain("pie");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_BridgeTimeout_FailsGracefully()
+    {
+        var sut = new RenderChartTool(new FakeBridge { Throw = new TimeoutException() });
+        var result = await sut.ExecuteAsync("render", Args(("promQL", "up")));
+        result.Success.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Cancellation_Propagates()
+    {
+        var sut = new RenderChartTool(new FakeBridge { Throw = new OperationCanceledException() });
+        var act = async () => await sut.ExecuteAsync("render", Args(("promQL", "up")));
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    private sealed class FakeBridge : IClientToolBridge
+    {
+        public bool ClientAttached { get; init; } = true;
+        public string Result { get; init; } = "ok";
+        public Exception? Throw { get; init; }
+
+        public int InvokeCount { get; private set; }
+        public string? LastToolName { get; private set; }
+        public string? LastArgsJson { get; private set; }
+
+        public bool IsClientAttached => ClientAttached;
+
+        public Task<string> InvokeAsync(string toolName, string argumentsJson, CancellationToken cancellationToken = default)
+        {
+            InvokeCount++;
+            LastToolName = toolName;
+            LastArgsJson = argumentsJson;
+            if (Throw is not null) return Task.FromException<string>(Throw);
+            return Task.FromResult(Result);
+        }
+    }
+}

--- a/src/Content/Tests/Presentation.AgentHub.Tests/AgUi/AgUiClientToolBridgeTests.cs
+++ b/src/Content/Tests/Presentation.AgentHub.Tests/AgUi/AgUiClientToolBridgeTests.cs
@@ -25,7 +25,7 @@ public sealed class AgUiClientToolBridgeTests
     public async Task InvokeAsync_EmitsToolCallSequence_BlocksUntilCompleted_ThenReturnsResult()
     {
         var writer = new CapturingEventWriter();
-        var accessor = new AgUiEventWriterAccessor { Writer = writer };
+        var accessor = new AgUiEventWriterAccessor { Writer = writer, ThreadId = "thread-1" };
         var registry = new PendingToolCallRegistry();
         var bridge = new AgUiClientToolBridge(accessor, registry, Options());
 
@@ -43,8 +43,8 @@ public sealed class AgUiClientToolBridgeTests
         args.Delta.Should().Contain("navigate");
         start.ToolCallId.Should().Be(args.ToolCallId).And.Be(end.ToolCallId);
 
-        // Resume out-of-band, exactly like the resume endpoint completing the registry.
-        registry.TryComplete(start.ToolCallId, "navigated").Should().BeTrue();
+        // Resume out-of-band, exactly like the resume endpoint completing the registry (same thread).
+        registry.TryComplete(start.ToolCallId, "thread-1", "navigated").Should().BeTrue();
 
         (await invokeTask.WaitAsync(TimeSpan.FromSeconds(5))).Should().Be("navigated");
     }

--- a/src/Content/Tests/Presentation.AgentHub.Tests/AgUi/AgUiClientToolBridgeTests.cs
+++ b/src/Content/Tests/Presentation.AgentHub.Tests/AgUi/AgUiClientToolBridgeTests.cs
@@ -1,0 +1,94 @@
+using FluentAssertions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Presentation.AgentHub.AgUi;
+using Presentation.AgentHub.Config;
+using Xunit;
+
+namespace Presentation.AgentHub.Tests.AgUi;
+
+/// <summary>
+/// Unit tests for <see cref="AgUiClientToolBridge"/> — the mid-run blocking proxy. Verifies it emits the
+/// <c>TOOL_CALL_START</c>/<c>ARGS</c>/<c>END</c> sequence (sharing one callId), parks until the registry
+/// is completed out-of-band, returns the client's result, and fails fast when no client is attached.
+/// </summary>
+public sealed class AgUiClientToolBridgeTests
+{
+    private static IOptionsMonitor<AgentHubConfig> Options(int timeoutSeconds = 30)
+    {
+        var mock = new Mock<IOptionsMonitor<AgentHubConfig>>();
+        mock.Setup(m => m.CurrentValue).Returns(new AgentHubConfig { ClientToolTimeoutSeconds = timeoutSeconds });
+        return mock.Object;
+    }
+
+    [Fact]
+    public async Task InvokeAsync_EmitsToolCallSequence_BlocksUntilCompleted_ThenReturnsResult()
+    {
+        var writer = new CapturingEventWriter();
+        var accessor = new AgUiEventWriterAccessor { Writer = writer };
+        var registry = new PendingToolCallRegistry();
+        var bridge = new AgUiClientToolBridge(accessor, registry, Options());
+
+        var invokeTask = bridge.InvokeAsync("dashboard_control", "{\"operation\":\"navigate\"}");
+
+        // The three events must be emitted before the call resolves, all sharing one callId.
+        await WaitForAsync(() => writer.Events.Count >= 3);
+        invokeTask.IsCompleted.Should().BeFalse("the bridge must block awaiting the client result");
+
+        var start = writer.Events[0].Should().BeOfType<ToolCallStartEvent>().Subject;
+        var args = writer.Events[1].Should().BeOfType<ToolCallArgsEvent>().Subject;
+        var end = writer.Events[2].Should().BeOfType<ToolCallEndEvent>().Subject;
+
+        start.ToolCallName.Should().Be("dashboard_control");
+        args.Delta.Should().Contain("navigate");
+        start.ToolCallId.Should().Be(args.ToolCallId).And.Be(end.ToolCallId);
+
+        // Resume out-of-band, exactly like the resume endpoint completing the registry.
+        registry.TryComplete(start.ToolCallId, "navigated").Should().BeTrue();
+
+        (await invokeTask.WaitAsync(TimeSpan.FromSeconds(5))).Should().Be("navigated");
+    }
+
+    [Fact]
+    public async Task InvokeAsync_NoClientAttached_Throws()
+    {
+        var accessor = new AgUiEventWriterAccessor { Writer = null };
+        var bridge = new AgUiClientToolBridge(accessor, new PendingToolCallRegistry(), Options());
+
+        bridge.IsClientAttached.Should().BeFalse();
+
+        var act = async () => await bridge.InvokeAsync("dashboard_control", "{}");
+        await act.Should().ThrowAsync<InvalidOperationException>();
+    }
+
+    [Fact]
+    public void IsClientAttached_ReflectsAmbientWriter()
+    {
+        var accessor = new AgUiEventWriterAccessor();
+        var bridge = new AgUiClientToolBridge(accessor, new PendingToolCallRegistry(), Options());
+
+        bridge.IsClientAttached.Should().BeFalse();
+        accessor.Writer = new CapturingEventWriter();
+        bridge.IsClientAttached.Should().BeTrue();
+    }
+
+    private static async Task WaitForAsync(Func<bool> condition)
+    {
+        for (var i = 0; i < 200 && !condition(); i++)
+            await Task.Delay(10);
+        condition().Should().BeTrue("the expected state was not reached within the timeout");
+    }
+
+    /// <summary>An <see cref="IAgUiEventWriter"/> that records every event written, in order.</summary>
+    private sealed class CapturingEventWriter : IAgUiEventWriter
+    {
+        private readonly List<AgUiEvent> _events = [];
+        public IReadOnlyList<AgUiEvent> Events => _events;
+
+        public Task WriteAsync(AgUiEvent evt, CancellationToken ct = default)
+        {
+            _events.Add(evt);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Content/Tests/Presentation.AgentHub.Tests/AgUi/AgUiEventWriterTests.cs
+++ b/src/Content/Tests/Presentation.AgentHub.Tests/AgUi/AgUiEventWriterTests.cs
@@ -55,6 +55,33 @@ public class AgUiEventWriterTests
     }
 
     [Fact]
+    public async Task WriteAsync_ConcurrentWrites_ProduceIntactNonInterleavedFrames()
+    {
+        // The agent runs tool calls concurrently (AllowConcurrentInvocation = true), and blocking-proxy
+        // tools emit frames onto the same writer from those concurrent invocations. WriteAsync must
+        // serialize so each frame is written atomically; without the gate, concurrent writes to the
+        // underlying stream interleave bytes and corrupt the SSE.
+        using var stream = new MemoryStream();
+        var writer = new AgUiEventWriter(stream);
+
+        const int count = 64;
+        var writes = Enumerable.Range(0, count)
+            .Select(i => writer.WriteAsync(new TextMessageContentEvent($"m{i}", $"delta-{i}")));
+        await Task.WhenAll(writes);
+
+        var frames = Encoding.UTF8.GetString(stream.ToArray())
+            .Split("\n\n", StringSplitOptions.RemoveEmptyEntries);
+        frames.Should().HaveCount(count);
+
+        // Every frame must be a complete, parseable JSON object — proof that no two writes interleaved.
+        var ids = frames
+            .Select(f => System.Text.Json.JsonDocument.Parse(f.Replace("data: ", "")))
+            .Select(d => d.RootElement.GetProperty("messageId").GetString())
+            .ToList();
+        ids.Should().BeEquivalentTo(Enumerable.Range(0, count).Select(i => $"m{i}"));
+    }
+
+    [Fact]
     public async Task WriteAsync_NullOptionalFields_OmittedFromJson()
     {
         using var stream = new MemoryStream();

--- a/src/Content/Tests/Presentation.AgentHub.Tests/AgUi/AgUiToolCallEventSerializationTests.cs
+++ b/src/Content/Tests/Presentation.AgentHub.Tests/AgUi/AgUiToolCallEventSerializationTests.cs
@@ -1,0 +1,59 @@
+using System.Text.Json;
+using FluentAssertions;
+using Presentation.AgentHub.AgUi;
+using Xunit;
+
+namespace Presentation.AgentHub.Tests.AgUi;
+
+/// <summary>
+/// Verifies the three client round-trip tool-call events serialize with the AG-UI wire discriminators
+/// and property names the browser expects. Serialization goes through the <see cref="AgUiEvent"/> base
+/// type so the polymorphic <c>type</c> field is emitted — exactly how <c>AgUiEventWriter</c> writes them.
+/// </summary>
+public sealed class AgUiToolCallEventSerializationTests
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    [Fact]
+    public void ToolCallStartEvent_Serializes_WithIdAndName()
+    {
+        var json = JsonSerializer.Serialize<AgUiEvent>(new ToolCallStartEvent("call-1", "dashboard_control"), JsonOptions);
+        json.Should().Contain("\"type\":\"TOOL_CALL_START\"");
+        json.Should().Contain("\"toolCallId\":\"call-1\"");
+        json.Should().Contain("\"toolCallName\":\"dashboard_control\"");
+    }
+
+    [Fact]
+    public void ToolCallArgsEvent_Serializes_WithDelta()
+    {
+        var json = JsonSerializer.Serialize<AgUiEvent>(new ToolCallArgsEvent("call-1", "{\"operation\":\"navigate\"}"), JsonOptions);
+        json.Should().Contain("\"type\":\"TOOL_CALL_ARGS\"");
+        json.Should().Contain("\"toolCallId\":\"call-1\"");
+        json.Should().Contain("\"delta\":");
+        json.Should().Contain("navigate");
+    }
+
+    [Fact]
+    public void ToolCallEndEvent_Serializes_WithId()
+    {
+        var json = JsonSerializer.Serialize<AgUiEvent>(new ToolCallEndEvent("call-1"), JsonOptions);
+        json.Should().Contain("\"type\":\"TOOL_CALL_END\"");
+        json.Should().Contain("\"toolCallId\":\"call-1\"");
+    }
+
+    [Fact]
+    public void ToolCallEvents_RoundTrip_ThroughPolymorphicBase()
+    {
+        var json = JsonSerializer.Serialize<AgUiEvent>(new ToolCallStartEvent("call-9", "list_metrics"), JsonOptions);
+
+        var back = JsonSerializer.Deserialize<AgUiEvent>(json, JsonOptions);
+
+        var typed = back.Should().BeOfType<ToolCallStartEvent>().Subject;
+        typed.ToolCallId.Should().Be("call-9");
+        typed.ToolCallName.Should().Be("list_metrics");
+    }
+}

--- a/src/Content/Tests/Presentation.AgentHub.Tests/AgUi/AgUiToolResultEndpointTests.cs
+++ b/src/Content/Tests/Presentation.AgentHub.Tests/AgUi/AgUiToolResultEndpointTests.cs
@@ -46,7 +46,7 @@ public sealed class AgUiToolResultEndpointTests : IClassFixture<TestWebApplicati
         var owner = $"tr-owner-{Guid.NewGuid():N}";
         var conv = await store.CreateAsync("dashboard-agent", owner);
         var callId = Guid.NewGuid().ToString("N");
-        var pending = registry.RegisterAsync(callId, TimeSpan.FromSeconds(30), CancellationToken.None);
+        var pending = registry.RegisterAsync(callId, conv.Id, TimeSpan.FromSeconds(30), CancellationToken.None);
 
         using var client = ClientAs(factory, owner);
         var response = await client.PostAsJsonAsync("/ag-ui/tool-result",
@@ -68,7 +68,7 @@ public sealed class AgUiToolResultEndpointTests : IClassFixture<TestWebApplicati
         var attacker = $"tr-attacker-{Guid.NewGuid():N}";
         var conv = await store.CreateAsync("dashboard-agent", owner);
         var callId = Guid.NewGuid().ToString("N");
-        _ = registry.RegisterAsync(callId, TimeSpan.FromSeconds(30), CancellationToken.None);
+        _ = registry.RegisterAsync(callId, conv.Id, TimeSpan.FromSeconds(30), CancellationToken.None);
 
         using var client = ClientAs(factory, attacker);
         var response = await client.PostAsJsonAsync("/ag-ui/tool-result",
@@ -76,6 +76,28 @@ public sealed class AgUiToolResultEndpointTests : IClassFixture<TestWebApplicati
 
         response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
         registry.PendingCount.Should().BeGreaterThan(0, "a rejected post must not complete the pending call");
+    }
+
+    [Fact]
+    public async Task PostToolResult_CallIdFromAnotherThread_Returns404_EvenWhenCallerOwnsThePostedThread()
+    {
+        var factory = AuthFactory();
+        var store = factory.Services.GetRequiredService<IConversationStore>();
+        var registry = factory.Services.GetRequiredService<PendingToolCallRegistry>();
+
+        // The caller owns BOTH conversations; the call is pending on convA, but they post it against convB.
+        var owner = $"tr-owner-{Guid.NewGuid():N}";
+        var convA = await store.CreateAsync("dashboard-agent", owner);
+        var convB = await store.CreateAsync("dashboard-agent", owner);
+        var callId = Guid.NewGuid().ToString("N");
+        _ = registry.RegisterAsync(callId, convA.Id, TimeSpan.FromSeconds(30), CancellationToken.None);
+
+        using var client = ClientAs(factory, owner);
+        var response = await client.PostAsJsonAsync("/ag-ui/tool-result",
+            new { threadId = convB.Id, callId, result = "mismatched" });
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        registry.PendingCount.Should().BeGreaterThan(0, "the call is bound to convA and must stay pending");
     }
 
     [Fact]

--- a/src/Content/Tests/Presentation.AgentHub.Tests/AgUi/AgUiToolResultEndpointTests.cs
+++ b/src/Content/Tests/Presentation.AgentHub.Tests/AgUi/AgUiToolResultEndpointTests.cs
@@ -1,0 +1,109 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Presentation.AgentHub.AgUi;
+using Presentation.AgentHub.Interfaces;
+using Presentation.AgentHub.Tests.Controllers;
+using System.Net;
+using System.Net.Http.Json;
+using Xunit;
+
+namespace Presentation.AgentHub.Tests.AgUi;
+
+/// <summary>
+/// Integration tests for <c>POST /ag-ui/tool-result</c> — the resume endpoint that completes a mid-run
+/// client round-trip. Drives the real auth + ownership pipeline against the SAME singleton
+/// <see cref="PendingToolCallRegistry"/> the endpoint resolves, by taking both the client and the
+/// registry from one configured server (each <c>WithWebHostBuilder</c> builds its own provider).
+/// </summary>
+public sealed class AgUiToolResultEndpointTests : IClassFixture<TestWebApplicationFactory>
+{
+    private readonly TestWebApplicationFactory _factory;
+
+    public AgUiToolResultEndpointTests(TestWebApplicationFactory factory) => _factory = factory;
+
+    private WebApplicationFactory<Program> AuthFactory() =>
+        _factory.WithWebHostBuilder(b => b.ConfigureTestServices(services =>
+            services.AddAuthentication(TestAuthHandler.SchemeName)
+                .AddScheme<AuthenticationSchemeOptions, TestAuthHandler>(TestAuthHandler.SchemeName, _ => { })));
+
+    private static HttpClient ClientAs(WebApplicationFactory<Program> factory, string userId)
+    {
+        var client = factory.CreateClient();
+        client.DefaultRequestHeaders.Add(TestAuthHandler.UserIdHeader, userId);
+        return client;
+    }
+
+    [Fact]
+    public async Task PostToolResult_OwnerWithPendingCall_Returns200_AndCompletesTheCall()
+    {
+        var factory = AuthFactory();
+        var store = factory.Services.GetRequiredService<IConversationStore>();
+        var registry = factory.Services.GetRequiredService<PendingToolCallRegistry>();
+
+        var owner = $"tr-owner-{Guid.NewGuid():N}";
+        var conv = await store.CreateAsync("dashboard-agent", owner);
+        var callId = Guid.NewGuid().ToString("N");
+        var pending = registry.RegisterAsync(callId, TimeSpan.FromSeconds(30), CancellationToken.None);
+
+        using var client = ClientAs(factory, owner);
+        var response = await client.PostAsJsonAsync("/ag-ui/tool-result",
+            new { threadId = conv.Id, callId, result = "applied" });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        (await pending.WaitAsync(TimeSpan.FromSeconds(5))).Should().Be("applied",
+            "the awaiting tool must observe the posted result");
+    }
+
+    [Fact]
+    public async Task PostToolResult_ForeignUser_Returns403_AndLeavesCallPending()
+    {
+        var factory = AuthFactory();
+        var store = factory.Services.GetRequiredService<IConversationStore>();
+        var registry = factory.Services.GetRequiredService<PendingToolCallRegistry>();
+
+        var owner = $"tr-owner-{Guid.NewGuid():N}";
+        var attacker = $"tr-attacker-{Guid.NewGuid():N}";
+        var conv = await store.CreateAsync("dashboard-agent", owner);
+        var callId = Guid.NewGuid().ToString("N");
+        _ = registry.RegisterAsync(callId, TimeSpan.FromSeconds(30), CancellationToken.None);
+
+        using var client = ClientAs(factory, attacker);
+        var response = await client.PostAsJsonAsync("/ag-ui/tool-result",
+            new { threadId = conv.Id, callId, result = "injected" });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+        registry.PendingCount.Should().BeGreaterThan(0, "a rejected post must not complete the pending call");
+    }
+
+    [Fact]
+    public async Task PostToolResult_UnknownCallId_Returns404()
+    {
+        var factory = AuthFactory();
+        var store = factory.Services.GetRequiredService<IConversationStore>();
+
+        var owner = $"tr-owner-{Guid.NewGuid():N}";
+        var conv = await store.CreateAsync("dashboard-agent", owner);
+
+        using var client = ClientAs(factory, owner);
+        var response = await client.PostAsJsonAsync("/ag-ui/tool-result",
+            new { threadId = conv.Id, callId = "never-registered", result = "x" });
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task PostToolResult_UnknownConversation_Returns404()
+    {
+        var factory = AuthFactory();
+        var owner = $"tr-owner-{Guid.NewGuid():N}";
+        using var client = ClientAs(factory, owner);
+
+        var response = await client.PostAsJsonAsync("/ag-ui/tool-result",
+            new { threadId = Guid.NewGuid().ToString(), callId = "c1", result = "x" });
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+}

--- a/src/Content/Tests/Presentation.AgentHub.Tests/AgUi/PendingToolCallRegistryTests.cs
+++ b/src/Content/Tests/Presentation.AgentHub.Tests/AgUi/PendingToolCallRegistryTests.cs
@@ -1,0 +1,98 @@
+using FluentAssertions;
+using Presentation.AgentHub.AgUi;
+using Xunit;
+
+namespace Presentation.AgentHub.Tests.AgUi;
+
+/// <summary>
+/// Unit tests for <see cref="PendingToolCallRegistry"/> — the rendezvous between a blocking proxy tool
+/// (awaiting inside a run) and the resume endpoint (a separate request). Covers completion, the
+/// failure modes that must never leak a pending entry (timeout, cancellation), and the unknown-callId
+/// path the endpoint reports as 404.
+/// </summary>
+public sealed class PendingToolCallRegistryTests
+{
+    [Fact]
+    public async Task RegisterThenComplete_ResolvesWithResult_AndRemovesEntry()
+    {
+        var registry = new PendingToolCallRegistry();
+        var task = registry.RegisterAsync("call-1", TimeSpan.FromSeconds(5), CancellationToken.None);
+
+        registry.PendingCount.Should().Be(1);
+        registry.TryComplete("call-1", "the-result").Should().BeTrue();
+
+        (await task).Should().Be("the-result");
+        registry.PendingCount.Should().Be(0, "a completed call must not leak a pending entry");
+    }
+
+    [Fact]
+    public async Task Register_WhenTimeoutElapses_ThrowsTimeout_AndRemovesEntry()
+    {
+        var registry = new PendingToolCallRegistry();
+        var task = registry.RegisterAsync("call-1", TimeSpan.FromMilliseconds(20), CancellationToken.None);
+
+        var act = async () => await task;
+        await act.Should().ThrowAsync<TimeoutException>();
+        registry.PendingCount.Should().Be(0, "a timed-out call must not leak a pending entry");
+    }
+
+    [Fact]
+    public async Task Register_WhenCancelled_ThrowsOperationCanceled_AndRemovesEntry()
+    {
+        var registry = new PendingToolCallRegistry();
+        using var cts = new CancellationTokenSource();
+        var task = registry.RegisterAsync("call-1", TimeSpan.FromSeconds(30), cts.Token);
+
+        cts.Cancel();
+
+        var act = async () => await task;
+        await act.Should().ThrowAsync<OperationCanceledException>();
+        registry.PendingCount.Should().Be(0, "a cancelled call must not leak a pending entry");
+    }
+
+    [Fact]
+    public async Task TryFail_FaultsTheAwaitingTask()
+    {
+        var registry = new PendingToolCallRegistry();
+        var task = registry.RegisterAsync("call-1", TimeSpan.FromSeconds(5), CancellationToken.None);
+
+        registry.TryFail("call-1", "client error").Should().BeTrue();
+
+        var act = async () => await task;
+        (await act.Should().ThrowAsync<InvalidOperationException>()).Which.Message.Should().Be("client error");
+        registry.PendingCount.Should().Be(0);
+    }
+
+    [Fact]
+    public void TryComplete_UnknownCallId_ReturnsFalse()
+    {
+        var registry = new PendingToolCallRegistry();
+        registry.TryComplete("never-registered", "x").Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task TryComplete_AfterAlreadyCompleted_ReturnsFalse()
+    {
+        var registry = new PendingToolCallRegistry();
+        var task = registry.RegisterAsync("call-1", TimeSpan.FromSeconds(5), CancellationToken.None);
+
+        registry.TryComplete("call-1", "first").Should().BeTrue();
+        await task;
+
+        registry.TryComplete("call-1", "second").Should().BeFalse("the call was already completed and removed");
+    }
+
+    [Fact]
+    public async Task Register_DuplicateCallId_Throws()
+    {
+        var registry = new PendingToolCallRegistry();
+        var first = registry.RegisterAsync("call-1", TimeSpan.FromSeconds(5), CancellationToken.None);
+
+        var act = () => registry.RegisterAsync("call-1", TimeSpan.FromSeconds(5), CancellationToken.None);
+        await act.Should().ThrowAsync<InvalidOperationException>();
+
+        // Drain the first registration so it doesn't surface as an unobserved timeout later.
+        registry.TryComplete("call-1", "done").Should().BeTrue();
+        await first;
+    }
+}

--- a/src/Content/Tests/Presentation.AgentHub.Tests/AgUi/PendingToolCallRegistryTests.cs
+++ b/src/Content/Tests/Presentation.AgentHub.Tests/AgUi/PendingToolCallRegistryTests.cs
@@ -7,19 +7,21 @@ namespace Presentation.AgentHub.Tests.AgUi;
 /// <summary>
 /// Unit tests for <see cref="PendingToolCallRegistry"/> — the rendezvous between a blocking proxy tool
 /// (awaiting inside a run) and the resume endpoint (a separate request). Covers completion, the
-/// failure modes that must never leak a pending entry (timeout, cancellation), and the unknown-callId
-/// path the endpoint reports as 404.
+/// failure modes that must never leak a pending entry (timeout, cancellation), the unknown-callId path
+/// the endpoint reports as 404, and the thread-binding that stops a foreign thread completing a call.
 /// </summary>
 public sealed class PendingToolCallRegistryTests
 {
+    private const string T = "thread-1";
+
     [Fact]
     public async Task RegisterThenComplete_ResolvesWithResult_AndRemovesEntry()
     {
         var registry = new PendingToolCallRegistry();
-        var task = registry.RegisterAsync("call-1", TimeSpan.FromSeconds(5), CancellationToken.None);
+        var task = registry.RegisterAsync("call-1", T, TimeSpan.FromSeconds(5), CancellationToken.None);
 
         registry.PendingCount.Should().Be(1);
-        registry.TryComplete("call-1", "the-result").Should().BeTrue();
+        registry.TryComplete("call-1", T, "the-result").Should().BeTrue();
 
         (await task).Should().Be("the-result");
         registry.PendingCount.Should().Be(0, "a completed call must not leak a pending entry");
@@ -29,7 +31,7 @@ public sealed class PendingToolCallRegistryTests
     public async Task Register_WhenTimeoutElapses_ThrowsTimeout_AndRemovesEntry()
     {
         var registry = new PendingToolCallRegistry();
-        var task = registry.RegisterAsync("call-1", TimeSpan.FromMilliseconds(20), CancellationToken.None);
+        var task = registry.RegisterAsync("call-1", T, TimeSpan.FromMilliseconds(20), CancellationToken.None);
 
         var act = async () => await task;
         await act.Should().ThrowAsync<TimeoutException>();
@@ -41,7 +43,7 @@ public sealed class PendingToolCallRegistryTests
     {
         var registry = new PendingToolCallRegistry();
         using var cts = new CancellationTokenSource();
-        var task = registry.RegisterAsync("call-1", TimeSpan.FromSeconds(30), cts.Token);
+        var task = registry.RegisterAsync("call-1", T, TimeSpan.FromSeconds(30), cts.Token);
 
         cts.Cancel();
 
@@ -54,9 +56,9 @@ public sealed class PendingToolCallRegistryTests
     public async Task TryFail_FaultsTheAwaitingTask()
     {
         var registry = new PendingToolCallRegistry();
-        var task = registry.RegisterAsync("call-1", TimeSpan.FromSeconds(5), CancellationToken.None);
+        var task = registry.RegisterAsync("call-1", T, TimeSpan.FromSeconds(5), CancellationToken.None);
 
-        registry.TryFail("call-1", "client error").Should().BeTrue();
+        registry.TryFail("call-1", T, "client error").Should().BeTrue();
 
         var act = async () => await task;
         (await act.Should().ThrowAsync<InvalidOperationException>()).Which.Message.Should().Be("client error");
@@ -67,32 +69,47 @@ public sealed class PendingToolCallRegistryTests
     public void TryComplete_UnknownCallId_ReturnsFalse()
     {
         var registry = new PendingToolCallRegistry();
-        registry.TryComplete("never-registered", "x").Should().BeFalse();
+        registry.TryComplete("never-registered", T, "x").Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task TryComplete_ForeignThread_ReturnsFalse_AndLeavesCallPendingForTheOwner()
+    {
+        var registry = new PendingToolCallRegistry();
+        var task = registry.RegisterAsync("call-1", T, TimeSpan.FromSeconds(5), CancellationToken.None);
+
+        // A caller who owns a different thread cannot complete this call, even with the right callId.
+        registry.TryComplete("call-1", "other-thread", "injected").Should().BeFalse();
+        registry.PendingCount.Should().Be(1, "the foreign completion must leave the call intact");
+
+        // The real owner still completes it.
+        registry.TryComplete("call-1", T, "owned").Should().BeTrue();
+        (await task).Should().Be("owned");
     }
 
     [Fact]
     public async Task TryComplete_AfterAlreadyCompleted_ReturnsFalse()
     {
         var registry = new PendingToolCallRegistry();
-        var task = registry.RegisterAsync("call-1", TimeSpan.FromSeconds(5), CancellationToken.None);
+        var task = registry.RegisterAsync("call-1", T, TimeSpan.FromSeconds(5), CancellationToken.None);
 
-        registry.TryComplete("call-1", "first").Should().BeTrue();
+        registry.TryComplete("call-1", T, "first").Should().BeTrue();
         await task;
 
-        registry.TryComplete("call-1", "second").Should().BeFalse("the call was already completed and removed");
+        registry.TryComplete("call-1", T, "second").Should().BeFalse("the call was already completed and removed");
     }
 
     [Fact]
     public async Task Register_DuplicateCallId_Throws()
     {
         var registry = new PendingToolCallRegistry();
-        var first = registry.RegisterAsync("call-1", TimeSpan.FromSeconds(5), CancellationToken.None);
+        var first = registry.RegisterAsync("call-1", T, TimeSpan.FromSeconds(5), CancellationToken.None);
 
-        var act = () => registry.RegisterAsync("call-1", TimeSpan.FromSeconds(5), CancellationToken.None);
+        var act = () => registry.RegisterAsync("call-1", T, TimeSpan.FromSeconds(5), CancellationToken.None);
         await act.Should().ThrowAsync<InvalidOperationException>();
 
         // Drain the first registration so it doesn't surface as an unobserved timeout later.
-        registry.TryComplete("call-1", "done").Should().BeTrue();
+        registry.TryComplete("call-1", T, "done").Should().BeTrue();
         await first;
     }
 }

--- a/src/Content/Tests/Presentation.AgentHub.Tests/Controllers/AgentsControllerCreateConversationTests.cs
+++ b/src/Content/Tests/Presentation.AgentHub.Tests/Controllers/AgentsControllerCreateConversationTests.cs
@@ -1,0 +1,99 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Presentation.AgentHub.Config;
+using Presentation.AgentHub.Controllers;
+using Presentation.AgentHub.Interfaces;
+using System.Net;
+using System.Net.Http.Json;
+using Xunit;
+
+namespace Presentation.AgentHub.Tests.Controllers;
+
+/// <summary>
+/// Integration tests for <c>POST /api/conversations</c> — the production conversation-create endpoint
+/// the dashboard agent panel calls before opening an AG-UI run. Verifies the new record is owned by the
+/// caller and bound to the requested agent, with the configured default used as the fallback.
+/// </summary>
+public sealed class AgentsControllerCreateConversationTests : IClassFixture<TestWebApplicationFactory>
+{
+    private readonly TestWebApplicationFactory _factory;
+    private readonly IConversationStore _store;
+
+    public AgentsControllerCreateConversationTests(TestWebApplicationFactory factory)
+    {
+        _factory = factory;
+        _store = factory.Services.GetRequiredService<IConversationStore>();
+    }
+
+    /// <summary>
+    /// Builds an authenticated client whose <see cref="AgentHubConfig.DefaultAgentName"/> is pinned to
+    /// <paramref name="defaultAgentName"/>, so the fallback behavior is deterministic regardless of the
+    /// host's ambient configuration.
+    /// </summary>
+    private HttpClient CreateClientAs(string userId, string defaultAgentName)
+    {
+        var options = new Mock<IOptionsMonitor<AgentHubConfig>>();
+        options.Setup(m => m.CurrentValue).Returns(new AgentHubConfig { DefaultAgentName = defaultAgentName });
+
+        var client = _factory
+            .WithWebHostBuilder(b => b.ConfigureTestServices(services =>
+            {
+                services.AddAuthentication(TestAuthHandler.SchemeName)
+                    .AddScheme<AuthenticationSchemeOptions, TestAuthHandler>(TestAuthHandler.SchemeName, _ => { });
+                services.RemoveAll<IOptionsMonitor<AgentHubConfig>>();
+                services.AddSingleton(options.Object);
+            }))
+            .CreateClient();
+        client.DefaultRequestHeaders.Add(TestAuthHandler.UserIdHeader, userId);
+        return client;
+    }
+
+    [Fact]
+    public async Task CreateConversation_WithAgentName_CreatesRecordOwnedByCaller_AndReturnsThreadId()
+    {
+        var userId = $"create-user-{Guid.NewGuid():N}";
+        using var client = CreateClientAs(userId, defaultAgentName: "");
+
+        var response = await client.PostAsJsonAsync("/api/conversations", new { agentName = "dashboard-agent" });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        var body = await response.Content.ReadFromJsonAsync<CreateConversationResponse>();
+        body.Should().NotBeNull();
+        body!.AgentName.Should().Be("dashboard-agent");
+        body.ThreadId.Should().NotBeNullOrWhiteSpace();
+
+        var stored = await _store.GetAsync(body.ThreadId);
+        stored.Should().NotBeNull();
+        stored!.UserId.Should().Be(userId, "the conversation must be owned by the caller");
+        stored.AgentName.Should().Be("dashboard-agent");
+    }
+
+    [Fact]
+    public async Task CreateConversation_NoAgentName_FallsBackToConfiguredDefault()
+    {
+        var userId = $"create-default-{Guid.NewGuid():N}";
+        using var client = CreateClientAs(userId, defaultAgentName: "fallback-agent");
+
+        var response = await client.PostAsJsonAsync("/api/conversations", new { });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        var body = await response.Content.ReadFromJsonAsync<CreateConversationResponse>();
+        body!.AgentName.Should().Be("fallback-agent");
+    }
+
+    [Fact]
+    public async Task CreateConversation_NoAgentNameAndNoDefault_Returns400()
+    {
+        var userId = $"create-noagent-{Guid.NewGuid():N}";
+        using var client = CreateClientAs(userId, defaultAgentName: "");
+
+        var response = await client.PostAsJsonAsync("/api/conversations", new { });
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+}


### PR DESCRIPTION
Embedded, CopilotKit-*style* agent panel inside `Presentation.Dashboard` that **chats and acts on the dashboard** over AG-UI, plus on-demand **in-chat charts**. Built on raw `@ag-ui/client` (not the CopilotKit library). Replaces the earlier mis-scoped WebUI merge (reverted in #106); `Presentation.WebUI` is untouched.

The hard unknown — can a model-invoked tool block mid-run awaiting a browser result and resume? — was proven by a spike and is the core mechanism here.

## Structure (review by commit)
| Commit | What |
|---|---|
| `spike` | feasibility proof: `.UseFunctionInvocation()` tolerates a tool blocking on an external `TaskCompletionSource` |
| **PR1** | backend AG-UI blocking round-trip |
| **PR2** | embedded panel + dashboard actions |
| **PR3** | in-chat generative charts |
| `fix` | code-review findings |
| `refactor` | /simplify cleanups |

## How it works
1. The agent calls a server-side tool (`dashboard_control` / `render_chart`).
2. The tool emits AG-UI `TOOL_CALL_*` events on the live SSE stream, then **blocks** awaiting the browser via `POST /ag-ui/tool-result`.
3. The browser executes the action (change time range, navigate, refresh, read state, or render a chart from real metric data) and POSTs the result.
4. The same run resumes with the agent's text reply.

The boundary is the agent's `allowed-tools` (only the `dashboard-agent` skill declares these) plus tool-invocation enforcement being opt-in — consistent with every other harness tool; the shipped governance policy is unchanged.

## Backend
- `PendingToolCallRegistry` (callId rendezvous, bounded timeout, no leaks), `IClientToolBridge` (Application seam) + `AgUiClientToolBridge` (Presentation), `BlockingProxyTool` base + `DashboardControlTool` / `RenderChartTool`, `ListMetricsTool` over a shared `IMetricCatalog`.
- `POST /ag-ui/tool-result` (auth + ownership) and `POST /api/conversations`.
- Tool-call event records + polymorphic registration; `AgUiEventWriter` serializes frame writes (concurrent tool calls).

## Frontend
- Raw `@ag-ui/client` `HttpAgent.run()` (low-level event observable, not the managed loop — clean fit for the non-standard blocking proxy).
- Radix slide-over panel (mirrors `ContextDrawer`), launcher in `Topbar`, mounted in `DashboardShell`.
- Action handlers map to existing stores/router/queryClient; charts reuse existing `TimeSeriesChart`/`MetricBarChart` populated via the existing Prometheus query path.

## Notable review fixes
- **SSE writer concurrency**: `AllowConcurrentInvocation=true` means two blocking-proxy tools can write the same response body at once → serialized writes (Kestrel forbids concurrent writes).
- **No bricked panel**: the tool-result POST is wrapped so a failed POST (or a `TOOL_CALL_END` with no matching START) recovers to an error state instead of hanging on `running` forever.

## Test plan
- **Automated (all green):** backend `dotnet test` — AgentHub 383, Infrastructure.AI 1953; frontend `npm run build` + `npm test` — 385 across 52 files. Covers registry (complete/timeout/cancel/leak), bridge event emission, resume endpoint (auth/ownership/unknown-call), conversation-create, both tools, event serialization, writer concurrency, the full hook round-trip (tool dispatch → result POST), chart rendering, and run-hang recovery.
- **Manual E2E (not yet run):** open the panel on `/pulse`, ask "show me the last 24 hours on the spend page," watch it navigate + set the range; ask "chart tokens by model" and see the chart inline. Requires AgentHub + dashboard running with an LLM provider configured.

## Deferred (low-risk, noted not skipped)
- `callId`→`threadId` binding on `/ag-ui/tool-result` — the 122-bit GUID already makes cross-run injection infeasible; binding is defense-in-depth for later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)