### PR TITLE
feat: escalation decision HTTP surface (H1)

### DIFF
--- a/src/Content/Application/Application.AI.Common/Interfaces/Escalation/IEscalationService.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Escalation/IEscalationService.cs
@@ -66,5 +66,14 @@ public interface IEscalationService
     /// Explicitly cancels a pending escalation. Used for agent disconnects,
     /// admin force-resolve, or governance context changes.
     /// </summary>
-    Task<EscalationOutcome> CancelEscalationAsync(Guid escalationId, string reason, CancellationToken ct);
+    /// <param name="escalationId">The pending escalation to cancel.</param>
+    /// <param name="reason">Free-text reason for the cancellation.</param>
+    /// <param name="cancelledBy">
+    /// The identity performing the cancellation (a token-derived approver name over HTTP, or a
+    /// system actor such as <c>"system:agent-disconnect"</c> for internal callers). Stamped on
+    /// the resulting <see cref="EscalationOutcome.CancelledBy"/> and therefore recorded in the
+    /// durable outcome audit — a force-denial must always be attributable.
+    /// </param>
+    /// <param name="ct">Cancellation token.</param>
+    Task<EscalationOutcome> CancelEscalationAsync(Guid escalationId, string reason, string cancelledBy, CancellationToken ct);
 }

--- a/src/Content/Application/Application.Core/CQRS/Escalation/ApproverDecisionSummary.cs
+++ b/src/Content/Application/Application.Core/CQRS/Escalation/ApproverDecisionSummary.cs
@@ -1,0 +1,36 @@
+using Domain.AI.Escalation;
+
+namespace Application.Core.CQRS.Escalation;
+
+/// <summary>
+/// A wire-safe projection of a single <see cref="ApproverDecision"/> inside a resolved
+/// escalation outcome: who decided, which way, why, and when.
+/// </summary>
+public sealed record ApproverDecisionSummary
+{
+    /// <summary>Identifier of the approver, exactly as recorded (original casing preserved).</summary>
+    public required string ApproverName { get; init; }
+
+    /// <summary>Whether the approver granted approval.</summary>
+    public required bool Approved { get; init; }
+
+    /// <summary>Optional reason the approver supplied with the decision.</summary>
+    public string? Reason { get; init; }
+
+    /// <summary>When the approver responded.</summary>
+    public required DateTimeOffset RespondedAt { get; init; }
+
+    /// <summary>Projects a domain <see cref="ApproverDecision"/> to the wire-safe shape.</summary>
+    /// <param name="decision">The recorded decision to project. Must not be null.</param>
+    public static ApproverDecisionSummary FromDecision(ApproverDecision decision)
+    {
+        ArgumentNullException.ThrowIfNull(decision);
+        return new ApproverDecisionSummary
+        {
+            ApproverName = decision.ApproverName,
+            Approved = decision.Approved,
+            Reason = decision.Reason,
+            RespondedAt = decision.RespondedAt
+        };
+    }
+}

--- a/src/Content/Application/Application.Core/CQRS/Escalation/CancelEscalationCommand.cs
+++ b/src/Content/Application/Application.Core/CQRS/Escalation/CancelEscalationCommand.cs
@@ -1,0 +1,29 @@
+using Domain.Common;
+using MediatR;
+
+namespace Application.Core.CQRS.Escalation;
+
+/// <summary>
+/// Administratively cancels a pending escalation, resolving it as denied. Used to clear stuck or
+/// obsolete approval requests (agent disconnects, superseded work, governance changes). The
+/// blocked agent turn — if any — is released with the denial.
+/// </summary>
+public sealed record CancelEscalationCommand : IRequest<Result<EscalationOutcomeSummary>>
+{
+    /// <summary>The pending escalation to cancel.</summary>
+    public required Guid EscalationId { get; init; }
+
+    /// <summary>Free-text reason for the cancellation, recorded in structured logs.</summary>
+    public required string Reason { get; init; }
+
+    /// <summary>
+    /// The identity of the administrator performing the cancellation, recorded in structured
+    /// logs for accountability.
+    /// </summary>
+    /// <remarks>
+    /// <b>Populated exclusively by the controller from the authenticated principal's token
+    /// claims</b> (the claim type configured by <c>EscalationConfig.ApproverClaimType</c>).
+    /// It must never be bound from a request body, query string, or header.
+    /// </remarks>
+    public required string CancelledBy { get; init; }
+}

--- a/src/Content/Application/Application.Core/CQRS/Escalation/CancelEscalationCommandHandler.cs
+++ b/src/Content/Application/Application.Core/CQRS/Escalation/CancelEscalationCommandHandler.cs
@@ -1,0 +1,101 @@
+using Application.AI.Common.Interfaces.Escalation;
+using Domain.AI.Escalation;
+using Domain.Common;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace Application.Core.CQRS.Escalation;
+
+/// <summary>
+/// Cancels a pending escalation via <see cref="IEscalationService.CancelEscalationAsync"/>,
+/// translating the service's exception-based contract into the <see cref="Result"/> failures the
+/// HTTP surface maps: unknown id → <c>NotFound</c> (404), already resolved → <c>Conflict</c>
+/// (409).
+/// </summary>
+/// <remarks>
+/// The service throws the same <see cref="InvalidOperationException"/> for "unknown" and
+/// "already resolved", so this handler disambiguates <em>before</em> cancelling: a pending
+/// lookup miss followed by a resolved-outcome hit is a conflict; a miss on both is not-found.
+/// If the escalation resolves between the pending check and the cancel call, the caught
+/// exception is reported as a conflict — the only state that race can reach.
+/// </remarks>
+public sealed class CancelEscalationCommandHandler
+    : IRequestHandler<CancelEscalationCommand, Result<EscalationOutcomeSummary>>
+{
+    private readonly IEscalationService _escalations;
+    private readonly ILogger<CancelEscalationCommandHandler> _logger;
+
+    /// <summary>Initializes a new instance of the <see cref="CancelEscalationCommandHandler"/> class.</summary>
+    /// <param name="escalations">The escalation lifecycle service.</param>
+    /// <param name="logger">Logger recording who cancelled what, and why.</param>
+    public CancelEscalationCommandHandler(
+        IEscalationService escalations,
+        ILogger<CancelEscalationCommandHandler> logger)
+    {
+        _escalations = escalations;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<Result<EscalationOutcomeSummary>> Handle(
+        CancelEscalationCommand request, CancellationToken cancellationToken)
+    {
+        var pending = await _escalations.GetPendingEscalationAsync(
+            request.EscalationId, cancellationToken);
+
+        if (pending is null)
+        {
+            var resolved = await _escalations.GetOutcomeAsync(request.EscalationId, cancellationToken);
+            return resolved is not null
+                ? Result<EscalationOutcomeSummary>.Conflict(
+                    "The escalation is already resolved and can no longer be cancelled.")
+                : Result<EscalationOutcomeSummary>.NotFound(
+                    "No pending escalation with the given id.");
+        }
+
+        try
+        {
+            var outcome = await _escalations.CancelEscalationAsync(
+                request.EscalationId, request.Reason, request.CancelledBy, cancellationToken);
+
+            _logger.LogInformation(
+                "Escalation {EscalationId} cancelled by {CancelledBy}: {Reason}",
+                request.EscalationId, request.CancelledBy, request.Reason);
+
+            return Result<EscalationOutcomeSummary>.Success(
+                EscalationOutcomeSummary.FromOutcome(outcome));
+        }
+        catch (InvalidOperationException ex)
+        {
+            return await ReconcileCancelRaceAsync(request, ex, cancellationToken);
+        }
+    }
+
+    /// <summary>
+    /// Disambiguates the cancel race honestly: if the recorded outcome is this very caller's own
+    /// cancellation (a retried or duplicated request whose first attempt won), report success —
+    /// the desired end state holds. Anything else (a decision or timeout won, or the state
+    /// vanished) is a genuine conflict.
+    /// </summary>
+    private async Task<Result<EscalationOutcomeSummary>> ReconcileCancelRaceAsync(
+        CancelEscalationCommand request, InvalidOperationException ex, CancellationToken cancellationToken)
+    {
+        var outcome = await _escalations.GetOutcomeAsync(request.EscalationId, cancellationToken);
+
+        if (outcome?.CancelledBy is not null
+            && ApproverNames.Comparer.Equals(outcome.CancelledBy, request.CancelledBy))
+        {
+            _logger.LogInformation(
+                "Cancel of escalation {EscalationId} by {CancelledBy} raced its own earlier cancellation; reporting success",
+                request.EscalationId, request.CancelledBy);
+            return Result<EscalationOutcomeSummary>.Success(
+                EscalationOutcomeSummary.FromOutcome(outcome));
+        }
+
+        _logger.LogWarning(ex,
+            "Cancel of escalation {EscalationId} by {CancelledBy} lost a resolution race",
+            request.EscalationId, request.CancelledBy);
+        return Result<EscalationOutcomeSummary>.Conflict(
+            "The escalation resolved while the cancellation was being processed.");
+    }
+}

--- a/src/Content/Application/Application.Core/CQRS/Escalation/CancelEscalationCommandHandler.cs
+++ b/src/Content/Application/Application.Core/CQRS/Escalation/CancelEscalationCommandHandler.cs
@@ -72,17 +72,29 @@ public sealed class CancelEscalationCommandHandler
     }
 
     /// <summary>
