### PR TITLE
fix: flow conversationId so skill prerequisites work on live path

### DIFF
--- a/src/Content/Application/Application.AI.Common/Services/AgentConversationCache.cs
+++ b/src/Content/Application/Application.AI.Common/Services/AgentConversationCache.cs
@@ -1,5 +1,7 @@
+using Application.AI.Common.Factories;
 using Application.AI.Common.Interfaces;
 using Application.AI.Common.Interfaces.Context;
+using Application.AI.Common.Interfaces.Skills;
 using Domain.AI.Agents;
 using Domain.AI.Skills;
 using Microsoft.Agents.AI;
@@ -16,6 +18,7 @@ internal sealed class AgentConversationCache : IAgentConversationCache
     private readonly IMemoryCache _cache;
     private readonly IAgentFactory _agentFactory;
     private readonly IConversationRegistrationTracker _registrationTracker;
+    private readonly ISkillCompletionTracker _completionTracker;
     private static readonly TimeSpan SlidingExpiration = TimeSpan.FromMinutes(30);
 
     private static string ContextCacheKey(string conversationId) => $"{conversationId}::context";
@@ -23,11 +26,13 @@ internal sealed class AgentConversationCache : IAgentConversationCache
     public AgentConversationCache(
         IMemoryCache cache,
         IAgentFactory agentFactory,
-        IConversationRegistrationTracker registrationTracker)
+        IConversationRegistrationTracker registrationTracker,
+        ISkillCompletionTracker completionTracker)
     {
         _cache = cache;
         _agentFactory = agentFactory;
         _registrationTracker = registrationTracker;
+        _completionTracker = completionTracker;
     }
 
     public async Task<AIAgent> GetOrCreateAsync(
@@ -39,8 +44,16 @@ internal sealed class AgentConversationCache : IAgentConversationCache
         if (_cache.TryGetValue(conversationId, out AIAgent? cached) && cached is not null)
             return cached;
 
+        // Flow the conversation id into the agent build so the skill-prerequisite middleware
+        // can scope completion tracking to this conversation. The factory reads it from
+        // SkillAgentOptions.AdditionalProperties[AgentFactory.ConversationIdPropertyKey] and
+        // throws when it is absent, so a skill declaring prerequisites would otherwise crash
+        // every turn on the live path. A scope-bearing copy is used so the caller's options
+        // instance is never mutated and cannot be cross-contaminated across conversations.
+        var scopedOptions = WithConversationScope(options, conversationId);
+
         var built = await _agentFactory.CreateAgentWithContextFromSkillsAsync(
-            skillIds, options, cancellationToken);
+            skillIds, scopedOptions, cancellationToken);
 
         var entryOptions = new MemoryCacheEntryOptions { SlidingExpiration = SlidingExpiration };
         _cache.Set(conversationId, built.Agent, entryOptions);
@@ -57,5 +70,36 @@ internal sealed class AgentConversationCache : IAgentConversationCache
         _cache.Remove(conversationId);
         _cache.Remove(ContextCacheKey(conversationId));
         _registrationTracker.Evict(conversationId);
