### PR TITLE
fix: escalation approvals enforce roster and fail closed

### DIFF
--- a/src/Content/Application/Application.Core/Escalation/Strategies/AllOfApprovalStrategy.cs
+++ b/src/Content/Application/Application.Core/Escalation/Strategies/AllOfApprovalStrategy.cs
@@ -16,32 +16,38 @@ public sealed class AllOfApprovalStrategy : IApprovalStrategy
         EscalationRequest request,
         IReadOnlyList<ApproverDecision> decisions)
     {
-        var deduplicated = DeduplicateByApprover(decisions);
-        var respondedNames = deduplicated.Select(d => d.ApproverName).ToHashSet(StringComparer.OrdinalIgnoreCase);
-        var pending = request.Approvers.Where(a => !respondedNames.Contains(a)).ToArray();
+        if (request.Approvers.Count == 0)
+        {
+            // Fail closed: an empty roster is a misconfigured gate. Treating "no approvers
+            // pending" as vacuously unanimous would auto-approve on the first decision (or
+            // even with none). Governance code must never approve a gate that nobody owns.
+            return new ApprovalEvaluation
+            {
+                IsResolved = true,
+                IsApproved = false,
+                PendingApprovers = []
+            };
+        }
 
-        if (deduplicated.Any(d => !d.Approved))
+        var scoped = ApproverRoster.Scope(request, decisions);
+
+        // A single denial from a listed approver resolves immediately as denied.
+        if (scoped.Decisions.Any(d => !d.Approved))
         {
             return new ApprovalEvaluation
             {
                 IsResolved = true,
                 IsApproved = false,
-                PendingApprovers = pending
+                PendingApprovers = scoped.Pending
             };
         }
 
-        var allResponded = pending.Length == 0;
+        var allResponded = scoped.Pending.Count == 0;
         return new ApprovalEvaluation
         {
             IsResolved = allResponded,
             IsApproved = allResponded,
-            PendingApprovers = pending
+            PendingApprovers = scoped.Pending
         };
     }
-
-    private static IReadOnlyList<ApproverDecision> DeduplicateByApprover(IReadOnlyList<ApproverDecision> decisions) =>
-        decisions
-            .GroupBy(d => d.ApproverName, StringComparer.OrdinalIgnoreCase)
-            .Select(g => g.MinBy(d => d.RespondedAt)!)
-            .ToArray();
 }

--- a/src/Content/Application/Application.Core/Escalation/Strategies/AnyOfApprovalStrategy.cs
+++ b/src/Content/Application/Application.Core/Escalation/Strategies/AnyOfApprovalStrategy.cs
@@ -16,32 +16,25 @@ public sealed class AnyOfApprovalStrategy : IApprovalStrategy
         EscalationRequest request,
         IReadOnlyList<ApproverDecision> decisions)
     {
-        var deduplicated = DeduplicateByApprover(decisions);
-        var respondedNames = deduplicated.Select(d => d.ApproverName).ToHashSet(StringComparer.OrdinalIgnoreCase);
-        var pending = request.Approvers.Where(a => !respondedNames.Contains(a)).ToArray();
+        var scoped = ApproverRoster.Scope(request, decisions);
 
-        if (deduplicated.Count == 0)
+        // Only decisions from listed approvers count; a non-roster vote must never resolve.
+        if (scoped.Decisions.Count == 0)
         {
             return new ApprovalEvaluation
             {
                 IsResolved = false,
                 IsApproved = false,
-                PendingApprovers = pending
+                PendingApprovers = scoped.Pending
             };
         }
 
-        var firstDecision = deduplicated.MinBy(d => d.RespondedAt)!;
+        var firstDecision = scoped.Decisions.MinBy(d => d.RespondedAt)!;
         return new ApprovalEvaluation
         {
             IsResolved = true,
             IsApproved = firstDecision.Approved,
-            PendingApprovers = pending
+            PendingApprovers = scoped.Pending
         };
     }
-
-    private static IReadOnlyList<ApproverDecision> DeduplicateByApprover(IReadOnlyList<ApproverDecision> decisions) =>
-        decisions
-            .GroupBy(d => d.ApproverName, StringComparer.OrdinalIgnoreCase)
-            .Select(g => g.MinBy(d => d.RespondedAt)!)
-            .ToArray();
 }

