### PR TITLE
fix: validate BundleExecution config at startup (#173)

### DIFF
--- a/src/Content/Application/Application.Core/Validation/BundleExecutionConfigValidator.cs
+++ b/src/Content/Application/Application.Core/Validation/BundleExecutionConfigValidator.cs
@@ -1,0 +1,74 @@
+using Domain.Common.Config.AI.BundleExecution;
+using FluentValidation;
+
+namespace Application.Core.Validation;
+
+/// <summary>
+/// Validates <see cref="BundleExecutionConfig"/>, asserting that every bound quantity the section's
+/// own contract declares "must be positive" actually is. The archive limits bound how much a hostile
+/// bundle can cost before it is parsed; the TTL/interval knobs govern how long staged bundles, run
+/// records, and unclaimed stream reservations survive; the concurrency cap bounds how many live
+/// streams a single caller may drive.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Every rule is unconditional (not gated on <see cref="BundleExecutionConfig.Enabled"/>): the class
+/// defaults are all positive, so a host that omits the section — or leaves the subsystem off — binds
+/// valid defaults and boots unchanged. A rule only bites when an operator supplies an explicit
+/// non-positive value, which is a misconfiguration regardless of whether the feature is switched on.
+/// </para>
+/// <para>
+/// The failure this closes is silent, not loud. A non-positive <see cref="BundleExecutionConfig.StreamReservationTtl"/>
+/// makes a streaming reservation expire at or before it is created (<c>InMemoryBundleRunJobStore.Create</c>
+/// seeds <c>ExpiresAt = now + StreamReservationTtl</c>), so the SSE feed is swept before the caller can
+/// connect and the stream is silently unreachable. Likewise a non-positive <see cref="BundleExecutionConfig.CleanupInterval"/>
+/// or TTL degrades the sweeper rather than crashing it. Failing closed at startup surfaces the operator's
+/// mistake with a clear message instead of a subsystem that appears healthy but never streams.
+/// </para>
+/// </remarks>
+public sealed class BundleExecutionConfigValidator : AbstractValidator<BundleExecutionConfig>
+{
+    /// <summary>
+    /// Initializes the rule set. Bounds are inclusive-of-nothing (strictly positive) for every quantity,
+    /// except <see cref="BundleExecutionConfig.MaxConcurrentStreamsPerCaller"/> where the meaningful floor
+    /// is a single concurrent stream.
+    /// </summary>
+    public BundleExecutionConfigValidator()
+    {
+        RuleFor(x => x.MaxArchiveBytes)
+            .GreaterThan(0)
+            .WithMessage("MaxArchiveBytes must be > 0 — a non-positive limit would reject every archive.");
+
+        RuleFor(x => x.MaxEntryCount)
+            .GreaterThan(0)
+            .WithMessage("MaxEntryCount must be > 0 — a non-positive limit would reject every archive.");
+
+        RuleFor(x => x.MaxTotalUncompressedBytes)
+            .GreaterThan(0)
+            .WithMessage("MaxTotalUncompressedBytes must be > 0 — the decompression-bomb guard would reject every archive otherwise.");
+
+        RuleFor(x => x.MaxCompressionRatio)
+            .GreaterThan(0)
+            .WithMessage("MaxCompressionRatio must be > 0 — the decompression-bomb ratio guard would reject every archive otherwise.");
+
+        RuleFor(x => x.HandleTtl)
+            .GreaterThan(TimeSpan.Zero)
+            .WithMessage("HandleTtl must be > 0 — a non-positive lifetime expires every staged bundle immediately.");
+
+        RuleFor(x => x.RunRecordTtl)
+            .GreaterThan(TimeSpan.Zero)
+            .WithMessage("RunRecordTtl must be > 0 — a non-positive lifetime evicts every completed run before it can be polled.");
+
+        RuleFor(x => x.StreamReservationTtl)
+            .GreaterThan(TimeSpan.Zero)
+            .WithMessage("StreamReservationTtl must be > 0 — a non-positive lifetime sweeps every stream reservation before the caller can connect, silently disabling the SSE feed.");
+
+        RuleFor(x => x.CleanupInterval)
+            .GreaterThan(TimeSpan.Zero)
+            .WithMessage("CleanupInterval must be > 0 — a non-positive interval breaks the background cleanup sweeper.");
+
+        RuleFor(x => x.MaxConcurrentStreamsPerCaller)
+            .GreaterThanOrEqualTo(1)
+            .WithMessage("MaxConcurrentStreamsPerCaller must be >= 1 — a non-positive cap would deny every stream.");
+    }
+}

--- a/src/Content/Presentation/Presentation.Common/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Content/Presentation/Presentation.Common/Extensions/IServiceCollectionExtensions.cs
@@ -6,6 +6,7 @@ using Application.Core;
 using Application.Core.Validation;
 using Domain.Common.Config;
 using Domain.Common.Config.AI;
+using Domain.Common.Config.AI.BundleExecution;
 using Domain.Common.Config.AI.GitOps;
 using Domain.Common.Config.AI.Governance;
 using Domain.Common.Config.AI.HarmonicMemory;
@@ -213,6 +214,17 @@ public static class IServiceCollectionExtensions
             .ValidateFluentValidation<
                 Domain.Common.Config.AI.ContextManagement.PromptCompositionConfig,
                 PromptCompositionConfigValidator>()
+            .ValidateOnStart();
+
+        // Bundle-execution knobs (archive limits, handle/run/stream TTLs, cleanup interval, per-caller
+        // stream cap). All rules are unconditional positivity checks and the class defaults are all
+        // positive, so hosts that omit the section (every host except the bundle API) keep booting on
+        // defaults; a host that sets an explicit non-positive value fails closed at startup instead of
+        // silently degrading at runtime (e.g. a zero StreamReservationTtl that sweeps every SSE
+        // reservation before the caller connects).
+        services.AddOptions<BundleExecutionConfig>()
+            .Bind(configuration.GetSection("AppConfig:AI:BundleExecution"))
+            .ValidateFluentValidation<BundleExecutionConfig, BundleExecutionConfigValidator>()
             .ValidateOnStart();
 
         return services;

--- a/src/Content/Tests/Application.Core.Tests/Validation/BundleExecutionConfigValidatorTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/Validation/BundleExecutionConfigValidatorTests.cs
@@ -1,0 +1,157 @@
+using Application.Core.Validation;
+using Domain.Common.Config.AI.BundleExecution;
+using FluentAssertions;
+using Xunit;
+
+namespace Application.Core.Tests.Validation;
+
+/// <summary>
+/// Tests for <see cref="BundleExecutionConfigValidator"/>.
+/// Pattern: the class defaults are the valid baseline; each test mutates one field to a non-positive
+/// value and asserts it is rejected. Every rule is unconditional (not gated on <c>Enabled</c>), so a
+/// disabled config with a bad value must still fail.
+/// </summary>
+public class BundleExecutionConfigValidatorTests
+{
+    private readonly BundleExecutionConfigValidator _validator = new();
+
+    [Fact]
+    public async Task Validate_DefaultConfig_NoErrors()
+    {
+        // The class defaults are all positive — a host that omits the section binds these and must boot.
+        var config = new BundleExecutionConfig();
+
+        var result = await _validator.ValidateAsync(config);
+
+        result.IsValid.Should().BeTrue();
+        result.Errors.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Validate_ZeroStreamReservationTtl_HasError()
+    {
+        // The headline bug from #173: a non-positive reservation TTL sweeps the SSE stream before the
+        // caller can connect, silently disabling streaming.
+        var config = new BundleExecutionConfig { StreamReservationTtl = TimeSpan.Zero };
+
+        var result = await _validator.ValidateAsync(config);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(BundleExecutionConfig.StreamReservationTtl));
+    }
+
+    [Fact]
+    public async Task Validate_NegativeStreamReservationTtl_HasError()
+    {
+        var config = new BundleExecutionConfig { StreamReservationTtl = TimeSpan.FromSeconds(-1) };
+
+        var result = await _validator.ValidateAsync(config);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(BundleExecutionConfig.StreamReservationTtl));
+    }
+
+    [Fact]
+    public async Task Validate_ZeroHandleTtl_HasError()
+    {
+        var config = new BundleExecutionConfig { HandleTtl = TimeSpan.Zero };
+
+        var result = await _validator.ValidateAsync(config);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(BundleExecutionConfig.HandleTtl));
+    }
+
+    [Fact]
+    public async Task Validate_ZeroRunRecordTtl_HasError()
+    {
+        var config = new BundleExecutionConfig { RunRecordTtl = TimeSpan.Zero };
+
+        var result = await _validator.ValidateAsync(config);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(BundleExecutionConfig.RunRecordTtl));
+    }
+
+    [Fact]
+    public async Task Validate_ZeroCleanupInterval_HasError()
+    {
+        var config = new BundleExecutionConfig { CleanupInterval = TimeSpan.Zero };
+
+        var result = await _validator.ValidateAsync(config);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(BundleExecutionConfig.CleanupInterval));
+    }
+
+    [Fact]
+    public async Task Validate_ZeroMaxConcurrentStreamsPerCaller_HasError()
+    {
+        var config = new BundleExecutionConfig { MaxConcurrentStreamsPerCaller = 0 };
+
+        var result = await _validator.ValidateAsync(config);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(BundleExecutionConfig.MaxConcurrentStreamsPerCaller));
+    }
+
+    [Fact]
+    public async Task Validate_ZeroMaxArchiveBytes_HasError()
+    {
+        var config = new BundleExecutionConfig { MaxArchiveBytes = 0 };
+
+        var result = await _validator.ValidateAsync(config);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(BundleExecutionConfig.MaxArchiveBytes));
+    }
+
+    [Fact]
+    public async Task Validate_ZeroMaxEntryCount_HasError()
+    {
+        var config = new BundleExecutionConfig { MaxEntryCount = 0 };
+
+        var result = await _validator.ValidateAsync(config);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(BundleExecutionConfig.MaxEntryCount));
+    }
+
+    [Fact]
+    public async Task Validate_ZeroMaxTotalUncompressedBytes_HasError()
+    {
+        var config = new BundleExecutionConfig { MaxTotalUncompressedBytes = 0 };
+
+        var result = await _validator.ValidateAsync(config);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(BundleExecutionConfig.MaxTotalUncompressedBytes));
+    }
+
+    [Fact]
+    public async Task Validate_ZeroMaxCompressionRatio_HasError()
+    {
+        var config = new BundleExecutionConfig { MaxCompressionRatio = 0 };
+
+        var result = await _validator.ValidateAsync(config);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(BundleExecutionConfig.MaxCompressionRatio));
+    }
+
+    [Fact]
+    public async Task Validate_DisabledConfigWithBadValue_StillFails()
+    {
+        // Rules are unconditional: switching the subsystem off does not license a non-positive TTL.
+        var config = new BundleExecutionConfig
+        {
+            Enabled = false,
+            StreamReservationTtl = TimeSpan.Zero,
+        };
+
+        var result = await _validator.ValidateAsync(config);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(BundleExecutionConfig.StreamReservationTtl));
+    }
+}

