### PR TITLE
fix: wire resilience pipelines onto live client paths

### DIFF
--- a/src/Content/Application/Application.AI.Common/Factories/AgentExecutionContextFactory.cs
+++ b/src/Content/Application/Application.AI.Common/Factories/AgentExecutionContextFactory.cs
@@ -141,17 +141,30 @@ public class AgentExecutionContextFactory
         if (prerequisiteMap.HasAnyPrerequisites)
             additionalProps[SkillPrerequisiteMap.AdditionalPropertiesKey] = prerequisiteMap;
 
-        // Stash the composed resilient chat client for AgentFactory to consume. Gated on
-        // ResilienceConfig.Enabled: when resilience is off the provider would return the PRIMARY
-        // raw client (AppConfig.AI.AgentFramework), which must not override the per-context
-        // deployment/framework resolved above — disabled means byte-identical legacy behavior.
+        // Stash the composed resilient chat client for AgentFactory to consume. Gated on:
+        // (a) ResilienceConfig.Enabled — when off the provider would return the PRIMARY raw
+        //     client, which must not override the per-context resolution above; and
+        // (b) ResilientClientEligibility — the fallback chain can only stand in for a context
+        //     that resolved to exactly the primary configured provider + default deployment.
+        //     Per-skill/per-options overrides, PersistentAgents (AgentId-bound), FoundryResponses,
+        //     and Echo contexts keep their raw client.
         if (_resilientChatClientProvider is not null
             && _appConfig.CurrentValue.AI?.Resilience?.Enabled == true)
         {
-            var resilientClient = await _resilientChatClientProvider.GetResilientChatClientAsync();
-            additionalProps[IResilientChatClientProvider.AdditionalPropertiesKey] = resilientClient;
+            if (ResilientClientEligibility.IsEligible(
+                    frameworkType, deploymentName, _appConfig.CurrentValue.AI?.AgentFramework))
+            {
+                var resilientClient = await _resilientChatClientProvider.GetResilientChatClientAsync();
+                additionalProps[IResilientChatClientProvider.AdditionalPropertiesKey] = resilientClient;
 
-            _logger.LogDebug("Stashed resilient chat client (fallback chain) for agent {AgentName}", agentName);
+                _logger.LogDebug("Stashed resilient chat client (fallback chain) for agent {AgentName}", agentName);
+            }
+            else
+            {
+                _logger.LogDebug(
+                    "Resilience enabled but agent {AgentName} keeps its raw client: resolved {FrameworkType}/{Deployment} is not the primary configured provider/deployment",
+                    agentName, frameworkType, deploymentName);
+            }
         }
 
         // Start a trace run when a store is wired in

--- a/src/Content/Application/Application.AI.Common/Factories/AgentExecutionContextFactory.cs
+++ b/src/Content/Application/Application.AI.Common/Factories/AgentExecutionContextFactory.cs
@@ -141,11 +141,17 @@ public class AgentExecutionContextFactory
         if (prerequisiteMap.HasAnyPrerequisites)
             additionalProps[SkillPrerequisiteMap.AdditionalPropertiesKey] = prerequisiteMap;
 
-        // Stash resilient chat client for transparent fallback when resilience is enabled
-        if (_resilientChatClientProvider is not null)
+        // Stash the composed resilient chat client for AgentFactory to consume. Gated on
+        // ResilienceConfig.Enabled: when resilience is off the provider would return the PRIMARY
+        // raw client (AppConfig.AI.AgentFramework), which must not override the per-context
+        // deployment/framework resolved above — disabled means byte-identical legacy behavior.
+        if (_resilientChatClientProvider is not null
+            && _appConfig.CurrentValue.AI?.Resilience?.Enabled == true)
         {
             var resilientClient = await _resilientChatClientProvider.GetResilientChatClientAsync();
-            additionalProps["__resilientChatClient"] = resilientClient;
+            additionalProps[IResilientChatClientProvider.AdditionalPropertiesKey] = resilientClient;
+
+            _logger.LogDebug("Stashed resilient chat client (fallback chain) for agent {AgentName}", agentName);
         }
 
         // Start a trace run when a store is wired in

--- a/src/Content/Application/Application.AI.Common/Factories/AgentFactory.cs
+++ b/src/Content/Application/Application.AI.Common/Factories/AgentFactory.cs
@@ -160,12 +160,17 @@ public class AgentFactory : IAgentFactory
     /// </summary>
     /// <remarks>
     /// When <see cref="AgentExecutionContextFactory"/> stashed a resilient chat client in the
-    /// context (only done when <c>ResilienceConfig.Enabled</c> is true), that client — which
-    /// spans the configured provider fallback chain with per-provider Polly retry, circuit
-    /// breaker, and timeout pipelines — replaces the raw per-provider client so every live turn
-    /// executes through the resilience pipelines. When resilience is disabled nothing is
-    /// stashed and the raw client resolved from <see cref="IChatClientFactory"/> is used,
-    /// preserving the per-context deployment and framework selection unchanged.
+    /// context (only done when <c>ResilienceConfig.Enabled</c> is true AND the context resolved
+    /// to the primary configured provider + default deployment), that client — which spans the
+    /// configured provider fallback chain with per-provider Polly retry, circuit breaker, and
+    /// timeout pipelines — replaces the raw per-provider client so live turns execute through
+    /// the resilience pipelines. The consume side re-checks eligibility
+    /// (<see cref="ResilientClientEligibility"/>) as defense in depth: PersistentAgents contexts
+    /// keep their provisioned AgentId path, and per-context deployment/framework overrides keep
+    /// their raw client even if a stash is present. Coverage note: only contexts built by
+    /// <see cref="AgentExecutionContextFactory"/> (skill-built agents) ever carry a stash —
+    /// callers constructing <see cref="AgentExecutionContext"/> manually (e.g. evaluation
+    /// harnesses) and FoundryResponses agents do not route through the resilient client.
     /// </remarks>
     private async Task<AIAgent> CreateChatClientAgentAsync(
         AgentExecutionContext agentContext,
@@ -174,7 +179,7 @@ public class AgentFactory : IAgentFactory
         ChatClientAgentOptions agentOptions,
         CancellationToken cancellationToken)
     {
-        var chatClient = ResolveStashedResilientClient(agentContext)
+        var chatClient = ResolveStashedResilientClient(agentContext, clientType, deploymentOrAgentId)
             ?? await _chatClientFactory.GetChatClientAsync(
                 clientType, deploymentOrAgentId, cancellationToken);
 
@@ -186,23 +191,37 @@ public class AgentFactory : IAgentFactory
     /// <summary>
     /// Returns the resilient chat client stashed in the execution context under
     /// <see cref="Interfaces.Resilience.IResilientChatClientProvider.AdditionalPropertiesKey"/>,
-    /// or <see langword="null"/> when resilience is disabled (nothing stashed) so the caller
-    /// falls back to the raw per-provider client.
+    /// or <see langword="null"/> when nothing is stashed (resilience disabled) or the context is
+    /// not eligible for substitution — PersistentAgents (AgentId-bound), Echo, or a per-context
+    /// framework/deployment override differing from the primary configured provider. Ineligible
+    /// contexts always fall back to the raw per-provider client, even if a stash is present.
     /// </summary>
-    private IChatClient? ResolveStashedResilientClient(AgentExecutionContext agentContext)
+    private IChatClient? ResolveStashedResilientClient(
+        AgentExecutionContext agentContext,
+        AIAgentFrameworkClientType clientType,
+        string deploymentOrAgentId)
     {
         if (agentContext.AdditionalProperties?.TryGetValue(
                 Interfaces.Resilience.IResilientChatClientProvider.AdditionalPropertiesKey,
-                out var stashed) == true
-            && stashed is IChatClient resilientClient)
+                out var stashed) != true
+            || stashed is not IChatClient resilientClient)
         {
-            _logger.LogInformation(
-                "Agent {AgentName} using resilient chat client (provider fallback chain) instead of raw provider client",
-                agentContext.Name);
-            return resilientClient;
+            return null;
         }
 
-        return null;
+        if (!ResilientClientEligibility.IsEligible(
+                clientType, deploymentOrAgentId, _appConfig.CurrentValue.AI?.AgentFramework))
+        {
+            _logger.LogDebug(
+                "Agent {AgentName} carries a stashed resilient client but resolved {ClientType}/{Deployment} is not eligible — using raw provider client",
+                agentContext.Name, clientType, deploymentOrAgentId);
+            return null;
+        }
+
+        _logger.LogInformation(
+            "Agent {AgentName} using resilient chat client (provider fallback chain) instead of raw provider client",
+            agentContext.Name);
+        return resilientClient;
     }
 
     /// <summary>

--- a/src/Content/Application/Application.AI.Common/Factories/AgentFactory.cs
+++ b/src/Content/Application/Application.AI.Common/Factories/AgentFactory.cs
@@ -158,6 +158,15 @@ public class AgentFactory : IAgentFactory
     /// Inference, Persistent Agents, Anthropic, Echo): resolves the chat client, wraps it in the
     /// harness middleware pipeline, and constructs a <see cref="ChatClientAgent"/>.
     /// </summary>
