### PR TITLE
fix: harden sandbox env isolation, attestation binding, cleanup

### DIFF
--- a/src/Content/Application/Application.AI.Common/Interfaces/Attestation/IAttestationService.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Attestation/IAttestationService.cs
@@ -58,10 +58,47 @@ public interface IAttestationService
     Task<ToolExecutionAttestation> SignFailureWithEgressAsync(string toolName, string input, string failureReason, string egressDigest, CancellationToken ct);
 
     /// <summary>
+    /// Signs a failed tool execution that nevertheless produced output (e.g. a process that
+    /// wrote to stdout before exiting non-zero). The content hash of the produced output is
+    /// bound into the signed payload alongside the failure reason, so the output returned to
+    /// the caller cannot silently diverge from the attested record. Legacy failure
+    /// attestations (no output hash) remain verifiable.
+    /// </summary>
+    /// <param name="toolName">Name of the tool that was executed.</param>
+    /// <param name="input">Serialized tool input.</param>
+    /// <param name="failureReason">Description of the failure.</param>
+    /// <param name="output">The output actually produced before the failure.</param>
+    /// <param name="egressDigest">Optional SHA-256 digest of the recorded egress decisions; null when no preflight ran.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>A signed failure attestation whose output hash covers the produced output.</returns>
+    Task<ToolExecutionAttestation> SignFailureWithOutputAsync(string toolName, string input, string failureReason, string output, string? egressDigest, CancellationToken ct);
+
+    /// <summary>
     /// Verifies the HMAC signature of an existing attestation.
     /// </summary>
+    /// <remarks>
+    /// This validates only the attestation's own fields. It does NOT prove that a separately
+    /// stored output still matches what was signed — use
+    /// <see cref="VerifyBoundAsync"/> when the actual output bytes are available.
+    /// </remarks>
     /// <param name="attestation">The attestation to verify.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>True if the attestation signature is valid; false otherwise.</returns>
     Task<bool> VerifyAsync(ToolExecutionAttestation attestation, CancellationToken ct);
+
+    /// <summary>
+    /// Verifies that an attestation is authentic AND that it was signed over exactly the
+    /// given output. Recomputes the content hash of <paramref name="actualOutput"/>, compares
+    /// it to the attested output hash, then verifies the HMAC signature. This binds the
+    /// attestation to the real output bytes: a result whose output was tampered after signing
+    /// fails this check even though the signature alone would still validate.
+    /// </summary>
+    /// <param name="attestation">The attestation to verify.</param>
+    /// <param name="actualOutput">The output the caller currently holds for this execution.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>
+    /// True only when the attestation recorded an output hash, that hash matches
+    /// <paramref name="actualOutput"/>, and the signature is valid.
+    /// </returns>
+    Task<bool> VerifyBoundAsync(ToolExecutionAttestation attestation, string actualOutput, CancellationToken ct);
 }

--- a/src/Content/Application/Application.AI.Common/Models/Sandbox/SandboxExecutionOptions.cs
+++ b/src/Content/Application/Application.AI.Common/Models/Sandbox/SandboxExecutionOptions.cs
@@ -35,6 +35,13 @@ public sealed class ContainerSandboxOptions
     public int StopGracePeriodSeconds { get; init; } = 10;
 
     /// <summary>
+    /// Maximum time in seconds allowed for container cleanup (force kill + remove) after an
+    /// execution ends. Cleanup runs on its own token so a cancelled or timed-out execution
+    /// still removes its container instead of leaking it running on the host.
+    /// </summary>
+    public int CleanupTimeoutSeconds { get; init; } = 30;
+
+    /// <summary>
     /// Allowed image registry prefixes. Only images starting with one of these
     /// prefixes can be used. Defaults to Microsoft Container Registry only.
     /// Add additional prefixes in appsettings to allow other registries.

--- a/src/Content/Domain/Domain.AI/Attestation/ToolExecutionAttestation.cs
+++ b/src/Content/Domain/Domain.AI/Attestation/ToolExecutionAttestation.cs
@@ -13,7 +13,11 @@ public sealed record ToolExecutionAttestation
     /// <summary>SHA-256 hash of the tool input parameters.</summary>
     public required string InputHash { get; init; }
 
-    /// <summary>SHA-256 hash of the tool output. Null if execution crashed before producing output.</summary>
+    /// <summary>
+    /// SHA-256 hash of the tool output actually produced. Null only when execution ended
+    /// without producing any output. Populated on failure attestations too when the tool
+    /// emitted output before failing, so the returned output stays bound to the signed record.
+    /// </summary>
     public string? OutputHash { get; init; }
 
     /// <summary>When the tool execution occurred.</summary>

--- a/src/Content/Domain/Domain.AI/Sandbox/ResourceLimits.cs
+++ b/src/Content/Domain/Domain.AI/Sandbox/ResourceLimits.cs
@@ -13,6 +13,13 @@ public sealed record ResourceLimits
     /// <summary>Maximum CPU time in seconds. Default: 30 seconds.</summary>
     public double CpuTimeSeconds { get; init; } = 30;
 
+    /// <summary>
+    /// Maximum CPU rate as a number of cores (e.g. 0.5 = half a core, 2.0 = two cores).
+    /// Enforced by the Docker sandbox via <c>NanoCPUs</c> so a runaway container cannot
+    /// starve the host. Default: 1 core (closed-by-default — callers opt into more).
+    /// </summary>
+    public double CpuCoreLimit { get; init; } = 1.0;
+
     /// <summary>Maximum number of child processes. Default: 5.</summary>
     public int MaxSubprocesses { get; init; } = 5;
 

--- a/src/Content/Domain/Domain.AI/Sandbox/SandboxExecutionRequest.cs
+++ b/src/Content/Domain/Domain.AI/Sandbox/SandboxExecutionRequest.cs
@@ -65,8 +65,12 @@ public sealed record SandboxExecutionRequest
     /// Explicit environment variables granted to the sandboxed process for this execution.
     /// The child process environment is cleared and rebuilt from the configured host
     /// allowlist (<c>SandboxConfig.ProcessEnvironmentAllowlist</c>) plus these grants —
-    /// nothing else from the host environment is visible to the tool. Grants are applied
-    /// last and may override allowlisted values. Null or empty means no extra variables.
+    /// nothing else from the host environment is visible to the tool via the environment.
+    /// Null or empty means no extra variables. Grant names colliding (case-insensitively)
+    /// with reserved variables — the pinned temp set (<c>TEMP</c>/<c>TMP</c>/<c>TMPDIR</c>)
+    /// and security-critical names (<c>PATH</c>, <c>COMSPEC</c>, <c>PATHEXT</c>,
+    /// <c>SystemRoot</c>) — cause the whole request to be REJECTED with a signed failure
+    /// attestation: grants can extend the environment, never override the sandbox's pins.
     /// </summary>
     public IReadOnlyDictionary<string, string>? EnvironmentVariables { get; init; }
 }

--- a/src/Content/Domain/Domain.AI/Sandbox/SandboxExecutionRequest.cs
+++ b/src/Content/Domain/Domain.AI/Sandbox/SandboxExecutionRequest.cs
@@ -60,4 +60,13 @@ public sealed record SandboxExecutionRequest
     /// </para>
     /// </remarks>
     public IReadOnlyList<Uri>? EgressPrecheckTargets { get; init; }
+
+    /// <summary>
+    /// Explicit environment variables granted to the sandboxed process for this execution.
+    /// The child process environment is cleared and rebuilt from the configured host
+    /// allowlist (<c>SandboxConfig.ProcessEnvironmentAllowlist</c>) plus these grants —
+    /// nothing else from the host environment is visible to the tool. Grants are applied
+    /// last and may override allowlisted values. Null or empty means no extra variables.
+    /// </summary>
+    public IReadOnlyDictionary<string, string>? EnvironmentVariables { get; init; }
 }

--- a/src/Content/Domain/Domain.Common/Config/AI/Sandbox/SandboxConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/Sandbox/SandboxConfig.cs
@@ -45,8 +45,8 @@ public sealed class SandboxConfig
     /// <summary>
     /// Names of host environment variables copied into sandboxed child processes.
     /// The child environment is cleared before launch (closed-by-default) and rebuilt from
-    /// this allowlist, so host secrets, tokens, and credentials never leak into tools.
-    /// The default set is the minimum a Windows/POSIX child needs to function:
+    /// this allowlist, so host secrets, tokens, and credentials are not inherited via the
+    /// environment. The default set is the minimum a Windows/POSIX child needs to function:
     /// <c>SystemRoot</c> (required by most Win32 APIs), <c>ComSpec</c> and <c>PATHEXT</c>
     /// (command resolution inside cmd), and <c>PATH</c> (executable lookup).
     /// <c>TEMP</c>/<c>TMP</c>/<c>TMPDIR</c> are never copied from the host — the executor
@@ -54,6 +54,15 @@ public sealed class SandboxConfig
     /// Additional per-execution values are granted explicitly via
     /// <c>SandboxExecutionRequest.EnvironmentVariables</c>, not by widening this list.
     /// </summary>
