### PR TITLE
fix: enable ValidateOnBuild across harness hosts (audit H2)

### DIFF
--- a/src/Content/Application/Application.AI.Common/Evaluation/NotConfiguredEvalRunner.cs
+++ b/src/Content/Application/Application.AI.Common/Evaluation/NotConfiguredEvalRunner.cs
@@ -1,0 +1,39 @@
+using Application.AI.Common.Evaluation.Interfaces;
+using Application.AI.Common.Evaluation.Models;
+using Domain.AI.Evaluation;
+
+namespace Application.AI.Common.Evaluation;
+
+/// <summary>
+/// Fail-fast default <see cref="IEvalRunner"/> for hosts that do not opt into the evaluation
+/// framework. Invoking it throws — see <c>NotConfiguredRolloutRunner</c> for the rationale.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The evaluation framework (real <c>EvalRunner</c>, metrics, reporters, YAML loader) is
+/// registered only by the EvalRunner host via <c>AddEvaluationDependencies()</c>. But
+/// <c>RunEvalSuiteCommandHandler</c> is discovered by global MediatR assembly scanning and
+/// therefore registered in every host. This default keeps that handler constructible so the
+/// composition root passes <c>ValidateOnBuild</c>.
+/// </para>
+/// <para>
+/// It deliberately throws rather than returning an empty report: an empty
+/// <see cref="EvalRunReport"/> would read as "the suite ran and found nothing", silently
+/// masking a mis-wired host. In a correctly configured host this type is never resolved —
+/// the EvalRunner host's <c>AddSingleton&lt;IEvalRunner, EvalRunner&gt;</c> wins via
+/// last-registration-wins — so the throw is only ever reached if the eval command is
+/// dispatched somewhere the framework was never wired.
+/// </para>
+/// </remarks>
+public sealed class NotConfiguredEvalRunner : IEvalRunner
+{
+    /// <inheritdoc />
+    public Task<EvalRunReport> RunAsync(
+        IReadOnlyList<EvalDataset> datasets,
+        EvalRunOptions options,
+        CancellationToken cancellationToken) =>
+        throw new InvalidOperationException(
+            "No IEvalRunner is configured. The evaluation framework is opt-in: call " +
+            "services.AddEvaluationDependencies() from the host that runs evaluations " +
+            "(e.g. Presentation.EvalRunner) before dispatching RunEvalSuiteCommand.");
+}

--- a/src/Content/Application/Application.AI.Common/Notifications/NullLearningNotificationChannel.cs
+++ b/src/Content/Application/Application.AI.Common/Notifications/NullLearningNotificationChannel.cs
@@ -1,0 +1,24 @@
+using Application.AI.Common.Interfaces.Learnings;
+using Domain.AI.Learnings;
+
+namespace Application.AI.Common.Notifications;
+
+/// <summary>
+/// Default <see cref="ILearningNotificationChannel"/> for hosts without a real-time
+/// client transport. All learning lifecycle notifications are dropped silently.
+/// </summary>
+/// <remarks>
+/// Registered as the always-on default in the standard composition root so
+/// <c>RememberCommandHandler</c> can resolve its dependency unconditionally. The AgentHub
+/// host overrides with a SignalR/AG-UI-backed implementation via last-registration-wins.
+/// </remarks>
+public sealed class NullLearningNotificationChannel : ILearningNotificationChannel
+{
+    /// <inheritdoc />
+    public Task NotifyLearningCapturedAsync(LearningEntry learning, CancellationToken ct) =>
+        Task.CompletedTask;
+
+    /// <inheritdoc />
+    public Task NotifyLearningAppliedAsync(LearningEntry learning, string agentId, CancellationToken ct) =>
+        Task.CompletedTask;
+}

