### PR TITLE
feat: bundle ingestion + ephemeral-agent overlay (Bundle-PR1)

### DIFF
--- a/src/Content/Application/Application.AI.Common/Interfaces/Bundles/IBundleStagingService.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Bundles/IBundleStagingService.cs
@@ -1,0 +1,45 @@
+using Domain.AI.Bundles;
+using Domain.Common;
+
+namespace Application.AI.Common.Interfaces.Bundles;
+
+/// <summary>
+/// Turns a received agent-bundle archive into a <see cref="StagedBundle"/> on disk, applying the host's
+/// hostile-input guards before any of the archive's content is trusted for parsing or execution.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A bundle is untrusted, externally-authored input. Staging is the boundary at which it is made safe:
+/// the archive is size- and shape-checked (compressed size, entry count, total uncompressed size,
+/// compression ratio), each entry's destination is verified to stay within the staging directory
+/// (zip-slip guard), the extracted tree is checked for symlinks that escape the staging root, and the
+/// staging root is verified to be disjoint from the configured skill and agent discovery roots so the
+/// global registries can never independently discover the bundle's skills. Only after all of that does
+/// the service reuse the host's ordinary <c>AGENT.md</c> / <c>SKILL.md</c> / <c>plugin.json</c> parsers
+/// to produce the definitions carried on the returned <see cref="StagedBundle"/>.
+/// </para>
+/// <para>
+/// Any guard failure returns a failed <see cref="Result{T}"/> with a safe, caller-facing reason and
+/// leaves no partial extraction behind. The caller owns the lifetime of a successfully staged bundle's
+/// directory on disk (the run-handle store deletes it on expiry).
+/// </para>
+/// </remarks>
+public interface IBundleStagingService
+{
+    /// <summary>
+    /// Validates and extracts <paramref name="archive"/> into an isolated staging directory, parsing its
+    /// manifests into a <see cref="StagedBundle"/>.
+    /// </summary>
+    /// <param name="archive">
+    /// The received archive stream (a zip). Read once; the caller retains ownership and disposal of the
+    /// stream. The compressed length is enforced against the configured maximum while reading, so a
+    /// non-seekable or oversized stream is rejected without buffering the whole of it.
+    /// </param>
+    /// <param name="cancellationToken">Token to cancel reading and extraction.</param>
+    /// <returns>
+    /// A successful result carrying the <see cref="StagedBundle"/>, or a failure describing the first
+    /// guard the archive tripped (oversized, too many entries, decompression bomb, path traversal,
+    /// escaping symlink, missing <c>AGENT.md</c>, or a staging root that overlaps a discovery root).
+    /// </returns>
+    Task<Result<StagedBundle>> StageAsync(Stream archive, CancellationToken cancellationToken = default);
+}

--- a/src/Content/Application/Application.AI.Common/Services/Bundles/EphemeralAgentOverlayAccessor.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Bundles/EphemeralAgentOverlayAccessor.cs
@@ -1,0 +1,68 @@
+using Domain.AI.Bundles;
+
+namespace Application.AI.Common.Services.Bundles;
+
+/// <summary>
+/// Ambient accessor that publishes the <see cref="EphemeralAgentOverlay"/> active for the current async
+/// flow, so the overlay-aware registries can resolve a bundle's ephemeral agent and its owned skills
+/// without those definitions ever entering the host's persistent registries.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Follows the same pattern as the host's other per-flow accessors (<c>ToolGovernanceAccessor</c>,
+/// <c>AgentTurnStreamSink</c>, <c>KnowledgeScopeAccessor</c>): an <see cref="AsyncLocal{T}"/> the run
+/// path sets at the start of a bundle run and clears in a <c>finally</c>, read at resolution time by the
+/// overlay-aware registries. When unset — every non-bundle code path — the registries fall through to
+/// the global singletons and behave identically to a host with no bundle concept.
+/// </para>
+/// <para>
+/// Prefer <see cref="Begin"/> to publish an overlay: it restores the previous ambient value on dispose,
+/// so nested or sequential runs on the same flow cannot leak an overlay into unrelated work.
+/// </para>
+/// <para>
+/// Caveat for the run path: like any <see cref="AsyncLocal{T}"/>, the overlay is captured into the
+/// <c>ExecutionContext</c> of any fire-and-forget or post-turn background work started <em>while it is
+/// active</em>, and that captured copy keeps seeing the overlay after the <see cref="Begin"/> scope
+/// disposes on the originating flow. Concurrent runs on separate requests are unaffected (each request
+/// is its own flow). The run driver must therefore not spawn detached work that should outlive — or be
+/// isolated from — the ephemeral agent while the overlay is active; scope the overlay tightly around the
+/// turn and let it fall out before any such work is queued.
+/// </para>
+/// </remarks>
+public static class EphemeralAgentOverlayAccessor
+{
+    private static readonly AsyncLocal<EphemeralAgentOverlay?> s_current = new();
+
+    /// <summary>
+    /// The overlay for the current async flow, or <see langword="null"/> when not inside a bundle run.
+    /// </summary>
+    public static EphemeralAgentOverlay? Current => s_current.Value;
+
+    /// <summary>
+    /// Publishes <paramref name="overlay"/> as the ambient overlay for the current async flow and returns
+    /// a handle that restores the previous ambient value when disposed. Use with <c>using</c> so the
+    /// overlay is guaranteed to be torn down when the run completes, even on exception.
+    /// </summary>
+    /// <param name="overlay">The overlay to make active; must not be null.</param>
+    public static IDisposable Begin(EphemeralAgentOverlay overlay)
+    {
+        ArgumentNullException.ThrowIfNull(overlay);
+        var previous = s_current.Value;
+        s_current.Value = overlay;
+        return new OverlayScope(previous);
+    }
+
+    private sealed class OverlayScope(EphemeralAgentOverlay? previous) : IDisposable
+    {
+        private bool _disposed;
+
+        public void Dispose()
+        {
+            if (_disposed)
+                return;
+
+            _disposed = true;
+            s_current.Value = previous;
+        }
+    }
+}

--- a/src/Content/Application/Application.AI.Common/Services/Bundles/OverlayAwareAgentMetadataRegistry.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Bundles/OverlayAwareAgentMetadataRegistry.cs
@@ -1,0 +1,84 @@
+using Application.AI.Common.Interfaces;
+using Domain.AI.Agents;
+using Domain.AI.Bundles;
+
+namespace Application.AI.Common.Services.Bundles;
+
+/// <summary>
+/// Decorates the host's <see cref="IAgentMetadataRegistry"/> so that, for the duration of a bundle run,
+/// the ephemeral agent published on the ambient <see cref="EphemeralAgentOverlay"/> is resolvable
+/// <em>ahead of</em> the persistent, startup-discovered agents — without ever being added to them.
+/// Outside a bundle run (the overlay is unset) every call forwards straight to the inner registry, so
+/// host behaviour is unchanged.
+/// </summary>
+/// <remarks>
+/// The overlay carries a single agent (the one being run). It shadows a persistent agent of the same id
+/// for that run only and is invisible to every other async flow, matching the isolation the persistent
+/// registries provide for host-installed agents.
+/// </remarks>
+public sealed class OverlayAwareAgentMetadataRegistry : IAgentMetadataRegistry
+{
+    private readonly IAgentMetadataRegistry _inner;
+
+    /// <summary>Initialises the decorator over the persistent agent registry.</summary>
+    /// <param name="inner">The host's real agent registry, populated by startup discovery.</param>
+    public OverlayAwareAgentMetadataRegistry(IAgentMetadataRegistry inner)
+    {
+        _inner = inner;
+    }
+
+    /// <inheritdoc />
+    public AgentDefinition? TryGet(string agentId)
+    {
+        var overlay = EphemeralAgentOverlayAccessor.Current;
+        return overlay is not null && overlay.OwnsAgent(agentId) ? overlay.Agent : _inner.TryGet(agentId);
+    }
+
+    /// <inheritdoc />
+    public IReadOnlyList<AgentDefinition> GetAll() =>
+        Merge(_inner.GetAll(), EphemeralAgentOverlayAccessor.Current, overlayMatchesQuery: true);
+
+    /// <inheritdoc />
+    public IReadOnlyList<AgentDefinition> GetByCategory(string category)
+    {
+        var overlay = EphemeralAgentOverlayAccessor.Current;
+        return Merge(_inner.GetByCategory(category), overlay,
+            overlayMatchesQuery: overlay is not null
+                && string.Equals(overlay.Agent.Category, category, StringComparison.OrdinalIgnoreCase));
+    }
+
+    /// <inheritdoc />
+    public IReadOnlyList<AgentDefinition> GetByTags(IEnumerable<string> tags)
+    {
+        var overlay = EphemeralAgentOverlayAccessor.Current;
+        if (overlay is null)
+            return _inner.GetByTags(tags);
+
+        var tagSet = new HashSet<string>(tags, StringComparer.OrdinalIgnoreCase);
+        return Merge(_inner.GetByTags(tagSet), overlay, overlay.Agent.Tags.Any(tagSet.Contains));
+    }
+
+    /// <inheritdoc />
+    public IReadOnlyList<string> SearchedPaths => _inner.SearchedPaths;
+
+    /// <summary>
+    /// Projects the inner result set with the overlay's shadow applied: the overlay agent replaces any
+    /// persistent agent it owns for the whole run, so that shadowed inner entry is dropped from
+    /// <em>every</em> projection (not just the ones the overlay happens to match). The overlay agent is
+    /// then included only when it satisfies the current query (<paramref name="overlayMatchesQuery"/>),
+    /// so a run never sees the stale persistent definition under its old category or tags.
+    /// </summary>
+    private static IReadOnlyList<AgentDefinition> Merge(
+        IReadOnlyList<AgentDefinition> inner, EphemeralAgentOverlay? overlay, bool overlayMatchesQuery)
+    {
+        if (overlay is null)
+            return inner;
+
+        var result = inner.Where(a => !overlay.OwnsAgent(a.Id)).ToList();
+
+        if (overlayMatchesQuery)
+            result.Add(overlay.Agent);
+
+        return result;
+    }
+}

