### PR TITLE
fix: escalation decision result, roster casing, Conflict failure type

### DIFF
--- a/src/Content/Application/Application.AI.Common/CQRS/Changes/ApproveChangeProposal/ApproveChangeProposalCommandHandler.cs
+++ b/src/Content/Application/Application.AI.Common/CQRS/Changes/ApproveChangeProposal/ApproveChangeProposalCommandHandler.cs
@@ -71,7 +71,7 @@ public sealed class ApproveChangeProposalCommandHandler
             _store,
             request.ProposalId,
             statusGuard: p => p.Status != ChangeProposalStatus.AwaitingApproval
-                ? Result<ChangeProposal>.Fail(
+                ? Result<ChangeProposal>.Conflict(
                     $"Cannot approve proposal in status {p.Status} (must be AwaitingApproval).")
                 : null,
             decisionFactory: () => new GateDecision

--- a/src/Content/Application/Application.AI.Common/CQRS/Changes/CancelChangeProposal/CancelChangeProposalCommandHandler.cs
+++ b/src/Content/Application/Application.AI.Common/CQRS/Changes/CancelChangeProposal/CancelChangeProposalCommandHandler.cs
@@ -44,12 +44,12 @@ public sealed class CancelChangeProposalCommandHandler
             {
                 if (p.IsTerminal)
                 {
-                    return Result<ChangeProposal>.Fail(
+                    return Result<ChangeProposal>.Conflict(
                         $"Cannot cancel proposal in terminal status {p.Status}.");
                 }
                 if (p.Status == ChangeProposalStatus.Merging)
                 {
-                    return Result<ChangeProposal>.Fail(
+                    return Result<ChangeProposal>.Conflict(
                         "Cannot cancel proposal while merge is in progress.");
                 }
                 return null;

--- a/src/Content/Application/Application.AI.Common/CQRS/Changes/ChangeProposalCommandHelper.cs
+++ b/src/Content/Application/Application.AI.Common/CQRS/Changes/ChangeProposalCommandHelper.cs
@@ -28,9 +28,10 @@ internal static class ChangeProposalCommandHelper
     /// <param name="proposalId">The id of the proposal to act on.</param>
     /// <param name="statusGuard">
     /// Returns a non-null <see cref="Result{T}"/> to short-circuit the pipeline
-    /// (typically <c>Fail</c> when the current status doesn't permit the
-    /// decision), or <c>null</c> to proceed. The proposal is passed in so the
-    /// guard can include its actual current status in the failure message.
+    /// (typically <c>Conflict</c> when the current status doesn't permit the
+    /// decision, so HTTP layers can map it to 409), or <c>null</c> to proceed.
+    /// The proposal is passed in so the guard can include its actual current
+    /// status in the failure message.
     /// </param>
     /// <param name="decisionFactory">Builds the <see cref="GateDecision"/> to record on the transition.</param>
     /// <param name="targetStatus">The status to transition the proposal into.</param>

--- a/src/Content/Application/Application.AI.Common/CQRS/Changes/RejectChangeProposal/RejectChangeProposalCommandHandler.cs
+++ b/src/Content/Application/Application.AI.Common/CQRS/Changes/RejectChangeProposal/RejectChangeProposalCommandHandler.cs
@@ -40,7 +40,7 @@ public sealed class RejectChangeProposalCommandHandler
             _store,
             request.ProposalId,
             statusGuard: p => p.Status != ChangeProposalStatus.AwaitingApproval
-                ? Result<ChangeProposal>.Fail(
+                ? Result<ChangeProposal>.Conflict(
                     $"Cannot reject proposal in status {p.Status} (must be AwaitingApproval).")
                 : null,
             decisionFactory: () => new GateDecision

--- a/src/Content/Application/Application.AI.Common/Interfaces/Escalation/IEscalationService.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Escalation/IEscalationService.cs
@@ -28,10 +28,15 @@ public interface IEscalationService
     Task<Guid> QueueEscalationAsync(EscalationRequest request, CancellationToken ct);
 
     /// <summary>
-    /// Submits an approver's decision. Returns the final outcome if this decision resolves
-    /// the escalation (per the approval strategy), or null if the escalation is still pending.
+    /// Submits an approver's decision and reports what happened as a discriminated
+    /// <see cref="EscalationDecisionResult"/>:
+    /// <see cref="EscalationDecisionStatus.UnknownEscalation"/> (no such pending escalation),
+    /// <see cref="EscalationDecisionStatus.ApproverNotAuthorized"/> (identity not on the roster),
+    /// <see cref="EscalationDecisionStatus.DecisionRecorded"/> (recorded, escalation still unresolved), or
+    /// <see cref="EscalationDecisionStatus.Resolved"/> (this decision resolved it; the result
+    /// carries the final <see cref="EscalationOutcome"/>).
     /// </summary>
-    Task<EscalationOutcome?> SubmitDecisionAsync(Guid escalationId, ApproverDecision decision, CancellationToken ct);
+    Task<EscalationDecisionResult> SubmitDecisionAsync(Guid escalationId, ApproverDecision decision, CancellationToken ct);
 
     /// <summary>
     /// Returns the pending escalation request, or null if resolved or unknown.

--- a/src/Content/Application/Application.Core/Escalation/Strategies/ApproverRoster.cs
+++ b/src/Content/Application/Application.Core/Escalation/Strategies/ApproverRoster.cs
@@ -30,19 +30,19 @@ internal static class ApproverRoster
         EscalationRequest request,
         IReadOnlyList<ApproverDecision> decisions)
     {
-        var approverSet = request.Approvers.ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var approverSet = request.Approvers.ToHashSet(ApproverNames.Comparer);
 
         // Only count decisions from identities actually listed as approvers, collapsing
         // repeat votes to the earliest response so a later flip cannot rewrite the outcome.
         var rostered = decisions
             .Where(d => approverSet.Contains(d.ApproverName))
-            .GroupBy(d => d.ApproverName, StringComparer.OrdinalIgnoreCase)
+            .GroupBy(d => d.ApproverName, ApproverNames.Comparer)
             .Select(g => g.MinBy(d => d.RespondedAt)!)
             .ToArray();
 
         var respondedNames = rostered
             .Select(d => d.ApproverName)
-            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+            .ToHashSet(ApproverNames.Comparer);
         var pending = request.Approvers
             .Where(a => !respondedNames.Contains(a))
             .ToArray();

--- a/src/Content/Domain/Domain.AI/Escalation/ApproverNames.cs
+++ b/src/Content/Domain/Domain.AI/Escalation/ApproverNames.cs
@@ -1,0 +1,24 @@
+namespace Domain.AI.Escalation;
+
+/// <summary>
+/// The single source of truth for how approver names are compared against an
+/// escalation's roster. Every roster lookup — the decide path, the pending-list
+/// path, and the approval-strategy evaluation — must use this comparer so a
+/// caller whose identity casing differs from the roster entry is treated
+/// identically on all of them.
+/// </summary>
+/// <remarks>
+/// Comparison is case-insensitive ordinal: approver names are operator-authored
+/// identifiers (roster strings in gate config, token claims over HTTP), where
+/// casing differences are accidental, not semantic. Normalizing at comparison
+/// time — rather than rewriting names at roster construction — preserves the
+/// original casing in audit records. A site that restates
+/// <see cref="StringComparer.OrdinalIgnoreCase"/> inline instead of using this
+/// member can silently drift back to case-sensitive matching; always reference
+/// <see cref="Comparer"/>.
+/// </remarks>
+public static class ApproverNames
+{
+    /// <summary>The comparer used for every approver-name/roster comparison.</summary>
+    public static StringComparer Comparer => StringComparer.OrdinalIgnoreCase;
+}

--- a/src/Content/Domain/Domain.AI/Escalation/EscalationDecisionResult.cs
+++ b/src/Content/Domain/Domain.AI/Escalation/EscalationDecisionResult.cs
@@ -1,0 +1,59 @@
+namespace Domain.AI.Escalation;
+
+/// <summary>
+/// The discriminated result of submitting an approver decision via
+/// <c>IEscalationService.SubmitDecisionAsync</c>: a <see cref="Status"/> naming
+/// which of the four distinct outcomes occurred, plus the resolved
+/// <see cref="Outcome"/> when — and only when — this decision resolved the escalation.
+/// </summary>
+/// <remarks>
+/// This type replaces the previous <c>EscalationOutcome?</c> return, whose
+/// <c>null</c> conflated three different situations (unknown escalation,
+/// non-roster approver, and decision-recorded-but-still-pending). A control
+/// plane exposing decisions over HTTP must distinguish those cases (404 / 403 /
+/// 202 respectively); collapsing them into <c>null</c> made that impossible.
+/// Construct instances via the static factories so the
+/// status/outcome pairing invariant (outcome present iff
+/// <see cref="EscalationDecisionStatus.Resolved"/>) always holds.
+/// </remarks>
+public sealed record EscalationDecisionResult
+{
+    /// <summary>What happened to the submitted decision.</summary>
+    public required EscalationDecisionStatus Status { get; init; }
+
+    /// <summary>
+    /// The final escalation verdict. Non-null if and only if <see cref="Status"/> is
+    /// <see cref="EscalationDecisionStatus.Resolved"/>.
+    /// </summary>
+    public EscalationOutcome? Outcome { get; init; }
+
+    // The three outcome-less results are stateless and immutable, so a single shared
+    // instance per status serves every call — the factories below hand these out.
+    private static readonly EscalationDecisionResult UnknownInstance =
+        new() { Status = EscalationDecisionStatus.UnknownEscalation };
+    private static readonly EscalationDecisionResult NotAuthorizedInstance =
+        new() { Status = EscalationDecisionStatus.ApproverNotAuthorized };
+    private static readonly EscalationDecisionResult RecordedInstance =
+        new() { Status = EscalationDecisionStatus.DecisionRecorded };
+
+    /// <summary>Creates a result for a decision targeting an escalation that is not pending.</summary>
+    public static EscalationDecisionResult UnknownEscalation() => UnknownInstance;
+
+    /// <summary>Creates a result for a decision rejected because the approver is not on the roster.</summary>
+    public static EscalationDecisionResult ApproverNotAuthorized() => NotAuthorizedInstance;
+
+    /// <summary>Creates a result for a decision that was recorded but left the escalation unresolved.</summary>
+    public static EscalationDecisionResult DecisionRecorded() => RecordedInstance;
+
+    /// <summary>Creates a result for a decision that resolved the escalation with the given verdict.</summary>
+    /// <param name="outcome">The final resolved outcome. Must not be null.</param>
+    public static EscalationDecisionResult Resolved(EscalationOutcome outcome)
+    {
+        ArgumentNullException.ThrowIfNull(outcome);
+        return new EscalationDecisionResult
+        {
+            Status = EscalationDecisionStatus.Resolved,
+            Outcome = outcome
+        };
+    }
+}

--- a/src/Content/Domain/Domain.AI/Escalation/EscalationDecisionStatus.cs
+++ b/src/Content/Domain/Domain.AI/Escalation/EscalationDecisionStatus.cs
@@ -1,0 +1,39 @@
+namespace Domain.AI.Escalation;
+
+/// <summary>
+/// Categorizes what happened when an approver decision was submitted via
+/// <c>IEscalationService.SubmitDecisionAsync</c>. Each value is a distinct,
+/// externally observable outcome that a transport layer (HTTP, hub, console)
+/// can map without ambiguity — replacing the earlier design where three of
+/// these cases were conflated into a single <c>null</c> return.
+/// </summary>
+public enum EscalationDecisionStatus
+{
+    /// <summary>
+    /// No escalation with the given ID is currently pending. The decision was not
+    /// recorded. Maps naturally to HTTP 404.
+    /// </summary>
+    UnknownEscalation = 0,
+
+    /// <summary>
+    /// The submitting identity is not on the escalation's approver roster. The
+    /// decision was rejected before being recorded or evaluated. Maps naturally
+    /// to HTTP 403.
+    /// </summary>
+    ApproverNotAuthorized,
+
+    /// <summary>
+    /// The decision was durably recorded but did not resolve the escalation:
+    /// either the approval strategy requires further decisions (e.g. AllOf with
+    /// approvers still pending), or another decision resolved the escalation
+    /// concurrently. Poll <c>IEscalationService.GetOutcomeAsync</c> for the final
+    /// verdict. Maps naturally to HTTP 202.
+    /// </summary>
+    DecisionRecorded,
+
+    /// <summary>
+    /// This decision resolved the escalation. <see cref="EscalationDecisionResult.Outcome"/>
+    /// carries the final <see cref="EscalationOutcome"/>. Maps naturally to HTTP 200.
+    /// </summary>
+    Resolved
+}

--- a/src/Content/Domain/Domain.Common/Extensions/ResultExtensions.cs
+++ b/src/Content/Domain/Domain.Common/Extensions/ResultExtensions.cs
@@ -131,6 +131,7 @@ public static class ResultExtensions
             ResultFailureType.PermissionRequired => Result<TOut>.PermissionRequired(JoinErrors(errors)),
             ResultFailureType.GovernanceBlocked => Result<TOut>.GovernanceBlocked(JoinErrors(errors)),
             ResultFailureType.PendingApproval => Result<TOut>.PendingApproval(JoinErrors(errors)),
+            ResultFailureType.Conflict => Result<TOut>.Conflict(JoinErrors(errors)),
             _ => Result<TOut>.Fail(errors.ToArray())
         };
     }

--- a/src/Content/Domain/Domain.Common/Result.cs
+++ b/src/Content/Domain/Domain.Common/Result.cs
@@ -87,6 +87,9 @@ public class Result
 
     /// <summary>Creates a pending-approval result with the escalation ID for correlation.</summary>
     public static Result PendingApproval(string reason) => new(false, [reason], ResultFailureType.PendingApproval);
+
+    /// <summary>Creates a conflict failure result for requests that clash with the resource's current state.</summary>
+    public static Result Conflict(string reason) => new(false, [reason], ResultFailureType.Conflict);
 }
 
 /// <summary>
@@ -134,6 +137,9 @@ public sealed class Result<T> : Result
     /// <summary>Creates a pending-approval result with the escalation ID for correlation.</summary>
     public new static Result<T> PendingApproval(string reason) => new(false, errors: [reason], failureType: ResultFailureType.PendingApproval);
 
+    /// <summary>Creates a conflict failure result for requests that clash with the resource's current state.</summary>
+    public new static Result<T> Conflict(string reason) => new(false, errors: [reason], failureType: ResultFailureType.Conflict);
+
     /// <summary>
     /// Implicit conversion from a non-null value to a successful result.
     /// Throws <see cref="ArgumentNullException"/> if value is null to prevent
@@ -172,5 +178,12 @@ public enum ResultFailureType
     /// <summary>Action blocked by governance policy.</summary>
     GovernanceBlocked,
     /// <summary>Action requires human approval; escalation is pending.</summary>
-    PendingApproval
+    PendingApproval,
+    /// <summary>
+    /// Request conflicts with the current state of the target resource (409) — e.g. a
+    /// status-machine guard rejecting a decision because the entity already moved on.
+    /// Distinct from <see cref="Validation"/> (the request itself is well-formed) and from
+    /// <see cref="General"/> (which HTTP layers map to an opaque 500).
+    /// </summary>
+    Conflict
 }

--- a/src/Content/Infrastructure/Infrastructure.AI/Escalation/DefaultEscalationService.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Escalation/DefaultEscalationService.cs
@@ -108,25 +108,25 @@ public sealed class DefaultEscalationService : IEscalationService, IDisposable
 	}
 
 	/// <inheritdoc />
