### PR TITLE
fix(eval): configure harmonic write-eval quality judge model

### DIFF
--- a/src/Content/Presentation/Presentation.EvalRunner/HarmonicWriteEval/HarmonicWriteEvalCli.cs
+++ b/src/Content/Presentation/Presentation.EvalRunner/HarmonicWriteEval/HarmonicWriteEvalCli.cs
@@ -1,5 +1,8 @@
+using Application.AI.Common.Evaluation.Models;
+using Domain.Common.Config;
 using Infrastructure.AI.Evaluation;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using Presentation.Common.Extensions;
 
 namespace Presentation.EvalRunner.HarmonicWriteEval;
@@ -125,8 +128,24 @@ public static class HarmonicWriteEvalCli
         {
             services.GetServices(includeHealthChecksUI: false);
             services.AddEvaluationDependencies();
+            ConfigureJudgeFromAgentFramework(services);
         }
         return services.BuildServiceProvider();
+    }
+
+    // The quality judge resolves its model from JudgeOptions — a DIFFERENT config section than the
+    // abstractor/consolidator, which read AppConfig:AI:AgentFramework. AddEvaluationDependencies leaves
+    // JudgeOptions.Deployment empty, so GetJudgeAsync throws "Deployment must be configured", DefaultLlmJudge
+    // soft-fails every call, and the abstraction-quality column comes back blank on a paid run. Bind the judge
+    // to the same model the eval already exercises so --llm actually scores abstraction quality.
+    internal static void ConfigureJudgeFromAgentFramework(IServiceCollection services)
+    {
+        services.AddOptions<JudgeOptions>().Configure<IOptionsMonitor<AppConfig>>((judge, appConfig) =>
+        {
+            var framework = appConfig.CurrentValue.AI.AgentFramework;
+            judge.ClientType = framework.ClientType;
+            judge.Deployment = framework.DefaultDeployment;
+        });
     }
 
     private static void PrintUsage()

--- a/src/Content/Presentation/Presentation.EvalRunner/Presentation.EvalRunner.csproj
+++ b/src/Content/Presentation/Presentation.EvalRunner/Presentation.EvalRunner.csproj
@@ -10,6 +10,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Presentation.EvalRunner.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" />
     <PackageReference Include="Microsoft.Extensions.Hosting" />
     <PackageReference Include="Spectre.Console" />

--- a/src/Content/Tests/Presentation.EvalRunner.Tests/HarmonicWriteEval/HarmonicWriteJudgeWiringTests.cs
+++ b/src/Content/Tests/Presentation.EvalRunner.Tests/HarmonicWriteEval/HarmonicWriteJudgeWiringTests.cs
@@ -1,0 +1,56 @@
+using Application.AI.Common.Evaluation.Models;
+using Domain.Common.Config;
+using Domain.Common.Config.AI;
+using FluentAssertions;
+using Infrastructure.AI.Evaluation;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Presentation.EvalRunner.HarmonicWriteEval;
+using Xunit;
+
+namespace Presentation.EvalRunner.Tests.HarmonicWriteEval;
+
+/// <summary>
+/// Guards the harmonic write-eval judge wiring. The abstraction-quality column silently came back
+/// blank on the first paid run because the judge resolves its model from <see cref="JudgeOptions"/> —
+/// a different config section than the abstractor/consolidator (which read
+/// <c>AppConfig:AI:AgentFramework</c>) — and nobody populated it, so every score soft-failed.
+/// </summary>
+public sealed class HarmonicWriteJudgeWiringTests
+{
+    [Fact]
+    public void AddEvaluationDependencies_Alone_LeavesJudgeDeploymentUnconfigured()
+    {
+        // Reproduces the root cause: the eval framework registers JudgeOptions but never sets
+        // Deployment, so GetJudgeAsync throws and DefaultLlmJudge soft-fails every quality score.
+        var services = new ServiceCollection();
+        services.AddEvaluationDependencies();
+
+        using var provider = services.BuildServiceProvider();
+
+        provider.GetRequiredService<IOptionsMonitor<JudgeOptions>>()
+            .CurrentValue.Deployment.Should().BeEmpty(
+                "AddEvaluationDependencies leaves the judge model unconfigured on its own");
+    }
+
+    [Fact]
+    public void ConfigureJudgeFromAgentFramework_BindsJudgeToAgentFrameworkModel()
+    {
+        var services = new ServiceCollection();
+        services.AddOptions<AppConfig>().Configure(cfg =>
+        {
+            cfg.AI.AgentFramework.ClientType = AIAgentFrameworkClientType.OpenAI;
+            cfg.AI.AgentFramework.DefaultDeployment = "anthropic/claude-sonnet-4.6";
+        });
+        services.AddEvaluationDependencies();
+
+        HarmonicWriteEvalCli.ConfigureJudgeFromAgentFramework(services);
+
+        using var provider = services.BuildServiceProvider();
+        var judge = provider.GetRequiredService<IOptionsMonitor<JudgeOptions>>().CurrentValue;
+
+        judge.Deployment.Should().Be("anthropic/claude-sonnet-4.6",
+            "the judge must reuse the same model the abstractor/consolidator exercise");
+        judge.ClientType.Should().Be(AIAgentFrameworkClientType.OpenAI);
+    }
+}


### PR DESCRIPTION
## Problem
On the paid `--llm` harmonic write-side eval, the **abstraction-quality column came back blank** (`AbstractionsJudged: 0` in every mode) despite the abstractor/consolidator LLM calls working.

**Root cause:** the quality judge resolves its model from `JudgeOptions` (via `IJudgeChatClientProvider`), a *different* config section than the abstractor/consolidator (`AppConfig:AI:AgentFramework`). `AddEvaluationDependencies` registers `JudgeOptions` but never sets `Deployment`, so `GetJudgeAsync` throws `"Deployment must be configured"`, `DefaultLlmJudge` catches it and soft-fails every score.

## Fix
Bind `JudgeOptions` to the same `AgentFramework` model the eval already exercises, in a testable seam (`ConfigureJudgeFromAgentFramework`), called from the eval host's `--llm` `BuildProvider`.

- `HarmonicWriteEvalCli.cs` — the binding + wiring
- `Presentation.EvalRunner.csproj` — `InternalsVisibleTo` for the test
- `HarmonicWriteJudgeWiringTests.cs` — 2 tests: one reproduces the unconfigured-judge root cause, one proves the binding

## Verification
- Both new tests green (2/2).
- Paid `--llm` re-run confirmed live: quality column now populates (~0.78 mean).
- `/code-review` (high) and `/simplify`: 0 findings.

## Test plan
- [x] `dotnet test` on the new wiring tests
- [x] Live paid eval run — quality scores present

🤖 Generated with [Claude Code](https://claude.com/claude-code)