### PR TITLE
feat: autonomy governance read endpoints (H3)

### DIFF
--- a/src/Content/Application/Application.Core/CQRS/Autonomy/AutonomyDecisionPreviewResult.cs
+++ b/src/Content/Application/Application.Core/CQRS/Autonomy/AutonomyDecisionPreviewResult.cs
@@ -1,0 +1,55 @@
+using Domain.AI.Agents;
+using Domain.AI.Changes;
+using Domain.AI.Governance;
+
+namespace Application.Core.CQRS.Autonomy;
+
+/// <summary>
+/// The outcome of a side-effect-free autonomy decision preview: what the graded-autonomy
+/// evaluator would decide for the described action, plus the inputs the decision was computed
+/// from. Mirrors <see cref="AutonomyDecisionResult"/> with the subagent type the caller asked
+/// about added for self-describing responses.
+/// </summary>
+/// <param name="SubagentType">The subagent type the preview was computed for.</param>
+/// <param name="Decision">The evaluator's verdict: <c>AutoApprove</c> (allowed without a gate), <c>RequiresApproval</c> (routes through human escalation), or <c>Forbidden</c> (denied outright).</param>
+/// <param name="Tier">The subagent's effective autonomy tier at evaluation time.</param>
+/// <param name="BlastRadius">The proposed action's blast radius, as submitted.</param>
+/// <param name="TargetKind">The proposed action's target kind, as submitted.</param>
+/// <param name="IsStateChange">Whether the proposed action mutates state.</param>
+/// <param name="Environment">The host environment name the decision was evaluated under.</param>
+/// <param name="SkillKey">The skill key the decision was evaluated for, or null when not skill-attributable.</param>
+/// <param name="Reason">Human-readable explanation pinning the rule that drove the decision.</param>
+public sealed record AutonomyDecisionPreviewResult(
+    SubagentType SubagentType,
+    AutonomyDecision Decision,
+    AutonomyLevel Tier,
+    BlastRadius BlastRadius,
+    ChangeTargetKind TargetKind,
+    bool IsStateChange,
+    string Environment,
+    string? SkillKey,
+    string Reason)
+{
+    /// <summary>
+    /// Projects the evaluator's <see cref="AutonomyDecisionResult"/> into the preview shape.
+    /// </summary>
+    /// <param name="subagentType">The subagent type the preview was computed for.</param>
+    /// <param name="result">The evaluator's decision result.</param>
+    /// <returns>The preview projection.</returns>
+    public static AutonomyDecisionPreviewResult FromResult(
+        SubagentType subagentType, AutonomyDecisionResult result)
+    {
+        ArgumentNullException.ThrowIfNull(result);
+
+        return new AutonomyDecisionPreviewResult(
+            subagentType,
+            result.Decision,
+            result.Tier,
+            result.BlastRadius,
+            result.TargetKind,
+            result.IsStateChange,
+            result.Environment,
+            result.SkillKey,
+            result.Reason);
+    }
+}

--- a/src/Content/Application/Application.Core/CQRS/Autonomy/AutonomyTierDetail.cs
+++ b/src/Content/Application/Application.Core/CQRS/Autonomy/AutonomyTierDetail.cs
@@ -1,0 +1,15 @@
+using Domain.AI.Agents;
+using Domain.AI.Governance;
+
+namespace Application.Core.CQRS.Autonomy;
+
+/// <summary>
+/// The effective autonomy tier for one subagent type, as resolved by
+/// <see cref="Application.AI.Common.Interfaces.Governance.IAutonomyTierResolver"/> — profile
+/// registry first, then the <c>PermissionsConfig.DefaultAutonomyLevel</c> fallback.
+/// </summary>
+/// <param name="SubagentType">The subagent type the tier was resolved for.</param>
+/// <param name="Tier">The effective autonomy tier at read time. Pure config — reading it has no side effects.</param>
+public sealed record AutonomyTierDetail(
+    SubagentType SubagentType,
+    AutonomyLevel Tier);

--- a/src/Content/Application/Application.Core/CQRS/Autonomy/AutonomyValidationRules.cs
+++ b/src/Content/Application/Application.Core/CQRS/Autonomy/AutonomyValidationRules.cs
@@ -1,0 +1,77 @@
+using Domain.AI.Changes;
+
+namespace Application.Core.CQRS.Autonomy;
+
+/// <summary>
+/// Shared validation constants, failure messages, and parsing rules for the autonomy governance
+/// read surface. Centralized so the tier-read and decision-preview paths agree on what a
+/// well-formed subagent type, enum name, and skill key look like — and so the FluentValidation
+/// boundary and the handlers' defense-in-depth re-checks emit the identical message for the
+/// identical problem.
+/// </summary>
+public static class AutonomyValidationRules
+{
+    /// <summary>
+    /// Failure message for a subagent type name that does not name a defined
+    /// <see cref="Domain.AI.Agents.SubagentType"/> member. Maps to 404 at the HTTP boundary.
+    /// Deliberately static — it never echoes the caller-supplied value.
+    /// </summary>
+    public const string UnknownSubagentTypeMessage = "No subagent type with the given name exists.";
+
+    /// <summary>
+    /// Failure message for a blast radius value that does not name a defined
+    /// <see cref="BlastRadius"/> member. Used by both the validator and the handler's
+    /// defense-in-depth re-check so the two paths cannot drift.
+    /// </summary>
+    public static readonly string InvalidBlastRadiusMessage =
+        $"BlastRadius must be one of: {string.Join(", ", Enum.GetNames<BlastRadius>())}.";
+
+    /// <summary>
+    /// Failure message for a target kind value that does not name a defined
+    /// <see cref="ChangeTargetKind"/> member. Used by both the validator and the handler's
+    /// defense-in-depth re-check so the two paths cannot drift.
+    /// </summary>
+    public static readonly string InvalidTargetKindMessage =
+        $"TargetKind must be one of: {string.Join(", ", Enum.GetNames<ChangeTargetKind>())}.";
+
+    /// <summary>
+    /// Maximum accepted length for an enum-name wire value (subagent type, blast radius,
+    /// target kind). The longest real member name is far shorter; 64 characters bounds log
+    /// lines and ProblemDetails payloads without ever rejecting a legitimate name.
+    /// </summary>
+    public const int MaxEnumNameLength = 64;
+
+    /// <summary>
+    /// Maximum accepted skill-key length. Skill keys are operator-authored identifiers used
+    /// in <c>GradedAutonomyConfig</c> lookups; 256 characters comfortably covers realistic
+    /// keys while bounding the evaluator's reason strings and audit lines.
+    /// </summary>
+    public const int MaxSkillKeyLength = 256;
+
+    /// <summary>
+    /// Parses an enum member by <em>name</em>, case-insensitively, rejecting numeric forms.
+    /// </summary>
+    /// <typeparam name="TEnum">The enum type to parse.</typeparam>
+    /// <param name="value">The candidate wire value.</param>
+    /// <param name="parsed">The parsed member when the method returns <see langword="true"/>.</param>
+    /// <returns><see langword="true"/> when <paramref name="value"/> names a defined member.</returns>
+    /// <remarks>
+    /// <see cref="Enum.TryParse{TEnum}(string?, bool, out TEnum)"/> alone would accept any
+    /// integer string — including values outside the defined range — so this helper rejects
+    /// leading digits and signs outright and additionally requires
+    /// <see cref="Enum.IsDefined{TEnum}(TEnum)"/>. The wire contract is names only.
+    /// </remarks>
+    public static bool TryParseEnumName<TEnum>(string? value, out TEnum parsed)
+        where TEnum : struct, Enum
+    {
+        parsed = default;
+
+        if (string.IsNullOrWhiteSpace(value))
+            return false;
+
+        if (char.IsAsciiDigit(value[0]) || value[0] is '-' or '+')
+            return false;
+
+        return Enum.TryParse(value, ignoreCase: true, out parsed) && Enum.IsDefined(parsed);
+    }
+}

--- a/src/Content/Application/Application.Core/CQRS/Autonomy/GetAutonomyTierQuery.cs
+++ b/src/Content/Application/Application.Core/CQRS/Autonomy/GetAutonomyTierQuery.cs
@@ -1,0 +1,20 @@
+using Domain.Common;
+using MediatR;
+
+namespace Application.Core.CQRS.Autonomy;
+
+/// <summary>
+/// Reads the effective autonomy tier for a subagent type. Strictly read-only: autonomy tiers
+/// are pure configuration (profile registry plus <c>PermissionsConfig</c> fallback), so this
+/// query performs no writes, no audit records, and no state changes.
+/// </summary>
+/// <remarks>
+/// The subagent type travels as a string because the HTTP surface receives it as a route
+/// segment; the handler parses it by name and returns <c>NotFound</c> for anything that does
+/// not name a defined <see cref="Domain.AI.Agents.SubagentType"/> member.
+/// </remarks>
+public sealed record GetAutonomyTierQuery : IRequest<Result<AutonomyTierDetail>>
+{
+    /// <summary>The subagent type name to resolve (case-insensitive, e.g. <c>Explore</c>).</summary>
+    public required string SubagentType { get; init; }
+}

