### PR TITLE
refactor: single shared ResultFailureType-to-ProblemDetails mapper

### DIFF
--- a/documentation/onboarding/assets/openapi/bundle-api.yaml
+++ b/documentation/onboarding/assets/openapi/bundle-api.yaml
@@ -453,12 +453,12 @@ components:
           examples:
             handle:
               value:
-                title: Not Found
+                title: Not found
                 status: 404
                 detail: Bundle handle not found or expired. Register the bundle again to obtain a fresh handle.
             run:
               value:
-                title: Not Found
+                title: Not found
                 status: 404
                 detail: Bundle run not found. It may never have existed, expired, or belongs to a different caller.
     RateLimited:

--- a/src/AgenticHarness.slnx
+++ b/src/AgenticHarness.slnx
@@ -270,6 +270,11 @@
       <BuildType Solution="Debug-AgentHub-Dashboard|*" Project="Debug" />
       <BuildType Solution="Debug-AgentHub-WebUI|*" Project="Debug" />
     </Project>
+    <Project Path="Content/Tests/Presentation.BundleApi.Tests/Presentation.BundleApi.Tests.csproj">
+      <BuildType Solution="Debug-AgentHub-All|*" Project="Debug" />
+      <BuildType Solution="Debug-AgentHub-Dashboard|*" Project="Debug" />
+      <BuildType Solution="Debug-AgentHub-WebUI|*" Project="Debug" />
+    </Project>
     <Project Path="Content/Tests/Presentation.Common.Tests/Presentation.Common.Tests.csproj">
       <BuildType Solution="Debug-AgentHub-All|*" Project="Debug" />
       <BuildType Solution="Debug-AgentHub-Dashboard|*" Project="Debug" />

--- a/src/Content/Presentation/Presentation.AgentHub/Controllers/ComplianceController.cs
+++ b/src/Content/Presentation/Presentation.AgentHub/Controllers/ComplianceController.cs
@@ -5,6 +5,7 @@ using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Presentation.Common.Extensions;
 
 namespace Presentation.AgentHub.Controllers;
 
@@ -73,35 +74,8 @@ public sealed class ComplianceController : ControllerBase
     /// codes. Failure bodies are generic — handlers have already logged the real detail; the client never
     /// receives store internals, paths, or stack traces (per the harness error-response security rule).
     /// </summary>
-    private IActionResult ToActionResult<T>(Result<T> result)
-    {
-        if (result.IsSuccess)
-        {
-            return Ok(result.Value);
-        }
-
-        return result.FailureType switch
-        {
-            ResultFailureType.Validation => Problem(
-                title: "Validation failed",
-                detail: string.Join(" / ", result.Errors),
-                statusCode: StatusCodes.Status400BadRequest),
-            ResultFailureType.Unauthorized => Problem(
-                title: "Unauthorized",
-                detail: string.Join(" / ", result.Errors),
-                statusCode: StatusCodes.Status401Unauthorized),
-            ResultFailureType.Forbidden => Problem(
-                title: "Forbidden",
-                detail: string.Join(" / ", result.Errors),
-                statusCode: StatusCodes.Status403Forbidden),
-            ResultFailureType.Conflict => Problem(
-                title: "Conflict",
-                detail: string.Join(" / ", result.Errors),
-                statusCode: StatusCodes.Status409Conflict),
-            _ => Problem(
-                title: "Erasure failed",
-                detail: "An error occurred processing the request. See server logs for details.",
-                statusCode: StatusCodes.Status500InternalServerError),
-        };
-    }
+    private IActionResult ToActionResult<T>(Result<T> result) =>
+        result.IsSuccess
+            ? Ok(result.Value)
+            : this.FailureResponse(result, "Erasure failed");
 }

--- a/src/Content/Presentation/Presentation.AgentHub/Controllers/EvalController.cs
+++ b/src/Content/Presentation/Presentation.AgentHub/Controllers/EvalController.cs
@@ -9,6 +9,7 @@ using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Presentation.Common.Extensions;
 
 namespace Presentation.AgentHub.Controllers;
 
@@ -146,7 +147,8 @@ public sealed class EvalController : ControllerBase
 
     /// <summary>
     /// Maps a <see cref="Result{T}"/> outcome to an MVC <see cref="IActionResult"/>:
-    /// Success → 200; NotFound → 404; Validation → 400; everything else → 500.
+    /// Success → 200; failures use the canonical shared mapping
+    /// (400/401/403/404/409, everything else → 500).
     /// </summary>
     /// <remarks>
     /// <para>