+    /// <remarks>
+    /// This is PARTIAL isolation — environment-level only. The child process runs as the
+    /// same OS user with the same token (no privilege drop), so secrets reachable through
+    /// the file system or OS APIs remain reachable. Copying <c>PATH</c> verbatim leaks the
+    /// host's directory layout and is a binary-planting surface when PATH contains
+    /// user-writable directories; remove <c>PATH</c> from this list for tools that do not
+    /// resolve executables. For a real security boundary use container isolation
+    /// (<c>SandboxIsolationLevel.Container</c>).
+    /// </remarks>
     public List<string> ProcessEnvironmentAllowlist { get; init; } =
     [
         "SystemRoot", "ComSpec", "PATHEXT", "PATH"

--- a/src/Content/Domain/Domain.Common/Config/AI/Sandbox/SandboxConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/Sandbox/SandboxConfig.cs
@@ -41,4 +41,21 @@ public sealed class SandboxConfig
     /// Overrides can restrict (never expand) compile-time <c>[ToolCapabilityAttribute]</c> declarations.
     /// </summary>
     public Dictionary<string, ToolOverrideConfig> ToolOverrides { get; init; } = new();
+
+    /// <summary>
+    /// Names of host environment variables copied into sandboxed child processes.
+    /// The child environment is cleared before launch (closed-by-default) and rebuilt from
+    /// this allowlist, so host secrets, tokens, and credentials never leak into tools.
+    /// The default set is the minimum a Windows/POSIX child needs to function:
+    /// <c>SystemRoot</c> (required by most Win32 APIs), <c>ComSpec</c> and <c>PATHEXT</c>
+    /// (command resolution inside cmd), and <c>PATH</c> (executable lookup).
+    /// <c>TEMP</c>/<c>TMP</c>/<c>TMPDIR</c> are never copied from the host — the executor
+    /// always points them at the disposable per-execution workspace directory.
+    /// Additional per-execution values are granted explicitly via
+    /// <c>SandboxExecutionRequest.EnvironmentVariables</c>, not by widening this list.
+    /// </summary>
+    public List<string> ProcessEnvironmentAllowlist { get; init; } =
+    [
+        "SystemRoot", "ComSpec", "PATHEXT", "PATH"
+    ];
 }

--- a/src/Content/Infrastructure/Infrastructure.AI/Attestation/HmacAttestationService.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Attestation/HmacAttestationService.cs
@@ -183,6 +183,54 @@ public sealed class HmacAttestationService : IAttestationService
     }
 
     /// <inheritdoc />
+    public Task<ToolExecutionAttestation> SignFailureWithOutputAsync(
+        string toolName,
+        string input,
+        string failureReason,
+        string output,
+        string? egressDigest,
+        CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(output);
+
+        var options = _optionsMonitor.CurrentValue;
+        var currentKey = GetKey(options, options.CurrentKeyVersion);
+        try
+        {
+            var timestamp = _timeProvider.GetUtcNow();
+            var inputHash = ComputeSha256Hex(input);
+            var outputHash = ComputeSha256Hex(output);
+            var failureHash = ComputeSha256Hex(failureReason);
+            // Failure payload with the produced output's content hash occupying the output
+            // slot (instead of the literal "null" used by output-less failures). The
+            // discriminator during verification is OutputHash being non-null on a failure
+            // attestation, so legacy failure attestations remain verifiable.
+            var basePayload = $"{toolName}|{inputHash}|{outputHash}|{failureHash}|{timestamp:O}";
+            var payload = egressDigest is null ? basePayload : $"{basePayload}|egress:{egressDigest}";
+            var signature = ComputeHmac(currentKey, payload);
+
+            var attestation = new ToolExecutionAttestation
+            {
+                ToolName = toolName,
+                InputHash = inputHash,
+                OutputHash = outputHash,
+                Timestamp = timestamp,
+                Signature = signature,
+                KeyVersion = options.CurrentKeyVersion,
+                IsFailureAttestation = true,
+                FailureReason = failureReason,
+                EgressDigest = egressDigest
+            };
+
+            return Task.FromResult(attestation);
+        }
+        finally
+        {
+            CryptographicOperations.ZeroMemory(currentKey);
+        }
+    }
+
+    /// <inheritdoc />
     public Task<bool> VerifyAsync(ToolExecutionAttestation attestation, CancellationToken ct)
     {
         var options = _optionsMonitor.CurrentValue;
@@ -222,19 +270,49 @@ public sealed class HmacAttestationService : IAttestationService
         }
     }
 
+    /// <inheritdoc />
+    public async Task<bool> VerifyBoundAsync(ToolExecutionAttestation attestation, string actualOutput, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(actualOutput);
+
+        if (attestation.OutputHash is null)
+        {
+            _logger.LogWarning(
+                "Output-bound verification rejected for tool {ToolName}: attestation recorded no output hash",
+                attestation.ToolName);
+            return false;
+        }
+
+        var actualHashBytes = Encoding.UTF8.GetBytes(ComputeSha256Hex(actualOutput));
+        var attestedHashBytes = Encoding.UTF8.GetBytes(attestation.OutputHash);
+
+        if (actualHashBytes.Length != attestedHashBytes.Length
+            || !CryptographicOperations.FixedTimeEquals(actualHashBytes, attestedHashBytes))
+        {
+            _logger.LogWarning(
+                "Output-bound verification failed for tool {ToolName}: actual output diverges from the attested output hash",
+                attestation.ToolName);
+            return false;
+        }
+
+        return await VerifyAsync(attestation, ct);
+    }
+
     private static string BuildVerificationPayload(ToolExecutionAttestation attestation)
     {
-        // Two payload shapes coexist: the PR-3a baseline (no egress digest) and
-        // the PR-3c extended shape (egress digest trailing). The discriminator
-        // is the presence of EgressDigest on the record. The baseline shape
-        // is preserved verbatim so PR-3a attestations remain verifiable after
-        // the PR-3c upgrade.
+        // Payload shapes coexist: the PR-3a baseline (no egress digest), the PR-3c
+        // extended shape (egress digest trailing), and the failure-with-output shape
+        // (produced output hash occupying the output slot). Discriminators are field
+        // presence on the record — EgressDigest for the egress suffix, OutputHash on a
+        // failure attestation for the output slot — so earlier attestations remain
+        // verifiable after each extension.
         if (attestation.IsFailureAttestation)
         {
             var failureHash = attestation.FailureReason is not null
                 ? ComputeSha256Hex(attestation.FailureReason)
                 : ComputeSha256Hex(string.Empty);
-            var baselineFailure = $"{attestation.ToolName}|{attestation.InputHash}|null|{failureHash}|{attestation.Timestamp:O}";
+            var outputSlot = attestation.OutputHash ?? "null";
+            var baselineFailure = $"{attestation.ToolName}|{attestation.InputHash}|{outputSlot}|{failureHash}|{attestation.Timestamp:O}";
             return attestation.EgressDigest is null
                 ? baselineFailure
                 : $"{baselineFailure}|egress:{attestation.EgressDigest}";

--- a/src/Content/Infrastructure/Infrastructure.AI/Planner/StepExecutors/ToolUseStepExecutor.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Planner/StepExecutors/ToolUseStepExecutor.cs
@@ -94,7 +94,14 @@ public sealed class ToolUseStepExecutor : IPlanStepExecutor
 
         if (sandboxResult.Attestation is not null)
         {
-            var verified = await _attestationService.VerifyAsync(sandboxResult.Attestation, ct);
+            // When the attestation carries an output hash, verify BOUND to the actual
+            // returned output — signature-only verification cannot detect a result whose
+            // Output was tampered after signing. Legacy/output-less attestations (timeouts,
+            // spawn refusals) have nothing to bind and fall back to signature verification.
+            var verified = sandboxResult.Attestation.OutputHash is not null
+                ? await _attestationService.VerifyBoundAsync(
+                    sandboxResult.Attestation, sandboxResult.Output ?? string.Empty, ct)
+                : await _attestationService.VerifyAsync(sandboxResult.Attestation, ct);
             if (!verified)
             {
                 sw.Stop();

--- a/src/Content/Infrastructure/Infrastructure.AI/Sandbox/DockerSandboxExecutor.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Sandbox/DockerSandboxExecutor.cs
@@ -47,6 +47,12 @@ public sealed class DockerSandboxExecutor : ISandboxExecutor
         if (!_sandboxConfig.CurrentValue.Enabled)
             throw new InvalidOperationException("Sandbox execution is disabled by configuration (Sandbox:Enabled=false).");
 
+        // NanoCPUs = 0 means "unlimited" to Docker, so a non-positive (or NaN) core limit
+        // must be rejected as invalid input rather than silently granting the container the
+        // whole host. Validated at the boundary, before any container work happens.
+        if (!(request.Limits.CpuCoreLimit > 0))
+            return await RejectInvalidCpuLimitAsync(request, ct);
+
         var egress = await RunEgressPreflightAsync(request, ct);
         if (egress.Blocked is { } block)
             return block;
@@ -112,6 +118,33 @@ public sealed class DockerSandboxExecutor : ISandboxExecutor
             await RemoveContainerSafeAsync(containerId);
             CleanupWorkspace(workspaceDir);
         }
+    }
+
+    /// <summary>
+    /// Rejects a request whose <c>CpuCoreLimit</c> is not a positive core count and leaves a
+    /// signed failure attestation for the audit trail. Mapping such values to Docker would
+    /// produce <c>NanoCPUs = 0</c>, which Docker interprets as unlimited CPU.
+    /// </summary>
+    private async Task<SandboxExecutionResult> RejectInvalidCpuLimitAsync(
+        SandboxExecutionRequest request, CancellationToken ct)
+    {
+        _logger.LogWarning(
+            "Docker sandbox refused request for tool {ToolName}: CpuCoreLimit {CpuCoreLimit} is not a positive core count",
+            request.ToolName, request.Limits.CpuCoreLimit);
+
+        var errorMessage =
+            $"Invalid resource limits: CpuCoreLimit must be a positive number of cores (was {request.Limits.CpuCoreLimit}). " +
+            "A non-positive value would map to NanoCPUs=0, which Docker treats as unlimited.";
+
+        var attestation = await _attestationService.SignFailureAsync(
+            request.ToolName, request.Input, errorMessage, ct);
+
+        return new SandboxExecutionResult
+        {
+            Success = false,
+            ErrorMessage = errorMessage,
+            Attestation = attestation
+        };
     }
 
     private async Task<bool> IsDockerAvailableAsync(CancellationToken ct)

--- a/src/Content/Infrastructure/Infrastructure.AI/Sandbox/DockerSandboxExecutor.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Sandbox/DockerSandboxExecutor.cs
@@ -109,7 +109,7 @@ public sealed class DockerSandboxExecutor : ISandboxExecutor
         }
         finally
         {
-            await RemoveContainerSafeAsync(containerId, ct);
+            await RemoveContainerSafeAsync(containerId);
             CleanupWorkspace(workspaceDir);
         }
     }
