### PR TITLE
fix(governance): enforce plugin AutonomyLevel baseline on the live path

### DIFF
--- a/documentation/security/04-tools-and-permissions.html
+++ b/documentation/security/04-tools-and-permissions.html
@@ -311,10 +311,36 @@
                             <tr>
                                 <td><code>AutonomyLevel</code></td>
                                 <td>Tier</td>
-                                <td>Overrides the tier policy for the whole plugin (e.g. force a noisier plugin to Supervised).</td>
+                                <td>
+                                    Overrides the tier policy for the plugin's own tools. The provider enumerates the
+                                    real tool names the plugin's skills declare (their <code>allowed-tools</code> /
+                                    tool declarations) and emits one <em>authoritative baseline</em> rule per name —
+                                    <code>Autonomous</code> → Allow (can loosen a stricter default),
+                                    <code>Supervised</code>/<code>Restricted</code> → Ask (tightens). The baseline runs
+                                    after the Deny phase, so a <code>DeniedTools</code> entry still wins over it.
+                                </td>
                             </tr>
                         </tbody>
                     </table>
+
+                    <div class="callout callout-info">
+                        <span class="callout-icon">i</span>
+                        <div class="callout-body">
+                            <div class="callout-title">Scope: <code>DeniedTools</code> is plugin-wide and turn-global, not per-skill</div>
+                            <p style="margin: 0">
+                                <code>AllowedTools</code>, <code>DeniedTools</code>, and <code>AutonomyLevel</code> are
+                                declared on the <em>plugin</em>, so they apply to <strong>every skill the plugin
+                                contributes</strong> — there is no per-skill knob inside a plugin. A tool listed in a
+                                plugin's <code>DeniedTools</code> is enforced two ways: it is filtered out of that
+                                plugin's own resolved tool set at build time (per-skill provisioning), <em>and</em> it
+                                emits a bypass-immune Deny rule keyed on the tool <em>name</em>. Because the resolver
+                                matches Deny rules by name across the whole turn, that name stays denied even if a
+                                different (non-plugin) skill surfaces a tool of the same name — the deny is
+                                cross-skill, not confined to the plugin that declared it. Scope a denial narrowly by
+                                naming a tool only that plugin exposes.
+                            </p>
+                        </div>
+                    </div>
 
                     <h2 id="bypass-immune">The bypass-immune DeniedTools rule</h2>
                     <p>
@@ -324,7 +350,7 @@
                     </p>
                     <p>
                         For each entry in <code>DeniedTools</code>, <code>PluginPermissionRuleProvider</code>
-                        (around lines 76–86) constructs this rule:
+                        constructs this rule:
                     </p>
 
                     <div class="code-block">

--- a/documentation/security/04-tools-and-permissions.html
+++ b/documentation/security/04-tools-and-permissions.html
@@ -342,6 +342,26 @@
                         </div>
                     </div>
 
+                    <div class="callout callout-warn">
+                        <span class="callout-icon">!</span>
+                        <div class="callout-body">
+                            <div class="callout-title"><code>Autonomous</code> auto-approves agent-wide — pair it with <code>DeniedTools</code></div>
+                            <p style="margin: 0">
+                                An <code>Autonomous</code> plugin baseline resolves an <em>authoritative Allow</em> by
+                                tool <em>name</em>, so the named tools auto-approve for the whole turn — for every
+                                caller, not just the plugin. To keep this from becoming a privilege-escalation path,
+                                the provider only emits the baseline for names on the plugin's <strong>own</strong>
+                                tool surface: a name that resolves to a globally-registered keyed-DI tool (a shared
+                                harness tool such as <code>file_system</code> or a shell) is excluded, even if the
+                                plugin's <code>SKILL.md</code> lists it. The plugin may still <em>use</em> that tool —
+                                it just cannot auto-approve it. When you mark a plugin <code>Autonomous</code>, treat
+                                the named tools as auto-approved agent-wide and add any sensitive global tool to that
+                                plugin's <code>DeniedTools</code> (bypass-immune) to be certain it can never be
+                                auto-run.
+                            </p>
+                        </div>
+                    </div>
+
                     <h2 id="bypass-immune">The bypass-immune DeniedTools rule</h2>
                     <p>
                         This is the most important behavior on the page, and the most counter-intuitive: a tool in a

--- a/src/Content/Application/Application.Core/Permissions/PluginPermissionRuleProvider.cs
+++ b/src/Content/Application/Application.Core/Permissions/PluginPermissionRuleProvider.cs
@@ -1,7 +1,9 @@
+using Application.AI.Common.Interfaces;
 using Application.AI.Common.Interfaces.Permissions;
 using Application.AI.Common.Interfaces.Plugins;
 using Domain.AI.Governance;
 using Domain.AI.Permissions;
+using Domain.AI.Skills;
 using Microsoft.Extensions.Logging;
 
 namespace Application.Core.Permissions;
@@ -12,28 +14,53 @@ namespace Application.Core.Permissions;
 /// resolver alongside agent-level autonomy tier rules.
 /// </summary>
 /// <remarks>
+/// <para>
 /// Any <c>DeniedTools</c> declared on a loaded plugin emit Deny rules at a lower priority value
 /// (checked first) and are marked <c>IsBypassImmune</c> so they cannot be overridden by
 /// auto-approve modes. These deny rules are emitted <b>regardless</b> of whether the plugin also
 /// sets an <c>AutonomyLevel</c> — the deny boundary is independent of the autonomy override.
-/// Additionally, each loaded plugin whose <c>AutonomyLevel</c> is set contributes one baseline
-/// rule scoped to <c>{pluginName}:*</c>.
+/// </para>
+/// <para>
+/// A plugin's <c>AutonomyLevel</c> is enforced as an <em>authoritative baseline</em> scoped to the
+/// plugin's <b>real, declared tool names</b> — never a synthetic <c>{plugin}:*</c> wildcard, which no
+/// live tool name ever matches. The provider enumerates every skill attributed to the plugin (via
+/// <see cref="SkillDefinition.PluginSource"/>) and collects the tool names those skills declare
+/// (<c>AllowedTools</c>, <c>ToolDeclarations</c>, and any pre-created <c>Tools</c>). Each distinct name
+/// gets one rule flagged <see cref="ToolPermissionRule.IsAuthoritativeBaseline"/>, so the resolver
+/// applies the plugin's autonomy in both directions (Autonomous → Allow can loosen a stricter
+/// default; Restricted/Supervised → Ask can tighten) while a bypass-immune <c>DeniedTools</c> rule
+/// still wins.
+/// </para>
+/// <para>
+/// <b>Limitation.</b> A plugin whose skills declare no tools (Injected mode — the skill receives all
+/// MCP tools at runtime) exposes no statically-enumerable tool names, so its autonomy baseline cannot
+/// be scoped to specific tools and is skipped with a warning. Operators who need an autonomy baseline
+/// on such a plugin must name its tools via the plugin's <c>AllowedTools</c> or per-skill
+/// <c>allowed-tools</c> declarations. (<c>DeniedTools</c> are unaffected — they name tools explicitly.)
+/// </para>
 /// </remarks>
 public sealed class PluginPermissionRuleProvider : IPermissionRuleProvider
 {
     private readonly IPluginRegistry _registry;
+    private readonly ISkillMetadataRegistry _skillRegistry;
     private readonly ILogger<PluginPermissionRuleProvider> _logger;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="PluginPermissionRuleProvider"/> class.
     /// </summary>
     /// <param name="registry">The plugin registry providing loaded plugin metadata.</param>
-    /// <param name="logger">Logger for invalid autonomy level warnings.</param>
+    /// <param name="skillRegistry">
+    /// The skill metadata registry, used to enumerate the tools declared by a plugin's skills so the
+    /// autonomy baseline can be scoped to real tool names.
+    /// </param>
+    /// <param name="logger">Logger for invalid autonomy level and unscoped-baseline warnings.</param>
     public PluginPermissionRuleProvider(
         IPluginRegistry registry,
+        ISkillMetadataRegistry skillRegistry,
         ILogger<PluginPermissionRuleProvider> logger)
     {
         _registry = registry;
+        _skillRegistry = skillRegistry;
         _logger = logger;
     }
 
@@ -86,14 +113,67 @@ public sealed class PluginPermissionRuleProvider : IPermissionRuleProvider
                 _ => PermissionBehaviorType.Ask
             };
 
