### PR TITLE
test: composition-root wiring tests; fix unbound GovernanceConfig

### DIFF
--- a/src/Content/Presentation/Presentation.Common/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Content/Presentation/Presentation.Common/Extensions/IServiceCollectionExtensions.cs
@@ -102,6 +102,17 @@ public static class IServiceCollectionExtensions
         services.Configure<ConnectorsConfig>(configuration.GetSection("AppConfig:Connectors"));
         services.Configure<ObservabilityConfig>(configuration.GetSection("AppConfig:Observability"));
         services.Configure<AIConfig>(configuration.GetSection("AppConfig:AI"));
+        // Governance switches consumed via IOptionsMonitor<GovernanceConfig> on the live
+        // agent path: ToolInvocationGovernor (EnforceToolInvocation), ProgressEvaluator
+        // (ProgressGuard), DefaultToolClassificationGate (DataClassification mode), and the
+        // PromptInjectionBehavior / ResponseSanitizationBehavior MediatR behaviors (Enabled +
+        // thresholds). Without this binding those services run on compiled defaults
+        // regardless of appsettings ("inert machinery", audit item I2). The Escalation and
+        // DataClassification subsections additionally have their own validated bindings in
+        // RegisterValidatedConfigSections; no FluentValidation validator exists yet for the
+        // parent GovernanceConfig — adding one is a tracked follow-up.
+        services.Configure<Domain.Common.Config.AI.GovernanceConfig>(
+            configuration.GetSection("AppConfig:AI:Governance"));
         services.Configure<EmbeddingConfig>(configuration.GetSection("AppConfig:AI:Embedding"));
         services.Configure<AzureConfig>(configuration.GetSection("AppConfig:Azure"));
         services.Configure<CacheConfig>(configuration.GetSection("AppConfig:Cache"));

--- a/src/Content/Tests/Presentation.Common.Tests/Composition/CompositionRootTestHost.cs
+++ b/src/Content/Tests/Presentation.Common.Tests/Composition/CompositionRootTestHost.cs
@@ -1,0 +1,89 @@
+using Domain.Common.Config;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Presentation.Common.Extensions;
+
+namespace Presentation.Common.Tests.Composition;
+
+/// <summary>
+/// Builds a service provider through the REAL composition root — the same
+/// <c>RegisterConfigSections</c> + <c>BuildGlobalSolutionServices</c> pair that
+/// <see cref="IServiceCollectionExtensions.GetServices"/> chains for every host
+/// (AgentHub, ConsoleUI, EvalRunner, FoundryHost) — differing only in that
+/// configuration comes from an in-memory dictionary instead of
+/// <c>AppConfigHelper.LoadAppConfig()</c>'s appsettings.json files.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This exists because the Wave-2 audit's worst failure mode was "inert machinery":
+/// features whose unit tests hand-construct the object graph with exactly the values
+/// production never supplies. Tests built on this host bind the production service
+/// graph, so a feature that is registered-but-never-wired (or wired with the wrong
+/// lifetime) fails here even when its isolated unit tests pass.
+/// </para>
+/// <para>
+/// The provider is built with <c>ValidateScopes = true</c> — stricter than the default
+/// host — so captive-dependency bugs (a singleton capturing a scoped service, the
+/// audit's H2 class) surface as resolution failures instead of silent stale state.
+/// </para>
+/// </remarks>
+internal static class CompositionRootTestHost
+{
+    /// <summary>
+    /// Composes the full production service graph from the given configuration values.
+    /// </summary>
+    /// <param name="settings">
+    /// In-memory configuration (same key syntax as appsettings.json paths, e.g.
+    /// <c>AppConfig:AI:Skills:BasePath</c>).
+    /// </param>
+    /// <param name="overrideServices">
+    /// Optional post-composition overrides, receiving the built configuration. Use ONLY to
+    /// replace external boundaries (LLM chat clients) or to supply a documented workaround
+    /// for a known production wiring bug; everything else must stay production wiring or
+    /// the test stops proving anything.
+    /// </param>
+    /// <returns>A scope-validating provider over the production composition.</returns>
+    public static ServiceProvider BuildProvider(
+        IEnumerable<KeyValuePair<string, string?>> settings,
+        Action<IServiceCollection, IConfiguration>? overrideServices = null)
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(settings)
+            .Build();
+
+        var services = new ServiceCollection();
+
+        // Real hosts get ILogger<T> from their HostBuilder before GetServices() runs;
+        // a bare ServiceCollection needs the equivalent registration explicitly.
+        services.AddLogging();
+
+        // Mirror GetServices() exactly, minus the file-based config loading.
+        services.RegisterConfigSections(configuration);
+        var appConfig = configuration.GetSection("AppConfig").Get<AppConfig>() ?? new AppConfig();
+        services.BuildGlobalSolutionServices(appConfig, includeHealthChecksUI: false);
+
+        overrideServices?.Invoke(services, configuration);
+
+        return services.BuildServiceProvider(new ServiceProviderOptions
+        {
+            ValidateScopes = true,
+        });
+    }
+
+    /// <summary>
+    /// Runs the production <see cref="Infrastructure.AI.Plugins.PluginStartupLoader"/> hosted
+    /// service exactly as a host does at boot: resolved from the registered
+    /// <see cref="IHostedService"/> collection (proving the registration exists), started once
+    /// before the first lazy skill/MCP discovery.
+    /// </summary>
+    /// <param name="provider">The composition-root provider to start plugin loading on.</param>
+    public static async Task RunPluginStartupLoaderAsync(ServiceProvider provider)
+    {
+        var loader = provider.GetServices<IHostedService>()
+            .OfType<Infrastructure.AI.Plugins.PluginStartupLoader>()
+            .Single();
+
+        await loader.StartAsync(CancellationToken.None);
+    }
+}

