### PR TITLE
feat: give agents their own instructions (system prompt)

### DIFF
--- a/src/Content/Application/Application.AI.Common/Factories/AgentExecutionContextFactory.cs
+++ b/src/Content/Application/Application.AI.Common/Factories/AgentExecutionContextFactory.cs
@@ -102,7 +102,7 @@ public class AgentExecutionContextFactory
         // PromptComposition is enabled, the authoritative section composer reframes that same skill
         // content with identity + permission-rules sections within a token budget; per-turn dynamic
         // context (session state, memory) stays on the AIContextProvider rail, never baked in here.
-        var instruction = SkillInstructionMerger.Merge(skills, options.AdditionalContext);
+        var instruction = SkillInstructionMerger.Merge(skills, options.AdditionalContext, options.AgentInstructions);
         if (_appConfig.CurrentValue.AI?.ContextManagement?.PromptComposition?.Enabled == true)
             instruction = await ComposeStaticSystemPromptAsync(agentName, instruction);
 

--- a/src/Content/Application/Application.AI.Common/Helpers/SkillInstructionMerger.cs
+++ b/src/Content/Application/Application.AI.Common/Helpers/SkillInstructionMerger.cs
@@ -3,8 +3,8 @@ using Domain.AI.Skills;
 namespace Application.AI.Common.Helpers;
 
 /// <summary>
-/// Single source of truth for how a set of skill definitions and optional additional context are
-/// merged into the agent's static instruction text.
+/// Single source of truth for how optional agent-level instructions, a set of skill definitions, and
+/// optional additional context are merged into the agent's static instruction text.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -21,9 +21,10 @@ namespace Application.AI.Common.Helpers;
 ///   </description></item>
 /// </list>
 /// <para>
-/// A single skill's instructions are emitted verbatim. Multiple skills are each wrapped in a
-/// <c>## Skill: {name}</c> header so the model can tell them apart. Additional context, when present,
-/// is appended as a final block. All blocks are joined by a blank line.
+/// Block order: the agent's own instructions (when supplied) lead, ahead of every skill — they are the
+/// agent's system prompt. A single skill's instructions are then emitted verbatim; multiple skills are
+/// each wrapped in a <c>## Skill: {name}</c> header so the model can tell them apart. Additional context,
+/// when present, is appended as a final block. All blocks are joined by a blank line.
 /// </para>
 /// </remarks>
 public static class SkillInstructionMerger
@@ -36,15 +37,25 @@ public static class SkillInstructionMerger
     /// <param name="additionalContext">
     /// Optional extra context appended after all skill instructions; ignored when null or empty.
     /// </param>
+    /// <param name="agentInstructions">
+    /// Optional agent-level instructions (the agent's own system prompt). When present, they lead the
+    /// merged text ahead of every skill; ignored when null or whitespace.
+    /// </param>
     /// <returns>
-    /// The merged instruction text, or an empty string when no skill carries instructions and no
-    /// additional context is supplied.
+    /// The merged instruction text, or an empty string when no agent instructions, skill instructions,
+    /// or additional context are supplied.
     /// </returns>
