### PR TITLE
fix: wire config-section validators into startup options validation

### DIFF
--- a/src/Content/Application/Application.Common/Extensions/FluentValidationValidateOptions.cs
+++ b/src/Content/Application/Application.Common/Extensions/FluentValidationValidateOptions.cs
@@ -1,0 +1,65 @@
+using FluentValidation;
+using Microsoft.Extensions.Options;
+
+namespace Application.Common.Extensions;
+
+/// <summary>
+/// Bridges a FluentValidation <see cref="IValidator{T}"/> into the Microsoft.Extensions.Options
+/// validation pipeline (<see cref="IValidateOptions{TOptions}"/>), so config-section validators
+/// participate in <c>ValidateOnStart()</c> fail-fast startup validation and per-reload
+/// revalidation.
+/// </summary>
+/// <typeparam name="TOptions">The bound configuration class being validated.</typeparam>
+/// <remarks>
+/// <para>
+/// Each validation failure is reported as
+/// <c>Configuration validation failed for '{Options}.{Property}': {message}</c>, giving the
+/// operator the exact appsettings path to fix. All failures for the instance are reported
+/// together, so a single boot surfaces the complete list rather than failing one rule at a time.
+/// </para>
+/// <para>
+/// Register via
+/// <see cref="OptionsBuilderFluentValidationExtensions.ValidateFluentValidation{TOptions, TValidator}"/>
+/// rather than instantiating directly.
+/// </para>
+/// </remarks>
+public sealed class FluentValidationValidateOptions<TOptions> : IValidateOptions<TOptions>
+    where TOptions : class
+{
+    private readonly string? _name;
+    private readonly IValidator<TOptions> _validator;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FluentValidationValidateOptions{TOptions}"/> class.
+    /// </summary>
+    /// <param name="name">
+    /// The named-options instance this validator applies to, or <see langword="null"/> to
+    /// validate every named instance of <typeparamref name="TOptions"/>.
+    /// </param>
+    /// <param name="validator">The FluentValidation validator holding the section's rules.</param>
+    public FluentValidationValidateOptions(string? name, IValidator<TOptions> validator)
+    {
+        _name = name;
+        _validator = validator ?? throw new ArgumentNullException(nameof(validator));
+    }
+
+    /// <inheritdoc />
+    public ValidateOptionsResult Validate(string? name, TOptions options)
+    {
+        // Named-options semantics: a validator registered for a specific name skips
+        // every other instance; a null registration name means "validate all".
+        if (_name is not null && _name != name)
+            return ValidateOptionsResult.Skip;
+
+        ArgumentNullException.ThrowIfNull(options);
+
+        var result = _validator.Validate(options);
+        if (result.IsValid)
+            return ValidateOptionsResult.Success;
+
+        var failures = result.Errors.Select(static failure =>
+            $"Configuration validation failed for '{typeof(TOptions).Name}.{failure.PropertyName}': {failure.ErrorMessage}");
+
+        return ValidateOptionsResult.Fail(failures);
+    }
+}