-            rules.Add(new ToolPermissionRule(
-                $"{plugin.Name}:*",
-                null,
-                defaultBehavior,
-                PermissionRuleSource.PluginDeclaration,
-                Priority: 5));
+            var pluginToolNames = EnumeratePluginToolNames(plugin.Name);
+            if (pluginToolNames.Count == 0)
+            {
+                _logger.LogWarning(
+                    "Plugin {Name}: AutonomyLevel '{Level}' set, but the plugin's skills declare no tool names " +
+                    "(Injected mode) — the autonomy baseline cannot be scoped to specific tools and is skipped. " +
+                    "Declare the tools via the plugin's AllowedTools or a skill's allowed-tools to enforce it.",
+                    plugin.Name, plugin.Declaration.AutonomyLevel);
+                continue;
+            }
+
+            foreach (var toolName in pluginToolNames)
+            {
+                rules.Add(new ToolPermissionRule(
+                    toolName,
+                    null,
+                    defaultBehavior,
+                    PermissionRuleSource.PluginDeclaration,
+                    Priority: 5,
+                    IsAuthoritativeBaseline: true));
+            }
         }
 
         return Task.FromResult<IReadOnlyList<ToolPermissionRule>>(rules);
+    }
+
+    /// <summary>
+    /// Collects the distinct tool names declared by every skill attributed to
+    /// <paramref name="pluginName"/>, drawn from each skill's <see cref="SkillDefinition.AllowedTools"/>,
+    /// <see cref="SkillDefinition.ToolDeclarations"/>, and pre-created <see cref="SkillDefinition.Tools"/>.
+    /// Names are matched at invocation against the live tool set, so they mirror the names the agent
+    /// actually calls.
+    /// </summary>
+    private IReadOnlyCollection<string> EnumeratePluginToolNames(string pluginName)
+    {
+        var names = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var skill in _skillRegistry.GetAll())
+        {
+            if (!string.Equals(skill.PluginSource, pluginName, StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            if (skill.AllowedTools is { Count: > 0 } allowed)
+                foreach (var name in allowed)
+                    AddIfNamed(names, name);
+
+            if (skill.ToolDeclarations is { Count: > 0 } declarations)
+                foreach (var declaration in declarations)
+                    AddIfNamed(names, declaration.Name);
+
+            if (skill.Tools is { Count: > 0 } tools)
+                foreach (var tool in tools)
+                    AddIfNamed(names, tool.Name);
+        }
+
+        return names;
+    }
+
+    private static void AddIfNamed(HashSet<string> names, string? name)
+    {
+        if (!string.IsNullOrWhiteSpace(name))
+            names.Add(name);
     }
 }

--- a/src/Content/Application/Application.Core/Permissions/PluginPermissionRuleProvider.cs
+++ b/src/Content/Application/Application.Core/Permissions/PluginPermissionRuleProvider.cs
@@ -1,9 +1,11 @@
 using Application.AI.Common.Interfaces;
 using Application.AI.Common.Interfaces.Permissions;
 using Application.AI.Common.Interfaces.Plugins;
+using Application.AI.Common.Interfaces.Tools;
 using Domain.AI.Governance;
 using Domain.AI.Permissions;
 using Domain.AI.Skills;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
 namespace Application.Core.Permissions;
@@ -32,6 +34,17 @@ namespace Application.Core.Permissions;
 /// still wins.
 /// </para>
 /// <para>
+/// <b>Own-surface constraint (security).</b> The baseline only covers names that are genuinely part of
+/// the plugin's own tool surface — tools it contributes (MCP or skill-provided). A name that resolves
+/// to a globally-registered keyed-DI tool (the shared, powerful harness tools such as
+/// <c>file_system</c> or a shell) is <em>not</em> owned by the plugin and is excluded from the
+/// baseline (with a warning), even if the plugin's <c>SKILL.md</c> names it. Otherwise an operator who
+/// marks a third-party plugin <c>Autonomous</c> — intending to auto-run that plugin's own narrow tools
+/// — would silently auto-approve a powerful global tool agent-wide (for every caller, not just the
+/// plugin). The plugin can still <em>use</em> such a tool; it just does not get to auto-approve it.
+/// Bypass-immune <c>DeniedTools</c> remains the backstop for sensitive global tools.
+/// </para>
+/// <para>
 /// <b>Limitation.</b> A plugin whose skills declare no tools (Injected mode — the skill receives all
 /// MCP tools at runtime) exposes no statically-enumerable tool names, so its autonomy baseline cannot
 /// be scoped to specific tools and is skipped with a warning. Operators who need an autonomy baseline
@@ -43,6 +56,7 @@ public sealed class PluginPermissionRuleProvider : IPermissionRuleProvider
 {
     private readonly IPluginRegistry _registry;
     private readonly ISkillMetadataRegistry _skillRegistry;
+    private readonly IServiceProvider _serviceProvider;
     private readonly ILogger<PluginPermissionRuleProvider> _logger;
 
     /// <summary>
@@ -53,14 +67,20 @@ public sealed class PluginPermissionRuleProvider : IPermissionRuleProvider
     /// The skill metadata registry, used to enumerate the tools declared by a plugin's skills so the
     /// autonomy baseline can be scoped to real tool names.
     /// </param>
+    /// <param name="serviceProvider">
+    /// Used to detect globally-registered keyed-DI tools so the autonomy baseline can exclude shared
+    /// harness tools the plugin does not own.
+    /// </param>
     /// <param name="logger">Logger for invalid autonomy level and unscoped-baseline warnings.</param>
     public PluginPermissionRuleProvider(
         IPluginRegistry registry,
         ISkillMetadataRegistry skillRegistry,
+        IServiceProvider serviceProvider,
         ILogger<PluginPermissionRuleProvider> logger)
     {
         _registry = registry;
         _skillRegistry = skillRegistry;
+        _serviceProvider = serviceProvider;
         _logger = logger;
     }
 
@@ -144,7 +164,9 @@ public sealed class PluginPermissionRuleProvider : IPermissionRuleProvider
     /// <paramref name="pluginName"/>, drawn from each skill's <see cref="SkillDefinition.AllowedTools"/>,
     /// <see cref="SkillDefinition.ToolDeclarations"/>, and pre-created <see cref="SkillDefinition.Tools"/>.
     /// Names are matched at invocation against the live tool set, so they mirror the names the agent
-    /// actually calls.
+    /// actually calls. Names that are <em>not</em> part of the plugin's own tool surface — i.e. tools
+    /// that resolve to a globally-registered keyed-DI tool — are excluded so the autonomy baseline
+    /// cannot loosen a shared harness tool the plugin does not own (see the type remarks).
     /// </summary>
     private IReadOnlyCollection<string> EnumeratePluginToolNames(string pluginName)
     {
@@ -157,23 +179,41 @@ public sealed class PluginPermissionRuleProvider : IPermissionRuleProvider
 
             if (skill.AllowedTools is { Count: > 0 } allowed)
                 foreach (var name in allowed)
-                    AddIfNamed(names, name);
+                    AddIfOwned(names, name, pluginName);
 
             if (skill.ToolDeclarations is { Count: > 0 } declarations)
                 foreach (var declaration in declarations)
-                    AddIfNamed(names, declaration.Name);
+                    AddIfOwned(names, declaration.Name, pluginName);
 
             if (skill.Tools is { Count: > 0 } tools)
                 foreach (var tool in tools)
-                    AddIfNamed(names, tool.Name);
+                    AddIfOwned(names, tool.Name, pluginName);
         }
 
         return names;
     }
 
