### PR TITLE
feat: bundle async-job + handle lifecycle (Bundle-PR3)

### DIFF
--- a/src/Content/Application/Application.AI.Common/CQRS/Bundles/GetBundleRun/GetBundleRunQuery.cs
+++ b/src/Content/Application/Application.AI.Common/CQRS/Bundles/GetBundleRun/GetBundleRunQuery.cs
@@ -1,0 +1,23 @@
+using Domain.AI.Bundles;
+using Domain.Common;
+using MediatR;
+
+namespace Application.AI.Common.CQRS.Bundles.GetBundleRun;
+
+/// <summary>
+/// Reads the current state of a bundle run. The application-level entry point for
+/// <c>GET /api/bundles/{handle}/runs/{jobId}</c> — callers poll it until the run reaches a terminal status.
+/// </summary>
+/// <remarks>
+/// The query is scoped by both <see cref="Handle"/> and <see cref="JobId"/>: a run is only readable under
+/// the handle it belongs to, so a caller cannot read another handle's run by guessing its job id (the run
+/// is reported as not found rather than revealing it exists under a different handle).
+/// </remarks>
+public sealed record GetBundleRunQuery : IRequest<Result<BundleRunRecord>>
+{
+    /// <summary>The handle the run belongs to.</summary>
+    public required string Handle { get; init; }
+
+    /// <summary>The job id of the run to read.</summary>
+    public required string JobId { get; init; }
+}

--- a/src/Content/Application/Application.AI.Common/CQRS/Bundles/GetBundleRun/GetBundleRunQueryHandler.cs
+++ b/src/Content/Application/Application.AI.Common/CQRS/Bundles/GetBundleRun/GetBundleRunQueryHandler.cs
@@ -1,0 +1,55 @@
+using Application.AI.Common.Interfaces.Bundles;
+using Domain.AI.Bundles;
+using Domain.Common;
+using Domain.Common.Config;
+using MediatR;
+using Microsoft.Extensions.Options;
+
+namespace Application.AI.Common.CQRS.Bundles.GetBundleRun;
+
+/// <summary>
+/// Handles <see cref="GetBundleRunQuery"/>: returns the current run record when it exists under the given
+/// handle, or a not-found result when the job id is unknown, already swept, or belongs to a different handle.
+/// </summary>
+/// <remarks>
+/// A run whose handle does not match the query's handle is reported as not found (never as
+/// "belongs to another handle"), so the poll surface leaks nothing about runs the caller does not own.
+/// </remarks>
+public sealed class GetBundleRunQueryHandler
+    : IRequestHandler<GetBundleRunQuery, Result<BundleRunRecord>>
+{
+    private readonly IBundleRunJobStore _jobStore;
+    private readonly IOptionsMonitor<AppConfig> _config;
+
+    /// <summary>Initializes a new <see cref="GetBundleRunQueryHandler"/>.</summary>
+    public GetBundleRunQueryHandler(IBundleRunJobStore jobStore, IOptionsMonitor<AppConfig> config)
+    {
+        ArgumentNullException.ThrowIfNull(jobStore);
+        ArgumentNullException.ThrowIfNull(config);
+
+        _jobStore = jobStore;
+        _config = config;
+    }
+
+    /// <inheritdoc />
+    public Task<Result<BundleRunRecord>> Handle(GetBundleRunQuery request, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (!_config.CurrentValue.AI.BundleExecution.Enabled)
+        {
+            return Task.FromResult(Result<BundleRunRecord>.Forbidden(
+                "Bundle execution is disabled. Set AppConfig.AI.BundleExecution.Enabled = true to enable it."));
+        }
+
+        var record = _jobStore.Get(request.JobId);
+        if (record is null || !string.Equals(record.Handle, request.Handle, StringComparison.Ordinal))
+        {
+            return Task.FromResult(Result<BundleRunRecord>.NotFound(
+                "Bundle run not found. It may never have existed, expired, or belongs to a different handle."));
+        }
+
+        return Task.FromResult(Result<BundleRunRecord>.Success(record));
+    }
+}

--- a/src/Content/Application/Application.AI.Common/CQRS/Bundles/GetBundleRun/GetBundleRunQueryValidator.cs
+++ b/src/Content/Application/Application.AI.Common/CQRS/Bundles/GetBundleRun/GetBundleRunQueryValidator.cs
@@ -1,0 +1,19 @@
+using FluentValidation;
+
+namespace Application.AI.Common.CQRS.Bundles.GetBundleRun;
+
+/// <summary>
+/// Validates <see cref="GetBundleRunQuery"/> before the handler runs.
+/// </summary>
+public sealed class GetBundleRunQueryValidator : AbstractValidator<GetBundleRunQuery>
+{
+    /// <summary>Initializes validation rules.</summary>
+    public GetBundleRunQueryValidator()
+    {
+        RuleFor(x => x.Handle)
+            .NotEmpty().WithMessage("Handle is required.");
+
+        RuleFor(x => x.JobId)
+            .NotEmpty().WithMessage("JobId is required.");
+    }
+}

--- a/src/Content/Application/Application.AI.Common/CQRS/Bundles/RegisterBundle/RegisterBundleCommand.cs
+++ b/src/Content/Application/Application.AI.Common/CQRS/Bundles/RegisterBundle/RegisterBundleCommand.cs
@@ -1,0 +1,24 @@
+using Domain.Common;
+using MediatR;
+
+namespace Application.AI.Common.CQRS.Bundles.RegisterBundle;
+
+/// <summary>
+/// Registers a received agent-bundle archive: validates and extracts it under the host's hostile-input
+/// guards, then holds the staged bundle behind a short-lived TTL handle the caller uses to run or delete it.
+/// The application-level entry point for <c>POST /api/bundles</c>.
+/// </summary>
+/// <remarks>
+/// The command carries the archive as a <see cref="Stream"/> rather than a buffered byte array so an
+/// oversized archive is rejected while reading, without first materialising all of it in memory. The stream
+/// is read once by the staging service; the caller retains ownership and disposal of it. Registration does
+/// not run the bundle — it only stages it and mints a handle.
+/// </remarks>
+public sealed record RegisterBundleCommand : IRequest<Result<RegisterBundleResult>>
+{
+    /// <summary>
+    /// The received archive stream (a zip). Read once during staging; the caller retains ownership and
+    /// disposal. Its compressed length is enforced against the configured maximum while reading.
+    /// </summary>
+    public required Stream Archive { get; init; }
+}