--- a/src/Content/Application/Application.AI.Common/Services/Bundles/OverlayAwareAgentOwnedSkillStore.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Bundles/OverlayAwareAgentOwnedSkillStore.cs
@@ -1,0 +1,64 @@
+using Application.AI.Common.Interfaces.Skills;
+using Domain.AI.Bundles;
+using Domain.AI.Skills;
+
+namespace Application.AI.Common.Services.Bundles;
+
+/// <summary>
+/// Decorates the host's <see cref="IAgentOwnedSkillStore"/> so that, for the duration of a bundle run,
+/// the ephemeral agent's owned skills resolve from the ambient <see cref="EphemeralAgentOverlay"/>
+/// <em>ahead of</em> the persistent store — without ever being written into it. Outside a bundle run
+/// (the overlay is unset) every call forwards straight to the inner store, so host behaviour is
+/// unchanged.
+/// </summary>
+/// <remarks>
+/// Writes (<see cref="Register"/>) always go to the inner store: the overlay is a read-only projection
+/// of a staged bundle and startup discovery must never land in it. Reads consult the overlay first, but
+/// only when its agent id matches the requested one, so a bundle can shadow nothing it does not own.
+/// </remarks>
+public sealed class OverlayAwareAgentOwnedSkillStore : IAgentOwnedSkillStore
+{
+    private readonly IAgentOwnedSkillStore _inner;
+
+    /// <summary>Initialises the decorator over the persistent owned-skill store.</summary>
+    /// <param name="inner">The host's real owned-skill store, populated by agent discovery.</param>
+    public OverlayAwareAgentOwnedSkillStore(IAgentOwnedSkillStore inner)
+    {
+        _inner = inner;
+    }
+
+    /// <inheritdoc />
+    public void Register(string agentId, SkillDefinition skill) => _inner.Register(agentId, skill);
+
+    /// <inheritdoc />
+    public SkillDefinition? TryGet(string agentId, string skillId)
+    {
+        var overlaySkills = OverlaySkillsFor(agentId);
+
+        // When the overlay owns this agent id it is AUTHORITATIVE for the agent's owned skills: resolve
+        // only from it and never fall through to the inner store. Otherwise a bundle whose ephemeral
+        // agent id collides with a host agent would silently inherit that host agent's private skills.
+        // A miss here returns null so the factory falls back to the GLOBAL shared pool — the intended
+        // reuse path — not to a colliding agent's owned skills.
+        if (overlaySkills is not null)
+            return overlaySkills.FirstOrDefault(s => string.Equals(s.Id, skillId, StringComparison.OrdinalIgnoreCase));
+
+        return _inner.TryGet(agentId, skillId);
+    }
+
+    /// <inheritdoc />
+    public IReadOnlyList<SkillDefinition> GetForAgent(string agentId) =>
+        // Authoritative when the overlay owns this agent id (see TryGet); otherwise forward to the inner store.
+        OverlaySkillsFor(agentId) ?? _inner.GetForAgent(agentId);
+
+    /// <summary>
+    /// Returns the ambient overlay's owned skills when an overlay is active <em>and</em> its agent id
+    /// matches <paramref name="agentId"/>; otherwise null (no overlay, or the overlay is for a different
+    /// agent).
+    /// </summary>
+    private static IReadOnlyList<SkillDefinition>? OverlaySkillsFor(string agentId)
+    {
+        var overlay = EphemeralAgentOverlayAccessor.Current;
+        return overlay is not null && overlay.OwnsAgent(agentId) ? overlay.OwnedSkills : null;
+    }
+}

--- a/src/Content/Domain/Domain.AI/Bundles/EphemeralAgentOverlay.cs
+++ b/src/Content/Domain/Domain.AI/Bundles/EphemeralAgentOverlay.cs
@@ -1,0 +1,39 @@
+using Domain.AI.Agents;
+using Domain.AI.Skills;
+
+namespace Domain.AI.Bundles;
+
+/// <summary>
+/// The agent and owned skills that are active for a single bundle run, layered over the host's
+/// startup-discovered registries for the duration of one async flow. A bundle's agent is never added to
+/// the host's persistent agent registry and its skills are never added to the global skill pool; instead
+/// this overlay is consulted <em>first</em> by the overlay-aware registries so the ephemeral definitions
+/// are resolvable only within the run that set it, and vanish the moment that flow completes.
+/// </summary>
+/// <remarks>
+/// This is the resolution-time projection of a <see cref="StagedBundle"/> — just the pieces the agent
+/// factory needs to resolve and build the agent (its definition and its owned skills), without the
+/// staging-only details. It is a pure value; the ambient plumbing that publishes it for a run lives in
+/// the accessor that carries it, mirroring the host's existing per-turn <c>AsyncLocal</c> accessors.
+/// </remarks>
+public sealed record EphemeralAgentOverlay
+{
+    /// <summary>The ephemeral agent for this run, parsed from the bundle's <c>AGENT.md</c>.</summary>
+    public required AgentDefinition Agent { get; init; }
+
+    /// <summary>
+    /// The skills owned by <see cref="Agent"/>, resolved owned-first (and only) for this run's agent id.
+    /// Empty when the bundle declares no nested skills.
+    /// </summary>
+    public IReadOnlyList<SkillDefinition> OwnedSkills { get; init; } = [];
+
+    /// <summary>
+    /// Whether this overlay is the one for the agent identified by <paramref name="agentId"/> — the single
+    /// authoritative definition of "the overlay owns this agent", so every resolution seam (agent metadata,
+    /// owned skills) applies the overlay by the same rule and cannot drift into a half-applied state.
+    /// Matching is case-insensitive, mirroring the host registries.
+    /// </summary>
+    /// <param name="agentId">The agent id being resolved.</param>
+    public bool OwnsAgent(string agentId) =>
+        string.Equals(Agent.Id, agentId, StringComparison.OrdinalIgnoreCase);
+}

--- a/src/Content/Domain/Domain.AI/Bundles/StagedBundle.cs
+++ b/src/Content/Domain/Domain.AI/Bundles/StagedBundle.cs
@@ -1,0 +1,60 @@
+using Domain.AI.Agents;
+using Domain.AI.Skills;
+using Domain.Common.Config.AI.Plugins;
+
+namespace Domain.AI.Bundles;
+
+/// <summary>
+/// The result of staging an externally-authored agent bundle: an <c>AGENT.md</c> (parsed into
+/// <see cref="Agent"/>), its nested <c>SKILL.md</c> files (parsed into <see cref="OwnedSkills"/>), and
+/// any plugin manifests, all extracted to an isolated directory on disk under the host's hostile-input
+/// guards. The parsed definitions carry file paths that point <em>into</em> <see cref="StagedRootDirectory"/>,
+/// so the existing skill-disclosure machinery (which reads Tier 2/3 content from disk) can serve the
+/// bundle exactly as it serves a host-installed agent-owned skill.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A staged bundle is a value: it describes what was extracted and where, but owns no process resources
+/// and performs no I/O. The lifetime of <see cref="StagedRootDirectory"/> on disk is owned by the caller
+/// that staged it — the bundle-run job store deletes it when the run handle expires. Nothing here deletes
+/// the directory, so holding a <see cref="StagedBundle"/> never has a side effect.
+/// </para>
+/// <para>
+/// The bundle's skills are <em>owned</em> by <see cref="Agent"/> in exactly the sense of an agent-owned
+/// nested skill: they are private to this bundle's ephemeral agent and must never enter a global registry.
+/// The per-run overlay resolves them owned-first, keyed by <see cref="AgentDefinition.Id"/>.
+/// </para>
+/// </remarks>
+public sealed record StagedBundle
+{
+    /// <summary>
+    /// Opaque identifier for this staged bundle, unique per staging operation. Used to name the
+    /// staging subdirectory and, later, to key the run handle. Distinct from
+    /// <see cref="AgentDefinition.Id"/>, which comes from the bundle's own <c>AGENT.md</c> and is not
+    /// guaranteed unique across bundles.
+    /// </summary>
+    public required string BundleId { get; init; }
+
+    /// <summary>
+    /// Absolute path to the directory the bundle was extracted into — the agent root. The
+    /// <c>AGENT.md</c> sits at its top level and nested skills under <c>&lt;root&gt;/skills/</c>. Every
+    /// path on <see cref="Agent"/> and <see cref="OwnedSkills"/> is contained within this directory.
+    /// </summary>
+    public required string StagedRootDirectory { get; init; }
+
+    /// <summary>The agent parsed from the bundle's <c>AGENT.md</c>.</summary>
+    public required AgentDefinition Agent { get; init; }
+
+    /// <summary>
+    /// The skills parsed from the bundle's nested <c>&lt;root&gt;/skills/*/SKILL.md</c> files. Owned by
+    /// <see cref="Agent"/>; empty when the bundle declares no nested skills.
+    /// </summary>
+    public IReadOnlyList<SkillDefinition> OwnedSkills { get; init; } = [];
+
+    /// <summary>
+    /// The plugin manifests parsed from any <c>plugin.json</c> files in the bundle. Empty when the
+    /// bundle ships no plugins. Carried through staging for completeness; wiring a bundle's plugins into
+    /// its ephemeral agent is a later concern.
+    /// </summary>
+    public IReadOnlyList<PluginManifest> PluginManifests { get; init; } = [];
+}

--- a/src/Content/Domain/Domain.Common/Config/AI/AIConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/AIConfig.cs
@@ -1,6 +1,7 @@
 using Domain.Common.Config.AI.A2A;
 using Domain.Common.Config.AI.AIFoundry;
 using Domain.Common.Config.AI.Audit;
+using Domain.Common.Config.AI.BundleExecution;
 using Domain.Common.Config.AI.ContextManagement;
 using Domain.Common.Config.AI.DriftDetection;
 using Domain.Common.Config.AI.GitOps;
@@ -192,6 +193,16 @@ public class AIConfig
     /// before the model runs.
     /// </summary>
     public LearningsRecallConfig LearningsRecall { get; set; } = new();
