### PR TITLE
fix: blocked steps resume when their escalation resolves (human-gate lifecycle)

### DIFF
--- a/src/Content/Application/Application.AI.Common/Interfaces/Escalation/IEscalationService.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Escalation/IEscalationService.cs
@@ -39,6 +39,20 @@ public interface IEscalationService
     Task<EscalationRequest?> GetPendingEscalationAsync(Guid escalationId, CancellationToken ct);
 
     /// <summary>
+    /// Returns the resolved <see cref="EscalationOutcome"/> for an escalation, or null if it is
+    /// still pending or unknown.
+    /// </summary>
+    /// <remarks>
+    /// Unlike <see cref="GetPendingEscalationAsync"/> — which reports only whether a request is
+    /// still open — this reports the final verdict (approved, denied, timed out, or escalated) once
+    /// the escalation has resolved. It is the query the plan executor uses on resume to decide the
+    /// fate of a step parked in <c>Blocked</c> awaiting a human decision: an approved outcome lets
+    /// the step complete and release its downstream, a non-approved outcome fails it. A null result
+    /// means "no decision yet" and the step remains blocked.
+    /// </remarks>
+    Task<EscalationOutcome?> GetOutcomeAsync(Guid escalationId, CancellationToken ct);
+
+    /// <summary>
     /// Returns all pending escalations assigned to a specific approver.
     /// </summary>
     Task<IReadOnlyList<EscalationRequest>> GetPendingEscalationsAsync(string approverName, CancellationToken ct);

--- a/src/Content/Infrastructure/Infrastructure.AI/Escalation/DefaultEscalationService.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Escalation/DefaultEscalationService.cs
@@ -21,10 +21,20 @@ namespace Infrastructure.AI.Escalation;
 /// durable compliance records, but automatic recovery from audit logs is not
 /// implemented (Phase 3+).
 /// </para>
+/// <para>
+/// Resolved outcomes are also retained in memory (see <see cref="_resolvedOutcomes"/>) so callers
+/// such as the plan executor can query a verdict via <see cref="GetOutcomeAsync"/> after the
+/// escalation has left the active set. Retention is process-lifetime and consistent with the
+/// active-state model above: a restart that loses a pending escalation would equally lose its
+/// resolved outcome, and such an escalation could never have been approved post-restart anyway.
+/// Escalations are human-scale, low-frequency events, so this retention does not grow unbounded in
+/// practice.
+/// </para>
 /// </remarks>
 public sealed class DefaultEscalationService : IEscalationService, IDisposable
 {
 	private readonly ConcurrentDictionary<Guid, EscalationState> _activeEscalations = new();
+	private readonly ConcurrentDictionary<Guid, EscalationOutcome> _resolvedOutcomes = new();
 	private readonly IServiceProvider _serviceProvider;
 	private readonly IEscalationNotifier _notifier;
 	private readonly IEscalationAuditStore _auditStore;
@@ -170,6 +180,13 @@ public sealed class DefaultEscalationService : IEscalationService, IDisposable
 	}
 
 	/// <inheritdoc />
+	public Task<EscalationOutcome?> GetOutcomeAsync(Guid escalationId, CancellationToken ct)
+	{
+		_resolvedOutcomes.TryGetValue(escalationId, out var outcome);
+		return Task.FromResult(outcome);
+	}
+
+	/// <inheritdoc />
 	public Task<IReadOnlyList<EscalationRequest>> GetPendingEscalationsAsync(
 		string approverName, CancellationToken ct)
 	{
@@ -292,6 +309,10 @@ public sealed class DefaultEscalationService : IEscalationService, IDisposable
 
 		state.TimeoutCts.Cancel();
 		_activeEscalations.TryRemove(state.Request.EscalationId, out _);
+
+		// Retain the verdict so GetOutcomeAsync can report it after the escalation leaves the
+		// active set — this is what lets a resumed plan unblock or fail a gated step.
+		_resolvedOutcomes[outcome.EscalationId] = outcome;
 
 		EscalationMetrics.Pending.Add(-1);
 		RecordResolutionMetrics(state, outcome);

--- a/src/Content/Infrastructure/Infrastructure.AI/Escalation/DefaultEscalationService.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Escalation/DefaultEscalationService.cs
@@ -310,10 +310,6 @@ public sealed class DefaultEscalationService : IEscalationService, IDisposable
 		state.TimeoutCts.Cancel();
 		_activeEscalations.TryRemove(state.Request.EscalationId, out _);
 
-		// Retain the verdict so GetOutcomeAsync can report it after the escalation leaves the
-		// active set — this is what lets a resumed plan unblock or fail a gated step.
-		_resolvedOutcomes[outcome.EscalationId] = outcome;
-
 		EscalationMetrics.Pending.Add(-1);
 		RecordResolutionMetrics(state, outcome);
 
@@ -338,6 +334,11 @@ public sealed class DefaultEscalationService : IEscalationService, IDisposable
 			state.Completion.TrySetException(ex);
 			throw;
 		}
