### PR TITLE
fix: enforce plugin DeniedTools (wire plugin boundary governance)

### DIFF
--- a/src/Content/Application/Application.AI.Common/Services/Tools/ToolChainBuilder.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/ToolChainBuilder.cs
@@ -61,13 +61,7 @@ public class ToolChainBuilder : IToolChainBuilder
             if (options.AdditionalTools?.Count > 0)
                 tools.AddRange(options.AdditionalTools);
 
-            if (!string.IsNullOrEmpty(skill.PluginSource))
-            {
-                var pluginRegistry = _serviceProvider.GetService<IPluginRegistry>();
-                var loadedPlugin = pluginRegistry?.GetPlugin(skill.PluginSource);
-                if (loadedPlugin != null)
-                    tools = ApplyPluginToolBoundary(tools, loadedPlugin.Declaration);
-            }
+            tools = ApplyPluginBoundaryIfPluginSkill(skill, tools);
 
             _logger.LogInformation(
                 "Injected mode: skill {SkillId} from plugin {Plugin} received {Count} MCP tools",
@@ -104,8 +98,29 @@ public class ToolChainBuilder : IToolChainBuilder
         if (options.AdditionalTools?.Count > 0)
             tools.AddRange(options.AdditionalTools);
 
+        tools = ApplyPluginBoundaryIfPluginSkill(skill, tools);
+
         var seen2 = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         return WrapGoverned(tools.Where(t => seen2.Add(t.Name)));
+    }
+
+    /// <summary>
+    /// Applies the owning plugin's AllowedTools/DeniedTools boundary to <paramref name="tools"/>
+    /// whenever the skill is plugin-sourced and the plugin is loaded. This runs on both the
+    /// Injected and Managed resolution paths so a plugin's <c>DeniedTools</c> are enforced
+    /// regardless of how the skill resolves its tools. A no-op for built-in skills or when the
+    /// plugin registry is unavailable.
+    /// </summary>
+    private List<AITool> ApplyPluginBoundaryIfPluginSkill(SkillDefinition skill, List<AITool> tools)
+    {
+        if (string.IsNullOrEmpty(skill.PluginSource))
+            return tools;
+
+        var pluginRegistry = _serviceProvider.GetService<IPluginRegistry>();
+        var loadedPlugin = pluginRegistry?.GetPlugin(skill.PluginSource);
+        return loadedPlugin is null
+            ? tools
+            : ApplyPluginToolBoundary(tools, loadedPlugin.Declaration);
     }
 
     /// <summary>

--- a/src/Content/Application/Application.Core/Permissions/PluginPermissionRuleProvider.cs
+++ b/src/Content/Application/Application.Core/Permissions/PluginPermissionRuleProvider.cs
@@ -12,10 +12,12 @@ namespace Application.Core.Permissions;
 /// resolver alongside agent-level autonomy tier rules.
 /// </summary>
 /// <remarks>
