### PR TITLE
test: fix flaky Prometheus range E2E and fire-and-forget behavior tests

### DIFF
--- a/src/Content/Tests/Application.AI.Common.Tests/MediatRBehaviors/KnowledgeExtractionBehaviorTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/MediatRBehaviors/KnowledgeExtractionBehaviorTests.cs
@@ -16,6 +16,11 @@ namespace Application.AI.Common.Tests.MediatRBehaviors;
 
 public class KnowledgeExtractionBehaviorTests
 {
+    // Deadline for polling the fire-and-forget background extraction. Generous because the work
+    // runs on the thread pool (Task.Run) and a CI machine under a parallel test load can delay
+    // scheduling far past a tight deadline; polling means passing runs still finish in ~10ms.
+    private static readonly TimeSpan ExtractionTimeout = TimeSpan.FromSeconds(30);
+
     private readonly Mock<IConversationFactExtractor> _mockExtractor = new();
     private readonly Mock<IKnowledgeMemory> _mockMemory = new();
     private readonly KnowledgeBridgeConfig _config;
@@ -118,7 +123,7 @@ public class KnowledgeExtractionBehaviorTests
         // until both facts land (or fail loudly on timeout) rather than racing a fixed delay.
         await WaitForAsync(
             () => MemoryInvocationCount() == 2,
-            TimeSpan.FromSeconds(2));
+            ExtractionTimeout);
 
         _mockMemory.Verify(m => m.RememberAsync("conv-1:3:0", "User prefers PostgreSQL", "Preference", It.IsAny<CancellationToken>()), Times.Once);
         _mockMemory.Verify(m => m.RememberAsync("conv-1:3:1", "Deadline is June 15", "Decision", It.IsAny<CancellationToken>()), Times.Once);
@@ -148,7 +153,7 @@ public class KnowledgeExtractionBehaviorTests
         // "extractor was called" would be vacuous because the task may not have started yet.
         await WaitForAsync(
             () => Volatile.Read(ref extractorInvocations) == 1,
-            TimeSpan.FromSeconds(2));
+            ExtractionTimeout);
 
         // The extractor threw before yielding any facts, so nothing should be persisted, and
         // the behavior's catch block must have absorbed the exception (no unobserved fault,
@@ -185,7 +190,7 @@ public class KnowledgeExtractionBehaviorTests
         // throws); a fixed delay would race the background task under CI load.
         await WaitForAsync(
             () => SecondFactRemembered(),
-            TimeSpan.FromSeconds(2));
+            ExtractionTimeout);
 
         // Second fact should still be remembered despite first one throwing
         _mockMemory.Verify(m => m.RememberAsync("conv-1:1:1", "Fact B", "Fact", It.IsAny<CancellationToken>()), Times.Once);

--- a/src/Content/Tests/Application.AI.Common.Tests/MediatRBehaviors/WorkEpisodeCaptureBehaviorTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/MediatRBehaviors/WorkEpisodeCaptureBehaviorTests.cs
@@ -20,6 +20,11 @@ namespace Application.AI.Common.Tests.MediatRBehaviors;
 
 public sealed class WorkEpisodeCaptureBehaviorTests
 {
+    // Deadline for polling the fire-and-forget background capture. Generous because the capture
+    // runs on the thread pool (Task.Run) and a CI machine under a parallel test load can delay
+    // scheduling far past a tight deadline; polling means passing runs still finish in ~10ms.
+    private static readonly TimeSpan CaptureTimeout = TimeSpan.FromSeconds(30);
+
     private readonly Mock<IWorkEpisodeStore> _store = new();
     private readonly Mock<IEpisodicSegmentStore> _segmentStore = new();
     private readonly AppConfig _appConfig = new();
@@ -66,7 +71,7 @@ public sealed class WorkEpisodeCaptureBehaviorTests
 
         await behavior.Handle(CreateCommand("the task", "conv-9", 4), () => Task.FromResult(response), CancellationToken.None);
 
-        await WaitForAsync(() => captured.Count == 1, TimeSpan.FromSeconds(2));
+        await WaitForAsync(() => CountOf(captured) == 1, CaptureTimeout);
 
         var episode = captured.Single();
         episode.AgentId.Should().Be("test-agent"); // ExecuteAgentTurnCommand.AgentId => AgentName
@@ -90,7 +95,7 @@ public sealed class WorkEpisodeCaptureBehaviorTests
 
         await behavior.Handle(CreateCommand("do it"), () => Task.FromResult(response), CancellationToken.None);
 
-        await WaitForAsync(() => captured.Count == 1, TimeSpan.FromSeconds(2));
+        await WaitForAsync(() => CountOf(captured) == 1, CaptureTimeout);
         captured.Single().Outcome.Should().Be(EpisodeOutcome.Failure);
     }
 
@@ -104,7 +109,7 @@ public sealed class WorkEpisodeCaptureBehaviorTests
 
         await behavior.Handle(CreateCommand("summarize"), () => Task.FromResult(response), CancellationToken.None);
 