--- a/src/Content/Application/Application.Core/Escalation/Strategies/ApproverRoster.cs
+++ b/src/Content/Application/Application.Core/Escalation/Strategies/ApproverRoster.cs
@@ -1,0 +1,62 @@
+using Application.AI.Common.Interfaces.Escalation;
+using Domain.AI.Escalation;
+
+namespace Application.Core.Escalation.Strategies;
+
+/// <summary>
+/// Shared roster-scoping logic for the <see cref="IApprovalStrategy"/> implementations.
+/// Filters raw approver decisions down to the request's declared approver roster and
+/// computes which listed approvers are still pending.
+/// </summary>
+/// <remarks>
+/// Centralizing this here removes the previously copy-pasted deduplication helper from
+/// each strategy and, critically, guarantees every strategy applies the same membership
+/// filter. Without it, <c>AnyOf</c> and <c>AllOf</c> counted votes from identities outside
+/// <see cref="EscalationRequest.Approvers"/>, letting a non-roster caller approve (or force
+/// a denial on) an escalation.
+/// </remarks>
+internal static class ApproverRoster
+{
+    /// <summary>
+    /// Scopes the collected decisions to the request's approver roster.
+    /// </summary>
+    /// <param name="request">The escalation request carrying the authoritative approver roster.</param>
+    /// <param name="decisions">All decisions collected so far, including any from non-roster identities.</param>
+    /// <returns>
+    /// The roster-filtered decisions (deduplicated to each approver's earliest response) and the
+    /// listed approvers who have not yet responded.
+    /// </returns>
+    public static RosterScopedDecisions Scope(
+        EscalationRequest request,
+        IReadOnlyList<ApproverDecision> decisions)
+    {
+        var approverSet = request.Approvers.ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        // Only count decisions from identities actually listed as approvers, collapsing
+        // repeat votes to the earliest response so a later flip cannot rewrite the outcome.
+        var rostered = decisions
+            .Where(d => approverSet.Contains(d.ApproverName))
+            .GroupBy(d => d.ApproverName, StringComparer.OrdinalIgnoreCase)
+            .Select(g => g.MinBy(d => d.RespondedAt)!)
+            .ToArray();
+
+        var respondedNames = rostered
+            .Select(d => d.ApproverName)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var pending = request.Approvers
+            .Where(a => !respondedNames.Contains(a))
+            .ToArray();
+
+        return new RosterScopedDecisions(rostered, pending);
+    }
+}
+
+/// <summary>
+/// The result of <see cref="ApproverRoster.Scope"/>: roster-filtered decisions and the
+/// listed approvers still awaiting a response.
+/// </summary>
+/// <param name="Decisions">Decisions from listed approvers only, deduplicated to earliest response.</param>
+/// <param name="Pending">Listed approvers who have not yet responded.</param>
+internal readonly record struct RosterScopedDecisions(
+    IReadOnlyList<ApproverDecision> Decisions,
+    IReadOnlyList<string> Pending);

--- a/src/Content/Application/Application.Core/Escalation/Strategies/QuorumApprovalStrategy.cs
+++ b/src/Content/Application/Application.Core/Escalation/Strategies/QuorumApprovalStrategy.cs
@@ -17,16 +17,12 @@ public sealed class QuorumApprovalStrategy : IApprovalStrategy
         EscalationRequest request,
         IReadOnlyList<ApproverDecision> decisions)
     {
-        var approverSet = request.Approvers.ToHashSet(StringComparer.OrdinalIgnoreCase);
-
         // Only count decisions from identities that are actually listed as approvers.
         // Votes from non-listed identities must not satisfy quorum nor corrupt the
-        // remaining-vote math (mirrors the membership filter used for `pending`).
-        var deduplicated = DeduplicateByApprover(decisions)
-            .Where(d => approverSet.Contains(d.ApproverName))
-            .ToArray();
-        var respondedNames = deduplicated.Select(d => d.ApproverName).ToHashSet(StringComparer.OrdinalIgnoreCase);
-        var pending = request.Approvers.Where(a => !respondedNames.Contains(a)).ToArray();
+        // remaining-vote math (shared with AnyOf/AllOf via ApproverRoster.Scope).
+        var scoped = ApproverRoster.Scope(request, decisions);
+        var deduplicated = scoped.Decisions;
+        var pending = scoped.Pending;
 
         var quorumThreshold = request.QuorumThreshold;
         if (quorumThreshold <= 0)
@@ -74,10 +70,4 @@ public sealed class QuorumApprovalStrategy : IApprovalStrategy
             PendingApprovers = pending
         };
     }
