### PR TITLE
feat: finish and wire the system-prompt composer (default-off)

### DIFF
--- a/src/Content/Application/Application.AI.Common/Factories/AgentExecutionContextFactory.cs
+++ b/src/Content/Application/Application.AI.Common/Factories/AgentExecutionContextFactory.cs
@@ -1,6 +1,7 @@
 using Application.AI.Common.Helpers;
 using Application.AI.Common.Interfaces;
 using Application.AI.Common.Interfaces.Context;
+using Application.AI.Common.Interfaces.Prompts;
 using Application.AI.Common.Interfaces.Resilience;
 using Application.AI.Common.Interfaces.Skills;
 using Application.AI.Common.Interfaces.Tools;
@@ -95,7 +96,16 @@ public class AgentExecutionContextFactory
         var primarySkill = skills[0];
         var deploymentName = ResolveDeploymentName(primarySkill, options);
         var agentName = options.AgentNameOverride ?? ToAgentName(primarySkill.Name);
-        var instruction = BuildMergedInstruction(skills, options);
+
+        // Static system prompt. The legacy path merges skill instructions + additional context
+        // verbatim (SkillInstructionMerger is the single source of truth for that format). When
+        // PromptComposition is enabled, the authoritative section composer reframes that same skill
+        // content with identity + permission-rules sections within a token budget; per-turn dynamic
+        // context (session state, memory) stays on the AIContextProvider rail, never baked in here.
+        var instruction = SkillInstructionMerger.Merge(skills, options.AdditionalContext);
+        if (_appConfig.CurrentValue.AI?.ContextManagement?.PromptComposition?.Enabled == true)
+            instruction = await ComposeStaticSystemPromptAsync(agentName, instruction);
+
         var mergedToolChain = await _toolChainBuilder.BuildMergedToolsWithSourcesAsync(skills, options, allowedTools);
         var tools = mergedToolChain.Tools.ToList();
         var middlewareTypes = ResolveMiddlewareTypes(primarySkill, options);
@@ -276,29 +286,66 @@ public class AgentExecutionContextFactory
     }
 
     /// <summary>
-    /// Merges instructions from all skills into a single instruction string.
-    /// When multiple skills are present, each skill's instructions are wrapped with a section header.
-    /// A single skill's instructions are used as-is without headers.
+    /// Builds the authoritative static system prompt via the scoped <see cref="ISystemPromptComposer"/>
+    /// when <c>PromptComposition</c> is enabled. Fails open to <paramref name="legacyInstruction"/>
+    /// (never throws): if no request scope is active, the composer/accessor cannot be resolved, or
+    /// composition faults or yields empty, the legacy merged instruction is returned unchanged.
     /// </summary>
-    private static string BuildMergedInstruction(IReadOnlyList<SkillDefinition> skills, SkillAgentOptions options)
+    /// <remarks>
+    /// The factory is a singleton while the composer and its section providers are scoped, so the
+    /// scoped services are resolved per invocation from the current request scope via
+    /// <see cref="IAmbientRequestScope"/> — the same idiom used for the Knowledge/Learnings context
+    /// providers. Only the authoritative static section types
+    /// (<see cref="AuthoritativePromptSections.Default"/>) are composed; per-turn dynamic sections are
+    /// deliberately excluded and remain on the <c>AIContextProvider</c> rail.
+    /// </remarks>
+    private async Task<string> ComposeStaticSystemPromptAsync(string agentName, string legacyInstruction)
     {
-        var parts = new List<string>();
-
-        foreach (var skill in skills)
+        var scope = _serviceProvider.GetService<IAmbientRequestScope>()?.Current;
+        if (scope is null)
         {
-            if (string.IsNullOrEmpty(skill.Instructions))
-                continue;
-
-            if (skills.Count > 1)
-                parts.Add($"## Skill: {skill.Name}\n\n{skill.Instructions}");
-            else
-                parts.Add(skill.Instructions);
+            _logger.LogDebug(
+                "PromptComposition enabled but no ambient request scope is active; using legacy instruction for {AgentName}",
+                agentName);
+            return legacyInstruction;
         }
 
-        if (!string.IsNullOrEmpty(options.AdditionalContext))
-            parts.Add(options.AdditionalContext);
+        var composer = scope.GetService<ISystemPromptComposer>();
+        var accessor = scope.GetService<ISkillInstructionAccessor>();
+        if (composer is null || accessor is null)
+        {
+            _logger.LogDebug(
+                "PromptComposition enabled but composer/accessor unavailable in the request scope; using legacy instruction for {AgentName}",
+                agentName);
+            return legacyInstruction;
+        }
 
-        return string.Join("\n\n", parts);
+        try
+        {
+            // Source the current agent's merged skill instructions into the scoped section provider.
+            accessor.Set(legacyInstruction);
+
+            var budget = _appConfig.CurrentValue.AI?.ContextManagement?.PromptComposition?.TokenBudget ?? 8000;
+            var composed = await composer.ComposeAsync(agentName, budget, AuthoritativePromptSections.Default);
+
+            if (string.IsNullOrEmpty(composed))
+            {
+                _logger.LogDebug(
+                    "PromptComposition produced an empty prompt for {AgentName}; using legacy instruction",
+                    agentName);
+                return legacyInstruction;
+            }
+
+            _logger.LogDebug("Composed authoritative static system prompt for agent {AgentName}", agentName);
+            return composed;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "PromptComposition failed for agent {AgentName}; falling back to legacy instruction",
+                agentName);
+            return legacyInstruction;
+        }
     }
 
     /// <summary>

--- a/src/Content/Application/Application.AI.Common/Helpers/SkillInstructionMerger.cs
+++ b/src/Content/Application/Application.AI.Common/Helpers/SkillInstructionMerger.cs
@@ -1,0 +1,65 @@
+using Domain.AI.Skills;
+
+namespace Application.AI.Common.Helpers;
+
+/// <summary>
+/// Single source of truth for how a set of skill definitions and optional additional context are
+/// merged into the agent's static instruction text.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Both prompt-building paths flow through this helper so their formatting can never drift apart:
+/// </para>
+/// <list type="bullet">
+///   <item><description>
+///     <c>AgentExecutionContextFactory</c> calls it to build the legacy merged instruction (the
+///     default, composer-off path).
+///   </description></item>
+///   <item><description>
+///     The <c>SkillInstructions</c> prompt section (used when the authoritative
+///     <c>ISystemPromptComposer</c> is enabled) surfaces exactly this text as its section content.
+///   </description></item>
+/// </list>
+/// <para>
+/// A single skill's instructions are emitted verbatim. Multiple skills are each wrapped in a
+/// <c>## Skill: {name}</c> header so the model can tell them apart. Additional context, when present,
+/// is appended as a final block. All blocks are joined by a blank line.
+/// </para>
+/// </remarks>
+public static class SkillInstructionMerger
+{
+    /// <summary>
+    /// Merges the instructions from <paramref name="skills"/> and the optional
+    /// <paramref name="additionalContext"/> into a single instruction string.
+    /// </summary>
+    /// <param name="skills">The skills whose instructions are merged, in order.</param>
+    /// <param name="additionalContext">
+    /// Optional extra context appended after all skill instructions; ignored when null or empty.
+    /// </param>
+    /// <returns>
+    /// The merged instruction text, or an empty string when no skill carries instructions and no
+    /// additional context is supplied.
+    /// </returns>
+    public static string Merge(IReadOnlyList<SkillDefinition> skills, string? additionalContext)
+    {
+        ArgumentNullException.ThrowIfNull(skills);
+
+        var parts = new List<string>();
+
+        foreach (var skill in skills)
+        {
+            if (string.IsNullOrEmpty(skill.Instructions))
+                continue;
+
+            if (skills.Count > 1)
+                parts.Add($"## Skill: {skill.Name}\n\n{skill.Instructions}");
+            else
+                parts.Add(skill.Instructions);
+        }
+
+        if (!string.IsNullOrEmpty(additionalContext))
+            parts.Add(additionalContext);
+
+        return string.Join("\n\n", parts);
+    }
+}

