### PR TITLE
feat: bundle capability envelope enforcement (Bundle-PR2)

### DIFF
--- a/.claude/plans/agent-bundle-injection-api.md
+++ b/.claude/plans/agent-bundle-injection-api.md
@@ -1,0 +1,197 @@
+# Plan: Inject & Run Agent Bundles via API (Issue #154)
+
+## Problem
+A first-party external system authors self-contained agent bundles (AGENT.md + SKILL.md files +
+plugin manifests) and wants to hand one to *this* solution over HTTP and have it run. This solution
+is the **execution host** for agents it did not write. We are **not** the system of record — bundles
+are short-lived; run results are returned, not persisted long-term.
+
+## Decisions locked with Matt
+| # | Decision |
+|---|----------|
+| Trust | **First-party** authors → moderate trust; confine as defense-in-depth |
+| Bundle | **Self-contained** archive (AGENT.md + SKILL.md files + plugin manifests) |
+| Lifecycle | **Short-lived TTL handle** (register → handle → invoke); not system of record |
+| Delivery | **Async-job is the contract; streaming is opt-in** |
+| Capability model | **Host grants from a fixed per-caller envelope; bundle *requests*; beyond-envelope is rejected, not honored** |
+
+## The load-bearing security posture
+1. **Capability envelope per caller.** The bundle's self-declared `AllowedTools` / autonomy / MCP refs
+   are *requests*. The host's per-credential envelope is the *grant*. Enforced by the EXISTING gate
+   chain (`GovernedAIFunction` → `IToolInvocationGovernor` → `ThreePhasePermissionResolver`) by adding
+   one new `IPermissionRuleProvider` that emits **bypass-immune Deny** for out-of-envelope tools + a
+   tier-ceiling baseline. Zero new gate code.
+2. **Governance forced ON for bundle runs.** `GovernanceConfig.EnforceToolInvocation` is opt-in and
+   OFF by default (governor is pass-through when off). The bundle-run path **forces it on** regardless
+   of global config — otherwise the envelope is inert.
+3. **MCP endpoints are reference-only.** Bundles may name host-registered MCP servers, never define
+   endpoints. This closes the SSRF-by-construction hole. (This is the ONE genuinely new enforcement
+   point — no per-caller MCP allowlist exists today; added as a filter in `ToolChainBuilder`.)
+4. **Archive is hostile input.** Zip-slip (path-traversal) guard on every entry; decompression-bomb
+   guard (max total size, max entry count, max ratio). Reject at ingest before anything touches disk.
+5. **Guaranteed temp-dir cleanup** on handle expiry AND on crash/timeout.
+
+## Core-Model Pass — PREREQUISITE (Option A, decided with Matt)
+
+The agent is a **hollow shell** today: `AgentDefinition` is pure metadata + a list of skill IDs, with
+no instructions and no tool ceiling. Everything substantive lives on `SkillDefinition`. This is the
+un-Claude part. Option A promotes the agent to **first-class** (own system prompt + own tool ceiling),
+while skills stay composable and can be **agent-owned (nested)** OR **shared (global pool)** — reuse
+preserved. A self-contained bundle is then just "a first-class agent that owns its skills," so this
+pass is the foundation the bundle API sits on, not a detour.
+
+**Threading route (low-churn):** extend `SkillAgentOptions` (`Domain.AI/Skills/SkillAgentOptions.cs`)
+with `AgentInstructions` + `AllowedTools`; populate at `ExecuteAgentTurnCommandHandler.cs:98-103`;
+consume in `AgentExecutionContextFactory.MapToAgentContextAsync`. No signature churn through the
+cache/factory chain. `AgentExecutionContextFactory` does NOT currently receive the `AgentDefinition`
+(it's reduced to skill IDs at `ExecuteAgentTurnCommandHandler.cs:91-93` and thrown away) — this route
+restores the agent's substance without touching the cache key.
+
+### Pinned seams (verified, with line numbers)
+- **S1 Agent instructions.** AGENT.md body is discarded at `AgentMetadataParser.cs:36` (`var (yaml, _)`).
+  Capture it → new `Instructions` init-prop on `AgentDefinition` (record ends `AgentDefinition.cs:56`).
+  Prepend before skill merge at `AgentExecutionContextFactory.cs:105`
+  (`SkillInstructionMerger.Merge(...)`); flows onto the agent via `AgentExecutionContext.Instruction`
+  (line 204) → `AgentFactory.cs:131` `ChatClientAgentOptions.Instructions`. Prepending at 105 also
+  covers the composer path (line 107 wraps whatever `instruction` holds).
+- **S2 Tool ceiling.** The ceiling wire EXISTS but is unused from the agent path (`allowedTools` param
+  is `null` at `AgentExecutionContextFactory.cs:450`). Apply `agentCeiling ∩ (union of skills'
+  AllowedTools)` in BOTH filters: pass the intersection as the `allowedTools` arg at
+  `AgentExecutionContextFactory.cs:109` (→ `ToolChainBuilder.BuildMergedToolsWithSourcesAsync`
+  filter at lines 172-176) AND construct the `ToolPermissionFilter` at line 382 from the same
+  intersection. **Intersect, never union** — can only tighten. Allowlist is a plain string list.
+- **S3 Agent-owned nested skills.** `AgentMetadataRegistry.DiscoverInDirectory` (after parsing the
+  AgentDefinition ~line 154): scan `<agentDir>/skills/*/SKILL.md` via
+  `SkillMetadataParser.ParseFromFile(skillFile, dir, agentSourceMarker)`, register into a **per-agent
+  store** (keyed by agent Id) so they never enter the global `SkillMetadataRegistry._cache`. Resolution
+  in `AgentFactory.CreateAgentWithContextFromSkillsAsync` (line 442) checks the agent-owned store
+  before `_skillRegistry.TryGet(id)`. Reuses the existing `SkillDefinition.PluginSource` ownership-tag
+  pattern (`ResolveOwningPlugin`, `SkillMetadataRegistry.cs:294-315`).
+
+### Core-model phasing (before the bundle API)
+- **CM-PR1 — Agent instructions.** S1. AGENT.md body → `AgentDefinition.Instructions` → prepended
+  system prompt. Tests: agent block leads the merged skill instructions.
+- **CM-PR2 — Agent tool ceiling.** S2. Parse agent `AllowedTools`; intersect (tighten-only). Tests:
+  ceiling strips out-of-envelope skill tools, never widens. *(security-reviewer — permission surface)*
+- **CM-PR3 — Agent-owned nested skills.** S3. `<agentDir>/skills/` discovery + per-agent store +
+  resolution precedence. Tests: nested skill resolvable by its agent, invisible to other agents, global
+  pool unpolluted.
+- **CM-PR4 — Delete the test-only `AgentManifest` class.** CORRECTED: `StateConfiguration` /
+  `DecisionFramework` are NOT dead — they're live in the StateManagement/checkpoint subsystem and are
+  fields on `SkillDefinition`. Do NOT delete them. The only inert thing is the `AgentManifest` class
+  itself (instantiated only in tests; prod references are doc `<see cref>` links). Once `AgentDefinition`
+  is first-class it fully supersedes `AgentManifest` → delete the class + its test file. Tiny, safe.
+
+## Key architecture facts (from subsystem research)
+- **Rich `AgentManifest` is inert.** Production execution is driven by `SkillDefinition` (SKILL.md),
+  resolved through `IMediator.Send(ExecuteAgentTurnCommand | RunConversationCommand)`. Do NOT touch
+  `AgentFactory`/`AgentConversationCache` directly — send the MediatR command.
+- **Tier 2/3 skill disclosure reads from DISK** via the framework's `UseFileSkill(path)`. So a pure
+  in-memory parse is impossible. Answer: **extract the bundle to a temp dir**, point the machinery at
+  it, run, delete on TTL. Reuses everything.
+- **Registries are immutable-after-startup singletons** scanning global config paths — no runtime
+  add/remove/overlay. Per-run ephemeral agents need a **per-run `AsyncLocal` overlay** consulted by a
+  composite registry that falls back to the global singleton. Matches existing `AsyncLocal` precedent
+  (`ToolGovernanceAccessor`, `KnowledgeScopeAccessor`, `AgentTurnStreamSink`).
+- **No generic async-job registry exists.** Reuse the `ChangeProposalBackgroundService` + `Channel`
+  pattern (BackgroundService, scope-per-item). Build a small in-memory, TTL'd job store.
+- **Streaming seam exists.** `IAgentTurnStreamSink` (AsyncLocal) + AG-UI SSE (`AgUiEventWriter`).
+- **No `RegisterPostEvictionCallback` usage anywhere** — temp-dir-on-expiry cleanup is net-new; pair
+  IMemoryCache sliding expiration with a post-eviction callback + a belt-and-suspenders idle sweeper
+  (`SessionIdleCleanupService` precedent).
+
+## API contract
+```
+POST   /api/bundles                         multipart zip → 201 { handle, expiresAt }   (validate+extract+overlay)
+POST   /api/bundles/{handle}/runs           { userMessages[], maxTurns?, stream? } → 202 { jobId, statusUrl }
+GET    /api/bundles/{handle}/runs/{jobId}   → { status, result?, error?, tokens? }    (poll)
+GET    /api/bundles/{handle}/runs/{jobId}/stream   text/event-stream (AG-UI events)   (opt-in)
+DELETE /api/bundles/{handle}                → 204   (explicit cleanup; TTL also handles it)
+```
+- Run contract exposes **multi-turn** (`RunConversationCommand` superset: `userMessages`, `maxTurns`).
+- Job records are **in-memory, TTL'd** (aligns with "not system of record").
+- Envelope resolved per-credential (subject claim) with role/default fallback.
+
+## Layer-by-layer file breakdown (Clean Architecture)
+
+### Domain (`Domain.AI`)
+- `Bundles/CapabilityEnvelope.cs` — value object: `AllowedTools`, `AutonomyCeiling`, `AllowedMcpServers`, limits.
+- `Bundles/BundleRunStatus.cs` — enum: Queued/Running/Succeeded/Failed.
+- `Bundles/BundleRunRecord.cs` — job record value object (id, handle, status, result, error, tokens, timestamps).
+
+### Application (`Application.AI.Common` / `Application.Core`)
+- `Interfaces/Bundles/IBundleStagingService.cs` — extract+validate archive → staged bundle (temp path + overlay defs).
+- `Interfaces/Bundles/IEphemeralAgentOverlay.cs` + accessor — AsyncLocal overlay of agent/skill defs for one run.
+- `Interfaces/Bundles/IBundleRunJobStore.cs` — create/get/update job record; TTL.
+- `Interfaces/Bundles/IBundleRunDispatchQueue.cs` — Channel enqueue/drain.
+- `Interfaces/Governance/ICapabilityEnvelopeResolver.cs` — ClaimsPrincipal → CapabilityEnvelope.
+- `Services/Governance/CapabilityEnvelopeAccessor.cs` — AsyncLocal<CapabilityEnvelope?>.
+- `Services/Governance/EnvelopePermissionRuleProvider.cs` — reads ambient envelope → bypass-immune Deny + tier ceiling.
+- `CQRS/Bundles/RegisterBundle/…` (Command + Handler + Validator) — stage bundle, return handle.
+- `CQRS/Bundles/RunBundle/…` (Command + Handler) — set overlay+envelope ambient, dispatch background run.
+- `CQRS/Bundles/GetBundleRun/…` (Query + Handler) — read job record.
+- Validators: `RegisterBundleCommandValidator` (archive limits), `BundleManifestValidator`.
+
+### Infrastructure (`Infrastructure.AI`)
+- `Bundles/BundleStagingService.cs` — zip-slip + bomb guards → temp dir; parse AGENT.md/SKILL.md/plugin.json → overlay defs whose FilePath points into temp dir.
+- `Bundles/EphemeralAgentOverlay.cs` — AsyncLocal overlay impl.
+- `Agents/OverlayAwareAgentMetadataRegistry.cs` + `Skills/OverlayAwareSkillMetadataRegistry.cs` — composite decorators over the global singletons.
+- `Bundles/InMemoryBundleRunJobStore.cs` — IMemoryCache-backed, sliding TTL, post-eviction temp-dir cleanup.
+- `Bundles/BundleRunBackgroundService.cs` + `Bundles/InMemoryBundleRunDispatchQueue.cs` — mirror ChangeProposal pattern.
+- `Bundles/BundleTempWorkspaceCleanupService.cs` — idle sweeper backstop.
+- `Governance/CapabilityEnvelopeResolver.cs` — config-driven per-caller envelope.
+- Parser content overloads: `AgentMetadataParser.ParseFromContent`, `SkillMetadataParser` pure-string overload, `PluginManifestReader.ReadFromJson`.
+- MCP envelope filter in `ToolChainBuilder` (Injected path + MCP provisioning) — filter by envelope's allowed server names. **(the one new gate)**
+
+### Presentation (`Presentation.AgentHub` OR new `Presentation.BundleApi` — see open decision)
+- `Controllers/BundlesController.cs` — the REST endpoints; `[Authorize]`, role-gated, per-path rate limits.
+- Middleware: extend scope capture to also set ambient `CapabilityEnvelope` from ClaimsPrincipal.
+- SSE stream endpoint reusing `AgUiEventWriter` + `AgentTurnStreamSink`.
+- DI: register composite registries (decorate singletons), job store, background services, staging, resolver, `EnvelopePermissionRuleProvider`; force `EnforceToolInvocation` on the bundle-run scope.
+
+### Config (`Domain.Common/Config`)
+- `AI/BundleExecution/BundleExecutionConfig.cs` — `Enabled`, per-caller envelopes, TTLs, archive limits (max size / entries / ratio), temp root. Default OFF.
+
+## Phasing (one PR per phase, security-gated where marked)
+- **PR1 — Ingestion + overlay (no API).** Content-parse overloads, `BundleStagingService` (zip-slip +
+  bomb guards), `EphemeralAgentOverlay` + composite registries. Proven by unit tests. *(security-reviewer)*
+- **PR2 — Capability envelope enforcement.** `CapabilityEnvelope`, resolver, accessor,
+  `EnvelopePermissionRuleProvider`, MCP allowlist filter, forced `EnforceToolInvocation`. Tests prove
+  out-of-envelope tool / MCP / autonomy is denied. *(security-reviewer)*
+  - **Scoped 2026-07-10, two sub-decisions LOCKED with Matt:**
+    1. *Force-enforce seam* = **lightweight ambient flag** (`AsyncLocal<bool>` override accessor,
+       OR-ed into `ToolInvocationGovernor`'s two enforce reads — line 88 `AuthorizeAsync`, line 270
+       `GetTrace`). `GovernanceConfig.EnforceToolInvocation` is `init`-only → cannot be rebound
+       per-scope, so an ambient override is the only viable shape. Matches existing accessor precedent.
+       Chosen over an `IOptionsMonitor<GovernanceConfig>` scoped-decorator (heavier, same result).
+    2. *Security depth* = **full adversarial pass** — security-reviewer subagent on the diff PLUS
+       explicit bypass-attempt tests (casing/glob escape, auto-approve trying to lift a bypass-immune
+       Deny, MCP name spoof, empty/null-envelope fail-closed), beyond the happy-path denials.
+  - **Envelope-Deny mechanism (verified against the resolver):** a catch-all `*` Deny is unusable — Deny
+    (Phase 1b) precedes Allow (Phase 3), so `*` Deny would also kill the *allowed* tools. Instead
+    `EnvelopePermissionRuleProvider` computes the concrete out-of-envelope set
+    `(overlay's requested tools) − envelope.AllowedTools` from the ambient overlay + ambient envelope
+    and emits one bypass-immune Deny per out-of-envelope tool. Two-layer defense: envelope also joins
+    the CM-PR2 construction-time intersection (`ToolPermissionFilter` / `BuildMergedToolsWithSourcesAsync`)
+    so out-of-envelope tools aren't even built into the chain; the provider is the runtime backstop
+    (also catches late-discovered MCP tools). MCP filter seam = `ToolChainBuilder` lines 54 + 218.
+- **PR3 — Async job + handle lifecycle.** Job store, background service + queue, TTL handle cache +
+  guaranteed temp-dir cleanup (post-eviction + idle sweeper).
+- **PR4 — API surface.** `BundlesController`, middleware envelope capture, DI wiring, config section,
+  `WebApplicationFactory` integration tests.
+- **PR5 — Streaming opt-in.** SSE endpoint reusing AG-UI writer + sink.
+
+## Full sequencing
+Core-model pass (CM-PR1 → CM-PR4) FIRST, then the bundle API (Bundle-PR1 → Bundle-PR5). The bundle's
+ingestion overlay (Bundle-PR1) reuses CM-PR3's agent-owned nested-skill discovery (a staged bundle is
+an agent dir with nested skills), and the bundle's envelope (Bundle-PR2) sits on top of CM-PR2's tool
+ceiling. Doing the core-model first is what makes the bundle drop in cleanly instead of bolting on.
+
+## Decisions (resolved)
+- **Host: DECIDED — new lean isolated `Presentation.BundleApi` web app.** Its own auth audience + rate
+  limits; no shared front door with the dashboard, since it runs externally-authored agents.
+- **Job records:** in-memory (non-durable), aligned with "not system of record". CONFIRMED.
+- **Envelope granularity:** per-credential (subject) with role/default fallback. CONFIRMED.
+- **CM-PR4:** delete only the test-only `AgentManifest` class; keep the workflow types. CORRECTED.
+- **Sequencing:** Part 1 (agent promotion) is its own approval + ships standalone; Part 2 (bundle API)
+  is a later decision on top of it.

