### PR TITLE
fix: compensate partial RAG ingest failures to prevent un-erasable orphans

### DIFF
--- a/src/Content/Application/Application.Core/CQRS/RAG/IngestDocument/IngestDocumentCommandHandler.cs
+++ b/src/Content/Application/Application.Core/CQRS/RAG/IngestDocument/IngestDocumentCommandHandler.cs
@@ -63,6 +63,9 @@ public sealed class IngestDocumentCommandHandler
 		var sw = Stopwatch.StartNew();
 		var jobId = Guid.NewGuid().ToString("N")[..12];
 
+		// Captured once chunks exist so the catch path can compensate partial store writes.
+		string? documentId = null;
+
 		try
 		{
 			_logger.LogInformation(
@@ -80,6 +83,11 @@ public sealed class IngestDocumentCommandHandler
 			var chunks = await _chunker.ChunkAsync(
 				markdown, structure, request.DocumentUri, cancellationToken);
 			activity?.SetTag(RagConventions.IngestChunksProduced, chunks.Count);
+
+			// All chunks (including RAPTOR summaries) share the source DocumentId, which is
+			// what both stores key deletion by. Capturing it here makes document-scoped
+			// compensation possible if a later parallel store write partially fails.
+			documentId = chunks.Count > 0 ? chunks[0].DocumentId : null;
 
 			// 4. Contextual enrichment (if enabled)
 			var ragConfig = _appConfigMonitor.CurrentValue.AI.Rag;
@@ -130,6 +138,16 @@ public sealed class IngestDocumentCommandHandler
 			_logger.LogError(ex, "RAG ingestion failed: {JobId}", jobId);
 			RagIngestionMetrics.Errors.Add(1);
 
+			// Compensate partial writes: the vector and BM25 stores are written in parallel,
+			// so a single-store failure can leave the other store's derived copies (chunks,
+			// RAPTOR summaries) persisted with no clean way to erase them later. Both deletes
+			// are document-scoped and idempotent, so calling them is safe even for the store
+			// that wrote nothing.
+			if (documentId is not null)
+			{
+				await CompensatePartialIngestAsync(documentId, request.CollectionName, jobId);
+			}
+
 			return new IngestDocumentResult
 			{
 				JobId = jobId,
@@ -139,6 +157,42 @@ public sealed class IngestDocumentCommandHandler
 				Success = false,
 				Error = "Document ingestion failed. Check server logs for details."
 			};
+		}
+	}
+
+	/// <summary>
+	/// Best-effort rollback of already-written derived copies for a failed ingest.
+	/// Deletes the document's entries from both the vector and BM25 stores so a partial
+	/// write does not leave un-erasable orphans. A compensating delete that itself fails
+	/// is logged and swallowed: it must not mask the original ingestion failure or abort
+	/// the sibling store's cleanup.
+	/// </summary>
+	private async Task CompensatePartialIngestAsync(
+		string documentId, string? collectionName, string jobId)
+	{
+		// Use CancellationToken.None: cleanup must complete even when the original
+		// ingestion failed due to cancellation — abandoning it would defeat the purpose.
+		await TryDeleteAsync(
+			ct => _vectorStore.DeleteAsync(documentId, collectionName, ct),
+			documentId, jobId, "vector");
+		await TryDeleteAsync(
+			ct => _bm25Store.DeleteAsync(documentId, collectionName, ct),
+			documentId, jobId, "BM25");
+	}
+
+	private async Task TryDeleteAsync(
+		Func<CancellationToken, Task> delete, string documentId, string jobId, string storeName)
+	{
+		try
+		{
+			await delete(CancellationToken.None);
+		}
+		catch (Exception ex)
+		{
+			_logger.LogError(
+				ex,
+				"RAG ingestion compensation failed to delete {DocumentId} from {StoreName} store: {JobId}",
+				documentId, storeName, jobId);
 		}
 	}
 }

