### PR TITLE
fix: tool-capable delegation, stream-abort on switch, persist agent (#96 follow-ups)

### DIFF
--- a/src/Content/Application/Application.AI.Common/Factories/AgentExecutionContextFactory.cs
+++ b/src/Content/Application/Application.AI.Common/Factories/AgentExecutionContextFactory.cs
@@ -266,8 +266,20 @@ public class AgentExecutionContextFactory
             AdditionalProperties = new Dictionary<string, object>()
         };
 
-        if (toolOverrides is { Count: > 0 })
-            context.AdditionalProperties["delegationToolOverrides"] = toolOverrides;
+        // Provision the subagent's tools so a delegated agent can actually use them, not just generate
+        // text. Names come from the caller's explicit override when supplied, otherwise the profile's
+        // own ToolAllowlist; the profile's ToolDenylist is then subtracted. They resolve from keyed DI
+        // through the same builder (convert + governance-wrap) the skill-based paths use. A null/empty
+        // allowlist — an "inherit everything" profile such as Execute/General — provisions nothing here:
+        // there is no parent tool pool to inherit from on the delegation path, so such subagents run
+        // generation-only unless the caller passes explicit tool overrides.
+        var requested = (toolOverrides is { Count: > 0 } ? toolOverrides : definition.ToolAllowlist) ?? [];
+        var toolNames = definition.ToolDenylist is { Count: > 0 } denylist
+            ? requested.Where(n => !denylist.Contains(n, StringComparer.OrdinalIgnoreCase)).ToList()
+            : requested;
+
+        if (toolNames.Count > 0)
+            context.Tools = _toolChainBuilder.BuildToolsByName(toolNames);
 
         return context;
     }

--- a/src/Content/Application/Application.AI.Common/Interfaces/Tools/IToolChainBuilder.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Tools/IToolChainBuilder.cs
@@ -26,6 +26,16 @@ public interface IToolChainBuilder
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Resolves a specific set of tools by name from keyed DI — converting and governance-wrapping each
+    /// exactly as the skill-based paths do — and returns them deduplicated by name. Used to provision a
+    /// delegated subagent's declared tools (its profile <c>ToolAllowlist</c>), which are named directly
+    /// rather than sourced from a skill. Names that resolve to no registered tool are skipped.
+    /// </summary>
+    /// <param name="toolNames">The keyed-DI tool names to resolve.</param>
+    /// <returns>The resolved, converted, governance-wrapped tools (empty when none resolve).</returns>
+    List<AITool> BuildToolsByName(IReadOnlyList<string> toolNames);
+
+    /// <summary>
     /// Merges and deduplicates tools from multiple skills, applying an optional whitelist.
     /// First occurrence wins during deduplication.
     /// </summary>

--- a/src/Content/Application/Application.AI.Common/Services/Tools/ToolChainBuilder.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/ToolChainBuilder.cs
@@ -137,6 +137,21 @@ public class ToolChainBuilder : IToolChainBuilder
             .ToList();
 
     /// <inheritdoc />
