### PR TITLE
fix: canonicalize owner/tenant identity across gate and storage backends

### DIFF
--- a/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/Compliance/ComplianceAwareGraphStore.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/Compliance/ComplianceAwareGraphStore.cs
@@ -2,6 +2,7 @@ using Application.AI.Common.Interfaces;
 using Application.AI.Common.Interfaces.KnowledgeGraph;
 using Domain.AI.KnowledgeGraph;
 using Domain.AI.KnowledgeGraph.Models;
+using Domain.AI.KnowledgeGraph.Scoping;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
@@ -109,8 +110,10 @@ public sealed class ComplianceAwareGraphStore : IKnowledgeGraphStore
         var stamped = edges.Select(e => e with
         {
             CreatedAt = e.CreatedAt ?? now,
-            TenantId = e.TenantId ?? tenantId,
-            OwnerId = e.OwnerId ?? edgeOwnerId
+            // Canonicalize owner/tenant so stored identity matches the case-insensitive gate and the
+            // case-sensitive backend owner filters (right-to-erasure sweep, tenant isolation) agree.
+            TenantId = ScopeIdentity.Canonicalize(e.TenantId ?? tenantId),
+            OwnerId = ScopeIdentity.Canonicalize(e.OwnerId ?? edgeOwnerId)
         }).ToList();
 
         await _inner.AddEdgesAsync(stamped, cancellationToken);
@@ -274,7 +277,12 @@ public sealed class ComplianceAwareGraphStore : IKnowledgeGraphStore
         {
             CreatedAt = node.CreatedAt ?? now,
             ExpiresAt = node.ExpiresAt ?? (policy.AllowIndefinite ? null : now + policy.RetentionPeriod),
-            TenantId = node.TenantId ?? tenantId
+            // Canonicalize owner/tenant to the shared form so the case-insensitive authorization gate
+            // and the case-sensitive backend owner/tenant filters compare identically. OwnerId stays
+            // writer-authoritative (null = shared) — canonicalization only normalizes casing/whitespace
+            // of an owner the writer set; it never assigns one.
+            OwnerId = ScopeIdentity.Canonicalize(node.OwnerId),
+            TenantId = ScopeIdentity.Canonicalize(node.TenantId ?? tenantId)
         };
     }
 

--- a/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/InMemory/InMemoryGraphStore.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/InMemory/InMemoryGraphStore.cs
@@ -1,6 +1,7 @@
 using System.Collections.Concurrent;
 using Application.AI.Common.Interfaces.KnowledgeGraph;
 using Domain.AI.KnowledgeGraph.Models;
+using Domain.AI.KnowledgeGraph.Scoping;
 using Microsoft.Extensions.Logging;
 
 namespace Infrastructure.AI.KnowledgeGraph.InMemory;