--- a/src/Content/Tests/Presentation.Common.Tests/Extensions/ConfigValidationStartupTests.cs
+++ b/src/Content/Tests/Presentation.Common.Tests/Extensions/ConfigValidationStartupTests.cs
@@ -120,6 +120,12 @@ public class ConfigValidationStartupTests
                 ["AppConfig:AI:ContextManagement:PromptComposition:TokenBudget"] = "0",
             }
         },
+        {
+            // A zero StreamReservationTtl sweeps every SSE reservation before the caller connects —
+            // unconditional, so it fails startup regardless of whether the subsystem is enabled.
+            "BundleExecutionConfig",
+            new Dictionary<string, string?> { ["AppConfig:AI:BundleExecution:StreamReservationTtl"] = "00:00:00" }
+        },
     };
 
     [Theory]


### PR DESCRIPTION
Closes #173.

## Problem
`BundleExecutionConfig.MaxConcurrentStreamsPerCaller` was defensively clamped, but the TTL/interval knobs (`StreamReservationTtl`, `RunRecordTtl`, `HandleTtl`, `CleanupInterval`) and the archive limits had **no positivity guard**. A non-positive `StreamReservationTtl` makes a streaming reservation expire at or before creation (`InMemoryBundleRunJobStore.Create` seeds `ExpiresAt = now + StreamReservationTtl`), so the SSE feed is swept before the caller can connect — the stream is silently unreachable. Misconfiguration-only (defaults are safe), but it degrades silently at runtime instead of failing loudly at boot.

