### PR TITLE
feat: enforce agent tool ceiling (CM-PR2)

### DIFF
--- a/src/Content/Application/Application.AI.Common/Factories/AgentExecutionContextFactory.cs
+++ b/src/Content/Application/Application.AI.Common/Factories/AgentExecutionContextFactory.cs
@@ -84,7 +84,11 @@ public class AgentExecutionContextFactory
     /// </summary>
     /// <param name="skills">The skill definitions to merge.</param>
     /// <param name="options">Configuration for resource loading and agent overrides.</param>
-    /// <param name="allowedTools">Optional tool allowlist applied after merge — only tools with matching names are kept.</param>
+    /// <param name="allowedTools">
+    /// Optional explicit per-call tool ceiling, applied on top of the skills' allowlist and the agent's
+    /// declared ceiling. It can only tighten (never widen) the effective set. <see langword="null"/> or
+    /// empty means "no extra ceiling from this call"; a non-empty list caps the agent to the intersection.
+    /// </param>
     public virtual async Task<AgentExecutionContext> MapToAgentContextAsync(
         IReadOnlyList<SkillDefinition> skills,
         SkillAgentOptions options,
@@ -106,10 +110,15 @@ public class AgentExecutionContextFactory
         if (_appConfig.CurrentValue.AI?.ContextManagement?.PromptComposition?.Enabled == true)
             instruction = await ComposeStaticSystemPromptAsync(agentName, instruction);
 
-        var mergedToolChain = await _toolChainBuilder.BuildMergedToolsWithSourcesAsync(skills, options, allowedTools);
+        // Agent tool ceiling. Resolve the one effective allowlist that governs this agent (see
+        // ResolveEffectiveAllowlist) and drive BOTH enforcement points with it — the merge-time tool
+        // filter and the runtime ToolPermissionFilter — so they can never disagree. null means no
+        // restriction (every tool passes); a non-null list is an active restriction (empty = deny all).
+        var effectiveAllowedTools = ResolveEffectiveAllowlist(skills, options, allowedTools);
+        var mergedToolChain = await _toolChainBuilder.BuildMergedToolsWithSourcesAsync(skills, options, effectiveAllowedTools);
         var tools = mergedToolChain.Tools.ToList();
         var middlewareTypes = ResolveMiddlewareTypes(primarySkill, options);
-        var aiContextProviders = BuildMergedAIContextProviders(skills, options);
+        var aiContextProviders = BuildMergedAIContextProviders(skills, options, effectiveAllowedTools);
         var frameworkType = options.FrameworkType
             ?? ResolveFrameworkTypeFromMetadata(primarySkill)
             ?? _appConfig.CurrentValue.AI?.AgentFramework?.ClientType
@@ -349,12 +358,49 @@ public class AgentExecutionContextFactory
     }
 
     /// <summary>
+    /// Resolves the single effective tool allowlist that governs an agent: the union of its skills'
+    /// <c>AllowedTools</c> constraints, capped by the agent's declared ceiling (<paramref name="options"/>'s
+    /// <see cref="SkillAgentOptions.AllowedTools"/>) and then by any explicit per-call
+    /// <paramref name="explicitAllowlist"/>. Each cap can only tighten (see <see cref="ToolCeilingResolver"/>).
+    /// Returns <see langword="null"/> when nothing restricts the agent (every tool is permitted); a
+    /// non-null list is an active restriction, and an empty one denies every tool.
+    /// </summary>
+    private static IReadOnlyList<string>? ResolveEffectiveAllowlist(
+        IReadOnlyList<SkillDefinition> skills,
+        SkillAgentOptions options,
+        IReadOnlyList<string>? explicitAllowlist)
+    {
+        var effective = ToolCeilingResolver.ApplyCeiling(MergeSkillAllowedTools(skills), options.AllowedTools);
+        return ToolCeilingResolver.ApplyCeiling(effective, explicitAllowlist);
+    }
+
+    /// <summary>
+    /// Deduplicated union of every skill's <c>AllowedTools</c> constraint, case-insensitively, or
+    /// <see langword="null"/> when no skill declares a constraint — the "unbounded" input the ceiling
+    /// resolver expects for "no restriction" (distinct from an empty list, which means deny all).
+    /// </summary>
+    private static IReadOnlyList<string>? MergeSkillAllowedTools(IReadOnlyList<SkillDefinition> skills)
+    {
+        var union = skills
+            .Where(s => s.AllowedTools?.Count > 0)
+            .SelectMany(s => s.AllowedTools!)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        return union.Count > 0 ? union : null;
+    }
+
+    /// <summary>
     /// Unions context providers from all skills. Skill paths are resolved once (from options or config).