-	public async Task<EscalationOutcome?> SubmitDecisionAsync(
+	public async Task<EscalationDecisionResult> SubmitDecisionAsync(
 		Guid escalationId, ApproverDecision decision, CancellationToken ct)
 	{
 		if (!_activeEscalations.TryGetValue(escalationId, out var state))
 		{
 			_logger.LogWarning("Decision submitted for unknown escalation {EscalationId}", escalationId);
-			return null;
+			return EscalationDecisionResult.UnknownEscalation();
 		}
 
 		// Authorization chokepoint: reject decisions from identities outside the approver
 		// roster before they are recorded, evaluated, or allowed to resolve the escalation.
 		// The strategies also filter non-roster votes (defense in depth), but stopping here
 		// keeps unauthorized decisions out of the audit trail and strategy evaluation entirely.
-		if (!state.Request.Approvers.Contains(decision.ApproverName, StringComparer.OrdinalIgnoreCase))
+		if (!state.Request.Approvers.Contains(decision.ApproverName, ApproverNames.Comparer))
 		{
 			_logger.LogWarning(
 				"Rejected decision from non-roster identity {ApproverName} for escalation {EscalationId}",
 				decision.ApproverName, escalationId);
-			return null;
+			return EscalationDecisionResult.ApproverNotAuthorized();
 		}
 
 		await SafeExecuteAsync(
@@ -142,8 +142,11 @@ public sealed class DefaultEscalationService : IEscalationService, IDisposable
 
 		lock (state.Lock)
 		{
+			// Recorded for audit above, but another decision resolved the escalation
+			// concurrently — this one arrives too late to participate. The caller polls
+			// GetOutcomeAsync for the verdict (see EscalationDecisionStatus.DecisionRecorded).
 			if (state.IsResolved)
-				return null;
+				return EscalationDecisionResult.DecisionRecorded();
 
 			state.Decisions.Add(decision);
 			var evaluation = strategy.EvaluateDecision(state.Request, state.Decisions.AsReadOnly());
@@ -153,7 +156,7 @@ public sealed class DefaultEscalationService : IEscalationService, IDisposable
 				escalationId, evaluation.IsResolved, evaluation.IsApproved);
 
 			if (!evaluation.IsResolved)
-				return null;
+				return EscalationDecisionResult.DecisionRecorded();
 
 			state.IsResolved = true;
 			outcome = new EscalationOutcome
@@ -169,7 +172,7 @@ public sealed class DefaultEscalationService : IEscalationService, IDisposable
 		}
 
 		await ResolveEscalationAsync(state, outcome);
-		return outcome;
+		return EscalationDecisionResult.Resolved(outcome);
 	}
 
 	/// <inheritdoc />
@@ -190,8 +193,11 @@ public sealed class DefaultEscalationService : IEscalationService, IDisposable
 	public Task<IReadOnlyList<EscalationRequest>> GetPendingEscalationsAsync(
 		string approverName, CancellationToken ct)
 	{
+		// Match the roster the same way the decide path does: an approver whose identity
+		// differs from the roster entry only by casing must see the escalations they are
+		// allowed to decide. ApproverNames.Comparer is the single source of that rule.
 		var pending = _activeEscalations.Values
-			.Where(s => s.Request.Approvers.Contains(approverName))
+			.Where(s => s.Request.Approvers.Contains(approverName, ApproverNames.Comparer))
 			.Select(s => s.Request)
 			.ToList();
 		return Task.FromResult<IReadOnlyList<EscalationRequest>>(pending.AsReadOnly());

--- a/src/Content/Presentation/Presentation.AgentHub/Controllers/ComplianceController.cs
+++ b/src/Content/Presentation/Presentation.AgentHub/Controllers/ComplianceController.cs
@@ -94,6 +94,10 @@ public sealed class ComplianceController : ControllerBase
                 title: "Forbidden",
                 detail: string.Join(" / ", result.Errors),
                 statusCode: StatusCodes.Status403Forbidden),
+            ResultFailureType.Conflict => Problem(
+                title: "Conflict",
+                detail: string.Join(" / ", result.Errors),
+                statusCode: StatusCodes.Status409Conflict),
             _ => Problem(
                 title: "Erasure failed",
                 detail: "An error occurred processing the request. See server logs for details.",

--- a/src/Content/Presentation/Presentation.AgentHub/Controllers/EvalController.cs
+++ b/src/Content/Presentation/Presentation.AgentHub/Controllers/EvalController.cs
@@ -194,6 +194,10 @@ public sealed class EvalController : ControllerBase
                 title: "Forbidden",
                 detail: string.Join(" / ", result.Errors),
                 statusCode: StatusCodes.Status403Forbidden),
+            ResultFailureType.Conflict => Problem(
+                title: "Conflict",
+                detail: string.Join(" / ", result.Errors),
+                statusCode: StatusCodes.Status409Conflict),
             _ => Problem(
                 title: "Eval operation failed",
                 detail: "An error occurred processing the request. See server logs for details.",

--- a/src/Content/Presentation/Presentation.BundleApi/Controllers/BundlesController.cs
+++ b/src/Content/Presentation/Presentation.BundleApi/Controllers/BundlesController.cs
@@ -239,6 +239,8 @@ public sealed class BundlesController : ControllerBase
             title: "Unauthorized", detail: string.Join(" / ", errors), statusCode: StatusCodes.Status401Unauthorized),
         ResultFailureType.Forbidden => Problem(
             title: "Forbidden", detail: string.Join(" / ", errors), statusCode: StatusCodes.Status403Forbidden),
+        ResultFailureType.Conflict => Problem(
+            title: "Conflict", detail: string.Join(" / ", errors), statusCode: StatusCodes.Status409Conflict),
         _ => Problem(
             title: "Bundle operation failed",
             detail: "An error occurred processing the request. See server logs for details.",

--- a/src/Content/Presentation/Presentation.ConsoleUI/Examples/EscalationApprovalsExample.cs
+++ b/src/Content/Presentation/Presentation.ConsoleUI/Examples/EscalationApprovalsExample.cs
@@ -77,8 +77,10 @@ public class EscalationApprovalsExample
             RespondedAt = DateTimeOffset.UtcNow
         };
 
-        var outcome = await _escalationService.SubmitDecisionAsync(escalationId, aliceDecision, cancellationToken);
-        if (outcome != null)
+        var result = await _escalationService.SubmitDecisionAsync(escalationId, aliceDecision, cancellationToken);
+        // Pattern-match binds the non-null outcome in one step — the status/outcome
+        // invariant (Outcome present iff Resolved) makes this safe without `!`.
+        if (result is { Status: EscalationDecisionStatus.Resolved, Outcome: { } outcome })
         {
             DisplayOutcome("AnyOf Result", outcome);
             AnsiConsole.MarkupLine($"[bold]Escalation Resolved After:[/] {outcome.Decisions.Count} approver decision(s)");
@@ -110,8 +112,8 @@ public class EscalationApprovalsExample
             RespondedAt = DateTimeOffset.UtcNow
         };
 
-        var outcome1 = await _escalationService.SubmitDecisionAsync(escalationId, aliceDecision, cancellationToken);
-        AnsiConsole.MarkupLine($"[yellow]After Alice approved: {(outcome1 == null ? "Still pending (Bob must approve)" : "Resolved")}[/]");
+        var result1 = await _escalationService.SubmitDecisionAsync(escalationId, aliceDecision, cancellationToken);
+        AnsiConsole.MarkupLine($"[yellow]After Alice approved: {(result1.Status == EscalationDecisionStatus.DecisionRecorded ? "Still pending (Bob must approve)" : "Resolved")}[/]");
 
         // Bob approves
         var bobDecision = new ApproverDecision
@@ -122,11 +124,11 @@ public class EscalationApprovalsExample
             RespondedAt = DateTimeOffset.UtcNow
         };
 
