### PR TITLE
fix: make prompt composer scoped, ending captive singleton context

### DIFF
--- a/src/Content/Infrastructure/Infrastructure.AI.Evaluation/Invokers/HarnessAgentInvoker.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.Evaluation/Invokers/HarnessAgentInvoker.cs
@@ -5,6 +5,7 @@ using Application.AI.Common.Evaluation.Models;
 using Application.Core.CQRS.Agents.ExecuteAgentTurn;
 using Domain.AI.Evaluation;
 using MediatR;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
 namespace Infrastructure.AI.Evaluation.Invokers;
@@ -33,20 +34,24 @@ public sealed class HarnessAgentInvoker : IAgentInvoker
     private const string DeploymentKey = "deployment";
     private const string TemperatureKey = "temperature";
 
-    private readonly IMediator _mediator;
+    private readonly IServiceScopeFactory _scopeFactory;
     private readonly ILogger<HarnessAgentInvoker> _logger;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="HarnessAgentInvoker"/> class.
     /// </summary>
-    /// <param name="mediator">MediatR dispatcher used to send the agent-turn command.</param>
+    /// <param name="scopeFactory">Scope factory used to resolve <see cref="IMediator"/> per invocation.
+    /// The invoker is a SINGLETON, but an agent-turn dispatch constructs pipeline behaviors that
+    /// ctor-inject the SCOPED <c>IAgentExecutionContext</c>, so each invocation runs inside a
+    /// fresh scope rather than against a root-bound mediator — which also gives every eval case
+    /// its own execution context instead of sharing one across the whole run.</param>
     /// <param name="logger">Logger for invocation diagnostics.</param>
-    public HarnessAgentInvoker(IMediator mediator, ILogger<HarnessAgentInvoker> logger)
+    public HarnessAgentInvoker(IServiceScopeFactory scopeFactory, ILogger<HarnessAgentInvoker> logger)
     {
-        ArgumentNullException.ThrowIfNull(mediator);
+        ArgumentNullException.ThrowIfNull(scopeFactory);
         ArgumentNullException.ThrowIfNull(logger);
 
-        _mediator = mediator;
+        _scopeFactory = scopeFactory;
         _logger = logger;
     }
 