--- a/src/Content/Application/Application.AI.Common/Notifications/NullPlanProgressNotifier.cs
+++ b/src/Content/Application/Application.AI.Common/Notifications/NullPlanProgressNotifier.cs
@@ -1,0 +1,48 @@
+using Application.AI.Common.Interfaces.Planner;
+using Domain.AI.Planner;
+using Domain.AI.Sandbox;
+
+namespace Application.AI.Common.Notifications;
+
+/// <summary>
+/// Default <see cref="IPlanProgressNotifier"/> for hosts without a real-time client
+/// transport (ConsoleUI, EvalRunner, FoundryHost, MCP server). All progress
+/// notifications are dropped silently.
+/// </summary>
+/// <remarks>
+/// Registered as the always-on default in the standard composition root so the
+/// scoped <c>PlanExecutor</c>, every keyed step executor, and the planner command
+/// handlers (<c>ExecutePlanCommand</c>, <c>CancelPlanCommand</c>, <c>RetryPlanStepCommand</c>)
+/// can resolve their dependency unconditionally. The AgentHub host overrides with a
+/// SignalR/AG-UI-backed implementation via last-registration-wins.
+/// </remarks>
+public sealed class NullPlanProgressNotifier : IPlanProgressNotifier
+{
+    /// <inheritdoc />
+    public Task NotifyPlanStartedAsync(PlanId planId, string planName, PlanGraph graph, CancellationToken ct) =>
+        Task.CompletedTask;
+
+    /// <inheritdoc />
+    public Task NotifyStepStartedAsync(PlanId planId, PlanStepId stepId, string stepName, StepType type, CancellationToken ct) =>
+        Task.CompletedTask;
+
+    /// <inheritdoc />
+    public Task NotifyStepCompletedAsync(PlanId planId, PlanStepId stepId, StepExecutionStatus status, TimeSpan duration, string? outputSummary, CancellationToken ct) =>
+        Task.CompletedTask;
+
+    /// <inheritdoc />
+    public Task NotifyStateUpdateAsync(PlanId planId, PlanStepId stepId, StepExecutionStatus previousStatus, StepExecutionStatus newStatus, CancellationToken ct) =>
+        Task.CompletedTask;
+
+    /// <inheritdoc />
+    public Task NotifySandboxStatusAsync(PlanId planId, PlanStepId stepId, string toolName, SandboxIsolationLevel isolationLevel, ResourceUsage usage, string? attestationHash, CancellationToken ct) =>
+        Task.CompletedTask;
+
+    /// <inheritdoc />
+    public Task NotifyPlanCompletedAsync(PlanId planId, TimeSpan totalDuration, CancellationToken ct) =>
+        Task.CompletedTask;
+
+    /// <inheritdoc />
+    public Task NotifyPlanFailedAsync(PlanId planId, PlanStepId failedStepId, string errorMessage, CancellationToken ct) =>
+        Task.CompletedTask;
+}