-        var outcome2 = await _escalationService.SubmitDecisionAsync(escalationId, bobDecision, cancellationToken);
-        if (outcome2 != null)
+        var result2 = await _escalationService.SubmitDecisionAsync(escalationId, bobDecision, cancellationToken);
+        if (result2 is { Status: EscalationDecisionStatus.Resolved, Outcome: { } outcome })
         {
-            DisplayOutcome("AllOf Result", outcome2);
-            AnsiConsole.MarkupLine($"[bold]Escalation Resolved After:[/] All {outcome2.Decisions.Count} approvers decided");
+            DisplayOutcome("AllOf Result", outcome);
+            AnsiConsole.MarkupLine($"[bold]Escalation Resolved After:[/] All {outcome.Decisions.Count} approvers decided");
         }
 
         AnsiConsole.WriteLine();
@@ -156,8 +158,8 @@ public class EscalationApprovalsExample
             RespondedAt = DateTimeOffset.UtcNow
         };
 
-        var outcome1 = await _escalationService.SubmitDecisionAsync(escalationId, aliceDecision, cancellationToken);
-        AnsiConsole.MarkupLine($"[yellow]After Alice: {(outcome1 == null ? "1/2 approvals received, pending" : "Quorum met")}[/]");
+        var result1 = await _escalationService.SubmitDecisionAsync(escalationId, aliceDecision, cancellationToken);
+        AnsiConsole.MarkupLine($"[yellow]After Alice: {(result1.Status == EscalationDecisionStatus.DecisionRecorded ? "1/2 approvals received, pending" : "Quorum met")}[/]");
 
         // Bob approves (quorum met)
         var bobDecision = new ApproverDecision
