### PR TITLE
feat: wire knowledge-graph build into document ingestion

### DIFF
--- a/src/Content/Application/Application.Core/CQRS/RAG/IngestDocument/IngestDocumentCommandHandler.cs
+++ b/src/Content/Application/Application.Core/CQRS/RAG/IngestDocument/IngestDocumentCommandHandler.cs
@@ -1,10 +1,13 @@
 using System.Diagnostics;
 using Application.AI.Common.Interfaces.RAG;
 using Application.AI.Common.OpenTelemetry.Metrics;
+using Application.Core.Workflows.KnowledgeGraph;
 using Domain.AI.RAG.Models;
 using Domain.AI.Telemetry.Conventions;
 using Domain.Common.Config;
 using MediatR;
+using Microsoft.Agents.AI.Workflows;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -12,7 +15,9 @@ namespace Application.Core.CQRS.RAG.IngestDocument;
 
 /// <summary>
 /// Orchestrates the document ingestion pipeline: parse, extract structure,
-/// chunk, enrich, embed, and index.
+/// chunk, enrich, embed, and index — plus two opt-in graph-build stages
+/// (corpus-graph indexing and knowledge-graph enrichment) that run after the
+/// vector and BM25 indexes commit.
 /// </summary>
 public sealed class IngestDocumentCommandHandler
 	: IRequestHandler<IngestDocumentCommand, IngestDocumentResult>
@@ -29,6 +34,7 @@ public sealed class IngestDocumentCommandHandler
 	private readonly IBm25Store _bm25Store;
 	private readonly ILogger<IngestDocumentCommandHandler> _logger;
 	private readonly IOptionsMonitor<AppConfig> _appConfigMonitor;
+	private readonly IServiceProvider _serviceProvider;
 
 	public IngestDocumentCommandHandler(
 		IDocumentParser parser,
@@ -40,7 +46,8 @@ public sealed class IngestDocumentCommandHandler
 		IVectorStore vectorStore,
 		IBm25Store bm25Store,
 		ILogger<IngestDocumentCommandHandler> logger,
-		IOptionsMonitor<AppConfig> appConfigMonitor)
+		IOptionsMonitor<AppConfig> appConfigMonitor,
+		IServiceProvider serviceProvider)
 	{
 		_parser = parser;
 		_structureExtractor = structureExtractor;
@@ -52,6 +59,12 @@ public sealed class IngestDocumentCommandHandler
 		_bm25Store = bm25Store;
 		_logger = logger;
 		_appConfigMonitor = appConfigMonitor;
+		// The graph-build stages resolve their collaborators lazily from the provider:
+		// IGraphRagService is registered only when the graph database backend is enabled,
+		// and the "kg-ingestion" keyed workflow should not be built on every ingest when
+		// enrichment is off. Constructor-injecting either would break hosts that run with
+		// the (default-off) graph stages disabled.
+		_serviceProvider = serviceProvider;
 	}
 
 	public async Task<IngestDocumentResult> Handle(
@@ -112,6 +125,23 @@ public sealed class IngestDocumentCommandHandler
 				_vectorStore.IndexAsync(chunks, request.CollectionName, cancellationToken),
 				_bm25Store.IndexAsync(chunks, request.CollectionName, cancellationToken));
 
+			// 8. Opt-in graph-build stages. These run AFTER the vector/BM25 commit and are
+			// deliberately non-fatal: the searchable ingest already succeeded, so a graph
+			// failure (including cancellation mid-stage) is logged and surfaced honestly on
+			// the result flags instead of failing the command — which would trigger the
+			// catch-path compensation and delete a perfectly usable ingest.
+			// The two stages write physically separate stores and only read the shared
+			// chunk list, so they run concurrently; neither ever throws, so awaiting them
+			// in sequence after starting both needs no aggregate exception handling.
+			var indexTask = ragConfig.GraphRag.IndexOnIngest
+				? TryIndexCorpusGraphAsync(chunks, jobId, cancellationToken)
+				: null;
+			var enrichTask = ragConfig.GraphRag.EnrichKnowledgeGraphOnIngest
+				? TryEnrichKnowledgeGraphAsync(chunks, jobId, cancellationToken)
+				: null;
+			bool? graphIndexed = indexTask is null ? null : await indexTask;
+			bool? knowledgeGraphEnriched = enrichTask is null ? null : await enrichTask;
+
 			sw.Stop();
 
 			RagIngestionMetrics.Documents.Add(1);
@@ -129,7 +159,9 @@ public sealed class IngestDocumentCommandHandler
 				ChunksProduced = chunks.Count,
 				TokensEmbedded = totalTokens,
 				Duration = sw.Elapsed,
-				Success = true
+				Success = true,
+				GraphIndexed = graphIndexed,
+				KnowledgeGraphEnriched = knowledgeGraphEnriched
 			};
 		}
 		catch (Exception ex)
@@ -193,6 +225,114 @@ public sealed class IngestDocumentCommandHandler
 				ex,
 				"RAG ingestion compensation failed to delete {DocumentId} from {StoreName} store: {JobId}",
 				documentId, storeName, jobId);
+		}
+	}
+
+	/// <summary>
+	/// Best-effort corpus-graph indexing stage (<c>GraphRagConfig.IndexOnIngest</c>).
+	/// Feeds the ingested chunks to <see cref="IGraphRagService.IndexCorpusAsync"/> so the
+	/// GraphRag retrieval strategy queries a populated graph. Resolves the service lazily
+	/// because it is registered only when <c>AppConfig:AI:Rag:GraphDatabase:Enabled</c> is
+	/// <c>true</c>. Never throws — including on cancellation — because the vector and BM25
+	/// writes have already committed; the outcome is reported on
+	/// <see cref="IngestDocumentResult.GraphIndexed"/>.
+	/// </summary>
+	private async Task<bool> TryIndexCorpusGraphAsync(
+		IReadOnlyList<DocumentChunk> chunks, string jobId, CancellationToken cancellationToken)
+	{
+		try
+		{
+			var graphRagService = _serviceProvider.GetService<IGraphRagService>();
+			if (graphRagService is null)
+			{
+				_logger.LogWarning(
+					"RAG ingestion {JobId}: GraphRag:IndexOnIngest is enabled but IGraphRagService is not " +
+					"registered — the graph database backend is disabled " +
+					"(AppConfig:AI:Rag:GraphDatabase:Enabled=false). Skipping corpus graph indexing.",
+					jobId);
+				return false;
+			}
+
+			await graphRagService.IndexCorpusAsync(chunks, cancellationToken);
+			_logger.LogInformation(
+				"RAG ingestion {JobId}: corpus graph indexed ({ChunkCount} chunks)",
+				jobId, chunks.Count);
+			return true;
+		}
+		catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+		{
+			_logger.LogInformation(
+				"RAG ingestion {JobId}: corpus graph indexing cancelled; vector and BM25 indexes remain committed",
+				jobId);
+			return false;
+		}
+		catch (Exception ex)
+		{
+			_logger.LogError(
+				ex,
+				"RAG ingestion {JobId}: corpus graph indexing failed; vector and BM25 indexes remain committed",
+				jobId);
+			return false;
+		}
+	}
+
+	/// <summary>
+	/// Best-effort knowledge-graph enrichment stage
+	/// (<c>GraphRagConfig.EnrichKnowledgeGraphOnIngest</c>). Runs the <c>"kg-ingestion"</c>
+	/// keyed workflow (extract entities → stamp provenance → store graph) over the ingested
+	/// chunks; extracted entities are persisted through the root
+	/// <c>IKnowledgeGraphStore</c> registration, i.e. the tenant-isolation and compliance
+	/// decorator chain. Never throws — including on cancellation — because the vector and
+	/// BM25 writes have already committed; the outcome is reported on
+	/// <see cref="IngestDocumentResult.KnowledgeGraphEnriched"/>.
+	/// </summary>
+	private async Task<bool> TryEnrichKnowledgeGraphAsync(
+		IReadOnlyList<DocumentChunk> chunks, string jobId, CancellationToken cancellationToken)
+	{
+		try
+		{
+			var workflow = _serviceProvider.GetRequiredKeyedService<Workflow>("kg-ingestion");
+			await using var run = await InProcessExecution.RunAsync(
+				workflow, new KgIngestionInput(chunks), cancellationToken: cancellationToken);
+
+			KgIngestionResult? outcome = null;
+			foreach (var evt in run.NewEvents)
+			{
+				if (evt is WorkflowOutputEvent output && output.Is<KgIngestionResult>(out var result))
+				{
+					outcome = result;
+				}
+			}
+
+			if (outcome is null)
+			{
+				_logger.LogWarning(
+					"RAG ingestion {JobId}: kg-ingestion workflow completed without producing an output event; " +
+					"treating knowledge graph enrichment as failed",
+					jobId);
+				return false;
+			}
+
+			_logger.LogInformation(
+				"RAG ingestion {JobId}: knowledge graph enriched ({NodesStored} nodes, {EdgesStored} edges " +
+				"from {ChunksProcessed} chunks)",
+				jobId, outcome.NodesStored, outcome.EdgesStored, outcome.ChunksProcessed);
+			return true;
+		}
+		catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+		{
+			_logger.LogInformation(
+				"RAG ingestion {JobId}: knowledge graph enrichment cancelled; vector and BM25 indexes remain committed",
+				jobId);
+			return false;
+		}
+		catch (Exception ex)
+		{
+			_logger.LogError(
+				ex,
+				"RAG ingestion {JobId}: knowledge graph enrichment failed; vector and BM25 indexes remain committed",
+				jobId);
+			return false;
 		}
 	}
 }