--- a/src/Content/Tests/Presentation.Common.Tests/Composition/GovernanceConfigBindingTests.cs
+++ b/src/Content/Tests/Presentation.Common.Tests/Composition/GovernanceConfigBindingTests.cs
@@ -1,0 +1,89 @@
+using Domain.Common.Config.AI;
+using Domain.Common.Config.AI.Governance;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Presentation.Common.Tests.Composition;
+
+/// <summary>
+/// REAL WIRING BUG, exposed by the I2 wiring integration tests and deliberately NOT fixed on
+/// this branch (test-only scope): no production composition root binds
+/// <see cref="GovernanceConfig"/> to <c>AppConfig:AI:Governance</c>, so every
+/// <c>IOptionsMonitor&lt;GovernanceConfig&gt;</c> consumer runs on compiled defaults regardless
+/// of appsettings.json.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Affected consumers (all inject <c>IOptionsMonitor&lt;GovernanceConfig&gt;</c>):
+/// </para>
+/// <list type="bullet">
+///   <item><description><c>ToolInvocationGovernor</c> — <c>EnforceToolInvocation</c> can never
+///     be turned on from config; the live 3-gate tool path stays a pass-through.</description></item>
+///   <item><description><c>ProgressEvaluator</c> — <c>ProgressGuard.Enabled</c> unreachable.</description></item>
+///   <item><description><c>DefaultToolClassificationGate</c> — reads
+///     <c>GovernanceConfig.DataClassification</c> from the unbound parent, so the DLP gate's
+///     Mode stays Off even though <c>DataClassificationConfig</c> is separately bound and
+///     validated at <c>AppConfig:AI:Governance:DataClassification</c>.</description></item>
+///   <item><description><c>PromptInjectionBehavior</c> / <c>ResponseSanitizationBehavior</c> —
+///     <c>Enabled</c>/<c>EnablePromptInjectionDetection</c> unreachable, so both MediatR
+///     behaviors are inert; hosts shipping <c>"Governance": { "Enabled": true, ... }</c> in
+///     appsettings.json get none of it at these consumers.</description></item>
+/// </list>
+/// <para>
+/// The unit tests for all of these pass because they construct <c>new GovernanceConfig
+/// {{ ... }}</c> directly — the exact "inert machinery" failure mode audit item I2 exists to
+/// catch. Note the composition-root <em>registration</em> decision
+/// (<c>AddGovernanceDependencies</c> vs no-op) DOES see the configured values, because it reads
+/// the <c>AppConfig</c> instance bound at startup — only the options-monitor path is dead.
+/// </para>
+/// <para>
+/// The sibling <see cref="PluginGovernanceCompositionTests"/> compensate with a single
+/// test-side <c>Configure&lt;GovernanceConfig&gt;</c> call so the rest of the governance chain
+/// is still proven wired. When the production binding lands (one line in
+/// <c>RegisterConfigSections</c>, ideally with a config validator like its siblings), unskip
+/// the test below and delete that workaround.
+/// </para>
+/// </remarks>
+public sealed class GovernanceConfigBindingTests
+{
+    [Fact(Skip = "KNOWN WIRING BUG (found by I2): GovernanceConfig is never bound to " +
+                 "AppConfig:AI:Governance in any composition root, so EnforceToolInvocation, " +
+                 "ProgressGuard, prompt-injection and response-sanitization switches are dead " +
+                 "config. Unskip when RegisterConfigSections binds GovernanceConfig.")]
+    public async Task RegisterConfigSections_GovernanceSection_ReachesGovernanceConfigMonitor()
+    {
+        await using var provider = CompositionRootTestHost.BuildProvider(new Dictionary<string, string?>
+        {
+            ["AppConfig:AI:Governance:Enabled"] = "true",
+            ["AppConfig:AI:Governance:EnforceToolInvocation"] = "true",
+        });
+
+        var governance = provider.GetRequiredService<IOptionsMonitor<GovernanceConfig>>().CurrentValue;
+
+        governance.Enabled.Should().BeTrue(
+            "AppConfig:AI:Governance:Enabled must reach IOptionsMonitor<GovernanceConfig> consumers");
+        governance.EnforceToolInvocation.Should().BeTrue(
+            "the live tool-invocation gate must be switchable from configuration");
+    }
+
+    [Fact]
+    public async Task RegisterConfigSections_EscalationSubsection_ReachesItsOwnMonitor()
+    {
+        // Contrast pin: the Escalation SUBSECTION of the same Governance tree IS bound (and
+        // validated) by RegisterConfigSections — proving the gap above is specific to the
+        // parent GovernanceConfig type, not the section path.
+        await using var provider = CompositionRootTestHost.BuildProvider(new Dictionary<string, string?>
+        {
+            ["AppConfig:AI:Governance:Escalation:Enabled"] = "true",
+            ["AppConfig:AI:Governance:Escalation:DefaultTimeoutSeconds"] = "600",
+            ["AppConfig:AI:Governance:Escalation:PriorityLevels:Blocking:TimeoutSeconds"] = "300",
+        });
+
+        var escalation = provider.GetRequiredService<IOptionsMonitor<EscalationConfig>>().CurrentValue;
+
+        escalation.Enabled.Should().BeTrue();
+        escalation.DefaultTimeoutSeconds.Should().Be(600);
+    }
+}

--- a/src/Content/Tests/Presentation.Common.Tests/Composition/GovernanceConfigBindingTests.cs
+++ b/src/Content/Tests/Presentation.Common.Tests/Composition/GovernanceConfigBindingTests.cs
@@ -8,64 +8,54 @@ using Xunit;
 namespace Presentation.Common.Tests.Composition;
 
 /// <summary>
-/// REAL WIRING BUG, exposed by the I2 wiring integration tests and deliberately NOT fixed on
-/// this branch (test-only scope): no production composition root binds
-/// <see cref="GovernanceConfig"/> to <c>AppConfig:AI:Governance</c>, so every
-/// <c>IOptionsMonitor&lt;GovernanceConfig&gt;</c> consumer runs on compiled defaults regardless
-/// of appsettings.json.
+/// Regression guard for a REAL wiring bug found (and fixed) by the I2 wiring integration
+/// tests: no composition root bound <see cref="GovernanceConfig"/> to
+/// <c>AppConfig:AI:Governance</c>, so every <c>IOptionsMonitor&lt;GovernanceConfig&gt;</c>
+/// consumer ran on compiled defaults regardless of appsettings.json.
 /// </summary>
 /// <remarks>
 /// <para>
 /// Affected consumers (all inject <c>IOptionsMonitor&lt;GovernanceConfig&gt;</c>):
-/// </para>
-/// <list type="bullet">
-///   <item><description><c>ToolInvocationGovernor</c> — <c>EnforceToolInvocation</c> can never
-///     be turned on from config; the live 3-gate tool path stays a pass-through.</description></item>
-///   <item><description><c>ProgressEvaluator</c> — <c>ProgressGuard.Enabled</c> unreachable.</description></item>
-///   <item><description><c>DefaultToolClassificationGate</c> — reads
-///     <c>GovernanceConfig.DataClassification</c> from the unbound parent, so the DLP gate's
-///     Mode stays Off even though <c>DataClassificationConfig</c> is separately bound and
-///     validated at <c>AppConfig:AI:Governance:DataClassification</c>.</description></item>
-///   <item><description><c>PromptInjectionBehavior</c> / <c>ResponseSanitizationBehavior</c> —
-///     <c>Enabled</c>/<c>EnablePromptInjectionDetection</c> unreachable, so both MediatR
-///     behaviors are inert; hosts shipping <c>"Governance": { "Enabled": true, ... }</c> in
-///     appsettings.json get none of it at these consumers.</description></item>
-/// </list>
-/// <para>
-/// The unit tests for all of these pass because they construct <c>new GovernanceConfig
-/// {{ ... }}</c> directly — the exact "inert machinery" failure mode audit item I2 exists to
-/// catch. Note the composition-root <em>registration</em> decision
-/// (<c>AddGovernanceDependencies</c> vs no-op) DOES see the configured values, because it reads
-/// the <c>AppConfig</c> instance bound at startup — only the options-monitor path is dead.
+/// <c>ToolInvocationGovernor</c> (<c>EnforceToolInvocation</c> could never be turned on from
+/// config — the live 3-gate tool path stayed a pass-through), <c>ProgressEvaluator</c>
+/// (<c>ProgressGuard.Enabled</c> unreachable), <c>DefaultToolClassificationGate</c> (reads
+/// <c>GovernanceConfig.DataClassification</c> from the parent, so the DLP gate's Mode stayed
+/// Off even though <c>DataClassificationConfig</c> is separately bound and validated), and
+/// the <c>PromptInjectionBehavior</c> / <c>ResponseSanitizationBehavior</c> MediatR behaviors
+/// (<c>Enabled</c>/<c>EnablePromptInjectionDetection</c> unreachable). Hosts shipping
+/// <c>"Governance": { "Enabled": true, ... }</c> in appsettings.json got none of it at these
+/// consumers, while their unit tests passed by constructing <c>new GovernanceConfig</c>
+/// directly — the exact "inert machinery" failure mode audit item I2 exists to catch.
 /// </para>
 /// <para>