@@ -168,11 +170,11 @@ public class EscalationApprovalsExample
             RespondedAt = DateTimeOffset.UtcNow
         };
 
-        var outcome2 = await _escalationService.SubmitDecisionAsync(escalationId, bobDecision, cancellationToken);
-        if (outcome2 != null)
+        var result2 = await _escalationService.SubmitDecisionAsync(escalationId, bobDecision, cancellationToken);
+        if (result2 is { Status: EscalationDecisionStatus.Resolved, Outcome: { } outcome })
         {
-            DisplayOutcome("Quorum Result", outcome2);
-            AnsiConsole.MarkupLine($"[bold]Escalation Resolved After:[/] {outcome2.Decisions.Count} approvers (quorum met)");
+            DisplayOutcome("Quorum Result", outcome);
+            AnsiConsole.MarkupLine($"[bold]Escalation Resolved After:[/] {outcome.Decisions.Count} approvers (quorum met)");
         }
 
         AnsiConsole.WriteLine();

--- a/src/Content/Tests/Application.AI.Common.Tests/CQRS/Changes/ApproveChangeProposalCommandHandlerTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/CQRS/Changes/ApproveChangeProposalCommandHandlerTests.cs
@@ -78,7 +78,7 @@ public sealed class ApproveChangeProposalCommandHandlerTests
     [InlineData(ChangeProposalStatus.Merged)]
     [InlineData(ChangeProposalStatus.Rejected)]
     [InlineData(ChangeProposalStatus.Cancelled)]