--- a/src/Content/Application/Application.Common/Extensions/OptionsBuilderFluentValidationExtensions.cs
+++ b/src/Content/Application/Application.Common/Extensions/OptionsBuilderFluentValidationExtensions.cs
@@ -1,0 +1,47 @@
+using FluentValidation;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace Application.Common.Extensions;
+
+/// <summary>
+/// Extension methods attaching FluentValidation config-section validators to the
+/// options pipeline, mirroring the built-in <c>ValidateDataAnnotations()</c> shape.
+/// </summary>
+public static class OptionsBuilderFluentValidationExtensions
+{
+    /// <summary>
+    /// Attaches a FluentValidation validator to this options registration so the bound
+    /// section is validated by the options pipeline — combine with
+    /// <c>ValidateOnStart()</c> to fail fast at host boot on invalid configuration.
+    /// </summary>
+    /// <typeparam name="TOptions">The bound configuration class.</typeparam>
+    /// <typeparam name="TValidator">
+    /// The FluentValidation validator holding the section's rules. Instantiated directly
+    /// (not resolved from DI) so validation works in any composition root regardless of
+    /// whether validator assembly-scanning has run — config validators are stateless with
+    /// parameterless constructors by convention.
+    /// </typeparam>
+    /// <param name="builder">The options builder returned by <c>AddOptions&lt;TOptions&gt;()</c>.</param>
+    /// <returns>The same builder for chaining.</returns>
+    /// <example>
+    /// <code>
+    /// services.AddOptions&lt;LearningsConfig&gt;()
+    ///     .Bind(configuration.GetSection("AppConfig:AI:Learnings"))
+    ///     .ValidateFluentValidation&lt;LearningsConfig, LearningsConfigValidator&gt;()
+    ///     .ValidateOnStart();
+    /// </code>
+    /// </example>
+    public static OptionsBuilder<TOptions> ValidateFluentValidation<TOptions, TValidator>(
+        this OptionsBuilder<TOptions> builder)
+        where TOptions : class
+        where TValidator : IValidator<TOptions>, new()
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        builder.Services.AddSingleton<IValidateOptions<TOptions>>(
+            new FluentValidationValidateOptions<TOptions>(builder.Name, new TValidator()));
+
+        return builder;
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.Planner.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.Planner.cs
@@ -92,6 +92,16 @@ public static partial class DependencyInjection
 
         services.AddScoped<IAttestationService, HmacAttestationService>();
 
+        // Options-pipeline validation for the attestation key material. Deliberately NOT
+        // ValidateOnStart(): AttestationKeyOptions is unbound by default (keys come from
+        // User Secrets / Key Vault, never appsettings), so eager validation would fail every
+        // host that doesn't use sandbox attestation. Instead the validator fires when the
+        // options are first materialized (and on every reload), turning bad key material
+        // into an OptionsValidationException at the point of use.
+        services.AddSingleton<
+            Microsoft.Extensions.Options.IValidateOptions<AttestationKeyOptions>,
+            AttestationKeyOptionsValidator>();
+
         if (OperatingSystem.IsWindows())
             services.AddSingleton<IProcessResourceLimiter, WindowsProcessResourceLimiter>();
         else

--- a/src/Content/Presentation/Presentation.Common/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Content/Presentation/Presentation.Common/Extensions/IServiceCollectionExtensions.cs
@@ -1,11 +1,18 @@
 using Application.AI.Common;
 using Application.Common;
+using Application.Common.Extensions;
 using Application.Common.Interfaces.Security;
 using Application.Core;
+using Application.Core.Validation;
 using Domain.Common.Config;
 using Domain.Common.Config.AI;
+using Domain.Common.Config.AI.GitOps;
 using Domain.Common.Config.AI.Governance;
+using Domain.Common.Config.AI.HarmonicMemory;
+using Domain.Common.Config.AI.Iac;
 using Domain.Common.Config.AI.Resilience;
+using Domain.Common.Config.AI.Telemetry;
+using Domain.Common.Config.AI.WorkMemory;
 using Domain.Common.Config.Azure;
 using Domain.Common.Config.Cache;
 using Domain.Common.Config.Connectors;
@@ -69,8 +76,18 @@ public static class IServiceCollectionExtensions
     /// </param>
     /// <returns>The service collection for chaining.</returns>
     /// <remarks>
+    /// <para>
     /// Each subsection path maps to <c>AppConfig:{SectionName}</c> in appsettings.json.
     /// All config classes support runtime reload via <c>IOptionsMonitor&lt;T&gt;</c>.
+    /// </para>
+    /// <para>
+    /// Sections that have a FluentValidation config validator (Application.Core/Validation)
+    /// are bound through <c>AddOptions&lt;T&gt;().Bind(...)</c> with the validator attached and
+    /// <c>ValidateOnStart()</c>, so invalid appsettings values fail the host at boot instead
+    /// of passing silently. IHost-based hosts run this natively inside <c>StartAsync</c>;
+    /// console-style hosts that start hosted services manually get the same guarantee via
+    /// <see cref="Startup.StartupRegistrationSmokeCheck"/>.
+    /// </para>
     /// </remarks>
     public static IServiceCollection RegisterConfigSections(
         this IServiceCollection services,
@@ -88,12 +105,6 @@ public static class IServiceCollectionExtensions
         services.Configure<EmbeddingConfig>(configuration.GetSection("AppConfig:AI:Embedding"));
         services.Configure<AzureConfig>(configuration.GetSection("AppConfig:Azure"));
         services.Configure<CacheConfig>(configuration.GetSection("AppConfig:Cache"));
-        services.Configure<EscalationConfig>(configuration.GetSection("AppConfig:AI:Governance:Escalation"));
-        services.Configure<ResilienceConfig>(configuration.GetSection("AppConfig:AI:Resilience"));
-        services.Configure<Domain.Common.Config.AI.DriftDetection.DriftDetectionConfig>(
-            configuration.GetSection("AppConfig:AI:DriftDetection"));
-        services.Configure<Domain.Common.Config.AI.Learnings.LearningsConfig>(
-            configuration.GetSection("AppConfig:AI:Learnings"));
         // Sandbox capability-enforcement knobs (SandboxConfig). Bound under a distinct
         // path from AppConfig:AI:Sandbox (which binds the unrelated SandboxOptions class).
         // Composes over the AddOptions<SandboxConfig>() defaults registered in
@@ -101,6 +112,90 @@ public static class IServiceCollectionExtensions
         // WorkspaceRoot / Enabled actually reach IOptionsMonitor<SandboxConfig> consumers.
         services.Configure<Domain.Common.Config.AI.Sandbox.SandboxConfig>(
             configuration.GetSection("AppConfig:AI:SandboxCapabilities"));
+
+        return services.RegisterValidatedConfigSections(configuration);
+    }
+
+    /// <summary>
+    /// Binds every AppConfig subsection that has a FluentValidation config validator, attaching
+    /// the validator to the options pipeline and enforcing it at host start.
+    /// </summary>
+    /// <param name="services">The service collection to configure.</param>
+    /// <param name="configuration">
+    /// The root <see cref="IConfiguration"/> containing the <c>AppConfig</c> section.
+    /// </param>
+    /// <returns>The service collection for chaining.</returns>
+    /// <remarks>
+    /// This is the single wiring point that keeps the config validators in
+    /// <c>Application.Core/Validation</c> live ("inert machinery" defense): each binding names
+    /// its section path and its validator, and <c>ValidateOnStart()</c> converts an invalid
+    /// value into an <see cref="Microsoft.Extensions.Options.OptionsValidationException"/> at
+    /// boot. Validators whose rules are conditional on an <c>Enabled</c> flag impose no
+    /// constraints while the feature is off, so hosts that omit these sections keep booting
+    /// on class defaults.
+    /// </remarks>
+    private static IServiceCollection RegisterValidatedConfigSections(
+        this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        services.AddOptions<EscalationConfig>()
+            .Bind(configuration.GetSection("AppConfig:AI:Governance:Escalation"))
+            .ValidateFluentValidation<EscalationConfig, EscalationConfigValidator>()
+            .ValidateOnStart();
+
+        services.AddOptions<ResilienceConfig>()
+            .Bind(configuration.GetSection("AppConfig:AI:Resilience"))
+            .ValidateFluentValidation<ResilienceConfig, ResilienceConfigValidator>()
+            .ValidateOnStart();
+
+        services.AddOptions<Domain.Common.Config.AI.DriftDetection.DriftDetectionConfig>()
+            .Bind(configuration.GetSection("AppConfig:AI:DriftDetection"))
+            .ValidateFluentValidation<
+                Domain.Common.Config.AI.DriftDetection.DriftDetectionConfig,
+                DriftDetectionConfigValidator>()
+            .ValidateOnStart();
+
+        services.AddOptions<Domain.Common.Config.AI.Learnings.LearningsConfig>()
+            .Bind(configuration.GetSection("AppConfig:AI:Learnings"))
+            .ValidateFluentValidation<
+                Domain.Common.Config.AI.Learnings.LearningsConfig,
+                LearningsConfigValidator>()
+            .ValidateOnStart();
+
+        services.AddOptions<WorkMemoryConfig>()
+            .Bind(configuration.GetSection("AppConfig:AI:WorkMemory"))
+            .ValidateFluentValidation<WorkMemoryConfig, WorkMemoryConfigValidator>()
+            .ValidateOnStart();
+
+        services.AddOptions<HarmonicMemoryConfig>()
+            .Bind(configuration.GetSection("AppConfig:AI:HarmonicMemory"))
+            .ValidateFluentValidation<HarmonicMemoryConfig, HarmonicMemoryConfigValidator>()
+            .ValidateOnStart();
+
+        services.AddOptions<LearningsRecallConfig>()
+            .Bind(configuration.GetSection("AppConfig:AI:LearningsRecall"))
+            .ValidateFluentValidation<LearningsRecallConfig, LearningsRecallConfigValidator>()
+            .ValidateOnStart();
+
+        services.AddOptions<GitOpsConfig>()
+            .Bind(configuration.GetSection("AppConfig:AI:GitOps"))
+            .ValidateFluentValidation<GitOpsConfig, GitOpsConfigValidator>()
+            .ValidateOnStart();
+
+        services.AddOptions<IacConfig>()
+            .Bind(configuration.GetSection("AppConfig:AI:Iac"))
+            .ValidateFluentValidation<IacConfig, IacConfigValidator>()
+            .ValidateOnStart();
+
+        services.AddOptions<DataClassificationConfig>()
+            .Bind(configuration.GetSection("AppConfig:AI:Governance:DataClassification"))
+            .ValidateFluentValidation<DataClassificationConfig, DataClassificationConfigValidator>()
+            .ValidateOnStart();
+
+        services.AddOptions<ContentCaptureConfig>()
+            .Bind(configuration.GetSection("AppConfig:AI:Telemetry:ContentCapture"))
+            .ValidateFluentValidation<ContentCaptureConfig, ContentCaptureConfigValidator>()
+            .ValidateOnStart();
 
         return services;
     }

--- a/src/Content/Presentation/Presentation.Common/Startup/StartupRegistrationSmokeCheck.cs
+++ b/src/Content/Presentation/Presentation.Common/Startup/StartupRegistrationSmokeCheck.cs
@@ -53,16 +53,28 @@ public sealed class StartupRegistrationSmokeCheck : IHostedService
     }
 
     /// <summary>
