### PR TITLE
Track A: bump Agent Framework 1.13 / Extensions.AI 10.7 / MCP 1.4.1 + fix execute_tool spans

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,6 @@ documentation/design/top-10-risks-full-catalogue.html
 documentation/design/top-10-risks-mitigations.md
 .claude/reviews/
 .claude/.review-receipts/
+
+# update-and-refactor skill scratch output (findings.json, report.html, plans/)
+.update-and-refactor/

--- a/src/Content/Application/Application.AI.Common/Factories/AgentFactory.cs
+++ b/src/Content/Application/Application.AI.Common/Factories/AgentFactory.cs
@@ -252,8 +252,10 @@ public class AgentFactory : IAgentFactory
 
     /// <summary>
     /// Wraps an inner <see cref="IChatClient"/> in the harness middleware pipeline:
-    /// OpenTelemetry → function invocation → observability → tool diagnostics →
-    /// (optional) skill-prerequisite gating → distributed cache. Shared by every provider path,
+    /// function invocation → OpenTelemetry → observability → tool diagnostics →
+    /// (optional) skill-prerequisite gating → distributed cache. OpenTelemetry sits below
+    /// function invocation so <c>FunctionInvokingChatClient</c> can resolve its ActivitySource and
+    /// emit execute_tool spans (see the ordering note on the builder below). Shared by every provider path,
     /// including the Foundry client-factory hook, so middleware behaviour is identical regardless of
     /// how the agent is constructed.
     /// </summary>

--- a/src/Content/Application/Application.AI.Common/Factories/AgentFactory.cs
+++ b/src/Content/Application/Application.AI.Common/Factories/AgentFactory.cs
@@ -266,7 +266,12 @@ public class AgentFactory : IAgentFactory
             _serviceProvider.GetService<IContentCapturePolicy>());
 
         var chatClientBuilder = chatClient.AsBuilder()
-            .UseOpenTelemetry(configure: c => c.EnableSensitiveData = captureSensitive)
+            // OpenTelemetry MUST sit below UseFunctionInvocation: FunctionInvokingChatClient
+            // resolves its ActivitySource via innerClient.GetService<ActivitySource>() (exposed
+            // only by the OpenTelemetry chat client) and emits per-tool execute_tool spans solely
+            // when that lookup succeeds. Composed above, the lookup returns null and no execute_tool
+            // span is produced, starving the tool-effectiveness/usefulness/causal span processors
+            // and their dashboard tiles.
             .UseFunctionInvocation(configure: c =>
             {
                 c.AllowConcurrentInvocation = true;
@@ -275,6 +280,7 @@ public class AgentFactory : IAgentFactory
                 c.MaximumIterationsPerRequest = 5;
                 c.TerminateOnUnknownCalls = true;
             })
+            .UseOpenTelemetry(configure: c => c.EnableSensitiveData = captureSensitive)
             .Use(inner => new Middleware.ObservabilityMiddleware(
                 inner,
                 _loggerFactory.CreateLogger<Middleware.ObservabilityMiddleware>()))

