### PR TITLE
test: prove planner step-config validators are wired via assembly scan

### DIFF
--- a/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlanValidatorTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlanValidatorTests.cs
@@ -1,8 +1,10 @@
+using Application.Core;
 using Application.Core.Validation.Planner;
 using Domain.AI.Planner;
 using FluentAssertions;
 using FluentValidation;
 using Infrastructure.AI.Planner;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Xunit;
@@ -386,6 +388,59 @@ public sealed class PlanValidatorTests
 
         result.IsSuccess.Should().BeFalse();
         result.Errors.Should().Contain(e => e.Contains("ApprovalStrategy"));
+    }
+
+    // --- Real DI Wiring (step-config validators resolved from Application.Core) ---
+    //
+    // Regression guard for the "inert machinery" audit finding: the five planner step-config
+    // validators (LlmCall/ToolUse/HumanGate/ConditionalBranch/SubPlan) are registered implicitly
+    // by AddApplicationCoreDependencies -> AddValidatorsFromAssembly, so a name grep shows no
+    // explicit registration and they can look dead. These tests prove PlanValidator's
+    // ValidateStepConfigurations actually resolves and applies them from the real container —
+    // if either the assembly scan or the delegation regresses, an invalid step config would
+    // silently pass and these tests would fail.
+
+    [Fact]
+    public async Task Validate_InvalidToolUseConfig_WithRealDiContainer_ReturnsFail()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddApplicationCoreDependencies();
+        using var provider = services.BuildServiceProvider();
+        using var scope = provider.CreateScope();
+
+        var sut = new PlanValidator(scope.ServiceProvider, NullLogger<PlanValidator>.Instance);
+        var step = CreateStep(
+            name: "BadTool",
+            type: StepType.ToolUse,
+            config: new ToolUseConfig { ToolName = "" });
+        var graph = CreateGraph([step]);
+
+        var result = await sut.ValidateAsync(graph, CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.Contains("ToolName"));
+    }
+
+    [Fact]
+    public async Task Validate_InvalidLlmCallConfig_WithRealDiContainer_ReturnsFail()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddApplicationCoreDependencies();
+        using var provider = services.BuildServiceProvider();
+        using var scope = provider.CreateScope();
+
+        var sut = new PlanValidator(scope.ServiceProvider, NullLogger<PlanValidator>.Instance);
+        var step = CreateStep(
+            name: "BadLlm",
+            config: new LlmCallConfig { SystemPrompt = "test", ModelDeploymentKey = "" });
+        var graph = CreateGraph([step]);
+
+        var result = await sut.ValidateAsync(graph, CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.Contains("ModelDeploymentKey"));
     }
 
     // --- Resource Estimation ---


### PR DESCRIPTION
Wave 4 (consolidation) — I1 lane. **Corrects a false "dead code" flag from the audit** and adds regression guards. Test-only, no production change.

## Finding
The audit flagged 5 planner step-config validators (`LlmCallConfigValidator`, `ToolUseConfigValidator`, `HumanGateConfigValidator`, `ConditionalBranchConfigValidator`, `SubPlanConfigValidator`) as unwired. **They are not** — they live in `Application.Core` and are registered implicitly by `AddApplicationCoreDependencies` → `AddValidatorsFromAssembly`, then resolved and applied per step by `PlanValidator.ValidateStepConfigurations`. Assembly scanning is invisible to a name-grep, which is what produced the false flag.

## Change
2 integration regression guards in `PlanValidatorTests` that build the **real** DI container, construct `PlanValidator`, and assert an invalid step config is rejected — proving the wiring is live and guarding against future regression:
- `Validate_InvalidToolUseConfig_WithRealDiContainer_ReturnsFail`
- `Validate_InvalidLlmCallConfig_WithRealDiContainer_ReturnsFail`

Both pass on current code. No production change.

## Also (report-only, deferred)
4 appsettings keys confirmed dead but **not removed here** — each is described in user-facing docs (README + onboarding site) as working config, so a correct removal is a coordinated code+docs change, not a config-only edit:
- `Agent:MaxTurnsPerConversation` (FoundryHost/EvalRunner/ConsoleUI) — no such property on `AgentConfig`
- `Observability:EnableTracing`, `Observability:EnableMetrics` (×3 hosts) — no such properties on `ObservabilityConfig` (the live `EnableMetrics` is `AI:Governance:EnableMetrics`, a different section)
- `Observability:EnableSensitiveData` — does not exist in any appsettings; real property is `EnableSensitiveTelemetry`

(`Observability:SamplingRatio` is dead by the same logic and intentionally collector-side.) Recommend a dedicated follow-up that removes the keys and fixes README + onboarding together.

## Verification
`PlanValidatorTests`: 27 passed (25 pre-existing + 2 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)