-    /// Disambiguates the cancel race honestly: if the recorded outcome is this very caller's own
-    /// cancellation (a retried or duplicated request whose first attempt won), report success —
-    /// the desired end state holds. Anything else (a decision or timeout won, or the state
-    /// vanished) is a genuine conflict.
+    /// Disambiguates the cancel race honestly, keyed on what the outcome store actually
+    /// retained. A retained outcome proves a durably audited resolution exists: if it is this
+    /// very caller's own cancellation (a retried request whose first attempt won), report
+    /// success — the desired end state holds; otherwise a decision or timeout genuinely won the
+    /// race — 409. NO retained outcome means the resolution's fail-closed audit write did not
+    /// complete (the exception may even be the audit store's own) — the escalation was force-
+    /// resolved with no durable record, which is a real failure, never a benign 409.
     /// </summary>
     private async Task<Result<EscalationOutcomeSummary>> ReconcileCancelRaceAsync(
         CancelEscalationCommand request, InvalidOperationException ex, CancellationToken cancellationToken)
     {
         var outcome = await _escalations.GetOutcomeAsync(request.EscalationId, cancellationToken);
 
-        if (outcome?.CancelledBy is not null
+        if (outcome is null)
+        {
+            _logger.LogError(ex,
+                "Cancel of escalation {EscalationId} by {CancelledBy} failed with no durably audited outcome retained; reporting failure, not conflict",
+                request.EscalationId, request.CancelledBy);
+            return Result<EscalationOutcomeSummary>.Fail(
+                "The cancellation could not be completed. See server logs for details.");
+        }
+
+        if (outcome.CancelledBy is not null
             && ApproverNames.Comparer.Equals(outcome.CancelledBy, request.CancelledBy))
         {
             _logger.LogInformation(

--- a/src/Content/Application/Application.Core/CQRS/Escalation/CancelEscalationCommandValidator.cs
+++ b/src/Content/Application/Application.Core/CQRS/Escalation/CancelEscalationCommandValidator.cs
@@ -1,0 +1,28 @@
+using FluentValidation;
+
+namespace Application.Core.CQRS.Escalation;
+
+/// <summary>
+/// Validates <see cref="CancelEscalationCommand"/>: a non-empty escalation id, a required bounded
+/// reason (cancellations are administrative actions — an unexplained one is not auditable), and a
+/// present, bounded controller-stamped canceller identity.
+/// </summary>
+public sealed class CancelEscalationCommandValidator : AbstractValidator<CancelEscalationCommand>
+{
+    /// <summary>Initializes validation rules.</summary>
+    public CancelEscalationCommandValidator()
+    {
+        RuleFor(x => x.EscalationId)
+            .NotEmpty().WithMessage("EscalationId must not be empty.");
+
+        RuleFor(x => x.Reason)
+            .NotEmpty().WithMessage("Reason must not be empty — cancellations must be explained for the audit trail.")
+            .MaximumLength(EscalationValidationRules.MaxReasonLength)
+                .WithMessage($"Reason must not exceed {EscalationValidationRules.MaxReasonLength} characters.");
+
+        RuleFor(x => x.CancelledBy)
+            .NotEmpty().WithMessage("CancelledBy must not be empty.")
+            .MaximumLength(EscalationValidationRules.MaxApproverNameLength)
+                .WithMessage($"CancelledBy must not exceed {EscalationValidationRules.MaxApproverNameLength} characters.");
+    }
+}

--- a/src/Content/Application/Application.Core/CQRS/Escalation/EscalationDetail.cs
+++ b/src/Content/Application/Application.Core/CQRS/Escalation/EscalationDetail.cs
@@ -1,0 +1,44 @@
+namespace Application.Core.CQRS.Escalation;
+
+/// <summary>Lifecycle state of an escalation as observed by the read surface.</summary>
+public enum EscalationReadStatus
+{
+    /// <summary>The escalation is awaiting approver decisions; <see cref="EscalationDetail.Pending"/> is populated.</summary>
+    Pending = 0,
+
+    /// <summary>The escalation has a final verdict; <see cref="EscalationDetail.Outcome"/> is populated.</summary>
+    Resolved
+}
+
+/// <summary>
+/// The discriminated read model for a single escalation: exactly one of
+/// <see cref="Pending"/> or <see cref="Outcome"/> is populated, selected by <see cref="Status"/>.
+/// Construct via the static factories so the pairing invariant always holds.
+/// </summary>
+public sealed record EscalationDetail
+{
+    /// <summary>Whether the escalation is still pending or already resolved.</summary>
+    public required EscalationReadStatus Status { get; init; }
+
+    /// <summary>The pending request summary. Non-null iff <see cref="Status"/> is <see cref="EscalationReadStatus.Pending"/>.</summary>
+    public EscalationSummary? Pending { get; init; }
+
+    /// <summary>The resolved outcome. Non-null iff <see cref="Status"/> is <see cref="EscalationReadStatus.Resolved"/>.</summary>
+    public EscalationOutcomeSummary? Outcome { get; init; }
+
+    /// <summary>Creates a detail for a still-pending escalation.</summary>
+    /// <param name="pending">The pending summary. Must not be null.</param>
+    public static EscalationDetail ForPending(EscalationSummary pending)
+    {
+        ArgumentNullException.ThrowIfNull(pending);
+        return new EscalationDetail { Status = EscalationReadStatus.Pending, Pending = pending };
+    }
+
+    /// <summary>Creates a detail for a resolved escalation.</summary>
+    /// <param name="outcome">The resolved outcome summary. Must not be null.</param>
+    public static EscalationDetail ForResolved(EscalationOutcomeSummary outcome)
+    {
+        ArgumentNullException.ThrowIfNull(outcome);
+        return new EscalationDetail { Status = EscalationReadStatus.Resolved, Outcome = outcome };
+    }
+}

--- a/src/Content/Application/Application.Core/CQRS/Escalation/EscalationOutcomeSummary.cs
+++ b/src/Content/Application/Application.Core/CQRS/Escalation/EscalationOutcomeSummary.cs
@@ -1,0 +1,42 @@
+using Domain.AI.Escalation;
+
+namespace Application.Core.CQRS.Escalation;
+
+/// <summary>
+/// A wire-safe projection of a resolved <see cref="EscalationOutcome"/>: the final verdict, how
+/// it was reached, and the individual decisions that produced it. Excludes
+/// <see cref="EscalationOutcome.EscalatedToTier"/>'s governance internals only in the sense of
+/// projecting it as-is — the tier enum is already a public domain concept.
+/// </summary>
+public sealed record EscalationOutcomeSummary
+{
+    /// <summary>Correlates back to the originating escalation.</summary>
+    public required Guid EscalationId { get; init; }
+
+    /// <summary>Final approval verdict.</summary>
+    public required bool IsApproved { get; init; }
+
+    /// <summary>How the escalation was resolved (approved, denied, timed out, escalated).</summary>
+    public required EscalationResolutionType ResolutionType { get; init; }
+
+    /// <summary>When the escalation was resolved.</summary>
+    public required DateTimeOffset ResolvedAt { get; init; }
+
+    /// <summary>The individual approver decisions collected before resolution.</summary>
+    public required IReadOnlyList<ApproverDecisionSummary> Decisions { get; init; }
+
+    /// <summary>Projects a domain <see cref="EscalationOutcome"/> to the wire-safe shape.</summary>
+    /// <param name="outcome">The resolved outcome to project. Must not be null.</param>
+    public static EscalationOutcomeSummary FromOutcome(EscalationOutcome outcome)
+    {
+        ArgumentNullException.ThrowIfNull(outcome);
+        return new EscalationOutcomeSummary
+        {
+            EscalationId = outcome.EscalationId,
+            IsApproved = outcome.IsApproved,
+            ResolutionType = outcome.ResolutionType,
+            ResolvedAt = outcome.ResolvedAt,
+            Decisions = outcome.Decisions.Select(ApproverDecisionSummary.FromDecision).ToList()
+        };
+    }
+}

--- a/src/Content/Application/Application.Core/CQRS/Escalation/EscalationSummary.cs
+++ b/src/Content/Application/Application.Core/CQRS/Escalation/EscalationSummary.cs
@@ -1,0 +1,78 @@
+using Domain.AI.Escalation;
+
+namespace Application.Core.CQRS.Escalation;
+
+/// <summary>
+/// A slim, wire-safe projection of a pending <see cref="EscalationRequest"/>. Deliberately
+/// excludes <see cref="EscalationRequest.OriginatingDecision"/> — the internal governance
+/// decision that raised the escalation carries rule internals that do not belong on the HTTP
+/// surface. Everything an approver needs to decide (what the agent tried to do, with which
+/// arguments, at what risk, and by when) is carried explicitly.
+/// </summary>
+public sealed record EscalationSummary
+{
+    /// <summary>Unique identifier of the escalation.</summary>
+    public required Guid EscalationId { get; init; }
+
+    /// <summary>The agent that attempted the action.</summary>
+    public required string AgentId { get; init; }
+
+    /// <summary>The tool or operation the agent tried to invoke.</summary>
+    public required string ToolName { get; init; }
+
+    /// <summary>Arguments passed to the tool (already sanitized for audit display upstream).</summary>
+    public required IReadOnlyDictionary<string, string> Arguments { get; init; }
+
+    /// <summary>Human-readable summary of the attempted action.</summary>
+    public required string Description { get; init; }
+
+    /// <summary>Risk level derived from the matched governance rule.</summary>
+    public required RiskLevel RiskLevel { get; init; }
+
+    /// <summary>Urgency of the escalation.</summary>
+    public required EscalationPriority Priority { get; init; }
+
+    /// <summary>Strategy used to evaluate the collected approver decisions.</summary>
+    public required ApprovalStrategyType ApprovalStrategy { get; init; }
+
+    /// <summary>For the Quorum strategy, the N in N-of-M required approvals. Zero otherwise.</summary>
+    public required int QuorumThreshold { get; init; }
+
+    /// <summary>
+    /// The approver roster. Visible by construction only to roster members (list and get are
+    /// roster-filtered), so exposing it lets co-approvers coordinate on AllOf/Quorum items.
+    /// </summary>
+    public required IReadOnlyList<string> Approvers { get; init; }
+
+    /// <summary>When the escalation was created.</summary>
+    public required DateTimeOffset RequestedAt { get; init; }
+
+    /// <summary>Seconds after <see cref="RequestedAt"/> at which the escalation times out.</summary>
+    public required int TimeoutSeconds { get; init; }
+
+    /// <summary>Action the service takes if the escalation times out undecided.</summary>
+    public required EscalationTimeoutAction TimeoutAction { get; init; }
+
+    /// <summary>Projects a domain <see cref="EscalationRequest"/> to the wire-safe shape.</summary>
+    /// <param name="request">The pending escalation request to project. Must not be null.</param>
+    public static EscalationSummary FromRequest(EscalationRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        return new EscalationSummary
+        {
+            EscalationId = request.EscalationId,
+            AgentId = request.AgentId,
+            ToolName = request.ToolName,
+            Arguments = request.Arguments,
+            Description = request.Description,
+            RiskLevel = request.RiskLevel,
+            Priority = request.Priority,
+            ApprovalStrategy = request.ApprovalStrategy,
+            QuorumThreshold = request.QuorumThreshold,
+            Approvers = request.Approvers,
+            RequestedAt = request.RequestedAt,
+            TimeoutSeconds = request.TimeoutSeconds,
+            TimeoutAction = request.TimeoutAction
+        };
+    }
+}

--- a/src/Content/Application/Application.Core/CQRS/Escalation/EscalationValidationRules.cs
+++ b/src/Content/Application/Application.Core/CQRS/Escalation/EscalationValidationRules.cs
@@ -1,0 +1,23 @@
+namespace Application.Core.CQRS.Escalation;
+
+/// <summary>
+/// Shared validation constants for the escalation CQRS surface. Centralized so every command and
+/// query agrees on what a well-formed approver name and decision reason look like — an identity
+/// that can list pending escalations can always also submit a decision.
+/// </summary>
+public static class EscalationValidationRules
+{
+    /// <summary>
+    /// Maximum accepted approver-name length. Approver names are token claims (UPNs, emails,
+    /// service-principal names) compared against operator-authored rosters; 256 characters
+    /// comfortably covers every realistic identity format while bounding log and audit lines.
+    /// </summary>
+    public const int MaxApproverNameLength = 256;
+
+    /// <summary>
+    /// Maximum accepted decision/cancellation reason length. Reasons are free-text audit
+    /// context, not documents — 2000 characters keeps the JSONL audit records readable and
+    /// prevents a single decision from ballooning the audit store.
+    /// </summary>
+    public const int MaxReasonLength = 2000;
+}

--- a/src/Content/Application/Application.Core/CQRS/Escalation/GetEscalationQuery.cs
+++ b/src/Content/Application/Application.Core/CQRS/Escalation/GetEscalationQuery.cs
@@ -1,0 +1,31 @@
+using Domain.Common;
+using MediatR;
+
+namespace Application.Core.CQRS.Escalation;
+
+/// <summary>
+/// Reads a single escalation: its pending summary while undecided, or its resolved outcome after
+/// a verdict. This is the poll target after a decision returns <c>DecisionRecorded</c> (202).
+/// </summary>
+/// <remarks>
+/// <b>Roster privacy:</b> a caller not on the escalation's approver roster receives
+/// <c>NotFound</c> — indistinguishable from an unknown id — for pending <em>and</em> resolved
+/// escalations alike. Resolved outcomes carry the originating roster forward
+/// (<c>EscalationOutcome.Approvers</c>) precisely so this check survives the pending request
+/// being discarded on resolution.
+/// </remarks>
+public sealed record GetEscalationQuery : IRequest<Result<EscalationDetail>>
+{
+    /// <summary>The escalation to read.</summary>
+    public required Guid EscalationId { get; init; }
+
+    /// <summary>
+    /// The caller's approver identity, used for the pending-state roster check.
+    /// </summary>
+    /// <remarks>
+    /// <b>Populated exclusively by the controller from the authenticated principal's token
+    /// claims</b> (the claim type configured by <c>EscalationConfig.ApproverClaimType</c>).
+    /// It must never be bound from a request body, query string, or header.
+    /// </remarks>
+    public required string ApproverName { get; init; }
+}

--- a/src/Content/Application/Application.Core/CQRS/Escalation/GetEscalationQueryHandler.cs
+++ b/src/Content/Application/Application.Core/CQRS/Escalation/GetEscalationQueryHandler.cs
@@ -1,0 +1,82 @@
+using Application.AI.Common.Interfaces.Escalation;
+using Domain.AI.Escalation;
+using Domain.Common;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace Application.Core.CQRS.Escalation;
+
+/// <summary>
+/// Reads one escalation as a discriminated <see cref="EscalationDetail"/>:
+/// pending summary (roster-gated), resolved outcome, or <c>NotFound</c>.
+/// </summary>
+/// <remarks>
+/// Both paths enforce roster privacy: a caller not on the roster gets the same <c>NotFound</c>
+/// as an unknown id, using <see cref="ApproverNames.Comparer"/> so the check matches the decide
+/// path exactly. Resolved outcomes carry the roster forward from the originating request
+/// (<see cref="EscalationOutcome.Approvers"/>), so a verdict is only readable by the identities
+/// that were entitled to produce it; an outcome without a roster denies (fail-closed).
+/// </remarks>
+public sealed class GetEscalationQueryHandler
+    : IRequestHandler<GetEscalationQuery, Result<EscalationDetail>>
+{
+    private const string NotFoundMessage = "No escalation with the given id is visible to the caller.";
+
+    private readonly IEscalationService _escalations;
+    private readonly ILogger<GetEscalationQueryHandler> _logger;
+
+    /// <summary>Initializes a new instance of the <see cref="GetEscalationQueryHandler"/> class.</summary>
+    /// <param name="escalations">The escalation lifecycle service.</param>
+    /// <param name="logger">Logger for recording read outcomes (never escalation content).</param>
+    public GetEscalationQueryHandler(
+        IEscalationService escalations,
+        ILogger<GetEscalationQueryHandler> logger)
+    {
+        _escalations = escalations;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<Result<EscalationDetail>> Handle(
+        GetEscalationQuery request, CancellationToken cancellationToken)
+    {
+        var pending = await _escalations.GetPendingEscalationAsync(
+            request.EscalationId, cancellationToken);
+
+        if (pending is not null)
+        {
+            if (!pending.Approvers.Contains(request.ApproverName, ApproverNames.Comparer))
+            {
+                // Roster privacy: identical response to an unknown id, so a non-roster caller
+                // cannot probe for the existence of pending escalations.
+                _logger.LogWarning(
+                    "Non-roster read of pending escalation {EscalationId} by {ApproverName} returned NotFound",
+                    request.EscalationId, request.ApproverName);
+                return Result<EscalationDetail>.NotFound(NotFoundMessage);
+            }
+
+            return Result<EscalationDetail>.Success(
+                EscalationDetail.ForPending(EscalationSummary.FromRequest(pending)));
+        }
+
+        var outcome = await _escalations.GetOutcomeAsync(request.EscalationId, cancellationToken);
+        if (outcome is not null)
+        {
+            // Same roster privacy as the pending path: the outcome carries the originating
+            // roster, and a caller outside it gets the indistinguishable NotFound. An empty
+            // roster (no roster known) denies everyone — fail-closed.
+            if (!outcome.Approvers.Contains(request.ApproverName, ApproverNames.Comparer))
+            {
+                _logger.LogWarning(
+                    "Non-roster read of resolved escalation {EscalationId} by {ApproverName} returned NotFound",
+                    request.EscalationId, request.ApproverName);
+                return Result<EscalationDetail>.NotFound(NotFoundMessage);
+            }
+
+            return Result<EscalationDetail>.Success(
+                EscalationDetail.ForResolved(EscalationOutcomeSummary.FromOutcome(outcome)));
+        }
+
+        return Result<EscalationDetail>.NotFound(NotFoundMessage);
+    }
+}

--- a/src/Content/Application/Application.Core/CQRS/Escalation/GetEscalationQueryValidator.cs
+++ b/src/Content/Application/Application.Core/CQRS/Escalation/GetEscalationQueryValidator.cs
@@ -1,0 +1,22 @@
+using FluentValidation;
+
+namespace Application.Core.CQRS.Escalation;
+
+/// <summary>
+/// Validates <see cref="GetEscalationQuery"/>: a non-empty escalation id and a present, bounded
+/// controller-stamped approver name.
+/// </summary>
+public sealed class GetEscalationQueryValidator : AbstractValidator<GetEscalationQuery>
+{
+    /// <summary>Initializes validation rules.</summary>
+    public GetEscalationQueryValidator()
+    {
+        RuleFor(x => x.EscalationId)
+            .NotEmpty().WithMessage("EscalationId must not be empty.");
+
+        RuleFor(x => x.ApproverName)
+            .NotEmpty().WithMessage("ApproverName must not be empty.")
+            .MaximumLength(EscalationValidationRules.MaxApproverNameLength)
+                .WithMessage($"ApproverName must not exceed {EscalationValidationRules.MaxApproverNameLength} characters.");
+    }
+}

--- a/src/Content/Application/Application.Core/CQRS/Escalation/GetPendingEscalationsForApproverQuery.cs
+++ b/src/Content/Application/Application.Core/CQRS/Escalation/GetPendingEscalationsForApproverQuery.cs
@@ -1,0 +1,25 @@
+using Domain.Common;
+using MediatR;
+
+namespace Application.Core.CQRS.Escalation;
+
+/// <summary>
+/// Lists the pending escalations whose approver roster contains the caller. Roster matching is
+/// case-insensitive via <c>ApproverNames.Comparer</c> — the single comparison authority shared
+/// with the decide path — so an identity that can decide an escalation always also sees it here.
+/// </summary>
+public sealed record GetPendingEscalationsForApproverQuery
+    : IRequest<Result<IReadOnlyList<EscalationSummary>>>
+{
+    /// <summary>
+    /// The caller's approver identity.
+    /// </summary>
+    /// <remarks>
+    /// <b>Populated exclusively by the controller from the authenticated principal's token
+    /// claims</b> (the claim type configured by <c>EscalationConfig.ApproverClaimType</c>).
+    /// It must never be bound from a request body, query string, or header — no wire DTO
+    /// carries an approver-name field by design, so a caller cannot assert an identity their
+    /// token does not prove.
+    /// </remarks>
+    public required string ApproverName { get; init; }
+}

--- a/src/Content/Application/Application.Core/CQRS/Escalation/GetPendingEscalationsForApproverQueryHandler.cs
+++ b/src/Content/Application/Application.Core/CQRS/Escalation/GetPendingEscalationsForApproverQueryHandler.cs
@@ -1,0 +1,46 @@
+using Application.AI.Common.Interfaces.Escalation;
+using Domain.Common;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace Application.Core.CQRS.Escalation;
+
+/// <summary>
+/// Lists pending escalations via <see cref="IEscalationService.GetPendingEscalationsAsync"/> and
+/// projects each to the wire-safe <see cref="EscalationSummary"/> shape. The roster filter lives
+/// in the service (using <c>ApproverNames.Comparer</c>); this handler only projects.
+/// </summary>
+public sealed class GetPendingEscalationsForApproverQueryHandler
+    : IRequestHandler<GetPendingEscalationsForApproverQuery, Result<IReadOnlyList<EscalationSummary>>>
+{
+    private readonly IEscalationService _escalations;
+    private readonly ILogger<GetPendingEscalationsForApproverQueryHandler> _logger;
+
+    /// <summary>Initializes a new instance of the <see cref="GetPendingEscalationsForApproverQueryHandler"/> class.</summary>
+    /// <param name="escalations">The escalation lifecycle service.</param>
+    /// <param name="logger">Logger for recording list statistics (never escalation content).</param>
+    public GetPendingEscalationsForApproverQueryHandler(
+        IEscalationService escalations,
+        ILogger<GetPendingEscalationsForApproverQueryHandler> logger)
+    {
+        _escalations = escalations;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<Result<IReadOnlyList<EscalationSummary>>> Handle(
+        GetPendingEscalationsForApproverQuery request, CancellationToken cancellationToken)
+    {
+        var pending = await _escalations.GetPendingEscalationsAsync(
+            request.ApproverName, cancellationToken);
+
+        IReadOnlyList<EscalationSummary> summaries =
+            pending.Select(EscalationSummary.FromRequest).ToList();
+
+        _logger.LogDebug(
+            "Pending escalation list for {ApproverName}: {Count} items",
+            request.ApproverName, summaries.Count);
+
+        return Result<IReadOnlyList<EscalationSummary>>.Success(summaries);
+    }
+}

--- a/src/Content/Application/Application.Core/CQRS/Escalation/GetPendingEscalationsForApproverQueryValidator.cs
+++ b/src/Content/Application/Application.Core/CQRS/Escalation/GetPendingEscalationsForApproverQueryValidator.cs
@@ -1,0 +1,22 @@
+using FluentValidation;
+
+namespace Application.Core.CQRS.Escalation;
+
+/// <summary>
+/// Validates <see cref="GetPendingEscalationsForApproverQuery"/>: the controller-stamped approver
+/// name must be present and bounded. An empty name means the principal lacked the configured
+/// identity claim — the controller rejects that before dispatch, so this rule is the
+/// defense-in-depth backstop.
+/// </summary>
+public sealed class GetPendingEscalationsForApproverQueryValidator
+    : AbstractValidator<GetPendingEscalationsForApproverQuery>
+{
+    /// <summary>Initializes validation rules.</summary>
+    public GetPendingEscalationsForApproverQueryValidator()
+    {
+        RuleFor(x => x.ApproverName)
+            .NotEmpty().WithMessage("ApproverName must not be empty.")
+            .MaximumLength(EscalationValidationRules.MaxApproverNameLength)
+                .WithMessage($"ApproverName must not exceed {EscalationValidationRules.MaxApproverNameLength} characters.");
+    }
+}

--- a/src/Content/Application/Application.Core/CQRS/Escalation/SubmitEscalationDecisionCommand.cs
+++ b/src/Content/Application/Application.Core/CQRS/Escalation/SubmitEscalationDecisionCommand.cs
@@ -1,0 +1,34 @@
+using Domain.Common;
+using MediatR;
+
+namespace Application.Core.CQRS.Escalation;
+
+/// <summary>
+/// Submits the caller's approve/deny decision on a pending escalation. The service records the
+/// decision, evaluates the approval strategy (AnyOf/AllOf/Quorum), and — when this decision
+/// resolves the escalation — releases the agent turn blocked on it in the same process.
+/// </summary>
+public sealed record SubmitEscalationDecisionCommand
+    : IRequest<Result<SubmitEscalationDecisionResult>>
+{
+    /// <summary>The escalation being decided.</summary>
+    public required Guid EscalationId { get; init; }
+
+    /// <summary>
+    /// The deciding approver's identity, compared against the escalation's roster by the
+    /// service using <c>ApproverNames.Comparer</c>.
+    /// </summary>
+    /// <remarks>
+    /// <b>Populated exclusively by the controller from the authenticated principal's token
+    /// claims</b> (the claim type configured by <c>EscalationConfig.ApproverClaimType</c>).
+    /// It must never be bound from a request body, query string, or header — the wire DTO
+    /// deliberately has no approver-name field, so a caller cannot decide as someone else.
+    /// </remarks>
+    public required string ApproverName { get; init; }
+
+    /// <summary>Whether the caller approves the escalated action.</summary>
+    public required bool Approve { get; init; }
+
+    /// <summary>Optional free-text reason recorded with the decision. Especially useful for denials.</summary>
+    public string? Reason { get; init; }
+}

--- a/src/Content/Application/Application.Core/CQRS/Escalation/SubmitEscalationDecisionCommandHandler.cs
+++ b/src/Content/Application/Application.Core/CQRS/Escalation/SubmitEscalationDecisionCommandHandler.cs
@@ -9,9 +9,12 @@ namespace Application.Core.CQRS.Escalation;
 /// <summary>
 /// Builds the domain <see cref="ApproverDecision"/> (stamping <c>RespondedAt</c> server-side)
 /// and submits it via <see cref="IEscalationService.SubmitDecisionAsync"/>. The service's
-/// discriminated result is returned as data, not failure: every one of the four statuses —
-/// unknown, not-authorized, recorded, resolved — is an expected, reportable outcome that the
-/// controller maps to its documented HTTP status.
+/// discriminated statuses — unknown, not-authorized, recorded, resolved — are returned as data,
+/// not failure: each is an expected, reportable outcome that the controller maps to its
+/// documented HTTP status. The one exception is
+/// <see cref="EscalationDecisionStatus.ConflictingDecision"/> (same approver, opposite verdict),
+/// which is a genuine request conflict and is translated to a
+/// <see cref="Result{T}.Conflict"/> failure so the shared failure mapper produces the 409.
 /// </summary>
 public sealed class SubmitEscalationDecisionCommandHandler
     : IRequestHandler<SubmitEscalationDecisionCommand, Result<SubmitEscalationDecisionResult>>
@@ -48,6 +51,12 @@ public sealed class SubmitEscalationDecisionCommandHandler
         _logger.LogInformation(
             "Escalation decision: EscalationId={EscalationId}, Approver={ApproverName}, Approve={Approve}, Status={Status}",
             request.EscalationId, request.ApproverName, request.Approve, result.Status);
+
+        if (result.Status == EscalationDecisionStatus.ConflictingDecision)
+        {
+            return Result<SubmitEscalationDecisionResult>.Conflict(
+                "A decision by this approver with the opposite verdict is already recorded; votes cannot be changed.");
+        }
 
         return Result<SubmitEscalationDecisionResult>.Success(
             SubmitEscalationDecisionResult.FromDecisionResult(result));

--- a/src/Content/Application/Application.Core/CQRS/Escalation/SubmitEscalationDecisionCommandHandler.cs
+++ b/src/Content/Application/Application.Core/CQRS/Escalation/SubmitEscalationDecisionCommandHandler.cs
@@ -1,0 +1,55 @@
+using Application.AI.Common.Interfaces.Escalation;
+using Domain.AI.Escalation;
+using Domain.Common;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace Application.Core.CQRS.Escalation;
+
+/// <summary>
+/// Builds the domain <see cref="ApproverDecision"/> (stamping <c>RespondedAt</c> server-side)
+/// and submits it via <see cref="IEscalationService.SubmitDecisionAsync"/>. The service's
+/// discriminated result is returned as data, not failure: every one of the four statuses —
+/// unknown, not-authorized, recorded, resolved — is an expected, reportable outcome that the
+/// controller maps to its documented HTTP status.
+/// </summary>
+public sealed class SubmitEscalationDecisionCommandHandler
+    : IRequestHandler<SubmitEscalationDecisionCommand, Result<SubmitEscalationDecisionResult>>
+{
+    private readonly IEscalationService _escalations;
+    private readonly ILogger<SubmitEscalationDecisionCommandHandler> _logger;
+
+    /// <summary>Initializes a new instance of the <see cref="SubmitEscalationDecisionCommandHandler"/> class.</summary>
+    /// <param name="escalations">The escalation lifecycle service.</param>
+    /// <param name="logger">Logger for recording decision statuses (never reason content).</param>
+    public SubmitEscalationDecisionCommandHandler(
+        IEscalationService escalations,
+        ILogger<SubmitEscalationDecisionCommandHandler> logger)
+    {
+        _escalations = escalations;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<Result<SubmitEscalationDecisionResult>> Handle(
+        SubmitEscalationDecisionCommand request, CancellationToken cancellationToken)
+    {
+        var decision = new ApproverDecision
+        {
+            ApproverName = request.ApproverName,
+            Approved = request.Approve,
+            Reason = request.Reason,
+            RespondedAt = DateTimeOffset.UtcNow
+        };
+
+        var result = await _escalations.SubmitDecisionAsync(
+            request.EscalationId, decision, cancellationToken);
+
+        _logger.LogInformation(
+            "Escalation decision: EscalationId={EscalationId}, Approver={ApproverName}, Approve={Approve}, Status={Status}",
+            request.EscalationId, request.ApproverName, request.Approve, result.Status);
+
+        return Result<SubmitEscalationDecisionResult>.Success(
+            SubmitEscalationDecisionResult.FromDecisionResult(result));
+    }
+}

--- a/src/Content/Application/Application.Core/CQRS/Escalation/SubmitEscalationDecisionCommandValidator.cs
+++ b/src/Content/Application/Application.Core/CQRS/Escalation/SubmitEscalationDecisionCommandValidator.cs
@@ -1,0 +1,27 @@
+using FluentValidation;
+
+namespace Application.Core.CQRS.Escalation;
+
+/// <summary>
+/// Validates <see cref="SubmitEscalationDecisionCommand"/>: a non-empty escalation id, a present
+/// and bounded controller-stamped approver name, and a bounded optional reason.
+/// </summary>
+public sealed class SubmitEscalationDecisionCommandValidator
+    : AbstractValidator<SubmitEscalationDecisionCommand>
+{
+    /// <summary>Initializes validation rules.</summary>
+    public SubmitEscalationDecisionCommandValidator()
+    {
+        RuleFor(x => x.EscalationId)
+            .NotEmpty().WithMessage("EscalationId must not be empty.");
+
+        RuleFor(x => x.ApproverName)
+            .NotEmpty().WithMessage("ApproverName must not be empty.")
+            .MaximumLength(EscalationValidationRules.MaxApproverNameLength)
+                .WithMessage($"ApproverName must not exceed {EscalationValidationRules.MaxApproverNameLength} characters.");
+
+        RuleFor(x => x.Reason)
+            .MaximumLength(EscalationValidationRules.MaxReasonLength)
+                .WithMessage($"Reason must not exceed {EscalationValidationRules.MaxReasonLength} characters.");
+    }
+}

--- a/src/Content/Application/Application.Core/CQRS/Escalation/SubmitEscalationDecisionResult.cs
+++ b/src/Content/Application/Application.Core/CQRS/Escalation/SubmitEscalationDecisionResult.cs
@@ -1,0 +1,35 @@
+using Domain.AI.Escalation;
+
+namespace Application.Core.CQRS.Escalation;
+
+/// <summary>
+/// The application-layer projection of an <see cref="EscalationDecisionResult"/>: the
+/// discriminated <see cref="Status"/> plus the wire-safe outcome summary when — and only when —
+/// this decision resolved the escalation. The controller maps <see cref="Status"/> to HTTP per
+/// the mapping documented on <see cref="EscalationDecisionStatus"/> (404/403/202/200).
+/// </summary>
+public sealed record SubmitEscalationDecisionResult
+{
+    /// <summary>What happened to the submitted decision.</summary>
+    public required EscalationDecisionStatus Status { get; init; }
+
+    /// <summary>
+    /// The final verdict. Non-null if and only if <see cref="Status"/> is
+    /// <see cref="EscalationDecisionStatus.Resolved"/>.
+    /// </summary>
+    public EscalationOutcomeSummary? Outcome { get; init; }
+
+    /// <summary>Projects a domain <see cref="EscalationDecisionResult"/> to the wire-safe shape.</summary>
+    /// <param name="result">The service's discriminated decision result. Must not be null.</param>
+    public static SubmitEscalationDecisionResult FromDecisionResult(EscalationDecisionResult result)
+    {
+        ArgumentNullException.ThrowIfNull(result);
+        return new SubmitEscalationDecisionResult
+        {
+            Status = result.Status,
+            Outcome = result.Outcome is null
+                ? null
+                : EscalationOutcomeSummary.FromOutcome(result.Outcome)
+        };
+    }
+}

--- a/src/Content/Application/Application.Core/Validation/ApproverClaimTypes.cs
+++ b/src/Content/Application/Application.Core/Validation/ApproverClaimTypes.cs
@@ -1,0 +1,73 @@
+using System.Security.Claims;
+
+namespace Application.Core.Validation;
+
+/// <summary>
+/// The single authority on which claim types may drive escalation approver identity, and on the
+/// equivalent wire/mapped forms each one appears under at runtime. The config validator's
+/// allowlist and the controller's claim resolution both read from here, so they cannot drift.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The equivalence map exists because of JWT inbound claim mapping:
+/// <c>System.IdentityModel.Tokens.Jwt</c> (the handler behind
+/// <c>AddMicrosoftIdentityWebApiAuthentication</c>) REMAPS short claim names on validated Entra
+/// tokens — <c>oid</c> becomes <c>http://schemas.microsoft.com/identity/claims/objectidentifier</c>,
+/// <c>sub</c> becomes <see cref="ClaimTypes.NameIdentifier"/>, <c>upn</c> becomes
+/// <see cref="ClaimTypes.Upn"/> — while dev/test handlers mint the raw short names.
+/// Resolving only the configured short name would find ZERO claims on real production tokens
+/// (the repo's <c>ClaimsPrincipalExtensions.GetUserIdOrNull()</c> works around the same
+/// remapping). Callers must therefore resolve across ALL equivalent forms.
+/// <c>preferred_username</c> has no inbound mapping and passes through unchanged.
+/// </para>
+/// <para>
+/// Unioning forms is preferred over <c>MapInboundClaims = false</c> because disabling the map is
+/// host-global and would silently change claim shapes for every other claims consumer in the
+/// host (user-id resolution, roles plumbing, knowledge scoping).
+/// </para>
+/// </remarks>
+public static class ApproverClaimTypes
+{
+    private static readonly Dictionary<string, IReadOnlyList<string>> EquivalentForms =
+        new(StringComparer.Ordinal)
+        {
+            ["oid"] = ["oid", "http://schemas.microsoft.com/identity/claims/objectidentifier"],
+            ["sub"] = ["sub", ClaimTypes.NameIdentifier],
+            ["preferred_username"] = ["preferred_username"],
+            ["upn"] = ["upn", ClaimTypes.Upn],
+        };
+
+    /// <summary>
+    /// The only claim types allowed to drive escalation approver identity (configuration-facing
+    /// short names). All four are issuer-asserted: <c>oid</c>/<c>sub</c> are immutable
+    /// object/subject ids; <c>upn</c> and <c>preferred_username</c> are sign-in names (mutable —
+    /// see <see cref="Mutable"/>). Anything user-editable (display name, unverified email) is
+    /// rejected at startup so it can never select the approver.
+    /// </summary>
+    public static IReadOnlyList<string> Allowed { get; } =
+        ["oid", "sub", "preferred_username", "upn"];
+
+    /// <summary>
+    /// The allowed claim types that are nonetheless mutable and reassignable (a departed
+    /// approver's UPN can be reissued to a new hire, who then inherits roster entries naming
+    /// it). Hosts configured with one of these get a startup warning; <c>oid</c> is the
+    /// production recommendation.
+    /// </summary>
+    public static IReadOnlyList<string> Mutable { get; } =
+        ["preferred_username", "upn"];
+
+    /// <summary>
+    /// Every claim-type form the configured type can appear under on a runtime principal: the
+    /// short name itself plus its known JWT inbound-mapped URI. Resolution must search the whole
+    /// union — production tokens carry the mapped form, dev/test principals the short form.
+    /// Unknown (non-allowlisted) types fall back to the raw configured name only, which keeps
+    /// resolution fail-closed and well-defined even when the allowlist is not enforced (the
+    /// validator skips it while escalation is disabled).
+    /// </summary>
+    /// <param name="claimType">The configured approver claim type.</param>
+    public static IReadOnlyList<string> EquivalentFormsOf(string claimType)
+    {
+        ArgumentNullException.ThrowIfNull(claimType);
+        return EquivalentForms.TryGetValue(claimType, out var forms) ? forms : [claimType];
+    }
+}

--- a/src/Content/Application/Application.Core/Validation/EscalationConfigValidator.cs
+++ b/src/Content/Application/Application.Core/Validation/EscalationConfigValidator.cs
@@ -19,6 +19,25 @@ public sealed class EscalationConfigValidator : AbstractValidator<EscalationConf
     private static readonly string[] ValidPriorityNames =
         Enum.GetNames<EscalationPriority>();
 
+    /// <summary>
+    /// The only claim types allowed to drive escalation approver identity. All four are
+    /// issuer-asserted: <c>oid</c>/<c>sub</c> are immutable object/subject ids; <c>upn</c> and
+    /// <c>preferred_username</c> are sign-in names (mutable — see
+    /// <see cref="MutableApproverClaimTypes"/>). Anything user-editable (display name,
+    /// unverified email) is rejected at startup so it can never select the approver.
+    /// </summary>
+    public static readonly IReadOnlyList<string> AllowedApproverClaimTypes =
+        ["oid", "sub", "preferred_username", "upn"];
+
+    /// <summary>
+    /// The allowed claim types that are nonetheless mutable and reassignable (a departed
+    /// approver's UPN can be reissued to a new hire, who then inherits roster entries naming
+    /// it). Hosts configured with one of these get a startup warning; <c>oid</c> is the
+    /// production recommendation.
+    /// </summary>
+    public static readonly IReadOnlyList<string> MutableApproverClaimTypes =
+        ["preferred_username", "upn"];
+
     public EscalationConfigValidator()
     {
         RuleFor(x => x.DefaultTimeoutSeconds)
@@ -36,6 +55,13 @@ public sealed class EscalationConfigValidator : AbstractValidator<EscalationConf
         RuleFor(x => x.AuditStoragePath)
             .NotEmpty()
             .WithMessage("AuditStoragePath must be configured.");
+
+        RuleFor(x => x.ApproverClaimType)
+            .Must(v => AllowedApproverClaimTypes.Contains(v, StringComparer.Ordinal))
+            .WithMessage(
+                "ApproverClaimType must be one of: " + string.Join(", ", AllowedApproverClaimTypes) +
+                ". Only issuer-asserted identity claims may drive roster authorization — " +
+                "user-editable claims like 'name' or unverified 'email' must never select the approver.");
 
         RuleFor(x => x.PriorityLevels)
             .NotEmpty()

--- a/src/Content/Application/Application.Core/Validation/EscalationConfigValidator.cs
+++ b/src/Content/Application/Application.Core/Validation/EscalationConfigValidator.cs
@@ -19,25 +19,6 @@ public sealed class EscalationConfigValidator : AbstractValidator<EscalationConf
     private static readonly string[] ValidPriorityNames =
         Enum.GetNames<EscalationPriority>();
 
-    /// <summary>
-    /// The only claim types allowed to drive escalation approver identity. All four are
-    /// issuer-asserted: <c>oid</c>/<c>sub</c> are immutable object/subject ids; <c>upn</c> and
-    /// <c>preferred_username</c> are sign-in names (mutable — see
-    /// <see cref="MutableApproverClaimTypes"/>). Anything user-editable (display name,
-    /// unverified email) is rejected at startup so it can never select the approver.
-    /// </summary>
-    public static readonly IReadOnlyList<string> AllowedApproverClaimTypes =
-        ["oid", "sub", "preferred_username", "upn"];
-
-    /// <summary>
-    /// The allowed claim types that are nonetheless mutable and reassignable (a departed
-    /// approver's UPN can be reissued to a new hire, who then inherits roster entries naming
-    /// it). Hosts configured with one of these get a startup warning; <c>oid</c> is the
-    /// production recommendation.
-    /// </summary>
-    public static readonly IReadOnlyList<string> MutableApproverClaimTypes =
-        ["preferred_username", "upn"];
-
     public EscalationConfigValidator()
     {
         RuleFor(x => x.DefaultTimeoutSeconds)
@@ -56,12 +37,16 @@ public sealed class EscalationConfigValidator : AbstractValidator<EscalationConf
             .NotEmpty()
             .WithMessage("AuditStoragePath must be configured.");
 
+        // Gated on Enabled like the sibling rules: while the escalation subsystem is off there
+        // is nothing the claim type can authorize, and these validators impose no constraints on
+        // disabled features (hosts booting on class defaults must keep booting).
         RuleFor(x => x.ApproverClaimType)
-            .Must(v => AllowedApproverClaimTypes.Contains(v, StringComparer.Ordinal))
+            .Must(v => ApproverClaimTypes.Allowed.Contains(v, StringComparer.Ordinal))
             .WithMessage(
-                "ApproverClaimType must be one of: " + string.Join(", ", AllowedApproverClaimTypes) +
+                "ApproverClaimType must be one of: " + string.Join(", ", ApproverClaimTypes.Allowed) +
                 ". Only issuer-asserted identity claims may drive roster authorization — " +
-                "user-editable claims like 'name' or unverified 'email' must never select the approver.");
+                "user-editable claims like 'name' or unverified 'email' must never select the approver.")
+            .When(x => x.Enabled);
 
         RuleFor(x => x.PriorityLevels)
             .NotEmpty()

--- a/src/Content/Domain/Domain.AI/Escalation/EscalationDecisionResult.cs
+++ b/src/Content/Domain/Domain.AI/Escalation/EscalationDecisionResult.cs
@@ -27,7 +27,7 @@ public sealed record EscalationDecisionResult
     /// </summary>
     public EscalationOutcome? Outcome { get; init; }
 
-    // The three outcome-less results are stateless and immutable, so a single shared
+    // The outcome-less results are stateless and immutable, so a single shared
     // instance per status serves every call — the factories below hand these out.
     private static readonly EscalationDecisionResult UnknownInstance =
         new() { Status = EscalationDecisionStatus.UnknownEscalation };
@@ -35,6 +35,8 @@ public sealed record EscalationDecisionResult
         new() { Status = EscalationDecisionStatus.ApproverNotAuthorized };
     private static readonly EscalationDecisionResult RecordedInstance =
         new() { Status = EscalationDecisionStatus.DecisionRecorded };
+    private static readonly EscalationDecisionResult ConflictingInstance =
+        new() { Status = EscalationDecisionStatus.ConflictingDecision };
 
     /// <summary>Creates a result for a decision targeting an escalation that is not pending.</summary>
     public static EscalationDecisionResult UnknownEscalation() => UnknownInstance;
@@ -44,6 +46,12 @@ public sealed record EscalationDecisionResult
 
     /// <summary>Creates a result for a decision that was recorded but left the escalation unresolved.</summary>
     public static EscalationDecisionResult DecisionRecorded() => RecordedInstance;
+
+    /// <summary>
+    /// Creates a result for a decision rejected because the same approver already recorded the
+    /// opposite verdict — votes cannot be changed over this surface.
+    /// </summary>
+    public static EscalationDecisionResult ConflictingDecision() => ConflictingInstance;
 
     /// <summary>Creates a result for a decision that resolved the escalation with the given verdict.</summary>
     /// <param name="outcome">The final resolved outcome. Must not be null.</param>

--- a/src/Content/Domain/Domain.AI/Escalation/EscalationDecisionStatus.cs
+++ b/src/Content/Domain/Domain.AI/Escalation/EscalationDecisionStatus.cs
@@ -26,10 +26,21 @@ public enum EscalationDecisionStatus
     /// The decision was durably recorded but did not resolve the escalation:
     /// either the approval strategy requires further decisions (e.g. AllOf with
     /// approvers still pending), or another decision resolved the escalation
-    /// concurrently. Poll <c>IEscalationService.GetOutcomeAsync</c> for the final
-    /// verdict. Maps naturally to HTTP 202.
+    /// concurrently. Also returned as an idempotent echo when the same approver
+    /// repeats a decision with the same verdict — the first submission already
+    /// speaks for them. Poll <c>IEscalationService.GetOutcomeAsync</c> for the
+    /// final verdict. Maps naturally to HTTP 202.
     /// </summary>
     DecisionRecorded,
+
+    /// <summary>
+    /// The submitting approver already has a recorded decision on this escalation with the
+    /// <em>opposite</em> verdict; the new decision was rejected, not recorded. Changing a vote
+    /// is not supported over this surface — silently discarding the change while reporting it
+    /// recorded would be dishonest, and silently flipping it would let a replayed request alter
+    /// an audit-final decision. Maps naturally to HTTP 409.
+    /// </summary>
+    ConflictingDecision,
 
     /// <summary>
     /// This decision resolved the escalation. <see cref="EscalationDecisionResult.Outcome"/>

--- a/src/Content/Domain/Domain.AI/Escalation/EscalationOutcome.cs
+++ b/src/Content/Domain/Domain.AI/Escalation/EscalationOutcome.cs
@@ -28,4 +28,20 @@ public sealed record EscalationOutcome
     /// which authority tier received the escalated request. Null otherwise.
     /// </summary>
     public AutonomyLevel? EscalatedToTier { get; init; }
+
+    /// <summary>
+    /// The approver roster carried over from the originating request. The escalation service
+    /// populates this on every resolution so roster-private reads keep working after the pending
+    /// request is discarded: a resolved verdict is only visible to the identities that were
+    /// entitled to produce it. An empty roster means no roster is known, and roster-gated reads
+    /// deny (fail-closed).
+    /// </summary>
+    public IReadOnlyList<string> Approvers { get; init; } = [];
+
+    /// <summary>
+    /// The identity that administratively cancelled the escalation, or null when it resolved by
+    /// decision or timeout. Carried on the outcome — and therefore into the durable outcome
+    /// audit record — so a force-denial is always attributable to its actor.
+    /// </summary>
+    public string? CancelledBy { get; init; }
 }

--- a/src/Content/Domain/Domain.Common/Config/AI/Governance/EscalationConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/Governance/EscalationConfig.cs
@@ -66,7 +66,8 @@ public class EscalationConfig
     /// establish the caller's approver identity — the name compared (case-insensitively, via
     /// <c>ApproverNames.Comparer</c>) against escalation rosters. Only identity-bearing claim
     /// types are accepted: <c>oid</c>, <c>sub</c>, <c>preferred_username</c>, or <c>upn</c>
-    /// (enforced at startup by the config validator). Defaults to <c>preferred_username</c>, the
+    /// (enforced at startup by the config validator while escalation is enabled; resolution also
+    /// searches each type's JWT inbound-mapped form on the principal). Defaults to <c>preferred_username</c>, the
     /// Entra ID v2.0 sign-in name, because the harness's roster surfaces (human-gate step
     /// config, governance rules) are authored with human-readable names.
     /// </summary>

--- a/src/Content/Domain/Domain.Common/Config/AI/Governance/EscalationConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/Governance/EscalationConfig.cs
@@ -60,4 +60,31 @@ public class EscalationConfig
     /// Relative paths are resolved from the application working directory.
     /// </summary>
     public string AuditStoragePath { get; set; } = ".agent-sessions/escalations";
+
+    /// <summary>
+    /// The claim type the escalation HTTP surface reads from the authenticated principal to
+    /// establish the caller's approver identity — the name compared (case-insensitively, via
+    /// <c>ApproverNames.Comparer</c>) against escalation rosters. Only identity-bearing claim
+    /// types are accepted: <c>oid</c>, <c>sub</c>, <c>preferred_username</c>, or <c>upn</c>
+    /// (enforced at startup by the config validator). Defaults to <c>preferred_username</c>, the
+    /// Entra ID v2.0 sign-in name, because the harness's roster surfaces (human-gate step
+    /// config, governance rules) are authored with human-readable names.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This is deliberately a server-side setting, never a request parameter: the approver name
+    /// must come from the validated token, so a caller can never assert an identity the token
+    /// does not carry. A request whose principal lacks this claim — or carries it more than
+    /// once — is rejected (fail-closed) rather than falling back to another claim.
+    /// </para>
+    /// <para>
+    /// <b>Production recommendation: <c>oid</c>.</b> <c>preferred_username</c> and <c>upn</c>
+    /// are mutable and reassignable — when a departed approver's UPN is reissued to a new hire,
+    /// the new account silently inherits every roster entry naming that UPN. The immutable
+    /// object id (<c>oid</c>, or <c>sub</c> for non-Entra issuers) has no such reuse window;
+    /// author rosters with object ids and set this to <c>oid</c> for production. Hosts that keep
+    /// a mutable claim type get a startup warning naming this risk.
+    /// </para>
+    /// </remarks>
+    public string ApproverClaimType { get; set; } = "preferred_username";
 }

--- a/src/Content/Infrastructure/Infrastructure.AI/Escalation/DefaultEscalationService.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Escalation/DefaultEscalationService.cs
@@ -132,9 +132,20 @@ public sealed class DefaultEscalationService : IEscalationService, IDisposable
 		// Idempotency chokepoint: one recorded decision per approver per escalation. A repeated
 		// submission (double-click, HTTP retry, replay) must not append to the decision list or
 		// grow the audit trail — the first decision already speaks for this approver. Checked
-		// BEFORE the audit write so a repeat produces a debug line, never an audit record.
-		if (HasDecisionFrom(state, decision.ApproverName))
+		// BEFORE the audit write so a repeat produces a log line, never an audit record. A
+		// repeat with the SAME verdict echoes DecisionRecorded (idempotent); a repeat with the
+		// OPPOSITE verdict is a conflict — silently dropping a changed vote while reporting it
+		// recorded would be dishonest, and recording it would let a replay flip a final vote.
+		if (TryGetExistingDecision(state, decision.ApproverName) is { } existing)
 		{
+			if (existing.Approved != decision.Approved)
+			{
+				_logger.LogWarning(
+					"Conflicting decision from {ApproverName} for escalation {EscalationId} rejected: {New} contradicts recorded {Recorded}",
+					decision.ApproverName, escalationId, decision.Approved, existing.Approved);
+				return EscalationDecisionResult.ConflictingDecision();
+			}
+
 			_logger.LogDebug(
 				"Duplicate decision from {ApproverName} for escalation {EscalationId} ignored (already recorded)",
 				decision.ApproverName, escalationId);
@@ -161,9 +172,14 @@ public sealed class DefaultEscalationService : IEscalationService, IDisposable
 				return EscalationDecisionResult.DecisionRecorded();
 
 			// Closes the race two concurrent submissions from the same approver can win against
-			// the pre-audit duplicate check: only the first may enter the decision list.
-			if (HasDecisionFrom(state, decision.ApproverName))
-				return EscalationDecisionResult.DecisionRecorded();
+			// the pre-audit duplicate check: only the first may enter the decision list, and a
+			// contradicting verdict is a conflict here exactly as at the chokepoint above.
+			if (TryGetExistingDecision(state, decision.ApproverName) is { } raced)
+			{
+				return raced.Approved != decision.Approved
+					? EscalationDecisionResult.ConflictingDecision()
+					: EscalationDecisionResult.DecisionRecorded();
+			}
 
 			state.Decisions.Add(decision);
 			var evaluation = strategy.EvaluateDecision(state.Request, state.Decisions.AsReadOnly());
@@ -338,20 +354,15 @@ public sealed class DefaultEscalationService : IEscalationService, IDisposable
 			return;
 
 		state.TimeoutCts.Cancel();
-		_activeEscalations.TryRemove(state.Request.EscalationId, out _);
-
-		EscalationMetrics.Pending.Add(-1);
-		RecordResolutionMetrics(state, outcome);
-
-		_logger.LogInformation(
-			"Escalation {EscalationId} resolved: {ResolutionType}, approved={IsApproved}",
-			outcome.EscalationId, outcome.ResolutionType, outcome.IsApproved);
 
 		// Record the audit outcome BEFORE releasing the caller awaiting Completion.Task.
 		// The durable outcome write is fail-CLOSED: if it throws, the escalation must NOT
 		// be reported as resolved. Propagate the failure to the awaiting caller instead of
 		// delivering an approval that was never recorded for compliance. (SafeExecuteAsync
 		// is reserved for best-effort notification, never for the durable audit write.)
+		// The escalation deliberately stays in _activeEscalations on failure: it must remain
+		// observable (a resolved-but-unaudited escalation vanishing entirely would read as an
+		// unknown id to every poller) rather than dropping into a state no reader can see.
 		try
 		{
 			await _auditStore.RecordOutcomeAsync(outcome, CancellationToken.None);
@@ -367,8 +378,20 @@ public sealed class DefaultEscalationService : IEscalationService, IDisposable
 
 		// Retain the verdict ONLY after it has been durably audited, so GetOutcomeAsync — and thus
 		// the plan executor's resume reconciliation — can never act on a verdict that failed the
-		// fail-closed audit write above and was rolled back to the awaiting caller.
+		// fail-closed audit write above and was rolled back to the awaiting caller. Publish it
+		// BEFORE removing the escalation from the active set: a reader landing between the two
+		// steps sees at least one view (brief dual presence is fine — readers check the active
+		// set first and simply serve the pending view), never the spurious not-found a
+		// remove-then-publish order produced on exactly the poll the 202 contract prescribes.
 		_resolvedOutcomes[outcome.EscalationId] = outcome;
+		_activeEscalations.TryRemove(state.Request.EscalationId, out _);
+
+		EscalationMetrics.Pending.Add(-1);
+		RecordResolutionMetrics(state, outcome);
+
+		_logger.LogInformation(
+			"Escalation {EscalationId} resolved: {ResolutionType}, approved={IsApproved}",
+			outcome.EscalationId, outcome.ResolutionType, outcome.IsApproved);
 
 		await SafeExecuteAsync(
 			() => _notifier.NotifyEscalationResolvedAsync(outcome, CancellationToken.None),
@@ -464,16 +487,17 @@ public sealed class DefaultEscalationService : IEscalationService, IDisposable
 	}
 
 	/// <summary>
-	/// Whether this approver already has a recorded decision on the escalation, using
-	/// <see cref="ApproverNames.Comparer"/> so a casing-variant retry is still a duplicate.
-	/// Takes the state lock itself, so callers may invoke it lock-free; the in-lock re-check in
-	/// <see cref="SubmitDecisionAsync"/> relies on the lock being reentrant for the same thread.
+	/// Returns this approver's already-recorded decision on the escalation, or null when none
+	/// exists, using <see cref="ApproverNames.Comparer"/> so a casing-variant retry is still a
+	/// duplicate. Takes the state lock itself, so callers may invoke it lock-free; the in-lock
+	/// re-check in <see cref="SubmitDecisionAsync"/> relies on the lock being reentrant for the
+	/// same thread.
 	/// </summary>
-	private static bool HasDecisionFrom(EscalationState state, string approverName)
+	private static ApproverDecision? TryGetExistingDecision(EscalationState state, string approverName)
 	{
 		lock (state.Lock)
 		{
-			return state.Decisions.Any(d =>
+			return state.Decisions.FirstOrDefault(d =>
 				ApproverNames.Comparer.Equals(d.ApproverName, approverName));
 		}
 	}

--- a/src/Content/Infrastructure/Infrastructure.AI/Escalation/DefaultEscalationService.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Escalation/DefaultEscalationService.cs
@@ -129,6 +129,18 @@ public sealed class DefaultEscalationService : IEscalationService, IDisposable
 			return EscalationDecisionResult.ApproverNotAuthorized();
 		}
 
+		// Idempotency chokepoint: one recorded decision per approver per escalation. A repeated
+		// submission (double-click, HTTP retry, replay) must not append to the decision list or
+		// grow the audit trail — the first decision already speaks for this approver. Checked
+		// BEFORE the audit write so a repeat produces a debug line, never an audit record.
+		if (HasDecisionFrom(state, decision.ApproverName))
+		{
+			_logger.LogDebug(
+				"Duplicate decision from {ApproverName} for escalation {EscalationId} ignored (already recorded)",
+				decision.ApproverName, escalationId);
+			return EscalationDecisionResult.DecisionRecorded();
+		}
+
 		await SafeExecuteAsync(
 			() => _auditStore.RecordDecisionAsync(escalationId, decision, ct),
 			"record decision", escalationId);
@@ -146,6 +158,11 @@ public sealed class DefaultEscalationService : IEscalationService, IDisposable
 			// concurrently — this one arrives too late to participate. The caller polls
 			// GetOutcomeAsync for the verdict (see EscalationDecisionStatus.DecisionRecorded).
 			if (state.IsResolved)
+				return EscalationDecisionResult.DecisionRecorded();
+
+			// Closes the race two concurrent submissions from the same approver can win against
+			// the pre-audit duplicate check: only the first may enter the decision list.
+			if (HasDecisionFrom(state, decision.ApproverName))
 				return EscalationDecisionResult.DecisionRecorded();
 
 			state.Decisions.Add(decision);
@@ -167,7 +184,8 @@ public sealed class DefaultEscalationService : IEscalationService, IDisposable
 				ResolutionType = evaluation.IsApproved
 					? EscalationResolutionType.Approved
 					: EscalationResolutionType.Denied,
-				ResolvedAt = DateTimeOffset.UtcNow
+				ResolvedAt = DateTimeOffset.UtcNow,
+				Approvers = state.Request.Approvers
 			};
 		}
 
@@ -205,7 +223,7 @@ public sealed class DefaultEscalationService : IEscalationService, IDisposable
 
 	/// <inheritdoc />
 	public async Task<EscalationOutcome> CancelEscalationAsync(
-		Guid escalationId, string reason, CancellationToken ct)
+		Guid escalationId, string reason, string cancelledBy, CancellationToken ct)
 	{
 		if (!_activeEscalations.TryGetValue(escalationId, out var state))
 			throw new InvalidOperationException($"No pending escalation found with ID {escalationId}");
@@ -223,11 +241,17 @@ public sealed class DefaultEscalationService : IEscalationService, IDisposable
 				IsApproved = false,
 				Decisions = state.Decisions.ToList().AsReadOnly(),
 				ResolutionType = EscalationResolutionType.Denied,
-				ResolvedAt = DateTimeOffset.UtcNow
+				ResolvedAt = DateTimeOffset.UtcNow,
+				Approvers = state.Request.Approvers,
+				// Stamped on the outcome — and thereby into the durable outcome audit record —
+				// so the force-denial is attributable to its actor, not just a log line.
+				CancelledBy = cancelledBy
 			};
 		}
 
-		_logger.LogInformation("Escalation {EscalationId} cancelled: {Reason}", escalationId, reason);
+		_logger.LogInformation(
+			"Escalation {EscalationId} cancelled by {CancelledBy}: {Reason}",
+			escalationId, cancelledBy, reason);
 		await ResolveEscalationAsync(state, outcome);
 		return outcome;
 	}
@@ -391,7 +415,8 @@ public sealed class DefaultEscalationService : IEscalationService, IDisposable
 				IsApproved = state.Request.TimeoutAction == EscalationTimeoutAction.Approve,
 				Decisions = state.Decisions.ToList().AsReadOnly(),
 				ResolutionType = EscalationResolutionType.TimedOut,
-				ResolvedAt = DateTimeOffset.UtcNow
+				ResolvedAt = DateTimeOffset.UtcNow,
+				Approvers = state.Request.Approvers
 			};
 		}
 
@@ -436,6 +461,21 @@ public sealed class DefaultEscalationService : IEscalationService, IDisposable
 		EscalationMetrics.DurationMs.Record(durationMs,
 			new KeyValuePair<string, object?>(EscalationConventions.Priority,
 				ToPriorityTag(state.Request.Priority)));
+	}
+
+	/// <summary>
+	/// Whether this approver already has a recorded decision on the escalation, using
+	/// <see cref="ApproverNames.Comparer"/> so a casing-variant retry is still a duplicate.
+	/// Takes the state lock itself, so callers may invoke it lock-free; the in-lock re-check in
+	/// <see cref="SubmitDecisionAsync"/> relies on the lock being reentrant for the same thread.
+	/// </summary>
+	private static bool HasDecisionFrom(EscalationState state, string approverName)
+	{
+		lock (state.Lock)
+		{
+			return state.Decisions.Any(d =>
+				ApproverNames.Comparer.Equals(d.ApproverName, approverName));
+		}
 	}
 
 	private async Task SafeExecuteAsync(Func<Task> action, string operationName, Guid escalationId)

