### PR TITLE
fix: fail-closed MCP server auth with ApiKey/Bearer enforcement

### DIFF
--- a/src/Content/Domain/Domain.Common/Config/AI/MCP/McpServerAuthConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/MCP/McpServerAuthConfig.cs
@@ -76,8 +76,51 @@ public class McpServerAuthConfig
     /// </remarks>
     public List<string> Scopes { get; set; } = [];
 
+    /// <summary>
+    /// Gets or sets the explicit opt-in that lets this application's own MCP server
+    /// (<see cref="McpConfig.Auth"/>) serve anonymously when <see cref="Type"/> is
+    /// <see cref="McpServerAuthType.None"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Default: <c>false</c> — the MCP server host is fail-closed and refuses to start
+    /// without a configured authentication scheme, in <strong>every</strong> environment.
+    /// Running <c>ASPNETCORE_ENVIRONMENT=Development</c> alone is never sufficient to
+    /// disable authentication; a developer must consciously set this flag, and the host
+    /// logs a prominent warning at startup while it is on.
+    /// </para>
+    /// <para>
+    /// Only honored when this config is used server-side. Outbound client connections
+    /// (<see cref="McpServerDefinition"/>) ignore it — a client with
+    /// <see cref="McpServerAuthType.None"/> simply sends no credential.
+    /// </para>
+    /// </remarks>
+    public bool AllowAnonymous { get; set; }
+
     /// <summary>Gets whether authentication is configured.</summary>
     public bool IsConfigured => Type != McpServerAuthType.None;
+
+    /// <summary>
+    /// Gets whether the configuration is valid for <em>server-side</em> enforcement —
+    /// when this application is the MCP server validating inbound credentials.
+    /// </summary>
+    /// <remarks>
+    /// Server-side requirements differ from <see cref="IsValid"/> (the client-side,
+    /// credential-minting shape): the server never mints tokens, so
+    /// <see cref="McpServerAuthType.Entra"/> only needs <see cref="TenantId"/> and
+    /// <see cref="ClientId"/> to validate issuer and audience — no secret, certificate,
+    /// or <see cref="Scopes"/>. ApiKey/Bearer require the shared credential material
+    /// the server compares inbound requests against.
+    /// </remarks>
+    public bool IsValidForServer => Type switch
+    {
+        McpServerAuthType.None => true,
+        McpServerAuthType.ApiKey => !string.IsNullOrWhiteSpace(ApiKey),
+        McpServerAuthType.Bearer => !string.IsNullOrWhiteSpace(BearerToken),
+        McpServerAuthType.Entra => !string.IsNullOrWhiteSpace(TenantId)
+                                   && !string.IsNullOrWhiteSpace(ClientId),
+        _ => false
+    };
 
     /// <summary>Gets whether the configuration is valid for the selected type.</summary>
     /// <remarks>

--- a/src/Content/Infrastructure/Infrastructure.AI.MCPServer/Authentication/McpAnonymousModeStartupWarning.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.MCPServer/Authentication/McpAnonymousModeStartupWarning.cs
@@ -1,0 +1,25 @@
+namespace Infrastructure.AI.MCPServer.Authentication;
+
+/// <summary>
+/// Logs a prominent warning at host startup while the MCP server is running with
+/// authentication explicitly disabled (<c>AppConfig:AI:MCP:Auth:AllowAnonymous=true</c>).
+/// Registered only on that opt-in path so the warning cannot be missed in logs.
+/// </summary>
+internal sealed class McpAnonymousModeStartupWarning(
+    ILogger<McpAnonymousModeStartupWarning> logger) : IHostedService
+{
+    /// <inheritdoc />
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        logger.LogWarning(
+            "MCP SERVER AUTHENTICATION IS DISABLED — running in explicit ANONYMOUS mode. " +
+            "Every MCP tool, prompt, and resource is served without credentials because " +
+            "AppConfig:AI:MCP:Auth:AllowAnonymous=true. This is only acceptable for local " +
+            "development. Configure AppConfig:AI:MCP:Auth (ApiKey, Bearer, or Entra) and " +
+            "remove AllowAnonymous before exposing this server on any network.");
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}

--- a/src/Content/Infrastructure/Infrastructure.AI.MCPServer/Authentication/McpSharedKeyAuthenticationDefaults.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.MCPServer/Authentication/McpSharedKeyAuthenticationDefaults.cs
@@ -1,0 +1,22 @@
+namespace Infrastructure.AI.MCPServer.Authentication;
+
+/// <summary>
+/// Authentication scheme names for the MCP server's shared-key schemes
+/// (<see cref="Domain.Common.Config.AI.MCP.McpServerAuthType.ApiKey"/> and
+/// <see cref="Domain.Common.Config.AI.MCP.McpServerAuthType.Bearer"/>).
+/// </summary>
+public static class McpSharedKeyAuthenticationDefaults
+{
+    /// <summary>
+    /// Scheme validating an API key carried in a configurable header
+    /// (default <c>X-API-Key</c>).
+    /// </summary>
+    public const string ApiKeyScheme = "McpApiKey";
+
+    /// <summary>
+    /// Scheme validating a static shared token carried as
+    /// <c>Authorization: Bearer {token}</c>. Distinct from JWT bearer — the token is a
+    /// pre-shared secret compared in constant time, not a signed claim set.
+    /// </summary>
+    public const string BearerScheme = "McpSharedBearer";
+}