+
+		// Retain the verdict ONLY after it has been durably audited, so GetOutcomeAsync — and thus
+		// the plan executor's resume reconciliation — can never act on a verdict that failed the
+		// fail-closed audit write above and was rolled back to the awaiting caller.
+		_resolvedOutcomes[outcome.EscalationId] = outcome;
 
 		await SafeExecuteAsync(
 			() => _notifier.NotifyEscalationResolvedAsync(outcome, CancellationToken.None),

--- a/src/Content/Infrastructure/Infrastructure.AI/Planner/PlanExecutor.Recovery.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Planner/PlanExecutor.Recovery.cs
@@ -77,16 +77,29 @@ public sealed partial class PlanExecutor
     /// <c>ExecuteAsync</c> after the escalation resolves, and this reconciliation acts on the verdict.
     /// </summary>
     /// <remarks>
-    /// Mapping per <see cref="IEscalationService.GetOutcomeAsync"/>:
+    /// <para>
+    /// Two distinct producers park a step in <c>Blocked</c>, and an <b>approval</b> means different
+    /// things for each — so they are handled differently:
+    /// </para>
     /// <list type="bullet">
-    ///   <item><description>Approved — the step is completed and its downstream released, so the plan can finish.</description></item>
-    ///   <item><description>Not approved (denied/timed-out) — the step is failed and routed through
-    ///   <see cref="HandleStepFailureAsync"/>, so its downstream is skipped or re-escalated per the step's retry policy.</description></item>
-    ///   <item><description>Unresolved (null) — the step remains <c>Blocked</c>.</description></item>
+    ///   <item><description><b>Human gate</b> (<see cref="StepType.HumanGate"/>) — a pure approval
+    ///   checkpoint with no work of its own. Approval <b>completes</b> it and releases its
+    ///   downstream. Its stored output holds only the escalation reference, which is never propagated
+    ///   as step output.</description></item>
+    ///   <item><description><b>Escalate-on-failure</b> block (a step whose real execution failed after
+    ///   exhausting retries and whose <see cref="ErrorRecovery.Escalate"/> policy then escalated) —
+    ///   approval means "let the real work run again", so the step is reset to <c>Pending</c> and
+    ///   re-executed by the scheduler; its downstream then receives the genuine output. A repeat
+    ///   failure re-escalates per the step's retry policy. It is <b>never</b> marked Completed without
+    ///   re-running, and its escalation-reference output is never fed downstream.</description></item>
     /// </list>
-    /// A blocked step without a recoverable escalation id (none was persisted) is left untouched.
-    /// This covers resume-time resolution; unblocking mid-execution the instant an approval lands is a
-    /// tracked follow-up — the scheduler currently drains when only blocked steps remain.
+    /// <para>Rejection is uniform: the step is failed and its downstream skipped terminally (a human
+    /// "no" is not re-run through the retry policy — that could re-escalate the rejected request). An
+    /// unresolved escalation (null outcome) leaves the step <c>Blocked</c>; a blocked step without a
+    /// recoverable escalation id is left untouched.</para>
+    /// <para>This covers resume-time resolution; unblocking mid-execution the instant an approval
+    /// lands is a tracked follow-up — the scheduler currently drains when only blocked steps
+    /// remain.</para>
     /// </remarks>
     private async Task ReconcileBlockedStepsAsync(PlanGraph plan, PlanExecutionRuntime ctx, CancellationToken ct)
     {
@@ -105,26 +118,62 @@ public sealed partial class PlanExecutor
                 continue;
 
             if (outcome.IsApproved)
-            {
-                _logger.LogInformation(
-                    "Blocked step {StepId} in plan {PlanId} released: escalation {EscalationId} approved",
-                    step.Id, ctx.PlanId, escalationId);
-
-                await TransitionStepAsync(ctx.PlanId, step.Id, StepExecutionStatus.Completed, ctx.StepStates, ct, output: state.Output);
-                if (state.Output is not null)
-                    ctx.StepOutputs[step.Id] = state.Output;
-                await EnqueueReadyDownstreamAsync(step.Id, ctx);
-            }
+                await ReleaseApprovedBlockAsync(step, escalationId.Value, ctx, ct);
             else
-            {
-                var reason = $"Escalation {escalationId} was not approved (resolution: {outcome.ResolutionType}).";
-                _logger.LogWarning(
-                    "Blocked step {StepId} in plan {PlanId} failed: {Reason}", step.Id, ctx.PlanId, reason);
-
-                await TransitionStepAsync(ctx.PlanId, step.Id, StepExecutionStatus.Failed, ctx.StepStates, ct, errorMessage: reason);
-                await HandleStepFailureAsync(step, reason, ctx, ct);
-            }
+                await FailRejectedBlockAsync(step, escalationId.Value, outcome, ctx, ct);
         }
+    }
+
+    /// <summary>
+    /// Releases a blocked step whose escalation was approved. A human gate is completed and its
+    /// downstream released; an escalate-on-failure block is reset to <c>Pending</c> so its real work
+    /// re-runs. In neither case is the escalation-reference output propagated as the step's output —
+    /// a gate produces no data, and a re-run produces its own genuine output.
+    /// </summary>
+    private async Task ReleaseApprovedBlockAsync(PlanStep step, Guid escalationId, PlanExecutionRuntime ctx, CancellationToken ct)
+    {
+        if (step.Type == StepType.HumanGate)
+        {
+            _logger.LogInformation(
+                "Human gate {StepId} in plan {PlanId} released: escalation {EscalationId} approved",
+                step.Id, ctx.PlanId, escalationId);
+
+            // Complete the gate and clear the escalation-reference output so it is never mistaken for
+            // real data. Downstream is released via EnqueueReadyDownstreamAsync, not via StepOutputs.
+            await TransitionStepAsync(ctx.PlanId, step.Id, StepExecutionStatus.Completed, ctx.StepStates, ct,
+                output: null, clearPriorOutputs: true);
+            await EnqueueReadyDownstreamAsync(step.Id, ctx);
+            return;
+        }
+
+        _logger.LogInformation(
+            "Escalated failure of step {StepId} in plan {PlanId} approved (escalation {EscalationId}); re-running the step",
+            step.Id, ctx.PlanId, escalationId);
+
+        // The step's real work failed; approval authorizes another attempt. Reset to Pending (clearing
+        // the stale error and escalation-reference output) so the scheduler re-runs it — the canonical
+        // Pending -> Ready promotion picks it up in EnqueueInitialReadyStepsAsync. Downstream then
+        // receives the genuine re-run output; a repeat failure re-escalates per the retry policy.
+        await TransitionStepAsync(ctx.PlanId, step.Id, StepExecutionStatus.Pending, ctx.StepStates, ct,
+            output: null, clearPriorOutputs: true);
+    }
+
+    /// <summary>
+    /// Fails a blocked step whose escalation was rejected (denied or timed out) and skips its
+    /// downstream subgraph. A rejection is a terminal human decision, so it deliberately does NOT
+    /// route back through <see cref="HandleStepFailureAsync"/>: that would re-run the step's retry
+    /// policy, and an <see cref="ErrorRecovery.Escalate"/> policy would re-escalate the very request
+    /// the human just rejected — an unbounded reject → re-escalate loop across resumes.
+    /// </summary>
+    private async Task FailRejectedBlockAsync(
+        PlanStep step, Guid escalationId, EscalationOutcome outcome, PlanExecutionRuntime ctx, CancellationToken ct)
+    {
+        var reason = $"Escalation {escalationId} was not approved (resolution: {outcome.ResolutionType}).";
+        _logger.LogWarning(
+            "Blocked step {StepId} in plan {PlanId} failed: {Reason}", step.Id, ctx.PlanId, reason);
+
+        await TransitionStepAsync(ctx.PlanId, step.Id, StepExecutionStatus.Failed, ctx.StepStates, ct, errorMessage: reason);
+        await SkipDownstreamSubgraphAsync(step.Id, ctx);
     }
 
     /// <summary>
@@ -196,6 +245,13 @@ public sealed partial class PlanExecutor
         }
     }
 
+    /// <summary>
+    /// Persists a step-state transition and notifies observers. By default <paramref name="output"/>
+    /// and <paramref name="errorMessage"/> fall back to the prior state when null (a status change
+    /// preserves existing data). Set <paramref name="clearPriorOutputs"/> to force the new values —
+    /// including null — so a step can be genuinely cleared of stale output/error (used when a blocked
+    /// step is completed or reset for re-run, to stop an escalation reference lingering as data).
+    /// </summary>
     private async Task TransitionStepAsync(
         PlanId planId,
         PlanStepId stepId,
@@ -203,7 +259,8 @@ public sealed partial class PlanExecutor
         ConcurrentDictionary<PlanStepId, StepExecutionState> stepStates,
         CancellationToken ct,
         string? output = null,
-        string? errorMessage = null)
+        string? errorMessage = null,
+        bool clearPriorOutputs = false)
     {
         var previous = stepStates.GetValueOrDefault(stepId);
         var previousStatus = previous?.Status ?? StepExecutionStatus.Pending;
@@ -216,8 +273,8 @@ public sealed partial class PlanExecutor
             StartedAt = newStatus == StepExecutionStatus.Running ? DateTimeOffset.UtcNow : previous?.StartedAt,
             CompletedAt = newStatus is StepExecutionStatus.Completed or StepExecutionStatus.Failed or StepExecutionStatus.Skipped or StepExecutionStatus.Cancelled
                 ? DateTimeOffset.UtcNow : null,
-            Output = output ?? previous?.Output,
-            ErrorMessage = errorMessage ?? previous?.ErrorMessage
+            Output = clearPriorOutputs ? output : (output ?? previous?.Output),
+            ErrorMessage = clearPriorOutputs ? errorMessage : (errorMessage ?? previous?.ErrorMessage)
         };
 
         stepStates[stepId] = newState;