-/// Each loaded plugin whose <c>AutonomyLevel</c> is set contributes one baseline rule
-/// scoped to <c>{pluginName}:*</c>. Any <c>DeniedTools</c> declared on the plugin emit
-/// additional Deny rules at a lower priority value (checked first) and are marked
-/// <c>IsBypassImmune</c> so they cannot be overridden by auto-approve modes.
+/// Any <c>DeniedTools</c> declared on a loaded plugin emit Deny rules at a lower priority value
+/// (checked first) and are marked <c>IsBypassImmune</c> so they cannot be overridden by
+/// auto-approve modes. These deny rules are emitted <b>regardless</b> of whether the plugin also
+/// sets an <c>AutonomyLevel</c> — the deny boundary is independent of the autonomy override.
+/// Additionally, each loaded plugin whose <c>AutonomyLevel</c> is set contributes one baseline
+/// rule scoped to <c>{pluginName}:*</c>.
 /// </remarks>
 public sealed class PluginPermissionRuleProvider : IPermissionRuleProvider
 {
@@ -47,13 +49,31 @@ public sealed class PluginPermissionRuleProvider : IPermissionRuleProvider
 
         foreach (var plugin in _registry.GetLoadedPlugins())
         {
+            // DeniedTools are bypass-immune and enforced independently of any AutonomyLevel:
+            // a plugin that only denies tools (no autonomy override) must still contribute its
+            // Deny rules. Emitted first so the boundary applies even when AutonomyLevel is unset
+            // or invalid.
+            if (plugin.Declaration.DeniedTools is { Count: > 0 } denied)
+            {
+                foreach (var deniedTool in denied)
+                {
+                    rules.Add(new ToolPermissionRule(
+                        deniedTool,
+                        null,
+                        PermissionBehaviorType.Deny,
+                        PermissionRuleSource.PluginDeclaration,
+                        Priority: 1,
+                        IsBypassImmune: true));
+                }
+            }
+
             if (string.IsNullOrEmpty(plugin.Declaration.AutonomyLevel))
                 continue;
 
             if (!Enum.TryParse<AutonomyLevel>(plugin.Declaration.AutonomyLevel, ignoreCase: true, out var autonomyLevel))
             {
                 _logger.LogWarning(
-                    "Plugin {Name}: invalid AutonomyLevel '{Level}', skipping governance rules",
+                    "Plugin {Name}: invalid AutonomyLevel '{Level}', skipping baseline governance rule",
                     plugin.Name, plugin.Declaration.AutonomyLevel);
                 continue;
             }
@@ -72,20 +92,6 @@ public sealed class PluginPermissionRuleProvider : IPermissionRuleProvider
                 defaultBehavior,
                 PermissionRuleSource.PluginDeclaration,
                 Priority: 5));
-
-            if (plugin.Declaration.DeniedTools is { Count: > 0 })
-            {
-                foreach (var denied in plugin.Declaration.DeniedTools)
-                {
-                    rules.Add(new ToolPermissionRule(
-                        denied,
-                        null,
-                        PermissionBehaviorType.Deny,
-                        PermissionRuleSource.PluginDeclaration,
-                        Priority: 1,
-                        IsBypassImmune: true));
-                }
-            }
         }
 
         return Task.FromResult<IReadOnlyList<ToolPermissionRule>>(rules);

--- a/src/Content/Infrastructure/Infrastructure.AI/Skills/SkillMetadataRegistry.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Skills/SkillMetadataRegistry.cs
@@ -1,4 +1,5 @@
 using Application.AI.Common.Interfaces;
+using Application.AI.Common.Interfaces.Plugins;
 using Domain.AI.Skills;
 using Domain.Common.Config;
 using Microsoft.Extensions.Logging;
@@ -26,19 +27,35 @@ public sealed class SkillMetadataRegistry : ISkillMetadataRegistry
     private readonly ILogger<SkillMetadataRegistry> _logger;
     private readonly IOptionsMonitor<AppConfig> _appConfig;
     private readonly SkillMetadataParser _parser;
+    private readonly IPluginRegistry? _pluginRegistry;
 
     private Dictionary<string, SkillDefinition>? _cache;
     private IReadOnlyList<string> _searchedPaths = [];
     private readonly Lock _lock = new();
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SkillMetadataRegistry"/> class.
+    /// </summary>
+    /// <param name="logger">Logger for discovery diagnostics.</param>
+    /// <param name="appConfig">Monitor over the live application configuration (skill search paths).</param>
+    /// <param name="parser">Parser that reads a SKILL.md file into a <see cref="SkillDefinition"/>.</param>
+    /// <param name="pluginRegistry">
+    /// Optional registry of loaded plugins. When supplied, each discovered skill whose directory
+    /// falls under a loaded plugin's <c>SkillPaths</c> is attributed to that plugin via
+    /// <see cref="SkillDefinition.PluginSource"/>, which activates plugin boundary governance
+    /// (AllowedTools/DeniedTools and Injected tool-resolution mode). Null in hosts that do not load
+    /// plugins (for example the standalone MCP server), where all skills are treated as built-in.
+    /// </param>
     public SkillMetadataRegistry(
         ILogger<SkillMetadataRegistry> logger,
         IOptionsMonitor<AppConfig> appConfig,
-        SkillMetadataParser parser)
+        SkillMetadataParser parser,
+        IPluginRegistry? pluginRegistry = null)
     {
         _logger = logger;
         _appConfig = appConfig;
         _parser = parser;
+        _pluginRegistry = pluginRegistry;
     }
 
     /// <inheritdoc />
