### PR TITLE
fix: stamp owner on work-memory graph nodes for owner-scoped erasure

### DIFF
--- a/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/DependencyInjection.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/DependencyInjection.cs
@@ -262,6 +262,7 @@ public static class DependencyInjection
         services.AddKeyedSingleton<ILearningsStore>("graph", (sp, _) =>
             new Learnings.GraphLearningsStore(
                 sp.GetRequiredService<IKnowledgeGraphStore>(),
+                sp.GetRequiredService<Application.AI.Common.Interfaces.IAmbientRequestScope>(),
                 sp.GetRequiredService<ILogger<Learnings.GraphLearningsStore>>()));
 
         services.AddKeyedSingleton<ILearningsStore>("in_memory", (_, _) =>
@@ -276,6 +277,7 @@ public static class DependencyInjection
         services.AddKeyedSingleton<IWorkEpisodeStore>("graph", (sp, _) =>
             new WorkMemory.GraphWorkEpisodeStore(
                 sp.GetRequiredService<IKnowledgeGraphStore>(),
+                sp.GetRequiredService<Application.AI.Common.Interfaces.IAmbientRequestScope>(),
                 sp.GetRequiredService<ILogger<WorkMemory.GraphWorkEpisodeStore>>()));
 
         services.AddKeyedSingleton<IWorkEpisodeStore>("in_memory", (_, _) =>
@@ -309,6 +311,7 @@ public static class DependencyInjection
         services.AddSingleton<IEpisodicSegmentStore>(sp =>
             new Memory.GraphEpisodicSegmentStore(
                 sp.GetRequiredService<IKnowledgeGraphStore>(),
+                sp.GetRequiredService<Application.AI.Common.Interfaces.IAmbientRequestScope>(),
                 sp.GetRequiredService<ILogger<Memory.GraphEpisodicSegmentStore>>()));
 
         return services;

--- a/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/Learnings/GraphLearningsStore.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/Learnings/GraphLearningsStore.cs
@@ -1,9 +1,12 @@
 using System.Globalization;
+using Application.AI.Common.Interfaces;
 using Application.AI.Common.Interfaces.KnowledgeGraph;
 using Application.AI.Common.Interfaces.Learnings;
 using Domain.AI.KnowledgeGraph.Models;
+using Domain.AI.KnowledgeGraph.Scoping;
 using Domain.AI.Learnings;
 using Domain.Common;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
 namespace Infrastructure.AI.KnowledgeGraph.Learnings;
@@ -13,9 +16,18 @@ namespace Infrastructure.AI.KnowledgeGraph.Learnings;
 /// and synthetic index nodes for efficient scope-hierarchy search.
 /// Registered with keyed DI key <c>"graph"</c>.
 /// </summary>
+/// <remarks>
+/// Owner attribution is stamped on every persisted node: the compliance decorator leaves
+/// <see cref="GraphNode.OwnerId"/> writer-authoritative, so an unstamped learning node would persist
+/// owner-less and escape owner-scoped right-to-erasure (<c>IKnowledgeGraphStore.GetNodesByOwnerAsync</c>).
+/// The caller's canonical owner is resolved per-operation from the ambient request scope, keeping this
+/// singleton store from capturing the scoped <see cref="IKnowledgeScope"/>. Index nodes stay owner-less
+/// on purpose — they are shared routing structures, not the subject's data.
+/// </remarks>
 public sealed class GraphLearningsStore : ILearningsStore
 {
     private readonly IKnowledgeGraphStore _graphStore;
+    private readonly IAmbientRequestScope _ambientScope;
     private readonly ILogger<GraphLearningsStore> _logger;
 
     private const string NodePrefix = "learning:";
@@ -25,16 +37,31 @@ public sealed class GraphLearningsStore : ILearningsStore
     private const string EdgePredicate = "has_learning";
     private const string ChunkId = "learningindex";
 
+    /// <summary>Initializes a new instance of the <see cref="GraphLearningsStore"/> class.</summary>
+    /// <param name="graphStore">The knowledge graph store nodes are persisted to.</param>
+    /// <param name="ambientScope">The ambient request scope used to resolve the caller's owner
+    /// per-operation for owner stamping (see the class remarks).</param>
+    /// <param name="logger">Logger for recording learning persistence operations.</param>
     public GraphLearningsStore(
         IKnowledgeGraphStore graphStore,
+        IAmbientRequestScope ambientScope,
         ILogger<GraphLearningsStore> logger)
     {
         ArgumentNullException.ThrowIfNull(graphStore);
+        ArgumentNullException.ThrowIfNull(ambientScope);
         ArgumentNullException.ThrowIfNull(logger);
 
         _graphStore = graphStore;
+        _ambientScope = ambientScope;
         _logger = logger;
     }
+
+    /// <summary>
+    /// The canonical owner ID of the caller in flight, resolved per-operation from the ambient
+    /// request scope. <see langword="null"/> for background/system work outside any request scope.
+    /// </summary>
+    private string? CurrentOwnerId =>
+        ScopeIdentity.Canonicalize(_ambientScope.Current?.GetService<IKnowledgeScope>()?.UserId);
 
     public async Task<Result> SaveAsync(LearningEntry learning, CancellationToken ct)
     {
@@ -46,7 +73,8 @@ public sealed class GraphLearningsStore : ILearningsStore
                 Id = nodeId,
                 Name = $"Learning: {learning.Content[..Math.Min(50, learning.Content.Length)]}",
                 Type = NodeType,
-                Properties = SerializeProperties(learning)
+                Properties = SerializeProperties(learning),
+                OwnerId = CurrentOwnerId
             };
 
             await _graphStore.AddNodesAsync([node], ct);
@@ -154,7 +182,11 @@ public sealed class GraphLearningsStore : ILearningsStore
                 Id = nodeId,
                 Name = $"Learning: {learning.Content[..Math.Min(50, learning.Content.Length)]}",
                 Type = NodeType,
-                Properties = SerializeProperties(learning)
+                Properties = SerializeProperties(learning),
+                // Preserve the owner stamped at save time — the LearningEntry carries no owner field,
+                // so rebuilding without this would strip owner attribution and re-orphan the node from
+                // owner-scoped erasure.
+                OwnerId = existing.OwnerId
             };
 
             await _graphStore.AddNodesAsync([node], ct);
@@ -185,7 +217,9 @@ public sealed class GraphLearningsStore : ILearningsStore
                 Id = nodeId,
                 Name = existing.Name,
                 Type = existing.Type,
-                Properties = updatedProps
+                Properties = updatedProps,
+                // Preserve owner attribution so a soft-deleted node stays reachable by owner-scoped erasure.
+                OwnerId = existing.OwnerId
             };
 
             await _graphStore.AddNodesAsync([updatedNode], ct);

--- a/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/Memory/GraphEpisodicSegmentStore.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/Memory/GraphEpisodicSegmentStore.cs
@@ -1,7 +1,10 @@
 using System.Globalization;
+using Application.AI.Common.Interfaces;
 using Application.AI.Common.Interfaces.KnowledgeGraph;
 using Domain.AI.KnowledgeGraph.Models;
+using Domain.AI.KnowledgeGraph.Scoping;
 using Domain.Common;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
 namespace Infrastructure.AI.KnowledgeGraph.Memory;
@@ -13,13 +16,24 @@ namespace Infrastructure.AI.KnowledgeGraph.Memory;
 /// <c>(ConversationId, TurnNumber)</c> pair.
 /// </summary>
 /// <remarks>
-/// Tenant/owner isolation is <strong>not</strong> implemented here — it is inherited from the injected
-/// <see cref="IKnowledgeGraphStore"/>, which in production is the tenant-isolating / compliance-aware
-/// decorator chain (stamps tenant on write, filters on read), exactly as <c>GraphWorkEpisodeStore</c> does.
+/// <para>
+/// Tenant isolation is inherited from the injected <see cref="IKnowledgeGraphStore"/>, which in
+/// production is the tenant-isolating / compliance-aware decorator chain (stamps tenant on write,
+/// filters on read), exactly as <c>GraphWorkEpisodeStore</c> does.
+/// </para>
+/// <para>
+/// Owner attribution is stamped <strong>here</strong> for the same reason as
+/// <c>GraphWorkEpisodeStore</c>: the compliance decorator leaves <see cref="GraphNode.OwnerId"/>
+/// writer-authoritative, so an unstamped segment node would persist owner-less and escape
+/// owner-scoped right-to-erasure. Each saved node is stamped with the caller's canonical owner,
+/// resolved per-operation from the ambient request scope so this singleton store never captures the
+/// scoped <see cref="IKnowledgeScope"/>.
+/// </para>
 /// </remarks>
 public sealed class GraphEpisodicSegmentStore : IEpisodicSegmentStore
 {
     private readonly IKnowledgeGraphStore _graphStore;
+    private readonly IAmbientRequestScope _ambientScope;
     private readonly ILogger<GraphEpisodicSegmentStore> _logger;
 
     private const string NodePrefix = "episodicsegment:";
@@ -30,16 +44,30 @@ public sealed class GraphEpisodicSegmentStore : IEpisodicSegmentStore
     private const string ChunkId = "episodicsegmentindex";
 
     /// <summary>Initializes a new instance of the <see cref="GraphEpisodicSegmentStore"/> class.</summary>
+    /// <param name="graphStore">The knowledge graph store nodes are persisted to.</param>
+    /// <param name="ambientScope">The ambient request scope used to resolve the caller's owner
+    /// per-operation for owner stamping (see the class remarks).</param>
+    /// <param name="logger">Logger for recording episodic-segment persistence operations.</param>
     public GraphEpisodicSegmentStore(
         IKnowledgeGraphStore graphStore,
+        IAmbientRequestScope ambientScope,
         ILogger<GraphEpisodicSegmentStore> logger)
     {
         ArgumentNullException.ThrowIfNull(graphStore);
+        ArgumentNullException.ThrowIfNull(ambientScope);
         ArgumentNullException.ThrowIfNull(logger);
 
         _graphStore = graphStore;
+        _ambientScope = ambientScope;
         _logger = logger;
     }
+
+    /// <summary>
+    /// The canonical owner ID of the caller in flight, resolved per-operation from the ambient
+    /// request scope. <see langword="null"/> for background/system work outside any request scope.
+    /// </summary>
+    private string? CurrentOwnerId =>
+        ScopeIdentity.Canonicalize(_ambientScope.Current?.GetService<IKnowledgeScope>()?.UserId);
 
     /// <inheritdoc />
     public async Task<Result> SaveAsync(EpisodicSegment segment, CancellationToken ct)
@@ -53,7 +81,8 @@ public sealed class GraphEpisodicSegmentStore : IEpisodicSegmentStore
                 Id = nodeId,
                 Name = $"Segment: {segment.ConversationId}#{segment.TurnNumber}",
                 Type = NodeType,
-                Properties = SerializeProperties(segment)
+                Properties = SerializeProperties(segment),
+                OwnerId = CurrentOwnerId
             };
 
             await _graphStore.AddNodesAsync([node], ct);

--- a/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/WorkMemory/GraphWorkEpisodeStore.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/WorkMemory/GraphWorkEpisodeStore.cs
@@ -1,9 +1,12 @@
 using System.Globalization;
+using Application.AI.Common.Interfaces;
 using Application.AI.Common.Interfaces.KnowledgeGraph;
 using Application.AI.Common.Interfaces.WorkMemory;
 using Domain.AI.KnowledgeGraph.Models;
+using Domain.AI.KnowledgeGraph.Scoping;
 using Domain.AI.WorkMemory;
 using Domain.Common;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
 namespace Infrastructure.AI.KnowledgeGraph.WorkMemory;
@@ -14,13 +17,25 @@ namespace Infrastructure.AI.KnowledgeGraph.WorkMemory;
 /// <c>"graph"</c>.
 /// </summary>
 /// <remarks>
-/// Tenant/owner isolation is <strong>not</strong> implemented here — it is inherited from the injected
-/// <see cref="IKnowledgeGraphStore"/>, which in production is the tenant-isolating / compliance-aware
-/// decorator chain (stamps tenant on write, filters on read). This mirrors <c>GraphLearningsStore</c>.
+/// <para>
+/// Tenant isolation is inherited from the injected <see cref="IKnowledgeGraphStore"/>, which in
+/// production is the tenant-isolating / compliance-aware decorator chain (stamps tenant on write,
+/// filters on read). This mirrors <c>GraphLearningsStore</c>.
+/// </para>
+/// <para>
+/// Owner attribution, however, is stamped <strong>here</strong>: the compliance decorator leaves
+/// <see cref="GraphNode.OwnerId"/> writer-authoritative (it only defaults tenant), so a work-memory
+/// node that does not set its own owner would persist with a null owner and become invisible to
+/// owner-scoped right-to-erasure (<c>IKnowledgeGraphStore.GetNodesByOwnerAsync</c>). Each saved node
+/// is therefore stamped with the caller's canonical owner, resolved per-operation from the ambient
+/// request scope — the same mechanism the singleton compliance decorator uses, which keeps this
+/// singleton store from capturing the scoped <see cref="IKnowledgeScope"/>.
+/// </para>
 /// </remarks>
 public sealed class GraphWorkEpisodeStore : IWorkEpisodeStore
 {
     private readonly IKnowledgeGraphStore _graphStore;
+    private readonly IAmbientRequestScope _ambientScope;
     private readonly ILogger<GraphWorkEpisodeStore> _logger;
 
     private const string NodePrefix = "workepisode:";
@@ -31,16 +46,31 @@ public sealed class GraphWorkEpisodeStore : IWorkEpisodeStore
     private const string ChunkId = "workepisodeindex";
 
     /// <summary>Initializes a new instance of the <see cref="GraphWorkEpisodeStore"/> class.</summary>
+    /// <param name="graphStore">The knowledge graph store nodes are persisted to.</param>
+    /// <param name="ambientScope">The ambient request scope used to resolve the caller's owner
+    /// per-operation for owner stamping (see the class remarks).</param>
+    /// <param name="logger">Logger for recording work-episode persistence operations.</param>
     public GraphWorkEpisodeStore(
         IKnowledgeGraphStore graphStore,
+        IAmbientRequestScope ambientScope,
         ILogger<GraphWorkEpisodeStore> logger)
     {
         ArgumentNullException.ThrowIfNull(graphStore);
+        ArgumentNullException.ThrowIfNull(ambientScope);
         ArgumentNullException.ThrowIfNull(logger);
 
         _graphStore = graphStore;
+        _ambientScope = ambientScope;
         _logger = logger;
     }
+
+    /// <summary>
+    /// The canonical owner ID of the caller in flight, resolved per-operation from the ambient
+    /// request scope. <see langword="null"/> for background/system work outside any request scope
+    /// (such nodes stay owner-less/global, matching the compliance decorator's behavior).
+    /// </summary>
+    private string? CurrentOwnerId =>
+        ScopeIdentity.Canonicalize(_ambientScope.Current?.GetService<IKnowledgeScope>()?.UserId);
 
     /// <inheritdoc />
     public async Task<Result> SaveAsync(WorkEpisode episode, CancellationToken ct)
@@ -54,7 +84,8 @@ public sealed class GraphWorkEpisodeStore : IWorkEpisodeStore
                 Id = nodeId,
                 Name = $"Episode: {episode.ConversationId}#{episode.TurnNumber}",
                 Type = NodeType,
-                Properties = SerializeProperties(episode)
+                Properties = SerializeProperties(episode),
+                OwnerId = CurrentOwnerId
             };
 
             await _graphStore.AddNodesAsync([node], ct);

--- a/src/Content/Tests/Infrastructure.AI.KnowledgeGraph.Tests/Learnings/GraphLearningsStoreTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.KnowledgeGraph.Tests/Learnings/GraphLearningsStoreTests.cs
@@ -5,6 +5,7 @@ using Domain.Common;
 using FluentAssertions;
 using Infrastructure.AI.KnowledgeGraph.InMemory;
 using Infrastructure.AI.KnowledgeGraph.Learnings;
+using Infrastructure.AI.KnowledgeGraph.Tests.TestSupport;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Xunit;
@@ -21,6 +22,7 @@ public sealed class GraphLearningsStoreTests
         _graphStore = new InMemoryGraphStore(Mock.Of<ILogger<InMemoryGraphStore>>());
         _sut = new GraphLearningsStore(
             _graphStore,
+            StubAmbientRequestScope.None(),
             Mock.Of<ILogger<GraphLearningsStore>>());
     }
 
