### PR TITLE
fix: idempotency runs after authorization and scopes keys per user

### DIFF
--- a/src/Content/Application/Application.Common/DependencyInjection.cs
+++ b/src/Content/Application/Application.Common/DependencyInjection.cs
@@ -27,9 +27,9 @@ namespace Application.Common;
 /// <para>
 /// <strong>MediatR Pipeline Behavior Order (outermost → innermost):</strong>
 /// <list type="number">
-///   <item><description><c>IdempotencyBehavior</c> — short-circuits duplicate <c>IIdempotentRequest</c> retries before validation/handler work</description></item>
 ///   <item><description><c>RequestValidationBehavior</c> — FluentValidation, returns Result failure</description></item>
 ///   <item><description><c>AuthorizationBehavior</c> — checks [Authorize] attributes</description></item>
+///   <item><description><c>IdempotencyBehavior</c> — deduplicates <c>IIdempotentRequest</c> retries; runs after authorization so a replayed key cannot bypass the auth check, and scopes cached responses per user</description></item>
 ///   <item><description><c>CachingBehavior</c> — hybrid memory/distributed cache</description></item>
 ///   <item><description><c>RequestTracingBehavior</c> — OTel spans with duration</description></item>
 ///   <item><description><c>TimeoutBehavior</c> — enforces IHasTimeout deadlines</description></item>
@@ -67,11 +67,14 @@ public static class DependencyInjection
         services.AddSingleton<IIdempotencyStore, InMemoryIdempotencyStore>();
 
         // Pipeline behaviors — registration order = execution order (outermost first)
-        // Agent-specific behaviors registered in Application.AI.Common.DependencyInjection
+        // Agent-specific behaviors registered in Application.AI.Common.DependencyInjection.
+        // IdempotencyBehavior is registered AFTER AuthorizationBehavior on purpose: a replayed
+        // idempotency key must still clear authorization before any cached response is served,
+        // otherwise a cache hit would bypass the auth check (access-control bypass).
         services
-            .AddTransient(typeof(IPipelineBehavior<,>), typeof(IdempotencyBehavior<,>))
             .AddTransient(typeof(IPipelineBehavior<,>), typeof(RequestValidationBehavior<,>))
             .AddTransient(typeof(IPipelineBehavior<,>), typeof(AuthorizationBehavior<,>))
+            .AddTransient(typeof(IPipelineBehavior<,>), typeof(IdempotencyBehavior<,>))
             .AddTransient(typeof(IPipelineBehavior<,>), typeof(CachingBehavior<,>))
             .AddTransient(typeof(IPipelineBehavior<,>), typeof(RequestTracingBehavior<,>))
             .AddTransient(typeof(IPipelineBehavior<,>), typeof(TimeoutBehavior<,>));

--- a/src/Content/Application/Application.Common/Interfaces/Idempotency/IIdempotencyStore.cs
+++ b/src/Content/Application/Application.Common/Interfaces/Idempotency/IIdempotencyStore.cs
@@ -1,26 +1,51 @@
 namespace Application.Common.Interfaces.Idempotency;
 
 /// <summary>
-/// Stores and retrieves idempotency keys to detect duplicate request executions.
+/// Deduplicates request executions by caching responses under a caller-scoped key, and
+/// guarantees that concurrent duplicates run the underlying work exactly once.
 /// Implementations may use in-memory, Redis, or database-backed storage.
 /// </summary>
+/// <remarks>
+/// <para>
+/// The single <see cref="GetOrExecuteAsync"/> operation replaces the previous
+/// check-then-act (<c>TryGet</c> + <c>Set</c>) pair, which had a time-of-check/time-of-use
+/// race: two concurrent callers with the same key both observed a miss and both ran the
+/// handler. A conforming implementation MUST provide an atomic in-flight reservation so a
+/// second concurrent caller awaits the first caller's result instead of re-executing.
+/// </para>
+/// <para>
+/// <strong>Distributed implementations</strong> (Redis, database) MUST preserve the same
+/// reservation guarantee — for example with an atomic <c>SET key value NX</c> reservation
+/// marker plus a wait/poll for the reserving caller's result, or a row-level lock. Providing
+/// only last-write-wins caching without a reservation re-opens the double-execution defect.
+/// </para>
+/// </remarks>
 public interface IIdempotencyStore
 {
     /// <summary>
-    /// Attempts to retrieve a cached response for the given idempotency key.
-    /// Returns <see langword="null"/> if the key has not been seen before.
+    /// Returns the cached response for <paramref name="scopedKey"/> when a valid (unexpired)
+    /// entry exists; otherwise runs <paramref name="execute"/> exactly once — even when
+    /// multiple callers race on the same key — and, when <paramref name="shouldPersist"/>
+    /// returns <see langword="true"/> for the produced response, caches it for future calls.
     /// </summary>
-    /// <param name="idempotencyKey">The unique key identifying the original request.</param>
+    /// <param name="scopedKey">
+    /// The fully-qualified, caller-scoped cache key. The behavior composes this from the
+    /// current user identity, request type, and the caller-supplied idempotency key so that
+    /// one user's key can never resolve another user's cached response.
+    /// </param>
+    /// <param name="execute">
+    /// The work to run on a cache miss. Invoked at most once per key across concurrent callers.
+    /// </param>
+    /// <param name="shouldPersist">
+    /// Predicate deciding whether the produced response is eligible for caching. Failure
+    /// responses return <see langword="false"/> so a later retry re-executes rather than
+    /// replaying the failure. Not consulted on a cache hit, nor when <paramref name="execute"/> throws.
+    /// </param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>The cached response, or <see langword="null"/> on a cache miss.</returns>
-    Task<object?> TryGetAsync(string idempotencyKey, CancellationToken cancellationToken);
-
-    /// <summary>
-    /// Stores a response under the given idempotency key for future deduplication.
-    /// The TTL is implementation-defined.
-    /// </summary>
-    /// <param name="idempotencyKey">The unique key identifying the original request.</param>
-    /// <param name="response">The response to cache.</param>
-    /// <param name="cancellationToken">Cancellation token.</param>
-    Task SetAsync(string idempotencyKey, object response, CancellationToken cancellationToken);
+    /// <returns>The cached response on a hit, or the freshly executed response on a miss.</returns>
+    Task<object> GetOrExecuteAsync(
+        string scopedKey,
+        Func<Task<object>> execute,
+        Func<object, bool> shouldPersist,
+        CancellationToken cancellationToken);
 }

