### PR TITLE
feat: document provenance stamping + opt-in scoped collections (K4)

### DIFF
--- a/src/Content/Application/Application.AI.Common/Interfaces/RAG/IBm25Store.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/RAG/IBm25Store.cs
@@ -52,13 +52,33 @@ public interface IBm25Store
         CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Deletes all chunks belonging to the specified document from the BM25 index.
+    /// Deletes all chunks belonging to the specified document from ONE collection of the
+    /// BM25 index.
     /// </summary>
     /// <param name="documentId">The document ID whose chunks should be removed.</param>
     /// <param name="collectionName">Optional collection/index name. Null uses the default.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    Task DeleteAsync(
+    /// <returns>
+    /// The number of rows actually removed. Callers that must not over-report (erasure
+    /// receipts, audits) rely on this being the true affected count, not the requested count.
+    /// </returns>
+    Task<int> DeleteAsync(
         string documentId,
         string? collectionName = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Deletes all chunks belonging to the specified document from EVERY collection the
+    /// backend holds. This is the right-to-erasure delete: with per-tenant scoped
+    /// collections a document's rows live in a tenant-derived collection, so a
+    /// default-collection <see cref="DeleteAsync"/> would silently miss them. Backends
+    /// with no physical collection concept (e.g. a single pre-provisioned Azure AI Search
+    /// index) delegate to <see cref="DeleteAsync"/>.
+    /// </summary>
+    /// <param name="documentId">The document ID whose chunks should be removed.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The number of rows actually removed across all collections.</returns>
+    Task<int> DeleteFromAllCollectionsAsync(
+        string documentId,
         CancellationToken cancellationToken = default);
 }

--- a/src/Content/Application/Application.AI.Common/Interfaces/RAG/IMultiSourceOrchestrator.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/RAG/IMultiSourceOrchestrator.cs
@@ -14,9 +14,18 @@ public interface IMultiSourceOrchestrator
     /// Retrieves results from all applicable sources based on query complexity,
     /// merges, deduplicates, and returns a unified result list sorted by fused score.
     /// </summary>
+    /// <param name="query">The natural-language query to retrieve for.</param>
+    /// <param name="topK">Maximum number of results to return after merging.</param>
+    /// <param name="complexity">The classified query complexity driving source selection.</param>
+    /// <param name="collectionName">
+    /// Optional collection/index name forwarded to each source. Null uses each source's
+    /// default. Only collection-aware sources (the <c>"vector"</c> source) honor it.
+    /// </param>
+    /// <param name="cancellationToken">Cancellation token.</param>
     Task<IReadOnlyList<RetrievalResult>> RetrieveFromAllSourcesAsync(
         string query,
         int topK,
         TaskComplexity complexity,
+        string? collectionName = null,
         CancellationToken cancellationToken = default);
 }

--- a/src/Content/Application/Application.AI.Common/Interfaces/RAG/IRetrievalSource.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/RAG/IRetrievalSource.cs
@@ -18,9 +18,20 @@ public interface IRetrievalSource
     /// <summary>
     /// Executes retrieval against this source and returns results with per-source latency and token metrics.
     /// </summary>
+    /// <param name="query">The natural-language query to retrieve for.</param>
+    /// <param name="topK">Maximum number of results to return.</param>
+    /// <param name="complexity">The classified query complexity driving source selection.</param>
+    /// <param name="collectionName">
+    /// Optional collection/index name. Null uses the source's default. Sources without a
+    /// collection concept (graph, web search, SQL) accept and ignore it — such sources are
+    /// tenant-shared even when <c>ScopedCollections</c> is enabled, as documented on
+    /// <c>ScopedCollectionsConfig</c>.
+    /// </param>
+    /// <param name="cancellationToken">Cancellation token.</param>
     Task<SourceRetrievalResult> RetrieveAsync(
         string query,
         int topK,
         TaskComplexity complexity,
-        CancellationToken cancellationToken);
+        string? collectionName = null,
+        CancellationToken cancellationToken = default);
 }

--- a/src/Content/Application/Application.AI.Common/Interfaces/RAG/IVectorStore.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/RAG/IVectorStore.cs
@@ -51,13 +51,33 @@ public interface IVectorStore
         CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Deletes all chunks belonging to the specified document.
+    /// Deletes all chunks belonging to the specified document from ONE collection.
     /// </summary>
     /// <param name="documentId">The document ID whose chunks should be removed.</param>
     /// <param name="collectionName">Optional collection/index name. Null uses the default.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    Task DeleteAsync(
+    /// <returns>
+    /// The number of chunk entries actually removed. Callers that must not over-report
+    /// (erasure receipts, audits) rely on this being the true affected count, not the
+    /// requested count.
+    /// </returns>
+    Task<int> DeleteAsync(
         string documentId,
         string? collectionName = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Deletes all chunks belonging to the specified document from EVERY collection the
+    /// backend holds. This is the right-to-erasure delete: with per-tenant scoped
+    /// collections a document's chunks live in a tenant-derived collection, so a
+    /// default-collection <see cref="DeleteAsync"/> would silently miss them. Backends
+    /// with no physical collection concept (e.g. a single pre-provisioned Azure AI Search
+    /// index) delegate to <see cref="DeleteAsync"/>.
+    /// </summary>
+    /// <param name="documentId">The document ID whose chunks should be removed.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The number of chunk entries actually removed across all collections.</returns>
+    Task<int> DeleteFromAllCollectionsAsync(
+        string documentId,
         CancellationToken cancellationToken = default);
 }

--- a/src/Content/Application/Application.Core/CQRS/RAG/IngestDocument/IngestDocumentCommandHandler.cs
+++ b/src/Content/Application/Application.Core/CQRS/RAG/IngestDocument/IngestDocumentCommandHandler.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using Application.AI.Common.Interfaces.KnowledgeGraph;
 using Application.AI.Common.Interfaces.RAG;
 using Application.AI.Common.OpenTelemetry.Metrics;
 using Application.Core.Workflows.KnowledgeGraph;
@@ -15,10 +16,21 @@ namespace Application.Core.CQRS.RAG.IngestDocument;
 
 /// <summary>
 /// Orchestrates the document ingestion pipeline: parse, extract structure,
-/// chunk, enrich, embed, and index — plus two opt-in graph-build stages
-/// (corpus-graph indexing and knowledge-graph enrichment) that run after the
-/// vector and BM25 indexes commit.
+/// chunk, enrich, embed, stamp provenance, and index — plus two opt-in
+/// graph-build stages (corpus-graph indexing and knowledge-graph enrichment)
+/// that run after the vector and BM25 indexes commit.
 /// </summary>
+/// <remarks>
+/// <para>
+/// Every indexed chunk is stamped with the ambient caller's owner/tenant identity
+/// (<see cref="ChunkMetadata.OwnerId"/>/<see cref="ChunkMetadata.TenantId"/>) — provenance
+/// for future erasure, never a retrieval filter. When
+/// <c>AppConfig:AI:Rag:ScopedCollections</c> is enabled, the target collection is derived
+/// server-side from the caller's tenant via <see cref="ScopedCollectionName"/>; the
+/// command validator has already rejected any caller-supplied collection name in that
+/// mode.
+/// </para>
+/// </remarks>
 public sealed class IngestDocumentCommandHandler
 	: IRequestHandler<IngestDocumentCommand, IngestDocumentResult>
 {
@@ -32,6 +44,7 @@ public sealed class IngestDocumentCommandHandler
 	private readonly IEmbeddingService _embeddingService;
 	private readonly IVectorStore _vectorStore;
 	private readonly IBm25Store _bm25Store;
+	private readonly IKnowledgeScope _knowledgeScope;
 	private readonly ILogger<IngestDocumentCommandHandler> _logger;
 	private readonly IOptionsMonitor<AppConfig> _appConfigMonitor;
 	private readonly IServiceProvider _serviceProvider;
@@ -45,6 +58,7 @@ public sealed class IngestDocumentCommandHandler
 		IEmbeddingService embeddingService,
 		IVectorStore vectorStore,
 		IBm25Store bm25Store,
+		IKnowledgeScope knowledgeScope,
 		ILogger<IngestDocumentCommandHandler> logger,
 		IOptionsMonitor<AppConfig> appConfigMonitor,
 		IServiceProvider serviceProvider)
@@ -57,6 +71,7 @@ public sealed class IngestDocumentCommandHandler
 		_embeddingService = embeddingService;
 		_vectorStore = vectorStore;
 		_bm25Store = bm25Store;
+		_knowledgeScope = knowledgeScope;
 		_logger = logger;
 		_appConfigMonitor = appConfigMonitor;
 		// The graph-build stages resolve their collaborators lazily from the provider:
@@ -78,6 +93,20 @@ public sealed class IngestDocumentCommandHandler
 
 		// Captured once chunks exist so the catch path can compensate partial store writes.
 		string? documentId = null;
+
+		// Ambient identity is captured ONCE, up front, so the collection resolution and the
+		// provenance stamps (applied after several awaits) are guaranteed to agree even if
+		// the ambient scope were mutated mid-pipeline.
+		var ownerId = _knowledgeScope.UserId;
+		var tenantId = _knowledgeScope.TenantId;
+
+		// Resolved before the try so the catch-path compensation deletes from the same
+		// collection the parallel index writes targeted. When ScopedCollections is on the
+		// collection is derived from the ambient tenant (the validator has already rejected
+		// caller-supplied names); when off, the caller's value passes through unchanged.
+		var ragConfig = _appConfigMonitor.CurrentValue.AI.Rag;
+		var effectiveCollection = ScopedCollectionName.Resolve(
+			ragConfig.ScopedCollections.Enabled, request.CollectionName, tenantId);
 
 		try
 		{
@@ -103,7 +132,6 @@ public sealed class IngestDocumentCommandHandler
 			documentId = chunks.Count > 0 ? chunks[0].DocumentId : null;
 
 			// 4. Contextual enrichment (if enabled)
-			var ragConfig = _appConfigMonitor.CurrentValue.AI.Rag;
 			if (ragConfig.Ingestion.EnableContextualEnrichment)
 			{
 				chunks = await _enricher.EnrichAsync(chunks, markdown, cancellationToken);
@@ -120,10 +148,15 @@ public sealed class IngestDocumentCommandHandler
 			chunks = await _embeddingService.EmbedAsync(chunks, cancellationToken);
 			var totalTokens = chunks.Sum(c => c.Tokens);
 
+			// 6.5. Stamp owner/tenant provenance captured at pipeline entry. Runs after
+			// every chunk-producing stage (chunking, enrichment, RAPTOR) so derived chunks are
+			// stamped too. Provenance only — retrieval never filters on these fields.
+			chunks = StampProvenance(chunks, ownerId, tenantId);
+
 			// 7. Index in vector store and BM25 store in parallel
 			await Task.WhenAll(
-				_vectorStore.IndexAsync(chunks, request.CollectionName, cancellationToken),
-				_bm25Store.IndexAsync(chunks, request.CollectionName, cancellationToken));
+				_vectorStore.IndexAsync(chunks, effectiveCollection, cancellationToken),
+				_bm25Store.IndexAsync(chunks, effectiveCollection, cancellationToken));
 
 			// 8. Opt-in graph-build stages. These run AFTER the vector/BM25 commit and are
 			// deliberately non-fatal: the searchable ingest already succeeded, so a graph
@@ -177,7 +210,7 @@ public sealed class IngestDocumentCommandHandler
 			// that wrote nothing.
 			if (documentId is not null)
 			{
-				await CompensatePartialIngestAsync(documentId, request.CollectionName, jobId);
+				await CompensatePartialIngestAsync(documentId, effectiveCollection, jobId);
 			}
 
 			return new IngestDocumentResult
@@ -190,6 +223,31 @@ public sealed class IngestDocumentCommandHandler
 				Error = "Document ingestion failed. Check server logs for details."
 			};
 		}
+	}
+
+	/// <summary>
+	/// Returns the chunk list with <see cref="ChunkMetadata.OwnerId"/> and
+	/// <see cref="ChunkMetadata.TenantId"/> stamped from the identity captured at
+	/// pipeline entry. Identity never comes from the request DTO: it is captured at the
+	/// entry point (middleware/hub filter), flows here ambiently, and is snapshotted once
+	/// in <see cref="Handle"/> so the stamps always agree with the resolved collection.
+	/// When no identity is present (in-process or CLI callers) the chunks are returned
+	/// unchanged — the stamps stay null and shared-corpus behavior is untouched.
+	/// </summary>
+	private static IReadOnlyList<DocumentChunk> StampProvenance(
+		IReadOnlyList<DocumentChunk> chunks, string? ownerId, string? tenantId)
+	{
+		if (ownerId is null && tenantId is null)
+		{
+			return chunks;
+		}
+
+		return chunks
+			.Select(c => c with
+			{
+				Metadata = c.Metadata with { OwnerId = ownerId, TenantId = tenantId },
+			})
+			.ToList();
 	}
 
 	/// <summary>

--- a/src/Content/Application/Application.Core/CQRS/RAG/IngestDocument/IngestDocumentCommandValidator.cs
+++ b/src/Content/Application/Application.Core/CQRS/RAG/IngestDocument/IngestDocumentCommandValidator.cs
@@ -1,11 +1,24 @@
+using Domain.Common.Config;
 using FluentValidation;
+using Microsoft.Extensions.Options;
 
 namespace Application.Core.CQRS.RAG.IngestDocument;
 
-/// <summary>Validates ingestion commands before processing.</summary>
+/// <summary>
+/// Validates ingestion commands before processing. When
+/// <c>AppConfig:AI:Rag:ScopedCollections</c> is enabled, any caller-supplied
+/// <see cref="IngestDocumentCommand.CollectionName"/> is rejected: the effective collection
+/// is derived server-side from the caller's ambient tenant, and honoring a caller-chosen
+/// name would let one tenant write into another tenant's collection.
+/// </summary>
 public sealed class IngestDocumentCommandValidator : AbstractValidator<IngestDocumentCommand>
 {
-	public IngestDocumentCommandValidator()
+	/// <summary>Initializes validation rules for ingestion commands.</summary>
+	/// <param name="appConfigMonitor">
+	/// Live application configuration; consulted per validation so a runtime toggle of
+	/// <c>ScopedCollections</c> takes effect without a restart.
+	/// </param>
+	public IngestDocumentCommandValidator(IOptionsMonitor<AppConfig> appConfigMonitor)
 	{
 		RuleFor(x => x.DocumentUri)
 			.NotNull()
@@ -15,5 +28,12 @@ public sealed class IngestDocumentCommandValidator : AbstractValidator<IngestDoc
 		RuleFor(x => x.CollectionName)
 			.MaximumLength(128)
 			.When(x => x.CollectionName is not null);
+
+		RuleFor(x => x.CollectionName)
+			.Null()
+			.When(_ => appConfigMonitor.CurrentValue.AI.Rag.ScopedCollections.Enabled)
+			.WithMessage(
+				"CollectionName must not be supplied when ScopedCollections is enabled: the " +
+				"target collection is derived server-side from the caller's tenant.");
 	}
 }

--- a/src/Content/Application/Application.Core/CQRS/RAG/SearchDocuments/SearchDocumentsQueryHandler.cs
+++ b/src/Content/Application/Application.Core/CQRS/RAG/SearchDocuments/SearchDocumentsQueryHandler.cs
@@ -1,10 +1,13 @@
 using System.Diagnostics;
+using Application.AI.Common.Interfaces.KnowledgeGraph;
 using Application.AI.Common.Interfaces.RAG;
 using Application.AI.Common.OpenTelemetry.Metrics;
 using Domain.AI.RAG.Models;
 using Domain.AI.Telemetry.Conventions;
+using Domain.Common.Config;
 using MediatR;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace Application.Core.CQRS.RAG.SearchDocuments;
 
@@ -12,20 +15,34 @@ namespace Application.Core.CQRS.RAG.SearchDocuments;
 /// Delegates to <see cref="IRagOrchestrator"/> for the full RAG pipeline
 /// (classify, transform, retrieve, rerank, evaluate, expand, assemble).
 /// </summary>
+/// <remarks>
+/// When <c>AppConfig:AI:Rag:ScopedCollections</c> is enabled, the collection searched is
+/// derived server-side from the caller's ambient tenant via
+/// <see cref="ScopedCollectionName"/> — the query validator has already rejected any
+/// caller-supplied collection name in that mode, so a caller can never name (and read)
+/// another tenant's collection. A caller with no ambient tenant searches the
+/// global/default collection.
+/// </remarks>
 public sealed class SearchDocumentsQueryHandler
     : IRequestHandler<SearchDocumentsQuery, SearchDocumentsResult>
 {
     private static readonly ActivitySource ActivitySource = new("AgenticHarness.RAG.Retrieval");
 
     private readonly IRagOrchestrator _orchestrator;
+    private readonly IKnowledgeScope _knowledgeScope;
+    private readonly IOptionsMonitor<AppConfig> _appConfigMonitor;
     private readonly ILogger<SearchDocumentsQueryHandler> _logger;
 
     /// <summary>Initializes a new instance of the <see cref="SearchDocumentsQueryHandler"/> class.</summary>
     public SearchDocumentsQueryHandler(
         IRagOrchestrator orchestrator,
+        IKnowledgeScope knowledgeScope,
+        IOptionsMonitor<AppConfig> appConfigMonitor,
         ILogger<SearchDocumentsQueryHandler> logger)
     {
         _orchestrator = orchestrator;
+        _knowledgeScope = knowledgeScope;
+        _appConfigMonitor = appConfigMonitor;
         _logger = logger;
     }
 
@@ -44,8 +61,13 @@ public sealed class SearchDocumentsQueryHandler
                 "RAG search started via orchestrator: TopK={TopK}",
                 request.TopK);
 
+            var effectiveCollection = ScopedCollectionName.Resolve(
+                _appConfigMonitor.CurrentValue.AI.Rag.ScopedCollections.Enabled,
+                request.CollectionName,
+                _knowledgeScope.TenantId);
+
             var context = await _orchestrator.SearchAsync(
-                request.Query, request.TopK, request.CollectionName,
+                request.Query, request.TopK, effectiveCollection,
                 request.StrategyOverride, cancellationToken);
 
             pipelineSw.Stop();

--- a/src/Content/Application/Application.Core/CQRS/RAG/SearchDocuments/SearchDocumentsQueryValidator.cs
+++ b/src/Content/Application/Application.Core/CQRS/RAG/SearchDocuments/SearchDocumentsQueryValidator.cs
@@ -1,14 +1,24 @@
+using Domain.Common.Config;
 using FluentValidation;
+using Microsoft.Extensions.Options;
 
 namespace Application.Core.CQRS.RAG.SearchDocuments;
 
 /// <summary>
-/// Validates <see cref="SearchDocumentsQuery"/> at the pipeline boundary.
+/// Validates <see cref="SearchDocumentsQuery"/> at the pipeline boundary. When
+/// <c>AppConfig:AI:Rag:ScopedCollections</c> is enabled, any caller-supplied
+/// <see cref="SearchDocumentsQuery.CollectionName"/> is rejected: the collection searched
+/// is derived server-side from the caller's ambient tenant, and honoring a caller-chosen
+/// name would be a cross-tenant read primitive.
 /// </summary>
 public sealed class SearchDocumentsQueryValidator : AbstractValidator<SearchDocumentsQuery>
 {
     /// <summary>Initializes validation rules for search queries.</summary>
-    public SearchDocumentsQueryValidator()
+    /// <param name="appConfigMonitor">
+    /// Live application configuration; consulted per validation so a runtime toggle of
+    /// <c>ScopedCollections</c> takes effect without a restart.
+    /// </param>
+    public SearchDocumentsQueryValidator(IOptionsMonitor<AppConfig> appConfigMonitor)
     {
         RuleFor(x => x.Query)
             .NotEmpty()
@@ -24,5 +34,12 @@ public sealed class SearchDocumentsQueryValidator : AbstractValidator<SearchDocu
             .MaximumLength(128)
             .When(x => x.CollectionName is not null)
             .WithMessage("CollectionName must not exceed 128 characters.");
+
+        RuleFor(x => x.CollectionName)
+            .Null()
+            .When(_ => appConfigMonitor.CurrentValue.AI.Rag.ScopedCollections.Enabled)
+            .WithMessage(
+                "CollectionName must not be supplied when ScopedCollections is enabled: the " +
+                "collection searched is derived server-side from the caller's tenant.");
     }
 }

--- a/src/Content/Application/Application.Core/Validation/RagConfigValidator.cs
+++ b/src/Content/Application/Application.Core/Validation/RagConfigValidator.cs
@@ -77,6 +77,12 @@ public sealed class RagConfigValidator : AbstractValidator<RagConfig>
 
         When(x => x.ScopedCollections.Enabled, () =>
         {
+            // COUPLING NOTE: this rule keys off VectorStore.Provider, which today also
+            // selects the BM25 store (VectorStoreFactory derives the BM25 key from the
+            // same value: "azure_ai_search" pairs both Azure stores, anything else pairs
+            // FAISS + SQLite FTS5). If a separate BM25 provider setting is ever
+            // introduced, it needs its own guard here or a collection-ignoring BM25
+            // backend would silently escape this check.
             RuleFor(x => x.VectorStore.Provider)
                 .Must(p => !string.Equals(p, "azure_ai_search", StringComparison.OrdinalIgnoreCase))
                 .WithMessage(

--- a/src/Content/Application/Application.Core/Validation/RagConfigValidator.cs
+++ b/src/Content/Application/Application.Core/Validation/RagConfigValidator.cs
@@ -18,6 +18,18 @@ namespace Application.Core.Validation;
 ///     backend must be enabled: corpus-graph indexing writes through
 ///     <c>IGraphRagService</c>, which exists only alongside the backend. Failing at boot is
 ///     kinder than silently skipping the stage on every ingest.</item>
+///   <item>When <see cref="ScopedCollectionsConfig.Enabled"/> is <c>true</c>, the retrieval
+///     stack must actually honor collection names: the <c>"azure_ai_search"</c> store pairing
+///     queries one pre-provisioned index and ignores the collection parameter, and the
+///     agentic-retrieval backend always queries its one configured knowledge base. Either
+///     combination would accept tenant-derived collection names and silently search the
+///     shared index anyway — a cross-tenant leak. Failing at boot is the closed, predictable
+///     alternative.</item>
+///   <item>When <see cref="ScopedCollectionsConfig.Enabled"/> is <c>true</c>,
+///     <see cref="GraphRagConfig.IndexOnIngest"/> must be off: the corpus graph is a single
+///     shared graph with no collection concept, so indexing scoped ingests into it would
+///     make every tenant's chunks readable through the GraphRag strategy and the Phase-D
+///     <c>"graph"</c> source. The validator makes the unsafe combination unrepresentable.</item>
 /// </list>
 /// All class defaults satisfy every rule, so hosts that omit the section keep booting
 /// unchanged.
@@ -61,6 +73,38 @@ public sealed class RagConfigValidator : AbstractValidator<RagConfig>
                     "indexing writes through IGraphRagService, which is registered only when " +
                     "AppConfig:AI:Rag:GraphDatabase:Enabled is true. Enable the backend or turn " +
                     "off AppConfig:AI:Rag:GraphRag:IndexOnIngest.");
+        });
+
+        When(x => x.ScopedCollections.Enabled, () =>
+        {
+            RuleFor(x => x.VectorStore.Provider)
+                .Must(p => !string.Equals(p, "azure_ai_search", StringComparison.OrdinalIgnoreCase))
+                .WithMessage(
+                    "ScopedCollections requires a collection-aware store pairing. The " +
+                    "'azure_ai_search' stores query one pre-provisioned index and ignore " +
+                    "collection names, so tenant-derived collections would silently search the " +
+                    "shared index — a cross-tenant leak. Set AppConfig:AI:Rag:VectorStore:Provider " +
+                    "to 'faiss' (FAISS + SQLite FTS5, both collection-aware), or provision " +
+                    "per-tenant Azure indexes and register a collection-aware store before " +
+                    "enabling AppConfig:AI:Rag:ScopedCollections.");
+
+            RuleFor(x => x.AgenticRetrieval.Enabled)
+                .Equal(false)
+                .WithMessage(
+                    "ScopedCollections cannot be combined with AgenticRetrieval: the Azure " +
+                    "knowledge-base retriever always queries the one configured knowledge base " +
+                    "and ignores collection names, so every tenant would search the same shared " +
+                    "knowledge base. Disable AppConfig:AI:Rag:AgenticRetrieval or " +
+                    "AppConfig:AI:Rag:ScopedCollections.");
+
+            RuleFor(x => x.GraphRag.IndexOnIngest)
+                .Equal(false)
+                .WithMessage(
+                    "ScopedCollections cannot be combined with GraphRag.IndexOnIngest: the corpus " +
+                    "graph is a single shared graph with no collection concept, so scoped ingests " +
+                    "would land every tenant's chunks in one graph readable via the GraphRag " +
+                    "strategy and the multi-source 'graph' source. Disable " +
+                    "AppConfig:AI:Rag:GraphRag:IndexOnIngest or AppConfig:AI:Rag:ScopedCollections.");
         });
     }
 }

--- a/src/Content/Domain/Domain.AI/KnowledgeGraph/Models/ErasureReceipt.cs
+++ b/src/Content/Domain/Domain.AI/KnowledgeGraph/Models/ErasureReceipt.cs
@@ -28,21 +28,33 @@ public record ErasureReceipt
     /// </summary>
     public required int FeedbackWeightsDeleted { get; init; }
     /// <summary>
