### PR TITLE
chore(agenthub): generative-UI follow-ups (dedup, skill home, DRY, widget persistence)

### DIFF
--- a/agents/default/AGENT.md
+++ b/agents/default/AGENT.md
@@ -7,7 +7,7 @@ category: general
 version: 1.0.0
 author: Microsoft Agentic Harness
 tags: ["default", "general"]
-skill: research-agent
+skill: default-agent
 ---
 
 # Default Agent

--- a/skills/default-agent/SKILL.md
+++ b/skills/default-agent/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: "default-agent"
+description: "General-purpose conversational assistant that reads project files and renders images, forms, and tables inline in its answers."
+category: "general"
+skill_type: "agent"
+version: "1.0.0"
+tags: ["default", "general", "generative-ui"]
+allowed-tools: ["file_system", "render_image", "render_form", "render_table"]
+tools:
+  - name: "file_system"
+    operations: ["read", "search", "list"]
+    optional: false
+    description: "Read and search project files"
+  - name: "render_image"
+    operations: ["render"]
+    optional: true
+    description: "Display an image inline in the answer from an https URL"
+  - name: "render_form"
+    operations: ["render"]
+    optional: true
+    description: "Display an interactive form inline to collect structured input"
+  - name: "render_table"
+    operations: ["render"]
+    optional: true
+    description: "Display a data table inline in the answer from columns and rows"
+---
+
+You are a helpful, general-purpose assistant. Answer the user's questions directly and concisely, and
+reach for a tool only when the request needs it.
+
+## Capabilities
+
+- Read and search project files with the `file_system` tool when a question needs information from the
+  codebase (operations `read`, `search`, `list`). Start searches from `src`.
+- Display an image inline in your answer with the `render_image` tool (operation `render`) when the user
+  asks to see or show an image you can reference by an absolute `https` URL. Pass `url` (required) and
+  optionally `alt` and `caption`. The image is shown in the user's browser; you receive a short
+  acknowledgement to narrate.
+- Collect structured input with the `render_form` tool (operation `render`) when you need several values
+  from the user — pass a `fields` array (each with `name`, `type`, optional `label`/`required`/`options`),
+  plus optional `title` and `submitLabel`. The form is shown in the user's browser and you get an
+  acknowledgement that it was displayed; the user's answers arrive as their next message after they
+  submit, so end your turn after presenting the form and continue when the answers come back.
+- Present tabular data with the `render_table` tool (operation `render`) when the data is naturally a
+  table — pass a `columns` array of header labels (required) and a `rows` array of arrays (each inner
+  array is one row aligned to the columns), plus an optional `title`. The table is shown in the user's
+  browser and you receive a short acknowledgement to narrate. Prefer this over a markdown table when the
+  data is structured.
+
+## Guidelines
+
+- Be concise and direct. Use tools only when they add value; answer from your own knowledge otherwise.
+- The generative-UI tools (`render_image`/`render_form`/`render_table`) render only when a browser client
+  is connected. If a render fails because no client is attached, say so plainly rather than pretending it
+  succeeded.
+- Do not attempt to call tools that are not listed in the `tools` section above.

--- a/skills/research-agent/SKILL.md
+++ b/skills/research-agent/SKILL.md
@@ -3,26 +3,14 @@ name: "research-agent"
 description: "Finds, reads, and analyzes information from project files and source code."
 category: "research"
 skill_type: "analysis"
-version: "1.1.0"
+version: "1.2.0"
 tags: ["research", "file-analysis", "standalone"]
-allowed-tools: ["file_system", "render_image", "render_form", "render_table"]
+allowed-tools: ["file_system"]
 tools:
   - name: "file_system"
     operations: ["read", "search", "list"]
     optional: false
     description: "Read and search project files"
-  - name: "render_image"
-    operations: ["render"]
-    optional: true
-    description: "Display an image inline in the answer from an https URL"
-  - name: "render_form"
-    operations: ["render"]
-    optional: true
-    description: "Display an interactive form inline to collect structured input"
-  - name: "render_table"
-    operations: ["render"]
-    optional: true
-    description: "Display a data table inline in the answer from columns and rows"
 ---
 
 You are a research agent specialized in finding and analyzing information from the local file system.
@@ -32,20 +20,6 @@ You are a research agent specialized in finding and analyzing information from t
 - Search and read files from the project file system using the `file_system` tool
 - Analyze source code, configuration, documentation, and data files
 - Locate specific classes, methods, constants, or configuration values
-- Display an image inline in your answer with the `render_image` tool (operation `render`) when the
-  user asks to see or show an image you can reference by an absolute `https` URL. Pass `url` (required)
-  and optionally `alt` and `caption`. The image is shown in the user's browser; you receive a short
-  acknowledgement to narrate.
-- Collect structured input with the `render_form` tool (operation `render`) when you need several
-  values from the user — pass a `fields` array (each with `name`, `type`, optional `label`/`required`/
-  `options`), plus optional `title` and `submitLabel`. The form is shown in the user's browser and you
-  get an acknowledgement that it was displayed; the user's answers arrive as their next message after
-  they submit, so end your turn after presenting the form and continue when the answers come back.
-- Present tabular data with the `render_table` tool (operation `render`) when findings are naturally a
-  table — pass a `columns` array of header labels (required) and a `rows` array of arrays (each inner
-  array is one row aligned to the columns), plus an optional `title`. The table is shown in the user's
-  browser and you receive a short acknowledgement to narrate. Prefer this over a markdown table when the
-  data is structured.
 
 ## File System Root
 

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/RenderChartTool.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/RenderChartTool.cs
@@ -1,4 +1,3 @@
-using System.Text.Json;
 using Application.AI.Common.Interfaces.Tools;
 using Domain.AI.Models;
 
@@ -25,14 +24,10 @@ namespace Infrastructure.AI.Tools;
 /// </code>
 /// </para>
 /// </remarks>