+    public List<AITool> BuildToolsByName(IReadOnlyList<string> toolNames)
+    {
+        var tools = new List<AITool>();
+        foreach (var name in toolNames)
+        {
+            var resolved = ResolveToolByName(name);
+            if (resolved != null)
+                tools.AddRange(resolved);
+        }
+
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        return WrapGoverned(tools.Where(t => seen.Add(t.Name)));
+    }
+
+    /// <inheritdoc />
     public async Task<List<AITool>> BuildMergedToolsAsync(
         IReadOnlyList<SkillDefinition> skills,
         SkillAgentOptions options,

--- a/src/Content/Infrastructure/Infrastructure.AI/Agents/CapabilityMatchSupervisor.Escalation.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Agents/CapabilityMatchSupervisor.Escalation.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using Application.AI.Common.OpenTelemetry.Metrics;
+using Application.AI.Common.Services;
 using Domain.AI.Agents;
 using Domain.AI.Escalation;
 using Domain.AI.Governance;
@@ -140,22 +141,38 @@ public sealed partial class CapabilityMatchSupervisor
         var agentContext = _contextFactory.CreateFromDelegation(definition, toolOverrides, currentDepth + 1, pendingRecord.DelegationId);
         var agent = await _agentFactory.CreateAgentAsync(agentContext, ct);
 
-        // Actually run the delegated subagent on the task. Creating the agent alone does no work —
-        // the task description must be sent as the subagent's user message and its response captured,
-        // otherwise the delegation returns a placeholder and the orchestrator has nothing to
-        // synthesize (the defect behind GitHub #96, Issue 2). Token accounting for this run flows
-        // through the chat-client middleware into the parent turn's usage capture, so DelegationResult
-        // carries duration + real output here and leaves TokensUsed at 0 — the parent turn owns the
-        // aggregate token count.
-        var response = await agent.RunAsync(
-            [new ChatMessage(ChatRole.User, pendingRecord.TaskDescription)],
-            cancellationToken: ct);
+        // Run the delegated subagent on the task, isolating its usage accounting from the parent turn.
+        // Creating the agent alone does no work — the task description must be sent as the subagent's
+        // user message and its response captured, otherwise the delegation returns a placeholder and the
+        // orchestrator has nothing to synthesize (the defect behind GitHub #96, Issue 2). The subagent
+        // now carries real tools, and the parent orchestrator turn has its own LlmUsageCapture set as the
+        // ambient AsyncLocal for the duration of its RunAsync; the subagent runs *inside* that turn (as a
+        // tool call), so without swapping the ambient here the subagent's tokens AND tool invocations
+        // would fold into the ORCHESTRATOR turn's telemetry — it would report tool calls it never made.
+        // A fresh capture scopes the subagent's work to this delegation and yields its real token cost.
+        // (Tool-invocation governance/progress ambients are intentionally left as-is; per-subagent
+        // governance re-scoping under enforcement is tracked as a follow-up — see the PR description.)
+        var delegationUsage = new LlmUsageCapture(_options);
+        var previousUsage = LlmUsageCapture.Current;
+        LlmUsageCapture.Current = delegationUsage;
+        AgentResponse response;
+        try
+        {
+            response = await agent.RunAsync(
+                [new ChatMessage(ChatRole.User, pendingRecord.TaskDescription)],
+                cancellationToken: ct);
+        }
+        finally
+        {
+            LlmUsageCapture.Current = previousUsage;
+        }
 
         stopwatch.Stop();
 
         await RecordCompletion(pendingRecord, ct);
 
         var durationMs = stopwatch.ElapsedMilliseconds;
+        var usage = delegationUsage.TakeSnapshot();
 
         SupervisorMetrics.DelegationsTotal.Add(1,
             new(SupervisorConventions.SupervisorId, SupervisorId),
@@ -176,7 +193,7 @@ public sealed partial class CapabilityMatchSupervisor
             pendingRecord.DelegationId, selection.SelectedAgent.AgentId, durationMs);
 
         var output = response.Text ?? string.Empty;
-        return DelegationResult.Success(output, 0, durationMs);
+        return DelegationResult.Success(output, usage.InputTokens + usage.OutputTokens, durationMs);
     }
 
     private async Task RecordCompletion(DelegationRecord pendingRecord, CancellationToken ct)