-/// The sibling <see cref="PluginGovernanceCompositionTests"/> compensate with a single
-/// test-side <c>Configure&lt;GovernanceConfig&gt;</c> call so the rest of the governance chain
-/// is still proven wired. When the production binding lands (one line in
-/// <c>RegisterConfigSections</c>, ideally with a config validator like its siblings), unskip
-/// the test below and delete that workaround.
+/// The fix is the <c>Configure&lt;GovernanceConfig&gt;</c> binding in
+/// <c>RegisterConfigSections</c>. Tracked follow-up: the parent <c>GovernanceConfig</c> has no
+/// FluentValidation config validator (its Escalation and DataClassification subsections do) —
+/// when one is added, move the binding into <c>RegisterValidatedConfigSections</c> with
+/// <c>ValidateOnStart()</c> like its siblings.
 /// </para>
 /// </remarks>
 public sealed class GovernanceConfigBindingTests
 {
-    [Fact(Skip = "KNOWN WIRING BUG (found by I2): GovernanceConfig is never bound to " +
-                 "AppConfig:AI:Governance in any composition root, so EnforceToolInvocation, " +
-                 "ProgressGuard, prompt-injection and response-sanitization switches are dead " +
-                 "config. Unskip when RegisterConfigSections binds GovernanceConfig.")]
+    [Fact]
     public async Task RegisterConfigSections_GovernanceSection_ReachesGovernanceConfigMonitor()
     {
+        // Deliberately probes with Enabled=false: EnforceToolInvocation and
+        // EnablePromptInjectionDetection are independent of Enabled, and Enabled=true would
+        // route composition into AddGovernanceDependencies (the AGT kernel path), which has
+        // its own config requirements — this test isolates the options BINDING only.
         await using var provider = CompositionRootTestHost.BuildProvider(new Dictionary<string, string?>
         {
-            ["AppConfig:AI:Governance:Enabled"] = "true",
             ["AppConfig:AI:Governance:EnforceToolInvocation"] = "true",
+            ["AppConfig:AI:Governance:EnablePromptInjectionDetection"] = "true",
         });
 
         var governance = provider.GetRequiredService<IOptionsMonitor<GovernanceConfig>>().CurrentValue;
 
-        governance.Enabled.Should().BeTrue(
-            "AppConfig:AI:Governance:Enabled must reach IOptionsMonitor<GovernanceConfig> consumers");
         governance.EnforceToolInvocation.Should().BeTrue(
             "the live tool-invocation gate must be switchable from configuration");
+        governance.EnablePromptInjectionDetection.Should().BeTrue(
+            "AppConfig:AI:Governance values must reach IOptionsMonitor<GovernanceConfig> consumers");
     }
 
     [Fact]

--- a/src/Content/Tests/Presentation.Common.Tests/Composition/PluginGovernanceCompositionTests.cs
+++ b/src/Content/Tests/Presentation.Common.Tests/Composition/PluginGovernanceCompositionTests.cs
@@ -104,27 +104,6 @@ public sealed class PluginGovernanceCompositionTests : IDisposable
         ["AppConfig:AI:Permissions:DefaultBehavior"] = "Allow",
     };
 
