### PR TITLE
fix: reconcile typed HttpClient timeouts and guard ResolveTotalTimeout overflow

### DIFF
--- a/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.Caching.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.Caching.cs
@@ -8,8 +8,6 @@ namespace Infrastructure.AI;
 
 public static partial class DependencyInjection
 {
-    private const int GenerationStatsTimeoutSeconds = 30;
-
     /// <summary>
     /// Registers the <see cref="IGenerationStatsClient"/> used to fetch out-of-band prompt-cache
     /// telemetry, but only on the OpenRouter path with prompt caching enabled — the one shape where
@@ -44,7 +42,12 @@ public static partial class DependencyInjection
         services.AddHttpClient<IGenerationStatsClient, OpenRouterGenerationStatsClient>(client =>
         {
             client.BaseAddress = new Uri(baseAddress);
-            client.Timeout = TimeSpan.FromSeconds(GenerationStatsTimeoutSeconds);
+            // The harness resilience pipeline (attached to every factory-created client by
+            // AddDefaultHttpClient) owns BOTH the per-attempt and the total timeout. A finite
+            // HttpClient.Timeout here would race that pipeline and could truncate the retry
+            // budget mid-attempt, so the client timeout is left infinite — consistent with the
+            // default (non-typed) clients.
+            client.Timeout = Timeout.InfiniteTimeSpan;
             if (!string.IsNullOrWhiteSpace(apiKey))
                 client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", apiKey);
         });

--- a/src/Content/Infrastructure/Infrastructure.APIAccess/Common/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Content/Infrastructure/Infrastructure.APIAccess/Common/Extensions/IServiceCollectionExtensions.cs
@@ -381,18 +381,39 @@ public static class IServiceCollectionExtensions
     /// <c>(HttpRetry.Count + 1) × per-attempt timeout</c> plus exponential-backoff headroom
     /// (<c>Delay × 2^Count</c>), capped at 24 hours (Polly's strategy maximum).
     /// </summary>
-    private static TimeSpan ResolveTotalTimeout(HttpPolicyConfig policies)
+    internal static TimeSpan ResolveTotalTimeout(HttpPolicyConfig policies)
     {
         if (policies.HttpTimeout.TotalTimeout is { } configured)
             return configured;
 
-        var attempts = policies.HttpRetry.Count + 1;
-        var backoffFactor = 1L << Math.Min(policies.HttpRetry.Count, 10);
-        var computed = TimeSpan.FromTicks(policies.HttpTimeout.Timeout.Ticks * attempts)
-            + TimeSpan.FromTicks(policies.HttpRetry.Delay.Ticks * backoffFactor);
-
         var max = TimeSpan.FromHours(24);
-        return computed < max ? computed : max;
+
+        // Clamp the retry count defensively before it drives any arithmetic: a negative or absurd
+        // value (config binding does not cap it) would otherwise overflow the (Count + 1) attempt
+        // multiplier or the 1 << Count backoff shift. 30 is far beyond any sane retry budget and
+        // any resulting duration is capped at `max` regardless.
+        var count = Math.Clamp(policies.HttpRetry.Count, 0, 30);
+        var attempts = count + 1L;
+        var backoffFactor = 1L << Math.Min(count, 10);
+
+        try
+        {
+            // `checked` promotes the tick multiplications to overflow-throwing; TimeSpan addition
+            // already throws on overflow. A pathological per-attempt timeout or delay therefore
+            // surfaces as OverflowException rather than silently wrapping to a negative budget.
+            var computed = checked(
+                TimeSpan.FromTicks(policies.HttpTimeout.Timeout.Ticks * attempts)
+                + TimeSpan.FromTicks(policies.HttpRetry.Delay.Ticks * backoffFactor));
+
+            // A non-positive result means the config itself is nonsensical (e.g. a negative
+            // per-attempt timeout); fall back to the strategy maximum rather than handing Polly a
+            // zero/negative budget that would fail every request instantly.
+            return computed > TimeSpan.Zero && computed < max ? computed : max;
+        }
+        catch (OverflowException)
+        {
+            return max;
+        }
     }
 
     /// <summary>

--- a/src/Content/Infrastructure/Infrastructure.APIAccess/Infrastructure.APIAccess.csproj
+++ b/src/Content/Infrastructure/Infrastructure.APIAccess/Infrastructure.APIAccess.csproj
@@ -19,6 +19,12 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- Exposes internal helpers (e.g. ResolveTotalTimeout) to the unit-test assembly so
+         the resilience-pipeline timeout arithmetic can be asserted directly. -->
+    <InternalsVisibleTo Include="Infrastructure.APIAccess.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\Application\Application.Common\Application.Common.csproj" />
     <ProjectReference Include="..\Infrastructure.Common\Infrastructure.Common.csproj" />
   </ItemGroup>

--- a/src/Content/Presentation/Presentation.AgentHub/Config/PrometheusConfig.cs
+++ b/src/Content/Presentation/Presentation.AgentHub/Config/PrometheusConfig.cs
@@ -9,9 +9,6 @@ public sealed record PrometheusConfig
     /// <summary>Base URL of the Prometheus server (e.g. <c>http://localhost:9090</c>).</summary>
     public string BaseUrl { get; init; } = "http://localhost:9090";
 
-    /// <summary>HTTP request timeout in seconds for Prometheus API calls.</summary>
-    public int TimeoutSeconds { get; init; } = 30;
-
     /// <summary>
     /// When <c>true</c>, serves synthetic demo data instead of querying Prometheus.
     /// Useful for template consumers previewing the dashboard without infrastructure.

--- a/src/Content/Presentation/Presentation.AgentHub/DependencyInjection.cs
+++ b/src/Content/Presentation/Presentation.AgentHub/DependencyInjection.cs
@@ -202,7 +202,12 @@ public static class DependencyInjection
             {
                 var config = sp.GetRequiredService<IOptions<PrometheusConfig>>().Value;
                 client.BaseAddress = new Uri(config.BaseUrl.TrimEnd('/') + '/');
-                client.Timeout = TimeSpan.FromSeconds(config.TimeoutSeconds);
+                // The harness resilience pipeline (attached to every factory-created client by
+                // AddDefaultHttpClient) owns BOTH the per-attempt and the total timeout. A finite
+                // HttpClient.Timeout here would race that pipeline and could truncate the retry
+                // budget mid-attempt, so the client timeout is left infinite — consistent with the
+                // default (non-typed) clients.
+                client.Timeout = Timeout.InfiniteTimeSpan;
             });
         }
 