-public sealed class RenderChartTool : BlockingProxyTool
+public sealed class RenderChartTool : SingleRenderProxyTool
 {
     /// <summary>The tool name matching keyed DI registration and SKILL.md declarations.</summary>
     public const string ToolName = "render_chart";
-
-    private const string Render = "render";
-
-    private static readonly IReadOnlyList<string> Operations = [Render];
 
     /// <summary>Initializes a new instance of the <see cref="RenderChartTool"/> class.</summary>
     /// <param name="bridge">The client round-trip bridge used to delegate rendering to the browser.</param>
@@ -54,26 +49,19 @@ public sealed class RenderChartTool : BlockingProxyTool
         "time range, so call set_time_range first if a different window is needed.";
 
     /// <inheritdoc />
-    public override IReadOnlyList<string> SupportedOperations => Operations;
+    protected override string NoClientMessage =>
+        "No dashboard client is connected to this conversation, so a chart cannot be rendered.";
 
     /// <inheritdoc />
-    public override Task<ToolResult> ExecuteAsync(
-        string operation,
-        IReadOnlyDictionary<string, object?> parameters,
-        CancellationToken cancellationToken = default)
+    protected override string TimeoutMessage => "The dashboard did not render the chart in time.";
+
+    /// <inheritdoc />
+    // Either a metricId or a promQL query must be present; both are top-level scalars, so check the
+    // parameter dictionary directly.
+    protected override string? ValidateArguments(
+        IReadOnlyDictionary<string, object?> parameters, string argumentsJson)
     {
-        if (!string.Equals(operation, Render, StringComparison.OrdinalIgnoreCase))
-            return Task.FromResult(ToolResult.Fail($"Unknown operation: {operation}. Supported: {Render}"));
-
-        if (!IsClientAttached)
-            return Task.FromResult(ToolResult.Fail("No dashboard client is connected to this conversation, so a chart cannot be rendered."));
-
         var hasMetric = parameters.ContainsKey("metricId") || parameters.ContainsKey("promQL");
-        if (!hasMetric)
-            return Task.FromResult(ToolResult.Fail("Provide a metricId (from list_metrics) or a promQL query to chart."));
-
-        var argumentsJson = JsonSerializer.Serialize(parameters, SerializerOptions);
-
-        return InvokeClientAsync(argumentsJson, "The dashboard did not render the chart in time.", cancellationToken);
+        return hasMetric ? null : "Provide a metricId (from list_metrics) or a promQL query to chart.";
     }
 }

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/RenderFormTool.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/RenderFormTool.cs
@@ -30,14 +30,10 @@ namespace Infrastructure.AI.Tools;
 /// </code>
 /// </para>
 /// </remarks>