-        await WaitForAsync(() => captured.Count == 1, TimeSpan.FromSeconds(2));
+        await WaitForAsync(() => CountOf(captured) == 1, CaptureTimeout);
         captured.Single().ResponseSummary.Should().HaveLength(10);
     }
 
@@ -120,7 +125,7 @@ public sealed class WorkEpisodeCaptureBehaviorTests
 
         await behavior.Handle(CreateCommand("emoji"), () => Task.FromResult(response), CancellationToken.None);
 
-        await WaitForAsync(() => captured.Count == 1, TimeSpan.FromSeconds(2));
+        await WaitForAsync(() => CountOf(captured) == 1, CaptureTimeout);
         var summary = captured.Single().ResponseSummary;
         summary.Should().HaveLength(4); // backed off one char to keep whole pairs
         char.IsHighSurrogate(summary[^1]).Should().BeFalse();
@@ -143,7 +148,7 @@ public sealed class WorkEpisodeCaptureBehaviorTests
         result.Should().BeSameAs(response);
 
         // Prove the background body ran (and threw) without faulting the test process.
-        await WaitForAsync(() => Volatile.Read(ref attempts) == 1, TimeSpan.FromSeconds(2));
+        await WaitForAsync(() => Volatile.Read(ref attempts) == 1, CaptureTimeout);
     }
 
     // --- Harmonic episodic-segment capture (shared turn-boundary seam) ---
@@ -160,7 +165,7 @@ public sealed class WorkEpisodeCaptureBehaviorTests
 
         await behavior.Handle(CreateCommand("the task", "conv-7", 3), () => Task.FromResult(response), CancellationToken.None);
 
-        await WaitForAsync(() => episodes.Count == 1 && segments.Count == 1, TimeSpan.FromSeconds(2));
+        await WaitForAsync(() => CountOf(episodes) == 1 && CountOf(segments) == 1, CaptureTimeout);
 
         var episode = episodes.Single();
         var segment = segments.Single();
@@ -186,7 +191,7 @@ public sealed class WorkEpisodeCaptureBehaviorTests
 
         await behavior.Handle(CreateCommand("q"), () => Task.FromResult(response), CancellationToken.None);
 
-        await WaitForAsync(() => segments.Count == 1, TimeSpan.FromSeconds(2));
+        await WaitForAsync(() => CountOf(segments) == 1, CaptureTimeout);
         // The episode is persisted before the segment in PersistAsync; once the segment lands, a
         // work-episode write (had it been enabled) would already have run. It must not have.
         _store.Verify(s => s.SaveAsync(It.IsAny<WorkEpisode>(), It.IsAny<CancellationToken>()), Times.Never);
@@ -224,7 +229,7 @@ public sealed class WorkEpisodeCaptureBehaviorTests
 
         await behavior.Handle(CreateCommand("q"), () => Task.FromResult(response), CancellationToken.None);
 
-        await WaitForAsync(() => segments.Count == 1, TimeSpan.FromSeconds(2));
+        await WaitForAsync(() => CountOf(segments) == 1, CaptureTimeout);
     }
 
     [Fact]
@@ -284,6 +289,18 @@ public sealed class WorkEpisodeCaptureBehaviorTests
             await Task.Delay(10);
         }
         throw new TimeoutException($"Predicate did not become true within {timeout.TotalMilliseconds}ms.");
+    }
+
+    /// <summary>
+    /// Reads the capture list's count under the same lock the mock callbacks take when adding,
+    /// so poll predicates never race the background writer with an unsynchronized read.
+    /// </summary>
+    private static int CountOf<T>(List<T> items)
+    {
+        lock (items)
+        {
+            return items.Count;
+        }
     }
 
     private IServiceScopeFactory BuildScopeFactory()

--- a/src/Content/Tests/Infrastructure.AI.Tests/Escalation/DefaultEscalationServiceTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Escalation/DefaultEscalationServiceTests.cs
@@ -188,8 +188,14 @@ public sealed class DefaultEscalationServiceTests : IDisposable
 
 		var task = Task.Run(() => _sut.RequestEscalationAsync(request, CancellationToken.None));
 
-		var completedEarly = await Task.WhenAny(task, Task.Delay(200)) == task;
-		completedEarly.Should().BeFalse("RequestEscalationAsync should block until resolved");
+		// Wait for the escalation to be registered before submitting: a decision submitted
+		// pre-registration is silently dropped (DefaultEscalationService.cs:88-92) and the
+		// request then resolves only via its 5-minute timeout with IsApproved=false — the
+		// same race documented on RequestEscalationAsync_AfterRegistrationSignal_*.
+		await WaitForRegistrationAsync(request.EscalationId);
+
+		// Registered but undecided: the blocking call must still be pending.
+		task.IsCompleted.Should().BeFalse("RequestEscalationAsync should block until resolved");
 
 		await _sut.SubmitDecisionAsync(request.EscalationId, CreateApproval(), CancellationToken.None);
 		var outcome = await task;

