### PR TITLE
feat: bundle streaming SSE endpoint (Bundle-PR5)

### DIFF
--- a/src/Content/Application/Application.AI.Common/CQRS/Bundles/RunBundle/RunBundleCommand.cs
+++ b/src/Content/Application/Application.AI.Common/CQRS/Bundles/RunBundle/RunBundleCommand.cs
@@ -42,4 +42,13 @@ public sealed record RunBundleCommand : IRequest<Result<RunBundleResult>>
 
     /// <summary>The maximum number of turns the conversation may run.</summary>
     public int MaxTurns { get; init; } = 10;
+
+    /// <summary>
+    /// Selects the run's dispatch mode. When true the run is reserved for external, streamed execution: the
+    /// record is created <see cref="BundleRunStatus.Queued"/> but is <em>not</em> enqueued to the dispatcher, so
+    /// its only driver is the transport that later claims and streams it. When false (the default) the run is
+    /// enqueued and executes in the background for the caller to poll. Either way the returned job id is what
+    /// the caller uses next — to poll the result, or to open the stream.
+    /// </summary>
+    public bool Stream { get; init; }
 }

--- a/src/Content/Application/Application.AI.Common/CQRS/Bundles/RunBundle/RunBundleCommandHandler.cs
+++ b/src/Content/Application/Application.AI.Common/CQRS/Bundles/RunBundle/RunBundleCommandHandler.cs
@@ -89,15 +89,22 @@ public sealed class RunBundleCommandHandler
             MaxTurns = request.MaxTurns,
             Envelope = request.Envelope,
             Status = BundleRunStatus.Queued,
+            Streaming = request.Stream,
             CreatedAt = _time.GetUtcNow()
         };
 
         _jobStore.Create(record);
-        await _dispatchQueue.EnqueueAsync(record.JobId, cancellationToken).ConfigureAwait(false);
+
+        // A streaming run is NOT enqueued: its sole driver is the caller opening the stream endpoint, which
+        // claims and drives it on the connection thread. Enqueuing it too would let the background dispatcher
+        // race the stream for the same job. A non-streaming run is handed to the dispatcher to run poll-only.
+        if (!request.Stream)
+            await _dispatchQueue.EnqueueAsync(record.JobId, cancellationToken).ConfigureAwait(false);
 
         _logger.LogInformation(
-            "Queued bundle run {JobId} for handle {Handle} (agent {AgentId}, {MessageCount} message(s), max {MaxTurns} turns).",
-            record.JobId, record.Handle, record.AgentName, record.UserMessages.Count, record.MaxTurns);
+            "Created bundle run {JobId} for handle {Handle} (agent {AgentId}, {MessageCount} message(s), max {MaxTurns} turns, {Mode}).",
+            record.JobId, record.Handle, record.AgentName, record.UserMessages.Count, record.MaxTurns,
+            request.Stream ? "awaiting stream" : "queued for background dispatch");
 
         return Result<RunBundleResult>.Success(new RunBundleResult { JobId = record.JobId });
     }

--- a/src/Content/Application/Application.AI.Common/Interfaces/Bundles/IBundleRunExecutor.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Bundles/IBundleRunExecutor.cs
@@ -1,0 +1,102 @@
+using Domain.AI.Bundles;
+
+namespace Application.AI.Common.Interfaces.Bundles;
+
+/// <summary>
+/// Drives a single staged-bundle run to a terminal state under its own capability envelope and
+/// ephemeral-agent overlay. This is the one place the security-critical ambient arming lives, so both
+/// triggers of a bundle run share it: the background dispatcher (for async, poll-only runs) and the live
+/// Server-Sent-Events stream endpoint (for opt-in streaming runs).
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>What it does.</strong> Given a job id, it acquires a lease on the run's staged bundle (pinning the
+/// staging directory against the cleanup sweeper for the run's duration), atomically claims the run
+/// (<see cref="BundleRunStatus.Queued"/> → <see cref="BundleRunStatus.Running"/>), re-publishes the run's
+/// capability envelope and ephemeral-agent overlay ambiently, drives a full multi-turn conversation, maps the
+/// result onto the run record, and releases the lease — recording a terminal state on every path.
+/// </para>
+/// <para>
+/// <strong>Why the envelope arming lives here.</strong> The tool-invocation governor enforces the per-caller
+/// grant only when an envelope is published ambiently for the running turn; with none it fails <em>open</em>.
+/// The background dispatcher runs on a thread detached from the originating request and the stream endpoint
+/// runs on the connection thread, so in both cases the envelope must be re-published around the drive. Keeping
+/// that arming in a single implementation is what stops one trigger from silently diverging and opening the
+/// gate. The envelope scope stays open across the entire drive: the conversation is fully materialised before
+/// this method returns (deltas are pushed out-of-band through the ambient turn-stream sink while it runs), so
+/// there is no deferred enumeration that could outlive the scope.
+/// </para>
+/// <para>
+/// <strong>Streaming.</strong> This method is transport-agnostic: it never touches the HTTP response. A
+/// streaming caller arms the ambient <c>AgentTurnStreamSink</c> before calling it, so assistant text deltas
+/// flow to that caller's sink as the conversation runs; a non-streaming caller (the dispatcher) arms no sink
+/// and the same drive runs blocking. Either way the terminal outcome is recorded identically.
+/// </para>
+/// <para>
+/// <strong>Ownership is not checked here.</strong> The executor authorizes nothing — it drives whatever job id
+/// it is given. Callers are responsible for having verified that the requesting principal owns the run (the
+/// dispatcher only ever runs records it created; the stream endpoint owner-checks via the poll query before
+/// calling). Do not expose this to an unauthenticated surface.
+/// </para>
+/// </remarks>
+public interface IBundleRunExecutor
+{
+    /// <summary>
+    /// Executes the run with <paramref name="jobId"/> to a terminal state, or reports why it could not begin.
+    /// </summary>
+    /// <param name="jobId">The id of the queued run to drive.</param>
+    /// <param name="cancellationToken">
+    /// Cancels the run. For a stream this is the connection's abort token, so a client disconnect ends the run.
+    /// </param>
+    /// <returns>The outcome of the attempt — see <see cref="BundleRunExecution"/>.</returns>
+    Task<BundleRunExecution> ExecuteAsync(string jobId, CancellationToken cancellationToken);
+}
+
+/// <summary>
+/// The result of an <see cref="IBundleRunExecutor.ExecuteAsync"/> attempt: whether this call drove the run and,
+/// when it did, the terminal record snapshot so a streaming caller can emit the right closing event.
+/// </summary>
+public sealed record BundleRunExecution
+{
+    /// <summary>What happened to the run when this call tried to drive it.</summary>
+    public required BundleRunExecutionStatus Status { get; init; }
+
+    /// <summary>
+    /// The run record. The terminal snapshot when <see cref="Status"/> is <see cref="BundleRunExecutionStatus.Ran"/>
+    /// (inspect its <see cref="BundleRunRecord.Status"/>/<see cref="BundleRunRecord.Outcome"/>); the
+    /// last-observed snapshot for <see cref="BundleRunExecutionStatus.AlreadyClaimed"/> (carried for context
+    /// only — a caller that lost the claim race owns nothing about the run); null for
+    /// <see cref="BundleRunExecutionStatus.NotFound"/>.
+    /// </summary>
+    public BundleRunRecord? Record { get; init; }
+
+    /// <summary>Convenience result for a job id that had no record.</summary>
+    public static BundleRunExecution NotFound { get; } = new() { Status = BundleRunExecutionStatus.NotFound };
+
+    /// <summary>Builds an <see cref="BundleRunExecutionStatus.AlreadyClaimed"/> result carrying the current snapshot.</summary>
+    public static BundleRunExecution AlreadyClaimed(BundleRunRecord? current) =>
+        new() { Status = BundleRunExecutionStatus.AlreadyClaimed, Record = current };
+
+    /// <summary>Builds a <see cref="BundleRunExecutionStatus.Ran"/> result carrying the terminal snapshot.</summary>
+    public static BundleRunExecution Ran(BundleRunRecord terminal) =>
+        new() { Status = BundleRunExecutionStatus.Ran, Record = terminal };
+}
+
+/// <summary>Whether an <see cref="IBundleRunExecutor.ExecuteAsync"/> call drove the run, and if not, why.</summary>
+public enum BundleRunExecutionStatus
+{
+    /// <summary>No run record exists for the job id (never created, or already swept).</summary>
+    NotFound = 0,
+
+    /// <summary>
+    /// The run was not <see cref="BundleRunStatus.Queued"/> when this call tried to claim it — another driver
+    /// already began it, or it had already reached a terminal state. This call drove nothing.
+    /// </summary>
+    AlreadyClaimed = 1,
+
+    /// <summary>
+    /// This call drove the run to a terminal state. The carried record's own
+    /// <see cref="BundleRunRecord.Status"/> distinguishes a completed conversation from a failed one.
+    /// </summary>
+    Ran = 2,
+}

--- a/src/Content/Application/Application.AI.Common/Interfaces/Bundles/IBundleRunJobStore.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Bundles/IBundleRunJobStore.cs
@@ -8,11 +8,27 @@ namespace Application.AI.Common.Interfaces.Bundles;
 /// record lives in memory just long enough for a caller to poll its result before it is swept.
 /// </summary>
 /// <remarks>