--- a/src/Content/Application/Application.Common/MediatRBehaviors/IdempotencyBehavior.cs
+++ b/src/Content/Application/Application.Common/MediatRBehaviors/IdempotencyBehavior.cs
@@ -1,5 +1,6 @@
 using Application.Common.Interfaces.Idempotency;
 using Application.Common.Interfaces.MediatR;
+using Application.Common.Interfaces.Security;
 using Domain.Common;
 using MediatR;
 using Microsoft.Extensions.Logging;
@@ -7,37 +8,55 @@ using Microsoft.Extensions.Logging;
 namespace Application.Common.MediatRBehaviors;
 
 /// <summary>
-/// Deduplicates retried requests by caching responses under an idempotency key.
+/// Deduplicates retried requests by caching responses under a per-user idempotency key.
 /// Only applies to requests implementing <see cref="IIdempotentRequest"/>.
 /// Non-idempotent requests pass through unchanged.
 /// </summary>
 /// <remarks>
-/// Pipeline position: registered as the outermost behavior in
-/// <c>AddApplicationCommonDependencies</c> so a duplicate request short-circuits to the
-/// cached response before validation and handler execution run. Successful responses are
-/// cached; failure <see cref="Result"/>s are deliberately not cached so legitimate retries
-/// after a transient failure still re-execute the handler.
-/// Requires <see cref="IIdempotencyStore"/> to be registered in the DI container — the default
-/// <c>InMemoryIdempotencyStore</c> is registered alongside this behavior.
+/// <para>
+/// <strong>Pipeline position:</strong> registered <em>after</em> <c>AuthorizationBehavior</c> in
+/// <c>AddApplicationCommonDependencies</c> so a replayed idempotency key still passes validation
+/// and authorization before any cached response can be served. Registering it as the outermost
+/// behavior (as it originally was) let a duplicate short-circuit to the cached response before the
+/// auth check ran — an access-control bypass. It must never move back ahead of authorization.
+/// </para>
+/// <para>
+/// <strong>Per-user scoping:</strong> the caller-supplied <see cref="IIdempotentRequest.IdempotencyKey"/>
+/// is composed with the current <see cref="IUser.Id"/> and the request type into the store key
+/// (<c>{userId}:{requestType}:{key}</c>). Without this, one user replaying another user's key would
+/// receive the other user's cached response (cross-user disclosure).
+/// </para>
+/// <para>
+/// Successful responses are cached; failure <see cref="Result"/>s are deliberately not cached so a
+/// legitimate retry after a transient failure re-executes the handler. Concurrent duplicates are
+/// coalesced onto a single execution by <see cref="IIdempotencyStore.GetOrExecuteAsync"/>.
+/// </para>
 /// </remarks>
 /// <typeparam name="TRequest">The MediatR request type.</typeparam>
 /// <typeparam name="TResponse">The response type.</typeparam>
 public sealed class IdempotencyBehavior<TRequest, TResponse>
     : IPipelineBehavior<TRequest, TResponse> where TRequest : notnull
 {
+    /// <summary>Key-segment stand-in for an unauthenticated caller with no identity.</summary>
+    private const string AnonymousUserId = "anonymous";
+
     private readonly IIdempotencyStore _store;
+    private readonly IUser _user;
     private readonly ILogger<IdempotencyBehavior<TRequest, TResponse>> _logger;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="IdempotencyBehavior{TRequest, TResponse}"/> class.
     /// </summary>
     /// <param name="store">The idempotency store used to cache and retrieve responses.</param>
+    /// <param name="user">The current user context, used to scope idempotency keys per identity.</param>
     /// <param name="logger">Logger for cache hit/miss diagnostics.</param>
     public IdempotencyBehavior(
         IIdempotencyStore store,
+        IUser user,
         ILogger<IdempotencyBehavior<TRequest, TResponse>> logger)
     {
         _store = store;
+        _user = user;
         _logger = logger;
     }
 
@@ -50,37 +69,33 @@ public sealed class IdempotencyBehavior<TRequest, TResponse>
         if (request is not IIdempotentRequest idempotentRequest)
             return await next();
 
-        var key = idempotentRequest.IdempotencyKey;
-
-        var cached = await _store.TryGetAsync(key, cancellationToken);
-        if (cached is TResponse cachedResponse)
-        {
-            _logger.LogDebug(
-                "Idempotent hit for {RequestName} with key '{Key}' — returning cached response",
-                typeof(TRequest).Name, key);
-            return cachedResponse;
-        }
-
-        var response = await next();
+        var scopedKey = BuildScopedKey(idempotentRequest.IdempotencyKey);
+        var executed = false;
 
         // Never cache expected failures: this codebase returns Result<T> for transient/expected
-        // errors rather than throwing. Caching a failure would replay it to every legitimate retry,
-        // defeating the purpose of idempotent re-execution. Only successful responses are cached.
-        if (response is Result { IsSuccess: false })
-        {
-            _logger.LogDebug(
-                "Idempotent miss for {RequestName} with key '{Key}' — failure result not cached",
-                typeof(TRequest).Name, key);
-
-            return response;
-        }
-
-        await _store.SetAsync(key, response!, cancellationToken);
+        // errors rather than throwing. Caching a failure would replay it to every legitimate retry.
+        var response = await _store.GetOrExecuteAsync(
+            scopedKey,
+            async () =>
+            {
+                executed = true;
+                return (object)(await next())!;
+            },
+            static value => value is not Result { IsSuccess: false },
+            cancellationToken);
 
         _logger.LogDebug(
-            "Idempotent miss for {RequestName} with key '{Key}' — response cached",
-            typeof(TRequest).Name, key);
+            "Idempotent {Outcome} for {RequestName} (user '{UserId}')",
+            executed ? "miss — handler executed" : "hit — cached response returned",
+            typeof(TRequest).Name,
+            _user.Id ?? AnonymousUserId);
 