--- a/src/Content/Application/Application.AI.Common/Interfaces/Prompts/AuthoritativePromptSections.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Prompts/AuthoritativePromptSections.cs
@@ -1,0 +1,42 @@
+using System.Collections.Frozen;
+using Domain.AI.Prompts;
+
+namespace Application.AI.Common.Interfaces.Prompts;
+
+/// <summary>
+/// Declares which <see cref="SystemPromptSectionType"/> values make up the agent's authoritative
+/// <em>static</em> system prompt when the <c>ISystemPromptComposer</c> path is enabled.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The composer can build any registered section, but only these types are baked into the once-built,
+/// cached static instruction:
+/// </para>
+/// <list type="bullet">
+///   <item><description><see cref="SystemPromptSectionType.AgentIdentity"/> — who the agent is.</description></item>
+///   <item><description><see cref="SystemPromptSectionType.SkillInstructions"/> — the merged skill instructions (the substantive prompt body).</description></item>
+///   <item><description><see cref="SystemPromptSectionType.PermissionRules"/> — active approval/deny constraints.</description></item>
+/// </list>
+/// <para>
+/// <see cref="SystemPromptSectionType.ToolSchemas"/> is deliberately excluded — the SDK already sends
+/// tool schemas via <c>ChatOptions.Tools</c>, so duplicating them in the prompt wastes budget.
+/// <see cref="SystemPromptSectionType.SessionState"/> is deliberately excluded — it is per-turn dynamic
+/// state that must not be frozen into a cached static prompt; that need is served on the per-turn
+/// <c>AIContextProvider</c> rail. Those two providers remain registered as available building blocks;
+/// they simply do not contribute to the authoritative static prompt.
+/// </para>
+/// </remarks>
+public static class AuthoritativePromptSections
+{
+    /// <summary>
+    /// The section types composing the authoritative static system prompt, passed to
+    /// <c>ISystemPromptComposer.ComposeAsync</c> to filter out every non-authoritative section.
+    /// </summary>
+    public static readonly IReadOnlySet<SystemPromptSectionType> Default =
+        new[]
+        {
+            SystemPromptSectionType.AgentIdentity,
+            SystemPromptSectionType.SkillInstructions,
+            SystemPromptSectionType.PermissionRules,
+        }.ToFrozenSet();
+}

--- a/src/Content/Application/Application.AI.Common/Interfaces/Prompts/ISkillInstructionAccessor.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Prompts/ISkillInstructionAccessor.cs
@@ -1,0 +1,35 @@
+namespace Application.AI.Common.Interfaces.Prompts;
+
+/// <summary>
+/// Per-request holder that carries the current agent's merged skill-instruction text from the
+/// singleton <c>AgentExecutionContextFactory</c> into the scoped <c>SkillInstructions</c> prompt
+/// section provider.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The factory is a singleton but the prompt composer and its section providers are scoped. To
+/// source the current agent's skill instructions into the <c>SkillInstructions</c> section, the
+/// factory resolves this accessor from the live request scope (via <c>IAmbientRequestScope</c>),
+/// stamps the merged instruction onto it, then invokes the composer — which reads the same scoped
+/// instance back through the provider. This mirrors how <c>SessionStateSectionProvider</c> sources
+/// its content from the scoped <c>IAgentExecutionContext</c>.
+/// </para>
+/// <para>
+/// Registered scoped in DI. Outside a request scope, or before the factory stamps a value,
+/// <see cref="Instructions"/> is <see langword="null"/> and the section yields no content.
+/// </para>
+/// </remarks>
+public interface ISkillInstructionAccessor
+{
+    /// <summary>
+    /// Gets the merged skill-instruction text for the current request, or <see langword="null"/>
+    /// when nothing has been set for this scope.
+    /// </summary>
+    string? Instructions { get; }
+
+    /// <summary>
+    /// Sets the merged skill-instruction text for the current request scope.
+    /// </summary>
+    /// <param name="instructions">The merged instruction text; may be null or empty.</param>
+    void Set(string? instructions);
+}

