### PR TITLE
fix: make right-to-erasure complete across edges, receipts, feedback

### DIFF
--- a/src/Content/Application/Application.AI.Common/Interfaces/KnowledgeGraph/IFeedbackStore.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/KnowledgeGraph/IFeedbackStore.cs
@@ -77,7 +77,21 @@ public interface IFeedbackStore
     /// </summary>
     /// <param name="nodeIds">The node IDs whose feedback weights should be deleted.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    Task DeleteWeightsByNodeIdsAsync(
+    /// <returns>The number of feedback weight entries actually removed.</returns>
+    Task<int> DeleteWeightsByNodeIdsAsync(
         IReadOnlyList<string> nodeIds,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Deletes feedback weights for the specified edge IDs. Used during
+    /// right-to-erasure cascading: feedback recorded against an erased edge is a
+    /// dangling reference that both leaks signal about erased data and skews
+    /// feedback-weighted retrieval. No-op for edge IDs without recorded feedback.
+    /// </summary>
+    /// <param name="edgeIds">The edge IDs whose feedback weights should be deleted.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The number of feedback weight entries actually removed.</returns>
+    Task<int> DeleteWeightsByEdgeIdsAsync(
+        IReadOnlyList<string> edgeIds,
         CancellationToken cancellationToken = default);
 }

--- a/src/Content/Application/Application.AI.Common/Interfaces/KnowledgeGraph/IKnowledgeGraphStore.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/KnowledgeGraph/IKnowledgeGraphStore.cs
@@ -112,6 +112,33 @@ public interface IKnowledgeGraphStore
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Deletes a batch of nodes and all edges connected to them (both incoming and
+    /// outgoing), reporting what was actually removed. Requested IDs that do not exist
+    /// are ignored and not counted. This is the accounting primitive used by the erasure
+    /// orchestrator: unlike <see cref="DeleteNodeAsync"/>, it returns the true node count
+    /// and the IDs of every cascade-deleted edge so receipts and feedback-weight cleanup
+    /// reflect reality.
+    /// </summary>
+    /// <param name="nodeIds">The node identifiers to delete.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<NodeDeletionResult> DeleteNodesAsync(
+        IReadOnlyList<string> nodeIds,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Deletes every edge owned by the specified owner (<see cref="GraphEdge.OwnerId"/>)
+    /// and returns the IDs of the edges actually removed. Used by right-to-erasure:
+    /// node-cascade deletion alone leaves behind edges the erased owner created between
+    /// surviving nodes, which this method removes. Edges owned by other owners (or
+    /// unowned edges) are never touched.
+    /// </summary>
+    /// <param name="ownerId">The owner identifier whose edges must be deleted.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<IReadOnlyList<string>> DeleteEdgesByOwnerAsync(
+        string ownerId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Returns the total number of nodes in the graph (optionally scoped by tenant/dataset
     /// when multi-tenant isolation is enabled).
     /// </summary>

--- a/src/Content/Domain/Domain.AI/KnowledgeGraph/Models/ErasureReceipt.cs
+++ b/src/Content/Domain/Domain.AI/KnowledgeGraph/Models/ErasureReceipt.cs
@@ -1,8 +1,9 @@
 namespace Domain.AI.KnowledgeGraph.Models;
 
 /// <summary>
-/// Immutable proof that a right-to-erasure request was fulfilled. Contains counts
-/// of all entities deleted across graph, feedback, and vector stores.
+/// Immutable proof that a right-to-erasure request was fulfilled. All counts report what
+/// the underlying delete operations <em>actually removed</em> — as returned by each store —
+/// never the requested or estimated counts, so the receipt is trustworthy compliance evidence.
 /// </summary>
 public record ErasureReceipt
 {
@@ -14,12 +15,22 @@ public record ErasureReceipt
     public required DateTimeOffset RequestedAt { get; init; }
     /// <summary>When the erasure completed.</summary>
     public required DateTimeOffset CompletedAt { get; init; }
-    /// <summary>Number of graph nodes deleted.</summary>
+    /// <summary>Number of graph nodes the store actually deleted (missing IDs are not counted).</summary>
     public required int NodesDeleted { get; init; }
-    /// <summary>Number of graph edges deleted.</summary>
+    /// <summary>
+    /// Number of graph edges actually deleted: the node-cascade edges plus any edges
+    /// owned by the erased subject that connected surviving nodes.
+    /// </summary>
     public required int EdgesDeleted { get; init; }
-    /// <summary>Number of feedback weight entries deleted.</summary>
+    /// <summary>
+    /// Number of feedback weight entries actually removed, across both node and edge
+    /// weights that referenced erased graph elements.
+    /// </summary>
     public required int FeedbackWeightsDeleted { get; init; }
-    /// <summary>Number of vector embeddings deleted.</summary>
+    /// <summary>
+    /// Number of vector embeddings deleted. <c>IVectorStore.DeleteAsync</c> returns no
+    /// per-item confirmation, so this counts the chunk IDs submitted for deletion —
+    /// each call either succeeded or the erasure faulted before producing a receipt.
+    /// </summary>
     public required int VectorEmbeddingsDeleted { get; init; }
 }

--- a/src/Content/Domain/Domain.AI/KnowledgeGraph/Models/NodeDeletionResult.cs
+++ b/src/Content/Domain/Domain.AI/KnowledgeGraph/Models/NodeDeletionResult.cs
@@ -1,0 +1,30 @@
+namespace Domain.AI.KnowledgeGraph.Models;
+
+/// <summary>
+/// The outcome of a batch node deletion, reporting what the store actually removed.
+/// Produced by <c>IKnowledgeGraphStore.DeleteNodesAsync</c> so that right-to-erasure
+/// receipts (<see cref="ErasureReceipt"/>) can report true counts instead of the
+/// requested counts, and so downstream cleanup (feedback-weight purging) knows exactly
+/// which edges were cascade-deleted.
+/// </summary>
+public record NodeDeletionResult
+{
+    /// <summary>
+    /// Number of nodes the store actually removed. Requested IDs that did not exist
+    /// are not counted.
+    /// </summary>
+    public required int NodesDeleted { get; init; }
+
+    /// <summary>
+    /// IDs of the edges removed by the cascade (every edge whose source or target was
+    /// one of the deleted node IDs). Used to purge edge feedback weights during erasure.
+    /// </summary>
+    public required IReadOnlyList<string> DeletedEdgeIds { get; init; }
+
+    /// <summary>A result representing no deletions (empty input or nothing matched).</summary>
+    public static NodeDeletionResult Empty { get; } = new()
+    {
+        NodesDeleted = 0,
+        DeletedEdgeIds = []
+    };
+}

--- a/src/Content/Domain/Domain.AI/KnowledgeGraph/Models/NodeDeletionResult.cs
+++ b/src/Content/Domain/Domain.AI/KnowledgeGraph/Models/NodeDeletionResult.cs
@@ -10,10 +10,16 @@ namespace Domain.AI.KnowledgeGraph.Models;
 public record NodeDeletionResult
 {
     /// <summary>
-    /// Number of nodes the store actually removed. Requested IDs that did not exist
-    /// are not counted.
+    /// IDs of the nodes the store actually removed. Requested IDs that did not exist are
+    /// absent. Audit events must record these actuals — never the requested IDs.
     /// </summary>
-    public required int NodesDeleted { get; init; }
+    public required IReadOnlyList<string> DeletedNodeIds { get; init; }
+
+    /// <summary>
+    /// Number of nodes the store actually removed. Always equals
+    /// <see cref="DeletedNodeIds"/>.Count — computed so count and IDs can never drift.
+    /// </summary>
+    public int NodesDeleted => DeletedNodeIds.Count;
 
     /// <summary>
     /// IDs of the edges removed by the cascade (every edge whose source or target was
@@ -24,7 +30,7 @@ public record NodeDeletionResult
     /// <summary>A result representing no deletions (empty input or nothing matched).</summary>
     public static NodeDeletionResult Empty { get; } = new()
     {
-        NodesDeleted = 0,
+        DeletedNodeIds = [],
         DeletedEdgeIds = []
     };
 }

--- a/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/Compliance/ComplianceAwareGraphStore.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/Compliance/ComplianceAwareGraphStore.cs
@@ -98,10 +98,19 @@ public sealed class ComplianceAwareGraphStore : IKnowledgeGraphStore
     {
         var now = _timeProvider.GetUtcNow();
         var tenantId = CurrentTenantId;
+        var edgeOwnerId = CurrentUserId;
+        // Unlike node ownership (which gates read visibility and is therefore
+        // writer-authoritative — see StampNode), edge ownership is pure right-to-erasure
+        // attribution: triplet visibility is decided by the endpoint nodes, never the edge
+        // owner. Defaulting OwnerId to the writing user is what makes
+        // DeleteEdgesByOwnerAsync able to match edges the harness itself writes — without
+        // this stamp the owner-edge sweep is inert on every shipped write path. Background/
+        // system writes (edgeOwnerId == null) stay unowned, and an explicit owner always wins.
         var stamped = edges.Select(e => e with
         {
             CreatedAt = e.CreatedAt ?? now,
-            TenantId = e.TenantId ?? tenantId
+            TenantId = e.TenantId ?? tenantId,
+            OwnerId = e.OwnerId ?? edgeOwnerId
         }).ToList();
 
         await _inner.AddEdgesAsync(stamped, cancellationToken);
@@ -190,16 +199,22 @@ public sealed class ComplianceAwareGraphStore : IKnowledgeGraphStore
     {
         var result = await _inner.DeleteNodesAsync(nodeIds, cancellationToken);
 
-        await _auditSink.EmitAsync(new MemoryAuditEvent
+        // Audit what was ACTUALLY deleted, and only when something was: a Forget event for
+        // IDs that never existed (or a fully missed batch) would be a false audit record.
+        // Mirrors DeleteEdgesByOwnerAsync below.
+        if (result.DeletedNodeIds.Count > 0 || result.DeletedEdgeIds.Count > 0)
         {
-            EventId = Guid.NewGuid().ToString(),
-            Action = MemoryAuditAction.Forget,
-            ActorId = CurrentUserId ?? "system",
-            Timestamp = _timeProvider.GetUtcNow(),
-            ScopeId = CurrentUserId ?? "system",
-            AffectedNodeIds = nodeIds,
-            AffectedEdgeIds = result.DeletedEdgeIds
-        }, cancellationToken);
+            await _auditSink.EmitAsync(new MemoryAuditEvent
+            {
+                EventId = Guid.NewGuid().ToString(),
+                Action = MemoryAuditAction.Forget,
+                ActorId = CurrentUserId ?? "system",
+                Timestamp = _timeProvider.GetUtcNow(),
+                ScopeId = CurrentUserId ?? "system",
+                AffectedNodeIds = result.DeletedNodeIds,
+                AffectedEdgeIds = result.DeletedEdgeIds
+            }, cancellationToken);
+        }
 
         return result;
     }

--- a/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/Compliance/ComplianceAwareGraphStore.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/Compliance/ComplianceAwareGraphStore.cs
@@ -184,6 +184,50 @@ public sealed class ComplianceAwareGraphStore : IKnowledgeGraphStore
     }
 
     /// <inheritdoc />
+    public async Task<NodeDeletionResult> DeleteNodesAsync(
+        IReadOnlyList<string> nodeIds,
+        CancellationToken cancellationToken = default)
+    {
+        var result = await _inner.DeleteNodesAsync(nodeIds, cancellationToken);
+
+        await _auditSink.EmitAsync(new MemoryAuditEvent
+        {
+            EventId = Guid.NewGuid().ToString(),
+            Action = MemoryAuditAction.Forget,
+            ActorId = CurrentUserId ?? "system",
+            Timestamp = _timeProvider.GetUtcNow(),
+            ScopeId = CurrentUserId ?? "system",
+            AffectedNodeIds = nodeIds,
+            AffectedEdgeIds = result.DeletedEdgeIds
+        }, cancellationToken);
+
+        return result;
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<string>> DeleteEdgesByOwnerAsync(
+        string ownerId,
+        CancellationToken cancellationToken = default)
+    {
+        var deleted = await _inner.DeleteEdgesByOwnerAsync(ownerId, cancellationToken);
+
+        if (deleted.Count > 0)
+        {
+            await _auditSink.EmitAsync(new MemoryAuditEvent
+            {
+                EventId = Guid.NewGuid().ToString(),
+                Action = MemoryAuditAction.Forget,
+                ActorId = CurrentUserId ?? "system",
+                Timestamp = _timeProvider.GetUtcNow(),
+                ScopeId = ownerId,
+                AffectedEdgeIds = deleted
+            }, cancellationToken);
+        }
+
+        return deleted;
+    }
+
+    /// <inheritdoc />
     public Task<int> GetNodeCountAsync(CancellationToken cancellationToken = default)
         => _inner.GetNodeCountAsync(cancellationToken);
 

--- a/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/Compliance/DefaultErasureOrchestrator.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/Compliance/DefaultErasureOrchestrator.cs
@@ -53,7 +53,7 @@ public sealed class DefaultErasureOrchestrator : IErasureOrchestrator
         var nodeIds = nodes.Select(n => n.Id).ToList();
 
         return await ExecuteErasureAsync(
-            requestId, ownerId, nodes, nodeIds, requestedAt, cancellationToken);
+            requestId, ownerId, ownerId, nodes, nodeIds, requestedAt, cancellationToken);
     }
 
     /// <inheritdoc />
