### PR TITLE
feat: agent-owned nested skills (CM-PR3)

### DIFF
--- a/src/Content/Application/Application.AI.Common/Factories/AgentExecutionContextFactory.cs
+++ b/src/Content/Application/Application.AI.Common/Factories/AgentExecutionContextFactory.cs
@@ -13,6 +13,7 @@ using Domain.AI.Skills;
 using Domain.AI.Telemetry.Conventions;
 using Domain.Common.Config;
 using Domain.Common.Config.AI;
+using Domain.Common.Helpers;
 using Domain.Common.MetaHarness;
 using Microsoft.Agents.AI;
 using Microsoft.Extensions.AI;
@@ -404,7 +405,7 @@ public class AgentExecutionContextFactory
     {
         var providers = new List<AIContextProvider>();
 
-        var skillPaths = ResolveSkillPaths(options);
+        var skillPaths = ResolveSkillPaths(options, skills);
 
         if (skillPaths.Count > 0)
         {
@@ -473,16 +474,47 @@ public class AgentExecutionContextFactory
         return providers.Count > 0 ? providers : null;
     }
 
-    private IReadOnlyList<string> ResolveSkillPaths(SkillAgentOptions options)
+    /// <summary>
+    /// Resolves the file-skill roots wired into the <c>AgentSkillsProvider</c> for progressive (Tier 2/3)
+    /// disclosure: the configured roots (or the per-call override), augmented with each resolved skill's
+    /// own directory when it is not already reachable under one of those roots. That augmentation is what
+    /// gives an agent-owned nested skill (whose directory lives under its <c>&lt;agentDir&gt;/skills/</c>,
+    /// outside the configured skill roots) the same on-demand access to its scripts and references as a
+    /// shared skill. Global skills, whose directories already sit under a configured root, are untouched.
+    /// </summary>
+    internal IReadOnlyList<string> ResolveSkillPaths(SkillAgentOptions options, IReadOnlyList<SkillDefinition> skills)
     {
-        if (options.SkillPaths?.Count > 0)
-            return [.. options.SkillPaths];
+        // Relative config paths are resolved against AppContext.BaseDirectory (the bin folder), matching
+        // SkillMetadataRegistry — the authority on where skills physically live. Resolving against the CWD
+        // instead would leave the base roots pointing nowhere under `dotnet run`, so the dedup below would
+        // fail to recognise that a global skill's directory is already covered and re-add every one.
+        var baseRoots = options.SkillPaths?.Count > 0
+            ? options.SkillPaths.Select(p => Path.IsPathRooted(p) ? p : Path.GetFullPath(p, AppContext.BaseDirectory)).ToList()
+            : _appConfig.CurrentValue.AI?.Skills?.AllPaths
+                .Select(p => Path.IsPathRooted(p) ? p : Path.GetFullPath(p, AppContext.BaseDirectory))
+                .Where(Directory.Exists)
+                .ToList() ?? [];
 
-        var configPaths = _appConfig.CurrentValue.AI?.Skills?.AllPaths.ToList() ?? [];
-        return configPaths
-            .Select(p => Path.IsPathRooted(p) ? p : Path.GetFullPath(p))
-            .Where(Directory.Exists)
-            .ToList();
+        var paths = new List<string>(baseRoots);
+        var normalizedRoots = baseRoots.Select(PathScope.Normalize).ToList();
+
+        // Ensure every resolved skill's own directory is reachable for Tier 2/3 disclosure, adding only
+        // those not already covered by a base root (agent-owned nested skills). Global skills, whose
+        // directories sit under a configured root, are skipped so the common case is unchanged.
+        foreach (var skill in skills)
+        {
+            var dir = skill.BaseDirectory;
+            if (string.IsNullOrEmpty(dir) || !Directory.Exists(dir))
+                continue;
+
+            var normalizedDir = PathScope.Normalize(dir);
+            if (normalizedRoots.Any(root => PathScope.IsSameOrUnderNormalized(normalizedDir, root)))
+                continue;
+            if (!paths.Contains(dir))
+                paths.Add(dir);
+        }
+
+        return paths;
     }
 
     private List<Type>? ResolveMiddlewareTypes(SkillDefinition skill, SkillAgentOptions options)

--- a/src/Content/Application/Application.AI.Common/Factories/AgentFactory.cs
+++ b/src/Content/Application/Application.AI.Common/Factories/AgentFactory.cs
@@ -436,12 +436,18 @@ public class AgentFactory : IAgentFactory
         _logger.LogDebug("Creating agent from {Count} skill(s): {SkillIds}",
             skillIds.Count, string.Join(", ", skillIds));
 
+        // Resolve each skill id, preferring the owning agent's own nested skills (its
+        // <agentDir>/skills/) over the global registry so an agent-owned skill can shadow — but never
+        // pollute — the shared pool. The owned store is optional: hosts that do not discover agents
+        // (for example the standalone MCP server) simply resolve everything from the global registry.
+        var ownedSkills = _serviceProvider.GetService<IAgentOwnedSkillStore>();
         var skills = new List<SkillDefinition>();
         foreach (var id in skillIds)
         {
-            var skill = _skillRegistry.TryGet(id)
+            var skill = ResolveSkill(id, options.OwningAgentId, ownedSkills)
                 ?? throw new InvalidOperationException(
-                    $"Skill '{id}' not found. Ensure it exists in the configured skill paths.");
+                    $"Skill '{id}' not found. Ensure it exists in the configured skill paths " +
+                    "or the owning agent's skills/ directory.");
             skills.Add(skill);
         }
 
@@ -453,6 +459,26 @@ public class AgentFactory : IAgentFactory
         _logger.LogInformation("Created agent {AgentName} from {Count} skill(s): {SkillIds}",
             agentContext.Name, skillIds.Count, string.Join(", ", skillIds));
         return new AgentBuildResult(agent, agentContext);
+    }
+
+    /// <summary>
+    /// Resolves a skill id to its definition, checking the owning agent's own nested skills first (when
+    /// an <paramref name="owningAgentId"/> and an <paramref name="ownedSkills"/> store are available)
+    /// and falling back to the global registry. Returns null when neither source knows the id.
+    /// </summary>
+    private SkillDefinition? ResolveSkill(
+        string id,
+        string? owningAgentId,
+        IAgentOwnedSkillStore? ownedSkills)
+    {
+        if (owningAgentId is not null && ownedSkills is not null)
+        {
+            var owned = ownedSkills.TryGet(owningAgentId, id);
+            if (owned is not null)
+                return owned;
+        }
+
+        return _skillRegistry.TryGet(id);
     }
 
     /// <inheritdoc />