@@ -137,9 +154,10 @@ public sealed class SkillMetadataRegistry : ISkillMetadataRegistry
         }
 
         var result = new Dictionary<string, SkillDefinition>(StringComparer.OrdinalIgnoreCase);
+        var pluginPaths = ResolvePluginSkillPaths();
 
         foreach (var rootPath in resolvedPaths)
-            DiscoverInDirectory(rootPath, rootPath, depth: 0, result);
+            DiscoverInDirectory(rootPath, depth: 0, pluginPaths, result);
 
         _logger.LogInformation(
             "Skill discovery complete: {Count} skills found across {PathCount} path(s)",
@@ -148,10 +166,37 @@ public sealed class SkillMetadataRegistry : ISkillMetadataRegistry
         return result;
     }
 
+    /// <summary>
+    /// Snapshots the skill directories of every successfully-loaded plugin, paired with the
+    /// plugin name. Used to attribute each discovered skill to its owning plugin so boundary
+    /// governance can apply. Empty when no plugin registry is available or no plugins are loaded.
+    /// </summary>
+    private IReadOnlyList<(string Path, string PluginName)> ResolvePluginSkillPaths()
+    {
+        if (_pluginRegistry is null)
+            return [];
+
+        var pairs = new List<(string Path, string PluginName)>();
+        foreach (var plugin in _pluginRegistry.GetLoadedPlugins())
+        {
+            if (plugin.Status != PluginLoadStatus.Loaded)
+                continue;
+
+            foreach (var skillPath in plugin.SkillPaths)
+            {
+                if (string.IsNullOrWhiteSpace(skillPath))
+                    continue;
+                pairs.Add((NormalizePath(skillPath), plugin.Name));
+            }
+        }
+
+        return pairs;
+    }
+
     private void DiscoverInDirectory(
         string directory,
-        string rootPath,
         int depth,
+        IReadOnlyList<(string Path, string PluginName)> pluginPaths,
         Dictionary<string, SkillDefinition> result)
     {
         if (depth > MaxSearchDepth)
@@ -161,19 +206,7 @@ public sealed class SkillMetadataRegistry : ISkillMetadataRegistry
 
         if (File.Exists(skillFile))
         {
-            try
-            {
-                var definition = _parser.ParseFromFile(skillFile, directory);
-                if (!string.IsNullOrEmpty(definition.Id))
-                {
-                    result[definition.Id] = definition;
-                    _logger.LogDebug("Discovered skill: {SkillId} from {Path}", definition.Id, directory);
-                }
-            }
-            catch (Exception ex)
-            {
-                _logger.LogWarning(ex, "Failed to parse skill from {Path}", skillFile);
-            }
+            TryAddSkill(skillFile, directory, pluginPaths, result);
 
             // A directory with SKILL.md is a skill — don't recurse into it
             return;
@@ -183,11 +216,91 @@ public sealed class SkillMetadataRegistry : ISkillMetadataRegistry
         try
         {
             foreach (var subDir in Directory.EnumerateDirectories(directory))
-                DiscoverInDirectory(subDir, rootPath, depth + 1, result);
+                DiscoverInDirectory(subDir, depth + 1, pluginPaths, result);
         }
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "Could not enumerate directory: {Path}", directory);
         }
     }
