### PR TITLE
fix: gate sensitive-data trace export behind content-capture config

### DIFF
--- a/src/Content/Application/Application.AI.Common/Factories/AgentFactory.cs
+++ b/src/Content/Application/Application.AI.Common/Factories/AgentFactory.cs
@@ -1,6 +1,7 @@
 using Application.AI.Common.Interfaces;
 using Application.AI.Common.Interfaces.Routing;
 using Application.AI.Common.Interfaces.Skills;
+using Application.AI.Common.Interfaces.Telemetry;
 using Application.AI.Common.Models;
 using Domain.AI.Agents;
 using Domain.AI.Routing.Models;
@@ -143,9 +144,12 @@ public class AgentFactory : IAgentFactory
             ? await CreateFoundryResponsesAgentAsync(agentContext, deploymentOrAgentId, agentOptions, cancellationToken)
             : await CreateChatClientAgentAsync(agentContext, clientType, deploymentOrAgentId, agentOptions, cancellationToken);
 
-        // Wrap with agent-level OpenTelemetry (sensitive data off at this level)
+        // Wrap with agent-level OpenTelemetry. Sensitive-data capture is gated by the
+        // configured content-capture policy (default off) — never hardcoded on.
+        var captureSensitive = ShouldEnableSensitiveData(
+            _serviceProvider.GetService<IContentCapturePolicy>());
         return agent.AsBuilder()
-            .UseOpenTelemetry(configure: c => c.EnableSensitiveData = false)
+            .UseOpenTelemetry(configure: c => c.EnableSensitiveData = captureSensitive)
             .Build();
     }
 