--- a/src/Content/Presentation/Presentation.AgentHub/appsettings.json
+++ b/src/Content/Presentation/Presentation.AgentHub/appsettings.json
@@ -304,7 +304,6 @@
     },
     "Prometheus": {
       "BaseUrl": "http://localhost:9090",
-      "TimeoutSeconds": 30,
       "EnableDemoData": false
     },
     "Logging": {

--- a/src/Content/Tests/Infrastructure.AI.Tests/DependencyInjectionTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/DependencyInjectionTests.cs
@@ -203,6 +203,32 @@ public sealed class DependencyInjectionTests
         channels.Should().NotContain(c => c.GetType() == typeof(CompositeEscalationNotifier));
     }
 
+    [Fact]
+    public void RegisterGenerationStatsClient_OpenRouterPath_LeavesTypedClientTimeoutInfinite()
+    {
+        // The OpenRouter generation-stats client is a typed HttpClient created via the factory, so
+        // it inherits the harness resilience pipeline (per-attempt + total timeout). A finite
+        // HttpClient.Timeout would race that pipeline and could truncate the retry budget
+        // mid-attempt; the registration must leave the client timeout infinite so the pipeline
+        // owns the budget — consistent with the default (non-typed) clients.
+        var config = new AppConfig();
+        config.AI.AgentFramework.ClientType = Domain.Common.Config.AI.AIAgentFrameworkClientType.OpenAI;
+        config.AI.AgentFramework.EnablePromptCaching = true;
+        config.AI.AgentFramework.Endpoint = "https://openrouter.ai/api/v1";
+        config.AI.AgentFramework.ApiKey = "test-key";
+
+        var services = CreateBaseServices(config);
+        services.AddInfrastructureAIDependencies(config);
+        using var provider = services.BuildServiceProvider();
+
+        var factory = provider.GetRequiredService<IHttpClientFactory>();
+        var client = factory.CreateClient(nameof(IGenerationStatsClient));
+
+        client.Timeout.Should().Be(
+            Timeout.InfiniteTimeSpan,
+            "the resilience pipeline owns the timeout; the typed client must not set a finite one that races it");
+    }
+
     /// <summary>
     /// Minimal IOptionsMonitor stub that returns a fixed value.
     /// </summary>

