### PR TITLE
feat: wire context compaction onto the live agent turn (Wave-3 dormant wiring)

### DIFF
--- a/src/Content/Application/Application.AI.Common/Factories/AgentFactory.cs
+++ b/src/Content/Application/Application.AI.Common/Factories/AgentFactory.cs
@@ -1,4 +1,5 @@
 using Application.AI.Common.Interfaces;
+using Application.AI.Common.Interfaces.Compaction;
 using Application.AI.Common.Interfaces.Routing;
 using Application.AI.Common.Interfaces.Skills;
 using Application.AI.Common.Interfaces.Telemetry;
@@ -279,6 +280,24 @@ public class AgentFactory : IAgentFactory
                 _loggerFactory.CreateLogger<Middleware.ObservabilityMiddleware>()))
             .Use(inner => new Middleware.ToolDiagnosticsMiddleware(
                 inner, _loggerFactory.CreateLogger<Middleware.ToolDiagnosticsMiddleware>()));
+
+        // Per-turn context compaction — only when enabled in config AND a compaction service is
+        // registered. Summarizes conversation history before the model call once its estimated
+        // token footprint exceeds the configured budget. Fail-open: a compaction problem forwards
+        // the untrimmed history rather than breaking the turn.
+        var compactionConfig = _appConfig.CurrentValue.AI?.ContextManagement?.Compaction;
+        var compactionService = _serviceProvider.GetService<IContextCompactionService>();
+        if (compactionConfig?.MiddlewareEnabled == true && compactionService is not null)
+        {
+            chatClientBuilder = chatClientBuilder.Use(inner =>
+                new Middleware.ContextCompactionMiddleware(
+                    inner,
+                    compactionService,
+                    agentContext.Name ?? "unknown",
+                    compactionConfig.MiddlewareMaxContextTokens,
+                    Domain.AI.Compaction.CompactionStrategy.Full,
+                    _loggerFactory.CreateLogger<Middleware.ContextCompactionMiddleware>()));
+        }
 
         // Cache-stats enrichment — only when a generation-stats client is registered (i.e. the
         // configured provider is the OpenRouter path with prompt caching enabled). For every other