-/// The record is immutable: the dispatcher advances a run by building a <c>with</c>-copy and calling
-/// <see cref="Update"/>, which atomically swaps the stored snapshot. Only a terminal record has a TTL — it
-/// starts when the run reaches a terminal state, so a completed run stays pollable for the configured window
-/// regardless of how long it queued or ran. A <see cref="BundleRunStatus.Queued"/>/<see cref="BundleRunStatus.Running"/>
-/// record is in-flight and is never expired, so a run is never dropped or its outcome lost to a mid-run sweep.
+/// <para>
+/// The record is immutable: a run is advanced by building a <c>with</c>-copy and calling <see cref="Update"/>,
+/// which atomically swaps the stored snapshot.
+/// </para>
+/// <para>
+/// <strong>Expiry contract (any implementation must honour this).</strong> Two — and only two — kinds of
+/// record are reclaimable:
+/// <list type="bullet">
+///   <item><description>A <em>terminal</em> record, once its pollable window elapses. That window starts when
+///   the run reaches a terminal state, so a completed run stays pollable for the configured retention window
+///   regardless of how long it queued or ran.</description></item>
+///   <item><description>An <em>unclaimed streaming reservation</em> — a <see cref="BundleRunStatus.Queued"/>
+///   record with <see cref="BundleRunRecord.Streaming"/> set — once its (separate, shorter) connect window
+///   elapses. Such a reservation has no background driver and may never be claimed, so it is reclaimed to bound
+///   memory.</description></item>
+/// </list>
+/// Every other non-terminal record — a background-queued run awaiting the dispatcher, or any
+/// <see cref="BundleRunStatus.Running"/> run (including a claimed streaming run) — is <em>never</em> expired,
+/// so an in-flight run is never dropped nor its outcome lost to a mid-run sweep. An implementation that expired
+/// a background-queued or running record would silently drop a run.
+/// </para>
 /// </remarks>
 public interface IBundleRunJobStore
 {
@@ -30,6 +46,20 @@ public interface IBundleRunJobStore
     /// <param name="jobId">The job id to look up.</param>
     /// <returns>The current record snapshot, or null.</returns>
     BundleRunRecord? Get(string jobId);
+
+    /// <summary>
+    /// Atomically transitions the run with <paramref name="jobId"/> from <see cref="BundleRunStatus.Queued"/> to
+    /// <see cref="BundleRunStatus.Running"/>, stamping <paramref name="startedAt"/>, and returns the claimed
+    /// snapshot. Returns null when the job id is unknown/swept or the run is no longer
+    /// <see cref="BundleRunStatus.Queued"/> (already claimed by another driver or already terminal). This is the
+    /// single point that guarantees a run is driven exactly once: both the background dispatcher and a live
+    /// stream call it, so two drivers racing for the same job — two stream connections, or a stream and the
+    /// dispatcher — cannot both begin it.
+    /// </summary>
+    /// <param name="jobId">The job id to claim.</param>
+    /// <param name="startedAt">The timestamp to record as the run's start.</param>
+    /// <returns>The claimed <see cref="BundleRunStatus.Running"/> snapshot, or null if it could not be claimed.</returns>
+    BundleRunRecord? TryBeginRun(string jobId, DateTimeOffset startedAt);
 
     /// <summary>
     /// Replaces the stored snapshot for <paramref name="record"/>'s job id. When the record is terminal its

--- a/src/Content/Domain/Domain.AI/Bundles/BundleRunRecord.cs
+++ b/src/Content/Domain/Domain.AI/Bundles/BundleRunRecord.cs
@@ -64,6 +64,18 @@ public sealed record BundleRunRecord
     /// <summary>The current lifecycle state. Starts <see cref="BundleRunStatus.Queued"/>.</summary>
     public required BundleRunStatus Status { get; init; }
 
+    /// <summary>
+    /// The run's dispatch mode. When false (the default) the run is background-dispatched: it is enqueued and a
+    /// worker drives it to completion for the caller to poll. When true the run is <em>externally driven</em>
+    /// instead — it is created <see cref="BundleRunStatus.Queued"/> but not enqueued, and whoever holds the run
+    /// (the live-stream transport) claims it (<see cref="BundleRunStatus.Queued"/> →
+    /// <see cref="BundleRunStatus.Running"/>) and drives it, binding the run's lifetime to that consumer.
+    /// Because such a reservation may never be claimed (the consumer might never attach), an unclaimed
+    /// externally-driven run is the one non-terminal record the job store may reclaim on TTL — every other
+    /// non-terminal record is retained until it completes.
+    /// </summary>
+    public bool Streaming { get; init; }
+
     /// <summary>The terminal outcome once the run has <see cref="BundleRunStatus.Succeeded"/>; null before then.</summary>
     public BundleRunOutcome? Outcome { get; init; }
 

--- a/src/Content/Domain/Domain.Common/Config/AI/BundleExecution/BundleExecutionConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/BundleExecution/BundleExecutionConfig.cs
@@ -101,6 +101,29 @@ public class BundleExecutionConfig
     public TimeSpan RunRecordTtl { get; set; } = TimeSpan.FromMinutes(30);
 
     /// <summary>
+    /// How long a run created for a live stream (rather than background dispatch) waits, unstarted, for its
+    /// caller to open the stream before it is reclaimed. A streamed run is not enqueued — its only driver is
+    /// the caller connecting — so this bounds the memory a caller could pin by creating runs and never
+    /// streaming them. Deliberately separate from <see cref="RunRecordTtl"/> (which governs how long a
+    /// <em>completed</em> result stays pollable): the two are unrelated timeouts, and tightening result
+    /// retention must not silently shrink the window a client has to connect. Applies only while the run is
+    /// unclaimed; once the stream connects, the run is in-flight and never expires. Must be positive.
+    /// </summary>
+    /// <value>Default: 5 minutes</value>
+    public TimeSpan StreamReservationTtl { get; set; } = TimeSpan.FromMinutes(5);
+
+    /// <summary>
+    /// The maximum number of live streams a single caller may hold open at once. A streamed run executes
+    /// inline on its connection for the whole conversation (it bypasses the background dispatcher that
+    /// serialises poll-only runs), so without a ceiling one caller could open many connections and drive
+    /// unbounded concurrent agent conversations — pinning leases, scopes, and token spend. Enforced as a
+    /// per-caller concurrency limit on the stream endpoint; excess connection attempts are rejected, not
+    /// queued. Must be positive.
+    /// </summary>
+    /// <value>Default: 4</value>
+    public int MaxConcurrentStreamsPerCaller { get; set; } = 4;
+
+    /// <summary>
     /// How often the background cleanup sweeper runs its pass over expired handles (deleting their staging
     /// directories) and expired run records. This is the belt-and-suspenders backstop that guarantees a
     /// staging directory is removed even if no explicit delete arrives. Must be positive.

--- a/src/Content/Infrastructure/Infrastructure.AI/Bundles/BundleRunBackgroundService.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Bundles/BundleRunBackgroundService.cs
@@ -1,74 +1,37 @@
 using Application.AI.Common.Interfaces.Bundles;
-using Application.AI.Common.Services.Bundles;
-using Application.AI.Common.Services.Governance;
-using Application.Core.CQRS.Agents.RunConversation;
-using Domain.AI.Bundles;
-using MediatR;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
 namespace Infrastructure.AI.Bundles;
 
 /// <summary>
-/// Drains the <see cref="IBundleRunDispatchQueue"/> and executes each queued bundle run: it acquires the
-/// staged bundle behind the run's handle, re-publishes the run's ephemeral-agent overlay and capability
-/// envelope ambiently, drives a full <see cref="RunConversationCommand"/>, and records the terminal outcome
-/// on the run record. Mirrors <c>ChangeProposalBackgroundService</c>: one DI scope per run, failure-isolated
-/// so one bad run never stalls the queue.
+/// Drains the <see cref="IBundleRunDispatchQueue"/> and drives each queued (non-streaming) bundle run to a
+/// terminal state through the shared <see cref="IBundleRunExecutor"/>. Mirrors <c>ChangeProposalBackgroundService</c>:
+/// failure-isolated so one bad run never stalls the queue. All the arm-the-ambients-and-run logic lives in the
+/// executor, which the streaming endpoint shares — see <see cref="IBundleRunExecutor"/>.
 /// </summary>
 /// <remarks>
-/// <para>
-/// <strong>Why the ambients are re-armed here.</strong> The dispatcher runs on a thread-pool flow detached
-/// from the HTTP request that enqueued the run, so the ambient overlay and capability envelope set during
-/// that request do not flow to it. Both are re-published from the run record and the staged bundle for the
-/// duration of the run. Arming the envelope is what makes the tool-invocation governor enforce — the
-/// governor forces enforcement on precisely from the envelope's presence, and the standard turn handler
-/// arms <c>ToolGovernanceAccessor</c> per turn — so without re-arming the envelope here the governor would
-/// see none and fail <em>open</em>.
-/// </para>
-/// <para>
-/// The envelope scope stays open across the whole <see cref="RunConversationCommand"/>, which returns a
-/// fully-materialised result (not a deferred stream), so disposing the scope once <c>Send</c> returns is
-/// safe. The streaming run path (a later phase) must instead keep the scope open across the full stream
-/// enumeration — see the deferred-execution note on <c>CapabilityEnvelopeAccessor</c>.
-/// </para>
-/// <para>
-/// The staged bundle is <em>pinned</em> through an <see cref="IBundleHandleLease"/> for the whole run, so
-/// the cleanup sweeper cannot delete its staging directory while the ephemeral agent is reading its skills
-/// from disk. A run whose handle expired before pickup fails cleanly with a caller-safe reason.
-/// </para>
+/// Streaming runs are never enqueued (their driver is the stream endpoint), so this service only ever sees
+/// poll-only runs.
 /// </remarks>
 public sealed class BundleRunBackgroundService : BackgroundService
 {
     private readonly IBundleRunDispatchQueue _queue;
-    private readonly IBundleRunJobStore _jobStore;
-    private readonly IBundleHandleStore _handleStore;
-    private readonly IServiceScopeFactory _scopeFactory;
-    private readonly TimeProvider _time;
+    private readonly IBundleRunExecutor _executor;
     private readonly ILogger<BundleRunBackgroundService> _logger;
 
     /// <summary>Initializes a new <see cref="BundleRunBackgroundService"/>.</summary>
     public BundleRunBackgroundService(
         IBundleRunDispatchQueue queue,
-        IBundleRunJobStore jobStore,
-        IBundleHandleStore handleStore,
-        IServiceScopeFactory scopeFactory,
-        TimeProvider time,
+        IBundleRunExecutor executor,
         ILogger<BundleRunBackgroundService> logger)
     {
         ArgumentNullException.ThrowIfNull(queue);
-        ArgumentNullException.ThrowIfNull(jobStore);
-        ArgumentNullException.ThrowIfNull(handleStore);
-        ArgumentNullException.ThrowIfNull(scopeFactory);
-        ArgumentNullException.ThrowIfNull(time);
+        ArgumentNullException.ThrowIfNull(executor);
         ArgumentNullException.ThrowIfNull(logger);
 
         _queue = queue;
-        _jobStore = jobStore;
-        _handleStore = handleStore;
-        _scopeFactory = scopeFactory;
-        _time = time;
+        _executor = executor;
         _logger = logger;
     }
 
@@ -80,113 +43,20 @@ public sealed class BundleRunBackgroundService : BackgroundService
             if (stoppingToken.IsCancellationRequested)
                 break;
 
-            await DispatchOneAsync(jobId, stoppingToken).ConfigureAwait(false);
+            try
+            {
+                await _executor.ExecuteAsync(jobId, stoppingToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break; // host shutdown — the executor already recorded the run as cancelled
+            }
+            catch (Exception ex)
+            {
+                // The executor records its own failures; this is a last-resort guard so a defect there can
+                // never tear down the drain loop and stall every subsequent run.
+                _logger.LogError(ex, "Bundle run {JobId} dispatch failed unexpectedly.", jobId);
+            }
         }
     }
-
-    private async Task DispatchOneAsync(string jobId, CancellationToken stoppingToken)
-    {
-        var record = _jobStore.Get(jobId);
-        if (record is null)
-        {
-            _logger.LogWarning(
-                "Bundle run {JobId} was not found when dispatched (expired or swept before pickup); dropping.",
-                jobId);
-            return;
-        }
-
-        // Acquire the handle BEFORE transitioning to Running: a run that never starts (its handle expired
-        // before pickup) is marked Failed straight from Queued, so it never carries a bogus StartedAt.
-        using var lease = _handleStore.Acquire(record.Handle);
-        if (lease is null)
-        {
-            _logger.LogWarning(
-                "Bundle run {JobId} could not start: handle {Handle} expired before the run began.",
-                jobId, record.Handle);
-            _jobStore.Update(record with
-            {
-                Status = BundleRunStatus.Failed,
-                Error = "The bundle handle expired before the run started.",
-                CompletedAt = _time.GetUtcNow()
-            });
-            return;
-        }
-
-        record = record with { Status = BundleRunStatus.Running, StartedAt = _time.GetUtcNow() };
-        _jobStore.Update(record);
-
-        try
-        {
-            var result = await RunConversationAsync(record, lease.Bundle, stoppingToken).ConfigureAwait(false);
-
-            _jobStore.Update(record with
-            {
-                Status = BundleRunStatus.Succeeded,
-                Outcome = MapOutcome(result),
-                CompletedAt = _time.GetUtcNow()
-            });
-        }
-        catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
-        {
-            _jobStore.Update(record with
-            {
-                Status = BundleRunStatus.Failed,
-                Error = "The run was cancelled by host shutdown.",
-                CompletedAt = _time.GetUtcNow()
-            });
-            throw; // propagate to exit the drain loop on shutdown
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Bundle run {JobId} failed with an unhandled exception.", jobId);
-            _jobStore.Update(record with
-            {
-                Status = BundleRunStatus.Failed,
-                Error = "bundle_run.unhandled_exception",
-                CompletedAt = _time.GetUtcNow()
-            });
-        }
-    }
-
-    private async Task<ConversationResult> RunConversationAsync(
-        BundleRunRecord record,
-        StagedBundle staged,
-        CancellationToken stoppingToken)
-    {
-        var overlay = new EphemeralAgentOverlay
-        {
-            Agent = staged.Agent,
-            OwnedSkills = staged.OwnedSkills
-        };
-
-        await using var scope = _scopeFactory.CreateAsyncScope();
-        var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
-
-        // Arm BOTH ambients for the whole conversation: the overlay so the ephemeral agent + its owned
-        // skills resolve, and the envelope so the governor enforces the per-caller grant. Disposed in
-        // reverse when the (materialised) conversation returns.
-        using (EphemeralAgentOverlayAccessor.Begin(overlay))
-        using (CapabilityEnvelopeAccessor.Begin(record.Envelope))
-        {
-            var command = new RunConversationCommand
-            {
-                AgentName = record.AgentName,
-                UserMessages = record.UserMessages,
-                MaxTurns = record.MaxTurns,
-                ConversationId = record.JobId
-            };
-
-            return await mediator.Send(command, stoppingToken).ConfigureAwait(false);
-        }
-    }
-
-    private static BundleRunOutcome MapOutcome(ConversationResult result) => new()
-    {
-        ConversationSucceeded = result.Success,
-        FinalResponse = result.FinalResponse,
-        TurnCount = result.Turns.Count,
-        TotalToolInvocations = result.TotalToolInvocations,
-        BudgetExhausted = result.BudgetExhausted,
-        ConversationError = result.Error
-    };
 }

