### PR TITLE
refactor(webui): drop redundant widget registry validate wrappers

### DIFF
--- a/src/Content/Presentation/Presentation.WebUI/src/features/chat/widgets/registry.tsx
+++ b/src/Content/Presentation/Presentation.WebUI/src/features/chat/widgets/registry.tsx
@@ -28,17 +28,17 @@ export interface WidgetDefinition {
 const WIDGET_REGISTRY = new Map<string, WidgetDefinition>([
   ['render_image', {
     render: (args) => <AgentImage args={args} />,
-    validate: (args) => { const r = parseImageArgs(args); return r.ok ? { ok: true } : { ok: false, reason: r.reason }; },
+    validate: parseImageArgs,
     ack: 'Displayed the image to the user.',
   }],
   ['render_form', {
     render: (args) => <AgentForm args={args} />,
-    validate: (args) => { const r = parseFormArgs(args); return r.ok ? { ok: true } : { ok: false, reason: r.reason }; },
+    validate: parseFormArgs,
     ack: 'Displayed the form to the user; their answers will arrive as their next message.',
   }],
   ['render_table', {
     render: (args) => <AgentTable args={args} />,
-    validate: (args) => { const r = parseTableArgs(args); return r.ok ? { ok: true } : { ok: false, reason: r.reason }; },
+    validate: parseTableArgs,
     ack: 'Displayed the table to the user.',
   }],
 ]);


### PR DESCRIPTION
The last (LOW-priority) generative-UI follow-up. Each `WIDGET_REGISTRY` entry wrapped its `parseXArgs` in a lambda that rebuilt an `{ok}`/`{ok,reason}` object, discarding `value`. The parse functions' result type is already structurally assignable to `ValidationResult`, so `validate: parseXArgs` typechecks directly — removing three boilerplate lambdas.

No behavior change: consumers (`useAgentStream.runWidgetToolCall`) read only `.ok`/`.reason`; the retained `value` field is ignored.

## Tests
`tsc --noEmit` clean (confirms the assignability), 41 widget tests pass, `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)