+    /// <remarks>
+    /// When <see cref="AgentExecutionContextFactory"/> stashed a resilient chat client in the
+    /// context (only done when <c>ResilienceConfig.Enabled</c> is true), that client — which
+    /// spans the configured provider fallback chain with per-provider Polly retry, circuit
+    /// breaker, and timeout pipelines — replaces the raw per-provider client so every live turn
+    /// executes through the resilience pipelines. When resilience is disabled nothing is
+    /// stashed and the raw client resolved from <see cref="IChatClientFactory"/> is used,
+    /// preserving the per-context deployment and framework selection unchanged.
+    /// </remarks>
     private async Task<AIAgent> CreateChatClientAgentAsync(
         AgentExecutionContext agentContext,
         AIAgentFrameworkClientType clientType,
@@ -165,12 +174,35 @@ public class AgentFactory : IAgentFactory
         ChatClientAgentOptions agentOptions,
         CancellationToken cancellationToken)
     {
-        var chatClient = await _chatClientFactory.GetChatClientAsync(
-            clientType, deploymentOrAgentId, cancellationToken);
+        var chatClient = ResolveStashedResilientClient(agentContext)
+            ?? await _chatClientFactory.GetChatClientAsync(
+                clientType, deploymentOrAgentId, cancellationToken);
 
         var middlewareEnabledChatClient = BuildMiddlewarePipeline(chatClient, agentContext);
 
         return new ChatClientAgent(middlewareEnabledChatClient, agentOptions);
+    }
+
+    /// <summary>
+    /// Returns the resilient chat client stashed in the execution context under
+    /// <see cref="Interfaces.Resilience.IResilientChatClientProvider.AdditionalPropertiesKey"/>,
+    /// or <see langword="null"/> when resilience is disabled (nothing stashed) so the caller
+    /// falls back to the raw per-provider client.
+    /// </summary>
+    private IChatClient? ResolveStashedResilientClient(AgentExecutionContext agentContext)
+    {
+        if (agentContext.AdditionalProperties?.TryGetValue(
+                Interfaces.Resilience.IResilientChatClientProvider.AdditionalPropertiesKey,
+                out var stashed) == true
+            && stashed is IChatClient resilientClient)
+        {
+            _logger.LogInformation(
+                "Agent {AgentName} using resilient chat client (provider fallback chain) instead of raw provider client",
+                agentContext.Name);
+            return resilientClient;
+        }
+
+        return null;
     }
 
     /// <summary>

--- a/src/Content/Application/Application.AI.Common/Factories/ResilientClientEligibility.cs
+++ b/src/Content/Application/Application.AI.Common/Factories/ResilientClientEligibility.cs
@@ -1,0 +1,68 @@
+using Domain.Common.Config.AI;
+
+namespace Application.AI.Common.Factories;
+
+/// <summary>
+/// Central eligibility rule deciding whether an agent execution context may be served by the
+/// composed resilient chat client (the <c>ResilienceConfig.FallbackChain</c>) instead of its
+/// raw per-context provider client. Shared by the stash side
+/// (<see cref="AgentExecutionContextFactory"/>) and the consume side (<see cref="AgentFactory"/>)
+/// so the two gates can never disagree.
+/// </summary>
+/// <remarks>
+/// The resilient client always talks to the configured fallback chain — it cannot honor a
+/// per-context provider or deployment choice. Substituting it is therefore only safe when the
+/// context resolved to exactly the primary configured provider and deployment:
+/// <list type="bullet">
+///   <item><description>the resolved framework equals <c>AppConfig.AI.AgentFramework.ClientType</c>
+///   (no per-skill or per-options framework override to a different provider);</description></item>
+///   <item><description>the framework is an <c>IChatClient</c>-style provider — never
+///   <see cref="AIAgentFrameworkClientType.PersistentAgents"/> (its deployment slot carries a
+///   provisioned AgentId that the fallback chain would silently abandon), never
+///   <see cref="AIAgentFrameworkClientType.FoundryResponses"/> (built via
+///   <c>IFoundryAgentProvider</c>, not the chat-client path), never
+///   <see cref="AIAgentFrameworkClientType.Echo"/> (deterministic test client);</description></item>
+///   <item><description>the resolved deployment equals the configured
+///   <c>DefaultDeployment</c> (no per-skill <c>ModelOverride</c> or options override).</description></item>
+/// </list>
+/// Contexts failing any check keep their raw client untouched — explicit per-context choices
+/// always win over the generic resilience chain.
+/// </remarks>
+internal static class ResilientClientEligibility
+{
+    /// <summary>
+    /// Returns <see langword="true"/> when a context resolved to the given framework and
+    /// deployment may be transparently served by the resilient fallback-chain client.
+    /// </summary>
+    /// <param name="resolvedFramework">The framework type the context resolved to.</param>
+    /// <param name="resolvedDeployment">
+    /// The deployment the context resolved to (for <see cref="AIAgentFrameworkClientType.PersistentAgents"/>
+    /// callers this slot carries the AgentId, which is excluded by the framework check anyway).
+    /// </param>
+    /// <param name="primaryConfig">The primary provider configuration (<c>AppConfig.AI.AgentFramework</c>).</param>
+    public static bool IsEligible(
+        AIAgentFrameworkClientType resolvedFramework,
+        string? resolvedDeployment,
+        AgentFrameworkConfig? primaryConfig)
+    {
+        if (primaryConfig is null)
+            return false;
+
+        // Non-IChatClient-style frameworks never route through the resilient client.
+        if (resolvedFramework is AIAgentFrameworkClientType.PersistentAgents
+            or AIAgentFrameworkClientType.FoundryResponses
+            or AIAgentFrameworkClientType.Echo)
+        {
+            return false;
+        }
+
+        // A framework override to a different provider than the primary config must win.
+        if (resolvedFramework != primaryConfig.ClientType)
+            return false;
+
+        // A deployment override differing from the configured default must win. Ordinal
+        // comparison: any difference is treated as an explicit override (conservative).
+        return string.IsNullOrEmpty(resolvedDeployment)
+            || string.Equals(resolvedDeployment, primaryConfig.DefaultDeployment, StringComparison.Ordinal);
+    }
+}