-public sealed class RenderFormTool : BlockingProxyTool
+public sealed class RenderFormTool : SingleRenderProxyTool
 {
     /// <summary>The tool name matching keyed DI registration and SKILL.md declarations.</summary>
     public const string ToolName = "render_form";
-
-    private const string Render = "render";
-
-    private static readonly IReadOnlyList<string> Operations = [Render];
 
     /// <summary>Field <c>type</c> values the browser knows how to render. Kept in sync with the client whitelist.</summary>
     private static readonly HashSet<string> AllowedFieldTypes =
@@ -65,30 +61,18 @@ public sealed class RenderFormTool : BlockingProxyTool
         "submit. Use this to collect structured input instead of asking for many values in prose.";
 
     /// <inheritdoc />
-    public override IReadOnlyList<string> SupportedOperations => Operations;
+    protected override string NoClientMessage =>
+        "No client is connected to this conversation, so a form cannot be displayed.";
 
     /// <inheritdoc />
-    public override Task<ToolResult> ExecuteAsync(
-        string operation,
-        IReadOnlyDictionary<string, object?> parameters,
-        CancellationToken cancellationToken = default)
-    {
-        if (!string.Equals(operation, Render, StringComparison.OrdinalIgnoreCase))
-            return Task.FromResult(ToolResult.Fail($"Unknown operation: {operation}. Supported: {Render}"));
+    protected override string TimeoutMessage => "The client did not display the form in time.";
 
-        if (!IsClientAttached)
-            return Task.FromResult(ToolResult.Fail("No client is connected to this conversation, so a form cannot be displayed."));
-
-        // Serialize once, then validate the structure from the JSON so nested `fields` are inspected
-        // deterministically regardless of how the tool arguments were deserialized into the dictionary.
-        var argumentsJson = JsonSerializer.Serialize(parameters, SerializerOptions);
-
-        var validationError = ValidateFields(argumentsJson);
-        if (validationError is not null)
-            return Task.FromResult(ToolResult.Fail(validationError));
-
-        return InvokeClientAsync(argumentsJson, "The client did not display the form in time.", cancellationToken);
-    }
+    /// <inheritdoc />
+    // Validate the structure from the serialized JSON so nested `fields` are inspected deterministically
+    // regardless of how the tool arguments were deserialized into the dictionary.
+    protected override string? ValidateArguments(
+        IReadOnlyDictionary<string, object?> parameters, string argumentsJson)
+        => ValidateFields(argumentsJson);
 
     /// <summary>Validates the serialized <c>fields</c> array; returns an error message, or null when valid.</summary>
     private static string? ValidateFields(string argumentsJson)

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/RenderImageTool.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/RenderImageTool.cs
@@ -1,4 +1,3 @@
-using System.Text.Json;
 using Application.AI.Common.Interfaces.Tools;
 using Domain.AI.Models;
 
@@ -26,15 +25,12 @@ namespace Infrastructure.AI.Tools;
 /// </code>
 /// </para>
 /// </remarks>
-public sealed class RenderImageTool : BlockingProxyTool
+public sealed class RenderImageTool : SingleRenderProxyTool
 {
     /// <summary>The tool name matching keyed DI registration and SKILL.md declarations.</summary>
     public const string ToolName = "render_image";
 
-    private const string Render = "render";
     private const string UrlKey = "url";
-
-    private static readonly IReadOnlyList<string> Operations = [Render];
 
     /// <summary>Initializes a new instance of the <see cref="RenderImageTool"/> class.</summary>
     /// <param name="bridge">The client round-trip bridge used to delegate rendering to the browser.</param>
@@ -54,28 +50,24 @@ public sealed class RenderImageTool : BlockingProxyTool
         "Use this when the user asks to see or display an image you can reference by URL.";
 
     /// <inheritdoc />
-    public override IReadOnlyList<string> SupportedOperations => Operations;
+    protected override string NoClientMessage =>
+        "No client is connected to this conversation, so an image cannot be displayed.";
 
     /// <inheritdoc />
-    public override Task<ToolResult> ExecuteAsync(
-        string operation,
-        IReadOnlyDictionary<string, object?> parameters,
-        CancellationToken cancellationToken = default)
+    protected override string TimeoutMessage => "The client did not display the image in time.";
+
+    /// <inheritdoc />
+    // The URL is a top-level scalar, so validate it straight from the parameter dictionary. It must be an
+    // absolute https URL so a malformed or unsafe reference (javascript:/data:) never reaches the browser.
+    protected override string? ValidateArguments(
+        IReadOnlyDictionary<string, object?> parameters, string argumentsJson)
     {
-        if (!string.Equals(operation, Render, StringComparison.OrdinalIgnoreCase))
-            return Task.FromResult(ToolResult.Fail($"Unknown operation: {operation}. Supported: {Render}"));
-
-        if (!IsClientAttached)
-            return Task.FromResult(ToolResult.Fail("No client is connected to this conversation, so an image cannot be displayed."));
-
         if (!parameters.TryGetValue(UrlKey, out var urlValue) || urlValue is not string url || string.IsNullOrWhiteSpace(url))
-            return Task.FromResult(ToolResult.Fail("Provide an image 'url' to display."));
+            return "Provide an image 'url' to display.";
 
         if (!Uri.TryCreate(url, UriKind.Absolute, out var uri) || uri.Scheme != Uri.UriSchemeHttps)
-            return Task.FromResult(ToolResult.Fail("The image 'url' must be an absolute https URL."));
+            return "The image 'url' must be an absolute https URL.";
 
-        var argumentsJson = JsonSerializer.Serialize(parameters, SerializerOptions);
-
-        return InvokeClientAsync(argumentsJson, "The client did not display the image in time.", cancellationToken);
+        return null;
     }
 }

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/RenderTableTool.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/RenderTableTool.cs
@@ -33,14 +33,10 @@ namespace Infrastructure.AI.Tools;
 /// </code>
 /// </para>
 /// </remarks>
-public sealed class RenderTableTool : BlockingProxyTool
+public sealed class RenderTableTool : SingleRenderProxyTool
 {
     /// <summary>The tool name matching keyed DI registration and SKILL.md declarations.</summary>
     public const string ToolName = "render_table";
-
-    private const string Render = "render";
-
-    private static readonly IReadOnlyList<string> Operations = [Render];
 
     /// <summary>Initializes a new instance of the <see cref="RenderTableTool"/> class.</summary>
     /// <param name="bridge">The client round-trip bridge used to delegate rendering to the browser.</param>
@@ -61,30 +57,18 @@ public sealed class RenderTableTool : BlockingProxyTool
         "Use this to present tabular or structured data instead of prose or a markdown table.";
 
     /// <inheritdoc />
-    public override IReadOnlyList<string> SupportedOperations => Operations;
+    protected override string NoClientMessage =>
+        "No client is connected to this conversation, so a table cannot be displayed.";
 
     /// <inheritdoc />
-    public override Task<ToolResult> ExecuteAsync(
-        string operation,
-        IReadOnlyDictionary<string, object?> parameters,
-        CancellationToken cancellationToken = default)
-    {
-        if (!string.Equals(operation, Render, StringComparison.OrdinalIgnoreCase))
-            return Task.FromResult(ToolResult.Fail($"Unknown operation: {operation}. Supported: {Render}"));
+    protected override string TimeoutMessage => "The client did not display the table in time.";
 
-        if (!IsClientAttached)
-            return Task.FromResult(ToolResult.Fail("No client is connected to this conversation, so a table cannot be displayed."));
-
-        // Serialize once, then validate the structure from the JSON so nested arrays are inspected
-        // deterministically regardless of how the tool arguments were deserialized into the dictionary.
-        var argumentsJson = JsonSerializer.Serialize(parameters, SerializerOptions);
-
-        var validationError = ValidateColumns(argumentsJson);
-        if (validationError is not null)
-            return Task.FromResult(ToolResult.Fail(validationError));
-
-        return InvokeClientAsync(argumentsJson, "The client did not display the table in time.", cancellationToken);
-    }
+    /// <inheritdoc />
+    // Validate the structure from the serialized JSON so nested arrays are inspected deterministically
+    // regardless of how the tool arguments were deserialized into the dictionary.
+    protected override string? ValidateArguments(
+        IReadOnlyDictionary<string, object?> parameters, string argumentsJson)
+        => ValidateColumns(argumentsJson);
 
     /// <summary>
     /// Validates that <c>columns</c> is a non-empty array; returns an error message, or null when valid.

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/SingleRenderProxyTool.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/SingleRenderProxyTool.cs
@@ -1,0 +1,73 @@
+using System.Text.Json;
+using Application.AI.Common.Interfaces.Tools;
+using Domain.AI.Models;
+
+namespace Infrastructure.AI.Tools;
+
+/// <summary>
+/// Base class for the single-operation "render" generative-UI tools — <see cref="RenderChartTool"/>,
+/// <see cref="RenderImageTool"/>, <see cref="RenderFormTool"/>, and <see cref="RenderTableTool"/>. Each
+/// summons one widget in the connected browser via the shared blocking-proxy round-trip and returns a
+/// short acknowledgement; they differ only in their name, description, argument validation, and the two
+/// user-facing failure messages. This base owns the identical execution scaffolding they would otherwise
+/// each duplicate: the <c>render</c>-operation gate, the client-attached check, the argument
+/// serialization, and the validate-then-invoke sequence.
+/// </summary>
+/// <remarks>
+/// Multi-operation proxy tools such as <see cref="DashboardControlTool"/> do <b>not</b> derive from this
+/// class — they extend <see cref="BlockingProxyTool"/> directly because their dispatch is not a single
+/// fixed operation. A subclass here supplies <see cref="NoClientMessage"/>, <see cref="TimeoutMessage"/>,
+/// and (optionally) an <see cref="ValidateArguments"/> override; everything else is inherited.
+/// </remarks>
+public abstract class SingleRenderProxyTool : BlockingProxyTool
+{
+    /// <summary>The single operation every render tool supports.</summary>
+    protected const string RenderOperation = "render";
+
+    private static readonly IReadOnlyList<string> RenderOperations = [RenderOperation];
+
+    /// <summary>Initializes the base with the client round-trip bridge.</summary>
+    /// <param name="bridge">The bridge used to delegate rendering to the browser.</param>
+    protected SingleRenderProxyTool(IClientToolBridge bridge) : base(bridge)
+    {
+    }
+
+    /// <inheritdoc />
+    public sealed override IReadOnlyList<string> SupportedOperations => RenderOperations;
+
+    /// <summary>The failure message returned when no client is attached to service the render.</summary>
+    protected abstract string NoClientMessage { get; }
+
+    /// <summary>The failure message returned when the client does not render within the bounded timeout.</summary>
+    protected abstract string TimeoutMessage { get; }
+
+    /// <summary>
+    /// Validates the render arguments; returns an error message, or null when valid. Both the raw
+    /// parameter dictionary and its serialized JSON are supplied so a subclass validates from whichever
+    /// is more convenient (a top-level scalar from the dictionary, nested structure from the JSON)
+    /// without re-serializing. The default accepts everything.
+    /// </summary>
+    protected virtual string? ValidateArguments(
+        IReadOnlyDictionary<string, object?> parameters, string argumentsJson) => null;
+
+    /// <inheritdoc />
+    public sealed override Task<ToolResult> ExecuteAsync(
+        string operation,
+        IReadOnlyDictionary<string, object?> parameters,
+        CancellationToken cancellationToken = default)
+    {
+        if (!string.Equals(operation, RenderOperation, StringComparison.OrdinalIgnoreCase))
+            return Task.FromResult(ToolResult.Fail($"Unknown operation: {operation}. Supported: {RenderOperation}"));
+
+        if (!IsClientAttached)
+            return Task.FromResult(ToolResult.Fail(NoClientMessage));
+
+        var argumentsJson = JsonSerializer.Serialize(parameters, SerializerOptions);
+
+        var validationError = ValidateArguments(parameters, argumentsJson);
+        if (validationError is not null)
+            return Task.FromResult(ToolResult.Fail(validationError));
+
+        return InvokeClientAsync(argumentsJson, TimeoutMessage, cancellationToken);
+    }
+}

--- a/src/Content/Presentation/Presentation.AgentHub/AgUi/AgUiClientToolBridge.cs
+++ b/src/Content/Presentation/Presentation.AgentHub/AgUi/AgUiClientToolBridge.cs
@@ -1,6 +1,10 @@
+using System.Text.Json;
 using Application.AI.Common.Interfaces.Tools;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Presentation.AgentHub.Config;
+using Presentation.AgentHub.DTOs;
+using Presentation.AgentHub.Interfaces;
 
 namespace Presentation.AgentHub.AgUi;
 
@@ -27,16 +31,25 @@ public sealed class AgUiClientToolBridge : IClientToolBridge
     private readonly IAgUiEventWriterAccessor _writerAccessor;
     private readonly PendingToolCallRegistry _registry;
     private readonly IOptionsMonitor<AgentHubConfig> _config;
+    private readonly IConversationStore _conversationStore;
+    private readonly ClientWidgetCatalog _widgetCatalog;
+    private readonly ILogger<AgUiClientToolBridge> _logger;
 
     /// <summary>Initializes a new <see cref="AgUiClientToolBridge"/>.</summary>
     public AgUiClientToolBridge(
         IAgUiEventWriterAccessor writerAccessor,
         PendingToolCallRegistry registry,
-        IOptionsMonitor<AgentHubConfig> config)
+        IOptionsMonitor<AgentHubConfig> config,
+        IConversationStore conversationStore,
+        ClientWidgetCatalog widgetCatalog,
+        ILogger<AgUiClientToolBridge> logger)
     {
         _writerAccessor = writerAccessor;
         _registry = registry;
         _config = config;
+        _conversationStore = conversationStore;
+        _widgetCatalog = widgetCatalog;
+        _logger = logger;
     }
 
     /// <inheritdoc />
@@ -66,6 +79,41 @@ public sealed class AgUiClientToolBridge : IClientToolBridge
         await writer.WriteAsync(new ToolCallArgsEvent(callId, argumentsJson ?? "{}"), cancellationToken).ConfigureAwait(false);
         await writer.WriteAsync(new ToolCallEndEvent(callId), cancellationToken).ConfigureAwait(false);
 
-        return await resultTask.ConfigureAwait(false);
+        var result = await resultTask.ConfigureAwait(false);
+
+        // Persist the widget as an assistant message so it re-renders on reload (the live in-browser
+        // message is not otherwise persisted). Only after the client posts its result — a timed-out or
+        // disconnected round-trip that never displayed the widget throws above, so we do not leave a
+        // phantom that reappears on reload contradicting the agent. This still precedes the run handler's
+        // final assistant-text append, so the widget lands in the right position. A persistence failure
+        // must not break the turn, so it is logged and swallowed.
+        if (_widgetCatalog.IsWidget(toolName))
+            await PersistWidgetAsync(threadId, toolName, argumentsJson, cancellationToken).ConfigureAwait(false);
+
+        return result;
+    }
+
+    /// <summary>
+    /// Appends an assistant message carrying the widget spec (empty text, so it renders as the widget
+    /// only, matching the live in-browser message). Errors are logged and swallowed — durability is
+    /// best-effort and must never fail the turn.
+    /// </summary>
+    private async Task PersistWidgetAsync(
+        string threadId, string toolName, string? argumentsJson, CancellationToken cancellationToken)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(string.IsNullOrWhiteSpace(argumentsJson) ? "{}" : argumentsJson);
+            var widget = new WidgetSpec(toolName, doc.RootElement.Clone());
+            var message = new ConversationMessage(
+                Guid.NewGuid(), MessageRole.Assistant, string.Empty, DateTimeOffset.UtcNow, Widget: widget);
+            await _conversationStore.AppendMessageAsync(threadId, message, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogWarning(ex,
+                "Failed to persist widget message for tool {ToolName} in conversation {ThreadId}; the widget " +
+                "was still displayed live but will not survive a reload.", toolName, threadId);
+        }
     }
 }