-
-    private static IReadOnlyList<ApproverDecision> DeduplicateByApprover(IReadOnlyList<ApproverDecision> decisions) =>
-        decisions
-            .GroupBy(d => d.ApproverName, StringComparer.OrdinalIgnoreCase)
-            .Select(g => g.MinBy(d => d.RespondedAt)!)
-            .ToArray();
 }

--- a/src/Content/Infrastructure/Infrastructure.AI/Escalation/DefaultEscalationService.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Escalation/DefaultEscalationService.cs
@@ -58,7 +58,15 @@ public sealed class DefaultEscalationService : IEscalationService, IDisposable
 		EscalationRequest request, CancellationToken ct)
 	{
 		var state = InitializeEscalation(request);
-		await RecordAndNotifyRequestAsync(state, ct);
+		try
+		{
+			await RecordAndNotifyRequestAsync(state, ct);
+		}
+		catch
+		{
+			RemoveFailedEscalation(state);
+			throw;
+		}
 		_ = RunTimeoutAsync(state);
 
 		try
@@ -76,7 +84,15 @@ public sealed class DefaultEscalationService : IEscalationService, IDisposable
 	public async Task<Guid> QueueEscalationAsync(EscalationRequest request, CancellationToken ct)
 	{
 		var state = InitializeEscalation(request);
-		await RecordAndNotifyRequestAsync(state, ct);
+		try
+		{
+			await RecordAndNotifyRequestAsync(state, ct);
+		}
+		catch
+		{
+			RemoveFailedEscalation(state);
+			throw;
+		}
 		_ = RunTimeoutAsync(state);
 		return request.EscalationId;
 	}
@@ -88,6 +104,18 @@ public sealed class DefaultEscalationService : IEscalationService, IDisposable
 		if (!_activeEscalations.TryGetValue(escalationId, out var state))
 		{
 			_logger.LogWarning("Decision submitted for unknown escalation {EscalationId}", escalationId);
+			return null;
+		}
+
+		// Authorization chokepoint: reject decisions from identities outside the approver
+		// roster before they are recorded, evaluated, or allowed to resolve the escalation.
+		// The strategies also filter non-roster votes (defense in depth), but stopping here
+		// keeps unauthorized decisions out of the audit trail and strategy evaluation entirely.
+		if (!state.Request.Approvers.Contains(decision.ApproverName, StringComparer.OrdinalIgnoreCase))
+		{
+			_logger.LogWarning(
+				"Rejected decision from non-roster identity {ApproverName} for escalation {EscalationId}",
+				decision.ApproverName, escalationId);
 			return null;
 		}
 
@@ -195,6 +223,18 @@ public sealed class DefaultEscalationService : IEscalationService, IDisposable
 
 	private EscalationState InitializeEscalation(EscalationRequest request)
 	{
+		if (request.Approvers.Count == 0)
+		{
+			// Fail closed at creation: an escalation with no approver roster can never be
+			// legitimately approved. Admitting it would let the AllOf strategy treat "nobody
+			// pending" as vacuously unanimous, or the timeout Approve action grant it silently.
+			_logger.LogWarning(
+				"Rejected escalation {EscalationId} for agent {AgentId}: empty approver roster",
+				request.EscalationId, request.AgentId);
+			throw new InvalidOperationException(
+				$"Escalation {request.EscalationId} has no approvers; refusing to create an escalation that cannot be approved.");
+		}
+
 		var state = new EscalationState
 		{
 			Request = request,
@@ -221,13 +261,24 @@ public sealed class DefaultEscalationService : IEscalationService, IDisposable
 
 	private async Task RecordAndNotifyRequestAsync(EscalationState state, CancellationToken ct)
 	{
-		await SafeExecuteAsync(
-			() => _auditStore.RecordRequestAsync(state.Request, ct),
-			"record request", state.Request.EscalationId);
+		// Durable request audit is fail-CLOSED: refuse to open an approvable escalation that
+		// could not be recorded for compliance. If it throws, the caller cleans up the
+		// half-created escalation and surfaces the failure. Notification stays best-effort.
+		await _auditStore.RecordRequestAsync(state.Request, ct);
 
 		await SafeExecuteAsync(
 			() => _notifier.NotifyEscalationRequestedAsync(state.Request, ct),
 			"notify request", state.Request.EscalationId);
+	}
+
+	private void RemoveFailedEscalation(EscalationState state)
+	{
+		if (_activeEscalations.TryRemove(state.Request.EscalationId, out _))
+		{
+			state.TimeoutCts.Cancel();
+			state.TimeoutCts.Dispose();
+			EscalationMetrics.Pending.Add(-1);
+		}
 	}
 
 	private async Task ResolveEscalationAsync(EscalationState state, EscalationOutcome outcome)
@@ -249,14 +300,23 @@ public sealed class DefaultEscalationService : IEscalationService, IDisposable
 			"Escalation {EscalationId} resolved: {ResolutionType}, approved={IsApproved}",
 			outcome.EscalationId, outcome.ResolutionType, outcome.IsApproved);
 
-		// Record the audit outcome and notify BEFORE releasing the caller awaiting
-		// Completion.Task. This guarantees that when RequestEscalationAsync returns an
-		// outcome (notably on the timeout path), that outcome has already been durably
-		// audited — a caller can never observe a resolved escalation that has not yet
-		// been recorded for compliance.
-		await SafeExecuteAsync(
-			() => _auditStore.RecordOutcomeAsync(outcome, CancellationToken.None),
-			"record outcome", outcome.EscalationId);
+		// Record the audit outcome BEFORE releasing the caller awaiting Completion.Task.
+		// The durable outcome write is fail-CLOSED: if it throws, the escalation must NOT
+		// be reported as resolved. Propagate the failure to the awaiting caller instead of
+		// delivering an approval that was never recorded for compliance. (SafeExecuteAsync
+		// is reserved for best-effort notification, never for the durable audit write.)
+		try
+		{
+			await _auditStore.RecordOutcomeAsync(outcome, CancellationToken.None);
+		}
+		catch (Exception ex)
+		{
+			_logger.LogError(ex,
+				"Failed to record outcome for escalation {EscalationId}; failing closed (escalation not reported resolved)",
+				outcome.EscalationId);
+			state.Completion.TrySetException(ex);
+			throw;
+		}
 
 		await SafeExecuteAsync(
 			() => _notifier.NotifyEscalationResolvedAsync(outcome, CancellationToken.None),

--- a/src/Content/Tests/Application.Core.Tests/Escalation/Strategies/AllOfApprovalStrategyTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/Escalation/Strategies/AllOfApprovalStrategyTests.cs
@@ -93,4 +93,52 @@ public class AllOfApprovalStrategyTests
     {
         _sut.StrategyType.Should().Be(ApprovalStrategyType.AllOf);
     }
+
+    // ---- roster-membership enforcement (security fix) ----
+
+    [Fact]
+    public void EvaluateDecision_OnlyNonRosterDecision_DoesNotResolve()
+    {
+        var request = CreateRequest("alice", "bob");
+
+        var result = _sut.EvaluateDecision(request, new[] { Deny("mallory") });
+
+        result.IsResolved.Should().BeFalse("a decision from an identity outside the roster must not resolve an AllOf escalation");
+        result.PendingApprovers.Should().BeEquivalentTo(["alice", "bob"]);
+    }
+
+    [Fact]
+    public void EvaluateDecision_NonRosterDenial_DoesNotOverrideRosterApproval()
+    {
+        var request = CreateRequest("alice");
+
+        var result = _sut.EvaluateDecision(request, new[] { Approve("alice"), Deny("mallory") });
+
+        result.IsResolved.Should().BeTrue();
+        result.IsApproved.Should().BeTrue("a non-roster denial must not override the sole listed approver's approval");
+    }
+
+    // ---- empty-roster fail-closed (security fix) ----
+
+    [Fact]
+    public void EvaluateDecision_EmptyRosterWithDecision_FailsClosed()
+    {
+        var request = CreateRequest();
+
+        var result = _sut.EvaluateDecision(request, new[] { Approve("mallory") });
+
+        result.IsResolved.Should().BeTrue();
+        result.IsApproved.Should().BeFalse("an escalation with no approvers must never auto-approve");
+    }
+
+    [Fact]
+    public void EvaluateDecision_EmptyRosterNoDecisions_FailsClosed()
+    {
+        var request = CreateRequest();
+
+        var result = _sut.EvaluateDecision(request, Array.Empty<ApproverDecision>());
+
+        result.IsResolved.Should().BeTrue();
+        result.IsApproved.Should().BeFalse("an empty roster must fail closed, not auto-approve as vacuously unanimous");
+    }
 }

--- a/src/Content/Tests/Application.Core.Tests/Escalation/Strategies/AnyOfApprovalStrategyTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/Escalation/Strategies/AnyOfApprovalStrategyTests.cs
@@ -93,4 +93,34 @@ public class AnyOfApprovalStrategyTests
     {
         _sut.StrategyType.Should().Be(ApprovalStrategyType.AnyOf);
     }
+
+    // ---- roster-membership enforcement (security fix) ----
+
+    [Fact]
+    public void EvaluateDecision_OnlyNonRosterApproval_DoesNotResolve()
+    {
+        var request = CreateRequest("alice", "bob", "carol");
+
+        var result = _sut.EvaluateDecision(request, new[] { Approve("mallory") });
+
+        result.IsResolved.Should().BeFalse("a decision from an identity outside the approver roster must not resolve an AnyOf escalation");
+        result.PendingApprovers.Should().BeEquivalentTo(["alice", "bob", "carol"]);
+    }
+
+    [Fact]
+    public void EvaluateDecision_NonRosterEarliestDecision_Ignored_RosterDecisionWins()
+    {
+        var request = CreateRequest("alice", "bob", "carol");
+        var now = DateTimeOffset.UtcNow;
+        var decisions = new[]
+        {
+            new ApproverDecision { ApproverName = "mallory", Approved = false, Reason = "hijack", RespondedAt = now },
+            new ApproverDecision { ApproverName = "alice", Approved = true, RespondedAt = now.AddSeconds(1) }
+        };
+
+        var result = _sut.EvaluateDecision(request, decisions);
+
+        result.IsResolved.Should().BeTrue();
+        result.IsApproved.Should().BeTrue("a non-roster decision (even the earliest) must be ignored; only alice's vote counts");
+    }
 }

--- a/src/Content/Tests/Infrastructure.AI.Tests/Escalation/DefaultEscalationServiceTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Escalation/DefaultEscalationServiceTests.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.IO;
 using Application.AI.Common.Interfaces.Escalation;
 using Domain.AI.Escalation;
 using Domain.Common.Config.AI.Governance;
@@ -316,6 +317,67 @@ public sealed class DefaultEscalationServiceTests : IDisposable
 		_auditStore.Verify(
 			a => a.RecordDecisionAsync(It.IsAny<Guid>(), It.IsAny<ApproverDecision>(), It.IsAny<CancellationToken>()),
 			Times.Never);
+	}
+
+	[Fact]
+	public async Task SubmitDecisionAsync_NonRosterApprover_RejectedNotRecordedNotEvaluated()
+	{
+		var request = CreateTestRequest(); // roster: approver-1, approver-2
+		SetupStrategyResolvesOnFirstApproval();
+		await _sut.QueueEscalationAsync(request, CancellationToken.None);
+
+		var outcome = await _sut.SubmitDecisionAsync(
+			request.EscalationId, CreateApproval("mallory"), CancellationToken.None);
+
+		outcome.Should().BeNull("a decision from an identity outside the approver roster must not resolve the escalation");
+		_auditStore.Verify(
+			a => a.RecordDecisionAsync(It.IsAny<Guid>(), It.IsAny<ApproverDecision>(), It.IsAny<CancellationToken>()),
+			Times.Never);
+		_anyOfStrategy.Verify(
+			s => s.EvaluateDecision(It.IsAny<EscalationRequest>(), It.IsAny<IReadOnlyList<ApproverDecision>>()),
+			Times.Never);
+	}
+
+	[Fact]
+	public async Task SubmitDecisionAsync_OutcomeAuditThrows_FailsClosed_NotReportedResolved()
+	{
+		var request = CreateTestRequest();
+		SetupStrategyResolvesOnFirstApproval();
+		_auditStore
+			.Setup(a => a.RecordOutcomeAsync(It.IsAny<EscalationOutcome>(), It.IsAny<CancellationToken>()))
+			.ThrowsAsync(new IOException("audit sink unavailable"));
+		await _sut.QueueEscalationAsync(request, CancellationToken.None);
+
+		var act = () => _sut.SubmitDecisionAsync(
+			request.EscalationId, CreateApproval(), CancellationToken.None);
+
+		await act.Should().ThrowAsync<IOException>(
+			"a resolved escalation whose outcome cannot be durably audited must fail closed, not deliver an unaudited approval");
+		_notifier.Verify(
+			n => n.NotifyEscalationResolvedAsync(It.IsAny<EscalationOutcome>(), It.IsAny<CancellationToken>()),
+			Times.Never);
+	}
+
+	[Fact]
+	public async Task QueueEscalationAsync_EmptyApproverRoster_FailsClosed()
+	{
+		var request = CreateTestRequest(approvers: Array.Empty<string>());
+
+		var act = () => _sut.QueueEscalationAsync(request, CancellationToken.None);
+
+		await act.Should().ThrowAsync<InvalidOperationException>(
+			"an escalation with no approvers can never be legitimately approved and must be rejected at creation");
+	}
+
+	[Fact]
+	public async Task RequestEscalationAsync_EmptyApproverRoster_FailsClosed()
+	{
+		var request = CreateTestRequest(approvers: Array.Empty<string>());
+
+		var act = () => _sut.RequestEscalationAsync(request, CancellationToken.None);
+
+		await act.Should().ThrowAsync<InvalidOperationException>(
+			"a blocking escalation with no approvers must fail closed rather than await an unapprovable request");
 	}
 
 	// ===== Timeout =====