-    /// Number of documents whose vector embeddings were submitted for deletion.
-    /// <c>IVectorStore.DeleteAsync</c> deletes by <em>document ID</em> and returns no per-item
-    /// confirmation, so this counts the distinct document IDs (derived from the erased nodes'
-    /// chunk IDs) submitted to the vector store — each call either succeeded or the erasure
-    /// faulted before producing a receipt. Zero when no vector store is configured.
+    /// Number of chunk embeddings the vector store <em>actually removed</em>, summed across
+    /// every collection (the erasure sweep uses the all-collections delete so per-tenant
+    /// scoped collections are reached), as returned by
+    /// <c>IVectorStore.DeleteFromAllCollectionsAsync</c>. Zero when no vector store is
+    /// configured — and zero when nothing matched, never the submitted document count.
     /// </summary>
     public required int VectorEmbeddingsDeleted { get; init; }
 
     /// <summary>
-    /// Number of documents whose BM25/full-text rows were submitted for deletion, by document
-    /// ID (derived from the erased nodes' chunk IDs). RAPTOR summary rows share the same
-    /// document ID and drop out via the same document-scoped delete. Zero when no BM25 store
-    /// is configured. Defaults to zero so pre-existing construction sites remain valid.
+    /// Number of BM25/full-text rows <em>actually removed</em>, summed across every
+    /// collection, as returned by <c>IBm25Store.DeleteFromAllCollectionsAsync</c>. RAPTOR
+    /// summary rows share the parent document ID and drop out via the same delete. Zero when
+    /// no BM25 store is configured — and zero when nothing matched, never the submitted
+    /// document count. Defaults to zero so pre-existing construction sites remain valid.
     /// </summary>
     public int Bm25DocumentsDeleted { get; init; }
+
+    /// <summary>
+    /// Document IDs that were derived from the erased nodes' chunk IDs and submitted to the
+    /// derived-content sweep, but matched <em>zero</em> rows in every configured store. A
+    /// non-empty list is the receipt's honest detail that content the graph manifest points
+    /// at was not found where the stores looked — instead of silently counting those
+    /// documents as purged. Empty when every submitted document matched rows or no
+    /// vector/BM25 store is configured. Defaults to empty so pre-existing construction sites
+    /// remain valid.
+    /// </summary>
+    public IReadOnlyList<string> UnmatchedDocumentIds { get; init; } = [];
 
     /// <summary>
     /// Number of cross-session memory records purged for the erased owner, across the store's

--- a/src/Content/Domain/Domain.AI/RAG/Models/ChunkMetadata.cs
+++ b/src/Content/Domain/Domain.AI/RAG/Models/ChunkMetadata.cs
@@ -41,4 +41,30 @@ public record ChunkMetadata
     /// a single chunk provides insufficient context for generation.
     /// </summary>
     public IReadOnlyList<string> SiblingChunkIds { get; init; } = [];
+
+    /// <summary>
+    /// The user who ingested the source document, captured from the ambient
+    /// knowledge scope at ingestion time. Null when the ingest ran without an
+    /// authenticated identity (in-process or CLI callers).
+    /// </summary>
+    /// <remarks>
+    /// This is <strong>provenance, not access control</strong>: retrieval never filters
+    /// on it, and the shared-corpus search behavior is unchanged by its presence. It
+    /// exists so a future right-to-erasure sweep can find every chunk a given user
+    /// contributed — without the stamp there is nothing to sweep by.
+    /// </remarks>
+    public string? OwnerId { get; init; }
+
+    /// <summary>
+    /// The tenant of the caller who ingested the source document, captured from the
+    /// ambient knowledge scope at ingestion time. Null when the ingest ran without an
+    /// authenticated identity (in-process or CLI callers) or in single-tenant deployments.
+    /// </summary>
+    /// <remarks>
+    /// Like <see cref="OwnerId"/>, this is provenance only. Tenant-level <em>isolation</em>
+    /// of the RAG corpus is a separate, opt-in concern
+    /// (<c>AppConfig:AI:Rag:ScopedCollections</c>); the stamp is written regardless of
+    /// that flag so erasure and audit remain possible for the shared corpus too.
+    /// </remarks>
+    public string? TenantId { get; init; }
 }

--- a/src/Content/Domain/Domain.AI/RAG/Models/ScopedCollectionName.cs
+++ b/src/Content/Domain/Domain.AI/RAG/Models/ScopedCollectionName.cs
@@ -1,0 +1,134 @@
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Domain.AI.RAG.Models;
+
+/// <summary>
+/// Derives the effective RAG collection name for a request when per-tenant collection
+/// isolation (<c>AppConfig:AI:Rag:ScopedCollections</c>) is enabled. The derivation is
+/// server-side only: caller-supplied collection names are rejected at validation when the
+/// feature is on, so the collection a request reads or writes is always a pure function of
+/// the caller's ambient tenant — never of request content.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>Derivation scheme.</strong> The tenant id is normalized with trim + lowercase
+/// (the same normalization idea as <c>KnowledgeMemoryService</c>'s private scope-key
+/// sanitization, though the character policy here is broader because collection names
+/// must satisfy store naming rules), then rendered as <c>tenant-{slug}-{hash}</c> where
+/// <c>{slug}</c> is the normalized tenant with every non <c>[a-z0-9]</c> character
+/// collapsed to a single dash (capped at <see cref="MaxSlugLength"/> characters, for
+/// readability in store dashboards) and <c>{hash}</c> is the first
+/// <see cref="HashLength"/> (16) hex characters — 64 bits — of the SHA-256 of the
+/// normalized tenant. The hash suffix makes the name collision-safe: two distinct tenants
+/// whose slugs sanitize to the same string still get distinct collections, and 64 bits
+/// puts a deliberately crafted colliding tenant id (which would merge two tenants'
+/// collections) out of offline-grinding reach.
+/// </para>
+/// <para>
+/// The output alphabet (<c>[a-z0-9-]</c>, starts with a letter, ≤ 56 characters) is valid
+/// for every store the harness ships: FAISS in-memory collection keys, SQLite FTS5
+/// collection values, and Azure AI Search index naming rules.
+/// </para>
+/// <para>
+/// <strong>No-identity semantics.</strong> A caller with no ambient tenant resolves to
+/// <see langword="null"/> — the store's global/default collection. This is closed and
+/// predictable: anonymous and in-process callers share one well-known collection and can
+/// never read or write a tenant-derived one.
+/// </para>
+/// </remarks>
+public static class ScopedCollectionName
+{
+    /// <summary>Prefix of every tenant-derived collection name.</summary>
+    public const string Prefix = "tenant-";
+
+    /// <summary>Maximum length of the human-readable slug segment.</summary>
+    public const int MaxSlugLength = 32;
+
+    /// <summary>
+    /// Length of the SHA-256 hex suffix (16 hex characters = 64 bits). Sized so that
+    /// deliberately crafting a tenant id whose derived name collides with another
+    /// tenant's is computationally infeasible offline.
+    /// </summary>
+    public const int HashLength = 16;
+
+    /// <summary>
+    /// Resolves the effective collection name for an ingest or search request.
+    /// </summary>
+    /// <param name="scopedCollectionsEnabled">
+    /// Whether <c>AppConfig:AI:Rag:ScopedCollections:Enabled</c> is on.
+    /// </param>
+    /// <param name="requestedCollectionName">
+    /// The caller-supplied collection name from the request DTO. Honored only when the
+    /// feature is off; when the feature is on it is ignored entirely (defense in depth —
+    /// request validation has already rejected non-null values).
+    /// </param>
+    /// <param name="tenantId">The ambient tenant of the caller, if any.</param>
+    /// <returns>
+    /// The collection name to pass to the vector and BM25 stores: the caller's value when
+    /// the feature is off; the tenant-derived name when the feature is on and a tenant is
+    /// present; <see langword="null"/> (the global/default collection) when the feature is
+    /// on and no tenant is present.
+    /// </returns>
+    public static string? Resolve(
+        bool scopedCollectionsEnabled,
+        string? requestedCollectionName,
+        string? tenantId)
+        => scopedCollectionsEnabled ? DeriveForTenant(tenantId) : requestedCollectionName;
+
+    /// <summary>
+    /// Derives the deterministic, collision-safe collection name for a tenant, or
+    /// <see langword="null"/> when <paramref name="tenantId"/> is null or whitespace
+    /// (the global/default collection).
+    /// </summary>
+    /// <param name="tenantId">The tenant identifier to derive from.</param>
+    /// <returns>The derived collection name, e.g. <c>tenant-contoso-a1b2c3d4</c>.</returns>
+    public static string? DeriveForTenant(string? tenantId)
+    {
+        if (string.IsNullOrWhiteSpace(tenantId))
+        {
+            return null;
+        }
+
+        var normalized = tenantId.Trim().ToLowerInvariant();
+        var hash = Convert.ToHexStringLower(
+            SHA256.HashData(Encoding.UTF8.GetBytes(normalized)))[..HashLength];
+        var slug = Slugify(normalized);
+
+        return $"{Prefix}{slug}-{hash}";
+    }
+
+    /// <summary>
+    /// Collapses every non <c>[a-z0-9]</c> character run to a single dash, trims leading
+    /// and trailing dashes, and caps the result at <see cref="MaxSlugLength"/> characters.
+    /// An input with no usable characters yields the placeholder slug <c>"t"</c> — the
+    /// hash suffix still disambiguates such tenants.
+    /// </summary>
+    private static string Slugify(string normalized)
+    {
+        var builder = new StringBuilder(Math.Min(normalized.Length, MaxSlugLength));
+        var lastWasDash = false;
+
+        foreach (var c in normalized)
+        {
+            if (builder.Length >= MaxSlugLength)
+            {
+                break;
+            }
+
+            if (c is >= 'a' and <= 'z' or >= '0' and <= '9')
+            {
+                builder.Append(c);
+                lastWasDash = false;
+            }
+            else if (!lastWasDash && builder.Length > 0)
+            {
+                builder.Append('-');
+                lastWasDash = true;
+            }
+        }
+
+        var slug = builder.ToString().TrimEnd('-');
+        return slug.Length == 0 ? "t" : slug;
+    }
+}

--- a/src/Content/Domain/Domain.Common/Config/AI/RAG/RagConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/RAG/RagConfig.cs
@@ -25,7 +25,8 @@ namespace Domain.Common.Config.AI.RAG;
 /// ├── MultiSource        — Multi-source retrieval orchestration
 /// ├── QualityGate        — CI/CD retrieval quality gates
 /// ├── WebSearch          — Web search retrieval source
-/// └── SqlDatabase        — SQL database retrieval source (disabled by default)
+/// ├── SqlDatabase        — SQL database retrieval source (disabled by default)
+/// └── ScopedCollections  — Opt-in per-tenant collection isolation (off by default)
 /// </code>
 /// </para>
 /// <para>
@@ -113,4 +114,11 @@ public class RagConfig
 
     /// <summary>SQL database retrieval source configuration (disabled by default).</summary>
     public SqlDatabaseConfig SqlDatabase { get; set; } = new();
+
+    /// <summary>
+    /// Opt-in per-tenant collection isolation for the document corpus (off by default).
+    /// When enabled, ingest and search collections are derived server-side from the
+    /// caller's tenant and caller-supplied collection names are rejected.
+    /// </summary>
+    public ScopedCollectionsConfig ScopedCollections { get; set; } = new();
 }

--- a/src/Content/Domain/Domain.Common/Config/AI/RAG/ScopedCollectionsConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/RAG/ScopedCollectionsConfig.cs
@@ -13,7 +13,12 @@ namespace Domain.Common.Config.AI.RAG;
 /// <para>
 /// <strong>Off by default.</strong> When disabled, the corpus keeps today's deliberate
 /// shared-corpus behavior: caller-supplied collection names are honored as before and
-/// nothing about collection naming changes.
+/// nothing about collection naming changes. One behavioral release-note applies
+/// regardless of this flag: the SQLite FTS5 BM25 store now partitions by collection
+/// <em>unconditionally</em> (it previously ignored collection names while the FAISS
+/// vector store partitioned — a dense/sparse asymmetry that leaked across collections),
+/// so flag-off callers who ingested under one collection name and searched under another
+/// relied on that bug and will see the corrected, partitioned behavior.
 /// </para>
 /// <para>
 /// <strong>Derivation.</strong> The effective collection is

--- a/src/Content/Domain/Domain.Common/Config/AI/RAG/ScopedCollectionsConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/RAG/ScopedCollectionsConfig.cs
@@ -1,0 +1,70 @@
+namespace Domain.Common.Config.AI.RAG;
+
+/// <summary>
+/// Opt-in per-tenant isolation of the RAG document corpus. When enabled, the collection
+/// that ingest writes to and search reads from is derived server-side from the caller's
+/// ambient tenant (see <c>ScopedCollectionName</c> in <c>Domain.AI</c>), and any
+/// caller-supplied collection name on an ingest or search request is rejected with a
+/// validation failure — otherwise a caller could name another tenant's collection and turn
+/// the parameter into a cross-tenant read primitive.
+/// Bound from <c>AppConfig:AI:Rag:ScopedCollections</c> in appsettings.json.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>Off by default.</strong> When disabled, the corpus keeps today's deliberate
+/// shared-corpus behavior: caller-supplied collection names are honored as before and
+/// nothing about collection naming changes.
+/// </para>
+/// <para>
+/// <strong>Derivation.</strong> The effective collection is
+/// <c>tenant-{slug}-{hash}</c> — a sanitized rendering of the ambient tenant id suffixed
+/// with 16 hex characters (64 bits) of its SHA-256, deterministic and collision-safe
+/// (trim + lowercase normalization). A caller with <em>no</em> ambient tenant resolves to
+/// the global/default collection — closed and predictable, not an error: anonymous and
+/// in-process callers share one well-known collection and can never reach a
+/// tenant-derived one.
+/// </para>
+/// <para>
+/// <strong>Enforcement.</strong> Belt and braces: the MediatR request validators reject
+/// caller-supplied collection names, and the shared entry points every retrieval path
+/// converges on (<c>RagOrchestrator.SearchAsync</c> and <c>HybridRetriever.RetrieveAsync</c>)
+/// re-derive the collection from the ambient tenant regardless of what was passed in — so
+/// agent tools, planner steps, and workflow executors that bypass the MediatR pipeline
+/// cannot name another tenant's collection either. Resolution is idempotent, so the
+/// double application is harmless.
+/// </para>
+/// <para>
+/// <strong>Which retrieval sources honor scoping.</strong> The hybrid dense + sparse
+/// pipeline honors it end-to-end with the local store pairing
+/// (<c>VectorStore.Provider = "faiss"</c>: FAISS partitions by collection natively and the
+/// SQLite FTS5 BM25 store partitions by a per-row collection value). The multi-source
+/// orchestrator forwards the derived collection to its <c>"vector"</c> source. Sources
+/// that are <em>not</em> collection-scoped and remain tenant-shared when enabled:
+/// <list type="bullet">
+///   <item><c>"graph"</c> — the corpus graph built by <c>GraphRag.IndexOnIngest</c> is a
+///     single shared graph (the tenant-isolated knowledge graph store is a separate
+///     surface with its own per-record isolation).</item>
+///   <item><c>"web_search"</c> and <c>"sql_database"</c> — external sources with no
+///     collection concept.</item>
+/// </list>
+/// Three combinations cannot honor scoping at all and are rejected at startup by
+/// <c>RagConfigValidator</c> rather than allowed to leak silently:
+/// <c>VectorStore.Provider = "azure_ai_search"</c> (both Azure stores query one
+/// pre-provisioned index and ignore collection names; supporting scoping there requires
+/// per-tenant index provisioning, which the harness deliberately leaves to
+/// infrastructure), <c>AgenticRetrieval.Enabled = true</c> (the knowledge-base
+/// retriever always queries the one configured knowledge base), and
+/// <c>GraphRag.IndexOnIngest = true</c> (the corpus graph is one shared graph, so scoped
+/// ingests would land every tenant's chunks in a graph readable by all).
+/// </para>
+/// </remarks>
+public class ScopedCollectionsConfig
+{
+    /// <summary>
+    /// Gets or sets a value indicating whether per-tenant collection isolation is active.
+    /// When <c>false</c> (default), the corpus is shared and caller-supplied collection
+    /// names are honored unchanged. When <c>true</c>, collection names are derived
+    /// server-side from the ambient tenant and caller-supplied names are rejected.
+    /// </summary>
+    public bool Enabled { get; set; }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/Compliance/DefaultErasureOrchestrator.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/Compliance/DefaultErasureOrchestrator.cs
@@ -183,6 +183,12 @@ public sealed class DefaultErasureOrchestrator : IErasureOrchestrator
         //    rows) by DOCUMENT id. Vector/BM25 delete by documentId, NOT chunkId — chunk IDs are
         //    "{documentId}_chunk_{i}" / "{documentId}_raptor_L{l}_C{c}", so we derive the document
         //    prefix. RAPTOR rows share the parent document id and drop out via the same delete.
+        //    The sweep uses the ALL-collections delete: with ScopedCollections a document's
+        //    chunks live in a tenant-derived collection, and a default-collection delete would
+        //    remove nothing while the receipt still reported the purge — a compliance-grade
+        //    over-report of a no-op. Counts come from the stores (rows actually removed), and a
+        //    document that matched zero rows in every configured store is surfaced on the receipt
+        //    instead of silently counting as done.
         var documentIds = nodes
             .SelectMany(n => n.ChunkIds)
             .Select(DeriveDocumentId)
@@ -190,26 +196,25 @@ public sealed class DefaultErasureOrchestrator : IErasureOrchestrator
             .Distinct(StringComparer.Ordinal)
             .ToList();
 
-        var vectorDocsDeleted = 0;
-        var bm25DocsDeleted = 0;
-        if (documentIds.Count > 0)
+        var vectorChunksDeleted = 0;
+        var bm25RowsDeleted = 0;
+        var unmatchedDocumentIds = new List<string>();
+        foreach (var documentId in documentIds)
         {
-            if (_vectorStore is not null)
-            {
-                foreach (var documentId in documentIds)
-                {
-                    await _vectorStore.DeleteAsync(documentId, cancellationToken: cancellationToken);
-                    vectorDocsDeleted++;
-                }
-            }
+            var vectorDeleted = _vectorStore is not null
+                ? await _vectorStore.DeleteFromAllCollectionsAsync(documentId, cancellationToken)
+                : 0;
+            var bm25Deleted = _bm25Store is not null
+                ? await _bm25Store.DeleteFromAllCollectionsAsync(documentId, cancellationToken)
+                : 0;
 
-            if (_bm25Store is not null)
+            vectorChunksDeleted += vectorDeleted;
+            bm25RowsDeleted += bm25Deleted;
+
+            if ((_vectorStore is not null || _bm25Store is not null)
+                && vectorDeleted == 0 && bm25Deleted == 0)
             {
-                foreach (var documentId in documentIds)
-                {
-                    await _bm25Store.DeleteAsync(documentId, cancellationToken: cancellationToken);
-                    bm25DocsDeleted++;
-                }
+                unmatchedDocumentIds.Add(documentId);
             }
         }
 
@@ -248,9 +253,10 @@ public sealed class DefaultErasureOrchestrator : IErasureOrchestrator
             NodesDeleted = nodeDeletion.NodesDeleted,
             EdgesDeleted = deletedEdgeIds.Count,
             FeedbackWeightsDeleted = nodeWeightsDeleted + edgeWeightsDeleted,
-            VectorEmbeddingsDeleted = vectorDocsDeleted,
-            Bm25DocumentsDeleted = bm25DocsDeleted,
+            VectorEmbeddingsDeleted = vectorChunksDeleted,
+            Bm25DocumentsDeleted = bm25RowsDeleted,
             CrossSessionMemoriesDeleted = crossSessionDeleted,
+            UnmatchedDocumentIds = unmatchedDocumentIds,
             Completeness = completeness,
             CompletenessReason = completenessReason
         };
@@ -272,10 +278,12 @@ public sealed class DefaultErasureOrchestrator : IErasureOrchestrator
 
         _logger.LogInformation(
             "Erasure completed: RequestId={RequestId}, Completeness={Completeness}, Nodes={Nodes}, " +
-            "Edges={Edges}, FeedbackWeights={FeedbackWeights}, VectorDocs={VectorDocs}, " +
-            "Bm25Docs={Bm25Docs}, CrossSessionMemories={CrossSessionMemories}{Reason}",
+            "Edges={Edges}, FeedbackWeights={FeedbackWeights}, VectorChunks={VectorChunks}, " +
+            "Bm25Rows={Bm25Rows}, CrossSessionMemories={CrossSessionMemories}, " +
+            "UnmatchedDocuments={UnmatchedDocuments}{Reason}",
             requestId, completeness, receipt.NodesDeleted, receipt.EdgesDeleted,
-            receipt.FeedbackWeightsDeleted, vectorDocsDeleted, bm25DocsDeleted, crossSessionDeleted,
+            receipt.FeedbackWeightsDeleted, vectorChunksDeleted, bm25RowsDeleted, crossSessionDeleted,
+            unmatchedDocumentIds.Count,
             completenessReason is null ? string.Empty : $", Reason={completenessReason}");
 
         return receipt;

--- a/src/Content/Infrastructure/Infrastructure.AI.RAG/DependencyInjection.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.RAG/DependencyInjection.cs
@@ -77,6 +77,9 @@ public static partial class DependencyInjection
                 sp.GetService<IRetrievalDecisionGate>(),
                 sp.GetService<IIterativeRetriever>(),
                 sp.GetService<IAnswerFaithfulnessEvaluator>(),
-                sp.GetKeyedService<IRetrievalSource>("web_search")));
+                sp.GetKeyedService<IRetrievalSource>("web_search"),
+                // ScopedCollections choke point: the orchestrator re-derives the effective
+                // collection from the ambient caller's tenant on every search.
+                sp.GetRequiredService<Application.AI.Common.Interfaces.IAmbientRequestScope>()));
     }
 }

--- a/src/Content/Infrastructure/Infrastructure.AI.RAG/DependencyInjection.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.RAG/DependencyInjection.cs
@@ -74,12 +74,12 @@ public static partial class DependencyInjection
                 sp.GetService<IRetrievalCostTracker>(),
                 sp.GetRequiredService<IOptionsMonitor<AppConfig>>(),
                 sp.GetRequiredService<ILogger<RagOrchestrator>>(),
+                // ScopedCollections choke point: the orchestrator re-derives the effective
+                // collection from the ambient caller's tenant on every search.
+                sp.GetRequiredService<Application.AI.Common.Interfaces.IAmbientRequestScope>(),
                 sp.GetService<IRetrievalDecisionGate>(),
                 sp.GetService<IIterativeRetriever>(),
                 sp.GetService<IAnswerFaithfulnessEvaluator>(),
-                sp.GetKeyedService<IRetrievalSource>("web_search"),
-                // ScopedCollections choke point: the orchestrator re-derives the effective
-                // collection from the ambient caller's tenant on every search.
-                sp.GetRequiredService<Application.AI.Common.Interfaces.IAmbientRequestScope>()));
+                sp.GetKeyedService<IRetrievalSource>("web_search")));
     }
 }

--- a/src/Content/Infrastructure/Infrastructure.AI.RAG/Orchestration/GraphRetrievalSource.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.RAG/Orchestration/GraphRetrievalSource.cs
@@ -16,8 +16,18 @@ internal sealed class GraphRetrievalSource(IGraphRagService graphRagService) : I
     public string SourceName => "graph";
 
     /// <inheritdoc />
+    /// <remarks>
+    /// The corpus graph is a single shared graph with no collection concept, so
+    /// <paramref name="collectionName"/> is accepted and ignored: graph retrieval stays
+    /// tenant-shared even when <c>ScopedCollections</c> is enabled (documented on
+    /// <c>ScopedCollectionsConfig</c>).
+    /// </remarks>
     public async Task<SourceRetrievalResult> RetrieveAsync(
-        string query, int topK, TaskComplexity complexity, CancellationToken cancellationToken)
+        string query,
+        int topK,
+        TaskComplexity complexity,
+        string? collectionName = null,
+        CancellationToken cancellationToken = default)
     {
         var sw = Stopwatch.StartNew();
         var results = await graphRagService.LocalSearchAsync(query, topK, cancellationToken);

--- a/src/Content/Infrastructure/Infrastructure.AI.RAG/Orchestration/MultiSourceOrchestrator.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.RAG/Orchestration/MultiSourceOrchestrator.cs
@@ -54,6 +54,7 @@ public sealed class MultiSourceOrchestrator : IMultiSourceOrchestrator
         string query,
         int topK,
         TaskComplexity complexity,
+        string? collectionName = null,
         CancellationToken cancellationToken = default)
     {
         using var activity = ActivitySource.StartActivity("rag.multi_source.retrieve");
@@ -68,7 +69,7 @@ public sealed class MultiSourceOrchestrator : IMultiSourceOrchestrator
             complexity, string.Join(", ", sourcesToQuery), topK);
 
         var sourceResults = await FanOutToSourcesAsync(
-            query, topK, complexity, sourcesToQuery, config.SourceTimeout, cancellationToken);
+            query, topK, complexity, collectionName, sourcesToQuery, config.SourceTimeout, cancellationToken);
 
         var allResults = new List<RetrievalResult>();
         foreach (var sourceResult in sourceResults)
@@ -107,12 +108,14 @@ public sealed class MultiSourceOrchestrator : IMultiSourceOrchestrator
         string query,
         int topK,
         TaskComplexity complexity,
+        string? collectionName,
         IReadOnlyList<string> sources,
         TimeSpan sourceTimeout,
         CancellationToken cancellationToken)
     {
         var tasks = sources.Select(source =>
-            ExecuteSourceWithTimeoutAsync(source, query, topK, complexity, sourceTimeout, cancellationToken));
+            ExecuteSourceWithTimeoutAsync(
+                source, query, topK, complexity, collectionName, sourceTimeout, cancellationToken));
 
         var results = await Task.WhenAll(tasks);
         return results.Where(r => r is not null).Cast<SourceRetrievalResult>().ToList();