--- a/src/Content/Application/Application.AI.Common/Interfaces/Prompts/ISystemPromptComposer.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Prompts/ISystemPromptComposer.cs
@@ -9,17 +9,25 @@ namespace Application.AI.Common.Interfaces.Prompts;
 public interface ISystemPromptComposer
 {
     /// <summary>
-    /// Composes the full system prompt for the specified agent within the given token budget.
+    /// Composes the system prompt for the specified agent within the given token budget.
     /// Sections are resolved from providers, cached when cacheable, sorted by priority,
     /// and concatenated. Low-priority sections are dropped if the budget is exceeded.
     /// </summary>
     /// <param name="agentId">The agent to compose the prompt for.</param>
     /// <param name="tokenBudget">Maximum token budget for the assembled prompt.</param>
+    /// <param name="sectionTypes">
+    /// Optional allowlist of section types to include. When <see langword="null"/> (the default),
+    /// every registered provider contributes. When supplied, only providers whose
+    /// <see cref="IPromptSectionProvider.SectionType"/> is in the set are composed — used to build
+    /// an authoritative <em>static</em> prompt (see
+    /// <see cref="AuthoritativePromptSections.Default"/>) that excludes per-turn dynamic sections.
+    /// </param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The assembled system prompt string.</returns>
     Task<string> ComposeAsync(
         string agentId,
         int tokenBudget,
+        IReadOnlySet<SystemPromptSectionType>? sectionTypes = null,
         CancellationToken cancellationToken = default);
 
     /// <summary>Invalidates all cached sections of the specified type.</summary>

--- a/src/Content/Application/Application.AI.Common/Services/Prompts/SkillInstructionAccessor.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Prompts/SkillInstructionAccessor.cs
@@ -1,0 +1,16 @@
+using Application.AI.Common.Interfaces.Prompts;
+
+namespace Application.AI.Common.Services.Prompts;
+
+/// <summary>
+/// Default scoped implementation of <see cref="ISkillInstructionAccessor"/>. Holds the merged
+/// skill-instruction text for the lifetime of a single request scope.
+/// </summary>
+public sealed class SkillInstructionAccessor : ISkillInstructionAccessor
+{
+    /// <inheritdoc />
+    public string? Instructions { get; private set; }
+
+    /// <inheritdoc />
+    public void Set(string? instructions) => Instructions = instructions;
+}

--- a/src/Content/Application/Application.AI.Common/Services/Prompts/SkillInstructionAccessor.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Prompts/SkillInstructionAccessor.cs
@@ -6,11 +6,21 @@ namespace Application.AI.Common.Services.Prompts;
 /// Default scoped implementation of <see cref="ISkillInstructionAccessor"/>. Holds the merged
 /// skill-instruction text for the lifetime of a single request scope.
 /// </summary>
+/// <remarks>
+/// The value is stored in an <see cref="AsyncLocal{T}"/> rather than a plain field so that two
+/// compositions running concurrently on the <em>same</em> request scope (e.g. a
+/// <c>Task.WhenAll</c> over several <c>MapToAgentContextAsync</c> calls) cannot clobber each
+/// other: each composition's <see cref="Set"/> writes into its own async execution context and is
+/// read back only within that same async flow. Shipped multi-agent paths compose sequentially
+/// today, so this is defense-in-depth against a future parallel path or a consumer's own fan-out.
+/// </remarks>
 public sealed class SkillInstructionAccessor : ISkillInstructionAccessor
 {
-    /// <inheritdoc />
-    public string? Instructions { get; private set; }
+    private readonly AsyncLocal<string?> _instructions = new();
 
     /// <inheritdoc />
-    public void Set(string? instructions) => Instructions = instructions;
+    public string? Instructions => _instructions.Value;
+
+    /// <inheritdoc />
+    public void Set(string? instructions) => _instructions.Value = instructions;
 }

--- a/src/Content/Application/Application.Core/Validation/PromptCompositionConfigValidator.cs
+++ b/src/Content/Application/Application.Core/Validation/PromptCompositionConfigValidator.cs
@@ -1,0 +1,35 @@
+using Domain.Common.Config.AI.ContextManagement;
+using FluentValidation;
+
+namespace Application.Core.Validation;
+
+/// <summary>
+/// Validates <see cref="PromptCompositionConfig"/> — the section-based system-prompt composition
+/// configuration bound from <c>AppConfig:AI:ContextManagement:PromptComposition</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Wired into the options pipeline with <c>ValidateOnStart()</c> in the composition root, so an
+/// invalid section fails the host at boot rather than at first use.
+/// </para>
+/// <para>
+/// Rules are armed only when <see cref="PromptCompositionConfig.Enabled"/> is <see langword="true"/>,
+/// so a default (or omitted) section always passes and hosts that never enable the composer keep
+/// booting on class defaults.
+/// </para>
+/// </remarks>
+public sealed class PromptCompositionConfigValidator : AbstractValidator<PromptCompositionConfig>
+{
+    /// <summary>Initializes a new instance of the <see cref="PromptCompositionConfigValidator"/> class.</summary>
+    public PromptCompositionConfigValidator()
+    {
+        When(x => x.Enabled, () =>
+        {
+            RuleFor(x => x.TokenBudget)
+                .GreaterThan(0)
+                .WithMessage(
+                    "PromptComposition.TokenBudget must be greater than zero when PromptComposition is " +
+                    "enabled — the composer requires a positive budget to assemble sections.");
+        });
+    }
+}

--- a/src/Content/Domain/Domain.AI/Prompts/SystemPromptSection.cs
+++ b/src/Content/Domain/Domain.AI/Prompts/SystemPromptSection.cs
@@ -16,4 +16,14 @@ public sealed record SystemPromptSection(
     int Priority,
     bool IsCacheable,
     int EstimatedTokens,
-    string Content);
+    string Content)
+{
+    /// <summary>
+    /// When <see langword="true"/>, this section is never dropped by the token-budget assembler —
+    /// the budget bounds only the optional sections. Used for the agent's core instructions (skill
+    /// instructions), which must always reach the model even when they alone exceed the soft budget:
+    /// a pathological budget then degrades to the required sections plus whatever optional tail fits,
+    /// never a prompt missing the agent's job description. Defaults to <see langword="false"/>.
+    /// </summary>
+    public bool IsRequired { get; init; }
+}

--- a/src/Content/Domain/Domain.Common/Config/AI/ContextManagement/ContextManagementConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/ContextManagement/ContextManagementConfig.cs
@@ -11,7 +11,8 @@ namespace Domain.Common.Config.AI.ContextManagement;
 /// AppConfig.AI.ContextManagement
 /// ├── Compaction        — Auto-compact triggers, circuit breaker, strategy limits
 /// ├── ToolResultStorage — Disk persistence thresholds for large tool results
-/// └── Budget            — Diminishing returns detection and completion thresholds
+/// ├── Budget            — Diminishing returns detection and completion thresholds
+/// └── PromptComposition — Authoritative section-based static system-prompt builder (off by default)
 /// </code>
 /// </para>
 /// </remarks>
@@ -34,4 +35,12 @@ public class ContextManagementConfig
     /// and completion thresholds.
     /// </summary>
     public BudgetConfig Budget { get; set; } = new();
+
+    /// <summary>
+    /// Gets or sets the prompt-composition configuration controlling whether the authoritative
+    /// section-based composer builds the agent's static system prompt. Off by default — when
+    /// enabled, the identity + skill-instructions + permission-rules sections are assembled within
+    /// a token budget in place of the legacy verbatim merged instruction.
+    /// </summary>
+    public PromptCompositionConfig PromptComposition { get; set; } = new();
 }