--- a/src/Content/Application/Application.Core/CQRS/Autonomy/GetAutonomyTierQueryHandler.cs
+++ b/src/Content/Application/Application.Core/CQRS/Autonomy/GetAutonomyTierQueryHandler.cs
@@ -1,0 +1,55 @@
+using Application.AI.Common.Interfaces.Governance;
+using Domain.AI.Agents;
+using Domain.Common;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace Application.Core.CQRS.Autonomy;
+
+/// <summary>
+/// Resolves the effective autonomy tier for a subagent type via the shared
+/// <see cref="IAutonomyTierResolver"/> — the same resolver the enforcement path consults —
+/// so the read surface can never drift from what enforcement actually applies.
+/// </summary>
+/// <remarks>
+/// Read-only by construction: the handler's only dependency besides logging is the resolver,
+/// which performs registry and configuration lookups. Nothing is written, audited, or cached.
+/// </remarks>
+public sealed class GetAutonomyTierQueryHandler
+    : IRequestHandler<GetAutonomyTierQuery, Result<AutonomyTierDetail>>
+{
+    private readonly IAutonomyTierResolver _tierResolver;
+    private readonly ILogger<GetAutonomyTierQueryHandler> _logger;
+
+    /// <summary>Initializes a new instance of the <see cref="GetAutonomyTierQueryHandler"/> class.</summary>
+    /// <param name="tierResolver">The shared tier resolver the enforcement path also uses.</param>
+    /// <param name="logger">Logger for unknown-type diagnostics (caller-supplied values are never logged verbatim).</param>
+    public GetAutonomyTierQueryHandler(
+        IAutonomyTierResolver tierResolver,
+        ILogger<GetAutonomyTierQueryHandler> logger)
+    {
+        ArgumentNullException.ThrowIfNull(tierResolver);
+        ArgumentNullException.ThrowIfNull(logger);
+        _tierResolver = tierResolver;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public Task<Result<AutonomyTierDetail>> Handle(
+        GetAutonomyTierQuery request, CancellationToken cancellationToken)
+    {
+        if (!AutonomyValidationRules.TryParseEnumName<SubagentType>(
+                request.SubagentType, out var subagentType))
+        {
+            // The raw value is caller-controlled and deliberately kept out of the log line.
+            _logger.LogWarning("Autonomy tier read for an unknown subagent type returned NotFound");
+            return Task.FromResult(Result<AutonomyTierDetail>.NotFound(
+                AutonomyValidationRules.UnknownSubagentTypeMessage));
+        }
+
+        var tier = _tierResolver.Resolve(subagentType);
+
+        return Task.FromResult(Result<AutonomyTierDetail>.Success(
+            new AutonomyTierDetail(subagentType, tier)));
+    }
+}

--- a/src/Content/Application/Application.Core/CQRS/Autonomy/GetAutonomyTierQueryValidator.cs
+++ b/src/Content/Application/Application.Core/CQRS/Autonomy/GetAutonomyTierQueryValidator.cs
@@ -1,0 +1,20 @@
+using FluentValidation;
+
+namespace Application.Core.CQRS.Autonomy;
+
+/// <summary>
+/// Validates <see cref="GetAutonomyTierQuery"/>: a present, bounded subagent type name.
+/// Whether the name maps to a defined subagent type is the handler's concern — an unknown
+/// name is a <c>NotFound</c> (404), not a validation failure (400).
+/// </summary>
+public sealed class GetAutonomyTierQueryValidator : AbstractValidator<GetAutonomyTierQuery>
+{
+    /// <summary>Initializes validation rules.</summary>
+    public GetAutonomyTierQueryValidator()
+    {
+        RuleFor(x => x.SubagentType)
+            .NotEmpty().WithMessage("SubagentType must not be empty.")
+            .MaximumLength(AutonomyValidationRules.MaxEnumNameLength)
+                .WithMessage($"SubagentType must not exceed {AutonomyValidationRules.MaxEnumNameLength} characters.");
+    }
+}

--- a/src/Content/Application/Application.Core/CQRS/Autonomy/PreviewAutonomyDecisionQuery.cs
+++ b/src/Content/Application/Application.Core/CQRS/Autonomy/PreviewAutonomyDecisionQuery.cs
@@ -1,0 +1,48 @@
+using Domain.AI.Changes;
+using Domain.Common;
+using MediatR;
+
+namespace Application.Core.CQRS.Autonomy;
+
+/// <summary>
+/// Previews the graded-autonomy decision for a hypothetical action without executing anything:
+/// "would this action, by this subagent, be allowed, routed through approval, or forbidden?".
+/// Strictly side-effect-free — the same pure evaluation the enforcement path runs, minus the
+/// enforcement. No audit records, no state changes, no escalations raised.
+/// </summary>
+/// <remarks>
+/// Enum inputs travel as strings because this is the HTTP boundary shape. The handler parses
+/// them by name: an unknown subagent type is <c>NotFound</c> (the resource being asked about
+/// does not exist); an unknown blast radius or target kind is a validation failure (the request
+/// itself is malformed).
+/// </remarks>
+public sealed record PreviewAutonomyDecisionQuery : IRequest<Result<AutonomyDecisionPreviewResult>>
+{
+    /// <summary>
+    /// The default <see cref="TargetKind"/> value when the caller does not supply one. Single
+    /// source of truth for the "omitted target kind evaluates as <c>Unspecified</c>" rule —
+    /// the HTTP controller references this constant rather than re-deriving it.
+    /// </summary>
+    public const string DefaultTargetKind = nameof(ChangeTargetKind.Unspecified);
+
+    /// <summary>The subagent type name the preview is for (case-insensitive, e.g. <c>Execute</c>).</summary>
+    public required string SubagentType { get; init; }
+
+    /// <summary>The proposed action's blast radius name (case-insensitive, e.g. <c>Medium</c>).</summary>
+    public required string BlastRadius { get; init; }
+
+    /// <summary>
+    /// The proposed action's target kind name (case-insensitive). Defaults to
+    /// <c>Unspecified</c>, matching how non-target-specific proposals are evaluated.
+    /// </summary>
+    public string TargetKind { get; init; } = DefaultTargetKind;
+
+    /// <summary>Whether the proposed action mutates state (writes a file, applies a deployment, runs a migration).</summary>
+    public bool IsStateChange { get; init; }
+
+    /// <summary>
+    /// The skill key the action is attributed to, or null when not skill-attributable.
+    /// Drives the evaluator's per-skill narrowing and state-changer opt-in checks.
+    /// </summary>
+    public string? SkillKey { get; init; }
+}

--- a/src/Content/Application/Application.Core/CQRS/Autonomy/PreviewAutonomyDecisionQueryHandler.cs
+++ b/src/Content/Application/Application.Core/CQRS/Autonomy/PreviewAutonomyDecisionQueryHandler.cs
@@ -1,0 +1,88 @@
+using Application.AI.Common.Interfaces.Governance;
+using Domain.AI.Agents;
+using Domain.AI.Changes;
+using Domain.Common;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace Application.Core.CQRS.Autonomy;
+
+/// <summary>
+/// Computes a decision preview by chaining the two shared governance services the enforcement
+/// path itself uses: <see cref="IAutonomyTierResolver"/> for the subagent's effective tier,
+/// then <see cref="IAutonomyDecisionEvaluator"/> for the graded-autonomy verdict. Because the
+/// preview and the enforcement path call the <em>same</em> evaluator with the same inputs, the
+/// preview can never drift from what enforcement would actually decide.
+/// </summary>
+/// <remarks>
+/// Side-effect-free by construction: both dependencies are pure lookup/evaluation services.
+/// The handler writes nothing, audits nothing, and raises no escalations — it answers a
+/// hypothetical.
+/// </remarks>
+public sealed class PreviewAutonomyDecisionQueryHandler
+    : IRequestHandler<PreviewAutonomyDecisionQuery, Result<AutonomyDecisionPreviewResult>>
+{
+    private readonly IAutonomyTierResolver _tierResolver;
+    private readonly IAutonomyDecisionEvaluator _decisionEvaluator;
+    private readonly ILogger<PreviewAutonomyDecisionQueryHandler> _logger;
+
+    /// <summary>Initializes a new instance of the <see cref="PreviewAutonomyDecisionQueryHandler"/> class.</summary>
+    /// <param name="tierResolver">The shared tier resolver the enforcement path also uses.</param>
+    /// <param name="decisionEvaluator">The shared graded-autonomy evaluator the enforcement path also uses.</param>
+    /// <param name="logger">Logger for malformed-input diagnostics (caller-supplied values are never logged verbatim).</param>
+    public PreviewAutonomyDecisionQueryHandler(
+        IAutonomyTierResolver tierResolver,
+        IAutonomyDecisionEvaluator decisionEvaluator,
+        ILogger<PreviewAutonomyDecisionQueryHandler> logger)
+    {
+        ArgumentNullException.ThrowIfNull(tierResolver);
+        ArgumentNullException.ThrowIfNull(decisionEvaluator);
+        ArgumentNullException.ThrowIfNull(logger);
+        _tierResolver = tierResolver;
+        _decisionEvaluator = decisionEvaluator;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public Task<Result<AutonomyDecisionPreviewResult>> Handle(
+        PreviewAutonomyDecisionQuery request, CancellationToken cancellationToken)
+    {
+        if (!AutonomyValidationRules.TryParseEnumName<SubagentType>(
+                request.SubagentType, out var subagentType))
+        {
+            // The raw value is caller-controlled and deliberately kept out of the log line.
+            _logger.LogWarning("Autonomy decision preview for an unknown subagent type returned NotFound");
+            return Task.FromResult(Result<AutonomyDecisionPreviewResult>.NotFound(
+                AutonomyValidationRules.UnknownSubagentTypeMessage));
+        }
+
+        // The FluentValidation validator already rejects malformed names with a 400 before the
+        // handler runs; these re-checks keep the handler safe when dispatched outside the
+        // MediatR pipeline (defense in depth, same failure classification).
+        if (!AutonomyValidationRules.TryParseEnumName<BlastRadius>(
+                request.BlastRadius, out var blastRadius))
+        {
+            return Task.FromResult(Result<AutonomyDecisionPreviewResult>.ValidationFailure(
+                [AutonomyValidationRules.InvalidBlastRadiusMessage]));
+        }
+
+        if (!AutonomyValidationRules.TryParseEnumName<ChangeTargetKind>(
+                request.TargetKind, out var targetKind))
+        {
+            return Task.FromResult(Result<AutonomyDecisionPreviewResult>.ValidationFailure(
+                [AutonomyValidationRules.InvalidTargetKindMessage]));
+        }
+
+        var tier = _tierResolver.Resolve(subagentType);
+
+        var decision = _decisionEvaluator.Evaluate(
+            tier,
+            blastRadius,
+            targetKind,
+            request.IsStateChange,
+            string.IsNullOrWhiteSpace(request.SkillKey) ? null : request.SkillKey);
+
+        return Task.FromResult(Result<AutonomyDecisionPreviewResult>.Success(
+            AutonomyDecisionPreviewResult.FromResult(subagentType, decision)));
+    }
+}

--- a/src/Content/Application/Application.Core/CQRS/Autonomy/PreviewAutonomyDecisionQueryValidator.cs
+++ b/src/Content/Application/Application.Core/CQRS/Autonomy/PreviewAutonomyDecisionQueryValidator.cs
@@ -1,0 +1,43 @@
+using Domain.AI.Changes;
+using FluentValidation;
+
+namespace Application.Core.CQRS.Autonomy;
+
+/// <summary>
+/// Validates <see cref="PreviewAutonomyDecisionQuery"/>: a present, bounded subagent type name;
+/// blast radius and target kind values that name defined enum members; and a bounded optional
+/// skill key. Whether the subagent type name maps to a defined type is the handler's concern —
+/// an unknown subagent is <c>NotFound</c> (404), not a validation failure (400).
+/// </summary>
+public sealed class PreviewAutonomyDecisionQueryValidator
+    : AbstractValidator<PreviewAutonomyDecisionQuery>
+{
+    /// <summary>Initializes validation rules.</summary>
+    public PreviewAutonomyDecisionQueryValidator()
+    {
+        RuleFor(x => x.SubagentType)
+            .NotEmpty().WithMessage("SubagentType must not be empty.")
+            .MaximumLength(AutonomyValidationRules.MaxEnumNameLength)
+                .WithMessage($"SubagentType must not exceed {AutonomyValidationRules.MaxEnumNameLength} characters.");
+
+        RuleFor(x => x.BlastRadius)
+            .NotEmpty().WithMessage("BlastRadius must not be empty.")
+            .MaximumLength(AutonomyValidationRules.MaxEnumNameLength)
+                .WithMessage($"BlastRadius must not exceed {AutonomyValidationRules.MaxEnumNameLength} characters.")
+            .Must(v => AutonomyValidationRules.TryParseEnumName<BlastRadius>(v, out _))
+                .When(x => !string.IsNullOrEmpty(x.BlastRadius), ApplyConditionTo.CurrentValidator)
+                .WithMessage(AutonomyValidationRules.InvalidBlastRadiusMessage);
+
+        RuleFor(x => x.TargetKind)
+            .NotEmpty().WithMessage("TargetKind must not be empty.")
+            .MaximumLength(AutonomyValidationRules.MaxEnumNameLength)
+                .WithMessage($"TargetKind must not exceed {AutonomyValidationRules.MaxEnumNameLength} characters.")
+            .Must(v => AutonomyValidationRules.TryParseEnumName<ChangeTargetKind>(v, out _))
+                .When(x => !string.IsNullOrEmpty(x.TargetKind), ApplyConditionTo.CurrentValidator)
+                .WithMessage(AutonomyValidationRules.InvalidTargetKindMessage);
+
+        RuleFor(x => x.SkillKey)
+            .MaximumLength(AutonomyValidationRules.MaxSkillKeyLength)
+                .WithMessage($"SkillKey must not exceed {AutonomyValidationRules.MaxSkillKeyLength} characters.");
+    }
+}

--- a/src/Content/Presentation/Presentation.AgentHub/Auth/DevAuthHandler.cs
+++ b/src/Content/Presentation/Presentation.AgentHub/Auth/DevAuthHandler.cs
@@ -33,6 +33,7 @@ internal sealed class DevAuthHandler(
             new Claim(ClaimTypes.Role, "Harness.Learnings.Read"),
             new Claim(ClaimTypes.Role, Presentation.Common.Escalations.EscalationsController.DecideRole),
             new Claim(ClaimTypes.Role, Presentation.Common.Escalations.EscalationsController.AdminRole),
+            new Claim(ClaimTypes.Role, Presentation.Common.Governance.AutonomyController.ReadRole),
         };
         var identity = new ClaimsIdentity(claims, Scheme.Name);
         var ticket = new AuthenticationTicket(new ClaimsPrincipal(identity), Scheme.Name);

--- a/src/Content/Presentation/Presentation.AgentHub/DependencyInjection.cs
+++ b/src/Content/Presentation/Presentation.AgentHub/DependencyInjection.cs
@@ -25,6 +25,7 @@ using Presentation.AgentHub.Planner;
 using Presentation.AgentHub.Config;
 using Presentation.AgentHub.Telemetry;
 using Presentation.Common.Escalations;
+using Presentation.Common.Governance;
 using Microsoft.Extensions.Options;
 
 namespace Presentation.AgentHub;
@@ -59,7 +60,11 @@ public static class DependencyInjection
             })
             // Deliberate opt-in: AgentHub runs the agent workload, so the in-process escalation
             // state lives here and the human approval API must be co-resident with it.
