### PR TITLE
feat: OTel logs signal + in-app PII redaction (#153 PR1)

### DIFF
--- a/documentation/design/event-hub-log-export.md
+++ b/documentation/design/event-hub-log-export.md
@@ -1,6 +1,6 @@
 # Story: OTel Log Export to Azure Event Hub (with in-app PII filtering)
 
-> **Status:** Decisions settled (§10) — ready to build; no code yet.
+> **Status:** PR1 shipped (OTel logs signal + PII processor + validation, off by default). PR2–PR4 pending.
 > **Issue:** [#153](https://github.com/MCKRUZ/microsoft-agentic-harness/issues/153) — "Event logging in Event Hub … make sure there is a filter in place for PII."
 > **Author:** design pass, 2026-07-12.
 
@@ -163,7 +163,9 @@ CI has no live Azure/Event Hub (consistent with the harness's no-live-Kestrel/Do
 
 ## 9. Rollout (one concern per PR)
 
-1. **PR1 — OTel logs signal + PII processor.** Bridge `ILogger` → OTel on both host shapes; add `ITelemetryConfigurator.ConfigureLogging`; add `LogRecordRedactionProcessor` (reusing `IContentRedactionFilter`); `Logs.OtelExportEnabled` + OTLP logs exporter. **Off by default.** *This PR alone closes the Grafana-logs gap.*
+1. **PR1 — OTel logs signal + PII processor. ✅ SHIPPED.** Bridges `ILogger` → OTel on both host shapes via `AddOpenTelemetry().WithLogging(...)` (uniform for web + console — the bridge is an `ILoggerProvider` the standard factory picks up); adds `LogRecordRedactionProcessor : BaseProcessor<LogRecord>` (reuses `IContentRedactionFilter`); adds `LogsConfig` (`OtelExportEnabled` + `MinExportLevel` + redaction) at `AppConfig:Observability:Logs` with `LogsConfigValidator` + `ValidateOnStart`; OTLP logs exporter (same endpoint as traces/metrics). **Off by default; byte-identical when off.** *This PR alone closes the Grafana-logs gap.*
+   - **Deviation 1 (better home):** redaction config lives under **`Logs`**, not `Exporters.EventHub.Redaction`. PII scrub is a *signal-wide* processor — it runs once before **every** log exporter (OTLP now, Event Hub later), so scoping it to one exporter would be wrong. §5.2's "before any exporter" is honored: the redactor is registered pre-build, ahead of the exporter, because the batch exporter snapshots the pooled record (an after-the-exporter processor would leak). PR2's `EventHub.Redaction` is therefore dropped as redundant.
+   - **Deviation 2 (YAGNI):** `ITelemetryConfigurator.ConfigureLogging` seam is **deferred to PR2**, when a second log exporter (Azure Monitor / Event Hub Direct) actually needs it. PR1 wires the redactor + OTLP exporter directly; adding an interface method with no implementer would be inert. The ordering constraint (redactor must precede the exporter, and OTLP must register pre-build) also means the deferred-configurator seam couldn't express PR1's pipeline anyway.
 2. **PR2 — Event Hub config + Collector mode.** `EventHubExporterConfig` + validator + `ValidateOnStart` wiring; Collector-mode docs (OTLP logs → collector Kafka/Azure exporter → Event Hub). Mostly config + docs; no SDK dependency.
 3. **PR3 — Direct mode.** Add `Azure.Messaging.EventHubs`; in-process `BaseExporter<LogRecord>` behind `IEventHubLogSink`; both auth modes; bounded queue + drop-on-overflow + dropped/failure counters + recursion guard.
 4. **PR4 (optional) — docs.** Security guide (PII flow, auth, recursion guard) + observability blueprint update (logs now a signal; Grafana Loki wiring notes).

--- a/src/Content/Application/Application.Core/Validation/LogsConfigValidator.cs
+++ b/src/Content/Application/Application.Core/Validation/LogsConfigValidator.cs
@@ -1,0 +1,65 @@
+using Domain.AI.Telemetry.Redaction;
+using Domain.Common.Config.Observability;
+using FluentValidation;
+using Microsoft.Extensions.Logging;
+
+namespace Application.Core.Validation;
+
+/// <summary>
+/// Validates <see cref="LogsConfig"/>. All rules are conditional on
+/// <see cref="LogsConfig.OtelExportEnabled"/> — the logs signal is OFF by default,
+/// so a host that omits the section (every host but those opting into OTel log
+/// export) binds valid defaults and boots unchanged. When export is on the rules
+/// keep the pipeline coherent: <see cref="LogsConfig.MinExportLevel"/> must parse
+/// to a real <see cref="LogLevel"/>, and — when redaction is on — at least one
+/// category must be requested and every requested name must map (case-insensitively)
+/// to a known <see cref="RedactionCategory"/>. This mirrors the parsing behaviour of
+/// the Infrastructure <c>LogRecordRedactionProcessor</c>, so a config typo surfaces
+/// both in the options-validation pipeline and (as a warning) at runtime.
+/// </summary>
+/// <remarks>
+/// Auto-discovered via <c>AddValidatorsFromAssembly</c> on the Application.Core
+/// assembly — no manual registration required. Wired into the startup options
+/// pipeline at <c>RegisterValidatedConfigSections</c> with <c>ValidateOnStart</c>.
+/// </remarks>
+public sealed class LogsConfigValidator : AbstractValidator<LogsConfig>
+{
+    private static readonly HashSet<string> KnownCategories =
+        new(Enum.GetNames<RedactionCategory>(), StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>Initializes a new instance of the <see cref="LogsConfigValidator"/> class.</summary>
+    public LogsConfigValidator()
+    {
+        When(x => x.OtelExportEnabled, () =>
+        {
+            RuleFor(x => x.MinExportLevel)
+                .Must(BeValidLogLevel)
+                .WithMessage(x =>
+                    $"MinExportLevel '{x.MinExportLevel}' is not a valid LogLevel. " +
+                    $"Valid values: {string.Join(", ", Enum.GetNames<LogLevel>())}.");
+
+            When(x => x.RedactionEnabled, () =>
+            {
+                RuleFor(x => x.RedactionCategories)
+                    .NotNull()
+                    .Must(c => c is { Count: > 0 })
+                    .WithMessage(
+                        "RedactionCategories must contain at least one category when log redaction is enabled. " +
+                        "An empty list would export log content unredacted.");
+
+                RuleForEach(x => x.RedactionCategories)
+                    .Must(BeKnownCategory)
+                    .WithMessage(category =>
+                        $"RedactionCategories contains '{category}', which is not a known RedactionCategory. " +
+                        $"Valid values: {string.Join(", ", Enum.GetNames<RedactionCategory>())}.");
+            });
+        });
+    }
+
+    private static bool BeValidLogLevel(string level)
+        => !string.IsNullOrWhiteSpace(level)
+            && Enum.TryParse<LogLevel>(level.Trim(), ignoreCase: true, out _);
+
+    private static bool BeKnownCategory(string category)
+        => !string.IsNullOrWhiteSpace(category) && KnownCategories.Contains(category.Trim());
+}

--- a/src/Content/Domain/Domain.Common/Config/Observability/LogsConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/Observability/LogsConfig.cs
@@ -1,0 +1,80 @@
+namespace Domain.Common.Config.Observability;
+
+/// <summary>
+/// Configuration for exporting application logs as an OpenTelemetry signal.
+/// OFF by default — the harness has always exported <em>traces</em> and
+/// <em>metrics</em> via OTel, but logs ran on a separate pipe (console / file /
+/// JSONL / ring-buffer) that never reached the collector. Turning
+/// <see cref="OtelExportEnabled"/> on bridges <c>ILogger</c> records into the
+/// OTel logs pipeline so they land in the same backend (e.g. Grafana) next to
+/// the trace waterfall and metric charts.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The local <c>ILogger</c> sinks are unaffected: this signal is
+/// <strong>additional</strong>, not a replacement. When enabled, PII is scrubbed
+/// in-process (see <see cref="RedactionEnabled"/>) before any log record leaves
+/// the process, so nothing sensitive transits the OTLP wire — even when the
+/// collector, not the app, ultimately forwards the logs.
+/// </para>
+/// <para>
+/// Binds from <c>AppConfig:Observability:Logs</c>. Validated at host start by
+/// <c>LogsConfigValidator</c> (<c>ValidateOnStart</c>), so a malformed level or
+/// redaction category fails the boot instead of silently degrading.
+/// </para>
+/// </remarks>
+public sealed class LogsConfig
+{
+    /// <summary>
+    /// Master switch for the <c>ILogger</c> → OpenTelemetry logs bridge. When
+    /// <c>false</c> (default), no OTel logs pipeline is wired and logging behaves
+    /// exactly as before (local sinks only). Default: <c>false</c>.
+    /// </summary>
+    public bool OtelExportEnabled { get; set; }
+
+    /// <summary>
+    /// Minimum severity a log record must have to be <em>exported</em> via OTel,
+    /// independent of the local sinks' own levels. Parses to a
+    /// <c>Microsoft.Extensions.Logging.LogLevel</c> (<c>Trace</c>, <c>Debug</c>,
+    /// <c>Information</c>, <c>Warning</c>, <c>Error</c>, <c>Critical</c>,
+    /// <c>None</c>). Default: <c>Information</c> — export the full routine +
+    /// problem trail. Set <c>Warning</c> to cap Event Hub / backend volume and
+    /// cost. Applied as a provider-scoped filter on the OTel logger provider.
+    /// </summary>
+    public string MinExportLevel { get; set; } = "Information";
+
+    /// <summary>
+    /// Whether PII / secret content is scrubbed from log records before export.
+    /// Default: <c>true</c> — a compliance-sensitive template must not leak PII
+    /// onto the wire, so redaction is on whenever export is on. The scrub runs
+    /// as the first pipeline stage (before any exporter), covering the formatted
+    /// message, the body, and every string-valued attribute.
+    /// </summary>
+    public bool RedactionEnabled { get; set; } = true;
+
+    /// <summary>
+    /// Names of <c>Domain.AI.Telemetry.Redaction.RedactionCategory</c> values the
+    /// redactor applies before export. Unknown names fail validation at boot.
+    /// Default: the full set, so a consumer that flips
+    /// <see cref="OtelExportEnabled"/> on without tuning categories still gets the
+    /// safest (over-redactive) posture.
+    /// </summary>
+    /// <remarks>
+    /// Held as strings (not the enum) because the <c>AppConfig</c> hierarchy lives
+    /// in <c>Domain.Common</c>, which must not depend on <c>Domain.AI</c>. The
+    /// Infrastructure <c>LogRecordRedactionProcessor</c> parses these back to the
+    /// enum and logs any value it does not recognise. Mirrors
+    /// <c>ContentCaptureConfig.RedactionCategories</c>.
+    /// </remarks>
+    public List<string> RedactionCategories { get; set; } =
+    [
+        "Email",
+        "Phone",
+        "Ssn",
+        "CreditCard",
+        "IpAddress",
+        "AwsKey",
+        "JwtToken",
+        "Generic",
+    ];
+}

--- a/src/Content/Domain/Domain.Common/Config/Observability/ObservabilityConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/Observability/ObservabilityConfig.cs
@@ -46,6 +46,14 @@ public class ObservabilityConfig
     public ExportersConfig Exporters { get; set; } = new();
 
     /// <summary>
+    /// Gets or sets the OpenTelemetry logs-signal configuration (the
+    /// <c>ILogger</c> → OTel bridge, PII scrub, and export level). OFF by default —
+    /// logs stay on the local sinks until <see cref="LogsConfig.OtelExportEnabled"/>
+    /// is set.
+    /// </summary>
+    public LogsConfig Logs { get; set; } = new();
+
+    /// <summary>
     /// Gets or sets the LLM token pricing configuration for cost estimation.
     /// </summary>
     public LlmPricingConfig LlmPricing { get; set; } = new();

--- a/src/Content/Infrastructure/Infrastructure.Observability/Processors/LogRecordRedactionProcessor.cs
+++ b/src/Content/Infrastructure/Infrastructure.Observability/Processors/LogRecordRedactionProcessor.cs
@@ -59,6 +59,21 @@ public sealed class LogRecordRedactionProcessor : BaseProcessor<LogRecord>
         _enabled = config.RedactionEnabled;
         _categories = ParseCategories(config.RedactionCategories, logger);
 
+        // Fail safe, not open. Startup validation (LogsConfigValidator) already rejects an
+        // enabled-but-empty/unknown category set on every host that wires ValidateOnStart. This
+        // guards the residual case — a consumer's custom host that bypasses that pipeline: if
+        // redaction is requested but no category resolves, over-redact with the full set rather
+        // than silently emitting unredacted PII. Matches the redactor's conservative-by-default
+        // posture (a false positive that masks text is acceptable; a leaked PAN is not).
+        if (_enabled && _categories.Length == 0)
+        {
+            _categories = Enum.GetValues<RedactionCategory>();
+            logger.LogWarning(
+                "Log redaction is enabled but no valid categories were configured; falling back " +
+                "to the full redaction set ({CategoryCount} categories) to avoid emitting unredacted PII.",
+                _categories.Length);
+        }
+
         logger.LogInformation(
             "Log-record redaction initialized: enabled={Enabled}, {CategoryCount} categories active.",
             _enabled,

--- a/src/Content/Infrastructure/Infrastructure.Observability/Processors/LogRecordRedactionProcessor.cs
+++ b/src/Content/Infrastructure/Infrastructure.Observability/Processors/LogRecordRedactionProcessor.cs
@@ -1,0 +1,155 @@
+using Application.AI.Common.Interfaces.Telemetry;
+using Domain.AI.Telemetry.Redaction;
+using Domain.Common.Config.Observability;
+using Microsoft.Extensions.Logging;
+using OpenTelemetry;
+using OpenTelemetry.Logs;
+
+namespace Infrastructure.Observability.Processors;
+
+/// <summary>
+/// Scrubs PII / secret content from OpenTelemetry <see cref="LogRecord"/>s before
+/// they reach any exporter. The log-signal counterpart to the span-side
+/// <see cref="PiiFilteringProcessor"/>: one PII processor per signal, both reusing
+/// the harness's content redactor.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Registered <strong>first</strong> in the logger pipeline — ahead of the OTLP
+/// (or any other) exporter — so redaction runs in-process before a record is
+/// serialized or copied for batching. Processor <see cref="BaseProcessor{T}.OnEnd"/>
+/// callbacks run in registration order on the emitting thread, and the batch
+/// exporter snapshots the pooled <see cref="LogRecord"/>; a redactor registered
+/// after the exporter would therefore export the raw record. Because the scrub
+/// happens before export, PII never transits the wire even when a downstream
+/// collector — not the app — forwards the logs to Event Hub / a SIEM.
+/// </para>
+/// <para>
+/// Three surfaces are scrubbed: the rendered <see cref="LogRecord.FormattedMessage"/>
+/// (populated because the pipeline sets <c>IncludeFormattedMessage = true</c>),
+/// the <see cref="LogRecord.Body"/>, and every string-valued entry in
+/// <see cref="LogRecord.Attributes"/> (the promoted structured fields). The
+/// underlying <see cref="IContentRedactionFilter"/> is intentionally
+/// over-redactive: a false positive that masks a token is acceptable, a false
+/// negative that leaks a credit-card number is not.
+/// </para>
+/// </remarks>
+public sealed class LogRecordRedactionProcessor : BaseProcessor<LogRecord>
+{
+    private readonly IContentRedactionFilter _filter;
+    private readonly RedactionCategory[] _categories;
+    private readonly bool _enabled;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="LogRecordRedactionProcessor"/> class.
+    /// </summary>
+    /// <param name="filter">The content redactor reused across all signals.</param>
+    /// <param name="config">The logs-signal configuration (redaction toggle + categories).</param>
+    /// <param name="logger">Logger for surfacing unrecognised category names once at startup.</param>
+    public LogRecordRedactionProcessor(
+        IContentRedactionFilter filter,
+        LogsConfig config,
+        ILogger<LogRecordRedactionProcessor> logger)
+    {
+        ArgumentNullException.ThrowIfNull(filter);
+        ArgumentNullException.ThrowIfNull(config);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _filter = filter;
+        _enabled = config.RedactionEnabled;
+        _categories = ParseCategories(config.RedactionCategories, logger);
+
+        logger.LogInformation(
+            "Log-record redaction initialized: enabled={Enabled}, {CategoryCount} categories active.",
+            _enabled,
+            _categories.Length);
+    }
+
+    /// <inheritdoc />
+    public override void OnEnd(LogRecord data)
+    {
+        if (!_enabled || _categories.Length == 0 || data is null)
+        {
+            return;
+        }
+
+        if (data.FormattedMessage is { Length: > 0 } message)
+        {
+            data.FormattedMessage = _filter.Redact(message, _categories);
+        }
+
+        if (data.Body is { Length: > 0 } body)
+        {
+            data.Body = _filter.Redact(body, _categories);
+        }
+
+        RedactAttributes(data);
+    }
+
+    /// <summary>
+    /// Rewrites string-valued attributes in place, allocating a replacement list only
+    /// when at least one value actually changed (the common case is no PII → no alloc).
+    /// </summary>
+    private void RedactAttributes(LogRecord data)
+    {
+        var attributes = data.Attributes;
+        if (attributes is null || attributes.Count == 0)
+        {
+            return;
+        }
+
+        List<KeyValuePair<string, object?>>? rewritten = null;
+        for (var i = 0; i < attributes.Count; i++)
+        {
+            var attribute = attributes[i];
+            if (attribute.Value is string raw && raw.Length > 0)
+            {
+                var scrubbed = _filter.Redact(raw, _categories);
+                if (scrubbed != raw)
+                {
+                    rewritten ??= [.. attributes];
+                    rewritten[i] = new KeyValuePair<string, object?>(attribute.Key, scrubbed);
+                }
+            }
+        }
+
+        if (rewritten is not null)
+        {
+            data.Attributes = rewritten;
+        }
+    }
+
+    /// <summary>
+    /// Parses the configured category names to <see cref="RedactionCategory"/> values,
+    /// skipping (and logging) any name the enum does not recognise. Startup validation
+    /// (<c>LogsConfigValidator</c>) already rejects unknown names, so this is defence in
+    /// depth for hosts that bypass the validated-options pipeline.
+    /// </summary>
+    private static RedactionCategory[] ParseCategories(
+        IReadOnlyList<string>? names,
+        ILogger logger)
+    {
+        if (names is null || names.Count == 0)
+        {
+            return [];
+        }
+
+        var parsed = new List<RedactionCategory>(names.Count);
+        foreach (var name in names)
+        {
+            if (Enum.TryParse<RedactionCategory>(name?.Trim(), ignoreCase: true, out var category))
+            {
+                parsed.Add(category);
+            }
+            else
+            {
+                logger.LogWarning(
+                    "Ignoring unknown log-redaction category '{Category}'. Valid values: {Valid}.",
+                    name,
+                    string.Join(", ", Enum.GetNames<RedactionCategory>()));
+            }
+        }
+
+        return [.. parsed.Distinct()];
+    }
+}

--- a/src/Content/Presentation/Presentation.Common/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Content/Presentation/Presentation.Common/Extensions/IServiceCollectionExtensions.cs
@@ -227,6 +227,15 @@ public static class IServiceCollectionExtensions
             .ValidateFluentValidation<BundleExecutionConfig, BundleExecutionConfigValidator>()
             .ValidateOnStart();
 
+        // OTel logs-signal knobs (export toggle, min export level, PII redaction). Rules are
+        // conditional on OtelExportEnabled and the defaults are all valid, so hosts that omit
+        // the section keep booting; a host that enables export with a bad level or an unknown
+        // redaction category fails closed at startup instead of silently mis-exporting.
+        services.AddOptions<LogsConfig>()
+            .Bind(configuration.GetSection("AppConfig:Observability:Logs"))
+            .ValidateFluentValidation<LogsConfig, LogsConfigValidator>()
+            .ValidateOnStart();
+
         return services;
     }
 

--- a/src/Content/Presentation/Presentation.Common/Extensions/OpenTelemetryServiceCollectionExtensions.cs
+++ b/src/Content/Presentation/Presentation.Common/Extensions/OpenTelemetryServiceCollectionExtensions.cs
@@ -1,12 +1,16 @@
+using Application.AI.Common.Interfaces.Telemetry;
 using Application.Common.Interfaces.Telemetry;
 using Domain.Common.Config;
 using Domain.Common.Config.Observability;
 using Domain.Common.Telemetry;
+using Infrastructure.Observability.Processors;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using OpenTelemetry;
 using OpenTelemetry.Exporter;
 using OpenTelemetry.Instrumentation.AspNetCore;
 using OpenTelemetry.Instrumentation.Http;
+using OpenTelemetry.Logs;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
@@ -71,6 +75,12 @@ public static class OpenTelemetryServiceCollectionExtensions
             services.AddWebTelemetry(appConfig);
         else
             services.AddDesktopTelemetry();
+
+        // Logs signal — bridges ILogger records into OTel so they reach the same
+        // backend as traces/metrics (closing the gap where app logs never left the
+        // local console/file sinks). Wired identically for both host shapes via the
+        // hosting integration's ILogger bridge, and OFF by default.
+        services.AddLogsSignal(appConfig);
 
         return services;
     }
@@ -194,6 +204,87 @@ public static class OpenTelemetryServiceCollectionExtensions
         services.AddHostedService<Telemetry.DesktopTelemetryHostedService>();
 
         return services;
+    }
+
+    /// <summary>
+    /// Wires the OpenTelemetry logs signal — the <c>ILogger</c> → OTel bridge — when
+    /// <c>Observability:Logs:OtelExportEnabled</c> is set. No-op (and zero pipeline
+    /// registration) when the flag is off, so hosts boot byte-identically by default.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Uses <c>AddOpenTelemetry().WithLogging(...)</c> rather than a standalone
+    /// <see cref="LoggerProvider"/>: the logs signal must originate from the host's
+    /// <c>ILoggerFactory</c>, and <c>WithLogging</c> registers the bridging
+    /// <c>ILoggerProvider</c> (aliased "OpenTelemetry") into DI where the standard
+    /// factory picks it up — so it works uniformly for both the web host and the
+    /// bare-<c>ServiceCollection</c> console hosts. This differs from the standalone
+    /// tracer/meter providers, which are built manually because nothing resolves them
+    /// on the console path; the logs bridge self-materializes on first log.
+    /// </para>
+    /// <para>
+    /// <see cref="LogsConfig.MinExportLevel"/> is applied as a provider-scoped filter,
+    /// so it caps what OTel <em>exports</em> without touching the local sinks' levels.
+    /// </para>
+    /// </remarks>
+    private static IServiceCollection AddLogsSignal(this IServiceCollection services, AppConfig appConfig)
+    {
+        var logsConfig = appConfig.Observability.Logs;
+        if (!logsConfig.OtelExportEnabled)
+            return services;
+
+        services.AddOpenTelemetry().WithLogging(
+            configureBuilder: builder => ConfigureLoggerProviderBuilder(builder, appConfig),
+            // Populate FormattedMessage so the rendered text (and any PII in it) is
+            // present for the redactor to scrub and for exporters to ship.
+            configureOptions: options => options.IncludeFormattedMessage = true);
+
+        // Cap OTel export at MinExportLevel independent of the console/file/JSONL sinks,
+        // which keep their own levels. Targets the bridge provider by its concrete type.
+        if (Enum.TryParse<LogLevel>(logsConfig.MinExportLevel, ignoreCase: true, out var minLevel))
+        {
+            services.AddLogging(logging =>
+                logging.AddFilter<OpenTelemetryLoggerProvider>(category: null, minLevel));
+        }
+
+        return services;
+    }
+
+    /// <summary>
+    /// Configures the OTel logger pipeline: PII redaction first, then the OTLP logs
+    /// exporter, then the shared resource attributes (resolved at build time so logs
+    /// correlate with traces/metrics in the backend).
+    /// </summary>
+    private static void ConfigureLoggerProviderBuilder(LoggerProviderBuilder builder, AppConfig appConfig)
+    {
+        var logsConfig = appConfig.Observability.Logs;
+
+        // Redaction is registered FIRST — ahead of the exporter — so PII is scrubbed
+        // before the batch exporter snapshots the pooled record. The DI factory defers
+        // construction to build time, resolving the shared content redactor.
+        if (logsConfig.RedactionEnabled)
+        {
+            builder.AddProcessor(sp => new LogRecordRedactionProcessor(
+                sp.GetRequiredService<IContentRedactionFilter>(),
+                logsConfig,
+                sp.GetRequiredService<ILoggerFactory>()
+                    .CreateLogger<LogRecordRedactionProcessor>()));
+        }
+
+        // OTLP logs exporter — same endpoint/options as traces/metrics. Registered
+        // pre-build (AddOtlpExporter calls ConfigureServices), and after redaction so
+        // the scrub runs first in the OnEnd chain.
+        var otlpConfig = appConfig.Observability.Exporters.Otlp;
+        if (otlpConfig.Enabled)
+        {
+            builder.AddOtlpExporter("otlp-logs", options =>
+                ConfigureOtlpOptions(options, otlpConfig));
+        }
+
+        // Resolve the ResourceBuilder singleton at provider-build time so logs carry the
+        // same service.name/version resource attributes as the other signals.
+        ((IDeferredLoggerProviderBuilder)builder).Configure((sp, b) =>
+            b.SetResourceBuilder(sp.GetRequiredService<ResourceBuilder>()));
     }
 
     /// <summary>

--- a/src/Content/Tests/Application.Core.Tests/Validation/LogsConfigValidatorTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/Validation/LogsConfigValidatorTests.cs
@@ -1,0 +1,136 @@
+using Application.Core.Validation;
+using Domain.Common.Config.Observability;
+using FluentAssertions;
+using Xunit;
+
+namespace Application.Core.Tests.Validation;
+
+/// <summary>
+/// Tests for <see cref="LogsConfigValidator"/>. All rules are conditional on
+/// <see cref="LogsConfig.OtelExportEnabled"/>: a disabled section is always valid
+/// (the signal is off by default); an enabled one requires a parseable
+/// <c>MinExportLevel</c> and — when redaction is on — a non-empty list of known
+/// <c>RedactionCategory</c> names. Pattern: a valid baseline, mutate one field per test.
+/// </summary>
+public class LogsConfigValidatorTests
+{
+    private readonly LogsConfigValidator _validator = new();
+
+    [Fact]
+    public void DefaultValues_AreExportOffWithSafeDefaults()
+    {
+        var config = new LogsConfig();
+
+        config.OtelExportEnabled.Should().BeFalse();
+        config.MinExportLevel.Should().Be("Information");
+        config.RedactionEnabled.Should().BeTrue();
+        config.RedactionCategories.Should()
+            .BeEquivalentTo("Email", "Phone", "Ssn", "CreditCard", "IpAddress", "AwsKey", "JwtToken", "Generic");
+    }
+
+    [Fact]
+    public async Task Validate_DisabledWithGarbageValues_IsValid()
+    {
+        // Export off short-circuits every rule, so an omitted/off section always boots.
+        var config = new LogsConfig
+        {
+            OtelExportEnabled = false,
+            MinExportLevel = "NotALevel",
+            RedactionCategories = ["Bogus"],
+        };
+
+        var result = await _validator.ValidateAsync(config);
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Validate_EnabledWithDefaults_IsValid()
+    {
+        var config = new LogsConfig { OtelExportEnabled = true };
+
+        var result = await _validator.ValidateAsync(config);
+
+        result.IsValid.Should().BeTrue();
+        result.Errors.Should().BeEmpty();
+    }
+
+    [Theory]
+    [InlineData("Trace")]
+    [InlineData("debug")]
+    [InlineData("INFORMATION")]
+    [InlineData("Warning")]
+    [InlineData("Error")]
+    [InlineData("Critical")]
+    [InlineData("None")]
+    public async Task Validate_EnabledWithValidLevelCaseInsensitive_NoLevelError(string level)
+    {
+        var config = new LogsConfig { OtelExportEnabled = true, MinExportLevel = level };
+
+        var result = await _validator.ValidateAsync(config);
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("Verbose")]
+    [InlineData("NotALevel")]
+    [InlineData("")]
+    public async Task Validate_EnabledWithInvalidLevel_HasError(string level)
+    {
+        var config = new LogsConfig { OtelExportEnabled = true, MinExportLevel = level };
+
+        var result = await _validator.ValidateAsync(config);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(LogsConfig.MinExportLevel));
+    }
+
+    [Fact]
+    public async Task Validate_EnabledRedactionWithEmptyCategories_HasError()
+    {
+        var config = new LogsConfig
+        {
+            OtelExportEnabled = true,
+            RedactionEnabled = true,
+            RedactionCategories = [],
+        };
+
+        var result = await _validator.ValidateAsync(config);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(LogsConfig.RedactionCategories));
+    }
+
+    [Fact]
+    public async Task Validate_EnabledRedactionWithUnknownCategory_HasError()
+    {
+        var config = new LogsConfig
+        {
+            OtelExportEnabled = true,
+            RedactionEnabled = true,
+            RedactionCategories = ["Email", "Bogus"],
+        };
+
+        var result = await _validator.ValidateAsync(config);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName.StartsWith(nameof(LogsConfig.RedactionCategories)));
+    }
+
+    [Fact]
+    public async Task Validate_EnabledButRedactionOff_EmptyCategoriesAllowed()
+    {
+        // With redaction off, the category rules don't fire (the operator has opted out).
+        var config = new LogsConfig
+        {
+            OtelExportEnabled = true,
+            RedactionEnabled = false,
+            RedactionCategories = [],
+        };
+
+        var result = await _validator.ValidateAsync(config);
+
+        result.IsValid.Should().BeTrue();
+    }
+}