--- a/src/Content/Application/Application.AI.Common/Prompts/NullPromptUsageStore.cs
+++ b/src/Content/Application/Application.AI.Common/Prompts/NullPromptUsageStore.cs
@@ -1,0 +1,43 @@
+using Application.AI.Common.Prompts.Interfaces;
+using Application.AI.Common.Prompts.Models;
+
+namespace Application.AI.Common.Prompts;
+
+/// <summary>
+/// Default <see cref="IPromptUsageStore"/> used when durable prompt-usage persistence is
+/// disabled (the default). Appends are dropped; queries return empty result sets.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Prompt-usage persistence is opt-in (<c>AppConfig:AI:PromptUsage:PersistenceEnabled</c>).
+/// When it is off, the real <c>EfCorePromptUsageStore</c> is not registered — yet the
+/// globally-scanned MediatR handlers that query it (prompt-version comparison, trace replay)
+/// are always registered. This No-op keeps those handlers constructible in every host.
+/// </para>
+/// <para>
+/// Empty results are the correct semantic here, not an error: with persistence off there are
+/// genuinely no recorded rows to return. When persistence is enabled the EfCore store is
+/// registered instead of this one (the two live in mutually exclusive registration branches).
+/// </para>
+/// </remarks>
+public sealed class NullPromptUsageStore : IPromptUsageStore
+{
+    /// <inheritdoc />
+    public Task AppendAsync(PromptUsageRecord record, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(record);
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public Task<IReadOnlyList<PromptUsageRecord>> QueryByTraceIdAsync(string traceId, CancellationToken cancellationToken) =>
+        Task.FromResult<IReadOnlyList<PromptUsageRecord>>([]);
+
+    /// <inheritdoc />
+    public Task<IReadOnlyList<PromptUsageRecord>> QueryByCaseIdAsync(string caseId, CancellationToken cancellationToken) =>
+        Task.FromResult<IReadOnlyList<PromptUsageRecord>>([]);
+
+    /// <inheritdoc />
+    public Task<IReadOnlyList<PromptUsageRecord>> QueryByPromptNameAsync(string promptName, CancellationToken cancellationToken) =>
+        Task.FromResult<IReadOnlyList<PromptUsageRecord>>([]);
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Prompts/DependencyInjection.Prompts.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Prompts/DependencyInjection.Prompts.cs
@@ -75,6 +75,15 @@ public static class PromptRegistryDependencyInjection
         {
             // Default path: OTel-only recorder. Zero infrastructure dependencies.
             services.AddSingleton<IPromptUsageRecorder, OtelPromptUsageRecorder>();
+
+            // No durable store in this branch, but the globally-scanned MediatR handlers that
+            // query prompt usage (version comparison, trace replay) are always registered.
+            // Register a No-op store so they stay constructible (audit item H2 / ValidateOnBuild);
+            // empty query results are the correct semantic when nothing is persisted. The real
+            // EfCorePromptUsageStore is registered instead in the persistence-enabled branch below.
+            services.AddSingleton<
+                Application.AI.Common.Prompts.Interfaces.IPromptUsageStore,
+                Application.AI.Common.Prompts.NullPromptUsageStore>();
             return services;
         }
 

--- a/src/Content/Presentation/Presentation.AgentHub/Program.cs
+++ b/src/Content/Presentation/Presentation.AgentHub/Program.cs
@@ -17,19 +17,16 @@ builder.Services.GetServices(includeHealthChecksUI: true);
 // Register AgentHub-specific services (auth, SignalR, CORS, rate limiting, config).
 builder.Services.AddAgentHubServices(builder.Configuration, builder.Environment);
 
-builder.Host.UseDefaultServiceProvider(options =>
-{
-    // ValidateScopes guards against captive dependencies — a singleton capturing scoped
-    // per-request state (the bug class behind the formerly-singleton prompt composer, which is
-    // now SCOPED via AddSystemPromptComposition). Enabled in ALL environments: the resolution
-    // cost is negligible and cross-request state bleed is a production correctness hazard.
-    options.ValidateScopes = true;
-    // ValidateOnBuild stays off: MediatR assembly scanning registers handlers whose
-    // dependencies are conditionally registered (e.g. IPromptUsageStore only when prompt-usage
-    // persistence is enabled, IEvalRunner only in the eval host), so eager build-time
-    // validation false-positives on handlers this host never dispatches.
-    options.ValidateOnBuild = false;
-});
+// Enforce the harness's boot-time DI validation policy (ValidateScopes + ValidateOnBuild,
+// audit item H2) in ALL environments. Single-sourced in IServiceCollectionExtensions so the
+// web host and the console-style hosts can never drift: ValidateScopes catches captive
+// dependencies (a singleton capturing per-request scoped state), and ValidateOnBuild turns the
+// audit's "inert machinery" class — a globally-scanned MediatR handler whose dependency only
+// one host supplies — from a silent-until-dispatched runtime crash into a caught-at-startup
+// error. AgentHub's real AG-UI notifiers still win over the composition root's No-op defaults
+// via last-registration-wins.
+builder.Host.UseDefaultServiceProvider(
+    Presentation.Common.Extensions.IServiceCollectionExtensions.ApplyValidationPolicy);
 
 var app = builder.Build();
 

--- a/src/Content/Presentation/Presentation.Common/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Content/Presentation/Presentation.Common/Extensions/IServiceCollectionExtensions.cs
@@ -301,6 +301,51 @@ public static class IServiceCollectionExtensions
     }
 
     /// <summary>
+    /// Applies the harness's boot-time DI validation policy (audit item H2) to the given
+    /// options: <c>ValidateScopes</c> (captive-dependency guard — a singleton must never
+    /// capture per-request scoped state) and <c>ValidateOnBuild</c> (every registered
+    /// service, including every assembly-scanned MediatR handler, must be constructible).
+    /// A mis-wired graph then fails loudly at boot instead of silently at first use.
+    /// </summary>
+    /// <param name="options">The provider options to configure.</param>
+    /// <remarks>
+    /// This is the single source of truth for the validation policy. It is consumed two ways:
+    /// the console-style hosts (ConsoleUI, EvalRunner, FoundryHost) apply it through
+    /// <see cref="BuildValidatedServiceProvider"/>; the AgentHub web host, which never calls
+    /// <c>BuildServiceProvider</c> directly, passes this method to <c>UseDefaultServiceProvider</c>
+    /// on its host builder. (The MCP server host does not yet enforce this policy — see the H2
+    /// follow-up; it composes a separate graph with no assembly-scanned harness handlers.)
+    /// </remarks>
+    public static void ApplyValidationPolicy(ServiceProviderOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        options.ValidateScopes = true;
+        options.ValidateOnBuild = true;
+    }
+
+    /// <summary>
+    /// Builds the service provider with the harness's boot-time validation policy
+    /// (<see cref="ApplyValidationPolicy"/>) enabled.
+    /// </summary>
+    /// <param name="services">The fully-composed service collection.</param>
+    /// <returns>A validating provider; dispose it to release the singletons it owns.</returns>
+    /// <remarks>
+    /// The single entry point for the console-style hosts (ConsoleUI, EvalRunner, FoundryHost)
+    /// that build their own provider from a bare <see cref="IServiceCollection"/>. ASP0000 warns
+    /// against calling <c>BuildServiceProvider</c> from application code; these hosts legitimately
+    /// own their root provider, so the suppression is centralized here rather than repeated at
+    /// each call site.
+    /// </remarks>
+    public static ServiceProvider BuildValidatedServiceProvider(this IServiceCollection services)
+    {
+        var options = new ServiceProviderOptions();
+        ApplyValidationPolicy(options);
+#pragma warning disable ASP0000
+        return services.BuildServiceProvider(options);
+#pragma warning restore ASP0000
+    }
+
+    /// <summary>
     /// Configures the caching strategy based on <see cref="CacheConfig.CacheType"/>.
     /// </summary>
     /// <param name="services">The service collection to configure.</param>
@@ -441,6 +486,24 @@ public static class IServiceCollectionExtensions
         services.AddSingleton<
             Application.AI.Common.Interfaces.Context.IContextSnapshotNotifier,
             Application.AI.Common.Notifications.NullContextSnapshotNotifier>();
+
+        // Host-overridable defaults for globally-scanned MediatR handlers whose live
+        // dependency is supplied by only one host (audit item H2). Without these, the
+        // handler is registered but uninstantiable in every other host — a latent crash
+        // that ValidateOnBuild (now on) would reject at boot. Same last-write-wins pattern
+        // as the notifiers above: the AgentHub host and the opt-in eval framework register
+        // their real implementations AFTER GetServices, so those win at resolution.
+        //   - IPlanProgressNotifier / ILearningNotificationChannel → AgentHub's AG-UI bridge
+        //   - IEvalRunner → EvalRunner host's AddEvaluationDependencies() (fail-fast default)
+        services.AddSingleton<
+            Application.AI.Common.Interfaces.Planner.IPlanProgressNotifier,
+            Application.AI.Common.Notifications.NullPlanProgressNotifier>();
+        services.AddSingleton<
+            Application.AI.Common.Interfaces.Learnings.ILearningNotificationChannel,
+            Application.AI.Common.Notifications.NullLearningNotificationChannel>();
+        services.AddSingleton<
+            Application.AI.Common.Evaluation.Interfaces.IEvalRunner,
+            Application.AI.Common.Evaluation.NotConfiguredEvalRunner>();
 
         return services;
     }