-    public static string Merge(IReadOnlyList<SkillDefinition> skills, string? additionalContext)
+    public static string Merge(
+        IReadOnlyList<SkillDefinition> skills,
+        string? additionalContext,
+        string? agentInstructions = null)
     {
         ArgumentNullException.ThrowIfNull(skills);
 
         var parts = new List<string>();
+
+        if (!string.IsNullOrWhiteSpace(agentInstructions))
+            parts.Add(agentInstructions);
 
         foreach (var skill in skills)
         {

--- a/src/Content/Application/Application.Core/CQRS/Agents/ExecuteAgentTurn/ExecuteAgentTurnCommandHandler.cs
+++ b/src/Content/Application/Application.Core/CQRS/Agents/ExecuteAgentTurn/ExecuteAgentTurnCommandHandler.cs
@@ -98,6 +98,7 @@ public class ExecuteAgentTurnCommandHandler : IRequestHandler<ExecuteAgentTurnCo
 				new SkillAgentOptions
 				{
 					AdditionalContext = request.SystemPromptOverride,
+					AgentInstructions = agentDef?.Instructions,
 					DeploymentName = request.DeploymentOverride,
 					Temperature = request.Temperature,
 				},

--- a/src/Content/Domain/Domain.AI/Agents/AgentDefinition.cs
+++ b/src/Content/Domain/Domain.AI/Agents/AgentDefinition.cs
@@ -45,6 +45,13 @@ public sealed record AgentDefinition
     /// </summary>
     public IReadOnlyList<string> Skills { get; init; } = [];
 
+    /// <summary>
+    /// The agent's own instructions — the markdown body of the <c>AGENT.md</c> file, below the YAML
+    /// frontmatter. This is the agent's system prompt and leads the final instruction text, ahead of
+    /// the instructions contributed by its skills. Null when the <c>AGENT.md</c> has no body.
+    /// </summary>
+    public string? Instructions { get; init; }
+
     /// <summary>Absolute path to the source <c>AGENT.md</c> file.</summary>
     public string FilePath { get; init; } = string.Empty;
 

--- a/src/Content/Domain/Domain.AI/Skills/SkillAgentOptions.cs
+++ b/src/Content/Domain/Domain.AI/Skills/SkillAgentOptions.cs
@@ -54,6 +54,13 @@ public sealed record SkillAgentOptions
 	public string? AdditionalContext { get; init; }
 
 	/// <summary>
+	/// The agent's own instructions (its system prompt), sourced from the <c>AGENT.md</c> body.
+	/// When present, they lead the merged instruction text ahead of every skill. Null when the
+	/// agent is invoked by a bare skill id with no owning <c>AGENT.md</c>.
+	/// </summary>
+	public string? AgentInstructions { get; init; }
+
+	/// <summary>
 	/// Override the sampling temperature for the underlying chat client.
 	/// When null, the provider default is used.
 	/// </summary>

--- a/src/Content/Infrastructure/Infrastructure.AI/Agents/AgentMetadataParser.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Agents/AgentMetadataParser.cs
@@ -33,7 +33,7 @@ public sealed class AgentMetadataParser
     public AgentDefinition ParseFromFile(string agentFilePath, string baseDirectory)
     {
         var raw = File.ReadAllText(agentFilePath);
-        var (yaml, _) = YamlFrontmatterHelper.ExtractFrontmatter(raw);
+        var (yaml, body) = YamlFrontmatterHelper.ExtractFrontmatter(raw);
 
         if (string.IsNullOrWhiteSpace(yaml))
             _logger.LogWarning("AGENT.md at {Path} has no YAML frontmatter; falling back to folder-name identity", agentFilePath);
@@ -52,6 +52,11 @@ public sealed class AgentMetadataParser
             Author = ParseString(yaml, "author"),
             Tags = ParseList(yaml, "tags"),
             Skills = ParseSkills(yaml),
+            // Only trust the body as instructions when frontmatter actually parsed. When `yaml` is
+            // empty the frontmatter was absent or malformed (already warned above), and ExtractFrontmatter
+            // returns the whole file as `body` — capturing that would leak the raw `---`/YAML lines into
+            // the agent's system prompt.
+            Instructions = string.IsNullOrWhiteSpace(yaml) || string.IsNullOrWhiteSpace(body) ? null : body.Trim(),
             FilePath = agentFilePath,
             BaseDirectory = baseDirectory,
             LoadedAt = DateTime.UtcNow,

--- a/src/Content/Tests/Application.AI.Common.Tests/Helpers/SkillInstructionMergerTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Helpers/SkillInstructionMergerTests.cs
@@ -1,0 +1,71 @@
+using Application.AI.Common.Helpers;
+using Domain.AI.Skills;
+using FluentAssertions;
+using Xunit;
+
+namespace Application.AI.Common.Tests.Helpers;
+
+/// <summary>
+/// Unit tests for <see cref="SkillInstructionMerger"/>. Covers agent-level instruction
+/// precedence (the agent's own system prompt leads the merged text) and the backward-compatible
+/// skill-only behaviour when no agent instructions are supplied.
+/// </summary>
+public sealed class SkillInstructionMergerTests
+{
+    private static SkillDefinition Skill(string name, string? instructions) =>
+        new() { Id = name, Name = name, Instructions = instructions };
+
+    [Fact]
+    public void Merge_WithAgentInstructions_PrependsThemAheadOfSkillContent()
+    {
+        var skills = new[] { Skill("Researcher", "Do the research.") };
+
+        var merged = SkillInstructionMerger.Merge(
+            skills, additionalContext: null, agentInstructions: "You are a careful analyst.");
+
+        merged.Should().StartWith("You are a careful analyst.");
+        merged.Should().Contain("Do the research.");
+        merged.IndexOf("You are a careful analyst.", StringComparison.Ordinal)
+            .Should().BeLessThan(
+                merged.IndexOf("Do the research.", StringComparison.Ordinal),
+                "the agent's own instructions must lead the merged system prompt, ahead of its skills");
+    }
+
+    [Fact]
+    public void Merge_WithoutAgentInstructions_PreservesSkillOnlyBehaviour()
+    {
+        var skills = new[] { Skill("Researcher", "Do the research.") };
+
+        var merged = SkillInstructionMerger.Merge(skills, additionalContext: null);
+
+        merged.Should().Be("Do the research.");
+    }
+
+    [Fact]
+    public void Merge_AgentInstructionsWithMultipleSkills_LeadsThenHeaderedSkills()
+    {
+        var skills = new[]
+        {
+            Skill("Alpha", "Alpha body."),
+            Skill("Beta", "Beta body."),
+        };
+
+        var merged = SkillInstructionMerger.Merge(
+            skills, additionalContext: null, agentInstructions: "Agent lead.");
+
+        merged.Should().StartWith("Agent lead.");
+        merged.Should().Contain("## Skill: Alpha");
+        merged.Should().Contain("## Skill: Beta");
+    }
+
+    [Fact]
+    public void Merge_EmptyAgentInstructions_IsIgnored()
+    {
+        var skills = new[] { Skill("Researcher", "Do the research.") };
+
+        var merged = SkillInstructionMerger.Merge(
+            skills, additionalContext: null, agentInstructions: "   ");
+
+        merged.Should().Be("Do the research.");
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Agents/AgentMetadataParserTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Agents/AgentMetadataParserTests.cs
@@ -175,6 +175,63 @@ public sealed class AgentMetadataParserTests : IDisposable
     }
 
     [Fact]
+    public void ParseFromFile_WithBody_CapturesBodyAsInstructions()
+    {
+        var dir = WriteAgent("with-body", """
+            ---
+            name: bodied-agent
+            ---
+
+            You are a specialist research agent.
+            Follow these rules carefully.
+            """);
+
+        var definition = CreateParser().ParseFromFile(Path.Combine(dir, "AGENT.md"), dir);
+
+        definition.Instructions.Should().NotBeNull();
+        definition.Instructions.Should().Contain("You are a specialist research agent.");
+        definition.Instructions.Should().Contain("Follow these rules carefully.");
+    }
+
+    [Fact]
+    public void ParseFromFile_NoFrontmatter_LeavesInstructionsNull()
+    {
+        // No frontmatter: ExtractFrontmatter returns the whole file as the body. It must NOT become
+        // the agent's instructions, or a malformed AGENT.md would leak its raw content into the prompt.
+        var dir = WriteAgent("raw-body", "# Raw markdown\nNo frontmatter here.");
+
+        var definition = CreateParser().ParseFromFile(Path.Combine(dir, "AGENT.md"), dir);
+
+        definition.Instructions.Should().BeNull();
+    }
+
+    [Fact]
+    public void ParseFromFile_MalformedFrontmatter_DoesNotLeakYamlIntoInstructions()
+    {
+        // Opening delimiter but no closing one: frontmatter parsing fails (empty yaml). The raw
+        // `---`/`name:` lines must not surface as instructions.
+        var dir = WriteAgent("unclosed", "---\nname: unclosed-agent\nskills: [x]\n\nBody text.");
+
+        var definition = CreateParser().ParseFromFile(Path.Combine(dir, "AGENT.md"), dir);
+
+        definition.Instructions.Should().BeNull();
+    }
+
+    [Fact]
+    public void ParseFromFile_WithoutBody_LeavesInstructionsNull()
+    {
+        var dir = WriteAgent("no-body", """
+            ---
+            name: bare-agent
+            ---
+            """);
+
+        var definition = CreateParser().ParseFromFile(Path.Combine(dir, "AGENT.md"), dir);
+
+        definition.Instructions.Should().BeNull();
+    }
+
+    [Fact]
     public void ParseFromFile_LegacySkillSingular_ParsesAsSingleElementList()
     {
         var dir = WriteAgent("legacy-skill", """


### PR DESCRIPTION
## What & why

**CM-PR1 of the agent-promotion pass** (foundation for issue #154 — "inject & run agent bundles via API"). Today `AgentDefinition` is pure metadata + a list of skill ids, and the `AGENT.md` body is parsed and **discarded** — an agent's entire system prompt comes from its skills. This is the "hollow agent" gap: unlike Claude subagents, our agent has no voice of its own.

This PR makes the agent first-class on the instruction axis: the `AGENT.md` body becomes the agent's own system prompt and **leads** the merged text, ahead of every skill.

## Changes
- `AgentDefinition` gains `Instructions` (the `AGENT.md` body).
- `AgentMetadataParser` captures the body — but only when frontmatter actually parsed, so a malformed/absent-frontmatter file can't leak raw `---`/YAML lines into the prompt.
- Threaded via a new `SkillAgentOptions.AgentInstructions` (sibling of the existing `AdditionalContext`) into `SkillInstructionMerger`, which prepends it as the leading block.
- `ExecuteAgentTurnCommandHandler` populates it from the resolved `AgentDefinition` (null on the bare-skill-id fallback path).

Additive and backward-compatible: agents invoked by a bare skill id keep identical behavior; the new merger param and options property both default to null. Works on both the default merge path and the prompt-composer path (the composer reuses the merged text, so nothing is dropped).

## Review
Ran `/code-review` (high) + `/simplify`:
- **Fixed (correctness):** malformed/no-frontmatter `AGENT.md` would have leaked raw YAML into the system prompt — now yaml-gated, with 2 regression tests.
- **Fixed (docs):** stale `SkillInstructionMerger` class doc updated for the new leading-agent-instructions contract.
- `/simplify`: clean, no changes; altitude confirmed right-depth.
- Deferred (follow-up, not a bug): under the prompt-composer, agent instructions ride inside the (un-truncatable, `IsRequired`) skill-instructions section rather than a distinct agent-identity section.

## Test plan
- `dotnet build src/AgenticHarness.slnx` → clean, 0 warnings.
- New: 4 `SkillInstructionMergerTests` (lead order, skill-only backward-compat, multi-skill headers, whitespace ignored) + 4 `AgentMetadataParserTests` (body captured; no-body/no-frontmatter/malformed → null).
- `Application.AI.Common.Tests` 1330/1330; `Infrastructure.AI.Tests` parser suite 13/13 green. (3 pre-existing `FileSystemService` write-test failures are environmental — this machine's TEMP is under `C:\WINDOWS\TEMP`, which the service blocklists — unrelated to this diff.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)