### PR TITLE
feat: planner schema init + plan ownership (W1)

### DIFF
--- a/src/Content/Application/Application.AI.Common/Services/KnowledgeGraph/NullKnowledgeScope.cs
+++ b/src/Content/Application/Application.AI.Common/Services/KnowledgeGraph/NullKnowledgeScope.cs
@@ -1,0 +1,45 @@
+using Application.AI.Common.Interfaces.KnowledgeGraph;
+
+namespace Application.AI.Common.Services.KnowledgeGraph;
+
+/// <summary>
+/// Null-object <see cref="IKnowledgeScope"/> representing an anonymous / system execution
+/// context: every scope property is <see langword="null"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Registered as a <c>TryAddScoped</c> fallback by subsystems that consume the ambient
+/// knowledge scope (e.g. the planner state store) so they stay resolvable — and
+/// <c>ValidateOnBuild</c>-safe — in hosts that do not wire the knowledge graph layer.
+/// Composed hosts register the real <c>KnowledgeScopeAccessor</c> (which flows caller
+/// identity via <see cref="AsyncLocal{T}"/>) and that registration wins resolution.
+/// </para>
+/// <para>
+/// Under this scope, ownership stamping writes <see langword="null"/> owner/tenant
+/// (a global record) and scope filtering exposes only global records — the closed-by-default
+/// posture for callers without identity.
+/// </para>
+/// </remarks>
+public sealed class NullKnowledgeScope : IKnowledgeScope
+{
+    /// <inheritdoc />
+    public string? UserId => null;
+
+    /// <inheritdoc />
+    public string? TenantId => null;
+
+    /// <inheritdoc />
+    public string? DatasetId => null;
+
+    /// <inheritdoc />
+    public string? DatasetName => null;
+
+    /// <inheritdoc />
+    public string? DatasetOwnerId => null;
+
+    /// <inheritdoc />
+    public string? AgentId => null;
+
+    /// <inheritdoc />
+    public string? ConversationId => null;
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Attestation/EfCoreAttestationStore.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Attestation/EfCoreAttestationStore.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using Application.AI.Common.Interfaces.Attestation;
+using Application.AI.Common.Interfaces.KnowledgeGraph;
 using Domain.AI.Attestation;
 using Domain.AI.Planner;
 using Domain.Common;
@@ -14,6 +15,13 @@ namespace Infrastructure.AI.Attestation;
 /// as JSON columns on <see cref="Persistence.Entities.StepExecutionStateEntity"/>.
 /// Uses <see cref="IDbContextFactory{TContext}"/> for singleton-safe context creation.
 /// </summary>
+/// <remarks>
+/// Attestations hang off plan steps, so this store enforces the same plan-ownership
+/// boundaries as <c>EfCorePlanStateStore</c> via the shared <see cref="PlannerScopeFilter"/>
+/// predicates: reads are gated by plan VISIBILITY (shared semantics — global plans readable
+/// by all), writes by strict WRITABILITY (exact owner+tenant match). Cross-owner access is
+/// indistinguishable from absence — null/empty/NotFound, never Forbidden (404-not-403).
+/// </remarks>
 public sealed class EfCoreAttestationStore : IAttestationStore
 {
     private static readonly JsonSerializerOptions JsonOptions = new()
@@ -24,13 +32,24 @@ public sealed class EfCoreAttestationStore : IAttestationStore
 
     private readonly IDbContextFactory<PlannerDbContext> _factory;
     private readonly ILogger<EfCoreAttestationStore> _logger;
+    private readonly IKnowledgeScope _scope;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EfCoreAttestationStore"/> class.
+    /// </summary>
+    /// <param name="factory">Factory for short-lived planner contexts.</param>
+    /// <param name="logger">Structured logger.</param>
+    /// <param name="scope">
+    /// Ambient knowledge scope of the caller; drives plan visibility/writability gating.
+    /// </param>
     public EfCoreAttestationStore(
         IDbContextFactory<PlannerDbContext> factory,
-        ILogger<EfCoreAttestationStore> logger)
+        ILogger<EfCoreAttestationStore> logger,
+        IKnowledgeScope scope)
     {
         _factory = factory;
         _logger = logger;
+        _scope = scope;
     }
 
     /// <inheritdoc />
@@ -38,13 +57,19 @@ public sealed class EfCoreAttestationStore : IAttestationStore
     {
         await using var context = await _factory.CreateDbContextAsync(ct);
 
+        // Write path: strict ownership — a step on a plan the caller doesn't own (including
+        // globally READABLE null-owner plans) is indistinguishable from missing (404-not-403).
+        if (!await PlannerScopeFilter.WritableBy(context.PlanGraphs, _scope)
+                .AnyAsync(g => g.Steps.Any(s => s.Id == stepId.Value), ct))
+            return Result.NotFound($"StepExecutionState not found for step {stepId.Value}");
+
         var entity = await context.StepExecutionStates
             .FirstOrDefaultAsync(s => s.StepId == stepId.Value, ct);
 
         if (entity is null)
         {
             _logger.LogWarning("StepExecutionState not found for step {StepId}", stepId.Value);
-            return Result.Fail($"StepExecutionState not found for step {stepId.Value}");
+            return Result.NotFound($"StepExecutionState not found for step {stepId.Value}");
         }
 
         entity.AttestationJson = JsonSerializer.Serialize(attestation, JsonOptions);
@@ -57,6 +82,12 @@ public sealed class EfCoreAttestationStore : IAttestationStore
     public async Task<Result<ToolExecutionAttestation?>> GetByStepAsync(PlanStepId stepId, CancellationToken ct)
     {
         await using var context = await _factory.CreateDbContextAsync(ct);
+
+        // Read path: shared visibility — an attestation on another owner's plan resolves to
+        // null, exactly like a missing one.
+        if (!await PlannerScopeFilter.VisibleTo(context.PlanGraphs, _scope)
+                .AnyAsync(g => g.Steps.Any(s => s.Id == stepId.Value), ct))
+            return Result<ToolExecutionAttestation?>.Success(null);
 
         var entity = await context.StepExecutionStates
             .AsNoTracking()
@@ -76,6 +107,12 @@ public sealed class EfCoreAttestationStore : IAttestationStore
     public async Task<Result<IReadOnlyList<ToolExecutionAttestation>>> GetByPlanAsync(PlanId planId, CancellationToken ct)
     {
         await using var context = await _factory.CreateDbContextAsync(ct);
+
+        // Read path: shared visibility — another owner's plan yields the same empty list as
+        // a missing plan.
+        if (!await PlannerScopeFilter.VisibleTo(context.PlanGraphs, _scope)
+                .AnyAsync(g => g.Id == planId.Value, ct))
+            return Result<IReadOnlyList<ToolExecutionAttestation>>.Success([]);
 
         var entities = await context.StepExecutionStates
             .AsNoTracking()

--- a/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.Planner.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.Planner.cs
@@ -1,7 +1,9 @@
 using Application.AI.Common.Interfaces.Attestation;
 using Application.AI.Common.Interfaces.Escalation;
+using Application.AI.Common.Interfaces.KnowledgeGraph;
 using Application.AI.Common.Interfaces.Planner;
 using Application.AI.Common.Interfaces.Sandbox;
+using Application.AI.Common.Services.KnowledgeGraph;
 using Domain.AI.Planner;
 using Domain.AI.Sandbox;
 using Domain.Common.Config;
@@ -34,6 +36,16 @@ public static partial class DependencyInjection
             .UseSqlite(connectionString)
             .AddInterceptors(new SqliteVersionInterceptor()));
         services.AddScoped(sp => sp.GetRequiredService<IDbContextFactory<PlannerDbContext>>().CreateDbContext());
+
+        // Ensure the schema is created before the first store operation. Idempotent.
+        // Same lifecycle as the PromptUsage and EvalDashboard persistence registrations,
+        // but through the planner-specific subclass: base EnsureCreated (no-op on existing
+        // databases) plus PRAGMA-guarded DDL that adds the OwnerId/TenantId columns to a
+        // pre-existing PlanGraphs table. EfCorePlanStateStore demands the initializer as a
+        // plain constructor dependency (visible to ValidateOnBuild), so resolving
+        // IPlanStateStore forces schema-create exactly once — closing the "no such table"
+        // hole the first SavePlanAsync would otherwise hit.
+        services.AddSingleton<SchemaInitializer<PlannerDbContext>, PlannerSchemaInitializer>();
     }
 
     /// <summary>
@@ -48,6 +60,15 @@ public static partial class DependencyInjection
         // rather than a factory with a GetService fallback — keeps PlanExecutor's dependencies
         // visible to ValidateOnBuild.
         services.TryAddSingleton(TimeProvider.System);
+
+        // TryAddScoped keeps Infrastructure.AI standalone-safe: EfCorePlanStateStore stamps
+        // and filters plan ownership from the ambient IKnowledgeScope, which composed hosts
+        // register first (KnowledgeScopeAccessor via AddKnowledgeGraphDependencies) so that
+        // registration wins resolution. Hosts without the knowledge graph layer fall back to
+        // the anonymous NullKnowledgeScope — plans save unstamped (global) and reads see only
+        // global plans, preserving today's single-user behavior while staying ValidateOnBuild-safe.
+        services.TryAddScoped<IKnowledgeScope, NullKnowledgeScope>();
+
         services.AddScoped<IPlanExecutor, PlanExecutor>();
         services.AddScoped<IPlanValidator, PlanValidator>();
         services.AddScoped<IPlanGenerator, LlmPlanGeneratorService>();

--- a/src/Content/Infrastructure/Infrastructure.AI/Persistence/Configurations/PlanGraphEntityConfiguration.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Persistence/Configurations/PlanGraphEntityConfiguration.cs
@@ -31,7 +31,17 @@ public sealed class PlanGraphEntityConfiguration : IEntityTypeConfiguration<Plan
             .HasForeignKey(e => e.ParentPlanId)
             .OnDelete(DeleteBehavior.SetNull);
 
+        builder.Property(e => e.OwnerId).HasMaxLength(PlannerScopeFilter.MaxIdentityLength);
+        builder.Property(e => e.TenantId).HasMaxLength(PlannerScopeFilter.MaxIdentityLength);
+
         builder.HasIndex(e => e.ParentPlanId);
         builder.HasIndex(e => e.CreatedAt);
+
+        // Serves exact-match owner/tenant lookups — the write-path predicate
+        // (PlannerScopeFilter.WritableBy: TenantId = ? AND OwnerId = ?) can seek it directly.
+        // The read-path visibility predicate's OR-under-AND shape (null-or-match per column)
+        // is not sargable against this index on SQLite; reads scan, which is acceptable at
+        // planner-table cardinality.
+        builder.HasIndex(e => new { e.TenantId, e.OwnerId });
     }
 }

