### PR TITLE
feat: bundle REST API host with per-caller isolation (Bundle-PR4)

### DIFF
--- a/src/AgenticHarness.slnx
+++ b/src/AgenticHarness.slnx
@@ -1,4 +1,14 @@
 <Solution>
+  <Folder Name="/Content/" />
+  <Folder Name="/Content/Application/" />
+  <Folder Name="/Content/Domain/" />
+  <Folder Name="/Content/Presentation/">
+    <Project Path="Content/Presentation/Presentation.BundleApi/Presentation.BundleApi.csproj">
+      <BuildType Solution="Debug-AgentHub-All|*" Project="Debug" />
+      <BuildType Solution="Debug-AgentHub-Dashboard|*" Project="Debug" />
+      <BuildType Solution="Debug-AgentHub-WebUI|*" Project="Debug" />
+    </Project>
+  </Folder>
   <Folder Name="/Dashboards/">
     <File Path="../Dashboards/docker-compose.yml" />
     <File Path="../Dashboards/prometheus.yml" />

--- a/src/Content/Application/Application.AI.Common/CQRS/Bundles/DeleteBundle/DeleteBundleCommand.cs
+++ b/src/Content/Application/Application.AI.Common/CQRS/Bundles/DeleteBundle/DeleteBundleCommand.cs
@@ -1,0 +1,26 @@
+using Domain.Common;
+using MediatR;
+
+namespace Application.AI.Common.CQRS.Bundles.DeleteBundle;
+
+/// <summary>
+/// Explicitly removes a staged bundle and deletes its staging directory, ahead of the TTL that would
+/// eventually reclaim it. The application-level entry point for <c>DELETE /api/bundles/{handle}</c>.
+/// </summary>
+/// <remarks>
+/// Idempotent: removing a handle that is already gone (never existed, already deleted, or already expired)
+/// is a success, not an error — the post-condition "the handle no longer exists" holds either way. The
+/// result's payload reports whether a handle was actually present to remove, for callers that care.
+/// </remarks>
+public sealed record DeleteBundleCommand : IRequest<Result<bool>>
+{
+    /// <summary>The handle of the staged bundle to remove.</summary>
+    public required string Handle { get; init; }
+
+    /// <summary>
+    /// Stable identifier of the caller requesting deletion. Only the owner the handle was registered under
+    /// can delete it; a non-owner request is a no-op (the handle is not theirs to remove). Resolved at the
+    /// transport boundary from the authenticated principal.
+    /// </summary>
+    public required string OwnerId { get; init; }
+}

--- a/src/Content/Application/Application.AI.Common/CQRS/Bundles/DeleteBundle/DeleteBundleCommandHandler.cs
+++ b/src/Content/Application/Application.AI.Common/CQRS/Bundles/DeleteBundle/DeleteBundleCommandHandler.cs
@@ -1,0 +1,64 @@
+using Application.AI.Common.Interfaces.Bundles;
+using Domain.Common;
+using Domain.Common.Config;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Application.AI.Common.CQRS.Bundles.DeleteBundle;
+
+/// <summary>
+/// Handles <see cref="DeleteBundleCommand"/>: refuses when bundle execution is disabled, otherwise removes
+/// the handle from the store (which deletes its staging directory once no run holds a lease). Idempotent —
+/// a missing handle still succeeds.
+/// </summary>
+public sealed class DeleteBundleCommandHandler : IRequestHandler<DeleteBundleCommand, Result<bool>>
+{
+    private readonly IBundleHandleStore _handleStore;
+    private readonly IOptionsMonitor<AppConfig> _config;
+    private readonly ILogger<DeleteBundleCommandHandler> _logger;
+
+    /// <summary>Initializes a new <see cref="DeleteBundleCommandHandler"/>.</summary>
+    public DeleteBundleCommandHandler(
+        IBundleHandleStore handleStore,
+        IOptionsMonitor<AppConfig> config,
+        ILogger<DeleteBundleCommandHandler> logger)
+    {
+        ArgumentNullException.ThrowIfNull(handleStore);
+        ArgumentNullException.ThrowIfNull(config);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _handleStore = handleStore;
+        _config = config;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public Task<Result<bool>> Handle(DeleteBundleCommand request, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (!_config.CurrentValue.AI.BundleExecution.Enabled)
+        {
+            return Task.FromResult(Result<bool>.Forbidden(
+                "Bundle execution is disabled. Set AppConfig.AI.BundleExecution.Enabled = true to enable it."));
+        }
+
+        // Only the owner may delete. A non-owner (or absent handle) is a non-disclosing no-op: from their
+        // view the handle is not theirs to remove, so nothing is deleted and the idempotent "already absent"
+        // outcome is returned rather than revealing that the handle exists for someone else.
+        if (_handleStore.GetOwner(request.Handle) != request.OwnerId)
+        {
+            _logger.LogInformation(
+                "Delete bundle handle {Handle}: not owned by caller (no-op).", request.Handle);
+            return Task.FromResult(Result<bool>.Success(false));
+        }
+
+        var removed = _handleStore.Remove(request.Handle);
+        _logger.LogInformation(
+            "Delete bundle handle {Handle}: {Outcome}.", request.Handle, removed ? "removed" : "already absent");
+
+        return Task.FromResult(Result<bool>.Success(removed));
+    }
+}

--- a/src/Content/Application/Application.AI.Common/CQRS/Bundles/DeleteBundle/DeleteBundleCommandValidator.cs
+++ b/src/Content/Application/Application.AI.Common/CQRS/Bundles/DeleteBundle/DeleteBundleCommandValidator.cs
@@ -1,0 +1,16 @@
+using FluentValidation;
+
+namespace Application.AI.Common.CQRS.Bundles.DeleteBundle;
+
+/// <summary>
+/// Validates <see cref="DeleteBundleCommand"/> before the handler runs.
+/// </summary>
+public sealed class DeleteBundleCommandValidator : AbstractValidator<DeleteBundleCommand>
+{
+    /// <summary>Initializes validation rules.</summary>
+    public DeleteBundleCommandValidator()
+    {
+        RuleFor(x => x.Handle)
+            .NotEmpty().WithMessage("Handle is required.");
+    }
+}

--- a/src/Content/Application/Application.AI.Common/CQRS/Bundles/GetBundleRun/GetBundleRunQuery.cs
+++ b/src/Content/Application/Application.AI.Common/CQRS/Bundles/GetBundleRun/GetBundleRunQuery.cs
@@ -20,4 +20,11 @@ public sealed record GetBundleRunQuery : IRequest<Result<BundleRunRecord>>
 
     /// <summary>The job id of the run to read.</summary>
     public required string JobId { get; init; }
+
+    /// <summary>
+    /// Stable identifier of the caller reading the run. A run is only readable by the owner it was created
+    /// under; a mismatch is reported as not found, so a run cannot be read across callers. Resolved at the
+    /// transport boundary from the authenticated principal.
+    /// </summary>
+    public required string OwnerId { get; init; }
 }

--- a/src/Content/Application/Application.AI.Common/CQRS/Bundles/GetBundleRun/GetBundleRunQueryHandler.cs
+++ b/src/Content/Application/Application.AI.Common/CQRS/Bundles/GetBundleRun/GetBundleRunQueryHandler.cs
@@ -44,10 +44,12 @@ public sealed class GetBundleRunQueryHandler
         }
 
         var record = _jobStore.Get(request.JobId);
-        if (record is null || !string.Equals(record.Handle, request.Handle, StringComparison.Ordinal))
+        if (record is null
+            || !string.Equals(record.Handle, request.Handle, StringComparison.Ordinal)
+            || !string.Equals(record.OwnerId, request.OwnerId, StringComparison.Ordinal))
         {
             return Task.FromResult(Result<BundleRunRecord>.NotFound(
-                "Bundle run not found. It may never have existed, expired, or belongs to a different handle."));
+                "Bundle run not found. It may never have existed, expired, or belongs to a different caller."));
         }
 
         return Task.FromResult(Result<BundleRunRecord>.Success(record));

--- a/src/Content/Application/Application.AI.Common/CQRS/Bundles/RegisterBundle/RegisterBundleCommand.cs
+++ b/src/Content/Application/Application.AI.Common/CQRS/Bundles/RegisterBundle/RegisterBundleCommand.cs
@@ -21,4 +21,11 @@ public sealed record RegisterBundleCommand : IRequest<Result<RegisterBundleResul
     /// disposal. Its compressed length is enforced against the configured maximum while reading.
     /// </summary>
     public required Stream Archive { get; init; }
+
+    /// <summary>
+    /// Stable identifier of the caller registering the bundle. The resulting handle is bound to this owner,
+    /// so only the same caller can later run, read, or delete it — a leaked handle cannot be used across
+    /// callers. Resolved at the transport boundary from the authenticated principal.
+    /// </summary>
+    public required string OwnerId { get; init; }
 }

--- a/src/Content/Application/Application.AI.Common/CQRS/Bundles/RegisterBundle/RegisterBundleCommandHandler.cs
+++ b/src/Content/Application/Application.AI.Common/CQRS/Bundles/RegisterBundle/RegisterBundleCommandHandler.cs
@@ -66,11 +66,14 @@ public sealed class RegisterBundleCommandHandler
         var staged = await _stagingService.StageAsync(request.Archive, cancellationToken).ConfigureAwait(false);
         if (!staged.IsSuccess || staged.Value is null)
         {
-            // The staging service's reasons are already caller-safe (no internal paths); pass them through.
-            return Result<RegisterBundleResult>.Fail([.. staged.Errors]);
+            // A staging-guard failure (oversized, decompression bomb, path traversal, missing AGENT.md, …) is
+            // a rejection of the caller's uploaded archive — client-input validation, not a server error — so
+            // it is surfaced as a validation failure (HTTP 400). The staging service's reasons are already
+            // caller-safe (no internal paths), so they pass through verbatim.
+            return Result<RegisterBundleResult>.ValidationFailure([.. staged.Errors]);
         }
 