+
+    private void TryAddSkill(
+        string skillFile,
+        string directory,
+        IReadOnlyList<(string Path, string PluginName)> pluginPaths,
+        Dictionary<string, SkillDefinition> result)
+    {
+        try
+        {
+            var pluginSource = ResolveOwningPlugin(directory, pluginPaths);
+            var definition = _parser.ParseFromFile(skillFile, directory, pluginSource);
+            if (string.IsNullOrEmpty(definition.Id))
+                return;
+
+            // Config/built-in paths are walked before plugin paths (see SkillsConfig.AllPaths),
+            // so the first definition for an ID wins. This prevents a plugin from shadowing a
+            // built-in skill's system prompt via an ID collision.
+            if (result.TryGetValue(definition.Id, out var existing))
+            {
+                _logger.LogWarning(
+                    "Skill ID collision on '{SkillId}': keeping first from {ExistingPath} (source: {ExistingSource}); " +
+                    "ignoring duplicate from {DuplicatePath} (source: {DuplicateSource})",
+                    definition.Id,
+                    existing.BaseDirectory, existing.PluginSource ?? "built-in",
+                    directory, pluginSource ?? "built-in");
+                return;
+            }
+
+            result[definition.Id] = definition;
+            _logger.LogDebug(
+                "Discovered skill: {SkillId} from {Path} (source: {Source})",
+                definition.Id, directory, pluginSource ?? "built-in");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to parse skill from {Path}", skillFile);
+        }
+    }
+
+    /// <summary>
+    /// Returns the name of the loaded plugin that owns <paramref name="skillDirectory"/>, or null
+    /// when the skill is built-in. A plugin owns the directory when the directory equals, or is
+    /// nested under, one of the plugin's skill paths. The most specific (longest) matching path
+    /// wins so nested plugin layouts attribute correctly.
+    /// </summary>
+    private static string? ResolveOwningPlugin(
+        string skillDirectory,
+        IReadOnlyList<(string Path, string PluginName)> pluginPaths)
+    {
+        if (pluginPaths.Count == 0)
+            return null;
+
+        var normalizedDir = NormalizePath(skillDirectory);
+        string? bestName = null;
+        var bestLength = -1;
+
+        foreach (var (path, pluginName) in pluginPaths)
+        {
+            if (IsSameOrUnder(normalizedDir, path) && path.Length > bestLength)
+            {
+                bestName = pluginName;
+                bestLength = path.Length;
+            }
+        }
+
+        return bestName;
+    }
+
+    private static bool IsSameOrUnder(string normalizedTarget, string normalizedBase)
+    {
+        var comparison = OperatingSystem.IsWindows()
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+
+        return string.Equals(normalizedTarget, normalizedBase, comparison)
+            || normalizedTarget.StartsWith(normalizedBase + Path.DirectorySeparatorChar, comparison);
+    }
+
+    private static string NormalizePath(string path) =>
+        Path.GetFullPath(path).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
 }

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/ToolChainBuilderTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/ToolChainBuilderTests.cs
@@ -162,6 +162,39 @@ public class ToolChainBuilderTests
         tools.Should().ContainSingle(t => t.Name == "safe");
     }
 
+    [Fact]
+    public async Task BuildToolsAsync_ManagedModePluginSkill_DeniedToolsRemovesBlacklisted()
+    {
+        // A plugin skill with pre-created tools resolves in Managed mode (it has Tools),
+        // yet its plugin's DeniedTools boundary must still filter — the boundary is not
+        // exclusive to Injected mode.
+        var pluginRegistry = new Mock<IPluginRegistry>();
+        pluginRegistry.Setup(r => r.GetPlugin("p")).Returns(
+            new LoadedPlugin("p", "1.0", "/plugins/p", new PluginManifest(),
+                PluginLoadStatus.Loaded, [], ["p:server"],
+                new PluginDeclaration { Name = "p", DeniedTools = ["dangerous"] }));
+
+        var services = new ServiceCollection();
+        services.AddSingleton(pluginRegistry.Object);
+
+        var builder = CreateBuilder(serviceProvider: services.BuildServiceProvider());
+
+        var skill = new SkillDefinition
+        {
+            Id = "p-skill", Name = "p-skill", Instructions = "Test", PluginSource = "p",
+            Tools =
+            [
+                AIFunctionFactory.Create(() => "r", "safe"),
+                AIFunctionFactory.Create(() => "r", "dangerous")
+            ]
+        };
+
+        var tools = await builder.BuildToolsAsync(skill, new SkillAgentOptions());
+
+        tools.Select(t => t.Name).Should().NotContain("dangerous");
+        tools.Should().ContainSingle(t => t.Name == "safe");
+    }
+
     // --- Managed mode: pre-created tools ---
 
     [Fact]

