### PR TITLE
feat: run memory decay on a scheduled background service (Wave-3 dormant wiring)

### DIFF
--- a/src/Content/Domain/Domain.Common/Config/AI/RAG/CrossSessionMemoryConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/RAG/CrossSessionMemoryConfig.cs
@@ -22,4 +22,10 @@ public sealed class CrossSessionMemoryConfig
 
     /// <summary>Interval between background syncs to graph backend. Default: 5 minutes.</summary>
     public TimeSpan SyncInterval { get; set; } = TimeSpan.FromMinutes(5);
+
+    /// <summary>
+    /// Background decay scheduler settings. Disabled by default (opt-in) — when enabled a
+    /// hosted service periodically applies decay and prunes low-weight memories.
+    /// </summary>
+    public MemoryDecaySchedulerConfig DecayScheduler { get; set; } = new();
 }

--- a/src/Content/Domain/Domain.Common/Config/AI/RAG/MemoryDecaySchedulerConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/RAG/MemoryDecaySchedulerConfig.cs
@@ -1,0 +1,18 @@
+namespace Domain.Common.Config.AI.RAG;
+
+/// <summary>
+/// Configuration for the background scheduler that periodically applies memory decay and
+/// prunes low-weight cross-session memories.
+/// Bound from <c>AppConfig:AI:Rag:CrossSessionMemory:DecayScheduler</c>.
+/// </summary>
+public sealed class MemoryDecaySchedulerConfig
+{
+    /// <summary>
+    /// Whether the background decay scheduler runs. Disabled by default so cloning the
+    /// template does not silently start mutating stored memory weights — opt in explicitly.
+    /// </summary>
+    public bool Enabled { get; set; }
+
+    /// <summary>Interval between decay+prune passes. Default: 6 hours.</summary>
+    public TimeSpan Interval { get; set; } = TimeSpan.FromHours(6);
+}

--- a/src/Content/Infrastructure/Infrastructure.AI.RAG/DependencyInjection.GraphRag.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.RAG/DependencyInjection.GraphRag.cs
@@ -66,6 +66,12 @@ public static partial class DependencyInjection
                 sp.GetRequiredService<ICrossSessionMemoryStore>(),
                 sp.GetRequiredService<IOptionsMonitor<AppConfig>>(),
                 sp.GetRequiredService<ILogger<MemoryDecayService>>()));
+
+        // Background scheduler that actually runs decay+prune over time. Opt-in: without it the
+        // decay service is inert (only ever invoked by tests). Resolves the decay service from a
+        // fresh scope per tick so it stays valid under ValidateScopes=true.
+        if (memoryConfig.DecayScheduler.Enabled)
+            services.AddHostedService<GraphRag.MemoryDecayScheduler>();
     }
 
     /// <summary>