--- a/src/Content/Tests/Infrastructure.Observability.Tests/Processors/LogRecordRedactionProcessorTests.cs
+++ b/src/Content/Tests/Infrastructure.Observability.Tests/Processors/LogRecordRedactionProcessorTests.cs
@@ -129,8 +129,10 @@ public sealed class LogRecordRedactionProcessorTests
     }
 
     [Fact]
-    public void OnEnd_NoCategories_LeavesRecordUnchanged()
+    public void OnEnd_EnabledWithEmptyCategories_FallsBackToFullRedaction()
     {
+        // Fail-safe (not fail-open): redaction requested but no category resolved — the
+        // processor over-redacts with the full set rather than emitting unredacted content.
         var config = EnabledConfig();
         config.RedactionCategories = [];
 
@@ -138,7 +140,20 @@ public sealed class LogRecordRedactionProcessorTests
             CreateProcessor(config),
             logger => logger.LogInformation("token is {Value}", Marker));
 
-        capture.Records[0].Message.Should().Be($"token is {Marker}");
+        capture.Records[0].Message.Should().Be($"token is {Redacted}");
+    }
+
+    [Fact]
+    public void OnEnd_EnabledWithAllInvalidCategories_FallsBackToFullRedaction()
+    {
+        var config = EnabledConfig();
+        config.RedactionCategories = ["Bogus", "AlsoBogus"];
+
+        var capture = RunPipeline(
+            CreateProcessor(config),
+            logger => logger.LogInformation("token is {Value}", Marker));
+
+        capture.Records[0].Message.Should().Be($"token is {Redacted}");
     }
 
     [Fact]