@@ -36,9 +37,17 @@ public sealed class InMemoryGraphStore : IKnowledgeGraphStore
         IReadOnlyList<GraphNode> nodes,
         CancellationToken cancellationToken = default)
     {
-        foreach (var node in nodes)
+        foreach (var rawNode in nodes)
         {
             cancellationToken.ThrowIfCancellationRequested();
+            // Canonicalize owner/tenant on write so the case-sensitive owner filter below matches the
+            // case-insensitive authorization gate. The decorator normally pre-canonicalizes, but this
+            // backend is also used directly (dev + tests), so it must guarantee canonical storage itself.
+            var node = rawNode with
+            {
+                OwnerId = ScopeIdentity.Canonicalize(rawNode.OwnerId),
+                TenantId = ScopeIdentity.Canonicalize(rawNode.TenantId)
+            };
             _nodes.AddOrUpdate(
                 node.Id,
                 node,
@@ -64,7 +73,13 @@ public sealed class InMemoryGraphStore : IKnowledgeGraphStore
         foreach (var edge in edges)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            _edges.TryAdd(edge.Id, edge);
+            // Canonicalize owner/tenant on write (see AddNodesAsync) so the owner-edge erasure sweep
+            // below matches regardless of the casing the caller supplied.
+            _edges.TryAdd(edge.Id, edge with
+            {
+                OwnerId = ScopeIdentity.Canonicalize(edge.OwnerId),
+                TenantId = ScopeIdentity.Canonicalize(edge.TenantId)
+            });
         }
 
         _logger.LogDebug("Added {Count} edges, total: {Total}", edges.Count, _edges.Count);
@@ -217,8 +232,11 @@ public sealed class InMemoryGraphStore : IKnowledgeGraphStore
         string ownerId,
         CancellationToken cancellationToken = default)
     {
+        // Canonicalize the incoming owner before the exact match: stored identity is already
+        // canonical (see AddEdgesAsync), so both sides are normalized and Ordinal is correct.
+        var canonicalOwner = ScopeIdentity.Canonicalize(ownerId);
         var ownedEdgeIds = _edges.Values
-            .Where(e => string.Equals(e.OwnerId, ownerId, StringComparison.Ordinal))
+            .Where(e => string.Equals(e.OwnerId, canonicalOwner, StringComparison.Ordinal))
             .Select(e => e.Id)
             .ToList();
 
@@ -250,8 +268,10 @@ public sealed class InMemoryGraphStore : IKnowledgeGraphStore
         string ownerId,
         CancellationToken cancellationToken = default)
     {
+        // Canonicalize the incoming owner before the exact match (see DeleteEdgesByOwnerAsync).
+        var canonicalOwner = ScopeIdentity.Canonicalize(ownerId);
         var owned = _nodes.Values
-            .Where(n => string.Equals(n.OwnerId, ownerId, StringComparison.Ordinal))
+            .Where(n => string.Equals(n.OwnerId, canonicalOwner, StringComparison.Ordinal))
             .ToList();
 
         return Task.FromResult<IReadOnlyList<GraphNode>>(owned);

--- a/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/InMemory/InMemoryGraphStore.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/InMemory/InMemoryGraphStore.cs
@@ -235,6 +235,15 @@ public sealed class InMemoryGraphStore : IKnowledgeGraphStore
         // Canonicalize the incoming owner before the exact match: stored identity is already
         // canonical (see AddEdgesAsync), so both sides are normalized and Ordinal is correct.
         var canonicalOwner = ScopeIdentity.Canonicalize(ownerId);
+
+        // A null canonical owner denotes an ABSENT/global owner, never an erasable subject. Without
+        // this guard, string.Equals(record.OwnerId, null) would be true for every owner-null record
+        // (the entire shared corpus/learnings/skill-memory), so an empty/whitespace erase request
+        // would mass-delete the shared graph. Match nothing instead. (SQL backends already no-match
+        // on null via SQL null semantics; this keeps all three backends in agreement.)
+        if (canonicalOwner is null)
+            return Task.FromResult<IReadOnlyList<string>>([]);
+
         var ownedEdgeIds = _edges.Values
             .Where(e => string.Equals(e.OwnerId, canonicalOwner, StringComparison.Ordinal))
             .Select(e => e.Id)
@@ -270,6 +279,12 @@ public sealed class InMemoryGraphStore : IKnowledgeGraphStore
     {
         // Canonicalize the incoming owner before the exact match (see DeleteEdgesByOwnerAsync).
         var canonicalOwner = ScopeIdentity.Canonicalize(ownerId);
+
+        // A null canonical owner is absent/global, never a queryable subject — match nothing rather
+        // than equating null with every owner-null (shared) record. See DeleteEdgesByOwnerAsync.
+        if (canonicalOwner is null)
+            return Task.FromResult<IReadOnlyList<GraphNode>>([]);
+
         var owned = _nodes.Values
             .Where(n => string.Equals(n.OwnerId, canonicalOwner, StringComparison.Ordinal))
             .ToList();

--- a/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/Neo4j/Neo4jGraphStore.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/Neo4j/Neo4jGraphStore.cs
@@ -313,13 +313,19 @@ public sealed class Neo4jGraphStore : IKnowledgeGraphStore, IAsyncDisposable
         CancellationToken cancellationToken = default)
     {
         using var activity = ActivitySource.StartActivity("kg.neo4j.delete_edges_by_owner");
+
+        // Canonicalize the incoming owner before the exact `= $ownerId` filter: stored identity is
+        // already canonical (see AddEdgesAsync), so both sides are normalized. A null canonical owner
+        // is absent/global, never an erasable subject — match nothing. (Cypher `= null` is never true
+        // so this is also defensive; the explicit guard documents the cross-backend invariant.)
+        var canonicalOwner = ScopeIdentity.Canonicalize(ownerId);
+        if (canonicalOwner is null)
+            return [];
+
         await using var session = _driver.AsyncSession();
 
         return await session.ExecuteWriteAsync(async tx =>
         {
-            // Canonicalize the incoming owner before the exact `= $ownerId` filter: stored
-            // identity is already canonical (see AddEdgesAsync), so both sides are normalized.
-            var canonicalOwner = ScopeIdentity.Canonicalize(ownerId);
             var cursor = await tx.RunAsync("""
                 MATCH ()-[r:RELATES]->() WHERE r.owner_id = $ownerId
                 WITH r, r.id AS rid
@@ -380,11 +386,15 @@ public sealed class Neo4jGraphStore : IKnowledgeGraphStore, IAsyncDisposable
         string ownerId,
         CancellationToken cancellationToken = default)
     {
+        // Canonicalize the incoming owner before the exact filter (see DeleteEdgesByOwnerAsync). A
+        // null canonical owner is absent/global, never a queryable subject — match nothing.
+        var canonicalOwner = ScopeIdentity.Canonicalize(ownerId);
+        if (canonicalOwner is null)
+            return [];
+
         await using var session = _driver.AsyncSession();
         return await session.ExecuteReadAsync(async tx =>
         {
-            // Canonicalize the incoming owner before the exact filter (see DeleteEdgesByOwnerAsync).
-            var canonicalOwner = ScopeIdentity.Canonicalize(ownerId);
             var cursor = await tx.RunAsync(
                 "MATCH (n:Entity) WHERE n.owner_id = $ownerId RETURN n",
                 new { ownerId = canonicalOwner });

--- a/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/Neo4j/Neo4jGraphStore.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/Neo4j/Neo4jGraphStore.cs
@@ -3,6 +3,7 @@ using System.Globalization;
 using System.Text.Json;
 using Application.AI.Common.Interfaces.KnowledgeGraph;
 using Domain.AI.KnowledgeGraph.Models;
+using Domain.AI.KnowledgeGraph.Scoping;
 using Domain.Common.Config;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -87,8 +88,10 @@ public sealed class Neo4jGraphStore : IKnowledgeGraphStore, IAsyncDisposable
                         id = node.Id, name = node.Name, type = node.Type,
                         props = JsonSerializer.Serialize(node.Properties, JsonOptions),
                         chunks = node.ChunkIds.ToList(),
-                        owner_id = node.OwnerId,
-                        tenant_id = node.TenantId,
+                        // Canonicalize owner/tenant on write so the case-insensitive gate and the
+                        // case-sensitive `= $ownerId` filters below compare identically.
+                        owner_id = ScopeIdentity.Canonicalize(node.OwnerId),
+                        tenant_id = ScopeIdentity.Canonicalize(node.TenantId),
                         created_at = node.CreatedAt?.ToString("O"),
                         expires_at = node.ExpiresAt?.ToString("O"),
                         prov = node.Provenance is not null
@@ -131,8 +134,9 @@ public sealed class Neo4jGraphStore : IKnowledgeGraphStore, IAsyncDisposable
                         target = edge.TargetNodeId, pred = edge.Predicate,
                         props = JsonSerializer.Serialize(edge.Properties, JsonOptions),
                         chunk = edge.ChunkId,
-                        owner_id = edge.OwnerId,
-                        tenant_id = edge.TenantId,
+                        // Canonicalize owner/tenant on write (see AddNodesAsync).
+                        owner_id = ScopeIdentity.Canonicalize(edge.OwnerId),
+                        tenant_id = ScopeIdentity.Canonicalize(edge.TenantId),
                         created_at = edge.CreatedAt?.ToString("O"),
                         expires_at = edge.ExpiresAt?.ToString("O"),
                         prov = edge.Provenance is not null
@@ -313,12 +317,15 @@ public sealed class Neo4jGraphStore : IKnowledgeGraphStore, IAsyncDisposable
 
         return await session.ExecuteWriteAsync(async tx =>
         {
+            // Canonicalize the incoming owner before the exact `= $ownerId` filter: stored
+            // identity is already canonical (see AddEdgesAsync), so both sides are normalized.
+            var canonicalOwner = ScopeIdentity.Canonicalize(ownerId);
             var cursor = await tx.RunAsync("""
                 MATCH ()-[r:RELATES]->() WHERE r.owner_id = $ownerId
                 WITH r, r.id AS rid
                 DELETE r
                 RETURN rid
-                """, new { ownerId });
+                """, new { ownerId = canonicalOwner });
 
             var deleted = await MaterializeIdsAsync(cursor, "rid");
 
@@ -376,9 +383,11 @@ public sealed class Neo4jGraphStore : IKnowledgeGraphStore, IAsyncDisposable
         await using var session = _driver.AsyncSession();
         return await session.ExecuteReadAsync(async tx =>
         {
+            // Canonicalize the incoming owner before the exact filter (see DeleteEdgesByOwnerAsync).
+            var canonicalOwner = ScopeIdentity.Canonicalize(ownerId);
             var cursor = await tx.RunAsync(
                 "MATCH (n:Entity) WHERE n.owner_id = $ownerId RETURN n",
-                new { ownerId });
+                new { ownerId = canonicalOwner });
 
             var results = new List<GraphNode>();
             while (await cursor.FetchAsync())

--- a/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/PostgreSql/PostgreSqlGraphStore.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/PostgreSql/PostgreSqlGraphStore.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using System.Text.Json;
 using Application.AI.Common.Interfaces.KnowledgeGraph;
 using Domain.AI.KnowledgeGraph.Models;
+using Domain.AI.KnowledgeGraph.Scoping;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Domain.Common.Config;
@@ -119,8 +120,10 @@ public sealed class PostgreSqlGraphStore : IKnowledgeGraphStore
                 node.Provenance is not null
                     ? JsonSerializer.Serialize(node.Provenance, JsonOptions)
                     : (object)DBNull.Value);
-            cmd.Parameters.AddWithValue("owner_id", (object?)node.OwnerId ?? DBNull.Value);
-            cmd.Parameters.AddWithValue("tenant_id", (object?)node.TenantId ?? DBNull.Value);
+            // Canonicalize owner/tenant on write so the case-insensitive gate and the
+            // case-sensitive `WHERE owner_id = @ownerId` filters below compare identically.
+            cmd.Parameters.AddWithValue("owner_id", (object?)ScopeIdentity.Canonicalize(node.OwnerId) ?? DBNull.Value);
+            cmd.Parameters.AddWithValue("tenant_id", (object?)ScopeIdentity.Canonicalize(node.TenantId) ?? DBNull.Value);
             cmd.Parameters.AddWithValue("created_at", (object?)node.CreatedAt ?? DBNull.Value);
             cmd.Parameters.AddWithValue("expires_at", (object?)node.ExpiresAt ?? DBNull.Value);
             await cmd.ExecuteNonQueryAsync(cancellationToken);
@@ -158,8 +161,9 @@ public sealed class PostgreSqlGraphStore : IKnowledgeGraphStore
                 edge.Provenance is not null
                     ? JsonSerializer.Serialize(edge.Provenance, JsonOptions)
                     : (object)DBNull.Value);
-            cmd.Parameters.AddWithValue("owner_id", (object?)edge.OwnerId ?? DBNull.Value);
-            cmd.Parameters.AddWithValue("tenant_id", (object?)edge.TenantId ?? DBNull.Value);
+            // Canonicalize owner/tenant on write (see AddNodesAsync).
+            cmd.Parameters.AddWithValue("owner_id", (object?)ScopeIdentity.Canonicalize(edge.OwnerId) ?? DBNull.Value);
+            cmd.Parameters.AddWithValue("tenant_id", (object?)ScopeIdentity.Canonicalize(edge.TenantId) ?? DBNull.Value);
             cmd.Parameters.AddWithValue("created_at", (object?)edge.CreatedAt ?? DBNull.Value);
             cmd.Parameters.AddWithValue("expires_at", (object?)edge.ExpiresAt ?? DBNull.Value);
             await cmd.ExecuteNonQueryAsync(cancellationToken);
@@ -358,7 +362,9 @@ public sealed class PostgreSqlGraphStore : IKnowledgeGraphStore
         await using var conn = await OpenConnectionAsync(cancellationToken);
         await using var cmd = new NpgsqlCommand(
             "DELETE FROM kg_edges WHERE owner_id = @ownerId RETURNING id", conn);
-        cmd.Parameters.AddWithValue("ownerId", ownerId);
+        // Canonicalize the incoming owner before the exact filter: stored identity is already
+        // canonical (see AddEdgesAsync), so both sides are normalized and the `=` match is correct.
+        cmd.Parameters.AddWithValue("ownerId", (object?)ScopeIdentity.Canonicalize(ownerId) ?? DBNull.Value);
 
         var deleted = new List<string>();
         await using var reader = await cmd.ExecuteReaderAsync(cancellationToken);
@@ -396,7 +402,8 @@ public sealed class PostgreSqlGraphStore : IKnowledgeGraphStore
         await using var cmd = new NpgsqlCommand(
             "SELECT id, name, type, properties, chunk_ids, provenance, owner_id, tenant_id, created_at, expires_at " +
             "FROM kg_nodes WHERE owner_id = @ownerId", conn);
-        cmd.Parameters.AddWithValue("ownerId", ownerId);
+        // Canonicalize the incoming owner before the exact filter (see DeleteEdgesByOwnerAsync).
+        cmd.Parameters.AddWithValue("ownerId", (object?)ScopeIdentity.Canonicalize(ownerId) ?? DBNull.Value);
 
         var results = new List<GraphNode>();
         await using var reader = await cmd.ExecuteReaderAsync(cancellationToken);

--- a/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/PostgreSql/PostgreSqlGraphStore.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/PostgreSql/PostgreSqlGraphStore.cs
@@ -359,12 +359,20 @@ public sealed class PostgreSqlGraphStore : IKnowledgeGraphStore
         CancellationToken cancellationToken = default)
     {
         using var activity = ActivitySource.StartActivity("kg.postgresql.delete_edges_by_owner");
+
+        // Canonicalize the incoming owner before the exact filter: stored identity is already
+        // canonical (see AddEdgesAsync), so both sides are normalized and the `=` match is correct.
+        // A null canonical owner is absent/global, never an erasable subject — match nothing. (SQL
+        // `owner_id = NULL` is UNKNOWN so already no-matches; the explicit guard documents the
+        // cross-backend invariant and avoids a pointless round-trip.)
+        var canonicalOwner = ScopeIdentity.Canonicalize(ownerId);
+        if (canonicalOwner is null)
+            return [];
+
         await using var conn = await OpenConnectionAsync(cancellationToken);
         await using var cmd = new NpgsqlCommand(
             "DELETE FROM kg_edges WHERE owner_id = @ownerId RETURNING id", conn);
-        // Canonicalize the incoming owner before the exact filter: stored identity is already
-        // canonical (see AddEdgesAsync), so both sides are normalized and the `=` match is correct.
-        cmd.Parameters.AddWithValue("ownerId", (object?)ScopeIdentity.Canonicalize(ownerId) ?? DBNull.Value);
+        cmd.Parameters.AddWithValue("ownerId", canonicalOwner);
 
         var deleted = new List<string>();
         await using var reader = await cmd.ExecuteReaderAsync(cancellationToken);
@@ -398,12 +406,17 @@ public sealed class PostgreSqlGraphStore : IKnowledgeGraphStore
         string ownerId,
         CancellationToken cancellationToken = default)
     {
+        // Canonicalize the incoming owner before the exact filter (see DeleteEdgesByOwnerAsync). A
+        // null canonical owner is absent/global, never a queryable subject — match nothing.
+        var canonicalOwner = ScopeIdentity.Canonicalize(ownerId);
+        if (canonicalOwner is null)
+            return [];
+
         await using var conn = await OpenConnectionAsync(cancellationToken);
         await using var cmd = new NpgsqlCommand(
             "SELECT id, name, type, properties, chunk_ids, provenance, owner_id, tenant_id, created_at, expires_at " +
             "FROM kg_nodes WHERE owner_id = @ownerId", conn);
-        // Canonicalize the incoming owner before the exact filter (see DeleteEdgesByOwnerAsync).
-        cmd.Parameters.AddWithValue("ownerId", (object?)ScopeIdentity.Canonicalize(ownerId) ?? DBNull.Value);
+        cmd.Parameters.AddWithValue("ownerId", canonicalOwner);
 
         var results = new List<GraphNode>();
         await using var reader = await cmd.ExecuteReaderAsync(cancellationToken);

--- a/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/Scoping/KnowledgeScopeValidator.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/Scoping/KnowledgeScopeValidator.cs
@@ -1,4 +1,5 @@
 using Application.AI.Common.Interfaces.KnowledgeGraph;
+using Domain.AI.KnowledgeGraph.Scoping;
 using Domain.Common.Config;
 using Microsoft.Extensions.Options;
 
@@ -48,7 +49,11 @@ public sealed class KnowledgeScopeValidator : IKnowledgeScopeValidator
         if (scope.TenantId is null)
             return false;
 
-        return string.Equals(scope.TenantId, targetTenantId, StringComparison.OrdinalIgnoreCase);
+        // Compare via the shared canonical form (trimmed, invariant-lowercase) so this gate agrees
+        // exactly with how the storage backends persist and filter tenant identity. A raw
+        // OrdinalIgnoreCase compare here would authorize access the case-sensitive backend filters
+        // then fail to honor — the drift this canonicalization closes.
+        return ScopeIdentity.AreSame(scope.TenantId, targetTenantId);
     }
 
     /// <inheritdoc />
@@ -64,6 +69,11 @@ public sealed class KnowledgeScopeValidator : IKnowledgeScopeValidator
         // that conflates two distinct id namespaces (a tenant id is not a user id) and would grant
         // cross-user access on any string collision. Tenant-level sharing requires a real TenantId
         // on the node model and is deferred to the tenant-isolation follow-up.
-        return string.Equals(scope.UserId, datasetOwnerId, StringComparison.OrdinalIgnoreCase);
+        //
+        // Compare via the shared canonical form (trimmed, invariant-lowercase) so this gate agrees
+        // exactly with the case-sensitive owner filters in every storage backend. Otherwise the gate
+        // could authorize an erasure the store then fails to match, silently leaving the subject's
+        // data in place.
+        return ScopeIdentity.AreSame(scope.UserId, datasetOwnerId);
     }
 }

--- a/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/Scoping/KnowledgeScopeValidator.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/Scoping/KnowledgeScopeValidator.cs
@@ -64,6 +64,14 @@ public sealed class KnowledgeScopeValidator : IKnowledgeScopeValidator
         if (!_configMonitor.CurrentValue.AI.Rag.GraphRag.MultiTenantIsolation)
             return true;
 
+        // An absent (null/empty/whitespace) dataset owner is never an authorizable dataset: it denotes
+        // a shared/global (owner-null) record, whose access is decided upstream by the caller
+        // (TenantIsolatedGraphStore short-circuits `ownerId is null`), not by a per-owner authorization.
+        // Guard first so ScopeIdentity.AreSame — which treats two absent ids as equal — cannot authorize
+        // a null-UserId caller against an absent owner (the old OrdinalIgnoreCase gate denied that).
+        if (ScopeIdentity.Canonicalize(datasetOwnerId) is null)
+            return false;
+
         // Owner-level isolation: the owner id is a user id, so access is granted only when the
         // caller is that user. We deliberately do NOT compare scope.TenantId against the owner id —
         // that conflates two distinct id namespaces (a tenant id is not a user id) and would grant

--- a/src/Content/Tests/Infrastructure.AI.KnowledgeGraph.Tests/Scoping/OwnerIdCanonicalizationTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.KnowledgeGraph.Tests/Scoping/OwnerIdCanonicalizationTests.cs
@@ -1,0 +1,137 @@
+using Application.AI.Common.Interfaces.KnowledgeGraph;
+using Domain.AI.KnowledgeGraph.Models;
+using Domain.Common.Config;
+using Domain.Common.Config.AI;
+using Domain.Common.Config.AI.RAG;
+using FluentAssertions;
+using Infrastructure.AI.KnowledgeGraph.InMemory;
+using Infrastructure.AI.KnowledgeGraph.Scoping;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Infrastructure.AI.KnowledgeGraph.Tests.Scoping;
+
+/// <summary>
+/// Regression tests for the owner/tenant identity canonicalization fix (D3, Lane 2).
+/// </summary>
+/// <remarks>
+/// The authorization gate (<see cref="KnowledgeScopeValidator"/>) compared owner/tenant IDs
+/// case-insensitively while every storage backend filtered case-sensitively. That drift let the
+/// gate authorize a right-to-erasure the store then failed to match — silently leaving the
+/// subject's data in place. These tests pin the closed behavior: identities are canonicalized on
+/// write and before the exact filter, so authorization and persistence agree.
+/// </remarks>
+public sealed class OwnerIdCanonicalizationTests
+{
+    /// <summary>
+    /// The core drift, end-to-end: an owner id differing only in case is authorized by the gate,
+    /// and the store's owner filter must then actually find the subject's node. Pre-fix the store
+    /// filtered case-sensitively and returned nothing — the data survived the "authorized" erasure.
+    /// </summary>
+    [Fact]
+    public async Task GateAuthorizesMixedCaseOwner_And_StoreOwnerFilterMatchesIt()
+    {
+        // A fact was remembered under a mixed-case owner id.
+        const string storedOwner = "Alice@Example.com";
+        // The erasure request arrives with the same principal in a different case.
+        const string erasureRequestOwner = "alice@example.COM";
+
+        var validator = CreateValidator(isolationEnabled: true);
+        var scope = CreateScope(userId: erasureRequestOwner);
+
+        // Gate: same principal → authorized.
+        validator.CanAccessDataset(scope, erasureRequestOwner).Should().BeTrue();
+
+        // Store: the authorized owner id must actually match the subject's node.
+        var store = new InMemoryGraphStore(Mock.Of<ILogger<InMemoryGraphStore>>());
+        await store.AddNodesAsync([new GraphNode
+        {
+            Id = "n1", Name = "secret", Type = "Fact", OwnerId = storedOwner
+        }]);
+
+        var owned = await store.GetNodesByOwnerAsync(erasureRequestOwner);
+
+        owned.Should().ContainSingle("the store must find the subject's data the gate authorized erasing")
+            .Which.Id.Should().Be("n1");
+    }
+
+    /// <summary>
+    /// The owner-edge erasure sweep must delete edges whose owner differs only in case from the
+    /// requested (authorized) owner id. Pre-fix the case-sensitive filter deleted nothing.
+    /// </summary>
+    [Fact]
+    public async Task DeleteEdgesByOwner_MixedCaseOwner_ErasesTheSubjectsEdge()
+    {
+        var store = new InMemoryGraphStore(Mock.Of<ILogger<InMemoryGraphStore>>());
+        await store.AddNodesAsync([
+            new GraphNode { Id = "n1", Name = "A", Type = "Fact" },
+            new GraphNode { Id = "n2", Name = "B", Type = "Fact" }
+        ]);
+        await store.AddEdgesAsync([new GraphEdge
+        {
+            Id = "e1", SourceNodeId = "n1", TargetNodeId = "n2",
+            Predicate = "relates_to", ChunkId = "c1", OwnerId = "Alice@Example.com"
+        }]);
+
+        var deleted = await store.DeleteEdgesByOwnerAsync("ALICE@EXAMPLE.COM");
+
+        deleted.Should().BeEquivalentTo(["e1"]);
+        (await store.GetEdgeCountAsync()).Should().Be(0, "the subject's edge must be erased");
+    }
+
+    /// <summary>
+    /// Owner ids are canonical in the store regardless of the casing supplied on write, so a
+    /// canonically-cased query matches a mixed-case write.
+    /// </summary>
+    [Fact]
+    public async Task Write_MixedCaseOwner_IsStoredCanonically()
+    {
+        var store = new InMemoryGraphStore(Mock.Of<ILogger<InMemoryGraphStore>>());
+        await store.AddNodesAsync([new GraphNode
+        {
+            Id = "n1", Name = "secret", Type = "Fact", OwnerId = "  Alice@Example.com  "
+        }]);
+
+        var stored = await store.GetNodeAsync("n1");
+
+        stored!.OwnerId.Should().Be("alice@example.com", "owner is canonicalized (trimmed, lower-cased) on write");
+    }
+
+    /// <summary>
+    /// Gate guard: two owner ids differing only in case denote the same principal.
+    /// </summary>
+    [Fact]
+    public void CanAccessDataset_MixedCaseOwner_TreatedAsSamePrincipal()
+    {
+        var validator = CreateValidator(isolationEnabled: true);
+        var scope = CreateScope(userId: "alice@example.com");
+
+        validator.CanAccessDataset(scope, "Alice@Example.COM").Should().BeTrue();
+    }
+
+    private static KnowledgeScopeValidator CreateValidator(bool isolationEnabled)
+    {
+        var monitor = new Mock<IOptionsMonitor<AppConfig>>();
+        monitor.Setup(m => m.CurrentValue).Returns(new AppConfig
+        {
+            AI = new AIConfig
+            {
+                Rag = new RagConfig
+                {
+                    GraphRag = new GraphRagConfig { MultiTenantIsolation = isolationEnabled }
+                }
+            }
+        });
+        return new KnowledgeScopeValidator(monitor.Object);
+    }
+
+    private static IKnowledgeScope CreateScope(string? userId = null, string? tenantId = null)
+    {
+        var mock = new Mock<IKnowledgeScope>();
+        mock.Setup(s => s.UserId).Returns(userId);
+        mock.Setup(s => s.TenantId).Returns(tenantId);
+        return mock.Object;
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.KnowledgeGraph.Tests/Scoping/OwnerIdCanonicalizationTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.KnowledgeGraph.Tests/Scoping/OwnerIdCanonicalizationTests.cs
@@ -111,6 +111,80 @@ public sealed class OwnerIdCanonicalizationTests
         validator.CanAccessDataset(scope, "Alice@Example.COM").Should().BeTrue();
     }
 
+    // --- Absent-owner guard: a null/empty/whitespace owner canonicalizes to null, which denotes an
+    // absent/global owner and must never over-match the owner-null (shared) corpus or authorize
+    // access. Without these guards, string.Equals(record.OwnerId, null) is true for every shared
+    // record, so an empty/whitespace erase request would mass-delete the shared graph on the
+    // in-memory backend (the DEFAULT: managed_code aliases to in_memory). ---
+
+    /// <summary>
+    /// A by-owner NODE query with an absent (empty/whitespace/null) owner must return nothing — and
+    /// crucially must NOT return the owner-null (shared/global) records. Pins the fix and the
+    /// cross-backend agreement (Neo4j/Postgres already no-match on null via SQL null semantics).
+    /// </summary>
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData(null)]
+    public async Task GetNodesByOwner_AbsentOwner_ReturnsEmpty_AndDoesNotTouchGlobalRecords(string? absentOwner)
+    {
+        var store = new InMemoryGraphStore(Mock.Of<ILogger<InMemoryGraphStore>>());
+        await store.AddNodesAsync([
+            new GraphNode { Id = "shared1", Name = "Corpus", Type = "Fact" },   // owner-null = shared/global
+            new GraphNode { Id = "shared2", Name = "Learning", Type = "Fact" }, // owner-null = shared/global
+            new GraphNode { Id = "owned", Name = "Memory", Type = "Fact", OwnerId = "alice@example.com" }
+        ]);
+
+        var result = await store.GetNodesByOwnerAsync(absentOwner!);
+
+        result.Should().BeEmpty("an absent owner is never a queryable subject and must not match shared records");
+    }
+
+    /// <summary>
+    /// A by-owner EDGE erasure with an absent owner must be a no-op — and must NOT delete the
+    /// owner-null (shared) edges. This is the data-destruction guard: on the default in-memory
+    /// backend, an empty erase request must not wipe the shared graph.
+    /// </summary>
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData(null)]
+    public async Task DeleteEdgesByOwner_AbsentOwner_IsNoOp_AndPreservesGlobalEdges(string? absentOwner)
+    {
+        var store = new InMemoryGraphStore(Mock.Of<ILogger<InMemoryGraphStore>>());
+        await store.AddNodesAsync([
+            new GraphNode { Id = "n1", Name = "A", Type = "Fact" },
+            new GraphNode { Id = "n2", Name = "B", Type = "Fact" }
+        ]);
+        await store.AddEdgesAsync([
+            new GraphEdge { Id = "e-shared1", SourceNodeId = "n1", TargetNodeId = "n2", Predicate = "cites", ChunkId = "c1" },  // owner-null
+            new GraphEdge { Id = "e-shared2", SourceNodeId = "n2", TargetNodeId = "n1", Predicate = "cites", ChunkId = "c1" },  // owner-null
+            new GraphEdge { Id = "e-owned", SourceNodeId = "n1", TargetNodeId = "n2", Predicate = "uses", ChunkId = "c1", OwnerId = "alice@example.com" }
+        ]);
+
+        var deleted = await store.DeleteEdgesByOwnerAsync(absentOwner!);
+
+        deleted.Should().BeEmpty("an absent owner erases nothing");
+        (await store.GetEdgeCountAsync()).Should().Be(3, "the shared (owner-null) corpus must survive an absent-owner erase");
+    }
+
+    /// <summary>
+    /// Gate guard (LOW): an absent dataset owner is never an authorizable dataset, even for a caller
+    /// whose own UserId is also absent — <see cref="ScopeIdentity.AreSame"/> would otherwise treat two
+    /// absent ids as equal and authorize access the old OrdinalIgnoreCase gate denied.
+    /// </summary>
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData(null)]
+    public void CanAccessDataset_AbsentOwner_Denies(string? absentOwner)
+    {
+        var validator = CreateValidator(isolationEnabled: true);
+        var scope = CreateScope(userId: null);
+
+        validator.CanAccessDataset(scope, absentOwner!).Should().BeFalse();
+    }
+
     private static KnowledgeScopeValidator CreateValidator(bool isolationEnabled)
     {
         var monitor = new Mock<IOptionsMonitor<AppConfig>>();


### PR DESCRIPTION
D3 erasure pass — Lane 2. Closes the owner-ID case drift between the authorization gate and the storage backends, and hardens the absent-owner edge.

## Gap
The gate `KnowledgeScopeValidator` compared owner/tenant IDs case-**insensitively** while every backend filtered case-**sensitively**, so the gate could authorize an erasure the store then failed to match — leaving the subject's data in place.

## Fix (canonicalize on write + exact match, via `ScopeIdentity`)
- **Gate**: `CanAccessDataset`/`ValidateAccess` compare via `ScopeIdentity.AreSame`.
- **Write**: `ComplianceAwareGraphStore.StampNode` + each backend's add path canonicalize `OwnerId`/`TenantId`.
- **Query**: the by-owner read/delete paths canonicalize the param before the (now exact) filter.
- `TenantIsolatedGraphStore` needs no change — all its owner/tenant decisions route through the gate.

## Adversarial security review (SAFE WITH FIXES → fixed)
- **HIGH (fixed):** canonicalizing an empty/whitespace/null query owner → `null`, which `string.Equals`-matched **every** owner-null (global) record — so `EraseByOwnerAsync("")` on the **default** in-memory backend would mass-delete the shared corpus (SQL backends safely no-match null, so the backends disagreed). Fix: the InMemory by-owner methods return empty when the canonical owner is null (before the filter); Neo4j/Postgres get the same guard for cross-backend agreement. A null canonical owner denotes absent/global — never an erasable subject.
- **LOW (fixed):** `CanAccessDataset` short-circuits to `false` for a null canonical dataset owner (verified `TenantIsolatedGraphStore` short-circuits owner-null *before* the gate, so legitimate global-access paths are unaffected).

## Verification
- Semantics-preserving for correctly-cased data; only absent-forms (null/empty/whitespace) collapse. `ToLowerInvariant` — safe for GUID object-ids / emails.
- `Infrastructure.AI.KnowledgeGraph.Tests`: 292 passed (9 new, incl. the mass-delete regression pin — edge count stays 3). Docker-backed Neo4j/Postgres fixtures run in CI.
- **Migration note:** pre-existing rows with mixed-case owner/tenant IDs need a one-time normalization (`UPDATE ... SET owner_id = lower(trim(owner_id))`); in-memory has no persistence. Documented, not run here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)