@@ -72,38 +72,61 @@ public sealed class DefaultErasureOrchestrator : IErasureOrchestrator
         }
 
         var scopeId = nodes.FirstOrDefault()?.OwnerId ?? "system";
+        // Node-scoped erasure has no owner to sweep edges for; the node cascade covers it.
         return await ExecuteErasureAsync(
-            requestId, scopeId, nodes, nodeIds.ToList(), requestedAt, cancellationToken);
+            requestId, scopeId, ownerId: null, nodes, nodeIds.ToList(), requestedAt, cancellationToken);
     }
 
     private async Task<ErasureReceipt> ExecuteErasureAsync(
         string requestId,
         string scopeId,
+        string? ownerId,
         IReadOnlyList<GraphNode> nodes,
         List<string> nodeIds,
         DateTimeOffset requestedAt,
         CancellationToken cancellationToken)
     {
-        // 1. Delete graph nodes (DeleteNodeAsync also removes connected edges)
-        foreach (var nodeId in nodeIds)
-            await _graphStore.DeleteNodeAsync(nodeId, cancellationToken);
+        // 1. Delete graph nodes and their connected edges. The store reports what it
+        //    actually removed — the receipt must never echo the requested counts.
+        var nodeDeletion = nodeIds.Count > 0
+            ? await _graphStore.DeleteNodesAsync(nodeIds, cancellationToken)
+            : NodeDeletionResult.Empty;
 
-        // 2. Delete feedback weights
-        if (nodeIds.Count > 0)
-            await _feedbackStore.DeleteWeightsByNodeIdsAsync(nodeIds, cancellationToken);
+        // 2. Delete edges owned by the erased subject. The node cascade only removes edges
+        //    touching the subject's nodes; edges the subject created between SURVIVING nodes
+        //    would otherwise outlive the erasure.
+        var ownerEdgeIds = ownerId is not null
+            ? await _graphStore.DeleteEdgesByOwnerAsync(ownerId, cancellationToken)
+            : [];
 
-        // 3. Delete vector embeddings (optional — not all deployments use vectors)
+        var deletedEdgeIds = nodeDeletion.DeletedEdgeIds
+            .Concat(ownerEdgeIds)
+            .Distinct(StringComparer.Ordinal)
+            .ToList();
+
+        // 3. Purge feedback weights for every erased node AND edge — dangling feedback both
+        //    leaks signal about erased data and skews feedback-weighted retrieval.
+        var nodeWeightsDeleted = nodeIds.Count > 0
+            ? await _feedbackStore.DeleteWeightsByNodeIdsAsync(nodeIds, cancellationToken)
+            : 0;
+        var edgeWeightsDeleted = deletedEdgeIds.Count > 0
+            ? await _feedbackStore.DeleteWeightsByEdgeIdsAsync(deletedEdgeIds, cancellationToken)
+            : 0;
+
+        // 4. Delete vector embeddings (optional — not all deployments use vectors).
+        //    IVectorStore.DeleteAsync returns no per-item confirmation, so this count is the
+        //    number of chunk IDs submitted for deletion (each call either succeeds or throws).
         var chunkIds = nodes.SelectMany(n => n.ChunkIds).Distinct().ToList();
         var embeddingsDeleted = 0;
         if (_vectorStore is not null && chunkIds.Count > 0)
         {
             // IVectorStore does not yet have DeleteByDocumentIdsAsync (batch).
             // When added, replace the loop below with a single batch call.
-            // For now, use the existing DeleteAsync per-document method.
             foreach (var chunkId in chunkIds)
+            {
                 await _vectorStore.DeleteAsync(chunkId, cancellationToken: cancellationToken);
-
-            embeddingsDeleted = chunkIds.Count;
+                embeddingsDeleted++;
+            }
         }
 
         var receipt = new ErasureReceipt
@@ -112,13 +135,13 @@ public sealed class DefaultErasureOrchestrator : IErasureOrchestrator
             ScopeId = scopeId,
             RequestedAt = requestedAt,
             CompletedAt = _timeProvider.GetUtcNow(),
-            NodesDeleted = nodeIds.Count,
-            EdgesDeleted = 0,
-            FeedbackWeightsDeleted = nodeIds.Count,
+            NodesDeleted = nodeDeletion.NodesDeleted,
+            EdgesDeleted = deletedEdgeIds.Count,
+            FeedbackWeightsDeleted = nodeWeightsDeleted + edgeWeightsDeleted,
             VectorEmbeddingsDeleted = embeddingsDeleted
         };
 
-        // 4. Emit audit event
+        // 5. Emit audit event covering everything that was actually erased.
         await _auditSink.EmitAsync(new MemoryAuditEvent
         {
             EventId = requestId,
@@ -126,12 +149,15 @@ public sealed class DefaultErasureOrchestrator : IErasureOrchestrator
             ActorId = scopeId,
             Timestamp = receipt.CompletedAt,
             ScopeId = scopeId,
-            AffectedNodeIds = nodeIds
+            AffectedNodeIds = nodeIds,
+            AffectedEdgeIds = deletedEdgeIds
         }, cancellationToken);
 
         _logger.LogInformation(
-            "Erasure completed: RequestId={RequestId}, Nodes={Nodes}, Embeddings={Embeddings}",
-            requestId, nodeIds.Count, embeddingsDeleted);
+            "Erasure completed: RequestId={RequestId}, Nodes={Nodes}, Edges={Edges}, " +
+            "FeedbackWeights={FeedbackWeights}, Embeddings={Embeddings}",
+            requestId, receipt.NodesDeleted, receipt.EdgesDeleted,
+            receipt.FeedbackWeightsDeleted, embeddingsDeleted);
 
         return receipt;
     }

--- a/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/Compliance/DefaultErasureOrchestrator.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/Compliance/DefaultErasureOrchestrator.cs
@@ -141,7 +141,10 @@ public sealed class DefaultErasureOrchestrator : IErasureOrchestrator
             VectorEmbeddingsDeleted = embeddingsDeleted
         };
 
-        // 5. Emit audit event covering everything that was actually erased.
+        // 5. Emit audit event covering everything that was ACTUALLY erased — the deleted
+        //    IDs reported by the stores, never the requested IDs. (The event itself is
+        //    always emitted: it is the proof the erasure REQUEST was processed, receipt
+        //    and all, even when nothing matched.)
         await _auditSink.EmitAsync(new MemoryAuditEvent
         {
             EventId = requestId,
@@ -149,7 +152,7 @@ public sealed class DefaultErasureOrchestrator : IErasureOrchestrator
             ActorId = scopeId,
             Timestamp = receipt.CompletedAt,
             ScopeId = scopeId,
-            AffectedNodeIds = nodeIds,
+            AffectedNodeIds = nodeDeletion.DeletedNodeIds,
             AffectedEdgeIds = deletedEdgeIds
         }, cancellationToken);
 

--- a/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/Feedback/GraphFeedbackStore.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/Feedback/GraphFeedbackStore.cs
@@ -137,7 +137,7 @@ public sealed class GraphFeedbackStore : IFeedbackStore
     }
 
     /// <inheritdoc />
-    public Task DeleteWeightsByNodeIdsAsync(
+    public Task<int> DeleteWeightsByNodeIdsAsync(
         IReadOnlyList<string> nodeIds,
         CancellationToken cancellationToken = default)
     {
@@ -149,7 +149,23 @@ public sealed class GraphFeedbackStore : IFeedbackStore
         }
 
         _logger.LogDebug("Deleted {Count} feedback weights for {Total} node IDs", deleted, nodeIds.Count);
-        return Task.CompletedTask;
+        return Task.FromResult(deleted);
+    }
+
+    /// <inheritdoc />
+    public Task<int> DeleteWeightsByEdgeIdsAsync(
+        IReadOnlyList<string> edgeIds,
+        CancellationToken cancellationToken = default)
+    {
+        var deleted = 0;
+        foreach (var edgeId in edgeIds)
+        {
+            if (_edgeWeights.TryRemove(edgeId, out _))
+                deleted++;
+        }
+
+        _logger.LogDebug("Deleted {Count} feedback weights for {Total} edge IDs", deleted, edgeIds.Count);
+        return Task.FromResult(deleted);
     }
 
     private static double NormalizeScore(double score) =>

--- a/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/InMemory/InMemoryGraphStore.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/InMemory/InMemoryGraphStore.cs
@@ -174,6 +174,66 @@ public sealed class InMemoryGraphStore : IKnowledgeGraphStore
     }
 
     /// <inheritdoc />
+    public Task<NodeDeletionResult> DeleteNodesAsync(
+        IReadOnlyList<string> nodeIds,
+        CancellationToken cancellationToken = default)
+    {
+        if (nodeIds.Count == 0)
+            return Task.FromResult(NodeDeletionResult.Empty);
+
+        var idSet = nodeIds.ToHashSet(StringComparer.Ordinal);
+        var nodesDeleted = 0;
+        foreach (var nodeId in idSet)
+        {
+            if (_nodes.TryRemove(nodeId, out _))
+                nodesDeleted++;
+        }
+
+        var cascadeEdgeIds = _edges.Values
+            .Where(e => idSet.Contains(e.SourceNodeId) || idSet.Contains(e.TargetNodeId))
+            .Select(e => e.Id)
+            .ToList();
+
+        var deletedEdgeIds = new List<string>(cascadeEdgeIds.Count);
+        foreach (var edgeId in cascadeEdgeIds)
+        {
+            if (_edges.TryRemove(edgeId, out _))
+                deletedEdgeIds.Add(edgeId);
+        }
+
+        _logger.LogDebug(
+            "Deleted {NodeCount} of {Requested} nodes and {EdgeCount} connected edges",
+            nodesDeleted, nodeIds.Count, deletedEdgeIds.Count);
+
+        return Task.FromResult(new NodeDeletionResult
+        {
+            NodesDeleted = nodesDeleted,
+            DeletedEdgeIds = deletedEdgeIds
+        });
+    }
+
+    /// <inheritdoc />
+    public Task<IReadOnlyList<string>> DeleteEdgesByOwnerAsync(
+        string ownerId,
+        CancellationToken cancellationToken = default)
+    {
+        var ownedEdgeIds = _edges.Values
+            .Where(e => string.Equals(e.OwnerId, ownerId, StringComparison.Ordinal))
+            .Select(e => e.Id)
+            .ToList();
+
+        var deleted = new List<string>(ownedEdgeIds.Count);
+        foreach (var edgeId in ownedEdgeIds)
+        {
+            if (_edges.TryRemove(edgeId, out _))
+                deleted.Add(edgeId);
+        }
+
+        _logger.LogDebug("Deleted {Count} edges owned by {OwnerId}", deleted.Count, ownerId);
+        return Task.FromResult<IReadOnlyList<string>>(deleted);
+    }
+
+    /// <inheritdoc />
     public Task<int> GetNodeCountAsync(CancellationToken cancellationToken = default)
     {
         return Task.FromResult(_nodes.Count);

--- a/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/InMemory/InMemoryGraphStore.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/InMemory/InMemoryGraphStore.cs
@@ -182,11 +182,11 @@ public sealed class InMemoryGraphStore : IKnowledgeGraphStore
             return Task.FromResult(NodeDeletionResult.Empty);
 
         var idSet = nodeIds.ToHashSet(StringComparer.Ordinal);
-        var nodesDeleted = 0;
+        var deletedNodeIds = new List<string>(idSet.Count);
         foreach (var nodeId in idSet)
         {
             if (_nodes.TryRemove(nodeId, out _))
-                nodesDeleted++;
+                deletedNodeIds.Add(nodeId);
         }
 
         var cascadeEdgeIds = _edges.Values
@@ -203,11 +203,11 @@ public sealed class InMemoryGraphStore : IKnowledgeGraphStore
 
         _logger.LogDebug(
             "Deleted {NodeCount} of {Requested} nodes and {EdgeCount} connected edges",
-            nodesDeleted, nodeIds.Count, deletedEdgeIds.Count);
+            deletedNodeIds.Count, nodeIds.Count, deletedEdgeIds.Count);
 
         return Task.FromResult(new NodeDeletionResult
         {
-            NodesDeleted = nodesDeleted,
+            DeletedNodeIds = deletedNodeIds,
             DeletedEdgeIds = deletedEdgeIds
         });
     }