--- a/src/Content/Infrastructure/Infrastructure.AI/Planner/PlanExecutor.Recovery.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Planner/PlanExecutor.Recovery.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Text.Json;
 using Application.AI.Common.Interfaces.Planner;
 using Domain.AI.Escalation;
 using Domain.AI.Planner;
@@ -8,10 +9,17 @@ namespace Infrastructure.AI.Planner;
 
 /// <summary>
 /// Failure handling and flow control: step failure recovery (including escalation),
-/// downstream subgraph skipping, state transitions, and step initialization.
+/// downstream subgraph skipping, blocked-step reconciliation, state transitions, and step
+/// initialization.
 /// </summary>
 public sealed partial class PlanExecutor
 {
+    /// <summary>
+    /// JSON property under which a blocked step's escalation identifier is stored in its output.
+    /// Must match the shape written by <c>HumanGateStepExecutor</c> (<c>{ "escalationId": "&lt;guid&gt;" }</c>)
+    /// and by the escalate failure-recovery branch below.
+    /// </summary>
+    private const string EscalationIdProperty = "escalationId";
     private async Task HandleStepFailureAsync(PlanStep step, string? errorMessage, PlanExecutionRuntime ctx, CancellationToken ct)
     {
         switch (step.RetryPolicy.OnExhausted)
@@ -40,7 +48,10 @@ public sealed partial class PlanExecutor
                 };
 
                 var escalationId = await _escalationService.QueueEscalationAsync(request, ct);
-                await TransitionStepAsync(ctx.PlanId, step.Id, StepExecutionStatus.Blocked, ctx.StepStates, ct);
+                // Persist the escalation id so the resume path can resolve this block. Without it the
+                // escalated step would be a permanent dead end exactly like an unpersisted human gate.
+                await TransitionStepAsync(ctx.PlanId, step.Id, StepExecutionStatus.Blocked, ctx.StepStates, ct,
+                    output: SerializeEscalationRef(escalationId));
 
                 _logger.LogWarning(
                     "Step {StepId} in plan {PlanId} escalated as {EscalationId} — step blocked pending human approval",
@@ -56,6 +67,99 @@ public sealed partial class PlanExecutor
                 MarkRemainingAsFailed(ctx.StepStates, "Plan failed due to step failure with FailPlan recovery");
                 break;
         }
+    }
+
+    /// <summary>
+    /// Re-evaluates every step currently parked in <see cref="StepExecutionStatus.Blocked"/> against
+    /// the resolution of the escalation that blocked it. This is the bridge that lets a human gate (or
+    /// an escalate-on-failure step) leave <c>Blocked</c> once a decision arrives, and it runs on each
+    /// re-entry into execution (resume): the plan blocks, the caller re-invokes
+    /// <c>ExecuteAsync</c> after the escalation resolves, and this reconciliation acts on the verdict.
+    /// </summary>
+    /// <remarks>
+    /// Mapping per <see cref="IEscalationService.GetOutcomeAsync"/>:
+    /// <list type="bullet">
+    ///   <item><description>Approved — the step is completed and its downstream released, so the plan can finish.</description></item>
+    ///   <item><description>Not approved (denied/timed-out) — the step is failed and routed through
+    ///   <see cref="HandleStepFailureAsync"/>, so its downstream is skipped or re-escalated per the step's retry policy.</description></item>
+    ///   <item><description>Unresolved (null) — the step remains <c>Blocked</c>.</description></item>
+    /// </list>
+    /// A blocked step without a recoverable escalation id (none was persisted) is left untouched.
+    /// This covers resume-time resolution; unblocking mid-execution the instant an approval lands is a
+    /// tracked follow-up — the scheduler currently drains when only blocked steps remain.
+    /// </remarks>
+    private async Task ReconcileBlockedStepsAsync(PlanGraph plan, PlanExecutionRuntime ctx, CancellationToken ct)
+    {
+        foreach (var step in plan.Steps)
+        {
+            var state = ctx.StepStates.GetValueOrDefault(step.Id);
+            if (state is null || state.Status != StepExecutionStatus.Blocked)
+                continue;
+
+            var escalationId = TryReadEscalationId(state.Output);
+            if (escalationId is null)
+                continue;
+
+            var outcome = await _escalationService.GetOutcomeAsync(escalationId.Value, ct);
+            if (outcome is null)
+                continue;
+
+            if (outcome.IsApproved)
+            {
+                _logger.LogInformation(
+                    "Blocked step {StepId} in plan {PlanId} released: escalation {EscalationId} approved",
+                    step.Id, ctx.PlanId, escalationId);
+
+                await TransitionStepAsync(ctx.PlanId, step.Id, StepExecutionStatus.Completed, ctx.StepStates, ct, output: state.Output);
+                if (state.Output is not null)
+                    ctx.StepOutputs[step.Id] = state.Output;
+                await EnqueueReadyDownstreamAsync(step.Id, ctx);
+            }
+            else
+            {
+                var reason = $"Escalation {escalationId} was not approved (resolution: {outcome.ResolutionType}).";
+                _logger.LogWarning(
+                    "Blocked step {StepId} in plan {PlanId} failed: {Reason}", step.Id, ctx.PlanId, reason);
+
+                await TransitionStepAsync(ctx.PlanId, step.Id, StepExecutionStatus.Failed, ctx.StepStates, ct, errorMessage: reason);
+                await HandleStepFailureAsync(step, reason, ctx, ct);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Serializes an escalation identifier into the JSON output shape stored on a blocked step,
+    /// matching the format read by <see cref="TryReadEscalationId"/>.
+    /// </summary>
+    private static string SerializeEscalationRef(Guid escalationId)
+        => JsonSerializer.Serialize(new Dictionary<string, string> { [EscalationIdProperty] = escalationId.ToString() });
+
+    /// <summary>
+    /// Extracts the escalation identifier previously persisted in a blocked step's output, or null
+    /// when the output is absent, malformed, or carries no escalation reference.
+    /// </summary>
+    private static Guid? TryReadEscalationId(string? output)
+    {
+        if (string.IsNullOrEmpty(output))
+            return null;
+
+        try
+        {
+            using var doc = JsonDocument.Parse(output);
+            if (doc.RootElement.ValueKind == JsonValueKind.Object
+                && doc.RootElement.TryGetProperty(EscalationIdProperty, out var idElement)
+                && idElement.ValueKind == JsonValueKind.String
+                && Guid.TryParse(idElement.GetString(), out var id))
+            {
+                return id;
+            }
+        }
+        catch (JsonException)
+        {
+            // Non-JSON or corrupt output — no escalation reference to recover.
+        }
+
+        return null;
     }
 
     private async Task SkipDownstreamSubgraphAsync(PlanStepId fromStepId, PlanExecutionRuntime ctx, bool includeRoot = false)

--- a/src/Content/Infrastructure/Infrastructure.AI/Planner/PlanExecutor.Scheduling.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Planner/PlanExecutor.Scheduling.cs
@@ -125,7 +125,11 @@ public sealed partial class PlanExecutor
                 break;
 
             case StepExecutionStatus.Blocked:
-                await TransitionStepAsync(ctx.PlanId, step.Id, StepExecutionStatus.Blocked, ctx.StepStates, ct);
+                // Persist the executor's output on the Blocked transition. For a human gate this
+                // output carries the escalation identifier, which the resume path
+                // (ReconcileBlockedStepsAsync) reads back to correlate the parked step to its
+                // escalation. Dropping it here would strand the step permanently in Blocked.
+                await TransitionStepAsync(ctx.PlanId, step.Id, StepExecutionStatus.Blocked, ctx.StepStates, ct, output: result.Output);
                 break;
 
             case StepExecutionStatus.Failed:

--- a/src/Content/Infrastructure/Infrastructure.AI/Planner/PlanExecutor.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Planner/PlanExecutor.cs
@@ -12,9 +12,17 @@ namespace Infrastructure.AI.Planner;
 
 /// <summary>
 /// Core DAG scheduling engine that drives plan execution. Implements dynamic ready-queue
-/// scheduling with bounded concurrency, checkpoint/resume, blocked step polling,
-/// conditional branching, and per-plan serialization.
+/// scheduling with bounded concurrency, checkpoint/resume, escalation-gated step reconciliation on
+/// resume, conditional branching, and per-plan serialization.
 /// </summary>
+/// <remarks>
+/// A step that reaches <see cref="Domain.AI.Planner.StepExecutionStatus.Blocked"/> (a human gate, or
+/// an escalate-on-failure step) is not polled in-loop. Instead the escalation identifier is persisted
+/// with the step, the scheduler drains when only blocked steps remain, and the block is resolved on
+/// the next call to <see cref="ExecuteAsync(Domain.AI.Planner.PlanId, System.Threading.CancellationToken)"/>
+/// via <c>ReconcileBlockedStepsAsync</c>: an approved escalation completes the step and continues the
+/// plan, a rejected one fails it through recovery.
+/// </remarks>
 public sealed partial class PlanExecutor : IPlanExecutor
 {
     private static readonly ActivitySource ActivitySource = new("PlanExecution");
@@ -339,13 +347,18 @@ public sealed partial class PlanExecutor : IPlanExecutor
         }
 
         var readyQueue = new ConcurrentQueue<PlanStep>();
-        await EnqueueInitialReadyStepsAsync(plan, stepStates, dependencyMap, readyQueue, planId, planCts.Token);
-
         using var concurrency = new SemaphoreSlim(plan.Configuration.MaxParallelSteps, plan.Configuration.MaxParallelSteps);
         var runningTasks = new HashSet<Task>();
 
         var execCtx = new PlanExecutionRuntime(
             planId, stepStates, stepOutputs, dependencyMap, dependentMap, stepLookup, readyQueue, concurrency);
+
+        // Resolve any steps parked in Blocked whose escalation has since been decided. Approved gates
+        // complete and release their downstream (which this may enqueue), rejected ones fail through
+        // recovery. Runs before the initial enqueue so freshly-released downstream steps are scheduled
+        // in this same execution.
+        await ReconcileBlockedStepsAsync(plan, execCtx, planCts.Token);
+        await EnqueueInitialReadyStepsAsync(plan, stepStates, dependencyMap, readyQueue, planId, planCts.Token);
 
         try
         {

--- a/src/Content/Infrastructure/Infrastructure.AI/Planner/StepExecutors/HumanGateStepExecutor.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Planner/StepExecutors/HumanGateStepExecutor.cs
@@ -10,9 +10,15 @@ using Microsoft.Extensions.Logging;
 namespace Infrastructure.AI.Planner.StepExecutors;
 
 /// <summary>
-/// Non-blocking human approval gate. Queues an escalation and transitions
-/// the step to Blocked. The plan executor polls for resolution.
+/// Non-blocking human approval gate. Queues an escalation and transitions the step to Blocked,
+/// carrying the escalation identifier in its <see cref="StepExecutionResult.Output"/>.
 /// </summary>
+/// <remarks>
+/// The gate does not poll. The plan executor persists the returned escalation id with the blocked
+/// step and, on a subsequent resume, reconciles the block against the escalation's outcome: an
+/// approval completes the gate and releases its downstream, a rejection fails it. The gate's job ends
+/// the moment the escalation is queued.
+/// </remarks>
 public sealed class HumanGateStepExecutor : IPlanStepExecutor
 {
     private readonly IEscalationService _escalationService;

--- a/src/Content/Tests/Infrastructure.AI.Tests/Changes/ChangeProposalStartupValidatorTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Changes/ChangeProposalStartupValidatorTests.cs
@@ -57,6 +57,8 @@ public sealed class ChangeProposalStartupValidatorTests
             Task.FromResult<EscalationOutcome?>(null);
         public Task<EscalationRequest?> GetPendingEscalationAsync(Guid escalationId, CancellationToken ct) =>
             Task.FromResult<EscalationRequest?>(null);
+        public Task<EscalationOutcome?> GetOutcomeAsync(Guid escalationId, CancellationToken ct) =>
+            Task.FromResult<EscalationOutcome?>(null);
         public Task<IReadOnlyList<EscalationRequest>> GetPendingEscalationsAsync(string approverName, CancellationToken ct) =>
             Task.FromResult<IReadOnlyList<EscalationRequest>>([]);
         public Task<EscalationOutcome> CancelEscalationAsync(Guid escalationId, string reason, CancellationToken ct) =>

--- a/src/Content/Tests/Infrastructure.AI.Tests/Changes/Gates/EscalationServiceApprovalRouterTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Changes/Gates/EscalationServiceApprovalRouterTests.cs
@@ -43,6 +43,7 @@ public sealed class EscalationServiceApprovalRouterTests : IDisposable
         public Task<EscalationOutcome> RequestEscalationAsync(EscalationRequest request, CancellationToken ct) => throw new NotImplementedException();
         public Task<EscalationOutcome?> SubmitDecisionAsync(Guid escalationId, ApproverDecision decision, CancellationToken ct) => throw new NotImplementedException();
         public Task<EscalationRequest?> GetPendingEscalationAsync(Guid escalationId, CancellationToken ct) => throw new NotImplementedException();
+        public Task<EscalationOutcome?> GetOutcomeAsync(Guid escalationId, CancellationToken ct) => throw new NotImplementedException();
         public Task<IReadOnlyList<EscalationRequest>> GetPendingEscalationsAsync(string approverName, CancellationToken ct) => throw new NotImplementedException();
         public Task<EscalationOutcome> CancelEscalationAsync(Guid escalationId, string reason, CancellationToken ct) => throw new NotImplementedException();
     }

--- a/src/Content/Tests/Infrastructure.AI.Tests/Escalation/DefaultEscalationServiceTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Escalation/DefaultEscalationServiceTests.cs
@@ -513,4 +513,62 @@ public sealed class DefaultEscalationServiceTests : IDisposable
 			request.EscalationId, CancellationToken.None);
 		pending.Should().BeNull();
 	}
+
+	// ===== GetOutcome (resolved-outcome cache) =====
+
+	[Fact]
+	public async Task GetOutcomeAsync_WhilePending_ReturnsNull()
+	{
+		var request = CreateTestRequest(strategy: ApprovalStrategyType.AllOf);
+		SetupStrategyNeverResolves(ApprovalStrategyType.AllOf);
+		await _sut.QueueEscalationAsync(request, CancellationToken.None);
+
+		var outcome = await _sut.GetOutcomeAsync(request.EscalationId, CancellationToken.None);
+
+		outcome.Should().BeNull("a still-pending escalation has no resolved verdict to report");
+	}
+
+	[Fact]
+	public async Task GetOutcomeAsync_UnknownId_ReturnsNull()
+	{
+		var outcome = await _sut.GetOutcomeAsync(Guid.NewGuid(), CancellationToken.None);
+
+		outcome.Should().BeNull();
+	}
+
+	[Fact]
+	public async Task GetOutcomeAsync_AfterApprovalResolves_ReturnsResolvedOutcome()
+	{
+		// Directly exercises the real _resolvedOutcomes population that the plan-executor resume
+		// bridge relies on: once a decision resolves the escalation, GetOutcomeAsync must surface it.
+		var request = CreateTestRequest();
+		SetupStrategyResolvesOnFirstApproval();
+		await _sut.QueueEscalationAsync(request, CancellationToken.None);
+
+		var submitted = await _sut.SubmitDecisionAsync(
+			request.EscalationId, CreateApproval(), CancellationToken.None);
+		submitted.Should().NotBeNull();
+
+		var outcome = await _sut.GetOutcomeAsync(request.EscalationId, CancellationToken.None);
+
+		outcome.Should().NotBeNull("the resolved verdict must be retrievable after resolution");
+		outcome!.EscalationId.Should().Be(request.EscalationId);
+		outcome.IsApproved.Should().BeTrue();
+		outcome.ResolutionType.Should().Be(EscalationResolutionType.Approved);
+	}
+
+	[Fact]
+	public async Task GetOutcomeAsync_AfterTimeoutResolves_ReturnsResolvedOutcome()
+	{
+		// The resolved-outcome cache must be populated on every resolution path, including timeout.
+		var request = CreateTestRequest(timeoutSeconds: 1, timeoutAction: EscalationTimeoutAction.Deny);
+
+		await _sut.RequestEscalationAsync(request, CancellationToken.None);
+
+		var outcome = await _sut.GetOutcomeAsync(request.EscalationId, CancellationToken.None);
+
+		outcome.Should().NotBeNull();
+		outcome!.ResolutionType.Should().Be(EscalationResolutionType.TimedOut);
+		outcome.IsApproved.Should().BeFalse();
+	}
 }

--- a/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlanExecutorHumanGateLifecycleTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlanExecutorHumanGateLifecycleTests.cs
@@ -161,6 +161,104 @@ public sealed class PlanExecutorHumanGateLifecycleTests : IDisposable
         Assert.Equal(StepExecutionStatus.Skipped, states.Value![workId].Status);
     }
 