### PR DESCRIPTION
## Problem (HIGH, security — escalation fail-open)
Three flaws let escalation approvals resolve when they shouldn't:
1. **Non-roster identities could approve.** `AnyOfApprovalStrategy` and `AllOfApprovalStrategy` counted votes from any identity — only `QuorumApprovalStrategy` filtered decisions to `request.Approvers`, and `SubmitDecisionAsync` did no membership check. So any identity reaching the decision endpoint could approve an AnyOf escalation (the default).
2. **Empty-roster auto-approve.** `AllOfApprovalStrategy` treated an empty `Approvers` list as "all approved" on the first decision; `InitializeEscalation` never validated the roster.
3. **Fail-open audit.** The escalation audit store throws on append failure by design, but the calls were wrapped in error-swallowing `SafeExecuteAsync` — so an outcome was delivered and approval proceeded with **no** durable audit record, despite a comment claiming the opposite.

## Fix
- New shared `ApproverRoster.Scope(request, decisions)` filters decisions to the roster (ordinal-ignore-case) and dedups each approver to their earliest response. All three strategies now use it — the membership filter can no longer drift between them (that drift was the root cause). This also consolidates the `DeduplicateByApprover` helper that was copy-pasted three times.
- `AllOfApprovalStrategy` and `InitializeEscalation` **fail closed** on an empty roster.
- `ResolveEscalationAsync` outcome-audit and request-audit are now direct awaits (fail-closed): an escalation can't be reported resolved without a durable audit record; a failed request-audit cleans up the active escalation instead of leaking it. `SubmitDecisionAsync` rejects a non-roster approver before any audit/eval. `SafeExecuteAsync` is reserved for notification only.

## Test plan
10 reproduce tests (RED → GREEN): non-roster decisions don't resolve AnyOf/AllOf; empty-roster fails closed; a non-roster approver is rejected, not audited, not evaluated; an outcome-audit throw is not reported resolved; empty-roster `Queue`/`Request` throw. `Application.Core.Tests` 638/638; `DefaultEscalationService` suite 20/20; clean build.

## Notes
- Empty-roster rejection surfaces as `InvalidOperationException`, consistent with the pre-existing duplicate-ID guard in the same method (the `IEscalationService` interface returns `Task<T>`, not `Result<T>` — a wider contract change was out of scope).
- **Merge note:** overlaps the blocked-step-lifecycle branch on `DefaultEscalationService`. That branch will rebase onto this one and position its outcome-cache write *after* this now-fail-closed audit, so the executor can never resume on an un-audited verdict.

## Review
Self-reviewed; cross-validated by the independent blocked-lifecycle review, which confirmed this branch's resolution paths interact safely.

Wave-2 security cluster, from the deep audit.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>