### PR TITLE
chore: remove dead appsettings keys and fix docs describing them

### DIFF
--- a/README.md
+++ b/README.md
@@ -453,7 +453,6 @@ The harness uses a strongly-typed `AppConfig` hierarchy bound through the Option
 {
   "AppConfig": {
     "Agent": {
-      "MaxTurnsPerConversation": 10,
       "DefaultTokenBudget": 128000
     },
     "AI": {
@@ -466,8 +465,6 @@ The harness uses a strongly-typed `AppConfig` hierarchy bound through the Option
       }
     },
     "Observability": {
-      "EnableTracing": true,
-      "EnableMetrics": true,
       "SamplingRatio": 1.0
     }
   }
@@ -564,14 +561,14 @@ The ConsoleUI launches an interactive [Spectre.Console](https://spectreconsole.n
 
 | Section | What it controls |
 |---------|-----------------|
-| `AppConfig.Agent` | Turn limits (`MaxTurnsPerConversation`), token budget (`DefaultTokenBudget`) |
+| `AppConfig.Agent` | Token budget (`DefaultTokenBudget`), request timeout (`DefaultRequestTimeoutSec`) |
 | `AppConfig.AI.AgentFramework` | Model deployment (`DefaultDeployment`), provider (`ClientType`: AzureOpenAI, OpenAI, AIFoundry) |
 | `AppConfig.AI.Skills` | Skill discovery paths (`BasePath`, `AdditionalPaths`) |
 | `AppConfig.AI.AIFoundry` | Persistent agent endpoint (`ProjectEndpoint`) |
 | `AppConfig.AI.A2A` | Agent-to-Agent settings (`Enabled`, `AgentName`, `BaseUrl`, `DiscoveryEndpoints`) |
 | `AppConfig.AI.MCP` | MCP server identity (`ServerName`) |
 | `AppConfig.AI.McpServers` | External MCP server connections (`Servers[]`) |
-| `AppConfig.Observability` | Tracing, metrics, and sampling (`EnableTracing`, `SamplingRatio`) |
+| `AppConfig.Observability` | PII filtering, exporters, budget tracking, sensitive-telemetry gate (`EnableSensitiveTelemetry`). Trace sampling is done collector-side, not in-app (`SamplingRatio` is a collector-tier hint) |
 | `AppConfig.Cache` | Cache backend (`CacheType`: Memory or Redis) |
 | `AppConfig.Logging` | Log output (`LogsBasePath`, `PipeName` for named pipe streaming) |
 | `AppConfig.AI.Rag` | RAG pipeline: `VectorStore` (provider, endpoint, embedding model), `Ingestion` (chunking strategy, overlap), `Reranker` (strategy), `Crag` (thresholds), `GraphRag` (enabled, provider, connection string) |

--- a/documentation/onboarding/02-configuration.html
+++ b/documentation/onboarding/02-configuration.html
@@ -877,14 +877,21 @@
                         </thead>
                         <tbody>
                             <tr>
-                                <td><code>EnableTracing</code> / <code>EnableMetrics</code></td>
-                                <td>Master toggles for the trace and metric pipelines respectively.</td>
+                                <td><code>EnableSensitiveTelemetry</code></td>
+                                <td>
+                                    When <code>true</code>, records sensitive GenAI content (prompt / completion text) in
+                                    traces. Defaults to <code>false</code> — only non-sensitive metadata (model, token
+                                    counts) is captured. Never enable in production without PII filtering and retention
+                                    policies in place. Tracing and metrics pipelines are always on; there are no
+                                    <code>EnableTracing</code> / <code>EnableMetrics</code> toggles.
+                                </td>
                             </tr>
                             <tr>
                                 <td><code>SamplingRatio</code></td>
                                 <td>
-                                    0.0–1.0. Fraction of traces sampled. <code>1.0</code> in dev, much lower
-                                    (0.01–0.1) in production with high traffic.
+                                    0.0–1.0. A collector-tier hint, not an in-app switch — the SDK exports all spans and
+                                    the OpenTelemetry Collector performs tail-based sampling (see
+                                    <a href="10-observability.html">Observability</a>). Left at <code>1.0</code> here.
                                 </td>
                             </tr>
                             <tr>

--- a/src/Content/Presentation/Presentation.ConsoleUI/appsettings.json
+++ b/src/Content/Presentation/Presentation.ConsoleUI/appsettings.json
@@ -9,7 +9,6 @@
       "SuppressConsoleOutput": true
     },
     "Agent": {
-      "MaxTurnsPerConversation": 10,
       "DefaultTokenBudget": 128000
     },
     "Infrastructure": {
@@ -206,8 +205,6 @@
     },
     "Observability": {
       "PostgresConnectionString": "",
-      "EnableTracing": true,
-      "EnableMetrics": true,
       "SamplingRatio": 1.0
     },
     "Cache": {

--- a/src/Content/Presentation/Presentation.EvalRunner/appsettings.json
+++ b/src/Content/Presentation/Presentation.EvalRunner/appsettings.json
@@ -9,7 +9,6 @@
       "SuppressConsoleOutput": true
     },
     "Agent": {
-      "MaxTurnsPerConversation": 10,
       "DefaultTokenBudget": 128000
     },
     "Infrastructure": {
@@ -206,8 +205,6 @@
     },
     "Observability": {
       "PostgresConnectionString": "",
-      "EnableTracing": true,
-      "EnableMetrics": true,
       "SamplingRatio": 1.0
     },
     "Cache": {

--- a/src/Content/Presentation/Presentation.FoundryHost/appsettings.Foundry.json
+++ b/src/Content/Presentation/Presentation.FoundryHost/appsettings.Foundry.json
@@ -12,8 +12,6 @@
       }
     },
     "Observability": {
-      "EnableTracing": true,
-      "EnableMetrics": true,
       "Exporters": {
         "AzureMonitor": {
           "Enabled": true,

--- a/src/Content/Presentation/Presentation.FoundryHost/appsettings.json
+++ b/src/Content/Presentation/Presentation.FoundryHost/appsettings.json
@@ -9,7 +9,6 @@
       "SuppressConsoleOutput": false
     },
     "Agent": {
-      "MaxTurnsPerConversation": 10,
       "DefaultTokenBudget": 128000
     },
     "Infrastructure": {
@@ -134,8 +133,6 @@
       }
     },
     "Observability": {
-      "EnableTracing": true,
-      "EnableMetrics": true,
       "SamplingRatio": 1.0
     },
     "Cache": {


### PR DESCRIPTION
D3/audit follow-up (I1). Removes appsettings keys with zero code readers and corrects the docs that described them as working config. Config + docs only — no source changes.

## Removed (each verified 0 readers)
- `Agent:MaxTurnsPerConversation` — `AgentConfig` has no such property (only `DefaultRequestTimeoutSec`/`DefaultTokenBudget`). Removed from ConsoleUI, EvalRunner, FoundryHost.
- `Observability:EnableTracing` / `Observability:EnableMetrics` — no such properties on `ObservabilityConfig`; the only live `EnableMetrics` is `AI:Governance:EnableMetrics` (different section, untouched). Removed from all 3 base hosts + `appsettings.Foundry.json`.
- `Observability:EnableSensitiveData` — confirmed absent from all appsettings (real property is `EnableSensitiveTelemetry`). Nothing to remove.

## Kept intentionally
- `Observability:SamplingRatio` — no in-app reader, but the POCO remarks document it as intentionally collector-side. Left intact.

## Docs fixed (verified against the config POCOs)
- `README.md` — config block + `AppConfig.Agent`/`AppConfig.Observability` reference rows.
- `documentation/onboarding/02-configuration.html` — Observability table now shows the real `EnableSensitiveTelemetry`; `SamplingRatio` corrected to a collector-tier hint (was falsely described as an in-app switch).

## Verification
- All 4 edited JSON files parse; all 3 hosts build 0 warnings / 0 errors.
- No config-validation test references the removed keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)