--- a/src/Content/Application/Application.AI.Common/Interfaces/Resilience/IResilientChatClientProvider.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Resilience/IResilientChatClientProvider.cs
@@ -25,6 +25,15 @@ namespace Application.AI.Common.Interfaces.Resilience;
 public interface IResilientChatClientProvider
 {
 	/// <summary>
+	/// Key under which <c>AgentExecutionContextFactory</c> stashes the composed resilient
+	/// chat client in <c>AgentExecutionContext.AdditionalProperties</c> when
+	/// <c>ResilienceConfig.Enabled</c> is true. <c>AgentFactory</c> consumes this key when
+	/// building the agent's chat-client pipeline so that live turns execute through the
+	/// per-provider Polly pipelines and the fallback chain instead of the raw provider client.
+	/// </summary>
+	const string AdditionalPropertiesKey = "__resilientChatClient";
+
+	/// <summary>
 	/// Returns a resilient chat client wrapping the full provider fallback chain.
 	/// The result is cached -- the provider chain does not change at runtime.
 	/// </summary>

--- a/src/Content/Application/Application.AI.Common/Interfaces/Resilience/IResilientChatClientProvider.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Resilience/IResilientChatClientProvider.cs
@@ -26,11 +26,19 @@ public interface IResilientChatClientProvider
 {
 	/// <summary>
 	/// Key under which <c>AgentExecutionContextFactory</c> stashes the composed resilient
-	/// chat client in <c>AgentExecutionContext.AdditionalProperties</c> when
-	/// <c>ResilienceConfig.Enabled</c> is true. <c>AgentFactory</c> consumes this key when
-	/// building the agent's chat-client pipeline so that live turns execute through the
-	/// per-provider Polly pipelines and the fallback chain instead of the raw provider client.
+	/// chat client in <c>AgentExecutionContext.AdditionalProperties</c>. Stashed only when
+	/// <c>ResilienceConfig.Enabled</c> is true AND the context resolved to the primary
+	/// configured provider and default deployment (see <c>ResilientClientEligibility</c>).
+	/// <c>AgentFactory</c> consumes this key when building the agent's chat-client pipeline so
+	/// that live turns execute through the per-provider Polly pipelines and the fallback chain
+	/// instead of the raw provider client.
 	/// </summary>
+	/// <remarks>
+	/// Coverage: skill-built <c>IChatClient</c>-style agents only. Contexts constructed
+	/// manually (evaluation harnesses, ad-hoc <c>AgentExecutionContext</c> callers),
+	/// PersistentAgents (AgentId-bound), FoundryResponses, Echo, and contexts with per-skill or
+	/// per-options framework/deployment overrides do NOT route through the resilient client.
+	/// </remarks>
 	const string AdditionalPropertiesKey = "__resilientChatClient";
 
 	/// <summary>

--- a/src/Content/Domain/Domain.Common/Config/Http/Policies/HttpTimeoutPolicyConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/Http/Policies/HttpTimeoutPolicyConfig.cs
@@ -4,14 +4,26 @@ namespace Domain.Common.Config.Http.Policies;
 
 /// <summary>
 /// Configuration for the HTTP timeout resilience policy.
-/// Controls the maximum duration allowed for HTTP operations.
+/// Controls the per-attempt and total durations allowed for HTTP operations.
 /// </summary>
 public class HttpTimeoutPolicyConfig
 {
     /// <summary>
-    /// Gets or sets the maximum timeout for HTTP operations.
+    /// Gets or sets the PER-ATTEMPT timeout: each individual HTTP send (including each retry
+    /// attempt) is cancelled after this duration. The whole operation across all retries is
+    /// bounded by <see cref="TotalTimeout"/>, not by this value — <c>HttpClient.Timeout</c> is
+    /// set to infinite so it cannot race the pipeline and truncate the retry budget.
     /// </summary>
     /// <value>Default: 30 seconds.</value>
     [Required]
     public TimeSpan Timeout { get; set; } = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// Gets or sets the TOTAL timeout for an HTTP operation across all retry attempts and
+    /// backoff delays. When <see langword="null"/> (the default) it is computed as
+    /// <c>(HttpRetry.Count + 1) × Timeout</c> plus exponential-backoff headroom, so the retry
+    /// budget always fits inside the total budget.
+    /// </summary>
+    /// <value>Default: <see langword="null"/> (computed from retry count, per-attempt timeout, and backoff).</value>
+    public TimeSpan? TotalTimeout { get; set; }
 }

--- a/src/Content/Infrastructure/Infrastructure.APIAccess/Common/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Content/Infrastructure/Infrastructure.APIAccess/Common/Extensions/IServiceCollectionExtensions.cs
@@ -257,32 +257,43 @@ public static class IServiceCollectionExtensions
     }
 
     /// <summary>
-    /// Configures Polly resilience pipelines with retry, timeout, circuit breaker, and rate limiting.
+    /// Attaches the harness Polly resilience pipeline (retry, timeout, circuit breaker, rate
+    /// limiter) to an HTTP client so every request the client sends executes through it.
+    /// Retries are safe for requests with content — the underlying
+    /// <c>Microsoft.Extensions.Http.Resilience</c> handler snapshots the request message
+    /// before each attempt.
     /// </summary>
-    /// <param name="services">The service collection to configure.</param>
-    /// <param name="configurationName">The name of the resilience pipeline configuration.</param>
-    /// <returns>The service collection for chaining.</returns>
+    /// <param name="httpClientBuilder">The HTTP client builder to attach the handler to.</param>
+    /// <returns>The HTTP client builder for chaining.</returns>
     /// <remarks>
-    /// Strategies applied in order:
+    /// Strategies applied in order (outermost to innermost):
     /// <list type="bullet">
     ///   <item>Retry - Exponential backoff with jitter for retryable exceptions</item>
     ///   <item>Timeout - Prevents operations from running too long</item>
     ///   <item>Circuit Breaker - Stops calling failing services after a threshold</item>
     ///   <item>Rate Limiter - Sliding window rate limiting (100 requests/minute)</item>
     /// </list>
+    /// All tuning values come from <c>AppConfig:Http:Policies</c> (<see cref="HttpPolicyConfig"/>).
+    /// <see cref="AddDefaultHttpClient"/> applies this handler to every client created via
+    /// <c>IHttpClientFactory</c>; do not attach it a second time to individual clients or
+    /// retries will compound multiplicatively.
     /// </remarks>
-    public static IServiceCollection AddResiliencePipelines(
-        this IServiceCollection services,
-        string configurationName)
+    public static IHttpClientBuilder AddCustomResilienceHandler(this IHttpClientBuilder httpClientBuilder)
     {
-        services.AddResiliencePipeline(configurationName, (builder, context) =>
+        httpClientBuilder.AddResilienceHandler("harness-http", (builder, context) =>
         {
-            var serviceProvider = context.ServiceProvider;
-            var httpConfig = serviceProvider.GetService<IOptionsMonitor<HttpConfig>>()!.CurrentValue;
+            var httpConfig = context.ServiceProvider
+                .GetRequiredService<IOptionsMonitor<HttpConfig>>().CurrentValue;
 
-            builder.AddRetry(new RetryStrategyOptions
+            builder.AddRetry(new RetryStrategyOptions<HttpResponseMessage>
             {
-                ShouldHandle = ex => new ValueTask<bool>(RetryableExceptions.Contains(ex.GetType())),
+                // Retry only when the ATTEMPT'S EXCEPTION is a declared retryable type. The
+                // predicate receives Polly's predicate-arguments struct — inspecting the struct
+                // itself (a former bug: RetryableExceptions.Contains(args.GetType())) can never
+                // match, silently disabling all retries.
+                ShouldHandle = args => new ValueTask<bool>(
+                    args.Outcome.Exception is { } exception
+                    && RetryableExceptions.Contains(exception.GetType())),
                 BackoffType = DelayBackoffType.Exponential,
                 UseJitter = true,
                 MaxRetryAttempts = httpConfig.Policies.HttpRetry.Count,
@@ -294,7 +305,7 @@ public static class IServiceCollectionExtensions
                 Timeout = httpConfig.Policies.HttpTimeout.Timeout,
             });
 
-            builder.AddCircuitBreaker(new CircuitBreakerStrategyOptions
+            builder.AddCircuitBreaker(new CircuitBreakerStrategyOptions<HttpResponseMessage>
             {
                 FailureRatio = httpConfig.Policies.HttpCircuitBreaker.FailureRatio,
                 SamplingDuration = TimeSpan.FromSeconds(30),
@@ -309,17 +320,9 @@ public static class IServiceCollectionExtensions
                     SegmentsPerWindow = 4,
                     Window = TimeSpan.FromMinutes(1),
                 }));
-
-            // TODO: Register telemetry enrichers when HttpClientCustomMeteringEnricher is ported.
-            // var telemetryOptions = new TelemetryOptions();
-            // telemetryOptions.MeteringEnrichers.Add(new HttpClientCustomMeteringEnricher());
-            // builder.ConfigureTelemetry(telemetryOptions);
         });
 
-        // TODO: AddResilienceEnricher() — requires Microsoft.Extensions.Http.Resilience enricher registration.
-        // services.AddResilienceEnricher();
-
-        return services;
+        return httpClientBuilder;
     }
 
     /// <summary>
@@ -330,7 +333,8 @@ public static class IServiceCollectionExtensions
     /// <returns>The service collection for chaining.</returns>
     /// <remarks>
     /// Configures <c>HttpClientDefaults</c> so every HTTP client created via
-    /// <c>IHttpClientFactory</c> inherits these handlers and the default timeout.
+    /// <c>IHttpClientFactory</c> inherits these handlers, the default timeout, and the harness
+    /// resilience pipeline (see <see cref="AddCustomResilienceHandler"/>).
     /// </remarks>
     public static IServiceCollection AddDefaultHttpClient(this IServiceCollection services)
     {
@@ -352,9 +356,12 @@ public static class IServiceCollectionExtensions
                 httpClientBuilder.AddHttpMessageHandler<CorrelationIdDelegatingHandler>();
                 httpClientBuilder.AddHttpMessageHandler<LoggingDelegatingHandler>();
                 httpClientBuilder.AddHttpMessageHandler<UserAgentDelegatingHandler>();
-            });
 
-        services.AddResiliencePipelines("");
+                // Attach the resilience pipeline to EVERY factory-created client. Registering
+                // the pipeline in the Polly registry alone (the previous approach) leaves it
+                // inert — nothing executes a registry pipeline unless a handler runs it.
+                httpClientBuilder.AddCustomResilienceHandler();
+            });
 
         return services;
     }
@@ -372,9 +379,12 @@ public static class IServiceCollectionExtensions
     /// </param>
     /// <returns>The service collection for chaining.</returns>
     /// <remarks>
-    /// Configures BaseAddress and Timeout from AppConfig, adds standard delegating
-    /// handlers, and applies resilience policies for retry, timeout, circuit breaker,
-    /// and rate limiting.
+    /// Configures BaseAddress and Timeout from AppConfig and adds standard delegating handlers.
+    /// The resilience pipeline (retry, timeout, circuit breaker, rate limiting) is inherited
+    /// from the client defaults registered by <see cref="AddDefaultHttpClient"/> — it is not
+    /// attached here a second time, because duplicate handlers compound retries
+    /// multiplicatively. Hosts must call <see cref="AddDefaultHttpClient"/> (done by
+    /// <c>AddInfrastructureApiAccessDependencies</c>) for typed clients to be resilient.
     /// </remarks>
     public static IServiceCollection AddHttpClient<TClient, TImplementation, TClientOptions>(
         this IServiceCollection services,
@@ -405,8 +415,6 @@ public static class IServiceCollectionExtensions
             .AddHttpMessageHandler<CorrelationIdDelegatingHandler>()
             .AddHttpMessageHandler<LoggingDelegatingHandler>()
             .AddHttpMessageHandler<UserAgentDelegatingHandler>();
-
-        services.AddResiliencePipelines(configurationSectionName);
 
         return services;
     }

--- a/src/Content/Infrastructure/Infrastructure.APIAccess/Common/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Content/Infrastructure/Infrastructure.APIAccess/Common/Extensions/IServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
 using Asp.Versioning;
 using CorrelationId.HttpClient;
 using Domain.Common.Config.Http;
+using Domain.Common.Config.Http.Policies;
 using Domain.Common.Constants;
 using Infrastructure.APIAccess.Handlers;
 using Infrastructure.APIAccess.Services;
