### PR TITLE
fix: stop phantom empty conversations in AgentHub WebUI (#96)

### DIFF
--- a/src/Content/Presentation/Presentation.WebUI/src/app/router.tsx
+++ b/src/Content/Presentation/Presentation.WebUI/src/app/router.tsx
@@ -32,6 +32,9 @@ const AppRoutes = () => (
     <Route element={<DashboardLayout />}>
       <Route index element={<Navigate to="/chat" replace />} />
       <Route path="chat" element={<ChatView />} />
+      {/* The active conversation lives in the URL so refresh/back/bookmark restore it. Blank `/chat`
+          (above) shows an empty composer; `/chat/:conversationId` opens that conversation. */}
+      <Route path="chat/:conversationId" element={<ChatView />} />
       <Route path="agents" element={<AgentsView />} />
       <Route path="tools" element={<ToolsView />} />
       <Route path="resources" element={<ResourcesView />} />

--- a/src/Content/Presentation/Presentation.WebUI/src/components/layout/DashboardLayout.tsx
+++ b/src/Content/Presentation/Presentation.WebUI/src/components/layout/DashboardLayout.tsx
@@ -4,6 +4,7 @@ import { Header } from './Header';
 import { AiProviderBanner } from './AiProviderBanner';
 import { SidebarSwitcher } from './SidebarSwitcher';
 import { useAppStore } from '@/stores/appStore';
+import { useChatStore } from '@/features/chat/useChatStore';
 import { CommandPalette, type CommandItem } from '@/features/commands/CommandPalette';
 import { useAgentsQuery } from '@/features/agents/useAgentsQuery';
 import { useTheme } from '@/hooks/useTheme';
@@ -12,9 +13,9 @@ import { NAV_ITEMS } from '@/lib/navigation';
 export function DashboardLayout() {
   const toggleSidebar = useAppStore((s) => s.toggleSidebar);
   const showSidebar = useAppStore((s) => s.showSidebar);
-  const setActiveConversationId = useAppStore((s) => s.setActiveConversationId);
   const setSelectedAgent = useAppStore((s) => s.setSelectedAgent);
   const selectedAgent = useAppStore((s) => s.selectedAgent);
+  const clearMessages = useChatStore((s) => s.clearMessages);
   const [paletteOpen, setPaletteOpen] = useState(false);
   const agentsQuery = useAgentsQuery();
   const { resolvedTheme, toggleTheme } = useTheme();
@@ -54,7 +55,8 @@ export function DashboardLayout() {
         group: 'Chat',
         keywords: ['reset', 'clear', 'start'],
         run: () => {
-          setActiveConversationId(crypto.randomUUID());
+          // Blank composer, no id minted — the conversation is created on the first message.
+          clearMessages();
           navigate('/chat');
         },
       },
@@ -96,7 +98,8 @@ export function DashboardLayout() {
         keywords: ['switch', 'agent', agent.name],
         run: () => {
           setSelectedAgent(agent.id);
-          setActiveConversationId(null);
+          // Fresh blank composer for the chosen agent; no phantom conversation.
+          clearMessages();
           navigate('/chat');
         },
       });
@@ -108,7 +111,7 @@ export function DashboardLayout() {
     pathname,
     agentsQuery.data,
     selectedAgent,
-    setActiveConversationId,
+    clearMessages,
     toggleSidebar,
     toggleTheme,
     setSelectedAgent,

--- a/src/Content/Presentation/Presentation.WebUI/src/features/agents/AgentsList.tsx
+++ b/src/Content/Presentation/Presentation.WebUI/src/features/agents/AgentsList.tsx
@@ -1,18 +1,23 @@
 import { Bot, Check } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
 import { useAgentsQuery } from './useAgentsQuery';
 import { useAppStore } from '@/stores/appStore';
+import { useChatStore } from '@/features/chat/useChatStore';
 import { cn } from '@/lib/utils';
 
 export function AgentsList() {
   const { data: agents, isLoading, error } = useAgentsQuery();
   const selectedAgent = useAppStore((s) => s.selectedAgent);
   const setSelectedAgent = useAppStore((s) => s.setSelectedAgent);
-  const setActiveConversationId = useAppStore((s) => s.setActiveConversationId);
+  const clearMessages = useChatStore((s) => s.clearMessages);
+  const navigate = useNavigate();
 
   const handleSelect = (id: string): void => {
-    if (id === selectedAgent) return;
-    setSelectedAgent(id);
-    setActiveConversationId(null);
+    if (id !== selectedAgent) setSelectedAgent(id);
+    // Land on a blank composer for the chosen agent. Navigating to `/chat` (no id) mints nothing
+    // server-side; the conversation is created only when the first message is sent.
+    clearMessages();
+    navigate('/chat');
   };
 
   if (isLoading) {

--- a/src/Content/Presentation/Presentation.WebUI/src/features/chat/ChatPanel.tsx
+++ b/src/Content/Presentation/Presentation.WebUI/src/features/chat/ChatPanel.tsx
@@ -1,14 +1,12 @@
 import { useEffect, useState } from 'react';
 import { Settings, Sparkles } from 'lucide-react';
-import { useQueryClient } from '@tanstack/react-query';
 import { cn } from '@/lib/utils';
 import { useChatStore } from './useChatStore';
 import { useAppStore } from '@/stores/appStore';
 import { useConversationSettingsStore } from '@/stores/conversationSettingsStore';
-import { useAgentHub, type ConnectionState, type ConversationSettingsInput, type ServerConversationMessage } from '@/hooks/useAgentHub';
+import { useAgentHub, type ConnectionState, type ConversationSettingsInput } from '@/hooks/useAgentHub';
 import { useSendUserMessage } from '@/hooks/useSendUserMessage';
-import type { ChatMessage } from './useChatStore';
-import { CONVERSATIONS_QUERY_KEY } from '@/features/conversations/useConversationsQuery';
+import { loadConversationHistory } from './loadConversationHistory';
 import { MessageList } from './MessageList';
 import { TypingIndicator } from './TypingIndicator';
 import { ChatInput } from './ChatInput';
@@ -109,13 +107,10 @@ function ErrorBanner() {
 }
 
 export function ChatPanel() {
-  const queryClient = useQueryClient();
   const setChatConversationId = useChatStore((s) => s.setConversationId);
   const selectedAgent = useAppStore((s) => s.selectedAgent);
   const activeConversationId = useAppStore((s) => s.activeConversationId);
-  const setActiveConversationId = useAppStore((s) => s.setActiveConversationId);
   const {
-    startConversation,
     retryFromMessage,
     editAndResubmit,
     setConversationSettings,
@@ -168,54 +163,53 @@ export function ChatPanel() {
     });
   };
 
+  // Adopt the URL-driven active conversation and load its transcript from the read-only history
+  // endpoint. This never creates the conversation server-side (a 404 for a not-yet-messaged id
+  // resolves to a blank transcript), so navigating to chat, switching agents, and refreshing mint no
+  // phantom conversations — the conversation is registered only when the first message is sent (see
+  // useSendUserMessage).
+  //
+  // The transcript reloads whenever the active id changes to one the store's transcript does NOT
+  // already belong to — including a switch via the browser back/forward buttons, which no click
+  // handler intercepts (so nothing clears the previous conversation's messages first). An
+  // optimistic/in-flight transcript that DOES belong to this id (a freshly minted id that was just
+  // sent, or a turn mid-stream) is preserved rather than clobbered by a reload.
   useEffect(() => {
-    if (selectedAgent && !activeConversationId) {
-      setActiveConversationId(crypto.randomUUID());
+    if (!activeConversationId) {
+      // Blank composer (`/chat` with no id) — ready immediately, nothing to load.
+      setConversationReady(true);
+      return;
     }
-  }, [selectedAgent, activeConversationId, setActiveConversationId]);
 
-  useEffect(() => {
-    if (activeConversationId) setChatConversationId(activeConversationId);
-  }, [activeConversationId, setChatConversationId]);
+    const store = useChatStore.getState();
+    const transcriptBelongsToActiveId =
+      store.conversationId === activeConversationId && store.messages.length > 0;
+    if (transcriptBelongsToActiveId) {
+      setConversationReady(true);
+      return;
+    }
 
-  useEffect(() => {
-    if (connectionState !== 'connected' || !selectedAgent || !activeConversationId) return;
+    // A switch (or a fresh page load): bind the transcript to the new id and load its history.
+    // setMessages always runs on completion — an empty history (a brand-new id) clears any stale
+    // previous-conversation messages rather than leaving them on screen under the new URL.
+    setChatConversationId(activeConversationId);
     setConversationReady(false);
     let cancelled = false;
-    void startConversation(selectedAgent, activeConversationId)
-      .then((history: ServerConversationMessage[]) => {
+    void loadConversationHistory(activeConversationId)
+      .then((messages) => {
         if (cancelled) return;
-        if (history?.length) {
-          const mapped: ChatMessage[] = history
-            .filter(m => {
-              const r = m.role.toLowerCase();
-              return r === 'user' || r === 'assistant';
-            })
-            .map(m => ({
-              id: m.id,
-              role: m.role.toLowerCase() as 'user' | 'assistant',
-              content: m.content,
-              timestamp: new Date(m.timestamp),
-              toolCalls: m.toolCalls ?? undefined,
-              widget: m.widget ?? undefined,
-            }));
-          if (mapped.length > 0) {
-            useChatStore.getState().setMessages(mapped);
-          }
-        }
-        void queryClient.invalidateQueries({ queryKey: CONVERSATIONS_QUERY_KEY });
+        useChatStore.getState().setMessages(messages);
         setConversationReady(true);
       })
       .catch((err: unknown) => {
         if (cancelled) return;
         useChatStore.getState().setError(
-          err instanceof Error ? err.message : 'Failed to start conversation',
+          err instanceof Error ? err.message : 'Failed to load conversation',
         );
         setConversationReady(true);
       });
     return () => { cancelled = true; };
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [connectionState, selectedAgent, activeConversationId]);
+  }, [activeConversationId, setChatConversationId]);
 
   if (!selectedAgent) {
     return (
@@ -246,9 +240,9 @@ export function ChatPanel() {
         />
       </div>
       <TypingIndicator />
-      {activeConversationId && (
-        <ChatInput disabled={!conversationReady} />
-      )}
+      {/* Always available once an agent is selected: a blank /chat with no id mints its conversation on
+          the first send, so the composer must be reachable before an id exists. */}
+      <ChatInput disabled={!conversationReady} />
       <ConversationSettingsDrawer
         open={settingsOpen}
         onClose={() => { setSettingsOpen(false); }}

--- a/src/Content/Presentation/Presentation.WebUI/src/features/chat/__tests__/ChatPanel.test.tsx
+++ b/src/Content/Presentation/Presentation.WebUI/src/features/chat/__tests__/ChatPanel.test.tsx
@@ -1,13 +1,16 @@
-import { screen, waitFor } from '@testing-library/react';
+import { screen, waitFor, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { vi, describe, it, expect, beforeEach } from 'vitest';
 import { useChatStore } from '../useChatStore';
 import { useAppStore } from '@/stores/appStore';
+import type { ChatMessage } from '../useChatStore';
 import { ChatPanel } from '../ChatPanel';
 import { renderWithProviders } from '@/test/utils';
 
 const mockSendMessage = vi.fn();
-const mockStartConversation = vi.fn().mockResolvedValue(undefined);
+// startConversation must NOT be called on mount/navigation any more — it is deferred to the first
+// user message (in useSendUserMessage). ChatPanel only ever loads history read-only.
+const mockStartConversation = vi.fn().mockResolvedValue([]);
 
 vi.mock('@/hooks/useAgentHub', () => ({
   useAgentHub: () => ({
@@ -28,6 +31,15 @@ vi.mock('@/hooks/useAgentStream', () => ({
   }),
 }));
 
+// ChatPanel loads the active conversation's transcript from this read-only helper (never creating it
+// server-side). Mock it so tests drive history/gating without HTTP.
+const mockLoadHistory = vi.fn<(id: string) => Promise<ChatMessage[]>>().mockResolvedValue([]);
+vi.mock('../loadConversationHistory', () => ({
+  loadConversationHistory: (id: string) => mockLoadHistory(id),
+}));
+
+const ACTIVE_ID = 'abcd1234-0000-0000-0000-000000000000';
+
 function getSubmitButton(): HTMLButtonElement {
   const btn = document.querySelector('button[type="submit"]');
   if (!btn) throw new Error('Submit button not found');
@@ -47,49 +59,83 @@ describe('ChatPanel', () => {
       streamingContent: '',
       error: null,
     });
-    useAppStore.setState({ selectedAgent: 'test-agent' });
+    // Simulates the URL-synced active conversation id (ChatView writes the route param into the store).
+    useAppStore.setState({ selectedAgent: 'test-agent', activeConversationId: ACTIVE_ID });
     mockSendMessage.mockReset();
-    mockStartConversation.mockReset().mockResolvedValue(undefined);
+    mockStartConversation.mockReset().mockResolvedValue([]);
+    mockLoadHistory.mockReset().mockResolvedValue([]);
   });
 
-  // --- StartConversation race (regression guard) ---
+  // --- Phantom-conversation regression (GitHub #96) ---
 
-  describe('ChatInput gating', () => {
-    it('disables Send until startConversation resolves (prevents "Conversation not found")', async () => {
-      let resolveStart!: () => void;
-      const startPromise = new Promise<void>((resolve) => { resolveStart = resolve; });
-      mockStartConversation.mockReturnValueOnce(startPromise);
-
+  describe('no phantom conversation on mount', () => {
+    it('does NOT call hub startConversation when the panel mounts', async () => {
       renderPanel();
-
-      // Submit button should be disabled while conversation is starting (disabled prop=true)
-      await waitFor(() => { expect(getSubmitButton()).toBeDisabled(); });
-
-      resolveStart();
-
-      // After start resolves, ChatInput disabled prop becomes false.
-      // The button is still disabled because there's no text typed yet,
-      // but the textarea should become enabled.
-      await waitFor(() => {
-        expect(screen.getByPlaceholderText(/message the agent/i)).not.toBeDisabled();
-      });
+      await waitFor(() => { expect(screen.getByPlaceholderText(/message the agent/i)).not.toBeDisabled(); });
+      expect(mockStartConversation).not.toHaveBeenCalled();
     });
 
-    it('does not invoke sendMessage when user clicks Send before startConversation resolves', async () => {
-      const user = userEvent.setup();
-      let resolveStart!: () => void;
-      const startPromise = new Promise<void>((resolve) => { resolveStart = resolve; });
-      mockStartConversation.mockReturnValueOnce(startPromise);
+    it('adopts the active conversation id from the store and loads its history (no id mint)', async () => {
+      mockLoadHistory.mockResolvedValueOnce([
+        { id: 'u1', role: 'user', content: 'earlier question', timestamp: new Date() },
+      ]);
+      renderPanel();
+
+      expect(await screen.findByText('earlier question')).toBeInTheDocument();
+      expect(mockLoadHistory).toHaveBeenCalledWith(ACTIVE_ID);
+      // The id is unchanged — the panel never mints a new one on mount.
+      expect(useAppStore.getState().activeConversationId).toBe(ACTIVE_ID);
+    });
+
+    it('with a blank composer (no active id) it loads nothing and stays enabled', async () => {
+      useAppStore.setState({ activeConversationId: null });
+      renderPanel();
+      await waitFor(() => { expect(screen.getByPlaceholderText(/message the agent/i)).not.toBeDisabled(); });
+      expect(mockLoadHistory).not.toHaveBeenCalled();
+      expect(mockStartConversation).not.toHaveBeenCalled();
+    });
+
+    it('reloads the target transcript when the active id changes via back/forward with the previous conversation still in the store', async () => {
+      // Regression: switching conversations with the browser back/forward buttons changes only the URL
+      // → the store's active id. No click handler runs, so the previous conversation's messages are
+      // still in the store. The panel must reload the new id's history and replace the stale transcript
+      // rather than leaving conversation A's messages on screen under conversation B's URL. Gating the
+      // skip on transcript *ownership* (chatStore.conversationId) — not mere message presence — is what
+      // makes this correct.
+      const CONV_B = 'ffff5678-0000-0000-0000-000000000000';
+
+      mockLoadHistory.mockResolvedValueOnce([
+        { id: 'a1', role: 'user', content: 'A question', timestamp: new Date() },
+      ]);
+      renderPanel();
+      expect(await screen.findByText('A question')).toBeInTheDocument();
+
+      mockLoadHistory.mockResolvedValueOnce([
+        { id: 'b1', role: 'user', content: 'B question', timestamp: new Date() },
+      ]);
+      act(() => {
+        useAppStore.setState({ activeConversationId: CONV_B });
+      });
+
+      expect(await screen.findByText('B question')).toBeInTheDocument();
+      expect(mockLoadHistory).toHaveBeenLastCalledWith(CONV_B);
+      expect(screen.queryByText('A question')).not.toBeInTheDocument();
+    });
+  });
+
+  // --- Composer gating on history load ---
+
+  describe('composer gating', () => {
+    it('disables the composer until history load resolves', async () => {
+      let resolveLoad!: (m: ChatMessage[]) => void;
+      mockLoadHistory.mockReturnValueOnce(new Promise<ChatMessage[]>((resolve) => { resolveLoad = resolve; }));
 
       renderPanel();
 
-      const textarea = await screen.findByPlaceholderText(/message the agent/i);
-      await user.type(textarea, 'hello');
-      await user.click(getSubmitButton());
+      await waitFor(() => { expect(screen.getByPlaceholderText(/message the agent/i)).toBeDisabled(); });
 
-      expect(mockSendMessage).not.toHaveBeenCalled();
+      resolveLoad([]);
 
-      resolveStart();
       await waitFor(() => {
         expect(screen.getByPlaceholderText(/message the agent/i)).not.toBeDisabled();
       });
@@ -99,20 +145,19 @@ describe('ChatPanel', () => {
   // --- Widget persistence on reload ---
 
   describe('widget re-render on reload', () => {
-    it('renders a persisted widget message returned by startConversation', async () => {
-      mockStartConversation.mockResolvedValueOnce([
+    it('renders a persisted widget message returned by the history loader', async () => {
+      mockLoadHistory.mockResolvedValueOnce([
         {
           id: 'w1',
           role: 'assistant',
           content: '',
-          timestamp: new Date().toISOString(),
+          timestamp: new Date(),
           widget: { type: 'render_table', args: { columns: ['Name'], rows: [['Ada']] } },
         },
       ]);
 
       renderPanel();
 
-      // The table widget re-renders from the persisted spec with no live tool call.
       expect(await screen.findByTestId('agent-table')).toBeInTheDocument();
       expect(screen.getByRole('cell', { name: 'Ada' })).toBeInTheDocument();
     });
@@ -123,7 +168,6 @@ describe('ChatPanel', () => {
   describe('ErrorBanner', () => {
     it('renders nothing when error is null', async () => {
       renderPanel();
-      // Wait for conversation to start so the full UI renders
       await waitFor(() => { expect(screen.getByPlaceholderText(/message the agent/i)).toBeInTheDocument(); });
       expect(screen.queryByRole('button', { name: /dismiss/i })).not.toBeInTheDocument();
     });
@@ -135,7 +179,6 @@ describe('ChatPanel', () => {
     });
 
     it('renders extracted .message not the raw [object Object]', async () => {
-      // Simulate what setError now receives after our fix — a clean string
       useChatStore.setState({ error: 'turn failed' });
       renderPanel();
       await waitFor(() => {
@@ -158,11 +201,10 @@ describe('ChatPanel', () => {
   // --- ConversationHeader ---
 
   describe('ConversationHeader', () => {
-    it('shows a truncated UUID (8 chars) after mount', async () => {
+    it('shows the truncated active conversation id (8 chars)', async () => {
       renderPanel();
       await waitFor(() => {
-        // The component renders conversationId.slice(0, 8) — an 8 char hex substring
-        expect(screen.getByText(/^[0-9a-f]{8}$/i)).toBeInTheDocument();
+        expect(screen.getByText(ACTIVE_ID.slice(0, 8))).toBeInTheDocument();
       });
     });
 

--- a/src/Content/Presentation/Presentation.WebUI/src/features/chat/loadConversationHistory.ts
+++ b/src/Content/Presentation/Presentation.WebUI/src/features/chat/loadConversationHistory.ts
@@ -1,0 +1,52 @@
+import axios from 'axios';
+import { apiClient } from '@/lib/apiClient';
+import type { ChatMessage } from './useChatStore';
+import type { ServerConversationMessage } from '@/hooks/useAgentHub';
+
+/** Shape of the record returned by <c>GET /api/conversations/:id</c> (only the fields the UI reads). */
+interface ConversationRecordResponse {
+  messages?: ServerConversationMessage[] | null;
+}
+
+/**
+ * Maps the server's persisted messages to the client {@link ChatMessage} shape, keeping only the
+ * user/assistant turns the transcript renders. Widget and tool-call payloads pass straight through.
+ * Shared shape with the SignalR <c>StartConversation</c> history contract, so both load paths agree.
+ */
+export function mapServerMessages(history: ServerConversationMessage[]): ChatMessage[] {
+  return history
+    .filter((m) => {
+      const r = m.role.toLowerCase();
+      return r === 'user' || r === 'assistant';
+    })
+    .map((m) => ({
+      id: m.id,
+      role: m.role.toLowerCase() as 'user' | 'assistant',
+      content: m.content,
+      timestamp: new Date(m.timestamp),
+      toolCalls: m.toolCalls ?? undefined,
+      widget: m.widget ?? undefined,
+    }));
+}
+
+/**
+ * Loads a conversation's persisted transcript for display <em>without ever creating it server-side</em>.
+ *
+ * Reads the pure query endpoint <c>GET /api/conversations/:id</c> and maps its stored messages. A 404
+ * (the id has never been messaged — e.g. a freshly minted "New chat" id, or a blank <c>/chat</c> that
+ * was refreshed) resolves to an empty transcript rather than an error. This replaces the old mount-time
+ * hub <c>StartConversation</c> call, which created an empty conversation as a side effect of loading
+ * history and was the source of the accumulating phantom conversations in the sidebar.
+ */
+export async function loadConversationHistory(conversationId: string): Promise<ChatMessage[]> {
+  try {
+    const res = await apiClient.get<ConversationRecordResponse>(
+      `/api/conversations/${conversationId}`,
+    );
+    return mapServerMessages(res.data.messages ?? []);
+  } catch (err) {
+    // A not-yet-persisted conversation is the normal state for a brand-new chat, not a failure.
+    if (axios.isAxiosError(err) && err.response?.status === 404) return [];
+    throw err;
+  }
+}

--- a/src/Content/Presentation/Presentation.WebUI/src/features/conversations/ConversationSidebar.tsx
+++ b/src/Content/Presentation/Presentation.WebUI/src/features/conversations/ConversationSidebar.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { MessageCircle, Plus, Trash2, Search } from 'lucide-react';
 import { useConversationsQuery } from './useConversationsQuery';
 import { useDeleteConversation } from './useDeleteConversation';
@@ -31,10 +32,10 @@ export function ConversationSidebar({ onSelect }: ConversationSidebarProps) {
   const { data: conversations, isLoading, error } = useConversationsQuery();
   const deleteMutation = useDeleteConversation();
   const activeId = useAppStore((s) => s.activeConversationId);
-  const setActive = useAppStore((s) => s.setActiveConversationId);
   const selectedAgent = useAppStore((s) => s.selectedAgent);
   const setSelectedAgent = useAppStore((s) => s.setSelectedAgent);
   const clearMessages = useChatStore((s) => s.clearMessages);
+  const navigate = useNavigate();
   const [search, setSearch] = useState('');
 
   const filtered = useMemo(() => {
@@ -49,8 +50,9 @@ export function ConversationSidebar({ onSelect }: ConversationSidebarProps) {
 
   const handleNewChat = (): void => {
     if (!selectedAgent) return;
+    // Blank composer, no id — nothing is created server-side until the first message is sent.
     clearMessages();
-    setActive(crypto.randomUUID());
+    navigate('/chat');
     onSelect?.();
   };
 
@@ -64,7 +66,8 @@ export function ConversationSidebar({ onSelect }: ConversationSidebarProps) {
     if (target && target.agentName !== selectedAgent) {
       setSelectedAgent(target.agentName);
     }
-    setActive(id);
+    // The URL drives the active conversation; ChatPanel loads this id's history once it syncs in.
+    navigate(`/chat/${id}`);
     onSelect?.();
   };
 
@@ -77,9 +80,10 @@ export function ConversationSidebar({ onSelect }: ConversationSidebarProps) {
       if (remaining.length > 0) {
         const next = remaining[0];
         if (next.agentName !== selectedAgent) setSelectedAgent(next.agentName);
-        setActive(next.id);
+        navigate(`/chat/${next.id}`);
       } else {
-        setActive(crypto.randomUUID());
+        // No conversations left — fall back to a blank composer rather than minting a phantom id.
+        navigate('/chat');
       }
     }
   };

--- a/src/Content/Presentation/Presentation.WebUI/src/hooks/__tests__/useSendUserMessage.test.ts
+++ b/src/Content/Presentation/Presentation.WebUI/src/hooks/__tests__/useSendUserMessage.test.ts
@@ -1,38 +1,136 @@
-import { renderHook } from '@testing-library/react';
+import { renderHook, waitFor } from '@testing-library/react';
 import { vi, describe, it, expect, beforeEach } from 'vitest';
 import { useSendUserMessage } from '../useSendUserMessage';
 import { useChatStore } from '@/stores/chatStore';
 import { useAppStore } from '@/stores/appStore';
 
+// The send path is where a conversation is lazily created (first message) and where a blank composer
+// mints its id. These mocks isolate that contract from SignalR / the AG-UI stream / MSAL / the router.
 const agUiSend = vi.fn();
 vi.mock('@/hooks/useAgentStream', () => ({
   useAgentStream: () => ({ sendMessage: agUiSend, abort: vi.fn() }),
 }));
 
+const startConversation = vi.fn().mockResolvedValue([]);
+let connectionState = 'connected';
+vi.mock('@/hooks/useAgentHub', () => ({
+  useAgentHub: () => ({ startConversation, connectionState }),
+}));
+
+const navigate = vi.fn();
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => navigate,
+}));
+
+const invalidateQueries = vi.fn();
+vi.mock('@tanstack/react-query', () => ({
+  useQueryClient: () => ({ invalidateQueries }),
+}));
+
 describe('useSendUserMessage', () => {
   beforeEach(() => {
     agUiSend.mockReset();
+    startConversation.mockReset().mockResolvedValue([]);
+    navigate.mockReset();
+    invalidateQueries.mockReset();
     useChatStore.getState().clearMessages();
-    useAppStore.setState({ activeConversationId: null });
+    useChatStore.getState().setError(null);
+    useAppStore.setState({ activeConversationId: null, selectedAgent: null });
+    connectionState = 'connected';
   });
 
-  it('sends nothing and returns false when there is no active conversation', () => {
+  it('sends nothing and returns false when no agent is selected', () => {
+    useAppStore.setState({ activeConversationId: 'conv-1', selectedAgent: null });
     const { result } = renderHook(() => useSendUserMessage());
+
     expect(result.current('hi')).toBe(false);
     expect(agUiSend).not.toHaveBeenCalled();
+    expect(startConversation).not.toHaveBeenCalled();
     expect(useChatStore.getState().messages).toHaveLength(0);
   });
 
-  it('adds the user message, starts streaming, dispatches the run, and returns true', () => {
-    useAppStore.setState({ activeConversationId: 'conv-1' });
+  it('registers the conversation exactly once on the FIRST message, then dispatches the run', async () => {
+    useAppStore.setState({ activeConversationId: 'conv-1', selectedAgent: 'agent-a' });
     const { result } = renderHook(() => useSendUserMessage());
 
     expect(result.current('hello there')).toBe(true);
 
+    // Optimistic user message is added synchronously and streaming starts.
     const messages = useChatStore.getState().messages;
     expect(messages).toHaveLength(1);
     expect(messages[0]).toMatchObject({ role: 'user', content: 'hello there' });
     expect(useChatStore.getState().isStreaming).toBe(true);
-    expect(agUiSend).toHaveBeenCalledWith('conv-1', expect.any(String), 'hello there');
+
+    // The server-side conversation is created before the run is dispatched.
+    await waitFor(() => { expect(agUiSend).toHaveBeenCalledWith('conv-1', expect.any(String), 'hello there'); });
+    expect(startConversation).toHaveBeenCalledTimes(1);
+    expect(startConversation).toHaveBeenCalledWith('agent-a', 'conv-1');
+    expect(invalidateQueries).toHaveBeenCalledTimes(1);
+    // An existing id in the store is not a new conversation — no navigation/mint.
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  it('does NOT register the conversation again on a subsequent message', () => {
+    useAppStore.setState({ activeConversationId: 'conv-1', selectedAgent: 'agent-a' });
+    // A non-empty transcript marks this as an ongoing conversation, not a first message.
+    useChatStore.getState().addMessage({ id: 'm0', role: 'assistant', content: 'earlier', timestamp: new Date() });
+    const { result } = renderHook(() => useSendUserMessage());
+
+    expect(result.current('follow up')).toBe(true);
+
+    expect(startConversation).not.toHaveBeenCalled();
+    // Ongoing conversations dispatch synchronously (no create round-trip to await).
+    expect(agUiSend).toHaveBeenCalledWith('conv-1', expect.any(String), 'follow up');
+  });
+
+  it('refuses to send while the hub is not connected — no mint, no create, no dispatch', () => {
+    connectionState = 'connecting';
+    useAppStore.setState({ activeConversationId: null, selectedAgent: 'agent-a' });
+    const { result } = renderHook(() => useSendUserMessage());
+
+    expect(result.current('too early')).toBe(false);
+    expect(startConversation).not.toHaveBeenCalled();
+    expect(agUiSend).not.toHaveBeenCalled();
+    expect(navigate).not.toHaveBeenCalled();
+    // Nothing minted server-side or locally; the user gets told to wait.
+    expect(useAppStore.getState().activeConversationId).toBeNull();
+    expect(useChatStore.getState().messages).toHaveLength(0);
+    expect(useChatStore.getState().error).toBeTruthy();
+  });
+
+  it('rolls back the optimistic message when the first-message create fails so a retry re-attempts it', async () => {
+    useAppStore.setState({ activeConversationId: 'conv-1', selectedAgent: 'agent-a' });
+    startConversation.mockRejectedValueOnce(new Error('hub down'));
+    const { result } = renderHook(() => useSendUserMessage());
+
+    expect(result.current('first try')).toBe(true);
+
+    // The failed create rolls the transcript back to empty and surfaces the error — no dangling
+    // optimistic message that would wedge every future send.
+    await waitFor(() => { expect(useChatStore.getState().error).toBeTruthy(); });
+    expect(useChatStore.getState().messages).toHaveLength(0);
+    expect(agUiSend).not.toHaveBeenCalled();
+
+    // Retry: the empty transcript means this still counts as the first message, so StartConversation is
+    // attempted again (idempotent on the reused id) and this time the run dispatches.
+    expect(result.current('second try')).toBe(true);
+    await waitFor(() => { expect(agUiSend).toHaveBeenCalledWith('conv-1', expect.any(String), 'second try'); });
+    expect(startConversation).toHaveBeenCalledTimes(2);
+  });
+
+  it('mints an id, reflects it in the store + URL, and registers it once when the composer is blank', async () => {
+    useAppStore.setState({ activeConversationId: null, selectedAgent: 'agent-a' });
+    const { result } = renderHook(() => useSendUserMessage());
+
+    expect(result.current('first message')).toBe(true);
+
+    const mintedId = useAppStore.getState().activeConversationId;
+    expect(mintedId).toEqual(expect.any(String));
+    expect(mintedId).not.toBeNull();
+    expect(navigate).toHaveBeenCalledWith(`/chat/${mintedId}`, { replace: true });
+
+    await waitFor(() => { expect(startConversation).toHaveBeenCalledWith('agent-a', mintedId); });
+    expect(startConversation).toHaveBeenCalledTimes(1);
+    await waitFor(() => { expect(agUiSend).toHaveBeenCalledWith(mintedId, expect.any(String), 'first message'); });
   });
 });

--- a/src/Content/Presentation/Presentation.WebUI/src/hooks/useSendUserMessage.ts
+++ b/src/Content/Presentation/Presentation.WebUI/src/hooks/useSendUserMessage.ts
@@ -1,22 +1,61 @@
+import { useNavigate } from 'react-router-dom';
+import { useQueryClient } from '@tanstack/react-query';
 import { useAppStore } from '@/stores/appStore';
 import { useChatStore } from '@/stores/chatStore';
 import { useAgentStream } from '@/hooks/useAgentStream';
+import { useAgentHub } from '@/hooks/useAgentHub';
+import { CONVERSATIONS_QUERY_KEY } from '@/features/conversations/useConversationsQuery';
 
 /**
  * Returns a function that sends `text` as the user's next message in the active conversation: it adds
  * the optimistic user message, starts the streaming indicator, and dispatches the agent run — the same
- * three-step sequence the chat input and suggestion chips use. Returns `false` when there is no active
- * conversation (nothing sent). Shared by {@link import('@/features/chat/ChatPanel').ChatPanel} and the
- * inline form widget so this send path lives in exactly one place.
+ * three-step sequence the chat input and suggestion chips use. Shared by
+ * {@link import('@/features/chat/ChatPanel').ChatPanel} and the inline form widget so this send path
+ * lives in exactly one place.
+ *
+ * Server-side conversation creation is deferred to the first message: the id is minted here (never on
+ * mount) when the composer is blank, and the conversation is registered lazily via
+ * {@link import('@/hooks/useAgentHub').useAgentHub}'s `startConversation` only on that first send. This
+ * is what keeps empty "phantom" conversations out of the sidebar — navigating to chat, switching agents,
+ * or refreshing never creates a conversation; only actually sending a message does.
+ *
+ * Returns `false` (nothing sent) when no agent is selected, since a new conversation has nothing to bind
+ * to. Once created, the conversation id is written to the store and reflected in the URL (`/chat/:id`) so
+ * refresh and the back button restore it.
  */
 export function useSendUserMessage(): (text: string) => boolean {
   const { sendMessage: agUiSend } = useAgentStream();
+  const { startConversation, connectionState } = useAgentHub();
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
 
   return (text: string): boolean => {
-    const conversationId = useAppStore.getState().activeConversationId;
-    if (!conversationId) return false;
+    const { activeConversationId, selectedAgent, setActiveConversationId } = useAppStore.getState();
+    // A new conversation must bind to an agent; without one there is nothing to send to.
+    if (!selectedAgent) return false;
+
+    // Both the first-message create and the run dispatch go over the SignalR hub, so a send before the
+    // hub has connected (cold start / slow network) would reject. Refuse up front with a clear message
+    // rather than minting an id and wedging on a failed StartConversation — the user can retry once the
+    // status dot shows connected.
+    if (connectionState !== 'connected') {
+      useChatStore.getState().setError('Still connecting to the agent service — please try again in a moment.');
+      return false;
+    }
+
+    // The active id is URL-driven. When the composer is blank (`/chat` with no id) we mint one here —
+    // on send, never on mount — so an unused conversation is never registered server-side.
+    const isNewConversation = activeConversationId === null;
+    const conversationId = activeConversationId ?? crypto.randomUUID();
+
+    // The first message is where the conversation must come to exist server-side. An empty transcript
+    // means either a freshly minted id or an existing-but-unloaded one; `startConversation` is
+    // idempotent (it returns the existing record when the id is already known), so registering it here
+    // is safe either way, and the AG-UI run below requires the record to exist.
+    const isFirstMessage = isNewConversation || useChatStore.getState().messages.length === 0;
 
     const userMessageId = crypto.randomUUID();
+    useChatStore.getState().setConversationId(conversationId);
     useChatStore.getState().addMessage({
       id: userMessageId,
       role: 'user',
@@ -24,7 +63,40 @@ export function useSendUserMessage(): (text: string) => boolean {
       timestamp: new Date(),
     });
     useChatStore.getState().startStreaming();
-    agUiSend(conversationId, userMessageId, text);
+
+    if (isFirstMessage) {
+      // Register the conversation, then dispatch the run — the run streams against a record that must
+      // already exist. A failed registration surfaces as an error rather than a stuck "Conversation
+      // not found" run.
+      void (async () => {
+        try {
+          await startConversation(selectedAgent, conversationId);
+          // The conversation now exists (and carries this first message after the run) — refresh the
+          // sidebar so it appears. Deferring this to the first message is what keeps phantoms out.
+          void queryClient.invalidateQueries({ queryKey: CONVERSATIONS_QUERY_KEY });
+          agUiSend(conversationId, userMessageId, text);
+        } catch (err: unknown) {
+          // Roll the optimistic first message back out. Leaving it in place would make the transcript
+          // non-empty, so `isFirstMessage` (messages.length === 0) would be false on every retry — the
+          // next send would skip StartConversation and dispatch against a conversation that was never
+          // created, wedging it until a full page reload. Clearing restores the empty transcript so a
+          // retry re-attempts creation (the minted id in the store/URL is reused, and StartConversation
+          // is idempotent).
+          const chat = useChatStore.getState();
+          chat.clearMessages();
+          chat.setError(err instanceof Error ? err.message : 'Failed to start the conversation.');
+        }
+      })();
+    } else {
+      agUiSend(conversationId, userMessageId, text);
+    }
+
+    if (isNewConversation) {
+      // Reflect the minted id in the store and URL so refresh/back restore this exact conversation.
+      setActiveConversationId(conversationId);
+      navigate(`/chat/${conversationId}`, { replace: true });
+    }
+
     return true;
   };
 }

--- a/src/Content/Presentation/Presentation.WebUI/src/views/ChatView.tsx
+++ b/src/Content/Presentation/Presentation.WebUI/src/views/ChatView.tsx
@@ -1,3 +1,5 @@
+import { useEffect } from 'react';
+import { useParams } from 'react-router-dom';
 import { ChevronsLeft, ChevronsRight } from 'lucide-react';
 import { ChatPanel } from '@/features/chat/ChatPanel';
 import { ConversationSidebar } from '@/features/conversations/ConversationSidebar';
@@ -7,6 +9,16 @@ import { cn } from '@/lib/utils';
 export function ChatView() {
   const showSidebar = useAppStore((s) => s.showSidebar);
   const toggleSidebar = useAppStore((s) => s.toggleSidebar);
+  const activeConversationId = useAppStore((s) => s.activeConversationId);
+  const setActiveConversationId = useAppStore((s) => s.setActiveConversationId);
+  const { conversationId } = useParams<{ conversationId: string }>();
+
+  // The URL is the source of truth for which conversation is active; mirror it into the store that the
+  // chat components read. `/chat` (no param) clears the active id → blank composer.
+  useEffect(() => {
+    const next = conversationId ?? null;
+    if (next !== activeConversationId) setActiveConversationId(next);
+  }, [conversationId, activeConversationId, setActiveConversationId]);
 
   return (
     <div className="relative flex flex-1 min-w-0 h-full">


### PR DESCRIPTION
## Problem (GitHub #96, Issue 1)
Clicking an agent tile then returning to chat, or refreshing the page, created a **new empty conversation server-side every time** — phantom chats piled up in the sidebar and you lost your place. Root cause: a mount effect minted a thread id and eagerly called the hub's `StartConversation` on every navigate/agent-select/refresh, and nothing persisted which conversation was active.

## Approach
Drive the active conversation from the **URL** and **defer server-side creation to the first message**.

- **`/chat/:conversationId` route param** — `ChatView` mirrors it into the store; refresh / back-forward / bookmark restore the exact conversation. `/chat` (no param) = blank composer.
- **Deferred creation** — `useSendUserMessage` mints the id on send *only when the composer is blank*, calls `StartConversation` once on the first message, then invalidates the sidebar query. Navigation, agent-select, and refresh create nothing.
- **Read-only history load** — `GET /api/conversations/:id` (404 → empty transcript), replacing the mount-time `StartConversation` side effect that was the phantom source.

## Correctness hardening (found during review)
- **Transcript-ownership guard** — the history-load skip is gated on `chatStore.conversationId === active id`, not mere message presence, so switching via the browser **back/forward** buttons reloads the target's transcript instead of showing the previous one's.
- **Connection guard** — the send path refuses to send until the hub is connected, avoiding a cold-start first-send failure.
- **First-message failure recovery** — if `StartConversation` rejects, the optimistic message is rolled back so a retry re-attempts creation instead of permanently wedging the conversation (would otherwise need a hard refresh).

## Tests
Rewrites the `ChatPanel` + `useSendUserMessage` suites to the corrected contract and adds regression tests for back/forward switching, the connection guard, and first-message-failure recovery. **142 WebUI unit tests pass; tsc + vite build clean.**

## Known follow-up (out of scope, pre-existing)
Switching conversations **mid-stream** can briefly flash the previous run's tokens into the newly-selected transcript (nothing aborts the stream on switch). It is pre-existing and display-only (a reload corrects it); the fix needs `useAgentStream` subscription-lifecycle work orthogonal to phantom chats.

Also pre-existing: refreshing directly on `/chat/:id` shows the "select an agent" placeholder because `selectedAgent` isn't persisted — the URL-restore story is only complete once that's persisted too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)