### PR TITLE
feat: read-only learnings recall endpoint (K3)

### DIFF
--- a/src/Content/Application/Application.Core/CQRS/Learnings/LearningsValidationRules.cs
+++ b/src/Content/Application/Application.Core/CQRS/Learnings/LearningsValidationRules.cs
@@ -1,0 +1,28 @@
+namespace Application.Core.CQRS.Learnings;
+
+/// <summary>
+/// Shared validation constants for the HTTP-facing learnings recall surface. Centralized so the
+/// wire-level query validator and its tests agree on the same bounds, mirroring
+/// <c>MemoryValidationRules</c> on the cross-session memory surface.
+/// </summary>
+/// <remarks>
+/// These bounds intentionally apply only to <see cref="RecallLearningsQuery"/> (the HTTP
+/// adapter), not to the internal <see cref="RecallQuery"/>: the in-process agent-turn recall
+/// path composes its context from conversation state under <c>LearningsRecallConfig</c>, so
+/// capping the shared <see cref="RecallQueryValidator"/> could silently break live agent turns.
+/// The HTTP boundary is where caller-supplied sizes must be bounded.
+/// </remarks>
+public static class LearningsValidationRules
+{
+    /// <summary>
+    /// Maximum accepted recall context length. Matches the memory surface's recall query cap —
+    /// the context is embedded for similarity scoring on every request, so an unbounded string
+    /// is a per-request embedding-cost amplifier.
+    /// </summary>
+    public const int MaxContextLength = 1024;
+
+    /// <summary>
+    /// Upper bound for recall <c>MaxResults</c> — caps per-request scoring work and payload size.
+    /// </summary>
+    public const int MaxRecallResults = 50;
+}

--- a/src/Content/Application/Application.Core/CQRS/Learnings/RecallLearningsQuery.cs
+++ b/src/Content/Application/Application.Core/CQRS/Learnings/RecallLearningsQuery.cs
@@ -1,0 +1,44 @@
+using Domain.AI.Learnings;
+using Domain.Common;
+using MediatR;
+
+namespace Application.Core.CQRS.Learnings;
+
+/// <summary>
+/// HTTP-facing adapter over the learnings recall pipeline: retrieves globally-scoped learnings
+/// relevant to the given context, ranked by relevance, feedback weight, and freshness.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This query exists so the HTTP surface can enforce wire-level bounds (context length and
+/// result count — see <see cref="LearningsValidationRules"/>) without touching the internal
+/// <see cref="RecallQuery"/> validator that the live agent-turn recall path depends on. The
+/// handler forwards to <see cref="RecallQuery"/> with the same
+/// <see cref="LearningScope.IsGlobal"/> scope the in-process recaller
+/// (<c>MediatorLearningRecaller</c>) uses, so callers see exactly the learnings view that is
+/// injected into agent turns.
+/// </para>
+/// <para>
+/// <b>Read-only by design.</b> Learnings writes are deliberately not exposed over HTTP: they
+/// bypass the memory write gate, learnings carry no owner/tenant scoping, and they sit outside
+/// the erasure surface — an HTTP write path would be a prompt-injection channel into every
+/// user's agent turns.
+/// </para>
+/// </remarks>
+public sealed record RecallLearningsQuery : IRequest<Result<IReadOnlyList<WeightedLearning>>>
+{
+    /// <summary>Natural-language context to match against stored learnings.</summary>
+    public required string Context { get; init; }
+
+    /// <summary>
+    /// Maximum number of results to return
+    /// (1–<see cref="LearningsValidationRules.MaxRecallResults"/>). Default 10.
+    /// </summary>
+    /// <remarks>
+    /// This caps the page size, not disclosure: the recall pipeline's diversity sampling can
+    /// return a different low-ranked tail on every call, so repeated queries eventually surface
+    /// any matching learning regardless of this bound. The operator role gate on the HTTP
+    /// endpoint is the disclosure control; this bound only limits per-request work and payload.
+    /// </remarks>
+    public int MaxResults { get; init; } = 10;
+}

--- a/src/Content/Application/Application.Core/CQRS/Learnings/RecallLearningsQueryHandler.cs
+++ b/src/Content/Application/Application.Core/CQRS/Learnings/RecallLearningsQueryHandler.cs
@@ -1,0 +1,73 @@
+using Domain.AI.Learnings;
+using Domain.Common;
+using Domain.Common.Config;
+using MediatR;
+using Microsoft.Extensions.Options;
+
+namespace Application.Core.CQRS.Learnings;
+
+/// <summary>
+/// Handles <see cref="RecallLearningsQuery"/> by forwarding to the existing
+/// <see cref="RecallQuery"/> pipeline with global scope, so the full scoring stack (semantic
+/// relevance, feedback weight, freshness decay, diversity injection in
+/// <see cref="RecallQueryHandler"/>) is reused rather than reimplemented.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Nested dispatch through <see cref="IMediator"/> follows the established precedent
+/// (<c>MediatorLearningRecaller</c>, the epoch-boundary skill-training commands): the inner
+/// query gets the standard MediatR pipeline. Unlike <c>MediatorLearningRecaller</c>, failures
+/// are propagated as <see cref="Result{T}"/> failures rather than swallowed — the HTTP surface
+/// must report store errors honestly instead of masking them as an empty result set.
+/// </para>
+/// <para>
+/// Two parity/safety decisions differ deliberately from a bare <see cref="RecallQuery"/>:
+/// <list type="bullet">
+///   <item><description>
+///     <b>MinRelevance parity.</b> The inner query carries the configured
+///     <c>AppConfig:AI:LearningsRecall:MinRelevance</c> floor — the same value the agent-turn
+///     recall passes — so HTTP results match what agents actually see rather than including
+///     low-relevance tails the agent path filters out. (Only the floor is shared; the
+///     <c>LearningsRecall.Enabled</c> flag gates the per-turn injection provider, not this
+///     endpoint — the recall pipeline itself is gated by <c>AI:Learnings:Enabled</c> inside
+///     <see cref="RecallQueryHandler"/>.)
+///   </description></item>
+///   <item><description>
+///     <b>No store writes.</b> <see cref="RecallQuery.RecordAccess"/> is set to false so the
+///     HTTP GET never triggers the fire-and-forget access-reinforcement write (see the
+///     property's remarks for the caller-steered-write and lost-update rationale).
+///   </description></item>
+/// </list>
+/// </para>
+/// </remarks>
+public sealed class RecallLearningsQueryHandler
+    : IRequestHandler<RecallLearningsQuery, Result<IReadOnlyList<WeightedLearning>>>
+{
+    private static readonly LearningScope GlobalScope = new() { IsGlobal = true };
+
+    private readonly IMediator _mediator;
+    private readonly IOptionsMonitor<AppConfig> _options;
+
+    /// <summary>Initializes the handler with its dependencies.</summary>
+    /// <param name="mediator">The mediator used to dispatch the inner <see cref="RecallQuery"/>.</param>
+    /// <param name="options">Application configuration; supplies the configured recall relevance floor.</param>
+    public RecallLearningsQueryHandler(IMediator mediator, IOptionsMonitor<AppConfig> options)
+    {
+        ArgumentNullException.ThrowIfNull(mediator);
+        ArgumentNullException.ThrowIfNull(options);
+        _mediator = mediator;
+        _options = options;
+    }
+
+    /// <inheritdoc />
+    public Task<Result<IReadOnlyList<WeightedLearning>>> Handle(
+        RecallLearningsQuery request, CancellationToken cancellationToken) =>
+        _mediator.Send(new RecallQuery
+        {
+            Context = request.Context,
+            Scope = GlobalScope,
+            MaxResults = request.MaxResults,
+            MinRelevance = _options.CurrentValue.AI.LearningsRecall.MinRelevance,
+            RecordAccess = false
+        }, cancellationToken);
+}