+    // (Escalate producer, approved) A step whose REAL work fails and whose Escalate retry policy
+    // blocks it must, on approval, RE-RUN its real work — not be faked Completed. Downstream must
+    // receive the genuine re-run output, never the escalation-reference JSON.
+    [Fact]
+    public async Task Execute_EscalateOnFailureApproved_RerunsRealWorkAndDownstreamGetsRealOutput()
+    {
+        var escalationId = Guid.NewGuid();
+        _escalation.Setup(e => e.QueueEscalationAsync(It.IsAny<EscalationRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(escalationId);
+
+        var (plan, stepAId, stepBId) = EscalatePlan();
+        var stepACalls = 0;
+        var downstreamUpstreamOutputs = new List<string>();
+        var executor = BuildLlmExecutor((step, upstream, _) =>
+        {
+            if (step.Id == stepAId)
+            {
+                stepACalls++;
+                return Task.FromResult(stepACalls == 1
+                    ? new StepExecutionResult { Status = StepExecutionStatus.Failed, ErrorMessage = "boom", Duration = TimeSpan.FromMilliseconds(1) }
+                    : new StepExecutionResult { Status = StepExecutionStatus.Completed, Output = "real-A-output", Duration = TimeSpan.FromMilliseconds(1) });
+            }
+            downstreamUpstreamOutputs.AddRange(upstream.Values);
+            return Task.FromResult(new StepExecutionResult { Status = StepExecutionStatus.Completed, Output = "B", Duration = TimeSpan.FromMilliseconds(1) });
+        });
+        await _store.SavePlanAsync(plan, CancellationToken.None);
+
+        var first = await executor.ExecuteAsync(plan.Id, CancellationToken.None);
+        Assert.Equal(StepExecutionStatus.Blocked, first.Value!.FinalStatus);
+        Assert.Equal(1, stepACalls);
+        Assert.Empty(downstreamUpstreamOutputs);
+
+        // The escalate-on-failure block must persist the escalation-ref just like a human gate.
+        var blocked = await _store.LoadStepStatesAsync(plan.Id, CancellationToken.None);
+        Assert.Equal(StepExecutionStatus.Blocked, blocked.Value![stepAId].Status);
+        Assert.Contains(escalationId.ToString(), blocked.Value![stepAId].Output);
+
+        _escalation.Setup(e => e.GetOutcomeAsync(escalationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Outcome(escalationId, approved: true));
+
+        var second = await executor.ExecuteAsync(plan.Id, CancellationToken.None);
+
+        Assert.True(second.IsSuccess);
+        Assert.Equal(StepExecutionStatus.Completed, second.Value!.FinalStatus);
+        // Real work re-ran (2 invocations), and downstream saw the genuine output, not the ref JSON.
+        Assert.Equal(2, stepACalls);
+        Assert.Equal(new[] { "real-A-output" }, downstreamUpstreamOutputs);
+        Assert.DoesNotContain(escalationId.ToString(), string.Concat(downstreamUpstreamOutputs));
+
+        var final = await _store.LoadStepStatesAsync(plan.Id, CancellationToken.None);
+        Assert.Equal(StepExecutionStatus.Completed, final.Value![stepAId].Status);
+        Assert.Equal("real-A-output", final.Value![stepAId].Output);
+        Assert.Equal(StepExecutionStatus.Completed, final.Value![stepBId].Status);
+    }
+
+    // (Escalate producer, rejected) A rejected escalation is terminal: the step fails and its
+    // downstream is skipped. It must NOT re-run the work and must NOT re-escalate (which the step's
+    // own Escalate policy would otherwise do, looping forever).
+    [Fact]
+    public async Task Execute_EscalateOnFailureRejected_FailsStepAndSkipsDownstream()
+    {
+        var escalationId = Guid.NewGuid();
+        _escalation.Setup(e => e.QueueEscalationAsync(It.IsAny<EscalationRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(escalationId);
+
+        var (plan, stepAId, stepBId) = EscalatePlan();
+        var stepACalls = 0;
+        var executor = BuildLlmExecutor((step, _, _) =>
+        {
+            if (step.Id == stepAId)
+            {
+                stepACalls++;
+                return Task.FromResult(new StepExecutionResult { Status = StepExecutionStatus.Failed, ErrorMessage = "boom", Duration = TimeSpan.FromMilliseconds(1) });
+            }
+            return Task.FromResult(new StepExecutionResult { Status = StepExecutionStatus.Completed, Output = "B", Duration = TimeSpan.FromMilliseconds(1) });
+        });
+        await _store.SavePlanAsync(plan, CancellationToken.None);
+
+        var first = await executor.ExecuteAsync(plan.Id, CancellationToken.None);
+        Assert.Equal(StepExecutionStatus.Blocked, first.Value!.FinalStatus);
+        Assert.Equal(1, stepACalls);
+
+        _escalation.Setup(e => e.GetOutcomeAsync(escalationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Outcome(escalationId, approved: false));
+
+        var second = await executor.ExecuteAsync(plan.Id, CancellationToken.None);
+
+        Assert.True(second.IsSuccess);
+        Assert.Equal(StepExecutionStatus.Failed, second.Value!.FinalStatus);
+        // Rejected work is not re-run, and the block is not re-escalated (QueueEscalation stays at 1).
+        Assert.Equal(1, stepACalls);
+        _escalation.Verify(e => e.QueueEscalationAsync(It.IsAny<EscalationRequest>(), It.IsAny<CancellationToken>()), Times.Once);
+
+        var states = await _store.LoadStepStatesAsync(plan.Id, CancellationToken.None);
+        Assert.Equal(StepExecutionStatus.Failed, states.Value![stepAId].Status);
+        Assert.Equal(StepExecutionStatus.Skipped, states.Value![stepBId].Status);
+    }
+
     // --- Helpers ---
 
     private PlanExecutor BuildExecutor(
@@ -178,6 +276,26 @@ public sealed class PlanExecutorHumanGateLifecycleTests : IDisposable
         var services = new ServiceCollection();
         services.AddKeyedSingleton<IPlanStepExecutor>(StepType.HumanGate, gateMock.Object);
         services.AddKeyedSingleton<IPlanStepExecutor>(StepType.LlmCall, workMock.Object);
+        var provider = services.BuildServiceProvider();
+
+        return new PlanExecutor(
+            _validator.Object,
+            _store,
+            _notifier.Object,
+            _escalation.Object,
+            provider,
+            NullLogger<PlanExecutor>.Instance);
+    }
+
+    private PlanExecutor BuildLlmExecutor(
+        Func<PlanStep, IReadOnlyDictionary<PlanStepId, string>, CancellationToken, Task<StepExecutionResult>> handler)
+    {
+        var mock = new Mock<IPlanStepExecutor>();
+        mock.Setup(e => e.ExecuteAsync(It.IsAny<PlanStep>(), It.IsAny<IReadOnlyDictionary<PlanStepId, string>>(), It.IsAny<CancellationToken>()))
+            .Returns<PlanStep, IReadOnlyDictionary<PlanStepId, string>, CancellationToken>(handler);
+
+        var services = new ServiceCollection();
+        services.AddKeyedSingleton<IPlanStepExecutor>(StepType.LlmCall, mock.Object);
         var provider = services.BuildServiceProvider();
 
         return new PlanExecutor(
@@ -255,6 +373,41 @@ public sealed class PlanExecutorHumanGateLifecycleTests : IDisposable
         };
 
         return (plan, gate.Id, work.Id);
+    }
+
+    private static (PlanGraph Plan, PlanStepId StepAId, PlanStepId StepBId) EscalatePlan()
+    {
+        var stepA = new PlanStep
+        {
+            Id = PlanStepId.New(),
+            Name = "A",
+            Type = StepType.LlmCall,
+            Configuration = new LlmCallConfig { SystemPrompt = "test", ModelDeploymentKey = "gpt-4" },
+            // Escalate on exhausted retries: a real-work failure escalates and blocks the step.
+            RetryPolicy = new RetryPolicy { MaxRetries = 0, OnExhausted = ErrorRecovery.Escalate },
+            Timeout = TimeSpan.FromSeconds(30)
+        };
+
+        var stepB = new PlanStep
+        {
+            Id = PlanStepId.New(),
+            Name = "B",
+            Type = StepType.LlmCall,
+            Configuration = new LlmCallConfig { SystemPrompt = "test", ModelDeploymentKey = "gpt-4" },
+            RetryPolicy = new RetryPolicy { MaxRetries = 0 },
+            Timeout = TimeSpan.FromSeconds(30)
+        };
+
+        var plan = new PlanGraph
+        {
+            Id = PlanId.New(),
+            Name = "escalate-plan",
+            Steps = [stepA, stepB],
+            Edges = [new PlanEdge(stepA.Id, stepB.Id, EdgeType.ControlFlow)],
+            Configuration = new PlanConfiguration { MaxParallelSteps = 2, PlanTimeout = TimeSpan.FromSeconds(10) }
+        };
+
+        return (plan, stepA.Id, stepB.Id);
     }
 
     private sealed class TestDbContextFactory(DbContextOptions<PlannerDbContext> options)

--- a/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlanExecutorHumanGateLifecycleTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlanExecutorHumanGateLifecycleTests.cs
@@ -1,0 +1,265 @@
+using System.Text.Json;
+using Application.AI.Common.Interfaces.Escalation;
+using Application.AI.Common.Interfaces.Planner;
+using Domain.AI.Escalation;
+using Domain.AI.Planner;
+using Domain.Common;
+using Infrastructure.AI.Persistence;
+using Infrastructure.AI.Planner;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Time.Testing;
+using Moq;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Planner;
+
+/// <summary>
+/// Human-gate lifecycle tests exercising the <see cref="PlanExecutor"/> against the real
+/// <see cref="EfCorePlanStateStore"/> backed by in-memory SQLite. These pin the fix for the
+/// dead-end <c>Blocked</c> bug: a step that reaches <c>Blocked</c> awaiting a human escalation must
+/// (a) persist its escalation identifier so it survives a resume, and (b) become runnable again
+/// once the escalation resolves — completing on approval, failing on rejection. A mocked store
+/// would hide the persistence half of the bug, so the production store is used deliberately.
+/// </summary>
+public sealed class PlanExecutorHumanGateLifecycleTests : IDisposable
+{
+    private readonly SqliteConnection _connection;
+    private readonly DbContextOptions<PlannerDbContext> _options;
+    private readonly FakeTimeProvider _timeProvider;
+    private readonly EfCorePlanStateStore _store;
+    private readonly Mock<IPlanValidator> _validator = new();
+    private readonly Mock<IPlanProgressNotifier> _notifier = new();
+    private readonly Mock<IEscalationService> _escalation = new();
+
+    public PlanExecutorHumanGateLifecycleTests()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+
+        _options = new DbContextOptionsBuilder<PlannerDbContext>()
+            .UseSqlite(_connection)
+            .Options;
+
+        using (var ctx = new PlannerDbContext(_options))
+        {
+            ctx.Database.EnsureCreated();
+        }
+
+        _timeProvider = new FakeTimeProvider(new DateTimeOffset(2026, 5, 15, 12, 0, 0, TimeSpan.Zero));
+        _store = new EfCorePlanStateStore(
+            new TestDbContextFactory(_options), NullLogger<EfCorePlanStateStore>.Instance, _timeProvider);
+
+        _validator.Setup(v => v.ValidateAsync(It.IsAny<PlanGraph>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<PlanValidationResult>.Success(new PlanValidationResult { IsValid = true }));
+
+        _notifier.Setup(n => n.NotifyPlanStartedAsync(It.IsAny<PlanId>(), It.IsAny<string>(), It.IsAny<PlanGraph>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        _notifier.Setup(n => n.NotifyStepStartedAsync(It.IsAny<PlanId>(), It.IsAny<PlanStepId>(), It.IsAny<string>(), It.IsAny<StepType>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        _notifier.Setup(n => n.NotifyStepCompletedAsync(It.IsAny<PlanId>(), It.IsAny<PlanStepId>(), It.IsAny<StepExecutionStatus>(), It.IsAny<TimeSpan>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        _notifier.Setup(n => n.NotifyStateUpdateAsync(It.IsAny<PlanId>(), It.IsAny<PlanStepId>(), It.IsAny<StepExecutionStatus>(), It.IsAny<StepExecutionStatus>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        _notifier.Setup(n => n.NotifyPlanCompletedAsync(It.IsAny<PlanId>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        _notifier.Setup(n => n.NotifyPlanFailedAsync(It.IsAny<PlanId>(), It.IsAny<PlanStepId>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        // Default: no escalation has resolved -> a blocked step stays blocked.
+        _escalation.Setup(e => e.GetOutcomeAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((EscalationOutcome?)null);
+    }
+
+    public void Dispose() => _connection.Dispose();
+
+    // (a) A step that reaches Blocked must persist its escalation id in the step's stored output,
+    // otherwise a resume cannot correlate the parked step back to its escalation. Before the fix the
+    // Blocked transition dropped the output entirely.
+    [Fact]
+    public async Task Execute_HumanGateBlocks_PersistsEscalationIdInStepOutput()
+    {
+        var escalationId = Guid.NewGuid();
+        var (plan, gateId, _) = GatedPlan();
+        var executor = BuildExecutor(BlockingGate(escalationId), CompletingWork(new List<PlanStepId>()));
+        await _store.SavePlanAsync(plan, CancellationToken.None);
+
+        var result = await executor.ExecuteAsync(plan.Id, CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(StepExecutionStatus.Blocked, result.Value!.FinalStatus);
+
+        var states = await _store.LoadStepStatesAsync(plan.Id, CancellationToken.None);
+        Assert.True(states.IsSuccess);
+        var gateState = states.Value![gateId];
+        Assert.Equal(StepExecutionStatus.Blocked, gateState.Status);
+        Assert.NotNull(gateState.Output);
+        Assert.Contains(escalationId.ToString(), gateState.Output);
+    }
+
+    // (b) Once the escalation is approved, re-executing the plan must complete the blocked gate and
+    // run its downstream so the plan finishes. Before the fix nothing ever left Blocked, so the
+    // downstream step never ran and the plan could never complete.
+    [Fact]
+    public async Task Execute_ResumeAfterEscalationApproved_RunsBlockedStepDownstreamAndCompletes()
+    {
+        var escalationId = Guid.NewGuid();
+        var (plan, gateId, workId) = GatedPlan();
+        var workInvocations = new List<PlanStepId>();
+        var executor = BuildExecutor(BlockingGate(escalationId), CompletingWork(workInvocations));
+        await _store.SavePlanAsync(plan, CancellationToken.None);
+
+        var first = await executor.ExecuteAsync(plan.Id, CancellationToken.None);
+        Assert.Equal(StepExecutionStatus.Blocked, first.Value!.FinalStatus);
+        Assert.Empty(workInvocations);
+
+        // The human approves the specific escalation the gate raised.
+        _escalation.Setup(e => e.GetOutcomeAsync(escalationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Outcome(escalationId, approved: true));
+
+        var second = await executor.ExecuteAsync(plan.Id, CancellationToken.None);
+
+        Assert.True(second.IsSuccess);
+        Assert.Equal(StepExecutionStatus.Completed, second.Value!.FinalStatus);
+        // The downstream step must actually run now that the gate has cleared.
+        Assert.Equal(new[] { workId }, workInvocations);
+
+        var states = await _store.LoadStepStatesAsync(plan.Id, CancellationToken.None);
+        Assert.Equal(StepExecutionStatus.Completed, states.Value![gateId].Status);
+        Assert.Equal(StepExecutionStatus.Completed, states.Value![workId].Status);
+    }
+
+    // (c) A rejected escalation must fail the blocked step and route its downstream through failure
+    // recovery. The plan must NOT falsely report Completed.
+    [Fact]
+    public async Task Execute_ResumeAfterEscalationRejected_FailsBlockedStepAndPlanDoesNotComplete()
+    {
+        var escalationId = Guid.NewGuid();
+        var (plan, gateId, workId) = GatedPlan();
+        var workInvocations = new List<PlanStepId>();
+        var executor = BuildExecutor(BlockingGate(escalationId), CompletingWork(workInvocations));
+        await _store.SavePlanAsync(plan, CancellationToken.None);
+
+        var first = await executor.ExecuteAsync(plan.Id, CancellationToken.None);
+        Assert.Equal(StepExecutionStatus.Blocked, first.Value!.FinalStatus);
+
+        _escalation.Setup(e => e.GetOutcomeAsync(escalationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Outcome(escalationId, approved: false));
+
+        var second = await executor.ExecuteAsync(plan.Id, CancellationToken.None);
+
+        Assert.True(second.IsSuccess);
+        Assert.NotEqual(StepExecutionStatus.Completed, second.Value!.FinalStatus);
+        Assert.Equal(StepExecutionStatus.Failed, second.Value.FinalStatus);
+        // The downstream step must never run behind a rejected gate.
+        Assert.Empty(workInvocations);
+
+        var states = await _store.LoadStepStatesAsync(plan.Id, CancellationToken.None);
+        Assert.Equal(StepExecutionStatus.Failed, states.Value![gateId].Status);
+        Assert.Equal(StepExecutionStatus.Skipped, states.Value![workId].Status);
+    }
+
+    // --- Helpers ---
+
+    private PlanExecutor BuildExecutor(
+        Func<PlanStep, IReadOnlyDictionary<PlanStepId, string>, CancellationToken, Task<StepExecutionResult>> gateHandler,
+        Func<PlanStep, IReadOnlyDictionary<PlanStepId, string>, CancellationToken, Task<StepExecutionResult>> workHandler)
+    {
+        var gateMock = new Mock<IPlanStepExecutor>();
+        gateMock.Setup(e => e.ExecuteAsync(It.IsAny<PlanStep>(), It.IsAny<IReadOnlyDictionary<PlanStepId, string>>(), It.IsAny<CancellationToken>()))
+            .Returns<PlanStep, IReadOnlyDictionary<PlanStepId, string>, CancellationToken>(gateHandler);
+
+        var workMock = new Mock<IPlanStepExecutor>();
+        workMock.Setup(e => e.ExecuteAsync(It.IsAny<PlanStep>(), It.IsAny<IReadOnlyDictionary<PlanStepId, string>>(), It.IsAny<CancellationToken>()))
+            .Returns<PlanStep, IReadOnlyDictionary<PlanStepId, string>, CancellationToken>(workHandler);
+
+        var services = new ServiceCollection();
+        services.AddKeyedSingleton<IPlanStepExecutor>(StepType.HumanGate, gateMock.Object);
+        services.AddKeyedSingleton<IPlanStepExecutor>(StepType.LlmCall, workMock.Object);
+        var provider = services.BuildServiceProvider();
+
+        return new PlanExecutor(
+            _validator.Object,
+            _store,
+            _notifier.Object,
+            _escalation.Object,
+            provider,
+            NullLogger<PlanExecutor>.Instance);
+    }
+
+    private static Func<PlanStep, IReadOnlyDictionary<PlanStepId, string>, CancellationToken, Task<StepExecutionResult>>
+        BlockingGate(Guid escalationId) => (_, _, _) => Task.FromResult(new StepExecutionResult
+        {
+            Status = StepExecutionStatus.Blocked,
+            Output = JsonSerializer.Serialize(new { escalationId }),
+            Duration = TimeSpan.FromMilliseconds(1)
+        });
+
+    private static Func<PlanStep, IReadOnlyDictionary<PlanStepId, string>, CancellationToken, Task<StepExecutionResult>>
+        CompletingWork(List<PlanStepId> invocations) => (step, _, _) =>
+        {
+            invocations.Add(step.Id);
+            return Task.FromResult(new StepExecutionResult
+            {
+                Status = StepExecutionStatus.Completed,
+                Output = $"output-{step.Name}",
+                Duration = TimeSpan.FromMilliseconds(1)
+            });
+        };
+
+    private static EscalationOutcome Outcome(Guid escalationId, bool approved) => new()
+    {
+        EscalationId = escalationId,
+        IsApproved = approved,
+        Decisions = [],
+        ResolutionType = approved ? EscalationResolutionType.Approved : EscalationResolutionType.Denied,
+        ResolvedAt = new DateTimeOffset(2026, 5, 15, 12, 5, 0, TimeSpan.Zero)
+    };
+
+    private static (PlanGraph Plan, PlanStepId GateId, PlanStepId WorkId) GatedPlan()
+    {
+        var gate = new PlanStep
+        {
+            Id = PlanStepId.New(),
+            Name = "gate-0",
+            Type = StepType.HumanGate,
+            Configuration = new HumanGateConfig
+            {
+                EscalationMessage = "approve me",
+                ApprovalStrategy = ApprovalStrategy.AnyOf,
+                Approvers = ["supervisor"]
+            },
+            RetryPolicy = new RetryPolicy { MaxRetries = 0 },
+            Timeout = TimeSpan.FromSeconds(30)
+        };
+
+        var work = new PlanStep
+        {
+            Id = PlanStepId.New(),
+            Name = "work-1",
+            Type = StepType.LlmCall,
+            Configuration = new LlmCallConfig { SystemPrompt = "test", ModelDeploymentKey = "gpt-4" },
+            RetryPolicy = new RetryPolicy { MaxRetries = 0 },
+            Timeout = TimeSpan.FromSeconds(30)
+        };
+
+        var plan = new PlanGraph
+        {
+            Id = PlanId.New(),
+            Name = "gated-plan",
+            Steps = [gate, work],
+            Edges = [new PlanEdge(gate.Id, work.Id, EdgeType.ControlFlow)],
+            Configuration = new PlanConfiguration { MaxParallelSteps = 2, PlanTimeout = TimeSpan.FromSeconds(10) }
+        };
+
+        return (plan, gate.Id, work.Id);
+    }
+
+    private sealed class TestDbContextFactory(DbContextOptions<PlannerDbContext> options)
+        : IDbContextFactory<PlannerDbContext>
+    {
+        public PlannerDbContext CreateDbContext() => new(options);
+    }
+}


### PR DESCRIPTION
## Problem (CRITICAL)
A DAG plan step that reached `Blocked` (produced by a HumanGate step, or by the Escalate-on-failure recovery policy) was a permanent dead end — nothing ever transitioned it out of `Blocked`, so those step types could never complete a plan. The escalation id was also dropped when persisting the Blocked transition (`output: null`), and `IEscalationService` had no bridge back to plan state. The XML docs claimed "blocked step polling" that did not exist.

## Fix
- Persist the escalation id on the Blocked transition (both the human-gate and escalate-on-failure paths).
- New `IEscalationService.GetOutcomeAsync` (additive — the 24 existing callers are unaffected), backed by an in-memory resolved-outcome cache populated at the single resolution chokepoint.
- `ReconcileBlockedStepsAsync` runs on every resume and maps each blocked step's escalation outcome:
  - **Human gate approved** → `Completed`, downstream released, the escalation-ref output cleared (a gate carries no data).
  - **Escalate-on-failure approved** → reset to `Pending` so the step's **real work re-runs** and downstream receives genuine output (never the escalation-ref JSON). A repeat failure re-escalates per the retry policy.
  - **Rejected** (both producers) → `Failed` + downstream skipped, **terminally** — deliberately not routed back through the failure handler, which would re-escalate the request the human just rejected (an unbounded reject→re-escalate loop).
  - **Unresolved** → stays `Blocked`.
- Replaced the false "polling" docs with the actual persist-then-reconcile behavior.

## Review-driven fixes (independent review verdict: safe-to-merge-with-fixes → applied)
1. The resolved-outcome cache write now happens **after** the fail-closed durable audit (from the escalation-authorization PR this rebased onto), so the resume bridge can never act on a verdict that was rolled back and never durably recorded.
2. Split the two Blocked producers so an approved **failed** step re-runs its real work instead of being marked Completed with a leaked escalation reference as its output.
3. Added a `clearPriorOutputs` flag to the state transition (default off; existing callers unchanged) to genuinely clear stale output/error.

## Test plan
Real `EfCorePlanStateStore` + in-memory SQLite. HumanGate: approved→completes, rejected→fails+skips. Escalate-on-failure: approved→work executes **twice** and downstream gets the real output (asserts the escalation JSON is absent), rejected→fails+skips with the escalation queued exactly once (proves no re-escalation loop). Plus 4 direct `GetOutcomeAsync`/cache tests (pending→null, unknown→null, approval-resolves, timeout-resolves). Infrastructure.AI build clean (0 warnings); full Infrastructure.AI.Tests 2005 pass (3 pre-existing FileSystem sandbox failures unrelated).

## Follow-up (tracked, not in scope)
Unblocking mid-execution the instant an approval lands (rather than at next resume) — the scheduler currently drains when only blocked steps remain.

Wave-2, from the deep audit — resolves the last of the four criticals.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>