### PR TITLE
fix: plan crash-resume re-runs interrupted steps; honest completion status

### DIFF
--- a/src/Content/Application/Application.AI.Common/Interfaces/Planner/IPlanStepExecutor.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Planner/IPlanStepExecutor.cs
@@ -12,6 +12,22 @@ public interface IPlanStepExecutor
     /// <summary>
     /// Executes the given step using outputs from upstream dependencies as context.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>At-least-once execution on resume.</b> Crash-resume re-runs any step that was in-flight
+    /// when the host stopped: a step persisted as <see cref="StepExecutionStatus.Running"/> is
+    /// renormalised to <see cref="StepExecutionStatus.Pending"/> and executed again — even if it had
+    /// actually finished its side effects before the crash but died before persisting
+    /// <see cref="StepExecutionStatus.Completed"/>. Manual retry via
+    /// <c>IPlanExecutor.RetryStepAsync</c> has the same effect.
+    /// </para>
+    /// <para>
+    /// Implementations of non-idempotent step types (for example <see cref="StepType.ToolUse"/> or
+    /// <see cref="StepType.SubPlanInvocation"/>) MUST therefore tolerate being invoked more than once
+    /// for the same step — guard external writes with idempotency keys, dedup checks, or compensating
+    /// logic. The harness guarantees at-least-once, not exactly-once, execution.
+    /// </para>
+    /// </remarks>
     /// <param name="step">The step to execute.</param>
     /// <param name="upstreamOutputs">
     /// Outputs from completed upstream steps, keyed by step ID. Provides data flow

