### PR TITLE
fix: honour RetryPolicy in plan step execution

### DIFF
--- a/src/Content/Domain/Domain.AI/Planner/PlanStep.cs
+++ b/src/Content/Domain/Domain.AI/Planner/PlanStep.cs
@@ -24,7 +24,12 @@ public sealed record PlanStep
     /// <summary>Retry behavior when the step fails.</summary>
     public required RetryPolicy RetryPolicy { get; init; }
 
-    /// <summary>Maximum wall-clock time for this individual step.</summary>
+    /// <summary>
+    /// Maximum wall-clock time for a single execution attempt of this step. Applies PER ATTEMPT:
+    /// every retry granted by <see cref="RetryPolicy"/> receives the full timeout again, so the
+    /// step's worst-case wall clock is (MaxRetries + 1) × Timeout plus backoff delays — all still
+    /// bounded by the plan-level timeout. A timed-out attempt counts against the retry budget.
+    /// </summary>
     public TimeSpan Timeout { get; init; } = TimeSpan.FromSeconds(60);
 
     /// <summary>

--- a/src/Content/Domain/Domain.AI/Planner/RetryPolicy.cs
+++ b/src/Content/Domain/Domain.AI/Planner/RetryPolicy.cs
@@ -6,7 +6,12 @@ namespace Domain.AI.Planner;
 /// </summary>
 public sealed record RetryPolicy
 {
-    /// <summary>Maximum number of retry attempts before invoking <see cref="OnExhausted"/>.</summary>
+    /// <summary>
+    /// Maximum number of automatic retries after the initial attempt before invoking
+    /// <see cref="OnExhausted"/> — a step is executed at most 1 + MaxRetries times. Zero disables
+    /// automatic retry. Failed results, per-attempt timeouts, and unhandled executor exceptions
+    /// all consume this budget; operator-initiated retries do not.
+    /// </summary>
     public int MaxRetries { get; init; } = 3;
 
     /// <summary>Delay before the first retry. Subsequent delays depend on <see cref="Strategy"/>.</summary>

--- a/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.Planner.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.Planner.cs
@@ -1,4 +1,5 @@
 using Application.AI.Common.Interfaces.Attestation;
+using Application.AI.Common.Interfaces.Escalation;
 using Application.AI.Common.Interfaces.Planner;
 using Application.AI.Common.Interfaces.Sandbox;
 using Domain.AI.Planner;
@@ -11,6 +12,8 @@ using Infrastructure.AI.Planner.StepExecutors;
 using Infrastructure.AI.Sandbox;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
 
 namespace Infrastructure.AI;
 
@@ -39,6 +42,12 @@ public static partial class DependencyInjection
     /// </summary>
     private static void RegisterPlannerServices(IServiceCollection services)
     {
+        // TryAddSingleton keeps Infrastructure.AI standalone-safe (the composed hosts already
+        // register TimeProvider.System via Application.Common) while letting tests or hosts that
+        // registered their own clock first win resolution. A plain constructor registration —
+        // rather than a factory with a GetService fallback — keeps PlanExecutor's dependencies
+        // visible to ValidateOnBuild.
+        services.TryAddSingleton(TimeProvider.System);
         services.AddScoped<IPlanExecutor, PlanExecutor>();
         services.AddScoped<IPlanValidator, PlanValidator>();
         services.AddScoped<IPlanGenerator, LlmPlanGeneratorService>();

--- a/src/Content/Infrastructure/Infrastructure.AI/Planner/PlanExecutor.Recovery.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Planner/PlanExecutor.Recovery.cs
@@ -20,6 +20,74 @@ public sealed partial class PlanExecutor
     /// and by the escalate failure-recovery branch below.
     /// </summary>
     private const string EscalationIdProperty = "escalationId";
+
+    /// <summary>
+    /// Exponent cap for exponential backoff. Prevents a pathological
+    /// <see cref="RetryPolicy.MaxRetries"/> configuration from overflowing
+    /// <see cref="TimeSpan"/> arithmetic (2^20 × InitialDelay is already far beyond any
+    /// realistic plan timeout).
+    /// </summary>
+    private const int MaxBackoffExponent = 20;
+
+    /// <summary>
+    /// Marks a step Failed after its retry budget is exhausted and fires the
+    /// <see cref="RetryPolicy.OnExhausted"/> recovery action. This — and only this — is where
+    /// exhausted failures (Failed results, per-attempt timeouts, and unhandled executor
+    /// exceptions alike) route into <see cref="HandleStepFailureAsync"/>, so all three failure
+    /// modes honour the same FailStep/SkipStep/FailPlan/Escalate policy.
+    /// </summary>
+    private async Task FailExhaustedStepAsync(PlanStep step, StepAttemptOutcome outcome, PlanExecutionRuntime ctx, CancellationToken ct)
+    {
+        await TransitionStepAsync(ctx.PlanId, step.Id, StepExecutionStatus.Failed, ctx.StepStates, ct, errorMessage: outcome.ErrorMessage);
+        await HandleStepFailureAsync(step, outcome.ErrorMessage, ctx, ct);
+
+        // Completed-notification carries the executor's own result when one exists (a Failed
+        // result); timeout/exception attempts produce no result and — as before this retry loop
+        // existed — no step-completed notification, only the state-update transitions.
+        if (outcome.Result is not null)
+            await _notifier.NotifyStepCompletedAsync(ctx.PlanId, step.Id, StepExecutionStatus.Failed, outcome.Result.Duration, outcome.Result.Output, ct);
+    }
+
+    /// <summary>
+    /// Whether the step still has automatic retry budget after <paramref name="attemptsMade"/>
+    /// attempts. <see cref="RetryPolicy.MaxRetries"/> counts retries, not attempts: a step is
+    /// allowed 1 + MaxRetries total attempts, so the default (3) runs a step at most 4 times and
+    /// MaxRetries = 0 means a single attempt with no automatic retry.
+    /// </summary>
+    private static bool ShouldRetry(RetryPolicy policy, int attemptsMade)
+        => attemptsMade <= policy.MaxRetries;
+
+    /// <summary>
+    /// Computes the backoff delay before the retry that follows failed attempt number
+    /// <paramref name="attemptsMade"/> (1-based). The first retry always waits
+    /// <see cref="RetryPolicy.InitialDelay"/>; later delays scale by
+    /// <see cref="RetryPolicy.Strategy"/>: Fixed stays constant, Linear multiplies by the attempt
+    /// number, Exponential doubles each attempt (exponent capped at
+    /// <see cref="MaxBackoffExponent"/> to avoid <see cref="TimeSpan"/> overflow).
+    /// Internal for direct unit testing of the delay ladder.
+    /// </summary>
+    internal static TimeSpan ComputeBackoffDelay(RetryPolicy policy, int attemptsMade)
+        => policy.Strategy switch
+        {
+            BackoffStrategy.Fixed => policy.InitialDelay,
+            BackoffStrategy.Linear => policy.InitialDelay * attemptsMade,
+            BackoffStrategy.Exponential => policy.InitialDelay * Math.Pow(2, Math.Min(attemptsMade - 1, MaxBackoffExponent)),
+            _ => policy.InitialDelay
+        };
+
+    /// <summary>
+    /// Waits the computed backoff delay on the injected <see cref="TimeProvider"/> (so tests can
+    /// drive it with a fake clock instead of sleeping real seconds). Honours
+    /// <paramref name="ct"/>: plan-level cancellation or plan timeout aborts the wait
+    /// immediately, and a cancelled backoff never starts another attempt.
+    /// </summary>
+    private Task DelayBeforeRetryAsync(RetryPolicy policy, int attemptsMade, CancellationToken ct)
+        => Task.Delay(ComputeBackoffDelay(policy, attemptsMade), _timeProvider, ct);
+
+    /// <summary>
+    /// Applies the step's <see cref="RetryPolicy.OnExhausted"/> recovery action. Invoked only
+    /// after the automatic retry budget is exhausted (see <see cref="FailExhaustedStepAsync"/>).
+    /// </summary>
     private async Task HandleStepFailureAsync(PlanStep step, string? errorMessage, PlanExecutionRuntime ctx, CancellationToken ct)
     {
         switch (step.RetryPolicy.OnExhausted)

--- a/src/Content/Infrastructure/Infrastructure.AI/Planner/PlanExecutor.Scheduling.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Planner/PlanExecutor.Scheduling.cs
@@ -60,45 +60,22 @@ public sealed partial class PlanExecutor
 
         try
         {
-            await TransitionStepAsync(ctx.PlanId, step.Id, StepExecutionStatus.Running, ctx.StepStates, ct);
-            await _notifier.NotifyStepStartedAsync(ctx.PlanId, step.Id, step.Name, step.Type, ct);
-
-            var executor = _serviceProvider.GetRequiredKeyedService<IPlanStepExecutor>(step.Type);
-            var upstreamOutputs = GetUpstreamOutputs(step.Id, ctx.DependencyMap, ctx.StepOutputs);
-
-            using var stepCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
-            stepCts.CancelAfter(step.Timeout);
-
-            var stepSw = Stopwatch.StartNew();
-            var result = await executor.ExecuteAsync(step, upstreamOutputs, stepCts.Token);
-            stepSw.Stop();
-
-            StepDurationHistogram.Record(stepSw.Elapsed.TotalMilliseconds,
-                new KeyValuePair<string, object?>("type", step.Type.ToString()));
-
-            await HandleStepResultAsync(step, result, ctx, ct);
-
-            StepExecutionsCounter.Add(1,
-                new KeyValuePair<string, object?>("type", step.Type.ToString()),
-                new KeyValuePair<string, object?>("status", result.Status.ToString()));
-
-            await _notifier.NotifyStepCompletedAsync(ctx.PlanId, step.Id, result.Status, result.Duration, result.Output, ct);
-        }
-        catch (OperationCanceledException) when (!ct.IsCancellationRequested)
-        {
-            await TransitionStepAsync(ctx.PlanId, step.Id, StepExecutionStatus.Failed, ctx.StepStates, ct, errorMessage: "Step timeout exceeded");
-            await SkipDownstreamSubgraphAsync(step.Id, ctx);
-            StepExecutionsCounter.Add(1,
-                new KeyValuePair<string, object?>("type", step.Type.ToString()),
-                new KeyValuePair<string, object?>("status", "timeout"));
+            await RunStepWithRetriesAsync(step, ctx, ct);
         }
         catch (OperationCanceledException)
         {
+            // Plan-level cancellation (caller token or plan timeout) — deliberately NOT retryable.
+            // Per-attempt timeouts never surface here: ExecuteSingleAttemptAsync converts them into
+            // failed attempts, so an OperationCanceledException at this level always means the
+            // whole plan is being torn down (including cancellation during a backoff delay).
             await TransitionStepAsync(ctx.PlanId, step.Id, StepExecutionStatus.Failed, ctx.StepStates, CancellationToken.None, errorMessage: "Cancelled");
             throw;
         }
         catch (Exception ex)
         {
+            // Non-attempt infrastructure failure (executor resolution, state persistence,
+            // notification). Attempt-level executor exceptions are consumed by the retry loop, so
+            // anything reaching here is outside the retry budget: fail the step and skip downstream.
             _logger.LogError(ex, "Unhandled exception executing step {StepId} in plan {PlanId}", step.Id, ctx.PlanId);
             await TransitionStepAsync(ctx.PlanId, step.Id, StepExecutionStatus.Failed, ctx.StepStates, ct, errorMessage: ex.Message);
             await SkipDownstreamSubgraphAsync(step.Id, ctx);
@@ -109,6 +86,140 @@ public sealed partial class PlanExecutor
         }
     }
 
+    /// <summary>
+    /// Drives the attempt/retry loop for a single step, honouring its <see cref="RetryPolicy"/>.
+    /// Each failed attempt — a <see cref="StepExecutionStatus.Failed"/> result, a per-attempt
+    /// timeout, or an unhandled executor exception — consumes one unit of the
+    /// <see cref="RetryPolicy.MaxRetries"/> budget; the next attempt starts after the backoff
+    /// delay dictated by <see cref="RetryPolicy.Strategy"/>. Only when the budget is exhausted
+    /// does the step transition to Failed and its <see cref="RetryPolicy.OnExhausted"/> recovery
+    /// fire. A <see cref="StepExecutionStatus.Blocked"/> result (human gate) is a park, not a
+    /// failure, and is never retried.
+    /// </summary>
+    /// <remarks>
+    /// The retry budget is tracked through the persisted <see cref="StepExecutionState.AttemptCount"/>,
+    /// which increments on every Running transition — so attempts made before a crash count after
+    /// resume, and each re-attempt is checkpointed before it executes (at-least-once semantics per
+    /// <see cref="IPlanStepExecutor.ExecuteAsync"/>). Step-started is notified once per scheduling
+    /// pass; individual retry attempts surface through the Running-transition state updates.
+    /// </remarks>
+    private async Task RunStepWithRetriesAsync(PlanStep step, PlanExecutionRuntime ctx, CancellationToken ct)
+    {
+        var executor = _serviceProvider.GetRequiredKeyedService<IPlanStepExecutor>(step.Type);
+        var upstreamOutputs = GetUpstreamOutputs(step.Id, ctx.DependencyMap, ctx.StepOutputs);
+        var firstIteration = true;
+
+        while (true)
+        {
+            // Each attempt transitions to Running, which increments and persists AttemptCount —
+            // checkpoint/resume therefore never loses retry progress.
+            await TransitionStepAsync(ctx.PlanId, step.Id, StepExecutionStatus.Running, ctx.StepStates, ct);
+            if (firstIteration)
+            {
+                await _notifier.NotifyStepStartedAsync(ctx.PlanId, step.Id, step.Name, step.Type, ct);
+                firstIteration = false;
+            }
+
+            var attemptsMade = ctx.StepStates[step.Id].AttemptCount;
+            var outcome = await ExecuteSingleAttemptAsync(step, executor, upstreamOutputs, ctx, ct);
+
+            if (outcome.Result is not null && outcome.Result.Status != StepExecutionStatus.Failed)
+            {
+                await HandleStepResultAsync(step, outcome.Result, ctx, ct);
+                await _notifier.NotifyStepCompletedAsync(ctx.PlanId, step.Id, outcome.Result.Status, outcome.Result.Duration, outcome.Result.Output, ct);
+                return;
+            }
+
+            if (ShouldRetry(step.RetryPolicy, attemptsMade))
+            {
+                _logger.LogWarning(
+                    "Step {StepId} in plan {PlanId} failed attempt {Attempt} of {MaxAttempts} ({Error}); retrying after backoff",
+                    step.Id, ctx.PlanId, attemptsMade, step.RetryPolicy.MaxRetries + 1, outcome.ErrorMessage);
+                await DelayBeforeRetryAsync(step.RetryPolicy, attemptsMade, ct);
+                continue;
+            }
+
+            await FailExhaustedStepAsync(step, outcome, ctx, ct);
+            return;
+        }
+    }
+
+    /// <summary>
+    /// Executes one attempt of a step under its per-attempt timeout and converts every retryable
+    /// failure mode into a <see cref="StepAttemptOutcome"/> instead of an exception. The step
+    /// <see cref="PlanStep.Timeout"/> applies PER ATTEMPT — every retry gets the full timeout
+    /// budget again, so a step's worst-case wall clock is (MaxRetries + 1) × Timeout plus backoff
+    /// delays, all still bounded by the plan-level timeout carried on <paramref name="ct"/>.
+    /// Plan-level cancellation is rethrown untouched (never retryable).
+    /// </summary>
+    private async Task<StepAttemptOutcome> ExecuteSingleAttemptAsync(
+        PlanStep step,
+        IPlanStepExecutor executor,
+        IReadOnlyDictionary<PlanStepId, string> upstreamOutputs,
+        PlanExecutionRuntime ctx,
+        CancellationToken ct)
+    {
+        using var stepCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        stepCts.CancelAfter(step.Timeout);
+
+        try
+        {
+            var stepSw = Stopwatch.StartNew();
+            var result = await executor.ExecuteAsync(step, upstreamOutputs, stepCts.Token);
+            stepSw.Stop();
+
+            StepDurationHistogram.Record(stepSw.Elapsed.TotalMilliseconds,
+                new KeyValuePair<string, object?>("type", step.Type.ToString()));
+            StepExecutionsCounter.Add(1,
+                new KeyValuePair<string, object?>("type", step.Type.ToString()),
+                new KeyValuePair<string, object?>("status", result.Status.ToString()));
+
+            return new StepAttemptOutcome(result, SynthesizedError: null);
+        }
+        catch (OperationCanceledException) when (!ct.IsCancellationRequested)
+        {
+            // Per-attempt timeout — counts as a failed, retryable attempt.
+            StepExecutionsCounter.Add(1,
+                new KeyValuePair<string, object?>("type", step.Type.ToString()),
+                new KeyValuePair<string, object?>("status", "timeout"));
+            return new StepAttemptOutcome(null, "Step timeout exceeded");
+        }
+        catch (OperationCanceledException)
+        {
+            // Plan-level cancellation — never retried; handled by ExecuteStepAsync.
+            throw;
+        }
+        catch (Exception ex)
+        {
+            // Unhandled executor exception — counts as a failed, retryable attempt.
+            _logger.LogError(ex, "Unhandled exception executing step {StepId} in plan {PlanId} (attempt will consume retry budget)", step.Id, ctx.PlanId);
+            return new StepAttemptOutcome(null, ex.Message);
+        }
+    }
+
+    /// <summary>
+    /// Outcome of a single execution attempt: either the executor's result, or — when
+    /// <see cref="Result"/> is null — a synthesized error for a per-attempt timeout or an
+    /// unhandled executor exception. Both null-result shapes and a Failed result are retryable.
+    /// </summary>
+    /// <summary>
+    /// The outcome of one step attempt: the executor's result when it produced one, or a
+    /// synthesized error for attempts that never returned (timeout, unhandled exception).
+    /// <see cref="ErrorMessage"/> derives from whichever is present, so there is a single
+    /// source of truth for the failure text.
+    /// </summary>
+    private sealed record StepAttemptOutcome(StepExecutionResult? Result, string? SynthesizedError)
+    {
+        /// <summary>The attempt's failure text: the executor's own error, else the synthesized one.</summary>
+        public string? ErrorMessage => Result?.ErrorMessage ?? SynthesizedError;
+    }
+
+    /// <summary>
+    /// Applies a successful (non-failure) attempt result: Completed steps propagate output and
+    /// release downstream, Blocked steps are parked. Failure routing deliberately does NOT pass
+    /// through here — it lives in the retry loop (<see cref="RunStepWithRetriesAsync"/>) so that
+    /// <see cref="RetryPolicy.OnExhausted"/> fires only after the retry budget is spent.
+    /// </summary>
     private async Task HandleStepResultAsync(PlanStep step, StepExecutionResult result, PlanExecutionRuntime ctx, CancellationToken ct)
     {
         switch (result.Status)
@@ -130,11 +241,6 @@ public sealed partial class PlanExecutor
                 // (ReconcileBlockedStepsAsync) reads back to correlate the parked step to its
                 // escalation. Dropping it here would strand the step permanently in Blocked.
                 await TransitionStepAsync(ctx.PlanId, step.Id, StepExecutionStatus.Blocked, ctx.StepStates, ct, output: result.Output);
-                break;
-
-            case StepExecutionStatus.Failed:
-                await TransitionStepAsync(ctx.PlanId, step.Id, StepExecutionStatus.Failed, ctx.StepStates, ct, errorMessage: result.ErrorMessage);
-                await HandleStepFailureAsync(step, result.ErrorMessage, ctx, ct);
                 break;
         }
     }

--- a/src/Content/Infrastructure/Infrastructure.AI/Planner/PlanExecutor.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Planner/PlanExecutor.cs
@@ -39,14 +39,26 @@ public sealed partial class PlanExecutor : IPlanExecutor
     private readonly IPlanProgressNotifier _notifier;
     private readonly IEscalationService _escalationService;
     private readonly IServiceProvider _serviceProvider;
+    private readonly TimeProvider _timeProvider;
     private readonly ILogger<PlanExecutor> _logger;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PlanExecutor"/> class.
+    /// </summary>
+    /// <param name="validator">Validates plan structure before execution.</param>
+    /// <param name="stateStore">Persists plan and step execution state for checkpoint/resume.</param>
+    /// <param name="notifier">Receives plan and step lifecycle notifications.</param>
+    /// <param name="escalationService">Resolves human-gate and escalate-on-failure outcomes.</param>
+    /// <param name="serviceProvider">Resolves keyed step executors by <see cref="StepType"/>.</param>
+    /// <param name="timeProvider">Clock used for retry backoff delays; injectable for tests.</param>
+    /// <param name="logger">Structured logger for execution auditing.</param>
     public PlanExecutor(
         IPlanValidator validator,
         IPlanStateStore stateStore,
         IPlanProgressNotifier notifier,
         IEscalationService escalationService,
         IServiceProvider serviceProvider,
+        TimeProvider timeProvider,
         ILogger<PlanExecutor> logger)
     {
         _validator = validator;
@@ -54,6 +66,7 @@ public sealed partial class PlanExecutor : IPlanExecutor
         _notifier = notifier;
         _escalationService = escalationService;
         _serviceProvider = serviceProvider;
+        _timeProvider = timeProvider;
         _logger = logger;
     }
 
@@ -148,6 +161,25 @@ public sealed partial class PlanExecutor : IPlanExecutor
         }
     }
 
