### PR TITLE
fix: disable inert Event Hub exporter that broke collector startup (CI red on main)

### DIFF
--- a/scripts/otel-collector/EVENTHUB-LOGS.md
+++ b/scripts/otel-collector/EVENTHUB-LOGS.md
@@ -59,9 +59,14 @@ from the app side. Redaction is on by default with the full category set — lea
 
 ## 2. Enable the Collector exporter
 
-The `logs` pipeline and a `kafka/eventhub` exporter are already defined in
-[`config.yaml`](./config.yaml). They ship **inert**: the pipeline exports only to `debug`
-(stdout) until you opt in.
+The `logs` pipeline is live in [`config.yaml`](./config.yaml) and exports only to `debug`
+(stdout); a fully-commented `kafka/eventhub` exporter template sits alongside it. It ships
+**disabled**: the exporter block is commented out in its entirety, not merely omitted from
+the pipeline. That is deliberate — the Collector runs every *defined* component's validation
+at startup even when no pipeline references it, and the kafka exporter requires a non-empty
+SASL password, so a defined-but-unused block would force valid Event Hub credentials on
+every Collector start (and break the Collector for anyone who doesn't use Event Hub). Enabling
+is therefore a two-part opt-in: uncomment the exporter block **and** its pipeline entry.
 
 1. Set the environment variables the Collector reads (e.g. in `scripts/otel-collector/.env`,
    which `start-collector.ps1` loads, or your orchestrator's secret store — **never inline
@@ -73,7 +78,11 @@ The `logs` pipeline and a `kafka/eventhub` exporter are already defined in
    EVENTHUB_CONNECTION_STRING=Endpoint=sb://<your-namespace>.servicebus.windows.net/;SharedAccessKeyName=...;SharedAccessKey=...
    ```
 
-2. In `config.yaml`, uncomment `kafka/eventhub` in the **logs** pipeline's exporter list:
+2. In `config.yaml`, uncomment the entire `kafka/eventhub` **exporter** block (remove the
+   `# ` prefix from each of its lines under `exporters:`). Leaving any required field
+   commented — or the whole block defined with the env vars unset — fails Collector startup.
+
+3. Also in `config.yaml`, uncomment `kafka/eventhub` in the **logs** pipeline's exporter list:
 
    ```yaml
    logs:
@@ -84,7 +93,7 @@ The `logs` pipeline and a `kafka/eventhub` exporter are already defined in
        - kafka/eventhub   # ← uncomment
    ```
 
-3. Restart the Collector: `./start-collector.ps1` (or `docker-compose up -d`).
+4. Restart the Collector: `./start-collector.ps1` (or `docker-compose up -d`).
 
 ---
 

--- a/scripts/otel-collector/config.yaml
+++ b/scripts/otel-collector/config.yaml
@@ -172,36 +172,50 @@ exporters:
   # Event Hubs exposes a Kafka-compatible endpoint, so the contrib `kafka` exporter
   # forwards OTLP logs there with no dedicated Event Hub component. PII is already
   # scrubbed in-process by the app (Observability:Logs redaction), so nothing sensitive
-  # transits this hop. Enable by setting the EVENTHUB_* env vars and uncommenting
-  # `kafka/eventhub` in the logs pipeline below.
+  # transits this hop.
   #
-  # NOTE: the kafka exporter's config surface is version-specific — verify field names
-  # against the exporter README for the collector version pinned in docker-compose.yml
-  # (0.123.0): https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/kafkaexporter/README.md
-  kafka/eventhub:
-    # <namespace>.servicebus.windows.net:9093
-    brokers:
-      - "${env:EVENTHUB_BOOTSTRAP}"
-    protocol_version: 2.0.0
-    # The Kafka "topic" is the Event Hub (entity) name.
-    logs:
-      topic: "${env:EVENTHUB_LOGS_TOPIC}"
-      encoding: otlp_proto
-    tls:
-      insecure: false
-    auth:
-      sasl:
-        mechanism: PLAIN
-        # Connection-string auth: username is the literal "$ConnectionString"; password is
-        # the Event Hub namespace connection string (from Key Vault / env, never inlined).
-        # For Microsoft Entra (OAuth) instead, see EVENTHUB-LOGS.md § Authentication.
-        username: "$$ConnectionString"
-        password: "${env:EVENTHUB_CONNECTION_STRING}"
-    retry_on_failure:
-      enabled: true
-      initial_interval: 5s
-      max_interval: 30s
-      max_elapsed_time: 300s
+  # DISABLED BY DEFAULT — the whole exporter is commented out, not just its pipeline entry.
+  # The collector runs every DEFINED component's Validate() at startup even when it is
+  # referenced by no pipeline, and the kafka exporter requires a non-empty SASL password.
+  # A defined-but-unused `kafka/eventhub` therefore forces valid Event Hub credentials on
+  # every collector start — breaking the collector for everyone who does not use Event Hub
+  # (this is what a bare block did: `sasl: password is required` → collector never starts).
+  # Keeping it fully commented is what makes "inert by default" actually true.
+  #
+  # To enable: uncomment this block AND the `kafka/eventhub` line in the logs pipeline,
+  # then set the EVENTHUB_* env vars (see EVENTHUB-LOGS.md for the full operator flow).
+  #
+  # NOTE: the kafka exporter's config surface is version-specific. The fields below are the
+  # schema for the collector version pinned in docker-compose.yml (0.123.0): `topic` and
+  # `encoding` are top-level (there is no per-signal `logs:` block in this version), and TLS
+  # is nested under `auth.tls` (not a top-level `tls:` key). Verify against the README for
+  # the pinned tag before enabling:
+  # https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.123.0/exporter/kafkaexporter/README.md
+  #
+  # kafka/eventhub:
+  #   # <namespace>.servicebus.windows.net:9093
+  #   brokers:
+  #     - "${env:EVENTHUB_BOOTSTRAP}"
+  #   protocol_version: 2.0.0
+  #   # The Kafka "topic" is the Event Hub (entity) name. This exporter is referenced only by
+  #   # the logs pipeline, so the top-level topic/encoding apply to the logs signal.
+  #   topic: "${env:EVENTHUB_LOGS_TOPIC}"
+  #   encoding: otlp_proto
+  #   auth:
+  #     tls:
+  #       insecure: false
+  #     sasl:
+  #       mechanism: PLAIN
+  #       # Connection-string auth: username is the literal "$ConnectionString"; password is
+  #       # the Event Hub namespace connection string (from Key Vault / env, never inlined).
+  #       # For Microsoft Entra (OAuth) instead, see EVENTHUB-LOGS.md § Authentication.
+  #       username: "$$ConnectionString"
+  #       password: "${env:EVENTHUB_CONNECTION_STRING}"
+  #   retry_on_failure:
+  #     enabled: true
+  #     initial_interval: 5s
+  #     max_interval: 30s
+  #     max_elapsed_time: 300s
 
 # Extensions - optional services for observability and debugging
 extensions:

--- a/src/Content/Tests/Presentation.AgentHub.Tests/Telemetry/Fixtures/PrometheusFixture.cs
+++ b/src/Content/Tests/Presentation.AgentHub.Tests/Telemetry/Fixtures/PrometheusFixture.cs
@@ -27,6 +27,14 @@ namespace Presentation.AgentHub.Tests.Telemetry.Fixtures;
 /// </remarks>
 public sealed class PrometheusFixture : IAsyncLifetime
 {
+    /// <summary>
+    /// Upper bound on how long to wait for a container to log its readiness message.
+    /// Both containers start in seconds with a valid config; without an explicit cap
+    /// Testcontainers waits its 1-hour default, so a config that fails to load hangs the
+    /// whole CI job for an hour before failing. Bounding it turns that into a fast timeout.
+    /// </summary>
+    private static readonly TimeSpan ContainerReadinessTimeout = TimeSpan.FromMinutes(2);
+
     private INetwork _network = null!;
     private IContainer _collector = null!;
     private IContainer _prometheus = null!;
@@ -65,8 +73,11 @@ public sealed class PrometheusFixture : IAsyncLifetime
             .WithEnvironment("DEPLOYMENT_ENVIRONMENT", "test")
             .WithEnvironment("TEMPO_ENDPOINT", "localhost:4317")
             .WithEnvironment("APPLICATIONINSIGHTS_CONNECTION_STRING", "InstrumentationKey=00000000-0000-0000-0000-000000000000")
+            // Bound the readiness wait so a config that fails to load surfaces as a fast
+            // timeout instead of Testcontainers' 1-hour default (see ContainerReadinessTimeout).
             .WithWaitStrategy(Wait.ForUnixContainer()
-                .UntilMessageIsLogged("Everything is ready"))
+                .UntilMessageIsLogged("Everything is ready",
+                    o => o.WithTimeout(ContainerReadinessTimeout)))
             .Build();
 
         await _collector.StartAsync();
@@ -93,7 +104,8 @@ public sealed class PrometheusFixture : IAsyncLifetime
             .WithPortBinding(9090, true)
             .WithResourceMapping(promConfigPath, "/etc/prometheus/")
             .WithWaitStrategy(Wait.ForUnixContainer()
-                .UntilMessageIsLogged("Server is ready to receive web requests"))
+                .UntilMessageIsLogged("Server is ready to receive web requests",
+                    o => o.WithTimeout(ContainerReadinessTimeout)))
             .Build();
 
         await _prometheus.StartAsync();


### PR DESCRIPTION
## Problem

`build-and-test` has been **red on `main` since the #181 merge** (2026-07-12 23:19). Every run since hangs for **~1 hour** on `MetricsE2ETests` and then fails all 9 E2E tests with `System.TimeoutException` from the Testcontainers wait strategy. The four runs before #181 passed in ~6 min.

## Root cause

#181 (#153 PR2) added a `kafka/eventhub` exporter to `scripts/otel-collector/config.yaml`, commented out of the logs pipeline but **defined** in the `exporters:` map. The OTel Collector schema-validates and runs `Validate()` on **every defined component at startup — even one no pipeline references.** For the pinned contrib image `0.123.0` the block had two faults:

1. **Invalid schema** — `logs:` sub-block + top-level `tls:`. In 0.123.0 the kafka exporter uses top-level `topic`/`encoding` and nests TLS under `auth.tls`.
2. Once the schema is corrected, a **required non-empty SASL `password`** that is unset in any environment without Event Hub credentials.

Either fault makes the collector fail to load → it never logs `Everything is ready` → the fixture waits its **default 1-hour timeout** → all 9 tests fail. Reproduced against the real 0.123.0 image: `'' has invalid keys: logs, tls`, then after correcting the schema, `sasl: password is required`.

This also means the exporter, as shipped, forced valid Event Hub credentials on **every** collector start — breaking the collector for anyone not using Event Hub, contrary to the block's own "inert by default" contract.

## Fix

- **Comment out the entire exporter block**, not just its pipeline entry — the only state that keeps the collector startable without Event Hub creds and honours "inert by default". The in-comment YAML is corrected to the 0.123.0 schema so it is copy-paste-correct when enabled.
- **`EVENTHUB-LOGS.md`** → two-part opt-in (uncomment exporter block **and** pipeline line) with the rationale.
- **`PrometheusFixture`** → bound both container readiness waits to **2 min** (named `ContainerReadinessTimeout`) so a future collector-config regression fails fast instead of hanging CI for an hour.

## Verification (ground truth, against the real 0.123.0 image)

- Broken config → `invalid keys: logs, tls`; schema-corrected-but-defined → `sasl: password is required`; block commented out → collector logs **`Everything is ready`** with only the fixture's 3 env vars.
- **All 9 `MetricsE2ETests` pass locally against Docker** (~13 s; the test that was hanging an hour now finishes in 8 s).
- `dotnet build` of the test project: 0 warnings, 0 errors.

## Reviews

Two-axis `/code-review` + `/simplify` run on the diff — both clean; the two nits they raised (extract the duplicated timeout literal; tighten one doc sentence) are applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)