### PR TITLE
docs: correct MCP rate-limit scope + document compaction/decay wiring

### DIFF
--- a/documentation/architecture/02-compute-and-ai.html
+++ b/documentation/architecture/02-compute-and-ai.html
@@ -180,6 +180,24 @@
                         </div>
                     </div>
 
+                    <div class="callout callout-info">
+                        <span class="callout-icon">i</span>
+                        <div class="callout-body">
+                            <div class="callout-title">Health probes on <code>harness-mcp</code>: don't point them at an authed endpoint</div>
+                            <p style="margin: 0">
+                                The MCP server is <strong>fail-closed</strong>: when authentication is configured, a
+                                fallback authorization policy (<code>RequireAuthenticatedUser</code>) protects
+                                <em>every</em> endpoint that lacks explicit authorization metadata. An unauthenticated
+                                liveness/readiness probe hitting the MCP endpoint (or any other route) therefore gets a
+                                <strong>401</strong>, which Container Apps reads as an unhealthy replica and will restart
+                                in a crash loop. Configure the probe as a <strong>TCP probe</strong> against the
+                                container port, or expose a dedicated <strong>anonymous</strong> <code>/health</code>
+                                endpoint (map it with <code>.AllowAnonymous()</code>) and point the probe there. Do not
+                                relax the fallback policy to make an authed route probe-friendly.
+                            </p>
+                        </div>
+                    </div>
+
                     <h3 id="bicep-example">Bicep example</h3>
                     <p>
                         A representative Container App resource definition for the main API. Note how secrets reference

--- a/documentation/reference/patterns-and-technologies.html
+++ b/documentation/reference/patterns-and-technologies.html
@@ -475,6 +475,30 @@ know the exact filename. Cite file paths in `path:line` form.</code></pre>
                         <code>Partial</code> (summarise older turns), or <code>Micro</code> (drop redundant tool
                         outputs). <code>AutoCompactStateMachine</code> picks the right strategy.
                     </p>
+                    <p>
+                        On the <strong>live agent turn</strong>, compaction runs as a chat-client middleware,
+                        <code>ContextCompactionMiddleware</code> (<code>Application.AI.Common/Middleware/ContextCompactionMiddleware.cs</code>).
+                        Before each model call it estimates the incoming history's token footprint and, once it exceeds
+                        <code>MiddlewareMaxContextTokens</code> (default 128&nbsp;000) scaled by
+                        <code>AutoCompactThresholdRatio</code> (default 0.85), summarises the older history and rebuilds
+                        the request as <code>[system summary] + [current turn]</code>.
+                    </p>
+                    <p>
+                        <strong>Opt-in, default OFF.</strong> The middleware is wired by <code>AgentFactory</code> only
+                        when <code>AppConfig:AI:ContextManagement:Compaction:MiddlewareEnabled</code> is <code>true</code>
+                        <em>and</em> an <code>IContextCompactionService</code> is registered; otherwise the pipeline omits
+                        it entirely and history is never compacted on the live path (legacy behaviour preserved). It is
+                        also <strong>fail-open</strong>: if the compaction service fails (LLM summariser unavailable,
+                        circuit breaker open), the original untrimmed history is forwarded unchanged — a compaction
+                        problem never breaks a live turn.
+                    </p>
+                    <p>
+                        <strong>Known limitation.</strong> The <code>Full</code> strategy sends the entire transcript to
+                        the LLM on <em>every</em> triggering turn with no cross-turn caching of the summary, so a long
+                        conversation that stays over budget re-summarises repeatedly and pays the summarisation cost each
+                        turn. Prefer <code>Partial</code>/<code>Micro</code> for cost-sensitive long sessions until
+                        summary caching is added.
+                    </p>
 
                     <h3 id="subagents">Subagent dispatch &amp; mailbox</h3>
                     <p>
@@ -734,6 +758,23 @@ return quality.MaxScore switch
                         <strong>STANDARD</strong> (slow decay), <strong>EPHEMERAL</strong> (fast decay). Scheduled
                         pruning removes anything below threshold.
                         <code>Infrastructure.AI.RAG/GraphRag/MemoryDecayService.cs</code>
+                    </p>
+                    <p>
+                        The decay service is inert on its own — it only ages weights when something calls it. A
+                        <code>BackgroundService</code>, <code>MemoryDecayScheduler</code>
+                        (<code>Infrastructure.AI.RAG/GraphRag/MemoryDecayScheduler.cs</code>), drives it on a timer:
+                        each pass runs <code>ApplyDecayAsync</code> then <code>PruneAsync</code>. It is
+                        <strong>opt-in, default OFF</strong> — registered only when
+                        <code>AppConfig:AI:Rag:CrossSessionMemory:DecayScheduler:Enabled</code> is <code>true</code>, so
+                        cloning the template never silently starts mutating stored memory weights. Cadence comes from
+                        <code>...:DecayScheduler:Interval</code> (default 6 hours) and the prune cut-off from
+                        <code>...:CrossSessionMemory:PruneThreshold</code>.
+                    </p>
+                    <p>
+                        <strong>Known limitation.</strong> The scheduler's <code>Interval</code> is read <em>once</em> at
+                        service start; changing it at runtime needs a host restart to take effect. The prune threshold,
+                        by contrast, is re-read live on every pass (via <code>IOptionsMonitor</code>), so it hot-reloads
+                        without a restart.
                     </p>
 
                     <h3 id="provenance">Entity-level provenance</h3>