--- a/src/Content/Application/Application.AI.Common/Interfaces/Governance/ICapabilityEnvelopeResolver.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Governance/ICapabilityEnvelopeResolver.cs
@@ -1,0 +1,29 @@
+using System.Security.Claims;
+using Domain.AI.Bundles;
+
+namespace Application.AI.Common.Interfaces.Governance;
+
+/// <summary>
+/// Resolves the <see cref="CapabilityEnvelope"/> the host grants to a bundle run for a given caller. The
+/// envelope is the authoritative grant against which a bundle's self-declared tool / MCP / autonomy
+/// requests are checked.
+/// </summary>
+/// <remarks>
+/// Resolution is per-credential: an exact subject-claim match takes precedence, then the least-privilege
+/// combination of the caller's matching roles, then a configured default. The result is always
+/// non-null — an unmatched caller resolves to the fail-closed default (which grants nothing unless an
+/// operator configured it), so there is no code path on which "no envelope" silently means "no
+/// restriction".
+/// </remarks>
+public interface ICapabilityEnvelopeResolver
+{
+    /// <summary>
+    /// Resolves the capability envelope for <paramref name="principal"/>.
+    /// </summary>
+    /// <param name="principal">
+    /// The caller's authenticated identity. When null (or carrying no subject/role claims that match a
+    /// configured grant), the configured default envelope is returned.
+    /// </param>
+    /// <returns>The granted envelope; never null.</returns>
+    CapabilityEnvelope Resolve(ClaimsPrincipal? principal);
+}

--- a/src/Content/Application/Application.AI.Common/Services/Governance/CapabilityEnvelopeAccessor.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Governance/CapabilityEnvelopeAccessor.cs
@@ -1,0 +1,76 @@
+using Domain.AI.Bundles;
+
+namespace Application.AI.Common.Services.Governance;
+
+/// <summary>
+/// Ambient accessor that publishes the <see cref="CapabilityEnvelope"/> in force for the current async
+/// flow, so the permission gate chain and the tool-chain builder can enforce a bundle run's per-caller
+/// grant without threading the envelope through every signature.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Follows the same pattern as the host's other per-flow accessors (<c>ToolGovernanceAccessor</c>,
+/// <c>EphemeralAgentOverlayAccessor</c>, <c>KnowledgeScopeAccessor</c>): an <see cref="AsyncLocal{T}"/>
+/// the run path sets at the start of a bundle run and clears in a <c>finally</c>, read at enforcement
+/// time. When unset — every non-bundle code path — the gate chain and tool builder see no envelope and
+/// behave identically to a host with no bundle concept, so this adds zero behaviour off the bundle path.
+/// </para>
+/// <para>
+/// Prefer <see cref="Begin"/> to publish an envelope: it restores the previous ambient value on dispose,
+/// so nested or sequential runs on the same flow cannot leak an envelope into unrelated work.
+/// </para>
+/// <para>
+/// Caveat, identical to the other ambient accessors: like any <see cref="AsyncLocal{T}"/>, the envelope
+/// is captured into the <c>ExecutionContext</c> of any fire-and-forget work started <em>while it is
+/// active</em>. Scope the envelope tightly around the turn and let it fall out before queuing detached
+/// work that should not run under the bundle's grant.
+/// </para>
+/// <para>
+/// <strong>Deferred-execution contract (for the run/streaming paths).</strong> The scope must stay open for
+/// the <em>entire</em> execution it governs, not merely the synchronous call that starts it. If a run returns
+/// a deferred <see cref="System.Collections.Generic.IAsyncEnumerable{T}"/> / stream, disposing the scope when
+/// that method returns clears the envelope before the streamed tool calls run — the governor (which forces
+/// enforcement on precisely from the envelope's presence) would then see no envelope and fail <em>open</em>.
+/// Keep the <c>using</c> around the full enumeration (dispose in the stream's <c>finally</c>), never around
+/// the call that merely produces the stream.
+/// </para>
+/// </remarks>
+public static class CapabilityEnvelopeAccessor
+{
+    private static readonly AsyncLocal<CapabilityEnvelope?> s_current = new();
+
+    /// <summary>
+    /// The envelope for the current async flow, or <see langword="null"/> when not inside a bundle run.
+    /// A null value means "no restriction" for the reading component — enforcement only engages when a
+    /// bundle run has published an envelope.
+    /// </summary>
+    public static CapabilityEnvelope? Current => s_current.Value;
+
+    /// <summary>
+    /// Publishes <paramref name="envelope"/> as the ambient envelope for the current async flow and
+    /// returns a handle that restores the previous ambient value when disposed. Use with <c>using</c> so
+    /// the envelope is guaranteed to be torn down when the run completes, even on exception.
+    /// </summary>
+    /// <param name="envelope">The envelope to make active; must not be null.</param>
+    public static IDisposable Begin(CapabilityEnvelope envelope)
+    {
+        ArgumentNullException.ThrowIfNull(envelope);
+        var previous = s_current.Value;
+        s_current.Value = envelope;
+        return new EnvelopeScope(previous);
+    }
+
+    private sealed class EnvelopeScope(CapabilityEnvelope? previous) : IDisposable
+    {
+        private bool _disposed;
+
+        public void Dispose()
+        {
+            if (_disposed)
+                return;
+
+            _disposed = true;
+            s_current.Value = previous;
+        }
+    }
+}

--- a/src/Content/Application/Application.AI.Common/Services/Governance/ToolInvocationGovernor.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Governance/ToolInvocationGovernor.cs
@@ -3,6 +3,7 @@ using Application.AI.Common.Interfaces.Governance;
 using Application.AI.Common.Interfaces.Permissions;
 using Application.AI.Common.Interfaces.Sandbox;
 using Application.AI.Common.Interfaces.Tools;
+using Domain.AI.Bundles;
 using Domain.AI.Changes;
 using Domain.AI.Governance;
 using Domain.AI.Permissions;
@@ -52,6 +53,10 @@ public sealed class ToolInvocationGovernor : IToolInvocationGovernor
     private readonly object _lock = new();
     private readonly List<ToolDecisionRecord> _decisions = [];
 
+    // Set true the first time a tool is authorized under active enforcement this turn, so GetTrace reports
+    // the turn as enforced even if it is called after the bundle run's ambient scope has torn down.
+    private bool _enforcedObserved;
+
     public ToolInvocationGovernor(
         IAgentExecutionContext executionContext,
         IToolPermissionService toolPermissionService,
@@ -80,23 +85,57 @@ public sealed class ToolInvocationGovernor : IToolInvocationGovernor
         _logger = logger;
     }
 