-    /// Runs every smoke check and throws an aggregated <see cref="InvalidOperationException"/>
-    /// when any required binding or registration is missing.
+    /// Runs startup options validation plus every smoke check, throwing an aggregated
+    /// <see cref="InvalidOperationException"/> when any required binding or registration
+    /// is missing.
     /// </summary>
     /// <param name="cancellationToken">Token to observe while starting.</param>
     /// <returns>A completed task when all checks pass.</returns>
+    /// <exception cref="OptionsValidationException">
+    /// Thrown when a config section registered with <c>ValidateOnStart()</c> holds invalid values.
+    /// </exception>
     /// <exception cref="InvalidOperationException">
     /// Thrown when one or more critical options bindings or services cannot be resolved.
     /// </exception>
     public Task StartAsync(CancellationToken cancellationToken)
     {
+        // Startup options validation (every ValidateOnStart() binding). IHost-based hosts run
+        // IStartupValidator natively inside Host.StartAsync, but console-style hosts (ConsoleUI,
+        // EvalRunner, FoundryHost) compose a bare ServiceCollection and start hosted services
+        // manually — without this call they would never trigger it and invalid config would
+        // boot silently. Runs first and rethrows as-is: OptionsValidationException already
+        // carries the per-property messages the operator needs.
+        _serviceProvider.GetService<IStartupValidator>()?.Validate();
+
         var failures = new List<string>();
 
         // Options bindings: resolving CurrentValue forces the bind to run. A missing

--- a/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlannerDiRegistrationTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlannerDiRegistrationTests.cs
@@ -65,6 +65,16 @@ public sealed class PlannerDiRegistrationTests : IDisposable
     }
 
     [Fact]