-            .AddEscalationApi();
+            .AddEscalationApi()
+            // Deliberate opt-in: the autonomy governance read API answers from this host's own
+            // configuration and profile registry, so it belongs in the workload host whose
+            // governance posture it describes.
+            .AddAutonomyApi();
 
         // Surfaces a missing/invalid AI provider configuration via /health/ai. Additive to the
         // health checks registered in Presentation.Common — Degraded (not Unhealthy) because the

--- a/src/Content/Presentation/Presentation.Common/Governance/AutonomyApiMarker.cs
+++ b/src/Content/Presentation/Presentation.Common/Governance/AutonomyApiMarker.cs
@@ -1,0 +1,22 @@
+namespace Presentation.Common.Governance;
+
+/// <summary>
+/// DI marker whose presence records that a host deliberately opted into serving the autonomy
+/// governance read API. Registered only by
+/// <see cref="AutonomyApiMvcBuilderExtensions.AddAutonomyApi"/>;
+/// <see cref="RequiresAutonomyApiOptInAttribute"/> checks for it at route-match time and
+/// un-matches every <see cref="AutonomyController"/> route when it is absent.
+/// </summary>
+/// <remarks>
+/// This runtime gate exists because compile-time placement cannot deliver the opt-in: the Web
+/// SDK auto-generates an <c>ApplicationPartAttribute</c> for every referenced assembly that
+/// references MVC, so any MVC host referencing <c>Presentation.Common</c> discovers this
+/// assembly's controllers whether or not it called <c>AddApplicationPart</c>. Although the
+/// autonomy surface is read-only, it still describes the governance posture of a specific
+/// workload host; a host that merely composes shared services must not accidentally expose it.
+/// Fail-closed: no marker, no routes (404 before authentication, indistinguishable from a host
+/// without the API).
+/// </remarks>
+public sealed class AutonomyApiMarker
+{
+}

--- a/src/Content/Presentation/Presentation.Common/Governance/AutonomyApiMvcBuilderExtensions.cs
+++ b/src/Content/Presentation/Presentation.Common/Governance/AutonomyApiMvcBuilderExtensions.cs
@@ -1,0 +1,42 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Presentation.Common.Governance;
+
+/// <summary>
+/// Deliberate opt-in mount for the autonomy governance read API. Hosts that should serve
+/// <c>/api/governance/autonomy</c> chain <see cref="AddAutonomyApi"/> onto their
+/// <c>AddControllers()</c> call; hosts that merely reference <c>Presentation.Common</c> for its
+/// shared services never expose the routes.
+/// </summary>
+public static class AutonomyApiMvcBuilderExtensions
+{
+    /// <summary>
+    /// Mounts <see cref="AutonomyController"/> into the host's MVC pipeline. Two things
+    /// happen: this assembly is added as an application part (required for hosts whose build
+    /// did not auto-register it), and <see cref="AutonomyApiMarker"/> is registered, which is
+    /// what actually arms the routes — <see cref="RequiresAutonomyApiOptInAttribute"/> keeps
+    /// them un-matched (404) in every host without the marker, including hosts where the Web
+    /// SDK auto-discovered this assembly as an application part.
+    /// </summary>
+    /// <param name="builder">The MVC builder returned by <c>AddControllers()</c>.</param>
+    /// <returns>The builder for chaining.</returns>
+    /// <remarks>
+    /// Mount this in hosts whose governance posture the API should describe — the effective
+    /// tier and decision preview are computed from the <em>host's</em> configuration and
+    /// profile registry, so the answers are only meaningful in a host that runs the agent
+    /// workload with that configuration.
+    /// </remarks>
+    public static IMvcBuilder AddAutonomyApi(this IMvcBuilder builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        // Idempotent: a second call must not stack duplicate application parts.
+        if (builder.Services.Any(d => d.ServiceType == typeof(AutonomyApiMarker)))
+            return builder;
+
+        builder.Services.TryAddSingleton<AutonomyApiMarker>();
+
+        return builder.AddApplicationPart(typeof(AutonomyController).Assembly);
+    }
+}

