### PR TITLE
feat: drift monitoring HTTP surface (H4)

### DIFF
--- a/src/Content/Application/Application.AI.Common/Interfaces/DriftDetection/IDriftBaselineStore.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/DriftDetection/IDriftBaselineStore.cs
@@ -24,9 +24,14 @@ public interface IDriftBaselineStore
     /// unknown id, so callers can map absence to their own not-found semantics.
     /// </summary>
     /// <remarks>
-    /// Baselines are keyed by scope + identifier, not by id, so this is a secondary lookup. It
-    /// exists so id-addressed callers (the drift HTTP surface's recalculate route) do not have to
-    /// pull the entire baseline set and filter in memory on every request.
+    /// <para>
+    /// Baselines are keyed by scope + identifier, not by id, so this is a secondary lookup and
+    /// implementations may still have to scan candidates. What it lets a backend avoid is
+    /// <em>materializing</em> them: the graph implementation filters on the stored
+    /// <c>BaselineId</c> property and deserializes at most one node's JSON payload, instead of
+    /// reconstructing every <see cref="DriftBaseline"/> in the store to find one. An
+    /// implementation with a real secondary index should use it.
+    /// </para>
     /// </remarks>
     /// <param name="baselineId">The baseline snapshot id to resolve.</param>
     /// <param name="ct">Cancellation token.</param>

--- a/src/Content/Application/Application.AI.Common/Interfaces/DriftDetection/IDriftBaselineStore.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/DriftDetection/IDriftBaselineStore.cs
@@ -17,4 +17,18 @@ public interface IDriftBaselineStore
 
     /// <summary>Lists all baselines, optionally filtered by scope.</summary>
     Task<Result<IReadOnlyList<DriftBaseline>>> GetBaselinesAsync(DriftScope? scope, CancellationToken ct);
+
+    /// <summary>
+    /// Retrieves the baseline snapshot carrying the given <see cref="DriftBaseline.BaselineId"/>,
+    /// or a null value when no active baseline has that id. Returns null (never a failure) for an
+    /// unknown id, so callers can map absence to their own not-found semantics.
+    /// </summary>
+    /// <remarks>
+    /// Baselines are keyed by scope + identifier, not by id, so this is a secondary lookup. It
+    /// exists so id-addressed callers (the drift HTTP surface's recalculate route) do not have to
+    /// pull the entire baseline set and filter in memory on every request.
+    /// </remarks>
+    /// <param name="baselineId">The baseline snapshot id to resolve.</param>
+    /// <param name="ct">Cancellation token.</param>
+    Task<Result<DriftBaseline?>> GetBaselineByIdAsync(Guid baselineId, CancellationToken ct);
 }

--- a/src/Content/Application/Application.Core/CQRS/DriftDetection/DriftOperatorActionAudit.cs
+++ b/src/Content/Application/Application.Core/CQRS/DriftDetection/DriftOperatorActionAudit.cs
@@ -1,0 +1,151 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Domain.AI.DriftDetection;
+using Domain.Common;
+
+namespace Application.Core.CQRS.DriftDetection;
+
+/// <summary>
+/// Which half of an operator action a <see cref="DriftOperatorActionAudit"/> record describes.
+/// Every drift write produces both, in order.
+/// </summary>
+public enum DriftOperatorActionPhase
+{
+    /// <summary>
+    /// Recorded <em>before</em> the write is dispatched, and required to succeed for the write
+    /// to proceed. This is the attributability guarantee: no evaluation reaches the EWMA
+    /// pipeline without a durable record naming who asked for it.
+    /// </summary>
+    Attempt,
+
+    /// <summary>
+    /// Recorded after the write returns, carrying the outcome and the evidence of what changed.
+    /// Best-effort: the mutation has already happened, so a failed append is logged rather than
+    /// reported as an operation failure.
+    /// </summary>
+    Outcome
+}
+
+/// <summary>
+/// The audit payload stamped onto <see cref="DriftAuditRecordType.EvaluationPushed"/> and
+/// <see cref="DriftAuditRecordType.BaselineRecalculationRequested"/> records: who performed the
+/// operator action, what it targeted, and — for the outcome record — how it ended and what it
+/// changed. Serialized into <see cref="DriftAuditRecord.Payload"/> by the drift command handlers.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Evaluation pushes are a history-poisoning vector — a caller who can push scores can shift
+/// baselines and EWMA state to mask real drift, or fabricate drift to trigger escalations. The
+/// audit trail is the compensating control, so every write through the HTTP surface is recorded
+/// twice: a fail-closed <see cref="DriftOperatorActionPhase.Attempt"/> record before dispatch
+/// and a best-effort <see cref="DriftOperatorActionPhase.Outcome"/> record after. Both carry
+/// the same <see cref="ActionId"/>, so an attempt with no matching outcome is itself a
+/// detectable signal.
+/// </para>
+/// <para>
+/// <see cref="FailureCode"/> carries a stable classification (never raw error or exception
+/// text), keeping the audit trail free of internal detail.
+/// </para>
+/// </remarks>
+public sealed record DriftOperatorActionAudit
+{
+    /// <summary>Stable action code for an evaluation push.</summary>
+    public const string EvaluationPushAction = "drift.evaluation_push";
+
+    /// <summary>Stable action code for a baseline recalculation request.</summary>
+    public const string BaselineRecalculateAction = "drift.baseline_recalculate";
+
+    private static readonly JsonSerializerOptions SerializeOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+        Converters = { new JsonStringEnumConverter() },
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+    };
+
+    /// <summary>
+    /// Correlates this record's attempt and outcome halves. Minted per operator action by the
+    /// handler; unrelated to any artifact id.
+    /// </summary>
+    public required Guid ActionId { get; init; }
+
+    /// <summary>Which half of the action this record describes.</summary>
+    public required DriftOperatorActionPhase Phase { get; init; }
+
+    /// <summary>
+    /// The authenticated caller's identity, resolved by the controller from the validated
+    /// token's configured claim (<c>DriftDetectionConfig.CallerIdentityClaimType</c>). Never
+    /// sourced from a request body.
+    /// </summary>
+    public required string CallerId { get; init; }
+
+    /// <summary>
+    /// Which operator action this record describes: <see cref="EvaluationPushAction"/> or
+    /// <see cref="BaselineRecalculateAction"/>.
+    /// </summary>
+    public required string Action { get; init; }
+
+    /// <summary>The targeted scope. Null when the target could not be resolved (e.g. an unknown baseline id).</summary>
+    public DriftScope? Scope { get; init; }
+
+    /// <summary>The targeted scope identifier. Null when the target could not be resolved.</summary>
+    public string? ScopeIdentifier { get; init; }
+
+    /// <summary>
+    /// Whether the action succeeded. Null on an <see cref="DriftOperatorActionPhase.Attempt"/>
+    /// record, where the outcome is not yet known.
+    /// </summary>
+    public bool? Succeeded { get; init; }
+
+    /// <summary>
+    /// Correlates the action to the artifact it produced: the resulting <c>DriftScore.ScoreId</c>
+    /// for an evaluation push, the new <c>DriftBaseline.BaselineId</c> for a recalculation.
+    /// Null on attempt records and on failures.
+    /// </summary>
+    public Guid? CorrelationId { get; init; }
+
+    /// <summary>
+    /// Stable failure classification when <see cref="Succeeded"/> is false (e.g.
+    /// <c>drift.conflict</c>, <c>drift.not_found</c>). Never raw error text.
+    /// </summary>
+    public string? FailureCode { get; init; }
+
+    /// <summary>
+    /// The <see cref="DriftBaseline.BaselineId"/> this recalculation replaced. Recalculation
+    /// overwrites the previous snapshot in the store, so this is the only surviving pointer to
+    /// what "normal" meant beforehand — without it, laundering poisoned evaluations into a new
+    /// baseline leaves no reconstructible before/after. Null for evaluation pushes.
+    /// </summary>
+    public Guid? PreviousBaselineId { get; init; }
+
+    /// <summary>
+    /// Number of evaluations the recalculation consumed. Null for evaluation pushes and failures.
+    /// </summary>
+    public int? SampleCount { get; init; }
+
+    /// <summary>
+    /// Start of the history window the recalculation consumed. Together with
+    /// <see cref="WindowEnd"/> this pins which evaluations fed the new baseline, so a reviewer
+    /// can re-query <c>GET /api/drift/history</c> for exactly that range. Null for evaluation
+    /// pushes and failures.
+    /// </summary>
+    public DateTimeOffset? WindowStart { get; init; }
+
+    /// <summary>End of the history window the recalculation consumed.</summary>
+    public DateTimeOffset? WindowEnd { get; init; }
+
+    /// <summary>Serializes this envelope to the JSON stored in <see cref="DriftAuditRecord.Payload"/>.</summary>
+    public string ToJson() => JsonSerializer.Serialize(this, SerializeOptions);
+
+    /// <summary>
+    /// Maps a <see cref="ResultFailureType"/> to the stable audit failure code recorded in
+    /// <see cref="FailureCode"/>.
+    /// </summary>
+    /// <param name="failureType">The failure classification of the failed operation.</param>
+    public static string FailureCodeFor(ResultFailureType failureType) => failureType switch
+    {
+        ResultFailureType.Conflict => "drift.conflict",
+        ResultFailureType.NotFound => "drift.not_found",
+        ResultFailureType.Validation => "drift.validation",
+        _ => "drift.failed"
+    };
+}

--- a/src/Content/Application/Application.Core/CQRS/DriftDetection/DriftOperatorAuditRecorder.cs
+++ b/src/Content/Application/Application.Core/CQRS/DriftDetection/DriftOperatorAuditRecorder.cs
@@ -1,0 +1,129 @@
+using Application.AI.Common.Interfaces.DriftDetection;
+using Domain.AI.DriftDetection;
+using Domain.Common;
+using Microsoft.Extensions.Logging;
+
+namespace Application.Core.CQRS.DriftDetection;
+
+/// <summary>
+/// Shared append logic for operator-action audit records so both drift write commands record
+/// caller identity identically, in two phases with deliberately different failure postures.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Why two records.</b> The threat model names history poisoning as the risk and this audit
+/// trail as the compensating control, so the control must hold when the store is under attack.
+/// Recording only after the mutation makes the trail fail-<em>open</em>: anyone who can make the
+/// audit store fail (fill the disk, revoke write permission on <c>AuditPath</c>) gets
+/// unattributed poisoning — pushes still advance EWMA, still persist, still return success, and
+/// nothing lands in the trail. <c>DefaultEscalationService</c> can be fail-closed because it
+/// audits the request <em>before</em> mutating; this recorder mirrors that ordering rather than
+/// its posture alone.
+/// </para>
+/// <para>
+/// <see cref="RecordAttemptAsync"/> therefore runs before dispatch and is fail-CLOSED: its
+/// result gates the write. <see cref="RecordOutcomeAsync"/> runs after and is fail-OPEN, which
+/// is sound precisely because the attempt record already exists — the mutation has happened and
+/// is already attributable, so refusing to report it would lose information rather than protect
+/// any.
+/// </para>
+/// </remarks>
+internal static class DriftOperatorAuditRecorder
+{
+    /// <summary>
+    /// Appends the pre-dispatch attempt record. <b>Fail-closed</b>: callers must abort the write
+    /// when this returns a failure, so no drift mutation can occur without a durable record of
+    /// who requested it.
+    /// </summary>
+    /// <param name="auditStore">The append-only drift audit store.</param>
+    /// <param name="recordType">The operator-action record type being appended.</param>
+    /// <param name="audit">The caller envelope; its phase must be <see cref="DriftOperatorActionPhase.Attempt"/>.</param>
+    /// <param name="recordedAt">The append timestamp.</param>
+    /// <param name="logger">Logger for append diagnostics.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Success when the attempt is durably recorded; otherwise a failure the caller must honour.</returns>
+    public static async Task<Result> RecordAttemptAsync(
+        IDriftAuditStore auditStore,
+        DriftAuditRecordType recordType,
+        DriftOperatorActionAudit audit,
+        DateTimeOffset recordedAt,
+        ILogger logger,
+        CancellationToken ct)
+    {
+        try
+        {
+            var result = await auditStore.RecordAsync(new DriftAuditRecord
+            {
+                RecordId = Guid.NewGuid(),
+                // Attempt records correlate by ActionId; the produced artifact does not exist yet.
+                EventId = audit.ActionId,
+                RecordType = recordType,
+                Payload = audit.ToJson(),
+                RecordedAt = recordedAt
+            }, ct);
+
+            if (result.IsSuccess)
+                return Result.Success();
+
+            logger.LogError(
+                "Refusing drift write: attempt audit could not be recorded ({Action} by {CallerId}, action {ActionId}): {Errors}",
+                audit.Action, audit.CallerId, audit.ActionId, string.Join(", ", result.Errors));
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            logger.LogError(ex,
+                "Refusing drift write: attempt audit could not be recorded ({Action} by {CallerId}, action {ActionId})",
+                audit.Action, audit.CallerId, audit.ActionId);
+        }
+
+        // Stable, scrubbed code — the store's error text never reaches the caller.
+        return Result.Fail("drift.audit_unavailable");
+    }
+
+    /// <summary>
+    /// Appends the post-dispatch outcome record. <b>Fail-open</b>: append failures are logged
+    /// but never fail the operation, because the mutation has already happened and the
+    /// fail-closed attempt record already made it attributable.
+    /// </summary>
+    /// <param name="auditStore">The append-only drift audit store.</param>
+    /// <param name="recordType">The operator-action record type being appended.</param>
+    /// <param name="audit">The caller/outcome envelope; its phase must be <see cref="DriftOperatorActionPhase.Outcome"/>.</param>
+    /// <param name="eventId">Correlation id for the record (the produced artifact's id, or the action id on failure).</param>
+    /// <param name="recordedAt">The append timestamp.</param>
+    /// <param name="logger">Logger for append diagnostics.</param>
+    /// <param name="ct">Cancellation token.</param>
+    public static async Task RecordOutcomeAsync(
+        IDriftAuditStore auditStore,
+        DriftAuditRecordType recordType,
+        DriftOperatorActionAudit audit,
+        Guid eventId,
+        DateTimeOffset recordedAt,
+        ILogger logger,
+        CancellationToken ct)
+    {
+        try
+        {
+            var result = await auditStore.RecordAsync(new DriftAuditRecord
+            {
+                RecordId = Guid.NewGuid(),
+                EventId = eventId,
+                RecordType = recordType,
+                Payload = audit.ToJson(),
+                RecordedAt = recordedAt
+            }, ct);
+
+            if (!result.IsSuccess)
+            {
+                logger.LogError(
+                    "Failed to append drift outcome audit ({Action} by {CallerId}, action {ActionId}): {Errors}. The attempt record remains as the attribution of record.",
+                    audit.Action, audit.CallerId, audit.ActionId, string.Join(", ", result.Errors));
+            }
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            logger.LogError(ex,
+                "Failed to append drift outcome audit ({Action} by {CallerId}, action {ActionId}). The attempt record remains as the attribution of record.",
+                audit.Action, audit.CallerId, audit.ActionId);
+        }
+    }
+}

--- a/src/Content/Application/Application.Core/CQRS/DriftDetection/DriftValidationRules.cs
+++ b/src/Content/Application/Application.Core/CQRS/DriftDetection/DriftValidationRules.cs
@@ -1,0 +1,52 @@
+namespace Application.Core.CQRS.DriftDetection;
+
+/// <summary>
+/// Shared validation constants for the drift-monitoring CQRS surface. Centralized so every
+/// command and query agrees on what a well-formed scope identifier, caller identity, and
+/// query window look like — and so the caps that keep a hostile caller from flooding the EWMA
+/// pipeline or the audit reader live in exactly one place.
+/// </summary>
+public static class DriftValidationRules
+{
+    /// <summary>
+    /// Maximum accepted scope-identifier length. Scope identifiers are agent ids, skill names,
+    /// or task-type names — short operational labels, not documents. Bounding them keeps graph
+    /// node ids, deterministic EWMA keys, and audit lines readable.
+    /// </summary>
+    public const int MaxScopeIdentifierLength = 200;
+
+    /// <summary>
+    /// Maximum accepted caller-identity length. Caller ids are token claims (object ids, UPNs,
+    /// service-principal names) stamped onto audit records; 256 characters covers every
+    /// realistic identity format while bounding audit lines. Matches the escalation surface's
+    /// approver-name cap.
+    /// </summary>
+    public const int MaxCallerIdLength = 256;
+
+    /// <summary>
+    /// Maximum number of dimension entries accepted in a single evaluation push. The
+    /// <c>DriftDimension</c> enum currently defines six dimensions; the cap leaves headroom for
+    /// consumer-extended enums while rejecting degenerate payloads outright.
+    /// </summary>
+    public const int MaxDimensionsPerEvaluation = 16;
+
+    /// <summary>
+    /// Maximum drift-history query window in days. History reads enumerate every persisted
+    /// evaluation for the scope; bounding the window bounds the response. The baseline
+    /// recalculation window (<c>DriftDetectionConfig.BaselineWindowDays</c>, default 7) fits
+    /// comfortably inside it.
+    /// </summary>
+    public const int MaxHistoryWindowDays = 90;
+
+    /// <summary>
+    /// Hard cap on audit records returned by a single audits query. The JSONL audit store is
+    /// append-only and unbounded over time; the cap keeps a single read from streaming the
+    /// whole trail over the wire.
+    /// </summary>
+    public const int MaxAuditResults = 1000;
+
+    /// <summary>
+    /// Default number of audit records returned when the caller does not specify a limit.
+    /// </summary>
+    public const int DefaultAuditResults = 500;
+}

--- a/src/Content/Application/Application.Core/CQRS/DriftDetection/GetDriftAuditsQuery.cs
+++ b/src/Content/Application/Application.Core/CQRS/DriftDetection/GetDriftAuditsQuery.cs
@@ -1,0 +1,33 @@
+using Domain.AI.DriftDetection;
+using Domain.Common;
+using MediatR;
+
+namespace Application.Core.CQRS.DriftDetection;
+
+/// <summary>
+/// Retrieves drift audit records — the append-only, hash-chained trail of detections,
+/// resolutions, baseline updates, escalation triggers, and operator actions (evaluation pushes
+/// and recalculation requests with their caller identities). All filters are optional; results
+/// are capped at <see cref="MaxResults"/> most-recent records.
+/// </summary>
+public sealed record GetDriftAuditsQuery : IRequest<Result<IReadOnlyList<DriftAuditRecord>>>
+{
+    /// <summary>Start of the query window (inclusive). Null leaves the window open on the left.</summary>
+    public DateTimeOffset? Start { get; init; }
+
+    /// <summary>End of the query window (inclusive). Null leaves the window open on the right.</summary>
+    public DateTimeOffset? End { get; init; }
+
+    /// <summary>Filter by audit record type.</summary>
+    public DriftAuditRecordType? RecordType { get; init; }
+
+    /// <summary>Filter by originating drift event ID.</summary>
+    public Guid? EventId { get; init; }
+
+    /// <summary>
+    /// Maximum number of records to return, between 1 and
+    /// <see cref="DriftValidationRules.MaxAuditResults"/>. When more records match, the
+    /// most recent ones are returned (still in chronological order).
+    /// </summary>
+    public int MaxResults { get; init; } = DriftValidationRules.DefaultAuditResults;
+}