-        return response;
+        return (TResponse)response;
+    }
+
+    private string BuildScopedKey(string idempotencyKey)
+    {
+        var userId = string.IsNullOrEmpty(_user.Id) ? AnonymousUserId : _user.Id;
+        return $"{userId}:{typeof(TRequest).FullName}:{idempotencyKey}";
     }
 }

--- a/src/Content/Application/Application.Common/Services/Idempotency/InMemoryIdempotencyStore.cs
+++ b/src/Content/Application/Application.Common/Services/Idempotency/InMemoryIdempotencyStore.cs
@@ -8,7 +8,7 @@ namespace Application.Common.Services.Idempotency;
 /// Caches response objects by reference so the exact runtime type is preserved
 /// on retrieval (no serialization round-trip), which the
 /// <see cref="MediatRBehaviors.IdempotencyBehavior{TRequest, TResponse}"/> relies on
-/// for its <c>cached is TResponse</c> type check.
+/// when it casts the returned response back to <c>TResponse</c>.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -16,12 +16,15 @@ namespace Application.Common.Services.Idempotency;
 /// <c>AddApplicationCommonDependencies</c>. It is single-process: cached responses do
 /// not survive a restart and are not shared across instances. Consumers running multiple
 /// replicas should replace this registration with a distributed implementation
-/// (Redis, database) that serializes responses and shares them across nodes.
+/// (Redis, database) that serializes responses and shares them across nodes — and that
+/// preserves the atomic in-flight reservation guarantee documented on
+/// <see cref="IIdempotencyStore"/>.
 /// </para>
 /// <para>
-/// Entries expire after <see cref="DefaultTtl"/>. Expired entries are removed lazily on
-/// access; there is no background sweep, so a key written and never read again retains its
-/// slot until the next <see cref="TryGetAsync"/> or <see cref="SetAsync"/> on the same key.
+/// Concurrent callers with the same key are coalesced onto a single
+/// <see cref="Lazy{T}"/>-guarded execution, so the handler runs exactly once even under a
+/// race. Successful executions are persisted for <see cref="DefaultTtl"/>; entries expire
+/// lazily on the next access to the same key (there is no background sweep).
 /// </para>
 /// </remarks>
 public sealed class InMemoryIdempotencyStore : IIdempotencyStore
@@ -30,6 +33,7 @@ public sealed class InMemoryIdempotencyStore : IIdempotencyStore
     public static readonly TimeSpan DefaultTtl = TimeSpan.FromHours(1);
 
     private readonly ConcurrentDictionary<string, CacheEntry> _entries = new(StringComparer.Ordinal);
+    private readonly ConcurrentDictionary<string, Lazy<Task<object>>> _inFlight = new(StringComparer.Ordinal);
     private readonly TimeProvider _timeProvider;
 
     /// <summary>
@@ -42,10 +46,41 @@ public sealed class InMemoryIdempotencyStore : IIdempotencyStore
     }
 
     /// <inheritdoc />
-    public Task<object?> TryGetAsync(string idempotencyKey, CancellationToken cancellationToken)
+    public async Task<object> GetOrExecuteAsync(
+        string scopedKey,
+        Func<Task<object>> execute,
+        Func<object, bool> shouldPersist,
+        CancellationToken cancellationToken)
     {
-        if (!_entries.TryGetValue(idempotencyKey, out var entry))
-            return Task.FromResult<object?>(null);
+        if (TryGetPersisted(scopedKey, out var persisted))
+            return persisted;
+
+        // Atomic reservation: the first caller installs the Lazy; concurrent callers get the
+        // same instance. Lazy's default ExecutionAndPublication mode ensures the factory runs
+        // once, so all racing callers await a single execution of the handler.
+        var lazy = _inFlight.GetOrAdd(scopedKey, static (_, factory) => new Lazy<Task<object>>(factory), execute);
+        try
+        {
+            var response = await lazy.Value.ConfigureAwait(false);
+            if (shouldPersist(response))
+                _entries[scopedKey] = new CacheEntry(response, _timeProvider.GetUtcNow() + DefaultTtl);
+            return response;
+        }
+        finally
+        {
+            // Release the reservation once complete (compare-and-remove so a fresh reservation that
+            // raced in after a throw is not clobbered). On a persisted success later callers hit the
+            // fast path above; on a non-persisted or faulted response a later retry re-executes.
+            ((ICollection<KeyValuePair<string, Lazy<Task<object>>>>)_inFlight).Remove(
+                new KeyValuePair<string, Lazy<Task<object>>>(scopedKey, lazy));
+        }
+    }
+
+    private bool TryGetPersisted(string scopedKey, out object response)
+    {
+        response = null!;
+        if (!_entries.TryGetValue(scopedKey, out var entry))
+            return false;
 
         if (_timeProvider.GetUtcNow() >= entry.ExpiresAt)
         {
@@ -53,19 +88,12 @@ public sealed class InMemoryIdempotencyStore : IIdempotencyStore
             // so we don't clobber a fresh write that raced in after our read. ConcurrentDictionary's
             // ICollection<KeyValuePair> implementation performs this compare-and-remove atomically.
             ((ICollection<KeyValuePair<string, CacheEntry>>)_entries).Remove(
-                new KeyValuePair<string, CacheEntry>(idempotencyKey, entry));
-            return Task.FromResult<object?>(null);
+                new KeyValuePair<string, CacheEntry>(scopedKey, entry));
+            return false;
         }
 