@@ -162,46 +164,9 @@ public sealed class EvalController : ControllerBase
     /// sensitive data." Handlers have already logged the original failure with
     /// structured detail; the client gets only a generic correlation message.
     /// </para>
-    /// <para>
-    /// Kept inline rather than in a shared helper because no other controller
-    /// currently consumes <see cref="Result{T}"/> directly. Promote to a shared
-    /// extension when a second consumer appears (matches the Phase 5.4.1
-    /// "no extraction until N=3" precedent for the ValueConverter).
-    /// </para>
     /// </remarks>
-    private IActionResult ToActionResult<T>(Result<T> result)
-    {
-        if (result.IsSuccess)
-        {
-            return Ok(result.Value);
-        }
-
-        return result.FailureType switch
-        {
-            ResultFailureType.NotFound => Problem(
-                title: "Not Found",
-                detail: string.Join(" / ", result.Errors),
-                statusCode: StatusCodes.Status404NotFound),
-            ResultFailureType.Validation => Problem(
-                title: "Validation failed",
-                detail: string.Join(" / ", result.Errors),
-                statusCode: StatusCodes.Status400BadRequest),
-            ResultFailureType.Unauthorized => Problem(
-                title: "Unauthorized",
-                detail: string.Join(" / ", result.Errors),
-                statusCode: StatusCodes.Status401Unauthorized),
-            ResultFailureType.Forbidden => Problem(
-                title: "Forbidden",
-                detail: string.Join(" / ", result.Errors),
-                statusCode: StatusCodes.Status403Forbidden),
-            ResultFailureType.Conflict => Problem(
-                title: "Conflict",
-                detail: string.Join(" / ", result.Errors),
-                statusCode: StatusCodes.Status409Conflict),
-            _ => Problem(
-                title: "Eval operation failed",
-                detail: "An error occurred processing the request. See server logs for details.",
-                statusCode: StatusCodes.Status500InternalServerError),
-        };
-    }
+    private IActionResult ToActionResult<T>(Result<T> result) =>
+        result.IsSuccess
+            ? Ok(result.Value)
+            : this.FailureResponse(result, "Eval operation failed");
 }

--- a/src/Content/Presentation/Presentation.AgentHub/Controllers/MemoryController.cs
+++ b/src/Content/Presentation/Presentation.AgentHub/Controllers/MemoryController.cs
@@ -3,6 +3,7 @@ using Domain.Common;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Presentation.Common.Extensions;
 
 namespace Presentation.AgentHub.Controllers;
 
@@ -124,35 +125,8 @@ public sealed class MemoryController : ControllerBase
         return result.IsSuccess ? NoContent() : MapFailure(result);
     }
 
-    /// <summary>
-    /// Maps a failed <see cref="Result"/> onto an HTTP response, translating failure categories to
-    /// status codes. General (500) failures return a generic body — handlers have already logged
-    /// the real detail; the client never receives store internals, paths, or stack traces (per the
-    /// harness error-response security rule).
-    /// </summary>
-    private IActionResult MapFailure(Result result) => result.FailureType switch
-    {
-        ResultFailureType.Validation => Problem(
-            title: "Validation failed",
-            detail: string.Join(" / ", result.Errors),
-            statusCode: StatusCodes.Status400BadRequest),
-        ResultFailureType.Unauthorized => Problem(
-            title: "Unauthorized",
-            detail: string.Join(" / ", result.Errors),
-            statusCode: StatusCodes.Status401Unauthorized),
-        ResultFailureType.Forbidden => Problem(
-            title: "Forbidden",
-            detail: string.Join(" / ", result.Errors),
-            statusCode: StatusCodes.Status403Forbidden),
-        ResultFailureType.NotFound => Problem(
-            title: "Not found",
-            detail: string.Join(" / ", result.Errors),
-            statusCode: StatusCodes.Status404NotFound),
-        _ => Problem(
-            title: "Memory operation failed",
-            detail: "An error occurred processing the request. See server logs for details.",
-            statusCode: StatusCodes.Status500InternalServerError),
-    };
+    private IActionResult MapFailure(Result result) =>
+        this.FailureResponse(result, "Memory operation failed");
 }
 
 /// <summary>Request body for <c>POST /api/memory</c>.</summary>

--- a/src/Content/Presentation/Presentation.BundleApi/Controllers/BundlesController.cs
+++ b/src/Content/Presentation/Presentation.BundleApi/Controllers/BundlesController.cs
@@ -13,6 +13,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.RateLimiting;
 using Presentation.BundleApi.DTOs;
 using Presentation.BundleApi.Extensions;