--- a/src/Content/Presentation/Presentation.AgentHub/AgUi/AgUiRunHandler.cs
+++ b/src/Content/Presentation/Presentation.AgentHub/AgUi/AgUiRunHandler.cs
@@ -383,6 +383,8 @@ public sealed class AgUiRunHandler
             ? parsed
             : Guid.NewGuid();
 
+    // Widget (empty-content) messages are already excluded upstream by GetHistoryForDispatch, so this is
+    // a straight projection of the dispatch history to the framework's chat-message shape.
     private static IReadOnlyList<ChatMessage> ToMeaiHistory(IReadOnlyList<ConversationMessage> messages) =>
         messages.Select(m => new ChatMessage(ToChatRole(m.Role), m.Content)).ToList();
 

--- a/src/Content/Presentation/Presentation.AgentHub/AgUi/ClientWidgetCatalog.cs
+++ b/src/Content/Presentation/Presentation.AgentHub/AgUi/ClientWidgetCatalog.cs
@@ -1,0 +1,25 @@
+namespace Presentation.AgentHub.AgUi;
+
+/// <summary>
+/// The set of client tool names whose mid-run invocation is persisted as a re-renderable widget message,
+/// so the rendered widget survives a page reload. These are the AgentHub WebUI generative-UI tools.
+/// </summary>
+/// <remarks>
+/// The names must match the corresponding tool <c>ToolName</c> constants in <c>Infrastructure.AI.Tools</c>
+/// (<c>RenderImageTool</c>/<c>RenderFormTool</c>/<c>RenderTableTool</c>); they are duplicated as literals
+/// here to avoid a Presentation → Infrastructure project reference for three protocol strings — the same
+/// strings the browser's widget registry already keys off. <c>render_chart</c> is intentionally excluded:
+/// its client is the separate dashboard app, whose reload path does not (yet) re-render persisted widgets,
+/// so persisting its calls would add empty placeholder messages there.
+/// </remarks>
+public sealed class ClientWidgetCatalog
+{
+    private static readonly HashSet<string> WidgetToolNames =
+        new(["render_image", "render_form", "render_table"], StringComparer.Ordinal);
+
+    /// <summary>
+    /// Returns true when a client tool call for <paramref name="toolName"/> should be persisted as a
+    /// widget message the browser can re-render on reload.
+    /// </summary>
+    public bool IsWidget(string toolName) => WidgetToolNames.Contains(toolName);
+}

