### PR TITLE
fix: bind localhost and scope file-system base path by default

### DIFF
--- a/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.cs
@@ -122,7 +122,15 @@ public static partial class DependencyInjection
                 ? Path.GetFullPath(lp, exeDir)
                 : string.Empty)
             .Where(p => !string.IsNullOrEmpty(p))
-            .Distinct();
+            .Distinct()
+            .ToArray();
+
+        // Ensure each configured sandbox base path exists so the file-system tool can read/list an
+        // out-of-box 'workspace' directory instead of failing on a missing folder. Idempotent for
+        // pre-existing paths (repo root, logs). A genuinely uncreatable path is a misconfiguration
+        // and surfaces loudly at startup rather than being silently masked.
+        foreach (var basePath in allowedBasePaths)
+            Directory.CreateDirectory(basePath);
 
         RegisterToolServices(services, appConfig, allowedBasePaths);
 

--- a/src/Content/Presentation/Presentation.AgentHub/appsettings.json
+++ b/src/Content/Presentation/Presentation.AgentHub/appsettings.json
@@ -10,7 +10,8 @@
   "AppConfig": {
     "Infrastructure": {
       "FileSystem": {
-        "AllowedBasePaths": [ "../../../../../../.." ]
+        "//": "SAFE DEFAULT: the file-system tool is sandboxed to a dedicated 'workspace' folder under the app content root (auto-created on startup), NOT the repository root. To allow broader repo access for local exploration, add wider paths in appsettings.Development.json — never here in the base default.",
+        "AllowedBasePaths": [ "workspace" ]
       }
     },
     "AI": {
@@ -364,9 +365,10 @@
     }
   },
   "Kestrel": {
+    "//": "SAFE DEFAULT: binds loopback only so a plain 'dotnet run' is NOT reachable from the LAN. Binding every interface is a deliberate PRODUCTION/container decision — override via the env var Kestrel__Endpoints__Http__Url=http://+:52000 (double underscore). NOTE: ASPNETCORE_URLS is IGNORED whenever Kestrel:Endpoints is set here, so the container override MUST use the Kestrel__Endpoints__* key, not ASPNETCORE_URLS.",
     "Endpoints": {
-      "Http":  { "Url": "http://*:52000" },
-      "Https": { "Url": "https://*:52001" }
+      "Http":  { "Url": "http://localhost:52000" },
+      "Https": { "Url": "https://localhost:52001" }
     }
   },
   "Logging": {

--- a/src/Content/Presentation/Presentation.ConsoleUI/appsettings.json
+++ b/src/Content/Presentation/Presentation.ConsoleUI/appsettings.json
@@ -14,7 +14,8 @@
     },
     "Infrastructure": {
       "FileSystem": {
-        "AllowedBasePaths": [ "../../../../../../.." ]
+        "//": "SAFE DEFAULT: the file-system tool is sandboxed to a dedicated 'workspace' folder under the app content root (auto-created on startup), NOT the repository root. To allow broader repo access for local exploration, add wider paths in appsettings.Development.json — never here in the base default.",
+        "AllowedBasePaths": [ "workspace" ]
       }
     },
     "AI": {

--- a/src/Content/Presentation/Presentation.EvalRunner/appsettings.json
+++ b/src/Content/Presentation/Presentation.EvalRunner/appsettings.json
@@ -14,7 +14,8 @@
     },
     "Infrastructure": {
       "FileSystem": {
-        "AllowedBasePaths": [ "../../../../../../.." ]
+        "//": "SAFE DEFAULT: the file-system tool is sandboxed to a dedicated 'workspace' folder under the app content root (auto-created on startup), NOT the repository root. Eval fixtures are read directly by the runner, not through this sandboxed tool.",
+        "AllowedBasePaths": [ "workspace" ]
       }
     },
     "AI": {

--- a/src/Content/Tests/Presentation.AgentHub.Tests/Configuration/SafeDefaultHostPostureTests.cs
+++ b/src/Content/Tests/Presentation.AgentHub.Tests/Configuration/SafeDefaultHostPostureTests.cs
@@ -1,0 +1,73 @@
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+namespace Presentation.AgentHub.Tests.Configuration;
+
+/// <summary>
+/// Security guard tests pinning a safe out-of-box host posture in the SHIPPED base
+/// <c>appsettings.json</c> of every host. These files are what enterprise consumers clone and
+/// run first; a wildcard Kestrel bind or a repository-root file-system sandbox turns a plain
+/// <c>dotnet run</c> into an unauthenticated agent reachable from the LAN with read access to the
+/// whole repo. The guard fails the build if either regresses.
+/// </summary>
+/// <remarks>
+/// The base config is asserted deliberately (no environment overlay). Broad local-exploration
+/// access is allowed to live in <c>appsettings.Development.json</c> — never in the base default.
+/// </remarks>
+public sealed class SafeDefaultHostPostureTests
+{
+    private const string AllowedBasePathsKey =
+        "AppConfig:Infrastructure:FileSystem:AllowedBasePaths";
+
+    private static IConfigurationRoot LoadBaseConfig(string linkedFileName) =>
+        new ConfigurationBuilder()
+            .AddJsonFile(Path.Combine(AppContext.BaseDirectory, "host-config", linkedFileName),
+                optional: false)
+            .Build();
+
+    [Fact]
+    public void AgentHubBaseConfig_KestrelBindsLocalhostOnly_NotWildcard()
+    {
+        var config = LoadBaseConfig("agenthub.appsettings.json");
+
+        var httpUrl = config["Kestrel:Endpoints:Http:Url"];
+        var httpsUrl = config["Kestrel:Endpoints:Https:Url"];
+
+        httpUrl.Should().NotBeNullOrWhiteSpace();
+        AssertLoopbackBind(httpUrl!);
+        if (!string.IsNullOrWhiteSpace(httpsUrl))
+            AssertLoopbackBind(httpsUrl!);
+    }
+
+    [Theory]
+    [InlineData("agenthub.appsettings.json")]
+    [InlineData("consoleui.appsettings.json")]
+    [InlineData("evalrunner.appsettings.json")]
+    [InlineData("foundryhost.appsettings.json")]
+    public void HostBaseConfig_FileSystemBasePath_IsScoped_NotRepositoryRoot(string linkedFileName)
+    {
+        var config = LoadBaseConfig(linkedFileName);
+
+        var basePaths = config.GetSection(AllowedBasePathsKey).Get<string[]>();
+
+        basePaths.Should().NotBeNullOrEmpty(
+            "every host must scope the file-system tool to an explicit base path");
+        basePaths.Should().OnlyContain(
+            p => !p.Contains("..", StringComparison.Ordinal),
+            "a parent-directory traversal ('..') escapes the app content root toward the repository root");
+    }
+
+    private static void AssertLoopbackBind(string url)
+    {
+        url.Should().NotContain("*",
+            "a wildcard host binds every network interface, exposing the agent on the LAN");
+        url.Should().NotContain("0.0.0.0",
+            "0.0.0.0 binds every network interface, exposing the agent on the LAN");
+        url.Should().NotContain("+",
+            "'+' binds every network interface (strong wildcard), exposing the agent on the LAN");
+        (url.Contains("localhost", StringComparison.OrdinalIgnoreCase)
+            || url.Contains("127.0.0.1", StringComparison.Ordinal))
+            .Should().BeTrue("the shipped default must bind loopback only");
+    }
+}

--- a/src/Content/Tests/Presentation.AgentHub.Tests/Presentation.AgentHub.Tests.csproj
+++ b/src/Content/Tests/Presentation.AgentHub.Tests/Presentation.AgentHub.Tests.csproj
@@ -27,4 +27,16 @@
     <ProjectReference Include="..\..\Presentation\Presentation.AgentHub\Presentation.AgentHub.csproj" />
   </ItemGroup>
 
+  <!--
+    Guard test inputs: the SHIPPED base appsettings.json for every host. Copied verbatim into the
+    test output so SafeDefaultHostPostureTests can assert the out-of-box posture (localhost bind,
+    scoped file-system base path) against the real files consumers clone.
+  -->
+  <ItemGroup>
+    <Content Include="..\..\Presentation\Presentation.AgentHub\appsettings.json" Link="host-config\agenthub.appsettings.json" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="..\..\Presentation\Presentation.ConsoleUI\appsettings.json" Link="host-config\consoleui.appsettings.json" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="..\..\Presentation\Presentation.EvalRunner\appsettings.json" Link="host-config\evalrunner.appsettings.json" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="..\..\Presentation\Presentation.FoundryHost\appsettings.json" Link="host-config\foundryhost.appsettings.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
## Problem (HIGH, security)
Out of the box, `dotnet run` exposed an unauthenticated agent on **all** network interfaces with file access to the **entire repository**. Three defaults composed badly: a wildcard Kestrel bind (`http://*:52000`) in the base config, committed dev-auth-off, and a `file_system` tool `AllowedBasePaths` that resolved to the repo root.

## Fix
- **Bind localhost by default.** Base `Kestrel:Endpoints` → `http://localhost:52000` / `https://localhost:52001`. Verified that `Kestrel:Endpoints` config **overrides** `ASPNETCORE_URLS` (this override is exactly why the wildcard was winning over the launch-profile localhost), so the documented production/container override is the `Kestrel__Endpoints__Http__Url` env var — not `ASPNETCORE_URLS`. A wildcard bind stays a deliberate, env-var opt-in for production, never a shipped default.
- **Scope the file-system tool.** Default `AllowedBasePaths` → `workspace/` (auto-created) across AgentHub, ConsoleUI, and EvalRunner (FoundryHost already shipped this). The path-traversal validation itself is untouched — only the default base path narrowed.

## Test plan
Guard tests (`SafeDefaultHostPostureTests`): the base Kestrel URLs contain no `*`/`0.0.0.0`/`+`, and each host's `AllowedBasePaths` is non-empty and free of `..` traversal. 4 fail on the old defaults, 5/5 pass after. `Presentation.AgentHub` builds clean (0 warnings); Infrastructure.AI file-system tests 145 pass. (3 pre-existing FileSystem integration failures are sandbox-env only — proven by stash + re-run.)

## Notes
- Only AgentHub had the wildcard bind; FoundryHost's container bind (`ASPNETCORE_URLS` in its Dockerfile, no `Kestrel:Endpoints`) is intentional and left as-is.
- The `appsettings.Development.json` files are permission-blocked in this environment, so rather than relocating the broad dev path there, `workspace` is the effective default in every environment (stricter-safe); broad local access is documented as a one-line opt-in.

## Review
Self-reviewed (correctness + simplify). No findings.

Wave-2 security cluster, from the deep audit.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>