@@ -123,6 +126,7 @@ public sealed class MultiSourceOrchestrator : IMultiSourceOrchestrator
         string query,
         int topK,
         TaskComplexity complexity,
+        string? collectionName,
         TimeSpan timeout,
         CancellationToken cancellationToken)
     {
@@ -138,7 +142,7 @@ public sealed class MultiSourceOrchestrator : IMultiSourceOrchestrator
 
         try
         {
-            return await source.RetrieveAsync(query, topK, complexity, timeoutCts.Token);
+            return await source.RetrieveAsync(query, topK, complexity, collectionName, timeoutCts.Token);
         }
         catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
         {

--- a/src/Content/Infrastructure/Infrastructure.AI.RAG/Orchestration/RagOrchestrator.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.RAG/Orchestration/RagOrchestrator.cs
@@ -59,7 +59,7 @@ public sealed partial class RagOrchestrator : IRagOrchestrator
     private readonly IFeedbackWeightedScorer? _feedbackScorer;
     private readonly QueryRouter _queryRouter;
     private readonly IMultiSourceOrchestrator? _multiSourceOrchestrator;
-    private readonly IAmbientRequestScope? _ambientScope;
+    private readonly IAmbientRequestScope _ambientScope;
     private readonly ITaskComplexityClassifier? _complexityClassifier;
     private readonly IRetrievalCostTracker? _costTracker;
     private readonly IOptionsMonitor<AppConfig> _configMonitor;
@@ -105,11 +105,11 @@ public sealed partial class RagOrchestrator : IRagOrchestrator
         IRetrievalCostTracker? costTracker,
         IOptionsMonitor<AppConfig> configMonitor,
         ILogger<RagOrchestrator> logger,
+        IAmbientRequestScope ambientScope,
         IRetrievalDecisionGate? decisionGate = null,
         IIterativeRetriever? iterativeRetriever = null,
         IAnswerFaithfulnessEvaluator? faithfulnessEvaluator = null,
-        IRetrievalSource? webSearchSource = null,
-        IAmbientRequestScope? ambientScope = null)
+        IRetrievalSource? webSearchSource = null)
     {
         ArgumentNullException.ThrowIfNull(hybridRetriever);
         ArgumentNullException.ThrowIfNull(reranker);
@@ -118,6 +118,9 @@ public sealed partial class RagOrchestrator : IRagOrchestrator
         ArgumentNullException.ThrowIfNull(queryRouter);
         ArgumentNullException.ThrowIfNull(configMonitor);
         ArgumentNullException.ThrowIfNull(logger);
+        // Required (not optional): a directly-constructed orchestrator without the ambient
+        // bridge would fail OPEN to the shared corpus under ScopedCollections.
+        ArgumentNullException.ThrowIfNull(ambientScope);
 
         _hybridRetriever = hybridRetriever;
         _reranker = reranker;
@@ -154,7 +157,7 @@ public sealed partial class RagOrchestrator : IRagOrchestrator
             return requestedCollectionName;
         }
 
-        var scope = _ambientScope?.Current?.GetService(typeof(IKnowledgeScope)) as IKnowledgeScope;
+        var scope = _ambientScope.Current?.GetService(typeof(IKnowledgeScope)) as IKnowledgeScope;
         return ScopedCollectionName.Resolve(
             scopedCollectionsEnabled: true, requestedCollectionName, scope?.TenantId);
     }

--- a/src/Content/Infrastructure/Infrastructure.AI.RAG/Orchestration/RagOrchestrator.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.RAG/Orchestration/RagOrchestrator.cs
@@ -1,4 +1,6 @@
 using System.Diagnostics;
+using Application.AI.Common.Interfaces;
+using Application.AI.Common.Interfaces.KnowledgeGraph;
 using Application.AI.Common.Interfaces.RAG;
 using Application.AI.Common.Interfaces.Routing;
 using Application.AI.Common.OpenTelemetry.Metrics;
@@ -57,6 +59,7 @@ public sealed partial class RagOrchestrator : IRagOrchestrator
     private readonly IFeedbackWeightedScorer? _feedbackScorer;
     private readonly QueryRouter _queryRouter;
     private readonly IMultiSourceOrchestrator? _multiSourceOrchestrator;
+    private readonly IAmbientRequestScope? _ambientScope;
     private readonly ITaskComplexityClassifier? _complexityClassifier;
     private readonly IRetrievalCostTracker? _costTracker;
     private readonly IOptionsMonitor<AppConfig> _configMonitor;
@@ -105,7 +108,8 @@ public sealed partial class RagOrchestrator : IRagOrchestrator
         IRetrievalDecisionGate? decisionGate = null,
         IIterativeRetriever? iterativeRetriever = null,
         IAnswerFaithfulnessEvaluator? faithfulnessEvaluator = null,
-        IRetrievalSource? webSearchSource = null)
+        IRetrievalSource? webSearchSource = null,
+        IAmbientRequestScope? ambientScope = null)
     {
         ArgumentNullException.ThrowIfNull(hybridRetriever);
         ArgumentNullException.ThrowIfNull(reranker);
@@ -131,6 +135,28 @@ public sealed partial class RagOrchestrator : IRagOrchestrator
         _iterativeRetriever = iterativeRetriever;
         _faithfulnessEvaluator = faithfulnessEvaluator;
         _webSearchSource = webSearchSource;
+        _ambientScope = ambientScope;
+    }
+
+    /// <summary>
+    /// Resolves the effective collection for this request. When
+    /// <c>AppConfig:AI:Rag:ScopedCollections</c> is off, the caller's value passes through
+    /// unchanged. When on, the caller-supplied name is discarded and the collection is
+    /// derived from the ambient caller's tenant (resolved per operation via
+    /// <see cref="IAmbientRequestScope"/>, the same singleton-safe bridge
+    /// <c>TenantIsolatedGraphStore</c> uses); no ambient identity resolves to the
+    /// global/default collection — closed, never an error.
+    /// </summary>
+    private string? ResolveScopedCollection(string? requestedCollectionName)
+    {
+        if (!_configMonitor.CurrentValue.AI.Rag.ScopedCollections.Enabled)
+        {
+            return requestedCollectionName;
+        }
+
+        var scope = _ambientScope?.Current?.GetService(typeof(IKnowledgeScope)) as IKnowledgeScope;
+        return ScopedCollectionName.Resolve(
+            scopedCollectionsEnabled: true, requestedCollectionName, scope?.TenantId);
     }
 
     /// <inheritdoc />
@@ -141,6 +167,14 @@ public sealed partial class RagOrchestrator : IRagOrchestrator
         RetrievalStrategy? strategyOverride = null,
         CancellationToken cancellationToken = default)
     {
+        // ScopedCollections choke point: every retrieval path converges on this entry
+        // (HTTP handlers, agent tools, planner steps), so the effective collection is
+        // resolved HERE from the ambient caller identity — a caller-supplied name can
+        // never survive when scoping is on. Resolution is idempotent: MediatR handlers
+        // resolve the same way before calling in, and re-deriving from the same ambient
+        // tenant yields the same name.
+        collectionName = ResolveScopedCollection(collectionName);
+
         using var activity = ActivitySource.StartActivity("rag.orchestrator.search");
         var sw = Stopwatch.StartNew();
         var ragConfig = _configMonitor.CurrentValue.AI.Rag;
@@ -227,7 +261,7 @@ public sealed partial class RagOrchestrator : IRagOrchestrator
                      && _complexityClassifier is not null)
             {
                 result = await ExecuteMultiSourcePipelineAsync(
-                    query, effectiveTopK, cancellationToken);
+                    query, effectiveTopK, collectionName, cancellationToken);
             }
             else
             {
@@ -455,7 +489,7 @@ public sealed partial class RagOrchestrator : IRagOrchestrator
     }
 
     private async Task<RagAssembledContext> ExecuteMultiSourcePipelineAsync(
-        string query, int topK, CancellationToken cancellationToken)
+        string query, int topK, string? collectionName, CancellationToken cancellationToken)
     {
         using var activity = ActivitySource.StartActivity("rag.orchestrator.multi_source_pipeline");
         var classification = await _complexityClassifier!.ClassifyAsync(
@@ -467,7 +501,7 @@ public sealed partial class RagOrchestrator : IRagOrchestrator
             classification!.Complexity, classification.Confidence);
 
         var candidates = await _multiSourceOrchestrator!.RetrieveFromAllSourcesAsync(
-            query, topK, classification.Complexity, cancellationToken);
+            query, topK, classification.Complexity, collectionName, cancellationToken);
 
         if (candidates.Count == 0)
         {
@@ -591,7 +625,7 @@ public sealed partial class RagOrchestrator : IRagOrchestrator
         CancellationToken cancellationToken)
     {
         var webResult = await _webSearchSource!.RetrieveAsync(
-            query, topK, TaskComplexity.Moderate, cancellationToken);
+            query, topK, TaskComplexity.Moderate, collectionName: null, cancellationToken);
 
         if (webResult.Results.Count == 0)
             return existing;

--- a/src/Content/Infrastructure/Infrastructure.AI.RAG/Orchestration/VectorRetrievalSource.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.RAG/Orchestration/VectorRetrievalSource.cs
@@ -16,10 +16,15 @@ internal sealed class VectorRetrievalSource(IHybridRetriever hybridRetriever) : 
 
     /// <inheritdoc />
     public async Task<SourceRetrievalResult> RetrieveAsync(
-        string query, int topK, TaskComplexity complexity, CancellationToken cancellationToken)
+        string query,
+        int topK,
+        TaskComplexity complexity,
+        string? collectionName = null,
+        CancellationToken cancellationToken = default)
     {
         var sw = Stopwatch.StartNew();
-        var results = await hybridRetriever.RetrieveAsync(query, topK, cancellationToken: cancellationToken);
+        var results = await hybridRetriever.RetrieveAsync(
+            query, topK, collectionName, cancellationToken);
         sw.Stop();
 
         return new SourceRetrievalResult

--- a/src/Content/Infrastructure/Infrastructure.AI.RAG/Retrieval/AzureAISearchBm25Store.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.RAG/Retrieval/AzureAISearchBm25Store.cs
@@ -18,6 +18,20 @@ namespace Infrastructure.AI.RAG.Retrieval;
 /// scoring. The <c>embedding</c> field is not used by this store -- it only performs
 /// keyword-based full-text search.
 /// </para>
+/// <para>
+/// Owner/tenant provenance stamps (<c>ownerId</c>/<c>tenantId</c>) are written only when
+/// the ingesting caller carries an identity — see the schema notes on
+/// <see cref="AzureAISearchVectorStore"/>, which shares this index. Search results never
+/// include the stamps (the <c>Select</c> projection is kept to the pre-stamp fields):
+/// they are persisted for erasure, not for retrieval, and exposing them would tell every
+/// searcher who ingested each chunk.
+/// </para>
+/// <para>
+/// <strong>Collections are not honored.</strong> This store always queries the one index
+/// its <see cref="SearchClient"/> was built for; the <c>collectionName</c> parameter is
+/// ignored, and <c>RagConfigValidator</c> rejects
+/// <c>AppConfig:AI:Rag:ScopedCollections</c> with this provider.
+/// </para>
 /// </remarks>
 public sealed class AzureAISearchBm25Store : IBm25Store
 {
@@ -45,12 +59,29 @@ public sealed class AzureAISearchBm25Store : IBm25Store
     {
         if (chunks.Count == 0) return;
 
-        var documents = chunks.Select(chunk => new SearchDocument
+        var documents = chunks.Select(chunk =>
         {
-            ["id"] = chunk.Id,
-            ["documentId"] = chunk.DocumentId,
-            ["content"] = chunk.Content,
-            ["sectionPath"] = chunk.SectionPath,
+            var doc = new SearchDocument
+            {
+                ["id"] = chunk.Id,
+                ["documentId"] = chunk.DocumentId,
+                ["content"] = chunk.Content,
+                ["sectionPath"] = chunk.SectionPath,
+            };
+
+            // Written only when present so identity-less ingest keeps working against
+            // indexes provisioned before the provenance fields existed.
+            if (chunk.Metadata.OwnerId is not null)
+            {
+                doc["ownerId"] = chunk.Metadata.OwnerId;
+            }
+
+            if (chunk.Metadata.TenantId is not null)
+            {
+                doc["tenantId"] = chunk.Metadata.TenantId;
+            }
+
+            return doc;
         }).ToList();
 
         var response = await _searchClient.MergeOrUploadDocumentsAsync(

--- a/src/Content/Infrastructure/Infrastructure.AI.RAG/Retrieval/AzureAISearchBm25Store.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.RAG/Retrieval/AzureAISearchBm25Store.cs
@@ -87,6 +87,12 @@ public sealed class AzureAISearchBm25Store : IBm25Store
         var response = await _searchClient.MergeOrUploadDocumentsAsync(
             documents, cancellationToken: cancellationToken);
 
+        // MergeOrUploadDocumentsAsync reports PER-DOCUMENT failures without throwing:
+        // treating a partial batch as success would let the ingest command report Success
+        // while chunks (and their provenance stamps) silently never landed. Failing the
+        // operation triggers the ingest handler's compensation path instead.
+        ThrowIfAnyFailed(response.Value, chunks.Count, "BM25 indexing");
+
         _logger.LogDebug(
             "Indexed {Count} chunks for BM25 into Azure AI Search, {Succeeded} succeeded",
             chunks.Count, response.Value.Results.Count(r => r.Succeeded));
@@ -129,7 +135,7 @@ public sealed class AzureAISearchBm25Store : IBm25Store
     }
 
     /// <inheritdoc />
-    public async Task DeleteAsync(
+    public async Task<int> DeleteAsync(
         string documentId,
         string? collectionName = null,
         CancellationToken cancellationToken = default)
@@ -151,15 +157,54 @@ public sealed class AzureAISearchBm25Store : IBm25Store
             keysToDelete.Add(new SearchDocument { ["id"] = result.Document["id"] });
         }
 
-        if (keysToDelete.Count > 0)
-        {
-            await _searchClient.DeleteDocumentsAsync(
-                keysToDelete, cancellationToken: cancellationToken);
+        if (keysToDelete.Count == 0) return 0;
 
-            _logger.LogInformation(
-                "Deleted {Count} BM25-indexed chunks for document {DocumentId}",
-                keysToDelete.Count, documentId);
+        var deleteResponse = await _searchClient.DeleteDocumentsAsync(
+            keysToDelete, cancellationToken: cancellationToken);
+
+        // Only confirmed deletions count — erasure receipts must never over-report.
+        var deleted = deleteResponse.Value.Results.Count(r => r.Succeeded);
+        var failed = keysToDelete.Count - deleted;
+        if (failed > 0)
+        {
+            _logger.LogError(
+                "Azure AI Search BM25 delete for document {DocumentId} failed for {FailedCount} of {Total} chunks",
+                documentId, failed, keysToDelete.Count);
         }
+
+        _logger.LogInformation(
+            "Deleted {Count} BM25-indexed chunks for document {DocumentId}",
+            deleted, documentId);
+
+        return deleted;
+    }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// The Azure store queries one pre-provisioned physical index and the collection
+    /// parameter has no meaning here (see the class remarks), so the all-collections
+    /// erasure delete is exactly the single-index delete.
+    /// </remarks>
+    public Task<int> DeleteFromAllCollectionsAsync(
+        string documentId,
+        CancellationToken cancellationToken = default) =>
+        DeleteAsync(documentId, collectionName: null, cancellationToken);
+
+    /// <summary>
+    /// Fails the operation when the Azure batch response reports any per-document
+    /// failure, with a structured log naming the failed count.
+    /// </summary>
+    private void ThrowIfAnyFailed(IndexDocumentsResult result, int total, string operation)
+    {
+        var failed = result.Results.Count(r => !r.Succeeded);
+        if (failed == 0) return;
+
+        _logger.LogError(
+            "Azure AI Search {Operation} failed for {FailedCount} of {Total} chunks",
+            operation, failed, total);
+        throw new InvalidOperationException(
+            $"Azure AI Search {operation} failed for {failed} of {total} chunks; " +
+            "the batch response reported per-document failures.");
     }
 
     private static DocumentChunk MapToChunk(SearchDocument doc) => new()

--- a/src/Content/Infrastructure/Infrastructure.AI.RAG/Retrieval/AzureAISearchVectorStore.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.RAG/Retrieval/AzureAISearchVectorStore.cs
@@ -22,7 +22,21 @@ namespace Infrastructure.AI.RAG.Retrieval;
 ///   <item><c>content</c> — searchable string for BM25 full-text search.</item>
 ///   <item><c>sectionPath</c> — searchable string for hierarchical navigation.</item>
 ///   <item><c>embedding</c> — vector field matching the configured dimensions.</item>
+///   <item><c>ownerId</c>, <c>tenantId</c> — filterable strings for the owner/tenant
+///     provenance stamps (the future erasure key). Written only when the ingesting caller
+///     carries an identity, so an index without these fields keeps working for
+///     identity-less ingest; a stamped ingest against such an index fails loudly rather
+///     than silently dropping the erasure key. The stamps are <strong>never returned on
+///     search results</strong>: they are erasure/audit data, and surfacing them would tell
+///     every searcher who ingested each chunk in the shared corpus.</item>
 /// </list>
+/// </para>
+/// <para>
+/// <strong>Collections are not honored.</strong> This store always queries the one index
+/// its <see cref="SearchClient"/> was built for; the <c>collectionName</c> parameter is
+/// ignored. <c>RagConfigValidator</c> therefore rejects
+/// <c>AppConfig:AI:Rag:ScopedCollections</c> with this provider — per-tenant isolation on
+/// Azure requires per-tenant index provisioning, which is an infrastructure concern.
 /// </para>
 /// </remarks>
 public sealed class AzureAISearchVectorStore : IVectorStore
@@ -68,6 +82,18 @@ public sealed class AzureAISearchVectorStore : IVectorStore
             if (chunk.Embedding is { Count: > 0 })
             {
                 doc["embedding"] = chunk.Embedding.ToArray();
+            }
+
+            // Written only when present so identity-less ingest keeps working against
+            // indexes provisioned before the provenance fields existed.
+            if (chunk.Metadata.OwnerId is not null)
+            {
+                doc["ownerId"] = chunk.Metadata.OwnerId;
+            }
+
+            if (chunk.Metadata.TenantId is not null)
+            {
+                doc["tenantId"] = chunk.Metadata.TenantId;
             }
 
             return doc;
@@ -159,6 +185,8 @@ public sealed class AzureAISearchVectorStore : IVectorStore
         }
     }
 
+    // ownerId/tenantId are deliberately NOT mapped: provenance stamps stay in the index
+    // for erasure and are never exposed on the read path.
     private static DocumentChunk MapToChunk(SearchDocument doc) => new()
     {
         Id = doc["id"]?.ToString() ?? string.Empty,

--- a/src/Content/Infrastructure/Infrastructure.AI.RAG/Retrieval/AzureAISearchVectorStore.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.RAG/Retrieval/AzureAISearchVectorStore.cs
@@ -102,6 +102,12 @@ public sealed class AzureAISearchVectorStore : IVectorStore
         var response = await _searchClient.MergeOrUploadDocumentsAsync(
             documents, cancellationToken: cancellationToken);
 
+        // MergeOrUploadDocumentsAsync reports PER-DOCUMENT failures without throwing:
+        // treating a partial batch as success would let the ingest command report Success
+        // while chunks (and their provenance stamps) silently never landed. Failing the
+        // operation triggers the ingest handler's compensation path instead.
+        ThrowIfAnyFailed(response.Value, chunks.Count, "vector indexing");
+
         _logger.LogDebug(
             "Indexed {Count} chunks into Azure AI Search, {Succeeded} succeeded",
             chunks.Count, response.Value.Results.Count(r => r.Succeeded));
@@ -152,7 +158,7 @@ public sealed class AzureAISearchVectorStore : IVectorStore
     }
 
     /// <inheritdoc />
-    public async Task DeleteAsync(
+    public async Task<int> DeleteAsync(
         string documentId,
         string? collectionName = null,
         CancellationToken cancellationToken = default)
@@ -174,15 +180,54 @@ public sealed class AzureAISearchVectorStore : IVectorStore
             keysToDelete.Add(new SearchDocument { ["id"] = result.Document["id"] });
         }
 
-        if (keysToDelete.Count > 0)
-        {
-            await _searchClient.DeleteDocumentsAsync(
-                keysToDelete, cancellationToken: cancellationToken);
+        if (keysToDelete.Count == 0) return 0;
 
-            _logger.LogInformation(
-                "Deleted {Count} chunks for document {DocumentId} from Azure AI Search",
-                keysToDelete.Count, documentId);
+        var deleteResponse = await _searchClient.DeleteDocumentsAsync(
+            keysToDelete, cancellationToken: cancellationToken);
+
+        // Only confirmed deletions count — erasure receipts must never over-report.
+        var deleted = deleteResponse.Value.Results.Count(r => r.Succeeded);
+        var failed = keysToDelete.Count - deleted;
+        if (failed > 0)
+        {
+            _logger.LogError(
+                "Azure AI Search delete for document {DocumentId} failed for {FailedCount} of {Total} chunks",
+                documentId, failed, keysToDelete.Count);
         }
+
+        _logger.LogInformation(
+            "Deleted {Count} chunks for document {DocumentId} from Azure AI Search",
+            deleted, documentId);
+
+        return deleted;
+    }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// The Azure store queries one pre-provisioned physical index and the collection
+    /// parameter has no meaning here (see the class remarks), so the all-collections
+    /// erasure delete is exactly the single-index delete.
+    /// </remarks>
+    public Task<int> DeleteFromAllCollectionsAsync(
+        string documentId,
+        CancellationToken cancellationToken = default) =>
+        DeleteAsync(documentId, collectionName: null, cancellationToken);
+
+    /// <summary>
+    /// Fails the operation when the Azure batch response reports any per-document
+    /// failure, with a structured log naming the failed count.
+    /// </summary>
+    private void ThrowIfAnyFailed(IndexDocumentsResult result, int total, string operation)
+    {
+        var failed = result.Results.Count(r => !r.Succeeded);
+        if (failed == 0) return;
+
+        _logger.LogError(
+            "Azure AI Search {Operation} failed for {FailedCount} of {Total} chunks",
+            operation, failed, total);
+        throw new InvalidOperationException(
+            $"Azure AI Search {operation} failed for {failed} of {total} chunks; " +
+            "the batch response reported per-document failures.");
     }
 
     // ownerId/tenantId are deliberately NOT mapped: provenance stamps stay in the index

--- a/src/Content/Infrastructure/Infrastructure.AI.RAG/Retrieval/FaissVectorStore.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.RAG/Retrieval/FaissVectorStore.cs
@@ -90,7 +90,7 @@ public sealed class FaissVectorStore : IVectorStore
             .Take(topK)
             .Select(s => new RetrievalResult
             {
-                Chunk = s.Chunk,
+                Chunk = StripProvenance(s.Chunk),
                 DenseScore = s.Score,
                 SparseScore = 0.0,
                 FusedScore = s.Score,
@@ -99,6 +99,18 @@ public sealed class FaissVectorStore : IVectorStore
 
         return Task.FromResult<IReadOnlyList<RetrievalResult>>(results);
     }
+
+    /// <summary>
+    /// Projects the owner/tenant provenance stamps out of a search result. The stamps
+    /// stay on the stored record (they are the future erasure key) but are never exposed
+    /// on the read path — surfacing them would tell every searcher who ingested each
+    /// chunk, and the persistent stores (SQLite FTS5, Azure AI Search) omit them from
+    /// reads for the same reason.
+    /// </summary>
+    private static DocumentChunk StripProvenance(DocumentChunk chunk) =>
+        chunk.Metadata is { OwnerId: null, TenantId: null }
+            ? chunk
+            : chunk with { Metadata = chunk.Metadata with { OwnerId = null, TenantId = null } };
 
     /// <inheritdoc />
     public Task DeleteAsync(

--- a/src/Content/Infrastructure/Infrastructure.AI.RAG/Retrieval/FaissVectorStore.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.RAG/Retrieval/FaissVectorStore.cs
@@ -113,27 +113,54 @@ public sealed class FaissVectorStore : IVectorStore
             : chunk with { Metadata = chunk.Metadata with { OwnerId = null, TenantId = null } };
 
     /// <inheritdoc />
-    public Task DeleteAsync(
+    public Task<int> DeleteAsync(
         string documentId,
         string? collectionName = null,
         CancellationToken cancellationToken = default)
     {
-        var collection = GetOrCreateCollection(collectionName);
+        var deleted = DeleteFromCollection(GetOrCreateCollection(collectionName), documentId);
+
+        _logger.LogDebug(
+            "Deleted {Count} chunks for document {DocumentId} from in-memory store (collection: {Collection})",
+            deleted, documentId, collectionName ?? DefaultCollection);
+
+        return Task.FromResult(deleted);
+    }
+
+    /// <inheritdoc />
+    public Task<int> DeleteFromAllCollectionsAsync(
+        string documentId,
+        CancellationToken cancellationToken = default)
+    {
+        var deleted = 0;
+        foreach (var collection in _collections.Values)
+        {
+            deleted += DeleteFromCollection(collection, documentId);
+        }
+
+        _logger.LogDebug(
+            "Deleted {Count} chunks for document {DocumentId} from in-memory store across all collections",
+            deleted, documentId);
+
+        return Task.FromResult(deleted);
+    }
+
+    private static int DeleteFromCollection(
+        ConcurrentDictionary<string, (DocumentChunk Chunk, float[] Embedding)> collection,
+        string documentId)
+    {
         var keysToRemove = collection
             .Where(kvp => kvp.Value.Chunk.DocumentId == documentId)
             .Select(kvp => kvp.Key)
             .ToList();
 
+        var deleted = 0;
         foreach (var key in keysToRemove)
         {
-            collection.TryRemove(key, out _);
+            if (collection.TryRemove(key, out _)) deleted++;
         }
 
-        _logger.LogDebug(
-            "Deleted {Count} chunks for document {DocumentId} from in-memory store",
-            keysToRemove.Count, documentId);
-
-        return Task.CompletedTask;
+        return deleted;
     }
 
     /// <summary>

--- a/src/Content/Infrastructure/Infrastructure.AI.RAG/Retrieval/HybridRetriever.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.RAG/Retrieval/HybridRetriever.cs
@@ -1,4 +1,6 @@
 using System.Diagnostics;
+using Application.AI.Common.Interfaces;
+using Application.AI.Common.Interfaces.KnowledgeGraph;
 using Application.AI.Common.Interfaces.RAG;
 using Domain.AI.RAG.Models;
 using Domain.AI.Retrieval;
@@ -35,6 +37,7 @@ public sealed class HybridRetriever : IHybridRetriever
     private readonly IEmbeddingService _embeddingService;
     private readonly IOptionsMonitor<AppConfig> _appConfig;
     private readonly ILogger<HybridRetriever> _logger;
+    private readonly IAmbientRequestScope? _ambientScope;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="HybridRetriever"/> class.
@@ -44,18 +47,26 @@ public sealed class HybridRetriever : IHybridRetriever
     /// <param name="embeddingService">The embedding service for query vectorization.</param>
     /// <param name="appConfig">The application configuration monitor.</param>
     /// <param name="logger">The logger instance.</param>
+    /// <param name="ambientScope">
+    /// Bridge to the current request's scoped services, used to resolve the ambient
+    /// caller's tenant when <c>ScopedCollections</c> is enabled. Optional so direct
+    /// construction stays simple; when null, scoped requests resolve to the
+    /// global/default collection (closed).
+    /// </param>
     public HybridRetriever(
         IVectorStore vectorStore,
         IBm25Store bm25Store,
         IEmbeddingService embeddingService,
         IOptionsMonitor<AppConfig> appConfig,
-        ILogger<HybridRetriever> logger)
+        ILogger<HybridRetriever> logger,
+        IAmbientRequestScope? ambientScope = null)
     {
         _vectorStore = vectorStore;
         _bm25Store = bm25Store;
         _embeddingService = embeddingService;
         _appConfig = appConfig;
         _logger = logger;
+        _ambientScope = ambientScope;
     }
 
     /// <inheritdoc />
@@ -65,6 +76,12 @@ public sealed class HybridRetriever : IHybridRetriever
         string? collectionName = null,
         CancellationToken cancellationToken = default)
     {
+        // ScopedCollections choke point for callers that bypass IRagOrchestrator (e.g.
+        // the RAG workflow's VectorRetrievalExecutor): when scoping is on, the
+        // caller-supplied name is discarded and the collection is derived from the
+        // ambient tenant. Idempotent with the orchestrator's own resolution.
+        collectionName = ResolveScopedCollection(collectionName);
+
         using var activity = ActivitySource.StartActivity("HybridRetrieval");
         var config = _appConfig.CurrentValue.AI.Rag.Retrieval;
 
@@ -102,6 +119,24 @@ public sealed class HybridRetriever : IHybridRetriever
         activity?.SetTag("rag.retrieval.fused_count", fused.Count);
 
         return fused;
+    }
+
+    /// <summary>
+    /// Resolves the effective collection for this request. Pass-through when
+    /// <c>AppConfig:AI:Rag:ScopedCollections</c> is off; when on, derives the collection
+    /// from the ambient caller's tenant (no ambient identity resolves to the
+    /// global/default collection — closed, never an error).
+    /// </summary>
+    private string? ResolveScopedCollection(string? requestedCollectionName)
+    {
+        if (!_appConfig.CurrentValue.AI.Rag.ScopedCollections.Enabled)
+        {
+            return requestedCollectionName;
+        }
+
+        var scope = _ambientScope?.Current?.GetService(typeof(IKnowledgeScope)) as IKnowledgeScope;
+        return ScopedCollectionName.Resolve(
+            scopedCollectionsEnabled: true, requestedCollectionName, scope?.TenantId);
     }
 
     private async Task<IReadOnlyList<RetrievalResult>> RunDenseSearchAsync(

--- a/src/Content/Infrastructure/Infrastructure.AI.RAG/Retrieval/HybridRetriever.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.RAG/Retrieval/HybridRetriever.cs
@@ -37,7 +37,7 @@ public sealed class HybridRetriever : IHybridRetriever
     private readonly IEmbeddingService _embeddingService;
     private readonly IOptionsMonitor<AppConfig> _appConfig;
     private readonly ILogger<HybridRetriever> _logger;
-    private readonly IAmbientRequestScope? _ambientScope;
+    private readonly IAmbientRequestScope _ambientScope;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="HybridRetriever"/> class.
@@ -49,9 +49,11 @@ public sealed class HybridRetriever : IHybridRetriever
     /// <param name="logger">The logger instance.</param>
     /// <param name="ambientScope">
     /// Bridge to the current request's scoped services, used to resolve the ambient
-    /// caller's tenant when <c>ScopedCollections</c> is enabled. Optional so direct
-    /// construction stays simple; when null, scoped requests resolve to the
-    /// global/default collection (closed).
+    /// caller's tenant when <c>ScopedCollections</c> is enabled. Required (not optional):
+    /// a directly-constructed retriever without the bridge would fail OPEN to the shared
+    /// corpus under the flag. When no request scope is in flight,
+    /// <see cref="IAmbientRequestScope.Current"/> is null and scoped requests resolve to
+    /// the global/default collection (closed).
     /// </param>
     public HybridRetriever(
         IVectorStore vectorStore,
@@ -59,8 +61,10 @@ public sealed class HybridRetriever : IHybridRetriever
         IEmbeddingService embeddingService,
         IOptionsMonitor<AppConfig> appConfig,
         ILogger<HybridRetriever> logger,
-        IAmbientRequestScope? ambientScope = null)
+        IAmbientRequestScope ambientScope)
     {
+        ArgumentNullException.ThrowIfNull(ambientScope);
+
         _vectorStore = vectorStore;
         _bm25Store = bm25Store;
         _embeddingService = embeddingService;
@@ -134,7 +138,7 @@ public sealed class HybridRetriever : IHybridRetriever
             return requestedCollectionName;
         }
 
-        var scope = _ambientScope?.Current?.GetService(typeof(IKnowledgeScope)) as IKnowledgeScope;
+        var scope = _ambientScope.Current?.GetService(typeof(IKnowledgeScope)) as IKnowledgeScope;
         return ScopedCollectionName.Resolve(
             scopedCollectionsEnabled: true, requestedCollectionName, scope?.TenantId);
     }

--- a/src/Content/Infrastructure/Infrastructure.AI.RAG/Retrieval/SqliteFts5Store.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.RAG/Retrieval/SqliteFts5Store.cs
@@ -173,12 +173,12 @@ public sealed class SqliteFts5Store : IBm25Store
     }
 
     /// <inheritdoc />
-    public async Task DeleteAsync(
+    public async Task<int> DeleteAsync(
         string documentId,
         string? collectionName = null,
         CancellationToken cancellationToken = default)
     {
-        if (!_initialized) return;
+        if (!_initialized) return 0;
 
         await using var connection = CreateConnection();
         await connection.OpenAsync(cancellationToken);
@@ -194,6 +194,34 @@ public sealed class SqliteFts5Store : IBm25Store
         _logger.LogDebug(
             "Deleted {Count} chunks for document {DocumentId} from SQLite FTS5 (collection: {Collection})",
             deleted, documentId, collectionName ?? DefaultCollection);
+
+        return deleted;
+    }
+
+    /// <inheritdoc />
+    public async Task<int> DeleteFromAllCollectionsAsync(
+        string documentId,
+        CancellationToken cancellationToken = default)
+    {
+        // Unlike the search/delete fast paths, the erasure delete must work in a process
+        // that has not ingested yet (persistent database, fresh host): initialize the
+        // schema (and run any pending migration) instead of returning a false 0.
+        await EnsureInitializedAsync(cancellationToken);
+
+        await using var connection = CreateConnection();
+        await connection.OpenAsync(cancellationToken);
+
+        await using var cmd = connection.CreateCommand();
+        cmd.CommandText = "DELETE FROM chunks_fts WHERE document_id = @documentId";
+        cmd.Parameters.AddWithValue("@documentId", documentId);
+
+        var deleted = await cmd.ExecuteNonQueryAsync(cancellationToken);
+
+        _logger.LogDebug(
+            "Deleted {Count} chunks for document {DocumentId} from SQLite FTS5 across all collections",
+            deleted, documentId);
+
+        return deleted;
     }
 
     private async Task EnsureInitializedAsync(CancellationToken cancellationToken)

--- a/src/Content/Infrastructure/Infrastructure.AI.RAG/Retrieval/SqliteFts5Store.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.RAG/Retrieval/SqliteFts5Store.cs
@@ -21,9 +21,34 @@ namespace Infrastructure.AI.RAG.Retrieval;
 /// FTS5 <c>rank</c> returns negative BM25 scores (more negative = more relevant).
 /// Results are normalized to [0, 1] for consistent fusion with dense scores.
 /// </para>
+/// <para>
+/// <strong>Collections.</strong> Rows carry a <c>collection</c> value
+/// (<c>collectionName ?? "default"</c>) and every search and delete is scoped to one
+/// collection, mirroring <see cref="FaissVectorStore"/>'s partitioning so the dense and
+/// sparse halves of the local hybrid pipeline see the same partition. A null
+/// <c>collectionName</c> addresses the global/default collection only. Partitioning is
+/// <strong>unconditional</strong> — deliberately independent of the <c>ScopedCollections</c>
+/// flag: before this store honored collections, the BM25 half ignored them while FAISS
+/// partitioned, a dense/sparse asymmetry that leaked across collections. Flag-off behavior
+/// changes only for callers who relied on that bug.
+/// </para>
+/// <para>
+/// <strong>Provenance.</strong> Rows persist the chunk's
+/// <see cref="ChunkMetadata.OwnerId"/>/<see cref="ChunkMetadata.TenantId"/> stamps but
+/// never return them on search results: the stamps are the future erasure key, not
+/// retrieval data — surfacing them would tell every searcher who ingested each chunk in
+/// the shared corpus. They are never used as a search filter either.
+/// </para>
+/// <para>
+/// <strong>Migration.</strong> A persistent database created before the collection and
+/// provenance columns existed is migrated in place on first use (rename → recreate →
+/// copy → drop); legacy rows land in the default collection with null stamps.
+/// </para>
 /// </remarks>
 public sealed class SqliteFts5Store : IBm25Store
 {
+    private const string DefaultCollection = "default";
+
     private readonly string _connectionString;
     private readonly ILogger<SqliteFts5Store> _logger;
     private readonly object _initLock = new();
@@ -68,19 +93,25 @@ public sealed class SqliteFts5Store : IBm25Store
         {
             await using var cmd = connection.CreateCommand();
             cmd.CommandText = """
-                INSERT OR REPLACE INTO chunks_fts(id, document_id, content, section_path)
-                VALUES (@id, @documentId, @content, @sectionPath)
+                INSERT OR REPLACE INTO chunks_fts(
+                    id, document_id, content, section_path, collection, owner_id, tenant_id)
+                VALUES (@id, @documentId, @content, @sectionPath, @collection, @ownerId, @tenantId)
                 """;
             cmd.Parameters.AddWithValue("@id", chunk.Id);
             cmd.Parameters.AddWithValue("@documentId", chunk.DocumentId);
             cmd.Parameters.AddWithValue("@content", chunk.Content);
             cmd.Parameters.AddWithValue("@sectionPath", chunk.SectionPath);
+            cmd.Parameters.AddWithValue("@collection", collectionName ?? DefaultCollection);
+            cmd.Parameters.AddWithValue("@ownerId", (object?)chunk.Metadata.OwnerId ?? DBNull.Value);
+            cmd.Parameters.AddWithValue("@tenantId", (object?)chunk.Metadata.TenantId ?? DBNull.Value);
             await cmd.ExecuteNonQueryAsync(cancellationToken);
         }
 
         await transaction.CommitAsync(cancellationToken);
 
-        _logger.LogDebug("Indexed {Count} chunks into SQLite FTS5", chunks.Count);
+        _logger.LogDebug(
+            "Indexed {Count} chunks into SQLite FTS5 (collection: {Collection})",
+            chunks.Count, collectionName ?? DefaultCollection);
     }
 
     /// <inheritdoc />
@@ -96,14 +127,17 @@ public sealed class SqliteFts5Store : IBm25Store
         await connection.OpenAsync(cancellationToken);
 
         await using var cmd = connection.CreateCommand();
+        // owner_id/tenant_id are deliberately NOT selected: provenance stamps stay in
+        // storage for erasure and are never exposed on the read path.
         cmd.CommandText = """
             SELECT id, document_id, content, section_path, rank
             FROM chunks_fts
-            WHERE chunks_fts MATCH @query
+            WHERE chunks_fts MATCH @query AND collection = @collection
             ORDER BY rank
             LIMIT @topK
             """;
         cmd.Parameters.AddWithValue("@query", EscapeFts5Query(query));
+        cmd.Parameters.AddWithValue("@collection", collectionName ?? DefaultCollection);
         cmd.Parameters.AddWithValue("@topK", topK);
 
         var results = new List<RetrievalResult>();
@@ -150,14 +184,16 @@ public sealed class SqliteFts5Store : IBm25Store
         await connection.OpenAsync(cancellationToken);
 
         await using var cmd = connection.CreateCommand();
-        cmd.CommandText = "DELETE FROM chunks_fts WHERE document_id = @documentId";
+        cmd.CommandText =
+            "DELETE FROM chunks_fts WHERE document_id = @documentId AND collection = @collection";
         cmd.Parameters.AddWithValue("@documentId", documentId);
+        cmd.Parameters.AddWithValue("@collection", collectionName ?? DefaultCollection);
 
         var deleted = await cmd.ExecuteNonQueryAsync(cancellationToken);
 
         _logger.LogDebug(
-            "Deleted {Count} chunks for document {DocumentId} from SQLite FTS5",
-            deleted, documentId);
+            "Deleted {Count} chunks for document {DocumentId} from SQLite FTS5 (collection: {Collection})",
+            deleted, documentId, collectionName ?? DefaultCollection);
     }
 
     private async Task EnsureInitializedAsync(CancellationToken cancellationToken)