--- a/src/Content/Infrastructure/Infrastructure.AI/Planner/PlanExecutor.Recovery.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Planner/PlanExecutor.Recovery.cs
@@ -132,7 +132,12 @@ public sealed partial class PlanExecutor
         {
             if (existingStates is not null && existingStates.TryGetValue(step.Id, out var existing))
             {
-                var state = existing.Status == StepExecutionStatus.Running
+                // A resumed step that was in-flight (Running) or merely queued (Ready) when the host
+                // crashed must be renormalised to Pending so the scheduler re-evaluates its
+                // dependencies and re-enqueues it through the canonical Pending -> Ready promotion
+                // path. Leaving it as Ready would strand it: EnqueueInitialReadyStepsAsync only picks
+                // up Pending steps, so the step would never run yet the plan would report Completed.
+                var state = existing.Status is StepExecutionStatus.Running or StepExecutionStatus.Ready
                     ? existing with { Status = StepExecutionStatus.Pending }
                     : existing;
                 stepStates[step.Id] = state;

--- a/src/Content/Infrastructure/Infrastructure.AI/Planner/PlanExecutor.Summary.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Planner/PlanExecutor.Summary.cs
@@ -17,14 +17,23 @@ public sealed partial class PlanExecutor
         var hasFailures = states.Any(s => s.Status == StepExecutionStatus.Failed);
         var hasBlocked = states.Any(s => s.Status == StepExecutionStatus.Blocked);
         var hasCancelled = states.Any(s => s.Status == StepExecutionStatus.Cancelled);
+        var hasNonTerminal = states.Any(s => s.Status is StepExecutionStatus.Pending
+            or StepExecutionStatus.Ready
+            or StepExecutionStatus.Running);
 
+        // Blocked/Cancelled are legitimate terminal outcomes and take precedence — a Blocked step
+        // with a waiting Pending downstream is a paused plan, not a failure. But if the scheduler
+        // exits with non-terminal steps and nothing explains the pause (no failure, no block, no
+        // cancellation), the plan did NOT complete: report Failed rather than dishonestly Completed.
         var finalStatus = hasFailures
             ? StepExecutionStatus.Failed
             : hasBlocked
                 ? StepExecutionStatus.Blocked
                 : hasCancelled
                     ? StepExecutionStatus.Cancelled
-                    : StepExecutionStatus.Completed;
+                    : hasNonTerminal
+                        ? StepExecutionStatus.Failed
+                        : StepExecutionStatus.Completed;
 
         return new PlanExecutionSummary
         {

--- a/src/Content/Infrastructure/Infrastructure.AI/Planner/PlanExecutor.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Planner/PlanExecutor.cs
@@ -171,10 +171,14 @@ public sealed partial class PlanExecutor : IPlanExecutor
             if (currentState.Status != StepExecutionStatus.Failed)
                 return Result.Fail($"Only failed steps can be retried. Step {stepId} is {currentState.Status}.");
 
+            // Reset to Pending — not Ready — so the next ExecuteAsync re-evaluates the step's
+            // dependencies and re-enqueues it through the canonical Pending -> Ready promotion path.
+            // A persisted Ready step is never picked up by EnqueueInitialReadyStepsAsync, so the
+            // retried step would never actually re-run.
             var resetState = new StepExecutionState
             {
                 StepId = stepId,
-                Status = StepExecutionStatus.Ready,
+                Status = StepExecutionStatus.Pending,
                 AttemptCount = currentState.AttemptCount,
                 StartedAt = null,
                 CompletedAt = null,
@@ -187,7 +191,7 @@ public sealed partial class PlanExecutor : IPlanExecutor
                 return Result.Fail(updateResult.Errors.ToArray());
 
             _logger.LogInformation(
-                "Step {StepId} in plan {PlanId} reset to Ready for retry (attempt {AttemptCount} total)",
+                "Step {StepId} in plan {PlanId} reset to Pending for retry (attempt {AttemptCount} total)",
                 stepId, planId, currentState.AttemptCount);
 
             return Result.Success();
@@ -363,10 +367,9 @@ public sealed partial class PlanExecutor : IPlanExecutor
         sw.Stop();
         var summary = BuildSummary(planId, stepStates, sw.Elapsed);
 
-        if (summary.FailedStepCount > 0)
+        if (summary.FinalStatus == StepExecutionStatus.Failed)
         {
-            var failedStep = summary.StepStates.First(s => s.Status == StepExecutionStatus.Failed);
-            await _notifier.NotifyPlanFailedAsync(planId, failedStep.StepId, failedStep.ErrorMessage ?? "Unknown error", ct);
+            await NotifyPlanFailureAsync(planId, summary, ct);
             PlanExecutionsCounter.Add(1, new KeyValuePair<string, object?>("status", "failed"));
         }
         else if (summary.StepStates.All(s => s.Status is StepExecutionStatus.Completed or StepExecutionStatus.Skipped))
@@ -376,5 +379,29 @@ public sealed partial class PlanExecutor : IPlanExecutor
         }
 
         return Result<PlanExecutionSummary>.Success(summary);
+    }
+
+    /// <summary>
+    /// Emits the plan-level failure notification. Reports the first failed step's error when one
+    /// exists; otherwise reports an incomplete plan — the scheduler exited with steps that never
+    /// reached a terminal state — so the outcome is never silently dropped.
+    /// </summary>
+    private async Task NotifyPlanFailureAsync(PlanId planId, PlanExecutionSummary summary, CancellationToken ct)
+    {
+        var failedStep = summary.StepStates.FirstOrDefault(s => s.Status == StepExecutionStatus.Failed);
+        if (failedStep is not null)
+        {
+            await _notifier.NotifyPlanFailedAsync(planId, failedStep.StepId, failedStep.ErrorMessage ?? "Unknown error", ct);
+            return;
+        }
+
+        var unexecuted = summary.StepStates
+            .Where(s => s.Status is StepExecutionStatus.Pending or StepExecutionStatus.Ready or StepExecutionStatus.Running)
+            .ToList();
+        await _notifier.NotifyPlanFailedAsync(
+            planId,
+            unexecuted[0].StepId,
+            $"Plan did not complete: {unexecuted.Count} step(s) never reached a terminal state",
+            ct);
     }
 }

--- a/src/Content/Infrastructure/Infrastructure.AI/Planner/StepExecutors/SubPlanStepExecutor.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Planner/StepExecutors/SubPlanStepExecutor.cs
@@ -88,20 +88,30 @@ public sealed class SubPlanStepExecutor : IPlanStepExecutor
             var childResult = await childExecutor.ExecuteAsync(childPlanId.Value, childContext, ct);
             sw.Stop();
 
-            if (childResult.IsSuccess)
+            // A successful Result only means the child executor ran to a conclusion — the plan's
+            // actual outcome lives in FinalStatus. A child that failed, blocked, or was cancelled
+            // (or was left with non-terminal steps) now returns Result.Success with a non-Completed
+            // FinalStatus, so the parent step is Completed ONLY when the child genuinely completed.
+            // Keying off IsSuccess alone would mark the parent step Completed for a failed child —
+            // the same "plan lies about success" bug, one level up.
+            if (childResult.IsSuccess && childResult.Value!.FinalStatus == StepExecutionStatus.Completed)
             {
                 return new StepExecutionResult
                 {
                     Status = StepExecutionStatus.Completed,
-                    Output = childResult.Value is not null ? JsonSerializer.Serialize(childResult.Value) : null,
+                    Output = JsonSerializer.Serialize(childResult.Value),
                     Duration = sw.Elapsed
                 };
             }
 
+            var errorMessage = childResult.IsSuccess
+                ? $"Child plan {childPlanId.Value} did not complete: final status {childResult.Value!.FinalStatus}."
+                : childResult.Errors.Count > 0 ? string.Join("; ", childResult.Errors) : "Child plan execution failed.";
+
             return new StepExecutionResult
             {
                 Status = StepExecutionStatus.Failed,
-                ErrorMessage = childResult.Errors.Count > 0 ? string.Join("; ", childResult.Errors) : "Child plan execution failed.",
+                ErrorMessage = errorMessage,
                 Duration = sw.Elapsed
             };
         }

