### PR TITLE
docs: document harmonic memory (reference, onboarding, architecture)

### DIFF
--- a/documentation/architecture/03-data-and-retrieval.html
+++ b/documentation/architecture/03-data-and-retrieval.html
@@ -245,6 +245,14 @@
                         <li>
                             <strong>Feedback weights</strong> &mdash; historical retrieval quality scores per node/edge
                         </li>
+                        <li>
+                            <strong>Harmonic scaffolding</strong> &mdash; when harmonic memory is enabled, each trusted
+                            memory node also carries a <strong>primary abstraction</strong> and <strong>cue anchors</strong>
+                            (short entity+aspect phrases) in its properties. On write, related facts can consolidate onto
+                            a shared abstraction (topic-adoption, not physical merge); on read, the query matches those
+                            fields and the result is fused with legacy recall. Off by default
+                            (<code>AppConfig:AI:HarmonicMemory:Mode</code>).
+                        </li>
                     </ul>
 
                     <h3 id="knowledge-graph-data-flow">Knowledge graph data flow</h3>

--- a/documentation/onboarding/07-rag.html
+++ b/documentation/onboarding/07-rag.html
@@ -322,6 +322,14 @@ Cite chunk IDs in the format [doc:chunk-id] when quoting passages.</code></pre>
                             decay tiers (CRITICAL / STANDARD / EPHEMERAL).
                         </li>
                         <li>
+                            <strong>Harmonic memory</strong> (opt-in, Memora-style) — indexes a lightweight
+                            <em>abstraction</em> + <em>cue-anchor</em> scaffolding over each remembered fact so recall
+                            matches on meaning and topic, not just literal text, and related facts cluster together.
+                            Recall fuses those matches with the legacy path via Reciprocal Rank Fusion. Gated behind
+                            <code>AppConfig:AI:HarmonicMemory:Mode</code> (<code>Off</code> by default — it costs an LLM
+                            call per write); <code>Off</code> is the unchanged legacy behavior.
+                        </li>
+                        <li>
                             <strong>Provenance + compliance</strong> — <code>DefaultProvenanceStamper</code> tags every
                             node and edge with source, pipeline, and timestamp. <code>ComplianceAwareGraphStore</code>
                             enforces retention; <code>DefaultErasureOrchestrator</code> handles right-to-erasure with

--- a/documentation/reference/patterns-and-technologies.html
+++ b/documentation/reference/patterns-and-technologies.html
@@ -697,6 +697,37 @@ return quality.MaxScore switch
                         <li><code>Infrastructure.AI.RAG/GraphRag/CrossSessionMemoryStore.cs</code></li>
                     </ul>
 
+                    <h3 id="harmonic-memory">Harmonic memory — abstraction + cue-anchor recall</h3>
+                    <p>
+                        A representation layer over cross-session memory, modeled on Microsoft Research's
+                        <strong>Memora</strong>. Instead of remembering only the raw fact, each trusted fact also gets a
+                        lightweight <em>scaffolding</em>: a <strong>primary abstraction</strong> (a canonical "what is
+                        this memory about" summary) and one to three <strong>cue anchors</strong> (short
+                        <code>[Entity] + [Aspect]</code> phrases). Facts that share a cue anchor form an implicit graph,
+                        so related memories cluster without any explicit edge-building. The raw value is always kept
+                        verbatim — the scaffolding is indexed <em>over</em> it, never a lossy replacement.
+                    </p>
+                    <p>
+                        <strong>On write</strong> (<code>Full</code> mode) the service can consolidate: a new fact that
+                        matches a similar existing entry <em>adopts that entry's abstraction</em> so the two share one
+                        topic — a logical topic-adoption, not a physical merge, so every fact keeps its own key, content,
+                        and trust marker. <strong>On read</strong>, the query is matched against the abstractions and cue
+                        anchors, the shared-anchor cluster around the best hits is pulled in, and that ranking is fused
+                        with the legacy substring/graph recall via <strong>Reciprocal Rank Fusion</strong>. Matching is
+                        lexical — no LLM on the recall path. The whole layer is a graduated, off-by-default toggle
+                        (<code>Off</code> / <code>AbstractOnly</code> / <code>Full</code> under
+                        <code>AppConfig:AI:HarmonicMemory</code>) because abstraction costs one to two LLM calls per
+                        write; <code>Off</code> is the byte-identical legacy path. The abstractor and consolidator ship as
+                        <code>NotConfigured</code> seams — the consumer supplies the agent-backed implementations.
+                    </p>
+                    <ul>
+                        <li><code>Memory/KnowledgeMemoryService.Harmonic.cs</code> — write path (abstraction + consolidation)</li>
+                        <li><code>Memory/KnowledgeMemoryService.Harmonic.Recall.cs</code> — cue-anchor recall + RRF fusion</li>
+                        <li><code>Domain.AI/Retrieval/ReciprocalRankFusion.cs</code> — generic RRF primitive (shared with hybrid RAG retrieval)</li>
+                        <li><code>Domain.AI/KnowledgeGraph/Models/GraphNodeMemoryExtensions.cs</code> — abstraction + cue anchors stored in node properties</li>
+                        <li><code>Domain.Common/Config/AI/HarmonicMemory/HarmonicMemoryConfig.cs</code> — the mode toggle + cost/recall knobs</li>
+                    </ul>
+
                     <h3 id="memory-decay">Memory decay tiers</h3>
                     <p>
                         Three tiers with configurable exponential half-lives: <strong>CRITICAL</strong> (never decay),


### PR DESCRIPTION
Documents the harmonic memory feature (shipped in #113–#117) across the three deployed doc sites an engineer or architect reads:

- **Reference** (`patterns-and-technologies.html`) — new *Harmonic memory* entry under Knowledge graph patterns: abstraction + cue-anchor scaffolding, on-write topic consolidation (logical adoption, not physical merge), lexical cue-anchor recall fused with legacy retrieval via RRF, off-by-default toggle, NotConfigured seams.
- **Onboarding** (`07-rag.html`) — a plain-language memory bullet in the Knowledge graph layer chapter.
- **Architecture** (`03-data-and-retrieval.html`) — harmonic scaffolding added to 'what the graph stores'.

Docs-only; sites are direct-edit HTML (no build step). Course site intentionally not touched (non-technical audience + fragment-rebuild overhead); security doc left as-is per review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)