--- a/src/Content/Presentation/Presentation.WebUI/src/components/layout/DashboardLayout.tsx
+++ b/src/Content/Presentation/Presentation.WebUI/src/components/layout/DashboardLayout.tsx
@@ -23,9 +23,13 @@ export function DashboardLayout() {
   const { pathname } = useLocation();
 
   useEffect(() => {
-    if (!selectedAgent && agentsQuery.data?.length) {
-      setSelectedAgent(agentsQuery.data[0].id);
-    }
+    const agents = agentsQuery.data;
+    if (!agents?.length) return;
+    // Auto-select the first agent when none is chosen, or when a persisted selection no longer exists
+    // (agent removed/renamed between sessions) — otherwise a stale stored id would strand the user on
+    // an invalid agent whose turns fail.
+    const isValid = selectedAgent !== null && agents.some((a) => a.id === selectedAgent);
+    if (!isValid) setSelectedAgent(agents[0].id);
   }, [selectedAgent, agentsQuery.data, setSelectedAgent]);
 
   useEffect(() => {

--- a/src/Content/Presentation/Presentation.WebUI/src/features/chat/ChatPanel.tsx
+++ b/src/Content/Presentation/Presentation.WebUI/src/features/chat/ChatPanel.tsx
@@ -6,6 +6,7 @@ import { useAppStore } from '@/stores/appStore';
 import { useConversationSettingsStore } from '@/stores/conversationSettingsStore';
 import { useAgentHub, type ConnectionState, type ConversationSettingsInput } from '@/hooks/useAgentHub';
 import { useSendUserMessage } from '@/hooks/useSendUserMessage';
+import { abortActiveStream } from '@/hooks/useAgentStream';
 import { loadConversationHistory } from './loadConversationHistory';
 import { MessageList } from './MessageList';
 import { TypingIndicator } from './TypingIndicator';
@@ -190,8 +191,14 @@ export function ChatPanel() {
     }
 
     // A switch (or a fresh page load): bind the transcript to the new id and load its history.
-    // setMessages always runs on completion — an empty history (a brand-new id) clears any stale
-    // previous-conversation messages rather than leaving them on screen under the new URL.
+    // Abort any run still streaming for the previous conversation first — neither the sidebar nor the
+    // browser back/forward buttons stop the stream, so without this its late tokens would land in the
+    // transcript we're about to show. setMessages always runs on completion — an empty history (a
+    // brand-new id) clears any stale previous-conversation messages rather than leaving them on screen.
+    abortActiveStream();
+    // Aborting the run leaves the store's streaming flags set; clear them so the conversation we're
+    // switching to doesn't render a phantom typing indicator or the aborted run's leftover partial text.
+    useChatStore.getState().resetStreaming();
     setChatConversationId(activeConversationId);
     setConversationReady(false);
     let cancelled = false;

--- a/src/Content/Presentation/Presentation.WebUI/src/features/chat/__tests__/ChatPanel.test.tsx
+++ b/src/Content/Presentation/Presentation.WebUI/src/features/chat/__tests__/ChatPanel.test.tsx
@@ -24,11 +24,15 @@ vi.mock('@/hooks/useAgentHub', () => ({
   AgentHubProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
 
+// ChatPanel aborts the app-wide active stream when the conversation switches (so the previous run's
+// late tokens don't land in the new transcript). Spy on the module-level abort to assert that.
+const mockAbortActiveStream = vi.fn();
 vi.mock('@/hooks/useAgentStream', () => ({
   useAgentStream: () => ({
     sendMessage: mockSendMessage,
     abort: vi.fn(),
   }),
+  abortActiveStream: () => mockAbortActiveStream(),
 }));
 
 // ChatPanel loads the active conversation's transcript from this read-only helper (never creating it
@@ -64,6 +68,7 @@ describe('ChatPanel', () => {
     mockSendMessage.mockReset();
     mockStartConversation.mockReset().mockResolvedValue([]);
     mockLoadHistory.mockReset().mockResolvedValue([]);
+    mockAbortActiveStream.mockReset();
   });
 
   // --- Phantom-conversation regression (GitHub #96) ---
@@ -110,6 +115,11 @@ describe('ChatPanel', () => {
       renderPanel();
       expect(await screen.findByText('A question')).toBeInTheDocument();
 
+      // Simulate leaving A mid-stream: the run is still marked streaming with a partial buffer.
+      act(() => {
+        useChatStore.setState({ isStreaming: true, streamingContent: 'partial A tokens' });
+      });
+
       mockLoadHistory.mockResolvedValueOnce([
         { id: 'b1', role: 'user', content: 'B question', timestamp: new Date() },
       ]);
@@ -120,6 +130,11 @@ describe('ChatPanel', () => {
       expect(await screen.findByText('B question')).toBeInTheDocument();
       expect(mockLoadHistory).toHaveBeenLastCalledWith(CONV_B);
       expect(screen.queryByText('A question')).not.toBeInTheDocument();
+      // The previous conversation's stream is aborted on the switch so its late tokens can't bleed into B.
+      expect(mockAbortActiveStream).toHaveBeenCalled();
+      // And the streaming flags are cleared, so B doesn't inherit A's phantom typing indicator / partial.
+      expect(useChatStore.getState().isStreaming).toBe(false);
+      expect(useChatStore.getState().streamingContent).toBe('');
     });
   });
 

--- a/src/Content/Presentation/Presentation.WebUI/src/features/chat/useChatStore.ts
+++ b/src/Content/Presentation/Presentation.WebUI/src/features/chat/useChatStore.ts
@@ -42,6 +42,12 @@ interface ChatState {
   startStreaming: () => void;
   appendToken: (token: string) => void;
   finalizeStream: (fullResponse: string, assistantMessageId?: string) => void;
+  /**
+   * Clears the streaming indicator and any partial buffer WITHOUT touching the transcript. Used when a
+   * run is aborted (e.g. switching conversations mid-stream) so the newly opened conversation doesn't
+   * inherit a phantom typing indicator or the previous run's leftover tokens.
+   */
+  resetStreaming: () => void;
   clearMessages: () => void;
   setError: (message: string | null) => void;
 }
@@ -86,6 +92,7 @@ export const useChatStore = create<ChatState>()((set) => ({
       messages: messages.length > 200 ? messages.slice(-200) : messages,
     };
   }),
+  resetStreaming: () => set({ isStreaming: false, streamingContent: '' }),
   clearMessages: () => set({
     messages: [],
     isStreaming: false,

--- a/src/Content/Presentation/Presentation.WebUI/src/hooks/useAgentStream.ts
+++ b/src/Content/Presentation/Presentation.WebUI/src/hooks/useAgentStream.ts
@@ -1,4 +1,3 @@
-import { useRef } from 'react';
 import { useMsal } from '@azure/msal-react';
 import type { Subscription } from 'rxjs';
 import { EventType } from '@ag-ui/core';
@@ -73,10 +72,27 @@ async function finishToolCall(threadId: string, callId: string, pending: Pending
   }
 }
 
+// The app streams a single AG-UI run at a time (one conversation in view), so its subscription is an
+// app-wide resource rather than per-hook-instance state. Any consumer (e.g. ChatPanel aborting on a
+// conversation switch) must be able to cancel the run that another consumer (the send hook) started;
+// with per-instance refs those were separate objects, so a cross-consumer abort() was a silent no-op
+// and the previous conversation's tokens kept streaming into the newly selected transcript.
+let activeSubscription: Subscription | null = null;
+const activePendingCalls = new Map<string, PendingCall>();
+
+/**
+ * Cancels the single active AG-UI run (if any) and drops its pending client tool calls. Exposed at
+ * module scope so a non-streaming consumer — e.g. ChatPanel switching conversations — can abort the run
+ * the send hook started, without holding its own hook instance whose identity would churn effect deps.
+ */
+export function abortActiveStream(): void {
+  activeSubscription?.unsubscribe();
+  activeSubscription = null;
+  activePendingCalls.clear();
+}
+
 export function useAgentStream(): UseAgentStreamReturn {
   const { instance } = useMsal();
-  const subscriptionRef = useRef<Subscription | null>(null);
-  const pendingCallsRef = useRef<Map<string, PendingCall>>(new Map());
 
   const getAccessToken = async (): Promise<string> => {
     if (IS_AUTH_DISABLED) return '';
@@ -86,11 +102,7 @@ export function useAgentStream(): UseAgentStreamReturn {
     return result.accessToken;
   };
 
-  const abort = (): void => {
-    subscriptionRef.current?.unsubscribe();
-    subscriptionRef.current = null;
-    pendingCallsRef.current.clear();
-  };
+  const abort = (): void => { abortActiveStream(); };
 
   const sendMessage = (conversationId: string, userMessageId: string, message: string): void => {
     abort();
@@ -116,7 +128,7 @@ export function useAgentStream(): UseAgentStreamReturn {
         forwardedProps: {},
       });
 
-      subscriptionRef.current = obs$.subscribe({
+      activeSubscription = obs$.subscribe({
         next: (event: BaseEvent) => {
           switch (event.type) {
             case EventType.TEXT_MESSAGE_START: {
@@ -137,19 +149,19 @@ export function useAgentStream(): UseAgentStreamReturn {
             }
             case EventType.TOOL_CALL_START: {
               const e = event as BaseEvent & { toolCallId: string; toolCallName: string };
-              pendingCallsRef.current.set(e.toolCallId, { name: e.toolCallName, args: '' });
+              activePendingCalls.set(e.toolCallId, { name: e.toolCallName, args: '' });
               break;
             }
             case EventType.TOOL_CALL_ARGS: {
               const e = event as BaseEvent & { toolCallId: string; delta: string };
-              const pending = pendingCallsRef.current.get(e.toolCallId);
+              const pending = activePendingCalls.get(e.toolCallId);
               if (pending) pending.args += e.delta;
               break;
             }
             case EventType.TOOL_CALL_END: {
               const e = event as BaseEvent & { toolCallId: string };
-              const pending = pendingCallsRef.current.get(e.toolCallId);
-              pendingCallsRef.current.delete(e.toolCallId);
+              const pending = activePendingCalls.get(e.toolCallId);
+              activePendingCalls.delete(e.toolCallId);
               // The server tool is parked awaiting this result; fire-and-forget the round-trip so the
               // same open run resumes with the widget rendered and the agent's follow-up narration.
               void finishToolCall(conversationId, e.toolCallId, pending);
@@ -167,10 +179,10 @@ export function useAgentStream(): UseAgentStreamReturn {
         error: (err: unknown) => {
           const message = err instanceof Error ? err.message : 'Streaming error';
           useChatStore.getState().setError(message);
-          subscriptionRef.current = null;
+          activeSubscription = null;
         },
         complete: () => {
-          subscriptionRef.current = null;
+          activeSubscription = null;
         },
       });
     });

--- a/src/Content/Presentation/Presentation.WebUI/src/stores/appStore.ts
+++ b/src/Content/Presentation/Presentation.WebUI/src/stores/appStore.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+import { persist, createJSONStorage } from 'zustand/middleware';
 
 interface AppState {
   selectedAgent: string | null;
@@ -9,11 +10,28 @@ interface AppState {
   toggleSidebar: () => void;
 }
 
-export const useAppStore = create<AppState>()((set) => ({
-  selectedAgent: null,
-  activeConversationId: null,
-  showSidebar: true,
-  setSelectedAgent: (name) => set({ selectedAgent: name }),
-  setActiveConversationId: (id) => set({ activeConversationId: id }),
-  toggleSidebar: () => set((s) => ({ showSidebar: !s.showSidebar })),
-}));
+/**
+ * App-level UI state. `selectedAgent` is persisted so a page refresh restores the agent the user was
+ * working with — without it, refreshing directly on `/chat/:id` fell back to the "select an agent"
+ * placeholder even though the conversation id was in the URL. `activeConversationId` is deliberately
+ * NOT persisted: it is owned by the URL route param (`/chat/:conversationId`) and mirrored in on load,
+ * so persisting it too would let a stale stored id fight the URL. `showSidebar` is a per-session
+ * preference and is left unpersisted.
+ */
+export const useAppStore = create<AppState>()(
+  persist(
+    (set) => ({
+      selectedAgent: null,
+      activeConversationId: null,
+      showSidebar: true,
+      setSelectedAgent: (name) => set({ selectedAgent: name }),
+      setActiveConversationId: (id) => set({ activeConversationId: id }),
+      toggleSidebar: () => set((s) => ({ showSidebar: !s.showSidebar })),
+    }),
+    {
+      name: 'agenthub-app',
+      storage: createJSONStorage(() => localStorage),
+      partialize: (s) => ({ selectedAgent: s.selectedAgent }),
+    },
+  ),
+);

--- a/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentExecutionContextFactoryTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentExecutionContextFactoryTests.cs
@@ -6,6 +6,7 @@ using Application.AI.Common.Interfaces.Traces;
 using Application.AI.Common.Models;
 using Application.AI.Common.Services.Skills;
 using Application.AI.Common.Services.Tools;
+using Domain.AI.Agents;
 using Domain.AI.Skills;
 using Domain.AI.Tools;
 using Domain.Common.Config;
@@ -77,6 +78,60 @@ public class AgentExecutionContextFactoryTests
         Name = name ?? id,
         Instructions = "You are a test agent."
     };
+
+    // --- Delegation tool provisioning ---
+
+    [Fact]
+    public void CreateFromDelegation_ProvisionsProfileToolAllowlistFromKeyedDi()
+    {
+        // A delegated subagent must actually receive its declared tools so it can do tool-using work,
+        // not just generate text. The profile's ToolAllowlist names resolve from keyed DI.
+        var toolMock = new Mock<ITool>();
+        toolMock.Setup(t => t.Name).Returns("file_system");
+        var converted = AIFunctionFactory.Create(() => "ok", "file_system");
+        var converter = new Mock<IToolConverter>();
+        converter.Setup(c => c.Convert(toolMock.Object, null)).Returns(converted);
+
+        var services = new ServiceCollection();
+        services.AddKeyedSingleton<ITool>("file_system", toolMock.Object);
+        var factory = CreateFactory(toolConverter: converter.Object, serviceProvider: services.BuildServiceProvider());
+
+        var definition = new SubagentDefinition
+        {
+            AgentType = SubagentType.Explore,
+            ToolAllowlist = ["file_system"]
+        };
+
+        var context = factory.CreateFromDelegation(
+            definition, toolOverrides: null, delegationDepth: 1, delegationId: Guid.NewGuid());
+
+        context.Tools.Should().NotBeNull();
+        context.Tools!.Select(t => t.Name).Should().ContainSingle().Which.Should().Be("file_system");
+    }
+
+    [Fact]
+    public void CreateFromDelegation_DenylistExcludesTool_AndNullAllowlistProvisionsNothing()
+    {
+        var factory = CreateFactory(serviceProvider: new ServiceCollection().BuildServiceProvider());
+
+        // Null allowlist (an "inherit everything" profile) provisions nothing on the delegation path —
+        // there is no parent tool pool to inherit from.
+        var noneCtx = factory.CreateFromDelegation(
+            new SubagentDefinition { AgentType = SubagentType.General },
+            toolOverrides: null, delegationDepth: 1, delegationId: Guid.NewGuid());
+        (noneCtx.Tools is null || noneCtx.Tools.Count == 0).Should().BeTrue();
+
+        // A denylisted name is dropped before resolution (so it never even reaches keyed DI).
+        var deniedCtx = factory.CreateFromDelegation(
+            new SubagentDefinition
+            {
+                AgentType = SubagentType.Explore,
+                ToolAllowlist = ["file_system"],
+                ToolDenylist = ["file_system"]
+            },
+            toolOverrides: null, delegationDepth: 1, delegationId: Guid.NewGuid());
+        (deniedCtx.Tools is null || deniedCtx.Tools.Count == 0).Should().BeTrue();
+    }
 
     // --- Framework type resolution ---
 

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/ToolChainBuilderTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/ToolChainBuilderTests.cs
@@ -271,6 +271,31 @@ public class ToolChainBuilderTests
     }
 
     [Fact]
+    public void BuildToolsByName_ResolvesRegisteredKeyedToolsAndSkipsUnknown()
+    {
+        // Used to provision a delegated subagent's declared tools by name (no skill involved).
+        var toolMock = new Mock<ITool>();
+        toolMock.Setup(t => t.Name).Returns("file_system");
+
+        var convertedTool = AIFunctionFactory.Create(() => "converted", "file_system");
+        var converter = new Mock<IToolConverter>();
+        converter.Setup(c => c.Convert(toolMock.Object, null)).Returns(convertedTool);
+
+        var services = new ServiceCollection();
+        services.AddKeyedSingleton<ITool>("file_system", toolMock.Object);
+
+        var builder = CreateBuilder(
+            toolConverter: converter.Object,
+            serviceProvider: services.BuildServiceProvider());
+
+        // "unregistered" has no keyed tool and is skipped; "file_system" resolves and is returned.
+        var tools = builder.BuildToolsByName(["file_system", "unregistered"]);
+
+        tools.Should().ContainSingle();
+        tools[0].Name.Should().Be("file_system");
+    }
+
+    [Fact]
     public async Task BuildToolsAsync_RequiredToolUnresolvable_Throws()
     {
         var builder = CreateBuilder();


### PR DESCRIPTION
Three follow-ups flagged in the #96 delegation (#174) and phantom-chat (#175) fixes.

## 1. Tool-capable delegation (backend)
Delegated sub-agents were created **tool-less** (`CreateFromDelegation` never set `context.Tools`), so delegation could only do pure-generation subtasks.

- New `IToolChainBuilder.BuildToolsByName` resolves keyed-DI tools by name — converting and governance-wrapping each exactly as the skill-based paths do (reuses `ResolveToolByName` + `WrapGoverned`).
- `AgentExecutionContextFactory.CreateFromDelegation` provisions the selected profile's `ToolAllowlist` (minus its `ToolDenylist`, honoring an explicit tool override). A null "inherit-everything" allowlist provisions nothing — there's no parent tool pool on the delegation path — so those profiles stay generation-only.

**Telemetry isolation (from review):** because the sub-agent now carries real tools and runs *inside* the orchestrator turn (as a `delegate_task` tool call), its tool calls would otherwise fold into the orchestrator turn's telemetry — reporting tool calls the orchestrator never made. Fixed by swapping `LlmUsageCapture.Current` to a fresh capture around the sub-agent `RunAsync`, attributing its tokens/tools to the delegation. `DelegationResult` now carries the sub-agent's real token cost.

## 2. Abort the active stream on conversation switch (frontend)
The AG-UI run subscription was per-hook-instance, so a switch (sidebar or browser back/forward) never cancelled it and the previous conversation's late tokens bled into the new transcript.

- The single active stream is now app-wide; `abortActiveStream()` is called in ChatPanel's switch branch before adopting the new conversation.
- **From review:** aborting left the streaming flags set, which would show a phantom typing indicator + leftover partial on the switched-to conversation. Fixed with a targeted `resetStreaming` store action.

## 3. Persist selectedAgent (frontend)
Refreshing directly on `/chat/:id` fell back to the agent picker because `selectedAgent` wasn't persisted. Now persisted via zustand `persist` (only `selectedAgent` — `activeConversationId` stays URL-owned). The auto-select effect falls back to the first agent when a persisted selection no longer exists.

## Tests
`BuildToolsByName` resolution; `CreateFromDelegation` provisioning (allowlist / denylist / null); stream-abort + streaming-reset on switch. **All backend + WebUI suites green; tsc + vite build clean.**

## Known follow-up (documented, out of scope)
Under **tool-invocation enforcement** (opt-in, off by default), a delegated sub-agent's tool calls are still governed by the parent orchestrator's ambient governor/progress-guard rather than its own identity (its profile denylist is already enforced at provisioning time, so denied tools are never attached). Per-sub-agent governance re-scoping needs child-scope isolation of the governance ambients — a deliberate, separate change that also affects the supervisor's testability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)