-    /// AllowedTools constraints from all skills are merged into a single <see cref="Services.Agent.ToolPermissionFilter"/>.
+    /// The <paramref name="effectiveAllowlist"/> (the skills' combined constraint already capped by any
+    /// agent tool ceiling) drives a single <see cref="Services.Agent.ToolPermissionFilter"/>. It is
+    /// <see langword="null"/> when no restriction is active (no filter is wired), or a concrete set —
+    /// possibly empty, meaning deny-all — when a restriction applies.
     /// </summary>
     private IList<AIContextProvider>? BuildMergedAIContextProviders(
         IReadOnlyList<SkillDefinition> skills,
-        SkillAgentOptions options)
+        SkillAgentOptions options,
+        IReadOnlyList<string>? effectiveAllowlist)
     {
         var providers = new List<AIContextProvider>();
 
@@ -371,18 +417,12 @@ public class AgentExecutionContextFactory
             _logger.LogDebug("Wired AgentSkillsProvider with {PathCount} path(s)", skillPaths.Count);
         }
 
-        var allAllowedTools = skills
-            .Where(s => s.AllowedTools?.Count > 0)
-            .SelectMany(s => s.AllowedTools!)
-            .Distinct(StringComparer.OrdinalIgnoreCase)
-            .ToList();
-
-        if (allAllowedTools.Count > 0)
+        if (effectiveAllowlist is not null)
         {
-            providers.Add(new Services.Agent.ToolPermissionFilter(allAllowedTools));
+            providers.Add(new Services.Agent.ToolPermissionFilter(effectiveAllowlist));
 
-            _logger.LogDebug("Wired ToolPermissionFilter with {Count} allowed tool(s) from {SkillCount} skill(s)",
-                allAllowedTools.Count, skills.Count);
+            _logger.LogDebug("Wired ToolPermissionFilter with {Count} allowed tool(s) for {SkillCount} skill(s)",
+                effectiveAllowlist.Count, skills.Count);
         }
 
         // Cross-session memory recall. The provider resolves tenant-aware IKnowledgeMemory per