--- a/src/Content/Application/Application.Core/CQRS/DriftDetection/GetDriftAuditsQueryHandler.cs
+++ b/src/Content/Application/Application.Core/CQRS/DriftDetection/GetDriftAuditsQueryHandler.cs
@@ -1,0 +1,59 @@
+using Application.AI.Common.Interfaces.DriftDetection;
+using Domain.AI.DriftDetection;
+using Domain.Common;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace Application.Core.CQRS.DriftDetection;
+
+/// <summary>
+/// Reads audit records from <see cref="IDriftAuditStore.GetRecordsAsync"/> and applies the
+/// query's result cap. The store returns records in chronological order; when the match set
+/// exceeds the cap, the tail (most recent records) is kept — for an operational audit surface
+/// the newest activity is the interesting end.
+/// </summary>
+public sealed class GetDriftAuditsQueryHandler
+    : IRequestHandler<GetDriftAuditsQuery, Result<IReadOnlyList<DriftAuditRecord>>>
+{
+    private readonly IDriftAuditStore _auditStore;
+    private readonly ILogger<GetDriftAuditsQueryHandler> _logger;
+
+    /// <summary>Initializes a new instance of the <see cref="GetDriftAuditsQueryHandler"/> class.</summary>
+    /// <param name="auditStore">The append-only drift audit store.</param>
+    /// <param name="logger">Logger for read statistics.</param>
+    public GetDriftAuditsQueryHandler(
+        IDriftAuditStore auditStore,
+        ILogger<GetDriftAuditsQueryHandler> logger)
+    {
+        _auditStore = auditStore;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<Result<IReadOnlyList<DriftAuditRecord>>> Handle(
+        GetDriftAuditsQuery request, CancellationToken cancellationToken)
+    {
+        var result = await _auditStore.GetRecordsAsync(new DriftAuditQuery
+        {
+            Start = request.Start,
+            End = request.End,
+            RecordType = request.RecordType,
+            EventId = request.EventId
+        }, cancellationToken);
+
+        if (!result.IsSuccess)
+            return result;
+
+        var records = result.Value!;
+        if (records.Count <= request.MaxResults)
+            return result;
+
+        _logger.LogDebug(
+            "Drift audit query matched {Matched} records; returning the most recent {Cap}",
+            records.Count, request.MaxResults);
+
+        IReadOnlyList<DriftAuditRecord> capped =
+            records.Skip(records.Count - request.MaxResults).ToList();
+        return Result<IReadOnlyList<DriftAuditRecord>>.Success(capped);
+    }
+}

--- a/src/Content/Application/Application.Core/CQRS/DriftDetection/GetDriftAuditsQueryValidator.cs
+++ b/src/Content/Application/Application.Core/CQRS/DriftDetection/GetDriftAuditsQueryValidator.cs
@@ -1,0 +1,28 @@
+using Domain.AI.DriftDetection;
+using FluentValidation;
+
+namespace Application.Core.CQRS.DriftDetection;
+
+/// <summary>
+/// Validates <see cref="GetDriftAuditsQuery"/>: an ordered window when both ends are supplied,
+/// a defined record-type filter, and a bounded result cap.
+/// </summary>
+public sealed class GetDriftAuditsQueryValidator : AbstractValidator<GetDriftAuditsQuery>
+{
+    /// <summary>Initializes validation rules.</summary>
+    public GetDriftAuditsQueryValidator()
+    {
+        RuleFor(x => x.Start)
+            .LessThan(x => x.End)
+            .When(x => x.Start.HasValue && x.End.HasValue)
+            .WithMessage("Start must be before End.");
+
+        RuleFor(x => x.RecordType)
+            .Must(recordType => recordType is null || Enum.IsDefined(recordType.Value))
+            .WithMessage("RecordType must be a defined DriftAuditRecordType value.");
+
+        RuleFor(x => x.MaxResults)
+            .InclusiveBetween(1, DriftValidationRules.MaxAuditResults)
+            .WithMessage($"MaxResults must be between 1 and {DriftValidationRules.MaxAuditResults}.");
+    }
+}

--- a/src/Content/Application/Application.Core/CQRS/DriftDetection/GetDriftBaselinesQuery.cs
+++ b/src/Content/Application/Application.Core/CQRS/DriftDetection/GetDriftBaselinesQuery.cs
@@ -1,0 +1,16 @@
+using Domain.AI.DriftDetection;
+using Domain.Common;
+using MediatR;
+
+namespace Application.Core.CQRS.DriftDetection;
+
+/// <summary>
+/// Lists the active drift baselines, optionally filtered to one scope level. Baselines are
+/// operational quality snapshots with no per-caller visibility rules, so the read is gated by
+/// role alone (<c>Harness.Drift.Read</c>) at the HTTP surface.
+/// </summary>
+public sealed record GetDriftBaselinesQuery : IRequest<Result<IReadOnlyList<DriftBaseline>>>
+{
+    /// <summary>Optional scope filter. Null returns baselines across all scope levels.</summary>
+    public DriftScope? Scope { get; init; }
+}

--- a/src/Content/Application/Application.Core/CQRS/DriftDetection/GetDriftBaselinesQueryHandler.cs
+++ b/src/Content/Application/Application.Core/CQRS/DriftDetection/GetDriftBaselinesQueryHandler.cs
@@ -1,0 +1,45 @@
+using Application.AI.Common.Interfaces.DriftDetection;
+using Domain.AI.DriftDetection;
+using Domain.Common;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace Application.Core.CQRS.DriftDetection;
+
+/// <summary>
+/// Reads baselines straight from <see cref="IDriftBaselineStore.GetBaselinesAsync"/>. The domain
+/// <see cref="DriftBaseline"/> record is wire-safe (means, sigmas, window metadata — no internal
+/// state), so no projection layer is needed.
+/// </summary>
+public sealed class GetDriftBaselinesQueryHandler
+    : IRequestHandler<GetDriftBaselinesQuery, Result<IReadOnlyList<DriftBaseline>>>
+{
+    private readonly IDriftBaselineStore _baselineStore;
+    private readonly ILogger<GetDriftBaselinesQueryHandler> _logger;
+
+    /// <summary>Initializes a new instance of the <see cref="GetDriftBaselinesQueryHandler"/> class.</summary>
+    /// <param name="baselineStore">The baseline persistence store.</param>
+    /// <param name="logger">Logger for list statistics.</param>
+    public GetDriftBaselinesQueryHandler(
+        IDriftBaselineStore baselineStore,
+        ILogger<GetDriftBaselinesQueryHandler> logger)
+    {
+        _baselineStore = baselineStore;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<Result<IReadOnlyList<DriftBaseline>>> Handle(
+        GetDriftBaselinesQuery request, CancellationToken cancellationToken)
+    {
+        var result = await _baselineStore.GetBaselinesAsync(request.Scope, cancellationToken);
+        if (result.IsSuccess)
+        {
+            _logger.LogDebug(
+                "Drift baseline list (scope filter {Scope}): {Count} items",
+                request.Scope, result.Value!.Count);
+        }
+
+        return result;
+    }
+}

--- a/src/Content/Application/Application.Core/CQRS/DriftDetection/GetDriftBaselinesQueryValidator.cs
+++ b/src/Content/Application/Application.Core/CQRS/DriftDetection/GetDriftBaselinesQueryValidator.cs
@@ -1,0 +1,19 @@
+using Domain.AI.DriftDetection;
+using FluentValidation;
+
+namespace Application.Core.CQRS.DriftDetection;
+
+/// <summary>
+/// Validates <see cref="GetDriftBaselinesQuery"/>: the optional scope filter, when present,
+/// must be a defined <see cref="DriftScope"/> member (model binding accepts any integer).
+/// </summary>
+public sealed class GetDriftBaselinesQueryValidator : AbstractValidator<GetDriftBaselinesQuery>
+{
+    /// <summary>Initializes validation rules.</summary>
+    public GetDriftBaselinesQueryValidator()
+    {
+        RuleFor(x => x.Scope)
+            .Must(scope => scope is null || Enum.IsDefined(scope.Value))
+            .WithMessage("Scope must be a defined DriftScope value.");
+    }
+}

--- a/src/Content/Application/Application.Core/CQRS/DriftDetection/GetDriftHistoryQuery.cs
+++ b/src/Content/Application/Application.Core/CQRS/DriftDetection/GetDriftHistoryQuery.cs
@@ -1,0 +1,26 @@
+using Domain.AI.DriftDetection;
+using Domain.Common;
+using MediatR;
+
+namespace Application.Core.CQRS.DriftDetection;
+
+/// <summary>
+/// Retrieves the persisted drift scores for one scope within a bounded time window — every
+/// evaluation (healthy and drifted) the subsystem recorded, in the shape baseline
+/// recalculation consumes.
+/// </summary>
+public sealed record GetDriftHistoryQuery : IRequest<Result<IReadOnlyList<DriftScore>>>
+{
+    /// <summary>The hierarchy level to query.</summary>
+    public required DriftScope Scope { get; init; }
+
+    /// <summary>Identifies the entity within the scope (agent ID, skill name, or task type).</summary>
+    public required string ScopeIdentifier { get; init; }
+
+    /// <summary>Start of the query window (inclusive).</summary>
+    public required DateTimeOffset Start { get; init; }
+
+    /// <summary>End of the query window (inclusive). The window is capped at
+    /// <see cref="DriftValidationRules.MaxHistoryWindowDays"/> days.</summary>
+    public required DateTimeOffset End { get; init; }
+}

--- a/src/Content/Application/Application.Core/CQRS/DriftDetection/GetDriftHistoryQuery.cs
+++ b/src/Content/Application/Application.Core/CQRS/DriftDetection/GetDriftHistoryQuery.cs
@@ -11,8 +11,13 @@ namespace Application.Core.CQRS.DriftDetection;
 /// </summary>
 public sealed record GetDriftHistoryQuery : IRequest<Result<IReadOnlyList<DriftScore>>>
 {
-    /// <summary>The hierarchy level to query.</summary>
-    public required DriftScope Scope { get; init; }
+    /// <summary>
+    /// The hierarchy level to query. Required — but modelled as nullable so an omitted query
+    /// parameter arrives as null and is rejected, rather than silently binding
+    /// <see cref="DriftScope.Agent"/> (the enum's zero value) and answering confidently for a
+    /// scope the caller never asked about.
+    /// </summary>
+    public DriftScope? Scope { get; init; }
 
     /// <summary>Identifies the entity within the scope (agent ID, skill name, or task type).</summary>
     public required string ScopeIdentifier { get; init; }

--- a/src/Content/Application/Application.Core/CQRS/DriftDetection/GetDriftHistoryQueryHandler.cs
+++ b/src/Content/Application/Application.Core/CQRS/DriftDetection/GetDriftHistoryQueryHandler.cs
@@ -1,0 +1,52 @@
+using Application.AI.Common.Interfaces.DriftDetection;
+using Domain.AI.DriftDetection;
+using Domain.Common;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace Application.Core.CQRS.DriftDetection;
+
+/// <summary>
+/// Delegates to <see cref="IDriftDetectionService.GetDriftHistoryAsync"/> — the same read path
+/// baseline recalculation uses — so the HTTP surface reports exactly the history the subsystem
+/// itself would compute from.
+/// </summary>
+public sealed class GetDriftHistoryQueryHandler
+    : IRequestHandler<GetDriftHistoryQuery, Result<IReadOnlyList<DriftScore>>>
+{
+    private readonly IDriftDetectionService _driftService;
+    private readonly ILogger<GetDriftHistoryQueryHandler> _logger;
+
+    /// <summary>Initializes a new instance of the <see cref="GetDriftHistoryQueryHandler"/> class.</summary>
+    /// <param name="driftService">The drift detection service that owns history reads.</param>
+    /// <param name="logger">Logger for read statistics.</param>
+    public GetDriftHistoryQueryHandler(
+        IDriftDetectionService driftService,
+        ILogger<GetDriftHistoryQueryHandler> logger)
+    {
+        _driftService = driftService;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<Result<IReadOnlyList<DriftScore>>> Handle(
+        GetDriftHistoryQuery request, CancellationToken cancellationToken)
+    {
+        var result = await _driftService.GetDriftHistoryAsync(new DriftHistoryQuery
+        {
+            Scope = request.Scope,
+            ScopeIdentifier = request.ScopeIdentifier,
+            Start = request.Start,
+            End = request.End
+        }, cancellationToken);
+
+        if (result.IsSuccess)
+        {
+            _logger.LogDebug(
+                "Drift history for {Scope}:{ScopeIdentifier} [{Start:o}..{End:o}]: {Count} scores",
+                request.Scope, request.ScopeIdentifier, request.Start, request.End, result.Value!.Count);
+        }
+
+        return result;
+    }
+}

--- a/src/Content/Application/Application.Core/CQRS/DriftDetection/GetDriftHistoryQueryHandler.cs
+++ b/src/Content/Application/Application.Core/CQRS/DriftDetection/GetDriftHistoryQueryHandler.cs
@@ -32,9 +32,10 @@ public sealed class GetDriftHistoryQueryHandler
     public async Task<Result<IReadOnlyList<DriftScore>>> Handle(
         GetDriftHistoryQuery request, CancellationToken cancellationToken)
     {
+        // Non-null past validation, which rejects a missing scope outright.
         var result = await _driftService.GetDriftHistoryAsync(new DriftHistoryQuery
         {
-            Scope = request.Scope,
+            Scope = request.Scope!.Value,
             ScopeIdentifier = request.ScopeIdentifier,
             Start = request.Start,
             End = request.End

--- a/src/Content/Application/Application.Core/CQRS/DriftDetection/GetDriftHistoryQueryValidator.cs
+++ b/src/Content/Application/Application.Core/CQRS/DriftDetection/GetDriftHistoryQueryValidator.cs
@@ -13,9 +13,13 @@ public sealed class GetDriftHistoryQueryValidator : AbstractValidator<GetDriftHi
     /// <summary>Initializes validation rules.</summary>
     public GetDriftHistoryQueryValidator()
     {
+        // A history read is always scoped, so an omitted scope is a bad request — never a
+        // default. Binding a missing value to DriftScope.Agent (enum zero) would return real
+        // Agent-scope data with a 200 to a caller who believes they asked for something else.
         RuleFor(x => x.Scope)
-            .Must(scope => Enum.IsDefined(scope))
-            .WithMessage("Scope must be a defined DriftScope value.");
+            .NotNull().WithMessage("Scope is required.")
+            .Must(scope => scope is null || Enum.IsDefined(scope.Value))
+                .WithMessage("Scope must be a defined DriftScope value.");
 
         RuleFor(x => x.ScopeIdentifier)
             .NotEmpty().WithMessage("ScopeIdentifier must not be empty.")

--- a/src/Content/Application/Application.Core/CQRS/DriftDetection/GetDriftHistoryQueryValidator.cs
+++ b/src/Content/Application/Application.Core/CQRS/DriftDetection/GetDriftHistoryQueryValidator.cs
@@ -1,0 +1,34 @@
+using Domain.AI.DriftDetection;
+using FluentValidation;
+
+namespace Application.Core.CQRS.DriftDetection;
+
+/// <summary>
+/// Validates <see cref="GetDriftHistoryQuery"/>: a defined scope, a bounded scope identifier,
+/// and an ordered time window no longer than
+/// <see cref="DriftValidationRules.MaxHistoryWindowDays"/> days.
+/// </summary>
+public sealed class GetDriftHistoryQueryValidator : AbstractValidator<GetDriftHistoryQuery>
+{
+    /// <summary>Initializes validation rules.</summary>
+    public GetDriftHistoryQueryValidator()
+    {
+        RuleFor(x => x.Scope)
+            .Must(scope => Enum.IsDefined(scope))
+            .WithMessage("Scope must be a defined DriftScope value.");
+
+        RuleFor(x => x.ScopeIdentifier)
+            .NotEmpty().WithMessage("ScopeIdentifier must not be empty.")
+            .MaximumLength(DriftValidationRules.MaxScopeIdentifierLength)
+                .WithMessage($"ScopeIdentifier must not exceed {DriftValidationRules.MaxScopeIdentifierLength} characters.");
+
+        RuleFor(x => x.Start)
+            .LessThan(x => x.End).WithMessage("Start must be before End.");
+
+        RuleFor(x => x)
+            .Must(x => (x.End - x.Start) <= TimeSpan.FromDays(DriftValidationRules.MaxHistoryWindowDays))
+            .WithMessage($"The query window must not exceed {DriftValidationRules.MaxHistoryWindowDays} days.")
+            .When(x => x.Start < x.End)
+            .OverridePropertyName(nameof(GetDriftHistoryQuery.End));
+    }
+}

--- a/src/Content/Application/Application.Core/CQRS/DriftDetection/PushDriftEvaluationCommand.cs
+++ b/src/Content/Application/Application.Core/CQRS/DriftDetection/PushDriftEvaluationCommand.cs
@@ -1,0 +1,44 @@
+using Domain.AI.DriftDetection;
+using Domain.Common;
+using MediatR;
+
+namespace Application.Core.CQRS.DriftDetection;
+
+/// <summary>
+/// Pushes one set of dimension scores into the drift subsystem: the scores are compared against
+/// the active baseline, EWMA state advances, the evaluation is persisted to history, and —
+/// above threshold — notifications and escalations fire. Returns the resulting
+/// <see cref="DriftScore"/>.
+/// </summary>
+/// <remarks>
+/// This is a history-poisoning vector: pushed scores feed the EWMA smoothing and the rolling
+/// window future baselines are recalculated from, so a hostile caller could mask real drift or
+/// fabricate it. The HTTP surface therefore gates this command behind the
+/// <c>Harness.Drift.Operate</c> role, and the handler records every push (including failed
+/// ones) in the drift audit trail with the token-derived caller identity.
+/// </remarks>
+public sealed record PushDriftEvaluationCommand : IRequest<Result<DriftScore>>
+{
+    /// <summary>The hierarchy level of the evaluation.</summary>
+    public required DriftScope Scope { get; init; }
+
+    /// <summary>Identifies the entity within the scope (agent ID, skill name, or task type).</summary>
+    public required string ScopeIdentifier { get; init; }
+
+    /// <summary>
+    /// Dimension scores to evaluate against the baseline. Each value must be a finite quality
+    /// score in [0, 1].
+    /// </summary>
+    public required IReadOnlyDictionary<DriftDimension, double> Dimensions { get; init; }
+
+    /// <summary>
+    /// The pushing caller's identity, recorded in the audit trail.
+    /// </summary>
+    /// <remarks>
+    /// <b>Populated exclusively by the controller from the authenticated principal's token
+    /// claims</b> (the claim type configured by <c>DriftDetectionConfig.CallerIdentityClaimType</c>).
+    /// It must never be bound from a request body, query string, or header — no wire DTO
+    /// carries a caller-id field by design, so a caller cannot attribute a push to someone else.
+    /// </remarks>
+    public required string CallerId { get; init; }
+}

--- a/src/Content/Application/Application.Core/CQRS/DriftDetection/PushDriftEvaluationCommandHandler.cs
+++ b/src/Content/Application/Application.Core/CQRS/DriftDetection/PushDriftEvaluationCommandHandler.cs
@@ -1,0 +1,154 @@
+using Application.AI.Common.Interfaces.DriftDetection;
+using Domain.AI.DriftDetection;
+using Domain.Common;
+using Domain.Common.Config;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Application.Core.CQRS.DriftDetection;
+
+/// <summary>
+/// Runs the pushed scores through <see cref="IDriftDetectionService.EvaluateDriftAsync"/> — the
+/// exact pipeline internal callers use (baseline fallback, EWMA scoring, severity
+/// classification, graph persistence, notification, escalation) — bracketed by
+/// <see cref="DriftAuditRecordType.EvaluationPushed"/> audit records carrying the caller
+/// identity, so every externally-sourced data point that moved EWMA state is attributable.
+/// </summary>
+/// <remarks>
+/// The fail-closed attempt record is appended <em>before</em> dispatch: a push that cannot be
+/// durably attributed is refused rather than allowed through unattributed. See
+/// <see cref="DriftOperatorAuditRecorder"/> for why the ordering, not just the posture, is what
+/// makes the audit trail a real compensating control.
+/// </remarks>
+public sealed class PushDriftEvaluationCommandHandler
+    : IRequestHandler<PushDriftEvaluationCommand, Result<DriftScore>>
+{
+    private readonly IDriftDetectionService _driftService;
+    private readonly IDriftAuditStore _auditStore;
+    private readonly IOptionsMonitor<AppConfig> _config;
+    private readonly TimeProvider _timeProvider;
+    private readonly ILogger<PushDriftEvaluationCommandHandler> _logger;
+
+    /// <summary>Initializes a new instance of the <see cref="PushDriftEvaluationCommandHandler"/> class.</summary>
+    /// <param name="driftService">The drift detection service that owns the evaluation pipeline.</param>
+    /// <param name="auditStore">The append-only drift audit store the caller identity is recorded in.</param>
+    /// <param name="config">Application configuration; supplies the drift subsystem's master toggle.</param>
+    /// <param name="timeProvider">Time provider for audit timestamps.</param>
+    /// <param name="logger">Logger for push diagnostics.</param>
+    public PushDriftEvaluationCommandHandler(
+        IDriftDetectionService driftService,
+        IDriftAuditStore auditStore,
+        IOptionsMonitor<AppConfig> config,
+        TimeProvider timeProvider,
+        ILogger<PushDriftEvaluationCommandHandler> logger)
+    {
+        _driftService = driftService;
+        _auditStore = auditStore;
+        _config = config;
+        _timeProvider = timeProvider;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<Result<DriftScore>> Handle(
+        PushDriftEvaluationCommand request, CancellationToken cancellationToken)
+    {
+        var actionId = Guid.NewGuid();
+        var now = _timeProvider.GetUtcNow();
+
+        var attempt = await DriftOperatorAuditRecorder.RecordAttemptAsync(
+            _auditStore,
+            DriftAuditRecordType.EvaluationPushed,
+            BuildAudit(request, actionId, DriftOperatorActionPhase.Attempt),
+            now,
+            _logger,
+            cancellationToken);
+
+        if (!attempt.IsSuccess)
+        {
+            // Fail-closed: without a durable attempt record this push would advance EWMA state
+            // and feed future baselines with nothing in the trail naming who caused it.
+            return Result<DriftScore>.Conflict(
+                "Drift audit trail is unavailable; evaluation pushes are refused while pushes cannot be attributed.");
+        }
+
+        var result = await EvaluateAsync(request, cancellationToken);
+
+        await DriftOperatorAuditRecorder.RecordOutcomeAsync(
+            _auditStore,
+            DriftAuditRecordType.EvaluationPushed,
+            BuildAudit(request, actionId, DriftOperatorActionPhase.Outcome) with
+            {
+                Succeeded = result.IsSuccess,
+                CorrelationId = result.IsSuccess ? result.Value!.ScoreId : null,
+                FailureCode = result.IsSuccess
+                    ? null
+                    : DriftOperatorActionAudit.FailureCodeFor(result.FailureType)
+            },
+            eventId: result.IsSuccess ? result.Value!.ScoreId : actionId,
+            recordedAt: _timeProvider.GetUtcNow(),
+            _logger,
+            cancellationToken);
+
+        if (result.IsSuccess)
+        {
+            _logger.LogInformation(
+                "Evaluation pushed by {CallerId} for {Scope}:{ScopeIdentifier} (action {ActionId}): severity {Severity}, overall {OverallDrift:F2}σ",
+                request.CallerId, request.Scope, request.ScopeIdentifier, actionId,
+                result.Value!.Severity, result.Value.OverallDrift);
+        }
+        else
+        {
+            _logger.LogWarning(
+                "Evaluation push by {CallerId} for {Scope}:{ScopeIdentifier} (action {ActionId}) failed ({FailureType})",
+                request.CallerId, request.Scope, request.ScopeIdentifier, actionId, result.FailureType);
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Dispatches to the drift pipeline, but only while the subsystem is enabled.
+    /// </summary>
+    /// <remarks>
+    /// The service's disabled arm deliberately returns a no-op <c>Success</c> with an all-zero,
+    /// never-persisted score (ConsoleUI's walkthrough relies on that), which through an HTTP
+    /// surface would be a lie: 200 plus an audit record claiming a successful push whose
+    /// CorrelationId points at a score no store ever held. Flipping one config value would then
+    /// silently stop monitoring while the API and the trail both kept reporting success — the
+    /// threat model's "mask real drift" outcome reached through configuration instead of data.
+    /// The push therefore refuses with the same <c>Conflict</c> posture
+    /// <c>UpdateBaselineAsync</c> already uses for the identical condition, and the caller sees
+    /// the 409 the controller documents.
+    /// </remarks>
+    private async Task<Result<DriftScore>> EvaluateAsync(
+        PushDriftEvaluationCommand request, CancellationToken cancellationToken)
+    {
+        if (!_config.CurrentValue.AI.DriftDetection.Enabled)
+        {
+            _logger.LogWarning(
+                "Evaluation push by {CallerId} for {Scope}:{ScopeIdentifier} refused: drift detection is disabled",
+                request.CallerId, request.Scope, request.ScopeIdentifier);
+            return Result<DriftScore>.Conflict("Drift detection is disabled");
+        }
+
+        return await _driftService.EvaluateDriftAsync(new DriftEvaluationRequest
+        {
+            Scope = request.Scope,
+            ScopeIdentifier = request.ScopeIdentifier,
+            Dimensions = request.Dimensions
+        }, cancellationToken);
+    }
+
+    private static DriftOperatorActionAudit BuildAudit(
+        PushDriftEvaluationCommand request, Guid actionId, DriftOperatorActionPhase phase) => new()
+        {
+            ActionId = actionId,
+            Phase = phase,
+            CallerId = request.CallerId,
+            Action = DriftOperatorActionAudit.EvaluationPushAction,
+            Scope = request.Scope,
+            ScopeIdentifier = request.ScopeIdentifier
+        };
+}

--- a/src/Content/Application/Application.Core/CQRS/DriftDetection/PushDriftEvaluationCommandValidator.cs
+++ b/src/Content/Application/Application.Core/CQRS/DriftDetection/PushDriftEvaluationCommandValidator.cs
@@ -1,0 +1,43 @@
+using Domain.AI.DriftDetection;
+using FluentValidation;
+
+namespace Application.Core.CQRS.DriftDetection;
+
+/// <summary>
+/// Validates <see cref="PushDriftEvaluationCommand"/>. The score-range rules are the poison
+/// guard: pushed values feed EWMA state and future baselines, so out-of-range or non-finite
+/// values (NaN, ±Infinity) — which would silently corrupt every downstream mean and sigma —
+/// are rejected at the boundary.
+/// </summary>
+public sealed class PushDriftEvaluationCommandValidator
+    : AbstractValidator<PushDriftEvaluationCommand>
+{
+    /// <summary>Initializes validation rules.</summary>
+    public PushDriftEvaluationCommandValidator()
+    {
+        RuleFor(x => x.Scope)
+            .Must(scope => Enum.IsDefined(scope))
+            .WithMessage("Scope must be a defined DriftScope value.");
+
+        RuleFor(x => x.ScopeIdentifier)
+            .NotEmpty().WithMessage("ScopeIdentifier must not be empty.")
+            .MaximumLength(DriftValidationRules.MaxScopeIdentifierLength)
+                .WithMessage($"ScopeIdentifier must not exceed {DriftValidationRules.MaxScopeIdentifierLength} characters.");
+
+        RuleFor(x => x.CallerId)
+            .NotEmpty().WithMessage("CallerId must not be empty.")
+            .MaximumLength(DriftValidationRules.MaxCallerIdLength)
+                .WithMessage($"CallerId must not exceed {DriftValidationRules.MaxCallerIdLength} characters.");
+
+        RuleFor(x => x.Dimensions)
+            .NotEmpty().WithMessage("At least one dimension must be provided.")
+            .Must(dimensions => dimensions is null || dimensions.Count <= DriftValidationRules.MaxDimensionsPerEvaluation)
+                .WithMessage($"At most {DriftValidationRules.MaxDimensionsPerEvaluation} dimensions may be provided.");
+
+        RuleForEach(x => x.Dimensions)
+            .Must(entry => Enum.IsDefined(entry.Key))
+                .WithMessage("Every dimension key must be a defined DriftDimension value.")
+            .Must(entry => double.IsFinite(entry.Value) && entry.Value is >= 0.0 and <= 1.0)
+                .WithMessage("Every dimension score must be a finite value in [0, 1].");
+    }
+}

--- a/src/Content/Application/Application.Core/CQRS/DriftDetection/RecalculateDriftBaselineCommand.cs
+++ b/src/Content/Application/Application.Core/CQRS/DriftDetection/RecalculateDriftBaselineCommand.cs
@@ -1,0 +1,33 @@
+using Domain.AI.DriftDetection;
+using Domain.Common;
+using MediatR;
+
+namespace Application.Core.CQRS.DriftDetection;
+
+/// <summary>
+/// Recalculates the baseline identified by <see cref="BaselineId"/> from its scope's recent
+/// evaluation history (the subsystem's configured rolling window), replacing the current
+/// snapshot. Returns the new <see cref="DriftBaseline"/>.
+/// </summary>
+/// <remarks>
+/// Recalculating a baseline re-anchors what "normal" means for the scope — a hostile
+/// recalculation after a run of poisoned evaluations would normalize the poison. The HTTP
+/// surface gates this behind the <c>Harness.Drift.Operate</c> role and the handler records
+/// every request (including unknown-id and insufficient-history failures) in the audit trail
+/// with the token-derived caller identity.
+/// </remarks>
+public sealed record RecalculateDriftBaselineCommand : IRequest<Result<DriftBaseline>>
+{
+    /// <summary>The id of the baseline snapshot to recalculate. Unknown ids yield a not-found failure.</summary>
+    public required Guid BaselineId { get; init; }
+
+    /// <summary>
+    /// The requesting caller's identity, recorded in the audit trail.
+    /// </summary>
+    /// <remarks>
+    /// <b>Populated exclusively by the controller from the authenticated principal's token
+    /// claims</b> (the claim type configured by <c>DriftDetectionConfig.CallerIdentityClaimType</c>).
+    /// It must never be bound from a request body, query string, or header.
+    /// </remarks>
+    public required string CallerId { get; init; }
+}

--- a/src/Content/Application/Application.Core/CQRS/DriftDetection/RecalculateDriftBaselineCommandHandler.cs
+++ b/src/Content/Application/Application.Core/CQRS/DriftDetection/RecalculateDriftBaselineCommandHandler.cs
@@ -130,9 +130,15 @@ public sealed class RecalculateDriftBaselineCommandHandler
             Succeeded = succeeded,
             CorrelationId = newBaseline?.BaselineId,
             FailureCode = succeeded ? null : DriftOperatorActionAudit.FailureCodeFor(failureType),
-            // The replaced snapshot's id, and the evidence of what the new one was built from.
-            // All four come from objects already in hand — no extra store round-trip.
-            PreviousBaselineId = target?.BaselineId,
+            // Always the id the caller asked for — which on success IS the replaced snapshot's
+            // id (the lookup resolves by it), and on failure is the id that was probed. Taking
+            // it from the resolved target instead would blank this field on a not-found, so an
+            // attacker sweeping ids to discover which baselines exist would leave outcome
+            // records naming no id at all, reconstructible only by joining back to the attempt
+            // record on ActionId. Enumeration is exactly when the id matters most, so each
+            // record stands on its own. The remaining three fields describe what the new
+            // baseline was built from; all come from objects already in hand.
+            PreviousBaselineId = request.BaselineId,
             SampleCount = newBaseline?.SampleCount,
             WindowStart = newBaseline?.WindowStart,
             WindowEnd = newBaseline?.WindowEnd

--- a/src/Content/Application/Application.Core/CQRS/DriftDetection/RecalculateDriftBaselineCommandHandler.cs
+++ b/src/Content/Application/Application.Core/CQRS/DriftDetection/RecalculateDriftBaselineCommandHandler.cs
@@ -1,0 +1,162 @@
+using Application.AI.Common.Interfaces.DriftDetection;
+using Domain.AI.DriftDetection;
+using Domain.Common;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace Application.Core.CQRS.DriftDetection;
+
+/// <summary>
+/// Resolves the target baseline by id, then delegates to
+/// <see cref="IDriftDetectionService.UpdateBaselineAsync"/> — the same recalculation path the
+/// learnings-drift bridge uses — bracketed by
+/// <see cref="DriftAuditRecordType.BaselineRecalculationRequested"/> audit records. The service
+/// additionally audits the successful recalculation as
+/// <see cref="DriftAuditRecordType.BaselineUpdated"/> with the new baseline serialized.
+/// </summary>
+/// <remarks>
+/// The outcome record captures what the recalculation <em>changed</em> — the replaced
+/// baseline's id plus the sample count and window the new one consumed. Recalculation overwrites
+/// the previous snapshot, so without those fields an operator could push poisoned evaluations,
+/// recalculate to launder them into the new "normal", and leave a trail proving only <em>that</em>
+/// they recalculated, never what it did.
+/// </remarks>
+public sealed class RecalculateDriftBaselineCommandHandler
+    : IRequestHandler<RecalculateDriftBaselineCommand, Result<DriftBaseline>>
+{
+    private readonly IDriftDetectionService _driftService;
+    private readonly IDriftBaselineStore _baselineStore;
+    private readonly IDriftAuditStore _auditStore;
+    private readonly TimeProvider _timeProvider;
+    private readonly ILogger<RecalculateDriftBaselineCommandHandler> _logger;
+
+    /// <summary>Initializes a new instance of the <see cref="RecalculateDriftBaselineCommandHandler"/> class.</summary>
+    /// <param name="driftService">The drift detection service that owns baseline recalculation.</param>
+    /// <param name="baselineStore">The baseline store used to resolve the id to a scope.</param>
+    /// <param name="auditStore">The append-only drift audit store the caller identity is recorded in.</param>
+    /// <param name="timeProvider">Time provider for audit timestamps.</param>
+    /// <param name="logger">Logger for recalculation diagnostics.</param>
+    public RecalculateDriftBaselineCommandHandler(
+        IDriftDetectionService driftService,
+        IDriftBaselineStore baselineStore,
+        IDriftAuditStore auditStore,
+        TimeProvider timeProvider,
+        ILogger<RecalculateDriftBaselineCommandHandler> logger)
+    {
+        _driftService = driftService;
+        _baselineStore = baselineStore;
+        _auditStore = auditStore;
+        _timeProvider = timeProvider;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<Result<DriftBaseline>> Handle(
+        RecalculateDriftBaselineCommand request, CancellationToken cancellationToken)
+    {
+        var actionId = Guid.NewGuid();
+
+        var attempt = await DriftOperatorAuditRecorder.RecordAttemptAsync(
+            _auditStore,
+            DriftAuditRecordType.BaselineRecalculationRequested,
+            BuildAudit(request, actionId, DriftOperatorActionPhase.Attempt),
+            _timeProvider.GetUtcNow(),
+            _logger,
+            cancellationToken);
+
+        if (!attempt.IsSuccess)
+        {
+            // Fail-closed: recalculation re-anchors what "normal" means and destroys the
+            // previous snapshot. It must not run while that cannot be attributed.
+            return Result<DriftBaseline>.Conflict(
+                "Drift audit trail is unavailable; baseline recalculation is refused while changes cannot be attributed.");
+        }
+
+        var lookup = await _baselineStore.GetBaselineByIdAsync(request.BaselineId, cancellationToken);
+        if (!lookup.IsSuccess)
+        {
+            await RecordOutcomeAsync(request, actionId, target: null, outcome: null,
+                ResultFailureType.General, cancellationToken);
+            return Result<DriftBaseline>.Fail([.. lookup.Errors]);
+        }
+
+        if (lookup.Value is not { } target)
+        {
+            await RecordOutcomeAsync(request, actionId, target: null, outcome: null,
+                ResultFailureType.NotFound, cancellationToken);
+            return Result<DriftBaseline>.NotFound("No baseline with the given id.");
+        }
+
+        var result = await _driftService.UpdateBaselineAsync(new DriftBaselineUpdateRequest
+        {
+            Scope = target.Scope,
+            ScopeIdentifier = target.ScopeIdentifier
+        }, cancellationToken);
+
+        await RecordOutcomeAsync(request, actionId, target, result, result.FailureType, cancellationToken);
+
+        if (result.IsSuccess)
+        {
+            _logger.LogInformation(
+                "Baseline {PreviousBaselineId} ({Scope}:{ScopeIdentifier}) recalculated by {CallerId} (action {ActionId}); new baseline {NewBaselineId} from {SampleCount} samples",
+                request.BaselineId, target.Scope, target.ScopeIdentifier, request.CallerId, actionId,
+                result.Value!.BaselineId, result.Value.SampleCount);
+        }
+        else
+        {
+            _logger.LogWarning(
+                "Baseline recalculation for {BaselineId} requested by {CallerId} (action {ActionId}) failed ({FailureType})",
+                request.BaselineId, request.CallerId, actionId, result.FailureType);
+        }
+
+        return result;
+    }
+
+    private Task RecordOutcomeAsync(
+        RecalculateDriftBaselineCommand request,
+        Guid actionId,
+        DriftBaseline? target,
+        Result<DriftBaseline>? outcome,
+        ResultFailureType failureType,
+        CancellationToken ct)
+    {
+        var succeeded = outcome?.IsSuccess ?? false;
+        var newBaseline = succeeded ? outcome!.Value! : null;
+
+        var audit = BuildAudit(request, actionId, DriftOperatorActionPhase.Outcome) with
+        {
+            Scope = target?.Scope,
+            ScopeIdentifier = target?.ScopeIdentifier,
+            Succeeded = succeeded,
+            CorrelationId = newBaseline?.BaselineId,
+            FailureCode = succeeded ? null : DriftOperatorActionAudit.FailureCodeFor(failureType),
+            // The replaced snapshot's id, and the evidence of what the new one was built from.
+            // All four come from objects already in hand — no extra store round-trip.
+            PreviousBaselineId = target?.BaselineId,
+            SampleCount = newBaseline?.SampleCount,
+            WindowStart = newBaseline?.WindowStart,
+            WindowEnd = newBaseline?.WindowEnd
+        };
+
+        return DriftOperatorAuditRecorder.RecordOutcomeAsync(
+            _auditStore,
+            DriftAuditRecordType.BaselineRecalculationRequested,
+            audit,
+            eventId: newBaseline?.BaselineId ?? actionId,
+            recordedAt: _timeProvider.GetUtcNow(),
+            _logger,
+            ct);
+    }
+
+    private static DriftOperatorActionAudit BuildAudit(
+        RecalculateDriftBaselineCommand request, Guid actionId, DriftOperatorActionPhase phase) => new()
+        {
+            ActionId = actionId,
+            Phase = phase,
+            CallerId = request.CallerId,
+            Action = DriftOperatorActionAudit.BaselineRecalculateAction,
+            // The attempt record names the requested target before it is resolved; the outcome
+            // record overwrites these with the scope the id actually resolved to.
+            PreviousBaselineId = request.BaselineId
+        };
+}

--- a/src/Content/Application/Application.Core/CQRS/DriftDetection/RecalculateDriftBaselineCommandValidator.cs
+++ b/src/Content/Application/Application.Core/CQRS/DriftDetection/RecalculateDriftBaselineCommandValidator.cs
@@ -1,0 +1,23 @@
+using FluentValidation;
+
+namespace Application.Core.CQRS.DriftDetection;
+
+/// <summary>
+/// Validates <see cref="RecalculateDriftBaselineCommand"/>: a non-empty baseline id and a
+/// present, bounded controller-stamped caller identity.
+/// </summary>
+public sealed class RecalculateDriftBaselineCommandValidator
+    : AbstractValidator<RecalculateDriftBaselineCommand>
+{
+    /// <summary>Initializes validation rules.</summary>
+    public RecalculateDriftBaselineCommandValidator()
+    {
+        RuleFor(x => x.BaselineId)
+            .NotEmpty().WithMessage("BaselineId must not be empty.");
+
+        RuleFor(x => x.CallerId)
+            .NotEmpty().WithMessage("CallerId must not be empty.")
+            .MaximumLength(DriftValidationRules.MaxCallerIdLength)
+                .WithMessage($"CallerId must not exceed {DriftValidationRules.MaxCallerIdLength} characters.");
+    }
+}

--- a/src/Content/Application/Application.Core/Validation/DriftDetectionConfigValidator.cs
+++ b/src/Content/Application/Application.Core/Validation/DriftDetectionConfigValidator.cs
@@ -39,5 +39,14 @@ public sealed class DriftDetectionConfigValidator : AbstractValidator<DriftDetec
 
         RuleFor(x => x.AuditPath)
             .NotEmpty().WithMessage("AuditPath must be configured.");
+
+        // The drift HTTP surface stamps write-audit records with the caller identity resolved
+        // from this claim type. Restrict it to issuer-asserted identity claims (the same
+        // allowlist as escalation approver identity) so a user-editable claim can never become
+        // the audit attribution source.
+        RuleFor(x => x.CallerIdentityClaimType)
+            .Must(claimType => ApproverClaimTypes.Allowed.Contains(claimType, StringComparer.Ordinal))
+            .WithMessage(
+                $"CallerIdentityClaimType must be one of: {string.Join(", ", ApproverClaimTypes.Allowed)}.");
     }
 }

--- a/src/Content/Domain/Domain.AI/DriftDetection/DriftAuditRecord.cs
+++ b/src/Content/Domain/Domain.AI/DriftDetection/DriftAuditRecord.cs
@@ -13,7 +13,19 @@ public enum DriftAuditRecordType
     /// <summary>A baseline was updated (recalculated or adjusted).</summary>
     BaselineUpdated,
     /// <summary>An escalation was triggered from a drift event.</summary>
-    EscalationTriggered
+    EscalationTriggered,
+    /// <summary>
+    /// An evaluation was pushed through the drift HTTP surface. The payload records the
+    /// authenticated caller's identity — evaluation pushes move EWMA state and feed future
+    /// baselines, so every push must be attributable to a principal.
+    /// </summary>
+    EvaluationPushed,
+    /// <summary>
+    /// A baseline recalculation was requested through the drift HTTP surface. The payload
+    /// records the authenticated caller's identity and the request outcome; the recalculated
+    /// baseline itself is still audited by the service as <see cref="BaselineUpdated"/>.
+    /// </summary>
+    BaselineRecalculationRequested
 }
 
 /// <summary>
@@ -43,6 +55,8 @@ public sealed record DriftAuditRecord
     ///   <item><see cref="DriftAuditRecordType.Resolved"/> → serialized <see cref="DriftResolution"/></item>
     ///   <item><see cref="DriftAuditRecordType.BaselineUpdated"/> → serialized <see cref="DriftBaseline"/></item>
     ///   <item><see cref="DriftAuditRecordType.EscalationTriggered"/> → serialized escalation reference</item>
+    ///   <item><see cref="DriftAuditRecordType.EvaluationPushed"/> → serialized operator-action envelope (caller identity, scope, outcome)</item>
+    ///   <item><see cref="DriftAuditRecordType.BaselineRecalculationRequested"/> → serialized operator-action envelope (caller identity, scope, outcome)</item>
     /// </list>
     /// </remarks>
     public required string Payload { get; init; }

--- a/src/Content/Domain/Domain.Common/Config/AI/DriftDetection/DriftDetectionConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/DriftDetection/DriftDetectionConfig.cs
@@ -89,4 +89,22 @@ public class DriftDetectionConfig
     /// </summary>
     /// <value>Default: "data/audit"</value>
     public string AuditPath { get; set; } = "data/audit";
+
+    /// <summary>
+    /// The claim type the drift HTTP surface reads from the authenticated principal to stamp
+    /// the caller identity onto evaluation-push and baseline-recalculation audit records.
+    /// Only identity-bearing claim types are accepted: <c>oid</c>, <c>sub</c>,
+    /// <c>preferred_username</c>, or <c>upn</c> (enforced at startup by
+    /// <c>DriftDetectionConfigValidator</c>; resolution also searches each type's JWT
+    /// inbound-mapped form on the principal).
+    /// </summary>
+    /// <remarks>
+    /// This is deliberately a server-side setting, never a request parameter: evaluation pushes
+    /// move EWMA state and feed future baselines, so the identity in the audit trail must come
+    /// from the validated token — a caller can never assert an identity the token does not
+    /// carry. The default is the immutable object id (<c>oid</c>) rather than a sign-in name so
+    /// audit attribution survives UPN reassignment.
+    /// </remarks>
+    /// <value>Default: "oid"</value>
+    public string CallerIdentityClaimType { get; set; } = "oid";
 }

--- a/src/Content/Infrastructure/Infrastructure.AI/DriftDetection/DefaultDriftDetectionService.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/DriftDetection/DefaultDriftDetectionService.cs
@@ -86,7 +86,10 @@ public sealed class DefaultDriftDetectionService : IDriftDetectionService
         {
             sw.Stop();
             DriftMetrics.EvaluationDurationMs.Record(sw.Elapsed.TotalMilliseconds);
-            return Result<DriftScore>.Fail($"No baseline available for scope {request.Scope}:{request.ScopeIdentifier}");
+            // Conflict, not General: "no baseline yet" is an expected state of the subsystem
+            // (the caller must establish a baseline first), so HTTP surfaces map it to 409
+            // instead of an opaque 500.
+            return Result<DriftScore>.Conflict($"No baseline available for scope {request.Scope}:{request.ScopeIdentifier}");
         }
 
         var dimensionScores = new Dictionary<DriftDimension, DriftDimensionScore>();
@@ -103,7 +106,14 @@ public sealed class DefaultDriftDetectionService : IDriftDetectionService
         {
             sw.Stop();
             DriftMetrics.EvaluationDurationMs.Record(sw.Elapsed.TotalMilliseconds);
-            return Result<DriftScore>.Fail("All dimensions failed scoring");
+            // Conflict, not General: this arm is reachable from perfectly valid input. The
+            // scorer fails a dimension the baseline does not carry (EwmaDriftScorer: "Dimension
+            // {d} not found in baseline"), so a caller pushing only dimensions absent from the
+            // resolved baseline lands here. That is an expected state of the subsystem — the
+            // baseline needs to cover the pushed dimensions — so HTTP surfaces map it to 409
+            // rather than an opaque 500. Per-dimension causes are logged above, not returned.
+            return Result<DriftScore>.Conflict(
+                "No pushed dimension could be scored against the resolved baseline");
         }
 
         var overallDrift = dimensionScores.Values.Max(d => d.Deviation);
@@ -162,8 +172,11 @@ public sealed class DefaultDriftDetectionService : IDriftDetectionService
         var config = _options.CurrentValue.AI.DriftDetection;
         var now = _timeProvider.GetUtcNow();
 
+        // Conflict, not General: both failure arms below are expected states (subsystem
+        // disabled, not enough history yet), not internal errors — HTTP surfaces map them
+        // to 409 with the message intact instead of an opaque 500.
         if (!config.Enabled)
-            return Result<DriftBaseline>.Fail("Drift detection is disabled");
+            return Result<DriftBaseline>.Conflict("Drift detection is disabled");
 
         var historyQuery = new DriftHistoryQuery
         {
@@ -179,7 +192,7 @@ public sealed class DefaultDriftDetectionService : IDriftDetectionService
 
         var scores = historyResult.Value!;
         if (scores.Count < config.MinSamplesForBaseline)
-            return Result<DriftBaseline>.Fail(
+            return Result<DriftBaseline>.Conflict(
                 $"Insufficient samples: {scores.Count}/{config.MinSamplesForBaseline}");
 
         var dimensionMeans = new Dictionary<DriftDimension, double>();
@@ -221,8 +234,14 @@ public sealed class DefaultDriftDetectionService : IDriftDetectionService
         if (!saveResult.IsSuccess)
             return Result<DriftBaseline>.Fail(saveResult.Errors.ToArray());
 
+        // Pass the recomputed baseline so the audit record carries the means, sigmas, sample
+        // count, and window the recalculation produced. Writing a content-free "{}" here left
+        // the trail unable to answer "what did this recalculation change?" — and because
+        // SaveBaselineAsync overwrites the previous snapshot, that evidence existed nowhere
+        // else. Both recalculation paths (the HTTP surface and LearningsDriftBridge) audit
+        // through here, so both are covered.
         await SafeExecuteAsync("audit",
-            () => RecordAuditAsync(null, DriftAuditRecordType.BaselineUpdated, now, ct));
+            () => RecordAuditAsync(null, DriftAuditRecordType.BaselineUpdated, now, ct, baseline));
 
         DriftMetrics.BaselinesUpdated.Add(1);
         return Result<DriftBaseline>.Success(baseline);
@@ -347,14 +366,32 @@ public sealed class DefaultDriftDetectionService : IDriftDetectionService
         DriftMetrics.EscalationsTriggered.Add(1);
     }
 
-    private async Task RecordAuditAsync(DriftScore? score, DriftAuditRecordType recordType, DateTimeOffset now, CancellationToken ct)
+    /// <summary>
+    /// Appends one lifecycle audit record. Exactly one of <paramref name="score"/> or
+    /// <paramref name="baseline"/> carries the payload, matching the record type: a
+    /// <see cref="DriftAuditRecordType.Detected"/> record serializes the score, a
+    /// <see cref="DriftAuditRecordType.BaselineUpdated"/> record serializes the new baseline
+    /// (as <c>DriftAuditRecord.Payload</c> documents). The correlating id follows the same
+    /// split, so <c>GET /api/drift/audits?eventId=…</c> resolves a baseline update by its new
+    /// <see cref="DriftBaseline.BaselineId"/> instead of matching every empty-guid record.
+    /// </summary>
+    private async Task RecordAuditAsync(
+        DriftScore? score,
+        DriftAuditRecordType recordType,
+        DateTimeOffset now,
+        CancellationToken ct,
+        DriftBaseline? baseline = null)
     {
+        var payload = score is not null
+            ? JsonSerializer.Serialize(score)
+            : baseline is not null ? JsonSerializer.Serialize(baseline) : "{}";
+
         var record = new DriftAuditRecord
         {
             RecordId = Guid.NewGuid(),
-            EventId = score?.ScoreId ?? Guid.Empty,
+            EventId = score?.ScoreId ?? baseline?.BaselineId ?? Guid.Empty,
             RecordType = recordType,
-            Payload = score is not null ? JsonSerializer.Serialize(score) : "{}",
+            Payload = payload,
             RecordedAt = now
         };
 

--- a/src/Content/Infrastructure/Infrastructure.AI/DriftDetection/GraphDriftBaselineStore.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/DriftDetection/GraphDriftBaselineStore.cs
@@ -131,6 +131,31 @@ public sealed class GraphDriftBaselineStore : IDriftBaselineStore
         }
     }
 
+    /// <inheritdoc />
+    public async Task<Result<DriftBaseline?>> GetBaselineByIdAsync(Guid baselineId, CancellationToken ct)
+    {
+        try
+        {
+            // Baseline nodes are addressed by scope + identifier, so BaselineId is a secondary
+            // key: filter on the indexed node property before deserializing, so at most one
+            // node's JSON payload is parsed instead of the whole DriftBaseline set.
+            var allNodes = await _graphStore.GetAllNodesAsync(ct);
+            var wanted = baselineId.ToString();
+
+            var node = allNodes.FirstOrDefault(n =>
+                n.Type == "DriftBaseline" &&
+                n.Properties.TryGetValue("BaselineId", out var id) &&
+                string.Equals(id, wanted, StringComparison.OrdinalIgnoreCase));
+
+            return Result<DriftBaseline?>.Success(node is null ? null : DeserializeBaseline(node));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to get drift baseline by id {BaselineId}", baselineId);
+            return Result<DriftBaseline?>.Fail($"Failed to retrieve drift baseline: {ex.Message}");
+        }
+    }
+
     private static string BuildId(DriftScope scope, string scopeIdentifier)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(scopeIdentifier);

--- a/src/Content/Infrastructure/Infrastructure.AI/DriftDetection/InMemoryDriftBaselineStore.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/DriftDetection/InMemoryDriftBaselineStore.cs
@@ -49,4 +49,13 @@ public sealed class InMemoryDriftBaselineStore : IDriftBaselineStore
 
         return Task.FromResult(Result<IReadOnlyList<DriftBaseline>>.Success(results.AsReadOnly()));
     }
+
+    /// <inheritdoc />
+    public Task<Result<DriftBaseline?>> GetBaselineByIdAsync(Guid baselineId, CancellationToken ct)
+    {
+        // The dictionary is keyed by scope + identifier, so an id lookup is a scan. Acceptable
+        // here: this store is the development/testing backend and holds one baseline per scope.
+        var match = _baselines.Values.FirstOrDefault(b => b.BaselineId == baselineId);
+        return Task.FromResult(Result<DriftBaseline?>.Success(match));
+    }
 }

--- a/src/Content/Presentation/Presentation.AgentHub/Auth/DevAuthHandler.cs
+++ b/src/Content/Presentation/Presentation.AgentHub/Auth/DevAuthHandler.cs
@@ -33,6 +33,14 @@ internal sealed class DevAuthHandler(
             new Claim(ClaimTypes.Role, "Harness.Learnings.Read"),
             new Claim(ClaimTypes.Role, Presentation.Common.Escalations.EscalationsController.DecideRole),
             new Claim(ClaimTypes.Role, Presentation.Common.Escalations.EscalationsController.AdminRole),
+            // This dev principal deliberately holds BOTH drift roles so the whole surface is
+            // exercisable locally — which means the read/operate separation (a reader must not
+            // be able to push evaluations) is never exercised by running the app, only by the
+            // controller's integration tests. A consumer who copies this handler as the shape
+            // of their own auth inherits an operator-capable principal; in any real deployment
+            // Harness.Drift.Operate must be granted separately from Harness.Drift.Read.
+            new Claim(ClaimTypes.Role, Presentation.Common.Drift.DriftController.ReadRole),
+            new Claim(ClaimTypes.Role, Presentation.Common.Drift.DriftController.OperateRole),
         };
         var identity = new ClaimsIdentity(claims, Scheme.Name);
         var ticket = new AuthenticationTicket(new ClaimsPrincipal(identity), Scheme.Name);

--- a/src/Content/Presentation/Presentation.AgentHub/DependencyInjection.cs
+++ b/src/Content/Presentation/Presentation.AgentHub/DependencyInjection.cs
@@ -24,6 +24,8 @@ using Presentation.AgentHub.Notifications;
 using Presentation.AgentHub.Planner;
 using Presentation.AgentHub.Config;
 using Presentation.AgentHub.Telemetry;
+using Domain.Common.Config;
+using Presentation.Common.Drift;
 using Presentation.Common.Escalations;
 using Microsoft.Extensions.Options;
 
@@ -59,7 +61,10 @@ public static class DependencyInjection
             })
             // Deliberate opt-in: AgentHub runs the agent workload, so the in-process escalation
             // state lives here and the human approval API must be co-resident with it.
-            .AddEscalationApi();
+            .AddEscalationApi()
+            // Deliberate opt-in: AgentHub runs the drift subsystem (stores, EWMA state,
+            // escalation bridge), so pushed evaluations must land in this process.
+            .AddDriftApi();
 
         // Surfaces a missing/invalid AI provider configuration via /health/ai. Additive to the
         // health checks registered in Presentation.Common — Degraded (not Unhealthy) because the
@@ -215,6 +220,35 @@ public static class DependencyInjection
                         ?? context.Connection.RemoteIpAddress?.ToString()
                         ?? "unknown";
                     return RateLimitPartition.GetFixedWindowLimiter($"escalation:{escalationCaller}", _ => new FixedWindowRateLimiterOptions
+                    {
+                        PermitLimit = 30,
+                        Window = TimeSpan.FromMinutes(1),
+                        QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+                        QueueLimit = 0,
+                    });
+                }
+
+                // Drift writes (push evaluation, recalculate baseline) move EWMA state and the
+                // history future baselines are computed from — the subsystem's poisoning
+                // surface — and append durable hash-chained audit records; cap them per
+                // authenticated caller so even a role-holding operator cannot bulk-shift a
+                // baseline or flood the audit store in one burst. Reads stay unthrottled,
+                // matching the escalation API's write-only posture.
+                if (context.Request.Method == HttpMethods.Post &&
+                    context.Request.Path.StartsWithSegments("/api/drift"))
+                {
+                    // Partition on the SAME claim the controller stamps into the audit trail,
+                    // not on GetUserIdOrNull()'s oid. A host configured with
+                    // CallerIdentityClaimType "sub" or "preferred_username", issuing tokens
+                    // without an oid, would otherwise collapse every operator into the shared
+                    // IP partition — one operator could then starve all the others.
+                    var driftClaimType = context.RequestServices
+                        .GetRequiredService<IOptionsMonitor<AppConfig>>()
+                        .CurrentValue.AI.DriftDetection.CallerIdentityClaimType;
+                    var driftCaller = DriftCallerIdentity.Resolve(context.User, driftClaimType)
+                        ?? context.Connection.RemoteIpAddress?.ToString()
+                        ?? "unknown";
+                    return RateLimitPartition.GetFixedWindowLimiter($"drift:{driftCaller}", _ => new FixedWindowRateLimiterOptions
                     {
                         PermitLimit = 30,
                         Window = TimeSpan.FromMinutes(1),

--- a/src/Content/Presentation/Presentation.Common/Drift/DriftApiMarker.cs
+++ b/src/Content/Presentation/Presentation.Common/Drift/DriftApiMarker.cs
@@ -1,0 +1,21 @@
+namespace Presentation.Common.Drift;
+
+/// <summary>
+/// DI marker whose presence records that a host deliberately opted into serving the drift
+/// monitoring API. Registered only by
+/// <see cref="DriftApiMvcBuilderExtensions.AddDriftApi"/>;
+/// <see cref="RequiresDriftApiOptInAttribute"/> checks for it at route-match time and
+/// un-matches every <see cref="DriftController"/> route when it is absent.
+/// </summary>
+/// <remarks>
+/// This runtime gate exists because compile-time placement cannot deliver the opt-in: the Web
+/// SDK auto-generates an <c>ApplicationPartAttribute</c> for every referenced assembly that
+/// references MVC, so any MVC host referencing <c>Presentation.Common</c> discovers this
+/// assembly's controllers whether or not it called <c>AddApplicationPart</c>. The drift write
+/// endpoints move EWMA state and feed future baselines — a host that merely composes shared
+/// services must not accidentally expose them. Fail-closed: no marker, no routes (404 before
+/// authentication, indistinguishable from a host without the API).
+/// </remarks>
+public sealed class DriftApiMarker
+{
+}

--- a/src/Content/Presentation/Presentation.Common/Drift/DriftApiMvcBuilderExtensions.cs
+++ b/src/Content/Presentation/Presentation.Common/Drift/DriftApiMvcBuilderExtensions.cs
@@ -1,0 +1,42 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Presentation.Common.Drift;
+
+/// <summary>
+/// Deliberate opt-in mount for the drift monitoring API. Hosts that should serve
+/// <c>/api/drift</c> chain <see cref="AddDriftApi"/> onto their <c>AddControllers()</c> call;
+/// hosts that merely reference <c>Presentation.Common</c> for its shared services never expose
+/// the routes.
+/// </summary>
+public static class DriftApiMvcBuilderExtensions
+{
+    /// <summary>
+    /// Mounts <see cref="DriftController"/> into the host's MVC pipeline. Two things happen:
+    /// this assembly is added as an application part (required for hosts whose build did not
+    /// auto-register it), and <see cref="DriftApiMarker"/> is registered, which is what
+    /// actually arms the routes — <see cref="RequiresDriftApiOptInAttribute"/> keeps them
+    /// un-matched (404) in every host without the marker, including hosts where the Web SDK
+    /// auto-discovered this assembly as an application part.
+    /// </summary>
+    /// <param name="builder">The MVC builder returned by <c>AddControllers()</c>.</param>
+    /// <returns>The builder for chaining.</returns>
+    /// <remarks>
+    /// Only mount this in a host that runs the drift subsystem itself (the agent workload
+    /// host): pushed evaluations must land in the same stores and EWMA state the workload's
+    /// own evaluations use, and drift escalations fire against that host's in-process
+    /// escalation service.
+    /// </remarks>
+    public static IMvcBuilder AddDriftApi(this IMvcBuilder builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        // Idempotent: a second call must not stack duplicate application parts.
+        if (builder.Services.Any(d => d.ServiceType == typeof(DriftApiMarker)))
+            return builder;
+
+        builder.Services.TryAddSingleton<DriftApiMarker>();
+
+        return builder.AddApplicationPart(typeof(DriftController).Assembly);
+    }
+}

--- a/src/Content/Presentation/Presentation.Common/Drift/DriftCallerIdentity.cs
+++ b/src/Content/Presentation/Presentation.Common/Drift/DriftCallerIdentity.cs
@@ -1,0 +1,49 @@
+using System.Security.Claims;
+using Application.Core.Validation;
+
+namespace Presentation.Common.Drift;
+
+/// <summary>
+/// The single authority on how the drift HTTP surface derives a caller identity from an
+/// authenticated principal. Both the controller (which stamps the identity into the audit
+/// trail) and the host's rate-limit partitioner read from here, so a host that configures a
+/// non-default <c>CallerIdentityClaimType</c> cannot end up throttling on one claim while
+/// auditing on another.
+/// </summary>
+public static class DriftCallerIdentity
+{
+    /// <summary>
+    /// Resolves the caller identity from the configured claim type, or null when the principal
+    /// does not carry exactly one usable value.
+    /// </summary>
+    /// <remarks>
+    /// Resolution searches the union of the configured type's equivalent forms
+    /// (<see cref="ApproverClaimTypes.EquivalentFormsOf"/>): production tokens carry the JWT
+    /// inbound-MAPPED form (e.g. <c>oid</c> arrives as the objectidentifier URI), dev/test
+    /// principals the short form — searching only one of them would reject every legitimate
+    /// operator on the other auth path. Across that union, more than one distinct value is an
+    /// ambiguous identity and yields null rather than a silent first-pick: an attacker who can
+    /// smuggle a second instance of the claim must not get to choose which one wins. The same
+    /// value appearing under both forms counts as one.
+    /// </remarks>
+    /// <param name="principal">The authenticated principal.</param>
+    /// <param name="claimType">The configured caller identity claim type.</param>
+    /// <returns>The single resolved identity, or <see langword="null"/> when absent or ambiguous.</returns>
+    public static string? Resolve(ClaimsPrincipal? principal, string claimType)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(claimType);
+
+        if (principal is null)
+            return null;
+
+        var values = ApproverClaimTypes.EquivalentFormsOf(claimType)
+            .SelectMany(principal.FindAll)
+            .Select(c => c.Value)
+            .Where(v => !string.IsNullOrWhiteSpace(v))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Take(2)
+            .ToList();
+
+        return values.Count == 1 ? values[0] : null;
+    }
+}

--- a/src/Content/Presentation/Presentation.Common/Drift/DriftController.cs
+++ b/src/Content/Presentation/Presentation.Common/Drift/DriftController.cs
@@ -1,0 +1,325 @@
+using Application.Core.CQRS.DriftDetection;
+using Application.Core.Validation;
+using Domain.AI.DriftDetection;
+using Domain.Common;
+using Domain.Common.Config;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Presentation.Common.Extensions;
+
+namespace Presentation.Common.Drift;
+
+/// <summary>
+/// REST API for the EWMA drift-monitoring subsystem: read baselines, evaluation history, and
+/// the audit trail; push evaluations into the pipeline; and request baseline recalculation.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Opt-in mount.</b> The controller ships in <c>Presentation.Common</c> but its routes only
+/// exist in hosts that called <see cref="DriftApiMvcBuilderExtensions.AddDriftApi"/> — see
+/// <see cref="RequiresDriftApiOptInAttribute"/>. Non-opted hosts answer these paths with a
+/// plain 404 before authentication.
+/// </para>
+/// <para>
+/// <b>Read/write role separation.</b> The subsystem is push-based: it has no internal
+/// collector, so whoever can POST evaluations shapes the EWMA state and the history future
+/// baselines are computed from — a history-poisoning vector that can mask real drift or
+/// fabricate it to trigger escalations. Reads are therefore gated by
+/// <see cref="ReadRole"/> while the two writes require the distinct ops role
+/// <see cref="OperateRole"/>; holding one never implies the other.
+/// </para>
+/// <para>
+/// <b>Identity from token, never from body.</b> Both writes are recorded in the drift audit
+/// trail with the caller identity resolved from the authenticated principal's claims (claim
+/// type configured by <c>DriftDetectionConfig.CallerIdentityClaimType</c>, allowlisted to
+/// issuer-asserted identity claims, default <c>oid</c>). No request DTO carries a caller-id
+/// field, so a push cannot be attributed to someone else. A principal lacking the configured
+/// claim — or carrying more than one distinct value (an ambiguous identity is no identity) —
+/// is rejected with 403 (fail-closed), never mapped through a fallback claim.
+/// </para>
+/// <para>
+/// <b>No scan endpoint.</b> There is deliberately no "trigger a drift scan" route: nothing in
+/// the subsystem collects scores on its own, so such an endpoint could only fake activity.
+/// Callers push real evaluations or read what has been pushed.
+/// </para>
+/// <para>
+/// <b>What a 409 body discloses.</b> Conflict responses surface the drift subsystem's own
+/// message verbatim, which can echo the caller's <c>ScopeIdentifier</c> (bounded to 200 chars
+/// by validation) and the configured <c>MinSamplesForBaseline</c> in
+/// "Insufficient samples: 3/20". Both are accepted disclosures: the identifier is the caller's
+/// own input reflected back, and the sample threshold is operational configuration an
+/// <see cref="OperateRole"/> holder is already trusted with — knowing it reveals nothing about
+/// other tenants, other scopes, or the data itself, and the alternative (an opaque 409) would
+/// leave operators unable to tell "wrong scope" from "not enough history yet". Every other
+/// failure type still maps through <see cref="ControllerBaseExtensions"/> to a generic body.
+/// </para>
+/// </remarks>
+[ApiController]
+[Route("api/drift")]
+[RequiresDriftApiOptIn]
+public sealed class DriftController : ControllerBase
+{
+    /// <summary>
+    /// App role required to read baselines, drift history, and the drift audit trail. Follows
+    /// the <c>Harness.*</c> read-role precedent (<c>Harness.Learnings.Read</c>).
+    /// </summary>
+    public const string ReadRole = "Harness.Drift.Read";
+
+    /// <summary>
+    /// App role required to push evaluations and recalculate baselines. Held separately from
+    /// <see cref="ReadRole"/>: writes shift the subsystem's notion of "normal" (an operator
+    /// power with poisoning potential), while reads are pure observation — neither role
+    /// implies the other.
+    /// </summary>
+    public const string OperateRole = "Harness.Drift.Operate";
+
+    private readonly IMediator _mediator;
+    private readonly IOptionsMonitor<AppConfig> _config;
+    private readonly ILogger<DriftController> _logger;
+
+    /// <summary>Initializes the controller with its dependencies.</summary>
+    /// <param name="mediator">The MediatR mediator used to dispatch drift operations.</param>
+    /// <param name="config">Application configuration; supplies the caller identity claim type.</param>
+    /// <param name="logger">Logger for identity-resolution diagnostics (claim details never leave the trust boundary in responses).</param>
+    public DriftController(
+        IMediator mediator,
+        IOptionsMonitor<AppConfig> config,
+        ILogger<DriftController> logger)
+    {
+        ArgumentNullException.ThrowIfNull(mediator);
+        ArgumentNullException.ThrowIfNull(config);
+        ArgumentNullException.ThrowIfNull(logger);
+        _mediator = mediator;
+        _config = config;
+        _logger = logger;
+    }
+
+    /// <summary>Lists the active drift baselines, optionally filtered to one scope level.</summary>
+    /// <param name="scope">Optional scope filter (<c>Agent</c>, <c>Skill</c>, or <c>TaskType</c>).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The active baselines (possibly empty — nothing has pushed evaluations yet in a fresh deployment).</returns>
+    /// <response code="200">The baselines (may contain zero results).</response>
+    /// <response code="400">Invalid scope filter.</response>
+    /// <response code="401">Caller is not authenticated.</response>
+    /// <response code="403">Caller lacks <see cref="ReadRole"/>.</response>
+    [HttpGet("baselines")]
+    [Authorize(Roles = ReadRole)]
+    [ProducesResponseType(typeof(IReadOnlyList<DriftBaseline>), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<IActionResult> GetBaselines(
+        [FromQuery] DriftScope? scope, CancellationToken cancellationToken)
+    {
+        var result = await _mediator.Send(
+            new GetDriftBaselinesQuery { Scope = scope },
+            cancellationToken).ConfigureAwait(false);
+
+        return result.IsSuccess ? Ok(result.Value) : MapFailure(result);
+    }
+
+    /// <summary>Retrieves the persisted drift scores for one scope within a bounded time window.</summary>
+    /// <param name="scope">The hierarchy level to query.</param>
+    /// <param name="scopeIdentifier">The entity within the scope (agent ID, skill name, or task type).</param>
+    /// <param name="start">Start of the query window (inclusive).</param>
+    /// <param name="end">End of the query window (inclusive); the window is capped server-side.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Every evaluation recorded for the scope in the window, healthy and drifted alike.</returns>
+    /// <response code="200">The drift scores (may contain zero results).</response>
+    /// <response code="400">Missing/oversized identifier, unordered window, or a window over the cap.</response>
+    /// <response code="401">Caller is not authenticated.</response>
+    /// <response code="403">Caller lacks <see cref="ReadRole"/>.</response>
+    [HttpGet("history")]
+    [Authorize(Roles = ReadRole)]
+    [ProducesResponseType(typeof(IReadOnlyList<DriftScore>), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<IActionResult> GetHistory(
+        [FromQuery] DriftScope scope,
+        [FromQuery] string? scopeIdentifier,
+        [FromQuery] DateTimeOffset start,
+        [FromQuery] DateTimeOffset end,
+        CancellationToken cancellationToken)
+    {
+        var result = await _mediator.Send(new GetDriftHistoryQuery
+        {
+            Scope = scope,
+            ScopeIdentifier = scopeIdentifier ?? string.Empty,
+            Start = start,
+            End = end
+        }, cancellationToken).ConfigureAwait(false);
+
+        return result.IsSuccess ? Ok(result.Value) : MapFailure(result);
+    }
+
+    /// <summary>
+    /// Retrieves drift audit records: detections, resolutions, baseline updates, escalation
+    /// triggers, and the operator actions performed through this API with their caller
+    /// identities.
+    /// </summary>
+    /// <param name="start">Optional window start (inclusive).</param>
+    /// <param name="end">Optional window end (inclusive).</param>
+    /// <param name="recordType">Optional record-type filter.</param>
+    /// <param name="eventId">Optional originating-event filter.</param>
+    /// <param name="maxResults">Result cap (1–1000, default 500); the most recent matches are returned.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The matching audit records in chronological order.</returns>
+    /// <response code="200">The audit records (may contain zero results).</response>
+    /// <response code="400">Unordered window, unknown record type, or an out-of-range cap.</response>
+    /// <response code="401">Caller is not authenticated.</response>
+    /// <response code="403">Caller lacks <see cref="ReadRole"/>.</response>
+    [HttpGet("audits")]
+    [Authorize(Roles = ReadRole)]
+    [ProducesResponseType(typeof(IReadOnlyList<DriftAuditRecord>), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<IActionResult> GetAudits(
+        [FromQuery] DateTimeOffset? start,
+        [FromQuery] DateTimeOffset? end,
+        [FromQuery] DriftAuditRecordType? recordType,
+        [FromQuery] Guid? eventId,
+        [FromQuery] int maxResults = DriftValidationRules.DefaultAuditResults,
+        CancellationToken cancellationToken = default)
+    {
+        var result = await _mediator.Send(new GetDriftAuditsQuery
+        {
+            Start = start,
+            End = end,
+            RecordType = recordType,
+            EventId = eventId,
+            MaxResults = maxResults
+        }, cancellationToken).ConfigureAwait(false);
+
+        return result.IsSuccess ? Ok(result.Value) : MapFailure(result);
+    }
+
+    /// <summary>
+    /// Pushes one set of dimension scores into the drift pipeline. The caller identity from
+    /// the token is recorded in the audit trail alongside the push.
+    /// </summary>
+    /// <param name="request">The scope and dimension scores to evaluate.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The resulting drift score with per-dimension deviations and classified severity.</returns>
+    /// <response code="200">The evaluation ran; the body carries the resulting score.</response>
+    /// <response code="400">Invalid request (empty dimensions, out-of-range or non-finite scores, oversized identifier).</response>
+    /// <response code="401">Caller is not authenticated.</response>
+    /// <response code="403">Caller lacks <see cref="OperateRole"/> or has no usable identity claim.</response>
+    /// <response code="409">No baseline exists for the scope yet — establish one before evaluating against it.</response>
+    [HttpPost("evaluations")]
+    [Authorize(Roles = OperateRole)]
+    [ProducesResponseType(typeof(DriftScore), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status409Conflict)]
+    public async Task<IActionResult> PushEvaluation(
+        [FromBody] PushDriftEvaluationRequest request,
+        CancellationToken cancellationToken)
+    {
+        if (ResolveCallerId() is not { } callerId)
+            return MissingCallerIdentity();
+
+        var result = await _mediator.Send(new PushDriftEvaluationCommand
+        {
+            Scope = request.Scope,
+            ScopeIdentifier = request.ScopeIdentifier,
+            Dimensions = request.Dimensions,
+            CallerId = callerId
+        }, cancellationToken).ConfigureAwait(false);
+
+        return result.IsSuccess ? Ok(result.Value) : MapFailure(result);
+    }
+
+    /// <summary>
+    /// Recalculates the identified baseline from its scope's recent evaluation history,
+    /// replacing the current snapshot. The caller identity from the token is recorded in the
+    /// audit trail alongside the request.
+    /// </summary>
+    /// <param name="id">The baseline id to recalculate.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The new baseline snapshot.</returns>
+    /// <response code="200">The baseline was recalculated; the body carries the new snapshot.</response>
+    /// <response code="401">Caller is not authenticated.</response>
+    /// <response code="403">Caller lacks <see cref="OperateRole"/> or has no usable identity claim.</response>
+    /// <response code="404">No baseline with the given id.</response>
+    /// <response code="409">Drift detection is disabled, or the window holds too few samples to recalculate from.</response>
+    [HttpPost("baselines/{id:guid}/recalculate")]
+    [Authorize(Roles = OperateRole)]
+    [ProducesResponseType(typeof(DriftBaseline), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status409Conflict)]
+    public async Task<IActionResult> RecalculateBaseline(Guid id, CancellationToken cancellationToken)
+    {
+        if (ResolveCallerId() is not { } callerId)
+            return MissingCallerIdentity();
+
+        var result = await _mediator.Send(new RecalculateDriftBaselineCommand
+        {
+            BaselineId = id,
+            CallerId = callerId
+        }, cancellationToken).ConfigureAwait(false);
+
+        return result.IsSuccess ? Ok(result.Value) : MapFailure(result);
+    }
+
+    /// <summary>
+    /// Resolves the caller identity for the audit trail via <see cref="DriftCallerIdentity"/>,
+    /// the shared resolver the host's rate-limit partitioner also uses. Absent or ambiguous
+    /// identities yield null and are rejected fail-closed by the caller.
+    /// </summary>
+    private string? ResolveCallerId()
+    {
+        var claimType = _config.CurrentValue.AI.DriftDetection.CallerIdentityClaimType;
+        var callerId = DriftCallerIdentity.Resolve(User, claimType);
+
+        if (callerId is null)
+        {
+            // Diagnostic detail (which claim type) goes to the log only; the HTTP body stays
+            // generic so the response never teaches a caller which claim to forge.
+            _logger.LogWarning(
+                "Drift caller identity resolution failed: configured claim '{CallerIdentityClaimType}' (incl. mapped forms) did not yield exactly one distinct value on the principal",
+                claimType);
+        }
+
+        return callerId;
+    }
+
+    /// <summary>
+    /// Fail-closed response for an authenticated, role-holding principal without exactly one
+    /// usable identity claim — without it the write cannot be attributed in the audit trail.
+    /// The detail is deliberately generic; the configured claim type appears only in server logs.
+    /// </summary>
+    private IActionResult MissingCallerIdentity() => Problem(
+        title: "Forbidden",
+        detail: "The authenticated principal does not carry a usable caller identity; the operation cannot be attributed in the audit trail.",
+        statusCode: StatusCodes.Status403Forbidden);
+
+    private IActionResult MapFailure(Result result) =>
+        this.FailureResponse(result, "Drift operation failed");
+}
+
+// The wire-contract record below is deliberately colocated with the controller (the
+// EscalationsController precedent): it is this endpoint set's HTTP contract, not a shared
+// application model, and reading it next to the action that binds it is the point.
+
+/// <summary>Request body for <c>POST /api/drift/evaluations</c>.</summary>
+/// <param name="Scope">The hierarchy level of the evaluation.</param>
+/// <param name="ScopeIdentifier">The entity within the scope (agent ID, skill name, or task type).</param>
+/// <param name="Dimensions">Dimension scores to evaluate — finite values in [0, 1].</param>
+/// <remarks>
+/// Deliberately carries no caller-id field: the pushing identity always comes from the
+/// authenticated token's configured claim, so a push cannot be attributed to someone else
+/// through the body.
+/// </remarks>
+public sealed record PushDriftEvaluationRequest(
+    DriftScope Scope,
+    string ScopeIdentifier,
+    IReadOnlyDictionary<DriftDimension, double> Dimensions);

--- a/src/Content/Presentation/Presentation.Common/Drift/DriftController.cs
+++ b/src/Content/Presentation/Presentation.Common/Drift/DriftController.cs
@@ -7,6 +7,7 @@ using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Presentation.Common.Extensions;
@@ -123,14 +124,22 @@ public sealed class DriftController : ControllerBase
     }
 
     /// <summary>Retrieves the persisted drift scores for one scope within a bounded time window.</summary>
-    /// <param name="scope">The hierarchy level to query.</param>
+    /// <param name="scope">
+    /// The hierarchy level to query. Required, and guarded twice. Bound as nullable so an
+    /// omitted parameter cannot land on <see cref="DriftScope.Agent"/> (the enum's zero value)
+    /// and answer for a scope the caller never asked about; <see cref="BindRequiredAttribute"/>
+    /// then makes its absence a model-state error, which <c>[ApiController]</c> turns into a 400
+    /// before the action body runs. The query's FluentValidation <c>NotNull</c> rule is the same
+    /// guard one layer down, for any non-HTTP dispatcher of
+    /// <see cref="GetDriftHistoryQuery"/> that never passes through model binding.
+    /// </param>
     /// <param name="scopeIdentifier">The entity within the scope (agent ID, skill name, or task type).</param>
     /// <param name="start">Start of the query window (inclusive).</param>
     /// <param name="end">End of the query window (inclusive); the window is capped server-side.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>Every evaluation recorded for the scope in the window, healthy and drifted alike.</returns>
     /// <response code="200">The drift scores (may contain zero results).</response>
-    /// <response code="400">Missing/oversized identifier, unordered window, or a window over the cap.</response>
+    /// <response code="400">Missing scope, missing/oversized identifier, unordered window, or a window over the cap.</response>
     /// <response code="401">Caller is not authenticated.</response>
     /// <response code="403">Caller lacks <see cref="ReadRole"/>.</response>
     [HttpGet("history")]
@@ -140,7 +149,7 @@ public sealed class DriftController : ControllerBase
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     public async Task<IActionResult> GetHistory(
-        [FromQuery] DriftScope scope,
+        [FromQuery][BindRequired] DriftScope? scope,
         [FromQuery] string? scopeIdentifier,
         [FromQuery] DateTimeOffset start,
         [FromQuery] DateTimeOffset end,

--- a/src/Content/Presentation/Presentation.Common/Drift/RequiresDriftApiOptInAttribute.cs
+++ b/src/Content/Presentation/Presentation.Common/Drift/RequiresDriftApiOptInAttribute.cs
@@ -1,0 +1,34 @@
+using Microsoft.AspNetCore.Mvc.ActionConstraints;
+
+namespace Presentation.Common.Drift;
+
+/// <summary>
+/// Action constraint that removes the decorated controller's routes from route matching unless
+/// the host registered <see cref="DriftApiMarker"/> via
+/// <see cref="DriftApiMvcBuilderExtensions.AddDriftApi"/>.
+/// </summary>
+/// <remarks>
+/// An action constraint (rather than a filter) is deliberate: constraints run during endpoint
+/// <em>selection</em>, before the authentication and authorization middleware. A non-opted host
+/// therefore answers drift paths with a plain 404 — never a 401 challenge that would reveal
+/// the routes exist. Filters would run after auth and could not provide that. Mirrors the
+/// escalation API's <c>RequiresEscalationApiOptInAttribute</c>.
+/// </remarks>
+[AttributeUsage(AttributeTargets.Class)]
+public sealed class RequiresDriftApiOptInAttribute : Attribute, IActionConstraint
+{
+    /// <inheritdoc />
+    public int Order => 0;
+
+    /// <summary>
+    /// Accepts the candidate action only when the host opted into the drift API.
+    /// </summary>
+    /// <param name="context">The constraint context supplied by routing.</param>
+    /// <returns><see langword="true"/> when <see cref="DriftApiMarker"/> is registered.</returns>
+    public bool Accept(ActionConstraintContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        return context.RouteContext.HttpContext.RequestServices
+            .GetService(typeof(DriftApiMarker)) is not null;
+    }
+}

--- a/src/Content/Tests/Application.Core.Tests/CQRS/DriftDetection/DriftCommandValidationTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/CQRS/DriftDetection/DriftCommandValidationTests.cs
@@ -1,0 +1,283 @@
+using Application.Core.CQRS.DriftDetection;
+using Domain.AI.DriftDetection;
+using FluentValidation.TestHelper;
+using Xunit;
+
+namespace Application.Core.Tests.CQRS.DriftDetection;
+
+/// <summary>
+/// Validator tests for the drift CQRS surface. The evaluation-push rules matter most: pushed
+/// scores feed EWMA state and future baselines, so poison values (out-of-range, NaN, infinity,
+/// undefined enum members) must die at the boundary.
+/// </summary>
+public sealed class DriftCommandValidationTests
+{
+    private readonly PushDriftEvaluationCommandValidator _pushValidator = new();
+    private readonly RecalculateDriftBaselineCommandValidator _recalculateValidator = new();
+    private readonly GetDriftBaselinesQueryValidator _baselinesValidator = new();
+    private readonly GetDriftHistoryQueryValidator _historyValidator = new();
+    private readonly GetDriftAuditsQueryValidator _auditsValidator = new();
+
+    private static PushDriftEvaluationCommand CreatePushCommand(
+        IReadOnlyDictionary<DriftDimension, double>? dimensions = null,
+        DriftScope scope = DriftScope.Skill,
+        string scopeIdentifier = "summarize",
+        string callerId = "ops@contoso.com") => new()
+    {
+        Scope = scope,
+        ScopeIdentifier = scopeIdentifier,
+        Dimensions = dimensions ?? new Dictionary<DriftDimension, double>
+        {
+            [DriftDimension.Faithfulness] = 0.85
+        },
+        CallerId = callerId
+    };
+
+    // == PushDriftEvaluationCommand ==
+
+    [Fact]
+    public void Validate_PushCommand_ValidInput_NoErrors()
+    {
+        var result = _pushValidator.TestValidate(CreatePushCommand());
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Theory]
+    [InlineData(-0.1)]
+    [InlineData(1.1)]
+    [InlineData(double.NaN)]
+    [InlineData(double.PositiveInfinity)]
+    [InlineData(double.NegativeInfinity)]
+    public void Validate_PushCommand_PoisonScore_HasError(double poison)
+    {
+        var command = CreatePushCommand(new Dictionary<DriftDimension, double>
+        {
+            [DriftDimension.Faithfulness] = poison
+        });
+
+        var result = _pushValidator.TestValidate(command);
+
+        Assert.False(result.IsValid);
+    }
+
+    [Theory]
+    [InlineData(0.0)]
+    [InlineData(1.0)]
+    public void Validate_PushCommand_BoundaryScore_NoErrors(double boundary)
+    {
+        var command = CreatePushCommand(new Dictionary<DriftDimension, double>
+        {
+            [DriftDimension.Faithfulness] = boundary
+        });
+
+        var result = _pushValidator.TestValidate(command);
+
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void Validate_PushCommand_EmptyDimensions_HasError()
+    {
+        var command = CreatePushCommand(new Dictionary<DriftDimension, double>());
+        var result = _pushValidator.TestValidate(command);
+        result.ShouldHaveValidationErrorFor(x => x.Dimensions);
+    }
+
+    [Fact]
+    public void Validate_PushCommand_UndefinedDimensionKey_HasError()
+    {
+        var command = CreatePushCommand(new Dictionary<DriftDimension, double>
+        {
+            [(DriftDimension)999] = 0.5
+        });
+
+        var result = _pushValidator.TestValidate(command);
+
+        Assert.False(result.IsValid);
+    }
+
+    [Fact]
+    public void Validate_PushCommand_TooManyDimensions_HasError()
+    {
+        var oversized = Enumerable.Range(0, DriftValidationRules.MaxDimensionsPerEvaluation + 1)
+            .ToDictionary(i => (DriftDimension)i, _ => 0.5);
+        var command = CreatePushCommand(oversized);
+
+        var result = _pushValidator.TestValidate(command);
+
+        result.ShouldHaveValidationErrorFor(x => x.Dimensions);
+    }
+
+    [Fact]
+    public void Validate_PushCommand_UndefinedScope_HasError()
+    {
+        var result = _pushValidator.TestValidate(CreatePushCommand(scope: (DriftScope)42));
+        result.ShouldHaveValidationErrorFor(x => x.Scope);
+    }
+
+    [Fact]
+    public void Validate_PushCommand_EmptyScopeIdentifier_HasError()
+    {
+        var result = _pushValidator.TestValidate(CreatePushCommand(scopeIdentifier: ""));
+        result.ShouldHaveValidationErrorFor(x => x.ScopeIdentifier);
+    }
+
+    [Fact]
+    public void Validate_PushCommand_OversizedScopeIdentifier_HasError()
+    {
+        var result = _pushValidator.TestValidate(CreatePushCommand(
+            scopeIdentifier: new string('x', DriftValidationRules.MaxScopeIdentifierLength + 1)));
+        result.ShouldHaveValidationErrorFor(x => x.ScopeIdentifier);
+    }
+
+    [Fact]
+    public void Validate_PushCommand_EmptyCallerId_HasError()
+    {
+        var result = _pushValidator.TestValidate(CreatePushCommand(callerId: ""));
+        result.ShouldHaveValidationErrorFor(x => x.CallerId);
+    }
+
+    // == RecalculateDriftBaselineCommand ==
+
+    [Fact]
+    public void Validate_RecalculateCommand_ValidInput_NoErrors()
+    {
+        var result = _recalculateValidator.TestValidate(new RecalculateDriftBaselineCommand
+        {
+            BaselineId = Guid.NewGuid(),
+            CallerId = "ops@contoso.com"
+        });
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void Validate_RecalculateCommand_EmptyBaselineId_HasError()
+    {
+        var result = _recalculateValidator.TestValidate(new RecalculateDriftBaselineCommand
+        {
+            BaselineId = Guid.Empty,
+            CallerId = "ops@contoso.com"
+        });
+        result.ShouldHaveValidationErrorFor(x => x.BaselineId);
+    }
+
+    [Fact]
+    public void Validate_RecalculateCommand_EmptyCallerId_HasError()
+    {
+        var result = _recalculateValidator.TestValidate(new RecalculateDriftBaselineCommand
+        {
+            BaselineId = Guid.NewGuid(),
+            CallerId = ""
+        });
+        result.ShouldHaveValidationErrorFor(x => x.CallerId);
+    }
+
+    // == GetDriftBaselinesQuery ==
+
+    [Fact]
+    public void Validate_BaselinesQuery_NullScope_NoErrors()
+    {
+        var result = _baselinesValidator.TestValidate(new GetDriftBaselinesQuery());
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void Validate_BaselinesQuery_UndefinedScope_HasError()
+    {
+        var result = _baselinesValidator.TestValidate(new GetDriftBaselinesQuery { Scope = (DriftScope)42 });
+        result.ShouldHaveValidationErrorFor(x => x.Scope);
+    }
+
+    // == GetDriftHistoryQuery ==
+
+    private static GetDriftHistoryQuery CreateHistoryQuery(
+        DateTimeOffset? start = null, DateTimeOffset? end = null, string scopeIdentifier = "summarize") => new()
+    {
+        Scope = DriftScope.Skill,
+        ScopeIdentifier = scopeIdentifier,
+        Start = start ?? new DateTimeOffset(2026, 7, 1, 0, 0, 0, TimeSpan.Zero),
+        End = end ?? new DateTimeOffset(2026, 7, 27, 0, 0, 0, TimeSpan.Zero)
+    };
+
+    [Fact]
+    public void Validate_HistoryQuery_ValidInput_NoErrors()
+    {
+        var result = _historyValidator.TestValidate(CreateHistoryQuery());
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void Validate_HistoryQuery_StartNotBeforeEnd_HasError()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var result = _historyValidator.TestValidate(CreateHistoryQuery(start: now, end: now));
+        result.ShouldHaveValidationErrorFor(x => x.Start);
+    }
+
+    [Fact]
+    public void Validate_HistoryQuery_WindowOverCap_HasError()
+    {
+        var start = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        var result = _historyValidator.TestValidate(CreateHistoryQuery(
+            start: start,
+            end: start.AddDays(DriftValidationRules.MaxHistoryWindowDays + 1)));
+        result.ShouldHaveValidationErrorFor(x => x.End);
+    }
+
+    [Fact]
+    public void Validate_HistoryQuery_WindowAtCap_NoErrors()
+    {
+        var start = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        var result = _historyValidator.TestValidate(CreateHistoryQuery(
+            start: start,
+            end: start.AddDays(DriftValidationRules.MaxHistoryWindowDays)));
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void Validate_HistoryQuery_EmptyScopeIdentifier_HasError()
+    {
+        var result = _historyValidator.TestValidate(CreateHistoryQuery(scopeIdentifier: ""));
+        result.ShouldHaveValidationErrorFor(x => x.ScopeIdentifier);
+    }
+
+    // == GetDriftAuditsQuery ==
+
+    [Fact]
+    public void Validate_AuditsQuery_Defaults_NoErrors()
+    {
+        var result = _auditsValidator.TestValidate(new GetDriftAuditsQuery());
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(DriftValidationRules.MaxAuditResults + 1)]
+    public void Validate_AuditsQuery_MaxResultsOutOfRange_HasError(int maxResults)
+    {
+        var result = _auditsValidator.TestValidate(new GetDriftAuditsQuery { MaxResults = maxResults });
+        result.ShouldHaveValidationErrorFor(x => x.MaxResults);
+    }
+
+    [Fact]
+    public void Validate_AuditsQuery_StartAfterEnd_HasError()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var result = _auditsValidator.TestValidate(new GetDriftAuditsQuery
+        {
+            Start = now,
+            End = now.AddDays(-1)
+        });
+        result.ShouldHaveValidationErrorFor(x => x.Start);
+    }
+
+    [Fact]
+    public void Validate_AuditsQuery_UndefinedRecordType_HasError()
+    {
+        var result = _auditsValidator.TestValidate(new GetDriftAuditsQuery
+        {
+            RecordType = (DriftAuditRecordType)99
+        });
+        result.ShouldHaveValidationErrorFor(x => x.RecordType);
+    }
+}

--- a/src/Content/Tests/Application.Core.Tests/CQRS/DriftDetection/DriftCommandValidationTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/CQRS/DriftDetection/DriftCommandValidationTests.cs
@@ -241,6 +241,22 @@ public sealed class DriftCommandValidationTests
         result.ShouldHaveValidationErrorFor(x => x.ScopeIdentifier);
     }
 
+    [Fact]
+    public void Validate_HistoryQuery_MissingScope_HasError()
+    {
+        // An omitted scope must not fall through to DriftScope.Agent (enum zero) and answer
+        // for a scope the caller never asked about.
+        var result = _historyValidator.TestValidate(CreateHistoryQuery() with { Scope = null });
+        result.ShouldHaveValidationErrorFor(x => x.Scope);
+    }
+
+    [Fact]
+    public void Validate_HistoryQuery_UndefinedScope_HasError()
+    {
+        var result = _historyValidator.TestValidate(CreateHistoryQuery() with { Scope = (DriftScope)42 });
+        result.ShouldHaveValidationErrorFor(x => x.Scope);
+    }
+
     // == GetDriftAuditsQuery ==
 
     [Fact]

--- a/src/Content/Tests/Application.Core.Tests/CQRS/DriftDetection/DriftQueryHandlerTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/CQRS/DriftDetection/DriftQueryHandlerTests.cs
@@ -1,0 +1,146 @@
+using Application.AI.Common.Interfaces.DriftDetection;
+using Application.Core.CQRS.DriftDetection;
+using Domain.AI.DriftDetection;
+using Domain.Common;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Application.Core.Tests.CQRS.DriftDetection;
+
+/// <summary>
+/// Tests for the drift read-query handlers: each read surfaces the real store/service data
+/// (no synthesis — an empty subsystem honestly returns empty), and the audits read enforces
+/// its result cap by keeping the most recent records.
+/// </summary>
+public sealed class DriftQueryHandlerTests
+{
+    // == GetDriftBaselinesQuery ==
+
+    [Fact]
+    public async Task HandleBaselines_ReturnsStoreDataAndPassesScopeFilterThrough()
+    {
+        var baselines = new[] { DriftTestData.CreateBaseline(), DriftTestData.CreateBaseline() };
+        var store = new Mock<IDriftBaselineStore>();
+        store
+            .Setup(s => s.GetBaselinesAsync(DriftScope.Skill, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<IReadOnlyList<DriftBaseline>>.Success(baselines));
+        var handler = new GetDriftBaselinesQueryHandler(
+            store.Object, NullLogger<GetDriftBaselinesQueryHandler>.Instance);
+
+        var result = await handler.Handle(
+            new GetDriftBaselinesQuery { Scope = DriftScope.Skill }, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeEquivalentTo(baselines,
+            "the read must surface exactly what the store holds");
+        store.Verify(s => s.GetBaselinesAsync(DriftScope.Skill, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleBaselines_EmptyStore_ReturnsEmptyListNotFailure()
+    {
+        var store = new Mock<IDriftBaselineStore>();
+        store
+            .Setup(s => s.GetBaselinesAsync(null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<IReadOnlyList<DriftBaseline>>.Success([]));
+        var handler = new GetDriftBaselinesQueryHandler(
+            store.Object, NullLogger<GetDriftBaselinesQueryHandler>.Instance);
+
+        var result = await handler.Handle(new GetDriftBaselinesQuery(), CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeEmpty(
+            "a fresh deployment where nothing has pushed evaluations is an honest empty system");
+    }
+
+    // == GetDriftHistoryQuery ==
+
+    [Fact]
+    public async Task HandleHistory_DelegatesToServiceWithTheExactWindow()
+    {
+        var scores = new[] { DriftTestData.CreateScore() };
+        var service = new Mock<IDriftDetectionService>();
+        DriftHistoryQuery? captured = null;
+        service
+            .Setup(s => s.GetDriftHistoryAsync(It.IsAny<DriftHistoryQuery>(), It.IsAny<CancellationToken>()))
+            .Callback<DriftHistoryQuery, CancellationToken>((q, _) => captured = q)
+            .ReturnsAsync(Result<IReadOnlyList<DriftScore>>.Success(scores));
+        var handler = new GetDriftHistoryQueryHandler(
+            service.Object, NullLogger<GetDriftHistoryQueryHandler>.Instance);
+
+        var start = new DateTimeOffset(2026, 7, 1, 0, 0, 0, TimeSpan.Zero);
+        var end = new DateTimeOffset(2026, 7, 27, 0, 0, 0, TimeSpan.Zero);
+        var result = await handler.Handle(new GetDriftHistoryQuery
+        {
+            Scope = DriftScope.Agent,
+            ScopeIdentifier = "agent-1",
+            Start = start,
+            End = end
+        }, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeEquivalentTo(scores);
+        captured.Should().NotBeNull();
+        captured!.Scope.Should().Be(DriftScope.Agent);
+        captured.ScopeIdentifier.Should().Be("agent-1");
+        captured.Start.Should().Be(start);
+        captured.End.Should().Be(end);
+    }
+
+    // == GetDriftAuditsQuery ==
+
+    [Fact]
+    public async Task HandleAudits_ReturnsStoreDataAndMapsFiltersThrough()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var records = new[] { DriftTestData.CreateAuditRecord(now) };
+        var store = new Mock<IDriftAuditStore>();
+        DriftAuditQuery? captured = null;
+        store
+            .Setup(s => s.GetRecordsAsync(It.IsAny<DriftAuditQuery>(), It.IsAny<CancellationToken>()))
+            .Callback<DriftAuditQuery, CancellationToken>((q, _) => captured = q)
+            .ReturnsAsync(Result<IReadOnlyList<DriftAuditRecord>>.Success(records));
+        var handler = new GetDriftAuditsQueryHandler(
+            store.Object, NullLogger<GetDriftAuditsQueryHandler>.Instance);
+
+        var eventId = Guid.NewGuid();
+        var result = await handler.Handle(new GetDriftAuditsQuery
+        {
+            Start = now.AddDays(-1),
+            End = now,
+            RecordType = DriftAuditRecordType.EvaluationPushed,
+            EventId = eventId
+        }, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeEquivalentTo(records);
+        captured.Should().NotBeNull();
+        captured!.RecordType.Should().Be(DriftAuditRecordType.EvaluationPushed);
+        captured.EventId.Should().Be(eventId);
+    }
+
+    [Fact]
+    public async Task HandleAudits_MoreMatchesThanCap_ReturnsMostRecentInChronologicalOrder()
+    {
+        var baseTime = new DateTimeOffset(2026, 7, 27, 0, 0, 0, TimeSpan.Zero);
+        var records = Enumerable.Range(0, 5)
+            .Select(i => DriftTestData.CreateAuditRecord(baseTime.AddMinutes(i)))
+            .ToList();
+        var store = new Mock<IDriftAuditStore>();
+        store
+            .Setup(s => s.GetRecordsAsync(It.IsAny<DriftAuditQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<IReadOnlyList<DriftAuditRecord>>.Success(records));
+        var handler = new GetDriftAuditsQueryHandler(
+            store.Object, NullLogger<GetDriftAuditsQueryHandler>.Instance);
+
+        var result = await handler.Handle(
+            new GetDriftAuditsQuery { MaxResults = 2 }, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().HaveCount(2);
+        // The cap keeps the newest activity, still chronologically ordered.
+        result.Value.Should().ContainInOrder(records[3], records[4]);
+    }
+}

--- a/src/Content/Tests/Application.Core.Tests/CQRS/DriftDetection/DriftTestData.cs
+++ b/src/Content/Tests/Application.Core.Tests/CQRS/DriftDetection/DriftTestData.cs
@@ -1,0 +1,56 @@
+using Domain.AI.DriftDetection;
+
+namespace Application.Core.Tests.CQRS.DriftDetection;
+
+/// <summary>Shared builders for drift CQRS tests.</summary>
+internal static class DriftTestData
+{
+    public static DriftScore CreateScore(
+        DriftScope scope = DriftScope.Skill,
+        string scopeIdentifier = "summarize",
+        DriftSeverity severity = DriftSeverity.None) => new()
+    {
+        ScoreId = Guid.NewGuid(),
+        BaselineId = Guid.NewGuid(),
+        Scope = scope,
+        ScopeIdentifier = scopeIdentifier,
+        Dimensions = new Dictionary<DriftDimension, DriftDimensionScore>
+        {
+            [DriftDimension.Faithfulness] = new()
+            {
+                CurrentValue = 0.85,
+                BaselineValue = 0.85,
+                EwmaValue = 0.85,
+                Deviation = 0.1
+            }
+        },
+        OverallDrift = 0.1,
+        Severity = severity,
+        ScoredAt = DateTimeOffset.UtcNow
+    };
+
+    public static DriftBaseline CreateBaseline(
+        Guid? baselineId = null,
+        DriftScope scope = DriftScope.Skill,
+        string scopeIdentifier = "summarize") => new()
+    {
+        BaselineId = baselineId ?? Guid.NewGuid(),
+        Scope = scope,
+        ScopeIdentifier = scopeIdentifier,
+        Dimensions = new Dictionary<DriftDimension, double> { [DriftDimension.Faithfulness] = 0.85 },
+        DimensionSigmas = new Dictionary<DriftDimension, double> { [DriftDimension.Faithfulness] = 0.02 },
+        SampleCount = 20,
+        WindowStart = DateTimeOffset.UtcNow.AddDays(-7),
+        WindowEnd = DateTimeOffset.UtcNow,
+        CreatedAt = DateTimeOffset.UtcNow
+    };
+
+    public static DriftAuditRecord CreateAuditRecord(DateTimeOffset recordedAt) => new()
+    {
+        RecordId = Guid.NewGuid(),
+        EventId = Guid.NewGuid(),
+        RecordType = DriftAuditRecordType.Detected,
+        Payload = "{}",
+        RecordedAt = recordedAt
+    };
+}

--- a/src/Content/Tests/Application.Core.Tests/CQRS/DriftDetection/PushDriftEvaluationCommandHandlerTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/CQRS/DriftDetection/PushDriftEvaluationCommandHandlerTests.cs
@@ -1,0 +1,226 @@
+using Application.AI.Common.Interfaces.DriftDetection;
+using Application.Core.CQRS.DriftDetection;
+using Domain.AI.DriftDetection;
+using Domain.Common;
+using Domain.Common.Config;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Time.Testing;
+using Moq;
+using Xunit;
+
+namespace Application.Core.Tests.CQRS.DriftDetection;
+
+/// <summary>
+/// Tests for <see cref="PushDriftEvaluationCommandHandler"/>: the push runs through the real
+/// drift pipeline (so it lands in EWMA state and history), every push is bracketed by
+/// attempt/outcome audit records carrying the token-derived caller identity, an unattributable
+/// push is refused outright, and a disabled subsystem refuses rather than reporting a hollow
+/// success — because pushed evaluations shape what the subsystem considers "normal".
+/// </summary>
+public sealed class PushDriftEvaluationCommandHandlerTests
+{
+    private readonly Mock<IDriftDetectionService> _driftService = new();
+    private readonly Mock<IDriftAuditStore> _auditStore = new();
+    private readonly AppConfig _appConfig = new();
+    private readonly FakeTimeProvider _timeProvider = new(new DateTimeOffset(2026, 7, 27, 12, 0, 0, TimeSpan.Zero));
+    private readonly List<DriftAuditRecord> _audited = [];
+    private readonly PushDriftEvaluationCommandHandler _handler;
+
+    public PushDriftEvaluationCommandHandlerTests()
+    {
+        _auditStore
+            .Setup(s => s.RecordAsync(It.IsAny<DriftAuditRecord>(), It.IsAny<CancellationToken>()))
+            .Callback<DriftAuditRecord, CancellationToken>((r, _) => _audited.Add(r))
+            .ReturnsAsync(Result.Success());
+        _handler = new PushDriftEvaluationCommandHandler(
+            _driftService.Object,
+            _auditStore.Object,
+            new StaticOptionsMonitor<AppConfig>(_appConfig),
+            _timeProvider,
+            NullLogger<PushDriftEvaluationCommandHandler>.Instance);
+    }
+
+    private static PushDriftEvaluationCommand CreateCommand(string callerId = "ops@contoso.com") => new()
+    {
+        Scope = DriftScope.Skill,
+        ScopeIdentifier = "summarize",
+        Dimensions = new Dictionary<DriftDimension, double>
+        {
+            [DriftDimension.Faithfulness] = 0.82,
+            [DriftDimension.Relevance] = 0.9
+        },
+        CallerId = callerId
+    };
+
+    private void SetupPipelineSuccess(DriftScore score) =>
+        _driftService
+            .Setup(s => s.EvaluateDriftAsync(It.IsAny<DriftEvaluationRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<DriftScore>.Success(score));
+
+    [Fact]
+    public async Task Handle_ServiceSucceeds_ReturnsScoreAndPassesDimensionsThroughUnchanged()
+    {
+        var score = DriftTestData.CreateScore();
+        DriftEvaluationRequest? captured = null;
+        _driftService
+            .Setup(s => s.EvaluateDriftAsync(It.IsAny<DriftEvaluationRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<DriftEvaluationRequest, CancellationToken>((r, _) => captured = r)
+            .ReturnsAsync(Result<DriftScore>.Success(score));
+
+        var command = CreateCommand();
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeSameAs(score, "the handler must surface the pipeline's real score");
+        captured.Should().NotBeNull();
+        captured!.Scope.Should().Be(command.Scope);
+        captured.ScopeIdentifier.Should().Be(command.ScopeIdentifier);
+        captured.Dimensions.Should().BeEquivalentTo(command.Dimensions,
+            "pushed scores must reach the EWMA pipeline exactly as validated");
+    }
+
+    [Fact]
+    public async Task Handle_ServiceSucceeds_AuditsAttemptThenOutcomeWithSharedActionId()
+    {
+        var score = DriftTestData.CreateScore();
+        SetupPipelineSuccess(score);
+
+        await _handler.Handle(CreateCommand("ops@contoso.com"), CancellationToken.None);
+
+        _audited.Should().HaveCount(2, "every push is bracketed by an attempt and an outcome record");
+        _audited.Should().AllSatisfy(r =>
+        {
+            r.RecordType.Should().Be(DriftAuditRecordType.EvaluationPushed);
+            r.Payload.Should().Contain("ops@contoso.com", "the caller identity is the point of the trail");
+            r.Payload.Should().Contain(DriftOperatorActionAudit.EvaluationPushAction);
+        });
+
+        _audited[0].Payload.Should().Contain("\"phase\":\"Attempt\"");
+        _audited[1].Payload.Should().Contain("\"phase\":\"Outcome\"");
+        _audited[1].EventId.Should().Be(score.ScoreId,
+            "the outcome record must correlate to the produced score for eventId queries");
+
+        var attemptActionId = _audited[0].EventId;
+        _audited[1].Payload.Should().Contain(attemptActionId.ToString(),
+            "both halves share an ActionId so an attempt with no outcome is detectable");
+    }
+
+    [Fact]
+    public async Task Handle_AttemptAuditFails_RefusesPushAndNeverReachesPipeline()
+    {
+        _auditStore
+            .Setup(s => s.RecordAsync(It.IsAny<DriftAuditRecord>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Fail("audit store unavailable"));
+        SetupPipelineSuccess(DriftTestData.CreateScore());
+
+        var result = await _handler.Handle(CreateCommand(), CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse(
+            "an unattributable push must be refused, not allowed through silently");
+        result.FailureType.Should().Be(ResultFailureType.Conflict);
+        _driftService.Verify(
+            s => s.EvaluateDriftAsync(It.IsAny<DriftEvaluationRequest>(), It.IsAny<CancellationToken>()),
+            Times.Never,
+            "filling the disk must not become a way to poison EWMA state with no trail");
+    }
+
+    [Fact]
+    public async Task Handle_AttemptAuditThrows_RefusesPushAndNeverReachesPipeline()
+    {
+        _auditStore
+            .Setup(s => s.RecordAsync(It.IsAny<DriftAuditRecord>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new UnauthorizedAccessException("AuditPath is not writable"));
+        SetupPipelineSuccess(DriftTestData.CreateScore());
+
+        var result = await _handler.Handle(CreateCommand(), CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.FailureType.Should().Be(ResultFailureType.Conflict);
+        result.Errors.Should().NotContain(e => e.Contains("AuditPath"),
+            "store internals must never reach the caller");
+        _driftService.Verify(
+            s => s.EvaluateDriftAsync(It.IsAny<DriftEvaluationRequest>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_DriftDetectionDisabled_ReturnsConflictAndNeverReachesPipeline()
+    {
+        _appConfig.AI.DriftDetection.Enabled = false;
+        SetupPipelineSuccess(DriftTestData.CreateScore());
+
+        var result = await _handler.Handle(CreateCommand(), CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse(
+            "the service's no-op success would report a push that never happened — through HTTP that is a 200 lie");
+        result.FailureType.Should().Be(ResultFailureType.Conflict,
+            "matching UpdateBaselineAsync's posture for the identical condition, and the controller's documented 409");
+        _driftService.Verify(
+            s => s.EvaluateDriftAsync(It.IsAny<DriftEvaluationRequest>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_DriftDetectionDisabled_AuditsRejectionAsFailedNotSucceeded()
+    {
+        _appConfig.AI.DriftDetection.Enabled = false;
+        SetupPipelineSuccess(DriftTestData.CreateScore());
+
+        await _handler.Handle(CreateCommand(), CancellationToken.None);
+
+        var outcome = _audited.Single(r => r.Payload.Contains("\"phase\":\"Outcome\""));
+        outcome.Payload.Should().Contain("\"succeeded\":false",
+            "a disabled subsystem must not leave a trail claiming successful monitoring");
+        outcome.Payload.Should().Contain("drift.conflict");
+        outcome.Payload.Should().NotContain("correlation_id",
+            "there is no score to correlate to when the push never ran");
+    }
+
+    [Fact]
+    public async Task Handle_ServiceFails_PropagatesFailureTypeAndAuditsFailedAttempt()
+    {
+        _driftService
+            .Setup(s => s.EvaluateDriftAsync(It.IsAny<DriftEvaluationRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<DriftScore>.Conflict("No baseline available for scope Skill:summarize"));
+
+        var result = await _handler.Handle(CreateCommand(), CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.FailureType.Should().Be(ResultFailureType.Conflict,
+            "no-baseline is an expected state the HTTP layer maps to 409");
+
+        var outcome = _audited.Single(r => r.Payload.Contains("\"phase\":\"Outcome\""));
+        outcome.Payload.Should().Contain("drift.conflict");
+        outcome.Payload.Should().NotContain("No baseline available",
+            "audit failure codes are stable classifications, never raw error text");
+    }
+
+    [Fact]
+    public async Task Handle_OutcomeAuditThrowsAfterSuccessfulAttempt_StillReturnsServiceResult()
+    {
+        var score = DriftTestData.CreateScore();
+        SetupPipelineSuccess(score);
+        var call = 0;
+        _auditStore
+            .Setup(s => s.RecordAsync(It.IsAny<DriftAuditRecord>(), It.IsAny<CancellationToken>()))
+            .Returns<DriftAuditRecord, CancellationToken>((_, _) =>
+                ++call == 1
+                    ? Task.FromResult(Result.Success())
+                    : throw new IOException("disk full"));
+
+        var result = await _handler.Handle(CreateCommand(), CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue(
+            "the attempt record already made the push attributable, so losing the outcome record must not fail the operation");
+    }
+}
+
+/// <summary>Minimal <see cref="IOptionsMonitor{T}"/> over a single mutable instance.</summary>
+internal sealed class StaticOptionsMonitor<T>(T value) : IOptionsMonitor<T>
+{
+    public T CurrentValue { get; } = value;
+    public T Get(string? name) => CurrentValue;
+    public IDisposable? OnChange(Action<T, string?> listener) => null;
+}

--- a/src/Content/Tests/Application.Core.Tests/CQRS/DriftDetection/RecalculateDriftBaselineCommandHandlerTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/CQRS/DriftDetection/RecalculateDriftBaselineCommandHandlerTests.cs
@@ -86,6 +86,9 @@ public sealed class RecalculateDriftBaselineCommandHandlerTests
         });
         OutcomeRecord().Payload.Should().Contain("drift.not_found",
             "probing baseline ids is operator activity worth attributing");
+        OutcomeRecord().Payload.Should().Contain(id.ToString(),
+            "an id sweep must leave outcome records naming the probed id, not records that only " +
+            "join back to the attempt half on ActionId");
     }
 
     [Fact]

--- a/src/Content/Tests/Application.Core.Tests/CQRS/DriftDetection/RecalculateDriftBaselineCommandHandlerTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/CQRS/DriftDetection/RecalculateDriftBaselineCommandHandlerTests.cs
@@ -1,0 +1,218 @@
+using Application.AI.Common.Interfaces.DriftDetection;
+using Application.Core.CQRS.DriftDetection;
+using Domain.AI.DriftDetection;
+using Domain.Common;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Time.Testing;
+using Moq;
+using Xunit;
+
+namespace Application.Core.Tests.CQRS.DriftDetection;
+
+/// <summary>
+/// Tests for <see cref="RecalculateDriftBaselineCommandHandler"/>: id-to-scope resolution
+/// through the store's indexed lookup with a clean 404 for unknown ids, delegation to the
+/// subsystem's own recalculation path, a fail-closed audit gate, and — critically — an outcome
+/// record that captures what the recalculation replaced and what it was built from, so the
+/// "launder poisoned evaluations into a new normal" step is reconstructible.
+/// </summary>
+public sealed class RecalculateDriftBaselineCommandHandlerTests
+{
+    private readonly Mock<IDriftDetectionService> _driftService = new();
+    private readonly Mock<IDriftBaselineStore> _baselineStore = new();
+    private readonly Mock<IDriftAuditStore> _auditStore = new();
+    private readonly FakeTimeProvider _timeProvider = new(new DateTimeOffset(2026, 7, 27, 12, 0, 0, TimeSpan.Zero));
+    private readonly List<DriftAuditRecord> _audited = [];
+    private readonly RecalculateDriftBaselineCommandHandler _handler;
+
+    public RecalculateDriftBaselineCommandHandlerTests()
+    {
+        _auditStore
+            .Setup(s => s.RecordAsync(It.IsAny<DriftAuditRecord>(), It.IsAny<CancellationToken>()))
+            .Callback<DriftAuditRecord, CancellationToken>((r, _) => _audited.Add(r))
+            .ReturnsAsync(Result.Success());
+        _handler = new RecalculateDriftBaselineCommandHandler(
+            _driftService.Object,
+            _baselineStore.Object,
+            _auditStore.Object,
+            _timeProvider,
+            NullLogger<RecalculateDriftBaselineCommandHandler>.Instance);
+    }
+
+    private static RecalculateDriftBaselineCommand CreateCommand(Guid baselineId) => new()
+    {
+        BaselineId = baselineId,
+        CallerId = "ops@contoso.com"
+    };
+
+    private void SetupLookup(Guid baselineId, DriftBaseline? found) =>
+        _baselineStore
+            .Setup(s => s.GetBaselineByIdAsync(baselineId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<DriftBaseline?>.Success(found));
+
+    private DriftAuditRecord OutcomeRecord() =>
+        _audited.Single(r => r.Payload.Contains("\"phase\":\"Outcome\""));
+
+    [Fact]
+    public async Task Handle_UnknownBaselineId_ReturnsNotFoundAndNeverRecalculates()
+    {
+        var id = Guid.NewGuid();
+        SetupLookup(id, null);
+
+        var result = await _handler.Handle(CreateCommand(id), CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.FailureType.Should().Be(ResultFailureType.NotFound,
+            "an unknown baseline id must map to 404 at the HTTP layer");
+        _driftService.Verify(
+            s => s.UpdateBaselineAsync(It.IsAny<DriftBaselineUpdateRequest>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_UnknownBaselineId_StillAuditsTheAttempt()
+    {
+        var id = Guid.NewGuid();
+        SetupLookup(id, null);
+
+        await _handler.Handle(CreateCommand(id), CancellationToken.None);
+
+        _audited.Should().HaveCount(2, "the attempt is recorded before the id is even resolved");
+        _audited.Should().AllSatisfy(r =>
+        {
+            r.RecordType.Should().Be(DriftAuditRecordType.BaselineRecalculationRequested);
+            r.Payload.Should().Contain("ops@contoso.com");
+        });
+        OutcomeRecord().Payload.Should().Contain("drift.not_found",
+            "probing baseline ids is operator activity worth attributing");
+    }
+
+    [Fact]
+    public async Task Handle_UsesIndexedLookupNotFullBaselineListing()
+    {
+        var id = Guid.NewGuid();
+        SetupLookup(id, DriftTestData.CreateBaseline(baselineId: id));
+        _driftService
+            .Setup(s => s.UpdateBaselineAsync(It.IsAny<DriftBaselineUpdateRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<DriftBaseline>.Success(DriftTestData.CreateBaseline()));
+
+        await _handler.Handle(CreateCommand(id), CancellationToken.None);
+
+        _baselineStore.Verify(s => s.GetBaselineByIdAsync(id, It.IsAny<CancellationToken>()), Times.Once);
+        _baselineStore.Verify(
+            s => s.GetBaselinesAsync(It.IsAny<DriftScope?>(), It.IsAny<CancellationToken>()),
+            Times.Never,
+            "resolving one id must not pull every baseline in the store on every request");
+    }
+
+    [Fact]
+    public async Task Handle_KnownBaselineId_RecalculatesUsingTheTargetScopeAndAuditsCaller()
+    {
+        var id = Guid.NewGuid();
+        var target = DriftTestData.CreateBaseline(
+            baselineId: id, scope: DriftScope.TaskType, scopeIdentifier: "qa-check");
+        var recalculated = DriftTestData.CreateBaseline(
+            scope: DriftScope.TaskType, scopeIdentifier: "qa-check");
+        SetupLookup(id, target);
+        DriftBaselineUpdateRequest? capturedRequest = null;
+        _driftService
+            .Setup(s => s.UpdateBaselineAsync(It.IsAny<DriftBaselineUpdateRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<DriftBaselineUpdateRequest, CancellationToken>((r, _) => capturedRequest = r)
+            .ReturnsAsync(Result<DriftBaseline>.Success(recalculated));
+
+        var result = await _handler.Handle(CreateCommand(id), CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeSameAs(recalculated);
+        capturedRequest.Should().NotBeNull();
+        capturedRequest!.Scope.Should().Be(DriftScope.TaskType,
+            "recalculation must target the scope the id resolved to");
+        capturedRequest.ScopeIdentifier.Should().Be("qa-check");
+
+        var outcome = OutcomeRecord();
+        outcome.EventId.Should().Be(recalculated.BaselineId,
+            "the audit record must correlate to the new baseline snapshot");
+        outcome.Payload.Should().Contain("ops@contoso.com");
+        outcome.Payload.Should().Contain(DriftOperatorActionAudit.BaselineRecalculateAction);
+    }
+
+    [Fact]
+    public async Task Handle_Success_AuditsPreviousBaselineIdAndTheWindowItConsumed()
+    {
+        var id = Guid.NewGuid();
+        var target = DriftTestData.CreateBaseline(baselineId: id);
+        var recalculated = DriftTestData.CreateBaseline() with
+        {
+            SampleCount = 42,
+            WindowStart = new DateTimeOffset(2026, 7, 20, 0, 0, 0, TimeSpan.Zero),
+            WindowEnd = new DateTimeOffset(2026, 7, 27, 0, 0, 0, TimeSpan.Zero)
+        };
+        SetupLookup(id, target);
+        _driftService
+            .Setup(s => s.UpdateBaselineAsync(It.IsAny<DriftBaselineUpdateRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<DriftBaseline>.Success(recalculated));
+
+        await _handler.Handle(CreateCommand(id), CancellationToken.None);
+
+        var payload = OutcomeRecord().Payload;
+        payload.Should().Contain(id.ToString(),
+            "the replaced baseline's id is the only surviving pointer to the prior 'normal' — SaveBaselineAsync overwrites it");
+        payload.Should().Contain("\"sample_count\":42");
+        payload.Should().Contain("2026-07-20",
+            "the consumed window lets a reviewer re-query exactly which evaluations fed the new baseline");
+        payload.Should().Contain("2026-07-27");
+    }
+
+    [Fact]
+    public async Task Handle_AttemptAuditFails_RefusesRecalculationAndNeverResolvesTarget()
+    {
+        _auditStore
+            .Setup(s => s.RecordAsync(It.IsAny<DriftAuditRecord>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Fail("audit store unavailable"));
+        var id = Guid.NewGuid();
+        SetupLookup(id, DriftTestData.CreateBaseline(baselineId: id));
+
+        var result = await _handler.Handle(CreateCommand(id), CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.FailureType.Should().Be(ResultFailureType.Conflict);
+        _driftService.Verify(
+            s => s.UpdateBaselineAsync(It.IsAny<DriftBaselineUpdateRequest>(), It.IsAny<CancellationToken>()),
+            Times.Never,
+            "recalculation destroys the previous snapshot; it must not run unattributed");
+    }
+
+    [Fact]
+    public async Task Handle_InsufficientHistory_PropagatesConflictAndAuditsFailure()
+    {
+        var id = Guid.NewGuid();
+        SetupLookup(id, DriftTestData.CreateBaseline(baselineId: id));
+        _driftService
+            .Setup(s => s.UpdateBaselineAsync(It.IsAny<DriftBaselineUpdateRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<DriftBaseline>.Conflict("Insufficient samples: 3/20"));
+
+        var result = await _handler.Handle(CreateCommand(id), CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.FailureType.Should().Be(ResultFailureType.Conflict,
+            "too-few-samples is an expected state the HTTP layer maps to 409");
+        OutcomeRecord().Payload.Should().Contain("drift.conflict");
+    }
+
+    [Fact]
+    public async Task Handle_BaselineLookupFails_PropagatesFailure()
+    {
+        var id = Guid.NewGuid();
+        _baselineStore
+            .Setup(s => s.GetBaselineByIdAsync(id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<DriftBaseline?>.Fail("store unavailable"));
+
+        var result = await _handler.Handle(CreateCommand(id), CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        _driftService.Verify(
+            s => s.UpdateBaselineAsync(It.IsAny<DriftBaselineUpdateRequest>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+}

--- a/src/Content/Tests/Application.Core.Tests/Validation/DriftDetectionConfigValidatorTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/Validation/DriftDetectionConfigValidatorTests.cs
@@ -29,6 +29,8 @@ public class DriftDetectionConfigValidatorTests
         config.EscalateThresholdSigma.Should().Be(3.0);
         config.EscalationEnabled.Should().BeTrue();
         config.AuditPath.Should().Be("data/audit");
+        config.CallerIdentityClaimType.Should().Be("oid",
+            "audit attribution should default to the immutable object id, not a reassignable sign-in name");
     }
 
     [Fact]
@@ -197,6 +199,38 @@ public class DriftDetectionConfigValidatorTests
 
         result.IsValid.Should().BeFalse();
         result.Errors.Should().Contain(e => e.PropertyName == "EscalateThresholdSigma");
+    }
+
+    [Theory]
+    [InlineData("oid")]
+    [InlineData("sub")]
+    [InlineData("preferred_username")]
+    [InlineData("upn")]
+    public async Task Validate_AllowlistedCallerIdentityClaimType_NoError(string claimType)
+    {
+        var config = CreateValidConfig();
+        config.CallerIdentityClaimType = claimType;
+
+        var result = await _validator.ValidateAsync(config);
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("email")]
+    [InlineData("name")]
+    [InlineData("OID")]
+    public async Task Validate_NonAllowlistedCallerIdentityClaimType_HasError(string claimType)
+    {
+        var config = CreateValidConfig();
+        config.CallerIdentityClaimType = claimType;
+
+        var result = await _validator.ValidateAsync(config);
+
+        result.IsValid.Should().BeFalse(
+            "only issuer-asserted identity claims may drive drift audit attribution");
+        result.Errors.Should().Contain(e => e.PropertyName == "CallerIdentityClaimType");
     }
 
     [Fact]

--- a/src/Content/Tests/Infrastructure.AI.Tests/DriftDetection/DefaultDriftDetectionServiceTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/DriftDetection/DefaultDriftDetectionServiceTests.cs
@@ -389,7 +389,10 @@ public sealed class DefaultDriftDetectionServiceTests
         var result = await service.EvaluateDriftAsync(CreateTestRequest(), CancellationToken.None);
 
         result.IsSuccess.Should().BeFalse();
-        result.Errors.Should().Contain(e => e.Contains("All dimensions failed"));
+        result.Errors.Should().Contain(e => e.Contains("No pushed dimension could be scored"));
+        result.FailureType.Should().Be(ResultFailureType.Conflict,
+            "this arm is reachable from valid input (a dimension the baseline does not carry), " +
+            "so HTTP surfaces must map it to 409 rather than an opaque 500");
     }
 
     [Fact]
@@ -453,6 +456,73 @@ public sealed class DefaultDriftDetectionServiceTests
 
         result.IsSuccess.Should().BeFalse();
         result.Errors.Should().Contain(e => e.Contains("Insufficient samples"));
+    }
+
+    [Fact]
+    public async Task UpdateBaseline_Success_AuditPayloadCarriesTheRecomputedBaseline()
+    {
+        SetupGraphSuccess();
+        SetupAuditSuccess();
+        _baselineStoreMock
+            .Setup(b => b.SaveBaselineAsync(It.IsAny<DriftBaseline>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Success());
+
+        // Two persisted evaluations are enough history with minSamples: 2.
+        var scoredAt = _timeProvider.GetUtcNow();
+        var historyNodes = Enumerable.Range(0, 2).Select(i => new GraphNode
+        {
+            Id = $"driftevent:{Guid.NewGuid()}",
+            Name = "DriftEvent",
+            Type = "DriftEvent",
+            OwnerId = "Skill:code_review",
+            Properties = new Dictionary<string, string>
+            {
+                ["ScoreId"] = Guid.NewGuid().ToString(),
+                ["BaselineId"] = Guid.NewGuid().ToString(),
+                ["Scope"] = "Skill",
+                ["ScopeIdentifier"] = "code_review",
+                ["Severity"] = "None",
+                ["OverallDrift"] = "0.1",
+                ["ScoredAt"] = scoredAt.AddMinutes(-i).ToString("o"),
+                ["DimensionsJson"] = System.Text.Json.JsonSerializer.Serialize(
+                    new Dictionary<DriftDimension, DriftDimensionScore>
+                    {
+                        [DriftDimension.Faithfulness] = new()
+                        {
+                            CurrentValue = 0.8, BaselineValue = 0.8, EwmaValue = 0.8, Deviation = 0.1
+                        }
+                    })
+            }.AsReadOnly()
+        }).ToList();
+
+        _graphStoreMock
+            .Setup(g => g.GetNodesByOwnerAsync("Skill:code_review", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(historyNodes.AsReadOnly());
+
+        DriftAuditRecord? audited = null;
+        _auditStoreMock
+            .Setup(a => a.RecordAsync(
+                It.Is<DriftAuditRecord>(r => r.RecordType == DriftAuditRecordType.BaselineUpdated),
+                It.IsAny<CancellationToken>()))
+            .Callback<DriftAuditRecord, CancellationToken>((r, _) => audited = r)
+            .ReturnsAsync(Result.Success());
+
+        var service = CreateService(minSamples: 2);
+        var result = await service.UpdateBaselineAsync(new DriftBaselineUpdateRequest
+        {
+            Scope = DriftScope.Skill,
+            ScopeIdentifier = "code_review"
+        }, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        audited.Should().NotBeNull();
+        audited!.Payload.Should().NotBe("{}",
+            "a content-free marker left the trail unable to answer what a recalculation changed, " +
+            "and SaveBaselineAsync had already overwritten the prior snapshot");
+        audited.Payload.Should().Contain(result.Value!.BaselineId.ToString());
+        audited.Payload.Should().Contain("SampleCount");
+        audited.EventId.Should().Be(result.Value.BaselineId,
+            "an empty-guid EventId made the documented eventId audit query return nothing");
     }
 
     // ===== GetBaselineAsync =====

--- a/src/Content/Tests/Presentation.AgentHub.Tests/Controllers/DriftControllerIntegrationTests.cs
+++ b/src/Content/Tests/Presentation.AgentHub.Tests/Controllers/DriftControllerIntegrationTests.cs
@@ -97,6 +97,39 @@ public sealed class DriftControllerIntegrationTests : IClassFixture<TestWebAppli
     }
 
     [Fact]
+    public async Task GetHistory_OmittedScope_Returns400NotAgentScopedData()
+    {
+        // DriftScope.Agent is the enum's zero value, so a non-nullable binding would have
+        // silently answered for Agent scope with a 200 while the caller believed they had
+        // asked for something else. A missing required filter must be a 400.
+        using var client = CreateAuthedClient(roles: DriftController.ReadRole);
+
+        var response = await client.GetAsync(
+            "/api/drift/history?scopeIdentifier=summarize" +
+            "&start=2026-07-01T00:00:00Z&end=2026-07-27T00:00:00Z");
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest,
+            "an omitted scope must be rejected, never defaulted to Agent");
+    }
+
+    [Fact]
+    public async Task GetHistory_WithScope_Returns200()
+    {
+        _factory.MockMediator
+            .Setup(m => m.Send(It.IsAny<GetDriftHistoryQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<IReadOnlyList<DriftScore>>.Success([]));
+
+        using var client = CreateAuthedClient(roles: DriftController.ReadRole);
+
+        var response = await client.GetAsync(
+            "/api/drift/history?scope=Skill&scopeIdentifier=summarize" +
+            "&start=2026-07-01T00:00:00Z&end=2026-07-27T00:00:00Z");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK,
+            "an explicit scope is the supported way to read history");
+    }
+
+    [Fact]
     public async Task PushEvaluation_WithReadRoleOnly_Returns403()
     {
         using var client = CreateAuthedClient(roles: DriftController.ReadRole);

--- a/src/Content/Tests/Presentation.AgentHub.Tests/Controllers/DriftControllerIntegrationTests.cs
+++ b/src/Content/Tests/Presentation.AgentHub.Tests/Controllers/DriftControllerIntegrationTests.cs
@@ -1,0 +1,208 @@
+using System.Net;
+using System.Net.Http.Json;
+using Application.Core.CQRS.DriftDetection;
+using Domain.AI.DriftDetection;
+using Domain.Common;
+using FluentAssertions;
+using MediatR;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Presentation.Common.Drift;
+using Xunit;
+
+namespace Presentation.AgentHub.Tests.Controllers;
+
+/// <summary>
+/// Wire-level tests for the drift API mounted into AgentHub via <c>AddDriftApi()</c>: the
+/// routes exist (opt-in wiring works end-to-end through the real host), role gating fails
+/// closed in both directions (the read role cannot write and the operate role cannot read),
+/// and the caller identity on writes comes from the token's <c>oid</c> claim — a spoofed
+/// caller-id field in the request body is ignored because no DTO binds it.
+/// </summary>
+public sealed class DriftControllerIntegrationTests : IClassFixture<TestWebApplicationFactory>
+{
+    private readonly TestWebApplicationFactory _factory;
+
+    public DriftControllerIntegrationTests(TestWebApplicationFactory factory) => _factory = factory;
+
+    private HttpClient CreateAuthedClient(string userId = "alice@contoso.com", string? roles = null)
+    {
+        var client = _factory
+            .WithWebHostBuilder(b => b.ConfigureTestServices(services =>
+                services.AddAuthentication(TestAuthHandler.SchemeName)
+                    .AddScheme<AuthenticationSchemeOptions, TestAuthHandler>(
+                        TestAuthHandler.SchemeName, _ => { })))
+            .CreateClient();
+        client.DefaultRequestHeaders.Add(TestAuthHandler.UserIdHeader, userId);
+        if (roles is not null)
+            client.DefaultRequestHeaders.Add(TestAuthHandler.RolesHeader, roles);
+        return client;
+    }
+
+    private static object CreateEvaluationBody() => new
+    {
+        scope = "Skill",
+        scopeIdentifier = "summarize",
+        dimensions = new Dictionary<string, double> { ["Faithfulness"] = 0.8 }
+    };
+
+    [Fact]
+    public async Task GetBaselines_Unauthenticated_Returns401()
+    {
+        // Also proves the routes are mounted at all: an unmounted route would 404, not challenge.
+        using var client = _factory.CreateClient();
+
+        var response = await client.GetAsync("/api/drift/baselines");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task GetBaselines_AuthenticatedWithoutReadRole_Returns403()
+    {
+        using var client = CreateAuthedClient();
+
+        var response = await client.GetAsync("/api/drift/baselines");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden,
+            "role gating must fail closed for authenticated callers without Harness.Drift.Read");
+    }
+
+    [Fact]
+    public async Task GetBaselines_WithOperateRoleOnly_Returns403()
+    {
+        using var client = CreateAuthedClient(roles: DriftController.OperateRole);
+
+        var response = await client.GetAsync("/api/drift/baselines");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden,
+            "role separation runs both ways: the ops write role must not imply read access");
+    }
+
+    [Fact]
+    public async Task GetBaselines_WithReadRole_Returns200()
+    {
+        _factory.MockMediator
+            .Setup(m => m.Send(It.IsAny<GetDriftBaselinesQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<IReadOnlyList<DriftBaseline>>.Success([]));
+
+        using var client = CreateAuthedClient(roles: DriftController.ReadRole);
+
+        var response = await client.GetAsync("/api/drift/baselines");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task PushEvaluation_WithReadRoleOnly_Returns403()
+    {
+        using var client = CreateAuthedClient(roles: DriftController.ReadRole);
+
+        var response = await client.PostAsJsonAsync("/api/drift/evaluations", CreateEvaluationBody());
+
+        // No Times.Never verify here: MockMediator is fixture-shared across this class, so
+        // other tests' legitimate sends would pollute the count. The 403 itself proves the
+        // request never reached the pipeline for THIS call — MVC rejects before the action runs.
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden,
+            "a reader must never be able to push evaluations — that is the poisoning boundary");
+    }
+
+    [Fact]
+    public async Task PushEvaluation_WithOperateRole_StampsCallerFromTokenAndIgnoresBodyField()
+    {
+        PushDriftEvaluationCommand? captured = null;
+        _factory.MockMediator
+            .Setup(m => m.Send(It.IsAny<PushDriftEvaluationCommand>(), It.IsAny<CancellationToken>()))
+            .Callback<IRequest<Result<DriftScore>>, CancellationToken>(
+                (c, _) => captured = (PushDriftEvaluationCommand)c)
+            .ReturnsAsync(Result<DriftScore>.Success(new DriftScore
+            {
+                ScoreId = Guid.NewGuid(),
+                BaselineId = Guid.NewGuid(),
+                Scope = DriftScope.Skill,
+                ScopeIdentifier = "summarize",
+                Dimensions = new Dictionary<DriftDimension, DriftDimensionScore>(),
+                OverallDrift = 0.2,
+                Severity = DriftSeverity.None,
+                ScoredAt = DateTimeOffset.UtcNow
+            }));
+
+        using var client = CreateAuthedClient("ops@contoso.com", DriftController.OperateRole);
+
+        // The spoofed callerId member has no binding target on the DTO and must be ignored.
+        var response = await client.PostAsJsonAsync("/api/drift/evaluations", new
+        {
+            scope = "Skill",
+            scopeIdentifier = "summarize",
+            dimensions = new Dictionary<string, double> { ["Faithfulness"] = 0.8 },
+            callerId = "mallory@evil.example"
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        captured.Should().NotBeNull();
+        captured!.CallerId.Should().Be("ops@contoso.com",
+            "the caller identity must come from the authenticated principal's oid claim, never the body");
+        captured.Dimensions.Should().ContainKey(DriftDimension.Faithfulness);
+    }
+
+    [Fact]
+    public async Task RecalculateBaseline_WithOperateRole_Returns200AndStampsCaller()
+    {
+        var baselineId = Guid.NewGuid();
+        RecalculateDriftBaselineCommand? captured = null;
+        _factory.MockMediator
+            .Setup(m => m.Send(It.IsAny<RecalculateDriftBaselineCommand>(), It.IsAny<CancellationToken>()))
+            .Callback<IRequest<Result<DriftBaseline>>, CancellationToken>(
+                (c, _) => captured = (RecalculateDriftBaselineCommand)c)
+            .ReturnsAsync(Result<DriftBaseline>.Success(new DriftBaseline
+            {
+                BaselineId = Guid.NewGuid(),
+                Scope = DriftScope.Skill,
+                ScopeIdentifier = "summarize",
+                Dimensions = new Dictionary<DriftDimension, double>(),
+                DimensionSigmas = new Dictionary<DriftDimension, double>(),
+                SampleCount = 25,
+                WindowStart = DateTimeOffset.UtcNow.AddDays(-7),
+                WindowEnd = DateTimeOffset.UtcNow,
+                CreatedAt = DateTimeOffset.UtcNow
+            }));
+
+        using var client = CreateAuthedClient("ops@contoso.com", DriftController.OperateRole);
+
+        var response = await client.PostAsync($"/api/drift/baselines/{baselineId}/recalculate", null);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        captured.Should().NotBeNull();
+        captured!.BaselineId.Should().Be(baselineId);
+        captured.CallerId.Should().Be("ops@contoso.com");
+    }
+
+    [Fact]
+    public async Task RecalculateBaseline_UnknownId_Returns404()
+    {
+        _factory.MockMediator
+            .Setup(m => m.Send(It.IsAny<RecalculateDriftBaselineCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<DriftBaseline>.NotFound("No baseline with the given id."));
+
+        using var client = CreateAuthedClient("ops@contoso.com", DriftController.OperateRole);
+
+        var response = await client.PostAsync($"/api/drift/baselines/{Guid.NewGuid()}/recalculate", null);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound,
+            "an unknown baseline id maps through the shared failure mapper to 404");
+    }
+
+    [Fact]
+    public async Task RecalculateBaseline_WithReadRoleOnly_Returns403()
+    {
+        using var client = CreateAuthedClient(roles: DriftController.ReadRole);
+
+        var response = await client.PostAsync($"/api/drift/baselines/{Guid.NewGuid()}/recalculate", null);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden,
+            "recalculation re-anchors 'normal' — an operator power the read role must not grant");
+    }
+}

--- a/src/Content/Tests/Presentation.BundleApi.Tests/DriftRoutesNotMountedTests.cs
+++ b/src/Content/Tests/Presentation.BundleApi.Tests/DriftRoutesNotMountedTests.cs
@@ -1,0 +1,44 @@
+using System.Net;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+
+namespace Presentation.BundleApi.Tests;
+
+/// <summary>
+/// Proves the drift API's opt-in gate against the exact real host it exists to protect.
+/// BundleApi references <c>Presentation.Common</c> and calls <c>AddControllers()</c>, so the Web
+/// SDK auto-registers Presentation.Common as an MVC application part and
+/// <c>DriftController</c> IS discovered here — but BundleApi never calls <c>AddDriftApi()</c>,
+/// so the opt-in action constraint must keep every drift route un-matched. Drift state (stores,
+/// EWMA, escalation bridge) lives in the workload host; a bundle host must not accidentally
+/// expose evaluation-push or baseline-recalculation endpoints.
+/// </summary>
+public sealed class DriftRoutesNotMountedTests : IClassFixture<WebApplicationFactory<Program>>
+{
+    private readonly WebApplicationFactory<Program> _factory;
+
+    public DriftRoutesNotMountedTests(WebApplicationFactory<Program> factory)
+    {
+        _factory = factory;
+    }
+
+    [Theory]
+    [InlineData("GET", "/api/drift/baselines")]
+    [InlineData("GET", "/api/drift/history")]
+    [InlineData("GET", "/api/drift/audits")]
+    [InlineData("POST", "/api/drift/evaluations")]
+    [InlineData("POST", "/api/drift/baselines/00000000-0000-0000-0000-000000000001/recalculate")]
+    public async Task DriftRoute_InNonOptedHost_Returns404NotAChallenge(string method, string path)
+    {
+        // 404 specifically — not 401/403. The gate is an action constraint that un-matches the
+        // route before authentication, so a probe cannot even learn the routes exist.
+        var client = _factory.CreateClient();
+
+        using var request = new HttpRequestMessage(new HttpMethod(method), path);
+        var response = await client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound,
+            "a host that never called AddDriftApi() must not expose drift routes");
+    }
+}

--- a/src/Content/Tests/Presentation.Common.Tests/Drift/DriftApiMountingTests.cs
+++ b/src/Content/Tests/Presentation.Common.Tests/Drift/DriftApiMountingTests.cs
@@ -1,0 +1,159 @@
+using System.Net;
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+using Application.Core.CQRS.DriftDetection;
+using Domain.AI.DriftDetection;
+using Domain.Common;
+using MediatR;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using FluentAssertions;
+using Presentation.Common.Drift;
+using Xunit;
+
+namespace Presentation.Common.Tests.Drift;
+
+/// <summary>
+/// Proves the drift API's opt-in mounting semantics against real hosts, mirroring the
+/// escalation API's gate:
+/// <list type="number">
+///   <item><description>A host that merely references the assembly (no application part, no
+///   marker) has no drift routes.</description></item>
+///   <item><description>A host where the assembly IS an application part — which the Web SDK
+///   does automatically for any MVC host referencing <c>Presentation.Common</c> — still has no
+///   drift routes without the marker: the action constraint un-matches them, yielding a plain
+///   404 before authentication. This is the case that makes the opt-in real.</description></item>
+///   <item><description>A host that called <c>AddDriftApi()</c> serves the routes.</description></item>
+/// </list>
+/// </summary>
+public sealed class DriftApiMountingTests
+{
+    [Fact]
+    public async Task Host_WithoutPartOrMarker_HasNoDriftRoutes()
+    {
+        using var host = await BuildHostAsync(mvc => { });
+
+        var response = await host.GetTestClient().GetAsync("/api/drift/baselines");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound,
+            "a host that never mounted the API must not expose its routes");
+    }
+
+    [Fact]
+    public async Task Host_WithApplicationPartButNoMarker_StillHasNoDriftRoutes()
+    {
+        // Simulates the Web SDK's automatic ApplicationPartAttribute for referenced MVC
+        // assemblies: the controller IS discovered, but the opt-in constraint must keep every
+        // route un-matched — a plain 404, not a 401 challenge that would reveal the route.
+        using var host = await BuildHostAsync(mvc =>
+            mvc.AddApplicationPart(typeof(DriftController).Assembly));
+
+        var response = await host.GetTestClient().GetAsync("/api/drift/baselines");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound,
+            "auto-discovery of the application part must not arm the routes without AddDriftApi()");
+    }
+
+    [Fact]
+    public async Task Host_WithAddDriftApi_ServesDriftRoutes()
+    {
+        using var host = await BuildHostAsync(mvc => mvc.AddDriftApi());
+
+        var response = await host.GetTestClient().GetAsync("/api/drift/baselines");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK,
+            "AddDriftApi() must arm the routes for an authorized caller");
+    }
+
+    [Fact]
+    public async Task Host_WithAddDriftApi_UnauthenticatedProbeIsChallengedNotHidden()
+    {
+        using var host = await BuildHostAsync(mvc => mvc.AddDriftApi(), authenticate: false);
+
+        var response = await host.GetTestClient().GetAsync("/api/drift/baselines");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized,
+            "an armed host enforces authentication on the mounted routes");
+    }
+
+    /// <summary>
+    /// Builds a minimal MVC host on TestServer with a permissive authentication scheme (read
+    /// role + oid identity claim), a stubbed mediator, and the caller-selected MVC configuration.
+    /// </summary>
+    private static async Task<IHost> BuildHostAsync(
+        Action<IMvcBuilder> configureMvc, bool authenticate = true)
+    {
+        var mediator = new Mock<IMediator>();
+        mediator.Setup(m => m.Send(It.IsAny<GetDriftBaselinesQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<IReadOnlyList<DriftBaseline>>.Success([]));
+
+        var host = await new HostBuilder()
+            .ConfigureWebHost(webHost => webHost
+                .UseTestServer()
+                .ConfigureServices(services =>
+                {
+                    services.AddOptions();
+                    services.AddSingleton(mediator.Object);
+                    configureMvc(services.AddControllers());
+                    var auth = services.AddAuthentication(PermissiveAuthHandler.SchemeName);
+                    if (authenticate)
+                    {
+                        auth.AddScheme<AuthenticationSchemeOptions, PermissiveAuthHandler>(
+                            PermissiveAuthHandler.SchemeName, _ => { });
+                    }
+                    else
+                    {
+                        auth.AddScheme<AuthenticationSchemeOptions, AnonymousChallengeHandler>(
+                            PermissiveAuthHandler.SchemeName, _ => { });
+                    }
+                    services.AddAuthorization();
+                })
+                .Configure(app =>
+                {
+                    app.UseRouting();
+                    app.UseAuthentication();
+                    app.UseAuthorization();
+                    app.UseEndpoints(endpoints => endpoints.MapControllers());
+                }))
+            .StartAsync();
+
+        return host;
+    }
+
+    /// <summary>Authenticates every request as an operator holding the read role.</summary>
+    private sealed class PermissiveAuthHandler(
+        IOptionsMonitor<AuthenticationSchemeOptions> options,
+        ILoggerFactory logger,
+        UrlEncoder encoder) : AuthenticationHandler<AuthenticationSchemeOptions>(options, logger, encoder)
+    {
+        public const string SchemeName = "DriftMountingTest";
+
+        protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+        {
+            var identity = new ClaimsIdentity(
+            [
+                new Claim("oid", "ops-object-id"),
+                new Claim(ClaimTypes.Role, DriftController.ReadRole),
+            ], SchemeName);
+            return Task.FromResult(AuthenticateResult.Success(
+                new AuthenticationTicket(new ClaimsPrincipal(identity), SchemeName)));
+        }
+    }
+
+    /// <summary>Never authenticates, so [Authorize] endpoints challenge with 401.</summary>
+    private sealed class AnonymousChallengeHandler(
+        IOptionsMonitor<AuthenticationSchemeOptions> options,
+        ILoggerFactory logger,
+        UrlEncoder encoder) : AuthenticationHandler<AuthenticationSchemeOptions>(options, logger, encoder)
+    {
+        protected override Task<AuthenticateResult> HandleAuthenticateAsync() =>
+            Task.FromResult(AuthenticateResult.NoResult());
+    }
+}

--- a/src/Content/Tests/Presentation.Common.Tests/Drift/DriftControllerIdentityTests.cs
+++ b/src/Content/Tests/Presentation.Common.Tests/Drift/DriftControllerIdentityTests.cs
@@ -1,0 +1,222 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+using Application.Core.CQRS.DriftDetection;
+using Domain.AI.DriftDetection;
+using Domain.Common;
+using MediatR;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using FluentAssertions;
+using Presentation.Common.Drift;
+using Xunit;
+
+namespace Presentation.Common.Tests.Drift;
+
+/// <summary>
+/// Proves the drift write endpoints' caller-identity contract at the wire level:
+/// <list type="bullet">
+///   <item><description>Union resolution — a production-shaped principal carrying only the JWT
+///   inbound-MAPPED objectidentifier URI (never the short <c>oid</c>) still resolves, because
+///   resolution searches <c>ApproverClaimTypes.EquivalentFormsOf</c>.</description></item>
+///   <item><description>Ambiguity is rejected — two distinct oid values yield 403, never a
+///   silent first-pick an attacker could exploit by smuggling a second claim.</description></item>
+///   <item><description>The same value under both forms counts as one identity.</description></item>
+///   <item><description>A body-supplied caller-id field is ignored: no DTO binds it, the token
+///   always wins.</description></item>
+/// </list>
+/// </summary>
+public sealed class DriftControllerIdentityTests
+{
+    private const string MappedOidUri = "http://schemas.microsoft.com/identity/claims/objectidentifier";
+
+    private static readonly object ValidBody = new
+    {
+        scope = 1, // DriftScope.Skill (numeric: the minimal host has no string-enum converter)
+        scopeIdentifier = "summarize",
+        dimensions = new Dictionary<string, double> { ["Faithfulness"] = 0.8 }
+    };
+
+    [Fact]
+    public async Task PushEvaluation_MappedUriFormClaimOnly_ResolvesViaUnionAndStampsCaller()
+    {
+        var (host, mediator) = await BuildHostAsync([new Claim(MappedOidUri, "ops-object-id")]);
+        using var _ = host;
+        PushDriftEvaluationCommand? captured = null;
+        SetupPush(mediator, c => captured = c);
+
+        var response = await host.GetTestClient()
+            .PostAsJsonAsync("/api/drift/evaluations", ValidBody);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK,
+            "production tokens carry the inbound-mapped URI form, and it must resolve");
+        captured.Should().NotBeNull();
+        captured!.CallerId.Should().Be("ops-object-id",
+            "the identity must come from the mapped claim form on the token");
+    }
+
+    [Fact]
+    public async Task PushEvaluation_TwoDistinctOidValues_Returns403FailClosed()
+    {
+        var (host, mediator) = await BuildHostAsync(
+        [
+            new Claim("oid", "real-operator"),
+            new Claim("oid", "smuggled-operator"),
+        ]);
+        using var _ = host;
+        SetupPush(mediator, _ => { });
+
+        var response = await host.GetTestClient()
+            .PostAsJsonAsync("/api/drift/evaluations", ValidBody);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden,
+            "an ambiguous identity is no identity — the attacker must not choose which value wins");
+        mediator.Verify(
+            m => m.Send(It.IsAny<PushDriftEvaluationCommand>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task PushEvaluation_SameValueUnderBothForms_CountsAsOneIdentity()
+    {
+        var (host, mediator) = await BuildHostAsync(
+        [
+            new Claim("oid", "ops-object-id"),
+            new Claim(MappedOidUri, "ops-object-id"),
+        ]);
+        using var _ = host;
+        PushDriftEvaluationCommand? captured = null;
+        SetupPush(mediator, c => captured = c);
+
+        var response = await host.GetTestClient()
+            .PostAsJsonAsync("/api/drift/evaluations", ValidBody);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK,
+            "one value appearing under short and mapped forms is one identity, not an ambiguity");
+        captured!.CallerId.Should().Be("ops-object-id");
+    }
+
+    [Fact]
+    public async Task PushEvaluation_NoIdentityClaim_Returns403FailClosed()
+    {
+        var (host, mediator) = await BuildHostAsync([]);
+        using var _ = host;
+        SetupPush(mediator, _ => { });
+
+        var response = await host.GetTestClient()
+            .PostAsJsonAsync("/api/drift/evaluations", ValidBody);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden,
+            "a write that cannot be attributed in the audit trail must not run");
+    }
+
+    [Fact]
+    public async Task PushEvaluation_BodyCallerIdField_IsIgnoredTokenWins()
+    {
+        var (host, mediator) = await BuildHostAsync([new Claim("oid", "real-operator")]);
+        using var _ = host;
+        PushDriftEvaluationCommand? captured = null;
+        SetupPush(mediator, c => captured = c);
+
+        // The spoofed callerId member has no binding target on the DTO and must be ignored.
+        var response = await host.GetTestClient().PostAsJsonAsync("/api/drift/evaluations", new
+        {
+            scope = 1,
+            scopeIdentifier = "summarize",
+            dimensions = new Dictionary<string, double> { ["Faithfulness"] = 0.8 },
+            callerId = "mallory@evil.example"
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        captured.Should().NotBeNull();
+        captured!.CallerId.Should().Be("real-operator",
+            "a body-supplied caller id must never influence the stamped identity");
+    }
+
+    private static void SetupPush(Mock<IMediator> mediator, Action<PushDriftEvaluationCommand> capture)
+    {
+        mediator
+            .Setup(m => m.Send(It.IsAny<PushDriftEvaluationCommand>(), It.IsAny<CancellationToken>()))
+            .Callback<IRequest<Result<DriftScore>>, CancellationToken>(
+                (c, _) => capture((PushDriftEvaluationCommand)c))
+            .ReturnsAsync(Result<DriftScore>.Success(new DriftScore
+            {
+                ScoreId = Guid.NewGuid(),
+                BaselineId = Guid.NewGuid(),
+                Scope = DriftScope.Skill,
+                ScopeIdentifier = "summarize",
+                Dimensions = new Dictionary<DriftDimension, DriftDimensionScore>(),
+                OverallDrift = 0.0,
+                Severity = DriftSeverity.None,
+                ScoredAt = DateTimeOffset.UtcNow
+            }));
+    }
+
+    /// <summary>
+    /// Builds a minimal MVC host with the drift API mounted, an authentication scheme minting
+    /// the supplied identity claims plus the operate role, and a mockable mediator. The default
+    /// <c>AppConfig</c> is used, so the configured caller identity claim type is <c>oid</c>.
+    /// </summary>
+    private static async Task<(IHost Host, Mock<IMediator> Mediator)> BuildHostAsync(
+        IReadOnlyList<Claim> identityClaims)
+    {
+        var mediator = new Mock<IMediator>();
+
+        var host = await new HostBuilder()
+            .ConfigureWebHost(webHost => webHost
+                .UseTestServer()
+                .ConfigureServices(services =>
+                {
+                    services.AddOptions();
+                    services.AddSingleton(mediator.Object);
+                    services.AddSingleton<IReadOnlyList<Claim>>(identityClaims);
+                    services.AddControllers().AddDriftApi();
+                    services.AddAuthentication(ClaimListAuthHandler.SchemeName)
+                        .AddScheme<AuthenticationSchemeOptions, ClaimListAuthHandler>(
+                            ClaimListAuthHandler.SchemeName, _ => { });
+                    services.AddAuthorization();
+                })
+                .Configure(app =>
+                {
+                    app.UseRouting();
+                    app.UseAuthentication();
+                    app.UseAuthorization();
+                    app.UseEndpoints(endpoints => endpoints.MapControllers());
+                }))
+            .StartAsync();
+
+        return (host, mediator);
+    }
+
+    /// <summary>
+    /// Authenticates every request with the DI-supplied identity claims plus the operate role,
+    /// letting each test shape the principal's identity claims exactly.
+    /// </summary>
+    private sealed class ClaimListAuthHandler(
+        IOptionsMonitor<AuthenticationSchemeOptions> options,
+        ILoggerFactory logger,
+        UrlEncoder encoder,
+        IReadOnlyList<Claim> identityClaims)
+        : AuthenticationHandler<AuthenticationSchemeOptions>(options, logger, encoder)
+    {
+        public const string SchemeName = "DriftIdentityTest";
+
+        protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+        {
+            var claims = identityClaims
+                .Append(new Claim(ClaimTypes.Role, DriftController.OperateRole))
+                .ToList();
+            var identity = new ClaimsIdentity(claims, SchemeName);
+            return Task.FromResult(AuthenticateResult.Success(
+                new AuthenticationTicket(new ClaimsPrincipal(identity), SchemeName)));
+        }
+    }
+}


### PR DESCRIPTION
Part of the external-trigger API program (Wave 2). Scope doc: `.claude/plans/external-trigger-api-scope.md` §4, H4 row.

## What this adds

- `GET /api/drift/baselines` · `GET /api/drift/history` · `GET /api/drift/audits` — role `Harness.Drift.Read`
- `POST /api/drift/evaluations` · `POST /api/drift/baselines/{id}/recalculate` — role `Harness.Drift.Operate`

Built on the existing drift services (EWMA scoring, baselines, `DriftEscalationBridge`). No drift math was duplicated or changed. Role separation is two-way: an Operate holder does not inherit Read, and vice versa.

**There is deliberately no "run a drift scan" endpoint.** Drift is push-based — callers supply dimension scores and there is no internal collector — so a parameterless scan would be a fiction. Reads may return an empty system until something pushes; that is honest, not broken.

## Threat model and what the reviews changed

Evaluation-push is a **history-poisoning vector**: whoever can post scores can shift baselines to mask real drift, or fabricate drift to trigger spurious escalations. Access control alone can't neutralise that — the compensating control is the audit trail. The security review found three ways this PR weakened that trail, all now fixed:

**A disabled subsystem still answered 200 and logged success.** With drift detection turned off, the evaluate call returned an all-zero score that was never stored, while the handler recorded `Succeeded=true` against a score id that did not exist. Flipping one config value would silently stop monitoring with the API and the audit trail both still reporting healthy pushes — the "mask real drift" outcome reached through configuration instead of data. The handler now short-circuits to 409 and audits the rejection. The service's disabled arm is untouched, so ConsoleUI's no-op success path still works.

**Recalculation left no reconstructible evidence.** Success was audited with a null score, which wrote `EventId = Guid.Empty` and an empty `{}` payload, while the operator record carried only caller, scope, and the new baseline id — and `SaveBaselineAsync` overwrites the prior baseline. So the laundering path (push poisoned scores, then recalculate them into the new "normal") left proof that someone recalculated but not what it did, with no way to compute the delta. `DriftOperatorActionAudit` now carries `PreviousBaselineId`, `SampleCount`, `WindowStart`, and `WindowEnd`, and the service serializes the real `DriftBaseline` per its own documented contract with `EventId = BaselineId` — which incidentally makes the `?eventId=` correlation the XML docs promised actually resolve.

**The audit append was fail-open.** Both a failed result and a thrown exception were swallowed with a log line, diverging from the escalation precedent this PR cites, which is explicitly fail-closed. Escalation can be fail-closed because it audits the request *before* mutating; drift audited *after*. So anyone able to break the audit store — fill the disk, revoke write permission on the audit path — got unattributed poisoning: pushes still advanced EWMA, still persisted, still returned 200, and nothing landed in the trail. Now split into a fail-**closed** attempt record appended before dispatch (refusing the write with a scrubbed `drift.audit_unavailable`) and the existing fail-open outcome record after, sharing an `ActionId` so an attempt with no outcome is itself detectable.

## Security posture

Caller identity for writes is stamped from token claims via `ApproverClaimTypes.EquivalentFormsOf()` (short form plus the JWT inbound-mapped URI), requires exactly one distinct value, and fails closed to 403 with nothing dispatched. No wire shape carries a caller field. The claim type is configurable via `DriftDetectionConfig.CallerIdentityClaimType` (default `oid`) and allowlisted at startup with `ValidateOnStart` — deliberately **not** conditioned on whether drift is enabled, which is the mistake found in the sibling change-proposal PR.

Poison guards were verified un-bypassable, not just present: NaN, ±Infinity, and out-of-range values are rejected at the validation boundary, and System.Text.Json rejects both `"Infinity"` strings and `1e400` overflow at deserialization before a handler ever runs. Caps on dimension count (16), history window (90 days), and audit results (1000) are enforced and tested.

The two new `DriftAuditRecordType` members are appended at the end of the enum, so pre-existing serialized records are byte-identical and hash-chain verification is unaffected.

## Behaviour changes worth flagging

- Three failure conditions in `DefaultDriftDetectionService` were reclassified from a general failure to `Conflict` (no baseline, subsystem disabled, insufficient samples) so they surface as 409 rather than an opaque 500. This changes failure-type classification only — the drift computation is untouched. Every call site was read: the learnings bridge discards `FailureType` entirely and ConsoleUI branches on `IsSuccess`, so nothing switches on the changed value.
- "All dimensions failed scoring" is reachable from valid input (a dimension the baseline lacks), so it is now a 409 with a clearer message rather than a 500.
- The rate-limit partition now keys on the configured identity claim rather than `oid` only — otherwise a host configured for `sub` or `preferred_username` would collapse every operator into one shared IP-keyed bucket.

## Tracked follow-up, not in this PR

The claim-resolution block and the opt-in mount trio are now their fourth copies (Escalations, ChangeProposals, Governance, Drift). Sibling PRs were in flight touching the same files, so extraction mid-batch would have guaranteed conflicts; one consolidation chore extracts a shared identity resolver and a generic `RequiresApiOptIn<TMarker>` once the batch lands.

## Test plan

- Identity resolution incl. long-form mapped URIs and body-spoof rejection; role separation in both directions; unknown baseline 404; poison-value rejection; audit content assertions for both the attempt and outcome records; not-mounted 404 in a real non-opted host.
- `dotnet build src/AgenticHarness.slnx` — 0 errors, 0 new warnings.
- `dotnet test src/AgenticHarness.slnx` — 21/21 projects green after merging main, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BnoLcufW278UxA9ssBM1Tc