### PR TITLE
refactor: convert SkillAgentOptions to immutable record

### DIFF
--- a/src/Content/Application/Application.AI.Common/Services/AgentConversationCache.cs
+++ b/src/Content/Application/Application.AI.Common/Services/AgentConversationCache.cs
@@ -87,19 +87,6 @@ internal sealed class AgentConversationCache : IAgentConversationCache
             : new Dictionary<string, object>(options.AdditionalProperties);
         scopedProperties[AgentFactory.ConversationIdPropertyKey] = conversationId;
 
-        return new SkillAgentOptions
-        {
-            SkillPaths = options.SkillPaths,
-            AgentNameOverride = options.AgentNameOverride,
-            DeploymentName = options.DeploymentName,
-            AgentId = options.AgentId,
-            FrameworkType = options.FrameworkType,
-            AdditionalContext = options.AdditionalContext,
-            Temperature = options.Temperature,
-            AdditionalTools = options.AdditionalTools,
-            MiddlewareTypes = options.MiddlewareTypes,
-            AdditionalProperties = scopedProperties,
-            TraceScope = options.TraceScope
-        };
+        return options with { AdditionalProperties = scopedProperties };
     }
 }

--- a/src/Content/Domain/Domain.AI/Skills/SkillAgentOptions.cs
+++ b/src/Content/Domain/Domain.AI/Skills/SkillAgentOptions.cs
@@ -8,7 +8,13 @@ namespace Domain.AI.Skills;
 /// Options for creating agents from skill definitions.
 /// Controls resource loading, deployment overrides, and additional configuration.
 /// </summary>
-public class SkillAgentOptions
+/// <remarks>
+/// Immutable: every property is init-only, so a scoped variant is produced with a
+/// <c>with</c> expression (e.g. <c>options with { AdditionalProperties = ... }</c>)
+/// rather than a hand-copied clone, which guarantees no property is silently dropped
+/// as the shape grows.
+/// </remarks>
+public sealed record SkillAgentOptions
 {
 	#region Skill Loading
 
@@ -16,7 +22,7 @@ public class SkillAgentOptions
 	/// Override the skill search paths for this agent creation.
 	/// When null, paths from <c>AppConfig.AI.Skills</c> are used.
 	/// </summary>
-	public IList<string>? SkillPaths { get; set; }
+	public IList<string>? SkillPaths { get; init; }
 
 	#endregion
 
@@ -25,54 +31,54 @@ public class SkillAgentOptions
 	/// <summary>
 	/// Override the generated agent name.
 	/// </summary>
-	public string? AgentNameOverride { get; set; }
+	public string? AgentNameOverride { get; init; }
 
 	/// <summary>
 	/// Override the default deployment name.
 	/// </summary>
-	public string? DeploymentName { get; set; }
+	public string? DeploymentName { get; init; }
 
 	/// <summary>
 	/// Override the persistent agent ID from skill metadata.
 	/// </summary>
-	public string? AgentId { get; set; }
+	public string? AgentId { get; init; }
 
 	/// <summary>
 	/// Override the default framework type.
 	/// </summary>
-	public AIAgentFrameworkClientType? FrameworkType { get; set; }
+	public AIAgentFrameworkClientType? FrameworkType { get; init; }
 
 	/// <summary>
 	/// Additional context to append to instructions.
 	/// </summary>
-	public string? AdditionalContext { get; set; }
+	public string? AdditionalContext { get; init; }
 
 	/// <summary>
 	/// Override the sampling temperature for the underlying chat client.
 	/// When null, the provider default is used.
 	/// </summary>
-	public float? Temperature { get; set; }
+	public float? Temperature { get; init; }
 
 	/// <summary>
 	/// Additional tools for the agent.
 	/// </summary>
-	public IList<AITool>? AdditionalTools { get; set; }
+	public IList<AITool>? AdditionalTools { get; init; }
 
 	/// <summary>
 	/// Additional middleware types.
 	/// </summary>
-	public IList<Type>? MiddlewareTypes { get; set; }
+	public IList<Type>? MiddlewareTypes { get; init; }
 
 	/// <summary>
 	/// Additional properties for the agent definition.
 	/// </summary>
-	public IDictionary<string, object>? AdditionalProperties { get; set; }
+	public IDictionary<string, object>? AdditionalProperties { get; init; }
 
 	/// <summary>
 	/// Optional trace scope for this run. When set, the factory uses this scope;
 	/// otherwise <c>TraceScope.ForExecution(Guid.NewGuid())</c> is created.
 	/// </summary>
-	public TraceScope? TraceScope { get; set; }
+	public TraceScope? TraceScope { get; init; }
 
 	#endregion
 }


### PR DESCRIPTION
Wave 4 (consolidation) — B3 follow-up from PR #121. Behavior-preserving refactor.

## Change
`SkillAgentOptions` was a `class` with `{ get; set; }` properties, and `AgentConversationCache.WithConversationScope` produced a scoped copy by hand-copying all 11 properties — fragile: a new property risks being silently dropped from the clone.

Converted to a `sealed record` with `{ get; init; }` properties. `WithConversationScope` collapses to:
```csharp
return options with { AdditionalProperties = scopedProperties };
```

## Why safe
- No public surface or logic change; property set + semantics identical.
- All construction sites use object-initializer syntax, which records accept identically — zero construction sites needed adjustment.
- Green build proves no post-construction mutation sites exist (init-only would fail to compile otherwise).
- `gitnexus_impact` = HIGH radius (6 callers) purely because the type is widely constructed; the change is source-compatible.

## Verification
- Application.AI.Common.Tests: 1319/1319
- Presentation.Common.Tests: 125/125
- Infrastructure.AI.Tests: unchanged (3 pre-existing FileSystemService env failures, unrelated)
- 0 new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)