--- a/src/Content/Application/Application.Core/CQRS/RAG/IngestDocument/IngestDocumentResult.cs
+++ b/src/Content/Application/Application.Core/CQRS/RAG/IngestDocument/IngestDocumentResult.cs
@@ -16,8 +16,33 @@ public record IngestDocumentResult
 	public required TimeSpan Duration { get; init; }
 
 	/// <summary>Whether the ingestion completed without errors.</summary>
+	/// <remarks>
+	/// Refers to the core pipeline (parse → chunk → enrich → embed → vector/BM25 index).
+	/// The optional graph stages report their own outcome via <see cref="GraphIndexed"/>
+	/// and <see cref="KnowledgeGraphEnriched"/>: because the vector and BM25 writes have
+	/// already committed when the graph stages run, a graph failure yields
+	/// <c>Success == true</c> with the corresponding flag set to <c>false</c> — an honest
+	/// partial success rather than a rollback of a usable ingest.
+	/// </remarks>
 	public required bool Success { get; init; }
 
 	/// <summary>Error message if the ingestion failed; null on success.</summary>
 	public string? Error { get; init; }
+
+	/// <summary>
+	/// Outcome of the optional corpus-graph indexing stage
+	/// (<c>AppConfig:AI:Rag:GraphRag:IndexOnIngest</c>): <c>null</c> when the stage is
+	/// disabled, <c>true</c> when the chunks were indexed into the GraphRag corpus graph,
+	/// <c>false</c> when the stage ran but failed (details in server logs).
+	/// </summary>
+	public bool? GraphIndexed { get; init; }
+
+	/// <summary>
+	/// Outcome of the optional knowledge-graph enrichment stage
+	/// (<c>AppConfig:AI:Rag:GraphRag:EnrichKnowledgeGraphOnIngest</c>): <c>null</c> when
+	/// the stage is disabled, <c>true</c> when the <c>"kg-ingestion"</c> workflow stored
+	/// extracted entities in the knowledge graph, <c>false</c> when the stage ran but
+	/// failed (details in server logs).
+	/// </summary>
+	public bool? KnowledgeGraphEnriched { get; init; }
 }

--- a/src/Content/Application/Application.Core/DependencyInjection.cs
+++ b/src/Content/Application/Application.Core/DependencyInjection.cs
@@ -86,7 +86,9 @@ public static class DependencyInjection
 	/// <para>Workflow keys (singleton unless noted):</para>
 	/// <list type="bullet">
 	///   <item><c>"rag-pipeline"</c> — RAG retrieval pipeline with CRAG evaluation</item>
-	///   <item><c>"kg-ingestion"</c> — Knowledge graph entity extraction and storage</item>
+	///   <item><c>"kg-ingestion"</c> — Knowledge graph entity extraction and storage. Consumed by
+	///     <c>IngestDocumentCommandHandler</c>'s enrichment stage when
+	///     <c>AppConfig:AI:Rag:GraphRag:EnrichKnowledgeGraphOnIngest</c> is <c>true</c></item>
 	///   <item><c>"governance-approval"</c> — Human-in-the-loop approval with <see cref="RequestPort"/></item>
 	///   <item>
 	///     <c>"optimization-iteration"</c> — Single meta-harness propose-evaluate-score iteration.

--- a/src/Content/Application/Application.Core/Validation/RagConfigValidator.cs
+++ b/src/Content/Application/Application.Core/Validation/RagConfigValidator.cs
@@ -1,0 +1,66 @@
+using Domain.Common.Config.AI.RAG;
+using FluentValidation;
+
+namespace Application.Core.Validation;
+
+/// <summary>
+/// Validates the cross-section coherence of <see cref="RagConfig"/> — specifically the
+/// contract between the GraphRag feature knobs (<see cref="GraphRagConfig"/>) and the graph
+/// database backend (<see cref="GraphDatabaseConfig"/>) they depend on. Rules:
+/// <list type="bullet">
+///   <item>When <see cref="GraphDatabaseConfig.Enabled"/> is <c>true</c>, the
+///     <see cref="GraphDatabaseConfig.Provider"/> must be a backend the DI layer actually
+///     registers (currently only <c>"kuzu"</c>). Before this rule, an enabled backend with an
+///     unregistered provider composed cleanly and threw on the first
+///     <c>IGraphDatabaseBackend</c> resolution — a first-use landmine instead of a startup
+///     failure.</item>
+///   <item>When <see cref="GraphRagConfig.IndexOnIngest"/> is <c>true</c>, the graph database
+///     backend must be enabled: corpus-graph indexing writes through
+///     <c>IGraphRagService</c>, which exists only alongside the backend. Failing at boot is
+///     kinder than silently skipping the stage on every ingest.</item>
+/// </list>
+/// All class defaults satisfy every rule, so hosts that omit the section keep booting
+/// unchanged.
+/// </summary>
+/// <remarks>
+/// Auto-discovered via <c>AddValidatorsFromAssembly</c> on the Application.Core assembly —
+/// no manual registration required. Wired into the startup options pipeline at
+/// <c>RegisterValidatedConfigSections</c> with <c>ValidateOnStart</c>.
+/// </remarks>
+public sealed class RagConfigValidator : AbstractValidator<RagConfig>
+{
+    /// <summary>
+    /// Backend provider keys registered by <c>Infrastructure.AI.RAG</c>'s
+    /// <c>AddRagGraphDatabase</c>. Kept case-insensitive to match keyed-DI lookup behavior
+    /// being driven by operator-typed configuration.
+    /// </summary>
+    private static readonly HashSet<string> RegisteredBackendProviders =
+        new(StringComparer.OrdinalIgnoreCase) { "kuzu" };
+
+    /// <summary>Initializes a new instance of the <see cref="RagConfigValidator"/> class.</summary>
+    public RagConfigValidator()
+    {
+        When(x => x.GraphDatabase.Enabled, () =>
+        {
+            RuleFor(x => x.GraphDatabase.Provider)
+                .Must(p => p is not null && RegisteredBackendProviders.Contains(p))
+                .WithMessage(x =>
+                    $"GraphDatabase.Provider '{x.GraphDatabase.Provider}' has no registered " +
+                    $"IGraphDatabaseBackend. Registered providers: " +
+                    $"{string.Join(", ", RegisteredBackendProviders)}. Either use a registered " +
+                    "provider, disable AppConfig:AI:Rag:GraphDatabase, or register a backend " +
+                    "for this key in Infrastructure.AI.RAG.");
+        });
+
+        When(x => x.GraphRag.IndexOnIngest, () =>
+        {
+            RuleFor(x => x.GraphDatabase.Enabled)
+                .Equal(true)
+                .WithMessage(
+                    "GraphRag.IndexOnIngest requires the graph database backend: corpus-graph " +
+                    "indexing writes through IGraphRagService, which is registered only when " +
+                    "AppConfig:AI:Rag:GraphDatabase:Enabled is true. Enable the backend or turn " +
+                    "off AppConfig:AI:Rag:GraphRag:IndexOnIngest.");
+        });
+    }
+}

--- a/src/Content/Application/Application.Core/Workflows/KnowledgeGraph/KgIngestionWorkflow.cs
+++ b/src/Content/Application/Application.Core/Workflows/KnowledgeGraph/KgIngestionWorkflow.cs
@@ -16,9 +16,21 @@ namespace Application.Core.Workflows.KnowledgeGraph;
 /// </summary>
 /// <remarks>
 /// <para>
-/// This workflow decomposes <see cref="IGraphRagService.IndexCorpusAsync"/> into discrete,
-/// observable executor stages. Each stage is independently testable and emits its own
-/// workflow events for observability.
+/// This is the build path for the <em>knowledge graph</em> — the tenant-aware
+/// <see cref="IKnowledgeGraphStore"/> shared with memory and learnings — as opposed to the
+/// corpus graph that <see cref="IGraphRagService.IndexCorpusAsync"/> builds for the GraphRag
+/// retrieval strategy. The two graphs are physically separate stores; this workflow mirrors
+/// the extract → stamp → store shape as discrete, observable executor stages, each
+/// independently testable and emitting its own workflow events.
+/// </para>
+/// <para>
+/// <b>Consumer:</b> the knowledge-graph enrichment stage of
+/// <c>IngestDocumentCommandHandler</c>, which resolves this workflow by its DI key
+/// (<c>"kg-ingestion"</c>) and runs it over the ingested chunks when
+/// <c>AppConfig:AI:Rag:GraphRag:EnrichKnowledgeGraphOnIngest</c> is <c>true</c>. Because
+/// <see cref="StoreGraphExecutor"/> writes through the root
+/// <see cref="IKnowledgeGraphStore"/> registration, extracted entities pass through the
+/// tenant-isolation and compliance decorator chain and are stamped accordingly.
 /// </para>
 /// <para>
 /// The workflow uses <see cref="IModelRouter"/> (via <see cref="ExtractEntitiesExecutor"/>)