--- a/src/Content/Tests/Infrastructure.Observability.Tests/Processors/LogRecordRedactionProcessorTests.cs
+++ b/src/Content/Tests/Infrastructure.Observability.Tests/Processors/LogRecordRedactionProcessorTests.cs
@@ -1,0 +1,166 @@
+using Application.AI.Common.Interfaces.Telemetry;
+using Domain.AI.Telemetry.Redaction;
+using Domain.Common.Config.Observability;
+using FluentAssertions;
+using Infrastructure.Observability.Processors;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using OpenTelemetry;
+using OpenTelemetry.Logs;
+using Xunit;
+
+namespace Infrastructure.Observability.Tests.Processors;
+
+/// <summary>
+/// Tests <see cref="LogRecordRedactionProcessor"/> by driving real
+/// <see cref="LogRecord"/>s through the OpenTelemetry logging pipeline. The
+/// <see cref="IContentRedactionFilter"/> is mocked (its own rule set is covered by
+/// <c>DefaultContentRedactionFilter</c> tests) so these tests pin the processor's
+/// own contract: which surfaces it scrubs, that it leaves non-string data alone,
+/// and that it runs before a downstream exporter sees the record.
+/// </summary>
+public sealed class LogRecordRedactionProcessorTests
+{
+    private const string Marker = "SECRET";
+    private const string Redacted = "[REDACTED]";
+
+    /// <summary>A capturing "exporter" that snapshots each record synchronously in OnEnd
+    /// (LogRecords are pooled and recycled, so fields are copied out immediately).</summary>
+    private sealed class CapturingProcessor : BaseProcessor<LogRecord>
+    {
+        public List<(string? Message, List<KeyValuePair<string, object?>> Attributes)> Records { get; } = [];
+
+        public override void OnEnd(LogRecord data) =>
+            Records.Add((data.FormattedMessage, data.Attributes?.ToList() ?? []));
+    }
+
+    private static Mock<IContentRedactionFilter> MockFilter()
+    {
+        // Stand-in for the real redactor: replace the marker token wherever it appears.
+        var mock = new Mock<IContentRedactionFilter>();
+        mock.Setup(f => f.Redact(It.IsAny<string?>(), It.IsAny<IReadOnlyList<RedactionCategory>>()))
+            .Returns((string? s, IReadOnlyList<RedactionCategory> _) => s?.Replace(Marker, Redacted) ?? string.Empty);
+        return mock;
+    }
+
+    private static LogsConfig EnabledConfig() => new()
+    {
+        OtelExportEnabled = true,
+        RedactionEnabled = true,
+        RedactionCategories = ["Email", "Generic"],
+    };
+
+    /// <summary>
+    /// Runs a single log call through a pipeline with the redaction processor registered
+    /// first and a capturing processor after it, returning what the capturer saw.
+    /// </summary>
+    private static CapturingProcessor RunPipeline(
+        LogRecordRedactionProcessor redactor,
+        Action<ILogger> log)
+    {
+        var capture = new CapturingProcessor();
+        using (var loggerFactory = LoggerFactory.Create(builder =>
+        {
+            builder.AddOpenTelemetry(options =>
+            {
+                options.IncludeFormattedMessage = true;
+                options.AddProcessor(redactor);   // FIRST — must scrub before export
+                options.AddProcessor(capture);     // AFTER — sees the redacted record
+            });
+        }))
+        {
+            log(loggerFactory.CreateLogger("test.redaction"));
+        }
+
+        return capture;
+    }
+
+    private static LogRecordRedactionProcessor CreateProcessor(LogsConfig config) =>
+        new(MockFilter().Object, config, NullLogger<LogRecordRedactionProcessor>.Instance);
+
+    [Fact]
+    public void OnEnd_ScrubsFormattedMessage()
+    {
+        var capture = RunPipeline(
+            CreateProcessor(EnabledConfig()),
+            logger => logger.LogInformation("token is {Value}", Marker));
+
+        capture.Records.Should().ContainSingle();
+        capture.Records[0].Message.Should().Be($"token is {Redacted}");
+    }
+
+    [Fact]
+    public void OnEnd_ScrubsStringAttributeValues()
+    {
+        var capture = RunPipeline(
+            CreateProcessor(EnabledConfig()),
+            logger => logger.LogInformation("value {Value}", Marker));
+
+        // The structured field {Value} is promoted to an attribute; its value must be scrubbed.
+        capture.Records[0].Attributes.Should()
+            .Contain(kvp => kvp.Key == "Value" && (string?)kvp.Value == Redacted);
+    }
+
+    [Fact]
+    public void OnEnd_LeavesNonStringAttributesUntouched()
+    {
+        var capture = RunPipeline(
+            CreateProcessor(EnabledConfig()),
+            logger => logger.LogInformation("count {Count}", 42));
+
+        capture.Records[0].Attributes.Should()
+            .Contain(kvp => kvp.Key == "Count" && (int)kvp.Value! == 42);
+    }
+
+    [Fact]
+    public void OnEnd_RedactionDisabled_LeavesRecordUnchanged()
+    {
+        var config = EnabledConfig();
+        config.RedactionEnabled = false;
+
+        var capture = RunPipeline(
+            CreateProcessor(config),
+            logger => logger.LogInformation("token is {Value}", Marker));
+
+        capture.Records[0].Message.Should().Be($"token is {Marker}");
+        capture.Records[0].Attributes.Should()
+            .Contain(kvp => kvp.Key == "Value" && (string?)kvp.Value == Marker);
+    }
+
+    [Fact]
+    public void OnEnd_NoCategories_LeavesRecordUnchanged()
+    {
+        var config = EnabledConfig();
+        config.RedactionCategories = [];
+
+        var capture = RunPipeline(
+            CreateProcessor(config),
+            logger => logger.LogInformation("token is {Value}", Marker));
+
+        capture.Records[0].Message.Should().Be($"token is {Marker}");
+    }
+
+    [Fact]
+    public void OnEnd_UnknownCategoryName_IsIgnoredAndKnownOnesStillApply()
+    {
+        var config = EnabledConfig();
+        config.RedactionCategories = ["Email", "NotACategory"];
+
+        var capture = RunPipeline(
+            CreateProcessor(config),
+            logger => logger.LogInformation("token is {Value}", Marker));
+
+        // The unknown name is skipped at construction; the known category still redacts.
+        capture.Records[0].Message.Should().Be($"token is {Redacted}");
+    }
+
+    [Fact]
+    public void Constructor_NullFilter_Throws()
+    {
+        var act = () => new LogRecordRedactionProcessor(
+            null!, EnabledConfig(), NullLogger<LogRecordRedactionProcessor>.Instance);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+}

--- a/src/Content/Tests/Presentation.Common.Tests/Extensions/ConfigValidationStartupTests.cs
+++ b/src/Content/Tests/Presentation.Common.Tests/Extensions/ConfigValidationStartupTests.cs
@@ -126,6 +126,16 @@ public class ConfigValidationStartupTests
             "BundleExecutionConfig",
             new Dictionary<string, string?> { ["AppConfig:AI:BundleExecution:StreamReservationTtl"] = "00:00:00" }
         },