@@ -182,6 +182,10 @@ public sealed class DockerSandboxExecutor : ISandboxExecutor
             HostConfig = new HostConfig
             {
                 Memory = request.Limits.MemoryLimitBytes,
+                // CPU cap alongside the memory cap: an unlimited container can starve the
+                // host. NanoCPUs is the core count scaled by 1e9 (Docker's CpuQuota/CpuPeriod
+                // shorthand); 1.0 core by default, callers opt into more via ResourceLimits.
+                NanoCPUs = (long)(request.Limits.CpuCoreLimit * 1_000_000_000),
                 NetworkMode = hasNetworkAccess ? "bridge" : "none",
                 ReadonlyRootfs = true,
                 AutoRemove = false,
@@ -306,9 +310,15 @@ public sealed class DockerSandboxExecutor : ISandboxExecutor
     {
         _logger.LogWarning("Container exited with code {ExitCode}", exitCode);
 
-        var attestation = await SignFailureAsync(
-            request.ToolName, request.Input,
-            $"Container exited with code {exitCode}: {logs}", egressDigest, ct);
+        // When the crashed container produced workspace output, that output is returned to
+        // the caller and must therefore be bound into the signed attestation. Only when no
+        // output exists does the legacy (output-less) failure shape apply.
+        var failureReason = $"Container exited with code {exitCode}: {logs}";
+        var attestation = output is not null
+            ? await _attestationService.SignFailureWithOutputAsync(
+                request.ToolName, request.Input, failureReason, output, egressDigest, ct)
+            : await SignFailureAsync(
+                request.ToolName, request.Input, failureReason, egressDigest, ct);
 
         return new SandboxExecutionResult
         {
@@ -387,19 +397,30 @@ public sealed class DockerSandboxExecutor : ISandboxExecutor
             : _attestationService.SignWithEgressAsync(toolName, input, output, egressDigest, ct);
     }
 
-    private async Task RemoveContainerSafeAsync(string? containerId, CancellationToken ct)
+    /// <summary>
+    /// Force-kills and removes the container on a dedicated cleanup token. The caller's
+    /// token is deliberately NOT used: when an execution is cancelled or times out, that
+    /// token is already cancelled, and using it here would abort the removal call and leak
+    /// the container running unbounded on the host. Cleanup gets its own bounded window
+    /// (<c>ContainerSandboxOptions.CleanupTimeoutSeconds</c>) instead.
+    /// </summary>
+    private async Task RemoveContainerSafeAsync(string? containerId)
     {
         if (containerId is null)
             return;
 
+        using var cleanupCts = new CancellationTokenSource(
+            TimeSpan.FromSeconds(_options.CurrentValue.Container.CleanupTimeoutSeconds));
+
         try
         {
             await _dockerClient.Containers.RemoveContainerAsync(containerId,
-                new ContainerRemoveParameters { Force = true }, ct);
+                new ContainerRemoveParameters { Force = true }, cleanupCts.Token);
         }
         catch (Exception ex)
         {
-            _logger.LogDebug(ex, "Container removal failed (may already be removed)");
+            _logger.LogWarning(ex,
+                "Container {ContainerId} removal failed — it may still be running on the host", containerId);
         }
     }
 

--- a/src/Content/Infrastructure/Infrastructure.AI/Sandbox/ProcessSandboxExecutor.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Sandbox/ProcessSandboxExecutor.cs
@@ -193,7 +193,7 @@ public sealed class ProcessSandboxExecutor : ISandboxExecutor
             : _attestationService.SignWithEgressAsync(toolName, input, output, egressDigest, ct);
     }
 
-    private static Process StartProcess(SandboxExecutionRequest request, string workspaceDir)
+    private Process StartProcess(SandboxExecutionRequest request, string workspaceDir)
     {
         var command = request.Command ?? request.ToolName;
 
@@ -219,6 +219,8 @@ public sealed class ProcessSandboxExecutor : ISandboxExecutor
             CreateNoWindow = true
         };
 
+        ConfigureIsolatedEnvironment(psi, request, workspaceDir);
+
         if (request.ArgumentList is { Count: > 0 })
         {
             foreach (var arg in request.ArgumentList)
@@ -228,6 +230,38 @@ public sealed class ProcessSandboxExecutor : ISandboxExecutor
         var process = new Process { StartInfo = psi };
         process.Start();
         return process;
+    }
+
+    /// <summary>
+    /// Rebuilds the child process environment from scratch. The host environment (secrets,
+    /// tokens, credential paths) is never inherited: only variables named in the configured
+    /// allowlist are copied from the host, temp variables are pinned to the disposable
+    /// workspace, and explicit per-request grants are applied last.
+    /// </summary>
+    private void ConfigureIsolatedEnvironment(
+        ProcessStartInfo psi, SandboxExecutionRequest request, string workspaceDir)
+    {
+        // Closed-by-default: drop everything inherited from the host process.
+        psi.EnvironmentVariables.Clear();
+
+        foreach (var name in _sandboxConfig.CurrentValue.ProcessEnvironmentAllowlist)
+        {
+            var value = Environment.GetEnvironmentVariable(name);
+            if (value is not null)
+                psi.EnvironmentVariables[name] = value;
+        }
+
+        // Temp always points inside the per-execution workspace (deleted after the run),
+        // never at the host temp directory — regardless of the allowlist contents.
+        psi.EnvironmentVariables["TEMP"] = workspaceDir;
+        psi.EnvironmentVariables["TMP"] = workspaceDir;
+        psi.EnvironmentVariables["TMPDIR"] = workspaceDir;
+
+        if (request.EnvironmentVariables is not null)
+        {
+            foreach (var (name, value) in request.EnvironmentVariables)
+                psi.EnvironmentVariables[name] = value;
+        }
     }
 
     private void ApplyResourceLimits(Process process, ResourceLimits limits)