--- a/src/Content/Application/Application.Core/Workflows/Rag/GraphRagSearchExecutor.cs
+++ b/src/Content/Application/Application.Core/Workflows/Rag/GraphRagSearchExecutor.cs
@@ -15,10 +15,15 @@ namespace Application.Core.Workflows.Rag;
 /// GraphRAG excels at broad thematic queries (e.g., "What are the main themes in this corpus?")
 /// where vector search performs poorly. The trade-off is higher indexing cost and the need
 /// for a populated knowledge graph. When the graph is empty, returns a context indicating
-/// that documents must be ingested first.
+/// that documents must be ingested first. When <paramref name="graphRagService"/> is null —
+/// the service is registered only while the graph database backend is enabled — the executor
+/// degrades the same way: an explanatory context naming the disabled backend, not an exception.
 /// </remarks>
+/// <param name="graphRagService">The graph retrieval service, or null when the graph database
+/// backend is disabled (<c>AppConfig:AI:Rag:GraphDatabase:Enabled=false</c>).</param>
+/// <param name="logger">Logger for recording search progress and degradations.</param>
 public sealed class GraphRagSearchExecutor(
-    IGraphRagService graphRagService,
+    IGraphRagService? graphRagService,
     ILogger<GraphRagSearchExecutor> logger)
     : Executor<ClassifiedQuery, RagAssembledContext>("graph_rag_search")
 {
@@ -37,6 +42,14 @@ public sealed class GraphRagSearchExecutor(
         IWorkflowContext context,
         CancellationToken cancellationToken = default)
     {
+        if (graphRagService is null)
+        {
+            logger.LogWarning(
+                "GraphRag branch reached but the graph database backend is disabled " +
+                "(AppConfig:AI:Rag:GraphDatabase:Enabled=false); returning explanatory context");
+            return RagAssembledContext.GraphRagUnavailable();
+        }
+
         logger.LogInformation("GraphRAG search started for query of {Length} chars", message.Query.Length);
 
         var result = await graphRagService.GlobalSearchAsync(

--- a/src/Content/Application/Application.Core/Workflows/Rag/RagPipelineWorkflow.cs
+++ b/src/Content/Application/Application.Core/Workflows/Rag/RagPipelineWorkflow.cs
@@ -43,8 +43,10 @@ public static class RagPipelineWorkflow
     /// The service provider used to resolve pipeline dependencies:
     /// <see cref="IQueryClassifier"/>, <see cref="IHybridRetriever"/>,
     /// <see cref="IReranker"/>, <see cref="ICragEvaluator"/>,
-    /// <see cref="IRagContextAssembler"/>, <see cref="IGraphRagService"/>,
-    /// and optionally <see cref="IFeedbackWeightedScorer"/>.
+    /// <see cref="IRagContextAssembler"/>, optionally <see cref="IGraphRagService"/>
+    /// (absent when the graph database backend is disabled — the GraphRag branch then
+    /// degrades with an explanatory context), and optionally
+    /// <see cref="IFeedbackWeightedScorer"/>.
     /// </param>
     /// <returns>A configured <see cref="Workflow"/> ready for execution via <see cref="InProcessExecution"/>.</returns>
     public static Workflow Build(IServiceProvider services)
@@ -66,8 +68,11 @@ public static class RagPipelineWorkflow
             services.GetRequiredService<IRagContextAssembler>(),
             services.GetRequiredService<ILogger<AssembleContextExecutor>>());
 
+        // Optional: IGraphRagService is registered only when the graph database backend is
+        // enabled. The executor tolerates null and degrades the GraphRag branch with an
+        // explanatory context, so the workflow keeps its shape under every configuration.
         var graphSearch = new GraphRagSearchExecutor(
-            services.GetRequiredService<IGraphRagService>(),
+            services.GetService<IGraphRagService>(),
             services.GetRequiredService<ILogger<GraphRagSearchExecutor>>());
 
         var builder = new WorkflowBuilder(classify);

--- a/src/Content/Domain/Domain.AI/RAG/Models/RagAssembledContext.cs
+++ b/src/Content/Domain/Domain.AI/RAG/Models/RagAssembledContext.cs
@@ -16,6 +16,22 @@ public record RagAssembledContext
     public required string AssembledText { get; init; }
 
     /// <summary>
+    /// The explanatory context returned when a GraphRAG retrieval is requested but the graph
+    /// database backend is disabled. A single factory keeps the operator guidance identical
+    /// at every degradation site (orchestrator strategy override, workflow branch).
+    /// </summary>
+    public static RagAssembledContext GraphRagUnavailable() => new()
+    {
+        AssembledText =
+            "GraphRAG retrieval is unavailable: the graph database backend is disabled " +
+            "(AppConfig:AI:Rag:GraphDatabase:Enabled=false). Use the default hybrid " +
+            "strategy, or enable the graph database and re-ingest with " +
+            "AppConfig:AI:Rag:GraphRag:IndexOnIngest=true to populate the graph.",
+        TotalTokens = 0,
+        WasTruncated = false
+    };
+
+    /// <summary>
     /// Citation spans linking regions of the assembled text back to their source
     /// chunks and documents. Used by the generation phase to produce inline citations
     /// and by the UI to render source attribution.

--- a/src/Content/Domain/Domain.Common/Config/AI/RAG/GraphDatabaseConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/RAG/GraphDatabaseConfig.cs
@@ -7,7 +7,10 @@ public sealed class GraphDatabaseConfig
 {
     /// <summary>
     /// Graph database provider. Selects keyed DI implementation.
-    /// Options: "kuzu" (default), "neo4j", "in_memory".
+    /// The template ships a backend registration for "kuzu" (default) only; other values
+    /// (e.g. "neo4j") are consumer extension points that require registering a matching
+    /// keyed <c>IGraphDatabaseBackend</c>. When <see cref="Enabled"/> is true, an
+    /// unregistered provider fails the host at startup via <c>RagConfigValidator</c>.
     /// </summary>
     public string Provider { get; set; } = "kuzu";
 

--- a/src/Content/Domain/Domain.Common/Config/AI/RAG/GraphRagConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/RAG/GraphRagConfig.cs
@@ -40,6 +40,30 @@ public class GraphRagConfig
     public int MaxEntityExtractionTokens { get; set; } = 4096;
 
     /// <summary>
+    /// Gets or sets whether the corpus graph (the <c>IGraphDatabaseBackend</c>-backed
+    /// graph queried by the GraphRag retrieval strategy) is built during document
+    /// ingestion. When <c>true</c>, <c>IngestDocumentCommandHandler</c> calls
+    /// <c>IGraphRagService.IndexCorpusAsync</c> with the ingested chunks after the
+    /// vector and BM25 indexes commit. Requires <c>GraphDatabaseConfig.Enabled</c>
+    /// (enforced at startup by <c>RagConfigValidator</c>): without the backend there
+    /// is no graph to index into. A graph-indexing failure never fails the ingestion —
+    /// it is logged and surfaced via <c>IngestDocumentResult.GraphIndexed</c>.
+    /// </summary>
+    public bool IndexOnIngest { get; set; } = false;
+
+    /// <summary>
+    /// Gets or sets whether the knowledge graph (the tenant-aware
+    /// <c>IKnowledgeGraphStore</c> shared with memory and learnings) is enriched during
+    /// document ingestion. When <c>true</c>, <c>IngestDocumentCommandHandler</c> runs
+    /// the <c>"kg-ingestion"</c> workflow (entity extraction, provenance stamping,
+    /// graph storage) over the ingested chunks; extracted entities land through the
+    /// decorated store chain, inheriting tenant isolation and compliance stamping.
+    /// An enrichment failure never fails the ingestion — it is logged and surfaced
+    /// via <c>IngestDocumentResult.KnowledgeGraphEnriched</c>.
+    /// </summary>
+    public bool EnrichKnowledgeGraphOnIngest { get; set; } = false;
+
+    /// <summary>
     /// Gets or sets whether feedback-weighted search is enabled. When <c>true</c>,
     /// retrieval results are re-ranked by blending semantic relevance with accumulated
     /// feedback weights on graph nodes and edges.

--- a/src/Content/Infrastructure/Infrastructure.AI.RAG/DependencyInjection.GraphRag.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.RAG/DependencyInjection.GraphRag.cs
@@ -78,8 +78,23 @@ public static partial class DependencyInjection
     /// Registers the GraphRAG knowledge graph service for entity-relationship
     /// based retrieval and community-level summarization.
     /// </summary>
+    /// <remarks>
+    /// Registration is gated on <c>GraphDatabaseConfig.Enabled</c> — the same gate as
+    /// <see cref="AddRagGraphDatabase"/> — because <see cref="ManagedCodeGraphRagService"/>
+    /// requires the <see cref="IGraphDatabaseBackend"/> that method registers. Registering
+    /// the service unconditionally would compose a landmine: the singleton factory hides the
+    /// missing backend from ValidateOnBuild and throws on first resolution instead of at
+    /// startup. When the backend is off, <c>IGraphRagService</c> is simply absent; every
+    /// consumer (<c>RagOrchestrator</c>, <c>RagPipelineWorkflow</c>, the keyed
+    /// <c>"graph"</c> retrieval source) resolves it optionally and degrades with an explicit
+    /// message. A host that enables the backend with an unregistered provider fails loudly at
+    /// startup via <c>RagConfigValidator</c>.
+    /// </remarks>
     private static void AddRagGraphRag(IServiceCollection services, AppConfig appConfig)
     {
+        if (!appConfig.AI.Rag.GraphDatabase.Enabled)
+            return;
+
         services.AddSingleton<IGraphRagService>(sp =>
             new ManagedCodeGraphRagService(
                 sp.GetRequiredService<IGraphDatabaseBackend>(),

--- a/src/Content/Infrastructure/Infrastructure.AI.RAG/DependencyInjection.Retrieval.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.RAG/DependencyInjection.Retrieval.cs
@@ -165,9 +165,15 @@ public static partial class DependencyInjection
         services.AddKeyedSingleton<IRetrievalSource>("vector", (sp, _) =>
             new VectorRetrievalSource(sp.GetRequiredService<IHybridRetriever>()));
 
-        // Adapter: existing IGraphRagService → IRetrievalSource
-        services.AddKeyedSingleton<IRetrievalSource>("graph", (sp, _) =>
-            new GraphRetrievalSource(sp.GetRequiredService<IGraphRagService>()));
+        // Adapter: existing IGraphRagService → IRetrievalSource. Registered only when the
+        // graph database backend (and therefore IGraphRagService) exists — see AddRagGraphRag.
+        // MultiSourceOrchestrator already logs-and-skips enabled sources with no registration,
+        // so a config that lists "graph" without the backend degrades gracefully per fan-out.
+        if (appConfig.AI.Rag.GraphDatabase.Enabled)
+        {
+            services.AddKeyedSingleton<IRetrievalSource>("graph", (sp, _) =>
+                new GraphRetrievalSource(sp.GetRequiredService<IGraphRagService>()));
+        }
 
         // Orchestrator resolves IRetrievalSource by key from the container
         services.AddSingleton<IMultiSourceOrchestrator>(sp =>

--- a/src/Content/Infrastructure/Infrastructure.AI.RAG/DependencyInjection.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.RAG/DependencyInjection.cs
@@ -62,7 +62,11 @@ public static partial class DependencyInjection
                 sp.GetRequiredService<IReranker>(),
                 sp.GetRequiredService<ICragEvaluator>(),
                 sp.GetRequiredService<IRagContextAssembler>(),
-                sp.GetRequiredService<IGraphRagService>(),
+                // Optional: registered only when the graph database backend is enabled
+                // (AddRagGraphRag). Null makes the orchestrator degrade the GraphRag
+                // strategy with an explicit "backend disabled" context instead of
+                // throwing on first resolution.
+                sp.GetService<IGraphRagService>(),
                 sp.GetService<IFeedbackWeightedScorer>(),
                 sp.GetRequiredService<QueryRouter>(),
                 sp.GetService<IMultiSourceOrchestrator>(),

--- a/src/Content/Infrastructure/Infrastructure.AI.RAG/Orchestration/RagOrchestrator.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.RAG/Orchestration/RagOrchestrator.cs
@@ -53,7 +53,7 @@ public sealed partial class RagOrchestrator : IRagOrchestrator
     private readonly IReranker _reranker;
     private readonly ICragEvaluator _cragEvaluator;
     private readonly IRagContextAssembler _contextAssembler;
-    private readonly IGraphRagService _graphRagService;
+    private readonly IGraphRagService? _graphRagService;
     private readonly IFeedbackWeightedScorer? _feedbackScorer;
     private readonly QueryRouter _queryRouter;
     private readonly IMultiSourceOrchestrator? _multiSourceOrchestrator;
@@ -73,7 +73,9 @@ public sealed partial class RagOrchestrator : IRagOrchestrator
     /// <param name="reranker">Cross-encoder or semantic reranker.</param>
     /// <param name="cragEvaluator">CRAG relevance evaluator.</param>
     /// <param name="contextAssembler">Final context assembly stage.</param>
-    /// <param name="graphRagService">Knowledge graph-based retrieval service.</param>
+    /// <param name="graphRagService">Knowledge graph-based retrieval service. Null when the
+    /// graph database backend is disabled (<c>AppConfig:AI:Rag:GraphDatabase:Enabled=false</c>);
+    /// the GraphRag strategy then degrades with an explicit "backend disabled" context.</param>
     /// <param name="feedbackScorer">Optional feedback-weighted scorer. Null when feedback is disabled.</param>
     /// <param name="queryRouter">Query classification and transformation router.</param>
     /// <param name="multiSourceOrchestrator">Optional multi-source retrieval orchestrator. Null disables multi-source routing.</param>
@@ -92,7 +94,7 @@ public sealed partial class RagOrchestrator : IRagOrchestrator
         IReranker reranker,
         ICragEvaluator cragEvaluator,
         IRagContextAssembler contextAssembler,
-        IGraphRagService graphRagService,
+        IGraphRagService? graphRagService,
         IFeedbackWeightedScorer? feedbackScorer,
         QueryRouter queryRouter,
         IMultiSourceOrchestrator? multiSourceOrchestrator,
@@ -109,7 +111,6 @@ public sealed partial class RagOrchestrator : IRagOrchestrator
         ArgumentNullException.ThrowIfNull(reranker);
         ArgumentNullException.ThrowIfNull(cragEvaluator);
         ArgumentNullException.ThrowIfNull(contextAssembler);
-        ArgumentNullException.ThrowIfNull(graphRagService);
         ArgumentNullException.ThrowIfNull(queryRouter);
         ArgumentNullException.ThrowIfNull(configMonitor);
         ArgumentNullException.ThrowIfNull(logger);
@@ -263,6 +264,17 @@ public sealed partial class RagOrchestrator : IRagOrchestrator
         string query, CancellationToken cancellationToken)
     {
         using var activity = ActivitySource.StartActivity("rag.orchestrator.graph_pipeline");
+
+        // The service is registered only when the graph database backend is enabled. Mirror the
+        // established empty-graph behavior (an explanatory context, not an exception) so a
+        // GraphRag strategy override degrades honestly instead of failing the whole search.
+        if (_graphRagService is null)
+        {
+            _logger.LogWarning(
+                "GraphRag strategy requested but the graph database backend is disabled " +
+                "(AppConfig:AI:Rag:GraphDatabase:Enabled=false); returning explanatory context");
+            return RagAssembledContext.GraphRagUnavailable();
+        }
 
         _logger.LogInformation("Routing to GraphRAG global search");
         return await _graphRagService.GlobalSearchAsync(query, communityLevel: 0, cancellationToken);

--- a/src/Content/Presentation/Presentation.AgentHub/appsettings.json
+++ b/src/Content/Presentation/Presentation.AgentHub/appsettings.json
@@ -229,7 +229,9 @@
           "GraphProvider": "managed_code",
           "ConnectionString": "",
           "CommunityLevel": 2,
-          "MaxEntityExtractionTokens": 4096
+          "MaxEntityExtractionTokens": 4096,
+          "IndexOnIngest": false,
+          "EnrichKnowledgeGraphOnIngest": false
         },
         "Reranker": {
           "Strategy": "none",

--- a/src/Content/Presentation/Presentation.Common/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Content/Presentation/Presentation.Common/Extensions/IServiceCollectionExtensions.cs
@@ -236,6 +236,17 @@ public static class IServiceCollectionExtensions
             .ValidateFluentValidation<LogsConfig, LogsConfigValidator>()
             .ValidateOnStart();
 
+        // RAG graph coherence (GraphRag feature knobs vs the graph database backend they need).
+        // Rules are conditional on GraphDatabase.Enabled / GraphRag.IndexOnIngest and the class
+        // defaults satisfy them, so hosts that omit the section keep booting; a host that
+        // enables the backend with an unregistered provider — or turns on IndexOnIngest without
+        // the backend — fails closed at startup instead of throwing on first resolution
+        // (the former GraphRag DI landmine) or silently skipping the indexing stage.
+        services.AddOptions<Domain.Common.Config.AI.RAG.RagConfig>()
+            .Bind(configuration.GetSection("AppConfig:AI:Rag"))
+            .ValidateFluentValidation<Domain.Common.Config.AI.RAG.RagConfig, RagConfigValidator>()
+            .ValidateOnStart();
+
         return services;
     }
 

--- a/src/Content/Tests/Application.Core.Tests/CQRS/RAG/IngestDocumentCommandHandlerCompensationTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/CQRS/RAG/IngestDocumentCommandHandlerCompensationTests.cs
@@ -3,6 +3,7 @@ using Application.Core.CQRS.RAG.IngestDocument;
 using Domain.AI.RAG.Models;
 using Domain.Common.Config;
 using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Moq;
@@ -83,7 +84,8 @@ public sealed class IngestDocumentCommandHandlerCompensationTests
             _vectorStore.Object,
             _bm25Store.Object,
             NullLogger<IngestDocumentCommandHandler>.Instance,
-            monitor.Object);
+            monitor.Object,
+            new ServiceCollection().BuildServiceProvider());
     }
 
     private static IngestDocumentCommand Command() => new()

--- a/src/Content/Tests/Application.Core.Tests/CQRS/RAG/IngestDocumentCommandHandlerGraphStagesTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/CQRS/RAG/IngestDocumentCommandHandlerGraphStagesTests.cs
@@ -1,0 +1,270 @@
+using Application.AI.Common.Interfaces.RAG;
+using Application.Core.CQRS.RAG.IngestDocument;
+using Application.Core.Workflows.KnowledgeGraph;
+using Domain.AI.RAG.Models;
+using Domain.Common.Config;
+using FluentAssertions;
+using Microsoft.Agents.AI.Workflows;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Application.Core.Tests.CQRS.RAG;
+
+/// <summary>
+/// Verifies the two opt-in graph-build stages of <see cref="IngestDocumentCommandHandler"/>:
+/// corpus-graph indexing (<c>GraphRag.IndexOnIngest</c>) and knowledge-graph enrichment
+/// (<c>GraphRag.EnrichKnowledgeGraphOnIngest</c>). Both default off, both feed the ingested
+/// chunks forward when on, and neither may ever fail the core ingestion — the vector and
+/// BM25 writes have already committed, so a graph failure must surface as an honest partial
+/// success (<c>Success == true</c> with the stage flag <c>false</c>), not as a rollback.
+/// </summary>
+public sealed class IngestDocumentCommandHandlerGraphStagesTests
+{
+    private const string DocumentId = "file:///docs/report.md";
+    private const string CollectionName = "corpus-a";
+
+    private readonly Mock<IDocumentParser> _parser = new();
+    private readonly Mock<IStructureExtractor> _structureExtractor = new();
+    private readonly Mock<IChunkingService> _chunker = new();
+    private readonly Mock<IContextualEnricher> _enricher = new();
+    private readonly Mock<IRaptorSummarizer> _raptor = new();
+    private readonly Mock<IEmbeddingService> _embedding = new();
+    private readonly Mock<IVectorStore> _vectorStore = new();
+    private readonly Mock<IBm25Store> _bm25Store = new();
+    private readonly Mock<IGraphRagService> _graphRag = new();
+
+    private readonly IReadOnlyList<DocumentChunk> _chunks;
+
+    public IngestDocumentCommandHandlerGraphStagesTests()
+    {
+        _chunks = new List<DocumentChunk>
+        {
+            new()
+            {
+                Id = $"{DocumentId}_chunk_0",
+                DocumentId = DocumentId,
+                SectionPath = "Root",
+                Content = "chunk text",
+                Tokens = 3,
+                Metadata = new ChunkMetadata
+                {
+                    SourceUri = new Uri(DocumentId),
+                    CreatedAt = DateTimeOffset.UtcNow,
+                },
+                Embedding = new[] { 0.1f, 0.2f },
+            },
+        };
+
+        _parser
+            .Setup(p => p.ParseAsync(It.IsAny<Uri>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync("# markdown");
+        _structureExtractor
+            .Setup(s => s.ExtractStructure(It.IsAny<string>()))
+            .Returns(new SkeletonNode { Title = "Root", Level = 1, StartOffset = 0, EndOffset = 10 });
+        _chunker
+            .Setup(c => c.ChunkAsync(
+                It.IsAny<string>(), It.IsAny<SkeletonNode>(), It.IsAny<Uri>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(_chunks);
+        _embedding
+            .Setup(e => e.EmbedAsync(It.IsAny<IReadOnlyList<DocumentChunk>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(_chunks);
+        _vectorStore
+            .Setup(v => v.IndexAsync(
+                It.IsAny<IReadOnlyList<DocumentChunk>>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        _bm25Store
+            .Setup(b => b.IndexAsync(
+                It.IsAny<IReadOnlyList<DocumentChunk>>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+    }
+
+    private IngestDocumentCommandHandler CreateHandler(
+        Action<AppConfig>? configure = null,
+        Action<IServiceCollection>? registerServices = null)
+    {
+        var appConfig = new AppConfig();
+        appConfig.AI.Rag.Ingestion.EnableContextualEnrichment = false;
+        appConfig.AI.Rag.Ingestion.EnableRaptorSummaries = false;
+        configure?.Invoke(appConfig);
+
+        var monitor = new Mock<IOptionsMonitor<AppConfig>>();
+        monitor.SetupGet(m => m.CurrentValue).Returns(appConfig);
+
+        var services = new ServiceCollection();
+        registerServices?.Invoke(services);
+
+        return new IngestDocumentCommandHandler(
+            _parser.Object,
+            _structureExtractor.Object,
+            _chunker.Object,
+            _enricher.Object,
+            _raptor.Object,
+            _embedding.Object,
+            _vectorStore.Object,
+            _bm25Store.Object,
+            NullLogger<IngestDocumentCommandHandler>.Instance,
+            monitor.Object,
+            services.BuildServiceProvider());
+    }
+
+    private static IngestDocumentCommand Command() => new()
+    {
+        DocumentUri = new Uri(DocumentId),
+        CollectionName = CollectionName,
+    };
+
+    /// <summary>
+    /// Builds a single-executor stand-in for the real "kg-ingestion" workflow so the
+    /// handler's resolution, invocation, and failure isolation can be verified without the
+    /// LLM-backed extraction pipeline (which has its own integration test against the
+    /// decorated store in Infrastructure.AI.Tests).
+    /// </summary>
+    private static Workflow BuildStubWorkflow(Func<KgIngestionInput, KgIngestionResult> handle)
+    {
+        var stub = new StubKgIngestionExecutor(handle);
+        var builder = new WorkflowBuilder(stub);
+        builder.WithOutputFrom(stub);
+        return builder.Build();
+    }
+
+    [Fact]
+    public async Task Handle_GraphStagesDisabledByDefault_NeverTouchesGraphAndFlagsAreNull()
+    {
+        var workflowInvoked = false;
+        var handler = CreateHandler(registerServices: services =>
+        {
+            services.AddSingleton(_graphRag.Object);
+            services.AddKeyedSingleton("kg-ingestion", BuildStubWorkflow(input =>
+            {
+                workflowInvoked = true;
+                return new KgIngestionResult(0, 0, input.Chunks.Count);
+            }));
+        });
+
+        var result = await handler.Handle(Command(), CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        result.GraphIndexed.Should().BeNull("the corpus-graph stage is off by default");
+        result.KnowledgeGraphEnriched.Should().BeNull("the enrichment stage is off by default");
+        workflowInvoked.Should().BeFalse();
+        _graphRag.Verify(
+            g => g.IndexCorpusAsync(It.IsAny<IReadOnlyList<DocumentChunk>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_IndexOnIngestEnabled_IndexesEmbeddedChunksAndReportsTrue()
+    {
+        IReadOnlyList<DocumentChunk>? indexedChunks = null;
+        _graphRag
+            .Setup(g => g.IndexCorpusAsync(It.IsAny<IReadOnlyList<DocumentChunk>>(), It.IsAny<CancellationToken>()))
+            .Callback<IReadOnlyList<DocumentChunk>, CancellationToken>((c, _) => indexedChunks = c)
+            .Returns(Task.CompletedTask);
+
+        var handler = CreateHandler(
+            configure: c => c.AI.Rag.GraphRag.IndexOnIngest = true,
+            registerServices: services => services.AddSingleton(_graphRag.Object));
+
+        var result = await handler.Handle(Command(), CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        result.GraphIndexed.Should().BeTrue();
+        indexedChunks.Should().NotBeNull();
+        indexedChunks!.Should().ContainSingle(c => c.Id == $"{DocumentId}_chunk_0",
+            "the graph must be built from the same embedded chunks the vector/BM25 stores received");
+    }
+
+    [Fact]
+    public async Task Handle_IndexOnIngestEnabled_GraphIndexingFails_IngestionStillSucceedsHonestly()
+    {
+        _graphRag
+            .Setup(g => g.IndexCorpusAsync(It.IsAny<IReadOnlyList<DocumentChunk>>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("graph backend down"));
+
+        var handler = CreateHandler(
+            configure: c => c.AI.Rag.GraphRag.IndexOnIngest = true,
+            registerServices: services => services.AddSingleton(_graphRag.Object));
+
+        var result = await handler.Handle(Command(), CancellationToken.None);
+
+        result.Success.Should().BeTrue("the vector and BM25 writes already committed");
+        result.GraphIndexed.Should().BeFalse("the failure must be surfaced, not hidden");
+        _vectorStore.Verify(
+            v => v.DeleteAsync(It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()),
+            Times.Never,
+            "a graph failure must not trigger compensation of the committed stores");
+        _bm25Store.Verify(
+            b => b.DeleteAsync(It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_IndexOnIngestEnabled_ServiceAbsent_ReportsFalseWithoutFailing()
+    {
+        // IGraphRagService is registered only when the graph database backend is enabled.
+        // RagConfigValidator rejects this combination at host startup, but the handler must
+        // still be correct for containers composed without options validation.
+        var handler = CreateHandler(configure: c => c.AI.Rag.GraphRag.IndexOnIngest = true);
+
+        var result = await handler.Handle(Command(), CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        result.GraphIndexed.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Handle_EnrichEnabled_RunsKgIngestionWorkflowOverChunksAndReportsTrue()
+    {
+        KgIngestionInput? received = null;
+        var handler = CreateHandler(
+            configure: c => c.AI.Rag.GraphRag.EnrichKnowledgeGraphOnIngest = true,
+            registerServices: services => services.AddKeyedSingleton(
+                "kg-ingestion",
+                BuildStubWorkflow(input =>
+                {
+                    received = input;
+                    return new KgIngestionResult(2, 1, input.Chunks.Count);
+                })));
+
+        var result = await handler.Handle(Command(), CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        result.KnowledgeGraphEnriched.Should().BeTrue();
+        received.Should().NotBeNull();
+        received!.Chunks.Should().ContainSingle(c => c.Id == $"{DocumentId}_chunk_0");
+        received.SourcePipeline.Should().Be("rag_ingestion",
+            "provenance stamps must attribute the entities to the ingestion pipeline");
+    }
+
+    [Fact]
+    public async Task Handle_EnrichEnabled_WorkflowFails_IngestionStillSucceedsHonestly()
+    {
+        var handler = CreateHandler(
+            configure: c => c.AI.Rag.GraphRag.EnrichKnowledgeGraphOnIngest = true,
+            registerServices: services => services.AddKeyedSingleton(
+                "kg-ingestion",
+                BuildStubWorkflow(_ => throw new InvalidOperationException("extraction exploded"))));
+
+        var result = await handler.Handle(Command(), CancellationToken.None);
+
+        result.Success.Should().BeTrue("the vector and BM25 writes already committed");
+        result.KnowledgeGraphEnriched.Should().BeFalse();
+        _vectorStore.Verify(
+            v => v.DeleteAsync(It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    private sealed class StubKgIngestionExecutor(
+        Func<KgIngestionInput, KgIngestionResult> handle)
+        : Executor<KgIngestionInput, KgIngestionResult>("stub_kg_ingestion")
+    {
+        public override ValueTask<KgIngestionResult> HandleAsync(
+            KgIngestionInput message,
+            IWorkflowContext context,
+            CancellationToken cancellationToken = default)
+            => ValueTask.FromResult(handle(message));
+    }
+}

--- a/src/Content/Tests/Application.Core.Tests/Validation/RagConfigValidatorTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/Validation/RagConfigValidatorTests.cs
@@ -1,0 +1,110 @@
+using Application.Core.Validation;
+using Domain.Common.Config.AI.RAG;
+using FluentAssertions;
+using Xunit;
+
+namespace Application.Core.Tests.Validation;
+
+/// <summary>
+/// Verifies the cross-section coherence rules of <see cref="RagConfigValidator"/>: an enabled
+/// graph database must name a registered backend provider, and corpus-graph indexing on ingest
+/// must have a backend to write into. Class defaults must always pass so every host keeps
+/// booting unchanged.
+/// </summary>
+public sealed class RagConfigValidatorTests
+{
+    private readonly RagConfigValidator _sut = new();
+
+    [Fact]
+    public void Validate_Defaults_Passes()
+    {
+        var result = _sut.Validate(new RagConfig());
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("neo4j")]
+    [InlineData("in_memory")]
+    [InlineData("")]
+    public void Validate_BackendEnabledWithUnregisteredProvider_Fails(string provider)
+    {
+        var config = new RagConfig();
+        config.GraphDatabase.Enabled = true;
+        config.GraphDatabase.Provider = provider;
+
+        var result = _sut.Validate(config);
+
+        result.IsValid.Should().BeFalse(
+            "an enabled backend with no registered IGraphDatabaseBackend used to throw on first " +
+            "resolution instead of failing at startup");
+        result.Errors.Should().Contain(e => e.PropertyName == "GraphDatabase.Provider");
+    }
+
+    [Theory]
+    [InlineData("kuzu")]
+    [InlineData("KUZU")]
+    public void Validate_BackendEnabledWithRegisteredProvider_Passes(string provider)
+    {
+        var config = new RagConfig();
+        config.GraphDatabase.Enabled = true;
+        config.GraphDatabase.Provider = provider;
+
+        var result = _sut.Validate(config);
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Validate_BackendDisabled_ProviderIsNotConstrained()
+    {
+        var config = new RagConfig();
+        config.GraphDatabase.Enabled = false;
+        config.GraphDatabase.Provider = "neo4j";
+
+        var result = _sut.Validate(config);
+
+        result.IsValid.Should().BeTrue("a disabled backend never resolves a provider");
+    }
+
+    [Fact]
+    public void Validate_IndexOnIngestWithBackendEnabled_Passes()
+    {
+        var config = new RagConfig();
+        config.GraphDatabase.Enabled = true;
+        config.GraphRag.IndexOnIngest = true;
+
+        var result = _sut.Validate(config);
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Validate_IndexOnIngestWithoutBackend_Fails()
+    {
+        var config = new RagConfig();
+        config.GraphDatabase.Enabled = false;
+        config.GraphRag.IndexOnIngest = true;
+
+        var result = _sut.Validate(config);
+
+        result.IsValid.Should().BeFalse(
+            "IndexOnIngest without a backend would silently skip graph indexing on every ingest");
+        result.Errors.Should().Contain(e => e.PropertyName == "GraphDatabase.Enabled");
+    }
+
+    [Fact]
+    public void Validate_EnrichKnowledgeGraphOnIngestWithoutBackend_Passes()
+    {
+        // Knowledge-graph enrichment writes to IKnowledgeGraphStore (registered
+        // unconditionally), not to the GraphRag corpus backend — it has no dependency on
+        // GraphDatabase.Enabled.
+        var config = new RagConfig();
+        config.GraphDatabase.Enabled = false;
+        config.GraphRag.EnrichKnowledgeGraphOnIngest = true;
+
+        var result = _sut.Validate(config);
+
+        result.IsValid.Should().BeTrue();
+    }
+}

--- a/src/Content/Tests/Application.Core.Tests/Workflows/Rag/GraphRagSearchExecutorTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/Workflows/Rag/GraphRagSearchExecutorTests.cs
@@ -1,0 +1,62 @@
+using Application.AI.Common.Interfaces.RAG;
+using Application.Core.Workflows.Rag;
+using Domain.AI.RAG.Enums;
+using Domain.AI.RAG.Models;
+using FluentAssertions;
+using Microsoft.Agents.AI.Workflows;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Application.Core.Tests.Workflows.Rag;
+
+/// <summary>
+/// Verifies <see cref="GraphRagSearchExecutor"/> behavior with and without an
+/// <see cref="IGraphRagService"/>. The service is registered only while the graph database
+/// backend is enabled, so the executor must degrade the GraphRag branch with an explanatory
+/// context — never an exception — when it is absent.
+/// </summary>
+public sealed class GraphRagSearchExecutorTests
+{
+    private static ClassifiedQuery Query() =>
+        new("What are the main themes?", TopK: 5, CollectionName: null, RetrievalStrategy.GraphRag);
+
+    [Fact]
+    public async Task HandleAsync_ServiceAbsent_ReturnsExplanatoryUnavailableContext()
+    {
+        var executor = new GraphRagSearchExecutor(
+            graphRagService: null,
+            NullLogger<GraphRagSearchExecutor>.Instance);
+
+        var result = await executor.HandleAsync(Query(), Mock.Of<IWorkflowContext>());
+
+        result.AssembledText.Should().Contain("GraphRAG retrieval is unavailable")
+            .And.Contain("AppConfig:AI:Rag:GraphDatabase:Enabled",
+                "the degraded context must name the config knob that re-enables the feature");
+        result.TotalTokens.Should().Be(0);
+        result.WasTruncated.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task HandleAsync_ServicePresent_DelegatesToGlobalSearch()
+    {
+        var expected = new RagAssembledContext
+        {
+            AssembledText = "themes",
+            TotalTokens = 2,
+            WasTruncated = false
+        };
+        var service = new Mock<IGraphRagService>();
+        service
+            .Setup(s => s.GlobalSearchAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expected);
+
+        var executor = new GraphRagSearchExecutor(
+            service.Object,
+            NullLogger<GraphRagSearchExecutor>.Instance);
+
+        var result = await executor.HandleAsync(Query(), Mock.Of<IWorkflowContext>());
+
+        result.Should().BeSameAs(expected);
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.RAG.Tests/GraphRag/GraphRagDiRegistrationTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.RAG.Tests/GraphRag/GraphRagDiRegistrationTests.cs
@@ -1,0 +1,78 @@
+using Application.AI.Common.Interfaces.KnowledgeGraph;
+using Application.AI.Common.Interfaces.RAG;
+using Domain.Common.Config;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Infrastructure.AI.RAG.Tests.GraphRag;
+
+/// <summary>
+/// Composition tests for the GraphRag registration gate. <c>IGraphRagService</c> requires the
+/// <c>IGraphDatabaseBackend</c> that only exists while <c>GraphDatabase.Enabled</c> is true,
+/// so its registration (and the keyed <c>"graph"</c> retrieval source that wraps it) must
+/// follow the same gate. Before this gate, a disabled backend composed a registered-but-broken
+/// singleton that threw on the first <c>RagOrchestrator</c> resolution — invisible to
+/// ValidateOnBuild because the factory hid the dependency.
+/// </summary>
+public sealed class GraphRagDiRegistrationTests
+{
+    private static ServiceCollection BuildRagServices(Action<AppConfig>? configure = null)
+    {
+        var appConfig = new AppConfig();
+        configure?.Invoke(appConfig);
+
+        var services = new ServiceCollection();
+        services.AddRagDependencies(appConfig);
+        return services;
+    }
+
+    [Fact]
+    public void AddRagDependencies_GraphDatabaseDisabled_DoesNotRegisterGraphServices()
+    {
+        var services = BuildRagServices(c => c.AI.Rag.GraphDatabase.Enabled = false);
+
+        services.Should().NotContain(
+            d => !d.IsKeyedService && d.ServiceType == typeof(IGraphRagService),
+            "IGraphRagService requires the graph database backend and must follow its gate");
+        services.Should().NotContain(
+            d => !d.IsKeyedService && d.ServiceType == typeof(IGraphDatabaseBackend));
+        services.Should().NotContain(
+            d => d.IsKeyedService
+                 && d.ServiceType == typeof(IRetrievalSource)
+                 && Equals(d.ServiceKey, "graph"),
+            "the keyed graph retrieval source wraps IGraphRagService and must follow the same gate");
+    }
+
+    [Fact]
+    public void AddRagDependencies_GraphDatabaseDisabled_GraphServicesResolveNullNotThrow()
+    {
+        var services = BuildRagServices(c => c.AI.Rag.GraphDatabase.Enabled = false);
+        using var provider = services.BuildServiceProvider();
+
+        provider.GetService<IGraphRagService>().Should().BeNull();
+        provider.GetKeyedService<IRetrievalSource>("graph").Should().BeNull(
+            "MultiSourceOrchestrator logs-and-skips a null keyed source, so absence degrades " +
+            "gracefully instead of throwing per fan-out");
+    }
+
+    [Fact]
+    public void AddRagDependencies_GraphDatabaseEnabled_RegistersGraphServices()
+    {
+        // GraphDatabaseConfig.Enabled defaults to true with Provider "kuzu".
+        var services = BuildRagServices();
+
+        services.Should().Contain(
+            d => !d.IsKeyedService && d.ServiceType == typeof(IGraphRagService));
+        services.Should().Contain(
+            d => !d.IsKeyedService && d.ServiceType == typeof(IGraphDatabaseBackend));
+        services.Should().Contain(
+            d => d.IsKeyedService
+                 && d.ServiceType == typeof(IGraphDatabaseBackend)
+                 && Equals(d.ServiceKey, "kuzu"));
+        services.Should().Contain(
+            d => d.IsKeyedService
+                 && d.ServiceType == typeof(IRetrievalSource)
+                 && Equals(d.ServiceKey, "graph"));
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.RAG.Tests/Orchestration/RagOrchestratorGraphRagUnavailableTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.RAG.Tests/Orchestration/RagOrchestratorGraphRagUnavailableTests.cs
@@ -1,0 +1,69 @@
+using Application.AI.Common.Interfaces.RAG;
+using Domain.AI.RAG.Enums;
+using FluentAssertions;
+using Infrastructure.AI.RAG.Orchestration;
+using Infrastructure.AI.RAG.QueryTransform;
+using Infrastructure.AI.RAG.Tests.Helpers;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Infrastructure.AI.RAG.Tests.Orchestration;
+
+/// <summary>
+/// Verifies that <see cref="RagOrchestrator"/> degrades the GraphRag strategy honestly when
+/// <c>IGraphRagService</c> is absent (the graph database backend is disabled): an explanatory
+/// context naming the disabled config, never an exception. Mirrors the established
+/// empty-graph behavior of <c>ManagedCodeGraphRagService.GlobalSearchAsync</c>.
+/// </summary>
+public sealed class RagOrchestratorGraphRagUnavailableTests
+{
+    private static RagOrchestrator CreateOrchestratorWithoutGraphRag()
+    {
+        var config = RagTestData.CreateConfigMonitor();
+        var queryRouter = new QueryRouter(
+            Mock.Of<IQueryClassifier>(),
+            Mock.Of<IServiceProvider>(),
+            config,
+            Mock.Of<ILogger<QueryRouter>>());
+
+        return new RagOrchestrator(
+            Mock.Of<IHybridRetriever>(),
+            Mock.Of<IReranker>(),
+            Mock.Of<ICragEvaluator>(),
+            Mock.Of<IRagContextAssembler>(),
+            graphRagService: null,
+            feedbackScorer: null,
+            queryRouter,
+            multiSourceOrchestrator: null,
+            complexityClassifier: null,
+            costTracker: null,
+            config,
+            Mock.Of<ILogger<RagOrchestrator>>());
+    }
+
+    [Fact]
+    public async Task SearchAsync_GraphRagOverrideWithoutBackend_ReturnsExplanatoryContext()
+    {
+        var orchestrator = CreateOrchestratorWithoutGraphRag();
+
+        var result = await orchestrator.SearchAsync(
+            "What are the main themes?",
+            strategyOverride: RetrievalStrategy.GraphRag);
+
+        result.AssembledText.Should().Contain("GraphRAG retrieval is unavailable")
+            .And.Contain("AppConfig:AI:Rag:GraphDatabase:Enabled",
+                "the degraded context must name the config knob that re-enables the feature");
+        result.TotalTokens.Should().Be(0);
+        result.WasTruncated.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Constructor_NullGraphRagService_DoesNotThrow()
+    {
+        var act = CreateOrchestratorWithoutGraphRag;
+
+        act.Should().NotThrow(
+            "the orchestrator must compose in hosts that run with the graph database disabled");
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/KnowledgeGraph/KgIngestionWorkflowDecoratedStoreTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/KnowledgeGraph/KgIngestionWorkflowDecoratedStoreTests.cs
@@ -1,0 +1,140 @@
+using Application.AI.Common.Interfaces;
+using Application.AI.Common.Interfaces.KnowledgeGraph;
+using Application.AI.Common.Interfaces.Routing;
+using Application.Core.Workflows.KnowledgeGraph;
+using Domain.AI.RAG.Models;
+using Domain.AI.Routing.Enums;
+using Domain.AI.Routing.Models;
+using Domain.Common.Config;
+using FluentAssertions;
+using Infrastructure.AI.KnowledgeGraph;
+using Microsoft.Agents.AI.Workflows;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.KnowledgeGraph;
+
+/// <summary>
+/// End-to-end proof that the "kg-ingestion" workflow (the enrichment stage consumed by
+/// <c>IngestDocumentCommandHandler</c>) writes extracted entities through the DECORATED
+/// <c>IKnowledgeGraphStore</c> chain, not the raw backend: with tenant isolation and
+/// compliance enabled on the in_memory provider, nodes persisted by
+/// <c>StoreGraphExecutor</c> must arrive tenant-stamped from the caller's ambient
+/// <c>IKnowledgeScope</c>, provenance-stamped for the ingestion pipeline, and — per the
+/// writer-authoritative ownership rule — unowned (shared within the tenant).
+/// </summary>
+public sealed class KgIngestionWorkflowDecoratedStoreTests
+{
+    private const string ExtractionJson =
+        """
+        {"entities":[{"name":"Contoso","type":"organization"},{"name":"Fabrikam","type":"organization"}],
+         "relationships":[{"source":"Contoso","predicate":"acquired","target":"Fabrikam"}]}
+        """;
+
+    [Fact]
+    public async Task Run_WithAmbientTenantScope_StoresTenantStampedNodesThroughDecoratedChain()
+    {
+        // Arrange: real KnowledgeGraph DI (in_memory provider, tenant isolation + compliance on),
+        // a mocked model router whose chat client returns a fixed extraction payload.
+        var appConfig = new AppConfig();
+        appConfig.AI.Rag.GraphRag.GraphProvider = "in_memory";
+        appConfig.AI.Rag.GraphRag.MultiTenantIsolation = true;
+        appConfig.AI.Rag.GraphRag.ComplianceEnabled = true;
+        appConfig.AI.Rag.GraphRag.ProvenanceEnabled = true;
+
+        var monitor = new Mock<IOptionsMonitor<AppConfig>>();
+        monitor.SetupGet(m => m.CurrentValue).Returns(appConfig);
+
+        var chatClient = new Mock<IChatClient>();
+        chatClient
+            .Setup(c => c.GetResponseAsync(
+                It.IsAny<IEnumerable<ChatMessage>>(), It.IsAny<ChatOptions?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ChatResponse(new ChatMessage(ChatRole.Assistant, ExtractionJson)));
+
+        var modelRouter = new Mock<IModelRouter>();
+        modelRouter
+            .Setup(r => r.RouteOperationAsync("graph_entity_extraction", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ModelRoutingDecision
+            {
+                SelectedTier = new ModelTier
+                {
+                    Name = "economy",
+                    ClientType = default,
+                    DeploymentName = "test-deployment"
+                },
+                Client = chatClient.Object,
+                Complexity = TaskComplexity.Simple,
+                Source = ClassificationSource.Heuristic,
+                Confidence = 1.0
+            });
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton(monitor.Object);
+        services.AddSingleton(modelRouter.Object);
+        services.AddKnowledgeGraphDependencies(appConfig);
+
+        await using var provider = services.BuildServiceProvider();
+        var workflow = KgIngestionWorkflow.Build(provider);
+
+        var chunk = new DocumentChunk
+        {
+            Id = "doc-1_chunk_0",
+            DocumentId = "doc-1",
+            SectionPath = "Root",
+            Content = "Contoso acquired Fabrikam in 2025.",
+            Tokens = 8,
+            Metadata = new ChunkMetadata
+            {
+                SourceUri = new Uri("file:///docs/report.md"),
+                CreatedAt = DateTimeOffset.UtcNow,
+            },
+        };
+
+        // Act: run the workflow inside an ambient request scope carrying the caller's
+        // knowledge scope — exactly how the ingestion handler runs it under the MediatR
+        // AmbientRequestScopeBehavior.
+        var knowledgeScope = Mock.Of<IKnowledgeScope>(s =>
+            s.UserId == "user-1" && s.TenantId == "tenant-1");
+        var scopeServices = new ServiceCollection();
+        scopeServices.AddSingleton(knowledgeScope);
+        await using var scopeProvider = scopeServices.BuildServiceProvider();
+
+        var ambient = provider.GetRequiredService<IAmbientRequestScope>();
+        KgIngestionResult? outcome;
+        using (ambient.BeginScope(scopeProvider))
+        {
+            await using var run = await InProcessExecution.RunAsync(
+                workflow, new KgIngestionInput([chunk]), cancellationToken: CancellationToken.None);
+
+            outcome = run.NewEvents
+                .OfType<WorkflowOutputEvent>()
+                .Select(e => e.Is<KgIngestionResult>(out var r) ? r : null)
+                .LastOrDefault(r => r is not null);
+        }
+
+        // Assert: the workflow reported stored entities...
+        outcome.Should().NotBeNull();
+        outcome!.NodesStored.Should().Be(2);
+        outcome.EdgesStored.Should().Be(1);
+
+        // ...and the RAW in_memory backend (beneath the decorators) holds nodes that only the
+        // decorated chain could have produced: tenant-stamped by ComplianceAwareGraphStore from
+        // the ambient scope, provenance-stamped for the ingestion pipeline, and unowned
+        // (ownership is writer-authoritative; corpus entities stay shared within the tenant).
+        var rawBackend = provider.GetRequiredKeyedService<IKnowledgeGraphStore>("in_memory");
+        var nodes = await rawBackend.GetAllNodesAsync(CancellationToken.None);
+
+        nodes.Should().HaveCount(2);
+        nodes.Should().OnlyContain(n => n.TenantId == "tenant-1",
+            "ComplianceAwareGraphStore stamps the ambient scope's tenant on write");
+        nodes.Should().OnlyContain(n => n.OwnerId == null,
+            "corpus entities are shared within the tenant — ownership is never defaulted");
+        nodes.Should().OnlyContain(n => n.Provenance != null,
+            "StampProvenanceExecutor stamps every node before storage");
+        nodes.Select(n => n.Name).Should().BeEquivalentTo("Contoso", "Fabrikam");
+    }
+}

--- a/src/Content/Tests/Presentation.Common.Tests/Extensions/ConfigValidationStartupTests.cs
+++ b/src/Content/Tests/Presentation.Common.Tests/Extensions/ConfigValidationStartupTests.cs
@@ -136,6 +136,28 @@ public class ConfigValidationStartupTests
                 ["AppConfig:Observability:Logs:MinExportLevel"] = "NotALevel",
             }
         },
+        {
+            // An enabled graph database naming a provider with no registered
+            // IGraphDatabaseBackend used to compose cleanly and throw on first resolution
+            // (the GraphRag DI landmine) — it must now refuse to start.
+            "RagConfig",
+            new Dictionary<string, string?>
+            {
+                ["AppConfig:AI:Rag:GraphDatabase:Enabled"] = "true",
+                ["AppConfig:AI:Rag:GraphDatabase:Provider"] = "neo4j",
+            }
+        },
+        {
+            // Corpus-graph indexing on ingest writes through IGraphRagService, which exists
+            // only alongside the graph database backend — enabling one without the other
+            // would silently skip the stage on every ingest.
+            "RagConfig (IndexOnIngest)",
+            new Dictionary<string, string?>
+            {
+                ["AppConfig:AI:Rag:GraphDatabase:Enabled"] = "false",
+                ["AppConfig:AI:Rag:GraphRag:IndexOnIngest"] = "true",
+            }
+        },
     };
 
     [Theory]


### PR DESCRIPTION
## What & why

PR **K2** of the external-trigger-API program (scope: `.claude/plans/external-trigger-api-scope.md` §6). Closes the "graph search over a permanently empty graph" hole: `IGraphRagService.IndexCorpusAsync` had **zero production callers**, and the `"kg-ingestion"` keyed workflow was registered but never resolved — so both graph-read paths (`Strategy=GraphRag` search, Phase-D multi-source `"graph"` fan-out) queried graphs nothing ever populated.

Honors Matt's explicit decision: the `"kg-ingestion"` workflow is **kept and retargeted** with a real consumer, not deleted.

## What changed

**Part 1 — corpus graph (`IndexOnIngest`, default off):** after the vector/BM25 commit succeeds, ingestion calls `IndexCorpusAsync(chunks)` — populating exactly the graph GlobalSearch queries.

**Part 2 — knowledge graph (`EnrichKnowledgeGraphOnIngest`, default off):** ingestion resolves the `"kg-ingestion"` keyed workflow (extract → stamp provenance → store) — its first-ever consumer, now named in its docs. Entities land through the **decorated** `IKnowledgeGraphStore` chain: proven by an integration test asserting TenantId stamping on the raw backend beneath the decorators. No adapter needed — the workflow's input contract already takes the handler's chunk list; the workflow itself is untouched except docs.

**Failure posture (both stages):** never fail the ingest — vector/BM25 already committed, and propagating would trigger compensation-delete of a usable ingest. Outcomes surface honestly on new `IngestDocumentResult.GraphIndexed` / `KnowledgeGraphEnriched` tri-state flags (null = stage off). The two stages run **concurrently** (independent stores, shared read-only chunks). Cancellation is logged as cancellation, not failure.

**Part 3 — DI landmine fix:** `IGraphRagService` was registered unconditionally but its required backend only existed under `GraphDatabase.Enabled` + provider `kuzu` — other configs threw at first orchestrator resolution. Now: conditional registration + null-tolerant consumers (GraphRag strategy degrades with an explanatory context via a single shared `RagAssembledContext.GraphRagUnavailable()` factory) + a new `RagConfigValidator` (ValidateOnStart) that fails startup loudly on *incoherent* config (backend enabled with unregistered provider; `IndexOnIngest` without backend). Belt-and-braces by design: the validator guards boot config, handler tolerance covers hot-reload flips. Also gated the keyed `"graph"` retrieval source — same hidden-backend species.

## Corrections & flags surfaced during build/review
- `GraphDatabaseConfig.Enabled` class default is **true** (scope doc said false) — implementation verified correct under the real default.
- Same-species landmine in `AddRagCrossSessionMemory` found and deliberately left (scope discipline) — one validator rule would close it; follow-up.
- Follow-up flagged: when BOTH flags are on, entity extraction runs twice over the same chunks (same router op `graph_entity_extraction`) for the two graphs — a shared-extraction pass is the deeper fix once prompt equivalence is verified.

## Review process
Two-axis `/code-review`: no standards violations; spec verified part-by-part including the decorated-store proof and both builder self-flags. 4-angle `/simplify`: three fixes applied (shared unavailable-context factory, stage parallelization, honest cancellation logging); Try*-method collapse correctly rejected (bodies differ materially).

## Tests
16 new + 1 updated: both stage trios (off→never called / on→called with chunks / failure→ingest still succeeds), decorated-store tenant-stamping proof, DI both-config-states, 8 validator cases, degradation-context tests. Full suite 8,114 green; RAG + ingestion suites 260/260 after review fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BnoLcufW278UxA9ssBM1Tc