### PR TITLE
refactor: consolidate attestation signing into one Sign surface

### DIFF
--- a/src/Content/Application/Application.AI.Common/Interfaces/Attestation/IAttestationService.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Attestation/IAttestationService.cs
@@ -10,68 +10,21 @@ namespace Application.AI.Common.Interfaces.Attestation;
 public interface IAttestationService
 {
     /// <summary>
-    /// Signs a successful tool execution, producing an attestation with input and output hashes.
+    /// Signs a tool execution described by <paramref name="request"/>, producing a
+    /// tamper-evident attestation. This single entry point replaces the former family of
+    /// <c>Sign*</c> overloads: the payload shape (success, failure, failure-with-output, and
+    /// the optional egress-digest binding) is selected from the request's fields. See
+    /// <see cref="AttestationRequest"/> for the field-to-shape mapping.
     /// </summary>
-    /// <param name="toolName">Name of the tool that was executed.</param>
-    /// <param name="input">Serialized tool input.</param>
-    /// <param name="output">Serialized tool output.</param>
+    /// <remarks>
+    /// Payload shapes coexist so attestations signed under any earlier overload remain
+    /// verifiable: field presence on the produced record (output hash, egress digest, the
+    /// failure flag) is the discriminator during verification.
+    /// </remarks>
+    /// <param name="request">The execution to attest.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>A signed attestation.</returns>
-    Task<ToolExecutionAttestation> SignAsync(string toolName, string input, string output, CancellationToken ct);
-
-    /// <summary>
-    /// Signs a failed tool execution, producing a failure attestation with a reason but no output hash.
-    /// </summary>
-    /// <param name="toolName">Name of the tool that was executed.</param>
-    /// <param name="input">Serialized tool input.</param>
-    /// <param name="failureReason">Description of the failure.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>A signed failure attestation.</returns>
-    Task<ToolExecutionAttestation> SignFailureAsync(string toolName, string input, string failureReason, CancellationToken ct);
-
-    /// <summary>
-    /// Signs a successful tool execution and binds the egress digest into the
-    /// attestation payload, proving which outbound destinations the harness
-    /// permitted during sandbox preflight. Produces the extended payload shape;
-    /// baseline <see cref="SignAsync"/> attestations remain verifiable.
-    /// </summary>
-    /// <param name="toolName">Name of the tool that was executed.</param>
-    /// <param name="input">Serialized tool input.</param>
-    /// <param name="output">Serialized tool output.</param>
-    /// <param name="egressDigest">SHA-256 digest of the recorded egress decisions.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>A signed attestation carrying the egress digest.</returns>
-    Task<ToolExecutionAttestation> SignWithEgressAsync(string toolName, string input, string output, string egressDigest, CancellationToken ct);
-
-    /// <summary>
-    /// Signs a failed tool execution and binds the egress digest into the
-    /// failure attestation payload. Used when an egress preflight deny aborts
-    /// execution before output is produced, so the signed record proves the
-    /// destinations evaluated at the point of failure.
-    /// </summary>
-    /// <param name="toolName">Name of the tool that was executed.</param>
-    /// <param name="input">Serialized tool input.</param>
-    /// <param name="failureReason">Description of the failure.</param>
-    /// <param name="egressDigest">SHA-256 digest of the recorded egress decisions.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>A signed failure attestation carrying the egress digest.</returns>
-    Task<ToolExecutionAttestation> SignFailureWithEgressAsync(string toolName, string input, string failureReason, string egressDigest, CancellationToken ct);
-
-    /// <summary>
-    /// Signs a failed tool execution that nevertheless produced output (e.g. a process that
-    /// wrote to stdout before exiting non-zero). The content hash of the produced output is
-    /// bound into the signed payload alongside the failure reason, so the output returned to
-    /// the caller cannot silently diverge from the attested record. Legacy failure
-    /// attestations (no output hash) remain verifiable.
-    /// </summary>
-    /// <param name="toolName">Name of the tool that was executed.</param>
-    /// <param name="input">Serialized tool input.</param>
-    /// <param name="failureReason">Description of the failure.</param>
-    /// <param name="output">The output actually produced before the failure.</param>
-    /// <param name="egressDigest">Optional SHA-256 digest of the recorded egress decisions; null when no preflight ran.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>A signed failure attestation whose output hash covers the produced output.</returns>
-    Task<ToolExecutionAttestation> SignFailureWithOutputAsync(string toolName, string input, string failureReason, string output, string? egressDigest, CancellationToken ct);
+    Task<ToolExecutionAttestation> SignAsync(AttestationRequest request, CancellationToken ct);
 
     /// <summary>
     /// Verifies the HMAC signature of an existing attestation.

--- a/src/Content/Domain/Domain.AI/Attestation/AttestationRequest.cs
+++ b/src/Content/Domain/Domain.AI/Attestation/AttestationRequest.cs
@@ -1,0 +1,101 @@
+namespace Domain.AI.Attestation;
+
+/// <summary>
+/// Describes a single tool execution to be attested. Carries the discriminator
+/// (<see cref="IsFailure"/>) plus every field any signing variant needs, so one
+/// signing method replaces the former family of <c>Sign*</c> overloads without
+/// changing the produced attestation payloads.
+/// </summary>
+/// <remarks>
+/// The signing payload shape is selected from this request's fields:
+/// <list type="bullet">
+/// <item><description>Success (<see cref="IsFailure"/> = false): the output content hash is bound; <see cref="Output"/> is required.</description></item>
+/// <item><description>Failure with no produced output (<see cref="Output"/> = null): a failure payload with a <c>null</c> output slot.</description></item>
+/// <item><description>Failure that produced output before failing (<see cref="Output"/> set): the produced output's content hash occupies the output slot, so the returned output stays bound to the signed record.</description></item>
+/// </list>
+/// A non-null <see cref="EgressDigest"/> appends the egress digest to any of the
+/// above shapes. Prefer the <see cref="Success"/> and <see cref="Failure"/> factory
+/// methods over the initializer for call-site clarity.
+/// </remarks>
+public sealed record AttestationRequest
+{
+    /// <summary>Name of the tool that was executed.</summary>
+    public required string ToolName { get; init; }
+
+    /// <summary>Serialized tool input.</summary>
+    public required string Input { get; init; }
+
+    /// <summary>
+    /// Whether this attestation records a failed execution. When true,
+    /// <see cref="FailureReason"/> must be supplied.
+    /// </summary>
+    public bool IsFailure { get; init; }
+
+    /// <summary>
+    /// Serialized tool output. Required for a success attestation. For a failure
+    /// attestation it is optional: supply it when the tool produced output before
+    /// failing (so the produced bytes are bound into the signed record), or leave it
+    /// null when execution failed without producing any output.
+    /// </summary>
+    public string? Output { get; init; }
+
+    /// <summary>
+    /// Description of the failure. Required when <see cref="IsFailure"/> is true;
+    /// ignored otherwise.
+    /// </summary>
+    public string? FailureReason { get; init; }
+
+    /// <summary>
+    /// SHA-256 digest of the egress decisions recorded during sandbox preflight.
+    /// Null when no preflight ran; a non-null value binds the digest into the
+    /// signed payload.
+    /// </summary>
+    public string? EgressDigest { get; init; }
+
+    /// <summary>
+    /// Creates a request for a successful tool execution, binding the produced
+    /// output's content hash into the attestation.
+    /// </summary>
+    /// <param name="toolName">Name of the tool that was executed.</param>
+    /// <param name="input">Serialized tool input.</param>
+    /// <param name="output">Serialized tool output.</param>
+    /// <param name="egressDigest">Optional SHA-256 digest of the recorded egress decisions.</param>
+    /// <returns>A success attestation request.</returns>
+    public static AttestationRequest Success(string toolName, string input, string output, string? egressDigest = null)
+        => new()
+        {
+            ToolName = toolName,
+            Input = input,
+            IsFailure = false,
+            Output = output,
+            EgressDigest = egressDigest
+        };
+
+    /// <summary>
+    /// Creates a request for a failed tool execution.
+    /// </summary>
+    /// <param name="toolName">Name of the tool that was executed.</param>
+    /// <param name="input">Serialized tool input.</param>
+    /// <param name="failureReason">Description of the failure.</param>
+    /// <param name="output">
+    /// Output produced before the failure, or null when none was produced. When
+    /// supplied, its content hash is bound into the signed payload.
+    /// </param>
+    /// <param name="egressDigest">Optional SHA-256 digest of the recorded egress decisions.</param>
+    /// <returns>A failure attestation request.</returns>
+    public static AttestationRequest Failure(
+        string toolName,
+        string input,
+        string failureReason,
+        string? output = null,
+        string? egressDigest = null)
+        => new()
+        {
+            ToolName = toolName,
+            Input = input,
+            IsFailure = true,
+            FailureReason = failureReason,
+            Output = output,
+            EgressDigest = egressDigest
+        };
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Attestation/HmacAttestationService.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Attestation/HmacAttestationService.cs
@@ -30,28 +30,37 @@ public sealed class HmacAttestationService : IAttestationService
     }
 
     /// <inheritdoc />
-    public Task<ToolExecutionAttestation> SignAsync(string toolName, string input, string output, CancellationToken ct)
+    public Task<ToolExecutionAttestation> SignAsync(AttestationRequest request, CancellationToken ct)
     {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(request.ToolName);
+        ArgumentNullException.ThrowIfNull(request.Input);
+
         var options = _optionsMonitor.CurrentValue;
         var currentKey = GetKey(options, options.CurrentKeyVersion);
         try
         {
             var timestamp = _timeProvider.GetUtcNow();
-            var inputHash = ComputeSha256Hex(input);
-            var outputHash = ComputeSha256Hex(output);
-            var payload = $"{toolName}|{inputHash}|{outputHash}|{timestamp:O}";
+            var inputHash = ComputeSha256Hex(request.Input);
+            // Algorithm and key derivation are fixed (HMAC-SHA256 over the UTF-8 payload
+            // string); only the payload *shape* varies by request kind. All shapes coexist so
+            // that attestations produced before egress/output-binding was added remain
+            // verifiable — field presence on the record is the discriminator during
+            // verification (see BuildVerificationPayload).
+            var payload = BuildSigningPayload(request, inputHash, timestamp, out var outputHash);
             var signature = ComputeHmac(currentKey, payload);
 
             var attestation = new ToolExecutionAttestation
             {
-                ToolName = toolName,
+                ToolName = request.ToolName,
                 InputHash = inputHash,
                 OutputHash = outputHash,
                 Timestamp = timestamp,
                 Signature = signature,
                 KeyVersion = options.CurrentKeyVersion,
-                IsFailureAttestation = false,
-                FailureReason = null
+                IsFailureAttestation = request.IsFailure,
+                FailureReason = request.IsFailure ? request.FailureReason : null,
+                EgressDigest = request.EgressDigest
             };
 
             return Task.FromResult(attestation);
@@ -62,172 +71,30 @@ public sealed class HmacAttestationService : IAttestationService
         }
     }
 
-    /// <inheritdoc />
-    public Task<ToolExecutionAttestation> SignFailureAsync(string toolName, string input, string failureReason, CancellationToken ct)
+    /// <summary>
+    /// Builds the HMAC payload string for a signing request and reports the output hash that
+    /// belongs on the resulting attestation. Success attestations bind the output hash; failure
+    /// attestations use a literal <c>null</c> output slot unless the tool produced output before
+    /// failing, in which case that output's content hash occupies the slot. A non-null egress
+    /// digest is appended to any shape.
+    /// </summary>
+    private static string BuildSigningPayload(
+        AttestationRequest request, string inputHash, DateTimeOffset timestamp, out string? outputHash)
     {
-        var options = _optionsMonitor.CurrentValue;
-        var currentKey = GetKey(options, options.CurrentKeyVersion);
-        try
+        if (!request.IsFailure)
         {
-            var timestamp = _timeProvider.GetUtcNow();
-            var inputHash = ComputeSha256Hex(input);
-            var failureHash = ComputeSha256Hex(failureReason);
-            var payload = $"{toolName}|{inputHash}|null|{failureHash}|{timestamp:O}";
-            var signature = ComputeHmac(currentKey, payload);
-
-            var attestation = new ToolExecutionAttestation
-            {
-                ToolName = toolName,
-                InputHash = inputHash,
-                OutputHash = null,
-                Timestamp = timestamp,
-                Signature = signature,
-                KeyVersion = options.CurrentKeyVersion,
-                IsFailureAttestation = true,
-                FailureReason = failureReason
-            };
-
-            return Task.FromResult(attestation);
+            ArgumentNullException.ThrowIfNull(request.Output);
+            outputHash = ComputeSha256Hex(request.Output);
+            var success = $"{request.ToolName}|{inputHash}|{outputHash}|{timestamp:O}";
+            return request.EgressDigest is null ? success : $"{success}|egress:{request.EgressDigest}";
         }
-        finally
-        {
-            CryptographicOperations.ZeroMemory(currentKey);
-        }
-    }
 
-    /// <inheritdoc />
-    public Task<ToolExecutionAttestation> SignWithEgressAsync(
-        string toolName,
-        string input,
-        string output,
-        string egressDigest,
-        CancellationToken ct)
-    {
-        ArgumentNullException.ThrowIfNull(egressDigest);
-
-        var options = _optionsMonitor.CurrentValue;
-        var currentKey = GetKey(options, options.CurrentKeyVersion);
-        try
-        {
-            var timestamp = _timeProvider.GetUtcNow();
-            var inputHash = ComputeSha256Hex(input);
-            var outputHash = ComputeSha256Hex(output);
-            // Payload schema extended (egress trailing field). Algorithm and
-            // key derivation unchanged — HMAC-SHA256 over UTF-8 of the payload
-            // string. PR-3a's existing payload shape is preserved by the
-            // SignAsync overload; new callers opt in to the extended shape
-            // explicitly.
-            var payload = $"{toolName}|{inputHash}|{outputHash}|{timestamp:O}|egress:{egressDigest}";
-            var signature = ComputeHmac(currentKey, payload);
-
-            var attestation = new ToolExecutionAttestation
-            {
-                ToolName = toolName,
-                InputHash = inputHash,
-                OutputHash = outputHash,
-                Timestamp = timestamp,
-                Signature = signature,
-                KeyVersion = options.CurrentKeyVersion,
-                IsFailureAttestation = false,
-                FailureReason = null,
-                EgressDigest = egressDigest
-            };
-
-            return Task.FromResult(attestation);
-        }
-        finally
-        {
-            CryptographicOperations.ZeroMemory(currentKey);
-        }
-    }
-
-    /// <inheritdoc />
-    public Task<ToolExecutionAttestation> SignFailureWithEgressAsync(
-        string toolName,
-        string input,
-        string failureReason,
-        string egressDigest,
-        CancellationToken ct)
-    {
-        ArgumentNullException.ThrowIfNull(egressDigest);
-
-        var options = _optionsMonitor.CurrentValue;
-        var currentKey = GetKey(options, options.CurrentKeyVersion);
-        try
-        {
-            var timestamp = _timeProvider.GetUtcNow();
-            var inputHash = ComputeSha256Hex(input);
-            var failureHash = ComputeSha256Hex(failureReason);
-            var payload = $"{toolName}|{inputHash}|null|{failureHash}|{timestamp:O}|egress:{egressDigest}";
-            var signature = ComputeHmac(currentKey, payload);
-
-            var attestation = new ToolExecutionAttestation
-            {
-                ToolName = toolName,
-                InputHash = inputHash,
-                OutputHash = null,
-                Timestamp = timestamp,
-                Signature = signature,
-                KeyVersion = options.CurrentKeyVersion,
-                IsFailureAttestation = true,
-                FailureReason = failureReason,
-                EgressDigest = egressDigest
-            };
-
-            return Task.FromResult(attestation);
-        }
-        finally
-        {
-            CryptographicOperations.ZeroMemory(currentKey);
-        }
-    }
-
-    /// <inheritdoc />
-    public Task<ToolExecutionAttestation> SignFailureWithOutputAsync(
-        string toolName,
-        string input,
-        string failureReason,
-        string output,
-        string? egressDigest,
-        CancellationToken ct)
-    {
-        ArgumentNullException.ThrowIfNull(output);
-
-        var options = _optionsMonitor.CurrentValue;
-        var currentKey = GetKey(options, options.CurrentKeyVersion);
-        try
-        {
-            var timestamp = _timeProvider.GetUtcNow();
-            var inputHash = ComputeSha256Hex(input);
-            var outputHash = ComputeSha256Hex(output);
-            var failureHash = ComputeSha256Hex(failureReason);
-            // Failure payload with the produced output's content hash occupying the output
-            // slot (instead of the literal "null" used by output-less failures). The
-            // discriminator during verification is OutputHash being non-null on a failure
-            // attestation, so legacy failure attestations remain verifiable.
-            var basePayload = $"{toolName}|{inputHash}|{outputHash}|{failureHash}|{timestamp:O}";
-            var payload = egressDigest is null ? basePayload : $"{basePayload}|egress:{egressDigest}";
-            var signature = ComputeHmac(currentKey, payload);
-
-            var attestation = new ToolExecutionAttestation
-            {
-                ToolName = toolName,
-                InputHash = inputHash,
-                OutputHash = outputHash,
-                Timestamp = timestamp,
-                Signature = signature,
-                KeyVersion = options.CurrentKeyVersion,
-                IsFailureAttestation = true,
-                FailureReason = failureReason,
-                EgressDigest = egressDigest
-            };
-
-            return Task.FromResult(attestation);
-        }
-        finally
-        {
-            CryptographicOperations.ZeroMemory(currentKey);
-        }
+        ArgumentNullException.ThrowIfNull(request.FailureReason);
+        var failureHash = ComputeSha256Hex(request.FailureReason);
+        outputHash = request.Output is null ? null : ComputeSha256Hex(request.Output);
+        var outputSlot = outputHash ?? "null";
+        var failure = $"{request.ToolName}|{inputHash}|{outputSlot}|{failureHash}|{timestamp:O}";
+        return request.EgressDigest is null ? failure : $"{failure}|egress:{request.EgressDigest}";
     }
 
     /// <inheritdoc />

--- a/src/Content/Infrastructure/Infrastructure.AI/Sandbox/DockerSandboxExecutor.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Sandbox/DockerSandboxExecutor.cs
@@ -136,8 +136,8 @@ public sealed class DockerSandboxExecutor : ISandboxExecutor
             $"Invalid resource limits: CpuCoreLimit must be a positive number of cores (was {request.Limits.CpuCoreLimit}). " +
             "A non-positive value would map to NanoCPUs=0, which Docker treats as unlimited.";
 
-        var attestation = await _attestationService.SignFailureAsync(
-            request.ToolName, request.Input, errorMessage, ct);
+        var attestation = await _attestationService.SignAsync(
+            Domain.AI.Attestation.AttestationRequest.Failure(request.ToolName, request.Input, errorMessage), ct);
 
         return new SandboxExecutionResult
         {
@@ -172,9 +172,11 @@ public sealed class DockerSandboxExecutor : ISandboxExecutor
                 "Docker unavailable but tool {ToolName} requires container isolation. Refusing execution",
                 request.ToolName);
 
-            var attestation = await _attestationService.SignFailureAsync(
-                request.ToolName, request.Input,
-                "Container isolation required but Docker is unavailable", ct);
+            var attestation = await _attestationService.SignAsync(
+                Domain.AI.Attestation.AttestationRequest.Failure(
+                    request.ToolName, request.Input,
+                    "Container isolation required but Docker is unavailable"),
+                ct);
 
             return new SandboxExecutionResult
             {
@@ -348,8 +350,10 @@ public sealed class DockerSandboxExecutor : ISandboxExecutor
         // output exists does the legacy (output-less) failure shape apply.
         var failureReason = $"Container exited with code {exitCode}: {logs}";
         var attestation = output is not null
-            ? await _attestationService.SignFailureWithOutputAsync(
-                request.ToolName, request.Input, failureReason, output, egressDigest, ct)
+            ? await _attestationService.SignAsync(
+                Domain.AI.Attestation.AttestationRequest.Failure(
+                    request.ToolName, request.Input, failureReason, output: output, egressDigest: egressDigest),
+                ct)
             : await SignFailureAsync(
                 request.ToolName, request.Input, failureReason, egressDigest, ct);
 
@@ -396,11 +400,12 @@ public sealed class DockerSandboxExecutor : ISandboxExecutor
                 "Docker sandbox refused to spawn container for tool {ToolName}: egress preflight denied '{Host}'",
                 request.ToolName, denied.Target.Host);
 
-            var attestation = await _attestationService.SignFailureWithEgressAsync(
-                request.ToolName,
-                request.Input,
-                $"Egress preflight denied: {denied.Target} ({denied.Reason})",
-                digest,
+            var attestation = await _attestationService.SignAsync(
+                Domain.AI.Attestation.AttestationRequest.Failure(
+                    request.ToolName,
+                    request.Input,
+                    $"Egress preflight denied: {denied.Target} ({denied.Reason})",
+                    egressDigest: digest),
                 ct);
 
             return (new SandboxExecutionResult
@@ -416,19 +421,15 @@ public sealed class DockerSandboxExecutor : ISandboxExecutor
 
     private Task<Domain.AI.Attestation.ToolExecutionAttestation> SignFailureAsync(
         string toolName, string input, string failureReason, string? egressDigest, CancellationToken ct)
-    {
-        return egressDigest is null
-            ? _attestationService.SignFailureAsync(toolName, input, failureReason, ct)
-            : _attestationService.SignFailureWithEgressAsync(toolName, input, failureReason, egressDigest, ct);
-    }
+        => _attestationService.SignAsync(
+            Domain.AI.Attestation.AttestationRequest.Failure(toolName, input, failureReason, egressDigest: egressDigest),
+            ct);
 
     private Task<Domain.AI.Attestation.ToolExecutionAttestation> SignSuccessAsync(
         string toolName, string input, string output, string? egressDigest, CancellationToken ct)
-    {
-        return egressDigest is null
-            ? _attestationService.SignAsync(toolName, input, output, ct)
-            : _attestationService.SignWithEgressAsync(toolName, input, output, egressDigest, ct);
-    }
+        => _attestationService.SignAsync(
+            Domain.AI.Attestation.AttestationRequest.Success(toolName, input, output, egressDigest),
+            ct);
 
     /// <summary>
     /// Force-kills and removes the container on a dedicated cleanup token. The caller's

--- a/src/Content/Infrastructure/Infrastructure.AI/Sandbox/ProcessSandboxExecutor.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Sandbox/ProcessSandboxExecutor.cs
@@ -174,11 +174,12 @@ public sealed class ProcessSandboxExecutor : ISandboxExecutor
                 "Sandbox refused to spawn process for tool {ToolName}: egress preflight denied '{Host}'",
                 request.ToolName, denied.Target.Host);
 
-            var attestation = await _attestationService.SignFailureWithEgressAsync(
-                request.ToolName,
-                request.Input,
-                $"Egress preflight denied: {denied.Target} ({denied.Reason})",
-                digest,
+            var attestation = await _attestationService.SignAsync(
+                Domain.AI.Attestation.AttestationRequest.Failure(
+                    request.ToolName,
+                    request.Input,
+                    $"Egress preflight denied: {denied.Target} ({denied.Reason})",
+                    egressDigest: digest),
                 ct);
 
             return (new SandboxExecutionResult
@@ -194,19 +195,15 @@ public sealed class ProcessSandboxExecutor : ISandboxExecutor
 
     private Task<Domain.AI.Attestation.ToolExecutionAttestation> SignFailureAsync(
         string toolName, string input, string failureReason, string? egressDigest, CancellationToken ct)
-    {
-        return egressDigest is null
-            ? _attestationService.SignFailureAsync(toolName, input, failureReason, ct)
-            : _attestationService.SignFailureWithEgressAsync(toolName, input, failureReason, egressDigest, ct);
-    }
+        => _attestationService.SignAsync(
+            Domain.AI.Attestation.AttestationRequest.Failure(toolName, input, failureReason, egressDigest: egressDigest),
+            ct);
 
     private Task<Domain.AI.Attestation.ToolExecutionAttestation> SignSuccessAsync(
         string toolName, string input, string output, string? egressDigest, CancellationToken ct)
-    {
-        return egressDigest is null
-            ? _attestationService.SignAsync(toolName, input, output, ct)
-            : _attestationService.SignWithEgressAsync(toolName, input, output, egressDigest, ct);
-    }
+        => _attestationService.SignAsync(
+            Domain.AI.Attestation.AttestationRequest.Success(toolName, input, output, egressDigest),
+            ct);
 
     private Process StartProcess(SandboxExecutionRequest request, string workspaceDir)
     {
@@ -277,8 +274,8 @@ public sealed class ProcessSandboxExecutor : ISandboxExecutor
             $"Environment grant rejected: '{reservedGrant}' collides with a reserved variable " +
             "(pinned temp or security-critical) and cannot be overridden by per-request grants.";
 
-        var attestation = await _attestationService.SignFailureAsync(
-            request.ToolName, request.Input, errorMessage, ct);
+        var attestation = await _attestationService.SignAsync(
+            Domain.AI.Attestation.AttestationRequest.Failure(request.ToolName, request.Input, errorMessage), ct);
 
         return new SandboxExecutionResult
         {
@@ -397,9 +394,11 @@ public sealed class ProcessSandboxExecutor : ISandboxExecutor
         // The crash result carries the stdout produced before the failure, so that output
         // must be bound into the signed attestation — otherwise a stored result's Output
         // could diverge from the attested record without detection.
-        var attestation = await _attestationService.SignFailureWithOutputAsync(
-            request.ToolName, request.Input,
-            $"Process exited with code {exitCode}: {stderr}", stdout, egressDigest, ct);
+        var attestation = await _attestationService.SignAsync(
+            Domain.AI.Attestation.AttestationRequest.Failure(
+                request.ToolName, request.Input,
+                $"Process exited with code {exitCode}: {stderr}", output: stdout, egressDigest: egressDigest),
+            ct);
 
         return new SandboxExecutionResult
         {

--- a/src/Content/Tests/Infrastructure.AI.Tests/Attestation/HmacAttestationOutputBindingTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Attestation/HmacAttestationOutputBindingTests.cs
@@ -17,7 +17,7 @@ namespace Infrastructure.AI.Tests.Attestation;
 /// fields, so a <c>SandboxExecutionResult.Output</c> tampered after signing still "verified".
 /// Crash results carried output that the failure attestation never covered at all.
 /// These tests pin the output-bound verification path (<c>VerifyBoundAsync</c>) and the
-/// failure-with-output signing shape (<c>SignFailureWithOutputAsync</c>).
+/// failure-with-output signing shape (<c>AttestationRequest.Failure</c> with an output).
 /// </summary>
 public sealed class HmacAttestationOutputBindingTests
 {
@@ -47,7 +47,7 @@ public sealed class HmacAttestationOutputBindingTests
     public async Task VerifyBound_ActualOutputMatches_ReturnsTrue()
     {
         var service = CreateService();
-        var attestation = await service.SignAsync("calculator", "{\"a\":1}", "{\"result\":2}", CancellationToken.None);
+        var attestation = await service.SignAsync(AttestationRequest.Success("calculator", "{\"a\":1}", "{\"result\":2}"), CancellationToken.None);
 
         var result = await service.VerifyBoundAsync(attestation, "{\"result\":2}", CancellationToken.None);
 
@@ -58,7 +58,7 @@ public sealed class HmacAttestationOutputBindingTests
     public async Task VerifyBound_ActualOutputDiverges_ReturnsFalse()
     {
         var service = CreateService();
-        var attestation = await service.SignAsync("calculator", "{\"a\":1}", "{\"result\":2}", CancellationToken.None);
+        var attestation = await service.SignAsync(AttestationRequest.Success("calculator", "{\"a\":1}", "{\"result\":2}"), CancellationToken.None);
 
         // The gap this closes: signature-only verification cannot see the real output,
         // so a tampered stored output still passes VerifyAsync.
@@ -74,7 +74,7 @@ public sealed class HmacAttestationOutputBindingTests
     public async Task VerifyBound_NoOutputHashOnAttestation_ReturnsFalse()
     {
         var service = CreateService();
-        var attestation = await service.SignFailureAsync("calculator", "{\"a\":1}", "boom", CancellationToken.None);
+        var attestation = await service.SignAsync(AttestationRequest.Failure("calculator", "{\"a\":1}", "boom"), CancellationToken.None);
 
         var result = await service.VerifyBoundAsync(attestation, "any-output", CancellationToken.None);
 
@@ -86,8 +86,8 @@ public sealed class HmacAttestationOutputBindingTests
     {
         var service = CreateService();
 
-        var attestation = await service.SignFailureWithOutputAsync(
-            "compiler", "{\"src\":\"x\"}", "exit code 1", "partial diagnostics", egressDigest: null, CancellationToken.None);
+        var attestation = await service.SignAsync(
+            AttestationRequest.Failure("compiler", "{\"src\":\"x\"}", "exit code 1", output: "partial diagnostics"), CancellationToken.None);
 
         attestation.IsFailureAttestation.Should().BeTrue();
         attestation.FailureReason.Should().Be("exit code 1");
@@ -101,8 +101,8 @@ public sealed class HmacAttestationOutputBindingTests
     public async Task SignFailureWithOutput_TamperedOutputHash_FailsSignatureVerification()
     {
         var service = CreateService();
-        var attestation = await service.SignFailureWithOutputAsync(
-            "compiler", "{\"src\":\"x\"}", "exit code 1", "real output", egressDigest: null, CancellationToken.None);
+        var attestation = await service.SignAsync(
+            AttestationRequest.Failure("compiler", "{\"src\":\"x\"}", "exit code 1", output: "real output"), CancellationToken.None);
 
         var tampered = attestation with { OutputHash = Sha256Hex("forged output") };
 
@@ -117,8 +117,8 @@ public sealed class HmacAttestationOutputBindingTests
     {
         var service = CreateService();
 
-        var attestation = await service.SignFailureWithOutputAsync(
-            "fetcher", "{}", "exit code 7", "stdout before crash", egressDigest: "abc123", CancellationToken.None);
+        var attestation = await service.SignAsync(
+            AttestationRequest.Failure("fetcher", "{}", "exit code 7", output: "stdout before crash", egressDigest: "abc123"), CancellationToken.None);
 
         attestation.EgressDigest.Should().Be("abc123");
         (await service.VerifyAsync(attestation, CancellationToken.None)).Should().BeTrue();
@@ -131,7 +131,7 @@ public sealed class HmacAttestationOutputBindingTests
     public async Task LegacyFailureAttestation_WithoutOutputHash_StillVerifies()
     {
         var service = CreateService();
-        var legacy = await service.SignFailureAsync("calculator", "{\"a\":1}", "timed out", CancellationToken.None);
+        var legacy = await service.SignAsync(AttestationRequest.Failure("calculator", "{\"a\":1}", "timed out"), CancellationToken.None);
 
         legacy.OutputHash.Should().BeNull();
         var result = await service.VerifyAsync(legacy, CancellationToken.None);

--- a/src/Content/Tests/Infrastructure.AI.Tests/Attestation/HmacAttestationServiceTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Attestation/HmacAttestationServiceTests.cs
@@ -40,7 +40,7 @@ public sealed class HmacAttestationServiceTests
     {
         var service = CreateService();
 
-        var attestation = await service.SignAsync("calculator", "{\"a\":1}", "{\"result\":2}", CancellationToken.None);
+        var attestation = await service.SignAsync(AttestationRequest.Success("calculator", "{\"a\":1}", "{\"result\":2}"), CancellationToken.None);
 
         attestation.ToolName.Should().Be("calculator");
         attestation.InputHash.Should().NotBeNullOrEmpty().And.HaveLength(64);
@@ -56,7 +56,7 @@ public sealed class HmacAttestationServiceTests
     public async Task Verify_AcceptsValidSignature()
     {
         var service = CreateService();
-        var attestation = await service.SignAsync("calculator", "{\"a\":1}", "{\"result\":2}", CancellationToken.None);
+        var attestation = await service.SignAsync(AttestationRequest.Success("calculator", "{\"a\":1}", "{\"result\":2}"), CancellationToken.None);
 
         var result = await service.VerifyAsync(attestation, CancellationToken.None);
 
@@ -67,7 +67,7 @@ public sealed class HmacAttestationServiceTests
     public async Task Verify_RejectsTamperedOutput()
     {
         var service = CreateService();
-        var attestation = await service.SignAsync("calculator", "{\"a\":1}", "{\"result\":2}", CancellationToken.None);
+        var attestation = await service.SignAsync(AttestationRequest.Success("calculator", "{\"a\":1}", "{\"result\":2}"), CancellationToken.None);
 
         var tampered = attestation with
         {
@@ -83,7 +83,7 @@ public sealed class HmacAttestationServiceTests
     public async Task Verify_RejectsTamperedInput()
     {
         var service = CreateService();
-        var attestation = await service.SignAsync("calculator", "{\"a\":1}", "{\"result\":2}", CancellationToken.None);
+        var attestation = await service.SignAsync(AttestationRequest.Success("calculator", "{\"a\":1}", "{\"result\":2}"), CancellationToken.None);
 
         var tampered = attestation with
         {
@@ -99,7 +99,7 @@ public sealed class HmacAttestationServiceTests
     public async Task Verify_RejectsTamperedTimestamp()
     {
         var service = CreateService();
-        var attestation = await service.SignAsync("calculator", "{\"a\":1}", "{\"result\":2}", CancellationToken.None);
+        var attestation = await service.SignAsync(AttestationRequest.Success("calculator", "{\"a\":1}", "{\"result\":2}"), CancellationToken.None);
 
         var tampered = attestation with { Timestamp = attestation.Timestamp.AddSeconds(1) };
 
@@ -113,7 +113,7 @@ public sealed class HmacAttestationServiceTests
     {
         var service = CreateService();
 
-        var attestation = await service.SignFailureAsync("calculator", "{\"a\":1}", "OOM kill", CancellationToken.None);
+        var attestation = await service.SignAsync(AttestationRequest.Failure("calculator", "{\"a\":1}", "OOM kill"), CancellationToken.None);
 
         attestation.OutputHash.Should().BeNull();
         attestation.IsFailureAttestation.Should().BeTrue();
@@ -138,7 +138,7 @@ public sealed class HmacAttestationServiceTests
             ]
         };
         var serviceV1 = CreateService(optionsV1);
-        var attestation = await serviceV1.SignAsync("calculator", "{\"a\":1}", "{\"result\":2}", CancellationToken.None);
+        var attestation = await serviceV1.SignAsync(AttestationRequest.Success("calculator", "{\"a\":1}", "{\"result\":2}"), CancellationToken.None);
         attestation.KeyVersion.Should().Be("v1");
 
         var optionsV2 = new AttestationKeyOptions
@@ -171,7 +171,7 @@ public sealed class HmacAttestationServiceTests
         };
         var service = CreateService(options);
 
-        var attestation = await service.SignAsync("calculator", "{\"a\":1}", "{\"result\":2}", CancellationToken.None);
+        var attestation = await service.SignAsync(AttestationRequest.Success("calculator", "{\"a\":1}", "{\"result\":2}"), CancellationToken.None);
 
         attestation.KeyVersion.Should().Be("v2");
     }
@@ -210,7 +210,7 @@ public sealed class HmacAttestationServiceTests
     public async Task Verify_ReturnsFalse_WhenKeyVersionRetired()
     {
         var service = CreateService();
-        var attestation = await service.SignAsync("calc", "{}", "{}", CancellationToken.None);
+        var attestation = await service.SignAsync(AttestationRequest.Success("calc", "{}", "{}"), CancellationToken.None);
 
         var retiredOptions = new AttestationKeyOptions
         {
@@ -228,7 +228,7 @@ public sealed class HmacAttestationServiceTests
     public async Task Verify_RejectsTamperedFailureReason()
     {
         var service = CreateService();
-        var attestation = await service.SignFailureAsync("calculator", "{\"a\":1}", "OOM kill", CancellationToken.None);
+        var attestation = await service.SignAsync(AttestationRequest.Failure("calculator", "{\"a\":1}", "OOM kill"), CancellationToken.None);
 
         var tampered = attestation with { FailureReason = "Permission denied" };
 

--- a/src/Content/Tests/Infrastructure.AI.Tests/Planner/StepExecutors/ToolUseStepExecutorAttestationBindingTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Planner/StepExecutors/ToolUseStepExecutorAttestationBindingTests.cs
@@ -2,6 +2,7 @@ using System.Security.Cryptography;
 using Application.AI.Common.Interfaces.Governance;
 using Application.AI.Common.Interfaces.Planner;
 using Application.AI.Common.Interfaces.Sandbox;
+using Domain.AI.Attestation;
 using Domain.AI.Governance;
 using Domain.AI.Planner;
 using Domain.AI.Sandbox;
@@ -90,7 +91,7 @@ public sealed class ToolUseStepExecutorAttestationBindingTests
     {
         // A valid signature over "genuine-output" — then the result's Output diverges.
         var attestation = await _attestationService.SignAsync(
-            "file_system", "{}", "genuine-output", CancellationToken.None);
+            AttestationRequest.Success("file_system", "{}", "genuine-output"), CancellationToken.None);
 
         _sandboxExecutor.Setup(s => s.ExecuteAsync(It.IsAny<SandboxExecutionRequest>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new SandboxExecutionResult
@@ -111,7 +112,7 @@ public sealed class ToolUseStepExecutorAttestationBindingTests
     public async Task ExecuteAsync_OutputMatchesSignedBytes_ReturnsCompleted()
     {
         var attestation = await _attestationService.SignAsync(
-            "file_system", "{}", "genuine-output", CancellationToken.None);
+            AttestationRequest.Success("file_system", "{}", "genuine-output"), CancellationToken.None);
 
         _sandboxExecutor.Setup(s => s.ExecuteAsync(It.IsAny<SandboxExecutionRequest>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new SandboxExecutionResult
@@ -134,8 +135,8 @@ public sealed class ToolUseStepExecutorAttestationBindingTests
         // Output-less failure attestations (timeout, spawn refusal) have no OutputHash to
         // bind against — signature-only verification still applies, and the step reports
         // the sandbox failure, not an attestation failure.
-        var attestation = await _attestationService.SignFailureAsync(
-            "file_system", "{}", "Process timed out", CancellationToken.None);
+        var attestation = await _attestationService.SignAsync(
+            AttestationRequest.Failure("file_system", "{}", "Process timed out"), CancellationToken.None);
 
         _sandboxExecutor.Setup(s => s.ExecuteAsync(It.IsAny<SandboxExecutionRequest>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new SandboxExecutionResult

--- a/src/Content/Tests/Infrastructure.AI.Tests/Sandbox/DockerSandboxExecutorHardeningTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Sandbox/DockerSandboxExecutorHardeningTests.cs
@@ -64,16 +64,9 @@ public class DockerSandboxExecutorHardeningTests
             .Returns(Task.CompletedTask);
 
         _attestation
-            .Setup(x => x.SignAsync(It.IsAny<string>(), It.IsAny<string>(),
-                It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((string tool, string _, string __, CancellationToken ___) =>
-                CreateAttestation(tool, false));
-
-        _attestation
-            .Setup(x => x.SignFailureAsync(It.IsAny<string>(), It.IsAny<string>(),
-                It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((string tool, string _, string reason, CancellationToken ___) =>
-                CreateAttestation(tool, true, reason));
+            .Setup(x => x.SignAsync(It.IsAny<AttestationRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((AttestationRequest r, CancellationToken _) =>
+                CreateAttestation(r.ToolName, r.IsFailure, r.FailureReason));
 
         _options.Setup(x => x.CurrentValue).Returns(new SandboxExecutionOptions());
 

--- a/src/Content/Tests/Infrastructure.AI.Tests/Sandbox/DockerSandboxExecutorSolutionReviewFixTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Sandbox/DockerSandboxExecutorSolutionReviewFixTests.cs
@@ -93,8 +93,7 @@ public class DockerSandboxExecutorSolutionReviewFixTests
     {
         _sandboxConfig.Setup(x => x.CurrentValue).Returns(new SandboxConfig { Enabled = true });
         _attestation
-            .Setup(x => x.SignAsync(It.IsAny<string>(), It.IsAny<string>(),
-                It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Setup(x => x.SignAsync(It.IsAny<Domain.AI.Attestation.AttestationRequest>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(CreateAttestation("test_tool", isFailure: false));
         var sut = CreateSut();
         var request = CreateRequest();

--- a/src/Content/Tests/Infrastructure.AI.Tests/Sandbox/DockerSandboxExecutorTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Sandbox/DockerSandboxExecutorTests.cs
@@ -58,16 +58,9 @@ public class DockerSandboxExecutorTests
             .Returns(Task.CompletedTask);
 
         _attestation
-            .Setup(x => x.SignAsync(It.IsAny<string>(), It.IsAny<string>(),
-                It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((string tool, string _, string __, CancellationToken ___) =>
-                CreateAttestation(tool, false));
-
-        _attestation
-            .Setup(x => x.SignFailureAsync(It.IsAny<string>(), It.IsAny<string>(),
-                It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((string tool, string _, string reason, CancellationToken ___) =>
-                CreateAttestation(tool, true, reason));
+            .Setup(x => x.SignAsync(It.IsAny<AttestationRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((AttestationRequest r, CancellationToken _) =>
+                CreateAttestation(r.ToolName, r.IsFailure, r.FailureReason));
 
         _options.Setup(x => x.CurrentValue).Returns(new SandboxExecutionOptions());
 

--- a/src/Content/Tests/Infrastructure.AI.Tests/Sandbox/ProcessSandboxEnvironmentIsolationTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Sandbox/ProcessSandboxEnvironmentIsolationTests.cs
@@ -32,18 +32,10 @@ public class ProcessSandboxEnvironmentIsolationTests
             .Returns(true);
 
         _attestation
-            .Setup(x => x.SignAsync(
-                It.IsAny<string>(), It.IsAny<string>(),
-                It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((string tool, string _, string __, CancellationToken ___) =>
-                CreateAttestation(tool));
-
-        _attestation
-            .Setup(x => x.SignFailureAsync(
-                It.IsAny<string>(), It.IsAny<string>(),
-                It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((string tool, string _, string reason, CancellationToken ___) =>
-                CreateAttestation(tool) with { IsFailureAttestation = true, OutputHash = null, FailureReason = reason });
+            .Setup(x => x.SignAsync(It.IsAny<AttestationRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((AttestationRequest r, CancellationToken _) => r.IsFailure
+                ? CreateAttestation(r.ToolName) with { IsFailureAttestation = true, OutputHash = null, FailureReason = r.FailureReason }
+                : CreateAttestation(r.ToolName));
 
         _sandboxConfig.Setup(x => x.CurrentValue).Returns(new SandboxConfig());
     }

--- a/src/Content/Tests/Infrastructure.AI.Tests/Sandbox/ProcessSandboxExecutorTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Sandbox/ProcessSandboxExecutorTests.cs
@@ -25,25 +25,9 @@ public class ProcessSandboxExecutorTests : IDisposable
         _limiter.Setup(x => x.IsSupported).Returns(true);
 
         _attestation
-            .Setup(x => x.SignAsync(
-                It.IsAny<string>(), It.IsAny<string>(),
-                It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((string tool, string _, string __, CancellationToken ___) =>
-                CreateAttestation(tool, isFailure: false));
-
-        _attestation
-            .Setup(x => x.SignFailureAsync(
-                It.IsAny<string>(), It.IsAny<string>(),
-                It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((string tool, string _, string reason, CancellationToken ___) =>
-                CreateAttestation(tool, isFailure: true, failureReason: reason));
-
-        _attestation
-            .Setup(x => x.SignFailureWithOutputAsync(
-                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
-                It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((string tool, string _, string reason, string __, string? ___, CancellationToken ____) =>
-                CreateAttestation(tool, isFailure: true, failureReason: reason));
+            .Setup(x => x.SignAsync(It.IsAny<AttestationRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((AttestationRequest r, CancellationToken _) =>
+                CreateAttestation(r.ToolName, isFailure: r.IsFailure, failureReason: r.FailureReason));
 
         var sandboxConfig = new Mock<IOptionsMonitor<SandboxConfig>>();
         sandboxConfig.Setup(x => x.CurrentValue).Returns(new SandboxConfig());

--- a/src/Content/Tests/Infrastructure.AI.Tests/Sandbox/SandboxAttestationBindingTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Sandbox/SandboxAttestationBindingTests.cs
@@ -49,17 +49,10 @@ public class SandboxAttestationBindingTests
                 .Returns(true);
 
             _attestation
-                .Setup(x => x.SignFailureWithOutputAsync(
-                    It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
-                    It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync((string tool, string _, string __, string ___, string? ____, CancellationToken _____) =>
-                    CreateAttestation(tool, isFailure: true, outputHash: "bound-hash"));
-
-            _attestation
-                .Setup(x => x.SignFailureAsync(
-                    It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync((string tool, string _, string __, CancellationToken ___) =>
-                    CreateAttestation(tool, isFailure: true));
+                .Setup(x => x.SignAsync(It.IsAny<AttestationRequest>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((AttestationRequest r, CancellationToken _) =>
+                    CreateAttestation(r.ToolName, isFailure: r.IsFailure,
+                        outputHash: r.Output is not null ? "bound-hash" : null));
 
             var sandboxConfig = new Mock<IOptionsMonitor<SandboxConfig>>();
             sandboxConfig.Setup(x => x.CurrentValue).Returns(new SandboxConfig());
@@ -98,12 +91,12 @@ public class SandboxAttestationBindingTests
             result.ExitCode.Should().Be(3);
             result.Output.Should().Contain("crash-stdout-data");
 
-            _attestation.Verify(x => x.SignFailureWithOutputAsync(
-                    "test_tool",
-                    It.IsAny<string>(),
-                    It.IsAny<string>(),
-                    It.Is<string>(o => o == result.Output),
-                    null,
+            _attestation.Verify(x => x.SignAsync(
+                    It.Is<AttestationRequest>(r =>
+                        r.ToolName == "test_tool"
+                        && r.IsFailure
+                        && r.Output == result.Output
+                        && r.EgressDigest == null),
                     It.IsAny<CancellationToken>()),
                 Times.Once,
                 "the crash output returned to the caller must be the exact bytes bound into the attestation");
@@ -156,17 +149,10 @@ public class SandboxAttestationBindingTests
                 .Returns(Task.CompletedTask);
 
             _attestation
-                .Setup(x => x.SignFailureWithOutputAsync(
-                    It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
-                    It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync((string tool, string _, string __, string ___, string? ____, CancellationToken _____) =>
-                    CreateAttestation(tool, isFailure: true, outputHash: "bound-hash"));
-
-            _attestation
-                .Setup(x => x.SignFailureAsync(
-                    It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync((string tool, string _, string __, CancellationToken ___) =>
-                    CreateAttestation(tool, isFailure: true));
+                .Setup(x => x.SignAsync(It.IsAny<AttestationRequest>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((AttestationRequest r, CancellationToken _) =>
+                    CreateAttestation(r.ToolName, isFailure: r.IsFailure,
+                        outputHash: r.Output is not null ? "bound-hash" : null));
 
             _options.Setup(x => x.CurrentValue).Returns(new SandboxExecutionOptions());
 
@@ -199,12 +185,12 @@ public class SandboxAttestationBindingTests
             result.Success.Should().BeFalse();
             result.Output.Should().Be(producedOutput);
 
-            _attestation.Verify(x => x.SignFailureWithOutputAsync(
-                    "test_tool",
-                    It.IsAny<string>(),
-                    It.IsAny<string>(),
-                    producedOutput,
-                    null,
+            _attestation.Verify(x => x.SignAsync(
+                    It.Is<AttestationRequest>(r =>
+                        r.ToolName == "test_tool"
+                        && r.IsFailure
+                        && r.Output == producedOutput
+                        && r.EgressDigest == null),
                     It.IsAny<CancellationToken>()),
                 Times.Once,
                 "the workspace output returned on a container crash must be bound into the attestation");
@@ -221,12 +207,14 @@ public class SandboxAttestationBindingTests
             result.Success.Should().BeFalse();
             result.Output.Should().BeNull();
 
-            _attestation.Verify(x => x.SignFailureAsync(
-                    "test_tool", It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            _attestation.Verify(x => x.SignAsync(
+                    It.Is<AttestationRequest>(r =>
+                        r.ToolName == "test_tool" && r.IsFailure && r.Output == null),
+                    It.IsAny<CancellationToken>()),
                 Times.Once);
-            _attestation.Verify(x => x.SignFailureWithOutputAsync(
-                    It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
-                    It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()),
+            _attestation.Verify(x => x.SignAsync(
+                    It.Is<AttestationRequest>(r => r.IsFailure && r.Output != null),
+                    It.IsAny<CancellationToken>()),
                 Times.Never,
                 "when no output was produced there is nothing to bind — the legacy failure shape applies");
         }


### PR DESCRIPTION
Wave 4 (consolidation) — A6 follow-up from PR #131. Behavior-preserving refactor.

## Change
`IAttestationService` exposed 5 `Sign*` overloads (`SignAsync`, `SignFailureAsync`, `SignWithEgressAsync`, `SignFailureWithEgressAsync`, `SignFailureWithOutputAsync`) called from ~30 sites. Consolidated to one:
```csharp
Task<ToolExecutionAttestation> SignAsync(AttestationRequest request, CancellationToken ct);
```
Backed by a new immutable `Domain.AI.Attestation.AttestationRequest` record (`ToolName`, `Input`, `IsFailure`, `Output?`, `FailureReason?`, `EgressDigest?`) with `Success(...)`/`Failure(...)` factories.

## Why safe (HMAC payload byte-identity verified)
A private `BuildSigningPayload` reproduces all 5 original payload shapes exactly, dispatching on `IsFailure` + `Output` presence + `EgressDigest` presence:
- success ±egress → `{tool}|{in}|{out}|{ts}`(`|egress:…`)
- failure/no-output ±egress → `{tool}|{in}|null|{failHash}|{ts}`(`|egress:…`)
- failure/with-output ±egress → `{tool}|{in}|{out}|{failHash}|{ts}`(`|egress:…`)

Attestation field population (OutputHash/FailureReason/EgressDigest/IsFailureAttestation) is identical; `BuildVerificationPayload`/`Verify*` are untouched, so legacy attestations still verify. HMAC key still zeroed in `finally`.

## Verification
- `Infrastructure.AI.Tests` (Attestation|Sandbox|ToolUseStepExecutor filter): 103 passed before and after, 0 warnings.
- gitnexus_impact: LOW, 0 execution flows affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)