--- a/src/Content/Tests/Infrastructure.APIAccess.Tests/Common/Extensions/ResolveTotalTimeoutTests.cs
+++ b/src/Content/Tests/Infrastructure.APIAccess.Tests/Common/Extensions/ResolveTotalTimeoutTests.cs
@@ -1,0 +1,101 @@
+using Domain.Common.Config.Http.Policies;
+using FluentAssertions;
+using ApiAccessExtensions = Infrastructure.APIAccess.Common.Extensions.IServiceCollectionExtensions;
+using Xunit;
+
+namespace Infrastructure.APIAccess.Tests.Common.Extensions;
+
+/// <summary>
+/// Unit tests for the resilience pipeline's total-timeout resolution
+/// (<c>IServiceCollectionExtensions.ResolveTotalTimeout</c>). The computed path multiplies the
+/// per-attempt timeout by the attempt count and adds exponential-backoff headroom; with
+/// pathological config values (an enormous per-attempt timeout/delay, or an absurd retry count)
+/// the tick arithmetic can overflow <see cref="long"/> and wrap NEGATIVE, which then slips past
+/// the <c>computed &lt; max</c> comparison and hands Polly a negative total timeout. These tests
+/// pin the overflow guard: the resolved timeout must always be a positive value no greater than
+/// the 24-hour strategy maximum.
+/// </summary>
+public sealed class ResolveTotalTimeoutTests
+{
+    private static readonly TimeSpan Max = TimeSpan.FromHours(24);
+
+    [Fact]
+    public void ResolveTotalTimeout_ConfiguredTotalTimeout_IsReturnedVerbatim()
+    {
+        var policies = new HttpPolicyConfig
+        {
+            HttpTimeout = new HttpTimeoutPolicyConfig
+            {
+                Timeout = TimeSpan.FromSeconds(30),
+                TotalTimeout = TimeSpan.FromMinutes(5),
+            },
+        };
+
+        ApiAccessExtensions.ResolveTotalTimeout(policies)
+            .Should().Be(TimeSpan.FromMinutes(5),
+                "an explicitly configured TotalTimeout must win over the computed budget");
+    }
+
+    [Fact]
+    public void ResolveTotalTimeout_DefaultConfig_ComputesBoundedBudget()
+    {
+        // Defaults: 3 retries (4 attempts), 30s per attempt, 2s base delay, backoff 2^3 = 8.
+        // => 4*30s + 2s*8 = 120s + 16s = 136s.
+        var policies = new HttpPolicyConfig();
+
+        var resolved = ApiAccessExtensions.ResolveTotalTimeout(policies);
+
+        resolved.Should().Be(TimeSpan.FromSeconds(136));
+        resolved.Should().BeGreaterThan(TimeSpan.Zero).And.BeLessThanOrEqualTo(Max);
+    }
+
+    [Fact]
+    public void ResolveTotalTimeout_PathologicalPerAttemptTimeout_ClampsToMaxWithoutOverflowing()
+    {
+        // A per-attempt timeout at TimeSpan.MaxValue plus any backoff headroom overflows the
+        // TimeSpan tick arithmetic. Unguarded this throws OverflowException; the guard must
+        // fall back to the strategy maximum instead.
+        var policies = new HttpPolicyConfig
+        {
+            HttpTimeout = new HttpTimeoutPolicyConfig { Timeout = TimeSpan.MaxValue },
+            HttpRetry = new HttpRetryPolicyConfig { Count = 0, Delay = TimeSpan.FromSeconds(2) },
+        };
+
+        var resolved = ApiAccessExtensions.ResolveTotalTimeout(policies);
+
+        resolved.Should().BePositive("a resolved timeout must never be negative");
+        resolved.Should().BeLessThanOrEqualTo(Max, "the budget is capped at the 24-hour strategy maximum");
+    }
+
+    [Fact]
+    public void ResolveTotalTimeout_PathologicalDelay_ClampsToMaxWithoutOverflowing()
+    {
+        var policies = new HttpPolicyConfig
+        {
+            HttpTimeout = new HttpTimeoutPolicyConfig { Timeout = TimeSpan.FromSeconds(1) },
+            HttpRetry = new HttpRetryPolicyConfig { Count = 0, Delay = TimeSpan.MaxValue },
+        };
+
+        var resolved = ApiAccessExtensions.ResolveTotalTimeout(policies);
+
+        resolved.Should().BePositive();
+        resolved.Should().BeLessThanOrEqualTo(Max);
+    }
+
+    [Fact]
+    public void ResolveTotalTimeout_PathologicalRetryCount_ClampsToMaxWithoutOverflowing()
+    {
+        // Count = int.MaxValue makes (Count + 1) overflow int to a negative attempt multiplier,
+        // producing a negative product against the per-attempt tick count.
+        var policies = new HttpPolicyConfig
+        {
+            HttpTimeout = new HttpTimeoutPolicyConfig { Timeout = TimeSpan.FromSeconds(30) },
+            HttpRetry = new HttpRetryPolicyConfig { Count = int.MaxValue, Delay = TimeSpan.FromSeconds(2) },
+        };
+
+        var resolved = ApiAccessExtensions.ResolveTotalTimeout(policies);
+
+        resolved.Should().BePositive();
+        resolved.Should().BeLessThanOrEqualTo(Max);
+    }
+}