-        var handle = _handleStore.Register(staged.Value);
+        var handle = _handleStore.Register(staged.Value, request.OwnerId);
         var expiresAt = _time.GetUtcNow() + bundleConfig.HandleTtl;
 
         _logger.LogInformation(

--- a/src/Content/Application/Application.AI.Common/CQRS/Bundles/RunBundle/RunBundleCommand.cs
+++ b/src/Content/Application/Application.AI.Common/CQRS/Bundles/RunBundle/RunBundleCommand.cs
@@ -33,6 +33,13 @@ public sealed record RunBundleCommand : IRequest<Result<RunBundleResult>>
     /// <summary>The resolved per-caller capability grant this run executes under.</summary>
     public required CapabilityEnvelope Envelope { get; init; }
 
+    /// <summary>
+    /// Stable identifier of the caller starting the run. The run proceeds only if this matches the owner the
+    /// handle was registered under, so a caller can only run bundles they registered. Resolved at the
+    /// transport boundary from the authenticated principal.
+    /// </summary>
+    public required string OwnerId { get; init; }
+
     /// <summary>The maximum number of turns the conversation may run.</summary>
     public int MaxTurns { get; init; } = 10;
 }

--- a/src/Content/Application/Application.AI.Common/CQRS/Bundles/RunBundle/RunBundleCommandHandler.cs
+++ b/src/Content/Application/Application.AI.Common/CQRS/Bundles/RunBundle/RunBundleCommandHandler.cs
@@ -68,8 +68,12 @@ public sealed class RunBundleCommandHandler
                 "Bundle execution is disabled. Set AppConfig.AI.BundleExecution.Enabled = true to enable it.");
         }
 