--- a/src/Content/Application/Application.AI.Common/CQRS/Bundles/RegisterBundle/RegisterBundleCommandHandler.cs
+++ b/src/Content/Application/Application.AI.Common/CQRS/Bundles/RegisterBundle/RegisterBundleCommandHandler.cs
@@ -1,0 +1,86 @@
+using Application.AI.Common.Interfaces.Bundles;
+using Domain.Common;
+using Domain.Common.Config;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Application.AI.Common.CQRS.Bundles.RegisterBundle;
+
+/// <summary>
+/// Handles <see cref="RegisterBundleCommand"/>: refuses when bundle execution is disabled, stages the
+/// archive through <see cref="IBundleStagingService"/> (applying every hostile-input guard), registers the
+/// resulting staged bundle in the <see cref="IBundleHandleStore"/>, and returns the handle with its expiry.
+/// </summary>
+/// <remarks>
+/// The handler never runs the bundle — it only makes it available to run. A staging failure is surfaced
+/// verbatim (the staging service already returns safe, caller-facing reasons); the handler adds no detail
+/// that could leak an internal path. The returned <see cref="RegisterBundleResult.ExpiresAt"/> is computed
+/// from the same TTL the store applies, so the caller gets an accurate earliest-expiry.
+/// </remarks>
+public sealed class RegisterBundleCommandHandler
+    : IRequestHandler<RegisterBundleCommand, Result<RegisterBundleResult>>
+{
+    private readonly IBundleStagingService _stagingService;
+    private readonly IBundleHandleStore _handleStore;
+    private readonly IOptionsMonitor<AppConfig> _config;
+    private readonly TimeProvider _time;
+    private readonly ILogger<RegisterBundleCommandHandler> _logger;
+
+    /// <summary>Initializes a new <see cref="RegisterBundleCommandHandler"/>.</summary>
+    public RegisterBundleCommandHandler(
+        IBundleStagingService stagingService,
+        IBundleHandleStore handleStore,
+        IOptionsMonitor<AppConfig> config,
+        TimeProvider time,
+        ILogger<RegisterBundleCommandHandler> logger)
+    {
+        ArgumentNullException.ThrowIfNull(stagingService);
+        ArgumentNullException.ThrowIfNull(handleStore);
+        ArgumentNullException.ThrowIfNull(config);
+        ArgumentNullException.ThrowIfNull(time);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _stagingService = stagingService;
+        _handleStore = handleStore;
+        _config = config;
+        _time = time;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<Result<RegisterBundleResult>> Handle(
+        RegisterBundleCommand request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var bundleConfig = _config.CurrentValue.AI.BundleExecution;
+        if (!bundleConfig.Enabled)
+        {
+            return Result<RegisterBundleResult>.Forbidden(
+                "Bundle execution is disabled. Set AppConfig.AI.BundleExecution.Enabled = true to enable it.");
+        }
+
+        var staged = await _stagingService.StageAsync(request.Archive, cancellationToken).ConfigureAwait(false);
+        if (!staged.IsSuccess || staged.Value is null)
+        {
+            // The staging service's reasons are already caller-safe (no internal paths); pass them through.
+            return Result<RegisterBundleResult>.Fail([.. staged.Errors]);
+        }
+
+        var handle = _handleStore.Register(staged.Value);
+        var expiresAt = _time.GetUtcNow() + bundleConfig.HandleTtl;
+
+        _logger.LogInformation(
+            "Registered bundle handle {Handle} (agent {AgentId}, {SkillCount} owned skill(s)); expires at {ExpiresAt:o}.",
+            handle, staged.Value.Agent.Id, staged.Value.OwnedSkills.Count, expiresAt);
+
+        return Result<RegisterBundleResult>.Success(new RegisterBundleResult
+        {
+            Handle = handle,
+            ExpiresAt = expiresAt
+        });
+    }
+}

--- a/src/Content/Application/Application.AI.Common/CQRS/Bundles/RegisterBundle/RegisterBundleCommandValidator.cs
+++ b/src/Content/Application/Application.AI.Common/CQRS/Bundles/RegisterBundle/RegisterBundleCommandValidator.cs
@@ -1,0 +1,19 @@
+using FluentValidation;
+
+namespace Application.AI.Common.CQRS.Bundles.RegisterBundle;
+
+/// <summary>
+/// Validates <see cref="RegisterBundleCommand"/> before the handler runs. The archive's size and shape are
+/// enforced by the staging service against configured limits (they need the config the validator does not
+/// have); this only ensures a readable stream was supplied.
+/// </summary>
+public sealed class RegisterBundleCommandValidator : AbstractValidator<RegisterBundleCommand>
+{
+    /// <summary>Initializes validation rules.</summary>
+    public RegisterBundleCommandValidator()
+    {
+        RuleFor(x => x.Archive)
+            .NotNull().WithMessage("Archive stream is required.")
+            .Must(s => s is null || s.CanRead).WithMessage("Archive stream must be readable.");
+    }
+}

--- a/src/Content/Application/Application.AI.Common/CQRS/Bundles/RegisterBundle/RegisterBundleResult.cs
+++ b/src/Content/Application/Application.AI.Common/CQRS/Bundles/RegisterBundle/RegisterBundleResult.cs
@@ -1,0 +1,15 @@
+namespace Application.AI.Common.CQRS.Bundles.RegisterBundle;
+
+/// <summary>
+/// The result of registering a bundle: the handle the caller uses to run or delete the staged bundle, and
+/// when that handle expires if left idle. The handle's lifetime is sliding, so <see cref="ExpiresAt"/> is
+/// the earliest it could expire — using the handle refreshes it.
+/// </summary>
+public sealed record RegisterBundleResult
+{
+    /// <summary>The opaque handle identifying the staged bundle.</summary>
+    public required string Handle { get; init; }
+
+    /// <summary>The earliest instant the handle expires if it is not used again before then.</summary>
+    public required DateTimeOffset ExpiresAt { get; init; }
+}

--- a/src/Content/Application/Application.AI.Common/CQRS/Bundles/RunBundle/RunBundleCommand.cs
+++ b/src/Content/Application/Application.AI.Common/CQRS/Bundles/RunBundle/RunBundleCommand.cs
@@ -1,0 +1,38 @@
+using Domain.AI.Bundles;
+using Domain.Common;
+using MediatR;
+
+namespace Application.AI.Common.CQRS.Bundles.RunBundle;
+
+/// <summary>
+/// Starts an asynchronous run of a previously staged bundle: creates a queued run record and hands it to the
+/// background dispatcher, returning a job id the caller polls for the result. The application-level entry
+/// point for <c>POST /api/bundles/{handle}/runs</c>. Async-job is the contract — this returns immediately,
+/// it does not block on the conversation.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The <see cref="Envelope"/> is the <em>resolved</em> per-caller capability grant, not the bundle's own
+/// requests. Resolving it from the caller's credential is the transport layer's job (the API middleware);
+/// this command takes the already-resolved grant so the background dispatcher can re-publish it ambiently
+/// for the whole run — the request-scoped ambient envelope does not flow onto the dispatcher's thread.
+/// </para>
+/// <para>
+/// Resolving the envelope per run (rather than binding it at registration) means even a leaked handle runs
+/// only under the <em>invoking</em> caller's grant, never the registrant's — defence in depth.
+/// </para>
+/// </remarks>
+public sealed record RunBundleCommand : IRequest<Result<RunBundleResult>>
+{
+    /// <summary>The handle of the staged bundle to run.</summary>
+    public required string Handle { get; init; }
+
+    /// <summary>The user messages seeding the conversation. One turn per message, bounded by <see cref="MaxTurns"/>.</summary>
+    public required IReadOnlyList<string> UserMessages { get; init; }
+
+    /// <summary>The resolved per-caller capability grant this run executes under.</summary>
+    public required CapabilityEnvelope Envelope { get; init; }
+
+    /// <summary>The maximum number of turns the conversation may run.</summary>
+    public int MaxTurns { get; init; } = 10;
+}

--- a/src/Content/Application/Application.AI.Common/CQRS/Bundles/RunBundle/RunBundleCommandHandler.cs
+++ b/src/Content/Application/Application.AI.Common/CQRS/Bundles/RunBundle/RunBundleCommandHandler.cs
@@ -1,0 +1,99 @@
+using Application.AI.Common.Interfaces.Bundles;
+using Domain.AI.Bundles;
+using Domain.Common;
+using Domain.Common.Config;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Application.AI.Common.CQRS.Bundles.RunBundle;
+
+/// <summary>
+/// Handles <see cref="RunBundleCommand"/>: refuses when bundle execution is disabled or the handle is
+/// unknown/expired, creates a <see cref="BundleRunStatus.Queued"/> run record carrying the resolved
+/// capability envelope, and enqueues its job id for background dispatch. Returns the job id immediately —
+/// the multi-turn conversation runs out-of-band on the <c>BundleRunBackgroundService</c>.
+/// </summary>
+/// <remarks>
+/// The agent name is captured from the staged bundle here so the dispatcher never has to re-read the bundle
+/// to know what to run. Create-then-Enqueue: a host crash between the two leaves a queued record with no
+/// worker to pick it up — the same non-durable loss profile as the in-memory job store and dispatch queue,
+/// which is consistent with bundle runs not being persisted.
+/// </remarks>
+public sealed class RunBundleCommandHandler
+    : IRequestHandler<RunBundleCommand, Result<RunBundleResult>>
+{
+    private readonly IBundleHandleStore _handleStore;
+    private readonly IBundleRunJobStore _jobStore;
+    private readonly IBundleRunDispatchQueue _dispatchQueue;
+    private readonly IOptionsMonitor<AppConfig> _config;
+    private readonly TimeProvider _time;
+    private readonly ILogger<RunBundleCommandHandler> _logger;
+
+    /// <summary>Initializes a new <see cref="RunBundleCommandHandler"/>.</summary>
+    public RunBundleCommandHandler(
+        IBundleHandleStore handleStore,
+        IBundleRunJobStore jobStore,
+        IBundleRunDispatchQueue dispatchQueue,
+        IOptionsMonitor<AppConfig> config,
+        TimeProvider time,
+        ILogger<RunBundleCommandHandler> logger)
+    {
+        ArgumentNullException.ThrowIfNull(handleStore);
+        ArgumentNullException.ThrowIfNull(jobStore);
+        ArgumentNullException.ThrowIfNull(dispatchQueue);
+        ArgumentNullException.ThrowIfNull(config);
+        ArgumentNullException.ThrowIfNull(time);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _handleStore = handleStore;
+        _jobStore = jobStore;
+        _dispatchQueue = dispatchQueue;
+        _config = config;
+        _time = time;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<Result<RunBundleResult>> Handle(
+        RunBundleCommand request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (!_config.CurrentValue.AI.BundleExecution.Enabled)
+        {
+            return Result<RunBundleResult>.Forbidden(
+                "Bundle execution is disabled. Set AppConfig.AI.BundleExecution.Enabled = true to enable it.");
+        }
+
+        var staged = _handleStore.TryGet(request.Handle);
+        if (staged is null)
+        {
+            return Result<RunBundleResult>.NotFound(
+                "Bundle handle not found or expired. Register the bundle again to obtain a fresh handle.");
+        }
+
+        var record = new BundleRunRecord
+        {
+            JobId = Guid.NewGuid().ToString("N"),
+            Handle = request.Handle,
+            AgentName = staged.Agent.Id,
+            UserMessages = request.UserMessages,
+            MaxTurns = request.MaxTurns,
+            Envelope = request.Envelope,
+            Status = BundleRunStatus.Queued,
+            CreatedAt = _time.GetUtcNow()
+        };
+
+        _jobStore.Create(record);
+        await _dispatchQueue.EnqueueAsync(record.JobId, cancellationToken).ConfigureAwait(false);
+
+        _logger.LogInformation(
+            "Queued bundle run {JobId} for handle {Handle} (agent {AgentId}, {MessageCount} message(s), max {MaxTurns} turns).",
+            record.JobId, record.Handle, record.AgentName, record.UserMessages.Count, record.MaxTurns);
+
+        return Result<RunBundleResult>.Success(new RunBundleResult { JobId = record.JobId });
+    }
+}

--- a/src/Content/Application/Application.AI.Common/CQRS/Bundles/RunBundle/RunBundleCommandValidator.cs
+++ b/src/Content/Application/Application.AI.Common/CQRS/Bundles/RunBundle/RunBundleCommandValidator.cs
@@ -1,0 +1,38 @@
+using FluentValidation;
+
+namespace Application.AI.Common.CQRS.Bundles.RunBundle;
+
+/// <summary>
+/// Validates <see cref="RunBundleCommand"/> before the handler runs.
+/// </summary>
+public sealed class RunBundleCommandValidator : AbstractValidator<RunBundleCommand>
+{
+    /// <summary>Upper bound on seed messages — a run seeds at most this many turns.</summary>
+    public const int MaxUserMessages = 100;
+
+    /// <summary>Upper bound on turns — a runaway turn count is almost always a caller bug.</summary>
+    public const int MaxTurnsLimit = 100;
+
+    /// <summary>Initializes validation rules.</summary>
+    public RunBundleCommandValidator()
+    {
+        RuleFor(x => x.Handle)
+            .NotEmpty().WithMessage("Handle is required.");
+
+        RuleFor(x => x.UserMessages)
+            .NotNull().WithMessage("UserMessages is required.")
+            .Must(m => m is null || m.Count > 0).WithMessage("UserMessages must contain at least one message.")
+            .Must(m => m is null || m.Count <= MaxUserMessages)
+                .WithMessage($"UserMessages exceeds {MaxUserMessages} messages.");
+
+        RuleForEach(x => x.UserMessages)
+            .NotEmpty().WithMessage("User messages must be non-empty.");
+
+        RuleFor(x => x.Envelope)
+            .NotNull().WithMessage("Envelope is required.");
+
+        RuleFor(x => x.MaxTurns)
+            .GreaterThan(0).WithMessage("MaxTurns must be greater than zero.")
+            .LessThanOrEqualTo(MaxTurnsLimit).WithMessage($"MaxTurns exceeds {MaxTurnsLimit}.");
+    }
+}

--- a/src/Content/Application/Application.AI.Common/CQRS/Bundles/RunBundle/RunBundleResult.cs
+++ b/src/Content/Application/Application.AI.Common/CQRS/Bundles/RunBundle/RunBundleResult.cs
@@ -1,0 +1,11 @@
+namespace Application.AI.Common.CQRS.Bundles.RunBundle;
+
+/// <summary>
+/// The result of starting a bundle run: the job id the caller polls (via <c>GetBundleRunQuery</c>) for the
+/// run's evolving status and eventual outcome.
+/// </summary>
+public sealed record RunBundleResult
+{
+    /// <summary>The opaque id of the queued run job.</summary>
+    public required string JobId { get; init; }
+}

--- a/src/Content/Application/Application.AI.Common/Interfaces/Bundles/IBundleHandleStore.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Bundles/IBundleHandleStore.cs
@@ -1,0 +1,85 @@
+using Domain.AI.Bundles;
+
+namespace Application.AI.Common.Interfaces.Bundles;
+
+/// <summary>
+/// Holds the <see cref="StagedBundle"/>s that have been accepted and extracted to disk, keyed by an opaque
+/// handle, and owns their on-disk lifetime: it deletes a bundle's staging directory when the handle expires,
+/// is explicitly removed, or the host shuts down. This is the store behind <c>register → handle → invoke</c>
+/// — the host is not the system of record for bundles, so a handle is short-lived and TTL'd.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>Lifetime is sliding and run-pinned.</strong> A handle's expiry is pushed out whenever it is read
+/// (<see cref="TryGet"/>) or a run acquires it (<see cref="Acquire"/>). A run in flight <em>pins</em> the
+/// handle through the lease returned by <see cref="Acquire"/>, so the cleanup sweeper can never delete a
+/// staging directory out from under an executing run — the ephemeral agent reads its skills from that
+/// directory on disk throughout the turn. The directory is deleted only once the handle is both expired
+/// (or removed) and has no outstanding lease.
+/// </para>
+/// <para>
+/// <strong>Guaranteed cleanup.</strong> Deletion happens on three paths: an explicit <see cref="Remove"/>,
+/// the periodic <see cref="SweepExpired"/> pass, and host shutdown disposal. The sweeper is the
+/// belt-and-suspenders backstop that guarantees an abandoned staging directory is removed even if no caller
+/// ever deletes the handle. Implementations are process-local and non-durable: handles do not survive a
+/// restart, but a restart also loses the in-memory job records that reference them, so the two stay
+/// consistent (an orphaned directory left by a crash is swept by the same pass on the next start).
+/// </para>
+/// </remarks>
+public interface IBundleHandleStore
+{
+    /// <summary>
+    /// Registers a freshly staged bundle and returns the opaque handle a caller uses to run or delete it.
+    /// The handle's initial expiry is <c>now + HandleTtl</c>.
+    /// </summary>
+    /// <param name="bundle">The staged bundle to hold. Its <see cref="StagedBundle.StagedRootDirectory"/> becomes owned by this store.</param>
+    /// <returns>The handle identifying the registered bundle.</returns>
+    string Register(StagedBundle bundle);
+
+    /// <summary>
+    /// Reads the staged bundle for <paramref name="handle"/> without pinning it, refreshing its sliding
+    /// expiry. Returns null when the handle is unknown or already expired. Use this for a read-only peek
+    /// (e.g. to name the agent when enqueuing a run); use <see cref="Acquire"/> to actually execute against it.
+    /// </summary>
+    /// <param name="handle">The handle to look up.</param>
+    /// <returns>The staged bundle, or null if the handle is unknown or expired.</returns>
+    StagedBundle? TryGet(string handle);
+
+    /// <summary>
+    /// Acquires <paramref name="handle"/> for the duration of a run: refreshes its sliding expiry, pins it
+    /// so the sweeper cannot delete its staging directory while the returned lease is held, and returns a
+    /// lease carrying the staged bundle. Returns null when the handle is unknown or already expired.
+    /// Dispose the lease when the run completes to unpin the handle.
+    /// </summary>
+    /// <param name="handle">The handle to acquire.</param>
+    /// <returns>A lease over the staged bundle, or null if the handle is unknown or expired.</returns>
+    IBundleHandleLease? Acquire(string handle);
+
+    /// <summary>
+    /// Explicitly removes <paramref name="handle"/>. The staging directory is deleted immediately if no run
+    /// currently holds a lease on it; otherwise deletion is deferred until the last lease is released, so an
+    /// in-flight run is never disrupted. Returns true if a handle was present to remove.
+    /// </summary>
+    /// <param name="handle">The handle to remove.</param>
+    /// <returns>True if the handle existed and was removed; false if it was already gone.</returns>
+    bool Remove(string handle);
+
+    /// <summary>
+    /// Deletes every handle whose sliding expiry is at or before now and that has no outstanding lease,
+    /// removing each one's staging directory. Called periodically by the cleanup sweeper. Returns the number
+    /// of handles evicted.
+    /// </summary>
+    /// <returns>The count of handles evicted and whose staging directories were deleted.</returns>
+    int SweepExpired();
+}
+
+/// <summary>
+/// A pin on a staged-bundle handle held for the duration of a run. While the lease is undisposed, the
+/// handle store will not delete the bundle's staging directory, so the ephemeral agent can read its skills
+/// from disk throughout the run. Disposing the lease unpins the handle and refreshes its sliding expiry.
+/// </summary>
+public interface IBundleHandleLease : IDisposable
+{
+    /// <summary>The staged bundle pinned by this lease.</summary>
+    StagedBundle Bundle { get; }
+}

--- a/src/Content/Application/Application.AI.Common/Interfaces/Bundles/IBundleRunDispatchQueue.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Bundles/IBundleRunDispatchQueue.cs
@@ -1,0 +1,44 @@
+namespace Application.AI.Common.Interfaces.Bundles;
+
+/// <summary>
+/// Queue of run job ids awaiting background dispatch. The <c>RunBundleCommand</c> handler enqueues a job id
+/// after creating its <c>BundleRunRecord</c>; a background worker (<c>BundleRunBackgroundService</c>) drains
+/// the queue and executes each run, so the command handler returns a job id immediately instead of blocking
+/// the request thread on a multi-turn agent conversation.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Mirrors the <c>IChangeProposalDispatchQueue</c> contract exactly (<c>Enqueue</c> + <c>DequeueAll</c>): the
+/// default in-memory implementation backs a single-reader <c>Channel&lt;string&gt;</c>, so ids enqueued
+/// before a host crash are lost — the same non-durable semantics as the in-memory run-job store they pair
+/// with. A consumer needing at-least-once delivery swaps this for an outbox-backed implementation without
+/// changing the worker.
+/// </para>
+/// <para>
+/// The queue carries only the job id; the worker loads the full <c>BundleRunRecord</c> from the job store,
+/// which is what lets the run be picked up on a thread detached from the request that enqueued it (the
+/// record carries the capability envelope the worker must re-arm — the ambient one does not flow across the
+/// thread-pool boundary).
+/// </para>
+/// </remarks>
+public interface IBundleRunDispatchQueue
+{
+    /// <summary>
+    /// Adds a run job id to the queue for asynchronous dispatch. Returns once the id is queued, not once the
+    /// run has executed.
+    /// </summary>
+    /// <param name="jobId">The run job to dispatch.</param>
+    /// <param name="cancellationToken">
+    /// Cancellation token honored by bounded-queue implementations that may wait for capacity. Unbounded
+    /// implementations complete synchronously.
+    /// </param>
+    ValueTask EnqueueAsync(string jobId, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Streams run job ids out of the queue in FIFO order, yielding each as it becomes available and
+    /// completing when the queue is shut down (host stop or cancellation).
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token; cancelling stops the enumeration.</param>
+    /// <returns>An async stream of run job ids ready for dispatch.</returns>
+    IAsyncEnumerable<string> DequeueAllAsync(CancellationToken cancellationToken);
+}

--- a/src/Content/Application/Application.AI.Common/Interfaces/Bundles/IBundleRunJobStore.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Bundles/IBundleRunJobStore.cs
@@ -1,0 +1,49 @@
+using Domain.AI.Bundles;
+
+namespace Application.AI.Common.Interfaces.Bundles;
+
+/// <summary>
+/// Holds <see cref="BundleRunRecord"/>s — the async jobs created when a caller invokes a staged bundle —
+/// keyed by job id, with a TTL. Bundle runs are not persisted (the host is not their system of record); a
+/// record lives in memory just long enough for a caller to poll its result before it is swept.
+/// </summary>
+/// <remarks>
+/// The record is immutable: the dispatcher advances a run by building a <c>with</c>-copy and calling
+/// <see cref="Update"/>, which atomically swaps the stored snapshot. Only a terminal record has a TTL — it
+/// starts when the run reaches a terminal state, so a completed run stays pollable for the configured window
+/// regardless of how long it queued or ran. A <see cref="BundleRunStatus.Queued"/>/<see cref="BundleRunStatus.Running"/>
+/// record is in-flight and is never expired, so a run is never dropped or its outcome lost to a mid-run sweep.
+/// </remarks>
+public interface IBundleRunJobStore
+{
+    /// <summary>
+    /// Stores a newly created run record and starts its TTL. The record is expected to be
+    /// <see cref="BundleRunStatus.Queued"/>. Throws if a record with the same job id already exists.
+    /// </summary>
+    /// <param name="record">The run record to store.</param>
+    void Create(BundleRunRecord record);
+
+    /// <summary>
+    /// Returns the current snapshot of the run with <paramref name="jobId"/>, or null when the job id is
+    /// unknown or its record has already been swept.
+    /// </summary>
+    /// <param name="jobId">The job id to look up.</param>
+    /// <returns>The current record snapshot, or null.</returns>
+    BundleRunRecord? Get(string jobId);
+
+    /// <summary>
+    /// Replaces the stored snapshot for <paramref name="record"/>'s job id. When the record is terminal its
+    /// TTL is extended so the completed result stays pollable. Returns false when the job id is no longer
+    /// present (already swept), in which case the update is dropped.
+    /// </summary>
+    /// <param name="record">The new snapshot to store.</param>
+    /// <returns>True if the record was present and updated; false if it had already been swept.</returns>
+    bool Update(BundleRunRecord record);
+
+    /// <summary>
+    /// Removes every run record whose TTL has elapsed. Called periodically by the cleanup sweeper. Returns
+    /// the number of records evicted.
+    /// </summary>
+    /// <returns>The count of records evicted.</returns>
+    int SweepExpired();
+}

--- a/src/Content/Domain/Domain.AI/Bundles/BundleRunOutcome.cs
+++ b/src/Content/Domain/Domain.AI/Bundles/BundleRunOutcome.cs
@@ -1,0 +1,46 @@
+namespace Domain.AI.Bundles;
+
+/// <summary>
+/// The terminal outcome of a bundle run, projected from the conversation the ephemeral agent ran. This is
+/// a Domain-pure summary — the pieces a poller needs — deliberately not the Application-layer
+/// <c>ConversationResult</c> itself: the bundle subsystem's contracts live in <c>Domain.AI</c> /
+/// <c>Application.AI.Common</c>, which cannot see <c>Application.Core</c> where that result type lives. The
+/// background service maps the rich result onto this value when it writes the terminal record.
+/// </summary>
+/// <remarks>
+/// A run reaching <see cref="BundleRunStatus.Succeeded"/> means the conversation completed; it does not mean
+/// every turn produced a good answer. <see cref="ConversationSucceeded"/> carries that inner distinction —
+/// a conversation whose agent reported a failed turn completed (so the run is Succeeded) but reports
+/// <see cref="ConversationSucceeded"/> false with the reason in <see cref="ConversationError"/>. Only an
+/// unhandled exception or a missing staged bundle makes the run itself <see cref="BundleRunStatus.Failed"/>.
+/// </remarks>
+public sealed record BundleRunOutcome
+{
+    /// <summary>
+    /// Whether the conversation itself reported success. False when a turn failed or the agent errored,
+    /// even though the run mechanically completed (and is therefore <see cref="BundleRunStatus.Succeeded"/>).
+    /// </summary>
+    public required bool ConversationSucceeded { get; init; }
+
+    /// <summary>The final agent response of the conversation, or empty when no turn produced one.</summary>
+    public required string FinalResponse { get; init; }
+
+    /// <summary>The number of turns that executed before the conversation ended.</summary>
+    public required int TurnCount { get; init; }
+
+    /// <summary>The total number of tool invocations across all turns.</summary>
+    public required int TotalToolInvocations { get; init; }
+
+    /// <summary>
+    /// Whether the conversation stopped early because it exhausted its lifetime token budget. A graceful
+    /// stop, not a failure — the turns that ran are still reflected in <see cref="TurnCount"/>.
+    /// </summary>
+    public bool BudgetExhausted { get; init; }
+
+    /// <summary>
+    /// The conversation-level error when <see cref="ConversationSucceeded"/> is false (e.g. "Turn 2
+    /// failed: …"), otherwise null. Distinct from the run-level <c>Error</c> on the record, which is set
+    /// only when the run failed outright.
+    /// </summary>
+    public string? ConversationError { get; init; }
+}

--- a/src/Content/Domain/Domain.AI/Bundles/BundleRunRecord.cs
+++ b/src/Content/Domain/Domain.AI/Bundles/BundleRunRecord.cs
@@ -1,0 +1,80 @@
+namespace Domain.AI.Bundles;
+
+/// <summary>
+/// The in-memory, TTL'd record of one bundle run — the async job created when a caller invokes a staged
+/// bundle. It carries both the run's <em>inputs</em> (the handle it targets, the resolved capability
+/// envelope, and the conversation request) and its evolving <em>state</em> (status, outcome, timestamps),
+/// so the background dispatcher can pick a run up by id alone, re-arm the ambient envelope on its detached
+/// thread, and drive it to completion.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The host is not the system of record for bundle runs: records live only in memory and are evicted by
+/// TTL. A record is created <see cref="BundleRunStatus.Queued"/>, transitions once to
+/// <see cref="BundleRunStatus.Running"/> when the dispatcher picks it up, and once more to a terminal
+/// <see cref="BundleRunStatus.Succeeded"/>/<see cref="BundleRunStatus.Failed"/>. It is immutable; each
+/// transition is a <c>with</c>-copy the store swaps in.
+/// </para>
+/// <para>
+/// <strong>Why the envelope rides on the record.</strong> The background dispatcher runs on a thread pool
+/// flow detached from the request that enqueued the run, so the ambient <c>CapabilityEnvelope</c> published
+/// during the HTTP request does not flow to it. The resolved grant is therefore captured here at enqueue
+/// time and re-published by the dispatcher (<c>CapabilityEnvelopeAccessor.Begin</c>) for the duration of the
+/// run — without it the governor would see no envelope and fail open. The staged bundle backing
+/// <see cref="Handle"/> supplies the ephemeral-agent overlay the same way (looked up by handle at dispatch),
+/// so the overlay is not duplicated here.
+/// </para>
+/// </remarks>
+public sealed record BundleRunRecord
+{
+    /// <summary>Opaque unique identifier for this run, returned to the caller as the job id to poll.</summary>
+    public required string JobId { get; init; }
+
+    /// <summary>
+    /// The handle of the staged bundle this run targets. The dispatcher looks the staged bundle up by this
+    /// handle to build the ephemeral-agent overlay; a run whose handle has expired fails cleanly.
+    /// </summary>
+    public required string Handle { get; init; }
+
+    /// <summary>
+    /// The ephemeral agent's id (its <c>AGENT.md</c> id), captured from the staged bundle at enqueue time
+    /// so the dispatcher can name it to <c>RunConversationCommand</c> without re-reading the bundle.
+    /// </summary>
+    public required string AgentName { get; init; }
+
+    /// <summary>The user messages seeding the conversation. One turn per message, bounded by <see cref="MaxTurns"/>.</summary>
+    public required IReadOnlyList<string> UserMessages { get; init; }
+
+    /// <summary>The maximum number of turns the conversation may run.</summary>
+    public required int MaxTurns { get; init; }
+
+    /// <summary>
+    /// The per-caller capability grant resolved for this run. The dispatcher re-publishes it ambiently for
+    /// the whole run so the permission gate chain and tool-chain builder confine the ephemeral agent.
+    /// </summary>
+    public required CapabilityEnvelope Envelope { get; init; }
+
+    /// <summary>The current lifecycle state. Starts <see cref="BundleRunStatus.Queued"/>.</summary>
+    public required BundleRunStatus Status { get; init; }
+
+    /// <summary>The terminal outcome once the run has <see cref="BundleRunStatus.Succeeded"/>; null before then.</summary>
+    public BundleRunOutcome? Outcome { get; init; }
+
+    /// <summary>
+    /// A stable, caller-safe reason when the run <see cref="BundleRunStatus.Failed"/> outright; null
+    /// otherwise. Never a raw exception message — the dispatcher logs the exception and stores a scrubbed code.
+    /// </summary>
+    public string? Error { get; init; }
+
+    /// <summary>When the run record was created and enqueued.</summary>
+    public required DateTimeOffset CreatedAt { get; init; }
+
+    /// <summary>When the dispatcher began executing the run; null while still <see cref="BundleRunStatus.Queued"/>.</summary>
+    public DateTimeOffset? StartedAt { get; init; }
+
+    /// <summary>When the run reached a terminal state; null before then.</summary>
+    public DateTimeOffset? CompletedAt { get; init; }
+
+    /// <summary>Whether the run has reached a terminal state and will not transition again.</summary>
+    public bool IsTerminal => Status is BundleRunStatus.Succeeded or BundleRunStatus.Failed;
+}

--- a/src/Content/Domain/Domain.AI/Bundles/BundleRunStatus.cs
+++ b/src/Content/Domain/Domain.AI/Bundles/BundleRunStatus.cs
@@ -1,0 +1,52 @@
+namespace Domain.AI.Bundles;
+
+/// <summary>
+/// The lifecycle state of a single bundle run — the async job created when a caller invokes a staged
+/// bundle and consumed by pollers until it reaches a terminal state. A run is created <see cref="Queued"/>,
+/// picked up by the background dispatcher into <see cref="Running"/>, and ends in exactly one of
+/// <see cref="Succeeded"/> or <see cref="Failed"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The numeric values are anchored by a Domain.AI enum test: run records are in-memory and TTL'd (the host
+/// is not the system of record for bundle runs), but a caller polling <c>GET .../runs/{jobId}</c> compares
+/// against these values, so renumbering them would silently change the wire contract. Add new states only
+/// at the end.
+/// </para>
+/// <para>
+/// <see cref="Succeeded"/> and <see cref="Failed"/> are terminal: once a run reaches either, the background
+/// service performs no further transition and the record is only read (by the poll query) until its TTL
+/// evicts it. <see cref="Succeeded"/> reflects that the conversation ran to completion; a conversation that
+/// completed but whose agent reported a turn failure is still surfaced as <see cref="Succeeded"/> with the
+/// failure carried in the result, mirroring how <c>RunConversationCommand</c> distinguishes a failed turn
+/// (a returned result) from an unhandled exception (a thrown escape) — only the latter is <see cref="Failed"/>.
+/// </para>
+/// </remarks>
+public enum BundleRunStatus
+{
+    /// <summary>
+    /// The run has been created and enqueued but the background dispatcher has not yet picked it up. This
+    /// is the initial state of every run record.
+    /// </summary>
+    Queued = 0,
+
+    /// <summary>
+    /// The background dispatcher has dequeued the run and is executing the bundle's ephemeral agent
+    /// conversation under the run's capability envelope. Transitions to <see cref="Succeeded"/> or
+    /// <see cref="Failed"/> when the conversation returns or throws.
+    /// </summary>
+    Running = 1,
+
+    /// <summary>
+    /// Terminal — the bundle conversation ran to completion. The <c>Result</c> on the run record carries
+    /// the conversation outcome (which may itself report a failed turn); the token totals are populated.
+    /// </summary>
+    Succeeded = 2,
+
+    /// <summary>
+    /// Terminal — the run could not complete: an unhandled exception escaped the conversation, the staged
+    /// bundle backing the handle was gone when the dispatcher tried to run it, or the run was cancelled by
+    /// host shutdown. The <c>Error</c> on the run record carries a stable, caller-safe reason.
+    /// </summary>
+    Failed = 3
+}

--- a/src/Content/Domain/Domain.Common/Config/AI/BundleExecution/BundleExecutionConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/BundleExecution/BundleExecutionConfig.cs
@@ -83,4 +83,28 @@ public class BundleExecutionConfig
     /// grants nothing until an operator configures it.
     /// </summary>
     public CapabilityEnvelopesConfig Envelopes { get; set; } = new();
+
+    /// <summary>
+    /// How long a staged-bundle handle stays valid. The lifetime is sliding: it is refreshed each time the
+    /// handle is looked up or a run against it starts, so an actively-used bundle stays alive while an
+    /// abandoned one expires and its staging directory is deleted by the cleanup sweeper. Must be positive.
+    /// </summary>
+    /// <value>Default: 30 minutes</value>
+    public TimeSpan HandleTtl { get; set; } = TimeSpan.FromMinutes(30);
+
+    /// <summary>
+    /// How long a run record stays pollable after it reaches a terminal state before the cleanup sweeper
+    /// evicts it. Bundle runs are not persisted (the host is not their system of record); this bounds how
+    /// long a caller has to read a completed run's result. Must be positive.
+    /// </summary>
+    /// <value>Default: 30 minutes</value>
+    public TimeSpan RunRecordTtl { get; set; } = TimeSpan.FromMinutes(30);
+
+    /// <summary>
+    /// How often the background cleanup sweeper runs its pass over expired handles (deleting their staging
+    /// directories) and expired run records. This is the belt-and-suspenders backstop that guarantees a
+    /// staging directory is removed even if no explicit delete arrives. Must be positive.
+    /// </summary>
+    /// <value>Default: 60 seconds</value>
+    public TimeSpan CleanupInterval { get; set; } = TimeSpan.FromSeconds(60);
 }

--- a/src/Content/Infrastructure/Infrastructure.AI/Bundles/BundleRunBackgroundService.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Bundles/BundleRunBackgroundService.cs
@@ -1,0 +1,192 @@
+using Application.AI.Common.Interfaces.Bundles;
+using Application.AI.Common.Services.Bundles;
+using Application.AI.Common.Services.Governance;
+using Application.Core.CQRS.Agents.RunConversation;
+using Domain.AI.Bundles;
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Infrastructure.AI.Bundles;
+
+/// <summary>
+/// Drains the <see cref="IBundleRunDispatchQueue"/> and executes each queued bundle run: it acquires the
+/// staged bundle behind the run's handle, re-publishes the run's ephemeral-agent overlay and capability
+/// envelope ambiently, drives a full <see cref="RunConversationCommand"/>, and records the terminal outcome
+/// on the run record. Mirrors <c>ChangeProposalBackgroundService</c>: one DI scope per run, failure-isolated
+/// so one bad run never stalls the queue.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>Why the ambients are re-armed here.</strong> The dispatcher runs on a thread-pool flow detached
+/// from the HTTP request that enqueued the run, so the ambient overlay and capability envelope set during
+/// that request do not flow to it. Both are re-published from the run record and the staged bundle for the
+/// duration of the run. Arming the envelope is what makes the tool-invocation governor enforce — the
+/// governor forces enforcement on precisely from the envelope's presence, and the standard turn handler
+/// arms <c>ToolGovernanceAccessor</c> per turn — so without re-arming the envelope here the governor would
+/// see none and fail <em>open</em>.
+/// </para>
+/// <para>
+/// The envelope scope stays open across the whole <see cref="RunConversationCommand"/>, which returns a
+/// fully-materialised result (not a deferred stream), so disposing the scope once <c>Send</c> returns is
+/// safe. The streaming run path (a later phase) must instead keep the scope open across the full stream
+/// enumeration — see the deferred-execution note on <c>CapabilityEnvelopeAccessor</c>.
+/// </para>
+/// <para>
+/// The staged bundle is <em>pinned</em> through an <see cref="IBundleHandleLease"/> for the whole run, so
+/// the cleanup sweeper cannot delete its staging directory while the ephemeral agent is reading its skills
+/// from disk. A run whose handle expired before pickup fails cleanly with a caller-safe reason.
+/// </para>
+/// </remarks>
+public sealed class BundleRunBackgroundService : BackgroundService
+{
+    private readonly IBundleRunDispatchQueue _queue;
+    private readonly IBundleRunJobStore _jobStore;
+    private readonly IBundleHandleStore _handleStore;
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly TimeProvider _time;
+    private readonly ILogger<BundleRunBackgroundService> _logger;
+
+    /// <summary>Initializes a new <see cref="BundleRunBackgroundService"/>.</summary>
+    public BundleRunBackgroundService(
+        IBundleRunDispatchQueue queue,
+        IBundleRunJobStore jobStore,
+        IBundleHandleStore handleStore,
+        IServiceScopeFactory scopeFactory,
+        TimeProvider time,
+        ILogger<BundleRunBackgroundService> logger)
+    {
+        ArgumentNullException.ThrowIfNull(queue);
+        ArgumentNullException.ThrowIfNull(jobStore);
+        ArgumentNullException.ThrowIfNull(handleStore);
+        ArgumentNullException.ThrowIfNull(scopeFactory);
+        ArgumentNullException.ThrowIfNull(time);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _queue = queue;
+        _jobStore = jobStore;
+        _handleStore = handleStore;
+        _scopeFactory = scopeFactory;
+        _time = time;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        await foreach (var jobId in _queue.DequeueAllAsync(stoppingToken).ConfigureAwait(false))
+        {
+            if (stoppingToken.IsCancellationRequested)
+                break;
+
+            await DispatchOneAsync(jobId, stoppingToken).ConfigureAwait(false);
+        }
+    }
+
+    private async Task DispatchOneAsync(string jobId, CancellationToken stoppingToken)
+    {
+        var record = _jobStore.Get(jobId);
+        if (record is null)
+        {
+            _logger.LogWarning(
+                "Bundle run {JobId} was not found when dispatched (expired or swept before pickup); dropping.",
+                jobId);
+            return;
+        }
+
+        // Acquire the handle BEFORE transitioning to Running: a run that never starts (its handle expired
+        // before pickup) is marked Failed straight from Queued, so it never carries a bogus StartedAt.
+        using var lease = _handleStore.Acquire(record.Handle);
+        if (lease is null)
+        {
+            _logger.LogWarning(
+                "Bundle run {JobId} could not start: handle {Handle} expired before the run began.",
+                jobId, record.Handle);
+            _jobStore.Update(record with
+            {
+                Status = BundleRunStatus.Failed,
+                Error = "The bundle handle expired before the run started.",
+                CompletedAt = _time.GetUtcNow()
+            });
+            return;
+        }
+
+        record = record with { Status = BundleRunStatus.Running, StartedAt = _time.GetUtcNow() };
+        _jobStore.Update(record);
+
+        try
+        {
+            var result = await RunConversationAsync(record, lease.Bundle, stoppingToken).ConfigureAwait(false);
+
+            _jobStore.Update(record with
+            {
+                Status = BundleRunStatus.Succeeded,
+                Outcome = MapOutcome(result),
+                CompletedAt = _time.GetUtcNow()
+            });
+        }
+        catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+        {
+            _jobStore.Update(record with
+            {
+                Status = BundleRunStatus.Failed,
+                Error = "The run was cancelled by host shutdown.",
+                CompletedAt = _time.GetUtcNow()
+            });
+            throw; // propagate to exit the drain loop on shutdown
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Bundle run {JobId} failed with an unhandled exception.", jobId);
+            _jobStore.Update(record with
+            {
+                Status = BundleRunStatus.Failed,
+                Error = "bundle_run.unhandled_exception",
+                CompletedAt = _time.GetUtcNow()
+            });
+        }
+    }
+
+    private async Task<ConversationResult> RunConversationAsync(
+        BundleRunRecord record,
+        StagedBundle staged,
+        CancellationToken stoppingToken)
+    {
+        var overlay = new EphemeralAgentOverlay
+        {
+            Agent = staged.Agent,
+            OwnedSkills = staged.OwnedSkills
+        };
+
+        await using var scope = _scopeFactory.CreateAsyncScope();
+        var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+
+        // Arm BOTH ambients for the whole conversation: the overlay so the ephemeral agent + its owned
+        // skills resolve, and the envelope so the governor enforces the per-caller grant. Disposed in
+        // reverse when the (materialised) conversation returns.
+        using (EphemeralAgentOverlayAccessor.Begin(overlay))
+        using (CapabilityEnvelopeAccessor.Begin(record.Envelope))
+        {
+            var command = new RunConversationCommand
+            {
+                AgentName = record.AgentName,
+                UserMessages = record.UserMessages,
+                MaxTurns = record.MaxTurns,
+                ConversationId = record.JobId
+            };
+
+            return await mediator.Send(command, stoppingToken).ConfigureAwait(false);
+        }
+    }
+
+    private static BundleRunOutcome MapOutcome(ConversationResult result) => new()
+    {
+        ConversationSucceeded = result.Success,
+        FinalResponse = result.FinalResponse,
+        TurnCount = result.Turns.Count,
+        TotalToolInvocations = result.TotalToolInvocations,
+        BudgetExhausted = result.BudgetExhausted,
+        ConversationError = result.Error
+    };
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Bundles/BundleWorkspaceCleanupService.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Bundles/BundleWorkspaceCleanupService.cs
@@ -1,0 +1,84 @@
+using Application.AI.Common.Interfaces.Bundles;
+using Domain.Common.Config;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Infrastructure.AI.Bundles;
+
+/// <summary>
+/// Periodically sweeps expired staged-bundle handles (deleting their staging directories) and expired run
+/// records. This is the belt-and-suspenders backstop behind the handle store's own explicit-delete and
+/// lease-release cleanup paths — it guarantees an abandoned staging directory is removed even when no caller
+/// ever deletes the handle, and reclaims completed run records after their pollable window. Mirrors
+/// <c>SessionIdleCleanupService</c>.
+/// </summary>
+internal sealed class BundleWorkspaceCleanupService : BackgroundService
+{
+    private static readonly TimeSpan MinInterval = TimeSpan.FromSeconds(1);
+
+    private readonly IBundleHandleStore _handleStore;
+    private readonly IBundleRunJobStore _jobStore;
+    private readonly IOptionsMonitor<AppConfig> _config;
+    private readonly ILogger<BundleWorkspaceCleanupService> _logger;
+
+    /// <summary>Initializes a new <see cref="BundleWorkspaceCleanupService"/>.</summary>
+    public BundleWorkspaceCleanupService(
+        IBundleHandleStore handleStore,
+        IBundleRunJobStore jobStore,
+        IOptionsMonitor<AppConfig> config,
+        ILogger<BundleWorkspaceCleanupService> logger)
+    {
+        ArgumentNullException.ThrowIfNull(handleStore);
+        ArgumentNullException.ThrowIfNull(jobStore);
+        ArgumentNullException.ThrowIfNull(config);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _handleStore = handleStore;
+        _jobStore = jobStore;
+        _config = config;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        try
+        {
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                var interval = _config.CurrentValue.AI.BundleExecution.CleanupInterval;
+                if (interval < MinInterval)
+                    interval = MinInterval;
+
+                await Task.Delay(interval, stoppingToken).ConfigureAwait(false);
+                Sweep();
+            }
+        }
+        catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+        {
+            // Host is shutting down — expected.
+        }
+    }
+
+    private void Sweep()
+    {
+        try
+        {
+            var handles = _handleStore.SweepExpired();
+            var jobs = _jobStore.SweepExpired();
+
+            if (handles > 0 || jobs > 0)
+            {
+                _logger.LogInformation(
+                    "Bundle workspace sweep evicted {HandleCount} expired handle(s) and {JobCount} expired run record(s).",
+                    handles, jobs);
+            }
+        }
+        catch (Exception ex)
+        {
+            // A sweep failure must not tear down the background service; log and try again next tick.
+            _logger.LogError(ex, "Bundle workspace cleanup sweep failed; will retry on the next interval.");
+        }
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Bundles/InMemoryBundleHandleStore.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Bundles/InMemoryBundleHandleStore.cs
@@ -1,0 +1,252 @@
+using System.Collections.Concurrent;
+using Application.AI.Common.Interfaces.Bundles;
+using Domain.AI.Bundles;
+using Domain.Common.Config;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Infrastructure.AI.Bundles;
+
+/// <summary>
+/// In-memory <see cref="IBundleHandleStore"/> backed by a <see cref="ConcurrentDictionary{TKey,TValue}"/>,
+/// with a sliding TTL per handle and run-pinning so a staging directory is never deleted while a run is
+/// executing against it. Owns the on-disk lifetime of every staged bundle it holds: it deletes the staging
+/// directory on explicit removal, on TTL expiry (via the cleanup sweeper), and on host shutdown (disposal).
+/// </summary>
+/// <remarks>
+/// <para>
+/// A dictionary + <see cref="TimeProvider"/>-driven sweep is used deliberately over an
+/// <c>IMemoryCache</c> post-eviction callback. The load-bearing requirement is <em>guaranteed</em> temp-dir
+/// cleanup with a run in flight never losing its directory: an in-use entry must be pinned against eviction,
+/// and eviction timing must be deterministic and testable. <c>IMemoryCache</c> cannot pin an in-use entry
+/// and fires its callbacks lazily; explicit refcounting plus a deterministic sweep gives exactly the
+/// guarantee the security posture requires.
+/// </para>
+/// <para>
+/// Each handle's mutable state (expiry, lease count, removal flag) is guarded by a lock on its entry, so
+/// concurrent reads, run acquisitions, releases, and sweeps agree on whether — and when — a directory may
+/// be deleted. The map itself is concurrent; entries are removed with a compare-and-remove so a sweep can
+/// never delete an entry a concurrent acquisition has just revived.
+/// </para>
+/// </remarks>
+public sealed class InMemoryBundleHandleStore : IBundleHandleStore, IDisposable
+{
+    private sealed class HandleEntry(StagedBundle bundle)
+    {
+        public StagedBundle Bundle { get; } = bundle;
+        public DateTimeOffset ExpiresAt { get; set; }
+        public int LeaseCount { get; set; }
+        public bool Removed { get; set; }
+    }
+
+    private readonly ConcurrentDictionary<string, HandleEntry> _entries = new(StringComparer.Ordinal);
+    private readonly IOptionsMonitor<AppConfig> _config;
+    private readonly TimeProvider _time;
+    private readonly ILogger<InMemoryBundleHandleStore> _logger;
+    private bool _disposed;
+
+    /// <summary>Initializes a new <see cref="InMemoryBundleHandleStore"/>.</summary>
+    public InMemoryBundleHandleStore(
+        IOptionsMonitor<AppConfig> config,
+        TimeProvider time,
+        ILogger<InMemoryBundleHandleStore> logger)
+    {
+        ArgumentNullException.ThrowIfNull(config);
+        ArgumentNullException.ThrowIfNull(time);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _config = config;
+        _time = time;
+        _logger = logger;
+    }
+
+    private TimeSpan Ttl => _config.CurrentValue.AI.BundleExecution.HandleTtl;
+
+    /// <inheritdoc />
+    public string Register(StagedBundle bundle)
+    {
+        ArgumentNullException.ThrowIfNull(bundle);
+
+        var handle = bundle.BundleId;
+        var entry = new HandleEntry(bundle) { ExpiresAt = _time.GetUtcNow() + Ttl };
+        _entries[handle] = entry;
+        return handle;
+    }
+
+    /// <inheritdoc />
+    public StagedBundle? TryGet(string handle)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(handle);
+        if (!_entries.TryGetValue(handle, out var entry))
+            return null;
+
+        lock (entry)
+        {
+            if (!IsLive(entry))
+                return null;
+
+            entry.ExpiresAt = _time.GetUtcNow() + Ttl;
+            return entry.Bundle;
+        }
+    }
+
+    /// <inheritdoc />
+    public IBundleHandleLease? Acquire(string handle)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(handle);
+        if (!_entries.TryGetValue(handle, out var entry))
+            return null;
+
+        lock (entry)
+        {
+            if (!IsLive(entry))
+                return null;
+
+            entry.LeaseCount++;
+            entry.ExpiresAt = _time.GetUtcNow() + Ttl;
+            return new HandleLease(this, handle, entry);
+        }
+    }
+
+    /// <inheritdoc />
+    public bool Remove(string handle)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(handle);
+        if (!_entries.TryGetValue(handle, out var entry))
+            return false;
+
+        var deletePath = default(string);
+        lock (entry)
+        {
+            entry.Removed = true;
+            if (entry.LeaseCount == 0)
+                deletePath = entry.Bundle.StagedRootDirectory;
+        }
+
+        if (deletePath is not null)
+            EvictAndDelete(handle, entry, deletePath);
+
+        return true;
+    }
+
+    /// <inheritdoc />
+    public int SweepExpired()
+    {
+        var now = _time.GetUtcNow();
+        var evicted = 0;
+
+        foreach (var (handle, entry) in _entries)
+        {
+            var deletePath = default(string);
+            lock (entry)
+            {
+                if (entry.LeaseCount == 0 && (entry.Removed || now >= entry.ExpiresAt))
+                {
+                    entry.Removed = true;
+                    deletePath = entry.Bundle.StagedRootDirectory;
+                }
+            }
+
+            if (deletePath is not null && EvictAndDelete(handle, entry, deletePath))
+                evicted++;
+        }
+
+        return evicted;
+    }
+
+    /// <summary>
+    /// Releases a run's pin on a handle: decrements the lease count, slides the expiry forward, and — if the
+    /// handle was removed while the run held it — deletes its staging directory now that no run remains.
+    /// </summary>
+    private void ReleaseLease(string handle, HandleEntry entry)
+    {
+        var deletePath = default(string);
+        lock (entry)
+        {
+            if (entry.LeaseCount > 0)
+                entry.LeaseCount--;
+
+            entry.ExpiresAt = _time.GetUtcNow() + Ttl;
+
+            if (entry.LeaseCount == 0 && entry.Removed)
+                deletePath = entry.Bundle.StagedRootDirectory;
+        }
+
+        if (deletePath is not null)
+            EvictAndDelete(handle, entry, deletePath);
+    }
+
+    /// <summary>
+    /// Removes the exact entry from the map (compare-and-remove, so a revived entry is never clobbered) and
+    /// deletes its staging directory. Deletion failures are logged, never thrown — a run has already
+    /// finished by the time we delete, so a transient I/O failure must not crash the sweeper or a caller.
+    /// </summary>
+    private bool EvictAndDelete(string handle, HandleEntry entry, string stagedRootDirectory)
+    {
+        if (!_entries.TryRemove(new KeyValuePair<string, HandleEntry>(handle, entry)))
+            return false;
+
+        DeleteDirectorySafely(stagedRootDirectory);
+        return true;
+    }
+
+    private void DeleteDirectorySafely(string path)
+    {
+        if (string.IsNullOrEmpty(path) || !Directory.Exists(path))
+            return;
+
+        try
+        {
+            Directory.Delete(path, recursive: true);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to delete staged bundle directory {StagedRootDirectory}", path);
+        }
+    }
+
+    private bool IsLive(HandleEntry entry) =>
+        !entry.Removed && (entry.LeaseCount > 0 || _time.GetUtcNow() < entry.ExpiresAt);
+
+    /// <summary>
+    /// Deletes remaining staging directories on host shutdown — the final guaranteed-cleanup path, so a clean
+    /// stop never leaves extracted bundles on disk. A directory still pinned by an in-flight run is left in
+    /// place: by the time disposal runs the hosted services have stopped, so a lingering lease means a run
+    /// ignored the shutdown token past the shutdown timeout and is still reading its skills from disk —
+    /// deleting under it would corrupt that run, and the process is exiting regardless, so leaving the (rare)
+    /// orphaned directory is the safe choice.
+    /// </summary>
+    public void Dispose()
+    {
+        if (_disposed)
+            return;
+        _disposed = true;
+
+        foreach (var (_, entry) in _entries)
+        {
+            lock (entry)
+            {
+                if (entry.LeaseCount == 0)
+                    DeleteDirectorySafely(entry.Bundle.StagedRootDirectory);
+            }
+        }
+
+        _entries.Clear();
+    }
+
+    private sealed class HandleLease(InMemoryBundleHandleStore store, string handle, HandleEntry entry)
+        : IBundleHandleLease
+    {
+        private bool _disposed;
+
+        public StagedBundle Bundle => entry.Bundle;
+
+        public void Dispose()
+        {
+            if (_disposed)
+                return;
+            _disposed = true;
+            store.ReleaseLease(handle, entry);
+        }
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Bundles/InMemoryBundleRunDispatchQueue.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Bundles/InMemoryBundleRunDispatchQueue.cs
@@ -1,0 +1,36 @@
+using System.Threading.Channels;
+using Application.AI.Common.Interfaces.Bundles;
+
+namespace Infrastructure.AI.Bundles;
+
+/// <summary>
+/// In-memory <see cref="IBundleRunDispatchQueue"/> backed by a single-reader <see cref="Channel{T}"/>.
+/// FIFO; unbounded so <see cref="EnqueueAsync"/> never blocks the caller waiting for capacity. Mirrors
+/// <see cref="Infrastructure.AI.Changes.InMemoryChangeProposalDispatchQueue"/>.
+/// </summary>
+/// <remarks>
+/// Process-local and crash-loses the queue — the same non-durable semantics as the in-memory run-job store
+/// it pairs with, and consistent with bundle runs not being persisted. Single-reader because only
+/// <c>BundleRunBackgroundService</c> reads it; multiple producers (concurrent run requests) are expected, so
+/// <c>SingleWriter</c> is not set.
+/// </remarks>
+public sealed class InMemoryBundleRunDispatchQueue : IBundleRunDispatchQueue
+{
+    private readonly Channel<string> _channel = Channel.CreateUnbounded<string>(
+        new UnboundedChannelOptions
+        {
+            SingleReader = true,
+            AllowSynchronousContinuations = false,
+        });
+
+    /// <inheritdoc />
+    public ValueTask EnqueueAsync(string jobId, CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(jobId);
+        return _channel.Writer.WriteAsync(jobId, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public IAsyncEnumerable<string> DequeueAllAsync(CancellationToken cancellationToken)
+        => _channel.Reader.ReadAllAsync(cancellationToken);
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Bundles/InMemoryBundleRunJobStore.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Bundles/InMemoryBundleRunJobStore.cs
@@ -1,0 +1,118 @@
+using System.Collections.Concurrent;
+using Application.AI.Common.Interfaces.Bundles;
+using Domain.AI.Bundles;
+using Domain.Common.Config;
+using Microsoft.Extensions.Options;
+
+namespace Infrastructure.AI.Bundles;
+
+/// <summary>
+/// In-memory <see cref="IBundleRunJobStore"/> backed by a <see cref="ConcurrentDictionary{TKey,TValue}"/>
+/// with a per-record TTL. Bundle runs are not persisted; a record lives only long enough for a caller to
+/// poll its result, then the cleanup sweeper evicts it.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>Only terminal records expire.</strong> A <see cref="BundleRunStatus.Queued"/> or
+/// <see cref="BundleRunStatus.Running"/> record is in-flight and is never expired or swept — otherwise a run
+/// still queued behind a slow predecessor, or one executing longer than the TTL, could have its record
+/// deleted out from under it (the dispatcher would then find nothing to update and silently drop a completed
+/// outcome). The TTL therefore governs only how long a completed run stays pollable: it starts when the
+/// record reaches a terminal state, so a caller gets the full configured window to read the result regardless
+/// of how long the run queued or ran first. A run that never reaches a terminal state is retained until the
+/// process exits; in practice the dispatcher always drives a queued run to a terminal state, and this
+/// in-memory store does not survive a restart.
+/// </para>
+/// <para>
+/// Each record's snapshot and expiry are guarded by a lock on its holder; in practice only the single
+/// background dispatcher updates a given run, so contention is nil, but the lock keeps a concurrent sweep and
+/// update consistent.
+/// </para>
+/// </remarks>
+public sealed class InMemoryBundleRunJobStore : IBundleRunJobStore
+{
+    private sealed class JobEntry(BundleRunRecord record, DateTimeOffset expiresAt)
+    {
+        public BundleRunRecord Record { get; set; } = record;
+        public DateTimeOffset ExpiresAt { get; set; } = expiresAt;
+    }
+
+    private readonly ConcurrentDictionary<string, JobEntry> _entries = new(StringComparer.Ordinal);
+    private readonly IOptionsMonitor<AppConfig> _config;
+    private readonly TimeProvider _time;
+
+    /// <summary>Initializes a new <see cref="InMemoryBundleRunJobStore"/>.</summary>
+    public InMemoryBundleRunJobStore(IOptionsMonitor<AppConfig> config, TimeProvider time)
+    {
+        ArgumentNullException.ThrowIfNull(config);
+        ArgumentNullException.ThrowIfNull(time);
+
+        _config = config;
+        _time = time;
+    }
+
+    private TimeSpan Ttl => _config.CurrentValue.AI.BundleExecution.RunRecordTtl;
+
+    /// <inheritdoc />
+    public void Create(BundleRunRecord record)
+    {
+        ArgumentNullException.ThrowIfNull(record);
+
+        var entry = new JobEntry(record, _time.GetUtcNow() + Ttl);
+        if (!_entries.TryAdd(record.JobId, entry))
+            throw new InvalidOperationException($"A bundle run record with job id '{record.JobId}' already exists.");
+    }
+
+    /// <inheritdoc />
+    public BundleRunRecord? Get(string jobId)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(jobId);
+        if (!_entries.TryGetValue(jobId, out var entry))
+            return null;
+
+        lock (entry)
+        {
+            // Non-terminal records never expire; a terminal record expires once its pollable window elapses.
+            return entry.Record.IsTerminal && _time.GetUtcNow() >= entry.ExpiresAt ? null : entry.Record;
+        }
+    }
+
+    /// <inheritdoc />
+    public bool Update(BundleRunRecord record)
+    {
+        ArgumentNullException.ThrowIfNull(record);
+        if (!_entries.TryGetValue(record.JobId, out var entry))
+            return false;
+
+        lock (entry)
+        {
+            entry.Record = record;
+            if (record.IsTerminal)
+                entry.ExpiresAt = _time.GetUtcNow() + Ttl;
+        }
+
+        return true;
+    }
+
+    /// <inheritdoc />
+    public int SweepExpired()
+    {
+        var now = _time.GetUtcNow();
+        var evicted = 0;
+
+        foreach (var (jobId, entry) in _entries)
+        {
+            bool expired;
+            lock (entry)
+            {
+                // Only terminal records are reclaimable — an in-flight run is never swept.
+                expired = entry.Record.IsTerminal && now >= entry.ExpiresAt;
+            }
+
+            if (expired && _entries.TryRemove(new KeyValuePair<string, JobEntry>(jobId, entry)))
+                evicted++;
+        }
+
+        return evicted;
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.cs
@@ -195,6 +195,22 @@ public static partial class DependencyInjection
         // the run/API surface that consults it is gated in a later layer.
         services.AddSingleton<ICapabilityEnvelopeResolver, CapabilityEnvelopeResolver>();
 
+        // --- Bundle execution (async job + handle lifecycle) ---
+        // In-memory, TTL'd stores + the FIFO dispatch queue. The handle store owns the on-disk lifetime of
+        // every staged bundle and is IDisposable, so it is registered by its concrete type and exposed
+        // through the interface via the same singleton — one instance both holds handles and is disposed
+        // (deleting remaining staging directories) on host shutdown.
+        services.AddSingleton<InMemoryBundleHandleStore>();
+        services.AddSingleton<IBundleHandleStore>(sp => sp.GetRequiredService<InMemoryBundleHandleStore>());
+        services.AddSingleton<IBundleRunJobStore, InMemoryBundleRunJobStore>();
+        services.AddSingleton<IBundleRunDispatchQueue, InMemoryBundleRunDispatchQueue>();
+
+        // Background workers. Both are passive when no bundle is registered/run: the dispatcher awaits an
+        // empty channel and the sweeper sweeps empty stores, so — like the staging service — they are
+        // registered unconditionally and cost nothing until the (config-gated) run surface feeds them.
+        services.AddHostedService<BundleRunBackgroundService>();
+        services.AddHostedService<BundleWorkspaceCleanupService>();
+
         // --- Plugins ---
 
         services.AddSingleton<IPluginManifestReader, PluginManifestReader>();

--- a/src/Content/Tests/Application.AI.Common.Tests/Application.AI.Common.Tests.csproj
+++ b/src/Content/Tests/Application.AI.Common.Tests/Application.AI.Common.Tests.csproj
@@ -12,6 +12,7 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" />
     <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Moq" />
     <PackageReference Include="xunit" />

--- a/src/Content/Tests/Application.AI.Common.Tests/CQRS/Bundles/GetBundleRunQueryHandlerTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/CQRS/Bundles/GetBundleRunQueryHandlerTests.cs
@@ -1,0 +1,90 @@
+using Application.AI.Common.CQRS.Bundles.GetBundleRun;
+using Application.AI.Common.Interfaces.Bundles;
+using Domain.AI.Bundles;
+using Domain.AI.Governance;
+using Domain.Common;
+using Domain.Common.Config;
+using FluentAssertions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Application.AI.Common.Tests.CQRS.Bundles;
+
+/// <summary>
+/// Tests for <see cref="GetBundleRunQueryHandler"/>: the disabled gate, not-found (unknown and
+/// wrong-handle), and the happy path — including that a run under a different handle is reported not found so
+/// the poll surface leaks nothing.
+/// </summary>
+public sealed class GetBundleRunQueryHandlerTests
+{
+    private readonly Mock<IBundleRunJobStore> _jobStore = new();
+
+    private sealed class StaticOptionsMonitor<T>(T value) : IOptionsMonitor<T>
+    {
+        public T CurrentValue { get; } = value;
+        public T Get(string? name) => CurrentValue;
+        public IDisposable? OnChange(Action<T, string?> listener) => null;
+    }
+
+    private GetBundleRunQueryHandler BuildSut(bool enabled = true)
+    {
+        var cfg = new AppConfig();
+        cfg.AI.BundleExecution.Enabled = enabled;
+        return new GetBundleRunQueryHandler(_jobStore.Object, new StaticOptionsMonitor<AppConfig>(cfg));
+    }
+
+    private static BundleRunRecord Record(string handle) => new()
+    {
+        JobId = "j1",
+        Handle = handle,
+        AgentName = "agent-1",
+        UserMessages = ["hello"],
+        MaxTurns = 3,
+        Envelope = new CapabilityEnvelope(),
+        Status = BundleRunStatus.Succeeded,
+        CreatedAt = DateTimeOffset.UnixEpoch
+    };
+
+    private static GetBundleRunQuery Query() => new() { Handle = "h1", JobId = "j1" };
+
+    [Fact]
+    public async Task Handle_WhenDisabled_ReturnsForbidden()
+    {
+        var result = await BuildSut(enabled: false).Handle(Query(), CancellationToken.None);
+
+        result.FailureType.Should().Be(ResultFailureType.Forbidden);
+    }
+
+    [Fact]
+    public async Task Handle_WhenUnknownJobId_ReturnsNotFound()
+    {
+        _jobStore.Setup(j => j.Get("j1")).Returns((BundleRunRecord?)null);
+
+        var result = await BuildSut().Handle(Query(), CancellationToken.None);
+
+        result.FailureType.Should().Be(ResultFailureType.NotFound);
+    }
+
+    [Fact]
+    public async Task Handle_WhenRunBelongsToDifferentHandle_ReturnsNotFound()
+    {
+        _jobStore.Setup(j => j.Get("j1")).Returns(Record(handle: "someone-else"));
+
+        var result = await BuildSut().Handle(Query(), CancellationToken.None);
+
+        result.FailureType.Should().Be(ResultFailureType.NotFound);
+    }
+
+    [Fact]
+    public async Task Handle_WhenRunMatchesHandle_ReturnsRecord()
+    {
+        _jobStore.Setup(j => j.Get("j1")).Returns(Record(handle: "h1"));
+
+        var result = await BuildSut().Handle(Query(), CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.JobId.Should().Be("j1");
+        result.Value.Status.Should().Be(BundleRunStatus.Succeeded);
+    }
+}

--- a/src/Content/Tests/Application.AI.Common.Tests/CQRS/Bundles/RegisterBundleCommandHandlerTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/CQRS/Bundles/RegisterBundleCommandHandlerTests.cs
@@ -1,0 +1,90 @@
+using Application.AI.Common.CQRS.Bundles.RegisterBundle;
+using Application.AI.Common.Interfaces.Bundles;
+using Domain.AI.Agents;
+using Domain.AI.Bundles;
+using Domain.Common;
+using Domain.Common.Config;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Time.Testing;
+using Moq;
+using Xunit;
+
+namespace Application.AI.Common.Tests.CQRS.Bundles;
+
+/// <summary>
+/// Tests for <see cref="RegisterBundleCommandHandler"/>: the disabled gate, staging-failure pass-through, and
+/// the happy path that registers a staged bundle and returns its handle.
+/// </summary>
+public sealed class RegisterBundleCommandHandlerTests
+{
+    private readonly FakeTimeProvider _time = new(new DateTimeOffset(2026, 7, 10, 12, 0, 0, TimeSpan.Zero));
+    private readonly Mock<IBundleStagingService> _staging = new();
+    private readonly Mock<IBundleHandleStore> _handleStore = new();
+
+    private sealed class StaticOptionsMonitor<T>(T value) : IOptionsMonitor<T>
+    {
+        public T CurrentValue { get; } = value;
+        public T Get(string? name) => CurrentValue;
+        public IDisposable? OnChange(Action<T, string?> listener) => null;
+    }
+
+    private RegisterBundleCommandHandler BuildSut(bool enabled)
+    {
+        var cfg = new AppConfig();
+        cfg.AI.BundleExecution.Enabled = enabled;
+        cfg.AI.BundleExecution.HandleTtl = TimeSpan.FromMinutes(30);
+        return new RegisterBundleCommandHandler(
+            _staging.Object, _handleStore.Object,
+            new StaticOptionsMonitor<AppConfig>(cfg), _time,
+            NullLogger<RegisterBundleCommandHandler>.Instance);
+    }
+
+    private static StagedBundle Staged() => new()
+    {
+        BundleId = "b1",
+        StagedRootDirectory = "/tmp/b1",
+        Agent = new AgentDefinition { Id = "agent-1", Name = "Agent 1" }
+    };
+
+    private static RegisterBundleCommand Command() => new() { Archive = new MemoryStream([1, 2, 3]) };
+
+    [Fact]
+    public async Task Handle_WhenDisabled_ReturnsForbidden_AndDoesNotStage()
+    {
+        var result = await BuildSut(enabled: false).Handle(Command(), CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.FailureType.Should().Be(ResultFailureType.Forbidden);
+        _staging.Verify(s => s.StageAsync(It.IsAny<Stream>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_WhenStagingFails_PassesReasonThrough_AndDoesNotRegister()
+    {
+        _staging.Setup(s => s.StageAsync(It.IsAny<Stream>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<StagedBundle>.Fail("archive too large"));
+
+        var result = await BuildSut(enabled: true).Handle(Command(), CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Errors.Should().Contain("archive too large");
+        _handleStore.Verify(h => h.Register(It.IsAny<StagedBundle>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_HappyPath_RegistersAndReturnsHandleWithExpiry()
+    {
+        _staging.Setup(s => s.StageAsync(It.IsAny<Stream>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<StagedBundle>.Success(Staged()));
+        _handleStore.Setup(h => h.Register(It.IsAny<StagedBundle>())).Returns("handle-1");
+
+        var result = await BuildSut(enabled: true).Handle(Command(), CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.Handle.Should().Be("handle-1");
+        result.Value.ExpiresAt.Should().Be(_time.GetUtcNow() + TimeSpan.FromMinutes(30));
+        _handleStore.Verify(h => h.Register(It.Is<StagedBundle>(b => b.BundleId == "b1")), Times.Once);
+    }
+}

--- a/src/Content/Tests/Application.AI.Common.Tests/CQRS/Bundles/RunBundleCommandHandlerTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/CQRS/Bundles/RunBundleCommandHandlerTests.cs
@@ -1,0 +1,99 @@
+using Application.AI.Common.CQRS.Bundles.RunBundle;
+using Application.AI.Common.Interfaces.Bundles;
+using Domain.AI.Agents;
+using Domain.AI.Bundles;
+using Domain.Common;
+using Domain.Common.Config;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Time.Testing;
+using Moq;
+using Xunit;
+
+namespace Application.AI.Common.Tests.CQRS.Bundles;
+
+/// <summary>
+/// Tests for <see cref="RunBundleCommandHandler"/>: the disabled gate, the missing-handle path, and the
+/// happy path that creates a queued run record (with the agent name captured from the staged bundle) and
+/// enqueues it for dispatch.
+/// </summary>
+public sealed class RunBundleCommandHandlerTests
+{
+    private readonly FakeTimeProvider _time = new(new DateTimeOffset(2026, 7, 10, 12, 0, 0, TimeSpan.Zero));
+    private readonly Mock<IBundleHandleStore> _handleStore = new();
+    private readonly Mock<IBundleRunJobStore> _jobStore = new();
+    private readonly Mock<IBundleRunDispatchQueue> _queue = new();
+
+    private sealed class StaticOptionsMonitor<T>(T value) : IOptionsMonitor<T>
+    {
+        public T CurrentValue { get; } = value;
+        public T Get(string? name) => CurrentValue;
+        public IDisposable? OnChange(Action<T, string?> listener) => null;
+    }
+
+    private RunBundleCommandHandler BuildSut(bool enabled)
+    {
+        var cfg = new AppConfig();
+        cfg.AI.BundleExecution.Enabled = enabled;
+        return new RunBundleCommandHandler(
+            _handleStore.Object, _jobStore.Object, _queue.Object,
+            new StaticOptionsMonitor<AppConfig>(cfg), _time,
+            NullLogger<RunBundleCommandHandler>.Instance);
+    }
+
+    private static StagedBundle Staged() => new()
+    {
+        BundleId = "b1",
+        StagedRootDirectory = "/tmp/b1",
+        Agent = new AgentDefinition { Id = "the-agent", Name = "The Agent" }
+    };
+
+    private static RunBundleCommand Command() => new()
+    {
+        Handle = "handle-1",
+        UserMessages = ["hello"],
+        Envelope = new CapabilityEnvelope(),
+        MaxTurns = 4
+    };
+
+    [Fact]
+    public async Task Handle_WhenDisabled_ReturnsForbidden_AndDoesNotEnqueue()
+    {
+        var result = await BuildSut(enabled: false).Handle(Command(), CancellationToken.None);
+
+        result.FailureType.Should().Be(ResultFailureType.Forbidden);
+        _queue.Verify(q => q.EnqueueAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_WhenHandleUnknown_ReturnsNotFound_AndDoesNotCreateOrEnqueue()
+    {
+        _handleStore.Setup(h => h.TryGet("handle-1")).Returns((StagedBundle?)null);
+
+        var result = await BuildSut(enabled: true).Handle(Command(), CancellationToken.None);
+
+        result.FailureType.Should().Be(ResultFailureType.NotFound);
+        _jobStore.Verify(j => j.Create(It.IsAny<BundleRunRecord>()), Times.Never);
+        _queue.Verify(q => q.EnqueueAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_HappyPath_CreatesQueuedRecord_CapturesAgentName_AndEnqueues()
+    {
+        _handleStore.Setup(h => h.TryGet("handle-1")).Returns(Staged());
+        BundleRunRecord? created = null;
+        _jobStore.Setup(j => j.Create(It.IsAny<BundleRunRecord>())).Callback<BundleRunRecord>(r => created = r);
+
+        var result = await BuildSut(enabled: true).Handle(Command(), CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        created.Should().NotBeNull();
+        created!.Status.Should().Be(BundleRunStatus.Queued);
+        created.AgentName.Should().Be("the-agent");
+        created.Handle.Should().Be("handle-1");
+        created.MaxTurns.Should().Be(4);
+        result.Value!.JobId.Should().Be(created.JobId);
+        _queue.Verify(q => q.EnqueueAsync(created.JobId, It.IsAny<CancellationToken>()), Times.Once);
+    }
+}

--- a/src/Content/Tests/Domain.AI.Tests/Bundles/BundleRunStatusEnumTests.cs
+++ b/src/Content/Tests/Domain.AI.Tests/Bundles/BundleRunStatusEnumTests.cs
@@ -1,0 +1,35 @@
+using Domain.AI.Bundles;
+using FluentAssertions;
+using Xunit;
+
+namespace Domain.AI.Tests.Bundles;
+
+/// <summary>
+/// Anchors the numeric values and membership of <see cref="BundleRunStatus"/>. Callers polling a run's
+/// status compare against these wire values, so renumbering or dropping a member would silently change the
+/// poll contract — this test forces a conscious choice if anyone does.
+/// </summary>
+public sealed class BundleRunStatusEnumTests
+{
+    [Theory]
+    [InlineData(BundleRunStatus.Queued, 0)]
+    [InlineData(BundleRunStatus.Running, 1)]
+    [InlineData(BundleRunStatus.Succeeded, 2)]
+    [InlineData(BundleRunStatus.Failed, 3)]
+    public void BundleRunStatus_NumericValues_Match(BundleRunStatus value, int expected)
+    {
+        ((int)value).Should().Be(expected);
+    }
+
+    [Fact]
+    public void BundleRunStatus_HasExactlyFourMembers()
+    {
+        Enum.GetValues<BundleRunStatus>().Should().BeEquivalentTo(new[]
+        {
+            BundleRunStatus.Queued,
+            BundleRunStatus.Running,
+            BundleRunStatus.Succeeded,
+            BundleRunStatus.Failed
+        });
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Bundles/BundleRunBackgroundServiceTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Bundles/BundleRunBackgroundServiceTests.cs
@@ -1,0 +1,265 @@
+using Application.AI.Common.Interfaces.Bundles;
+using Application.AI.Common.Services.Bundles;
+using Application.AI.Common.Services.Governance;
+using Application.Core.CQRS.Agents.RunConversation;
+using Domain.AI.Agents;
+using Domain.AI.Bundles;
+using Domain.AI.Governance;
+using Domain.Common.Config;
+using FluentAssertions;
+using Infrastructure.AI.Bundles;
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Time.Testing;
+using Moq;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Bundles;
+
+/// <summary>
+/// Tests for <see cref="BundleRunBackgroundService"/>: it drains the queue, re-arms the capability envelope
+/// and ephemeral-agent overlay on its detached thread, drives the conversation, pins the staging directory
+/// against the sweeper for the run's duration, and records the terminal outcome.
+/// </summary>
+public sealed class BundleRunBackgroundServiceTests : IDisposable
+{
+    private static readonly TimeSpan Ttl = TimeSpan.FromMinutes(30);
+    private readonly FakeTimeProvider _time = new(new DateTimeOffset(2026, 7, 10, 12, 0, 0, TimeSpan.Zero));
+    private readonly List<string> _tempDirs = [];
+
+    private sealed class StaticOptionsMonitor<T>(T value) : IOptionsMonitor<T>
+    {
+        public T CurrentValue { get; } = value;
+        public T Get(string? name) => CurrentValue;
+        public IDisposable? OnChange(Action<T, string?> listener) => null;
+    }
+
+    private AppConfig Config()
+    {
+        var cfg = new AppConfig();
+        cfg.AI.BundleExecution.HandleTtl = Ttl;
+        cfg.AI.BundleExecution.RunRecordTtl = Ttl;
+        return cfg;
+    }
+
+    private StagedBundle StageOnDisk(string bundleId, out string dir)
+    {
+        dir = Path.Combine(Path.GetTempPath(), "bundle-dispatch-tests", bundleId);
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, "AGENT.md"), "# agent");
+        _tempDirs.Add(dir);
+
+        return new StagedBundle
+        {
+            BundleId = bundleId,
+            StagedRootDirectory = dir,
+            Agent = new AgentDefinition { Id = "agent-" + bundleId, Name = "Agent " + bundleId }
+        };
+    }
+
+    private static ConversationResult SampleResult() => new()
+    {
+        Success = true,
+        Turns = [new TurnSummary { TurnNumber = 1, UserMessage = "hi", AgentResponse = "hello" }],
+        FinalResponse = "hello",
+        TotalToolInvocations = 2
+    };
+
+    /// <summary>
+    /// Builds the dispatcher wired to the real in-memory queue/stores and a scope factory whose IMediator is
+    /// <paramref name="mediator"/>, so a test controls exactly what the conversation returns (or does).
+    /// </summary>
+    private (BundleRunBackgroundService Service,
+             InMemoryBundleRunDispatchQueue Queue,
+             InMemoryBundleRunJobStore JobStore,
+             InMemoryBundleHandleStore HandleStore)
+        BuildSut(IMediator mediator)
+    {
+        var monitor = new StaticOptionsMonitor<AppConfig>(Config());
+        var queue = new InMemoryBundleRunDispatchQueue();
+        var jobStore = new InMemoryBundleRunJobStore(monitor, _time);
+        var handleStore = new InMemoryBundleHandleStore(monitor, _time, NullLogger<InMemoryBundleHandleStore>.Instance);
+
+        var services = new ServiceCollection();
+        services.AddSingleton(mediator);
+        var scopeFactory = services.BuildServiceProvider().GetRequiredService<IServiceScopeFactory>();
+
+        var service = new BundleRunBackgroundService(
+            queue, jobStore, handleStore, scopeFactory, _time,
+            NullLogger<BundleRunBackgroundService>.Instance);
+
+        return (service, queue, jobStore, handleStore);
+    }
+
+    private BundleRunRecord QueuedRecord(string jobId, string handle, string agentId, CapabilityEnvelope envelope) => new()
+    {
+        JobId = jobId,
+        Handle = handle,
+        AgentName = agentId,
+        UserMessages = ["hello"],
+        MaxTurns = 3,
+        Envelope = envelope,
+        Status = BundleRunStatus.Queued,
+        CreatedAt = _time.GetUtcNow()
+    };
+
+    private static async Task WaitForAsync(Func<bool> predicate, TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            if (predicate()) return;
+            await Task.Delay(10);
+        }
+        throw new TimeoutException($"Predicate did not become true within {timeout.TotalMilliseconds}ms.");
+    }
+
+    [Fact]
+    public async Task Dispatch_RunsConversationUnderArmedEnvelopeAndOverlay_MarksSucceeded()
+    {
+        CapabilityEnvelope? seenEnvelope = null;
+        EphemeralAgentOverlay? seenOverlay = null;
+
+        var mediator = new Mock<IMediator>();
+        mediator.Setup(m => m.Send(It.IsAny<RunConversationCommand>(), It.IsAny<CancellationToken>()))
+            .Returns((RunConversationCommand _, CancellationToken _) =>
+            {
+                // Captured INSIDE Send: proves both ambients are armed for the duration of the conversation.
+                seenEnvelope = CapabilityEnvelopeAccessor.Current;
+                seenOverlay = EphemeralAgentOverlayAccessor.Current;
+                return Task.FromResult(SampleResult());
+            });
+
+        var (service, queue, jobStore, handleStore) = BuildSut(mediator.Object);
+        var staged = StageOnDisk("b1", out _);
+        var handle = handleStore.Register(staged);
+        var envelope = new CapabilityEnvelope { AllowedTools = ["read_file"], AutonomyCeiling = AutonomyLevel.Autonomous };
+        jobStore.Create(QueuedRecord("j1", handle, staged.Agent.Id, envelope));
+        await queue.EnqueueAsync("j1", CancellationToken.None);
+
+        _ = service.StartAsync(CancellationToken.None);
+        await WaitForAsync(() => jobStore.Get("j1")?.IsTerminal == true, TimeSpan.FromSeconds(2));
+        await service.StopAsync(CancellationToken.None);
+
+        seenEnvelope.Should().BeSameAs(envelope);
+        seenOverlay.Should().NotBeNull();
+        seenOverlay!.Agent.Id.Should().Be(staged.Agent.Id);
+
+        var record = jobStore.Get("j1")!;
+        record.Status.Should().Be(BundleRunStatus.Succeeded);
+        record.StartedAt.Should().NotBeNull();
+        record.CompletedAt.Should().NotBeNull();
+        record.Outcome.Should().NotBeNull();
+        record.Outcome!.ConversationSucceeded.Should().BeTrue();
+        record.Outcome.FinalResponse.Should().Be("hello");
+        record.Outcome.TotalToolInvocations.Should().Be(2);
+
+        // The ambient must NOT leak past the run.
+        CapabilityEnvelopeAccessor.Current.Should().BeNull();
+        EphemeralAgentOverlayAccessor.Current.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Dispatch_PinsStagingDirectory_ForDurationOfRun()
+    {
+        var dirExistedDuringRun = false;
+        var sweepDuringRun = -1;
+
+        InMemoryBundleHandleStore? handleStoreRef = null;
+        string? dirRef = null;
+
+        var mediator = new Mock<IMediator>();
+        mediator.Setup(m => m.Send(It.IsAny<RunConversationCommand>(), It.IsAny<CancellationToken>()))
+            .Returns((RunConversationCommand _, CancellationToken _) =>
+            {
+                // While the run is executing, expire the clock and sweep: the pinned directory must survive.
+                _time.Advance(Ttl + TimeSpan.FromMinutes(5));
+                sweepDuringRun = handleStoreRef!.SweepExpired();
+                dirExistedDuringRun = Directory.Exists(dirRef!);
+                return Task.FromResult(SampleResult());
+            });
+
+        var (service, queue, jobStore, handleStore) = BuildSut(mediator.Object);
+        handleStoreRef = handleStore;
+        var staged = StageOnDisk("b1", out var dir);
+        dirRef = dir;
+        var handle = handleStore.Register(staged);
+        jobStore.Create(QueuedRecord("j1", handle, staged.Agent.Id, new CapabilityEnvelope()));
+        await queue.EnqueueAsync("j1", CancellationToken.None);
+
+        _ = service.StartAsync(CancellationToken.None);
+        await WaitForAsync(() => jobStore.Get("j1")?.IsTerminal == true, TimeSpan.FromSeconds(2));
+        await service.StopAsync(CancellationToken.None);
+
+        sweepDuringRun.Should().Be(0, "a leased handle is pinned against the sweeper");
+        dirExistedDuringRun.Should().BeTrue("the staging directory must survive while the run reads its skills");
+
+        // Releasing the lease slides the TTL forward (a completed run is a use), so the handle survives the
+        // immediate sweep; advance past the fresh TTL and it becomes reclaimable and its directory is deleted.
+        handleStore.SweepExpired().Should().Be(0);
+        Directory.Exists(dir).Should().BeTrue();
+        _time.Advance(Ttl + TimeSpan.FromMinutes(1));
+        handleStore.SweepExpired().Should().Be(1);
+        Directory.Exists(dir).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Dispatch_HandleExpiredBeforePickup_MarksFailed()
+    {
+        var mediator = new Mock<IMediator>();
+        mediator.Setup(m => m.Send(It.IsAny<RunConversationCommand>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("should not run"));
+
+        var (service, queue, jobStore, handleStore) = BuildSut(mediator.Object);
+        var staged = StageOnDisk("b1", out _);
+        var handle = handleStore.Register(staged);
+        jobStore.Create(QueuedRecord("j1", handle, staged.Agent.Id, new CapabilityEnvelope()));
+        // Remove the handle before the run is dispatched.
+        handleStore.Remove(handle);
+        await queue.EnqueueAsync("j1", CancellationToken.None);
+
+        _ = service.StartAsync(CancellationToken.None);
+        await WaitForAsync(() => jobStore.Get("j1")?.IsTerminal == true, TimeSpan.FromSeconds(2));
+        await service.StopAsync(CancellationToken.None);
+
+        var record = jobStore.Get("j1")!;
+        record.Status.Should().Be(BundleRunStatus.Failed);
+        record.Error.Should().Contain("expired");
+        record.StartedAt.Should().BeNull("a run that never started must not carry a start time");
+        mediator.Verify(m => m.Send(It.IsAny<RunConversationCommand>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Dispatch_ConversationThrows_MarksFailed_WithScrubbedReason()
+    {
+        var mediator = new Mock<IMediator>();
+        mediator.Setup(m => m.Send(It.IsAny<RunConversationCommand>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("secret internal detail"));
+
+        var (service, queue, jobStore, handleStore) = BuildSut(mediator.Object);
+        var staged = StageOnDisk("b1", out _);
+        var handle = handleStore.Register(staged);
+        jobStore.Create(QueuedRecord("j1", handle, staged.Agent.Id, new CapabilityEnvelope()));
+        await queue.EnqueueAsync("j1", CancellationToken.None);
+
+        _ = service.StartAsync(CancellationToken.None);
+        await WaitForAsync(() => jobStore.Get("j1")?.IsTerminal == true, TimeSpan.FromSeconds(2));
+        await service.StopAsync(CancellationToken.None);
+
+        var record = jobStore.Get("j1")!;
+        record.Status.Should().Be(BundleRunStatus.Failed);
+        record.Error.Should().Be("bundle_run.unhandled_exception");
+        record.Error.Should().NotContain("secret internal detail");
+    }
+
+    public void Dispose()
+    {
+        foreach (var dir in _tempDirs)
+        {
+            try { if (Directory.Exists(dir)) Directory.Delete(dir, recursive: true); }
+            catch { /* best-effort test cleanup */ }
+        }
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Bundles/InMemoryBundleHandleStoreTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Bundles/InMemoryBundleHandleStoreTests.cs
@@ -1,0 +1,201 @@
+using Application.AI.Common.Interfaces.Bundles;
+using Domain.AI.Agents;
+using Domain.AI.Bundles;
+using Domain.Common.Config;
+using FluentAssertions;
+using Infrastructure.AI.Bundles;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Time.Testing;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Bundles;
+
+/// <summary>
+/// Tests for <see cref="InMemoryBundleHandleStore"/>: sliding TTL, run-pinning that protects an in-flight
+/// run's staging directory from the sweeper, and guaranteed directory deletion on removal, expiry, and
+/// disposal.
+/// </summary>
+public sealed class InMemoryBundleHandleStoreTests : IDisposable
+{
+    private static readonly TimeSpan Ttl = TimeSpan.FromMinutes(30);
+    private readonly FakeTimeProvider _time = new(new DateTimeOffset(2026, 7, 10, 12, 0, 0, TimeSpan.Zero));
+    private readonly List<string> _tempDirs = [];
+
+    private sealed class StaticOptionsMonitor<T>(T value) : IOptionsMonitor<T>
+    {
+        public T CurrentValue { get; } = value;
+        public T Get(string? name) => CurrentValue;
+        public IDisposable? OnChange(Action<T, string?> listener) => null;
+    }
+
+    private InMemoryBundleHandleStore BuildSut()
+    {
+        var cfg = new AppConfig();
+        cfg.AI.BundleExecution.HandleTtl = Ttl;
+        return new InMemoryBundleHandleStore(
+            new StaticOptionsMonitor<AppConfig>(cfg),
+            _time,
+            NullLogger<InMemoryBundleHandleStore>.Instance);
+    }
+
+    private StagedBundle StageOnDisk(string bundleId)
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "bundle-handle-tests", bundleId);
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, "AGENT.md"), "# agent");
+        _tempDirs.Add(dir);
+
+        return new StagedBundle
+        {
+            BundleId = bundleId,
+            StagedRootDirectory = dir,
+            Agent = new AgentDefinition { Id = "agent-" + bundleId, Name = "Agent " + bundleId }
+        };
+    }
+
+    [Fact]
+    public void Register_ThenTryGet_ReturnsBundle()
+    {
+        var sut = BuildSut();
+        var handle = sut.Register(StageOnDisk("b1"));
+
+        var got = sut.TryGet(handle);
+
+        got.Should().NotBeNull();
+        got!.BundleId.Should().Be("b1");
+    }
+
+    [Fact]
+    public void TryGet_UnknownHandle_ReturnsNull()
+    {
+        BuildSut().TryGet("nope").Should().BeNull();
+    }
+
+    [Fact]
+    public void TryGet_AfterTtlElapses_ReturnsNull()
+    {
+        var sut = BuildSut();
+        var handle = sut.Register(StageOnDisk("b1"));
+
+        _time.Advance(Ttl + TimeSpan.FromSeconds(1));
+
+        sut.TryGet(handle).Should().BeNull();
+    }
+
+    [Fact]
+    public void TryGet_RefreshesSlidingExpiry()
+    {
+        var sut = BuildSut();
+        var handle = sut.Register(StageOnDisk("b1"));
+
+        // Advance almost to expiry, touch it, then advance another almost-full TTL: still alive.
+        _time.Advance(Ttl - TimeSpan.FromMinutes(1));
+        sut.TryGet(handle).Should().NotBeNull();
+        _time.Advance(Ttl - TimeSpan.FromMinutes(1));
+
+        sut.TryGet(handle).Should().NotBeNull();
+    }
+
+    [Fact]
+    public void Acquire_PinsHandle_SweepDoesNotDeleteWhileLeased()
+    {
+        var sut = BuildSut();
+        var bundle = StageOnDisk("b1");
+        var handle = sut.Register(bundle);
+
+        using (var lease = sut.Acquire(handle))
+        {
+            lease.Should().NotBeNull();
+            lease!.Bundle.BundleId.Should().Be("b1");
+
+            _time.Advance(Ttl + TimeSpan.FromMinutes(5));
+
+            // Pinned: the sweeper must not evict or delete a leased handle even though its clock expiry passed.
+            sut.SweepExpired().Should().Be(0);
+            Directory.Exists(bundle.StagedRootDirectory).Should().BeTrue();
+        }
+
+        // Once released and expired, the sweeper reclaims it and deletes the directory.
+        _time.Advance(Ttl + TimeSpan.FromMinutes(5));
+        sut.SweepExpired().Should().Be(1);
+        Directory.Exists(bundle.StagedRootDirectory).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Remove_Unleased_DeletesDirectoryImmediately()
+    {
+        var sut = BuildSut();
+        var bundle = StageOnDisk("b1");
+        var handle = sut.Register(bundle);
+
+        sut.Remove(handle).Should().BeTrue();
+
+        Directory.Exists(bundle.StagedRootDirectory).Should().BeFalse();
+        sut.TryGet(handle).Should().BeNull();
+    }
+
+    [Fact]
+    public void Remove_WhileLeased_DefersDeletionUntilRelease()
+    {
+        var sut = BuildSut();
+        var bundle = StageOnDisk("b1");
+        var handle = sut.Register(bundle);
+
+        var lease = sut.Acquire(handle)!;
+        sut.Remove(handle).Should().BeTrue();
+
+        // A removed-but-leased handle is invisible to new lookups but its directory survives the run.
+        sut.TryGet(handle).Should().BeNull();
+        Directory.Exists(bundle.StagedRootDirectory).Should().BeTrue();
+
+        lease.Dispose();
+        Directory.Exists(bundle.StagedRootDirectory).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Remove_UnknownHandle_ReturnsFalse()
+    {
+        BuildSut().Remove("nope").Should().BeFalse();
+    }
+
+    [Fact]
+    public void SweepExpired_DeletesExpiredDirectories_ReturnsCount()
+    {
+        var sut = BuildSut();
+        var b1 = StageOnDisk("b1");
+        var b2 = StageOnDisk("b2");
+        sut.Register(b1);
+        sut.Register(b2);
+
+        _time.Advance(Ttl + TimeSpan.FromSeconds(1));
+
+        sut.SweepExpired().Should().Be(2);
+        Directory.Exists(b1.StagedRootDirectory).Should().BeFalse();
+        Directory.Exists(b2.StagedRootDirectory).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Dispose_DeletesAllRemainingDirectories()
+    {
+        var sut = BuildSut();
+        var b1 = StageOnDisk("b1");
+        var b2 = StageOnDisk("b2");
+        sut.Register(b1);
+        sut.Register(b2);
+
+        sut.Dispose();
+
+        Directory.Exists(b1.StagedRootDirectory).Should().BeFalse();
+        Directory.Exists(b2.StagedRootDirectory).Should().BeFalse();
+    }
+
+    public void Dispose()
+    {
+        foreach (var dir in _tempDirs)
+        {
+            try { if (Directory.Exists(dir)) Directory.Delete(dir, recursive: true); }
+            catch { /* best-effort test cleanup */ }
+        }
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Bundles/InMemoryBundleRunJobStoreTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Bundles/InMemoryBundleRunJobStoreTests.cs
@@ -1,0 +1,160 @@
+using Domain.AI.Bundles;
+using Domain.AI.Governance;
+using Domain.Common.Config;
+using FluentAssertions;
+using Infrastructure.AI.Bundles;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Time.Testing;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Bundles;
+
+/// <summary>
+/// Tests for <see cref="InMemoryBundleRunJobStore"/>: create/get/update snapshots, per-record TTL, and the
+/// terminal-state TTL extension that keeps a completed run pollable for the full window.
+/// </summary>
+public sealed class InMemoryBundleRunJobStoreTests
+{
+    private static readonly TimeSpan Ttl = TimeSpan.FromMinutes(30);
+    private readonly FakeTimeProvider _time = new(new DateTimeOffset(2026, 7, 10, 12, 0, 0, TimeSpan.Zero));
+
+    private sealed class StaticOptionsMonitor<T>(T value) : IOptionsMonitor<T>
+    {
+        public T CurrentValue { get; } = value;
+        public T Get(string? name) => CurrentValue;
+        public IDisposable? OnChange(Action<T, string?> listener) => null;
+    }
+
+    private InMemoryBundleRunJobStore BuildSut()
+    {
+        var cfg = new AppConfig();
+        cfg.AI.BundleExecution.RunRecordTtl = Ttl;
+        return new InMemoryBundleRunJobStore(new StaticOptionsMonitor<AppConfig>(cfg), _time);
+    }
+
+    private BundleRunRecord NewRecord(string jobId = "j1", BundleRunStatus status = BundleRunStatus.Queued) => new()
+    {
+        JobId = jobId,
+        Handle = "h1",
+        AgentName = "agent-1",
+        UserMessages = ["hello"],
+        MaxTurns = 5,
+        Envelope = new CapabilityEnvelope(),
+        Status = status,
+        CreatedAt = _time.GetUtcNow()
+    };
+
+    [Fact]
+    public void Create_ThenGet_ReturnsRecord()
+    {
+        var sut = BuildSut();
+        sut.Create(NewRecord());
+
+        sut.Get("j1").Should().NotBeNull();
+        sut.Get("j1")!.Status.Should().Be(BundleRunStatus.Queued);
+    }
+
+    [Fact]
+    public void Create_DuplicateJobId_Throws()
+    {
+        var sut = BuildSut();
+        sut.Create(NewRecord());
+
+        var act = () => sut.Create(NewRecord());
+
+        act.Should().Throw<InvalidOperationException>();
+    }
+
+    [Fact]
+    public void Get_UnknownJobId_ReturnsNull()
+    {
+        BuildSut().Get("nope").Should().BeNull();
+    }
+
+    [Fact]
+    public void Get_NonTerminalRecord_NeverExpires()
+    {
+        var sut = BuildSut();
+        sut.Create(NewRecord()); // Queued
+
+        _time.Advance(Ttl + TimeSpan.FromHours(1));
+
+        // An in-flight (Queued/Running) run is never expired — its record must survive for the dispatcher.
+        sut.Get("j1").Should().NotBeNull();
+    }
+
+    [Fact]
+    public void Get_TerminalRecord_AfterTtlElapses_ReturnsNull()
+    {
+        var sut = BuildSut();
+        sut.Create(NewRecord());
+        sut.Update(sut.Get("j1")! with { Status = BundleRunStatus.Succeeded });
+
+        _time.Advance(Ttl + TimeSpan.FromSeconds(1));
+
+        sut.Get("j1").Should().BeNull();
+    }
+
+    [Fact]
+    public void Update_ReplacesSnapshot()
+    {
+        var sut = BuildSut();
+        sut.Create(NewRecord());
+
+        var updated = sut.Get("j1")! with { Status = BundleRunStatus.Running };
+        sut.Update(updated).Should().BeTrue();
+
+        sut.Get("j1")!.Status.Should().Be(BundleRunStatus.Running);
+    }
+
+    [Fact]
+    public void Update_TerminalStatus_ExtendsTtl()
+    {
+        var sut = BuildSut();
+        sut.Create(NewRecord());
+
+        // Advance almost to the original expiry, then complete the run — which resets the TTL window.
+        _time.Advance(Ttl - TimeSpan.FromMinutes(1));
+        var done = sut.Get("j1")! with { Status = BundleRunStatus.Succeeded };
+        sut.Update(done).Should().BeTrue();
+
+        // Past the ORIGINAL expiry but within the extended window: still pollable.
+        _time.Advance(TimeSpan.FromMinutes(2));
+        sut.Get("j1").Should().NotBeNull();
+        sut.Get("j1")!.Status.Should().Be(BundleRunStatus.Succeeded);
+    }
+
+    [Fact]
+    public void Update_UnknownJobId_ReturnsFalse()
+    {
+        BuildSut().Update(NewRecord("ghost")).Should().BeFalse();
+    }
+
+    [Fact]
+    public void SweepExpired_RemovesExpiredTerminalRecords_ReturnsCount()
+    {
+        var sut = BuildSut();
+        sut.Create(NewRecord("j1"));
+        sut.Create(NewRecord("j2"));
+        sut.Update(sut.Get("j1")! with { Status = BundleRunStatus.Succeeded });
+        sut.Update(sut.Get("j2")! with { Status = BundleRunStatus.Failed });
+
+        _time.Advance(Ttl + TimeSpan.FromSeconds(1));
+
+        sut.SweepExpired().Should().Be(2);
+        sut.Get("j1").Should().BeNull();
+        sut.Get("j2").Should().BeNull();
+    }
+
+    [Fact]
+    public void SweepExpired_LeavesNonTerminalRecords()
+    {
+        var sut = BuildSut();
+        sut.Create(NewRecord("j1")); // Queued, in-flight
+
+        _time.Advance(Ttl + TimeSpan.FromHours(1));
+
+        sut.SweepExpired().Should().Be(0);
+        sut.Get("j1").Should().NotBeNull();
+    }
+}


### PR DESCRIPTION
## Bundle-PR3 — async job + handle lifecycle

Third phase of the bundle-injection API (Issue #154, Part 2). Adds the async-job and handle-lifecycle layer between PR2's capability envelope (#169) and PR4's REST surface. **Off by default; inert until a run is fed** (no production caller yet).

### What it delivers
- **Domain** (`Domain.AI/Bundles`) — `BundleRunStatus` (+ enum tripwire test), `BundleRunRecord`, `BundleRunOutcome`.
- **Application** (`Application.AI.Common`) — `IBundleHandleStore` (lease-based run-pinning) / `IBundleRunJobStore` / `IBundleRunDispatchQueue`; `RegisterBundle` / `RunBundle` / `GetBundleRun` CQRS trios (validator + disabled-gate each).
- **Infrastructure** (`Infrastructure.AI/Bundles`) — in-memory stores + FIFO dispatch queue (mirrors the `ChangeProposal` pattern) + `BundleRunBackgroundService` + `BundleWorkspaceCleanupService`; DI wiring.

### Carried invariants (both honored)
1. The dispatcher re-arms **both** ambients on its detached thread (`CapabilityEnvelopeAccessor.Begin` + `EphemeralAgentOverlayAccessor.Begin`) — the request-scoped ambient does not flow across the thread-pool boundary. The standard turn handler arms `ToolGovernanceAccessor` per turn, so the governor enforces the per-caller grant (**fails closed**, not open).
2. `RunConversationCommand` returns a materialized result, so the envelope scope disposes safely after `Send`. The streaming (PR5) path is documented as needing the scope held across enumeration.

### Design calls
- **`ConcurrentDictionary` + `TimeProvider` sweeper, not `IMemoryCache` post-eviction** — the security requirement is *guaranteed* temp-dir cleanup with a run pinned against deletion (skill disclosure reads from disk mid-run); IMemoryCache can't pin an in-use entry or fire deterministically. Impl choice, not a re-litigation of the locked "in-memory, TTL'd" decision.
- **Record + outcome in `Domain.AI`** (primitive projection) because `Application.AI.Common` cannot see `Application.Core`'s `ConversationResult`; the background service maps it.

### Review (`/code-review` high) — 3 bugs found and fixed
1. Job-store TTL could expire in-flight runs → **non-terminal records never expire; TTL governs only terminal records** (fixes silent-drop + mid-run-sweep outcome loss + record revival, one change).
2. `Dispose` deleted staging dirs ignoring leases → skip leased entries.
3. `StartedAt` stamped before `Acquire` → transition to `Running` only after a successful lease.

### Verification
- `dotnet build src/AgenticHarness.slnx` — **0 warnings / 0 errors**.
- 45 new bundle tests green (handle store, job store, dispatcher integration incl. ambient-arming + pin-during-run, 3 CQRS trios, enum tripwire).
- Full Domain.AI (815) + Application.AI.Common (1393) green; Infrastructure.AI: only the 3 pre-existing env-only `FileSystemService` temp-write failures.

### Follow-ups (noted, not in scope)
- **PR4 must** resolve the `CapabilityEnvelope` from the caller's credential (`ICapabilityEnvelopeResolver`) and pass it to `RunBundleCommand`; keep the envelope scope open across the full streamed turn in PR5.
- Foresight token-snapshot omits overlay-owned skills (a PR1 overlay-decoration gap; cosmetic token attribution).

🤖 Generated with [Claude Code](https://claude.com/claude-code)