-    /// <summary>
-    /// Builds the composition-root provider WITH the missing <c>GovernanceConfig</c> binding
-    /// supplied test-side.
-    /// </summary>
-    /// <remarks>
-    /// WORKAROUND for a REAL wiring bug these tests exposed (pinned red by
-    /// <see cref="GovernanceConfigBindingTests"/>): no production composition root binds
-    /// <c>GovernanceConfig</c> to <c>AppConfig:AI:Governance</c>, so
-    /// <c>EnforceToolInvocation</c> — and every other <c>IOptionsMonitor&lt;GovernanceConfig&gt;</c>
-    /// switch — can never be enabled from configuration. The single <c>Configure</c> call below
-    /// supplies ONLY that missing binding so the rest of the governance chain
-    /// (PluginPermissionRuleProvider → ThreePhasePermissionResolver → ToolInvocationGovernor →
-    /// GovernedAIFunction) can be proven wired. DELETE this override when the production
-    /// binding lands and rely on config alone.
-    /// </remarks>
-    private static Microsoft.Extensions.DependencyInjection.ServiceProvider BuildGovernanceProvider(
-        Dictionary<string, string?> settings) =>
-        CompositionRootTestHost.BuildProvider(settings, (services, configuration) =>
-            services.Configure<Domain.Common.Config.AI.GovernanceConfig>(
-                configuration.GetSection("AppConfig:AI:Governance")));
-
     [Fact]
     public async Task PluginStartupLoader_DeclaredPlugin_LoadsAndAttributesSkillThroughCompositionRoot()
     {
@@ -179,7 +158,7 @@ public sealed class PluginGovernanceCompositionTests : IDisposable
         // filter cannot remove it) must still be blocked at invocation time: the plugin's
         // bypass-immune Deny rule flows PluginPermissionRuleProvider → ThreePhasePermissionResolver
         // → ToolInvocationGovernor → GovernedAIFunction, all resolved from the production graph.
-        await using var provider = BuildGovernanceProvider(BaseSettings());
+        await using var provider = CompositionRootTestHost.BuildProvider(BaseSettings());
         await CompositionRootTestHost.RunPluginStartupLoaderAsync(provider);
 
         var executed = false;
@@ -203,7 +182,7 @@ public sealed class PluginGovernanceCompositionTests : IDisposable
         // Ask rule scoped "sentinel:*". Ask rules resolve in phase 2, BEFORE any Allow rule, so
         // the plugin baseline tightens an otherwise Allow-by-default environment for tools whose
         // names carry the plugin prefix — while unprefixed tools stay allowed.
-        await using var provider = BuildGovernanceProvider(BaseSettings("Supervised"));
+        await using var provider = CompositionRootTestHost.BuildProvider(BaseSettings("Supervised"));
         await CompositionRootTestHost.RunPluginStartupLoaderAsync(provider);
 
         var prefixedExecuted = false;
@@ -247,7 +226,7 @@ public sealed class PluginGovernanceCompositionTests : IDisposable
         // plugin baselines effective must consciously update it.
         var settings = BaseSettings("Autonomous");
         settings["AppConfig:AI:Permissions:DefaultBehavior"] = "Ask"; // resolver default
-        await using var provider = BuildGovernanceProvider(settings);
+        await using var provider = CompositionRootTestHost.BuildProvider(settings);
         await CompositionRootTestHost.RunPluginStartupLoaderAsync(provider);
 
         var executed = false;

--- a/src/Content/Tests/Presentation.Common.Tests/Composition/PluginGovernanceCompositionTests.cs
+++ b/src/Content/Tests/Presentation.Common.Tests/Composition/PluginGovernanceCompositionTests.cs
@@ -1,0 +1,323 @@
+using Application.AI.Common.Interfaces;
+using Application.AI.Common.Interfaces.Governance;
+using Application.AI.Common.Interfaces.Agent;
+using Application.AI.Common.Interfaces.Plugins;
+using Application.AI.Common.Interfaces.Tools;
+using Application.AI.Common.Services.Governance;
+using Domain.AI.Governance;
+using FluentAssertions;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Presentation.Common.Tests.Composition;
+
+/// <summary>
+/// Wiring integration tests (audit item I2) proving plugin boundary governance is live on the
+/// REAL composition root: a plugin declared under <c>AppConfig:AI:Plugins:Packages</c> is loaded
+/// by the production <c>PluginStartupLoader</c>, its skill is discovered and attributed by the
+/// production <c>SkillMetadataRegistry</c>, its <c>DeniedTools</c> filter the production
+/// <c>IToolChainBuilder</c> output, and its bypass-immune Deny rules block invocation through
+/// the production scoped <see cref="IToolInvocationGovernor"/> — the same 3-gate chokepoint
+/// (governor → classification → progress) every agent tool call passes through.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Nothing here hand-constructs the object graph. Every service is resolved from the graph
+/// that <c>GetServices()</c> builds for real hosts, so a regression that unregisters a rule
+/// provider, changes the governor's lifetime, or breaks plugin→skill attribution fails these
+/// tests even when each component's isolated unit tests stay green.
+/// </para>
+/// <para>
+/// The only test-supplied step is publishing the scoped governor to
+/// <see cref="ToolGovernanceAccessor"/> — the single line
+/// <c>ExecuteAgentTurnCommandHandler</c> performs at the start of a governed turn (and clears
+/// in its finally). The tests mirror that exact pattern.
+/// </para>
+/// </remarks>
+public sealed class PluginGovernanceCompositionTests : IDisposable
+{
+    private const string PluginName = "sentinel";
+    private const string PluginSkillId = "sentinel-skill";
+    private const string HostSkillId = "host-skill";
+    private const string DeniedToolName = "dangerous_tool";
+
+    private readonly string _tempRoot;
+    private readonly string _builtInSkillsDir;
+    private readonly string _pluginDir;
+
+    public PluginGovernanceCompositionTests()
+    {
+        _tempRoot = Path.Combine(Path.GetTempPath(), "composition-gov-" + Guid.NewGuid().ToString("N"));
+        _builtInSkillsDir = Path.Combine(_tempRoot, "skills");
+        _pluginDir = Path.Combine(_tempRoot, "plugins", PluginName);
+
+        // Built-in (non-plugin) skill so the Managed resolution path is exercised too.
+        WriteSkill(Path.Combine(_builtInSkillsDir, "host"), $"""
+            ---
+            name: {HostSkillId}
+            description: A built-in skill with no tool declarations.
+            ---
+            Host instructions.
+            """);
+
+        // Plugin package on disk: plugin.json manifest + one skill under ./skills/.
+        Directory.CreateDirectory(_pluginDir);
+        File.WriteAllText(Path.Combine(_pluginDir, "plugin.json"), $$"""
+            { "name": "{{PluginName}}", "version": "1.0.0", "skills": "./skills/" }
+            """);
+        WriteSkill(Path.Combine(_pluginDir, "skills", "do-thing"), $"""
+            ---
+            name: {PluginSkillId}
+            description: A plugin skill with no tool declarations.
+            ---
+            Plugin instructions.
+            """);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_tempRoot, recursive: true); }
+        catch (IOException) { /* best-effort temp cleanup */ }
+    }
+
+    private static void WriteSkill(string dir, string skillMarkdown)
+    {
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, "SKILL.md"), skillMarkdown);
+    }
+
+    /// <summary>
+    /// Production-shaped configuration: one declared plugin with a DeniedTools boundary and an
+    /// autonomy-level override, tool-invocation enforcement on, and an Allow-by-default
+    /// permission environment so that any block observed is attributable to plugin governance
+    /// rather than the resolver's fallback.
+    /// </summary>
+    private Dictionary<string, string?> BaseSettings(string pluginAutonomyLevel = "Supervised") => new()
+    {
+        ["AppConfig:AI:Skills:BasePath"] = _builtInSkillsDir,
+        ["AppConfig:AI:Plugins:Packages:0:Name"] = PluginName,
+        ["AppConfig:AI:Plugins:Packages:0:Path"] = _pluginDir,
+        ["AppConfig:AI:Plugins:Packages:0:DeniedTools:0"] = DeniedToolName,
+        ["AppConfig:AI:Plugins:Packages:0:AutonomyLevel"] = pluginAutonomyLevel,
+        ["AppConfig:AI:Governance:EnforceToolInvocation"] = "true",
+        ["AppConfig:AI:Permissions:DefaultBehavior"] = "Allow",
+    };
+
+    /// <summary>
+    /// Builds the composition-root provider WITH the missing <c>GovernanceConfig</c> binding
+    /// supplied test-side.
+    /// </summary>
+    /// <remarks>
+    /// WORKAROUND for a REAL wiring bug these tests exposed (pinned red by
+    /// <see cref="GovernanceConfigBindingTests"/>): no production composition root binds
+    /// <c>GovernanceConfig</c> to <c>AppConfig:AI:Governance</c>, so
+    /// <c>EnforceToolInvocation</c> — and every other <c>IOptionsMonitor&lt;GovernanceConfig&gt;</c>
+    /// switch — can never be enabled from configuration. The single <c>Configure</c> call below
+    /// supplies ONLY that missing binding so the rest of the governance chain
+    /// (PluginPermissionRuleProvider → ThreePhasePermissionResolver → ToolInvocationGovernor →
+    /// GovernedAIFunction) can be proven wired. DELETE this override when the production
+    /// binding lands and rely on config alone.
+    /// </remarks>
+    private static Microsoft.Extensions.DependencyInjection.ServiceProvider BuildGovernanceProvider(
+        Dictionary<string, string?> settings) =>
+        CompositionRootTestHost.BuildProvider(settings, (services, configuration) =>
+            services.Configure<Domain.Common.Config.AI.GovernanceConfig>(
+                configuration.GetSection("AppConfig:AI:Governance")));
+
+    [Fact]
+    public async Task PluginStartupLoader_DeclaredPlugin_LoadsAndAttributesSkillThroughCompositionRoot()
+    {
+        await using var provider = CompositionRootTestHost.BuildProvider(BaseSettings());
+
+        await CompositionRootTestHost.RunPluginStartupLoaderAsync(provider);
+
+        var registry = provider.GetRequiredService<IPluginRegistry>();
+        var plugin = registry.GetPlugin(PluginName);
+        plugin.Should().NotBeNull("the declared plugin must be loaded by the registered hosted service");
+        plugin!.Declaration.DeniedTools.Should().Contain(DeniedToolName);
+
+        var skillRegistry = provider.GetRequiredService<ISkillMetadataRegistry>();
+        var skill = skillRegistry.TryGet(PluginSkillId);
+        skill.Should().NotBeNull("the plugin's skill directory must be visible to lazy skill discovery");
+        skill!.PluginSource.Should().Be(PluginName,
+            "boundary governance only fires when discovery attributes the skill to its plugin");
+    }
+
+    [Fact]
+    public async Task BuildToolsAsync_PluginSkillWithDeniedTool_FiltersDeniedToolOnLivePath()
+    {
+        await using var provider = CompositionRootTestHost.BuildProvider(BaseSettings());
+        await CompositionRootTestHost.RunPluginStartupLoaderAsync(provider);
+
+        var skill = provider.GetRequiredService<ISkillMetadataRegistry>().TryGet(PluginSkillId);
+        skill.Should().NotBeNull();
+
+        var builder = provider.GetRequiredService<IToolChainBuilder>();
+        var options = new Domain.AI.Skills.SkillAgentOptions
+        {
+            AdditionalTools =
+            [
+                AIFunctionFactory.Create(() => "ok", "audit_tool"),
+                AIFunctionFactory.Create(() => "boom", DeniedToolName),
+            ],
+        };
+
+        var tools = await builder.BuildToolsAsync(skill!, options);
+
+        tools.Select(t => t.Name).Should().NotContain(DeniedToolName,
+            "the plugin's DeniedTools boundary must remove the tool from the resolved set on the live path");
+        tools.Select(t => t.Name).Should().Contain("audit_tool");
+        tools.Should().OnlyContain(t => t.GetType().Name == "GovernedAIFunction",
+            "every agent-callable tool must be wrapped in the per-invocation governance chokepoint");
+    }
+
+    [Fact]
+    public async Task GovernedTool_PluginDeniedTool_BlockedAtInvocationByRealGovernor()
+    {
+        // A denied tool that leaks into the toolset via a NON-plugin skill (so the boundary
+        // filter cannot remove it) must still be blocked at invocation time: the plugin's
+        // bypass-immune Deny rule flows PluginPermissionRuleProvider → ThreePhasePermissionResolver
+        // → ToolInvocationGovernor → GovernedAIFunction, all resolved from the production graph.
+        await using var provider = BuildGovernanceProvider(BaseSettings());
+        await CompositionRootTestHost.RunPluginStartupLoaderAsync(provider);
+
+        var executed = false;
+        var wrapped = await BuildGovernedHostTool(provider,
+            AIFunctionFactory.Create(() => { executed = true; return "ran"; }, DeniedToolName));
+
+        using var scope = provider.CreateScope();
+        var (results, trace) = await InvokeUnderGovernedTurn(scope, wrapped);
+
+        ResultText(results[0]).Should().Contain("is not permitted",
+            "the governor's model-facing denial must replace the tool result");
+        executed.Should().BeFalse("a governance-denied tool must never execute");
+        trace.ToolDecisions.Should().ContainSingle(d =>
+            d.ToolName == DeniedToolName && d.Outcome == ToolDecisionOutcome.Denied);
+    }
+
+    [Fact]
+    public async Task GovernedTool_PluginScopedSupervisedBaseline_RequiresApprovalForPluginPrefixedTool()
+    {
+        // The {plugin}:* case that IS enforced: a Supervised/Restricted plugin baseline emits an
+        // Ask rule scoped "sentinel:*". Ask rules resolve in phase 2, BEFORE any Allow rule, so
+        // the plugin baseline tightens an otherwise Allow-by-default environment for tools whose
+        // names carry the plugin prefix — while unprefixed tools stay allowed.
+        await using var provider = BuildGovernanceProvider(BaseSettings("Supervised"));
+        await CompositionRootTestHost.RunPluginStartupLoaderAsync(provider);
+
+        var prefixedExecuted = false;
+        var plainExecuted = false;
+        var prefixed = await BuildGovernedHostTool(provider,
+            AIFunctionFactory.Create(() => { prefixedExecuted = true; return "ran"; }, $"{PluginName}:deploy"));
+        var plain = await BuildGovernedHostTool(provider,
+            AIFunctionFactory.Create(() => { plainExecuted = true; return "ran"; }, "plain_tool"));
+
+        using var scope = provider.CreateScope();
+        var (results, trace) = await InvokeUnderGovernedTurn(scope, prefixed, plain);
+
+        ResultText(results[0]).Should().Contain("is not permitted",
+            "the plugin's Supervised baseline maps to Ask, which fail-closes to a block pending approval");
+        prefixedExecuted.Should().BeFalse();
+        plainExecuted.Should().BeTrue("an unprefixed tool is outside the plugin baseline and stays allowed");
+        trace.ToolDecisions.Should().Contain(d =>
+            d.ToolName == $"{PluginName}:deploy" && d.Outcome == ToolDecisionOutcome.PendingApproval);
+        trace.ToolDecisions.Should().Contain(d =>
+            d.ToolName == "plain_tool" && d.Outcome == ToolDecisionOutcome.Allowed);
+    }
+
+    [Fact]
+    public async Task GovernedTool_AutonomousPluginBaseline_KnownInert_CannotLoosenDefaultAskEnvironment()
+    {
+        // KNOWN-INERT AUTONOMY BASELINE — tracked follow-up, deliberately NOT fixed here.
+        //
+        // A plugin declaring AutonomyLevel=Autonomous emits an Allow rule scoped "{plugin}:*"
+        // (phase 3). It is inert on the live path for two independent reasons:
+        //
+        //   1. Phase masking: AutonomyTierRuleProvider ALWAYS emits a "*" rule from
+        //      PermissionsConfig.DefaultBehavior (default "Ask"). Ask rules resolve in phase 2,
+        //      before ANY Allow rule is consulted, so the plugin's Allow can never loosen the
+        //      environment. (Under DefaultBehavior=Allow the tier's own "*" Allow at priority 0
+        //      wins instead, so the plugin rule is redundant there too.)
+        //   2. Tool naming: tools resolved by ToolChainBuilder keep their original names —
+        //      nothing on the live path namespaces them "{plugin}:", so the pattern only ever
+        //      matches synthetic names like the probe below.
+        //
+        // This test PINS the current inert behavior so the follow-up that makes Autonomous
+        // plugin baselines effective must consciously update it.
+        var settings = BaseSettings("Autonomous");
+        settings["AppConfig:AI:Permissions:DefaultBehavior"] = "Ask"; // resolver default
+        await using var provider = BuildGovernanceProvider(settings);
+        await CompositionRootTestHost.RunPluginStartupLoaderAsync(provider);
+
+        var executed = false;
+        var wrapped = await BuildGovernedHostTool(provider,
+            AIFunctionFactory.Create(() => { executed = true; return "ran"; }, $"{PluginName}:deploy"));
+
+        using var scope = provider.CreateScope();
+        var (results, trace) = await InvokeUnderGovernedTurn(scope, wrapped);
+
+        ResultText(results[0]).Should().Contain("is not permitted",
+            "the tier's '*' Ask baseline masks the plugin's Autonomous Allow rule (known-inert, see remarks)");
+        executed.Should().BeFalse();
+        trace.ToolDecisions.Should().ContainSingle(d =>
+            d.ToolName == $"{PluginName}:deploy" && d.Outcome == ToolDecisionOutcome.PendingApproval);
+    }
+
+    /// <summary>
+    /// Extracts the model-facing text from an <see cref="AIFunction.InvokeAsync"/> result.
+    /// The invocation pipeline marshals return values through JSON, so a governance denial
+    /// string arrives as a <see cref="System.Text.Json.JsonElement"/> rather than a raw string.
+    /// </summary>
+    private static string ResultText(object? invocationResult) => invocationResult switch
+    {
+        System.Text.Json.JsonElement { ValueKind: System.Text.Json.JsonValueKind.String } element
+            => element.GetString()!,
+        _ => invocationResult?.ToString() ?? string.Empty,
+    };
+
+    /// <summary>
+    /// Builds the governed tool set for the built-in (non-plugin) skill through the production
+    /// <see cref="IToolChainBuilder"/>, returning the wrapped functions for the given probes.
+    /// </summary>
+    private static async Task<AIFunction> BuildGovernedHostTool(
+        ServiceProvider provider, AIFunction probe)
+    {
+        var skill = provider.GetRequiredService<ISkillMetadataRegistry>().TryGet(HostSkillId);
+        skill.Should().NotBeNull("the built-in skill must be discoverable from the configured BasePath");
+
+        var tools = await provider.GetRequiredService<IToolChainBuilder>().BuildToolsAsync(
+            skill!, new Domain.AI.Skills.SkillAgentOptions { AdditionalTools = [probe] });
+
+        return tools.OfType<AIFunction>().Single(t => t.Name == probe.Name);
+    }
+
+    /// <summary>
+    /// Invokes the given governed functions inside a governed turn shaped exactly like
+    /// <c>ExecuteAgentTurnCommandHandler</c>'s: scoped execution context initialized with an
+    /// agent identity, the scope's governor published to <see cref="ToolGovernanceAccessor"/>,
+    /// and the accessor cleared in a finally. Returns each invocation's result (in call order)
+    /// plus the governor's recorded trace.
+    /// </summary>
+    private static async Task<(IReadOnlyList<object?> Results, GovernanceTrace Trace)> InvokeUnderGovernedTurn(
+        IServiceScope scope, params AIFunction[] functions)
+    {
+        scope.ServiceProvider.GetRequiredService<IAgentExecutionContext>()
+            .Initialize("composition-test-agent", "conv-gov", turnNumber: 1);
+
+        var governor = scope.ServiceProvider.GetRequiredService<IToolInvocationGovernor>();
+        ToolGovernanceAccessor.Current = governor;
+        try
+        {
+            var results = new List<object?>();
+            foreach (var function in functions)
+                results.Add(await function.InvokeAsync(new AIFunctionArguments(), CancellationToken.None));
+
+            return (results, governor.GetTrace());
+        }
+        finally
+        {
+            ToolGovernanceAccessor.Current = null;
+        }
+    }
+}