+    /// <summary>
+    /// Operator-initiated retry of a failed step: resets it to <see cref="StepExecutionStatus.Pending"/>
+    /// so the next <see cref="ExecuteAsync(PlanId, CancellationToken)"/> re-runs it.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>Deliberately unbounded.</b> This method does NOT consult
+    /// <see cref="RetryPolicy.MaxRetries"/> — that budget governs only the executor's automatic
+    /// in-run retries. A human operator explicitly re-arming a failed step is an intentional
+    /// override, so the number of manual retries is not capped.
+    /// </para>
+    /// <para>
+    /// The step's <see cref="StepExecutionState.AttemptCount"/> is preserved across the reset, so
+    /// the automatic retry budget stays spent: the re-run executes once and, if it fails again,
+    /// goes straight back through <see cref="RetryPolicy.OnExhausted"/> rather than restarting
+    /// the backoff ladder. Each execution remains subject to at-least-once semantics — see
+    /// <see cref="IPlanStepExecutor.ExecuteAsync"/>.
+    /// </para>
+    /// </remarks>
     public async Task<Result> RetryStepAsync(PlanId planId, PlanStepId stepId, CancellationToken ct)
     {
         _logger.LogInformation("Retry requested for step {StepId} in plan {PlanId}", stepId, planId);

--- a/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlanExecutorHumanGateLifecycleTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlanExecutorHumanGateLifecycleTests.cs
@@ -284,6 +284,7 @@ public sealed class PlanExecutorHumanGateLifecycleTests : IDisposable
             _notifier.Object,
             _escalation.Object,
             provider,
+            TimeProvider.System,
             NullLogger<PlanExecutor>.Instance);
     }
 
