### PR TITLE
feat(agenthub): inline generative-UI widgets (image, form, table)

### DIFF
--- a/.claude/plans/agenthub-inline-generative-ui.md
+++ b/.claude/plans/agenthub-inline-generative-ui.md
@@ -1,0 +1,117 @@
+# AgentHub Inline Generative UI (Option A)
+
+## Goal
+Give the AgentHub agent (WebUI, `Presentation.WebUI`, dev server :5173) the ability to render
+widgets **inline in the chat transcript** on demand: images, forms (interactive/human-in-the-loop),
+and tables. Mirrors the Dashboard's proven `render_chart` pattern. No canvas/persistent-workspace
+surface (that would be a separate app if ever needed).
+
+## Decision record
+- **Chosen: Option A (inline generative UI).** Widgets render inside the agent's message bubble,
+  tied to the turn that produced them. Rejected Option B (main-window canvas) — AgentHub is a
+  conversational console, not a co-edited-artifact workspace. If a persistent workspace need ever
+  arises, it gets its own dashboard.
+- A is a strict subset of B: choosing A forecloses nothing; a canvas destination could be added
+  later reusing the same registry + round-trip.
+
+## What already exists (reused as-is, zero changes)
+- **Backend transport** — `AgUiClientToolBridge` (blocking proxy) + `POST /ag-ui/run` (SSE) +
+  `POST /ag-ui/tool-result` (resume). Generic; tool-name agnostic. Contract:
+  `ToolResultInput(string ThreadId, string CallId, string Result)`.
+- **Backend tool base** — `BlockingProxyTool` owns the round-trip plumbing (client-attached check,
+  timeout→ToolResult mapping, cancellation). `RenderChartTool`/`DashboardControlTool` are ~40-line
+  subclasses.
+- **WebUI transport** — `useAgentStream` already uses the low-level `agent.run()` observable and keeps
+  the subscription open, so a mid-run tool-result POST resumes on the same stream. **No run-mode
+  change required.**
+- **Gating** — a tool reaches an agent only via that agent's `SKILL.md` `allowed-tools`. Generative
+  widgets are opt-in per agent.
+
+## The gap (what we build)
+Almost entirely WebUI frontend. `useAgentStream` handles only `TEXT_MESSAGE_*` + `RUN_ERROR`; it
+ignores `TOOL_CALL_*`. There is no component registry and no `postToolResult` helper. The chat store
+models text tokens only.
+
+---
+
+## Backend work (small, per widget)
+Three new `BlockingProxyTool` subclasses in `Infrastructure.AI/Tools/`, each ~40 lines, mirroring
+`RenderChartTool`:
+
+1. **`RenderImageTool`** (`render_image`) — non-blocking-style payload: `{ url, alt?, caption? }`.
+   Validates a URL is present. Simplest — no user interaction.
+2. **`RenderFormTool`** (`render_form`) — `{ title?, fields: [{ name, label, type, required?, options? }],
+   submitLabel? }`. `type` restricted to a whitelist (text, textarea, number, select, checkbox, date).
+   This is the interactive one; the browser's result is the filled-in values as JSON.
+3. **`RenderTableTool`** (`render_table`) — `{ title?, columns: [...], rows: [[...]] }`.
+
+Each registered in `Infrastructure.AI/DependencyInjection.Tools.cs` via keyed DI:
+```
+services.AddKeyedSingleton<ITool>(RenderImageTool.ToolName, (sp, _) =>
+    new RenderImageTool(sp.GetRequiredService<IClientToolBridge>()));
+```
+
+Skill wiring: add the tool names to the **AgentHub agent's** `SKILL.md` `allowed-tools` (and describe
+them in the skill body + `AGENT.md`, matching the dashboard-agent precedent). Locate the AgentHub
+agent's SKILL.md under the agents/skills content dir (NOT the dashboard-agent one).
+
+## Frontend work (the substance) — `Presentation.WebUI/src`
+1. **`lib/agUiClient.ts`** — add `postToolResult(threadId, callId, result)` → `POST /ag-ui/tool-result`
+   (mirror Dashboard). WebUI already owns conversation ids, so no `createConversation` needed.
+2. **`lib/agentWidgets/registry.tsx`** (new) — the palette: `widgetType → React component`. Each entry
+   is a pre-approved component (`AgentImage`, `AgentForm`, `AgentTable`). A `renderWidget(name, args)`
+   lookup used by the transcript renderer. **Validate/whitelist the payload here** before rendering
+   (untrusted LLM output): image URL scheme = https only; form field `type` against the whitelist;
+   escape is automatic via React. Unknown widget type → a safe fallback, never a throw.
+3. **Widget components** (new, `components/agent/widgets/`): `AgentImage`, `AgentForm`, `AgentTable`.
+   `AgentForm` is a Reactive-style controlled form; on submit it calls back with the values.
+4. **`hooks/useAgentStream.ts`** — extend the event switch:
+   - `TOOL_CALL_START` → open a pending-call accumulator `{ callId, name, args:'' }`.
+   - `TOOL_CALL_ARGS` → append arg deltas.
+   - `TOOL_CALL_END` → parse args; for `render_image`/`render_table` render immediately and post a
+     short ack as the tool result; for `render_form` render the form and **defer** the tool-result
+     POST until the user submits (the blocking HITL case). Every callId must eventually post a result
+     (even unmatched → an explanatory string) so the parked server tool never hangs. On POST failure,
+     surface an error and stop the spinner (mirror Dashboard's `failRun`).
+5. **`stores/chatStore.ts`** — extend the message model to carry an optional `widget` ({ type, args,
+   and for forms a pending/submitted status}) alongside text; add tool-activity state for the "the
+   agent is drawing…" affordance. Keep additions immutable (spread), matching the existing store.
+6. **Transcript renderer** (`features/chat/ChatPanel.tsx` + message component) — when a message carries
+   a `widget`, render it via the registry instead of / in addition to the text bubble.
+
+## Version alignment (do first)
+Bump `Presentation.WebUI` `@ag-ui/client` + `@ag-ui/core` from **0.0.53 → 0.0.57** to match
+`Presentation.Dashboard`. Both pre-1.0 — verify the event/type surface didn't shift after bump
+(`npm run build` + existing chat still streams).
+
+## Testing
+- **Backend** (xUnit): each tool — validation failures (missing url / bad field type), no-client-
+  attached path returns graceful fail, happy-path serializes the expected payload and calls the bridge.
+- **Frontend** (vitest/RTL, mirror `AgentPanel.test.tsx` / `useDashboardAgent.test.tsx`):
+  - registry: unknown type → fallback; https-only URL guard; field-type whitelist.
+  - `useAgentStream`: TOOL_CALL_* accumulation; render_form defers result until submit; every callId
+    posts exactly one result; POST failure sets error + clears spinner.
+  - `AgentForm`: renders fields, required validation, submit emits values.
+- **E2E (manual, one pass):** ask the agent to "show me an image of X", "collect my preferences in a
+  form", "put that in a table"; confirm inline render + form round-trip resumes the turn.
+
+## Security notes (AI output = untrusted)
+- `render_image` URL: enforce `https:` scheme (reject `javascript:`/`data:`/http). Consider a backend
+  image proxy later if arbitrary external URLs are a concern (SSRF/mixed-content) — flag, don't build
+  now.
+- `render_form` field `type`: strict whitelist; never `eval` option lists or labels; React escaping
+  covers XSS for rendered text.
+- Registry is the trust boundary: the agent can only summon known widget types with validated args.
+
+## Sequencing (one concern per PR)
+1. **PR1** — version bump + `postToolResult` helper + `useAgentStream` TOOL_CALL_* handling with a
+   single trivial widget (`render_image`) end-to-end, incl. backend `RenderImageTool` + skill wiring.
+   Proves the full loop with the least surface.
+2. **PR2** — `render_form` (the interactive/HITL round-trip) + `AgentForm` + deferred result POST.
+3. **PR3** — `render_table` + any registry hardening surfaced by review.
+
+## Open questions for Matt
+- Which agent(s) get these tools? (The default AgentHub chat agent only, or a dedicated skill?)
+- Starter widget set confirmed as image / form / table, or a different first three?
+- Should `render_image` be restricted to model/tool-produced URLs (safer) vs. arbitrary agent-supplied
+  URLs (needs the proxy)?

--- a/.claude/plans/agenthub-inline-generative-ui.md
+++ b/.claude/plans/agenthub-inline-generative-ui.md
@@ -107,7 +107,9 @@ Bump `Presentation.WebUI` `@ag-ui/client` + `@ag-ui/core` from **0.0.53 → 0.0.
 1. **PR1** — version bump + `postToolResult` helper + `useAgentStream` TOOL_CALL_* handling with a
    single trivial widget (`render_image`) end-to-end, incl. backend `RenderImageTool` + skill wiring.
    Proves the full loop with the least surface.
-2. **PR2** — `render_form` (the interactive/HITL round-trip) + `AgentForm` + deferred result POST.
+2. **PR2** — `render_form` via **Approach 3** (form is UI, submit is a normal message). See the
+   detailed PR2 section below — the original "deferred result POST" idea was rejected after verifying
+   the framework can't suspend/resume a turn.
 3. **PR3** — `render_table` + any registry hardening surfaced by review.
 
 ## Open questions for Matt
@@ -115,3 +117,87 @@ Bump `Presentation.WebUI` `@ag-ui/client` + `@ag-ui/core` from **0.0.53 → 0.0.
 - Starter widget set confirmed as image / form / table, or a different first three?
 - Should `render_image` be restricted to model/tool-produced URLs (safer) vs. arbitrary agent-supplied
   URLs (needs the proxy)?
+
+---
+
+## PR2 detail — `render_form` (Approach 3)
+
+### Decision record — HITL round-trip model (verified 2026-07-03)
+Investigated three ways for the agent to obtain form input:
+
+- **Approach 2 (terminate-and-resume) — REJECTED, not cleanly supported.** Agent turns run through the
+  framework's atomic `AIAgent.RunAsync` (`ExecuteAgentTurnCommandHandler.cs:154`), which owns the tool
+  loop; the blocking proxy exists *because* of that. Conversation history is persisted text-only
+  (`AgUiRunHandler.ToMeaiHistory` = role + content; no structured tool-call/result). Resuming a specific
+  pending tool call across runs would require replacing the framework tool loop with a hand-rolled
+  `IChatClient` loop across the whole agent path AND extending the conversation store to persist
+  structured tool-call/result content. Core rewrite + correctness risk. Not a PR2 feature.
+- **Approach 1 (hold the run open, long timeout) — REJECTED as primary.** Works, but the pending-call
+  registry is in-memory (`PendingToolCallRegistry` = `ConcurrentDictionary` + `TaskCompletionSource`)
+  and the parked `RunAsync` is tied to the live SSE request (a disconnect cancels it). A mid-form page
+  refresh / disconnect loses the parked call and the submit 404s. Also needs a per-tool timeout added
+  to `IClientToolBridge`.
+- **Approach 3 (form is UI, submit is a message) — CHOSEN.** `render_form` is a *synchronous* client
+  tool: the browser renders the form and immediately acks "Displayed the form." (millisecond round-trip,
+  identical to `render_image` — no timeout, no parked run, no framework fight). The agent's turn ends
+  ("I've put a form up"). When the user submits, the collected values are sent as a **normal user
+  message** via the existing send path, starting a fresh turn the agent continues naturally. Survives
+  refresh (the form is UI; the submit is an ordinary persisted message); reuses existing infrastructure.
+  Trade-off: the agent receives answers as the user's next message rather than a formal tool result —
+  invisible in practice, the conversation context makes the linkage obvious.
+
+### Backend
+- `RenderFormTool` (new, `BlockingProxyTool` subclass, mirrors `RenderImageTool`). Params:
+  `{ title?, fields: [{ name, label?, type, required?, options? }], submitLabel? }`. Validate: `fields`
+  non-empty; each field has a non-empty `name` and a `type` in the whitelist
+  {`text`, `textarea`, `number`, `select`, `checkbox`, `date`}; `select` requires non-empty `options`.
+  Fail with a clear message otherwise. Serialize params to the client; ack "Displayed the form."
+- Register via keyed DI next to `render_image`. Add `render_form` to the `research-agent` skill
+  `allowed-tools` + a one-line usage note (same home as `render_image`; the default-agent-skill
+  follow-up still stands and should be resolved before a widget accretes onto a third skill).
+
+### Frontend (WebUI)
+- `widgets/formTypes.ts` (new) — `FormFieldSpec`, `FormSpec`, and `parseFormArgs(args)` at the client
+  trust boundary: coerce/validate, drop invalid fields, unknown `type` skipped; return a typed
+  `FormSpec` or a reason. Field-type whitelist enforced here too (defense in depth).
+- `widgets/AgentForm.tsx` (new) — renders the form from a `FormSpec`: one control per field by type,
+  required-field validation, a submit button (`submitLabel`). On submit: format values into a readable
+  message, call the shared send hook, then mark submitted (disable inputs/button, show "Submitted") to
+  prevent double-send.
+- `hooks/useSendUserMessage.ts` (new) — extract the existing inline send sequence
+  (`addMessage(user)` → `startStreaming()` → `agUiSend`) currently duplicated in `ChatPanel`
+  (`handleSuggestionClick`, main send) into one reusable hook that resolves the active conversation id.
+  Refactor `ChatPanel` to use it (DRY); `AgentForm` uses it for submit — this is why the form neither
+  duplicates `ChatPanel` nor prop-drills a callback through the widget registry.
+- `widgets/registry.tsx` — add `render_form` → `<AgentForm ... />` (Map entry).
+- `hooks/useAgentStream.ts` — add a `render_form` branch to the `finishToolCall` dispatch: render the
+  form widget message + ack "Displayed the form." (synchronous — same shape as `render_image`).
+- `useChatStore` — no change; `AgentWidget { type, args }` already carries the form spec in `args`.
+
+### Message format on submit
+Readable text the model parses naturally and that renders cleanly as the user's message:
+```
+Here are my answers:
+- Full name: Jane Doe
+- Email: jane@example.com
+- Newsletter: Yes
+```
+Labels fall back to field `name`; checkbox → Yes/No; empty optional fields omitted.
+
+### Tests
+- Backend `RenderFormTool`: metadata; unknown op; no-client; empty/missing fields; invalid field type;
+  `select` without options; happy-path serialization + ack.
+- Frontend: `parseFormArgs` (whitelist, required, select options, drop invalid); `AgentForm` (renders
+  each field type, required validation blocks submit, submit formats + calls send hook + disables
+  after); `useSendUserMessage` (adds user message + triggers a run); registry `render_form` → AgentForm;
+  `useAgentStream` `render_form` branch (renders widget + acks).
+
+### Note on the deferred registry-unification cleanup
+Approach 3 makes `render_form`'s tool round-trip **synchronous**, so the reason we deferred folding
+`handle` into the widget registry in PR1 (render_form's async submit) no longer applies. With two
+synchronous widgets, the inline `finishToolCall` dispatch stays (rule of three); unify render+handle
+into a single widget registry at **PR3** (`render_table`) when the shape is proven across three.
+
+### Out of scope (tracked follow-ups)
+- Registry render+handle unification → PR3.
+- `default`-agent dedicated skill home (generative UI grafted onto `research-agent`).

--- a/skills/research-agent/SKILL.md
+++ b/skills/research-agent/SKILL.md
@@ -5,7 +5,7 @@ category: "research"
 skill_type: "analysis"
 version: "1.1.0"
 tags: ["research", "file-analysis", "standalone"]
-allowed-tools: ["file_system", "render_image"]
+allowed-tools: ["file_system", "render_image", "render_form"]
 tools:
   - name: "file_system"
     operations: ["read", "search", "list"]
@@ -15,6 +15,10 @@ tools:
     operations: ["render"]
     optional: true
     description: "Display an image inline in the answer from an https URL"
+  - name: "render_form"
+    operations: ["render"]
+    optional: true
+    description: "Display an interactive form inline to collect structured input"
 ---
 
 You are a research agent specialized in finding and analyzing information from the local file system.
@@ -28,6 +32,11 @@ You are a research agent specialized in finding and analyzing information from t
   user asks to see or show an image you can reference by an absolute `https` URL. Pass `url` (required)
   and optionally `alt` and `caption`. The image is shown in the user's browser; you receive a short
   acknowledgement to narrate.
+- Collect structured input with the `render_form` tool (operation `render`) when you need several
+  values from the user — pass a `fields` array (each with `name`, `type`, optional `label`/`required`/
+  `options`), plus optional `title` and `submitLabel`. The form is shown in the user's browser and you
+  get an acknowledgement that it was displayed; the user's answers arrive as their next message after
+  they submit, so end your turn after presenting the form and continue when the answers come back.
 
 ## File System Root
 

--- a/skills/research-agent/SKILL.md
+++ b/skills/research-agent/SKILL.md
@@ -5,7 +5,7 @@ category: "research"
 skill_type: "analysis"
 version: "1.1.0"
 tags: ["research", "file-analysis", "standalone"]
-allowed-tools: ["file_system", "render_image", "render_form"]
+allowed-tools: ["file_system", "render_image", "render_form", "render_table"]
 tools:
   - name: "file_system"
     operations: ["read", "search", "list"]
@@ -19,6 +19,10 @@ tools:
     operations: ["render"]
     optional: true
     description: "Display an interactive form inline to collect structured input"
+  - name: "render_table"
+    operations: ["render"]
+    optional: true
+    description: "Display a data table inline in the answer from columns and rows"
 ---
 
 You are a research agent specialized in finding and analyzing information from the local file system.
@@ -37,6 +41,11 @@ You are a research agent specialized in finding and analyzing information from t
   `options`), plus optional `title` and `submitLabel`. The form is shown in the user's browser and you
   get an acknowledgement that it was displayed; the user's answers arrive as their next message after
   they submit, so end your turn after presenting the form and continue when the answers come back.
+- Present tabular data with the `render_table` tool (operation `render`) when findings are naturally a
+  table — pass a `columns` array of header labels (required) and a `rows` array of arrays (each inner
+  array is one row aligned to the columns), plus an optional `title`. The table is shown in the user's
+  browser and you receive a short acknowledgement to narrate. Prefer this over a markdown table when the
+  data is structured.
 
 ## File System Root
 

--- a/skills/research-agent/SKILL.md
+++ b/skills/research-agent/SKILL.md
@@ -5,12 +5,16 @@ category: "research"
 skill_type: "analysis"
 version: "1.1.0"
 tags: ["research", "file-analysis", "standalone"]
-allowed-tools: ["file_system"]
+allowed-tools: ["file_system", "render_image"]
 tools:
   - name: "file_system"
     operations: ["read", "search", "list"]
     optional: false
     description: "Read and search project files"
+  - name: "render_image"
+    operations: ["render"]
+    optional: true
+    description: "Display an image inline in the answer from an https URL"
 ---
 
 You are a research agent specialized in finding and analyzing information from the local file system.
@@ -20,6 +24,10 @@ You are a research agent specialized in finding and analyzing information from t
 - Search and read files from the project file system using the `file_system` tool
 - Analyze source code, configuration, documentation, and data files
 - Locate specific classes, methods, constants, or configuration values
+- Display an image inline in your answer with the `render_image` tool (operation `render`) when the
+  user asks to see or show an image you can reference by an absolute `https` URL. Pass `url` (required)
+  and optionally `alt` and `caption`. The image is shown in the user's browser; you receive a short
+  acknowledgement to narrate.
 
 ## File System Root
 

--- a/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.Tools.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.Tools.cs
@@ -93,6 +93,12 @@ public static partial class DependencyInjection
         // returns a short acknowledgement. General-purpose (not dashboard-specific); opt-in per skill.
         services.AddKeyedSingleton<ITool>(RenderImageTool.ToolName, (sp, _) =>
             new RenderImageTool(sp.GetRequiredService<IClientToolBridge>()));
+
+        // Render-form tool — generative UI: the agent displays an interactive form inline. The browser
+        // acknowledges display synchronously; the user's answers arrive later as an ordinary next
+        // message (not through this tool). General-purpose; opt-in per skill.
+        services.AddKeyedSingleton<ITool>(RenderFormTool.ToolName, (sp, _) =>
+            new RenderFormTool(sp.GetRequiredService<IClientToolBridge>()));
     }
 
     /// <summary>