+
+    /// <summary>
+    /// Bundle-execution subsystem configuration. Off by default — when enabled, the host can accept a
+    /// self-contained, externally-authored agent bundle (a zip of <c>AGENT.md</c> + nested
+    /// <c>SKILL.md</c> + plugin manifests), stage it to an isolated temp directory under hostile-input
+    /// guards, and run it as an ephemeral agent resolved through a per-run overlay. Distinct from
+    /// <see cref="Plugins"/> (host-declared local plugin directories, trusted and startup-scanned):
+    /// a bundle arrives at runtime from an external caller and is confined as untrusted input.
+    /// </summary>
+    public BundleExecutionConfig BundleExecution { get; set; } = new();
 
     /// <summary>Agent Governance Toolkit configuration.</summary>
     public GovernanceConfig Governance { get; init; } = new();

--- a/src/Content/Domain/Domain.Common/Config/AI/BundleExecution/BundleExecutionConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/BundleExecution/BundleExecutionConfig.cs
@@ -1,0 +1,78 @@
+namespace Domain.Common.Config.AI.BundleExecution;
+
+/// <summary>
+/// Root configuration for the bundle-execution subsystem — the host's ability to accept a
+/// self-contained, externally-authored agent bundle (an <c>AGENT.md</c> with nested <c>SKILL.md</c>
+/// files and plugin manifests, delivered as a zip archive), stage it to an isolated temp directory,
+/// and run it as an ephemeral agent. Bound from <c>AppConfig:AI:BundleExecution</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>Off by default.</strong> A bundle is untrusted, externally-authored input, and the subsystem
+/// that runs it is only useful once the full ingest → envelope → job → API sequence exists. A fresh
+/// consumer therefore pays no cost and exposes no surface until they deliberately opt in.
+/// </para>
+/// <para>
+/// The archive limits here are the first line of defence against a hostile archive: they bound how much
+/// a bundle can cost the host before anything is parsed or built. They are enforced by the staging
+/// service at ingest time, before untrusted content is trusted for execution. See
+/// <c>IBundleStagingService</c>.
+/// </para>
+/// <code>
+/// AppConfig.AI.BundleExecution
+/// ├── Enabled                     — Master toggle (default false)
+/// ├── TempRoot                    — Directory under which each bundle is staged in its own subfolder
+/// ├── MaxArchiveBytes             — Reject archives larger than this on the wire (compressed size)
+/// ├── MaxEntryCount               — Reject archives with more than this many entries
+/// ├── MaxTotalUncompressedBytes   — Reject when the sum of entry sizes exceeds this (bomb guard)
+/// └── MaxCompressionRatio         — Reject when uncompressed/compressed exceeds this (bomb guard)
+/// </code>
+/// </remarks>
+public class BundleExecutionConfig
+{
+    /// <summary>
+    /// Master toggle. When disabled (the default), no bundle staging, overlay, or run surface is active
+    /// and the host behaves identically to one with no bundle-execution concept at all.
+    /// </summary>
+    /// <value>Default: false</value>
+    public bool Enabled { get; set; }
+
+    /// <summary>
+    /// Directory under which each accepted bundle is staged into its own uniquely-named subdirectory.
+    /// Must be a location outside every configured skill and agent discovery root (the staging service
+    /// asserts this), so the global registries never independently discover a staged bundle's skills.
+    /// When empty, the staging service falls back to a subdirectory of the system temp path.
+    /// </summary>
+    /// <value>Default: "" (system temp path)</value>
+    public string TempRoot { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Maximum accepted size, in bytes, of the archive as received (its compressed size on the wire).
+    /// Archives larger than this are rejected before extraction. Must be positive.
+    /// </summary>
+    /// <value>Default: 10485760 (10 MiB)</value>
+    public long MaxArchiveBytes { get; set; } = 10 * 1024 * 1024;
+
+    /// <summary>
+    /// Maximum number of entries an accepted archive may contain. Bounds the cost of iterating and
+    /// extracting entries and caps a "many tiny files" denial-of-service. Must be positive.
+    /// </summary>
+    /// <value>Default: 2000</value>
+    public int MaxEntryCount { get; set; } = 2000;
+
+    /// <summary>
+    /// Maximum total uncompressed size, in bytes, summed across all entries. This is the primary
+    /// decompression-bomb guard: extraction is aborted the moment the running total would exceed it.
+    /// Must be positive.
+    /// </summary>
+    /// <value>Default: 52428800 (50 MiB)</value>
+    public long MaxTotalUncompressedBytes { get; set; } = 50 * 1024 * 1024;
+
+    /// <summary>
+    /// Maximum permitted ratio of total uncompressed size to compressed archive size. A high ratio is
+    /// the signature of a decompression bomb (a tiny archive that explodes on disk). Evaluated once the
+    /// compressed size is known and non-trivial. Must be positive.
+    /// </summary>
+    /// <value>Default: 100</value>
+    public double MaxCompressionRatio { get; set; } = 100;
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Agents/AgentMetadataRegistry.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Agents/AgentMetadataRegistry.cs
@@ -219,41 +219,11 @@ public sealed class AgentMetadataRegistry : IAgentMetadataRegistry
     private void DiscoverAgentOwnedSkills(string agentDirectory, string agentId)
     {
         var skillsRoot = Path.Combine(agentDirectory, "skills");
-        if (!Directory.Exists(skillsRoot))
-            return;
-
-        IEnumerable<string> skillDirs;
-        try
+        foreach (var skill in NestedSkillScanner.Scan(skillsRoot, _skillParser, _logger))
         {
-            skillDirs = Directory.EnumerateDirectories(skillsRoot);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "Could not enumerate agent-owned skills directory: {Path}", skillsRoot);
-            return;
-        }
-
-        foreach (var skillDir in skillDirs)
-        {
-            var skillFile = Path.Combine(skillDir, "SKILL.md");
-            if (!File.Exists(skillFile))
-                continue;
-
-            try
-            {
-                var skill = _skillParser.ParseFromFile(skillFile, skillDir);
-                if (string.IsNullOrEmpty(skill.Id))
-                    continue;
-
-                _ownedSkills.Register(agentId, skill);
-                _logger.LogDebug(
-                    "Discovered agent-owned skill {SkillId} for agent {AgentId} from {Path}",
-                    skill.Id, agentId, skillDir);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogWarning(ex, "Failed to parse agent-owned skill from {Path}", skillFile);
-            }
+            _ownedSkills.Register(agentId, skill);
+            _logger.LogDebug(
+                "Discovered agent-owned skill {SkillId} for agent {AgentId}", skill.Id, agentId);
         }
     }
 }