@@ -8,6 +9,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Http.Resilience;
 using Microsoft.Extensions.Options;
 using Microsoft.OpenApi;
 using Polly;
@@ -37,13 +39,16 @@ public static class IServiceCollectionExtensions
     ];
 
     /// <summary>
-    /// Exception types related to resilience strategies and eligible for retry.
+    /// Resilience-strategy exception types eligible for retry. Only the per-attempt timeout
+    /// qualifies: it sits INSIDE the retry strategy, so retrying a timed-out attempt is the
+    /// point of having it. <c>BrokenCircuitException</c> and <c>RateLimiterRejectedException</c>
+    /// are deliberately NOT retryable — they are raised by strategies inside this same
+    /// pipeline, so retrying them only burns exponential backoff on self-inflicted rejections;
+    /// callers should fast-fail and let the circuit/limiter recover.
     /// </summary>
     private static readonly ImmutableArray<Type> StrategyExceptions =
     [
         typeof(TimeoutRejectedException),
-        typeof(BrokenCircuitException),
-        typeof(RateLimiterRejectedException),
     ];
 
     /// <summary>
@@ -51,6 +56,36 @@ public static class IServiceCollectionExtensions
     /// </summary>
     private static readonly ImmutableArray<Type> RetryableExceptions =
         NetworkExceptions.Union(StrategyExceptions).ToImmutableArray();
+
+    /// <summary>
+    /// HTTP methods that are idempotent by contract and therefore safe to retry
+    /// automatically. Kept deliberately conservative (GET/HEAD/OPTIONS): although RFC 9110
+    /// also declares PUT and DELETE idempotent, harness consumers routinely front
+    /// non-idempotent handlers with them, so those are excluded too.
+    /// </summary>
+    private static readonly ImmutableArray<HttpMethod> IdempotentHttpMethods =
+    [
+        HttpMethod.Get,
+        HttpMethod.Head,
+        HttpMethod.Options,
+    ];
+
+    /// <summary>
+    /// Decides whether a failed HTTP attempt may be retried automatically: the failure must be
+    /// a declared transient exception type AND the request method must be idempotent
+    /// (GET/HEAD/OPTIONS). Non-idempotent requests (POST, PATCH, ...) are never retried — a
+    /// "transient" network failure can surface AFTER the server processed the request
+    /// (connection dropped on the response path), so retrying would duplicate side effects
+    /// (A2A messages, GitOps syncs, connector mutations, webhooks, label operations).
+    /// </summary>
+    /// <param name="exception">The exception the attempt failed with, if any.</param>
+    /// <param name="requestMethod">The HTTP method of the request being executed, if known.</param>
+    /// <returns><see langword="true"/> when the attempt may be retried.</returns>
+    public static bool IsRetryableHttpFailure(Exception? exception, HttpMethod? requestMethod)
+        => exception is not null
+           && RetryableExceptions.Contains(exception.GetType())
+           && requestMethod is not null
+           && IdempotentHttpMethods.Contains(requestMethod);
 
     /// <summary>
     /// Configures Kestrel server options with production-ready limits.
@@ -257,26 +292,32 @@ public static class IServiceCollectionExtensions
     }
 
     /// <summary>
-    /// Attaches the harness Polly resilience pipeline (retry, timeout, circuit breaker, rate
-    /// limiter) to an HTTP client so every request the client sends executes through it.
-    /// Retries are safe for requests with content — the underlying
-    /// <c>Microsoft.Extensions.Http.Resilience</c> handler snapshots the request message
-    /// before each attempt.
+    /// Attaches the harness Polly resilience pipeline (total timeout, retry, per-attempt
+    /// timeout, circuit breaker, rate limiter) to an HTTP client so every request the client
+    /// sends executes through it. The underlying <c>Microsoft.Extensions.Http.Resilience</c>
+    /// handler snapshots the request message before each attempt, which makes a request
+    /// RE-SENDABLE — it does not make resending SAFE. Retries are therefore restricted to
+    /// idempotent methods (GET/HEAD/OPTIONS); POST and other non-idempotent requests are
+    /// deliberately never retried, because a transient failure can surface after the server
+    /// already processed the request and a retry would duplicate its side effects.
     /// </summary>
     /// <param name="httpClientBuilder">The HTTP client builder to attach the handler to.</param>
     /// <returns>The HTTP client builder for chaining.</returns>
     /// <remarks>
     /// Strategies applied in order (outermost to innermost):
     /// <list type="bullet">
-    ///   <item>Retry - Exponential backoff with jitter for retryable exceptions</item>
-    ///   <item>Timeout - Prevents operations from running too long</item>
+    ///   <item>Total Timeout - Bounds the whole operation across all attempts (see
+    ///   <c>HttpTimeoutPolicyConfig.TotalTimeout</c>; computed from the retry budget when unset)</item>
+    ///   <item>Retry - Exponential backoff with jitter, idempotent methods only</item>
+    ///   <item>Per-Attempt Timeout - Cancels a single slow attempt so the next one can start</item>
     ///   <item>Circuit Breaker - Stops calling failing services after a threshold</item>
     ///   <item>Rate Limiter - Sliding window rate limiting (100 requests/minute)</item>
     /// </list>
     /// All tuning values come from <c>AppConfig:Http:Policies</c> (<see cref="HttpPolicyConfig"/>).
     /// <see cref="AddDefaultHttpClient"/> applies this handler to every client created via