-    private static void AddIfNamed(HashSet<string> names, string? name)
+    /// <summary>
+    /// Adds <paramref name="name"/> to the baseline set only when it is a non-empty name genuinely
+    /// owned by the plugin. A name that resolves to a globally-registered keyed-DI tool is a shared
+    /// harness tool the plugin does not own; it is skipped with a warning so the plugin's autonomy
+    /// baseline can never auto-approve it agent-wide.
+    /// </summary>
+    private void AddIfOwned(HashSet<string> names, string? name, string pluginName)
     {
-        if (!string.IsNullOrWhiteSpace(name))
-            names.Add(name);
+        if (string.IsNullOrWhiteSpace(name))
+            return;
+
+        if (_serviceProvider.GetKeyedService<ITool>(name) is not null)
+        {
+            _logger.LogWarning(
+                "Plugin {Name}: tool '{Tool}' named in the plugin's skills is a global keyed-DI tool the plugin " +
+                "does not own — excluded from the plugin's autonomy baseline. Use a per-tool AutonomyTier override " +
+                "or DeniedTools to govern shared tools.",
+                pluginName, name);
+            return;
+        }
+
+        names.Add(name);
     }
 }

--- a/src/Content/Domain/Domain.AI/Permissions/ToolPermissionRule.cs
+++ b/src/Content/Domain/Domain.AI/Permissions/ToolPermissionRule.cs
@@ -10,10 +10,20 @@ namespace Domain.AI.Permissions;
 /// <param name="Source">Where this rule originated.</param>
 /// <param name="Priority">Evaluation priority. Lower values are checked first.</param>
 /// <param name="IsBypassImmune">When true, this rule cannot be overridden by bypass/auto-approve modes.</param>
+/// <param name="IsAuthoritativeBaseline">
+/// When true, this rule is an operator-set authoritative baseline for the tools it matches: it takes
+/// precedence over generic tier/default rules in <em>both</em> directions (a specific Allow beats a
+/// generic Ask, and a specific Ask beats a generic Allow), independent of the resolver's normal
+/// Deny&gt;Ask&gt;Allow phase ordering. It is evaluated after safety gates and Deny rules, so a Deny
+/// (including a bypass-immune <c>DeniedTools</c> rule) or a safety gate still wins over it. This is
+/// how a plugin's <c>AutonomyLevel</c> scopes the autonomy of its own tools without editing the
+/// global default tier. Ordinary rules leave this false and are unaffected.
+/// </param>
 public sealed record ToolPermissionRule(
     string ToolPattern,
     string? OperationPattern,
     PermissionBehaviorType Behavior,
     PermissionRuleSource Source,
     int Priority,
-    bool IsBypassImmune = false);
+    bool IsBypassImmune = false,
+    bool IsAuthoritativeBaseline = false);

--- a/src/Content/Infrastructure/Infrastructure.AI/Permissions/ThreePhasePermissionResolver.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Permissions/ThreePhasePermissionResolver.cs
@@ -209,16 +209,21 @@ public sealed class ThreePhasePermissionResolver : IToolPermissionService
     }
 
     /// <summary>
-    /// Finds the highest-precedence (lowest <see cref="ToolPermissionRule.Priority"/>) rule flagged
-    /// <see cref="ToolPermissionRule.IsAuthoritativeBaseline"/> that matches the tool name and
-    /// operation, regardless of its <see cref="PermissionBehaviorType"/>. Returns null when no
-    /// authoritative-baseline rule matches (the overwhelmingly common case).
+    /// Selects the governing rule flagged <see cref="ToolPermissionRule.IsAuthoritativeBaseline"/>
+    /// among all that match the tool name and operation. When more than one matches (for example two
+    /// plugins declaring the same tool name with opposite autonomy levels), the <b>most restrictive</b>
+    /// behavior wins — Deny &gt; Ask &gt; Allow — so a permissive baseline can never silently override a
+    /// restrictive one on iteration/load order. Ties within the same behavior fall back to the lowest
+    /// <see cref="ToolPermissionRule.Priority"/>. Returns null when no authoritative-baseline rule
+    /// matches (the overwhelmingly common case).
     /// </summary>
     private ToolPermissionRule? FindFirstAuthoritativeBaseline(
         IReadOnlyList<ToolPermissionRule> rules,
         string toolName,
         string? operation)
     {
+        ToolPermissionRule? best = null;
+
         foreach (var rule in rules)
         {
             if (!rule.IsAuthoritativeBaseline)
@@ -237,11 +242,36 @@ public sealed class ThreePhasePermissionResolver : IToolPermissionService
             if (rule.OperationPattern is not null && operation is null)
                 continue;
 
-            return rule;
+            if (best is null || IsMoreRestrictive(rule, best))
+                best = rule;
         }
 
-        return null;
+        return best;
     }
+
+    /// <summary>
+    /// Orders permission behaviors by restrictiveness for authoritative-baseline arbitration:
+    /// Deny (0) is most restrictive, then Ask (1), then Allow (2). A <paramref name="candidate"/> wins
+    /// over the <paramref name="incumbent"/> when it is strictly more restrictive, or equally
+    /// restrictive but with a lower (earlier) priority.
+    /// </summary>
+    private static bool IsMoreRestrictive(ToolPermissionRule candidate, ToolPermissionRule incumbent)
+    {
+        var candidateRank = RestrictivenessRank(candidate.Behavior);
+        var incumbentRank = RestrictivenessRank(incumbent.Behavior);
+
+        if (candidateRank != incumbentRank)
+            return candidateRank < incumbentRank;
+
+        return candidate.Priority < incumbent.Priority;
+    }
+
+    private static int RestrictivenessRank(PermissionBehaviorType behavior) => behavior switch
+    {
+        PermissionBehaviorType.Deny => 0,
+        PermissionBehaviorType.Ask => 1,
+        _ => 2
+    };
 
     private void LogDecision(string agentId, string toolName, PermissionDecision decision)
     {

--- a/src/Content/Infrastructure/Infrastructure.AI/Permissions/ThreePhasePermissionResolver.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Permissions/ThreePhasePermissionResolver.cs
@@ -102,6 +102,24 @@ public sealed class ThreePhasePermissionResolver : IToolPermissionService
             return denyDecision;
         }
 
+        // Phase 1.5: Authoritative baseline (e.g. a plugin's AutonomyLevel scoped to its own tools).
+        // Runs after Deny so a bypass-immune DeniedTools rule or a safety gate still wins, but before
+        // Ask/Allow phase ordering so an operator-set per-plugin baseline takes precedence over the
+        // generic tier/default rules in BOTH directions (Allow can loosen, Ask can tighten). Ordinary
+        // rules never set this flag, so this phase is a no-op for every non-plugin deployment.
+        var baselineRule = FindFirstAuthoritativeBaseline(sortedRules, toolName, operation);
+        if (baselineRule is not null)
+        {
+            var baselineDecision = new PermissionDecision(
+                baselineRule.Behavior,
+                $"Authoritative baseline from {baselineRule.Source} (pattern: '{baselineRule.ToolPattern}').",
+                baselineRule,
+                baselineRule.Source);
+
+            LogDecision(agentId, toolName, baselineDecision);
+            return baselineDecision;
+        }
+
         // Phase 2: Ask rules
         var askRule = FindFirstMatchingRule(sortedRules, toolName, operation, PermissionBehaviorType.Ask);
         if (askRule is not null)