--- a/src/Content/Infrastructure/Infrastructure.AI.MCPServer/README.md
+++ b/src/Content/Infrastructure/Infrastructure.AI.MCPServer/README.md
@@ -55,7 +55,7 @@ External MCP Clients
 2. Register MCP server services with HTTP transport.
 3. Configure authentication **fail-closed**: ApiKey, static Bearer token, or Entra ID (JWT). If no scheme is properly configured and `Auth.AllowAnonymous` is not explicitly `true`, the host throws at startup — in every environment, including Development.
 4. Register the skill catalog (`SkillMetadataRegistry`) for tool queries.
-5. Add rate limiting (100 requests/minute per client).
+5. Add rate limiting (100 requests/minute, shared **globally** across all clients — a single fixed-window partition, not per-client).
 6. Build the pipeline: Authentication -> Authorization -> Rate Limiter -> MCP endpoint.
 7. Map the MCP endpoint at the root with auth + rate limiting required (or a deliberate `.AllowAnonymous()` when the opt-in is set).
 
@@ -132,6 +132,8 @@ else
 **What it is:** A fixed-window rate limiter that caps MCP requests at 100 per minute.
 
 **Why it exists:** MCP tools can trigger expensive operations (LLM calls, database queries). Rate limiting prevents abuse and protects downstream resources.
+
+**Scope — global, not per-client:** the limiter is registered with a **constant partition key** (`RateLimitPartition.GetFixedWindowLimiter("mcp", ...)` in `Program.cs`), so every inbound request maps to the *same* partition. The 100 req/min budget is therefore shared across all callers, not allocated per authenticated client or per IP. One busy client can exhaust the window for everyone. If you need per-client fairness, replace the constant key with a per-caller partition key (e.g. derived from the authenticated principal or an `X-Forwarded-For` value). Note this differs from the AgentHub SignalR limiter, which *is* partitioned per user id.
 
 ### Resource Subscriptions
 
@@ -239,7 +241,7 @@ Infrastructure.AI.MCPServer/
 | `Auth.ApiKeyHeader` | Header carrying the API key | Default `X-API-Key` |
 | `Auth.TenantId` | Entra tenant for token validation | Your organization's tenant |
 | `Auth.ClientId` | App registration for audience validation | Dedicated app registration |
-| Rate limit | 100 requests per minute per partition | Tune based on expected load |
+| Rate limit | 100 requests per minute, global (single shared partition — not per-client) | Tune based on expected load; re-key the partition for per-client fairness |
 
 ## Common Tasks
 
@@ -273,6 +275,8 @@ dotnet run --project src/Content/Infrastructure/Infrastructure.AI.MCPServer
 ```
 
 The server starts on the configured URLs (default: `http://localhost:5000`). Connect any MCP client to `http://localhost:5000/mcp`.
+
+> **Health probes (fail-closed auth):** because a fallback `RequireAuthenticatedUser` policy protects every endpoint without explicit authorization metadata, an unauthenticated liveness/readiness probe gets a **401** — which an orchestrator (Kubernetes, Container Apps) treats as unhealthy and restarts in a crash loop. Use a **TCP probe** against the listening port, or map a dedicated **anonymous** `/health` endpoint with `.AllowAnonymous()` and probe that. Do not weaken the fallback policy to make an authed route probe-friendly.
 
 ### How to Test MCP Tools Locally
 


### PR DESCRIPTION
Wave 4 (consolidation) — docs-only lane. Corrects/adds documentation to match shipped Wave-2/3 behavior. No source or test changes.

## Changes (all verified against current code)
- **MCP rate-limit scope corrected (per-client → global):** `Infrastructure.AI.MCPServer/README.md`. The limiter uses a constant partition key (`Program.cs:46` `RateLimitPartition.GetFixedWindowLimiter("mcp", ...)`), so the 100 req/min budget is shared across all callers — one busy client can starve the rest. README previously implied per-client.
- **Liveness-probe 401 note:** `documentation/architecture/02-compute-and-ai.html` + MCP README. Auth is fail-closed (`FallbackPolicy = RequireAuthenticatedUser`, `McpServerExtensions.cs:192`), so unauthenticated probes get 401 → restart loop. Documented: use a TCP probe or an anonymous `/health` endpoint; don't weaken the fallback policy.
- **Context compaction documented:** `documentation/reference/patterns-and-technologies.html`. `ContextCompactionMiddleware` on the live turn, opt-in default OFF (`AppConfig:AI:ContextManagement:Compaction:MiddlewareEnabled`), fail-open. Noted the tracked limitation that `Full` re-summarizes the whole transcript every triggering turn with no cross-turn caching.
- **Memory-decay documented:** same reference doc. `MemoryDecayScheduler` (BackgroundService, opt-in default OFF), decay-then-prune per pass. Noted `Interval` is read once at start (needs host restart) while `PruneThreshold` is re-read live per pass.

## Verification
Docs-only; no build/test impact. Each claim was verified against the cited source line before writing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)