--- a/src/Content/Application/Application.AI.Common/Interfaces/Skills/IAgentOwnedSkillStore.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Skills/IAgentOwnedSkillStore.cs
@@ -1,0 +1,48 @@
+using Domain.AI.Skills;
+
+namespace Application.AI.Common.Interfaces.Skills;
+
+/// <summary>
+/// Holds skills that are <em>owned</em> by a specific agent — the <c>SKILL.md</c> files discovered
+/// under an agent's own <c>&lt;agentDir&gt;/skills/</c> directory. These are private to their owning
+/// agent: this store resolves them only for that agent, and discovery writes them here rather than into
+/// the global <see cref="ISkillMetadataRegistry"/>, so one agent's nested skill can neither be seen by
+/// another agent through this store nor collide with a shared skill of the same id in the global pool.
+/// This isolation assumes the configured skill roots and agent roots are disjoint (the shipped default):
+/// the global registry scans skill roots recursively and is agent-unaware, so pointing a skill root at
+/// an ancestor of an agent directory would let it independently discover — and globally publish — that
+/// agent's nested skills. Keep the roots disjoint.
+/// </summary>
+/// <remarks>
+/// This is the storage half of the "a skill is a sub-level of its agent" model: agent discovery
+/// (<c>AgentMetadataRegistry</c>) populates the store as it parses each <c>AGENT.md</c>, and agent
+/// construction (<c>AgentFactory</c>) consults it — keyed by the owning agent id — <em>before</em>
+/// falling back to the global registry. An implementation must be safe for concurrent reads during
+/// agent construction and the (one-time, discovery-driven) writes that populate it.
+/// </remarks>
+public interface IAgentOwnedSkillStore
+{
+    /// <summary>
+    /// Registers a skill as owned by the agent with id <paramref name="agentId"/>. Re-registering the
+    /// same <c>(agentId, skill.Id)</c> pair overwrites the prior definition (idempotent re-discovery).
+    /// </summary>
+    /// <param name="agentId">The id of the owning agent.</param>
+    /// <param name="skill">The discovered nested skill definition.</param>
+    void Register(string agentId, SkillDefinition skill);
+
+    /// <summary>
+    /// Returns the skill with id <paramref name="skillId"/> owned by <paramref name="agentId"/>, or
+    /// <see langword="null"/> when that agent owns no such skill. Agent id and skill id are matched
+    /// case-insensitively, mirroring the global registry.
+    /// </summary>
+    /// <param name="agentId">The id of the owning agent.</param>
+    /// <param name="skillId">The id of the skill to resolve.</param>
+    SkillDefinition? TryGet(string agentId, string skillId);
+
+    /// <summary>
+    /// Returns every skill owned by <paramref name="agentId"/>, or an empty list when the agent owns
+    /// none.
+    /// </summary>
+    /// <param name="agentId">The id of the owning agent.</param>
+    IReadOnlyList<SkillDefinition> GetForAgent(string agentId);
+}

--- a/src/Content/Application/Application.Core/CQRS/Agents/ExecuteAgentTurn/ExecuteAgentTurnCommandHandler.cs
+++ b/src/Content/Application/Application.Core/CQRS/Agents/ExecuteAgentTurn/ExecuteAgentTurnCommandHandler.cs
@@ -100,6 +100,7 @@ public class ExecuteAgentTurnCommandHandler : IRequestHandler<ExecuteAgentTurnCo
 					AdditionalContext = request.SystemPromptOverride,
 					AgentInstructions = agentDef?.Instructions,
 					AllowedTools = agentDef?.AllowedTools,
+					OwningAgentId = agentDef?.Id,
 					DeploymentName = request.DeploymentOverride,
 					Temperature = request.Temperature,
 				},

--- a/src/Content/Domain/Domain.AI/Skills/SkillAgentOptions.cs
+++ b/src/Content/Domain/Domain.AI/Skills/SkillAgentOptions.cs
@@ -70,6 +70,13 @@ public sealed record SkillAgentOptions
 	public IReadOnlyList<string>? AllowedTools { get; init; }
 
 	/// <summary>
+	/// The id of the agent that owns this construction, used to resolve the agent's own nested skills
+	/// (its <c>&lt;agentDir&gt;/skills/</c>) ahead of the global skill registry. Null when the agent is
+	/// invoked by a bare skill id with no owning <c>AGENT.md</c>, in which case only global skills resolve.
+	/// </summary>
+	public string? OwningAgentId { get; init; }
+
+	/// <summary>
 	/// Override the sampling temperature for the underlying chat client.
 	/// When null, the provider default is used.
 	/// </summary>