@@ -181,6 +199,41 @@ public sealed class ThreePhasePermissionResolver : IToolPermissionService
             }
 
             // If rule has an operation pattern but no operation was provided, skip
+            if (rule.OperationPattern is not null && operation is null)
+                continue;
+
+            return rule;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Finds the highest-precedence (lowest <see cref="ToolPermissionRule.Priority"/>) rule flagged
+    /// <see cref="ToolPermissionRule.IsAuthoritativeBaseline"/> that matches the tool name and
+    /// operation, regardless of its <see cref="PermissionBehaviorType"/>. Returns null when no
+    /// authoritative-baseline rule matches (the overwhelmingly common case).
+    /// </summary>
+    private ToolPermissionRule? FindFirstAuthoritativeBaseline(
+        IReadOnlyList<ToolPermissionRule> rules,
+        string toolName,
+        string? operation)
+    {
+        foreach (var rule in rules)
+        {
+            if (!rule.IsAuthoritativeBaseline)
+                continue;
+
+            if (!_patternMatcher.IsMatch(rule.ToolPattern, toolName))
+                continue;
+
+            if (rule.OperationPattern is not null
+                && operation is not null
+                && !_patternMatcher.IsMatch(rule.OperationPattern, operation))
+            {
+                continue;
+            }
+
             if (rule.OperationPattern is not null && operation is null)
                 continue;
 

--- a/src/Content/Infrastructure/Infrastructure.AI/Skills/SkillMetadataRegistry.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Skills/SkillMetadataRegistry.cs
@@ -121,6 +121,8 @@ public sealed class SkillMetadataRegistry : ISkillMetadataRegistry
 
     private Dictionary<string, SkillDefinition> Discover()
     {
+        GuardPluginRegistryPresent();
+
         var skillsConfig = _appConfig.CurrentValue.AI?.Skills;
         var paths = skillsConfig?.AllPaths.ToList() ?? [];
 
@@ -164,6 +166,27 @@ public sealed class SkillMetadataRegistry : ISkillMetadataRegistry
             result.Count, resolvedPaths.Count);
 
         return result;
+    }
+
+    /// <summary>
+    /// Fails fast when the host declares plugins but no <see cref="IPluginRegistry"/> was registered.
+    /// Without the registry, discovered skills can never be attributed to their owning plugin, so
+    /// plugin boundary governance (AllowedTools/DeniedTools and AutonomyLevel) would silently no-op —
+    /// a security-relevant misconfiguration. A clear startup exception is preferable to ungoverned
+    /// plugin tools. Hosts that declare no plugins (for example the standalone MCP server) are
+    /// unaffected: the registry stays legitimately optional there.
+    /// </summary>
+    private void GuardPluginRegistryPresent()
+    {
+        var declaredPlugins = _appConfig.CurrentValue.AI?.Plugins?.Packages?.Count ?? 0;
+        if (declaredPlugins > 0 && _pluginRegistry is null)
+        {
+            throw new InvalidOperationException(
+                $"{declaredPlugins} plugin(s) are declared under AppConfig.AI.Plugins.Packages, but no " +
+                $"{nameof(IPluginRegistry)} is registered. Plugin boundary governance " +
+                "(AllowedTools/DeniedTools/AutonomyLevel) cannot be enforced without it. Register the " +
+                "plugin services (which include IPluginRegistry) or remove the plugin declarations.");
+        }
     }
 
     /// <summary>

--- a/src/Content/Tests/Application.Core.Tests/Permissions/PluginPermissionRuleProviderTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/Permissions/PluginPermissionRuleProviderTests.cs
@@ -1,21 +1,25 @@
 using Application.AI.Common.Interfaces;
 using Application.AI.Common.Interfaces.Plugins;
+using Application.AI.Common.Interfaces.Tools;
 using Application.Core.Permissions;
 using Domain.AI.Governance;
 using Domain.AI.Permissions;
 using Domain.AI.Skills;
 using Domain.Common.Config.AI.Plugins;
 using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Xunit;
 
 namespace Application.Core.Tests.Permissions;
 
-public sealed class PluginPermissionRuleProviderTests
+public sealed class PluginPermissionRuleProviderTests : IDisposable
 {
     private readonly Mock<IPluginRegistry> _registryMock = new();
     private readonly Mock<ISkillMetadataRegistry> _skillRegistryMock = new();
+    private readonly ServiceCollection _services = new();
+    private ServiceProvider? _serviceProvider;
 
     public PluginPermissionRuleProviderTests()
     {
@@ -23,11 +27,19 @@ public sealed class PluginPermissionRuleProviderTests
         _skillRegistryMock.Setup(r => r.GetAll()).Returns(new List<SkillDefinition>());
     }
 
+    public void Dispose() => _serviceProvider?.Dispose();
+
+    /// <summary>Registers <paramref name="toolName"/> as a global keyed-DI tool (i.e. NOT plugin-owned).</summary>
+    private void GivenGlobalKeyedTool(string toolName) =>
+        _services.AddKeyedSingleton<ITool>(toolName, (_, _) => Mock.Of<ITool>());
+
     private PluginPermissionRuleProvider CreateProvider()
     {
+        _serviceProvider = _services.BuildServiceProvider();
         return new PluginPermissionRuleProvider(
             _registryMock.Object,
             _skillRegistryMock.Object,
+            _serviceProvider,
             NullLogger<PluginPermissionRuleProvider>.Instance);
     }
 
@@ -138,6 +150,26 @@ public sealed class PluginPermissionRuleProviderTests
             "the Supervised baseline must apply to the plugin skill's real declared tool");
         rules.Should().NotContain(r => r.ToolPattern == "sentinel:*",
             "the inert synthetic wildcard must be gone");
+    }
+
+    [Fact]
+    public async Task GetRulesAsync_AutonomousPlugin_CannotLoosenGlobalToolItDoesNotOwn()
+    {
+        // Security (F2): a plugin's SKILL.md names a powerful GLOBAL tool ("bash") alongside its own
+        // tool ("run_x"). Marking the plugin Autonomous must NOT emit an authoritative Allow baseline
+        // for "bash" (which would auto-approve it agent-wide for every caller) — only the plugin's own
+        // "run_x" gets the baseline. The plugin can still use "bash"; it just cannot auto-approve it.
+        var declaration = new PluginDeclaration { Name = "trusted", AutonomyLevel = "Autonomous" };
+        _registryMock.Setup(r => r.GetLoadedPlugins()).Returns(new List<LoadedPlugin> { Loaded(declaration) });
+        GivenPluginSkillDeclaresTools("trusted", "run_x", "bash");
+        GivenGlobalKeyedTool("bash"); // bash is a shared harness tool, not owned by the plugin
+
+        var rules = await CreateProvider().GetRulesAsync("any-agent");
+
+        rules.Should().Contain(r => r.ToolPattern == "run_x"
+            && r.Behavior == PermissionBehaviorType.Allow && r.IsAuthoritativeBaseline);
+        rules.Should().NotContain(r => r.ToolPattern == "bash",
+            "a global keyed-DI tool the plugin does not own must be excluded from its autonomy baseline");
     }
 
     [Fact]

--- a/src/Content/Tests/Application.Core.Tests/Permissions/PluginPermissionRuleProviderTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/Permissions/PluginPermissionRuleProviderTests.cs
@@ -1,7 +1,9 @@
+using Application.AI.Common.Interfaces;
 using Application.AI.Common.Interfaces.Plugins;
 using Application.Core.Permissions;
 using Domain.AI.Governance;
 using Domain.AI.Permissions;