--- a/src/Content/Tests/Presentation.Common.Tests/Composition/PromptCompositionRootTests.cs
+++ b/src/Content/Tests/Presentation.Common.Tests/Composition/PromptCompositionRootTests.cs
@@ -1,0 +1,73 @@
+using Application.AI.Common.Interfaces.Agent;
+using Application.AI.Common.Interfaces.Prompts;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Presentation.Common.Tests.Composition;
+
+/// <summary>
+/// Wiring integration tests (audit item I2) for per-request prompt composition (PR #135,
+/// audit finding H2) at the FULL composition-root level. The existing
+/// <c>PromptComposerScopeIsolationTests</c> bind <c>AddSystemPromptComposition()</c> in
+/// isolation; these tests close the remaining wiring gap by proving the composer resolves and
+/// composes per-request inside the complete graph that <c>GetServices()</c> builds — where a
+/// different registration (or a future one) could reintroduce the captive-singleton bug
+/// without the isolated tests noticing.
+/// </summary>
+/// <remarks>
+/// The provider is built with <c>ValidateScopes = true</c>: if the composer (or any section
+/// provider it chains) is ever registered as a singleton capturing the scoped
+/// <see cref="IAgentExecutionContext"/> again, resolution here throws instead of silently
+/// composing against another conversation's state.
+/// </remarks>
+public sealed class PromptCompositionRootTests
+{
+    private static ServiceProvider BuildProvider() =>
+        CompositionRootTestHost.BuildProvider(new Dictionary<string, string?>());
+
+    [Fact]
+    public async Task Composer_ResolvesFromRequestScope_InFullCompositionRootUnderScopeValidation()
+    {
+        await using var provider = BuildProvider();
+        using var scope = provider.CreateScope();
+
+        var act = () => scope.ServiceProvider.GetRequiredService<ISystemPromptComposer>();
+
+        act.Should().NotThrow(
+            "the composer must resolve from a request scope without capturing scoped state from the root");
+    }
+
+    [Fact]
+    public async Task ComposeAsync_TwoRequestScopesInFullRoot_EachSeesOwnConversationContext()
+    {
+        await using var provider = BuildProvider();
+
+        // Turn 1: conversation conv-1, turn 3.
+        using (var scope1 = provider.CreateScope())
+        {
+            scope1.ServiceProvider.GetRequiredService<IAgentExecutionContext>()
+                .Initialize("agent-a", "conv-1", turnNumber: 3);
+
+            var prompt1 = await scope1.ServiceProvider
+                .GetRequiredService<ISystemPromptComposer>()
+                .ComposeAsync("agent-a", tokenBudget: 10_000);
+
+            prompt1.Should().Contain("Current turn: 3",
+                "a host turn must compose against the CURRENT conversation's context, not a frozen one");
+        }
+
+        // Turn 2: a different conversation in a fresh scope must not see turn 1's state.
+        using var scope2 = provider.CreateScope();
+        scope2.ServiceProvider.GetRequiredService<IAgentExecutionContext>()
+            .Initialize("agent-b", "conv-2", turnNumber: 7);
+
+        var prompt2 = await scope2.ServiceProvider
+            .GetRequiredService<ISystemPromptComposer>()
+            .ComposeAsync("agent-b", tokenBudget: 10_000);
+
+        prompt2.Should().Contain("Current turn: 7");
+        prompt2.Should().NotContain("Current turn: 3",
+            "session state must never bleed across request scopes through the full production graph");
+    }
+}

