### PR TITLE
feat: add ScopeIdentity owner/tenant canonicalizer for erasure scoping

### DIFF
--- a/src/Content/Domain/Domain.AI/KnowledgeGraph/Scoping/ScopeIdentity.cs
+++ b/src/Content/Domain/Domain.AI/KnowledgeGraph/Scoping/ScopeIdentity.cs
@@ -1,0 +1,51 @@
+namespace Domain.AI.KnowledgeGraph.Scoping;
+
+/// <summary>
+/// Canonicalizes knowledge-scope identity strings — owner IDs and tenant IDs — to a
+/// single normalized form so that authorization gates and storage-backend filters
+/// compare them identically.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The knowledge graph is scoped by owner and tenant identity (see
+/// <see cref="Models.KnowledgeScopeDescriptor"/>). Historically the authorization gate
+/// compared these identifiers case-insensitively while the storage backends filtered
+/// case-sensitively, so the gate could authorize a right-to-erasure the store then
+/// failed to match — silently leaving the subject's data in place.
+/// </para>
+/// <para>
+/// This helper defines the single canonical form (trimmed, invariant-lowercase) that
+/// MUST be applied on every write of an owner/tenant identity AND before every
+/// comparison, so authorization and persistence agree. Identity providers issue these
+/// values as GUID object-ids or e-mail-style names, both of which are case-insensitive
+/// by nature, so lowercasing is a safe canonicalization that never merges two distinct
+/// principals.
+/// </para>
+/// <para>
+/// Whitespace-only and empty inputs canonicalize to <c>null</c>, matching the graph's
+/// convention that a <c>null</c> owner/tenant denotes a global (unscoped) record.
+/// </para>
+/// </remarks>
+public static class ScopeIdentity
+{
+    /// <summary>
+    /// Returns the canonical form of a scope identity (owner ID or tenant ID): the
+    /// trimmed, invariant-lowercase value, or <c>null</c> when the input is null, empty,
+    /// or whitespace.
+    /// </summary>
+    /// <param name="id">The raw owner or tenant identifier.</param>
+    /// <returns>The canonical identifier, or <c>null</c> for an absent identity.</returns>
+    public static string? Canonicalize(string? id)
+        => string.IsNullOrWhiteSpace(id) ? null : id.Trim().ToLowerInvariant();
+
+    /// <summary>
+    /// Determines whether two scope identities refer to the same principal after
+    /// canonicalization. Two absent (null/empty) identities are considered the same
+    /// (both denote the global scope).
+    /// </summary>
+    /// <param name="left">The first identifier.</param>
+    /// <param name="right">The second identifier.</param>
+    /// <returns><c>true</c> when the canonical forms are equal; otherwise <c>false</c>.</returns>
+    public static bool AreSame(string? left, string? right)
+        => string.Equals(Canonicalize(left), Canonicalize(right), StringComparison.Ordinal);
+}

--- a/src/Content/Tests/Domain.AI.Tests/KnowledgeGraph/Scoping/ScopeIdentityTests.cs
+++ b/src/Content/Tests/Domain.AI.Tests/KnowledgeGraph/Scoping/ScopeIdentityTests.cs
@@ -1,0 +1,52 @@
+using Domain.AI.KnowledgeGraph.Scoping;
+using FluentAssertions;
+using Xunit;
+
+namespace Domain.AI.Tests.KnowledgeGraph.Scoping;
+
+/// <summary>
+/// Verifies that <see cref="ScopeIdentity"/> produces a single canonical form for owner
+/// and tenant identifiers so authorization gates and storage filters agree.
+/// </summary>
+public class ScopeIdentityTests
+{
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("\t")]
+    public void Canonicalize_AbsentIdentity_ReturnsNull(string? input)
+    {
+        ScopeIdentity.Canonicalize(input).Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData("Alice", "alice")]
+    [InlineData("ALICE", "alice")]
+    [InlineData("  Alice  ", "alice")]
+    [InlineData("ABC-123-DEF", "abc-123-def")]
+    [InlineData("User@Example.COM", "user@example.com")]
+    public void Canonicalize_MixedCaseOrPadded_ReturnsTrimmedLowercase(string input, string expected)
+    {
+        ScopeIdentity.Canonicalize(input).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("Alice", "alice")]
+    [InlineData("ALICE", "  alice  ")]
+    [InlineData(null, "")]
+    [InlineData("", "   ")]
+    public void AreSame_EquivalentAfterCanonicalization_ReturnsTrue(string? left, string? right)
+    {
+        ScopeIdentity.AreSame(left, right).Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("alice", "bob")]
+    [InlineData("alice", null)]
+    [InlineData("owner-1", "owner-2")]
+    public void AreSame_DistinctPrincipals_ReturnsFalse(string? left, string? right)
+    {
+        ScopeIdentity.AreSame(left, right).Should().BeFalse();
+    }
+}


### PR DESCRIPTION
D3 erasure pass — **foundation piece.** Adds the single canonical form for knowledge-scope identity (owner IDs, tenant IDs) that the authorization gate and every storage backend will apply, so authz and persistence agree.

## Why
The audit found the erasure authorization gate compares owner/tenant IDs case-**insensitively** while the storage backends filter case-**sensitively** — so the gate can authorize a right-to-erasure the store then fails to match, silently leaving the subject's data in place. The fix (per decision) is to **canonicalize on write + exact match**. This PR introduces the canonicalizer; the follow-up D3 lanes wire it into the gate, the backend write/query paths, and the cross-session memory purge.

## Change
`Domain.AI.KnowledgeGraph.Scoping.ScopeIdentity` (pure, no deps):
- `Canonicalize(string?)` → trimmed invariant-lowercase, or `null` for null/empty/whitespace (matching the graph's convention that null owner/tenant = global).
- `AreSame(string?, string?)` → equality after canonicalization.

Lowercasing is safe for the identity types `OwnerId`/`TenantId` hold (GUID object-ids, email-style names — both case-insensitive by nature), so it never merges two distinct principals.

## Scope / safety
No production callers yet — the D3 lanes consume it. Zero behavior change on merge. 16 unit tests (null/empty/whitespace→null, mixed-case/padded canonicalization, `AreSame` equivalence + distinctness).

> Note for the wiring lanes: pre-existing rows written before canonicalization may hold mixed-case owner IDs; a one-time normalization of existing data is a documented migration follow-up (can't run against a live store here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)