-    /// <c>IHttpClientFactory</c>; do not attach it a second time to individual clients or
-    /// retries will compound multiplicatively.
+    /// <c>IHttpClientFactory</c> and sets <c>HttpClient.Timeout</c> to infinite so the outer
+    /// client timeout cannot race the pipeline and truncate the retry budget; do not attach the
+    /// handler a second time to individual clients or retries will compound multiplicatively.
     /// </remarks>
     public static IHttpClientBuilder AddCustomResilienceHandler(this IHttpClientBuilder httpClientBuilder)
     {
@@ -285,21 +326,30 @@ public static class IServiceCollectionExtensions
             var httpConfig = context.ServiceProvider
                 .GetRequiredService<IOptionsMonitor<HttpConfig>>().CurrentValue;
 
+            // Total timeout (outermost): bounds attempts + backoff. HttpClient.Timeout is
+            // infinite, so this strategy owns the overall budget.
+            builder.AddTimeout(new TimeoutStrategyOptions
+            {
+                Timeout = ResolveTotalTimeout(httpConfig.Policies),
+            });
+
             builder.AddRetry(new RetryStrategyOptions<HttpResponseMessage>
             {
-                // Retry only when the ATTEMPT'S EXCEPTION is a declared retryable type. The
-                // predicate receives Polly's predicate-arguments struct — inspecting the struct
-                // itself (a former bug: RetryableExceptions.Contains(args.GetType())) can never
-                // match, silently disabling all retries.
-                ShouldHandle = args => new ValueTask<bool>(
-                    args.Outcome.Exception is { } exception
-                    && RetryableExceptions.Contains(exception.GetType())),
+                // Retry only when the ATTEMPT'S EXCEPTION is a declared retryable type AND the
+                // request method is idempotent. The predicate receives Polly's
+                // predicate-arguments struct — inspecting the struct itself (a former bug:
+                // RetryableExceptions.Contains(args.GetType())) can never match, silently
+                // disabling all retries.
+                ShouldHandle = args => new ValueTask<bool>(IsRetryableHttpFailure(
+                    args.Outcome.Exception, args.Context.GetRequestMessage()?.Method)),
                 BackoffType = DelayBackoffType.Exponential,
                 UseJitter = true,
                 MaxRetryAttempts = httpConfig.Policies.HttpRetry.Count,
                 Delay = httpConfig.Policies.HttpRetry.Delay,
             });
 
+            // Per-attempt timeout (inside retry): cancels one slow attempt; the retry strategy
+            // decides whether another attempt is allowed.
             builder.AddTimeout(new TimeoutStrategyOptions
             {
                 Timeout = httpConfig.Policies.HttpTimeout.Timeout,
@@ -326,6 +376,26 @@ public static class IServiceCollectionExtensions
     }
 
     /// <summary>
+    /// Resolves the total-operation timeout for the resilience pipeline: the configured
+    /// <c>HttpTimeoutPolicyConfig.TotalTimeout</c> when set, otherwise
+    /// <c>(HttpRetry.Count + 1) × per-attempt timeout</c> plus exponential-backoff headroom
+    /// (<c>Delay × 2^Count</c>), capped at 24 hours (Polly's strategy maximum).
+    /// </summary>
+    private static TimeSpan ResolveTotalTimeout(HttpPolicyConfig policies)
+    {
+        if (policies.HttpTimeout.TotalTimeout is { } configured)
+            return configured;
+
+        var attempts = policies.HttpRetry.Count + 1;
+        var backoffFactor = 1L << Math.Min(policies.HttpRetry.Count, 10);
+        var computed = TimeSpan.FromTicks(policies.HttpTimeout.Timeout.Ticks * attempts)
+            + TimeSpan.FromTicks(policies.HttpRetry.Delay.Ticks * backoffFactor);
+
+        var max = TimeSpan.FromHours(24);
+        return computed < max ? computed : max;
+    }
+
+    /// <summary>
     /// Adds the default HTTP client configuration with standard delegating handlers
     /// for correlation, logging, and User-Agent propagation.
     /// </summary>
@@ -346,8 +416,11 @@ public static class IServiceCollectionExtensions
             {
                 httpClientBuilder.ConfigureHttpClient((serviceProvider, httpClient) =>
                 {
-                    var httpConfig = serviceProvider.GetRequiredService<IOptionsMonitor<HttpConfig>>().CurrentValue;
-                    httpClient.Timeout = httpConfig.Policies.HttpTimeout.Timeout;
+                    // The resilience pipeline owns BOTH the per-attempt timeout and the total
+                    // timeout (see AddCustomResilienceHandler). HttpClient.Timeout must not
+                    // race it: when both are 30s the outer timeout cancels the whole operation
+                    // on the first slow attempt, making timeout-triggered retries dead code.
+                    httpClient.Timeout = System.Threading.Timeout.InfiniteTimeSpan;
                 });
 
                 httpClientBuilder.ConfigurePrimaryHttpMessageHandler(_ => new DefaultHttpClientHandler());

--- a/src/Content/Infrastructure/Infrastructure.APIAccess/README.md
+++ b/src/Content/Infrastructure/Infrastructure.APIAccess/README.md
@@ -72,7 +72,10 @@ Every `HttpClient` created via `IHttpClientFactory` inherits four delegating han
 
 ### Polly Resilience Pipeline
 
-`AddResiliencePipelines()` configures four strategies that protect against downstream failures:
+`AddCustomResilienceHandler()` attaches four strategies to every client created via
+`IHttpClientFactory` (wired once in `AddDefaultHttpClient()` through
+`ConfigureHttpClientDefaults`, so each request actually executes through the pipeline — do
+not attach it a second time per client, or retries compound multiplicatively):
 
 | Strategy | Behavior | Config Source |
 |----------|----------|---------------|

--- a/src/Content/Infrastructure/Infrastructure.APIAccess/README.md
+++ b/src/Content/Infrastructure/Infrastructure.APIAccess/README.md
@@ -72,17 +72,22 @@ Every `HttpClient` created via `IHttpClientFactory` inherits four delegating han
 
 ### Polly Resilience Pipeline
 
-`AddCustomResilienceHandler()` attaches four strategies to every client created via
+`AddCustomResilienceHandler()` attaches five strategies to every client created via
 `IHttpClientFactory` (wired once in `AddDefaultHttpClient()` through
 `ConfigureHttpClientDefaults`, so each request actually executes through the pipeline — do
 not attach it a second time per client, or retries compound multiplicatively):
 
 | Strategy | Behavior | Config Source |
 |----------|----------|---------------|
-| Retry | Exponential backoff + jitter for `SocketException`, `HttpRequestException`, `TimeoutRejectedException`, `BrokenCircuitException`, `RateLimiterRejectedException` | `HttpRetry.Count`, `HttpRetry.Delay` |
-| Timeout | Per-operation timeout | `HttpTimeout.Timeout` |
+| Total Timeout | Bounds the whole operation across all attempts + backoff; `HttpClient.Timeout` is set to infinite so it cannot race the pipeline and truncate the retry budget | `HttpTimeout.TotalTimeout` (computed from the retry budget when unset) |
+| Retry | Exponential backoff + jitter for `SocketException`, `HttpRequestException`, `TimeoutRejectedException` — **idempotent methods only (GET/HEAD/OPTIONS)**. POST/PATCH/PUT/DELETE are never retried: a transient failure can surface after the server already processed the request, so a retry would duplicate side effects. Circuit-breaker and rate-limiter rejections are not retried — they come from strategies inside this same pipeline | `HttpRetry.Count`, `HttpRetry.Delay` |
+| Per-Attempt Timeout | Cancels a single slow attempt so the retry strategy can start the next one | `HttpTimeout.Timeout` |
 | Circuit Breaker | Opens after failure ratio exceeds threshold; 30s sampling window | `HttpCircuitBreaker.FailureRatio`, `.DurationOfBreak` |
 | Rate Limiter | Sliding window: 100 requests/min, 4 segments | Hardcoded |
+
+Note: the `Microsoft.Extensions.Http.Resilience` handler snapshots requests, which makes them
+**re-sendable** — it does not make resending **safe**. Safety comes from the idempotent-method
+restriction above.
 
 ### API Endpoint Resolution
 

--- a/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentFactoryResilienceWiringTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentFactoryResilienceWiringTests.cs
@@ -43,7 +43,8 @@ public sealed class AgentFactoryResilienceWiringTests
     // AgentFactory: consumption of the stashed resilient client
     // ---------------------------------------------------------------------
 
-    private static AgentFactory CreateAgentFactory(FakeChatClient rawClient)
+    private static (AgentFactory Factory, Mock<IChatClientFactory> ChatClientFactory) CreateAgentFactory(
+        FakeChatClient rawClient)
     {
         var chatClientFactory = new Mock<IChatClientFactory>();
         chatClientFactory
@@ -76,7 +77,7 @@ public sealed class AgentFactoryResilienceWiringTests
             NullLoggerFactory.Instance,
             null!, null!, null!, null!, null!, null!);
 
-        return new AgentFactory(
+        var factory = new AgentFactory(
             NullLogger<AgentFactory>.Instance,
             monitor,
             new MemoryDistributedCache(Options.Create(new MemoryDistributedCacheOptions())),
@@ -86,6 +87,8 @@ public sealed class AgentFactoryResilienceWiringTests
             chatClientFactory.Object,
             new ServiceCollection().BuildServiceProvider(),
             new InMemorySkillCompletionTracker());
+
+        return (factory, chatClientFactory);
     }
 
     [Fact]
@@ -95,7 +98,7 @@ public sealed class AgentFactoryResilienceWiringTests
         // stashed resilient client was never consumed — the raw factory client took the call.
         var resilientCanary = new FakeChatClient().WithDefaultResponse("from-resilient-chain");
         var rawClient = new FakeChatClient().WithDefaultResponse("from-raw-client");
-        var factory = CreateAgentFactory(rawClient);
+        var (factory, _) = CreateAgentFactory(rawClient);
 
         var context = new AgentExecutionContext
         {
@@ -124,7 +127,7 @@ public sealed class AgentFactoryResilienceWiringTests
         // Resilience disabled (nothing stashed) => shipped default behavior is unchanged:
         // the per-context raw client from IChatClientFactory carries the turn.
         var rawClient = new FakeChatClient().WithDefaultResponse("from-raw-client");
-        var factory = CreateAgentFactory(rawClient);
+        var (factory, _) = CreateAgentFactory(rawClient);
 
         var context = new AgentExecutionContext
         {
@@ -139,6 +142,78 @@ public sealed class AgentFactoryResilienceWiringTests
 
         rawClient.RequestHistory.Should().NotBeEmpty();
         response.Text.Should().Contain("from-raw-client");
+    }
+
+    [Fact]
+    public async Task CreateAgentAsync_PersistentAgentsContext_IgnoresStashedResilientClient()
+    {
+        // A PersistentAgents context carries a provisioned AgentId in its deployment slot.
+        // The resilient client only knows the generic FallbackChain — substituting it would
+        // silently abandon the provisioned Foundry persistent agent. The stash must be ignored.
+        var resilientCanary = new FakeChatClient().WithDefaultResponse("from-resilient-chain");
+        var rawClient = new FakeChatClient().WithDefaultResponse("from-raw-client");
+        var (factory, chatClientFactory) = CreateAgentFactory(rawClient);
+
+        var context = new AgentExecutionContext
+        {
+            Name = "persistent-agent",
+            Instruction = "You are a test agent.",
+            AIAgentFrameworkType = AIAgentFrameworkClientType.PersistentAgents,
+            AgentId = "agent-123",
+            AdditionalProperties = new Dictionary<string, object>
+            {
+                [ResilientClientKey] = resilientCanary
+            }
+        };
+
+        var agent = await factory.CreateAgentAsync(context);
+        var response = await agent.RunAsync("hello");
+
+        rawClient.RequestHistory.Should().NotBeEmpty(
+            "PersistentAgents contexts must keep their AgentId-bound raw client");
+        resilientCanary.RequestHistory.Should().BeEmpty(
+            "the generic fallback chain must never hijack a provisioned persistent agent");
+        response.Text.Should().Contain("from-raw-client");
+        chatClientFactory.Verify(
+            f => f.GetChatClientAsync(
+                AIAgentFrameworkClientType.PersistentAgents, "agent-123", It.IsAny<CancellationToken>()),
+            Times.Once,
+            "the validated AgentId path must be used");
+    }
+
+    [Fact]
+    public async Task CreateAgentAsync_DeploymentOverrideContext_IgnoresStashedResilientClient()
+    {
+        // A context resolved to a deployment other than the primary configured default (per-skill
+        // ModelOverride, options.DeploymentName, ...) must keep its raw client: the resilient
+        // client can only talk to the FallbackChain, not the overridden deployment.
+        var resilientCanary = new FakeChatClient().WithDefaultResponse("from-resilient-chain");
+        var rawClient = new FakeChatClient().WithDefaultResponse("from-raw-client");
+        var (factory, chatClientFactory) = CreateAgentFactory(rawClient);
+
+        var context = new AgentExecutionContext
+        {
+            Name = "override-agent",
+            Instruction = "You are a test agent.",
+            AIAgentFrameworkType = AIAgentFrameworkClientType.AzureOpenAI,
+            DeploymentName = "custom-model", // differs from configured default "gpt-4o"
+            AdditionalProperties = new Dictionary<string, object>
+            {
+                [ResilientClientKey] = resilientCanary
+            }
+        };
+
+        var agent = await factory.CreateAgentAsync(context);
+        var response = await agent.RunAsync("hello");
+
+        rawClient.RequestHistory.Should().NotBeEmpty(
+            "deployment overrides must win over the generic fallback chain");
+        resilientCanary.RequestHistory.Should().BeEmpty();
+        response.Text.Should().Contain("from-raw-client");
+        chatClientFactory.Verify(
+            f => f.GetChatClientAsync(
+                AIAgentFrameworkClientType.AzureOpenAI, "custom-model", It.IsAny<CancellationToken>()),
+            Times.Once);
     }
 
     // ---------------------------------------------------------------------
@@ -215,5 +290,58 @@ public sealed class AgentFactoryResilienceWiringTests
         context.AdditionalProperties.Should().ContainKey(ResilientClientKey);
         context.AdditionalProperties![ResilientClientKey].Should().BeSameAs(canary,
             "the exact composed resilient client must flow to AgentFactory");
+    }
+
+    [Fact]
+    public async Task MapToAgentContextAsync_PerSkillDeploymentOverride_DoesNotStashResilientClient()
+    {
+        // A per-context deployment override means the caller explicitly chose a model the
+        // FallbackChain knows nothing about. The stash must be skipped (and the chain not
+        // composed) so the override keeps winning.
+        var provider = new Mock<IResilientChatClientProvider>(MockBehavior.Strict);
+        var factory = CreateContextFactory(resilienceEnabled: true, provider.Object);
+        var options = new SkillAgentOptions { DeploymentName = "custom-model" };
+
+        var context = await factory.MapToAgentContextAsync(SimpleSkill(), options);
+
+        context.DeploymentName.Should().Be("custom-model");
+        context.AdditionalProperties.Should().NotContainKey(ResilientClientKey,
+            "a deployment override differing from the configured default disqualifies the fallback chain");
+        provider.Verify(
+            p => p.GetResilientChatClientAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task MapToAgentContextAsync_FrameworkTypeOverride_DoesNotStashResilientClient()
+    {
+        // A framework override to a different provider than the primary configured ClientType
+        // must not be silently replaced by the fallback chain.
+        var provider = new Mock<IResilientChatClientProvider>(MockBehavior.Strict);
+        var factory = CreateContextFactory(resilienceEnabled: true, provider.Object);
+        var options = new SkillAgentOptions { FrameworkType = AIAgentFrameworkClientType.OpenAI };
+
+        var context = await factory.MapToAgentContextAsync(SimpleSkill(), options);
+
+        context.AIAgentFrameworkType.Should().Be(AIAgentFrameworkClientType.OpenAI);
+        context.AdditionalProperties.Should().NotContainKey(ResilientClientKey,
+            "a framework override differing from the primary configured provider disqualifies the fallback chain");
+        provider.Verify(
+            p => p.GetResilientChatClientAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task MapToAgentContextAsync_FoundryResponsesFramework_DoesNotStashResilientClient()
+    {
+        // FoundryResponses agents never flow through the chat-client path, so a stash would be
+        // a dead entry at best and misleading at worst.
+        var provider = new Mock<IResilientChatClientProvider>(MockBehavior.Strict);
+        var factory = CreateContextFactory(resilienceEnabled: true, provider.Object);
+        var options = new SkillAgentOptions { FrameworkType = AIAgentFrameworkClientType.FoundryResponses };
+
+        var context = await factory.MapToAgentContextAsync(SimpleSkill(), options);
+
+        context.AdditionalProperties.Should().NotContainKey(ResilientClientKey);
+        provider.Verify(
+            p => p.GetResilientChatClientAsync(It.IsAny<CancellationToken>()), Times.Never);
     }
 }

--- a/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentFactoryResilienceWiringTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentFactoryResilienceWiringTests.cs
@@ -1,0 +1,219 @@
+using Application.AI.Common.Factories;
+using Application.AI.Common.Interfaces;
+using Application.AI.Common.Interfaces.Resilience;
+using Application.AI.Common.Interfaces.Skills;
+using Application.AI.Common.Services.Skills;
+using Application.AI.Common.Services.Tools;
+using Application.AI.Common.Tests.Fakes;
+using Domain.AI.Agents;
+using Domain.AI.Skills;
+using Domain.Common.Config;
+using Domain.Common.Config.AI;
+using Domain.Common.Config.AI.Resilience;
+using FluentAssertions;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Application.AI.Common.Tests.Factories;
+
+/// <summary>
+/// Proves the resilience subsystem is wired to the live agent path (audit item F3).
+/// Pre-fix, <see cref="AgentExecutionContextFactory"/> stashed the composed resilient chat
+/// client into <c>AdditionalProperties["__resilientChatClient"]</c> but nothing ever read it —
+/// <see cref="AgentFactory"/> always built agents on the raw <see cref="IChatClientFactory"/>
+/// client, so the Polly retry/circuit-breaker/fallback pipelines never executed on any turn.
+/// These tests use a canary <see cref="FakeChatClient"/> as the "resilient" client and assert
+/// that live turns actually route through it when resilience is enabled, and that the raw
+/// per-context client is used (byte-identical legacy behavior) when resilience is disabled.
+/// </summary>
+public sealed class AgentFactoryResilienceWiringTests
+{
+    /// <summary>
+    /// Key AgentExecutionContextFactory uses to stash the resilient client. Bound to the
+    /// production constant so the producer/consumer contract cannot silently drift.
+    /// </summary>
+    private const string ResilientClientKey = IResilientChatClientProvider.AdditionalPropertiesKey;
+
+    // ---------------------------------------------------------------------
+    // AgentFactory: consumption of the stashed resilient client
+    // ---------------------------------------------------------------------
+
+    private static AgentFactory CreateAgentFactory(FakeChatClient rawClient)
+    {
+        var chatClientFactory = new Mock<IChatClientFactory>();
+        chatClientFactory
+            .Setup(f => f.IsAvailable(It.IsAny<AIAgentFrameworkClientType>()))
+            .Returns(true);
+        chatClientFactory
+            .Setup(f => f.GetChatClientAsync(
+                It.IsAny<AIAgentFrameworkClientType>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(rawClient);
+
+        var appConfig = new AppConfig
+        {
+            AI = new AIConfig
+            {
+                AgentFramework = new AgentFrameworkConfig
+                {
+                    DefaultDeployment = "gpt-4o",
+                    ClientType = AIAgentFrameworkClientType.AzureOpenAI
+                }
+            }
+        };
+        var monitor = Mock.Of<IOptionsMonitor<AppConfig>>(m => m.CurrentValue == appConfig);
+
+        var contextFactory = new Mock<AgentExecutionContextFactory>(
+            NullLogger<AgentExecutionContextFactory>.Instance,
+            monitor,
+            new ServiceCollection().BuildServiceProvider(),
+            NullLoggerFactory.Instance,
+            null!, null!, null!, null!, null!, null!);
+
+        return new AgentFactory(
+            NullLogger<AgentFactory>.Instance,
+            monitor,
+            new MemoryDistributedCache(Options.Create(new MemoryDistributedCacheOptions())),
+            NullLoggerFactory.Instance,
+            contextFactory.Object,
+            Mock.Of<ISkillMetadataRegistry>(),
+            chatClientFactory.Object,
+            new ServiceCollection().BuildServiceProvider(),
+            new InMemorySkillCompletionTracker());
+    }
+
+    [Fact]
+    public async Task CreateAgentAsync_ResilientClientInContext_TurnsRouteThroughResilientClient()
+    {
+        // The canary records every request it receives. Pre-fix it records ZERO because the
+        // stashed resilient client was never consumed — the raw factory client took the call.
+        var resilientCanary = new FakeChatClient().WithDefaultResponse("from-resilient-chain");
+        var rawClient = new FakeChatClient().WithDefaultResponse("from-raw-client");
+        var factory = CreateAgentFactory(rawClient);
+
+        var context = new AgentExecutionContext
+        {
+            Name = "resilience-canary-agent",
+            Instruction = "You are a test agent.",
+            AIAgentFrameworkType = AIAgentFrameworkClientType.AzureOpenAI,
+            AdditionalProperties = new Dictionary<string, object>
+            {
+                [ResilientClientKey] = resilientCanary
+            }
+        };
+
+        var agent = await factory.CreateAgentAsync(context);
+        var response = await agent.RunAsync("hello");
+
+        resilientCanary.RequestHistory.Should().NotBeEmpty(
+            "when resilience is enabled the composed fallback-chain client must carry live turns");
+        rawClient.RequestHistory.Should().BeEmpty(
+            "the raw per-provider client must not bypass the resilience pipelines");
+        response.Text.Should().Contain("from-resilient-chain");
+    }
+
+    [Fact]
+    public async Task CreateAgentAsync_NoResilientClientInContext_TurnsRouteThroughFactoryClient()
+    {
+        // Resilience disabled (nothing stashed) => shipped default behavior is unchanged:
+        // the per-context raw client from IChatClientFactory carries the turn.
+        var rawClient = new FakeChatClient().WithDefaultResponse("from-raw-client");
+        var factory = CreateAgentFactory(rawClient);
+
+        var context = new AgentExecutionContext
+        {
+            Name = "plain-agent",
+            Instruction = "You are a test agent.",
+            AIAgentFrameworkType = AIAgentFrameworkClientType.AzureOpenAI,
+            AdditionalProperties = new Dictionary<string, object>()
+        };
+
+        var agent = await factory.CreateAgentAsync(context);
+        var response = await agent.RunAsync("hello");
+
+        rawClient.RequestHistory.Should().NotBeEmpty();
+        response.Text.Should().Contain("from-raw-client");
+    }
+
+    // ---------------------------------------------------------------------
+    // AgentExecutionContextFactory: config-gated stash
+    // ---------------------------------------------------------------------
+
+    private static AgentExecutionContextFactory CreateContextFactory(
+        bool resilienceEnabled,
+        IResilientChatClientProvider resilientProvider)
+    {
+        var appConfig = new AppConfig
+        {
+            AI = new AIConfig
+            {
+                AgentFramework = new AgentFrameworkConfig
+                {
+                    ClientType = AIAgentFrameworkClientType.AzureOpenAI,
+                    DefaultDeployment = "gpt-4o"
+                },
+                Resilience = new ResilienceConfig { Enabled = resilienceEnabled }
+            }
+        };
+        var monitor = Mock.Of<IOptionsMonitor<AppConfig>>(m => m.CurrentValue == appConfig);
+        var services = new ServiceCollection().BuildServiceProvider();
+
+        return new AgentExecutionContextFactory(
+            NullLogger<AgentExecutionContextFactory>.Instance,
+            monitor,
+            services,
+            NullLoggerFactory.Instance,
+            new ToolChainBuilder(NullLogger<ToolChainBuilder>.Instance, services),
+            new SkillPrerequisiteResolver(),
+            resilientChatClientProvider: resilientProvider);
+    }
+
+    private static SkillDefinition SimpleSkill() => new()
+    {
+        Id = "test-skill",
+        Name = "test-skill",
+        Instructions = "You are a test agent."
+    };
+
+    [Fact]
+    public async Task MapToAgentContextAsync_ResilienceDisabled_DoesNotStashResilientClient()
+    {
+        // When ResilienceConfig.Enabled=false the provider would return the PRIMARY raw client
+        // (AppConfig.AI.AgentFramework), which must not override per-skill deployment/framework
+        // overrides on the context. The stash must therefore be config-gated.
+        var provider = new Mock<IResilientChatClientProvider>(MockBehavior.Strict);
+        var factory = CreateContextFactory(resilienceEnabled: false, provider.Object);
+
+        var context = await factory.MapToAgentContextAsync(SimpleSkill(), new SkillAgentOptions());
+
+        context.AdditionalProperties.Should().NotContainKey(ResilientClientKey,
+            "resilience is disabled, so the raw per-context client path must remain untouched");
+        provider.Verify(
+            p => p.GetResilientChatClientAsync(It.IsAny<CancellationToken>()),
+            Times.Never,
+            "the fallback chain must not even be composed when resilience is off");
+    }
+
+    [Fact]
+    public async Task MapToAgentContextAsync_ResilienceEnabled_StashesResilientClient()
+    {
+        var canary = new FakeChatClient();
+        var provider = new Mock<IResilientChatClientProvider>();
+        provider
+            .Setup(p => p.GetResilientChatClientAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(canary);
+        var factory = CreateContextFactory(resilienceEnabled: true, provider.Object);
+
+        var context = await factory.MapToAgentContextAsync(SimpleSkill(), new SkillAgentOptions());
+
+        context.AdditionalProperties.Should().ContainKey(ResilientClientKey);
+        context.AdditionalProperties![ResilientClientKey].Should().BeSameAs(canary,
+            "the exact composed resilient client must flow to AgentFactory");
+    }
+}

--- a/src/Content/Tests/Infrastructure.APIAccess.Tests/Common/Extensions/HttpResilienceWiringTests.cs
+++ b/src/Content/Tests/Infrastructure.APIAccess.Tests/Common/Extensions/HttpResilienceWiringTests.cs
@@ -1,0 +1,103 @@
+using CorrelationId.DependencyInjection;
+using Domain.Common.Config.Http;
+using FluentAssertions;
+using Infrastructure.APIAccess.Common.Extensions;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Infrastructure.APIAccess.Tests.Common.Extensions;
+
+/// <summary>
+/// Proves the HTTP resilience pipelines actually execute on the live <see cref="HttpClient"/>
+/// path (audit item F3). Pre-fix, <c>AddResiliencePipelines</c> registered named pipelines in
+/// the Polly registry that no client ever executed, and the retry <c>ShouldHandle</c> predicate
+/// inspected the Polly ARGUMENTS struct type instead of the thrown EXCEPTION type
+/// (<c>RetryableExceptions.Contains(args.GetType())</c> is always false), so retries could never
+/// fire even if the pipeline had been attached. These tests drive a real
+/// <see cref="IHttpClientFactory"/> client whose primary handler counts attempts.
+/// </summary>
+public sealed class HttpResilienceWiringTests
+{
+    /// <summary>
+    /// Terminal handler that records every send attempt and always throws the configured
+    /// exception, simulating a persistently failing downstream service.
+    /// </summary>
+    private sealed class CountingFailingHandler : HttpMessageHandler
+    {
+        private int _attempts;
+
+        /// <summary>Total number of HTTP send attempts observed.</summary>
+        public int Attempts => _attempts;
+
+        /// <summary>Exception thrown on every attempt.</summary>
+        public Func<Exception> ExceptionFactory { get; init; } =
+            () => new HttpRequestException("simulated transient network failure");
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Interlocked.Increment(ref _attempts);
+            throw ExceptionFactory();
+        }
+    }
+
+    private static ServiceProvider BuildProvider(CountingFailingHandler primaryHandler)
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddDefaultCorrelationId(options => options.AddToLoggingScope = true);
+        services.Configure<HttpConfig>(config =>
+        {
+            // 2 retries, near-zero delay so the test completes quickly.
+            config.Policies.HttpRetry.Count = 2;
+            config.Policies.HttpRetry.Delay = TimeSpan.FromMilliseconds(1);
+        });
+
+        // The production wiring under test: defaults applied to every factory-created client.
+        services.AddDefaultHttpClient();
+
+        // A canary client whose primary handler counts attempts instead of hitting the network.
+        services.AddHttpClient("resilience-canary")
+            .ConfigurePrimaryHttpMessageHandler(() => primaryHandler);
+
+        return services.BuildServiceProvider();
+    }
+
+    [Fact]
+    public async Task HttpClient_TransientNetworkFailure_RetriesThroughAttachedPipeline()
+    {
+        // 1 initial attempt + HttpRetry.Count retries. Pre-fix this observes exactly 1 attempt:
+        // the registry pipeline was never attached to any client AND the ShouldHandle predicate
+        // could never match the exception.
+        var handler = new CountingFailingHandler();
+        await using var provider = BuildProvider(handler);
+        var client = provider.GetRequiredService<IHttpClientFactory>().CreateClient("resilience-canary");
+
+        var act = () => client.GetAsync("http://localhost/canary");
+
+        await act.Should().ThrowAsync<HttpRequestException>(
+            "the failure is persistent, so retries must eventually surface the original exception");
+        handler.Attempts.Should().Be(3,
+            "a transient HttpRequestException must be retried HttpRetry.Count (2) times " +
+            "after the initial attempt by the attached resilience pipeline");
+    }
+
+    [Fact]
+    public async Task HttpClient_NonRetryableFailure_DoesNotRetry()
+    {
+        // The predicate must stay selective: only the declared retryable exception types
+        // (network + resilience-strategy exceptions) are retried.
+        var handler = new CountingFailingHandler
+        {
+            ExceptionFactory = () => new InvalidOperationException("non-transient bug")
+        };
+        await using var provider = BuildProvider(handler);
+        var client = provider.GetRequiredService<IHttpClientFactory>().CreateClient("resilience-canary");
+
+        var act = () => client.GetAsync("http://localhost/canary");
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+        handler.Attempts.Should().Be(1,
+            "non-retryable exceptions must not trigger retries");
+    }
+}

--- a/src/Content/Tests/Infrastructure.APIAccess.Tests/Common/Extensions/HttpResilienceWiringTests.cs
+++ b/src/Content/Tests/Infrastructure.APIAccess.Tests/Common/Extensions/HttpResilienceWiringTests.cs
@@ -2,6 +2,7 @@ using CorrelationId.DependencyInjection;
 using Domain.Common.Config.Http;
 using FluentAssertions;
 using Infrastructure.APIAccess.Common.Extensions;
+using ApiAccessExtensions = Infrastructure.APIAccess.Common.Extensions.IServiceCollectionExtensions;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
@@ -83,6 +84,39 @@ public sealed class HttpResilienceWiringTests
     }
 
     [Fact]
+    public async Task HttpClient_TransientFailureOnPost_DoesNotRetry()
+    {
+        // POST is not idempotent: a "transient" HttpRequestException can surface AFTER the
+        // server processed the request (connection dropped on the response path). Retrying
+        // would duplicate side effects (A2A messages, GitOps syncs, connector mutations,
+        // webhooks). Only idempotent methods (GET/HEAD/OPTIONS) may be retried.
+        var handler = new CountingFailingHandler();
+        await using var provider = BuildProvider(handler);
+        var client = provider.GetRequiredService<IHttpClientFactory>().CreateClient("resilience-canary");
+
+        var act = () => client.PostAsync("http://localhost/canary", new StringContent("payload"));
+
+        await act.Should().ThrowAsync<HttpRequestException>();
+        handler.Attempts.Should().Be(1,
+            "non-idempotent requests must never be retried, even on transient network failures");
+    }
+
+    [Fact]
+    public void HttpClient_OuterTimeout_IsInfinite_SoPipelineOwnsTimeouts()
+    {
+        // If HttpClient.Timeout equals the pipeline's per-attempt timeout, timeout-triggered
+        // retries are dead code (the outer timeout cancels the whole operation first). The
+        // pipeline owns both the per-attempt and the total timeout; the client must not race it.
+        var handler = new CountingFailingHandler();
+        using var provider = BuildProvider(handler);
+
+        var client = provider.GetRequiredService<IHttpClientFactory>().CreateClient("resilience-canary");
+
+        client.Timeout.Should().Be(System.Threading.Timeout.InfiniteTimeSpan,
+            "the resilience pipeline's total-timeout strategy bounds the request, not HttpClient.Timeout");
+    }
+
+    [Fact]
     public async Task HttpClient_NonRetryableFailure_DoesNotRetry()
     {
         // The predicate must stay selective: only the declared retryable exception types
@@ -99,5 +133,64 @@ public sealed class HttpResilienceWiringTests
         await act.Should().ThrowAsync<InvalidOperationException>();
         handler.Attempts.Should().Be(1,
             "non-retryable exceptions must not trigger retries");
+    }
+
+    // ---------------------------------------------------------------------
+    // Retry predicate unit tests (IsRetryableHttpFailure drives ShouldHandle)
+    // ---------------------------------------------------------------------
+
+    [Fact]
+    public void IsRetryableHttpFailure_RateLimiterRejection_IsNotRetried()
+    {
+        // The rate limiter sits INSIDE this same pipeline: retrying its rejection only burns
+        // exponential backoff on a self-inflicted rejection. Callers must fast-fail.
+        ApiAccessExtensions
+            .IsRetryableHttpFailure(new Polly.RateLimiting.RateLimiterRejectedException(), HttpMethod.Get)
+            .Should().BeFalse("rate-limiter rejections are self-inflicted and must not be retried");
+    }
+
+    [Fact]
+    public void IsRetryableHttpFailure_BrokenCircuit_IsNotRetried()
+    {
+        ApiAccessExtensions
+            .IsRetryableHttpFailure(new Polly.CircuitBreaker.BrokenCircuitException(), HttpMethod.Get)
+            .Should().BeFalse("an open circuit means the downstream is known-bad; retrying inside the same pipeline is pointless");
+    }
+
+    [Theory]
+    [InlineData("GET")]
+    [InlineData("HEAD")]
+    [InlineData("OPTIONS")]
+    public void IsRetryableHttpFailure_TransientExceptionOnIdempotentMethod_IsRetried(string method)
+    {
+        ApiAccessExtensions
+            .IsRetryableHttpFailure(new HttpRequestException("transient"), new HttpMethod(method))
+            .Should().BeTrue();
+        ApiAccessExtensions
+            .IsRetryableHttpFailure(new Polly.Timeout.TimeoutRejectedException(), new HttpMethod(method))
+            .Should().BeTrue("the per-attempt timeout sits inside the retry strategy — retrying a timed-out attempt is its purpose");
+    }
+
+    [Theory]
+    [InlineData("POST")]
+    [InlineData("PATCH")]
+    [InlineData("PUT")]
+    [InlineData("DELETE")]
+    public void IsRetryableHttpFailure_TransientExceptionOnNonIdempotentMethod_IsNotRetried(string method)
+    {
+        ApiAccessExtensions
+            .IsRetryableHttpFailure(new HttpRequestException("transient"), new HttpMethod(method))
+            .Should().BeFalse("a transient failure can surface after the server processed the request; retrying duplicates side effects");
+    }
+
+    [Fact]
+    public void IsRetryableHttpFailure_UnknownMethodOrNoException_IsNotRetried()
+    {
+        ApiAccessExtensions
+            .IsRetryableHttpFailure(new HttpRequestException("transient"), requestMethod: null)
+            .Should().BeFalse("without a known request method, retrying cannot be proven safe");
+        ApiAccessExtensions
+            .IsRetryableHttpFailure(exception: null, HttpMethod.Get)
+            .Should().BeFalse();
     }
 }


### PR DESCRIPTION
## Summary
Wave-2 audit item **F3** (Gate-3 decision: WIRE, don't delete), reproduce-test-first, plus adversarial-review fixes (verdict was MERGE AFTER FIXES; all blockers fixed and re-proven).

The Resilience subsystem (Polly circuit breakers, provider fallback chains, health tracking) existed and was unit-tested but was **inert on the live path** — the audit's signature pattern, found here in two forms:

### 1. LLM seam — the resilient client was built and thrown away
`AgentExecutionContextFactory` composed a `ResilientChatClient` and stashed it into `AdditionalProperties["__resilientChatClient"]` with **zero readers** — `AgentFactory` used the raw `IChatClientFactory` client for every live turn. Now `AgentFactory` consumes the stash as the innermost client of the middleware pipeline, so live turns run through the fallback chain + Polly retry/circuit-breaker/timeout and feed `PollyProviderHealthMonitor`.
- **Config-gated**: shipped default `ResilienceConfig.Enabled=false` → byte-identical legacy behavior (verified by review).
- **Review fix (HIGH-1)**: substitution is now gated by a shared `ResilientClientEligibility` rule — it only applies when the context's framework is the primary `ClientType`, is a ChatClient-style framework (never PersistentAgents/FoundryResponses/Echo), and carries no deployment/framework override. Prevents enabling resilience from silently hijacking a provisioned persistent agent's `AgentId` or a per-skill deployment override. Consume side re-checks (defense-in-depth for the copied-properties path).

### 2. HTTP seam — pipeline never attached + retry predicate never matched
The named-registry pipelines were never executed by any client, and the retry `ShouldHandle` predicate tested Polly's `RetryPredicateArguments` **struct type** instead of the exception — so retries never fired even once. Now a single resilience handler is attached via `ConfigureHttpClientDefaults` (no double-attach on typed clients), and the predicate inspects `args.Outcome.Exception`.
- **Review fix (HIGH-2)**: retries are restricted to **idempotent methods (GET/HEAD/OPTIONS)** so transient-exception retries can't double-execute non-idempotent mutations (A2A messages, GitOps sync/rollback, connector creates, webhooks, Purview labels). XML docs corrected — a snapshotted body is re-sendable, not safe-to-resend.
- **Review fix (MEDIUM-1)**: `HttpClient.Timeout = InfiniteTimeSpan`; the pipeline owns both a per-attempt timeout and a new total timeout (`HttpTimeout.TotalTimeout`, computed default, keys backward compatible) — previously the outer timeout equalled the per-attempt timeout, making timeout-triggered retries dead code.
- **Review fix (MEDIUM-2)**: `BrokenCircuitException`/`RateLimiterRejectedException` removed from the retryable set — they're raised by strategies inside the same pipeline, so retrying them just burned backoff on self-inflicted rejections.

## Reproduce-first proof
7 tests red pre-fix, green post-fix: canary resilient client records 0 requests pre-fix (raw client took the turn) → routes through post-fix; disabled config no longer composes/stashes; HTTP POST transient failure = 1 attempt (no retry), GET = 3 attempts; PersistentAgents/override contexts keep their own client; predicate matrix (GET/HEAD/OPTIONS retry, POST/PATCH/PUT/DELETE + self-inflicted rejections don't); infinite outer timeout.

## Test plan
- [x] Infrastructure.APIAccess.Tests 147/147, Application.AI.Common.Tests 1316/1316, Application.Core.Tests 638/638, Presentation.Common.Tests 113/113, Domain.Common.Tests 705/705, Infrastructure.AI.Tests (Resilience+DI) 87/87
- [x] gitnexus: `CreateAgentAsync` CRITICAL radius — mitigated (additive, signature-preserving, gated off by default; all 4 affected processes exercised green)

## Coverage boundary (documented honestly)
Resilient routing covers **skill-built ChatClient agents only** — manual-context callers (evaluation harnesses, `AgentDefinitions`) and FoundryResponses do not route through it.

## Follow-ups (tracked, not here)
- `LlmRetryQueue.EnqueueAsync` has zero callers; `ProviderCapabilityRegistry` registered but never injected (both Wave-3 Gate-4 dormant-subsystem wire-ups)
- Shared-singleton `ResilientChatClient` dispose blast (LOW); HTTP 5xx/429 response-code retries deliberately absent (documented); mid-stream failover duplicate-delta is a pre-existing `ResilientChatClient` property

🤖 Generated with [Claude Code](https://claude.com/claude-code)