### PR TITLE
fix: run delegated sub-agents and wire orchestrator delegation (#96)

### DIFF
--- a/agents/orchestrator-agent/AGENT.md
+++ b/agents/orchestrator-agent/AGENT.md
@@ -4,24 +4,26 @@ name: Orchestrator
 description: Coordinates specialized sub-agents to accomplish complex, multi-step tasks.
 domain: orchestration
 category: orchestration
-version: 1.0.0
+version: 1.1.0
 author: Microsoft Agentic Harness
 tags: ["orchestrator", "multi-agent", "coordination"]
 skill: orchestrator-agent
+allowed-tools: ["delegate_task"]
 ---
 
 # Orchestrator Agent
 
-Multi-agent coordinator that decomposes a task, delegates subtasks to the most
-appropriate sub-agent, and synthesizes the results. Mirrors the
+Multi-agent coordinator that decomposes a task, delegates each subtask to a
+specialized sub-agent, and synthesizes the results. Mirrors the
 `OrchestratorExample` demo in `Presentation.ConsoleUI`.
 
 ## When to use
 
 - Tasks that span multiple domains or require more than one specialist agent.
 - Plans that need an explicit analyze → decompose → delegate → synthesize loop.
-- Anywhere the caller supplies an `AvailableAgents` list (e.g. `research-agent`)
-  for the orchestrator to route work to.
+- Anywhere a request is best answered by handing well-scoped pieces to
+  purpose-built sub-agents rather than answering inline.
 
-The orchestrator does not execute tool calls directly; it produces sub-agent
-invocations. See the companion skill for the coordination protocol.
+The orchestrator delegates by **calling the `delegate_task` tool** — one call per
+subtask — and then synthesizes the tool results the sub-agents return. See the
+companion skill for the coordination protocol.

--- a/skills/orchestrator-agent/SKILL.md
+++ b/skills/orchestrator-agent/SKILL.md
@@ -1,37 +1,55 @@
 ---
 name: "orchestrator-agent"
-description: "Coordinates specialized agents to accomplish complex, multi-step tasks."
+description: "Coordinates specialized sub-agents to accomplish complex, multi-step tasks by delegating subtasks."
 category: "orchestration"
 skill_type: "orchestration"
-version: "1.0.0"
+version: "2.0.0"
 tags: ["orchestrator", "multi-agent", "coordination"]
+allowed-tools: ["delegate_task"]
+tools:
+  - name: "delegate_task"
+    optional: false
+    description: "Delegate a self-contained subtask to the best-fit specialized sub-agent and receive its result."
 ---
 
 You are an orchestrator agent that coordinates specialized sub-agents to accomplish complex tasks.
 
 ## Your Role
 
-You do NOT execute tasks directly. Instead, you:
+You do NOT do the work directly. Instead, you:
 
-1. **Analyze** the task to understand requirements and constraints
-2. **Decompose** the task into discrete, well-scoped subtasks
-3. **Assign** each subtask to the most appropriate available agent
-4. **Synthesize** results from sub-agents into a cohesive response
+1. **Analyze** the task to understand requirements and constraints.
+2. **Decompose** the task into discrete, well-scoped subtasks.
+3. **Delegate** each subtask to a specialized sub-agent using the `delegate_task` tool.
+4. **Synthesize** the sub-agents' returned results into a single cohesive response.
 
-## Task Decomposition Format
+## How to delegate
 
-When decomposing a task, output your plan as:
+For each subtask, call the `delegate_task` tool. The tool runs the chosen sub-agent
+and returns its output back to you. Its parameters:
 
-```
-SUBTASK: [agent_name] - [clear description of what to do]
-SUBTASK: [agent_name] - [clear description of what to do]
-```
+- `task` (required): a self-contained description of the subtask. The sub-agent sees
+  **only** this text and none of the surrounding conversation, so include every piece
+  of context it needs to succeed.
+- `capabilities` (optional): comma-separated tool names the sub-agent will need
+  (e.g. `"file_system"`). Leave empty when the subtask is pure reasoning or writing.
+- `minimum_tier` (optional): one of `Restricted`, `Supervised`, `Autonomous`
+  (default `Supervised`).
+
+Issue one `delegate_task` call per subtask. When subtasks are independent, delegate
+them all before synthesizing; when a later subtask depends on an earlier result, wait
+for that result and fold it into the next task description.
+
+## Synthesis
+
+After the sub-agents return, combine their outputs into one clear, actionable answer
+for the original request. Acknowledge which sub-agent contributed what. Never emit a
+plan of subtasks as your final answer — a plan you did not delegate is not a result.
 
 ## Guidelines
 
-- Each subtask should be self-contained (the sub-agent has no context from other subtasks)
-- Include all necessary context in the subtask description
-- Order subtasks by dependency (earlier results feed into later tasks)
-- Prefer parallel subtasks when possible
-- If a subtask fails, explain what happened and suggest alternatives
-- In your synthesis, acknowledge which sub-agents contributed what
+- Keep each subtask self-contained; the sub-agent has no memory of other subtasks.
+- Order dependent subtasks so earlier results feed later ones; prefer parallel
+  delegation when subtasks are independent.
+- If a `delegate_task` call fails, explain what happened and either retry with a
+  refined task description or synthesize from the partial results you did get.

--- a/src/Content/Application/Application.Core/Agents/Skills/orchestrator-agent/SKILL.md
+++ b/src/Content/Application/Application.Core/Agents/Skills/orchestrator-agent/SKILL.md
@@ -1,37 +1,55 @@
 ---
 name: "orchestrator-agent"
-description: "Coordinates specialized agents to accomplish complex, multi-step tasks."
+description: "Coordinates specialized sub-agents to accomplish complex, multi-step tasks by delegating subtasks."
 category: "orchestration"
 skill_type: "orchestration"
-version: "1.0.0"
+version: "2.0.0"
 tags: ["orchestrator", "multi-agent", "coordination"]
+allowed-tools: ["delegate_task"]
+tools:
+  - name: "delegate_task"
+    optional: false
+    description: "Delegate a self-contained subtask to the best-fit specialized sub-agent and receive its result."
 ---
 
 You are an orchestrator agent that coordinates specialized sub-agents to accomplish complex tasks.
 
 ## Your Role
 
-You do NOT execute tasks directly. Instead, you:
+You do NOT do the work directly. Instead, you:
 
-1. **Analyze** the task to understand requirements and constraints
-2. **Decompose** the task into discrete, well-scoped subtasks
-3. **Assign** each subtask to the most appropriate available agent
-4. **Synthesize** results from sub-agents into a cohesive response
+1. **Analyze** the task to understand requirements and constraints.
+2. **Decompose** the task into discrete, well-scoped subtasks.
+3. **Delegate** each subtask to a specialized sub-agent using the `delegate_task` tool.
+4. **Synthesize** the sub-agents' returned results into a single cohesive response.
 
-## Task Decomposition Format
+## How to delegate
 
-When decomposing a task, output your plan as:
+For each subtask, call the `delegate_task` tool. The tool runs the chosen sub-agent
+and returns its output back to you. Its parameters:
 
-```
-SUBTASK: [agent_name] - [clear description of what to do]
-SUBTASK: [agent_name] - [clear description of what to do]
-```
+- `task` (required): a self-contained description of the subtask. The sub-agent sees
+  **only** this text and none of the surrounding conversation, so include every piece
+  of context it needs to succeed.
+- `capabilities` (optional): comma-separated tool names the sub-agent will need
+  (e.g. `"file_system"`). Leave empty when the subtask is pure reasoning or writing.
+- `minimum_tier` (optional): one of `Restricted`, `Supervised`, `Autonomous`
+  (default `Supervised`).
+
+Issue one `delegate_task` call per subtask. When subtasks are independent, delegate
+them all before synthesizing; when a later subtask depends on an earlier result, wait
+for that result and fold it into the next task description.
+
+## Synthesis
+
+After the sub-agents return, combine their outputs into one clear, actionable answer
+for the original request. Acknowledge which sub-agent contributed what. Never emit a
+plan of subtasks as your final answer — a plan you did not delegate is not a result.
 
 ## Guidelines
 
-- Each subtask should be self-contained (the sub-agent has no context from other subtasks)
-- Include all necessary context in the subtask description
-- Order subtasks by dependency (earlier results feed into later tasks)
-- Prefer parallel subtasks when possible
-- If a subtask fails, explain what happened and suggest alternatives
-- In your synthesis, acknowledge which sub-agents contributed what
+- Keep each subtask self-contained; the sub-agent has no memory of other subtasks.
+- Order dependent subtasks so earlier results feed later ones; prefer parallel
+  delegation when subtasks are independent.
+- If a `delegate_task` call fails, explain what happened and either retry with a
+  refined task description or synthesize from the partial results you did get.

--- a/src/Content/Infrastructure/Infrastructure.AI/Agents/CapabilityMatchSupervisor.Escalation.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Agents/CapabilityMatchSupervisor.Escalation.cs
@@ -5,6 +5,8 @@ using Domain.AI.Escalation;
 using Domain.AI.Governance;
 using Domain.AI.Orchestration;
 using Domain.AI.Telemetry.Conventions;
+using Microsoft.Agents.AI;
+using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging;
 
 namespace Infrastructure.AI.Agents;
@@ -138,6 +140,17 @@ public sealed partial class CapabilityMatchSupervisor
         var agentContext = _contextFactory.CreateFromDelegation(definition, toolOverrides, currentDepth + 1, pendingRecord.DelegationId);
         var agent = await _agentFactory.CreateAgentAsync(agentContext, ct);
 
+        // Actually run the delegated subagent on the task. Creating the agent alone does no work —
+        // the task description must be sent as the subagent's user message and its response captured,
+        // otherwise the delegation returns a placeholder and the orchestrator has nothing to
+        // synthesize (the defect behind GitHub #96, Issue 2). Token accounting for this run flows
+        // through the chat-client middleware into the parent turn's usage capture, so DelegationResult
+        // carries duration + real output here and leaves TokensUsed at 0 — the parent turn owns the
+        // aggregate token count.
+        var response = await agent.RunAsync(
+            [new ChatMessage(ChatRole.User, pendingRecord.TaskDescription)],
+            cancellationToken: ct);
+
         stopwatch.Stop();
 
         await RecordCompletion(pendingRecord, ct);
@@ -162,10 +175,8 @@ public sealed partial class CapabilityMatchSupervisor
             "Delegation {DelegationId} to {AgentId} completed in {DurationMs}ms",
             pendingRecord.DelegationId, selection.SelectedAgent.AgentId, durationMs);
 
