### PR TITLE
ci: bump actions off deprecated Node 20 runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,10 +34,10 @@ jobs:
       OBSERVABILITY_TEST_CONN: "Host=localhost;Port=5432;Database=observability;Username=observability;Password=observability"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '10.x'
 
@@ -68,7 +68,7 @@ jobs:
           --results-directory coverage
 
       - name: Upload coverage
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: coverage
@@ -79,10 +79,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-and-test
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '10.x'
 
@@ -106,7 +106,7 @@ jobs:
           --results-directory owasp-results
 
       - name: Upload OWASP gate results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: owasp-agentic-gate-results

--- a/.github/workflows/correctness-review.yml
+++ b/.github/workflows/correctness-review.yml
@@ -50,7 +50,7 @@ jobs:
     if: github.event.pull_request.draft == false
     steps:
       - name: Checkout PR
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/docs-drift-check.yml
+++ b/.github/workflows/docs-drift-check.yml
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/eval-suite.yml
+++ b/.github/workflows/eval-suite.yml
@@ -49,10 +49,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           global-json-file: global.json
           cache: true
@@ -105,7 +105,7 @@ jobs:
 
       - name: Publish JUnit results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: eval-results-junit
           path: eval-results.junit.xml
@@ -113,7 +113,7 @@ jobs:
 
       - name: Publish JSON report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: eval-results-json
           path: eval-results.json

--- a/.github/workflows/grader.yml
+++ b/.github/workflows/grader.yml
@@ -34,7 +34,7 @@ jobs:
     if: github.event.pull_request.draft == false
     steps:
       - name: Checkout PR
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Pages
         uses: actions/configure-pages@v5

--- a/.github/workflows/security-review.yml
+++ b/.github/workflows/security-review.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout PR
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
GitHub is force-migrating `actions/checkout@v4`, `actions/setup-dotnet@v4`, and `actions/upload-artifact@v4` off the deprecated Node 20 runner — every CI run currently logs a deprecation warning for them.

## Change

Bump the three flagged action families to their current majors (all run on Node 24) across every workflow:

| Action | From | To |
|---|---|---|
| `actions/checkout` | v4 | **v7** |
| `actions/setup-dotnet` | v4 | **v5** |
| `actions/upload-artifact` | v4 | **v7** |

## Why these targets are safe

Checked the release notes for each major from v4 → latest. The only "breaking changes" are the Node 24 runtime bump itself and a runner-version floor (`2.327.1`) that GitHub-hosted `ubuntu-latest` already exceeds. None touch the inputs we use — bare `checkout`, `setup-dotnet: 10.x`, `upload-artifact: name/path/if:always()`. No workflow logic changed.

`actions/configure-pages`, `upload-pages-artifact`, `deploy-pages`, and the third-party `claude-code-action` were **not** in the deprecation warning and are left untouched.

All 8 workflow files re-validated as parseable YAML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)