@@ -60,6 +62,25 @@ public sealed class GraphLearningsStoreTests
             Confidence = 0.95
         }
     };
+
+    [Fact]
+    public async Task Save_StampsCallerCanonicalOwner_SoOwnerScopedErasureCanFindIt()
+    {
+        // D3 owner-stamp: an unstamped learning node persists owner-less and escapes owner-scoped
+        // right-to-erasure (GetNodesByOwnerAsync). Owner is canonicalized (trimmed/lowercased).
+        var sut = new GraphLearningsStore(
+            _graphStore, StubAmbientRequestScope.ForOwner("  User-42  "), Mock.Of<ILogger<GraphLearningsStore>>());
+        var id = Guid.NewGuid();
+
+        await sut.SaveAsync(BuildEntry(id: id, isGlobal: true), CancellationToken.None);
+
+        var node = await _graphStore.GetNodeAsync($"learning:{id}".ToLowerInvariant(), CancellationToken.None);
+        node!.OwnerId.Should().Be("user-42", "the saved node must carry the caller's canonical owner");
+
+        var owned = await _graphStore.GetNodesByOwnerAsync("user-42", CancellationToken.None);
+        owned.Should().Contain(n => n.Id == node.Id,
+            "owner-scoped erasure resolves nodes via GetNodesByOwnerAsync and must reach the learning node");
+    }
 
     [Fact]
     public async Task Save_Graph_CreatesNodeWithDeterministicId()

