### PR TITLE
fix: rank web-fallback results on one scale + preserve feedback blending

### DIFF
--- a/src/Content/Infrastructure/Infrastructure.AI.RAG/Orchestration/RagOrchestrator.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.RAG/Orchestration/RagOrchestrator.cs
@@ -349,7 +349,7 @@ public sealed partial class RagOrchestrator : IRagOrchestrator
                     _logger.LogInformation(
                         "CRAG web fallback: score={Score:F2}, augmenting with web search results",
                         evaluation.RelevanceScore);
-                    var augmented = await AppendWebResultsAsync(
+                    var augmented = await MergeAndRerankWebResultsAsync(
                         currentQuery, reranked, topK, cancellationToken);
                     return await _contextAssembler.AssembleAsync(
                         augmented, DefaultMaxTokens, cancellationToken);
@@ -544,11 +544,21 @@ public sealed partial class RagOrchestrator : IRagOrchestrator
     }
 
     /// <summary>
-    /// Invokes the web-search retrieval source and appends its results to the existing reranked set
-    /// (ranks continue after the local results). Returns the original set unchanged when web search
-    /// yields nothing.
+    /// Invokes the web-search retrieval source, merges its results with the existing reranked local
+    /// set, and re-ranks the combined candidate pool through the configured <see cref="IReranker"/> so
+    /// local and web hits are scored on a single comparable scale before assembly. Returns the original
+    /// set unchanged when web search yields nothing.
     /// </summary>