+using Presentation.Common.Extensions;
 using Presentation.BundleApi.Services;
 using Presentation.BundleApi.Streaming;
 
@@ -69,7 +70,7 @@ public sealed class BundlesController : ControllerBase
             .ConfigureAwait(false);
 
         if (!result.IsSuccess || result.Value is null)
-            return MapFailure(result.FailureType, result.Errors);
+            return MapFailure(result);
 
         var response = new RegisterBundleResponse { Handle = result.Value.Handle, ExpiresAt = result.Value.ExpiresAt };
         return Created($"/api/bundles/{response.Handle}", response);
@@ -104,7 +105,7 @@ public sealed class BundlesController : ControllerBase
         }, cancellationToken).ConfigureAwait(false);
 
         if (!result.IsSuccess || result.Value is null)
-            return MapFailure(result.FailureType, result.Errors);
+            return MapFailure(result);
 
         var statusUrl = $"/api/bundles/{handle}/runs/{result.Value.JobId}";
         var streamUrl = request.Stream ? $"{statusUrl}/stream" : null;
@@ -146,7 +147,7 @@ public sealed class BundlesController : ControllerBase
             .ConfigureAwait(false);
 
         if (!lookup.IsSuccess || lookup.Value is null)
-            return MapFailure(lookup.FailureType, lookup.Errors);
+            return MapFailure(lookup);
 
         var record = lookup.Value;
         if (!record.Streaming || record.Status != BundleRunStatus.Queued)
@@ -183,7 +184,7 @@ public sealed class BundlesController : ControllerBase
             .ConfigureAwait(false);
 
         if (!result.IsSuccess || result.Value is null)
-            return MapFailure(result.FailureType, result.Errors);
+            return MapFailure(result);
 
         return Ok(BundleRunResponse.FromRecord(result.Value));
     }
@@ -202,7 +203,7 @@ public sealed class BundlesController : ControllerBase
             .Send(new DeleteBundleCommand { Handle = handle, OwnerId = callerId }, cancellationToken)
             .ConfigureAwait(false);
 
-        return result.IsSuccess ? NoContent() : MapFailure(result.FailureType, result.Errors);
+        return result.IsSuccess ? NoContent() : MapFailure(result);
     }
 
     /// <summary>
@@ -223,27 +224,6 @@ public sealed class BundlesController : ControllerBase
         detail: "The authenticated principal carries no usable identity.",
         statusCode: StatusCodes.Status401Unauthorized);
 
-    /// <summary>
-    /// Maps a failed <see cref="Result"/>/<see cref="Result{T}"/> to an HTTP problem response. Validation,
-    /// NotFound, and auth reasons are safe to surface verbatim (validator strings / lookups / declared
-    /// reasons); a general failure returns a generic message only — handlers have already logged the detail,
-    /// and raw error text can leak internal state. Mirrors the mapping used by the harness's other controllers.
-    /// </summary>
-    private IActionResult MapFailure(ResultFailureType failureType, IReadOnlyList<string> errors) => failureType switch
-    {
-        ResultFailureType.NotFound => Problem(
-            title: "Not Found", detail: string.Join(" / ", errors), statusCode: StatusCodes.Status404NotFound),
-        ResultFailureType.Validation => Problem(
-            title: "Validation failed", detail: string.Join(" / ", errors), statusCode: StatusCodes.Status400BadRequest),
-        ResultFailureType.Unauthorized => Problem(
-            title: "Unauthorized", detail: string.Join(" / ", errors), statusCode: StatusCodes.Status401Unauthorized),
-        ResultFailureType.Forbidden => Problem(
-            title: "Forbidden", detail: string.Join(" / ", errors), statusCode: StatusCodes.Status403Forbidden),
-        ResultFailureType.Conflict => Problem(
-            title: "Conflict", detail: string.Join(" / ", errors), statusCode: StatusCodes.Status409Conflict),
-        _ => Problem(
-            title: "Bundle operation failed",
-            detail: "An error occurred processing the request. See server logs for details.",
-            statusCode: StatusCodes.Status500InternalServerError),
-    };
+    private IActionResult MapFailure(Result result) =>
+        this.FailureResponse(result, "Bundle operation failed");
 }

