### PR TITLE
fix: enable ValidateOnBuild on the MCP server host (H2 follow-up)

### DIFF
--- a/src/Content/Infrastructure/Infrastructure.AI.MCPServer/Program.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.MCPServer/Program.cs
@@ -21,6 +21,18 @@ public class Program
     {
         var builder = WebApplication.CreateBuilder(args);
 
+        // Enforce the harness's boot-time DI validation policy (audit item H2) in ALL
+        // environments: ValidateScopes catches captive dependencies (a singleton capturing
+        // per-request scoped state) and ValidateOnBuild eagerly constructs every registered
+        // service, failing loudly at boot instead of silently at first use. The flags are
+        // inlined rather than sharing Presentation.Common's ApplyValidationPolicy because this
+        // Infrastructure-layer host must not take a Presentation dependency (Clean Architecture).
+        builder.Host.UseDefaultServiceProvider(options =>
+        {
+            options.ValidateScopes = true;
+            options.ValidateOnBuild = true;
+        });
+
         // Bind AppConfig
         builder.Services.Configure<AppConfig>(
             builder.Configuration.GetSection("AppConfig"));

--- a/src/Content/Presentation/Presentation.Common/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Content/Presentation/Presentation.Common/Extensions/IServiceCollectionExtensions.cs
@@ -313,8 +313,9 @@ public static class IServiceCollectionExtensions
     /// the console-style hosts (ConsoleUI, EvalRunner, FoundryHost) apply it through
     /// <see cref="BuildValidatedServiceProvider"/>; the AgentHub web host, which never calls
     /// <c>BuildServiceProvider</c> directly, passes this method to <c>UseDefaultServiceProvider</c>
-    /// on its host builder. (The MCP server host does not yet enforce this policy — see the H2
-    /// follow-up; it composes a separate graph with no assembly-scanned harness handlers.)
+    /// on its host builder. The MCP server host enforces the same two flags but inlines them
+    /// (it composes a separate graph and, as an Infrastructure-layer host, must not take a
+    /// dependency on this Presentation-layer helper).
     /// </remarks>
     public static void ApplyValidationPolicy(ServiceProviderOptions options)
     {

--- a/src/Content/Tests/Infrastructure.AI.MCPServer.Tests/Hosting/McpServerAuthFailClosedTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.MCPServer.Tests/Hosting/McpServerAuthFailClosedTests.cs
@@ -22,6 +22,25 @@ public sealed class McpServerAuthFailClosedTests
     private const string TestApiKey = "test-api-key-not-a-real-secret";
     private const string TestBearerToken = "test-bearer-token-not-a-real-secret";
 
+    // -- Boot-time DI validation (audit item H2) --
+
+    [Fact]
+    public void Start_InProduction_BuildsUnderValidateOnBuild()
+    {
+        // The MCP server enables ValidateScopes + ValidateOnBuild in ALL environments
+        // (Program.cs). This guards that the full host graph — MCP SDK services, auth
+        // handlers, skill registry, rate limiter — is actually constructible under that
+        // policy in Production, where the framework would NOT enable ValidateOnBuild by
+        // default. A missing/captive registration would throw here at host build instead
+        // of surviving to a runtime request. AllowAnonymous keeps the config minimal-valid.
+        using var factory = CreateFactory(new Dictionary<string, string?>
+        {
+            ["AppConfig:AI:MCP:Auth:AllowAnonymous"] = "true"
+        }, environment: "Production");
+
+        factory.Server.Should().NotBeNull();
+    }
+
     // -- Startup fail-closed --
 
     [Theory]


### PR DESCRIPTION
## What & why

Completes audit item **H2** for the last host. PR #162 flipped `ValidateOnBuild` on the four hosts that share the harness composition root. The **MCP server** was deliberately left out: it composes a *separate* `WebApplication` graph (`AddMcpServerServices` + auth + skill registry + rate limiter, **no** assembly-scanned harness MediatR handlers), and I wanted a real boot check before flipping it rather than asserting it blind.

That check is now possible in-process: the MCP test project already boots the real host via `WebApplicationFactory<Program>`. Before this, the MCP server only got `ValidateOnBuild` from the framework's Development-only default — **never in Production**.

## Change
- Enable `ValidateScopes` + `ValidateOnBuild` in **all environments** via `builder.Host.UseDefaultServiceProvider(...)`.
- Flags are **inlined** rather than reusing `Presentation.Common.ApplyValidationPolicy`: this Infrastructure-layer host must not depend on the Presentation layer (Clean Architecture). Corrected that helper's now-stale XML doc accordingly.
- Added a dedicated **Production-environment** guard test — proves the full host graph is constructible where the framework would *not* enable `ValidateOnBuild` by default.

## Verification
- The existing `WebApplicationFactory<Program>` auth boot tests (ApiKey / Bearer / Entra / AllowAnonymous) **now run under `ValidateOnBuild`** — all green, so the MCP graph is validate-clean.
- New explicit guard green. **78 MCP server tests pass**; full solution build **0/0**.

With this, every harness host enforces boot-time DI validation. H2 fully closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)