--- a/src/Content/Presentation/Presentation.ConsoleUI/Program.cs
+++ b/src/Content/Presentation/Presentation.ConsoleUI/Program.cs
@@ -64,7 +64,8 @@ public class Program
 		// `await using` guarantees the container (and every IDisposable/IAsyncDisposable
 		// singleton it owns — named-pipe logger provider, JSONL audit writers, EF Core
 		// resources) is flushed and disposed on exit, mirroring Presentation.EvalRunner.
-		await using var serviceProvider = services.BuildServiceProvider();
+		// BuildValidatedServiceProvider enables ValidateScopes + ValidateOnBuild (audit H2).
+		await using var serviceProvider = services.BuildValidatedServiceProvider();
 
 		// Track only the services we actually started so a mid-startup failure on service N
 		// doesn't leave us calling StopAsync on services that never started.

--- a/src/Content/Presentation/Presentation.EvalRunner/HarmonicWriteEval/HarmonicWriteEvalCli.cs
+++ b/src/Content/Presentation/Presentation.EvalRunner/HarmonicWriteEval/HarmonicWriteEvalCli.cs
@@ -130,7 +130,10 @@ public static class HarmonicWriteEvalCli
             services.AddEvaluationDependencies();
             ConfigureJudgeFromAgentFramework(services);
         }
