### PR TITLE
fix: guard optional injection detector + validate governance config

### DIFF
--- a/src/Content/Application/Application.Core/Validation/GovernanceConfigValidator.cs
+++ b/src/Content/Application/Application.Core/Validation/GovernanceConfigValidator.cs
@@ -1,0 +1,77 @@
+using Domain.Common.Config.AI;
+using FluentValidation;
+
+namespace Application.Core.Validation;
+
+/// <summary>
+/// Validates <see cref="GovernanceConfig"/> — the parent Agent Governance Toolkit configuration bound
+/// from <c>AppConfig:AI:Governance</c>. Its <c>Escalation</c> and <c>DataClassification</c> subsections
+/// have their own validators; this one covers the parent-level flags and guards against
+/// internally-inconsistent combinations that would otherwise start up silently and behave as no-ops.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Auto-discovered via <c>AddValidatorsFromAssembly</c> on the Application.Core assembly and wired into
+/// the options pipeline with <c>ValidateOnStart()</c> in the composition root, so an invalid governance
+/// section fails the host at boot rather than at first use.
+/// </para>
+/// <para>
+/// Rules are shaped so a default (or omitted) section always passes: <see cref="GovernanceConfig.Enabled"/>,
+/// <see cref="GovernanceConfig.EnablePromptInjectionDetection"/>, and
+/// <see cref="GovernanceConfig.EnableMcpSecurity"/> all default to <see langword="false"/>, and the enum /
+/// path rules accept the class defaults.
+/// </para>
+/// </remarks>
+public sealed class GovernanceConfigValidator : AbstractValidator<GovernanceConfig>
+{
+    /// <summary>Initializes a new instance of the <see cref="GovernanceConfigValidator"/> class.</summary>
+    public GovernanceConfigValidator()
+    {
+        // Enum sanity — an out-of-range integer bound from config must not flow through as a silent
+        // undefined enum value that later switch/threshold comparisons mishandle.
+        RuleFor(x => x.ConflictStrategy)
+            .IsInEnum()
+            .WithMessage("ConflictStrategy must be a defined ConflictResolutionStrategy value.");
+
+        RuleFor(x => x.InjectionBlockThreshold)
+            .IsInEnum()
+            .WithMessage("InjectionBlockThreshold must be a defined ThreatLevel value.");
+
+        RuleFor(x => x.ResponseBlockThreshold)
+            .IsInEnum()
+            .WithMessage("ResponseBlockThreshold must be a defined ThreatLevel value.");
+
+        // A blank policy path can never resolve to a file — the DI registration filters it out via
+        // File.Exists, so it never loads. Surface it as a typo rather than silently dropping it.
+        RuleForEach(x => x.PolicyPaths)
+            .Must(path => !string.IsNullOrWhiteSpace(path))
+            .WithMessage(
+                "PolicyPaths contains a blank entry. A blank path resolves to no file and is silently " +
+                "dropped — remove it or supply the policy file path.");
+
+        // Landmine guard: these sub-features only run through the AGT kernel path, which the composition
+        // root wires exclusively when Enabled=true. Turning one on while governance is disabled is a
+        // no-op the operator cannot see — the composition root registers the no-op scanner/scanner and
+        // the corresponding MediatR behaviour passes through — so the flag never fires. Reject it so the
+        // contradiction surfaces at boot instead of masquerading as protection at runtime. (Independent
+        // of EnforceToolInvocation, ProgressGuard, and DataClassification.Mode, which are consumed on the
+        // live tool path regardless of Enabled and so are intentionally not constrained here.)
+        When(x => !x.Enabled, () =>
+        {
+            RuleFor(x => x.EnablePromptInjectionDetection)
+                .Equal(false)
+                .WithMessage(
+                    "EnablePromptInjectionDetection requires Governance.Enabled=true. With governance " +
+                    "disabled the composition root wires the no-op injection scanner and " +
+                    "PromptInjectionBehavior passes through, so detection never runs — enable governance " +
+                    "or clear this flag.");
+
+            RuleFor(x => x.EnableMcpSecurity)
+                .Equal(false)
+                .WithMessage(
+                    "EnableMcpSecurity requires Governance.Enabled=true. With governance disabled the " +
+                    "composition root wires the no-op MCP scanner, so tool-registration scanning never " +
+                    "runs — enable governance or clear this flag.");
+        });
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI.Governance/DependencyInjection.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.Governance/DependencyInjection.cs
@@ -59,8 +59,18 @@ public static class DependencyInjection
         // valid Enabled=true, EnablePromptInjectionDetection=false configuration — AddSingleton throws on a
         // null instance. When detection is off, satisfy IPromptInjectionScanner with the no-op scanner so
         // every consumer resolves and the PromptInjectionBehavior simply passes through.
-        if (config.EnablePromptInjectionDetection && kernel.InjectionDetector is not null)
+        if (config.EnablePromptInjectionDetection)
         {
+            // Fail closed: if detection is configured on, the kernel must have produced a detector.
+            // Silently falling back to the no-op scanner here would leave a *configured* security
+            // control inert — the exact silent-degradation failure this hardening pass targets.
+            if (kernel.InjectionDetector is null)
+            {
+                throw new InvalidOperationException(
+                    "GovernanceConfig.EnablePromptInjectionDetection is true but the governance kernel " +
+                    "produced no InjectionDetector; refusing to start with the configured control disabled.");
+            }
+
             services.AddSingleton(kernel.InjectionDetector);
             services.AddSingleton<IPromptInjectionScanner, AgtPromptInjectionAdapter>();
         }

--- a/src/Content/Infrastructure/Infrastructure.AI.Governance/DependencyInjection.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.Governance/DependencyInjection.cs
@@ -49,13 +49,26 @@ public static class DependencyInjection
 
         services.AddSingleton(kernel);
         services.AddSingleton(kernel.PolicyEngine);
-        // non-null when prompt-injection detection is enabled; AddSingleton throws on a null instance
-        // regardless, so the null-forgiving here does not change runtime behavior.
-        services.AddSingleton(kernel.InjectionDetector!);
         services.AddSingleton<AuditLogger>();
 
         services.AddSingleton<IGovernancePolicyEngine, AgtPolicyEngineAdapter>();
-        services.AddSingleton<IPromptInjectionScanner, AgtPromptInjectionAdapter>();
+
+        // Prompt-injection detection is optional. The AGT kernel only builds an InjectionDetector when
+        // GovernanceConfig.EnablePromptInjectionDetection is true, so registering kernel.InjectionDetector
+        // (or the AgtPromptInjectionAdapter that requires it) unconditionally crashes composition for the
+        // valid Enabled=true, EnablePromptInjectionDetection=false configuration — AddSingleton throws on a
+        // null instance. When detection is off, satisfy IPromptInjectionScanner with the no-op scanner so
+        // every consumer resolves and the PromptInjectionBehavior simply passes through.
+        if (config.EnablePromptInjectionDetection && kernel.InjectionDetector is not null)
+        {
+            services.AddSingleton(kernel.InjectionDetector);
+            services.AddSingleton<IPromptInjectionScanner, AgtPromptInjectionAdapter>();
+        }
+        else
+        {
+            services.AddSingleton<IPromptInjectionScanner, NoOpInjectionScanner>();
+        }
+
         services.AddSingleton<IGovernanceAuditService, AgtAuditAdapter>();
         services.AddSingleton<IMcpSecurityScanner, McpSecurityScannerAdapter>();
 

--- a/src/Content/Presentation/Presentation.Common/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Content/Presentation/Presentation.Common/Extensions/IServiceCollectionExtensions.cs
@@ -102,17 +102,12 @@ public static class IServiceCollectionExtensions
         services.Configure<ConnectorsConfig>(configuration.GetSection("AppConfig:Connectors"));
         services.Configure<ObservabilityConfig>(configuration.GetSection("AppConfig:Observability"));
         services.Configure<AIConfig>(configuration.GetSection("AppConfig:AI"));
-        // Governance switches consumed via IOptionsMonitor<GovernanceConfig> on the live
-        // agent path: ToolInvocationGovernor (EnforceToolInvocation), ProgressEvaluator
-        // (ProgressGuard), DefaultToolClassificationGate (DataClassification mode), and the
-        // PromptInjectionBehavior / ResponseSanitizationBehavior MediatR behaviors (Enabled +
-        // thresholds). Without this binding those services run on compiled defaults
-        // regardless of appsettings ("inert machinery", audit item I2). The Escalation and
-        // DataClassification subsections additionally have their own validated bindings in
-        // RegisterValidatedConfigSections; no FluentValidation validator exists yet for the
-        // parent GovernanceConfig — adding one is a tracked follow-up.
-        services.Configure<Domain.Common.Config.AI.GovernanceConfig>(
-            configuration.GetSection("AppConfig:AI:Governance"));
+        // GovernanceConfig is bound-with-validation in RegisterValidatedConfigSections (it now has a
+        // GovernanceConfigValidator, closing the tracked follow-up from audit item I2). It is consumed via
+        // IOptionsMonitor<GovernanceConfig> on the live agent path: ToolInvocationGovernor
+        // (EnforceToolInvocation), ProgressEvaluator (ProgressGuard), DefaultToolClassificationGate
+        // (DataClassification mode), and the PromptInjectionBehavior / ResponseSanitizationBehavior MediatR
+        // behaviors (Enabled + thresholds).
         services.Configure<EmbeddingConfig>(configuration.GetSection("AppConfig:AI:Embedding"));
         services.Configure<AzureConfig>(configuration.GetSection("AppConfig:Azure"));
         services.Configure<CacheConfig>(configuration.GetSection("AppConfig:Cache"));
@@ -149,6 +144,11 @@ public static class IServiceCollectionExtensions
         this IServiceCollection services,
         IConfiguration configuration)
     {
+        services.AddOptions<Domain.Common.Config.AI.GovernanceConfig>()
+            .Bind(configuration.GetSection("AppConfig:AI:Governance"))
+            .ValidateFluentValidation<Domain.Common.Config.AI.GovernanceConfig, GovernanceConfigValidator>()
+            .ValidateOnStart();
+
         services.AddOptions<EscalationConfig>()
             .Bind(configuration.GetSection("AppConfig:AI:Governance:Escalation"))
             .ValidateFluentValidation<EscalationConfig, EscalationConfigValidator>()

--- a/src/Content/Tests/Application.Core.Tests/Validation/GovernanceConfigValidatorTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/Validation/GovernanceConfigValidatorTests.cs
@@ -1,0 +1,124 @@
+using Application.Core.Validation;
+using Domain.Common.Config.AI;
+using FluentAssertions;
+using Xunit;
+
+namespace Application.Core.Tests.Validation;
+
+/// <summary>
+/// Tests for <see cref="GovernanceConfigValidator"/>. The default section is valid (so omitted /
+/// default hosts keep booting); the landmine rules fire only when governance is disabled but a
+/// kernel-path-only feature is switched on. Pattern: a valid baseline, mutate one field per test.
+/// </summary>
+public class GovernanceConfigValidatorTests
+{
+    private readonly GovernanceConfigValidator _validator = new();
+
+    [Fact]
+    public async Task Validate_DefaultConfig_IsValid()
+    {
+        var result = await _validator.ValidateAsync(new GovernanceConfig());
+
+        result.IsValid.Should().BeTrue();
+        result.Errors.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Validate_EnabledWithInjectionDetectionOff_IsValid()
+    {
+        // The exact combination the composition crash fix makes valid: governance on, detection off.
+        var config = new GovernanceConfig { Enabled = true, EnablePromptInjectionDetection = false };
+
+        var result = await _validator.ValidateAsync(config);
+
+        result.IsValid.Should().BeTrue();
+        result.Errors.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Validate_EnabledWithAllFeaturesOn_IsValid()
+    {
+        // Mirrors the shape every host ships today.
+        var config = new GovernanceConfig
+        {
+            Enabled = true,
+            EnablePromptInjectionDetection = true,
+            EnableMcpSecurity = true,
+        };
+
+        var result = await _validator.ValidateAsync(config);
+
+        result.IsValid.Should().BeTrue();
+        result.Errors.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Validate_DisabledWithInjectionDetectionOn_HasError()
+    {
+        var config = new GovernanceConfig { Enabled = false, EnablePromptInjectionDetection = true };
+
+        var result = await _validator.ValidateAsync(config);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(GovernanceConfig.EnablePromptInjectionDetection));
+    }
+
+    [Fact]
+    public async Task Validate_DisabledWithMcpSecurityOn_HasError()
+    {
+        var config = new GovernanceConfig { Enabled = false, EnableMcpSecurity = true };
+
+        var result = await _validator.ValidateAsync(config);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(GovernanceConfig.EnableMcpSecurity));
+    }
+
+    [Fact]
+    public async Task Validate_DisabledWithEnforceToolInvocationOn_IsValid()
+    {
+        // EnforceToolInvocation is consumed on the live tool path independent of Enabled, so it is
+        // intentionally not constrained by the landmine guard.
+        var config = new GovernanceConfig { Enabled = false, EnforceToolInvocation = true };
+
+        var result = await _validator.ValidateAsync(config);
+
+        result.IsValid.Should().BeTrue();
+        result.Errors.Should().BeEmpty();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task Validate_BlankPolicyPath_HasError(string blankPath)
+    {
+        var config = new GovernanceConfig { PolicyPaths = [blankPath] };
+
+        var result = await _validator.ValidateAsync(config);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName.StartsWith(nameof(GovernanceConfig.PolicyPaths)));
+    }
+
+    [Fact]
+    public async Task Validate_OutOfRangeConflictStrategy_HasError()
+    {
+        var config = new GovernanceConfig { ConflictStrategy = (ConflictResolutionStrategy)999 };
+
+        var result = await _validator.ValidateAsync(config);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(GovernanceConfig.ConflictStrategy));
+    }
+
+    [Fact]
+    public async Task Validate_OutOfRangeInjectionBlockThreshold_HasError()
+    {
+        var config = new GovernanceConfig { InjectionBlockThreshold = (ThreatLevel)999 };
+
+        var result = await _validator.ValidateAsync(config);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(GovernanceConfig.InjectionBlockThreshold));
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Governance.Tests/Composition/GovernanceDependencyInjectionTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Governance.Tests/Composition/GovernanceDependencyInjectionTests.cs
@@ -1,0 +1,55 @@
+using Application.AI.Common.Interfaces.Governance;
+using Domain.Common.Config.AI;
+using FluentAssertions;
+using Infrastructure.AI.Governance.Adapters;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Infrastructure.AI.Governance.Tests.Composition;
+
+/// <summary>
+/// Composition tests for <see cref="DependencyInjection.AddGovernanceDependencies"/> covering the
+/// optional prompt-injection detector wiring. The Agent Governance Toolkit kernel only builds an
+/// <c>InjectionDetector</c> when <see cref="GovernanceConfig.EnablePromptInjectionDetection"/> is on;
+/// the registration must not attempt to register a null detector (nor the adapter that requires it)
+/// when detection is off, or the composition root crashes at startup for the otherwise-valid
+/// <c>Enabled=true, EnablePromptInjectionDetection=false</c> combination.
+/// </summary>
+public sealed class GovernanceDependencyInjectionTests
+{
+    [Fact]
+    public void AddGovernanceDependencies_EnabledButInjectionDetectionOff_DoesNotThrowAndResolvesNoOpScanner()
+    {
+        // Regression guard: this exact combination used to register the kernel's null InjectionDetector
+        // via AddSingleton (which throws ArgumentNullException on a null instance), crashing composition.
+        var config = new GovernanceConfig { Enabled = true, EnablePromptInjectionDetection = false };
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        var act = () => services.AddGovernanceDependencies(config);
+
+        act.Should().NotThrow(
+            "governance may be enabled without prompt-injection detection; the detector is optional");
+
+        using var provider = services.BuildServiceProvider();
+        provider.GetRequiredService<IPromptInjectionScanner>()
+            .Should().BeOfType<NoOpInjectionScanner>(
+                "with detection off the scanner must degrade to a no-op so every consumer still resolves");
+    }
+
+    [Fact]
+    public void AddGovernanceDependencies_InjectionDetectionOn_ResolvesAgtAdapter()
+    {
+        var config = new GovernanceConfig { Enabled = true, EnablePromptInjectionDetection = true };
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddGovernanceDependencies(config);
+
+        using var provider = services.BuildServiceProvider();
+        provider.GetRequiredService<IPromptInjectionScanner>()
+            .Should().BeOfType<AgtPromptInjectionAdapter>(
+                "with detection on the scanner must wrap the AGT PromptInjectionDetector");
+    }
+}

--- a/src/Content/Tests/Presentation.Common.Tests/Composition/GovernanceConfigBindingTests.cs
+++ b/src/Content/Tests/Presentation.Common.Tests/Composition/GovernanceConfigBindingTests.cs
@@ -28,11 +28,9 @@ namespace Presentation.Common.Tests.Composition;
 /// directly — the exact "inert machinery" failure mode audit item I2 exists to catch.
 /// </para>
 /// <para>
-/// The fix is the <c>Configure&lt;GovernanceConfig&gt;</c> binding in
-/// <c>RegisterConfigSections</c>. Tracked follow-up: the parent <c>GovernanceConfig</c> has no
-/// FluentValidation config validator (its Escalation and DataClassification subsections do) —
-/// when one is added, move the binding into <c>RegisterValidatedConfigSections</c> with
-/// <c>ValidateOnStart()</c> like its siblings.
+/// The fix is the validated <c>GovernanceConfig</c> binding, now living in
+/// <c>RegisterValidatedConfigSections</c> with a <c>GovernanceConfigValidator</c> and
+/// <c>ValidateOnStart()</c> like its siblings (the tracked follow-up is closed).
 /// </para>
 /// </remarks>
 public sealed class GovernanceConfigBindingTests
@@ -40,21 +38,23 @@ public sealed class GovernanceConfigBindingTests
     [Fact]
     public async Task RegisterConfigSections_GovernanceSection_ReachesGovernanceConfigMonitor()
     {
-        // Deliberately probes with Enabled=false: EnforceToolInvocation and
-        // EnablePromptInjectionDetection are independent of Enabled, and Enabled=true would
-        // route composition into AddGovernanceDependencies (the AGT kernel path), which has
-        // its own config requirements — this test isolates the options BINDING only.
+        // Deliberately probes with Enabled=false so composition stays off the AGT kernel path
+        // (AddGovernanceDependencies), isolating the options BINDING only. EnforceToolInvocation is
+        // consumed on the live tool path independent of Enabled, and InjectionBlockThreshold is a
+        // non-default value — together they prove the parent GovernanceConfig binding reaches the
+        // monitor. Both are valid with Enabled=false, so the GovernanceConfigValidator (which reading
+        // CurrentValue now runs) passes.
         await using var provider = CompositionRootTestHost.BuildProvider(new Dictionary<string, string?>
         {
             ["AppConfig:AI:Governance:EnforceToolInvocation"] = "true",
-            ["AppConfig:AI:Governance:EnablePromptInjectionDetection"] = "true",
+            ["AppConfig:AI:Governance:InjectionBlockThreshold"] = "Critical",
         });
 
         var governance = provider.GetRequiredService<IOptionsMonitor<GovernanceConfig>>().CurrentValue;
 
         governance.EnforceToolInvocation.Should().BeTrue(
             "the live tool-invocation gate must be switchable from configuration");
-        governance.EnablePromptInjectionDetection.Should().BeTrue(
+        governance.InjectionBlockThreshold.Should().Be(ThreatLevel.Critical,
             "AppConfig:AI:Governance values must reach IOptionsMonitor<GovernanceConfig> consumers");
     }
 

--- a/src/Content/Tests/Presentation.Common.Tests/Extensions/ConfigValidationStartupTests.cs
+++ b/src/Content/Tests/Presentation.Common.Tests/Extensions/ConfigValidationStartupTests.cs
@@ -58,6 +58,16 @@ public class ConfigValidationStartupTests
             new Dictionary<string, string?> { ["AppConfig:AI:Governance:Escalation:DefaultTimeoutAction"] = "NotAnAction" }
         },
         {
+            // Landmine: injection detection requested while governance is disabled. It only runs on the
+            // AGT kernel path (composed only when Enabled=true), so the flag is silently ineffective.
+            "GovernanceConfig",
+            new Dictionary<string, string?>
+            {
+                ["AppConfig:AI:Governance:Enabled"] = "false",
+                ["AppConfig:AI:Governance:EnablePromptInjectionDetection"] = "true",
+            }
+        },
+        {
             "WorkMemoryConfig",
             new Dictionary<string, string?> { ["AppConfig:AI:WorkMemory:StoreProvider"] = "not_a_provider" }
         },


### PR DESCRIPTION
Wave 4 (consolidation) — I2 follow-up from PR #136. A boot-crash fix + a config validator.

## 1. Boot-crash fix (config landmine)
`AddGovernanceDependencies` registered `kernel.InjectionDetector` unconditionally, but the AGT `GovernanceKernel` only builds a detector when `EnablePromptInjectionDetection=true`. So the valid config `Enabled=true, EnablePromptInjectionDetection=false` crashed the host at startup (`AddSingleton(null)` throws), and `AgtPromptInjectionAdapter` (registered unconditionally) needed that null detector too.

Now:
- detection **off** → `NoOpInjectionScanner` satisfies `IPromptInjectionScanner`; `PromptInjectionBehavior` passes through.
- detection **on** + detector present → real `AgtPromptInjectionAdapter`.
- detection **on** + detector **null** → **throws** (fail closed). A configured security control can never silently degrade to no-op — the exact silent-degradation failure this audit targets.

## 2. GovernanceConfigValidator + ValidateOnStart
New `GovernanceConfigValidator : AbstractValidator<GovernanceConfig>` wired through the existing `FluentValidationValidateOptions` adapter + `ValidateOnStart` (matching the 11 sibling section validators from #130). Rejects internally-inconsistent config at boot: `Enabled=false`+detection/McpSecurity=true, undefined enum values, blank `PolicyPaths`. Deliberately does **not** reject the valid `Enabled=true`+detection=false combo, and does not constrain flags consumed independently of `Enabled`. The PR #136 `GovernanceConfig` binding was relocated into the validated-sections block (not recreated).

## Verification
- Red→green: `AddGovernanceDependencies_EnabledButInjectionDetectionOff_DoesNotThrowAndResolvesNoOpScanner` (+ sibling detection-on test), startup-rejection row in `ConfigValidationStartupTests`.
- Infrastructure.AI.Governance.Tests 124, Application.Core.Tests 648 (9 validator tests), Presentation.Common.Tests 126 — all pass, 0 warnings.
- gitnexus_impact LOW, 0 execution flows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)