--- a/src/Content/Tests/Infrastructure.AI.KnowledgeGraph.Tests/Memory/GraphEpisodicSegmentStoreTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.KnowledgeGraph.Tests/Memory/GraphEpisodicSegmentStoreTests.cs
@@ -2,6 +2,7 @@ using Domain.AI.KnowledgeGraph.Models;
 using FluentAssertions;
 using Infrastructure.AI.KnowledgeGraph.InMemory;
 using Infrastructure.AI.KnowledgeGraph.Memory;
+using Infrastructure.AI.KnowledgeGraph.Tests.TestSupport;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Xunit;
@@ -20,7 +21,8 @@ public sealed class GraphEpisodicSegmentStoreTests
     public GraphEpisodicSegmentStoreTests()
     {
         _graphStore = new InMemoryGraphStore(Mock.Of<ILogger<InMemoryGraphStore>>());
-        _sut = new GraphEpisodicSegmentStore(_graphStore, Mock.Of<ILogger<GraphEpisodicSegmentStore>>());
+        _sut = new GraphEpisodicSegmentStore(
+            _graphStore, StubAmbientRequestScope.None(), Mock.Of<ILogger<GraphEpisodicSegmentStore>>());
     }
 
     private static EpisodicSegment BuildSegment(
@@ -144,5 +146,24 @@ public sealed class GraphEpisodicSegmentStoreTests
         var node = await _graphStore.GetNodeAsync($"episodicsegment:{id}".ToLowerInvariant(), CancellationToken.None);
         node.Should().NotBeNull();
         node!.Type.Should().Be("EpisodicSegment");
+    }
+
+    [Fact]
+    public async Task Save_StampsCallerCanonicalOwner_SoOwnerScopedErasureCanFindIt()
+    {
+        // D3 owner-stamp: an unstamped segment node persists owner-less and escapes owner-scoped
+        // right-to-erasure (GetNodesByOwnerAsync). Owner is canonicalized (trimmed/lowercased).
+        var sut = new GraphEpisodicSegmentStore(
+            _graphStore, StubAmbientRequestScope.ForOwner("  User-42  "), Mock.Of<ILogger<GraphEpisodicSegmentStore>>());
+        var segment = BuildSegment();
+
+        await sut.SaveAsync(segment, CancellationToken.None);
+
+        var node = await _graphStore.GetNodeAsync($"episodicsegment:{segment.SegmentId}".ToLowerInvariant(), CancellationToken.None);
+        node!.OwnerId.Should().Be("user-42", "the saved node must carry the caller's canonical owner");
+
+        var owned = await _graphStore.GetNodesByOwnerAsync("user-42", CancellationToken.None);
+        owned.Should().Contain(n => n.Id == node.Id,
+            "owner-scoped erasure resolves nodes via GetNodesByOwnerAsync and must reach the episodic-segment node");
     }
 }

