### PR TITLE
feat(memory): harmonic cue-anchor recall + generic RRF fusion (PR3)

### DIFF
--- a/.claude/plans/harmonic-memory-representation.md
+++ b/.claude/plans/harmonic-memory-representation.md
@@ -157,32 +157,104 @@ Make `RememberAsync` produce harmonic entries when `Mode != Off`.
   post-consolidation, tenant/owner isolation preserved through the new path, cost-guard knobs honored,
   episodic segment captured raw + cross-linked to WorkEpisode without double-capturing the seam.
 
-### 🔬 EVAL GATE — run PR4 eval here before building PR3
-Per decision 1: after PR2, run the write-side eval (below) and get Matt's go/no-go before the read path.
+### 🔬 EVAL GATE — ✅ DONE (2026-07-07, paid `--llm` run, Matt reviewed)
+Write-side eval built + MERGED (#115); judge-wiring fix MERGED (#116). Paid run ⇒ **write side ACCEPTED,
+PR3 GREENLIT.** Key finding that reshapes PR3: of the residual Full-mode fragments, **5/6 shared ≥1 token
+with their cluster** (surfaceable by *lexical* abstraction match) and only **1/6** was a pure-semantic miss.
+⇒ semantic/embedding recall has ~0 marginal leverage on this workload (**Option A abandoned**); the recall
+win comes from *using* the abstraction + cue-anchor data at all, not from embeddings. See the "EVAL GATE
+RUN" section in `memory/project_harmonic_memory_memora.md` for the full scorecard.
 
-### PR3 — Cue-anchor recall + RRF fusion — **DEFERRED to post-eval** — `feat/harmonic-memory-pr3-recall`
-Add the joint abstraction+cue read path; keep the legacy path as one fusion input.
-- **Infrastructure**: a cue-anchor index (second collection / graph label). `RecallAsync` (impact-analyze
-  first) becomes: match query against **abstraction index + cue-anchor index** → traverse shared-anchor
-  neighbors (bounded fan-out) → fuse with the existing substring/graph results via **RRF (reuse
-  `Infrastructure.AI.RAG` — we already own the primitive)**. Behind `Mode != Off`; `Off` = today's path.
-- **Tests**: cue-anchor hit surfaces a memory that substring misses; traversal returns the coherent
-  cluster; RRF ordering; isolation holds on recall; `Off` mode = byte-identical legacy behavior.
+---
 
-### PR4 — Eval harness (the gate) — runs after PR2, BEFORE PR3 — `feat/harmonic-memory-pr4-eval`
-Small LoCoMo-style eval (reuse our Phase 5 eval framework + LLM-as-judge) comparing Off vs AbstractOnly vs
-Full on a fixed multi-session fixture. Report retrieval relevance + answer score + **LLM-call cost delta**
-(the toggle's whole justification). Purpose: confirm the gain transfers before recommending anyone flip it
-on in production — benchmark numbers rarely port 1:1.
+## PR3 — Cue-anchor recall + RRF fusion — `feat/harmonic-memory-pr3-recall`  *(drafted 2026-07-07, not built)*
+
+**The problem PR3 solves.** PR2 writes a primary abstraction + cue anchors into every trusted memory node's
+`GraphNode.Properties` (`memory.abstraction`, `memory.cue_anchors`). **Recall never reads them.** Today
+`RecallAsync` → `SearchGraphAsync` → `MatchesQuery` substring-matches only `node.Name`/`node.Type`
+(`KnowledgeMemoryService.cs:332`). That is exactly why the pre-PR3 eval showed **zero recall delta across
+modes** — the harmonic write side is inert until recall consumes it. PR3 makes recall match the query against
+abstraction + cue anchors, traverse the implicit shared-anchor graph, and fuse that with the legacy path.
+
+**Corrections to the old stub (from the 2026-07-07 code map):**
+- There is **no reusable RRF** — the only impl is `private static HybridRetriever.ApplyReciprocalRankFusion`
+  (`Infrastructure.AI.RAG/Retrieval/HybridRetriever.cs:142`), coupled to `RetrievalResult`/`DocumentChunk`.
+  PR3 must **extract a generic helper**, not "reuse `Infrastructure.AI.RAG`" (and infra-to-infra dep is wrong
+  anyway).
+- Abstractions live in `GraphNode.Properties` (a string bag), **not** a separate index/collection.
+- `RecallAsync(string query, int maxResults)` takes a **bare string** — no query object, no embedder wired.
+- No property-filtered graph query exists; PR2 already accepts an **O(n) `GetAllNodesAsync` scan** (documented
+  caveat). PR3 recall inherits that tradeoff.
+
+### Recommended design — lexical joint match, no LLM on the recall hot path
+Reuse the write partial's `Tokenize`/`TokenOverlap` (`KnowledgeMemoryService.Harmonic.cs:213/229`) to score
+the **raw query** against each in-scope trusted node's abstraction + cue anchors. This is the honest default
+because (a) the eval proved lexical catches 5/6 of the fragments semantic would and (b) recall runs per-turn
+during context assembly — paying an LLM call per recall (query-abstraction) or standing up an embedder
+(semantic) buys ≤1/6 for real cost. See **Decision R1** for the fork; recommendation = lexical.
+
+### Stages
+1. **Generic RRF helper** — new `ReciprocalRankFusion` static (proposed `Domain.AI/Retrieval/`, pure algorithm,
+   zero deps): `Fuse<T>(IEnumerable<IReadOnlyList<T>> rankedLists, Func<T,string> keySelector, double k=60,
+   int topK)`. **Migrate `HybridRetriever` to call it** (replace the private method — "replace, don't
+   deprecate"; one true RRF, its existing RAG tests prove equivalence). Risk: touches RAG tests → verify green.
+2. **Harmonic recall matcher** — new partial `KnowledgeMemoryService.Harmonic.Recall.cs` mirroring the write
+   partial. `RecallHarmonicAsync(query, maxResults)`: scope-filtered trusted nodes with an abstraction (same
+   filter as `FindConsolidationCandidatesAsync`) → score by `max(TokenOverlap(qTokens, abstractionTokens),
+   TokenOverlap(qTokens, cueAnchorTokens))` → ranked list. Cue anchors are the second entry point the legacy
+   substring path lacks.
+3. **Shared-cue-anchor traversal** — from the top seeds' cue anchors, pull in-scope trusted nodes sharing ≥1
+   anchor (Memora's implicit graph), bounded by `RecallCueAnchorFanout` (new knob). These join the fusion at a
+   lower rank so a query that hits one member surfaces the coherent cluster.
+4. **Fuse in `RecallAsync`** — when `Mode != Off`: build (a) the harmonic ranked list (stages 2–3) and (b) the
+   existing `SearchGraphAsync` list, fuse via the generic RRF, keep `IsRecallable` as the single trust
+   chokepoint, `Take(maxResults)`. **`Mode == Off` = byte-identical legacy path** (guard at the top).
+5. **Config + validator** — extend `HarmonicMemoryConfig`: `RecallCueAnchorFanout` (default 3), `RecallRrfK`
+   (default 60). Extend `HarmonicMemoryConfigValidator` (fanout ≥ 0, k > 0). Optional `AbstractQueryOnRecall`
+   (default false) only if Decision R1 picks the LLM path.
+6. **DI** — inject `IMemoryAbstractor` into the `KnowledgeMemoryService` factory
+   (`Infrastructure.AI.KnowledgeGraph/DependencyInjection.cs:164`) **only if** R1 = LLM-query-abstraction;
+   the lexical default needs no new dependency (the constructor already has the abstractor arg, currently
+   null from the factory).
+7. **Tests** (`Infrastructure.AI.KnowledgeGraph.Tests/Memory/`, real `InMemoryGraphStore` + Fake seams, per
+   PR2 pattern): cue-anchor hit surfaces a node substring misses; shared-anchor traversal returns the cluster;
+   RRF ordering; **`Off` byte-identical to legacy**; tenant/owner isolation holds on recall; quarantined
+   (untrusted) nodes never surface. Plus generic-RRF unit tests + HybridRetriever regression stays green.
+
+### 🔬 Recall eval (proves PR3, mirrors the PR2 write eval)
+The write eval explicitly **under-measured** because it couldn't test recall. Add a `harmonic-recall` eval
+subcommand (template: `Presentation.EvalRunner/HarmonicWriteEval/`) over a fixture of `(query → expected
+memory-id)` pairs, reporting **recall@k / MRR for Off vs AbstractOnly vs Full** + LLM-call cost delta. This is
+the real go/no-go on whether harmonic recall beats substring — ship it with PR3.
+
+### Open decisions for PR3 (confirm before building)
+- **R1 — recall matching:** **lexical token-overlap (no LLM, recommended)** vs LLM query-abstraction (1 call
+  /recall) vs embeddings. Eval evidence + hot-path cost point to lexical; the others buy ≤1/6 for real cost.
+- **R2 — RRF placement + HybridRetriever migration:** extract generic + **migrate HybridRetriever
+  (recommended, DRY/replace-don't-deprecate)** vs add generic but leave HybridRetriever (two impls = debt).
+- **R3 — episodic grounding:** **split to a separate PR3b (recommended)** vs fold into PR3. It needs a
+  write-side change (factual nodes don't carry conversation/turn or an `EpisodicMemoryIds` link yet — the
+  `GraphNode` has no such field), so it's a clean separate unit; the greenlight was for recall+RRF specifically.
+- **R4 — O(n) recall scan:** **accept now (recommended, matches PR2's documented caveat, fixture-scale)** vs
+  add an abstraction-indexed `IKnowledgeGraphStore` primitive. Recall is hotter than write, so flag the scan
+  as the primary scaling risk with a TODO, but don't build the index speculatively (YAGNI).
+
+### PR3b (optional follow-up) — Episodic grounding — `feat/harmonic-memory-pr3b-episodic`
+Wire the deferred factual→episodic link. Add `memory.episodic_ids` (or reconstruct via `(ConversationId,
+TurnNumber)` provenance) so recall can attach raw `EpisodicSegment`s (via `IEpisodicSegmentStore
+.GetByConversationAsync`) as grounding context for a recalled factual node. Separate PR because it requires the
+write path to stamp conversation/turn onto factual nodes (which it doesn't today).
 
 ## Verification (each PR)
 `dotnet build src/AgenticHarness.slnx && dotnet test src/AgenticHarness.slnx`; `gitnexus_impact` before
 editing `RememberAsync`/`RecallAsync`; `/code-review` + `/simplify` per `rules/review-cadence.md`;
 `gitnexus_detect_changes` before commit.
 
-## Decisions — all resolved 2026-07-06 (see "Decisions locked" above)
+## Decisions — original scope resolved 2026-07-06 (see "Decisions locked" above)
 1. Scope → **PR1 + PR2, then eval gate.** 2. Provider → **`NotConfigured` seams only.**
 3. Episodic → **include + reconcile with shipped `WorkEpisode` (share seam, distinct records, cross-link).**
-4. Retriever → **Semantic only.**
+4. Retriever → **Semantic only** (superseded on the *recall* side by the 2026-07-07 eval → lexical default; see R1).
 
-Build not yet started — awaiting Matt's go to begin PR1.
+**Progress:** PR1 MERGED (#113) · PR2 write path MERGED (#114) · write-side eval + judge fix MERGED (#115/#116)
+· eval gate DONE → PR3 GREENLIT. **PR3 (recall + RRF) drafted above, NOT built — awaiting Matt's answers on
+R1–R4 before build.**

--- a/src/Content/Application/Application.Core/Validation/HarmonicMemoryConfigValidator.cs
+++ b/src/Content/Application/Application.Core/Validation/HarmonicMemoryConfigValidator.cs
@@ -4,9 +4,10 @@ using FluentValidation;
 namespace Application.Core.Validation;
 
 /// <summary>
-/// Validates <see cref="HarmonicMemoryConfig"/>: the content-length floor must be non-negative and the
-/// consolidation fan-out must be positive. Auto-discovered via <c>AddValidatorsFromAssembly</c>,
-/// consistent with the sibling config validators (<c>WorkMemoryConfigValidator</c> et al.).
+/// Validates <see cref="HarmonicMemoryConfig"/>: the content-length floor and recall cue-anchor fan-out must
+/// be non-negative, and the consolidation top-K and recall RRF constant must be positive. Auto-discovered via
+/// <c>AddValidatorsFromAssembly</c>, consistent with the sibling config validators
+/// (<c>WorkMemoryConfigValidator</c> et al.).
 /// </summary>
 /// <remarks>
 /// <para>
@@ -33,6 +34,12 @@ public sealed class HarmonicMemoryConfigValidator : AbstractValidator<HarmonicMe
 
         RuleFor(x => x.ConsolidationTopK)
             .GreaterThan(0).WithMessage("ConsolidationTopK must be > 0.");
+
+        RuleFor(x => x.RecallCueAnchorFanout)
+            .GreaterThanOrEqualTo(0).WithMessage("RecallCueAnchorFanout must be >= 0.");
+
+        RuleFor(x => x.RecallRrfK)
+            .GreaterThan(0).WithMessage("RecallRrfK must be > 0.");
 
         RuleFor(x => x.BatchAtSessionFlush)
             .Equal(false)

--- a/src/Content/Domain/Domain.AI/Retrieval/FusedResult.cs
+++ b/src/Content/Domain/Domain.AI/Retrieval/FusedResult.cs
@@ -1,0 +1,17 @@
+namespace Domain.AI.Retrieval;
+
+/// <summary>
+/// One entry in a <see cref="ReciprocalRankFusion"/> result: a representative item, its fused score, and the
+/// per-input-list items that shared the entry's fusion key.
+/// </summary>
+/// <typeparam name="T">The ranked item type.</typeparam>
+/// <param name="Item">The representative item — the one from the earliest input list that carried this
+/// fusion key. Callers that only need the fused ranking can read this and ignore the rest.</param>
+/// <param name="Score">The fused Reciprocal Rank Fusion score (higher ranks first).</param>
+/// <param name="PerListItems">The contribution from each input list, positionally aligned to the
+/// <c>rankedLists</c> argument: <c>PerListItems[i]</c> is the item list <c>i</c> contributed under this
+/// fusion key, or <see langword="null"/> when list <c>i</c> did not contain the key. Lets a caller
+/// reconstruct a per-source-enriched output (e.g. keep a dense score from one list and a sparse score from
+/// another) without re-scanning the inputs.</param>
+public sealed record FusedResult<T>(T Item, double Score, IReadOnlyList<T?> PerListItems)
+    where T : class;

--- a/src/Content/Domain/Domain.AI/Retrieval/ReciprocalRankFusion.cs
+++ b/src/Content/Domain/Domain.AI/Retrieval/ReciprocalRankFusion.cs
@@ -1,0 +1,117 @@
+namespace Domain.AI.Retrieval;
+
+/// <summary>
+/// Generic Reciprocal Rank Fusion (RRF): merges any number of independently-ranked lists into one ranked
+/// list by summing each item's <c>1 / (k + rank)</c> contribution across the lists in which it appears.
+/// RRF needs only the <em>rank</em> of an item in each list, not comparable per-list scores, which is what
+/// makes it the standard way to fuse heterogeneous retrievers (dense + sparse, lexical + semantic, …).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Items are matched across lists by a caller-supplied string key. Ordering is deterministic: entries are
+/// ranked by fused score descending, and ties are broken by first appearance (an item seen earlier, in an
+/// earlier list or at a lower rank, sorts first) — so the same inputs always yield the same output, which
+/// keeps fusion testable.
+/// </para>
+/// <para>
+/// This is the single RRF primitive in the codebase; the hybrid RAG retriever and the harmonic memory
+/// recall path both fuse through it. It lives in the domain layer because it is a pure, dependency-free
+/// algorithm over abstract ranked lists — no retrieval, AI, or storage types leak in.
+/// </para>
+/// </remarks>
+public static class ReciprocalRankFusion
+{
+    /// <summary>
+    /// The default RRF constant. Higher values flatten the influence of top ranks (a large <c>k</c> makes
+    /// rank 1 and rank 10 nearly equal); 60 is the value from the original Cormack et al. RRF paper and the
+    /// default across this codebase's retrievers.
+    /// </summary>
+    public const double DefaultK = 60.0;
+
+    /// <summary>
+    /// Fuses the given ranked lists into a single ranked result.
+    /// </summary>
+    /// <typeparam name="T">The ranked item type.</typeparam>
+    /// <param name="rankedLists">The input lists, each already ordered best-first. Empty lists are allowed
+    /// and contribute nothing. The positional order of the lists is preserved in
+    /// <see cref="FusedResult{T}.PerListItems"/>.</param>
+    /// <param name="keySelector">Extracts the fusion key that identifies "the same item" across lists.
+    /// Items with equal keys are fused; items with distinct keys stay distinct.</param>
+    /// <param name="k">The RRF constant (defaults to <see cref="DefaultK"/>). Must be positive.</param>
+    /// <param name="topK">Optional cap on the number of returned entries. <see langword="null"/> (the
+    /// default) returns every fused entry.</param>
+    /// <returns>The fused entries, ranked by descending score with a deterministic first-appearance
+    /// tiebreak.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="rankedLists"/> or
+    /// <paramref name="keySelector"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="k"/> is not positive, or
+    /// <paramref name="topK"/> is negative.</exception>
+    public static IReadOnlyList<FusedResult<T>> Fuse<T>(
+        IReadOnlyList<IReadOnlyList<T>> rankedLists,
+        Func<T, string> keySelector,
+        double k = DefaultK,
+        int? topK = null)
+        where T : class
+    {
+        ArgumentNullException.ThrowIfNull(rankedLists);
+        ArgumentNullException.ThrowIfNull(keySelector);
+        if (k <= 0)
+            throw new ArgumentOutOfRangeException(nameof(k), k, "The RRF constant k must be positive.");
+        if (topK is < 0)
+            throw new ArgumentOutOfRangeException(nameof(topK), topK, "topK must not be negative.");
+
+        var listCount = rankedLists.Count;
+
+        // Accumulate per key, remembering first-appearance order for a deterministic tiebreak and each
+        // list's contribution so callers can reconstruct a per-source-enriched output.
+        var accumulators = new Dictionary<string, Accumulator<T>>(StringComparer.Ordinal);
+        var order = 0;
+
+        for (var listIndex = 0; listIndex < listCount; listIndex++)
+        {
+            var list = rankedLists[listIndex];
+            for (var rank = 0; rank < list.Count; rank++)
+            {
+                var item = list[rank];
+                var key = keySelector(item);
+                var rrfScore = 1.0 / (k + rank + 1);
+
+                if (!accumulators.TryGetValue(key, out var acc))
+                {
+                    acc = new Accumulator<T>(item, order++, new T?[listCount]);
+                    accumulators[key] = acc;
+                }
+
+                // Each list contributes to a key at most once, at its best (first-seen) rank. Lists are
+                // ordered best-first, so a key repeated later in the same list is an inferior rank and must
+                // not double-count — counting it would inflate the item's fused score. A key appearing in
+                // several distinct lists still accumulates one contribution per list, which is the point of
+                // fusion.
+                if (acc.PerListItems[listIndex] is null)
+                {
+                    acc.PerListItems[listIndex] = item;
+                    acc.Score += rrfScore;
+                }
+            }
+        }
+
+        var ranked = accumulators.Values
+            .OrderByDescending(a => a.Score)
+            .ThenBy(a => a.Order)
+            .Select(a => new FusedResult<T>(a.Representative, a.Score, a.PerListItems));
+
+        if (topK is int cap)
+            ranked = ranked.Take(cap);
+
+        return ranked.ToList();
+    }
+
+    private sealed class Accumulator<T>(T representative, int order, T?[] perListItems)
+        where T : class
+    {
+        public T Representative { get; } = representative;
+        public int Order { get; } = order;
+        public T?[] PerListItems { get; } = perListItems;
+        public double Score { get; set; }
+    }
+}

--- a/src/Content/Domain/Domain.Common/Config/AI/HarmonicMemory/HarmonicMemoryConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/HarmonicMemory/HarmonicMemoryConfig.cs
@@ -18,10 +18,12 @@ namespace Domain.Common.Config.AI.HarmonicMemory;
 /// </para>
 /// <code>
 /// AppConfig.AI.HarmonicMemory
-/// ├── Mode                  — Off (default) / AbstractOnly / Full — governs the write-time LLM cost
-/// ├── MinContentLengthChars — Only abstract facts at least this long (short facts stay on the legacy path)
-/// ├── ConsolidationTopK     — How many similar existing entries the consolidator sees (Full mode)
-/// └── BatchAtSessionFlush   — Defer abstraction to session flush instead of per-RememberAsync
+/// ├── Mode                   — Off (default) / AbstractOnly / Full — governs the write-time LLM cost
+/// ├── MinContentLengthChars  — Only abstract facts at least this long (short facts stay on the legacy path)
+/// ├── ConsolidationTopK      — How many similar existing entries the consolidator sees (Full mode)
+/// ├── RecallCueAnchorFanout  — How many shared-cue-anchor neighbors recall pulls into a cluster
+/// ├── RecallRrfK             — RRF constant fusing the harmonic and legacy recall lists
+/// └── BatchAtSessionFlush    — Defer abstraction to session flush instead of per-RememberAsync
 /// </code>
 /// </remarks>
 public class HarmonicMemoryConfig
@@ -48,6 +50,24 @@ public class HarmonicMemoryConfig
     /// </summary>
     /// <value>Default: 5</value>
     public int ConsolidationTopK { get; set; } = 5;
+
+    /// <summary>
+    /// Number of shared-cue-anchor neighbors the recall path pulls in around its best abstraction/cue matches
+    /// (harmonic recall only; ignored when <see cref="HarmonicMemoryMode.Off"/>). Cue anchors form an implicit
+    /// memory graph — two facts sharing an anchor are neighbors — so after ranking the query's direct hits,
+    /// recall expands the coherent cluster around them, bounded by this fan-out to keep the result focused.
+    /// Zero disables traversal (direct matches only). Must not be negative.
+    /// </summary>
+    /// <value>Default: 3</value>
+    public int RecallCueAnchorFanout { get; set; } = 3;
+
+    /// <summary>
+    /// The Reciprocal Rank Fusion constant used to blend the harmonic recall list (abstraction + cue-anchor
+    /// matches) with the legacy substring/graph list into one ranking (harmonic recall only). Higher values
+    /// flatten the influence of top ranks; 60 matches the RAG retriever's default. Must be positive.
+    /// </summary>
+    /// <value>Default: 60</value>
+    public double RecallRrfK { get; set; } = 60.0;
 
     /// <summary>
     /// Reserved for a future deferred-batching mode that would amortize the abstraction LLM cost across a

--- a/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/Memory/KnowledgeMemoryService.Harmonic.Recall.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/Memory/KnowledgeMemoryService.Harmonic.Recall.cs
@@ -1,0 +1,171 @@
+using Domain.AI.KnowledgeGraph.Models;
+using Domain.AI.Retrieval;
+using Domain.Common.Config.AI.HarmonicMemory;
+using Microsoft.Extensions.Logging;
+
+namespace Infrastructure.AI.KnowledgeGraph.Memory;
+
+/// <summary>
+/// The harmonic memory recall path (Memora port) for <see cref="KnowledgeMemoryService"/>. Split into its
+/// own partial so the legacy substring/graph recall stays the plainly-readable default and the harmonic
+/// read logic — matching the query against the primary abstraction + cue anchors, expanding the shared-anchor
+/// cluster, and fusing with the legacy list — lives together.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is what makes the write-side scaffolding pay off: the write path stamps a primary abstraction and cue
+/// anchors onto each trusted node, but the legacy recall (<c>SearchGraphAsync</c>) matches only the node's
+/// name/type and never reads them. Harmonic recall matches the query against those indexed fields — a second
+/// set of entry points the substring path lacks — then fuses the two rankings so nothing the legacy path
+/// found is lost.
+/// </para>
+/// <para>
+/// <strong>Matching is lexical, no LLM on the recall hot path.</strong> The query is tokenized and scored by
+/// token overlap against each candidate's abstraction and cue anchors (the same <c>Tokenize</c>/
+/// <c>TokenOverlap</c> the write path uses). Recall runs per turn during context assembly, and a benchmark on
+/// this codebase found embedding-based semantic matching adds negligible recall over lexical overlap for this
+/// workload — so paying an LLM call (or standing up an embedder) per recall is not worth it here.
+/// </para>
+/// </remarks>
+public sealed partial class KnowledgeMemoryService
+{
+    /// <summary>
+    /// Harmonic recall: build the legacy list and the harmonic ranked list (abstraction + cue-anchor matches,
+    /// plus the shared-cue-anchor cluster around them), then fuse the two with Reciprocal Rank Fusion. The
+    /// final list is re-filtered through <see cref="IsRecallable"/> so the "quarantined facts are never
+    /// served" invariant holds even though both inputs already filter — recall stays the single chokepoint.
+    /// </summary>
+    /// <remarks>
+    /// The legacy list is fused first, so on a score tie a legacy hit outranks a harmonic-only hit: a fact the
+    /// legacy (Off-mode) path would have surfaced at the top is never displaced by a merely-tying harmonic
+    /// match. Harmonic matches still win when they score strictly higher (including facts found by both paths,
+    /// whose contributions sum), which is the reranking harmonic recall exists to provide.
+    /// </remarks>
+    private async Task<IReadOnlyList<GraphNode>> RecallHarmonicFusedAsync(
+        string query,
+        int maxResults,
+        HarmonicMemoryConfig config,
+        CancellationToken cancellationToken)
+    {
+        // Cast a wider net than maxResults on each source so the fusion has enough overlap to reorder
+        // meaningfully (mirrors the RAG hybrid retriever requesting extra candidates before fusing).
+        var candidateCount = maxResults * 2;
+
+        var legacyHits = await RecallLegacyAsync(query, candidateCount, cancellationToken);
+        var harmonicHits = await RecallHarmonicAsync(query, candidateCount, config, cancellationToken);
+
+        // Legacy first: on a tie its first-appearance order wins, preserving the legacy path's top hits.
+        var fused = ReciprocalRankFusion.Fuse(
+            [legacyHits, harmonicHits],
+            static n => n.Id,
+            config.RecallRrfK,
+            topK: null);
+
+        var results = fused
+            .Select(f => f.Item)
+            .Where(IsRecallable)
+            .Take(maxResults)
+            .ToList();
+
+        _logger.LogDebug(
+            "Harmonic recall: {HarmonicHits} harmonic, {LegacyHits} legacy, {Returned} returned (top {Max})",
+            harmonicHits.Count, legacyHits.Count, results.Count, maxResults);
+
+        return results;
+    }
+
+    /// <summary>
+    /// Ranks this scope's trusted harmonic nodes against the query by the better of their abstraction- or
+    /// cue-anchor-token overlap, then expands the top matches with their shared-cue-anchor neighbors (the
+    /// implicit memory graph) so a query that hits one member of a cluster surfaces the coherent cluster.
+    /// Direct matches rank ahead of the traversal neighbors they pulled in.
+    /// </summary>
+    private async Task<IReadOnlyList<GraphNode>> RecallHarmonicAsync(
+        string query,
+        int maxResults,
+        HarmonicMemoryConfig config,
+        CancellationToken cancellationToken)
+    {
+        var queryTokens = Tokenize(query);
+        if (queryTokens.Count == 0)
+            return [];
+
+        var nodes = await GetScopedTrustedMemoryNodesAsync(cancellationToken);
+
+        // Order by score, then by id — the id tiebreak keeps recall deterministic regardless of the graph
+        // backend's node enumeration order (GetAllNodesAsync is not order-guaranteed), so the same query
+        // returns the same facts run-to-run.
+        var seeds = nodes
+            .Select(n => (Node: n, Score: HarmonicMatchScore(queryTokens, n)))
+            .Where(x => x.Score > 0)
+            .OrderByDescending(x => x.Score)
+            .ThenBy(x => x.Node.Id, StringComparer.Ordinal)
+            .Take(maxResults)
+            .Select(x => x.Node)
+            .ToList();
+
+        if (seeds.Count == 0)
+            return seeds;
+
+        var neighbors = ExpandSharedCueAnchors(seeds, nodes, config.RecallCueAnchorFanout);
+
+        // Seeds first (higher rank in the fused ranking), then the cluster neighbors they anchored.
+        return seeds.Concat(neighbors).ToList();
+    }
+
+    /// <summary>
+    /// Scores a node against the query as the maximum of its abstraction-token overlap and its
+    /// cue-anchor-token overlap — a hit on either indexed field surfaces the node, matching Memora's joint
+    /// abstraction+cue match. Zero when the node carries neither (which excludes it from recall).
+    /// </summary>
+    private static double HarmonicMatchScore(HashSet<string> queryTokens, GraphNode node)
+    {
+        var abstraction = node.GetAbstraction();
+        var abstractionScore = abstraction is null
+            ? 0.0
+            : TokenOverlap(queryTokens, Tokenize(abstraction));
+
+        var cueAnchors = node.GetCueAnchors();
+        var cueScore = cueAnchors.Count == 0
+            ? 0.0
+            : TokenOverlap(queryTokens, Tokenize(string.Join(' ', cueAnchors)));
+
+        return Math.Max(abstractionScore, cueScore);
+    }
+
+    /// <summary>
+    /// Expands the seed set with other pool nodes that share at least one cue anchor with a seed — the
+    /// implicit memory graph, where a shared <c>[Entity]+[Aspect]</c> anchor is an edge. Bounded by
+    /// <paramref name="fanout"/> to keep the returned cluster focused; anchors are matched case-insensitively
+    /// as whole phrases (matching how the write path dedupes them). Seeds themselves are never re-included.
+    /// </summary>
+    private static IReadOnlyList<GraphNode> ExpandSharedCueAnchors(
+        IReadOnlyList<GraphNode> seeds,
+        IReadOnlyList<GraphNode> pool,
+        int fanout)
+    {
+        if (fanout <= 0)
+            return [];
+
+        var seedIds = seeds.Select(s => s.Id).ToHashSet(StringComparer.Ordinal);
+        var seedAnchors = seeds
+            .SelectMany(s => s.GetCueAnchors())
+            .Select(NormalizeAnchor)
+            .Where(a => a.Length > 0)
+            .ToHashSet(StringComparer.Ordinal);
+        if (seedAnchors.Count == 0)
+            return [];
+
+        return pool
+            .Where(n => !seedIds.Contains(n.Id))
+            .Where(n => n.GetCueAnchors().Any(a => seedAnchors.Contains(NormalizeAnchor(a))))
+            // Deterministic id ordering before the fan-out cap, so which neighbors survive does not depend on
+            // the graph backend's node enumeration order.
+            .OrderBy(n => n.Id, StringComparer.Ordinal)
+            .Take(fanout)
+            .ToList();
+    }
+
+    /// <summary>Normalizes a cue anchor for case-insensitive whole-phrase comparison (trim + lowercase).</summary>
+    private static string NormalizeAnchor(string anchor) => anchor.Trim().ToLowerInvariant();
+}

--- a/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/Memory/KnowledgeMemoryService.Harmonic.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/Memory/KnowledgeMemoryService.Harmonic.cs
@@ -146,16 +146,14 @@ public sealed partial class KnowledgeMemoryService
 
     /// <summary>
     /// Retrieves this scope's harmonic memory nodes whose abstraction overlaps the candidate's, ranked by
-    /// token overlap, top-K. Reuses the scope-filtered <see cref="IKnowledgeGraphStore.GetAllNodesAsync"/>
-    /// (the tenant-isolating decorator filters it to the caller's visible nodes) and additionally restricts
-    /// to this scope's <c>memory:</c> nodes — excluding the node the current key itself would write to — so
-    /// consolidation never considers corpus entities, another scope's memory, or the fact being written.
+    /// token overlap, top-K. Excludes the node the current key itself would write to, so consolidation never
+    /// considers the fact being written.
     /// </summary>
     /// <remarks>
-    /// Ranking is deliberately lightweight (token-overlap, no embeddings) — semantic embedding-based recall
-    /// is the PR3 read-path concern. The full-scan is O(n) over the visible graph; acceptable at template
-    /// scale, and a follow-up would add an abstraction-indexed query primitive for large backends (the same
-    /// caveat carried by <c>GetNodeCountAsync</c> and the retention scan).
+    /// Ranking is deliberately lightweight (token-overlap, no embeddings) — a benchmark on this codebase
+    /// found embedding-based semantic matching adds negligible recall over lexical overlap for this workload.
+    /// The candidate pool comes from <see cref="GetScopedTrustedMemoryNodesAsync"/> (an O(n) visible-graph
+    /// scan; see its remarks).
     /// </remarks>
     private async Task<IReadOnlyList<GraphNode>> FindConsolidationCandidatesAsync(
         string candidateAbstraction,
@@ -163,26 +161,50 @@ public sealed partial class KnowledgeMemoryService
         int topK,
         CancellationToken cancellationToken)
     {
-        var all = await _graphStore.GetAllNodesAsync(cancellationToken);
-        var scopePrefix = $"memory:{ScopeKey()}:";
-        var selfId = MemoryNodeId(currentKey);
         var candidateTokens = Tokenize(candidateAbstraction);
         if (candidateTokens.Count == 0)
             return [];
 
-        return all
-            .Where(n => n.Id.StartsWith(scopePrefix, StringComparison.Ordinal) && n.Id != selfId)
-            // Quarantined entries are never served to recall; likewise they are never offered to the
-            // consolidator LLM, so untrusted content and its metadata cannot ride onto a trusted fact.
-            // (Quarantined facts also carry no abstraction, but this mirrors IsRecallable as defense-in-depth.)
-            .Where(n => n.GetTrust() == MemoryTrust.Trusted)
-            .Select(n => (Node: n, Abstraction: n.GetAbstraction()))
-            .Where(x => x.Abstraction is not null)
-            .Select(x => (x.Node, Score: TokenOverlap(candidateTokens, Tokenize(x.Abstraction!))))
+        var selfId = MemoryNodeId(currentKey);
+        var nodes = await GetScopedTrustedMemoryNodesAsync(cancellationToken);
+
+        return nodes
+            .Where(n => n.Id != selfId)
+            .Select(n => (Node: n, Score: TokenOverlap(candidateTokens, Tokenize(n.GetAbstraction()!))))
             .Where(x => x.Score > 0)
             .OrderByDescending(x => x.Score)
+            // Id tiebreak keeps candidate selection deterministic regardless of GetAllNodesAsync order.
+            .ThenBy(x => x.Node.Id, StringComparer.Ordinal)
             .Take(topK)
             .Select(x => x.Node)
+            .ToList();
+    }
+
+    /// <summary>
+    /// Retrieves this scope's recallable harmonic memory nodes — the shared candidate pool for both
+    /// consolidation (write) and harmonic recall (read). Reuses the scope-filtered
+    /// <see cref="IKnowledgeGraphStore.GetAllNodesAsync"/> (the tenant-isolating decorator filters it to the
+    /// caller's visible nodes) and additionally restricts to this scope's <c>memory:</c> nodes that are
+    /// trusted and carry an abstraction, so corpus entities, another scope's memory, quarantined facts, and
+    /// legacy/off nodes are all excluded.
+    /// </summary>
+    /// <remarks>
+    /// Quarantined (untrusted) entries are never served to recall and never offered to the consolidator LLM,
+    /// so untrusted content and its metadata cannot ride onto a trusted fact — the trust filter here mirrors
+    /// <see cref="IsRecallable"/> as defense-in-depth. The full scan is O(n) over the visible graph;
+    /// acceptable at template scale, and a follow-up would add an abstraction-indexed query primitive for
+    /// large backends (the same caveat carried by <c>GetNodeCountAsync</c> and the retention scan). Recall is
+    /// a hotter path than write, so that primitive is the primary scaling lever if node counts grow.
+    /// </remarks>
+    private async Task<IReadOnlyList<GraphNode>> GetScopedTrustedMemoryNodesAsync(CancellationToken cancellationToken)
+    {
+        var all = await _graphStore.GetAllNodesAsync(cancellationToken);
+        var scopePrefix = $"memory:{ScopeKey()}:";
+
+        return all
+            .Where(n => n.Id.StartsWith(scopePrefix, StringComparison.Ordinal))
+            .Where(n => n.GetTrust() == MemoryTrust.Trusted)
+            .Where(n => n.GetAbstraction() is not null)
             .ToList();
     }
 

--- a/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/Memory/KnowledgeMemoryService.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/Memory/KnowledgeMemoryService.cs
@@ -194,10 +194,31 @@ public sealed partial class KnowledgeMemoryService : IKnowledgeMemory
         int maxResults = 5,
         CancellationToken cancellationToken = default)
     {
-        // RecallAsync is the single chokepoint that enforces "quarantined facts are never served":
-        // both sources are passed through IsRecallable here, so the trust invariant lives in one
-        // place and cannot be bypassed by a future read path or a stray cache insertion.
+        // Dispatch on the harmonic memory mode, mirroring the write path. Off (the default) is the legacy
+        // substring/graph recall, byte-for-byte. Above Off, recall additionally matches the query against
+        // the primary abstraction + cue anchors the write path stamped on each node, and fuses that with the
+        // legacy list (see RecallHarmonicFusedAsync). Both paths funnel through IsRecallable, so the
+        // "quarantined facts are never served" invariant holds regardless of mode.
+        var harmonic = _configMonitor.CurrentValue.AI.HarmonicMemory;
+        if (harmonic.Mode != HarmonicMemoryMode.Off)
+            return await RecallHarmonicFusedAsync(query, maxResults, harmonic, cancellationToken);
 
+        return await RecallLegacyAsync(query, maxResults, cancellationToken);
+    }
+
+    /// <summary>
+    /// The legacy two-source recall path: session cache first (fast substring), then a full graph traversal.
+    /// Unchanged from before harmonic memory existed; this is exactly what runs when
+    /// <c>HarmonicMemoryMode.Off</c> (the default), and it is also reused as the legacy input to harmonic
+    /// fusion. RecallAsync is the single chokepoint that enforces "quarantined facts are never served": both
+    /// sources are passed through <see cref="IsRecallable"/> here, so the trust invariant lives in one place
+    /// and cannot be bypassed by a future read path or a stray cache insertion.
+    /// </summary>
+    private async Task<IReadOnlyList<GraphNode>> RecallLegacyAsync(
+        string query,
+        int maxResults,
+        CancellationToken cancellationToken)
+    {
         // Source 1: Session cache (fast, sub-millisecond)
         var cached = _sessionCache.Search(query, maxResults).Where(IsRecallable).ToList();
         if (cached.Count >= maxResults)

--- a/src/Content/Infrastructure/Infrastructure.AI.RAG/Retrieval/HybridRetriever.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.RAG/Retrieval/HybridRetriever.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using Application.AI.Common.Interfaces.RAG;
 using Domain.AI.RAG.Models;
+using Domain.AI.Retrieval;
 using Domain.Common.Config;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -139,50 +140,31 @@ public sealed class HybridRetriever : IHybridRetriever
         }
     }
 
+    /// <summary>
+    /// Fuses the dense and sparse result lists with Reciprocal Rank Fusion (via the shared
+    /// <see cref="ReciprocalRankFusion"/> primitive), then reconstructs each fused hit's per-source scores:
+    /// the dense score from the dense list's contribution and the sparse score from the sparse list's. Chunks
+    /// are matched across the two lists by <see cref="DocumentChunk.Id"/>.
+    /// </summary>
     private static IReadOnlyList<RetrievalResult> ApplyReciprocalRankFusion(
         IReadOnlyList<RetrievalResult> denseResults,
         IReadOnlyList<RetrievalResult> sparseResults,
         double rrfK,
         int topK)
     {
-        var chunkScores = new Dictionary<string, (DocumentChunk Chunk, double DenseScore, double SparseScore, double FusedScore)>();
+        var fused = ReciprocalRankFusion.Fuse(
+            [denseResults, sparseResults],
+            static r => r.Chunk.Id,
+            rrfK,
+            topK);
 
-        for (var rank = 0; rank < denseResults.Count; rank++)
-        {
-            var result = denseResults[rank];
-            var rrfScore = 1.0 / (rrfK + rank + 1);
-
-            chunkScores[result.Chunk.Id] = (result.Chunk, result.DenseScore, 0.0, rrfScore);
-        }
-
-        for (var rank = 0; rank < sparseResults.Count; rank++)
-        {
-            var result = sparseResults[rank];
-            var rrfScore = 1.0 / (rrfK + rank + 1);
-
-            if (chunkScores.TryGetValue(result.Chunk.Id, out var existing))
+        return fused
+            .Select(f => new RetrievalResult
             {
-                chunkScores[result.Chunk.Id] = (
-                    existing.Chunk,
-                    existing.DenseScore,
-                    result.SparseScore,
-                    existing.FusedScore + rrfScore);
-            }
-            else
-            {
-                chunkScores[result.Chunk.Id] = (result.Chunk, 0.0, result.SparseScore, rrfScore);
-            }
-        }
-
-        return chunkScores.Values
-            .OrderByDescending(s => s.FusedScore)
-            .Take(topK)
-            .Select(s => new RetrievalResult
-            {
-                Chunk = s.Chunk,
-                DenseScore = s.DenseScore,
-                SparseScore = s.SparseScore,
-                FusedScore = s.FusedScore,
+                Chunk = f.Item.Chunk,
+                DenseScore = f.PerListItems[0]?.DenseScore ?? 0.0,
+                SparseScore = f.PerListItems[1]?.SparseScore ?? 0.0,
+                FusedScore = f.Score,
             })
             .ToList();
     }

--- a/src/Content/Tests/Application.Core.Tests/Validation/HarmonicMemoryConfigValidatorTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/Validation/HarmonicMemoryConfigValidatorTests.cs
@@ -55,6 +55,35 @@ public sealed class HarmonicMemoryConfigValidatorTests
     }
 
     [Fact]
+    public void Validate_NegativeRecallCueAnchorFanout_Fails()
+    {
+        var result = _sut.Validate(new HarmonicMemoryConfig { RecallCueAnchorFanout = -1 });
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(HarmonicMemoryConfig.RecallCueAnchorFanout));
+    }
+
+    [Fact]
+    public void Validate_ZeroRecallCueAnchorFanout_Passes()
+    {
+        // Zero is valid — it disables shared-anchor traversal (direct matches only).
+        var result = _sut.Validate(new HarmonicMemoryConfig { RecallCueAnchorFanout = 0 });
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void Validate_NonPositiveRecallRrfK_Fails(double rrfK)
+    {
+        var result = _sut.Validate(new HarmonicMemoryConfig { RecallRrfK = rrfK });
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(HarmonicMemoryConfig.RecallRrfK));
+    }
+
+    [Fact]
     public void Validate_BatchAtSessionFlushTrue_Fails()
     {
         // The flag is not supported in this build (no session-flush seam to defer into). It must fail

--- a/src/Content/Tests/Domain.AI.Tests/Retrieval/ReciprocalRankFusionTests.cs
+++ b/src/Content/Tests/Domain.AI.Tests/Retrieval/ReciprocalRankFusionTests.cs
@@ -1,0 +1,138 @@
+using Domain.AI.Retrieval;
+using FluentAssertions;
+using Xunit;
+
+namespace Domain.AI.Tests.Retrieval;
+
+/// <summary>
+/// Tests for the generic <see cref="ReciprocalRankFusion"/> primitive: cross-list fusion, deterministic
+/// ordering, per-list contribution tracking, the topK cap, and argument validation.
+/// </summary>
+public sealed class ReciprocalRankFusionTests
+{
+    private sealed record Item(string Key, string Payload);
+
+    private static IReadOnlyList<Item> List(params string[] keys) =>
+        keys.Select(k => new Item(k, k)).ToList();
+
+    [Fact]
+    public void SingleList_PreservesOrder_ScoresDecreaseByRank()
+    {
+        var fused = ReciprocalRankFusion.Fuse([List("a", "b", "c")], static i => i.Key);
+
+        fused.Select(f => f.Item.Key).Should().Equal("a", "b", "c");
+        fused.Select(f => f.Score).Should().BeInDescendingOrder();
+    }
+
+    [Fact]
+    public void SharedItem_SumsContributions_AndRanksAboveSingletons()
+    {
+        // "shared" appears at rank 0 in both lists, so its summed RRF score (two rank-0 contributions) beats
+        // any item that appears in only one list.
+        var listA = List("shared", "x", "y");
+        var listB = List("shared", "p", "q");
+
+        var fused = ReciprocalRankFusion.Fuse([listA, listB], static i => i.Key, k: 1.0);
+
+        fused[0].Item.Key.Should().Be("shared", "an item found by both lists outranks any single-list hit");
+        fused[0].Score.Should().BeApproximately((1.0 / (1 + 0 + 1)) * 2, 1e-9);
+    }
+
+    [Fact]
+    public void PerListItems_TracksContributionPositionally()
+    {
+        var dense = new[] { new Item("shared", "from-dense"), new Item("d-only", "d") };
+        var sparse = new[] { new Item("s-only", "s"), new Item("shared", "from-sparse") };
+
+        var fused = ReciprocalRankFusion.Fuse([dense, sparse], static i => i.Key);
+
+        var shared = fused.Single(f => f.Item.Key == "shared");
+        shared.PerListItems.Should().HaveCount(2);
+        shared.PerListItems[0]!.Payload.Should().Be("from-dense", "list 0's contribution is kept at index 0");
+        shared.PerListItems[1]!.Payload.Should().Be("from-sparse", "list 1's contribution is kept at index 1");
+
+        var dOnly = fused.Single(f => f.Item.Key == "d-only");
+        dOnly.PerListItems[0].Should().NotBeNull();
+        dOnly.PerListItems[1].Should().BeNull("d-only never appeared in list 1");
+    }
+
+    [Fact]
+    public void Representative_IsFromEarliestList()
+    {
+        var listA = new[] { new Item("shared", "A") };
+        var listB = new[] { new Item("shared", "B") };
+
+        var fused = ReciprocalRankFusion.Fuse([listA, listB], static i => i.Key);
+
+        fused.Single().Item.Payload.Should().Be("A", "the representative is the earliest list's item");
+    }
+
+    [Fact]
+    public void EqualScores_BreakTiesByFirstAppearance_Deterministic()
+    {
+        // Two disjoint items both at rank 0 of their own list have identical scores; the one seen first
+        // (list 0) must sort first, every time.
+        var fused = ReciprocalRankFusion.Fuse([List("first"), List("second")], static i => i.Key);
+
+        fused.Select(f => f.Item.Key).Should().Equal("first", "second");
+        fused[0].Score.Should().BeApproximately(fused[1].Score, 1e-9, "the two singletons tie on score");
+    }
+
+    [Fact]
+    public void DuplicateKeyWithinList_CountedOnceAtBestRank()
+    {
+        // "dup" appears twice in the same list (rank 0 and rank 2). Its contribution must be counted once,
+        // at its best (rank 0) score — summing both occurrences would inflate its fused score.
+        var list = new[] { new Item("dup", "first"), new Item("x", "x"), new Item("dup", "second") };
+
+        var fused = ReciprocalRankFusion.Fuse([list], static i => i.Key, k: 1.0);
+
+        fused.Should().HaveCount(2, "the duplicate key collapses to a single fused entry");
+        var dup = fused.Single(f => f.Item.Key == "dup");
+        dup.Score.Should().BeApproximately(1.0 / (1 + 0 + 1), 1e-9, "counted once at its best rank, not summed");
+        dup.Item.Payload.Should().Be("first", "the representative is the best-rank (first-seen) occurrence");
+    }
+
+    [Fact]
+    public void TopK_CapsResults()
+    {
+        var fused = ReciprocalRankFusion.Fuse([List("a", "b", "c", "d")], static i => i.Key, topK: 2);
+
+        fused.Should().HaveCount(2);
+        fused.Select(f => f.Item.Key).Should().Equal("a", "b");
+    }
+
+    [Fact]
+    public void EmptyLists_ReturnEmpty()
+    {
+        var fused = ReciprocalRankFusion.Fuse<Item>([[], []], static i => i.Key);
+
+        fused.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void NonPositiveK_Throws()
+    {
+        var act = () => ReciprocalRankFusion.Fuse([List("a")], static i => i.Key, k: 0);
+
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Fact]
+    public void NegativeTopK_Throws()
+    {
+        var act = () => ReciprocalRankFusion.Fuse([List("a")], static i => i.Key, topK: -1);
+
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Fact]
+    public void NullArguments_Throw()
+    {
+        var nullLists = () => ReciprocalRankFusion.Fuse(null!, static (Item i) => i.Key);
+        var nullSelector = () => ReciprocalRankFusion.Fuse([List("a")], null!);
+
+        nullLists.Should().Throw<ArgumentNullException>();
+        nullSelector.Should().Throw<ArgumentNullException>();
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.KnowledgeGraph.Tests/Memory/KnowledgeMemoryServiceHarmonicRecallTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.KnowledgeGraph.Tests/Memory/KnowledgeMemoryServiceHarmonicRecallTests.cs
@@ -1,0 +1,226 @@
+using Application.AI.Common.Interfaces.KnowledgeGraph;
+using Domain.AI.KnowledgeGraph.Models;
+using Domain.Common.Config;
+using Domain.Common.Config.AI;
+using Domain.Common.Config.AI.HarmonicMemory;
+using Domain.Common.Config.AI.RAG;
+using FluentAssertions;
+using Infrastructure.AI.KnowledgeGraph.InMemory;
+using Infrastructure.AI.KnowledgeGraph.Memory;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Infrastructure.AI.KnowledgeGraph.Tests.Memory;
+
+/// <summary>
+/// Tests for the harmonic memory (Memora port) recall path of <see cref="KnowledgeMemoryService"/>: matching
+/// the query against the primary abstraction + cue anchors, shared-cue-anchor cluster traversal, RRF fusion
+/// with the legacy substring/graph path, and preservation of the trust + scope-isolation guarantees on read.
+/// </summary>
+public sealed class KnowledgeMemoryServiceHarmonicRecallTests
+{
+    private readonly InMemoryGraphStore _graphStore = new(NullLogger<InMemoryGraphStore>.Instance);
+
+    private const string DefaultNs = "memory:default:anon";
+
+    [Fact]
+    public async Task CueAnchorHit_HarmonicSurfacesNode_LegacyMisses()
+    {
+        // The node's name/type carry nothing about "vegetarian" — only its cue anchor does. The legacy
+        // substring path (Off) matches name/type and misses it; harmonic recall matches the cue anchor.
+        await SeedMemoryNodeAsync($"{DefaultNs}:pref-1", "pref-1", "The user is vegetarian",
+            new MemoryAbstraction { Abstraction = "user dietary preference", CueAnchors = ["vegetarian diet"] });
+
+        var offResult = await CreateService(ConfigWith(HarmonicMemoryMode.Off)).RecallAsync("vegetarian");
+        offResult.Should().BeEmpty("the legacy path matches only node name/type, which carry no cue anchor");
+
+        var harmonicResult = await CreateService(ConfigWith(HarmonicMemoryMode.AbstractOnly)).RecallAsync("vegetarian");
+        harmonicResult.Should().ContainSingle(n => n.Id == $"{DefaultNs}:pref-1",
+            "harmonic recall matches the query against the indexed cue anchors the legacy path ignores");
+    }
+
+    [Fact]
+    public async Task AbstractionHit_HarmonicSurfacesNode()
+    {
+        await SeedMemoryNodeAsync($"{DefaultNs}:orion-1", "orion-1", "Milestone one shipped",
+            new MemoryAbstraction { Abstraction = "Project Orion timeline" });
+
+        var result = await CreateService(ConfigWith(HarmonicMemoryMode.AbstractOnly)).RecallAsync("timeline");
+
+        result.Should().ContainSingle(n => n.Id == $"{DefaultNs}:orion-1",
+            "the query token overlaps the primary abstraction");
+    }
+
+    [Fact]
+    public async Task SharedCueAnchor_Traversal_ReturnsCoherentCluster()
+    {
+        // A directly matches the query; B does not, but shares a cue anchor with A, so the shared-anchor
+        // traversal pulls B into the returned cluster.
+        await SeedMemoryNodeAsync($"{DefaultNs}:a", "a", "timeline notes",
+            new MemoryAbstraction { Abstraction = "Project Orion timeline", CueAnchors = ["Orion project"] });
+        await SeedMemoryNodeAsync($"{DefaultNs}:b", "b", "budget figures",
+            new MemoryAbstraction { Abstraction = "quarterly budget", CueAnchors = ["Orion project"] });
+
+        var result = await CreateService(ConfigWith(HarmonicMemoryMode.Full)).RecallAsync("timeline");
+
+        result.Should().Contain(n => n.Id == $"{DefaultNs}:a", "A is a direct abstraction hit");
+        result.Should().Contain(n => n.Id == $"{DefaultNs}:b",
+            "B shares the 'Orion project' cue anchor with A, so traversal surfaces the cluster");
+    }
+
+    [Fact]
+    public async Task Traversal_FanoutZero_ReturnsOnlyDirectMatches()
+    {
+        await SeedMemoryNodeAsync($"{DefaultNs}:a", "a", "timeline notes",
+            new MemoryAbstraction { Abstraction = "Project Orion timeline", CueAnchors = ["Orion project"] });
+        await SeedMemoryNodeAsync($"{DefaultNs}:b", "b", "budget figures",
+            new MemoryAbstraction { Abstraction = "quarterly budget", CueAnchors = ["Orion project"] });
+
+        var result = await CreateService(ConfigWith(HarmonicMemoryMode.Full, fanout: 0)).RecallAsync("timeline");
+
+        result.Should().Contain(n => n.Id == $"{DefaultNs}:a");
+        result.Should().NotContain(n => n.Id == $"{DefaultNs}:b",
+            "fanout 0 disables shared-anchor traversal, so only the direct match is returned");
+    }
+
+    [Fact]
+    public async Task RrfFusion_CombinesHarmonicAndLegacyHits()
+    {
+        // X is found only by the legacy path (its key equals the query term); Y is found only by harmonic
+        // (its cue anchor carries the query token). Fusion must return both.
+        await SeedMemoryNodeAsync($"{DefaultNs}:orion", "orion", "the orion fact",
+            new MemoryAbstraction { Abstraction = "cloud infrastructure" });
+        await SeedMemoryNodeAsync($"{DefaultNs}:fan", "fan", "a fan note",
+            new MemoryAbstraction { Abstraction = "personal note", CueAnchors = ["orion enthusiast"] });
+
+        var result = await CreateService(ConfigWith(HarmonicMemoryMode.Full)).RecallAsync("orion");
+
+        result.Should().Contain(n => n.Id == $"{DefaultNs}:orion", "X is a legacy direct-key hit");
+        result.Should().Contain(n => n.Id == $"{DefaultNs}:fan", "Y is a harmonic cue-anchor hit");
+    }
+
+    [Fact]
+    public async Task ScoreTie_LegacyHitWins_NotDroppedByHarmonicOnlyMatch()
+    {
+        // A legacy-only hit (found by direct key lookup, carries no abstraction) and a harmonic-only hit
+        // (matched via its abstraction) tie on fused score. With maxResults=1, the legacy hit — which Off
+        // mode would return — must survive; harmonic-only matches never displace a tying legacy result.
+        var legacyOnly = new GraphNode
+        {
+            Id = $"{DefaultNs}:orion",
+            Name = "orion",
+            Type = "Fact",
+            Properties = new Dictionary<string, string> { ["content"] = "the legacy orion fact" }
+        };
+        await _graphStore.AddNodesAsync([legacyOnly]);
+        await SeedMemoryNodeAsync($"{DefaultNs}:fan", "fan", "a fan note",
+            new MemoryAbstraction { Abstraction = "orion enthusiast" });
+
+        var result = await CreateService(ConfigWith(HarmonicMemoryMode.Full)).RecallAsync("orion", maxResults: 1);
+
+        result.Should().ContainSingle(n => n.Id == $"{DefaultNs}:orion",
+            "on a score tie the legacy path's hit is preserved, not displaced by a harmonic-only match");
+    }
+
+    [Fact]
+    public async Task QuarantinedNode_NeverSurfaces_EvenOnAbstractionMatch()
+    {
+        await SeedMemoryNodeAsync($"{DefaultNs}:evil", "evil", "poison payload",
+            new MemoryAbstraction { Abstraction = "exfiltration plan", CueAnchors = ["exfiltrate data"] },
+            MemoryTrust.Untrusted);
+
+        var result = await CreateService(ConfigWith(HarmonicMemoryMode.Full)).RecallAsync("exfiltrate");
+
+        result.Should().BeEmpty("a quarantined node is never served by recall, even when its abstraction matches");
+    }
+
+    [Fact]
+    public async Task OtherScopeNode_NotReturned_OnRecall()
+    {
+        // A node in another tenant/user scope with a matching abstraction must never cross the scope boundary.
+        await SeedMemoryNodeAsync("memory:tenant-x:user-y:secret", "secret", "someone else's fact",
+            new MemoryAbstraction { Abstraction = "Project Orion timeline" });
+
+        var result = await CreateService(ConfigWith(HarmonicMemoryMode.Full), new FakeScope()).RecallAsync("timeline");
+
+        result.Should().BeEmpty("harmonic recall is restricted to the caller's own scope namespace");
+    }
+
+    [Fact]
+    public async Task Off_DoesNotUseHarmonicScaffolding()
+    {
+        // Guards the byte-identical-legacy contract: with Mode Off, a node findable only via its abstraction
+        // is not surfaced — recall behaves exactly as it did before harmonic memory existed.
+        await SeedMemoryNodeAsync($"{DefaultNs}:pref-1", "pref-1", "The user is vegetarian",
+            new MemoryAbstraction { Abstraction = "user dietary preference", CueAnchors = ["vegetarian diet"] });
+
+        var result = await CreateService(ConfigWith(HarmonicMemoryMode.Off)).RecallAsync("dietary");
+
+        result.Should().BeEmpty("Off is the legacy path and never reads the abstraction/cue-anchor index");
+    }
+
+    // --- Helpers ---
+
+    private async Task SeedMemoryNodeAsync(
+        string id, string name, string content, MemoryAbstraction abstraction,
+        MemoryTrust trust = MemoryTrust.Trusted)
+    {
+        var node = new GraphNode
+        {
+            Id = id,
+            Name = name,
+            Type = "Fact",
+            Properties = new Dictionary<string, string> { ["content"] = content }
+        }.WithAbstraction(abstraction);
+
+        if (trust == MemoryTrust.Untrusted)
+            node = node.WithTrust(MemoryTrust.Untrusted);
+
+        await _graphStore.AddNodesAsync([node]);
+    }
+
+    private KnowledgeMemoryService CreateService(AppConfig config, IKnowledgeScope? scope = null)
+    {
+        var monitor = new Mock<IOptionsMonitor<AppConfig>>();
+        monitor.Setup(m => m.CurrentValue).Returns(config);
+
+        return new KnowledgeMemoryService(
+            new InMemorySessionCache(),
+            _graphStore,
+            scope ?? new FakeScope(),
+            feedbackDetector: null,
+            feedbackStore: null,
+            monitor.Object,
+            NullLogger<KnowledgeMemoryService>.Instance,
+            writeGate: null,
+            abstractor: null,
+            consolidator: null);
+    }
+
+    private static AppConfig ConfigWith(HarmonicMemoryMode mode, int fanout = 3, double rrfK = 60.0) => new()
+    {
+        AI = new AIConfig
+        {
+            Rag = new RagConfig { GraphRag = new GraphRagConfig { FeedbackAlpha = 0.3 } },
+            HarmonicMemory = new HarmonicMemoryConfig
+            {
+                Mode = mode,
+                RecallCueAnchorFanout = fanout,
+                RecallRrfK = rrfK
+            }
+        }
+    };
+
+    private sealed class FakeScope : IKnowledgeScope
+    {
+        public string? UserId { get; set; }
+        public string? TenantId { get; set; }
+        public string? DatasetId { get; set; }
+        public string? DatasetName { get; set; }
+        public string? DatasetOwnerId { get; set; }
+        public string? AgentId { get; set; }
+        public string? ConversationId { get; set; }
+    }
+}


### PR DESCRIPTION
## What & why

PR3 of the harmonic memory (Memora port). PR2 stamps a **primary abstraction + cue anchors** on each trusted memory node, but the legacy recall (`SearchGraphAsync`) only substring-matches node name/type and **never reads them** — the write-side eval showed *zero* recall delta across modes because the scaffolding was inert. This PR makes recall consume it.

## Changes

- **Generic RRF** — new `Domain.AI/Retrieval/ReciprocalRankFusion.Fuse<T>` (pure, dependency-free): fuses N ranked lists with a deterministic first-appearance tiebreak; each list contributes **once per key at its best rank**. `HybridRetriever` migrated onto it, replacing its private RAG-coupled copy (one true RRF). RAG suite (217) confirms the migration is behavior-preserving.
- **Harmonic recall** — `RecallAsync` now dispatches on `HarmonicMemory.Mode`, mirroring the write path:
  - `Off` = **byte-identical legacy recall** (guarded).
  - Above `Off`: lexical query→abstraction/cue-anchor match over scope-filtered **trusted** nodes → bounded **shared-cue-anchor** cluster traversal (Memora's implicit graph) → **RRF-fused** with the legacy list. Legacy is fused first, so it wins ties and is never displaced by a merely-tying harmonic hit.
- **Lexical, no LLM on the recall hot path** — the paid eval found semantic/embedding matching adds negligible recall over token overlap for this workload (Option A abandoned). Recall runs per turn; it stays cheap.
- **Deterministic** ordering (Ordinal id tiebreaks on seeds/traversal/candidate scan) so recall does not depend on `GetAllNodesAsync` enumeration order.
- **Config** — new `RecallCueAnchorFanout` (3) / `RecallRrfK` (60) knobs + validator rules.
- **Shared pool** — `GetScopedTrustedMemoryNodesAsync` reused by write consolidation and read recall.

## Scope boundaries
- O(n) recall scan **accepted** per plan (abstraction-indexed primitive is a deferred follow-up; flagged as the primary scaling lever).
- Episodic grounding (factual→episodic cross-link) **split to PR3b** — it needs a write-side change and the greenlight was for recall+RRF specifically.

## Review
`/code-review` (high) found **3 confirmed correctness findings, all fixed**: (1) RRF tie-break dropped legacy hits → fuse legacy-first; (2) non-deterministic seed/traversal → id tiebreaks; (3) generic RRF double-counted intra-list duplicate keys → count once at best rank. `/simplify` clean (code improves reuse; one log-wording fix). Both receipts recorded.

## Tests
Build 0 warnings. RRF **11**, harmonic write+recall **26**, validator **14**, RAG **217** (migration equivalence). Neo4j/Postgres integration tests need Docker (green in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)