### PR TITLE
fix: close five right-to-erasure gaps in the erasure orchestrator

### DIFF
--- a/src/Content/Application/Application.AI.Common/Interfaces/KnowledgeGraph/ICrossSessionMemoryStore.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/KnowledgeGraph/ICrossSessionMemoryStore.cs
@@ -17,6 +17,18 @@ public interface ICrossSessionMemoryStore
     /// <summary>Permanently deletes a memory by ID from cache and graph backend.</summary>
     Task ForgetAsync(string memoryId, CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Permanently purges every cross-session memory owned by <paramref name="ownerId"/> from
+    /// both the in-memory cache and the durable graph backend, for right-to-erasure. The owner
+    /// is matched after canonicalization (see
+    /// <see cref="Domain.AI.KnowledgeGraph.Scoping.ScopeIdentity"/>), so casing differences do
+    /// not leave records behind. A whitespace/empty owner purges nothing.
+    /// </summary>
+    /// <param name="ownerId">The knowledge-scope owner whose memories must be erased.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The number of distinct memory records actually purged (cache and backend, deduplicated).</returns>
+    Task<int> PurgeByOwnerAsync(string ownerId, CancellationToken cancellationToken = default);
+
     /// <summary>Applies a feedback delta to a memory's weight. Clamped to [0.0, 1.0].</summary>
     Task ImproveAsync(string memoryId, double feedbackDelta, CancellationToken cancellationToken = default);
 }

--- a/src/Content/Application/Application.AI.Common/Interfaces/KnowledgeGraph/IErasureOrchestrator.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/KnowledgeGraph/IErasureOrchestrator.cs
@@ -14,4 +14,30 @@ public interface IErasureOrchestrator
 
     /// <summary>Erase specific nodes and all their associated data.</summary>
     Task<ErasureReceipt> EraseByNodeIdsAsync(IReadOnlyList<string> nodeIds, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Erase the supplied nodes and all their associated data <em>without re-fetching them</em>
+    /// from the graph store. This is the primitive the retention enforcer uses: it already holds
+    /// the full expired <see cref="GraphNode"/> instances (including their
+    /// <see cref="GraphNode.ChunkIds"/>) from an unfiltered scan, and the compliance-aware store
+    /// returns <see langword="null"/> for expired nodes on re-fetch — so
+    /// <see cref="EraseByNodeIdsAsync"/> would collect zero chunk IDs and silently skip the
+    /// derived-content (vector/BM25) purge. Passing the nodes directly preserves their chunk IDs
+    /// so derived content is erased.
+    /// </summary>
+    /// <remarks>
+    /// <strong>Callers MUST pass authentic, store-sourced <see cref="GraphNode"/> instances</strong>
+    /// (obtained from <see cref="IKnowledgeGraphStore.GetAllNodesAsync"/> /
+    /// <see cref="IKnowledgeGraphStore.GetNodesByOwnerAsync"/> / <see cref="IKnowledgeGraphStore.GetNodeAsync"/>).
+    /// This method trusts each node's <see cref="GraphNode.ChunkIds"/> to derive the document IDs it
+    /// purges from the vector and BM25 stores; it does NOT re-validate the node↔chunk association.
+    /// Passing fabricated or caller-mutated <see cref="GraphNode.ChunkIds"/> would delete another
+    /// document's derived content. Never call this with caller-constructed nodes — use
+    /// <see cref="EraseByNodeIdsAsync"/> (which re-fetches) when you hold only IDs.
+    /// </remarks>
+    /// <param name="nodes">
+    /// The store-sourced nodes to erase, carrying their chunk references for derived-content cleanup.
+    /// </param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<ErasureReceipt> EraseByNodesAsync(IReadOnlyList<GraphNode> nodes, CancellationToken cancellationToken = default);
 }

--- a/src/Content/Domain/Domain.AI/KnowledgeGraph/Models/ErasureCompleteness.cs
+++ b/src/Content/Domain/Domain.AI/KnowledgeGraph/Models/ErasureCompleteness.cs
@@ -1,0 +1,25 @@
+namespace Domain.AI.KnowledgeGraph.Models;
+
+/// <summary>
+/// Whether a right-to-erasure request was fulfilled across its full declared scope, or only
+/// partially. Recorded on <see cref="ErasureReceipt"/> so an erasure that could not complete
+/// its scope never presents as a clean success.
+/// </summary>
+public enum ErasureCompleteness
+{
+    /// <summary>
+    /// Every sweep the request's scope implies ran successfully. For an owner-scoped erasure
+    /// this means the owner's nodes, owner-scoped edges, feedback weights, derived vector/BM25
+    /// content, and cross-session memory were all purged. For a node-scoped erasure it means
+    /// the targeted nodes and their derived content were purged.
+    /// </summary>
+    Full = 0,
+
+    /// <summary>
+    /// The erasure ran but could not fulfil its full declared scope — for example an
+    /// owner-scoped request whose owner identity could not be resolved, so owner-scoped edge
+    /// and cross-session-memory sweeps were skipped. The accompanying
+    /// <see cref="ErasureReceipt.CompletenessReason"/> explains what was left unpurged.
+    /// </summary>
+    Partial = 1
+}

--- a/src/Content/Domain/Domain.AI/KnowledgeGraph/Models/ErasureReceipt.cs
+++ b/src/Content/Domain/Domain.AI/KnowledgeGraph/Models/ErasureReceipt.cs
@@ -28,9 +28,42 @@ public record ErasureReceipt
     /// </summary>
     public required int FeedbackWeightsDeleted { get; init; }
     /// <summary>
-    /// Number of vector embeddings deleted. <c>IVectorStore.DeleteAsync</c> returns no
-    /// per-item confirmation, so this counts the chunk IDs submitted for deletion —
-    /// each call either succeeded or the erasure faulted before producing a receipt.
+    /// Number of documents whose vector embeddings were submitted for deletion.
+    /// <c>IVectorStore.DeleteAsync</c> deletes by <em>document ID</em> and returns no per-item
+    /// confirmation, so this counts the distinct document IDs (derived from the erased nodes'
+    /// chunk IDs) submitted to the vector store — each call either succeeded or the erasure
+    /// faulted before producing a receipt. Zero when no vector store is configured.
     /// </summary>
     public required int VectorEmbeddingsDeleted { get; init; }