--- a/src/Content/Presentation/Presentation.AgentHub/DTOs/ConversationMessage.cs
+++ b/src/Content/Presentation/Presentation.AgentHub/DTOs/ConversationMessage.cs
@@ -6,10 +6,16 @@ namespace Presentation.AgentHub.DTOs;
 /// stable reference used by retry/edit operations. Clients MAY supply the id when appending
 /// a user message (so optimistic UI and server record share the same id); otherwise the server
 /// generates one. Legacy records with <see cref="Guid.Empty"/> ids are migrated on read.
+/// <para>
+/// <see cref="Widget"/> is set only on the assistant message that stands in for an inline generative-UI
+/// render (image/form/table); such a message carries empty <see cref="Content"/> and the widget is
+/// re-rendered from the spec on reload. It is null for every ordinary text message.
+/// </para>
 /// </remarks>
 public sealed record ConversationMessage(
     Guid Id,
     MessageRole Role,
     string Content,
     DateTimeOffset Timestamp,
-    IReadOnlyList<ToolCallRecord>? ToolCalls = null);
+    IReadOnlyList<ToolCallRecord>? ToolCalls = null,
+    WidgetSpec? Widget = null);

--- a/src/Content/Presentation/Presentation.AgentHub/DTOs/WidgetSpec.cs
+++ b/src/Content/Presentation/Presentation.AgentHub/DTOs/WidgetSpec.cs
@@ -1,0 +1,12 @@
+using System.Text.Json;
+
+namespace Presentation.AgentHub.DTOs;
+
+/// <summary>
+/// A generative-UI widget the agent rendered inline during a turn (an image, form, or table),
+/// persisted on its <see cref="ConversationMessage"/> so it re-renders when the conversation is
+/// reloaded. <see cref="Type"/> is the client tool name (for example <c>render_table</c>) that keys
+/// into the browser's widget registry; <see cref="Args"/> is the validated argument payload the tool
+/// sent to the client, replayed verbatim at render time.
+/// </summary>
+public sealed record WidgetSpec(string Type, JsonElement Args);

--- a/src/Content/Presentation/Presentation.AgentHub/DependencyInjection.cs
+++ b/src/Content/Presentation/Presentation.AgentHub/DependencyInjection.cs
@@ -235,6 +235,9 @@ public static class DependencyInjection
         // it MUST be a singleton. The bridge holds no per-run state (writer is ambient, pending map
         // lives in the registry) and the catalog provider is immutable — both safe as singletons.
         services.AddSingleton<AgUi.PendingToolCallRegistry>();
+        // Immutable catalog of client tool names whose calls are persisted as re-renderable widget
+        // messages; consumed by the bridge to make inline generative-UI widgets survive a reload.
+        services.AddSingleton<AgUi.ClientWidgetCatalog>();
         services.AddSingleton<Application.AI.Common.Interfaces.Tools.IClientToolBridge, AgUi.AgUiClientToolBridge>();
         services.AddSingleton<Application.AI.Common.Interfaces.Observability.IMetricCatalog, AgUi.MetricCatalogProvider>();
         services.AddSingleton<IEscalationNotificationChannel, AgUiEscalationNotifier>();

--- a/src/Content/Presentation/Presentation.AgentHub/Services/FileSystemConversationStore.cs
+++ b/src/Content/Presentation/Presentation.AgentHub/Services/FileSystemConversationStore.cs
@@ -309,7 +309,11 @@ public sealed class FileSystemConversationStore : IConversationStore
         if (record is null)
             return null;
 
-        var messages = record.Messages;
+        // Exclude empty-content messages (an inline-widget message carries its payload in WidgetSpec, not
+        // text, so it is not model-relevant). Filtering before the window keeps the cap counting real
+        // conversational turns — otherwise widget-heavy conversations would silently starve the model of
+        // context as the widgets consume window slots then get dropped at mapping time.
+        var messages = record.Messages.Where(m => !string.IsNullOrEmpty(m.Content)).ToList();
         if (messages.Count <= maxMessages)
             return messages;
 

--- a/src/Content/Presentation/Presentation.WebUI/src/features/chat/ChatInput.tsx
+++ b/src/Content/Presentation/Presentation.WebUI/src/features/chat/ChatInput.tsx
@@ -10,6 +10,7 @@ import { Textarea } from '@/components/ui/textarea';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { MentionPicker, type MentionItem } from './MentionPicker';
 import { usePromptsQuery, useToolsQuery } from '@/features/mcp/useMcpQuery';
+import { useSendUserMessage } from '@/hooks/useSendUserMessage';
 
 const MAX_ATTACHMENT_BYTES = 500 * 1024;
 const MAX_MESSAGE_CHARS = 40_000;
@@ -28,8 +29,6 @@ interface Attachment {
 }
 
 interface ChatInputProps {
-  conversationId: string;
-  sendMessage: (conversationId: string, userMessageId: string, message: string) => Promise<void>;
   disabled?: boolean;
 }
 
@@ -63,10 +62,9 @@ function detectTrigger(value: string, caret: number): TriggerState | null {
   return null;
 }
 