+        // Clear skill-prerequisite completion state keyed by this conversation so a re-created
+        // conversation reusing the same id starts with no unlocked skills and no leaked entries.
+        _completionTracker.ClearConversation(conversationId);
+    }
+
+    /// <summary>
+    /// Returns a copy of <paramref name="options"/> carrying <paramref name="conversationId"/>
+    /// under <see cref="AgentFactory.ConversationIdPropertyKey"/> in its additional properties,
+    /// without mutating the caller-supplied instance or its dictionary.
+    /// </summary>
+    private static SkillAgentOptions WithConversationScope(SkillAgentOptions options, string conversationId)
+    {
+        var scopedProperties = options.AdditionalProperties is null
+            ? new Dictionary<string, object>()
+            : new Dictionary<string, object>(options.AdditionalProperties);
+        scopedProperties[AgentFactory.ConversationIdPropertyKey] = conversationId;
+
+        return new SkillAgentOptions
+        {
+            SkillPaths = options.SkillPaths,
+            AgentNameOverride = options.AgentNameOverride,
+            DeploymentName = options.DeploymentName,
+            AgentId = options.AgentId,
+            FrameworkType = options.FrameworkType,
+            AdditionalContext = options.AdditionalContext,
+            Temperature = options.Temperature,
+            AdditionalTools = options.AdditionalTools,
+            MiddlewareTypes = options.MiddlewareTypes,
+            AdditionalProperties = scopedProperties,
+            TraceScope = options.TraceScope
+        };
     }
 }

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/AgentConversationCacheTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/AgentConversationCacheTests.cs
@@ -1,0 +1,144 @@
+using Application.AI.Common.Factories;
+using Application.AI.Common.Interfaces;
+using Application.AI.Common.Interfaces.Skills;
+using Application.AI.Common.Services;
+using Application.AI.Common.Services.Context;
+using Application.AI.Common.Services.Skills;
+using Application.AI.Common.Services.Tools;
+using Application.AI.Common.Tests.Fakes;
+using Domain.AI.Skills;
+using Domain.Common.Config;
+using Domain.Common.Config.AI;
+using FluentAssertions;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Application.AI.Common.Tests.Services;
+
+/// <summary>
+/// Integration tests for <see cref="AgentConversationCache"/> exercising the LIVE agent-build
+/// path (real <see cref="AgentFactory"/> + real <see cref="AgentExecutionContextFactory"/>).
+/// </summary>
+/// <remarks>
+/// Regression coverage for the prerequisite-scope bug: a skill declaring <c>prerequisites</c>
+/// crashed on every conversation turn because <see cref="AgentFactory.ResolvePrerequisiteScope"/>
+/// requires a conversation id under <see cref="AgentFactory.ConversationIdPropertyKey"/> in the
+/// execution context, and nothing on the live path supplied it. The cache holds the
+/// <c>conversationId</c> and is the only component positioned to flow it into
+/// <see cref="SkillAgentOptions.AdditionalProperties"/> — these tests assert it does so WITHOUT
+/// the caller hand-setting the key, which is the exact production scenario.
+/// </remarks>
+public sealed class AgentConversationCacheTests
+{
+    private const string ValidateSkillId = "validate";
+    private const string DeploySkillId = "deploy";
+
+    private readonly InMemorySkillCompletionTracker _completionTracker = new();
+    private readonly ConversationRegistrationTracker _registrationTracker = new();
+    private readonly IMemoryCache _memoryCache = new MemoryCache(new MemoryCacheOptions());
+    private readonly AgentConversationCache _cache;
+
+    public AgentConversationCacheTests()
+    {
+        var appConfig = new AppConfig
+        {
+            AI = new AIConfig
+            {
+                AgentFramework = new AgentFrameworkConfig
+                {
+                    DefaultDeployment = "gpt-4o",
+                    ClientType = AIAgentFrameworkClientType.AzureOpenAI
+                }
+            }
+        };
+        var monitor = Mock.Of<IOptionsMonitor<AppConfig>>(m => m.CurrentValue == appConfig);
+        var services = new ServiceCollection().BuildServiceProvider();
+
+        var contextFactory = new AgentExecutionContextFactory(
+            NullLogger<AgentExecutionContextFactory>.Instance,
+            monitor,
+            services,
+            NullLoggerFactory.Instance,
+            new ToolChainBuilder(NullLogger<ToolChainBuilder>.Instance, services, null, null),
+            new SkillPrerequisiteResolver());
+
+        // Registry returns a two-skill graph where "deploy" depends on "validate".
+        var registry = new Mock<ISkillMetadataRegistry>();
+        registry.Setup(r => r.TryGet(ValidateSkillId)).Returns(new SkillDefinition
+        {
+            Id = ValidateSkillId,
+            Name = ValidateSkillId,
+            Instructions = "Validate."
+        });
+        registry.Setup(r => r.TryGet(DeploySkillId)).Returns(new SkillDefinition
+        {
+            Id = DeploySkillId,
+            Name = DeploySkillId,
+            Instructions = "Deploy.",
+            Prerequisites = new List<string> { ValidateSkillId }
+        });
+
+        var factory = new AgentFactory(
+            NullLogger<AgentFactory>.Instance,
+            monitor,
+            Mock.Of<IDistributedCache>(),
+            NullLoggerFactory.Instance,
+            contextFactory,
+            registry.Object,
+            new FakeChatClientFactory(),
+            services,
+            _completionTracker);
+
+        _cache = new AgentConversationCache(
+            _memoryCache, factory, _registrationTracker, _completionTracker);
+    }
+
+    [Fact]
+    public async Task GetOrCreateAsync_SkillWithPrerequisites_ResolvesScopeWithoutThrowing()
+    {
+        // Arrange — production shape: caller supplies NO conversationId in options.
+        var options = new SkillAgentOptions();
+
+        // Act — the cache must flow the conversationId into the agent build so the
+        // prerequisite middleware can resolve its scope.
+        var act = () => _cache.GetOrCreateAsync(
+            "conv-live-path", [ValidateSkillId, DeploySkillId], options);
+
+        // Assert — before the fix this throws InvalidOperationException ("no conversation scope").
+        var agent = await act.Should().NotThrowAsync();
+        agent.Subject.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task GetOrCreateAsync_DoesNotMutateCallerSuppliedOptions()
+    {
+        // Arrange — a shared options instance the caller may reuse for another conversation.
+        var options = new SkillAgentOptions();
+
+        // Act
+        await _cache.GetOrCreateAsync("conv-x", [ValidateSkillId, DeploySkillId], options);
+
+        // Assert — the cache injected the scope into a copy, never the caller's object.
+        options.AdditionalProperties.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Evict_ClearsPrerequisiteCompletionState()
+    {
+        // Arrange — build the agent, then record a completion under the same scope.
+        await _cache.GetOrCreateAsync("conv-evict", [ValidateSkillId, DeploySkillId], new SkillAgentOptions());
+        _completionTracker.MarkCompleted("conv-evict", ValidateSkillId);
+        _completionTracker.IsCompleted("conv-evict", ValidateSkillId).Should().BeTrue();
+
+        // Act
+        _cache.Evict("conv-evict");
+
+        // Assert — a re-created conversation with the same id starts clean.
+        _completionTracker.IsCompleted("conv-evict", ValidateSkillId).Should().BeFalse();
+    }
+}


### PR DESCRIPTION
## Problem
Any skill declaring `prerequisites:` crashed on every conversation turn with "An internal error occurred". `AgentFactory.ResolvePrerequisiteScope` requires the conversation id under `AgentExecutionContext.AdditionalProperties[conversationId]` and throws when it is absent. On the live path (`AgentConversationCache.GetOrCreateAsync` → `CreateAgentWithContextFromSkillsAsync`) the cache held the `conversationId` but never flowed it into `SkillAgentOptions` — only tests ever set it, so the crash never surfaced in CI.

## Fix
- `AgentConversationCache.GetOrCreateAsync` now builds a scope-bearing **copy** of the options carrying `conversationId` under `AgentFactory.ConversationIdPropertyKey`; the caller's instance is never mutated (no cross-conversation contamination).
- `Evict` now clears the skill-prerequisite completion state keyed by the conversation so a re-created conversation with the same id starts clean.

## Test plan
New `AgentConversationCacheTests` exercise the LIVE agent-build path (real `AgentFactory` + `AgentExecutionContextFactory`, two-skill graph where `deploy` requires `validate`):
- `GetOrCreateAsync_SkillWithPrerequisites_ResolvesScopeWithoutThrowing` — caller supplies NO conversationId (the production shape); throws before the fix, passes after.
- `..._DoesNotMutateCallerSuppliedOptions` — caller's `AdditionalProperties` stays null.
- `Evict_ClearsPrerequisiteCompletionState`.

Full `Application.AI.Common.Tests`: 1299 passed, 0 failed.

## Review
Self-reviewed (correctness + simplify). One tracked, non-blocking follow-up: `WithConversationScope` copies the 11 options properties by hand and would silently drop a future new property — collapses to a one-line `with` when `SkillAgentOptions` becomes a record under the planned immutability item (G4).

Part of the Wave-1 "inert machinery" remediation from the deep audit.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>