--- a/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlanExecutorResumeRecoveryTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlanExecutorResumeRecoveryTests.cs
@@ -1,0 +1,254 @@
+using Application.AI.Common.Interfaces.Escalation;
+using Application.AI.Common.Interfaces.Planner;
+using Domain.AI.Planner;
+using Domain.Common;
+using Infrastructure.AI.Persistence;
+using Infrastructure.AI.Planner;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Time.Testing;
+using Moq;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Planner;
+
+/// <summary>
+/// Crash-resume and manual-retry recovery tests that exercise the <see cref="PlanExecutor"/>
+/// against the real <see cref="EfCorePlanStateStore"/> backed by in-memory SQLite. These use the
+/// production state store — not a mock — because the resume bug lived in the interaction between
+/// the store's persisted states and the executor's scheduling, which a mocked store hides.
+/// </summary>
+public sealed class PlanExecutorResumeRecoveryTests : IDisposable
+{
+    private readonly SqliteConnection _connection;
+    private readonly DbContextOptions<PlannerDbContext> _options;
+    private readonly FakeTimeProvider _timeProvider;
+    private readonly EfCorePlanStateStore _store;
+    private readonly Mock<IPlanValidator> _validator = new();
+    private readonly Mock<IPlanProgressNotifier> _notifier = new();
+    private readonly Mock<IEscalationService> _escalation = new();
+
+    public PlanExecutorResumeRecoveryTests()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+
+        _options = new DbContextOptionsBuilder<PlannerDbContext>()
+            .UseSqlite(_connection)
+            .Options;
+
+        using (var ctx = new PlannerDbContext(_options))
+        {
+            ctx.Database.EnsureCreated();
+        }
+
+        _timeProvider = new FakeTimeProvider(new DateTimeOffset(2026, 5, 15, 12, 0, 0, TimeSpan.Zero));
+        _store = new EfCorePlanStateStore(
+            new TestDbContextFactory(_options), NullLogger<EfCorePlanStateStore>.Instance, _timeProvider);
+
+        _validator.Setup(v => v.ValidateAsync(It.IsAny<PlanGraph>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<PlanValidationResult>.Success(new PlanValidationResult { IsValid = true }));
+
+        _notifier.Setup(n => n.NotifyPlanStartedAsync(It.IsAny<PlanId>(), It.IsAny<string>(), It.IsAny<PlanGraph>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        _notifier.Setup(n => n.NotifyStepStartedAsync(It.IsAny<PlanId>(), It.IsAny<PlanStepId>(), It.IsAny<string>(), It.IsAny<StepType>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        _notifier.Setup(n => n.NotifyStepCompletedAsync(It.IsAny<PlanId>(), It.IsAny<PlanStepId>(), It.IsAny<StepExecutionStatus>(), It.IsAny<TimeSpan>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        _notifier.Setup(n => n.NotifyStateUpdateAsync(It.IsAny<PlanId>(), It.IsAny<PlanStepId>(), It.IsAny<StepExecutionStatus>(), It.IsAny<StepExecutionStatus>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        _notifier.Setup(n => n.NotifyPlanCompletedAsync(It.IsAny<PlanId>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        _notifier.Setup(n => n.NotifyPlanFailedAsync(It.IsAny<PlanId>(), It.IsAny<PlanStepId>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+    }
+
+    public void Dispose() => _connection.Dispose();
+
+    // === Crash-resume: interrupted (Running) step must re-execute ===
+
+    [Fact]
+    public async Task Execute_ResumeAfterCrashMidStep_ReExecutesInterruptedStepAndCompletes()
+    {
+        var invocations = new List<PlanStepId>();
+        var executor = BuildExecutor(RecordingCompletingExecutor(invocations));
+        var plan = SingleStepPlan();
+        await _store.SavePlanAsync(plan, CancellationToken.None);
+        await CrashStepAsRunning(plan.Steps[0].Id);
+
+        var result = await executor.ExecuteAsync(plan.Id, CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        // The step that was interrupted mid-flight must actually re-run — this is the core resume fix.
+        Assert.Single(invocations);
+        Assert.Equal(plan.Steps[0].Id, invocations[0]);
+        // And because it genuinely re-ran to success, Completed is now honest.
+        Assert.Equal(StepExecutionStatus.Completed, result.Value!.FinalStatus);
+    }
+
+    [Fact]
+    public async Task Execute_ResumeAfterCrash_WhenReRunFails_DoesNotReportCompleted()
+    {
+        // Guards the false-completed bug: a plan whose interrupted step re-runs and fails
+        // must NOT be summarised as Completed. Before the fix the step never re-ran yet the
+        // summary reported Completed.
+        var invocations = new List<PlanStepId>();
+        var executor = BuildExecutor(RecordingFailingExecutor(invocations));
+        var plan = SingleStepPlan();
+        await _store.SavePlanAsync(plan, CancellationToken.None);
+        await CrashStepAsRunning(plan.Steps[0].Id);
+
+        var result = await executor.ExecuteAsync(plan.Id, CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Single(invocations);
+        Assert.NotEqual(StepExecutionStatus.Completed, result.Value!.FinalStatus);
+        Assert.Equal(StepExecutionStatus.Failed, result.Value.FinalStatus);
+    }
+
+    // === Summary honesty: a step that never terminalises must not read as Completed ===
+
+    [Fact]
+    public async Task Execute_SchedulerExitsWithNonTerminalStep_DoesNotReportCompleted()
+    {
+        // An executor that returns a status the result handler does not terminalise leaves the
+        // step non-terminal (Running) when the scheduling loop drains. BuildSummary must not
+        // paper over this by reporting Completed.
+        var executor = BuildExecutor((_, _, _) => Task.FromResult(new StepExecutionResult
+        {
+            Status = StepExecutionStatus.Skipped, // not handled by HandleStepResultAsync -> step stays non-terminal
+            Duration = TimeSpan.FromMilliseconds(1)
+        }));
+        var plan = SingleStepPlan();
+        await _store.SavePlanAsync(plan, CancellationToken.None);
+
+        var result = await executor.ExecuteAsync(plan.Id, CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.NotEqual(StepExecutionStatus.Completed, result.Value!.FinalStatus);
+    }
+
+    // === Manual retry: a retried failed step must re-execute on next run ===
+
+    [Fact]
+    public async Task RetryStep_ThenExecute_ReExecutesFailedStep()
+    {
+        var invocations = new List<PlanStepId>();
+        var fail = true;
+        var executor = BuildExecutor((step, _, _) =>
+        {
+            invocations.Add(step.Id);
+            var status = fail ? StepExecutionStatus.Failed : StepExecutionStatus.Completed;
+            return Task.FromResult(new StepExecutionResult
+            {
+                Status = status,
+                Output = status == StepExecutionStatus.Completed ? "ok" : null,
+                ErrorMessage = status == StepExecutionStatus.Failed ? "boom" : null,
+                Duration = TimeSpan.FromMilliseconds(1)
+            });
+        });
+        var plan = SingleStepPlan();
+        await _store.SavePlanAsync(plan, CancellationToken.None);
+
+        var first = await executor.ExecuteAsync(plan.Id, CancellationToken.None);
+        Assert.Equal(StepExecutionStatus.Failed, first.Value!.FinalStatus);
+        Assert.Single(invocations);
+
+        var retry = await executor.RetryStepAsync(plan.Id, plan.Steps[0].Id, CancellationToken.None);
+        Assert.True(retry.IsSuccess);
+
+        fail = false;
+        var second = await executor.ExecuteAsync(plan.Id, CancellationToken.None);
+
+        Assert.True(second.IsSuccess);
+        // The retried step must actually run a second time.
+        Assert.Equal(2, invocations.Count);
+        Assert.Equal(StepExecutionStatus.Completed, second.Value!.FinalStatus);
+    }
+
+    // --- Helpers ---
+
+    private PlanExecutor BuildExecutor(
+        Func<PlanStep, IReadOnlyDictionary<PlanStepId, string>, CancellationToken, Task<StepExecutionResult>> handler)
+    {
+        var mock = new Mock<IPlanStepExecutor>();
+        mock.Setup(e => e.ExecuteAsync(It.IsAny<PlanStep>(), It.IsAny<IReadOnlyDictionary<PlanStepId, string>>(), It.IsAny<CancellationToken>()))
+            .Returns<PlanStep, IReadOnlyDictionary<PlanStepId, string>, CancellationToken>(handler);
+
+        var services = new ServiceCollection();
+        services.AddKeyedSingleton<IPlanStepExecutor>(StepType.LlmCall, mock.Object);
+        var provider = services.BuildServiceProvider();
+
+        return new PlanExecutor(
+            _validator.Object,
+            _store,
+            _notifier.Object,
+            _escalation.Object,
+            provider,
+            NullLogger<PlanExecutor>.Instance);
+    }
+
+    private static Func<PlanStep, IReadOnlyDictionary<PlanStepId, string>, CancellationToken, Task<StepExecutionResult>>
+        RecordingCompletingExecutor(List<PlanStepId> invocations) => (step, _, _) =>
+    {
+        invocations.Add(step.Id);
+        return Task.FromResult(new StepExecutionResult
+        {
+            Status = StepExecutionStatus.Completed,
+            Output = $"output-{step.Name}",
+            Duration = TimeSpan.FromMilliseconds(1)
+        });
+    };
+
+    private static Func<PlanStep, IReadOnlyDictionary<PlanStepId, string>, CancellationToken, Task<StepExecutionResult>>
+        RecordingFailingExecutor(List<PlanStepId> invocations) => (step, _, _) =>
+    {
+        invocations.Add(step.Id);
+        return Task.FromResult(new StepExecutionResult
+        {
+            Status = StepExecutionStatus.Failed,
+            ErrorMessage = "boom",
+            Duration = TimeSpan.FromMilliseconds(1)
+        });
+    };
+
+    private async Task CrashStepAsRunning(PlanStepId stepId)
+    {
+        await using var ctx = new PlannerDbContext(_options);
+        var state = await ctx.StepExecutionStates.FirstAsync(s => s.StepId == stepId.Value);
+        state.Status = StepExecutionStatus.Running;
+        state.AttemptCount = 1;
+        state.StartedAt = _timeProvider.GetUtcNow();
+        await ctx.SaveChangesAsync();
+    }
+
+    private static PlanGraph SingleStepPlan()
+    {
+        var step = new PlanStep
+        {
+            Id = PlanStepId.New(),
+            Name = "step-0",
+            Type = StepType.LlmCall,
+            Configuration = new LlmCallConfig { SystemPrompt = "test", ModelDeploymentKey = "gpt-4" },
+            RetryPolicy = new RetryPolicy { MaxRetries = 0 },
+            Timeout = TimeSpan.FromSeconds(30)
+        };
+
+        return new PlanGraph
+        {
+            Id = PlanId.New(),
+            Name = "resume-plan",
+            Steps = [step],
+            Edges = [],
+            Configuration = new PlanConfiguration { MaxParallelSteps = 2, PlanTimeout = TimeSpan.FromSeconds(10) }
+        };
+    }
+
+    private sealed class TestDbContextFactory(DbContextOptions<PlannerDbContext> options)
+        : IDbContextFactory<PlannerDbContext>
+    {
+        public PlannerDbContext CreateDbContext() => new(options);
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlanExecutorResumeRecoveryTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlanExecutorResumeRecoveryTests.cs
@@ -132,6 +132,12 @@ public sealed class PlanExecutorResumeRecoveryTests : IDisposable
 
     // === Manual retry: a retried failed step must re-execute on next run ===
 
+    // End-to-end coverage of the retry loop: a retried step's persisted state must flow back through
+    // Resume -> InitializeStepStates -> enqueue and actually re-run against the real store. This does
+    // NOT isolate RetryStepAsync's reset value on its own — InitializeStepStates now normalizes
+    // Ready->Pending, so the loop would re-run even if RetryStepAsync reverted to Ready. The exact
+    // reset-to-Pending value is pinned separately by the mocked unit test
+    // PlanExecutorTests.RetryStepAsync_FailedStep_ResetsToPending.
     [Fact]
     public async Task RetryStep_ThenExecute_ReExecutesFailedStep()
     {

--- a/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlanExecutorTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlanExecutorTests.cs
@@ -844,7 +844,7 @@ public sealed class PlanExecutorTests : IDisposable
     // === RetryStepAsync ===
 
     [Fact]
-    public async Task RetryStepAsync_FailedStep_ResetsToReady()
+    public async Task RetryStepAsync_FailedStep_ResetsToPending()
     {
         var planId = PlanId.New();
         var stepId = new PlanStepId(Guid.NewGuid());
@@ -872,7 +872,7 @@ public sealed class PlanExecutorTests : IDisposable
         _stateStore.Verify(s => s.UpdateStepStateAsync(
             It.Is<StepExecutionState>(st =>
                 st.StepId == stepId &&
-                st.Status == StepExecutionStatus.Ready &&
+                st.Status == StepExecutionStatus.Pending &&
                 st.AttemptCount == 2 &&
                 st.ErrorMessage == null &&
                 st.CompletedAt == null),

--- a/src/Content/Tests/Infrastructure.AI.Tests/Planner/SubPlanStepExecutorTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Planner/SubPlanStepExecutorTests.cs
@@ -1,0 +1,98 @@
+using Application.AI.Common.Interfaces.Planner;
+using Domain.AI.Planner;
+using Domain.Common;
+using Infrastructure.AI.Planner.StepExecutors;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Planner;
+
+/// <summary>
+/// Verifies that <see cref="SubPlanStepExecutor"/> propagates a child sub-plan's honest outcome to
+/// the parent step. A child plan now returns <c>Result.Success</c> even when its summary's
+/// <see cref="PlanExecutionSummary.FinalStatus"/> is Failed/Blocked/Cancelled, so keying the parent
+/// step's status off <c>childResult.IsSuccess</c> alone would falsely mark the parent Completed.
+/// </summary>
+public sealed class SubPlanStepExecutorTests
+{
+    private readonly Mock<IPlanExecutor> _childExecutor = new();
+    private readonly Mock<IPlanProgressNotifier> _notifier = new();
+
+    [Theory]
+    [InlineData(StepExecutionStatus.Failed)]
+    [InlineData(StepExecutionStatus.Blocked)]
+    [InlineData(StepExecutionStatus.Cancelled)]
+    public async Task ExecuteAsync_ChildPlanDidNotSucceed_ReturnsFailedNotCompleted(StepExecutionStatus childFinalStatus)
+    {
+        var childPlanId = PlanId.New();
+        var summary = new PlanExecutionSummary
+        {
+            PlanId = childPlanId,
+            FinalStatus = childFinalStatus,
+            TotalDuration = TimeSpan.FromSeconds(1),
+            StepStates = []
+        };
+        _childExecutor
+            .Setup(e => e.ExecuteAsync(It.IsAny<PlanId>(), It.IsAny<PlanExecutionContext>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<PlanExecutionSummary>.Success(summary));
+
+        var executor = BuildExecutor();
+        var step = SubPlanStep(childPlanId);
+
+        var result = await executor.ExecuteAsync(step, EmptyOutputs, CancellationToken.None);
+
+        Assert.NotEqual(StepExecutionStatus.Completed, result.Status);
+        Assert.Equal(StepExecutionStatus.Failed, result.Status);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ChildPlanCompleted_ReturnsCompleted()
+    {
+        var childPlanId = PlanId.New();
+        var summary = new PlanExecutionSummary
+        {
+            PlanId = childPlanId,
+            FinalStatus = StepExecutionStatus.Completed,
+            TotalDuration = TimeSpan.FromSeconds(1),
+            StepStates = []
+        };
+        _childExecutor
+            .Setup(e => e.ExecuteAsync(It.IsAny<PlanId>(), It.IsAny<PlanExecutionContext>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<PlanExecutionSummary>.Success(summary));
+
+        var executor = BuildExecutor();
+        var step = SubPlanStep(childPlanId);
+
+        var result = await executor.ExecuteAsync(step, EmptyOutputs, CancellationToken.None);
+
+        Assert.Equal(StepExecutionStatus.Completed, result.Status);
+    }
+
+    private static readonly IReadOnlyDictionary<PlanStepId, string> EmptyOutputs =
+        new Dictionary<PlanStepId, string>();
+
+    private SubPlanStepExecutor BuildExecutor()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton(_childExecutor.Object);
+        var provider = services.BuildServiceProvider();
+
+        return new SubPlanStepExecutor(
+            provider.GetRequiredService<IServiceScopeFactory>(),
+            Mock.Of<IPlanStateStore>(),
+            _notifier.Object,
+            new PlanExecutionContext { Depth = 0, MaxDepth = 5 },
+            NullLogger<SubPlanStepExecutor>.Instance);
+    }
+
+    private static PlanStep SubPlanStep(PlanId childPlanId) => new()
+    {
+        Id = PlanStepId.New(),
+        Name = "sub-plan-step",
+        Type = StepType.SubPlanInvocation,
+        Configuration = new SubPlanConfig { ChildPlanId = childPlanId },
+        RetryPolicy = new RetryPolicy { MaxRetries = 0 }
+    };
+}


### PR DESCRIPTION
## Problem (CRITICAL)
Crash-resume of a DAG plan was broken end-to-end, and interrupted plans falsely reported `Completed`. On resume the state store rewrites an interrupted `Running` step to `Ready`, but the executor only ever re-enqueued `Pending` steps — so the step was never re-run, the scheduler went idle, and `BuildSummary` (seeing nothing Failed/Blocked/Cancelled) returned `FinalStatus = Completed` for a plan whose work never finished. Manual retry (`RetryStepAsync`) had the same stranding bug. The one existing resume test mocked the store and only covered already-`Completed` prior states, which is why it slipped through.

## Fix
- `InitializeStepStates` normalizes a resumed step that is `Running` **or** `Ready` → `Pending`, so both crash windows re-enter the scheduling queue. `RetryStepAsync` resets to `Pending`, not `Ready`.
- `BuildSummary` returns `Failed` (not `Completed`) when non-terminal steps remain with no failure/block/cancel to explain the pause; a new `NotifyPlanFailureAsync` fires the failed notification. Precedence `Failed > Blocked > Cancelled > non-terminal > Completed` is preserved (a plan legitimately paused on a Blocked human gate still reports Blocked).
- **Sub-plan honesty:** `SubPlanStepExecutor` now marks the parent step `Completed` only when the child `IsSuccess` **and** `FinalStatus == Completed` — so a failed or stranded child sub-plan no longer reports success upward (previously it keyed off `IsSuccess` alone and swallowed the child's real status).

Fix is at the executor's `InitializeStepStates` chokepoint rather than changing the documented `ResumeAsync` store contract — lower blast radius, and it covers the `Ready` crash window a store-only fix would miss.

## Test plan
New `PlanExecutorResumeRecoveryTests` use a **real** `EfCorePlanStateStore` + in-memory SQLite (not a mock): resume-after-crash re-executes the step and completes; a failing re-run reports `Failed` not `Completed`; a stranded step is not reported `Completed`; retry re-executes. New `SubPlanStepExecutorTests` (Theory over Failed/Blocked/Cancelled) prove a non-completing child yields a Failed parent step. All fail before the fix, pass after. Planner suite: **128/128**, build clean 0 warnings. (3 pre-existing FileSystem tests fail in the sandbox env only, unrelated.)

## Review
Independent adversarial **correctness review**: verdict SAFE TO MERGE AS-IS, no critical/high — resume correctness, dependency re-evaluation, summary precedence, and the absence of double-execution of completed steps all verified. At-least-once resume semantics for non-idempotent step types are now documented on `IPlanStepExecutor`.

Part of the Wave-1 "inert machinery" remediation from the deep audit.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>