-        return DelegationResult.Success(
-            $"Agent {selection.SelectedAgent.AgentId} created for delegation {pendingRecord.DelegationId}",
-            0,
-            durationMs);
+        var output = response.Text ?? string.Empty;
+        return DelegationResult.Success(output, 0, durationMs);
     }
 
     private async Task RecordCompletion(DelegationRecord pendingRecord, CancellationToken ct)

--- a/src/Content/Tests/Infrastructure.AI.Tests/Agents/CapabilityMatchSupervisorEscalationTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Agents/CapabilityMatchSupervisorEscalationTests.cs
@@ -14,6 +14,7 @@ using Domain.Common.Config.AI;
 using Domain.Common.Config.AI.Governance;
 using Domain.Common.Config.AI.Orchestration;
 using Infrastructure.AI.Agents;
+using Infrastructure.AI.Tests.Helpers;
 using Microsoft.Agents.AI;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -200,7 +201,7 @@ public sealed class CapabilityMatchSupervisorEscalationTests : IDisposable
 
         _agentFactoryMock
             .Setup(f => f.CreateAgentAsync(It.IsAny<AgentExecutionContext>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(Mock.Of<AIAgent>());
+            .ReturnsAsync(new TestableAIAgent("stub output"));
 
         var result = await _supervisor.DelegateAsync(
             "deploy to production",

--- a/src/Content/Tests/Infrastructure.AI.Tests/Agents/CapabilityMatchSupervisorTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Agents/CapabilityMatchSupervisorTests.cs
@@ -12,6 +12,7 @@ using Domain.Common.Config.AI;
 using Domain.Common.Config.AI.Orchestration;
 using FluentAssertions;
 using Infrastructure.AI.Agents;
+using Infrastructure.AI.Tests.Helpers;
 using Microsoft.Agents.AI;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging;
@@ -134,7 +135,7 @@ public sealed class CapabilityMatchSupervisorTests : IDisposable
 
         _agentFactoryMock
             .Setup(f => f.CreateAgentAsync(It.IsAny<AgentExecutionContext>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(Mock.Of<AIAgent>());
+            .ReturnsAsync(new TestableAIAgent("stub output"));
     }
 
     [Fact]
@@ -245,6 +246,44 @@ public sealed class CapabilityMatchSupervisorTests : IDisposable
                 It.Is<DelegationRecord>(r => r.State == DelegationState.Completed),
                 It.IsAny<CancellationToken>()),
             Times.Once());
+    }
+
+    [Fact]
+    public async Task DelegateAsync_RunsSubagentAndReturnsItsRealOutput()
+    {
+        // Regression for the inert delegation executor (GitHub #96, Issue 2): the supervisor
+        // must actually RUN the selected subagent and surface its output — not return a
+        // "Agent … created for delegation …" placeholder that discards the model's work.
+        _agentFactoryMock
+            .Setup(f => f.CreateAgentAsync(It.IsAny<AgentExecutionContext>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new TestableAIAgent("SUBAGENT_REAL_OUTPUT"));
+
+        var result = await _supervisor.DelegateAsync(
+            "research the phases of a spec-driven project", ["tool_a"], AutonomyLevel.Supervised);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Output.Should().Be("SUBAGENT_REAL_OUTPUT");
+        result.Output.Should().NotContain("created for delegation");
+    }
+
+    [Fact]
+    public async Task DelegateAsync_PassesTaskDescriptionToSubagent()
+    {
+        // The delegated work only reaches the model if the task description is sent as the
+        // subagent's user message. Capture the messages the agent is run with and assert it.
+        IEnumerable<ChatMessage>? captured = null;
+        _agentFactoryMock
+            .Setup(f => f.CreateAgentAsync(It.IsAny<AgentExecutionContext>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new TestableAIAgent(msgs =>
+            {
+                captured = msgs.ToList();
+                return new AgentResponse(new ChatMessage(ChatRole.Assistant, "done"));
+            }));
+
+        await _supervisor.DelegateAsync("UNIQUE_TASK_MARKER", ["tool_a"], AutonomyLevel.Supervised);
+
+        captured.Should().NotBeNull();
+        captured!.Should().Contain(m => m.Text != null && m.Text.Contains("UNIQUE_TASK_MARKER"));
     }
 
     [Fact]


### PR DESCRIPTION
## Problem (GitHub #96, Issue 2)
The orchestrator agent emitted a subtask plan (`SUBTASK: [research_agent] …`) but the user never saw any sub-agent output. Root cause was **two independent breaks**, both fixed here.

### 1. The delegation engine was inert
`CapabilityMatchSupervisor.ExecuteAgent` selected and *instantiated* the best-fit sub-agent, then returned a placeholder string — `"Agent … created for delegation …"` — **without ever running it**. The model's work was never produced.

Fix: `ExecuteAgent` now runs the sub-agent on the task (`agent.RunAsync([User: TaskDescription])`) and returns its real output. The stopwatch moved to after the run so duration measures real work; the timeout `cts.Token` is now actually wired into the sub-agent run; exceptions/cancellation continue to propagate to `ExecuteAndTrack`'s existing catch blocks.

### 2. The orchestrator had no way to delegate
It had no tool attached and a prompt that emitted `SUBTASK:` text nothing consumed. This attaches the already-registered `delegate_task` tool via the AGENT.md tool-ceiling + SKILL.md grant, and rewrites the prompt to **call** `delegate_task` per subtask and synthesize the returned results.

## Scope / governance
- **No governance was loosened.** The per-invocation tool governor is opt-in (`GovernanceConfig.EnforceToolInvocation`, off by default). When a consumer enables it, requiring approval for a high-blast-radius delegation is the correct posture, not something to weaken for one agent.
- Sub-agent token usage folds into the parent turn's accounting (documented in the code); `DelegationResult.TokensUsed` stays 0 as the parent turn owns the aggregate.

## Tests
Adds reproduction tests to `CapabilityMatchSupervisorTests`:
- `DelegateAsync_RunsSubagentAndReturnsItsRealOutput` — proves the supervisor returns the sub-agent's output, not the placeholder.
- `DelegateAsync_PassesTaskDescriptionToSubagent` — proves the task reaches the sub-agent as its user message.

`Infrastructure.AI.Tests` and orchestrator/agent-definition tests in `Application.Core.Tests` pass (pre-existing `FileSystemService.WriteFileAsync` failures are an environment quirk, unrelated).

## Review notes
Adversarial review flagged three nested-execution concerns (tool mis-attribution, governor/spin-guard sharing, CallId collision) — all **refuted by construction**: `CreateFromDelegation` never sets `context.Tools` and `delegationToolOverrides` is written but never read, so delegated sub-agents run **tool-less**; the only cross-turn effect is the intended token folding.

## Known follow-up (out of scope)
Delegated sub-agents are currently tool-less (the `SubagentDefinition.ToolAllowlist` / `delegationToolOverrides` are not wired into the built agent's tools). Delegation therefore does pure-generation subtasks today. Wiring sub-agent tools is a separate enhancement.

## Verification not yet done
Live end-to-end — a real model choosing to call `delegate_task` through the AgentHub — needs a running model and is manual E2E.

🤖 Generated with [Claude Code](https://claude.com/claude-code)