--- a/src/Content/Application/Application.Core/CQRS/Learnings/RecallLearningsQueryValidator.cs
+++ b/src/Content/Application/Application.Core/CQRS/Learnings/RecallLearningsQueryValidator.cs
@@ -1,0 +1,25 @@
+using FluentValidation;
+
+namespace Application.Core.CQRS.Learnings;
+
+/// <summary>
+/// Validates <see cref="RecallLearningsQuery"/>: context non-empty and bounded, MaxResults within
+/// [1, <see cref="LearningsValidationRules.MaxRecallResults"/>]. Mirrors the memory surface's
+/// <c>RecallMemoryQueryValidator</c> so both HTTP recall surfaces enforce the same style of
+/// wire-level bounds.
+/// </summary>
+public sealed class RecallLearningsQueryValidator : AbstractValidator<RecallLearningsQuery>
+{
+    /// <summary>Initializes validation rules.</summary>
+    public RecallLearningsQueryValidator()
+    {
+        RuleFor(x => x.Context)
+            .NotEmpty().WithMessage("Context must not be empty.")
+            .MaximumLength(LearningsValidationRules.MaxContextLength)
+                .WithMessage($"Context must not exceed {LearningsValidationRules.MaxContextLength} characters.");
+
+        RuleFor(x => x.MaxResults)
+            .InclusiveBetween(1, LearningsValidationRules.MaxRecallResults)
+                .WithMessage($"MaxResults must be between 1 and {LearningsValidationRules.MaxRecallResults}.");
+    }
+}

--- a/src/Content/Application/Application.Core/CQRS/Learnings/RecallQuery.cs
+++ b/src/Content/Application/Application.Core/CQRS/Learnings/RecallQuery.cs
@@ -20,4 +20,18 @@ public sealed record RecallQuery : IRequest<Result<IReadOnlyList<WeightedLearnin
 
     /// <summary>Minimum relevance score threshold (0.0-1.0). Default 0.0 (no filter).</summary>
     public double MinRelevance { get; init; } = 0.0;
+
+    /// <summary>
+    /// Whether this recall reinforces the recalled learnings' access metadata
+    /// (<c>LastAccessedAt</c>, via a fire-and-forget <see cref="RecordLearningAccessCommand"/>).
+    /// Default true — the in-process agent-turn recall path keeps its behavior unchanged.
+    /// </summary>
+    /// <remarks>
+    /// The HTTP recall surface (<see cref="RecallLearningsQuery"/>) sets this to false: an HTTP
+    /// GET must not perform caller-steered store writes — a role-holder looping the endpoint
+    /// would rewrite <c>LastAccessedAt</c> on whichever learnings its context matches, and the
+    /// read-modify-write access update can race (and clobber) a concurrent feedback-weight
+    /// improvement.
+    /// </remarks>
+    public bool RecordAccess { get; init; } = true;
 }

--- a/src/Content/Application/Application.Core/CQRS/Learnings/RecallQueryHandler.cs
+++ b/src/Content/Application/Application.Core/CQRS/Learnings/RecallQueryHandler.cs
@@ -108,7 +108,10 @@ public sealed class RecallQueryHandler : IRequestHandler<RecallQuery, Result<IRe
         List<WeightedLearning> results = ApplyDiversityInjection(scored, request.MaxResults, config.DiversityInjectionRatio);
         results = results.Take(request.MaxResults).ToList();
 
-        _ = RecordAccessSafeAsync(results);
+        // Access reinforcement is opt-out: the HTTP recall surface passes RecordAccess = false
+        // so a GET never performs caller-steered store writes (see RecallQuery.RecordAccess).
+        if (request.RecordAccess)
+            _ = RecordAccessSafeAsync(results);
 
         sw.Stop();
         LearningsMetrics.Recalled.Add(results.Count);

--- a/src/Content/Presentation/Presentation.AgentHub/Auth/DevAuthHandler.cs
+++ b/src/Content/Presentation/Presentation.AgentHub/Auth/DevAuthHandler.cs
@@ -27,6 +27,7 @@ internal sealed class DevAuthHandler(
             new Claim(ClaimTypes.Role, "AgentHub.Traces.ReadAll"),
             new Claim(ClaimTypes.Role, "AgentHub.EvalDashboard.Read"),
             new Claim(ClaimTypes.Role, "AgentHub.Foresight.Observe"),
+            new Claim(ClaimTypes.Role, "Harness.Learnings.Read"),
         };
         var identity = new ClaimsIdentity(claims, Scheme.Name);
         var ticket = new AuthenticationTicket(new ClaimsPrincipal(identity), Scheme.Name);