--- a/src/Content/Tests/Application.Core.Tests/Permissions/PluginPermissionRuleProviderTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/Permissions/PluginPermissionRuleProviderTests.cs
@@ -109,6 +109,33 @@ public sealed class PluginPermissionRuleProviderTests
     }
 
     [Fact]
+    public async Task GetRulesAsync_DeniedToolsWithoutAutonomyLevel_StillEmitsBypassImmuneDenyRules()
+    {
+        // DeniedTools are bypass-immune and must be enforced regardless of whether the
+        // plugin also sets an AutonomyLevel. A plugin that only denies tools (no autonomy
+        // override) must still contribute its Deny rules.
+        var declaration = new PluginDeclaration
+        {
+            Name = "deny-only",
+            AutonomyLevel = null,
+            DeniedTools = ["bash", "deploy_production"]
+        };
+        _registryMock.Setup(r => r.GetLoadedPlugins()).Returns(new List<LoadedPlugin>
+        {
+            new("deny-only", "1.0", "/plugins/deny-only", new PluginManifest(),
+                PluginLoadStatus.Loaded, [], ["deny-only:server"], declaration)
+        });
+
+        var rules = await CreateProvider().GetRulesAsync("any-agent");
+
+        rules.Should().HaveCount(2, "no baseline autonomy rule, but both Deny rules must be present");
+        rules.Should().OnlyContain(r =>
+            r.Behavior == PermissionBehaviorType.Deny && r.IsBypassImmune);
+        rules.Should().Contain(r => r.ToolPattern == "bash");
+        rules.Should().Contain(r => r.ToolPattern == "deploy_production");
+    }
+
+    [Fact]
     public async Task GetRulesAsync_DenyRules_HaveHigherPriorityThanBaseline()
     {
         var declaration = new PluginDeclaration

--- a/src/Content/Tests/Infrastructure.AI.Tests/Skills/PluginGovernanceWiringTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Skills/PluginGovernanceWiringTests.cs
@@ -1,0 +1,162 @@
+using Application.AI.Common.Interfaces;
+using Application.AI.Common.Interfaces.Plugins;
+using Application.AI.Common.Interfaces.Tools;
+using Application.AI.Common.Services.Tools;
+using Domain.AI.Skills;
+using Domain.Common.Config;
+using Domain.Common.Config.AI;
+using Domain.Common.Config.AI.Plugins;
+using FluentAssertions;
+using Infrastructure.AI.Plugins;
+using Infrastructure.AI.Skills;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Skills;
+
+/// <summary>
+/// End-to-end tests proving that plugin boundary governance is actually wired through the
+/// real skill-discovery path — not just the unit tests that pass <c>pluginSource</c> explicitly.
+/// </summary>
+/// <remarks>
+/// These tests exercise the production wiring: a plugin is registered in <see cref="PluginRegistry"/>
+/// with its skills directory recorded in <see cref="LoadedPlugin.SkillPaths"/>, and
+/// <see cref="SkillMetadataRegistry"/> discovers a SKILL.md under that directory. The regression they
+/// guard against is that <c>SkillMetadataRegistry.Discover</c> never told the parser which plugin owned
+/// a skill, so <see cref="SkillDefinition.PluginSource"/> stayed null, every skill collapsed to
+/// <see cref="SkillMode.Managed"/>, and the plugin's <c>DeniedTools</c> boundary never fired.
+/// </remarks>
+public sealed class PluginGovernanceWiringTests : IDisposable
+{
+    private readonly string _tempRoot;
+    private readonly string _pluginSkillsDir;
+
+    public PluginGovernanceWiringTests()
+    {
+        _tempRoot = Path.Combine(Path.GetTempPath(), "plugin-gov-" + Guid.NewGuid().ToString("N"));
+        _pluginSkillsDir = Path.Combine(_tempRoot, "myplugin", "skills");
+        Directory.CreateDirectory(_pluginSkillsDir);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_tempRoot, recursive: true); }
+        catch (IOException) { /* best-effort temp cleanup */ }
+    }
+
+    private void WriteSkill(string skillFolder, string skillMarkdown)
+    {
+        var dir = Path.Combine(_pluginSkillsDir, skillFolder);
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, "SKILL.md"), skillMarkdown);
+    }
+
+    private static PluginRegistry RegistryWithPlugin(string skillsDir, PluginDeclaration declaration)
+    {
+        var registry = new PluginRegistry();
+        registry.Register(new LoadedPlugin(
+            declaration.Name,
+            "1.0",
+            Path.GetDirectoryName(skillsDir)!,
+            new PluginManifest { Name = declaration.Name, Skills = "./skills/" },
+            PluginLoadStatus.Loaded,
+            SkillPaths: [skillsDir],
+            McpServerNames: [],
+            declaration));
+        return registry;
+    }
+
+    private SkillMetadataRegistry CreateSkillRegistry(IPluginRegistry pluginRegistry)
+    {
+        var appConfig = new AppConfig
+        {
+            AI = new AIConfig { Skills = new SkillsConfig { BasePath = _pluginSkillsDir } }
+        };
+        return new SkillMetadataRegistry(
+            NullLogger<SkillMetadataRegistry>.Instance,
+            new OptionsMonitorStub(appConfig),
+            new SkillMetadataParser(NullLogger<SkillMetadataParser>.Instance),
+            pluginRegistry);
+    }
+
+    [Fact]
+    public void Discover_SkillUnderPluginSkillPath_PopulatesPluginSourceAndInjectedMode()
+    {
+        WriteSkill("do-thing", """
+            ---
+            name: injected-plugin-skill
+            description: A plugin skill with no tool declarations.
+            ---
+            Do the thing.
+            """);
+
+        var pluginRegistry = RegistryWithPlugin(
+            _pluginSkillsDir,
+            new PluginDeclaration { Name = "myplugin", DeniedTools = ["dangerous"] });
+        var skillRegistry = CreateSkillRegistry(pluginRegistry);
+
+        var skill = skillRegistry.TryGet("injected-plugin-skill");
+
+        skill.Should().NotBeNull();
+        skill!.PluginSource.Should().Be("myplugin",
+            "the discovered skill lives under the plugin's SkillPaths and must be attributed to it");
+        skill.Mode.Should().Be(SkillMode.Injected,
+            "a plugin skill with no tool declarations resolves in Injected mode");
+    }
+
+    [Fact]
+    public async Task DeniedTool_IsFilteredOut_ForDiscoveredPluginSkill()
+    {
+        WriteSkill("do-thing", """
+            ---
+            name: injected-plugin-skill
+            description: A plugin skill with no tool declarations.
+            ---
+            Do the thing.
+            """);
+
+        var declaration = new PluginDeclaration { Name = "myplugin", DeniedTools = ["dangerous"] };
+        var pluginRegistry = RegistryWithPlugin(_pluginSkillsDir, declaration);
+        var skillRegistry = CreateSkillRegistry(pluginRegistry);
+        var skill = skillRegistry.TryGet("injected-plugin-skill");
+        skill.Should().NotBeNull();
+
+        var mcpProvider = new Mock<IMcpToolProvider>();
+        mcpProvider
+            .Setup(p => p.GetAllToolsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<string, IList<AITool>>
+            {
+                ["server"] =
+                [
+                    AIFunctionFactory.Create(() => "r", "safe"),
+                    AIFunctionFactory.Create(() => "r", "dangerous")
+                ]
+            });
+
+        var services = new ServiceCollection();
+        services.AddSingleton<IPluginRegistry>(pluginRegistry);
+
+        var builder = new ToolChainBuilder(
+            NullLogger<ToolChainBuilder>.Instance,
+            services.BuildServiceProvider(),
+            toolConverter: null,
+            mcpToolProvider: mcpProvider.Object);
+
+        var tools = await builder.BuildToolsAsync(skill!, new SkillAgentOptions());
+
+        tools.Select(t => t.Name).Should().NotContain("dangerous",
+            "the plugin's DeniedTools boundary must filter the tool out of the resolved set");
+        tools.Select(t => t.Name).Should().Contain("safe");
+    }
+
+    private sealed class OptionsMonitorStub(AppConfig value) : IOptionsMonitor<AppConfig>
+    {
+        public AppConfig CurrentValue { get; } = value;
+        public AppConfig Get(string? name) => CurrentValue;
+        public IDisposable? OnChange(Action<AppConfig, string?> listener) => null;
+    }
+}