--- a/src/Content/Infrastructure/Infrastructure.AI/Bundles/BundleStagingService.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Bundles/BundleStagingService.cs
@@ -1,0 +1,421 @@
+using System.IO.Compression;
+using Application.AI.Common.Interfaces.Bundles;
+using Application.AI.Common.Interfaces.Plugins;
+using Domain.AI.Bundles;
+using Domain.AI.Skills;
+using Domain.Common;
+using Domain.Common.Config;
+using Domain.Common.Config.AI.BundleExecution;
+using Domain.Common.Config.AI.Plugins;
+using Domain.Common.Helpers;
+using Infrastructure.AI.Agents;
+using Infrastructure.AI.Skills;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Infrastructure.AI.Bundles;
+
+/// <summary>
+/// Default <see cref="IBundleStagingService"/>. Validates a received zip against the configured archive
+/// limits, extracts it into an isolated per-bundle directory under hostile-input guards (zip-slip,
+/// decompression bomb, escaping symlinks, staging/discovery-root disjointness), then reuses the host's
+/// ordinary <c>AGENT.md</c>/<c>SKILL.md</c>/<c>plugin.json</c> parsers to produce a <see cref="StagedBundle"/>.
+/// </summary>
+/// <remarks>
+/// Nothing extracted from the archive is parsed until every structural guard has passed, and any guard
+/// failure deletes the partial extraction before returning. The service never surfaces archive content
+/// in a failure reason — reasons describe the guard, not the payload.
+/// </remarks>
+public sealed class BundleStagingService : IBundleStagingService
+{
+    private const int CopyBufferSize = 81920;
+
+    /// <summary>
+    /// Compression-ratio checking is skipped below this uncompressed size. Small, highly-compressible
+    /// text bundles (a handful of markdown files) can legitimately exceed the ratio; the absolute
+    /// <see cref="BundleExecutionConfig.MaxTotalUncompressedBytes"/> guard already bounds them. The ratio
+    /// guard exists for the large-payload case where a bomb's signature is a runaway expansion factor.
+    /// </summary>
+    private const long RatioGuardFloorBytes = 1024 * 1024;
+
+    private readonly IOptionsMonitor<AppConfig> _appConfig;
+    private readonly AgentMetadataParser _agentParser;
+    private readonly SkillMetadataParser _skillParser;
+    private readonly IPluginManifestReader _pluginReader;
+    private readonly ILogger<BundleStagingService> _logger;
+
+    /// <summary>Initialises the staging service with its parsers, configuration, and logger.</summary>
+    public BundleStagingService(
+        IOptionsMonitor<AppConfig> appConfig,
+        AgentMetadataParser agentParser,
+        SkillMetadataParser skillParser,
+        IPluginManifestReader pluginReader,
+        ILogger<BundleStagingService> logger)
+    {
+        _appConfig = appConfig;
+        _agentParser = agentParser;
+        _skillParser = skillParser;
+        _pluginReader = pluginReader;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<Result<StagedBundle>> StageAsync(Stream archive, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(archive);
+        var cfg = _appConfig.CurrentValue.AI.BundleExecution;
+
+        var stagingRoot = ResolveStagingRoot(cfg);
+        var disjoint = ValidateStagingRootDisjoint(stagingRoot);
+        if (!disjoint.IsSuccess)
+            return Result<StagedBundle>.Fail([.. disjoint.Errors]);
+
+        var buffered = await BufferArchiveAsync(archive, cfg, cancellationToken);
+        if (!buffered.IsSuccess)
+            return Result<StagedBundle>.Fail([.. buffered.Errors]);
+
+        using var buffer = buffered.Value!.Stream;
+
+        ZipArchive zip;
+        try
+        {
+            zip = new ZipArchive(buffer, ZipArchiveMode.Read, leaveOpen: true);
+        }
+        catch (InvalidDataException)
+        {
+            return Result<StagedBundle>.Fail("Bundle is not a valid zip archive.");
+        }
+
+        using (zip)
+            return await StageOpenedArchiveAsync(zip, buffered.Value!.CompressedLength, cfg, stagingRoot, cancellationToken);
+    }
+
+    /// <summary>
+    /// Validates the opened archive's shape, extracts it into a fresh per-bundle directory under the
+    /// hostile-input guards, and parses the result. Guarantees the staging directory is deleted on every
+    /// non-success exit — a guard failure, an unexpected error, or cancellation — so a partial extraction
+    /// never survives.
+    /// </summary>
+    private async Task<Result<StagedBundle>> StageOpenedArchiveAsync(
+        ZipArchive zip, long compressedLength, BundleExecutionConfig cfg, string stagingRoot, CancellationToken cancellationToken)
+    {
+        var structural = ValidateArchiveShape(zip, compressedLength, cfg);
+        if (!structural.IsSuccess)
+            return Result<StagedBundle>.Fail([.. structural.Errors]);
+
+        var bundleId = $"bundle-{Guid.NewGuid():N}";
+        var bundleDir = Path.Combine(stagingRoot, bundleId);
+        Directory.CreateDirectory(bundleDir);
+
+        try
+        {
+            var extract = await ExtractWithGuardsAsync(zip, bundleDir, cfg, compressedLength, cancellationToken);
+            if (!extract.IsSuccess)
+                return CleanupAndFail(bundleDir, [.. extract.Errors]);
+
+            var symlinks = ValidateNoEscapingSymlinks(bundleDir);
+            if (!symlinks.IsSuccess)
+                return CleanupAndFail(bundleDir, [.. symlinks.Errors]);
+
+            return ParseStagedBundle(bundleDir, bundleId);
+        }
+        catch (OperationCanceledException)
+        {
+            // Honour cancellation, but never leave the partial extraction behind.
+            TryCleanup(bundleDir);
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Bundle staging failed while extracting into {BundleDir}", bundleDir);
+            return CleanupAndFail(bundleDir, "Bundle staging failed while extracting the archive.");
+        }
+    }
+
+    private static string ResolveStagingRoot(BundleExecutionConfig cfg) =>
+        string.IsNullOrWhiteSpace(cfg.TempRoot)
+            ? Path.Combine(Path.GetTempPath(), "agent-bundles")
+            : ResolveConfiguredPath(cfg.TempRoot);
+
+    /// <summary>
+    /// Resolves a configured path to an absolute one, relative paths being taken against
+    /// <see cref="AppContext.BaseDirectory"/> (the bin folder) to match the registries. Used for both the
+    /// staging root and the discovery roots so the disjointness guard compares like against like — a
+    /// difference here could let an overlapping root slip past.
+    /// </summary>
+    private static string ResolveConfiguredPath(string path) =>
+        Path.IsPathRooted(path) ? path : Path.GetFullPath(path, AppContext.BaseDirectory);
+
+    /// <summary>
+    /// Rejects a staging root that overlaps any configured skill or agent discovery root. The global
+    /// registries scan those roots recursively and are bundle-unaware, so a staging root nested under
+    /// (or an ancestor of) a discovery root would let them independently discover — and globally publish
+    /// — a bundle's skills, defeating the per-run isolation.
+    /// </summary>
+    private Result ValidateStagingRootDisjoint(string stagingRoot)
+    {
+        var normalizedStaging = PathScope.Normalize(stagingRoot);
+        foreach (var root in ConfiguredDiscoveryRoots())
+        {
+            var normalizedRoot = PathScope.Normalize(root);
+            if (PathScope.IsSameOrUnderNormalized(normalizedStaging, normalizedRoot)
+                || PathScope.IsSameOrUnderNormalized(normalizedRoot, normalizedStaging))
+            {
+                _logger.LogError(
+                    "Bundle staging root {StagingRoot} overlaps discovery root {DiscoveryRoot}; refusing to stage",
+                    normalizedStaging, normalizedRoot);
+                return Result.Fail(
+                    "Bundle staging root overlaps a configured skill or agent discovery root. " +
+                    "Configure AI:BundleExecution:TempRoot to a location outside the skill and agent paths.");
+            }
+        }
+
+        return Result.Success();
+    }
+
+    private IEnumerable<string> ConfiguredDiscoveryRoots()
+    {
+        var ai = _appConfig.CurrentValue.AI;
+        foreach (var p in ai.Skills.AllPaths.Concat(ai.Agents.AllPaths))
+            yield return ResolveConfiguredPath(p);
+    }
+
+    private async Task<Result<BufferedArchive>> BufferArchiveAsync(
+        Stream archive, BundleExecutionConfig cfg, CancellationToken cancellationToken)
+    {
+        // The buffered stream is handed to the caller (which owns its disposal and reads the zip directly
+        // from it); on any failure path here we dispose it ourselves before returning.
+        var sink = new MemoryStream();
+        try
+        {
+            var chunk = new byte[CopyBufferSize];
+            long total = 0;
+            int read;
+            while ((read = await archive.ReadAsync(chunk, cancellationToken)) > 0)
+            {
+                total += read;
+                if (total > cfg.MaxArchiveBytes)
+                {
+                    sink.Dispose();
+                    return Result<BufferedArchive>.Fail(
+                        $"Bundle archive exceeds the maximum accepted size of {cfg.MaxArchiveBytes} bytes.");
+                }
+
+                sink.Write(chunk, 0, read);
+            }
+
+            if (total == 0)
+            {
+                sink.Dispose();
+                return Result<BufferedArchive>.Fail("Bundle archive is empty.");
+            }
+
+            sink.Position = 0;
+            return Result<BufferedArchive>.Success(new BufferedArchive(sink, total));
+        }
+        catch
+        {
+            sink.Dispose();
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// The archive read fully into a seekable in-memory stream, with the compressed length observed
+    /// while reading. The <see cref="Stream"/> is positioned at zero and owned by the caller.
+    /// </summary>
+    private sealed record BufferedArchive(MemoryStream Stream, long CompressedLength);
+
+    /// <summary>
+    /// Structural guards read from the archive's central directory before any bytes are written to disk:
+    /// entry count, declared total uncompressed size, and (for large payloads) the compression ratio.
+    /// The declared sizes here are attacker-controllable header values, so extraction re-checks the
+    /// running total against actual bytes written — this pass is the cheap first rejection.
+    /// </summary>
+    private static Result ValidateArchiveShape(ZipArchive zip, long compressedLength, BundleExecutionConfig cfg)
+    {
+        if (zip.Entries.Count > cfg.MaxEntryCount)
+            return Result.Fail($"Bundle archive has more than the maximum {cfg.MaxEntryCount} entries.");
+
+        long declaredUncompressed = 0;
+        foreach (var entry in zip.Entries)
+            declaredUncompressed += entry.Length;
+
+        var expansion = CheckExpansionLimits(declaredUncompressed, compressedLength, cfg);
+        return expansion is not null ? Result.Fail(expansion) : Result.Success();
+    }
+
+    /// <summary>
+    /// The shared decompression-bomb predicate: rejects when the uncompressed size (declared at pre-pass
+    /// time, actual at extraction time) exceeds the absolute cap, or when it exceeds the ratio limit above
+    /// the small-payload floor. Kept in one place so the cheap declared-size pass and the authoritative
+    /// per-chunk actual-size check can never drift apart. Returns a caller-facing failure reason, or null
+    /// when the bytes are within limits.
+    /// </summary>
+    private static string? CheckExpansionLimits(long uncompressedBytes, long compressedLength, BundleExecutionConfig cfg)
+    {
+        if (uncompressedBytes > cfg.MaxTotalUncompressedBytes)
+            return $"Bundle archive expands to more than the maximum {cfg.MaxTotalUncompressedBytes} bytes.";
+
+        if (uncompressedBytes > RatioGuardFloorBytes
+            && compressedLength > 0
+            && (double)uncompressedBytes / compressedLength > cfg.MaxCompressionRatio)
+            return $"Bundle archive compression ratio exceeds the maximum {cfg.MaxCompressionRatio}.";
+
+        return null;
+    }
+
+    private async Task<Result> ExtractWithGuardsAsync(
+        ZipArchive zip, string bundleDir, BundleExecutionConfig cfg, long compressedLength, CancellationToken cancellationToken)
+    {
+        var normalizedBundleDir = PathScope.Normalize(bundleDir);
+        var chunk = new byte[CopyBufferSize];
+        long actualUncompressed = 0;
+
+        foreach (var entry in zip.Entries)
+        {
+            var destination = Path.GetFullPath(Path.Combine(bundleDir, entry.FullName));
+
+            // Zip-slip: every entry must resolve to a path inside the bundle directory. Catches "../"
+            // traversal and absolute paths (Path.Combine returns a rooted second argument verbatim).
+            if (!PathScope.IsSameOrUnderNormalized(PathScope.Normalize(destination), normalizedBundleDir))
+                return Result.Fail("Bundle archive contains an entry that escapes the staging directory.");
+
+            // Directory entry (name is empty when the full name ends in a separator).
+            if (string.IsNullOrEmpty(entry.Name))
+            {
+                Directory.CreateDirectory(destination);
+                continue;
+            }
+
+            Directory.CreateDirectory(Path.GetDirectoryName(destination)!);
+
+            await using var entryStream = entry.Open();
+            await using var fileStream = new FileStream(
+                destination, FileMode.Create, FileAccess.Write, FileShare.None, CopyBufferSize, useAsync: true);
+
+            int read;
+            while ((read = await entryStream.ReadAsync(chunk, cancellationToken)) > 0)
+            {
+                actualUncompressed += read;
+
+                // Bomb guard on ACTUAL bytes decompressed, not the attacker-declared header sizes — a
+                // bomb that lies about its entry lengths still trips this once real expansion exceeds the
+                // limits the declared-size pre-pass also uses.
+                var expansion = CheckExpansionLimits(actualUncompressed, compressedLength, cfg);
+                if (expansion is not null)
+                    return Result.Fail(expansion);
+
+                await fileStream.WriteAsync(chunk.AsMemory(0, read), cancellationToken);
+            }
+        }
+
+        return Result.Success();
+    }
+
+    /// <summary>
+    /// Rejects the bundle when any extracted entry is a symlink whose final target resolves outside the
+    /// staging directory. Modern .NET extraction writes link entries as regular files rather than
+    /// creating links, so this is defence-in-depth against a filesystem or future extractor that does
+    /// materialise them.
+    /// </summary>
+    private Result ValidateNoEscapingSymlinks(string bundleDir)
+    {
+        var normalizedBundleDir = PathScope.Normalize(bundleDir);
+        foreach (var path in Directory.EnumerateFileSystemEntries(bundleDir, "*", SearchOption.AllDirectories))
+        {
+            FileSystemInfo info = Directory.Exists(path) ? new DirectoryInfo(path) : new FileInfo(path);
+            var target = info.ResolveLinkTarget(returnFinalTarget: true);
+            if (target is not null
+                && !PathScope.IsSameOrUnderNormalized(PathScope.Normalize(target.FullName), normalizedBundleDir))
+            {
+                _logger.LogWarning("Bundle contains a symlink at {Path} that escapes the staging root", path);
+                return Result.Fail("Bundle contains a symlink that escapes the staging directory.");
+            }
+        }
+
+        return Result.Success();
+    }
+
+    private Result<StagedBundle> ParseStagedBundle(string bundleDir, string bundleId)
+    {
+        var agentFile = Path.Combine(bundleDir, "AGENT.md");
+        if (!File.Exists(agentFile))
+            return CleanupAndFail(bundleDir, "Bundle has no AGENT.md at its root.");
+
+        var agent = _agentParser.ParseFromFile(agentFile, bundleDir);
+        if (string.IsNullOrEmpty(agent.Id))
+            return CleanupAndFail(bundleDir, "Bundle AGENT.md has no resolvable id.");
+
+        var ownedSkills = ParseNestedSkills(bundleDir);
+        var manifests = ParsePluginManifests(bundleDir);
+
+        return Result<StagedBundle>.Success(new StagedBundle
+        {
+            BundleId = bundleId,
+            StagedRootDirectory = bundleDir,
+            Agent = agent,
+            OwnedSkills = ownedSkills,
+            PluginManifests = manifests,
+        });
+    }
+
+    private IReadOnlyList<SkillDefinition> ParseNestedSkills(string bundleDir)
+    {
+        // Reuses the same nested-skill discovery a host agent uses for its own <agentDir>/skills/, so a
+        // malformed SKILL.md is skipped-and-warned rather than aborting the whole bundle. This layer only
+        // adds bundle-specific de-duplication (keep first) on top of the shared scan.
+        var scanned = NestedSkillScanner.Scan(Path.Combine(bundleDir, "skills"), _skillParser, _logger);
+
+        var byId = new Dictionary<string, SkillDefinition>(StringComparer.OrdinalIgnoreCase);
+        foreach (var skill in scanned)
+        {
+            if (!byId.TryAdd(skill.Id, skill))
+                _logger.LogWarning(
+                    "Bundle declares duplicate nested skill id '{SkillId}'; keeping the first", skill.Id);
+        }
+
+        return [.. byId.Values];
+    }
+
+    private IReadOnlyList<PluginManifest> ParsePluginManifests(string bundleDir)
+    {
+        var manifests = new List<PluginManifest>();
+
+        var rootManifest = _pluginReader.Read(bundleDir);
+        if (rootManifest is not null)
+            manifests.Add(rootManifest);
+
+        var pluginsRoot = Path.Combine(bundleDir, "plugins");
+        if (Directory.Exists(pluginsRoot))
+        {
+            foreach (var pluginDir in Directory.EnumerateDirectories(pluginsRoot))
+            {
+                var manifest = _pluginReader.Read(pluginDir);
+                if (manifest is not null)
+                    manifests.Add(manifest);
+            }
+        }
+
+        return manifests;
+    }
+
+    private Result<StagedBundle> CleanupAndFail(string bundleDir, params string[] errors)
+    {
+        TryCleanup(bundleDir);
+        return Result<StagedBundle>.Fail(errors);
+    }
+
+    private void TryCleanup(string bundleDir)
+    {
+        try
+        {
+            if (Directory.Exists(bundleDir))
+                Directory.Delete(bundleDir, recursive: true);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to clean up staging directory {BundleDir}", bundleDir);
+        }
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.cs
@@ -3,6 +3,7 @@ using Application.AI.Common.Interfaces;
 using Application.AI.Common.Interfaces.Agent;
 using Application.AI.Common.Interfaces.Compression;
 using Application.AI.Common.Interfaces.Agents;
+using Application.AI.Common.Interfaces.Bundles;
 using Application.AI.Common.Interfaces.Compaction;
 using Application.AI.Common.Interfaces.Config;
 using Application.AI.Common.Interfaces.Context;
@@ -10,6 +11,7 @@ using Application.AI.Common.Interfaces.Hooks;
 using Application.AI.Common.Interfaces.MetaHarness;
 using Application.AI.Common.Interfaces.Plugins;
 using Application.AI.Common.Interfaces.Skills;
+using Application.AI.Common.Services.Bundles;
 using Application.AI.Common.Interfaces.Prompts;
 using Application.AI.Common.Interfaces.Routing;
 using Application.AI.Common.Interfaces.Tools;
@@ -19,6 +21,7 @@ using Domain.Common.Config;
 using Domain.Common.Workflow;
 using Infrastructure.AI.Agents;
 using Infrastructure.AI.Audit;
+using Infrastructure.AI.Bundles;
 using Infrastructure.AI.Compaction;
 using Infrastructure.AI.Compaction.Strategies;
 using Infrastructure.AI.Tools.GitOps;
@@ -165,9 +168,25 @@ public static partial class DependencyInjection
 
         services.AddSingleton<SkillMetadataParser>();
         services.AddSingleton<ISkillMetadataRegistry, SkillMetadataRegistry>();
-        services.AddSingleton<IAgentOwnedSkillStore, AgentOwnedSkillStore>();
+
+        // The owned-skill store and agent registry are decorated so a bundle run can resolve its
+        // ephemeral agent and owned skills from an ambient overlay ahead of the persistent registries,
+        // without those definitions ever being written into them. The decorators are behaviour-neutral
+        // pass-throughs whenever no overlay is active — i.e. on every non-bundle code path.
+        services.AddSingleton<AgentOwnedSkillStore>();
+        services.AddSingleton<IAgentOwnedSkillStore>(sp =>
+            new OverlayAwareAgentOwnedSkillStore(sp.GetRequiredService<AgentOwnedSkillStore>()));
+
         services.AddSingleton<AgentMetadataParser>();
-        services.AddSingleton<IAgentMetadataRegistry, AgentMetadataRegistry>();
+        services.AddSingleton<AgentMetadataRegistry>();
+        services.AddSingleton<IAgentMetadataRegistry>(sp =>
+            new OverlayAwareAgentMetadataRegistry(sp.GetRequiredService<AgentMetadataRegistry>()));
+
+        // --- Bundle execution (staging) ---
+        // Off by default (AI:BundleExecution:Enabled). The staging service is passive — it does nothing
+        // until an ingest call reaches it — so it is registered unconditionally; the run/API surface that
+        // invokes it is gated in a later layer.
+        services.AddSingleton<IBundleStagingService, BundleStagingService>();
 
         // --- Plugins ---
 

--- a/src/Content/Infrastructure/Infrastructure.AI/Skills/NestedSkillScanner.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Skills/NestedSkillScanner.cs
@@ -1,0 +1,67 @@
+using Domain.AI.Skills;
+using Microsoft.Extensions.Logging;
+
+namespace Infrastructure.AI.Skills;
+
+/// <summary>
+/// Scans a <c>skills/</c> directory for nested <c>&lt;skill&gt;/SKILL.md</c> files and parses each into a
+/// <see cref="SkillDefinition"/>. This is the one shared implementation of the "skills owned under a
+/// parent directory" discovery contract, used both by agent discovery (a host agent's
+/// <c>&lt;agentDir&gt;/skills/</c>) and by bundle staging (a staged bundle's <c>&lt;bundleDir&gt;/skills/</c>),
+/// so the two cannot drift in how they enumerate, which manifest they read, or how they tolerate a
+/// malformed entry.
+/// </summary>
+/// <remarks>
+/// Discovery is best-effort and resilient: a missing directory yields an empty list, a directory that
+/// cannot be enumerated logs a warning and yields empty, and a single malformed <c>SKILL.md</c> logs a
+/// warning and is skipped without aborting the scan of its siblings. Skills whose id could not be
+/// resolved are dropped. Callers own de-duplication and any per-skill side effects (registering, caching).
+/// </remarks>
+internal static class NestedSkillScanner
+{
+    /// <summary>
+    /// Returns the skills found directly under <paramref name="skillsRoot"/> (one per
+    /// <c>&lt;subdir&gt;/SKILL.md</c>), in filesystem-enumeration order and possibly containing duplicate
+    /// ids if two subdirectories declare the same one — the caller decides how to resolve those.
+    /// </summary>
+    /// <param name="skillsRoot">The <c>skills/</c> directory to scan. A non-existent path yields an empty list.</param>
+    /// <param name="parser">Parser used to read each <c>SKILL.md</c>.</param>
+    /// <param name="logger">Logger for enumeration and per-skill parse diagnostics.</param>
+    public static IReadOnlyList<SkillDefinition> Scan(string skillsRoot, SkillMetadataParser parser, ILogger logger)
+    {
+        if (!Directory.Exists(skillsRoot))
+            return [];
+
+        IEnumerable<string> skillDirs;
+        try
+        {
+            skillDirs = Directory.EnumerateDirectories(skillsRoot);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Could not enumerate nested skills directory: {Path}", skillsRoot);
+            return [];
+        }
+
+        var skills = new List<SkillDefinition>();
+        foreach (var skillDir in skillDirs)
+        {
+            var skillFile = Path.Combine(skillDir, "SKILL.md");
+            if (!File.Exists(skillFile))
+                continue;
+
+            try
+            {
+                var skill = parser.ParseFromFile(skillFile, skillDir);
+                if (!string.IsNullOrEmpty(skill.Id))
+                    skills.Add(skill);
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "Failed to parse nested skill from {Path}", skillFile);
+            }
+        }
+
+        return skills;
+    }
+}

--- a/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentFactoryEphemeralOverlayTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentFactoryEphemeralOverlayTests.cs
@@ -1,0 +1,144 @@
+using Application.AI.Common.Factories;
+using Application.AI.Common.Interfaces;
+using Application.AI.Common.Interfaces.Skills;
+using Application.AI.Common.Services.Bundles;
+using Application.AI.Common.Services.Skills;
+using Application.AI.Common.Tests.Fakes;
+using Domain.AI.Agents;
+using Domain.AI.Bundles;
+using Domain.AI.Skills;
+using Domain.Common.Config;
+using Domain.Common.Config.AI;
+using FluentAssertions;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Application.AI.Common.Tests.Factories;
+
+/// <summary>
+/// Proves the bundle-overlay seam end-to-end through the real <see cref="AgentFactory"/>: with an
+/// ephemeral overlay active, the factory resolves and builds an agent from a skill that exists <em>only</em>
+/// in the overlay (absent from both the global registry and the persistent owned-skill store), and that
+/// same build fails once the overlay is gone — so the overlay is demonstrably what makes the ephemeral
+/// agent runnable, and it leaves nothing behind.
+/// </summary>
+public sealed class AgentFactoryEphemeralOverlayTests
+{
+    private readonly Mock<ISkillMetadataRegistry> _skillRegistry = new();
+    private readonly Mock<AgentExecutionContextFactory> _contextFactory;
+    private readonly AgentFactory _factory;
+    private IReadOnlyList<SkillDefinition>? _capturedSkills;
+
+    public AgentFactoryEphemeralOverlayTests()
+    {
+        var chatClientFactory = new Mock<IChatClientFactory>();
+        chatClientFactory.Setup(f => f.IsAvailable(It.IsAny<AIAgentFrameworkClientType>())).Returns(true);
+        chatClientFactory
+            .Setup(f => f.GetChatClientAsync(It.IsAny<AIAgentFrameworkClientType>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new FakeChatClient());
+
+        var appConfig = new AppConfig
+        {
+            AI = new AIConfig
+            {
+                AgentFramework = new AgentFrameworkConfig
+                {
+                    DefaultDeployment = "gpt-4o",
+                    ClientType = AIAgentFrameworkClientType.AzureOpenAI
+                }
+            }
+        };
+        var monitor = Mock.Of<IOptionsMonitor<AppConfig>>(m => m.CurrentValue == appConfig);
+
+        _contextFactory = new Mock<AgentExecutionContextFactory>(
+            NullLogger<AgentExecutionContextFactory>.Instance,
+            monitor,
+            new ServiceCollection().BuildServiceProvider(),
+            NullLoggerFactory.Instance,
+            null!, null!, null!, null!, null!, null!);
+
+        _contextFactory
+            .Setup(f => f.MapToAgentContextAsync(
+                It.IsAny<IReadOnlyList<SkillDefinition>>(),
+                It.IsAny<SkillAgentOptions>(),
+                It.IsAny<IReadOnlyList<string>?>()))
+            .Callback<IReadOnlyList<SkillDefinition>, SkillAgentOptions, IReadOnlyList<string>?>(
+                (skills, _, _) => _capturedSkills = skills)
+            .ReturnsAsync(new AgentExecutionContext
+            {
+                Name = "BundleAgent",
+                Instruction = "merged",
+                AIAgentFrameworkType = AIAgentFrameworkClientType.AzureOpenAI
+            });
+
+        // The factory resolves IAgentOwnedSkillStore lazily from the provider. Register the real
+        // overlay-aware decorator over an empty persistent store, exactly as the composition root does.
+        var sp = new ServiceCollection()
+            .AddSingleton<IAgentOwnedSkillStore>(new OverlayAwareAgentOwnedSkillStore(new FakeOwnedSkillStore()))
+            .BuildServiceProvider();
+
+        _factory = new AgentFactory(
+            NullLogger<AgentFactory>.Instance,
+            monitor,
+            Mock.Of<IDistributedCache>(),
+            NullLoggerFactory.Instance,
+            _contextFactory.Object,
+            _skillRegistry.Object,
+            chatClientFactory.Object,
+            sp,
+            new InMemorySkillCompletionTracker());
+    }
+
+    [Fact]
+    public async Task OverlaySkill_ResolvesThroughFactory_OnlyWhileOverlayIsActive()
+    {
+        // The bundle skill exists in neither the global registry nor the persistent owned store.
+        _skillRegistry.Setup(r => r.TryGet(It.IsAny<string>())).Returns((SkillDefinition?)null);
+
+        var overlay = new EphemeralAgentOverlay
+        {
+            Agent = new AgentDefinition { Id = "bundle-agent", Name = "Bundle Agent" },
+            OwnedSkills = [new SkillDefinition { Id = "bundle-skill", Name = "bundle-skill", Description = "OVERLAY" }],
+        };
+
+        using (EphemeralAgentOverlayAccessor.Begin(overlay))
+        {
+            await _factory.CreateAgentFromSkillsAsync(
+                ["bundle-skill"], new SkillAgentOptions { OwningAgentId = "bundle-agent" });
+        }
+
+        _capturedSkills.Should().ContainSingle();
+        _capturedSkills![0].Description.Should().Be("OVERLAY",
+            "the ephemeral agent's skill resolved from the overlay through the real factory");
+    }
+
+    [Fact]
+    public async Task OverlaySkill_IsUnresolvable_OnceTheOverlayScopeEnds()
+    {
+        _skillRegistry.Setup(r => r.TryGet(It.IsAny<string>())).Returns((SkillDefinition?)null);
+
+        // No overlay active — the same skill id cannot be resolved from any persistent source.
+        var act = () => _factory.CreateAgentFromSkillsAsync(
+            ["bundle-skill"], new SkillAgentOptions { OwningAgentId = "bundle-agent" });
+
+        await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("*bundle-skill*not found*");
+    }
+
+    private sealed class FakeOwnedSkillStore : IAgentOwnedSkillStore
+    {
+        private readonly Dictionary<(string, string), SkillDefinition> _skills = new();
+
+        public void Register(string agentId, SkillDefinition skill) => _skills[(agentId, skill.Id)] = skill;
+
+        public SkillDefinition? TryGet(string agentId, string skillId) =>
+            _skills.TryGetValue((agentId, skillId), out var s) ? s : null;
+
+        public IReadOnlyList<SkillDefinition> GetForAgent(string agentId) =>
+            _skills.Where(kv => kv.Key.Item1 == agentId).Select(kv => kv.Value).ToList();
+    }
+}

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/Bundles/OverlayAwareResolutionTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/Bundles/OverlayAwareResolutionTests.cs
@@ -1,0 +1,211 @@
+using Application.AI.Common.Interfaces;
+using Application.AI.Common.Interfaces.Skills;
+using Application.AI.Common.Services.Bundles;
+using Domain.AI.Agents;
+using Domain.AI.Bundles;
+using Domain.AI.Skills;
+using FluentAssertions;
+using Xunit;
+
+namespace Application.AI.Common.Tests.Services.Bundles;
+
+/// <summary>
+/// Tests the per-run overlay mechanism that lets a bundle's ephemeral agent and owned skills resolve
+/// ahead of the persistent registries for the duration of one async flow, then vanish — proving both
+/// the ambient accessor and the two overlay-aware decorators, without any HTTP or job machinery.
+/// </summary>
+public sealed class OverlayAwareResolutionTests
+{
+    // --- Ambient accessor ---------------------------------------------------------------------------
+
+    [Fact]
+    public void Accessor_Begin_PublishesOverlayThenRestoresOnDispose()
+    {
+        EphemeralAgentOverlayAccessor.Current.Should().BeNull("no overlay is active outside a run");
+
+        var overlay = Overlay(Agent("ephem"));
+        using (EphemeralAgentOverlayAccessor.Begin(overlay))
+        {
+            EphemeralAgentOverlayAccessor.Current.Should().BeSameAs(overlay);
+        }
+
+        EphemeralAgentOverlayAccessor.Current.Should().BeNull("the scope restored the previous value");
+    }
+
+    [Fact]
+    public void Accessor_Begin_RestoresPreviousOverlay_NotJustNull()
+    {
+        var outer = Overlay(Agent("outer"));
+        var inner = Overlay(Agent("inner"));
+
+        using (EphemeralAgentOverlayAccessor.Begin(outer))
+        {
+            using (EphemeralAgentOverlayAccessor.Begin(inner))
+                EphemeralAgentOverlayAccessor.Current.Should().BeSameAs(inner);
+
+            EphemeralAgentOverlayAccessor.Current.Should().BeSameAs(outer, "the inner scope restored the outer overlay");
+        }
+    }
+
+    // --- Owned-skill store decorator ----------------------------------------------------------------
+
+    [Fact]
+    public void OwnedStore_NoOverlay_ForwardsToInner()
+    {
+        var inner = new FakeOwnedSkillStore();
+        inner.Register("host", Skill("hostskill", "HOST"));
+        var store = new OverlayAwareAgentOwnedSkillStore(inner);
+
+        store.TryGet("host", "hostskill")!.Description.Should().Be("HOST");
+        store.TryGet("ephem", "bundleskill").Should().BeNull();
+    }
+
+    [Fact]
+    public void OwnedStore_OverlayMatchingAgent_ResolvesOverlaySkillFirst()
+    {
+        var inner = new FakeOwnedSkillStore();
+        inner.Register("host", Skill("hostskill", "HOST"));
+        var store = new OverlayAwareAgentOwnedSkillStore(inner);
+
+        using (EphemeralAgentOverlayAccessor.Begin(Overlay(Agent("ephem"), Skill("bundleskill", "OVERLAY"))))
+        {
+            store.TryGet("ephem", "bundleskill")!.Description.Should().Be("OVERLAY");
+            // A different agent id is untouched by the overlay — still resolves from the inner store.
+            store.TryGet("host", "hostskill")!.Description.Should().Be("HOST");
+        }
+
+        store.TryGet("ephem", "bundleskill").Should().BeNull("the overlay is gone after the scope");
+    }
+
+    [Fact]
+    public void OwnedStore_Register_AlwaysWritesToInner_NeverTheOverlay()
+    {
+        var inner = new FakeOwnedSkillStore();
+        var store = new OverlayAwareAgentOwnedSkillStore(inner);
+
+        using (EphemeralAgentOverlayAccessor.Begin(Overlay(Agent("ephem"), Skill("bundleskill", "OVERLAY"))))
+            store.Register("host", Skill("hostskill", "HOST"));
+
+        // The write landed in the persistent store, not the ephemeral overlay.
+        inner.TryGet("host", "hostskill")!.Description.Should().Be("HOST");
+    }
+
+    [Fact]
+    public void OwnedStore_OverlayMatchedAgent_IsAuthoritative_DoesNotLeakInnerOwnedSkills()
+    {
+        // The bundle's ephemeral agent shares an id with a host agent that owns a private skill. The
+        // overlay must fully own its agent's skill namespace, so the host's private skill is NOT visible.
+        var inner = new FakeOwnedSkillStore();
+        inner.Register("ephem", Skill("host-secret", "HOST"));
+        var store = new OverlayAwareAgentOwnedSkillStore(inner);
+
+        using (EphemeralAgentOverlayAccessor.Begin(Overlay(Agent("ephem"), Skill("bundle-only", "OVERLAY"))))
+        {
+            // A skill only the host agent owns must NOT resolve through the overlaid agent id...
+            store.TryGet("ephem", "host-secret").Should()
+                .BeNull("the overlay is authoritative for its agent; a miss falls back to the global pool, not host-owned skills");
+            // ...and GetForAgent returns exactly the overlay's skills, never merged with the inner store.
+            store.GetForAgent("ephem").Select(s => s.Id).Should().BeEquivalentTo(["bundle-only"]);
+        }
+    }
+
+    // --- Agent metadata registry decorator ----------------------------------------------------------
+
+    [Fact]
+    public void AgentRegistry_NoOverlay_ForwardsToInner()
+    {
+        var registry = new OverlayAwareAgentMetadataRegistry(new FakeAgentRegistry(Agent("host")));
+
+        registry.TryGet("host").Should().NotBeNull();
+        registry.TryGet("ephem").Should().BeNull();
+        registry.GetAll().Should().ContainSingle();
+    }
+
+    [Fact]
+    public void AgentRegistry_OverlayAgent_IsResolvableAndEnumeratedForTheRun()
+    {
+        var registry = new OverlayAwareAgentMetadataRegistry(new FakeAgentRegistry(Agent("host")));
+
+        using (EphemeralAgentOverlayAccessor.Begin(Overlay(Agent("ephem", "bundle-cat", "b-tag"))))
+        {
+            registry.TryGet("ephem").Should().NotBeNull();
+            registry.TryGet("host").Should().NotBeNull("the persistent agent is still visible");
+            registry.GetAll().Select(a => a.Id).Should().BeEquivalentTo(["host", "ephem"]);
+            registry.GetByCategory("bundle-cat").Select(a => a.Id).Should().ContainSingle(id => id == "ephem");
+            registry.GetByTags(["b-tag"]).Select(a => a.Id).Should().ContainSingle(id => id == "ephem");
+        }
+
+        registry.TryGet("ephem").Should().BeNull("the ephemeral agent is gone after the scope");
+        registry.GetAll().Should().ContainSingle();
+    }
+
+    [Fact]
+    public void AgentRegistry_OverlayShadowsSameIdAgent_AcrossEveryProjection()
+    {
+        // A persistent agent and the overlay share an id but differ in category/tags. For the run the
+        // overlay fully replaces the persistent one: the stale definition must not surface under its old
+        // category or tags, and the id must appear exactly once (as the overlay) in GetAll.
+        var inner = new FakeAgentRegistry(Agent("dup", "research", "old-tag"));
+        var registry = new OverlayAwareAgentMetadataRegistry(inner);
+
+        using (EphemeralAgentOverlayAccessor.Begin(Overlay(Agent("dup", "analysis", "new-tag"))))
+        {
+            registry.TryGet("dup")!.Category.Should().Be("analysis", "the overlay definition wins");
+            registry.GetByCategory("research").Should().BeEmpty("the shadowed persistent agent must not surface under its old category");
+            registry.GetByCategory("analysis").Select(a => a.Id).Should().ContainSingle(id => id == "dup");
+            registry.GetByTags(["old-tag"]).Should().BeEmpty("the shadowed persistent agent must not surface under its old tag");
+            registry.GetByTags(["new-tag"]).Select(a => a.Id).Should().ContainSingle(id => id == "dup");
+            registry.GetAll().Should().ContainSingle(a => a.Id == "dup", "the id appears once, as the overlay");
+        }
+
+        registry.GetByCategory("research").Select(a => a.Id).Should().ContainSingle(id => id == "dup",
+            "after the scope the persistent agent is visible again under its own category");
+    }
+
+    // --- Helpers ------------------------------------------------------------------------------------
+
+    private static AgentDefinition Agent(string id, string? category = null, params string[] tags) =>
+        new() { Id = id, Name = id, Category = category, Tags = tags };
+
+    private static SkillDefinition Skill(string id, string marker) =>
+        new() { Id = id, Name = id, Description = marker };
+
+    private static EphemeralAgentOverlay Overlay(AgentDefinition agent, params SkillDefinition[] skills) =>
+        new() { Agent = agent, OwnedSkills = skills };
+
+    private sealed class FakeOwnedSkillStore : IAgentOwnedSkillStore
+    {
+        private readonly Dictionary<(string, string), SkillDefinition> _skills = new();
+
+        public void Register(string agentId, SkillDefinition skill) => _skills[(agentId, skill.Id)] = skill;
+
+        public SkillDefinition? TryGet(string agentId, string skillId) =>
+            _skills.TryGetValue((agentId, skillId), out var s) ? s : null;
+
+        public IReadOnlyList<SkillDefinition> GetForAgent(string agentId) =>
+            _skills.Where(kv => kv.Key.Item1 == agentId).Select(kv => kv.Value).ToList();
+    }
+
+    private sealed class FakeAgentRegistry : IAgentMetadataRegistry
+    {
+        private readonly List<AgentDefinition> _agents;
+
+        public FakeAgentRegistry(params AgentDefinition[] agents) => _agents = [.. agents];
+
+        public IReadOnlyList<AgentDefinition> GetAll() => _agents;
+
+        public AgentDefinition? TryGet(string agentId) =>
+            _agents.FirstOrDefault(a => string.Equals(a.Id, agentId, StringComparison.OrdinalIgnoreCase));
+
+        public IReadOnlyList<AgentDefinition> GetByCategory(string category) =>
+            _agents.Where(a => string.Equals(a.Category, category, StringComparison.OrdinalIgnoreCase)).ToList();
+
+        public IReadOnlyList<AgentDefinition> GetByTags(IEnumerable<string> tags)
+        {
+            var set = new HashSet<string>(tags, StringComparer.OrdinalIgnoreCase);
+            return _agents.Where(a => a.Tags.Any(set.Contains)).ToList();
+        }
+
+        public IReadOnlyList<string> SearchedPaths => [];
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Bundles/BundleStagingServiceTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Bundles/BundleStagingServiceTests.cs
@@ -1,0 +1,246 @@
+using System.IO.Compression;
+using System.Text;
+using Domain.Common.Config;
+using Domain.Common.Config.AI;
+using Domain.Common.Config.AI.BundleExecution;
+using FluentAssertions;
+using Infrastructure.AI.Agents;
+using Infrastructure.AI.Bundles;
+using Infrastructure.AI.Plugins;
+using Infrastructure.AI.Skills;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Bundles;
+
+/// <summary>
+/// Tests for <see cref="BundleStagingService"/> — the boundary at which an untrusted, externally-authored
+/// agent bundle is validated and extracted before any of its content is trusted. Each hostile-archive
+/// guard (oversize, entry count, decompression bomb, zip-slip, discovery-root overlap) gets a test, plus
+/// the happy path that a well-formed bundle yields a staged agent with its owned skills on disk.
+/// </summary>
+public sealed class BundleStagingServiceTests : IDisposable
+{
+    private readonly string _stagingRoot =
+        Path.Combine(Path.GetTempPath(), $"bundle-staging-tests-{Guid.NewGuid():N}");
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_stagingRoot))
+            Directory.Delete(_stagingRoot, recursive: true);
+    }
+
+    // --- Happy path ---------------------------------------------------------------------------------
+
+    [Fact]
+    public async Task StageAsync_WellFormedBundle_StagesAgentAndOwnedSkillOnDisk()
+    {
+        using var zip = ZipOf(
+            ("AGENT.md", "---\nid: my-bundle\nname: My Bundle\nskills: [greet]\n---\nBundle instructions."),
+            ("skills/greet/SKILL.md", "---\nid: greet\nname: greet\n---\nGreet the user."),
+            ("plugin.json", "{ \"name\": \"my-plugin\", \"version\": \"1.0.0\" }"));
+
+        var result = await CreateService().StageAsync(zip);
+
+        result.IsSuccess.Should().BeTrue(string.Join("; ", result.Errors));
+        var bundle = result.Value!;
+        bundle.Agent.Id.Should().Be("my-bundle");
+        bundle.Agent.Instructions.Should().Contain("Bundle instructions.");
+        bundle.OwnedSkills.Select(s => s.Id).Should().ContainSingle(id => id == "greet");
+        bundle.PluginManifests.Select(m => m.Name).Should().ContainSingle(n => n == "my-plugin");
+
+        // The staged files really live under the staging root, so disk-based skill disclosure can read them.
+        Directory.Exists(bundle.StagedRootDirectory).Should().BeTrue();
+        bundle.StagedRootDirectory.Should().StartWith(_stagingRoot);
+        File.Exists(Path.Combine(bundle.StagedRootDirectory, "AGENT.md")).Should().BeTrue();
+        bundle.OwnedSkills[0].BaseDirectory.Should().StartWith(bundle.StagedRootDirectory);
+    }
+
+    [Fact]
+    public async Task StageAsync_NestedSkillDirWithoutSkillMd_IsSkippedNotFatal()
+    {
+        // A skills/ subdirectory with no SKILL.md (or an otherwise unreadable one) must be skipped without
+        // failing the whole bundle — the good nested skill still stages.
+        using var zip = ZipOf(
+            ("AGENT.md", "---\nid: b\nname: B\n---\nx"),
+            ("skills/good/SKILL.md", "---\nid: good\nname: good\n---\nA valid skill."),
+            ("skills/empty/notes.txt", "no SKILL.md here"));
+
+        var result = await CreateService().StageAsync(zip);
+
+        result.IsSuccess.Should().BeTrue(string.Join("; ", result.Errors));
+        result.Value!.OwnedSkills.Select(s => s.Id).Should().BeEquivalentTo(["good"]);
+    }
+
+    // --- Hostile-archive guards ---------------------------------------------------------------------
+
+    [Fact]
+    public async Task StageAsync_ZipSlipEntry_IsRejectedAndLeavesNothingBehind()
+    {
+        using var zip = ZipOf(
+            ("AGENT.md", "---\nid: a\nname: A\n---\nx"),
+            ("../escape.txt", "pwned"));
+
+        var result = await CreateService().StageAsync(zip);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Errors.Should().ContainMatch("*escapes the staging directory*");
+        NoStagedDirectoriesRemain();
+        File.Exists(Path.Combine(Path.GetDirectoryName(_stagingRoot)!, "escape.txt")).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task StageAsync_TooManyEntries_IsRejected()
+    {
+        using var zip = ZipOf(
+            ("AGENT.md", "---\nid: a\nname: A\n---\nx"),
+            ("a.txt", "1"),
+            ("b.txt", "2"));
+
+        var result = await CreateService(new BundleExecutionConfig { MaxEntryCount = 2 }).StageAsync(zip);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Errors.Should().ContainMatch("*more than the maximum 2 entries*");
+    }
+
+    [Fact]
+    public async Task StageAsync_ExceedsMaxUncompressedSize_IsRejected()
+    {
+        using var zip = ZipOf(("AGENT.md", new string('x', 4096)));
+
+        var result = await CreateService(new BundleExecutionConfig { MaxTotalUncompressedBytes = 64 }).StageAsync(zip);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Errors.Should().ContainMatch("*expands to more than the maximum 64 bytes*");
+        NoStagedDirectoriesRemain();
+    }
+
+    [Fact]
+    public async Task StageAsync_ExceedsMaxArchiveSize_IsRejected()
+    {
+        using var zip = ZipOf(("AGENT.md", new string('x', 4096)));
+
+        var result = await CreateService(new BundleExecutionConfig { MaxArchiveBytes = 16 }).StageAsync(zip);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Errors.Should().ContainMatch("*exceeds the maximum accepted size*");
+    }
+
+    [Fact]
+    public async Task StageAsync_HighCompressionRatio_IsRejected()
+    {
+        // ~2 MiB of a single repeated byte compresses to a few KB — a ratio far above the default 100,
+        // and above the 1 MiB floor at which the ratio guard engages.
+        using var zip = ZipOf(("AGENT.md", new string('a', 2 * 1024 * 1024)));
+
+        var result = await CreateService().StageAsync(zip);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Errors.Should().ContainMatch("*compression ratio exceeds*");
+    }
+
+    [Fact]
+    public async Task StageAsync_NotAZip_IsRejected()
+    {
+        using var garbage = new MemoryStream("this is not a zip archive"u8.ToArray());
+
+        var result = await CreateService().StageAsync(garbage);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Errors.Should().ContainMatch("*not a valid zip archive*");
+    }
+
+    [Fact]
+    public async Task StageAsync_EmptyArchive_IsRejected()
+    {
+        using var empty = new MemoryStream();
+
+        var result = await CreateService().StageAsync(empty);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Errors.Should().ContainMatch("*empty*");
+    }
+
+    [Fact]
+    public async Task StageAsync_MissingAgentMd_IsRejectedAndCleansUp()
+    {
+        using var zip = ZipOf(("skills/greet/SKILL.md", "---\nid: greet\nname: greet\n---\nx"));
+
+        var result = await CreateService().StageAsync(zip);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Errors.Should().ContainMatch("*no AGENT.md at its root*");
+        NoStagedDirectoriesRemain();
+    }
+
+    [Fact]
+    public async Task StageAsync_StagingRootOverlapsAgentDiscoveryRoot_IsRejected()
+    {
+        using var zip = ZipOf(("AGENT.md", "---\nid: a\nname: A\n---\nx"));
+
+        // Point the agent discovery root at the very staging root: the global registry would then be
+        // able to discover the bundle's agent/skills, defeating isolation — staging must refuse.
+        var appConfig = new AppConfig
+        {
+            AI = new AIConfig
+            {
+                BundleExecution = new BundleExecutionConfig { TempRoot = _stagingRoot },
+                Agents = new AgentsConfig { BasePath = _stagingRoot },
+            }
+        };
+
+        var result = await CreateService(appConfig).StageAsync(zip);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Errors.Should().ContainMatch("*overlaps a configured skill or agent discovery root*");
+    }
+
+    // --- Helpers ------------------------------------------------------------------------------------
+
+    private BundleStagingService CreateService(BundleExecutionConfig? overrides = null)
+    {
+        var cfg = overrides ?? new BundleExecutionConfig();
+        cfg.TempRoot = _stagingRoot;
+        return CreateService(new AppConfig { AI = new AIConfig { BundleExecution = cfg } });
+    }
+
+    private static BundleStagingService CreateService(AppConfig appConfig) =>
+        new(
+            new OptionsMonitorStub(appConfig),
+            new AgentMetadataParser(NullLogger<AgentMetadataParser>.Instance),
+            new SkillMetadataParser(NullLogger<SkillMetadataParser>.Instance),
+            new PluginManifestReader(NullLogger<PluginManifestReader>.Instance),
+            NullLogger<BundleStagingService>.Instance);
+
+    private void NoStagedDirectoriesRemain()
+    {
+        if (Directory.Exists(_stagingRoot))
+            Directory.GetDirectories(_stagingRoot).Should().BeEmpty("a rejected bundle must leave no partial extraction");
+    }
+
+    private static MemoryStream ZipOf(params (string Path, string Content)[] entries)
+    {
+        var ms = new MemoryStream();
+        using (var archive = new ZipArchive(ms, ZipArchiveMode.Create, leaveOpen: true))
+        {
+            foreach (var (path, content) in entries)
+            {
+                var entry = archive.CreateEntry(path);
+                using var stream = entry.Open();
+                var bytes = Encoding.UTF8.GetBytes(content);
+                stream.Write(bytes, 0, bytes.Length);
+            }
+        }
+
+        ms.Position = 0;
+        return ms;
+    }
+
+    private sealed class OptionsMonitorStub(AppConfig value) : IOptionsMonitor<AppConfig>
+    {
+        public AppConfig CurrentValue { get; } = value;
+        public AppConfig Get(string? name) => CurrentValue;
+        public IDisposable? OnChange(Action<AppConfig, string?> listener) => null;
+    }
+}


### PR DESCRIPTION
## What & why
First slice of the **bundle-injection API** (issue #154, Part 2): let this solution accept a self-contained, externally-authored agent bundle (a zip of `AGENT.md` + nested `SKILL.md` files + plugin manifests), stage it safely, and resolve it as an **ephemeral, per-run agent** — without an HTTP surface yet and **off by default** (`AI:BundleExecution:Enabled`). It sits on the Part 1 agent-promotion foundation (a bundle is "a first-class agent that owns its skills").

## What's in it
- **`BundleStagingService`** (Infrastructure) — the untrusted-input boundary. Guards: zip-slip / path-traversal, decompression-bomb (entry count + declared **and** actual-bytes ratio + absolute cap), escaping symlinks, and staging/discovery-root **disjointness** (so the global registries can never independently discover a bundle's skills). Extracts to a temp dir, then reuses the existing `AGENT.md`/`SKILL.md`/`plugin.json` parsers. Guaranteed cleanup on every non-success exit, including cancellation.
- **Per-run overlay** — `EphemeralAgentOverlayAccessor` (AsyncLocal, mirroring the existing `ToolGovernanceAccessor`/`KnowledgeScopeAccessor` precedent) + `OverlayAwareAgentMetadataRegistry` / `OverlayAwareAgentOwnedSkillStore`, wired **behaviour-neutral** over the singleton registries. The overlay is **authoritative for its own agent id**, so a bundle can never inherit a host agent's private skills, and it shadows a same-id host agent uniformly across all queries.
- **`NestedSkillScanner`** — one shared, resilient nested-skill discovery used by both host agents and bundles (a malformed `SKILL.md` is skipped, not fatal).
- **`BundleExecutionConfig`** — default OFF; archive limits + temp root.

## Design notes (refinements vs the plan sketch)
- Dropped the planned parse-from-content overloads — Tier 2/3 skill disclosure reads from disk anyway, so staging extracts first and reuses the existing parsers (no duplicated parse logic).
- Decorators live in **Application** (they depend only on Application + Domain — the Clean-Architecture litmus test), wired in Infrastructure DI.
- Skill decorator targets the **owned-skill store**, which is what keeps bundle skills out of the shared pool.

## Testing
- **22 new tests**: staging guards (zip-slip, bomb, ratio, disjointness, missing `AGENT.md`, resilience), the overlay decorators, and the overlay resolving end-to-end through the real `AgentFactory`.
- Build **0 warnings / 0 errors**. Full `Infrastructure.AI` (2098 pass; 3 pre-existing environmental `FileSystemService` write failures, unrelated) and `Application.AI.Common` (1369/0) suites green.

## Review
Self-ran multi-agent `/code-review` (high) → **8 findings, all fixed** (2 HIGH, 2 MED correctness + hardening, cleanup) and `/simplify` → 5 quality fixes. Receipts bound to the pushed commit.

## Not in this PR (later phases)
Capability envelope (PR2), async job + handle lifecycle (PR3), the REST API surface (PR4), streaming (PR5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)