--- a/src/Content/Presentation/Presentation.Common/Extensions/ControllerBaseExtensions.cs
+++ b/src/Content/Presentation/Presentation.Common/Extensions/ControllerBaseExtensions.cs
@@ -1,0 +1,66 @@
+using Domain.Common;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Presentation.Common.Extensions;
+
+/// <summary>
+/// Shared HTTP mapping for failed <see cref="Result"/> instances so every controller in every
+/// host returns identical status-code semantics for the same <see cref="ResultFailureType"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is the single canonical copy of the failure→ProblemDetails switch. Controllers must not
+/// hand-roll their own variant: the per-controller copies this replaced had drifted (one lacked
+/// the <see cref="ResultFailureType.NotFound"/> arm, another lacked
+/// <see cref="ResultFailureType.Conflict"/>), which silently turned well-defined failures into
+/// opaque 500s on some routes but not others.
+/// </para>
+/// <para>
+/// The canonical mapping: <see cref="ResultFailureType.Validation"/> → 400,
+/// <see cref="ResultFailureType.Unauthorized"/> → 401,
+/// <see cref="ResultFailureType.Forbidden"/> → 403,
+/// <see cref="ResultFailureType.NotFound"/> → 404,
+/// <see cref="ResultFailureType.Conflict"/> → 409, and every other failure type → 500 with the
+/// caller-supplied title and a deliberately generic detail line — internal error text must never
+/// leave the trust boundary on an unclassified failure.
+/// </para>
+/// </remarks>
+public static class ControllerBaseExtensions
+{
+    /// <summary>
+    /// Converts a failed <see cref="Result"/> into the canonical RFC 7807 ProblemDetails
+    /// response for its <see cref="Result.FailureType"/>.
+    /// </summary>
+    /// <param name="controller">The controller producing the response; its
+    /// <see cref="ControllerBase.Problem(string?, string?, int?, string?, string?)"/> factory is
+    /// used so host-level ProblemDetails customization (trace ids, extensions) still applies.</param>
+    /// <param name="result">The failed result to translate. Callers should check
+    /// <see cref="Result.IsSuccess"/> first; passing a successful result yields the 500 arm.</param>
+    /// <param name="serverErrorTitle">Problem title used for the unclassified (500) arm — one
+    /// short operation-scoped phrase such as <c>"Memory operation failed"</c>.</param>
+    /// <returns>The mapped <see cref="IActionResult"/>.</returns>
+    public static IActionResult FailureResponse(
+        this ControllerBase controller,
+        Result result,
+        string serverErrorTitle)
+    {
+        var (statusCode, title) = result.FailureType switch
+        {
+            ResultFailureType.Validation => (StatusCodes.Status400BadRequest, "Validation failed"),
+            ResultFailureType.Unauthorized => (StatusCodes.Status401Unauthorized, "Unauthorized"),
+            ResultFailureType.Forbidden => (StatusCodes.Status403Forbidden, "Forbidden"),
+            ResultFailureType.NotFound => (StatusCodes.Status404NotFound, "Not found"),
+            ResultFailureType.Conflict => (StatusCodes.Status409Conflict, "Conflict"),
+            _ => (StatusCodes.Status500InternalServerError, serverErrorTitle),
+        };
+
+        // Unclassified failures may carry raw exception text (store internals, paths); the
+        // classified arms carry validator/lookup strings that are safe to surface verbatim.
+        var detail = statusCode == StatusCodes.Status500InternalServerError
+            ? "An error occurred processing the request. See server logs for details."
+            : string.Join(" / ", result.Errors);
+
+        return controller.Problem(title: title, detail: detail, statusCode: statusCode);
+    }
+}