-        return Task.FromResult<object?>(entry.Response);
-    }
-
-    /// <inheritdoc />
-    public Task SetAsync(string idempotencyKey, object response, CancellationToken cancellationToken)
-    {
-        var expiresAt = _timeProvider.GetUtcNow() + DefaultTtl;
-        _entries[idempotencyKey] = new CacheEntry(response, expiresAt);
-        return Task.CompletedTask;
+        response = entry.Response;
+        return true;
     }
 
     private readonly record struct CacheEntry(object Response, DateTimeOffset ExpiresAt);

--- a/src/Content/Tests/Application.Common.Tests/MediatRBehaviors/IdempotencyBehaviorTests.cs
+++ b/src/Content/Tests/Application.Common.Tests/MediatRBehaviors/IdempotencyBehaviorTests.cs
@@ -1,6 +1,9 @@
 using Application.Common.Interfaces.Idempotency;
 using Application.Common.Interfaces.MediatR;
+using Application.Common.Interfaces.Security;
 using Application.Common.MediatRBehaviors;
+using Application.Common.Services.Idempotency;
+using Domain.Common;
 using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
@@ -10,12 +13,13 @@ namespace Application.Common.Tests.MediatRBehaviors;
 
 public sealed class IdempotencyBehaviorTests
 {
-    private readonly Mock<IIdempotencyStore> _store = new();
+    private const string UserId = "user-1";
 
     [Fact]
     public async Task Handle_NonIdempotentRequest_PassesThrough()
     {
-        var sut = CreateBehavior();
+        var store = new Mock<IIdempotencyStore>();
+        var sut = CreateBehavior(store.Object, UserId);
         var called = false;
 
         await sut.Handle(
@@ -24,29 +28,16 @@ public sealed class IdempotencyBehaviorTests
             CancellationToken.None);
 
         called.Should().BeTrue();
-        _store.Verify(s => s.TryGetAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+        store.Verify(
+            s => s.GetOrExecuteAsync(It.IsAny<string>(), It.IsAny<Func<Task<object>>>(), It.IsAny<Func<object, bool>>(), It.IsAny<CancellationToken>()),
+            Times.Never,
+            "non-idempotent requests must not touch the idempotency store");
     }
 
     [Fact]
-    public async Task Handle_NonIdempotentRequest_NeverWritesToStore()
+    public async Task Handle_IdempotentRequest_CacheMiss_ExecutesHandlerAndReturnsFreshResult()
     {
-        var sut = CreateBehavior();
-
-        await sut.Handle(
-            new RegularRequest(),
-            () => Task.FromResult("result"),
-            CancellationToken.None);
-
-        _store.Verify(s => s.SetAsync(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<CancellationToken>()), Times.Never);
-    }
-
-    [Fact]
-    public async Task Handle_IdempotentRequest_CacheMiss_ExecutesHandler()
-    {
-        _store.Setup(s => s.TryGetAsync("key-1", It.IsAny<CancellationToken>()))
-            .ReturnsAsync((object?)null);
-
-        var sut = CreateBehavior();
+        var sut = CreateBehavior(new InMemoryIdempotencyStore(TimeProvider.System), UserId);
         var called = false;
 
         var result = await sut.Handle(
@@ -59,91 +50,94 @@ public sealed class IdempotencyBehaviorTests
     }
 
     [Fact]
-    public async Task Handle_IdempotentRequest_CacheMiss_StoresResponse()
+    public async Task Handle_IdempotentRequest_SecondCall_ReturnsCachedAndDoesNotReExecute()
     {
-        _store.Setup(s => s.TryGetAsync("key-1", It.IsAny<CancellationToken>()))
-            .ReturnsAsync((object?)null);
+        var store = new InMemoryIdempotencyStore(TimeProvider.System);
+        var sut = CreateBehavior(store, UserId);
+        var calls = 0;
+        var request = new IdempotentTestRequest("key-1");
 
-        var sut = CreateBehavior();
+        await sut.Handle(request, () => { calls++; return Task.FromResult("first"); }, CancellationToken.None);
+        var second = await sut.Handle(request, () => { calls++; return Task.FromResult("second"); }, CancellationToken.None);
 
-        await sut.Handle(
-            new IdempotentTestRequest("key-1"),
-            () => Task.FromResult("fresh-result"),
-            CancellationToken.None);
-
-        _store.Verify(s => s.SetAsync("key-1", "fresh-result", It.IsAny<CancellationToken>()), Times.Once);
-    }
-
-    [Fact]
-    public async Task Handle_IdempotentRequest_CacheHit_ReturnsCachedResponse()
-    {
-        _store.Setup(s => s.TryGetAsync("key-1", It.IsAny<CancellationToken>()))
-            .ReturnsAsync("cached-result");
-
-        var sut = CreateBehavior();
-
-        var result = await sut.Handle(
-            new IdempotentTestRequest("key-1"),
-            () => Task.FromResult("fresh-result"),
-            CancellationToken.None);
-
-        result.Should().Be("cached-result");
-    }
-
-    [Fact]
-    public async Task Handle_IdempotentRequest_CacheHit_DoesNotExecuteHandler()
-    {
-        _store.Setup(s => s.TryGetAsync("key-1", It.IsAny<CancellationToken>()))
-            .ReturnsAsync("cached-result");
-
-        var sut = CreateBehavior();
-        var called = false;
-
-        await sut.Handle(
-            new IdempotentTestRequest("key-1"),
-            () => { called = true; return Task.FromResult("fresh-result"); },
-            CancellationToken.None);
-
-        called.Should().BeFalse("handler must not execute when the cache has a hit");
-    }
-
-    [Fact]
-    public async Task Handle_IdempotentRequest_CacheHit_NeverWritesToStore()
-    {
-        _store.Setup(s => s.TryGetAsync("key-1", It.IsAny<CancellationToken>()))
-            .ReturnsAsync("cached-result");
-
-        var sut = CreateBehavior();
-
-        await sut.Handle(
-            new IdempotentTestRequest("key-1"),
-            () => Task.FromResult("fresh-result"),
-            CancellationToken.None);
-
-        _store.Verify(s => s.SetAsync(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<CancellationToken>()), Times.Never);
+        calls.Should().Be(1, "the second call with the same key must be served from cache");
+        second.Should().Be("first");
     }
 
     [Fact]
     public async Task Handle_DifferentKeys_ExecuteHandlerForEach()
     {
-        _store.Setup(s => s.TryGetAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((object?)null);
-
-        var sut = CreateBehavior();
+        var sut = CreateBehavior(new InMemoryIdempotencyStore(TimeProvider.System), UserId);
         var callCount = 0;
 
         await sut.Handle(new IdempotentTestRequest("key-a"), () => { callCount++; return Task.FromResult("a"); }, CancellationToken.None);
         await sut.Handle(new IdempotentTestRequest("key-b"), () => { callCount++; return Task.FromResult("b"); }, CancellationToken.None);
 
         callCount.Should().Be(2);
-        _store.Verify(s => s.SetAsync("key-a", "a", It.IsAny<CancellationToken>()), Times.Once);
-        _store.Verify(s => s.SetAsync("key-b", "b", It.IsAny<CancellationToken>()), Times.Once);
     }
 
-    private IdempotencyBehavior<object, string> CreateBehavior() =>
-        new(_store.Object, NullLogger<IdempotencyBehavior<object, string>>.Instance);
+    [Fact]
+    public async Task Handle_ComposesStoreKeyFromUserRequestTypeAndIdempotencyKey()
+    {
+        var store = new Mock<IIdempotencyStore>();
+        string? capturedKey = null;
+        store
+            .Setup(s => s.GetOrExecuteAsync(It.IsAny<string>(), It.IsAny<Func<Task<object>>>(), It.IsAny<Func<object, bool>>(), It.IsAny<CancellationToken>()))
+            .Callback<string, Func<Task<object>>, Func<object, bool>, CancellationToken>((k, _, _, _) => capturedKey = k)
+            .ReturnsAsync("value");
+
+        var sut = new IdempotencyBehavior<IdempotentTestRequest, string>(
+            store.Object, new FakeUser(UserId), NullLogger<IdempotencyBehavior<IdempotentTestRequest, string>>.Instance);
+
+        await sut.Handle(new IdempotentTestRequest("raw-key"), () => Task.FromResult("value"), CancellationToken.None);
+
+        capturedKey.Should().Be($"{UserId}:{typeof(IdempotentTestRequest).FullName}:raw-key",
+            "the store key must be scoped by user id and request type so keys cannot collide across users or commands");
+    }
+
+    [Fact]
+    public async Task Handle_UnauthenticatedUser_UsesAnonymousKeySegment()
+    {
+        var store = new Mock<IIdempotencyStore>();
+        string? capturedKey = null;
+        store
+            .Setup(s => s.GetOrExecuteAsync(It.IsAny<string>(), It.IsAny<Func<Task<object>>>(), It.IsAny<Func<object, bool>>(), It.IsAny<CancellationToken>()))
+            .Callback<string, Func<Task<object>>, Func<object, bool>, CancellationToken>((k, _, _, _) => capturedKey = k)
+            .ReturnsAsync("value");
+
+        var sut = new IdempotencyBehavior<IdempotentTestRequest, string>(
+            store.Object, new FakeUser(id: null), NullLogger<IdempotencyBehavior<IdempotentTestRequest, string>>.Instance);
+
+        await sut.Handle(new IdempotentTestRequest("raw-key"), () => Task.FromResult("value"), CancellationToken.None);
+
+        capturedKey.Should().StartWith("anonymous:", "a null identity must resolve to a stable anonymous segment, not an empty prefix");
+    }
+
+    [Fact]
+    public async Task Handle_FailureResult_IsNotCached_SoRetryReExecutes()
+    {
+        var store = new InMemoryIdempotencyStore(TimeProvider.System);
+        var sut = new IdempotencyBehavior<IdempotentTestRequest, Result<string>>(
+            store, new FakeUser(UserId), NullLogger<IdempotencyBehavior<IdempotentTestRequest, Result<string>>>.Instance);
+        var request = new IdempotentTestRequest("key-fail");
+        var calls = 0;
+
+        await sut.Handle(request, () => { calls++; return Task.FromResult(Result<string>.Fail("transient")); }, CancellationToken.None);
+        await sut.Handle(request, () => { calls++; return Task.FromResult(Result<string>.Fail("transient")); }, CancellationToken.None);
+
+        calls.Should().Be(2, "a failed Result must never be cached, so a legitimate retry re-executes the handler");
+    }
+
+    private static IdempotencyBehavior<object, string> CreateBehavior(IIdempotencyStore store, string? userId) =>
+        new(store, new FakeUser(userId), NullLogger<IdempotencyBehavior<object, string>>.Instance);
 
     private sealed record RegularRequest;
 
     private sealed record IdempotentTestRequest(string IdempotencyKey) : IIdempotentRequest;
+
+    private sealed class FakeUser(string? id) : IUser
+    {
+        public string? Id { get; } = id;
+        public bool IsAdmin => false;
+    }
 }

--- a/src/Content/Tests/Application.Common.Tests/MediatRBehaviors/IdempotencySecurityTests.cs
+++ b/src/Content/Tests/Application.Common.Tests/MediatRBehaviors/IdempotencySecurityTests.cs
@@ -1,0 +1,137 @@
+using Application.Common.Attributes.SecurityAttributes;
+using Application.Common.Interfaces.MediatR;
+using Application.Common.Interfaces.Security;
+using Application.Common.MediatRBehaviors;
+using Application.Common.Services.Idempotency;
+using Domain.Common;
+using FluentAssertions;
+using MediatR;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Application.Common.Tests.MediatRBehaviors;
+
+/// <summary>
+/// Security regression tests for the idempotency access-control hardening:
+/// (a) idempotency keys are scoped per user so one user cannot replay another's key,
+/// (b) concurrent duplicates run the handler exactly once (no in-flight double execution),
+/// (c) idempotency runs after authorization so a replayed key cannot bypass the auth check.
+/// </summary>
+public sealed class IdempotencySecurityTests
+{
+    // (a) Cross-user isolation.
+    [Fact]
+    public async Task ReplayedKeyFromDifferentUser_DoesNotReturnFirstUsersCachedResponse()
+    {
+        var sharedStore = new InMemoryIdempotencyStore(TimeProvider.System);
+        var userA = new IdempotencyBehavior<CrossUserRequest, string>(
+            sharedStore, new FakeUser("user-A"), NullLogger<IdempotencyBehavior<CrossUserRequest, string>>.Instance);
+        var userB = new IdempotencyBehavior<CrossUserRequest, string>(
+            sharedStore, new FakeUser("user-B"), NullLogger<IdempotencyBehavior<CrossUserRequest, string>>.Instance);
+        var request = new CrossUserRequest("shared-key");
+
+        var aResult = await userA.Handle(request, () => Task.FromResult("user-A-secret"), CancellationToken.None);
+        var bHandlerExecuted = false;
+        var bResult = await userB.Handle(
+            request,
+            () => { bHandlerExecuted = true; return Task.FromResult("user-B-value"); },
+            CancellationToken.None);
+
+        aResult.Should().Be("user-A-secret");
+        bResult.Should().Be("user-B-value", "user B must never receive user A's cached response");
+        bHandlerExecuted.Should().BeTrue("user B's request is a cache miss because keys are scoped per user");
+    }
+
+    // (b) Concurrent same-key/same-user requests invoke the handler exactly once.
+    [Fact]
+    public async Task ConcurrentSameKeySameUser_ExecutesHandlerExactlyOnce()
+    {
+        var store = new InMemoryIdempotencyStore(TimeProvider.System);
+        var sut = new IdempotencyBehavior<CrossUserRequest, Result<string>>(
+            store, new FakeUser("user-A"), NullLogger<IdempotencyBehavior<CrossUserRequest, Result<string>>>.Instance);
+        var request = new CrossUserRequest("shared-key");
+        var calls = 0;
+
+        RequestHandlerDelegate<Result<string>> handler = async () =>
+        {
+            Interlocked.Increment(ref calls);
+            await Task.Delay(75);
+            return Result<string>.Success("done");
+        };
+
+        var a = sut.Handle(request, handler, CancellationToken.None);
+        var b = sut.Handle(request, handler, CancellationToken.None);
+        var results = await Task.WhenAll(a, b);
+
+        calls.Should().Be(1, "concurrent duplicates must be coalesced into a single handler execution");
+        results[0].Should().BeSameAs(results[1], "both concurrent callers observe the one shared response");
+    }
+
+    // (c) Idempotency runs after authorization: a replay by a now-unauthorized user is rejected
+    // by auth, not served from the cache. Behaviors are composed in registration order
+    // (authorization outer, idempotency inner) to mirror the real MediatR pipeline.
+    [Fact]
+    public async Task UnauthorizedReplay_IsRejectedByAuthorization_NotServedFromCache()
+    {
+        var store = new InMemoryIdempotencyStore(TimeProvider.System);
+        var user = new FakeUser("user-A");
+        var identity = new ToggleIdentityService { Allow = true };
+        var command = new SecuredCommand("shared-key");
+
+        var authorization = new AuthorizationBehavior<SecuredCommand, Result<string>>(user, identity);
+        var idempotency = new IdempotencyBehavior<SecuredCommand, Result<string>>(
+            store, user, NullLogger<IdempotencyBehavior<SecuredCommand, Result<string>>>.Instance);
+
+        var handlerCalls = 0;
+        RequestHandlerDelegate<Result<string>> handler = () =>
+        {
+            handlerCalls++;
+            return Task.FromResult(Result<string>.Success("secret"));
+        };
+        RequestHandlerDelegate<Result<string>> idempotencyStep = () => idempotency.Handle(command, handler, CancellationToken.None);
+
+        // First call: authorized -> auth passes -> handler runs -> success cached.
+        var first = await authorization.Handle(command, idempotencyStep, CancellationToken.None);
+
+        // Replay after access is revoked: auth must reject before idempotency can serve the cache.
+        identity.Allow = false;
+        var replay = await authorization.Handle(command, idempotencyStep, CancellationToken.None);
+
+        first.IsSuccess.Should().BeTrue();
+        first.Value.Should().Be("secret");
+        replay.IsSuccess.Should().BeFalse("authorization runs before idempotency, so a revoked user is denied");
+        replay.FailureType.Should().Be(ResultFailureType.Forbidden);
+        replay.Value.Should().NotBe("secret", "the cached success must not be leaked to a now-unauthorized replay");
+        handlerCalls.Should().Be(1, "the handler ran once for the authorized call and never for the denied replay");
+    }
+
+    private sealed record CrossUserRequest(string IdempotencyKey)
+        : IRequest<string>, IIdempotentRequest;
+
+    [Authorize(Roles = "admin")]
+    private sealed record SecuredCommand(string IdempotencyKey)
+        : IRequest<Result<string>>, IIdempotentRequest;
+
+    private sealed class FakeUser(string? id) : IUser
+    {
+        public string? Id { get; } = id;
+        public bool IsAdmin => false;
+    }
+
+    private sealed class ToggleIdentityService : IIdentityService
+    {
+        public bool Allow { get; set; } = true;
+
+        public Task<bool> IsInRoleAsync(string userId, string role) => Task.FromResult(Allow);
+
+        public Task<bool> AuthorizeAsync(string userId, string policyName) => Task.FromResult(Allow);
+
+        public Task<string?> GetUserNameAsync(string userId) => Task.FromResult<string?>(userId);
+
+        public Task<Result<string>> CreateUserAsync(string userName, string password) =>
+            throw new NotSupportedException();
+
+        public Task<Result> DeleteUserAsync(string userId) =>
+            throw new NotSupportedException();
+    }
+}

--- a/src/Content/Tests/Application.Common.Tests/MediatRBehaviors/IdempotencyWiringTests.cs
+++ b/src/Content/Tests/Application.Common.Tests/MediatRBehaviors/IdempotencyWiringTests.cs
@@ -1,23 +1,25 @@
 using Application.Common.Interfaces.Idempotency;
-using Application.Common.Interfaces.MediatR;
 using Application.Common.MediatRBehaviors;
 using Application.Common.Services.Idempotency;
 using Domain.Common;
 using FluentAssertions;
 using MediatR;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
 namespace Application.Common.Tests.MediatRBehaviors;
 
 /// <summary>
-/// Regression tests for the idempotency wiring defect (solution-review finding 25):
-/// IdempotencyBehavior was dead code — never registered and IIdempotencyStore had no
-/// implementation — and the behavior cached failure results unconditionally.
+/// Regression tests for the idempotency wiring and store contract:
+/// the behavior must be registered (not dead code), the store must not cache failures,
+/// concurrent duplicates must run once, and — critically — idempotency must be ordered
+/// after authorization so a replayed key cannot bypass the auth check.
 /// </summary>
 public sealed class IdempotencyWiringTests
 {
+    private static readonly Func<object, bool> PersistSuccesses =
+        value => value is not Result { IsSuccess: false };
+
     [Fact]
     public void AddApplicationCommonDependencies_RegistersIdempotencyStore()
     {
@@ -26,8 +28,7 @@ public sealed class IdempotencyWiringTests
         services.AddApplicationCommonDependencies();
         using var provider = services.BuildServiceProvider();
 
-        var store = provider.GetService<IIdempotencyStore>();
-        store.Should().BeOfType<InMemoryIdempotencyStore>(
+        provider.GetService<IIdempotencyStore>().Should().BeOfType<InMemoryIdempotencyStore>(
             "the behavior throws on an unresolvable IIdempotencyStore if no default is registered");
     }
 
@@ -38,9 +39,6 @@ public sealed class IdempotencyWiringTests
 
         services.AddApplicationCommonDependencies();
 
-        // Inspect the registration rather than resolving the whole pipeline (which would also
-        // construct the pre-existing AuthorizationBehavior and its auth-stack dependencies). The
-        // behavior is registered as an open-generic pipeline behavior.
         services.Should().ContainSingle(d =>
             d.ServiceType == typeof(IPipelineBehavior<,>) &&
             d.ImplementationType == typeof(IdempotencyBehavior<,>),
@@ -48,74 +46,83 @@ public sealed class IdempotencyWiringTests
     }
 
     [Fact]
-    public async Task Handle_FailureResult_IsNotCached()
+    public void IdempotencyBehavior_IsRegisteredAfterAuthorizationBehavior()
     {
-        var store = new InMemoryIdempotencyStore(TimeProvider.System);
-        var sut = new IdempotencyBehavior<IdempotentCommand, Result<string>>(
-            store, NullLogger<IdempotencyBehavior<IdempotentCommand, Result<string>>>.Instance);
-        var request = new IdempotentCommand("key-fail");
+        var services = new ServiceCollection();
+        services.AddApplicationCommonDependencies();
 
-        var first = await sut.Handle(request, () => Task.FromResult(Result<string>.Fail("transient")), CancellationToken.None);
-        var cached = await store.TryGetAsync("key-fail", CancellationToken.None);
+        var pipeline = services
+            .Where(d => d.ServiceType == typeof(IPipelineBehavior<,>))
+            .Select(d => d.ImplementationType)
+            .ToList();
 
-        first.IsSuccess.Should().BeFalse();
-        cached.Should().BeNull("a failed Result must never be cached and replayed to legitimate retries");
+        var authIndex = pipeline.IndexOf(typeof(AuthorizationBehavior<,>));
+        var idempotencyIndex = pipeline.IndexOf(typeof(IdempotencyBehavior<,>));
+
+        authIndex.Should().BeGreaterThanOrEqualTo(0);
+        idempotencyIndex.Should().BeGreaterThan(authIndex,
+            "a replayed idempotency key must clear authorization before any cached response is served");
     }
 
     [Fact]
-    public async Task Handle_FailureThenSuccess_SecondCallReExecutesAndCachesSuccess()
+    public async Task Store_FailureResult_IsNotPersisted_SoNextCallReExecutes()
     {
         var store = new InMemoryIdempotencyStore(TimeProvider.System);
-        var sut = new IdempotencyBehavior<IdempotentCommand, Result<string>>(
-            store, NullLogger<IdempotencyBehavior<IdempotentCommand, Result<string>>>.Instance);
-        var request = new IdempotentCommand("key-retry");
         var calls = 0;
+        Func<Task<object>> execute = () => { calls++; return Task.FromResult<object>(Result<string>.Fail("transient")); };
 
-        RequestHandlerDelegate<Result<string>> handler = () =>
-        {
-            calls++;
-            return Task.FromResult(calls == 1
-                ? Result<string>.Fail("transient")
-                : Result<string>.Success("ok"));
-        };
+        await store.GetOrExecuteAsync("k", execute, PersistSuccesses, CancellationToken.None);
+        await store.GetOrExecuteAsync("k", execute, PersistSuccesses, CancellationToken.None);
 
-        await sut.Handle(request, handler, CancellationToken.None);
-        var second = await sut.Handle(request, handler, CancellationToken.None);
-
-        calls.Should().Be(2, "the failure must not be cached, so the retry re-executes the handler");
-        second.IsSuccess.Should().BeTrue();
-        (await store.TryGetAsync("key-retry", CancellationToken.None)).Should().NotBeNull(
-            "the eventual success must be cached for subsequent retries");
+        calls.Should().Be(2, "a failed Result must never be cached and replayed to legitimate retries");
     }
 
     [Fact]
-    public async Task Store_SuccessResult_RoundTripsExactRuntimeType()
+    public async Task Store_SuccessResult_IsPersisted_SoNextCallDoesNotReExecute()
     {
         var store = new InMemoryIdempotencyStore(TimeProvider.System);
-        var response = Result<string>.Success("value");
+        var calls = 0;
+        Func<Task<object>> execute = () => { calls++; return Task.FromResult<object>(Result<string>.Success("ok")); };
 
-        await store.SetAsync("k", response, CancellationToken.None);
-        var cached = await store.TryGetAsync("k", CancellationToken.None);
+        await store.GetOrExecuteAsync("k", execute, PersistSuccesses, CancellationToken.None);
+        var second = await store.GetOrExecuteAsync("k", execute, PersistSuccesses, CancellationToken.None);
 
-        cached.Should().BeOfType<Result<string>>(
-            "the in-memory store caches by reference so the behavior's 'cached is TResponse' check holds");
+        calls.Should().Be(1, "a persisted success must be replayed from cache, not re-executed");
+        second.Should().BeOfType<Result<string>>("the store caches by reference and returns the exact runtime type");
     }
 
     [Fact]
-    public async Task Store_ExpiredEntry_ReturnsNull()
+    public async Task Store_ExpiredEntry_ReExecutes()
     {
         var time = new MutableTimeProvider(DateTimeOffset.UnixEpoch);
         var store = new InMemoryIdempotencyStore(time);
+        var calls = 0;
+        Func<Task<object>> execute = () => { calls++; return Task.FromResult<object>(Result<string>.Success("ok")); };
 
-        await store.SetAsync("k", "v", CancellationToken.None);
+        await store.GetOrExecuteAsync("k", execute, PersistSuccesses, CancellationToken.None);
         time.Advance(InMemoryIdempotencyStore.DefaultTtl + TimeSpan.FromSeconds(1));
-        var cached = await store.TryGetAsync("k", CancellationToken.None);
+        await store.GetOrExecuteAsync("k", execute, PersistSuccesses, CancellationToken.None);
 
-        cached.Should().BeNull("entries must expire after their TTL");
+        calls.Should().Be(2, "an expired entry must be treated as a miss and re-executed");
     }
 
-    private sealed record IdempotentCommand(string IdempotencyKey)
-        : IRequest<Result<string>>, IIdempotentRequest;
+    [Fact]
+    public async Task Store_ExecuteThrows_PropagatesAndDoesNotPersist()
+    {
+        var store = new InMemoryIdempotencyStore(TimeProvider.System);
+        var calls = 0;
+        Func<Task<object>> execute = () =>
+        {
+            calls++;
+            throw new InvalidOperationException("boom");
+        };
+
+        var act = () => store.GetOrExecuteAsync("k", execute, PersistSuccesses, CancellationToken.None);
+        await act.Should().ThrowAsync<InvalidOperationException>();
+        await act.Should().ThrowAsync<InvalidOperationException>();
+
+        calls.Should().Be(2, "a faulted execution must release its reservation so a retry re-executes");
+    }
 
     private sealed class MutableTimeProvider(DateTimeOffset start) : TimeProvider
     {


### PR DESCRIPTION
## Problem (HIGH, security)
The MediatR `IdempotencyBehavior` was registered **outside** authorization, and its keys were not user-scoped. On a cache hit the cached response returned with **no** authorization check, and the key was caller-supplied with no user scoping — so user B could send user A's idempotency key and receive A's cached response (access-control bypass + cross-user disclosure). There was also no in-flight reservation, so concurrent duplicate requests both executed the handler. (Dormant seam today — no production `IIdempotentRequest` implementers — but consumers are told to adopt it.)

## Fix
- **Order after authorization:** `IdempotencyBehavior` now registers after `AuthorizationBehavior` (only that one position moved; the other behaviors' relative order is unchanged).
- **User-scoped keys:** composed as `{userId}:{requestType}:{idempotencyKey}` using the same `IUser` identity `AuthorizationBehavior` consumes (null id → `anonymous`).
- **In-flight reservation:** the racy `TryGet`/`Set` pair is replaced with one atomic `GetOrExecuteAsync` backed by `Lazy<Task>` (ExecutionAndPublication), so concurrent duplicates execute the handler exactly once; entries are TTL-bounded; a failed `Result` is not cached; a throw releases the reservation so retries re-execute. Distributed replacements are documented to provide the same guarantee.

## Test plan
Three security tests (RED first, GREEN after):
- cross-user replay → user B gets its own miss, never A's cached value;
- concurrent same-key/same-user → handler runs exactly once;
- unauthorized replay → rejected by authorization, not served from cache.
Plus a DI-order test locking idempotency after authorization. Full `Application.Common.Tests`: 199/199, 0 warnings.

## Review
Self-reviewed (correctness + simplify). No findings. The broader validation-vs-authorization reorder is intentionally left to a separate PR.

Wave-2 security cluster, from the deep audit.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>