+
+    /// <summary>
+    /// Number of documents whose BM25/full-text rows were submitted for deletion, by document
+    /// ID (derived from the erased nodes' chunk IDs). RAPTOR summary rows share the same
+    /// document ID and drop out via the same document-scoped delete. Zero when no BM25 store
+    /// is configured. Defaults to zero so pre-existing construction sites remain valid.
+    /// </summary>
+    public int Bm25DocumentsDeleted { get; init; }
+
+    /// <summary>
+    /// Number of cross-session memory records purged for the erased owner, across the store's
+    /// in-memory cache and its durable graph backend. Zero for node-scoped erasures (which do
+    /// not touch cross-session memory) and when no cross-session memory store is configured.
+    /// Defaults to zero so pre-existing construction sites remain valid.
+    /// </summary>
+    public int CrossSessionMemoriesDeleted { get; init; }
+
+    /// <summary>
+    /// Whether the erasure fulfilled its full declared scope. Defaults to
+    /// <see cref="ErasureCompleteness.Full"/> so pre-existing construction sites remain valid;
+    /// the orchestrator downgrades it to <see cref="ErasureCompleteness.Partial"/> and populates
+    /// <see cref="CompletenessReason"/> when a scoped sweep could not run.
+    /// </summary>
+    public ErasureCompleteness Completeness { get; init; } = ErasureCompleteness.Full;
+
+    /// <summary>
+    /// Human-readable explanation of what was left unpurged when <see cref="Completeness"/> is
+    /// <see cref="ErasureCompleteness.Partial"/>; <see langword="null"/> when the erasure was
+    /// <see cref="ErasureCompleteness.Full"/>.
+    /// </summary>
+    public string? CompletenessReason { get; init; }
 }

--- a/src/Content/Domain/Domain.AI/KnowledgeGraph/Models/MemoryRecord.cs
+++ b/src/Content/Domain/Domain.AI/KnowledgeGraph/Models/MemoryRecord.cs
@@ -29,4 +29,20 @@ public sealed record MemoryRecord
 
     /// <summary>Arbitrary metadata (entity types, topic tags). Strings for graph portability.</summary>
     public IReadOnlyDictionary<string, string> Metadata { get; init; } = new Dictionary<string, string>();
+
+    /// <summary>
+    /// The knowledge-scope owner (user/tenant ID) this memory belongs to, or <see langword="null"/>
+    /// for a global/unscoped memory. Canonicalized via
+    /// <see cref="Scoping.ScopeIdentity.Canonicalize"/> when the record is written, so owner
+    /// comparisons and right-to-erasure purges match regardless of casing. Right-to-erasure of an
+    /// owner deletes every memory record carrying that owner.
+    /// </summary>
+    /// <remarks>
+    /// This property is <c>required</c> — not to forbid global memories (an explicit
+    /// <see langword="null"/> is a legitimate global record) but to force every writer to make a
+    /// conscious ownership decision. A record whose owner is left <see langword="null"/> by
+    /// oversight is unreachable by an owner-scoped right-to-erasure purge, so ownership must never
+    /// be defaulted silently.
+    /// </remarks>
+    public required string? OwnerId { get; init; }
 }

--- a/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/Compliance/DefaultErasureOrchestrator.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/Compliance/DefaultErasureOrchestrator.cs
@@ -2,30 +2,58 @@ using Application.AI.Common.Interfaces.KnowledgeGraph;
 using Application.AI.Common.Interfaces.RAG;
 using Domain.AI.KnowledgeGraph;
 using Domain.AI.KnowledgeGraph.Models;
+using Domain.AI.KnowledgeGraph.Scoping;
 using Microsoft.Extensions.Logging;
 
 namespace Infrastructure.AI.KnowledgeGraph.Compliance;
 
 /// <summary>
-/// Coordinates right-to-erasure across graph, feedback, and vector stores.
-/// Produces an <see cref="ErasureReceipt"/> as proof of compliance.
+/// Coordinates right-to-erasure across every storage layer that can retain a subject's data:
+/// graph nodes/edges, feedback weights, derived vector + BM25 (including RAPTOR summary) content,
+/// and cross-session memory. Produces an <see cref="ErasureReceipt"/> as proof of compliance, and
+/// records honestly — via <see cref="ErasureReceipt.Completeness"/> — when a scoped sweep could
+/// not run rather than presenting a partial erasure as a clean success.
 /// </summary>
 public sealed class DefaultErasureOrchestrator : IErasureOrchestrator
 {
     private readonly IKnowledgeGraphStore _graphStore;
     private readonly IFeedbackStore _feedbackStore;
     private readonly IVectorStore? _vectorStore;
+    private readonly IBm25Store? _bm25Store;
+    private readonly ICrossSessionMemoryStore? _crossSessionMemory;
     private readonly IMemoryAuditSink _auditSink;
     private readonly TimeProvider _timeProvider;
     private readonly ILogger<DefaultErasureOrchestrator> _logger;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DefaultErasureOrchestrator"/> class.
+    /// </summary>
+    /// <param name="graphStore">The knowledge graph store holding nodes and edges.</param>
+    /// <param name="feedbackStore">The feedback-weight store keyed by node/edge id.</param>
+    /// <param name="vectorStore">
+    /// Optional vector store. <see langword="null"/> when no vector backend is deployed, in which
+    /// case there are no embeddings to purge.
+    /// </param>
+    /// <param name="auditSink">The audit sink that records the erasure as compliance proof.</param>
+    /// <param name="timeProvider">Time source for receipt timestamps.</param>
+    /// <param name="logger">Logger for recording erasure activity.</param>
+    /// <param name="bm25Store">
+    /// Optional BM25/full-text store. <see langword="null"/> when no BM25 backend is deployed, in
+    /// which case there are no sparse rows (nor RAPTOR summary rows) to purge.
+    /// </param>
+    /// <param name="crossSessionMemory">
+    /// Optional cross-session memory store. <see langword="null"/> when cross-session memory is
+    /// not enabled, in which case there is no memory to purge. Only ever swept on the owner path.
+    /// </param>
     public DefaultErasureOrchestrator(
         IKnowledgeGraphStore graphStore,
         IFeedbackStore feedbackStore,
         IVectorStore? vectorStore,
         IMemoryAuditSink auditSink,
         TimeProvider timeProvider,
-        ILogger<DefaultErasureOrchestrator> logger)
+        ILogger<DefaultErasureOrchestrator> logger,
+        IBm25Store? bm25Store = null,
+        ICrossSessionMemoryStore? crossSessionMemory = null)
     {
         ArgumentNullException.ThrowIfNull(graphStore);
         ArgumentNullException.ThrowIfNull(feedbackStore);
@@ -36,6 +64,8 @@ public sealed class DefaultErasureOrchestrator : IErasureOrchestrator
         _graphStore = graphStore;
         _feedbackStore = feedbackStore;
         _vectorStore = vectorStore;
+        _bm25Store = bm25Store;
+        _crossSessionMemory = crossSessionMemory;
         _auditSink = auditSink;
         _timeProvider = timeProvider;
         _logger = logger;
@@ -49,11 +79,26 @@ public sealed class DefaultErasureOrchestrator : IErasureOrchestrator
         var requestedAt = _timeProvider.GetUtcNow();
         var requestId = Guid.NewGuid().ToString();
 
-        var nodes = await _graphStore.GetNodesByOwnerAsync(ownerId, cancellationToken);
+        // Canonicalize the owner ONCE at the entry point and drive every downstream sweep — graph
+        // nodes, owner-scoped edges, and cross-session memory — off the single canonical value.
+        // Graph owner matching is case-sensitive, so mixing raw and canonical owners could leave
+        // graph data behind while the receipt still reported Full (the exact silent-survival case
+        // ScopeIdentity guards against). When the owner canonicalizes to null the scope is
+        // unresolvable: skip every owner-scoped sweep uniformly and report Partial honestly.
+        var canonicalOwner = ScopeIdentity.Canonicalize(ownerId);
+
+        var nodes = canonicalOwner is not null
+            ? await _graphStore.GetNodesByOwnerAsync(canonicalOwner, cancellationToken)
+            : [];
         var nodeIds = nodes.Select(n => n.Id).ToList();
 
+        // Prefer the canonical owner as the receipt/audit scope; fall back to the raw input for
+        // traceability when it canonicalizes to null.
+        var scopeId = canonicalOwner ?? ownerId;
+
         return await ExecuteErasureAsync(
-            requestId, ownerId, ownerId, nodes, nodeIds, requestedAt, cancellationToken);
+            requestId, scopeId, canonicalOwner, ownerScopeRequested: true,
+            nodes, nodeIds, requestedAt, cancellationToken);
     }
 
     /// <inheritdoc />