+        {
+            // Logs OTel export enabled with a MinExportLevel that is not a real LogLevel —
+            // the rule is armed by OtelExportEnabled, so the host must refuse to start.
+            "LogsConfig",
+            new Dictionary<string, string?>
+            {
+                ["AppConfig:Observability:Logs:OtelExportEnabled"] = "true",
+                ["AppConfig:Observability:Logs:MinExportLevel"] = "NotALevel",
+            }
+        },
     };
 
     [Theory]

--- a/src/Content/Tests/Presentation.Common.Tests/Extensions/OpenTelemetryLogsSignalTests.cs
+++ b/src/Content/Tests/Presentation.Common.Tests/Extensions/OpenTelemetryLogsSignalTests.cs
@@ -1,0 +1,101 @@
+using Application.AI.Common.Interfaces.Telemetry;
+using Domain.Common.Config;
+using FluentAssertions;
+using Infrastructure.AI.Telemetry.Redaction;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using OpenTelemetry;
+using OpenTelemetry.Logs;
+using Presentation.Common.Extensions;
+using Xunit;
+
+namespace Presentation.Common.Tests.Extensions;
+
+/// <summary>
+/// Proves the OpenTelemetry logs signal is wired only when
+/// <c>Observability:Logs:OtelExportEnabled</c> is set. When off, no logs pipeline
+/// is registered at all, so hosts boot byte-identically to before the feature
+/// existed; when on, the OTel <see cref="LoggerProvider"/> (the ILogger→OTel bridge)
+/// is present in the container.
+/// </summary>
+/// <remarks>
+/// Asserts on the registered <see cref="ServiceDescriptor"/> set rather than building
+/// the provider: materializing the <see cref="LoggerProvider"/> would resolve the
+/// deferred resource builder and content redactor, which belong to the full
+/// composition root, not this focused wiring check.
+/// </remarks>
+public class OpenTelemetryLogsSignalTests
+{
+    private static ServiceCollection ServicesWithLogsExport(bool enabled)
+    {
+        var appConfig = new AppConfig();
+        appConfig.Observability.Logs.OtelExportEnabled = enabled;
+
+        var services = new ServiceCollection();
+        services.AddOpenTelemetry(appConfig);
+        return services;
+    }
+
+    [Fact]
+    public void AddOpenTelemetry_LogsExportEnabled_RegistersOtelLoggerProvider()
+    {
+        var services = ServicesWithLogsExport(enabled: true);
+
+        services.Should().Contain(
+            d => d.ServiceType == typeof(LoggerProvider),
+            "enabling Observability:Logs:OtelExportEnabled must wire the ILogger→OTel bridge");
+    }
+
+    [Fact]
+    public void AddOpenTelemetry_LogsExportDisabled_DoesNotRegisterLoggerProvider()
+    {
+        var services = ServicesWithLogsExport(enabled: false);
+
+        services.Should().NotContain(
+            d => d.ServiceType == typeof(LoggerProvider),
+            "with the flag off there must be no logs pipeline, so the host is unchanged");
+    }
+
+    /// <summary>A synchronous "exporter" that snapshots each record's rendered message.</summary>
+    private sealed class CapturingProcessor : BaseProcessor<LogRecord>
+    {
+        public List<string?> Messages { get; } = [];
+
+        public override void OnEnd(LogRecord data) => Messages.Add(data.FormattedMessage);
+    }
+
+    [Fact]
+    public void ProductionWiring_LogsExportEnabled_ScrubsPiiEndToEnd()
+    {
+        // Exercises the REAL composition — AddOpenTelemetry(appConfig) → AddLogsSignal →
+        // ConfigureLoggerProviderBuilder — with the shipped DefaultContentRedactionFilter,
+        // then appends a capturing processor (registered after the production redactor, so
+        // it observes the scrubbed record) to prove PII is redacted before export. OTLP is
+        // left disabled so no real exporter/endpoint is needed. This closes the story's §8
+        // "WithLogging pipeline emits redacted LogRecords end-to-end" requirement against the
+        // production wiring rather than a hand-built LoggerFactory. Logs wiring is identical
+        // for web and desktop hosts (AddLogsSignal runs outside the host-shape branch), so a
+        // single composition covers both shapes.
+        var appConfig = new AppConfig();
+        appConfig.Observability.Logs.OtelExportEnabled = true;   // redaction on by default
+        appConfig.Observability.Exporters.Otlp.Enabled = false;  // no real export endpoint
+
+        var capture = new CapturingProcessor();
+        var services = new ServiceCollection();
+        services.AddSingleton<IContentRedactionFilter, DefaultContentRedactionFilter>();
+        services.AddOpenTelemetry(appConfig);
+        // Append the capturer to the same logger pipeline, after the production stages.
+        services.AddOpenTelemetry().WithLogging(builder => builder.AddProcessor(capture));
+
+        using var provider = services.BuildServiceProvider();
+        // Force the logger pipeline to build (executes ConfigureLoggerProviderBuilder).
+        _ = provider.GetRequiredService<LoggerProvider>();
+
+        var logger = provider.GetRequiredService<ILoggerFactory>().CreateLogger("test.e2e");
+        logger.LogInformation("user {Email} signed in", "alice@example.com");
+
+        capture.Messages.Should().ContainSingle();
+        capture.Messages[0].Should().NotContain("alice@example.com");
+        capture.Messages[0].Should().Contain("[REDACTED:Email]");
+    }
+}