--- a/src/Content/Presentation/Presentation.AgentHub/Controllers/LearningsController.cs
+++ b/src/Content/Presentation/Presentation.AgentHub/Controllers/LearningsController.cs
@@ -1,0 +1,181 @@
+using Application.Core.CQRS.Learnings;
+using Domain.AI.Learnings;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Presentation.Common.Extensions;
+
+namespace Presentation.AgentHub.Controllers;
+
+/// <summary>
+/// Read-only REST API over the learnings subsystem: recalls captured learnings relevant to a
+/// given context, ranked by the same scoring pipeline that injects learnings into agent turns.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Cross-user disclosure — why the role gate exists.</b> Learnings are scoped to
+/// agent/team/global, <b>not</b> to users: an entry captured from one user's correction,
+/// escalation resolution, or drift event is recalled into every user's agent turns, and its
+/// content can embed material from any user's sessions. This endpoint therefore discloses
+/// cross-user data by construction, so the whole controller is gated with
+/// <see cref="OperatorRole"/> — following the <c>AgentHub.Traces.ReadAll</c> precedent on
+/// <see cref="SessionsController"/>. A plain authenticated chat user (no role) gets 403.
+/// </para>
+/// <para>
+/// <b>Read-only by design.</b> No learnings write (remember, improve, forget, or access
+/// recording) is exposed over HTTP, deliberately: learnings writes bypass the memory write
+/// gate, carry no owner/tenant scoping, and sit outside the erasure surface — an HTTP write
+/// path would be a prompt-injection channel into every user's agent turns.
+/// </para>
+/// <para>
+/// <b>Wire shape.</b> Results are projected to <see cref="LearningRecallEntryDto"/> rather
+/// than returning the domain records: the projection excludes <c>LearningSource</c> (its
+/// <c>SourceId</c> can carry a user session identifier), pipeline provenance, and internal
+/// bookkeeping (<c>LastAccessedAt</c>, <c>UpdateCount</c>). The role gate is the disclosure
+/// control, but the endpoint still returns no more than a recall consumer needs.
+/// </para>
+/// </remarks>
+[ApiController]
+[Route("api/learnings")]
+[Authorize(Roles = OperatorRole)]
+public sealed class LearningsController : ControllerBase
+{
+    /// <summary>
+    /// App role required to read the learnings recall surface. Learnings are cross-user by
+    /// construction (agent/team/global scope, no per-user isolation), so recall is restricted
+    /// to operators — mirroring how <see cref="SessionsController.ObserverRole"/> gates the
+    /// cross-user session observability surface.
+    /// </summary>
+    public const string OperatorRole = "Harness.Learnings.Read";
+
+    private readonly IMediator _mediator;
+
+    /// <summary>Initializes the controller with its MediatR dependency.</summary>
+    /// <param name="mediator">The MediatR mediator used to dispatch the recall query.</param>
+    public LearningsController(IMediator mediator)
+    {
+        ArgumentNullException.ThrowIfNull(mediator);
+        _mediator = mediator;
+    }
+
+    /// <summary>
+    /// Recalls globally-scoped learnings relevant to the given context — the same view the
+    /// in-process recall path injects into agent turns.
+    /// </summary>
+    /// <param name="context">Natural-language context to match against stored learnings (max 1024 characters).</param>
+    /// <param name="maxResults">
+    /// Maximum number of results (1–50). Default 10. Caps the page, not disclosure — diversity
+    /// sampling returns different low-ranked tails per call, so the role gate (not this bound)
+    /// is the disclosure control.
+    /// </param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Matching learnings ranked by blended relevance score (possibly empty).</returns>
+    /// <response code="200">Recall completed (may contain zero results).</response>
+    /// <response code="400">Missing or oversized context, or out-of-range maxResults.</response>
+    /// <response code="401">Caller is not authenticated.</response>
+    /// <response code="403">Caller lacks the <c>Harness.Learnings.Read</c> role.</response>
+    [HttpGet]
+    [ProducesResponseType(typeof(IReadOnlyList<LearningRecallEntryDto>), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<IActionResult> Recall(
+        [FromQuery] string? context,
+        [FromQuery] int maxResults = 10,
+        CancellationToken cancellationToken = default)
+    {
+        var result = await _mediator.Send(new RecallLearningsQuery
+        {
+            Context = context ?? string.Empty,
+            MaxResults = maxResults
+        }, cancellationToken).ConfigureAwait(false);
+
+        if (!result.IsSuccess)
+            return this.FailureResponse(result, "Learnings recall failed");
+
+        var entries = result.Value!
+            .Select(LearningRecallEntryDto.From)
+            .ToArray();
+
+        return Ok(entries);
+    }
+}
+
+/// <summary>
+/// Wire-safe projection of a recalled learning for <c>GET /api/learnings</c>.
+/// </summary>
+/// <remarks>
+/// Deliberately excludes fields from <c>LearningEntry</c> that the recall consumer does not
+/// need: <c>Source</c> (its <c>SourceId</c> can carry a user session identifier — cross-user
+/// identifying data), <c>Provenance</c> (internal pipeline metadata), <c>LastAccessedAt</c> /
+/// <c>UpdateCount</c> (internal bookkeeping), and the soft-delete pair (deleted entries are
+/// never returned by search). A wire-shape guard test in the AgentHub test suite pins this
+/// exclusion set so the fields cannot creep back in unnoticed.
+/// </remarks>
+public sealed record LearningRecallEntryDto
+{
+    /// <summary>Unique identifier of the learning.</summary>
+    public required Guid LearningId { get; init; }
+
+    /// <summary>The learned knowledge content — a natural-language description of what was learned.</summary>
+    public required string Content { get; init; }
+
+    /// <summary>Knowledge category name (e.g. <c>"DomainKnowledge"</c>, <c>"StylePreference"</c>).</summary>
+    public required string Category { get; init; }
+
+    /// <summary>Temporal decay class name (<c>"Volatile"</c>, <c>"Stable"</c>, or <c>"Permanent"</c>).</summary>
+    public required string DecayClass { get; init; }
+
+    /// <summary>Visibility scope of the learning (agent, team, or global).</summary>
+    public required LearningScopeDto Scope { get; init; }
+
+    /// <summary>Semantic similarity between the recall context and the learning content (0.0–1.0).</summary>
+    public required double RelevanceScore { get; init; }
+
+    /// <summary>EMA-weighted feedback score (1.0 = neutral; higher = repeatedly validated as useful).</summary>
+    public required double FeedbackScore { get; init; }
+
+    /// <summary>Temporal freshness based on decay class and age (0.0–1.0).</summary>
+    public required double FreshnessScore { get; init; }
+
+    /// <summary>Blended final ranking score computed by the recall pipeline.</summary>
+    public required double FinalScore { get; init; }
+
+    /// <summary>When the learning was first captured.</summary>
+    public required DateTimeOffset CreatedAt { get; init; }
+
+    /// <summary>When the learning was last reinforced by positive feedback; null if never.</summary>
+    public DateTimeOffset? LastReinforcedAt { get; init; }
+
+    /// <summary>Projects a scored domain result to the wire shape, dropping internal fields.</summary>
+    /// <param name="weighted">The scored learning returned by the recall pipeline.</param>
+    /// <returns>The wire-safe projection.</returns>
+    public static LearningRecallEntryDto From(WeightedLearning weighted)
+    {
+        ArgumentNullException.ThrowIfNull(weighted);
+
+        return new LearningRecallEntryDto
+        {
+            LearningId = weighted.Learning.LearningId,
+            Content = weighted.Learning.Content,
+            Category = weighted.Learning.Category.ToString(),
+            DecayClass = weighted.Learning.DecayClass.ToString(),
+            Scope = new LearningScopeDto(
+                weighted.Learning.Scope.AgentId,
+                weighted.Learning.Scope.TeamId,
+                weighted.Learning.Scope.IsGlobal),
+            RelevanceScore = weighted.RelevanceScore,
+            FeedbackScore = weighted.FeedbackScore,
+            FreshnessScore = weighted.FreshnessScore,
+            FinalScore = weighted.FinalScore,
+            CreatedAt = weighted.Learning.CreatedAt,
+            LastReinforcedAt = weighted.Learning.LastReinforcedAt,
+        };
+    }
+}
+
+/// <summary>Visibility scope of a learning (agent, team, or global).</summary>
+/// <param name="AgentId">Agent the learning is scoped to; null when not agent-scoped.</param>
+/// <param name="TeamId">Team the learning is scoped to; null when not team-scoped.</param>
+/// <param name="IsGlobal">True when the learning is visible to all agents.</param>
+public sealed record LearningScopeDto(string? AgentId, string? TeamId, bool IsGlobal);

--- a/src/Content/Presentation/Presentation.AgentHub/DependencyInjection.cs
+++ b/src/Content/Presentation/Presentation.AgentHub/DependencyInjection.cs
@@ -198,6 +198,24 @@ public static class DependencyInjection
                         QueueLimit = 0,
                     });
                 }