+    /// <summary>
+    /// Whether the current flow is a bundle run — i.e. a per-caller <see cref="CapabilityEnvelope"/> has been
+    /// published for it. A bundle executes an externally-authored agent, so its whole flow must be governed
+    /// and fail closed; this is the single ambient fact the enforcement decision derives from, so there is no
+    /// way to publish an envelope without also arming the governor.
+    /// </summary>
+    private static bool BundleRunActive => CapabilityEnvelopeAccessor.Current is not null;
+
+    /// <summary>
+    /// Whether per-invocation enforcement is active for the current flow. True when the host has opted in
+    /// globally (<c>GovernanceConfig.EnforceToolInvocation</c>) <em>or</em> a bundle run is active
+    /// (<see cref="BundleRunActive"/>) — bundle runs must always be governed so the per-caller capability
+    /// envelope is never inert. Off both paths this is false and the governor is a pure pass-through,
+    /// unchanged for existing deployments.
+    /// </summary>
+    private bool EnforcementActive =>
+        _governanceConfig.CurrentValue.EnforceToolInvocation || BundleRunActive;
+
     /// <inheritdoc />
     public async ValueTask<ToolInvocationDecision> AuthorizeAsync(string toolName, CancellationToken cancellationToken)
     {
         // Opt-in: when enforcement is off the governor never engages — pure pass-through, no record,
         // no behaviour change for existing deployments.
-        if (!_governanceConfig.CurrentValue.EnforceToolInvocation)
+        if (!EnforcementActive)
             return ToolInvocationDecision.Allow();
+
+        // Enforcement ran this turn; remember it so the trace reports the turn as governed even if GetTrace
+        // is called after a bundle run's ambient envelope scope has already disposed.
+        _enforcedObserved = true;
 
         var profile = _toolRiskClassifier.Classify(toolName);
 
-        // No agent identity means this isn't a fully-scoped agent turn (e.g. an execution path that
-        // did not initialize the context). Pass through rather than guess an identity — but RECORD it
-        // as ungoverned (Enforced=false) so the trace surfaces the gap instead of it being invisible
-        // to an evaluator.
+        // No agent identity means this isn't a fully-scoped agent turn (e.g. an execution path that did not
+        // initialize the context). Off the bundle path we pass through but RECORD it ungoverned so the trace
+        // surfaces the gap. Inside a bundle run we must NEVER allow ungoverned — an ephemeral agent whose
+        // identity is missing is exactly the shape a bypass would take, so fail closed.
         var agentId = _executionContext.AgentId;
         if (string.IsNullOrEmpty(agentId))
         {
+            if (BundleRunActive)
+            {
+                _logger.LogWarning(
+                    "Tool governance: no AgentId in execution context for {ToolName} during a bundle run — denied (fail-closed)",
+                    toolName);
+                Record(new ToolDecisionRecord(toolName, ToolDecisionOutcome.Denied,
+                    "no agent identity in a bundle run", profile.Radius,
+                    RequiredApproval: false, ApprovalGranted: false, Enforced: true));
+                return ToolInvocationDecision.Deny(
+                    $"Error: tool '{toolName}' is not permitted in the current context.");
+            }
+
             _logger.LogWarning(
                 "Tool governance: no AgentId in execution context for {ToolName} — allowed ungoverned and recorded", toolName);
             Record(new ToolDecisionRecord(toolName, ToolDecisionOutcome.Allowed,
@@ -261,13 +300,19 @@ public sealed class ToolInvocationGovernor : IToolInvocationGovernor
     public void Reset()
     {
         lock (_lock)
+        {
             _decisions.Clear();
+            _enforcedObserved = false;
+        }
     }
 
     /// <inheritdoc />
     public GovernanceTrace GetTrace()
     {
-        var enforced = _governanceConfig.CurrentValue.EnforceToolInvocation;
+        // Prefer the snapshot taken while authorizing: a bundle run's ambient enforcement signal may have
+        // torn down by the time the trace is assembled, but a turn that authorized under enforcement is
+        // still an enforced turn.
+        var enforced = _enforcedObserved || EnforcementActive;
         lock (_lock)
         {
             if (!enforced && _decisions.Count == 0)

--- a/src/Content/Application/Application.AI.Common/Services/Tools/ToolChainBuilder.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/ToolChainBuilder.cs
@@ -1,6 +1,7 @@
 using Application.AI.Common.Interfaces;
 using Application.AI.Common.Interfaces.Plugins;
 using Application.AI.Common.Interfaces.Tools;
+using Application.AI.Common.Services.Governance;
 using Domain.AI.Skills;
 using Domain.Common.Config.AI.Plugins;
 using Microsoft.Extensions.AI;
@@ -51,8 +52,7 @@ public class ToolChainBuilder : IToolChainBuilder
 
         if (skill.Mode == SkillMode.Injected && _mcpToolProvider != null)
         {
-            var allMcpTools = await _mcpToolProvider.GetAllToolsAsync(cancellationToken);
-            foreach (var serverTools in allMcpTools.Values)
+            foreach (var serverTools in await ResolveInjectedMcpToolsAsync(cancellationToken))
             {
                 tools.AddRange(serverTools);
                 foreach (var t in serverTools) mcpCollector.Add(t.Name);
@@ -211,7 +211,10 @@ public class ToolChainBuilder : IToolChainBuilder
         ISet<string> mcpCollector,
         CancellationToken cancellationToken = default)
     {
-        if (_mcpToolProvider != null)
+        // Reference-only MCP: a bundle run resolves a tool from an MCP server only when the caller's
+        // envelope grants that server; otherwise the MCP attempt is skipped and resolution falls through
+        // to keyed DI (itself governed at invocation time). Off the bundle path every server is permitted.
+        if (_mcpToolProvider != null && IsMcpServerAllowed(declaration.Name))
         {
             try
             {
@@ -253,6 +256,65 @@ public class ToolChainBuilder : IToolChainBuilder
         }
 
         return null;
+    }
+
+    /// <summary>
+    /// Resolves the MCP tools to inject for an Injected-mode skill. Off the bundle path this is every
+    /// configured server's tools (the historical behaviour). On a bundle run it contacts <em>only</em> the
+    /// servers the caller's envelope grants — never enumerating every host server — so an ungranted server
+    /// is never reached at all (no side-effect connection, no tool-schema disclosure), closing
+    /// SSRF-by-construction. An empty grant yields no MCP tools.
+    /// </summary>
+    private async Task<IReadOnlyList<IList<AITool>>> ResolveInjectedMcpToolsAsync(CancellationToken cancellationToken)
+    {
+        var envelope = CapabilityEnvelopeAccessor.Current;
+        if (envelope is null)
+            return [.. (await _mcpToolProvider!.GetAllToolsAsync(cancellationToken)).Values];
+
+        // Reference-only MCP on a bundle run: contact ONLY the granted servers, concurrently. A server that
+        // fails is skipped (its tools are simply unavailable this turn) rather than failing the whole build.
+        var fetches = envelope.AllowedMcpServers.Select(async server =>
+        {
+            try
+            {
+                return await _mcpToolProvider!.GetToolsAsync(server, cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Capability envelope: granted MCP server '{Server}' could not be reached — skipped", server);
+                return null;
+            }
+        });
+
+        var granted = (await Task.WhenAll(fetches))
+            .Where(t => t is { Count: > 0 })
+            .Cast<IList<AITool>>()
+            .ToList();
+
+        _logger.LogInformation(
+            "Capability envelope: injecting MCP tools from {Count} granted server(s); ungranted servers are not contacted",
+            granted.Count);
+
+        return granted;
+    }
+
+    /// <summary>
+    /// Whether the ambient capability envelope permits reaching the named MCP server on the managed
+    /// resolution path. Off the bundle path no envelope is published, so this returns
+    /// <see langword="true"/> and every server passes through unchanged. On a bundle run only servers named
+    /// in the caller's envelope are permitted; a denied server is logged and never contacted, so a bundle
+    /// can never reach a host MCP server it was not granted.
+    /// </summary>
+    private bool IsMcpServerAllowed(string serverName)
+    {
+        var envelope = CapabilityEnvelopeAccessor.Current;
+        if (envelope is null || envelope.GrantsMcpServer(serverName))
+            return true;
+
+        _logger.LogInformation(
+            "Capability envelope: MCP server '{Server}' is outside the bundle run's grant — not contacted and its tools excluded",
+            serverName);
+        return false;
     }
 
     private IEnumerable<AITool>? ResolveToolByName(string toolName)

--- a/src/Content/Application/Application.Core/DependencyInjection.cs
+++ b/src/Content/Application/Application.Core/DependencyInjection.cs
@@ -56,6 +56,11 @@ public static class DependencyInjection
 		// Plugin-boundary rule provider — generates permission rules from plugin governance config
 		services.AddSingleton<IPermissionRuleProvider, PluginPermissionRuleProvider>();
 
+		// Capability-envelope rule provider — confines a bundle run to its per-caller grant by emitting
+		// bypass-immune Deny for out-of-envelope tools plus an autonomy-ceiling baseline. Inert (returns no
+		// rules) unless a bundle run has published an ambient envelope, so non-bundle deployments are unaffected.
+		services.AddSingleton<IPermissionRuleProvider, EnvelopePermissionRuleProvider>();
+
 		// Graded autonomy decision evaluator (PR-4) — consulted by the ChangeProposal
 		// gate resolver to decide whether the approval gate is included in a proposal's
 		// frozen gate list. When AppConfig.AI.Permissions.GradedAutonomy.Enabled is false

--- a/src/Content/Application/Application.Core/Permissions/EnvelopePermissionRuleProvider.cs
+++ b/src/Content/Application/Application.Core/Permissions/EnvelopePermissionRuleProvider.cs
@@ -1,0 +1,151 @@
+using Application.AI.Common.Interfaces.Permissions;
+using Application.AI.Common.Services.Bundles;
+using Application.AI.Common.Services.Governance;
+using Domain.AI.Bundles;
+using Domain.AI.Governance;
+using Domain.AI.Permissions;
+
+namespace Application.Core.Permissions;
+
+/// <summary>
+/// Emits permission rules from the ambient per-caller <see cref="CapabilityEnvelope"/> so a bundle run is
+/// confined to exactly what the host granted it — the enforcement half of the capability envelope, carried
+/// entirely by the existing 3-phase permission resolver with no new gate code.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The provider contributes rules <em>only</em> while an envelope is ambient (i.e. inside a bundle run).
+/// Off the bundle path <see cref="CapabilityEnvelopeAccessor.Current"/> is null and it returns nothing, so
+/// every existing deployment is completely unaffected.
+/// </para>
+/// <para>
+/// When an envelope is active it emits two kinds of rule:
+/// </para>
+/// <list type="number">
+///   <item>
+///     <description>
+///     <strong>Bypass-immune Deny</strong> for every tool the bundle <em>declares</em> (drawn from the
+///     ambient <see cref="EphemeralAgentOverlay"/>: the ephemeral agent's tool ceiling plus each owned
+///     skill's tools) that the envelope does not grant. A catch-all <c>*</c> Deny cannot express
+///     "deny all but the allowlist" because the resolver evaluates Deny (phase 1b) before Allow — a
+///     wildcard Deny would also kill the granted tools — so the out-of-envelope set is enumerated and
+///     denied by exact name. These denies are <see cref="ToolPermissionRule.IsBypassImmune"/> so no
+///     auto-approve mode can lift them.
+///     </description>
+///   </item>
+///   <item>
+///     <description>
+///     <strong>Autonomy-ceiling baseline</strong> for every granted tool: an
+///     <see cref="ToolPermissionRule.IsAuthoritativeBaseline"/> rule whose behavior is the envelope's
+///     <see cref="CapabilityEnvelope.AutonomyCeiling"/> mapped to Allow (Autonomous) or Ask (Supervised /
+///     Restricted). Evaluated after Deny, so an out-of-envelope Deny still wins; and it only ever caps
+///     autonomy — the governor's own graded-autonomy risk gate can tighten an Allow further but never
+///     loosens it.
+///     </description>
+///   </item>
+/// </list>
+/// <para>
+/// This is the strongest tier of a layered guarantee, not the whole of it: a tool the bundle did
+/// <em>not</em> statically declare but tries to call at runtime is still blocked, because with no matching
+/// Allow or baseline the resolver defaults to Ask and the fail-closed governor turns that into a denial.
+/// Enumerating declared tools lets the common case be an explicit, bypass-immune Deny rather than a
+/// default block.
+/// </para>
+/// </remarks>
+public sealed class EnvelopePermissionRuleProvider : IPermissionRuleProvider
+{
+    /// <summary>Deny out-of-envelope tools ahead of any other rule.</summary>
+    private const int DenyPriority = 1;
+
+    /// <summary>Apply the autonomy-ceiling baseline after the deny set.</summary>
+    private const int BaselinePriority = 5;
+
+    /// <inheritdoc />
+    public PermissionRuleSource Source => PermissionRuleSource.CapabilityEnvelope;
+
+    /// <inheritdoc />
+    public Task<IReadOnlyList<ToolPermissionRule>> GetRulesAsync(
+        string agentId,
+        CancellationToken cancellationToken = default)
+    {
+        var envelope = CapabilityEnvelopeAccessor.Current;
+        if (envelope is null)
+            return Task.FromResult<IReadOnlyList<ToolPermissionRule>>([]);
+
+        var rules = new List<ToolPermissionRule>();
+
+        // 1. Bypass-immune Deny for each declared tool the envelope does not grant. Build the grant set once
+        //    so the membership test is O(1) per declared tool rather than a linear scan of the allowlist.
+        var granted = new HashSet<string>(envelope.AllowedTools, StringComparer.OrdinalIgnoreCase);
+        foreach (var toolName in EnumerateDeclaredTools(agentId))
+        {
+            if (!granted.Contains(toolName))
+            {
+                rules.Add(new ToolPermissionRule(
+                    toolName,
+                    null,
+                    PermissionBehaviorType.Deny,
+                    PermissionRuleSource.CapabilityEnvelope,
+                    Priority: DenyPriority,
+                    IsBypassImmune: true));
+            }
+        }
+
+        // 2. Authoritative autonomy-ceiling baseline for each granted tool. Restricted and Supervised both
+        //    map to Ask (approval required); only Autonomous maps to Allow (shared with every other rule
+        //    provider so the tier-to-behavior policy cannot drift). NOTE: because live mid-tool-call approval
+        //    routing is deferred, the governor currently treats Ask as a fail-closed block — so today a
+        //    non-Autonomous ceiling effectively suspends the bundle's tool use rather than gating it for
+        //    approval. This matches how plugin and tier baselines behave and is documented on
+        //    CapabilityEnvelope.AutonomyCeiling; wiring the ceiling into live approval is a follow-up.
+        var ceilingBehavior = envelope.AutonomyCeiling.ToDefaultPermissionBehavior();
+
+        foreach (var toolName in envelope.AllowedTools)
+        {
+            rules.Add(new ToolPermissionRule(
+                toolName,
+                null,
+                ceilingBehavior,
+                PermissionRuleSource.CapabilityEnvelope,
+                Priority: BaselinePriority,
+                IsAuthoritativeBaseline: true));
+        }
+
+        return Task.FromResult<IReadOnlyList<ToolPermissionRule>>(rules);
+    }
+
+    /// <summary>
+    /// Collects the distinct tool names the bundle statically declares for <paramref name="agentId"/> —
+    /// the ephemeral agent's own tool ceiling plus every tool named by its owned skills (their
+    /// <c>AllowedTools</c> and <c>ToolDeclarations</c>). Read from the ambient overlay, and only when that
+    /// overlay owns the agent being resolved; any other flow declares nothing here (its out-of-envelope
+    /// calls are still caught by the fail-closed default).
+    /// </summary>
+    private static IReadOnlyCollection<string> EnumerateDeclaredTools(string agentId)
+    {
+        var overlay = EphemeralAgentOverlayAccessor.Current;
+        if (overlay is null || !overlay.OwnsAgent(agentId))
+            return [];
+
+        var names = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var toolName in overlay.Agent.AllowedTools)
+            if (!string.IsNullOrWhiteSpace(toolName))
+                names.Add(toolName);
+
+        foreach (var skill in overlay.OwnedSkills)
+        {
+            if (skill.AllowedTools is { Count: > 0 } allowed)
+                foreach (var name in allowed)
+                    if (!string.IsNullOrWhiteSpace(name))
+                        names.Add(name);
+
+            if (skill.ToolDeclarations is { Count: > 0 } declarations)
+                foreach (var declaration in declarations)
+                    if (!string.IsNullOrWhiteSpace(declaration.Name))
+                        names.Add(declaration.Name);
+        }
+
+        return names;
+    }
+}

--- a/src/Content/Application/Application.Core/Permissions/PluginPermissionRuleProvider.cs
+++ b/src/Content/Application/Application.Core/Permissions/PluginPermissionRuleProvider.cs
@@ -126,12 +126,9 @@ public sealed class PluginPermissionRuleProvider : IPermissionRuleProvider
             }
 
             // Both Restricted and Supervised map to Ask — differentiation is via per-tool
-            // overrides in AutonomyTierRuleProvider config, not at the plugin boundary.
-            var defaultBehavior = autonomyLevel switch
-            {
-                AutonomyLevel.Autonomous => PermissionBehaviorType.Allow,
-                _ => PermissionBehaviorType.Ask
-            };
+            // overrides in AutonomyTierRuleProvider config, not at the plugin boundary. Shared mapping so
+            // the plugin and capability-envelope providers cannot drift on the tier-to-behavior rule.
+            var defaultBehavior = autonomyLevel.ToDefaultPermissionBehavior();
 
             var pluginToolNames = EnumeratePluginToolNames(plugin.Name);
             if (pluginToolNames.Count == 0)

--- a/src/Content/Domain/Domain.AI/Bundles/CapabilityEnvelope.cs
+++ b/src/Content/Domain/Domain.AI/Bundles/CapabilityEnvelope.cs
@@ -1,0 +1,76 @@
+using Domain.AI.Governance;
+
+namespace Domain.AI.Bundles;
+
+/// <summary>
+/// The set of capabilities the host <em>grants</em> to one bundle run for one caller — the tools it may
+/// invoke, the MCP servers it may reach, and the ceiling on how autonomously it may act. A bundle
+/// declares what it <em>wants</em>; this envelope is what it <em>gets</em>. Anything the bundle requests
+/// beyond the envelope is denied, never honoured.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The envelope is the load-bearing security boundary for running externally-authored agents: the host
+/// is the execution host for code it did not write, so the bundle's self-declared <c>AllowedTools</c> /
+/// autonomy / MCP references are treated as <em>requests</em> and this per-caller envelope is the
+/// authoritative <em>grant</em>. It is resolved once per run (from the caller's credential) and published
+/// ambiently for the duration of that run; the permission gate chain and the tool-chain builder read it
+/// to deny out-of-envelope tools (bypass-immune), cap autonomy, and drop non-allowlisted MCP servers.
+/// </para>
+/// <para>
+/// <strong>Fail-closed by construction.</strong> The default value grants nothing — empty tool and MCP
+/// allowlists and the most restrictive <see cref="AutonomyLevel"/>. A host that has not configured an
+/// envelope for a caller therefore denies everything to that caller's bundle rather than defaulting open.
+/// </para>
+/// <para>
+/// This is a pure value object. The ambient plumbing that publishes it for a run lives in the accessor
+/// that carries it, mirroring the host's existing per-turn <c>AsyncLocal</c> accessors.
+/// </para>
+/// </remarks>
+public sealed record CapabilityEnvelope
+{
+    /// <summary>
+    /// The tool names this caller's bundle run may invoke. A tool the bundle requests that is not in this
+    /// list is denied. Empty (the default) grants no tools — every tool call is denied.
+    /// </summary>
+    public IReadOnlyList<string> AllowedTools { get; init; } = [];
+
+    /// <summary>
+    /// The names of host-registered MCP servers this caller's bundle run may reach. Bundles reference
+    /// servers by name and never define endpoints, so this list is the whole of a bundle's outbound MCP
+    /// surface — closing SSRF-by-construction. Empty (the default) grants no MCP servers.
+    /// </summary>
+    public IReadOnlyList<string> AllowedMcpServers { get; init; } = [];
+
+    /// <summary>
+    /// The highest autonomy tier this caller's bundle run may act under. Enforced as a ceiling: the
+    /// effective autonomy is the most restrictive of this value, the host's own graded-autonomy gate, and
+    /// each tool's blast radius — this can only tighten, never loosen. Defaults to the most restrictive
+    /// tier (<see cref="AutonomyLevel.Restricted"/>) so an unset ceiling forces approval on every action.
+    /// </summary>
+    /// <remarks>
+    /// <strong>Current limitation:</strong> only <see cref="AutonomyLevel.Autonomous"/> lets a granted tool
+    /// execute without human sign-off. Because live mid-tool-call approval routing is deferred, the governor
+    /// treats a required approval as a fail-closed block — so a <see cref="AutonomyLevel.Supervised"/> or
+    /// <see cref="AutonomyLevel.Restricted"/> ceiling currently <em>suspends</em> the bundle's tool use
+    /// entirely rather than gating it for approval. This matches how the host's plugin and tier baselines
+    /// behave today. A bundle that must do work therefore uses an <see cref="AutonomyLevel.Autonomous"/>
+    /// ceiling and relies on <see cref="AllowedTools"/> / <see cref="AllowedMcpServers"/> plus the host's
+    /// risk and capability gates for confinement.
+    /// </remarks>
+    public AutonomyLevel AutonomyCeiling { get; init; } = AutonomyLevel.Restricted;
+
+    /// <summary>
+    /// Whether this envelope grants the named tool. Case-insensitive, mirroring how the permission
+    /// resolver and tool-chain builder match tool names.
+    /// </summary>
+    /// <param name="toolName">The tool name being checked.</param>
+    public bool GrantsTool(string toolName) => AllowedTools.Contains(toolName, StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Whether this envelope grants access to the named MCP server. Case-insensitive, mirroring how the
+    /// MCP tool provider keys servers by name.
+    /// </summary>
+    /// <param name="serverName">The MCP server name being checked.</param>
+    public bool GrantsMcpServer(string serverName) => AllowedMcpServers.Contains(serverName, StringComparer.OrdinalIgnoreCase);
+}

--- a/src/Content/Domain/Domain.AI/Governance/AutonomyLevelExtensions.cs
+++ b/src/Content/Domain/Domain.AI/Governance/AutonomyLevelExtensions.cs
@@ -1,0 +1,26 @@
+using Domain.AI.Permissions;
+
+namespace Domain.AI.Governance;
+
+/// <summary>
+/// Helpers projecting an <see cref="AutonomyLevel"/> onto the permission model.
+/// </summary>
+public static class AutonomyLevelExtensions
+{
+    /// <summary>
+    /// Maps an autonomy tier to the default permission behavior it grants: <see cref="AutonomyLevel.Autonomous"/>
+    /// acts within guardrails so its baseline is <see cref="PermissionBehaviorType.Allow"/>; every lower tier
+    /// (<see cref="AutonomyLevel.Supervised"/>, <see cref="AutonomyLevel.Restricted"/>) recommends-and-waits, so
+    /// its baseline is <see cref="PermissionBehaviorType.Ask"/>.
+    /// </summary>
+    /// <remarks>
+    /// This is the single source of the "Autonomous grants Allow, everything else asks" rule, shared by every
+    /// permission-rule provider (autonomy-tier, plugin boundary, capability envelope) so the tier-to-behavior
+    /// policy cannot drift between them. Differentiation <em>within</em> the Ask tiers is expressed through
+    /// per-tool overrides in tier-policy configuration, not here.
+    /// </remarks>
+    /// <param name="level">The autonomy tier.</param>
+    /// <returns>The baseline permission behavior for the tier.</returns>
+    public static PermissionBehaviorType ToDefaultPermissionBehavior(this AutonomyLevel level) =>
+        level == AutonomyLevel.Autonomous ? PermissionBehaviorType.Allow : PermissionBehaviorType.Ask;
+}

--- a/src/Content/Domain/Domain.AI/Permissions/PermissionRuleSource.cs
+++ b/src/Content/Domain/Domain.AI/Permissions/PermissionRuleSource.cs
@@ -25,5 +25,7 @@ public enum PermissionRuleSource
     /// <summary>Rule generated from the agent's autonomy tier assignment.</summary>
     AutonomyTier,
     /// <summary>Rule from a plugin declaration's governance configuration.</summary>
-    PluginDeclaration
+    PluginDeclaration,
+    /// <summary>Rule from the per-caller capability envelope granted to a bundle run.</summary>
+    CapabilityEnvelope
 }

--- a/src/Content/Domain/Domain.Common/Config/AI/BundleExecution/BundleExecutionConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/BundleExecution/BundleExecutionConfig.cs
@@ -75,4 +75,12 @@ public class BundleExecutionConfig
     /// </summary>
     /// <value>Default: 100</value>
     public double MaxCompressionRatio { get; set; } = 100;
+
+    /// <summary>
+    /// The per-caller capability-grant table. A bundle's self-declared tools, MCP references, and autonomy
+    /// are only <em>requests</em>; the envelope resolved from this table for the calling credential is the
+    /// authoritative <em>grant</em>, and anything beyond it is denied. Defaults to a fail-closed table that
+    /// grants nothing until an operator configures it.
+    /// </summary>
+    public CapabilityEnvelopesConfig Envelopes { get; set; } = new();
 }

--- a/src/Content/Domain/Domain.Common/Config/AI/BundleExecution/CapabilityEnvelopeConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/BundleExecution/CapabilityEnvelopeConfig.cs
@@ -1,0 +1,34 @@
+namespace Domain.Common.Config.AI.BundleExecution;
+
+/// <summary>
+/// The configured grant for one caller (or role, or the default) — the raw, bindable form of a
+/// capability envelope. The resolver maps this into the domain <c>CapabilityEnvelope</c> the gate chain
+/// enforces. Bound from entries under <c>AppConfig:AI:BundleExecution:Envelopes</c>.
+/// </summary>
+/// <remarks>
+/// This is deliberately a plain settable POCO (string autonomy, mutable lists) so it binds cleanly from
+/// configuration; the resolver validates and projects it into the immutable domain value. An
+/// unconfigured / empty grant maps to a fail-closed envelope that grants nothing.
+/// </remarks>
+public class CapabilityEnvelopeConfig
+{
+    /// <summary>
+    /// Tool names the bundle run may invoke. Anything the bundle requests outside this list is denied.
+    /// Empty grants no tools.
+    /// </summary>
+    public List<string> AllowedTools { get; set; } = [];
+
+    /// <summary>
+    /// Names of host-registered MCP servers the bundle run may reach. Bundles reference servers by name
+    /// only. Empty grants no MCP access.
+    /// </summary>
+    public List<string> AllowedMcpServers { get; set; } = [];
+
+    /// <summary>
+    /// The highest autonomy tier the bundle run may act under, parsed case-insensitively against
+    /// <c>Domain.AI.Governance.AutonomyLevel</c> (<c>Restricted</c> / <c>Supervised</c> / <c>Autonomous</c>).
+    /// An unset or unrecognised value resolves to the most restrictive tier (<c>Restricted</c>).
+    /// </summary>
+    /// <value>Default: "Restricted"</value>
+    public string AutonomyCeiling { get; set; } = "Restricted";
+}

--- a/src/Content/Domain/Domain.Common/Config/AI/BundleExecution/CapabilityEnvelopesConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/BundleExecution/CapabilityEnvelopesConfig.cs
@@ -1,0 +1,42 @@
+namespace Domain.Common.Config.AI.BundleExecution;
+
+/// <summary>
+/// The per-caller capability-grant table for bundle runs. Resolution precedence is
+/// <see cref="BySubject"/> (exact credential) → <see cref="ByRole"/> (least-privilege combination of the
+/// caller's matching roles) → <see cref="Default"/>. Bound from
+/// <c>AppConfig:AI:BundleExecution:Envelopes</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Envelopes are keyed to the caller's identity because the host runs externally-authored agents on
+/// behalf of many callers with different trust: one caller may be granted a broad tool/MCP surface while
+/// another is confined to a read-only slice. Keeping the grant table in configuration (not in the bundle)
+/// is what makes the bundle's own declarations mere requests.
+/// </para>
+/// <para>
+/// <strong>Fail-closed default.</strong> When no subject and no role matches, the <see cref="Default"/>
+/// envelope applies — and an unconfigured <see cref="Default"/> grants nothing. A host that enables
+/// bundle execution without configuring envelopes therefore denies every capability rather than opening up.
+/// </para>
+/// </remarks>
+public class CapabilityEnvelopesConfig
+{
+    /// <summary>
+    /// The grant applied when the caller matches no subject and no role entry. Defaults to a fail-closed
+    /// envelope that grants nothing.
+    /// </summary>
+    public CapabilityEnvelopeConfig Default { get; set; } = new();
+
+    /// <summary>
+    /// Per-credential grants, keyed by the caller's subject claim. An exact subject match takes precedence
+    /// over any role match. Keys are matched case-insensitively by the resolver.
+    /// </summary>
+    public Dictionary<string, CapabilityEnvelopeConfig> BySubject { get; set; } = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Per-role grants, keyed by role name. When a caller has several matching roles the resolver combines
+    /// them to the <em>least-privilege</em> result (intersection of tools and MCP servers, minimum
+    /// autonomy) so overlapping roles can never widen a grant. Keys are matched case-insensitively.
+    /// </summary>
+    public Dictionary<string, CapabilityEnvelopeConfig> ByRole { get; set; } = new(StringComparer.OrdinalIgnoreCase);
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.cs
@@ -7,6 +7,7 @@ using Application.AI.Common.Interfaces.Bundles;
 using Application.AI.Common.Interfaces.Compaction;
 using Application.AI.Common.Interfaces.Config;
 using Application.AI.Common.Interfaces.Context;
+using Application.AI.Common.Interfaces.Governance;
 using Application.AI.Common.Interfaces.Hooks;
 using Application.AI.Common.Interfaces.MetaHarness;
 using Application.AI.Common.Interfaces.Plugins;
@@ -33,6 +34,7 @@ using Infrastructure.AI.Config;
 using Infrastructure.AI.ContentSafety;
 using Infrastructure.AI.Factories;
 using Infrastructure.AI.Generators;
+using Infrastructure.AI.Governance;
 using Infrastructure.AI.Routing.Evaluation;
 using Infrastructure.AI.Hooks;
 using Infrastructure.AI.MetaHarness;
@@ -187,6 +189,11 @@ public static partial class DependencyInjection
         // until an ingest call reaches it — so it is registered unconditionally; the run/API surface that
         // invokes it is gated in a later layer.
         services.AddSingleton<IBundleStagingService, BundleStagingService>();
+
+        // Capability-envelope resolver — maps the calling credential to its configured per-caller grant.
+        // Passive like staging: it only reads config when asked, so it is registered unconditionally and
+        // the run/API surface that consults it is gated in a later layer.
+        services.AddSingleton<ICapabilityEnvelopeResolver, CapabilityEnvelopeResolver>();
 
         // --- Plugins ---
 

--- a/src/Content/Infrastructure/Infrastructure.AI/Governance/CapabilityEnvelopeResolver.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Governance/CapabilityEnvelopeResolver.cs
@@ -1,0 +1,149 @@
+using System.Security.Claims;
+using Application.AI.Common.Interfaces.Governance;
+using Domain.AI.Bundles;
+using Domain.AI.Governance;
+using Domain.Common.Config;
+using Domain.Common.Config.AI.BundleExecution;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Infrastructure.AI.Governance;
+
+/// <summary>
+/// Resolves a caller's <see cref="CapabilityEnvelope"/> from the configured per-caller grant table
+/// (<c>AppConfig:AI:BundleExecution:Envelopes</c>). Precedence is exact subject claim → least-privilege
+/// combination of matching roles → configured default.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The subject claim (<see cref="ClaimTypes.NameIdentifier"/> or the raw <c>sub</c> claim) is the most
+/// specific identity, so an exact subject grant wins outright. When no subject grant matches, the caller's
+/// roles are consulted: because roles are additive on a principal but a security grant must never widen by
+/// accident, several matching roles are combined to the <em>least-privilege</em> result — the intersection
+/// of their tool and MCP allowlists and the minimum of their autonomy ceilings. When neither a subject nor
+/// any role matches, the configured default applies, which is itself fail-closed unless an operator has
+/// widened it.
+/// </para>
+/// <para>
+/// The result is always non-null: there is no path on which an unmatched caller silently escapes the
+/// envelope. An unrecognised <see cref="CapabilityEnvelopeConfig.AutonomyCeiling"/> string degrades to the
+/// most restrictive tier with a warning rather than opening up.
+/// </para>
+/// </remarks>
+public sealed class CapabilityEnvelopeResolver : ICapabilityEnvelopeResolver
+{
+    private readonly IOptionsMonitor<AppConfig> _options;
+    private readonly ILogger<CapabilityEnvelopeResolver> _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CapabilityEnvelopeResolver"/> class.
+    /// </summary>
+    /// <param name="options">Application configuration providing the per-caller envelope table.</param>
+    /// <param name="logger">Logger for invalid-autonomy-ceiling warnings.</param>
+    public CapabilityEnvelopeResolver(
+        IOptionsMonitor<AppConfig> options,
+        ILogger<CapabilityEnvelopeResolver> logger)
+    {
+        _options = options;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public CapabilityEnvelope Resolve(ClaimsPrincipal? principal)
+    {
+        var envelopes = _options.CurrentValue.AI.BundleExecution.Envelopes;
+
+        if (principal is not null)
+        {
+            var subject = principal.FindFirst(ClaimTypes.NameIdentifier)?.Value
+                          ?? principal.FindFirst("sub")?.Value;
+
+            if (!string.IsNullOrEmpty(subject) && envelopes.BySubject.TryGetValue(subject, out var bySubject))
+                return Map(bySubject);
+
+            var matchingRoles = RoleValues(principal)
+                .Where(role => envelopes.ByRole.ContainsKey(role))
+                .Select(role => envelopes.ByRole[role])
+                .ToList();
+
+            if (matchingRoles.Count > 0)
+                return CombineLeastPrivilege(matchingRoles);
+        }
+
+        return Map(envelopes.Default);
+    }
+
+    /// <summary>
+    /// The caller's role values, drawn from the standard <see cref="ClaimTypes.Role"/> claim and the common
+    /// short <c>roles</c> / <c>role</c> claim names. Hosts whose token pipeline does not map roles onto the
+    /// long SOAP claim URI (e.g. Azure AD app roles emitted as a <c>roles</c> claim) would otherwise see
+    /// their <c>ByRole</c> grants become dead config — mirrors the subject path's <c>sub</c> fallback.
+    /// </summary>
+    private static IEnumerable<string> RoleValues(ClaimsPrincipal principal) => principal.Claims
+        .Where(c => c.Type is ClaimTypes.Role or "roles" or "role")
+        .Select(c => c.Value);
+
+    /// <summary>Projects a bindable config grant into the immutable domain envelope.</summary>
+    private CapabilityEnvelope Map(CapabilityEnvelopeConfig config) => new()
+    {
+        AllowedTools = [.. config.AllowedTools],
+        AllowedMcpServers = [.. config.AllowedMcpServers],
+        AutonomyCeiling = ParseCeiling(config.AutonomyCeiling)
+    };
+
+    /// <summary>
+    /// Combines several role grants into the least-privilege envelope: the intersection of their tool and
+    /// MCP allowlists and the minimum (most restrictive) autonomy ceiling. Overlapping roles can therefore
+    /// only ever narrow the grant, never widen it.
+    /// </summary>
+    private CapabilityEnvelope CombineLeastPrivilege(IReadOnlyList<CapabilityEnvelopeConfig> configs)
+    {
+        var mapped = configs.Select(Map).ToList();
+
+        return new CapabilityEnvelope
+        {
+            AllowedTools = IntersectAll(mapped.Select(m => m.AllowedTools)),
+            AllowedMcpServers = IntersectAll(mapped.Select(m => m.AllowedMcpServers)),
+            AutonomyCeiling = mapped.Min(m => m.AutonomyCeiling)
+        };
+    }
+
+    /// <summary>
+    /// Case-insensitive intersection of a sequence of name lists. Returns the names present in every list.
+    /// </summary>
+    private static IReadOnlyList<string> IntersectAll(IEnumerable<IReadOnlyList<string>> lists)
+    {
+        HashSet<string>? acc = null;
+
+        foreach (var list in lists)
+        {
+            if (acc is null)
+            {
+                acc = new HashSet<string>(list, StringComparer.OrdinalIgnoreCase);
+            }
+            else
+            {
+                acc.IntersectWith(list);
+            }
+        }
+
+        return acc is null ? [] : [.. acc];
+    }
+
+    private AutonomyLevel ParseCeiling(string value)
+    {
+        // Match only against the defined tier NAMES, case-insensitively. Enum.TryParse would also accept a
+        // numeric string ("2") or a comma-composite ("Restricted,Autonomous" -> 2) — either of which would
+        // silently WIDEN a config typo to full autonomy. An unrecognised value must degrade closed, so we
+        // reject anything that is not an exact tier name.
+        foreach (var name in Enum.GetNames<AutonomyLevel>())
+            if (string.Equals(name, value?.Trim(), StringComparison.OrdinalIgnoreCase))
+                return Enum.Parse<AutonomyLevel>(name);
+
+        _logger.LogWarning(
+            "Capability envelope: invalid AutonomyCeiling '{Ceiling}', falling back to the most restrictive tier (Restricted)",
+            value);
+
+        return AutonomyLevel.Restricted;
+    }
+}

--- a/src/Content/Tests/Application.AI.Common.Tests/Governance/ToolInvocationGovernorEnvelopeTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Governance/ToolInvocationGovernorEnvelopeTests.cs
@@ -1,0 +1,146 @@
+using Application.AI.Common.Interfaces.Agent;
+using Application.AI.Common.Interfaces.Governance;
+using Application.AI.Common.Interfaces.Permissions;
+using Application.AI.Common.Interfaces.Sandbox;
+using Application.AI.Common.Interfaces.Tools;
+using Application.AI.Common.Services.Governance;
+using Domain.AI.Bundles;
+using Domain.AI.Changes;
+using Domain.AI.Governance;
+using Domain.AI.Permissions;
+using Domain.Common;
+using Domain.Common.Config.AI;
+using Domain.Common.Config.AI.Permissions;
+using Domain.Common.Config.AI.Sandbox;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Application.AI.Common.Tests.Governance;
+
+/// <summary>
+/// Verifies that a bundle run forces the governor on. Enforcement derives from the single ambient fact that
+/// a <see cref="CapabilityEnvelope"/> has been published for the flow — so with global
+/// <c>EnforceToolInvocation</c> left off (its default), an active envelope still makes the governor evaluate
+/// every tool call, and a missing agent identity fails closed. Outside a bundle run the governor stays a pure
+/// pass-through — the existing default behavior.
+/// </summary>
+public sealed class ToolInvocationGovernorEnvelopeTests
+{
+    private const string Agent = "bundle-agent";
+    private const string Tool = "file_system";
+
+    private readonly Mock<IAgentExecutionContext> _context = new();
+    private readonly Mock<IToolPermissionService> _permissions = new();
+    private readonly Mock<IAutonomyDecisionEvaluator> _autonomy = new();
+    private readonly Mock<IGovernancePolicyEngine> _policyEngine = new();
+    private readonly Mock<IDenialTracker> _denialTracker = new();
+    private readonly Mock<ICapabilityEnforcer> _capabilities = new();
+    private readonly IToolRiskClassifier _riskClassifier =
+        Mock.Of<IToolRiskClassifier>(c => c.Classify(It.IsAny<string>()) == new ToolRiskProfile(BlastRadius.Low, true));
+
+    // Global enforcement OFF — the host has not opted in. Only an active bundle envelope should flip it on.
+    private readonly GovernanceConfig _governanceOff = new() { EnforceToolInvocation = false };
+    private readonly PermissionsConfig _permissionsConfig = new();
+    private readonly SandboxConfig _sandbox = new();
+
+    public ToolInvocationGovernorEnvelopeTests()
+    {
+        _context.Setup(x => x.AgentId).Returns(Agent);
+        _permissions
+            .Setup(x => x.ResolvePermissionAsync(It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<string?>(), It.IsAny<IReadOnlyDictionary<string, object?>?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(PermissionDecision.Deny("outside the envelope"));
+        _capabilities
+            .Setup(x => x.EnforceAsync(It.IsAny<string>(), It.IsAny<Domain.AI.Sandbox.ToolCapability>(),
+                It.IsAny<IReadOnlyList<string>?>(), It.IsAny<IReadOnlyList<string>?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Success());
+        _policyEngine.SetupGet(x => x.HasPolicies).Returns(false);
+    }
+
+    private ToolInvocationGovernor Build() => new(
+        _context.Object, _permissions.Object, _riskClassifier, _autonomy.Object, _policyEngine.Object,
+        Mock.Of<IGovernanceAuditService>(), _denialTracker.Object, _capabilities.Object,
+        Mock.Of<IOptionsMonitor<GovernanceConfig>>(m => m.CurrentValue == _governanceOff),
+        Mock.Of<IOptionsMonitor<PermissionsConfig>>(m => m.CurrentValue == _permissionsConfig),
+        Mock.Of<IOptionsMonitor<SandboxConfig>>(m => m.CurrentValue == _sandbox),
+        NullLogger<ToolInvocationGovernor>.Instance);
+
+    private static CapabilityEnvelope Envelope() => new() { AllowedTools = [Tool] };
+
+    [Fact]
+    public async Task GlobalOff_NoBundleRun_PassesThroughWithoutEvaluating()
+    {
+        var governor = Build();
+
+        var decision = await governor.AuthorizeAsync(Tool, CancellationToken.None);
+
+        Assert.True(decision.IsAllowed);
+        _permissions.Verify(x => x.ResolvePermissionAsync(It.IsAny<string>(), It.IsAny<string>(),
+            It.IsAny<string?>(), It.IsAny<IReadOnlyDictionary<string, object?>?>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task GlobalOff_InsideBundleRun_EnforcesAndBlocksOutOfEnvelopeTool()
+    {
+        var governor = Build();
+
+        ToolInvocationDecision decision;
+        using (CapabilityEnvelopeAccessor.Begin(Envelope()))
+            decision = await governor.AuthorizeAsync(Tool, CancellationToken.None);
+
+        Assert.False(decision.IsAllowed);
+        _permissions.Verify(x => x.ResolvePermissionAsync(Agent, Tool,
+            It.IsAny<string?>(), It.IsAny<IReadOnlyDictionary<string, object?>?>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task GlobalOff_InsideBundleRun_MissingAgentId_FailsClosed()
+    {
+        // An ephemeral agent whose identity is missing is exactly the shape a governance bypass would take.
+        // Off the bundle path this passes through ungoverned; inside a bundle run it MUST deny.
+        _context.Setup(x => x.AgentId).Returns((string?)null);
+        var governor = Build();
+
+        ToolInvocationDecision decision;
+        using (CapabilityEnvelopeAccessor.Begin(Envelope()))
+            decision = await governor.AuthorizeAsync(Tool, CancellationToken.None);
+
+        Assert.False(decision.IsAllowed);
+        // The permission service is never consulted — we deny before needing an identity.
+        _permissions.Verify(x => x.ResolvePermissionAsync(It.IsAny<string>(), It.IsAny<string>(),
+            It.IsAny<string?>(), It.IsAny<IReadOnlyDictionary<string, object?>?>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Trace_AfterEnvelopeScopeDisposed_StillReportsEnforced()
+    {
+        // The trace may be assembled after the run's ambient envelope has torn down. A turn that authorized
+        // under enforcement must still report EnforcementEnabled=true, not be mislabelled as ungoverned.
+        var governor = Build();
+
+        using (CapabilityEnvelopeAccessor.Begin(Envelope()))
+            await governor.AuthorizeAsync(Tool, CancellationToken.None);
+
+        // Scope disposed — the ambient envelope is gone, but the trace must still say the turn was enforced.
+        Assert.True(governor.GetTrace().EnforcementEnabled);
+    }
+
+    [Fact]
+    public async Task BundleRunEnded_ReturnsToPassThrough()
+    {
+        var governor = Build();
+
+        using (CapabilityEnvelopeAccessor.Begin(Envelope()))
+            await governor.AuthorizeAsync(Tool, CancellationToken.None);
+
+        governor.Reset();
+        _permissions.Invocations.Clear();
+        var decision = await governor.AuthorizeAsync(Tool, CancellationToken.None);
+
+        Assert.True(decision.IsAllowed);
+        _permissions.Verify(x => x.ResolvePermissionAsync(It.IsAny<string>(), It.IsAny<string>(),
+            It.IsAny<string?>(), It.IsAny<IReadOnlyDictionary<string, object?>?>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+}

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/Governance/CapabilityEnvelopeAmbientTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/Governance/CapabilityEnvelopeAmbientTests.cs
@@ -1,0 +1,54 @@
+using Application.AI.Common.Services.Governance;
+using Domain.AI.Bundles;
+using Domain.AI.Governance;
+using FluentAssertions;
+using Xunit;
+
+namespace Application.AI.Common.Tests.Services.Governance;
+
+/// <summary>
+/// Tests the per-run ambient primitive the capability envelope rides on: the
+/// <see cref="CapabilityEnvelopeAccessor"/> that publishes the active grant. It must be absent outside a run
+/// and must restore the previous value on dispose so nested runs cannot leak state. (The envelope's presence
+/// is itself the signal that forces governance on for a bundle flow — there is no separate enforcement flag.)
+/// </summary>
+public sealed class CapabilityEnvelopeAmbientTests
+{
+    [Fact]
+    public void Envelope_IsNull_OutsideAnyRun()
+        => CapabilityEnvelopeAccessor.Current.Should().BeNull();
+
+    [Fact]
+    public void Envelope_Begin_PublishesThenRestoresOnDispose()
+    {
+        var envelope = new CapabilityEnvelope { AllowedTools = ["t"], AutonomyCeiling = AutonomyLevel.Supervised };
+
+        using (CapabilityEnvelopeAccessor.Begin(envelope))
+            CapabilityEnvelopeAccessor.Current.Should().BeSameAs(envelope);
+
+        CapabilityEnvelopeAccessor.Current.Should().BeNull("the scope restored the previous (absent) value");
+    }
+
+    [Fact]
+    public void Envelope_NestedBegin_RestoresOuter_NotJustNull()
+    {
+        var outer = new CapabilityEnvelope { AllowedTools = ["outer"] };
+        var inner = new CapabilityEnvelope { AllowedTools = ["inner"] };
+
+        using (CapabilityEnvelopeAccessor.Begin(outer))
+        {
+            using (CapabilityEnvelopeAccessor.Begin(inner))
+                CapabilityEnvelopeAccessor.Current.Should().BeSameAs(inner);
+
+            CapabilityEnvelopeAccessor.Current.Should().BeSameAs(outer, "the inner scope restored the outer envelope");
+        }
+    }
+
+    [Fact]
+    public void Envelope_Begin_NullEnvelope_Throws()
+    {
+        var act = () => CapabilityEnvelopeAccessor.Begin(null!);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+}

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/ToolChainBuilderMcpEnvelopeTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/ToolChainBuilderMcpEnvelopeTests.cs
@@ -1,0 +1,140 @@
+using Application.AI.Common.Interfaces;
+using Application.AI.Common.Interfaces.Tools;
+using Application.AI.Common.Services.Governance;
+using Application.AI.Common.Services.Tools;
+using Domain.AI.Bundles;
+using Domain.AI.Skills;
+using Domain.AI.Tools;
+using FluentAssertions;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Application.AI.Common.Tests.Services.Tools;
+
+/// <summary>
+/// Tests the reference-only MCP allowlist in <see cref="ToolChainBuilder"/>: on a bundle run (an ambient
+/// capability envelope) only MCP servers the envelope names are reachable, and — critically — an ungranted
+/// server is never <em>contacted</em>, so a bundle cannot even probe a host server it was not granted
+/// (no SSRF, no tool-schema disclosure). Off the bundle path (no envelope) every server passes through
+/// unchanged, which the existing suite already covers.
+/// </summary>
+public sealed class ToolChainBuilderMcpEnvelopeTests
+{
+    private static ToolChainBuilder Builder(IMcpToolProvider mcp, IServiceProvider? sp = null) => new(
+        NullLogger<ToolChainBuilder>.Instance,
+        sp ?? new ServiceCollection().BuildServiceProvider(),
+        toolConverter: null,
+        mcpToolProvider: mcp);
+
+    private static SkillDefinition InjectedSkill() =>
+        new() { Id = "bundle-skill", Name = "bundle-skill", Instructions = "x", PluginSource = "bundle" };
+
+    [Fact]
+    public async Task InjectedMode_WithEnvelope_ContactsOnlyGrantedServers()
+    {
+        var mcp = new Mock<IMcpToolProvider>();
+        mcp.Setup(p => p.GetToolsAsync("granted-server", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([AIFunctionFactory.Create(() => "r", "granted_tool")]);
+
+        var builder = Builder(mcp.Object);
+
+        List<AITool> tools;
+        using (CapabilityEnvelopeAccessor.Begin(Envelope("granted-server")))
+            tools = await builder.BuildToolsAsync(InjectedSkill(), new SkillAgentOptions());
+
+        tools.Select(t => t.Name).Should().BeEquivalentTo(["granted_tool"]);
+        // The forbidden server is never contacted, and the all-servers enumeration is never called.
+        mcp.Verify(p => p.GetToolsAsync("granted-server", It.IsAny<CancellationToken>()), Times.Once);
+        mcp.Verify(p => p.GetAllToolsAsync(It.IsAny<CancellationToken>()), Times.Never,
+            "under an envelope we must never enumerate every host server — that would contact ungranted ones");
+    }
+
+    [Fact]
+    public async Task InjectedMode_NoEnvelope_EnumeratesAllServers()
+    {
+        var mcp = new Mock<IMcpToolProvider>();
+        mcp.Setup(p => p.GetAllToolsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<string, IList<AITool>>
+            {
+                ["server-a"] = [AIFunctionFactory.Create(() => "r", "tool_a")],
+                ["server-b"] = [AIFunctionFactory.Create(() => "r", "tool_b")]
+            });
+
+        var builder = Builder(mcp.Object);
+
+        var tools = await builder.BuildToolsAsync(InjectedSkill(), new SkillAgentOptions());
+
+        tools.Select(t => t.Name).Should().BeEquivalentTo(["tool_a", "tool_b"],
+            "off the bundle path there is no envelope and every server is reachable");
+    }
+
+    [Fact]
+    public async Task InjectedMode_EmptyEnvelope_ContactsNoServer()
+    {
+        var mcp = new Mock<IMcpToolProvider>();
+        var builder = Builder(mcp.Object);
+
+        List<AITool> tools;
+        using (CapabilityEnvelopeAccessor.Begin(Envelope(/* no servers granted */)))
+            tools = await builder.BuildToolsAsync(InjectedSkill(), new SkillAgentOptions());
+
+        tools.Should().BeEmpty("a fail-closed envelope grants no MCP server");
+        mcp.Verify(p => p.GetAllToolsAsync(It.IsAny<CancellationToken>()), Times.Never);
+        mcp.Verify(p => p.GetToolsAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ManagedDeclaration_ForbiddenServer_NeverContacted_FallsToKeyedDi()
+    {
+        // The declaration names a server the envelope does not grant. The MCP attempt must be skipped
+        // entirely so the forbidden server is never contacted; resolution falls through to keyed DI, which
+        // here has nothing, so the optional tool resolves to empty.
+        var mcp = new Mock<IMcpToolProvider>();
+        mcp.Setup(p => p.GetToolsAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([AIFunctionFactory.Create(() => "r", "forbidden_tool")]);
+
+        var builder = Builder(mcp.Object);
+        var skill = new SkillDefinition
+        {
+            Id = "s", Name = "s", Instructions = "x",
+            ToolDeclarations = [new ToolDeclaration { Name = "forbidden-server", Optional = true }]
+        };
+
+        List<AITool> tools;
+        using (CapabilityEnvelopeAccessor.Begin(Envelope("granted-server")))
+            tools = await builder.BuildToolsAsync(skill, new SkillAgentOptions());
+
+        tools.Should().BeEmpty();
+        mcp.Verify(p => p.GetToolsAsync("forbidden-server", It.IsAny<CancellationToken>()), Times.Never,
+            "a forbidden server must never even be contacted");
+    }
+
+    [Fact]
+    public async Task ManagedDeclaration_GrantedServer_ResolvesFromMcp_CaseInsensitiveGrant()
+    {
+        // The envelope grants "Granted-Server" (different casing); the declaration names "granted-server".
+        // The grant match is case-insensitive, so casing cannot be used to spoof or evade a grant.
+        var mcp = new Mock<IMcpToolProvider>();
+        mcp.Setup(p => p.GetToolsAsync("granted-server", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([AIFunctionFactory.Create(() => "r", "granted_tool")]);
+
+        var builder = Builder(mcp.Object);
+        var skill = new SkillDefinition
+        {
+            Id = "s", Name = "s", Instructions = "x",
+            ToolDeclarations = [new ToolDeclaration { Name = "granted-server" }]
+        };
+
+        List<AITool> tools;
+        using (CapabilityEnvelopeAccessor.Begin(Envelope("Granted-Server")))
+            tools = await builder.BuildToolsAsync(skill, new SkillAgentOptions());
+
+        tools.Select(t => t.Name).Should().Contain("granted_tool");
+    }
+
+    private static CapabilityEnvelope Envelope(params string[] servers) =>
+        new() { AllowedMcpServers = servers };
+}

--- a/src/Content/Tests/Application.Core.Tests/Permissions/EnvelopePermissionRuleProviderTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/Permissions/EnvelopePermissionRuleProviderTests.cs
@@ -1,0 +1,173 @@
+using Application.AI.Common.Services.Bundles;
+using Application.AI.Common.Services.Governance;
+using Application.Core.Permissions;
+using Domain.AI.Agents;
+using Domain.AI.Bundles;
+using Domain.AI.Governance;
+using Domain.AI.Permissions;
+using Domain.AI.Skills;
+using Domain.AI.Tools;
+using FluentAssertions;
+using Xunit;
+
+namespace Application.Core.Tests.Permissions;
+
+/// <summary>
+/// Tests the capability-envelope rule provider — the enforcement half of the per-caller grant. It is inert
+/// off the bundle path (no ambient envelope) and, when an envelope is active, emits bypass-immune Deny for
+/// the tools a bundle declares but is not granted plus an autonomy-ceiling baseline for the granted tools.
+/// The tests set the ambient envelope and overlay directly, exactly how a bundle run will at runtime.
+/// </summary>
+public sealed class EnvelopePermissionRuleProviderTests
+{
+    private readonly EnvelopePermissionRuleProvider _provider = new();
+
+    [Fact]
+    public void Source_IsCapabilityEnvelope()
+        => _provider.Source.Should().Be(PermissionRuleSource.CapabilityEnvelope);
+
+    [Fact]
+    public async Task NoAmbientEnvelope_EmitsNoRules()
+    {
+        // Off the bundle path the provider must be completely silent — no rule can leak into a normal turn.
+        var rules = await _provider.GetRulesAsync("any-agent");
+
+        rules.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task DeclaredToolOutsideEnvelope_EmitsBypassImmuneDeny()
+    {
+        var overlay = Overlay(Agent("bundle", "file_system", "bash"));
+        using (EphemeralAgentOverlayAccessor.Begin(overlay))
+        using (CapabilityEnvelopeAccessor.Begin(Envelope(tools: ["file_system"])))
+        {
+            var rules = await _provider.GetRulesAsync("bundle");
+
+            var deny = rules.Should().ContainSingle(r => r.Behavior == PermissionBehaviorType.Deny).Subject;
+            deny.ToolPattern.Should().Be("bash", "the declared tool the envelope does not grant is denied by name");
+            deny.IsBypassImmune.Should().BeTrue("an out-of-envelope deny cannot be lifted by any auto-approve mode");
+            deny.Source.Should().Be(PermissionRuleSource.CapabilityEnvelope);
+        }
+    }
+
+    [Fact]
+    public async Task GrantedTool_IsNotDenied_AndGetsCeilingBaseline()
+    {
+        var overlay = Overlay(Agent("bundle", "file_system"));
+        using (EphemeralAgentOverlayAccessor.Begin(overlay))
+        using (CapabilityEnvelopeAccessor.Begin(Envelope(tools: ["file_system"], ceiling: AutonomyLevel.Supervised)))
+        {
+            var rules = await _provider.GetRulesAsync("bundle");
+
+            rules.Should().NotContain(r => r.Behavior == PermissionBehaviorType.Deny);
+            var baseline = rules.Should().ContainSingle(r => r.IsAuthoritativeBaseline).Subject;
+            baseline.ToolPattern.Should().Be("file_system");
+            baseline.Behavior.Should().Be(PermissionBehaviorType.Ask, "Supervised caps autonomy at approval-required");
+        }
+    }
+
+    [Theory]
+    [InlineData(AutonomyLevel.Autonomous, PermissionBehaviorType.Allow)]
+    [InlineData(AutonomyLevel.Supervised, PermissionBehaviorType.Ask)]
+    [InlineData(AutonomyLevel.Restricted, PermissionBehaviorType.Ask)]
+    public async Task CeilingBaseline_MapsAutonomyToBehavior(AutonomyLevel ceiling, PermissionBehaviorType expected)
+    {
+        using (CapabilityEnvelopeAccessor.Begin(Envelope(tools: ["t"], ceiling: ceiling)))
+        {
+            var rules = await _provider.GetRulesAsync("bundle");
+
+            rules.Should().ContainSingle(r => r.IsAuthoritativeBaseline)
+                .Which.Behavior.Should().Be(expected);
+        }
+    }
+
+    [Fact]
+    public async Task EmptyEnvelope_DeniesEveryDeclaredTool_AndGrantsNoBaseline()
+    {
+        // A deny-all envelope (grants nothing) is the fail-closed default. Every tool the bundle declares
+        // is denied bypass-immune, and there is no allow/baseline for anything.
+        var overlay = Overlay(Agent("bundle", "file_system", "bash"));
+        using (EphemeralAgentOverlayAccessor.Begin(overlay))
+        using (CapabilityEnvelopeAccessor.Begin(Envelope()))
+        {
+            var rules = await _provider.GetRulesAsync("bundle");
+
+            rules.Should().OnlyContain(r => r.Behavior == PermissionBehaviorType.Deny && r.IsBypassImmune);
+            rules.Select(r => r.ToolPattern).Should().BeEquivalentTo(["file_system", "bash"]);
+        }
+    }
+
+    [Fact]
+    public async Task EnvelopeGrantMatchesToolCaseInsensitively_NoDeny()
+    {
+        // The bundle declares "file_system"; the envelope grants "File_System". A case-sensitive check would
+        // wrongly deny the granted tool — the envelope's grant is case-insensitive, so it must not.
+        var overlay = Overlay(Agent("bundle", "file_system"));
+        using (EphemeralAgentOverlayAccessor.Begin(overlay))
+        using (CapabilityEnvelopeAccessor.Begin(Envelope(tools: ["File_System"])))
+        {
+            var rules = await _provider.GetRulesAsync("bundle");
+
+            rules.Should().NotContain(r => r.Behavior == PermissionBehaviorType.Deny);
+        }
+    }
+
+    [Fact]
+    public async Task DeclaredToolsPulledFromOwnedSkills_Denied_WhenOutsideEnvelope()
+    {
+        // Tools the bundle declares live on the agent's ceiling AND on each owned skill; the provider must
+        // consider both when computing the out-of-envelope deny set.
+        var overlay = new EphemeralAgentOverlay
+        {
+            Agent = Agent("bundle"),
+            OwnedSkills =
+            [
+                new SkillDefinition { Id = "s1", Name = "s1", AllowedTools = ["skill_tool"] },
+                new SkillDefinition
+                {
+                    Id = "s2", Name = "s2",
+                    ToolDeclarations = [new ToolDeclaration { Name = "declared_tool" }]
+                }
+            ]
+        };
+
+        using (EphemeralAgentOverlayAccessor.Begin(overlay))
+        using (CapabilityEnvelopeAccessor.Begin(Envelope(tools: ["skill_tool"])))
+        {
+            var rules = await _provider.GetRulesAsync("bundle");
+
+            rules.Where(r => r.Behavior == PermissionBehaviorType.Deny).Select(r => r.ToolPattern)
+                .Should().BeEquivalentTo(["declared_tool"], "only the skill tool outside the envelope is denied");
+        }
+    }
+
+    [Fact]
+    public async Task OverlayForDifferentAgent_ContributesNoDenySet_ButStillCapsAutonomy()
+    {
+        // If the resolved agent is not the one the overlay owns, the provider can't enumerate its declared
+        // tools, so it emits no deny set — but the envelope's autonomy ceiling still applies to granted tools
+        // (the fail-closed default handles anything else at runtime).
+        var overlay = Overlay(Agent("bundle", "bash"));
+        using (EphemeralAgentOverlayAccessor.Begin(overlay))
+        using (CapabilityEnvelopeAccessor.Begin(Envelope(tools: ["file_system"], ceiling: AutonomyLevel.Supervised)))
+        {
+            var rules = await _provider.GetRulesAsync("some-other-agent");
+
+            rules.Should().NotContain(r => r.Behavior == PermissionBehaviorType.Deny);
+            rules.Should().ContainSingle(r => r.IsAuthoritativeBaseline)
+                .Which.ToolPattern.Should().Be("file_system");
+        }
+    }
+
+    private static AgentDefinition Agent(string id, params string[] allowedTools) =>
+        new() { Id = id, Name = id, AllowedTools = allowedTools };
+
+    private static EphemeralAgentOverlay Overlay(AgentDefinition agent) =>
+        new() { Agent = agent };
+
+    private static CapabilityEnvelope Envelope(
+        IReadOnlyList<string>? tools = null,
+        AutonomyLevel ceiling = AutonomyLevel.Restricted) =>
+        new() { AllowedTools = tools ?? [], AutonomyCeiling = ceiling };
+}

--- a/src/Content/Tests/Domain.AI.Tests/Permissions/PermissionEnumTests.cs
+++ b/src/Content/Tests/Domain.AI.Tests/Permissions/PermissionEnumTests.cs
@@ -36,14 +36,15 @@ public sealed class PermissionEnumTests
     [InlineData(PermissionRuleSource.CliArgument, 7)]
     [InlineData(PermissionRuleSource.AutonomyTier, 8)]
     [InlineData(PermissionRuleSource.PluginDeclaration, 9)]
+    [InlineData(PermissionRuleSource.CapabilityEnvelope, 10)]
     public void PermissionRuleSource_Values_HaveExpectedIntegers(PermissionRuleSource value, int expected)
     {
         ((int)value).Should().Be(expected);
     }
 
     [Fact]
-    public void PermissionRuleSource_HasExactlyTenValues()
+    public void PermissionRuleSource_HasExactlyElevenValues()
     {
-        Enum.GetValues<PermissionRuleSource>().Should().HaveCount(10);
+        Enum.GetValues<PermissionRuleSource>().Should().HaveCount(11);
     }
 }

--- a/src/Content/Tests/Infrastructure.AI.Tests/Governance/CapabilityEnvelopeResolverTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Governance/CapabilityEnvelopeResolverTests.cs
@@ -1,0 +1,185 @@
+using System.Security.Claims;
+using Domain.AI.Governance;
+using Domain.Common.Config;
+using Domain.Common.Config.AI;
+using Domain.Common.Config.AI.BundleExecution;
+using FluentAssertions;
+using Infrastructure.AI.Governance;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Governance;
+
+/// <summary>
+/// Tests <see cref="CapabilityEnvelopeResolver"/> — the config-to-grant mapping. Covers the precedence
+/// (exact subject → least-privilege combination of matching roles → default), the fail-closed default for
+/// an unmatched caller, safe degradation of an invalid autonomy ceiling, and the invariant that overlapping
+/// roles can only ever narrow a grant.
+/// </summary>
+public sealed class CapabilityEnvelopeResolverTests
+{
+    private static CapabilityEnvelopeResolver Resolver(CapabilityEnvelopesConfig envelopes)
+    {
+        var appConfig = new AppConfig
+        {
+            AI = new AIConfig
+            {
+                BundleExecution = new Domain.Common.Config.AI.BundleExecution.BundleExecutionConfig { Envelopes = envelopes }
+            }
+        };
+
+        return new CapabilityEnvelopeResolver(
+            Mock.Of<IOptionsMonitor<AppConfig>>(o => o.CurrentValue == appConfig),
+            NullLogger<CapabilityEnvelopeResolver>.Instance);
+    }
+
+    private static ClaimsPrincipal Principal(string? subject = null, params string[] roles)
+    {
+        var claims = new List<Claim>();
+        if (subject is not null)
+            claims.Add(new Claim(ClaimTypes.NameIdentifier, subject));
+        claims.AddRange(roles.Select(r => new Claim(ClaimTypes.Role, r)));
+        return new ClaimsPrincipal(new ClaimsIdentity(claims, "test"));
+    }
+
+    [Fact]
+    public void NullPrincipal_ReturnsDefault()
+    {
+        var resolver = Resolver(new CapabilityEnvelopesConfig
+        {
+            Default = new CapabilityEnvelopeConfig { AllowedTools = ["read_only"], AutonomyCeiling = "Supervised" }
+        });
+
+        var envelope = resolver.Resolve(null);
+
+        envelope.AllowedTools.Should().BeEquivalentTo(["read_only"]);
+        envelope.AutonomyCeiling.Should().Be(AutonomyLevel.Supervised);
+    }
+
+    [Fact]
+    public void UnmatchedCaller_UnconfiguredDefault_GrantsNothing_AndIsRestricted()
+    {
+        var resolver = Resolver(new CapabilityEnvelopesConfig());
+
+        var envelope = resolver.Resolve(Principal(subject: "nobody", roles: "stranger"));
+
+        envelope.AllowedTools.Should().BeEmpty("the fail-closed default grants no tools");
+        envelope.AllowedMcpServers.Should().BeEmpty();
+        envelope.AutonomyCeiling.Should().Be(AutonomyLevel.Restricted);
+    }
+
+    [Fact]
+    public void SubjectMatch_WinsOverRole()
+    {
+        var resolver = Resolver(new CapabilityEnvelopesConfig
+        {
+            BySubject = { ["alice"] = new CapabilityEnvelopeConfig { AllowedTools = ["subject_tool"], AutonomyCeiling = "Autonomous" } },
+            ByRole = { ["admin"] = new CapabilityEnvelopeConfig { AllowedTools = ["role_tool"], AutonomyCeiling = "Restricted" } }
+        });
+
+        var envelope = resolver.Resolve(Principal(subject: "alice", roles: "admin"));
+
+        envelope.AllowedTools.Should().BeEquivalentTo(["subject_tool"], "an exact subject grant takes precedence over any role");
+        envelope.AutonomyCeiling.Should().Be(AutonomyLevel.Autonomous);
+    }
+
+    [Fact]
+    public void SubjectKey_MatchedCaseInsensitively()
+    {
+        var resolver = Resolver(new CapabilityEnvelopesConfig
+        {
+            BySubject = { ["Alice"] = new CapabilityEnvelopeConfig { AllowedTools = ["t"] } }
+        });
+
+        resolver.Resolve(Principal(subject: "alice")).AllowedTools.Should().BeEquivalentTo(["t"]);
+    }
+
+    [Fact]
+    public void RoleMatch_UsedWhenNoSubjectGrant()
+    {
+        var resolver = Resolver(new CapabilityEnvelopesConfig
+        {
+            ByRole = { ["reader"] = new CapabilityEnvelopeConfig { AllowedTools = ["doc_search"], AllowedMcpServers = ["kb"], AutonomyCeiling = "Supervised" } }
+        });
+
+        var envelope = resolver.Resolve(Principal(subject: "unknown", roles: "reader"));
+
+        envelope.AllowedTools.Should().BeEquivalentTo(["doc_search"]);
+        envelope.AllowedMcpServers.Should().BeEquivalentTo(["kb"]);
+        envelope.AutonomyCeiling.Should().Be(AutonomyLevel.Supervised);
+    }
+
+    [Fact]
+    public void MultipleRoles_CombineToLeastPrivilege()
+    {
+        // Two roles grant overlapping-but-different surfaces at different ceilings. The caller with both
+        // gets the INTERSECTION of tools/servers and the MINIMUM ceiling — overlapping roles never widen.
+        var resolver = Resolver(new CapabilityEnvelopesConfig
+        {
+            ByRole =
+            {
+                ["writer"] = new CapabilityEnvelopeConfig
+                {
+                    AllowedTools = ["file_system", "search"], AllowedMcpServers = ["kb", "web"], AutonomyCeiling = "Autonomous"
+                },
+                ["auditor"] = new CapabilityEnvelopeConfig
+                {
+                    AllowedTools = ["search", "log_read"], AllowedMcpServers = ["kb"], AutonomyCeiling = "Supervised"
+                }
+            }
+        });
+
+        var envelope = resolver.Resolve(Principal(subject: "u", roles: ["writer", "auditor"]));
+
+        envelope.AllowedTools.Should().BeEquivalentTo(["search"], "only the tool common to both roles survives");
+        envelope.AllowedMcpServers.Should().BeEquivalentTo(["kb"]);
+        envelope.AutonomyCeiling.Should().Be(AutonomyLevel.Supervised, "the minimum of the two ceilings");
+    }
+
+    [Fact]
+    public void OnlyOneRoleConfigured_OtherRolesIgnored()
+    {
+        var resolver = Resolver(new CapabilityEnvelopesConfig
+        {
+            ByRole = { ["reader"] = new CapabilityEnvelopeConfig { AllowedTools = ["doc_search"] } }
+        });
+
+        // "writer" has no config entry, so only "reader" contributes — no accidental intersection to empty.
+        var envelope = resolver.Resolve(Principal(subject: "u", roles: ["reader", "writer"]));
+
+        envelope.AllowedTools.Should().BeEquivalentTo(["doc_search"]);
+    }
+
+    [Theory]
+    [InlineData("SuperUser")]   // unknown name
+    [InlineData("2")]           // numeric — Enum.TryParse would accept this as Autonomous
+    [InlineData("Restricted,Autonomous")] // comma-composite — Enum.TryParse would OR to Autonomous
+    [InlineData("")]            // empty
+    public void NonTierNameCeiling_FallsBackToRestricted_NeverWidens(string ceiling)
+    {
+        var resolver = Resolver(new CapabilityEnvelopesConfig
+        {
+            Default = new CapabilityEnvelopeConfig { AllowedTools = ["t"], AutonomyCeiling = ceiling }
+        });
+
+        resolver.Resolve(null).AutonomyCeiling.Should().Be(AutonomyLevel.Restricted,
+            "only an exact tier name is accepted; anything else degrades closed rather than silently granting autonomy");
+    }
+
+    [Fact]
+    public void Role_FromShortRolesClaim_IsMatched()
+    {
+        // Hosts whose token pipeline emits a short "roles" claim (e.g. Azure AD app roles) instead of the
+        // long SOAP ClaimTypes.Role URI must still resolve their ByRole grant — otherwise role config is dead.
+        var resolver = Resolver(new CapabilityEnvelopesConfig
+        {
+            ByRole = { ["reader"] = new CapabilityEnvelopeConfig { AllowedTools = ["doc_search"] } }
+        });
+
+        var principal = new ClaimsPrincipal(new ClaimsIdentity([new Claim("roles", "reader")], "test"));
+
+        resolver.Resolve(principal).AllowedTools.Should().BeEquivalentTo(["doc_search"]);
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Permissions/EnvelopeEnforcementIntegrationTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Permissions/EnvelopeEnforcementIntegrationTests.cs
@@ -1,0 +1,128 @@
+using Application.AI.Common.Interfaces.Permissions;
+using Application.AI.Common.Services.Bundles;
+using Application.AI.Common.Services.Governance;
+using Application.Core.Permissions;
+using Domain.AI.Agents;
+using Domain.AI.Bundles;
+using Domain.AI.Governance;
+using Domain.AI.Permissions;
+using Domain.Common.Config;
+using Domain.Common.Config.AI;
+using Domain.Common.Config.AI.Permissions;
+using FluentAssertions;
+using Infrastructure.AI.Permissions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Permissions;
+
+/// <summary>
+/// End-to-end enforcement of the capability envelope through the <em>real</em>
+/// <see cref="ThreePhasePermissionResolver"/> and glob pattern matcher, driven only by the real
+/// <see cref="EnvelopePermissionRuleProvider"/>. Proves the phase interaction the envelope relies on: an
+/// out-of-envelope tool resolves to a bypass-immune Deny (phase 1b) that wins over the autonomy-ceiling
+/// baseline (phase 1.5), and a granted tool resolves to exactly the ceiling behavior.
+/// </summary>
+public sealed class EnvelopeEnforcementIntegrationTests
+{
+    private const string AgentId = "bundle";
+
+    private readonly Mock<ISafetyGateRegistry> _safetyGates = new();
+    private readonly Mock<IDenialTracker> _denialTracker = new();
+    private readonly GlobPatternMatcher _matcher = new();
+    private readonly IOptionsMonitor<AppConfig> _options;
+
+    public EnvelopeEnforcementIntegrationTests()
+    {
+        _options = Mock.Of<IOptionsMonitor<AppConfig>>(o => o.CurrentValue == new AppConfig
+        {
+            AI = new AIConfig { Permissions = new PermissionsConfig { DenialRateLimitThreshold = 5 } }
+        });
+        _safetyGates
+            .Setup(r => r.CheckSafetyGate(It.IsAny<string>(), It.IsAny<IReadOnlyDictionary<string, object?>?>()))
+            .Returns((SafetyGate?)null);
+    }
+
+    private ThreePhasePermissionResolver Resolver() => new(
+        [new EnvelopePermissionRuleProvider()],
+        _safetyGates.Object,
+        _matcher,
+        _denialTracker.Object,
+        _options,
+        NullLogger<ThreePhasePermissionResolver>.Instance);
+
+    [Fact]
+    public async Task OutOfEnvelopeTool_ResolvesToBypassImmuneDeny()
+    {
+        var overlay = Overlay("file_system", "bash");
+        using (EphemeralAgentOverlayAccessor.Begin(overlay))
+        using (CapabilityEnvelopeAccessor.Begin(Envelope(["file_system"], AutonomyLevel.Autonomous)))
+        {
+            var decision = await Resolver().ResolvePermissionAsync(AgentId, "bash");
+
+            decision.Behavior.Should().Be(PermissionBehaviorType.Deny);
+            decision.MatchedRule!.IsBypassImmune.Should().BeTrue();
+            decision.MatchedRule.Source.Should().Be(PermissionRuleSource.CapabilityEnvelope);
+        }
+    }
+
+    [Fact]
+    public async Task GrantedTool_AutonomousCeiling_ResolvesToAllow()
+    {
+        var overlay = Overlay("file_system");
+        using (EphemeralAgentOverlayAccessor.Begin(overlay))
+        using (CapabilityEnvelopeAccessor.Begin(Envelope(["file_system"], AutonomyLevel.Autonomous)))
+        {
+            var decision = await Resolver().ResolvePermissionAsync(AgentId, "file_system");
+
+            decision.Behavior.Should().Be(PermissionBehaviorType.Allow);
+        }
+    }
+
+    [Fact]
+    public async Task GrantedTool_SupervisedCeiling_ResolvesToAsk()
+    {
+        var overlay = Overlay("file_system");
+        using (EphemeralAgentOverlayAccessor.Begin(overlay))
+        using (CapabilityEnvelopeAccessor.Begin(Envelope(["file_system"], AutonomyLevel.Supervised)))
+        {
+            var decision = await Resolver().ResolvePermissionAsync(AgentId, "file_system");
+
+            decision.Behavior.Should().Be(PermissionBehaviorType.Ask);
+        }
+    }
+
+    [Fact]
+    public async Task UndeclaredOutOfEnvelopeTool_FailsClosedToAsk()
+    {
+        // A tool the bundle never declared (so no explicit deny is emitted) and the envelope never granted
+        // must still not resolve to Allow: with no matching allow/baseline the resolver defaults to Ask,
+        // which the fail-closed governor turns into a denial.
+        var overlay = Overlay("file_system");
+        using (EphemeralAgentOverlayAccessor.Begin(overlay))
+        using (CapabilityEnvelopeAccessor.Begin(Envelope(["file_system"], AutonomyLevel.Autonomous)))
+        {
+            var decision = await Resolver().ResolvePermissionAsync(AgentId, "surprise_tool");
+
+            decision.Behavior.Should().Be(PermissionBehaviorType.Ask);
+        }
+    }
+
+    [Fact]
+    public async Task NoEnvelope_ProviderContributesNothing_DefaultsToAsk()
+    {
+        var decision = await Resolver().ResolvePermissionAsync(AgentId, "anything");
+
+        decision.Behavior.Should().Be(PermissionBehaviorType.Ask, "with no rules at all the resolver defaults to Ask");
+    }
+
+    private static EphemeralAgentOverlay Overlay(params string[] declaredTools) => new()
+    {
+        Agent = new AgentDefinition { Id = AgentId, Name = AgentId, AllowedTools = declaredTools }
+    };
+
+    private static CapabilityEnvelope Envelope(IReadOnlyList<string> tools, AutonomyLevel ceiling) =>
+        new() { AllowedTools = tools, AutonomyCeiling = ceiling };
+}


### PR DESCRIPTION
## What & why
**Part 2 of Issue #154 — the security spine of the bundle-injection API.** The harness can run externally-authored agent *bundles*; this PR guarantees a bundle gets **only** the tools, MCP servers, and autonomy the host granted *its caller*. A bundle's self-declared capabilities are **requests**; the per-caller **capability envelope** is the authoritative **grant**. Enforced entirely through the existing 3-phase permission gate — no new gate machinery. Off by default; byte-identical behaviour when no envelope is present.

Still no HTTP surface (that's PR4) — this layer is proven through its ambient accessors and unit/integration tests.

## What's in it
- **`CapabilityEnvelope`** (domain grant: allowed tools, allowed MCP servers, autonomy ceiling) + a config-driven **resolver** (`subject` → least-privilege combination of matching roles → fail-closed default).
- **`EnvelopePermissionRuleProvider`** — emits bypass-immune `Deny` for out-of-envelope tools + an autonomy-ceiling baseline, riding `ThreePhasePermissionResolver`. Inert unless a bundle envelope is ambient.
- **Enforcement armed by a single ambient fact** — the envelope's *presence* forces governance on for the flow, so enforcement can never be desynced from the grant.
- **Reference-only MCP** in `ToolChainBuilder` — only granted servers are contacted (closing SSRF-by-construction), fetched concurrently with graceful per-server degradation.

## Review (Matt asked for a full adversarial pass)
8 code-review finder angles + a dedicated **security-reviewer** (2 passes: find, then adversarially verify the fixes). Fixed and re-verified CLOSED:
- **HIGH** — two decoupled enforcement flags could leave tool-level confinement inert → collapsed to the single envelope-presence signal.
- **HIGH** — empty AgentId failed open under a bundle run → now fail-closed deny.
- **MEDIUM (SSRF)** — Injected path enumerated *every* MCP server before filtering → now contacts only granted servers.
- Trace-timing mislabel, `ParseCeiling` numeric/composite silent-widening, role-claim asymmetry — all fixed.

Then `/simplify` (4 angles): applied idiomatic `Contains`, parallelized the MCP fetch, O(1) grant-set membership.

## Tests
Full suites green — **2150** across Application.AI.Common (1383), Application.Core (672), Infrastructure permissions/governance (95) — plus DI composition smoke. New tests cover envelope resolution, provider deny/ceiling, end-to-end enforcement through the real resolver, the MCP allowlist (incl. the never-contact-ungranted-server assertion), the empty-AgentId fail-closed path, and the adversarial cases (numeric/composite ceiling, casing, empty/null fail-closed).

## Deferred (follow-ups, with reason)
- **Resolver allowlist-confinement primitive** — teach `ThreePhasePermissionResolver` a first-class "confine to allowlist" rule so the envelope emits one confine rule instead of enumerating denied tools + a second ambient. Cleaner *and* slightly more secure; deferred because it changes shared permission infra (plan scoped this PR to "zero new gate code"). Also subsumes a `SkillDefinition` tool-name-enumeration dedup.
- **PR4/PR5 integration invariant** — the run/streaming path must keep the envelope scope open across the entire (possibly streamed) turn; documented on the accessor, wants an integration test when the run path lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)