+    public void DependencyInjection_AttestationKeyOptionsValidator_WiredIntoOptionsPipeline()
+    {
+        // Regression guard for the "inert machinery" audit finding: the validator existed but
+        // was never registered as IValidateOptions, so misconfigured key material was only
+        // caught by the service's own runtime check instead of the options pipeline.
+        _provider.GetService<IValidateOptions<AttestationKeyOptions>>()
+            .Should().NotBeNull().And.BeOfType<AttestationKeyOptionsValidator>();
+    }
+
+    [Fact]
     public void DependencyInjection_KeyedStepExecutors_ResolveAllFiveTypes()
     {
         using var scope = _provider.CreateScope();

--- a/src/Content/Tests/Presentation.Common.Tests/Extensions/ConfigValidationStartupTests.cs
+++ b/src/Content/Tests/Presentation.Common.Tests/Extensions/ConfigValidationStartupTests.cs
@@ -1,0 +1,214 @@
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Presentation.Common.Extensions;
+using Presentation.Common.Startup;
+using Xunit;
+
+namespace Presentation.Common.Tests.Extensions;
+
+/// <summary>
+/// Proves that every AppConfig section with a FluentValidation config validator fails fast at
+/// startup when the bound values are invalid, and that default (omitted) sections keep passing
+/// so existing hosts boot unchanged.
+/// </summary>
+/// <remarks>
+/// Regression guard for the Wave-2 audit finding "config validators are inert machinery":
+/// the validators existed and were unit-tested, but nothing wired them into the options
+/// pipeline, so invalid appsettings values started up silently. These tests exercise the
+/// wiring itself — <c>RegisterConfigSections</c> → <see cref="IStartupValidator"/> — not the
+/// individual validator rules (those have their own unit tests).
+/// </remarks>
+public class ConfigValidationStartupTests
+{
+    private static ServiceProvider BuildProvider(Dictionary<string, string?> settings)
+    {
+        var services = new ServiceCollection();
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(settings)
+            .Build();
+
+        services.RegisterConfigSections(config);
+        return services.BuildServiceProvider();
+    }
+
+    /// <summary>
+    /// One obviously-invalid probe per validated config section. Each row violates an
+    /// unconditional (or trivially armed) rule of the section's validator.
+    /// </summary>
+    public static TheoryData<string, Dictionary<string, string?>> InvalidSectionValues => new()
+    {
+        {
+            "ResilienceConfig",
+            new Dictionary<string, string?> { ["AppConfig:AI:Resilience:Retry:BackoffType"] = "Bogus" }
+        },
+        {
+            "DriftDetectionConfig",
+            new Dictionary<string, string?> { ["AppConfig:AI:DriftDetection:EwmaLambda"] = "0" }
+        },
+        {
+            "LearningsConfig",
+            new Dictionary<string, string?> { ["AppConfig:AI:Learnings:FeedbackAlpha"] = "0" }
+        },
+        {
+            "EscalationConfig",
+            new Dictionary<string, string?> { ["AppConfig:AI:Governance:Escalation:DefaultTimeoutAction"] = "NotAnAction" }
+        },
+        {
+            "WorkMemoryConfig",
+            new Dictionary<string, string?> { ["AppConfig:AI:WorkMemory:StoreProvider"] = "not_a_provider" }
+        },
+        {
+            "HarmonicMemoryConfig",
+            new Dictionary<string, string?> { ["AppConfig:AI:HarmonicMemory:BatchAtSessionFlush"] = "true" }
+        },
+        {
+            "LearningsRecallConfig",
+            new Dictionary<string, string?> { ["AppConfig:AI:LearningsRecall:MaxResults"] = "0" }
+        },
+        {
+            "GitOpsConfig",
+            new Dictionary<string, string?>
+            {
+                ["AppConfig:AI:GitOps:Enabled"] = "true",
+                ["AppConfig:AI:GitOps:ActiveController"] = "not-a-controller",
+            }
+        },
+        {
+            "IacConfig",
+            new Dictionary<string, string?>
+            {
+                ["AppConfig:AI:Iac:Enabled"] = "true",
+                ["AppConfig:AI:Iac:BlockingSeverity"] = "NotASeverity",
+            }
+        },
+        {
+            "DataClassificationConfig",
+            new Dictionary<string, string?>
+            {
+                ["AppConfig:AI:Governance:DataClassification:Mode"] = "Audit",
+                ["AppConfig:AI:Governance:DataClassification:ResultCacheTtl"] = "-00:05:00",
+            }
+        },
+        {
+            "ContentCaptureConfig",
+            new Dictionary<string, string?>
+            {
+                ["AppConfig:AI:Telemetry:ContentCapture:Enabled"] = "true",
+                ["AppConfig:AI:Telemetry:ContentCapture:RedactionCategories:0"] = "NotACategory",
+            }
+        },
+    };
+
+    [Theory]
+    [MemberData(nameof(InvalidSectionValues))]
+    public void RegisterConfigSections_InvalidSectionValue_FailsStartupValidation(
+        string sectionLabel, Dictionary<string, string?> invalidSettings)
+    {
+        using var provider = BuildProvider(invalidSettings);
+
+        // ValidateOnStart registers the IStartupValidator that hosts run at boot.
+        // If this resolves to null, config validation is not wired at startup at all
+        // (the original audit finding).
+        var startupValidator = provider.GetService<IStartupValidator>();
+        startupValidator.Should().NotBeNull(
+            $"config validation for {sectionLabel} must be wired into startup via ValidateOnStart");
+
+        var act = () => startupValidator!.Validate();
+        act.Should().Throw<OptionsValidationException>(
+            $"an invalid {sectionLabel} value must fail host startup instead of passing silently");
+    }
+
+    [Fact]
+    public void RegisterConfigSections_EmptyConfiguration_PassesStartupValidation()
+    {
+        // Hosts omit most validated sections entirely (FoundryHost, MCPServer, …) — the
+        // config-class defaults must satisfy every validator or wiring validation would
+        // break currently-valid hosts.
+        using var provider = BuildProvider([]);
+
+        var startupValidator = provider.GetService<IStartupValidator>();
+        startupValidator.Should().NotBeNull(
+            "config validation must be wired into startup via ValidateOnStart");
+
+        var act = () => startupValidator!.Validate();
+        act.Should().NotThrow(
+            "default config values must pass validation so hosts without these sections keep booting");
+    }
+
+    [Fact]
+    public void RegisterConfigSections_CurrentHostSectionShape_PassesStartupValidation()
+    {
+        // Mirrors the values every host appsettings.json actually ships today
+        // (AgentHub/ConsoleUI/EvalRunner/FoundryHost) — wiring validation must not
+        // reject the existing, valid configuration.
+        using var provider = BuildProvider(new Dictionary<string, string?>
+        {
+            ["AppConfig:AI:Resilience:Enabled"] = "false",
+            ["AppConfig:AI:Resilience:FallbackChain:0:ClientType"] = "AzureOpenAI",
+            ["AppConfig:AI:Resilience:FallbackChain:0:DeploymentId"] = "gpt-4o",
+            ["AppConfig:AI:DriftDetection:Enabled"] = "true",
+            ["AppConfig:AI:DriftDetection:EwmaLambda"] = "0.2",
+            ["AppConfig:AI:Learnings:Enabled"] = "true",
+            ["AppConfig:AI:Learnings:FeedbackAlpha"] = "0.25",
+            ["AppConfig:AI:Governance:Escalation:Enabled"] = "true",
+            ["AppConfig:AI:Governance:Escalation:DefaultTimeoutAction"] = "DenyAndEscalate",
+            ["AppConfig:AI:Governance:Escalation:PriorityLevels:Blocking:TimeoutSeconds"] = "300",
+            ["AppConfig:AI:Governance:DataClassification:Mode"] = "Off",
+        });
+
+        var startupValidator = provider.GetService<IStartupValidator>();
+        startupValidator.Should().NotBeNull();
+
+        var act = () => startupValidator!.Validate();
+        act.Should().NotThrow("the configuration every host ships today is valid and must keep booting");
+    }
+
+    [Fact]
+    public async Task Host_WithInvalidConfigValue_FailsFastOnStart()
+    {
+        // Representative end-to-end proof at the real host level: a web-style IHost runs
+        // IStartupValidator inside StartAsync, so an invalid value aborts boot.
+        var builder = Host.CreateApplicationBuilder();
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["AppConfig:AI:DriftDetection:EwmaLambda"] = "0",
+        });
+        builder.Services.RegisterConfigSections(builder.Configuration);
+
+        using var host = builder.Build();
+
+        var act = () => host.StartAsync();
+        await act.Should().ThrowAsync<OptionsValidationException>(
+            "an IHost-based composition root must refuse to start on invalid config");
+    }
+
+    [Fact]
+    public async Task StartupRegistrationSmokeCheck_WithInvalidConfigValue_ThrowsOptionsValidation()
+    {
+        // Console-style hosts (ConsoleUI, EvalRunner, FoundryHost) compose a bare
+        // ServiceCollection and start hosted services manually — no IHost means the
+        // native IStartupValidator hook never runs. StartupRegistrationSmokeCheck is
+        // the hosted service every host runs, so it must trigger startup options
+        // validation for those hosts.
+        var services = new ServiceCollection();
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["AppConfig:AI:Learnings:FeedbackAlpha"] = "0",
+            })
+            .Build();
+        services.RegisterConfigSections(config);
+        await using var provider = services.BuildServiceProvider();
+
+        var smokeCheck = new StartupRegistrationSmokeCheck(
+            provider, NullLogger<StartupRegistrationSmokeCheck>.Instance);
+
+        var act = () => smokeCheck.StartAsync(CancellationToken.None);
+        await act.Should().ThrowAsync<OptionsValidationException>(
+            "console hosts rely on the smoke check to run startup options validation");
+    }
+}