+using Domain.AI.Skills;
 using Domain.Common.Config.AI.Plugins;
 using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -13,13 +15,39 @@ namespace Application.Core.Tests.Permissions;
 public sealed class PluginPermissionRuleProviderTests
 {
     private readonly Mock<IPluginRegistry> _registryMock = new();
+    private readonly Mock<ISkillMetadataRegistry> _skillRegistryMock = new();
+
+    public PluginPermissionRuleProviderTests()
+    {
+        // Default: no skills discovered. Tests that need plugin-declared tools override this.
+        _skillRegistryMock.Setup(r => r.GetAll()).Returns(new List<SkillDefinition>());
+    }
 
     private PluginPermissionRuleProvider CreateProvider()
     {
         return new PluginPermissionRuleProvider(
             _registryMock.Object,
+            _skillRegistryMock.Object,
             NullLogger<PluginPermissionRuleProvider>.Instance);
     }
+
+    /// <summary>Attributes one skill declaring <paramref name="toolNames"/> to <paramref name="pluginName"/>.</summary>
+    private void GivenPluginSkillDeclaresTools(string pluginName, params string[] toolNames)
+    {
+        _skillRegistryMock.Setup(r => r.GetAll()).Returns(new List<SkillDefinition>
+        {
+            new()
+            {
+                Id = $"{pluginName}-skill",
+                PluginSource = pluginName,
+                AllowedTools = toolNames.ToList()
+            }
+        });
+    }
+
+    private static LoadedPlugin Loaded(PluginDeclaration declaration) =>
+        new(declaration.Name, "1.0", $"/plugins/{declaration.Name}", new PluginManifest(),
+            PluginLoadStatus.Loaded, [$"/plugins/{declaration.Name}/skills"], [], declaration);
 
     [Fact]
     public void Source_ReturnsPluginDeclaration()
@@ -40,49 +68,90 @@ public sealed class PluginPermissionRuleProviderTests
     public async Task GetRulesAsync_PluginWithNoAutonomyLevel_ReturnsEmpty()
     {
         var declaration = new PluginDeclaration { Name = "azure", AutonomyLevel = null };
-        _registryMock.Setup(r => r.GetLoadedPlugins()).Returns(new List<LoadedPlugin>
-        {
-            new("azure", "1.0", "/plugins/azure", new PluginManifest(),
-                PluginLoadStatus.Loaded, ["skill1"], ["azure:server"], declaration)
-        });
+        _registryMock.Setup(r => r.GetLoadedPlugins()).Returns(new List<LoadedPlugin> { Loaded(declaration) });
 
         var rules = await CreateProvider().GetRulesAsync("any-agent");
         rules.Should().BeEmpty();
     }
 
     [Fact]
-    public async Task GetRulesAsync_RestrictedPlugin_EmitsAskRules()
+    public async Task GetRulesAsync_RestrictedPlugin_EmitsAuthoritativeAskRulesForDeclaredTools()
     {
         var declaration = new PluginDeclaration { Name = "untrusted", AutonomyLevel = "Restricted" };
-        _registryMock.Setup(r => r.GetLoadedPlugins()).Returns(new List<LoadedPlugin>
-        {
-            new("untrusted", "1.0", "/plugins/untrusted", new PluginManifest(),
-                PluginLoadStatus.Loaded, [], ["untrusted:server"], declaration)
-        });
+        _registryMock.Setup(r => r.GetLoadedPlugins()).Returns(new List<LoadedPlugin> { Loaded(declaration) });
+        GivenPluginSkillDeclaresTools("untrusted", "run_x");
 
         var rules = await CreateProvider().GetRulesAsync("any-agent");
 
         rules.Should().ContainSingle();
         var rule = rules[0];
-        rule.ToolPattern.Should().Be("untrusted:*");
+        rule.ToolPattern.Should().Be("run_x");
         rule.Behavior.Should().Be(PermissionBehaviorType.Ask);
         rule.Source.Should().Be(PermissionRuleSource.PluginDeclaration);
+        rule.IsAuthoritativeBaseline.Should().BeTrue();
     }
 
     [Fact]
-    public async Task GetRulesAsync_AutonomousPlugin_EmitsAllowRules()
+    public async Task GetRulesAsync_AutonomousPlugin_EmitsAuthoritativeAllowRulesForDeclaredTools()
     {
         var declaration = new PluginDeclaration { Name = "trusted", AutonomyLevel = "Autonomous" };
-        _registryMock.Setup(r => r.GetLoadedPlugins()).Returns(new List<LoadedPlugin>
-        {
-            new("trusted", "1.0", "/plugins/trusted", new PluginManifest(),
-                PluginLoadStatus.Loaded, [], ["trusted:server"], declaration)
-        });
+        _registryMock.Setup(r => r.GetLoadedPlugins()).Returns(new List<LoadedPlugin> { Loaded(declaration) });
+        GivenPluginSkillDeclaresTools("trusted", "run_x");
 
         var rules = await CreateProvider().GetRulesAsync("any-agent");
 
         rules.Should().ContainSingle();
+        rules[0].ToolPattern.Should().Be("run_x");
         rules[0].Behavior.Should().Be(PermissionBehaviorType.Allow);
+        rules[0].IsAuthoritativeBaseline.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task GetRulesAsync_MultipleDeclaredTools_EmitsOneBaselinePerDistinctToolName()
+    {
+        var declaration = new PluginDeclaration { Name = "p", AutonomyLevel = "Supervised" };
+        _registryMock.Setup(r => r.GetLoadedPlugins()).Returns(new List<LoadedPlugin> { Loaded(declaration) });
+        GivenPluginSkillDeclaresTools("p", "a", "b", "a"); // duplicate must collapse
+
+        var rules = await CreateProvider().GetRulesAsync("any-agent");
+
+        rules.Select(r => r.ToolPattern).Should().BeEquivalentTo("a", "b");
+        rules.Should().OnlyContain(r => r.Behavior == PermissionBehaviorType.Ask && r.IsAuthoritativeBaseline);
+    }
+
+    [Fact]
+    public async Task GetRulesAsync_SupervisedPlugin_EmitsBaselineForRealDeclaredToolName_NotWildcard()
+    {
+        // Regression pin for the inert-baseline bug: the Supervised baseline must apply to the
+        // plugin skill's REAL declared tool name — never the synthetic "{plugin}:*" wildcard that
+        // no live tool name ever matches.
+        var declaration = new PluginDeclaration { Name = "sentinel", AutonomyLevel = "Supervised" };
+        _registryMock.Setup(r => r.GetLoadedPlugins()).Returns(new List<LoadedPlugin> { Loaded(declaration) });
+        GivenPluginSkillDeclaresTools("sentinel", "deploy_widget");
+
+        var rules = await CreateProvider().GetRulesAsync("any-agent");
+
+        rules.Should().Contain(
+            r => r.ToolPattern == "deploy_widget"
+                 && r.Behavior == PermissionBehaviorType.Ask
+                 && r.IsAuthoritativeBaseline,
+            "the Supervised baseline must apply to the plugin skill's real declared tool");
+        rules.Should().NotContain(r => r.ToolPattern == "sentinel:*",
+            "the inert synthetic wildcard must be gone");
+    }
+
+    [Fact]
+    public async Task GetRulesAsync_AutonomyLevelSet_ButNoDeclaredTools_SkipsBaseline()
+    {
+        // Injected-mode plugin: skills declare no tools, so the baseline cannot be scoped to real
+        // tool names and must be skipped (with a warning) rather than emitting an inert wildcard.
+        var declaration = new PluginDeclaration { Name = "injected", AutonomyLevel = "Supervised" };
+        _registryMock.Setup(r => r.GetLoadedPlugins()).Returns(new List<LoadedPlugin> { Loaded(declaration) });
+        // No skills attributed to "injected".
+
+        var rules = await CreateProvider().GetRulesAsync("any-agent");
+
+        rules.Should().BeEmpty();
     }
 
     [Fact]
@@ -94,16 +163,14 @@ public sealed class PluginPermissionRuleProviderTests
             AutonomyLevel = "Supervised",
             DeniedTools = ["bash", "deploy_production"]
         };
-        _registryMock.Setup(r => r.GetLoadedPlugins()).Returns(new List<LoadedPlugin>
-        {
-            new("limited", "1.0", "/plugins/limited", new PluginManifest(),
-                PluginLoadStatus.Loaded, [], ["limited:server"], declaration)
-        });
+        _registryMock.Setup(r => r.GetLoadedPlugins()).Returns(new List<LoadedPlugin> { Loaded(declaration) });
+        GivenPluginSkillDeclaresTools("limited", "run_x");
 
         var rules = await CreateProvider().GetRulesAsync("any-agent");
 
-        rules.Should().HaveCount(3); // 1 global Ask + 2 Deny overrides
-        rules.Should().Contain(r => r.ToolPattern == "limited:*" && r.Behavior == PermissionBehaviorType.Ask);
+        rules.Should().HaveCount(3); // 1 authoritative baseline + 2 Deny overrides
+        rules.Should().Contain(r => r.ToolPattern == "run_x"
+            && r.Behavior == PermissionBehaviorType.Ask && r.IsAuthoritativeBaseline);
         rules.Should().Contain(r => r.ToolPattern == "bash" && r.Behavior == PermissionBehaviorType.Deny);
         rules.Should().Contain(r => r.ToolPattern == "deploy_production" && r.Behavior == PermissionBehaviorType.Deny);
     }