@@ -203,8 +207,14 @@ public class AgentFactory : IAgentFactory
     /// </summary>
     private IChatClient BuildMiddlewarePipeline(IChatClient chatClient, AgentExecutionContext agentContext)
     {
+        // Gate prompt/completion/tool-argument capture behind the configured content-capture
+        // policy (default off). Previously hardcoded true, which exported sensitive content to
+        // every trace exporter in every deployment.
+        var captureSensitive = ShouldEnableSensitiveData(
+            _serviceProvider.GetService<IContentCapturePolicy>());
+
         var chatClientBuilder = chatClient.AsBuilder()
-            .UseOpenTelemetry(configure: c => c.EnableSensitiveData = true)
+            .UseOpenTelemetry(configure: c => c.EnableSensitiveData = captureSensitive)
             .UseFunctionInvocation(configure: c =>
             {
                 c.AllowConcurrentInvocation = true;
@@ -254,6 +264,35 @@ public class AgentFactory : IAgentFactory
 
         return chatClientBuilder.Build();
     }
+
+    /// <summary>
+    /// Computes whether the OpenTelemetry chat/agent instrumentation may attach sensitive GenAI
+    /// content — prompts, completions, and tool-call arguments/results — to spans. Returns
+    /// <see langword="true"/> only when the configured <see cref="IContentCapturePolicy"/> permits
+    /// at least one such capture; defaults to <see langword="false"/> (the secure default) when no
+    /// policy is registered.
+    /// </summary>
+    /// <param name="policy">
+    /// The content-capture policy resolved from configuration, or <see langword="null"/> when the
+    /// content-capture pipeline is not wired into the container.
+    /// </param>
+    /// <returns>
+    /// <see langword="true"/> to enable OpenTelemetry sensitive-data capture; otherwise
+    /// <see langword="false"/>.
+    /// </returns>
+    /// <remarks>
+    /// The single OTel <c>EnableSensitiveData</c> boolean cannot express the policy's finer-grained
+    /// per-attribute toggles (prompt vs. output vs. tool arguments vs. tool result). It is therefore
+    /// driven by the "is any sensitive capture enabled" decision. Enforcing each attribute
+    /// independently would require a dedicated GenAI span processor that strips the disallowed
+    /// attributes after the built-in instrumentation writes them — tracked as a follow-up.
+    /// </remarks>
+    internal static bool ShouldEnableSensitiveData(IContentCapturePolicy? policy)
+        => policy is not null
+           && (policy.ShouldCapturePromptContent()
+               || policy.ShouldCaptureOutputContent()
+               || policy.ShouldCaptureToolCallArguments()
+               || policy.ShouldCaptureToolCallResult());
 
     /// <inheritdoc />
     public async Task<(AIAgent Agent, string AgentId)> CreatePersistentAgentAsync(

--- a/src/Content/Tests/Application.AI.Common.Tests/Application.AI.Common.Tests.csproj
+++ b/src/Content/Tests/Application.AI.Common.Tests/Application.AI.Common.Tests.csproj
@@ -24,6 +24,9 @@
     <!-- The ASI06 memory-poisoning fixture drives the real KnowledgeMemoryService quarantine
          runtime (write gate + trust-aware recall) instead of a hardcoded stub. -->
     <ProjectReference Include="../../Infrastructure/Infrastructure.AI.KnowledgeGraph/Infrastructure.AI.KnowledgeGraph.csproj" />
+    <!-- Drives the real ContentCapturePolicy (backed by AppConfig) through the AgentFactory
+         sensitive-data gate so the test proves the config default (off), not a stub. -->
+    <ProjectReference Include="../../Infrastructure/Infrastructure.AI/Infrastructure.AI.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentFactorySensitiveDataGateTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentFactorySensitiveDataGateTests.cs
@@ -1,0 +1,82 @@
+using Application.AI.Common.Factories;
+using Application.AI.Common.Interfaces.Telemetry;
+using Domain.Common.Config;
+using Domain.Common.Config.AI;
+using Domain.Common.Config.AI.Telemetry;
+using FluentAssertions;
+using Infrastructure.AI.Telemetry.Redaction;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Application.AI.Common.Tests.Factories;
+
+/// <summary>
+/// Proves that the OpenTelemetry <c>EnableSensitiveData</c> flag AgentFactory sets on the
+/// chat-client and agent instrumentation is driven by the configured content-capture policy
+/// (default OFF) rather than hardcoded on. Regression guard for the finding that prompts,
+/// completions, and tool arguments were exported to every trace exporter in every deployment.
+/// </summary>
+public sealed class AgentFactorySensitiveDataGateTests
+{
+    private static IContentCapturePolicy PolicyFor(ContentCaptureConfig contentCapture)
+    {
+        var appConfig = new AppConfig
+        {
+            AI = new AIConfig
+            {
+                Telemetry = new TelemetryConfig { ContentCapture = contentCapture }
+            }
+        };
+        var monitor = Mock.Of<IOptionsMonitor<AppConfig>>(m => m.CurrentValue == appConfig);
+        return new ContentCapturePolicy(monitor, NullLogger<ContentCapturePolicy>.Instance);
+    }
+
+    [Fact]
+    public void ShouldEnableSensitiveData_DefaultConfig_ReturnsFalse()
+    {
+        // Default ContentCaptureConfig => master flag off, every per-attribute toggle off.
+        var policy = PolicyFor(new ContentCaptureConfig());
+
+        AgentFactory.ShouldEnableSensitiveData(policy).Should().BeFalse(
+            "content capture defaults to off, so sensitive prompt/completion/tool data must not be exported");
+    }
+
+    [Fact]
+    public void ShouldEnableSensitiveData_NoPolicyRegistered_ReturnsFalse()
+    {
+        // Secure default: absent policy (content-capture pipeline not wired) must not enable capture.
+        AgentFactory.ShouldEnableSensitiveData(null).Should().BeFalse();
+    }
+
+    [Fact]
+    public void ShouldEnableSensitiveData_MasterEnabledButAllAttributesOff_ReturnsFalse()
+    {
+        var policy = PolicyFor(new ContentCaptureConfig { Enabled = true });
+
+        AgentFactory.ShouldEnableSensitiveData(policy).Should().BeFalse(
+            "flipping only the master flag with no attribute opted in captures nothing");
+    }
+
+    [Theory]
+    [InlineData(true, false, false, false)]
+    [InlineData(false, true, false, false)]
+    [InlineData(false, false, true, false)]
+    [InlineData(false, false, false, true)]
+    public void ShouldEnableSensitiveData_ConfigFlagFlippedOn_ReturnsTrue(
+        bool prompt, bool output, bool toolArgs, bool toolResult)
+    {
+        var policy = PolicyFor(new ContentCaptureConfig
+        {
+            Enabled = true,
+            CapturePromptContent = prompt,
+            CaptureOutputContent = output,
+            CaptureToolCallArguments = toolArgs,
+            CaptureToolCallResult = toolResult
+        });
+
+        AgentFactory.ShouldEnableSensitiveData(policy).Should().BeTrue(
+            "enabling any sensitive content-capture attribute must flip the OTel sensitive-data flag on");
+    }
+}


### PR DESCRIPTION
## Problem (HIGH, security)
Full prompts, completions, and tool arguments were exported to **every** trace exporter in every deployment. `AgentFactory` hardcoded `UseOpenTelemetry(c => c.EnableSensitiveData = true)` on the chat-client pipeline, bypassing the purpose-built, config-gated `ContentCapturePolicy` that defaults **off**. PII/secrets in user prompts landed in Jaeger / Azure Monitor / the SignalR dashboard. (A second capture site was hardcoded the opposite way — `false` — so agent-level content was suppressed even when an operator wanted it, an inconsistency.)

## Fix
Both `UseOpenTelemetry` sites now derive `EnableSensitiveData` from a pure helper `ShouldEnableSensitiveData(IContentCapturePolicy?)` that reads the existing, already-bound `AppConfig.AI.Telemetry.ContentCapture` policy (defaults all-off; a null policy → false). The policy is now the single source of truth. Resolved optionally via the service provider, so the constructor signature is unchanged.

## Test plan
New `AgentFactorySensitiveDataGateTests` (7 cases) drive the **real** `ContentCapturePolicy` from a real `AppConfig`:
- default config → false; no policy registered → false; master-enabled-but-all-attributes-off → false; each attribute flipped on → true.

Did not compile against the old hardcoded `true` (RED); 7/7 pass after. Full `Application.AI.Common.Tests`: 1307/1307, 0 warnings.

## Notes
- Intended behavior change: when content-capture is **explicitly enabled**, agent-level spans now also emit sensitive data (single source of truth). The default-off posture is unchanged.
- Tracked follow-up (not built): honoring the policy's per-attribute toggles (prompt vs output vs tool-args vs tool-result) independently needs a dedicated GenAI span processor — the single OTel `EnableSensitiveData` boolean can't express that granularity.

## Review
Self-reviewed (correctness + simplify). No findings.

Wave-2 security cluster, from the deep audit.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>