--- a/src/Content/Tests/Presentation.Common.Tests/Extensions/IServiceCollectionExtensionsTests.cs
+++ b/src/Content/Tests/Presentation.Common.Tests/Extensions/IServiceCollectionExtensionsTests.cs
@@ -165,6 +165,9 @@ public sealed class IServiceCollectionExtensionsTests
             {
                 ["AppConfig:AI:Governance:Escalation:Enabled"] = "true",
                 ["AppConfig:AI:Governance:Escalation:DefaultTimeoutSeconds"] = "600",
+                // Escalation is enabled above, so the now-enforced config validator requires
+                // at least one priority level (as every real host appsettings.json provides).
+                ["AppConfig:AI:Governance:Escalation:PriorityLevels:Blocking:TimeoutSeconds"] = "300",
             })
             .Build();
 
@@ -184,6 +187,10 @@ public sealed class IServiceCollectionExtensionsTests
             .AddInMemoryCollection(new Dictionary<string, string?>
             {
                 ["AppConfig:AI:Resilience:Enabled"] = "true",
+                // Resilience is enabled above, so the now-enforced config validator requires a
+                // non-empty fallback chain (as every real host appsettings.json provides).
+                ["AppConfig:AI:Resilience:FallbackChain:0:ClientType"] = "AzureOpenAI",
+                ["AppConfig:AI:Resilience:FallbackChain:0:DeploymentId"] = "gpt-4o",
             })
             .Build();
 