--- a/src/Content/Infrastructure/Infrastructure.AI/Persistence/Entities/PlanGraphEntity.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Persistence/Entities/PlanGraphEntity.cs
@@ -30,6 +30,21 @@ public sealed class PlanGraphEntity
     /// <summary>Optimistic concurrency token incremented on each save.</summary>
     public int Version { get; set; }
 
+    /// <summary>
+    /// Canonicalized owner (user) identity stamped from the ambient knowledge scope at save
+    /// time (see <see cref="Domain.AI.KnowledgeGraph.Scoping.ScopeIdentity"/>). Null denotes
+    /// a global (unowned) plan, visible to every caller. Never accepted from a command/DTO —
+    /// the state store stamps it itself.
+    /// </summary>
+    public string? OwnerId { get; set; }
+
+    /// <summary>
+    /// Canonicalized tenant identity stamped from the ambient knowledge scope at save time.
+    /// Null denotes a global (tenant-unscoped) plan. Mirrors the knowledge-record visibility
+    /// semantics used by the knowledge graph's tenant isolation.
+    /// </summary>
+    public string? TenantId { get; set; }
+
     // Navigation properties
 
     /// <summary>Steps belonging to this plan graph.</summary>

--- a/src/Content/Infrastructure/Infrastructure.AI/Persistence/PlannerSchemaInitializer.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Persistence/PlannerSchemaInitializer.cs
@@ -50,6 +50,12 @@ public sealed class PlannerSchemaInitializer : SchemaInitializer<PlannerDbContex
     {
         var columns = ReadColumnNames(context);
 
+        // EnsureCreated short-circuits when the database has ANY table, so a database file
+        // with other tables but no PlanGraphs would reach this point with zero columns —
+        // ALTER TABLE would then throw at startup. No table means nothing to evolve.
+        if (columns.Count == 0)
+            return;
+
         if (!columns.Contains("OwnerId"))
             context.Database.ExecuteSqlRaw("ALTER TABLE \"PlanGraphs\" ADD COLUMN \"OwnerId\" TEXT NULL;");
 

--- a/src/Content/Infrastructure/Infrastructure.AI/Persistence/PlannerSchemaInitializer.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Persistence/PlannerSchemaInitializer.cs
@@ -1,0 +1,85 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace Infrastructure.AI.Persistence;
+
+/// <summary>
+/// Planner-specific schema initializer: runs the base EnsureCreated lifecycle, then applies
+/// idempotent, PRAGMA-guarded DDL for schema additions that EnsureCreated cannot deliver to
+/// a pre-existing database.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="SchemaInitializer{TContext}"/> only calls <c>EnsureCreated</c>, which is a
+/// no-op when the database already exists — so a template consumer who created a planner
+/// database before the ownership columns shipped would never receive them, and the first
+/// scope-filtered query would fail with "no such column". This subclass checks
+/// <c>PRAGMA table_info(PlanGraphs)</c> and adds the missing <c>OwnerId</c>/<c>TenantId</c>
+/// columns (plus the composite index) in place. Existing rows keep <c>NULL</c> ownership —
+/// the documented "global record" semantics — so no backfill is needed.
+/// </para>
+/// <para>
+/// SQLite-specific by design (the planner registration is SQLite-only); the evolution step
+/// is skipped for any other provider, where a fresh EnsureCreated already contains the
+/// columns. Kept planner-specific deliberately — the shared
+/// <see cref="SchemaInitializer{TContext}"/> stays a pure EnsureCreated wrapper for the
+/// other subsystems.
+/// </para>
+/// </remarks>
+public sealed class PlannerSchemaInitializer : SchemaInitializer<PlannerDbContext>
+{
+    /// <summary>
+    /// Initializes a new instance: ensures the database exists (base), then ensures the
+    /// ownership columns and their composite index exist on <c>PlanGraphs</c>.
+    /// </summary>
+    /// <param name="contextFactory">Factory for short-lived planner contexts.</param>
+    public PlannerSchemaInitializer(IDbContextFactory<PlannerDbContext> contextFactory)
+        : base(contextFactory)
+    {
+        using var context = contextFactory.CreateDbContext();
+        if (context.Database.IsSqlite())
+            EnsureOwnershipColumns(context);
+    }
+
+    /// <summary>
+    /// Adds <c>OwnerId</c>/<c>TenantId</c> to <c>PlanGraphs</c> when a pre-existing database
+    /// lacks them, and (re)creates the composite scope index. Idempotent: guarded by
+    /// <c>PRAGMA table_info</c> and <c>CREATE INDEX IF NOT EXISTS</c>.
+    /// </summary>
+    /// <param name="context">An open planner context on the target database.</param>
+    private static void EnsureOwnershipColumns(PlannerDbContext context)
+    {
+        var columns = ReadColumnNames(context);
+
+        if (!columns.Contains("OwnerId"))
+            context.Database.ExecuteSqlRaw("ALTER TABLE \"PlanGraphs\" ADD COLUMN \"OwnerId\" TEXT NULL;");
+
+        if (!columns.Contains("TenantId"))
+            context.Database.ExecuteSqlRaw("ALTER TABLE \"PlanGraphs\" ADD COLUMN \"TenantId\" TEXT NULL;");
+
+        context.Database.ExecuteSqlRaw(
+            "CREATE INDEX IF NOT EXISTS \"IX_PlanGraphs_TenantId_OwnerId\" " +
+            "ON \"PlanGraphs\" (\"TenantId\", \"OwnerId\");");
+    }
+
+    /// <summary>
+    /// Reads the current column names of <c>PlanGraphs</c> via <c>PRAGMA table_info</c>
+    /// (name is the second result column).
+    /// </summary>
+    /// <param name="context">An open planner context on the target database.</param>
+    /// <returns>The case-insensitive set of existing column names.</returns>
+    private static HashSet<string> ReadColumnNames(PlannerDbContext context)
+    {
+        var columns = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var connection = context.Database.GetDbConnection();
+        if (connection.State != System.Data.ConnectionState.Open)
+            connection.Open();
+
+        using var command = connection.CreateCommand();
+        command.CommandText = "PRAGMA table_info(\"PlanGraphs\");";
+        using var reader = command.ExecuteReader();
+        while (reader.Read())
+            columns.Add(reader.GetString(1));
+
+        return columns;
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Persistence/PlannerScopeFilter.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Persistence/PlannerScopeFilter.cs
@@ -1,0 +1,75 @@
+using Application.AI.Common.Interfaces.KnowledgeGraph;
+using Domain.AI.KnowledgeGraph.Scoping;
+using Infrastructure.AI.Persistence.Entities;
+
+namespace Infrastructure.AI.Persistence;
+
+/// <summary>
+/// Shared scope predicates for every consumer of <see cref="PlannerDbContext"/>
+/// (<c>EfCorePlanStateStore</c>, <c>EfCoreAttestationStore</c>), so plan visibility and
+/// writability are decided identically no matter which store a future host arms.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Reads</b> use <see cref="VisibleTo"/> — the knowledge-record sharing semantics
+/// (tenant matches or record tenant is null/global, AND owner matches or record owner is
+/// null/unowned), mirroring <c>TenantIsolatedGraphStore</c>.
+/// </para>
+/// <para>
+/// <b>Writes</b> use <see cref="WritableBy"/> — strict exact-match: the record's
+/// canonicalized tenant AND owner must equal the caller's. A null-owner (global) plan is
+/// therefore readable by everyone but mutable only by a caller with no ambient identity
+/// (system context); a scoped caller can never mutate a plan they don't own.
+/// </para>
+/// <para>
+/// Caller identity is canonicalized via <see cref="ScopeIdentity.Canonicalize"/> — the same
+/// form stamped on write — so plain SQL equality is exact, and EF Core rewrites the
+/// null-parameter comparisons to <c>IS NULL</c>.
+/// </para>
+/// </remarks>
+internal static class PlannerScopeFilter
+{
+    /// <summary>
+    /// Maximum persisted length for a canonicalized owner or tenant identity. Mirrors the
+    /// <c>HasMaxLength</c> mapping on <see cref="PlanGraphEntity"/>; writers must guard
+    /// against longer values explicitly because SQLite does not enforce column lengths.
+    /// </summary>
+    internal const int MaxIdentityLength = 256;
+
+    /// <summary>
+    /// Filters to the plans the ambient caller may read: tenant matches (or the plan's
+    /// tenant is null/global) AND owner matches (or the plan's owner is null/unowned).
+    /// A caller without identity sees only global plans — closed-by-default.
+    /// </summary>
+    /// <param name="plans">The plan graph query to filter.</param>
+    /// <param name="scope">The ambient knowledge scope of the caller.</param>
+    /// <returns>The scope-filtered query.</returns>
+    internal static IQueryable<PlanGraphEntity> VisibleTo(
+        IQueryable<PlanGraphEntity> plans, IKnowledgeScope scope)
+    {
+        var owner = ScopeIdentity.Canonicalize(scope.UserId);
+        var tenant = ScopeIdentity.Canonicalize(scope.TenantId);
+
+        return plans.Where(g =>
+            (g.TenantId == null || g.TenantId == tenant) &&
+            (g.OwnerId == null || g.OwnerId == owner));
+    }
+
+    /// <summary>
+    /// Filters to the plans the ambient caller may mutate: the plan's canonicalized tenant
+    /// AND owner must exactly equal the caller's. Unlike <see cref="VisibleTo"/>, a
+    /// null-owner (global) plan is writable only when the caller's canonicalized owner is
+    /// also null — shared visibility never grants shared mutation.
+    /// </summary>
+    /// <param name="plans">The plan graph query to filter.</param>
+    /// <param name="scope">The ambient knowledge scope of the caller.</param>
+    /// <returns>The scope-filtered query.</returns>
+    internal static IQueryable<PlanGraphEntity> WritableBy(
+        IQueryable<PlanGraphEntity> plans, IKnowledgeScope scope)
+    {
+        var owner = ScopeIdentity.Canonicalize(scope.UserId);
+        var tenant = ScopeIdentity.Canonicalize(scope.TenantId);
+
+        return plans.Where(g => g.TenantId == tenant && g.OwnerId == owner);
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Planner/EfCorePlanStateStore.Reads.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Planner/EfCorePlanStateStore.Reads.cs
@@ -152,10 +152,16 @@ public sealed partial class EfCorePlanStateStore
 
         // Write path: resume mutates step states, so it demands strict ownership — resuming
         // a plan the caller doesn't own (including globally READABLE null-owner plans)
-        // returns the same NotFound as a missing plan (404-not-403).
+        // returns the same NotFound as a missing plan (404-not-403). The warning keeps a
+        // mis-wired scope diagnosable without weakening the outward NotFound.
         if (!await IsPlanWritableAsync(ctx, planId.Value, ct))
+        {
+            _logger.LogWarning(
+                "Plan {PlanId} is missing or not writable in the current scope; resume rejected",
+                planId.Value);
             return Result<IReadOnlyDictionary<PlanStepId, StepExecutionState>>.NotFound(
                 $"No step states found for plan {planId.Value}");
+        }
 
         var entities = await ctx.StepExecutionStates
             .Where(s => ctx.PlanSteps.Any(ps => ps.Id == s.StepId && ps.PlanGraphId == planId.Value))

--- a/src/Content/Infrastructure/Infrastructure.AI/Planner/EfCorePlanStateStore.Reads.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Planner/EfCorePlanStateStore.Reads.cs
@@ -15,7 +15,8 @@ public sealed partial class EfCorePlanStateStore
     {
         await using var ctx = _factory.CreateDbContext();
 
-        var entity = await ctx.PlanGraphs
+        // Scope-filtered: another owner's plan resolves to null, exactly like a missing plan.
+        var entity = await VisiblePlans(ctx)
             .AsNoTracking()
             .Include(g => g.Steps).ThenInclude(s => s.ExecutionState)
             .Include(g => g.Edges)
@@ -32,6 +33,11 @@ public sealed partial class EfCorePlanStateStore
         PlanId planId, CancellationToken ct)
     {
         await using var ctx = _factory.CreateDbContext();
+
+        // Scope-filtered: another owner's plan yields the same empty map as a missing plan.
+        if (!await IsPlanVisibleAsync(ctx, planId.Value, ct))
+            return Result<IReadOnlyDictionary<PlanStepId, StepExecutionState>>.Success(
+                new Dictionary<PlanStepId, StepExecutionState>());
 
         var entities = await ctx.StepExecutionStates
             .AsNoTracking()
@@ -55,7 +61,9 @@ public sealed partial class EfCorePlanStateStore
     {
         await using var ctx = _factory.CreateDbContext();
 
-        IQueryable<PlanGraphEntity> query = ctx.PlanGraphs
+        // Scope-filtered: the listing only ever contains the caller's own plans plus
+        // global (unstamped) ones — other owners' plans are simply absent.
+        IQueryable<PlanGraphEntity> query = VisiblePlans(ctx)
             .AsNoTracking()
             .Include(g => g.Steps).ThenInclude(s => s.ExecutionState)
             .Include(g => g.Edges);
@@ -85,6 +93,10 @@ public sealed partial class EfCorePlanStateStore
         PlanId planId, CancellationToken ct)
     {
         await using var ctx = _factory.CreateDbContext();
+
+        // Scope-filtered: another owner's plan yields the same empty history as a missing plan.
+        if (!await IsPlanVisibleAsync(ctx, planId.Value, ct))
+            return Result<IReadOnlyList<PlanExecutionLogEntry>>.Success([]);
 
         var logs = await ctx.PlanExecutionLogs
             .AsNoTracking()
@@ -137,6 +149,13 @@ public sealed partial class EfCorePlanStateStore
         PlanId planId, CancellationToken ct)
     {
         await using var ctx = _factory.CreateDbContext();
+
+        // Write path: resume mutates step states, so it demands strict ownership — resuming
+        // a plan the caller doesn't own (including globally READABLE null-owner plans)
+        // returns the same NotFound as a missing plan (404-not-403).
+        if (!await IsPlanWritableAsync(ctx, planId.Value, ct))
+            return Result<IReadOnlyDictionary<PlanStepId, StepExecutionState>>.NotFound(
+                $"No step states found for plan {planId.Value}");
 
         var entities = await ctx.StepExecutionStates
             .Where(s => ctx.PlanSteps.Any(ps => ps.Id == s.StepId && ps.PlanGraphId == planId.Value))

--- a/src/Content/Infrastructure/Infrastructure.AI/Planner/EfCorePlanStateStore.Visibility.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Planner/EfCorePlanStateStore.Visibility.cs
@@ -1,0 +1,67 @@
+using Infrastructure.AI.Persistence;
+using Infrastructure.AI.Persistence.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace Infrastructure.AI.Planner;
+
+public sealed partial class EfCorePlanStateStore
+{
+    /// <summary>
+    /// Returns the plan graphs the ambient caller may READ, delegating to
+    /// <see cref="PlannerScopeFilter.VisibleTo"/> (shared with the attestation store):
+    /// tenant matches or is null/global, AND owner matches or is null/unowned.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately NOT a system bypass: a caller with no ambient identity sees only global
+    /// plans — closed-by-default for the future HTTP host, where an anonymous request must
+    /// never enumerate tenant- or owner-stamped plans. Request-initiated executor work is
+    /// unaffected — the ambient scope flows via <c>AsyncLocal</c> into child DI scopes and
+    /// post-turn continuations (see <c>KnowledgeScopeAccessor</c>).
+    /// </remarks>
+    /// <param name="ctx">The active planner context.</param>
+    /// <returns>A query over the plans the ambient caller may see.</returns>
+    private IQueryable<PlanGraphEntity> VisiblePlans(PlannerDbContext ctx)
+        => PlannerScopeFilter.VisibleTo(ctx.PlanGraphs, _scope);
+
+    /// <summary>
+    /// Returns the plan graphs the ambient caller may MUTATE, delegating to
+    /// <see cref="PlannerScopeFilter.WritableBy"/>: exact tenant AND owner equality.
+    /// A globally readable (null-owner) plan is never mutable by a scoped caller.
+    /// </summary>
+    /// <param name="ctx">The active planner context.</param>
+    /// <returns>A query over the plans the ambient caller may mutate.</returns>
+    private IQueryable<PlanGraphEntity> WritablePlans(PlannerDbContext ctx)
+        => PlannerScopeFilter.WritableBy(ctx.PlanGraphs, _scope);
+
+    /// <summary>
+    /// Determines whether the plan exists AND is visible to the ambient caller. Callers must
+    /// map <c>false</c> to the same NotFound/null/empty result they return for a missing plan,
+    /// so cross-owner access is indistinguishable from absence (404-not-403).
+    /// </summary>
+    /// <param name="ctx">The active planner context.</param>
+    /// <param name="planId">The plan identifier to probe.</param>
+    /// <param name="ct">Cancellation token.</param>
+    private Task<bool> IsPlanVisibleAsync(PlannerDbContext ctx, Guid planId, CancellationToken ct)
+        => VisiblePlans(ctx).AnyAsync(g => g.Id == planId, ct);
+
+    /// <summary>
+    /// Determines whether the plan exists AND is mutable by the ambient caller. Same
+    /// NotFound-on-failure contract as <see cref="IsPlanVisibleAsync"/> — a plan the caller
+    /// can read but not mutate still reads as NotFound on the write path, never Forbidden.
+    /// </summary>
+    /// <param name="ctx">The active planner context.</param>
+    /// <param name="planId">The plan identifier to probe.</param>
+    /// <param name="ct">Cancellation token.</param>
+    private Task<bool> IsPlanWritableAsync(PlannerDbContext ctx, Guid planId, CancellationToken ct)
+        => WritablePlans(ctx).AnyAsync(g => g.Id == planId, ct);
+
+    /// <summary>
+    /// Determines whether the step exists on a plan mutable by the ambient caller. Same
+    /// NotFound-on-failure contract as <see cref="IsPlanWritableAsync"/>.
+    /// </summary>
+    /// <param name="ctx">The active planner context.</param>
+    /// <param name="stepId">The step identifier to probe.</param>
+    /// <param name="ct">Cancellation token.</param>
+    private Task<bool> IsStepWritableAsync(PlannerDbContext ctx, Guid stepId, CancellationToken ct)
+        => WritablePlans(ctx).AnyAsync(g => g.Steps.Any(s => s.Id == stepId), ct);
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Planner/EfCorePlanStateStore.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Planner/EfCorePlanStateStore.cs
@@ -1,5 +1,7 @@
 using System.Text.Json;
+using Application.AI.Common.Interfaces.KnowledgeGraph;
 using Application.AI.Common.Interfaces.Planner;
+using Domain.AI.KnowledgeGraph.Scoping;
 using Domain.AI.Planner;
 using Domain.Common;
 using Infrastructure.AI.Persistence;
@@ -14,6 +16,23 @@ namespace Infrastructure.AI.Planner;
 /// operations to the persistence layer. Uses <see cref="IDbContextFactory{TContext}"/>
 /// for short-lived contexts, making it safe for singleton and scoped callers.
 /// </summary>
+/// <remarks>
+/// <para>
+/// <b>Ownership:</b> every saved plan is stamped with the canonicalized owner/tenant from
+/// the ambient <see cref="IKnowledgeScope"/> (set per-request by the host's scope
+/// middleware/hub filter and flowing via <c>AsyncLocal</c>), mirroring how
+/// <c>KnowledgeMemoryService</c> self-stamps knowledge records. Identity is never accepted
+/// from a command or DTO — ambient scope only. Every read/list/execute path filters by the
+/// same scope; a plan another owner saved is indistinguishable from a missing plan
+/// (NotFound/null/empty, never Forbidden).
+/// </para>
+/// <para>
+/// <b>Schema:</b> the constructor demands <see cref="SchemaInitializer{TContext}"/> so
+/// resolving the store forces the SQLite schema into existence before the first operation —
+/// the same lifecycle the prompt-usage and eval-dashboard stores use, expressed as a plain
+/// constructor dependency so it stays visible to <c>ValidateOnBuild</c>.
+/// </para>
+/// </remarks>
 public sealed partial class EfCorePlanStateStore : IPlanStateStore
 {
     private static readonly JsonSerializerOptions JsonOptions = new()
@@ -25,15 +44,20 @@ public sealed partial class EfCorePlanStateStore : IPlanStateStore
     private readonly IDbContextFactory<PlannerDbContext> _factory;
     private readonly ILogger<EfCorePlanStateStore> _logger;
     private readonly TimeProvider _timeProvider;
+    private readonly IKnowledgeScope _scope;
 
     public EfCorePlanStateStore(
         IDbContextFactory<PlannerDbContext> factory,
         ILogger<EfCorePlanStateStore> logger,
-        TimeProvider timeProvider)
+        TimeProvider timeProvider,
+        IKnowledgeScope scope,
+        SchemaInitializer<PlannerDbContext> schemaInitializer)
     {
+        ArgumentNullException.ThrowIfNull(schemaInitializer);
         _factory = factory;
         _logger = logger;
         _timeProvider = timeProvider;
+        _scope = scope;
     }
 
     /// <inheritdoc />
@@ -41,6 +65,22 @@ public sealed partial class EfCorePlanStateStore : IPlanStateStore
     {
         await using var ctx = _factory.CreateDbContext();
         var now = _timeProvider.GetUtcNow();
+
+        // Self-stamped from the ambient scope (never from caller-supplied data) in the
+        // shared canonical form, so scope filters compare identically on read/write.
+        var owner = ScopeIdentity.Canonicalize(_scope.UserId);
+        var tenant = ScopeIdentity.Canonicalize(_scope.TenantId);
+
+        // SQLite treats HasMaxLength as advisory; guard explicitly so an oversized identity
+        // fails cleanly here instead of silently truncating on providers that would.
+        if (owner?.Length > PlannerScopeFilter.MaxIdentityLength
+            || tenant?.Length > PlannerScopeFilter.MaxIdentityLength)
+            return Result.Fail("Ambient scope identity exceeds the maximum supported length.");
+
+        // Plan ids are caller-supplied; a colliding id must not surface as an unhandled
+        // constraint exception. Generic message — no internals echoed.
+        if (await ctx.PlanGraphs.AsNoTracking().AnyAsync(g => g.Id == plan.Id.Value, ct))
+            return Result.Fail("A plan with this id already exists.");
 
         var graphEntity = new PlanGraphEntity
         {
@@ -50,6 +90,8 @@ public sealed partial class EfCorePlanStateStore : IPlanStateStore
             ConfigurationJson = JsonSerializer.Serialize(plan.Configuration, JsonOptions),
             CreatedAt = now,
             UpdatedAt = now,
+            OwnerId = owner,
+            TenantId = tenant,
         };
 
         foreach (var step in plan.Steps)
@@ -96,7 +138,17 @@ public sealed partial class EfCorePlanStateStore : IPlanStateStore
         });
 
         ctx.PlanGraphs.Add(graphEntity);
-        await ctx.SaveChangesAsync(ct);
+        try
+        {
+            await ctx.SaveChangesAsync(ct);
+        }
+        catch (DbUpdateException ex)
+        {
+            // Race with a concurrent insert of the same id: same generic answer as the
+            // pre-check, full detail to structured logging only.
+            _logger.LogWarning(ex, "Failed to persist plan {PlanId}: constraint violation", plan.Id.Value);
+            return Result.Fail("A plan with this id already exists.");
+        }
 
         _logger.LogInformation("Saved plan {PlanId} with {StepCount} steps", plan.Id.Value, plan.Steps.Count);
         return Result.Success();
@@ -106,6 +158,11 @@ public sealed partial class EfCorePlanStateStore : IPlanStateStore
     public async Task<Result> UpdateStepStateAsync(StepExecutionState state, CancellationToken ct)
     {
         await using var ctx = _factory.CreateDbContext();
+
+        // Write path: strict ownership — a step on a plan the caller doesn't own (including
+        // globally READABLE null-owner plans) is indistinguishable from missing (404-not-403).
+        if (!await IsStepWritableAsync(ctx, state.StepId.Value, ct))
+            return Result.NotFound($"Execution state not found for step {state.StepId.Value}");
 
         var entity = await ctx.StepExecutionStates
             .FirstOrDefaultAsync(s => s.StepId == state.StepId.Value, ct);
@@ -157,6 +214,11 @@ public sealed partial class EfCorePlanStateStore : IPlanStateStore
         PlanId planId, IReadOnlyList<StepExecutionState> states, CancellationToken ct)
     {
         await using var ctx = _factory.CreateDbContext();
+
+        // Write path: strict ownership — a plan the caller doesn't own (including globally
+        // READABLE null-owner plans) is indistinguishable from missing (404-not-403).
+        if (!await IsPlanWritableAsync(ctx, planId.Value, ct))
+            return Result.NotFound($"No step states found for plan {planId.Value}");
 
         var entities = await ctx.StepExecutionStates
             .Where(s => ctx.PlanSteps.Any(ps => ps.Id == s.StepId && ps.PlanGraphId == planId.Value))

--- a/src/Content/Infrastructure/Infrastructure.AI/Planner/EfCorePlanStateStore.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Planner/EfCorePlanStateStore.cs
@@ -78,8 +78,10 @@ public sealed partial class EfCorePlanStateStore : IPlanStateStore
             return Result.Fail("Ambient scope identity exceeds the maximum supported length.");
 
         // Plan ids are caller-supplied; a colliding id must not surface as an unhandled
-        // constraint exception. Generic message — no internals echoed.
-        if (await ctx.PlanGraphs.AsNoTracking().AnyAsync(g => g.Id == plan.Id.Value, ct))
+        // constraint exception. The probe is scope-filtered so a collision with a plan the
+        // caller cannot see never confirms its existence — that case falls through to the
+        // insert and surfaces as the same generic constraint failure as any other race.
+        if (await VisiblePlans(ctx).AsNoTracking().AnyAsync(g => g.Id == plan.Id.Value, ct))
             return Result.Fail("A plan with this id already exists.");
 
         var graphEntity = new PlanGraphEntity
@@ -144,10 +146,11 @@ public sealed partial class EfCorePlanStateStore : IPlanStateStore
         }
         catch (DbUpdateException ex)
         {
-            // Race with a concurrent insert of the same id: same generic answer as the
-            // pre-check, full detail to structured logging only.
+            // A concurrent insert of the same id, or a collision with a plan outside the
+            // caller's scope (deliberately not confirmed by the pre-check above). One
+            // generic answer for both; full detail goes to structured logging only.
             _logger.LogWarning(ex, "Failed to persist plan {PlanId}: constraint violation", plan.Id.Value);
-            return Result.Fail("A plan with this id already exists.");
+            return Result.Fail("Failed to persist the plan.");
         }
 
         _logger.LogInformation("Saved plan {PlanId} with {StepCount} steps", plan.Id.Value, plan.Steps.Count);
@@ -161,8 +164,15 @@ public sealed partial class EfCorePlanStateStore : IPlanStateStore
 
         // Write path: strict ownership — a step on a plan the caller doesn't own (including
         // globally READABLE null-owner plans) is indistinguishable from missing (404-not-403).
+        // The warning keeps a mis-wired scope (e.g. tenant fallback changed between save and
+        // update) diagnosable without weakening the outward NotFound.
         if (!await IsStepWritableAsync(ctx, state.StepId.Value, ct))
+        {
+            _logger.LogWarning(
+                "Step {StepId} is missing or not writable in the current scope; update rejected",
+                state.StepId.Value);
             return Result.NotFound($"Execution state not found for step {state.StepId.Value}");
+        }
 
         var entity = await ctx.StepExecutionStates
             .FirstOrDefaultAsync(s => s.StepId == state.StepId.Value, ct);
@@ -217,8 +227,14 @@ public sealed partial class EfCorePlanStateStore : IPlanStateStore
 
         // Write path: strict ownership — a plan the caller doesn't own (including globally
         // READABLE null-owner plans) is indistinguishable from missing (404-not-403).
+        // The warning keeps a mis-wired scope diagnosable without weakening the NotFound.
         if (!await IsPlanWritableAsync(ctx, planId.Value, ct))
+        {
+            _logger.LogWarning(
+                "Plan {PlanId} is missing or not writable in the current scope; checkpoint rejected",
+                planId.Value);
             return Result.NotFound($"No step states found for plan {planId.Value}");
+        }
 
         var entities = await ctx.StepExecutionStates
             .Where(s => ctx.PlanSteps.Any(ps => ps.Id == s.StepId && ps.PlanGraphId == planId.Value))

--- a/src/Content/Tests/Infrastructure.AI.Tests/Attestation/EfCoreAttestationStoreOwnershipTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Attestation/EfCoreAttestationStoreOwnershipTests.cs
@@ -1,0 +1,202 @@
+using Application.AI.Common.Interfaces.KnowledgeGraph;
+using Domain.AI.Attestation;
+using Domain.AI.Planner;
+using Domain.Common;
+using FluentAssertions;
+using Infrastructure.AI.Attestation;
+using Infrastructure.AI.Persistence;
+using Infrastructure.AI.Planner;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Time.Testing;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Attestation;
+
+/// <summary>
+/// Ownership tests for <see cref="EfCoreAttestationStore"/>: attestations inherit their
+/// plan's scope boundaries via the shared <c>PlannerScopeFilter</c> — reads gated by
+/// visibility, saves by strict writability, cross-owner access indistinguishable from
+/// absence (404-not-403).
+/// </summary>
+public sealed class EfCoreAttestationStoreOwnershipTests : IDisposable
+{
+    private readonly SqliteConnection _connection;
+    private readonly TestDbContextFactory _factory;
+    private readonly StubKnowledgeScope _scope;
+    private readonly EfCorePlanStateStore _planStore;
+    private readonly EfCoreAttestationStore _attestationStore;
+
+    public EfCoreAttestationStoreOwnershipTests()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+
+        var options = new DbContextOptionsBuilder<PlannerDbContext>()
+            .UseSqlite(_connection)
+            .Options;
+        _factory = new TestDbContextFactory(options);
+        _scope = new StubKnowledgeScope();
+
+        _planStore = new EfCorePlanStateStore(
+            _factory,
+            NullLogger<EfCorePlanStateStore>.Instance,
+            new FakeTimeProvider(new DateTimeOffset(2026, 7, 27, 12, 0, 0, TimeSpan.Zero)),
+            _scope,
+            new PlannerSchemaInitializer(_factory));
+
+        _attestationStore = new EfCoreAttestationStore(
+            _factory,
+            NullLogger<EfCoreAttestationStore>.Instance,
+            _scope);
+    }
+
+    public void Dispose() => _connection.Dispose();
+
+    [Fact]
+    public async Task SaveAsync_SameOwnerScope_PersistsAttestation()
+    {
+        var graph = await SavePlanAsOwnerAsync("alice", "acme");
+
+        var save = await _attestationStore.SaveAsync(
+            graph.Steps[0].Id, CreateAttestation(), CancellationToken.None);
+        var read = await _attestationStore.GetByStepAsync(graph.Steps[0].Id, CancellationToken.None);
+
+        save.IsSuccess.Should().BeTrue();
+        read.IsSuccess.Should().BeTrue();
+        read.Value.Should().NotBeNull("the owner must round-trip their own attestations");
+    }
+
+    [Fact]
+    public async Task SaveAsync_DifferentOwnerScope_ReturnsNotFound()
+    {
+        var graph = await SavePlanAsOwnerAsync("alice", "acme");
+
+        SetCaller("bob", "acme");
+        var result = await _attestationStore.SaveAsync(
+            graph.Steps[0].Id, CreateAttestation(), CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.FailureType.Should().Be(ResultFailureType.NotFound,
+            "cross-owner writes must read as NotFound, never Forbidden");
+    }
+
+    [Fact]
+    public async Task SaveAsync_GlobalPlanWithScopedCaller_ReturnsNotFound()
+    {
+        var graph = await SavePlanAsOwnerAsync(null, null); // global plan
+
+        SetCaller("alice", "acme");
+        var result = await _attestationStore.SaveAsync(
+            graph.Steps[0].Id, CreateAttestation(), CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse("shared visibility must never grant shared mutation");
+        result.FailureType.Should().Be(ResultFailureType.NotFound);
+    }
+
+    [Fact]
+    public async Task GetByStepAsync_DifferentOwnerScope_ReturnsNullLikeMissing()
+    {
+        var graph = await SavePlanAsOwnerAsync("alice", "acme");
+        (await _attestationStore.SaveAsync(
+            graph.Steps[0].Id, CreateAttestation(), CancellationToken.None))
+            .IsSuccess.Should().BeTrue();
+
+        SetCaller("bob", "acme");
+        var result = await _attestationStore.GetByStepAsync(graph.Steps[0].Id, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeNull("another owner's attestation must be indistinguishable from a missing one");
+    }
+
+    [Fact]
+    public async Task GetByPlanAsync_DifferentOwnerScope_ReturnsEmptyLikeMissing()
+    {
+        var graph = await SavePlanAsOwnerAsync("alice", "acme");
+        (await _attestationStore.SaveAsync(
+            graph.Steps[0].Id, CreateAttestation(), CancellationToken.None))
+            .IsSuccess.Should().BeTrue();
+
+        SetCaller("bob", "acme");
+        var result = await _attestationStore.GetByPlanAsync(graph.Id, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeEmpty();
+    }
+
+    // --- Helpers ---
+
+    private void SetCaller(string? userId, string? tenantId)
+    {
+        _scope.UserId = userId;
+        _scope.TenantId = tenantId;
+    }
+
+    private async Task<PlanGraph> SavePlanAsOwnerAsync(string? userId, string? tenantId)
+    {
+        SetCaller(userId, tenantId);
+        var graph = CreateTestGraph();
+        var saved = await _planStore.SavePlanAsync(graph, CancellationToken.None);
+        saved.IsSuccess.Should().BeTrue();
+        return graph;
+    }
+
+    private static ToolExecutionAttestation CreateAttestation() => new()
+    {
+        ToolName = "file_system",
+        InputHash = "input-hash",
+        OutputHash = "output-hash",
+        Timestamp = new DateTimeOffset(2026, 7, 27, 12, 0, 0, TimeSpan.Zero),
+        Signature = "signature",
+        KeyVersion = "v1",
+    };
+
+    private static PlanGraph CreateTestGraph()
+    {
+        var step = new PlanStep
+        {
+            Id = PlanStepId.New(),
+            Name = "Step 0",
+            Type = StepType.LlmCall,
+            Configuration = new LlmCallConfig
+            {
+                SystemPrompt = "Prompt",
+                ModelDeploymentKey = "gpt-4o",
+            },
+            RetryPolicy = new RetryPolicy { MaxRetries = 2 },
+            Timeout = TimeSpan.FromSeconds(30),
+        };
+
+        return new PlanGraph
+        {
+            Id = PlanId.New(),
+            Name = "Attestation Ownership Test Plan",
+            Steps = [step],
+            Edges = [],
+            Configuration = new PlanConfiguration
+            {
+                MaxParallelSteps = 1,
+                PlanTimeout = TimeSpan.FromMinutes(10),
+            },
+        };
+    }
+
+    /// <summary>Mutable <see cref="IKnowledgeScope"/> stub simulating different ambient callers.</summary>
+    private sealed class StubKnowledgeScope : IKnowledgeScope
+    {
+        public string? UserId { get; set; }
+        public string? TenantId { get; set; }
+        public string? DatasetId => null;
+        public string? DatasetName => null;
+        public string? DatasetOwnerId => null;
+        public string? AgentId => null;
+        public string? ConversationId => null;
+    }
+
+    private sealed class TestDbContextFactory(DbContextOptions<PlannerDbContext> options)
+        : IDbContextFactory<PlannerDbContext>
+    {
+        public PlannerDbContext CreateDbContext() => new(options);
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Planner/EfCorePlanStateStoreOwnershipTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Planner/EfCorePlanStateStoreOwnershipTests.cs
@@ -1,0 +1,428 @@
+using Application.AI.Common.Interfaces.KnowledgeGraph;
+using Domain.AI.Planner;
+using Domain.Common;
+using FluentAssertions;
+using Infrastructure.AI.Persistence;
+using Infrastructure.AI.Planner;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Time.Testing;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Planner;
+
+/// <summary>
+/// Ownership tests for <see cref="EfCorePlanStateStore"/> (PR W1): schema initialization via
+/// the registered <see cref="SchemaInitializer{TContext}"/>, owner/tenant stamping from the
+/// ambient <see cref="IKnowledgeScope"/>, and 404-not-403 scope filtering on every
+/// read/list/execute path.
+/// </summary>
+public sealed class EfCorePlanStateStoreOwnershipTests : IDisposable
+{
+    private readonly SqliteConnection _connection;
+    private readonly DbContextOptions<PlannerDbContext> _options;
+    private readonly TestDbContextFactory _factory;
+    private readonly FakeTimeProvider _timeProvider;
+    private readonly StubKnowledgeScope _scope;
+    private readonly EfCorePlanStateStore _store;
+
+    public EfCorePlanStateStoreOwnershipTests()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+
+        _options = new DbContextOptionsBuilder<PlannerDbContext>()
+            .UseSqlite(_connection)
+            .Options;
+
+        // Deliberately NO manual EnsureCreated: schema creation must come from the
+        // SchemaInitializer the store demands, proving the production "no such table"
+        // hole is closed by the registered lifecycle.
+        _timeProvider = new FakeTimeProvider(new DateTimeOffset(2026, 7, 27, 12, 0, 0, TimeSpan.Zero));
+        _factory = new TestDbContextFactory(_options);
+        _scope = new StubKnowledgeScope();
+        _store = new EfCorePlanStateStore(
+            _factory,
+            NullLogger<EfCorePlanStateStore>.Instance,
+            _timeProvider,
+            _scope,
+            new PlannerSchemaInitializer(_factory));
+    }
+
+    public void Dispose() => _connection.Dispose();
+
+    // --- Schema initialization ---
+
+    [Fact]
+    public async Task SavePlanAsync_FreshDatabaseWithSchemaInitializerOnly_Succeeds()
+    {
+        var graph = CreateTestGraph();
+
+        var result = await _store.SavePlanAsync(graph, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue(
+            "the SchemaInitializer demanded by the store's constructor must have created the schema");
+
+        var loaded = await _store.LoadPlanAsync(graph.Id, CancellationToken.None);
+        loaded.IsSuccess.Should().BeTrue();
+        loaded.Value.Should().NotBeNull();
+    }
+
+    // --- Stamping ---
+
+    [Fact]
+    public async Task SavePlanAsync_WithAmbientScope_StampsCanonicalOwnerAndTenant()
+    {
+        _scope.UserId = " Alice ";
+        _scope.TenantId = "ACME";
+        var graph = CreateTestGraph();
+
+        var result = await _store.SavePlanAsync(graph, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        await using var ctx = _factory.CreateDbContext();
+        var entity = await ctx.PlanGraphs.SingleAsync(g => g.Id == graph.Id.Value);
+        entity.OwnerId.Should().Be("alice", "identity is canonicalized (trimmed, lowercase) on write");
+        entity.TenantId.Should().Be("acme");
+    }
+
+    [Fact]
+    public async Task SavePlanAsync_WithoutAmbientScope_LeavesOwnerAndTenantNull()
+    {
+        var graph = CreateTestGraph();
+
+        var result = await _store.SavePlanAsync(graph, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        await using var ctx = _factory.CreateDbContext();
+        var entity = await ctx.PlanGraphs.SingleAsync(g => g.Id == graph.Id.Value);
+        entity.OwnerId.Should().BeNull("no ambient identity means a global (unowned) plan");
+        entity.TenantId.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task SavePlanAsync_DuplicatePlanId_ReturnsGenericFailure()
+    {
+        var graph = CreateTestGraph();
+        (await _store.SavePlanAsync(graph, CancellationToken.None)).IsSuccess.Should().BeTrue();
+
+        var result = await _store.SavePlanAsync(graph, CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse("a colliding id must not surface as an unhandled exception");
+        result.Errors.Should().ContainSingle()
+            .Which.Should().Be("A plan with this id already exists.", "no internals may be echoed");
+    }
+
+    [Fact]
+    public async Task SavePlanAsync_OversizedScopeIdentity_ReturnsFailure()
+    {
+        SetCaller(new string('a', 300), "acme");
+        var graph = CreateTestGraph();
+
+        var result = await _store.SavePlanAsync(graph, CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse(
+            "SQLite's HasMaxLength is advisory, so oversized identities must fail cleanly instead of truncating");
+    }
+
+    // --- Read/list/execute filtering ---
+
+    [Fact]
+    public async Task LoadPlanAsync_DifferentOwnerScope_ReturnsNullLikeMissingPlan()
+    {
+        var graph = await SaveAsOwnerAsync("alice", "acme");
+
+        SetCaller("bob", "acme");
+        var result = await _store.LoadPlanAsync(graph.Id, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeNull("another owner's plan must be indistinguishable from a missing one");
+    }
+
+    [Fact]
+    public async Task LoadPlanAsync_DifferentTenantScope_ReturnsNullLikeMissingPlan()
+    {
+        var graph = await SaveAsOwnerAsync("alice", "acme");
+
+        SetCaller("alice", "globex");
+        var result = await _store.LoadPlanAsync(graph.Id, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task LoadPlanAsync_SameOwnerScope_RoundTripsPlan()
+    {
+        var graph = await SaveAsOwnerAsync("alice", "acme");
+
+        SetCaller("alice", "acme");
+        var result = await _store.LoadPlanAsync(graph.Id, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBeNull();
+        result.Value!.Id.Should().Be(graph.Id);
+        result.Value.Steps.Should().HaveCount(graph.Steps.Count);
+    }
+
+    [Fact]
+    public async Task LoadPlanAsync_GlobalPlanWithScopedCaller_ReturnsPlan()
+    {
+        var graph = CreateTestGraph();
+        await _store.SavePlanAsync(graph, CancellationToken.None); // unscoped save = global plan
+
+        SetCaller("alice", "acme");
+        var result = await _store.LoadPlanAsync(graph.Id, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBeNull("a null-owner/null-tenant plan is global and visible to every caller");
+    }
+
+    [Fact]
+    public async Task ListPlansAsync_DifferentOwnerScope_ExcludesOtherOwnersPlans()
+    {
+        var alicePlan = await SaveAsOwnerAsync("alice", "acme");
+        SetCaller("bob", "acme");
+        var bobPlan = CreateTestGraph();
+        await _store.SavePlanAsync(bobPlan, CancellationToken.None);
+
+        var result = await _store.ListPlansAsync(null, null, null, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.Select(p => p.Id).Should().Contain(bobPlan.Id)
+            .And.NotContain(alicePlan.Id, "listing must never surface another owner's plans");
+    }
+
+    [Fact]
+    public async Task LoadStepStatesAsync_DifferentOwnerScope_ReturnsEmptyLikeMissingPlan()
+    {
+        var graph = await SaveAsOwnerAsync("alice", "acme");
+
+        SetCaller("bob", "acme");
+        var result = await _store.LoadStepStatesAsync(graph.Id, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetExecutionHistoryAsync_DifferentOwnerScope_ReturnsEmptyLikeMissingPlan()
+    {
+        var graph = await SaveAsOwnerAsync("alice", "acme");
+
+        SetCaller("bob", "acme");
+        var result = await _store.GetExecutionHistoryAsync(graph.Id, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ResumeAsync_DifferentOwnerScope_ReturnsNotFound()
+    {
+        var graph = await SaveAsOwnerAsync("alice", "acme");
+
+        SetCaller("bob", "acme");
+        var result = await _store.ResumeAsync(graph.Id, CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.FailureType.Should().Be(ResultFailureType.NotFound,
+            "cross-owner access must read as NotFound, never Forbidden");
+    }
+
+    [Fact]
+    public async Task UpdateStepStateAsync_DifferentOwnerScope_ReturnsNotFound()
+    {
+        var graph = await SaveAsOwnerAsync("alice", "acme");
+
+        SetCaller("bob", "acme");
+        var state = new StepExecutionState
+        {
+            StepId = graph.Steps[0].Id,
+            Status = StepExecutionStatus.Running,
+            AttemptCount = 1,
+            StartedAt = _timeProvider.GetUtcNow(),
+        };
+        var result = await _store.UpdateStepStateAsync(state, CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.FailureType.Should().Be(ResultFailureType.NotFound);
+    }
+
+    [Fact]
+    public async Task CheckpointAsync_DifferentOwnerScope_ReturnsNotFound()
+    {
+        var graph = await SaveAsOwnerAsync("alice", "acme");
+
+        SetCaller("bob", "acme");
+        var states = graph.Steps.Select(s => new StepExecutionState
+        {
+            StepId = s.Id,
+            Status = StepExecutionStatus.Completed,
+            AttemptCount = 1,
+        }).ToList();
+        var result = await _store.CheckpointAsync(graph.Id, states, CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.FailureType.Should().Be(ResultFailureType.NotFound);
+    }
+
+    // --- Global plans: readable by all, mutable only from a null-identity (system) context ---
+
+    [Fact]
+    public async Task UpdateStepStateAsync_GlobalPlanWithScopedCaller_ReturnsNotFound()
+    {
+        var graph = CreateTestGraph();
+        await _store.SavePlanAsync(graph, CancellationToken.None); // unscoped save = global plan
+
+        SetCaller("alice", "acme");
+        var state = new StepExecutionState
+        {
+            StepId = graph.Steps[0].Id,
+            Status = StepExecutionStatus.Running,
+            AttemptCount = 1,
+        };
+        var result = await _store.UpdateStepStateAsync(state, CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse("shared visibility must never grant shared mutation");
+        result.FailureType.Should().Be(ResultFailureType.NotFound);
+    }
+
+    [Fact]
+    public async Task CheckpointAsync_GlobalPlanWithScopedCaller_ReturnsNotFound()
+    {
+        var graph = CreateTestGraph();
+        await _store.SavePlanAsync(graph, CancellationToken.None);
+
+        SetCaller("alice", "acme");
+        var states = graph.Steps.Select(s => new StepExecutionState
+        {
+            StepId = s.Id,
+            Status = StepExecutionStatus.Completed,
+            AttemptCount = 1,
+        }).ToList();
+        var result = await _store.CheckpointAsync(graph.Id, states, CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.FailureType.Should().Be(ResultFailureType.NotFound);
+    }
+
+    [Fact]
+    public async Task ResumeAsync_GlobalPlanWithScopedCaller_ReturnsNotFound()
+    {
+        var graph = CreateTestGraph();
+        await _store.SavePlanAsync(graph, CancellationToken.None);
+
+        SetCaller("alice", "acme");
+        var result = await _store.ResumeAsync(graph.Id, CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.FailureType.Should().Be(ResultFailureType.NotFound);
+    }
+
+    [Fact]
+    public async Task ResumeAsync_GlobalPlanWithNullScopeCaller_Succeeds()
+    {
+        var graph = CreateTestGraph();
+        await _store.SavePlanAsync(graph, CancellationToken.None);
+
+        var result = await _store.ResumeAsync(graph.Id, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue("a null-identity caller owns global (null-stamped) plans");
+        result.Value.Should().HaveCount(graph.Steps.Count);
+    }
+
+    [Fact]
+    public async Task UpdateStepStateAsync_SameOwnerScope_Succeeds()
+    {
+        var graph = await SaveAsOwnerAsync("alice", "acme");
+
+        var state = new StepExecutionState
+        {
+            StepId = graph.Steps[0].Id,
+            Status = StepExecutionStatus.Running,
+            AttemptCount = 1,
+            StartedAt = _timeProvider.GetUtcNow(),
+        };
+        var result = await _store.UpdateStepStateAsync(state, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue("owners must retain full mutation rights over their own plans");
+    }
+
+    [Fact]
+    public async Task ResumeAsync_SameOwnerScope_Succeeds()
+    {
+        var graph = await SaveAsOwnerAsync("alice", "acme");
+
+        var result = await _store.ResumeAsync(graph.Id, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().HaveCount(graph.Steps.Count);
+    }
+
+    // --- Helpers ---
+
+    private void SetCaller(string? userId, string? tenantId)
+    {
+        _scope.UserId = userId;
+        _scope.TenantId = tenantId;
+    }
+
+    private async Task<PlanGraph> SaveAsOwnerAsync(string userId, string tenantId)
+    {
+        SetCaller(userId, tenantId);
+        var graph = CreateTestGraph();
+        var saved = await _store.SavePlanAsync(graph, CancellationToken.None);
+        saved.IsSuccess.Should().BeTrue();
+        return graph;
+    }
+
+    private static PlanGraph CreateTestGraph()
+    {
+        var steps = Enumerable.Range(0, 2).Select(i => new PlanStep
+        {
+            Id = PlanStepId.New(),
+            Name = $"Step {i}",
+            Type = StepType.LlmCall,
+            Configuration = new LlmCallConfig
+            {
+                SystemPrompt = $"Prompt for step {i}",
+                ModelDeploymentKey = "gpt-4o",
+            },
+            RetryPolicy = new RetryPolicy { MaxRetries = 2 },
+            Timeout = TimeSpan.FromSeconds(30),
+        }).ToList();
+
+        return new PlanGraph
+        {
+            Id = PlanId.New(),
+            Name = "Ownership Test Plan",
+            Steps = steps,
+            Edges = [new PlanEdge(steps[0].Id, steps[1].Id, EdgeType.ControlFlow)],
+            Configuration = new PlanConfiguration
+            {
+                MaxParallelSteps = 4,
+                PlanTimeout = TimeSpan.FromMinutes(10),
+            },
+        };
+    }
+
+    /// <summary>Mutable <see cref="IKnowledgeScope"/> stub simulating different ambient callers.</summary>
+    private sealed class StubKnowledgeScope : IKnowledgeScope
+    {
+        public string? UserId { get; set; }
+        public string? TenantId { get; set; }
+        public string? DatasetId => null;
+        public string? DatasetName => null;
+        public string? DatasetOwnerId => null;
+        public string? AgentId => null;
+        public string? ConversationId => null;
+    }
+
+    private sealed class TestDbContextFactory(DbContextOptions<PlannerDbContext> options)
+        : IDbContextFactory<PlannerDbContext>
+    {
+        public PlannerDbContext CreateDbContext() => new(options);
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Planner/EfCorePlanStateStoreTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Planner/EfCorePlanStateStoreTests.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using Application.AI.Common.Services.KnowledgeGraph;
 using Domain.AI.Planner;
 using FluentAssertions;
 using Infrastructure.AI.Persistence;
@@ -34,7 +35,12 @@ public sealed class EfCorePlanStateStoreTests : IDisposable
         _timeProvider = new FakeTimeProvider(new DateTimeOffset(2026, 5, 15, 12, 0, 0, TimeSpan.Zero));
 
         var factory = new TestDbContextFactory(_options);
-        _store = new EfCorePlanStateStore(factory, NullLogger<EfCorePlanStateStore>.Instance, _timeProvider);
+        _store = new EfCorePlanStateStore(
+            factory,
+            NullLogger<EfCorePlanStateStore>.Instance,
+            _timeProvider,
+            new NullKnowledgeScope(),
+            new SchemaInitializer<PlannerDbContext>(factory));
     }
 
     public void Dispose() => _connection.Dispose();
@@ -157,7 +163,11 @@ public sealed class EfCorePlanStateStoreTests : IDisposable
 
             var fileFactory = new TestDbContextFactory(fileOptions);
             var fileStore = new EfCorePlanStateStore(
-                fileFactory, NullLogger<EfCorePlanStateStore>.Instance, _timeProvider);
+                fileFactory,
+                NullLogger<EfCorePlanStateStore>.Instance,
+                _timeProvider,
+                new NullKnowledgeScope(),
+                new SchemaInitializer<PlannerDbContext>(fileFactory));
 
             var graph = CreateTestGraph(stepCount: 1, edgeCount: 0);
             await fileStore.SavePlanAsync(graph, CancellationToken.None);

--- a/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlanExecutorHumanGateLifecycleTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlanExecutorHumanGateLifecycleTests.cs
@@ -49,8 +49,13 @@ public sealed class PlanExecutorHumanGateLifecycleTests : IDisposable
         }
 
         _timeProvider = new FakeTimeProvider(new DateTimeOffset(2026, 5, 15, 12, 0, 0, TimeSpan.Zero));
+        var factory = new TestDbContextFactory(_options);
         _store = new EfCorePlanStateStore(
-            new TestDbContextFactory(_options), NullLogger<EfCorePlanStateStore>.Instance, _timeProvider);
+            factory,
+            NullLogger<EfCorePlanStateStore>.Instance,
+            _timeProvider,
+            new Application.AI.Common.Services.KnowledgeGraph.NullKnowledgeScope(),
+            new SchemaInitializer<PlannerDbContext>(factory));
 
         _validator.Setup(v => v.ValidateAsync(It.IsAny<PlanGraph>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result<PlanValidationResult>.Success(new PlanValidationResult { IsValid = true }));

--- a/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlanExecutorResumeRecoveryTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlanExecutorResumeRecoveryTests.cs
@@ -45,8 +45,13 @@ public sealed class PlanExecutorResumeRecoveryTests : IDisposable
         }
 
         _timeProvider = new FakeTimeProvider(new DateTimeOffset(2026, 5, 15, 12, 0, 0, TimeSpan.Zero));
+        var factory = new TestDbContextFactory(_options);
         _store = new EfCorePlanStateStore(
-            new TestDbContextFactory(_options), NullLogger<EfCorePlanStateStore>.Instance, _timeProvider);
+            factory,
+            NullLogger<EfCorePlanStateStore>.Instance,
+            _timeProvider,
+            new Application.AI.Common.Services.KnowledgeGraph.NullKnowledgeScope(),
+            new SchemaInitializer<PlannerDbContext>(factory));
 
         _validator.Setup(v => v.ValidateAsync(It.IsAny<PlanGraph>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result<PlanValidationResult>.Success(new PlanValidationResult { IsValid = true }));

--- a/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlannerDiRegistrationTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlannerDiRegistrationTests.cs
@@ -56,6 +56,15 @@ public sealed class PlannerDiRegistrationTests : IDisposable
     }
 
     [Fact]
+    public void DependencyInjection_PlannerSchemaInitializer_RegisteredAndCreatesSchema()
+    {
+        // PR W1 regression guard: without this registration the first SavePlanAsync in any
+        // host fails with "no such table" — the planner had no production schema init.
+        _provider.GetService<SchemaInitializer<PlannerDbContext>>().Should().NotBeNull(
+            "the planner must ensure its SQLite schema exists before the first store operation");
+    }
+
+    [Fact]
     public void DependencyInjection_AllSandboxServices_Resolvable()
     {
         using var scope = _provider.CreateScope();
@@ -150,6 +159,10 @@ public sealed class PlannerDiRegistrationTests : IDisposable
             }));
 
         // External dependencies not registered by Infrastructure.AI
+        // IAgentExecutionContext comes from Application.AI.Common's DI in production; the
+        // knowledge-scope accessor (now consumed by EfCorePlanStateStore for plan ownership)
+        // delegates agent identity to it.
+        services.AddScoped(_ => new Mock<Application.AI.Common.Interfaces.Agent.IAgentExecutionContext>().Object);
         services.AddSingleton<ISender>(new Mock<ISender>().Object);
         services.AddSingleton<IPlanProgressNotifier>(new Mock<IPlanProgressNotifier>().Object);
         services.AddSingleton<ICapabilityEnforcer>(new Mock<ICapabilityEnforcer>().Object);

--- a/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlannerSchemaInitializerTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlannerSchemaInitializerTests.cs
@@ -1,0 +1,152 @@
+using Application.AI.Common.Services.KnowledgeGraph;
+using Domain.AI.Planner;
+using FluentAssertions;
+using Infrastructure.AI.Persistence;
+using Infrastructure.AI.Planner;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Time.Testing;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Planner;
+
+/// <summary>
+/// Tests for <see cref="PlannerSchemaInitializer"/>: schema evolution on a pre-existing
+/// (legacy) planner database that lacks the ownership columns — the case EnsureCreated
+/// alone can never fix because it no-ops on existing databases.
+/// </summary>
+public sealed class PlannerSchemaInitializerTests : IDisposable
+{
+    private readonly SqliteConnection _connection;
+    private readonly DbContextOptions<PlannerDbContext> _options;
+    private readonly TestDbContextFactory _factory;
+
+    public PlannerSchemaInitializerTests()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+
+        _options = new DbContextOptionsBuilder<PlannerDbContext>()
+            .UseSqlite(_connection)
+            .Options;
+        _factory = new TestDbContextFactory(_options);
+    }
+
+    public void Dispose() => _connection.Dispose();
+
+    [Fact]
+    public async Task Initialize_LegacyDatabaseWithoutOwnershipColumns_AddsColumns()
+    {
+        await CreateLegacySchemaAsync();
+
+        _ = new PlannerSchemaInitializer(_factory);
+
+        var columns = await ReadPlanGraphColumnsAsync();
+        columns.Should().Contain("OwnerId", "the initializer must evolve pre-existing databases in place")
+            .And.Contain("TenantId");
+    }
+
+    [Fact]
+    public async Task Initialize_LegacyDatabase_ScopeFilteredQueriesWorkAfterwards()
+    {
+        await CreateLegacySchemaAsync();
+
+        var store = new EfCorePlanStateStore(
+            _factory,
+            NullLogger<EfCorePlanStateStore>.Instance,
+            new FakeTimeProvider(new DateTimeOffset(2026, 7, 27, 12, 0, 0, TimeSpan.Zero)),
+            new NullKnowledgeScope(),
+            new PlannerSchemaInitializer(_factory));
+
+        var graph = CreateTestGraph();
+        var saved = await store.SavePlanAsync(graph, CancellationToken.None);
+        saved.IsSuccess.Should().BeTrue();
+
+        // LoadPlanAsync exercises the ownership-column visibility predicate — this is what
+        // threw "no such column" on a legacy database before the evolution step.
+        var loaded = await store.LoadPlanAsync(graph.Id, CancellationToken.None);
+        loaded.IsSuccess.Should().BeTrue();
+        loaded.Value.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task Initialize_RunTwice_IsIdempotent()
+    {
+        await CreateLegacySchemaAsync();
+
+        _ = new PlannerSchemaInitializer(_factory);
+        var second = () => new PlannerSchemaInitializer(_factory);
+
+        second.Should().NotThrow("the PRAGMA guard and IF NOT EXISTS make re-runs no-ops");
+    }
+
+    [Fact]
+    public void Initialize_FreshDatabase_CreatesFullSchemaIncludingOwnership()
+    {
+        _ = new PlannerSchemaInitializer(_factory);
+
+        var columns = ReadPlanGraphColumnsAsync().GetAwaiter().GetResult();
+        columns.Should().Contain("OwnerId").And.Contain("TenantId");
+    }
+
+    /// <summary>
+    /// Creates the CURRENT schema, then strips the ownership columns and their composite
+    /// index to reproduce a database created before PR W1 shipped.
+    /// </summary>
+    private async Task CreateLegacySchemaAsync()
+    {
+        await using var ctx = new PlannerDbContext(_options);
+        await ctx.Database.EnsureCreatedAsync();
+        await ctx.Database.ExecuteSqlRawAsync("DROP INDEX \"IX_PlanGraphs_TenantId_OwnerId\";");
+        await ctx.Database.ExecuteSqlRawAsync("ALTER TABLE \"PlanGraphs\" DROP COLUMN \"OwnerId\";");
+        await ctx.Database.ExecuteSqlRawAsync("ALTER TABLE \"PlanGraphs\" DROP COLUMN \"TenantId\";");
+    }
+
+    private async Task<List<string>> ReadPlanGraphColumnsAsync()
+    {
+        var columns = new List<string>();
+        await using var command = _connection.CreateCommand();
+        command.CommandText = "PRAGMA table_info(\"PlanGraphs\");";
+        await using var reader = await command.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+            columns.Add(reader.GetString(1));
+        return columns;
+    }
+
+    private static PlanGraph CreateTestGraph()
+    {
+        var step = new PlanStep
+        {
+            Id = PlanStepId.New(),
+            Name = "Step 0",
+            Type = StepType.LlmCall,
+            Configuration = new LlmCallConfig
+            {
+                SystemPrompt = "Prompt",
+                ModelDeploymentKey = "gpt-4o",
+            },
+            RetryPolicy = new RetryPolicy { MaxRetries = 2 },
+            Timeout = TimeSpan.FromSeconds(30),
+        };
+
+        return new PlanGraph
+        {
+            Id = PlanId.New(),
+            Name = "Schema Evolution Test Plan",
+            Steps = [step],
+            Edges = [],
+            Configuration = new PlanConfiguration
+            {
+                MaxParallelSteps = 1,
+                PlanTimeout = TimeSpan.FromMinutes(10),
+            },
+        };
+    }
+
+    private sealed class TestDbContextFactory(DbContextOptions<PlannerDbContext> options)
+        : IDbContextFactory<PlannerDbContext>
+    {
+        public PlannerDbContext CreateDbContext() => new(options);
+    }
+}


### PR DESCRIPTION
## What

Wave 2 PR **W1** of the external-trigger API program: gives the plan subsystem a working production schema and per-caller ownership, ahead of the workflow HTTP surface (W3).

- **Schema init**: `PlannerDbContext` had no production schema initialization anywhere — the first `SavePlanAsync` in any host would fail with "no such table". New `PlannerSchemaInitializer` runs `EnsureCreated` plus an idempotent, PRAGMA-guarded evolution step that adds `OwnerId`/`TenantId` to a pre-existing database (template consumers may have wired the DB themselves; existing rows keep NULL = global semantics, no backfill).
- **Ownership**: nullable `OwnerId`/`TenantId` on `PlanGraphEntity`, stamped in `EfCorePlanStateStore` from the ambient `IKnowledgeScope` (the `KnowledgeMemoryService` precedent) — identity is never read from commands/DTOs.
- **Isolation**: every `IPlanStateStore` member filters by scope through shared predicates (`PlannerScopeFilter`): reads use shared-visibility semantics (global/null rows visible to all), writes require strict owner+tenant equality — a global plan is readable by everyone but mutable only by null-scope (in-process) callers. Cross-owner access is byte-identical to not-found; no existence oracle.
- **Closed by default**: no ambient identity ⇒ callers see only global plans. Deliberately stricter than `TenantIsolatedGraphStore`'s posture, because the coming HTTP host must fail closed if scope middleware is missing. Today's hosts never arm the scope, so behavior is unchanged.
- `EfCoreAttestationStore` (shares the same DbContext; currently unregistered) is gated with the same predicates so it can't become a cross-tenant leak when a future host wires it.

## Review trail

Standards/spec + 4-angle simplify + security review (PASS) ran pre-push; fixes applied: schema evolution for pre-existing DBs (HIGH), strict write-path predicate (MED), attestation-store gating (MED), save existence-oracle genericized (LOW), 256-char identity stamp guard (LOW), index comment corrected (NIT).

## Test plan

- `Infrastructure.AI.Tests`: 2211 passed (+16 new: ownership, legacy-DB schema evolution, attestation gating).
- Full solution: all 20 test projects green, 0 failures, 0 new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BnoLcufW278UxA9ssBM1Tc