--- a/src/Content/Application/Application.AI.Common/Helpers/ToolCeilingResolver.cs
+++ b/src/Content/Application/Application.AI.Common/Helpers/ToolCeilingResolver.cs
@@ -1,0 +1,78 @@
+namespace Application.AI.Common.Helpers;
+
+/// <summary>
+/// Resolves the effective tool allowlist for an agent by applying its declared tool <em>ceiling</em>
+/// to the allowlist its skills already grant. This is the single, security-critical primitive behind
+/// the agent tool ceiling: a ceiling can only ever <em>tighten</em> the set of tools an agent may
+/// invoke — it can never widen it.
+/// </summary>
+/// <remarks>
+/// <para>
+/// An agent's <c>allowed-tools</c> frontmatter is a request for an upper bound, not a grant. The tools
+/// an agent can actually use are the ones its skills contribute; the ceiling can remove tools from that
+/// set but never add one the skills did not already permit. This mirrors how a bundle's self-declared
+/// capabilities are only <em>requests</em> against a host-granted envelope — the same tighten-only
+/// posture applied one level down, at the agent/skill boundary.
+/// </para>
+/// <para>
+/// A bare <c>IReadOnlyList&lt;string&gt;</c> cannot distinguish "no restriction at all" from "a
+/// restriction that happens to permit nothing", and conflating the two is a privilege-escalation bug:
+/// once an intersection has narrowed to nothing, a later ceiling must NOT be able to re-grant tools.
+/// So this primitive uses <see langword="null"/> for <em>unbounded</em> (no restriction) and a non-null
+/// list — <em>including an empty one</em> — for <em>bounded</em> (empty = deny all). With that
+/// distinction the operation is a monotone intersection that is always safe to chain: applying more
+/// ceilings can only ever shrink the set.
+/// </para>
+/// </remarks>
+public static class ToolCeilingResolver
+{
+    /// <summary>
+    /// Caps <paramref name="current"/> by an optional tool <paramref name="ceiling"/>, tighten-only.
+    /// </summary>
+    /// <param name="current">
+    /// The allowlist granted so far. <see langword="null"/> means <em>unbounded</em> (no restriction —
+    /// every tool is permitted); a non-null list is an active restriction, and an empty one denies all.
+    /// </param>
+    /// <param name="ceiling">
+    /// The ceiling to apply. When null or empty the ceiling is absent and <paramref name="current"/> is
+    /// returned unchanged.
+    /// </param>
+    /// <returns>
+    /// <list type="bullet">
+    ///   <item><description>
+    ///     <paramref name="current"/> unchanged when the ceiling is null or empty (no ceiling declared).
+    ///   </description></item>
+    ///   <item><description>
+    ///     the ceiling (de-duplicated) when <paramref name="current"/> is <see langword="null"/> — a
+    ///     ceiling caps an otherwise-unbounded allowlist.
+    ///   </description></item>
+    ///   <item><description>
+    ///     otherwise the intersection of the two (a subset of <paramref name="current"/>, order
+    ///     preserved). An empty intersection is a genuine deny-all and is preserved, so chaining another
+    ///     ceiling onto it can never re-grant a tool.
+    ///   </description></item>
+    /// </list>
+    /// Comparison is case-insensitive and the result is de-duplicated.
+    /// </returns>
+    public static IReadOnlyList<string>? ApplyCeiling(
+        IReadOnlyList<string>? current,
+        IReadOnlyList<string>? ceiling)
+    {
+        // No ceiling declared: whatever restriction `current` carries (including none) stands unchanged.
+        if (ceiling is null || ceiling.Count == 0)
+            return current;
+
+        // Unbounded so far: the ceiling alone becomes the allowlist (a tightening from "everything").
+        if (current is null)
+            return ceiling.Distinct(StringComparer.OrdinalIgnoreCase).ToList();
+
+        // Both bounded: intersect. The result is always a subset of `current`, so the ceiling can never
+        // grant a tool the current allowlist did not already permit. An empty result stays empty
+        // (deny all) and remains a subset under any further ceiling — the invariant that makes chaining safe.
+        var cap = new HashSet<string>(ceiling, StringComparer.OrdinalIgnoreCase);
+        return current
+            .Where(cap.Contains)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+}

--- a/src/Content/Application/Application.AI.Common/Interfaces/Tools/IToolChainBuilder.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Tools/IToolChainBuilder.cs
@@ -31,7 +31,11 @@ public interface IToolChainBuilder
     /// </summary>
     /// <param name="skills">The skill definitions to merge tools from.</param>
     /// <param name="options">Options providing additional tools and overrides.</param>
-    /// <param name="allowedTools">Optional tool allowlist — only tools with matching names are kept.</param>
+    /// <param name="allowedTools">
+    /// Optional tool allowlist. <see langword="null"/> means no restriction (every resolved tool is
+    /// kept); a non-null list keeps only tools with matching names, so an empty (but non-null) list
+    /// keeps nothing (deny all).
+    /// </param>
     /// <param name="cancellationToken">
     /// Cancels tool resolution. Implementations perform network I/O against MCP servers, so a
     /// hung or slow server must not block agent construction past caller cancellation.
@@ -51,7 +55,11 @@ public interface IToolChainBuilder
     /// </summary>
     /// <param name="skills">The skill definitions to merge tools from.</param>
     /// <param name="options">Options providing additional tools and overrides.</param>
-    /// <param name="allowedTools">Optional tool allowlist — only tools with matching names are kept.</param>
+    /// <param name="allowedTools">
+    /// Optional tool allowlist. <see langword="null"/> means no restriction (every resolved tool is
+    /// kept); a non-null list keeps only tools with matching names, so an empty (but non-null) list
+    /// keeps nothing (deny all).
+    /// </param>
     /// <param name="cancellationToken">
     /// Cancels tool resolution. Implementations perform network I/O against MCP servers, so a
     /// hung or slow server must not block agent construction past caller cancellation.

--- a/src/Content/Application/Application.AI.Common/Services/Agent/ToolPermissionFilter.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Agent/ToolPermissionFilter.cs
@@ -4,10 +4,9 @@ using Microsoft.Extensions.AI;
 namespace Application.AI.Common.Services.Agent;
 
 /// <summary>
-/// An <see cref="AIContextProvider"/> that enforces a per-skill allowed-tools constraint on
-/// every agent invocation. Any tool not in the allow-list is stripped from the accumulated
-/// <see cref="AIContext"/> before the model is called, ensuring an agent can only see —
-/// and invoke — the tools its skill declaration explicitly permits.
+/// An <see cref="AIContextProvider"/> that enforces an allowed-tools constraint on every agent
+/// invocation. Any tool not in the allow-list is stripped from the accumulated <see cref="AIContext"/>
+/// before the model is called, ensuring an agent can only see — and invoke — the tools it is permitted.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -16,37 +15,55 @@ namespace Application.AI.Common.Services.Agent;
 /// framework tools surfaced by progressive skill disclosure.
 /// </para>
 /// <para>
-/// When the allow-list is empty the filter is a no-op: all tools pass through unchanged.
-/// Tool name comparison is case-insensitive.
+/// The allow-list distinguishes two states that a bare empty collection cannot. A <see langword="null"/>
+/// allow-list means <em>no restriction</em> — every tool passes through; callers that want no filter
+/// should simply not register this provider (or pass null). A non-null allow-list — <em>including an
+/// empty one</em> — is an active restriction: only the listed tools survive, and an empty list therefore
+/// denies every tool. This is what lets an agent tool ceiling that is disjoint from the skills' tools
+/// leave the agent with no tools rather than accidentally granting all of them. Tool name comparison
+/// is case-insensitive.
 /// </para>
 /// </remarks>
 public class ToolPermissionFilter : AIContextProvider
 {
-    private readonly IReadOnlySet<string> _allowedTools;
+    private readonly IReadOnlySet<string>? _allowedTools;
 
     /// <summary>
     /// Initializes a new <see cref="ToolPermissionFilter"/> that restricts invocations to
     /// the specified tool names.
     /// </summary>
     /// <param name="allowedTools">
-    /// The set of tool names the agent may use. An empty collection means no restriction.
+    /// The set of tool names the agent may use. <see langword="null"/> means no restriction (every
+    /// tool passes through). A non-null collection is an active restriction — only these tools survive,
+    /// and an empty collection denies every tool.
     /// </param>
-    public ToolPermissionFilter(IEnumerable<string> allowedTools)
+    public ToolPermissionFilter(IEnumerable<string>? allowedTools)
         : base(
             provideInputMessageFilter: messages => messages,
             storeInputRequestMessageFilter: messages => messages,
             storeInputResponseMessageFilter: messages => messages)
     {
-        _allowedTools = new HashSet<string>(allowedTools, StringComparer.OrdinalIgnoreCase);
+        _allowedTools = allowedTools is null
+            ? null
+            : new HashSet<string>(allowedTools, StringComparer.OrdinalIgnoreCase);
     }
+
+    /// <summary>
+    /// The set of tool names this filter permits, or <see langword="null"/> when the filter imposes no
+    /// restriction. A non-null (possibly empty) set is an active restriction. Exposed read-only so
+    /// callers and tests can observe the effective allowlist wired onto an agent (for example, the
+    /// agent tool ceiling intersected with its skills' allowlists).
+    /// </summary>
+    public IReadOnlySet<string>? AllowedTools => _allowedTools;
 
     /// <inheritdoc />
     protected override ValueTask<AIContext> ProvideAIContextAsync(
         InvokingContext context,
         CancellationToken cancellationToken = default)
     {
-        // No restriction when allow-list is empty — pass context through unchanged
-        if (_allowedTools.Count == 0)
+        // No restriction — pass context through unchanged. An empty (but non-null) allow-list is NOT
+        // this case: it is an active restriction that denies every tool.
+        if (_allowedTools is null)
             return ValueTask.FromResult(context.AIContext);
 
         var allTools = context.AIContext.Tools?.ToList();

--- a/src/Content/Application/Application.AI.Common/Services/Tools/ToolChainBuilder.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/ToolChainBuilder.cs
@@ -169,7 +169,10 @@ public class ToolChainBuilder : IToolChainBuilder
         var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         var deduplicated = allTools.Where(t => seen.Add(t.Name)).ToList();
 
-        if (allowedTools is { Count: > 0 })
+        // A null allowlist means no restriction; a non-null one is an active restriction that keeps
+        // only the listed tools — an empty (but non-null) list therefore denies every tool, which is
+        // how an agent tool ceiling disjoint from the skills' tools collapses to no tools rather than all.
+        if (allowedTools is not null)
         {
             var allowed = new HashSet<string>(allowedTools, StringComparer.OrdinalIgnoreCase);
             deduplicated = deduplicated.Where(t => allowed.Contains(t.Name)).ToList();

--- a/src/Content/Application/Application.Core/CQRS/Agents/ExecuteAgentTurn/ExecuteAgentTurnCommandHandler.cs
+++ b/src/Content/Application/Application.Core/CQRS/Agents/ExecuteAgentTurn/ExecuteAgentTurnCommandHandler.cs
@@ -99,6 +99,7 @@ public class ExecuteAgentTurnCommandHandler : IRequestHandler<ExecuteAgentTurnCo
 				{
 					AdditionalContext = request.SystemPromptOverride,
 					AgentInstructions = agentDef?.Instructions,
+					AllowedTools = agentDef?.AllowedTools,
 					DeploymentName = request.DeploymentOverride,
 					Temperature = request.Temperature,
 				},

--- a/src/Content/Domain/Domain.AI/Agents/AgentDefinition.cs
+++ b/src/Content/Domain/Domain.AI/Agents/AgentDefinition.cs
@@ -52,6 +52,16 @@ public sealed record AgentDefinition
     /// </summary>
     public string? Instructions { get; init; }
 
+    /// <summary>
+    /// The agent's tool ceiling — the allowlist declared in the <c>allowed-tools</c> frontmatter of
+    /// <c>AGENT.md</c>. Acts as an upper bound: the agent may invoke a tool only when it appears here
+    /// <em>and</em> is granted by one of its skills. The ceiling can only ever <em>tighten</em> the
+    /// skills' combined allowlist, never widen it — a tool listed here but not granted by any skill
+    /// stays unavailable. Empty when the agent declares no ceiling, in which case the skills' own
+    /// allowlists govern unchanged. Populated from the <c>allowed-tools:</c> frontmatter list.
+    /// </summary>
+    public IReadOnlyList<string> AllowedTools { get; init; } = [];
+
     /// <summary>Absolute path to the source <c>AGENT.md</c> file.</summary>
     public string FilePath { get; init; } = string.Empty;
 

--- a/src/Content/Domain/Domain.AI/Skills/SkillAgentOptions.cs
+++ b/src/Content/Domain/Domain.AI/Skills/SkillAgentOptions.cs
@@ -61,6 +61,15 @@ public sealed record SkillAgentOptions
 	public string? AgentInstructions { get; init; }
 
 	/// <summary>
+	/// The agent's tool ceiling (its declared <c>allowed-tools</c>), sourced from
+	/// <c>AgentDefinition.AllowedTools</c>. When non-empty it caps the tools the agent may use to the
+	/// intersection with its skills' combined allowlist — it can only tighten, never widen. Null or
+	/// empty when the agent declares no ceiling, in which case the skills' own allowlists govern
+	/// unchanged.
+	/// </summary>
+	public IReadOnlyList<string>? AllowedTools { get; init; }
+
+	/// <summary>
 	/// Override the sampling temperature for the underlying chat client.
 	/// When null, the provider default is used.
 	/// </summary>

--- a/src/Content/Infrastructure/Infrastructure.AI/Agents/AgentMetadataParser.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Agents/AgentMetadataParser.cs
@@ -52,6 +52,7 @@ public sealed class AgentMetadataParser
             Author = ParseString(yaml, "author"),
             Tags = ParseList(yaml, "tags"),
             Skills = ParseSkills(yaml),
+            AllowedTools = ParseList(yaml, "allowed-tools"),
             // Only trust the body as instructions when frontmatter actually parsed. When `yaml` is
             // empty the frontmatter was absent or malformed (already warned above), and ExtractFrontmatter
             // returns the whole file as `body` — capturing that would leak the raw `---`/YAML lines into

--- a/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentExecutionContextFactoryToolCeilingTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentExecutionContextFactoryToolCeilingTests.cs
@@ -1,0 +1,136 @@
+using Application.AI.Common.Factories;
+using Application.AI.Common.Services.Agent;
+using Application.AI.Common.Services.Skills;
+using Application.AI.Common.Services.Tools;
+using Domain.AI.Skills;
+using Domain.Common.Config;
+using Domain.Common.Config.AI;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Application.AI.Common.Tests.Factories;
+
+/// <summary>
+/// Tests that the agent tool ceiling declared on <see cref="SkillAgentOptions.AllowedTools"/> reaches
+/// the runtime <see cref="ToolPermissionFilter"/> as the intersection with the skills' combined
+/// allowlist. Complements <c>ToolCeilingResolverTests</c> (which proves the tighten-only invariant on
+/// the pure primitive) by proving the factory actually wires that invariant onto the agent.
+/// </summary>
+public sealed class AgentExecutionContextFactoryToolCeilingTests
+{
+    private readonly AgentExecutionContextFactory _factory;
+
+    public AgentExecutionContextFactoryToolCeilingTests()
+    {
+        var appConfig = new AppConfig
+        {
+            AI = new AIConfig
+            {
+                AgentFramework = new AgentFrameworkConfig
+                {
+                    DefaultDeployment = "gpt-4o",
+                    ClientType = AIAgentFrameworkClientType.AzureOpenAI
+                }
+            }
+        };
+        var monitor = Mock.Of<IOptionsMonitor<AppConfig>>(m => m.CurrentValue == appConfig);
+        var sp = new ServiceCollection().BuildServiceProvider();
+
+        _factory = new AgentExecutionContextFactory(
+            NullLogger<AgentExecutionContextFactory>.Instance,
+            monitor,
+            sp,
+            NullLoggerFactory.Instance,
+            new ToolChainBuilder(NullLogger<ToolChainBuilder>.Instance, sp),
+            new SkillPrerequisiteResolver());
+    }
+
+    private static SkillDefinition Skill(string id, params string[] allowedTools) => new()
+    {
+        Id = id,
+        Name = id,
+        Instructions = $"Instructions for {id}",
+        AllowedTools = allowedTools.Length > 0 ? allowedTools : null
+    };
+
+    private static ToolPermissionFilter? GetFilter(Domain.AI.Agents.AgentExecutionContext context) =>
+        context.AIContextProviders?.OfType<ToolPermissionFilter>().SingleOrDefault();
+
+    [Fact]
+    public async Task Ceiling_NarrowsSkillUnion_FilterHoldsIntersection()
+    {
+        var skills = new[] { Skill("s", "read", "write", "delete") };
+        var options = new SkillAgentOptions { AllowedTools = ["read", "write"] };
+
+        var context = await _factory.MapToAgentContextAsync(skills, options);
+
+        GetFilter(context)!.AllowedTools.Should().BeEquivalentTo(["read", "write"]);
+    }
+
+    [Fact]
+    public async Task Ceiling_NamesToolSkillsDoNotGrant_FilterNeverWidens()
+    {
+        var skills = new[] { Skill("s", "read", "write") };
+        var options = new SkillAgentOptions { AllowedTools = ["read", "write", "delete"] };
+
+        var context = await _factory.MapToAgentContextAsync(skills, options);
+
+        var filter = GetFilter(context)!;
+        filter.AllowedTools.Should().BeEquivalentTo(["read", "write"]);
+        filter.AllowedTools.Should().NotContain("delete");
+    }
+
+    [Fact]
+    public async Task Ceiling_OnSkillThatDeclaredNoRestriction_CapsToCeiling()
+    {
+        // The skill imposes no allowlist (all tools flow through). Declaring an agent ceiling must still
+        // cap the agent — a ToolPermissionFilter appears where there was none, holding exactly the ceiling.
+        var skills = new[] { Skill("open") };
+        var options = new SkillAgentOptions { AllowedTools = ["read"] };
+
+        var context = await _factory.MapToAgentContextAsync(skills, options);
+
+        GetFilter(context)!.AllowedTools.Should().BeEquivalentTo(["read"]);
+    }
+
+    [Fact]
+    public async Task NoCeiling_WithSkillAllowlist_FilterEqualsSkillUnion()
+    {
+        // Backward compatibility: with no agent ceiling the filter is exactly the skills' union.
+        var skills = new[] { Skill("a", "read"), Skill("b", "write") };
+        var options = new SkillAgentOptions();
+
+        var context = await _factory.MapToAgentContextAsync(skills, options);
+
+        GetFilter(context)!.AllowedTools.Should().BeEquivalentTo(["read", "write"]);
+    }
+
+    [Fact]
+    public async Task NoCeiling_SkillsUnrestricted_NoFilterWired()
+    {
+        // Backward compatibility: no ceiling and no skill allowlist means no ToolPermissionFilter at all.
+        var skills = new[] { Skill("open") };
+        var options = new SkillAgentOptions();
+
+        var context = await _factory.MapToAgentContextAsync(skills, options);
+
+        GetFilter(context).Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Ceiling_DisjointFromSkillUnion_FilterIsEmptyAndStripsEverything()
+    {
+        var skills = new[] { Skill("s", "read", "write") };
+        var options = new SkillAgentOptions { AllowedTools = ["deploy"] };
+
+        var context = await _factory.MapToAgentContextAsync(skills, options);
+
+        // A ceiling disjoint from what the skills grant leaves an empty intersection. The filter is still
+        // wired (the agent asked for a ceiling) but permits nothing from the skills' set.
+        GetFilter(context)!.AllowedTools.Should().BeEmpty();
+    }
+}

--- a/src/Content/Tests/Application.AI.Common.Tests/Helpers/ToolCeilingResolverTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Helpers/ToolCeilingResolverTests.cs
@@ -1,0 +1,154 @@
+using Application.AI.Common.Helpers;
+using FluentAssertions;
+using Xunit;
+
+namespace Application.AI.Common.Tests.Helpers;
+
+/// <summary>
+/// Unit tests for <see cref="ToolCeilingResolver"/>. These encode the load-bearing security invariant
+/// of the agent tool ceiling: applying a ceiling can only ever <em>tighten</em> the allowlist — it can
+/// never grant a tool the current allowlist did not already permit, and chaining ceilings can never
+/// re-grant a tool a prior intersection had already denied. <see langword="null"/> means "unbounded";
+/// a non-null list is an active restriction (empty = deny all).
+/// </summary>
+public sealed class ToolCeilingResolverTests
+{
+    [Fact]
+    public void ApplyCeiling_NullCeiling_ReturnsCurrentUnchanged()
+    {
+        IReadOnlyList<string> current = ["read", "write"];
+
+        var result = ToolCeilingResolver.ApplyCeiling(current, null);
+
+        result.Should().BeSameAs(current);
+    }
+
+    [Fact]
+    public void ApplyCeiling_EmptyCeiling_ReturnsCurrentUnchanged()
+    {
+        IReadOnlyList<string> current = ["read", "write"];
+
+        var result = ToolCeilingResolver.ApplyCeiling(current, []);
+
+        result.Should().BeSameAs(current);
+    }
+
+    [Fact]
+    public void ApplyCeiling_UnboundedCurrent_CapsToCeiling()
+    {
+        // A null current means the skills imposed no restriction (unbounded). A ceiling must still cap
+        // the agent — capping "everything" down to the ceiling is a tightening, which is the point.
+        var result = ToolCeilingResolver.ApplyCeiling(null, ["read", "search"]);
+
+        result.Should().BeEquivalentTo(["read", "search"]);
+    }
+
+    [Fact]
+    public void ApplyCeiling_CeilingIsSubset_ReturnsIntersection()
+    {
+        IReadOnlyList<string> current = ["read", "write", "delete"];
+
+        var result = ToolCeilingResolver.ApplyCeiling(current, ["read", "write"]);
+
+        result.Should().BeEquivalentTo(["read", "write"]);
+    }
+
+    [Fact]
+    public void ApplyCeiling_CeilingListsToolCurrentDoesNotGrant_NeverWidens()
+    {
+        // The ceiling names `delete`, but the current allowlist never granted it. The intersection must
+        // exclude it: a ceiling requests an upper bound, it does not confer new capability.
+        IReadOnlyList<string> current = ["read", "write"];
+
+        var result = ToolCeilingResolver.ApplyCeiling(current, ["read", "write", "delete"]);
+
+        result.Should().BeEquivalentTo(["read", "write"]);
+        result.Should().NotContain("delete");
+    }
+
+    [Fact]
+    public void ApplyCeiling_DisjointCeiling_ProducesEmptyDenyAll()
+    {
+        IReadOnlyList<string> current = ["read", "write"];
+
+        var result = ToolCeilingResolver.ApplyCeiling(current, ["deploy", "delete"]);
+
+        // Non-null but empty: an active deny-all, NOT "unbounded".
+        result.Should().NotBeNull();
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ApplyCeiling_ChainedAfterDenyAll_StaysDenyAll_NeverReGrants()
+    {
+        // Regression for the composition-widening bug: once an intersection has narrowed to empty
+        // (deny-all), applying a further ceiling must NOT resurrect any tool. Empty stays empty.
+        IReadOnlyList<string> skillUnion = ["read", "write"];
+
+        var afterDisjointCeiling = ToolCeilingResolver.ApplyCeiling(skillUnion, ["deploy"]); // => [] deny-all
+        var afterSecondCeiling = ToolCeilingResolver.ApplyCeiling(afterDisjointCeiling, ["read"]);
+
+        afterSecondCeiling.Should().NotBeNull();
+        afterSecondCeiling.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ApplyCeiling_ResultIsAlwaysSubsetOfCurrent_WhenCurrentBounded()
+    {
+        IReadOnlyList<string> current = ["read", "write", "search"];
+
+        var result = ToolCeilingResolver.ApplyCeiling(current, ["read", "search", "delete", "deploy"]);
+
+        result.Should().BeSubsetOf(current);
+    }
+
+    [Fact]
+    public void ApplyCeiling_IsCaseInsensitive()
+    {
+        IReadOnlyList<string> current = ["Read", "Write"];
+
+        var result = ToolCeilingResolver.ApplyCeiling(current, ["READ"]);
+
+        result.Should().ContainSingle().Which.Should().Be("Read");
+    }
+
+    [Fact]
+    public void ApplyCeiling_PreservesCurrentOrder()
+    {
+        IReadOnlyList<string> current = ["zebra", "alpha", "mike"];
+
+        var result = ToolCeilingResolver.ApplyCeiling(current, ["mike", "zebra", "alpha"]);
+
+        result.Should().ContainInOrder("zebra", "alpha", "mike");
+    }
+
+    [Fact]
+    public void ApplyCeiling_DeduplicatesCeilingWhenCappingUnboundedCurrent()
+    {
+        var result = ToolCeilingResolver.ApplyCeiling(null, ["read", "READ", "write"]);
+
+        result.Should().HaveCount(2);
+        result.Should().BeEquivalentTo(["read", "write"]);
+    }
+
+    [Fact]
+    public void ApplyCeiling_ComposedCeilings_ApplyBothTightenings()
+    {
+        // Two ceilings applied in sequence (agent ceiling, then an explicit per-call allowlist) must
+        // compose to the intersection of all three sets — the strictest wins at every step.
+        IReadOnlyList<string> skillUnion = ["read", "write", "search"];
+
+        var afterAgentCeiling = ToolCeilingResolver.ApplyCeiling(skillUnion, ["read", "write"]);
+        var afterExplicit = ToolCeilingResolver.ApplyCeiling(afterAgentCeiling, ["read"]);
+
+        afterExplicit.Should().BeEquivalentTo(["read"]);
+    }
+
+    [Fact]
+    public void ApplyCeiling_NullCurrentAndNoCeiling_StaysUnbounded()
+    {
+        var result = ToolCeilingResolver.ApplyCeiling(null, null);
+
+        result.Should().BeNull();
+    }
+}

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/Agent/ToolPermissionFilterTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/Agent/ToolPermissionFilterTests.cs
@@ -13,7 +13,7 @@ public sealed class ToolPermissionFilterTests
     /// Exposes the protected <c>ProvideAIContextAsync</c> for unit testing.
     /// <see cref="ToolPermissionFilter"/> is not sealed so this is safe.
     /// </summary>
-    private sealed class TestableFilter(IEnumerable<string> allowedTools) : ToolPermissionFilter(allowedTools)
+    private sealed class TestableFilter(IEnumerable<string>? allowedTools) : ToolPermissionFilter(allowedTools)
     {
         public ValueTask<AIContext> InvokeAsync(AIContextProvider.InvokingContext context, CancellationToken ct = default)
             => ProvideAIContextAsync(context, ct);
@@ -30,12 +30,12 @@ public sealed class ToolPermissionFilterTests
     private static AIContextProvider.InvokingContext MakeContext(AIContext aiContext) =>
         new(new Mock<AIAgent>().Object, new Mock<AgentSession>().Object, aiContext);
 
-    // ── empty allow-list ─────────────────────────────────────────────────────
+    // ── null allow-list = no restriction ─────────────────────────────────────
 
     [Fact]
-    public async Task EmptyAllowList_NoTools_ReturnsContextUnchanged()
+    public async Task NullAllowList_NoTools_ReturnsContextUnchanged()
     {
-        var filter = new TestableFilter([]);
+        var filter = new TestableFilter(null);
         var aiContext = new AIContext();
         var context = MakeContext(aiContext);
 
@@ -45,15 +45,31 @@ public sealed class ToolPermissionFilterTests
     }
 
     [Fact]
-    public async Task EmptyAllowList_WithTools_AllToolsPassThrough()
+    public async Task NullAllowList_WithTools_AllToolsPassThrough()
     {
-        var filter = new TestableFilter([]);
+        var filter = new TestableFilter(null);
         var aiContext = new AIContext { Tools = [MakeTool("Read"), MakeTool("Write")] };
         var context = MakeContext(aiContext);
 
         var result = await filter.InvokeAsync(context);
 
         result.Tools.Should().HaveCount(2);
+    }
+
+    // ── empty (non-null) allow-list = deny all ───────────────────────────────
+
+    [Fact]
+    public async Task EmptyAllowList_WithTools_StripsEveryTool()
+    {
+        // An empty but non-null allow-list is an active restriction that permits nothing — this is the
+        // deny-all state a tool ceiling collapses to when it is disjoint from the skills' tools.
+        var filter = new TestableFilter([]);
+        var aiContext = new AIContext { Tools = [MakeTool("Read"), MakeTool("Write")] };
+        var context = MakeContext(aiContext);
+
+        var result = await filter.InvokeAsync(context);
+
+        result.Tools.Should().BeEmpty();
     }
 
     // ── filtering behavior ───────────────────────────────────────────────────

--- a/src/Content/Tests/Infrastructure.AI.Tests/Agents/AgentMetadataParserTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Agents/AgentMetadataParserTests.cs
@@ -232,6 +232,37 @@ public sealed class AgentMetadataParserTests : IDisposable
     }
 
     [Fact]
+    public void ParseFromFile_AllowedToolsInFrontmatter_ParsesToolCeiling()
+    {
+        var dir = WriteAgent("ceilinged", """
+            ---
+            name: ceilinged-agent
+            allowed-tools: [file_system, calculation_engine]
+            ---
+            Agent body.
+            """);
+
+        var definition = CreateParser().ParseFromFile(Path.Combine(dir, "AGENT.md"), dir);
+
+        definition.AllowedTools.Should().BeEquivalentTo(["file_system", "calculation_engine"]);
+    }
+
+    [Fact]
+    public void ParseFromFile_NoAllowedTools_ReturnsEmptyCeiling()
+    {
+        var dir = WriteAgent("no-ceiling", """
+            ---
+            name: open-agent
+            ---
+            Agent body.
+            """);
+
+        var definition = CreateParser().ParseFromFile(Path.Combine(dir, "AGENT.md"), dir);
+
+        definition.AllowedTools.Should().BeEmpty();
+    }
+
+    [Fact]
     public void ParseFromFile_LegacySkillSingular_ParsesAsSingleElementList()
     {
         var dir = WriteAgent("legacy-skill", """


### PR DESCRIPTION
## What

Part 1 (agent promotion), step 2 of issue #154. Promotes the agent's `AGENT.md` `allowed-tools` frontmatter into a real **tool ceiling** — an upper bound that can only *tighten*, never widen, the union of tools its skills grant. Follows CM-PR1 (agent instructions, #164) and is the foundation the future bundle capability-envelope sits on.

## Flow

`AGENT.md allowed-tools` → `AgentDefinition.AllowedTools` → `SkillAgentOptions.AllowedTools` → `AgentExecutionContextFactory` resolves **one** effective allowlist (`ToolCeilingResolver.ApplyCeiling`: skill union, capped by the agent ceiling, then by any explicit per-call ceiling) and drives **both** enforcement points with it:
- **merge-time** — `ToolChainBuilder` filters the registered tool set
- **runtime** — `ToolPermissionFilter` re-strips every turn (catches framework tools surfaced by progressive skill disclosure)

Because both consume the same value, they can never disagree.

## Security invariant

`ToolCeilingResolver.ApplyCeiling` is a **monotone intersection**: a ceiling can only remove tools, never add one the skills didn't grant. It is **null-aware** — `null` = unbounded (no restriction), a non-null list = active restriction, an **empty** list = deny-all. That distinction is load-bearing: an intersection that narrows to nothing (a ceiling disjoint from the skills' tools) is a genuine **deny-all** that stays empty under any further ceiling — never allow-all, and never re-granting a denied tool.

`ToolPermissionFilter` and `ToolChainBuilder` adopt the same `null` = no restriction / empty = deny-all contract. The factory is their only production caller, so the contract change is fully contained.

### Review caught a real bug (fixed)
`/code-review` (high, 8 angles) found a CONFIRMED widening bug: a bare `IReadOnlyList` can't tell "unbounded" from "restricted to nothing", so chaining ceilings could re-grant a tool past a deny-all. Fixed by the null-aware redesign above; `ApplyCeiling_ChainedAfterDenyAll_StaysDenyAll_NeverReGrants` is the regression test. Re-verified adversarially — invariant holds, APPROVE.

## Backward compatibility

Agents with no ceiling and no skill restriction are unchanged (effective allowlist is `null` → no filter). No existing `AGENT.md` declares `allowed-tools`, so the behavioral change is opt-in.

## Test plan

- `ToolCeilingResolverTests` (13) — tighten-only, disjoint deny-all, chain-after-deny-all, composition, case-insensitivity, order preservation
- `AgentExecutionContextFactoryToolCeilingTests` (6) — effective set reaches the runtime filter across narrow / extra-in-ceiling / unrestricted-skill / no-ceiling / disjoint cases
- `ToolPermissionFilterTests` — null = pass-through, empty non-null = deny-all
- `AgentMetadataParserTests` — `allowed-tools` frontmatter → `AllowedTools`
- Full `Application.AI.Common.Tests`: 1350 pass. Remaining solution failures are pre-existing environmental only (Docker/Testcontainers: Neo4j/PostgreSQL/Prometheus; `C:\WINDOWS\TEMP` write-blocklist).

🤖 Generated with [Claude Code](https://claude.com/claude-code)