-        return services.BuildServiceProvider();
+        // Same validation policy as the main EvalRunner host (audit H2). The offline path
+        // composes nothing, so validation is a no-op there; the --llm path validates the
+        // full eval-host graph, matching Program.cs.
+        return services.BuildValidatedServiceProvider();
     }
 
     // The quality judge resolves its model from JudgeOptions — a DIFFERENT config section than the

--- a/src/Content/Presentation/Presentation.EvalRunner/Program.cs
+++ b/src/Content/Presentation/Presentation.EvalRunner/Program.cs
@@ -107,7 +107,10 @@ public static class Program
         services.GetServices(includeHealthChecksUI: false);
         services.AddEvaluationDependencies();
 
-        await using var provider = services.BuildServiceProvider();
+        // BuildValidatedServiceProvider enables ValidateScopes + ValidateOnBuild (audit H2).
+        // The real IEvalRunner registered by AddEvaluationDependencies above wins over the
+        // composition root's not-configured default via last-registration-wins.
+        await using var provider = services.BuildValidatedServiceProvider();
 
         // Validate --out formats against actually-registered reporter format keys (not a
         // hardcoded list) so consumers who register custom IEvalReporter implementations

--- a/src/Content/Presentation/Presentation.FoundryHost/Program.cs
+++ b/src/Content/Presentation/Presentation.FoundryHost/Program.cs
@@ -60,9 +60,9 @@ public static class Program
         // AgentHost — an ordering the single-container alternative (resolving the agent from DI after
         // Build) cannot guarantee. The agent captures its pipeline from this provider, so the
         // provider is held for the process lifetime and disposed only after the host stops.
-#pragma warning disable ASP0000
-        var provider = services.BuildServiceProvider();
-#pragma warning restore ASP0000
+        // BuildValidatedServiceProvider enables ValidateScopes + ValidateOnBuild (audit H2)
+        // and centralizes the ASP0000 suppression for the console-style hosts.
+        var provider = services.BuildValidatedServiceProvider();
 
         // Start hosted services (skill seeding, planner DB migration, governance bootstrap, drift
         // baseline loader, OpenTelemetry). The harness expects these to run before any agent turn —

--- a/src/Content/Tests/Infrastructure.AI.Tests/Prompts/PromptRegistryPersistenceDiTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Prompts/PromptRegistryPersistenceDiTests.cs
@@ -1,3 +1,4 @@
+using Application.AI.Common.Prompts;
 using Application.AI.Common.Prompts.Interfaces;
 using Domain.Common.Config.AI;
 using FluentAssertions;