--- a/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/Neo4j/Neo4jGraphStore.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/Neo4j/Neo4jGraphStore.cs
@@ -258,6 +258,83 @@ public sealed class Neo4jGraphStore : IKnowledgeGraphStore, IAsyncDisposable
     }
 
     /// <inheritdoc />
+    public async Task<NodeDeletionResult> DeleteNodesAsync(
+        IReadOnlyList<string> nodeIds,
+        CancellationToken cancellationToken = default)
+    {
+        if (nodeIds.Count == 0) return NodeDeletionResult.Empty;
+
+        using var activity = ActivitySource.StartActivity("kg.neo4j.delete_nodes");
+        await using var session = _driver.AsyncSession();
+
+        return await session.ExecuteWriteAsync(async tx =>
+        {
+            // Delete connected edges first, capturing their ids for feedback-weight cleanup.
+            // DISTINCT guards against an edge matching twice when both endpoints are in the set.
+            var edgeCursor = await tx.RunAsync("""
+                MATCH (n:Entity)-[r:RELATES]-() WHERE n.id IN $ids
+                WITH DISTINCT r, r.id AS rid
+                DELETE r
+                RETURN rid
+                """, new { ids = nodeIds.ToList() });
+
+            var deletedEdgeIds = new List<string>();
+            while (await edgeCursor.FetchAsync())
+                deletedEdgeIds.Add(edgeCursor.Current["rid"].As<string>());
+
+            // Then the nodes themselves; size(nodes) is the true deleted count because
+            // MATCH only binds nodes that exist. DETACH is belt-and-braces for edges
+            // added concurrently between the two statements.
+            var nodeCursor = await tx.RunAsync("""
+                MATCH (n:Entity) WHERE n.id IN $ids
+                WITH collect(n) AS nodes
+                FOREACH (x IN nodes | DETACH DELETE x)
+                RETURN size(nodes) AS cnt
+                """, new { ids = nodeIds.ToList() });
+
+            var nodesDeleted = await nodeCursor.FetchAsync()
+                ? nodeCursor.Current["cnt"].As<int>()
+                : 0;
+
+            _logger.LogDebug(
+                "Neo4j: deleted {NodeCount} of {Requested} nodes and {EdgeCount} connected edges",
+                nodesDeleted, nodeIds.Count, deletedEdgeIds.Count);
+
+            return new NodeDeletionResult
+            {
+                NodesDeleted = nodesDeleted,
+                DeletedEdgeIds = deletedEdgeIds
+            };
+        });
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<string>> DeleteEdgesByOwnerAsync(
+        string ownerId,
+        CancellationToken cancellationToken = default)
+    {
+        using var activity = ActivitySource.StartActivity("kg.neo4j.delete_edges_by_owner");
+        await using var session = _driver.AsyncSession();
+
+        return await session.ExecuteWriteAsync(async tx =>
+        {
+            var cursor = await tx.RunAsync("""
+                MATCH ()-[r:RELATES]->() WHERE r.owner_id = $ownerId
+                WITH r, r.id AS rid
+                DELETE r
+                RETURN rid
+                """, new { ownerId });
+
+            var deleted = new List<string>();
+            while (await cursor.FetchAsync())
+                deleted.Add(cursor.Current["rid"].As<string>());
+
+            _logger.LogDebug("Neo4j: deleted {Count} edges owned by {OwnerId}", deleted.Count, ownerId);
+            return (IReadOnlyList<string>)deleted;
+        });
+    }
+
+    /// <inheritdoc />
     public async Task<int> GetNodeCountAsync(CancellationToken cancellationToken = default)
     {
         await using var session = _driver.AsyncSession();

--- a/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/Neo4j/Neo4jGraphStore.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/Neo4j/Neo4jGraphStore.cs
@@ -278,31 +278,26 @@ public sealed class Neo4jGraphStore : IKnowledgeGraphStore, IAsyncDisposable
                 RETURN rid
                 """, new { ids = nodeIds.ToList() });
 
-            var deletedEdgeIds = new List<string>();
-            while (await edgeCursor.FetchAsync())
-                deletedEdgeIds.Add(edgeCursor.Current["rid"].As<string>());
+            var deletedEdgeIds = await MaterializeIdsAsync(edgeCursor, "rid");
 
-            // Then the nodes themselves; size(nodes) is the true deleted count because
-            // MATCH only binds nodes that exist. DETACH is belt-and-braces for edges
-            // added concurrently between the two statements.
+            // Then the nodes themselves, projecting each id BEFORE the delete so the audit
+            // trail records what was actually removed (MATCH only binds nodes that exist).
             var nodeCursor = await tx.RunAsync("""
                 MATCH (n:Entity) WHERE n.id IN $ids
-                WITH collect(n) AS nodes
-                FOREACH (x IN nodes | DETACH DELETE x)
-                RETURN size(nodes) AS cnt
+                WITH n, n.id AS nid
+                DETACH DELETE n
+                RETURN nid
                 """, new { ids = nodeIds.ToList() });
 
-            var nodesDeleted = await nodeCursor.FetchAsync()
-                ? nodeCursor.Current["cnt"].As<int>()
-                : 0;
+            var deletedNodeIds = await MaterializeIdsAsync(nodeCursor, "nid");
 
             _logger.LogDebug(
                 "Neo4j: deleted {NodeCount} of {Requested} nodes and {EdgeCount} connected edges",
-                nodesDeleted, nodeIds.Count, deletedEdgeIds.Count);
+                deletedNodeIds.Count, nodeIds.Count, deletedEdgeIds.Count);
 
             return new NodeDeletionResult
             {
-                NodesDeleted = nodesDeleted,
+                DeletedNodeIds = deletedNodeIds,
                 DeletedEdgeIds = deletedEdgeIds
             };
         });
@@ -325,13 +320,30 @@ public sealed class Neo4jGraphStore : IKnowledgeGraphStore, IAsyncDisposable
                 RETURN rid
                 """, new { ownerId });
 
-            var deleted = new List<string>();
-            while (await cursor.FetchAsync())
-                deleted.Add(cursor.Current["rid"].As<string>());
+            var deleted = await MaterializeIdsAsync(cursor, "rid");
 
             _logger.LogDebug("Neo4j: deleted {Count} edges owned by {OwnerId}", deleted.Count, ownerId);
             return (IReadOnlyList<string>)deleted;
         });
+    }
+
+    /// <summary>
+    /// Drains a cursor of projected IDs into a list, skipping <see langword="null"/> values.
+    /// Legacy graph elements written before the <c>id</c> property was mandatory materialize
+    /// a null projection — propagating it would fault downstream feedback-weight cleanup
+    /// (dictionary keys cannot be null) and abort the whole erasure.
+    /// </summary>
+    private static async Task<List<string>> MaterializeIdsAsync(IResultCursor cursor, string column)
+    {
+        var ids = new List<string>();
+        while (await cursor.FetchAsync())
+        {
+            var value = cursor.Current[column];
+            if (value is not null)
+                ids.Add(value.As<string>());
+        }
+
+        return ids;
     }
 
     /// <inheritdoc />

--- a/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/PostgreSql/PostgreSqlGraphStore.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/PostgreSql/PostgreSqlGraphStore.cs
@@ -303,6 +303,71 @@ public sealed class PostgreSqlGraphStore : IKnowledgeGraphStore
     }
 
     /// <inheritdoc />
+    public async Task<NodeDeletionResult> DeleteNodesAsync(
+        IReadOnlyList<string> nodeIds,
+        CancellationToken cancellationToken = default)
+    {
+        if (nodeIds.Count == 0) return NodeDeletionResult.Empty;
+
+        using var activity = ActivitySource.StartActivity("kg.postgresql.delete_nodes");
+        await using var conn = await OpenConnectionAsync(cancellationToken);
+        await using var tx = await conn.BeginTransactionAsync(cancellationToken);
+
+        // Delete connected edges first, capturing their ids for feedback-weight cleanup.
+        var deletedEdgeIds = new List<string>();
+        await using (var edgeCmd = new NpgsqlCommand(
+            "DELETE FROM kg_edges WHERE source_node_id = ANY(@ids) OR target_node_id = ANY(@ids) RETURNING id",
+            conn, tx))
+        {
+            edgeCmd.Parameters.AddWithValue("ids", nodeIds.ToArray());
+            await using var reader = await edgeCmd.ExecuteReaderAsync(cancellationToken);
+            while (await reader.ReadAsync(cancellationToken))
+                deletedEdgeIds.Add(reader.GetString(0));
+        }
+
+        // Then the nodes; the command's rows-affected is the true deleted count.
+        int nodesDeleted;
+        await using (var nodeCmd = new NpgsqlCommand(
+            "DELETE FROM kg_nodes WHERE id = ANY(@ids)", conn, tx))
+        {
+            nodeCmd.Parameters.AddWithValue("ids", nodeIds.ToArray());
+            nodesDeleted = await nodeCmd.ExecuteNonQueryAsync(cancellationToken);
+        }
+
+        await tx.CommitAsync(cancellationToken);
+
+        _logger.LogDebug(
+            "PostgreSQL: deleted {NodeCount} of {Requested} nodes and {EdgeCount} connected edges",
+            nodesDeleted, nodeIds.Count, deletedEdgeIds.Count);
+
+        return new NodeDeletionResult
+        {
+            NodesDeleted = nodesDeleted,
+            DeletedEdgeIds = deletedEdgeIds
+        };
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<string>> DeleteEdgesByOwnerAsync(
+        string ownerId,
+        CancellationToken cancellationToken = default)
+    {
+        using var activity = ActivitySource.StartActivity("kg.postgresql.delete_edges_by_owner");
+        await using var conn = await OpenConnectionAsync(cancellationToken);
+        await using var cmd = new NpgsqlCommand(
+            "DELETE FROM kg_edges WHERE owner_id = @ownerId RETURNING id", conn);
+        cmd.Parameters.AddWithValue("ownerId", ownerId);
+
+        var deleted = new List<string>();
+        await using var reader = await cmd.ExecuteReaderAsync(cancellationToken);
+        while (await reader.ReadAsync(cancellationToken))
+            deleted.Add(reader.GetString(0));
+
+        _logger.LogDebug("PostgreSQL: deleted {Count} edges owned by {OwnerId}", deleted.Count, ownerId);
+        return deleted;
+    }
+
+    /// <inheritdoc />
     public async Task<int> GetNodeCountAsync(CancellationToken cancellationToken = default)
     {
         await using var conn = await OpenConnectionAsync(cancellationToken);

--- a/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/PostgreSql/PostgreSqlGraphStore.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/PostgreSql/PostgreSqlGraphStore.cs
@@ -325,24 +325,26 @@ public sealed class PostgreSqlGraphStore : IKnowledgeGraphStore
                 deletedEdgeIds.Add(reader.GetString(0));
         }
 
-        // Then the nodes; the command's rows-affected is the true deleted count.
-        int nodesDeleted;
+        // Then the nodes, RETURNING the ids actually removed so audits record actuals.
+        var deletedNodeIds = new List<string>();
         await using (var nodeCmd = new NpgsqlCommand(
-            "DELETE FROM kg_nodes WHERE id = ANY(@ids)", conn, tx))
+            "DELETE FROM kg_nodes WHERE id = ANY(@ids) RETURNING id", conn, tx))
         {
             nodeCmd.Parameters.AddWithValue("ids", nodeIds.ToArray());
-            nodesDeleted = await nodeCmd.ExecuteNonQueryAsync(cancellationToken);
+            await using var reader = await nodeCmd.ExecuteReaderAsync(cancellationToken);
+            while (await reader.ReadAsync(cancellationToken))
+                deletedNodeIds.Add(reader.GetString(0));
         }
 
         await tx.CommitAsync(cancellationToken);
 
         _logger.LogDebug(
             "PostgreSQL: deleted {NodeCount} of {Requested} nodes and {EdgeCount} connected edges",
-            nodesDeleted, nodeIds.Count, deletedEdgeIds.Count);
+            deletedNodeIds.Count, nodeIds.Count, deletedEdgeIds.Count);
 
         return new NodeDeletionResult
         {
-            NodesDeleted = nodesDeleted,
+            DeletedNodeIds = deletedNodeIds,
             DeletedEdgeIds = deletedEdgeIds
         };
     }

--- a/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/README.md
+++ b/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/README.md
@@ -58,7 +58,7 @@ Application.AI.Common/Interfaces/KnowledgeGraph/
 **Why it exists:** Different deployment environments need different graph databases. Development uses in-memory (zero setup). Simple production uses PostgreSQL (which teams likely already have). High-scale graph workloads use Neo4j (purpose-built for traversals).
 
 **How it works:**