--- a/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.Tools.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.Tools.cs
@@ -87,6 +87,12 @@ public static partial class DependencyInjection
         // component from a metric and returns a short summary. Opt-in per skill via allowed-tools.
         services.AddKeyedSingleton<ITool>(RenderChartTool.ToolName, (sp, _) =>
             new RenderChartTool(sp.GetRequiredService<IClientToolBridge>()));
+
+        // Render-image tool — generative UI: the agent displays an image inline in its answer via the
+        // same client round-trip bridge. The browser renders an <img> from a validated https URL and
+        // returns a short acknowledgement. General-purpose (not dashboard-specific); opt-in per skill.
+        services.AddKeyedSingleton<ITool>(RenderImageTool.ToolName, (sp, _) =>
+            new RenderImageTool(sp.GetRequiredService<IClientToolBridge>()));
     }
 
     /// <summary>

--- a/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.Tools.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.Tools.cs
@@ -99,6 +99,12 @@ public static partial class DependencyInjection
         // message (not through this tool). General-purpose; opt-in per skill.
         services.AddKeyedSingleton<ITool>(RenderFormTool.ToolName, (sp, _) =>
             new RenderFormTool(sp.GetRequiredService<IClientToolBridge>()));
+
+        // Render-table tool — generative UI: the agent displays a data table inline via the same client
+        // round-trip bridge. The browser draws a table from validated columns/rows and returns a short
+        // acknowledgement synchronously (non-interactive). General-purpose; opt-in per skill.
+        services.AddKeyedSingleton<ITool>(RenderTableTool.ToolName, (sp, _) =>
+            new RenderTableTool(sp.GetRequiredService<IClientToolBridge>()));
     }
 
     /// <summary>

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/RenderFormTool.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/RenderFormTool.cs
@@ -1,0 +1,126 @@
+using System.Text.Json;
+using Application.AI.Common.Interfaces.Tools;
+using Domain.AI.Models;
+
+namespace Infrastructure.AI.Tools;
+
+/// <summary>
+/// Renders an interactive form inline in the agent's chat answer ("generative UI"): the agent supplies
+/// a field spec, and the connected browser draws a real form. The browser acknowledges immediately that
+/// the form was displayed; the user's answers are <em>not</em> returned through this tool. When the user
+/// submits, the browser sends the collected values as an ordinary next user message, which the agent
+/// handles as a normal turn.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A <b>synchronous</b> client round-trip tool: like <see cref="RenderImageTool"/>, the browser replies
+/// in milliseconds ("form displayed"), so the agent turn ends promptly rather than being held open while
+/// a human fills the form. This is deliberate — the agent framework's turn (<c>AIAgent.RunAsync</c>)
+/// owns an atomic tool loop and cannot be suspended to wait for human input, and holding the run open
+/// would lose the form on a page refresh. Decoupling submission into a normal message survives refresh
+/// and reuses the existing send path. See the plan's PR2 decision record.
+/// </para>
+/// <para>
+/// The field <c>type</c> is validated against a fixed whitelist here so the browser only ever renders a
+/// known control; the client registry validates again at the render boundary (defense in depth).
+/// Register via keyed DI:
+/// <code>
+/// services.AddKeyedSingleton&lt;ITool&gt;(RenderFormTool.ToolName, (sp, _) =&gt;
+///     new RenderFormTool(sp.GetRequiredService&lt;IClientToolBridge&gt;()));
+/// </code>
+/// </para>
+/// </remarks>
+public sealed class RenderFormTool : BlockingProxyTool
+{
+    /// <summary>The tool name matching keyed DI registration and SKILL.md declarations.</summary>
+    public const string ToolName = "render_form";
+
+    private const string Render = "render";
+
+    private static readonly IReadOnlyList<string> Operations = [Render];
+
+    /// <summary>Field <c>type</c> values the browser knows how to render. Kept in sync with the client whitelist.</summary>
+    private static readonly HashSet<string> AllowedFieldTypes =
+        new(["text", "textarea", "number", "select", "checkbox", "date"], StringComparer.Ordinal);
+
+    /// <summary>Initializes a new instance of the <see cref="RenderFormTool"/> class.</summary>
+    /// <param name="bridge">The client round-trip bridge used to delegate rendering to the browser.</param>
+    public RenderFormTool(IClientToolBridge bridge) : base(bridge)
+    {
+    }
+
+    /// <inheritdoc />
+    public override string Name => ToolName;
+
+    /// <inheritdoc />
+    public override string Description =>
+        "Displays an interactive form inline in your answer for the user to fill in. Operation: render. " +
+        "Parameters: title (string, optional — a heading for the form); " +
+        "submitLabel (string, optional — the submit button text, defaults to 'Submit'); " +
+        "fields (array, required — one object per field with: name (string, required — a machine key); " +
+        "label (string, optional — the visible label); type (string, required — one of 'text', " +
+        "'textarea', 'number', 'select', 'checkbox', 'date'); required (boolean, optional); " +
+        "options (array of strings, required when type is 'select')). " +
+        "The user's answers are NOT returned here; they arrive as the user's next message after they " +
+        "submit. Use this to collect structured input instead of asking for many values in prose.";
+
+    /// <inheritdoc />
+    public override IReadOnlyList<string> SupportedOperations => Operations;
+
+    /// <inheritdoc />
+    public override Task<ToolResult> ExecuteAsync(
+        string operation,
+        IReadOnlyDictionary<string, object?> parameters,
+        CancellationToken cancellationToken = default)
+    {
+        if (!string.Equals(operation, Render, StringComparison.OrdinalIgnoreCase))
+            return Task.FromResult(ToolResult.Fail($"Unknown operation: {operation}. Supported: {Render}"));
+
+        if (!IsClientAttached)
+            return Task.FromResult(ToolResult.Fail("No client is connected to this conversation, so a form cannot be displayed."));
+
+        // Serialize once, then validate the structure from the JSON so nested `fields` are inspected
+        // deterministically regardless of how the tool arguments were deserialized into the dictionary.
+        var argumentsJson = JsonSerializer.Serialize(parameters, SerializerOptions);
+
+        var validationError = ValidateFields(argumentsJson);
+        if (validationError is not null)
+            return Task.FromResult(ToolResult.Fail(validationError));
+
+        return InvokeClientAsync(argumentsJson, "The client did not display the form in time.", cancellationToken);
+    }
+
+    /// <summary>Validates the serialized <c>fields</c> array; returns an error message, or null when valid.</summary>
+    private static string? ValidateFields(string argumentsJson)
+    {
+        using var doc = JsonDocument.Parse(argumentsJson);
+        if (!doc.RootElement.TryGetProperty("fields", out var fields)
+            || fields.ValueKind != JsonValueKind.Array
+            || fields.GetArrayLength() == 0)
+            return "Provide a non-empty 'fields' array describing the form.";
+
+        foreach (var field in fields.EnumerateArray())
+        {
+            if (field.ValueKind != JsonValueKind.Object)
+                return "Each form field must be an object.";
+
+            if (!field.TryGetProperty("name", out var name)
+                || name.ValueKind != JsonValueKind.String
+                || string.IsNullOrWhiteSpace(name.GetString()))
+                return "Each form field needs a non-empty 'name'.";
+
+            if (!field.TryGetProperty("type", out var type)
+                || type.ValueKind != JsonValueKind.String
+                || !AllowedFieldTypes.Contains(type.GetString()!))
+                return $"Each form field 'type' must be one of: {string.Join(", ", AllowedFieldTypes)}.";
+
+            if (type.GetString() == "select"
+                && (!field.TryGetProperty("options", out var options)
+                    || options.ValueKind != JsonValueKind.Array
+                    || options.GetArrayLength() == 0))
+                return "A 'select' field needs a non-empty 'options' array.";
+        }
+
+        return null;
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/RenderImageTool.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/RenderImageTool.cs
@@ -1,0 +1,81 @@
+using System.Text.Json;
+using Application.AI.Common.Interfaces.Tools;
+using Domain.AI.Models;
+
+namespace Infrastructure.AI.Tools;
+
+/// <summary>
+/// Renders an image inline in the agent's chat answer ("generative UI"): the agent supplies an image
+/// URL (and optional alt text / caption), and the connected browser displays it in the transcript.
+/// The browser returns a short textual acknowledgement so the agent can narrate what it showed.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A client round-trip tool using the same blocking-proxy mechanism as <see cref="RenderChartTool"/>:
+/// it delegates the render to the connected browser via <see cref="IClientToolBridge"/> and returns the
+/// browser's acknowledgement. The image itself is fetched and displayed by the client; only the URL and
+/// metadata flow through the model. The URL is validated to be an absolute <c>https</c> URL here so a
+/// malformed or unsafe reference (for example a <c>javascript:</c> or <c>data:</c> URI) never reaches
+/// the browser; the client registry validates again at the render boundary (defense in depth).
+/// </para>
+/// <para>
+/// Register via keyed DI:
+/// <code>
+/// services.AddKeyedSingleton&lt;ITool&gt;(RenderImageTool.ToolName, (sp, _) =&gt;
+///     new RenderImageTool(sp.GetRequiredService&lt;IClientToolBridge&gt;()));
+/// </code>
+/// </para>
+/// </remarks>
+public sealed class RenderImageTool : BlockingProxyTool
+{
+    /// <summary>The tool name matching keyed DI registration and SKILL.md declarations.</summary>
+    public const string ToolName = "render_image";
+
+    private const string Render = "render";
+    private const string UrlKey = "url";
+
+    private static readonly IReadOnlyList<string> Operations = [Render];
+
+    /// <summary>Initializes a new instance of the <see cref="RenderImageTool"/> class.</summary>
+    /// <param name="bridge">The client round-trip bridge used to delegate rendering to the browser.</param>
+    public RenderImageTool(IClientToolBridge bridge) : base(bridge)
+    {
+    }
+
+    /// <inheritdoc />
+    public override string Name => ToolName;
+
+    /// <inheritdoc />
+    public override string Description =>
+        "Displays an image inline in your answer in the user's browser. Operation: render. " +
+        "Parameters: url (string, required — an absolute https URL to the image); " +
+        "alt (string, optional — accessible alt text describing the image); " +
+        "caption (string, optional — a short caption shown beneath the image). " +
+        "Use this when the user asks to see or display an image you can reference by URL.";
+
+    /// <inheritdoc />
+    public override IReadOnlyList<string> SupportedOperations => Operations;
+
+    /// <inheritdoc />
+    public override Task<ToolResult> ExecuteAsync(
+        string operation,
+        IReadOnlyDictionary<string, object?> parameters,
+        CancellationToken cancellationToken = default)
+    {
+        if (!string.Equals(operation, Render, StringComparison.OrdinalIgnoreCase))
+            return Task.FromResult(ToolResult.Fail($"Unknown operation: {operation}. Supported: {Render}"));
+
+        if (!IsClientAttached)
+            return Task.FromResult(ToolResult.Fail("No client is connected to this conversation, so an image cannot be displayed."));
+
+        if (!parameters.TryGetValue(UrlKey, out var urlValue) || urlValue is not string url || string.IsNullOrWhiteSpace(url))
+            return Task.FromResult(ToolResult.Fail("Provide an image 'url' to display."));
+
+        if (!Uri.TryCreate(url, UriKind.Absolute, out var uri) || uri.Scheme != Uri.UriSchemeHttps)
+            return Task.FromResult(ToolResult.Fail("The image 'url' must be an absolute https URL."));
+
+        var argumentsJson = JsonSerializer.Serialize(parameters, SerializerOptions);
+
+        return InvokeClientAsync(argumentsJson, "The client did not display the image in time.", cancellationToken);
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/RenderTableTool.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/RenderTableTool.cs
@@ -1,0 +1,105 @@
+using System.Text.Json;
+using Application.AI.Common.Interfaces.Tools;
+using Domain.AI.Models;
+
+namespace Infrastructure.AI.Tools;
+
+/// <summary>
+/// Renders a data table inline in the agent's chat answer ("generative UI"): the agent supplies column
+/// headers and rows, and the connected browser draws a real table in the transcript. The browser returns
+/// a short textual acknowledgement so the agent can narrate what it showed.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A <b>synchronous</b> client round-trip tool using the same blocking-proxy mechanism as
+/// <see cref="RenderImageTool"/>: it delegates the render to the connected browser via
+/// <see cref="IClientToolBridge"/> and returns the browser's acknowledgement in milliseconds. The table
+/// is non-interactive (no user input flows back), so the agent's turn ends promptly. Only the structured
+/// data flows through the model; the browser owns the markup, so the agent can never inject arbitrary
+/// HTML — React escapes every cell.
+/// </para>
+/// <para>
+/// The essential contract is validated here — <c>columns</c> must be a non-empty array — so a table
+/// request that could never render fails fast. <c>rows</c> are deliberately <em>not</em> validated on
+/// the server: they are best-effort data that the client's <c>parseTableArgs</c> normalizes (a null or
+/// a non-array becomes an empty table; an individual malformed row is dropped and the rest render). The
+/// client is the single source of row-normalization truth, so the two boundaries never disagree and the
+/// server never rejects a ragged table the client would have shown. Every cell is coerced to display
+/// text and escaped by React at the render boundary.
+/// Register via keyed DI:
+/// <code>
+/// services.AddKeyedSingleton&lt;ITool&gt;(RenderTableTool.ToolName, (sp, _) =&gt;
+///     new RenderTableTool(sp.GetRequiredService&lt;IClientToolBridge&gt;()));
+/// </code>
+/// </para>
+/// </remarks>
+public sealed class RenderTableTool : BlockingProxyTool
+{
+    /// <summary>The tool name matching keyed DI registration and SKILL.md declarations.</summary>
+    public const string ToolName = "render_table";
+
+    private const string Render = "render";
+
+    private static readonly IReadOnlyList<string> Operations = [Render];
+
+    /// <summary>Initializes a new instance of the <see cref="RenderTableTool"/> class.</summary>
+    /// <param name="bridge">The client round-trip bridge used to delegate rendering to the browser.</param>
+    public RenderTableTool(IClientToolBridge bridge) : base(bridge)
+    {
+    }
+
+    /// <inheritdoc />
+    public override string Name => ToolName;
+
+    /// <inheritdoc />
+    public override string Description =>
+        "Displays a data table inline in your answer in the user's browser. Operation: render. " +
+        "Parameters: title (string, optional — a heading for the table); " +
+        "columns (array of strings, required — the column headers, left to right); " +
+        "rows (array of arrays, optional — each inner array is one row of cell values aligned to the " +
+        "columns; extra cells are dropped and missing cells render blank). " +
+        "Use this to present tabular or structured data instead of prose or a markdown table.";
+
+    /// <inheritdoc />
+    public override IReadOnlyList<string> SupportedOperations => Operations;
+
+    /// <inheritdoc />
+    public override Task<ToolResult> ExecuteAsync(
+        string operation,
+        IReadOnlyDictionary<string, object?> parameters,
+        CancellationToken cancellationToken = default)
+    {
+        if (!string.Equals(operation, Render, StringComparison.OrdinalIgnoreCase))
+            return Task.FromResult(ToolResult.Fail($"Unknown operation: {operation}. Supported: {Render}"));
+
+        if (!IsClientAttached)
+            return Task.FromResult(ToolResult.Fail("No client is connected to this conversation, so a table cannot be displayed."));
+
+        // Serialize once, then validate the structure from the JSON so nested arrays are inspected
+        // deterministically regardless of how the tool arguments were deserialized into the dictionary.
+        var argumentsJson = JsonSerializer.Serialize(parameters, SerializerOptions);
+
+        var validationError = ValidateColumns(argumentsJson);
+        if (validationError is not null)
+            return Task.FromResult(ToolResult.Fail(validationError));
+
+        return InvokeClientAsync(argumentsJson, "The client did not display the table in time.", cancellationToken);
+    }
+
+    /// <summary>
+    /// Validates that <c>columns</c> is a non-empty array; returns an error message, or null when valid.
+    /// <c>rows</c> are intentionally not validated — they are normalized client-side (see the type remarks),
+    /// so a null, a non-array, or an individual malformed row renders as empty/dropped rather than failing
+    /// the whole table.
+    /// </summary>
+    private static string? ValidateColumns(string argumentsJson)
+    {
+        using var doc = JsonDocument.Parse(argumentsJson);
+        if (!doc.RootElement.TryGetProperty("columns", out var columns)
+            || columns.ValueKind != JsonValueKind.Array
+            || columns.GetArrayLength() == 0)
+            return "Provide a non-empty 'columns' array of header labels.";
+
+        return null;
+    }
+}

--- a/src/Content/Presentation/Presentation.WebUI/package-lock.json
+++ b/src/Content/Presentation/Presentation.WebUI/package-lock.json
@@ -8,8 +8,8 @@
       "name": "presentation-webui",
       "version": "0.0.0",
       "dependencies": {
-        "@ag-ui/client": "^0.0.53",
-        "@ag-ui/core": "^0.0.53",
+        "@ag-ui/client": "^0.0.57",
+        "@ag-ui/core": "^0.0.57",
         "@azure/msal-browser": "^5.6.3",
         "@azure/msal-react": "^5.2.1",
         "@base-ui/react": "^1.4.0",
@@ -74,13 +74,13 @@
       "license": "MIT"
     },
     "node_modules/@ag-ui/client": {
-      "version": "0.0.53",
-      "resolved": "https://registry.npmjs.org/@ag-ui/client/-/client-0.0.53.tgz",
-      "integrity": "sha512-Mkup36KUp0KXy9v89QtAOWDUoh8H1s1Vgl4zvQv9HqXuAK1TkbtpXJHpbgZJXIxTqd54KT6yCurmC2UkOP7FDQ==",
+      "version": "0.0.57",
+      "resolved": "https://registry.npmjs.org/@ag-ui/client/-/client-0.0.57.tgz",
+      "integrity": "sha512-Xap2alG9Z0/j5kb3x4D7oTpe2sw1dfrC9rgJJr2NZu5vKcm8dzIPNd31mF2B4zS3BKqYIu245yxKPhEtT30MHw==",
       "dependencies": {
-        "@ag-ui/core": "0.0.53",
-        "@ag-ui/encoder": "0.0.53",
-        "@ag-ui/proto": "0.0.53",
+        "@ag-ui/core": "0.0.57",
+        "@ag-ui/encoder": "0.0.57",
+        "@ag-ui/proto": "0.0.57",
         "@types/uuid": "^10.0.0",
         "compare-versions": "^6.1.1",
         "fast-json-patch": "^3.1.1",
@@ -109,9 +109,9 @@
       }
     },
     "node_modules/@ag-ui/core": {
-      "version": "0.0.53",
-      "resolved": "https://registry.npmjs.org/@ag-ui/core/-/core-0.0.53.tgz",
-      "integrity": "sha512-11UocR7fFdMWw503bWCX2IOK15vbWfxT11Mn9xOiPBVO/UVcn57ywGrlLL4UaBlPgmUTvuzr2yYR2ElSqiN2wQ==",
+      "version": "0.0.57",
+      "resolved": "https://registry.npmjs.org/@ag-ui/core/-/core-0.0.57.tgz",
+      "integrity": "sha512-gho1OWjNE6E3Rl7ZEZ1wr2CEpUHjLFU0FqzCZZk439TicLu+BfLCMkMokB07bMGlRmbJ60hM6LW60iOVauCx+Q==",
       "dependencies": {
         "zod": "^3.22.4"
       }
@@ -126,20 +126,20 @@
       }
     },
     "node_modules/@ag-ui/encoder": {
-      "version": "0.0.53",
-      "resolved": "https://registry.npmjs.org/@ag-ui/encoder/-/encoder-0.0.53.tgz",
-      "integrity": "sha512-bAOcfVdm6U4H6G6tW+DZfwPEQm1w/snVBTwaFn9nJcEMW69M7/HZuwvEc/7Zo0rK1jRL32N/j60PwTAeky19fw==",
+      "version": "0.0.57",
+      "resolved": "https://registry.npmjs.org/@ag-ui/encoder/-/encoder-0.0.57.tgz",
+      "integrity": "sha512-ifD9NctR4xyPDR58xF9GK1bj/S8oECFkTeDfuYD8tXdbcOstIJ2TOqU2zhiCKnw7Vw+zR9Qv3TbsM9E7Gi9X3Q==",
       "dependencies": {
-        "@ag-ui/core": "0.0.53",
-        "@ag-ui/proto": "0.0.53"
+        "@ag-ui/core": "0.0.57",
+        "@ag-ui/proto": "0.0.57"
       }
     },
     "node_modules/@ag-ui/proto": {
-      "version": "0.0.53",
-      "resolved": "https://registry.npmjs.org/@ag-ui/proto/-/proto-0.0.53.tgz",
-      "integrity": "sha512-swjz22xWT8YUZt5OhmUwkARDQdwt8XM1hmGZbQrhRnNPXKwrKJX9ELlbnQ4iFUQIKkMWpphzE3vA3yNKs2bbKw==",
+      "version": "0.0.57",
+      "resolved": "https://registry.npmjs.org/@ag-ui/proto/-/proto-0.0.57.tgz",
+      "integrity": "sha512-pPENOZt0P6ibH8sCTgq05wLYXi5t3P9B5r/1bWYehXjUxtyOdnukSlWM++SsCIwUXsQdm/b3aBgGjEeTF7RenA==",
       "dependencies": {
-        "@ag-ui/core": "0.0.53",
+        "@ag-ui/core": "0.0.57",
         "@bufbuild/protobuf": "^2.2.5",
         "@protobuf-ts/protoc": "^2.11.1"
       }
@@ -737,9 +737,9 @@
       }
     },
     "node_modules/@bufbuild/protobuf": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.12.0.tgz",
-      "integrity": "sha512-B/XlCaFIP8LOwzo+bz5uFzATYokcwCKQcghqnlfwSmM5eX/qTkvDBnDPs+gXtX/RyjxJ4DRikECcPJbyALA8FA==",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.12.1.tgz",
+      "integrity": "sha512-BvAMfS6LrgZiryOAZ4pBYucu4wG/Ei/9o9DZ9akbREnMLbPJiom2i8b9C8IsKErQoiKqVhrerzt3kOT/RrzLHg==",
       "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/@csstools/color-helpers": {

--- a/src/Content/Presentation/Presentation.WebUI/package.json
+++ b/src/Content/Presentation/Presentation.WebUI/package.json
@@ -17,8 +17,8 @@
     "test:e2e:ui": "playwright test --ui"
   },
   "dependencies": {
-    "@ag-ui/client": "^0.0.53",
-    "@ag-ui/core": "^0.0.53",
+    "@ag-ui/client": "^0.0.57",
+    "@ag-ui/core": "^0.0.57",
     "@azure/msal-browser": "^5.6.3",
     "@azure/msal-react": "^5.2.1",
     "@base-ui/react": "^1.4.0",

--- a/src/Content/Presentation/Presentation.WebUI/src/features/chat/ChatPanel.tsx
+++ b/src/Content/Presentation/Presentation.WebUI/src/features/chat/ChatPanel.tsx
@@ -7,13 +7,13 @@ import { useAppStore } from '@/stores/appStore';
 import { useConversationSettingsStore } from '@/stores/conversationSettingsStore';
 import { useAgentHub, type ConnectionState, type ConversationSettingsInput, type ServerConversationMessage } from '@/hooks/useAgentHub';
 import { useAgentStream } from '@/hooks/useAgentStream';
+import { useSendUserMessage } from '@/hooks/useSendUserMessage';
 import type { ChatMessage } from './useChatStore';
 import { CONVERSATIONS_QUERY_KEY } from '@/features/conversations/useConversationsQuery';
 import { MessageList } from './MessageList';
 import { TypingIndicator } from './TypingIndicator';
 import { ChatInput } from './ChatInput';
 import { ConversationSettingsDrawer } from './ConversationSettingsDrawer';
-import { Badge } from '@/components/ui/badge';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { EmptyState } from '@/components/ui/empty-state';
 
@@ -123,6 +123,7 @@ export function ChatPanel() {
     connectionState,
   } = useAgentHub();
   const { sendMessage: agUiSend } = useAgentStream();
+  const sendUserMessage = useSendUserMessage();
   const [conversationReady, setConversationReady] = useState(false);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const currentSettings = useConversationSettingsStore((s) =>
@@ -149,16 +150,8 @@ export function ChatPanel() {
   };
 
   const handleSuggestionClick = (text: string): void => {
-    if (!activeConversationId || !conversationReady) return;
-    const userMessageId = crypto.randomUUID();
-    useChatStore.getState().addMessage({
-      id: userMessageId,
-      role: 'user',
-      content: text,
-      timestamp: new Date(),
-    });
-    useChatStore.getState().startStreaming();
-    agUiSend(activeConversationId, userMessageId, text);
+    if (!conversationReady) return;
+    sendUserMessage(text);
   };
 
   const handleEdit = (userMessageId: string, newContent: string): void => {

--- a/src/Content/Presentation/Presentation.WebUI/src/features/chat/MessageItem.tsx
+++ b/src/Content/Presentation/Presentation.WebUI/src/features/chat/MessageItem.tsx
@@ -8,6 +8,7 @@ import { Badge } from '@/components/ui/badge';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { JsonViewer } from '@/components/ui/json-viewer';
+import { renderWidget } from './widgets/registry';
 import type { ChatMessage, ToolCallSummary } from './useChatStore';
 
 function ToolCallCard({ toolCall }: { toolCall: ToolCallSummary }) {
@@ -145,6 +146,8 @@ export function MessageItem({
   };
 
   const hasActions = canRetry || canEdit || canCopy;
+  // A widget-only assistant message (empty content) shows just the widget — no empty bubble.
+  const showBubble = isEditing || isStreaming || message.content.length > 0;
 
   return (
     <div
@@ -173,47 +176,56 @@ export function MessageItem({
         </span>
 
         {/* Message bubble */}
-        <div
-          className={cn(
-            'rounded-2xl px-4 py-3 text-sm leading-relaxed',
-            isUser
-              ? 'bg-primary text-primary-foreground rounded-tr-sm'
-              : 'bg-card border border-border/50 text-card-foreground rounded-tl-sm',
-          )}
-        >
-          {isEditing ? (
-            <div className="flex flex-col gap-2 min-w-[280px]">
-              <Textarea
-                value={draft}
-                onChange={(e) => { setDraft(e.target.value); }}
-                onKeyDown={handleKeyDown}
-                rows={3}
-                aria-label="Edit message"
-                autoFocus
-                className="bg-background/50 border-border/50"
-              />
-              <div className="flex justify-end gap-2">
-                <Button type="button" variant="ghost" size="sm" onClick={handleCancelEdit}>
-                  <X size={14} className="mr-1" /> Cancel
-                </Button>
-                <Button type="button" size="sm" onClick={handleSaveEdit}>
-                  <Check size={14} className="mr-1" /> Save
-                </Button>
+        {showBubble && (
+          <div
+            className={cn(
+              'rounded-2xl px-4 py-3 text-sm leading-relaxed',
+              isUser
+                ? 'bg-primary text-primary-foreground rounded-tr-sm'
+                : 'bg-card border border-border/50 text-card-foreground rounded-tl-sm',
+            )}
+          >
+            {isEditing ? (
+              <div className="flex flex-col gap-2 min-w-[280px]">
+                <Textarea
+                  value={draft}
+                  onChange={(e) => { setDraft(e.target.value); }}
+                  onKeyDown={handleKeyDown}
+                  rows={3}
+                  aria-label="Edit message"
+                  autoFocus
+                  className="bg-background/50 border-border/50"
+                />
+                <div className="flex justify-end gap-2">
+                  <Button type="button" variant="ghost" size="sm" onClick={handleCancelEdit}>
+                    <X size={14} className="mr-1" /> Cancel
+                  </Button>
+                  <Button type="button" size="sm" onClick={handleSaveEdit}>
+                    <Check size={14} className="mr-1" /> Save
+                  </Button>
+                </div>
               </div>
-            </div>
-          ) : isUser ? (
-            <p className="whitespace-pre-wrap">{message.content}</p>
-          ) : (
-            <Markdown content={message.content} isStreaming={isStreaming} />
-          )}
+            ) : isUser ? (
+              <p className="whitespace-pre-wrap">{message.content}</p>
+            ) : (
+              <Markdown content={message.content} isStreaming={isStreaming} />
+            )}
 
-          {isStreaming && (
-            <span
-              className="inline-block w-0.5 h-4 bg-current animate-[cursor-blink_1s_ease-in-out_infinite] ml-0.5 align-middle rounded-full"
-              aria-hidden
-            />
-          )}
-        </div>
+            {isStreaming && (
+              <span
+                className="inline-block w-0.5 h-4 bg-current animate-[cursor-blink_1s_ease-in-out_infinite] ml-0.5 align-middle rounded-full"
+                aria-hidden
+              />
+            )}
+          </div>
+        )}
+
+        {/* Inline generative-UI widget (e.g. an image) — rendered outside the bubble. */}
+        {!isUser && message.widget && (
+          <div className="w-full mt-1">
+            {renderWidget(message.widget)}
+          </div>
+        )}
 
         {/* Tool calls — outside the bubble for cleaner layout */}
         {!isUser && (message.toolCalls ?? []).length > 0 && (

--- a/src/Content/Presentation/Presentation.WebUI/src/features/chat/useChatStore.ts
+++ b/src/Content/Presentation/Presentation.WebUI/src/features/chat/useChatStore.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+import type { AgentWidget } from './widgets/types';
 
 export interface ToolCallSummary {
   toolName: string;
@@ -12,6 +13,12 @@ export interface ChatMessage {
   content: string;
   timestamp: Date;
   toolCalls?: ToolCallSummary[];
+  /**
+   * An inline generative-UI widget the agent rendered mid-run (e.g. an image). When present on an
+   * assistant message with empty `content`, the transcript shows only the widget. Rendered via the
+   * widget registry.
+   */
+  widget?: AgentWidget;
 }
 
 interface ChatState {

--- a/src/Content/Presentation/Presentation.WebUI/src/features/chat/widgets/AgentForm.tsx
+++ b/src/Content/Presentation/Presentation.WebUI/src/features/chat/widgets/AgentForm.tsx
@@ -1,0 +1,152 @@
+import { useMemo, useState, type FormEvent } from 'react';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Button } from '@/components/ui/button';
+import { useSendUserMessage } from '@/hooks/useSendUserMessage';
+import { parseFormArgs, formatSubmission, type FormFieldSpec, type FormSpec } from './formTypes';
+
+type FieldValue = string | boolean;
+type FormValues = Record<string, FieldValue>;
+
+function initialValues(spec: FormSpec): FormValues {
+  const values: FormValues = {};
+  for (const field of spec.fields) values[field.name] = field.type === 'checkbox' ? false : '';
+  return values;
+}
+
+function isBlank(field: FormFieldSpec, value: FieldValue): boolean {
+  return field.type === 'checkbox' ? value !== true : String(value ?? '').trim() === '';
+}
+
+/** Renders one field control by type. `select` uses a native element so agent-generated option lists
+ *  render without the heavier composed Select primitive. */
+function Field({
+  field,
+  value,
+  onChange,
+  disabled,
+}: {
+  field: FormFieldSpec;
+  value: FieldValue;
+  onChange: (name: string, value: FieldValue) => void;
+  disabled: boolean;
+}) {
+  const id = `agent-form-${field.name}`;
+  const label = field.label ?? field.name;
+
+  if (field.type === 'checkbox') {
+    return (
+      <label htmlFor={id} className="flex items-center gap-2 text-xs font-medium text-foreground">
+        <input
+          type="checkbox"
+          id={id}
+          name={field.name}
+          checked={value === true}
+          disabled={disabled}
+          onChange={(e) => { onChange(field.name, e.target.checked); }}
+          className="h-4 w-4 rounded border-border accent-primary"
+        />
+        {label}
+      </label>
+    );
+  }
+
+  const labelEl = (
+    <label htmlFor={id} className="text-xs font-medium text-foreground">
+      {label}{field.required && <span className="text-destructive"> *</span>}
+    </label>
+  );
+
+  let control: React.ReactNode;
+  switch (field.type) {
+    case 'textarea':
+      control = (
+        <Textarea id={id} name={field.name} value={String(value)} rows={3} disabled={disabled}
+          onChange={(e) => { onChange(field.name, e.target.value); }} />
+      );
+      break;
+    case 'select':
+      control = (
+        <select id={id} name={field.name} value={String(value)} disabled={disabled}
+          onChange={(e) => { onChange(field.name, e.target.value); }}
+          className="flex h-9 w-full rounded-md border border-border bg-background px-3 py-1 text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-ring disabled:opacity-50">
+          <option value="" disabled>Select…</option>
+          {field.options?.map((opt) => <option key={opt} value={opt}>{opt}</option>)}
+        </select>
+      );
+      break;
+    default:
+      // text, number, and date all render a single-line Input; the input type follows the field
+      // (only text/number/date reach here — checkbox/textarea/select are handled above).
+      control = (
+        <Input id={id} name={field.name} type={field.type} value={String(value)} disabled={disabled}
+          onChange={(e) => { onChange(field.name, e.target.value); }} />
+      );
+  }
+
+  return <div className="space-y-1">{labelEl}{control}</div>;
+}
+
+/**
+ * Renders an agent-supplied interactive form inline in the transcript. On submit it does NOT return
+ * through the tool round-trip (that already acknowledged synchronously); it sends the answers as the
+ * user's next message via {@link useSendUserMessage}, so the agent continues in a fresh turn. Locks
+ * after a successful submit to prevent double-sending. Re-validates the spec at render time (agent
+ * output is untrusted); an invalid spec shows a fallback instead of a broken form.
+ */
+export function AgentForm({ args }: { args: Record<string, unknown> }) {
+  const send = useSendUserMessage();
+  const parsed = useMemo(() => parseFormArgs(args), [args]);
+  const [values, setValues] = useState<FormValues>(() => (parsed.ok ? initialValues(parsed.value) : {}));
+  const [submitted, setSubmitted] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  if (!parsed.ok) {
+    return (
+      <div data-testid="agent-form-fallback"
+        className="rounded-lg border border-border/50 bg-muted/40 px-3 py-2 text-xs text-muted-foreground">
+        {parsed.reason}
+      </div>
+    );
+  }
+  const spec = parsed.value;
+
+  const setValue = (name: string, value: FieldValue): void => {
+    setValues((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = (e: FormEvent): void => {
+    e.preventDefault();
+    if (submitted) return;
+
+    const missing = spec.fields.filter((f) => f.required && isBlank(f, values[f.name]));
+    if (missing.length > 0) {
+      setError(`Please fill in: ${missing.map((f) => f.label ?? f.name).join(', ')}`);
+      return;
+    }
+
+    if (!send(formatSubmission(spec, values))) {
+      setError('There is no active conversation to submit to.');
+      return;
+    }
+    setError(null);
+    setSubmitted(true);
+  };
+
+  return (
+    <form onSubmit={handleSubmit} data-testid="agent-form"
+      className="rounded-lg border border-border/50 bg-card/50 p-3 space-y-3 max-w-md">
+      {spec.title && <div className="text-sm font-medium text-foreground">{spec.title}</div>}
+      {spec.fields.map((field) => (
+        <Field key={field.name} field={field} value={values[field.name]} onChange={setValue} disabled={submitted} />
+      ))}
+      {error && <p data-testid="agent-form-error" className="text-xs text-destructive">{error}</p>}
+      <div className="flex items-center gap-2">
+        <Button type="submit" size="sm" disabled={submitted}>
+          {submitted ? 'Submitted' : (spec.submitLabel ?? 'Submit')}
+        </Button>
+        {submitted && <span className="text-xs text-muted-foreground">Your answers were sent.</span>}
+      </div>
+    </form>
+  );
+}

--- a/src/Content/Presentation/Presentation.WebUI/src/features/chat/widgets/AgentImage.tsx
+++ b/src/Content/Presentation/Presentation.WebUI/src/features/chat/widgets/AgentImage.tsx
@@ -1,0 +1,47 @@
+import { useState } from 'react';
+import { ImageOff } from 'lucide-react';
+import { parseImageArgs } from './types';
+
+/**
+ * Renders an agent-supplied image inline in the transcript. Re-validates the arguments at render time
+ * (the agent's output is untrusted) and shows a safe fallback for an invalid URL or a load failure
+ * rather than a broken image. This component is the only thing the `render_image` tool can summon —
+ * the agent chooses the URL and captions, never the markup.
+ */
+export function AgentImage({ args }: { args: Record<string, unknown> }) {
+  const [failed, setFailed] = useState(false);
+  const result = parseImageArgs(args);
+
+  if (!result.ok || failed) {
+    const reason = result.ok ? 'The image could not be loaded.' : result.reason;
+    return (
+      <div
+        data-testid="agent-image-fallback"
+        className="flex items-center gap-2 rounded-lg border border-border/50 bg-muted/40 px-3 py-2 text-xs text-muted-foreground"
+      >
+        <ImageOff size={14} aria-hidden /> {reason}
+      </div>
+    );
+  }
+
+  const { url, alt, caption } = result.value;
+  return (
+    <figure
+      data-testid="agent-image"
+      className="rounded-lg border border-border/50 bg-card/50 overflow-hidden max-w-md"
+    >
+      <img
+        src={url}
+        alt={alt ?? caption ?? 'Image provided by the assistant'}
+        className="max-h-96 w-full object-contain bg-background"
+        loading="lazy"
+        onError={() => { setFailed(true); }}
+      />
+      {caption && (
+        <figcaption className="px-3 py-2 text-xs text-muted-foreground border-t border-border/50">
+          {caption}
+        </figcaption>
+      )}
+    </figure>
+  );
+}

--- a/src/Content/Presentation/Presentation.WebUI/src/features/chat/widgets/AgentTable.tsx
+++ b/src/Content/Presentation/Presentation.WebUI/src/features/chat/widgets/AgentTable.tsx
@@ -1,0 +1,69 @@
+import { parseTableArgs } from './tableTypes';
+
+/**
+ * Renders an agent-supplied data table inline in the transcript. Re-validates the arguments at render
+ * time (the agent's output is untrusted) and shows a safe fallback for a spec with no columns rather
+ * than a broken table. Every cell is plain text — React escapes it — so the agent chooses the data,
+ * never the markup. Wide tables scroll horizontally inside their own container so the transcript never
+ * scrolls sideways.
+ */
+export function AgentTable({ args }: { args: Record<string, unknown> }) {
+  const result = parseTableArgs(args);
+
+  if (!result.ok) {
+    return (
+      <div
+        data-testid="agent-table-fallback"
+        className="rounded-lg border border-border/50 bg-muted/40 px-3 py-2 text-xs text-muted-foreground"
+      >
+        {result.reason}
+      </div>
+    );
+  }
+
+  const { title, columns, rows } = result.value;
+  return (
+    <figure
+      data-testid="agent-table"
+      className="rounded-lg border border-border/50 bg-card/50 overflow-hidden max-w-full"
+    >
+      {title && (
+        <figcaption className="px-3 py-2 text-sm font-medium text-foreground border-b border-border/50">
+          {title}
+        </figcaption>
+      )}
+      <div className="overflow-x-auto">
+        <table className="w-full border-collapse text-xs">
+          <thead>
+            <tr className="border-b border-border/50 bg-muted/30">
+              {columns.map((col, i) => (
+                <th key={i} scope="col" className="px-3 py-2 text-left font-medium text-foreground whitespace-nowrap">
+                  {col}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {rows.length === 0 ? (
+              <tr>
+                <td colSpan={columns.length} className="px-3 py-2 text-center text-muted-foreground">
+                  No rows
+                </td>
+              </tr>
+            ) : (
+              rows.map((row, r) => (
+                <tr key={r} className="border-b border-border/30 last:border-b-0">
+                  {row.map((cell, c) => (
+                    <td key={c} className="px-3 py-2 text-muted-foreground align-top">
+                      {cell}
+                    </td>
+                  ))}
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+    </figure>
+  );
+}

--- a/src/Content/Presentation/Presentation.WebUI/src/features/chat/widgets/__tests__/AgentForm.test.tsx
+++ b/src/Content/Presentation/Presentation.WebUI/src/features/chat/widgets/__tests__/AgentForm.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { AgentForm } from '../AgentForm';
+
+const send = vi.fn<(text: string) => boolean>();
+vi.mock('@/hooks/useSendUserMessage', () => ({ useSendUserMessage: () => send }));
+
+describe('AgentForm', () => {
+  beforeEach(() => { send.mockReset().mockReturnValue(true); });
+
+  it('renders a fallback for an invalid spec instead of a broken form', () => {
+    render(<AgentForm args={{ fields: [] }} />);
+    expect(screen.getByTestId('agent-form-fallback')).toBeInTheDocument();
+    expect(screen.queryByTestId('agent-form')).not.toBeInTheDocument();
+  });
+
+  it('renders a control per field and the title', () => {
+    render(<AgentForm args={{ title: 'Preferences', fields: [
+      { name: 'email', label: 'Email', type: 'text' },
+      { name: 'bio', label: 'Bio', type: 'textarea' },
+      { name: 'color', label: 'Color', type: 'select', options: ['red', 'blue'] },
+      { name: 'news', label: 'Newsletter', type: 'checkbox' },
+    ] }} />);
+    expect(screen.getByText('Preferences')).toBeInTheDocument();
+    expect(screen.getByLabelText('Email')).toBeInTheDocument();
+    expect(screen.getByLabelText('Bio')).toBeInTheDocument();
+    expect(screen.getByLabelText('Color')).toBeInTheDocument();
+    expect(screen.getByLabelText('Newsletter')).toBeInTheDocument();
+  });
+
+  it('blocks submit and shows an error when a required field is blank', async () => {
+    const user = userEvent.setup();
+    render(<AgentForm args={{ fields: [{ name: 'email', label: 'Email', type: 'text', required: true }] }} />);
+    await user.click(screen.getByRole('button', { name: /submit/i }));
+    expect(send).not.toHaveBeenCalled();
+    expect(screen.getByTestId('agent-form-error')).toHaveTextContent(/Email/);
+  });
+
+  it('on valid submit sends a formatted message and locks the form', async () => {
+    const user = userEvent.setup();
+    render(<AgentForm args={{ fields: [
+      { name: 'email', label: 'Email', type: 'text', required: true },
+      { name: 'news', label: 'Newsletter', type: 'checkbox' },
+    ], submitLabel: 'Send it' }} />);
+
+    // Required fields render their label with a trailing "*", so match by regex.
+    await user.type(screen.getByLabelText(/Email/), 'a@b.com');
+    await user.click(screen.getByLabelText('Newsletter'));
+    await user.click(screen.getByRole('button', { name: 'Send it' }));
+
+    expect(send).toHaveBeenCalledTimes(1);
+    const message = send.mock.calls[0][0];
+    expect(message).toContain('- Email: a@b.com');
+    expect(message).toContain('- Newsletter: Yes');
+
+    // Locked after submit — button relabeled and disabled, inputs disabled.
+    const button = screen.getByRole('button', { name: /submitted/i });
+    expect(button).toBeDisabled();
+    expect(screen.getByLabelText(/Email/)).toBeDisabled();
+  });
+
+  it('does not lock the form when there is no active conversation to send to', async () => {
+    send.mockReturnValue(false);
+    const user = userEvent.setup();
+    render(<AgentForm args={{ fields: [{ name: 'q', label: 'Q', type: 'text' }] }} />);
+    await user.click(screen.getByRole('button', { name: /submit/i }));
+    expect(screen.getByTestId('agent-form-error')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /submit/i })).not.toBeDisabled();
+  });
+});

--- a/src/Content/Presentation/Presentation.WebUI/src/features/chat/widgets/__tests__/AgentTable.test.tsx
+++ b/src/Content/Presentation/Presentation.WebUI/src/features/chat/widgets/__tests__/AgentTable.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { AgentTable } from '../AgentTable';
+
+describe('AgentTable', () => {
+  it('renders headers and cells from a valid spec', () => {
+    render(<AgentTable args={{ title: 'Scores', columns: ['Name', 'Score'], rows: [['Ada', '97']] }} />);
+    expect(screen.getByTestId('agent-table')).toBeInTheDocument();
+    expect(screen.getByText('Scores')).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: 'Name' })).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: 'Score' })).toBeInTheDocument();
+    expect(screen.getByRole('cell', { name: 'Ada' })).toBeInTheDocument();
+    expect(screen.getByRole('cell', { name: '97' })).toBeInTheDocument();
+  });
+
+  it('renders a "No rows" affordance for a headers-only table', () => {
+    render(<AgentTable args={{ columns: ['A', 'B'] }} />);
+    expect(screen.getByText('No rows')).toBeInTheDocument();
+  });
+
+  it('shows a safe fallback (not a broken table) when there are no columns', () => {
+    render(<AgentTable args={{ rows: [['x']] }} />);
+    expect(screen.queryByRole('table')).not.toBeInTheDocument();
+    expect(screen.getByTestId('agent-table-fallback')).toBeInTheDocument();
+  });
+
+  it('does not render agent cell text as markup', () => {
+    render(<AgentTable args={{ columns: ['A'], rows: [['<b>bold</b>']] }} />);
+    // React escapes the string, so it appears as literal text, not an element.
+    expect(screen.getByText('<b>bold</b>')).toBeInTheDocument();
+  });
+});

--- a/src/Content/Presentation/Presentation.WebUI/src/features/chat/widgets/__tests__/formTypes.test.ts
+++ b/src/Content/Presentation/Presentation.WebUI/src/features/chat/widgets/__tests__/formTypes.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import { parseFormArgs, formatSubmission, type FormSpec } from '../formTypes';
+
+describe('parseFormArgs', () => {
+  it('accepts a valid spec and carries title/submitLabel/required/options', () => {
+    const result = parseFormArgs({
+      title: 'Sign up',
+      submitLabel: 'Go',
+      fields: [
+        { name: 'email', label: 'Email', type: 'text', required: true },
+        { name: 'color', type: 'select', options: ['red', 'blue'] },
+      ],
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.title).toBe('Sign up');
+    expect(result.value.submitLabel).toBe('Go');
+    expect(result.value.fields).toHaveLength(2);
+    expect(result.value.fields[0]).toMatchObject({ name: 'email', type: 'text', required: true });
+    expect(result.value.fields[1].options).toEqual(['red', 'blue']);
+  });
+
+  it('rejects a spec with no fields', () => {
+    expect(parseFormArgs({ title: 'x' }).ok).toBe(false);
+    expect(parseFormArgs({ fields: [] }).ok).toBe(false);
+  });
+
+  it('drops fields with an unknown type', () => {
+    const result = parseFormArgs({ fields: [{ name: 'a', type: 'text' }, { name: 'b', type: 'hologram' }] });
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value.fields.map((f) => f.name)).toEqual(['a']);
+  });
+
+  it('drops a select field that has no options', () => {
+    const result = parseFormArgs({ fields: [{ name: 'a', type: 'text' }, { name: 'c', type: 'select' }] });
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value.fields.map((f) => f.name)).toEqual(['a']);
+  });
+
+  it('drops fields without a name', () => {
+    const result = parseFormArgs({ fields: [{ type: 'text' }, { name: 'ok', type: 'text' }] });
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value.fields.map((f) => f.name)).toEqual(['ok']);
+  });
+
+  it('fails when every field is invalid', () => {
+    expect(parseFormArgs({ fields: [{ name: 'a', type: 'bogus' }] }).ok).toBe(false);
+  });
+
+  it('drops duplicate field names, keeping the first', () => {
+    const result = parseFormArgs({ fields: [{ name: 'x', type: 'text' }, { name: 'x', type: 'number' }] });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.fields).toHaveLength(1);
+      expect(result.value.fields[0].type).toBe('text');
+    }
+  });
+});
+
+describe('formatSubmission', () => {
+  const spec: FormSpec = {
+    fields: [
+      { name: 'email', label: 'Email', type: 'text' },
+      { name: 'news', label: 'Newsletter', type: 'checkbox' },
+      { name: 'phone', label: 'Phone', type: 'text' },
+    ],
+  };
+
+  it('renders labels and checkbox as Yes/No, omitting empty optional fields', () => {
+    const message = formatSubmission(spec, { email: 'a@b.com', news: true, phone: '' });
+    expect(message).toContain('Here are my answers:');
+    expect(message).toContain('- Email: a@b.com');
+    expect(message).toContain('- Newsletter: Yes');
+    expect(message).not.toContain('Phone'); // empty optional omitted
+  });
+
+  it('falls back to the field name when no label is given', () => {
+    const message = formatSubmission({ fields: [{ name: 'code', type: 'text' }] }, { code: 'X1' });
+    expect(message).toContain('- code: X1');
+  });
+});

--- a/src/Content/Presentation/Presentation.WebUI/src/features/chat/widgets/__tests__/parseImageArgs.test.ts
+++ b/src/Content/Presentation/Presentation.WebUI/src/features/chat/widgets/__tests__/parseImageArgs.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { parseImageArgs } from '../types';
+
+describe('parseImageArgs', () => {
+  it('accepts an absolute https url and extracts optional alt/caption', () => {
+    const result = parseImageArgs({ url: 'https://example.com/cat.png', alt: 'a cat', caption: 'Fluffy' });
+    expect(result).toEqual({ ok: true, value: { url: 'https://example.com/cat.png', alt: 'a cat', caption: 'Fluffy' } });
+  });
+
+  it('trims surrounding whitespace on the url', () => {
+    const result = parseImageArgs({ url: '  https://example.com/cat.png  ' });
+    expect(result.ok && result.value.url).toBe('https://example.com/cat.png');
+  });
+
+  it('rejects a missing url', () => {
+    expect(parseImageArgs({ alt: 'x' })).toEqual({ ok: false, reason: expect.stringContaining('url') });
+  });
+
+  it.each([
+    ['http://example.com/cat.png', 'http (not https)'],
+    ['javascript:alert(1)', 'javascript: scheme'],
+    ['data:image/png;base64,AAAA', 'data: scheme'],
+  ])('rejects non-https url %s (%s)', (url) => {
+    const result = parseImageArgs({ url });
+    expect(result.ok).toBe(false);
+    expect(!result.ok && result.reason).toContain('https');
+  });
+
+  it('rejects an unparseable url', () => {
+    const result = parseImageArgs({ url: 'not a url' });
+    expect(result.ok).toBe(false);
+  });
+
+  it('ignores non-string alt/caption rather than passing them through', () => {
+    const result = parseImageArgs({ url: 'https://example.com/x.png', alt: 42, caption: { nope: true } });
+    expect(result.ok && result.value.alt).toBeUndefined();
+    expect(result.ok && result.value.caption).toBeUndefined();
+  });
+});

--- a/src/Content/Presentation/Presentation.WebUI/src/features/chat/widgets/__tests__/registry.test.tsx
+++ b/src/Content/Presentation/Presentation.WebUI/src/features/chat/widgets/__tests__/registry.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { renderWidget } from '../registry';
+
+describe('widget registry', () => {
+  it('renders the AgentImage component for a render_image widget', () => {
+    render(<>{renderWidget({ type: 'render_image', args: { url: 'https://example.com/cat.png', caption: 'Fluffy' } })}</>);
+    const img = screen.getByRole('img');
+    expect(img).toHaveAttribute('src', 'https://example.com/cat.png');
+    expect(screen.getByText('Fluffy')).toBeInTheDocument();
+  });
+
+  it('renders a safe fallback (not a broken image) for a non-https url', () => {
+    render(<>{renderWidget({ type: 'render_image', args: { url: 'http://example.com/cat.png' } })}</>);
+    expect(screen.queryByRole('img')).not.toBeInTheDocument();
+    expect(screen.getByTestId('agent-image-fallback')).toBeInTheDocument();
+  });
+
+  it('renders nothing for an unknown widget type rather than throwing', () => {
+    const { container } = render(<>{renderWidget({ type: 'render_hologram', args: {} })}</>);
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/src/Content/Presentation/Presentation.WebUI/src/features/chat/widgets/__tests__/registry.test.tsx
+++ b/src/Content/Presentation/Presentation.WebUI/src/features/chat/widgets/__tests__/registry.test.tsx
@@ -29,4 +29,16 @@ describe('widget registry', () => {
     expect(screen.getByTestId('agent-form')).toBeInTheDocument();
     expect(screen.getByLabelText('Email')).toBeInTheDocument();
   });
+
+  it('renders the AgentTable component for a render_table widget', () => {
+    render(<>{renderWidget({ type: 'render_table', args: { columns: ['Name', 'Score'], rows: [['Ada', '97']] } })}</>);
+    expect(screen.getByTestId('agent-table')).toBeInTheDocument();
+    expect(screen.getByRole('cell', { name: 'Ada' })).toBeInTheDocument();
+  });
+
+  it('renders a safe fallback (not a broken table) for a render_table widget with no columns', () => {
+    render(<>{renderWidget({ type: 'render_table', args: { rows: [['x']] } })}</>);
+    expect(screen.queryByRole('table')).not.toBeInTheDocument();
+    expect(screen.getByTestId('agent-table-fallback')).toBeInTheDocument();
+  });
 });

--- a/src/Content/Presentation/Presentation.WebUI/src/features/chat/widgets/__tests__/registry.test.tsx
+++ b/src/Content/Presentation/Presentation.WebUI/src/features/chat/widgets/__tests__/registry.test.tsx
@@ -1,6 +1,9 @@
 import { render, screen } from '@testing-library/react';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { renderWidget } from '../registry';
+
+// AgentForm (render_form) pulls in the send hook → MSAL; stub it so the registry test stays isolated.
+vi.mock('@/hooks/useSendUserMessage', () => ({ useSendUserMessage: () => () => true }));
 
 describe('widget registry', () => {
   it('renders the AgentImage component for a render_image widget', () => {
@@ -19,5 +22,11 @@ describe('widget registry', () => {
   it('renders nothing for an unknown widget type rather than throwing', () => {
     const { container } = render(<>{renderWidget({ type: 'render_hologram', args: {} })}</>);
     expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders the AgentForm component for a render_form widget', () => {
+    render(<>{renderWidget({ type: 'render_form', args: { title: 'Sign up', fields: [{ name: 'email', label: 'Email', type: 'text' }] } })}</>);
+    expect(screen.getByTestId('agent-form')).toBeInTheDocument();
+    expect(screen.getByLabelText('Email')).toBeInTheDocument();
   });
 });

--- a/src/Content/Presentation/Presentation.WebUI/src/features/chat/widgets/__tests__/tableTypes.test.ts
+++ b/src/Content/Presentation/Presentation.WebUI/src/features/chat/widgets/__tests__/tableTypes.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { parseTableArgs } from '../tableTypes';
+
+describe('parseTableArgs', () => {
+  it('accepts columns + rows and coerces cells to text', () => {
+    const result = parseTableArgs({ title: 'Scores', columns: ['Name', 'Score'], rows: [['Ada', 97], ['Alan', true]] });
+    expect(result).toEqual({
+      ok: true,
+      value: { title: 'Scores', columns: ['Name', 'Score'], rows: [['Ada', '97'], ['Alan', 'true']] },
+    });
+  });
+
+  it('rejects a spec with no columns', () => {
+    expect(parseTableArgs({ rows: [['x']] })).toEqual({ ok: false, reason: expect.stringContaining('columns') });
+  });
+
+  it('rejects an empty columns array', () => {
+    expect(parseTableArgs({ columns: [] }).ok).toBe(false);
+  });
+
+  it('defaults rows to empty when absent', () => {
+    const result = parseTableArgs({ columns: ['A'] });
+    expect(result.ok && result.value.rows).toEqual([]);
+  });
+
+  it('treats an explicit null rows as empty (agents emit null for optional params)', () => {
+    const result = parseTableArgs({ columns: ['A'], rows: null });
+    expect(result.ok && result.value.rows).toEqual([]);
+  });
+
+  it('pads short rows and truncates long rows to the column count', () => {
+    const result = parseTableArgs({ columns: ['A', 'B'], rows: [['only-a'], ['a', 'b', 'c']] });
+    expect(result.ok && result.value.rows).toEqual([['only-a', ''], ['a', 'b']]);
+  });
+
+  it('drops non-array rows rather than throwing', () => {
+    const result = parseTableArgs({ columns: ['A'], rows: ['flat', ['ok'], 42] });
+    expect(result.ok && result.value.rows).toEqual([['ok']]);
+  });
+
+  it('coerces object/null cells to blank so no markup leaks through', () => {
+    const result = parseTableArgs({ columns: ['A', 'B'], rows: [[{ nope: 1 }, null]] });
+    expect(result.ok && result.value.rows).toEqual([['', '']]);
+  });
+
+  it('ignores a non-string title', () => {
+    const result = parseTableArgs({ columns: ['A'], title: 42 });
+    expect(result.ok && result.value.title).toBeUndefined();
+  });
+});

--- a/src/Content/Presentation/Presentation.WebUI/src/features/chat/widgets/formTypes.ts
+++ b/src/Content/Presentation/Presentation.WebUI/src/features/chat/widgets/formTypes.ts
@@ -1,0 +1,87 @@
+/** Field control types the form widget can render. Kept in sync with RenderFormTool's server whitelist. */
+export type FormFieldType = 'text' | 'textarea' | 'number' | 'select' | 'checkbox' | 'date';
+
+const ALLOWED_TYPES: readonly FormFieldType[] = ['text', 'textarea', 'number', 'select', 'checkbox', 'date'];
+
+/** A single validated form field. */
+export interface FormFieldSpec {
+  name: string;
+  label?: string;
+  type: FormFieldType;
+  required?: boolean;
+  /** Present (non-empty) only for `select`. */
+  options?: string[];
+}
+
+/** A validated form specification. */
+export interface FormSpec {
+  title?: string;
+  submitLabel?: string;
+  fields: FormFieldSpec[];
+}
+
+/** Outcome of validating raw `render_form` arguments at the client trust boundary. */
+export type FormArgsResult =
+  | { ok: true; value: FormSpec }
+  | { ok: false; reason: string };
+
+/**
+ * Validates raw agent-supplied form arguments and coerces them into a typed {@link FormSpec}. Fields
+ * with an unknown `type`, a missing `name`, or (for `select`) no `options` are dropped rather than
+ * rendered — the field-type whitelist is the client trust boundary mirroring the server-side check in
+ * RenderFormTool. Agent output is untrusted, so this runs both when deciding the tool acknowledgement
+ * and again at render time.
+ */
+export function parseFormArgs(args: Record<string, unknown>): FormArgsResult {
+  const rawFields = Array.isArray(args.fields) ? args.fields : null;
+  if (!rawFields || rawFields.length === 0) return { ok: false, reason: 'The form has no fields.' };
+
+  const fields: FormFieldSpec[] = [];
+  const seen = new Set<string>();
+  for (const raw of rawFields) {
+    if (typeof raw !== 'object' || raw === null) continue;
+    const f = raw as Record<string, unknown>;
+
+    const name = typeof f.name === 'string' ? f.name.trim() : '';
+    const type = typeof f.type === 'string' ? f.type : '';
+    // Duplicate names would collide in the values map and produce duplicate React keys — keep the first.
+    if (!name || seen.has(name) || !ALLOWED_TYPES.includes(type as FormFieldType)) continue;
+
+    const field: FormFieldSpec = { name, type: type as FormFieldType };
+    if (typeof f.label === 'string') field.label = f.label;
+    if (typeof f.required === 'boolean') field.required = f.required;
+
+    if (type === 'select') {
+      const options = Array.isArray(f.options)
+        ? f.options.filter((o): o is string => typeof o === 'string')
+        : [];
+      if (options.length === 0) continue; // a select with no options is unusable — drop it
+      field.options = options;
+    }
+
+    seen.add(name);
+    fields.push(field);
+  }
+
+  if (fields.length === 0) return { ok: false, reason: 'The form has no valid fields.' };
+
+  const spec: FormSpec = { fields };
+  if (typeof args.title === 'string') spec.title = args.title;
+  if (typeof args.submitLabel === 'string') spec.submitLabel = args.submitLabel;
+  return { ok: true, value: spec };
+}
+
+/** Formats submitted values into a readable message the agent receives as the user's next turn. */
+export function formatSubmission(spec: FormSpec, values: Record<string, string | boolean>): string {
+  const lines = spec.fields
+    .map((field) => {
+      const raw = values[field.name];
+      const label = field.label ?? field.name;
+      if (field.type === 'checkbox') return `- ${label}: ${raw === true ? 'Yes' : 'No'}`;
+      const text = typeof raw === 'string' ? raw.trim() : '';
+      return text ? `- ${label}: ${text}` : null; // omit empty optional fields
+    })
+    .filter((line): line is string => line !== null);
+
+  return `Here are my answers:\n${lines.join('\n')}`;
+}

--- a/src/Content/Presentation/Presentation.WebUI/src/features/chat/widgets/registry.tsx
+++ b/src/Content/Presentation/Presentation.WebUI/src/features/chat/widgets/registry.tsx
@@ -1,0 +1,30 @@
+import type { ReactNode } from 'react';
+import { AgentImage } from './AgentImage';
+import type { AgentWidget } from './types';
+
+type WidgetRenderer = (args: Record<string, unknown>) => ReactNode;
+
+/**
+ * The palette of inline widgets the agent can summon: a client tool name → the component that renders
+ * its result. This is the generative-UI trust boundary — the agent selects a widget and supplies its
+ * arguments, but can never introduce a component that is not registered here. Add a new widget by
+ * registering its tool name and a renderer; nothing else in the transcript path changes.
+ */
+// NOTE: this maps a tool name to how its result RENDERS. The matching round-trip handler (validate
+// args, push the widget message, produce the agent acknowledgement) currently lives in
+// useAgentStream's dispatch — a widget must be added in both places until PR2 (render_form) unifies
+// them. render_form defers its acknowledgement until user submit, so the unified shape can't be
+// designed against render_image's synchronous ack alone; keep the two in sync by hand until then.
+// A Map (not an object) so an agent-influenced widget.type can never resolve to an inherited member
+// like "constructor" and get invoked — lookups are prototype-safe by construction.
+const WIDGET_REGISTRY = new Map<string, WidgetRenderer>([
+  ['render_image', (args) => <AgentImage args={args} />],
+]);
+
+/**
+ * Renders an inline widget by tool name. An unknown type renders nothing (a safe fallback) rather than
+ * throwing — the transcript must never crash on an unexpected agent tool call.
+ */
+export function renderWidget(widget: AgentWidget): ReactNode {
+  return WIDGET_REGISTRY.get(widget.type)?.(widget.args) ?? null;
+}

--- a/src/Content/Presentation/Presentation.WebUI/src/features/chat/widgets/registry.tsx
+++ b/src/Content/Presentation/Presentation.WebUI/src/features/chat/widgets/registry.tsx
@@ -1,30 +1,50 @@
 import type { ReactNode } from 'react';
 import { AgentImage } from './AgentImage';
-import type { AgentWidget } from './types';
+import { AgentForm } from './AgentForm';
+import { parseImageArgs, type AgentWidget } from './types';
+import { parseFormArgs } from './formTypes';
 
-type WidgetRenderer = (args: Record<string, unknown>) => ReactNode;
+/** Outcome of validating a widget's raw args: ok → it renders and `ack` is returned to the agent;
+ *  not ok → `reason` is returned and no widget is shown. */
+type ValidationResult = { ok: true } | { ok: false; reason: string };
 
 /**
- * The palette of inline widgets the agent can summon: a client tool name → the component that renders
- * its result. This is the generative-UI trust boundary — the agent selects a widget and supplies its
- * arguments, but can never introduce a component that is not registered here. Add a new widget by
- * registering its tool name and a renderer; nothing else in the transcript path changes.
+ * Everything the transcript and the stream handler need for one inline widget: how its result renders,
+ * how to validate the agent's raw args at the client trust boundary, and the acknowledgement the agent
+ * observes once it is displayed. Adding a widget is one entry in {@link WIDGET_REGISTRY} — the stream
+ * handler (generic) and the transcript renderer both dispatch off it, so nothing else changes. This is
+ * the generative-UI trust boundary: the agent can only summon a registered widget, with validated args.
  */
-// NOTE: this maps a tool name to how its result RENDERS. The matching round-trip handler (validate
-// args, push the widget message, produce the agent acknowledgement) currently lives in
-// useAgentStream's dispatch — a widget must be added in both places until PR2 (render_form) unifies
-// them. render_form defers its acknowledgement until user submit, so the unified shape can't be
-// designed against render_image's synchronous ack alone; keep the two in sync by hand until then.
-// A Map (not an object) so an agent-influenced widget.type can never resolve to an inherited member
+export interface WidgetDefinition {
+  render: (args: Record<string, unknown>) => ReactNode;
+  validate: (args: Record<string, unknown>) => ValidationResult;
+  ack: string;
+}
+
+// A Map (not an object) so an agent-influenced widget type can never resolve to an inherited member
 // like "constructor" and get invoked — lookups are prototype-safe by construction.
-const WIDGET_REGISTRY = new Map<string, WidgetRenderer>([
-  ['render_image', (args) => <AgentImage args={args} />],
+const WIDGET_REGISTRY = new Map<string, WidgetDefinition>([
+  ['render_image', {
+    render: (args) => <AgentImage args={args} />,
+    validate: (args) => { const r = parseImageArgs(args); return r.ok ? { ok: true } : { ok: false, reason: r.reason }; },
+    ack: 'Displayed the image to the user.',
+  }],
+  ['render_form', {
+    render: (args) => <AgentForm args={args} />,
+    validate: (args) => { const r = parseFormArgs(args); return r.ok ? { ok: true } : { ok: false, reason: r.reason }; },
+    ack: 'Displayed the form to the user; their answers will arrive as their next message.',
+  }],
 ]);
+
+/** The widget definition for a client tool name, or undefined if it is not a widget tool. */
+export function getWidget(type: string): WidgetDefinition | undefined {
+  return WIDGET_REGISTRY.get(type);
+}
 
 /**
  * Renders an inline widget by tool name. An unknown type renders nothing (a safe fallback) rather than
  * throwing — the transcript must never crash on an unexpected agent tool call.
  */
 export function renderWidget(widget: AgentWidget): ReactNode {
-  return WIDGET_REGISTRY.get(widget.type)?.(widget.args) ?? null;
+  return WIDGET_REGISTRY.get(widget.type)?.render(widget.args) ?? null;
 }

--- a/src/Content/Presentation/Presentation.WebUI/src/features/chat/widgets/registry.tsx
+++ b/src/Content/Presentation/Presentation.WebUI/src/features/chat/widgets/registry.tsx
@@ -1,8 +1,10 @@
 import type { ReactNode } from 'react';
 import { AgentImage } from './AgentImage';
 import { AgentForm } from './AgentForm';
+import { AgentTable } from './AgentTable';
 import { parseImageArgs, type AgentWidget } from './types';
 import { parseFormArgs } from './formTypes';
+import { parseTableArgs } from './tableTypes';
 
 /** Outcome of validating a widget's raw args: ok → it renders and `ack` is returned to the agent;
  *  not ok → `reason` is returned and no widget is shown. */
@@ -33,6 +35,11 @@ const WIDGET_REGISTRY = new Map<string, WidgetDefinition>([
     render: (args) => <AgentForm args={args} />,
     validate: (args) => { const r = parseFormArgs(args); return r.ok ? { ok: true } : { ok: false, reason: r.reason }; },
     ack: 'Displayed the form to the user; their answers will arrive as their next message.',
+  }],
+  ['render_table', {
+    render: (args) => <AgentTable args={args} />,
+    validate: (args) => { const r = parseTableArgs(args); return r.ok ? { ok: true } : { ok: false, reason: r.reason }; },
+    ack: 'Displayed the table to the user.',
   }],
 ]);
 

--- a/src/Content/Presentation/Presentation.WebUI/src/features/chat/widgets/tableTypes.ts
+++ b/src/Content/Presentation/Presentation.WebUI/src/features/chat/widgets/tableTypes.ts
@@ -1,0 +1,50 @@
+/** A validated data-table specification: header row + normalized cell rows. */
+export interface TableSpec {
+  title?: string;
+  columns: string[];
+  /** Each row is exactly `columns.length` cells — padded/truncated during parsing. */
+  rows: string[][];
+}
+
+/** Outcome of validating raw `render_table` arguments at the client trust boundary. */
+export type TableArgsResult =
+  | { ok: true; value: TableSpec }
+  | { ok: false; reason: string };
+
+/** Coerces an agent-supplied cell/header value to display text; non-primitives render blank. */
+function toText(value: unknown): string {
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+  return '';
+}
+
+/** Pads or truncates a row to exactly `width` cells so every row aligns to the header. */
+function normalizeRow(row: unknown[], width: number): string[] {
+  const cells = row.slice(0, width).map(toText);
+  while (cells.length < width) cells.push('');
+  return cells;
+}
+
+/**
+ * Validates raw agent-supplied table arguments and coerces them into a typed {@link TableSpec}. The
+ * `columns` array is the client trust boundary (mirroring the server-side check in RenderTableTool): a
+ * missing or empty one is rejected. Rows are best-effort — non-array rows are dropped and each surviving
+ * row is normalized to the column count so a ragged table from the agent still renders cleanly. Cell
+ * values are coerced to text (React escapes them), so the agent can never inject markup. Agent output is
+ * untrusted, so this runs both when deciding the tool acknowledgement and again at render time.
+ */
+export function parseTableArgs(args: Record<string, unknown>): TableArgsResult {
+  const rawColumns = Array.isArray(args.columns) ? args.columns : null;
+  if (!rawColumns || rawColumns.length === 0) return { ok: false, reason: 'The table has no columns.' };
+
+  const columns = rawColumns.map(toText);
+
+  const rawRows = Array.isArray(args.rows) ? args.rows : [];
+  const rows = rawRows
+    .filter((r): r is unknown[] => Array.isArray(r))
+    .map((r) => normalizeRow(r, columns.length));
+
+  const spec: TableSpec = { columns, rows };
+  if (typeof args.title === 'string') spec.title = args.title;
+  return { ok: true, value: spec };
+}

--- a/src/Content/Presentation/Presentation.WebUI/src/features/chat/widgets/types.ts
+++ b/src/Content/Presentation/Presentation.WebUI/src/features/chat/widgets/types.ts
@@ -1,0 +1,51 @@
+/**
+ * A renderable inline widget the agent summoned mid-run via a client tool call. Stored on a
+ * {@link import('../useChatStore').ChatMessage} and rendered by the widget registry.
+ */
+export interface AgentWidget {
+  /** The client tool name that produced it, e.g. `render_image`. Keys into the widget registry. */
+  type: string;
+  /** Raw arguments the agent supplied. Each renderer re-validates these before use (untrusted input). */
+  args: Record<string, unknown>;
+}
+
+/** Validated arguments for the `render_image` widget. */
+export interface AgentImageArgs {
+  url: string;
+  alt?: string;
+  caption?: string;
+}
+
+/** Outcome of validating raw `render_image` arguments at the client trust boundary. */
+export type ImageArgsResult =
+  | { ok: true; value: AgentImageArgs }
+  | { ok: false; reason: string };
+
+/**
+ * Validates raw agent-supplied image arguments. The URL must be an absolute `https` URL — this is the
+ * client-side trust boundary that keeps unsafe references (`javascript:`, `data:`, `http:`) out of the
+ * DOM, mirroring the server-side check in `RenderImageTool` (defense in depth). Agent output is
+ * untrusted, so this runs both when deciding the tool-result acknowledgement and again at render time.
+ */
+export function parseImageArgs(args: Record<string, unknown>): ImageArgsResult {
+  const url = typeof args.url === 'string' ? args.url.trim() : '';
+  if (!url) return { ok: false, reason: 'No image url was provided.' };
+
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return { ok: false, reason: 'The image url is not a valid URL.' };
+  }
+
+  if (parsed.protocol !== 'https:') return { ok: false, reason: 'The image url must use https.' };
+
+  return {
+    ok: true,
+    value: {
+      url,
+      alt: typeof args.alt === 'string' ? args.alt : undefined,
+      caption: typeof args.caption === 'string' ? args.caption : undefined,
+    },
+  };
+}

--- a/src/Content/Presentation/Presentation.WebUI/src/hooks/__tests__/useAgentStream.test.tsx
+++ b/src/Content/Presentation/Presentation.WebUI/src/hooks/__tests__/useAgentStream.test.tsx
@@ -1,0 +1,94 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { Subject } from 'rxjs';
+import { EventType } from '@ag-ui/core';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { useAgentStream } from '../useAgentStream';
+import { useChatStore } from '@/stores/chatStore';
+
+const postToolResult = vi.fn<(threadId: string, callId: string, result: string) => Promise<void>>();
+
+vi.mock('@/lib/devAuth', () => ({ IS_AUTH_DISABLED: true }));
+vi.mock('@azure/msal-react', () => ({ useMsal: () => ({ instance: {} }) }));
+vi.mock('@/lib/authConfig', () => ({ loginRequest: { scopes: [] } }));
+vi.mock('@/lib/agUiClient', () => ({
+  createAuthenticatedAgUiAgent: vi.fn(),
+  postToolResult: (threadId: string, callId: string, result: string) => postToolResult(threadId, callId, result),
+}));
+
+// Imported after the mock declaration; vi.mock is hoisted so this resolves to the mocked module.
+import { createAuthenticatedAgUiAgent } from '@/lib/agUiClient';
+const mockedCreate = vi.mocked(createAuthenticatedAgUiAgent);
+
+/** Drives the hook, waits until it has subscribed to the run, then returns the event stream to feed. */
+async function startRun(conversationId = 'conv-1'): Promise<Subject<unknown>> {
+  const events$ = new Subject<unknown>();
+  mockedCreate.mockResolvedValue({ run: () => events$ } as never);
+
+  const { result } = renderHook(() => useAgentStream());
+  act(() => { result.current.sendMessage(conversationId, 'user-1', 'show me a cat'); });
+  // The subscribe happens after the createAuthenticatedAgUiAgent promise resolves; a Subject does not
+  // replay, so events emitted before subscription would be lost. Wait for the subscription to attach.
+  await waitFor(() => { expect(events$.observed).toBe(true); });
+  return events$;
+}
+
+describe('useAgentStream — render_image round-trip', () => {
+  beforeEach(() => {
+    postToolResult.mockReset().mockResolvedValue(undefined);
+    mockedCreate.mockReset();
+    useChatStore.getState().clearMessages();
+    useChatStore.getState().setConversationId('conv-1');
+  });
+
+  it('renders the image widget and posts a success result that unblocks the run', async () => {
+    const events$ = await startRun();
+
+    act(() => {
+      events$.next({ type: EventType.TOOL_CALL_START, toolCallId: 'call-1', toolCallName: 'render_image' });
+      events$.next({ type: EventType.TOOL_CALL_ARGS, toolCallId: 'call-1', delta: JSON.stringify({ url: 'https://example.com/cat.png', caption: 'Fluffy' }) });
+      events$.next({ type: EventType.TOOL_CALL_END, toolCallId: 'call-1' });
+    });
+
+    await waitFor(() => {
+      expect(postToolResult).toHaveBeenCalledWith('conv-1', 'call-1', expect.stringContaining('Displayed'));
+    });
+
+    const widgetMsg = useChatStore.getState().messages.find((m) => m.widget?.type === 'render_image');
+    expect(widgetMsg?.widget?.args).toMatchObject({ url: 'https://example.com/cat.png', caption: 'Fluffy' });
+  });
+
+  it('accumulates argument deltas that arrive in multiple chunks', async () => {
+    const events$ = await startRun();
+
+    act(() => {
+      events$.next({ type: EventType.TOOL_CALL_START, toolCallId: 'call-2', toolCallName: 'render_image' });
+      events$.next({ type: EventType.TOOL_CALL_ARGS, toolCallId: 'call-2', delta: '{"url":"https://exa' });
+      events$.next({ type: EventType.TOOL_CALL_ARGS, toolCallId: 'call-2', delta: 'mple.com/dog.png"}' });
+      events$.next({ type: EventType.TOOL_CALL_END, toolCallId: 'call-2' });
+    });
+
+    await waitFor(() => { expect(postToolResult).toHaveBeenCalledWith('conv-1', 'call-2', expect.stringContaining('Displayed')); });
+    expect(useChatStore.getState().messages.some((m) => m.widget?.args.url === 'https://example.com/dog.png')).toBe(true);
+  });
+
+  it('posts an explanatory result and renders no widget for a non-https url', async () => {
+    const events$ = await startRun();
+
+    act(() => {
+      events$.next({ type: EventType.TOOL_CALL_START, toolCallId: 'call-3', toolCallName: 'render_image' });
+      events$.next({ type: EventType.TOOL_CALL_ARGS, toolCallId: 'call-3', delta: JSON.stringify({ url: 'http://example.com/cat.png' }) });
+      events$.next({ type: EventType.TOOL_CALL_END, toolCallId: 'call-3' });
+    });
+
+    await waitFor(() => { expect(postToolResult).toHaveBeenCalledWith('conv-1', 'call-3', expect.stringContaining('https')); });
+    expect(useChatStore.getState().messages.some((m) => m.widget)).toBe(false);
+  });
+
+  it('still posts a result for a tool call it never saw a START for, so the server never hangs', async () => {
+    const events$ = await startRun();
+
+    act(() => { events$.next({ type: EventType.TOOL_CALL_END, toolCallId: 'orphan' }); });
+
+    await waitFor(() => { expect(postToolResult).toHaveBeenCalledWith('conv-1', 'orphan', expect.stringContaining('No client handler')); });
+  });
+});

--- a/src/Content/Presentation/Presentation.WebUI/src/hooks/__tests__/useAgentStream.test.tsx
+++ b/src/Content/Presentation/Presentation.WebUI/src/hooks/__tests__/useAgentStream.test.tsx
@@ -84,6 +84,34 @@ describe('useAgentStream — render_image round-trip', () => {
     expect(useChatStore.getState().messages.some((m) => m.widget)).toBe(false);
   });
 
+  it('renders the form widget and posts a "displayed" ack (answers come later as a message)', async () => {
+    const events$ = await startRun();
+
+    act(() => {
+      events$.next({ type: EventType.TOOL_CALL_START, toolCallId: 'call-f', toolCallName: 'render_form' });
+      events$.next({ type: EventType.TOOL_CALL_ARGS, toolCallId: 'call-f', delta: JSON.stringify({ title: 'Prefs', fields: [{ name: 'email', type: 'text' }] }) });
+      events$.next({ type: EventType.TOOL_CALL_END, toolCallId: 'call-f' });
+    });
+
+    await waitFor(() => {
+      expect(postToolResult).toHaveBeenCalledWith('conv-1', 'call-f', expect.stringContaining('Displayed the form'));
+    });
+    expect(useChatStore.getState().messages.some((m) => m.widget?.type === 'render_form')).toBe(true);
+  });
+
+  it('posts an explanatory result and renders no widget for a form with no valid fields', async () => {
+    const events$ = await startRun();
+
+    act(() => {
+      events$.next({ type: EventType.TOOL_CALL_START, toolCallId: 'call-g', toolCallName: 'render_form' });
+      events$.next({ type: EventType.TOOL_CALL_ARGS, toolCallId: 'call-g', delta: JSON.stringify({ fields: [] }) });
+      events$.next({ type: EventType.TOOL_CALL_END, toolCallId: 'call-g' });
+    });
+
+    await waitFor(() => { expect(postToolResult).toHaveBeenCalledWith('conv-1', 'call-g', expect.stringContaining('no fields')); });
+    expect(useChatStore.getState().messages.some((m) => m.widget?.type === 'render_form')).toBe(false);
+  });
+
   it('still posts a result for a tool call it never saw a START for, so the server never hangs', async () => {
     const events$ = await startRun();
 

--- a/src/Content/Presentation/Presentation.WebUI/src/hooks/__tests__/useSendUserMessage.test.ts
+++ b/src/Content/Presentation/Presentation.WebUI/src/hooks/__tests__/useSendUserMessage.test.ts
@@ -1,0 +1,38 @@
+import { renderHook } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { useSendUserMessage } from '../useSendUserMessage';
+import { useChatStore } from '@/stores/chatStore';
+import { useAppStore } from '@/stores/appStore';
+
+const agUiSend = vi.fn();
+vi.mock('@/hooks/useAgentStream', () => ({
+  useAgentStream: () => ({ sendMessage: agUiSend, abort: vi.fn() }),
+}));
+
+describe('useSendUserMessage', () => {
+  beforeEach(() => {
+    agUiSend.mockReset();
+    useChatStore.getState().clearMessages();
+    useAppStore.setState({ activeConversationId: null });
+  });
+
+  it('sends nothing and returns false when there is no active conversation', () => {
+    const { result } = renderHook(() => useSendUserMessage());
+    expect(result.current('hi')).toBe(false);
+    expect(agUiSend).not.toHaveBeenCalled();
+    expect(useChatStore.getState().messages).toHaveLength(0);
+  });
+
+  it('adds the user message, starts streaming, dispatches the run, and returns true', () => {
+    useAppStore.setState({ activeConversationId: 'conv-1' });
+    const { result } = renderHook(() => useSendUserMessage());
+
+    expect(result.current('hello there')).toBe(true);
+
+    const messages = useChatStore.getState().messages;
+    expect(messages).toHaveLength(1);
+    expect(messages[0]).toMatchObject({ role: 'user', content: 'hello there' });
+    expect(useChatStore.getState().isStreaming).toBe(true);
+    expect(agUiSend).toHaveBeenCalledWith('conv-1', expect.any(String), 'hello there');
+  });
+});

--- a/src/Content/Presentation/Presentation.WebUI/src/hooks/useAgentStream.ts
+++ b/src/Content/Presentation/Presentation.WebUI/src/hooks/useAgentStream.ts
@@ -3,7 +3,8 @@ import { useMsal } from '@azure/msal-react';
 import type { Subscription } from 'rxjs';
 import { EventType } from '@ag-ui/core';
 import type { BaseEvent, TextMessageContentEvent, TextMessageStartEvent, RunErrorEvent } from '@ag-ui/core';
-import { createAuthenticatedAgUiAgent } from '@/lib/agUiClient';
+import { createAuthenticatedAgUiAgent, postToolResult } from '@/lib/agUiClient';
+import { parseImageArgs, type AgentWidget } from '@/features/chat/widgets/types';
 import { loginRequest } from '@/lib/authConfig';
 import { IS_AUTH_DISABLED } from '@/lib/devAuth';
 import { useChatStore } from '@/stores/chatStore';
@@ -13,9 +14,72 @@ export interface UseAgentStreamReturn {
   abort: () => void;
 }
 
+/** Accumulator for an in-flight client tool call as its name and argument deltas stream in. */
+interface PendingCall {
+  name: string;
+  args: string;
+}
+
+/**
+ * Renders the `render_image` widget as an assistant message and returns the acknowledgement the agent
+ * should observe. Validates the agent-supplied arguments at the client trust boundary; an invalid URL
+ * yields an explanatory ack (and no widget) so the agent can recover rather than showing a broken image.
+ */
+function handleRenderImage(argsJson: string): string {
+  let args: Record<string, unknown>;
+  try {
+    args = JSON.parse(argsJson || '{}') as Record<string, unknown>;
+  } catch {
+    return 'The image arguments could not be parsed.';
+  }
+
+  const parsed = parseImageArgs(args);
+  if (!parsed.ok) return parsed.reason;
+
+  const widget: AgentWidget = { type: 'render_image', args };
+  useChatStore.getState().addMessage({
+    id: crypto.randomUUID(),
+    role: 'assistant',
+    content: '',
+    timestamp: new Date(),
+    widget,
+  });
+  return 'Displayed the image to the user.';
+}
+
+/**
+ * Completes a mid-run client tool call: computes a result for the call (rendering its widget as a side
+ * effect) and POSTs it back so the parked server-side tool unblocks and the run resumes. A result is
+ * posted for every callId — including one with no matching START — so the awaiting server tool never
+ * hangs. A failed POST surfaces an error rather than leaving the run stuck.
+ *
+ * Dispatch is a plain branch on the tool name while there is a single synchronous-ack widget. When
+ * render_form lands (PR2) it defers its result until user submit rather than returning a string here,
+ * so this is intentionally not abstracted into a handler registry until that second shape is known.
+ * Each widget added here must also be registered for rendering in widgets/registry.tsx.
+ */
+async function finishToolCall(threadId: string, callId: string, pending: PendingCall | undefined): Promise<void> {
+  let result: string;
+  if (!pending) {
+    result = `No client handler matched tool call ${callId}.`;
+  } else if (pending.name === 'render_image') {
+    result = handleRenderImage(pending.args);
+  } else {
+    result = `The client has no handler for widget "${pending.name}".`;
+  }
+
+  try {
+    await postToolResult(threadId, callId, result);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Could not deliver the tool result to the agent.';
+    useChatStore.getState().setError(message);
+  }
+}
+
 export function useAgentStream(): UseAgentStreamReturn {
   const { instance } = useMsal();
   const subscriptionRef = useRef<Subscription | null>(null);
+  const pendingCallsRef = useRef<Map<string, PendingCall>>(new Map());
 
   const getAccessToken = async (): Promise<string> => {
     if (IS_AUTH_DISABLED) return '';
@@ -28,6 +92,7 @@ export function useAgentStream(): UseAgentStreamReturn {
   const abort = (): void => {
     subscriptionRef.current?.unsubscribe();
     subscriptionRef.current = null;
+    pendingCallsRef.current.clear();
   };
 
   const sendMessage = (conversationId: string, userMessageId: string, message: string): void => {
@@ -71,6 +136,26 @@ export function useAgentStream(): UseAgentStreamReturn {
               const streamingContent = useChatStore.getState().streamingContent;
               useChatStore.getState().finalizeStream(streamingContent, currentMessageId ?? undefined);
               currentMessageId = null;
+              break;
+            }
+            case EventType.TOOL_CALL_START: {
+              const e = event as BaseEvent & { toolCallId: string; toolCallName: string };
+              pendingCallsRef.current.set(e.toolCallId, { name: e.toolCallName, args: '' });
+              break;
+            }
+            case EventType.TOOL_CALL_ARGS: {
+              const e = event as BaseEvent & { toolCallId: string; delta: string };
+              const pending = pendingCallsRef.current.get(e.toolCallId);
+              if (pending) pending.args += e.delta;
+              break;
+            }
+            case EventType.TOOL_CALL_END: {
+              const e = event as BaseEvent & { toolCallId: string };
+              const pending = pendingCallsRef.current.get(e.toolCallId);
+              pendingCallsRef.current.delete(e.toolCallId);
+              // The server tool is parked awaiting this result; fire-and-forget the round-trip so the
+              // same open run resumes with the widget rendered and the agent's follow-up narration.
+              void finishToolCall(conversationId, e.toolCallId, pending);
               break;
             }
             case EventType.RUN_ERROR: {

--- a/src/Content/Presentation/Presentation.WebUI/src/hooks/useAgentStream.ts
+++ b/src/Content/Presentation/Presentation.WebUI/src/hooks/useAgentStream.ts
@@ -4,7 +4,8 @@ import type { Subscription } from 'rxjs';
 import { EventType } from '@ag-ui/core';
 import type { BaseEvent, TextMessageContentEvent, TextMessageStartEvent, RunErrorEvent } from '@ag-ui/core';
 import { createAuthenticatedAgUiAgent, postToolResult } from '@/lib/agUiClient';
-import { parseImageArgs, type AgentWidget } from '@/features/chat/widgets/types';
+import { getWidget } from '@/features/chat/widgets/registry';
+import type { AgentWidget } from '@/features/chat/widgets/types';
 import { loginRequest } from '@/lib/authConfig';
 import { IS_AUTH_DISABLED } from '@/lib/devAuth';
 import { useChatStore } from '@/stores/chatStore';
@@ -21,52 +22,48 @@ interface PendingCall {
 }
 
 /**
- * Renders the `render_image` widget as an assistant message and returns the acknowledgement the agent
- * should observe. Validates the agent-supplied arguments at the client trust boundary; an invalid URL
- * yields an explanatory ack (and no widget) so the agent can recover rather than showing a broken image.
+ * Runs a completed client widget tool call: validates the agent's args at the client trust boundary,
+ * renders the widget as an assistant message on success, and returns the acknowledgement the agent
+ * observes. Everything widget-specific (validation, component, ack text) lives in the widget registry,
+ * so this stays generic across all widgets and is unchanged when a new one is added. On invalid args it
+ * returns the validator's reason and renders nothing, so the agent can recover.
  */
-function handleRenderImage(argsJson: string): string {
+function runWidgetToolCall(name: string, argsJson: string): string {
+  const widget = getWidget(name);
+  if (!widget) return `The client has no handler for widget "${name}".`;
+
   let args: Record<string, unknown>;
   try {
     args = JSON.parse(argsJson || '{}') as Record<string, unknown>;
   } catch {
-    return 'The image arguments could not be parsed.';
+    return `The ${name} arguments could not be parsed.`;
   }
 
-  const parsed = parseImageArgs(args);
-  if (!parsed.ok) return parsed.reason;
+  const check = widget.validate(args);
+  if (!check.ok) return check.reason;
 
-  const widget: AgentWidget = { type: 'render_image', args };
+  const rendered: AgentWidget = { type: name, args };
   useChatStore.getState().addMessage({
     id: crypto.randomUUID(),
     role: 'assistant',
     content: '',
     timestamp: new Date(),
-    widget,
+    widget: rendered,
   });
-  return 'Displayed the image to the user.';
+  return widget.ack;
 }
 
 /**
  * Completes a mid-run client tool call: computes a result for the call (rendering its widget as a side
  * effect) and POSTs it back so the parked server-side tool unblocks and the run resumes. A result is
  * posted for every callId — including one with no matching START — so the awaiting server tool never
- * hangs. A failed POST surfaces an error rather than leaving the run stuck.
- *
- * Dispatch is a plain branch on the tool name while there is a single synchronous-ack widget. When
- * render_form lands (PR2) it defers its result until user submit rather than returning a string here,
- * so this is intentionally not abstracted into a handler registry until that second shape is known.
- * Each widget added here must also be registered for rendering in widgets/registry.tsx.
+ * hangs. A failed POST surfaces an error rather than leaving the run stuck. Widget dispatch is generic
+ * over the widget registry, so adding a widget touches only widgets/registry.tsx.
  */
 async function finishToolCall(threadId: string, callId: string, pending: PendingCall | undefined): Promise<void> {
-  let result: string;
-  if (!pending) {
-    result = `No client handler matched tool call ${callId}.`;
-  } else if (pending.name === 'render_image') {
-    result = handleRenderImage(pending.args);
-  } else {
-    result = `The client has no handler for widget "${pending.name}".`;
-  }
+  const result = pending
+    ? runWidgetToolCall(pending.name, pending.args)
+    : `No client handler matched tool call ${callId}.`;
 
   try {
     await postToolResult(threadId, callId, result);

--- a/src/Content/Presentation/Presentation.WebUI/src/hooks/useSendUserMessage.ts
+++ b/src/Content/Presentation/Presentation.WebUI/src/hooks/useSendUserMessage.ts
@@ -1,0 +1,30 @@
+import { useAppStore } from '@/stores/appStore';
+import { useChatStore } from '@/stores/chatStore';
+import { useAgentStream } from '@/hooks/useAgentStream';
+
+/**
+ * Returns a function that sends `text` as the user's next message in the active conversation: it adds
+ * the optimistic user message, starts the streaming indicator, and dispatches the agent run — the same
+ * three-step sequence the chat input and suggestion chips use. Returns `false` when there is no active
+ * conversation (nothing sent). Shared by {@link import('@/features/chat/ChatPanel').ChatPanel} and the
+ * inline form widget so this send path lives in exactly one place.
+ */
+export function useSendUserMessage(): (text: string) => boolean {
+  const { sendMessage: agUiSend } = useAgentStream();
+
+  return (text: string): boolean => {
+    const conversationId = useAppStore.getState().activeConversationId;
+    if (!conversationId) return false;
+
+    const userMessageId = crypto.randomUUID();
+    useChatStore.getState().addMessage({
+      id: userMessageId,
+      role: 'user',
+      content: text,
+      timestamp: new Date(),
+    });
+    useChatStore.getState().startStreaming();
+    agUiSend(conversationId, userMessageId, text);
+    return true;
+  };
+}

--- a/src/Content/Presentation/Presentation.WebUI/src/lib/agUiClient.ts
+++ b/src/Content/Presentation/Presentation.WebUI/src/lib/agUiClient.ts
@@ -1,5 +1,6 @@
 import { HttpAgent } from '@ag-ui/client';
 import type { HttpAgentConfig } from '@ag-ui/client';
+import { apiClient } from '@/lib/apiClient';
 
 const AG_UI_BASE_URL = '/ag-ui/run';
 
@@ -45,4 +46,18 @@ export async function createAuthenticatedAgUiAgent(
 ): Promise<HttpAgent> {
   const headers = await buildAgUiHeaders(getAccessToken);
   return createAgUiAgent(headers);
+}
+
+/**
+ * Posts the browser's result for a mid-run client tool call back to the server, unblocking the
+ * parked server-side tool so the same agent run resumes with the result in hand. Mirrors the
+ * `POST /ag-ui/tool-result` contract (`{ threadId, callId, result }`); the shared `apiClient`
+ * supplies the base URL and the Authorization header via its request interceptor.
+ */
+export async function postToolResult(
+  threadId: string,
+  callId: string,
+  result: string,
+): Promise<void> {
+  await apiClient.post('/ag-ui/tool-result', { threadId, callId, result });
 }

--- a/src/Content/Tests/Infrastructure.AI.Tests/Tools/RenderFormToolTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Tools/RenderFormToolTests.cs
@@ -1,0 +1,150 @@
+using Application.AI.Common.Interfaces.Tools;
+using FluentAssertions;
+using Infrastructure.AI.Tools;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Tools;
+
+/// <summary>
+/// Tests for <see cref="RenderFormTool"/> — the generative-UI tool that displays an interactive form via
+/// the client round-trip. Covers operation validation, the no-client failure, field-spec validation
+/// (empty, missing name, bad type, select-without-options), the serialized payload, and the ack.
+/// </summary>
+public sealed class RenderFormToolTests
+{
+    private static Dictionary<string, object?> Args(params (string Key, object? Value)[] pairs)
+    {
+        var d = new Dictionary<string, object?>();
+        foreach (var (k, v) in pairs) d[k] = v;
+        return d;
+    }
+
+    private static Dictionary<string, object?> FieldOf(string name, string type, object? options = null)
+    {
+        var f = new Dictionary<string, object?> { ["name"] = name, ["type"] = type };
+        if (options is not null) f["options"] = options;
+        return f;
+    }
+
+    private static object[] Fields(params Dictionary<string, object?>[] fields) => fields;
+
+    [Fact]
+    public void Metadata_IsCorrect()
+    {
+        var sut = new RenderFormTool(new FakeBridge());
+        sut.Name.Should().Be("render_form");
+        sut.SupportedOperations.Should().BeEquivalentTo(["render"]);
+        sut.Description.Should().Contain("fields");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_UnknownOperation_Fails()
+    {
+        var bridge = new FakeBridge();
+        var result = await new RenderFormTool(bridge).ExecuteAsync("explode", Args(("fields", Fields(FieldOf("email", "text")))));
+        result.Success.Should().BeFalse();
+        bridge.InvokeCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_NoClientAttached_Fails()
+    {
+        var sut = new RenderFormTool(new FakeBridge { ClientAttached = false });
+        var result = await sut.ExecuteAsync("render", Args(("fields", Fields(FieldOf("email", "text")))));
+        result.Success.Should().BeFalse();
+        result.Error.Should().Contain("client");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_MissingFields_Fails()
+    {
+        var bridge = new FakeBridge();
+        var result = await new RenderFormTool(bridge).ExecuteAsync("render", Args(("title", "Sign up")));
+        result.Success.Should().BeFalse();
+        bridge.InvokeCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_EmptyFields_Fails()
+    {
+        var bridge = new FakeBridge();
+        var result = await new RenderFormTool(bridge).ExecuteAsync("render", Args(("fields", Array.Empty<object>())));
+        result.Success.Should().BeFalse();
+        bridge.InvokeCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_FieldMissingName_Fails()
+    {
+        var bridge = new FakeBridge();
+        var badField = new Dictionary<string, object?> { ["type"] = "text" }; // no name
+        var result = await new RenderFormTool(bridge).ExecuteAsync("render", Args(("fields", Fields(badField))));
+        result.Success.Should().BeFalse();
+        result.Error.Should().Contain("name");
+        bridge.InvokeCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_UnknownFieldType_Fails()
+    {
+        var bridge = new FakeBridge();
+        var result = await new RenderFormTool(bridge).ExecuteAsync("render", Args(("fields", Fields(FieldOf("x", "hologram")))));
+        result.Success.Should().BeFalse();
+        result.Error.Should().Contain("type");
+        bridge.InvokeCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_SelectWithoutOptions_Fails()
+    {
+        var bridge = new FakeBridge();
+        var result = await new RenderFormTool(bridge).ExecuteAsync("render", Args(("fields", Fields(FieldOf("color", "select")))));
+        result.Success.Should().BeFalse();
+        result.Error.Should().Contain("options");
+        bridge.InvokeCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_HappyPath_PassesSerializedArgs_AndReturnsAck()
+    {
+        var bridge = new FakeBridge { Result = "Displayed the form to the user; their answers will arrive as their next message." };
+        var result = await new RenderFormTool(bridge).ExecuteAsync("render", Args(
+            ("title", "Preferences"),
+            ("fields", Fields(FieldOf("email", "text"), FieldOf("color", "select", new[] { "red", "blue" })))));
+
+        result.Success.Should().BeTrue();
+        result.Output.Should().Contain("Displayed the form");
+        bridge.LastToolName.Should().Be("render_form");
+        bridge.LastArgsJson.Should().Contain("email").And.Contain("select").And.Contain("blue");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_BridgeTimeout_FailsGracefully()
+    {
+        var sut = new RenderFormTool(new FakeBridge { Throw = new TimeoutException() });
+        var result = await sut.ExecuteAsync("render", Args(("fields", Fields(FieldOf("email", "text")))));
+        result.Success.Should().BeFalse();
+    }
+
+    private sealed class FakeBridge : IClientToolBridge
+    {
+        public bool ClientAttached { get; init; } = true;
+        public string Result { get; init; } = "ok";
+        public Exception? Throw { get; init; }
+
+        public int InvokeCount { get; private set; }
+        public string? LastToolName { get; private set; }
+        public string? LastArgsJson { get; private set; }
+
+        public bool IsClientAttached => ClientAttached;
+
+        public Task<string> InvokeAsync(string toolName, string argumentsJson, CancellationToken cancellationToken = default)
+        {
+            InvokeCount++;
+            LastToolName = toolName;
+            LastArgsJson = argumentsJson;
+            if (Throw is not null) return Task.FromException<string>(Throw);
+            return Task.FromResult(Result);
+        }
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Tools/RenderImageToolTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Tools/RenderImageToolTests.cs
@@ -1,0 +1,124 @@
+using Application.AI.Common.Interfaces.Tools;
+using FluentAssertions;
+using Infrastructure.AI.Tools;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Tools;
+
+/// <summary>
+/// Tests for <see cref="RenderImageTool"/> — the generative-UI tool that delegates image display to the
+/// connected client via <see cref="IClientToolBridge"/>. Covers operation validation, the no-client and
+/// URL-validation failures (missing / non-https), the serialized payload, and timeout/cancellation.
+/// </summary>
+public sealed class RenderImageToolTests
+{
+    private const string ValidUrl = "https://example.com/cat.png";
+
+    private static Dictionary<string, object?> Args(params (string Key, object? Value)[] pairs)
+    {
+        var d = new Dictionary<string, object?>();
+        foreach (var (k, v) in pairs) d[k] = v;
+        return d;
+    }
+
+    [Fact]
+    public void Metadata_IsCorrect()
+    {
+        var sut = new RenderImageTool(new FakeBridge());
+        sut.Name.Should().Be("render_image");
+        sut.SupportedOperations.Should().BeEquivalentTo(["render"]);
+        sut.Description.Should().Contain("url");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_UnknownOperation_Fails()
+    {
+        var bridge = new FakeBridge();
+        var result = await new RenderImageTool(bridge).ExecuteAsync("explode", Args(("url", ValidUrl)));
+        result.Success.Should().BeFalse();
+        bridge.InvokeCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_NoClientAttached_Fails()
+    {
+        var sut = new RenderImageTool(new FakeBridge { ClientAttached = false });
+        var result = await sut.ExecuteAsync("render", Args(("url", ValidUrl)));
+        result.Success.Should().BeFalse();
+        result.Error.Should().Contain("client");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_MissingUrl_Fails()
+    {
+        var bridge = new FakeBridge();
+        var result = await new RenderImageTool(bridge).ExecuteAsync("render", Args(("alt", "a cat")));
+        result.Success.Should().BeFalse();
+        bridge.InvokeCount.Should().Be(0);
+    }
+
+    [Theory]
+    [InlineData("http://example.com/cat.png")]
+    [InlineData("javascript:alert(1)")]
+    [InlineData("data:image/png;base64,AAAA")]
+    [InlineData("not a url")]
+    public async Task ExecuteAsync_NonHttpsUrl_Fails(string url)
+    {
+        var bridge = new FakeBridge();
+        var result = await new RenderImageTool(bridge).ExecuteAsync("render", Args(("url", url)));
+        result.Success.Should().BeFalse();
+        result.Error.Should().Contain("https");
+        bridge.InvokeCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_HappyPath_PassesSerializedArgs_AndReturnsAck()
+    {
+        var bridge = new FakeBridge { Result = "Displayed the image to the user." };
+        var result = await new RenderImageTool(bridge).ExecuteAsync(
+            "render", Args(("url", ValidUrl), ("caption", "A cat")));
+
+        result.Success.Should().BeTrue();
+        result.Output.Should().Be("Displayed the image to the user.");
+        bridge.LastToolName.Should().Be("render_image");
+        bridge.LastArgsJson.Should().Contain(ValidUrl).And.Contain("A cat");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_BridgeTimeout_FailsGracefully()
+    {
+        var sut = new RenderImageTool(new FakeBridge { Throw = new TimeoutException() });
+        var result = await sut.ExecuteAsync("render", Args(("url", ValidUrl)));
+        result.Success.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Cancellation_Propagates()
+    {
+        var sut = new RenderImageTool(new FakeBridge { Throw = new OperationCanceledException() });
+        var act = async () => await sut.ExecuteAsync("render", Args(("url", ValidUrl)));
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    private sealed class FakeBridge : IClientToolBridge
+    {
+        public bool ClientAttached { get; init; } = true;
+        public string Result { get; init; } = "ok";
+        public Exception? Throw { get; init; }
+
+        public int InvokeCount { get; private set; }
+        public string? LastToolName { get; private set; }
+        public string? LastArgsJson { get; private set; }
+
+        public bool IsClientAttached => ClientAttached;
+
+        public Task<string> InvokeAsync(string toolName, string argumentsJson, CancellationToken cancellationToken = default)
+        {
+            InvokeCount++;
+            LastToolName = toolName;
+            LastArgsJson = argumentsJson;
+            if (Throw is not null) return Task.FromException<string>(Throw);
+            return Task.FromResult(Result);
+        }
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Tools/RenderTableToolTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Tools/RenderTableToolTests.cs
@@ -1,0 +1,158 @@
+using Application.AI.Common.Interfaces.Tools;
+using FluentAssertions;
+using Infrastructure.AI.Tools;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Tools;
+
+/// <summary>
+/// Tests for <see cref="RenderTableTool"/> — the generative-UI tool that displays a data table via the
+/// client round-trip. Covers operation validation, the no-client failure, structure validation (missing/
+/// empty columns, non-array rows, a non-array row), the serialized payload, and the ack.
+/// </summary>
+public sealed class RenderTableToolTests
+{
+    private static Dictionary<string, object?> Args(params (string Key, object? Value)[] pairs)
+    {
+        var d = new Dictionary<string, object?>();
+        foreach (var (k, v) in pairs) d[k] = v;
+        return d;
+    }
+
+    private static object[] Columns(params string[] columns) => columns;
+
+    private static object[] Rows(params object[][] rows) => rows;
+
+    [Fact]
+    public void Metadata_IsCorrect()
+    {
+        var sut = new RenderTableTool(new FakeBridge());
+        sut.Name.Should().Be("render_table");
+        sut.SupportedOperations.Should().BeEquivalentTo(["render"]);
+        sut.Description.Should().Contain("columns");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_UnknownOperation_Fails()
+    {
+        var bridge = new FakeBridge();
+        var result = await new RenderTableTool(bridge).ExecuteAsync("explode", Args(("columns", Columns("A"))));
+        result.Success.Should().BeFalse();
+        bridge.InvokeCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_NoClientAttached_Fails()
+    {
+        var sut = new RenderTableTool(new FakeBridge { ClientAttached = false });
+        var result = await sut.ExecuteAsync("render", Args(("columns", Columns("A"))));
+        result.Success.Should().BeFalse();
+        result.Error.Should().Contain("client");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_MissingColumns_Fails()
+    {
+        var bridge = new FakeBridge();
+        var result = await new RenderTableTool(bridge).ExecuteAsync("render", Args(("title", "Results")));
+        result.Success.Should().BeFalse();
+        result.Error.Should().Contain("columns");
+        bridge.InvokeCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_EmptyColumns_Fails()
+    {
+        var bridge = new FakeBridge();
+        var result = await new RenderTableTool(bridge).ExecuteAsync("render", Args(("columns", Array.Empty<object>())));
+        result.Success.Should().BeFalse();
+        bridge.InvokeCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_RowsNull_RelaysToClient()
+    {
+        // An explicit null for the optional 'rows' (LLMs routinely emit these) must not fail the table:
+        // the client normalizes null to an empty table. The server validates columns only.
+        var bridge = new FakeBridge { Result = "Displayed the table to the user." };
+        var result = await new RenderTableTool(bridge).ExecuteAsync("render", Args(("columns", Columns("A")), ("rows", null)));
+        result.Success.Should().BeTrue();
+        bridge.InvokeCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_RowsNotAnArray_RelaysToClient()
+    {
+        // A malformed 'rows' is not rejected server-side; the client's parseTableArgs treats a non-array
+        // as no rows. Server strictness must not exceed the client's leniency (they'd disagree otherwise).
+        var bridge = new FakeBridge { Result = "Displayed the table to the user." };
+        var result = await new RenderTableTool(bridge).ExecuteAsync("render", Args(("columns", Columns("A")), ("rows", "not-an-array")));
+        result.Success.Should().BeTrue();
+        bridge.InvokeCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_RaggedRows_RelaysToClient()
+    {
+        // One scalar amid valid rows must not fail the whole table — the client drops the bad row and
+        // renders the rest. The server relays the ragged payload unchanged.
+        var bridge = new FakeBridge { Result = "Displayed the table to the user." };
+        var result = await new RenderTableTool(bridge).ExecuteAsync("render", Args(("columns", Columns("A")), ("rows", new object[] { "flat", new[] { "ok" } })));
+        result.Success.Should().BeTrue();
+        bridge.InvokeCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ColumnsOnly_NoRows_Succeeds()
+    {
+        var bridge = new FakeBridge { Result = "Displayed the table to the user." };
+        var result = await new RenderTableTool(bridge).ExecuteAsync("render", Args(("columns", Columns("Name", "Score"))));
+        result.Success.Should().BeTrue();
+        bridge.LastToolName.Should().Be("render_table");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_HappyPath_PassesSerializedArgs_AndReturnsAck()
+    {
+        var bridge = new FakeBridge { Result = "Displayed the table to the user." };
+        var result = await new RenderTableTool(bridge).ExecuteAsync("render", Args(
+            ("title", "Scores"),
+            ("columns", Columns("Name", "Score")),
+            ("rows", Rows(["Ada", "97"], ["Alan", "91"]))));
+
+        result.Success.Should().BeTrue();
+        result.Output.Should().Contain("Displayed the table");
+        bridge.LastToolName.Should().Be("render_table");
+        bridge.LastArgsJson.Should().Contain("Name").And.Contain("Ada").And.Contain("97");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_BridgeTimeout_FailsGracefully()
+    {
+        var sut = new RenderTableTool(new FakeBridge { Throw = new TimeoutException() });
+        var result = await sut.ExecuteAsync("render", Args(("columns", Columns("A"))));
+        result.Success.Should().BeFalse();
+    }
+
+    private sealed class FakeBridge : IClientToolBridge
+    {
+        public bool ClientAttached { get; init; } = true;
+        public string Result { get; init; } = "ok";
+        public Exception? Throw { get; init; }
+
+        public int InvokeCount { get; private set; }
+        public string? LastToolName { get; private set; }
+        public string? LastArgsJson { get; private set; }
+
+        public bool IsClientAttached => ClientAttached;
+
+        public Task<string> InvokeAsync(string toolName, string argumentsJson, CancellationToken cancellationToken = default)
+        {
+            InvokeCount++;
+            LastToolName = toolName;
+            LastArgsJson = argumentsJson;
+            if (Throw is not null) return Task.FromException<string>(Throw);
+            return Task.FromResult(Result);
+        }
+    }
+}


### PR DESCRIPTION
Gives the AgentHub main chat (`Presentation.WebUI`) the ability to render widgets **inline in the transcript** on demand — image, form, and table — mirroring the Dashboard's proven `render_chart` client round-trip. Option A (inline generative UI), not a separate canvas surface.

## What ships (3 commits, one per widget)
- **`render_image`** (`c74d15ba`) — displays an image inline from a validated absolute-https URL. Non-interactive.
- **`render_form`** (`a9199f75`) — displays an interactive form; **Approach 3** (verified): the tool acks synchronously ("form displayed") and the user's answers arrive as their normal next message on submit. The framework's `AIAgent.RunAsync` owns an atomic tool loop and can't be suspended/resumed, so a deferred round-trip isn't possible; this survives refresh and reuses the existing send path.
- **`render_table`** (`bd8241ba`) — displays a data table from `columns` + `rows`. Non-interactive.

## Architecture
- **Backend**: each widget is a ~40-line `BlockingProxyTool` subclass (`RenderImageTool`/`RenderFormTool`/`RenderTableTool`) relaying to the connected browser via `IClientToolBridge`, registered keyed-DI, opt-in per agent via `SKILL.md` `allowed-tools` (on `research-agent`, backing the `default` agent).
- **Frontend**: a unified widget registry (`features/chat/widgets/registry.tsx`) — each entry is `{ render, validate, ack }` in a prototype-safe `Map`. `useAgentStream` handles `TOOL_CALL_*` with a **generic** dispatch off the registry (no per-widget branches), so adding a widget is one registry entry + a component + a types/validator.

## Security (agent output = untrusted)
The registry is the trust boundary: the agent can only summon a registered widget with validated args. Image URLs are https-only (server + client, defense-in-depth); form field types are whitelisted; table cells are coerced to text and React-escaped. Backend validation never exceeds the client trust boundary — for tables the backend validates `columns` only and the client `parseTableArgs` is the single source of row-normalization truth (an agent-emitted `rows: null` renders a header-only table instead of failing).

## Tests
- Backend (xUnit): `RenderImageToolTests`, `RenderFormToolTests`, `RenderTableToolTests` — metadata, unknown-op, no-client, validation failures, happy-path serialization + ack. 31 pass.
- Frontend (vitest/RTL): `parseImageArgs`/`parseFormArgs`/`parseTableArgs`, `AgentForm`/`AgentTable`, registry dispatch + safe fallbacks. 133 WebUI unit tests pass (3 "failed" files are pre-existing Playwright e2e specs vitest wrongly globs). `tsc` + `eslint` clean.

## Deferred follow-ups (tracked, none in this PR)
- `default` agent should get its own skill home (widgets currently grafted onto `research-agent`).
- Widgets are client-only/ephemeral — a refresh loses them (agent is not stranded); persisting widget specs into history would make them durable.
- Family-wide backend dedup: the `ExecuteAsync` preamble is copy-pasted across the three render tools (rule of three) — candidate `BlockingProxyTool` template method.
- Registry `validate` wrappers are redundant (the parse-fn return type is already assignable to `ValidationResult`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)