--- a/src/Content/Presentation/Presentation.AgentHub/Auth/DevAuthHandler.cs
+++ b/src/Content/Presentation/Presentation.AgentHub/Auth/DevAuthHandler.cs
@@ -24,9 +24,14 @@ internal sealed class DevAuthHandler(
             new Claim(ClaimTypes.NameIdentifier, "dev-user"),
             new Claim(ClaimTypes.Name, "Dev User"),
             new Claim("oid", "dev-user"),
+            // Approver identity claim read by the escalation API (EscalationConfig.ApproverClaimType
+            // default). Rosters targeting "dev-user" make the approval loop exercisable locally.
+            new Claim("preferred_username", "dev-user"),
             new Claim(ClaimTypes.Role, "AgentHub.Traces.ReadAll"),
             new Claim(ClaimTypes.Role, "AgentHub.EvalDashboard.Read"),
             new Claim(ClaimTypes.Role, "AgentHub.Foresight.Observe"),
+            new Claim(ClaimTypes.Role, Presentation.Common.Escalations.EscalationsController.DecideRole),
+            new Claim(ClaimTypes.Role, Presentation.Common.Escalations.EscalationsController.AdminRole),
         };
         var identity = new ClaimsIdentity(claims, Scheme.Name);
         var ticket = new AuthenticationTicket(new ClaimsPrincipal(identity), Scheme.Name);