--- a/src/Content/Tests/Presentation.Common.Tests/Composition/SkillPrerequisiteCompositionTests.cs
+++ b/src/Content/Tests/Presentation.Common.Tests/Composition/SkillPrerequisiteCompositionTests.cs
@@ -1,0 +1,134 @@
+using Application.AI.Common.Interfaces;
+using Application.AI.Common.Interfaces.Tools;
+using Domain.AI.Skills;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Presentation.Common.Tests.Fakes;
+using Xunit;
+
+namespace Presentation.Common.Tests.Composition;
+
+/// <summary>
+/// Wiring integration tests (audit item I2) for the skill-prerequisite conversation scope
+/// (PR #121): through the REAL composition root, a skill declaring <c>prerequisites</c> must
+/// build successfully because <c>AgentConversationCache</c> flows the conversation id into
+/// <c>SkillAgentOptions.AdditionalProperties["conversationId"]</c> before the agent is built.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The pre-fix bug: <c>AgentFactory.ResolvePrerequisiteScope</c> requires the conversation id
+/// in the execution context's additional properties and throws when absent. Only unit tests
+/// ever supplied that key — the live path (<c>IAgentConversationCache.GetOrCreateAsync</c>)
+/// never did, so every prerequisite-bearing skill crashed every conversation turn while all
+/// unit tests stayed green. This is the canonical "inert machinery" shape: production never
+/// supplies the value the tests inject.
+/// </para>
+/// <para>
+/// These tests resolve <see cref="IAgentConversationCache"/> from the graph
+/// <c>GetServices()</c> builds — real <c>AgentFactory</c>, real
+/// <c>AgentExecutionContextFactory</c>, real <c>SkillMetadataRegistry</c> discovering real
+/// SKILL.md files from disk. Only <see cref="IChatClientFactory"/> (the external LLM boundary)
+/// is replaced.
+/// </para>
+/// </remarks>
+public sealed class SkillPrerequisiteCompositionTests : IDisposable
+{
+    private const string ValidateSkillId = "validate-skill";
+    private const string DeploySkillId = "deploy-skill";
+
+    private readonly string _skillsDir;
+
+    public SkillPrerequisiteCompositionTests()
+    {
+        _skillsDir = Path.Combine(Path.GetTempPath(), "composition-prereq-" + Guid.NewGuid().ToString("N"));
+
+        WriteSkill("validate", $"""
+            ---
+            name: {ValidateSkillId}
+            description: Validates the change before deployment.
+            ---
+            Validate.
+            """);
+        WriteSkill("deploy", $"""
+            ---
+            name: {DeploySkillId}
+            description: Deploys the change after validation.
+            prerequisites: [{ValidateSkillId}]
+            ---
+            Deploy.
+            """);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_skillsDir, recursive: true); }
+        catch (IOException) { /* best-effort temp cleanup */ }
+    }
+
+    private void WriteSkill(string folder, string skillMarkdown)
+    {
+        var dir = Path.Combine(_skillsDir, folder);
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, "SKILL.md"), skillMarkdown);
+    }
+
+    private ServiceProvider BuildProvider() => CompositionRootTestHost.BuildProvider(
+        new Dictionary<string, string?>
+        {
+            ["AppConfig:AI:Skills:BasePath"] = _skillsDir,
+            ["AppConfig:AI:AgentFramework:ClientType"] = "AzureOpenAI",
+            ["AppConfig:AI:AgentFramework:DefaultDeployment"] = "gpt-4o",
+        },
+        overrideServices: (services, _) =>
+            // Replace ONLY the external LLM boundary. Last-registered wins, so the fake
+            // shadows the production ChatClientFactory registration.
+            services.AddSingleton<IChatClientFactory>(new FakeChatClientFactory()));
+
+    [Fact]
+    public async Task SkillRegistry_DeploySkill_DiscoversPrerequisitesFromDisk()
+    {
+        await using var provider = BuildProvider();
+
+        var skill = provider.GetRequiredService<ISkillMetadataRegistry>().TryGet(DeploySkillId);
+
+        skill.Should().NotBeNull("the skill must be discoverable from the configured BasePath");
+        skill!.Prerequisites.Should().ContainSingle()
+            .Which.Should().Be(ValidateSkillId,
+                "prerequisite metadata must survive the real parse+discovery path or the middleware never arms");
+    }
+
+    [Fact]
+    public async Task GetOrCreateAsync_PrerequisiteSkill_ResolvesConversationScopeThroughCompositionRoot()
+    {
+        await using var provider = BuildProvider();
+        var cache = provider.GetRequiredService<IAgentConversationCache>();
+
+        // Production shape: the caller supplies NO conversationId in the options — the cache
+        // is the only component holding it and must flow it into the agent build.
+        var act = () => cache.GetOrCreateAsync(
+            "conv-composition-root", [ValidateSkillId, DeploySkillId], new SkillAgentOptions());
+
+        // Pre-#121 this threw InvalidOperationException from AgentFactory.ResolvePrerequisiteScope
+        // ("no conversation scope") on every turn of every prerequisite-bearing skill.
+        var agent = await act.Should().NotThrowAsync(
+            "the live cache→factory path must supply the prerequisite conversation scope itself");
+        agent.Subject.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task GetOrCreateAsync_SameConversation_ReturnsCachedAgentInstance()
+    {
+        // Companion wiring guarantee: the conversation scope injected by the cache must not
+        // break agent identity caching — a second turn on the same conversation reuses the
+        // same agent instead of rebuilding (and re-scoping) it.
+        await using var provider = BuildProvider();
+        var cache = provider.GetRequiredService<IAgentConversationCache>();
+
+        var first = await cache.GetOrCreateAsync(
+            "conv-reuse", [ValidateSkillId, DeploySkillId], new SkillAgentOptions());
+        var second = await cache.GetOrCreateAsync(
+            "conv-reuse", [ValidateSkillId, DeploySkillId], new SkillAgentOptions());
+
+        second.Should().BeSameAs(first);
+    }
+}