-        var staged = _handleStore.TryGet(request.Handle);
-        if (staged is null)
+        // Owner check first: a caller can only run a handle they registered. A mismatch (or an absent handle)
+        // is reported identically as not found, so the endpoint never reveals that a handle exists for
+        // someone else.
+        var owner = _handleStore.GetOwner(request.Handle);
+        var staged = owner == request.OwnerId ? _handleStore.TryGet(request.Handle) : null;
+        if (owner != request.OwnerId || staged is null)
         {
             return Result<RunBundleResult>.NotFound(
                 "Bundle handle not found or expired. Register the bundle again to obtain a fresh handle.");
@@ -79,6 +83,7 @@ public sealed class RunBundleCommandHandler
         {
             JobId = Guid.NewGuid().ToString("N"),
             Handle = request.Handle,
+            OwnerId = request.OwnerId,
             AgentName = staged.Agent.Id,
             UserMessages = request.UserMessages,
             MaxTurns = request.MaxTurns,

--- a/src/Content/Application/Application.AI.Common/Interfaces/Bundles/IBundleHandleStore.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Bundles/IBundleHandleStore.cs
@@ -29,12 +29,25 @@ namespace Application.AI.Common.Interfaces.Bundles;
 public interface IBundleHandleStore
 {
     /// <summary>
-    /// Registers a freshly staged bundle and returns the opaque handle a caller uses to run or delete it.
-    /// The handle's initial expiry is <c>now + HandleTtl</c>.
+    /// Registers a freshly staged bundle under an owning caller and returns the opaque handle used to run or
+    /// delete it. The handle is bound to <paramref name="ownerId"/>; callers verify ownership via
+    /// <see cref="GetOwner"/> before acting on a handle, so a leaked handle cannot be used across callers. The
+    /// handle's initial expiry is <c>now + HandleTtl</c>.
     /// </summary>
     /// <param name="bundle">The staged bundle to hold. Its <see cref="StagedBundle.StagedRootDirectory"/> becomes owned by this store.</param>
+    /// <param name="ownerId">The stable identifier of the caller that owns this handle.</param>
     /// <returns>The handle identifying the registered bundle.</returns>
-    string Register(StagedBundle bundle);
+    string Register(StagedBundle bundle, string ownerId);
+
+    /// <summary>
+    /// Returns the owner the handle was registered under, or null when the handle is unknown or expired.
+    /// Callers compare this against the requesting caller to enforce per-owner isolation before running,
+    /// reading, or deleting a bundle. Does not refresh the sliding expiry — it is an authorization check, not
+    /// a use of the handle.
+    /// </summary>
+    /// <param name="handle">The handle to look up.</param>
+    /// <returns>The owner id, or null if the handle is unknown or expired.</returns>
+    string? GetOwner(string handle);
 
     /// <summary>
     /// Reads the staged bundle for <paramref name="handle"/> without pinning it, refreshing its sliding

--- a/src/Content/Domain/Domain.AI/Bundles/BundleRunRecord.cs
+++ b/src/Content/Domain/Domain.AI/Bundles/BundleRunRecord.cs
@@ -37,6 +37,13 @@ public sealed record BundleRunRecord
     public required string Handle { get; init; }
 
     /// <summary>
+    /// Stable identifier of the caller that created this run. Only this owner may poll the run; the poll
+    /// query rejects a mismatch as not found, so a run's result cannot be read across callers even if the
+    /// job id leaks.
+    /// </summary>
+    public required string OwnerId { get; init; }
+
+    /// <summary>
     /// The ephemeral agent's id (its <c>AGENT.md</c> id), captured from the staged bundle at enqueue time
     /// so the dispatcher can name it to <c>RunConversationCommand</c> without re-reading the bundle.
     /// </summary>

--- a/src/Content/Domain/Domain.Common/Config/AI/BundleExecution/BundleApiAuthConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/BundleExecution/BundleApiAuthConfig.cs
@@ -1,0 +1,57 @@
+namespace Domain.Common.Config.AI.BundleExecution;
+
+/// <summary>
+/// Authentication configuration for the standalone <c>Presentation.BundleApi</c> host — the HTTP front door
+/// through which an external system registers and runs agent bundles. Bound from
+/// <c>AppConfig:AI:BundleExecution:Auth</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The bundle API runs externally-authored agents, so it is deliberately isolated behind its <em>own</em>
+/// authentication audience — never sharing a credential surface with the MCP server or the agent hub. This
+/// config carries the Entra ID identifiers that identify that audience.
+/// </para>
+/// <para>
+/// <strong>Fail-closed.</strong> The host refuses to start unless either a valid scheme is configured
+/// (<see cref="IsConfigured"/>) or a developer has consciously opted into anonymous serving
+/// (<see cref="AllowAnonymous"/>). Running under <c>Environment=Development</c> alone never disables
+/// authentication — the opt-in is explicit and logged loudly at startup.
+/// </para>
+/// </remarks>
+public sealed class BundleApiAuthConfig
+{
+    /// <summary>
+    /// The Entra ID tenant whose tokens the host accepts. Combined with <see cref="ClientId"/> to validate
+    /// the issuer and audience of inbound bearer tokens. Required for a configured scheme.
+    /// </summary>
+    public string? TenantId { get; set; }
+
+    /// <summary>
+    /// The Entra ID application (client) id that identifies this API's audience. Inbound tokens must target
+    /// <c>api://&lt;ClientId&gt;</c>. This is the host's own audience — distinct from every other service's.
+    /// Required for a configured scheme.
+    /// </summary>
+    public string? ClientId { get; set; }
+
+    /// <summary>
+    /// Explicit opt-in that lets the host serve anonymously when no scheme is configured. Default
+    /// <c>false</c> — the host is fail-closed and refuses to start without authentication in every
+    /// environment. A developer must consciously set this for local work, and the host logs a prominent
+    /// warning at startup while it is on.
+    /// </summary>
+    public bool AllowAnonymous { get; set; }
+
+    /// <summary>Whether a token-validation scheme is configured (both tenant and client id supplied).</summary>
+    public bool IsConfigured =>
+        !string.IsNullOrWhiteSpace(TenantId) && !string.IsNullOrWhiteSpace(ClientId);
+
+    /// <summary>
+    /// Whether exactly one of <see cref="TenantId"/>/<see cref="ClientId"/> is supplied — a half-configured
+    /// scheme. This is treated as a misconfiguration the host refuses to start on, rather than silently
+    /// falling through to the anonymous path: an operator who set a tenant plainly intended real auth, so a
+    /// forgotten client id (or vice versa) must fail loudly, not boot the door open.
+    /// </summary>
+    public bool IsPartiallyConfigured =>
+        !IsConfigured
+        && (!string.IsNullOrWhiteSpace(TenantId) || !string.IsNullOrWhiteSpace(ClientId));
+}

--- a/src/Content/Domain/Domain.Common/Config/AI/BundleExecution/BundleExecutionConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/BundleExecution/BundleExecutionConfig.cs
@@ -107,4 +107,12 @@ public class BundleExecutionConfig
     /// </summary>
     /// <value>Default: 60 seconds</value>
     public TimeSpan CleanupInterval { get; set; } = TimeSpan.FromSeconds(60);
+
+    /// <summary>
+    /// Authentication for the standalone <c>Presentation.BundleApi</c> HTTP host. The bundle API is isolated
+    /// behind its own authentication audience (it runs externally-authored agents); this section carries that
+    /// audience's Entra identifiers. Fail-closed: the host refuses to start unless a scheme is configured or
+    /// anonymous serving is explicitly opted into. Only consulted by the bundle API host.
+    /// </summary>
+    public BundleApiAuthConfig Auth { get; set; } = new();
 }

--- a/src/Content/Infrastructure/Infrastructure.AI/Bundles/InMemoryBundleHandleStore.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Bundles/InMemoryBundleHandleStore.cs
@@ -31,9 +31,10 @@ namespace Infrastructure.AI.Bundles;
 /// </remarks>
 public sealed class InMemoryBundleHandleStore : IBundleHandleStore, IDisposable
 {
-    private sealed class HandleEntry(StagedBundle bundle)
+    private sealed class HandleEntry(StagedBundle bundle, string ownerId)
     {
         public StagedBundle Bundle { get; } = bundle;
+        public string OwnerId { get; } = ownerId;
         public DateTimeOffset ExpiresAt { get; set; }
         public int LeaseCount { get; set; }
         public bool Removed { get; set; }
@@ -63,14 +64,28 @@ public sealed class InMemoryBundleHandleStore : IBundleHandleStore, IDisposable
     private TimeSpan Ttl => _config.CurrentValue.AI.BundleExecution.HandleTtl;
 
     /// <inheritdoc />
-    public string Register(StagedBundle bundle)
+    public string Register(StagedBundle bundle, string ownerId)
     {
         ArgumentNullException.ThrowIfNull(bundle);
+        ArgumentException.ThrowIfNullOrEmpty(ownerId);
 
         var handle = bundle.BundleId;
-        var entry = new HandleEntry(bundle) { ExpiresAt = _time.GetUtcNow() + Ttl };
+        var entry = new HandleEntry(bundle, ownerId) { ExpiresAt = _time.GetUtcNow() + Ttl };
         _entries[handle] = entry;
         return handle;
+    }
+
+    /// <inheritdoc />
+    public string? GetOwner(string handle)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(handle);
+        if (!_entries.TryGetValue(handle, out var entry))
+            return null;
+
+        lock (entry)
+        {
+            return IsLive(entry) ? entry.OwnerId : null;
+        }
     }
 
     /// <inheritdoc />

--- a/src/Content/Presentation/Presentation.BundleApi/Controllers/BundlesController.cs
+++ b/src/Content/Presentation/Presentation.BundleApi/Controllers/BundlesController.cs
@@ -1,0 +1,186 @@
+using Application.AI.Common.CQRS.Bundles.DeleteBundle;
+using Application.AI.Common.CQRS.Bundles.GetBundleRun;
+using Application.AI.Common.CQRS.Bundles.RegisterBundle;
+using Application.AI.Common.CQRS.Bundles.RunBundle;
+using Application.AI.Common.Interfaces.Governance;
+using Domain.Common;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+using Presentation.BundleApi.DTOs;
+using Presentation.BundleApi.Extensions;
+using Presentation.BundleApi.Services;
+
+namespace Presentation.BundleApi.Controllers;
+
+/// <summary>
+/// REST surface for registering and running externally-authored agent bundles. Every endpoint dispatches via
+/// MediatR so the pipeline behaviors (validation, audit) wrap each call, and the whole controller requires an
+/// authenticated caller — the capability envelope resolved from that caller's identity is what confines a
+/// run, so authentication is the load-bearing gate.
+/// </summary>
+/// <remarks>
+/// The run endpoint resolves the caller's capability envelope <em>here</em>, at the transport boundary, and
+/// passes it into the run command: a run therefore executes under the grant of the credential that
+/// <em>invoked</em> it, never the one that registered the handle, so a leaked handle cannot escalate.
+/// </remarks>
+[ApiController]
+[Route("api/bundles")]
+[Authorize]
+[EnableRateLimiting(BundleApiServiceCollectionExtensions.DefaultRateLimitPolicy)]
+public sealed class BundlesController : ControllerBase
+{
+    private readonly IMediator _mediator;
+    private readonly ICapabilityEnvelopeResolver _envelopeResolver;
+
+    /// <summary>Initializes the controller with its MediatR and envelope-resolver dependencies.</summary>
+    public BundlesController(IMediator mediator, ICapabilityEnvelopeResolver envelopeResolver)
+    {
+        ArgumentNullException.ThrowIfNull(mediator);
+        ArgumentNullException.ThrowIfNull(envelopeResolver);
+        _mediator = mediator;
+        _envelopeResolver = envelopeResolver;
+    }
+
+    /// <summary>Registers a bundle archive (multipart upload), returning a short-lived handle.</summary>
+    [HttpPost]
+    [EnableRateLimiting(BundleApiServiceCollectionExtensions.RegisterRateLimitPolicy)]
+    [ProducesResponseType(typeof(RegisterBundleResponse), StatusCodes.Status201Created)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<IActionResult> Register(IFormFile file, CancellationToken cancellationToken)
+    {
+        if (file is null || file.Length == 0)
+            return Problem(title: "Validation failed", detail: "A non-empty bundle archive file is required.",
+                statusCode: StatusCodes.Status400BadRequest);
+
+        var callerId = ResolveCallerId();
+        if (callerId is null)
+            return NoUsableIdentity();
+
+        await using var stream = file.OpenReadStream();
+        var result = await _mediator
+            .Send(new RegisterBundleCommand { Archive = stream, OwnerId = callerId }, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (!result.IsSuccess || result.Value is null)
+            return MapFailure(result.FailureType, result.Errors);
+
+        var response = new RegisterBundleResponse { Handle = result.Value.Handle, ExpiresAt = result.Value.ExpiresAt };
+        return Created($"/api/bundles/{response.Handle}", response);
+    }
+
+    /// <summary>Starts an asynchronous run of a staged bundle, returning a job id to poll.</summary>
+    [HttpPost("{handle}/runs")]
+    [ProducesResponseType(typeof(StartRunResponse), StatusCodes.Status202Accepted)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> Run(
+        string handle, [FromBody] RunBundleRequest request, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var callerId = ResolveCallerId();
+        if (callerId is null)
+            return NoUsableIdentity();
+
+        // Resolve the per-caller grant at the transport boundary from the authenticated principal.
+        var envelope = _envelopeResolver.Resolve(User);
+
+        var result = await _mediator.Send(new RunBundleCommand
+        {
+            Handle = handle,
+            UserMessages = request.UserMessages,
+            MaxTurns = request.MaxTurns,
+            Envelope = envelope,
+            OwnerId = callerId
+        }, cancellationToken).ConfigureAwait(false);
+
+        if (!result.IsSuccess || result.Value is null)
+            return MapFailure(result.FailureType, result.Errors);
+
+        var statusUrl = $"/api/bundles/{handle}/runs/{result.Value.JobId}";
+        return Accepted(statusUrl, new StartRunResponse { JobId = result.Value.JobId, StatusUrl = statusUrl });
+    }
+
+    /// <summary>Reads the current status and (once complete) result of a run.</summary>
+    [HttpGet("{handle}/runs/{jobId}")]
+    [ProducesResponseType(typeof(BundleRunResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> GetRun(string handle, string jobId, CancellationToken cancellationToken)
+    {
+        var callerId = ResolveCallerId();
+        if (callerId is null)
+            return NoUsableIdentity();
+
+        var result = await _mediator
+            .Send(new GetBundleRunQuery { Handle = handle, JobId = jobId, OwnerId = callerId }, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (!result.IsSuccess || result.Value is null)
+            return MapFailure(result.FailureType, result.Errors);
+
+        return Ok(BundleRunResponse.FromRecord(result.Value));
+    }
+
+    /// <summary>Explicitly deletes a staged bundle (TTL also reclaims it). Idempotent.</summary>
+    [HttpDelete("{handle}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<IActionResult> Delete(string handle, CancellationToken cancellationToken)
+    {
+        var callerId = ResolveCallerId();
+        if (callerId is null)
+            return NoUsableIdentity();
+
+        var result = await _mediator
+            .Send(new DeleteBundleCommand { Handle = handle, OwnerId = callerId }, cancellationToken)
+            .ConfigureAwait(false);
+
+        return result.IsSuccess ? NoContent() : MapFailure(result.FailureType, result.Errors);
+    }
+
+    /// <summary>
+    /// Resolves a stable identifier for the calling principal, used to bind and authorize bundle handles and
+    /// runs per owner. Prefers the Entra object id (<c>oid</c>, stable per user across tokens), then the
+    /// subject (<c>sub</c>/name-identifier), then the name. In the anonymous development mode every request
+    /// carries the same synthetic principal, so all callers share one owner — there is no cross-caller
+    /// isolation without real authentication, by design.
+    /// </summary>
+    private string? ResolveCallerId() =>
+        BundleCallerIdentity.StableId(User) ?? NullIfBlank(User.Identity?.Name);
+
+    private static string? NullIfBlank(string? value) => string.IsNullOrWhiteSpace(value) ? null : value;
+
+    /// <summary>401 response when the authenticated principal has no usable identity to own resources under.</summary>
+    private IActionResult NoUsableIdentity() => Problem(
+        title: "Unauthorized",
+        detail: "The authenticated principal carries no usable identity.",
+        statusCode: StatusCodes.Status401Unauthorized);
+
+    /// <summary>
+    /// Maps a failed <see cref="Result"/>/<see cref="Result{T}"/> to an HTTP problem response. Validation,
+    /// NotFound, and auth reasons are safe to surface verbatim (validator strings / lookups / declared
+    /// reasons); a general failure returns a generic message only — handlers have already logged the detail,
+    /// and raw error text can leak internal state. Mirrors the mapping used by the harness's other controllers.
+    /// </summary>
+    private IActionResult MapFailure(ResultFailureType failureType, IReadOnlyList<string> errors) => failureType switch
+    {
+        ResultFailureType.NotFound => Problem(
+            title: "Not Found", detail: string.Join(" / ", errors), statusCode: StatusCodes.Status404NotFound),
+        ResultFailureType.Validation => Problem(
+            title: "Validation failed", detail: string.Join(" / ", errors), statusCode: StatusCodes.Status400BadRequest),
+        ResultFailureType.Unauthorized => Problem(
+            title: "Unauthorized", detail: string.Join(" / ", errors), statusCode: StatusCodes.Status401Unauthorized),
+        ResultFailureType.Forbidden => Problem(
+            title: "Forbidden", detail: string.Join(" / ", errors), statusCode: StatusCodes.Status403Forbidden),
+        _ => Problem(
+            title: "Bundle operation failed",
+            detail: "An error occurred processing the request. See server logs for details.",
+            statusCode: StatusCodes.Status500InternalServerError),
+    };
+}

--- a/src/Content/Presentation/Presentation.BundleApi/DTOs/BundleApiContracts.cs
+++ b/src/Content/Presentation/Presentation.BundleApi/DTOs/BundleApiContracts.cs
@@ -1,0 +1,107 @@
+using Domain.AI.Bundles;
+
+namespace Presentation.BundleApi.DTOs;
+
+/// <summary>Response to a successful bundle registration.</summary>
+public sealed record RegisterBundleResponse
+{
+    /// <summary>The opaque handle used to run or delete the staged bundle.</summary>
+    public required string Handle { get; init; }
+
+    /// <summary>The earliest instant the handle expires if it is not used again before then.</summary>
+    public required DateTimeOffset ExpiresAt { get; init; }
+}
+
+/// <summary>Request body for starting a bundle run.</summary>
+public sealed record RunBundleRequest
+{
+    /// <summary>The user messages seeding the conversation. One turn per message, bounded by <see cref="MaxTurns"/>.</summary>
+    public IReadOnlyList<string> UserMessages { get; init; } = [];
+
+    /// <summary>The maximum number of turns the conversation may run. Defaults to 10.</summary>
+    public int MaxTurns { get; init; } = 10;
+}
+
+/// <summary>Response to a successfully queued bundle run.</summary>
+public sealed record StartRunResponse
+{
+    /// <summary>The opaque id of the queued run job.</summary>
+    public required string JobId { get; init; }
+
+    /// <summary>Relative URL to poll for the run's status and result.</summary>
+    public required string StatusUrl { get; init; }
+}
+
+/// <summary>
+/// The pollable view of a bundle run. Deliberately a projection of the internal <see cref="BundleRunRecord"/>:
+/// it never surfaces the capability envelope, the seed messages, or any other execution input — only the
+/// run's lifecycle state and, once complete, its outcome.
+/// </summary>
+public sealed record BundleRunResponse
+{
+    /// <summary>The run's job id.</summary>
+    public required string JobId { get; init; }
+
+    /// <summary>The current lifecycle state (Queued, Running, Succeeded, Failed).</summary>
+    public required string Status { get; init; }
+
+    /// <summary>A caller-safe reason when the run failed outright; null otherwise.</summary>
+    public string? Error { get; init; }
+
+    /// <summary>When the run was created and queued.</summary>
+    public required DateTimeOffset CreatedAt { get; init; }
+
+    /// <summary>When execution began; null while still queued.</summary>
+    public DateTimeOffset? StartedAt { get; init; }
+
+    /// <summary>When the run reached a terminal state; null before then.</summary>
+    public DateTimeOffset? CompletedAt { get; init; }
+
+    /// <summary>The run outcome once it has succeeded; null before then.</summary>
+    public BundleRunOutcomeResponse? Result { get; init; }
+
+    /// <summary>Projects an internal run record onto the pollable response, dropping all execution inputs.</summary>
+    public static BundleRunResponse FromRecord(BundleRunRecord record) => new()
+    {
+        JobId = record.JobId,
+        Status = record.Status.ToString(),
+        Error = record.Error,
+        CreatedAt = record.CreatedAt,
+        StartedAt = record.StartedAt,
+        CompletedAt = record.CompletedAt,
+        Result = record.Outcome is null ? null : BundleRunOutcomeResponse.FromOutcome(record.Outcome)
+    };
+}
+
+/// <summary>The terminal outcome of a bundle run, as surfaced to a poller.</summary>
+public sealed record BundleRunOutcomeResponse
+{
+    /// <summary>Whether the conversation itself reported success (distinct from the run completing).</summary>
+    public required bool ConversationSucceeded { get; init; }
+
+    /// <summary>The final agent response, or empty when none was produced.</summary>
+    public required string FinalResponse { get; init; }
+
+    /// <summary>The number of turns that executed.</summary>
+    public required int TurnCount { get; init; }
+
+    /// <summary>The total number of tool invocations across all turns.</summary>
+    public required int TotalToolInvocations { get; init; }
+
+    /// <summary>Whether the conversation stopped early on its lifetime token budget.</summary>
+    public bool BudgetExhausted { get; init; }
+
+    /// <summary>The conversation-level error when <see cref="ConversationSucceeded"/> is false; null otherwise.</summary>
+    public string? ConversationError { get; init; }
+
+    /// <summary>Projects an internal outcome onto the response shape.</summary>
+    public static BundleRunOutcomeResponse FromOutcome(BundleRunOutcome outcome) => new()
+    {
+        ConversationSucceeded = outcome.ConversationSucceeded,
+        FinalResponse = outcome.FinalResponse,
+        TurnCount = outcome.TurnCount,
+        TotalToolInvocations = outcome.TotalToolInvocations,
+        BudgetExhausted = outcome.BudgetExhausted,
+        ConversationError = outcome.ConversationError
+    };
+}

--- a/src/Content/Presentation/Presentation.BundleApi/Extensions/BundleApiServiceCollectionExtensions.cs
+++ b/src/Content/Presentation/Presentation.BundleApi/Extensions/BundleApiServiceCollectionExtensions.cs
@@ -1,0 +1,180 @@
+using System.Text.Json.Serialization;
+using System.Threading.RateLimiting;
+using Domain.Common.Config.AI.BundleExecution;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.IdentityModel.Tokens;
+using Presentation.BundleApi.Services;
+
+namespace Presentation.BundleApi.Extensions;
+
+/// <summary>
+/// Host-specific service registration for <c>Presentation.BundleApi</c>: controllers, the fail-closed
+/// authentication scheme (its own audience), authorization, and per-path rate limiting. The cross-layer
+/// wiring (MediatR handlers, bundle stores, background services) is composed separately by
+/// <c>Presentation.Common</c>'s <c>GetServices</c>, exactly as the other hosts do.
+/// </summary>
+public static class BundleApiServiceCollectionExtensions
+{
+    /// <summary>Rate-limit policy applied to the whole controller (run, poll, delete).</summary>
+    public const string DefaultRateLimitPolicy = "bundles";
+
+    /// <summary>Stricter rate-limit policy for registration — staging an archive is comparatively expensive.</summary>
+    public const string RegisterRateLimitPolicy = "bundles-register";
+
+    /// <summary>
+    /// Registers the bundle API's controllers, authentication, authorization, and rate limiters.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="configuration">Configuration, read for <c>AppConfig:AI:BundleExecution:Auth</c>.</param>
+    public static IServiceCollection AddBundleApiServices(
+        this IServiceCollection services, IConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        services
+            .AddControllers()
+            .AddJsonOptions(options =>
+                // Serialize BundleRunStatus and friends as their names, not ordinals, so the poll contract
+                // is human-readable and stable against enum renumbering.
+                options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter()));
+
+        var bundleConfig = configuration
+            .GetSection("AppConfig:AI:BundleExecution")
+            .Get<BundleExecutionConfig>() ?? new BundleExecutionConfig();
+
+        services.AddBundleApiAuthentication(bundleConfig.Auth);
+
+        // Bound the multipart upload at the transport boundary to the same limit the staging service enforces,
+        // so an oversized archive is rejected before MVC buffers the whole body to a temp file — the app's
+        // declared MaxArchiveBytes is the first line of defence, not a post-buffering afterthought.
+        services.Configure<FormOptions>(options =>
+            options.MultipartBodyLengthLimit = bundleConfig.MaxArchiveBytes);
+
+        services.AddRateLimiter(options =>
+        {
+            options.AddPolicy(DefaultRateLimitPolicy, httpContext =>
+                RateLimitPartition.GetFixedWindowLimiter(ResolvePartitionKey(httpContext), _ =>
+                    new FixedWindowRateLimiterOptions { PermitLimit = 60, Window = TimeSpan.FromMinutes(1) }));
+
+            options.AddPolicy(RegisterRateLimitPolicy, httpContext =>
+                RateLimitPartition.GetFixedWindowLimiter(ResolvePartitionKey(httpContext), _ =>
+                    new FixedWindowRateLimiterOptions { PermitLimit = 10, Window = TimeSpan.FromMinutes(1) }));
+        });
+
+        return services;
+    }
+
+    /// <summary>
+    /// Partitions the rate limiter per caller so one client cannot exhaust a shared global window and starve
+    /// every other caller. Keys on the caller's stable, per-principal-unique id (never the non-unique display
+    /// name), falling back to the remote IP — the only distinguishing signal in the anonymous dev mode, where
+    /// every request shares one synthetic principal — then a constant last resort.
+    /// </summary>
+    private static string ResolvePartitionKey(HttpContext httpContext)
+    {
+        var stableId = BundleCallerIdentity.StableId(httpContext.User);
+        if (stableId is not null)
+            return $"user:{stableId}";
+
+        var ip = httpContext.Connection.RemoteIpAddress?.ToString();
+        return string.IsNullOrWhiteSpace(ip) ? "unknown" : $"ip:{ip}";
+    }
+
+    /// <summary>
+    /// Installs the bundle API's authentication scheme, fail-closed. The host refuses to start unless a valid
+    /// Entra scheme is configured or a developer has consciously opted into anonymous serving.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="auth">The bundle API auth configuration.</param>
+    /// <exception cref="InvalidOperationException">
+    /// Authentication is unconfigured without the anonymous opt-in, or the anonymous opt-in is contradictorily
+    /// combined with a configured scheme.
+    /// </exception>
+    public static IServiceCollection AddBundleApiAuthentication(
+        this IServiceCollection services, BundleApiAuthConfig auth)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(auth);
+
+        if (auth.AllowAnonymous && auth.IsConfigured)
+            throw new InvalidOperationException(
+                "AppConfig:AI:BundleExecution:Auth is contradictory: AllowAnonymous=true cannot be combined " +
+                "with a configured scheme (TenantId + ClientId). Remove AllowAnonymous to enforce the scheme, " +
+                "or clear TenantId/ClientId to run anonymously.");
+
+        // A half-configured scheme (exactly one of TenantId/ClientId) is a misconfiguration, not an implicit
+        // request to serve anonymously — fail closed so a forgotten identifier never silently opens the door.
+        if (auth.IsPartiallyConfigured)
+            throw new InvalidOperationException(
+                "AppConfig:AI:BundleExecution:Auth is half-configured — exactly one of TenantId/ClientId is set. " +
+                "Supply BOTH to enforce Entra validation, or clear both (and set AllowAnonymous=true for local " +
+                "development) to serve anonymously. Refusing to start (fail-closed).");
+
+        if (!auth.IsConfigured)
+        {
+            if (!auth.AllowAnonymous)
+                throw new InvalidOperationException(
+                    "Bundle API authentication is not configured — refusing to start (fail-closed). Set " +
+                    "AppConfig:AI:BundleExecution:Auth:TenantId and :ClientId to this API's own Entra audience. " +
+                    "For local development only, authentication can be consciously disabled with " +
+                    "AppConfig:AI:BundleExecution:Auth:AllowAnonymous=true; running under Environment=Development " +
+                    "alone does not disable it.");
+
+            // Explicit anonymous opt-in — boot open, loudly. A permissive handler authenticates every
+            // request as a synthetic principal so the controller's [Authorize] is satisfied; the capability
+            // envelope still resolves to the fail-closed default (no subject), so an anonymous run is confined.
+            services
+                .AddAuthentication(AnonymousAuthenticationHandler.SchemeName)
+                .AddScheme<AuthenticationSchemeOptions, AnonymousAuthenticationHandler>(
+                    AnonymousAuthenticationHandler.SchemeName, _ => { });
+            services.AddAuthorization();
+            services.AddHostedService<BundleApiAnonymousModeStartupWarning>();
+            return services;
+        }
+
+        var authority = $"https://login.microsoftonline.com/{auth.TenantId}/v2.0";
+        var audience = $"api://{auth.ClientId}";
+
+        services
+            .AddAuthentication(options =>
+            {
+                options.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
+                options.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
+            })
+            .AddJwtBearer(options =>
+            {
+                options.Authority = authority;
+                options.Audience = audience;
+                options.TokenValidationParameters = new TokenValidationParameters
+                {
+                    ValidateIssuer = true,
+                    ValidIssuers =
+                    [
+                        $"https://sts.windows.net/{auth.TenantId}/",
+                        $"https://login.microsoftonline.com/{auth.TenantId}/v2.0"
+                    ],
+                    ValidateAudience = true,
+                    ValidAudience = audience,
+                    ValidateLifetime = true,
+                    ValidateIssuerSigningKey = true,
+                    ClockSkew = TimeSpan.Zero // repo security baseline: no grace window
+                };
+            });
+
+        // Fallback policy closes the unmapped-endpoint gap: any endpoint added without explicit authorization
+        // metadata still requires an authenticated caller.
+        services.AddAuthorization(options =>
+            options.FallbackPolicy = new AuthorizationPolicyBuilder()
+                .RequireAuthenticatedUser()
+                .Build());
+
+        return services;
+    }
+}

--- a/src/Content/Presentation/Presentation.BundleApi/Presentation.BundleApi.csproj
+++ b/src/Content/Presentation/Presentation.BundleApi/Presentation.BundleApi.csproj
@@ -1,0 +1,37 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RootNamespace>Presentation.BundleApi</RootNamespace>
+    <AssemblyName>Presentation.BundleApi</AssemblyName>
+    <UserSecretsId>agentic-harness-bundle-api</UserSecretsId>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="appsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="appsettings.Development.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>Presentation.BundleApi.Tests</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Application\Application.AI.Common\Application.AI.Common.csproj" />
+    <ProjectReference Include="..\..\Domain\Domain.AI\Domain.AI.csproj" />
+    <ProjectReference Include="..\..\Domain\Domain.Common\Domain.Common.csproj" />
+    <ProjectReference Include="..\Presentation.Common\Presentation.Common.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Content/Presentation/Presentation.BundleApi/Program.cs
+++ b/src/Content/Presentation/Presentation.BundleApi/Program.cs
@@ -1,0 +1,46 @@
+using Presentation.BundleApi.Extensions;
+using Presentation.Common.Extensions;
+
+var builder = WebApplication.CreateBuilder(args);
+
+// Composition root — binds AppConfig and wires every Application + Infrastructure layer, including the bundle
+// command/query handlers, the in-memory handle/job stores, the dispatch queue, and the background dispatcher
+// + cleanup sweeper. This one call is what makes the bundle endpoints resolve end-to-end. HealthChecks UI is
+// off: this is a lean, headless API host.
+builder.Services.GetServices(includeHealthChecksUI: false);
+
+// Host-specific wiring: controllers, the fail-closed authentication scheme (its own audience), authorization,
+// and per-path rate limiting.
+builder.Services.AddBundleApiServices(builder.Configuration);
+
+// Enforce the harness's boot-time DI validation policy (ValidateScopes + ValidateOnBuild) in ALL environments,
+// single-sourced so hosts cannot drift: it catches captive dependencies and turns a mis-wired handler into a
+// caught-at-startup failure rather than a first-dispatch crash.
+builder.Host.UseDefaultServiceProvider(
+    Presentation.Common.Extensions.IServiceCollectionExtensions.ApplyValidationPolicy);
+
+var app = builder.Build();
+
+// Middleware pipeline — order is not negotiable. Security headers and exception handling run before routing
+// so every response is covered; rate limiting runs after authentication so per-caller partitions can see the
+// authenticated principal.
+app.UseSecurityHeadersMiddleware();
+app.UseGlobalExceptionMiddleware();
+if (!app.Environment.IsDevelopment())
+{
+    app.UseHsts();
+    app.UseHttpsRedirection();
+}
+app.UseRouting();
+app.UseAuthentication();
+app.UseAuthorization();
+app.UseRateLimiter();
+app.MapControllers();
+
+app.Run();
+
+/// <summary>
+/// Exposes <c>Program</c> as a public partial class so <c>WebApplicationFactory&lt;Program&gt;</c> can host the
+/// full bundle-API pipeline from the integration test project.
+/// </summary>
+public partial class Program { }

--- a/src/Content/Presentation/Presentation.BundleApi/Services/AnonymousAuthenticationHandler.cs
+++ b/src/Content/Presentation/Presentation.BundleApi/Services/AnonymousAuthenticationHandler.cs
@@ -1,0 +1,40 @@
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Presentation.BundleApi.Services;
+
+/// <summary>
+/// Authentication handler used only in the explicit anonymous opt-in
+/// (<c>AppConfig:AI:BundleExecution:Auth:AllowAnonymous=true</c>). It authenticates every request as a fixed
+/// synthetic development principal, so the controller's <c>[Authorize]</c> is satisfied while no real identity
+/// is required. The capability-envelope resolver then resolves this principal to the fail-closed default
+/// grant (it carries no subject), so an anonymous run is still confined — the door is open, but the room is
+/// empty. Never registered when a real scheme is configured.
+/// </summary>
+public sealed class AnonymousAuthenticationHandler : AuthenticationHandler<AuthenticationSchemeOptions>
+{
+    /// <summary>The scheme name under which this handler is registered.</summary>
+    public const string SchemeName = "BundleApiAnonymous";
+
+    /// <summary>Initializes a new <see cref="AnonymousAuthenticationHandler"/>.</summary>
+    public AnonymousAuthenticationHandler(
+        IOptionsMonitor<AuthenticationSchemeOptions> options,
+        ILoggerFactory logger,
+        UrlEncoder encoder)
+        : base(options, logger, encoder)
+    {
+    }
+
+    /// <inheritdoc />
+    protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+    {
+        var identity = new ClaimsIdentity(
+            [new Claim(ClaimTypes.Name, "anonymous-dev")], SchemeName);
+        var principal = new ClaimsPrincipal(identity);
+        var ticket = new AuthenticationTicket(principal, SchemeName);
+        return Task.FromResult(AuthenticateResult.Success(ticket));
+    }
+}

--- a/src/Content/Presentation/Presentation.BundleApi/Services/BundleApiAnonymousModeStartupWarning.cs
+++ b/src/Content/Presentation/Presentation.BundleApi/Services/BundleApiAnonymousModeStartupWarning.cs
@@ -1,0 +1,33 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Presentation.BundleApi.Services;
+
+/// <summary>
+/// Emits a prominent warning at startup while the bundle API is serving without authentication (the explicit
+/// <c>AppConfig:AI:BundleExecution:Auth:AllowAnonymous</c> opt-in). Makes the open-door state impossible to
+/// miss in logs, so an anonymous deployment is a conscious, visible choice rather than a silent oversight.
+/// </summary>
+internal sealed class BundleApiAnonymousModeStartupWarning : IHostedService
+{
+    private readonly ILogger<BundleApiAnonymousModeStartupWarning> _logger;
+
+    /// <summary>Initializes a new <see cref="BundleApiAnonymousModeStartupWarning"/>.</summary>
+    public BundleApiAnonymousModeStartupWarning(ILogger<BundleApiAnonymousModeStartupWarning> logger)
+    {
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        _logger.LogWarning(
+            "Bundle API is running WITHOUT authentication (AppConfig:AI:BundleExecution:Auth:AllowAnonymous=true). " +
+            "Every caller is anonymous and the per-caller capability envelope resolves from an unauthenticated " +
+            "principal. This is intended for local development only — never enable it in a shared or production host.");
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}

--- a/src/Content/Presentation/Presentation.BundleApi/Services/BundleCallerIdentity.cs
+++ b/src/Content/Presentation/Presentation.BundleApi/Services/BundleCallerIdentity.cs
@@ -1,0 +1,31 @@
+using System.Security.Claims;
+
+namespace Presentation.BundleApi.Services;
+
+/// <summary>
+/// Resolves a stable per-caller identifier from an authenticated principal, used to bind bundle handles/runs
+/// to their owner and to partition the rate limiter. Prefers identifiers that are guaranteed unique per
+/// principal within the tenant — the Entra object id (<c>oid</c>) then the subject (<c>sub</c>/name-identifier)
+/// — and deliberately excludes the display name (<c>name</c>), which is not unique.
+/// </summary>
+public static class BundleCallerIdentity
+{
+    /// <summary>
+    /// Returns a stable, per-principal-unique identifier, or null when the principal carries none. A null
+    /// result means the caller has no durable identity to own resources under: callers treat that as a
+    /// rejection rather than bucketing the caller into a shared identity.
+    /// </summary>
+    /// <param name="principal">The authenticated principal.</param>
+    public static string? StableId(ClaimsPrincipal principal)
+    {
+        ArgumentNullException.ThrowIfNull(principal);
+
+        return NullIfBlank(principal.FindFirstValue("oid"))
+            ?? NullIfBlank(principal.FindFirstValue("http://schemas.microsoft.com/identity/claims/objectidentifier"))
+            ?? NullIfBlank(principal.FindFirstValue(ClaimTypes.NameIdentifier))
+            ?? NullIfBlank(principal.FindFirstValue("sub"));
+    }
+
+    private static string? NullIfBlank(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? null : value;
+}

--- a/src/Content/Presentation/Presentation.BundleApi/appsettings.Development.json
+++ b/src/Content/Presentation/Presentation.BundleApi/appsettings.Development.json
@@ -1,0 +1,11 @@
+{
+  "AppConfig": {
+    "AI": {
+      "BundleExecution": {
+        "Auth": {
+          "AllowAnonymous": true
+        }
+      }
+    }
+  }
+}

--- a/src/Content/Presentation/Presentation.BundleApi/appsettings.json
+++ b/src/Content/Presentation/Presentation.BundleApi/appsettings.json
@@ -1,0 +1,72 @@
+{
+  "AppConfig": {
+    "Common": {
+      "SlowThresholdSec": 5
+    },
+    "Logging": {
+      "LogsBasePath": "logs",
+      "PipeName": "AgenticHarnessLogs.BundleApi",
+      "SuppressConsoleOutput": false
+    },
+    "Agent": {
+      "DefaultTokenBudget": 128000
+    },
+    "Infrastructure": {
+      "FileSystem": {
+        "AllowedBasePaths": [ "workspace" ]
+      }
+    },
+    "AI": {
+      "AgentFramework": {
+        "DefaultDeployment": "gpt-4o",
+        "ClientType": "FoundryResponses"
+      },
+      "AIFoundry": {
+        "ProjectEndpoint": ""
+      },
+      "Governance": {
+        "Enabled": true,
+        "PolicyPaths": [ "Policies/default-policy.yaml" ],
+        "EnablePromptInjectionDetection": true,
+        "EnableMcpSecurity": true,
+        "EnableAudit": true,
+        "EnableMetrics": true,
+        "InjectionBlockThreshold": "High",
+        "Escalation": {
+          "Enabled": true,
+          "DefaultTimeoutSeconds": 300,
+          "DefaultTimeoutAction": "DenyAndEscalate",
+          "DefaultApprovalStrategy": "AnyOf",
+          "AuditStoragePath": ".agent-sessions/escalations",
+          "PriorityLevels": {
+            "Informational": { "TimeoutSeconds": 0, "Async": true, "EscalateToAll": false },
+            "Blocking": { "TimeoutSeconds": 300, "Async": false, "EscalateToAll": false },
+            "Critical": { "TimeoutSeconds": 600, "Async": false, "EscalateToAll": true }
+          }
+        }
+      },
+      "Resilience": {
+        "Enabled": false
+      },
+      "Permissions": {
+        "DefaultBehavior": "Allow",
+        "DefaultAutonomyLevel": "Autonomous"
+      },
+      "Skills": {
+        "BasePath": "skills",
+        "AdditionalPaths": []
+      },
+      "BundleExecution": {
+        "Enabled": true,
+        "Auth": {
+        }
+      }
+    },
+    "Observability": {
+      "SamplingRatio": 1.0
+    },
+    "Cache": {
+      "CacheType": "Memory"
+    }
+  }
+}

--- a/src/Content/Tests/Application.AI.Common.Tests/CQRS/Bundles/DeleteBundleCommandHandlerTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/CQRS/Bundles/DeleteBundleCommandHandlerTests.cs
@@ -1,0 +1,82 @@
+using Application.AI.Common.CQRS.Bundles.DeleteBundle;
+using Application.AI.Common.Interfaces.Bundles;
+using Domain.Common;
+using Domain.Common.Config;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Application.AI.Common.Tests.CQRS.Bundles;
+
+/// <summary>
+/// Tests for <see cref="DeleteBundleCommandHandler"/>: the disabled gate and the idempotent removal path.
+/// </summary>
+public sealed class DeleteBundleCommandHandlerTests
+{
+    private readonly Mock<IBundleHandleStore> _handleStore = new();
+
+    private sealed class StaticOptionsMonitor<T>(T value) : IOptionsMonitor<T>
+    {
+        public T CurrentValue { get; } = value;
+        public T Get(string? name) => CurrentValue;
+        public IDisposable? OnChange(Action<T, string?> listener) => null;
+    }
+
+    private DeleteBundleCommandHandler BuildSut(bool enabled)
+    {
+        var cfg = new AppConfig();
+        cfg.AI.BundleExecution.Enabled = enabled;
+        return new DeleteBundleCommandHandler(
+            _handleStore.Object, new StaticOptionsMonitor<AppConfig>(cfg),
+            NullLogger<DeleteBundleCommandHandler>.Instance);
+    }
+
+    private static DeleteBundleCommand Command(string handle = "h1") => new() { Handle = handle, OwnerId = "owner-1" };
+
+    [Fact]
+    public async Task Handle_WhenDisabled_ReturnsForbidden_AndDoesNotRemove()
+    {
+        var result = await BuildSut(enabled: false).Handle(Command(), CancellationToken.None);
+
+        result.FailureType.Should().Be(ResultFailureType.Forbidden);
+        _handleStore.Verify(h => h.Remove(It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_WhenOwnedByCaller_RemovesAndReportsTrue()
+    {
+        _handleStore.Setup(h => h.GetOwner("h1")).Returns("owner-1");
+        _handleStore.Setup(h => h.Remove("h1")).Returns(true);
+
+        var result = await BuildSut(enabled: true).Handle(Command(), CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Handle_WhenAbsent_StillSucceeds_ReportsFalse_Idempotent()
+    {
+        _handleStore.Setup(h => h.GetOwner("gone")).Returns((string?)null);
+
+        var result = await BuildSut(enabled: true).Handle(Command("gone"), CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeFalse();
+        _handleStore.Verify(h => h.Remove(It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_WhenOwnedByAnotherCaller_IsNoOp_DoesNotRemove()
+    {
+        _handleStore.Setup(h => h.GetOwner("h1")).Returns("someone-else");
+
+        var result = await BuildSut(enabled: true).Handle(Command(), CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeFalse();
+        _handleStore.Verify(h => h.Remove(It.IsAny<string>()), Times.Never);
+    }
+}

--- a/src/Content/Tests/Application.AI.Common.Tests/CQRS/Bundles/GetBundleRunQueryHandlerTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/CQRS/Bundles/GetBundleRunQueryHandlerTests.cs
@@ -34,10 +34,11 @@ public sealed class GetBundleRunQueryHandlerTests
         return new GetBundleRunQueryHandler(_jobStore.Object, new StaticOptionsMonitor<AppConfig>(cfg));
     }
 
-    private static BundleRunRecord Record(string handle) => new()
+    private static BundleRunRecord Record(string handle, string ownerId = "owner-1") => new()
     {
         JobId = "j1",
         Handle = handle,
+        OwnerId = ownerId,
         AgentName = "agent-1",
         UserMessages = ["hello"],
         MaxTurns = 3,
@@ -46,7 +47,7 @@ public sealed class GetBundleRunQueryHandlerTests
         CreatedAt = DateTimeOffset.UnixEpoch
     };
 
-    private static GetBundleRunQuery Query() => new() { Handle = "h1", JobId = "j1" };
+    private static GetBundleRunQuery Query() => new() { Handle = "h1", JobId = "j1", OwnerId = "owner-1" };
 
     [Fact]
     public async Task Handle_WhenDisabled_ReturnsForbidden()
@@ -77,7 +78,18 @@ public sealed class GetBundleRunQueryHandlerTests
     }
 
     [Fact]
-    public async Task Handle_WhenRunMatchesHandle_ReturnsRecord()
+    public async Task Handle_WhenRunBelongsToDifferentCaller_ReturnsNotFound()
+    {
+        // Right handle + right job id, but the run was created by another owner: not found, no leak.
+        _jobStore.Setup(j => j.Get("j1")).Returns(Record(handle: "h1", ownerId: "someone-else"));
+
+        var result = await BuildSut().Handle(Query(), CancellationToken.None);
+
+        result.FailureType.Should().Be(ResultFailureType.NotFound);
+    }
+
+    [Fact]
+    public async Task Handle_WhenRunMatchesHandleAndOwner_ReturnsRecord()
     {
         _jobStore.Setup(j => j.Get("j1")).Returns(Record(handle: "h1"));
 

--- a/src/Content/Tests/Application.AI.Common.Tests/CQRS/Bundles/RegisterBundleCommandHandlerTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/CQRS/Bundles/RegisterBundleCommandHandlerTests.cs
@@ -48,7 +48,7 @@ public sealed class RegisterBundleCommandHandlerTests
         Agent = new AgentDefinition { Id = "agent-1", Name = "Agent 1" }
     };
 
-    private static RegisterBundleCommand Command() => new() { Archive = new MemoryStream([1, 2, 3]) };
+    private static RegisterBundleCommand Command() => new() { Archive = new MemoryStream([1, 2, 3]), OwnerId = "owner-1" };
 
     [Fact]
     public async Task Handle_WhenDisabled_ReturnsForbidden_AndDoesNotStage()
@@ -70,7 +70,7 @@ public sealed class RegisterBundleCommandHandlerTests
 
         result.IsSuccess.Should().BeFalse();
         result.Errors.Should().Contain("archive too large");
-        _handleStore.Verify(h => h.Register(It.IsAny<StagedBundle>()), Times.Never);
+        _handleStore.Verify(h => h.Register(It.IsAny<StagedBundle>(), It.IsAny<string>()), Times.Never);
     }
 
     [Fact]
@@ -78,13 +78,13 @@ public sealed class RegisterBundleCommandHandlerTests
     {
         _staging.Setup(s => s.StageAsync(It.IsAny<Stream>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result<StagedBundle>.Success(Staged()));
-        _handleStore.Setup(h => h.Register(It.IsAny<StagedBundle>())).Returns("handle-1");
+        _handleStore.Setup(h => h.Register(It.IsAny<StagedBundle>(), It.IsAny<string>())).Returns("handle-1");
 
         var result = await BuildSut(enabled: true).Handle(Command(), CancellationToken.None);
 
         result.IsSuccess.Should().BeTrue();
         result.Value!.Handle.Should().Be("handle-1");
         result.Value.ExpiresAt.Should().Be(_time.GetUtcNow() + TimeSpan.FromMinutes(30));
-        _handleStore.Verify(h => h.Register(It.Is<StagedBundle>(b => b.BundleId == "b1")), Times.Once);
+        _handleStore.Verify(h => h.Register(It.Is<StagedBundle>(b => b.BundleId == "b1"), "owner-1"), Times.Once);
     }
 }

--- a/src/Content/Tests/Application.AI.Common.Tests/CQRS/Bundles/RunBundleCommandHandlerTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/CQRS/Bundles/RunBundleCommandHandlerTests.cs
@@ -54,6 +54,7 @@ public sealed class RunBundleCommandHandlerTests
         Handle = "handle-1",
         UserMessages = ["hello"],
         Envelope = new CapabilityEnvelope(),
+        OwnerId = "owner-1",
         MaxTurns = 4
     };
 
@@ -79,8 +80,9 @@ public sealed class RunBundleCommandHandlerTests
     }
 
     [Fact]
-    public async Task Handle_HappyPath_CreatesQueuedRecord_CapturesAgentName_AndEnqueues()
+    public async Task Handle_HappyPath_CreatesQueuedRecord_CapturesAgentAndOwner_AndEnqueues()
     {
+        _handleStore.Setup(h => h.GetOwner("handle-1")).Returns("owner-1");
         _handleStore.Setup(h => h.TryGet("handle-1")).Returns(Staged());
         BundleRunRecord? created = null;
         _jobStore.Setup(j => j.Create(It.IsAny<BundleRunRecord>())).Callback<BundleRunRecord>(r => created = r);
@@ -92,8 +94,23 @@ public sealed class RunBundleCommandHandlerTests
         created!.Status.Should().Be(BundleRunStatus.Queued);
         created.AgentName.Should().Be("the-agent");
         created.Handle.Should().Be("handle-1");
+        created.OwnerId.Should().Be("owner-1");
         created.MaxTurns.Should().Be(4);
         result.Value!.JobId.Should().Be(created.JobId);
         _queue.Verify(q => q.EnqueueAsync(created.JobId, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_WhenHandleOwnedByAnotherCaller_ReturnsNotFound_AndDoesNotRun()
+    {
+        // The handle exists, but for a different owner: must be indistinguishable from "not found".
+        _handleStore.Setup(h => h.GetOwner("handle-1")).Returns("someone-else");
+        _handleStore.Setup(h => h.TryGet("handle-1")).Returns(Staged());
+
+        var result = await BuildSut(enabled: true).Handle(Command(), CancellationToken.None);
+
+        result.FailureType.Should().Be(ResultFailureType.NotFound);
+        _jobStore.Verify(j => j.Create(It.IsAny<BundleRunRecord>()), Times.Never);
+        _queue.Verify(q => q.EnqueueAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 }

--- a/src/Content/Tests/Infrastructure.AI.Tests/Bundles/BundleRunBackgroundServiceTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Bundles/BundleRunBackgroundServiceTests.cs
@@ -97,6 +97,7 @@ public sealed class BundleRunBackgroundServiceTests : IDisposable
     {
         JobId = jobId,
         Handle = handle,
+        OwnerId = "owner-1",
         AgentName = agentId,
         UserMessages = ["hello"],
         MaxTurns = 3,
@@ -134,7 +135,7 @@ public sealed class BundleRunBackgroundServiceTests : IDisposable
 
         var (service, queue, jobStore, handleStore) = BuildSut(mediator.Object);
         var staged = StageOnDisk("b1", out _);
-        var handle = handleStore.Register(staged);
+        var handle = handleStore.Register(staged, "owner-1");
         var envelope = new CapabilityEnvelope { AllowedTools = ["read_file"], AutonomyCeiling = AutonomyLevel.Autonomous };
         jobStore.Create(QueuedRecord("j1", handle, staged.Agent.Id, envelope));
         await queue.EnqueueAsync("j1", CancellationToken.None);
@@ -185,7 +186,7 @@ public sealed class BundleRunBackgroundServiceTests : IDisposable
         handleStoreRef = handleStore;
         var staged = StageOnDisk("b1", out var dir);
         dirRef = dir;
-        var handle = handleStore.Register(staged);
+        var handle = handleStore.Register(staged, "owner-1");
         jobStore.Create(QueuedRecord("j1", handle, staged.Agent.Id, new CapabilityEnvelope()));
         await queue.EnqueueAsync("j1", CancellationToken.None);
 
@@ -214,7 +215,7 @@ public sealed class BundleRunBackgroundServiceTests : IDisposable
 
         var (service, queue, jobStore, handleStore) = BuildSut(mediator.Object);
         var staged = StageOnDisk("b1", out _);
-        var handle = handleStore.Register(staged);
+        var handle = handleStore.Register(staged, "owner-1");
         jobStore.Create(QueuedRecord("j1", handle, staged.Agent.Id, new CapabilityEnvelope()));
         // Remove the handle before the run is dispatched.
         handleStore.Remove(handle);
@@ -240,7 +241,7 @@ public sealed class BundleRunBackgroundServiceTests : IDisposable
 
         var (service, queue, jobStore, handleStore) = BuildSut(mediator.Object);
         var staged = StageOnDisk("b1", out _);
-        var handle = handleStore.Register(staged);
+        var handle = handleStore.Register(staged, "owner-1");
         jobStore.Create(QueuedRecord("j1", handle, staged.Agent.Id, new CapabilityEnvelope()));
         await queue.EnqueueAsync("j1", CancellationToken.None);
 

--- a/src/Content/Tests/Infrastructure.AI.Tests/Bundles/InMemoryBundleHandleStoreTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Bundles/InMemoryBundleHandleStoreTests.cs
@@ -58,7 +58,7 @@ public sealed class InMemoryBundleHandleStoreTests : IDisposable
     public void Register_ThenTryGet_ReturnsBundle()
     {
         var sut = BuildSut();
-        var handle = sut.Register(StageOnDisk("b1"));
+        var handle = sut.Register(StageOnDisk("b1"), "owner-1");
 
         var got = sut.TryGet(handle);
 
@@ -73,10 +73,23 @@ public sealed class InMemoryBundleHandleStoreTests : IDisposable
     }
 
     [Fact]
+    public void GetOwner_ReturnsRegisteredOwner_AndNullWhenUnknownOrExpired()
+    {
+        var sut = BuildSut();
+        var handle = sut.Register(StageOnDisk("b1"), "owner-42");
+
+        sut.GetOwner(handle).Should().Be("owner-42");
+        sut.GetOwner("unknown").Should().BeNull();
+
+        _time.Advance(Ttl + TimeSpan.FromSeconds(1));
+        sut.GetOwner(handle).Should().BeNull("an expired handle exposes no owner");
+    }
+
+    [Fact]
     public void TryGet_AfterTtlElapses_ReturnsNull()
     {
         var sut = BuildSut();
-        var handle = sut.Register(StageOnDisk("b1"));
+        var handle = sut.Register(StageOnDisk("b1"), "owner-1");
 
         _time.Advance(Ttl + TimeSpan.FromSeconds(1));
 
@@ -87,7 +100,7 @@ public sealed class InMemoryBundleHandleStoreTests : IDisposable
     public void TryGet_RefreshesSlidingExpiry()
     {
         var sut = BuildSut();
-        var handle = sut.Register(StageOnDisk("b1"));
+        var handle = sut.Register(StageOnDisk("b1"), "owner-1");
 
         // Advance almost to expiry, touch it, then advance another almost-full TTL: still alive.
         _time.Advance(Ttl - TimeSpan.FromMinutes(1));
@@ -102,7 +115,7 @@ public sealed class InMemoryBundleHandleStoreTests : IDisposable
     {
         var sut = BuildSut();
         var bundle = StageOnDisk("b1");
-        var handle = sut.Register(bundle);
+        var handle = sut.Register(bundle, "owner-1");
 
         using (var lease = sut.Acquire(handle))
         {
@@ -127,7 +140,7 @@ public sealed class InMemoryBundleHandleStoreTests : IDisposable
     {
         var sut = BuildSut();
         var bundle = StageOnDisk("b1");
-        var handle = sut.Register(bundle);
+        var handle = sut.Register(bundle, "owner-1");
 
         sut.Remove(handle).Should().BeTrue();
 
@@ -140,7 +153,7 @@ public sealed class InMemoryBundleHandleStoreTests : IDisposable
     {
         var sut = BuildSut();
         var bundle = StageOnDisk("b1");
-        var handle = sut.Register(bundle);
+        var handle = sut.Register(bundle, "owner-1");
 
         var lease = sut.Acquire(handle)!;
         sut.Remove(handle).Should().BeTrue();
@@ -165,8 +178,8 @@ public sealed class InMemoryBundleHandleStoreTests : IDisposable
         var sut = BuildSut();
         var b1 = StageOnDisk("b1");
         var b2 = StageOnDisk("b2");
-        sut.Register(b1);
-        sut.Register(b2);
+        sut.Register(b1, "owner-1");
+        sut.Register(b2, "owner-1");
 
         _time.Advance(Ttl + TimeSpan.FromSeconds(1));
 
@@ -181,8 +194,8 @@ public sealed class InMemoryBundleHandleStoreTests : IDisposable
         var sut = BuildSut();
         var b1 = StageOnDisk("b1");
         var b2 = StageOnDisk("b2");
-        sut.Register(b1);
-        sut.Register(b2);
+        sut.Register(b1, "owner-1");
+        sut.Register(b2, "owner-1");
 
         sut.Dispose();
 

--- a/src/Content/Tests/Infrastructure.AI.Tests/Bundles/InMemoryBundleRunJobStoreTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Bundles/InMemoryBundleRunJobStoreTests.cs
@@ -36,6 +36,7 @@ public sealed class InMemoryBundleRunJobStoreTests
     {
         JobId = jobId,
         Handle = "h1",
+        OwnerId = "owner-1",
         AgentName = "agent-1",
         UserMessages = ["hello"],
         MaxTurns = 5,

--- a/src/Content/Tests/Presentation.BundleApi.Tests/BundleApiAuthenticationTests.cs
+++ b/src/Content/Tests/Presentation.BundleApi.Tests/BundleApiAuthenticationTests.cs
@@ -1,0 +1,89 @@
+using Domain.Common.Config.AI.BundleExecution;
+using FluentAssertions;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Presentation.BundleApi.Extensions;
+using Presentation.BundleApi.Services;
+using Xunit;
+
+namespace Presentation.BundleApi.Tests;
+
+/// <summary>
+/// Unit tests for the bundle API's fail-closed authentication wiring — the security-critical decision ladder
+/// in <see cref="BundleApiServiceCollectionExtensions.AddBundleApiAuthentication"/>.
+/// </summary>
+public sealed class BundleApiAuthenticationTests
+{
+    private static IServiceCollection NewServices()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        return services;
+    }
+
+    [Fact]
+    public void Unconfigured_WithoutAnonymousOptIn_Throws_FailClosed()
+    {
+        var act = () => NewServices().AddBundleApiAuthentication(new BundleApiAuthConfig());
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*fail-closed*");
+    }
+
+    [Fact]
+    public void Anonymous_CombinedWithConfiguredScheme_Throws_Contradiction()
+    {
+        var auth = new BundleApiAuthConfig
+        {
+            TenantId = "tenant",
+            ClientId = "client",
+            AllowAnonymous = true
+        };
+
+        var act = () => NewServices().AddBundleApiAuthentication(auth);
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*contradictory*");
+    }
+
+    [Theory]
+    [InlineData("tenant", null)]
+    [InlineData(null, "client")]
+    public void HalfConfiguredScheme_Throws_FailClosed(string? tenantId, string? clientId)
+    {
+        var auth = new BundleApiAuthConfig { TenantId = tenantId, ClientId = clientId };
+
+        var act = () => NewServices().AddBundleApiAuthentication(auth);
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*half-configured*");
+    }
+
+    [Fact]
+    public void AnonymousOptIn_RegistersSyntheticAuth_AndStartupWarning()
+    {
+        var services = NewServices();
+
+        services.AddBundleApiAuthentication(new BundleApiAuthConfig { AllowAnonymous = true });
+
+        services.Should().Contain(d => d.ImplementationType == typeof(BundleApiAnonymousModeStartupWarning),
+            "the anonymous open-door state must announce itself loudly at startup");
+
+        // AddAuthentication ran (synthetic handler), so [Authorize] endpoints are reachable in anonymous mode.
+        using var provider = services.BuildServiceProvider();
+        provider.GetService<Microsoft.AspNetCore.Authentication.IAuthenticationService>()
+            .Should().NotBeNull();
+    }
+
+    [Fact]
+    public void ConfiguredEntra_RegistersJwtBearer_WithoutThrowing()
+    {
+        var services = NewServices();
+        var auth = new BundleApiAuthConfig { TenantId = "tenant-id", ClientId = "client-id" };
+
+        var act = () => services.AddBundleApiAuthentication(auth);
+
+        act.Should().NotThrow();
+        // A configured scheme installs JwtBearer options for the host's own audience.
+        services.Should().Contain(d => d.ServiceType == typeof(IConfigureOptions<JwtBearerOptions>));
+    }
+}

--- a/src/Content/Tests/Presentation.BundleApi.Tests/BundleCallerIdentityTests.cs
+++ b/src/Content/Tests/Presentation.BundleApi.Tests/BundleCallerIdentityTests.cs
@@ -1,0 +1,48 @@
+using System.Security.Claims;
+using FluentAssertions;
+using Presentation.BundleApi.Services;
+using Xunit;
+
+namespace Presentation.BundleApi.Tests;
+
+/// <summary>
+/// Tests for <see cref="BundleCallerIdentity.StableId"/> — the per-principal-unique id that owner-binding and
+/// rate-limit partitioning depend on. It must prefer the Entra object id, never fall back to the non-unique
+/// display name, and return null (not a shared constant) when no stable claim is present.
+/// </summary>
+public sealed class BundleCallerIdentityTests
+{
+    private static ClaimsPrincipal Principal(params (string Type, string Value)[] claims) =>
+        new(new ClaimsIdentity(claims.Select(c => new Claim(c.Type, c.Value)), "test"));
+
+    [Fact]
+    public void StableId_PrefersOid()
+    {
+        var user = Principal(("oid", "the-oid"), ("sub", "the-sub"), (ClaimTypes.Name, "Display Name"));
+
+        BundleCallerIdentity.StableId(user).Should().Be("the-oid");
+    }
+
+    [Fact]
+    public void StableId_FallsBackToSubject_WhenNoOid()
+    {
+        var user = Principal(("sub", "the-sub"), (ClaimTypes.Name, "Display Name"));
+
+        BundleCallerIdentity.StableId(user).Should().Be("the-sub");
+    }
+
+    [Fact]
+    public void StableId_IgnoresDisplayName_ReturnsNull_WhenNoStableClaim()
+    {
+        // A display name is NOT a stable per-principal id — it must never be used as an owner/partition key.
+        var user = Principal((ClaimTypes.Name, "Display Name"));
+
+        BundleCallerIdentity.StableId(user).Should().BeNull();
+    }
+
+    [Fact]
+    public void StableId_ReturnsNull_ForClaimlessPrincipal()
+    {
+        BundleCallerIdentity.StableId(new ClaimsPrincipal(new ClaimsIdentity())).Should().BeNull();
+    }
+}

--- a/src/Content/Tests/Presentation.BundleApi.Tests/BundlesControllerIntegrationTests.cs
+++ b/src/Content/Tests/Presentation.BundleApi.Tests/BundlesControllerIntegrationTests.cs
@@ -1,0 +1,116 @@
+using System.IO.Compression;
+using System.Net;
+using System.Net.Http.Json;
+using System.Text;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+
+namespace Presentation.BundleApi.Tests;
+
+/// <summary>
+/// Full-stack HTTP tests for the bundle API, hosting the real composition via
+/// <see cref="WebApplicationFactory{TEntryPoint}"/>. The host boots under the shipped Development config
+/// (bundle execution enabled, anonymous auth), so these prove the entire pipeline — DI composition, auth,
+/// controller, MediatR handlers, and the bundle stores — is wired correctly end to end.
+/// </summary>
+public sealed class BundlesControllerIntegrationTests : IClassFixture<WebApplicationFactory<Program>>
+{
+    private readonly WebApplicationFactory<Program> _factory;
+
+    public BundlesControllerIntegrationTests(WebApplicationFactory<Program> factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact]
+    public async Task Host_Boots_AndUnknownRunReturns404()
+    {
+        // Proves the full composition boots (ValidateOnBuild) and an authenticated (anonymous-dev) request
+        // reaches the controller and the real GetBundleRun handler, which reports an unknown run as 404.
+        var client = _factory.CreateClient();
+
+        var response = await client.GetAsync("/api/bundles/nohandle/runs/nojob");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task Register_WithNoFile_Returns400()
+    {
+        var client = _factory.CreateClient();
+
+        // multipart with no file part
+        using var content = new MultipartFormDataContent();
+        var response = await client.PostAsync("/api/bundles", content);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task Run_AgainstUnknownHandle_Returns404()
+    {
+        var client = _factory.CreateClient();
+
+        var response = await client.PostAsJsonAsync(
+            "/api/bundles/does-not-exist/runs",
+            new { userMessages = new[] { "hello" }, maxTurns = 1 });
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task Run_WithNoMessages_Returns400()
+    {
+        var client = _factory.CreateClient();
+
+        var response = await client.PostAsJsonAsync(
+            "/api/bundles/whatever/runs",
+            new { userMessages = Array.Empty<string>(), maxTurns = 1 });
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task Delete_UnknownHandle_Returns204_Idempotent()
+    {
+        var client = _factory.CreateClient();
+
+        var response = await client.DeleteAsync("/api/bundles/never-existed");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+    }
+
+    [Fact]
+    public async Task Register_WithArchiveMissingAgentManifest_IsRejected()
+    {
+        // A zip with no AGENT.md trips a staging guard → the register command fails (not 201/500).
+        var client = _factory.CreateClient();
+        using var content = new MultipartFormDataContent
+        {
+            { new ByteArrayContent(BuildZip(("readme.txt", "not an agent"))), "file", "bundle.zip" }
+        };
+
+        var response = await client.PostAsync("/api/bundles", content);
+
+        var body = await response.Content.ReadAsStringAsync();
+        response.StatusCode.Should().BeOneOf(
+            [HttpStatusCode.BadRequest, HttpStatusCode.UnprocessableEntity],
+            "staging guard rejection is a client error; body was: {0}", body);
+    }
+
+    private static byte[] BuildZip(params (string Name, string Content)[] entries)
+    {
+        using var ms = new MemoryStream();
+        using (var archive = new ZipArchive(ms, ZipArchiveMode.Create, leaveOpen: true))
+        {
+            foreach (var (name, content) in entries)
+            {
+                var entry = archive.CreateEntry(name);
+                using var writer = new StreamWriter(entry.Open(), Encoding.UTF8);
+                writer.Write(content);
+            }
+        }
+        return ms.ToArray();
+    }
+}

--- a/src/Content/Tests/Presentation.BundleApi.Tests/Presentation.BundleApi.Tests.csproj
+++ b/src/Content/Tests/Presentation.BundleApi.Tests/Presentation.BundleApi.Tests.csproj
@@ -1,0 +1,38 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+  </ItemGroup>
+
+  <!--
+    LoadAppConfig anchors on AppContext.BaseDirectory (this test project's output) and REQUIRES
+    appsettings.json there. WebApplicationFactory sets the host's content root to the BundleApi project
+    dir, but LoadAppConfig ignores that and reads the test bin dir — so copy the host's config here so the
+    full composition boots under test with BundleExecution enabled + anonymous auth (Development).
+  -->
+  <ItemGroup>
+    <Content Include="..\..\Presentation\Presentation.BundleApi\appsettings.json"
+             Link="appsettings.json" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="..\..\Presentation\Presentation.BundleApi\appsettings.Development.json"
+             Link="appsettings.Development.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Presentation\Presentation.BundleApi\Presentation.BundleApi.csproj" />
+    <ProjectReference Include="..\..\Application\Application.AI.Common\Application.AI.Common.csproj" />
+    <ProjectReference Include="..\..\Domain\Domain.AI\Domain.AI.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Bundle-PR4 — REST API surface (`Presentation.BundleApi`)

Fourth phase of the bundle-injection API (Issue #154, Part 2). A new **lean, isolated web host** — the REST front door through which an external system registers and runs externally-authored agent bundles. Sits on PR3's async-job/lifecycle machinery (#170). **Off by default** (`AppConfig:AI:BundleExecution:Enabled`); its own auth audience, fail-closed.

### Endpoints
```
POST   /api/bundles                        multipart zip → 201 { handle, expiresAt }
POST   /api/bundles/{handle}/runs          { userMessages[], maxTurns? } → 202 { jobId, statusUrl }
GET    /api/bundles/{handle}/runs/{jobId}  → 200 { status, result?, error?, timestamps }
DELETE /api/bundles/{handle}               → 204 (idempotent)
```
Each dispatches through MediatR; the run endpoint resolves the caller's `CapabilityEnvelope` at the boundary and passes it in. Poll DTOs project the run record, dropping every execution input (envelope, messages).

### Delivered
- `Presentation.BundleApi`: `Program` (`GetServices` composition + fail-closed auth + `ValidateScopes`/`ValidateOnBuild`), `BundlesController`, `AddBundleApiAuthentication` (Entra JWT, own audience, ClockSkew 0) + conscious anonymous dev opt-in, per-caller rate limiting, DTOs.
- `DeleteBundle` CQRS trio completes the contract.
- `BundleApiAuthConfig` (`AppConfig:AI:BundleExecution:Auth`).
- `WebApplicationFactory<Program>` integration tests (**the full host boots end-to-end**) + fail-closed auth-ladder + stable-caller-id unit tests.

### Security — `/code-review` (high) + a dedicated adversarial pass; all fixed
1. **Per-caller ownership (IDOR):** every handle + run is bound to the creating caller's stable id (`oid`/`sub`); run/poll/delete reject other callers (non-disclosing `NotFound` / no-op), so a leaked handle can't be used across callers. Adversarially re-verified — no bypass, no TOCTOU, no timing/existence leak.
2. **Rate limiter** partitions per caller (stable id, IP fallback), not one global bucket.
3. **Upload** bounded to `MaxArchiveBytes` at the transport boundary (before MVC buffers).
4. **Half-configured auth** fails closed; a **claimless authenticated principal** is rejected, never bucketed into a shared owner.
5. Staging-guard failures now surface as **400** (validation), not 500.

Adversarial pass confirmed safe: fail-closed ladder, 128-bit ticket unguessability, non-disclosing errors, envelope resolves fail-closed for the anonymous principal.

### Verification
- `dotnet build src/AgenticHarness.slnx` — **0 warnings / 0 errors**.
- **73 bundle tests green** (16 Application + 36 Infrastructure + 16 BundleApi + 5 Domain); Domain.AI 815 + Application.AI.Common 1399 green; Infrastructure.AI only the 3 pre-existing env-only `FileSystemService` temp-write failures.

### Deferred (own PR, out of scope)
- The `Result`→HTTP mapper is now duplicated across 3 controllers (N=3); extraction into `Presentation.Common` + fixing a pre-existing 404→500 drift in AgentHub's `ComplianceController` is a separate AgentHub-touching cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)