--- a/src/Content/Domain/Domain.Common/Helpers/PathScope.cs
+++ b/src/Content/Domain/Domain.Common/Helpers/PathScope.cs
@@ -1,0 +1,41 @@
+namespace Domain.Common.Helpers;
+
+/// <summary>
+/// Filesystem path-containment checks shared across layers. Centralises the "is this path the same as,
+/// or nested under, that directory?" predicate so skill/agent path-ownership decisions use one
+/// authoritative implementation rather than diverging copies (a divergence here is security-relevant:
+/// it governs which directories an agent's skills are discovered from and disclosed under).
+/// </summary>
+public static class PathScope
+{
+    /// <summary>
+    /// Returns the absolute, separator-trimmed form of <paramref name="path"/> so two paths can be
+    /// compared for containment without being tripped up by relative segments or trailing separators.
+    /// </summary>
+    public static string Normalize(string path) =>
+        Path.GetFullPath(path).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+
+    /// <summary>
+    /// Returns <see langword="true"/> when <paramref name="target"/> equals, or is nested under,
+    /// <paramref name="baseDir"/>. Both paths are normalised first. Comparison is case-insensitive on
+    /// Windows and ordinal elsewhere. The trailing-separator check on the prefix ensures a sibling whose
+    /// name merely starts with the base (e.g. <c>C:\skills-config</c> against <c>C:\skills</c>) is not
+    /// mistaken for a child.
+    /// </summary>
+    public static bool IsSameOrUnder(string target, string baseDir) =>
+        IsSameOrUnderNormalized(Normalize(target), Normalize(baseDir));
+
+    /// <summary>
+    /// Containment check for paths that are already <see cref="Normalize"/>d. Prefer this overload when
+    /// the base directory is compared against many targets, so the base is normalised only once.
+    /// </summary>
+    public static bool IsSameOrUnderNormalized(string normalizedTarget, string normalizedBase)
+    {
+        var comparison = OperatingSystem.IsWindows()
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+
+        return string.Equals(normalizedTarget, normalizedBase, comparison)
+            || normalizedTarget.StartsWith(normalizedBase + Path.DirectorySeparatorChar, comparison);
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Agents/AgentMetadataRegistry.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Agents/AgentMetadataRegistry.cs
@@ -1,6 +1,8 @@
 using Application.AI.Common.Interfaces;
+using Application.AI.Common.Interfaces.Skills;
 using Domain.AI.Agents;
 using Domain.Common.Config;
+using Infrastructure.AI.Skills;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -24,20 +26,35 @@ public sealed class AgentMetadataRegistry : IAgentMetadataRegistry
     private readonly ILogger<AgentMetadataRegistry> _logger;
     private readonly IOptionsMonitor<AppConfig> _appConfig;
     private readonly AgentMetadataParser _parser;
+    private readonly SkillMetadataParser _skillParser;
+    private readonly IAgentOwnedSkillStore _ownedSkills;
 
     private Dictionary<string, AgentDefinition>? _cache;
     private IReadOnlyList<string> _searchedPaths = [];
     private readonly Lock _lock = new();
 
     /// <summary>Initialises the registry with its dependencies.</summary>
+    /// <param name="logger">Logger for discovery diagnostics.</param>
+    /// <param name="appConfig">Monitor over the live application configuration (agent search paths).</param>
+    /// <param name="parser">Parser that reads an <c>AGENT.md</c> file into an <see cref="AgentDefinition"/>.</param>
+    /// <param name="skillParser">Parser used to read each agent's own nested <c>SKILL.md</c> files.</param>
+    /// <param name="ownedSkills">
+    /// Store populated during discovery with the skills found under each agent's
+    /// <c>&lt;agentDir&gt;/skills/</c> directory, so <c>AgentFactory</c> can resolve them ahead of the
+    /// global registry without polluting it.
+    /// </param>
     public AgentMetadataRegistry(
         ILogger<AgentMetadataRegistry> logger,
         IOptionsMonitor<AppConfig> appConfig,
-        AgentMetadataParser parser)
+        AgentMetadataParser parser,
+        SkillMetadataParser skillParser,
+        IAgentOwnedSkillStore ownedSkills)
     {
         _logger = logger;
         _appConfig = appConfig;
         _parser = parser;
+        _skillParser = skillParser;
+        _ownedSkills = ownedSkills;
     }
 
     /// <inheritdoc />
@@ -154,8 +171,21 @@ public sealed class AgentMetadataRegistry : IAgentMetadataRegistry
                 var definition = _parser.ParseFromFile(agentFile, directory);
                 if (!string.IsNullOrEmpty(definition.Id))
                 {
-                    result[definition.Id] = definition;
-                    _logger.LogDebug("Discovered agent: {AgentId} from {Path}", definition.Id, directory);
+                    // Keep the first agent for a given id and warn on collision (mirrors
+                    // SkillMetadataRegistry). Critically, the owned-skill scan runs only for the winning
+                    // agent, so two agents that collide on id never merge their private skill namespaces.
+                    if (result.TryGetValue(definition.Id, out var existing))
+                    {
+                        _logger.LogWarning(
+                            "Agent ID collision on '{AgentId}': keeping first from {ExistingPath}; ignoring duplicate from {DuplicatePath}",
+                            definition.Id, existing.BaseDirectory, directory);
+                    }
+                    else
+                    {
+                        result[definition.Id] = definition;
+                        _logger.LogDebug("Discovered agent: {AgentId} from {Path}", definition.Id, directory);
+                        DiscoverAgentOwnedSkills(directory, definition.Id);
+                    }
                 }
             }
             catch (Exception ex)
@@ -175,6 +205,55 @@ public sealed class AgentMetadataRegistry : IAgentMetadataRegistry
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "Could not enumerate directory: {Path}", directory);
+        }
+    }
+
+    /// <summary>
+    /// Scans an agent's own <c>skills/</c> subdirectory for nested <c>SKILL.md</c> files and registers
+    /// each into the <see cref="IAgentOwnedSkillStore"/> keyed by <paramref name="agentId"/>. These
+    /// skills are private to the agent: they are deliberately kept out of the global
+    /// <c>SkillMetadataRegistry</c> so they neither leak to other agents nor collide with shared skills.
+    /// A missing <c>skills/</c> directory is the common case and is silently skipped; a single malformed
+    /// nested skill logs a warning without failing the rest of discovery.
+    /// </summary>
+    private void DiscoverAgentOwnedSkills(string agentDirectory, string agentId)
+    {
+        var skillsRoot = Path.Combine(agentDirectory, "skills");
+        if (!Directory.Exists(skillsRoot))
+            return;
+
+        IEnumerable<string> skillDirs;
+        try
+        {
+            skillDirs = Directory.EnumerateDirectories(skillsRoot);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Could not enumerate agent-owned skills directory: {Path}", skillsRoot);
+            return;
+        }
+
+        foreach (var skillDir in skillDirs)
+        {
+            var skillFile = Path.Combine(skillDir, "SKILL.md");
+            if (!File.Exists(skillFile))
+                continue;
+
+            try
+            {
+                var skill = _skillParser.ParseFromFile(skillFile, skillDir);
+                if (string.IsNullOrEmpty(skill.Id))
+                    continue;
+
+                _ownedSkills.Register(agentId, skill);
+                _logger.LogDebug(
+                    "Discovered agent-owned skill {SkillId} for agent {AgentId} from {Path}",
+                    skill.Id, agentId, skillDir);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to parse agent-owned skill from {Path}", skillFile);
+            }
         }
     }
 }

--- a/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.cs
@@ -9,6 +9,7 @@ using Application.AI.Common.Interfaces.Context;
 using Application.AI.Common.Interfaces.Hooks;
 using Application.AI.Common.Interfaces.MetaHarness;
 using Application.AI.Common.Interfaces.Plugins;
+using Application.AI.Common.Interfaces.Skills;
 using Application.AI.Common.Interfaces.Prompts;
 using Application.AI.Common.Interfaces.Routing;
 using Application.AI.Common.Interfaces.Tools;
@@ -164,6 +165,7 @@ public static partial class DependencyInjection
 
         services.AddSingleton<SkillMetadataParser>();
         services.AddSingleton<ISkillMetadataRegistry, SkillMetadataRegistry>();