## Fix
A `BundleExecutionConfigValidator` (FluentValidation) asserting every quantity the config's own XML docs declare "must be positive":

| Knob | Rule |
|------|------|
| `MaxArchiveBytes`, `MaxEntryCount`, `MaxTotalUncompressedBytes`, `MaxCompressionRatio` | `> 0` |
| `HandleTtl`, `RunRecordTtl`, `StreamReservationTtl`, `CleanupInterval` | `> TimeSpan.Zero` |
| `MaxConcurrentStreamsPerCaller` | `>= 1` |

Wired at the single `RegisterValidatedConfigSections` point with `.ValidateOnStart()`, exactly like every sibling config validator. Per the issue's guidance this is a **pass over the whole section, not a one-off** for `StreamReservationTtl`.

Rules are **unconditional** (not gated on `Enabled`): the class defaults are all positive, so hosts that omit the section — every host except the bundle API — bind valid defaults and boot unchanged. A host that sets an explicit non-positive value now fails closed at startup with a clear message.

## Notes
- The `Math.Max(1, …)` clamp on `MaxConcurrentStreamsPerCaller` in `BundleApiServiceCollectionExtensions` is left in place: it reads config via a direct `.Get<>()` (not the validated IOptions path) and is now benign redundant defense — `ValidateOnStart` aborts boot before any request is served, so it can never silently substitute a value.
- Both host appsettings set only `Enabled` + `Auth` for `BundleExecution` (no numeric overrides), so no shipping config is affected.

## Tests
- `BundleExecutionConfigValidatorTests` — 12 tests (default config valid; each knob rejected at zero/negative; disabled-config-with-bad-value still fails).
- `ConfigValidationStartupTests` — new row proving a zero `StreamReservationTtl` fails host startup through the real `IStartupValidator` wiring.
- Green: 12 validator + 18 startup tests; `Presentation.Common` builds 0 warnings.

## Review
Two independent finder agents (correctness+cross-file, altitude+conventions) — both returned clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)