@@ -171,22 +207,94 @@ public sealed class SqliteFts5Store : IBm25Store
             _keepAliveConnection = CreateConnection();
             _keepAliveConnection.Open();
 
+            // BEGIN IMMEDIATE takes the database write lock BEFORE the schema check, so
+            // check-and-migrate is atomic across processes sharing a database file. A
+            // deferred transaction would re-open the classic TOCTOU: two processes both
+            // see the legacy schema, the loser re-migrates the already-migrated table and
+            // collapses every collection into 'default' with nulled stamps.
+            using var transaction = _keepAliveConnection.BeginTransaction(
+                System.Data.IsolationLevel.Serializable, deferred: false);
+
+            if (TableNeedsMigration(_keepAliveConnection))
+            {
+                MigrateLegacyTable(_keepAliveConnection);
+            }
+
             using var cmd = _keepAliveConnection.CreateCommand();
-            cmd.CommandText = """
-                CREATE VIRTUAL TABLE IF NOT EXISTS chunks_fts USING fts5(
-                    id UNINDEXED,
-                    document_id UNINDEXED,
-                    content,
-                    section_path
-                )
-                """;
+            cmd.CommandText = $"CREATE VIRTUAL TABLE IF NOT EXISTS chunks_fts USING fts5({SchemaColumns})";
             cmd.ExecuteNonQuery();
+
+            transaction.Commit();
             _initialized = true;
         }
 
         await Task.CompletedTask;
 
         _logger.LogDebug("SQLite FTS5 table initialized");
+    }
+
+    /// <summary>
+    /// Column list of the FTS5 virtual table. Only <c>content</c> and <c>section_path</c>
+    /// participate in full-text matching; identifiers, the collection partition value, and
+    /// the provenance stamps are stored unindexed.
+    /// </summary>
+    private const string SchemaColumns =
+        "id UNINDEXED, document_id UNINDEXED, content, section_path, " +
+        "collection UNINDEXED, owner_id UNINDEXED, tenant_id UNINDEXED";
+
+    /// <summary>
+    /// Returns whether an existing <c>chunks_fts</c> table predates the collection and
+    /// provenance columns. FTS5 virtual tables cannot <c>ALTER TABLE ... ADD COLUMN</c>,
+    /// so a legacy persistent database must be rebuilt via copy.
+    /// </summary>
+    private static bool TableNeedsMigration(SqliteConnection connection)
+    {
+        using (var exists = connection.CreateCommand())
+        {
+            exists.CommandText =
+                "SELECT count(*) FROM sqlite_master WHERE type = 'table' AND name = 'chunks_fts'";
+            if (Convert.ToInt64(exists.ExecuteScalar()) == 0) return false;
+        }
+
+        using var columns = connection.CreateCommand();
+        columns.CommandText = "PRAGMA table_info(chunks_fts)";
+        using var reader = columns.ExecuteReader();
+        while (reader.Read())
+        {
+            if (string.Equals(reader.GetString(1), "collection", StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Rebuilds a legacy table into the current schema: rename aside, create the new
+    /// table, copy every row into the default collection with null provenance stamps,
+    /// drop the legacy copy. Runs inside the caller's already-open IMMEDIATE transaction
+    /// (see <see cref="EnsureInitializedAsync"/>), which both makes a crash mid-migration
+    /// leave the legacy table intact and guarantees the schema re-check that gated this
+    /// call cannot go stale under a concurrent process.
+    /// </summary>
+    private void MigrateLegacyTable(SqliteConnection connection)
+    {
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = $"""
+            ALTER TABLE chunks_fts RENAME TO chunks_fts_legacy;
+            CREATE VIRTUAL TABLE chunks_fts USING fts5({SchemaColumns});
+            INSERT INTO chunks_fts(id, document_id, content, section_path, collection)
+                SELECT id, document_id, content, section_path, '{DefaultCollection}'
+                FROM chunks_fts_legacy;
+            DROP TABLE chunks_fts_legacy;
+            """;
+        cmd.ExecuteNonQuery();
+
+        _logger.LogInformation(
+            "Migrated legacy SQLite FTS5 table to the collection-aware schema; " +
+            "existing rows moved to the '{Collection}' collection",
+            DefaultCollection);
     }
 
     private SqliteConnection CreateConnection() => new(_connectionString);

--- a/src/Content/Infrastructure/Infrastructure.AI.RAG/SqlDatabase/SqlDatabaseRetrievalSource.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.RAG/SqlDatabase/SqlDatabaseRetrievalSource.cs
@@ -28,8 +28,16 @@ internal sealed class SqlDatabaseRetrievalSource(
     public string SourceName => "sql_database";
 
     /// <inheritdoc />
+    /// <remarks>
+    /// The SQL database is an external source with no collection concept, so
+    /// <paramref name="collectionName"/> is accepted and ignored.
+    /// </remarks>
     public async Task<SourceRetrievalResult> RetrieveAsync(
-        string query, int topK, TaskComplexity complexity, CancellationToken cancellationToken)
+        string query,
+        int topK,
+        TaskComplexity complexity,
+        string? collectionName = null,
+        CancellationToken cancellationToken = default)
     {
         var sw = Stopwatch.StartNew();
         var config = configMonitor.CurrentValue.AI.Rag.SqlDatabase;

--- a/src/Content/Infrastructure/Infrastructure.AI.RAG/WebSearch/WebSearchRetrievalSource.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.RAG/WebSearch/WebSearchRetrievalSource.cs
@@ -18,8 +18,16 @@ internal sealed class WebSearchRetrievalSource(IWebSearchProvider webSearchProvi
     public string SourceName => "web_search";
 
     /// <inheritdoc />
+    /// <remarks>
+    /// Web search is an external source with no collection concept, so
+    /// <paramref name="collectionName"/> is accepted and ignored.
+    /// </remarks>
     public async Task<SourceRetrievalResult> RetrieveAsync(
-        string query, int topK, TaskComplexity complexity, CancellationToken cancellationToken)
+        string query,
+        int topK,
+        TaskComplexity complexity,
+        string? collectionName = null,
+        CancellationToken cancellationToken = default)
     {
         var sw = Stopwatch.StartNew();
         var webResults = await webSearchProvider.SearchAsync(query, topK, cancellationToken);

--- a/src/Content/Infrastructure/Infrastructure.AI/Planner/StepExecutors/RetrievalPlanStepExecutor.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Planner/StepExecutors/RetrievalPlanStepExecutor.cs
@@ -143,7 +143,7 @@ public sealed class RetrievalPlanStepExecutor : IPlanStepExecutor
             classification.Complexity, classification.Confidence);
 
         var results = await _multiSourceOrchestrator.RetrieveFromAllSourcesAsync(
-            query, config.TopK ?? 10, classification.Complexity, ct);
+            query, config.TopK ?? 10, classification.Complexity, collectionName: null, ct);
 
         var output = new
         {

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/DocumentIngestTool.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/DocumentIngestTool.cs
@@ -58,7 +58,10 @@ public sealed class DocumentIngestTool : ITool
 
     /// <inheritdoc />
     public string Description =>
-        "Ingests documents into the RAG index for later retrieval. Supports markdown and text files.";
+        "Ingests documents into the RAG index for later retrieval. Supports markdown and text " +
+        "files. When per-tenant collection isolation (ScopedCollections) is enabled, the " +
+        "'collection' parameter is rejected with a validation failure: the target collection " +
+        "is always derived server-side from the caller's tenant.";
 
     /// <inheritdoc />
     public IReadOnlyList<string> SupportedOperations => Operations;

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/DocumentSearchTool.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/DocumentSearchTool.cs
@@ -63,7 +63,9 @@ public sealed class DocumentSearchTool : ITool
     /// <inheritdoc />
     public string Description =>
         "Searches indexed documents using hybrid retrieval with vector and keyword search, " +
-        "reranking, and optional GraphRAG for thematic queries.";
+        "reranking, and optional GraphRAG for thematic queries. When per-tenant collection " +
+        "isolation (ScopedCollections) is enabled, the 'collection' parameter is ignored: " +
+        "the collection searched is always derived server-side from the caller's tenant.";
 
     /// <inheritdoc />
     public IReadOnlyList<string> SupportedOperations => Operations;

--- a/src/Content/Presentation/Presentation.ConsoleUI/Examples/MultiSourceRetrievalExample.cs
+++ b/src/Content/Presentation/Presentation.ConsoleUI/Examples/MultiSourceRetrievalExample.cs
@@ -98,6 +98,7 @@ public class MultiSourceRetrievalExample
                         simpleQuery,
                         topK: 5,
                         TaskComplexity.Simple,
+                        collectionName: null,
                         cancellationToken);
 
                     DisplayRetrievalResults(results, "Vector Store");
@@ -129,6 +130,7 @@ public class MultiSourceRetrievalExample
                         complexQuery,
                         topK: 10,
                         TaskComplexity.Complex,
+                        collectionName: null,
                         cancellationToken);
 
                     DisplayRetrievalResults(results, "Vector + Graph + Web");
@@ -159,6 +161,7 @@ public class MultiSourceRetrievalExample
                         "What is Clean Architecture?",
                         topK: 5,
                         TaskComplexity.Simple,
+                        collectionName: null,
                         cancellationToken);
                 });
         }
@@ -182,6 +185,7 @@ public class MultiSourceRetrievalExample
                         "How does the MediatR pipeline integrate with governance?",
                         topK: 10,
                         TaskComplexity.Complex,
+                        collectionName: null,
                         cancellationToken);
                 });
         }

--- a/src/Content/Tests/Application.Core.Tests/CQRS/RAG/IngestDocumentCommandHandlerCompensationTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/CQRS/RAG/IngestDocumentCommandHandlerCompensationTests.cs
@@ -1,3 +1,4 @@
+using Application.AI.Common.Interfaces.KnowledgeGraph;
 using Application.AI.Common.Interfaces.RAG;
 using Application.Core.CQRS.RAG.IngestDocument;
 using Domain.AI.RAG.Models;
@@ -83,6 +84,7 @@ public sealed class IngestDocumentCommandHandlerCompensationTests
             _embedding.Object,
             _vectorStore.Object,
             _bm25Store.Object,
+            new Mock<IKnowledgeScope>().Object,
             NullLogger<IngestDocumentCommandHandler>.Instance,
             monitor.Object,
             new ServiceCollection().BuildServiceProvider());

--- a/src/Content/Tests/Application.Core.Tests/CQRS/RAG/IngestDocumentCommandHandlerGraphStagesTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/CQRS/RAG/IngestDocumentCommandHandlerGraphStagesTests.cs
@@ -1,3 +1,4 @@
+using Application.AI.Common.Interfaces.KnowledgeGraph;
 using Application.AI.Common.Interfaces.RAG;
 using Application.Core.CQRS.RAG.IngestDocument;
 using Application.Core.Workflows.KnowledgeGraph;
@@ -105,6 +106,7 @@ public sealed class IngestDocumentCommandHandlerGraphStagesTests
             _embedding.Object,
             _vectorStore.Object,
             _bm25Store.Object,
+            new Mock<IKnowledgeScope>().Object,
             NullLogger<IngestDocumentCommandHandler>.Instance,
             monitor.Object,
             services.BuildServiceProvider());

