### PR TITLE
ci: cut Claude API spend on non-code and draft PRs

### DIFF
--- a/.github/workflows/grader.yml
+++ b/.github/workflows/grader.yml
@@ -38,27 +38,44 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Compute changed-line anchors
-        id: anchors
-        # The grader NEVER adds red to a PR (it advises). Anchors are a best-effort
-        # aid: if the fetch hiccups or the helper exits non-zero, swallow it and let
-        # the grade step fall back to inspecting the diff directly.
+      - name: Detect source changes and compute anchors
+        id: detect
+        # The grader NEVER adds red to a PR (it advises). This step decides whether
+        # grading is worth spending a model turn on: it grades only when compilable
+        # source under src/ changed, so docs-only, plan-only, and config-only PRs
+        # skip the Claude call entirely (the dominant source of wasted grader spend).
+        # Fail-open: if the scope can't be computed, grade anyway rather than silently
+        # skip a code PR. A best-effort helper hiccup never blocks (advisory rail).
         continue-on-error: true
         env:
           BASE_REF: ${{ github.base_ref }}
         run: |
-          set -euo pipefail
+          set -uo pipefail
           # Full fetch of the base so the merge-base (and thus the diff) resolves.
-          git fetch --no-tags origin "$BASE_REF"
-          # Deterministic changed-line set, shared with the correctness rail, so
-          # the grader's evidence pins to exact lines instead of drifting prose.
+          git fetch --no-tags origin "$BASE_REF" || true
+          # Deterministic changed-line set scoped to src/, shared with the correctness
+          # rail, so the grader's evidence pins to exact lines instead of drifting prose
+          # AND so non-code PRs are recognised as not-worth-grading.
           ANCHORS_FILE="${RUNNER_TEMP}/grader-anchors.txt"
-          scripts/rails/diff-anchors.sh --base "$BASE_REF" > "$ANCHORS_FILE"
           echo "anchors_file=${ANCHORS_FILE}" >> "$GITHUB_OUTPUT"
-          echo "Changed-line anchors:"; cat "$ANCHORS_FILE" || true
+          if scripts/rails/diff-anchors.sh --base "$BASE_REF" -- 'src/' > "$ANCHORS_FILE" 2>/dev/null; then
+            echo "Changed-line anchors under src/:"; cat "$ANCHORS_FILE" || true
+            if [ -s "$ANCHORS_FILE" ]; then
+              echo "review_required=true" >> "$GITHUB_OUTPUT"
+              echo "Grading required — source under src/ changed."
+            else
+              echo "review_required=false" >> "$GITHUB_OUTPUT"
+              echo "No source under src/ changed — skipping the grader (advisory, saves a model turn)."
+            fi
+          else
+            # Couldn't determine scope — grade anyway (fail-open; the grader never blocks).
+            echo "review_required=true" >> "$GITHUB_OUTPUT"
+            echo "::warning::Could not compute changed-line scope; grading anyway (fail-open, advisory)."
+          fi
 
       - name: Grade the change against its spec
         id: grade
+        if: steps.detect.outputs.review_required == 'true'
         continue-on-error: true
         uses: anthropics/claude-code-action@v1
         with:
@@ -68,7 +85,7 @@ jobs:
             You are running as the grader for PR #${{ github.event.pull_request.number }}.
             Read the grading rubric at .github/grader-rubric.md and follow it exactly.
             The "spec" is this PR's description and any linked issue.
-            The changed-line anchor set is at ${{ steps.anchors.outputs.anchors_file }} —
+            The changed-line anchor set is at ${{ steps.detect.outputs.anchors_file }} —
             cite a `path:line` from it as the evidence for each check, and treat it as
             the authoritative list of what this PR changed.
             Inspect the PR diff (the base is origin/${{ github.base_ref }}) and the
@@ -78,3 +95,7 @@ jobs:
             --model sonnet
             --max-turns 20
             --allowedTools Bash,Read,Grep,Glob
+
+      - name: No grading required
+        if: steps.detect.outputs.review_required != 'true'
+        run: echo "No source under src/ changed — grader skipped (advisory rail, no model turn spent)."

--- a/.github/workflows/security-review.yml
+++ b/.github/workflows/security-review.yml
@@ -41,6 +41,7 @@ jobs:
         env:
           BASE_REF: ${{ github.base_ref }}
           HAS_RISK_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'risk:high') }}
+          IS_DRAFT: ${{ github.event.pull_request.draft }}
         run: |
           set -euo pipefail
           # Full (non-shallow) fetch of the base so the merge-base exists; a
@@ -61,7 +62,15 @@ jobs:
             GATED=false
           fi
 
-          if [ "$GATED" = "true" ] || [ "$HAS_RISK_LABEL" = "true" ]; then
+          # Drafts are work-in-progress and cannot merge, so defer the expensive
+          # (Opus) reviewer until the PR is marked ready — the `ready_for_review`
+          # trigger re-runs this job. Unlike a job-level draft skip, short-circuiting
+          # here keeps this REQUIRED check always reporting a conclusion (a trivial
+          # pass on drafts), so the merge is never left stuck "pending".
+          if [ "$IS_DRAFT" = "true" ]; then
+            echo "review_required=false" >> "$GITHUB_OUTPUT"
+            echo "Draft PR — security reviewer deferred until ready_for_review (check passes trivially)."
+          elif [ "$GATED" = "true" ] || [ "$HAS_RISK_LABEL" = "true" ]; then
             echo "review_required=true" >> "$GITHUB_OUTPUT"
             echo "Security review REQUIRED (gated=$GATED, risk:high=$HAS_RISK_LABEL)."
           else


### PR DESCRIPTION
Reduces the Anthropic API spend of the CI review rails, per two zero-tradeoff wins identified in a spend analysis. **Model tiers are unchanged** (the correctness reviewer stays on Opus by decision).

## 1. Grader skips non-code PRs
The grader (advisory, Sonnet, 20-turn budget) ran on **every** PR — including docs-only, plan-only, and config-only PRs, of which this repo produces many. The correctness rail already gates on `src/` changes; the grader was the outlier.

- Now grades only when compilable source under `src/` changed (same `diff-anchors.sh -- 'src/'` gate as `correctness-review.yml`).
- **Fail-open:** if the changed-line scope can't be computed, it grades anyway — the rail stays advisory and never adds red.
- Expected: eliminates grader spend on all non-code PRs.

## 2. Security review defers its Opus reviewer on draft PRs
`grader` and `correctness-review` already skip drafts; `security-review` did not, so it ran the **Opus** reviewer on every push to a WIP security/infra branch.

- Folded the draft check **into the detect gate**, not a job-level skip — because `security-review` is a *required* check, short-circuiting inside detect keeps it always reporting a trivial pass on drafts (the merge is never left stuck "pending"). The `ready_for_review` trigger re-runs the real review once the PR is marked ready.
- Expected: no Opus runs on in-progress security drafts.

## Not changed
- Correctness reviewer stays on **Opus** (deliberate — security/correctness defects are higher-consequence than the token saving).
- `concurrency: cancel-in-progress` was already present on all three rails.

## Validation
Both workflow files parse cleanly (`yaml.safe_load`). No `src/**` touched, so no application build/test impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)