### PR DESCRIPTION
## Summary
Wave-2 audit item **I1**. The 11 FluentValidation AppConfig-section validators and the `AttestationKeyOptionsValidator` (`IValidateOptions`) were dead — written and unit-tested but never attached to the options pipeline, so invalid appsettings values booted silently ("inert machinery" audit through-line).

- New shared `FluentValidationValidateOptions<TOptions>` adapter + `ValidateFluentValidation<TOptions,TValidator>()` extension (Application.Common). Validator is instantiated directly, not DI-resolved, so validation cannot be silently inert when assembly scanning hasn't run.
- All 11 validated sections bound via `AddOptions<T>().Bind(section).ValidateFluentValidation().ValidateOnStart()` in `RegisterConfigSections` (4 converted from `Configure<T>`, 7 newly bound: WorkMemory, HarmonicMemory, LearningsRecall, GitOps, Iac, DataClassification, ContentCapture).
- Console-host gap closed: ConsoleUI/EvalRunner/FoundryHost compose bare ServiceCollections where `ValidateOnStart` never fires — `StartupRegistrationSmokeCheck.StartAsync` now invokes `IStartupValidator` first, so every host fails fast.
- `AttestationKeyOptionsValidator` registered as `IValidateOptions` (deliberately without ValidateOnStart: options are unbound by default; keys come from User Secrets/Key Vault — eager validation would break hosts not using sandbox attestation).