-export function ChatInput({ conversationId, sendMessage, disabled = false }: ChatInputProps) {
+export function ChatInput({ disabled = false }: ChatInputProps) {
   const isStreaming = useChatStore((s) => s.isStreaming);
-  const addMessage = useChatStore((s) => s.addMessage);
-  const startStreaming = useChatStore((s) => s.startStreaming);
+  const sendUserMessage = useSendUserMessage();
   const [attachment, setAttachment] = useState<Attachment | null>(null);
   const [attachmentError, setAttachmentError] = useState<string | null>(null);
   const [isDragOver, setIsDragOver] = useState(false);
@@ -207,24 +205,16 @@ export function ChatInput({ conversationId, sendMessage, disabled = false }: Cha
     setAttachmentError(null);
   };
 
-  const onSubmit = async (data: FormData): Promise<void> => {
+  const onSubmit = (data: FormData): void => {
     if (disabled || isStreaming) return;
     const composed = composeMessage(data.message, attachment);
-    const userMessageId = crypto.randomUUID();
-    addMessage({
-      id: userMessageId,
-      role: 'user',
-      content: composed,
-      timestamp: new Date(),
-    });
-    startStreaming();
     form.reset();
     clearAttachment();
     setTrigger(null);
-    try {
-      await sendMessage(conversationId, userMessageId, composed);
-    } catch (err) {
-      useChatStore.getState().setError(err instanceof Error ? err.message : 'Failed to send message');
+    // The shared hook owns the send sequence (optimistic message → start streaming → dispatch run);
+    // it returns false only when there is no active conversation to send to.
+    if (!sendUserMessage(composed)) {
+      useChatStore.getState().setError('There is no active conversation to send to.');
     }
   };
 

--- a/src/Content/Presentation/Presentation.WebUI/src/features/chat/ChatPanel.tsx
+++ b/src/Content/Presentation/Presentation.WebUI/src/features/chat/ChatPanel.tsx
@@ -6,7 +6,6 @@ import { useChatStore } from './useChatStore';
 import { useAppStore } from '@/stores/appStore';
 import { useConversationSettingsStore } from '@/stores/conversationSettingsStore';
 import { useAgentHub, type ConnectionState, type ConversationSettingsInput, type ServerConversationMessage } from '@/hooks/useAgentHub';
-import { useAgentStream } from '@/hooks/useAgentStream';
 import { useSendUserMessage } from '@/hooks/useSendUserMessage';
 import type { ChatMessage } from './useChatStore';
 import { CONVERSATIONS_QUERY_KEY } from '@/features/conversations/useConversationsQuery';
@@ -122,7 +121,6 @@ export function ChatPanel() {
     setConversationSettings,
     connectionState,
   } = useAgentHub();
-  const { sendMessage: agUiSend } = useAgentStream();
   const sendUserMessage = useSendUserMessage();
   const [conversationReady, setConversationReady] = useState(false);
   const [settingsOpen, setSettingsOpen] = useState(false);
@@ -143,10 +141,6 @@ export function ChatPanel() {
     void retryFromMessage(activeConversationId, assistantMessageId).catch((err: unknown) => {
       useChatStore.getState().setError(err instanceof Error ? err.message : 'Retry failed');
     });
-  };
-
-  const sendMessage = async (conversationId: string, userMessageId: string, message: string): Promise<void> => {
-    agUiSend(conversationId, userMessageId, message);
   };
 
   const handleSuggestionClick = (text: string): void => {
@@ -252,11 +246,7 @@ export function ChatPanel() {
       </div>
       <TypingIndicator />
       {activeConversationId && (
-        <ChatInput
-          conversationId={activeConversationId}
-          sendMessage={sendMessage}
-          disabled={!conversationReady}
-        />
+        <ChatInput disabled={!conversationReady} />
       )}
       <ConversationSettingsDrawer
         open={settingsOpen}

--- a/src/Content/Presentation/Presentation.WebUI/src/features/chat/ChatPanel.tsx
+++ b/src/Content/Presentation/Presentation.WebUI/src/features/chat/ChatPanel.tsx
@@ -197,6 +197,7 @@ export function ChatPanel() {
               content: m.content,
               timestamp: new Date(m.timestamp),
               toolCalls: m.toolCalls ?? undefined,
+              widget: m.widget ?? undefined,
             }));
           if (mapped.length > 0) {
             useChatStore.getState().setMessages(mapped);

--- a/src/Content/Presentation/Presentation.WebUI/src/features/chat/__tests__/ChatInput.test.tsx
+++ b/src/Content/Presentation/Presentation.WebUI/src/features/chat/__tests__/ChatInput.test.tsx
@@ -22,10 +22,13 @@ vi.mock('@/features/mcp/useMcpQuery', () => ({
   }),
 }));
 
-const mockSendMessage = vi.fn().mockResolvedValue(undefined);
+// ChatInput delegates the send sequence to the shared useSendUserMessage hook; mock it so the test
+// asserts on the composed text without pulling in the agent stream / MSAL.
+const mockSend = vi.fn().mockReturnValue(true);
+vi.mock('@/hooks/useSendUserMessage', () => ({ useSendUserMessage: () => mockSend }));
 
 function renderInput() {
-  return renderWithProviders(<ChatInput conversationId="test-conv" sendMessage={mockSendMessage} />);
+  return renderWithProviders(<ChatInput />);
 }
 
 function getSubmitButton(): HTMLButtonElement {
@@ -40,12 +43,12 @@ describe('ChatInput', () => {
     useChatStore.setState({ conversationId: null, messages: [], isStreaming: false, streamingContent: '' });
   });
 
-  it('submit calls sendMessage with input value', async () => {
+  it('submit sends the input value via the shared hook', async () => {
     const user = userEvent.setup();
     renderInput();
     await user.type(screen.getByPlaceholderText(/message the agent/i), 'hello world');
     await user.click(getSubmitButton());
-    expect(mockSendMessage).toHaveBeenCalledWith('test-conv', expect.any(String), 'hello world');
+    expect(mockSend).toHaveBeenCalledWith('hello world');
   });
 
   it('is disabled while isStreaming is true', () => {
@@ -63,11 +66,11 @@ describe('ChatInput', () => {
     expect(screen.getByPlaceholderText(/message the agent/i)).toHaveValue('');
   });
 
-  it('rejects empty string (does not call sendMessage)', async () => {
+  it('rejects empty string (does not call the send hook)', async () => {
     const user = userEvent.setup();
     renderInput();
     await user.click(getSubmitButton());
-    expect(mockSendMessage).not.toHaveBeenCalled();
+    expect(mockSend).not.toHaveBeenCalled();
   });
 
   it('rejects messages over 40000 characters', async () => {
@@ -77,7 +80,7 @@ describe('ChatInput', () => {
     });
     fireEvent.click(getSubmitButton());
     expect(await screen.findByText(/message too long/i)).toBeInTheDocument();
-    expect(mockSendMessage).not.toHaveBeenCalled();
+    expect(mockSend).not.toHaveBeenCalled();
   });
 
   it('shows prompt picker when user types @', async () => {

--- a/src/Content/Presentation/Presentation.WebUI/src/features/chat/__tests__/ChatPanel.test.tsx
+++ b/src/Content/Presentation/Presentation.WebUI/src/features/chat/__tests__/ChatPanel.test.tsx
@@ -96,6 +96,28 @@ describe('ChatPanel', () => {
     });
   });
 
+  // --- Widget persistence on reload ---
+
+  describe('widget re-render on reload', () => {
+    it('renders a persisted widget message returned by startConversation', async () => {
+      mockStartConversation.mockResolvedValueOnce([
+        {
+          id: 'w1',
+          role: 'assistant',
+          content: '',
+          timestamp: new Date().toISOString(),
+          widget: { type: 'render_table', args: { columns: ['Name'], rows: [['Ada']] } },
+        },
+      ]);
+
+      renderPanel();
+
+      // The table widget re-renders from the persisted spec with no live tool call.
+      expect(await screen.findByTestId('agent-table')).toBeInTheDocument();
+      expect(screen.getByRole('cell', { name: 'Ada' })).toBeInTheDocument();
+    });
+  });
+
   // --- ErrorBanner ---
 
   describe('ErrorBanner', () => {

--- a/src/Content/Presentation/Presentation.WebUI/src/hooks/useAgentHub.tsx
+++ b/src/Content/Presentation/Presentation.WebUI/src/hooks/useAgentHub.tsx
@@ -14,6 +14,8 @@ export interface ServerConversationMessage {
   content: string;
   timestamp: string;
   toolCalls?: { toolName: string; input: Record<string, unknown>; output: unknown }[] | null;
+  /** Set on an assistant message that carried an inline generative-UI widget, so it re-renders on reload. */
+  widget?: { type: string; args: Record<string, unknown> } | null;
 }
 
 export interface ConversationSettingsInput {

--- a/src/Content/Tests/Presentation.AgentHub.Tests/AgUi/AgUiClientToolBridgeTests.cs
+++ b/src/Content/Tests/Presentation.AgentHub.Tests/AgUi/AgUiClientToolBridgeTests.cs
@@ -1,8 +1,11 @@
 using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Moq;
 using Presentation.AgentHub.AgUi;
 using Presentation.AgentHub.Config;
+using Presentation.AgentHub.DTOs;
+using Presentation.AgentHub.Interfaces;
 using Xunit;
 
 namespace Presentation.AgentHub.Tests.AgUi;
@@ -10,7 +13,8 @@ namespace Presentation.AgentHub.Tests.AgUi;
 /// <summary>
 /// Unit tests for <see cref="AgUiClientToolBridge"/> — the mid-run blocking proxy. Verifies it emits the
 /// <c>TOOL_CALL_START</c>/<c>ARGS</c>/<c>END</c> sequence (sharing one callId), parks until the registry
-/// is completed out-of-band, returns the client's result, and fails fast when no client is attached.
+/// is completed out-of-band, returns the client's result, fails fast when no client is attached, and
+/// persists a widget message for widget tools (so the render survives a reload) but not for others.
 /// </summary>
 public sealed class AgUiClientToolBridgeTests
 {
@@ -21,13 +25,21 @@ public sealed class AgUiClientToolBridgeTests
         return mock.Object;
     }
 
+    private static AgUiClientToolBridge Bridge(
+        IAgUiEventWriterAccessor accessor,
+        PendingToolCallRegistry registry,
+        IConversationStore? store = null,
+        int timeoutSeconds = 30) =>
+        new(accessor, registry, Options(timeoutSeconds), store ?? new RecordingConversationStore(),
+            new ClientWidgetCatalog(), NullLogger<AgUiClientToolBridge>.Instance);
+
     [Fact]
     public async Task InvokeAsync_EmitsToolCallSequence_BlocksUntilCompleted_ThenReturnsResult()
     {
         var writer = new CapturingEventWriter();
         var accessor = new AgUiEventWriterAccessor { Writer = writer, ThreadId = "thread-1" };
         var registry = new PendingToolCallRegistry();
-        var bridge = new AgUiClientToolBridge(accessor, registry, Options());
+        var bridge = Bridge(accessor, registry);
 
         var invokeTask = bridge.InvokeAsync("dashboard_control", "{\"operation\":\"navigate\"}");
 
@@ -53,7 +65,7 @@ public sealed class AgUiClientToolBridgeTests
     public async Task InvokeAsync_NoClientAttached_Throws()
     {
         var accessor = new AgUiEventWriterAccessor { Writer = null };
-        var bridge = new AgUiClientToolBridge(accessor, new PendingToolCallRegistry(), Options());
+        var bridge = Bridge(accessor, new PendingToolCallRegistry());
 
         bridge.IsClientAttached.Should().BeFalse();
 
@@ -65,11 +77,75 @@ public sealed class AgUiClientToolBridgeTests
     public void IsClientAttached_ReflectsAmbientWriter()
     {
         var accessor = new AgUiEventWriterAccessor();
-        var bridge = new AgUiClientToolBridge(accessor, new PendingToolCallRegistry(), Options());
+        var bridge = Bridge(accessor, new PendingToolCallRegistry());
 
         bridge.IsClientAttached.Should().BeFalse();
         accessor.Writer = new CapturingEventWriter();
         bridge.IsClientAttached.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task InvokeAsync_WidgetTool_PersistsWidgetMessage()
+    {
+        var accessor = new AgUiEventWriterAccessor { Writer = new CapturingEventWriter(), ThreadId = "thread-w" };
+        var registry = new PendingToolCallRegistry();
+        var store = new RecordingConversationStore();
+        var bridge = Bridge(accessor, registry, store);
+
+        var invokeTask = bridge.InvokeAsync("render_table", "{\"columns\":[\"Name\"],\"rows\":[[\"Ada\"]]}");
+
+        // Persistence must wait for the client to confirm the render: while the call is still parked the
+        // widget is NOT yet persisted, so a timed-out/never-rendered round-trip leaves no phantom.
+        await WaitForAsync(() => ((CapturingEventWriter)accessor.Writer!).Events.Count >= 3);
+        store.Appended.Should().BeEmpty("the widget is persisted only after the client acknowledges the render");
+
+        // Complete the round-trip as the client posting its result; only now is the widget persisted.
+        var callId = ((ToolCallStartEvent)((CapturingEventWriter)accessor.Writer!).Events[0]).ToolCallId;
+        registry.TryComplete(callId, "thread-w", "ok").Should().BeTrue();
+        await invokeTask.WaitAsync(TimeSpan.FromSeconds(5));
+
+        store.Appended.Should().HaveCount(1);
+        var (conversationId, message) = store.Appended[0];
+        conversationId.Should().Be("thread-w");
+        message.Role.Should().Be(MessageRole.Assistant);
+        message.Content.Should().BeEmpty("the widget message renders as the widget only, matching the live message");
+        message.Widget.Should().NotBeNull();
+        message.Widget!.Type.Should().Be("render_table");
+        message.Widget.Args.GetProperty("columns").GetArrayLength().Should().Be(1);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_WidgetTool_TimesOut_DoesNotPersist()
+    {
+        var accessor = new AgUiEventWriterAccessor { Writer = new CapturingEventWriter(), ThreadId = "thread-t" };
+        var registry = new PendingToolCallRegistry();
+        var store = new RecordingConversationStore();
+        var bridge = Bridge(accessor, registry, store, timeoutSeconds: 1);
+
+        // Never complete the registry: the parked call times out and the widget must NOT be persisted,
+        // so a round-trip that never rendered leaves no phantom widget on reload.
+        var act = async () => await bridge.InvokeAsync("render_table", "{\"columns\":[\"Name\"]}");
+        await act.Should().ThrowAsync<TimeoutException>();
+
+        store.Appended.Should().BeEmpty("a timed-out render must not persist a widget");
+    }
+
+    [Fact]
+    public async Task InvokeAsync_NonWidgetTool_DoesNotPersist()
+    {
+        var accessor = new AgUiEventWriterAccessor { Writer = new CapturingEventWriter(), ThreadId = "thread-n" };
+        var registry = new PendingToolCallRegistry();
+        var store = new RecordingConversationStore();
+        var bridge = Bridge(accessor, registry, store);
+
+        var invokeTask = bridge.InvokeAsync("dashboard_control", "{\"operation\":\"refresh_data\"}");
+
+        await WaitForAsync(() => ((CapturingEventWriter)accessor.Writer!).Events.Count >= 3);
+        store.Appended.Should().BeEmpty("only widget tools are persisted for reload");
+
+        var callId = ((ToolCallStartEvent)((CapturingEventWriter)accessor.Writer!).Events[0]).ToolCallId;
+        registry.TryComplete(callId, "thread-n", "ok").Should().BeTrue();
+        await invokeTask.WaitAsync(TimeSpan.FromSeconds(5));
     }
 
     private static async Task WaitForAsync(Func<bool> condition)
@@ -90,5 +166,35 @@ public sealed class AgUiClientToolBridgeTests
             _events.Add(evt);
             return Task.CompletedTask;
         }
+    }
+
+    /// <summary>An <see cref="IConversationStore"/> that records appended messages; other members are unused.</summary>
+    private sealed class RecordingConversationStore : IConversationStore
+    {
+        private readonly List<(string ConversationId, ConversationMessage Message)> _appended = [];
+        public IReadOnlyList<(string ConversationId, ConversationMessage Message)> Appended => _appended;
+
+        public Task AppendMessageAsync(string conversationId, ConversationMessage message, CancellationToken ct = default)
+        {
+            _appended.Add((conversationId, message));
+            return Task.CompletedTask;
+        }
+
+        public Task<ConversationRecord?> GetAsync(string conversationId, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+        public Task<IReadOnlyList<ConversationRecord>> ListAsync(string userId, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+        public Task<ConversationRecord> CreateAsync(string agentName, string userId, string? conversationId = null, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+        public Task DeleteAsync(string conversationId, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+        public Task<IReadOnlyList<ConversationMessage>?> GetHistoryForDispatch(string conversationId, int maxMessages, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+        public Task<ConversationRecord?> TruncateFromMessageAsync(string conversationId, Guid messageId, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+        public Task<ConversationRecord?> UpdateSettingsAsync(string conversationId, ConversationSettings settings, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+        public Task<ConversationRecord?> UpdateTelemetryAsync(string conversationId, Guid observabilitySessionId, TelemetryAccumulator telemetry, CancellationToken ct = default) =>
+            throw new NotSupportedException();
     }
 }


### PR DESCRIPTION
Clears the four tracked follow-ups from the inline generative-UI feature (PR #109). Four focused commits.

## Commits
1. **`refactor(tools)` — `SingleRenderProxyTool` base.** The four single-`render` tools (chart/image/form/table) each duplicated the same `ExecuteAsync` preamble (op-gate + client-attached check + serialize + validate-then-invoke). Hoisted into a shared base; each tool now supplies only its name, description, two failure messages, and an argument validator. Behavior-preserving (multi-op `DashboardControlTool` keeps extending `BlockingProxyTool` directly).
2. **`refactor(agents)` — dedicated `default-agent` skill.** The generative-UI tools were grafted onto `research-agent` (a file-analysis skill) only because the default agent reused it. Added a `default-agent` skill (general assistant + the three widgets), repointed `agents/default`, and restored `research-agent` to file-analysis only. Mirrors the `dashboard-agent` agent+skill pairing.
3. **`refactor(webui)` — `ChatInput` uses `useSendUserMessage`.** `ChatInput` held a third copy of the optimistic-message → start-streaming → dispatch-run sequence. Routed through the shared hook (as `handleSuggestionClick` already did), dropping two props; `ChatPanel` drops the wrapper and its redundant `useAgentStream` instance.
4. **`feat(agenthub)` — widget persistence.** Inline widgets lived only in browser memory and vanished on refresh. The blocking-proxy bridge now persists a widget-bearing assistant message (empty text + `WidgetSpec{type,args}`) so it re-renders from history on reload. A `ClientWidgetCatalog` names the persisted widget tools (image/form/table; `render_chart` excluded — its client is the dashboard app). Best-effort (a persistence failure is logged, never breaks the turn).

## Review (2 finder agents, adversarial focus on #4) — 2 real defects found and fixed
- **Phantom widget**: persisted on `TOOL_CALL_END` before the client confirmed the render, so a timed-out/rejected round-trip left a widget that reappears on reload contradicting the agent. **Fixed** — persist only after the round-trip result returns (new `…_TimesOut_DoesNotPersist` test).
- **Context-window shrinkage**: empty widget messages consumed slots in the 50-message dispatch window then got dropped at mapping time, starving the model. **Fixed** — filter empty-content messages in `GetHistoryForDispatch` (single source for both AG-UI + SignalR), reverting the now-redundant `ToMeaiHistory` filter.

Cleanup review: no reuse/duplication/convention issues; two LOW findings assessed as no-action (serialize-before-validate is side-effect-free on the discarded error path; `WidgetSpec` param docs match the sibling `ToolCallRecord` precedent).

## Tests
- Backend: 1985 Infrastructure.AI + 388 AgentHub (incl. new bridge persistence + timeout tests) + 39 render-tool tests. Build 0 warnings.
- Frontend: 135 WebUI unit tests (incl. new `ChatPanel` widget-reload test), `tsc` clean, changed-file `eslint` clean. The 3 "failed" vitest files are pre-existing Playwright e2e specs vitest mis-globs.

## Note (pre-existing, out of scope)
`useAgentHub.tsx` carries two pre-existing eslint errors on lines I didn't touch (unused `ChatMessage` import; a react-refresh export warning) — present on `main`, left alone to keep this diff scoped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)