--- a/src/Content/Tests/Presentation.AgentHub.Tests/Telemetry/MetricsE2ETests.cs
+++ b/src/Content/Tests/Presentation.AgentHub.Tests/Telemetry/MetricsE2ETests.cs
@@ -180,21 +180,22 @@ public class MetricsE2ETests : IClassFixture<PrometheusFixture>, IAsyncLifetime
     {
         await SendChatAsync("e2e-range-agent", "Range query test");
 
-        await _infra.WaitForMetric(
+        var found = await _infra.WaitForMetric(
             "agentic_harness_agent_session_started_total",
             TimeSpan.FromSeconds(30));
 
-        var now = DateTimeOffset.UtcNow;
-        var start = now.AddMinutes(-5).ToUnixTimeSeconds();
-        var end = now.ToUnixTimeSeconds();
+        found.Should().BeTrue(
+            "agent_session_started_total should propagate through collector → Prometheus within 30s");
 
-        var response = await _client.GetAsync(
-            $"/api/metrics/range?query=agentic_harness_agent_session_started_total" +
-            $"&start={start}&end={end}&step=15s");
-
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
-
-        var result = await response.Content.ReadFromJsonAsync<MetricsQueryResponse>();
+        // An instant query proving the sample exists does NOT guarantee a range query sees it
+        // yet: start/end are truncated to whole Unix seconds, so right after the metric lands
+        // via the very first 2s Prometheus scrape, floor(now) can fall BEFORE the sample's
+        // timestamp — every range evaluation step then precedes the only sample and the query
+        // is legitimately empty for up to one scrape interval. Poll with a deadline instead
+        // of assuming a single shot works.
+        var result = await WaitForRangeSeriesAsync(
+            "agentic_harness_agent_session_started_total",
+            TimeSpan.FromSeconds(30));
 
         result.Should().NotBeNull();
         result!.Success.Should().BeTrue();
@@ -279,6 +280,38 @@ public class MetricsE2ETests : IClassFixture<PrometheusFixture>, IAsyncLifetime
     // ─────────────────────────────────────────────────────────────────────────
     // Helpers
     // ─────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Polls <c>/api/metrics/range</c> for <paramref name="promql"/> until it returns a successful
+    /// response with at least one series, or <paramref name="timeout"/> elapses. The 5-minute query
+    /// window is recomputed on every attempt because <see cref="DateTimeOffset.ToUnixTimeSeconds"/>
+    /// truncates: immediately after the metric's first scrape, floor(now) can precede the only
+    /// sample's timestamp, making a one-shot range query empty for up to one scrape interval (~2s).
+    /// Returns the last response so the caller's assertions produce the real failure message on timeout.
+    /// </summary>
+    private async Task<MetricsQueryResponse?> WaitForRangeSeriesAsync(string promql, TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+
+        while (true)
+        {
+            var now = DateTimeOffset.UtcNow;
+            var start = now.AddMinutes(-5).ToUnixTimeSeconds();
+            var end = now.ToUnixTimeSeconds();
+
+            var response = await _client.GetAsync(
+                $"/api/metrics/range?query={Uri.EscapeDataString(promql)}" +
+                $"&start={start}&end={end}&step=15s");
+
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+            var result = await response.Content.ReadFromJsonAsync<MetricsQueryResponse>();
+            if (result is { Success: true, Series.Count: > 0 } || DateTime.UtcNow >= deadline)
+                return result;
+
+            await Task.Delay(500);
+        }
+    }
 
     private async Task SendChatAsync(string agentName, string message)
     {


### PR DESCRIPTION
## Summary
Fixes the two known flaky CI test groups (tracked audit item I3, pulled forward because they cause false reds on unrelated PRs). Test-only — no production code, no weakened assertions.

### 1. `MetricsController_RangeQueryReturnsTimeSeries` (Prometheus E2E)
Root cause: the range query's `start`/`end` are floor-truncated via `ToUnixTimeSeconds()`. When the metric lands on the very first 2s Prometheus scrape, `floor(now)` can fall *before* the only sample's timestamp — every range evaluation step precedes the sample and the query is legitimately empty for up to one scrape interval, even though the instant-query gate just passed.
Fix: new `WaitForRangeSeriesAsync` helper polls every 500ms with a 30s deadline, **recomputing the 5-minute window each attempt** so a later `floor(now)` moves past the sample; the last response feeds the original assertions so failures keep their real message. Also asserts the previously-discarded `WaitForMetric` result. No fixed sleeps.
Caveat: analysis-based fix — Docker will not start headless on the dev machine; this PR's CI run is the live validation.

### 2. `WorkEpisodeCaptureBehaviorTests` / `KnowledgeExtractionBehaviorTests`
Root cause: the behaviors persist via fire-and-forget `Task.Run`; the tests' poll loops used a hard 2s deadline that CI thread-pool starvation can exceed before the background task is even scheduled — plus the WorkEpisode poll predicates read `List.Count` without the lock the writer callbacks take.
Fix: poll deadline 2s → 30s (named constants; exit-on-first-success so green runs are unchanged in speed) and count reads moved under the writer's lock via a `CountOf` helper.

## Test plan
- [x] Behavior tests: 6 consecutive green filtered runs + full `Application.AI.Common.Tests` 1307/1307
- [x] Both test projects build 0 warnings / 0 errors
- [x] Prometheus E2E validated by this PR's CI run (Docker unavailable locally — documented in commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)