+        services.AddSingleton<IAgentOwnedSkillStore, AgentOwnedSkillStore>();
         services.AddSingleton<AgentMetadataParser>();
         services.AddSingleton<IAgentMetadataRegistry, AgentMetadataRegistry>();
 

--- a/src/Content/Infrastructure/Infrastructure.AI/Skills/AgentOwnedSkillStore.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Skills/AgentOwnedSkillStore.cs
@@ -1,0 +1,47 @@
+using System.Collections.Concurrent;
+using Application.AI.Common.Interfaces.Skills;
+using Domain.AI.Skills;
+
+namespace Infrastructure.AI.Skills;
+
+/// <summary>
+/// In-memory, thread-safe <see cref="IAgentOwnedSkillStore"/>. Skills are held in a two-level map —
+/// agent id → (skill id → definition) — both levels compared case-insensitively to match the global
+/// registry. Registered as a singleton so the writer (agent discovery) and the readers (agent
+/// construction) share one instance.
+/// </summary>
+public sealed class AgentOwnedSkillStore : IAgentOwnedSkillStore
+{
+    private readonly ConcurrentDictionary<string, ConcurrentDictionary<string, SkillDefinition>> _byAgent =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    /// <inheritdoc />
+    public void Register(string agentId, SkillDefinition skill)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(agentId);
+        ArgumentNullException.ThrowIfNull(skill);
+
+        var skills = _byAgent.GetOrAdd(agentId, _ => new(StringComparer.OrdinalIgnoreCase));
+        skills[skill.Id] = skill;
+    }
+
+    /// <inheritdoc />
+    public SkillDefinition? TryGet(string agentId, string skillId)
+    {
+        if (string.IsNullOrWhiteSpace(agentId) || string.IsNullOrWhiteSpace(skillId))
+            return null;
+
+        return _byAgent.TryGetValue(agentId, out var skills) && skills.TryGetValue(skillId, out var skill)
+            ? skill
+            : null;
+    }
+
+    /// <inheritdoc />
+    public IReadOnlyList<SkillDefinition> GetForAgent(string agentId)
+    {
+        if (string.IsNullOrWhiteSpace(agentId))
+            return [];
+
+        return _byAgent.TryGetValue(agentId, out var skills) ? skills.Values.ToList() : [];
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Skills/SkillMetadataRegistry.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Skills/SkillMetadataRegistry.cs
@@ -2,6 +2,7 @@ using Application.AI.Common.Interfaces;
 using Application.AI.Common.Interfaces.Plugins;
 using Domain.AI.Skills;
 using Domain.Common.Config;
+using Domain.Common.Helpers;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -209,7 +210,7 @@ public sealed class SkillMetadataRegistry : ISkillMetadataRegistry
             {
                 if (string.IsNullOrWhiteSpace(skillPath))
                     continue;
-                pairs.Add((NormalizePath(skillPath), plugin.Name));
+                pairs.Add((PathScope.Normalize(skillPath), plugin.Name));
             }
         }
 
@@ -298,13 +299,13 @@ public sealed class SkillMetadataRegistry : ISkillMetadataRegistry
         if (pluginPaths.Count == 0)
             return null;
 
-        var normalizedDir = NormalizePath(skillDirectory);
+        var normalizedDir = PathScope.Normalize(skillDirectory);
         string? bestName = null;
         var bestLength = -1;
 
         foreach (var (path, pluginName) in pluginPaths)
         {
-            if (IsSameOrUnder(normalizedDir, path) && path.Length > bestLength)
+            if (PathScope.IsSameOrUnderNormalized(normalizedDir, path) && path.Length > bestLength)
             {
                 bestName = pluginName;
                 bestLength = path.Length;
@@ -313,17 +314,4 @@ public sealed class SkillMetadataRegistry : ISkillMetadataRegistry
 
         return bestName;
     }
-
-    private static bool IsSameOrUnder(string normalizedTarget, string normalizedBase)
-    {
-        var comparison = OperatingSystem.IsWindows()
-            ? StringComparison.OrdinalIgnoreCase
-            : StringComparison.Ordinal;
-
-        return string.Equals(normalizedTarget, normalizedBase, comparison)
-            || normalizedTarget.StartsWith(normalizedBase + Path.DirectorySeparatorChar, comparison);
-    }
-
-    private static string NormalizePath(string path) =>
-        Path.GetFullPath(path).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
 }

--- a/src/Content/Presentation/Presentation.FoundryHost/Program.cs
+++ b/src/Content/Presentation/Presentation.FoundryHost/Program.cs
@@ -155,7 +155,10 @@ public static class Program
 
         var factory = provider.GetRequiredService<IAgentFactory>();
         return await factory
-            .CreateAgentFromSkillsAsync(skillIds, new SkillAgentOptions(), cancellationToken)
+            .CreateAgentFromSkillsAsync(
+                skillIds,
+                new SkillAgentOptions { OwningAgentId = definition.Id },
+                cancellationToken)
             .ConfigureAwait(false);
     }
 