--- a/src/Content/Tests/Presentation.AgentHub.Tests/Services/PrometheusHttpClientTimeoutTests.cs
+++ b/src/Content/Tests/Presentation.AgentHub.Tests/Services/PrometheusHttpClientTimeoutTests.cs
@@ -1,0 +1,37 @@
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Presentation.AgentHub.Interfaces;
+using Xunit;
+
+namespace Presentation.AgentHub.Tests.Services;
+
+/// <summary>
+/// Verifies the Prometheus typed <see cref="System.Net.Http.HttpClient"/> follows the harness
+/// resilience pipeline's timeout model. Because the typed client is created via
+/// <see cref="System.Net.Http.IHttpClientFactory"/> it inherits the resilience pipeline
+/// (per-attempt + total timeout) attached to every factory-created client by
+/// <c>AddDefaultHttpClient</c>. A finite <c>HttpClient.Timeout</c> would race that pipeline and
+/// could truncate the retry budget mid-attempt, so the registration must leave the client timeout
+/// infinite — consistent with the default (non-typed) clients.
+/// </summary>
+public sealed class PrometheusHttpClientTimeoutTests : IClassFixture<TestWebApplicationFactory>
+{
+    private readonly TestWebApplicationFactory _factory;
+
+    public PrometheusHttpClientTimeoutTests(TestWebApplicationFactory factory) => _factory = factory;
+
+    [Fact]
+    public void PrometheusTypedClient_TimeoutIsInfinite_SoResiliencePipelineOwnsIt()
+    {
+        var httpClientFactory = _factory.Services.GetRequiredService<IHttpClientFactory>();
+
+        // The typed-client logical name for AddHttpClient<TClient, TImplementation> is the
+        // TClient type name.
+        var client = httpClientFactory.CreateClient(nameof(IPrometheusQueryService));
+
+        client.Timeout.Should().Be(
+            Timeout.InfiniteTimeSpan,
+            "the resilience pipeline owns the timeout; the typed Prometheus client must not set a " +
+            "finite one that races it");
+    }
+}


### PR DESCRIPTION
Wave 4 (consolidation) — F3 follow-up from PR #137.

## Two fixes
1. **Typed-client timeout race:** The OpenRouter stats client (`DependencyInjection.Caching.cs`) and Prometheus client (`Presentation.AgentHub/DependencyInjection.cs`) are factory-created typed clients, so they inherit the resilience pipeline attached by `AddDefaultHttpClient` (#137) — but kept a finite `client.Timeout` that races the pipeline's per-attempt + total timeout. #137 set the default clients to `Timeout.InfiniteTimeSpan`; these two were missed. Both set to Infinite so the pipeline owns timeout. Both are read-only GET clients. Removed the now-orphaned `PrometheusConfig.TimeoutSeconds` field + appsettings entry and the `GenerationStatsTimeoutSeconds` const (they existed only to feed the racing timeout).
2. **`ResolveTotalTimeout` overflow:** With pathological config (`Count=int.MaxValue` → negative duration; `Timeout`/`Delay = TimeSpan.MaxValue` → `OverflowException`). Now clamps count to [0,30], uses `checked` tick arithmetic, catches `OverflowException` and falls back to the 24h strategy max, and treats non-positive results as nonsensical → max.

## Verification
- New tests (all red→green where applicable): `ResolveTotalTimeoutTests` (5), `RegisterGenerationStatsClient_OpenRouterPath_LeavesTypedClientTimeoutInfinite`, `PrometheusTypedClient_TimeoutIsInfinite_SoResiliencePipelineOwnsIt`.
- Infrastructure.APIAccess.Tests 152, Infrastructure.AI.Tests (DI) 34, Presentation.AgentHub.Tests (Config+Prometheus) 24 — all pass, 0 warnings.
- Did NOT touch the shared `DependencyInjection.Governance.cs`. gitnexus_impact LOW.

🤖 Generated with [Claude Code](https://claude.com/claude-code)