@@ -304,6 +305,7 @@ public sealed class PlanExecutorHumanGateLifecycleTests : IDisposable
             _notifier.Object,
             _escalation.Object,
             provider,
+            TimeProvider.System,
             NullLogger<PlanExecutor>.Instance);
     }
 

--- a/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlanExecutorResumeRecoveryTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlanExecutorResumeRecoveryTests.cs
@@ -193,6 +193,7 @@ public sealed class PlanExecutorResumeRecoveryTests : IDisposable
             _notifier.Object,
             _escalation.Object,
             provider,
+            TimeProvider.System,
             NullLogger<PlanExecutor>.Instance);
     }
 

--- a/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlanExecutorRetryPolicyTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlanExecutorRetryPolicyTests.cs
@@ -1,0 +1,467 @@
+using Application.AI.Common.Interfaces.Escalation;
+using Application.AI.Common.Interfaces.Planner;
+using Domain.AI.Planner;
+using Domain.Common;
+using Infrastructure.AI.Planner;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Time.Testing;
+using Moq;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Planner;
+
+/// <summary>
+/// Covers automatic retry of failed plan steps per <see cref="RetryPolicy"/>: budget consumption,
+/// backoff computation and scheduling on the injected <see cref="TimeProvider"/>, exhaustion
+/// routing into <see cref="RetryPolicy.OnExhausted"/>, timeout/exception retryability,
+/// cancellation during backoff, and the exclusion of Blocked (human gate) results from retry.
+/// </summary>
+public sealed class PlanExecutorRetryPolicyTests : IDisposable
+{
+    private readonly Mock<IPlanValidator> _validator = new();
+    private readonly Mock<IPlanStateStore> _stateStore = new();
+    private readonly Mock<IPlanProgressNotifier> _notifier = new();
+    private readonly Mock<IEscalationService> _escalation = new();
+    private readonly ServiceCollection _services = new();
+    private readonly FakeTimeProvider _time = new(new DateTimeOffset(2026, 7, 27, 12, 0, 0, TimeSpan.Zero));
+    private ServiceProvider? _serviceProvider;
+
+    public PlanExecutorRetryPolicyTests()
+    {
+        _validator.Setup(v => v.ValidateAsync(It.IsAny<PlanGraph>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<PlanValidationResult>.Success(new PlanValidationResult { IsValid = true }));
+
+        _notifier.Setup(n => n.NotifyPlanStartedAsync(It.IsAny<PlanId>(), It.IsAny<string>(), It.IsAny<PlanGraph>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        _notifier.Setup(n => n.NotifyStepStartedAsync(It.IsAny<PlanId>(), It.IsAny<PlanStepId>(), It.IsAny<string>(), It.IsAny<StepType>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        _notifier.Setup(n => n.NotifyStepCompletedAsync(It.IsAny<PlanId>(), It.IsAny<PlanStepId>(), It.IsAny<StepExecutionStatus>(), It.IsAny<TimeSpan>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        _notifier.Setup(n => n.NotifyStateUpdateAsync(It.IsAny<PlanId>(), It.IsAny<PlanStepId>(), It.IsAny<StepExecutionStatus>(), It.IsAny<StepExecutionStatus>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        _notifier.Setup(n => n.NotifyPlanCompletedAsync(It.IsAny<PlanId>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        _notifier.Setup(n => n.NotifyPlanFailedAsync(It.IsAny<PlanId>(), It.IsAny<PlanStepId>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _stateStore.Setup(s => s.UpdateStepStateAsync(It.IsAny<StepExecutionState>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Success());
+        _stateStore.Setup(s => s.ResumeAsync(It.IsAny<PlanId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<IReadOnlyDictionary<PlanStepId, StepExecutionState>>.Success(
+                new Dictionary<PlanStepId, StepExecutionState>()));
+    }
+
+    public void Dispose() => _serviceProvider?.Dispose();
+
+    // === Retry budget & OnExhausted ===
+
+    [Fact]
+    public async Task Execute_FailingStep_RetriedUpToMaxRetriesThenOnExhaustedFires()
+    {
+        var flaky = Step("flaky", new RetryPolicy
+        {
+            MaxRetries = 2,
+            InitialDelay = TimeSpan.Zero,
+            Strategy = BackoffStrategy.Fixed,
+            OnExhausted = ErrorRecovery.SkipStep
+        });
+        var down = Step("down", NoRetry());
+        var plan = LinearPlan(flaky, down);
+        SetupPlanLoad(plan);
+
+        var flakyInvocations = 0;
+        var downInvocations = 0;
+        RegisterExecutor(StepType.LlmCall, (s, _, _) =>
+        {
+            if (s.Id == flaky.Id)
+            {
+                Interlocked.Increment(ref flakyInvocations);
+                return Task.FromResult(FailedResult());
+            }
+
+            Interlocked.Increment(ref downInvocations);
+            return Task.FromResult(CompletedResult());
+        });
+        var sut = CreateSut();
+
+        var result = await sut.ExecuteAsync(plan.Id, CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(3, flakyInvocations); // 1 initial attempt + MaxRetries(2) retries
+        var flakyState = result.Value!.StepStates.Single(s => s.StepId == flaky.Id);
+        // OnExhausted (SkipStep) fired exactly once, only after the budget was spent.
+        Assert.Equal(StepExecutionStatus.Skipped, flakyState.Status);
+        Assert.Equal(3, flakyState.AttemptCount);
+        Assert.Equal(1, downInvocations); // SkipStep released the downstream step
+    }
+
+    [Fact]
+    public async Task Execute_FailsOnceThenSucceeds_CompletedWithAttemptCountTwo()
+    {
+        var step = Step("recovers", new RetryPolicy { MaxRetries = 3, InitialDelay = TimeSpan.Zero });
+        var plan = SinglePlan(step);
+        SetupPlanLoad(plan);
+
+        var invocations = 0;
+        RegisterExecutor(StepType.LlmCall, (_, _, _) =>
+        {
+            var n = Interlocked.Increment(ref invocations);
+            return Task.FromResult(n == 1 ? FailedResult() : CompletedResult("second-time-lucky"));
+        });
+        var sut = CreateSut();
+
+        var result = await sut.ExecuteAsync(plan.Id, CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(2, invocations);
+        var state = result.Value!.StepStates.Single();
+        Assert.Equal(StepExecutionStatus.Completed, state.Status);
+        Assert.Equal(2, state.AttemptCount);
+        Assert.Equal("second-time-lucky", state.Output);
+    }
+
+    [Fact]
+    public async Task Execute_MaxRetriesZero_SingleAttemptThenImmediateOnExhausted()
+    {
+        var failing = Step("fails", NoRetry()); // OnExhausted defaults to FailStep
+        var down = Step("down", NoRetry());
+        var plan = LinearPlan(failing, down);
+        SetupPlanLoad(plan);
+
+        var invocations = 0;
+        RegisterExecutor(StepType.LlmCall, (s, _, _) =>
+        {
+            if (s.Id == failing.Id)
+            {
+                Interlocked.Increment(ref invocations);
+                return Task.FromResult(FailedResult());
+            }
+
+            return Task.FromResult(CompletedResult());
+        });
+        var sut = CreateSut();
+
+        var result = await sut.ExecuteAsync(plan.Id, CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(1, invocations);
+        var failingState = result.Value!.StepStates.Single(s => s.StepId == failing.Id);
+        Assert.Equal(StepExecutionStatus.Failed, failingState.Status);
+        Assert.Equal(1, failingState.AttemptCount);
+        // FailStep skipped the downstream subgraph — no retry could have resurrected it.
+        var downState = result.Value.StepStates.Single(s => s.StepId == down.Id);
+        Assert.Equal(StepExecutionStatus.Skipped, downState.Status);
+    }
+
+    [Fact]
+    public async Task Execute_ExecutorThrows_ExceptionCountsAsRetryableAttempt()
+    {
+        var step = Step("throws-once", new RetryPolicy { MaxRetries = 1, InitialDelay = TimeSpan.Zero });
+        var plan = SinglePlan(step);
+        SetupPlanLoad(plan);
+
+        var invocations = 0;
+        RegisterExecutor(StepType.LlmCall, (_, _, _) =>
+        {
+            var n = Interlocked.Increment(ref invocations);
+            if (n == 1)
+                throw new InvalidOperationException("transient explosion");
+            return Task.FromResult(CompletedResult());
+        });
+        var sut = CreateSut();
+
+        var result = await sut.ExecuteAsync(plan.Id, CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(2, invocations);
+        var state = result.Value!.StepStates.Single();
+        Assert.Equal(StepExecutionStatus.Completed, state.Status);
+        Assert.Equal(2, state.AttemptCount);
+    }
+
+    // === Timeout interaction ===
+
+    [Fact]
+    public async Task Execute_AttemptTimesOut_TimeoutCountsAsRetryableAttempt()
+    {
+        // Per-attempt timeout: the first attempt hangs and is cancelled at 200 ms; the retry gets
+        // the full timeout budget again and completes.
+        var step = Step("timeouty", new RetryPolicy { MaxRetries = 1, InitialDelay = TimeSpan.Zero },
+            timeout: TimeSpan.FromMilliseconds(200));
+        var plan = SinglePlan(step);
+        SetupPlanLoad(plan);
+
+        var invocations = 0;
+        RegisterExecutor(StepType.LlmCall, async (_, _, ct) =>
+        {
+            var n = Interlocked.Increment(ref invocations);
+            if (n == 1)
+                await Task.Delay(Timeout.InfiniteTimeSpan, ct); // hangs until the per-attempt timeout fires
+            return CompletedResult();
+        });
+        var sut = CreateSut();
+
+        var result = await sut.ExecuteAsync(plan.Id, CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(2, invocations);
+        var state = result.Value!.StepStates.Single();
+        Assert.Equal(StepExecutionStatus.Completed, state.Status);
+        Assert.Equal(2, state.AttemptCount);
+    }
+
+    // === Blocked (human gate) is not a failure ===
+
+    [Fact]
+    public async Task Execute_HumanGateBlocked_NotRetried()
+    {
+        var gate = Step("gate", new RetryPolicy { MaxRetries = 3, InitialDelay = TimeSpan.Zero }, StepType.HumanGate);
+        var plan = SinglePlan(gate);
+        SetupPlanLoad(plan);
+
+        var invocations = 0;
+        RegisterExecutor(StepType.HumanGate, (_, _, _) =>
+        {
+            Interlocked.Increment(ref invocations);
+            return Task.FromResult(new StepExecutionResult
+            {
+                Status = StepExecutionStatus.Blocked,
+                Output = $$"""{"escalationId":"{{Guid.NewGuid()}}"}""",
+                Duration = TimeSpan.FromMilliseconds(1)
+            });
+        });
+        var sut = CreateSut();
+
+        var result = await sut.ExecuteAsync(plan.Id, CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(1, invocations); // Blocked is a park, never a retryable failure
+        var state = result.Value!.StepStates.Single();
+        Assert.Equal(StepExecutionStatus.Blocked, state.Status);
+        Assert.Equal(1, state.AttemptCount);
+    }
+
+    // === Backoff computation (pure) ===
+
+    [Theory]
+    [InlineData(1, 1)]
+    [InlineData(2, 2)]
+    [InlineData(3, 4)]
+    [InlineData(4, 8)]
+    public void ComputeBackoffDelay_Exponential_DoublesPerAttempt(int attemptsMade, int expectedSeconds)
+    {
+        var policy = new RetryPolicy { InitialDelay = TimeSpan.FromSeconds(1), Strategy = BackoffStrategy.Exponential };
+
+        var delay = PlanExecutor.ComputeBackoffDelay(policy, attemptsMade);
+
+        Assert.Equal(TimeSpan.FromSeconds(expectedSeconds), delay);
+    }
+
+    [Theory]
+    [InlineData(1, 1)]
+    [InlineData(2, 2)]
+    [InlineData(3, 3)]
+    public void ComputeBackoffDelay_Linear_ScalesWithAttemptNumber(int attemptsMade, int expectedSeconds)
+    {
+        var policy = new RetryPolicy { InitialDelay = TimeSpan.FromSeconds(1), Strategy = BackoffStrategy.Linear };
+
+        var delay = PlanExecutor.ComputeBackoffDelay(policy, attemptsMade);
+
+        Assert.Equal(TimeSpan.FromSeconds(expectedSeconds), delay);
+    }
+
+    [Fact]
+    public void ComputeBackoffDelay_Fixed_ConstantAcrossAttempts()
+    {
+        var policy = new RetryPolicy { InitialDelay = TimeSpan.FromSeconds(7), Strategy = BackoffStrategy.Fixed };
+
+        Assert.Equal(TimeSpan.FromSeconds(7), PlanExecutor.ComputeBackoffDelay(policy, 1));
+        Assert.Equal(TimeSpan.FromSeconds(7), PlanExecutor.ComputeBackoffDelay(policy, 5));
+    }
+
+    [Fact]
+    public void ComputeBackoffDelay_Exponential_ExponentCappedToAvoidOverflow()
+    {
+        var policy = new RetryPolicy { InitialDelay = TimeSpan.FromMilliseconds(1), Strategy = BackoffStrategy.Exponential };
+
+        // Attempt 100 would be 2^99 without the cap; the ladder plateaus at 2^20.
+        var delay = PlanExecutor.ComputeBackoffDelay(policy, 100);
+
+        Assert.Equal(TimeSpan.FromMilliseconds(1) * Math.Pow(2, 20), delay);
+    }
+
+    // === Backoff scheduling on the TimeProvider ===
+
+    [Fact]
+    public async Task Execute_RetryWaitsBackoffDelay_OnInjectedTimeProvider()
+    {
+        var step = Step("slow-retry", new RetryPolicy
+        {
+            MaxRetries = 1,
+            InitialDelay = TimeSpan.FromMinutes(5),
+            Strategy = BackoffStrategy.Fixed
+        });
+        var plan = SinglePlan(step, planTimeout: TimeSpan.FromMinutes(30));
+        SetupPlanLoad(plan);
+
+        var invocations = 0;
+        RegisterExecutor(StepType.LlmCall, (_, _, _) =>
+        {
+            var n = Interlocked.Increment(ref invocations);
+            return Task.FromResult(n == 1 ? FailedResult() : CompletedResult());
+        });
+        var sut = CreateSut();
+
+        var task = sut.ExecuteAsync(plan.Id, CancellationToken.None);
+        await WaitUntilAsync(() => Volatile.Read(ref invocations) == 1);
+        await Task.Delay(100); // real yield: let the retry loop reach the backoff await
+
+        // Clock frozen — the retry must not run.
+        Assert.Equal(1, Volatile.Read(ref invocations));
+        Assert.False(task.IsCompleted);
+
+        // Advance fake time in 1-minute steps; the retry may fire no earlier than the 5-minute
+        // backoff, so at least 5 advances are required.
+        var advanced = TimeSpan.Zero;
+        while (Volatile.Read(ref invocations) < 2 && advanced < TimeSpan.FromMinutes(20))
+        {
+            _time.Advance(TimeSpan.FromMinutes(1));
+            advanced += TimeSpan.FromMinutes(1);
+            await Task.Delay(10);
+        }
+
+        Assert.Equal(2, Volatile.Read(ref invocations));
+        Assert.True(advanced >= TimeSpan.FromMinutes(5), $"retry fired after only {advanced} of fake time");
+
+        var result = await task;
+        Assert.Equal(StepExecutionStatus.Completed, result.Value!.StepStates.Single().Status);
+    }
+
+    [Fact]
+    public async Task Execute_CancelledDuringBackoffDelay_AbortsWithoutFurtherAttempts()
+    {
+        var step = Step("cancelled-mid-backoff", new RetryPolicy
+        {
+            MaxRetries = 5,
+            InitialDelay = TimeSpan.FromHours(1),
+            Strategy = BackoffStrategy.Fixed
+        });
+        var plan = SinglePlan(step, planTimeout: TimeSpan.FromHours(2));
+        SetupPlanLoad(plan);
+
+        var invocations = 0;
+        RegisterExecutor(StepType.LlmCall, (_, _, _) =>
+        {
+            Interlocked.Increment(ref invocations);
+            return Task.FromResult(FailedResult());
+        });
+        var sut = CreateSut();
+
+        using var cts = new CancellationTokenSource();
+        var task = sut.ExecuteAsync(plan.Id, cts.Token);
+        await WaitUntilAsync(() => Volatile.Read(ref invocations) == 1);
+        await Task.Delay(100); // real yield: let the retry loop reach the backoff await
+
+        cts.Cancel();
+
+        // Cancellation must abort the (1-hour, fake-clock) backoff promptly without a new attempt.
+        var result = await task.WaitAsync(TimeSpan.FromSeconds(10));
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(1, Volatile.Read(ref invocations));
+        var state = result.Value!.StepStates.Single();
+        Assert.Equal(StepExecutionStatus.Failed, state.Status);
+        Assert.Equal(1, state.AttemptCount);
+        Assert.Equal("Cancelled", state.ErrorMessage);
+    }
+
+    // === Harness ===
+
+    private PlanExecutor CreateSut()
+    {
+        _serviceProvider = _services.BuildServiceProvider();
+        return new PlanExecutor(
+            _validator.Object,
+            _stateStore.Object,
+            _notifier.Object,
+            _escalation.Object,
+            _serviceProvider,
+            _time,
+            NullLogger<PlanExecutor>.Instance);
+    }
+
+    private void RegisterExecutor(
+        StepType type,
+        Func<PlanStep, IReadOnlyDictionary<PlanStepId, string>, CancellationToken, Task<StepExecutionResult>> handler)
+    {
+        var mock = new Mock<IPlanStepExecutor>();
+        mock.Setup(e => e.ExecuteAsync(It.IsAny<PlanStep>(), It.IsAny<IReadOnlyDictionary<PlanStepId, string>>(), It.IsAny<CancellationToken>()))
+            .Returns<PlanStep, IReadOnlyDictionary<PlanStepId, string>, CancellationToken>(handler);
+        _services.AddKeyedSingleton<IPlanStepExecutor>(type, mock.Object);
+    }
+
+    private void SetupPlanLoad(PlanGraph plan)
+        => _stateStore.Setup(s => s.LoadPlanAsync(plan.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<PlanGraph?>.Success(plan));
+
+    private static RetryPolicy NoRetry() => new() { MaxRetries = 0, InitialDelay = TimeSpan.Zero };
+
+    private static PlanStep Step(string name, RetryPolicy retry, StepType type = StepType.LlmCall, TimeSpan? timeout = null) => new()
+    {
+        Id = PlanStepId.New(),
+        Name = name,
+        Type = type,
+        Configuration = type == StepType.HumanGate
+            ? new HumanGateConfig
+            {
+                EscalationMessage = "approve me",
+                ApprovalStrategy = ApprovalStrategy.AnyOf,
+                Approvers = ["supervisor"]
+            }
+            : new LlmCallConfig { SystemPrompt = "test", ModelDeploymentKey = "gpt-4" },
+        RetryPolicy = retry,
+        Timeout = timeout ?? TimeSpan.FromSeconds(30)
+    };
+
+    private static PlanGraph SinglePlan(PlanStep step, TimeSpan? planTimeout = null) => new()
+    {
+        Id = PlanId.New(),
+        Name = "retry-plan",
+        Steps = [step],
+        Edges = [],
+        Configuration = new PlanConfiguration { PlanTimeout = planTimeout ?? TimeSpan.FromSeconds(30) }
+    };
+
+    private static PlanGraph LinearPlan(PlanStep first, PlanStep second) => new()
+    {
+        Id = PlanId.New(),
+        Name = "retry-linear-plan",
+        Steps = [first, second],
+        Edges = [new PlanEdge(first.Id, second.Id, EdgeType.ControlFlow)],
+        Configuration = new PlanConfiguration { PlanTimeout = TimeSpan.FromSeconds(30) }
+    };
+
+    private static StepExecutionResult CompletedResult(string output = "ok") => new()
+    {
+        Status = StepExecutionStatus.Completed,
+        Output = output,
+        Duration = TimeSpan.FromMilliseconds(1)
+    };
+
+    private static StepExecutionResult FailedResult(string error = "deliberate failure") => new()
+    {
+        Status = StepExecutionStatus.Failed,
+        ErrorMessage = error,
+        Duration = TimeSpan.FromMilliseconds(1)
+    };
+
+    private static async Task WaitUntilAsync(Func<bool> condition, int timeoutMs = 10_000)
+    {
+        for (var elapsed = 0; !condition(); elapsed += 10)
+        {
+            Assert.True(elapsed < timeoutMs, "condition not reached within timeout");
+            await Task.Delay(10);
+        }
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlanExecutorSolutionReviewFixTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlanExecutorSolutionReviewFixTests.cs
@@ -127,6 +127,7 @@ public sealed class PlanExecutorSolutionReviewFixTests
             notifier.Object,
             escalation.Object,
             provider,
+            TimeProvider.System,
             NullLogger<PlanExecutor>.Instance);
     }
 

--- a/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlanExecutorTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlanExecutorTests.cs
@@ -58,6 +58,7 @@ public sealed class PlanExecutorTests : IDisposable
             _notifier.Object,
             _escalation.Object,
             _serviceProvider,
+            TimeProvider.System,
             NullLogger<PlanExecutor>.Instance);
     }
 


### PR DESCRIPTION
## What & why

PR **W0** of the external-trigger-API program (scope: `.claude/plans/external-trigger-api-scope.md` §2). Fixes verified-dead configuration: every plan step declares `RetryPolicy { MaxRetries=3, InitialDelay=1s, Strategy=Exponential }`, but the only field production code ever read was `OnExhausted` — no retry loop existed. A failed step failed immediately while its config promised three retries.

## What changed

- **`ExecuteStepAsync` restructured** (PlanExecutor.Scheduling.cs): thin wrapper → `RunStepWithRetriesAsync` (attempt loop) → `ExecuteSingleAttemptAsync` (one attempt under a per-attempt timeout). Failure routing moved out of `HandleStepResultAsync` into the loop so `OnExhausted` (FailStep/SkipStep/FailPlan/Escalate) fires only after the budget is spent.
- **All three failure modes consume budget**: Failed result, per-attempt timeout, and unhandled executor exception are retryable. Previously timeouts/exceptions hard-skipped downstream and *bypassed recovery entirely* — they now route through `OnExhausted` like any exhausted failure. Plan-level cancellation is never retried (distinguished via `ct.IsCancellationRequested`, race-safe toward cancel).
- **Backoff** (PlanExecutor.Recovery.cs): `ComputeBackoffDelay` (Fixed/Linear/Exponential, exponent capped against overflow), delays via `Task.Delay(delay, TimeProvider, ct)` — testable with `FakeTimeProvider`, abortable mid-backoff.
- **Attempt semantics**: `AttemptCount` increments on the Running transition and is persisted before each attempt — crash/resume retains spent retry budget. Documented: `Timeout` is per-attempt; `MaxRetries` counts retries (1+N total attempts).
- **Manual `RetryStepAsync`** documented as a deliberately unbounded operator override (per scope decision: document, don't bound).
- **DI**: plain constructor registration + `TryAddSingleton(TimeProvider.System)` — keeps `PlanExecutor`'s dependencies visible to ValidateOnBuild (review fix: the initial factory-with-fallback shape hid them, and the fallback was dead code since Application.Common registers the system clock).

## Review process
Two-axis `/code-review`: spec verified item-by-item (attempt-count off-by-one, timeout-vs-cancel distinction, resume budget retention all specifically scrutinized and confirmed); one standards finding (missing ctor XML doc) fixed. 4-agent `/simplify`: Polly deliberately not reused (persisted attempt-count semantics don't fit its in-memory model — analyzed, not assumed); DI shape deepened per above; `StepAttemptOutcome.ErrorMessage` made derived. Known non-blocking edge: `Task.Delay`'s ~49.7-day cap can throw on pathological config (InitialDelay ≥4.2s AND MaxRetries ≥21) — lands in Failed+skip rather than OnExhausted.

## Tests
New `PlanExecutorRetryPolicyTests.cs`: 17 cases — exhaustion→OnExhausted, success-on-2nd-attempt (AttemptCount=2), MaxRetries=0, exception/timeout retryable, Blocked (HumanGate) never retried, 9-case backoff ladder incl. overflow cap, FakeTimeProvider scheduling, cancel-during-backoff. Full suite 8,107 green; planner suites 156/156 after review fixes.

## Notes
- The plan subsystem still has no production caller or schema init — that's W1/W3 (this PR is deliberately engine-internal).
- `Presentation.BundleApi.Tests` missing from slnx (pre-existing; 26/26 standalone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BnoLcufW278UxA9ssBM1Tc