--- a/src/Content/Infrastructure/Infrastructure.AI/Bundles/BundleRunExecutor.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Bundles/BundleRunExecutor.cs
@@ -1,0 +1,197 @@
+using Application.AI.Common.Interfaces.Bundles;
+using Application.AI.Common.Services.Bundles;
+using Application.AI.Common.Services.Governance;
+using Application.Core.CQRS.Agents.RunConversation;
+using Domain.AI.Bundles;
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Infrastructure.AI.Bundles;
+
+/// <summary>
+/// The shared engine that drives a single bundle run to a terminal state under its capability envelope and
+/// ephemeral-agent overlay. Both triggers of a bundle run call it: the <see cref="BundleRunBackgroundService"/>
+/// (async, poll-only runs) and the streaming endpoint (opt-in live runs). Concentrating the security-critical
+/// ambient arming here is what stops the two triggers from diverging — see <see cref="IBundleRunExecutor"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>Ordering that preserves the invariants.</strong> The lease on the staged bundle is acquired
+/// <em>before</em> the run is claimed <see cref="BundleRunStatus.Running"/>: a run whose handle expired before
+/// it could start is failed straight from <see cref="BundleRunStatus.Queued"/> so it never carries a bogus
+/// start time, and the lease then pins the staging directory against the cleanup sweeper for the whole run so
+/// the ephemeral agent can read its skills from disk. The claim itself is an atomic
+/// <see cref="IBundleRunJobStore.TryBeginRun"/> compare-and-set, so if two drivers race for the same job (two
+/// stream connections, or a stream and the dispatcher) exactly one wins and drives it; the loser releases its
+/// lease and reports <see cref="BundleRunExecutionStatus.AlreadyClaimed"/>.
+/// </para>
+/// <para>
+/// <strong>Ambients.</strong> The capability envelope and overlay are re-published for the duration of the
+/// drive; the envelope's presence is what makes the tool-invocation governor enforce, so omitting it would
+/// fail the gate open. The scope wraps the whole <see cref="RunConversationCommand"/>, which returns a fully
+/// materialised result — assistant text is streamed out-of-band through the ambient turn-stream sink while the
+/// command runs, so there is no deferred enumeration outliving the scope.
+/// </para>
+/// </remarks>
+public sealed class BundleRunExecutor : IBundleRunExecutor
+{
+    private readonly IBundleRunJobStore _jobStore;
+    private readonly IBundleHandleStore _handleStore;
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly TimeProvider _time;
+    private readonly ILogger<BundleRunExecutor> _logger;
+
+    /// <summary>Initializes a new <see cref="BundleRunExecutor"/>.</summary>
+    public BundleRunExecutor(
+        IBundleRunJobStore jobStore,
+        IBundleHandleStore handleStore,
+        IServiceScopeFactory scopeFactory,
+        TimeProvider time,
+        ILogger<BundleRunExecutor> logger)
+    {
+        ArgumentNullException.ThrowIfNull(jobStore);
+        ArgumentNullException.ThrowIfNull(handleStore);
+        ArgumentNullException.ThrowIfNull(scopeFactory);
+        ArgumentNullException.ThrowIfNull(time);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _jobStore = jobStore;
+        _handleStore = handleStore;
+        _scopeFactory = scopeFactory;
+        _time = time;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<BundleRunExecution> ExecuteAsync(string jobId, CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(jobId);
+
+        var record = _jobStore.Get(jobId);
+        if (record is null)
+        {
+            _logger.LogWarning(
+                "Bundle run {JobId} was not found when dispatched (expired or swept before pickup); dropping.",
+                jobId);
+            return BundleRunExecution.NotFound;
+        }
+
+        // Only a queued run is ours to drive. Anything else was already claimed by another driver or has
+        // already finished — report it back without touching it.
+        if (record.Status != BundleRunStatus.Queued)
+            return BundleRunExecution.AlreadyClaimed(record);
+
+        // Acquire the handle BEFORE claiming Running: a run whose handle expired before pickup is failed
+        // straight from Queued (never stamped with a start time). While the run holds the lease the sweeper
+        // cannot delete the staging directory out from under the ephemeral agent.
+        using var lease = _handleStore.Acquire(record.Handle);
+        if (lease is null)
+        {
+            _logger.LogWarning(
+                "Bundle run {JobId} could not start: handle {Handle} expired before the run began.",
+                jobId, record.Handle);
+            var failed = record with
+            {
+                Status = BundleRunStatus.Failed,
+                Error = "The bundle handle expired before the run started.",
+                CompletedAt = _time.GetUtcNow()
+            };
+            _jobStore.Update(failed);
+            return BundleRunExecution.Ran(failed);
+        }
+
+        // Atomically claim the run. If another driver won the race, stand down and release the lease. The
+        // carried snapshot is the one already in hand — no caller reads it, so a fresh store read would be
+        // wasted work on this rare race-loss path.
+        var running = _jobStore.TryBeginRun(jobId, _time.GetUtcNow());
+        if (running is null)
+            return BundleRunExecution.AlreadyClaimed(record);
+
+        return await DriveAsync(running, lease, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<BundleRunExecution> DriveAsync(
+        BundleRunRecord running, IBundleHandleLease lease, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var result = await RunConversationAsync(running, lease.Bundle, cancellationToken).ConfigureAwait(false);
+
+            var succeeded = running with
+            {
+                Status = BundleRunStatus.Succeeded,
+                Outcome = MapOutcome(result),
+                CompletedAt = _time.GetUtcNow()
+            };
+            _jobStore.Update(succeeded);
+            return BundleRunExecution.Ran(succeeded);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            // Host shutdown or client disconnect — record the stop and propagate so a caller draining a queue
+            // exits its loop. The streaming caller's connection is already gone.
+            _jobStore.Update(running with
+            {
+                Status = BundleRunStatus.Failed,
+                Error = "The run was cancelled.",
+                CompletedAt = _time.GetUtcNow()
+            });
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Bundle run {JobId} failed with an unhandled exception.", running.JobId);
+            var failed = running with
+            {
+                Status = BundleRunStatus.Failed,
+                Error = "bundle_run.unhandled_exception",
+                CompletedAt = _time.GetUtcNow()
+            };
+            _jobStore.Update(failed);
+            return BundleRunExecution.Ran(failed);
+        }
+    }
+
+    private async Task<ConversationResult> RunConversationAsync(
+        BundleRunRecord record,
+        StagedBundle staged,
+        CancellationToken cancellationToken)
+    {
+        var overlay = new EphemeralAgentOverlay
+        {
+            Agent = staged.Agent,
+            OwnedSkills = staged.OwnedSkills
+        };
+
+        await using var scope = _scopeFactory.CreateAsyncScope();
+        var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+
+        // Arm BOTH ambients for the whole conversation: the overlay so the ephemeral agent + its owned skills
+        // resolve, and the envelope so the governor enforces the per-caller grant. Disposed in reverse when the
+        // (materialised) conversation returns.
+        using (EphemeralAgentOverlayAccessor.Begin(overlay))
+        using (CapabilityEnvelopeAccessor.Begin(record.Envelope))
+        {
+            var command = new RunConversationCommand
+            {
+                AgentName = record.AgentName,
+                UserMessages = record.UserMessages,
+                MaxTurns = record.MaxTurns,
+                ConversationId = record.JobId
+            };
+
+            return await mediator.Send(command, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private static BundleRunOutcome MapOutcome(ConversationResult result) => new()
+    {
+        ConversationSucceeded = result.Success,
+        FinalResponse = result.FinalResponse,
+        TurnCount = result.Turns.Count,
+        TotalToolInvocations = result.TotalToolInvocations,
+        BudgetExhausted = result.BudgetExhausted,
+        ConversationError = result.Error
+    };
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Bundles/InMemoryBundleRunJobStore.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Bundles/InMemoryBundleRunJobStore.cs
@@ -13,15 +13,15 @@ namespace Infrastructure.AI.Bundles;
 /// </summary>
 /// <remarks>
 /// <para>
-/// <strong>Only terminal records expire.</strong> A <see cref="BundleRunStatus.Queued"/> or
-/// <see cref="BundleRunStatus.Running"/> record is in-flight and is never expired or swept — otherwise a run
-/// still queued behind a slow predecessor, or one executing longer than the TTL, could have its record
-/// deleted out from under it (the dispatcher would then find nothing to update and silently drop a completed
-/// outcome). The TTL therefore governs only how long a completed run stays pollable: it starts when the
-/// record reaches a terminal state, so a caller gets the full configured window to read the result regardless
-/// of how long the run queued or ran first. A run that never reaches a terminal state is retained until the
-/// process exits; in practice the dispatcher always drives a queued run to a terminal state, and this
-/// in-memory store does not survive a restart.
+/// <strong>What expires.</strong> A record is reclaimable only when it is terminal (its TTL then governs how
+/// long the completed result stays pollable, starting from completion — so a caller gets the full window
+/// regardless of how long the run queued or ran) <em>or</em> when it is an <em>unclaimed streaming
+/// reservation</em>: a <see cref="BundleRunStatus.Queued"/> record with <see cref="BundleRunRecord.Streaming"/>
+/// set, whose only driver is a caller opening the stream endpoint. Such a reservation may never be claimed
+/// (the caller might never connect), so it is reclaimed once its window elapses to bound memory. Every other
+/// non-terminal record — a background-queued run awaiting the dispatcher, or any run already
+/// <see cref="BundleRunStatus.Running"/> — is never swept, so an in-flight run is never dropped or its outcome
+/// lost to a mid-run sweep. This in-memory store does not survive a restart.
 /// </para>
 /// <para>
 /// Each record's snapshot and expiry are guarded by a lock on its holder; in practice only the single
@@ -52,13 +52,20 @@ public sealed class InMemoryBundleRunJobStore : IBundleRunJobStore
     }
 
     private TimeSpan Ttl => _config.CurrentValue.AI.BundleExecution.RunRecordTtl;
+    private TimeSpan StreamReservationTtl => _config.CurrentValue.AI.BundleExecution.StreamReservationTtl;
 
     /// <inheritdoc />
     public void Create(BundleRunRecord record)
     {
         ArgumentNullException.ThrowIfNull(record);
 
-        var entry = new JobEntry(record, _time.GetUtcNow() + Ttl);
+        // A streaming reservation's initial expiry is the (separate, short) connect window — its own knob, so
+        // tightening the completed-result retention window never shrinks how long a caller has to connect. It
+        // is only consulted while the reservation is unclaimed; once claimed the run is in-flight and the
+        // expiry is irrelevant. Every other record's initial expiry is the run-record window (which only
+        // starts governing anything once the record is terminal).
+        var initialExpiry = _time.GetUtcNow() + (record.Streaming ? StreamReservationTtl : Ttl);
+        var entry = new JobEntry(record, initialExpiry);
         if (!_entries.TryAdd(record.JobId, entry))
             throw new InvalidOperationException($"A bundle run record with job id '{record.JobId}' already exists.");
     }
@@ -72,9 +79,39 @@ public sealed class InMemoryBundleRunJobStore : IBundleRunJobStore
 
         lock (entry)
         {
-            // Non-terminal records never expire; a terminal record expires once its pollable window elapses.
-            return entry.Record.IsTerminal && _time.GetUtcNow() >= entry.ExpiresAt ? null : entry.Record;
+            return IsExpired(entry, _time.GetUtcNow()) ? null : entry.Record;
         }
+    }
+
+    /// <inheritdoc />
+    public BundleRunRecord? TryBeginRun(string jobId, DateTimeOffset startedAt)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(jobId);
+        if (!_entries.TryGetValue(jobId, out var entry))
+            return null;
+
+        lock (entry)
+        {
+            // Refuse to claim a run that is not (still) an unexpired Queued reservation: another driver may have
+            // already claimed it, it may have finished, or an unclaimed streaming reservation may have lapsed.
+            if (entry.Record.Status != BundleRunStatus.Queued || IsExpired(entry, _time.GetUtcNow()))
+                return null;
+
+            entry.Record = entry.Record with { Status = BundleRunStatus.Running, StartedAt = startedAt };
+            return entry.Record;
+        }
+    }
+
+    /// <summary>
+    /// A record is reclaimable when it is terminal (past its pollable window) or an unclaimed streaming
+    /// reservation (a <see cref="BundleRunStatus.Queued"/> streaming run that was never picked up) past its
+    /// window. Every other non-terminal record is retained. Callers must hold the entry lock.
+    /// </summary>
+    private static bool IsExpired(JobEntry entry, DateTimeOffset now)
+    {
+        var reclaimable = entry.Record.IsTerminal
+            || (entry.Record.Streaming && entry.Record.Status == BundleRunStatus.Queued);
+        return reclaimable && now >= entry.ExpiresAt;
     }
 
     /// <inheritdoc />
@@ -105,8 +142,7 @@ public sealed class InMemoryBundleRunJobStore : IBundleRunJobStore
             bool expired;
             lock (entry)
             {
-                // Only terminal records are reclaimable — an in-flight run is never swept.
-                expired = entry.Record.IsTerminal && now >= entry.ExpiresAt;
+                expired = IsExpired(entry, now);
             }
 
             if (expired && _entries.TryRemove(new KeyValuePair<string, JobEntry>(jobId, entry)))

--- a/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.cs
@@ -205,6 +205,11 @@ public static partial class DependencyInjection
         services.AddSingleton<IBundleRunJobStore, InMemoryBundleRunJobStore>();
         services.AddSingleton<IBundleRunDispatchQueue, InMemoryBundleRunDispatchQueue>();
 
+        // The shared engine that drives a run to terminal under its envelope + overlay. Both the background
+        // dispatcher and the streaming endpoint resolve it, so the security-critical ambient arming lives in
+        // exactly one place. Stateless singleton — it opens a fresh DI scope per run.
+        services.AddSingleton<IBundleRunExecutor, BundleRunExecutor>();
+
         // Background workers. Both are passive when no bundle is registered/run: the dispatcher awaits an
         // empty channel and the sweeper sweeps empty stores, so — like the staging service — they are
         // registered unconditionally and cost nothing until the (config-gated) run surface feeds them.

--- a/src/Content/Presentation/Presentation.BundleApi/Controllers/BundlesController.cs
+++ b/src/Content/Presentation/Presentation.BundleApi/Controllers/BundlesController.cs
@@ -3,15 +3,18 @@ using Application.AI.Common.CQRS.Bundles.GetBundleRun;
 using Application.AI.Common.CQRS.Bundles.RegisterBundle;
 using Application.AI.Common.CQRS.Bundles.RunBundle;
 using Application.AI.Common.Interfaces.Governance;
+using Domain.AI.Bundles;
 using Domain.Common;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.RateLimiting;
 using Presentation.BundleApi.DTOs;
 using Presentation.BundleApi.Extensions;
 using Presentation.BundleApi.Services;
+using Presentation.BundleApi.Streaming;
 
 namespace Presentation.BundleApi.Controllers;
 
@@ -96,14 +99,72 @@ public sealed class BundlesController : ControllerBase
             UserMessages = request.UserMessages,
             MaxTurns = request.MaxTurns,
             Envelope = envelope,
-            OwnerId = callerId
+            OwnerId = callerId,
+            Stream = request.Stream
         }, cancellationToken).ConfigureAwait(false);
 
         if (!result.IsSuccess || result.Value is null)
             return MapFailure(result.FailureType, result.Errors);
 
         var statusUrl = $"/api/bundles/{handle}/runs/{result.Value.JobId}";
-        return Accepted(statusUrl, new StartRunResponse { JobId = result.Value.JobId, StatusUrl = statusUrl });
+        var streamUrl = request.Stream ? $"{statusUrl}/stream" : null;
+        return Accepted(statusUrl, new StartRunResponse
+        {
+            JobId = result.Value.JobId, StatusUrl = statusUrl, StreamUrl = streamUrl
+        });
+    }
+
+    /// <summary>
+    /// Opens the live Server-Sent-Events feed for a run started with <c>stream: true</c>, driving it on this
+    /// connection and streaming the agent's output as it is generated. Owner-locked exactly like the poll and
+    /// delete endpoints: a caller can only stream a run they started.
+    /// </summary>
+    /// <remarks>
+    /// Only a run reserved for streaming and still awaiting its stream is driveable here; a background run, a
+    /// run already being streamed, or a finished run is a 409 — poll its status endpoint instead. The run
+    /// executes under the capability envelope captured when it was started, and closing the connection cancels
+    /// it (<see cref="HttpContext.RequestAborted"/> flows into the executor).
+    /// </remarks>
+    [HttpGet("{handle}/runs/{jobId}/stream")]
+    [EnableRateLimiting(BundleApiServiceCollectionExtensions.StreamRateLimitPolicy)]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status409Conflict)]
+    [ProducesResponseType(StatusCodes.Status429TooManyRequests)]
+    public async Task<IActionResult> Stream(
+        string handle, string jobId, [FromServices] BundleRunStreamer streamer, CancellationToken cancellationToken)
+    {
+        var callerId = ResolveCallerId();
+        if (callerId is null)
+            return NoUsableIdentity();
+
+        // Owner-scoped pre-flight: the poll query reports an unknown or foreign run as not found, so this both
+        // resolves the record and enforces ownership before we commit the response to an event stream.
+        var lookup = await _mediator
+            .Send(new GetBundleRunQuery { Handle = handle, JobId = jobId, OwnerId = callerId }, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (!lookup.IsSuccess || lookup.Value is null)
+            return MapFailure(lookup.FailureType, lookup.Errors);
+
+        var record = lookup.Value;
+        if (!record.Streaming || record.Status != BundleRunStatus.Queued)
+        {
+            return Problem(
+                title: "Run not streamable",
+                detail: "This run is not awaiting a stream. Poll its status endpoint for the result.",
+                statusCode: StatusCodes.Status409Conflict);
+        }
+
+        Response.ContentType = "text/event-stream";
+        Response.Headers.CacheControl = "no-cache";
+        Response.Headers["X-Accel-Buffering"] = "no"; // defeat proxy buffering so frames arrive promptly
+        HttpContext.Features.Get<IHttpResponseBodyFeature>()?.DisableBuffering();
+
+        using var writer = new BundleStreamEventWriter(Response.Body);
+        await streamer.StreamAsync(record, writer, cancellationToken).ConfigureAwait(false);
+        return new EmptyResult();
     }
 
     /// <summary>Reads the current status and (once complete) result of a run.</summary>

--- a/src/Content/Presentation/Presentation.BundleApi/DTOs/BundleApiContracts.cs
+++ b/src/Content/Presentation/Presentation.BundleApi/DTOs/BundleApiContracts.cs
@@ -20,16 +20,30 @@ public sealed record RunBundleRequest
 
     /// <summary>The maximum number of turns the conversation may run. Defaults to 10.</summary>
     public int MaxTurns { get; init; } = 10;
+
+    /// <summary>
+    /// When true the run is reserved for a live stream instead of background dispatch: it is not executed until
+    /// the caller opens the returned <see cref="StartRunResponse.StreamUrl"/>, which then drives it and streams
+    /// the agent's output token-by-token. When false (the default) the run executes in the background and the
+    /// caller polls <see cref="StartRunResponse.StatusUrl"/> for the result.
+    /// </summary>
+    public bool Stream { get; init; }
 }
 