--- a/src/Content/Tests/Application.Core.Tests/CQRS/RAG/IngestDocumentCommandHandlerProvenanceTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/CQRS/RAG/IngestDocumentCommandHandlerProvenanceTests.cs
@@ -1,0 +1,204 @@
+using Application.AI.Common.Interfaces.KnowledgeGraph;
+using Application.AI.Common.Interfaces.RAG;
+using Application.Core.CQRS.RAG.IngestDocument;
+using Domain.AI.RAG.Models;
+using Domain.Common.Config;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Application.Core.Tests.CQRS.RAG;
+
+/// <summary>
+/// Verifies the K4 behaviors of <see cref="IngestDocumentCommandHandler"/>:
+/// owner/tenant provenance stamping from the ambient <see cref="IKnowledgeScope"/>
+/// (always on, null without identity, never a filter), and opt-in
+/// <c>ScopedCollections</c> resolution (derived from the tenant when on, caller
+/// pass-through when off, compensation targeting the same derived collection).
+/// </summary>
+public sealed class IngestDocumentCommandHandlerProvenanceTests
+{
+    private const string DocumentId = "file:///docs/report.md";
+
+    private readonly Mock<IDocumentParser> _parser = new();
+    private readonly Mock<IStructureExtractor> _structureExtractor = new();
+    private readonly Mock<IChunkingService> _chunker = new();
+    private readonly Mock<IContextualEnricher> _enricher = new();
+    private readonly Mock<IRaptorSummarizer> _raptor = new();
+    private readonly Mock<IEmbeddingService> _embedding = new();
+    private readonly Mock<IVectorStore> _vectorStore = new();
+    private readonly Mock<IBm25Store> _bm25Store = new();
+    private readonly Mock<IKnowledgeScope> _scope = new();
+
+    public IngestDocumentCommandHandlerProvenanceTests()
+    {
+        var chunks = new List<DocumentChunk>
+        {
+            new()
+            {
+                Id = $"{DocumentId}_chunk_0",
+                DocumentId = DocumentId,
+                SectionPath = "Root",
+                Content = "chunk text",
+                Tokens = 3,
+                Metadata = new ChunkMetadata
+                {
+                    SourceUri = new Uri(DocumentId),
+                    CreatedAt = DateTimeOffset.UtcNow,
+                },
+                Embedding = new[] { 0.1f, 0.2f },
+            },
+        };
+
+        _parser
+            .Setup(p => p.ParseAsync(It.IsAny<Uri>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync("# markdown");
+        _structureExtractor
+            .Setup(s => s.ExtractStructure(It.IsAny<string>()))
+            .Returns(new SkeletonNode { Title = "Root", Level = 1, StartOffset = 0, EndOffset = 10 });
+        _chunker
+            .Setup(c => c.ChunkAsync(
+                It.IsAny<string>(), It.IsAny<SkeletonNode>(), It.IsAny<Uri>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(chunks);
+        _embedding
+            .Setup(e => e.EmbedAsync(It.IsAny<IReadOnlyList<DocumentChunk>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IReadOnlyList<DocumentChunk> c, CancellationToken _) => c);
+    }
+
+    private IngestDocumentCommandHandler CreateHandler(Action<AppConfig>? configure = null)
+    {
+        var appConfig = new AppConfig();
+        appConfig.AI.Rag.Ingestion.EnableContextualEnrichment = false;
+        appConfig.AI.Rag.Ingestion.EnableRaptorSummaries = false;
+        configure?.Invoke(appConfig);
+
+        var monitor = new Mock<IOptionsMonitor<AppConfig>>();
+        monitor.SetupGet(m => m.CurrentValue).Returns(appConfig);
+
+        return new IngestDocumentCommandHandler(
+            _parser.Object,
+            _structureExtractor.Object,
+            _chunker.Object,
+            _enricher.Object,
+            _raptor.Object,
+            _embedding.Object,
+            _vectorStore.Object,
+            _bm25Store.Object,
+            _scope.Object,
+            NullLogger<IngestDocumentCommandHandler>.Instance,
+            monitor.Object,
+            new ServiceCollection().BuildServiceProvider());
+    }
+
+    private static IngestDocumentCommand Command(string? collectionName = null) => new()
+    {
+        DocumentUri = new Uri(DocumentId),
+        CollectionName = collectionName,
+    };
+
+    private IReadOnlyList<DocumentChunk> CapturedVectorChunks()
+    {
+        var invocation = _vectorStore.Invocations
+            .Single(i => i.Method.Name == nameof(IVectorStore.IndexAsync));
+        return (IReadOnlyList<DocumentChunk>)invocation.Arguments[0];
+    }
+
+    [Fact]
+    public async Task Handle_AmbientIdentityPresent_StampsOwnerAndTenantOnIndexedChunks()
+    {
+        _scope.SetupGet(s => s.UserId).Returns("user-1");
+        _scope.SetupGet(s => s.TenantId).Returns("tenant-a");
+
+        var result = await CreateHandler().Handle(Command(), CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        var chunks = CapturedVectorChunks();
+        chunks.Should().AllSatisfy(c =>
+        {
+            c.Metadata.OwnerId.Should().Be("user-1");
+            c.Metadata.TenantId.Should().Be("tenant-a");
+        });
+    }
+
+    [Fact]
+    public async Task Handle_NoAmbientIdentity_LeavesStampsNull()
+    {
+        var result = await CreateHandler().Handle(Command(), CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        var chunks = CapturedVectorChunks();
+        chunks.Should().AllSatisfy(c =>
+        {
+            c.Metadata.OwnerId.Should().BeNull();
+            c.Metadata.TenantId.Should().BeNull();
+        });
+    }
+
+    [Fact]
+    public async Task Handle_ScopedCollectionsEnabled_DerivesCollectionFromAmbientTenant()
+    {
+        _scope.SetupGet(s => s.TenantId).Returns("tenant-a");
+        var expected = ScopedCollectionName.DeriveForTenant("tenant-a");
+        var handler = CreateHandler(cfg => cfg.AI.Rag.ScopedCollections.Enabled = true);
+
+        var result = await handler.Handle(Command(), CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        _vectorStore.Verify(v => v.IndexAsync(
+            It.IsAny<IReadOnlyList<DocumentChunk>>(), expected, It.IsAny<CancellationToken>()), Times.Once);
+        _bm25Store.Verify(b => b.IndexAsync(
+            It.IsAny<IReadOnlyList<DocumentChunk>>(), expected, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ScopedCollectionsEnabledWithoutTenant_UsesGlobalDefaultCollection()
+    {
+        var handler = CreateHandler(cfg => cfg.AI.Rag.ScopedCollections.Enabled = true);
+
+        var result = await handler.Handle(Command(), CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        _vectorStore.Verify(v => v.IndexAsync(
+            It.IsAny<IReadOnlyList<DocumentChunk>>(), null, It.IsAny<CancellationToken>()), Times.Once);
+        _bm25Store.Verify(b => b.IndexAsync(
+            It.IsAny<IReadOnlyList<DocumentChunk>>(), null, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ScopedCollectionsDisabled_PassesCallerSuppliedCollectionUnchanged()
+    {
+        _scope.SetupGet(s => s.TenantId).Returns("tenant-a");
+
+        var result = await CreateHandler().Handle(Command("corpus-a"), CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        _vectorStore.Verify(v => v.IndexAsync(
+            It.IsAny<IReadOnlyList<DocumentChunk>>(), "corpus-a", It.IsAny<CancellationToken>()), Times.Once);
+        _bm25Store.Verify(b => b.IndexAsync(
+            It.IsAny<IReadOnlyList<DocumentChunk>>(), "corpus-a", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ScopedCollectionsEnabledAndStoreWriteFails_CompensatesInDerivedCollection()
+    {
+        _scope.SetupGet(s => s.TenantId).Returns("tenant-a");
+        var expected = ScopedCollectionName.DeriveForTenant("tenant-a");
+        _bm25Store
+            .Setup(b => b.IndexAsync(
+                It.IsAny<IReadOnlyList<DocumentChunk>>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("bm25 down"));
+        var handler = CreateHandler(cfg => cfg.AI.Rag.ScopedCollections.Enabled = true);
+
+        var result = await handler.Handle(Command(), CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+        _vectorStore.Verify(v => v.DeleteAsync(
+            DocumentId, expected, It.IsAny<CancellationToken>()), Times.Once,
+            "compensation must delete from the same derived collection the index writes targeted");
+        _bm25Store.Verify(b => b.DeleteAsync(
+            DocumentId, expected, It.IsAny<CancellationToken>()), Times.Once);
+    }
+}

--- a/src/Content/Tests/Application.Core.Tests/CQRS/RAG/IngestDocumentCommandValidatorTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/CQRS/RAG/IngestDocumentCommandValidatorTests.cs
@@ -1,0 +1,66 @@
+using Application.Core.CQRS.RAG.IngestDocument;
+using Domain.Common.Config;
+using FluentAssertions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Application.Core.Tests.CQRS.RAG;
+
+/// <summary>
+/// Verifies <see cref="IngestDocumentCommandValidator"/>'s ScopedCollections boundary:
+/// caller-supplied collection names are rejected when the feature is on (they would let a
+/// caller write into another tenant's collection) and honored when it is off.
+/// </summary>
+public sealed class IngestDocumentCommandValidatorTests
+{
+    private static IngestDocumentCommandValidator CreateValidator(bool scopedCollections)
+    {
+        var appConfig = new AppConfig();
+        appConfig.AI.Rag.ScopedCollections.Enabled = scopedCollections;
+
+        var monitor = new Mock<IOptionsMonitor<AppConfig>>();
+        monitor.SetupGet(m => m.CurrentValue).Returns(appConfig);
+        return new IngestDocumentCommandValidator(monitor.Object);
+    }
+
+    private static IngestDocumentCommand Command(string? collectionName) => new()
+    {
+        DocumentUri = new Uri("file:///docs/report.md"),
+        CollectionName = collectionName,
+    };
+
+    [Fact]
+    public void Validate_ScopedCollectionsOnWithCallerSuppliedCollection_Fails()
+    {
+        var result = CreateValidator(scopedCollections: true).Validate(Command("corpus-a"));
+
+        result.IsValid.Should().BeFalse(
+            "a caller-chosen collection under ScopedCollections is a cross-tenant write primitive");
+        result.Errors.Should().Contain(e =>
+            e.PropertyName == nameof(IngestDocumentCommand.CollectionName));
+    }
+
+    [Fact]
+    public void Validate_ScopedCollectionsOnWithoutCollection_Passes()
+    {
+        CreateValidator(scopedCollections: true).Validate(Command(null))
+            .IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Validate_ScopedCollectionsOffWithCollection_Passes()
+    {
+        CreateValidator(scopedCollections: false).Validate(Command("corpus-a"))
+            .IsValid.Should().BeTrue("flag-off behavior must be unchanged");
+    }
+
+    [Fact]
+    public void Validate_NonFileUri_StillFails()
+    {
+        var command = new IngestDocumentCommand { DocumentUri = new Uri("https://example.com/doc") };
+
+        CreateValidator(scopedCollections: false).Validate(command)
+            .IsValid.Should().BeFalse("the pre-existing file:// scheme rule must survive the change");
+    }
+}

--- a/src/Content/Tests/Application.Core.Tests/CQRS/RAG/SearchDocumentsQueryHandlerScopedCollectionsTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/CQRS/RAG/SearchDocumentsQueryHandlerScopedCollectionsTests.cs
@@ -1,0 +1,119 @@
+using Application.AI.Common.Interfaces.KnowledgeGraph;
+using Application.AI.Common.Interfaces.RAG;
+using Application.Core.CQRS.RAG.SearchDocuments;
+using Domain.AI.RAG.Enums;
+using Domain.AI.RAG.Models;
+using Domain.Common.Config;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Application.Core.Tests.CQRS.RAG;
+
+/// <summary>
+/// Verifies that <see cref="SearchDocumentsQueryHandler"/> resolves the collection it
+/// searches server-side when <c>ScopedCollections</c> is enabled: the ambient tenant's
+/// derived collection is passed to the orchestrator, no-identity callers search the
+/// global/default collection, and the flag-off path passes the caller's collection
+/// through byte-for-byte.
+/// </summary>
+public sealed class SearchDocumentsQueryHandlerScopedCollectionsTests
+{
+    private readonly Mock<IRagOrchestrator> _orchestrator = new();
+    private readonly Mock<IKnowledgeScope> _scope = new();
+
+    public SearchDocumentsQueryHandlerScopedCollectionsTests()
+    {
+        _orchestrator
+            .Setup(o => o.SearchAsync(
+                It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<string?>(),
+                It.IsAny<RetrievalStrategy?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new RagAssembledContext
+            {
+                AssembledText = "assembled",
+                TotalTokens = 10,
+                WasTruncated = false,
+            });
+    }
+
+    private SearchDocumentsQueryHandler CreateHandler(bool scopedCollections)
+    {
+        var appConfig = new AppConfig();
+        appConfig.AI.Rag.ScopedCollections.Enabled = scopedCollections;
+
+        var monitor = new Mock<IOptionsMonitor<AppConfig>>();
+        monitor.SetupGet(m => m.CurrentValue).Returns(appConfig);
+
+        return new SearchDocumentsQueryHandler(
+            _orchestrator.Object,
+            _scope.Object,
+            monitor.Object,
+            NullLogger<SearchDocumentsQueryHandler>.Instance);
+    }
+
+    [Fact]
+    public async Task Handle_ScopedCollectionsEnabled_PassesDerivedCollectionToOrchestrator()
+    {
+        _scope.SetupGet(s => s.TenantId).Returns("tenant-a");
+        var expected = ScopedCollectionName.DeriveForTenant("tenant-a");
+
+        var result = await CreateHandler(scopedCollections: true)
+            .Handle(new SearchDocumentsQuery { Query = "find things" }, CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        _orchestrator.Verify(o => o.SearchAsync(
+            "find things", It.IsAny<int?>(), expected,
+            It.IsAny<RetrievalStrategy?>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ScopedCollectionsEnabledWithoutTenant_SearchesGlobalDefaultCollection()
+    {
+        var result = await CreateHandler(scopedCollections: true)
+            .Handle(new SearchDocumentsQuery { Query = "find things" }, CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        _orchestrator.Verify(o => o.SearchAsync(
+            "find things", It.IsAny<int?>(), null,
+            It.IsAny<RetrievalStrategy?>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ScopedCollectionsDisabled_PassesCallerSuppliedCollectionUnchanged()
+    {
+        _scope.SetupGet(s => s.TenantId).Returns("tenant-a");
+
+        var result = await CreateHandler(scopedCollections: false)
+            .Handle(
+                new SearchDocumentsQuery { Query = "find things", CollectionName = "corpus-a" },
+                CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        _orchestrator.Verify(o => o.SearchAsync(
+            "find things", It.IsAny<int?>(), "corpus-a",
+            It.IsAny<RetrievalStrategy?>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_CrossTenantScopes_DeriveDistinctCollections()
+    {
+        _scope.SetupGet(s => s.TenantId).Returns("tenant-a");
+        await CreateHandler(scopedCollections: true)
+            .Handle(new SearchDocumentsQuery { Query = "q" }, CancellationToken.None);
+
+        _scope.SetupGet(s => s.TenantId).Returns("tenant-b");
+        await CreateHandler(scopedCollections: true)
+            .Handle(new SearchDocumentsQuery { Query = "q" }, CancellationToken.None);
+
+        var collections = _orchestrator.Invocations
+            .Where(i => i.Method.Name == nameof(IRagOrchestrator.SearchAsync))
+            .Select(i => (string?)i.Arguments[2])
+            .ToList();
+
+        collections.Should().HaveCount(2);
+        collections.Should().OnlyHaveUniqueItems(
+            "two tenants must never resolve to the same collection");
+    }
+}

--- a/src/Content/Tests/Application.Core.Tests/CQRS/RAG/SearchDocumentsQueryValidatorTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/CQRS/RAG/SearchDocumentsQueryValidatorTests.cs
@@ -1,0 +1,62 @@
+using Application.Core.CQRS.RAG.SearchDocuments;
+using Domain.Common.Config;
+using FluentAssertions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Application.Core.Tests.CQRS.RAG;
+
+/// <summary>
+/// Verifies <see cref="SearchDocumentsQueryValidator"/>'s ScopedCollections boundary:
+/// caller-supplied collection names are rejected when the feature is on (naming another
+/// tenant's collection would be a cross-tenant read primitive) and honored when it is off.
+/// </summary>
+public sealed class SearchDocumentsQueryValidatorTests
+{
+    private static SearchDocumentsQueryValidator CreateValidator(bool scopedCollections)
+    {
+        var appConfig = new AppConfig();
+        appConfig.AI.Rag.ScopedCollections.Enabled = scopedCollections;
+
+        var monitor = new Mock<IOptionsMonitor<AppConfig>>();
+        monitor.SetupGet(m => m.CurrentValue).Returns(appConfig);
+        return new SearchDocumentsQueryValidator(monitor.Object);
+    }
+
+    [Fact]
+    public void Validate_ScopedCollectionsOnWithCallerSuppliedCollection_Fails()
+    {
+        var result = CreateValidator(scopedCollections: true)
+            .Validate(new SearchDocumentsQuery { Query = "q", CollectionName = "tenant-other-abc" });
+
+        result.IsValid.Should().BeFalse(
+            "naming a collection under ScopedCollections would be a cross-tenant read primitive");
+        result.Errors.Should().Contain(e =>
+            e.PropertyName == nameof(SearchDocumentsQuery.CollectionName));
+    }
+
+    [Fact]
+    public void Validate_ScopedCollectionsOnWithoutCollection_Passes()
+    {
+        CreateValidator(scopedCollections: true)
+            .Validate(new SearchDocumentsQuery { Query = "q" })
+            .IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Validate_ScopedCollectionsOffWithCollection_Passes()
+    {
+        CreateValidator(scopedCollections: false)
+            .Validate(new SearchDocumentsQuery { Query = "q", CollectionName = "corpus-a" })
+            .IsValid.Should().BeTrue("flag-off behavior must be unchanged");
+    }
+
+    [Fact]
+    public void Validate_EmptyQuery_StillFails()
+    {
+        CreateValidator(scopedCollections: false)
+            .Validate(new SearchDocumentsQuery { Query = "" })
+            .IsValid.Should().BeFalse("the pre-existing query rules must survive the change");
+    }
+}

--- a/src/Content/Tests/Application.Core.Tests/Validation/RagConfigValidatorTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/Validation/RagConfigValidatorTests.cs
@@ -107,4 +107,89 @@ public sealed class RagConfigValidatorTests
 
         result.IsValid.Should().BeTrue();
     }
+
+    [Fact]
+    public void Validate_ScopedCollectionsWithAzureSearchProvider_Fails()
+    {
+        // The class default provider IS azure_ai_search, so enabling the flag alone must fail:
+        // the Azure stores ignore collection names and every tenant would silently share one index.
+        var config = new RagConfig();
+        config.ScopedCollections.Enabled = true;
+
+        var result = _sut.Validate(config);
+
+        result.IsValid.Should().BeFalse(
+            "azure_ai_search stores ignore collection names — allowing the combination would leak cross-tenant");
+        result.Errors.Should().Contain(e => e.PropertyName == "VectorStore.Provider");
+    }
+
+    [Fact]
+    public void Validate_ScopedCollectionsWithFaissProvider_Passes()
+    {
+        var config = new RagConfig();
+        config.ScopedCollections.Enabled = true;
+        config.VectorStore.Provider = "faiss";
+
+        var result = _sut.Validate(config);
+
+        result.IsValid.Should().BeTrue("FAISS + SQLite FTS5 are both collection-aware");
+    }
+
+    [Fact]
+    public void Validate_ScopedCollectionsWithAgenticRetrieval_Fails()
+    {
+        var config = new RagConfig();
+        config.ScopedCollections.Enabled = true;
+        config.VectorStore.Provider = "faiss";
+        config.AgenticRetrieval.Enabled = true;
+
+        var result = _sut.Validate(config);
+
+        result.IsValid.Should().BeFalse(
+            "the knowledge-base retriever always queries its one configured knowledge base");
+        result.Errors.Should().Contain(e => e.PropertyName == "AgenticRetrieval.Enabled");
+    }
+
+    [Fact]
+    public void Validate_ScopedCollectionsDisabled_AzureProviderAndAgenticRetrievalUnconstrained()
+    {
+        var config = new RagConfig();
+        config.AgenticRetrieval.Enabled = true;
+
+        var result = _sut.Validate(config);
+
+        result.IsValid.Should().BeTrue("the invariants only bind when ScopedCollections is on");
+    }
+
+    [Fact]
+    public void Validate_ScopedCollectionsWithIndexOnIngest_Fails()
+    {
+        var config = new RagConfig();
+        config.ScopedCollections.Enabled = true;
+        config.VectorStore.Provider = "faiss";
+        config.GraphDatabase.Enabled = true;
+        config.GraphRag.IndexOnIngest = true;
+
+        var result = _sut.Validate(config);
+
+        result.IsValid.Should().BeFalse(
+            "the corpus graph is one shared graph, so scoped ingests would land every tenant's " +
+            "chunks in a graph readable via GraphRag and the multi-source 'graph' source");
+        result.Errors.Should().Contain(e => e.PropertyName == "GraphRag.IndexOnIngest");
+    }
+
+    [Fact]
+    public void Validate_ScopedCollectionsWithoutIndexOnIngest_GraphBackendAloneIsAllowed()
+    {
+        // The graph database backend itself (e.g. for knowledge-graph memory) is fine;
+        // only building the shared corpus graph FROM scoped ingests is banned.
+        var config = new RagConfig();
+        config.ScopedCollections.Enabled = true;
+        config.VectorStore.Provider = "faiss";
+        config.GraphDatabase.Enabled = true;
+
+        var result = _sut.Validate(config);
+
+        result.IsValid.Should().BeTrue();
+    }
 }

--- a/src/Content/Tests/Domain.AI.Tests/RAG/ScopedCollectionNameTests.cs
+++ b/src/Content/Tests/Domain.AI.Tests/RAG/ScopedCollectionNameTests.cs
@@ -1,0 +1,148 @@
+using System.Text.RegularExpressions;
+using Domain.AI.RAG.Models;
+using FluentAssertions;
+using Xunit;
+
+namespace Domain.AI.Tests.RAG;
+
+/// <summary>
+/// Tests for <see cref="ScopedCollectionName"/> — the server-side derivation of per-tenant
+/// RAG collection names. The derivation must be deterministic (same tenant → same name),
+/// collision-safe (distinct tenants → distinct names even when their slugs sanitize
+/// identically), and emit only store-safe characters.
+/// </summary>
+public sealed class ScopedCollectionNameTests
+{
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void DeriveForTenant_NullOrWhitespaceTenant_ReturnsNull(string? tenantId)
+    {
+        ScopedCollectionName.DeriveForTenant(tenantId).Should().BeNull(
+            "a caller with no ambient tenant addresses the global/default collection");
+    }
+
+    [Fact]
+    public void DeriveForTenant_SameTenant_IsDeterministic()
+    {
+        var first = ScopedCollectionName.DeriveForTenant("contoso");
+        var second = ScopedCollectionName.DeriveForTenant("contoso");
+
+        first.Should().Be(second);
+    }
+
+    [Fact]
+    public void DeriveForTenant_CaseAndPaddingVariants_NormalizeToSameName()
+    {
+        var canonical = ScopedCollectionName.DeriveForTenant("contoso");
+
+        ScopedCollectionName.DeriveForTenant("Contoso").Should().Be(canonical);
+        ScopedCollectionName.DeriveForTenant("  contoso  ").Should().Be(canonical,
+            "derivation mirrors the knowledge-memory scope key's trim + lowercase normalization");
+    }
+
+    [Fact]
+    public void DeriveForTenant_DistinctTenantsWithIdenticalSlugs_ProduceDistinctNames()
+    {
+        // All three sanitize to the slug "a-b"; only the hash suffix can tell them apart.
+        var names = new[] { "a b", "a-b", "a:b" }
+            .Select(ScopedCollectionName.DeriveForTenant)
+            .ToList();
+
+        names.Should().OnlyHaveUniqueItems(
+            "the SHA-256 suffix makes sanitization collisions impossible to exploit");
+        names.Should().AllSatisfy(n => n.Should().StartWith("tenant-a-b-"));
+    }
+
+    [Theory]
+    [InlineData("contoso")]
+    [InlineData("Contoso Ltd: EU/West")]
+    [InlineData("日本のテナント")]
+    [InlineData("!!!")]
+    public void DeriveForTenant_AnyTenant_EmitsStoreSafeName(string tenantId)
+    {
+        var name = ScopedCollectionName.DeriveForTenant(tenantId);
+
+        name.Should().MatchRegex("^tenant-[a-z0-9-]+$",
+            "the output alphabet must be valid for FAISS keys, SQLite values, and Azure index names");
+        Regex.IsMatch(name!, "--").Should().BeFalse("dash runs are collapsed");
+        name!.Length.Should().BeLessThanOrEqualTo(
+            ScopedCollectionName.Prefix.Length + ScopedCollectionName.MaxSlugLength
+            + 1 + ScopedCollectionName.HashLength);
+    }
+
+    [Fact]
+    public void DeriveForTenant_HashSuffix_Is64Bits()
+    {
+        var name = ScopedCollectionName.DeriveForTenant("contoso")!;
+
+        name[(name.LastIndexOf('-') + 1)..].Should().MatchRegex(
+            $"^[0-9a-f]{{{ScopedCollectionName.HashLength}}}$",
+            "8 hex chars (32 bits) would be offline-grindable for a crafted colliding tenant id; " +
+            "the suffix must be 16 hex chars (64 bits)");
+    }
+
+    [Fact]
+    public void DeriveForTenant_TenantWithNoUsableCharacters_UsesPlaceholderSlug()
+    {
+        var name = ScopedCollectionName.DeriveForTenant("!!!");
+
+        name.Should().StartWith("tenant-t-",
+            "an all-symbol tenant falls back to the 't' placeholder slug; the hash still disambiguates");
+    }
+
+    [Fact]
+    public void DeriveForTenant_VeryLongTenant_CapsSlugLength()
+    {
+        var name = ScopedCollectionName.DeriveForTenant(new string('a', 500));
+
+        name!.Length.Should().BeLessThanOrEqualTo(
+            ScopedCollectionName.Prefix.Length + ScopedCollectionName.MaxSlugLength
+            + 1 + ScopedCollectionName.HashLength);
+    }
+
+    [Fact]
+    public void Resolve_AlreadyDerivedNameWithSameTenant_IsIdempotent()
+    {
+        // The MediatR handlers resolve before calling the orchestrator, which resolves
+        // again at its choke point — double application must be a no-op.
+        var derived = ScopedCollectionName.DeriveForTenant("contoso");
+
+        ScopedCollectionName.Resolve(
+                scopedCollectionsEnabled: true, requestedCollectionName: derived, tenantId: "contoso")
+            .Should().Be(derived);
+    }
+
+    [Fact]
+    public void Resolve_FeatureDisabled_ReturnsCallerSuppliedName()
+    {
+        ScopedCollectionName.Resolve(
+                scopedCollectionsEnabled: false,
+                requestedCollectionName: "corpus-a",
+                tenantId: "contoso")
+            .Should().Be("corpus-a", "when the feature is off, today's behavior is unchanged");
+    }
+
+    [Fact]
+    public void Resolve_FeatureEnabled_IgnoresCallerSuppliedNameAndDerives()
+    {
+        var resolved = ScopedCollectionName.Resolve(
+            scopedCollectionsEnabled: true,
+            requestedCollectionName: "another-tenants-collection",
+            tenantId: "contoso");
+
+        resolved.Should().Be(ScopedCollectionName.DeriveForTenant("contoso"),
+            "the effective collection is a pure function of the ambient tenant — never of request content");
+    }
+
+    [Fact]
+    public void Resolve_FeatureEnabledWithoutTenant_ReturnsNullForGlobalCollection()
+    {
+        ScopedCollectionName.Resolve(
+                scopedCollectionsEnabled: true,
+                requestedCollectionName: null,
+                tenantId: null)
+            .Should().BeNull("no-identity callers go to the global/default collection, not an error");
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.KnowledgeGraph.Tests/Compliance/DefaultErasureOrchestratorTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.KnowledgeGraph.Tests/Compliance/DefaultErasureOrchestratorTests.cs
@@ -200,8 +200,10 @@ public sealed class DefaultErasureOrchestratorTests
     [Fact]
     public async Task EraseByOwner_DeletesVectorsByDocumentId_NotChunkId()
     {
-        // Chunk IDs are "{documentId}_chunk_{i}" / "{documentId}_raptor_*"; IVectorStore.DeleteAsync
-        // deletes by documentId. Passing a chunkId matches nothing, so the embeddings survive.
+        // Chunk IDs are "{documentId}_chunk_{i}" / "{documentId}_raptor_*"; the store deletes by
+        // documentId. Passing a chunkId matches nothing, so the embeddings survive. The sweep must
+        // use the ALL-collections delete: under ScopedCollections the chunks live in a
+        // tenant-derived collection a default-collection delete would miss.
         _graphStore.Setup(g => g.GetNodesByOwnerAsync("user-1", It.IsAny<CancellationToken>()))
             .ReturnsAsync([
                 new GraphNode
@@ -210,16 +212,21 @@ public sealed class DefaultErasureOrchestratorTests
                     ChunkIds = ["docA_chunk_0", "docA_chunk_1", "docA_raptor_L0_C0"]
                 }
             ]);
+        _vectorStore
+            .Setup(v => v.DeleteFromAllCollectionsAsync("docA", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(3);
 
         var receipt = await _orchestrator.EraseByOwnerAsync("user-1");
 
         // All three chunk IDs derive to the single document "docA" — deleted once.
-        _vectorStore.Verify(v => v.DeleteAsync("docA", It.IsAny<string?>(), It.IsAny<CancellationToken>()),
+        _vectorStore.Verify(v => v.DeleteFromAllCollectionsAsync("docA", It.IsAny<CancellationToken>()),
             Times.Once);
-        _vectorStore.Verify(v => v.DeleteAsync(
+        _vectorStore.Verify(v => v.DeleteFromAllCollectionsAsync(
             It.Is<string>(id => id.Contains("_chunk_") || id.Contains("_raptor_")),
-            It.IsAny<string?>(), It.IsAny<CancellationToken>()), Times.Never);
-        receipt.VectorEmbeddingsDeleted.Should().Be(1, "one distinct document's embeddings were submitted");
+            It.IsAny<CancellationToken>()), Times.Never);
+        receipt.VectorEmbeddingsDeleted.Should().Be(3,
+            "the receipt reports the chunk rows the store actually removed, not the submitted document count");
+        receipt.UnmatchedDocumentIds.Should().BeEmpty();
     }
 
     // ------------------------------------------------------------------
@@ -241,11 +248,15 @@ public sealed class DefaultErasureOrchestratorTests
                 }
             ]);
 
+        bm25.Setup(b => b.DeleteFromAllCollectionsAsync("docA", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(2);
+
         var receipt = await orchestrator.EraseByOwnerAsync("user-1");
 
-        bm25.Verify(b => b.DeleteAsync("docA", It.IsAny<string?>(), It.IsAny<CancellationToken>()),
+        bm25.Verify(b => b.DeleteFromAllCollectionsAsync("docA", It.IsAny<CancellationToken>()),
             Times.Once);
-        receipt.Bm25DocumentsDeleted.Should().Be(1);
+        receipt.Bm25DocumentsDeleted.Should().Be(2,
+            "the receipt reports the rows the store actually removed, not the submitted document count");
     }
 
     // ------------------------------------------------------------------

--- a/src/Content/Tests/Infrastructure.AI.KnowledgeGraph.Tests/Compliance/ErasureCompletenessTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.KnowledgeGraph.Tests/Compliance/ErasureCompletenessTests.cs
@@ -286,11 +286,11 @@ public sealed class ErasureCompletenessTests
         await service.EnforceRetentionAsync(DateTimeOffset.UtcNow, CancellationToken.None);
 
         vectorStore.Verify(
-            v => v.DeleteAsync("docExpired", It.IsAny<string?>(), It.IsAny<CancellationToken>()),
+            v => v.DeleteFromAllCollectionsAsync("docExpired", It.IsAny<CancellationToken>()),
             Times.Once,
             "the expired node's derived embeddings must be purged — its chunk IDs must survive to the derived-content sweep");
         bm25Store.Verify(
-            b => b.DeleteAsync("docExpired", It.IsAny<string?>(), It.IsAny<CancellationToken>()),
+            b => b.DeleteFromAllCollectionsAsync("docExpired", It.IsAny<CancellationToken>()),
             Times.Once);
     }
 

--- a/src/Content/Tests/Infrastructure.AI.KnowledgeGraph.Tests/Compliance/ErasureScopedCollectionsIntegrationTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.KnowledgeGraph.Tests/Compliance/ErasureScopedCollectionsIntegrationTests.cs
@@ -1,0 +1,123 @@
+using Application.AI.Common.Interfaces.KnowledgeGraph;
+using Domain.AI.KnowledgeGraph;
+using Domain.AI.KnowledgeGraph.Models;
+using Domain.AI.RAG.Models;
+using FluentAssertions;
+using Infrastructure.AI.KnowledgeGraph.Compliance;
+using Infrastructure.AI.RAG.Retrieval;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Infrastructure.AI.KnowledgeGraph.Tests.Compliance;
+
+/// <summary>
+/// End-to-end proof that the right-to-erasure cascade reaches per-tenant scoped
+/// collections: chunks ingested into a tenant-derived collection through the REAL local
+/// stores (FAISS + SQLite FTS5) are gone from BOTH stores after
+/// <see cref="DefaultErasureOrchestrator.EraseByOwnerAsync"/>, the receipt counts match
+/// the rows actually removed, and a document the graph manifest points at that matches
+/// nothing surfaces on <see cref="ErasureReceipt.UnmatchedDocumentIds"/> instead of
+/// silently counting as purged.
+/// </summary>
+public sealed class ErasureScopedCollectionsIntegrationTests
+{
+    private const string Owner = "user-1";
+    private const string DocumentId = "doc-erase";
+    private const string ChunkId = $"{DocumentId}_chunk_0";
+
+    private static readonly float[] Embedding = [0.5f, 0.5f, 0.5f];
+    private static readonly string TenantCollection =
+        ScopedCollectionName.DeriveForTenant("tenant-a")!;
+
+    private readonly Mock<IKnowledgeGraphStore> _graphStore = new();
+    private readonly Mock<IFeedbackStore> _feedbackStore = new();
+    private readonly FaissVectorStore _vectorStore = new(NullLogger<FaissVectorStore>.Instance);
+    private readonly SqliteFts5Store _bm25Store = new(
+        $"Data Source=ErasureScoped-{Guid.NewGuid():N};Mode=Memory;Cache=Shared",
+        NullLogger<SqliteFts5Store>.Instance);
+
+    public ErasureScopedCollectionsIntegrationTests()
+    {
+        _graphStore.Setup(g => g.DeleteNodesAsync(
+                It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IReadOnlyList<string> ids, CancellationToken _) =>
+                new NodeDeletionResult { DeletedNodeIds = ids.ToList(), DeletedEdgeIds = [] });
+        _graphStore.Setup(g => g.DeleteEdgesByOwnerAsync(
+                It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+    }
+
+    private DefaultErasureOrchestrator CreateOrchestrator() => new(
+        _graphStore.Object,
+        _feedbackStore.Object,
+        _vectorStore,
+        Mock.Of<IMemoryAuditSink>(),
+        TimeProvider.System,
+        NullLogger<DefaultErasureOrchestrator>.Instance,
+        _bm25Store);
+
+    private void SetupOwnerNode(string chunkId)
+    {
+        _graphStore.Setup(g => g.GetNodesByOwnerAsync(Owner, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([
+                new GraphNode
+                {
+                    Id = "n1", Name = "T", Type = "Fact", OwnerId = Owner,
+                    ChunkIds = [chunkId],
+                },
+            ]);
+    }
+
+    private static DocumentChunk StampedChunk() => new()
+    {
+        Id = ChunkId,
+        DocumentId = DocumentId,
+        SectionPath = "Root",
+        Content = "erasable tenant scoped content",
+        Tokens = 4,
+        Embedding = Embedding,
+        Metadata = new ChunkMetadata
+        {
+            SourceUri = new Uri($"file:///docs/{DocumentId}.md"),
+            CreatedAt = DateTimeOffset.UtcNow,
+            OwnerId = Owner,
+            TenantId = "tenant-a",
+        },
+    };
+
+    [Fact]
+    public async Task EraseByOwner_ChunksInTenantDerivedCollection_RemovedFromBothStoresWithMatchingCounts()
+    {
+        await _vectorStore.IndexAsync([StampedChunk()], TenantCollection);
+        await _bm25Store.IndexAsync([StampedChunk()], TenantCollection);
+        SetupOwnerNode(ChunkId);
+
+        var receipt = await CreateOrchestrator().EraseByOwnerAsync(Owner);
+
+        receipt.VectorEmbeddingsDeleted.Should().Be(1,
+            "the tenant-derived collection must be reached — a default-collection delete would remove 0");
+        receipt.Bm25DocumentsDeleted.Should().Be(1);
+        receipt.UnmatchedDocumentIds.Should().BeEmpty();
+
+        (await _vectorStore.SearchAsync(Embedding, topK: 5, TenantCollection))
+            .Should().BeEmpty("the embeddings must be gone from the tenant collection");
+        (await _bm25Store.SearchAsync("erasable tenant", topK: 5, TenantCollection))
+            .Should().BeEmpty("the BM25 rows must be gone from the tenant collection");
+    }
+
+    [Fact]
+    public async Task EraseByOwner_ManifestPointsAtDocumentWithNoRows_ReceiptDoesNotOverCount()
+    {
+        // Nothing ingested: the graph manifest references chunks whose derived content was
+        // never (or no longer) in the stores. The receipt must report 0 — never the
+        // submitted document count — and surface the unmatched document as detail.
+        SetupOwnerNode("ghost-doc_chunk_0");
+
+        var receipt = await CreateOrchestrator().EraseByOwnerAsync(Owner);
+
+        receipt.VectorEmbeddingsDeleted.Should().Be(0);
+        receipt.Bm25DocumentsDeleted.Should().Be(0);
+        receipt.UnmatchedDocumentIds.Should().ContainSingle().Which.Should().Be("ghost-doc");
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.RAG.Tests/Orchestration/ComplexityRoutingIntegrationTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.RAG.Tests/Orchestration/ComplexityRoutingIntegrationTests.cs
@@ -1,3 +1,4 @@
+using Application.AI.Common.Interfaces;
 using Application.AI.Common.Interfaces.RAG;
 using Application.AI.Common.Interfaces.Routing;
 using Domain.AI.RAG.Models;
@@ -50,6 +51,7 @@ public sealed class ComplexityRoutingIntegrationTests
             costTracker: null,
             config,
             Mock.Of<ILogger<RagOrchestrator>>(),
+            Mock.Of<IAmbientRequestScope>(),
             gate);
     }
 

--- a/src/Content/Tests/Infrastructure.AI.RAG.Tests/Orchestration/FullAutonomyIntegrationTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.RAG.Tests/Orchestration/FullAutonomyIntegrationTests.cs
@@ -115,7 +115,7 @@ public sealed class FullAutonomyIntegrationTests
         _mockMultiSource
             .Setup(m => m.RetrieveFromAllSourcesAsync(
                 It.IsAny<string>(), It.IsAny<int>(),
-                It.IsAny<TaskComplexity>(), It.IsAny<CancellationToken>()))
+                It.IsAny<TaskComplexity>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(retrievalResults);
         _mockComplexityClassifier
             .Setup(c => c.ClassifyAsync(It.IsAny<AgentTurnContext>(), It.IsAny<CancellationToken>()))

--- a/src/Content/Tests/Infrastructure.AI.RAG.Tests/Orchestration/GraphRetrievalSourceTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.RAG.Tests/Orchestration/GraphRetrievalSourceTests.cs
@@ -23,7 +23,7 @@ public sealed class GraphRetrievalSourceTests
 
         var sut = new GraphRetrievalSource(_graphRag.Object);
 
-        var result = await sut.RetrieveAsync("test query", 10, TaskComplexity.Moderate, CancellationToken.None);
+        var result = await sut.RetrieveAsync("test query", 10, TaskComplexity.Moderate, collectionName: null, cancellationToken: CancellationToken.None);
 
         result.SourceName.Should().Be("graph");
         result.Results.Should().HaveCount(1);

--- a/src/Content/Tests/Infrastructure.AI.RAG.Tests/Orchestration/MultiHopIntegrationTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.RAG.Tests/Orchestration/MultiHopIntegrationTests.cs
@@ -1,3 +1,4 @@
+using Application.AI.Common.Interfaces;
 using Application.AI.Common.Interfaces.RAG;
 using Application.AI.Common.Interfaces.Routing;
 using Domain.AI.RAG.Models;
@@ -57,6 +58,7 @@ public sealed class MultiHopIntegrationTests
             costTracker: null,
             config,
             Mock.Of<ILogger<RagOrchestrator>>(),
+            Mock.Of<IAmbientRequestScope>(),
             gate,
             _mockIterativeRetriever.Object,
             _mockFaithfulness.Object);

--- a/src/Content/Tests/Infrastructure.AI.RAG.Tests/Orchestration/MultiSourceIntegrationTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.RAG.Tests/Orchestration/MultiSourceIntegrationTests.cs
@@ -77,7 +77,7 @@ public sealed class MultiSourceIntegrationTests
         var mock = new Mock<IRetrievalSource>();
         mock.Setup(s => s.SourceName).Returns(name);
         mock.Setup(s => s.RetrieveAsync(
-                It.IsAny<string>(), It.IsAny<int>(), It.IsAny<TaskComplexity>(), It.IsAny<CancellationToken>()))
+                It.IsAny<string>(), It.IsAny<int>(), It.IsAny<TaskComplexity>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new SourceRetrievalResult
             {
                 SourceName = name, Results = results, Latency = TimeSpan.FromMilliseconds(50), TokensUsed = 0

--- a/src/Content/Tests/Infrastructure.AI.RAG.Tests/Orchestration/MultiSourceOrchestratorCollectionForwardingTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.RAG.Tests/Orchestration/MultiSourceOrchestratorCollectionForwardingTests.cs
@@ -1,0 +1,86 @@
+using Application.AI.Common.Interfaces.RAG;
+using Domain.AI.RAG.Models;
+using Domain.AI.Routing.Enums;
+using Domain.Common.Config;
+using FluentAssertions;
+using Infrastructure.AI.RAG.Orchestration;
+using Infrastructure.AI.RAG.Tests.Helpers;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Infrastructure.AI.RAG.Tests.Orchestration;
+
+/// <summary>
+/// Verifies that <see cref="MultiSourceOrchestrator"/> forwards the collection name to
+/// every fanned-out <see cref="IRetrievalSource"/>. Without this, the Phase-D pipeline
+/// would drop a tenant-derived collection on the floor and the vector source would search
+/// the shared default collection — a silent cross-tenant leak under ScopedCollections.
+/// </summary>
+public sealed class MultiSourceOrchestratorCollectionForwardingTests
+{
+    private readonly Mock<IRetrievalSource> _vectorSource = new();
+
+    private MultiSourceOrchestrator CreateOrchestrator()
+    {
+        var config = RagTestData.CreateConfigMonitor(cfg =>
+        {
+            cfg.AI.Rag.MultiSource.Enabled = true;
+            cfg.AI.Rag.MultiSource.EnabledSources = ["vector"];
+            cfg.AI.Rag.MultiSource.SourcesByComplexity = new() { ["Simple"] = ["vector"] };
+        });
+
+        var services = new ServiceCollection();
+        services.AddKeyedSingleton<IRetrievalSource>("vector", _vectorSource.Object);
+
+        return new MultiSourceOrchestrator(
+            services.BuildServiceProvider(),
+            Mock.Of<IRetrievalCostTracker>(),
+            config,
+            Mock.Of<ILogger<MultiSourceOrchestrator>>());
+    }
+
+    private void SetupVectorSource()
+    {
+        _vectorSource.Setup(s => s.SourceName).Returns("vector");
+        _vectorSource
+            .Setup(s => s.RetrieveAsync(
+                It.IsAny<string>(), It.IsAny<int>(), It.IsAny<TaskComplexity>(),
+                It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SourceRetrievalResult
+            {
+                SourceName = "vector",
+                Results = RagTestData.CreateRetrievalResults(1),
+                Latency = TimeSpan.FromMilliseconds(1),
+                TokensUsed = 0,
+            });
+    }
+
+    [Fact]
+    public async Task RetrieveFromAllSourcesAsync_WithCollectionName_ForwardsItToSources()
+    {
+        SetupVectorSource();
+        var collection = ScopedCollectionName.DeriveForTenant("tenant-a");
+
+        await CreateOrchestrator().RetrieveFromAllSourcesAsync(
+            "query", 5, TaskComplexity.Simple, collection);
+
+        _vectorSource.Verify(s => s.RetrieveAsync(
+            "query", 5, TaskComplexity.Simple, collection, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task RetrieveFromAllSourcesAsync_WithoutCollectionName_ForwardsNull()
+    {
+        SetupVectorSource();
+
+        await CreateOrchestrator().RetrieveFromAllSourcesAsync(
+            "query", 5, TaskComplexity.Simple);
+
+        _vectorSource.Verify(s => s.RetrieveAsync(
+            "query", 5, TaskComplexity.Simple, null, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.RAG.Tests/Orchestration/MultiSourceOrchestratorRefactorTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.RAG.Tests/Orchestration/MultiSourceOrchestratorRefactorTests.cs
@@ -62,6 +62,7 @@ public sealed class MultiSourceOrchestratorRefactorTests
                 It.IsAny<string>(),
                 It.IsAny<int>(),
                 It.IsAny<TaskComplexity>(),
+                It.IsAny<string?>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(new SourceRetrievalResult
             {
@@ -93,10 +94,10 @@ public sealed class MultiSourceOrchestratorRefactorTests
 
         // Assert — both sources were called via keyed DI resolution
         mockVector.Verify(s => s.RetrieveAsync(
-            It.IsAny<string>(), It.IsAny<int>(), It.IsAny<TaskComplexity>(), It.IsAny<CancellationToken>()),
+            It.IsAny<string>(), It.IsAny<int>(), It.IsAny<TaskComplexity>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()),
             Times.Once);
         mockGraph.Verify(s => s.RetrieveAsync(
-            It.IsAny<string>(), It.IsAny<int>(), It.IsAny<TaskComplexity>(), It.IsAny<CancellationToken>()),
+            It.IsAny<string>(), It.IsAny<int>(), It.IsAny<TaskComplexity>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()),
             Times.Once);
         results.Should().HaveCount(4);
     }
@@ -124,10 +125,10 @@ public sealed class MultiSourceOrchestratorRefactorTests
 
         // Assert — graph is in SourcesByComplexity["Moderate"] but not in EnabledSources
         mockVector.Verify(s => s.RetrieveAsync(
-            It.IsAny<string>(), It.IsAny<int>(), It.IsAny<TaskComplexity>(), It.IsAny<CancellationToken>()),
+            It.IsAny<string>(), It.IsAny<int>(), It.IsAny<TaskComplexity>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()),
             Times.Once);
         mockGraph.Verify(s => s.RetrieveAsync(
-            It.IsAny<string>(), It.IsAny<int>(), It.IsAny<TaskComplexity>(), It.IsAny<CancellationToken>()),
+            It.IsAny<string>(), It.IsAny<int>(), It.IsAny<TaskComplexity>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()),
             Times.Never);
         results.Should().HaveCount(3);
     }
@@ -151,7 +152,7 @@ public sealed class MultiSourceOrchestratorRefactorTests
 
         // Assert — vector results returned, graph silently skipped (logged warning, no exception)
         mockVector.Verify(s => s.RetrieveAsync(
-            It.IsAny<string>(), It.IsAny<int>(), It.IsAny<TaskComplexity>(), It.IsAny<CancellationToken>()),
+            It.IsAny<string>(), It.IsAny<int>(), It.IsAny<TaskComplexity>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()),
             Times.Once);
         results.Should().HaveCount(3);
     }

--- a/src/Content/Tests/Infrastructure.AI.RAG.Tests/Orchestration/MultiSourceOrchestratorTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.RAG.Tests/Orchestration/MultiSourceOrchestratorTests.cs
@@ -46,7 +46,7 @@ public sealed class MultiSourceOrchestratorTests
     {
         _mockVectorSource.Setup(s => s.SourceName).Returns("vector");
         _mockVectorSource
-            .Setup(s => s.RetrieveAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<TaskComplexity>(), It.IsAny<CancellationToken>()))
+            .Setup(s => s.RetrieveAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<TaskComplexity>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new SourceRetrievalResult
             {
                 SourceName = "vector",
@@ -71,7 +71,7 @@ public sealed class MultiSourceOrchestratorTests
 
         _mockGraphSource.Setup(s => s.SourceName).Returns("graph");
         _mockGraphSource
-            .Setup(s => s.RetrieveAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<TaskComplexity>(), It.IsAny<CancellationToken>()))
+            .Setup(s => s.RetrieveAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<TaskComplexity>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new SourceRetrievalResult
             {
                 SourceName = "graph",
@@ -93,10 +93,10 @@ public sealed class MultiSourceOrchestratorTests
 
         results.Should().HaveCount(3);
         _mockVectorSource.Verify(
-            s => s.RetrieveAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<TaskComplexity>(), It.IsAny<CancellationToken>()),
+            s => s.RetrieveAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<TaskComplexity>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()),
             Times.Once);
         _mockGraphSource.Verify(
-            s => s.RetrieveAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<TaskComplexity>(), It.IsAny<CancellationToken>()),
+            s => s.RetrieveAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<TaskComplexity>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()),
             Times.Never);
     }
 
@@ -112,10 +112,10 @@ public sealed class MultiSourceOrchestratorTests
 
         results.Should().HaveCount(5);
         _mockVectorSource.Verify(
-            s => s.RetrieveAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<TaskComplexity>(), It.IsAny<CancellationToken>()),
+            s => s.RetrieveAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<TaskComplexity>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()),
             Times.Once);
         _mockGraphSource.Verify(
-            s => s.RetrieveAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<TaskComplexity>(), It.IsAny<CancellationToken>()),
+            s => s.RetrieveAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<TaskComplexity>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()),
             Times.Once);
     }
 
@@ -132,10 +132,10 @@ public sealed class MultiSourceOrchestratorTests
 
         results.Should().HaveCountGreaterThanOrEqualTo(3);
         _mockVectorSource.Verify(
-            s => s.RetrieveAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<TaskComplexity>(), It.IsAny<CancellationToken>()),
+            s => s.RetrieveAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<TaskComplexity>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()),
             Times.Once);
         _mockGraphSource.Verify(
-            s => s.RetrieveAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<TaskComplexity>(), It.IsAny<CancellationToken>()),
+            s => s.RetrieveAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<TaskComplexity>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()),
             Times.Once);
     }
 
@@ -145,8 +145,8 @@ public sealed class MultiSourceOrchestratorTests
         SetupVectorResults(3);
         _mockGraphSource.Setup(s => s.SourceName).Returns("graph");
         _mockGraphSource
-            .Setup(s => s.RetrieveAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<TaskComplexity>(), It.IsAny<CancellationToken>()))
-            .Returns(async (string _, int _, TaskComplexity _, CancellationToken ct) =>
+            .Setup(s => s.RetrieveAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<TaskComplexity>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .Returns(async (string _, int _, TaskComplexity _, string? _, CancellationToken ct) =>
             {
                 await Task.Delay(TimeSpan.FromSeconds(30), ct);
                 return new SourceRetrievalResult
@@ -179,7 +179,7 @@ public sealed class MultiSourceOrchestratorTests
 
         _mockVectorSource.Setup(s => s.SourceName).Returns("vector");
         _mockVectorSource
-            .Setup(s => s.RetrieveAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<TaskComplexity>(), It.IsAny<CancellationToken>()))
+            .Setup(s => s.RetrieveAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<TaskComplexity>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new SourceRetrievalResult
             {
                 SourceName = "vector",
@@ -190,7 +190,7 @@ public sealed class MultiSourceOrchestratorTests
 
         _mockGraphSource.Setup(s => s.SourceName).Returns("graph");
         _mockGraphSource
-            .Setup(s => s.RetrieveAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<TaskComplexity>(), It.IsAny<CancellationToken>()))
+            .Setup(s => s.RetrieveAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<TaskComplexity>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new SourceRetrievalResult
             {
                 SourceName = "graph",
@@ -213,12 +213,12 @@ public sealed class MultiSourceOrchestratorTests
     {
         _mockVectorSource.Setup(s => s.SourceName).Returns("vector");
         _mockVectorSource
-            .Setup(s => s.RetrieveAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<TaskComplexity>(), It.IsAny<CancellationToken>()))
+            .Setup(s => s.RetrieveAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<TaskComplexity>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new InvalidOperationException("Vector store unavailable"));
 
         _mockGraphSource.Setup(s => s.SourceName).Returns("graph");
         _mockGraphSource
-            .Setup(s => s.RetrieveAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<TaskComplexity>(), It.IsAny<CancellationToken>()))
+            .Setup(s => s.RetrieveAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<TaskComplexity>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new InvalidOperationException("Graph unavailable"));
 
         var orchestrator = CreateOrchestrator();
@@ -244,7 +244,7 @@ public sealed class MultiSourceOrchestratorTests
 
         results.Should().HaveCount(3);
         _mockGraphSource.Verify(
-            s => s.RetrieveAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<TaskComplexity>(), It.IsAny<CancellationToken>()),
+            s => s.RetrieveAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<TaskComplexity>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()),
             Times.Never);
     }
 }

--- a/src/Content/Tests/Infrastructure.AI.RAG.Tests/Orchestration/RagOrchestratorGraphRagUnavailableTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.RAG.Tests/Orchestration/RagOrchestratorGraphRagUnavailableTests.cs
@@ -1,3 +1,4 @@
+using Application.AI.Common.Interfaces;
 using Application.AI.Common.Interfaces.RAG;
 using Domain.AI.RAG.Enums;
 using FluentAssertions;
@@ -39,7 +40,8 @@ public sealed class RagOrchestratorGraphRagUnavailableTests
             complexityClassifier: null,
             costTracker: null,
             config,
-            Mock.Of<ILogger<RagOrchestrator>>());
+            Mock.Of<ILogger<RagOrchestrator>>(),
+            Mock.Of<IAmbientRequestScope>());
     }
 
     [Fact]

--- a/src/Content/Tests/Infrastructure.AI.RAG.Tests/Orchestration/RagOrchestratorMultiHopTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.RAG.Tests/Orchestration/RagOrchestratorMultiHopTests.cs
@@ -1,3 +1,4 @@
+using Application.AI.Common.Interfaces;
 using Application.AI.Common.Interfaces.RAG;
 using Application.AI.Common.Interfaces.Routing;
 using Domain.AI.RAG.Models;
@@ -59,6 +60,7 @@ public sealed class RagOrchestratorMultiHopTests
             costTracker: null,
             config,
             Mock.Of<ILogger<RagOrchestrator>>(),
+            Mock.Of<IAmbientRequestScope>(),
             gate,
             _mockIterativeRetriever.Object,
             _mockFaithfulness.Object);

--- a/src/Content/Tests/Infrastructure.AI.RAG.Tests/Orchestration/RagOrchestratorTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.RAG.Tests/Orchestration/RagOrchestratorTests.cs
@@ -345,7 +345,7 @@ public sealed class RagOrchestratorTests
             .ReturnsAsync(RagTestData.CreateModerateClassification());
         _mockMultiSource
             .Setup(m => m.RetrieveFromAllSourcesAsync(
-                It.IsAny<string>(), It.IsAny<int>(), It.IsAny<TaskComplexity>(), It.IsAny<CancellationToken>()))
+                It.IsAny<string>(), It.IsAny<int>(), It.IsAny<TaskComplexity>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(retrievalResults);
         _mockReranker
             .Setup(r => r.RerankAsync(It.IsAny<string>(), It.IsAny<IReadOnlyList<RetrievalResult>>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
@@ -367,7 +367,7 @@ public sealed class RagOrchestratorTests
 
         result.AssembledText.Should().Be("assembled text");
         _mockMultiSource.Verify(
-            m => m.RetrieveFromAllSourcesAsync(It.IsAny<string>(), It.IsAny<int>(), TaskComplexity.Moderate, It.IsAny<CancellationToken>()),
+            m => m.RetrieveFromAllSourcesAsync(It.IsAny<string>(), It.IsAny<int>(), TaskComplexity.Moderate, It.IsAny<string?>(), It.IsAny<CancellationToken>()),
             Times.Once);
         _mockRetriever.Verify(
             r => r.RetrieveAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()),
@@ -382,7 +382,7 @@ public sealed class RagOrchestratorTests
             .ReturnsAsync(RagTestData.CreateSimpleClassification());
         _mockMultiSource
             .Setup(m => m.RetrieveFromAllSourcesAsync(
-                It.IsAny<string>(), It.IsAny<int>(), It.IsAny<TaskComplexity>(), It.IsAny<CancellationToken>()))
+                It.IsAny<string>(), It.IsAny<int>(), It.IsAny<TaskComplexity>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<RetrievalResult>());
 
         var orchestrator = CreateOrchestrator(cfg =>
@@ -486,7 +486,7 @@ public sealed class RagOrchestratorTests
         var webSource = new Mock<IRetrievalSource>();
         webSource.SetupGet(s => s.SourceName).Returns("web_search");
         webSource
-            .Setup(s => s.RetrieveAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<TaskComplexity>(), It.IsAny<CancellationToken>()))
+            .Setup(s => s.RetrieveAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<TaskComplexity>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(RagTestData.CreateSourceResult("web_search", resultCount: 2));
 
         _mockRetriever
@@ -515,7 +515,7 @@ public sealed class RagOrchestratorTests
 
         result.AssembledText.Should().Be("assembled text");
         webSource.Verify(
-            s => s.RetrieveAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<TaskComplexity>(), It.IsAny<CancellationToken>()),
+            s => s.RetrieveAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<TaskComplexity>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()),
             Times.Once);
         _mockAssembler.Verify(
             a => a.AssembleAsync(It.IsAny<IReadOnlyList<RerankedResult>>(), It.IsAny<int>(), It.IsAny<CancellationToken>()),
@@ -547,7 +547,7 @@ public sealed class RagOrchestratorTests
         var webSource = new Mock<IRetrievalSource>();
         webSource.SetupGet(s => s.SourceName).Returns("web_search");
         webSource
-            .Setup(s => s.RetrieveAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<TaskComplexity>(), It.IsAny<CancellationToken>()))
+            .Setup(s => s.RetrieveAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<TaskComplexity>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(webSourceResult);
 
         _mockRetriever
@@ -625,7 +625,7 @@ public sealed class RagOrchestratorTests
         var webSource = new Mock<IRetrievalSource>();
         webSource.SetupGet(s => s.SourceName).Returns("web_search");
         webSource
-            .Setup(s => s.RetrieveAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<TaskComplexity>(), It.IsAny<CancellationToken>()))
+            .Setup(s => s.RetrieveAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<TaskComplexity>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new SourceRetrievalResult
             {
                 SourceName = "web_search",
@@ -730,7 +730,7 @@ public sealed class RagOrchestratorTests
         await orchestrator.SearchAsync("query needing web fallback");
 
         webSource.Verify(
-            s => s.RetrieveAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<TaskComplexity>(), It.IsAny<CancellationToken>()),
+            s => s.RetrieveAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<TaskComplexity>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()),
             Times.Never);
     }
 

--- a/src/Content/Tests/Infrastructure.AI.RAG.Tests/Orchestration/RagOrchestratorTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.RAG.Tests/Orchestration/RagOrchestratorTests.cs
@@ -1,3 +1,4 @@
+using Application.AI.Common.Interfaces;
 using Application.AI.Common.Interfaces.RAG;
 using Application.AI.Common.Interfaces.Routing;
 using Domain.AI.RAG.Enums;
@@ -62,6 +63,7 @@ public sealed class RagOrchestratorTests
             _mockCostTracker.Object,
             config,
             Mock.Of<ILogger<RagOrchestrator>>(),
+            Mock.Of<IAmbientRequestScope>(),
             _mockDecisionGate.Object,
             iterativeRetriever: null,
             faithfulnessEvaluator: null,

--- a/src/Content/Tests/Infrastructure.AI.RAG.Tests/Orchestration/ScopedCollectionsChokePointTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.RAG.Tests/Orchestration/ScopedCollectionsChokePointTests.cs
@@ -1,0 +1,293 @@
+using Application.AI.Common.Interfaces;
+using Application.AI.Common.Interfaces.KnowledgeGraph;
+using Application.AI.Common.Interfaces.Planner;
+using Application.AI.Common.Interfaces.RAG;
+using Application.AI.Common.Interfaces.Routing;
+using Application.Core.Workflows.Rag;
+using Domain.AI.Planner;
+using Domain.AI.RAG.Enums;
+using Domain.AI.RAG.Models;
+using Domain.Common.Config;
+using FluentAssertions;
+using Infrastructure.AI.Planner.StepExecutors;
+using Infrastructure.AI.RAG.Orchestration;
+using Infrastructure.AI.RAG.QueryTransform;
+using Infrastructure.AI.RAG.Retrieval;
+using Infrastructure.AI.RAG.Tests.Helpers;
+using Infrastructure.AI.Tools;
+using Microsoft.Agents.AI.Workflows;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Infrastructure.AI.RAG.Tests.Orchestration;
+
+/// <summary>
+/// Regression tests for the ScopedCollections enforcement choke points. The MediatR
+/// request validators only guard the HTTP/CQRS surface; these tests prove the paths that
+/// call the orchestrator or retriever DIRECTLY with a caller-supplied collection —
+/// <see cref="DocumentSearchTool"/> (reachable by MCP clients and prompt-injected agents),
+/// <see cref="RetrievalPlanStepExecutor"/>, and <see cref="VectorRetrievalExecutor"/> —
+/// cannot escape the tenant-derived collection when the flag is on, because
+/// <see cref="RagOrchestrator.SearchAsync"/> and <see cref="HybridRetriever.RetrieveAsync"/>
+/// re-derive the collection from the ambient caller identity. Derived names are a pure
+/// function of the tenant id and computable offline, so passing a "correct-looking"
+/// derived name must not help an attacker either.
+/// </summary>
+public sealed class ScopedCollectionsChokePointTests
+{
+    private const string Tenant = "tenant-a";
+    private const string VictimCollection = "tenant-victim-0123456789abcdef";
+
+    private static readonly string Derived = ScopedCollectionName.DeriveForTenant(Tenant)!;
+
+    private readonly Mock<IHybridRetriever> _retriever = new();
+    private readonly Mock<IReranker> _reranker = new();
+    private readonly Mock<ICragEvaluator> _crag = new();
+    private readonly Mock<IRagContextAssembler> _assembler = new();
+    private readonly Mock<IVectorStore> _vectorStore = new();
+    private readonly Mock<IBm25Store> _bm25Store = new();
+    private readonly Mock<IEmbeddingService> _embedding = new();
+
+    /// <summary>Ambient bridge whose request scope resolves the given tenant.</summary>
+    private static IAmbientRequestScope AmbientScopeFor(string? tenantId)
+    {
+        var scope = new Mock<IKnowledgeScope>();
+        scope.SetupGet(s => s.TenantId).Returns(tenantId);
+        var provider = new ServiceCollection()
+            .AddSingleton(scope.Object)
+            .BuildServiceProvider();
+        return new FakeAmbientRequestScope(provider);
+    }
+
+    private sealed class FakeAmbientRequestScope(IServiceProvider provider) : IAmbientRequestScope
+    {
+        public IServiceProvider? Current => provider;
+
+        public IDisposable BeginScope(IServiceProvider requestServices) => new NoOpToken();
+
+        private sealed class NoOpToken : IDisposable
+        {
+            public void Dispose()
+            {
+            }
+        }
+    }
+
+    private static IOptionsMonitor<AppConfig> ScopedConfig(bool enabled = true) =>
+        RagTestData.CreateConfigMonitor(cfg =>
+        {
+            cfg.AI.Rag.ScopedCollections.Enabled = enabled;
+            cfg.AI.Rag.VectorStore.Provider = "faiss";
+            cfg.AI.ModelRouting.Enabled = false;
+        });
+
+    private RagOrchestrator CreateOrchestrator(
+        IOptionsMonitor<AppConfig> config, string? ambientTenant = Tenant)
+    {
+        _retriever
+            .Setup(r => r.RetrieveAsync(
+                It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(RagTestData.CreateRetrievalResults(2));
+        SetupPostRetrievalPipeline();
+
+        return new RagOrchestrator(
+            _retriever.Object,
+            _reranker.Object,
+            _crag.Object,
+            _assembler.Object,
+            graphRagService: null,
+            feedbackScorer: null,
+            new QueryRouter(
+                Mock.Of<IQueryClassifier>(), Mock.Of<IServiceProvider>(), config,
+                Mock.Of<ILogger<QueryRouter>>()),
+            multiSourceOrchestrator: null,
+            complexityClassifier: null,
+            costTracker: null,
+            config,
+            Mock.Of<ILogger<RagOrchestrator>>(),
+            ambientScope: AmbientScopeFor(ambientTenant));
+    }
+
+    private HybridRetriever CreateHybridRetriever(
+        IOptionsMonitor<AppConfig> config, string? ambientTenant = Tenant)
+    {
+        _embedding
+            .Setup(e => e.EmbedQueryAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ReadOnlyMemory<float>([0.1f, 0.2f]));
+        _vectorStore
+            .Setup(v => v.SearchAsync(
+                It.IsAny<ReadOnlyMemory<float>>(), It.IsAny<int>(), It.IsAny<string?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+        _bm25Store
+            .Setup(b => b.SearchAsync(
+                It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+
+        return new HybridRetriever(
+            _vectorStore.Object,
+            _bm25Store.Object,
+            _embedding.Object,
+            config,
+            Mock.Of<ILogger<HybridRetriever>>(),
+            AmbientScopeFor(ambientTenant));
+    }
+
+    private void SetupPostRetrievalPipeline()
+    {
+        _reranker
+            .Setup(r => r.RerankAsync(
+                It.IsAny<string>(), It.IsAny<IReadOnlyList<RetrievalResult>>(), It.IsAny<int>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(RagTestData.CreateRerankedResults(2));
+        _crag
+            .Setup(e => e.EvaluateAsync(
+                It.IsAny<string>(), It.IsAny<IReadOnlyList<RetrievalResult>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(RagTestData.CreateAcceptEvaluation());
+        _assembler
+            .Setup(a => a.AssembleAsync(
+                It.IsAny<IReadOnlyList<RerankedResult>>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new RagAssembledContext
+            {
+                AssembledText = "assembled",
+                TotalTokens = 10,
+                WasTruncated = false,
+            });
+    }
+
+    private void VerifyRetrieverSawOnlyDerivedCollection()
+    {
+        _retriever.Verify(r => r.RetrieveAsync(
+            It.IsAny<string>(), It.IsAny<int>(), Derived, It.IsAny<CancellationToken>()),
+            Times.AtLeastOnce);
+        _retriever.Verify(r => r.RetrieveAsync(
+            It.IsAny<string>(), It.IsAny<int>(), VictimCollection, It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task SearchAsync_ScopingOnWithCallerSuppliedCollection_UsesDerivedCollection()
+    {
+        var orchestrator = CreateOrchestrator(ScopedConfig());
+
+        await orchestrator.SearchAsync("query", 5, VictimCollection);
+
+        VerifyRetrieverSawOnlyDerivedCollection();
+    }
+
+    [Fact]
+    public async Task SearchAsync_ScopingOnWithAlreadyDerivedName_ResolutionIsIdempotent()
+    {
+        var orchestrator = CreateOrchestrator(ScopedConfig());
+
+        // The MediatR handler resolves before calling in; the orchestrator resolves again.
+        await orchestrator.SearchAsync("query", 5, Derived);
+
+        VerifyRetrieverSawOnlyDerivedCollection();
+    }
+
+    [Fact]
+    public async Task SearchAsync_ScopingOnWithoutAmbientTenant_FallsToGlobalDefaultCollection()
+    {
+        var orchestrator = CreateOrchestrator(ScopedConfig(), ambientTenant: null);
+
+        await orchestrator.SearchAsync("query", 5, VictimCollection);
+
+        _retriever.Verify(r => r.RetrieveAsync(
+            It.IsAny<string>(), It.IsAny<int>(), null, It.IsAny<CancellationToken>()),
+            Times.AtLeastOnce,
+            "a caller with no ambient identity must be closed into the global collection, " +
+            "never into the collection it named");
+    }
+
+    [Fact]
+    public async Task SearchAsync_ScopingOff_PassesCallerSuppliedCollectionUnchanged()
+    {
+        var orchestrator = CreateOrchestrator(ScopedConfig(enabled: false));
+
+        await orchestrator.SearchAsync("query", 5, "corpus-a");
+
+        _retriever.Verify(r => r.RetrieveAsync(
+            It.IsAny<string>(), It.IsAny<int>(), "corpus-a", It.IsAny<CancellationToken>()),
+            Times.AtLeastOnce, "flag-off behavior must be byte-for-byte unchanged");
+    }
+
+    [Fact]
+    public async Task DocumentSearchTool_ScopingOnWithCollectionParameter_CannotEscapeDerivedCollection()
+    {
+        var tool = new DocumentSearchTool(CreateOrchestrator(ScopedConfig()));
+
+        var result = await tool.ExecuteAsync("search", new Dictionary<string, object?>
+        {
+            ["query"] = "query",
+            ["collection"] = VictimCollection,
+        });
+
+        result.Success.Should().BeTrue();
+        VerifyRetrieverSawOnlyDerivedCollection();
+    }
+
+    [Fact]
+    public async Task RetrievalPlanStepExecutor_ScopingOnWithConfiguredCollection_CannotEscapeDerivedCollection()
+    {
+        var executor = new RetrievalPlanStepExecutor(
+            CreateOrchestrator(ScopedConfig()),
+            Mock.Of<IMultiSourceOrchestrator>(),
+            Mock.Of<ITaskComplexityClassifier>(),
+            new RetrievalCostTracker(RagTestData.CreateConfigMonitor()),
+            Mock.Of<IPlanProgressNotifier>(),
+            new PlanExecutionContext(),
+            Mock.Of<ILogger<RetrievalPlanStepExecutor>>());
+
+        var step = new PlanStep
+        {
+            Id = PlanStepId.New(),
+            Name = "Scoped retrieval",
+            Type = StepType.Retrieval,
+            Configuration = new RetrievalStepConfiguration
+            {
+                Query = "query",
+                TopK = 5,
+                CollectionName = VictimCollection,
+            },
+            RetryPolicy = new RetryPolicy { MaxRetries = 1 },
+        };
+
+        var result = await executor.ExecuteAsync(
+            step, new Dictionary<PlanStepId, string>(), CancellationToken.None);
+
+        result.Status.Should().Be(StepExecutionStatus.Completed);
+        VerifyRetrieverSawOnlyDerivedCollection();
+    }
+
+    [Fact]
+    public async Task VectorRetrievalExecutor_ScopingOnWithMessageCollection_CannotEscapeDerivedCollection()
+    {
+        var hybridRetriever = CreateHybridRetriever(ScopedConfig());
+        var executor = new VectorRetrievalExecutor(
+            hybridRetriever,
+            _reranker.Object,
+            _crag.Object,
+            feedbackScorer: null,
+            Mock.Of<ILogger<VectorRetrievalExecutor>>());
+
+        await executor.HandleAsync(
+            new ClassifiedQuery("query", 5, VictimCollection, RetrievalStrategy.HybridVectorBm25),
+            Mock.Of<IWorkflowContext>());
+
+        _vectorStore.Verify(v => v.SearchAsync(
+            It.IsAny<ReadOnlyMemory<float>>(), It.IsAny<int>(), Derived, It.IsAny<CancellationToken>()),
+            Times.AtLeastOnce);
+        _vectorStore.Verify(v => v.SearchAsync(
+            It.IsAny<ReadOnlyMemory<float>>(), It.IsAny<int>(), VictimCollection,
+            It.IsAny<CancellationToken>()),
+            Times.Never);
+        _bm25Store.Verify(b => b.SearchAsync(
+            It.IsAny<string>(), It.IsAny<int>(), VictimCollection, It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.RAG.Tests/Orchestration/VectorRetrievalSourceTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.RAG.Tests/Orchestration/VectorRetrievalSourceTests.cs
@@ -23,7 +23,7 @@ public sealed class VectorRetrievalSourceTests
 
         var sut = new VectorRetrievalSource(_retriever.Object);
 
-        var result = await sut.RetrieveAsync("test query", 10, TaskComplexity.Moderate, CancellationToken.None);
+        var result = await sut.RetrieveAsync("test query", 10, TaskComplexity.Moderate, collectionName: null, cancellationToken: CancellationToken.None);
 
         result.SourceName.Should().Be("vector");
         result.Results.Should().HaveCount(1);

--- a/src/Content/Tests/Infrastructure.AI.RAG.Tests/Retrieval/AzureAISearchStoreIndexingFailureTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.RAG.Tests/Retrieval/AzureAISearchStoreIndexingFailureTests.cs
@@ -1,0 +1,101 @@
+using Application.AI.Common.Interfaces.RAG;
+using Azure;
+using Azure.Search.Documents;
+using Azure.Search.Documents.Models;
+using Domain.AI.RAG.Models;
+using FluentAssertions;
+using Infrastructure.AI.RAG.Retrieval;
+using Infrastructure.AI.RAG.Tests.Helpers;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Infrastructure.AI.RAG.Tests.Retrieval;
+
+/// <summary>
+/// Verifies the Azure stores' partial-batch handling: <c>MergeOrUploadDocumentsAsync</c>
+/// reports per-document failures WITHOUT throwing, so a store that ignored
+/// <c>IndexingResult.Succeeded</c> would let the ingest command report Success while
+/// chunks (and their provenance stamps) silently never landed. Both stores must fail the
+/// operation on any per-document failure so the ingest handler's compensation runs.
+/// </summary>
+public sealed class AzureAISearchStoreIndexingFailureTests
+{
+    private static Response<IndexDocumentsResult> BatchResponse(params bool[] outcomes)
+    {
+        var results = outcomes
+            .Select((succeeded, i) => SearchModelFactory.IndexingResult(
+                key: $"chunk-{i}",
+                errorMessage: succeeded ? null : "storage quota exceeded",
+                succeeded: succeeded,
+                status: succeeded ? 200 : 503))
+            .ToList();
+        return Response.FromValue(
+            SearchModelFactory.IndexDocumentsResult(results), Mock.Of<Response>());
+    }
+
+    private static Mock<SearchClient> ClientReturning(Response<IndexDocumentsResult> response)
+    {
+        var client = new Mock<SearchClient>();
+        client
+            .Setup(c => c.MergeOrUploadDocumentsAsync(
+                It.IsAny<IEnumerable<SearchDocument>>(),
+                It.IsAny<IndexDocumentsOptions>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(response);
+        return client;
+    }
+
+    private static IReadOnlyList<DocumentChunk> Chunks(int count) =>
+        Enumerable.Range(0, count)
+            .Select(i => RagTestData.CreateChunk(id: $"chunk-{i}", documentId: "doc-1"))
+            .ToList();
+
+    [Fact]
+    public async Task VectorStore_IndexAsync_PartialBatchFailure_Throws()
+    {
+        var store = new AzureAISearchVectorStore(
+            ClientReturning(BatchResponse(true, false)).Object,
+            Mock.Of<IEmbeddingService>(),
+            NullLogger<AzureAISearchVectorStore>.Instance);
+
+        var act = () => store.IndexAsync(Chunks(2));
+
+        (await act.Should().ThrowAsync<InvalidOperationException>())
+            .WithMessage("*1 of 2*", "the failure must name the failed count");
+    }
+
+    [Fact]
+    public async Task VectorStore_IndexAsync_AllSucceeded_DoesNotThrow()
+    {
+        var store = new AzureAISearchVectorStore(
+            ClientReturning(BatchResponse(true, true)).Object,
+            Mock.Of<IEmbeddingService>(),
+            NullLogger<AzureAISearchVectorStore>.Instance);
+
+        await store.Invoking(s => s.IndexAsync(Chunks(2))).Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task Bm25Store_IndexAsync_PartialBatchFailure_Throws()
+    {
+        var store = new AzureAISearchBm25Store(
+            ClientReturning(BatchResponse(false, true, true)).Object,
+            NullLogger<AzureAISearchBm25Store>.Instance);
+
+        var act = () => store.IndexAsync(Chunks(3));
+
+        (await act.Should().ThrowAsync<InvalidOperationException>())
+            .WithMessage("*1 of 3*");
+    }
+
+    [Fact]
+    public async Task Bm25Store_IndexAsync_AllSucceeded_DoesNotThrow()
+    {
+        var store = new AzureAISearchBm25Store(
+            ClientReturning(BatchResponse(true)).Object,
+            NullLogger<AzureAISearchBm25Store>.Instance);
+
+        await store.Invoking(s => s.IndexAsync(Chunks(1))).Should().NotThrowAsync();
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.RAG.Tests/Retrieval/FaissVectorStoreProvenanceTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.RAG.Tests/Retrieval/FaissVectorStoreProvenanceTests.cs
@@ -1,0 +1,58 @@
+using Domain.AI.RAG.Models;
+using FluentAssertions;
+using Infrastructure.AI.RAG.Retrieval;
+using Infrastructure.AI.RAG.Tests.Helpers;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Infrastructure.AI.RAG.Tests.Retrieval;
+
+/// <summary>
+/// Verifies that <see cref="FaissVectorStore"/> keeps the owner/tenant provenance stamps
+/// on the stored record but never exposes them on search results (matching the read-path
+/// projection of the persistent stores), and that tenant-derived collections are isolated
+/// from each other on the dense side of the local hybrid pairing.
+/// </summary>
+public sealed class FaissVectorStoreProvenanceTests
+{
+    private static readonly float[] Embedding = [0.5f, 0.5f, 0.5f];
+
+    private static DocumentChunk StampedChunk(string id, string? ownerId, string? tenantId)
+    {
+        var chunk = RagTestData.CreateChunk(id: id, documentId: $"doc-{id}");
+        return chunk with
+        {
+            Embedding = Embedding,
+            Metadata = chunk.Metadata with { OwnerId = ownerId, TenantId = tenantId },
+        };
+    }
+
+    [Fact]
+    public async Task SearchAsync_StampedChunk_DoesNotExposeStampsOnResults()
+    {
+        var store = new FaissVectorStore(NullLogger<FaissVectorStore>.Instance);
+        await store.IndexAsync([StampedChunk("s1", "user-1", "tenant-a")]);
+
+        var results = await store.SearchAsync(Embedding, topK: 5);
+
+        var metadata = results.Should().ContainSingle().Which.Chunk.Metadata;
+        metadata.OwnerId.Should().BeNull(
+            "stamps are erasure data; exposing them would tell every searcher who ingested each chunk");
+        metadata.TenantId.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task SearchAsync_TenantDerivedCollections_AreIsolated()
+    {
+        var store = new FaissVectorStore(NullLogger<FaissVectorStore>.Instance);
+        await store.IndexAsync(
+            [StampedChunk("a1", "u1", "tenant-a")], ScopedCollectionName.DeriveForTenant("tenant-a"));
+        await store.IndexAsync(
+            [StampedChunk("b1", "u2", "tenant-b")], ScopedCollectionName.DeriveForTenant("tenant-b"));
+
+        var seenByB = await store.SearchAsync(
+            Embedding, topK: 5, ScopedCollectionName.DeriveForTenant("tenant-b"));
+
+        seenByB.Should().ContainSingle().Which.Chunk.Id.Should().Be("b1");
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.RAG.Tests/Retrieval/HybridRetrieverTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.RAG.Tests/Retrieval/HybridRetrieverTests.cs
@@ -1,3 +1,4 @@
+using Application.AI.Common.Interfaces;
 using Application.AI.Common.Interfaces.RAG;
 using Domain.AI.RAG.Models;
 using FluentAssertions;
@@ -36,7 +37,8 @@ public sealed class HybridRetrieverTests
             _mockBm25Store.Object,
             _mockEmbedding.Object,
             config,
-            Mock.Of<ILogger<HybridRetriever>>());
+            Mock.Of<ILogger<HybridRetriever>>(),
+            Mock.Of<IAmbientRequestScope>());
     }
 
     [Fact]

--- a/src/Content/Tests/Infrastructure.AI.RAG.Tests/Retrieval/SqliteFts5StoreScopedCollectionsTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.RAG.Tests/Retrieval/SqliteFts5StoreScopedCollectionsTests.cs
@@ -1,0 +1,202 @@
+using Domain.AI.RAG.Models;
+using FluentAssertions;
+using Infrastructure.AI.RAG.Retrieval;
+using Infrastructure.AI.RAG.Tests.Helpers;
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Infrastructure.AI.RAG.Tests.Retrieval;
+
+/// <summary>
+/// Verifies the K4 store behaviors of <see cref="SqliteFts5Store"/>: genuine collection
+/// partitioning (search and delete scoped to one collection, mirroring
+/// <see cref="FaissVectorStore"/> so the local hybrid pipeline's dense and sparse halves
+/// agree), owner/tenant provenance stamps persisted for erasure but never exposed on the
+/// read path, and safe in-place migration of a legacy pre-collection table.
+/// </summary>
+public sealed class SqliteFts5StoreScopedCollectionsTests
+{
+    private static string UniqueConnectionString() =>
+        $"Data Source=Fts5Scoped-{Guid.NewGuid():N};Mode=Memory;Cache=Shared";
+
+    private static SqliteFts5Store CreateStore(string connectionString) =>
+        new(connectionString, NullLogger<SqliteFts5Store>.Instance);
+
+    private static DocumentChunk StampedChunk(
+        string id, string content, string documentId, string? ownerId, string? tenantId)
+    {
+        var chunk = RagTestData.CreateChunk(id: id, content: content, documentId: documentId);
+        return chunk with
+        {
+            Metadata = chunk.Metadata with { OwnerId = ownerId, TenantId = tenantId },
+        };
+    }
+
+    /// <summary>Reads persisted column values for a chunk row straight from the database.</summary>
+    private static async Task<(string? OwnerId, string? TenantId, string Collection)> ReadRowAsync(
+        string connectionString, string chunkId)
+    {
+        await using var connection = new SqliteConnection(connectionString);
+        await connection.OpenAsync();
+        await using var cmd = connection.CreateCommand();
+        cmd.CommandText = "SELECT owner_id, tenant_id, collection FROM chunks_fts WHERE id = @id";
+        cmd.Parameters.AddWithValue("@id", chunkId);
+        await using var reader = await cmd.ExecuteReaderAsync();
+        (await reader.ReadAsync()).Should().BeTrue($"row '{chunkId}' should exist");
+        return (
+            reader.IsDBNull(0) ? null : reader.GetString(0),
+            reader.IsDBNull(1) ? null : reader.GetString(1),
+            reader.GetString(2));
+    }
+
+    [Fact]
+    public async Task SearchAsync_TwoTenantDerivedCollections_CannotSeeEachOthersChunks()
+    {
+        var store = CreateStore(UniqueConnectionString());
+        var collectionA = ScopedCollectionName.DeriveForTenant("tenant-a");
+        var collectionB = ScopedCollectionName.DeriveForTenant("tenant-b");
+
+        await store.IndexAsync(
+            [StampedChunk("a1", "confidential alpha report", "doc-a", "user-1", "tenant-a")],
+            collectionA);
+        await store.IndexAsync(
+            [StampedChunk("b1", "confidential beta report", "doc-b", "user-2", "tenant-b")],
+            collectionB);
+
+        var seenByA = await store.SearchAsync("confidential report", topK: 10, collectionA);
+        var seenByB = await store.SearchAsync("confidential report", topK: 10, collectionB);
+
+        seenByA.Should().ContainSingle().Which.Chunk.Id.Should().Be("a1");
+        seenByB.Should().ContainSingle().Which.Chunk.Id.Should().Be("b1",
+            "a tenant-derived collection must never surface another tenant's chunks");
+    }
+
+    [Fact]
+    public async Task SearchAsync_NullCollection_SearchesDefaultCollectionOnly()
+    {
+        var store = CreateStore(UniqueConnectionString());
+
+        await store.IndexAsync(
+            [StampedChunk("g1", "shared corpus knowledge", "doc-g", null, null)]);
+        await store.IndexAsync(
+            [StampedChunk("t1", "shared corpus knowledge tenant copy", "doc-t", "u", "t")],
+            ScopedCollectionName.DeriveForTenant("tenant-a"));
+
+        var results = await store.SearchAsync("shared corpus", topK: 10);
+
+        results.Should().ContainSingle().Which.Chunk.Id.Should().Be("g1",
+            "no-identity callers address the closed default collection, not the whole table");
+    }
+
+    [Fact]
+    public async Task IndexAsync_StampedChunk_PersistsOwnerAndTenantColumns()
+    {
+        var connectionString = UniqueConnectionString();
+        var store = CreateStore(connectionString);
+        await store.IndexAsync(
+            [StampedChunk("s1", "provenance stamped content", "doc-s", "user-1", "tenant-a")]);
+
+        var row = await ReadRowAsync(connectionString, "s1");
+
+        row.OwnerId.Should().Be("user-1", "the persisted stamp is the future erasure key");
+        row.TenantId.Should().Be("tenant-a");
+        row.Collection.Should().Be("default");
+    }
+
+    [Fact]
+    public async Task SearchAsync_StampedChunk_DoesNotExposeStampsOnResults()
+    {
+        var store = CreateStore(UniqueConnectionString());
+        await store.IndexAsync(
+            [StampedChunk("s1", "provenance stamped content", "doc-s", "user-1", "tenant-a")]);
+
+        var results = await store.SearchAsync("provenance stamped", topK: 10);
+
+        var metadata = results.Should().ContainSingle().Which.Chunk.Metadata;
+        metadata.OwnerId.Should().BeNull(
+            "stamps are erasure data; exposing them would tell every searcher who ingested each chunk");
+        metadata.TenantId.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task DeleteAsync_ScopedToCollection_LeavesOtherCollectionsIntact()
+    {
+        var store = CreateStore(UniqueConnectionString());
+
+        await store.IndexAsync(
+            [StampedChunk("d1", "duplicated document text", "doc-1", null, "tenant-a")], "coll-a");
+        await store.IndexAsync(
+            [StampedChunk("d2", "duplicated document text", "doc-1", null, "tenant-b")], "coll-b");
+
+        await store.DeleteAsync("doc-1", "coll-a");
+
+        (await store.SearchAsync("duplicated document", topK: 10, "coll-a")).Should().BeEmpty();
+        (await store.SearchAsync("duplicated document", topK: 10, "coll-b")).Should().ContainSingle(
+            "deletion is collection-scoped, mirroring FaissVectorStore");
+    }
+
+    [Fact]
+    public async Task IndexAsync_LegacyPreCollectionTable_MigratesRowsIntoDefaultCollection()
+    {
+        var connectionString = UniqueConnectionString();
+
+        // Keep the shared in-memory database alive and create the pre-K4 schema with a row,
+        // exactly as a persistent database written by the old store would contain.
+        await using var keepAlive = new SqliteConnection(connectionString);
+        await keepAlive.OpenAsync();
+        await using (var cmd = keepAlive.CreateCommand())
+        {
+            cmd.CommandText = """
+                CREATE VIRTUAL TABLE chunks_fts USING fts5(
+                    id UNINDEXED, document_id UNINDEXED, content, section_path);
+                INSERT INTO chunks_fts(id, document_id, content, section_path)
+                VALUES ('legacy-1', 'doc-legacy', 'legacy corpus content survives migration', 'Root');
+                """;
+            await cmd.ExecuteNonQueryAsync();
+        }
+
+        var store = CreateStore(connectionString);
+        await store.IndexAsync(
+            [StampedChunk("new-1", "fresh content after migration", "doc-new", "u1", "t1")]);
+
+        var legacyHits = await store.SearchAsync("legacy corpus", topK: 10);
+        legacyHits.Should().ContainSingle().Which.Chunk.Id.Should().Be("legacy-1");
+
+        var legacyRow = await ReadRowAsync(connectionString, "legacy-1");
+        legacyRow.Collection.Should().Be("default", "legacy rows land in the default collection");
+        legacyRow.OwnerId.Should().BeNull("legacy rows carry no stamps");
+
+        // "fresh" is unique to the new row (the FTS query ORs its tokens, so a shared
+        // token like "content" would match the legacy row too).
+        (await store.SearchAsync("fresh", topK: 10)).Should().ContainSingle(
+            "new rows land in the migrated table alongside the copied legacy rows");
+    }
+
+    [Fact]
+    public async Task EnsureInitialized_SecondStoreOnMigratedDatabase_DoesNotReMigrate()
+    {
+        var connectionString = UniqueConnectionString();
+
+        // First store initializes the current schema and writes into a named collection.
+        var first = CreateStore(connectionString);
+        await first.IndexAsync(
+            [StampedChunk("n1", "partitioned tenant content", "doc-n", "u1", "tenant-a")],
+            "coll-a");
+
+        // A second store instance (e.g. another process on the same database file) must
+        // see the already-current schema and leave it alone — a re-migration would
+        // collapse every collection into 'default' and null the stamps.
+        var second = CreateStore(connectionString);
+        await second.IndexAsync(
+            [StampedChunk("n2", "other partitioned content", "doc-n2", "u2", "tenant-b")],
+            "coll-b");
+
+        var row = await ReadRowAsync(connectionString, "n1");
+        row.Collection.Should().Be("coll-a", "re-initialization must not collapse collections");
+        row.OwnerId.Should().Be("u1", "re-initialization must not null the stamps");
+
+        (await second.SearchAsync("partitioned tenant", topK: 10, "coll-a"))
+            .Should().ContainSingle().Which.Chunk.Id.Should().Be("n1");
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.RAG.Tests/Retrieval/StoreEraseAllCollectionsTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.RAG.Tests/Retrieval/StoreEraseAllCollectionsTests.cs
@@ -1,0 +1,99 @@
+using Domain.AI.RAG.Models;
+using FluentAssertions;
+using Infrastructure.AI.RAG.Retrieval;
+using Infrastructure.AI.RAG.Tests.Helpers;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Infrastructure.AI.RAG.Tests.Retrieval;
+
+/// <summary>
+/// Verifies the erasure-delete contract of the local stores: <c>DeleteAsync</c> returns
+/// the rows it actually removed (never the requested count), and
+/// <c>DeleteFromAllCollectionsAsync</c> reaches a document's chunks in EVERY collection —
+/// including named collections a default-scoped delete would silently miss, which is both
+/// the ScopedCollections erasure path and the flag-off named-collection regression.
+/// </summary>
+public sealed class StoreEraseAllCollectionsTests
+{
+    private static readonly float[] Embedding = [0.4f, 0.4f, 0.4f];
+
+    private static SqliteFts5Store CreateFtsStore() => new(
+        $"Data Source=EraseAll-{Guid.NewGuid():N};Mode=Memory;Cache=Shared",
+        NullLogger<SqliteFts5Store>.Instance);
+
+    private static DocumentChunk Chunk(string id, string documentId)
+    {
+        var chunk = RagTestData.CreateChunk(
+            id: id, content: "erasable content body", documentId: documentId);
+        return chunk with { Embedding = Embedding };
+    }
+
+    [Fact]
+    public async Task DeleteFromAllCollectionsAsync_Sqlite_RemovesDocumentFromNamedCollection()
+    {
+        // BLOCKING-2 regression: flag OFF, caller ingested into a named collection; the
+        // erasure delete must still remove the rows (the collection-scoped DeleteAsync
+        // deliberately would not).
+        var store = CreateFtsStore();
+        await store.IndexAsync([Chunk("c1", "doc-1")], "docs");
+
+        var deleted = await store.DeleteFromAllCollectionsAsync("doc-1");
+
+        deleted.Should().Be(1);
+        (await store.SearchAsync("erasable content", topK: 5, "docs")).Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task DeleteFromAllCollectionsAsync_Sqlite_SpansMultipleCollections()
+    {
+        var store = CreateFtsStore();
+        await store.IndexAsync([Chunk("c1", "doc-1")], "coll-a");
+        await store.IndexAsync([Chunk("c2", "doc-1")], "coll-b");
+        await store.IndexAsync([Chunk("c3", "doc-other")], "coll-a");
+
+        var deleted = await store.DeleteFromAllCollectionsAsync("doc-1");
+
+        deleted.Should().Be(2, "the document's rows in every collection count, others do not");
+        (await store.SearchAsync("erasable content", topK: 5, "coll-a"))
+            .Should().ContainSingle().Which.Chunk.Id.Should().Be("c3");
+    }
+
+    [Fact]
+    public async Task DeleteAsync_Sqlite_ReturnsActualRemovedCount()
+    {
+        var store = CreateFtsStore();
+        await store.IndexAsync([Chunk("c1", "doc-1"), Chunk("c2", "doc-1")]);
+
+        (await store.DeleteAsync("doc-1")).Should().Be(2);
+        (await store.DeleteAsync("doc-1")).Should().Be(0, "a repeat delete removes nothing");
+    }
+
+    [Fact]
+    public async Task DeleteFromAllCollectionsAsync_Faiss_SpansMultipleCollections()
+    {
+        var store = new FaissVectorStore(NullLogger<FaissVectorStore>.Instance);
+        await store.IndexAsync([Chunk("c1", "doc-1")], "coll-a");
+        await store.IndexAsync([Chunk("c2", "doc-1")], "coll-b");
+        await store.IndexAsync([Chunk("c3", "doc-other")], "coll-a");
+
+        var deleted = await store.DeleteFromAllCollectionsAsync("doc-1");
+
+        deleted.Should().Be(2);
+        (await store.SearchAsync(Embedding, topK: 5, "coll-a"))
+            .Should().ContainSingle().Which.Chunk.Id.Should().Be("c3");
+        (await store.SearchAsync(Embedding, topK: 5, "coll-b")).Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task DeleteAsync_Faiss_ScopedToOneCollection_ReturnsActualCount()
+    {
+        var store = new FaissVectorStore(NullLogger<FaissVectorStore>.Instance);
+        await store.IndexAsync([Chunk("c1", "doc-1")], "coll-a");
+        await store.IndexAsync([Chunk("c2", "doc-1")], "coll-b");
+
+        (await store.DeleteAsync("doc-1", "coll-a")).Should().Be(1);
+        (await store.SearchAsync(Embedding, topK: 5, "coll-b"))
+            .Should().ContainSingle("the other collection's copy survives a collection-scoped delete");
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.RAG.Tests/SqlDatabase/SqlDatabaseRetrievalSourceTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.RAG.Tests/SqlDatabase/SqlDatabaseRetrievalSourceTests.cs
@@ -50,7 +50,7 @@ public sealed class SqlDatabaseRetrievalSourceTests
 
         var sut = CreateSut(allowLlmFallback: true);
 
-        var result = await sut.RetrieveAsync("Find user Alice", 10, TaskComplexity.Moderate, CancellationToken.None);
+        var result = await sut.RetrieveAsync("Find user Alice", 10, TaskComplexity.Moderate, collectionName: null, cancellationToken: CancellationToken.None);
 
         result.SourceName.Should().Be("sql_database");
         result.Results.Should().HaveCount(1);
@@ -78,7 +78,7 @@ public sealed class SqlDatabaseRetrievalSourceTests
 
         var sut = CreateSut(allowLlmFallback: true);
 
-        var result = await sut.RetrieveAsync("Cheap products", 10, TaskComplexity.Moderate, CancellationToken.None);
+        var result = await sut.RetrieveAsync("Cheap products", 10, TaskComplexity.Moderate, collectionName: null, cancellationToken: CancellationToken.None);
 
         result.Results.Should().HaveCount(1);
     }
@@ -92,7 +92,7 @@ public sealed class SqlDatabaseRetrievalSourceTests
 
         var sut = CreateSut(allowLlmFallback: false);
 
-        var result = await sut.RetrieveAsync("Cheap products", 10, TaskComplexity.Moderate, CancellationToken.None);
+        var result = await sut.RetrieveAsync("Cheap products", 10, TaskComplexity.Moderate, collectionName: null, cancellationToken: CancellationToken.None);
 
         result.Results.Should().BeEmpty();
     }
@@ -114,7 +114,7 @@ public sealed class SqlDatabaseRetrievalSourceTests
 
         var sut = CreateSut(allowLlmFallback: true);
 
-        var result = await sut.RetrieveAsync("Unknown query", 10, TaskComplexity.Moderate, CancellationToken.None);
+        var result = await sut.RetrieveAsync("Unknown query", 10, TaskComplexity.Moderate, collectionName: null, cancellationToken: CancellationToken.None);
 
         result.Results.Should().BeEmpty();
     }

--- a/src/Content/Tests/Infrastructure.AI.RAG.Tests/WebSearch/WebSearchRetrievalSourceTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.RAG.Tests/WebSearch/WebSearchRetrievalSourceTests.cs
@@ -24,7 +24,7 @@ public sealed class WebSearchRetrievalSourceTests
 
         var sut = new WebSearchRetrievalSource(_provider.Object);
 
-        var result = await sut.RetrieveAsync("test", 5, TaskComplexity.Complex, CancellationToken.None);
+        var result = await sut.RetrieveAsync("test", 5, TaskComplexity.Complex, collectionName: null, cancellationToken: CancellationToken.None);
 
         result.SourceName.Should().Be("web_search");
         result.Results.Should().HaveCount(2);
@@ -43,7 +43,7 @@ public sealed class WebSearchRetrievalSourceTests
 
         var sut = new WebSearchRetrievalSource(_provider.Object);
 
-        var result = await sut.RetrieveAsync("test", 5, TaskComplexity.Complex, CancellationToken.None);
+        var result = await sut.RetrieveAsync("test", 5, TaskComplexity.Complex, collectionName: null, cancellationToken: CancellationToken.None);
 
         result.Results.Should().BeEmpty();
     }

--- a/src/Content/Tests/Infrastructure.AI.Tests/Planner/StepExecutors/RetrievalPlanStepExecutorTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Planner/StepExecutors/RetrievalPlanStepExecutorTests.cs
@@ -101,7 +101,7 @@ public sealed class RetrievalPlanStepExecutorTests
             });
 
         _mockMultiSource
-            .Setup(m => m.RetrieveFromAllSourcesAsync("Multi-hop query", 10, TaskComplexity.Complex, It.IsAny<CancellationToken>()))
+            .Setup(m => m.RetrieveFromAllSourcesAsync("Multi-hop query", 10, TaskComplexity.Complex, null, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<RetrievalResult>
             {
                 new()
@@ -131,7 +131,7 @@ public sealed class RetrievalPlanStepExecutorTests
         Assert.Equal(StepExecutionStatus.Completed, result.Status);
 
         _mockMultiSource.Verify(
-            m => m.RetrieveFromAllSourcesAsync("Multi-hop query", 10, TaskComplexity.Complex, It.IsAny<CancellationToken>()),
+            m => m.RetrieveFromAllSourcesAsync("Multi-hop query", 10, TaskComplexity.Complex, null, It.IsAny<CancellationToken>()),
             Times.Once);
         _mockRagOrchestrator.Verify(
             r => r.SearchAsync(It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<string?>(), It.IsAny<RetrievalStrategy?>(), It.IsAny<CancellationToken>()),


### PR DESCRIPTION
## What

Wave 2 PR **K4** (both halves per the locked decision):

1. **Provenance stamping (always on)**: every ingested chunk is stamped with `OwnerId`/`TenantId` from the ambient knowledge scope — after all chunk-producing stages so RAPTOR/enrichment-derived chunks are stamped too. Stamps are provenance only (the future erasure key), never a retrieval filter; identity never comes from the DTO; stamps survive round-trip in all three stores and are **projected out of every search response** (searchers must not learn who ingested what).
2. **Opt-in `ScopedCollections` (default OFF)**: when on, the effective collection for ingest/search/delete is derived server-side — `tenant-{slug≤32}-{sha256:16hex}` — and caller-supplied collection names are rejected (validators) and ignored (defense-in-depth at the choke points below). Startup hard-fails the combinations that cannot honor collections: `azure_ai_search` vector store, `AgenticRetrieval`, and `GraphRag.IndexOnIngest` (the corpus graph is inherently tenant-shared).

## The security finding that shaped this PR

The pre-push security review returned **BLOCK**: validator-level enforcement left three direct-call paths (the `document_search` tool, plan retrieval steps, workflow vector retrieval) able to pass an offline-computable collection name straight to the stores. Enforcement now lives at two shared choke points — `RagOrchestrator.SearchAsync` and `HybridRetriever.RetrieveAsync` re-derive the collection from the ambient tenant whenever the flag is on (idempotent, so double-resolution from the MediatR handlers is harmless). Seven end-to-end regression tests drive each named bypass path with a "correct-looking" victim collection and prove the stores never see it.

## One deliberate deviation

`SqliteFts5Store` now partitions by collection **unconditionally** (schema migration included, guarded by `BEGIN IMMEDIATE` against concurrent-host double-migration). Pre-K4 the BM25 side ignored collection names entirely while FAISS partitioned — a dense/sparse asymmetry where sparse search leaked across collections. Flag-OFF behavior changes only for callers who relied on that bug; keeping it gated would have preserved a leak.

## Review trail

Standards/spec + 4-angle simplify + security review pre-push; all BLOCK items fixed (choke-point enforcement CRITICAL, GraphRag combo HIGH, wire provenance + 64-bit hash suffix + migration TOCTOU MEDs, identity snapshot LOW).

## Test plan

Infrastructure.AI.RAG.Tests 256 (+15), Domain.AI.Tests 836, Application.Core.Tests 777, Infrastructure.AI.Tests 2180, Presentation.AgentHub.Tests 411 — all green post-merge with main; build 0 errors, 0 new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BnoLcufW278UxA9ssBM1Tc