--- a/src/Content/Infrastructure/Infrastructure.AI.RAG/GraphRag/MemoryDecayScheduler.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.RAG/GraphRag/MemoryDecayScheduler.cs
@@ -1,0 +1,122 @@
+using Application.AI.Common.Interfaces.KnowledgeGraph;
+using Domain.Common.Config;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Infrastructure.AI.RAG.GraphRag;
+
+/// <summary>
+/// Background service that periodically drives <see cref="IMemoryDecayService"/>, applying
+/// time-based decay to cross-session memory weights and pruning memories that fall below the
+/// configured threshold.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Without this scheduler the decay service is inert: <see cref="IMemoryDecayService.ApplyDecayAsync"/>
+/// only runs when something calls it, so in a live host stored weights never age and low-value
+/// memories accumulate indefinitely. This hosted service is what makes the decay tier system
+/// actually run over time.
+/// </para>
+/// <para>
+/// <strong>Opt-in.</strong> Registered only when
+/// <see cref="Domain.Common.Config.AI.RAG.MemoryDecaySchedulerConfig.Enabled"/> is <c>true</c>.
+/// A fresh clone leaves it disabled so cloning the template does not silently start mutating
+/// stored memory weights.
+/// </para>
+/// <para>
+/// <strong>Scope per tick.</strong> The host runs with <c>ValidateScopes=true</c>, so this
+/// singleton hosted service must not capture scoped dependencies. Each tick creates a fresh
+/// <see cref="IServiceScope"/> and resolves <see cref="IMemoryDecayService"/> from it, keeping
+/// the wiring correct even if a consumer re-lifetimes the decay service (or its graph backend)
+/// to a scoped registration.
+/// </para>
+/// <para>
+/// <strong>Cadence.</strong> The interval comes from configuration (never hardcoded). Each pass
+/// runs <see cref="IMemoryDecayService.ApplyDecayAsync"/> followed by
+/// <see cref="IMemoryDecayService.PruneAsync"/> using the configured prune threshold, completing
+/// the decay-then-prune cycle.
+/// </para>
+/// <para>
+/// <strong>Failure isolation.</strong> Exceptions from a pass are logged and swallowed so one bad
+/// tick never tears down the host or stops future passes.
+/// </para>
+/// </remarks>
+public sealed class MemoryDecayScheduler : BackgroundService
+{
+    private static readonly TimeSpan _fallbackInterval = TimeSpan.FromHours(6);
+
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly IOptionsMonitor<AppConfig> _config;
+    private readonly ILogger<MemoryDecayScheduler> _logger;
+
+    /// <summary>Initializes a new <see cref="MemoryDecayScheduler"/>.</summary>
+    /// <param name="scopeFactory">Factory used to create a fresh DI scope per tick.</param>
+    /// <param name="config">Live configuration providing cadence and prune threshold.</param>
+    /// <param name="logger">Logger for pass-level operational metrics.</param>
+    public MemoryDecayScheduler(
+        IServiceScopeFactory scopeFactory,
+        IOptionsMonitor<AppConfig> config,
+        ILogger<MemoryDecayScheduler> logger)
+    {
+        ArgumentNullException.ThrowIfNull(scopeFactory);
+        ArgumentNullException.ThrowIfNull(config);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _scopeFactory = scopeFactory;
+        _config = config;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        var interval = ResolveInterval();
+        using var timer = new PeriodicTimer(interval);
+
+        _logger.LogInformation(
+            "MemoryDecayScheduler started; running a decay+prune pass every {Interval}.", interval);
+
+        try
+        {
+            while (await timer.WaitForNextTickAsync(stoppingToken).ConfigureAwait(false))
+            {
+                await RunPassAsync(stoppingToken).ConfigureAwait(false);
+            }
+        }
+        catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+        {
+            // Expected during host shutdown.
+        }
+    }
+
+    private async Task RunPassAsync(CancellationToken stoppingToken)
+    {
+        var pruneThreshold = _config.CurrentValue.AI.Rag.CrossSessionMemory.PruneThreshold;
+
+        try
+        {
+            await using var scope = _scopeFactory.CreateAsyncScope();
+            var decayService = scope.ServiceProvider.GetRequiredService<IMemoryDecayService>();
+
+            await decayService.ApplyDecayAsync(stoppingToken).ConfigureAwait(false);
+            await decayService.PruneAsync(pruneThreshold, stoppingToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+        {
+            // Host shutdown — propagate by exiting the loop.
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "MemoryDecayScheduler pass failed; the next scheduled pass will retry.");
+        }
+    }
+
+    private TimeSpan ResolveInterval()
+    {
+        var configured = _config.CurrentValue.AI.Rag.CrossSessionMemory.DecayScheduler.Interval;
+        return configured > TimeSpan.Zero ? configured : _fallbackInterval;
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.RAG.Tests/GraphRag/MemoryDecaySchedulerTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.RAG.Tests/GraphRag/MemoryDecaySchedulerTests.cs
@@ -1,0 +1,90 @@
+using Application.AI.Common.Interfaces.KnowledgeGraph;
+using Domain.Common.Config;
+using Domain.Common.Config.AI;
+using Domain.Common.Config.AI.RAG;
+using Infrastructure.AI.RAG.GraphRag;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Infrastructure.AI.RAG.Tests.GraphRag;
+
+/// <summary>
+/// Tests for <see cref="MemoryDecayScheduler"/> proving the hosted service actually drives
+/// <see cref="IMemoryDecayService"/> on its live tick path — not just in unit-level calls.
+/// </summary>
+public sealed class MemoryDecaySchedulerTests
+{
+    [Fact]
+    public async Task Scheduler_OnTick_InvokesApplyDecayAndPruneFromScope()
+    {
+        // Arrange — spy decay service that signals the first time ApplyDecayAsync fires.
+        var decayFired = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var applyCount = 0;
+        var spy = new Mock<IMemoryDecayService>();
+        spy.Setup(s => s.ApplyDecayAsync(It.IsAny<CancellationToken>()))
+            .Returns(() =>
+            {
+                Interlocked.Increment(ref applyCount);
+                decayFired.TrySetResult();
+                return Task.CompletedTask;
+            });
+        spy.Setup(s => s.PruneAsync(It.IsAny<double>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var config = BuildConfig(enabled: true, interval: TimeSpan.FromMilliseconds(20), pruneThreshold: 0.05);
+        var scopeFactory = BuildScopeFactory(spy.Object);
+
+        var scheduler = new MemoryDecayScheduler(
+            scopeFactory,
+            config,
+            NullLogger<MemoryDecayScheduler>.Instance);
+
+        // Act — start the hosted service and wait for the first tick to drive decay.
+        await scheduler.StartAsync(CancellationToken.None);
+        var completed = await Task.WhenAny(decayFired.Task, Task.Delay(TimeSpan.FromSeconds(5)));
+        await scheduler.StopAsync(CancellationToken.None);
+
+        // Assert — decay ran on the scheduler's live path, resolved from a fresh scope.
+        Assert.Same(decayFired.Task, completed);
+        Assert.True(applyCount >= 1, "Expected ApplyDecayAsync to be invoked at least once by the scheduler tick.");
+        spy.Verify(s => s.PruneAsync(0.05, It.IsAny<CancellationToken>()), Times.AtLeastOnce);
+    }
+
+    private static IServiceScopeFactory BuildScopeFactory(IMemoryDecayService decayService)
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton(decayService);
+
+        var provider = services.BuildServiceProvider(new ServiceProviderOptions { ValidateScopes = true });
+        return provider.GetRequiredService<IServiceScopeFactory>();
+    }
+
+    private static IOptionsMonitor<AppConfig> BuildConfig(bool enabled, TimeSpan interval, double pruneThreshold)
+    {
+        var appConfig = new AppConfig
+        {
+            AI = new AIConfig
+            {
+                Rag = new RagConfig
+                {
+                    CrossSessionMemory = new CrossSessionMemoryConfig
+                    {
+                        PruneThreshold = pruneThreshold,
+                        DecayScheduler = new MemoryDecaySchedulerConfig
+                        {
+                            Enabled = enabled,
+                            Interval = interval
+                        }
+                    }
+                }
+            }
+        };
+
+        var monitor = new Mock<IOptionsMonitor<AppConfig>>();
+        monitor.Setup(m => m.CurrentValue).Returns(appConfig);
+        return monitor.Object;
+    }
+}


### PR DESCRIPTION
## What & why
Wave-3 "inert machinery" remediation. `MemoryDecayService` (CRITICAL/STANDARD/EPHEMERAL decay tiers on cross-session memory) was registered as a plain `AddSingleton` with **no timer** — `ApplyDecayAsync` only ever ran in unit tests, so a live host never aged stored memory weights or pruned low-value entries. This wires it to actually run.

## Change
- **`MemoryDecayScheduler : BackgroundService`** (`Infrastructure.AI.RAG/GraphRag/`) — `PeriodicTimer` on a config-driven interval; each tick creates a fresh `IServiceScope`, resolves `IMemoryDecayService`, runs `ApplyDecayAsync` then `PruneAsync(PruneThreshold)`. Per-pass exceptions logged + swallowed so one bad tick can't tear down the host; shutdown cancellation exits cleanly.
- **DI** (`DependencyInjection.GraphRag.cs`) — hosted service registered **only when** `AI:Rag:CrossSessionMemory:DecayScheduler:Enabled == true`.
- **Config** — new `MemoryDecaySchedulerConfig { Enabled (default false), Interval (default 6h) }` under `CrossSessionMemoryConfig`.

## Default behavior preserved
`Enabled` defaults **false** → no hosted service is registered → byte-identical to today. A fresh clone does not silently start mutating stored memory weights; consumers opt in explicitly.

## Scope safety
Singleton hosted service never captures a scoped dep — it resolves `IMemoryDecayService` from `CreateAsyncScope()` per tick, correct under `ValidateScopes=true` (on in all environments here).

## Test (prove-first)
`MemoryDecaySchedulerTests.Scheduler_OnTick_InvokesApplyDecayAndPruneFromScope` — spy service behind a real `ValidateScopes=true` scope factory, 20ms interval; asserts `ApplyDecayAsync` fired and `PruneAsync(0.05)` called on the live tick. Red before wiring (type didn't exist), green after. Affected-project build: 0 warnings; RAG tests 6/6 green.

## Follow-ups (non-blocking, tracked)
- Interval read once at `ExecuteAsync` start — live cadence reload needs host restart (prune threshold *is* re-read live per pass). Deferred as YAGNI.
- Enabling in shipped `appsettings*.json` is a Presentation/Config concern, deliberately not touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)