## Reproduce-first proof
`ConfigValidationStartupTests` (15 tests): all 15 FAILED pre-fix (invalid config booted silently), 15/15 pass post-fix — one invalid-probe per section throws `OptionsValidationException`; defaults and current host shapes still boot.

## Report-only findings (no code change)
- Dead appsettings keys: `AppConfig:Agent:MaxTurnsPerConversation` (3 hosts), `AppConfig:Observability:EnableSensitiveData` (ConsoleUI dev), `AppConfig:Observability:EnableMetrics`/`EnableTracing` (FoundryHost Foundry profile).
- 5 planner step-config validators (LlmCall/ToolUse/HumanGate/ConditionalBranch/SubPlanConfigValidator) are also dead but validate plan-graph runtime data, not appsettings — follow-up: wire into `PlanValidator`.

## Test plan
- [x] 15/15 repro tests red→green
- [x] Project-scoped suites green: Presentation.Common.Tests 113, Application.Common.Tests 199, Application.Core.Tests 638, FoundryHost 21, EvalRunner 21, MCPServer 34, AgentHub 384 (+ known Docker-gated E2E), Infrastructure.AI.Tests 2006 (+3 machine-env failures verified pre-existing)
- [x] gitnexus impact LOW; detect_changes: 0 affected execution flows

🤖 Generated with [Claude Code](https://claude.com/claude-code)