--- a/src/Content/Tests/Application.Core.Tests/CQRS/RAG/IngestDocumentCommandHandlerCompensationTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/CQRS/RAG/IngestDocumentCommandHandlerCompensationTests.cs
@@ -1,0 +1,166 @@
+using Application.AI.Common.Interfaces.RAG;
+using Application.Core.CQRS.RAG.IngestDocument;
+using Domain.AI.RAG.Models;
+using Domain.Common.Config;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Application.Core.Tests.CQRS.RAG;
+
+/// <summary>
+/// Verifies that a partial ingest failure (one store write succeeds, the other throws)
+/// compensates by deleting the already-written derived copies from BOTH stores, so no
+/// un-erasable orphaned chunks/summaries remain for the failed document.
+/// </summary>
+public sealed class IngestDocumentCommandHandlerCompensationTests
+{
+    private const string DocumentId = "file:///docs/report.md";
+    private const string CollectionName = "corpus-a";
+
+    private readonly Mock<IDocumentParser> _parser = new();
+    private readonly Mock<IStructureExtractor> _structureExtractor = new();
+    private readonly Mock<IChunkingService> _chunker = new();
+    private readonly Mock<IContextualEnricher> _enricher = new();
+    private readonly Mock<IRaptorSummarizer> _raptor = new();
+    private readonly Mock<IEmbeddingService> _embedding = new();
+    private readonly Mock<IVectorStore> _vectorStore = new();
+    private readonly Mock<IBm25Store> _bm25Store = new();
+
+    public IngestDocumentCommandHandlerCompensationTests()
+    {
+        var chunks = new List<DocumentChunk>
+        {
+            new()
+            {
+                Id = $"{DocumentId}_chunk_0",
+                DocumentId = DocumentId,
+                SectionPath = "Root",
+                Content = "chunk text",
+                Tokens = 3,
+                Metadata = new ChunkMetadata
+                {
+                    SourceUri = new Uri(DocumentId),
+                    CreatedAt = DateTimeOffset.UtcNow,
+                },
+                Embedding = new[] { 0.1f, 0.2f },
+            },
+        };
+
+        _parser
+            .Setup(p => p.ParseAsync(It.IsAny<Uri>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync("# markdown");
+        _structureExtractor
+            .Setup(s => s.ExtractStructure(It.IsAny<string>()))
+            .Returns(new SkeletonNode { Title = "Root", Level = 1, StartOffset = 0, EndOffset = 10 });
+        _chunker
+            .Setup(c => c.ChunkAsync(
+                It.IsAny<string>(), It.IsAny<SkeletonNode>(), It.IsAny<Uri>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(chunks);
+        _embedding
+            .Setup(e => e.EmbedAsync(It.IsAny<IReadOnlyList<DocumentChunk>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(chunks);
+    }
+
+    private IngestDocumentCommandHandler CreateHandler()
+    {
+        var appConfig = new AppConfig();
+        appConfig.AI.Rag.Ingestion.EnableContextualEnrichment = false;
+        appConfig.AI.Rag.Ingestion.EnableRaptorSummaries = false;
+
+        var monitor = new Mock<IOptionsMonitor<AppConfig>>();
+        monitor.SetupGet(m => m.CurrentValue).Returns(appConfig);
+
+        return new IngestDocumentCommandHandler(
+            _parser.Object,
+            _structureExtractor.Object,
+            _chunker.Object,
+            _enricher.Object,
+            _raptor.Object,
+            _embedding.Object,
+            _vectorStore.Object,
+            _bm25Store.Object,
+            NullLogger<IngestDocumentCommandHandler>.Instance,
+            monitor.Object);
+    }
+
+    private static IngestDocumentCommand Command() => new()
+    {
+        DocumentUri = new Uri(DocumentId),
+        CollectionName = CollectionName,
+    };
+
+    [Fact]
+    public async Task Handle_Bm25WriteThrowsAfterVectorWriteSucceeds_CompensatesBothStores()
+    {
+        _vectorStore
+            .Setup(v => v.IndexAsync(
+                It.IsAny<IReadOnlyList<DocumentChunk>>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        _bm25Store
+            .Setup(b => b.IndexAsync(
+                It.IsAny<IReadOnlyList<DocumentChunk>>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("bm25 index unavailable"));
+
+        var result = await CreateHandler().Handle(Command(), CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+
+        _vectorStore.Verify(
+            v => v.DeleteAsync(DocumentId, CollectionName, It.IsAny<CancellationToken>()),
+            Times.Once,
+            "the vector store wrote its chunks and must be rolled back on partial failure");
+        _bm25Store.Verify(
+            b => b.DeleteAsync(DocumentId, CollectionName, It.IsAny<CancellationToken>()),
+            Times.Once,
+            "the BM25 delete is document-scoped and idempotent — safe even if nothing was written");
+    }
+
+    [Fact]
+    public async Task Handle_VectorWriteThrowsAfterBm25WriteSucceeds_CompensatesBothStores()
+    {
+        _bm25Store
+            .Setup(b => b.IndexAsync(
+                It.IsAny<IReadOnlyList<DocumentChunk>>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        _vectorStore
+            .Setup(v => v.IndexAsync(
+                It.IsAny<IReadOnlyList<DocumentChunk>>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("vector index unavailable"));
+
+        var result = await CreateHandler().Handle(Command(), CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+
+        _vectorStore.Verify(
+            v => v.DeleteAsync(DocumentId, CollectionName, It.IsAny<CancellationToken>()),
+            Times.Once);
+        _bm25Store.Verify(
+            b => b.DeleteAsync(DocumentId, CollectionName, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_CompensatingDeleteItselfFails_StillReturnsOriginalFailureWithoutThrowing()
+    {
+        _vectorStore
+            .Setup(v => v.IndexAsync(
+                It.IsAny<IReadOnlyList<DocumentChunk>>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        _bm25Store
+            .Setup(b => b.IndexAsync(
+                It.IsAny<IReadOnlyList<DocumentChunk>>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("bm25 index unavailable"));
+        _vectorStore
+            .Setup(v => v.DeleteAsync(
+                It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("delete also failed"));
+
+        var act = async () => await CreateHandler().Handle(Command(), CancellationToken.None);
+
+        var result = await act.Should().NotThrowAsync();
+        result.Which.Success.Should().BeFalse();
+    }
+}


### PR DESCRIPTION
D3 erasure pass — Lane 4. Closes a gap where partial ingestion failures leave derived copies that later erasure can't reach.

## Gap
`IngestDocumentCommandHandler` writes the vector and BM25 stores in parallel (`Task.WhenAll`). If one throws, the other's already-written chunks/RAPTOR summaries remain, and the catch returned failure with **no rollback** — leaving orphaned derived content with no clean erasure path.

(The originally-flagged "crash-retry orphans via non-deterministic keys" is NOT the bug — chunk IDs are deterministic and all stores upsert. The real gap is the missing compensation.)

## Fix
On partial failure, compensate by deleting the document's entries from **both** stores (`DeleteAsync(documentId)` — document-scoped, idempotent, safe even for the store that wrote nothing). `documentId` is captured after chunking. Each compensating delete is wrapped in its own try/catch: a failed compensation is structured-logged and swallowed so it never masks the original failure or aborts the sibling cleanup; runs with `CancellationToken.None` so cleanup completes even on cancellation.

## Verification
- Red→green: `Handle_Bm25WriteThrowsAfterVectorWriteSucceeds_CompensatesBothStores` + the reverse direction; `Handle_CompensatingDeleteItselfFails_StillReturnsOriginalFailureWithoutThrowing`.
- `Application.Core.Tests`: 655 passed. gitnexus_impact LOW.

🤖 Generated with [Claude Code](https://claude.com/claude-code)