-/// <summary>Response to a successfully queued bundle run.</summary>
+/// <summary>Response to a successfully started bundle run.</summary>
 public sealed record StartRunResponse
 {
-    /// <summary>The opaque id of the queued run job.</summary>
+    /// <summary>The opaque id of the run job.</summary>
     public required string JobId { get; init; }
 
     /// <summary>Relative URL to poll for the run's status and result.</summary>
     public required string StatusUrl { get; init; }
+
+    /// <summary>
+    /// Relative URL of the live Server-Sent-Events feed for this run; null unless the run was started with
+    /// <see cref="RunBundleRequest.Stream"/> set. Opening it is what drives a streaming run.
+    /// </summary>
+    public string? StreamUrl { get; init; }
 }
 
 /// <summary>

--- a/src/Content/Presentation/Presentation.BundleApi/Extensions/BundleApiServiceCollectionExtensions.cs
+++ b/src/Content/Presentation/Presentation.BundleApi/Extensions/BundleApiServiceCollectionExtensions.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.IdentityModel.Tokens;
 using Presentation.BundleApi.Services;
+using Presentation.BundleApi.Streaming;
 
 namespace Presentation.BundleApi.Extensions;
 
@@ -26,6 +27,15 @@ public static class BundleApiServiceCollectionExtensions
 
     /// <summary>Stricter rate-limit policy for registration — staging an archive is comparatively expensive.</summary>
     public const string RegisterRateLimitPolicy = "bundles-register";
+
+    /// <summary>
+    /// Per-caller <em>concurrency</em> policy for the live-stream endpoint. A streamed run executes inline on
+    /// its connection for the whole conversation and bypasses the single-threaded background dispatcher, so the
+    /// fixed-window request-rate limiter (which counts starts, not simultaneous connections) cannot bound it.
+    /// A concurrency limiter holds each permit for the connection's lifetime, capping how many agent
+    /// conversations one caller can drive at once.
+    /// </summary>
+    public const string StreamRateLimitPolicy = "bundles-stream";
 
     /// <summary>
     /// Registers the bundle API's controllers, authentication, authorization, and rate limiters.
@@ -49,6 +59,10 @@ public static class BundleApiServiceCollectionExtensions
             .GetSection("AppConfig:AI:BundleExecution")
             .Get<BundleExecutionConfig>() ?? new BundleExecutionConfig();
 
+        // Drives the opt-in live SSE feed: arms the assistant-text sink and calls the shared run executor.
+        // Stateless — per-request state is local to each call.
+        services.AddTransient<BundleRunStreamer>();
+
         services.AddBundleApiAuthentication(bundleConfig.Auth);
 
         // Bound the multipart upload at the transport boundary to the same limit the staging service enforces,
@@ -66,6 +80,14 @@ public static class BundleApiServiceCollectionExtensions
             options.AddPolicy(RegisterRateLimitPolicy, httpContext =>
                 RateLimitPartition.GetFixedWindowLimiter(ResolvePartitionKey(httpContext), _ =>
                     new FixedWindowRateLimiterOptions { PermitLimit = 10, Window = TimeSpan.FromMinutes(1) }));
+
+            // Concurrency (not rate): each open stream holds a permit for its whole lifetime, so a caller can
+            // drive at most MaxConcurrentStreamsPerCaller agent conversations at once. QueueLimit 0 rejects a
+            // caller's excess connections outright rather than parking them.
+            var maxStreams = Math.Max(1, bundleConfig.MaxConcurrentStreamsPerCaller);
+            options.AddPolicy(StreamRateLimitPolicy, httpContext =>
+                RateLimitPartition.GetConcurrencyLimiter(ResolvePartitionKey(httpContext), _ =>
+                    new ConcurrencyLimiterOptions { PermitLimit = maxStreams, QueueLimit = 0 }));
         });
 
         return services;