-    public async Task Handle_WrongStatus_ReturnsFailureAndDoesNotEnqueue(ChangeProposalStatus status)
+    public async Task Handle_WrongStatus_ReturnsConflictAndDoesNotEnqueue(ChangeProposalStatus status)
     {
         var store = new InMemoryChangeProposalStore();
         var proposal = TestHelpers.NewProposal(status);
@@ -91,6 +91,8 @@ public sealed class ApproveChangeProposalCommandHandlerTests
             CancellationToken.None);
 
         result.IsSuccess.Should().BeFalse();
+        result.FailureType.Should().Be(ResultFailureType.Conflict,
+            "a status-machine guard rejection is a state conflict (HTTP 409), not an opaque general failure (500)");
         dispatcher.Enqueued.Should().BeEmpty();
     }
 

--- a/src/Content/Tests/Application.AI.Common.Tests/CQRS/Changes/CancelChangeProposalCommandHandlerTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/CQRS/Changes/CancelChangeProposalCommandHandlerTests.cs
@@ -40,7 +40,7 @@ public sealed class CancelChangeProposalCommandHandlerTests
     }
 
     [Fact]
-    public async Task Handle_Merging_ReturnsFailure()
+    public async Task Handle_Merging_ReturnsConflict()
     {
         var store = new InMemoryChangeProposalStore();
         var merging = TestHelpers.NewProposal(ChangeProposalStatus.Merging);
@@ -52,6 +52,8 @@ public sealed class CancelChangeProposalCommandHandlerTests
             CancellationToken.None);
 
         result.IsSuccess.Should().BeFalse();
+        result.FailureType.Should().Be(ResultFailureType.Conflict,
+            "cancel-during-merge is a state conflict (HTTP 409), not an opaque general failure (500)");
         result.Errors.Should().ContainSingle().Which.Should().Contain("merge is in progress");
     }
 
@@ -59,7 +61,7 @@ public sealed class CancelChangeProposalCommandHandlerTests
     [InlineData(ChangeProposalStatus.Merged)]
     [InlineData(ChangeProposalStatus.Rejected)]
     [InlineData(ChangeProposalStatus.Cancelled)]
-    public async Task Handle_TerminalStatus_ReturnsFailure(ChangeProposalStatus status)
+    public async Task Handle_TerminalStatus_ReturnsConflict(ChangeProposalStatus status)
     {
         var store = new InMemoryChangeProposalStore();
         var terminal = TestHelpers.NewProposal(status);
@@ -71,6 +73,8 @@ public sealed class CancelChangeProposalCommandHandlerTests
             CancellationToken.None);
 
         result.IsSuccess.Should().BeFalse();
+        result.FailureType.Should().Be(ResultFailureType.Conflict,
+            "cancelling a terminal proposal is a state conflict (HTTP 409), not an opaque general failure (500)");
     }
 
     [Fact]