@@ -78,7 +83,12 @@ public sealed class HarnessAgentInvoker : IAgentInvoker
 
         try
         {
-            var turn = await _mediator.Send(command, cancellationToken).ConfigureAwait(false);
+            // Dispatch inside a fresh scope: the MediatR pipeline resolves scoped services
+            // (IAgentExecutionContext et al.), which a singleton must never pull from the root.
+            await using var scope = _scopeFactory.CreateAsyncScope();
+            var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+
+            var turn = await mediator.Send(command, cancellationToken).ConfigureAwait(false);
             sw.Stop();
 
             // Per AgentInvocationResult contract: Output must be empty when Success is false.

--- a/src/Content/Infrastructure/Infrastructure.AI/Compaction/ContextCompactionService.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Compaction/ContextCompactionService.cs
@@ -18,7 +18,7 @@ public sealed class ContextCompactionService : IContextCompactionService
 {
     private readonly IReadOnlyDictionary<CompactionStrategy, ICompactionStrategyExecutor> _strategies;
     private readonly IHookExecutor _hookExecutor;
-    private readonly ISystemPromptComposer _promptComposer;
+    private readonly IPromptSectionCache _sectionCache;
     private readonly IAutoCompactStateMachine _stateMachine;
     private readonly IOptionsMonitor<AppConfig> _options;
     private readonly ILogger<ContextCompactionService> _logger;
@@ -28,21 +28,23 @@ public sealed class ContextCompactionService : IContextCompactionService
     /// </summary>
     /// <param name="strategies">All registered compaction strategy executors.</param>
     /// <param name="hookExecutor">Hook executor for PreCompact/PostCompact lifecycle events.</param>
-    /// <param name="promptComposer">System prompt composer whose cache is invalidated after compaction.</param>
+    /// <param name="sectionCache">Prompt section cache invalidated after compaction. Injected
+    /// directly (not via the scoped <c>ISystemPromptComposer</c>) so this singleton never
+    /// captures per-request composition state.</param>
     /// <param name="stateMachine">Circuit breaker state machine for auto-compact tracking.</param>
     /// <param name="options">Application configuration containing compaction settings.</param>
     /// <param name="logger">Logger for compaction operations.</param>
     public ContextCompactionService(
         IEnumerable<ICompactionStrategyExecutor> strategies,
         IHookExecutor hookExecutor,
-        ISystemPromptComposer promptComposer,
+        IPromptSectionCache sectionCache,
         IAutoCompactStateMachine stateMachine,
         IOptionsMonitor<AppConfig> options,
         ILogger<ContextCompactionService> logger)
     {
         _strategies = strategies.ToDictionary(s => s.Strategy);
         _hookExecutor = hookExecutor;
-        _promptComposer = promptComposer;
+        _sectionCache = sectionCache;
         _stateMachine = stateMachine;
         _options = options;
         _logger = logger;
@@ -84,7 +86,7 @@ public sealed class ContextCompactionService : IContextCompactionService
             };
 
             await _hookExecutor.ExecuteHooksAsync(HookEvent.PostCompact, postContext, cancellationToken);
-            _promptComposer.InvalidateAll();
+            _sectionCache.InvalidateAll();
             _stateMachine.RecordSuccess(agentId);
 
             _logger.LogInformation(

--- a/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.Tools.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.Tools.cs
@@ -54,9 +54,11 @@ public static partial class DependencyInjection
         services.AddKeyedSingleton<ITool>(DocumentSearchTool.ToolName, (sp, _) =>
             new DocumentSearchTool(sp.GetRequiredService<IRagOrchestrator>()));
 
-        // Document ingest tool — RAG pipeline ingestion for LLM consumption
+        // Document ingest tool — RAG pipeline ingestion for LLM consumption.
+        // Takes the scope factory (not IMediator): the mediator pipeline resolves
+        // scoped services, so the singleton tool dispatches inside a fresh scope.
         services.AddKeyedSingleton<ITool>(DocumentIngestTool.ToolName, (sp, _) =>
-            new DocumentIngestTool(sp.GetRequiredService<IMediator>()));
+            new DocumentIngestTool(sp.GetRequiredService<IServiceScopeFactory>()));
 
         // Echo tools — deterministic tools for E2E testing pipeline verification
         services.AddKeyedSingleton<ITool>(EchoLookupTool.ToolName, (_, _) => new EchoLookupTool());

--- a/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.cs
@@ -215,13 +215,7 @@ public static partial class DependencyInjection
 
         // --- System prompt composition ---
 
-        services.AddSingleton<IPromptSectionCache, InMemoryPromptSectionCache>();
-        services.AddSingleton<ISystemPromptComposer, MemoizedPromptComposer>();
-        services.AddTransient<IPromptSectionProvider, AgentIdentitySectionProvider>();
-        services.AddTransient<IPromptSectionProvider, ToolSchemasSectionProvider>();
-        services.AddTransient<IPromptSectionProvider, PermissionRulesSectionProvider>();
-        services.AddTransient<IPromptSectionProvider, SessionStateSectionProvider>();
-        services.AddSingleton<IPromptCacheTracker, Sha256PromptCacheTracker>();
+        services.AddSystemPromptComposition();
 
         // --- Context compaction ---
 

--- a/src/Content/Infrastructure/Infrastructure.AI/GitOps/GitOpsRemediationDispatcher.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/GitOps/GitOpsRemediationDispatcher.cs
@@ -4,6 +4,7 @@ using Domain.AI.Changes;
 using Domain.AI.GitOps;
 using Domain.Common;
 using MediatR;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
 namespace Infrastructure.AI.GitOps;
@@ -32,16 +33,21 @@ namespace Infrastructure.AI.GitOps;
 /// </remarks>
 public sealed class GitOpsRemediationDispatcher : IGitOpsRemediationDispatcher
 {
-    private readonly IMediator _mediator;
+    private readonly IServiceScopeFactory _scopeFactory;
     private readonly ILogger<GitOpsRemediationDispatcher> _logger;
 
     /// <summary>Initializes a new <see cref="GitOpsRemediationDispatcher"/>.</summary>
-    public GitOpsRemediationDispatcher(IMediator mediator, ILogger<GitOpsRemediationDispatcher> logger)
+    /// <param name="scopeFactory">Scope factory used to resolve <see cref="IMediator"/> per dispatch.
+    /// The dispatcher is a SINGLETON, but a mediator dispatch constructs pipeline behaviors that
+    /// ctor-inject the SCOPED <c>IAgentExecutionContext</c>, so each dispatch runs inside a fresh
+    /// scope rather than against a root-bound mediator.</param>
+    /// <param name="logger">Logger for dispatch diagnostics.</param>
+    public GitOpsRemediationDispatcher(IServiceScopeFactory scopeFactory, ILogger<GitOpsRemediationDispatcher> logger)
     {
-        ArgumentNullException.ThrowIfNull(mediator);
+        ArgumentNullException.ThrowIfNull(scopeFactory);
         ArgumentNullException.ThrowIfNull(logger);
 
-        _mediator = mediator;
+        _scopeFactory = scopeFactory;
         _logger = logger;
     }
 
@@ -72,7 +78,12 @@ public sealed class GitOpsRemediationDispatcher : IGitOpsRemediationDispatcher
 
         try
         {
-            var result = await _mediator.Send(command, cancellationToken).ConfigureAwait(false);
+            // Dispatch inside a fresh scope: the MediatR pipeline resolves scoped services
+            // (IAgentExecutionContext et al.), which a singleton must never pull from the root.
+            await using var scope = _scopeFactory.CreateAsyncScope();
+            var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+
+            var result = await mediator.Send(command, cancellationToken).ConfigureAwait(false);
             if (!result.IsSuccess)
             {
                 _logger.LogWarning(

--- a/src/Content/Infrastructure/Infrastructure.AI/Iac/BicepGenerator.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Iac/BicepGenerator.cs
@@ -4,6 +4,7 @@ using Domain.AI.Iac;
 using Domain.AI.Sandbox;
 using Domain.Common;
 using Domain.Common.Config;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -37,27 +38,33 @@ public sealed class BicepGenerator : IIacGenerator
     private const string MainFile = "main.bicep";
 
     private readonly IOptionsMonitor<AppConfig> _config;
-    private readonly ISandboxExecutor _sandbox;
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly SandboxIsolationLevel _isolationLevel;
     private readonly ILogger<BicepGenerator> _logger;
     private readonly TimeProvider _timeProvider;
 
     /// <summary>Initialises a new <see cref="BicepGenerator"/>.</summary>
     /// <param name="config">Application configuration monitor — supplies version pins, registry allowlist, and blocking severity.</param>
-    /// <param name="sandbox">The Process-isolation sandbox executor the CLIs run inside.</param>
+    /// <param name="scopeFactory">Scope factory used to resolve the keyed-SCOPED <see cref="ISandboxExecutor"/> per CLI run.
+    /// The generator is a keyed SINGLETON, so a construction-time executor would be a captive dependency
+    /// that scope validation rejects and that shares scoped state across requests.</param>
     /// <param name="logger">Structured logger.</param>
     /// <param name="timeProvider">Clock abstraction (injected for parity and future use).</param>
+    /// <param name="isolationLevel">The sandbox isolation level to resolve the executor for. Defaults to <see cref="SandboxIsolationLevel.Process"/>.</param>
     public BicepGenerator(
         IOptionsMonitor<AppConfig> config,
-        ISandboxExecutor sandbox,
+        IServiceScopeFactory scopeFactory,
         ILogger<BicepGenerator> logger,
-        TimeProvider timeProvider)
+        TimeProvider timeProvider,
+        SandboxIsolationLevel isolationLevel = SandboxIsolationLevel.Process)
     {
         ArgumentNullException.ThrowIfNull(config);
-        ArgumentNullException.ThrowIfNull(sandbox);
+        ArgumentNullException.ThrowIfNull(scopeFactory);
         ArgumentNullException.ThrowIfNull(logger);
         ArgumentNullException.ThrowIfNull(timeProvider);
         _config = config;
-        _sandbox = sandbox;
+        _scopeFactory = scopeFactory;
+        _isolationLevel = isolationLevel;
         _logger = logger;
         _timeProvider = timeProvider;
     }
@@ -167,7 +174,12 @@ public sealed class BicepGenerator : IIacGenerator
     {
         try
         {
-            return await IacSandboxRunner.RunAsync(program, args, moduleDirectory, allowlist, _sandbox, toolName, cancellationToken: cancellationToken);
+            // The executor is SCOPED — resolve it from a fresh scope per run
+            // so this singleton generator never captures scope-bound state.
+            await using var scope = _scopeFactory.CreateAsyncScope();
+            var sandbox = scope.ServiceProvider.GetRequiredKeyedService<ISandboxExecutor>(_isolationLevel);
+
+            return await IacSandboxRunner.RunAsync(program, args, moduleDirectory, allowlist, sandbox, toolName, cancellationToken: cancellationToken);
         }
         catch (OperationCanceledException)
         {

--- a/src/Content/Infrastructure/Infrastructure.AI/Iac/TerraformGenerator.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Iac/TerraformGenerator.cs
@@ -4,6 +4,7 @@ using Domain.AI.Iac;
 using Domain.AI.Sandbox;
 using Domain.Common;
 using Domain.Common.Config;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -30,27 +31,33 @@ public sealed class TerraformGenerator : IIacGenerator
     private const string TfsecProgram = "tfsec";
 
     private readonly IOptionsMonitor<AppConfig> _config;
-    private readonly ISandboxExecutor _sandbox;
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly SandboxIsolationLevel _isolationLevel;
     private readonly ILogger<TerraformGenerator> _logger;
     private readonly TimeProvider _timeProvider;
 
     /// <summary>Initialises a new <see cref="TerraformGenerator"/>.</summary>
     /// <param name="config">Application configuration monitor — supplies version pins, registry allowlist, and blocking severity.</param>
-    /// <param name="sandbox">The Process-isolation sandbox executor the CLIs run inside.</param>
+    /// <param name="scopeFactory">Scope factory used to resolve the keyed-SCOPED <see cref="ISandboxExecutor"/> per CLI run.
+    /// The generator is a keyed SINGLETON, so a construction-time executor would be a captive dependency
+    /// that scope validation rejects and that shares scoped state across requests.</param>
     /// <param name="logger">Structured logger.</param>
     /// <param name="timeProvider">Clock abstraction (unused for timing here but injected for parity and future use).</param>
+    /// <param name="isolationLevel">The sandbox isolation level to resolve the executor for. Defaults to <see cref="SandboxIsolationLevel.Process"/>.</param>
     public TerraformGenerator(
         IOptionsMonitor<AppConfig> config,
-        ISandboxExecutor sandbox,
+        IServiceScopeFactory scopeFactory,
         ILogger<TerraformGenerator> logger,
-        TimeProvider timeProvider)
+        TimeProvider timeProvider,
+        SandboxIsolationLevel isolationLevel = SandboxIsolationLevel.Process)
     {
         ArgumentNullException.ThrowIfNull(config);
-        ArgumentNullException.ThrowIfNull(sandbox);
+        ArgumentNullException.ThrowIfNull(scopeFactory);
         ArgumentNullException.ThrowIfNull(logger);
         ArgumentNullException.ThrowIfNull(timeProvider);
         _config = config;
-        _sandbox = sandbox;
+        _scopeFactory = scopeFactory;
+        _isolationLevel = isolationLevel;
         _logger = logger;
         _timeProvider = timeProvider;
     }
@@ -168,7 +175,12 @@ public sealed class TerraformGenerator : IIacGenerator
     {
         try
         {
-            return await IacSandboxRunner.RunAsync(program, args, moduleDirectory, allowlist, _sandbox, toolName, cancellationToken: cancellationToken);
+            // The executor is SCOPED — resolve it from a fresh scope per run
+            // so this singleton generator never captures scope-bound state.
+            await using var scope = _scopeFactory.CreateAsyncScope();
+            var sandbox = scope.ServiceProvider.GetRequiredKeyedService<ISandboxExecutor>(_isolationLevel);
+
+            return await IacSandboxRunner.RunAsync(program, args, moduleDirectory, allowlist, sandbox, toolName, cancellationToken: cancellationToken);
         }
         catch (OperationCanceledException)
         {

--- a/src/Content/Infrastructure/Infrastructure.AI/Orchestration/Magentic/MagenticChangeProposalRouter.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Orchestration/Magentic/MagenticChangeProposalRouter.cs
@@ -2,6 +2,7 @@ using Application.AI.Common.CQRS.Changes.SubmitChangeProposal;
 using Domain.AI.Changes;
 using Domain.Common;
 using MediatR;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
 namespace Infrastructure.AI.Orchestration.Magentic;
@@ -35,7 +36,7 @@ namespace Infrastructure.AI.Orchestration.Magentic;
 /// </remarks>
 public sealed class MagenticChangeProposalRouter
 {
-    private readonly IMediator _mediator;
+    private readonly IServiceScopeFactory _scopeFactory;
     private readonly ILogger<MagenticChangeProposalRouter> _logger;
 
     private static readonly string[] DefaultStateChangeVerbs =
@@ -53,9 +54,17 @@ public sealed class MagenticChangeProposalRouter
     /// <summary>
     /// Creates a router that submits qualifying replans via MediatR.
     /// </summary>
-    public MagenticChangeProposalRouter(IMediator mediator, ILogger<MagenticChangeProposalRouter> logger)
+    /// <param name="scopeFactory">Scope factory used to resolve <see cref="IMediator"/> per routed replan.
+    /// The router is a SINGLETON, but a mediator dispatch constructs pipeline behaviors that
+    /// ctor-inject the SCOPED <c>IAgentExecutionContext</c>, so each submission runs inside a
+    /// fresh scope rather than against a root-bound mediator.</param>
+    /// <param name="logger">Logger for routing diagnostics.</param>
+    public MagenticChangeProposalRouter(IServiceScopeFactory scopeFactory, ILogger<MagenticChangeProposalRouter> logger)
     {
-        _mediator = mediator;
+        ArgumentNullException.ThrowIfNull(scopeFactory);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _scopeFactory = scopeFactory;
         _logger = logger;
     }
 
@@ -101,7 +110,12 @@ public sealed class MagenticChangeProposalRouter
         Result<ChangeProposal> result;
         try
         {
-            result = await _mediator.Send(command, ct).ConfigureAwait(false);
+            // Dispatch inside a fresh scope: the MediatR pipeline resolves scoped services
+            // (IAgentExecutionContext et al.), which a singleton must never pull from the root.
+            await using var scope = _scopeFactory.CreateAsyncScope();
+            var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+
+            result = await mediator.Send(command, ct).ConfigureAwait(false);
         }
         catch (Exception ex)
         {

--- a/src/Content/Infrastructure/Infrastructure.AI/Prompts/MemoizedPromptComposer.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Prompts/MemoizedPromptComposer.cs
@@ -12,6 +12,12 @@ namespace Infrastructure.AI.Prompts;
 /// Non-cacheable sections are recomputed on every call. Sections exceeding the token
 /// budget are dropped from the end (lowest priority = highest number).
 /// </summary>
+/// <remarks>
+/// Registered SCOPED: section providers consume the scoped <c>IAgentExecutionContext</c>,
+/// so each request scope must compose against its own live conversation state. Memoized
+/// cacheable sections still survive across requests via the singleton
+/// <see cref="IPromptSectionCache"/>.
+/// </remarks>
 public sealed class MemoizedPromptComposer : ISystemPromptComposer
 {
     private readonly IReadOnlyList<IPromptSectionProvider> _providers;

--- a/src/Content/Infrastructure/Infrastructure.AI/Prompts/PromptCompositionDependencyInjection.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Prompts/PromptCompositionDependencyInjection.cs
@@ -1,0 +1,42 @@
+using Application.AI.Common.Interfaces.Prompts;
+using Infrastructure.AI.Prompts.Sections;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Infrastructure.AI.Prompts;
+
+/// <summary>
+/// DI registrations for section-based system prompt composition.
+/// </summary>
+public static class PromptCompositionDependencyInjection
+{
+    /// <summary>
+    /// Registers the system prompt composition pipeline: the singleton
+    /// <see cref="IPromptSectionCache"/> (memoization survives across requests), the scoped
+    /// <see cref="ISystemPromptComposer"/>, the built-in <see cref="IPromptSectionProvider"/>
+    /// implementations, and the <see cref="IPromptCacheTracker"/>.
+    /// </summary>
+    /// <remarks>
+    /// Section providers consume the scoped <c>IAgentExecutionContext</c>, so the composer is
+    /// registered SCOPED — each request scope composes against its own live conversation state.
+    /// A singleton composer would capture the root-scope context at first resolution and every
+    /// conversation would see stale or cross-request session state (audit finding H2). Memoized
+    /// cacheable sections still persist across requests because the backing
+    /// <see cref="IPromptSectionCache"/> stays a singleton.
+    /// </remarks>
+    /// <param name="services">The service collection.</param>
+    /// <returns>The service collection, for chaining.</returns>
+    public static IServiceCollection AddSystemPromptComposition(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.AddSingleton<IPromptSectionCache, InMemoryPromptSectionCache>();
+        services.AddScoped<ISystemPromptComposer, MemoizedPromptComposer>();
+        services.AddTransient<IPromptSectionProvider, AgentIdentitySectionProvider>();
+        services.AddTransient<IPromptSectionProvider, ToolSchemasSectionProvider>();
+        services.AddTransient<IPromptSectionProvider, PermissionRulesSectionProvider>();
+        services.AddTransient<IPromptSectionProvider, SessionStateSectionProvider>();
+        services.AddSingleton<IPromptCacheTracker, Sha256PromptCacheTracker>();
+
+        return services;
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Prompts/Sections/AgentIdentitySectionProvider.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Prompts/Sections/AgentIdentitySectionProvider.cs
@@ -1,5 +1,4 @@
 using Application.AI.Common.Helpers;
-using Application.AI.Common.Interfaces.Agent;
 using Application.AI.Common.Interfaces.Prompts;
 using Domain.AI.Prompts;
 
@@ -10,20 +9,16 @@ namespace Infrastructure.AI.Prompts.Sections;
 /// This is always the highest-priority section (Priority = 10) and is cacheable
 /// because agent identity does not change within a conversation.
 /// </summary>
+/// <remarks>
+/// The section content is a pure function of the <c>agentId</c> parameter — the
+/// same value the singleton <c>IPromptSectionCache</c> keys on. It must NOT be
+/// derived from the scoped <c>IAgentExecutionContext</c>: a cacheable section
+/// whose content depends on per-scope state but whose cache key does not would
+/// let one conversation's identity poison the cached section served to another
+/// conversation composing for the same <c>agentId</c>.
+/// </remarks>
 public sealed class AgentIdentitySectionProvider : IPromptSectionProvider
 {
-    private readonly IAgentExecutionContext _executionContext;
-
-    /// <summary>
-    /// Initializes a new instance of <see cref="AgentIdentitySectionProvider"/>.
-    /// </summary>
-    /// <param name="executionContext">The scoped agent execution context.</param>
-    public AgentIdentitySectionProvider(IAgentExecutionContext executionContext)
-    {
-        ArgumentNullException.ThrowIfNull(executionContext);
-        _executionContext = executionContext;
-    }
-
     /// <inheritdoc />
     public SystemPromptSectionType SectionType => SystemPromptSectionType.AgentIdentity;
 
@@ -32,13 +27,11 @@ public sealed class AgentIdentitySectionProvider : IPromptSectionProvider
         string agentId,
         CancellationToken cancellationToken = default)
     {
-        var agentName = _executionContext.AgentId ?? agentId;
-
         // Without identity info, we can't produce a meaningful section
-        if (string.IsNullOrEmpty(agentName))
+        if (string.IsNullOrEmpty(agentId))
             return Task.FromResult<SystemPromptSection?>(null);
 
-        var content = $"You are {agentName}.";
+        var content = $"You are {agentId}.";
 
         var section = new SystemPromptSection(
             Name: "Agent Identity",

--- a/src/Content/Infrastructure/Infrastructure.AI/README.md
+++ b/src/Content/Infrastructure/Infrastructure.AI/README.md
@@ -113,8 +113,8 @@ var decision = await _permissionService.ResolvePermissionAsync(
 **Why it exists:** System prompts are complex. They include agent identity, tool schemas, permission rules, skill instructions, and session state. Each section changes at different rates (tool schemas change when MCP servers connect; session state changes every turn). Section-based caching avoids regenerating the entire prompt when only one part changes.
 
 **How it works:**
-- `MemoizedPromptComposer` iterates `IPromptSectionProvider` instances, each contributing a section.
-- `InMemoryPromptSectionCache` caches each section independently.
+- `MemoizedPromptComposer` (scoped — its providers read the scoped `IAgentExecutionContext`, so each request composes against its own conversation state) iterates `IPromptSectionProvider` instances, each contributing a section.
+- `InMemoryPromptSectionCache` (singleton) caches each section independently, so memoization survives across request scopes.
 - `Sha256PromptCacheTracker` detects which section caused a prompt cache break between turns.
 
 Four built-in section providers:
@@ -345,7 +345,7 @@ Infrastructure.AI/
 | `ChatClientFactory` | Multi-provider LLM client creation | `IChatClientFactory` | Singleton |
 | `ThreePhasePermissionResolver` | Tool permission evaluation | `IToolPermissionService` | Singleton |
 | `ContextCompactionService` | Context reduction orchestration | `IContextCompactionService` | Singleton |
-| `MemoizedPromptComposer` | Section-based prompt assembly | `ISystemPromptComposer` | Singleton |
+| `MemoizedPromptComposer` | Section-based prompt assembly | `ISystemPromptComposer` | Scoped |
 | `CompositeHookExecutor` | Lifecycle hook execution | `IHookExecutor` | Transient |
 | `BatchedToolExecutionStrategy` | Concurrent/serial tool dispatch | `IToolExecutionStrategy` | Transient |
 | `FileSystemService` | Sandboxed file I/O | `IFileSystemService` | Singleton |

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/DocumentIngestTool.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/DocumentIngestTool.cs
@@ -4,6 +4,7 @@ using Application.Core.CQRS.RAG.IngestDocument;
 using Domain.AI.Changes;
 using Domain.AI.Models;
 using MediatR;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Infrastructure.AI.Tools;
 
@@ -17,13 +18,20 @@ namespace Infrastructure.AI.Tools;
 /// Register via keyed DI:
 /// <code>
 /// services.AddKeyedSingleton&lt;ITool&gt;("document_ingest", (sp, _) =&gt;
-///     new DocumentIngestTool(sp.GetRequiredService&lt;IMediator&gt;()));
+///     new DocumentIngestTool(sp.GetRequiredService&lt;IServiceScopeFactory&gt;()));
 /// </code>
 /// </para>
 /// <para>
 /// This tool is write-oriented and not concurrency-safe because ingestion
 /// modifies vector store and BM25 index state. The batched tool execution
 /// strategy will serialize calls to this tool.
+/// </para>
+/// <para>
+/// The tool is a keyed SINGLETON, but a mediator dispatch constructs pipeline
+/// behaviors that ctor-inject the SCOPED <c>IAgentExecutionContext</c>, so
+/// each ingestion resolves <see cref="IMediator"/> from a fresh DI scope via
+/// <see cref="IServiceScopeFactory"/> — a root-bound mediator would be a
+/// captive dependency rejected by scope validation.
 /// </para>
 /// </remarks>
 public sealed class DocumentIngestTool : ITool
@@ -33,16 +41,16 @@ public sealed class DocumentIngestTool : ITool
 
     private static readonly IReadOnlyList<string> Operations = ["ingest"];
 
-    private readonly IMediator _mediator;
+    private readonly IServiceScopeFactory _scopeFactory;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="DocumentIngestTool"/> class.
     /// </summary>
-    /// <param name="mediator">MediatR mediator for dispatching ingestion commands.</param>
-    public DocumentIngestTool(IMediator mediator)
+    /// <param name="scopeFactory">Scope factory used to resolve <see cref="IMediator"/> per ingestion dispatch.</param>
+    public DocumentIngestTool(IServiceScopeFactory scopeFactory)
     {
-        ArgumentNullException.ThrowIfNull(mediator);
-        _mediator = mediator;
+        ArgumentNullException.ThrowIfNull(scopeFactory);
+        _scopeFactory = scopeFactory;
     }
 
     /// <inheritdoc />
@@ -102,7 +110,12 @@ public sealed class DocumentIngestTool : ITool
             CollectionName = collection
         };
 
-        var result = await _mediator.Send(command, cancellationToken);
+        // Dispatch inside a fresh scope: the MediatR pipeline resolves scoped services
+        // (IAgentExecutionContext et al.), which a singleton must never pull from the root.
+        await using var scope = _scopeFactory.CreateAsyncScope();
+        var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+
+        var result = await mediator.Send(command, cancellationToken);
 
         if (!result.Success)
             return ToolResult.Fail($"Ingestion failed: {result.Error}");

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/Iac/DependencyInjection.Iac.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/Iac/DependencyInjection.Iac.cs
@@ -30,11 +30,14 @@ namespace Infrastructure.AI.Tools.Iac;
 /// </list>
 /// </para>
 /// <para>
-/// The generators are keyed singletons that resolve the <c>Process</c>-isolation
-/// <see cref="ISandboxExecutor"/> at construction — the same pattern the workspace
-/// skill pack uses for its verifier tools. Registrations are unconditional (the
-/// tools are inert until a skill resolves them); <see cref="IacStartupValidator"/>
-/// turns a bad config into a fail-loud boot error whenever the skill pack is enabled.
+/// The generators are keyed SINGLETONS but <see cref="ISandboxExecutor"/> is keyed
+/// SCOPED, so each generator resolves the <c>Process</c>-isolation executor per CLI
+/// run from a fresh DI scope (via <see cref="IServiceScopeFactory"/>) — the same
+/// pattern the workspace skill pack uses for its verifier tools. A construction-time
+/// executor would be a captive dependency rejected by scope validation. Registrations
+/// are unconditional (the tools are inert until a skill resolves them);
+/// <see cref="IacStartupValidator"/> turns a bad config into a fail-loud boot error
+/// whenever the skill pack is enabled.
 /// </para>
 /// </remarks>
 public static class IacDependencyInjection
@@ -50,19 +53,24 @@ public static class IacDependencyInjection
         ArgumentNullException.ThrowIfNull(services);
 
         // --- Generators, keyed by backend canonical key ---
+        // The generators take the scope factory (not ISandboxExecutor): the executor is
+        // keyed SCOPED, so each CLI run resolves it from a fresh scope instead of the
+        // singleton factory capturing it from the root provider.
         services.AddKeyedSingleton<IIacGenerator>(IacBackendKeys.Terraform, static (sp, _) =>
             new TerraformGenerator(
                 sp.GetRequiredService<IOptionsMonitor<AppConfig>>(),
-                sp.GetRequiredKeyedService<ISandboxExecutor>(SandboxIsolationLevel.Process),
+                sp.GetRequiredService<IServiceScopeFactory>(),
                 sp.GetRequiredService<ILogger<TerraformGenerator>>(),
-                sp.GetRequiredService<TimeProvider>()));
+                sp.GetRequiredService<TimeProvider>(),
+                SandboxIsolationLevel.Process));
 
         services.AddKeyedSingleton<IIacGenerator>(IacBackendKeys.Bicep, static (sp, _) =>
             new BicepGenerator(
                 sp.GetRequiredService<IOptionsMonitor<AppConfig>>(),
-                sp.GetRequiredKeyedService<ISandboxExecutor>(SandboxIsolationLevel.Process),
+                sp.GetRequiredService<IServiceScopeFactory>(),
                 sp.GetRequiredService<ILogger<BicepGenerator>>(),
-                sp.GetRequiredService<TimeProvider>()));
+                sp.GetRequiredService<TimeProvider>(),
+                SandboxIsolationLevel.Process));
 
         // --- Agent-facing tools (keyed by ToolName) ---
         services.AddKeyedSingleton<ITool>(IacGenerateTool.ToolName, static (sp, _) =>

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/Workspace/DependencyInjection.WorkspaceTools.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/Workspace/DependencyInjection.WorkspaceTools.cs
@@ -2,7 +2,6 @@ using Application.AI.Common.Interfaces.Sandbox;
 using Application.AI.Common.Interfaces.Tools;
 using Application.AI.Common.Interfaces.Workspace;
 using Domain.AI.Sandbox;
-using MediatR;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Infrastructure.AI.Tools.Workspace;
@@ -27,16 +26,20 @@ namespace Infrastructure.AI.Tools.Workspace;
 /// </para>
 /// <para>
 /// The accessor is a singleton because the backing store is per-async-flow,
-/// not per-DI-scope. Tools are singletons; their only state is the injected
-/// accessor + executor + mediator.
+/// not per-DI-scope. Tools are singletons; scope-bound collaborators (the
+/// keyed-SCOPED <see cref="ISandboxExecutor"/>, the request-scoped MediatR
+/// pipeline) are resolved per execution from a fresh scope via
+/// <see cref="IServiceScopeFactory"/> — never captured at construction, so a
+/// singleton tool can never hold captive scoped state.
 /// </para>
 /// <para>
-/// The sandbox executor is resolved as a keyed singleton on
+/// The sandbox executor is registered keyed SCOPED on
 /// <see cref="SandboxIsolationLevel"/> elsewhere in the DI graph. The
 /// workspace tools pull the <c>Process</c> isolation level by default — the
 /// sandbox lives on the host but enforces capability + resource limits via
 /// Job Objects (Windows) / cgroups (Linux). Consumers that prefer Docker can
-/// override the registration after calling this method.
+/// override the registration after calling this method (the tools accept the
+/// isolation level as a constructor argument).
 /// </para>
 /// </remarks>
 public static class WorkspaceDependencyInjection
@@ -63,17 +66,19 @@ public static class WorkspaceDependencyInjection
         services.AddKeyedSingleton<ITool>(WorkspaceWriteFileTool.ToolName, (sp, _) =>
             new WorkspaceWriteFileTool(
                 sp.GetRequiredService<IWorkspaceContextAccessor>(),
-                sp.GetRequiredService<IMediator>()));
+                sp.GetRequiredService<IServiceScopeFactory>()));
 
         services.AddKeyedSingleton<ITool>(WorkspaceRunTestsTool.ToolName, (sp, _) =>
             new WorkspaceRunTestsTool(
                 sp.GetRequiredService<IWorkspaceContextAccessor>(),
-                sp.GetRequiredKeyedService<ISandboxExecutor>(SandboxIsolationLevel.Process)));
+                sp.GetRequiredService<IServiceScopeFactory>(),
+                SandboxIsolationLevel.Process));
 
         services.AddKeyedSingleton<ITool>(WorkspaceRunLintTool.ToolName, (sp, _) =>
             new WorkspaceRunLintTool(
                 sp.GetRequiredService<IWorkspaceContextAccessor>(),
-                sp.GetRequiredKeyedService<ISandboxExecutor>(SandboxIsolationLevel.Process)));
+                sp.GetRequiredService<IServiceScopeFactory>(),
+                SandboxIsolationLevel.Process));
 
         return services;
     }

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/Workspace/WorkspaceRunLintTool.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/Workspace/WorkspaceRunLintTool.cs
@@ -3,6 +3,8 @@ using Application.AI.Common.Interfaces.Tools;
 using Application.AI.Common.Interfaces.Workspace;
 using Domain.AI.Changes;
 using Domain.AI.Models;
+using Domain.AI.Sandbox;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Infrastructure.AI.Tools.Workspace;
 
@@ -13,10 +15,19 @@ namespace Infrastructure.AI.Tools.Workspace;
 /// resource limits; the tool only resolves which command to run.
 /// </summary>
 /// <remarks>
+/// <para>
 /// Lint is treated as a separate capability so a workspace can opt in to
 /// tests but not lint (or vice versa) without having to fold both into a
 /// single command. Both tools expose the same operation name (<c>run</c>)
 /// so the agent's mental model stays consistent.
+/// </para>
+/// <para>
+/// The tool is a keyed SINGLETON but <see cref="ISandboxExecutor"/> is keyed
+/// SCOPED, so the executor is resolved per execution from a fresh DI scope
+/// (via <see cref="IServiceScopeFactory"/>) instead of being captured at
+/// construction — a captured executor would be a captive dependency that
+/// scope validation rejects and that shares scoped state across requests.
+/// </para>
 /// </remarks>
 public sealed class WorkspaceRunLintTool : ITool
 {
@@ -26,19 +37,25 @@ public sealed class WorkspaceRunLintTool : ITool
     private static readonly IReadOnlyList<string> Operations = ["run"];
 
     private readonly IWorkspaceContextAccessor _workspace;
-    private readonly ISandboxExecutor _sandbox;
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly SandboxIsolationLevel _isolationLevel;
 
     /// <summary>
     /// Initialises a new instance of the <see cref="WorkspaceRunLintTool"/> class.
     /// </summary>
     /// <param name="workspace">Ambient accessor exposing the active sandbox workspace.</param>
-    /// <param name="sandbox">Sandbox executor used to dispatch the lint command in isolation.</param>
-    public WorkspaceRunLintTool(IWorkspaceContextAccessor workspace, ISandboxExecutor sandbox)
+    /// <param name="scopeFactory">Scope factory used to resolve the scoped sandbox executor per execution.</param>
+    /// <param name="isolationLevel">The sandbox isolation level to resolve the executor for. Defaults to <see cref="SandboxIsolationLevel.Process"/>.</param>
+    public WorkspaceRunLintTool(
+        IWorkspaceContextAccessor workspace,
+        IServiceScopeFactory scopeFactory,
+        SandboxIsolationLevel isolationLevel = SandboxIsolationLevel.Process)
     {
         ArgumentNullException.ThrowIfNull(workspace);
-        ArgumentNullException.ThrowIfNull(sandbox);
+        ArgumentNullException.ThrowIfNull(scopeFactory);
         _workspace = workspace;
-        _sandbox = sandbox;
+        _scopeFactory = scopeFactory;
+        _isolationLevel = isolationLevel;
     }
 
     /// <inheritdoc />
@@ -70,10 +87,15 @@ public sealed class WorkspaceRunLintTool : ITool
         if (!workspace.HasLintCommand)
             return ToolResult.Fail("Workspace has no LintCommand configured.");
 
+        // The executor is SCOPED — resolve it from a fresh scope per execution
+        // so this singleton tool never captures scope-bound state.
+        await using var scope = _scopeFactory.CreateAsyncScope();
+        var sandbox = scope.ServiceProvider.GetRequiredKeyedService<ISandboxExecutor>(_isolationLevel);
+
         return await WorkspaceCommandRunner.RunAsync(
             workspace.LintCommand,
             workspace,
-            _sandbox,
+            sandbox,
             ToolName,
             timeout: null,
             cancellationToken);

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/Workspace/WorkspaceRunTestsTool.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/Workspace/WorkspaceRunTestsTool.cs
@@ -3,6 +3,8 @@ using Application.AI.Common.Interfaces.Tools;
 using Application.AI.Common.Interfaces.Workspace;
 using Domain.AI.Changes;
 using Domain.AI.Models;
+using Domain.AI.Sandbox;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Infrastructure.AI.Tools.Workspace;
 
@@ -19,6 +21,13 @@ namespace Infrastructure.AI.Tools.Workspace;
 /// rewiring the tool. The sandbox enforces the resource limits +
 /// capability profile — the tool itself never spawns processes directly.
 /// </para>
+/// <para>
+/// The tool is a keyed SINGLETON but <see cref="ISandboxExecutor"/> is keyed
+/// SCOPED, so the executor is resolved per execution from a fresh DI scope
+/// (via <see cref="IServiceScopeFactory"/>) instead of being captured at
+/// construction — a captured executor would be a captive dependency that
+/// scope validation rejects and that shares scoped state across requests.
+/// </para>
 /// </remarks>
 public sealed class WorkspaceRunTestsTool : ITool
 {
@@ -28,19 +37,25 @@ public sealed class WorkspaceRunTestsTool : ITool
     private static readonly IReadOnlyList<string> Operations = ["run"];
 
     private readonly IWorkspaceContextAccessor _workspace;
-    private readonly ISandboxExecutor _sandbox;
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly SandboxIsolationLevel _isolationLevel;
 
     /// <summary>
     /// Initialises a new instance of the <see cref="WorkspaceRunTestsTool"/> class.
     /// </summary>
     /// <param name="workspace">Ambient accessor exposing the active sandbox workspace.</param>
-    /// <param name="sandbox">Sandbox executor used to dispatch the test command in isolation.</param>
-    public WorkspaceRunTestsTool(IWorkspaceContextAccessor workspace, ISandboxExecutor sandbox)
+    /// <param name="scopeFactory">Scope factory used to resolve the scoped sandbox executor per execution.</param>
+    /// <param name="isolationLevel">The sandbox isolation level to resolve the executor for. Defaults to <see cref="SandboxIsolationLevel.Process"/>.</param>
+    public WorkspaceRunTestsTool(
+        IWorkspaceContextAccessor workspace,
+        IServiceScopeFactory scopeFactory,
+        SandboxIsolationLevel isolationLevel = SandboxIsolationLevel.Process)
     {
         ArgumentNullException.ThrowIfNull(workspace);
-        ArgumentNullException.ThrowIfNull(sandbox);
+        ArgumentNullException.ThrowIfNull(scopeFactory);
         _workspace = workspace;
-        _sandbox = sandbox;
+        _scopeFactory = scopeFactory;
+        _isolationLevel = isolationLevel;
     }
 
     /// <inheritdoc />
@@ -72,10 +87,15 @@ public sealed class WorkspaceRunTestsTool : ITool
         if (!workspace.HasTestCommand)
             return ToolResult.Fail("Workspace has no TestCommand configured.");
 
+        // The executor is SCOPED — resolve it from a fresh scope per execution
+        // so this singleton tool never captures scope-bound state.
+        await using var scope = _scopeFactory.CreateAsyncScope();
+        var sandbox = scope.ServiceProvider.GetRequiredKeyedService<ISandboxExecutor>(_isolationLevel);
+
         return await WorkspaceCommandRunner.RunAsync(
             workspace.TestCommand,
             workspace,
-            _sandbox,
+            sandbox,
             ToolName,
             timeout: null,
             cancellationToken);

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/Workspace/WorkspaceWriteFileTool.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/Workspace/WorkspaceWriteFileTool.cs
@@ -5,6 +5,7 @@ using Domain.AI.Changes;
 using Domain.AI.Models;
 using Domain.AI.SkillTraining;
 using MediatR;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Infrastructure.AI.Tools.Workspace;
 
@@ -38,19 +39,22 @@ public sealed class WorkspaceWriteFileTool : ITool
     private static readonly IReadOnlyList<string> Operations = ["submit"];
 
     private readonly IWorkspaceContextAccessor _workspace;
-    private readonly IMediator _mediator;
+    private readonly IServiceScopeFactory _scopeFactory;
 
     /// <summary>
     /// Initialises a new instance of the <see cref="WorkspaceWriteFileTool"/> class.
     /// </summary>
     /// <param name="workspace">Ambient accessor exposing the active sandbox workspace.</param>
-    /// <param name="mediator">MediatR dispatcher used to submit the <see cref="SubmitChangeProposalCommand"/>.</param>
-    public WorkspaceWriteFileTool(IWorkspaceContextAccessor workspace, IMediator mediator)
+    /// <param name="scopeFactory">Scope factory used to resolve <see cref="IMediator"/> per submission.
+    /// The tool is a keyed SINGLETON, but a mediator dispatch constructs pipeline behaviors that
+    /// ctor-inject the SCOPED <c>IAgentExecutionContext</c>, so the dispatch must run inside a
+    /// created scope rather than against a root-bound mediator.</param>
+    public WorkspaceWriteFileTool(IWorkspaceContextAccessor workspace, IServiceScopeFactory scopeFactory)
     {
         ArgumentNullException.ThrowIfNull(workspace);
-        ArgumentNullException.ThrowIfNull(mediator);
+        ArgumentNullException.ThrowIfNull(scopeFactory);
         _workspace = workspace;
-        _mediator = mediator;
+        _scopeFactory = scopeFactory;
     }
 
     /// <inheritdoc />
@@ -140,7 +144,12 @@ public sealed class WorkspaceWriteFileTool : ITool
             IsStateChange = true
         };
 
-        var result = await _mediator.Send(command, cancellationToken);
+        // Dispatch inside a fresh scope: the MediatR pipeline resolves scoped services
+        // (IAgentExecutionContext et al.), which a singleton must never pull from the root.
+        await using var scope = _scopeFactory.CreateAsyncScope();
+        var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+
+        var result = await mediator.Send(command, cancellationToken);
         if (!result.IsSuccess)
         {
             var reason = result.Errors.Count > 0

--- a/src/Content/Presentation/Presentation.AgentHub/Program.cs
+++ b/src/Content/Presentation/Presentation.AgentHub/Program.cs
@@ -17,17 +17,19 @@ builder.Services.GetServices(includeHealthChecksUI: true);
 // Register AgentHub-specific services (auth, SignalR, CORS, rate limiting, config).
 builder.Services.AddAgentHubServices(builder.Configuration, builder.Environment);
 
-// MemoizedPromptComposer (singleton) → IPromptSectionProvider (transient) → IAgentExecutionContext (scoped)
-// creates a captive dependency that ASP.NET Core rejects by default. Scope validation is suppressed
-// in Development only. Production runs with validation enabled to catch data leakage between requests.
-if (builder.Environment.IsDevelopment())
+builder.Host.UseDefaultServiceProvider(options =>
 {
-    builder.Host.UseDefaultServiceProvider(options =>
-    {
-        options.ValidateScopes = false;
-        options.ValidateOnBuild = false;
-    });
-}
+    // ValidateScopes guards against captive dependencies — a singleton capturing scoped
+    // per-request state (the bug class behind the formerly-singleton prompt composer, which is
+    // now SCOPED via AddSystemPromptComposition). Enabled in ALL environments: the resolution
+    // cost is negligible and cross-request state bleed is a production correctness hazard.
+    options.ValidateScopes = true;
+    // ValidateOnBuild stays off: MediatR assembly scanning registers handlers whose
+    // dependencies are conditionally registered (e.g. IPromptUsageStore only when prompt-usage
+    // persistence is enabled, IEvalRunner only in the eval host), so eager build-time
+    // validation false-positives on handlers this host never dispatches.
+    options.ValidateOnBuild = false;
+});
 
 var app = builder.Build();
 

--- a/src/Content/Tests/Infrastructure.AI.Evaluation.Tests/Invokers/HarnessAgentInvokerScopeTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Evaluation.Tests/Invokers/HarnessAgentInvokerScopeTests.cs
@@ -1,0 +1,43 @@
+using FluentAssertions;
+using Infrastructure.AI.Evaluation;
+using Infrastructure.AI.Evaluation.Invokers;
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Xunit;
+
+namespace Infrastructure.AI.Evaluation.Tests.Invokers;
+
+/// <summary>
+/// Regression test for the captive root-bound <see cref="IMediator"/> in
+/// <see cref="HarnessAgentInvoker"/> (audit finding H2 follow-up). The invoker
+/// is a SINGLETON, but a mediator dispatch constructs the pipeline behaviors —
+/// six of which ctor-inject the SCOPED <c>IAgentExecutionContext</c> — so a
+/// root-bound mediator throws under <c>ValidateScopes</c>. The invoker must
+/// create a scope per invocation via <see cref="IServiceScopeFactory"/>.
+/// The <see cref="IMediator"/> double is registered SCOPED to encode that
+/// constraint without booting the full MediatR pipeline.
+/// </summary>
+public sealed class HarnessAgentInvokerScopeTests
+{
+    [Fact]
+    public void HarnessAgentInvoker_ResolvesFromRoot_UnderScopeValidation()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddScoped(_ => Mock.Of<IMediator>());
+
+        // Production registrations under test (Infrastructure.AI.Evaluation/DependencyInjection.cs).
+        services.AddEvaluationDependencies();
+
+        using var provider = services.BuildServiceProvider(new ServiceProviderOptions
+        {
+            ValidateScopes = true,
+        });
+
+        var act = () => provider.GetRequiredService<HarnessAgentInvoker>();
+
+        act.Should().NotThrow(
+            "the singleton invoker must not hold a root-bound IMediator; it must dispatch inside a created scope");
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Evaluation.Tests/Invokers/HarnessAgentInvokerTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Evaluation.Tests/Invokers/HarnessAgentInvokerTests.cs
@@ -2,6 +2,7 @@ using Application.Core.CQRS.Agents.ExecuteAgentTurn;
 using Domain.AI.Evaluation;
 using FluentAssertions;
 using MediatR;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Xunit;
@@ -34,8 +35,18 @@ public sealed class HarnessAgentInvokerTests
 
     private static Infrastructure.AI.Evaluation.Invokers.HarnessAgentInvoker MakeSut(
         IMediator mediator) => new(
-            mediator,
+            ScopeFactoryFor(mediator),
             NullLogger<Infrastructure.AI.Evaluation.Invokers.HarnessAgentInvoker>.Instance);
+
+    /// <summary>
+    /// Minimal scope factory whose scopes resolve <see cref="IMediator"/> to the supplied
+    /// double — the invoker resolves the mediator per invocation from a fresh scope.
+    /// </summary>
+    private static IServiceScopeFactory ScopeFactoryFor(IMediator mediator) =>
+        new ServiceCollection()
+            .AddScoped(_ => mediator)
+            .BuildServiceProvider()
+            .GetRequiredService<IServiceScopeFactory>();
 
     [Fact]
     public async Task Sends_command_with_agent_name_from_case_overrides()

--- a/src/Content/Tests/Infrastructure.AI.Evaluation.Tests/Invokers/RouterEvalInvokerTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Evaluation.Tests/Invokers/RouterEvalInvokerTests.cs
@@ -5,6 +5,7 @@ using Domain.AI.Evaluation;
 using FluentAssertions;
 using Infrastructure.AI.Evaluation.Invokers;
 using MediatR;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Xunit;
@@ -115,9 +116,19 @@ public sealed class RouterEvalInvokerTests
 
     private static RouterEvalInvoker MakeSut(Mock<IMediator> mediator, params IRouterEvalProbe[] probes)
     {
-        var inner = new HarnessAgentInvoker(mediator.Object, NullLogger<HarnessAgentInvoker>.Instance);
+        var inner = new HarnessAgentInvoker(ScopeFactoryFor(mediator.Object), NullLogger<HarnessAgentInvoker>.Instance);
         return new RouterEvalInvoker(inner, probes, NullLogger<RouterEvalInvoker>.Instance);
     }
+
+    /// <summary>
+    /// Minimal scope factory whose scopes resolve <see cref="IMediator"/> to the supplied
+    /// double — the invoker resolves the mediator per invocation from a fresh scope.
+    /// </summary>
+    private static IServiceScopeFactory ScopeFactoryFor(IMediator mediator) =>
+        new ServiceCollection()
+            .AddScoped(_ => mediator)
+            .BuildServiceProvider()
+            .GetRequiredService<IServiceScopeFactory>();
 
     private static Mock<IMediator> MediatorReturning(string response)
     {

--- a/src/Content/Tests/Infrastructure.AI.Tests/Compaction/ContextCompactionServiceTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Compaction/ContextCompactionServiceTests.cs
@@ -20,7 +20,7 @@ public sealed class ContextCompactionServiceTests
 {
     private readonly Mock<ICompactionStrategyExecutor> _fullExecutor;
     private readonly Mock<IHookExecutor> _hookExecutor;
-    private readonly Mock<ISystemPromptComposer> _promptComposer;
+    private readonly Mock<IPromptSectionCache> _sectionCache;
     private readonly Mock<IAutoCompactStateMachine> _stateMachine;
     private readonly IOptionsMonitor<AppConfig> _options;
     private readonly ContextCompactionService _sut;
@@ -35,7 +35,7 @@ public sealed class ContextCompactionServiceTests
             .Setup(x => x.ExecuteHooksAsync(It.IsAny<HookEvent>(), It.IsAny<HookExecutionContext>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Array.Empty<HookResult>());
 
-        _promptComposer = new Mock<ISystemPromptComposer>();
+        _sectionCache = new Mock<IPromptSectionCache>();
         _stateMachine = new Mock<IAutoCompactStateMachine>();
 
         var appConfig = new AppConfig
@@ -59,7 +59,7 @@ public sealed class ContextCompactionServiceTests
         _sut = new ContextCompactionService(
             new[] { _fullExecutor.Object },
             _hookExecutor.Object,
-            _promptComposer.Object,
+            _sectionCache.Object,
             _stateMachine.Object,
             _options,
             NullLogger<ContextCompactionService>.Instance);
@@ -148,7 +148,7 @@ public sealed class ContextCompactionServiceTests
         var messages = new List<ChatMessage> { new(ChatRole.User, "Hello") };
         await _sut.CompactAsync("agent-1", messages, CompactionStrategy.Full);
 
-        _promptComposer.Verify(x => x.InvalidateAll(), Times.Once);
+        _sectionCache.Verify(x => x.InvalidateAll(), Times.Once);
     }
 
     [Fact]
@@ -164,7 +164,7 @@ public sealed class ContextCompactionServiceTests
         result.Success.Should().BeFalse();
         _stateMachine.Verify(x => x.RecordFailure("agent-1"), Times.Once);
         _stateMachine.Verify(x => x.RecordSuccess(It.IsAny<string>()), Times.Never);
-        _promptComposer.Verify(x => x.InvalidateAll(), Times.Never);
+        _sectionCache.Verify(x => x.InvalidateAll(), Times.Never);
     }
 
     [Fact]

--- a/src/Content/Tests/Infrastructure.AI.Tests/GitOps/GitOpsRemediationDispatcherTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/GitOps/GitOpsRemediationDispatcherTests.cs
@@ -6,6 +6,7 @@ using Domain.AI.SkillTraining;
 using Domain.Common;
 using FluentAssertions;
 using Infrastructure.AI.GitOps;
+using Infrastructure.AI.Tests.Support;
 using MediatR;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
@@ -24,7 +25,7 @@ public sealed class GitOpsRemediationDispatcherTests
     private readonly Mock<IMediator> _mediator = new();
 
     private GitOpsRemediationDispatcher CreateSut()
-        => new(_mediator.Object, NullLogger<GitOpsRemediationDispatcher>.Instance);
+        => new(TestScopeFactory.For(_mediator.Object), NullLogger<GitOpsRemediationDispatcher>.Instance);
 
     private static RemediationPlan ValidPlan(
         GitOpsControllerKind kind = GitOpsControllerKind.Flux,

--- a/src/Content/Tests/Infrastructure.AI.Tests/Iac/BicepGeneratorTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Iac/BicepGeneratorTests.cs
@@ -17,7 +17,7 @@ public sealed class BicepGeneratorTests
     private static BicepGenerator Create(Application.AI.Common.Interfaces.Sandbox.ISandboxExecutor sandbox, string blockingSeverity = "High")
         => new(
             IacTestConfig.ValidMonitor(blockingSeverity),
-            sandbox,
+            Support.TestScopeFactory.ForSandbox(sandbox),
             NullLogger<BicepGenerator>.Instance,
             TimeProvider.System);
 

--- a/src/Content/Tests/Infrastructure.AI.Tests/Iac/IacDependencyInjectionTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Iac/IacDependencyInjectionTests.cs
@@ -45,8 +45,9 @@ public sealed class IacDependencyInjectionTests
         services.AddLogging();
         services.AddSingleton(IacTestConfig.ValidMonitor());
         services.AddSingleton(TimeProvider.System);
-        // The generators resolve the keyed Process sandbox executor at construction.
-        services.AddKeyedSingleton<ISandboxExecutor>(SandboxIsolationLevel.Process, Mock.Of<ISandboxExecutor>());
+        // Production lifetime (DependencyInjection.Planner.cs): keyed SCOPED executor.
+        // The generators resolve it per CLI run from a fresh scope — never at construction.
+        services.AddKeyedScoped<ISandboxExecutor>(SandboxIsolationLevel.Process, (_, _) => Mock.Of<ISandboxExecutor>());
         return services;
     }
 

--- a/src/Content/Tests/Infrastructure.AI.Tests/Iac/TerraformGeneratorTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Iac/TerraformGeneratorTests.cs
@@ -17,7 +17,7 @@ public sealed class TerraformGeneratorTests
     private static TerraformGenerator Create(Application.AI.Common.Interfaces.Sandbox.ISandboxExecutor sandbox, string blockingSeverity = "High")
         => new(
             IacTestConfig.ValidMonitor(blockingSeverity),
-            sandbox,
+            Support.TestScopeFactory.ForSandbox(sandbox),
             NullLogger<TerraformGenerator>.Instance,
             TimeProvider.System);
 

--- a/src/Content/Tests/Infrastructure.AI.Tests/Orchestration/Magentic/MagenticChangeProposalRouterTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Orchestration/Magentic/MagenticChangeProposalRouterTests.cs
@@ -4,6 +4,7 @@ using Domain.AI.Identity;
 using Domain.Common;
 using FluentAssertions;
 using Infrastructure.AI.Orchestration.Magentic;
+using Infrastructure.AI.Tests.Support;
 using MediatR;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
@@ -28,7 +29,7 @@ public sealed class MagenticChangeProposalRouterTests
             .Callback<object, CancellationToken>((cmd, _) => captured = (SubmitChangeProposalCommand)cmd)
             .ReturnsAsync((object cmd, CancellationToken _) => Result<ChangeProposal>.Success(StubProposal((SubmitChangeProposalCommand)cmd)));
 
-        var router = new MagenticChangeProposalRouter(mediator.Object, NullLogger<MagenticChangeProposalRouter>.Instance);
+        var router = new MagenticChangeProposalRouter(TestScopeFactory.For(mediator.Object), NullLogger<MagenticChangeProposalRouter>.Instance);
 
         var proposal = await router.TryRouteAsync(new MagenticReplanInfo
         {
@@ -49,7 +50,7 @@ public sealed class MagenticChangeProposalRouterTests
     public async Task Non_state_change_replan_is_dropped()
     {
         var mediator = new Mock<IMediator>();
-        var router = new MagenticChangeProposalRouter(mediator.Object, NullLogger<MagenticChangeProposalRouter>.Instance);
+        var router = new MagenticChangeProposalRouter(TestScopeFactory.For(mediator.Object), NullLogger<MagenticChangeProposalRouter>.Instance);
 
         var proposal = await router.TryRouteAsync(new MagenticReplanInfo
         {

--- a/src/Content/Tests/Infrastructure.AI.Tests/Orchestration/Magentic/MagenticTestHelpers.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Orchestration/Magentic/MagenticTestHelpers.cs
@@ -3,6 +3,7 @@ using Application.AI.Common.Interfaces.Orchestration.Magentic;
 using Application.AI.Common.Interfaces.Telemetry;
 using Domain.AI.Telemetry.Conventions;
 using Infrastructure.AI.Orchestration.Magentic;
+using Infrastructure.AI.Tests.Support;
 using MediatR;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -90,7 +91,9 @@ internal static class MagenticTestHelpers
     {
         bridge = new Mock<IMagenticPlanReviewBridge>();
         mediator = new Mock<IMediator>();
-        var router = new MagenticChangeProposalRouter(mediator.Object, NullLogger<MagenticChangeProposalRouter>.Instance);
+        var router = new MagenticChangeProposalRouter(
+            TestScopeFactory.For(mediator.Object),
+            NullLogger<MagenticChangeProposalRouter>.Instance);
         return new MagenticEventSubscriber(
             emitter ?? new MagenticSpanEmitter(),
             bridge.Object,

--- a/src/Content/Tests/Infrastructure.AI.Tests/Prompts/PromptComposerScopeIsolationTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Prompts/PromptComposerScopeIsolationTests.cs
@@ -105,6 +105,44 @@ public sealed class PromptComposerScopeIsolationTests
     }
 
     [Fact]
+    public async Task ComposeAsync_CacheableIdentitySection_NotPoisonedByScopeContext()
+    {
+        using var provider = BuildProvider();
+
+        // A scope bound to agent-b composes for cache key "agent-a" (e.g. a
+        // supervisor composing a subagent's prompt). The cacheable identity
+        // section is stored under the agent-a key, so its content must derive
+        // from that key — not from the composing scope's execution context.
+        using (var scope1 = provider.CreateScope())
+        {
+            scope1.ServiceProvider.GetRequiredService<IAgentExecutionContext>()
+                .Initialize("agent-b", "conv-1", turnNumber: 1);
+
+            var prompt = await scope1.ServiceProvider
+                .GetRequiredService<ISystemPromptComposer>()
+                .ComposeAsync("agent-a", tokenBudget: 10_000);
+
+            prompt.Should().Contain("You are agent-a.");
+            prompt.Should().NotContain("You are agent-b.",
+                "the cacheable identity section must be a pure function of the cache key");
+        }
+
+        // A later scope composing for agent-a must get agent-a content from the
+        // shared cache — not whatever identity the first scope happened to carry.
+        using var scope2 = provider.CreateScope();
+        scope2.ServiceProvider.GetRequiredService<IAgentExecutionContext>()
+            .Initialize("agent-a", "conv-2", turnNumber: 1);
+
+        var prompt2 = await scope2.ServiceProvider
+            .GetRequiredService<ISystemPromptComposer>()
+            .ComposeAsync("agent-a", tokenBudget: 10_000);
+
+        prompt2.Should().Contain("You are agent-a.");
+        prompt2.Should().NotContain("You are agent-b.",
+            "a cached section must never carry another conversation's identity");
+    }
+
+    [Fact]
     public void Composer_ResolvesFromRequestScope_UnderScopeValidation()
     {
         // Regression: the singleton registration forced the AgentHub host and its test

--- a/src/Content/Tests/Infrastructure.AI.Tests/Prompts/PromptComposerScopeIsolationTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Prompts/PromptComposerScopeIsolationTests.cs
@@ -1,0 +1,120 @@
+using Application.AI.Common.Interfaces.Agent;
+using Application.AI.Common.Interfaces.Context;
+using Application.AI.Common.Interfaces.Prompts;
+using Application.AI.Common.Services.Agent;
+using FluentAssertions;
+using Infrastructure.AI.Prompts;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Prompts;
+
+/// <summary>
+/// Regression tests for the captive-singleton prompt composer (audit finding H2).
+/// The composer's section providers consume the scoped <see cref="IAgentExecutionContext"/>;
+/// a singleton composer freezes the root-scope context at first resolution, so every
+/// conversation composes against stale (or another request's) session state. These tests
+/// bind to the production <see cref="PromptCompositionDependencyInjection"/> registrations
+/// and run with <c>ValidateScopes</c> enabled — exactly what the AgentHub host had to
+/// suppress to tolerate the captive dependency.
+/// </summary>
+public sealed class PromptComposerScopeIsolationTests
+{
+    private static ServiceProvider BuildProvider()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        // Production lifetime (Application.AI.Common.DependencyInjection): scoped ambient context.
+        services.AddScoped<IAgentExecutionContext, AgentExecutionContext>();
+        services.AddSingleton(Mock.Of<IContextBudgetTracker>());
+
+        // Production prompt composition registrations under test.
+        services.AddSystemPromptComposition();
+
+        return services.BuildServiceProvider(new ServiceProviderOptions
+        {
+            ValidateScopes = true,
+        });
+    }
+
+    [Fact]
+    public async Task ComposeAsync_TwoRequestScopesWithDifferentContexts_EachSeesOwnSessionState()
+    {
+        using var provider = BuildProvider();
+
+        // Request 1: conversation conv-1, turn 3.
+        using (var scope1 = provider.CreateScope())
+        {
+            scope1.ServiceProvider.GetRequiredService<IAgentExecutionContext>()
+                .Initialize("agent-a", "conv-1", turnNumber: 3);
+
+            var prompt1 = await scope1.ServiceProvider
+                .GetRequiredService<ISystemPromptComposer>()
+                .ComposeAsync("agent-a", tokenBudget: 10_000);
+
+            prompt1.Should().Contain("Current turn: 3",
+                "the composer must see the live scope's execution context, not a captured root-scope instance");
+            prompt1.Should().Contain("You are agent-a.");
+        }
+
+        // Request 2: a different conversation in a fresh scope must not see request 1's state.
+        using var scope2 = provider.CreateScope();
+        scope2.ServiceProvider.GetRequiredService<IAgentExecutionContext>()
+            .Initialize("agent-b", "conv-2", turnNumber: 7);
+
+        var prompt2 = await scope2.ServiceProvider
+            .GetRequiredService<ISystemPromptComposer>()
+            .ComposeAsync("agent-b", tokenBudget: 10_000);
+
+        prompt2.Should().Contain("Current turn: 7");
+        prompt2.Should().NotContain("Current turn: 3",
+            "session state from another request scope must never bleed into this composition");
+        prompt2.Should().Contain("You are agent-b.");
+    }
+
+    [Fact]
+    public async Task ComposeAsync_SameConversationAcrossTurns_SeesFreshTurnNumber()
+    {
+        using var provider = BuildProvider();
+
+        using (var turn1 = provider.CreateScope())
+        {
+            turn1.ServiceProvider.GetRequiredService<IAgentExecutionContext>()
+                .Initialize("agent-a", "conv-1", turnNumber: 1);
+
+            var prompt = await turn1.ServiceProvider
+                .GetRequiredService<ISystemPromptComposer>()
+                .ComposeAsync("agent-a", tokenBudget: 10_000);
+
+            prompt.Should().Contain("Current turn: 1");
+        }
+
+        using var turn2 = provider.CreateScope();
+        turn2.ServiceProvider.GetRequiredService<IAgentExecutionContext>()
+            .Initialize("agent-a", "conv-1", turnNumber: 2);
+
+        var prompt2 = await turn2.ServiceProvider
+            .GetRequiredService<ISystemPromptComposer>()
+            .ComposeAsync("agent-a", tokenBudget: 10_000);
+
+        prompt2.Should().Contain("Current turn: 2",
+            "each turn's scope must recompute non-cacheable sections from its own context");
+        prompt2.Should().NotContain("Current turn: 1");
+    }
+
+    [Fact]
+    public void Composer_ResolvesFromRequestScope_UnderScopeValidation()
+    {
+        // Regression: the singleton registration forced the AgentHub host and its test
+        // factories to disable ValidateScopes/ValidateOnBuild entirely, hiding every future
+        // captive-dependency bug. The composer must resolve cleanly under scope validation.
+        using var provider = BuildProvider();
+        using var scope = provider.CreateScope();
+
+        var act = () => scope.ServiceProvider.GetRequiredService<ISystemPromptComposer>();
+
+        act.Should().NotThrow();
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Prompts/Sections/AgentIdentitySectionProviderTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Prompts/Sections/AgentIdentitySectionProviderTests.cs
@@ -1,24 +1,24 @@
-using Application.AI.Common.Interfaces.Agent;
 using Domain.AI.Prompts;
 using FluentAssertions;
 using Infrastructure.AI.Prompts.Sections;
-using Moq;
 using Xunit;
 
 namespace Infrastructure.AI.Tests.Prompts.Sections;
 
+/// <summary>
+/// Tests for <see cref="AgentIdentitySectionProvider"/>. The cacheable identity
+/// content must be a pure function of the <c>agentId</c> parameter — the cache
+/// key — never of ambient scoped state, so a cached section can never carry one
+/// conversation's identity into another (cross-agent cache poisoning).
+/// </summary>
 public class AgentIdentitySectionProviderTests
 {
-    private readonly Mock<IAgentExecutionContext> _contextMock = new();
+    private readonly AgentIdentitySectionProvider _provider = new();
 
     [Fact]
     public async Task GetSectionAsync_ReturnsAgentIdentity()
     {
-        _contextMock.Setup(c => c.AgentId).Returns("ResearchAgent");
-
-        var provider = new AgentIdentitySectionProvider(_contextMock.Object);
-
-        var section = await provider.GetSectionAsync("ResearchAgent");
+        var section = await _provider.GetSectionAsync("ResearchAgent");
 
         section.Should().NotBeNull();
         section!.Content.Should().Contain("ResearchAgent");
@@ -29,37 +29,28 @@ public class AgentIdentitySectionProviderTests
     [Fact]
     public async Task GetSectionAsync_IsCacheable()
     {
-        _contextMock.Setup(c => c.AgentId).Returns("TestAgent");
-
-        var provider = new AgentIdentitySectionProvider(_contextMock.Object);
-
-        var section = await provider.GetSectionAsync("TestAgent");
+        var section = await _provider.GetSectionAsync("TestAgent");
 
         section.Should().NotBeNull();
         section!.IsCacheable.Should().BeTrue();
     }
 
     [Fact]
-    public async Task GetSectionAsync_FallsBackToAgentIdParameter_WhenContextNull()
+    public async Task GetSectionAsync_ContentDerivesOnlyFromCacheKeyInput()
     {
-        _contextMock.Setup(c => c.AgentId).Returns((string?)null);
-
-        var provider = new AgentIdentitySectionProvider(_contextMock.Object);
-
-        var section = await provider.GetSectionAsync("fallback-agent");
+        // Regression: the cache keys on the agentId PARAMETER. Content derived
+        // from anything else (e.g. the scoped IAgentExecutionContext) would let
+        // a scope bound to agent-b poison the cached section under agent-a's key.
+        var section = await _provider.GetSectionAsync("agent-a");
 
         section.Should().NotBeNull();
-        section!.Content.Should().Contain("fallback-agent");
+        section!.Content.Should().Be("You are agent-a.");
     }
 
     [Fact]
-    public async Task GetSectionAsync_ReturnsNull_WhenBothIdsEmpty()
+    public async Task GetSectionAsync_ReturnsNull_WhenAgentIdEmpty()
     {
-        _contextMock.Setup(c => c.AgentId).Returns((string?)null);
-
-        var provider = new AgentIdentitySectionProvider(_contextMock.Object);
-
-        var section = await provider.GetSectionAsync("");
+        var section = await _provider.GetSectionAsync("");
 
         section.Should().BeNull();
     }
@@ -67,19 +58,13 @@ public class AgentIdentitySectionProviderTests
     [Fact]
     public void SectionType_IsAgentIdentity()
     {
-        var provider = new AgentIdentitySectionProvider(_contextMock.Object);
-
-        provider.SectionType.Should().Be(SystemPromptSectionType.AgentIdentity);
+        _provider.SectionType.Should().Be(SystemPromptSectionType.AgentIdentity);
     }
 
     [Fact]
     public async Task GetSectionAsync_EstimatedTokens_IsPositive()
     {
-        _contextMock.Setup(c => c.AgentId).Returns("Agent");
-
-        var provider = new AgentIdentitySectionProvider(_contextMock.Object);
-
-        var section = await provider.GetSectionAsync("Agent");
+        var section = await _provider.GetSectionAsync("Agent");
 
         section.Should().NotBeNull();
         section!.EstimatedTokens.Should().BeGreaterThan(0);

--- a/src/Content/Tests/Infrastructure.AI.Tests/Support/TestScopeFactory.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Support/TestScopeFactory.cs
@@ -1,0 +1,35 @@
+using Application.AI.Common.Interfaces.Sandbox;
+using Domain.AI.Sandbox;
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Infrastructure.AI.Tests.Support;
+
+/// <summary>
+/// Builds minimal <see cref="IServiceScopeFactory"/> instances around test
+/// doubles, for exercising services that resolve scope-bound collaborators
+/// (<see cref="IMediator"/>, the keyed-scoped <see cref="ISandboxExecutor"/>)
+/// from a fresh scope per operation instead of capturing them at construction.
+/// </summary>
+internal static class TestScopeFactory
+{
+    /// <summary>Scope factory whose scopes resolve <see cref="IMediator"/> to <paramref name="mediator"/>.</summary>
+    public static IServiceScopeFactory For(IMediator mediator) =>
+        new ServiceCollection()
+            .AddScoped(_ => mediator)
+            .BuildServiceProvider()
+            .GetRequiredService<IServiceScopeFactory>();
+
+    /// <summary>
+    /// Scope factory whose scopes resolve the keyed <see cref="ISandboxExecutor"/> for
+    /// <paramref name="isolationLevel"/> to <paramref name="sandbox"/>. Mirrors the
+    /// production keyed-SCOPED registration in <c>DependencyInjection.Planner.cs</c>.
+    /// </summary>
+    public static IServiceScopeFactory ForSandbox(
+        ISandboxExecutor sandbox,
+        SandboxIsolationLevel isolationLevel = SandboxIsolationLevel.Process) =>
+        new ServiceCollection()
+            .AddKeyedScoped(isolationLevel, (_, _) => sandbox)
+            .BuildServiceProvider()
+            .GetRequiredService<IServiceScopeFactory>();
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Tools/CaptiveDependencyRegressionTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Tools/CaptiveDependencyRegressionTests.cs
@@ -1,0 +1,168 @@
+using Application.AI.Common.Interfaces.GitOps;
+using Application.AI.Common.Interfaces.Sandbox;
+using Application.AI.Common.Interfaces.Tools;
+using Domain.AI.Sandbox;
+using FluentAssertions;
+using Infrastructure.AI.Orchestration.Magentic;
+using Infrastructure.AI.Tests.Tools.Workspace.Support;
+using Infrastructure.AI.Tools.GitOps;
+using Infrastructure.AI.Tools.Workspace;
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Tools;
+
+/// <summary>
+/// Regression tests for captive-dependency bugs flushed out by enabling
+/// <c>ValidateScopes</c> in the AgentHub host (audit finding H2 follow-up).
+/// Keyed-SINGLETON tool factories and singleton services must never resolve
+/// scope-bound services (<c>ISandboxExecutor</c> is keyed SCOPED; a dispatched
+/// <c>IMediator</c> pipeline ctor-injects the scoped <c>IAgentExecutionContext</c>)
+/// from the root provider — they must create a scope per execution via
+/// <see cref="IServiceScopeFactory"/>, the same pattern
+/// <c>WorkMemorySynthesisBackgroundService</c> uses.
+/// </summary>
+/// <remarks>
+/// The <see cref="IMediator"/> test double is registered SCOPED. Production
+/// registers MediatR transient, but any <c>Send</c> resolved from the root
+/// provider constructs the pipeline behaviors from the root, and six behaviors
+/// ctor-inject the scoped <c>IAgentExecutionContext</c> — so under scope
+/// validation a root-bound mediator dispatch throws. The scoped double encodes
+/// that constraint ("IMediator must be consumed from a request scope") in
+/// miniature without booting the full MediatR pipeline.
+/// </remarks>
+public sealed class CaptiveDependencyRegressionTests
+{
+    private static ServiceProvider BuildWorkspaceProvider(
+        ISandboxExecutor sandbox,
+        IMediator mediator)
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        // Production registrations under test.
+        services.AddWorkspaceSkillTools();
+
+        // Production lifetime (DependencyInjection.Planner.cs): the sandbox
+        // executor is keyed SCOPED on the isolation level.
+        services.AddKeyedScoped<ISandboxExecutor>(
+            SandboxIsolationLevel.Process, (_, _) => sandbox);
+
+        services.AddScoped(_ => mediator);
+
+        return services.BuildServiceProvider(new ServiceProviderOptions
+        {
+            ValidateScopes = true,
+        });
+    }
+
+    [Fact]
+    public void RunTestsTool_ResolvesFromRoot_UnderScopeValidation()
+    {
+        using var provider = BuildWorkspaceProvider(
+            Mock.Of<ISandboxExecutor>(), Mock.Of<IMediator>());
+
+        var act = () => provider.GetRequiredKeyedService<ITool>(WorkspaceRunTestsTool.ToolName);
+
+        act.Should().NotThrow(
+            "the keyed-singleton tool factory must not resolve the keyed-scoped ISandboxExecutor from the root provider");
+    }
+
+    [Fact]
+    public void RunLintTool_ResolvesFromRoot_UnderScopeValidation()
+    {
+        using var provider = BuildWorkspaceProvider(
+            Mock.Of<ISandboxExecutor>(), Mock.Of<IMediator>());
+
+        var act = () => provider.GetRequiredKeyedService<ITool>(WorkspaceRunLintTool.ToolName);
+
+        act.Should().NotThrow(
+            "the keyed-singleton tool factory must not resolve the keyed-scoped ISandboxExecutor from the root provider");
+    }
+
+    [Fact]
+    public void WriteFileTool_ResolvesFromRoot_UnderScopeValidation()
+    {
+        using var provider = BuildWorkspaceProvider(
+            Mock.Of<ISandboxExecutor>(), Mock.Of<IMediator>());
+
+        var act = () => provider.GetRequiredKeyedService<ITool>(WorkspaceWriteFileTool.ToolName);
+
+        act.Should().NotThrow(
+            "the keyed-singleton tool factory must not capture a root-bound IMediator");
+    }
+
+    [Fact]
+    public async Task RunTestsTool_ExecutesThroughScopedSandboxExecutor()
+    {
+        var recorded = new List<SandboxExecutionRequest>();
+        var sandboxMock = new Mock<ISandboxExecutor>();
+        sandboxMock
+            .Setup(s => s.ExecuteAsync(It.IsAny<SandboxExecutionRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<SandboxExecutionRequest, CancellationToken>((req, _) => recorded.Add(req))
+            .ReturnsAsync(new SandboxExecutionResult
+            {
+                Success = true,
+                ExitCode = 0,
+                Output = "5 tests passed",
+            });
+
+        using var provider = BuildWorkspaceProvider(sandboxMock.Object, Mock.Of<IMediator>());
+        using var fx = new WorkspaceTestFixture(testCommand: "dotnet test");
+
+        var accessor = provider.GetRequiredService<Application.AI.Common.Interfaces.Workspace.IWorkspaceContextAccessor>();
+        using var workspaceScope = accessor.BeginScope(fx.Context);
+
+        var tool = provider.GetRequiredKeyedService<ITool>(WorkspaceRunTestsTool.ToolName);
+        var result = await tool.ExecuteAsync("run", new Dictionary<string, object?>());
+
+        result.Success.Should().BeTrue();
+        recorded.Should().ContainSingle("the tool must dispatch through the scoped executor resolved per execution");
+    }
+
+    [Fact]
+    public void GitOpsRemediationDispatcher_ResolvesFromRoot_UnderScopeValidation()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddScoped(_ => Mock.Of<IMediator>());
+
+        // Production registrations under test (DependencyInjection.GitOps.cs).
+        services.AddGitOpsSkillTools();
+
+        using var provider = services.BuildServiceProvider(new ServiceProviderOptions
+        {
+            ValidateScopes = true,
+        });
+
+        var act = () => provider.GetRequiredService<IGitOpsRemediationDispatcher>();
+
+        act.Should().NotThrow(
+            "the singleton dispatcher must not hold a root-bound IMediator; it must dispatch inside a created scope");
+    }
+
+    [Fact]
+    public void MagenticChangeProposalRouter_ResolvesFromRoot_UnderScopeValidation()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddScoped(_ => Mock.Of<IMediator>());
+
+        // Mirrors the production lifetime (DependencyInjection.Magentic.cs —
+        // RegisterMagenticServices is private, so the registration line is
+        // replicated verbatim here).
+        services.AddSingleton<MagenticChangeProposalRouter>();
+
+        using var provider = services.BuildServiceProvider(new ServiceProviderOptions
+        {
+            ValidateScopes = true,
+        });
+
+        var act = () => provider.GetRequiredService<MagenticChangeProposalRouter>();
+
+        act.Should().NotThrow(
+            "the singleton router must not hold a root-bound IMediator; it must dispatch inside a created scope");
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Tools/CaptiveDependencyRegressionTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Tools/CaptiveDependencyRegressionTests.cs
@@ -1,11 +1,15 @@
 using Application.AI.Common.Interfaces.GitOps;
+using Application.AI.Common.Interfaces.Iac;
 using Application.AI.Common.Interfaces.Sandbox;
 using Application.AI.Common.Interfaces.Tools;
+using Domain.AI.Iac;
 using Domain.AI.Sandbox;
 using FluentAssertions;
 using Infrastructure.AI.Orchestration.Magentic;
+using Infrastructure.AI.Tests.Iac;
 using Infrastructure.AI.Tests.Tools.Workspace.Support;
 using Infrastructure.AI.Tools.GitOps;
+using Infrastructure.AI.Tools.Iac;
 using Infrastructure.AI.Tools.Workspace;
 using MediatR;
 using Microsoft.Extensions.DependencyInjection;
@@ -120,6 +124,36 @@ public sealed class CaptiveDependencyRegressionTests
 
         result.Success.Should().BeTrue();
         recorded.Should().ContainSingle("the tool must dispatch through the scoped executor resolved per execution");
+    }
+
+    [Fact]
+    public void IacGenerators_ResolveFromRoot_UnderScopeValidation()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton(IacTestConfig.ValidMonitor());
+        services.AddSingleton(TimeProvider.System);
+
+        // Production lifetime (DependencyInjection.Planner.cs): the sandbox
+        // executor is keyed SCOPED on the isolation level.
+        services.AddKeyedScoped<ISandboxExecutor>(
+            SandboxIsolationLevel.Process, (_, _) => Mock.Of<ISandboxExecutor>());
+
+        // Production registrations under test (DependencyInjection.Iac.cs).
+        services.AddIacSkillTools();
+
+        using var provider = services.BuildServiceProvider(new ServiceProviderOptions
+        {
+            ValidateScopes = true,
+        });
+
+        var terraform = () => provider.GetRequiredKeyedService<IIacGenerator>(IacBackendKeys.Terraform);
+        var bicep = () => provider.GetRequiredKeyedService<IIacGenerator>(IacBackendKeys.Bicep);
+
+        terraform.Should().NotThrow(
+            "the keyed-singleton generator factory must not resolve the keyed-scoped ISandboxExecutor from the root provider");
+        bicep.Should().NotThrow(
+            "the keyed-singleton generator factory must not resolve the keyed-scoped ISandboxExecutor from the root provider");
     }
 
     [Fact]

--- a/src/Content/Tests/Infrastructure.AI.Tests/Tools/KeyedServiceScopeSweepTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Tools/KeyedServiceScopeSweepTests.cs
@@ -1,0 +1,139 @@
+using Application.AI.Common.Interfaces;
+using Application.AI.Common.Interfaces.Iac;
+using Application.AI.Common.Interfaces.Sandbox;
+using Application.AI.Common.Interfaces.Tools;
+using Domain.AI.Sandbox;
+using Domain.Common.Config;
+using Domain.Common.Config.AI;
+using Domain.Common.Config.AI.GitOps;
+using FluentAssertions;
+using FluentAssertions.Execution;
+using Infrastructure.AI.Tests.Iac;
+using Infrastructure.AI.Tools.GitOps;
+using Infrastructure.AI.Tools.Iac;
+using Infrastructure.AI.Tools.Workspace;
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Tools;
+
+/// <summary>
+/// Captive-dependency SWEEP: binds every public skill-pack DI extension
+/// (workspace, GitOps, IaC), then resolves EVERY keyed <see cref="ITool"/> and
+/// every keyed <see cref="IIacGenerator"/> from a created scope under
+/// <c>ValidateScopes = true</c>. Any keyed-singleton factory that resolves a
+/// scope-bound service (the keyed-SCOPED <see cref="ISandboxExecutor"/>, a
+/// root-bound <see cref="IMediator"/>) from the root provider fails here —
+/// so new tools cannot reintroduce the captive-dependency class of bug that
+/// the per-service regression tests only catch for services they enumerate.
+/// </summary>
+/// <remarks>
+/// Coverage boundary: tools registered by the private
+/// <c>DependencyInjection.RegisterToolServices</c> (file_system, document_ingest,
+/// echo, …) are not swept — that method is not callable in isolation. Their
+/// mediator-shaped member (<c>document_ingest</c>) is covered by its own
+/// scope-per-dispatch design and the sibling regression tests.
+/// </remarks>
+public sealed class KeyedServiceScopeSweepTests
+{
+    private static ServiceCollection BuildProductionComposition()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddHttpClient();
+        services.AddSingleton(TimeProvider.System);
+        services.AddSingleton(SweepConfigMonitor());
+        services.AddScoped(_ => Mock.Of<IMediator>());
+        services.AddSingleton(Mock.Of<IMcpToolProvider>());
+
+        // Production lifetime (DependencyInjection.Planner.cs): keyed SCOPED executors.
+        services.AddKeyedScoped<ISandboxExecutor>(
+            SandboxIsolationLevel.Process, (_, _) => Mock.Of<ISandboxExecutor>());
+        services.AddKeyedScoped<ISandboxExecutor>(
+            SandboxIsolationLevel.Container, (_, _) => Mock.Of<ISandboxExecutor>());
+
+        // The public skill-pack extensions, exactly as the production composition
+        // root chains them.
+        services.AddWorkspaceSkillTools();
+        services.AddGitOpsSkillTools();
+        services.AddIacSkillTools();
+
+        return services;
+    }
+
+    private static IOptionsMonitor<AppConfig> SweepConfigMonitor()
+    {
+        // Valid IaC section + an active GitOps controller so the default
+        // IGitOpsController registration can resolve the keyed "flux" controller.
+        var config = IacTestConfig.ValidAppConfig();
+        config.AI.GitOps = new GitOpsConfig
+        {
+            Enabled = true,
+            ActiveController = "flux",
+        };
+        return IacTestConfig.Monitor(config);
+    }
+
+    [Fact]
+    public void EveryKeyedTool_ResolvesFromScope_UnderScopeValidation()
+    {
+        var services = BuildProductionComposition();
+
+        var toolKeys = services
+            .Where(d => d.IsKeyedService && d.ServiceType == typeof(ITool) && d.ServiceKey is not null)
+            .Select(d => d.ServiceKey!)
+            .Distinct()
+            .ToList();
+
+        toolKeys.Should().NotBeEmpty("the sweep is pointless if no keyed tools were registered");
+
+        using var provider = services.BuildServiceProvider(new ServiceProviderOptions
+        {
+            ValidateScopes = true,
+        });
+        using var scope = provider.CreateScope();
+
+        using (new AssertionScope())
+        {
+            foreach (var key in toolKeys)
+            {
+                var act = () => scope.ServiceProvider.GetRequiredKeyedService<ITool>(key);
+                act.Should().NotThrow(
+                    "keyed tool '{0}' must not resolve scope-bound services from the root provider at construction", key);
+            }
+        }
+    }
+
+    [Fact]
+    public void EveryKeyedIacGenerator_ResolvesFromScope_UnderScopeValidation()
+    {
+        var services = BuildProductionComposition();
+
+        var generatorKeys = services
+            .Where(d => d.IsKeyedService && d.ServiceType == typeof(IIacGenerator) && d.ServiceKey is not null)
+            .Select(d => d.ServiceKey!)
+            .Distinct()
+            .ToList();
+
+        generatorKeys.Should().NotBeEmpty("AddIacSkillTools registers both backend generators");
+
+        using var provider = services.BuildServiceProvider(new ServiceProviderOptions
+        {
+            ValidateScopes = true,
+        });
+        using var scope = provider.CreateScope();
+
+        using (new AssertionScope())
+        {
+            foreach (var key in generatorKeys)
+            {
+                var act = () => scope.ServiceProvider.GetRequiredKeyedService<IIacGenerator>(key);
+                act.Should().NotThrow(
+                    "keyed IaC generator '{0}' must not resolve scope-bound services from the root provider at construction", key);
+            }
+        }
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Tools/Workspace/WorkspaceRunCommandsToolTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Tools/Workspace/WorkspaceRunCommandsToolTests.cs
@@ -1,6 +1,7 @@
 using Application.AI.Common.Interfaces.Sandbox;
 using Domain.AI.Sandbox;
 using FluentAssertions;
+using Infrastructure.AI.Tests.Support;
 using Infrastructure.AI.Tests.Tools.Workspace.Support;
 using Infrastructure.AI.Tools.Workspace;
 using Xunit;
@@ -21,7 +22,7 @@ public sealed class WorkspaceRunCommandsToolTests
     {
         using var fx = new WorkspaceTestFixture(testCommand: "dotnet test src/Solution.slnx");
         var sandbox = new RecordingSandbox(success: true, exitCode: 0, output: "12 tests passed");
-        var sut = new WorkspaceRunTestsTool(fx.Accessor, sandbox);
+        var sut = new WorkspaceRunTestsTool(fx.Accessor, TestScopeFactory.ForSandbox(sandbox));
 
         var result = await sut.ExecuteAsync(
             "run",
@@ -52,7 +53,7 @@ public sealed class WorkspaceRunCommandsToolTests
     {
         using var fx = new WorkspaceTestFixture(testCommand: "");
         var sandbox = new RecordingSandbox(success: true, exitCode: 0, output: "");
-        var sut = new WorkspaceRunTestsTool(fx.Accessor, sandbox);
+        var sut = new WorkspaceRunTestsTool(fx.Accessor, TestScopeFactory.ForSandbox(sandbox));
 
         var result = await sut.ExecuteAsync("run", new Dictionary<string, object?>());
 
@@ -66,7 +67,7 @@ public sealed class WorkspaceRunCommandsToolTests
     {
         using var fx = new WorkspaceTestFixture(testCommand: "dotnet test");
         var sandbox = new RecordingSandbox(success: false, exitCode: 1, output: "2 tests failed");
-        var sut = new WorkspaceRunTestsTool(fx.Accessor, sandbox);
+        var sut = new WorkspaceRunTestsTool(fx.Accessor, TestScopeFactory.ForSandbox(sandbox));
 
         var result = await sut.ExecuteAsync("run", new Dictionary<string, object?>());
 
@@ -79,7 +80,7 @@ public sealed class WorkspaceRunCommandsToolTests
     {
         using var fx = new WorkspaceTestFixture(lintCommand: "dotnet format --verify-no-changes");
         var sandbox = new RecordingSandbox(success: true, exitCode: 0, output: "lint clean");
-        var sut = new WorkspaceRunLintTool(fx.Accessor, sandbox);
+        var sut = new WorkspaceRunLintTool(fx.Accessor, TestScopeFactory.ForSandbox(sandbox));
 
         var result = await sut.ExecuteAsync("run", new Dictionary<string, object?>());
 
@@ -95,7 +96,7 @@ public sealed class WorkspaceRunCommandsToolTests
     {
         using var fx = new WorkspaceTestFixture();
         var sandbox = new RecordingSandbox(success: true, exitCode: 0, output: "");
-        var sut = new WorkspaceRunLintTool(fx.Accessor, sandbox);
+        var sut = new WorkspaceRunLintTool(fx.Accessor, TestScopeFactory.ForSandbox(sandbox));
 
         var result = await sut.ExecuteAsync("run", new Dictionary<string, object?>());
 
@@ -108,7 +109,7 @@ public sealed class WorkspaceRunCommandsToolTests
     {
         var bareAccessor = new WorkspaceContextAccessor();
         var sandbox = new RecordingSandbox(success: true, exitCode: 0, output: "");
-        var sut = new WorkspaceRunTestsTool(bareAccessor, sandbox);
+        var sut = new WorkspaceRunTestsTool(bareAccessor, TestScopeFactory.ForSandbox(sandbox));
 
         var result = await sut.ExecuteAsync("run", new Dictionary<string, object?>());
 

--- a/src/Content/Tests/Infrastructure.AI.Tests/Tools/Workspace/WorkspaceWriteFileToolTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Tools/Workspace/WorkspaceWriteFileToolTests.cs
@@ -3,6 +3,7 @@ using Domain.AI.Changes;
 using Domain.AI.Identity;
 using Domain.Common;
 using FluentAssertions;
+using Infrastructure.AI.Tests.Support;
 using Infrastructure.AI.Tests.Tools.Workspace.Support;
 using Infrastructure.AI.Tools.Workspace;
 using MediatR;
@@ -25,7 +26,7 @@ public sealed class WorkspaceWriteFileToolTests
         using var fx = new WorkspaceTestFixture();
         var existingPath = fx.WriteFile("foo.txt", "original-content");
         var mediator = new RecordingMediator(SuccessProposal());
-        var sut = new WorkspaceWriteFileTool(fx.Accessor, mediator);
+        var sut = new WorkspaceWriteFileTool(fx.Accessor, TestScopeFactory.For(mediator));
 
         var result = await sut.ExecuteAsync(
             "submit",
@@ -59,7 +60,7 @@ public sealed class WorkspaceWriteFileToolTests
     {
         using var fx = new WorkspaceTestFixture();
         var mediator = new RecordingMediator(SuccessProposal());
-        var sut = new WorkspaceWriteFileTool(fx.Accessor, mediator);
+        var sut = new WorkspaceWriteFileTool(fx.Accessor, TestScopeFactory.For(mediator));
 
         var result = await sut.ExecuteAsync(
             "submit",
@@ -81,7 +82,7 @@ public sealed class WorkspaceWriteFileToolTests
     {
         var bareAccessor = new WorkspaceContextAccessor();
         var mediator = new RecordingMediator(SuccessProposal());
-        var sut = new WorkspaceWriteFileTool(bareAccessor, mediator);
+        var sut = new WorkspaceWriteFileTool(bareAccessor, TestScopeFactory.For(mediator));
 
         var result = await sut.ExecuteAsync(
             "submit",
@@ -101,7 +102,7 @@ public sealed class WorkspaceWriteFileToolTests
     {
         using var fx = new WorkspaceTestFixture();
         var mediator = new RecordingMediator(SuccessProposal());
-        var sut = new WorkspaceWriteFileTool(fx.Accessor, mediator);
+        var sut = new WorkspaceWriteFileTool(fx.Accessor, TestScopeFactory.For(mediator));
 
         var result = await sut.ExecuteAsync(
             "submit",
@@ -123,7 +124,7 @@ public sealed class WorkspaceWriteFileToolTests
         using var fx = new WorkspaceTestFixture();
         var failureResult = Result<ChangeProposal>.Fail(["validation failed: target unsupported"]);
         var mediator = new RecordingMediator(failureResult);
-        var sut = new WorkspaceWriteFileTool(fx.Accessor, mediator);
+        var sut = new WorkspaceWriteFileTool(fx.Accessor, TestScopeFactory.For(mediator));
 
         var result = await sut.ExecuteAsync(
             "submit",
@@ -143,7 +144,7 @@ public sealed class WorkspaceWriteFileToolTests
     {
         using var fx = new WorkspaceTestFixture();
         var mediator = new RecordingMediator(SuccessProposal());
-        var sut = new WorkspaceWriteFileTool(fx.Accessor, mediator);
+        var sut = new WorkspaceWriteFileTool(fx.Accessor, TestScopeFactory.For(mediator));
 
         await sut.ExecuteAsync(
             "submit",

--- a/src/Content/Tests/Presentation.AgentHub.Tests/IntegrationTestFactory.cs
+++ b/src/Content/Tests/Presentation.AgentHub.Tests/IntegrationTestFactory.cs
@@ -6,7 +6,6 @@ using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
-using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Presentation.AgentHub.Config;
@@ -69,17 +68,6 @@ public class IntegrationTestFactory : WebApplicationFactory<Program>
             services.RemoveAll<IChatClientFactory>();
             services.AddSingleton<IChatClientFactory>(FakeChatClientFactory);
         });
-    }
-
-    /// <inheritdoc/>
-    protected override IHost CreateHost(IHostBuilder builder)
-    {
-        builder.UseDefaultServiceProvider(options =>
-        {
-            options.ValidateScopes = false;
-            options.ValidateOnBuild = false;
-        });
-        return base.CreateHost(builder);
     }
 
     /// <inheritdoc/>

--- a/src/Content/Tests/Presentation.AgentHub.Tests/TestWebApplicationFactory.cs
+++ b/src/Content/Tests/Presentation.AgentHub.Tests/TestWebApplicationFactory.cs
@@ -6,7 +6,6 @@ using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
-using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Moq;
@@ -119,21 +118,6 @@ public class TestWebApplicationFactory : WebApplicationFactory<Program>
             services.RemoveAll<IMediator>();
             services.AddSingleton<IMediator>(MockMediator.Object);
         });
-    }
-
-    /// <inheritdoc/>
-    protected override IHost CreateHost(IHostBuilder builder)
-    {
-        // Suppress scope validation: MemoizedPromptComposer (singleton) → IPromptSectionProvider
-        // (transient) → IAgentExecutionContext (scoped) creates a captive dependency that ASP.NET
-        // Core's hosting rejects by default. Matches ConsoleUI behaviour where BuildServiceProvider()
-        // does not validate scopes.
-        builder.UseDefaultServiceProvider(options =>
-        {
-            options.ValidateScopes = false;
-            options.ValidateOnBuild = false;
-        });
-        return base.CreateHost(builder);
     }
 
     /// <inheritdoc/>


### PR DESCRIPTION
## Summary
Wave-2 audit item **H2**, plus adversarial-review fixes (verdict was MERGE AFTER FIXES; both CRITICALs and the MEDIUM fixed and re-proven).

### The captive composer
`MemoizedPromptComposer` was registered as a **singleton** while its section providers (`SessionStateSectionProvider`, `AgentIdentitySectionProvider`) inject the **scoped** `IAgentExecutionContext` — so prompt composition permanently saw the root scope's frozen context instead of the live conversation's turn/identity, shared across all requests. The bug was papered over: `Program.cs` and both AgentHub test factories set `ValidateScopes=false`, which also hid every future captive dependency.

Fix: composer → **scoped** via new `AddSystemPromptComposition()` extension (memoization unchanged — the backing `IPromptSectionCache` stays singleton); `ContextCompactionService` injects the cache directly; **all validation suppressions removed and AgentHub now runs `ValidateScopes=true` in every environment** (previously off in prod).

### Review fixes — captives the flip would have detonated
The adversarial reviewer hunted the whole composition graph for other singleton→scoped captures that scope validation would turn into runtime throws on untested paths, and found two:
- **`run_tests`/`run_lint` tools**: their keyed-singleton factories resolved the keyed-**scoped** `ISandboxExecutor` from the root provider — first tool resolution would throw. Now resolved from a fresh scope per execution via `IServiceScopeFactory`.
- **Five singletons with root-bound `IMediator`** (`DocumentIngestTool`, `WorkspaceWriteFileTool`, `GitOpsRemediationDispatcher`, `MagenticChangeProposalRouter`, `HarnessAgentInvoker`): MediatR pipeline behaviors ctor-inject the scoped `IAgentExecutionContext`, so any `Send` from these would throw. All five now dispatch inside `CreateAsyncScope()` — the existing `WorkMemorySynthesisBackgroundService` pattern. Scope semantics verified equivalent: the fresh scope's context is uninitialized exactly as the frozen root context was, and the interface contract requires null tolerance.
- **Identity cache poisoning (MEDIUM)**: `AgentIdentitySectionProvider` derived cacheable content from the scoped context while the singleton cache keys on the `agentId` parameter — a scope initialized for agent-b could poison the cache under agent-a's key. Content is now a pure function of the cache key; the scoped dependency is gone. Red-run proven against the temporarily-restored old provider.

## Reproduce-first proof
- `PromptComposerScopeIsolationTests`: 3 tests failed pre-fix with `Cannot consume scoped service 'IAgentExecutionContext' from singleton 'ISystemPromptComposer'`; pass post-fix with per-scope composition, binding the production registration under `ValidateScopes=true`.
- `CaptiveDependencyRegressionTests` + `HarnessAgentInvokerScopeTests`: all red pre-fix (root-provider resolution errors) through the real DI extensions, green post-fix.
- Cache-poisoning test red against old provider, green now.

## Test plan
- [x] Infrastructure.AI.Tests 2015 green (3 pre-existing machine-env failures), Infrastructure.AI.Evaluation.Tests 206/206, Presentation.AgentHub.Tests 384 green under ValidateScopes (9 Docker-gated E2E), builds 0 warnings
- [x] gitnexus impact LOW on all touched symbols; test factories now inherit production provider validation (no test-only rebinding)

## Follow-ups (tracked, not here)
- Flow the caller's ambient agent context into the per-dispatch scopes (`IAmbientRequestScope` mechanism)
- `ValidateOnBuild` stays off: enabling it surfaces ~106 pre-existing MediatR conditional-registration gaps (separate audit finding)
- `ISystemPromptComposer.ComposeAsync` has zero production callers (pre-existing inert machinery — audit backlog)

🤖 Generated with [Claude Code](https://claude.com/claude-code)