--- a/src/Content/Tests/Presentation.Common.Tests/Extensions/ControllerBaseExtensionsTests.cs
+++ b/src/Content/Tests/Presentation.Common.Tests/Extensions/ControllerBaseExtensionsTests.cs
@@ -1,0 +1,87 @@
+using Domain.Common;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
+using Moq;
+using Presentation.Common.Extensions;
+using Xunit;
+
+namespace Presentation.Common.Tests.Extensions;
+
+/// <summary>
+/// Locks the canonical failure→ProblemDetails contract of
+/// <see cref="ControllerBaseExtensions.FailureResponse"/>: every classified failure type maps to
+/// its own status code with the result's errors as detail, and unclassified failures collapse to
+/// an opaque 500 that never echoes the result's error text.
+/// </summary>
+public sealed class ControllerBaseExtensionsTests
+{
+    private sealed class ProbeController : ControllerBase;
+
+    private static ProbeController CreateController()
+    {
+        var factory = new Mock<ProblemDetailsFactory>();
+        factory
+            .Setup(f => f.CreateProblemDetails(
+                It.IsAny<HttpContext>(), It.IsAny<int?>(), It.IsAny<string?>(),
+                It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<string?>()))
+            .Returns((HttpContext _, int? status, string? title, string? _, string? detail, string? _) =>
+                new ProblemDetails { Status = status, Title = title, Detail = detail });
+
+        return new ProbeController
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() },
+            ProblemDetailsFactory = factory.Object,
+        };
+    }
+
+    private static ProblemDetails Payload(IActionResult response) =>
+        response.Should().BeOfType<ObjectResult>().Which.Value
+            .Should().BeOfType<ProblemDetails>().Subject;
+
+    public static TheoryData<Result, int, string> ClassifiedFailures => new()
+    {
+        { Result.ValidationFailure(["bad input"]), StatusCodes.Status400BadRequest, "Validation failed" },
+        { Result.Unauthorized("no token"), StatusCodes.Status401Unauthorized, "Unauthorized" },
+        { Result.Forbidden("kill switch"), StatusCodes.Status403Forbidden, "Forbidden" },
+        { Result.NotFound("no such thing"), StatusCodes.Status404NotFound, "Not found" },
+        { Result.Conflict("already resolved"), StatusCodes.Status409Conflict, "Conflict" },
+    };
+
+    [Theory]
+    [MemberData(nameof(ClassifiedFailures))]
+    public void FailureResponse_ClassifiedFailure_MapsStatusTitleAndDetail(
+        Result result, int expectedStatus, string expectedTitle)
+    {
+        var response = CreateController().FailureResponse(result, "Operation failed");
+
+        var problem = Payload(response);
+        problem.Status.Should().Be(expectedStatus);
+        problem.Title.Should().Be(expectedTitle);
+        problem.Detail.Should().Be(string.Join(" / ", result.Errors));
+    }
+
+    [Fact]
+    public void FailureResponse_GeneralFailure_Returns500WithoutLeakingErrorText()
+    {
+        var response = CreateController()
+            .FailureResponse(Result.Fail("SqliteException: no such table at C:\\secret\\path"), "Widget operation failed");
+
+        var problem = Payload(response);
+        problem.Status.Should().Be(StatusCodes.Status500InternalServerError);
+        problem.Title.Should().Be("Widget operation failed");
+        problem.Detail.Should().NotContain("SqliteException").And.NotContain("secret");
+    }
+
+    [Fact]
+    public void FailureResponse_UnmappedClassifiedType_FallsBackToOpaque500()
+    {
+        var response = CreateController()
+            .FailureResponse(Result.GovernanceBlocked("policy X vetoed the call"), "Operation failed");
+
+        var problem = Payload(response);
+        problem.Status.Should().Be(StatusCodes.Status500InternalServerError);
+        problem.Detail.Should().NotContain("policy X");
+    }
+}


### PR DESCRIPTION
## What

Extracts the four per-controller copies of the `ResultFailureType` → ProblemDetails switch (MemoryController, EvalController, ComplianceController, BundlesController) into one canonical `ControllerBase` extension: `Presentation.Common/Extensions/ControllerBaseExtensions.FailureResponse`.

## Why

The copies had drifted: ComplianceController lacked the **NotFound** arm and MemoryController lacked **Conflict**, so well-defined failures degraded to opaque 500s on some routes but not others. Wave 2 adds three more controllers (escalations, learnings, document scoping) — extraction now stops the drift before it multiplies. EvalController's own XML remarks said "promote to a shared extension when a second consumer appears"; we were at four.

## Behavior deltas (intended, all additive-correct)

- ComplianceController: NotFound failures now → 404 (was 500).
- MemoryController: Conflict failures now → 409 (was 500).
- BundlesController and EvalController: 404 title casing normalized `"Not Found"` → `"Not found"` (no test or client asserts titles; the two `bundle-api.yaml` examples are updated to match).
- Everything else verified arm-by-arm identical, including the per-controller 500 titles and the no-leak generic 500 detail.

## Also

- Adds `Presentation.BundleApi.Tests` to `AgenticHarness.slnx` — it existed on disk but never ran in CI (Wave 1 follow-up chore #2).
- New direct contract test for the extension (7 cases, incl. 500-arm never echoes raw error text).

## Test plan

- `Presentation.Common.Tests` 142/142 (7 new), `Presentation.AgentHub.Tests` 402/402, `Presentation.BundleApi.Tests` 26/26.
- Full solution build: 0 errors, no new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BnoLcufW278UxA9ssBM1Tc