-    private async Task<IReadOnlyList<RerankedResult>> AppendWebResultsAsync(
+    /// <remarks>
+    /// The <see cref="IRagContextAssembler"/> orders purely by <see cref="RerankedResult.RerankScore"/>.
+    /// Web results arrive carrying a <see cref="RetrievalResult.FusedScore"/> on a foreign scale (the web
+    /// source's own scoring), so copying that raw value into <c>RerankScore</c> and concatenating it —
+    /// as the previous implementation did — let web hits dominate the context or sink to the bottom
+    /// regardless of true relevance, and risked blowing the token budget. Re-ranking the union puts every
+    /// hit through the same cross-encoder / semantic scorer, which is the single comparable scale the
+    /// assembler needs to make web and local compete fairly.
+    /// </remarks>
+    private async Task<IReadOnlyList<RerankedResult>> MergeAndRerankWebResultsAsync(
         string query,
         IReadOnlyList<RerankedResult> existing,
         int topK,
@@ -560,16 +570,14 @@ public sealed partial class RagOrchestrator : IRagOrchestrator
         if (webResult.Results.Count == 0)
             return existing;
 
-        var startRank = existing.Count;
-        var webReranked = webResult.Results.Select((r, i) => new RerankedResult
-        {
-            RetrievalResult = r,
-            RerankScore = r.FusedScore,
-            OriginalRank = startRank + i + 1,
-            RerankRank = startRank + i + 1,
-        });
+        var merged = existing
+            .Select(r => r.RetrievalResult)
+            .Concat(webResult.Results)
+            .ToList();
 
-        return existing.Concat(webReranked).ToList();
+        // Re-rank the full union so both local and web hits are scored on one comparable scale.
+        // topK = merged.Count keeps every candidate (the assembler enforces the token budget).
+        return await _reranker.RerankAsync(query, merged, merged.Count, cancellationToken);
     }
 
     private static RagAssembledContext CreateEmptyContext(string reasoning) => new()

--- a/src/Content/Infrastructure/Infrastructure.AI.RAG/Orchestration/RagOrchestrator.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.RAG/Orchestration/RagOrchestrator.cs
@@ -550,13 +550,27 @@ public sealed partial class RagOrchestrator : IRagOrchestrator
     /// set unchanged when web search yields nothing.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// The <see cref="IRagContextAssembler"/> orders purely by <see cref="RerankedResult.RerankScore"/>.
     /// Web results arrive carrying a <see cref="RetrievalResult.FusedScore"/> on a foreign scale (the web
     /// source's own scoring), so copying that raw value into <c>RerankScore</c> and concatenating it —
     /// as the previous implementation did — let web hits dominate the context or sink to the bottom
     /// regardless of true relevance, and risked blowing the token budget. Re-ranking the union puts every
-    /// hit through the same cross-encoder / semantic scorer, which is the single comparable scale the
-    /// assembler needs to make web and local compete fairly.
+    /// hit through the same reranker, giving the assembler one ordering to work from.
+    /// </para>
+    /// <para>
+    /// The single-comparable-scale guarantee holds for the real rerankers
+    /// (<c>cross_encoder</c>, <c>azure_semantic</c>), which score each <c>(query, chunk)</c> pair jointly.
+    /// The <c>none</c> passthrough reranker is an explicit opt-out of reranking: it echoes each result's
+    /// raw <see cref="RetrievalResult.FusedScore"/>, so under that configuration web and local scores stay
+    /// on their original scales — web-fallback with reranking disabled is a degenerate combination.
+    /// </para>
+    /// <para>
+    /// When a feedback scorer is registered, the local set was feedback-blended before CRAG evaluation.
+    /// Re-ranking the union resets scores to the reranker's output, so feedback blending is re-applied to
+    /// the merged set afterwards to preserve local results' historical weighting. Web results have no
+    /// feedback history, so blending leaves them unchanged.
+    /// </para>
     /// </remarks>
     private async Task<IReadOnlyList<RerankedResult>> MergeAndRerankWebResultsAsync(
         string query,
@@ -577,7 +591,16 @@ public sealed partial class RagOrchestrator : IRagOrchestrator
 
         // Re-rank the full union so both local and web hits are scored on one comparable scale.
         // topK = merged.Count keeps every candidate (the assembler enforces the token budget).
-        return await _reranker.RerankAsync(query, merged, merged.Count, cancellationToken);
+        var mergedReranked = await _reranker.RerankAsync(
+            query, merged, merged.Count, cancellationToken);
+
+        // The union rerank discards the feedback signal the local set carried before CRAG; re-blend so
+        // local results keep their historical weighting (web results have no feedback history).
+        if (_feedbackScorer is not null)
+            mergedReranked = await _feedbackScorer.BlendFeedbackAsync(
+                mergedReranked, query, cancellationToken);
+
+        return mergedReranked;
     }
 
     private static RagAssembledContext CreateEmptyContext(string reasoning) => new()

--- a/src/Content/Tests/Infrastructure.AI.RAG.Tests/Orchestration/RagOrchestratorTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.RAG.Tests/Orchestration/RagOrchestratorTests.cs
@@ -39,7 +39,8 @@ public sealed class RagOrchestratorTests
     private RagOrchestrator CreateOrchestrator(
         Action<AppConfig>? configure = null,
         QueryRouter? router = null,
-        IRetrievalSource? webSearchSource = null)
+        IRetrievalSource? webSearchSource = null,
+        IFeedbackWeightedScorer? feedbackScorer = null)
     {
         var config = RagTestData.CreateConfigMonitor(configure);
         var queryRouter = router ?? new QueryRouter(
@@ -54,7 +55,7 @@ public sealed class RagOrchestratorTests
             _mockCrag.Object,
             _mockAssembler.Object,
             _mockGraphRag.Object,
-            feedbackScorer: null,
+            feedbackScorer: feedbackScorer,
             queryRouter,
             _mockMultiSource.Object,
             _mockComplexityClassifier.Object,
@@ -606,6 +607,100 @@ public sealed class RagOrchestratorTests
         assembled.Should().NotBeNull();
         assembled!.Should().Contain(r => r.RetrievalResult.Chunk.Id == "web-1");
         assembled!.Should().OnlyContain(r => r.RerankScore <= 1.0);
+    }
+
+    [Fact]
+    public async Task SearchAsync_WebFallbackWithFeedbackScorer_ReAppliesFeedbackToMergedSet()
+    {
+        // Pre-CRAG the local set is reranked then feedback-blended, so a registered scorer's historical
+        // weighting is baked into the local ordering. Re-ranking the local+web union resets scores to
+        // the reranker's output — discarding that signal — so feedback blending must be re-applied to
+        // the merged set. This test proves the local feedback signal survives web-fallback.
+        const double feedbackSentinel = 5.0; // Off the reranker's [0,1] scale, so its presence is unambiguous.
+
+        var webResults = new[]
+        {
+            RagTestData.CreateRetrievalResult(id: "web-1", content: "Web content 1.", fusedScore: 999.0),
+        };
+        var webSource = new Mock<IRetrievalSource>();
+        webSource.SetupGet(s => s.SourceName).Returns("web_search");
+        webSource
+            .Setup(s => s.RetrieveAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<TaskComplexity>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SourceRetrievalResult
+            {
+                SourceName = "web_search",
+                Results = webResults,
+                Latency = TimeSpan.FromMilliseconds(200),
+                TokensUsed = 90,
+            });
+
+        _mockRetriever
+            .Setup(r => r.RetrieveAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(RagTestData.CreateRetrievalResults(3));
+
+        // Reranker assigns calibrated [0,1] scores; chunk-3 lands last (score 0.7).
+        _mockReranker
+            .Setup(r => r.RerankAsync(It.IsAny<string>(), It.IsAny<IReadOnlyList<RetrievalResult>>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string _, IReadOnlyList<RetrievalResult> results, int topK, CancellationToken _) =>
+                results
+                    .Take(topK)
+                    .Select((r, i) => new RerankedResult
+                    {
+                        RetrievalResult = r,
+                        RerankScore = Math.Max(0.0, 0.9 - (i * 0.1)),
+                        OriginalRank = i + 1,
+                        RerankRank = i + 1,
+                    })
+                    .ToList());
+
+        // Feedback scorer boosts chunk-3 to a sentinel score (historical weighting) and re-sorts.
+        // Web results have no feedback history, so they pass through unchanged.
+        var feedbackScorer = new Mock<IFeedbackWeightedScorer>();
+        feedbackScorer
+            .Setup(f => f.BlendFeedbackAsync(It.IsAny<IReadOnlyList<RerankedResult>>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IReadOnlyList<RerankedResult> results, string _, CancellationToken _) =>
+                results
+                    .Select(r => r.RetrievalResult.Chunk.Id == "chunk-3"
+                        ? r with { RerankScore = feedbackSentinel }
+                        : r)
+                    .OrderByDescending(r => r.RerankScore)
+                    .ToList());
+
+        _mockCrag
+            .Setup(e => e.EvaluateAsync(It.IsAny<string>(), It.IsAny<IReadOnlyList<RetrievalResult>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(RagTestData.CreateWebFallbackEvaluation());
+
+        IReadOnlyList<RerankedResult>? assembled = null;
+        _mockAssembler
+            .Setup(a => a.AssembleAsync(It.IsAny<IReadOnlyList<RerankedResult>>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .Callback<IReadOnlyList<RerankedResult>, int, CancellationToken>((results, _, _) => assembled = results)
+            .ReturnsAsync(_expectedContext);
+
+        var orchestrator = CreateOrchestrator(
+            configure: cfg =>
+            {
+                cfg.AI.ModelRouting.Enabled = false;
+                cfg.AI.Rag.Crag.AllowWebFallback = true;
+                cfg.AI.Rag.MultiSource.EnabledSources = ["vector", "graph", "web_search"];
+            },
+            webSearchSource: webSource.Object,
+            feedbackScorer: feedbackScorer.Object);
+
+        await orchestrator.SearchAsync("query needing web fallback");
+
+        // Feedback blending must run on the merged set (a candidate list that includes the web chunk),
+        // not just the pre-CRAG local-only set that the union rerank discarded.
+        feedbackScorer.Verify(
+            f => f.BlendFeedbackAsync(
+                It.Is<IReadOnlyList<RerankedResult>>(list => list.Any(x => x.RetrievalResult.Chunk.Id.StartsWith("web", StringComparison.Ordinal))),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        // The sentinel boost survived to assembly — local feedback weighting was preserved after merge.
+        assembled.Should().NotBeNull();
+        assembled!.Should().Contain(r =>
+            r.RetrievalResult.Chunk.Id == "chunk-3" && r.RerankScore == feedbackSentinel);
     }
 
     [Fact]

--- a/src/Content/Tests/Infrastructure.AI.RAG.Tests/Orchestration/RagOrchestratorTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.RAG.Tests/Orchestration/RagOrchestratorTests.cs
@@ -522,6 +522,93 @@ public sealed class RagOrchestratorTests
     }
 
     [Fact]
+    public async Task SearchAsync_WebFallback_ReranksMergedSet_SoWebHitsCompeteOnOneScale()
+    {
+        // Local candidates are reranked onto a calibrated [0,1] scale. Web results arrive carrying a
+        // huge raw FusedScore on a foreign scale (999/888). Pre-fix, AppendWebResultsAsync copied that
+        // raw score into RerankScore and concatenated it; the assembler orders by RerankScore alone,
+        // so the web hits dominated the context purely by scale. The fix re-ranks the merged
+        // (local + web) candidate set through the same reranker so every hit is scored on one
+        // comparable scale before assembly.
+        var webResults = new[]
+        {
+            RagTestData.CreateRetrievalResult(id: "web-1", content: "Web content 1.", fusedScore: 999.0),
+            RagTestData.CreateRetrievalResult(id: "web-2", content: "Web content 2.", fusedScore: 888.0),
+        };
+        var webSourceResult = new SourceRetrievalResult
+        {
+            SourceName = "web_search",
+            Results = webResults,
+            Latency = TimeSpan.FromMilliseconds(250),
+            TokensUsed = 120,
+        };
+
+        var webSource = new Mock<IRetrievalSource>();
+        webSource.SetupGet(s => s.SourceName).Returns("web_search");
+        webSource
+            .Setup(s => s.RetrieveAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<TaskComplexity>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(webSourceResult);
+
+        _mockRetriever
+            .Setup(r => r.RetrieveAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(RagTestData.CreateRetrievalResults(3));
+
+        // Reranker simulates a cross-encoder: it assigns calibrated [0,1] scores to whatever candidate
+        // set it is handed, ignoring the incoming (foreign-scale) FusedScore. This is what makes local
+        // and web hits comparable — and it means a hit only reaches the assembler with score > 1.0 if
+        // its raw FusedScore was copied through WITHOUT going via the reranker (the bug).
+        _mockReranker
+            .Setup(r => r.RerankAsync(It.IsAny<string>(), It.IsAny<IReadOnlyList<RetrievalResult>>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string _, IReadOnlyList<RetrievalResult> results, int topK, CancellationToken _) =>
+                results
+                    .Take(topK)
+                    .Select((r, i) => new RerankedResult
+                    {
+                        RetrievalResult = r,
+                        RerankScore = Math.Max(0.0, 0.9 - (i * 0.1)),
+                        OriginalRank = i + 1,
+                        RerankRank = i + 1,
+                    })
+                    .ToList());
+
+        _mockCrag
+            .Setup(e => e.EvaluateAsync(It.IsAny<string>(), It.IsAny<IReadOnlyList<RetrievalResult>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(RagTestData.CreateWebFallbackEvaluation());
+
+        IReadOnlyList<RerankedResult>? assembled = null;
+        _mockAssembler
+            .Setup(a => a.AssembleAsync(It.IsAny<IReadOnlyList<RerankedResult>>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .Callback<IReadOnlyList<RerankedResult>, int, CancellationToken>((results, _, _) => assembled = results)
+            .ReturnsAsync(_expectedContext);
+
+        var orchestrator = CreateOrchestrator(
+            configure: cfg =>
+            {
+                cfg.AI.ModelRouting.Enabled = false;
+                cfg.AI.Rag.Crag.AllowWebFallback = true;
+                cfg.AI.Rag.MultiSource.EnabledSources = ["vector", "graph", "web_search"];
+            },
+            webSearchSource: webSource.Object);
+
+        await orchestrator.SearchAsync("query needing web fallback");
+
+        // The reranker must see the merged set — i.e., a candidate list that contains the web chunks.
+        _mockReranker.Verify(
+            r => r.RerankAsync(
+                It.IsAny<string>(),
+                It.Is<IReadOnlyList<RetrievalResult>>(list => list.Any(x => x.Chunk.Id.StartsWith("web", StringComparison.Ordinal))),
+                It.IsAny<int>(),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        // Nothing handed to the assembler may carry a foreign-scale score: web hits went through the
+        // reranker, so every RerankScore sits on the calibrated [0,1] scale (never the raw 999/888).
+        assembled.Should().NotBeNull();
+        assembled!.Should().Contain(r => r.RetrievalResult.Chunk.Id == "web-1");
+        assembled!.Should().OnlyContain(r => r.RerankScore <= 1.0);
+    }
+
+    [Fact]
     public async Task SearchAsync_WebFallbackWithWebDisabled_DoesNotInvokeWebSource()
     {
         var webSource = new Mock<IRetrievalSource>();


### PR DESCRIPTION
Wave 4 (consolidation) — RAG correctness follow-up from Wave-3 PR #141 (CRAG web-fallback). Gates enabling the `web_search` source.

## Bug
Web-fallback results were concatenated onto the reranked-local set with `RerankScore = raw FusedScore` (a foreign, uncalibrated scale), and `RagContextAssembler` orders by `RerankScore` only (`OriginalRank`/`RerankRank` are dead). Net: web hits either dominate the assembled context or sink arbitrarily regardless of true relevance, and can crowd out the token budget with foreign-scale junk.

## Fix
`AppendWebResultsAsync` → `MergeAndRerankWebResultsAsync`: re-ranks the **union** of local + web through the same canonical `IReranker` (`topK = merged.Count`, nothing dropped), so local and web compete on one comparable scale. More principled than min-max normalizing two independent score distributions. Then re-applies `BlendFeedbackAsync` over the union when a feedback scorer is registered (web hits have no feedback history, so they're unchanged; local results keep their historical weighting).

## Adversarial review (SAFE WITH FIXES → fixed)
An adversarial reviewer confirmed: disabled path byte-identical (`IsWebFallbackEnabled()` guard), token budget still enforced by the assembler, new test genuinely fails on the pre-fix bug. It found one regression — the union rerank initially dropped local feedback-blending; **fixed** by re-applying the blend after the union rerank (second commit). NoOp-reranker (`"none"`) caveat documented in the method comment.

## Verification
- `Infrastructure.AI.RAG.Tests`: 228 passed (226 existing + 2 new — `...ReranksMergedSet_SoWebHitsCompeteOnOneScale` and `...ReAppliesFeedbackToMergedSet`).
- All behind the same #141 opt-in flags; web-disabled path unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)