### PR DESCRIPTION
## What & why

Application **logs** never reached the observability backend. The harness has always exported **traces** (→ Tempo) and **metrics** (→ Prometheus) via OpenTelemetry, but `ILogger` records ran on a separate pipe — console / file / JSONL / ring-buffer — that the collector never saw. So in Grafana you got the trace waterfall and metric charts, but **not the log lines next to them**.

This is **PR1 of 4** for #153. It makes logs a first-class OTel signal and scrubs PII in-process before anything is exported. **This PR alone closes the Grafana-logs gap.** Event Hub delivery, auth modes, and the Direct exporter are PR2–PR3 (not here).

## Changes

- **`LogsConfig`** (`AppConfig:Observability:Logs`) — `OtelExportEnabled`, `MinExportLevel`, redaction toggle + categories. **Off by default; byte-identical when off** (early-return before any pipeline registration).
- **`AddLogsSignal`** wires `AddOpenTelemetry().WithLogging(...)` uniformly for web and console hosts — the bridge is an `ILoggerProvider` the standard `ILoggerFactory` picks up, so no standalone provider is needed. `MinExportLevel` is applied as a provider-scoped filter, capping OTel export **independent of** the local sinks' levels.
- **`LogRecordRedactionProcessor : BaseProcessor<LogRecord>`** — reuses the existing `IContentRedactionFilter` (the same over-redactive engine used on the span path). Registered **before** the exporter, because the batch exporter snapshots the pooled record — so PII is scrubbed in-process before anything leaves, covering the OTLP wire, not just Event Hub. Scrubs formatted message, body, and string attributes; leaves non-string attributes untouched.
- **`LogsConfigValidator` + `ValidateOnStart`** — a bad `MinExportLevel` or unknown redaction category fails host boot instead of degrading silently (same pattern as #173/#177).

## Two deliberate refinements vs the original story sketch

1. **Redaction config lives under `Logs`, not `Exporters.EventHub.Redaction`.** PII scrub is a *signal-wide* processor — it runs once before **every** log exporter — so scoping it to one exporter would be wrong.
2. **The `ITelemetryConfigurator.ConfigureLogging` seam is deferred to PR2**, when a second log exporter actually needs it (adding an interface method with no implementer would be inert, and PR1's pre-build ordering couldn't route through a deferred seam anyway).

Both are documented in `documentation/design/event-hub-log-export.md` §9.

## Tests

- `LogRecordRedactionProcessorTests` — redaction across message/body/attributes through a **real OTel logs pipeline** (mocked filter), plus disabled / no-category / unknown-category branches.
- `OpenTelemetryLogsSignalTests` — flag gates the pipeline (registered on, absent off = byte-identical), **and an end-to-end test through the production composition** asserting a PII log (`alice@example.com`) exits as `[REDACTED:Email]`.
- `LogsConfigValidatorTests` — level + category rules, all gated on `OtelExportEnabled`.
- `ConfigValidationStartupTests` — a bad `LogsConfig` aborts host boot.

Full solution builds clean (0 warnings). Affected test projects: 133 + 166 + 700 pass.

## Deferred follow-ups (noted, out of scope here)
- Shared `string → RedactionCategory` parser + a FluentValidation category-rule extension, to dedupe against `ContentCapturePolicy` / `ContentCaptureConfigValidator`.
- Per-call `HashSet` allocation in `DefaultContentRedactionFilter.Redact` (touches the shared interface used by the span path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)