+                // Learnings recall embeds the query AND every candidate learning on each request
+                // (1+N uncached embedding calls), so even a role-holding operator can loop the
+                // endpoint into real provider spend. Cap reads per authenticated user, matching
+                // the memory-write limiter's 30/min posture (both are per-request AI-cost paths).
+                if (context.Request.Method == HttpMethods.Get &&
+                    context.Request.Path.StartsWithSegments("/api/learnings"))
+                {
+                    var learningsCaller = context.User.GetUserIdOrNull()
+                        ?? context.Connection.RemoteIpAddress?.ToString()
+                        ?? "unknown";
+                    return RateLimitPartition.GetFixedWindowLimiter($"learnings:{learningsCaller}", _ => new FixedWindowRateLimiterOptions
+                    {
+                        PermitLimit = 30,
+                        Window = TimeSpan.FromMinutes(1),
+                        QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+                        QueueLimit = 0,
+                    });
+                }
                 return RateLimitPartition.GetNoLimiter("none");
             });
 

--- a/src/Content/Tests/Application.Core.Tests/CQRS/Learnings/RecallLearningsQueryHandlerTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/CQRS/Learnings/RecallLearningsQueryHandlerTests.cs
@@ -1,0 +1,128 @@
+using Application.Core.CQRS.Learnings;
+using Domain.AI.Learnings;
+using Domain.Common;
+using Domain.Common.Config;
+using Domain.Common.Config.AI;
+using FluentAssertions;
+using MediatR;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Application.Core.Tests.CQRS.Learnings;
+
+/// <summary>
+/// Verifies <see cref="RecallLearningsQueryHandler"/>: it must forward to the inner
+/// <see cref="RecallQuery"/> with global scope and the caller's context/limits, and propagate
+/// the inner result unchanged — success values pass through, and failures surface as failures
+/// so the HTTP layer can report store errors honestly instead of masking them as empty results
+/// (the deliberate difference from <c>MediatorLearningRecaller</c>, which swallows failures).
+/// </summary>
+public sealed class RecallLearningsQueryHandlerTests
+{
+    private const double ConfiguredMinRelevance = 0.4;
+
+    private readonly Mock<IMediator> _mediator = new();
+    private readonly RecallLearningsQueryHandler _sut;
+
+    public RecallLearningsQueryHandlerTests() =>
+        _sut = new RecallLearningsQueryHandler(_mediator.Object, CreateOptions(ConfiguredMinRelevance));
+
+    private static IOptionsMonitor<AppConfig> CreateOptions(double minRelevance)
+    {
+        var appConfig = new AppConfig
+        {
+            AI = new AIConfig
+            {
+                LearningsRecall = new LearningsRecallConfig { MinRelevance = minRelevance }
+            }
+        };
+        var mock = new Mock<IOptionsMonitor<AppConfig>>();
+        mock.Setup(m => m.CurrentValue).Returns(appConfig);
+        return mock.Object;
+    }
+
+    [Fact]
+    public async Task Handle_ValidQuery_ForwardsContextAndMaxResultsWithGlobalScope()
+    {
+        RecallQuery? captured = null;
+        _mediator.Setup(m => m.Send(It.IsAny<RecallQuery>(), It.IsAny<CancellationToken>()))
+            .Callback<IRequest<Result<IReadOnlyList<WeightedLearning>>>, CancellationToken>(
+                (q, _) => captured = (RecallQuery)q)
+            .ReturnsAsync(Result<IReadOnlyList<WeightedLearning>>.Success(Array.Empty<WeightedLearning>()));
+
+        await _sut.Handle(
+            new RecallLearningsQuery { Context = "deploy checklist", MaxResults = 7 },
+            CancellationToken.None);
+
+        captured.Should().NotBeNull();
+        captured!.Context.Should().Be("deploy checklist");
+        captured.MaxResults.Should().Be(7);
+        captured.MinRelevance.Should().Be(ConfiguredMinRelevance,
+            "the HTTP surface must apply the same configured relevance floor as the agent-turn recall");
+        captured.RecordAccess.Should().BeFalse(
+            "an HTTP GET must never trigger the access-reinforcement store write");
+        captured.Scope.IsGlobal.Should().BeTrue(
+            "the HTTP recall must mirror the global scope the in-process agent-turn recall uses");
+        captured.Scope.AgentId.Should().BeNull();
+        captured.Scope.TeamId.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Handle_InnerSuccess_PropagatesValueUnchanged()
+    {
+        IReadOnlyList<WeightedLearning> learnings = [CreateWeighted()];
+        _mediator.Setup(m => m.Send(It.IsAny<RecallQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<IReadOnlyList<WeightedLearning>>.Success(learnings));
+
+        var result = await _sut.Handle(
+            new RecallLearningsQuery { Context = "anything" }, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeSameAs(learnings);
+    }
+
+    [Fact]
+    public async Task Handle_InnerFailure_PropagatesFailure()
+    {
+        _mediator.Setup(m => m.Send(It.IsAny<RecallQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<IReadOnlyList<WeightedLearning>>.Fail("store unavailable"));
+
+        var result = await _sut.Handle(
+            new RecallLearningsQuery { Context = "anything" }, CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse(
+            "store failures must surface as failures, not as an empty 200 body");
+        result.Errors.Should().Contain("store unavailable");
+    }
+
+    private static WeightedLearning CreateWeighted() => new()
+    {
+        Learning = new LearningEntry
+        {
+            LearningId = Guid.NewGuid(),
+            Category = LearningCategory.DomainKnowledge,
+            DecayClass = DecayClass.Stable,
+            Scope = new LearningScope { IsGlobal = true },
+            Content = "Prefer Result<T> over exceptions for expected failures",
+            Source = new LearningSource
+            {
+                SourceType = LearningSourceType.HumanCorrection,
+                SourceId = "session-123",
+                SourceDescription = "User corrected error-handling approach"
+            },
+            Provenance = new LearningProvenance
+            {
+                OriginPipeline = "drift-detection",
+                OriginTask = "auto_correct",
+                OriginTimestamp = DateTimeOffset.UtcNow,
+                Confidence = 0.9
+            },
+            CreatedAt = DateTimeOffset.UtcNow.AddDays(-3)
+        },
+        RelevanceScore = 0.8,
+        FeedbackScore = 1.2,
+        FreshnessScore = 0.9,
+        FinalScore = 0.85
+    };
+}

--- a/src/Content/Tests/Application.Core.Tests/CQRS/Learnings/RecallLearningsQueryPipelineTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/CQRS/Learnings/RecallLearningsQueryPipelineTests.cs
@@ -1,0 +1,73 @@
+using Application.Common.MediatRBehaviors;
+using Application.Core.CQRS.Learnings;
+using Domain.Common;
+using FluentAssertions;
+using FluentValidation;
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Application.Core.Tests.CQRS.Learnings;
+
+/// <summary>
+/// Real-pipeline test for the HTTP-facing recall query: wires an actual MediatR pipeline with
+/// <see cref="RequestValidationBehavior{TRequest,TResponse}"/> and the real validator, then
+/// dispatches an invalid <see cref="RecallLearningsQuery"/>. This proves the wire-level bounds
+/// short-circuit as a <c>Validation</c> Result failure in the pipeline itself — coverage the
+/// controller tests (which mock <see cref="IMediator"/>) cannot provide.
+/// </summary>
+public sealed class RecallLearningsQueryPipelineTests
+{
+    private static ServiceProvider BuildPipeline()
+    {
+        var services = new ServiceCollection();
+
+        services.AddSingleton<ILoggerFactory>(NullLoggerFactory.Instance);
+        services.AddSingleton(typeof(ILogger<>), typeof(NullLogger<>));
+
+        // Real MediatR over Application.Core (handlers resolve lazily, so unrelated handlers'
+        // dependencies never need to be registered here) + the real validation behavior and
+        // the real validator — the exact pieces that gate the HTTP recall surface.
+        services.AddMediatR(cfg =>
+            cfg.RegisterServicesFromAssembly(typeof(RecallLearningsQueryHandler).Assembly));
+        services.AddTransient(typeof(IPipelineBehavior<,>), typeof(RequestValidationBehavior<,>));
+        services.AddTransient<IValidator<RecallLearningsQuery>, RecallLearningsQueryValidator>();
+
+        return services.BuildServiceProvider();
+    }
+
+    [Fact]
+    public async Task Send_OverlongContext_ValidationFailureSurfacesThroughRealPipeline()
+    {
+        await using var provider = BuildPipeline();
+        var mediator = provider.GetRequiredService<IMediator>();
+        var query = new RecallLearningsQuery
+        {
+            Context = new string('x', LearningsValidationRules.MaxContextLength + 1)
+        };
+
+        var result = await mediator.Send(query);
+
+        result.IsSuccess.Should().BeFalse(
+            "an over-long context must be rejected by the validation behavior before any handler runs");
+        result.FailureType.Should().Be(ResultFailureType.Validation,
+            "the failure must map to HTTP 400 through the shared FailureResponse switch");
+        result.Errors.Should().Contain(e =>
+            e.Contains($"{LearningsValidationRules.MaxContextLength}"),
+            "the error must name the enforced bound");
+    }
+
+    [Fact]
+    public async Task Send_EmptyContext_ValidationFailureSurfacesThroughRealPipeline()
+    {
+        await using var provider = BuildPipeline();
+        var mediator = provider.GetRequiredService<IMediator>();
+
+        var result = await mediator.Send(new RecallLearningsQuery { Context = "" });
+
+        result.IsSuccess.Should().BeFalse();
+        result.FailureType.Should().Be(ResultFailureType.Validation);
+    }
+}

--- a/src/Content/Tests/Application.Core.Tests/CQRS/Learnings/RecallLearningsQueryValidatorTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/CQRS/Learnings/RecallLearningsQueryValidatorTests.cs
@@ -1,0 +1,88 @@
+using Application.Core.CQRS.Learnings;
+using FluentValidation.TestHelper;
+using Xunit;
+
+namespace Application.Core.Tests.CQRS.Learnings;
+
+/// <summary>
+/// Verifies <see cref="RecallLearningsQueryValidator"/> — the wire-level bounds for the
+/// HTTP-facing learnings recall surface. These caps exist on the adapter query (not the shared
+/// <see cref="RecallQueryValidator"/>) so the HTTP boundary is bounded without constraining the
+/// internal agent-turn recall path; the boundary tests pin the exact limits from
+/// <see cref="LearningsValidationRules"/>.
+/// </summary>
+public sealed class RecallLearningsQueryValidatorTests
+{
+    private readonly RecallLearningsQueryValidator _validator = new();
+
+    [Fact]
+    public void Validate_ValidInput_NoErrors()
+    {
+        var query = new RecallLearningsQuery { Context = "error handling conventions", MaxResults = 10 };
+
+        var result = _validator.TestValidate(query);
+
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void Validate_EmptyContext_HasError()
+    {
+        var query = new RecallLearningsQuery { Context = "" };
+
+        var result = _validator.TestValidate(query);
+
+        result.ShouldHaveValidationErrorFor(x => x.Context);
+    }
+
+    [Fact]
+    public void Validate_ContextAtMaxLength_NoError()
+    {
+        var query = new RecallLearningsQuery
+        {
+            Context = new string('x', LearningsValidationRules.MaxContextLength)
+        };
+
+        var result = _validator.TestValidate(query);
+
+        result.ShouldNotHaveValidationErrorFor(x => x.Context);
+    }
+
+    [Fact]
+    public void Validate_ContextExceedsMaxLength_HasError()
+    {
+        var query = new RecallLearningsQuery
+        {
+            Context = new string('x', LearningsValidationRules.MaxContextLength + 1)
+        };
+
+        var result = _validator.TestValidate(query);
+
+        result.ShouldHaveValidationErrorFor(x => x.Context);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(LearningsValidationRules.MaxRecallResults + 1)]
+    public void Validate_MaxResultsOutOfRange_HasError(int maxResults)
+    {
+        var query = new RecallLearningsQuery { Context = "valid", MaxResults = maxResults };
+
+        var result = _validator.TestValidate(query);
+
+        result.ShouldHaveValidationErrorFor(x => x.MaxResults);
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(LearningsValidationRules.MaxRecallResults)]
+    public void Validate_MaxResultsAtBounds_NoError(int maxResults)
+    {
+        var query = new RecallLearningsQuery { Context = "valid", MaxResults = maxResults };
+
+        var result = _validator.TestValidate(query);
+
+        result.ShouldNotHaveValidationErrorFor(x => x.MaxResults);
+    }
+}

--- a/src/Content/Tests/Application.Core.Tests/CQRS/Learnings/RecallQueryHandlerTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/CQRS/Learnings/RecallQueryHandlerTests.cs
@@ -96,6 +96,28 @@ public sealed class RecallQueryHandlerTests
     }
 
     [Fact]
+    public async Task Handle_RecordAccessDisabled_DoesNotDispatchRecordLearningAccessCommand()
+    {
+        // The HTTP recall surface opts out of access reinforcement (RecallQuery.RecordAccess =
+        // false) so a GET never performs caller-steered store writes. The recall result itself
+        // must be unaffected by the opt-out.
+        var learnings = new List<LearningEntry> { CreateLearning("l1"), CreateLearning("l2") };
+        SetupStore(learnings);
+        SetupUniformEmbedding(0.8);
+        _decayService.Setup(d => d.CalculateFreshnessAsync(It.IsAny<LearningEntry>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1.0);
+
+        var handler = CreateHandler();
+        var result = await handler.Handle(CreateQuery() with { RecordAccess = false }, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().HaveCount(2);
+        _mediator.Verify(
+            m => m.Send(It.IsAny<RecordLearningAccessCommand>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
     public async Task Handle_EmptyResults_ReturnsEmptyList()
     {
         _store.Setup(s => s.SearchAsync(It.IsAny<LearningSearchCriteria>(), It.IsAny<CancellationToken>()))

--- a/src/Content/Tests/Presentation.AgentHub.Tests/Controllers/LearningsControllerAuthorizationTests.cs
+++ b/src/Content/Tests/Presentation.AgentHub.Tests/Controllers/LearningsControllerAuthorizationTests.cs
@@ -1,0 +1,100 @@
+using Application.Core.CQRS.Learnings;
+using Domain.AI.Learnings;
+using Domain.Common;
+using FluentAssertions;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Presentation.AgentHub.Controllers;
+using System.Net;
+using Xunit;
+
+namespace Presentation.AgentHub.Tests.Controllers;
+
+/// <summary>
+/// Wire-level authorization tests for <see cref="LearningsController"/>.
+///
+/// The learnings recall endpoint returns <b>cross-user</b> data by construction — learnings are
+/// scoped to agent/team/global, never to users, so a single response can surface knowledge
+/// captured from any user's corrections, escalations, or drift events. The controller is
+/// therefore role-gated with <see cref="LearningsController.OperatorRole"/>, following the
+/// <see cref="SessionsController.ObserverRole"/> precedent for cross-user surfaces.
+///
+/// These tests assert the boundary directly: an unauthenticated caller is challenged, an
+/// authenticated caller <em>without</em> the role is forbidden, and one <em>with</em> the role
+/// is admitted.
+/// </summary>
+public sealed class LearningsControllerAuthorizationTests
+    : IClassFixture<TestWebApplicationFactory>
+{
+    private readonly TestWebApplicationFactory _factory;
+
+    /// <summary>Initialises the test class with the shared integration factory.</summary>
+    public LearningsControllerAuthorizationTests(TestWebApplicationFactory factory) =>
+        _factory = factory;
+
+    /// <summary>Creates an HTTP client authenticated as <paramref name="userId"/> with the supplied roles.</summary>
+    private HttpClient CreateClientAs(string userId, params string[] roles)
+    {
+        var client = _factory
+            .WithWebHostBuilder(b => b.ConfigureTestServices(services =>
+            {
+                services.AddAuthentication(TestAuthHandler.SchemeName)
+                    .AddScheme<AuthenticationSchemeOptions, TestAuthHandler>(
+                        TestAuthHandler.SchemeName, _ => { });
+            }))
+            .CreateClient();
+
+        client.DefaultRequestHeaders.Add(TestAuthHandler.UserIdHeader, userId);
+        if (roles.Length > 0)
+            client.DefaultRequestHeaders.Add(TestAuthHandler.RolesHeader, string.Join(',', roles));
+        return client;
+    }
+
+    /// <summary>
+    /// GET /api/learnings challenges an unauthenticated caller with 401 — the endpoint must not
+    /// be reachable anonymously at all.
+    /// </summary>
+    [Fact]
+    public async Task Recall_Unauthenticated_Returns401()
+    {
+        using var client = _factory.CreateClient();
+
+        var response = await client.GetAsync("/api/learnings?context=anything");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    /// <summary>
+    /// GET /api/learnings returns 403 for an authenticated caller lacking the operator role —
+    /// an ordinary chat user must not be able to read cross-user learnings over HTTP.
+    /// </summary>
+    [Fact]
+    public async Task Recall_AuthenticatedWithoutOperatorRole_Returns403()
+    {
+        using var client = CreateClientAs("chat-user-no-role");
+
+        var response = await client.GetAsync("/api/learnings?context=anything");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    /// <summary>
+    /// GET /api/learnings succeeds for a caller holding the operator role — the gate admits
+    /// authorized operators inspecting what the system has learned.
+    /// </summary>
+    [Fact]
+    public async Task Recall_AuthenticatedWithOperatorRole_Returns200()
+    {
+        _factory.MockMediator
+            .Setup(m => m.Send(It.IsAny<RecallLearningsQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<IReadOnlyList<WeightedLearning>>.Success(Array.Empty<WeightedLearning>()));
+
+        using var client = CreateClientAs("operator-user", LearningsController.OperatorRole);
+
+        var response = await client.GetAsync("/api/learnings?context=anything");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+}

--- a/src/Content/Tests/Presentation.AgentHub.Tests/Controllers/LearningsControllerRateLimitTests.cs
+++ b/src/Content/Tests/Presentation.AgentHub.Tests/Controllers/LearningsControllerRateLimitTests.cs
@@ -1,0 +1,76 @@
+using Application.Core.CQRS.Learnings;
+using Domain.AI.Learnings;
+using Domain.Common;
+using FluentAssertions;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Presentation.AgentHub.Controllers;
+using System.Net;
+using Xunit;
+
+namespace Presentation.AgentHub.Tests.Controllers;
+
+/// <summary>
+/// Wire-level rate-limit tests for <c>GET /api/learnings</c>.
+///
+/// Every recall embeds the query and each candidate learning (1+N uncached embedding calls),
+/// so even a role-holding operator can loop the endpoint into real provider spend. The
+/// <c>learnings:{user}</c> fixed-window limiter (30/min, mirroring the memory-write limiter's
+/// posture) caps that; this test proves the limiter actually fires on the wire rather than
+/// only asserting its registration.
+/// </summary>
+public sealed class LearningsControllerRateLimitTests
+    : IClassFixture<TestWebApplicationFactory>
+{
+    private readonly TestWebApplicationFactory _factory;
+
+    /// <summary>Initialises the test class with the shared integration factory.</summary>
+    public LearningsControllerRateLimitTests(TestWebApplicationFactory factory) =>
+        _factory = factory;
+
+    /// <summary>
+    /// The 31st request inside one fixed window is rejected with 429 while the first 30
+    /// succeed — the per-user window admits exactly the configured budget.
+    /// </summary>
+    [Fact]
+    public async Task Recall_ExceedingPerUserWindow_Returns429()
+    {
+        _factory.MockMediator
+            .Setup(m => m.Send(It.IsAny<RecallLearningsQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<IReadOnlyList<WeightedLearning>>.Success(Array.Empty<WeightedLearning>()));
+
+        using var client = CreateClientAs("rate-limit-user", LearningsController.OperatorRole);
+
+        var statuses = new List<HttpStatusCode>();
+        for (var i = 0; i < 31; i++)
+        {
+            using var response = await client.GetAsync("/api/learnings?context=spend-loop");
+            statuses.Add(response.StatusCode);
+        }
+
+        statuses.Take(30).Should().OnlyContain(s => s == HttpStatusCode.OK,
+            "the fixed window admits 30 recalls per minute per user");
+        statuses[30].Should().Be(HttpStatusCode.TooManyRequests,
+            "the 31st recall in the window must be rejected — unbounded recalls are an embedding-spend loop");
+    }
+
+    /// <summary>Creates an HTTP client authenticated as <paramref name="userId"/> with the supplied roles.</summary>
+    private HttpClient CreateClientAs(string userId, params string[] roles)
+    {
+        var client = _factory
+            .WithWebHostBuilder(b => b.ConfigureTestServices(services =>
+            {
+                services.AddAuthentication(TestAuthHandler.SchemeName)
+                    .AddScheme<AuthenticationSchemeOptions, TestAuthHandler>(
+                        TestAuthHandler.SchemeName, _ => { });
+            }))
+            .CreateClient();
+
+        client.DefaultRequestHeaders.Add(TestAuthHandler.UserIdHeader, userId);
+        if (roles.Length > 0)
+            client.DefaultRequestHeaders.Add(TestAuthHandler.RolesHeader, string.Join(',', roles));
+        return client;
+    }
+}

--- a/src/Content/Tests/Presentation.AgentHub.Tests/Controllers/LearningsControllerTests.cs
+++ b/src/Content/Tests/Presentation.AgentHub.Tests/Controllers/LearningsControllerTests.cs
@@ -1,0 +1,199 @@
+using Application.Core.CQRS.Learnings;
+using Domain.AI.Learnings;
+using Domain.Common;
+using FluentAssertions;
+using MediatR;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using Presentation.AgentHub.Controllers;
+using Xunit;
+
+namespace Presentation.AgentHub.Tests.Controllers;
+
+/// <summary>
+/// Direct controller unit tests — no WebApplicationFactory. Verifies the
+/// <see cref="LearningsController"/>'s <c>Result</c> → MVC status-code mapping, the wire-safe
+/// projection to <see cref="LearningRecallEntryDto"/> (internal and cross-user-identifying
+/// fields must never reach the wire), and that the endpoint dispatches the correct query
+/// through MediatR.
+/// </summary>
+/// <remarks>
+/// Wire-level (auth, routing, role gate) coverage lives in
+/// <see cref="LearningsControllerAuthorizationTests"/>; handler behavior is covered by the
+/// Application.Core.Tests handler suite.
+/// </remarks>
+public sealed class LearningsControllerTests
+{
+    private readonly Mock<IMediator> _mediator = new();
+    private readonly LearningsController _sut;
+
+    public LearningsControllerTests()
+    {
+        _sut = new LearningsController(_mediator.Object);
+    }
+
+    [Fact]
+    public async Task Recall_MatchingLearnings_ReturnsOkWithWireSafeProjectionAndPassesParameters()
+    {
+        var weighted = CreateWeighted();
+        RecallLearningsQuery? captured = null;
+        _mediator.Setup(m => m.Send(It.IsAny<RecallLearningsQuery>(), It.IsAny<CancellationToken>()))
+            .Callback<IRequest<Result<IReadOnlyList<WeightedLearning>>>, CancellationToken>(
+                (q, _) => captured = (RecallLearningsQuery)q)
+            .ReturnsAsync(Result<IReadOnlyList<WeightedLearning>>.Success([weighted]));
+
+        var result = await _sut.Recall("error handling", 7, CancellationToken.None);
+
+        captured!.Context.Should().Be("error handling");
+        captured.MaxResults.Should().Be(7);
+
+        var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+        var entries = ok.Value.Should().BeAssignableTo<IReadOnlyList<LearningRecallEntryDto>>().Subject;
+        entries.Should().HaveCount(1);
+
+        var dto = entries[0];
+        dto.LearningId.Should().Be(weighted.Learning.LearningId);
+        dto.Content.Should().Be(weighted.Learning.Content);
+        dto.Category.Should().Be("DomainKnowledge");
+        dto.DecayClass.Should().Be("Stable");
+        dto.Scope.IsGlobal.Should().BeTrue();
+        dto.Scope.AgentId.Should().BeNull();
+        dto.Scope.TeamId.Should().BeNull();
+        dto.RelevanceScore.Should().Be(weighted.RelevanceScore);
+        dto.FeedbackScore.Should().Be(weighted.FeedbackScore);
+        dto.FreshnessScore.Should().Be(weighted.FreshnessScore);
+        dto.FinalScore.Should().Be(weighted.FinalScore);
+        dto.CreatedAt.Should().Be(weighted.Learning.CreatedAt);
+        dto.LastReinforcedAt.Should().Be(weighted.Learning.LastReinforcedAt);
+    }
+
+    [Fact]
+    public async Task Recall_NullContext_DispatchesEmptyContextWithDefaultMaxResults()
+    {
+        RecallLearningsQuery? captured = null;
+        _mediator.Setup(m => m.Send(It.IsAny<RecallLearningsQuery>(), It.IsAny<CancellationToken>()))
+            .Callback<IRequest<Result<IReadOnlyList<WeightedLearning>>>, CancellationToken>(
+                (q, _) => captured = (RecallLearningsQuery)q)
+            .ReturnsAsync(Result<IReadOnlyList<WeightedLearning>>.ValidationFailure(
+                ["Context must not be empty."]));
+
+        await _sut.Recall(null, cancellationToken: CancellationToken.None);
+
+        captured!.Context.Should().Be(string.Empty,
+            "a missing query parameter must reach the validator as an empty string, not crash binding");
+        captured.MaxResults.Should().Be(10);
+    }
+
+    [Fact]
+    public async Task Recall_ValidationFailure_Returns400()
+    {
+        _mediator.Setup(m => m.Send(It.IsAny<RecallLearningsQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<IReadOnlyList<WeightedLearning>>.ValidationFailure(
+                ["Context must not be empty."]));
+
+        var result = await _sut.Recall("", 10, CancellationToken.None);
+
+        var problem = result.Should().BeOfType<ObjectResult>().Subject;
+        problem.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
+    }
+
+    [Fact]
+    public async Task Recall_GeneralFailure_Returns500WithGenericBody()
+    {
+        _mediator.Setup(m => m.Send(It.IsAny<RecallLearningsQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<IReadOnlyList<WeightedLearning>>.Fail(
+                "Neo4j connection refused at 10.0.0.5"));
+
+        var result = await _sut.Recall("anything", 10, CancellationToken.None);
+
+        // Security guard: store exceptions can contain connection strings or internal endpoints.
+        // Per the harness security rules, General failures must map to a generic body.
+        var problem = result.Should().BeOfType<ObjectResult>().Subject;
+        problem.StatusCode.Should().Be(StatusCodes.Status500InternalServerError);
+        var details = problem.Value.Should().BeAssignableTo<ProblemDetails>().Subject;
+        details.Detail.Should().NotContain("Neo4j",
+            "raw store errors must not leak through FailureResponse on General failures");
+        details.Detail.Should().NotContain("10.0.0.5",
+            "internal endpoints must not leak through FailureResponse on General failures");
+    }
+
+    [Fact]
+    public void WireShape_LearningRecallEntryDto_ExcludesInternalAndCrossUserFields()
+    {
+        // Pins the exclusion set documented on LearningRecallEntryDto: Source.SourceId can carry
+        // a user session identifier, Provenance is internal pipeline metadata, and the remaining
+        // fields are internal bookkeeping. If a property creeps back in, this test names it.
+        var propertyNames = typeof(LearningRecallEntryDto)
+            .GetProperties()
+            .Select(p => p.Name);
+
+        propertyNames.Should().BeEquivalentTo(
+        [
+            nameof(LearningRecallEntryDto.LearningId),
+            nameof(LearningRecallEntryDto.Content),
+            nameof(LearningRecallEntryDto.Category),
+            nameof(LearningRecallEntryDto.DecayClass),
+            nameof(LearningRecallEntryDto.Scope),
+            nameof(LearningRecallEntryDto.RelevanceScore),
+            nameof(LearningRecallEntryDto.FeedbackScore),
+            nameof(LearningRecallEntryDto.FreshnessScore),
+            nameof(LearningRecallEntryDto.FinalScore),
+            nameof(LearningRecallEntryDto.CreatedAt),
+            nameof(LearningRecallEntryDto.LastReinforcedAt),
+        ]);
+
+        // Recurse into the nested scope DTO: a field added there also reaches the wire, so it
+        // gets the same pinning as the top-level shape.
+        typeof(LearningScopeDto)
+            .GetProperties()
+            .Select(p => p.Name)
+            .Should().BeEquivalentTo(
+            [
+                nameof(LearningScopeDto.AgentId),
+                nameof(LearningScopeDto.TeamId),
+                nameof(LearningScopeDto.IsGlobal),
+            ]);
+
+        // And pin that the wire shape's property types introduce no other DTO nesting — if a
+        // future field embeds a new complex type, this fails and demands the same treatment.
+        typeof(LearningRecallEntryDto)
+            .GetProperties()
+            .Select(p => Nullable.GetUnderlyingType(p.PropertyType) ?? p.PropertyType)
+            .Where(t => !t.IsPrimitive && t != typeof(string) && t != typeof(Guid)
+                        && t != typeof(DateTimeOffset) && t != typeof(decimal))
+            .Should().BeEquivalentTo([typeof(LearningScopeDto)],
+                "every nested wire type must be explicitly pinned by this guard");
+    }
+
+    private static WeightedLearning CreateWeighted() => new()
+    {
+        Learning = new LearningEntry
+        {
+            LearningId = Guid.NewGuid(),
+            Category = LearningCategory.DomainKnowledge,
+            DecayClass = DecayClass.Stable,
+            Scope = new LearningScope { IsGlobal = true },
+            Content = "Validate at system boundaries, trust internal code",
+            Source = new LearningSource
+            {
+                SourceType = LearningSourceType.HumanCorrection,
+                SourceId = "session-8f3a-user-identifying",
+                SourceDescription = "User corrected validation approach"
+            },
+            Provenance = new LearningProvenance
+            {
+                OriginPipeline = "escalation_resolution",
+                OriginTask = "human_review",
+                OriginTimestamp = DateTimeOffset.UtcNow.AddDays(-3),
+                Confidence = 0.9
+            },
+            CreatedAt = DateTimeOffset.UtcNow.AddDays(-3),
+            LastReinforcedAt = DateTimeOffset.UtcNow.AddDays(-1)
+        },
+        RelevanceScore = 0.82,
+        FeedbackScore = 1.15,
+        FreshnessScore = 0.94,
+        FinalScore = 0.87
+    };
+}


### PR DESCRIPTION
## What

Wave 2 PR **K3**: `GET /api/learnings?context=&maxResults=` on AgentHub — read-only recall over the learnings subsystem, gated by the operator role `Harness.Learnings.Read`.

## Why read-only and role-gated

Learnings are cross-user knowledge with no owner/tenant scoping and no erasure coverage. Writes over HTTP would bypass the memory write gate and allow injecting a global "learning" recalled into every user's turns — so writes are deliberately not exposed (locked decision). Reads disclose cross-user content, hence the operator role.

## Design

- Thin `RecallLearningsQuery` adapter over the existing `RecallQuery` scoring pipeline (relevance + feedback + freshness + diversity), global scope, with the same configured `MinRelevance` floor the agent-turn path uses. The adapter carries wire-only validation caps (context ≤1024, maxResults 1–50) — capping the shared validator would break long-message agent turns.
- **The HTTP path performs zero store writes**: new `RecallQuery.RecordAccess` opt-out stops the pipeline's fire-and-forget access-recording for HTTP calls (caller-steered writes on a GET, plus a lost-update race with feedback improvements). Agent-turn behavior unchanged (default true).
- Response DTO excludes `LearningSource` (can carry session identifiers), provenance, and bookkeeping fields; a recursive reflection guard test pins the wire shape including nested types.
- Per-user rate limit 30/min (`learnings:` partition) — each recall costs 1+N uncached embedding calls, so the spend needed a cap.

## Review trail

Standards/spec + 4-angle simplify + security review (PASS, no CRIT/HIGH) ran pre-push; fixes applied: RecordAccess opt-out (MED), rate limit with wire-level 429 test (MED), MinRelevance parity, real-pipeline validation tests, nested wire-shape guard.

## Test plan

- `Presentation.AgentHub.Tests` 411/411 (auth 401/403/200, rate-limit 429, wire shape), `Application.Core.Tests` 768/768 (handler, validator, real-pipeline 400s).
- Full solution build: 0 errors, 0 new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BnoLcufW278UxA9ssBM1Tc