--- a/src/Content/Domain/Domain.Common/Config/AI/ContextManagement/PromptCompositionConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/ContextManagement/PromptCompositionConfig.cs
@@ -1,0 +1,47 @@
+namespace Domain.Common.Config.AI.ContextManagement;
+
+/// <summary>
+/// Configuration for section-based system-prompt composition. Bound from
+/// <c>AppConfig:AI:ContextManagement:PromptComposition</c> in appsettings.json.
+/// </summary>
+/// <remarks>
+/// <para>
+/// When <see cref="Enabled"/> is <see langword="false"/> (the default), the agent's static
+/// system prompt is built exactly as it always has been — the merged skill instructions plus
+/// any additional context, joined verbatim (see
+/// <c>Application.AI.Common.Helpers.SkillInstructionMerger</c>). Turning this on switches the
+/// static prompt onto the authoritative <c>ISystemPromptComposer</c> path, which frames the
+/// same skill instructions with an agent-identity section and the active permission-rules
+/// section, and enforces <see cref="TokenBudget"/>.
+/// </para>
+/// <para>
+/// The composer only assembles <em>static</em> sections (identity, skill instructions,
+/// permission rules). Per-turn dynamic context — session state, live budget, retrieved memory
+/// — is deliberately excluded so it is not frozen into the once-built, cached instruction; that
+/// need is served on the per-turn <c>AIContextProvider</c> rail instead.
+/// </para>
+/// </remarks>
+public class PromptCompositionConfig
+{
+    /// <summary>
+    /// Gets or sets a value indicating whether the authoritative <c>ISystemPromptComposer</c>
+    /// builds the agent's static system prompt. When <see langword="false"/> (the default), the
+    /// legacy merged-instruction path is used and behaviour is byte-identical to before this
+    /// feature existed. When <see langword="true"/>, the composer assembles the identity, skill
+    /// instructions, and permission-rules sections within <see cref="TokenBudget"/>.
+    /// </summary>
+    public bool Enabled { get; set; }
+
+    /// <summary>
+    /// Gets or sets the maximum token budget for the composed static system prompt. Sections are
+    /// assembled in priority order and the lowest-priority (highest-numbered) sections are dropped
+    /// when the running total would exceed this budget. Only consulted when <see cref="Enabled"/>
+    /// is <see langword="true"/>; must be greater than zero in that case.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to 8000 tokens — comfortably larger than a typical multi-skill instruction set plus
+    /// identity and permission framing, so the budget never truncates a normal prompt, while still
+    /// bounding a pathological, oversized skill document.
+    /// </remarks>
+    public int TokenBudget { get; set; } = 8000;
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Prompts/MemoizedPromptComposer.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Prompts/MemoizedPromptComposer.cs
@@ -151,7 +151,11 @@ public sealed class MemoizedPromptComposer : ISystemPromptComposer
         foreach (var section in sortedSections)
         {
             var sectionTokens = section.EstimatedTokens;
-            if (runningTokens + sectionTokens > tokenBudget)
+
+            // Required sections (e.g. the agent's core skill instructions) are never dropped — the
+            // budget bounds only the optional sections. They still accrue toward runningTokens so
+            // subsequent optional sections see the real total.
+            if (!section.IsRequired && runningTokens + sectionTokens > tokenBudget)
             {
                 _logger.LogInformation(
                     "Dropping section {SectionName} ({SectionType}) for agent {AgentId}: " +

--- a/src/Content/Infrastructure/Infrastructure.AI/Prompts/MemoizedPromptComposer.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Prompts/MemoizedPromptComposer.cs
@@ -48,12 +48,17 @@ public sealed class MemoizedPromptComposer : ISystemPromptComposer
     public async Task<string> ComposeAsync(
         string agentId,
         int tokenBudget,
+        IReadOnlySet<SystemPromptSectionType>? sectionTypes = null,
         CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrEmpty(agentId);
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(tokenBudget);
 
-        var (cachedSections, providersToCompute) = ResolveCachedSections(agentId);
+        var activeProviders = sectionTypes is null
+            ? _providers
+            : _providers.Where(p => sectionTypes.Contains(p.SectionType)).ToList();
+
+        var (cachedSections, providersToCompute) = ResolveCachedSections(agentId, activeProviders);
 
         var computedSections = await ComputeMissingSectionsAsync(
             agentId, providersToCompute, cancellationToken);
@@ -89,12 +94,13 @@ public sealed class MemoizedPromptComposer : ISystemPromptComposer
     }
 
     private (List<SystemPromptSection> Cached, List<IPromptSectionProvider> ToCompute) ResolveCachedSections(
-        string agentId)
+        string agentId,
+        IReadOnlyList<IPromptSectionProvider> providers)
     {
         var cached = new List<SystemPromptSection>();
         var toCompute = new List<IPromptSectionProvider>();
 
-        foreach (var provider in _providers)
+        foreach (var provider in providers)
         {
             if (_cache.TryGet(agentId, provider.SectionType, out var section) && section is not null)
             {

--- a/src/Content/Infrastructure/Infrastructure.AI/Prompts/PromptCompositionDependencyInjection.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Prompts/PromptCompositionDependencyInjection.cs
@@ -1,4 +1,5 @@
 using Application.AI.Common.Interfaces.Prompts;
+using Application.AI.Common.Services.Prompts;
 using Infrastructure.AI.Prompts.Sections;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -31,7 +32,15 @@ public static class PromptCompositionDependencyInjection
 
         services.AddSingleton<IPromptSectionCache, InMemoryPromptSectionCache>();
         services.AddScoped<ISystemPromptComposer, MemoizedPromptComposer>();
+        // Scoped holder that carries the current request's merged skill instructions from the
+        // singleton AgentExecutionContextFactory into the (scoped) SkillInstructions section.
+        services.AddScoped<ISkillInstructionAccessor, SkillInstructionAccessor>();
         services.AddTransient<IPromptSectionProvider, AgentIdentitySectionProvider>();
+        services.AddTransient<IPromptSectionProvider, SkillInstructionsSectionProvider>();
+        // ToolSchemas and SessionState remain registered as available building blocks. They are
+        // excluded from the AUTHORITATIVE static prompt (AuthoritativePromptSections.Default) — the
+        // SDK already sends tool schemas via ChatOptions.Tools, and session state is per-turn dynamic
+        // context served on the AIContextProvider rail — but stay available for direct/full composition.
         services.AddTransient<IPromptSectionProvider, ToolSchemasSectionProvider>();
         services.AddTransient<IPromptSectionProvider, PermissionRulesSectionProvider>();
         services.AddTransient<IPromptSectionProvider, SessionStateSectionProvider>();

--- a/src/Content/Infrastructure/Infrastructure.AI/Prompts/Sections/SkillInstructionsSectionProvider.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Prompts/Sections/SkillInstructionsSectionProvider.cs
@@ -1,0 +1,67 @@
+using Application.AI.Common.Helpers;
+using Application.AI.Common.Interfaces.Prompts;
+using Domain.AI.Prompts;
+
+namespace Infrastructure.AI.Prompts.Sections;
+
+/// <summary>
+/// Provides the skill-instructions section — the substantive body of the agent's static system
+/// prompt. Its content is the merged skill instructions (plus any additional context) produced by
+/// <see cref="SkillInstructionMerger"/>, sourced from the scoped <see cref="ISkillInstructionAccessor"/>
+/// that <c>AgentExecutionContextFactory</c> stamps before composing.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Priority 20 places this section immediately after agent identity (10) and before permission rules
+/// (40), matching the position of <see cref="SystemPromptSectionType.SkillInstructions"/> in the
+/// section-type ordering.
+/// </para>
+/// <para>
+/// Not cacheable. The content derives from per-request scoped state (the accessor), whereas the
+/// composer's memoization cache is keyed only by <c>agentId</c>. Caching a scope-derived section under
+/// an agent-id-only key is the exact poisoning hazard documented on
+/// <c>AgentIdentitySectionProvider</c> — one request's additional context could bleed into another
+/// request composing for the same agent. Recomputing this section per composition is cheap (a string
+/// join and a token estimate) and composition happens roughly once per conversation, so the section is
+/// intentionally recomputed rather than cached.
+/// </para>
+/// </remarks>
+public sealed class SkillInstructionsSectionProvider : IPromptSectionProvider
+{
+    private readonly ISkillInstructionAccessor _accessor;
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="SkillInstructionsSectionProvider"/>.
+    /// </summary>
+    /// <param name="accessor">The scoped holder carrying the current request's merged skill instructions.</param>
+    public SkillInstructionsSectionProvider(ISkillInstructionAccessor accessor)
+    {
+        ArgumentNullException.ThrowIfNull(accessor);
+        _accessor = accessor;
+    }
+
+    /// <inheritdoc />
+    public SystemPromptSectionType SectionType => SystemPromptSectionType.SkillInstructions;
+
+    /// <inheritdoc />
+    public Task<SystemPromptSection?> GetSectionAsync(
+        string agentId,
+        CancellationToken cancellationToken = default)
+    {
+        var instructions = _accessor.Instructions;
+
+        // No skill instructions stamped for this scope — yield no content.
+        if (string.IsNullOrEmpty(instructions))
+            return Task.FromResult<SystemPromptSection?>(null);
+
+        var section = new SystemPromptSection(
+            Name: "Skill Instructions",
+            Type: SystemPromptSectionType.SkillInstructions,
+            Priority: 20,
+            IsCacheable: false,
+            EstimatedTokens: TokenEstimationHelper.EstimateTokens(instructions),
+            Content: instructions);
+
+        return Task.FromResult<SystemPromptSection?>(section);
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Prompts/Sections/SkillInstructionsSectionProvider.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Prompts/Sections/SkillInstructionsSectionProvider.cs
@@ -60,7 +60,11 @@ public sealed class SkillInstructionsSectionProvider : IPromptSectionProvider
             Priority: 20,
             IsCacheable: false,
             EstimatedTokens: TokenEstimationHelper.EstimateTokens(instructions),
-            Content: instructions);
+            Content: instructions)
+        {
+            // The agent's core job description must never be silently dropped by a too-small budget.
+            IsRequired = true,
+        };
 
         return Task.FromResult<SystemPromptSection?>(section);
     }

--- a/src/Content/Presentation/Presentation.Common/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Content/Presentation/Presentation.Common/Extensions/IServiceCollectionExtensions.cs
@@ -208,6 +208,13 @@ public static class IServiceCollectionExtensions
             .ValidateFluentValidation<ContentCaptureConfig, ContentCaptureConfigValidator>()
             .ValidateOnStart();
 
+        services.AddOptions<Domain.Common.Config.AI.ContextManagement.PromptCompositionConfig>()
+            .Bind(configuration.GetSection("AppConfig:AI:ContextManagement:PromptComposition"))
+            .ValidateFluentValidation<
+                Domain.Common.Config.AI.ContextManagement.PromptCompositionConfig,
+                PromptCompositionConfigValidator>()
+            .ValidateOnStart();
+
         return services;
     }
 

--- a/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentExecutionContextFactoryPromptComposerTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentExecutionContextFactoryPromptComposerTests.cs
@@ -110,23 +110,65 @@ public sealed class AgentExecutionContextFactoryPromptComposerTests
     // --- OFF: byte-identical to the legacy merged instruction ---
 
     [Fact]
-    public async Task MapToAgentContext_PromptCompositionDisabled_InstructionIsByteIdenticalToLegacyMerge()
+    public async Task MapToAgentContext_PromptCompositionDisabled_InstructionMatchesExactLegacyFormat()
     {
         await using var root = BuildCompositionProvider();
         var factory = CreateFactory(Config(promptCompositionEnabled: false), root);
         var skills = new List<SkillDefinition>
         {
-            Skill("research", "Search sources."),
-            Skill("present", "Make slides."),
+            Skill("Research", "Search sources."),
+            Skill("Present", "Make slides."),
         };
         var options = new SkillAgentOptions { AdditionalContext = "Extra context." };
 
         var context = await factory.MapToAgentContextAsync(skills, options);
 
-        var legacy = SkillInstructionMerger.Merge(skills, options.AdditionalContext);
-        context.Instruction.Should().Be(legacy);
+        // Hardcoded expected format (multi-skill => "## Skill: {name}\n\n{instructions}" wrapping,
+        // AdditionalContext appended, blocks joined by a blank line). Pinned literally so a future
+        // change to the merge format is caught, not silently mirrored.
+        const string expected =
+            "## Skill: Research\n\nSearch sources.\n\n" +
+            "## Skill: Present\n\nMake slides.\n\n" +
+            "Extra context.";
+        context.Instruction.Should().Be(expected);
         // The legacy path must NOT carry the composer's identity framing.
         context.Instruction.Should().NotContain("You are ");
+    }
+
+    [Fact]
+    public async Task MapToAgentContext_SingleSkill_DisabledInstructionIsVerbatim()
+    {
+        await using var root = BuildCompositionProvider();
+        var factory = CreateFactory(Config(promptCompositionEnabled: false), root);
+
+        var context = await factory.MapToAgentContextAsync(
+            Skill("Research", "Search sources."), new SkillAgentOptions());
+
+        // Single skill, no additional context => instructions used verbatim, no header.
+        context.Instruction.Should().Be("Search sources.");
+    }
+
+    // --- Budget MUST NOT silently drop the core skill instructions (ON path) ---
+
+    [Fact]
+    public async Task MapToAgentContext_EnabledWithTinyBudget_StillContainsSkillInstructions()
+    {
+        // A pathologically small budget (1 token) cannot fit the skill body. The composer must
+        // degrade to a prompt that STILL contains the skill instructions — never one without them.
+        await using var root = BuildCompositionProvider();
+        var factory = CreateFactory(Config(promptCompositionEnabled: true, tokenBudget: 1), root);
+        var longBody = string.Join(" ", Enumerable.Repeat("SYNTHESIZE-SOURCES-CAREFULLY", 40));
+        var skill = Skill("research", longBody);
+
+        var ambient = root.GetRequiredService<IAmbientRequestScope>();
+        using var scope = root.CreateScope();
+        using (ambient.BeginScope(scope.ServiceProvider))
+        {
+            var context = await factory.MapToAgentContextAsync(skill, new SkillAgentOptions());
+
+            context.Instruction.Should().Contain(longBody,
+                "the agent's core job description must survive even a too-small token budget");
+        }
     }
 
     [Fact]

--- a/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentExecutionContextFactoryPromptComposerTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentExecutionContextFactoryPromptComposerTests.cs
@@ -1,0 +1,187 @@
+using Application.AI.Common.Factories;
+using Application.AI.Common.Helpers;
+using Application.AI.Common.Interfaces;
+using Application.AI.Common.Interfaces.Agent;
+using Application.AI.Common.Interfaces.Context;
+using Application.AI.Common.Services;
+using Application.AI.Common.Services.Agent;
+using Application.AI.Common.Services.Skills;
+using Application.AI.Common.Services.Tools;
+using Domain.AI.Skills;
+using Domain.Common.Config;
+using Domain.Common.Config.AI;
+using Domain.Common.Config.AI.ContextManagement;
+using FluentAssertions;
+using Infrastructure.AI.Prompts;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Application.AI.Common.Tests.Factories;
+
+/// <summary>
+/// Tests for wiring the authoritative <c>ISystemPromptComposer</c> onto the live agent-context
+/// build path in <see cref="AgentExecutionContextFactory"/>, behind the default-off
+/// <c>PromptComposition</c> flag. Covers: the ON path composing skill instructions into the static
+/// prompt, the OFF path staying byte-identical to the legacy merged instruction, budget bounding
+/// (via the composer), and fail-open when the composer cannot be resolved.
+/// </summary>
+public sealed class AgentExecutionContextFactoryPromptComposerTests
+{
+    private static IOptionsMonitor<AppConfig> Config(bool promptCompositionEnabled, int tokenBudget = 8000)
+    {
+        var appConfig = new AppConfig
+        {
+            AI = new AIConfig
+            {
+                AgentFramework = new AgentFrameworkConfig
+                {
+                    ClientType = AIAgentFrameworkClientType.AzureOpenAI,
+                    DefaultDeployment = "default-model",
+                    ApiKey = "test-key",
+                    Endpoint = "https://test.example.com",
+                },
+                ContextManagement = new ContextManagementConfig
+                {
+                    PromptComposition = new PromptCompositionConfig
+                    {
+                        Enabled = promptCompositionEnabled,
+                        TokenBudget = tokenBudget,
+                    },
+                },
+            },
+        };
+        return Mock.Of<IOptionsMonitor<AppConfig>>(m => m.CurrentValue == appConfig);
+    }
+
+    private static AgentExecutionContextFactory CreateFactory(
+        IOptionsMonitor<AppConfig> config,
+        IServiceProvider serviceProvider) =>
+        new(
+            NullLogger<AgentExecutionContextFactory>.Instance,
+            config,
+            serviceProvider,
+            NullLoggerFactory.Instance,
+            new ToolChainBuilder(NullLogger<ToolChainBuilder>.Instance, serviceProvider),
+            new SkillPrerequisiteResolver());
+
+    /// <summary>
+    /// Builds a root provider containing the full prompt-composition graph plus the ambient request
+    /// scope bridge, exactly as the composition root wires them.
+    /// </summary>
+    private static ServiceProvider BuildCompositionProvider()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddScoped<IAgentExecutionContext, AgentExecutionContext>();
+        services.AddSingleton(Mock.Of<IContextBudgetTracker>());
+        services.AddSingleton<IAmbientRequestScope, AmbientRequestScope>();
+        services.AddSystemPromptComposition();
+        return services.BuildServiceProvider(new ServiceProviderOptions { ValidateScopes = true });
+    }
+
+    private static SkillDefinition Skill(string name, string instructions) =>
+        new() { Id = name, Name = name, Instructions = instructions };
+
+    // --- ON: the composer becomes authoritative and includes the skill instructions ---
+
+    [Fact]
+    public async Task MapToAgentContext_PromptCompositionEnabled_ComposedPromptContainsSkillInstructions()
+    {
+        await using var root = BuildCompositionProvider();
+        var factory = CreateFactory(Config(promptCompositionEnabled: true), root);
+        var skill = Skill("research", "SEARCH AND SYNTHESIZE SOURCES.");
+
+        var ambient = root.GetRequiredService<IAmbientRequestScope>();
+        using var scope = root.CreateScope();
+        using (ambient.BeginScope(scope.ServiceProvider))
+        {
+            var context = await factory.MapToAgentContextAsync(skill, new SkillAgentOptions());
+
+            // Proof the composer is authoritative — not just identity/permissions, the actual skill body.
+            context.Instruction.Should().Contain("SEARCH AND SYNTHESIZE SOURCES.");
+            // And the composer reframes it with the identity section (the delta vs the legacy path).
+            context.Instruction.Should().Contain("You are ResearchAgent.");
+        }
+    }
+
+    // --- OFF: byte-identical to the legacy merged instruction ---
+
+    [Fact]
+    public async Task MapToAgentContext_PromptCompositionDisabled_InstructionIsByteIdenticalToLegacyMerge()
+    {
+        await using var root = BuildCompositionProvider();
+        var factory = CreateFactory(Config(promptCompositionEnabled: false), root);
+        var skills = new List<SkillDefinition>
+        {
+            Skill("research", "Search sources."),
+            Skill("present", "Make slides."),
+        };
+        var options = new SkillAgentOptions { AdditionalContext = "Extra context." };
+
+        var context = await factory.MapToAgentContextAsync(skills, options);
+
+        var legacy = SkillInstructionMerger.Merge(skills, options.AdditionalContext);
+        context.Instruction.Should().Be(legacy);
+        // The legacy path must NOT carry the composer's identity framing.
+        context.Instruction.Should().NotContain("You are ");
+    }
+
+    [Fact]
+    public async Task MapToAgentContext_DisabledVsEnabled_ProduceDifferentInstructions()
+    {
+        await using var root = BuildCompositionProvider();
+        var skill = Skill("research", "Search sources.");
+
+        var offContext = await CreateFactory(Config(false), root)
+            .MapToAgentContextAsync(skill, new SkillAgentOptions());
+
+        var ambient = root.GetRequiredService<IAmbientRequestScope>();
+        using var scope = root.CreateScope();
+        string? onInstruction;
+        using (ambient.BeginScope(scope.ServiceProvider))
+        {
+            var onContext = await CreateFactory(Config(true), root)
+                .MapToAgentContextAsync(skill, new SkillAgentOptions());
+            onInstruction = onContext.Instruction;
+        }
+
+        offContext.Instruction.Should().Be("Search sources.");
+        onInstruction.Should().Contain("Search sources.");
+        onInstruction.Should().Contain("You are ResearchAgent.");
+        onInstruction.Should().NotBe(offContext.Instruction);
+    }
+
+    // --- Fail-open: composer/scope unavailable while ON → legacy instruction, no throw ---
+
+    [Fact]
+    public async Task MapToAgentContext_EnabledButNoAmbientScope_FailsOpenToLegacyInstruction()
+    {
+        // A service provider WITHOUT IAmbientRequestScope registered — the factory cannot reach a
+        // request scope, so it must fall back to the legacy instruction rather than throw.
+        await using var barren = new ServiceCollection().BuildServiceProvider();
+        var factory = CreateFactory(Config(promptCompositionEnabled: true), barren);
+        var skill = Skill("research", "Search sources.");
+
+        var act = async () => await factory.MapToAgentContextAsync(skill, new SkillAgentOptions());
+
+        var context = await act.Should().NotThrowAsync();
+        context.Subject.Instruction.Should().Be("Search sources.",
+            "with no request scope the composer cannot run and the legacy merged instruction is used verbatim");
+    }
+
+    [Fact]
+    public async Task MapToAgentContext_EnabledButScopeNotEntered_FailsOpenToLegacyInstruction()
+    {
+        // IAmbientRequestScope is registered but no BeginScope has been called, so Current is null.
+        await using var root = BuildCompositionProvider();
+        var factory = CreateFactory(Config(promptCompositionEnabled: true), root);
+        var skill = Skill("research", "Search sources.");
+
+        var context = await factory.MapToAgentContextAsync(skill, new SkillAgentOptions());
+
+        context.Instruction.Should().Be("Search sources.");
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Prompts/MemoizedPromptComposerTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Prompts/MemoizedPromptComposerTests.cs
@@ -151,6 +151,71 @@ public class MemoizedPromptComposerTests
     }
 
     [Fact]
+    public async Task ComposeAsync_SectionTypesFilter_ExcludesNonAuthoritativeSections()
+    {
+        var identity = CreateSection("Identity", SystemPromptSectionType.AgentIdentity, 10, false, 5, "You are agent-1.");
+        var skills = CreateSection("Skills", SystemPromptSectionType.SkillInstructions, 20, false, 5, "SKILL BODY");
+        var tools = CreateSection("Tools", SystemPromptSectionType.ToolSchemas, 30, false, 5, "TOOL SCHEMAS");
+        var state = CreateSection("State", SystemPromptSectionType.SessionState, 50, false, 5, "SESSION STATE");
+
+        SystemPromptSection? nullSection = null;
+        _cacheMock.Setup(c => c.TryGet(It.IsAny<string>(), It.IsAny<SystemPromptSectionType>(), out nullSection))
+            .Returns(false);
+
+        var composer = CreateComposer(
+            CreateProviderMock(SystemPromptSectionType.AgentIdentity, identity).Object,
+            CreateProviderMock(SystemPromptSectionType.SkillInstructions, skills).Object,
+            CreateProviderMock(SystemPromptSectionType.ToolSchemas, tools).Object,
+            CreateProviderMock(SystemPromptSectionType.SessionState, state).Object);
+
+        var authoritative = new HashSet<SystemPromptSectionType>
+        {
+            SystemPromptSectionType.AgentIdentity,
+            SystemPromptSectionType.SkillInstructions,
+            SystemPromptSectionType.PermissionRules,
+        };
+
+        var result = await composer.ComposeAsync("agent-1", 10_000, authoritative);
+
+        result.Should().Contain("You are agent-1.");
+        result.Should().Contain("SKILL BODY");
+        result.Should().NotContain("TOOL SCHEMAS", "tool schemas are excluded from the authoritative static prompt");
+        result.Should().NotContain("SESSION STATE", "session state is excluded from the authoritative static prompt");
+    }
+
+    [Fact]
+    public async Task ComposeAsync_TightBudget_DropsPermissionRulesBeforeSkillInstructions()
+    {
+        // Authoritative set at production priorities: identity(10) < skill instructions(20) < permission rules(40).
+        var identity = CreateSection("Identity", SystemPromptSectionType.AgentIdentity, 10, false, 50, "IDENTITY");
+        var skills = CreateSection("Skills", SystemPromptSectionType.SkillInstructions, 20, false, 50, "SKILL BODY");
+        var permissions = CreateSection("Permissions", SystemPromptSectionType.PermissionRules, 40, false, 50, "PERMISSION RULES");
+
+        SystemPromptSection? nullSection = null;
+        _cacheMock.Setup(c => c.TryGet(It.IsAny<string>(), It.IsAny<SystemPromptSectionType>(), out nullSection))
+            .Returns(false);
+
+        var composer = CreateComposer(
+            CreateProviderMock(SystemPromptSectionType.AgentIdentity, identity).Object,
+            CreateProviderMock(SystemPromptSectionType.SkillInstructions, skills).Object,
+            CreateProviderMock(SystemPromptSectionType.PermissionRules, permissions).Object);
+
+        var authoritative = new HashSet<SystemPromptSectionType>
+        {
+            SystemPromptSectionType.AgentIdentity,
+            SystemPromptSectionType.SkillInstructions,
+            SystemPromptSectionType.PermissionRules,
+        };
+
+        // Budget fits identity(50) + skill instructions(50) = 100, but not the tail permission rules(150 > 120).
+        var result = await composer.ComposeAsync("agent-1", 120, authoritative);
+
+        result.Should().Contain("IDENTITY");
+        result.Should().Contain("SKILL BODY", "skill instructions must never be dropped before the lower-priority permission rules");
+        result.Should().NotContain("PERMISSION RULES", "the lowest-priority tail section is dropped first when over budget");
+    }
+
+    [Fact]
     public void InvalidateSection_ClearsSpecificType()
     {
         var composer = CreateComposer();

--- a/src/Content/Tests/Infrastructure.AI.Tests/Prompts/MemoizedPromptComposerTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Prompts/MemoizedPromptComposerTests.cs
@@ -216,6 +216,29 @@ public class MemoizedPromptComposerTests
     }
 
     [Fact]
+    public async Task ComposeAsync_RequiredSection_NeverDroppedEvenWhenAloneOverBudget()
+    {
+        // A required section larger than the entire budget must still be included, while optional
+        // sections that would exceed the budget are dropped.
+        var requiredSkills = CreateSection("Skills", SystemPromptSectionType.SkillInstructions, 20, false, 500, "SKILL BODY")
+            with { IsRequired = true };
+        var optionalPermissions = CreateSection("Permissions", SystemPromptSectionType.PermissionRules, 40, false, 500, "PERMISSION RULES");
+
+        SystemPromptSection? nullSection = null;
+        _cacheMock.Setup(c => c.TryGet(It.IsAny<string>(), It.IsAny<SystemPromptSectionType>(), out nullSection))
+            .Returns(false);
+
+        var composer = CreateComposer(
+            CreateProviderMock(SystemPromptSectionType.SkillInstructions, requiredSkills).Object,
+            CreateProviderMock(SystemPromptSectionType.PermissionRules, optionalPermissions).Object);
+
+        var result = await composer.ComposeAsync("agent-1", tokenBudget: 10);
+
+        result.Should().Contain("SKILL BODY", "a required section is never dropped by the budget assembler");
+        result.Should().NotContain("PERMISSION RULES", "optional sections over budget are still dropped");
+    }
+
+    [Fact]
     public void InvalidateSection_ClearsSpecificType()
     {
         var composer = CreateComposer();

--- a/src/Content/Tests/Infrastructure.AI.Tests/Prompts/Sections/SkillInstructionsSectionProviderTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Prompts/Sections/SkillInstructionsSectionProviderTests.cs
@@ -1,0 +1,63 @@
+using Application.AI.Common.Interfaces.Prompts;
+using Application.AI.Common.Services.Prompts;
+using Domain.AI.Prompts;
+using FluentAssertions;
+using Infrastructure.AI.Prompts.Sections;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Prompts.Sections;
+
+/// <summary>
+/// Unit tests for <see cref="SkillInstructionsSectionProvider"/> — the section that surfaces the
+/// merged skill instructions stamped onto the scoped <see cref="ISkillInstructionAccessor"/>.
+/// </summary>
+public sealed class SkillInstructionsSectionProviderTests
+{
+    private static SkillInstructionsSectionProvider CreateProvider(string? instructions)
+    {
+        var accessor = new SkillInstructionAccessor();
+        accessor.Set(instructions);
+        return new SkillInstructionsSectionProvider(accessor);
+    }
+
+    [Fact]
+    public void SectionType_IsSkillInstructions()
+    {
+        CreateProvider("x").SectionType.Should().Be(SystemPromptSectionType.SkillInstructions);
+    }
+
+    [Fact]
+    public async Task GetSectionAsync_WithInstructions_ReturnsSectionWithVerbatimContent()
+    {
+        var provider = CreateProvider("You are a research agent.\n\nDo the thing.");
+
+        var section = await provider.GetSectionAsync("ResearchAgent");
+
+        section.Should().NotBeNull();
+        section!.Content.Should().Be("You are a research agent.\n\nDo the thing.");
+        section.Type.Should().Be(SystemPromptSectionType.SkillInstructions);
+        section.Priority.Should().Be(20);
+        section.IsCacheable.Should().BeFalse("skill instructions derive from per-request scoped state");
+        section.EstimatedTokens.Should().BeGreaterThan(0);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public async Task GetSectionAsync_NoInstructions_ReturnsNull(string? instructions)
+    {
+        var provider = CreateProvider(instructions);
+
+        var section = await provider.GetSectionAsync("AnyAgent");
+
+        section.Should().BeNull();
+    }
+
+    [Fact]
+    public void Constructor_NullAccessor_Throws()
+    {
+        var act = () => new SkillInstructionsSectionProvider(null!);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Prompts/Sections/SkillInstructionsSectionProviderTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Prompts/Sections/SkillInstructionsSectionProviderTests.cs
@@ -60,4 +60,32 @@ public sealed class SkillInstructionsSectionProviderTests
 
         act.Should().Throw<ArgumentNullException>();
     }
+
+    [Fact]
+    public async Task ConcurrentCompositions_SameSharedAccessor_DoNotLeakAcrossAsyncFlows()
+    {
+        // The accessor is scoped and shared; two compositions running concurrently on the same scope
+        // each stamp their own skill content. AsyncLocal storage must isolate them so neither leaks
+        // into the other.
+        var accessor = new SkillInstructionAccessor();
+        var provider = new SkillInstructionsSectionProvider(accessor);
+
+        async Task<string?> ComposeFor(string body)
+        {
+            accessor.Set(body);
+            await Task.Yield();
+            await Task.Delay(15);
+            var section = await provider.GetSectionAsync("AnyAgent");
+            return section?.Content;
+        }
+
+        var results = await Task.WhenAll(
+            ComposeFor("AAA-INSTRUCTIONS"),
+            ComposeFor("BBB-INSTRUCTIONS"),
+            ComposeFor("CCC-INSTRUCTIONS"));
+
+        results.Should().BeEquivalentTo(
+            new[] { "AAA-INSTRUCTIONS", "BBB-INSTRUCTIONS", "CCC-INSTRUCTIONS" },
+            "each concurrent composition must read back its own stamped instructions, not another flow's");
+    }
 }

--- a/src/Content/Tests/Presentation.Common.Tests/Extensions/ConfigValidationStartupTests.cs
+++ b/src/Content/Tests/Presentation.Common.Tests/Extensions/ConfigValidationStartupTests.cs
@@ -111,6 +111,15 @@ public class ConfigValidationStartupTests
                 ["AppConfig:AI:Telemetry:ContentCapture:RedactionCategories:0"] = "NotACategory",
             }
         },
+        {
+            // TokenBudget must be > 0 once the composer is enabled.
+            "PromptCompositionConfig",
+            new Dictionary<string, string?>
+            {
+                ["AppConfig:AI:ContextManagement:PromptComposition:Enabled"] = "true",
+                ["AppConfig:AI:ContextManagement:PromptComposition:TokenBudget"] = "0",
+            }
+        },
     };
 
     [Theory]


### PR DESCRIPTION
Finishes the previously-inert `ISystemPromptComposer` and wires it as the authoritative **static** system-prompt builder on the live agent turn, behind a **default-OFF** flag. Turns a built-but-unused component into a real, opt-in capability: token-budget-aware, section-composed agent instructions.

## What was missing / what this adds
The composer could never produce a real prompt — it had no provider for the agent's **skill instructions** (its core job description). This adds that and makes the model coherent:
- **New `SkillInstructionsSectionProvider`** produces the skill-instructions + `AdditionalContext` content. The merge format is extracted into one shared `SkillInstructionMerger` (single source of truth; the old `AgentExecutionContextFactory.BuildMergedInstruction` is deleted and both paths flow through the helper).
- **Authoritative section set** when ON = `AgentIdentity` + `SkillInstructions` + `PermissionRules` (via a per-call `sectionTypes` filter). `ToolSchemas` is excluded (the SDK already sends tool schemas) and `SessionState` is excluded (per-turn dynamic state belongs on the `AIContextProvider` rail, not baked into a once-built cached instruction) — this resolves the staleness hazard by design, no per-turn middleware needed.
- **New config** `AppConfig.AI.ContextManagement.PromptComposition { Enabled=false; TokenBudget=8000 }` + FluentValidation + `ValidateOnStart`.
- **Wiring** in `AgentExecutionContextFactory.MapToAgentContextAsync`: OFF → legacy merged instruction **verbatim**; ON → composer (scoped, resolved via `IAmbientRequestScope`), **fail-open to legacy** on any unavailability/throw/empty.

## Safety (adversarially reviewed — SAFE WITH FIXES → all applied)
- **OFF is byte-identical** to today (reviewer diffed the extracted merger char-for-char vs the deleted original; now pinned by a hardcoded-expected-string test). Default path unaffected.
- **Fix — a tiny budget can no longer produce a job-less agent.** The old tail-drop used `continue`, so an over-budget `SkillInstructions` could be dropped while smaller `PermissionRules` survived. Added `SystemPromptSection.IsRequired` (additive, non-breaking); the budget now bounds only optional sections, and `SkillInstructions` is required → degrades to identity + full skill instructions + dropped optional tail, never a prompt without the agent's instructions.
- **Concurrency:** the multi-agent creation paths are sequential (no live race); the scoped `SkillInstructionAccessor` stores its value in `AsyncLocal` anyway as defense-in-depth against future parallel fan-out.
- **Cache:** `SkillInstructions` is non-cacheable (content varies by `AdditionalContext`; the memo cache is keyed by agentId only). No cacheable section varies by anything but agentId.
- `CreateAgentAsync` (CRITICAL blast radius) is **untouched** — default-off keeps its input byte-identical.

## Behavior delta when ON
`"You are {AgentName}."` + the same merged skill instructions + a permission-rules section, joined `\n\n`, bounded by `TokenBudget` (optional sections only). OFF = just the merged skill instructions, exactly as before.

## Verification
- Application.AI.Common.Tests 1326, Infrastructure.AI Prompts 143, Domain.AI `SystemPromptSection` 13 — all green, 0 warnings.
- Reproduce tests (red→green): skill-instructions-present ON, budget floor keeps required section, OFF byte-identical (hardcoded), fail-open, concurrent-flow isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)