### PR DESCRIPTION
## Problem (CRITICAL)
Plugin boundary governance (`AllowedTools` / `DeniedTools` / Injected mode) was dead code — a plugin's `DeniedTools` were never actually enforced, so the "bypass-immune DeniedTools" guarantee in the docs did not hold. Root cause: skill discovery called the parser **without** the `pluginSource` argument (only tests passed it), so `PluginSource` was always null → every skill resolved as `Managed` → the Injected branch and `ApplyPluginToolBoundary` never fired. A second bug skipped the DeniedTools deny-rules whenever a plugin declared no `AutonomyLevel`.

## Fix
1. `SkillMetadataRegistry.Discover` now attributes each discovered skill to its owning plugin (matching resolved roots against the loaded plugins' skill paths) and passes it to the parser, so `PluginSource` is populated. Attribution is registry-derived, never read from SKILL.md frontmatter — a malicious skill cannot forge it.
2. `ToolChainBuilder` applies the plugin boundary on **both** the Managed and Injected paths whenever `PluginSource` is set.
3. `PluginPermissionRuleProvider` emits DeniedTools deny-rules **unconditionally** and bypass-immune (out of the `AutonomyLevel` guard).
4. Skill-ID collisions log a warning and keep the first-discovered definition; built-in paths are walked before plugin paths, so a plugin cannot shadow a built-in skill's system prompt.

## Test plan
- `PluginGovernanceWiringTests.DeniedTool_IsFilteredOut_ForDiscoveredPluginSkill` — real discovery → attribution → Injected-mode filtering end-to-end; the denied tool is absent from the resolved set. Before the fix this test did not even compile (the wiring seam did not exist).
- `..._PopulatesPluginSourceAndInjectedMode`, `ToolChainBuilderTests` Managed-path denial, `PluginPermissionRuleProviderTests` bypass-immune deny-rules without an AutonomyLevel.
- Application.AI.Common.Tests 1297/1297, Application.Core.Tests 632/632. (3 pre-existing Infrastructure.AI FileSystem tests fail in the sandbox env only, unrelated.)

## Review
Independent adversarial **security review**: verdict SAFE TO MERGE AS-IS, no critical/high. Confirmed DeniedTools cannot be bypassed via keyed-DI/MCP/allow-lists/auto-approve, no plugin-path false-match, and the tests genuinely pin enforcement.

Tracked non-blocking follow-ups (Wave 2):
- **Medium** — the `{plugin}:*` autonomy-baseline rule is inert at invocation (MCP tool names aren't plugin-prefixed); a plugin's `AutonomyLevel` override silently doesn't apply. DeniedTools still enforces — this is the separate "autonomy setting doesn't bite" gap.
- **Low** — add a fail-fast guard so a future host that loads plugins without registering `IPluginRegistry` can't silently skip the boundary.
- **Low** — document that a plugin's DeniedTools is a per-plugin filter, not a global kill-switch, when invocation-time enforcement is off.

Part of the Wave-1 "inert machinery" remediation from the deep audit.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>