--- a/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentExecutionContextFactoryNestedSkillPathTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentExecutionContextFactoryNestedSkillPathTests.cs
@@ -1,0 +1,120 @@
+using Application.AI.Common.Factories;
+using Application.AI.Common.Interfaces.Skills;
+using Application.AI.Common.Services.Skills;
+using Application.AI.Common.Services.Tools;
+using Domain.AI.Skills;
+using Domain.Common.Config;
+using Domain.Common.Config.AI;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Application.AI.Common.Tests.Factories;
+
+/// <summary>
+/// Tests <see cref="AgentExecutionContextFactory"/>'s file-skill path resolution: an agent-owned nested
+/// skill's own directory (outside the configured skill roots) is added so its Tier 2/3 content is
+/// disclosable, while a global skill already under a configured root is not double-added. This pins the
+/// augment-not-replace behaviour that keeps a mixed owned+shared agent from losing disclosure for its
+/// shared skills.
+/// </summary>
+public sealed class AgentExecutionContextFactoryNestedSkillPathTests : IDisposable
+{
+    private readonly string _tempRoot;
+    private readonly string _configSkillRoot;
+
+    public AgentExecutionContextFactoryNestedSkillPathTests()
+    {
+        _tempRoot = Path.Combine(Path.GetTempPath(), $"nestedpath-{Guid.NewGuid():N}");
+        _configSkillRoot = Path.Combine(_tempRoot, "skills-config");
+        Directory.CreateDirectory(_configSkillRoot);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempRoot))
+            Directory.Delete(_tempRoot, recursive: true);
+    }
+
+    private AgentExecutionContextFactory CreateFactory()
+    {
+        var appConfig = new AppConfig
+        {
+            AI = new AIConfig
+            {
+                AgentFramework = new AgentFrameworkConfig { DefaultDeployment = "gpt-4o" },
+                Skills = new SkillsConfig { BasePath = _configSkillRoot },
+            }
+        };
+        var monitor = Mock.Of<IOptionsMonitor<AppConfig>>(m => m.CurrentValue == appConfig);
+        var sp = new ServiceCollection().BuildServiceProvider();
+
+        return new AgentExecutionContextFactory(
+            NullLogger<AgentExecutionContextFactory>.Instance,
+            monitor,
+            sp,
+            NullLoggerFactory.Instance,
+            new ToolChainBuilder(NullLogger<ToolChainBuilder>.Instance, sp),
+            new SkillPrerequisiteResolver());
+    }
+
+    private string MakeDir(string relative)
+    {
+        var dir = Path.Combine(_tempRoot, relative);
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+
+    [Fact]
+    public void ResolveSkillPaths_AgentOwnedSkillOutsideConfigRoots_AddsItsDirectory()
+    {
+        // Nested skill lives under an agent dir, outside the configured skill root.
+        var ownedDir = MakeDir(Path.Combine("agents", "alpha", "skills", "nested"));
+        var skill = new SkillDefinition { Id = "nested", Name = "nested", BaseDirectory = ownedDir };
+
+        var paths = CreateFactory().ResolveSkillPaths(new SkillAgentOptions(), [skill]);
+
+        paths.Should().Contain(p => Path.GetFullPath(p) == Path.GetFullPath(_configSkillRoot));
+        paths.Should().Contain(p => Path.GetFullPath(p) == Path.GetFullPath(ownedDir));
+    }
+
+    [Fact]
+    public void ResolveSkillPaths_GlobalSkillUnderConfigRoot_IsNotDoubleAdded()
+    {
+        // Global skill's directory sits under the configured root — it is already reachable.
+        var globalDir = MakeDir(Path.Combine("skills-config", "research"));
+        var skill = new SkillDefinition { Id = "research", Name = "research", BaseDirectory = globalDir };
+
+        var paths = CreateFactory().ResolveSkillPaths(new SkillAgentOptions(), [skill]);
+
+        paths.Where(p => Path.GetFullPath(p) == Path.GetFullPath(globalDir)).Should().BeEmpty();
+        paths.Should().ContainSingle(p => Path.GetFullPath(p) == Path.GetFullPath(_configSkillRoot));
+    }
+
+    [Fact]
+    public void ResolveSkillPaths_MixedOwnedAndShared_KeepsConfigRootAndAddsOnlyOwned()
+    {
+        var globalDir = MakeDir(Path.Combine("skills-config", "shared"));
+        var ownedDir = MakeDir(Path.Combine("agents", "alpha", "skills", "private"));
+        var shared = new SkillDefinition { Id = "shared", Name = "shared", BaseDirectory = globalDir };
+        var owned = new SkillDefinition { Id = "private", Name = "private", BaseDirectory = ownedDir };
+
+        var paths = CreateFactory().ResolveSkillPaths(new SkillAgentOptions(), [shared, owned]);
+
+        // Config root present (so the shared skill discloses), owned dir added, global dir not re-added.
+        paths.Should().Contain(p => Path.GetFullPath(p) == Path.GetFullPath(_configSkillRoot));
+        paths.Should().Contain(p => Path.GetFullPath(p) == Path.GetFullPath(ownedDir));
+        paths.Where(p => Path.GetFullPath(p) == Path.GetFullPath(globalDir)).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ResolveSkillPaths_NoSkills_ReturnsOnlyConfigRoots()
+    {
+        var paths = CreateFactory().ResolveSkillPaths(new SkillAgentOptions(), []);
+
+        paths.Should().ContainSingle(p => Path.GetFullPath(p) == Path.GetFullPath(_configSkillRoot));
+    }
+}

--- a/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentFactoryAgentOwnedSkillTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentFactoryAgentOwnedSkillTests.cs
@@ -1,0 +1,159 @@
+using Application.AI.Common.Factories;
+using Application.AI.Common.Interfaces;
+using Application.AI.Common.Interfaces.Skills;
+using Application.AI.Common.Services.Skills;
+using Application.AI.Common.Tests.Fakes;
+using Domain.AI.Agents;
+using Domain.AI.Skills;
+using Domain.Common.Config;
+using Domain.Common.Config.AI;
+using FluentAssertions;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Application.AI.Common.Tests.Factories;
+
+/// <summary>
+/// Tests that <see cref="AgentFactory"/> resolves an agent's own nested skills (from
+/// <see cref="IAgentOwnedSkillStore"/>) ahead of the global registry, keyed by the owning agent id,
+/// and falls back to the global registry when there is no owner or no owned skill.
+/// </summary>
+public sealed class AgentFactoryAgentOwnedSkillTests
+{
+    /// <summary>Minimal in-memory <see cref="IAgentOwnedSkillStore"/> so this Application-layer test
+    /// need not depend on the Infrastructure implementation.</summary>
+    private sealed class FakeOwnedSkillStore : IAgentOwnedSkillStore
+    {
+        private readonly Dictionary<(string, string), SkillDefinition> _skills = new();
+
+        public void Register(string agentId, SkillDefinition skill) =>
+            _skills[(agentId, skill.Id)] = skill;
+
+        public SkillDefinition? TryGet(string agentId, string skillId) =>
+            _skills.TryGetValue((agentId, skillId), out var s) ? s : null;
+
+        public IReadOnlyList<SkillDefinition> GetForAgent(string agentId) =>
+            _skills.Where(kv => kv.Key.Item1 == agentId).Select(kv => kv.Value).ToList();
+    }
+
+    private readonly Mock<ISkillMetadataRegistry> _skillRegistry = new();
+    private readonly Mock<AgentExecutionContextFactory> _contextFactory;
+    private readonly FakeOwnedSkillStore _ownedStore = new();
+    private readonly AgentFactory _factory;
+    private IReadOnlyList<SkillDefinition>? _capturedSkills;
+
+    public AgentFactoryAgentOwnedSkillTests()
+    {
+        var chatClientFactory = new Mock<IChatClientFactory>();
+        chatClientFactory.Setup(f => f.IsAvailable(It.IsAny<AIAgentFrameworkClientType>())).Returns(true);
+        chatClientFactory
+            .Setup(f => f.GetChatClientAsync(It.IsAny<AIAgentFrameworkClientType>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new FakeChatClient());
+
+        var appConfig = new AppConfig
+        {
+            AI = new AIConfig
+            {
+                AgentFramework = new AgentFrameworkConfig
+                {
+                    DefaultDeployment = "gpt-4o",
+                    ClientType = AIAgentFrameworkClientType.AzureOpenAI
+                }
+            }
+        };
+        var monitor = Mock.Of<IOptionsMonitor<AppConfig>>(m => m.CurrentValue == appConfig);
+
+        _contextFactory = new Mock<AgentExecutionContextFactory>(
+            NullLogger<AgentExecutionContextFactory>.Instance,
+            monitor,
+            new ServiceCollection().BuildServiceProvider(),
+            NullLoggerFactory.Instance,
+            null!, null!, null!, null!, null!, null!);
+
+        _contextFactory
+            .Setup(f => f.MapToAgentContextAsync(
+                It.IsAny<IReadOnlyList<SkillDefinition>>(),
+                It.IsAny<SkillAgentOptions>(),
+                It.IsAny<IReadOnlyList<string>?>()))
+            .Callback<IReadOnlyList<SkillDefinition>, SkillAgentOptions, IReadOnlyList<string>?>(
+                (skills, _, _) => _capturedSkills = skills)
+            .ReturnsAsync(new AgentExecutionContext
+            {
+                Name = "TestAgent",
+                Instruction = "merged",
+                AIAgentFrameworkType = AIAgentFrameworkClientType.AzureOpenAI
+            });
+
+        // A real service provider carrying the owned-skill store (the factory resolves it lazily).
+        var sp = new ServiceCollection()
+            .AddSingleton<IAgentOwnedSkillStore>(_ownedStore)
+            .BuildServiceProvider();
+
+        _factory = new AgentFactory(
+            NullLogger<AgentFactory>.Instance,
+            monitor,
+            Mock.Of<IDistributedCache>(),
+            NullLoggerFactory.Instance,
+            _contextFactory.Object,
+            _skillRegistry.Object,
+            chatClientFactory.Object,
+            sp,
+            new InMemorySkillCompletionTracker());
+    }
+
+    private static SkillDefinition Skill(string id, string marker) =>
+        new() { Id = id, Name = id, Description = marker };
+
+    [Fact]
+    public async Task OwnedSkill_ShadowsGlobalSkillOfSameId_ForOwningAgent()
+    {
+        _skillRegistry.Setup(r => r.TryGet("shared")).Returns(Skill("shared", "GLOBAL"));
+        _ownedStore.Register("agent-a", Skill("shared", "OWNED"));
+
+        await _factory.CreateAgentFromSkillsAsync(
+            ["shared"], new SkillAgentOptions { OwningAgentId = "agent-a" });
+
+        _capturedSkills.Should().ContainSingle();
+        _capturedSkills![0].Description.Should().Be("OWNED", "the owning agent's nested skill wins over the global one");
+        _skillRegistry.Verify(r => r.TryGet("shared"), Times.Never, "the global registry must not even be consulted when the owner has the skill");
+    }
+
+    [Fact]
+    public async Task OwnedSkill_IsInvisibleToAnotherAgent_FallsBackToGlobal()
+    {
+        _skillRegistry.Setup(r => r.TryGet("shared")).Returns(Skill("shared", "GLOBAL"));
+        _ownedStore.Register("agent-a", Skill("shared", "OWNED"));
+
+        await _factory.CreateAgentFromSkillsAsync(
+            ["shared"], new SkillAgentOptions { OwningAgentId = "agent-b" });
+
+        _capturedSkills![0].Description.Should().Be("GLOBAL", "agent-b owns no such skill, so the global one resolves");
+    }
+
+    [Fact]
+    public async Task NoOwningAgentId_ResolvesFromGlobalRegistry()
+    {
+        _skillRegistry.Setup(r => r.TryGet("shared")).Returns(Skill("shared", "GLOBAL"));
+        _ownedStore.Register("agent-a", Skill("shared", "OWNED"));
+
+        await _factory.CreateAgentFromSkillsAsync(["shared"], new SkillAgentOptions());
+
+        _capturedSkills![0].Description.Should().Be("GLOBAL");
+    }
+
+    [Fact]
+    public async Task UnknownSkill_EvenWithOwner_Throws()
+    {
+        _skillRegistry.Setup(r => r.TryGet(It.IsAny<string>())).Returns((SkillDefinition?)null);
+
+        var act = () => _factory.CreateAgentFromSkillsAsync(
+            ["missing"], new SkillAgentOptions { OwningAgentId = "agent-a" });
+
+        await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("*missing*not found*");
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Agents/AgentMetadataRegistryTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Agents/AgentMetadataRegistryTests.cs
@@ -1,8 +1,10 @@
 using Application.AI.Common.Interfaces;
+using Application.AI.Common.Interfaces.Skills;
 using Domain.Common.Config;
 using Domain.Common.Config.AI;
 using FluentAssertions;
 using Infrastructure.AI.Agents;
+using Infrastructure.AI.Skills;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
@@ -22,6 +24,9 @@ public sealed class AgentMetadataRegistryTests
         Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "..", "..", "..", "agents"));
 
     private static AgentMetadataRegistry CreateRegistry(string? agentsPath = null)
+        => CreateRegistry(new AgentOwnedSkillStore(), agentsPath);
+
+    private static AgentMetadataRegistry CreateRegistry(IAgentOwnedSkillStore ownedSkills, string? agentsPath = null)
     {
         var resolvedPath = agentsPath ?? RepoAgentsPath;
         var appConfig = new AppConfig
@@ -34,7 +39,9 @@ public sealed class AgentMetadataRegistryTests
         return new AgentMetadataRegistry(
             NullLogger<AgentMetadataRegistry>.Instance,
             new OptionsMonitorStub(appConfig),
-            new AgentMetadataParser(NullLogger<AgentMetadataParser>.Instance));
+            new AgentMetadataParser(NullLogger<AgentMetadataParser>.Instance),
+            new SkillMetadataParser(NullLogger<SkillMetadataParser>.Instance),
+            ownedSkills);
     }
 
     [Fact]
@@ -128,6 +135,8 @@ public sealed class AgentMetadataRegistryTests
         services.AddLogging();
         services.AddSingleton<IOptionsMonitor<AppConfig>>(new OptionsMonitorStub(new AppConfig()));
         services.AddSingleton<AgentMetadataParser>();
+        services.AddSingleton<SkillMetadataParser>();
+        services.AddSingleton<IAgentOwnedSkillStore, AgentOwnedSkillStore>();
         services.AddSingleton<IAgentMetadataRegistry, AgentMetadataRegistry>();
 
         using var provider = services.BuildServiceProvider();
@@ -136,11 +145,156 @@ public sealed class AgentMetadataRegistryTests
         registry.Should().NotBeNull();
     }
 