--- a/src/Content/Tests/Infrastructure.AI.KnowledgeGraph.Tests/TestSupport/StubAmbientRequestScope.cs
+++ b/src/Content/Tests/Infrastructure.AI.KnowledgeGraph.Tests/TestSupport/StubAmbientRequestScope.cs
@@ -1,0 +1,48 @@
+using Application.AI.Common.Interfaces;
+using Application.AI.Common.Interfaces.KnowledgeGraph;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Infrastructure.AI.KnowledgeGraph.Tests.TestSupport;
+
+/// <summary>
+/// Test double for <see cref="IAmbientRequestScope"/> that exposes a fixed request service
+/// provider carrying a single <see cref="IKnowledgeScope"/>. Mirrors how the production
+/// singleton graph stores (e.g. <c>ComplianceAwareGraphStore</c>) resolve the caller's owner
+/// per-operation from the ambient request scope rather than capturing a scoped dependency.
+/// </summary>
+internal sealed class StubAmbientRequestScope : IAmbientRequestScope
+{
+    private readonly IServiceProvider? _current;
+
+    private StubAmbientRequestScope(IServiceProvider? current) => _current = current;
+
+    /// <inheritdoc />
+    public IServiceProvider? Current => _current;
+
+    /// <inheritdoc />
+    public IDisposable BeginScope(IServiceProvider requestServices)
+        => throw new NotSupportedException("Test stub does not support establishing nested scopes.");
+
+    /// <summary>No ambient request scope in flight (background/system context — owner stays null).</summary>
+    public static StubAmbientRequestScope None() => new(current: null);
+
+    /// <summary>An ambient scope whose caller owner (<see cref="IKnowledgeScope.UserId"/>) is <paramref name="ownerId"/>.</summary>
+    public static StubAmbientRequestScope ForOwner(string? ownerId)
+    {
+        var provider = new ServiceCollection()
+            .AddSingleton<IKnowledgeScope>(new StubKnowledgeScope(ownerId))
+            .BuildServiceProvider();
+        return new StubAmbientRequestScope(provider);
+    }
+
+    private sealed class StubKnowledgeScope(string? userId) : IKnowledgeScope
+    {
+        public string? UserId { get; } = userId;
+        public string? TenantId => null;
+        public string? DatasetId => null;
+        public string? DatasetName => null;
+        public string? DatasetOwnerId => null;
+        public string? AgentId => null;
+        public string? ConversationId => null;
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.KnowledgeGraph.Tests/WorkMemory/GraphWorkEpisodeStoreTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.KnowledgeGraph.Tests/WorkMemory/GraphWorkEpisodeStoreTests.cs
@@ -2,6 +2,7 @@ using Application.AI.Common.Interfaces.WorkMemory;
 using Domain.AI.WorkMemory;
 using FluentAssertions;
 using Infrastructure.AI.KnowledgeGraph.InMemory;
+using Infrastructure.AI.KnowledgeGraph.Tests.TestSupport;
 using Infrastructure.AI.KnowledgeGraph.WorkMemory;
 using Microsoft.Extensions.Logging;
 using Moq;
@@ -17,7 +18,8 @@ public sealed class GraphWorkEpisodeStoreTests
     public GraphWorkEpisodeStoreTests()
     {
         _graphStore = new InMemoryGraphStore(Mock.Of<ILogger<InMemoryGraphStore>>());
-        _sut = new GraphWorkEpisodeStore(_graphStore, Mock.Of<ILogger<GraphWorkEpisodeStore>>());
+        _sut = new GraphWorkEpisodeStore(
+            _graphStore, StubAmbientRequestScope.None(), Mock.Of<ILogger<GraphWorkEpisodeStore>>());
     }
 
     private static WorkEpisode BuildEpisode(
@@ -128,5 +130,25 @@ public sealed class GraphWorkEpisodeStoreTests
         var node = await _graphStore.GetNodeAsync($"workepisode:{id}".ToLowerInvariant(), CancellationToken.None);
         node.Should().NotBeNull();
         node!.Type.Should().Be("WorkEpisode");
+    }
+
+    [Fact]
+    public async Task Save_StampsCallerCanonicalOwner_SoOwnerScopedErasureCanFindIt()
+    {
+        // D3 owner-stamp: the compliance decorator leaves OwnerId writer-authoritative, so unless the
+        // store stamps the caller's owner the node persists owner-less and owner-scoped right-to-erasure
+        // (GetNodesByOwnerAsync) can never match it. Owner is canonicalized (trimmed/lowercased).
+        var sut = new GraphWorkEpisodeStore(
+            _graphStore, StubAmbientRequestScope.ForOwner("  User-42  "), Mock.Of<ILogger<GraphWorkEpisodeStore>>());
+        var episode = BuildEpisode();
+
+        await sut.SaveAsync(episode, CancellationToken.None);
+
+        var node = await _graphStore.GetNodeAsync($"workepisode:{episode.EpisodeId}".ToLowerInvariant(), CancellationToken.None);
+        node!.OwnerId.Should().Be("user-42", "the saved node must carry the caller's canonical owner");
+
+        var owned = await _graphStore.GetNodesByOwnerAsync("user-42", CancellationToken.None);
+        owned.Should().Contain(n => n.Id == node.Id,
+            "owner-scoped erasure resolves nodes via GetNodesByOwnerAsync and must reach the work-memory node");
     }
 }


### PR DESCRIPTION
D3 erasure pass — Lane 1. Makes work-memory nodes targetable by owner-scoped right-to-erasure.

## Gap
`GraphWorkEpisodeStore`, `GraphEpisodicSegmentStore`, and `GraphLearningsStore` persisted their `GraphNode` without an `OwnerId` (the compliance decorator leaves `OwnerId` writer-authoritative). Owner-scoped erasure filters on `OwnerId` via `GetNodesByOwnerAsync`, so these owner-less nodes were never matched → never erased.

## Fix
Each store stamps the caller's **canonical** owner (`ScopeIdentity.Canonicalize(...)`) on write. The owner is resolved **per-operation** from the ambient request scope (`IAmbientRequestScope.Current?.GetService<IKnowledgeScope>()?.UserId`) — mirroring the singleton-safe pattern already used by `ComplianceAwareGraphStore`. Injecting the scoped `IKnowledgeScope` directly into these singleton stores would trip the `ValidateScopes` captive-dependency guard, so it's resolved lazily instead.

- `Update`/`SoftDelete` rebuild paths preserve `existing.OwnerId` (the `LearningEntry` carries no owner field, so re-serializing would otherwise strip attribution).
- Synthetic index/routing nodes stay owner-less on purpose — shared structures, not the subject's data.

## Verification
- 3 red→green reproduce tests (`Save_StampsCallerCanonicalOwner_SoOwnerScopedErasureCanFindIt`, one per store) — each proved `OwnerId` was null pre-fix and asserts canonicalization + reachability by `GetNodesByOwnerAsync`.
- `Infrastructure.AI.KnowledgeGraph.Tests`: 282 passed (incl. `KnowledgeMemoryServiceDiWiringTests` under real DI + `ValidateScopes`). The 16 Docker-backed Neo4j/Postgres fixtures don't run headless (known constraint); they run in CI.
- Only DI change: 3 keyed factory registrations pass the already-registered `IAmbientRequestScope`. gitnexus_impact LOW.

🤖 Generated with [Claude Code](https://claude.com/claude-code)