@@ -72,20 +117,41 @@ public sealed class DefaultErasureOrchestrator : IErasureOrchestrator
         }
 
         var scopeId = nodes.FirstOrDefault()?.OwnerId ?? "system";
-        // Node-scoped erasure has no owner to sweep edges for; the node cascade covers it.
+        // Node-scoped erasure has no owner to sweep edges/memory for; the node cascade covers it.
         return await ExecuteErasureAsync(
-            requestId, scopeId, ownerId: null, nodes, nodeIds.ToList(), requestedAt, cancellationToken);
+            requestId, scopeId, ownerId: null, ownerScopeRequested: false,
+            nodes, nodeIds.ToList(), requestedAt, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public Task<ErasureReceipt> EraseByNodesAsync(
+        IReadOnlyList<GraphNode> nodes,
+        CancellationToken cancellationToken = default)
+    {
+        var requestedAt = _timeProvider.GetUtcNow();
+        var requestId = Guid.NewGuid().ToString();
+
+        // Trust the caller's node instances (they hold the ChunkIds the compliance-aware store
+        // would return null for on re-fetch). Node-scoped: no owner sweep.
+        var scopeId = nodes.FirstOrDefault()?.OwnerId ?? "system";
+        var nodeIds = nodes.Select(n => n.Id).ToList();
+        return ExecuteErasureAsync(
+            requestId, scopeId, ownerId: null, ownerScopeRequested: false,
+            nodes, nodeIds, requestedAt, cancellationToken);
     }
 
     private async Task<ErasureReceipt> ExecuteErasureAsync(
         string requestId,
         string scopeId,
         string? ownerId,
+        bool ownerScopeRequested,
         IReadOnlyList<GraphNode> nodes,
         List<string> nodeIds,
         DateTimeOffset requestedAt,
         CancellationToken cancellationToken)
     {
+        var partialReasons = new List<string>();
+
         // 1. Delete graph nodes and their connected edges. The store reports what it
         //    actually removed — the receipt must never echo the requested counts.
         var nodeDeletion = nodeIds.Count > 0
@@ -113,21 +179,65 @@ public sealed class DefaultErasureOrchestrator : IErasureOrchestrator
             ? await _feedbackStore.DeleteWeightsByEdgeIdsAsync(deletedEdgeIds, cancellationToken)
             : 0;
 
-        // 4. Delete vector embeddings (optional — not all deployments use vectors).
-        //    IVectorStore.DeleteAsync returns no per-item confirmation, so this count is the
-        //    number of chunk IDs submitted for deletion (each call either succeeds or throws).
-        var chunkIds = nodes.SelectMany(n => n.ChunkIds).Distinct().ToList();
-        var embeddingsDeleted = 0;
-        if (_vectorStore is not null && chunkIds.Count > 0)
+        // 4. Purge derived content (vector embeddings + BM25/full-text, including RAPTOR summary
+        //    rows) by DOCUMENT id. Vector/BM25 delete by documentId, NOT chunkId — chunk IDs are
+        //    "{documentId}_chunk_{i}" / "{documentId}_raptor_L{l}_C{c}", so we derive the document
+        //    prefix. RAPTOR rows share the parent document id and drop out via the same delete.
+        var documentIds = nodes
+            .SelectMany(n => n.ChunkIds)
+            .Select(DeriveDocumentId)
+            .Where(id => !string.IsNullOrEmpty(id))
+            .Distinct(StringComparer.Ordinal)
+            .ToList();
+
+        var vectorDocsDeleted = 0;
+        var bm25DocsDeleted = 0;
+        if (documentIds.Count > 0)
         {
-            // IVectorStore does not yet have DeleteByDocumentIdsAsync (batch).
-            // When added, replace the loop below with a single batch call.
-            foreach (var chunkId in chunkIds)
+            if (_vectorStore is not null)
             {
-                await _vectorStore.DeleteAsync(chunkId, cancellationToken: cancellationToken);
-                embeddingsDeleted++;
+                foreach (var documentId in documentIds)
+                {
+                    await _vectorStore.DeleteAsync(documentId, cancellationToken: cancellationToken);
+                    vectorDocsDeleted++;
+                }
+            }
+
+            if (_bm25Store is not null)
+            {
+                foreach (var documentId in documentIds)
+                {
+                    await _bm25Store.DeleteAsync(documentId, cancellationToken: cancellationToken);
+                    bm25DocsDeleted++;
+                }
             }
         }
+
+        // 5. Purge cross-session memory owned by the subject. Only meaningful on the owner path
+        //    (memory is owner-scoped, not node-scoped) and when the subsystem is deployed.
+        var crossSessionDeleted = 0;
+        var canonicalOwner = ScopeIdentity.Canonicalize(ownerId);
+        if (ownerScopeRequested && canonicalOwner is not null && _crossSessionMemory is not null)
+        {
+            crossSessionDeleted = await _crossSessionMemory
+                .PurgeByOwnerAsync(canonicalOwner, cancellationToken);
+        }
+
+        // Completeness: an owner-scoped request whose owner could not be resolved cannot sweep
+        // owner-scoped edges or cross-session memory, so it must NOT report as a clean success.
+        if (ownerScopeRequested && canonicalOwner is null)
+        {
+            partialReasons.Add(
+                "owner scope could not be resolved from an empty/whitespace owner id; " +
+                "owner-scoped edge and cross-session-memory sweeps were skipped");
+        }
+
+        var completeness = partialReasons.Count == 0
+            ? ErasureCompleteness.Full
+            : ErasureCompleteness.Partial;
+        var completenessReason = partialReasons.Count == 0
+            ? null
+            : string.Join("; ", partialReasons);
 
         var receipt = new ErasureReceipt
         {
@@ -138,10 +248,14 @@ public sealed class DefaultErasureOrchestrator : IErasureOrchestrator
             NodesDeleted = nodeDeletion.NodesDeleted,
             EdgesDeleted = deletedEdgeIds.Count,
             FeedbackWeightsDeleted = nodeWeightsDeleted + edgeWeightsDeleted,
-            VectorEmbeddingsDeleted = embeddingsDeleted
+            VectorEmbeddingsDeleted = vectorDocsDeleted,
+            Bm25DocumentsDeleted = bm25DocsDeleted,
+            CrossSessionMemoriesDeleted = crossSessionDeleted,
+            Completeness = completeness,
+            CompletenessReason = completenessReason
         };
 
-        // 5. Emit audit event covering everything that was ACTUALLY erased — the deleted
+        // 6. Emit audit event covering everything that was ACTUALLY erased — the deleted
         //    IDs reported by the stores, never the requested IDs. (The event itself is
         //    always emitted: it is the proof the erasure REQUEST was processed, receipt
         //    and all, even when nothing matched.)
@@ -157,11 +271,30 @@ public sealed class DefaultErasureOrchestrator : IErasureOrchestrator
         }, cancellationToken);
 
         _logger.LogInformation(
-            "Erasure completed: RequestId={RequestId}, Nodes={Nodes}, Edges={Edges}, " +
-            "FeedbackWeights={FeedbackWeights}, Embeddings={Embeddings}",
-            requestId, receipt.NodesDeleted, receipt.EdgesDeleted,
-            receipt.FeedbackWeightsDeleted, embeddingsDeleted);
+            "Erasure completed: RequestId={RequestId}, Completeness={Completeness}, Nodes={Nodes}, " +
+            "Edges={Edges}, FeedbackWeights={FeedbackWeights}, VectorDocs={VectorDocs}, " +
+            "Bm25Docs={Bm25Docs}, CrossSessionMemories={CrossSessionMemories}{Reason}",
+            requestId, completeness, receipt.NodesDeleted, receipt.EdgesDeleted,
+            receipt.FeedbackWeightsDeleted, vectorDocsDeleted, bm25DocsDeleted, crossSessionDeleted,
+            completenessReason is null ? string.Empty : $", Reason={completenessReason}");
 
         return receipt;