--- a/src/Content/Tests/Application.AI.Common.Tests/CQRS/Changes/RejectChangeProposalCommandHandlerTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/CQRS/Changes/RejectChangeProposalCommandHandlerTests.cs
@@ -57,7 +57,7 @@ public sealed class RejectChangeProposalCommandHandlerTests
     }
 
     [Fact]
-    public async Task Handle_DraftStatus_ReturnsFailure()
+    public async Task Handle_DraftStatus_ReturnsConflict()
     {
         var store = new InMemoryChangeProposalStore();
         var draft = TestHelpers.NewProposal(ChangeProposalStatus.Draft);
@@ -74,5 +74,7 @@ public sealed class RejectChangeProposalCommandHandlerTests
             CancellationToken.None);
 
         result.IsSuccess.Should().BeFalse();
+        result.FailureType.Should().Be(ResultFailureType.Conflict,
+            "a status-machine guard rejection is a state conflict (HTTP 409), not an opaque general failure (500)");
     }
 }

--- a/src/Content/Tests/Domain.Common.Tests/Enums/ResultFailureTypeTests.cs
+++ b/src/Content/Tests/Domain.Common.Tests/Enums/ResultFailureTypeTests.cs
@@ -19,6 +19,7 @@ public class ResultFailureTypeTests
     [InlineData(ResultFailureType.PermissionRequired, 7)]
     [InlineData(ResultFailureType.GovernanceBlocked, 8)]
     [InlineData(ResultFailureType.PendingApproval, 9)]
+    [InlineData(ResultFailureType.Conflict, 10)]
     public void Value_HasExpectedInteger(ResultFailureType type, int expected)
     {
         ((int)type).Should().Be(expected);
@@ -30,7 +31,7 @@ public class ResultFailureTypeTests
         var values = Enum.GetValues<ResultFailureType>();
 
         values.Should().OnlyHaveUniqueItems();
-        values.Should().HaveCount(10);
+        values.Should().HaveCount(11);
     }
 
     [Theory]

--- a/src/Content/Tests/Domain.Common.Tests/Extensions/ResultExtensionsLogicTests.cs
+++ b/src/Content/Tests/Domain.Common.Tests/Extensions/ResultExtensionsLogicTests.cs
@@ -190,6 +190,17 @@ public class ResultExtensionsLogicTests
     }
 
     [Fact]
+    public void Map_ConflictFailure_PropagatesConflictType()
+    {
+        var result = Result<int>.Conflict("state moved on");
+
+        var mapped = result.Map(v => v.ToString());
+
+        mapped.IsSuccess.Should().BeFalse();
+        mapped.FailureType.Should().Be(ResultFailureType.Conflict);
+    }
+
+    [Fact]
     public void Map_GeneralFailure_PropagatesGeneralType()
     {
         var result = Result<int>.Fail("general error");

--- a/src/Content/Tests/Domain.Common.Tests/ResultTests.cs
+++ b/src/Content/Tests/Domain.Common.Tests/ResultTests.cs
@@ -107,6 +107,27 @@ public class ResultTests
     }
 
     [Fact]
+    public void Conflict_SetsCorrectType()
+    {
+        var result = Result.Conflict("proposal already merged");
+
+        result.IsSuccess.Should().BeFalse();
+        result.FailureType.Should().Be(ResultFailureType.Conflict);
+        result.Errors.Should().ContainSingle().Which.Should().Be("proposal already merged");
+    }
+
+    [Fact]
+    public void ConflictGeneric_SetsCorrectTypeWithoutValue()
+    {
+        var result = Result<int>.Conflict("state moved on");
+
+        result.IsSuccess.Should().BeFalse();
+        result.Value.Should().Be(default(int));
+        result.FailureType.Should().Be(ResultFailureType.Conflict);
+        result.Errors.Should().ContainSingle().Which.Should().Be("state moved on");
+    }
+
+    [Fact]
     public void Fail_WithMultipleErrors_StoresAll()
     {
         var result = Result.Fail("error one", "error two", "error three");

--- a/src/Content/Tests/Infrastructure.AI.Tests/Changes/ChangeProposalStartupValidatorTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Changes/ChangeProposalStartupValidatorTests.cs
@@ -53,8 +53,8 @@ public sealed class ChangeProposalStartupValidatorTests
             throw new NotImplementedException();
         public Task<Guid> QueueEscalationAsync(EscalationRequest request, CancellationToken ct) =>
             Task.FromResult(Guid.Empty);
-        public Task<EscalationOutcome?> SubmitDecisionAsync(Guid escalationId, ApproverDecision decision, CancellationToken ct) =>
-            Task.FromResult<EscalationOutcome?>(null);
+        public Task<EscalationDecisionResult> SubmitDecisionAsync(Guid escalationId, ApproverDecision decision, CancellationToken ct) =>
+            Task.FromResult(EscalationDecisionResult.UnknownEscalation());
         public Task<EscalationRequest?> GetPendingEscalationAsync(Guid escalationId, CancellationToken ct) =>
             Task.FromResult<EscalationRequest?>(null);
         public Task<EscalationOutcome?> GetOutcomeAsync(Guid escalationId, CancellationToken ct) =>

--- a/src/Content/Tests/Infrastructure.AI.Tests/Changes/Gates/EscalationServiceApprovalRouterTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Changes/Gates/EscalationServiceApprovalRouterTests.cs
@@ -41,7 +41,7 @@ public sealed class EscalationServiceApprovalRouterTests : IDisposable
         }
 
         public Task<EscalationOutcome> RequestEscalationAsync(EscalationRequest request, CancellationToken ct) => throw new NotImplementedException();
-        public Task<EscalationOutcome?> SubmitDecisionAsync(Guid escalationId, ApproverDecision decision, CancellationToken ct) => throw new NotImplementedException();
+        public Task<EscalationDecisionResult> SubmitDecisionAsync(Guid escalationId, ApproverDecision decision, CancellationToken ct) => throw new NotImplementedException();
         public Task<EscalationRequest?> GetPendingEscalationAsync(Guid escalationId, CancellationToken ct) => throw new NotImplementedException();
         public Task<EscalationOutcome?> GetOutcomeAsync(Guid escalationId, CancellationToken ct) => throw new NotImplementedException();
         public Task<IReadOnlyList<EscalationRequest>> GetPendingEscalationsAsync(string approverName, CancellationToken ct) => throw new NotImplementedException();