--- a/src/Content/Application/Application.AI.Common/Middleware/ContextCompactionMiddleware.cs
+++ b/src/Content/Application/Application.AI.Common/Middleware/ContextCompactionMiddleware.cs
@@ -1,0 +1,168 @@
+using System.Runtime.CompilerServices;
+using Application.AI.Common.Helpers;
+using Application.AI.Common.Interfaces.Compaction;
+using Domain.AI.Compaction;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
+
+namespace Application.AI.Common.Middleware;
+
+/// <summary>
+/// Chat client middleware that compacts conversation history before it is sent to the model
+/// when the estimated token footprint exceeds the configured budget. Runs on every live turn,
+/// re-evaluating the incoming history so that growth mid-conversation (including tool-call
+/// rounds) is trimmed before the next model call.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Positioned in the chat client pipeline alongside the other per-call concerns (after
+/// <see cref="ToolDiagnosticsMiddleware"/>, before the distributed cache). Each call estimates the
+/// token count of the incoming messages and, when
+/// <see cref="IContextCompactionService.ShouldAutoCompact"/> reports the budget is exceeded,
+/// delegates to <see cref="IContextCompactionService.CompactAsync"/> to produce a summary of the
+/// prior history. The middleware then rebuilds the outgoing message list as
+/// <c>[system summary] + [current turn]</c> so the model retains the immediate request while the
+/// older context collapses into the summary.
+/// </para>
+/// <para>
+/// Compaction is <b>fail-open</b>: when the compaction service returns a failure (for example the
+/// LLM summarizer is unavailable or the circuit breaker is open), the original, untrimmed history
+/// is forwarded unchanged. A compaction problem must never break a live turn.
+/// </para>
+/// <para>
+/// Wired only when <c>AppConfig.AI.ContextManagement.Compaction.MiddlewareEnabled</c> is
+/// <see langword="true"/> and an <see cref="IContextCompactionService"/> is registered; otherwise
+/// <see cref="Factories.AgentFactory"/> leaves it out of the pipeline entirely, preserving the
+/// default (no-compaction) behaviour.
+/// </para>
+/// </remarks>
+public sealed class ContextCompactionMiddleware : DelegatingChatClient
+{
+    private readonly IContextCompactionService _service;
+    private readonly string _agentId;
+    private readonly int _maxContextTokens;
+    private readonly CompactionStrategy _strategy;
+    private readonly ILogger _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ContextCompactionMiddleware"/> class.
+    /// </summary>
+    /// <param name="innerClient">The inner chat client to wrap.</param>
+    /// <param name="service">The compaction service that decides and performs compaction.</param>
+    /// <param name="agentId">Identifier of the agent, used to scope circuit-breaker state.</param>
+    /// <param name="maxContextTokens">
+    /// The maximum context-window token budget. Compaction triggers once the estimated history
+    /// tokens reach this value scaled by the configured auto-compact threshold ratio.
+    /// </param>
+    /// <param name="strategy">The compaction strategy to apply when the budget is exceeded.</param>
+    /// <param name="logger">Logger for compaction diagnostics.</param>
+    public ContextCompactionMiddleware(
+        IChatClient innerClient,
+        IContextCompactionService service,
+        string agentId,
+        int maxContextTokens,
+        CompactionStrategy strategy,
+        ILogger<ContextCompactionMiddleware> logger)
+        : base(innerClient)
+    {
+        ArgumentNullException.ThrowIfNull(service);
+        _service = service;
+        _agentId = agentId;
+        _maxContextTokens = maxContextTokens;
+        _strategy = strategy;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public override async Task<ChatResponse> GetResponseAsync(
+        IEnumerable<ChatMessage> messages,
+        ChatOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        var effective = await CompactIfNeededAsync(messages, cancellationToken);
+        return await base.GetResponseAsync(effective, options, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public override async IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+        IEnumerable<ChatMessage> messages,
+        ChatOptions? options = null,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        var effective = await CompactIfNeededAsync(messages, cancellationToken);
+
+        await foreach (var update in base.GetStreamingResponseAsync(effective, options, cancellationToken))
+        {
+            yield return update;
+        }
+    }
+
+    /// <summary>
+    /// Compacts the supplied history when it exceeds the configured budget, returning the trimmed
+    /// message list. Returns the original messages unchanged when compaction is not needed or fails.
+    /// </summary>
+    private async Task<IReadOnlyList<ChatMessage>> CompactIfNeededAsync(
+        IEnumerable<ChatMessage> messages,
+        CancellationToken cancellationToken)
+    {
+        var history = messages as IReadOnlyList<ChatMessage> ?? messages.ToList();
+
+        var currentTokens = TokenEstimationHelper.EstimateTokens(history);
+        if (!_service.ShouldAutoCompact(_agentId, currentTokens, _maxContextTokens))
+            return history;
+
+        _logger.LogInformation(
+            "[Compaction] Agent {AgentId} history ~{Tokens} tokens exceeds budget {Budget}; applying {Strategy} compaction",
+            _agentId, currentTokens, _maxContextTokens, _strategy);
+
+        var result = await _service.CompactAsync(_agentId, history, _strategy, cancellationToken);
+
+        if (!result.Success || result.Boundary is null)
+        {
+            _logger.LogWarning(
+                "[Compaction] Compaction did not apply for agent {AgentId} ({Error}); forwarding full history",
+                _agentId, result.Error ?? "no boundary produced");
+            return history;
+        }
+
+        var rebuilt = RebuildHistory(history, result.Boundary.Summary);
+        _logger.LogInformation(
+            "[Compaction] Agent {AgentId} history compacted: {Before} -> {After} messages (~{Saved} tokens saved)",
+            _agentId, history.Count, rebuilt.Count, result.Boundary.TokensSaved);
+        return rebuilt;
+    }
+
+    /// <summary>
+    /// Rebuilds the outgoing history as a single summary system message followed by the current
+    /// turn (every message from the last user message onward). When no user message is present the
+    /// final message is preserved so the model still has an actionable prompt.
+    /// </summary>
+    private static IReadOnlyList<ChatMessage> RebuildHistory(
+        IReadOnlyList<ChatMessage> history,
+        string summary)
+    {
+        var lastUserIndex = -1;
+        for (var i = history.Count - 1; i >= 0; i--)
+        {
+            if (history[i].Role == ChatRole.User)
+            {
+                lastUserIndex = i;
+                break;
+            }
+        }
+
+        var tailStart = lastUserIndex >= 0
+            ? lastUserIndex
+            : Math.Max(0, history.Count - 1);
+
+        var rebuilt = new List<ChatMessage>(history.Count - tailStart + 1)
+        {
+            new(ChatRole.System, summary)
+        };
+
+        for (var i = tailStart; i < history.Count; i++)
+            rebuilt.Add(history[i]);
+
+        return rebuilt;
+    }
+}

--- a/src/Content/Domain/Domain.Common/Config/AI/ContextManagement/CompactionConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/ContextManagement/CompactionConfig.cs
@@ -19,6 +19,25 @@ namespace Domain.Common.Config.AI.ContextManagement;
 public class CompactionConfig
 {
     /// <summary>
+    /// Gets or sets a value indicating whether the per-turn context-compaction middleware is
+    /// inserted into the agent chat-client pipeline. When <see langword="false"/> (the default),
+    /// conversation history is never compacted on the live turn path, preserving legacy behaviour.
+    /// When <see langword="true"/>, each turn whose estimated history exceeds
+    /// <see cref="MiddlewareMaxContextTokens"/> scaled by <see cref="AutoCompactThresholdRatio"/>
+    /// is summarized before being sent to the model.
+    /// </summary>
+    public bool MiddlewareEnabled { get; set; }
+
+    /// <summary>
+    /// Gets or sets the maximum context-window token budget used by the compaction middleware to
+    /// decide when a turn's history should be compacted. The middleware triggers once the estimated
+    /// history tokens reach this value scaled by <see cref="AutoCompactThresholdRatio"/>. Defaults
+    /// to a high value so that, even when <see cref="MiddlewareEnabled"/> is turned on, compaction
+    /// only fires for genuinely large conversations.
+    /// </summary>
+    public int MiddlewareMaxContextTokens { get; set; } = 128_000;
+
+    /// <summary>
     /// Gets or sets the ratio of token usage to max context window that triggers auto-compaction.
     /// For example, 0.85 means compaction triggers when 85% of the context window is consumed.
     /// </summary>

--- a/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentFactoryCompactionWiringTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentFactoryCompactionWiringTests.cs
@@ -1,0 +1,207 @@
+using Application.AI.Common.Factories;
+using Application.AI.Common.Interfaces;
+using Application.AI.Common.Interfaces.Compaction;
+using Application.AI.Common.Interfaces.Skills;
+using Application.AI.Common.Services.Skills;
+using Application.AI.Common.Tests.Fakes;
+using Domain.AI.Agents;
+using Domain.AI.Compaction;
+using Domain.Common.Config;
+using Domain.Common.Config.AI;
+using Domain.Common.Config.AI.ContextManagement;
+using FluentAssertions;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Application.AI.Common.Tests.Factories;
+
+/// <summary>
+/// Proves the context-compaction subsystem is wired to the live agent turn path. Before this
+/// wiring, <see cref="IContextCompactionService"/> was DI-registered but had zero consumers, so
+/// conversation history was never compacted on any turn. These tests use a canary
+/// <see cref="FakeChatClient"/> and a spy <see cref="IContextCompactionService"/> to assert that
+/// when compaction is enabled in config, live turns invoke the service and the trimmed (summary)
+/// history reaches the model; and that when compaction is disabled (the default) the full history
+/// passes through untouched.
+/// </summary>
+public sealed class AgentFactoryCompactionWiringTests
+{
+    private const string SummaryMarker = "COMPACTED_SUMMARY";
+
+    private static AgentFactory CreateFactory(
+        FakeChatClient innerClient,
+        bool compactionEnabled,
+        IContextCompactionService compactionService)
+    {
+        var chatClientFactory = new Mock<IChatClientFactory>();
+        chatClientFactory
+            .Setup(f => f.IsAvailable(It.IsAny<AIAgentFrameworkClientType>()))
+            .Returns(true);
+        chatClientFactory
+            .Setup(f => f.GetChatClientAsync(
+                It.IsAny<AIAgentFrameworkClientType>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(innerClient);
+
+        var appConfig = new AppConfig
+        {
+            AI = new AIConfig
+            {
+                AgentFramework = new AgentFrameworkConfig
+                {
+                    DefaultDeployment = "gpt-4o",
+                    ClientType = AIAgentFrameworkClientType.AzureOpenAI
+                },
+                ContextManagement = new ContextManagementConfig
+                {
+                    Compaction = new CompactionConfig
+                    {
+                        MiddlewareEnabled = compactionEnabled,
+                        MiddlewareMaxContextTokens = 1000
+                    }
+                }
+            }
+        };
+        var monitor = Mock.Of<IOptionsMonitor<AppConfig>>(m => m.CurrentValue == appConfig);
+
+        var contextFactory = new Mock<AgentExecutionContextFactory>(
+            NullLogger<AgentExecutionContextFactory>.Instance,
+            monitor,
+            new ServiceCollection().BuildServiceProvider(),
+            NullLoggerFactory.Instance,
+            null!, null!, null!, null!, null!, null!);
+
+        var services = new ServiceCollection();
+        services.AddSingleton(compactionService);
+        var serviceProvider = services.BuildServiceProvider();
+
+        return new AgentFactory(
+            NullLogger<AgentFactory>.Instance,
+            monitor,
+            new MemoryDistributedCache(Options.Create(new MemoryDistributedCacheOptions())),
+            NullLoggerFactory.Instance,
+            contextFactory.Object,
+            Mock.Of<ISkillMetadataRegistry>(),
+            chatClientFactory.Object,
+            serviceProvider,
+            new InMemorySkillCompletionTracker());
+    }
+
+    private static CompactionResult SuccessfulCompaction() =>
+        CompactionResult.Succeeded(new CompactionBoundaryMessage
+        {
+            Id = "boundary-1",
+            Trigger = CompactionTrigger.Manual,
+            Strategy = CompactionStrategy.Full,
+            PreCompactionTokens = 5000,
+            PostCompactionTokens = 50,
+            Timestamp = DateTimeOffset.UtcNow,
+            Summary = SummaryMarker
+        });
+
+    private static AgentExecutionContext AgentContext() => new()
+    {
+        Name = "compaction-canary-agent",
+        Instruction = "You are a test agent.",
+        AIAgentFrameworkType = AIAgentFrameworkClientType.AzureOpenAI
+    };
+
+    [Fact]
+    public async Task CreateAgentAsync_CompactionEnabledAndBudgetExceeded_TurnRoutesThroughCompaction()
+    {
+        var innerClient = new FakeChatClient().WithDefaultResponse("ok");
+        var service = new Mock<IContextCompactionService>();
+        service
+            .Setup(s => s.ShouldAutoCompact(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>()))
+            .Returns(true);
+        service
+            .Setup(s => s.CompactAsync(
+                It.IsAny<string>(),
+                It.IsAny<IReadOnlyList<ChatMessage>>(),
+                It.IsAny<CompactionStrategy>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SuccessfulCompaction());
+
+        var factory = CreateFactory(innerClient, compactionEnabled: true, service.Object);
+
+        var agent = await factory.CreateAgentAsync(AgentContext());
+        await agent.RunAsync("please answer this");
+
+        // The compaction service must have been consulted and asked to compact on the live turn.
+        service.Verify(
+            s => s.CompactAsync(
+                It.IsAny<string>(),
+                It.IsAny<IReadOnlyList<ChatMessage>>(),
+                CompactionStrategy.Full,
+                It.IsAny<CancellationToken>()),
+            Times.Once,
+            "an enabled compaction middleware must invoke the service when the budget is exceeded");
+
+        // The trimmed history (summary system message) must be what the model actually receives.
+        innerClient.RequestHistory.Should().NotBeEmpty();
+        innerClient.RequestHistory[^1]
+            .Should().Contain(m => m.Text == SummaryMarker,
+                "the compacted summary must replace the prior history before the model call");
+    }
+
+    [Fact]
+    public async Task CreateAgentAsync_CompactionDisabled_FullHistoryPassesThroughUntouched()
+    {
+        var innerClient = new FakeChatClient().WithDefaultResponse("ok");
+        var service = new Mock<IContextCompactionService>(MockBehavior.Strict);
+
+        var factory = CreateFactory(innerClient, compactionEnabled: false, service.Object);
+
+        var agent = await factory.CreateAgentAsync(AgentContext());
+        await agent.RunAsync("please answer this");
+
+        // Default (disabled) behavior: the compaction service is never touched.
+        service.Verify(
+            s => s.CompactAsync(
+                It.IsAny<string>(),
+                It.IsAny<IReadOnlyList<ChatMessage>>(),
+                It.IsAny<CompactionStrategy>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+
+        innerClient.RequestHistory.Should().NotBeEmpty();
+        innerClient.RequestHistory[^1]
+            .Should().NotContain(m => m.Text == SummaryMarker);
+    }
+
+    [Fact]
+    public async Task CreateAgentAsync_CompactionFails_FailsOpenAndForwardsOriginalHistory()
+    {
+        var innerClient = new FakeChatClient().WithDefaultResponse("ok");
+        var service = new Mock<IContextCompactionService>();
+        service
+            .Setup(s => s.ShouldAutoCompact(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>()))
+            .Returns(true);
+        service
+            .Setup(s => s.CompactAsync(
+                It.IsAny<string>(),
+                It.IsAny<IReadOnlyList<ChatMessage>>(),
+                It.IsAny<CompactionStrategy>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CompactionResult.Failed("summarizer unavailable"));
+
+        var factory = CreateFactory(innerClient, compactionEnabled: true, service.Object);
+
+        var agent = await factory.CreateAgentAsync(AgentContext());
+        var response = await agent.RunAsync("please answer this");
+
+        // Compaction failure must not break the turn, and must not inject a phantom summary.
+        response.Should().NotBeNull();
+        innerClient.RequestHistory.Should().NotBeEmpty();
+        innerClient.RequestHistory[^1]
+            .Should().NotContain(m => m.Text == SummaryMarker,
+                "a failed compaction forwards the original history rather than a summary");
+    }
+}


### PR DESCRIPTION
## What & why
Wave-3 "inert machinery" remediation. `IContextCompactionService` was DI-registered but had **zero consumers** — conversation history was never compacted on any live turn. This wires it into the agent chat-client pipeline.

## Change
- **`ContextCompactionMiddleware`** (`Application.AI.Common/Middleware/`) — a `DelegatingChatClient` that, per turn, estimates history tokens (`TokenEstimationHelper`), calls `ShouldAutoCompact`, and on trigger `CompactAsync(Full)` then rebuilds the outgoing list as `[system summary] + [current turn from last user message onward]`. Covers both `GetResponseAsync` and `GetStreamingResponseAsync`.
- **`AgentFactory`** — inserts the middleware **only when** `AI:ContextManagement:Compaction:MiddlewareEnabled == true` AND an `IContextCompactionService` resolves (optional-service pattern, same region as `SkillPrerequisiteMiddleware`).
- **Config** — additive `MiddlewareEnabled` (default false) + `MiddlewareMaxContextTokens` (default 128000); trigger reuses existing `AutoCompactThresholdRatio`.

## Default behavior preserved
`MiddlewareEnabled` defaults **false** → the middleware is not inserted at all → zero cost, byte-identical to today.

## Fail-open
A failed/empty compaction result forwards the original untrimmed history unchanged — a compaction problem (summarizer down, circuit open) never breaks a live turn. Covered by test.

## Test (prove-first)
`AgentFactoryCompactionWiringTests` — 3 tests through the real `AgentFactory` + `RunAsync`: enabled+budget-exceeded → service invoked once and summary reaches the inner client; disabled (strict mock) → never touched; compaction fails → fails open, turn completes, no phantom summary. Red before wiring, green after. Build 0 warnings; 1319 Application.AI.Common + 34 compaction-owner tests green. gitnexus `AgentFactory` upstream = LOW.

## Follow-ups (non-blocking, tracked)
- `CompactAsync` returns only a summary (not a reconstructed message list), so the middleware owns the `[summary]+[last-user-turn]` rebuild heuristic. Cleaner: have the service return the compacted list authoritatively.
- `Full` strategy re-summarizes every turn once at the threshold, with no cross-turn summary caching — consider a min-interval / reuse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)