--- a/src/Content/Tests/Presentation.Common.Tests/Fakes/FakeChatClientFactory.cs
+++ b/src/Content/Tests/Presentation.Common.Tests/Fakes/FakeChatClientFactory.cs
@@ -1,0 +1,70 @@
+using Application.AI.Common.Interfaces;
+using Application.AI.Common.Models;
+using Domain.Common.Config.AI;
+using Microsoft.Extensions.AI;
+
+namespace Presentation.Common.Tests.Fakes;
+
+/// <summary>
+/// In-memory <see cref="IChatClientFactory"/> for composition-root tests. Replaces ONLY the
+/// external LLM boundary (the production <c>ChatClientFactory</c> would build a real Azure
+/// OpenAI client); everything else in the graph stays production wiring.
+/// </summary>
+public sealed class FakeChatClientFactory : IChatClientFactory
+{
+    private readonly FakeChatClient _client = new();
+
+    /// <inheritdoc />
+    public bool IsAvailable(AIAgentFrameworkClientType clientType) => true;
+
+    /// <inheritdoc />
+    public Task<IChatClient> GetChatClientAsync(
+        AIAgentFrameworkClientType clientType,
+        string deploymentOrAgentId,
+        CancellationToken cancellationToken = default)
+        => Task.FromResult<IChatClient>(_client);
+
+    /// <inheritdoc />
+    public IReadOnlyDictionary<AIAgentFrameworkClientType, bool> GetAvailableProviders() =>
+        new Dictionary<AIAgentFrameworkClientType, bool>
+        {
+            [AIAgentFrameworkClientType.AzureOpenAI] = true,
+        };
+
+    /// <inheritdoc />
+    public AiProviderStatus GetProviderStatus() =>
+        new(AIAgentFrameworkClientType.AzureOpenAI, "fake-deployment", IsConfigured: true, MissingSettings: []);
+
+    /// <inheritdoc />
+    public Task<string> CreatePersistentAgentAsync(
+        string model, string name, string? instructions = null,
+        string? description = null, CancellationToken cancellationToken = default)
+        => Task.FromResult($"fake-agent-{Guid.NewGuid():N}");
+
+    /// <summary>Minimal <see cref="IChatClient"/> that returns a canned assistant response.</summary>
+    private sealed class FakeChatClient : IChatClient
+    {
+        public Task<ChatResponse> GetResponseAsync(
+            IEnumerable<ChatMessage> messages,
+            ChatOptions? options = null,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult(new ChatResponse(new ChatMessage(ChatRole.Assistant, "fake response")));
+
+        public async IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+            IEnumerable<ChatMessage> messages,
+            ChatOptions? options = null,
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            var response = await GetResponseAsync(messages, options, cancellationToken);
+            foreach (var message in response.Messages)
+                yield return new ChatResponseUpdate(message.Role, message.Contents);
+        }
+
+        public object? GetService(Type serviceType, object? serviceKey = null) => null;
+
+        public void Dispose()
+        {
+            // Nothing to release — the fake holds no unmanaged resources.
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Wave-2 audit item **I2**: integration tests that bind the REAL composition root and prove headline features are wired on the live path — the test layer that would have caught the audit's "inert machinery" class. And it immediately earned its keep: writing these tests exposed a live wiring bug, fixed here.

## ⚠️ Deliberate behavior change (read this)
**`GovernanceConfig` was never bound to `AppConfig:AI:Governance` in any composition root.** Five services consuming `IOptionsMonitor<GovernanceConfig>` ran on compiled defaults regardless of appsettings: `ToolInvocationGovernor` (`EnforceToolInvocation` could never be enabled from config), `ProgressEvaluator`, `DefaultToolClassificationGate`, `PromptInjectionBehavior`, `ResponseSanitizationBehavior`. Every host ships `"Governance": { "Enabled": true, "EnablePromptInjectionDetection": true }` that these consumers never saw. All their unit tests pass because they construct the config directly — the exact I2 failure mode.

Fixed with one `Configure<GovernanceConfig>` binding. Exhaustive per-host delta audit of what becomes live:
- **Material**: `PromptInjectionBehavior` now actually runs in all four hosts — `ExecuteAgentTurnCommand` / `IngestDocumentCommand` / `SearchDocumentsQuery` are scanned and blocked at threat ≥ High. This is what shipped appsettings has declared all along, and it matches the repo's security rules (content safety on all agent endpoints). To opt out: set `EnablePromptInjectionDetection: false` in host appsettings.
- **No other change**: `EnforceToolInvocation` stays off (but is now genuinely switchable), `ProgressGuard` off, `DataClassification.Mode` Off, `ResponseSanitizationBehavior` still gates on a dead seam (zero `IToolRequest` implementers), audit/metrics already equal to defaults. MCPServer host unaffected (separate binding path).

## Tests added (12, `Presentation.Common.Tests/Composition/`)
- `CompositionRootTestHost` — mirrors `GetServices()` exactly (`RegisterConfigSections` + `BuildGlobalSolutionServices`), `ValidateScopes=true`, runs the real `PluginStartupLoader`.
- **Plugin governance on the live path**: plugin loads through the root; DeniedTools filtered in `BuildToolsAsync` (every tool `GovernedAIFunction`-wrapped); bypass-immune Deny blocked at invocation by the real scoped governor (probe never executes, trace records Denied); `{plugin}:*` Supervised baseline enforced; the known-inert Autonomous-baseline case pinned with full documentation (tracked follow-up, deliberately not fixed here).
- **Skill prerequisites (PR #121 regression)**: conversationId flows through the real `IAgentConversationCache` → `AgentFactory` chain; pre-#121 this exact call threw.
- **Prompt composition (PR #135 gap)**: `ISystemPromptComposer` resolved from the FULL root under scope validation; two host scopes compose with their own conversation's turn state.
- **MCP auth 401**: existing PR #132 suite verified as complete wiring-level coverage (18/18) — not duplicated.

## Red→green proof
The pin test ran red pre-fix (`EnforceToolInvocation` found False through the root) and is now un-skipped and green; the loudly-marked test-side `Configure<GovernanceConfig>` workaround is deleted — governance tests pass through the real binding.

## Test plan
- [x] Presentation.Common.Tests 125/125 (0 skipped), Application.AI.Common.Tests 1307, Application.Core.Tests 638, FoundryHost 21, EvalRunner 21, AgentHub 384 (9 = Docker-unavailable Prometheus E2E on dev machine, env-only)
- [x] gitnexus: RegisterConfigSections LOW (1 caller)

## Follow-ups (tracked, not here)
- `GovernanceConfigValidator` + move binding to `RegisterValidatedConfigSections` with `ValidateOnStart` (no parent validator exists yet)
- `AddGovernanceDependencies` crashes composition when `Enabled=true` + `EnablePromptInjectionDetection=false` (null detector registration) — config landmine
- Inert `{plugin}:*` Autonomous autonomy-baseline (pinned by test with explanation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)