@@ -13,7 +14,7 @@ namespace Infrastructure.AI.Tests.Prompts;
 public sealed class PromptRegistryPersistenceDiTests
 {
     [Fact]
-    public void Persistence_disabled_registers_OtelPromptUsageRecorder_only()
+    public void Persistence_disabled_registers_Otel_recorder_and_NoOp_store()
     {
         var services = new ServiceCollection();
         services.AddSingleton(NullLoggerFactory.Instance);
@@ -27,7 +28,10 @@ public sealed class PromptRegistryPersistenceDiTests
         var recorder = provider.GetRequiredService<IPromptUsageRecorder>();
 
         recorder.Should().BeOfType<OtelPromptUsageRecorder>();
-        provider.GetService<IPromptUsageStore>().Should().BeNull();
+        // A No-op store is registered even with persistence off, so the globally-scanned MediatR
+        // handlers that query prompt usage stay constructible under ValidateOnBuild (audit H2).
+        // It returns empty results (no rows persisted) and needs no DbContext.
+        provider.GetService<IPromptUsageStore>().Should().BeOfType<NullPromptUsageStore>();
         provider.GetService<IDbContextFactory<PromptUsageDbContext>>().Should().BeNull();
     }
 

--- a/src/Content/Tests/Presentation.Common.Tests/Composition/ValidateOnBuildSweepTests.cs
+++ b/src/Content/Tests/Presentation.Common.Tests/Composition/ValidateOnBuildSweepTests.cs
@@ -1,0 +1,63 @@
+using Domain.Common.Config;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Presentation.Common.Extensions;
+using Xunit;
+
+namespace Presentation.Common.Tests.Composition;
+
+/// <summary>
+/// Self-maintaining guard for audit item H2: the production composition root must
+/// pass <c>ValidateOnBuild = true</c>, meaning EVERY registered service — including
+/// every MediatR handler discovered by assembly scanning — can actually be constructed.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Before this guard, four globally-scanned handlers depended on interfaces supplied by
+/// only one host (AgentHub's SignalR notifiers) or one opt-in subsystem (the eval runner,
+/// the prompt-usage store). Any other host registered the handler but could not build it —
+/// a latent runtime crash the moment that command was dispatched. <c>ValidateOnBuild</c>
+/// converts that silent-until-dispatched failure into a loud boot failure, and this test
+/// converts it further into a caught-at-CI failure.
+/// </para>
+/// <para>
+/// The fix is a No-op / not-configured default for each such dependency (mirroring the
+/// existing <c>NullEvalRunNotifier</c> pattern), so the graph is constructible in every
+/// host; the real host-specific implementation still wins via last-registration-wins.
+/// If a future change adds a handler whose dependency has no default, this test fails with
+/// the exact unresolved service — not a customer's production stack trace.
+/// </para>
+/// </remarks>
+public sealed class ValidateOnBuildSweepTests
+{
+    [Fact]
+    public void ProductionCompositionRoot_BuildsWithValidateOnBuild()
+    {
+        // Empty configuration = the default, all-features-off registration set every host
+        // shares before its host-specific overrides. This is the baseline that must always
+        // be constructible.
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>())
+            .Build();
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.RegisterConfigSections(configuration);
+        var appConfig = configuration.GetSection("AppConfig").Get<AppConfig>() ?? new AppConfig();
+        services.BuildGlobalSolutionServices(appConfig, includeHealthChecksUI: false);
+
+        // ValidateOnBuild eagerly constructs every non-open-generic descriptor and throws an
+        // AggregateException listing ALL that cannot be built. ValidateScopes is kept on to
+        // match the production hosts (captive-dependency guard, audit item H2's sibling).
+        var exception = Record.Exception(() =>
+        {
+            using var provider = services.BuildServiceProvider(new ServiceProviderOptions
+            {
+                ValidateOnBuild = true,
+                ValidateScopes = true,
+            });
+        });
+
+        Assert.Null(exception);
+    }
+}

--- a/src/Content/Tests/Presentation.EvalRunner.Tests/Composition/EvalRunnerValidateOnBuildTests.cs
+++ b/src/Content/Tests/Presentation.EvalRunner.Tests/Composition/EvalRunnerValidateOnBuildTests.cs
@@ -1,0 +1,70 @@
+using Application.AI.Common.Evaluation.Interfaces;
+using Domain.Common.Config;
+using FluentAssertions;
+using Infrastructure.AI.Evaluation;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Presentation.Common.Extensions;
+using Xunit;
+
+namespace Presentation.EvalRunner.Tests.Composition;
+
+/// <summary>
+/// Guards the EvalRunner host's composition for audit item H2. The EvalRunner is the one host
+/// that opts into the evaluation framework, so it exercises two things the shared-root sweep
+/// test cannot: the eval-specific service graph under <c>ValidateOnBuild</c>, and the
+/// last-registration-wins override that must replace the composition root's fail-fast
+/// <c>NotConfiguredEvalRunner</c> default with the real
+/// <see cref="Infrastructure.AI.Evaluation.Runners.EvalRunner"/>.
+/// </summary>
+public sealed class EvalRunnerValidateOnBuildTests
+{
+    private static ServiceCollection BuildEvalRunnerServices()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>())
+            .Build();
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.RegisterConfigSections(configuration);
+        var appConfig = configuration.GetSection("AppConfig").Get<AppConfig>() ?? new AppConfig();
+        services.BuildGlobalSolutionServices(appConfig, includeHealthChecksUI: false);
+
+        // Mirror Program.cs: the eval host opts into the framework AFTER the shared root.
+        services.AddEvaluationDependencies();
+        return services;
+    }
+
+    [Fact]
+    public void EvalRunnerComposition_BuildsWithValidateOnBuild()
+    {
+        var services = BuildEvalRunnerServices();
+
+        var exception = Record.Exception(() =>
+        {
+            using var provider = services.BuildServiceProvider(new ServiceProviderOptions
+            {
+                ValidateOnBuild = true,
+                ValidateScopes = true,
+            });
+        });
+
+        exception.Should().BeNull();
+    }
+
+    [Fact]
+    public void EvalRunnerComposition_ResolvesRealEvalRunner_NotTheNotConfiguredDefault()
+    {
+        var services = BuildEvalRunnerServices();
+
+        // No validation flags needed here — this asserts resolution only; the sibling
+        // BuildsWithValidateOnBuild test pins the validation policy for this same graph.
+        using var provider = services.BuildServiceProvider();
+
+        // The composition root registers NotConfiguredEvalRunner so every host can construct
+        // RunEvalSuiteCommandHandler; AddEvaluationDependencies (called after) must win here.
+        provider.GetRequiredService<IEvalRunner>()
+            .Should().BeOfType<Infrastructure.AI.Evaluation.Runners.EvalRunner>();
+    }
+}