@@ -293,9 +327,12 @@ public sealed class ProcessSandboxExecutor : ISandboxExecutor
     {
         _logger.LogWarning("Process exited with code {ExitCode}: {Stderr}", exitCode, stderr);
 
-        var attestation = await SignFailureAsync(
+        // The crash result carries the stdout produced before the failure, so that output
+        // must be bound into the signed attestation — otherwise a stored result's Output
+        // could diverge from the attested record without detection.
+        var attestation = await _attestationService.SignFailureWithOutputAsync(
             request.ToolName, request.Input,
-            $"Process exited with code {exitCode}: {stderr}", egressDigest, ct);
+            $"Process exited with code {exitCode}: {stderr}", stdout, egressDigest, ct);
 
         return new SandboxExecutionResult
         {

--- a/src/Content/Infrastructure/Infrastructure.AI/Sandbox/ProcessSandboxExecutor.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Sandbox/ProcessSandboxExecutor.cs
@@ -64,11 +64,26 @@ public sealed class ProcessSandboxExecutor : ISandboxExecutor
             File.SetUnixFileMode(path, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
     }
 
+    /// <summary>
+    /// Environment variable names that per-request grants may never override, compared
+    /// case-insensitively (Windows environment lookups ignore case). Covers the pinned temp
+    /// set (always redirected into the workspace) and the security-critical variables the
+    /// allowlist controls — a grant of <c>temp</c>, <c>Path</c>, or <c>COMSPEC</c> would
+    /// otherwise un-pin or re-smuggle them.
+    /// </summary>
+    private static readonly string[] ReservedEnvironmentVariableNames =
+    [
+        "TEMP", "TMP", "TMPDIR", "PATH", "COMSPEC", "PATHEXT", "SYSTEMROOT"
+    ];
+
     public async Task<SandboxExecutionResult> ExecuteAsync(
         SandboxExecutionRequest request, CancellationToken ct)
     {
         if (!_sandboxConfig.CurrentValue.Enabled)
             throw new InvalidOperationException("Sandbox execution is disabled by configuration (Sandbox:Enabled=false).");
+
+        if (FindReservedEnvironmentGrant(request) is { } reservedGrant)
+            return await RejectReservedGrantAsync(request, reservedGrant, ct);
 
         var egress = await RunEgressPreflightAsync(request, ct);
         if (egress.Blocked is { } block)
@@ -233,11 +248,63 @@ public sealed class ProcessSandboxExecutor : ISandboxExecutor
     }
 
     /// <summary>
-    /// Rebuilds the child process environment from scratch. The host environment (secrets,
-    /// tokens, credential paths) is never inherited: only variables named in the configured
-    /// allowlist are copied from the host, temp variables are pinned to the disposable
-    /// workspace, and explicit per-request grants are applied last.
+    /// Returns the first per-request environment grant whose name collides
+    /// (case-insensitively) with a reserved variable, or null when all grants are benign.
     /// </summary>
+    private static string? FindReservedEnvironmentGrant(SandboxExecutionRequest request)
+    {
+        if (request.EnvironmentVariables is null)
+            return null;
+
+        return request.EnvironmentVariables.Keys.FirstOrDefault(
+            name => ReservedEnvironmentVariableNames.Contains(name, StringComparer.OrdinalIgnoreCase));
+    }
+
+    /// <summary>
+    /// Rejects a request whose environment grants collide with reserved variables — before
+    /// any process is spawned — and leaves a signed failure attestation for the audit trail.
+    /// Explicit rejection (rather than silently skipping the grant) makes the policy
+    /// violation visible to the caller and the audit log.
+    /// </summary>
+    private async Task<SandboxExecutionResult> RejectReservedGrantAsync(
+        SandboxExecutionRequest request, string reservedGrant, CancellationToken ct)
+    {
+        _logger.LogWarning(
+            "Sandbox refused to spawn process for tool {ToolName}: environment grant '{GrantName}' collides with a reserved variable",
+            request.ToolName, reservedGrant);
+
+        var errorMessage =
+            $"Environment grant rejected: '{reservedGrant}' collides with a reserved variable " +
+            "(pinned temp or security-critical) and cannot be overridden by per-request grants.";
+
+        var attestation = await _attestationService.SignFailureAsync(
+            request.ToolName, request.Input, errorMessage, ct);
+
+        return new SandboxExecutionResult
+        {
+            Success = false,
+            ErrorMessage = errorMessage,
+            Attestation = attestation
+        };
+    }
+
+    /// <summary>
+    /// Rebuilds the child process environment from scratch: only variables named in the
+    /// configured allowlist are copied from the host, temp variables are pinned to the
+    /// disposable workspace, and pre-validated per-request grants are applied last (grants
+    /// colliding with reserved names were already rejected in
+    /// <see cref="ExecuteAsync"/>, so they can never un-pin these values).
+    /// </summary>
+    /// <remarks>
+    /// This is environment-level isolation only, and it is deliberately documented as
+    /// partial: the child still runs as the same OS user with the same token (no privilege
+    /// drop), so it can read anything the host user can read through the file system. PATH
+    /// is copied verbatim by default (cmd/child executable resolution needs it), which leaks
+    /// host directory layout and carries binary-planting risk if PATH contains
+    /// user-writable directories — operators can remove PATH from
+    /// <c>SandboxConfig.ProcessEnvironmentAllowlist</c> when tools do not need it. Use
+    /// container isolation for a real security boundary.
+    /// </remarks>
     private void ConfigureIsolatedEnvironment(
         ProcessStartInfo psi, SandboxExecutionRequest request, string workspaceDir)
     {

--- a/src/Content/Tests/Infrastructure.AI.Tests/Attestation/HmacAttestationOutputBindingTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Attestation/HmacAttestationOutputBindingTests.cs
@@ -1,0 +1,144 @@
+using System.Security.Cryptography;
+using System.Text;
+using Domain.AI.Attestation;
+using FluentAssertions;
+using Infrastructure.AI.Attestation;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Time.Testing;
+using Moq;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Attestation;
+
+/// <summary>
+/// Security regression coverage for sandbox audit finding A6-2: attestations were not bound
+/// to the actual produced output. <c>VerifyAsync</c> validates only the attestation's own
+/// fields, so a <c>SandboxExecutionResult.Output</c> tampered after signing still "verified".
+/// Crash results carried output that the failure attestation never covered at all.
+/// These tests pin the output-bound verification path (<c>VerifyBoundAsync</c>) and the
+/// failure-with-output signing shape (<c>SignFailureWithOutputAsync</c>).
+/// </summary>
+public sealed class HmacAttestationOutputBindingTests
+{
+    private static readonly string TestKeyBase64 = Convert.ToBase64String(RandomNumberGenerator.GetBytes(32));
+    private static readonly DateTimeOffset FixedTime = new(2026, 1, 15, 12, 0, 0, TimeSpan.Zero);
+
+    private readonly FakeTimeProvider _timeProvider = new(FixedTime);
+
+    private HmacAttestationService CreateService()
+    {
+        var options = new AttestationKeyOptions
+        {
+            CurrentKeyVersion = "v1",
+            HmacKeys = [new HmacKeyEntry { Version = "v1", Key = TestKeyBase64 }]
+        };
+
+        var monitor = Mock.Of<IOptionsMonitor<AttestationKeyOptions>>(
+            m => m.CurrentValue == options);
+
+        return new HmacAttestationService(
+            monitor,
+            _timeProvider,
+            NullLogger<HmacAttestationService>.Instance);
+    }
+
+    [Fact]
+    public async Task VerifyBound_ActualOutputMatches_ReturnsTrue()
+    {
+        var service = CreateService();
+        var attestation = await service.SignAsync("calculator", "{\"a\":1}", "{\"result\":2}", CancellationToken.None);
+
+        var result = await service.VerifyBoundAsync(attestation, "{\"result\":2}", CancellationToken.None);
+
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task VerifyBound_ActualOutputDiverges_ReturnsFalse()
+    {
+        var service = CreateService();
+        var attestation = await service.SignAsync("calculator", "{\"a\":1}", "{\"result\":2}", CancellationToken.None);
+
+        // The gap this closes: signature-only verification cannot see the real output,
+        // so a tampered stored output still passes VerifyAsync.
+        (await service.VerifyAsync(attestation, CancellationToken.None)).Should().BeTrue();
+
+        var bound = await service.VerifyBoundAsync(attestation, "{\"result\":999}", CancellationToken.None);
+
+        bound.Should().BeFalse(
+            "an attestation must only verify against the exact output bytes that were signed");
+    }
+
+    [Fact]
+    public async Task VerifyBound_NoOutputHashOnAttestation_ReturnsFalse()
+    {
+        var service = CreateService();
+        var attestation = await service.SignFailureAsync("calculator", "{\"a\":1}", "boom", CancellationToken.None);
+
+        var result = await service.VerifyBoundAsync(attestation, "any-output", CancellationToken.None);
+
+        result.Should().BeFalse("an attestation that recorded no output cannot vouch for any output");
+    }
+
+    [Fact]
+    public async Task SignFailureWithOutput_BindsContentHashOfProducedOutput()
+    {
+        var service = CreateService();
+
+        var attestation = await service.SignFailureWithOutputAsync(
+            "compiler", "{\"src\":\"x\"}", "exit code 1", "partial diagnostics", egressDigest: null, CancellationToken.None);
+
+        attestation.IsFailureAttestation.Should().BeTrue();
+        attestation.FailureReason.Should().Be("exit code 1");
+        attestation.OutputHash.Should().Be(Sha256Hex("partial diagnostics"));
+        (await service.VerifyAsync(attestation, CancellationToken.None)).Should().BeTrue();
+        (await service.VerifyBoundAsync(attestation, "partial diagnostics", CancellationToken.None)).Should().BeTrue();
+        (await service.VerifyBoundAsync(attestation, "tampered diagnostics", CancellationToken.None)).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task SignFailureWithOutput_TamperedOutputHash_FailsSignatureVerification()
+    {
+        var service = CreateService();
+        var attestation = await service.SignFailureWithOutputAsync(
+            "compiler", "{\"src\":\"x\"}", "exit code 1", "real output", egressDigest: null, CancellationToken.None);
+
+        var tampered = attestation with { OutputHash = Sha256Hex("forged output") };
+
+        var result = await service.VerifyAsync(tampered, CancellationToken.None);
+
+        result.Should().BeFalse(
+            "the output hash on a failure attestation must be covered by the HMAC signature, not a free-floating claim");
+    }
+
+    [Fact]
+    public async Task SignFailureWithOutput_WithEgressDigest_CarriesDigestAndVerifies()
+    {
+        var service = CreateService();
+
+        var attestation = await service.SignFailureWithOutputAsync(
+            "fetcher", "{}", "exit code 7", "stdout before crash", egressDigest: "abc123", CancellationToken.None);
+
+        attestation.EgressDigest.Should().Be("abc123");
+        (await service.VerifyAsync(attestation, CancellationToken.None)).Should().BeTrue();
+
+        var tampered = attestation with { EgressDigest = "def456" };
+        (await service.VerifyAsync(tampered, CancellationToken.None)).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task LegacyFailureAttestation_WithoutOutputHash_StillVerifies()
+    {
+        var service = CreateService();
+        var legacy = await service.SignFailureAsync("calculator", "{\"a\":1}", "timed out", CancellationToken.None);
+
+        legacy.OutputHash.Should().BeNull();
+        var result = await service.VerifyAsync(legacy, CancellationToken.None);
+
+        result.Should().BeTrue("pre-existing failure attestations must remain verifiable after the payload extension");
+    }
+
+    private static string Sha256Hex(string value)
+        => Convert.ToHexStringLower(SHA256.HashData(Encoding.UTF8.GetBytes(value)));
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Planner/StepExecutors/ToolUseStepExecutorAttestationBindingTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Planner/StepExecutors/ToolUseStepExecutorAttestationBindingTests.cs
@@ -1,0 +1,154 @@
+using System.Security.Cryptography;
+using Application.AI.Common.Interfaces.Governance;
+using Application.AI.Common.Interfaces.Planner;
+using Application.AI.Common.Interfaces.Sandbox;
+using Domain.AI.Governance;
+using Domain.AI.Planner;
+using Domain.AI.Sandbox;
+using Infrastructure.AI.Attestation;
+using Infrastructure.AI.Planner.StepExecutors;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Planner.StepExecutors;
+
+/// <summary>
+/// Security regression coverage for the live attestation verification path (audit A6-2
+/// review follow-up): <see cref="ToolUseStepExecutor"/> called signature-only
+/// <c>VerifyAsync</c>, which never re-hashes the returned output — so a
+/// <c>SandboxExecutionResult.Output</c> tampered after signing still verified. These tests
+/// use the REAL <see cref="HmacAttestationService"/> so the tamper scenario is genuine:
+/// the signature is valid, only the output diverges.
+/// </summary>
+public sealed class ToolUseStepExecutorAttestationBindingTests
+{
+    private readonly Mock<ICapabilityEnforcer> _capabilityEnforcer = new();
+    private readonly Mock<ICompositeResponseSanitizer> _responseSanitizer = new();
+    private readonly Mock<IPlanProgressNotifier> _notifier = new();
+    private readonly Mock<ISandboxExecutor> _sandboxExecutor = new();
+    private readonly HmacAttestationService _attestationService;
+    private readonly ToolUseStepExecutor _sut;
+
+    public ToolUseStepExecutorAttestationBindingTests()
+    {
+        _notifier.Setup(n => n.NotifySandboxStatusAsync(
+                It.IsAny<PlanId>(), It.IsAny<PlanStepId>(), It.IsAny<string>(), It.IsAny<SandboxIsolationLevel>(),
+                It.IsAny<ResourceUsage>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _capabilityEnforcer.Setup(c => c.ResolveProfileAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ToolPermissionProfile { RequiredCapabilities = ToolCapability.FileRead });
+
+        _responseSanitizer.Setup(s => s.Sanitize(It.IsAny<string>(), It.IsAny<string?>()))
+            .Returns<string, string?>((content, _) => SanitizationResult.Clean(content));
+
+        var keyOptions = new AttestationKeyOptions
+        {
+            CurrentKeyVersion = "v1",
+            HmacKeys =
+            [
+                new HmacKeyEntry
+                {
+                    Version = "v1",
+                    Key = Convert.ToBase64String(RandomNumberGenerator.GetBytes(32))
+                }
+            ]
+        };
+        _attestationService = new HmacAttestationService(
+            Mock.Of<IOptionsMonitor<AttestationKeyOptions>>(m => m.CurrentValue == keyOptions),
+            TimeProvider.System,
+            NullLogger<HmacAttestationService>.Instance);
+
+        var services = new ServiceCollection();
+        services.AddKeyedSingleton<ISandboxExecutor>(SandboxIsolationLevel.Process, _sandboxExecutor.Object);
+        services.AddKeyedSingleton<ISandboxExecutor>(SandboxIsolationLevel.Container, _sandboxExecutor.Object);
+
+        _sut = new ToolUseStepExecutor(
+            _capabilityEnforcer.Object,
+            services.BuildServiceProvider(),
+            _attestationService,
+            _responseSanitizer.Object,
+            _notifier.Object,
+            new PlanExecutionContext { CurrentPlanId = new PlanId(Guid.NewGuid()) },
+            NullLogger<ToolUseStepExecutor>.Instance);
+    }
+
+    private static PlanStep CreateStep() => new()
+    {
+        Id = new PlanStepId(Guid.NewGuid()),
+        Name = "tool-step",
+        Type = StepType.ToolUse,
+        Configuration = new ToolUseConfig { ToolName = "file_system" },
+        RetryPolicy = new RetryPolicy()
+    };
+
+    [Fact]
+    public async Task ExecuteAsync_OutputTamperedAfterSigning_ReturnsFailed()
+    {
+        // A valid signature over "genuine-output" — then the result's Output diverges.
+        var attestation = await _attestationService.SignAsync(
+            "file_system", "{}", "genuine-output", CancellationToken.None);
+
+        _sandboxExecutor.Setup(s => s.ExecuteAsync(It.IsAny<SandboxExecutionRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SandboxExecutionResult
+            {
+                Success = true,
+                Output = "tampered-output",
+                Attestation = attestation,
+                ResourceUsage = new ResourceUsage()
+            });
+
+        var result = await _sut.ExecuteAsync(CreateStep(), new Dictionary<PlanStepId, string>(), CancellationToken.None);
+
+        Assert.Equal(StepExecutionStatus.Failed, result.Status);
+        Assert.Contains("Attestation verification failed", result.ErrorMessage);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_OutputMatchesSignedBytes_ReturnsCompleted()
+    {
+        var attestation = await _attestationService.SignAsync(
+            "file_system", "{}", "genuine-output", CancellationToken.None);
+
+        _sandboxExecutor.Setup(s => s.ExecuteAsync(It.IsAny<SandboxExecutionRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SandboxExecutionResult
+            {
+                Success = true,
+                Output = "genuine-output",
+                Attestation = attestation,
+                ResourceUsage = new ResourceUsage()
+            });
+
+        var result = await _sut.ExecuteAsync(CreateStep(), new Dictionary<PlanStepId, string>(), CancellationToken.None);
+
+        Assert.Equal(StepExecutionStatus.Completed, result.Status);
+        Assert.Equal("genuine-output", result.Output);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_LegacyOutputlessFailureAttestation_FallsBackToSignatureVerification()
+    {
+        // Output-less failure attestations (timeout, spawn refusal) have no OutputHash to
+        // bind against — signature-only verification still applies, and the step reports
+        // the sandbox failure, not an attestation failure.
+        var attestation = await _attestationService.SignFailureAsync(
+            "file_system", "{}", "Process timed out", CancellationToken.None);
+
+        _sandboxExecutor.Setup(s => s.ExecuteAsync(It.IsAny<SandboxExecutionRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SandboxExecutionResult
+            {
+                Success = false,
+                ErrorMessage = "Process timed out",
+                Attestation = attestation,
+                ResourceUsage = new ResourceUsage()
+            });
+
+        var result = await _sut.ExecuteAsync(CreateStep(), new Dictionary<PlanStepId, string>(), CancellationToken.None);
+
+        Assert.Equal(StepExecutionStatus.Failed, result.Status);
+        Assert.Equal("Process timed out", result.ErrorMessage);
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Sandbox/DockerSandboxExecutorHardeningTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Sandbox/DockerSandboxExecutorHardeningTests.cs
@@ -157,6 +157,29 @@ public class DockerSandboxExecutorHardeningTests
             "closed-by-default: a request that does not opt into more CPU gets one core");
     }
 
+    [Theory]
+    [InlineData(0.0)]
+    [InlineData(-1.0)]
+    [InlineData(double.NaN)]
+    public async Task ExecuteAsync_NonPositiveCpuLimit_RejectsRequestInsteadOfRunningUnlimited(double cpuCoreLimit)
+    {
+        // NanoCPUs = 0 means "unlimited" to Docker, so a zero/negative CpuCoreLimit must be
+        // rejected as invalid rather than silently granting the container the whole host.
+        var request = CreateRequest() with
+        {
+            Limits = new ResourceLimits { CpuCoreLimit = cpuCoreLimit }
+        };
+
+        var result = await _sut.ExecuteAsync(request, CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("CpuCoreLimit");
+        result.Attestation.Should().NotBeNull("the rejection must leave a signed audit record");
+        result.Attestation!.IsFailureAttestation.Should().BeTrue();
+        _containers.Verify(x => x.CreateContainerAsync(
+            It.IsAny<CreateContainerParameters>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
     private static SandboxExecutionRequest CreateRequest() => new()
     {
         ToolName = "test_tool",

--- a/src/Content/Tests/Infrastructure.AI.Tests/Sandbox/DockerSandboxExecutorHardeningTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Sandbox/DockerSandboxExecutorHardeningTests.cs
@@ -1,0 +1,185 @@
+using Application.AI.Common.Interfaces.Attestation;
+using Application.AI.Common.Models.Sandbox;
+using Docker.DotNet;
+using Docker.DotNet.Models;
+using Domain.AI.Attestation;
+using Domain.AI.Sandbox;
+using Domain.Common.Config.AI.Sandbox;
+using FluentAssertions;
+using Infrastructure.AI.Sandbox;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Sandbox;
+
+/// <summary>
+/// Security regression coverage for sandbox audit finding A6-3: <see cref="DockerSandboxExecutor"/>
+/// leaked running containers when the caller's token was cancelled (cleanup used the already
+/// cancelled token) and applied no CPU limit to sandboxed containers. These tests assert
+/// cleanup survives cancellation and CPU limits reach the Docker host config.
+/// </summary>
+public class DockerSandboxExecutorHardeningTests
+{
+    private readonly Mock<IDockerClient> _dockerClient = new();
+    private readonly Mock<IContainerOperations> _containers = new();
+    private readonly Mock<IImageOperations> _images = new();
+    private readonly Mock<ISystemOperations> _system = new();
+    private readonly Mock<IAttestationService> _attestation = new();
+    private readonly Mock<IOptionsMonitor<SandboxExecutionOptions>> _options = new();
+    private readonly DockerSandboxExecutor _sut;
+
+    public DockerSandboxExecutorHardeningTests()
+    {
+        _dockerClient.Setup(x => x.Containers).Returns(_containers.Object);
+        _dockerClient.Setup(x => x.System).Returns(_system.Object);
+        _dockerClient.Setup(x => x.Images).Returns(_images.Object);
+
+        _system.Setup(x => x.PingAsync(It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _images.Setup(x => x.InspectImageAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ImageInspectResponse());
+
+        _containers.Setup(x => x.CreateContainerAsync(
+                It.IsAny<CreateContainerParameters>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new CreateContainerResponse { ID = "test-container-id" });
+
+        _containers.Setup(x => x.StartContainerAsync(
+                It.IsAny<string>(), It.IsAny<ContainerStartParameters>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        _containers.Setup(x => x.WaitContainerAsync(
+                It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ContainerWaitResponse { StatusCode = 0 });
+
+        _containers.Setup(x => x.GetContainerLogsAsync(
+                It.IsAny<string>(), It.IsAny<bool>(),
+                It.IsAny<ContainerLogsParameters>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new MultiplexedStream(Stream.Null, default));
+
+        _containers.Setup(x => x.RemoveContainerAsync(
+                It.IsAny<string>(), It.IsAny<ContainerRemoveParameters>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _attestation
+            .Setup(x => x.SignAsync(It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string tool, string _, string __, CancellationToken ___) =>
+                CreateAttestation(tool, false));
+
+        _attestation
+            .Setup(x => x.SignFailureAsync(It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string tool, string _, string reason, CancellationToken ___) =>
+                CreateAttestation(tool, true, reason));
+
+        _options.Setup(x => x.CurrentValue).Returns(new SandboxExecutionOptions());
+
+        var sandboxConfig = new Mock<IOptionsMonitor<SandboxConfig>>();
+        sandboxConfig.Setup(x => x.CurrentValue).Returns(new SandboxConfig { Enabled = true });
+
+        _sut = new DockerSandboxExecutor(
+            _dockerClient.Object,
+            _attestation.Object,
+            _options.Object,
+            sandboxConfig.Object,
+            Mock.Of<ILogger<DockerSandboxExecutor>>());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ExternalCancellation_StillRemovesContainer()
+    {
+        using var externalCts = new CancellationTokenSource();
+
+        _containers.Setup(x => x.WaitContainerAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns<string, CancellationToken>(async (_, ct) =>
+            {
+                externalCts.CancelAfter(TimeSpan.FromMilliseconds(50));
+                await Task.Delay(Timeout.InfiniteTimeSpan, ct);
+                return new ContainerWaitResponse { StatusCode = 0 };
+            });
+
+        // Mimic the real Docker client: a call made with an already cancelled token
+        // throws immediately and never reaches the daemon.
+        var removed = false;
+        _containers.Setup(x => x.RemoveContainerAsync(
+                It.IsAny<string>(), It.IsAny<ContainerRemoveParameters>(), It.IsAny<CancellationToken>()))
+            .Returns<string, ContainerRemoveParameters, CancellationToken>((_, _, ct) =>
+            {
+                ct.ThrowIfCancellationRequested();
+                removed = true;
+                return Task.CompletedTask;
+            });
+
+        var act = () => _sut.ExecuteAsync(CreateRequest(), externalCts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+        removed.Should().BeTrue(
+            "a cancelled execution must still force-remove its container — otherwise the container keeps running unbounded on the host");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_CpuLimit_PassedToHostConfigAsNanoCpus()
+    {
+        CreateContainerParameters? captured = null;
+        _containers.Setup(x => x.CreateContainerAsync(
+                It.IsAny<CreateContainerParameters>(), It.IsAny<CancellationToken>()))
+            .Callback<CreateContainerParameters, CancellationToken>((p, _) => captured = p)
+            .ReturnsAsync(new CreateContainerResponse { ID = "test-id" });
+
+        var request = CreateRequest() with
+        {
+            Limits = new ResourceLimits { CpuCoreLimit = 2.0 }
+        };
+
+        await _sut.ExecuteAsync(request, CancellationToken.None);
+
+        captured.Should().NotBeNull();
+        captured!.HostConfig.NanoCPUs.Should().Be(2_000_000_000L,
+            "the sandbox must cap container CPU alongside memory — an unlimited container can starve the host");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_DefaultCpuLimit_OneCore()
+    {
+        CreateContainerParameters? captured = null;
+        _containers.Setup(x => x.CreateContainerAsync(
+                It.IsAny<CreateContainerParameters>(), It.IsAny<CancellationToken>()))
+            .Callback<CreateContainerParameters, CancellationToken>((p, _) => captured = p)
+            .ReturnsAsync(new CreateContainerResponse { ID = "test-id" });
+
+        await _sut.ExecuteAsync(CreateRequest(), CancellationToken.None);
+
+        captured.Should().NotBeNull();
+        captured!.HostConfig.NanoCPUs.Should().Be(1_000_000_000L,
+            "closed-by-default: a request that does not opt into more CPU gets one core");
+    }
+
+    private static SandboxExecutionRequest CreateRequest() => new()
+    {
+        ToolName = "test_tool",
+        Input = "{\"action\":\"test\"}",
+        Limits = new ResourceLimits(),
+        PermissionProfile = new ToolPermissionProfile
+        {
+            RequiredCapabilities = ToolCapability.None,
+            MinimumIsolation = SandboxIsolationLevel.Process
+        },
+        Timeout = TimeSpan.FromSeconds(30)
+    };
+
+    private static ToolExecutionAttestation CreateAttestation(
+        string toolName, bool isFailure, string? reason = null) => new()
+    {
+        ToolName = toolName,
+        InputHash = "test-hash",
+        OutputHash = isFailure ? null : "test-output-hash",
+        Timestamp = DateTimeOffset.UtcNow,
+        Signature = "test-sig",
+        KeyVersion = "v1",
+        IsFailureAttestation = isFailure,
+        FailureReason = reason
+    };
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Sandbox/ProcessSandboxEnvironmentIsolationTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Sandbox/ProcessSandboxEnvironmentIsolationTests.cs
@@ -38,6 +38,13 @@ public class ProcessSandboxEnvironmentIsolationTests
             .ReturnsAsync((string tool, string _, string __, CancellationToken ___) =>
                 CreateAttestation(tool));
 
+        _attestation
+            .Setup(x => x.SignFailureAsync(
+                It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string tool, string _, string reason, CancellationToken ___) =>
+                CreateAttestation(tool) with { IsFailureAttestation = true, OutputHash = null, FailureReason = reason });
+
         _sandboxConfig.Setup(x => x.CurrentValue).Returns(new SandboxConfig());
     }
 
@@ -158,6 +165,34 @@ public class ProcessSandboxEnvironmentIsolationTests
         result.Success.Should().BeTrue();
         result.Output!.Trim().Should().Be(workspaceDir,
             "TEMP must point inside the disposable sandbox workspace, not at the host temp directory");
+    }
+
+    [Theory]
+    [InlineData("temp")]
+    [InlineData("TMP")]
+    [InlineData("tmpdir")]
+    [InlineData("Path")]
+    [InlineData("COMSPEC")]
+    [InlineData("PathExt")]
+    [InlineData("systemroot")]
+    public async Task ExecuteAsync_ReservedEnvironmentGrant_RejectsRequestBeforeSpawning(string grantName)
+    {
+        // Reserved names are checked case-insensitively: Windows environment lookups are
+        // case-insensitive, so a grant of "temp" or "Path" would otherwise override the
+        // pinned temp redirection or the allowlisted PATH.
+        var request = CreateRequest(argumentList: ["/c", "echo", "should-not-run"]) with
+        {
+            EnvironmentVariables = new Dictionary<string, string> { [grantName] = @"C:\attacker-controlled" }
+        };
+
+        var result = await CreateSut().ExecuteAsync(request, CancellationToken.None);
+
+        result.Success.Should().BeFalse(
+            "grants colliding with pinned or security-critical variables must be rejected, not silently applied or skipped");
+        result.ErrorMessage.Should().Contain(grantName);
+        result.Output.Should().BeNull("the child process must never be spawned for a rejected request");
+        result.Attestation.Should().NotBeNull("the rejection must leave a signed audit record");
+        result.Attestation!.IsFailureAttestation.Should().BeTrue();
     }
 
     private static SandboxExecutionRequest CreateRequest(string[] argumentList) => new()

--- a/src/Content/Tests/Infrastructure.AI.Tests/Sandbox/ProcessSandboxEnvironmentIsolationTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Sandbox/ProcessSandboxEnvironmentIsolationTests.cs
@@ -1,0 +1,188 @@
+using Application.AI.Common.Interfaces.Attestation;
+using Application.AI.Common.Interfaces.Sandbox;
+using Domain.AI.Attestation;
+using Domain.AI.Sandbox;
+using Domain.Common.Config.AI.Sandbox;
+using FluentAssertions;
+using Infrastructure.AI.Sandbox;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Sandbox;
+
+/// <summary>
+/// Security regression coverage for sandbox audit finding A6-1: <see cref="ProcessSandboxExecutor"/>
+/// launched child processes that inherited the full host environment (secrets, tokens, paths).
+/// These tests assert the child environment is cleared and rebuilt from an explicit,
+/// closed-by-default allowlist plus per-request grants.
+/// </summary>
+[Trait("Category", "WindowsOnly")]
+public class ProcessSandboxEnvironmentIsolationTests
+{
+    private readonly Mock<IProcessResourceLimiter> _limiter = new();
+    private readonly Mock<IAttestationService> _attestation = new();
+    private readonly Mock<IOptionsMonitor<SandboxConfig>> _sandboxConfig = new();
+
+    public ProcessSandboxEnvironmentIsolationTests()
+    {
+        _limiter.Setup(x => x.IsSupported).Returns(true);
+        _limiter.Setup(x => x.Apply(It.IsAny<System.Diagnostics.Process>(), It.IsAny<ResourceLimits>()))
+            .Returns(true);
+
+        _attestation
+            .Setup(x => x.SignAsync(
+                It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string tool, string _, string __, CancellationToken ___) =>
+                CreateAttestation(tool));
+
+        _sandboxConfig.Setup(x => x.CurrentValue).Returns(new SandboxConfig());
+    }
+
+    private ProcessSandboxExecutor CreateSut() => new(
+        _limiter.Object,
+        _attestation.Object,
+        Mock.Of<ILogger<ProcessSandboxExecutor>>(),
+        TimeProvider.System,
+        _sandboxConfig.Object);
+
+    [SkippableFact]
+    public async Task ExecuteAsync_HostSecretEnvVar_NotVisibleToChildProcess()
+    {
+        Skip.IfNot(OperatingSystem.IsWindows(), "Windows-only: uses cmd.exe environment expansion.");
+
+        const string canaryName = "SANDBOX_CANARY_SECRET_A6";
+        const string canaryValue = "leaked-host-secret-value-a6";
+        Environment.SetEnvironmentVariable(canaryName, canaryValue);
+        try
+        {
+            var request = CreateRequest(argumentList: ["/c", "echo", $"%{canaryName}%"]);
+
+            var result = await CreateSut().ExecuteAsync(request, CancellationToken.None);
+
+            result.Success.Should().BeTrue();
+            result.Output.Should().NotContain(canaryValue,
+                "the child process environment must be cleared — host secrets must never leak into sandboxed tools");
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(canaryName, null);
+        }
+    }
+
+    [SkippableFact]
+    public async Task ExecuteAsync_AllowlistedHostVariable_FlowsToChildProcess()
+    {
+        Skip.IfNot(OperatingSystem.IsWindows(), "Windows-only: uses cmd.exe environment expansion.");
+
+        // SystemRoot is in the default host allowlist and always set on Windows.
+        var request = CreateRequest(argumentList: ["/c", "echo", "%SystemRoot%"]);
+
+        var result = await CreateSut().ExecuteAsync(request, CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        result.Output!.Trim().Should().Be(
+            Environment.GetEnvironmentVariable("SystemRoot"),
+            "allowlisted system variables must still flow through so child processes remain functional");
+    }
+
+    [SkippableFact]
+    public async Task ExecuteAsync_NonAllowlistedHostVariable_BlockedEvenWhenAllowlistCustomized()
+    {
+        Skip.IfNot(OperatingSystem.IsWindows(), "Windows-only: uses cmd.exe environment expansion.");
+
+        const string canaryName = "SANDBOX_CANARY_CUSTOM_A6";
+        const string canaryValue = "custom-allowlist-must-not-leak";
+        Environment.SetEnvironmentVariable(canaryName, canaryValue);
+        try
+        {
+            _sandboxConfig.Setup(x => x.CurrentValue).Returns(new SandboxConfig
+            {
+                ProcessEnvironmentAllowlist = ["SystemRoot"]
+            });
+
+            var request = CreateRequest(argumentList: ["/c", "echo", $"%{canaryName}%"]);
+
+            var result = await CreateSut().ExecuteAsync(request, CancellationToken.None);
+
+            result.Success.Should().BeTrue();
+            result.Output.Should().NotContain(canaryValue,
+                "only variables named in the configured allowlist may cross the sandbox boundary");
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(canaryName, null);
+        }
+    }
+
+    [SkippableFact]
+    public async Task ExecuteAsync_RequestEnvironmentGrant_VisibleToChildProcess()
+    {
+        Skip.IfNot(OperatingSystem.IsWindows(), "Windows-only: uses cmd.exe environment expansion.");
+
+        var request = CreateRequest(argumentList: ["/c", "echo", "%TOOL_GRANTED_SETTING%"]) with
+        {
+            EnvironmentVariables = new Dictionary<string, string>
+            {
+                ["TOOL_GRANTED_SETTING"] = "explicitly-granted-value"
+            }
+        };
+
+        var result = await CreateSut().ExecuteAsync(request, CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        result.Output.Should().Contain("explicitly-granted-value",
+            "explicit per-request environment grants are the sanctioned channel for passing values into the sandbox");
+    }
+
+    [SkippableFact]
+    public async Task ExecuteAsync_TempVariables_RedirectedIntoSandboxWorkspace()
+    {
+        Skip.IfNot(OperatingSystem.IsWindows(), "Windows-only: uses cmd.exe environment expansion.");
+
+        var sut = CreateSut();
+        string? workspaceDir = null;
+        sut.CreateWorkspaceDirectory = () =>
+        {
+            workspaceDir = Path.Combine(Path.GetTempPath(), $"sandbox-envtest-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(workspaceDir);
+            return workspaceDir;
+        };
+
+        var request = CreateRequest(argumentList: ["/c", "echo", "%TEMP%"]);
+
+        var result = await sut.ExecuteAsync(request, CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        result.Output!.Trim().Should().Be(workspaceDir,
+            "TEMP must point inside the disposable sandbox workspace, not at the host temp directory");
+    }
+
+    private static SandboxExecutionRequest CreateRequest(string[] argumentList) => new()
+    {
+        ToolName = "test_tool",
+        Input = "{}",
+        Limits = new ResourceLimits(),
+        PermissionProfile = new ToolPermissionProfile
+        {
+            RequiredCapabilities = ToolCapability.None,
+            AllowedPrograms = ["cmd.exe"]
+        },
+        Command = "cmd.exe",
+        ArgumentList = argumentList,
+        Timeout = TimeSpan.FromSeconds(10)
+    };
+
+    private static ToolExecutionAttestation CreateAttestation(string toolName) => new()
+    {
+        ToolName = toolName,
+        InputHash = "test-hash",
+        OutputHash = "test-output-hash",
+        Timestamp = DateTimeOffset.UtcNow,
+        Signature = "test-sig",
+        KeyVersion = "v1",
+        IsFailureAttestation = false
+    };
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Sandbox/ProcessSandboxExecutorTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Sandbox/ProcessSandboxExecutorTests.cs
@@ -38,6 +38,13 @@ public class ProcessSandboxExecutorTests : IDisposable
             .ReturnsAsync((string tool, string _, string reason, CancellationToken ___) =>
                 CreateAttestation(tool, isFailure: true, failureReason: reason));
 
+        _attestation
+            .Setup(x => x.SignFailureWithOutputAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string tool, string _, string reason, string __, string? ___, CancellationToken ____) =>
+                CreateAttestation(tool, isFailure: true, failureReason: reason));
+
         var sandboxConfig = new Mock<IOptionsMonitor<SandboxConfig>>();
         sandboxConfig.Setup(x => x.CurrentValue).Returns(new SandboxConfig());
 

--- a/src/Content/Tests/Infrastructure.AI.Tests/Sandbox/SandboxAttestationBindingTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Sandbox/SandboxAttestationBindingTests.cs
@@ -1,0 +1,247 @@
+using Application.AI.Common.Interfaces.Attestation;
+using Application.AI.Common.Interfaces.Sandbox;
+using Application.AI.Common.Models.Sandbox;
+using Docker.DotNet;
+using Docker.DotNet.Models;
+using Domain.AI.Attestation;
+using Domain.AI.Sandbox;
+using Domain.Common.Config.AI.Sandbox;
+using FluentAssertions;
+using Infrastructure.AI.Sandbox;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Sandbox;
+
+/// <summary>
+/// Security regression coverage for sandbox audit finding A6-2 at the executor level:
+/// crash results carried an <c>Output</c> that the failure attestation never covered, so
+/// the returned output could diverge from the signed record without detection. These tests
+/// assert both executors bind the actually produced output into the failure attestation.
+/// </summary>
+public class SandboxAttestationBindingTests
+{
+    private static ToolExecutionAttestation CreateAttestation(
+        string toolName, bool isFailure, string? outputHash = null) => new()
+    {
+        ToolName = toolName,
+        InputHash = "test-hash",
+        OutputHash = outputHash,
+        Timestamp = DateTimeOffset.UtcNow,
+        Signature = "test-sig",
+        KeyVersion = "v1",
+        IsFailureAttestation = isFailure
+    };
+
+    [Trait("Category", "WindowsOnly")]
+    public class ProcessCrashBinding
+    {
+        private readonly Mock<IProcessResourceLimiter> _limiter = new();
+        private readonly Mock<IAttestationService> _attestation = new();
+        private readonly ProcessSandboxExecutor _sut;
+
+        public ProcessCrashBinding()
+        {
+            _limiter.Setup(x => x.IsSupported).Returns(true);
+            _limiter.Setup(x => x.Apply(It.IsAny<System.Diagnostics.Process>(), It.IsAny<ResourceLimits>()))
+                .Returns(true);
+
+            _attestation
+                .Setup(x => x.SignFailureWithOutputAsync(
+                    It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                    It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((string tool, string _, string __, string ___, string? ____, CancellationToken _____) =>
+                    CreateAttestation(tool, isFailure: true, outputHash: "bound-hash"));
+
+            _attestation
+                .Setup(x => x.SignFailureAsync(
+                    It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((string tool, string _, string __, CancellationToken ___) =>
+                    CreateAttestation(tool, isFailure: true));
+
+            var sandboxConfig = new Mock<IOptionsMonitor<SandboxConfig>>();
+            sandboxConfig.Setup(x => x.CurrentValue).Returns(new SandboxConfig());
+
+            _sut = new ProcessSandboxExecutor(
+                _limiter.Object,
+                _attestation.Object,
+                Mock.Of<ILogger<ProcessSandboxExecutor>>(),
+                TimeProvider.System,
+                sandboxConfig.Object);
+        }
+
+        [SkippableFact]
+        public async Task ExecuteAsync_ProcessCrashWithStdout_BindsStdoutIntoFailureAttestation()
+        {
+            Skip.IfNot(OperatingSystem.IsWindows(), "Windows-only: uses cmd.exe.");
+
+            var request = new SandboxExecutionRequest
+            {
+                ToolName = "test_tool",
+                Input = "{}",
+                Limits = new ResourceLimits(),
+                PermissionProfile = new ToolPermissionProfile
+                {
+                    RequiredCapabilities = ToolCapability.None,
+                    AllowedPrograms = ["cmd.exe"]
+                },
+                Command = "cmd.exe",
+                ArgumentList = ["/c", "echo", "crash-stdout-data", "&", "exit", "3"],
+                Timeout = TimeSpan.FromSeconds(10)
+            };
+
+            var result = await _sut.ExecuteAsync(request, CancellationToken.None);
+
+            result.Success.Should().BeFalse();
+            result.ExitCode.Should().Be(3);
+            result.Output.Should().Contain("crash-stdout-data");
+
+            _attestation.Verify(x => x.SignFailureWithOutputAsync(
+                    "test_tool",
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.Is<string>(o => o == result.Output),
+                    null,
+                    It.IsAny<CancellationToken>()),
+                Times.Once,
+                "the crash output returned to the caller must be the exact bytes bound into the attestation");
+        }
+    }
+
+    public class DockerCrashBinding
+    {
+        private readonly Mock<IDockerClient> _dockerClient = new();
+        private readonly Mock<IContainerOperations> _containers = new();
+        private readonly Mock<IImageOperations> _images = new();
+        private readonly Mock<ISystemOperations> _system = new();
+        private readonly Mock<IAttestationService> _attestation = new();
+        private readonly Mock<IOptionsMonitor<SandboxExecutionOptions>> _options = new();
+        private readonly DockerSandboxExecutor _sut;
+        private string? _capturedWorkspaceDir;
+
+        public DockerCrashBinding()
+        {
+            _dockerClient.Setup(x => x.Containers).Returns(_containers.Object);
+            _dockerClient.Setup(x => x.System).Returns(_system.Object);
+            _dockerClient.Setup(x => x.Images).Returns(_images.Object);
+
+            _system.Setup(x => x.PingAsync(It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
+            _images.Setup(x => x.InspectImageAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ImageInspectResponse());
+
+            _containers.Setup(x => x.CreateContainerAsync(
+                    It.IsAny<CreateContainerParameters>(), It.IsAny<CancellationToken>()))
+                .Callback<CreateContainerParameters, CancellationToken>((p, _) =>
+                {
+                    var bind = p.HostConfig.Binds[0];
+                    _capturedWorkspaceDir = bind[..bind.IndexOf(":/workspace", StringComparison.Ordinal)];
+                })
+                .ReturnsAsync(new CreateContainerResponse { ID = "test-container-id" });
+
+            _containers.Setup(x => x.StartContainerAsync(
+                    It.IsAny<string>(), It.IsAny<ContainerStartParameters>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(true);
+
+            _containers.Setup(x => x.GetContainerLogsAsync(
+                    It.IsAny<string>(), It.IsAny<bool>(),
+                    It.IsAny<ContainerLogsParameters>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new MultiplexedStream(Stream.Null, default));
+
+            _containers.Setup(x => x.RemoveContainerAsync(
+                    It.IsAny<string>(), It.IsAny<ContainerRemoveParameters>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
+            _attestation
+                .Setup(x => x.SignFailureWithOutputAsync(
+                    It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                    It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((string tool, string _, string __, string ___, string? ____, CancellationToken _____) =>
+                    CreateAttestation(tool, isFailure: true, outputHash: "bound-hash"));
+
+            _attestation
+                .Setup(x => x.SignFailureAsync(
+                    It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((string tool, string _, string __, CancellationToken ___) =>
+                    CreateAttestation(tool, isFailure: true));
+
+            _options.Setup(x => x.CurrentValue).Returns(new SandboxExecutionOptions());
+
+            var sandboxConfig = new Mock<IOptionsMonitor<SandboxConfig>>();
+            sandboxConfig.Setup(x => x.CurrentValue).Returns(new SandboxConfig { Enabled = true });
+
+            _sut = new DockerSandboxExecutor(
+                _dockerClient.Object,
+                _attestation.Object,
+                _options.Object,
+                sandboxConfig.Object,
+                Mock.Of<ILogger<DockerSandboxExecutor>>());
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_ContainerCrashWithWorkspaceOutput_BindsOutputIntoFailureAttestation()
+        {
+            const string producedOutput = "{\"partial\":\"result-before-crash\"}";
+
+            _containers.Setup(x => x.WaitContainerAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .Returns<string, CancellationToken>(async (_, _) =>
+                {
+                    await File.WriteAllTextAsync(
+                        Path.Combine(_capturedWorkspaceDir!, "output.json"), producedOutput);
+                    return new ContainerWaitResponse { StatusCode = 1 };
+                });
+
+            var result = await _sut.ExecuteAsync(CreateRequest(), CancellationToken.None);
+
+            result.Success.Should().BeFalse();
+            result.Output.Should().Be(producedOutput);
+
+            _attestation.Verify(x => x.SignFailureWithOutputAsync(
+                    "test_tool",
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    producedOutput,
+                    null,
+                    It.IsAny<CancellationToken>()),
+                Times.Once,
+                "the workspace output returned on a container crash must be bound into the attestation");
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_ContainerCrashWithoutOutput_UsesLegacyFailureAttestation()
+        {
+            _containers.Setup(x => x.WaitContainerAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ContainerWaitResponse { StatusCode = 1 });
+
+            var result = await _sut.ExecuteAsync(CreateRequest(), CancellationToken.None);
+
+            result.Success.Should().BeFalse();
+            result.Output.Should().BeNull();
+
+            _attestation.Verify(x => x.SignFailureAsync(
+                    "test_tool", It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+                Times.Once);
+            _attestation.Verify(x => x.SignFailureWithOutputAsync(
+                    It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                    It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()),
+                Times.Never,
+                "when no output was produced there is nothing to bind — the legacy failure shape applies");
+        }
+
+        private static SandboxExecutionRequest CreateRequest() => new()
+        {
+            ToolName = "test_tool",
+            Input = "{\"action\":\"test\"}",
+            Limits = new ResourceLimits(),
+            PermissionProfile = new ToolPermissionProfile
+            {
+                RequiredCapabilities = ToolCapability.None,
+                MinimumIsolation = SandboxIsolationLevel.Process
+            },
+            Timeout = TimeSpan.FromSeconds(30)
+        };
+    }
+}


### PR DESCRIPTION
## Summary
Wave-2 audit item **A6** (Infrastructure.AI/Sandbox), reproduce-test-first, plus adversarial security-review fixes (verdict was MERGE AFTER FIXES; both blockers fixed and re-proven).

### 1. Child process environment isolation (ProcessSandboxExecutor)
- Child env is now cleared and rebuilt from an allowlist (`SandboxConfig.ProcessEnvironmentAllowlist`, default `SystemRoot, ComSpec, PATHEXT, PATH`) — host secrets/tokens no longer inherited via the environment.
- `TEMP`/`TMP`/`TMPDIR` pinned to the disposable per-execution workspace.
- New closed-by-default per-request grants (`SandboxExecutionRequest.EnvironmentVariables`); **review fix:** grants whose names case-insensitively collide with reserved names (`TEMP/TMP/TMPDIR/PATH/COMSPEC/PATHEXT/SYSTEMROOT`) are rejected with an explicit failure + signed failure attestation (no silent skip, no un-pinning).
- Honest docs: isolation is partial (same OS user/token, no privilege drop; PATH inheritance risk documented with removal instructions).

### 2. Attestation bound to actual output (HmacAttestationService + executors)
- Crash paths in both executors previously returned output that the failure attestation never covered; they now sign the exact output they return (`SignFailureWithOutputAsync`).
- New `VerifyBoundAsync` re-hashes the actual output (SHA-256, fixed-time compare) before signature verification; legacy null-slot attestations verify unchanged (downgrade-forgery requires the HMAC key — reviewer-verified).
- **Review fix (the big one):** the only live verifier, `ToolUseStepExecutor`, still called `VerifyAsync` — the binding was inert on the live path. It now calls `VerifyBoundAsync` for output-carrying attestations; a tampered-output repro test (real `HmacAttestationService`) fails pre-fix and passes post-fix.

### 3. Docker executor hardening (DockerSandboxExecutor)
- Cleanup-on-cancel: force kill+remove runs on a dedicated bounded token (`CleanupTimeoutSeconds`, default 30) instead of the caller's already-cancelled token (which guaranteed container leaks).
- CPU limits: `NanoCPUs` from new `ResourceLimits.CpuCoreLimit` (default 1.0); **review fix:** non-positive/NaN values rejected before any container work instead of silently meaning unlimited.

## Test plan
- [x] 31 new tests, reproduce-first: 9/11 env tests + 7-case reserved-grant theory + tamper-binding tests + cancel/CPU tests all red against pre-fix code, green after
- [x] Infrastructure.AI.Tests 2039/2039 (2 pre-existing Kuzu skips), Application.AI.Common.Tests 1307, Domain.AI.Tests 819
- [x] gitnexus impact LOW on all touched symbols incl. ToolUseStepExecutor (keyed-DI only, 0 upstream callers)
- [x] Adversarial security review: both blocking findings fixed; LOW recommendations (CPU floor, honest PATH docs) also done

## Follow-up (tracked, not in this PR)
- Consolidate the 6 `IAttestationService.Sign*` variants (~30 call/mock sites — standalone refactor)
- Process-sandbox CPU rate control (Job Object CPU_RATE_CONTROL)

🤖 Generated with [Claude Code](https://claude.com/claude-code)