@@ -120,11 +187,7 @@ public sealed class PluginPermissionRuleProviderTests
             AutonomyLevel = null,
             DeniedTools = ["bash", "deploy_production"]
         };
-        _registryMock.Setup(r => r.GetLoadedPlugins()).Returns(new List<LoadedPlugin>
-        {
-            new("deny-only", "1.0", "/plugins/deny-only", new PluginManifest(),
-                PluginLoadStatus.Loaded, [], ["deny-only:server"], declaration)
-        });
+        _registryMock.Setup(r => r.GetLoadedPlugins()).Returns(new List<LoadedPlugin> { Loaded(declaration) });
 
         var rules = await CreateProvider().GetRulesAsync("any-agent");
 
@@ -144,15 +207,12 @@ public sealed class PluginPermissionRuleProviderTests
             AutonomyLevel = "Autonomous",
             DeniedTools = ["dangerous_tool"]
         };
-        _registryMock.Setup(r => r.GetLoadedPlugins()).Returns(new List<LoadedPlugin>
-        {
-            new("plugin", "1.0", "/plugins/plugin", new PluginManifest(),
-                PluginLoadStatus.Loaded, [], ["plugin:server"], declaration)
-        });
+        _registryMock.Setup(r => r.GetLoadedPlugins()).Returns(new List<LoadedPlugin> { Loaded(declaration) });
+        GivenPluginSkillDeclaresTools("plugin", "run_x");
 
         var rules = await CreateProvider().GetRulesAsync("any-agent");
 
-        var baseline = rules.First(r => r.ToolPattern == "plugin:*");
+        var baseline = rules.First(r => r.ToolPattern == "run_x");
         var deny = rules.First(r => r.ToolPattern == "dangerous_tool");
 
         deny.Priority.Should().BeLessThan(baseline.Priority);
@@ -164,11 +224,8 @@ public sealed class PluginPermissionRuleProviderTests
     public async Task GetRulesAsync_InvalidAutonomyLevel_SkipsPlugin()
     {
         var declaration = new PluginDeclaration { Name = "bad", AutonomyLevel = "NotAValidLevel" };
-        _registryMock.Setup(r => r.GetLoadedPlugins()).Returns(new List<LoadedPlugin>
-        {
-            new("bad", "1.0", "/plugins/bad", new PluginManifest(),
-                PluginLoadStatus.Loaded, [], [], declaration)
-        });
+        _registryMock.Setup(r => r.GetLoadedPlugins()).Returns(new List<LoadedPlugin> { Loaded(declaration) });
+        GivenPluginSkillDeclaresTools("bad", "run_x");
 
         var rules = await CreateProvider().GetRulesAsync("any-agent");
 

--- a/src/Content/Tests/Infrastructure.AI.Tests/Permissions/ThreePhasePermissionResolverAutonomyTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Permissions/ThreePhasePermissionResolverAutonomyTests.cs
@@ -136,4 +136,64 @@ public sealed class ThreePhasePermissionResolverAutonomyTests
         // Ask(*) matches in Phase 2 before Allow(query_kg) in Phase 3
         decision.Behavior.Should().Be(PermissionBehaviorType.Ask);
     }
+
+    [Fact]
+    public async Task AuthoritativeBaselineAllow_BeatsGenericTierAsk()
+    {
+        // A plugin's Autonomous baseline (authoritative Allow scoped to its tool) must LOOSEN a
+        // stricter generic default: it wins over the tier's "*" Ask despite Allow living in the
+        // later phase, because the authoritative-baseline phase runs before Ask/Allow ordering.
+        var provider = BuildProvider(
+            new ToolPermissionRule("*", null, PermissionBehaviorType.Ask, PermissionRuleSource.AutonomyTier, 0),
+            new ToolPermissionRule("deploy_widget", null, PermissionBehaviorType.Allow,
+                PermissionRuleSource.PluginDeclaration, 5, IsAuthoritativeBaseline: true));
+
+        var resolver = CreateResolver(provider.Object);
+
+        var decision = await resolver.ResolvePermissionAsync("agent", "deploy_widget");
+
+        decision.Behavior.Should().Be(PermissionBehaviorType.Allow);
+        decision.MatchedRule!.Source.Should().Be(PermissionRuleSource.PluginDeclaration);
+
+        // A tool NOT covered by the baseline still gets the generic tier Ask.
+        var other = await resolver.ResolvePermissionAsync("agent", "unrelated_tool");
+        other.Behavior.Should().Be(PermissionBehaviorType.Ask);
+    }
+
+    [Fact]
+    public async Task AuthoritativeBaselineAsk_BeatsGenericTierAllow()
+    {
+        // A plugin's Supervised baseline (authoritative Ask) must TIGHTEN a looser generic default:
+        // it wins over the tier's "*" Allow for the plugin's tool.
+        var provider = BuildProvider(
+            new ToolPermissionRule("*", null, PermissionBehaviorType.Allow, PermissionRuleSource.AutonomyTier, 0),
+            new ToolPermissionRule("deploy_widget", null, PermissionBehaviorType.Ask,
+                PermissionRuleSource.PluginDeclaration, 5, IsAuthoritativeBaseline: true));
+
+        var resolver = CreateResolver(provider.Object);
+
+        var decision = await resolver.ResolvePermissionAsync("agent", "deploy_widget");
+
+        decision.Behavior.Should().Be(PermissionBehaviorType.Ask);
+        decision.MatchedRule!.Source.Should().Be(PermissionRuleSource.PluginDeclaration);
+    }
+
+    [Fact]
+    public async Task BypassImmuneDeny_BeatsAuthoritativeBaselineAllow()
+    {
+        // DeniedTools (bypass-immune Deny) must still win over a plugin's Autonomous Allow baseline:
+        // the Deny phase runs before the authoritative-baseline phase, so a plugin cannot auto-allow
+        // a tool the operator explicitly denied.
+        var provider = BuildProvider(
+            new ToolPermissionRule("deploy_widget", null, PermissionBehaviorType.Deny,
+                PermissionRuleSource.PluginDeclaration, 1, IsBypassImmune: true),
+            new ToolPermissionRule("deploy_widget", null, PermissionBehaviorType.Allow,
+                PermissionRuleSource.PluginDeclaration, 5, IsAuthoritativeBaseline: true));
+
+        var resolver = CreateResolver(provider.Object);
+
+        var decision = await resolver.ResolvePermissionAsync("agent", "deploy_widget");
+
+        decision.Behavior.Should().Be(PermissionBehaviorType.Deny);
+    }
 }