--- a/src/Content/Presentation/Presentation.BundleApi/Streaming/BundleRunStreamer.cs
+++ b/src/Content/Presentation/Presentation.BundleApi/Streaming/BundleRunStreamer.cs
@@ -1,0 +1,109 @@
+using Application.AI.Common.Interfaces.Bundles;
+using Application.AI.Common.Services;
+using Domain.AI.Bundles;
+
+namespace Presentation.BundleApi.Streaming;
+
+/// <summary>
+/// Drives one bundle run as a live Server-Sent-Events feed: it emits the run-lifecycle events, arms the ambient
+/// assistant-text sink so tokens stream to the client as the agent generates them, and calls the shared
+/// <see cref="IBundleRunExecutor"/> to run the conversation under its capability envelope and overlay.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The executor is what arms the security ambients (envelope + overlay) around the run; this type adds only the
+/// transport concern — translating the agent's text deltas into AG-UI <c>TEXT_MESSAGE_CONTENT</c> frames. The
+/// sink is armed <em>around</em> the executor call and cleared in a <c>finally</c> so it can never leak onto a
+/// later request on the same thread, and because the executor materialises the whole run before returning, the
+/// sink stays armed for the entire stream.
+/// </para>
+/// <para>
+/// A cancelled connection surfaces as an <see cref="OperationCanceledException"/> from the executor: the sink is
+/// cleared and the exception propagates (the client is already gone), while the executor has already recorded
+/// the run as cancelled. Every non-cancelled path ends with exactly one terminal frame —
+/// <see cref="BundleRunFinishedEvent"/> on success or <see cref="BundleRunErrorEvent"/> otherwise.
+/// </para>
+/// </remarks>
+public sealed class BundleRunStreamer
+{
+    private readonly IBundleRunExecutor _executor;
+
+    /// <summary>Initializes a new <see cref="BundleRunStreamer"/>.</summary>
+    public BundleRunStreamer(IBundleRunExecutor executor)
+    {
+        ArgumentNullException.ThrowIfNull(executor);
+        _executor = executor;
+    }
+
+    /// <summary>
+    /// Streams the run identified by <paramref name="record"/> to <paramref name="writer"/>. The caller must
+    /// have already verified the requesting principal owns the run and set the SSE response headers.
+    /// </summary>
+    /// <param name="record">The queued run to drive (its handle is the stream's thread id, its job id the run id).</param>
+    /// <param name="writer">The SSE writer targeting the client's response stream.</param>
+    /// <param name="cancellationToken">The connection's abort token — cancelling it ends the run.</param>
+    public async Task StreamAsync(
+        BundleRunRecord record, BundleStreamEventWriter writer, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(record);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        var threadId = record.Handle;
+        var runId = record.JobId;
+        var messageId = Guid.NewGuid().ToString("N");
+
+        await writer.WriteAsync(new BundleRunStartedEvent(threadId, runId), cancellationToken).ConfigureAwait(false);
+
+        // Lazily open the assistant message on the first real delta, so a run that emits no text produces no
+        // stray empty message. Deltas arrive strictly sequentially (one turn's stream at a time), so the flag
+        // needs no synchronisation.
+        var textStarted = false;
+        var previousSink = AgentTurnStreamSink.Current;
+        AgentTurnStreamSink.Current = new AgentTurnStreamSink(async (delta, ct) =>
+        {
+            if (!textStarted)
+            {
+                textStarted = true;
+                await writer.WriteAsync(new BundleTextMessageStartEvent(messageId, "assistant"), ct).ConfigureAwait(false);
+            }
+
+            await writer.WriteAsync(new BundleTextMessageContentEvent(messageId, delta), ct).ConfigureAwait(false);
+        });
+
+        BundleRunExecution execution;
+        try
+        {
+            execution = await _executor.ExecuteAsync(record.JobId, cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            // Never let the sink outlive this request, on any path (success, failure, or cancellation).
+            AgentTurnStreamSink.Current = previousSink;
+        }
+
+        if (textStarted)
+            await writer.WriteAsync(new BundleTextMessageEndEvent(messageId), cancellationToken).ConfigureAwait(false);
+
+        if (IsSuccessful(execution))
+            await writer.WriteAsync(new BundleRunFinishedEvent(threadId, runId), cancellationToken).ConfigureAwait(false);
+        else
+            await writer.WriteAsync(new BundleRunErrorEvent(DescribeFailure(execution)), cancellationToken).ConfigureAwait(false);
+    }
+
+    private static bool IsSuccessful(BundleRunExecution execution) =>
+        execution.Status == BundleRunExecutionStatus.Ran
+        && execution.Record is { Status: BundleRunStatus.Succeeded, Outcome.ConversationSucceeded: true };
+
+    /// <summary>Maps a non-success execution to a caller-safe message — never a raw exception or internal code.</summary>
+    private static string DescribeFailure(BundleRunExecution execution) => execution.Status switch
+    {
+        BundleRunExecutionStatus.NotFound => "The run could not be found. Start it again to obtain a new job id.",
+        BundleRunExecutionStatus.AlreadyClaimed =>
+            "The run is already being streamed or has already completed.",
+        // Ran but not a clean success: a handle that expired before the run started (never stamped a start
+        // time) vs. an agent run that started and then failed to complete successfully.
+        _ => execution.Record?.StartedAt is null
+            ? "The bundle handle expired before the run could start."
+            : "The agent run did not complete successfully.",
+    };
+}

--- a/src/Content/Presentation/Presentation.BundleApi/Streaming/BundleStreamEventWriter.cs
+++ b/src/Content/Presentation/Presentation.BundleApi/Streaming/BundleStreamEventWriter.cs
@@ -1,0 +1,58 @@
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Presentation.BundleApi.Streaming;
+
+/// <summary>
+/// Writes <see cref="BundleStreamEvent"/>s to a response stream as Server-Sent-Events frames
+/// (<c>data: {json}\n\n</c>, camelCase), flushing each so the client receives it immediately.
+/// </summary>
+/// <remarks>
+/// Events are serialized against the <see cref="BundleStreamEvent"/> base type so
+/// <see cref="JsonPolymorphicAttribute"/> emits the <c>type</c> discriminator on every frame — serializing by
+/// runtime type would silently drop it. Writes are serialized behind a lock: even though a bundle run streams
+/// from a single async flow, keeping frame writes atomic guards against any future concurrent producer
+/// interleaving bytes into an unparseable frame (Kestrel also forbids concurrent response writes).
+/// </remarks>
+public sealed class BundleStreamEventWriter : IDisposable
+{
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    private readonly Stream _stream;
+    private readonly SemaphoreSlim _writeLock = new(1, 1);
+
+    /// <summary>Initializes a writer targeting <paramref name="responseBody"/> (typically the HTTP response body).</summary>
+    public BundleStreamEventWriter(Stream responseBody)
+    {
+        ArgumentNullException.ThrowIfNull(responseBody);
+        _stream = responseBody;
+    }
+
+    /// <summary>Serializes <paramref name="evt"/> as one SSE frame and flushes it to the client.</summary>
+    public async Task WriteAsync(BundleStreamEvent evt, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(evt);
+
+        var json = JsonSerializer.Serialize(evt, typeof(BundleStreamEvent), SerializerOptions);
+        var frame = Encoding.UTF8.GetBytes($"data: {json}\n\n");
+
+        await _writeLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            await _stream.WriteAsync(frame, cancellationToken).ConfigureAwait(false);
+            await _stream.FlushAsync(cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            _writeLock.Release();
+        }
+    }
+
+    /// <summary>Releases the write-serialization semaphore. The response stream is owned by the host.</summary>
+    public void Dispose() => _writeLock.Dispose();
+}

--- a/src/Content/Presentation/Presentation.BundleApi/Streaming/BundleStreamEvents.cs
+++ b/src/Content/Presentation/Presentation.BundleApi/Streaming/BundleStreamEvents.cs
@@ -1,0 +1,71 @@
+using System.Text.Json.Serialization;
+
+namespace Presentation.BundleApi.Streaming;
+
+/// <summary>
+/// Base type for the events the bundle streaming endpoint writes as Server-Sent-Events <c>data:</c> frames.
+/// </summary>
+/// <remarks>
+/// <para>
+/// These records reproduce the subset of the AG-UI protocol a bundle run needs — run lifecycle plus assistant
+/// text streaming — so any AG-UI client library consumes the feed unchanged. The bundle API deliberately ships
+/// its <em>own</em> small copy rather than referencing the dashboard's full AG-UI vocabulary: this is a lean,
+/// isolated host for externally-authored agents, and coupling it to the dashboard's 25-event protocol (plan,
+/// drift, learning, escalation events it will never emit) would defeat that isolation. If a third host ever
+/// needs this, extract a shared Server-Sent-Events primitive then.
+/// </para>
+/// <para>
+/// The <c>type</c> property is the polymorphic discriminator on the wire. Frames MUST be serialized against
+/// this base type so <see cref="JsonPolymorphicAttribute"/> emits the discriminator; serializing a derived
+/// type directly omits it. The discriminator values match the AG-UI wire spec exactly (uppercase, underscores).
+/// </para>
+/// </remarks>
+[JsonPolymorphic(TypeDiscriminatorPropertyName = "type")]
+[JsonDerivedType(typeof(BundleRunStartedEvent), "RUN_STARTED")]
+[JsonDerivedType(typeof(BundleTextMessageStartEvent), "TEXT_MESSAGE_START")]
+[JsonDerivedType(typeof(BundleTextMessageContentEvent), "TEXT_MESSAGE_CONTENT")]
+[JsonDerivedType(typeof(BundleTextMessageEndEvent), "TEXT_MESSAGE_END")]
+[JsonDerivedType(typeof(BundleRunFinishedEvent), "RUN_FINISHED")]
+[JsonDerivedType(typeof(BundleRunErrorEvent), "RUN_ERROR")]
+public abstract record BundleStreamEvent;
+
+/// <summary>Emitted once at the start of a streamed run, before any text.</summary>
+public sealed record BundleRunStartedEvent(
+    /// <summary>Thread the run belongs to; the bundle handle, stable across the run.</summary>
+    [property: JsonPropertyName("threadId")] string ThreadId,
+    /// <summary>Unique id for this run (the job id), echoed in the terminal event.</summary>
+    [property: JsonPropertyName("runId")] string RunId) : BundleStreamEvent;
+
+/// <summary>Signals the start of the assistant message. Followed by content deltas and one end frame.</summary>
+public sealed record BundleTextMessageStartEvent(
+    /// <summary>Id of the message, stable across all of its delta frames.</summary>
+    [property: JsonPropertyName("messageId")] string MessageId,
+    /// <summary>Message role — always <c>assistant</c> for a bundle run.</summary>
+    [property: JsonPropertyName("role")] string Role) : BundleStreamEvent;
+
+/// <summary>A streaming text delta to append to the in-progress assistant message.</summary>
+public sealed record BundleTextMessageContentEvent(
+    /// <summary>The message this delta belongs to.</summary>
+    [property: JsonPropertyName("messageId")] string MessageId,
+    /// <summary>The incremental text to append to the message buffer.</summary>
+    [property: JsonPropertyName("delta")] string Delta) : BundleStreamEvent;
+
+/// <summary>Signals the end of the assistant message.</summary>
+public sealed record BundleTextMessageEndEvent(
+    /// <summary>The message that has finished streaming.</summary>
+    [property: JsonPropertyName("messageId")] string MessageId) : BundleStreamEvent;
+
+/// <summary>Emitted once on successful completion of a streamed run. Terminal; no further frames follow.</summary>
+public sealed record BundleRunFinishedEvent(
+    /// <summary>Thread the completed run belonged to.</summary>
+    [property: JsonPropertyName("threadId")] string ThreadId,
+    /// <summary>Id of the run that has completed.</summary>
+    [property: JsonPropertyName("runId")] string RunId) : BundleStreamEvent;
+
+/// <summary>
+/// Emitted once when a streamed run fails. Terminal; no <see cref="BundleRunFinishedEvent"/> follows. The
+/// message is always a caller-safe reason — never a raw exception (the executor logs and scrubs those).
+/// </summary>
+public sealed record BundleRunErrorEvent(
+    /// <summary>A caller-safe, human-readable description of why the run failed.</summary>
+    [property: JsonPropertyName("message")] string Message) : BundleStreamEvent;

--- a/src/Content/Tests/Application.AI.Common.Tests/CQRS/Bundles/RunBundleCommandHandlerTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/CQRS/Bundles/RunBundleCommandHandlerTests.cs
@@ -101,6 +101,25 @@ public sealed class RunBundleCommandHandlerTests
     }
 
     [Fact]