--- a/src/Content/Infrastructure/Infrastructure.AI.MCPServer/Authentication/McpSharedKeyAuthenticationHandler.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.MCPServer/Authentication/McpSharedKeyAuthenticationHandler.cs
@@ -35,10 +35,17 @@ public sealed class McpSharedKeyAuthenticationHandler(
 
         if (Options.ValuePrefix.Length > 0)
         {
-            if (!presented.StartsWith(Options.ValuePrefix, StringComparison.Ordinal))
+            // RFC 7235: the auth-scheme token is case-insensitive and separated from
+            // the credential by at least one space (extra whitespace tolerated).
+            var scheme = Options.ValuePrefix.TrimEnd(' ');
+            if (presented.Length <= scheme.Length
+                || !presented.StartsWith(scheme, StringComparison.OrdinalIgnoreCase)
+                || presented[scheme.Length] != ' ')
                 return Task.FromResult(AuthenticateResult.NoResult());
 
-            presented = presented[Options.ValuePrefix.Length..];
+            presented = presented[scheme.Length..].TrimStart(' ');
+            if (presented.Length == 0)
+                return Task.FromResult(AuthenticateResult.NoResult());
         }
 
         if (!CredentialsMatch(presented, Options.ExpectedCredential))

--- a/src/Content/Infrastructure/Infrastructure.AI.MCPServer/Authentication/McpSharedKeyAuthenticationHandler.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.MCPServer/Authentication/McpSharedKeyAuthenticationHandler.cs
@@ -1,0 +1,68 @@
+using System.Security.Claims;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Options;
+
+namespace Infrastructure.AI.MCPServer.Authentication;
+
+/// <summary>
+/// Authenticates inbound MCP requests against a pre-shared credential — either an API
+/// key in a configurable header (<see cref="McpSharedKeyAuthenticationDefaults.ApiKeyScheme"/>)
+/// or a static token in <c>Authorization: Bearer</c>
+/// (<see cref="McpSharedKeyAuthenticationDefaults.BearerScheme"/>).
+/// </summary>
+/// <remarks>
+/// The comparison hashes both values and uses
+/// <see cref="CryptographicOperations.FixedTimeEquals(ReadOnlySpan{byte}, ReadOnlySpan{byte})"/>
+/// so neither content nor length differences leak through response timing.
+/// Failures return 401 with no detail about which part of the credential was wrong.
+/// </remarks>
+public sealed class McpSharedKeyAuthenticationHandler(
+    IOptionsMonitor<McpSharedKeyAuthenticationOptions> options,
+    ILoggerFactory logger,
+    UrlEncoder encoder)
+    : AuthenticationHandler<McpSharedKeyAuthenticationOptions>(options, logger, encoder)
+{
+    /// <inheritdoc />
+    protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+    {
+        if (!Request.Headers.TryGetValue(Options.HeaderName, out var headerValues))
+            return Task.FromResult(AuthenticateResult.NoResult());
+
+        var presented = headerValues.ToString();
+
+        if (Options.ValuePrefix.Length > 0)
+        {
+            if (!presented.StartsWith(Options.ValuePrefix, StringComparison.Ordinal))
+                return Task.FromResult(AuthenticateResult.NoResult());
+
+            presented = presented[Options.ValuePrefix.Length..];
+        }
+
+        if (!CredentialsMatch(presented, Options.ExpectedCredential))
+        {
+            Logger.LogWarning(
+                "MCP shared-key authentication failed. Scheme={Scheme} Header={Header}",
+                Scheme.Name, Options.HeaderName);
+            return Task.FromResult(AuthenticateResult.Fail("Invalid credential."));
+        }
+
+        var identity = new ClaimsIdentity(
+            [new Claim(ClaimTypes.Name, "mcp-shared-key-client")], Scheme.Name);
+        var ticket = new AuthenticationTicket(new ClaimsPrincipal(identity), Scheme.Name);
+        return Task.FromResult(AuthenticateResult.Success(ticket));
+    }
+
+    /// <summary>
+    /// Compares a presented credential to the expected one in constant time by
+    /// comparing SHA-256 digests, which also normalizes length differences.
+    /// </summary>
+    internal static bool CredentialsMatch(string presented, string expected)
+    {
+        var presentedHash = SHA256.HashData(Encoding.UTF8.GetBytes(presented));
+        var expectedHash = SHA256.HashData(Encoding.UTF8.GetBytes(expected));
+        return CryptographicOperations.FixedTimeEquals(presentedHash, expectedHash);
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI.MCPServer/Authentication/McpSharedKeyAuthenticationOptions.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.MCPServer/Authentication/McpSharedKeyAuthenticationOptions.cs
@@ -1,0 +1,46 @@
+using Microsoft.AspNetCore.Authentication;
+
+namespace Infrastructure.AI.MCPServer.Authentication;
+
+/// <summary>
+/// Options for <see cref="McpSharedKeyAuthenticationHandler"/> — shared-secret
+/// authentication for inbound MCP requests via API key header or static bearer token.
+/// </summary>
+public sealed class McpSharedKeyAuthenticationOptions : AuthenticationSchemeOptions
+{
+    /// <summary>
+    /// Gets or sets the HTTP header carrying the credential
+    /// (e.g. <c>X-API-Key</c> or <c>Authorization</c>).
+    /// </summary>
+    public string HeaderName { get; set; } = "X-API-Key";
+
+    /// <summary>
+    /// Gets or sets the required prefix of the header value, stripped before comparison.
+    /// Empty for raw API keys; <c>"Bearer "</c> for the static bearer scheme.
+    /// </summary>
+    public string ValuePrefix { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the expected credential inbound requests are compared against.
+    /// Sourced from configuration (User Secrets / Key Vault) — never hardcoded.
+    /// </summary>
+    public string ExpectedCredential { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Validates that the scheme has usable key material, so a half-configured scheme
+    /// fails at startup rather than silently rejecting (or worse, accepting) requests.
+    /// </summary>
+    public override void Validate()
+    {
+        base.Validate();
+
+        if (string.IsNullOrWhiteSpace(HeaderName))
+            throw new InvalidOperationException(
+                $"{nameof(McpSharedKeyAuthenticationOptions)}.{nameof(HeaderName)} must be set.");
+
+        if (string.IsNullOrWhiteSpace(ExpectedCredential))
+            throw new InvalidOperationException(
+                $"{nameof(McpSharedKeyAuthenticationOptions)}.{nameof(ExpectedCredential)} must be set. " +
+                "Configure the shared credential via AppConfig:AI:MCP:Auth (User Secrets or Key Vault).");
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI.MCPServer/Authentication/McpSharedKeyAuthenticationOptions.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.MCPServer/Authentication/McpSharedKeyAuthenticationOptions.cs
@@ -15,8 +15,10 @@ public sealed class McpSharedKeyAuthenticationOptions : AuthenticationSchemeOpti
     public string HeaderName { get; set; } = "X-API-Key";
 
     /// <summary>
-    /// Gets or sets the required prefix of the header value, stripped before comparison.
-    /// Empty for raw API keys; <c>"Bearer "</c> for the static bearer scheme.
+    /// Gets or sets the auth-scheme prefix of the header value, stripped before
+    /// comparison. Empty for raw API keys; <c>"Bearer "</c> for the static bearer
+    /// scheme. Per RFC 7235 the scheme token is matched case-insensitively and any
+    /// amount of whitespace between scheme and credential is tolerated.
     /// </summary>
     public string ValuePrefix { get; set; } = string.Empty;
 

--- a/src/Content/Infrastructure/Infrastructure.AI.MCPServer/Authorization/McpToolAuthorizationFilter.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.MCPServer/Authorization/McpToolAuthorizationFilter.cs
@@ -11,9 +11,10 @@ namespace Infrastructure.AI.MCPServer.Authorization;
 /// </summary>
 /// <remarks>
 /// <para>
-/// This is the baseline gate: when authentication is configured (all non-Development
-/// environments), every tool call must carry an authenticated principal. The logic is
-/// extracted from the server-builder wiring so it can be unit-tested in isolation.
+/// This is the baseline gate: unless the operator explicitly opted into anonymous
+/// serving (<c>AppConfig:AI:MCP:Auth:AllowAnonymous=true</c>), every tool call must
+/// carry an authenticated principal. The logic is extracted from the server-builder
+/// wiring so it can be unit-tested in isolation.
 /// </para>
 /// <para>
 /// Finer-grained, per-tool restriction is layered on top via standard
@@ -29,9 +30,9 @@ internal static class McpToolAuthorizationFilter
     /// Evaluates whether an inbound tool call is permitted to proceed.
     /// </summary>
     /// <param name="authenticationRequired">
-    /// True when the server has authentication configured (non-Development). When false
-    /// (Development with no configured auth) the gate is inert, matching the server's
-    /// existing unauthenticated-development posture.
+    /// True whenever the server enforces authentication — every mode except the
+    /// explicit <c>AllowAnonymous=true</c> opt-in, where the gate is deliberately
+    /// inert to match the operator's conscious choice to serve anonymously.
     /// </param>
     /// <param name="user">The caller principal carried on the request, if any.</param>
     /// <returns>

--- a/src/Content/Infrastructure/Infrastructure.AI.MCPServer/Extensions/McpServerExtensions.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.MCPServer/Extensions/McpServerExtensions.cs
@@ -3,8 +3,10 @@ using System.Diagnostics;
 using Domain.Common.Config;
 using Domain.Common.Config.AI.MCP;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.IdentityModel.Tokens;
-using Microsoft.Extensions.Hosting;
+using Microsoft.Net.Http.Headers;
+using Infrastructure.AI.MCPServer.Authentication;
 using Infrastructure.AI.MCPServer.Authorization;
 using ModelContextProtocol;
 using ModelContextProtocol.AspNetCore;
@@ -29,11 +31,12 @@ public static class McpServerExtensions
         var subscriptions = new ConcurrentDictionary<string, byte>();
         services.AddSingleton(subscriptions);
 
-        // Auth is configured in all non-Development environments (AddMcpAuthentication
-        // enforces this). When it is, every inbound tool call must carry an
-        // authenticated principal — re-checked at the tool-dispatch layer below as
-        // defense-in-depth behind the endpoint's RequireAuthorization().
-        var authenticationRequired = mcpConfig.Auth.IsConfigured;
+        // AddMcpAuthentication is fail-closed: the host only boots with a configured
+        // scheme or the explicit AllowAnonymous opt-in. Unless that opt-in is set,
+        // every inbound tool call must carry an authenticated principal — re-checked
+        // at the tool-dispatch layer below as defense-in-depth behind the endpoint's
+        // RequireAuthorization().
+        var authenticationRequired = !mcpConfig.Auth.AllowAnonymous;
 
         services
             .AddMcpServer(options =>
@@ -112,63 +115,163 @@ public static class McpServerExtensions
     }
 
     /// <summary>
-    /// Configures JWT Bearer authentication for the MCP server.
+    /// Configures fail-closed authentication for the MCP server host: ApiKey, static
+    /// Bearer token, or Entra ID (JWT) enforcement on every MCP endpoint.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <strong>Fail-closed contract:</strong> if no authentication scheme is properly
+    /// configured (<c>Type=None</c>, or a type missing its credential material), this
+    /// method throws and the host refuses to start — in <em>every</em> environment.
+    /// The single escape hatch is the explicit
+    /// <c>AppConfig:AI:MCP:Auth:AllowAnonymous=true</c> opt-in, which boots the server
+    /// open and logs a prominent startup warning. Combining that opt-in with a
+    /// configured type is rejected as contradictory.
+    /// </para>
+    /// <para>
+    /// When authentication is configured, a fallback authorization policy requiring an
+    /// authenticated user is installed, so any endpoint mapped without explicit
+    /// authorization metadata is still protected.
+    /// </para>
+    /// </remarks>
+    /// <exception cref="InvalidOperationException">
+    /// Authentication is unconfigured without the anonymous opt-in, misconfigured for
+    /// the selected type, or contradictorily combined with <c>AllowAnonymous</c>.
+    /// </exception>
     public static IServiceCollection AddMcpAuthentication(
-        this IServiceCollection services, AppConfig appConfig, IConfiguration configuration,
-        IHostEnvironment environment)
+        this IServiceCollection services, AppConfig appConfig)
     {
         var auth = appConfig.AI.MCP.Auth;
 
+        if (auth.AllowAnonymous && auth.IsConfigured)
+            throw new InvalidOperationException(
+                "AppConfig:AI:MCP:Auth is contradictory: AllowAnonymous=true cannot be combined " +
+                $"with a configured authentication type ({auth.Type}). Remove AllowAnonymous to " +
+                "enforce the configured scheme, or set Type=None to run anonymously.");
+
         if (!auth.IsConfigured)
         {
-            if (!environment.IsDevelopment())
+            if (!auth.AllowAnonymous)
                 throw new InvalidOperationException(
-                    "MCP server authentication must be configured in non-Development environments. " +
-                    "Set AppConfig:AI:MCP:Auth in appsettings or User Secrets.");
+                    "MCP server authentication is not configured — refusing to start (fail-closed). " +
+                    "Set AppConfig:AI:MCP:Auth:Type to ApiKey, Bearer, or Entra and supply the matching " +
+                    "credential material via User Secrets or Key Vault. For local development only, " +
+                    "authentication can be consciously disabled with AppConfig:AI:MCP:Auth:AllowAnonymous=true; " +
+                    "running under Environment=Development alone does not disable it.");
 
+            // Explicit anonymous opt-in — boot open, loudly.
             services.AddAuthentication();
-            services.AddAuthorization(options =>
-            {
-                options.FallbackPolicy = null;
-            });
+            services.AddAuthorization();
+            services.AddHostedService<McpAnonymousModeStartupWarning>();
             return services;
         }
 
-        if (auth.Type == McpServerAuthType.Entra)
-        {
-            var authority = $"https://login.microsoftonline.com/{auth.TenantId}/v2.0";
-            var audience = $"api://{auth.ClientId}";
+        if (!auth.IsValidForServer)
+            throw new InvalidOperationException(
+                $"AppConfig:AI:MCP:Auth:Type={auth.Type} is missing required credential material: " +
+                $"{RequiredServerMaterial(auth.Type)}. Refusing to start (fail-closed).");
 
-            services
-                .AddAuthentication(options =>
-                {
-                    options.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
-                    options.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
-                })
-                .AddJwtBearer(options =>
-                {
-                    options.Authority = authority;
-                    options.Audience = audience;
-                    options.TokenValidationParameters = new TokenValidationParameters
-                    {
-                        ValidateIssuer = true,
-                        ValidIssuers =
-                        [
-                            $"https://sts.windows.net/{auth.TenantId}/",
-                            $"https://login.microsoftonline.com/{auth.TenantId}/v2.0"
-                        ],
-                        ValidateAudience = true,
-                        ValidAudience = audience,
-                        ValidateLifetime = true,
-                        ValidateIssuerSigningKey = true,
-                        ClockSkew = TimeSpan.Zero
-                    };
-                });
+        switch (auth.Type)
+        {
+            case McpServerAuthType.ApiKey:
+                AddApiKeyScheme(services, auth);
+                break;
+            case McpServerAuthType.Bearer:
+                AddSharedBearerScheme(services, auth);
+                break;
+            case McpServerAuthType.Entra:
+                AddEntraScheme(services, auth);
+                break;
+            default:
+                throw new InvalidOperationException(
+                    $"Unsupported MCP server authentication type '{auth.Type}'. Refusing to start (fail-closed).");
         }
 
-        services.AddAuthorization();
+        // Fallback policy closes the unmapped-endpoint gap: an endpoint added without
+        // explicit authorization metadata still requires an authenticated caller.
+        services.AddAuthorization(options =>
+            options.FallbackPolicy = new AuthorizationPolicyBuilder()
+                .RequireAuthenticatedUser()
+                .Build());
+
         return services;
+    }
+
+    /// <summary>
+    /// Describes the credential material a server-side auth type requires, for
+    /// startup error messages (names config keys only — never secret values).
+    /// </summary>
+    private static string RequiredServerMaterial(McpServerAuthType type) => type switch
+    {
+        McpServerAuthType.ApiKey => "ApiKey (the shared key inbound requests must present)",
+        McpServerAuthType.Bearer => "BearerToken (the shared token inbound requests must present)",
+        McpServerAuthType.Entra => "TenantId and ClientId (issuer and audience validation)",
+        _ => "a supported authentication type"
+    };
+
+    /// <summary>Registers API-key authentication on the configured header.</summary>
+    private static void AddApiKeyScheme(IServiceCollection services, McpServerAuthConfig auth)
+    {
+        services
+            .AddAuthentication(McpSharedKeyAuthenticationDefaults.ApiKeyScheme)
+            .AddScheme<McpSharedKeyAuthenticationOptions, McpSharedKeyAuthenticationHandler>(
+                McpSharedKeyAuthenticationDefaults.ApiKeyScheme, options =>
+                {
+                    options.HeaderName = auth.ApiKeyHeader;
+                    options.ExpectedCredential = auth.ApiKey!;
+                });
+    }
+
+    /// <summary>
+    /// Registers static shared-token authentication on <c>Authorization: Bearer</c>.
+    /// </summary>
+    private static void AddSharedBearerScheme(IServiceCollection services, McpServerAuthConfig auth)
+    {
+        services
+            .AddAuthentication(McpSharedKeyAuthenticationDefaults.BearerScheme)
+            .AddScheme<McpSharedKeyAuthenticationOptions, McpSharedKeyAuthenticationHandler>(
+                McpSharedKeyAuthenticationDefaults.BearerScheme, options =>
+                {
+                    options.HeaderName = HeaderNames.Authorization;
+                    options.ValuePrefix = "Bearer ";
+                    options.ExpectedCredential = auth.BearerToken!;
+                });
+    }
+
+    /// <summary>
+    /// Registers Entra ID JWT bearer validation (issuer + audience + lifetime +
+    /// signing key, zero clock skew) per the repo security baseline.
+    /// </summary>
+    private static void AddEntraScheme(IServiceCollection services, McpServerAuthConfig auth)
+    {
+        var authority = $"https://login.microsoftonline.com/{auth.TenantId}/v2.0";
+        var audience = $"api://{auth.ClientId}";
+
+        services
+            .AddAuthentication(options =>
+            {
+                options.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
+                options.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
+            })
+            .AddJwtBearer(options =>
+            {
+                options.Authority = authority;
+                options.Audience = audience;
+                options.TokenValidationParameters = new TokenValidationParameters
+                {
+                    ValidateIssuer = true,
+                    ValidIssuers =
+                    [
+                        $"https://sts.windows.net/{auth.TenantId}/",
+                        $"https://login.microsoftonline.com/{auth.TenantId}/v2.0"
+                    ],
+                    ValidateAudience = true,
+                    ValidAudience = audience,
+                    ValidateLifetime = true,
+                    ValidateIssuerSigningKey = true,
+                    ClockSkew = TimeSpan.Zero
+                };
+            });
     }
 
     private static McpRequestHandler<SubscribeRequestParams, EmptyResult>

--- a/src/Content/Infrastructure/Infrastructure.AI.MCPServer/Program.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.MCPServer/Program.cs
@@ -11,7 +11,11 @@ namespace Infrastructure.AI.MCPServer;
 /// Entry point for the agentic harness MCP server.
 /// Exposes tools, prompts, and resources via MCP protocol over HTTP transport.
 /// </summary>
-public static class Program
+/// <remarks>
+/// Non-static so integration tests can host the full pipeline via
+/// <c>WebApplicationFactory&lt;Program&gt;</c> (static types cannot be type arguments).
+/// </remarks>
+public class Program
 {
     public static void Main(string[] args)
     {
@@ -27,7 +31,9 @@ public static class Program
             .Get<AppConfig>() ?? new AppConfig();
 
         builder.Services.AddMcpServerServices(appConfig);
-        builder.Services.AddMcpAuthentication(appConfig, builder.Configuration, builder.Environment);
+        // Fail-closed: throws unless an auth scheme is configured or the operator
+        // explicitly opted into anonymous serving — regardless of environment.
+        builder.Services.AddMcpAuthentication(appConfig);
 
         // Skill catalog — discovered from the configured skills directory
         builder.Services.AddSingleton<SkillMetadataParser>();
@@ -57,10 +63,16 @@ public static class Program
         app.UseAuthorization();
         app.UseRateLimiter();
 
-        // Map MCP endpoints with auth + rate limiting
-        app.MapMcp()
-            .RequireAuthorization()
-            .RequireRateLimiting("mcp");
+        // Map MCP endpoints with auth + rate limiting. Authorization is mandatory on
+        // every MCP endpoint; the only exception is the explicit AllowAnonymous
+        // opt-in, made visible here as a deliberate .AllowAnonymous() rather than a
+        // silently weakened policy. AddMcpAuthentication has already validated the
+        // config, so these two flags are mutually exclusive.
+        var mcpEndpoints = app.MapMcp().RequireRateLimiting("mcp");
+        if (appConfig.AI.MCP.Auth.AllowAnonymous)
+            mcpEndpoints.AllowAnonymous();
+        else
+            mcpEndpoints.RequireAuthorization();
 
         app.Run();
     }

--- a/src/Content/Infrastructure/Infrastructure.AI.MCPServer/README.md
+++ b/src/Content/Infrastructure/Infrastructure.AI.MCPServer/README.md
@@ -22,7 +22,7 @@ External MCP Clients
 |       Infrastructure.AI.MCPServer              |
 |                                                |
 |  ASP.NET Core Pipeline:                        |
-|    Authentication (JWT Bearer / anonymous)     |
+|    Authentication (ApiKey / Bearer / Entra)    |
 |    Authorization                               |
 |    Rate Limiting (fixed window)                |
 |    MCP Endpoint (/mcp)                         |
@@ -53,16 +53,18 @@ External MCP Clients
 **How the startup works (Program.cs):**
 1. Bind `AppConfig` from configuration.
 2. Register MCP server services with HTTP transport.
-3. Configure JWT Bearer authentication (Entra ID or anonymous for dev).
+3. Configure authentication **fail-closed**: ApiKey, static Bearer token, or Entra ID (JWT). If no scheme is properly configured and `Auth.AllowAnonymous` is not explicitly `true`, the host throws at startup — in every environment, including Development.
 4. Register the skill catalog (`SkillMetadataRegistry`) for tool queries.
 5. Add rate limiting (100 requests/minute per client).
 6. Build the pipeline: Authentication -> Authorization -> Rate Limiter -> MCP endpoint.
-7. Map the MCP endpoint at the root with auth + rate limiting required.
+7. Map the MCP endpoint at the root with auth + rate limiting required (or a deliberate `.AllowAnonymous()` when the opt-in is set).
 
 ```csharp
-app.MapMcp()
-    .RequireAuthorization()
-    .RequireRateLimiting("mcp");
+var mcpEndpoints = app.MapMcp().RequireRateLimiting("mcp");
+if (appConfig.AI.MCP.Auth.AllowAnonymous)
+    mcpEndpoints.AllowAnonymous();
+else
+    mcpEndpoints.RequireAuthorization();
 ```
 
 ### SkillTools (Built-in MCP Tools)
@@ -107,18 +109,23 @@ app.MapMcp()
 - Each loads assemblies by name via `Assembly.Load()` and registers any types decorated with `[McpServerToolType]`, `[McpServerPromptType]`, or `[McpServerResourceType]`.
 - The built-in assembly (containing `SkillTools`) is always loaded first.
 
-### Authentication
+### Authentication (fail-closed)
 
-**What it is:** JWT Bearer authentication using Microsoft Entra ID (Azure AD).
+**What it is:** Mandatory authentication on every MCP endpoint, supporting three schemes — API key header, static Bearer token, and Entra ID JWT — with a fail-closed startup contract.
 
-**Why it exists:** MCP servers should not be open to the internet without authentication. The server validates JWT tokens issued by Entra ID, checking issuer, audience, lifetime, and signing key.
+**Why it exists:** MCP servers must never silently end up open. If authentication is absent or misconfigured, the host refuses to start with a clear error instead of booting anonymous. The environment name is never an implicit bypass.
 
 **How it works:**
-- When `McpConfig.Auth.IsConfigured` is true and `Auth.Type == Entra`:
+- `Auth.Type == ApiKey`: inbound requests must present the shared key in the configured header (default `X-API-Key`). Compared in constant time.
+- `Auth.Type == Bearer`: inbound requests must present the shared token as `Authorization: Bearer {token}`. Compared in constant time.
+- `Auth.Type == Entra`: JWT Bearer validation —
   - Authority: `https://login.microsoftonline.com/{TenantId}/v2.0`
   - Audience: `api://{ClientId}`
   - Token validation: issuer, audience, lifetime, signing key, zero clock skew
-- When auth is not configured (development): anonymous access is allowed via null fallback policy.
+- `Auth.Type == None` and `Auth.AllowAnonymous == false` (the default): the host **throws at startup** in every environment.
+- `Auth.Type == None` and `Auth.AllowAnonymous == true`: the explicit local-development opt-in. The server serves anonymously and logs a prominent warning at startup. Combining `AllowAnonymous=true` with a configured type is rejected as contradictory.
+- A configured type missing its credential material (e.g. `ApiKey` with no key, `Entra` with no `TenantId`) also fails at startup.
+- When authentication is configured, a fallback authorization policy (`RequireAuthenticatedUser`) covers any endpoint mapped without explicit authorization metadata, and a per-tool-call gate (`McpToolAuthorizationFilter`) re-checks the principal at the dispatch layer as defense-in-depth.
 
 ### Rate Limiting
 
@@ -167,8 +174,15 @@ External MCP Client (e.g., Claude Desktop)
 
 ```
 Infrastructure.AI.MCPServer/
+├── Authentication/
+│   ├── McpSharedKeyAuthenticationDefaults.cs   Scheme name constants (ApiKey / shared Bearer)
+│   ├── McpSharedKeyAuthenticationOptions.cs    Header, prefix, expected credential + validation
+│   ├── McpSharedKeyAuthenticationHandler.cs    Constant-time shared-secret authentication
+│   └── McpAnonymousModeStartupWarning.cs       Prominent warning while AllowAnonymous=true
+├── Authorization/
+│   └── McpToolAuthorizationFilter.cs   Per-tool-call gate (defense-in-depth)
 ├── Extensions/
-│   ├── McpServerExtensions.cs          Server setup, auth, subscription handlers
+│   ├── McpServerExtensions.cs          Server setup, fail-closed auth, subscription handlers
 │   └── McpServerBuilderExtensions.cs   Assembly scanning for tools/prompts/resources
 ├── Tools/
 │   └── SkillTools.cs                   list_skills, get_skill, find_skills_by_tag
@@ -202,10 +216,12 @@ Infrastructure.AI.MCPServer/
           "MyCustomTools.Assembly"
         ],
         "Auth": {
-          "IsConfigured": true,                    // false = anonymous (dev only)
-          "Type": "Entra",                         // Only Entra supported currently
-          "TenantId": "xxxxxxxx-xxxx-...",         // Azure AD tenant
-          "ClientId": "yyyyyyyy-yyyy-..."          // App registration client ID
+          "Type": "Entra",                         // None | ApiKey | Bearer | Entra
+          "AllowAnonymous": false,                 // Explicit dev-only opt-in; default false (fail-closed)
+          "TenantId": "xxxxxxxx-xxxx-...",         // Entra: Azure AD tenant
+          "ClientId": "yyyyyyyy-yyyy-...",         // Entra: app registration client ID
+          "ApiKeyHeader": "X-API-Key"              // ApiKey: header name (key itself via User Secrets/Key Vault)
+          // "ApiKey" / "BearerToken": supply via User Secrets or Key Vault — never appsettings.json
         }
       }
     }
@@ -217,7 +233,10 @@ Infrastructure.AI.MCPServer/
 
 | Setting | Purpose | Recommendation |
 |---------|---------|---------------|
-| `Auth.IsConfigured` | Enables/disables auth | Always `true` in production |
+| `Auth.Type` | Selects the enforcement scheme (`ApiKey`, `Bearer`, `Entra`) | `Entra` in production; `None` refuses to start unless `AllowAnonymous=true` |
+| `Auth.AllowAnonymous` | Explicit opt-in to serve without authentication | Never in production; logs a prominent startup warning while on |
+| `Auth.ApiKey` / `Auth.BearerToken` | Shared credential inbound requests must present | User Secrets or Key Vault only |
+| `Auth.ApiKeyHeader` | Header carrying the API key | Default `X-API-Key` |
 | `Auth.TenantId` | Entra tenant for token validation | Your organization's tenant |
 | `Auth.ClientId` | App registration for audience validation | Dedicated app registration |
 | Rate limit | 100 requests per minute per partition | Tune based on expected load |
@@ -278,7 +297,7 @@ Or configure Claude Desktop's `claude_desktop_config.json`:
 1. Verify `Auth.TenantId` and `Auth.ClientId` match your Entra app registration.
 2. Check that the token's `aud` claim matches `api://{ClientId}`.
 3. Check that the token's `iss` claim matches one of the two valid issuer patterns.
-4. For development, set `Auth.IsConfigured = false` to bypass auth entirely.
+4. If the host refuses to start with a fail-closed error, that is intentional: configure `Auth.Type` with its credential material, or — for local development only — consciously set `Auth.AllowAnonymous = true` (a warning is logged at startup while it is on). Running under `ASPNETCORE_ENVIRONMENT=Development` does not bypass authentication.
 
 ## Dependencies
 

--- a/src/Content/Infrastructure/Infrastructure.AI.MCPServer/appsettings.json
+++ b/src/Content/Infrastructure/Infrastructure.AI.MCPServer/appsettings.json
@@ -8,7 +8,8 @@
         "InitializationTimeout": "00:01:00",
         "ScanAssemblies": [],
         "Auth": {
-          "Type": "None"
+          "Type": "None",
+          "AllowAnonymous": false
         }
       }
     }

--- a/src/Content/Tests/Infrastructure.AI.MCPServer.Tests/Authentication/McpSharedKeyAuthenticationTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.MCPServer.Tests/Authentication/McpSharedKeyAuthenticationTests.cs
@@ -1,0 +1,132 @@
+using Domain.Common.Config.AI.MCP;
+using FluentAssertions;
+using Infrastructure.AI.MCPServer.Authentication;
+using Xunit;
+
+namespace Infrastructure.AI.MCPServer.Tests.Authentication;
+
+/// <summary>
+/// Unit tests for the shared-key authentication building blocks: constant-time
+/// credential comparison, options validation, and the server-side config validity
+/// rules that back the fail-closed startup check.
+/// </summary>
+public sealed class McpSharedKeyAuthenticationTests
+{
+    // -- CredentialsMatch --
+
+    [Fact]
+    public void CredentialsMatch_SameValue_ReturnsTrue() =>
+        McpSharedKeyAuthenticationHandler.CredentialsMatch("key-123", "key-123")
+            .Should().BeTrue();
+
+    [Theory]
+    [InlineData("key-123", "key-124")]
+    [InlineData("key-123", "key-1234")]
+    [InlineData("key-123", "")]
+    [InlineData("", "key-123")]
+    [InlineData("KEY-123", "key-123")]
+    public void CredentialsMatch_DifferentValues_ReturnsFalse(string presented, string expected) =>
+        McpSharedKeyAuthenticationHandler.CredentialsMatch(presented, expected)
+            .Should().BeFalse();
+
+    // -- Options validation --
+
+    [Fact]
+    public void OptionsValidate_MissingExpectedCredential_Throws()
+    {
+        var options = new McpSharedKeyAuthenticationOptions { HeaderName = "X-API-Key" };
+
+        Action act = options.Validate;
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*ExpectedCredential*");
+    }
+
+    [Fact]
+    public void OptionsValidate_MissingHeaderName_Throws()
+    {
+        var options = new McpSharedKeyAuthenticationOptions
+        {
+            HeaderName = " ",
+            ExpectedCredential = "test-key-not-a-real-secret"
+        };
+
+        Action act = options.Validate;
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*HeaderName*");
+    }
+
+    [Fact]
+    public void OptionsValidate_FullyConfigured_DoesNotThrow()
+    {
+        var options = new McpSharedKeyAuthenticationOptions
+        {
+            HeaderName = "X-API-Key",
+            ExpectedCredential = "test-key-not-a-real-secret"
+        };
+
+        Action act = options.Validate;
+
+        act.Should().NotThrow();
+    }
+
+    // -- Server-side config validity (backs the fail-closed startup check) --
+
+    [Fact]
+    public void IsValidForServer_None_IsTrue() =>
+        new McpServerAuthConfig().IsValidForServer.Should().BeTrue();
+
+    [Fact]
+    public void IsValidForServer_ApiKeyWithoutKey_IsFalse() =>
+        new McpServerAuthConfig { Type = McpServerAuthType.ApiKey }
+            .IsValidForServer.Should().BeFalse();
+
+    [Fact]
+    public void IsValidForServer_ApiKeyWithKey_IsTrue() =>
+        new McpServerAuthConfig
+        {
+            Type = McpServerAuthType.ApiKey,
+            ApiKey = "test-key-not-a-real-secret"
+        }.IsValidForServer.Should().BeTrue();
+
+    [Fact]
+    public void IsValidForServer_BearerWithoutToken_IsFalse() =>
+        new McpServerAuthConfig { Type = McpServerAuthType.Bearer }
+            .IsValidForServer.Should().BeFalse();
+
+    [Fact]
+    public void IsValidForServer_BearerWithToken_IsTrue() =>
+        new McpServerAuthConfig
+        {
+            Type = McpServerAuthType.Bearer,
+            BearerToken = "test-token-not-a-real-secret"
+        }.IsValidForServer.Should().BeTrue();
+
+    [Theory]
+    [InlineData(null, "client-id")]
+    [InlineData("tenant-id", null)]
+    [InlineData(null, null)]
+    public void IsValidForServer_EntraMissingTenantOrClient_IsFalse(string? tenantId, string? clientId) =>
+        new McpServerAuthConfig
+        {
+            Type = McpServerAuthType.Entra,
+            TenantId = tenantId,
+            ClientId = clientId
+        }.IsValidForServer.Should().BeFalse();
+
+    [Fact]
+    public void IsValidForServer_EntraWithTenantAndClient_IsTrue_WithoutClientSecretOrScopes() =>
+        new McpServerAuthConfig
+        {
+            Type = McpServerAuthType.Entra,
+            TenantId = "tenant-id",
+            ClientId = "client-id"
+        }.IsValidForServer.Should().BeTrue(
+            "server-side validation only checks issuer/audience material — it never mints tokens");
+
+    [Fact]
+    public void AllowAnonymous_DefaultsToFalse() =>
+        new McpServerAuthConfig().AllowAnonymous.Should().BeFalse(
+            "the MCP server must be fail-closed by default");
+}

--- a/src/Content/Tests/Infrastructure.AI.MCPServer.Tests/Extensions/McpServerExtensionsTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.MCPServer.Tests/Extensions/McpServerExtensionsTests.cs
@@ -3,11 +3,9 @@ using Domain.Common.Config;
 using Domain.Common.Config.AI;
 using Domain.Common.Config.AI.MCP;
 using FluentAssertions;
+using Infrastructure.AI.MCPServer.Authentication;
 using Infrastructure.AI.MCPServer.Extensions;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
-using Moq;
 using Xunit;
 
 namespace Infrastructure.AI.MCPServer.Tests.Extensions;
@@ -18,13 +16,6 @@ namespace Infrastructure.AI.MCPServer.Tests.Extensions;
 /// </summary>
 public sealed class McpServerExtensionsTests
 {
-    private static IHostEnvironment CreateDevelopmentEnvironment()
-    {
-        var mock = new Mock<IHostEnvironment>();
-        mock.Setup(e => e.EnvironmentName).Returns("Development");
-        return mock.Object;
-    }
-
     private static AppConfig CreateAppConfig(
         string serverName = "test-harness",
         string serverVersion = "1.0.0",
@@ -97,15 +88,76 @@ public sealed class McpServerExtensionsTests
     // -- AddMcpAuthentication --
 
     [Fact]
-    public void AddMcpAuthentication_NoAuthConfigured_RegistersAnonymousAuth()
+    public void AddMcpAuthentication_NoAuthConfigured_ThrowsFailClosed()
     {
         var services = new ServiceCollection();
         var appConfig = CreateAppConfig();
-        var configuration = new ConfigurationBuilder().Build();
 
-        services.AddMcpAuthentication(appConfig, configuration, CreateDevelopmentEnvironment());
+        var act = () => services.AddMcpAuthentication(appConfig);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*fail-closed*");
+    }
+
+    [Fact]
+    public void AddMcpAuthentication_AllowAnonymous_RegistersAuthAndStartupWarning()
+    {
+        var services = new ServiceCollection();
+        var appConfig = CreateAppConfig(auth: new McpServerAuthConfig { AllowAnonymous = true });
+
+        services.AddMcpAuthentication(appConfig);
 
         services.Any(d => d.ServiceType.Name.Contains("Authentication")).Should().BeTrue();
+        services.Any(d => d.ServiceType.Name.Contains("Authorization")).Should().BeTrue();
+        services.Any(d => d.ImplementationType == typeof(McpAnonymousModeStartupWarning))
+            .Should().BeTrue("anonymous mode must log a prominent startup warning");
+    }
+
+    [Fact]
+    public void AddMcpAuthentication_AllowAnonymousWithConfiguredType_ThrowsContradiction()
+    {
+        var services = new ServiceCollection();
+        var appConfig = CreateAppConfig(auth: new McpServerAuthConfig
+        {
+            Type = McpServerAuthType.ApiKey,
+            ApiKey = "test-key-not-a-real-secret",
+            AllowAnonymous = true
+        });
+
+        var act = () => services.AddMcpAuthentication(appConfig);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*AllowAnonymous*");
+    }
+
+    [Theory]
+    [InlineData(McpServerAuthType.ApiKey)]
+    [InlineData(McpServerAuthType.Bearer)]
+    public void AddMcpAuthentication_TypeWithoutKeyMaterial_ThrowsFailClosed(McpServerAuthType type)
+    {
+        var services = new ServiceCollection();
+        var appConfig = CreateAppConfig(auth: new McpServerAuthConfig { Type = type });
+
+        var act = () => services.AddMcpAuthentication(appConfig);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*missing required credential material*");
+    }
+
+    [Fact]
+    public void AddMcpAuthentication_EntraMissingTenant_ThrowsFailClosed()
+    {
+        var services = new ServiceCollection();
+        var appConfig = CreateAppConfig(auth: new McpServerAuthConfig
+        {
+            Type = McpServerAuthType.Entra,
+            ClientId = "test-client-id"
+        });
+
+        var act = () => services.AddMcpAuthentication(appConfig);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*missing required credential material*");
     }
 
     [Fact]
@@ -119,22 +171,29 @@ public sealed class McpServerExtensionsTests
             ClientId = "test-client-id"
         };
         var appConfig = CreateAppConfig(auth: auth);
-        var configuration = new ConfigurationBuilder().Build();
 
-        services.AddMcpAuthentication(appConfig, configuration, CreateDevelopmentEnvironment());
+        services.AddMcpAuthentication(appConfig);
 
         services.Any(d => d.ServiceType.Name.Contains("Authentication")).Should().BeTrue();
     }
 
-    [Fact]
-    public void AddMcpAuthentication_NoAuth_RegistersAuthorizationServices()
+    [Theory]
+    [InlineData(McpServerAuthType.ApiKey)]
+    [InlineData(McpServerAuthType.Bearer)]
+    public void AddMcpAuthentication_SharedKeyTypes_RegisterAuthenticationServices(McpServerAuthType type)
     {
         var services = new ServiceCollection();
-        var appConfig = CreateAppConfig();
-        var configuration = new ConfigurationBuilder().Build();
+        var auth = new McpServerAuthConfig
+        {
+            Type = type,
+            ApiKey = "test-key-not-a-real-secret",
+            BearerToken = "test-token-not-a-real-secret"
+        };
+        var appConfig = CreateAppConfig(auth: auth);
 
-        services.AddMcpAuthentication(appConfig, configuration, CreateDevelopmentEnvironment());
+        services.AddMcpAuthentication(appConfig);
 
+        services.Any(d => d.ServiceType.Name.Contains("Authentication")).Should().BeTrue();
         services.Any(d => d.ServiceType.Name.Contains("Authorization")).Should().BeTrue();
     }
 
@@ -142,12 +201,9 @@ public sealed class McpServerExtensionsTests
     public void AddMcpAuthentication_ReturnsSameServiceCollection()
     {
         var services = new ServiceCollection();
-        var appConfig = CreateAppConfig();
-        var configuration = new ConfigurationBuilder().Build();
+        var appConfig = CreateAppConfig(auth: new McpServerAuthConfig { AllowAnonymous = true });
 
-        var environment = CreateDevelopmentEnvironment();
-
-        var result = services.AddMcpAuthentication(appConfig, configuration, environment);
+        var result = services.AddMcpAuthentication(appConfig);
 
         result.Should().BeSameAs(services);
     }

--- a/src/Content/Tests/Infrastructure.AI.MCPServer.Tests/Hosting/McpServerAuthFailClosedTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.MCPServer.Tests/Hosting/McpServerAuthFailClosedTests.cs
@@ -172,6 +172,59 @@ public sealed class McpServerAuthFailClosedTests
             $"a correctly authenticated MCP initialize must be served (got {(int)response.StatusCode})");
     }
 
+    // RFC 7235: the auth-scheme token is case-insensitive and standards-compliant
+    // clients may send extra whitespace between scheme and credential.
+
+    [Theory]
+    [InlineData("bearer")]
+    [InlineData("BEARER")]
+    [InlineData("BeArEr")]
+    public async Task Request_BearerConfigured_SchemeCaseInsensitive_IsServed(string scheme)
+    {
+        using var factory = CreateBearerFactory();
+        using var client = factory.CreateClient();
+
+        var request = CreateInitializeRequest();
+        request.Headers.TryAddWithoutValidation("Authorization", $"{scheme} {TestBearerToken}")
+            .Should().BeTrue();
+
+        using var response = await client.SendAsync(request);
+
+        response.IsSuccessStatusCode.Should().BeTrue(
+            $"RFC 7235 auth-scheme names are case-insensitive (got {(int)response.StatusCode})");
+    }
+
+    [Fact]
+    public async Task Request_BearerConfigured_ExtraWhitespaceAfterScheme_IsServed()
+    {
+        using var factory = CreateBearerFactory();
+        using var client = factory.CreateClient();
+
+        var request = CreateInitializeRequest();
+        request.Headers.TryAddWithoutValidation("Authorization", $"Bearer   {TestBearerToken}")
+            .Should().BeTrue();
+
+        using var response = await client.SendAsync(request);
+
+        response.IsSuccessStatusCode.Should().BeTrue(
+            $"whitespace between scheme and credential is tolerated (got {(int)response.StatusCode})");
+    }
+
+    [Fact]
+    public async Task Request_BearerConfigured_WrongTokenUnderLowercaseScheme_Returns401()
+    {
+        using var factory = CreateBearerFactory();
+        using var client = factory.CreateClient();
+
+        var request = CreateInitializeRequest();
+        request.Headers.TryAddWithoutValidation("Authorization", "bearer wrong-token")
+            .Should().BeTrue();
+
+        using var response = await client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
     // -- Entra (JWT) enforcement --
 
     [Fact]

--- a/src/Content/Tests/Infrastructure.AI.MCPServer.Tests/Hosting/McpServerAuthFailClosedTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.MCPServer.Tests/Hosting/McpServerAuthFailClosedTests.cs
@@ -1,0 +1,340 @@
+using System.Collections.Concurrent;
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text;
+using FluentAssertions;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace Infrastructure.AI.MCPServer.Tests.Hosting;
+
+/// <summary>
+/// Full-host integration tests proving the MCP server is fail-closed: it refuses to
+/// start when no authentication is configured, enforces ApiKey / Bearer / Entra
+/// credentials on the MCP endpoints, and serves anonymously only behind the explicit
+/// <c>AppConfig:AI:MCP:Auth:AllowAnonymous</c> opt-in (with a prominent startup warning).
+/// </summary>
+public sealed class McpServerAuthFailClosedTests
+{
+    private const string TestApiKey = "test-api-key-not-a-real-secret";
+    private const string TestBearerToken = "test-bearer-token-not-a-real-secret";
+
+    // -- Startup fail-closed --
+
+    [Theory]
+    [InlineData("Development")]
+    [InlineData("Production")]
+    public void Start_NoAuthConfigured_AllowAnonymousFalse_RefusesToStart(string environment)
+    {
+        // Environment name alone must never open the server: with Type=None and no
+        // explicit AllowAnonymous opt-in, the host must fail at startup in EVERY
+        // environment — including Development.
+        var act = () => CreateFactory(new Dictionary<string, string?>
+        {
+            ["AppConfig:AI:MCP:Auth:Type"] = "None"
+        }, environment);
+
+        act.Should().Throw<Exception>()
+            .Which.Should().Match<Exception>(e =>
+                FlattenMessages(e).Contains("authentication is not configured", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void Start_ApiKeyTypeWithoutKeyMaterial_RefusesToStart()
+    {
+        // Type=ApiKey with no key is a misconfiguration — it must fail loudly at
+        // startup, never boot un-enforced.
+        var act = () => CreateFactory(new Dictionary<string, string?>
+        {
+            ["AppConfig:AI:MCP:Auth:Type"] = "ApiKey"
+        });
+
+        act.Should().Throw<Exception>()
+            .Which.Should().Match<Exception>(e =>
+                FlattenMessages(e).Contains("missing required credential material", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void Start_EntraTypeMissingTenant_RefusesToStart()
+    {
+        var act = () => CreateFactory(new Dictionary<string, string?>
+        {
+            ["AppConfig:AI:MCP:Auth:Type"] = "Entra",
+            ["AppConfig:AI:MCP:Auth:ClientId"] = "test-client-id"
+        });
+
+        act.Should().Throw<Exception>()
+            .Which.Should().Match<Exception>(e =>
+                FlattenMessages(e).Contains("missing required credential material", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void Start_AllowAnonymousTrue_WithAuthConfigured_RefusesToStart()
+    {
+        // Contradictory config: an explicit anonymous opt-in combined with configured
+        // credentials is ambiguous — fail loudly instead of guessing.
+        var act = () => CreateFactory(new Dictionary<string, string?>
+        {
+            ["AppConfig:AI:MCP:Auth:Type"] = "ApiKey",
+            ["AppConfig:AI:MCP:Auth:ApiKey"] = TestApiKey,
+            ["AppConfig:AI:MCP:Auth:AllowAnonymous"] = "true"
+        });
+
+        act.Should().Throw<Exception>()
+            .Which.Should().Match<Exception>(e =>
+                FlattenMessages(e).Contains("contradictory", StringComparison.OrdinalIgnoreCase));
+    }
+
+    // -- ApiKey enforcement --
+
+    [Fact]
+    public async Task Request_ApiKeyConfigured_NoCredential_Returns401()
+    {
+        using var factory = CreateApiKeyFactory();
+        using var client = factory.CreateClient();
+
+        using var response = await client.SendAsync(CreateInitializeRequest());
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task Request_ApiKeyConfigured_WrongKey_Returns401()
+    {
+        using var factory = CreateApiKeyFactory();
+        using var client = factory.CreateClient();
+
+        var request = CreateInitializeRequest();
+        request.Headers.Add("X-API-Key", "wrong-key");
+
+        using var response = await client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task Request_ApiKeyConfigured_CorrectKey_IsServed()
+    {
+        using var factory = CreateApiKeyFactory();
+        using var client = factory.CreateClient();
+
+        var request = CreateInitializeRequest();
+        request.Headers.Add("X-API-Key", TestApiKey);
+
+        using var response = await client.SendAsync(request);
+
+        response.IsSuccessStatusCode.Should().BeTrue(
+            $"a correctly authenticated MCP initialize must be served (got {(int)response.StatusCode})");
+    }
+
+    // -- Bearer (static shared token) enforcement --
+
+    [Fact]
+    public async Task Request_BearerConfigured_NoCredential_Returns401()
+    {
+        using var factory = CreateBearerFactory();
+        using var client = factory.CreateClient();
+
+        using var response = await client.SendAsync(CreateInitializeRequest());
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task Request_BearerConfigured_WrongToken_Returns401()
+    {
+        using var factory = CreateBearerFactory();
+        using var client = factory.CreateClient();
+
+        var request = CreateInitializeRequest();
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", "wrong-token");
+
+        using var response = await client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task Request_BearerConfigured_CorrectToken_IsServed()
+    {
+        using var factory = CreateBearerFactory();
+        using var client = factory.CreateClient();
+
+        var request = CreateInitializeRequest();
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", TestBearerToken);
+
+        using var response = await client.SendAsync(request);
+
+        response.IsSuccessStatusCode.Should().BeTrue(
+            $"a correctly authenticated MCP initialize must be served (got {(int)response.StatusCode})");
+    }
+
+    // -- Entra (JWT) enforcement --
+
+    [Fact]
+    public async Task Request_EntraConfigured_NoToken_Returns401()
+    {
+        using var factory = CreateFactory(new Dictionary<string, string?>
+        {
+            ["AppConfig:AI:MCP:Auth:Type"] = "Entra",
+            ["AppConfig:AI:MCP:Auth:TenantId"] = "00000000-0000-0000-0000-000000000001",
+            ["AppConfig:AI:MCP:Auth:ClientId"] = "00000000-0000-0000-0000-000000000002"
+        });
+        using var client = factory.CreateClient();
+
+        using var response = await client.SendAsync(CreateInitializeRequest());
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    // -- Explicit dev anonymous opt-in --
+
+    [Fact]
+    public async Task Request_AllowAnonymousTrue_IsServedAnonymously_AndWarningLogged()
+    {
+        var logs = new CapturingLoggerProvider();
+        using var factory = CreateFactory(new Dictionary<string, string?>
+        {
+            ["AppConfig:AI:MCP:Auth:Type"] = "None",
+            ["AppConfig:AI:MCP:Auth:AllowAnonymous"] = "true"
+        }, loggerProvider: logs);
+        using var client = factory.CreateClient();
+
+        using var response = await client.SendAsync(CreateInitializeRequest());
+
+        response.IsSuccessStatusCode.Should().BeTrue(
+            $"AllowAnonymous=true is the explicit opt-in for anonymous serving (got {(int)response.StatusCode})");
+        logs.Messages.Should().Contain(
+            m => m.StartsWith("Warning:", StringComparison.Ordinal)
+                 && m.Contains("ANONYMOUS", StringComparison.OrdinalIgnoreCase),
+            "disabling authentication must log a prominent startup warning");
+    }
+
+    // -- Helpers --
+
+    /// <summary>
+    /// Serializes environment-variable overrides across factory startups: xUnit runs
+    /// tests within this class sequentially, but the lock also guards against any
+    /// future parallel host-booting test class.
+    /// </summary>
+    private static readonly object EnvironmentLock = new();
+
+    /// <summary>
+    /// Boots the full MCP server host with the given config overrides applied as
+    /// environment variables. Env vars are the only default configuration source that
+    /// both outranks appsettings.json and is visible to Program.Main's eager
+    /// <c>builder.Configuration.GetSection("AppConfig").Get&lt;AppConfig&gt;()</c> read —
+    /// WebApplicationFactory's ConfigureAppConfiguration overrides apply too late for it.
+    /// Startup is forced inside the override scope; startup failures propagate to the caller.
+    /// </summary>
+    private static WebApplicationFactory<Program> CreateFactory(
+        Dictionary<string, string?> settings,
+        string environment = "Development",
+        ILoggerProvider? loggerProvider = null)
+    {
+        lock (EnvironmentLock)
+        {
+            var variables = settings.ToDictionary(
+                pair => pair.Key.Replace(":", "__", StringComparison.Ordinal),
+                pair => pair.Value);
+            foreach (var (key, value) in variables)
+                Environment.SetEnvironmentVariable(key, value);
+
+            var factory = new WebApplicationFactory<Program>().WithWebHostBuilder(builder =>
+            {
+                builder.UseEnvironment(environment);
+                if (loggerProvider is not null)
+                    builder.ConfigureLogging(logging => logging.AddProvider(loggerProvider));
+            });
+
+            try
+            {
+                _ = factory.Server; // Force host startup while the overrides are visible.
+                return factory;
+            }
+            catch
+            {
+                factory.Dispose();
+                throw;
+            }
+            finally
+            {
+                foreach (var key in variables.Keys)
+                    Environment.SetEnvironmentVariable(key, null);
+            }
+        }
+    }
+
+    private static WebApplicationFactory<Program> CreateApiKeyFactory() =>
+        CreateFactory(new Dictionary<string, string?>
+        {
+            ["AppConfig:AI:MCP:Auth:Type"] = "ApiKey",
+            ["AppConfig:AI:MCP:Auth:ApiKey"] = TestApiKey
+        });
+
+    private static WebApplicationFactory<Program> CreateBearerFactory() =>
+        CreateFactory(new Dictionary<string, string?>
+        {
+            ["AppConfig:AI:MCP:Auth:Type"] = "Bearer",
+            ["AppConfig:AI:MCP:Auth:BearerToken"] = TestBearerToken
+        });
+
+    /// <summary>
+    /// Builds an MCP <c>initialize</c> JSON-RPC request against the streamable HTTP
+    /// endpoint — the entry point every MCP client must call first, and therefore the
+    /// canonical probe for whether the server serves protocol traffic.
+    /// </summary>
+    private static HttpRequestMessage CreateInitializeRequest()
+    {
+        const string body = """
+            {"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"auth-tests","version":"1.0"}}}
+            """;
+        var request = new HttpRequestMessage(HttpMethod.Post, "/")
+        {
+            Content = new StringContent(body, Encoding.UTF8, "application/json")
+        };
+        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("text/event-stream"));
+        return request;
+    }
+
+    private static string FlattenMessages(Exception exception)
+    {
+        var builder = new StringBuilder();
+        for (Exception? current = exception; current is not null; current = current.InnerException)
+            builder.Append(current.Message).Append(" | ");
+        if (exception is AggregateException aggregate)
+            foreach (var inner in aggregate.InnerExceptions)
+                builder.Append(FlattenMessages(inner));
+        return builder.ToString();
+    }
+
+    /// <summary>Captures log output so tests can assert on startup warnings.</summary>
+    private sealed class CapturingLoggerProvider : ILoggerProvider
+    {
+        /// <summary>Formatted log lines as "{Level}:{Category}:{Message}".</summary>
+        public ConcurrentBag<string> Messages { get; } = [];
+
+        public ILogger CreateLogger(string categoryName) => new CapturingLogger(Messages, categoryName);
+
+        public void Dispose()
+        {
+            // Nothing to release — messages are kept for assertion after the host stops.
+        }
+
+        private sealed class CapturingLogger(ConcurrentBag<string> messages, string category) : ILogger
+        {
+            public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+            public bool IsEnabled(LogLevel logLevel) => true;
+
+            public void Log<TState>(
+                LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+                Func<TState, Exception?, string> formatter) =>
+                messages.Add($"{logLevel}:{category}:{formatter(state, exception)}");
+        }
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.MCPServer.Tests/Infrastructure.AI.MCPServer.Tests.csproj
+++ b/src/Content/Tests/Infrastructure.AI.MCPServer.Tests/Infrastructure.AI.MCPServer.Tests.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" />
     <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Moq" />
     <PackageReference Include="xunit" />


### PR DESCRIPTION
## Summary
Wave-2 audit item **B5** (Infrastructure.AI.MCPServer). The MCP server could boot wide open; it is now fail-closed with real credential enforcement.

### How it booted open before (reproduced with failing tests)
- **Development + `Type=None`** (the shipped default): the dev bypass disabled authentication entirely — tools servable anonymously wherever endpoint authz metadata was missing, and the per-tool defense-in-depth gate was explicitly inert.
- **`Type=ApiKey` / `Type=Bearer` (any environment)**: passed the startup check but *no handler was ever registered* — enforcement for these modes was simply unimplemented (requests 500'd instead of being authenticated).
- **Invalid Entra config**: never validated at startup; garbage config booted.

### New behavior
- **Fail-closed startup** (environment-independent): throws on `Type=None` without explicit opt-in, on missing credential material (`IsValidForServer` — whitespace-proof), on unknown type, and on the contradiction `AllowAnonymous=true` + a configured type. A fresh clone deliberately refuses to start with instructions — no more silently-open template.
- **Enforced schemes**: ApiKey header (default `X-API-Key`) and static `Authorization: Bearer` via new `McpSharedKeyAuthenticationHandler` — SHA-256 + `CryptographicOperations.FixedTimeEquals` over fixed-length digests (security-reviewer-verified constant-time, no secret-dependent early exit, credentials never logged). Entra JWT path unchanged (issuer+audience+lifetime+signing key, `ClockSkew=Zero`). RFC 7235 case-insensitive `Bearer` scheme matching (review fix).
- **No policy gaps**: `FallbackPolicy = RequireAuthenticatedUser` covers any future unmapped endpoint; `MapMcp().RequireAuthorization()` on top; per-tool filter enforces on both POST and SSE dispatch.
- **Explicit dev anonymous**: `AppConfig:AI:MCP:Auth:AllowAnonymous` (default `false`) — conscious opt-in, prominent startup warning, per-tool `[Authorize]` attributes still enforced. `Environment=Development` alone no longer means anything.

## Security review
Adversarial security-review verdict: **SAFE TO MERGE AS-IS** (handler constant-time ✓, no scheme downgrade ✓, startup validation whitespace/env-var-proof ✓, secrets hygiene ✓). The single LOW (Bearer casing interop) fixed in the follow-up commit.

## Test plan
- [x] Reproduce-first: 12/13 new auth tests failed pre-fix (Dev booted open; ApiKey requests 500'd)
- [x] Post-fix: Infrastructure.AI.MCPServer.Tests **77/77** — startup-throw matrix (Dev+Prod), 401/200 matrices for ApiKey/Bearer/Entra, anonymous opt-in + warning, case-insensitive scheme
- [x] Domain.Common.Tests 705, Infrastructure.AI.MCP.Tests 76, Infrastructure.AI.Tests identity slice 99
- [x] gitnexus impact LOW (callers: Program.cs + tests only); client-side config semantics untouched

## Config keys
`AppConfig:AI:MCP:Auth:` — `Type` (`None|ApiKey|Bearer|Entra`), `AllowAnonymous` (new, default false), `ApiKey`/`ApiKeyHeader`/`BearerToken` (secrets via User Secrets/Key Vault). README fully updated (it previously documented the removed dev bypass).

## Breaking change (intentional)
Environments relying on implicit Development=anonymous must set `AllowAnonymous=true` (dev) or configure real credentials. Liveness probes expecting 2xx on `/` will get 401 in configured mode — use a TCP probe or add an anonymous health endpoint (tracked for deployment docs).

## Follow-ups (tracked, not here)
Rate-limiter partition key is global, not per-client as README claims (pre-existing); deployment-topology docs note for probes/dev-compose opt-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)