--- a/src/Content/Tests/Infrastructure.AI.Tests/Permissions/ThreePhasePermissionResolverAutonomyTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Permissions/ThreePhasePermissionResolverAutonomyTests.cs
@@ -178,6 +178,28 @@ public sealed class ThreePhasePermissionResolverAutonomyTests
         decision.MatchedRule!.Source.Should().Be(PermissionRuleSource.PluginDeclaration);
     }
 
+    [Theory]
+    [InlineData(false)] // Allow rule listed first
+    [InlineData(true)]  // Ask rule listed first
+    public async Task AuthoritativeBaseline_MostRestrictiveWins_RegardlessOfOrder(bool askFirst)
+    {
+        // F1: two plugins declare the SAME tool name with opposite autonomy — plugin A Autonomous
+        // (Allow) and plugin B Restricted (Ask), both authoritative at Priority 5. The MOST
+        // RESTRICTIVE behavior (Ask) must win, never decided by rule/load order.
+        var allow = new ToolPermissionRule("deploy_widget", null, PermissionBehaviorType.Allow,
+            PermissionRuleSource.PluginDeclaration, 5, IsAuthoritativeBaseline: true);
+        var ask = new ToolPermissionRule("deploy_widget", null, PermissionBehaviorType.Ask,
+            PermissionRuleSource.PluginDeclaration, 5, IsAuthoritativeBaseline: true);
+
+        var provider = askFirst ? BuildProvider(ask, allow) : BuildProvider(allow, ask);
+        var resolver = CreateResolver(provider.Object);
+
+        var decision = await resolver.ResolvePermissionAsync("agent", "deploy_widget");
+
+        decision.Behavior.Should().Be(PermissionBehaviorType.Ask,
+            "the restrictive baseline must win over the permissive one irrespective of order");
+    }
+
     [Fact]
     public async Task BypassImmuneDeny_BeatsAuthoritativeBaselineAllow()
     {

--- a/src/Content/Tests/Infrastructure.AI.Tests/Skills/SkillMetadataRegistryTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Skills/SkillMetadataRegistryTests.cs
@@ -37,6 +37,37 @@ public sealed class SkillMetadataRegistryTests
     }
 
     [Fact]
+    public void GetAll_PluginsDeclaredButNoPluginRegistry_ThrowsFailFast()
+    {
+        // Fail-fast guard: declaring plugins without an IPluginRegistry would silently no-op plugin
+        // boundary governance (attribution never happens). A clear startup exception is required.
+        var appConfig = new AppConfig
+        {
+            AI = new AIConfig
+            {
+                Skills = new SkillsConfig { BasePath = SkillsPath },
+                Plugins = new Domain.Common.Config.AI.Plugins.PluginsConfig
+                {
+                    Packages =
+                    [
+                        new Domain.Common.Config.AI.Plugins.PluginDeclaration { Name = "some-plugin", Path = "./plugins/some-plugin" }
+                    ]
+                }
+            }
+        };
+        var registry = new SkillMetadataRegistry(
+            NullLogger<SkillMetadataRegistry>.Instance,
+            new OptionsMonitorStub(appConfig),
+            new SkillMetadataParser(NullLogger<SkillMetadataParser>.Instance),
+            pluginRegistry: null);
+
+        var act = () => registry.GetAll();
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*IPluginRegistry*");
+    }
+
+    [Fact]
     public void GetAll_WithValidSkillsPath_ReturnsDiscoveredSkills()
     {
         if (!Directory.Exists(SkillsPath))

--- a/src/Content/Tests/Presentation.Common.Tests/Composition/PluginGovernanceCompositionTests.cs
+++ b/src/Content/Tests/Presentation.Common.Tests/Composition/PluginGovernanceCompositionTests.cs
@@ -42,6 +42,10 @@ public sealed class PluginGovernanceCompositionTests : IDisposable
     private const string HostSkillId = "host-skill";
     private const string DeniedToolName = "dangerous_tool";
 
+    // A real tool the plugin's skill declares. The plugin's AutonomyLevel baseline is scoped to
+    // this name (not a synthetic "{plugin}:*" wildcard), mirroring how a live plugin tool is named.
+    private const string PluginToolName = "deploy_widget";
+
     private readonly string _tempRoot;
     private readonly string _builtInSkillsDir;
     private readonly string _pluginDir;
@@ -69,7 +73,8 @@ public sealed class PluginGovernanceCompositionTests : IDisposable
         WriteSkill(Path.Combine(_pluginDir, "skills", "do-thing"), $"""
             ---
             name: {PluginSkillId}
-            description: A plugin skill with no tool declarations.
+            description: A plugin skill declaring one tool so the autonomy baseline can scope to it.
+            allowed-tools: [{PluginToolName}]
             ---
             Plugin instructions.
             """);
@@ -176,71 +181,72 @@ public sealed class PluginGovernanceCompositionTests : IDisposable
     }
 
     [Fact]
-    public async Task GovernedTool_PluginScopedSupervisedBaseline_RequiresApprovalForPluginPrefixedTool()
+    public async Task GovernedTool_PluginSupervisedBaseline_TightensRealDeclaredToolToPendingApproval()
     {
-        // The {plugin}:* case that IS enforced: a Supervised/Restricted plugin baseline emits an
-        // Ask rule scoped "sentinel:*". Ask rules resolve in phase 2, BEFORE any Allow rule, so
-        // the plugin baseline tightens an otherwise Allow-by-default environment for tools whose
-        // names carry the plugin prefix — while unprefixed tools stay allowed.
+        // A Supervised plugin baseline maps to an authoritative Ask scoped to the plugin's REAL
+        // declared tool ("deploy_widget"), enumerated from the plugin skill's allowed-tools. The
+        // authoritative baseline tightens the otherwise Allow-by-default environment for that tool,
+        // while an unrelated tool stays allowed. (Pre-fix this used a synthetic "{plugin}:*"
+        // wildcard that no live tool name ever matched, so the baseline was inert.)
         await using var provider = CompositionRootTestHost.BuildProvider(BaseSettings("Supervised"));
         await CompositionRootTestHost.RunPluginStartupLoaderAsync(provider);
 
-        var prefixedExecuted = false;
+        var pluginToolExecuted = false;
         var plainExecuted = false;
-        var prefixed = await BuildGovernedHostTool(provider,
-            AIFunctionFactory.Create(() => { prefixedExecuted = true; return "ran"; }, $"{PluginName}:deploy"));
+        var pluginTool = await BuildGovernedHostTool(provider,
+            AIFunctionFactory.Create(() => { pluginToolExecuted = true; return "ran"; }, PluginToolName));
         var plain = await BuildGovernedHostTool(provider,
             AIFunctionFactory.Create(() => { plainExecuted = true; return "ran"; }, "plain_tool"));
 
         using var scope = provider.CreateScope();
-        var (results, trace) = await InvokeUnderGovernedTurn(scope, prefixed, plain);
+        var (results, trace) = await InvokeUnderGovernedTurn(scope, pluginTool, plain);
 
         ResultText(results[0]).Should().Contain("is not permitted",
             "the plugin's Supervised baseline maps to Ask, which fail-closes to a block pending approval");
-        prefixedExecuted.Should().BeFalse();
-        plainExecuted.Should().BeTrue("an unprefixed tool is outside the plugin baseline and stays allowed");
+        pluginToolExecuted.Should().BeFalse();
+        plainExecuted.Should().BeTrue("a tool outside the plugin's declared surface stays allowed");
         trace.ToolDecisions.Should().Contain(d =>
-            d.ToolName == $"{PluginName}:deploy" && d.Outcome == ToolDecisionOutcome.PendingApproval);
+            d.ToolName == PluginToolName && d.Outcome == ToolDecisionOutcome.PendingApproval);
         trace.ToolDecisions.Should().Contain(d =>
             d.ToolName == "plain_tool" && d.Outcome == ToolDecisionOutcome.Allowed);
     }
 
     [Fact]