-- All three backends implement `IKnowledgeGraphStore` with operations: `AddNodesAsync`, `AddEdgesAsync`, `GetNodeAsync`, `GetNeighborsAsync`, `GetTripletsAsync`, `DeleteNodeAsync`, `DeleteEdgeAsync`, `NodeExistsAsync`, `GetNodeCountAsync`, `GetEdgeCountAsync`.
+- All three backends implement `IKnowledgeGraphStore` with operations: `AddNodesAsync`, `AddEdgesAsync`, `GetNodeAsync`, `GetNeighborsAsync`, `GetTripletsAsync`, `DeleteNodeAsync`, `DeleteEdgeAsync`, `DeleteNodesAsync` (batch; returns the actual node count and cascade-deleted edge IDs), `DeleteEdgesByOwnerAsync` (right-to-erasure sweep of an owner's edges), `NodeExistsAsync`, `GetNodeCountAsync`, `GetEdgeCountAsync`.
 - Registered with keyed DI (`"in_memory"`, `"postgresql"`, `"neo4j"`).
 - The default (non-keyed) registration resolves from `AppConfig.AI.Rag.GraphRag.GraphProvider`.
 

--- a/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/Scoping/TenantIsolatedGraphStore.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/Scoping/TenantIsolatedGraphStore.cs
@@ -225,6 +225,60 @@ public sealed class TenantIsolatedGraphStore : IKnowledgeGraphStore
         => _inner.DeleteEdgeAsync(edgeId, cancellationToken);
 
     /// <inheritdoc />
+    public async Task<NodeDeletionResult> DeleteNodesAsync(
+        IReadOnlyList<string> nodeIds,
+        CancellationToken cancellationToken = default)
+    {
+        var scope = CurrentScope;
+        if (scope is null)
+            return await _inner.DeleteNodesAsync(nodeIds, cancellationToken);
+
+        // Same per-record gate as DeleteNodeAsync, applied to the batch: a scoped caller may
+        // only cascade-delete nodes they can access. Missing nodes pass through (idempotent
+        // no-op at the backend); foreign nodes are dropped from the batch and logged.
+        var permitted = new List<string>(nodeIds.Count);
+        foreach (var nodeId in nodeIds)
+        {
+            var node = await _inner.GetNodeAsync(nodeId, cancellationToken);
+            if (node is null || CanAccess(node.TenantId, node.OwnerId, scope))
+            {
+                permitted.Add(nodeId);
+                continue;
+            }
+
+            _logger.LogWarning(
+                "Tenant isolation: blocked batch delete of foreign node {NodeId} for User={UserId}",
+                nodeId, scope.UserId);
+        }
+
+        return permitted.Count == 0
+            ? NodeDeletionResult.Empty
+            : await _inner.DeleteNodesAsync(permitted, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<string>> DeleteEdgesByOwnerAsync(
+        string ownerId,
+        CancellationToken cancellationToken = default)
+    {
+        var scope = CurrentScope;
+        if (scope is null)
+            return await _inner.DeleteEdgesByOwnerAsync(ownerId, cancellationToken);
+
+        // Owner-scoped erasure normally runs system-scoped (no ambient request scope). A scoped
+        // caller may only erase edges of an owner dataset they can access — i.e. their own.
+        if (!_validator.CanAccessDataset(scope, ownerId))
+        {
+            _logger.LogWarning(
+                "Tenant isolation: blocked owner-edge erasure of {OwnerId} for User={UserId}",
+                ownerId, scope.UserId);
+            return [];
+        }
+
+        return await _inner.DeleteEdgesByOwnerAsync(ownerId, cancellationToken);
+    }
+
+    /// <inheritdoc />
     public async Task<int> GetNodeCountAsync(CancellationToken cancellationToken = default)
     {
         var scope = CurrentScope;

--- a/src/Content/Infrastructure/Infrastructure.AI.RAG/GraphRag/KuzuGraphBackend.Crud.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.RAG/GraphRag/KuzuGraphBackend.Crud.cs
@@ -237,6 +237,90 @@ public sealed partial class KuzuGraphBackend
     }
 
     /// <inheritdoc />
+    public async Task<NodeDeletionResult> DeleteNodesAsync(
+        IReadOnlyList<string> nodeIds,
+        CancellationToken cancellationToken = default)
+    {
+        if (nodeIds.Count == 0) return NodeDeletionResult.Empty;
+
+        await PopulateTempTableAsync(nodeIds, cancellationToken).ConfigureAwait(false);
+
+        // Capture connected edge ids BEFORE deleting so feedback-weight cleanup and the
+        // erasure receipt reflect what was actually removed.
+        var deletedEdgeIds = new List<string>();
+        using (var selectCmd = _connection.CreateCommand())
+        {
+            selectCmd.CommandText = """
+                SELECT id FROM Edges
+                WHERE source_node_id IN (SELECT id FROM _TempIds)
+                   OR target_node_id  IN (SELECT id FROM _TempIds)
+                """;
+            using var reader = await selectCmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+            while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+                deletedEdgeIds.Add(reader.GetString(0));
+        }
+
+        using (var cmd = _connection.CreateCommand())
+        {
+            cmd.CommandText = """
+                DELETE FROM Edges
+                WHERE source_node_id IN (SELECT id FROM _TempIds)
+                   OR target_node_id  IN (SELECT id FROM _TempIds)
+                """;
+            await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        using (var cmd = _connection.CreateCommand())
+        {
+            cmd.CommandText = "DELETE FROM CommunityAssignments WHERE node_id IN (SELECT id FROM _TempIds)";
+            await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        int nodesDeleted;
+        using (var cmd = _connection.CreateCommand())
+        {
+            cmd.CommandText = "DELETE FROM Nodes WHERE id IN (SELECT id FROM _TempIds)";
+            nodesDeleted = await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        _logger.LogDebug(
+            "Deleted {NodeCount} of {Requested} nodes and {EdgeCount} connected edges",
+            nodesDeleted, nodeIds.Count, deletedEdgeIds.Count);
+
+        return new NodeDeletionResult
+        {
+            NodesDeleted = nodesDeleted,
+            DeletedEdgeIds = deletedEdgeIds
+        };
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<string>> DeleteEdgesByOwnerAsync(
+        string ownerId,
+        CancellationToken cancellationToken = default)
+    {
+        var deleted = new List<string>();
+        using (var selectCmd = _connection.CreateCommand())
+        {
+            selectCmd.CommandText = "SELECT id FROM Edges WHERE owner_id = @owner";
+            selectCmd.Parameters.AddWithValue("@owner", ownerId);
+            using var reader = await selectCmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+            while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+                deleted.Add(reader.GetString(0));
+        }
+
+        using (var cmd = _connection.CreateCommand())
+        {
+            cmd.CommandText = "DELETE FROM Edges WHERE owner_id = @owner";
+            cmd.Parameters.AddWithValue("@owner", ownerId);
+            await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        _logger.LogDebug("Deleted {Count} edges owned by {OwnerId}", deleted.Count, ownerId);
+        return deleted;
+    }
+
+    /// <inheritdoc />
     public async Task<int> GetNodeCountAsync(CancellationToken cancellationToken = default)
     {
         using var cmd = _connection.CreateCommand();

--- a/src/Content/Infrastructure/Infrastructure.AI.RAG/GraphRag/KuzuGraphBackend.Crud.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.RAG/GraphRag/KuzuGraphBackend.Crud.cs
@@ -243,13 +243,31 @@ public sealed partial class KuzuGraphBackend
     {
         if (nodeIds.Count == 0) return NodeDeletionResult.Empty;
 
-        await PopulateTempTableAsync(nodeIds, cancellationToken).ConfigureAwait(false);
+        // The whole populate/select/delete sequence is one SQLite transaction: a crash
+        // midway must not leave orphaned edges or community assignments, and the _TempIds
+        // population is atomic with the DELETEs that read it, so no interleaved
+        // PopulateTempTableAsync caller can repoint the temp table at a different id set
+        // between our statements.
+        using var transaction = _connection.BeginTransaction();
 
-        // Capture connected edge ids BEFORE deleting so feedback-weight cleanup and the
-        // erasure receipt reflect what was actually removed.
+        await PopulateTempTableAsync(nodeIds, cancellationToken, transaction).ConfigureAwait(false);
+
+        // Capture node and edge ids BEFORE deleting so feedback-weight cleanup, the erasure
+        // receipt, and audit events reflect what was actually removed.
+        var deletedNodeIds = new List<string>();
+        using (var selectCmd = _connection.CreateCommand())
+        {
+            selectCmd.Transaction = transaction;
+            selectCmd.CommandText = "SELECT id FROM Nodes WHERE id IN (SELECT id FROM _TempIds)";
+            using var reader = await selectCmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+            while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+                deletedNodeIds.Add(reader.GetString(0));
+        }
+
         var deletedEdgeIds = new List<string>();
         using (var selectCmd = _connection.CreateCommand())
         {
+            selectCmd.Transaction = transaction;
             selectCmd.CommandText = """
                 SELECT id FROM Edges
                 WHERE source_node_id IN (SELECT id FROM _TempIds)
@@ -262,6 +280,7 @@ public sealed partial class KuzuGraphBackend
 
         using (var cmd = _connection.CreateCommand())
         {
+            cmd.Transaction = transaction;
             cmd.CommandText = """
                 DELETE FROM Edges
                 WHERE source_node_id IN (SELECT id FROM _TempIds)
@@ -272,24 +291,27 @@ public sealed partial class KuzuGraphBackend
 
         using (var cmd = _connection.CreateCommand())
         {
+            cmd.Transaction = transaction;
             cmd.CommandText = "DELETE FROM CommunityAssignments WHERE node_id IN (SELECT id FROM _TempIds)";
             await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        int nodesDeleted;
         using (var cmd = _connection.CreateCommand())
         {
+            cmd.Transaction = transaction;
             cmd.CommandText = "DELETE FROM Nodes WHERE id IN (SELECT id FROM _TempIds)";
-            nodesDeleted = await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
         }
+
+        transaction.Commit();
 
         _logger.LogDebug(
             "Deleted {NodeCount} of {Requested} nodes and {EdgeCount} connected edges",
-            nodesDeleted, nodeIds.Count, deletedEdgeIds.Count);
+            deletedNodeIds.Count, nodeIds.Count, deletedEdgeIds.Count);
 
         return new NodeDeletionResult
         {
-            NodesDeleted = nodesDeleted,
+            DeletedNodeIds = deletedNodeIds,
             DeletedEdgeIds = deletedEdgeIds
         };
     }
@@ -299,9 +321,14 @@ public sealed partial class KuzuGraphBackend
         string ownerId,
         CancellationToken cancellationToken = default)
     {
+        // Transactional so the captured id list and the DELETE observe the same edge set,
+        // and a crash between them cannot report deletions that never happened.
+        using var transaction = _connection.BeginTransaction();
+
         var deleted = new List<string>();
         using (var selectCmd = _connection.CreateCommand())
         {
+            selectCmd.Transaction = transaction;
             selectCmd.CommandText = "SELECT id FROM Edges WHERE owner_id = @owner";
             selectCmd.Parameters.AddWithValue("@owner", ownerId);
             using var reader = await selectCmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
@@ -311,10 +338,13 @@ public sealed partial class KuzuGraphBackend
 
         using (var cmd = _connection.CreateCommand())
         {
+            cmd.Transaction = transaction;
             cmd.CommandText = "DELETE FROM Edges WHERE owner_id = @owner";
             cmd.Parameters.AddWithValue("@owner", ownerId);
             await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
         }
+
+        transaction.Commit();
 
         _logger.LogDebug("Deleted {Count} edges owned by {OwnerId}", deleted.Count, ownerId);
         return deleted;

--- a/src/Content/Infrastructure/Infrastructure.AI.RAG/GraphRag/KuzuGraphBackend.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.RAG/GraphRag/KuzuGraphBackend.cs
@@ -159,11 +159,13 @@ public sealed partial class KuzuGraphBackend : IGraphDatabaseBackend, IDisposabl
     /// </summary>
     private async Task PopulateTempTableAsync(
         IEnumerable<string> ids,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        SqliteTransaction? transaction = null)
     {
         // Create (idempotent) and clear.
         using (var createCmd = _connection.CreateCommand())
         {
+            createCmd.Transaction = transaction;
             createCmd.CommandText = """
                 CREATE TEMP TABLE IF NOT EXISTS _TempIds (id TEXT PRIMARY KEY);
                 DELETE FROM _TempIds;
@@ -173,6 +175,7 @@ public sealed partial class KuzuGraphBackend : IGraphDatabaseBackend, IDisposabl
 
         // Insert each ID individually via a prepared statement — safe by construction.
         using var insertCmd = _connection.CreateCommand();
+        insertCmd.Transaction = transaction;
         insertCmd.CommandText = "INSERT OR IGNORE INTO _TempIds (id) VALUES (@id)";
         var param = insertCmd.Parameters.Add("@id", SqliteType.Text);
 

--- a/src/Content/Tests/Infrastructure.AI.KnowledgeGraph.Tests/Compliance/ComplianceAwareGraphStoreTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.KnowledgeGraph.Tests/Compliance/ComplianceAwareGraphStoreTests.cs
@@ -189,6 +189,65 @@ public sealed class ComplianceAwareGraphStoreTests
                 e.AffectedNodeIds!.Contains("n1")),
             It.IsAny<CancellationToken>()), Times.Once);
     }
+
+    [Fact]
+    public async Task DeleteNodesAsync_DelegatesAndEmitsForgetAuditWithEdgeIds()
+    {
+        await _innerStore.AddNodesAsync([
+            new GraphNode { Id = "n1", Name = "A", Type = "Fact" },
+            new GraphNode { Id = "n2", Name = "B", Type = "Fact" }
+        ]);
+        await _innerStore.AddEdgesAsync([new GraphEdge
+        {
+            Id = "e1", SourceNodeId = "n1", TargetNodeId = "n2",
+            Predicate = "relates_to", ChunkId = "c1"
+        }]);
+
+        var result = await _store.DeleteNodesAsync(["n1"]);
+
+        result.NodesDeleted.Should().Be(1);
+        result.DeletedEdgeIds.Should().BeEquivalentTo(["e1"]);
+        _auditSink.Verify(s => s.EmitAsync(
+            It.Is<MemoryAuditEvent>(e =>
+                e.Action == MemoryAuditAction.Forget &&
+                e.AffectedNodeIds!.Contains("n1") &&
+                e.AffectedEdgeIds!.Contains("e1")),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task DeleteEdgesByOwnerAsync_DelegatesAndEmitsForgetAudit()
+    {
+        await _innerStore.AddNodesAsync([
+            new GraphNode { Id = "n1", Name = "A", Type = "Fact" },
+            new GraphNode { Id = "n2", Name = "B", Type = "Fact" }
+        ]);
+        await _innerStore.AddEdgesAsync([new GraphEdge
+        {
+            Id = "e1", SourceNodeId = "n1", TargetNodeId = "n2",
+            Predicate = "relates_to", ChunkId = "c1", OwnerId = "owner-x"
+        }]);
+
+        var deleted = await _store.DeleteEdgesByOwnerAsync("owner-x");
+
+        deleted.Should().BeEquivalentTo(["e1"]);
+        _auditSink.Verify(s => s.EmitAsync(
+            It.Is<MemoryAuditEvent>(e =>
+                e.Action == MemoryAuditAction.Forget &&
+                e.ScopeId == "owner-x" &&
+                e.AffectedEdgeIds!.Contains("e1")),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task DeleteEdgesByOwnerAsync_NothingDeleted_EmitsNoAudit()
+    {
+        var deleted = await _store.DeleteEdgesByOwnerAsync("owner-with-no-edges");
+
+        deleted.Should().BeEmpty();
+        _auditSink.Verify(s => s.EmitAsync(
+            It.IsAny<MemoryAuditEvent>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
 }
 
 /// <summary>

--- a/src/Content/Tests/Infrastructure.AI.KnowledgeGraph.Tests/Compliance/ComplianceAwareGraphStoreTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.KnowledgeGraph.Tests/Compliance/ComplianceAwareGraphStoreTests.cs
@@ -191,6 +191,72 @@ public sealed class ComplianceAwareGraphStoreTests
     }
 
     [Fact]
+    public async Task AddEdgesAsync_StampsOwnerFromScope()
+    {
+        // Edges must be owner-stamped on the live write path or the right-to-erasure
+        // owner-edge sweep (DeleteEdgesByOwnerAsync) can never match anything the harness
+        // writes. Unlike node ownership (which controls read visibility and is writer-
+        // authoritative), edge ownership is pure erasure attribution — triplet visibility
+        // is decided by the endpoints, so stamping is safe for reads.
+        await _innerStore.AddNodesAsync([
+            new GraphNode { Id = "n1", Name = "A", Type = "Fact" },
+            new GraphNode { Id = "n2", Name = "B", Type = "Fact" }
+        ]);
+
+        await _store.AddEdgesAsync([new GraphEdge
+        {
+            Id = "e1", SourceNodeId = "n1", TargetNodeId = "n2",
+            Predicate = "relates_to", ChunkId = "c1"
+        }]);
+
+        var stored = (await _innerStore.GetTripletsAsync(["n1"])).Single().Edge;
+        stored.OwnerId.Should().Be("user-1",
+            "the decorator must stamp the writing user's ID so their edges are erasable");
+    }
+
+    [Fact]
+    public async Task AddEdgesAsync_PreservesExplicitOwner()
+    {
+        await _innerStore.AddNodesAsync([
+            new GraphNode { Id = "n1", Name = "A", Type = "Fact" },
+            new GraphNode { Id = "n2", Name = "B", Type = "Fact" }
+        ]);
+
+        await _store.AddEdgesAsync([new GraphEdge
+        {
+            Id = "e1", SourceNodeId = "n1", TargetNodeId = "n2",
+            Predicate = "relates_to", ChunkId = "c1", OwnerId = "explicit-owner"
+        }]);
+
+        var stored = (await _innerStore.GetTripletsAsync(["n1"])).Single().Edge;
+        stored.OwnerId.Should().Be("explicit-owner");
+    }
+
+    [Fact]
+    public async Task DeleteNodesAsync_AuditReportsOnlyActuallyDeletedNodeIds()
+    {
+        await _innerStore.AddNodesAsync([new GraphNode { Id = "n1", Name = "A", Type = "Fact" }]);
+
+        await _store.DeleteNodesAsync(["n1", "does-not-exist"]);
+
+        _auditSink.Verify(s => s.EmitAsync(
+            It.Is<MemoryAuditEvent>(e =>
+                e.Action == MemoryAuditAction.Forget &&
+                e.AffectedNodeIds!.Count == 1 &&
+                e.AffectedNodeIds.Contains("n1")),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task DeleteNodesAsync_NothingDeleted_EmitsNoAudit()
+    {
+        await _store.DeleteNodesAsync(["does-not-exist"]);
+
+        _auditSink.Verify(s => s.EmitAsync(
+            It.IsAny<MemoryAuditEvent>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
     public async Task DeleteNodesAsync_DelegatesAndEmitsForgetAuditWithEdgeIds()
     {
         await _innerStore.AddNodesAsync([

--- a/src/Content/Tests/Infrastructure.AI.KnowledgeGraph.Tests/Compliance/DefaultErasureOrchestratorTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.KnowledgeGraph.Tests/Compliance/DefaultErasureOrchestratorTests.cs
@@ -25,6 +25,21 @@ public sealed class DefaultErasureOrchestratorTests
         _vectorStore = new Mock<IVectorStore>();
         _auditSink = new Mock<IMemoryAuditSink>();
 
+        // Default: the store deletes everything it is asked to and cascades no edges.
+        _graphStore.Setup(g => g.DeleteNodesAsync(
+                It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IReadOnlyList<string> ids, CancellationToken _) =>
+                new NodeDeletionResult { NodesDeleted = ids.Count, DeletedEdgeIds = [] });
+        _graphStore.Setup(g => g.DeleteEdgesByOwnerAsync(
+                It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+        _feedbackStore.Setup(f => f.DeleteWeightsByNodeIdsAsync(
+                It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IReadOnlyList<string> ids, CancellationToken _) => ids.Count);
+        _feedbackStore.Setup(f => f.DeleteWeightsByEdgeIdsAsync(
+                It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IReadOnlyList<string> ids, CancellationToken _) => ids.Count);
+
         _orchestrator = new DefaultErasureOrchestrator(
             _graphStore.Object,
             _feedbackStore.Object,
@@ -50,13 +65,66 @@ public sealed class DefaultErasureOrchestratorTests
         receipt.ScopeId.Should().Be("user-1");
         receipt.NodesDeleted.Should().Be(2);
 
-        _graphStore.Verify(g => g.DeleteNodeAsync("n1", It.IsAny<CancellationToken>()), Times.Once);
-        _graphStore.Verify(g => g.DeleteNodeAsync("n2", It.IsAny<CancellationToken>()), Times.Once);
+        _graphStore.Verify(g => g.DeleteNodesAsync(
+            It.Is<IReadOnlyList<string>>(ids => ids.Count == 2 && ids.Contains("n1") && ids.Contains("n2")),
+            It.IsAny<CancellationToken>()), Times.Once);
+        _graphStore.Verify(g => g.DeleteEdgesByOwnerAsync("user-1", It.IsAny<CancellationToken>()), Times.Once);
         _feedbackStore.Verify(f => f.DeleteWeightsByNodeIdsAsync(
             It.Is<IReadOnlyList<string>>(ids => ids.Count == 2),
             It.IsAny<CancellationToken>()), Times.Once);
         _auditSink.Verify(a => a.EmitAsync(
             It.Is<MemoryAuditEvent>(e => e.Action == MemoryAuditAction.Erasure),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task EraseByOwner_ReceiptUsesCountsReturnedByStores_NotRequestedCounts()
+    {
+        var nodes = new List<GraphNode>
+        {
+            new() { Id = "n1", Name = "Test1", Type = "Fact", OwnerId = "user-1" },
+            new() { Id = "n2", Name = "Test2", Type = "Fact", OwnerId = "user-1" }
+        };
+        _graphStore.Setup(g => g.GetNodesByOwnerAsync("user-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(nodes);
+
+        // The store reports fewer deletions than requested (e.g. a concurrent delete won).
+        _graphStore.Setup(g => g.DeleteNodesAsync(
+                It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new NodeDeletionResult { NodesDeleted = 1, DeletedEdgeIds = ["e-cascade"] });
+        _graphStore.Setup(g => g.DeleteEdgesByOwnerAsync("user-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(["e-owned"]);
+        _feedbackStore.Setup(f => f.DeleteWeightsByNodeIdsAsync(
+                It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+        _feedbackStore.Setup(f => f.DeleteWeightsByEdgeIdsAsync(
+                It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(2);
+
+        var receipt = await _orchestrator.EraseByOwnerAsync("user-1");
+
+        receipt.NodesDeleted.Should().Be(1, "the receipt must report the store's actual deletion count");
+        receipt.EdgesDeleted.Should().Be(2, "cascade edge + owner-scoped edge were actually removed");
+        receipt.FeedbackWeightsDeleted.Should().Be(3, "1 node weight + 2 edge weights were actually removed");
+    }
+
+    [Fact]
+    public async Task EraseByOwner_PurgesEdgeFeedbackForAllDeletedEdges()
+    {
+        _graphStore.Setup(g => g.GetNodesByOwnerAsync("user-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([new GraphNode { Id = "n1", Name = "T", Type = "Fact", OwnerId = "user-1" }]);
+        _graphStore.Setup(g => g.DeleteNodesAsync(
+                It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new NodeDeletionResult { NodesDeleted = 1, DeletedEdgeIds = ["e1", "e2"] });
+        _graphStore.Setup(g => g.DeleteEdgesByOwnerAsync("user-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(["e2", "e3"]);
+
+        await _orchestrator.EraseByOwnerAsync("user-1");
+
+        // Union of cascade + owner edges, deduplicated.
+        _feedbackStore.Verify(f => f.DeleteWeightsByEdgeIdsAsync(
+            It.Is<IReadOnlyList<string>>(ids =>
+                ids.Count == 3 && ids.Contains("e1") && ids.Contains("e2") && ids.Contains("e3")),
             It.IsAny<CancellationToken>()), Times.Once);
     }
 
@@ -84,7 +152,21 @@ public sealed class DefaultErasureOrchestratorTests
         var receipt = await _orchestrator.EraseByNodeIdsAsync(nodeIds);
 
         receipt.NodesDeleted.Should().Be(2);
-        _graphStore.Verify(g => g.DeleteNodeAsync("n1", It.IsAny<CancellationToken>()), Times.Once);
-        _graphStore.Verify(g => g.DeleteNodeAsync("n2", It.IsAny<CancellationToken>()), Times.Once);
+        _graphStore.Verify(g => g.DeleteNodesAsync(
+            It.Is<IReadOnlyList<string>>(ids => ids.Count == 2 && ids.Contains("n1") && ids.Contains("n2")),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task EraseByNodeIds_DoesNotSweepOwnerEdges()
+    {
+        _graphStore.Setup(g => g.GetNodeAsync("n1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new GraphNode { Id = "n1", Name = "T1", Type = "Fact", OwnerId = "user-1" });
+
+        await _orchestrator.EraseByNodeIdsAsync(["n1"]);
+
+        // Node-scoped erasure targets nodes, not the owner's whole edge set.
+        _graphStore.Verify(g => g.DeleteEdgesByOwnerAsync(
+            It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 }

--- a/src/Content/Tests/Infrastructure.AI.KnowledgeGraph.Tests/Compliance/DefaultErasureOrchestratorTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.KnowledgeGraph.Tests/Compliance/DefaultErasureOrchestratorTests.cs
@@ -29,7 +29,7 @@ public sealed class DefaultErasureOrchestratorTests
         _graphStore.Setup(g => g.DeleteNodesAsync(
                 It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((IReadOnlyList<string> ids, CancellationToken _) =>
-                new NodeDeletionResult { NodesDeleted = ids.Count, DeletedEdgeIds = [] });
+                new NodeDeletionResult { DeletedNodeIds = ids.ToList(), DeletedEdgeIds = [] });
         _graphStore.Setup(g => g.DeleteEdgesByOwnerAsync(
                 It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync([]);
@@ -91,7 +91,7 @@ public sealed class DefaultErasureOrchestratorTests
         // The store reports fewer deletions than requested (e.g. a concurrent delete won).
         _graphStore.Setup(g => g.DeleteNodesAsync(
                 It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new NodeDeletionResult { NodesDeleted = 1, DeletedEdgeIds = ["e-cascade"] });
+            .ReturnsAsync(new NodeDeletionResult { DeletedNodeIds = ["n1"], DeletedEdgeIds = ["e-cascade"] });
         _graphStore.Setup(g => g.DeleteEdgesByOwnerAsync("user-1", It.IsAny<CancellationToken>()))
             .ReturnsAsync(["e-owned"]);
         _feedbackStore.Setup(f => f.DeleteWeightsByNodeIdsAsync(
@@ -115,7 +115,7 @@ public sealed class DefaultErasureOrchestratorTests
             .ReturnsAsync([new GraphNode { Id = "n1", Name = "T", Type = "Fact", OwnerId = "user-1" }]);
         _graphStore.Setup(g => g.DeleteNodesAsync(
                 It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new NodeDeletionResult { NodesDeleted = 1, DeletedEdgeIds = ["e1", "e2"] });
+            .ReturnsAsync(new NodeDeletionResult { DeletedNodeIds = ["n1"], DeletedEdgeIds = ["e1", "e2"] });
         _graphStore.Setup(g => g.DeleteEdgesByOwnerAsync("user-1", It.IsAny<CancellationToken>()))
             .ReturnsAsync(["e2", "e3"]);
 
@@ -125,6 +125,29 @@ public sealed class DefaultErasureOrchestratorTests
         _feedbackStore.Verify(f => f.DeleteWeightsByEdgeIdsAsync(
             It.Is<IReadOnlyList<string>>(ids =>
                 ids.Count == 3 && ids.Contains("e1") && ids.Contains("e2") && ids.Contains("e3")),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task EraseByOwner_AuditRecordsActualDeletedIds_NotRequested()
+    {
+        _graphStore.Setup(g => g.GetNodesByOwnerAsync("user-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([
+                new GraphNode { Id = "n1", Name = "T1", Type = "Fact", OwnerId = "user-1" },
+                new GraphNode { Id = "n2", Name = "T2", Type = "Fact", OwnerId = "user-1" }
+            ]);
+        // The store only actually removed n1 (n2 raced away).
+        _graphStore.Setup(g => g.DeleteNodesAsync(
+                It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new NodeDeletionResult { DeletedNodeIds = ["n1"], DeletedEdgeIds = ["e1"] });
+
+        await _orchestrator.EraseByOwnerAsync("user-1");
+
+        _auditSink.Verify(a => a.EmitAsync(
+            It.Is<MemoryAuditEvent>(e =>
+                e.Action == MemoryAuditAction.Erasure &&
+                e.AffectedNodeIds!.Count == 1 && e.AffectedNodeIds.Contains("n1") &&
+                e.AffectedEdgeIds!.Contains("e1")),
             It.IsAny<CancellationToken>()), Times.Once);
     }
 

--- a/src/Content/Tests/Infrastructure.AI.KnowledgeGraph.Tests/Compliance/ErasureCompletenessTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.KnowledgeGraph.Tests/Compliance/ErasureCompletenessTests.cs
@@ -1,9 +1,12 @@
+using Application.AI.Common.Interfaces;
 using Application.AI.Common.Interfaces.KnowledgeGraph;
+using Domain.AI.KnowledgeGraph;
 using Domain.AI.KnowledgeGraph.Models;
 using FluentAssertions;
 using Infrastructure.AI.KnowledgeGraph.Compliance;
 using Infrastructure.AI.KnowledgeGraph.Feedback;
 using Infrastructure.AI.KnowledgeGraph.InMemory;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Xunit;
@@ -140,6 +143,85 @@ public sealed class ErasureCompletenessTests
         var weight = await _feedbackStore.GetEdgeWeightAsync("e-cascade");
         weight.UpdateCount.Should().Be(0,
             "feedback recorded against an erased edge is a dangling reference that leaks signal about erased data");
+    }
+
+    // ------------------------------------------------------------------
+    // Live write path — edges must be erasable WITHOUT hand-stamped OwnerId
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public async Task EraseByOwner_DeletesEdgeWrittenThroughLiveDecoratedStorePath()
+    {
+        // The shipped write path: callers write through ComplianceAwareGraphStore, which is
+        // responsible for stamping ownership metadata. If it does not stamp GraphEdge.OwnerId,
+        // the owner-edge sweep matches nothing the harness itself writes and erasure is inert.
+        var scope = Mock.Of<IKnowledgeScope>(s => s.UserId == "user-1" && s.TenantId == null);
+        var services = new ServiceCollection();
+        services.AddSingleton(scope);
+        var ambient = Mock.Of<IAmbientRequestScope>(a => a.Current == services.BuildServiceProvider());
+
+        var retention = new Mock<IRetentionPolicyProvider>();
+        retention.Setup(r => r.GetPolicy(It.IsAny<string>()))
+            .Returns(new RetentionPolicy { EntityType = "Entity", RetentionPeriod = TimeSpan.FromDays(365) });
+
+        var decoratedStore = new ComplianceAwareGraphStore(
+            _graphStore,
+            Mock.Of<IMemoryAuditSink>(),
+            ambient,
+            retention.Object,
+            TimeProvider.System,
+            NullLogger<ComplianceAwareGraphStore>.Instance);
+
+        // user-1 writes an edge between two SHARED (unowned) nodes through the live path,
+        // without setting OwnerId — exactly what every production call site does.
+        await decoratedStore.AddNodesAsync([Node("s1"), Node("s2")]);
+        await decoratedStore.AddEdgesAsync([Edge("e-live", "s1", "s2")]);
+
+        var orchestrator = new DefaultErasureOrchestrator(
+            decoratedStore,
+            _feedbackStore,
+            vectorStore: null,
+            Mock.Of<IMemoryAuditSink>(),
+            TimeProvider.System,
+            NullLogger<DefaultErasureOrchestrator>.Instance);
+
+        await orchestrator.EraseByOwnerAsync("user-1");
+
+        var remaining = (await _graphStore.GetTripletsAsync(["s1", "s2"]))
+            .Select(t => t.Edge.Id).Distinct().ToList();
+        remaining.Should().NotContain("e-live",
+            "an edge the erased user wrote through the live decorated store path must be erased");
+    }
+
+    // ------------------------------------------------------------------
+    // Audit truthfulness — audits must record what was DELETED, not requested
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public async Task EraseByNodeIds_AuditReportsOnlyNodesActuallyDeleted()
+    {
+        var auditSink = new Mock<IMemoryAuditSink>();
+        MemoryAuditEvent? captured = null;
+        auditSink.Setup(a => a.EmitAsync(It.IsAny<MemoryAuditEvent>(), It.IsAny<CancellationToken>()))
+            .Callback<MemoryAuditEvent, CancellationToken>((e, _) => captured = e)
+            .Returns(Task.CompletedTask);
+
+        var orchestrator = new DefaultErasureOrchestrator(
+            _graphStore,
+            _feedbackStore,
+            vectorStore: null,
+            auditSink.Object,
+            TimeProvider.System,
+            NullLogger<DefaultErasureOrchestrator>.Instance);
+
+        await _graphStore.AddNodesAsync([Node("n1", "user-1")]);
+
+        await orchestrator.EraseByNodeIdsAsync(["n1", "does-not-exist"]);
+
+        captured.Should().NotBeNull();
+        captured!.Action.Should().Be(MemoryAuditAction.Erasure);
+        captured.AffectedNodeIds.Should().BeEquivalentTo(["n1"],
+            "the erasure audit must record the nodes actually deleted, not the requested IDs");
     }
 
     [Fact]

--- a/src/Content/Tests/Infrastructure.AI.KnowledgeGraph.Tests/Compliance/ErasureCompletenessTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.KnowledgeGraph.Tests/Compliance/ErasureCompletenessTests.cs
@@ -1,0 +1,157 @@
+using Application.AI.Common.Interfaces.KnowledgeGraph;
+using Domain.AI.KnowledgeGraph.Models;
+using FluentAssertions;
+using Infrastructure.AI.KnowledgeGraph.Compliance;
+using Infrastructure.AI.KnowledgeGraph.Feedback;
+using Infrastructure.AI.KnowledgeGraph.InMemory;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Infrastructure.AI.KnowledgeGraph.Tests.Compliance;
+
+/// <summary>
+/// End-to-end erasure completeness tests (audit item D3) running the orchestrator against
+/// the REAL in-memory graph and feedback stores — not mocks — so they prove what actually
+/// remains in the stores after a right-to-erasure request:
+/// <list type="number">
+///   <item>Owner-scoped edges between surviving nodes are deleted, not just node-cascade edges.</item>
+///   <item><see cref="ErasureReceipt"/> counts reflect what the delete operations actually removed.</item>
+///   <item>Feedback weights referencing erased nodes AND edges are purged.</item>
+/// </list>
+/// </summary>
+public sealed class ErasureCompletenessTests
+{
+    private readonly InMemoryGraphStore _graphStore;
+    private readonly GraphFeedbackStore _feedbackStore;
+    private readonly DefaultErasureOrchestrator _orchestrator;
+
+    public ErasureCompletenessTests()
+    {
+        _graphStore = new InMemoryGraphStore(NullLogger<InMemoryGraphStore>.Instance);
+        _feedbackStore = new GraphFeedbackStore(
+            NullLogger<GraphFeedbackStore>.Instance, TimeProvider.System);
+
+        _orchestrator = new DefaultErasureOrchestrator(
+            _graphStore,
+            _feedbackStore,
+            vectorStore: null,
+            Mock.Of<IMemoryAuditSink>(),
+            TimeProvider.System,
+            NullLogger<DefaultErasureOrchestrator>.Instance);
+    }
+
+    private static GraphNode Node(string id, string? ownerId = null) => new()
+    {
+        Id = id, Name = id, Type = "Entity", OwnerId = ownerId
+    };
+
+    private static GraphEdge Edge(string id, string source, string target, string? ownerId = null) => new()
+    {
+        Id = id, SourceNodeId = source, TargetNodeId = target,
+        Predicate = "relates_to", ChunkId = "chunk-1", OwnerId = ownerId
+    };
+
+    // ------------------------------------------------------------------
+    // Finding 1 — owner-scoped edge deletion
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public async Task EraseByOwner_DeletesOwnerScopedEdgesBetweenSurvivingNodes()
+    {
+        // Shared nodes owned by nobody, plus one node owned by the erased subject.
+        await _graphStore.AddNodesAsync([Node("s1"), Node("s2"), Node("u1-node", "user-1")]);
+        await _graphStore.AddEdgesAsync([
+            Edge("e-owned-by-u1", "s1", "s2", "user-1"),   // owner's edge between SURVIVING nodes
+            Edge("e-cascade", "u1-node", "s2"),            // removed by node cascade
+            Edge("e-foreign", "s2", "s1", "user-2")        // another owner's edge — must survive
+        ]);
+
+        await _orchestrator.EraseByOwnerAsync("user-1");
+
+        var triplets = await _graphStore.GetTripletsAsync(["s1", "s2"]);
+        var remainingEdgeIds = triplets.Select(t => t.Edge.Id).Distinct().ToList();
+
+        remainingEdgeIds.Should().NotContain("e-owned-by-u1",
+            "erasing an owner must delete edges they own even when both endpoints survive");
+        remainingEdgeIds.Should().NotContain("e-cascade");
+        remainingEdgeIds.Should().Contain("e-foreign",
+            "erasure must not delete another owner's edges");
+    }
+
+    // ------------------------------------------------------------------
+    // Finding 2 — receipt counts must reflect actual deletions
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public async Task EraseByOwner_ReceiptReportsActualEdgesDeleted()
+    {
+        await _graphStore.AddNodesAsync([Node("s1"), Node("s2"), Node("u1-node", "user-1")]);
+        await _graphStore.AddEdgesAsync([
+            Edge("e-owned-by-u1", "s1", "s2", "user-1"),
+            Edge("e-cascade", "u1-node", "s2"),
+            Edge("e-foreign", "s2", "s1", "user-2")
+        ]);
+
+        var receipt = await _orchestrator.EraseByOwnerAsync("user-1");
+
+        receipt.NodesDeleted.Should().Be(1);
+        receipt.EdgesDeleted.Should().Be(2,
+            "the cascade edge and the owner-scoped edge were actually removed; the foreign edge was not");
+    }
+
+    [Fact]
+    public async Task EraseByOwner_ReceiptReportsActualFeedbackWeightsDeleted()
+    {
+        // Two owned nodes, but feedback was only ever recorded against one of them.
+        await _graphStore.AddNodesAsync([Node("n1", "user-1"), Node("n2", "user-1")]);
+        await _feedbackStore.ApplyNodeFeedbackAsync("n1", feedbackScore: 5.0, alpha: 0.3);
+
+        var receipt = await _orchestrator.EraseByOwnerAsync("user-1");
+
+        receipt.FeedbackWeightsDeleted.Should().Be(1,
+            "only one feedback weight actually existed, so only one was deleted");
+    }
+
+    [Fact]
+    public async Task EraseByNodeIds_ReceiptCountsOnlyNodesActuallyDeleted()
+    {
+        await _graphStore.AddNodesAsync([Node("n1", "user-1")]);
+
+        var receipt = await _orchestrator.EraseByNodeIdsAsync(["n1", "does-not-exist"]);
+
+        receipt.NodesDeleted.Should().Be(1,
+            "the receipt must report nodes the store actually removed, not the requested count");
+    }
+
+    // ------------------------------------------------------------------
+    // Finding 3 — feedback purge must cover edges
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public async Task EraseByOwner_PurgesFeedbackWeightsForErasedEdges()
+    {
+        await _graphStore.AddNodesAsync([Node("s1"), Node("u1-node", "user-1")]);
+        await _graphStore.AddEdgesAsync([Edge("e-cascade", "u1-node", "s1")]);
+        await _feedbackStore.ApplyEdgeFeedbackAsync("e-cascade", feedbackScore: 5.0, alpha: 0.3);
+
+        await _orchestrator.EraseByOwnerAsync("user-1");
+
+        var weight = await _feedbackStore.GetEdgeWeightAsync("e-cascade");
+        weight.UpdateCount.Should().Be(0,
+            "feedback recorded against an erased edge is a dangling reference that leaks signal about erased data");
+    }
+
+    [Fact]
+    public async Task EraseByOwner_PurgesFeedbackWeightsForOwnerScopedEdges()
+    {
+        await _graphStore.AddNodesAsync([Node("s1"), Node("s2"), Node("u1-node", "user-1")]);
+        await _graphStore.AddEdgesAsync([Edge("e-owned-by-u1", "s1", "s2", "user-1")]);
+        await _feedbackStore.ApplyEdgeFeedbackAsync("e-owned-by-u1", feedbackScore: 4.0, alpha: 0.3);
+
+        await _orchestrator.EraseByOwnerAsync("user-1");
+
+        var weight = await _feedbackStore.GetEdgeWeightAsync("e-owned-by-u1");
+        weight.UpdateCount.Should().Be(0);
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.KnowledgeGraph.Tests/Feedback/GraphFeedbackStoreTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.KnowledgeGraph.Tests/Feedback/GraphFeedbackStoreTests.cs
@@ -131,6 +131,41 @@ public sealed class GraphFeedbackStoreTests
         weight.Weight.Should().Be(1.0);
     }
 
+    [Fact]
+    public async Task DeleteWeightsByNodeIds_ReturnsActualDeletedCount()
+    {
+        await _store.ApplyNodeFeedbackAsync("n1", feedbackScore: 5.0, alpha: 0.3);
+
+        var deleted = await _store.DeleteWeightsByNodeIdsAsync(["n1", "never-had-feedback"]);
+
+        deleted.Should().Be(1, "only n1 had a recorded weight");
+        (await _store.GetNodeWeightAsync("n1")).UpdateCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task DeleteWeightsByEdgeIds_RemovesEdgeWeightsAndReturnsActualCount()
+    {
+        await _store.ApplyEdgeFeedbackAsync("e1", feedbackScore: 5.0, alpha: 0.3);
+        await _store.ApplyEdgeFeedbackAsync("e2", feedbackScore: 2.0, alpha: 0.3);
+
+        var deleted = await _store.DeleteWeightsByEdgeIdsAsync(["e1", "e2", "never-had-feedback"]);
+
+        deleted.Should().Be(2);
+        (await _store.GetEdgeWeightAsync("e1")).UpdateCount.Should().Be(0);
+        (await _store.GetEdgeWeightAsync("e2")).UpdateCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task DeleteWeightsByEdgeIds_DoesNotTouchNodeWeights()
+    {
+        await _store.ApplyNodeFeedbackAsync("shared-id", feedbackScore: 5.0, alpha: 0.3);
+
+        var deleted = await _store.DeleteWeightsByEdgeIdsAsync(["shared-id"]);
+
+        deleted.Should().Be(0);
+        (await _store.GetNodeWeightAsync("shared-id")).UpdateCount.Should().Be(1);
+    }
+
     private sealed class FakeTimeProvider : TimeProvider
     {
         private readonly DateTimeOffset _utcNow;

--- a/src/Content/Tests/Infrastructure.AI.KnowledgeGraph.Tests/InMemory/InMemoryGraphStoreTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.KnowledgeGraph.Tests/InMemory/InMemoryGraphStoreTests.cs
@@ -228,6 +228,53 @@ public sealed class InMemoryGraphStoreTests
         await _store.AddEdgesAsync([edge]);
     }
 
+    [Fact]
+    public async Task DeleteNodes_ReturnsActualCountsAndCascadedEdgeIds()
+    {
+        await _store.AddNodesAsync([
+            CreateNode("n1", "A", "Entity"),
+            CreateNode("n2", "B", "Entity"),
+            CreateNode("n3", "C", "Entity")
+        ]);
+        await _store.AddEdgesAsync([
+            CreateEdge("e1", "n1", "n2", "uses", "c1"),
+            CreateEdge("e2", "n3", "n1", "uses", "c1"),
+            CreateEdge("e3", "n2", "n3", "uses", "c1") // untouched by deleting n1
+        ]);
+
+        var result = await _store.DeleteNodesAsync(["n1", "missing"]);
+
+        result.NodesDeleted.Should().Be(1, "only n1 existed");
+        result.DeletedEdgeIds.Should().BeEquivalentTo(["e1", "e2"]);
+        (await _store.GetEdgeCountAsync()).Should().Be(1);
+        (await _store.GetNodeCountAsync()).Should().Be(2);
+    }
+
+    [Fact]
+    public async Task DeleteNodes_EmptyInput_ReturnsEmptyResult()
+    {
+        var result = await _store.DeleteNodesAsync([]);
+
+        result.NodesDeleted.Should().Be(0);
+        result.DeletedEdgeIds.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task DeleteEdgesByOwner_RemovesOnlyThatOwnersEdges()
+    {
+        await _store.AddNodesAsync([CreateNode("n1", "A", "Entity"), CreateNode("n2", "B", "Entity")]);
+        await _store.AddEdgesAsync([
+            CreateEdge("e-owned", "n1", "n2", "uses", "c1") with { OwnerId = "user-1" },
+            CreateEdge("e-foreign", "n2", "n1", "uses", "c1") with { OwnerId = "user-2" },
+            CreateEdge("e-unowned", "n1", "n2", "cites", "c1")
+        ]);
+
+        var deleted = await _store.DeleteEdgesByOwnerAsync("user-1");
+
+        deleted.Should().BeEquivalentTo(["e-owned"]);
+        (await _store.GetEdgeCountAsync()).Should().Be(2, "foreign and unowned edges must survive");
+    }
+
     private static GraphNode CreateNode(
         string id, string name, string type, string[]? chunkIds = null) =>
         new()

--- a/src/Content/Tests/Infrastructure.AI.KnowledgeGraph.Tests/Neo4j/Neo4jGraphStoreTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.KnowledgeGraph.Tests/Neo4j/Neo4jGraphStoreTests.cs
@@ -240,4 +240,70 @@ public sealed class Neo4jGraphStoreTests : IClassFixture<Neo4jStoreFixture>
         triplet.Edge.Provenance.ExtractionConfidence.Should().BeApproximately(0.55, 1e-9);
         triplet.Edge.Provenance.Timestamp.Should().BeCloseTo(stamp.Timestamp, TimeSpan.FromSeconds(1));
     }
+
+    [Fact]
+    public async Task DeleteNodesAsync_ReturnsActualCountsAndCascadedEdgeIds()
+    {
+        await _store.AddNodesAsync([
+            new GraphNode { Id = "neo-del-1", Name = "A", Type = "Entity" },
+            new GraphNode { Id = "neo-del-2", Name = "B", Type = "Entity" },
+            new GraphNode { Id = "neo-del-3", Name = "C", Type = "Entity" }
+        ]);
+        await _store.AddEdgesAsync([
+            new GraphEdge
+            {
+                Id = "neo-del-e1", SourceNodeId = "neo-del-1", TargetNodeId = "neo-del-2",
+                Predicate = "links", ChunkId = "c1"
+            },
+            new GraphEdge
+            {
+                Id = "neo-del-e2", SourceNodeId = "neo-del-3", TargetNodeId = "neo-del-1",
+                Predicate = "links", ChunkId = "c1"
+            },
+            new GraphEdge
+            {
+                Id = "neo-del-e3", SourceNodeId = "neo-del-2", TargetNodeId = "neo-del-3",
+                Predicate = "links", ChunkId = "c1"
+            }
+        ]);
+
+        // One requested id does not exist and must not be counted.
+        var result = await _store.DeleteNodesAsync(["neo-del-1", "neo-del-missing"]);
+
+        result.NodesDeleted.Should().Be(1);
+        result.DeletedEdgeIds.Should().BeEquivalentTo(["neo-del-e1", "neo-del-e2"]);
+        (await _store.GetNodeAsync("neo-del-1")).Should().BeNull();
+        (await _store.GetNodeAsync("neo-del-2")).Should().NotBeNull();
+        (await _store.GetTripletsAsync(["neo-del-2", "neo-del-3"]))
+            .Select(t => t.Edge.Id).Should().Contain("neo-del-e3");
+    }
+
+    [Fact]
+    public async Task DeleteEdgesByOwnerAsync_RemovesOnlyThatOwnersEdges()
+    {
+        await _store.AddNodesAsync([
+            new GraphNode { Id = "neo-oe-1", Name = "A", Type = "Entity" },
+            new GraphNode { Id = "neo-oe-2", Name = "B", Type = "Entity" }
+        ]);
+        await _store.AddEdgesAsync([
+            new GraphEdge
+            {
+                Id = "neo-oe-owned", SourceNodeId = "neo-oe-1", TargetNodeId = "neo-oe-2",
+                Predicate = "links", ChunkId = "c1", OwnerId = "neo-erase-owner"
+            },
+            new GraphEdge
+            {
+                Id = "neo-oe-foreign", SourceNodeId = "neo-oe-2", TargetNodeId = "neo-oe-1",
+                Predicate = "links", ChunkId = "c1", OwnerId = "neo-other-owner"
+            }
+        ]);
+
+        var deleted = await _store.DeleteEdgesByOwnerAsync("neo-erase-owner");
+
+        deleted.Should().BeEquivalentTo(["neo-oe-owned"]);
+        var remaining = (await _store.GetTripletsAsync(["neo-oe-1", "neo-oe-2"]))
+            .Select(t => t.Edge.Id).Distinct().ToList();
+        remaining.Should().Contain("neo-oe-foreign");
+        remaining.Should().NotContain("neo-oe-owned");
+    }
 }

--- a/src/Content/Tests/Infrastructure.AI.KnowledgeGraph.Tests/PostgreSql/PostgreSqlGraphStoreTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.KnowledgeGraph.Tests/PostgreSql/PostgreSqlGraphStoreTests.cs
@@ -135,4 +135,70 @@ public sealed class PostgreSqlGraphStoreTests : IClassFixture<PostgreSqlStoreFix
         triplets[0].Source.TenantId.Should().Be("tenant-a");
         triplets[0].Target.Id.Should().Be("pg-t");
     }
+
+    [Fact]
+    public async Task DeleteNodesAsync_ReturnsActualCountsAndCascadedEdgeIds()
+    {
+        await _store.AddNodesAsync([
+            new GraphNode { Id = "pg-del-1", Name = "A", Type = "Entity" },
+            new GraphNode { Id = "pg-del-2", Name = "B", Type = "Entity" },
+            new GraphNode { Id = "pg-del-3", Name = "C", Type = "Entity" }
+        ]);
+        await _store.AddEdgesAsync([
+            new GraphEdge
+            {
+                Id = "pg-del-e1", SourceNodeId = "pg-del-1", TargetNodeId = "pg-del-2",
+                Predicate = "links", ChunkId = "c1"
+            },
+            new GraphEdge
+            {
+                Id = "pg-del-e2", SourceNodeId = "pg-del-3", TargetNodeId = "pg-del-1",
+                Predicate = "links", ChunkId = "c1"
+            },
+            new GraphEdge
+            {
+                Id = "pg-del-e3", SourceNodeId = "pg-del-2", TargetNodeId = "pg-del-3",
+                Predicate = "links", ChunkId = "c1"
+            }
+        ]);
+
+        // One requested id does not exist and must not be counted.
+        var result = await _store.DeleteNodesAsync(["pg-del-1", "pg-del-missing"]);
+
+        result.NodesDeleted.Should().Be(1);
+        result.DeletedEdgeIds.Should().BeEquivalentTo(["pg-del-e1", "pg-del-e2"]);
+        (await _store.GetNodeAsync("pg-del-1")).Should().BeNull();
+        (await _store.GetNodeAsync("pg-del-2")).Should().NotBeNull();
+        (await _store.GetTripletsAsync(["pg-del-2", "pg-del-3"]))
+            .Select(t => t.Edge.Id).Should().Contain("pg-del-e3");
+    }
+
+    [Fact]
+    public async Task DeleteEdgesByOwnerAsync_RemovesOnlyThatOwnersEdges()
+    {
+        await _store.AddNodesAsync([
+            new GraphNode { Id = "pg-oe-1", Name = "A", Type = "Entity" },
+            new GraphNode { Id = "pg-oe-2", Name = "B", Type = "Entity" }
+        ]);
+        await _store.AddEdgesAsync([
+            new GraphEdge
+            {
+                Id = "pg-oe-owned", SourceNodeId = "pg-oe-1", TargetNodeId = "pg-oe-2",
+                Predicate = "links", ChunkId = "c1", OwnerId = "pg-erase-owner"
+            },
+            new GraphEdge
+            {
+                Id = "pg-oe-foreign", SourceNodeId = "pg-oe-2", TargetNodeId = "pg-oe-1",
+                Predicate = "links", ChunkId = "c1", OwnerId = "pg-other-owner"
+            }
+        ]);
+
+        var deleted = await _store.DeleteEdgesByOwnerAsync("pg-erase-owner");
+
+        deleted.Should().BeEquivalentTo(["pg-oe-owned"]);
+        var remaining = (await _store.GetTripletsAsync(["pg-oe-1", "pg-oe-2"]))
+            .Select(t => t.Edge.Id).Distinct().ToList();
+        remaining.Should().Contain("pg-oe-foreign");
+        remaining.Should().NotContain("pg-oe-owned");
+    }
 }

--- a/src/Content/Tests/Infrastructure.AI.KnowledgeGraph.Tests/Scoping/TenantIsolatedGraphStoreTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.KnowledgeGraph.Tests/Scoping/TenantIsolatedGraphStoreTests.cs
@@ -244,6 +244,72 @@ public sealed class TenantIsolatedGraphStoreTests
         ids.Should().BeEquivalentTo(["mine", "tenantShared", "global"]);
     }
 
+    // --- Batch deletion (right-to-erasure primitives) ---
+
+    [Fact]
+    public async Task DeleteNodes_ScopedCaller_SkipsForeignNodesButDeletesOwn()
+    {
+        await SeedNode("mine", owner: UserA);
+        await SeedNode("theirs", owner: UserB);
+        var store = StoreFor(UserA);
+
+        var result = await store.DeleteNodesAsync(["mine", "theirs"]);
+
+        result.NodesDeleted.Should().Be(1);
+        (await _innerStore.GetNodeAsync("mine")).Should().BeNull();
+        (await _innerStore.GetNodeAsync("theirs")).Should().NotBeNull(
+            "a scoped caller must never cascade-delete another user's node");
+    }
+
+    [Fact]
+    public async Task DeleteNodes_NoAmbientScope_DeletesEverythingRequested()
+    {
+        // Right-to-erasure runs system-scoped and must reach foreign-owned nodes.
+        await SeedNode("theirs", owner: UserB);
+        var store = SystemStore();
+
+        var result = await store.DeleteNodesAsync(["theirs"]);
+
+        result.NodesDeleted.Should().Be(1);
+        (await _innerStore.GetNodeAsync("theirs")).Should().BeNull();
+    }
+
+    [Fact]
+    public async Task DeleteEdgesByOwner_ScopedCaller_ForeignOwner_IsBlocked()
+    {
+        await SeedNode("s", owner: null);
+        await SeedNode("t", owner: null);
+        await _innerStore.AddEdgesAsync([new GraphEdge
+        {
+            Id = "e1", SourceNodeId = "s", TargetNodeId = "t",
+            Predicate = "relates_to", ChunkId = "c1", OwnerId = UserB
+        }]);
+        var store = StoreFor(UserA);
+
+        var deleted = await store.DeleteEdgesByOwnerAsync(UserB);
+
+        deleted.Should().BeEmpty("a scoped caller cannot erase another owner's edges");
+        (await _innerStore.GetEdgeCountAsync()).Should().Be(1);
+    }
+
+    [Fact]
+    public async Task DeleteEdgesByOwner_NoAmbientScope_DeletesOwnersEdges()
+    {
+        await SeedNode("s", owner: null);
+        await SeedNode("t", owner: null);
+        await _innerStore.AddEdgesAsync([new GraphEdge
+        {
+            Id = "e1", SourceNodeId = "s", TargetNodeId = "t",
+            Predicate = "relates_to", ChunkId = "c1", OwnerId = UserB
+        }]);
+        var store = SystemStore();
+
+        var deleted = await store.DeleteEdgesByOwnerAsync(UserB);
+
+        deleted.Should().BeEquivalentTo(["e1"]);
+        (await _innerStore.GetEdgeCountAsync()).Should().Be(0);
+    }
+
     private Task SeedNode(string id, string? owner) =>
         _innerStore.AddNodesAsync([new GraphNode { Id = id, Name = id, Type = "Fact", OwnerId = owner }]);
 

--- a/src/Content/Tests/Infrastructure.AI.RAG.Tests/GraphRag/KuzuGraphBackendTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.RAG.Tests/GraphRag/KuzuGraphBackendTests.cs
@@ -223,4 +223,66 @@ public sealed class KuzuGraphBackendTests : IDisposable
         var triplets = await _sut.GetTripletsAsync(["n2"]);
         Assert.Empty(triplets);
     }
+
+    // ── DeleteNodesAsync / DeleteEdgesByOwnerAsync (erasure primitives) ──────
+
+    [Fact]
+    public async Task DeleteNodesAsync_ReturnsActualCountsAndCascadedEdgeIds()
+    {
+        // Arrange
+        await _sut.AddNodesAsync([
+            new GraphNode { Id = "n1", Name = "A", Type = "T", ChunkIds = ["c1"] },
+            new GraphNode { Id = "n2", Name = "B", Type = "T", ChunkIds = ["c1"] },
+            new GraphNode { Id = "n3", Name = "C", Type = "T", ChunkIds = ["c1"] }
+        ]);
+        await _sut.AddEdgesAsync([
+            new GraphEdge { Id = "e1", SourceNodeId = "n1", TargetNodeId = "n2", Predicate = "links", ChunkId = "c1" },
+            new GraphEdge { Id = "e2", SourceNodeId = "n3", TargetNodeId = "n1", Predicate = "links", ChunkId = "c1" },
+            new GraphEdge { Id = "e3", SourceNodeId = "n2", TargetNodeId = "n3", Predicate = "links", ChunkId = "c1" }
+        ]);
+
+        // Act — one requested id does not exist and must not be counted
+        var result = await _sut.DeleteNodesAsync(["n1", "missing"]);
+
+        // Assert
+        Assert.Equal(1, result.NodesDeleted);
+        Assert.Equal(["e1", "e2"], result.DeletedEdgeIds.OrderBy(x => x, StringComparer.Ordinal));
+        Assert.Null(await _sut.GetNodeAsync("n1"));
+        Assert.Equal(1, await _sut.GetEdgeCountAsync());
+        Assert.Equal(2, await _sut.GetNodeCountAsync());
+    }
+
+    [Fact]
+    public async Task DeleteEdgesByOwnerAsync_RemovesOnlyThatOwnersEdges()
+    {
+        // Arrange
+        await _sut.AddNodesAsync([
+            new GraphNode { Id = "n1", Name = "A", Type = "T", ChunkIds = ["c1"] },
+            new GraphNode { Id = "n2", Name = "B", Type = "T", ChunkIds = ["c1"] }
+        ]);
+        await _sut.AddEdgesAsync([
+            new GraphEdge
+            {
+                Id = "e-owned", SourceNodeId = "n1", TargetNodeId = "n2",
+                Predicate = "links", ChunkId = "c1", OwnerId = "user-1"
+            },
+            new GraphEdge
+            {
+                Id = "e-foreign", SourceNodeId = "n2", TargetNodeId = "n1",
+                Predicate = "links", ChunkId = "c1", OwnerId = "user-2"
+            },
+            new GraphEdge
+            {
+                Id = "e-unowned", SourceNodeId = "n1", TargetNodeId = "n2",
+                Predicate = "cites", ChunkId = "c1"
+            }
+        ]);
+
+        // Act
+        var deleted = await _sut.DeleteEdgesByOwnerAsync("user-1");
+
+        // Assert
+        Assert.Equal(["e-owned"], deleted);
+        Assert.Equal(2, await _sut.GetEdgeCountAsync());
+    }
 }


### PR DESCRIPTION
## Summary
Wave-2 audit item **D3** (Infrastructure.AI.KnowledgeGraph), reproduce-test-first, plus adversarial-review fixes (verdict was MERGE AFTER FIXES; all blockers fixed and re-proven).

### 1. Owner-scoped edges now actually erased
- New `IKnowledgeGraphStore.DeleteEdgesByOwnerAsync(ownerId)` (returns deleted edge IDs), wired into `DefaultErasureOrchestrator.EraseByOwnerAsync`, implemented across in-memory, Neo4j, PostgreSQL, and Kuzu plus both decorators (tenant isolation gates scoped callers; system scope passes through).
- **Review fix (the critical one):** the sweep was inert — no live write path ever stamped `GraphEdge.OwnerId`, so it matched nothing the harness itself writes. `ComplianceAwareGraphStore.AddEdgesAsync` now stamps `OwnerId = e.OwnerId ?? CurrentUserId`, mirroring the existing TenantId stamping. Repro test writes an edge through the live decorated store (no hand-stamping) and proves erasure removes it — red pre-fix, green post. No read regression (triplet visibility filters by endpoints; all backends coalesce-preserve on rewrite).

### 2. Truthful receipts and audits
- `ErasureReceipt` counts now come solely from what stores actually deleted: new batch `DeleteNodesAsync` returns `NodeDeletionResult` with `DeletedNodeIds` (count computed from the list — cannot drift); `IFeedbackStore` deletes return actual counts; `EdgesDeleted` is the deduped union of cascade + owner-swept edges (previously hardcoded 0).
- **Review fix:** Forget audit events now record the *actually deleted* node IDs (not the requested set, which could include nonexistent or tenant-filtered foreign IDs) and are skipped entirely when nothing was deleted.
- `VectorEmbeddingsDeleted` documented honestly as chunk-IDs-submitted (`IVectorStore.DeleteAsync` returns void; changing that RAG-wide interface is out of scope).

### 3. Feedback-weight purge
New `IFeedbackStore.DeleteWeightsByEdgeIdsAsync`; erasure purges node and edge weights for all erased graph elements — no dangling feedback referencing erased data skewing future feedback-weighted retrieval.

### 4. Backend correctness (review fixes)
- **Kuzu/SQLite:** node/edge erasure now runs in single SQLite transactions — fixes both crash-mid-sequence partial state and a shared `_TempIds` temp-table race with concurrent readers. Verified live against real SQLite.
- **Neo4j:** null-safe ID materialization — a legacy edge without an `id` property can no longer inject null into the feedback purge and fault the whole erasure.

## Test plan
- [x] Reproduce-first: 6 original + 5 review repro tests all red pre-fix, green post (real in-memory graph + feedback stores; live decorated store path)
- [x] KnowledgeGraph.Tests 279/279, RAG.Tests 219/219 (non-E2E, local); Kuzu live-verified
- [x] Neo4j + PostgreSQL Testcontainers erasure tests execute in **this PR's CI** — verified `ci.yml` runs `dotnet test` with no category filter on ubuntu (Docker available); Docker is unavailable on the dev machine
- [x] gitnexus: `IKnowledgeGraphStore` HIGH blast radius — all 6 implementers deliberately updated; orchestrator/feedback LOW

## Tracked backlog (pre-existing gaps, deliberately NOT this PR)
Cross-session memory store (separate Kuzu backend) untouched by erasure; work episodes/segments/learnings not owner-stamped; BM25/RAPTOR artifacts never purged; crash-retry orphans vector embeddings; retention-path vector purge collects zero chunks; scope-degraded partial erasure still yields a success receipt; owner-ID case-sensitivity drift between gate and stores.

🤖 Generated with [Claude Code](https://claude.com/claude-code)