--- a/src/Content/Tests/Infrastructure.AI.Tests/Escalation/DefaultEscalationServiceTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Escalation/DefaultEscalationServiceTests.cs
@@ -235,11 +235,11 @@ public sealed class DefaultEscalationServiceTests : IDisposable
 		var task = Task.Run(() => _sut.RequestEscalationAsync(request, CancellationToken.None));
 		await WaitForRegistrationAsync(request.EscalationId);
 
-		var submitOutcome = await _sut.SubmitDecisionAsync(
+		var submitResult = await _sut.SubmitDecisionAsync(
 			request.EscalationId, CreateApproval(), CancellationToken.None);
 		var outcome = await task;
 
-		submitOutcome.Should().NotBeNull(
+		submitResult.Status.Should().Be(EscalationDecisionStatus.Resolved,
 			"the decision must hit a registered escalation, not be dropped as unknown");
 		outcome.ResolutionType.Should().Be(EscalationResolutionType.Approved,
 			"the escalation must resolve from the submitted approval, not from a timeout");
@@ -270,18 +270,20 @@ public sealed class DefaultEscalationServiceTests : IDisposable
 	// ===== SubmitDecisionAsync =====
 
 	[Fact]
-	public async Task SubmitDecisionAsync_TriggersStrategyEvaluation_ReturnsOutcomeIfResolved()
+	public async Task SubmitDecisionAsync_ResolvingDecision_ReturnsResolvedCarryingOutcome()
 	{
 		var request = CreateTestRequest();
 		SetupStrategyResolvesOnFirstApproval();
 		await _sut.QueueEscalationAsync(request, CancellationToken.None);
 
-		var outcome = await _sut.SubmitDecisionAsync(
+		var result = await _sut.SubmitDecisionAsync(
 			request.EscalationId, CreateApproval(), CancellationToken.None);
 
-		outcome.Should().NotBeNull();
-		outcome!.IsApproved.Should().BeTrue();
-		outcome.ResolutionType.Should().Be(EscalationResolutionType.Approved);
+		result.Status.Should().Be(EscalationDecisionStatus.Resolved);
+		result.Outcome.Should().NotBeNull(
+			"a Resolved result must carry the final verdict for the caller");
+		result.Outcome!.IsApproved.Should().BeTrue();
+		result.Outcome.ResolutionType.Should().Be(EscalationResolutionType.Approved);
 
 		_auditStore.Verify(
 			a => a.RecordDecisionAsync(request.EscalationId, It.IsAny<ApproverDecision>(), It.IsAny<CancellationToken>()),
@@ -295,16 +297,18 @@ public sealed class DefaultEscalationServiceTests : IDisposable
 	}
 
 	[Fact]
-	public async Task SubmitDecisionAsync_PartialDecision_ReturnsNull()
+	public async Task SubmitDecisionAsync_PartialDecisionUnderAllOf_ReturnsDecisionRecorded()
 	{
 		var request = CreateTestRequest(strategy: ApprovalStrategyType.AllOf);
 		SetupStrategyNeverResolves(ApprovalStrategyType.AllOf);
 		await _sut.QueueEscalationAsync(request, CancellationToken.None);
 
-		var outcome = await _sut.SubmitDecisionAsync(
+		var result = await _sut.SubmitDecisionAsync(
 			request.EscalationId, CreateApproval(), CancellationToken.None);
 
-		outcome.Should().BeNull();
+		result.Status.Should().Be(EscalationDecisionStatus.DecisionRecorded,
+			"a recorded decision that does not satisfy the strategy must be reported as recorded-but-pending, not conflated with unknown/unauthorized");
+		result.Outcome.Should().BeNull("only a Resolved result carries an outcome");
 		_auditStore.Verify(
 			a => a.RecordDecisionAsync(request.EscalationId, It.IsAny<ApproverDecision>(), It.IsAny<CancellationToken>()),
 			Times.Once);
@@ -314,12 +318,13 @@ public sealed class DefaultEscalationServiceTests : IDisposable
 	}
 
 	[Fact]
-	public async Task SubmitDecisionAsync_UnknownEscalationId_ReturnsNull()
+	public async Task SubmitDecisionAsync_UnknownEscalationId_ReturnsUnknownEscalation()
 	{
-		var outcome = await _sut.SubmitDecisionAsync(
+		var result = await _sut.SubmitDecisionAsync(
 			Guid.NewGuid(), CreateApproval(), CancellationToken.None);
 
-		outcome.Should().BeNull();
+		result.Status.Should().Be(EscalationDecisionStatus.UnknownEscalation,
+			"an HTTP layer must be able to map a missing escalation to 404, distinct from the other non-resolving cases");
 		_auditStore.Verify(
 			a => a.RecordDecisionAsync(It.IsAny<Guid>(), It.IsAny<ApproverDecision>(), It.IsAny<CancellationToken>()),
 			Times.Never);
@@ -332,10 +337,11 @@ public sealed class DefaultEscalationServiceTests : IDisposable
 		SetupStrategyResolvesOnFirstApproval();
 		await _sut.QueueEscalationAsync(request, CancellationToken.None);
 
-		var outcome = await _sut.SubmitDecisionAsync(
+		var result = await _sut.SubmitDecisionAsync(
 			request.EscalationId, CreateApproval("mallory"), CancellationToken.None);
 
-		outcome.Should().BeNull("a decision from an identity outside the approver roster must not resolve the escalation");
+		result.Status.Should().Be(EscalationDecisionStatus.ApproverNotAuthorized,
+			"a decision from an identity outside the approver roster must be rejected as unauthorized, mappable to 403");
 		_auditStore.Verify(
 			a => a.RecordDecisionAsync(It.IsAny<Guid>(), It.IsAny<ApproverDecision>(), It.IsAny<CancellationToken>()),
 			Times.Never);
@@ -447,8 +453,8 @@ public sealed class DefaultEscalationServiceTests : IDisposable
 				CancellationToken.None))
 			.ToArray();
 
-		var outcomes = await Task.WhenAll(tasks);
-		outcomes.Count(o => o is not null).Should().Be(1,
+		var results = await Task.WhenAll(tasks);
+		results.Count(r => r.Status == EscalationDecisionStatus.Resolved).Should().Be(1,
 			"exactly one concurrent decision should resolve the escalation");
 	}
 
@@ -506,6 +512,39 @@ public sealed class DefaultEscalationServiceTests : IDisposable
 	}
 
 	[Fact]
+	public async Task GetPendingEscalationsAsync_ApproverCasedDifferentlyFromRoster_SeesPendingEscalation()
+	{
+		// Regression (roster case-sensitivity mismatch): SubmitDecisionAsync matched the roster
+		// OrdinalIgnoreCase while GetPendingEscalationsAsync used case-sensitive Contains — an
+		// approver whose identity differed from the roster entry only by casing could decide
+		// an escalation they could never see in their pending list.
+		var request = CreateTestRequest(); // roster: approver-1, approver-2
+		SetupStrategyNeverResolves(ApprovalStrategyType.AnyOf);
+		await _sut.QueueEscalationAsync(request, CancellationToken.None);
+
+		var pending = await _sut.GetPendingEscalationsAsync("APPROVER-1", CancellationToken.None);
+
+		pending.Should().ContainSingle(r => r.EscalationId == request.EscalationId,
+			"the pending view must use the same case-insensitive roster match as the decide path");
+	}
+
+	[Fact]
+	public async Task SubmitDecisionAsync_ApproverCasedDifferentlyFromRoster_CanDecide()
+	{
+		// Companion to the pending-view casing test: the same differently-cased approver must
+		// also be able to decide, proving see-and-decide agree on roster membership semantics.
+		var request = CreateTestRequest(); // roster: approver-1, approver-2
+		SetupStrategyResolvesOnFirstApproval();
+		await _sut.QueueEscalationAsync(request, CancellationToken.None);
+
+		var result = await _sut.SubmitDecisionAsync(
+			request.EscalationId, CreateApproval("APPROVER-1"), CancellationToken.None);
+
+		result.Status.Should().Be(EscalationDecisionStatus.Resolved);
+		result.Outcome!.IsApproved.Should().BeTrue();
+	}
+
+	[Fact]
 	public async Task GetPendingEscalationAsync_ResolvedEscalation_ReturnsNull()
 	{
 		var request = CreateTestRequest();
@@ -553,7 +592,7 @@ public sealed class DefaultEscalationServiceTests : IDisposable
 
 		var submitted = await _sut.SubmitDecisionAsync(
 			request.EscalationId, CreateApproval(), CancellationToken.None);
-		submitted.Should().NotBeNull();
+		submitted.Status.Should().Be(EscalationDecisionStatus.Resolved);
 
 		var outcome = await _sut.GetOutcomeAsync(request.EscalationId, CancellationToken.None);
 


### PR DESCRIPTION
## What & why

PR **H0** of the external-trigger-API program (scope: `.claude/plans/external-trigger-api-scope.md` §4). Fixes three pre-existing defects in the escalation/change-proposal services that block building HTTP approval endpoints (Track H) on top of them.

### 1. `SubmitDecisionAsync` null-conflation → discriminated result
The method returned `null` for three distinct situations — unknown escalation, approver not on the roster, and decision-recorded-but-still-pending — which an HTTP layer cannot map to 404/403/202. New `EscalationDecisionResult` (sealed record, factory-enforced invariant: `Outcome` non-null **iff** `Resolved`) + `EscalationDecisionStatus` enum replace the nullable return outright (replace, don't wrap). All callers updated.

### 2. Roster casing mismatch
The decide path matched approver names `OrdinalIgnoreCase`; `GetPendingEscalationsAsync` was case-sensitive — an approver cased differently from the roster entry could *decide* escalations but saw an empty pending list. Now single-sourced via new `ApproverNames.Comparer` (used by decide, list, and strategy paths — no site restates the comparer inline).

### 3. Missing `Conflict` failure type
State-machine guard failures (approve/reject/cancel a proposal in the wrong status) used plain `Result.Fail` → opaque 500. Added `ResultFailureType.Conflict` + factories, mapped → **409** in all three failure→HTTP switches (BundleApi `MapFailure`, EvalController, ComplianceController), preserved through `ResultExtensions.PropagateFailure` (without which Map/Bind chains would silently downgrade it to 500), and applied to exactly the four state-conflict guards in the Changes handlers.

## Review process
Two-axis `/code-review` (standards + spec): PASS both axes, spec verified line-by-line including all-callers and all-switches greps. 4-agent `/simplify`: four fixes applied (comparer centralization, cached stateless factory instances, pattern-matching in the ConsoleUI example removing six `!` operators, one stale doc). Deferred follow-up (pre-existing, not this PR): the failure→`Problem()` switch is triplicated across three controllers and ComplianceController lacks a `NotFound` arm — a shared mapper in Presentation.Common is the fix.

## Tests
+~25 assertions across 8 test files: all four decision statuses (incl. AllOf-partial → `DecisionRecorded`), both casing directions (sees pending AND can decide), `Conflict` factories, propagation, and all three wrong-status handler paths now asserting `Conflict`. Full suite 8,122 green; touched-area suites 914/914 after review fixes.

## Notes
- `Presentation.BundleApi.Tests` is missing from `AgenticHarness.slnx` (pre-existing; ran standalone 26/26 green). One-line chore candidate.
- No HTTP endpoints in this PR — those are H1/H2, which this unblocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BnoLcufW278UxA9ssBM1Tc