+    [Fact]
+    public void GetAll_AgentWithNestedSkills_RegistersThemUnderThatAgentOnly()
+    {
+        var tempRoot = Path.Combine(Path.GetTempPath(), $"agents-nested-{Guid.NewGuid():N}");
+        var store = new AgentOwnedSkillStore();
+        try
+        {
+            WriteAgent(tempRoot, "alpha", """
+                ---
+                id: alpha
+                name: Alpha
+                skills: [alpha-only]
+                ---
+                """);
+            WriteNestedSkill(tempRoot, "alpha", "alpha-only", "Alpha's private skill.");
+
+            WriteAgent(tempRoot, "beta", """
+                ---
+                id: beta
+                name: Beta
+                ---
+                """);
+
+            var registry = CreateRegistry(store, agentsPath: tempRoot);
+            registry.GetAll().Should().HaveCount(2); // triggers discovery
+
+            // Resolvable only for its owning agent...
+            store.TryGet("alpha", "alpha-only").Should().NotBeNull();
+            // ...invisible to another agent...
+            store.TryGet("beta", "alpha-only").Should().BeNull();
+            // ...and it never enters the global registry surface (the store is separate by construction).
+            store.GetForAgent("alpha").Select(s => s.Id).Should().ContainSingle(id => id == "alpha-only");
+        }
+        finally
+        {
+            Directory.Delete(tempRoot, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void GetAll_AgentWithoutSkillsDirectory_RegistersNothing()
+    {
+        var tempRoot = Path.Combine(Path.GetTempPath(), $"agents-noskills-{Guid.NewGuid():N}");
+        var store = new AgentOwnedSkillStore();
+        try
+        {
+            WriteAgent(tempRoot, "solo", """
+                ---
+                id: solo
+                name: Solo
+                ---
+                """);
+
+            var registry = CreateRegistry(store, agentsPath: tempRoot);
+            registry.GetAll().Should().ContainSingle();
+
+            store.GetForAgent("solo").Should().BeEmpty();
+        }
+        finally
+        {
+            Directory.Delete(tempRoot, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void GetAll_NestedSkillDirWithoutSkillMd_IsSkippedAndDoesNotAbortDiscovery()
+    {
+        var tempRoot = Path.Combine(Path.GetTempPath(), $"agents-emptyskill-{Guid.NewGuid():N}");
+        var store = new AgentOwnedSkillStore();
+        try
+        {
+            WriteAgent(tempRoot, "alpha", """
+                ---
+                id: alpha
+                name: Alpha
+                ---
+                """);
+            WriteNestedSkill(tempRoot, "alpha", "good", "A valid nested skill.");
+
+            // A skills/ subdir with no SKILL.md must be skipped without aborting discovery of the valid one.
+            Directory.CreateDirectory(Path.Combine(tempRoot, "alpha", "skills", "empty"));
+
+            var registry = CreateRegistry(store, agentsPath: tempRoot);
+            registry.GetAll().Should().ContainSingle();
+
+            store.GetForAgent("alpha").Select(s => s.Id).Should().ContainSingle(id => id == "good");
+        }
+        finally
+        {
+            Directory.Delete(tempRoot, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void GetAll_DuplicateAgentId_KeepsFirstAndDoesNotMergeOwnedSkills()
+    {
+        var tempRoot = Path.Combine(Path.GetTempPath(), $"agents-dup-{Guid.NewGuid():N}");
+        var store = new AgentOwnedSkillStore();
+        try
+        {
+            // Two agent directories declaring the same id, each with its own private nested skill.
+            WriteAgent(tempRoot, "first", """
+                ---
+                id: dup
+                name: First
+                ---
+                """);
+            WriteNestedSkill(tempRoot, "first", "first-skill", "First's private skill.");
+
+            WriteAgent(tempRoot, "second", """
+                ---
+                id: dup
+                name: Second
+                ---
+                """);
+            WriteNestedSkill(tempRoot, "second", "second-skill", "Second's private skill.");
+
+            var registry = CreateRegistry(store, agentsPath: tempRoot);
+            registry.GetAll().Should().ContainSingle(a => a.Id == "dup");
+
+            // Only the winning (first-discovered) agent's owned skills are registered — the colliding
+            // agent's private skills must not merge into the same id's namespace.
+            var owned = store.GetForAgent("dup").Select(s => s.Id).ToList();
+            owned.Should().ContainSingle();
+            owned.Should().BeSubsetOf(["first-skill", "second-skill"]);
+        }
+        finally
+        {
+            Directory.Delete(tempRoot, recursive: true);
+        }
+    }
+
     private static void WriteAgent(string root, string folderName, string content)
     {
         var dir = Path.Combine(root, folderName);
         Directory.CreateDirectory(dir);
         File.WriteAllText(Path.Combine(dir, "AGENT.md"), content);
+    }
+
+    private static void WriteNestedSkill(string root, string agentFolder, string skillId, string body)
+    {
+        var dir = Path.Combine(root, agentFolder, "skills", skillId);
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, "SKILL.md"), $"""
+            ---
+            id: {skillId}
+            name: {skillId}
+            ---
+            {body}
+            """);
     }
 
     private sealed class OptionsMonitorStub : IOptionsMonitor<AppConfig>

--- a/src/Content/Tests/Infrastructure.AI.Tests/Skills/AgentOwnedSkillStoreTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Skills/AgentOwnedSkillStoreTests.cs
@@ -1,0 +1,106 @@
+using Domain.AI.Skills;
+using FluentAssertions;
+using Infrastructure.AI.Skills;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Skills;
+
+/// <summary>
+/// Unit tests for <see cref="AgentOwnedSkillStore"/>. These pin the isolation guarantees that make
+/// agent-owned skills safe: a skill is resolvable only for its owning agent, invisible to others, and
+/// re-registration is idempotent. Matching is case-insensitive to mirror the global registry.
+/// </summary>
+public sealed class AgentOwnedSkillStoreTests
+{
+    private static SkillDefinition Skill(string id) => new() { Id = id, Name = id };
+
+    [Fact]
+    public void TryGet_RegisteredSkill_ReturnsItForOwningAgent()
+    {
+        var store = new AgentOwnedSkillStore();
+        var skill = Skill("nested");
+        store.Register("agent-a", skill);
+
+        store.TryGet("agent-a", "nested").Should().BeSameAs(skill);
+    }
+
+    [Fact]
+    public void TryGet_SkillOwnedByAnotherAgent_IsInvisible()
+    {
+        var store = new AgentOwnedSkillStore();
+        store.Register("agent-a", Skill("nested"));
+
+        // Agent B never registered "nested": one agent's owned skill must not leak to another.
+        store.TryGet("agent-b", "nested").Should().BeNull();
+    }
+
+    [Fact]
+    public void TryGet_UnknownSkillForKnownAgent_ReturnsNull()
+    {
+        var store = new AgentOwnedSkillStore();
+        store.Register("agent-a", Skill("nested"));
+
+        store.TryGet("agent-a", "other").Should().BeNull();
+    }
+
+    [Fact]
+    public void TryGet_AgentIdAndSkillId_AreCaseInsensitive()
+    {
+        var store = new AgentOwnedSkillStore();
+        var skill = Skill("Nested");
+        store.Register("Agent-A", skill);
+
+        store.TryGet("agent-a", "nested").Should().BeSameAs(skill);
+    }
+
+    [Fact]
+    public void Register_SameAgentAndSkillId_OverwritesIdempotently()
+    {
+        var store = new AgentOwnedSkillStore();
+        store.Register("agent-a", Skill("nested"));
+        var replacement = Skill("nested");
+        store.Register("agent-a", replacement);
+
+        store.TryGet("agent-a", "nested").Should().BeSameAs(replacement);
+        store.GetForAgent("agent-a").Should().ContainSingle();
+    }
+
+    [Fact]
+    public void GetForAgent_ReturnsAllSkillsForThatAgentOnly()
+    {
+        var store = new AgentOwnedSkillStore();
+        store.Register("agent-a", Skill("s1"));
+        store.Register("agent-a", Skill("s2"));
+        store.Register("agent-b", Skill("s3"));
+
+        store.GetForAgent("agent-a").Select(s => s.Id).Should().BeEquivalentTo(["s1", "s2"]);
+    }
+
+    [Fact]
+    public void GetForAgent_UnknownAgent_ReturnsEmpty()
+    {
+        var store = new AgentOwnedSkillStore();
+
+        store.GetForAgent("nobody").Should().BeEmpty();
+    }
+
+    [Fact]
+    public void TryGet_NullOrWhitespaceKeys_ReturnNull()
+    {
+        var store = new AgentOwnedSkillStore();
+        store.Register("agent-a", Skill("nested"));
+
+        store.TryGet("", "nested").Should().BeNull();
+        store.TryGet("agent-a", " ").Should().BeNull();
+    }
+
+    [Fact]
+    public void Register_BlankAgentId_Throws()
+    {
+        var store = new AgentOwnedSkillStore();
+
+        var act = () => store.Register("  ", Skill("nested"));
+
+        act.Should().Throw<ArgumentException>();
+    }
+}


### PR DESCRIPTION
## What

Part 1 (agent promotion), step 3 of issue #154. Makes **a skill a sub-level of its agent** — the way Claude works. An agent can now own private skills under its own `<agentDir>/skills/*/SKILL.md`: they resolve **only** for that agent, **shadow** a same-id global skill for that agent alone, and **never** enter the global skill pool. Follows CM-PR1 (instructions, #164) and CM-PR2 (tool ceiling, #165).

## Flow

- **Discovery** — `AgentMetadataRegistry` scans `<agentDir>/skills/` as it parses each `AGENT.md` and registers the nested skills into a new `IAgentOwnedSkillStore`, keyed by agent id. They never touch the global `SkillMetadataRegistry`.
- **Resolution** — `AgentFactory` resolves each skill id **owned-first** (via `SkillAgentOptions.OwningAgentId`, set from the agent id) then falls back to the global registry.
- **Disclosure** — `AgentExecutionContextFactory` adds each resolved skill's own directory to the file-skill roots when it isn't already under a configured root, so an agent-owned skill gets the same Tier 2/3 progressive disclosure as a shared one. Global skills (already under a config root) are untouched.

## Isolation

A `(agentId, skillId)` two-level store structurally guarantees: no cross-agent resolution, no global-pool pollution, owner-scoped shadow bounded by the CM-PR2 tool ceiling. Assumes skill roots and agent roots stay disjoint (the shipped default) — documented on the store. Symlink canonicalization and a root-overlap guard are **deferred to the bundle-injection API**, where the agent directory stops being operator-trusted.

## Review caught real bugs (all fixed in this PR)

An 8-angle `/code-review` + adversarial security pass found:
- **FoundryHost** built agents with a bare `SkillAgentOptions` → owned skills were silently unresolvable on that host → now sets `OwningAgentId`.
- `ResolveSkillPaths` resolved config paths against the **CWD** while the registry uses `AppContext.BaseDirectory` → the "global skills untouched" dedup broke under `dotnet run` → aligned.
- Two `AGENT.md` files sharing an id **silently merged** their private skills → **keep-first-and-warn** (mirrors the skill registry); the owned-skill scan runs only for the winning agent.
- Extracted the duplicated path-containment predicate into a shared `Domain.Common/PathScope` and repointed both the factory and `SkillMetadataRegistry` onto it.

## Follow-up noted (not in this PR)

`/simplify` surfaced **5 pre-existing** sandbox path-traversal guards that hand-roll the same containment check and hardcode `OrdinalIgnoreCase` (latent Linux case-sensitivity widening). Adopting `PathScope` there is a worthwhile, security-sensitive cleanup that deserves its own reviewed PR.

## Test plan

- `AgentOwnedSkillStoreTests` — isolation, precedence data, case-insensitivity, idempotent overwrite
- `AgentMetadataRegistryTests` — nested-skill discovery, no-skills-dir, empty-skill-dir skip, **duplicate-id no-merge**
- `AgentFactoryAgentOwnedSkillTests` — owner shadows global, invisible to other agents, no-owner fallback, unknown throws
- `AgentExecutionContextFactoryNestedSkillPathTests` — augment-not-replace, global dir not double-added
- Full suite green apart from pre-existing environmental failures (Docker/Testcontainers, `C:\WINDOWS\TEMP` writes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)