--- a/src/Content/Presentation/Presentation.AgentHub/DependencyInjection.cs
+++ b/src/Content/Presentation/Presentation.AgentHub/DependencyInjection.cs
@@ -24,6 +24,7 @@ using Presentation.AgentHub.Notifications;
 using Presentation.AgentHub.Planner;
 using Presentation.AgentHub.Config;
 using Presentation.AgentHub.Telemetry;
+using Presentation.Common.Escalations;
 using Microsoft.Extensions.Options;
 
 namespace Presentation.AgentHub;
@@ -55,7 +56,10 @@ public static class DependencyInjection
                 // System.Text.Json emits numeric values and the dashboard cannot map them.
                 options.JsonSerializerOptions.Converters.Add(
                     new System.Text.Json.Serialization.JsonStringEnumConverter());
-            });
+            })
+            // Deliberate opt-in: AgentHub runs the agent workload, so the in-process escalation
+            // state lives here and the human approval API must be co-resident with it.
+            .AddEscalationApi();
 
         // Surfaces a missing/invalid AI provider configuration via /health/ai. Additive to the
         // health checks registered in Presentation.Common — Degraded (not Unhealthy) because the
@@ -191,6 +195,26 @@ public static class DependencyInjection
                         ?? context.Connection.RemoteIpAddress?.ToString()
                         ?? "unknown";
                     return RateLimitPartition.GetFixedWindowLimiter($"memory:{memoryCaller}", _ => new FixedWindowRateLimiterOptions
+                    {
+                        PermitLimit = 30,
+                        Window = TimeSpan.FromMinutes(1),
+                        QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+                        QueueLimit = 0,
+                    });
+                }
+
+                // Escalation writes (submit decision, admin cancel) mutate approval state, append
+                // durable JSONL audit records, and can release blocked agent turns; cap them per
+                // authenticated caller so a scripted or stuck client cannot hammer the approval
+                // loop or flood the audit store. Reads (pending list, detail polling after a 202)
+                // stay unthrottled, matching the memory API's write-only posture.
+                if (context.Request.Method == HttpMethods.Post &&
+                    context.Request.Path.StartsWithSegments("/api/escalations"))
+                {
+                    var escalationCaller = context.User.GetUserIdOrNull()
+                        ?? context.Connection.RemoteIpAddress?.ToString()
+                        ?? "unknown";
+                    return RateLimitPartition.GetFixedWindowLimiter($"escalation:{escalationCaller}", _ => new FixedWindowRateLimiterOptions
                     {
                         PermitLimit = 30,
                         Window = TimeSpan.FromMinutes(1),

--- a/src/Content/Presentation/Presentation.Common/Escalations/EscalationApiMarker.cs
+++ b/src/Content/Presentation/Presentation.Common/Escalations/EscalationApiMarker.cs
@@ -1,0 +1,21 @@
+namespace Presentation.Common.Escalations;
+
+/// <summary>
+/// DI marker whose presence records that a host deliberately opted into serving the escalation
+/// decision API. Registered only by
+/// <see cref="EscalationApiMvcBuilderExtensions.AddEscalationApi"/>;
+/// <see cref="RequiresEscalationApiOptInAttribute"/> checks for it at route-match time and
+/// un-matches every <see cref="EscalationsController"/> route when it is absent.
+/// </summary>
+/// <remarks>
+/// This runtime gate exists because compile-time placement cannot deliver the opt-in: the Web
+/// SDK auto-generates an <c>ApplicationPartAttribute</c> for every referenced assembly that
+/// references MVC, so any MVC host referencing <c>Presentation.Common</c> discovers this
+/// assembly's controllers whether or not it called <c>AddApplicationPart</c>. Escalation state
+/// is an in-process singleton that only specific hosts own; a host that merely composes shared
+/// services must not accidentally expose approval routes. Fail-closed: no marker, no routes
+/// (404 before authentication, indistinguishable from a host without the API).
+/// </remarks>
+public sealed class EscalationApiMarker
+{
+}

--- a/src/Content/Presentation/Presentation.Common/Escalations/EscalationApiMutableClaimStartupWarning.cs
+++ b/src/Content/Presentation/Presentation.Common/Escalations/EscalationApiMutableClaimStartupWarning.cs
@@ -1,0 +1,60 @@
+using Application.Core.Validation;
+using Domain.Common.Config.AI.Governance;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Presentation.Common.Escalations;
+
+/// <summary>
+/// Startup advisory for hosts that mounted the escalation API with a mutable approver identity
+/// claim (<c>preferred_username</c> or <c>upn</c>). Registered only by
+/// <see cref="EscalationApiMvcBuilderExtensions.AddEscalationApi"/>, so hosts that never serve
+/// the routes never warn.
+/// </summary>
+/// <remarks>
+/// The risk being named: sign-in names are reassignable. When a departed approver's UPN is
+/// reissued to a new hire, the new account silently inherits every roster entry naming that UPN
+/// — approval rights transfer without anyone granting them. The immutable object id (<c>oid</c>)
+/// has no reuse window and is the production recommendation; this stays a warning rather than a
+/// startup failure because name-form rosters are the harness's authoring default and are
+/// legitimate in environments that retire UPNs.
+/// </remarks>
+public sealed class EscalationApiMutableClaimStartupWarning : IHostedService
+{
+    private readonly IOptionsMonitor<EscalationConfig> _config;
+    private readonly ILogger<EscalationApiMutableClaimStartupWarning> _logger;
+
+    /// <summary>Initializes the advisory with its configuration and logging dependencies.</summary>
+    /// <param name="config">Escalation configuration carrying the approver claim type.</param>
+    /// <param name="logger">Logger the warning is emitted through.</param>
+    public EscalationApiMutableClaimStartupWarning(
+        IOptionsMonitor<EscalationConfig> config,
+        ILogger<EscalationApiMutableClaimStartupWarning> logger)
+    {
+        ArgumentNullException.ThrowIfNull(config);
+        ArgumentNullException.ThrowIfNull(logger);
+        _config = config;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        var claimType = _config.CurrentValue.ApproverClaimType;
+        if (EscalationConfigValidator.MutableApproverClaimTypes.Contains(claimType, StringComparer.Ordinal))
+        {
+            _logger.LogWarning(
+                "Escalation API approver identity is bound to the mutable claim '{ApproverClaimType}'. " +
+                "Sign-in names are reassignable: a departed approver's UPN reissued to a new hire silently " +
+                "inherits that approver's roster entries. For production, author rosters with object ids and " +
+                "set AppConfig:AI:Governance:Escalation:ApproverClaimType to 'oid'.",
+                claimType);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}

--- a/src/Content/Presentation/Presentation.Common/Escalations/EscalationApiMutableClaimStartupWarning.cs
+++ b/src/Content/Presentation/Presentation.Common/Escalations/EscalationApiMutableClaimStartupWarning.cs
@@ -42,7 +42,7 @@ public sealed class EscalationApiMutableClaimStartupWarning : IHostedService
     public Task StartAsync(CancellationToken cancellationToken)
     {
         var claimType = _config.CurrentValue.ApproverClaimType;
-        if (EscalationConfigValidator.MutableApproverClaimTypes.Contains(claimType, StringComparer.Ordinal))
+        if (ApproverClaimTypes.Mutable.Contains(claimType, StringComparer.Ordinal))
         {
             _logger.LogWarning(
                 "Escalation API approver identity is bound to the mutable claim '{ApproverClaimType}'. " +

--- a/src/Content/Presentation/Presentation.Common/Escalations/EscalationApiMvcBuilderExtensions.cs
+++ b/src/Content/Presentation/Presentation.Common/Escalations/EscalationApiMvcBuilderExtensions.cs
@@ -1,0 +1,45 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Presentation.Common.Escalations;
+
+/// <summary>
+/// Deliberate opt-in mount for the escalation decision API. Hosts that should serve
+/// <c>/api/escalations</c> chain <see cref="AddEscalationApi"/> onto their
+/// <c>AddControllers()</c> call; hosts that merely reference <c>Presentation.Common</c> for its
+/// shared services never expose the routes.
+/// </summary>
+public static class EscalationApiMvcBuilderExtensions
+{
+    /// <summary>
+    /// Mounts <see cref="EscalationsController"/> into the host's MVC pipeline. Two things
+    /// happen: this assembly is added as an application part (required for hosts whose build
+    /// did not auto-register it), and <see cref="EscalationApiMarker"/> is registered, which is
+    /// what actually arms the routes — <see cref="RequiresEscalationApiOptInAttribute"/> keeps
+    /// them un-matched (404) in every host without the marker, including hosts where the Web
+    /// SDK auto-discovered this assembly as an application part.
+    /// </summary>
+    /// <param name="builder">The MVC builder returned by <c>AddControllers()</c>.</param>
+    /// <returns>The builder for chaining.</returns>
+    /// <remarks>
+    /// Only mount this in a host that runs the agent workload itself: escalation state lives in
+    /// the in-process <c>DefaultEscalationService</c> singleton, so the decision endpoint must
+    /// be co-resident with the process whose agent turns are blocked on those escalations.
+    /// </remarks>
+    public static IMvcBuilder AddEscalationApi(this IMvcBuilder builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        // Idempotent: a second call must not stack duplicate hosted services or parts.
+        if (builder.Services.Any(d => d.ServiceType == typeof(EscalationApiMarker)))
+            return builder;
+
+        builder.Services.TryAddSingleton<EscalationApiMarker>();
+
+        // Advisory only in hosts that actually serve the routes: warns at startup when the
+        // approver identity claim is a mutable sign-in name (UPN-reuse risk; 'oid' recommended).
+        builder.Services.AddHostedService<EscalationApiMutableClaimStartupWarning>();
+
+        return builder.AddApplicationPart(typeof(EscalationsController).Assembly);
+    }
+}

--- a/src/Content/Presentation/Presentation.Common/Escalations/EscalationsController.cs
+++ b/src/Content/Presentation/Presentation.Common/Escalations/EscalationsController.cs
@@ -1,0 +1,317 @@
+using Application.Core.CQRS.Escalation;
+using Domain.AI.Escalation;
+using Domain.Common;
+using Domain.Common.Config.AI.Governance;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Presentation.Common.Extensions;
+
+namespace Presentation.Common.Escalations;
+
+/// <summary>
+/// REST API for answering escalations — the human side of the approval loop. Approvers list and
+/// inspect the pending escalations on their roster and submit approve/deny decisions;
+/// administrators cancel stuck escalations. A decision that resolves an escalation immediately
+/// releases the agent turn blocked on it in this process.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Opt-in mount.</b> The controller ships in <c>Presentation.Common</c> but its routes only
+/// exist in hosts that called <see cref="EscalationApiMvcBuilderExtensions.AddEscalationApi"/> —
+/// see <see cref="RequiresEscalationApiOptInAttribute"/>. Escalation state is an in-process
+/// singleton, so the API must be co-resident with the agent workload.
+/// </para>
+/// <para>
+/// <b>Identity from token, never from body.</b> The caller's approver name is stamped from the
+/// authenticated principal's claims (claim type configured by
+/// <c>EscalationConfig.ApproverClaimType</c>, allowlisted to issuer-asserted identity claims,
+/// default <c>preferred_username</c>) and compared to rosters with
+/// <c>ApproverNames.Comparer</c>. No request DTO carries an approver-name field, so a caller
+/// cannot decide as someone else. A principal lacking the configured claim — or carrying it more
+/// than once (an ambiguous identity is no identity) — is rejected with 403 (fail-closed), never
+/// mapped through a fallback claim.
+/// </para>
+/// <para>
+/// <b>Existence disclosure.</b> <c>GET /{id}</c> treats escalations as roster-private in both
+/// lifecycle states: a caller outside the roster receives the same 404 as an unknown id, pending
+/// or resolved (resolved outcomes carry the originating roster forward for exactly this check).
+/// <c>POST /{id}/decision</c> deliberately differs — the service returns its documented 403
+/// (<c>ApproverNotAuthorized</c>) for a non-roster decision on an existing escalation, which
+/// reveals existence to authenticated, role-holding callers. That is the accepted design: for
+/// the decision path the roster check <em>is</em> the authorization, and an honest 403 beats
+/// disguising an authorization failure as absence.
+/// </para>
+/// </remarks>
+[ApiController]
+[Route("api/escalations")]
+[RequiresEscalationApiOptIn]
+public sealed class EscalationsController : ControllerBase
+{
+    /// <summary>
+    /// App role required to list, read, and decide escalations. Follows the
+    /// <c>AgentHub.Traces.ReadAll</c> precedent of role-gating privileged surfaces; the
+    /// per-escalation approver roster then narrows which items a role holder can actually see
+    /// and decide.
+    /// </summary>
+    public const string DecideRole = "Harness.Approvals.Decide";
+
+    /// <summary>
+    /// App role required to administratively cancel a pending escalation. Held separately from
+    /// <see cref="DecideRole"/>: cancellation force-denies an escalation regardless of roster
+    /// membership, which is an operator power, not an approver power.
+    /// </summary>
+    public const string AdminRole = "Harness.Approvals.Admin";
+
+    private readonly IMediator _mediator;
+    private readonly IOptionsMonitor<EscalationConfig> _config;
+    private readonly ILogger<EscalationsController> _logger;
+
+    /// <summary>Initializes the controller with its dependencies.</summary>
+    /// <param name="mediator">The MediatR mediator used to dispatch escalation operations.</param>
+    /// <param name="config">Escalation configuration; supplies the approver identity claim type.</param>
+    /// <param name="logger">Logger for identity-resolution diagnostics (claim details never leave the trust boundary in responses).</param>
+    public EscalationsController(
+        IMediator mediator,
+        IOptionsMonitor<EscalationConfig> config,
+        ILogger<EscalationsController> logger)
+    {
+        ArgumentNullException.ThrowIfNull(mediator);
+        ArgumentNullException.ThrowIfNull(config);
+        ArgumentNullException.ThrowIfNull(logger);
+        _mediator = mediator;
+        _config = config;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Lists the pending escalations whose approver roster contains the caller.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The caller's pending escalations (possibly empty).</returns>
+    /// <response code="200">The caller's roster items (may contain zero results).</response>
+    /// <response code="401">Caller is not authenticated.</response>
+    /// <response code="403">Caller lacks <see cref="DecideRole"/> or has no approver identity claim.</response>
+    [HttpGet]
+    [Authorize(Roles = DecideRole)]
+    [ProducesResponseType(typeof(IReadOnlyList<EscalationSummary>), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<IActionResult> GetPending(CancellationToken cancellationToken)
+    {
+        if (ResolveApproverName() is not { } approverName)
+            return MissingApproverClaim();
+
+        var result = await _mediator.Send(
+            new GetPendingEscalationsForApproverQuery { ApproverName = approverName },
+            cancellationToken).ConfigureAwait(false);
+
+        return result.IsSuccess ? Ok(result.Value) : MapFailure(result);
+    }
+
+    /// <summary>
+    /// Reads one escalation: its pending summary while undecided (roster-private), or its
+    /// resolved outcome after a verdict — the poll target following a 202 decision response.
+    /// </summary>
+    /// <param name="id">The escalation id.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The discriminated pending/resolved detail.</returns>
+    /// <response code="200">The escalation detail (pending summary or resolved outcome).</response>
+    /// <response code="401">Caller is not authenticated.</response>
+    /// <response code="403">Caller lacks <see cref="DecideRole"/> or has no approver identity claim.</response>
+    /// <response code="404">Unknown id — or a pending escalation whose roster excludes the caller (indistinguishable by design).</response>
+    [HttpGet("{id:guid}")]
+    [Authorize(Roles = DecideRole)]
+    [ProducesResponseType(typeof(EscalationDetail), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> GetById(Guid id, CancellationToken cancellationToken)
+    {
+        if (ResolveApproverName() is not { } approverName)
+            return MissingApproverClaim();
+
+        var result = await _mediator.Send(
+            new GetEscalationQuery { EscalationId = id, ApproverName = approverName },
+            cancellationToken).ConfigureAwait(false);
+
+        return result.IsSuccess ? Ok(result.Value) : MapFailure(result);
+    }
+
+    /// <summary>
+    /// Submits the caller's approve/deny decision on a pending escalation. The approver identity
+    /// is taken from the token, never from the body.
+    /// </summary>
+    /// <param name="id">The escalation id.</param>
+    /// <param name="request">The decision: approve flag and optional reason.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The decision status, with the final outcome when this decision resolved the escalation.</returns>
+    /// <response code="200">This decision resolved the escalation; the body carries the final outcome.</response>
+    /// <response code="202">Decision recorded but the escalation is still unresolved (e.g. AllOf awaiting others); poll <c>GET /{id}</c> for the verdict.</response>
+    /// <response code="400">Invalid request (e.g. oversized reason).</response>
+    /// <response code="401">Caller is not authenticated.</response>
+    /// <response code="403">Caller lacks <see cref="DecideRole"/>, has no approver identity claim, or is not on this escalation's roster.</response>
+    /// <response code="404">No pending escalation with the given id.</response>
+    [HttpPost("{id:guid}/decision")]
+    [Authorize(Roles = DecideRole)]
+    [ProducesResponseType(typeof(EscalationDecisionResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(EscalationDecisionResponse), StatusCodes.Status202Accepted)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> SubmitDecision(
+        Guid id,
+        [FromBody] SubmitEscalationDecisionRequest request,
+        CancellationToken cancellationToken)
+    {
+        if (ResolveApproverName() is not { } approverName)
+            return MissingApproverClaim();
+
+        var result = await _mediator.Send(new SubmitEscalationDecisionCommand
+        {
+            EscalationId = id,
+            ApproverName = approverName,
+            Approve = request.Approve,
+            Reason = request.Reason
+        }, cancellationToken).ConfigureAwait(false);
+
+        if (!result.IsSuccess)
+            return MapFailure(result);
+
+        // The four decision statuses map exactly as documented on EscalationDecisionStatus:
+        // UnknownEscalation → 404, ApproverNotAuthorized → 403, DecisionRecorded → 202,
+        // Resolved → 200.
+        var value = result.Value!;
+        return value.Status switch
+        {
+            EscalationDecisionStatus.UnknownEscalation => Problem(
+                title: "Not found",
+                detail: "No pending escalation with the given id.",
+                statusCode: StatusCodes.Status404NotFound),
+            EscalationDecisionStatus.ApproverNotAuthorized => Problem(
+                title: "Forbidden",
+                detail: "The caller is not on this escalation's approver roster.",
+                statusCode: StatusCodes.Status403Forbidden),
+            EscalationDecisionStatus.DecisionRecorded =>
+                Accepted(new EscalationDecisionResponse(value.Status, null)),
+            EscalationDecisionStatus.Resolved =>
+                Ok(new EscalationDecisionResponse(value.Status, value.Outcome)),
+            _ => Problem(
+                title: "Escalation operation failed",
+                detail: "An error occurred processing the request. See server logs for details.",
+                statusCode: StatusCodes.Status500InternalServerError)
+        };
+    }
+
+    /// <summary>
+    /// Administratively cancels a pending escalation, resolving it as denied and releasing any
+    /// agent turn blocked on it.
+    /// </summary>
+    /// <param name="id">The escalation id.</param>
+    /// <param name="request">The cancellation reason (required, audited).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The denial outcome recorded for the cancellation.</returns>
+    /// <response code="200">The escalation was cancelled; the body carries the denial outcome.</response>
+    /// <response code="400">Missing or oversized reason.</response>
+    /// <response code="401">Caller is not authenticated.</response>
+    /// <response code="403">Caller lacks <see cref="AdminRole"/> or has no approver identity claim.</response>
+    /// <response code="404">No pending escalation with the given id.</response>
+    /// <response code="409">The escalation is already resolved (or resolved concurrently) and cannot be cancelled.</response>
+    [HttpPost("{id:guid}/cancel")]
+    [Authorize(Roles = AdminRole)]
+    [ProducesResponseType(typeof(EscalationOutcomeSummary), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status409Conflict)]
+    public async Task<IActionResult> Cancel(
+        Guid id,
+        [FromBody] CancelEscalationRequest request,
+        CancellationToken cancellationToken)
+    {
+        if (ResolveApproverName() is not { } cancelledBy)
+            return MissingApproverClaim();
+
+        var result = await _mediator.Send(new CancelEscalationCommand
+        {
+            EscalationId = id,
+            Reason = request.Reason,
+            CancelledBy = cancelledBy
+        }, cancellationToken).ConfigureAwait(false);
+
+        return result.IsSuccess ? Ok(result.Value) : MapFailure(result);
+    }
+
+    /// <summary>
+    /// Resolves the caller's approver identity from the configured claim type, or null when the
+    /// principal does not carry exactly one usable value. A claim that appears more than once is
+    /// an ambiguous identity and is rejected rather than silently first-picked — an attacker who
+    /// can smuggle a second instance of the claim must not get to choose which one wins.
+    /// </summary>
+    private string? ResolveApproverName()
+    {
+        var claimType = _config.CurrentValue.ApproverClaimType;
+        var values = User.FindAll(claimType)
+            .Select(c => c.Value)
+            .Where(v => !string.IsNullOrWhiteSpace(v))
+            .ToList();
+
+        if (values.Count == 1)
+            return values[0];
+
+        // Diagnostic detail (which claim type, how many values) goes to the log only; the HTTP
+        // body stays generic so the response never teaches a caller which claim to forge.
+        _logger.LogWarning(
+            "Approver identity resolution failed: configured claim '{ApproverClaimType}' present {Count} time(s) on the principal",
+            claimType, values.Count);
+        return null;
+    }
+
+    /// <summary>
+    /// Fail-closed response for an authenticated, role-holding principal without exactly one
+    /// usable approver identity claim — without it no roster comparison is possible. The detail
+    /// is deliberately generic; the configured claim type appears only in server logs.
+    /// </summary>
+    private IActionResult MissingApproverClaim() => Problem(
+        title: "Forbidden",
+        detail: "The authenticated principal does not carry a usable approver identity; no roster comparison is possible.",
+        statusCode: StatusCodes.Status403Forbidden);
+
+    private IActionResult MapFailure(Result result) =>
+        this.FailureResponse(result, "Escalation operation failed");
+}
+
+// The wire-contract records below are deliberately colocated with the controller (the
+// MemoryController precedent): they are this endpoint set's HTTP contract, not shared
+// application models, and reading them next to the actions that bind them is the point.
+
+/// <summary>Request body for <c>POST /api/escalations/{id}/decision</c>.</summary>
+/// <param name="Approve">Whether the caller approves the escalated action.</param>
+/// <param name="Reason">Optional free-text reason recorded with the decision (max 2000 characters).</param>
+/// <remarks>
+/// Deliberately carries no approver-name field: the deciding identity always comes from the
+/// authenticated token's configured claim, so it cannot be spoofed through the body.
+/// </remarks>
+public sealed record SubmitEscalationDecisionRequest(bool Approve, string? Reason = null);
+
+/// <summary>Request body for <c>POST /api/escalations/{id}/cancel</c>.</summary>
+/// <param name="Reason">Required free-text reason for the cancellation (max 2000 characters).</param>
+public sealed record CancelEscalationRequest(string Reason);
+
+/// <summary>
+/// Response body for <c>POST /api/escalations/{id}/decision</c>.
+/// </summary>
+/// <param name="Status">
+/// What happened to the decision: <c>Resolved</c> (this decision produced the final verdict) or
+/// <c>DecisionRecorded</c> (recorded, escalation still pending others). The error statuses are
+/// returned as ProblemDetails, never in this shape.
+/// </param>
+/// <param name="Outcome">The final outcome; non-null only when <paramref name="Status"/> is <c>Resolved</c>.</param>
+public sealed record EscalationDecisionResponse(
+    EscalationDecisionStatus Status,
+    EscalationOutcomeSummary? Outcome);

--- a/src/Content/Presentation/Presentation.Common/Escalations/EscalationsController.cs
+++ b/src/Content/Presentation/Presentation.Common/Escalations/EscalationsController.cs
@@ -1,4 +1,5 @@
 using Application.Core.CQRS.Escalation;
+using Application.Core.Validation;
 using Domain.AI.Escalation;
 using Domain.Common;
 using Domain.Common.Config.AI.Governance;
@@ -155,6 +156,7 @@ public sealed class EscalationsController : ControllerBase
     /// <response code="401">Caller is not authenticated.</response>
     /// <response code="403">Caller lacks <see cref="DecideRole"/>, has no approver identity claim, or is not on this escalation's roster.</response>
     /// <response code="404">No pending escalation with the given id.</response>
+    /// <response code="409">This approver already recorded the opposite verdict; votes cannot be changed. (A repeat with the same verdict echoes 202.)</response>
     [HttpPost("{id:guid}/decision")]
     [Authorize(Roles = DecideRole)]
     [ProducesResponseType(typeof(EscalationDecisionResponse), StatusCodes.Status200OK)]
@@ -163,6 +165,7 @@ public sealed class EscalationsController : ControllerBase
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status409Conflict)]
     public async Task<IActionResult> SubmitDecision(
         Guid id,
         [FromBody] SubmitEscalationDecisionRequest request,
@@ -249,16 +252,24 @@ public sealed class EscalationsController : ControllerBase
 
     /// <summary>
     /// Resolves the caller's approver identity from the configured claim type, or null when the
-    /// principal does not carry exactly one usable value. A claim that appears more than once is
-    /// an ambiguous identity and is rejected rather than silently first-picked — an attacker who
-    /// can smuggle a second instance of the claim must not get to choose which one wins.
+    /// principal does not carry exactly one usable value. Resolution searches the union of the
+    /// configured type's equivalent forms (<see cref="ApproverClaimTypes.EquivalentFormsOf"/>):
+    /// production tokens carry the JWT inbound-MAPPED form (e.g. <c>oid</c> arrives as the
+    /// objectidentifier URI), dev/test principals the short form — searching only one of them
+    /// would 403 every legitimate approver on the other auth path. Across that union, more than
+    /// one distinct value (per <c>ApproverNames.Comparer</c>) is an ambiguous identity and is
+    /// rejected rather than silently first-picked — an attacker who can smuggle a second
+    /// instance of the claim must not get to choose which one wins; the same value appearing
+    /// under both forms counts as one.
     /// </summary>
     private string? ResolveApproverName()
     {
         var claimType = _config.CurrentValue.ApproverClaimType;
-        var values = User.FindAll(claimType)
+        var values = ApproverClaimTypes.EquivalentFormsOf(claimType)
+            .SelectMany(form => User.FindAll(form))
             .Select(c => c.Value)
             .Where(v => !string.IsNullOrWhiteSpace(v))
+            .Distinct(ApproverNames.Comparer)
             .ToList();
 
         if (values.Count == 1)
@@ -267,7 +278,7 @@ public sealed class EscalationsController : ControllerBase
         // Diagnostic detail (which claim type, how many values) goes to the log only; the HTTP
         // body stays generic so the response never teaches a caller which claim to forge.
         _logger.LogWarning(
-            "Approver identity resolution failed: configured claim '{ApproverClaimType}' present {Count} time(s) on the principal",
+            "Approver identity resolution failed: configured claim '{ApproverClaimType}' (incl. mapped forms) yielded {Count} distinct value(s) on the principal",
             claimType, values.Count);
         return null;
     }

--- a/src/Content/Presentation/Presentation.Common/Escalations/RequiresEscalationApiOptInAttribute.cs
+++ b/src/Content/Presentation/Presentation.Common/Escalations/RequiresEscalationApiOptInAttribute.cs
@@ -1,0 +1,33 @@
+using Microsoft.AspNetCore.Mvc.ActionConstraints;
+
+namespace Presentation.Common.Escalations;
+
+/// <summary>
+/// Action constraint that removes the decorated controller's routes from route matching unless
+/// the host registered <see cref="EscalationApiMarker"/> via
+/// <see cref="EscalationApiMvcBuilderExtensions.AddEscalationApi"/>.
+/// </summary>
+/// <remarks>
+/// An action constraint (rather than a filter) is deliberate: constraints run during endpoint
+/// <em>selection</em>, before the authentication and authorization middleware. A non-opted host
+/// therefore answers escalation paths with a plain 404 — never a 401 challenge that would reveal
+/// the routes exist. Filters would run after auth and could not provide that.
+/// </remarks>
+[AttributeUsage(AttributeTargets.Class)]
+public sealed class RequiresEscalationApiOptInAttribute : Attribute, IActionConstraint
+{
+    /// <inheritdoc />
+    public int Order => 0;
+
+    /// <summary>
+    /// Accepts the candidate action only when the host opted into the escalation API.
+    /// </summary>
+    /// <param name="context">The constraint context supplied by routing.</param>
+    /// <returns><see langword="true"/> when <see cref="EscalationApiMarker"/> is registered.</returns>
+    public bool Accept(ActionConstraintContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        return context.RouteContext.HttpContext.RequestServices
+            .GetService(typeof(EscalationApiMarker)) is not null;
+    }
+}

--- a/src/Content/Presentation/Presentation.ConsoleUI/Examples/EscalationApprovalsExample.cs
+++ b/src/Content/Presentation/Presentation.ConsoleUI/Examples/EscalationApprovalsExample.cs
@@ -199,6 +199,7 @@ public class EscalationApprovalsExample
         var cancelOutcome = await _escalationService.CancelEscalationAsync(
             escalationId,
             "Feature release postponed, cancelling approval request",
+            "console-example-operator",
             cancellationToken);
 
         DisplayOutcome("Cancellation Outcome", cancelOutcome);

--- a/src/Content/Tests/Application.Core.Tests/CQRS/Escalation/CancelEscalationCommandHandlerTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/CQRS/Escalation/CancelEscalationCommandHandlerTests.cs
@@ -107,6 +107,30 @@ public sealed class CancelEscalationCommandHandlerTests
     }
 
     [Fact]
+    public async Task Handle_RaceWithNoRetainedOutcome_ReturnsFailureNotConflict()
+    {
+        // If the cancel path throws but NO outcome was retained, the resolution's fail-closed
+        // audit write did not complete — the escalation was force-resolved with no durable
+        // record. That is a genuine failure (500-shaped), never a benign 409 "lost race".
+        var request = EscalationTestData.NewRequest();
+        var id = request.EscalationId;
+        _service.Setup(s => s.GetPendingEscalationAsync(id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(request);
+        _service.Setup(s => s.CancelEscalationAsync(id, It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("audit store rejected the outcome write"));
+        _service.Setup(s => s.GetOutcomeAsync(id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Domain.AI.Escalation.EscalationOutcome?)null);
+
+        var result = await _handler.Handle(NewCommand(id), CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.FailureType.Should().Be(ResultFailureType.General,
+            "an unaudited force-resolution must map to 500, not 409");
+        result.Errors.Should().NotContain(e => e.Contains("audit store"),
+            "internal exception text must not surface in the result");
+    }
+
+    [Fact]
     public async Task Handle_OwnCancellationWinsRace_ReturnsSuccessNotConflict()
     {
         // A duplicated/retried cancel whose first attempt already won must not misreport 409:

--- a/src/Content/Tests/Application.Core.Tests/CQRS/Escalation/CancelEscalationCommandHandlerTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/CQRS/Escalation/CancelEscalationCommandHandlerTests.cs
@@ -1,0 +1,139 @@
+using Application.AI.Common.Interfaces.Escalation;
+using Application.Core.CQRS.Escalation;
+using Domain.AI.Escalation;
+using Domain.Common;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Application.Core.Tests.CQRS.Escalation;
+
+/// <summary>
+/// Tests for <see cref="CancelEscalationCommandHandler"/> — the handler translates the service's
+/// exception-based contract into mappable failures: unknown → NotFound (404), already resolved →
+/// Conflict (409), and a lost resolution race → Conflict rather than a 500.
+/// </summary>
+public sealed class CancelEscalationCommandHandlerTests
+{
+    private readonly Mock<IEscalationService> _service = new();
+    private readonly CancelEscalationCommandHandler _handler;
+
+    public CancelEscalationCommandHandlerTests()
+    {
+        _handler = new CancelEscalationCommandHandler(
+            _service.Object, NullLogger<CancelEscalationCommandHandler>.Instance);
+    }
+
+    [Fact]
+    public async Task Handle_PendingEscalation_CancelsAndReturnsDenialOutcome()
+    {
+        var request = EscalationTestData.NewRequest();
+        var id = request.EscalationId;
+        _service.Setup(s => s.GetPendingEscalationAsync(id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(request);
+        _service.Setup(s => s.CancelEscalationAsync(id, "superseded", "admin@contoso.com", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(EscalationTestData.NewOutcome(id, approved: false));
+
+        var result = await _handler.Handle(new CancelEscalationCommand
+        {
+            EscalationId = id,
+            Reason = "superseded",
+            CancelledBy = "admin@contoso.com"
+        }, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.IsApproved.Should().BeFalse("cancellation resolves the escalation as denied");
+        _service.Verify(
+            s => s.CancelEscalationAsync(id, "superseded", "admin@contoso.com", It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_UnknownEscalation_ReturnsNotFound()
+    {
+        var id = Guid.NewGuid();
+        _service.Setup(s => s.GetPendingEscalationAsync(id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((EscalationRequest?)null);
+        _service.Setup(s => s.GetOutcomeAsync(id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((EscalationOutcome?)null);
+
+        var result = await _handler.Handle(NewCommand(id), CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.FailureType.Should().Be(ResultFailureType.NotFound);
+        _service.Verify(
+            s => s.CancelEscalationAsync(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_AlreadyResolvedEscalation_ReturnsConflict()
+    {
+        var id = Guid.NewGuid();
+        _service.Setup(s => s.GetPendingEscalationAsync(id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((EscalationRequest?)null);
+        _service.Setup(s => s.GetOutcomeAsync(id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(EscalationTestData.NewOutcome(id));
+
+        var result = await _handler.Handle(NewCommand(id), CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.FailureType.Should().Be(ResultFailureType.Conflict);
+        _service.Verify(
+            s => s.CancelEscalationAsync(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_DecisionWinsRaceDuringCancel_ReturnsConflictNot500()
+    {
+        // The service throws InvalidOperationException when a decision or timeout wins the race
+        // between the pending pre-check and the cancel call; that is an expected concurrency
+        // outcome and must surface as 409, never as an unclassified 500.
+        var request = EscalationTestData.NewRequest();
+        var id = request.EscalationId;
+        _service.Setup(s => s.GetPendingEscalationAsync(id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(request);
+        _service.Setup(s => s.CancelEscalationAsync(id, It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException($"Escalation {id} is already resolved"));
+        _service.Setup(s => s.GetOutcomeAsync(id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(EscalationTestData.NewOutcome(id, approved: true));
+
+        var result = await _handler.Handle(NewCommand(id), CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse("an approval outcome is not this caller's cancellation");
+        result.FailureType.Should().Be(ResultFailureType.Conflict);
+    }
+
+    [Fact]
+    public async Task Handle_OwnCancellationWinsRace_ReturnsSuccessNotConflict()
+    {
+        // A duplicated/retried cancel whose first attempt already won must not misreport 409:
+        // the recorded outcome IS this caller's own denial, so the desired end state holds.
+        var request = EscalationTestData.NewRequest();
+        var id = request.EscalationId;
+        var ownCancellation = EscalationTestData.NewOutcome(id, approved: false) with
+        {
+            CancelledBy = "Admin@Contoso.COM" // casing differs from the command's actor
+        };
+        _service.Setup(s => s.GetPendingEscalationAsync(id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(request);
+        _service.Setup(s => s.CancelEscalationAsync(id, It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException($"Escalation {id} is already resolved"));
+        _service.Setup(s => s.GetOutcomeAsync(id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ownCancellation);
+
+        var result = await _handler.Handle(NewCommand(id), CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue("the caller's own earlier cancellation already produced the desired end state");
+        result.Value!.IsApproved.Should().BeFalse();
+    }
+
+    private static CancelEscalationCommand NewCommand(Guid id) => new()
+    {
+        EscalationId = id,
+        Reason = "superseded",
+        CancelledBy = "admin@contoso.com"
+    };
+}

--- a/src/Content/Tests/Application.Core.Tests/CQRS/Escalation/EscalationCqrsValidationTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/CQRS/Escalation/EscalationCqrsValidationTests.cs
@@ -1,0 +1,161 @@
+using Application.Core.CQRS.Escalation;
+using FluentAssertions;
+using Xunit;
+
+namespace Application.Core.Tests.CQRS.Escalation;
+
+/// <summary>
+/// Validator tests for the escalation CQRS surface. The approver-name rules are the
+/// defense-in-depth backstop behind the controller's fail-closed claim resolution; the reason
+/// bounds keep the JSONL audit records sane.
+/// </summary>
+public sealed class EscalationCqrsValidationTests
+{
+    private static readonly string LongName = new('a', EscalationValidationRules.MaxApproverNameLength + 1);
+    private static readonly string LongReason = new('r', EscalationValidationRules.MaxReasonLength + 1);
+
+    // --- GetPendingEscalationsForApproverQuery ---
+
+    [Fact]
+    public void PendingListValidator_ValidQuery_Passes()
+    {
+        var result = new GetPendingEscalationsForApproverQueryValidator().Validate(
+            new GetPendingEscalationsForApproverQuery { ApproverName = "alice@contoso.com" });
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    public void PendingListValidator_MissingApproverName_Fails(string name)
+    {
+        var result = new GetPendingEscalationsForApproverQueryValidator().Validate(
+            new GetPendingEscalationsForApproverQuery { ApproverName = name });
+
+        result.IsValid.Should().BeFalse();
+    }
+
+    [Fact]
+    public void PendingListValidator_OversizedApproverName_Fails()
+    {
+        var result = new GetPendingEscalationsForApproverQueryValidator().Validate(
+            new GetPendingEscalationsForApproverQuery { ApproverName = LongName });
+
+        result.IsValid.Should().BeFalse();
+    }
+
+    // --- GetEscalationQuery ---
+
+    [Fact]
+    public void GetValidator_ValidQuery_Passes()
+    {
+        var result = new GetEscalationQueryValidator().Validate(new GetEscalationQuery
+        {
+            EscalationId = Guid.NewGuid(),
+            ApproverName = "alice@contoso.com"
+        });
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void GetValidator_EmptyId_Fails()
+    {
+        var result = new GetEscalationQueryValidator().Validate(new GetEscalationQuery
+        {
+            EscalationId = Guid.Empty,
+            ApproverName = "alice@contoso.com"
+        });
+
+        result.IsValid.Should().BeFalse();
+    }
+
+    // --- SubmitEscalationDecisionCommand ---
+
+    [Fact]
+    public void DecisionValidator_ValidCommand_Passes()
+    {
+        var result = new SubmitEscalationDecisionCommandValidator().Validate(
+            new SubmitEscalationDecisionCommand
+            {
+                EscalationId = Guid.NewGuid(),
+                ApproverName = "alice@contoso.com",
+                Approve = true,
+                Reason = null
+            });
+
+        result.IsValid.Should().BeTrue("the reason is optional on decisions");
+    }
+
+    [Fact]
+    public void DecisionValidator_EmptyApproverName_Fails()
+    {
+        var result = new SubmitEscalationDecisionCommandValidator().Validate(
+            new SubmitEscalationDecisionCommand
+            {
+                EscalationId = Guid.NewGuid(),
+                ApproverName = string.Empty,
+                Approve = true
+            });
+
+        result.IsValid.Should().BeFalse();
+    }
+
+    [Fact]
+    public void DecisionValidator_OversizedReason_Fails()
+    {
+        var result = new SubmitEscalationDecisionCommandValidator().Validate(
+            new SubmitEscalationDecisionCommand
+            {
+                EscalationId = Guid.NewGuid(),
+                ApproverName = "alice@contoso.com",
+                Approve = false,
+                Reason = LongReason
+            });
+
+        result.IsValid.Should().BeFalse();
+    }
+
+    // --- CancelEscalationCommand ---
+
+    [Fact]
+    public void CancelValidator_ValidCommand_Passes()
+    {
+        var result = new CancelEscalationCommandValidator().Validate(new CancelEscalationCommand
+        {
+            EscalationId = Guid.NewGuid(),
+            Reason = "superseded by new plan",
+            CancelledBy = "admin@contoso.com"
+        });
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void CancelValidator_EmptyReason_Fails()
+    {
+        // Cancellations are administrative force-denials; an unexplained one is not auditable.
+        var result = new CancelEscalationCommandValidator().Validate(new CancelEscalationCommand
+        {
+            EscalationId = Guid.NewGuid(),
+            Reason = string.Empty,
+            CancelledBy = "admin@contoso.com"
+        });
+
+        result.IsValid.Should().BeFalse();
+    }
+
+    [Fact]
+    public void CancelValidator_EmptyCancelledBy_Fails()
+    {
+        var result = new CancelEscalationCommandValidator().Validate(new CancelEscalationCommand
+        {
+            EscalationId = Guid.NewGuid(),
+            Reason = "superseded",
+            CancelledBy = string.Empty
+        });
+
+        result.IsValid.Should().BeFalse();
+    }
+}

--- a/src/Content/Tests/Application.Core.Tests/CQRS/Escalation/EscalationTestData.cs
+++ b/src/Content/Tests/Application.Core.Tests/CQRS/Escalation/EscalationTestData.cs
@@ -1,0 +1,49 @@
+using Domain.AI.Escalation;
+
+namespace Application.Core.Tests.CQRS.Escalation;
+
+/// <summary>
+/// Shared fixture factories for the escalation CQRS test suite: a well-formed pending request
+/// and a resolved outcome, with overridable identity fields.
+/// </summary>
+internal static class EscalationTestData
+{
+    /// <summary>Creates a pending escalation request with the given roster.</summary>
+    public static EscalationRequest NewRequest(Guid? id = null, params string[] approvers) => new()
+    {
+        EscalationId = id ?? Guid.NewGuid(),
+        AgentId = "agent-1",
+        ToolName = "file_system",
+        Arguments = new Dictionary<string, string> { ["path"] = "/etc/hosts" },
+        Description = "Agent wants to write outside the workspace",
+        RiskLevel = RiskLevel.High,
+        Priority = EscalationPriority.Blocking,
+        ApprovalStrategy = ApprovalStrategyType.AnyOf,
+        Approvers = approvers.Length > 0 ? approvers : ["alice@contoso.com"],
+        RequestedAt = DateTimeOffset.UtcNow
+    };
+
+    /// <summary>
+    /// Creates a resolved outcome correlated to the given escalation id. Carries the roster
+    /// (as the service does on every resolution) so roster-gated resolved reads pass for
+    /// <c>alice@contoso.com</c>; override <paramref name="approvers"/> to test denial paths.
+    /// </summary>
+    public static EscalationOutcome NewOutcome(Guid id, bool approved = true, params string[] approvers) => new()
+    {
+        EscalationId = id,
+        IsApproved = approved,
+        Approvers = approvers.Length > 0 ? approvers : ["alice@contoso.com"],
+        Decisions =
+        [
+            new ApproverDecision
+            {
+                ApproverName = "alice@contoso.com",
+                Approved = approved,
+                Reason = approved ? "looks safe" : "too risky",
+                RespondedAt = DateTimeOffset.UtcNow
+            }
+        ],
+        ResolutionType = approved ? EscalationResolutionType.Approved : EscalationResolutionType.Denied,
+        ResolvedAt = DateTimeOffset.UtcNow
+    };
+}

--- a/src/Content/Tests/Application.Core.Tests/CQRS/Escalation/GetEscalationQueryHandlerTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/CQRS/Escalation/GetEscalationQueryHandlerTests.cs
@@ -1,0 +1,145 @@
+using Application.AI.Common.Interfaces.Escalation;
+using Application.Core.CQRS.Escalation;
+using Domain.AI.Escalation;
+using Domain.Common;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Application.Core.Tests.CQRS.Escalation;
+
+/// <summary>
+/// Tests for <see cref="GetEscalationQueryHandler"/> — pending reads are roster-private (a
+/// non-roster caller gets the same NotFound as an unknown id), roster matching is
+/// case-insensitive, and resolved reads surface the outcome for polling after a 202.
+/// </summary>
+public sealed class GetEscalationQueryHandlerTests
+{
+    private readonly Mock<IEscalationService> _service = new();
+    private readonly GetEscalationQueryHandler _handler;
+
+    public GetEscalationQueryHandlerTests()
+    {
+        _handler = new GetEscalationQueryHandler(
+            _service.Object, NullLogger<GetEscalationQueryHandler>.Instance);
+    }
+
+    [Fact]
+    public async Task Handle_PendingAndCallerOnRoster_ReturnsPendingDetail()
+    {
+        var request = EscalationTestData.NewRequest(approvers: ["alice@contoso.com"]);
+        _service.Setup(s => s.GetPendingEscalationAsync(request.EscalationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(request);
+
+        var result = await _handler.Handle(new GetEscalationQuery
+        {
+            EscalationId = request.EscalationId,
+            ApproverName = "alice@contoso.com"
+        }, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.Status.Should().Be(EscalationReadStatus.Pending);
+        result.Value.Pending!.EscalationId.Should().Be(request.EscalationId);
+        result.Value.Outcome.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Handle_PendingRosterMatch_IsCaseInsensitive()
+    {
+        // ApproverNames.Comparer is the single roster-comparison authority; a caller whose
+        // token casing differs from the roster entry must still see the escalation.
+        var request = EscalationTestData.NewRequest(approvers: ["Alice@Contoso.com"]);
+        _service.Setup(s => s.GetPendingEscalationAsync(request.EscalationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(request);
+
+        var result = await _handler.Handle(new GetEscalationQuery
+        {
+            EscalationId = request.EscalationId,
+            ApproverName = "alice@contoso.com"
+        }, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.Status.Should().Be(EscalationReadStatus.Pending);
+    }
+
+    [Fact]
+    public async Task Handle_PendingButCallerNotOnRoster_ReturnsNotFound()
+    {
+        // Roster privacy: existence of a pending escalation must not be observable outside its
+        // roster, so the failure is NotFound — indistinguishable from an unknown id.
+        var request = EscalationTestData.NewRequest(approvers: ["alice@contoso.com"]);
+        _service.Setup(s => s.GetPendingEscalationAsync(request.EscalationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(request);
+
+        var result = await _handler.Handle(new GetEscalationQuery
+        {
+            EscalationId = request.EscalationId,
+            ApproverName = "mallory@contoso.com"
+        }, CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.FailureType.Should().Be(ResultFailureType.NotFound);
+    }
+
+    [Fact]
+    public async Task Handle_ResolvedAndCallerOnOutcomeRoster_ReturnsOutcomeDetail()
+    {
+        var id = Guid.NewGuid();
+        _service.Setup(s => s.GetPendingEscalationAsync(id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((EscalationRequest?)null);
+        _service.Setup(s => s.GetOutcomeAsync(id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(EscalationTestData.NewOutcome(id, approved: true, "Alice@Contoso.com"));
+
+        var result = await _handler.Handle(new GetEscalationQuery
+        {
+            EscalationId = id,
+            ApproverName = "alice@contoso.com"
+        }, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue("the outcome roster match is case-insensitive like every roster check");
+        result.Value!.Status.Should().Be(EscalationReadStatus.Resolved);
+        result.Value.Outcome!.IsApproved.Should().BeTrue();
+        result.Value.Pending.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Handle_ResolvedButCallerNotOnOutcomeRoster_ReturnsNotFound()
+    {
+        // Roster privacy survives resolution: a verdict is only readable by the identities that
+        // were entitled to produce it, and outsiders get the unknown-id NotFound.
+        var id = Guid.NewGuid();
+        _service.Setup(s => s.GetPendingEscalationAsync(id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((EscalationRequest?)null);
+        _service.Setup(s => s.GetOutcomeAsync(id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(EscalationTestData.NewOutcome(id, approved: true, "alice@contoso.com"));
+
+        var result = await _handler.Handle(new GetEscalationQuery
+        {
+            EscalationId = id,
+            ApproverName = "mallory@contoso.com"
+        }, CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.FailureType.Should().Be(ResultFailureType.NotFound);
+    }
+
+    [Fact]
+    public async Task Handle_UnknownId_ReturnsNotFound()
+    {
+        var id = Guid.NewGuid();
+        _service.Setup(s => s.GetPendingEscalationAsync(id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((EscalationRequest?)null);
+        _service.Setup(s => s.GetOutcomeAsync(id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((EscalationOutcome?)null);
+
+        var result = await _handler.Handle(new GetEscalationQuery
+        {
+            EscalationId = id,
+            ApproverName = "alice@contoso.com"
+        }, CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.FailureType.Should().Be(ResultFailureType.NotFound);
+    }
+}

--- a/src/Content/Tests/Application.Core.Tests/CQRS/Escalation/GetPendingEscalationsForApproverQueryHandlerTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/CQRS/Escalation/GetPendingEscalationsForApproverQueryHandlerTests.cs
@@ -1,0 +1,76 @@
+using Application.AI.Common.Interfaces.Escalation;
+using Application.Core.CQRS.Escalation;
+using Domain.AI.Escalation;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Application.Core.Tests.CQRS.Escalation;
+
+/// <summary>
+/// Tests for <see cref="GetPendingEscalationsForApproverQueryHandler"/> — the handler delegates
+/// the roster filter to the service and projects results to the wire-safe summary, dropping the
+/// internal originating governance decision.
+/// </summary>
+public sealed class GetPendingEscalationsForApproverQueryHandlerTests
+{
+    private readonly Mock<IEscalationService> _service = new();
+    private readonly GetPendingEscalationsForApproverQueryHandler _handler;
+
+    public GetPendingEscalationsForApproverQueryHandlerTests()
+    {
+        _handler = new GetPendingEscalationsForApproverQueryHandler(
+            _service.Object, NullLogger<GetPendingEscalationsForApproverQueryHandler>.Instance);
+    }
+
+    [Fact]
+    public async Task Handle_PendingItems_ProjectsToSummaries()
+    {
+        var request = EscalationTestData.NewRequest(approvers: ["alice@contoso.com", "bob@contoso.com"]);
+        _service.Setup(s => s.GetPendingEscalationsAsync("alice@contoso.com", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([request]);
+
+        var result = await _handler.Handle(
+            new GetPendingEscalationsForApproverQuery { ApproverName = "alice@contoso.com" },
+            CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().HaveCount(1);
+        var summary = result.Value![0];
+        summary.EscalationId.Should().Be(request.EscalationId);
+        summary.ToolName.Should().Be("file_system");
+        summary.Approvers.Should().BeEquivalentTo("alice@contoso.com", "bob@contoso.com");
+    }
+
+    [Fact]
+    public async Task Handle_PassesApproverNameToServiceVerbatim()
+    {
+        // The service owns roster matching (ApproverNames.Comparer); the handler must not
+        // normalize or rewrite the identity on the way through.
+        _service.Setup(s => s.GetPendingEscalationsAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+
+        await _handler.Handle(
+            new GetPendingEscalationsForApproverQuery { ApproverName = "Alice@Contoso.COM" },
+            CancellationToken.None);
+
+        _service.Verify(
+            s => s.GetPendingEscalationsAsync("Alice@Contoso.COM", It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_NoPendingItems_ReturnsEmptySuccess()
+    {
+        _service.Setup(s => s.GetPendingEscalationsAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+
+        var result = await _handler.Handle(
+            new GetPendingEscalationsForApproverQuery { ApproverName = "nobody@contoso.com" },
+            CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeEmpty();
+    }
+}

--- a/src/Content/Tests/Application.Core.Tests/CQRS/Escalation/SubmitEscalationDecisionCommandHandlerTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/CQRS/Escalation/SubmitEscalationDecisionCommandHandlerTests.cs
@@ -92,6 +92,21 @@ public sealed class SubmitEscalationDecisionCommandHandlerTests
     }
 
     [Fact]
+    public async Task Handle_ConflictingDecision_ReturnsConflictFailure()
+    {
+        // A changed vote (same approver, opposite verdict) is the one status that IS a request
+        // failure: it must surface as ResultFailureType.Conflict so the shared mapper emits 409,
+        // never as a 202 that pretends the change was recorded.
+        _service.Setup(s => s.SubmitDecisionAsync(It.IsAny<Guid>(), It.IsAny<ApproverDecision>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(EscalationDecisionResult.ConflictingDecision());
+
+        var result = await _handler.Handle(NewCommand(), CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.FailureType.Should().Be(Domain.Common.ResultFailureType.Conflict);
+    }
+
+    [Fact]
     public async Task Handle_Resolved_ReturnsSuccessCarryingProjectedOutcome()
     {
         var id = Guid.NewGuid();

--- a/src/Content/Tests/Application.Core.Tests/CQRS/Escalation/SubmitEscalationDecisionCommandHandlerTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/CQRS/Escalation/SubmitEscalationDecisionCommandHandlerTests.cs
@@ -1,0 +1,119 @@
+using Application.AI.Common.Interfaces.Escalation;
+using Application.Core.CQRS.Escalation;
+using Domain.AI.Escalation;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Application.Core.Tests.CQRS.Escalation;
+
+/// <summary>
+/// Tests for <see cref="SubmitEscalationDecisionCommandHandler"/> — the handler builds the
+/// domain decision faithfully (identity, verdict, reason, server-stamped timestamp) and passes
+/// every one of the four discriminated service statuses through as reportable data, never as a
+/// failure.
+/// </summary>
+public sealed class SubmitEscalationDecisionCommandHandlerTests
+{
+    private readonly Mock<IEscalationService> _service = new();
+    private readonly SubmitEscalationDecisionCommandHandler _handler;
+
+    public SubmitEscalationDecisionCommandHandlerTests()
+    {
+        _handler = new SubmitEscalationDecisionCommandHandler(
+            _service.Object, NullLogger<SubmitEscalationDecisionCommandHandler>.Instance);
+    }
+
+    [Fact]
+    public async Task Handle_BuildsDecisionFromCommandAndStampsRespondedAt()
+    {
+        var id = Guid.NewGuid();
+        ApproverDecision? captured = null;
+        _service.Setup(s => s.SubmitDecisionAsync(id, It.IsAny<ApproverDecision>(), It.IsAny<CancellationToken>()))
+            .Callback<Guid, ApproverDecision, CancellationToken>((_, d, _) => captured = d)
+            .ReturnsAsync(EscalationDecisionResult.DecisionRecorded());
+
+        var before = DateTimeOffset.UtcNow;
+        await _handler.Handle(new SubmitEscalationDecisionCommand
+        {
+            EscalationId = id,
+            ApproverName = "alice@contoso.com",
+            Approve = false,
+            Reason = "touches production config"
+        }, CancellationToken.None);
+        var after = DateTimeOffset.UtcNow;
+
+        captured.Should().NotBeNull();
+        captured!.ApproverName.Should().Be("alice@contoso.com");
+        captured.Approved.Should().BeFalse();
+        captured.Reason.Should().Be("touches production config");
+        captured.RespondedAt.Should().BeOnOrAfter(before).And.BeOnOrBefore(after,
+            "the response time must be stamped server-side, never caller-supplied");
+    }
+
+    [Fact]
+    public async Task Handle_UnknownEscalation_ReturnsSuccessCarryingUnknownStatus()
+    {
+        _service.Setup(s => s.SubmitDecisionAsync(It.IsAny<Guid>(), It.IsAny<ApproverDecision>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(EscalationDecisionResult.UnknownEscalation());
+
+        var result = await _handler.Handle(NewCommand(), CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue("the discriminated status is data for the transport to map, not a handler failure");
+        result.Value!.Status.Should().Be(EscalationDecisionStatus.UnknownEscalation);
+        result.Value.Outcome.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Handle_ApproverNotAuthorized_ReturnsSuccessCarryingNotAuthorizedStatus()
+    {
+        _service.Setup(s => s.SubmitDecisionAsync(It.IsAny<Guid>(), It.IsAny<ApproverDecision>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(EscalationDecisionResult.ApproverNotAuthorized());
+
+        var result = await _handler.Handle(NewCommand(), CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.Status.Should().Be(EscalationDecisionStatus.ApproverNotAuthorized);
+        result.Value.Outcome.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Handle_DecisionRecorded_ReturnsSuccessCarryingRecordedStatus()
+    {
+        _service.Setup(s => s.SubmitDecisionAsync(It.IsAny<Guid>(), It.IsAny<ApproverDecision>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(EscalationDecisionResult.DecisionRecorded());
+
+        var result = await _handler.Handle(NewCommand(), CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.Status.Should().Be(EscalationDecisionStatus.DecisionRecorded);
+        result.Value.Outcome.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Handle_Resolved_ReturnsSuccessCarryingProjectedOutcome()
+    {
+        var id = Guid.NewGuid();
+        var outcome = EscalationTestData.NewOutcome(id, approved: true);
+        _service.Setup(s => s.SubmitDecisionAsync(id, It.IsAny<ApproverDecision>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(EscalationDecisionResult.Resolved(outcome));
+
+        var result = await _handler.Handle(NewCommand(id), CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.Status.Should().Be(EscalationDecisionStatus.Resolved);
+        result.Value.Outcome.Should().NotBeNull();
+        result.Value.Outcome!.EscalationId.Should().Be(id);
+        result.Value.Outcome.IsApproved.Should().BeTrue();
+        result.Value.Outcome.Decisions.Should().HaveCount(1);
+    }
+
+    private static SubmitEscalationDecisionCommand NewCommand(Guid? id = null) => new()
+    {
+        EscalationId = id ?? Guid.NewGuid(),
+        ApproverName = "alice@contoso.com",
+        Approve = true,
+        Reason = null
+    };
+}

--- a/src/Content/Tests/Application.Core.Tests/Validation/EscalationConfigValidatorTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/Validation/EscalationConfigValidatorTests.cs
@@ -24,6 +24,41 @@ public class EscalationConfigValidatorTests
         result.Errors.Should().BeEmpty();
     }
 
+    [Theory]
+    [InlineData("oid")]
+    [InlineData("sub")]
+    [InlineData("preferred_username")]
+    [InlineData("upn")]
+    public async Task Validate_AllowlistedApproverClaimType_NoErrors(string claimType)
+    {
+        var config = CreateValidConfig();
+        config.ApproverClaimType = claimType;
+
+        var result = await _validator.ValidateAsync(config);
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("")]                       // empty is not an identity claim
+    [InlineData("   ")]                    // whitespace neither
+    [InlineData("name")]                   // user-editable display name
+    [InlineData("email")]                  // unverified, user-editable
+    [InlineData("Preferred_Username")]     // allowlist is exact-match: claim types are case-sensitive
+    public async Task Validate_NonAllowlistedApproverClaimType_HasError(string claimType)
+    {
+        // Roster authorization may only ever be driven by issuer-asserted identity claims; a
+        // claim a user can self-edit (display name, unverified email) must fail at startup, not
+        // silently become the approval identity.
+        var config = CreateValidConfig();
+        config.ApproverClaimType = claimType;
+
+        var result = await _validator.ValidateAsync(config);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == "ApproverClaimType");
+    }
+
     [Fact]
     public async Task Validate_NegativeTimeout_HasError()
     {

--- a/src/Content/Tests/Application.Core.Tests/Validation/EscalationConfigValidatorTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/Validation/EscalationConfigValidatorTests.cs
@@ -60,6 +60,21 @@ public class EscalationConfigValidatorTests
     }
 
     [Fact]
+    public async Task Validate_NonAllowlistedClaimTypeWhileDisabled_NoErrors()
+    {
+        // These validators impose no constraints while the feature is off (documented posture):
+        // a host with escalation disabled must keep booting regardless of the claim type value.
+        var config = CreateValidConfig();
+        config.Enabled = false;
+        config.PriorityLevels.Clear();
+        config.ApproverClaimType = "email";
+
+        var result = await _validator.ValidateAsync(config);
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
     public async Task Validate_NegativeTimeout_HasError()
     {
         var config = CreateValidConfig();

--- a/src/Content/Tests/Infrastructure.AI.Tests/Changes/ChangeProposalStartupValidatorTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Changes/ChangeProposalStartupValidatorTests.cs
@@ -61,7 +61,7 @@ public sealed class ChangeProposalStartupValidatorTests
             Task.FromResult<EscalationOutcome?>(null);
         public Task<IReadOnlyList<EscalationRequest>> GetPendingEscalationsAsync(string approverName, CancellationToken ct) =>
             Task.FromResult<IReadOnlyList<EscalationRequest>>([]);
-        public Task<EscalationOutcome> CancelEscalationAsync(Guid escalationId, string reason, CancellationToken ct) =>
+        public Task<EscalationOutcome> CancelEscalationAsync(Guid escalationId, string reason, string cancelledBy, CancellationToken ct) =>
             throw new NotImplementedException();
     }
 

--- a/src/Content/Tests/Infrastructure.AI.Tests/Changes/Gates/EscalationServiceApprovalRouterTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Changes/Gates/EscalationServiceApprovalRouterTests.cs
@@ -45,7 +45,7 @@ public sealed class EscalationServiceApprovalRouterTests : IDisposable
         public Task<EscalationRequest?> GetPendingEscalationAsync(Guid escalationId, CancellationToken ct) => throw new NotImplementedException();
         public Task<EscalationOutcome?> GetOutcomeAsync(Guid escalationId, CancellationToken ct) => throw new NotImplementedException();
         public Task<IReadOnlyList<EscalationRequest>> GetPendingEscalationsAsync(string approverName, CancellationToken ct) => throw new NotImplementedException();
-        public Task<EscalationOutcome> CancelEscalationAsync(Guid escalationId, string reason, CancellationToken ct) => throw new NotImplementedException();
+        public Task<EscalationOutcome> CancelEscalationAsync(Guid escalationId, string reason, string cancelledBy, CancellationToken ct) => throw new NotImplementedException();
     }
 
     private static GateContext Ctx(int attempt = 1) => new()

--- a/src/Content/Tests/Infrastructure.AI.Tests/Escalation/DefaultEscalationServiceTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Escalation/DefaultEscalationServiceTests.cs
@@ -467,7 +467,7 @@ public sealed class DefaultEscalationServiceTests : IDisposable
 		await _sut.QueueEscalationAsync(request, CancellationToken.None);
 
 		var outcome = await _sut.CancelEscalationAsync(
-			request.EscalationId, "No longer needed", CancellationToken.None);
+			request.EscalationId, "No longer needed", "admin@contoso.com", CancellationToken.None);
 
 		outcome.IsApproved.Should().BeFalse();
 		outcome.ResolutionType.Should().Be(EscalationResolutionType.Denied);
@@ -485,9 +485,64 @@ public sealed class DefaultEscalationServiceTests : IDisposable
 		await _sut.SubmitDecisionAsync(request.EscalationId, CreateApproval(), CancellationToken.None);
 
 		var act = () => _sut.CancelEscalationAsync(
-			request.EscalationId, "Too late", CancellationToken.None);
+			request.EscalationId, "Too late", "admin@contoso.com", CancellationToken.None);
 
 		await act.Should().ThrowAsync<InvalidOperationException>();
+	}
+
+	[Fact]
+	public async Task CancelEscalationAsync_StampsActorAndRosterOnOutcome()
+	{
+		// The force-denial must be attributable in the durable outcome audit (CancelledBy) and
+		// must retain the roster so roster-private reads keep working after resolution.
+		var request = CreateTestRequest(approvers: ["approver-1", "approver-2"]);
+		await _sut.QueueEscalationAsync(request, CancellationToken.None);
+
+		var outcome = await _sut.CancelEscalationAsync(
+			request.EscalationId, "No longer needed", "admin@contoso.com", CancellationToken.None);
+
+		outcome.CancelledBy.Should().Be("admin@contoso.com");
+		outcome.Approvers.Should().BeEquivalentTo("approver-1", "approver-2");
+	}
+
+	[Fact]
+	public async Task SubmitDecisionAsync_ResolvedOutcome_CarriesRoster()
+	{
+		var request = CreateTestRequest(approvers: ["approver-1", "approver-2"]);
+		SetupStrategyResolvesOnFirstApproval();
+		await _sut.QueueEscalationAsync(request, CancellationToken.None);
+
+		var result = await _sut.SubmitDecisionAsync(
+			request.EscalationId, CreateApproval(), CancellationToken.None);
+
+		result.Status.Should().Be(EscalationDecisionStatus.Resolved);
+		result.Outcome!.Approvers.Should().BeEquivalentTo("approver-1", "approver-2");
+		result.Outcome.CancelledBy.Should().BeNull("decision resolutions have no cancelling actor");
+	}
+
+	[Fact]
+	public async Task SubmitDecisionAsync_DuplicateApprover_IgnoredWithoutSecondAuditRecord()
+	{
+		// One recorded decision per approver per escalation: a retried submission (even with
+		// different casing) must not append to the decision list, must not re-run the strategy,
+		// and must not grow the audit trail — it reports DecisionRecorded and stops.
+		var request = CreateTestRequest(strategy: ApprovalStrategyType.AllOf);
+		SetupStrategyNeverResolves(ApprovalStrategyType.AllOf);
+		await _sut.QueueEscalationAsync(request, CancellationToken.None);
+
+		var first = await _sut.SubmitDecisionAsync(
+			request.EscalationId, CreateApproval("approver-1"), CancellationToken.None);
+		var repeat = await _sut.SubmitDecisionAsync(
+			request.EscalationId, CreateApproval("APPROVER-1"), CancellationToken.None);
+
+		first.Status.Should().Be(EscalationDecisionStatus.DecisionRecorded);
+		repeat.Status.Should().Be(EscalationDecisionStatus.DecisionRecorded);
+		_auditStore.Verify(
+			a => a.RecordDecisionAsync(request.EscalationId, It.IsAny<ApproverDecision>(), It.IsAny<CancellationToken>()),
+			Times.Once);
+		_allOfStrategy.Verify(
+			s => s.EvaluateDecision(It.IsAny<EscalationRequest>(), It.IsAny<IReadOnlyList<ApproverDecision>>()),
+			Times.Once);
 	}
 
 	// ===== GetPending =====

--- a/src/Content/Tests/Infrastructure.AI.Tests/Escalation/DefaultEscalationServiceTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Escalation/DefaultEscalationServiceTests.cs
@@ -521,6 +521,73 @@ public sealed class DefaultEscalationServiceTests : IDisposable
 	}
 
 	[Fact]
+	public async Task SubmitDecisionAsync_DuplicateApproverWithOppositeVerdict_ReturnsConflictWithoutRecording()
+	{
+		// A changed vote must be rejected honestly (ConflictingDecision → 409), not silently
+		// dropped while echoing "recorded": no audit append, no strategy re-evaluation.
+		var request = CreateTestRequest(strategy: ApprovalStrategyType.AllOf);
+		SetupStrategyNeverResolves(ApprovalStrategyType.AllOf);
+		await _sut.QueueEscalationAsync(request, CancellationToken.None);
+
+		var first = await _sut.SubmitDecisionAsync(
+			request.EscalationId, CreateApproval("approver-1"), CancellationToken.None);
+		var changed = await _sut.SubmitDecisionAsync(
+			request.EscalationId, CreateDenial("APPROVER-1"), CancellationToken.None);
+
+		first.Status.Should().Be(EscalationDecisionStatus.DecisionRecorded);
+		changed.Status.Should().Be(EscalationDecisionStatus.ConflictingDecision);
+		_auditStore.Verify(
+			a => a.RecordDecisionAsync(request.EscalationId, It.IsAny<ApproverDecision>(), It.IsAny<CancellationToken>()),
+			Times.Once);
+		_allOfStrategy.Verify(
+			s => s.EvaluateDecision(It.IsAny<EscalationRequest>(), It.IsAny<IReadOnlyList<ApproverDecision>>()),
+			Times.Once);
+	}
+
+	[Fact]
+	public async Task SubmitDecisionAsync_OutcomeAuditFails_EscalationStaysObservableAndVerdictUnpublished()
+	{
+		// Resolution ordering contract: the outcome is durably audited FIRST; on failure the
+		// escalation must remain in the active set (still observable as pending) and the verdict
+		// must never be published to GetOutcomeAsync. The old remove-then-audit order made a
+		// failed-audit escalation vanish from every reader.
+		var request = CreateTestRequest();
+		SetupStrategyResolvesOnFirstApproval();
+		_auditStore
+			.Setup(a => a.RecordOutcomeAsync(It.IsAny<EscalationOutcome>(), It.IsAny<CancellationToken>()))
+			.ThrowsAsync(new InvalidOperationException("audit store unavailable"));
+		await _sut.QueueEscalationAsync(request, CancellationToken.None);
+
+		var act = () => _sut.SubmitDecisionAsync(
+			request.EscalationId, CreateApproval(), CancellationToken.None);
+
+		await act.Should().ThrowAsync<InvalidOperationException>();
+		(await _sut.GetOutcomeAsync(request.EscalationId, CancellationToken.None))
+			.Should().BeNull("an unaudited verdict must never be served");
+		(await _sut.GetPendingEscalationAsync(request.EscalationId, CancellationToken.None))
+			.Should().NotBeNull("a resolved-but-unaudited escalation must stay observable, not vanish");
+	}
+
+	[Fact]
+	public async Task SubmitDecisionAsync_ResolvedEscalation_OutcomeRetrievableImmediately()
+	{
+		// The 202→poll contract: once a decision resolves, GetOutcomeAsync must serve the
+		// verdict (published before the active-set removal, after the audit write).
+		var request = CreateTestRequest();
+		SetupStrategyResolvesOnFirstApproval();
+		await _sut.QueueEscalationAsync(request, CancellationToken.None);
+
+		var result = await _sut.SubmitDecisionAsync(
+			request.EscalationId, CreateApproval(), CancellationToken.None);
+
+		result.Status.Should().Be(EscalationDecisionStatus.Resolved);
+		(await _sut.GetOutcomeAsync(request.EscalationId, CancellationToken.None))
+			.Should().NotBeNull();
+		(await _sut.GetPendingEscalationAsync(request.EscalationId, CancellationToken.None))
+			.Should().BeNull("resolution removes the escalation from the active set");
+	}
+
+	[Fact]
 	public async Task SubmitDecisionAsync_DuplicateApprover_IgnoredWithoutSecondAuditRecord()
 	{
 		// One recorded decision per approver per escalation: a retried submission (even with

--- a/src/Content/Tests/Presentation.AgentHub.Tests/Controllers/EscalationsControllerIntegrationTests.cs
+++ b/src/Content/Tests/Presentation.AgentHub.Tests/Controllers/EscalationsControllerIntegrationTests.cs
@@ -1,0 +1,147 @@
+using System.Net;
+using System.Net.Http.Json;
+using Application.Core.CQRS.Escalation;
+using Domain.AI.Escalation;
+using Domain.Common;
+using FluentAssertions;
+using MediatR;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Presentation.Common.Escalations;
+using Xunit;
+
+namespace Presentation.AgentHub.Tests.Controllers;
+
+/// <summary>
+/// Wire-level tests for the escalation API mounted into AgentHub via <c>AddEscalationApi()</c>:
+/// the routes exist (opt-in wiring works end-to-end through the real host), role gating fails
+/// closed, cancel is admin-only, and the approver identity comes from the token's
+/// <c>preferred_username</c> claim — a spoofed approver-name field in the request body is
+/// ignored because no DTO binds it.
+/// </summary>
+public sealed class EscalationsControllerIntegrationTests : IClassFixture<TestWebApplicationFactory>
+{
+    private readonly TestWebApplicationFactory _factory;
+
+    public EscalationsControllerIntegrationTests(TestWebApplicationFactory factory) => _factory = factory;
+
+    private HttpClient CreateAuthedClient(string userId = "alice@contoso.com", string? roles = null)
+    {
+        var client = _factory
+            .WithWebHostBuilder(b => b.ConfigureTestServices(services =>
+                services.AddAuthentication(TestAuthHandler.SchemeName)
+                    .AddScheme<AuthenticationSchemeOptions, TestAuthHandler>(
+                        TestAuthHandler.SchemeName, _ => { })))
+            .CreateClient();
+        client.DefaultRequestHeaders.Add(TestAuthHandler.UserIdHeader, userId);
+        if (roles is not null)
+            client.DefaultRequestHeaders.Add(TestAuthHandler.RolesHeader, roles);
+        return client;
+    }
+
+    [Fact]
+    public async Task GetPending_Unauthenticated_Returns401()
+    {
+        // Also proves the routes are mounted at all: an unmounted route would 404, not challenge.
+        using var client = _factory.CreateClient();
+
+        var response = await client.GetAsync("/api/escalations");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task GetPending_AuthenticatedWithoutDecideRole_Returns403()
+    {
+        using var client = CreateAuthedClient();
+
+        var response = await client.GetAsync("/api/escalations");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden,
+            "role gating must fail closed for authenticated callers without Harness.Approvals.Decide");
+    }
+
+    [Fact]
+    public async Task GetPending_WithDecideRole_Returns200AndStampsIdentityFromToken()
+    {
+        GetPendingEscalationsForApproverQuery? captured = null;
+        _factory.MockMediator
+            .Setup(m => m.Send(It.IsAny<GetPendingEscalationsForApproverQuery>(), It.IsAny<CancellationToken>()))
+            .Callback<IRequest<Result<IReadOnlyList<EscalationSummary>>>, CancellationToken>(
+                (q, _) => captured = (GetPendingEscalationsForApproverQuery)q)
+            .ReturnsAsync(Result<IReadOnlyList<EscalationSummary>>.Success([]));
+
+        using var client = CreateAuthedClient("bob@contoso.com", EscalationsController.DecideRole);
+
+        var response = await client.GetAsync("/api/escalations");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        captured.Should().NotBeNull();
+        captured!.ApproverName.Should().Be("bob@contoso.com",
+            "the approver identity must come from the authenticated principal's claim");
+    }
+
+    [Fact]
+    public async Task SubmitDecision_BodyApproverNameField_IsIgnoredTokenWins()
+    {
+        SubmitEscalationDecisionCommand? captured = null;
+        _factory.MockMediator
+            .Setup(m => m.Send(It.IsAny<SubmitEscalationDecisionCommand>(), It.IsAny<CancellationToken>()))
+            .Callback<IRequest<Result<SubmitEscalationDecisionResult>>, CancellationToken>(
+                (c, _) => captured = (SubmitEscalationDecisionCommand)c)
+            .ReturnsAsync(Result<SubmitEscalationDecisionResult>.Success(
+                new SubmitEscalationDecisionResult { Status = EscalationDecisionStatus.DecisionRecorded }));
+
+        using var client = CreateAuthedClient("alice@contoso.com", EscalationsController.DecideRole);
+
+        // The spoofed approverName member has no binding target on the DTO and must be ignored.
+        var response = await client.PostAsJsonAsync(
+            $"/api/escalations/{Guid.NewGuid()}/decision",
+            new { approve = true, reason = "ok", approverName = "mallory@evil.example" });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Accepted,
+            "DecisionRecorded maps to 202 per the documented status mapping");
+        captured.Should().NotBeNull();
+        captured!.ApproverName.Should().Be("alice@contoso.com",
+            "a body-supplied approver name must never influence the stamped identity");
+        captured.Approve.Should().BeTrue();
+        captured.Reason.Should().Be("ok");
+    }
+
+    [Fact]
+    public async Task Cancel_WithDecideRoleOnly_Returns403()
+    {
+        using var client = CreateAuthedClient("alice@contoso.com", EscalationsController.DecideRole);
+
+        var response = await client.PostAsJsonAsync(
+            $"/api/escalations/{Guid.NewGuid()}/cancel", new { reason = "stale" });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden,
+            "cancel is admin-only; the decide role must not suffice");
+    }
+
+    [Fact]
+    public async Task Cancel_WithAdminRole_Returns200()
+    {
+        _factory.MockMediator
+            .Setup(m => m.Send(It.IsAny<CancelEscalationCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<EscalationOutcomeSummary>.Success(new EscalationOutcomeSummary
+            {
+                EscalationId = Guid.NewGuid(),
+                IsApproved = false,
+                ResolutionType = EscalationResolutionType.Denied,
+                ResolvedAt = DateTimeOffset.UtcNow,
+                Decisions = []
+            }));
+
+        using var client = CreateAuthedClient("ops@contoso.com", EscalationsController.AdminRole);
+
+        var response = await client.PostAsJsonAsync(
+            $"/api/escalations/{Guid.NewGuid()}/cancel", new { reason = "superseded" });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+}

--- a/src/Content/Tests/Presentation.AgentHub.Tests/TestAuthHandler.cs
+++ b/src/Content/Tests/Presentation.AgentHub.Tests/TestAuthHandler.cs
@@ -49,6 +49,9 @@ public class TestAuthHandler(
             new("oid", userId),
             new(ClaimTypes.NameIdentifier, userId),
             new(ClaimTypes.Name, userId),
+            // Approver identity claim read by the escalation API
+            // (EscalationConfig.ApproverClaimType default "preferred_username").
+            new("preferred_username", userId),
         };
 
         foreach (var role in roles)

--- a/src/Content/Tests/Presentation.BundleApi.Tests/EscalationRoutesNotMountedTests.cs
+++ b/src/Content/Tests/Presentation.BundleApi.Tests/EscalationRoutesNotMountedTests.cs
@@ -1,0 +1,43 @@
+using System.Net;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+
+namespace Presentation.BundleApi.Tests;
+
+/// <summary>
+/// Proves the escalation API's opt-in gate against the exact real host it exists to protect.
+/// BundleApi references <c>Presentation.Common</c> and calls <c>AddControllers()</c>, so the Web
+/// SDK auto-registers Presentation.Common as an MVC application part and
+/// <c>EscalationsController</c> IS discovered here — but BundleApi never calls
+/// <c>AddEscalationApi()</c>, so the opt-in action constraint must keep every escalation route
+/// un-matched. Escalation state lives in the workload host's in-process singleton; a bundle host
+/// must not accidentally expose approval endpoints.
+/// </summary>
+public sealed class EscalationRoutesNotMountedTests : IClassFixture<WebApplicationFactory<Program>>
+{
+    private readonly WebApplicationFactory<Program> _factory;
+
+    public EscalationRoutesNotMountedTests(WebApplicationFactory<Program> factory)
+    {
+        _factory = factory;
+    }
+
+    [Theory]
+    [InlineData("GET", "/api/escalations")]
+    [InlineData("GET", "/api/escalations/00000000-0000-0000-0000-000000000001")]
+    [InlineData("POST", "/api/escalations/00000000-0000-0000-0000-000000000001/decision")]
+    [InlineData("POST", "/api/escalations/00000000-0000-0000-0000-000000000001/cancel")]
+    public async Task EscalationRoute_InNonOptedHost_Returns404NotAChallenge(string method, string path)
+    {
+        // 404 specifically — not 401/403. The gate is an action constraint that un-matches the
+        // route before authentication, so a probe cannot even learn the routes exist.
+        var client = _factory.CreateClient();
+
+        using var request = new HttpRequestMessage(new HttpMethod(method), path);
+        var response = await client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound,
+            "a host that never called AddEscalationApi() must not expose escalation routes");
+    }
+}

--- a/src/Content/Tests/Presentation.Common.Tests/Escalations/EscalationApiMountingTests.cs
+++ b/src/Content/Tests/Presentation.Common.Tests/Escalations/EscalationApiMountingTests.cs
@@ -1,0 +1,157 @@
+using System.Net;
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+using Application.Core.CQRS.Escalation;
+using Domain.Common;
+using MediatR;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using FluentAssertions;
+using Presentation.Common.Escalations;
+using Xunit;
+
+namespace Presentation.Common.Tests.Escalations;
+
+/// <summary>
+/// Proves the escalation API's opt-in mounting semantics against real hosts:
+/// <list type="number">
+///   <item><description>A host that merely references the assembly (no application part, no
+///   marker) has no escalation routes.</description></item>
+///   <item><description>A host where the assembly IS an application part — which the Web SDK
+///   does automatically for any MVC host referencing <c>Presentation.Common</c> — still has no
+///   escalation routes without the marker: the action constraint un-matches them, yielding a
+///   plain 404 before authentication. This is the case that makes the opt-in real.</description></item>
+///   <item><description>A host that called <c>AddEscalationApi()</c> serves the routes.</description></item>
+/// </list>
+/// </summary>
+public sealed class EscalationApiMountingTests
+{
+    [Fact]
+    public async Task Host_WithoutPartOrMarker_HasNoEscalationRoutes()
+    {
+        using var host = await BuildHostAsync(mvc => { });
+
+        var response = await host.GetTestClient().GetAsync("/api/escalations");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound,
+            "a host that never mounted the API must not expose its routes");
+    }
+
+    [Fact]
+    public async Task Host_WithApplicationPartButNoMarker_StillHasNoEscalationRoutes()
+    {
+        // Simulates the Web SDK's automatic ApplicationPartAttribute for referenced MVC
+        // assemblies: the controller IS discovered, but the opt-in constraint must keep every
+        // route un-matched — a plain 404, not a 401 challenge that would reveal the route.
+        using var host = await BuildHostAsync(mvc =>
+            mvc.AddApplicationPart(typeof(EscalationsController).Assembly));
+
+        var response = await host.GetTestClient().GetAsync("/api/escalations");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound,
+            "auto-discovery of the application part must not arm the routes without AddEscalationApi()");
+    }
+
+    [Fact]
+    public async Task Host_WithAddEscalationApi_ServesEscalationRoutes()
+    {
+        using var host = await BuildHostAsync(mvc => mvc.AddEscalationApi());
+
+        var response = await host.GetTestClient().GetAsync("/api/escalations");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK,
+            "AddEscalationApi() must arm the routes for an authorized caller");
+    }
+
+    [Fact]
+    public async Task Host_WithAddEscalationApi_UnauthenticatedProbeIsChallengedNotHidden()
+    {
+        using var host = await BuildHostAsync(mvc => mvc.AddEscalationApi(), authenticate: false);
+
+        var response = await host.GetTestClient().GetAsync("/api/escalations");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized,
+            "an armed host enforces authentication on the mounted routes");
+    }
+
+    /// <summary>
+    /// Builds a minimal MVC host on TestServer with a permissive authentication scheme (decide
+    /// role + approver claim), a stubbed mediator, and the caller-selected MVC configuration.
+    /// </summary>
+    private static async Task<IHost> BuildHostAsync(
+        Action<IMvcBuilder> configureMvc, bool authenticate = true)
+    {
+        var mediator = new Mock<IMediator>();
+        mediator.Setup(m => m.Send(It.IsAny<GetPendingEscalationsForApproverQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<IReadOnlyList<EscalationSummary>>.Success([]));
+
+        var host = await new HostBuilder()
+            .ConfigureWebHost(webHost => webHost
+                .UseTestServer()
+                .ConfigureServices(services =>
+                {
+                    services.AddOptions();
+                    services.AddSingleton(mediator.Object);
+                    configureMvc(services.AddControllers());
+                    var auth = services.AddAuthentication(PermissiveAuthHandler.SchemeName);
+                    if (authenticate)
+                    {
+                        auth.AddScheme<AuthenticationSchemeOptions, PermissiveAuthHandler>(
+                            PermissiveAuthHandler.SchemeName, _ => { });
+                    }
+                    else
+                    {
+                        auth.AddScheme<AuthenticationSchemeOptions, AnonymousChallengeHandler>(
+                            PermissiveAuthHandler.SchemeName, _ => { });
+                    }
+                    services.AddAuthorization();
+                })
+                .Configure(app =>
+                {
+                    app.UseRouting();
+                    app.UseAuthentication();
+                    app.UseAuthorization();
+                    app.UseEndpoints(endpoints => endpoints.MapControllers());
+                }))
+            .StartAsync();
+
+        return host;
+    }
+
+    /// <summary>Authenticates every request as an approver holding the decide role.</summary>
+    private sealed class PermissiveAuthHandler(
+        IOptionsMonitor<AuthenticationSchemeOptions> options,
+        ILoggerFactory logger,
+        UrlEncoder encoder) : AuthenticationHandler<AuthenticationSchemeOptions>(options, logger, encoder)
+    {
+        public const string SchemeName = "MountingTest";
+
+        protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+        {
+            var identity = new ClaimsIdentity(
+            [
+                new Claim("preferred_username", "alice@contoso.com"),
+                new Claim(ClaimTypes.Role, EscalationsController.DecideRole),
+            ], SchemeName);
+            return Task.FromResult(AuthenticateResult.Success(
+                new AuthenticationTicket(new ClaimsPrincipal(identity), SchemeName)));
+        }
+    }
+
+    /// <summary>Never authenticates, so [Authorize] endpoints challenge with 401.</summary>
+    private sealed class AnonymousChallengeHandler(
+        IOptionsMonitor<AuthenticationSchemeOptions> options,
+        ILoggerFactory logger,
+        UrlEncoder encoder) : AuthenticationHandler<AuthenticationSchemeOptions>(options, logger, encoder)
+    {
+        protected override Task<AuthenticateResult> HandleAuthenticateAsync() =>
+            Task.FromResult(AuthenticateResult.NoResult());
+    }
+}

--- a/src/Content/Tests/Presentation.Common.Tests/Escalations/EscalationsControllerTests.cs
+++ b/src/Content/Tests/Presentation.Common.Tests/Escalations/EscalationsControllerTests.cs
@@ -109,6 +109,85 @@ public sealed class EscalationsControllerTests
             Times.Never);
     }
 
+    [Theory]
+    [InlineData("oid", "http://schemas.microsoft.com/identity/claims/objectidentifier")]
+    [InlineData("sub", "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier")]
+    [InlineData("upn", "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/upn")]
+    public async Task GetPending_MappedClaimForm_ResolvesConfiguredShortName(
+        string configuredType, string mappedType)
+    {
+        // Production tokens pass through System.IdentityModel.Tokens.Jwt's inbound claim map,
+        // which REMAPS these short names to their long-form URIs. Resolution must find the
+        // mapped form, or configuring 'oid' (this surface's own production recommendation)
+        // would 403 every legitimate approver on the real auth path.
+        _config.ApproverClaimType = configuredType;
+        GetPendingEscalationsForApproverQuery? captured = null;
+        _mediator.Setup(m => m.Send(It.IsAny<GetPendingEscalationsForApproverQuery>(), It.IsAny<CancellationToken>()))
+            .Callback<IRequest<Result<IReadOnlyList<EscalationSummary>>>, CancellationToken>(
+                (q, _) => captured = (GetPendingEscalationsForApproverQuery)q)
+            .ReturnsAsync(Result<IReadOnlyList<EscalationSummary>>.Success([]));
+
+        var result = await CreateSut(new Claim(mappedType, "mapped-identity"))
+            .GetPending(CancellationToken.None);
+
+        result.Should().BeOfType<OkObjectResult>();
+        captured!.ApproverName.Should().Be("mapped-identity");
+    }
+
+    [Fact]
+    public async Task GetPending_SameValueUnderShortAndMappedForm_CountsAsOneAndResolves()
+    {
+        // The same identity arriving under both the short and the mapped form (mixed handler
+        // scenarios) is one identity, not an ambiguity.
+        _config.ApproverClaimType = "oid";
+        _mediator.Setup(m => m.Send(It.IsAny<GetPendingEscalationsForApproverQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<IReadOnlyList<EscalationSummary>>.Success([]));
+
+        var sut = CreateSut(
+            new Claim("oid", "user-object-id"),
+            new Claim("http://schemas.microsoft.com/identity/claims/objectidentifier", "USER-OBJECT-ID"));
+
+        var result = await sut.GetPending(CancellationToken.None);
+
+        result.Should().BeOfType<OkObjectResult>(
+            "identical values under equivalent forms (case-insensitively) must count as one identity");
+    }
+
+    [Fact]
+    public async Task GetPending_DifferentValuesAcrossEquivalentForms_Returns403WithoutDispatch()
+    {
+        // Distinct values under the short and mapped forms are an ambiguous identity — reject,
+        // never pick one.
+        _config.ApproverClaimType = "oid";
+        var sut = CreateSut(
+            new Claim("oid", "real-object-id"),
+            new Claim("http://schemas.microsoft.com/identity/claims/objectidentifier", "smuggled-object-id"));
+
+        var result = await sut.GetPending(CancellationToken.None);
+
+        result.Should().BeOfType<ObjectResult>()
+            .Which.StatusCode.Should().Be(StatusCodes.Status403Forbidden);
+        _mediator.Verify(
+            m => m.Send(It.IsAny<GetPendingEscalationsForApproverQuery>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task SubmitDecision_ConflictFailure_Returns409()
+    {
+        // A changed vote comes back from the handler as a Conflict failure and must map to 409
+        // through the shared failure mapper.
+        _mediator.Setup(m => m.Send(It.IsAny<SubmitEscalationDecisionCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<SubmitEscalationDecisionResult>.Conflict(
+                "A decision by this approver with the opposite verdict is already recorded; votes cannot be changed."));
+
+        var result = await CreateSut(ApproverClaim()).SubmitDecision(
+            Guid.NewGuid(), new SubmitEscalationDecisionRequest(true), CancellationToken.None);
+
+        result.Should().BeOfType<ObjectResult>()
+            .Which.StatusCode.Should().Be(StatusCodes.Status409Conflict);
+    }
+
     [Fact]
     public async Task GetPending_ConfiguredClaimAppearsTwice_Returns403WithoutDispatch()
     {

--- a/src/Content/Tests/Presentation.Common.Tests/Escalations/EscalationsControllerTests.cs
+++ b/src/Content/Tests/Presentation.Common.Tests/Escalations/EscalationsControllerTests.cs
@@ -1,0 +1,306 @@
+using System.Security.Claims;
+using Application.Core.CQRS.Escalation;
+using Domain.AI.Escalation;
+using Domain.Common;
+using Domain.Common.Config.AI.Governance;
+using FluentAssertions;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Presentation.Common.Escalations;
+using Xunit;
+
+namespace Presentation.Common.Tests.Escalations;
+
+/// <summary>
+/// Direct controller unit tests — no WebApplicationFactory. Verifies that the approver identity
+/// is stamped exclusively from the principal's configured claim (the body cannot supply it),
+/// that a missing claim fails closed with 403 before any dispatch, and that every
+/// <see cref="EscalationDecisionStatus"/> maps to its documented HTTP status
+/// (404 / 403 / 202 / 200). Wire-level auth and routing coverage lives in
+/// <c>Presentation.AgentHub.Tests</c>.
+/// </summary>
+public sealed class EscalationsControllerTests
+{
+    private const string Approver = "alice@contoso.com";
+
+    private readonly Mock<IMediator> _mediator = new();
+    private readonly EscalationConfig _config = new();
+
+    private EscalationsController CreateSut(params Claim[] claims)
+    {
+        var monitor = new Mock<IOptionsMonitor<EscalationConfig>>();
+        monitor.SetupGet(m => m.CurrentValue).Returns(_config);
+
+        var sut = new EscalationsController(
+            _mediator.Object, monitor.Object, NullLogger<EscalationsController>.Instance)
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext
+                {
+                    User = new ClaimsPrincipal(new ClaimsIdentity(claims, "test"))
+                }
+            }
+        };
+        return sut;
+    }
+
+    private static Claim ApproverClaim(string type = "preferred_username", string value = Approver) =>
+        new(type, value);
+
+    // --- Identity stamping ---
+
+    [Fact]
+    public async Task GetPending_ClaimPresent_StampsApproverFromToken()
+    {
+        GetPendingEscalationsForApproverQuery? captured = null;
+        _mediator.Setup(m => m.Send(It.IsAny<GetPendingEscalationsForApproverQuery>(), It.IsAny<CancellationToken>()))
+            .Callback<IRequest<Result<IReadOnlyList<EscalationSummary>>>, CancellationToken>(
+                (q, _) => captured = (GetPendingEscalationsForApproverQuery)q)
+            .ReturnsAsync(Result<IReadOnlyList<EscalationSummary>>.Success([]));
+
+        var result = await CreateSut(ApproverClaim()).GetPending(CancellationToken.None);
+
+        result.Should().BeOfType<OkObjectResult>();
+        captured!.ApproverName.Should().Be(Approver);
+    }
+
+    [Fact]
+    public async Task GetPending_CustomClaimTypeConfigured_ReadsConfiguredClaimOnly()
+    {
+        _config.ApproverClaimType = "upn";
+        GetPendingEscalationsForApproverQuery? captured = null;
+        _mediator.Setup(m => m.Send(It.IsAny<GetPendingEscalationsForApproverQuery>(), It.IsAny<CancellationToken>()))
+            .Callback<IRequest<Result<IReadOnlyList<EscalationSummary>>>, CancellationToken>(
+                (q, _) => captured = (GetPendingEscalationsForApproverQuery)q)
+            .ReturnsAsync(Result<IReadOnlyList<EscalationSummary>>.Success([]));
+
+        // The principal carries BOTH claims; only the configured one may be used.
+        var sut = CreateSut(
+            ApproverClaim("preferred_username", "spoof@contoso.com"),
+            ApproverClaim("upn", "real@contoso.com"));
+
+        await sut.GetPending(CancellationToken.None);
+
+        captured!.ApproverName.Should().Be("real@contoso.com");
+    }
+
+    [Fact]
+    public async Task GetPending_MissingConfiguredClaim_Returns403WithGenericDetailAndNoDispatch()
+    {
+        // Fail-closed: an authenticated, role-holding caller without the configured identity
+        // claim cannot be roster-matched and must be rejected before any query is dispatched.
+        var sut = CreateSut(new Claim(ClaimTypes.Name, Approver));
+
+        var result = await sut.GetPending(CancellationToken.None);
+
+        var problem = result.Should().BeOfType<ObjectResult>().Subject;
+        problem.StatusCode.Should().Be(StatusCodes.Status403Forbidden);
+        var details = problem.Value.Should().BeAssignableTo<ProblemDetails>().Subject;
+        details.Detail.Should().NotContain("preferred_username",
+            "the response must not teach a caller which claim type to forge; that detail is log-only");
+        _mediator.Verify(
+            m => m.Send(It.IsAny<GetPendingEscalationsForApproverQuery>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task GetPending_ConfiguredClaimAppearsTwice_Returns403WithoutDispatch()
+    {
+        // An ambiguous identity is no identity: if the configured claim is present more than
+        // once, the controller must reject rather than silently first-pick — an attacker able to
+        // smuggle a second instance must not get to choose which value wins.
+        var sut = CreateSut(
+            ApproverClaim(value: "alice@contoso.com"),
+            ApproverClaim(value: "mallory@evil.example"));
+
+        var result = await sut.GetPending(CancellationToken.None);
+
+        var problem = result.Should().BeOfType<ObjectResult>().Subject;
+        problem.StatusCode.Should().Be(StatusCodes.Status403Forbidden);
+        _mediator.Verify(
+            m => m.Send(It.IsAny<GetPendingEscalationsForApproverQuery>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task SubmitDecision_StampsApproverFromTokenNotBody()
+    {
+        // The wire DTO has no approver-name field at all; this proves the command's identity is
+        // exactly the token claim.
+        SubmitEscalationDecisionCommand? captured = null;
+        _mediator.Setup(m => m.Send(It.IsAny<SubmitEscalationDecisionCommand>(), It.IsAny<CancellationToken>()))
+            .Callback<IRequest<Result<SubmitEscalationDecisionResult>>, CancellationToken>(
+                (c, _) => captured = (SubmitEscalationDecisionCommand)c)
+            .ReturnsAsync(Result<SubmitEscalationDecisionResult>.Success(new SubmitEscalationDecisionResult
+            {
+                Status = EscalationDecisionStatus.DecisionRecorded
+            }));
+
+        var id = Guid.NewGuid();
+        await CreateSut(ApproverClaim()).SubmitDecision(
+            id, new SubmitEscalationDecisionRequest(Approve: false, Reason: "risky"), CancellationToken.None);
+
+        captured!.ApproverName.Should().Be(Approver);
+        captured.EscalationId.Should().Be(id);
+        captured.Approve.Should().BeFalse();
+        captured.Reason.Should().Be("risky");
+    }
+
+    [Fact]
+    public async Task Cancel_StampsCancelledByFromToken()
+    {
+        CancelEscalationCommand? captured = null;
+        _mediator.Setup(m => m.Send(It.IsAny<CancelEscalationCommand>(), It.IsAny<CancellationToken>()))
+            .Callback<IRequest<Result<EscalationOutcomeSummary>>, CancellationToken>(
+                (c, _) => captured = (CancelEscalationCommand)c)
+            .ReturnsAsync(Result<EscalationOutcomeSummary>.Success(NewOutcomeSummary(Guid.NewGuid())));
+
+        await CreateSut(ApproverClaim()).Cancel(
+            Guid.NewGuid(), new CancelEscalationRequest("superseded"), CancellationToken.None);
+
+        captured!.CancelledBy.Should().Be(Approver);
+        captured.Reason.Should().Be("superseded");
+    }
+
+    // --- Decision status → HTTP mapping (the four documented arms) ---
+
+    [Fact]
+    public async Task SubmitDecision_UnknownEscalation_Returns404()
+    {
+        SetupDecision(new SubmitEscalationDecisionResult { Status = EscalationDecisionStatus.UnknownEscalation });
+
+        var result = await CreateSut(ApproverClaim()).SubmitDecision(
+            Guid.NewGuid(), new SubmitEscalationDecisionRequest(true), CancellationToken.None);
+
+        result.Should().BeOfType<ObjectResult>()
+            .Which.StatusCode.Should().Be(StatusCodes.Status404NotFound);
+    }
+
+    [Fact]
+    public async Task SubmitDecision_ApproverNotAuthorized_Returns403()
+    {
+        SetupDecision(new SubmitEscalationDecisionResult { Status = EscalationDecisionStatus.ApproverNotAuthorized });
+
+        var result = await CreateSut(ApproverClaim()).SubmitDecision(
+            Guid.NewGuid(), new SubmitEscalationDecisionRequest(true), CancellationToken.None);
+
+        result.Should().BeOfType<ObjectResult>()
+            .Which.StatusCode.Should().Be(StatusCodes.Status403Forbidden);
+    }
+
+    [Fact]
+    public async Task SubmitDecision_DecisionRecorded_Returns202()
+    {
+        SetupDecision(new SubmitEscalationDecisionResult { Status = EscalationDecisionStatus.DecisionRecorded });
+
+        var result = await CreateSut(ApproverClaim()).SubmitDecision(
+            Guid.NewGuid(), new SubmitEscalationDecisionRequest(true), CancellationToken.None);
+
+        var accepted = result.Should().BeOfType<AcceptedResult>().Subject;
+        var body = accepted.Value.Should().BeOfType<EscalationDecisionResponse>().Subject;
+        body.Status.Should().Be(EscalationDecisionStatus.DecisionRecorded);
+        body.Outcome.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task SubmitDecision_Resolved_Returns200WithOutcome()
+    {
+        var id = Guid.NewGuid();
+        SetupDecision(new SubmitEscalationDecisionResult
+        {
+            Status = EscalationDecisionStatus.Resolved,
+            Outcome = NewOutcomeSummary(id)
+        });
+
+        var result = await CreateSut(ApproverClaim()).SubmitDecision(
+            id, new SubmitEscalationDecisionRequest(true), CancellationToken.None);
+
+        var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+        var body = ok.Value.Should().BeOfType<EscalationDecisionResponse>().Subject;
+        body.Status.Should().Be(EscalationDecisionStatus.Resolved);
+        body.Outcome!.EscalationId.Should().Be(id);
+    }
+
+    // --- Read/cancel Result mapping through the shared failure mapper ---
+
+    [Fact]
+    public async Task GetById_NotFoundResult_Returns404()
+    {
+        _mediator.Setup(m => m.Send(It.IsAny<GetEscalationQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<EscalationDetail>.NotFound("No escalation with the given id is visible to the caller."));
+
+        var result = await CreateSut(ApproverClaim()).GetById(Guid.NewGuid(), CancellationToken.None);
+
+        result.Should().BeOfType<ObjectResult>()
+            .Which.StatusCode.Should().Be(StatusCodes.Status404NotFound);
+    }
+
+    [Fact]
+    public async Task GetById_Success_ReturnsOkWithDetail()
+    {
+        var detail = EscalationDetail.ForResolved(NewOutcomeSummary(Guid.NewGuid()));
+        _mediator.Setup(m => m.Send(It.IsAny<GetEscalationQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<EscalationDetail>.Success(detail));
+
+        var result = await CreateSut(ApproverClaim()).GetById(Guid.NewGuid(), CancellationToken.None);
+
+        result.Should().BeOfType<OkObjectResult>().Which.Value.Should().BeSameAs(detail);
+    }
+
+    [Fact]
+    public async Task Cancel_ConflictResult_Returns409()
+    {
+        _mediator.Setup(m => m.Send(It.IsAny<CancelEscalationCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<EscalationOutcomeSummary>.Conflict("The escalation is already resolved."));
+
+        var result = await CreateSut(ApproverClaim()).Cancel(
+            Guid.NewGuid(), new CancelEscalationRequest("stale"), CancellationToken.None);
+
+        result.Should().BeOfType<ObjectResult>()
+            .Which.StatusCode.Should().Be(StatusCodes.Status409Conflict);
+    }
+
+    // --- Authorization metadata (role gating shape; wire enforcement tested in AgentHub) ---
+
+    [Fact]
+    public void Controller_ListGetDecide_RequireDecideRole_CancelRequiresAdminRole()
+    {
+        static string? RolesOf(string method) =>
+            typeof(EscalationsController).GetMethod(method)!
+                .GetCustomAttributes(typeof(AuthorizeAttribute), inherit: false)
+                .Cast<AuthorizeAttribute>().Single().Roles;
+
+        RolesOf(nameof(EscalationsController.GetPending)).Should().Be(EscalationsController.DecideRole);
+        RolesOf(nameof(EscalationsController.GetById)).Should().Be(EscalationsController.DecideRole);
+        RolesOf(nameof(EscalationsController.SubmitDecision)).Should().Be(EscalationsController.DecideRole);
+        RolesOf(nameof(EscalationsController.Cancel)).Should().Be(EscalationsController.AdminRole,
+            "cancellation is an operator power, gated separately from approving");
+    }
+
+    [Fact]
+    public void Controller_CarriesOptInConstraint()
+    {
+        typeof(EscalationsController)
+            .GetCustomAttributes(typeof(RequiresEscalationApiOptInAttribute), inherit: false)
+            .Should().HaveCount(1, "routes must be un-matched in hosts that did not call AddEscalationApi");
+    }
+
+    private void SetupDecision(SubmitEscalationDecisionResult value) =>
+        _mediator.Setup(m => m.Send(It.IsAny<SubmitEscalationDecisionCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<SubmitEscalationDecisionResult>.Success(value));
+
+    private static EscalationOutcomeSummary NewOutcomeSummary(Guid id) => new()
+    {
+        EscalationId = id,
+        IsApproved = false,
+        ResolutionType = EscalationResolutionType.Denied,
+        ResolvedAt = DateTimeOffset.UtcNow,
+        Decisions = []
+    };
+}


### PR DESCRIPTION
## What

Wave 2 PR **H1**: humans can now answer agent escalations over HTTP. Four routes on a shared controller (mounted in AgentHub; a future ExecutionApi mounts the same one):

- `GET /api/escalations` — pending items where the **caller** is on the roster
- `GET /api/escalations/{id}` — roster-private (pending AND resolved): non-roster callers get a 404 indistinguishable from an unknown id
- `POST /api/escalations/{id}/decision` `{approve, reason}` — maps H0's `EscalationDecisionStatus` to 404/403/202/200; a decision releases the blocked agent turn in-process via the existing waiter
- `POST /api/escalations/{id}/cancel` — `Harness.Approvals.Admin` only; the cancel actor is now durably recorded in the JSONL audit

## Identity and authorization

- Approver identity comes **only** from a configurable token claim (`ApproverClaimType`, default `preferred_username`) — no DTO carries an approver field, and a wire-level test posts a spoofed `approverName` body member to prove the token wins. Multi-valued or missing claims fail closed (403, generic detail).
- Claim types are **allowlisted** (`oid`, `sub`, `preferred_username`, `upn`) at startup; mutable claims (`preferred_username`/`upn`) trigger a startup warning naming the UPN-reuse risk, with `oid` documented as the production recommendation. Default stays `preferred_username` because every existing roster-authoring surface uses human-readable names.
- Roles per the Traces.ReadAll precedent: `Harness.Approvals.Decide` (read/decide), `Harness.Approvals.Admin` (cancel).
- Duplicate decisions from the same approver (any casing) are detected **before** the audit write — one audit line, one strategy evaluation, no unbounded growth. Decision/cancel POSTs are rate-limited 30/min per caller.

## The mount gate

`Presentation.Common` is an auto-discovered MVC application part in every host, so a bare controller there would have silently mounted in BundleApi too. `AddEscalationApi()` registers a marker; an `IActionConstraint` un-matches all escalation routes when the marker is absent — at endpoint selection, before auth, so non-opted hosts return a plain 404 that doesn't reveal the route. A `WebApplicationFactory` test against the **real BundleApi host** proves all four routes 404 there.

## Review trail

Standards/spec + 4-angle simplify + security review ran pre-push. Security (APPROVE-WITH-CHANGES) items all applied: claim allowlist + mutable-claim warning (HIGH×2), rate limit + duplicate-decision dedup (MED), roster retained on resolution so resolved reads stay roster-private (MED), cancel actor in the audit record (MED), multi-valued-claim rejection + generic 403 detail (LOW×2).

## Test plan

Application.Core.Tests 793, Presentation.Common.Tests 161, Presentation.AgentHub.Tests 408, Presentation.BundleApi.Tests 30, Infrastructure.AI.Tests 2183, Domain.AI.Tests 819 — all green; full-solution build 0 errors, 0 new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BnoLcufW278UxA9ssBM1Tc