+    }
+
+    /// <summary>
+    /// Derives the document id from a chunk id. Chunk ids are
+    /// <c>"{documentId}_chunk_{i}"</c> or <c>"{documentId}_raptor_L{l}_C{c}"</c>; the document id
+    /// is the prefix before the rightmost marker. Because a document id may itself contain
+    /// underscores (or even a literal <c>"_chunk_"</c>), the split is on the <em>last</em>
+    /// occurrence of either marker, whichever sits further right. A chunk id with no marker
+    /// (unexpected for corpus content) is returned unchanged — a delete-by that id is a harmless
+    /// no-op if no such document exists.
+    /// </summary>
+    private static string DeriveDocumentId(string chunkId)
+    {
+        var chunkMarker = chunkId.LastIndexOf("_chunk_", StringComparison.Ordinal);
+        var raptorMarker = chunkId.LastIndexOf("_raptor_", StringComparison.Ordinal);
+        var cut = Math.Max(chunkMarker, raptorMarker);
+        return cut > 0 ? chunkId[..cut] : chunkId;
     }
 }

--- a/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/Compliance/RetentionEnforcementService.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/Compliance/RetentionEnforcementService.cs
@@ -82,16 +82,19 @@ public sealed class RetentionEnforcementService : BackgroundService
     {
         var allNodes = await _graphStore.GetAllNodesAsync(cancellationToken);
 
-        var expiredIds = allNodes
+        var expiredNodes = allNodes
             .Where(n => n.ExpiresAt.HasValue && n.ExpiresAt.Value < now)
-            .Select(n => n.Id)
             .ToList();
 
-        if (expiredIds.Count > 0)
+        if (expiredNodes.Count > 0)
         {
             await using var scope = _scopeFactory.CreateAsyncScope();
             var erasureOrchestrator = scope.ServiceProvider.GetRequiredService<IErasureOrchestrator>();
-            var receipt = await erasureOrchestrator.EraseByNodeIdsAsync(expiredIds, cancellationToken);
+            // Pass the node instances we already scanned — NOT their ids. The erasure orchestrator
+            // otherwise re-fetches each node through the compliance-aware store, which returns null
+            // for expired nodes, dropping their ChunkIds and silently skipping the derived-content
+            // (vector/BM25) purge.
+            var receipt = await erasureOrchestrator.EraseByNodesAsync(expiredNodes, cancellationToken);
             _logger.LogInformation(
                 "Retention enforcement: purged {Nodes} expired nodes",
                 receipt.NodesDeleted);

--- a/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/DependencyInjection.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/DependencyInjection.cs
@@ -222,7 +222,9 @@ public static class DependencyInjection
             new ConfigRetentionPolicyProvider(
                 sp.GetRequiredService<IOptionsMonitor<AppConfig>>()));
 
-        // Erasure orchestrator
+        // Erasure orchestrator. Vector, BM25, and cross-session memory stores are optional:
+        // when a subsystem is not deployed the corresponding store is absent and there is
+        // nothing to purge there. When present, the orchestrator cascades erasure into it.
         services.AddScoped<IErasureOrchestrator>(sp =>
             new DefaultErasureOrchestrator(
                 sp.GetRequiredService<IKnowledgeGraphStore>(),
@@ -230,7 +232,9 @@ public static class DependencyInjection
                 sp.GetService<IVectorStore>(),
                 sp.GetRequiredService<IMemoryAuditSink>(),
                 sp.GetService<TimeProvider>() ?? TimeProvider.System,
-                sp.GetRequiredService<ILogger<DefaultErasureOrchestrator>>()));
+                sp.GetRequiredService<ILogger<DefaultErasureOrchestrator>>(),
+                sp.GetService<IBm25Store>(),
+                sp.GetService<ICrossSessionMemoryStore>()));
 
         // Retention enforcement background service
         if (appConfig.AI.Rag.GraphRag.ComplianceEnabled &&

--- a/src/Content/Infrastructure/Infrastructure.AI.RAG/GraphRag/CrossSessionMemoryStore.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.RAG/GraphRag/CrossSessionMemoryStore.cs
@@ -2,6 +2,7 @@ using System.Collections.Concurrent;
 using System.Diagnostics;
 using Application.AI.Common.Interfaces.KnowledgeGraph;
 using Domain.AI.KnowledgeGraph.Models;
+using Domain.AI.KnowledgeGraph.Scoping;
 using Domain.Common.Config;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -35,6 +36,13 @@ public sealed class CrossSessionMemoryStore : ICrossSessionMemoryStore, IDisposa
 {
     private static readonly ActivitySource _activitySource =
         new("Infrastructure.AI.RAG.GraphRag");
+
+    /// <summary>
+    /// Graph node type used when a memory record is synced to the backend. Owner-scoped purge
+    /// filters on this so a right-to-erasure over the shared backend only removes memory nodes,
+    /// never corpus or other subsystems' owned nodes.
+    /// </summary>
+    private const string MemoryNodeType = "Memory";
 
     private readonly IGraphDatabaseBackend _graphBackend;
     private readonly IOptionsMonitor<AppConfig> _configMonitor;
@@ -74,8 +82,11 @@ public sealed class CrossSessionMemoryStore : ICrossSessionMemoryStore, IDisposa
         using var activity = _activitySource.StartActivity("CrossSessionMemory.Remember");
         activity?.SetTag("memory.id", memory.Id);
 
-        _cache.AddOrUpdate(memory.Id, memory, (_, _) => memory);
-        _dirty[memory.Id] = true;
+        // Canonicalize the owner on write so owner-scoped recall and right-to-erasure purge
+        // match regardless of casing (mirrors ComplianceAwareGraphStore's owner stamping).
+        var canonical = memory with { OwnerId = ScopeIdentity.Canonicalize(memory.OwnerId) };
+        _cache.AddOrUpdate(canonical.Id, canonical, (_, _) => canonical);
+        _dirty[canonical.Id] = true;
 
         PruneToCapacity();
 
@@ -131,6 +142,54 @@ public sealed class CrossSessionMemoryStore : ICrossSessionMemoryStore, IDisposa
         _dirty.TryRemove(memoryId, out _);
 
         await _graphBackend.DeleteNodeAsync(memoryId, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc/>
+    public async Task<int> PurgeByOwnerAsync(string ownerId, CancellationToken cancellationToken = default)
+    {
+        using var activity = _activitySource.StartActivity("CrossSessionMemory.PurgeByOwner");
+
+        var canonical = ScopeIdentity.Canonicalize(ownerId);
+        if (canonical is null)
+            return 0;
+
+        activity?.SetTag("memory.owner", canonical);
+
+        // 1. Purge the in-memory cache (authoritative for records not yet synced or already
+        //    loaded this session). Compare canonically — cached owners are canonicalized on write.
+        var cacheVictims = _cache.Values
+            .Where(r => ScopeIdentity.AreSame(r.OwnerId, canonical))
+            .Select(r => r.Id)
+            .ToList();
+        foreach (var id in cacheVictims)
+        {
+            _cache.TryRemove(id, out _);
+            _dirty.TryRemove(id, out _);
+        }
+
+        // 2. Purge the durable backend. The backend is shared with other subsystems (corpus,
+        //    episodic segments), so restrict deletion to memory nodes owned by this owner —
+        //    never another subsystem's owned nodes.
+        var ownedNodes = await _graphBackend
+            .GetNodesByOwnerAsync(canonical, cancellationToken)
+            .ConfigureAwait(false);
+        var backendMemoryIds = ownedNodes
+            .Where(n => string.Equals(n.Type, MemoryNodeType, StringComparison.Ordinal))
+            .Select(n => n.Id)
+            .ToList();
+        if (backendMemoryIds.Count > 0)
+            await _graphBackend.DeleteNodesAsync(backendMemoryIds, cancellationToken).ConfigureAwait(false);
+
+        var purged = cacheVictims
+            .Concat(backendMemoryIds)
+            .Distinct(StringComparer.Ordinal)
+            .Count();
+
+        _logger.LogInformation(
+            "CrossSessionMemoryStore: purged {Count} memory records for owner {Owner}",
+            purged, canonical);
+
+        return purged;
     }
 
     /// <inheritdoc/>
@@ -191,7 +250,10 @@ public sealed class CrossSessionMemoryStore : ICrossSessionMemoryStore, IDisposa
             {
                 Id = record.Id,
                 Name = record.Id,
-                Type = "Memory",
+                Type = MemoryNodeType,
+                // Persist the owner so the durable backend row can be found by an owner-scoped
+                // right-to-erasure purge even after the cache entry is evicted.
+                OwnerId = record.OwnerId,
                 Properties = new Dictionary<string, string>
                 {
                     ["content"] = record.Content,

--- a/src/Content/Tests/Infrastructure.AI.KnowledgeGraph.Tests/Compliance/DefaultErasureOrchestratorTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.KnowledgeGraph.Tests/Compliance/DefaultErasureOrchestratorTests.cs
@@ -192,4 +192,172 @@ public sealed class DefaultErasureOrchestratorTests
         _graphStore.Verify(g => g.DeleteEdgesByOwnerAsync(
             It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
     }
+
+    // ------------------------------------------------------------------
+    // Gap 3 — vector deletion must use the documentId, not the chunkId
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public async Task EraseByOwner_DeletesVectorsByDocumentId_NotChunkId()
+    {
+        // Chunk IDs are "{documentId}_chunk_{i}" / "{documentId}_raptor_*"; IVectorStore.DeleteAsync
+        // deletes by documentId. Passing a chunkId matches nothing, so the embeddings survive.
+        _graphStore.Setup(g => g.GetNodesByOwnerAsync("user-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([
+                new GraphNode
+                {
+                    Id = "n1", Name = "T", Type = "Fact", OwnerId = "user-1",
+                    ChunkIds = ["docA_chunk_0", "docA_chunk_1", "docA_raptor_L0_C0"]
+                }
+            ]);
+
+        var receipt = await _orchestrator.EraseByOwnerAsync("user-1");
+
+        // All three chunk IDs derive to the single document "docA" — deleted once.
+        _vectorStore.Verify(v => v.DeleteAsync("docA", It.IsAny<string?>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+        _vectorStore.Verify(v => v.DeleteAsync(
+            It.Is<string>(id => id.Contains("_chunk_") || id.Contains("_raptor_")),
+            It.IsAny<string?>(), It.IsAny<CancellationToken>()), Times.Never);
+        receipt.VectorEmbeddingsDeleted.Should().Be(1, "one distinct document's embeddings were submitted");
+    }
+
+    // ------------------------------------------------------------------
+    // Gap 2 — BM25 (and RAPTOR) content must be purged by documentId
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public async Task EraseByOwner_DeletesBm25ByDocumentId()
+    {
+        var bm25 = new Mock<IBm25Store>();
+        var orchestrator = OrchestratorWith(bm25: bm25.Object);
+
+        _graphStore.Setup(g => g.GetNodesByOwnerAsync("user-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([
+                new GraphNode
+                {
+                    Id = "n1", Name = "T", Type = "Fact", OwnerId = "user-1",
+                    ChunkIds = ["docA_chunk_0", "docA_raptor_L1_C2"]
+                }
+            ]);
+
+        var receipt = await orchestrator.EraseByOwnerAsync("user-1");
+
+        bm25.Verify(b => b.DeleteAsync("docA", It.IsAny<string?>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+        receipt.Bm25DocumentsDeleted.Should().Be(1);
+    }
+
+    // ------------------------------------------------------------------
+    // Gap 1 — cross-session memory must be purged on owner erasure
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public async Task EraseByOwner_PurgesCrossSessionMemory()
+    {
+        var memory = new Mock<ICrossSessionMemoryStore>();
+        memory.Setup(m => m.PurgeByOwnerAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(3);
+        var orchestrator = OrchestratorWith(crossSession: memory.Object);
+
+        _graphStore.Setup(g => g.GetNodesByOwnerAsync("user-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([new GraphNode { Id = "n1", Name = "T", Type = "Fact", OwnerId = "user-1" }]);
+
+        var receipt = await orchestrator.EraseByOwnerAsync("user-1");
+
+        memory.Verify(m => m.PurgeByOwnerAsync("user-1", It.IsAny<CancellationToken>()), Times.Once);
+        receipt.CrossSessionMemoriesDeleted.Should().Be(3);
+    }
+
+    [Fact]
+    public async Task EraseByNodeIds_DoesNotPurgeCrossSessionMemory()
+    {
+        var memory = new Mock<ICrossSessionMemoryStore>();
+        var orchestrator = OrchestratorWith(crossSession: memory.Object);
+        _graphStore.Setup(g => g.GetNodeAsync("n1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new GraphNode { Id = "n1", Name = "T", Type = "Fact", OwnerId = "user-1" });
+
+        await orchestrator.EraseByNodeIdsAsync(["n1"]);
+
+        // Memory is owner-scoped; a node-scoped erasure must not touch it.
+        memory.Verify(m => m.PurgeByOwnerAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    // ------------------------------------------------------------------
+    // Gap 5 — degraded scope must NOT report a clean-success receipt
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public async Task EraseByOwner_ResolvedOwner_ReceiptIsFull()
+    {
+        _graphStore.Setup(g => g.GetNodesByOwnerAsync("user-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([new GraphNode { Id = "n1", Name = "T", Type = "Fact", OwnerId = "user-1" }]);
+
+        var receipt = await _orchestrator.EraseByOwnerAsync("user-1");
+
+        receipt.Completeness.Should().Be(ErasureCompleteness.Full);
+        receipt.CompletenessReason.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task EraseByOwner_DifferentlyCasedOwner_CanonicalizesEverySweep_ReportsFull()
+    {
+        var memory = new Mock<ICrossSessionMemoryStore>();
+        memory.Setup(m => m.PurgeByOwnerAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+        var orchestrator = OrchestratorWith(crossSession: memory.Object);
+
+        // The subject's data is stored under the canonical (lowercase) owner; the erasure request
+        // arrives with different casing. Every owner-scoped sweep must canonicalize, or graph
+        // nodes/edges survive while the receipt dishonestly reports Full.
+        _graphStore.Setup(g => g.GetNodesByOwnerAsync("user-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([new GraphNode { Id = "n1", Name = "T", Type = "Fact", OwnerId = "user-1" }]);
+
+        var receipt = await orchestrator.EraseByOwnerAsync("User-1");
+
+        _graphStore.Verify(g => g.GetNodesByOwnerAsync("user-1", It.IsAny<CancellationToken>()), Times.Once);
+        _graphStore.Verify(g => g.GetNodesByOwnerAsync("User-1", It.IsAny<CancellationToken>()), Times.Never);
+        _graphStore.Verify(g => g.DeleteEdgesByOwnerAsync("user-1", It.IsAny<CancellationToken>()), Times.Once);
+        memory.Verify(m => m.PurgeByOwnerAsync("user-1", It.IsAny<CancellationToken>()), Times.Once);
+        receipt.NodesDeleted.Should().Be(1, "the node stored under the canonical owner must be erased");
+        receipt.CrossSessionMemoriesDeleted.Should().Be(1);
+        receipt.ScopeId.Should().Be("user-1", "the receipt scope is the canonical owner");
+        receipt.Completeness.Should().Be(ErasureCompleteness.Full);
+    }
+
+    [Fact]
+    public async Task EraseByOwner_UnresolvableOwner_ReceiptIsPartial()
+    {
+        var memory = new Mock<ICrossSessionMemoryStore>();
+        var orchestrator = OrchestratorWith(crossSession: memory.Object);
+
+        // Whitespace owner canonicalizes to null: EVERY owner-scoped sweep is skipped uniformly.
+        var receipt = await orchestrator.EraseByOwnerAsync("   ");
+
+        receipt.Completeness.Should().Be(ErasureCompleteness.Partial,
+            "an owner erasure that could not resolve its owner must not present as a clean success");
+        receipt.CompletenessReason.Should().NotBeNullOrEmpty();
+        receipt.CrossSessionMemoriesDeleted.Should().Be(0);
+        // No owner-scoped store call may run with a degraded (null) owner — proving the reason is honest.
+        _graphStore.Verify(g => g.GetNodesByOwnerAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _graphStore.Verify(g => g.DeleteEdgesByOwnerAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        memory.Verify(m => m.PurgeByOwnerAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    private DefaultErasureOrchestrator OrchestratorWith(
+        IBm25Store? bm25 = null,
+        ICrossSessionMemoryStore? crossSession = null) =>
+        new(
+            _graphStore.Object,
+            _feedbackStore.Object,
+            _vectorStore.Object,
+            _auditSink.Object,
+            TimeProvider.System,
+            Mock.Of<ILogger<DefaultErasureOrchestrator>>(),
+            bm25,
+            crossSession);
 }

--- a/src/Content/Tests/Infrastructure.AI.KnowledgeGraph.Tests/Compliance/ErasureCompletenessTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.KnowledgeGraph.Tests/Compliance/ErasureCompletenessTests.cs
@@ -1,5 +1,6 @@
 using Application.AI.Common.Interfaces;
 using Application.AI.Common.Interfaces.KnowledgeGraph;
+using Application.AI.Common.Interfaces.RAG;
 using Domain.AI.KnowledgeGraph;
 using Domain.AI.KnowledgeGraph.Models;
 using FluentAssertions;
@@ -235,5 +236,72 @@ public sealed class ErasureCompletenessTests
 
         var weight = await _feedbackStore.GetEdgeWeightAsync("e-owned-by-u1");
         weight.UpdateCount.Should().Be(0);
+    }
+
+    // ------------------------------------------------------------------
+    // Gap 4 — retention must purge derived content for EXPIRED nodes even
+    // though the compliance-aware store returns null when re-fetching them
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public async Task RetentionEnforcement_PurgesDerivedContentForExpiredNodes_ThroughComplianceStore()
+    {
+        // Seed an EXPIRED node carrying derived chunk IDs directly into the inner store, so we
+        // control ExpiresAt (bypassing the decorator's retention stamping).
+        await _graphStore.AddNodesAsync([new GraphNode
+        {
+            Id = "expired-1", Name = "Old", Type = "Fact",
+            CreatedAt = DateTimeOffset.UtcNow.AddDays(-400),
+            ExpiresAt = DateTimeOffset.UtcNow.AddDays(-1),
+            ChunkIds = ["docExpired_chunk_0", "docExpired_raptor_L0_C0"]
+        }]);
+
+        // Live decorated store: ComplianceAwareGraphStore.GetNodeAsync returns null for an expired
+        // node, so an id-based re-fetch would drop its ChunkIds and skip the vector purge.
+        var scope = Mock.Of<IKnowledgeScope>(s => s.UserId == null && s.TenantId == null);
+        var services = new ServiceCollection();
+        services.AddSingleton(scope);
+        var ambient = Mock.Of<IAmbientRequestScope>(a => a.Current == services.BuildServiceProvider());
+
+        var retention = new Mock<IRetentionPolicyProvider>();
+        retention.Setup(r => r.GetPolicy(It.IsAny<string>()))
+            .Returns(new RetentionPolicy { EntityType = "Fact", RetentionPeriod = TimeSpan.FromDays(365) });
+
+        var decorated = new ComplianceAwareGraphStore(
+            _graphStore, Mock.Of<IMemoryAuditSink>(), ambient, retention.Object,
+            TimeProvider.System, NullLogger<ComplianceAwareGraphStore>.Instance);
+
+        var vectorStore = new Mock<IVectorStore>();
+        var bm25Store = new Mock<IBm25Store>();
+
+        var orchestrator = new DefaultErasureOrchestrator(
+            decorated, _feedbackStore, vectorStore.Object, Mock.Of<IMemoryAuditSink>(),
+            TimeProvider.System, NullLogger<DefaultErasureOrchestrator>.Instance,
+            bm25Store.Object);
+
+        var service = new RetentionEnforcementService(
+            decorated, ScopeFactoryFor(orchestrator),
+            NullLogger<RetentionEnforcementService>.Instance);
+
+        await service.EnforceRetentionAsync(DateTimeOffset.UtcNow, CancellationToken.None);
+
+        vectorStore.Verify(
+            v => v.DeleteAsync("docExpired", It.IsAny<string?>(), It.IsAny<CancellationToken>()),
+            Times.Once,
+            "the expired node's derived embeddings must be purged — its chunk IDs must survive to the derived-content sweep");
+        bm25Store.Verify(
+            b => b.DeleteAsync("docExpired", It.IsAny<string?>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    /// <summary>
+    /// Builds a real <see cref="IServiceScopeFactory"/> that resolves the given orchestrator from a
+    /// fresh scope, mirroring how the singleton retention service obtains its scoped dependency.
+    /// </summary>
+    private static IServiceScopeFactory ScopeFactoryFor(IErasureOrchestrator orchestrator)
+    {
+        var services = new ServiceCollection();
+        services.AddScoped(_ => orchestrator);
+        return services.BuildServiceProvider().GetRequiredService<IServiceScopeFactory>();
     }
 }

--- a/src/Content/Tests/Infrastructure.AI.KnowledgeGraph.Tests/Compliance/RetentionEnforcementServiceTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.KnowledgeGraph.Tests/Compliance/RetentionEnforcementServiceTests.cs
@@ -18,7 +18,7 @@ public sealed class RetentionEnforcementServiceTests
         var store = new InMemoryGraphStore(Mock.Of<ILogger<InMemoryGraphStore>>());
         var erasureOrchestrator = new Mock<IErasureOrchestrator>();
         erasureOrchestrator
-            .Setup(e => e.EraseByNodeIdsAsync(It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>()))
+            .Setup(e => e.EraseByNodesAsync(It.IsAny<IReadOnlyList<GraphNode>>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ErasureReceipt
             {
                 RequestId = "test", ScopeId = "system",
@@ -49,8 +49,11 @@ public sealed class RetentionEnforcementServiceTests
 
         await service.EnforceRetentionAsync(now, CancellationToken.None);
 
-        erasureOrchestrator.Verify(e => e.EraseByNodeIdsAsync(
-            It.Is<IReadOnlyList<string>>(ids => ids.Contains("expired") && !ids.Contains("valid")),
+        // Passes the full node instances (not ids) so their ChunkIds survive for the
+        // derived-content purge — see EraseByNodesAsync.
+        erasureOrchestrator.Verify(e => e.EraseByNodesAsync(
+            It.Is<IReadOnlyList<GraphNode>>(ns =>
+                ns.Any(n => n.Id == "expired") && ns.All(n => n.Id != "valid")),
             It.IsAny<CancellationToken>()), Times.Once);
     }
 
@@ -76,7 +79,7 @@ public sealed class RetentionEnforcementServiceTests
         await service.EnforceRetentionAsync(DateTimeOffset.UtcNow, CancellationToken.None);
 
         erasureOrchestrator.Verify(
-            e => e.EraseByNodeIdsAsync(It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>()),
+            e => e.EraseByNodesAsync(It.IsAny<IReadOnlyList<GraphNode>>(), It.IsAny<CancellationToken>()),
             Times.Never);
     }
 

--- a/src/Content/Tests/Infrastructure.AI.RAG.Tests/GraphRag/CrossSessionMemoryStoreTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.RAG.Tests/GraphRag/CrossSessionMemoryStoreTests.cs
@@ -2,6 +2,7 @@ using Application.AI.Common.Interfaces.KnowledgeGraph;
 using Domain.AI.KnowledgeGraph.Models;
 using Domain.Common.Config;
 using Domain.Common.Config.AI.RAG;
+using FluentAssertions;
 using Infrastructure.AI.RAG.GraphRag;
 using Infrastructure.AI.RAG.Tests.Helpers;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -25,6 +26,9 @@ public sealed class CrossSessionMemoryStoreTests : IDisposable
         _backendMock = new Mock<IGraphDatabaseBackend>();
         _backendMock
             .Setup(b => b.GetAllNodesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+        _backendMock
+            .Setup(b => b.GetNodesByOwnerAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync([]);
 
         var appConfig = new AppConfig();
@@ -243,5 +247,102 @@ public sealed class CrossSessionMemoryStoreTests : IDisposable
 
         // Assert — the lowest-weight entry (mem-prune-4 at weight 0.6) was pruned
         Assert.DoesNotContain(results, r => r.Id == "mem-prune-4");
+    }
+
+    // ── PurgeByOwnerAsync (right-to-erasure, gap 1) ───────────────────────────
+
+    private static MemoryRecord OwnedMemory(string id, string content, string? ownerId) => new()
+    {
+        Id = id,
+        Content = content,
+        Source = "session-test",
+        Weight = 0.9,
+        CreatedAt = DateTimeOffset.UtcNow,
+        LastAccessedAt = DateTimeOffset.UtcNow,
+        AccessCount = 0,
+        OwnerId = ownerId
+    };
+
+    [Fact]
+    public async Task PurgeByOwnerAsync_RemovesOwnerMemoriesFromCache_KeepsOthers()
+    {
+        await _sut.RememberAsync(OwnedMemory("mem-u1-a", "erase owner knowledge alpha", "user-1"));
+        await _sut.RememberAsync(OwnedMemory("mem-u1-b", "erase owner knowledge beta", "user-1"));
+        await _sut.RememberAsync(OwnedMemory("mem-u2", "keep owner knowledge", "user-2"));
+
+        var purged = await _sut.PurgeByOwnerAsync("user-1");
+
+        purged.Should().Be(2);
+        var remaining = await _sut.RecallAsync(
+            RagTestData.CreateMemoryQuery(query: "owner knowledge", topK: 10, minWeight: 0.0));
+        Assert.DoesNotContain(remaining, r => r.Id == "mem-u1-a");
+        Assert.DoesNotContain(remaining, r => r.Id == "mem-u1-b");
+        Assert.Contains(remaining, r => r.Id == "mem-u2");
+    }
+
+    [Fact]
+    public async Task PurgeByOwnerAsync_MatchesOwnerCaseInsensitively()
+    {
+        // Owner is canonicalized (invariant-lowercase) on write; a differently-cased purge must match.
+        await _sut.RememberAsync(OwnedMemory("mem-cased", "cased owner knowledge", "User-1"));
+
+        var purged = await _sut.PurgeByOwnerAsync("USER-1");
+
+        purged.Should().Be(1);
+        var remaining = await _sut.RecallAsync(
+            RagTestData.CreateMemoryQuery(query: "cased owner", topK: 10, minWeight: 0.0));
+        Assert.DoesNotContain(remaining, r => r.Id == "mem-cased");
+    }
+
+    [Fact]
+    public async Task PurgeByOwnerAsync_DeletesOnlyMemoryTypeNodesFromBackend()
+    {
+        // The durable backend is shared with other subsystems: only Memory-typed owned nodes may
+        // be deleted by a cross-session-memory purge.
+        _backendMock
+            .Setup(b => b.GetNodesByOwnerAsync("user-9", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([
+                new GraphNode { Id = "mem-backend", Name = "m", Type = "Memory", OwnerId = "user-9" },
+                new GraphNode { Id = "corpus-backend", Name = "c", Type = "Entity", OwnerId = "user-9" }
+            ]);
+
+        await _sut.PurgeByOwnerAsync("user-9");
+
+        _backendMock.Verify(b => b.DeleteNodesAsync(
+            It.Is<IReadOnlyList<string>>(ids => ids.Count == 1 && ids.Contains("mem-backend")),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task PurgeByOwnerAsync_WhitespaceOwner_PurgesNothing()
+    {
+        await _sut.RememberAsync(OwnedMemory("mem-x", "whitespace owner knowledge", "user-1"));
+
+        var purged = await _sut.PurgeByOwnerAsync("   ");
+
+        purged.Should().Be(0);
+        _backendMock.Verify(b => b.GetNodesByOwnerAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _backendMock.Verify(b => b.DeleteNodesAsync(It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task SyncToBackendAsync_PersistsCanonicalOwnerIdOnMemoryNode()
+    {
+        // The owner must be written to the durable node so an owner-scoped purge can find it after
+        // the cache entry is evicted; it must be canonicalized to match at purge time.
+        IReadOnlyList<GraphNode>? synced = null;
+        _backendMock
+            .Setup(b => b.AddNodesAsync(It.IsAny<IReadOnlyList<GraphNode>>(), It.IsAny<CancellationToken>()))
+            .Callback<IReadOnlyList<GraphNode>, CancellationToken>((ns, _) => synced = ns)
+            .Returns(Task.CompletedTask);
+
+        await _sut.RememberAsync(OwnedMemory("mem-sync", "sync owner knowledge", "User-1"));
+        await _sut.SyncToBackendAsync();
+
+        synced.Should().NotBeNull();
+        var node = synced!.Single(n => n.Id == "mem-sync");
+        node.OwnerId.Should().Be("user-1", "the synced node carries the canonicalized owner");
     }
 }

--- a/src/Content/Tests/Infrastructure.AI.RAG.Tests/Helpers/RagTestData.cs
+++ b/src/Content/Tests/Infrastructure.AI.RAG.Tests/Helpers/RagTestData.cs
@@ -297,14 +297,16 @@ internal static class RagTestData
         string content = "The user prefers concise answers over verbose explanations.",
         string source = "session-abc", double weight = 0.8,
         DateTimeOffset? createdAt = null, DateTimeOffset? lastAccessedAt = null,
-        int accessCount = 1, IReadOnlyDictionary<string, string>? metadata = null) =>
+        int accessCount = 1, IReadOnlyDictionary<string, string>? metadata = null,
+        string? ownerId = null) =>
         new()
         {
             Id = id, Content = content, Source = source, Weight = weight,
             CreatedAt = createdAt ?? DateTimeOffset.UtcNow,
             LastAccessedAt = lastAccessedAt ?? DateTimeOffset.UtcNow,
             AccessCount = accessCount,
-            Metadata = metadata ?? new Dictionary<string, string>()
+            Metadata = metadata ?? new Dictionary<string, string>(),
+            OwnerId = ownerId
         };
 
     public static MemoryQuery CreateMemoryQuery(


### PR DESCRIPTION
D3 erasure pass — Lane 3 (the compliance-critical core). One coherent change to `DefaultErasureOrchestrator` fixing five verified right-to-erasure gaps so a subject's data is actually deleted and the receipt tells the truth.

## Gaps fixed
1. **CrossSessionMemory (Kuzu) never purged** — new `ICrossSessionMemoryStore.PurgeByOwnerAsync` (cache + Memory-typed backend nodes) + `MemoryRecord.OwnerId`, called on the owner path.
2. **BM25 / RAPTOR never purged** — inject `IBm25Store`, delete by documentId (RAPTOR summaries drop out via the same document-scoped delete).
3. **Vector delete used the wrong key** — the old code passed a chunkId where the store deletes by documentId, so it matched nothing and vectors survived. `DeriveDocumentId` recovers the documentId; deletes are exact-match (no wrong-document deletion).
4. **Retention collected zero chunk IDs** — expired nodes null out through the compliance decorator's `GetNodeAsync`. New `EraseByNodesAsync` overload lets `RetentionEnforcementService` pass the nodes it already scanned (no re-fetch), so `ChunkIds` survive and derived content is purged.
5. **Scope-degraded partial erase reported success** — `ErasureReceipt.Completeness` (`Full`/`Partial` + reason) is now set honestly.

## Security review (SAFE WITH FIXES → all applied)
The 5 fixes were confirmed correct (incl. adversarial tracing of `DeriveDocumentId` against ids containing `_chunk_`/`_raptor_` — no wrong-document deletion). Applied:
- **MEDIUM-1:** canonicalize the owner **once at `EraseByOwnerAsync` entry** and drive graph, edge, and memory sweeps off that single canonical value (was graph-raw / memory-canonical → a differently-cased owner could leave graph data while the receipt said `Full`).
- **MEDIUM-2:** `MemoryRecord.OwnerId` is now `required` — no writer can silently default it and leave an unerasable-but-`Full` record.
- **LOW-1:** completeness reason text is now accurate (a whitespace owner canonicalizes to null → all sweeps uniformly skipped → `Partial` with a true reason).
- **LOW-2:** `EraseByNodesAsync` XML doc mandates authentic store-sourced nodes.

## Compatibility & safety
- `EraseByOwnerAsync` signature unchanged (Lane 5 depends on it); new ctor deps optional + null-safe; new receipt fields defaulted. A mid-purge store throw propagates as an exception (never a false `Full`); deletes are idempotent.
- Rebased on merged Lane 1 (shared KnowledgeGraph DI): build 0 warnings, `Infrastructure.AI.KnowledgeGraph.Tests` 290 pass (non-Docker) + `Infrastructure.AI.RAG.Tests` 233 pass. Red→green tests for canonical-every-sweep-`Full` and degraded-owner-`Partial`. Docker-backed backend tests run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)