+    public async Task Handle_StreamRequested_CreatesStreamingRecord_ButDoesNotEnqueue()
+    {
+        // A streaming run's sole driver is the caller opening the stream endpoint; enqueuing it too would let
+        // the background dispatcher race the stream for the same job.
+        _handleStore.Setup(h => h.GetOwner("handle-1")).Returns("owner-1");
+        _handleStore.Setup(h => h.TryGet("handle-1")).Returns(Staged());
+        BundleRunRecord? created = null;
+        _jobStore.Setup(j => j.Create(It.IsAny<BundleRunRecord>())).Callback<BundleRunRecord>(r => created = r);
+
+        var result = await BuildSut(enabled: true)
+            .Handle(Command() with { Stream = true }, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        created!.Streaming.Should().BeTrue();
+        created.Status.Should().Be(BundleRunStatus.Queued);
+        _queue.Verify(q => q.EnqueueAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
     public async Task Handle_WhenHandleOwnedByAnotherCaller_ReturnsNotFound_AndDoesNotRun()
     {
         // The handle exists, but for a different owner: must be indistinguishable from "not found".

--- a/src/Content/Tests/Infrastructure.AI.Tests/Bundles/BundleRunBackgroundServiceTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Bundles/BundleRunBackgroundServiceTests.cs
@@ -86,9 +86,10 @@ public sealed class BundleRunBackgroundServiceTests : IDisposable
         services.AddSingleton(mediator);
         var scopeFactory = services.BuildServiceProvider().GetRequiredService<IServiceScopeFactory>();
 
+        var executor = new BundleRunExecutor(
+            jobStore, handleStore, scopeFactory, _time, NullLogger<BundleRunExecutor>.Instance);
         var service = new BundleRunBackgroundService(
-            queue, jobStore, handleStore, scopeFactory, _time,
-            NullLogger<BundleRunBackgroundService>.Instance);
+            queue, executor, NullLogger<BundleRunBackgroundService>.Instance);
 
         return (service, queue, jobStore, handleStore);
     }

--- a/src/Content/Tests/Infrastructure.AI.Tests/Bundles/BundleRunExecutorTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Bundles/BundleRunExecutorTests.cs
@@ -1,0 +1,196 @@
+using Application.AI.Common.Interfaces.Bundles;
+using Application.Core.CQRS.Agents.RunConversation;
+using Domain.AI.Agents;
+using Domain.AI.Bundles;
+using Domain.Common.Config;
+using FluentAssertions;
+using Infrastructure.AI.Bundles;
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Time.Testing;
+using Moq;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Bundles;
+
+/// <summary>
+/// Tests for <see cref="BundleRunExecutor"/> — the shared engine both the background dispatcher and the stream
+/// endpoint call. These cover the engine's own decisions (not-found, already-claimed, claim-then-drive); the
+/// end-to-end ambient-arming/pinning/failure-scrubbing behaviour is proven through the dispatcher in
+/// <see cref="BundleRunBackgroundServiceTests"/>, which now runs through this same executor.
+/// </summary>
+public sealed class BundleRunExecutorTests : IDisposable
+{
+    private static readonly TimeSpan Ttl = TimeSpan.FromMinutes(30);
+    private readonly FakeTimeProvider _time = new(new DateTimeOffset(2026, 7, 11, 12, 0, 0, TimeSpan.Zero));
+    private readonly List<string> _tempDirs = [];
+
+    private sealed class StaticOptionsMonitor<T>(T value) : IOptionsMonitor<T>
+    {
+        public T CurrentValue { get; } = value;
+        public T Get(string? name) => CurrentValue;
+        public IDisposable? OnChange(Action<T, string?> listener) => null;
+    }
+
+    private AppConfig Config()
+    {
+        var cfg = new AppConfig();
+        cfg.AI.BundleExecution.HandleTtl = Ttl;
+        cfg.AI.BundleExecution.RunRecordTtl = Ttl;
+        return cfg;
+    }
+
+    private (BundleRunExecutor Executor, InMemoryBundleRunJobStore JobStore, InMemoryBundleHandleStore HandleStore)
+        BuildSut(IMediator mediator)
+    {
+        var monitor = new StaticOptionsMonitor<AppConfig>(Config());
+        var jobStore = new InMemoryBundleRunJobStore(monitor, _time);
+        var handleStore = new InMemoryBundleHandleStore(monitor, _time, NullLogger<InMemoryBundleHandleStore>.Instance);
+
+        var services = new ServiceCollection();
+        services.AddSingleton(mediator);
+        var scopeFactory = services.BuildServiceProvider().GetRequiredService<IServiceScopeFactory>();
+
+        var executor = new BundleRunExecutor(
+            jobStore, handleStore, scopeFactory, _time, NullLogger<BundleRunExecutor>.Instance);
+        return (executor, jobStore, handleStore);
+    }
+
+    private StagedBundle StageOnDisk(string bundleId)
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "bundle-executor-tests", bundleId);
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, "AGENT.md"), "# agent");
+        _tempDirs.Add(dir);
+        return new StagedBundle
+        {
+            BundleId = bundleId,
+            StagedRootDirectory = dir,
+            Agent = new AgentDefinition { Id = "agent-" + bundleId, Name = "Agent " + bundleId }
+        };
+    }
+
+    private BundleRunRecord QueuedRecord(string jobId, string handle, string agentId, bool streaming = false) => new()
+    {
+        JobId = jobId,
+        Handle = handle,
+        OwnerId = "owner-1",
+        AgentName = agentId,
+        UserMessages = ["hello"],
+        MaxTurns = 3,
+        Envelope = new CapabilityEnvelope(),
+        Status = BundleRunStatus.Queued,
+        Streaming = streaming,
+        CreatedAt = _time.GetUtcNow()
+    };
+
+    private static Mock<IMediator> MediatorReturning(ConversationResult result)
+    {
+        var mediator = new Mock<IMediator>();
+        mediator.Setup(m => m.Send(It.IsAny<RunConversationCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(result);
+        return mediator;
+    }
+
+    private static ConversationResult Ok() => new()
+    {
+        Success = true,
+        Turns = [new TurnSummary { TurnNumber = 1, UserMessage = "hi", AgentResponse = "hello" }],
+        FinalResponse = "hello",
+        TotalToolInvocations = 1
+    };
+
+    [Fact]
+    public async Task ExecuteAsync_UnknownJobId_ReturnsNotFound()
+    {
+        var (executor, _, _) = BuildSut(new Mock<IMediator>().Object);
+
+        var result = await executor.ExecuteAsync("ghost", CancellationToken.None);
+
+        result.Status.Should().Be(BundleRunExecutionStatus.NotFound);
+        result.Record.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_NonQueuedRecord_ReturnsAlreadyClaimed_WithoutDriving()
+    {
+        var mediator = new Mock<IMediator>();
+        var (executor, jobStore, handleStore) = BuildSut(mediator.Object);
+        var staged = StageOnDisk("b1");
+        var handle = handleStore.Register(staged, "owner-1");
+        jobStore.Create(QueuedRecord("j1", handle, staged.Agent.Id) with { Status = BundleRunStatus.Running });
+
+        var result = await executor.ExecuteAsync("j1", CancellationToken.None);
+
+        result.Status.Should().Be(BundleRunExecutionStatus.AlreadyClaimed);
+        mediator.Verify(m => m.Send(It.IsAny<RunConversationCommand>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_AlreadyClaimedByAnotherDriver_StandsDown()
+    {
+        var mediator = MediatorReturning(Ok());
+        var (executor, jobStore, handleStore) = BuildSut(mediator.Object);
+        var staged = StageOnDisk("b1");
+        var handle = handleStore.Register(staged, "owner-1");
+        jobStore.Create(QueuedRecord("j1", handle, staged.Agent.Id, streaming: true));
+
+        // Another driver claims the run first (CAS win); this call must stand down and drive nothing.
+        jobStore.TryBeginRun("j1", _time.GetUtcNow());
+
+        var result = await executor.ExecuteAsync("j1", CancellationToken.None);
+
+        result.Status.Should().Be(BundleRunExecutionStatus.AlreadyClaimed);
+        mediator.Verify(m => m.Send(It.IsAny<RunConversationCommand>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_QueuedStreamingRun_ClaimsAndDrivesToSucceeded()
+    {
+        var mediator = MediatorReturning(Ok());
+        var (executor, jobStore, handleStore) = BuildSut(mediator.Object);
+        var staged = StageOnDisk("b1");
+        var handle = handleStore.Register(staged, "owner-1");
+        jobStore.Create(QueuedRecord("j1", handle, staged.Agent.Id, streaming: true));
+
+        var result = await executor.ExecuteAsync("j1", CancellationToken.None);
+
+        result.Status.Should().Be(BundleRunExecutionStatus.Ran);
+        result.Record!.Status.Should().Be(BundleRunStatus.Succeeded);
+        result.Record.StartedAt.Should().NotBeNull();
+        result.Record.Outcome!.ConversationSucceeded.Should().BeTrue();
+        jobStore.Get("j1")!.Status.Should().Be(BundleRunStatus.Succeeded);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_HandleExpiredBeforeStart_MarksFailed_WithoutStartTime()
+    {
+        var mediator = new Mock<IMediator>();
+        mediator.Setup(m => m.Send(It.IsAny<RunConversationCommand>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("must not run"));
+        var (executor, jobStore, handleStore) = BuildSut(mediator.Object);
+        var staged = StageOnDisk("b1");
+        var handle = handleStore.Register(staged, "owner-1");
+        jobStore.Create(QueuedRecord("j1", handle, staged.Agent.Id, streaming: true));
+        handleStore.Remove(handle); // handle gone before the stream connected
+
+        var result = await executor.ExecuteAsync("j1", CancellationToken.None);
+
+        result.Status.Should().Be(BundleRunExecutionStatus.Ran);
+        result.Record!.Status.Should().Be(BundleRunStatus.Failed);
+        result.Record.StartedAt.Should().BeNull("a run that never started must not carry a start time");
+        result.Record.Error.Should().Contain("expired");
+        mediator.Verify(m => m.Send(It.IsAny<RunConversationCommand>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    public void Dispose()
+    {
+        foreach (var dir in _tempDirs)
+        {
+            try { if (Directory.Exists(dir)) Directory.Delete(dir, recursive: true); }
+            catch { /* best-effort test cleanup */ }
+        }
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Bundles/InMemoryBundleRunJobStoreTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Bundles/InMemoryBundleRunJobStoreTests.cs
@@ -29,10 +29,20 @@ public sealed class InMemoryBundleRunJobStoreTests
     {
         var cfg = new AppConfig();
         cfg.AI.BundleExecution.RunRecordTtl = Ttl;
+        cfg.AI.BundleExecution.StreamReservationTtl = Ttl; // same window here so the shared streaming tests read cleanly
         return new InMemoryBundleRunJobStore(new StaticOptionsMonitor<AppConfig>(cfg), _time);
     }
 
-    private BundleRunRecord NewRecord(string jobId = "j1", BundleRunStatus status = BundleRunStatus.Queued) => new()
+    private InMemoryBundleRunJobStore BuildSut(TimeSpan runRecordTtl, TimeSpan streamReservationTtl)
+    {
+        var cfg = new AppConfig();
+        cfg.AI.BundleExecution.RunRecordTtl = runRecordTtl;
+        cfg.AI.BundleExecution.StreamReservationTtl = streamReservationTtl;
+        return new InMemoryBundleRunJobStore(new StaticOptionsMonitor<AppConfig>(cfg), _time);
+    }
+
+    private BundleRunRecord NewRecord(
+        string jobId = "j1", BundleRunStatus status = BundleRunStatus.Queued, bool streaming = false) => new()
     {
         JobId = jobId,
         Handle = "h1",
@@ -42,6 +52,7 @@ public sealed class InMemoryBundleRunJobStoreTests
         MaxTurns = 5,
         Envelope = new CapabilityEnvelope(),
         Status = status,
+        Streaming = streaming,
         CreatedAt = _time.GetUtcNow()
     };
 
@@ -157,5 +168,136 @@ public sealed class InMemoryBundleRunJobStoreTests
 
         sut.SweepExpired().Should().Be(0);
         sut.Get("j1").Should().NotBeNull();
+    }
+
+    // --- TryBeginRun (atomic claim) ---
+
+    [Fact]
+    public void TryBeginRun_QueuedRecord_TransitionsToRunning_StampsStartedAt()
+    {
+        var sut = BuildSut();
+        sut.Create(NewRecord());
+        var startedAt = _time.GetUtcNow();
+
+        var claimed = sut.TryBeginRun("j1", startedAt);
+
+        claimed.Should().NotBeNull();
+        claimed!.Status.Should().Be(BundleRunStatus.Running);
+        claimed.StartedAt.Should().Be(startedAt);
+        sut.Get("j1")!.Status.Should().Be(BundleRunStatus.Running);
+    }
+
+    [Fact]
+    public void TryBeginRun_UnknownJobId_ReturnsNull()
+    {
+        BuildSut().TryBeginRun("ghost", _time.GetUtcNow()).Should().BeNull();
+    }
+
+    [Fact]
+    public void TryBeginRun_NonQueuedRecord_ReturnsNull()
+    {
+        var sut = BuildSut();
+        sut.Create(NewRecord(status: BundleRunStatus.Running));
+
+        sut.TryBeginRun("j1", _time.GetUtcNow()).Should().BeNull();
+    }
+
+    [Fact]
+    public void TryBeginRun_CalledTwice_ClaimsExactlyOnce()
+    {
+        // The single guarantee that a run is driven once: whoever wins the CAS gets the record; the loser
+        // gets null. This is what stops two stream connections, or a stream and the dispatcher, double-running.
+        var sut = BuildSut();
+        sut.Create(NewRecord());
+
+        var first = sut.TryBeginRun("j1", _time.GetUtcNow());
+        var second = sut.TryBeginRun("j1", _time.GetUtcNow());
+
+        first.Should().NotBeNull();
+        second.Should().BeNull();
+    }
+
+    [Fact]
+    public void TryBeginRun_ExpiredStreamingReservation_ReturnsNull()
+    {
+        var sut = BuildSut();
+        sut.Create(NewRecord(streaming: true)); // unclaimed streaming reservation
+
+        _time.Advance(Ttl + TimeSpan.FromSeconds(1)); // reservation window elapsed
+
+        sut.TryBeginRun("j1", _time.GetUtcNow()).Should().BeNull("a lapsed reservation must not be driveable");
+    }
+
+    // --- Streaming reservation expiry ---
+
+    [Fact]
+    public void Get_UnclaimedStreamingReservation_ExpiresAfterTtl()
+    {
+        var sut = BuildSut();
+        sut.Create(NewRecord(streaming: true)); // Queued streaming, never claimed
+
+        _time.Advance(Ttl + TimeSpan.FromSeconds(1));
+
+        // A reservation the caller never streamed is reclaimable — unlike a background-queued run.
+        sut.Get("j1").Should().BeNull();
+    }
+
+    [Fact]
+    public void Get_ClaimedStreamingRun_NeverExpires()
+    {
+        var sut = BuildSut();
+        sut.Create(NewRecord(streaming: true));
+        sut.TryBeginRun("j1", _time.GetUtcNow()); // now Running
+
+        _time.Advance(Ttl + TimeSpan.FromHours(1));
+
+        // Once claimed, a streaming run is in-flight and is protected exactly like any other Running run.
+        sut.Get("j1").Should().NotBeNull();
+        sut.Get("j1")!.Status.Should().Be(BundleRunStatus.Running);
+    }
+
+    [Fact]
+    public void SweepExpired_RemovesUnclaimedStreamingReservation_ButNotBackgroundQueued()
+    {
+        var sut = BuildSut();
+        sut.Create(NewRecord("stream", streaming: true)); // reclaimable once its window lapses
+        sut.Create(NewRecord("bg")); // background-queued: never reclaimable until terminal
+
+        _time.Advance(Ttl + TimeSpan.FromSeconds(1));
+
+        sut.SweepExpired().Should().Be(1);
+        sut.Get("stream").Should().BeNull();
+        sut.Get("bg").Should().NotBeNull();
+    }
+
+    [Fact]
+    public void StreamingReservation_ExpiryUsesStreamReservationTtl_NotRunRecordTtl()
+    {
+        // The connect window is its own knob: an unclaimed reservation lapses on the (short) reservation TTL,
+        // NOT the (longer) result-retention TTL — so tightening result retention never shrinks the window a
+        // caller has to connect.
+        var sut = BuildSut(runRecordTtl: TimeSpan.FromMinutes(30), streamReservationTtl: TimeSpan.FromMinutes(2));
+        sut.Create(NewRecord(streaming: true));
+
+        _time.Advance(TimeSpan.FromMinutes(3)); // past the 2-min reservation window, far within RunRecordTtl
+
+        sut.Get("j1").Should().BeNull();
+    }
+
+    [Fact]
+    public void CompletedStreamingRun_PollableWindowUsesRunRecordTtl_NotReservationTtl()
+    {
+        // Once a streaming run is claimed and completes, its pollable window is the result-retention TTL like
+        // any other terminal run — the short reservation window governs only the unclaimed phase.
+        var sut = BuildSut(runRecordTtl: TimeSpan.FromMinutes(30), streamReservationTtl: TimeSpan.FromMinutes(2));
+        sut.Create(NewRecord(streaming: true));
+        sut.TryBeginRun("j1", _time.GetUtcNow());
+        sut.Update(sut.Get("j1")! with { Status = BundleRunStatus.Succeeded });
+
+        _time.Advance(TimeSpan.FromMinutes(3)); // past the reservation window...
+        sut.Get("j1").Should().NotBeNull("a completed streamed run stays pollable for the full result window");
+
+        _time.Advance(TimeSpan.FromMinutes(30)); // ...and reclaimed only once the result window elapses
+        sut.Get("j1").Should().BeNull();
     }
 }

--- a/src/Content/Tests/Presentation.BundleApi.Tests/BundleRunStreamerTests.cs
+++ b/src/Content/Tests/Presentation.BundleApi.Tests/BundleRunStreamerTests.cs
@@ -1,0 +1,179 @@
+using System.Text;
+using System.Text.Json;
+using Application.AI.Common.Interfaces.Bundles;
+using Application.AI.Common.Services;
+using Domain.AI.Bundles;
+using FluentAssertions;
+using Presentation.BundleApi.Streaming;
+using Xunit;
+
+namespace Presentation.BundleApi.Tests;
+
+/// <summary>
+/// Tests for <see cref="BundleRunStreamer"/> — the event sequence it writes, the load-bearing guarantee that
+/// the assistant-text sink is armed for the duration of the run and cleared afterward, and that failures are
+/// surfaced as caller-safe messages rather than raw internal detail.
+/// </summary>
+public sealed class BundleRunStreamerTests
+{
+    /// <summary>A fake executor that records whether the ambient sink was armed, optionally emits deltas through
+    /// it, then returns a configured outcome.</summary>
+    private sealed class FakeExecutor(BundleRunExecution result, params string[] deltas) : IBundleRunExecutor
+    {
+        public bool SinkArmedDuringRun { get; private set; }
+
+        public async Task<BundleRunExecution> ExecuteAsync(string jobId, CancellationToken cancellationToken)
+        {
+            var sink = AgentTurnStreamSink.Current;
+            SinkArmedDuringRun = sink is not null;
+            if (sink is not null)
+                foreach (var delta in deltas)
+                    await sink.EmitAsync(delta, cancellationToken);
+            return result;
+        }
+    }
+
+    private static BundleRunRecord Record(
+        BundleRunStatus status = BundleRunStatus.Queued,
+        bool conversationSucceeded = true,
+        DateTimeOffset? startedAt = null,
+        string? error = null) => new()
+    {
+        JobId = "job-1",
+        Handle = "handle-1",
+        OwnerId = "owner-1",
+        AgentName = "agent-1",
+        UserMessages = ["hi"],
+        MaxTurns = 3,
+        Envelope = new CapabilityEnvelope(),
+        Status = status,
+        Streaming = true,
+        StartedAt = startedAt,
+        Error = error,
+        CreatedAt = DateTimeOffset.UnixEpoch,
+        Outcome = status == BundleRunStatus.Succeeded
+            ? new BundleRunOutcome
+            {
+                ConversationSucceeded = conversationSucceeded,
+                FinalResponse = "done",
+                TurnCount = 1,
+                TotalToolInvocations = 0
+            }
+            : null
+    };
+
+    private static async Task<IReadOnlyList<JsonElement>> RunAndParseAsync(FakeExecutor executor, BundleRunRecord record)
+    {
+        using var stream = new MemoryStream();
+        using (var writer = new BundleStreamEventWriter(stream))
+        {
+            var streamer = new BundleRunStreamer(executor);
+            await streamer.StreamAsync(record, writer, CancellationToken.None);
+        }
+
+        return ParseFrames(Encoding.UTF8.GetString(stream.ToArray()));
+    }
+
+    /// <summary>Parses an SSE body into its event JSON objects, in order.</summary>
+    private static IReadOnlyList<JsonElement> ParseFrames(string body) => body
+        .Split("\n\n", StringSplitOptions.RemoveEmptyEntries)
+        .Select(chunk => chunk.Trim())
+        .Where(chunk => chunk.StartsWith("data: ", StringComparison.Ordinal))
+        .Select(chunk => JsonDocument.Parse(chunk["data: ".Length..]).RootElement.Clone())
+        .ToList();
+
+    private static string Type(JsonElement e) => e.GetProperty("type").GetString()!;
+
+    [Fact]
+    public async Task StreamAsync_SuccessWithText_EmitsRunStarted_OneMessage_RunFinished()
+    {
+        var executor = new FakeExecutor(BundleRunExecution.Ran(Record(BundleRunStatus.Succeeded)), "Hello", " world");
+
+        var frames = await RunAndParseAsync(executor, Record());
+
+        frames.Select(Type).Should().Equal(
+            "RUN_STARTED", "TEXT_MESSAGE_START", "TEXT_MESSAGE_CONTENT", "TEXT_MESSAGE_CONTENT",
+            "TEXT_MESSAGE_END", "RUN_FINISHED");
+
+        // Every text frame shares one messageId, and the deltas arrive verbatim and in order.
+        var messageIds = frames.Where(f => Type(f).StartsWith("TEXT_MESSAGE", StringComparison.Ordinal))
+            .Select(f => f.GetProperty("messageId").GetString()).Distinct().ToList();
+        messageIds.Should().HaveCount(1);
+        frames.Where(f => Type(f) == "TEXT_MESSAGE_CONTENT").Select(f => f.GetProperty("delta").GetString())
+            .Should().Equal("Hello", " world");
+    }
+
+    [Fact]
+    public async Task StreamAsync_NoText_SkipsMessageFrames()
+    {
+        var executor = new FakeExecutor(BundleRunExecution.Ran(Record(BundleRunStatus.Succeeded)));
+
+        var frames = await RunAndParseAsync(executor, Record());
+
+        frames.Select(Type).Should().Equal("RUN_STARTED", "RUN_FINISHED");
+    }
+
+    [Fact]
+    public async Task StreamAsync_ArmsSinkDuringRun_AndClearsAfterward()
+    {
+        var executor = new FakeExecutor(BundleRunExecution.Ran(Record(BundleRunStatus.Succeeded)), "x");
+
+        await RunAndParseAsync(executor, Record());
+
+        executor.SinkArmedDuringRun.Should().BeTrue("assistant deltas must flow to the stream during the run");
+        AgentTurnStreamSink.Current.Should().BeNull("the sink must never leak past the request");
+    }
+
+    [Fact]
+    public async Task StreamAsync_RanButFailed_EmitsRunError_WithScrubbedMessage()
+    {
+        // A run that started then failed carries an internal scrubbed code — it must NOT reach the client.
+        var failed = Record(BundleRunStatus.Failed, startedAt: DateTimeOffset.UnixEpoch,
+            error: "bundle_run.unhandled_exception");
+        var executor = new FakeExecutor(BundleRunExecution.Ran(failed));
+
+        var frames = await RunAndParseAsync(executor, Record());
+
+        Type(frames[^1]).Should().Be("RUN_ERROR");
+        var message = frames[^1].GetProperty("message").GetString()!;
+        message.Should().Be("The agent run did not complete successfully.");
+        message.Should().NotContain("bundle_run");
+    }
+
+    [Fact]
+    public async Task StreamAsync_HandleExpired_EmitsRunError_ExpiredMessage()
+    {
+        // Failed with no start time == the handle expired before the run began.
+        var expired = Record(BundleRunStatus.Failed, startedAt: null, error: "The bundle handle expired ...");
+        var executor = new FakeExecutor(BundleRunExecution.Ran(expired));
+
+        var frames = await RunAndParseAsync(executor, Record());
+
+        frames.Select(Type).Should().Equal("RUN_STARTED", "RUN_ERROR");
+        frames[^1].GetProperty("message").GetString().Should().Be(
+            "The bundle handle expired before the run could start.");
+    }
+
+    [Fact]
+    public async Task StreamAsync_ConversationReportedFailure_EmitsRunError()
+    {
+        // The run reached Succeeded, but the conversation itself reported failure — not a clean success.
+        var executor = new FakeExecutor(
+            BundleRunExecution.Ran(Record(BundleRunStatus.Succeeded, conversationSucceeded: false)));
+
+        var frames = await RunAndParseAsync(executor, Record());
+
+        Type(frames[^1]).Should().Be("RUN_ERROR");
+    }
+
+    [Fact]
+    public async Task StreamAsync_AlreadyClaimed_EmitsRunError()
+    {
+        var executor = new FakeExecutor(BundleRunExecution.AlreadyClaimed(Record(BundleRunStatus.Running)));
+
+        var frames = await RunAndParseAsync(executor, Record());
+
+        Type(frames[^1]).Should().Be("RUN_ERROR");
+        frames[^1].GetProperty("message").GetString().Should().Contain("already being streamed");
+    }
+}

--- a/src/Content/Tests/Presentation.BundleApi.Tests/BundleStreamingIntegrationTests.cs
+++ b/src/Content/Tests/Presentation.BundleApi.Tests/BundleStreamingIntegrationTests.cs
@@ -1,0 +1,115 @@
+using System.IO.Compression;
+using System.Net;
+using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+
+namespace Presentation.BundleApi.Tests;
+
+/// <summary>
+/// Full-stack HTTP tests for the streaming surface, hosting the real composition via
+/// <see cref="WebApplicationFactory{TEntryPoint}"/> under the shipped Development config (bundle execution
+/// enabled, anonymous auth). They prove the stream endpoint's owner-scoping, the reserve-then-stream lifecycle
+/// (a streaming run is created but not executed until the feed is opened), and that opening the feed drives the
+/// run and emits AG-UI events — exercised on the fast path where the handle is gone, so no agent/LLM is needed.
+/// </summary>
+public sealed class BundleStreamingIntegrationTests : IClassFixture<WebApplicationFactory<Program>>
+{
+    private readonly WebApplicationFactory<Program> _factory;
+
+    public BundleStreamingIntegrationTests(WebApplicationFactory<Program> factory) => _factory = factory;
+
+    [Fact]
+    public async Task Stream_UnknownRun_Returns404()
+    {
+        var client = _factory.CreateClient();
+
+        var response = await client.GetAsync("/api/bundles/nohandle/runs/nojob/stream");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task RunWithStream_Returns202_WithStreamUrl_AndReservationStaysQueuedUntilStreamed()
+    {
+        var client = _factory.CreateClient();
+        var handle = await RegisterValidBundleAsync(client);
+
+        var run = await client.PostAsJsonAsync(
+            $"/api/bundles/{handle}/runs",
+            new { userMessages = new[] { "hi" }, maxTurns = 1, stream = true });
+
+        run.StatusCode.Should().Be(HttpStatusCode.Accepted);
+        var (jobId, streamUrl) = await ReadStartRunAsync(run);
+        streamUrl.Should().Be($"/api/bundles/{handle}/runs/{jobId}/stream",
+            "a streamed run must advertise its feed URL");
+
+        // The reservation exists but has NOT been executed — its only driver is opening the stream, which this
+        // test has not done. Polling must therefore still report it Queued.
+        var poll = await client.GetAsync($"/api/bundles/{handle}/runs/{jobId}");
+        poll.StatusCode.Should().Be(HttpStatusCode.OK);
+        using var doc = JsonDocument.Parse(await poll.Content.ReadAsStringAsync());
+        doc.RootElement.GetProperty("status").GetString().Should().Be("Queued");
+    }
+
+    [Fact]
+    public async Task Stream_DrivesRun_AndEmitsAgUiEvents_WhenHandleGone()
+    {
+        var client = _factory.CreateClient();
+        var handle = await RegisterValidBundleAsync(client);
+
+        var run = await client.PostAsJsonAsync(
+            $"/api/bundles/{handle}/runs",
+            new { userMessages = new[] { "hi" }, maxTurns = 1, stream = true });
+        var (_, streamUrl) = await ReadStartRunAsync(run);
+
+        // Delete the bundle so the run fails immediately when it tries to acquire the (now-gone) handle — this
+        // drives the full stream plumbing to a terminal event without ever building an agent or calling an LLM.
+        (await client.DeleteAsync($"/api/bundles/{handle}")).StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        var stream = await client.GetAsync(streamUrl);
+
+        stream.StatusCode.Should().Be(HttpStatusCode.OK);
+        stream.Content.Headers.ContentType!.MediaType.Should().Be("text/event-stream");
+        var body = await stream.Content.ReadAsStringAsync();
+        body.Should().Contain("RUN_STARTED").And.Contain("RUN_ERROR");
+        body.Should().NotContain("RUN_FINISHED", "a run whose handle vanished did not complete successfully");
+    }
+
+    private static async Task<string> RegisterValidBundleAsync(HttpClient client)
+    {
+        using var content = new MultipartFormDataContent
+        {
+            { new ByteArrayContent(BuildValidBundleZip()), "file", "bundle.zip" }
+        };
+
+        var register = await client.PostAsync("/api/bundles", content);
+        register.StatusCode.Should().Be(HttpStatusCode.Created,
+            "a well-formed bundle must register; body was: {0}", await register.Content.ReadAsStringAsync());
+
+        using var doc = JsonDocument.Parse(await register.Content.ReadAsStringAsync());
+        return doc.RootElement.GetProperty("handle").GetString()!;
+    }
+
+    private static async Task<(string JobId, string StreamUrl)> ReadStartRunAsync(HttpResponseMessage response)
+    {
+        using var doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        return (doc.RootElement.GetProperty("jobId").GetString()!,
+                doc.RootElement.GetProperty("streamUrl").GetString()!);
+    }
+
+    private static byte[] BuildValidBundleZip()
+    {
+        using var ms = new MemoryStream();
+        using (var archive = new ZipArchive(ms, ZipArchiveMode.Create, leaveOpen: true))
+        {
+            var entry = archive.CreateEntry("AGENT.md");
+            using var writer = new StreamWriter(entry.Open(), Encoding.UTF8);
+            writer.Write("---\nid: stream-bundle\nname: Stream Bundle\n---\nStream bundle instructions.");
+        }
+        return ms.ToArray();
+    }
+}


### PR DESCRIPTION
## Summary
Final phase of the bundle-injection API (Issue #154, Part 2). Adds the **opt-in live-stream** delivery mode: a caller starts a run with `stream: true` and opens `GET /api/bundles/{handle}/runs/{jobId}/stream` to watch the agent's output stream in token-by-token as AG-UI Server-Sent-Events. Owner-scoped like the poll/delete endpoints; client disconnect cancels the run. Off by default (`BundleExecution.Enabled=false`), inert until a host opts in.

## Design: one shared run-engine
`BundleRunExecutor` is extracted from `BundleRunBackgroundService` so that **both** the background dispatcher (poll-only runs) and the live-stream endpoint arm the capability envelope + ephemeral-agent overlay through **one code path**. The envelope arming is what makes the tool-invocation governor enforce — with it in two places, one could silently drift and fail the gate open. It now lives in exactly one place. The job store gains an atomic `TryBeginRun` (Queued → Running CAS) that guarantees a run is driven **exactly once**, even if two drivers race (two stream connections, or a stream and the dispatcher).

A streamed run is created but **not enqueued** — its sole driver is the caller connecting — so it can never race the background dispatcher.

## Security & correctness (from `/code-review` + `/simplify`)
Six review agents across all eight angles plus an adversarial security pass. **No high/critical findings; the security model verified sound** (no fail-open governor, no IDOR, no double-run/TOCTOU, no SSE info-leak, no AsyncLocal sink leak) and every prior behavior preserved through the refactor. Fixed:

- **Security (Medium)** — the long-lived SSE endpoint was guarded only by a fixed-window *rate* limiter, which caps request rate, not *simultaneous* streams. A caller could accumulate unbounded concurrent agent conversations (each pinning a lease + burning tokens). Added a **per-caller concurrency limiter** (`MaxConcurrentStreamsPerCaller`, default 4).
- **Correctness** — the stream connect window was coupled to `RunRecordTtl` (result retention). Decoupled via a dedicated `StreamReservationTtl` (default 5 min).
- **Docs/altitude** — removed HTTP-route vocabulary from the Domain/Application flag docs; the `IBundleRunJobStore` **contract** now states the reservation-expiry rule so a future persistent-store implementer sees it; added per-property XML docs to the event records.
- **Cleanup** — reuse the snapshot already in hand on the CAS-loss path instead of a redundant store read.

Consciously **declined** (rationale in commit): a new `Reserved` enum status (over-modeling one store's predicate — fixed the interface contract doc instead), removing the write-semaphore (parity with the sibling `AgUiEventWriter`), and micro-optimizing the per-delta string alloc (matches the reference idiom).

## Isolation
The bundle host ships its **own** small SSE writer + 6 AG-UI-shaped event records rather than referencing `Presentation.AgentHub`, keeping it the lean isolated host it was designed to be. The wire format is identical, so any AG-UI client interops. (Rule-of-three not met for extracting a shared primitive — deferred.)

## Test plan
- Build **0 warnings / 0 errors**.
- **129 bundle tests green**: BundleApi 26, Infrastructure 51, Application 26, Domain 815.
- Includes an end-to-end `WebApplicationFactory` stream test that reserves a run → deletes the handle → drives the stream to `RUN_ERROR` **without ever calling an LLM** (fast, deterministic), the reserve-stays-Queued-until-streamed lifecycle, owner-scoping (404), the CAS claim-exactly-once guarantee, and the `StreamReservationTtl` / `RunRecordTtl` decoupling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)