### PR DESCRIPTION
## What & why (audit item H2)

Turning on .NET DI **`ValidateOnBuild`** makes each host verify at startup that every registered service can actually be constructed — converting the audit's signature *"inert machinery"* failure (a globally-scanned MediatR handler whose dependency only one host supplies) from a **silent-until-dispatched runtime crash** into a **loud boot failure**.

The audit backlog estimated this as a multi-day job blocked on "~106 MediatR gaps." Building the real composition root with `ValidateOnBuild=true` showed the true picture: **13 failures that collapse to 4 missing registrations**, all the same shape.

| Missing interface | Supplied only by | Handlers it stranded |
|---|---|---|
| `IPlanProgressNotifier` | AgentHub (AG-UI) | 9 — PlanExecutor, 5 step executors, 3 planner cmd handlers |
| `IPromptUsageStore` | Infra, only when prompt-persistence on | 2 — prompt comparison, trace replay |
| `IEvalRunner` | EvalRunner host (opt-in eval framework) | 1 — RunEvalSuite |
| `ILearningNotificationChannel` | AgentHub (AG-UI) | 1 — Remember |

Every *other* host registered these handlers but could not build them — a latent crash the moment the command was dispatched, silent because `ValidateOnBuild` was off.

## The fix

1. **Four host-overridable defaults**, mirroring the existing `NullEvalRunNotifier` pattern:
   - `NullPlanProgressNotifier`, `NullLearningNotificationChannel` — silent no-op (notifications optional)
   - `NullPromptUsageStore` — returns empty results (no persistence ⇒ genuinely no rows)
   - `NotConfiguredEvalRunner` — **throws** if invoked (an empty eval report would falsely read as "suite passed"), matching the codebase's `NotConfigured*` convention
   
   The real host-specific implementations still win via **last-registration-wins**.
2. **`ValidateScopes` + `ValidateOnBuild` enabled** in the 4 harness-composition hosts (AgentHub, ConsoleUI, EvalRunner, FoundryHost), single-sourced through `ApplyValidationPolicy` / `BuildValidatedServiceProvider` in `Presentation.Common` so the web host and console hosts can't drift.
3. **Two self-maintaining guard tests** — the shared root and the EvalRunner graph (incl. proving the real `EvalRunner` overrides the not-configured default) both build clean under `ValidateOnBuild`.

## Scope note
The **MCP server** is deliberately out of scope: it composes a *separate* `WebApplication` graph via `AddMcpServerServices` (no assembly-scanned harness MediatR handlers), so the 4 defaults don't touch it and faithfully validating it needs a live Kestrel boot. Tracked as a small follow-up.

## Verification
- Full solution build **0 warnings / 0 errors**
- New guard tests green; Presentation.Common.Tests (128), Application.AI.Common.Tests (1326), Infrastructure.AI prompt (163) + planner (139) green
- **AgentHub boots clean under real `ValidateOnBuild`** via `WebApplicationFactory<Program>`
- Reviewed with high-effort `/code-review` + `/simplify` (findings applied: shared helper, missed 5th composition path, doc accuracy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)