--- a/src/Content/Presentation/Presentation.Common/Governance/AutonomyController.cs
+++ b/src/Content/Presentation/Presentation.Common/Governance/AutonomyController.cs
@@ -1,0 +1,142 @@
+using Application.Core.CQRS.Autonomy;
+using Domain.AI.Changes;
+using Domain.Common;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Presentation.Common.Extensions;
+
+namespace Presentation.Common.Governance;
+
+/// <summary>
+/// Read-only REST API over the autonomy governance configuration: the effective autonomy tier
+/// per subagent type, and a side-effect-free preview of the graded-autonomy decision for a
+/// hypothetical action. Autonomy tiers are pure configuration enforced by the MediatR pipeline;
+/// there is no mutable runtime state, so this surface deliberately exposes no writes.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Opt-in mount.</b> The controller ships in <c>Presentation.Common</c> but its routes only
+/// exist in hosts that called <see cref="AutonomyApiMvcBuilderExtensions.AddAutonomyApi"/> —
+/// see <see cref="RequiresAutonomyApiOptInAttribute"/>. The answers are computed from the
+/// host's own configuration and profile registry, so the API belongs in the workload host
+/// whose governance posture it describes.
+/// </para>
+/// <para>
+/// <b>Parity with enforcement.</b> Both endpoints dispatch to handlers that call the same
+/// shared services the enforcement path uses (<c>IAutonomyTierResolver</c>,
+/// <c>IAutonomyDecisionEvaluator</c>) — the preview cannot drift from what enforcement would
+/// actually decide for the same inputs.
+/// </para>
+/// </remarks>
+[ApiController]
+[Route("api/governance/autonomy")]
+[RequiresAutonomyApiOptIn]
+public sealed class AutonomyController : ControllerBase
+{
+    /// <summary>
+    /// App role required to read autonomy governance state. Follows the
+    /// <c>Harness.Learnings.Read</c> precedent of role-gating read-only governance surfaces:
+    /// tier assignments and decision policy describe the deployment's security posture and are
+    /// operator information, not anonymous data.
+    /// </summary>
+    public const string ReadRole = "Harness.Governance.Read";
+
+    private readonly IMediator _mediator;
+
+    /// <summary>Initializes the controller with its dependencies.</summary>
+    /// <param name="mediator">The MediatR mediator used to dispatch autonomy read operations.</param>
+    public AutonomyController(IMediator mediator)
+    {
+        ArgumentNullException.ThrowIfNull(mediator);
+        _mediator = mediator;
+    }
+
+    /// <summary>
+    /// Reads the effective autonomy tier for a subagent type — profile registry first, then
+    /// the configured default. Pure config read; nothing is written or audited.
+    /// </summary>
+    /// <param name="subagentType">The subagent type name (case-insensitive, e.g. <c>Explore</c>).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The effective tier for the subagent type.</returns>
+    /// <response code="200">The effective autonomy tier.</response>
+    /// <response code="400">The subagent type value is empty or exceeds the length cap.</response>
+    /// <response code="401">Caller is not authenticated.</response>
+    /// <response code="403">Caller lacks <see cref="ReadRole"/>.</response>
+    /// <response code="404">No subagent type with the given name exists.</response>
+    [HttpGet("tiers/{subagentType}")]
+    [Authorize(Roles = ReadRole)]
+    [ProducesResponseType(typeof(AutonomyTierDetail), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> GetTier(string subagentType, CancellationToken cancellationToken)
+    {
+        var result = await _mediator.Send(
+            new GetAutonomyTierQuery { SubagentType = subagentType },
+            cancellationToken).ConfigureAwait(false);
+
+        return result.IsSuccess ? Ok(result.Value) : MapFailure(result);
+    }
+
+    /// <summary>
+    /// Previews the graded-autonomy decision for a hypothetical action: would it auto-approve,
+    /// require human approval, or be forbidden? Side-effect-free — nothing is executed,
+    /// escalated, audited, or persisted.
+    /// </summary>
+    /// <param name="request">The hypothetical action to evaluate.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The decision the evaluator would reach, with the rule that drove it.</returns>
+    /// <response code="200">The preview decision.</response>
+    /// <response code="400">A required field is missing, or a blast radius / target kind value does not name a defined member.</response>
+    /// <response code="401">Caller is not authenticated.</response>
+    /// <response code="403">Caller lacks <see cref="ReadRole"/>.</response>
+    /// <response code="404">No subagent type with the given name exists.</response>
+    [HttpPost("decision-preview")]
+    [Authorize(Roles = ReadRole)]
+    [ProducesResponseType(typeof(AutonomyDecisionPreviewResult), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> PreviewDecision(
+        [FromBody] AutonomyDecisionPreviewRequest request, CancellationToken cancellationToken)
+    {
+        var result = await _mediator.Send(
+            new PreviewAutonomyDecisionQuery
+            {
+                SubagentType = request.SubagentType ?? string.Empty,
+                BlastRadius = request.BlastRadius ?? string.Empty,
+                TargetKind = request.TargetKind ?? PreviewAutonomyDecisionQuery.DefaultTargetKind,
+                IsStateChange = request.IsStateChange,
+                SkillKey = request.SkillKey,
+            },
+            cancellationToken).ConfigureAwait(false);
+
+        return result.IsSuccess ? Ok(result.Value) : MapFailure(result);
+    }
+
+    private IActionResult MapFailure(Result result) =>
+        this.FailureResponse(result, "Autonomy governance read failed");
+}
+
+// The wire-contract record below is deliberately colocated with the controller (the
+// EscalationsController precedent): it is this endpoint set's HTTP contract, not a shared
+// application model, and reading it next to the action that binds it is the point.
+
+/// <summary>Request body for <c>POST /api/governance/autonomy/decision-preview</c>.</summary>
+/// <param name="SubagentType">The subagent type name the preview is for (case-insensitive, e.g. <c>Execute</c>).</param>
+/// <param name="BlastRadius">The proposed action's blast radius name (case-insensitive, e.g. <c>Medium</c>).</param>
+/// <param name="TargetKind">The proposed action's target kind name. Optional at the wire: when
+/// omitted or null, the preview evaluates the action as <c>Unspecified</c> (the same way
+/// non-target-specific proposals are evaluated); when supplied, it must name a defined member.</param>
+/// <param name="IsStateChange">Whether the proposed action mutates state. Defaults to false.</param>
+/// <param name="SkillKey">The skill key the action is attributed to, or null when not skill-attributable.</param>
+public sealed record AutonomyDecisionPreviewRequest(
+    string? SubagentType,
+    string? BlastRadius,
+    string? TargetKind = null,
+    bool IsStateChange = false,
+    string? SkillKey = null);

--- a/src/Content/Presentation/Presentation.Common/Governance/RequiresAutonomyApiOptInAttribute.cs
+++ b/src/Content/Presentation/Presentation.Common/Governance/RequiresAutonomyApiOptInAttribute.cs
@@ -1,0 +1,33 @@
+using Microsoft.AspNetCore.Mvc.ActionConstraints;
+
+namespace Presentation.Common.Governance;
+
+/// <summary>
+/// Action constraint that removes the decorated controller's routes from route matching unless
+/// the host registered <see cref="AutonomyApiMarker"/> via
+/// <see cref="AutonomyApiMvcBuilderExtensions.AddAutonomyApi"/>.
+/// </summary>
+/// <remarks>
+/// An action constraint (rather than a filter) is deliberate: constraints run during endpoint
+/// <em>selection</em>, before the authentication and authorization middleware. A non-opted host
+/// therefore answers autonomy governance paths with a plain 404 — never a 401 challenge that
+/// would reveal the routes exist. Filters would run after auth and could not provide that.
+/// </remarks>
+[AttributeUsage(AttributeTargets.Class)]
+public sealed class RequiresAutonomyApiOptInAttribute : Attribute, IActionConstraint
+{
+    /// <inheritdoc />
+    public int Order => 0;
+
+    /// <summary>
+    /// Accepts the candidate action only when the host opted into the autonomy governance API.
+    /// </summary>
+    /// <param name="context">The constraint context supplied by routing.</param>
+    /// <returns><see langword="true"/> when <see cref="AutonomyApiMarker"/> is registered.</returns>
+    public bool Accept(ActionConstraintContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        return context.RouteContext.HttpContext.RequestServices
+            .GetService(typeof(AutonomyApiMarker)) is not null;
+    }
+}

--- a/src/Content/Tests/Application.Core.Tests/CQRS/Autonomy/AutonomyCqrsValidationTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/CQRS/Autonomy/AutonomyCqrsValidationTests.cs
@@ -1,0 +1,140 @@
+using Application.Core.CQRS.Autonomy;
+using Domain.AI.Agents;
+using Domain.AI.Changes;
+using FluentAssertions;
+using Xunit;
+
+namespace Application.Core.Tests.CQRS.Autonomy;
+
+/// <summary>
+/// Validator tests for the autonomy governance read surface: required fields, length caps, and
+/// the 400-vs-404 boundary — malformed blast radius / target kind names fail validation, while
+/// a well-formed-but-unknown subagent type passes (its 404 belongs to the handler).
+/// </summary>
+public sealed class AutonomyCqrsValidationTests
+{
+    private readonly GetAutonomyTierQueryValidator _tierValidator = new();
+    private readonly PreviewAutonomyDecisionQueryValidator _previewValidator = new();
+
+    private static PreviewAutonomyDecisionQuery ValidPreview() => new()
+    {
+        SubagentType = nameof(SubagentType.Explore),
+        BlastRadius = nameof(BlastRadius.Low),
+        TargetKind = nameof(ChangeTargetKind.GitRepo),
+        IsStateChange = true,
+        SkillKey = "skill.demo",
+    };
+
+    [Fact]
+    public void TierValidator_ValidQuery_Passes()
+    {
+        var result = _tierValidator.Validate(
+            new GetAutonomyTierQuery { SubagentType = nameof(SubagentType.Explore) });
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void TierValidator_UnknownButWellFormedName_Passes()
+    {
+        // Existence is the handler's concern (404, not 400).
+        var result = _tierValidator.Validate(
+            new GetAutonomyTierQuery { SubagentType = "NotARealType" });
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void TierValidator_EmptySubagentType_Fails()
+    {
+        var result = _tierValidator.Validate(new GetAutonomyTierQuery { SubagentType = "" });
+
+        result.IsValid.Should().BeFalse();
+    }
+
+    [Fact]
+    public void TierValidator_OverlongSubagentType_Fails()
+    {
+        var result = _tierValidator.Validate(new GetAutonomyTierQuery
+        {
+            SubagentType = new string('a', AutonomyValidationRules.MaxEnumNameLength + 1),
+        });
+
+        result.IsValid.Should().BeFalse();
+    }
+
+    [Fact]
+    public void PreviewValidator_ValidQuery_Passes()
+    {
+        var result = _previewValidator.Validate(ValidPreview());
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void PreviewValidator_CaseInsensitiveEnumNames_Passes()
+    {
+        var result = _previewValidator.Validate(ValidPreview() with
+        {
+            BlastRadius = "medium",
+            TargetKind = "gitrepo",
+        });
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void PreviewValidator_EmptySubagentType_Fails()
+    {
+        var result = _previewValidator.Validate(ValidPreview() with { SubagentType = "" });
+
+        result.IsValid.Should().BeFalse();
+    }
+
+    [Fact]
+    public void PreviewValidator_EmptyBlastRadius_Fails()
+    {
+        var result = _previewValidator.Validate(ValidPreview() with { BlastRadius = "" });
+
+        result.IsValid.Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData("NotARadius")]
+    [InlineData("3")] // numeric forms are not part of the wire contract
+    public void PreviewValidator_MalformedBlastRadius_Fails(string blastRadius)
+    {
+        var result = _previewValidator.Validate(ValidPreview() with { BlastRadius = blastRadius });
+
+        result.IsValid.Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData("NotAKind")]
+    [InlineData("1")]
+    public void PreviewValidator_MalformedTargetKind_Fails(string targetKind)
+    {
+        var result = _previewValidator.Validate(ValidPreview() with { TargetKind = targetKind });
+
+        result.IsValid.Should().BeFalse();
+    }
+
+    [Fact]
+    public void PreviewValidator_OverlongSkillKey_Fails()
+    {
+        var result = _previewValidator.Validate(ValidPreview() with
+        {
+            SkillKey = new string('k', AutonomyValidationRules.MaxSkillKeyLength + 1),
+        });
+
+        result.IsValid.Should().BeFalse();
+    }
+
+    [Fact]
+    public void PreviewValidator_NullSkillKey_Passes()
+    {
+        var result = _previewValidator.Validate(ValidPreview() with { SkillKey = null });
+
+        result.IsValid.Should().BeTrue();
+    }
+}

--- a/src/Content/Tests/Application.Core.Tests/CQRS/Autonomy/GetAutonomyTierQueryHandlerTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/CQRS/Autonomy/GetAutonomyTierQueryHandlerTests.cs
@@ -1,0 +1,84 @@
+using Application.AI.Common.Interfaces.Governance;
+using Application.Core.CQRS.Autonomy;
+using Domain.AI.Agents;
+using Domain.AI.Governance;
+using Domain.Common;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Application.Core.Tests.CQRS.Autonomy;
+
+/// <summary>
+/// Tests for <see cref="GetAutonomyTierQueryHandler"/>: the tier read reflects exactly what the
+/// shared <see cref="IAutonomyTierResolver"/> reports (config parity), unknown subagent type
+/// names map to <c>NotFound</c>, and the read path performs no calls beyond the single resolver
+/// lookup (side-effect-free).
+/// </summary>
+public sealed class GetAutonomyTierQueryHandlerTests
+{
+    private static GetAutonomyTierQueryHandler BuildHandler(Mock<IAutonomyTierResolver> resolver) =>
+        new(resolver.Object, NullLogger<GetAutonomyTierQueryHandler>.Instance);
+
+    [Theory]
+    [InlineData(SubagentType.Explore, AutonomyLevel.Restricted)]
+    [InlineData(SubagentType.Plan, AutonomyLevel.Supervised)]
+    [InlineData(SubagentType.Execute, AutonomyLevel.Autonomous)]
+    public async Task Handle_KnownSubagentType_ReturnsTierFromSharedResolver(
+        SubagentType subagentType, AutonomyLevel configuredTier)
+    {
+        // Strict: any call other than the single expected Resolve throws, proving the read
+        // path touches nothing else.
+        var resolver = new Mock<IAutonomyTierResolver>(MockBehavior.Strict);
+        resolver.Setup(r => r.Resolve(subagentType)).Returns(configuredTier);
+        var handler = BuildHandler(resolver);
+
+        var result = await handler.Handle(
+            new GetAutonomyTierQuery { SubagentType = subagentType.ToString() },
+            CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.SubagentType.Should().Be(subagentType);
+        result.Value.Tier.Should().Be(configuredTier,
+            "the endpoint must report exactly what the enforcement path's resolver reports");
+        resolver.Verify(r => r.Resolve(subagentType), Times.Once);
+        resolver.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task Handle_SubagentTypeName_IsCaseInsensitive()
+    {
+        var resolver = new Mock<IAutonomyTierResolver>(MockBehavior.Strict);
+        resolver.Setup(r => r.Resolve(SubagentType.Explore)).Returns(AutonomyLevel.Supervised);
+        var handler = BuildHandler(resolver);
+
+        var result = await handler.Handle(
+            new GetAutonomyTierQuery { SubagentType = "explore" },
+            CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.SubagentType.Should().Be(SubagentType.Explore);
+    }
+
+    [Theory]
+    [InlineData("Nonexistent")]
+    [InlineData("2")] // numeric forms are rejected even when they match a defined value
+    [InlineData("999")]
+    [InlineData("")]
+    public async Task Handle_UnknownSubagentType_ReturnsNotFoundWithoutTouchingResolver(string name)
+    {
+        // Strict with zero setups: resolving an unknown type must not reach the resolver at all.
+        var resolver = new Mock<IAutonomyTierResolver>(MockBehavior.Strict);
+        var handler = BuildHandler(resolver);
+
+        var result = await handler.Handle(
+            new GetAutonomyTierQuery { SubagentType = name },
+            CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.FailureType.Should().Be(ResultFailureType.NotFound,
+            "an unknown subagent type must map to 404 at the HTTP boundary");
+        resolver.VerifyNoOtherCalls();
+    }
+}

--- a/src/Content/Tests/Application.Core.Tests/CQRS/Autonomy/PreviewAutonomyDecisionQueryHandlerTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/CQRS/Autonomy/PreviewAutonomyDecisionQueryHandlerTests.cs
@@ -1,0 +1,203 @@
+using Application.AI.Common.Interfaces.Governance;
+using Application.Core.CQRS.Autonomy;
+using Application.Core.Permissions;
+using Domain.AI.Agents;
+using Domain.AI.Changes;
+using Domain.AI.Governance;
+using Domain.Common;
+using Domain.Common.Config;
+using FluentAssertions;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Application.Core.Tests.CQRS.Autonomy;
+
+/// <summary>
+/// Tests for <see cref="PreviewAutonomyDecisionQueryHandler"/>. The core property is parity:
+/// the preview runs the <em>same</em> <see cref="AutonomyDecisionEvaluator"/> the enforcement
+/// path uses, so for identical inputs the preview must return the identical decision. Also
+/// covers the 404/400 classification of malformed inputs and the zero-side-effect guarantee.
+/// </summary>
+public sealed class PreviewAutonomyDecisionQueryHandlerTests
+{
+    private static AutonomyDecisionEvaluator BuildRealEvaluator(
+        AppConfig config, string environmentName = "Development")
+    {
+        var monitor = Mock.Of<IOptionsMonitor<AppConfig>>(o => o.CurrentValue == config);
+        var env = new Mock<IHostEnvironment>();
+        env.SetupGet(e => e.EnvironmentName).Returns(environmentName);
+        return new AutonomyDecisionEvaluator(
+            monitor, env.Object, NullLogger<AutonomyDecisionEvaluator>.Instance);
+    }
+
+    private static PreviewAutonomyDecisionQueryHandler BuildHandler(
+        IAutonomyDecisionEvaluator evaluator, AutonomyLevel tier)
+    {
+        var resolver = new Mock<IAutonomyTierResolver>();
+        resolver.Setup(r => r.Resolve(It.IsAny<SubagentType>())).Returns(tier);
+        return new PreviewAutonomyDecisionQueryHandler(
+            resolver.Object, evaluator, NullLogger<PreviewAutonomyDecisionQueryHandler>.Instance);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Parity: preview == enforcement-path evaluator, same inputs, both with
+    // graded autonomy disabled (PR-2 fallback) and enabled (layered rules).
+    // ─────────────────────────────────────────────────────────────────────
+
+    public static TheoryData<bool, AutonomyLevel, BlastRadius, bool> ParityCases() => new()
+    {
+        { false, AutonomyLevel.Restricted, BlastRadius.Trivial, false },
+        { false, AutonomyLevel.Supervised, BlastRadius.Medium, true },
+        { false, AutonomyLevel.Autonomous, BlastRadius.Critical, false },
+        { true, AutonomyLevel.Restricted, BlastRadius.Low, false },
+        { true, AutonomyLevel.Supervised, BlastRadius.High, true },
+        { true, AutonomyLevel.Autonomous, BlastRadius.Trivial, false },
+        { true, AutonomyLevel.Autonomous, BlastRadius.Medium, true },
+    };
+
+    [Theory]
+    [MemberData(nameof(ParityCases))]
+    public async Task Handle_SameInputsAsEnforcementEvaluator_ReturnsIdenticalDecision(
+        bool gradedEnabled, AutonomyLevel tier, BlastRadius radius, bool isStateChange)
+    {
+        var config = new AppConfig();
+        config.AI.Permissions.GradedAutonomy.Enabled = gradedEnabled;
+        var evaluator = BuildRealEvaluator(config);
+
+        // What the enforcement path would decide for these exact inputs.
+        var expected = evaluator.Evaluate(
+            tier, radius, ChangeTargetKind.GitRepo, isStateChange, "skill.demo");
+
+        var handler = BuildHandler(evaluator, tier);
+        var result = await handler.Handle(
+            new PreviewAutonomyDecisionQuery
+            {
+                SubagentType = nameof(SubagentType.Execute),
+                BlastRadius = radius.ToString(),
+                TargetKind = nameof(ChangeTargetKind.GitRepo),
+                IsStateChange = isStateChange,
+                SkillKey = "skill.demo",
+            },
+            CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        var preview = result.Value!;
+        preview.Decision.Should().Be(expected.Decision,
+            "the preview must never drift from the enforcement path's decision");
+        preview.Tier.Should().Be(expected.Tier);
+        preview.BlastRadius.Should().Be(expected.BlastRadius);
+        preview.TargetKind.Should().Be(expected.TargetKind);
+        preview.IsStateChange.Should().Be(expected.IsStateChange);
+        preview.Environment.Should().Be(expected.Environment);
+        preview.SkillKey.Should().Be(expected.SkillKey);
+        preview.Reason.Should().Be(expected.Reason);
+        preview.SubagentType.Should().Be(SubagentType.Execute);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Input classification: unknown subagent → NotFound; malformed enum
+    // names → ValidationFailure.
+    // ─────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Handle_UnknownSubagentType_ReturnsNotFoundWithoutEvaluating()
+    {
+        var resolver = new Mock<IAutonomyTierResolver>(MockBehavior.Strict);
+        var evaluator = new Mock<IAutonomyDecisionEvaluator>(MockBehavior.Strict);
+        var handler = new PreviewAutonomyDecisionQueryHandler(
+            resolver.Object, evaluator.Object,
+            NullLogger<PreviewAutonomyDecisionQueryHandler>.Instance);
+
+        var result = await handler.Handle(
+            new PreviewAutonomyDecisionQuery
+            {
+                SubagentType = "Nonexistent",
+                BlastRadius = nameof(BlastRadius.Low),
+            },
+            CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.FailureType.Should().Be(ResultFailureType.NotFound);
+        resolver.VerifyNoOtherCalls();
+        evaluator.VerifyNoOtherCalls();
+    }
+
+    [Theory]
+    [InlineData("NotARadius", nameof(ChangeTargetKind.GitRepo))]
+    [InlineData("3", nameof(ChangeTargetKind.GitRepo))] // numeric forms rejected
+    [InlineData(nameof(BlastRadius.Low), "NotAKind")]
+    [InlineData(nameof(BlastRadius.Low), "1")]
+    public async Task Handle_MalformedEnumName_ReturnsValidationFailure(
+        string blastRadius, string targetKind)
+    {
+        var resolver = new Mock<IAutonomyTierResolver>(MockBehavior.Strict);
+        var evaluator = new Mock<IAutonomyDecisionEvaluator>(MockBehavior.Strict);
+        var handler = new PreviewAutonomyDecisionQueryHandler(
+            resolver.Object, evaluator.Object,
+            NullLogger<PreviewAutonomyDecisionQueryHandler>.Instance);
+
+        var result = await handler.Handle(
+            new PreviewAutonomyDecisionQuery
+            {
+                SubagentType = nameof(SubagentType.Explore),
+                BlastRadius = blastRadius,
+                TargetKind = targetKind,
+            },
+            CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.FailureType.Should().Be(ResultFailureType.Validation);
+        resolver.VerifyNoOtherCalls();
+        evaluator.VerifyNoOtherCalls();
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Side-effect freedom: exactly one Resolve and one Evaluate, nothing else.
+    // ─────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Handle_ValidPreview_PerformsExactlyOneResolveAndOneEvaluate()
+    {
+        var expected = new AutonomyDecisionResult(
+            AutonomyDecision.RequiresApproval, AutonomyLevel.Supervised, BlastRadius.Medium,
+            ChangeTargetKind.Unspecified, false, "Development", null, "test reason");
+
+        // Strict: any interaction beyond the two expected read calls throws, proving the
+        // preview cannot write, audit, or escalate through its dependencies.
+        var resolver = new Mock<IAutonomyTierResolver>(MockBehavior.Strict);
+        resolver.Setup(r => r.Resolve(SubagentType.Plan)).Returns(AutonomyLevel.Supervised);
+        var evaluator = new Mock<IAutonomyDecisionEvaluator>(MockBehavior.Strict);
+        evaluator
+            .Setup(e => e.Evaluate(
+                AutonomyLevel.Supervised, BlastRadius.Medium, ChangeTargetKind.Unspecified,
+                false, null))
+            .Returns(expected);
+
+        var handler = new PreviewAutonomyDecisionQueryHandler(
+            resolver.Object, evaluator.Object,
+            NullLogger<PreviewAutonomyDecisionQueryHandler>.Instance);
+
+        var result = await handler.Handle(
+            new PreviewAutonomyDecisionQuery
+            {
+                SubagentType = nameof(SubagentType.Plan),
+                BlastRadius = nameof(BlastRadius.Medium),
+                SkillKey = "   ", // whitespace-only skill keys normalize to null
+            },
+            CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.Decision.Should().Be(AutonomyDecision.RequiresApproval);
+        resolver.Verify(r => r.Resolve(SubagentType.Plan), Times.Once);
+        evaluator.Verify(
+            e => e.Evaluate(
+                AutonomyLevel.Supervised, BlastRadius.Medium, ChangeTargetKind.Unspecified,
+                false, null),
+            Times.Once);
+        resolver.VerifyNoOtherCalls();
+        evaluator.VerifyNoOtherCalls();
+    }
+}

--- a/src/Content/Tests/Presentation.AgentHub.Tests/Controllers/AutonomyControllerIntegrationTests.cs
+++ b/src/Content/Tests/Presentation.AgentHub.Tests/Controllers/AutonomyControllerIntegrationTests.cs
@@ -1,0 +1,164 @@
+using System.Net;
+using System.Net.Http.Json;
+using Application.Core.CQRS.Autonomy;
+using Domain.AI.Agents;
+using Domain.AI.Changes;
+using Domain.AI.Governance;
+using Domain.Common;
+using FluentAssertions;
+using MediatR;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Presentation.Common.Governance;
+using Xunit;
+
+namespace Presentation.AgentHub.Tests.Controllers;
+
+/// <summary>
+/// Wire-level tests for the autonomy governance read API mounted into AgentHub via
+/// <c>AddAutonomyApi()</c>: the routes exist (opt-in wiring works end-to-end through the real
+/// host), role gating fails closed for callers without <c>Harness.Governance.Read</c>, route
+/// and body values bind into the dispatched queries, and <c>NotFound</c> results map to 404.
+/// </summary>
+public sealed class AutonomyControllerIntegrationTests : IClassFixture<TestWebApplicationFactory>
+{
+    private readonly TestWebApplicationFactory _factory;
+
+    public AutonomyControllerIntegrationTests(TestWebApplicationFactory factory) => _factory = factory;
+
+    [Fact]
+    public async Task GetTier_Unauthenticated_Returns401()
+    {
+        // Also proves the routes are mounted at all: an unmounted route would 404, not challenge.
+        using var client = _factory.CreateClient();
+
+        var response = await client.GetAsync("/api/governance/autonomy/tiers/Explore");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task GetTier_AuthenticatedWithoutReadRole_Returns403()
+    {
+        using var client = _factory.CreateAuthedClient();
+
+        var response = await client.GetAsync("/api/governance/autonomy/tiers/Explore");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden,
+            "role gating must fail closed for authenticated callers without Harness.Governance.Read");
+    }
+
+    [Fact]
+    public async Task GetTier_WithReadRole_Returns200AndBindsRouteValue()
+    {
+        GetAutonomyTierQuery? captured = null;
+        _factory.MockMediator
+            .Setup(m => m.Send(It.IsAny<GetAutonomyTierQuery>(), It.IsAny<CancellationToken>()))
+            .Callback<IRequest<Result<AutonomyTierDetail>>, CancellationToken>(
+                (q, _) => captured = (GetAutonomyTierQuery)q)
+            .ReturnsAsync(Result<AutonomyTierDetail>.Success(
+                new AutonomyTierDetail(SubagentType.Explore, AutonomyLevel.Supervised)));
+
+        using var client = _factory.CreateAuthedClient("bob@contoso.com", AutonomyController.ReadRole);
+
+        var response = await client.GetAsync("/api/governance/autonomy/tiers/Explore");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        captured.Should().NotBeNull();
+        captured!.SubagentType.Should().Be("Explore",
+            "the route segment must flow into the dispatched query untouched");
+    }
+
+    [Fact]
+    public async Task GetTier_UnknownSubagentType_Returns404()
+    {
+        _factory.MockMediator
+            .Setup(m => m.Send(It.IsAny<GetAutonomyTierQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<AutonomyTierDetail>.NotFound(
+                "No subagent type with the given name exists."));
+
+        using var client = _factory.CreateAuthedClient("bob@contoso.com", AutonomyController.ReadRole);
+
+        var response = await client.GetAsync("/api/governance/autonomy/tiers/Nonexistent");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound,
+            "a NotFound result must map through the shared FailureResponse extension to 404");
+    }
+
+    [Fact]
+    public async Task PreviewDecision_AuthenticatedWithoutReadRole_Returns403()
+    {
+        using var client = _factory.CreateAuthedClient();
+
+        var response = await client.PostAsJsonAsync(
+            "/api/governance/autonomy/decision-preview",
+            new { subagentType = "Execute", blastRadius = "Medium" });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task PreviewDecision_WithReadRole_Returns200AndBindsBody()
+    {
+        PreviewAutonomyDecisionQuery? captured = null;
+        _factory.MockMediator
+            .Setup(m => m.Send(It.IsAny<PreviewAutonomyDecisionQuery>(), It.IsAny<CancellationToken>()))
+            .Callback<IRequest<Result<AutonomyDecisionPreviewResult>>, CancellationToken>(
+                (q, _) => captured = (PreviewAutonomyDecisionQuery)q)
+            .ReturnsAsync(Result<AutonomyDecisionPreviewResult>.Success(
+                new AutonomyDecisionPreviewResult(
+                    SubagentType.Execute, AutonomyDecision.RequiresApproval,
+                    AutonomyLevel.Supervised, BlastRadius.Medium, ChangeTargetKind.GitRepo,
+                    true, "Development", "skill.demo", "tier baseline")));
+
+        using var client = _factory.CreateAuthedClient("ops@contoso.com", AutonomyController.ReadRole);
+
+        var response = await client.PostAsJsonAsync(
+            "/api/governance/autonomy/decision-preview",
+            new
+            {
+                subagentType = "Execute",
+                blastRadius = "Medium",
+                targetKind = "GitRepo",
+                isStateChange = true,
+                skillKey = "skill.demo",
+            });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        captured.Should().NotBeNull();
+        captured!.SubagentType.Should().Be("Execute");
+        captured.BlastRadius.Should().Be("Medium");
+        captured.TargetKind.Should().Be("GitRepo");
+        captured.IsStateChange.Should().BeTrue();
+        captured.SkillKey.Should().Be("skill.demo");
+    }
+
+    [Fact]
+    public async Task PreviewDecision_OmittedTargetKind_DefaultsToUnspecified()
+    {
+        PreviewAutonomyDecisionQuery? captured = null;
+        _factory.MockMediator
+            .Setup(m => m.Send(It.IsAny<PreviewAutonomyDecisionQuery>(), It.IsAny<CancellationToken>()))
+            .Callback<IRequest<Result<AutonomyDecisionPreviewResult>>, CancellationToken>(
+                (q, _) => captured = (PreviewAutonomyDecisionQuery)q)
+            .ReturnsAsync(Result<AutonomyDecisionPreviewResult>.Success(
+                new AutonomyDecisionPreviewResult(
+                    SubagentType.Plan, AutonomyDecision.AutoApprove, AutonomyLevel.Autonomous,
+                    BlastRadius.Trivial, ChangeTargetKind.Unspecified, false, "Development",
+                    null, "trivial fallback")));
+
+        using var client = _factory.CreateAuthedClient("ops@contoso.com", AutonomyController.ReadRole);
+
+        var response = await client.PostAsJsonAsync(
+            "/api/governance/autonomy/decision-preview",
+            new { subagentType = "Plan", blastRadius = "Trivial" });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        captured.Should().NotBeNull();
+        captured!.TargetKind.Should().Be(nameof(ChangeTargetKind.Unspecified),
+            "an omitted target kind must evaluate as Unspecified, matching non-target-specific proposals");
+    }
+}

--- a/src/Content/Tests/Presentation.AgentHub.Tests/Controllers/ClientLogsControllerTests.cs
+++ b/src/Content/Tests/Presentation.AgentHub.Tests/Controllers/ClientLogsControllerTests.cs
@@ -16,22 +16,10 @@ public sealed class ClientLogsControllerTests : IClassFixture<TestWebApplication
 
     public ClientLogsControllerTests(TestWebApplicationFactory factory) => _factory = factory;
 
-    private HttpClient CreateAuthedClient(string userId = "client-log-user")
-    {
-        var client = _factory
-            .WithWebHostBuilder(b => b.ConfigureTestServices(services =>
-                services.AddAuthentication(TestAuthHandler.SchemeName)
-                    .AddScheme<AuthenticationSchemeOptions, TestAuthHandler>(
-                        TestAuthHandler.SchemeName, _ => { })))
-            .CreateClient();
-        client.DefaultRequestHeaders.Add(TestAuthHandler.UserIdHeader, userId);
-        return client;
-    }
-
     [Fact]
     public async Task Post_NullBody_Returns400()
     {
-        using var client = CreateAuthedClient();
+        using var client = _factory.CreateAuthedClient("client-log-user");
 
         var response = await client.PostAsJsonAsync<IReadOnlyList<ClientLogEntry>?>(
             "/api/client-logs", null);
@@ -42,7 +30,7 @@ public sealed class ClientLogsControllerTests : IClassFixture<TestWebApplication
     [Fact]
     public async Task Post_EmptyArray_Returns400()
     {
-        using var client = CreateAuthedClient();
+        using var client = _factory.CreateAuthedClient("client-log-user");
 
         var response = await client.PostAsJsonAsync("/api/client-logs",
             Array.Empty<ClientLogEntry>());
@@ -53,7 +41,7 @@ public sealed class ClientLogsControllerTests : IClassFixture<TestWebApplication
     [Fact]
     public async Task Post_ValidEntries_Returns202()
     {
-        using var client = CreateAuthedClient();
+        using var client = _factory.CreateAuthedClient("client-log-user");
         var entries = new[]
         {
             new ClientLogEntry("sess-1", "info", "Test message",
@@ -68,7 +56,7 @@ public sealed class ClientLogsControllerTests : IClassFixture<TestWebApplication
     [Fact]
     public async Task Post_OverMaxBatchSize_Returns413()
     {
-        using var client = CreateAuthedClient();
+        using var client = _factory.CreateAuthedClient("client-log-user");
 
         // MaxBatchSize is 100; send 101 entries
         var entries = Enumerable.Range(0, 101)
@@ -85,7 +73,7 @@ public sealed class ClientLogsControllerTests : IClassFixture<TestWebApplication
     [Fact]
     public async Task Post_MultipleValidEntries_Returns202()
     {
-        using var client = CreateAuthedClient();
+        using var client = _factory.CreateAuthedClient("client-log-user");
         var entries = new[]
         {
             new ClientLogEntry("sess-1", "debug", "Debug msg",
@@ -104,7 +92,7 @@ public sealed class ClientLogsControllerTests : IClassFixture<TestWebApplication
     [Fact]
     public async Task Post_ExactlyMaxBatchSize_Returns202()
     {
-        using var client = CreateAuthedClient();
+        using var client = _factory.CreateAuthedClient("client-log-user");
 
         var entries = Enumerable.Range(0, 100)
             .Select(i => new ClientLogEntry("sess-1", "info", $"msg-{i}",
@@ -119,7 +107,7 @@ public sealed class ClientLogsControllerTests : IClassFixture<TestWebApplication
     [Fact]
     public async Task Post_UnknownLogLevel_TreatedAsInformation()
     {
-        using var client = CreateAuthedClient();
+        using var client = _factory.CreateAuthedClient("client-log-user");
         var entries = new[]
         {
             new ClientLogEntry("sess-1", "unknown-level", "Unknown level msg",

--- a/src/Content/Tests/Presentation.AgentHub.Tests/Controllers/ConfigControllerTests.cs
+++ b/src/Content/Tests/Presentation.AgentHub.Tests/Controllers/ConfigControllerTests.cs
@@ -21,29 +21,10 @@ public sealed class ConfigControllerTests : IClassFixture<TestWebApplicationFact
 
     public ConfigControllerTests(TestWebApplicationFactory factory) => _factory = factory;
 
-    private HttpClient CreateAuthedClient(
-        Action<IServiceCollection>? configureServices = null)
-    {
-        var client = _factory
-            .WithWebHostBuilder(b =>
-            {
-                b.ConfigureTestServices(services =>
-                {
-                    services.AddAuthentication(TestAuthHandler.SchemeName)
-                        .AddScheme<AuthenticationSchemeOptions, TestAuthHandler>(
-                            TestAuthHandler.SchemeName, _ => { });
-                    configureServices?.Invoke(services);
-                });
-            })
-            .CreateClient();
-        client.DefaultRequestHeaders.Add(TestAuthHandler.UserIdHeader, "config-user");
-        return client;
-    }
-
     [Fact]
     public async Task GetDeployments_Returns200()
     {
-        using var client = CreateAuthedClient();
+        using var client = _factory.CreateAuthedClient("config-user");
 
         var response = await client.GetAsync("/api/config/deployments");
 
@@ -53,7 +34,7 @@ public sealed class ConfigControllerTests : IClassFixture<TestWebApplicationFact
     [Fact]
     public async Task GetDeployments_ReturnsDeploymentAndDefault()
     {
-        using var client = CreateAuthedClient();
+        using var client = _factory.CreateAuthedClient("config-user");
 
         var response = await client.GetAsync("/api/config/deployments");
         var result = await response.Content.ReadFromJsonAsync<DeploymentsResponse>();
@@ -66,7 +47,7 @@ public sealed class ConfigControllerTests : IClassFixture<TestWebApplicationFact
     [Fact]
     public async Task GetDeployments_WhenNoDeploymentsConfigured_FallsBackToDefault()
     {
-        using var client = CreateAuthedClient();
+        using var client = _factory.CreateAuthedClient("config-user");
 
         var response = await client.GetAsync("/api/config/deployments");
         var result = await response.Content.ReadFromJsonAsync<DeploymentsResponse>();
@@ -80,7 +61,7 @@ public sealed class ConfigControllerTests : IClassFixture<TestWebApplicationFact
     public async Task GetStatus_WhenProviderUnconfigured_ReportsMissingSettings()
     {
         var missing = new[] { "AppConfig:AI:AgentFramework:Endpoint", "AppConfig:AI:AgentFramework:ApiKey" };
-        using var client = CreateAuthedClient(services =>
+        using var client = _factory.CreateAuthedClient("config-user", configureServices: services =>
         {
             services.AddSingleton<IChatClientFactory>(new FakeChatClientFactory
             {
@@ -103,7 +84,7 @@ public sealed class ConfigControllerTests : IClassFixture<TestWebApplicationFact
     [Fact]
     public async Task GetStatus_WhenProviderConfigured_ReportsConfigured()
     {
-        using var client = CreateAuthedClient(services =>
+        using var client = _factory.CreateAuthedClient("config-user", configureServices: services =>
         {
             services.AddSingleton<IChatClientFactory>(new FakeChatClientFactory
             {

--- a/src/Content/Tests/Presentation.AgentHub.Tests/Controllers/EscalationsControllerIntegrationTests.cs
+++ b/src/Content/Tests/Presentation.AgentHub.Tests/Controllers/EscalationsControllerIntegrationTests.cs
@@ -28,20 +28,6 @@ public sealed class EscalationsControllerIntegrationTests : IClassFixture<TestWe
 
     public EscalationsControllerIntegrationTests(TestWebApplicationFactory factory) => _factory = factory;
 
-    private HttpClient CreateAuthedClient(string userId = "alice@contoso.com", string? roles = null)
-    {
-        var client = _factory
-            .WithWebHostBuilder(b => b.ConfigureTestServices(services =>
-                services.AddAuthentication(TestAuthHandler.SchemeName)
-                    .AddScheme<AuthenticationSchemeOptions, TestAuthHandler>(
-                        TestAuthHandler.SchemeName, _ => { })))
-            .CreateClient();
-        client.DefaultRequestHeaders.Add(TestAuthHandler.UserIdHeader, userId);
-        if (roles is not null)
-            client.DefaultRequestHeaders.Add(TestAuthHandler.RolesHeader, roles);
-        return client;
-    }
-
     [Fact]
     public async Task GetPending_Unauthenticated_Returns401()
     {
@@ -56,7 +42,7 @@ public sealed class EscalationsControllerIntegrationTests : IClassFixture<TestWe
     [Fact]
     public async Task GetPending_AuthenticatedWithoutDecideRole_Returns403()
     {
-        using var client = CreateAuthedClient();
+        using var client = _factory.CreateAuthedClient();
 
         var response = await client.GetAsync("/api/escalations");
 
@@ -74,7 +60,7 @@ public sealed class EscalationsControllerIntegrationTests : IClassFixture<TestWe
                 (q, _) => captured = (GetPendingEscalationsForApproverQuery)q)
             .ReturnsAsync(Result<IReadOnlyList<EscalationSummary>>.Success([]));
 
-        using var client = CreateAuthedClient("bob@contoso.com", EscalationsController.DecideRole);
+        using var client = _factory.CreateAuthedClient("bob@contoso.com", EscalationsController.DecideRole);
 
         var response = await client.GetAsync("/api/escalations");
 
@@ -95,7 +81,7 @@ public sealed class EscalationsControllerIntegrationTests : IClassFixture<TestWe
             .ReturnsAsync(Result<SubmitEscalationDecisionResult>.Success(
                 new SubmitEscalationDecisionResult { Status = EscalationDecisionStatus.DecisionRecorded }));
 
-        using var client = CreateAuthedClient("alice@contoso.com", EscalationsController.DecideRole);
+        using var client = _factory.CreateAuthedClient("alice@contoso.com", EscalationsController.DecideRole);
 
         // The spoofed approverName member has no binding target on the DTO and must be ignored.
         var response = await client.PostAsJsonAsync(
@@ -114,7 +100,7 @@ public sealed class EscalationsControllerIntegrationTests : IClassFixture<TestWe
     [Fact]
     public async Task Cancel_WithDecideRoleOnly_Returns403()
     {
-        using var client = CreateAuthedClient("alice@contoso.com", EscalationsController.DecideRole);
+        using var client = _factory.CreateAuthedClient("alice@contoso.com", EscalationsController.DecideRole);
 
         var response = await client.PostAsJsonAsync(
             $"/api/escalations/{Guid.NewGuid()}/cancel", new { reason = "stale" });
@@ -137,7 +123,7 @@ public sealed class EscalationsControllerIntegrationTests : IClassFixture<TestWe
                 Decisions = []
             }));
 
-        using var client = CreateAuthedClient("ops@contoso.com", EscalationsController.AdminRole);
+        using var client = _factory.CreateAuthedClient("ops@contoso.com", EscalationsController.AdminRole);
 
         var response = await client.PostAsJsonAsync(
             $"/api/escalations/{Guid.NewGuid()}/cancel", new { reason = "superseded" });

--- a/src/Content/Tests/Presentation.AgentHub.Tests/Controllers/McpControllerTests.cs
+++ b/src/Content/Tests/Presentation.AgentHub.Tests/Controllers/McpControllerTests.cs
@@ -31,22 +31,6 @@ public sealed class McpControllerTests : IClassFixture<TestWebApplicationFactory
 
     // ── Helpers ──────────────────────────────────────────────────────────────
 
-    /// <summary>Creates an authenticated HTTP client using <see cref="TestAuthHandler"/>.</summary>
-    private HttpClient CreateAuthedClient(
-        string userId = "mcp-test-user",
-        WebApplicationFactory<Program>? factory = null)
-    {
-        var f = factory ?? _factory;
-        var client = f
-            .WithWebHostBuilder(b => b.ConfigureTestServices(services =>
-                services.AddAuthentication(TestAuthHandler.SchemeName)
-                    .AddScheme<AuthenticationSchemeOptions, TestAuthHandler>(
-                        TestAuthHandler.SchemeName, _ => { })))
-            .CreateClient();
-        client.DefaultRequestHeaders.Add(TestAuthHandler.UserIdHeader, userId);
-        return client;
-    }
-
     /// <summary>
     /// Creates a factory variant that registers a fake <see cref="IMcpToolProvider"/>
     /// and a log-capturing provider, then returns both along with a configured client.
@@ -135,7 +119,7 @@ public sealed class McpControllerTests : IClassFixture<TestWebApplicationFactory
     [Fact]
     public async Task GetPrompts_ReturnsEmptyArrayWhenNoProviderRegistered()
     {
-        using var client = CreateAuthedClient();
+        using var client = _factory.CreateAuthedClient("mcp-test-user");
         using var response = await client.GetAsync("/api/mcp/prompts");
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
@@ -218,7 +202,7 @@ public sealed class McpControllerTests : IClassFixture<TestWebApplicationFactory
     [Fact]
     public async Task InvokeTool_OversizedBody_Returns413()
     {
-        using var client = CreateAuthedClient();
+        using var client = _factory.CreateAuthedClient("mcp-test-user");
 
         // 33 KB of JSON — safely over the 32 KB limit.
         var oversized = new string('x', 33 * 1024);

--- a/src/Content/Tests/Presentation.AgentHub.Tests/Controllers/MetricsControllerTests.cs
+++ b/src/Content/Tests/Presentation.AgentHub.Tests/Controllers/MetricsControllerTests.cs
@@ -17,25 +17,6 @@ public sealed class MetricsControllerTests : IClassFixture<TestWebApplicationFac
 
     public MetricsControllerTests(TestWebApplicationFactory factory) => _factory = factory;
 
-    private HttpClient CreateAuthedClient(
-        Action<IServiceCollection>? configureServices = null)
-    {
-        var client = _factory
-            .WithWebHostBuilder(b =>
-            {
-                b.ConfigureTestServices(services =>
-                {
-                    services.AddAuthentication(TestAuthHandler.SchemeName)
-                        .AddScheme<AuthenticationSchemeOptions, TestAuthHandler>(
-                            TestAuthHandler.SchemeName, _ => { });
-                    configureServices?.Invoke(services);
-                });
-            })
-            .CreateClient();
-        client.DefaultRequestHeaders.Add(TestAuthHandler.UserIdHeader, "metrics-user");
-        return client;
-    }
-
     private static Mock<IPrometheusQueryService> CreateMockPrometheus(
         MetricsQueryResponse? instantResponse = null,
         MetricsQueryResponse? rangeResponse = null,
@@ -61,7 +42,7 @@ public sealed class MetricsControllerTests : IClassFixture<TestWebApplicationFac
     public async Task QueryInstant_ValidQuery_Returns200()
     {
         var mock = CreateMockPrometheus();
-        using var client = CreateAuthedClient(s =>
+        using var client = _factory.CreateAuthedClient("metrics-user", configureServices: s =>
             s.AddSingleton<IPrometheusQueryService>(mock.Object));
 
         var response = await client.GetAsync("/api/metrics/instant?query=up");
@@ -86,7 +67,7 @@ public sealed class MetricsControllerTests : IClassFixture<TestWebApplicationFac
             ],
         };
         var mock = CreateMockPrometheus(instantResponse: expected);
-        using var client = CreateAuthedClient(s =>
+        using var client = _factory.CreateAuthedClient("metrics-user", configureServices: s =>
             s.AddSingleton<IPrometheusQueryService>(mock.Object));
 
         var response = await client.GetAsync("/api/metrics/instant?query=up");
@@ -102,7 +83,7 @@ public sealed class MetricsControllerTests : IClassFixture<TestWebApplicationFac
     public async Task QueryInstant_MissingQuery_Returns400()
     {
         var mock = CreateMockPrometheus();
-        using var client = CreateAuthedClient(s =>
+        using var client = _factory.CreateAuthedClient("metrics-user", configureServices: s =>
             s.AddSingleton<IPrometheusQueryService>(mock.Object));
 
         var response = await client.GetAsync("/api/metrics/instant?query=");
@@ -114,7 +95,7 @@ public sealed class MetricsControllerTests : IClassFixture<TestWebApplicationFac
     public async Task QueryInstant_EmptyQueryParam_Returns400()
     {
         var mock = CreateMockPrometheus();
-        using var client = CreateAuthedClient(s =>
+        using var client = _factory.CreateAuthedClient("metrics-user", configureServices: s =>
             s.AddSingleton<IPrometheusQueryService>(mock.Object));
 
         var response = await client.GetAsync("/api/metrics/instant");
@@ -131,7 +112,7 @@ public sealed class MetricsControllerTests : IClassFixture<TestWebApplicationFac
     public async Task QueryInstant_InjectionAttempt_Returns400(string maliciousQuery)
     {
         var mock = CreateMockPrometheus();
-        using var client = CreateAuthedClient(s =>
+        using var client = _factory.CreateAuthedClient("metrics-user", configureServices: s =>
             s.AddSingleton<IPrometheusQueryService>(mock.Object));
 
         var response = await client.GetAsync($"/api/metrics/instant?query={Uri.EscapeDataString(maliciousQuery)}");
@@ -144,7 +125,7 @@ public sealed class MetricsControllerTests : IClassFixture<TestWebApplicationFac
     {
         var errorResponse = new MetricsQueryResponse { Success = false, Error = "bad_data: invalid expression" };
         var mock = CreateMockPrometheus(instantResponse: errorResponse);
-        using var client = CreateAuthedClient(s =>
+        using var client = _factory.CreateAuthedClient("metrics-user", configureServices: s =>
             s.AddSingleton<IPrometheusQueryService>(mock.Object));
 
         var response = await client.GetAsync("/api/metrics/instant?query=invalid{");
@@ -158,7 +139,7 @@ public sealed class MetricsControllerTests : IClassFixture<TestWebApplicationFac
     public async Task QueryRange_ValidParams_Returns200()
     {
         var mock = CreateMockPrometheus();
-        using var client = CreateAuthedClient(s =>
+        using var client = _factory.CreateAuthedClient("metrics-user", configureServices: s =>
             s.AddSingleton<IPrometheusQueryService>(mock.Object));
 
         var response = await client.GetAsync(
@@ -171,7 +152,7 @@ public sealed class MetricsControllerTests : IClassFixture<TestWebApplicationFac
     public async Task QueryRange_MissingStart_Returns400()
     {
         var mock = CreateMockPrometheus();
-        using var client = CreateAuthedClient(s =>
+        using var client = _factory.CreateAuthedClient("metrics-user", configureServices: s =>
             s.AddSingleton<IPrometheusQueryService>(mock.Object));
 
         var response = await client.GetAsync(
@@ -184,7 +165,7 @@ public sealed class MetricsControllerTests : IClassFixture<TestWebApplicationFac
     public async Task QueryRange_MissingStep_Returns400()
     {
         var mock = CreateMockPrometheus();
-        using var client = CreateAuthedClient(s =>
+        using var client = _factory.CreateAuthedClient("metrics-user", configureServices: s =>
             s.AddSingleton<IPrometheusQueryService>(mock.Object));
 
         var response = await client.GetAsync(
@@ -197,7 +178,7 @@ public sealed class MetricsControllerTests : IClassFixture<TestWebApplicationFac
     public async Task QueryRange_MissingQuery_Returns400()
     {
         var mock = CreateMockPrometheus();
-        using var client = CreateAuthedClient(s =>
+        using var client = _factory.CreateAuthedClient("metrics-user", configureServices: s =>
             s.AddSingleton<IPrometheusQueryService>(mock.Object));
 
         var response = await client.GetAsync(
@@ -212,7 +193,7 @@ public sealed class MetricsControllerTests : IClassFixture<TestWebApplicationFac
     public async Task GetCatalog_Returns200WithEntries()
     {
         var mock = CreateMockPrometheus();
-        using var client = CreateAuthedClient(s =>
+        using var client = _factory.CreateAuthedClient("metrics-user", configureServices: s =>
             s.AddSingleton<IPrometheusQueryService>(mock.Object));
 
         var response = await client.GetAsync("/api/metrics/catalog");
@@ -227,7 +208,7 @@ public sealed class MetricsControllerTests : IClassFixture<TestWebApplicationFac
     public async Task GetCatalog_AllEntriesHaveRequiredFields()
     {
         var mock = CreateMockPrometheus();
-        using var client = CreateAuthedClient(s =>
+        using var client = _factory.CreateAuthedClient("metrics-user", configureServices: s =>
             s.AddSingleton<IPrometheusQueryService>(mock.Object));
 
         var response = await client.GetAsync("/api/metrics/catalog");
@@ -246,7 +227,7 @@ public sealed class MetricsControllerTests : IClassFixture<TestWebApplicationFac
     public async Task GetCatalog_ContainsExpectedCategories()
     {
         var mock = CreateMockPrometheus();
-        using var client = CreateAuthedClient(s =>
+        using var client = _factory.CreateAuthedClient("metrics-user", configureServices: s =>
             s.AddSingleton<IPrometheusQueryService>(mock.Object));
 
         var response = await client.GetAsync("/api/metrics/catalog");
@@ -267,7 +248,7 @@ public sealed class MetricsControllerTests : IClassFixture<TestWebApplicationFac
     {
         var mock = CreateMockPrometheus(
             healthResponse: new PrometheusHealthResponse { Healthy = true, Version = "2.53.0" });
-        using var client = CreateAuthedClient(s =>
+        using var client = _factory.CreateAuthedClient("metrics-user", configureServices: s =>
             s.AddSingleton<IPrometheusQueryService>(mock.Object));
 
         var response = await client.GetAsync("/api/metrics/health");
@@ -283,7 +264,7 @@ public sealed class MetricsControllerTests : IClassFixture<TestWebApplicationFac
     {
         var mock = CreateMockPrometheus(
             healthResponse: new PrometheusHealthResponse { Healthy = false, Error = "Connection refused" });
-        using var client = CreateAuthedClient(s =>
+        using var client = _factory.CreateAuthedClient("metrics-user", configureServices: s =>
             s.AddSingleton<IPrometheusQueryService>(mock.Object));
 
         var response = await client.GetAsync("/api/metrics/health");

--- a/src/Content/Tests/Presentation.AgentHub.Tests/TestClientFactoryExtensions.cs
+++ b/src/Content/Tests/Presentation.AgentHub.Tests/TestClientFactoryExtensions.cs
@@ -1,0 +1,47 @@
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Presentation.AgentHub.Tests;
+
+/// <summary>
+/// Shared authenticated-client construction for AgentHub wire-level controller tests. Replaces
+/// the per-test-class <c>CreateAuthedClient</c> copies: every controller test that needs an
+/// authenticated caller swaps the host's authentication for <see cref="TestAuthHandler"/> and
+/// stamps the synthetic identity headers the same way, so the recipe lives once, here.
+/// </summary>
+public static class TestClientFactoryExtensions
+{
+    /// <summary>
+    /// Creates an <see cref="HttpClient"/> whose requests authenticate through
+    /// <see cref="TestAuthHandler"/> as the given synthetic user.
+    /// </summary>
+    /// <param name="factory">The web application factory to create the client from.</param>
+    /// <param name="userId">The synthetic user id stamped into <see cref="TestAuthHandler.UserIdHeader"/>.</param>
+    /// <param name="roles">Optional comma-separated role names stamped into <see cref="TestAuthHandler.RolesHeader"/>; omit for a role-less principal.</param>
+    /// <param name="configureServices">Optional extra test-service configuration applied after the authentication swap (e.g. replacing a controller dependency with a mock).</param>
+    /// <returns>The configured client.</returns>
+    public static HttpClient CreateAuthedClient(
+        this WebApplicationFactory<Program> factory,
+        string userId = "alice@contoso.com",
+        string? roles = null,
+        Action<IServiceCollection>? configureServices = null)
+    {
+        ArgumentNullException.ThrowIfNull(factory);
+
+        var client = factory
+            .WithWebHostBuilder(b => b.ConfigureTestServices(services =>
+            {
+                services.AddAuthentication(TestAuthHandler.SchemeName)
+                    .AddScheme<AuthenticationSchemeOptions, TestAuthHandler>(
+                        TestAuthHandler.SchemeName, _ => { });
+                configureServices?.Invoke(services);
+            }))
+            .CreateClient();
+        client.DefaultRequestHeaders.Add(TestAuthHandler.UserIdHeader, userId);
+        if (roles is not null)
+            client.DefaultRequestHeaders.Add(TestAuthHandler.RolesHeader, roles);
+        return client;
+    }
+}

--- a/src/Content/Tests/Presentation.BundleApi.Tests/AutonomyRoutesNotMountedTests.cs
+++ b/src/Content/Tests/Presentation.BundleApi.Tests/AutonomyRoutesNotMountedTests.cs
@@ -1,0 +1,41 @@
+using System.Net;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+
+namespace Presentation.BundleApi.Tests;
+
+/// <summary>
+/// Proves the autonomy governance API's opt-in gate against the exact real host it exists to
+/// protect. BundleApi references <c>Presentation.Common</c> and calls <c>AddControllers()</c>,
+/// so the Web SDK auto-registers Presentation.Common as an MVC application part and
+/// <c>AutonomyController</c> IS discovered here — but BundleApi never calls
+/// <c>AddAutonomyApi()</c>, so the opt-in action constraint must keep every autonomy route
+/// un-matched. The API describes the workload host's governance posture; a bundle host must
+/// not accidentally expose it.
+/// </summary>
+public sealed class AutonomyRoutesNotMountedTests : IClassFixture<WebApplicationFactory<Program>>
+{
+    private readonly WebApplicationFactory<Program> _factory;
+
+    public AutonomyRoutesNotMountedTests(WebApplicationFactory<Program> factory)
+    {
+        _factory = factory;
+    }
+
+    [Theory]
+    [InlineData("GET", "/api/governance/autonomy/tiers/Explore")]
+    [InlineData("POST", "/api/governance/autonomy/decision-preview")]
+    public async Task AutonomyRoute_InNonOptedHost_Returns404NotAChallenge(string method, string path)
+    {
+        // 404 specifically — not 401/403. The gate is an action constraint that un-matches the
+        // route before authentication, so a probe cannot even learn the routes exist.
+        var client = _factory.CreateClient();
+
+        using var request = new HttpRequestMessage(new HttpMethod(method), path);
+        var response = await client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound,
+            "a host that never called AddAutonomyApi() must not expose autonomy governance routes");
+    }
+}


### PR DESCRIPTION
Part of the external-trigger API program (Wave 2). Scope doc: `.claude/plans/external-trigger-api-scope.md` §4, H3 row.

## What this adds

Two **strictly read-only** governance endpoints, mounted opt-in:

- `GET /api/governance/autonomy/tiers/{subagentType}` — the effective autonomy tier for a subagent type.
- `POST /api/governance/autonomy/decision-preview` — side-effect-free preview: would this action be allowed, require escalation, or be denied, and why.

Autonomy tiers are pure config enforced by a MediatR pipeline behavior; there is no mutable runtime state, so reads plus a preview are the entire honest surface. **No mutation endpoint** — that is deliberate and documented.

## Why it cannot drift from enforcement

The preview handler chains the *same* `IAutonomyTierResolver` + `IAutonomyDecisionEvaluator` the enforcement path uses. No policy logic was duplicated and **no enforcement file was touched** — the only modified non-test files are `DevAuthHandler.cs` (+1 role claim) and AgentHub `DependencyInjection.cs` (+1 chained `AddAutonomyApi()`). A parity test drives the same evaluator instance directly and through the handler and asserts identical outcomes across graded-autonomy on/off, all tiers, and all blast radii.

## Zero side effects

Verified by reading the full call chain (resolver → evaluator: config reads and logging only) and locked in with `MockBehavior.Strict` + `VerifyNoOtherCalls` — no store writes, no audit records, no escalations.

## Security posture

- Role `Harness.Governance.Read` via `[Authorize(Roles = …)]` on both routes; claim appended to the dev auth handler.
- **Opt-in mount**: `Presentation.Common` is an auto-discovered MVC application part, so a bare controller there would mount in *every* host. Uses the H1 pattern — marker service + `IActionConstraint` — so routes un-match and return a plain 404 (no route disclosure, no auth challenge) in hosts that did not opt in. `AutonomyRoutesNotMountedTests` proves this against the real BundleApi host.
- Failure mapping exclusively via the shared `ControllerBaseExtensions.FailureResponse`; unknown subagent type → 404; enum parsing is names-only and rejects numeric forms.

## Review

Standards, spec-fidelity, and two cleanup axes reviewed pre-push. No hard violations, no scope creep, no HIGH findings. Fix round applied: shared message strings hoisted into `AutonomyValidationRules`, the `TargetKind` wire default single-sourced and its optionality documented, and `CreateAuthedClient` — which had grown to six identical private copies across AgentHub test classes — extracted to a shared `TestClientFactoryExtensions` with all 41 call sites migrated.

Known follow-up (deliberately **not** in this PR): the opt-in mount trio is now its second copy. Parallel PRs are adding more; once they land, one chore generalizes it to `RequiresApiOptInAttribute<TMarker>` + `AddOptInApi<TMarker>()`.

## Test plan

- 18 new tests: tier read matches resolver/config, preview parity with the real evaluator, zero-side-effect proofs, role denial 403 + unauthenticated 401, unknown-subagent 404 at the wire, body/route binding, not-mounted 404.
- `dotnet build src/AgenticHarness.slnx` — 0 errors, 0 new warnings.
- `dotnet test src/AgenticHarness.slnx` — full suite green, 8,500+ tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BnoLcufW278UxA9ssBM1Tc