--- a/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentFactoryToolSpanTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentFactoryToolSpanTests.cs
@@ -1,0 +1,129 @@
+using System.Diagnostics;
+using Application.AI.Common.Factories;
+using Application.AI.Common.Interfaces;
+using Application.AI.Common.Interfaces.Skills;
+using Application.AI.Common.Services.Skills;
+using Application.AI.Common.Tests.Fakes;
+using Domain.AI.Agents;
+using Domain.AI.Telemetry.Conventions;
+using Domain.Common.Config;
+using Domain.Common.Config.AI;
+using FluentAssertions;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Application.AI.Common.Tests.Factories;
+
+/// <summary>
+/// Guards the OpenTelemetry composition invariant that makes per-tool telemetry observable.
+/// <para>
+/// Microsoft.Extensions.AI's <c>FunctionInvokingChatClient</c> only emits an
+/// <c>execute_tool</c> span when it can resolve an <see cref="ActivitySource"/> from the client
+/// composed <em>below</em> it (<c>innerClient.GetService&lt;ActivitySource&gt;()</c>), which is
+/// exposed by <c>.UseOpenTelemetry()</c>. If OpenTelemetry is composed <em>above</em> function
+/// invocation, that lookup returns <see langword="null"/> and no <c>execute_tool</c> span is ever
+/// created — silently starving the tool-effectiveness / tool-usefulness / causal-attribution span
+/// processors and their dashboard tiles.
+/// </para>
+/// <para>
+/// This test drives a real <see cref="AgentFactory"/> pipeline (the same
+/// <c>BuildMiddlewarePipeline</c> production uses) over a deterministic <see cref="FakeChatClient"/>
+/// tool round-trip and asserts the <c>execute_tool</c> span is emitted. It fails loudly if the
+/// OpenTelemetry / function-invocation ordering regresses.
+/// </para>
+/// </summary>
+public sealed class AgentFactoryToolSpanTests
+{
+    // The Microsoft.Extensions.AI OpenTelemetry source that FunctionInvokingChatClient emits
+    // execute_tool spans on (matched loosely so it survives the SDK dropping the Experimental
+    // prefix at GA).
+    private const string MeaiSourceFragment = "Microsoft.Extensions.AI";
+
+    private static AgentFactory CreateFactory(FakeChatClient innerClient)
+    {
+        var chatClientFactory = new Mock<IChatClientFactory>();
+        chatClientFactory
+            .Setup(f => f.IsAvailable(It.IsAny<AIAgentFrameworkClientType>()))
+            .Returns(true);
+        chatClientFactory
+            .Setup(f => f.GetChatClientAsync(
+                It.IsAny<AIAgentFrameworkClientType>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(innerClient);
+
+        var appConfig = new AppConfig
+        {
+            AI = new AIConfig
+            {
+                AgentFramework = new AgentFrameworkConfig
+                {
+                    DefaultDeployment = "gpt-4o",
+                    ClientType = AIAgentFrameworkClientType.AzureOpenAI
+                }
+            }
+        };
+        var monitor = Mock.Of<IOptionsMonitor<AppConfig>>(m => m.CurrentValue == appConfig);
+
+        return new AgentFactory(
+            NullLogger<AgentFactory>.Instance,
+            monitor,
+            new MemoryDistributedCache(Options.Create(new MemoryDistributedCacheOptions())),
+            NullLoggerFactory.Instance,
+            // The AgentExecutionContext overload of CreateAgentAsync never touches the context
+            // factory (only the skills overload does), and the constructor stores it without a
+            // guard — so this path is exercised fully with a null factory.
+            agentContextFactory: null!,
+            Mock.Of<ISkillMetadataRegistry>(),
+            chatClientFactory.Object,
+            new ServiceCollection().BuildServiceProvider(),
+            new InMemorySkillCompletionTracker());
+    }
+
+    [Fact]
+    public async Task AgentTurnInvokingATool_EmitsExecuteToolSpan()
+    {
+        var toolOperations = new List<string>();
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name.Contains(MeaiSourceFragment, StringComparison.Ordinal),
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
+            ActivityStopped = activity =>
+            {
+                if (activity.GetTagItem(ToolConventions.GenAiOperationName) is string operation)
+                    toolOperations.Add(operation);
+            }
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        var tool = AIFunctionFactory.Create(() => "the-result", "my_tool", "does a thing");
+
+        var innerClient = new FakeChatClient()
+            .EnqueueResponseWithToolCall("my_tool", "call-1")
+            .EnqueueResponse("done after tool");
+
+        var factory = CreateFactory(innerClient);
+
+        var agent = await factory.CreateAgentAsync(new AgentExecutionContext
+        {
+            Name = "tool-span-agent",
+            Instruction = "You are a test agent.",
+            AIAgentFrameworkType = AIAgentFrameworkClientType.AzureOpenAI,
+            Tools = new List<AITool> { tool }
+        });
+
+        await agent.RunAsync("please use the tool");
+
+        toolOperations.Should().Contain(
+            ToolConventions.ExecuteToolOperation,
+            "FunctionInvokingChatClient must emit an execute_tool span, which requires "
+            + ".UseOpenTelemetry() to be composed below .UseFunctionInvocation() in "
+            + "AgentFactory.BuildMiddlewarePipeline");
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/A2A/A2AVersionPinTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/A2A/A2AVersionPinTests.cs
@@ -12,7 +12,7 @@ namespace Infrastructure.AI.Tests.A2A;
 /// <list type="number">
 /// <item><description>Pin the harness <see cref="A2AEnvelope"/> schema version
 /// so any breaking shape change forces an explicit bump.</description></item>
-/// <item><description>Assert <c>Microsoft.Agents.AI</c> (MAF) 1.10.0 still
+/// <item><description>Assert <c>Microsoft.Agents.AI</c> (MAF) 1.13.0 still
 /// lacks a public A2A surface. The moment MAF ships one, this test fails and
 /// the harness should switch to wrapping it instead of carrying its own
 /// transport implementation.</description></item>
@@ -59,18 +59,19 @@ public sealed class A2AVersionPinTests
             .ToList();
 
         probes.Should().BeEmpty(
-            "Microsoft Agent Framework 1.10.0 does not expose A2A primitives; if this test fails MAF has added them and the harness should wrap them — see documentation/architecture/a2a-message-contract.md 'Version pin' section");
+            "Microsoft Agent Framework 1.13.0 does not expose A2A primitives; if this test fails MAF has added them and the harness should wrap them — see documentation/architecture/a2a-message-contract.md 'Version pin' section");
     }
 
     [Fact]
-    public void Maf_assembly_is_pinned_to_1_10_x()
+    public void Maf_assembly_is_pinned_to_1_13_x()
     {
         var maf = typeof(Microsoft.Agents.AI.AIAgent).Assembly;
         var version = maf.GetName().Version;
         version.Should().NotBeNull();
         version!.Major.Should().Be(1, "harness pins to MAF 1.x");
-        version.Minor.Should().Be(10,
-            "harness pins to MAF 1.10.x (bumped from 1.9.x to adopt Azure AI Foundry Responses agents via " +
-            "Microsoft.Agents.AI.Foundry); bumping minor requires re-running canary");
+        version.Minor.Should().Be(13,
+            "harness pins to MAF 1.13.x (Track A catch-up from 1.10.x); the A2A-surface canary above " +
+            "was re-run at 1.13 and still finds no public A2A primitives. Bumping minor requires " +
+            "re-running these canaries");
     }
 }

--- a/src/Content/Tests/Infrastructure.AI.Tests/Skills/FrameworkLoaderSpikeTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Skills/FrameworkLoaderSpikeTests.cs
@@ -76,7 +76,7 @@ public class FrameworkLoaderSpikeTests
         var provider = new AgentSkillsProviderBuilder()
             .UseFileSkill(_skillsRoot)
             .UseFileScriptRunner(NoOpRunner)
-            .UseFilter(s => s.Frontmatter.Name != "internal")
+            .UseFilter((s, _) => s.Frontmatter.Name != "internal")
             .Build();
 
         provider.Should().NotBeNull();

--- a/src/Content/Tests/Presentation.AgentHub.Tests/Telemetry/DashboardMetricEmissionTests.cs
+++ b/src/Content/Tests/Presentation.AgentHub.Tests/Telemetry/DashboardMetricEmissionTests.cs
@@ -98,12 +98,12 @@ public sealed partial class DashboardMetricEmissionTests : IClassFixture<Metrics
 
             // ── Tools (counts work once a tool runs; quality metrics are a gap) ──
             ["tools_calls_total"] = (TileStatus.Conditional, "needs a tool call (agent_tool_invocations works in prod)"),
-            ["tools_errors_total"] = (TileStatus.KnownGap, "tool_errors only records on an 'execute_tool' span the function-invocation middleware never emits"),
-            ["tools_avg_latency"] = (TileStatus.KnownGap, "tool_duration depends on the missing 'execute_tool' span"),
-            ["tools_result_size"] = (TileStatus.KnownGap, "tool_result_size depends on the missing 'execute_tool' span"),
+            ["tools_errors_total"] = (TileStatus.Conditional, "needs a tool call that errors; the execute_tool span now emits after OpenTelemetry was composed below UseFunctionInvocation (fixed 2026-07-12)"),
+            ["tools_avg_latency"] = (TileStatus.Conditional, "needs a tool call; the execute_tool span now emits (fixed 2026-07-12: OTel below function invocation)"),
+            ["tools_result_size"] = (TileStatus.Conditional, "needs a tool call; the execute_tool span now emits (fixed 2026-07-12: OTel below function invocation)"),
             ["tools_calls_by_tool"] = (TileStatus.Conditional, "needs a tool call"),
-            ["tools_latency_by_tool"] = (TileStatus.KnownGap, "tool_duration depends on the missing 'execute_tool' span"),
-            ["tools_error_rate"] = (TileStatus.KnownGap, "tool_errors depends on the missing 'execute_tool' span"),
+            ["tools_latency_by_tool"] = (TileStatus.Conditional, "needs a tool call; the execute_tool span now emits (fixed 2026-07-12: OTel below function invocation)"),
+            ["tools_error_rate"] = (TileStatus.Conditional, "needs a tool call that errors; the execute_tool span now emits (fixed 2026-07-12: OTel below function invocation)"),
 
             // ── Safety ──
             ["safety_total"] = (TileStatus.AlwaysOn, "evaluations emit every turn"),

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -7,12 +7,12 @@
   <ItemGroup>
 
     <!-- Domain layer -->
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
 
     <!-- Domain.AI -->
-    <PackageVersion Include="Microsoft.Agents.AI.Abstractions" Version="1.10.0" />
-    <PackageVersion Include="Microsoft.Extensions.AI.Abstractions" Version="10.6.0" />
+    <PackageVersion Include="Microsoft.Agents.AI.Abstractions" Version="1.13.0" />
+    <PackageVersion Include="Microsoft.Extensions.AI.Abstractions" Version="10.7.0" />
 
     <!-- Application layer -->
     <PackageVersion Include="Azure.Identity" Version="1.21.0" />
@@ -20,22 +20,22 @@
     <PackageVersion Include="FluentValidation.DependencyInjectionExtensions" Version="12.1.1" />
     <PackageVersion Include="MediatR" Version="12.4.1" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Hybrid" Version="10.1.0" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.9" />
     <PackageVersion Include="OpenTelemetry" Version="1.15.3" />
 
     <!-- Application.AI.Common -->
     <PackageVersion Include="Azure.AI.Agents.Persistent" Version="1.0.0" />
-    <PackageVersion Include="Microsoft.Agents.AI" Version="1.10.0" />
-    <PackageVersion Include="Microsoft.Agents.AI.Workflows" Version="1.10.0" />
-    <PackageVersion Include="Microsoft.Extensions.AI" Version="10.6.0" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Agents.AI" Version="1.13.0" />
+    <PackageVersion Include="Microsoft.Agents.AI.Workflows" Version="1.13.0" />
+    <PackageVersion Include="Microsoft.Extensions.AI" Version="10.7.0" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="10.0.9" />
 
     <!-- Infrastructure layer -->
     <PackageVersion Include="Ardalis.GuardClauses" Version="5.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.9" />
 
     <!-- Infrastructure.AI.Governance -->
     <!-- Held at 3.0.2: AgentGovernance 4.0.0 makes PolicyEngine.Evaluate reject non-DID
@@ -66,7 +66,11 @@
     <PackageVersion Include="Anthropic.SDK" Version="5.10.0" />
     <PackageVersion Include="Azure.AI.Inference" Version="1.0.0-beta.5" />
     <PackageVersion Include="Azure.AI.OpenAI" Version="2.8.0-beta.1" />
-    <PackageVersion Include="Microsoft.Agents.AI.OpenAI" Version="1.10.0" />
+    <PackageVersion Include="Microsoft.Agents.AI.OpenAI" Version="1.13.0" />
+    <!-- Foundry stays on the 1.10 preview line while the rest of the Microsoft.Agents.AI
+         family moves to 1.13.0: there is no 1.13 Foundry preview, and the 1.13 core does
+         not force it — Foundry 1.10.0-preview consumes Microsoft.Extensions.AI 10.7.0
+         cleanly (verified at restore). Bump both together when a matching preview ships. -->
     <PackageVersion Include="Microsoft.Agents.AI.Foundry" Version="1.10.0-preview.260610.1" />
     <PackageVersion Include="Microsoft.Agents.AI.Foundry.Hosting" Version="1.10.0-preview.260610.1" />
     <PackageVersion Include="Azure.AI.Projects" Version="2.1.0-beta.3" />
@@ -81,11 +85,11 @@
     <PackageVersion Include="Scriban" Version="7.2.3" />
 
     <!-- Infrastructure.AI.MCP -->
-    <PackageVersion Include="ModelContextProtocol" Version="1.1.0" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.8" />
+    <PackageVersion Include="ModelContextProtocol" Version="1.4.1" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
 
     <!-- Infrastructure.AI.MCPServer -->
-    <PackageVersion Include="ModelContextProtocol.AspNetCore" Version="1.1.0" />
+    <PackageVersion Include="ModelContextProtocol.AspNetCore" Version="1.4.1" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.5" />
 
     <!-- Infrastructure.APIAccess -->
@@ -124,7 +128,7 @@
     <PackageVersion Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.4.0" />
     <PackageVersion Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.AzureAppConfiguration" Version="8.1.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.9" />
     <PackageVersion Include="Microsoft.AspNetCore.SpaProxy" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Identity.Web" Version="4.11.0" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />


### PR DESCRIPTION
## What & why

Two related changes, both grounded in a live NuGet audit + build-verify (my training cutoff predates these releases, so every version and behavior here was checked, not recalled):

**1. Catch-up bump** — three Microsoft AI package families that were behind:
- `Microsoft.Agents.AI(.Abstractions/.Workflows/.OpenAI)` `1.10.0 → 1.13.0` (3 minors)
- `Microsoft.Extensions.AI(.Abstractions)` `10.6.0 → 10.7.0`
- `ModelContextProtocol(.AspNetCore)` `1.1.0 → 1.4.1` (3 minors; includes the 1.4.1 Streamable-HTTP memory-leak fix on the transport we use, plus session-DELETE user validation)

Companion floor bump: AF 1.13 (OpenAI) and Extensions.AI 10.7 raise transitive minimums on `Logging.Abstractions` / `Caching.Abstractions` to `10.0.9`; since `NU1605` is an error here, the 10 `Microsoft.Extensions.*` pins move `10.0.8 → 10.0.9` (drop-in .NET 10 servicing). **Foundry preview packages are intentionally NOT bumped** — the 1.13 core consumes them cleanly; documented inline.

The only source break was a test: AF 1.13 changed the skills `UseFilter` predicate to `Func<AgentSkill, AgentSkillsSourceContext, bool>` — the spike-test lambda now takes the discard.

**2. Fix: `execute_tool` OpenTelemetry spans were never emitted** — closing a documented dashboard gap (5 `KnownGap` tiles).

Root cause, confirmed against the Microsoft.Extensions.AI source: `FunctionInvokingChatClient` resolves its `ActivitySource` via `innerClient.GetService<ActivitySource>()` (exposed only by the OpenTelemetry chat client) and emits per-tool `execute_tool` spans **only when that lookup succeeds**. `AgentFactory.BuildMiddlewarePipeline` composed `.UseOpenTelemetry()` **above** `.UseFunctionInvocation()`, so the lookup returned `null` and the tool-effectiveness / tool-usefulness / causal-attribution processors (and their tiles) stayed dark.

Fix: compose OpenTelemetry **below** function invocation (framework-canonical order). The five tool-quality tiles flip `KnownGap → Conditional` (they populate when a tool runs).

### Intended side effect
The `gen_ai.chat` span now wraps a single model call rather than the whole tool loop, so a multi-step turn produces one chat span per model round-trip. Token/duration metrics become per-call and correctly summed (previously only the last iteration's usage was recorded). The per-turn envelope remains the agent-level `invoke_agent` span. Any dashboard/alert that read the outer chat span as "the whole turn" should read `invoke_agent`.

## Test plan
- Full solution **builds clean** (0 errors, 0 warnings) after both changes; build-verified first in an isolated git worktree.
- **New regression test** `AgentFactoryToolSpanTests` drives a real `AgentFactory` tool round-trip and asserts an `execute_tool` span is emitted — proven RED→GREEN (fails on the old order, passes on the new). Guards against re-regression.
- The span→metric link is covered by the pre-existing `ToolEffectivenessProcessorTests`.
- Green locally (non-Docker projects): Application.AI.Common (1404), Domain.AI (815), MCPServer (78), Infra.AI M.E.AI-canary/MCP/Magentic/resilience (66), AgentHub excl. `Category=E2E` (385).
- The `MetricsE2ETests` (`[Category=E2E]`, Testcontainers Prometheus/Collector) are Docker-gated and only run in CI — not exercised locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)