-    public async Task GovernedTool_AutonomousPluginBaseline_KnownInert_CannotLoosenDefaultAskEnvironment()
+    public async Task GovernedTool_AutonomousPluginBaseline_LoosensRealDeclaredToolUnderStricterDefault()
     {
-        // KNOWN-INERT AUTONOMY BASELINE — tracked follow-up, deliberately NOT fixed here.
+        // ENFORCED AUTONOMY BASELINE (was "known-inert" before the fix).
         //
-        // A plugin declaring AutonomyLevel=Autonomous emits an Allow rule scoped "{plugin}:*"
-        // (phase 3). It is inert on the live path for two independent reasons:
-        //
-        //   1. Phase masking: AutonomyTierRuleProvider ALWAYS emits a "*" rule from
-        //      PermissionsConfig.DefaultBehavior (default "Ask"). Ask rules resolve in phase 2,
-        //      before ANY Allow rule is consulted, so the plugin's Allow can never loosen the
-        //      environment. (Under DefaultBehavior=Allow the tier's own "*" Allow at priority 0
-        //      wins instead, so the plugin rule is redundant there too.)
-        //   2. Tool naming: tools resolved by ToolChainBuilder keep their original names —
-        //      nothing on the live path namespaces them "{plugin}:", so the pattern only ever
-        //      matches synthetic names like the probe below.
-        //
-        // This test PINS the current inert behavior so the follow-up that makes Autonomous
-        // plugin baselines effective must consciously update it.
+        // A plugin declaring AutonomyLevel=Autonomous now emits an *authoritative* Allow baseline
+        // scoped to its REAL declared tool ("deploy_widget"). The resolver's authoritative-baseline
+        // phase runs before the Ask/Allow phases, so the plugin's Allow LOOSENS an otherwise
+        // stricter (DefaultBehavior=Ask) environment for that tool — while an unrelated tool still
+        // gets the strict tier Ask. This is the operator's per-plugin trust decision winning over
+        // the generic default, without touching the resolver's fail-safe Deny precedence.
         var settings = BaseSettings("Autonomous");
-        settings["AppConfig:AI:Permissions:DefaultBehavior"] = "Ask"; // resolver default
+        settings["AppConfig:AI:Permissions:DefaultBehavior"] = "Ask"; // stricter generic default
         await using var provider = CompositionRootTestHost.BuildProvider(settings);
         await CompositionRootTestHost.RunPluginStartupLoaderAsync(provider);
 
-        var executed = false;
-        var wrapped = await BuildGovernedHostTool(provider,
-            AIFunctionFactory.Create(() => { executed = true; return "ran"; }, $"{PluginName}:deploy"));
+        var pluginToolExecuted = false;
+        var plainExecuted = false;
+        var pluginTool = await BuildGovernedHostTool(provider,
+            AIFunctionFactory.Create(() => { pluginToolExecuted = true; return "ran"; }, PluginToolName));
+        var plain = await BuildGovernedHostTool(provider,
+            AIFunctionFactory.Create(() => { plainExecuted = true; return "ran"; }, "plain_tool"));
 
         using var scope = provider.CreateScope();
-        var (results, trace) = await InvokeUnderGovernedTurn(scope, wrapped);
+        var (results, trace) = await InvokeUnderGovernedTurn(scope, pluginTool, plain);
 
-        ResultText(results[0]).Should().Contain("is not permitted",
-            "the tier's '*' Ask baseline masks the plugin's Autonomous Allow rule (known-inert, see remarks)");
-        executed.Should().BeFalse();
-        trace.ToolDecisions.Should().ContainSingle(d =>
-            d.ToolName == $"{PluginName}:deploy" && d.Outcome == ToolDecisionOutcome.PendingApproval);
+        pluginToolExecuted.Should().BeTrue(
+            "the plugin's Autonomous authoritative baseline loosens its declared tool to Allow");
+        ResultText(results[0]).Should().Be("ran");
+        ResultText(results[1]).Should().Contain("is not permitted",
+            "a tool outside the plugin's declared surface still hits the strict tier Ask default");
+        plainExecuted.Should().BeFalse();
+        trace.ToolDecisions.Should().Contain(d =>
+            d.ToolName == PluginToolName && d.Outcome == ToolDecisionOutcome.Allowed);
+        trace.ToolDecisions.Should().Contain(d =>
+            d.ToolName == "plain_tool" && d.Outcome == ToolDecisionOutcome.PendingApproval);
     }
 
     /// <summary>


### PR DESCRIPTION
Wave 4 (consolidation) — B1 follow-up from the CRITICAL plugin-governance PR #122. Fixes the inert autonomy-baseline residual on the live tool-permission path.

## Bug (inert security feature)
A plugin's `AutonomyLevel` was expressed as a `{plugin}:*` wildcard rule, but real tools keep their original names (never `{plugin}:`-prefixed) so the wildcard matched nothing. An `Autonomous` (Allow) baseline was additionally masked by the tier's generic `*` Ask, which resolves before any Allow. `DeniedTools` already worked (exact-name Deny); only the autonomy baseline was dead.

## Fix
- `PluginPermissionRuleProvider` enumerates the plugin's **real declared tool names** (via `ISkillMetadataRegistry`) and emits one `IsAuthoritativeBaseline` rule per name.
- New `ToolPermissionRule.IsAuthoritativeBaseline` + a resolver phase in `ThreePhasePermissionResolver` **after Deny, before Ask/Allow** — an operator-set per-plugin baseline wins over the generic tier default in both directions (Autonomous loosens, Supervised/Restricted tighten).
- `SkillMetadataRegistry.Discover()` fails fast (throws) if plugins are declared but no `IPluginRegistry` is registered, instead of silently no-opping governance.

## Security invariants (test-proven, adversarially reviewed)
- Bypass-immune `DeniedTools` Deny still wins over an Autonomous baseline (Deny resolves in an earlier phase).
- Safety gates + rate-limit auto-deny still win.
- Default-off is byte-identical: no `AutonomyLevel` set ⇒ no baseline rules ⇒ new phase is a no-op; non-plugin deployments unchanged.

## Adversarial review (SAFE WITH FIXES → both applied)
- **F1:** among same-named authoritative baselines from multiple plugins, the **most restrictive** behavior wins (Deny > Ask > Allow), not the first by load order — a permissive plugin can't loosen a tool another plugin gates.
- **F2:** the baseline is constrained to the plugin's **own** tool surface — a declared name that resolves to a globally-registered keyed `ITool` (e.g. `bash`, `file_system`) is excluded, so setting a plugin `Autonomous` can't silently auto-approve a powerful global tool agent-wide. Documented in `security/04-tools-and-permissions.html`; bypass-immune `DeniedTools` remains the backstop.

## Verification
- Red→green reproduce test + F1/F2 tests + flipped PR #136 pinned-inert composition test (now asserts secure scoped behavior).
- Application.Core.Tests 642, Presentation.Common.Tests 125, Domain.AI.Tests (permissions) 36, Infrastructure.AI.Tests permissions/skills green (3 pre-existing FileSystemService env failures unrelated).
- No DI-registration file touched. gitnexus_impact LOW.

🤖 Generated with [Claude Code](https://claude.com/claude-code)