### PR TITLE
feat: confine plan execution to the caller capability envelope (W2)

### DIFF
--- a/src/Content/Application/Application.AI.Common/Factories/AgentExecutionContextFactory.cs
+++ b/src/Content/Application/Application.AI.Common/Factories/AgentExecutionContextFactory.cs
@@ -479,7 +479,8 @@ public class AgentExecutionContextFactory
         // Inert (and skipped entirely) when enforcement is off, so default behaviour is unchanged.
         if (_appConfig.CurrentValue.AI?.Governance?.EnforceToolInvocation == true)
         {
-            providers.Add(new Services.Agent.GoverningToolContextProvider());
+            providers.Add(new Services.Agent.GoverningToolContextProvider(
+                _loggerFactory.CreateLogger<Services.Agent.GoverningToolContextProvider>()));
             _logger.LogDebug("Wired GoverningToolContextProvider (tool-invocation enforcement enabled)");
         }
 

--- a/src/Content/Application/Application.AI.Common/Interfaces/Permissions/IPatternMatcher.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Permissions/IPatternMatcher.cs
@@ -13,4 +13,24 @@ public interface IPatternMatcher
     /// <param name="value">The value to test.</param>
     /// <returns>True if the value matches the pattern.</returns>
     bool IsMatch(string pattern, string value);
+
+    /// <summary>
+    /// Ranks how narrowly <paramref name="pattern"/> selects values, so a caller can prefer the most
+    /// specific of several patterns that all match the same value. Higher is more specific.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Only the matcher knows its own pattern language, so the rank lives here rather than being
+    /// re-derived by every consumer. Implementations must satisfy one contract: for any value, an
+    /// exact-match pattern ranks strictly above every wildcard pattern that also matches it, and a
+    /// match-everything pattern ranks lowest. Callers rely on that ordering to stop a catch-all rule
+    /// from overriding a rule written for one specific name.
+    /// </para>
+    /// <para>
+    /// Ranks are comparable only against each other; the absolute values carry no meaning.
+    /// </para>
+    /// </remarks>
+    /// <param name="pattern">The pattern to rank.</param>
+    /// <returns>A non-negative rank; higher values select more narrowly.</returns>
+    int Specificity(string pattern);
 }

--- a/src/Content/Application/Application.AI.Common/Interfaces/Planner/IPlanRunExecutor.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Planner/IPlanRunExecutor.cs
@@ -1,0 +1,115 @@
+using Domain.AI.Bundles;
+using Domain.AI.Planner;
+using Domain.Common;
+
+namespace Application.AI.Common.Interfaces.Planner;
+
+/// <summary>
+/// Drives a single plan execution under a caller's <see cref="CapabilityEnvelope"/> and governance
+/// identity. This is the one place the security-critical ambient arming for a plan run lives, so
+/// every trigger of an enveloped plan run (the workflow HTTP surface, background dispatchers, any
+/// future host entry point) shares it — mirroring the <c>IBundleRunExecutor</c> doctrine for bundle
+/// runs.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>What it does.</strong> Given a <see cref="PlanRunRequest"/>, it initializes the scoped
+/// agent execution context with the caller's governance identity, publishes the caller's capability
+/// envelope ambiently, and drives <see cref="IPlanExecutor.ExecuteAsync(PlanId, CancellationToken)"/>
+/// to completion inside that scope. The envelope is torn down on every path — success, failure, or
+/// exception — before this method returns.
+/// </para>
+/// <para>
+/// <strong>Why the arming lives here.</strong> The tool-invocation governor enforces the per-caller
+/// grant only when an envelope is published ambiently for the running flow, and it fails
+/// <em>closed</em> on any identity-less tool call made under an envelope — so both halves (identity
+/// and envelope) must be armed together, in one place. Scattering that arming across callers is how
+/// one trigger silently diverges and opens the gate; concentrating it here is what makes the plan
+/// engine's <c>ToolUse</c>, <c>Retrieval</c>, and autonomy-ceiling checks impossible to skip on this
+/// path. The envelope scope stays open across the entire execution: the plan summary is fully
+/// materialised before this method returns, so there is no deferred enumeration that could outlive
+/// the scope.
+/// </para>
+/// <para>
+/// <strong>Fail-closed posture.</strong> This path never runs un-enveloped: a request with no
+/// envelope or no agent identity is rejected before any plan state is touched. By contrast, direct
+/// in-process <see cref="IPlanExecutor"/> callers (tests, trusted host code) arm nothing and remain
+/// ungoverned-by-default exactly as before this executor existed — the plan engine's envelope checks
+/// are all conditioned on an ambient envelope being present.
+/// </para>
+/// <para>
+/// <strong>Ownership is not checked here.</strong> The executor authorizes nothing about the
+/// caller-to-plan relationship — it drives whatever plan id it is given under whatever envelope it
+/// is handed. Callers are responsible for having resolved the envelope from the caller's credential
+/// and for having verified the requesting principal may execute the plan (the planner scope filter
+/// governs plan visibility). Do not expose this to an unauthenticated surface.
+/// </para>
+/// </remarks>
+public interface IPlanRunExecutor
+{
+    /// <summary>
+    /// Executes the plan identified by <see cref="PlanRunRequest.PlanId"/> under the request's
+    /// capability envelope and governance identity.
+    /// </summary>
+    /// <param name="request">The plan to run and the grant to confine it to.</param>
+    /// <param name="cancellationToken">Cancels the run.</param>
+    /// <returns>
+    /// The plan execution summary, or a failure carrying a stable error code
+    /// (<c>plan_run.envelope_required</c>, <c>plan_run.agent_identity_required</c>,
+    /// <c>plan_run.agent_identity_invalid</c>, <c>plan_run.execution_failed</c>) — never raw
+    /// exception text.
+    /// </returns>
+    Task<Result<PlanExecutionSummary>> ExecuteAsync(PlanRunRequest request, CancellationToken cancellationToken);
+}
+
+/// <summary>
+/// A request to execute one plan under one caller's capability envelope. The envelope and agent
+/// identity are required by design: this record cannot express an ungoverned run.
+/// </summary>
+public sealed record PlanRunRequest
+{
+    /// <summary>The plan to execute.</summary>
+    public required PlanId PlanId { get; init; }
+
+    /// <summary>
+    /// The capability grant confining the run — the tools its steps may invoke, the retrieval
+    /// capability, and the autonomy ceiling. Resolved by the caller (from the caller's credential),
+    /// never from the plan itself.
+    /// </summary>
+    public required CapabilityEnvelope Envelope { get; init; }
+
+    /// <summary>
+    /// The governance identity the run executes as. Tool permissions resolve against this id and
+    /// every governance decision is audited under it. The governor fails closed on enveloped tool
+    /// calls without an identity, so this is required.
+    /// </summary>
+    /// <remarks>
+    /// Constrained to <see cref="MaxAgentIdLength"/> characters of
+    /// <c>[A-Za-z0-9._:-]</c> — see <see cref="IsWellFormedAgentId"/>. This value is the
+    /// permission-resolution key and the audit subject: it is glob-matched against permission rules
+    /// and written into audit records, so an unbounded or punctuation-bearing id is both a
+    /// rule-matching hazard (wildcards, separators) and a log-forging one (newlines).
+    /// </remarks>
+    public required string AgentId { get; init; }
+
+    /// <summary>Maximum accepted length of <see cref="AgentId"/>.</summary>
+    public const int MaxAgentIdLength = 128;
+
+    /// <summary>
+    /// Whether <paramref name="agentId"/> is safe to use as a permission-resolution key and audit
+    /// subject: non-blank, at most <see cref="MaxAgentIdLength"/> characters, and restricted to
+    /// ASCII letters, digits, and the separators <c>. _ : -</c>.
+    /// </summary>
+    /// <param name="agentId">The candidate identity.</param>
+    /// <returns><c>true</c> when the value is well formed.</returns>
+    public static bool IsWellFormedAgentId(string? agentId) =>
+        !string.IsNullOrWhiteSpace(agentId)
+        && agentId.Length <= MaxAgentIdLength
+        && agentId.All(c => char.IsAsciiLetterOrDigit(c) || c is '.' or '_' or ':' or '-');
+
+    /// <summary>
+    /// Optional conversation/session identifier for the execution context. Defaults to the plan id
+    /// when omitted.
+    /// </summary>
+    public string? ConversationId { get; init; }
+}

--- a/src/Content/Application/Application.AI.Common/Interfaces/Planner/IPlanRunExecutor.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Planner/IPlanRunExecutor.cs
@@ -56,8 +56,8 @@ public interface IPlanRunExecutor
     /// <returns>
     /// The plan execution summary, or a failure carrying a stable error code
     /// (<c>plan_run.envelope_required</c>, <c>plan_run.agent_identity_required</c>,
-    /// <c>plan_run.agent_identity_invalid</c>, <c>plan_run.execution_failed</c>) — never raw
-    /// exception text.
+    /// <c>plan_run.agent_identity_invalid</c>, <c>plan_run.conversation_id_invalid</c>,
+    /// <c>plan_run.execution_failed</c>) — never raw exception text.
     /// </returns>
     Task<Result<PlanExecutionSummary>> ExecuteAsync(PlanRunRequest request, CancellationToken cancellationToken);
 }
@@ -111,5 +111,13 @@ public sealed record PlanRunRequest
     /// Optional conversation/session identifier for the execution context. Defaults to the plan id
     /// when omitted.
     /// </summary>
+    /// <remarks>
+    /// When supplied it must satisfy <see cref="IsWellFormedAgentId"/>'s charset and length rules, for
+    /// the same reasons plus one more: it becomes the run scope from which every per-step conversation
+    /// id and the run's budget key are derived. A blank value would produce a blank run scope, which
+    /// downstream <c>IsNullOrEmpty</c> checks read as <em>no run scope at all</em> — silently disabling
+    /// the run-level budget gate while the execution context stayed bound to an empty conversation.
+    /// Null is accepted and means "derive the scope from the plan id"; empty or whitespace is not.
+    /// </remarks>
     public string? ConversationId { get; init; }
 }

--- a/src/Content/Application/Application.AI.Common/Services/Agent/GoverningToolContextProvider.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Agent/GoverningToolContextProvider.cs
@@ -1,37 +1,54 @@
 using Application.AI.Common.Services.Tools;
 using Microsoft.Agents.AI;
 using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
 
 namespace Application.AI.Common.Services.Agent;
 
 /// <summary>
-/// An <see cref="AIContextProvider"/> that wraps every callable tool in the accumulated
-/// <see cref="AIContext"/> in a <see cref="GovernedAIFunction"/> at invocation time, so the
-/// per-invocation governance check runs even for tools that never pass through
-/// <see cref="ToolChainBuilder"/> — notably framework tools surfaced by progressive skill disclosure.
+/// An <see cref="AIContextProvider"/> that closes the <see cref="AIContext"/> tool channel: it drops
+/// tools colliding with a reserved plan-capability name and wraps the rest in a
+/// <see cref="GovernedAIFunction"/> at invocation time, so both checks run even for tools that never
+/// pass through <see cref="ToolChainBuilder"/> — notably framework tools surfaced by progressive skill
+/// disclosure, and any tool a consumer's own <see cref="AIContextProvider"/> contributes.
 /// </summary>
 /// <remarks>
 /// <para>
 /// Register this provider <em>last</em> in the <c>AIContextProviders</c> list (after the skills
-/// provider and <see cref="ToolPermissionFilter"/>) so it wraps the final, filtered tool set.
+/// provider and <see cref="ToolPermissionFilter"/>) so it sees the final, filtered tool set.
 /// Already-wrapped functions and non-function tools pass through unchanged, so it composes safely
 /// with the build-time wrapping in <see cref="ToolChainBuilder"/> (no double-wrapping).
 /// </para>
 /// <para>
-/// The wrapper is inert unless a governor is ambient for the turn (see
-/// <see cref="Governance.ToolGovernanceAccessor"/>), so this only adds enforcement, never changes
-/// which tools exist or their schemas.
+/// <strong>Two channels, one filter.</strong> The framework merges <c>ChatOptions.Tools</c> (built by
+/// <see cref="ToolChainBuilder"/>) with <c>AIContext.Tools</c> contributed by providers. Only the first
+/// passes through the builder, so the reserved plan-capability check is applied here through the shared
+/// <see cref="ReservedPlanCapabilityFilter"/> rather than being duplicated — a name the plan engine owns
+/// cannot reach the model down either route, and the two enforcement points cannot drift.
+/// </para>
+/// <para>
+/// The governance wrapper is inert unless a governor is ambient for the turn (see
+/// <see cref="Governance.ToolGovernanceAccessor"/>), so wrapping only adds enforcement. The reserved-name
+/// drop is the one case where this provider changes which tools exist, and only for names that must never
+/// have been publishable in the first place.
 /// </para>
 /// </remarks>
 public sealed class GoverningToolContextProvider : AIContextProvider
 {
+    /// <summary>Describes this channel on the reserved plan-capability drop log.</summary>
+    private const string ChannelDescription = "AIContext.Tools contributed by an AIContextProvider";
+
+    private readonly ILogger<GoverningToolContextProvider> _logger;
+
     /// <summary>Initializes a new <see cref="GoverningToolContextProvider"/>.</summary>
-    public GoverningToolContextProvider()
+    /// <param name="logger">Logger that receives reserved plan-capability collision reports.</param>
+    public GoverningToolContextProvider(ILogger<GoverningToolContextProvider> logger)
         : base(
             provideInputMessageFilter: messages => messages,
             storeInputRequestMessageFilter: messages => messages,
             storeInputResponseMessageFilter: messages => messages)
     {
+        _logger = logger;
     }
 
     /// <inheritdoc />
@@ -39,23 +56,10 @@ public sealed class GoverningToolContextProvider : AIContextProvider
         InvokingContext context,
         CancellationToken cancellationToken = default)
     {
-        var tools = context.AIContext.Tools?.ToList();
-        if (tools is null or { Count: 0 })
-            return ValueTask.FromResult(context.AIContext);
+        var tools = FilterAndGovern(context.AIContext.Tools, _logger);
 
-        var changed = false;
-        for (var i = 0; i < tools.Count; i++)
-        {
-            var governed = Govern(tools[i]);
-            if (!ReferenceEquals(governed, tools[i]))
-            {
-                tools[i] = governed;
-                changed = true;
-            }
-        }
-
-        // Nothing needed wrapping — avoid allocating a new AIContext.
-        if (!changed)
+        // Nothing was dropped or needed wrapping — avoid allocating a new AIContext.
+        if (tools is null)
             return ValueTask.FromResult(context.AIContext);
 
         return ValueTask.FromResult(new AIContext
@@ -64,6 +68,37 @@ public sealed class GoverningToolContextProvider : AIContextProvider
             Messages = context.AIContext.Messages,
             Tools = tools
         });
+    }
+
+    /// <summary>
+    /// Applies both checks to one context's tool list: drops reserved plan-capability names, then wraps
+    /// the survivors for governance. Returns <see langword="null"/> when the list needs no change, so the
+    /// caller can keep the existing <see cref="AIContext"/> instead of allocating an identical one.
+    /// Extracted for unit testing of the combined filter.
+    /// </summary>
+    /// <param name="tools">The tools accumulated on the context, possibly null or empty.</param>
+    /// <param name="logger">Logger that receives reserved plan-capability collision reports.</param>
+    internal static List<AITool>? FilterAndGovern(IEnumerable<AITool>? tools, ILogger logger)
+    {
+        var original = tools?.ToList();
+        if (original is null or { Count: 0 })
+            return null;
+
+        // Reserved-name drop first: a colliding tool must never be published, wrapped or not.
+        var permitted = ReservedPlanCapabilityFilter.Exclude(original, ChannelDescription, logger);
+        var changed = permitted.Count != original.Count;
+
+        for (var i = 0; i < permitted.Count; i++)
+        {
+            var governed = Govern(permitted[i]);
+            if (!ReferenceEquals(governed, permitted[i]))
+            {
+                permitted[i] = governed;
+                changed = true;
+            }
+        }
+
+        return changed ? permitted : null;
     }
 
     /// <summary>

--- a/src/Content/Application/Application.AI.Common/Services/Governance/DefaultToolClassificationGate.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Governance/DefaultToolClassificationGate.cs
@@ -168,10 +168,10 @@ public sealed class DefaultToolClassificationGate : IToolClassificationGate
         GovernanceMetrics.ClassificationDecisions.Add(1, tags);
     }
 
-    // Deliberately generic, matching the tool governor's denial wording: the detailed reason (label name,
-    // policy rule, asset path — even that a classification regime exists) stays in the structured log,
-    // audit, and metric tags, never relayed to the model, so model-visible content leaks no operator
-    // policy detail an adversary could probe.
+    // Deliberately generic, and shared verbatim with every other gate via GovernanceDenials: the
+    // detailed reason (label name, policy rule, asset path — even that a classification regime exists)
+    // stays in the structured log, audit, and metric tags, never relayed to the model, so model-visible
+    // content leaks no operator policy detail an adversary could probe — including which gate fired.
     private static string DeniedMessage(string toolName) =>
-        $"Error: tool '{toolName}' is not permitted in the current context.";
+        GovernanceDenials.NotPermitted(toolName);
 }

--- a/src/Content/Application/Application.AI.Common/Services/Governance/ToolInvocationGovernor.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Governance/ToolInvocationGovernor.cs
@@ -94,6 +94,36 @@ public sealed class ToolInvocationGovernor : IToolInvocationGovernor
     private static bool BundleRunActive => CapabilityEnvelopeAccessor.Current is not null;
 
     /// <summary>
+    /// Independently confirms that an ambient capability envelope grants <paramref name="toolName"/>,
+    /// after the permission resolver has already said Allow. Returns true when no envelope is armed.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <strong>This is defence in depth, and until now there was none.</strong> The permission resolver
+    /// was the sole enforcement point for tool names at invocation: when its arbitration was wrong, the
+    /// caller got the tool. That arbitration has been wrong twice — a tier default that allowed anything
+    /// unmatched, then a plugin baseline that outranked the envelope's closing deny — and both were
+    /// found by review rather than by the system refusing.
+    /// </para>
+    /// <para>
+    /// <c>CapabilityEnvelope.GrantsTool</c> existed for exactly this check and had zero callers, which is
+    /// why neither defect was caught at the point of use. This wires it in: a resolver Allow for a tool
+    /// the armed envelope does not list is refused and recorded as a denial, so a future arbitration bug
+    /// costs a blocked call rather than an unauthorized one.
+    /// </para>
+    /// <para>
+    /// The two must agree by construction — the envelope's own rules are built from the same
+    /// <c>AllowedTools</c> list this reads, matched with the same case-insensitive comparer. A
+    /// disagreement therefore means the resolver reached Allow by a path that did not consult the
+    /// envelope, which is precisely the condition worth failing closed on.
+    /// </para>
+    /// </remarks>
+    /// <param name="toolName">The tool the resolver has authorized.</param>
+    /// <returns>True when no envelope is armed, or when the armed envelope grants the tool.</returns>
+    private static bool EnvelopeGrantsToolWhenArmed(string toolName)
+        => CapabilityEnvelopeAccessor.Current is not { } envelope || envelope.GrantsTool(toolName);
+
+    /// <summary>
     /// Whether per-invocation enforcement is active for the current flow. True when the host has opted in
     /// globally (<c>GovernanceConfig.EnforceToolInvocation</c>) <em>or</em> a bundle run is active
     /// (<see cref="BundleRunActive"/>) — bundle runs must always be governed so the per-caller capability
@@ -164,6 +194,14 @@ public sealed class ToolInvocationGovernor : IToolInvocationGovernor
                     requiredApproval: true, agentId);
 
             case PermissionBehaviorType.Allow:
+                if (!EnvelopeGrantsToolWhenArmed(toolName))
+                {
+                    _denialTracker.RecordDenial(agentId, toolName);
+                    return Blocked(toolName, ToolDecisionOutcome.Denied,
+                        GovernanceDenials.NotPermitted(toolName), profile.Radius,
+                        requiredApproval: false, agentId);
+                }
+
                 return await AuthorizeAllowedAsync(agentId, toolName, profile, cancellationToken)
                     .ConfigureAwait(false);
 

--- a/src/Content/Application/Application.AI.Common/Services/Governance/ToolInvocationGovernor.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Governance/ToolInvocationGovernor.cs
@@ -132,8 +132,7 @@ public sealed class ToolInvocationGovernor : IToolInvocationGovernor
                 Record(new ToolDecisionRecord(toolName, ToolDecisionOutcome.Denied,
                     "no agent identity in a bundle run", profile.Radius,
                     RequiredApproval: false, ApprovalGranted: false, Enforced: true));
-                return ToolInvocationDecision.Deny(
-                    $"Error: tool '{toolName}' is not permitted in the current context.");
+                return ToolInvocationDecision.Deny(GovernanceDenials.NotPermitted(toolName));
             }
 
             _logger.LogWarning(
@@ -250,7 +249,7 @@ public sealed class ToolInvocationGovernor : IToolInvocationGovernor
         // Model-facing message is deliberately generic: the detailed reason (rule ids, paths,
         // capability internals) stays in the structured log and the GovernanceTrace, never relayed
         // to the LLM — avoids leaking operator-authored policy detail into model-visible content.
-        return ToolInvocationDecision.Deny($"Error: tool '{toolName}' is not permitted in the current context.");
+        return ToolInvocationDecision.Deny(GovernanceDenials.NotPermitted(toolName));
     }
 
     /// <summary>

--- a/src/Content/Application/Application.AI.Common/Services/Tools/ReservedPlanCapabilityFilter.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/ReservedPlanCapabilityFilter.cs
@@ -1,0 +1,95 @@
+using Application.AI.Common.OpenTelemetry.Metrics;
+using Domain.AI.Planner;
+using Domain.AI.Telemetry.Conventions;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
+
+namespace Application.AI.Common.Services.Tools;
+
+/// <summary>
+/// Drops tools whose names collide with a reserved <see cref="PlanCapabilities"/> name before they reach
+/// an agent's callable surface, reporting each drop to the log and the governance-violation counter.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>Why this is shared rather than inlined.</strong> Plan capabilities are authorized by name out
+/// of the same flat, case-insensitively matched string space that <c>CapabilityEnvelope.AllowedTools</c>
+/// draws tool names from, so a tool published as <c>rag_retrieval</c> would be handed to the model by any
+/// envelope granting retrieval — and an envelope granting that tool would grant plan inference. Closing
+/// that requires the check to run on <em>every</em> channel onto the callable surface, not just one.
+/// <see cref="ToolChainBuilder"/> is the main channel, but the framework also merges
+/// <c>AIContext.Tools</c> contributed by <c>AIContextProvider</c>s (progressive skill disclosure, and any
+/// provider a consumer adds), which never pass through the builder. Both call here so the two cannot
+/// drift apart as the harness is extended.
+/// </para>
+/// <para>
+/// <strong>Drop, never throw.</strong> The names this guards against arrive at runtime from third-party
+/// sources — MCP servers and plugin manifests — that a boot-time DI scan cannot see. A third party
+/// editing its tool list must not be able to take down every agent turn in the host, so a collision
+/// degrades to one loud <c>Error</c> log plus a governance-violation counter and the run continues
+/// without that tool. <c>ReservedPlanCapabilityGuard</c> stays the louder, fail-fast check for the
+/// first-party keyed registrations the host controls.
+/// </para>
+/// </remarks>
+public static class ReservedPlanCapabilityFilter
+{
+    /// <summary>
+    /// Telemetry policy tag identifying a drop made by this filter, so a governance dashboard can
+    /// separate this fail-open closure from ordinary policy violations.
+    /// </summary>
+    public const string PolicyName = "reserved_plan_capability";
+
+    /// <summary>
+    /// Returns the tools that may be published to the model: every tool in <paramref name="tools"/>
+    /// except those whose name matches a reserved plan-capability name. Each exclusion is logged and
+    /// counted.
+    /// </summary>
+    /// <param name="tools">The candidate tools for one callable surface.</param>
+    /// <param name="source">
+    /// Human-readable description of where the tools were resolved from, recorded on the drop log so the
+    /// source that needs re-keying is identifiable.
+    /// </param>
+    /// <param name="logger">Logger that receives the collision report.</param>
+    /// <returns>The permitted tools, in their original order.</returns>
+    public static List<AITool> Exclude(IEnumerable<AITool> tools, string source, ILogger logger)
+    {
+        ArgumentNullException.ThrowIfNull(tools);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        var permitted = new List<AITool>();
+        foreach (var tool in tools)
+        {
+            if (PlanCapabilities.IsReserved(tool.Name))
+                ReportCollision(tool.Name, source, logger);
+            else
+                permitted.Add(tool);
+        }
+
+        return permitted;
+    }
+
+    /// <summary>
+    /// Records a runtime-sourced tool that was dropped for colliding with a reserved plan-capability
+    /// name — loudly, because it means a source is publishing a name the plan engine owns and that
+    /// source needs re-keying.
+    /// </summary>
+    private static void ReportCollision(string toolName, string source, ILogger logger)
+    {
+        var reserved = PlanCapabilities.ReservedNames
+            .First(name => string.Equals(name, toolName, StringComparison.OrdinalIgnoreCase));
+
+        logger.LogError(
+            "Reserved plan-capability collision: tool '{ToolName}' from {ToolSource} matches reserved " +
+            "plan capability '{ReservedName}' and was excluded from the callable tool chain. Plan " +
+            "capabilities are authorized out of the same CapabilityEnvelope.AllowedTools string space as " +
+            "tool names, so granting that capability would otherwise also grant this tool. Re-key the tool " +
+            "at its source.",
+            toolName, source, reserved);
+
+        // Tagged with the normalised reserved name rather than the verbatim tool name: a case variant is
+        // attacker-influenced text and would put unbounded cardinality on the metric.
+        GovernanceMetrics.Violations.Add(1,
+            new KeyValuePair<string, object?>(GovernanceConventions.PolicyName, PolicyName),
+            new KeyValuePair<string, object?>(GovernanceConventions.ToolName, reserved));
+    }
+}

--- a/src/Content/Application/Application.AI.Common/Services/Tools/ToolChainBuilder.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/ToolChainBuilder.cs
@@ -1,8 +1,11 @@
 using Application.AI.Common.Interfaces;
 using Application.AI.Common.Interfaces.Plugins;
 using Application.AI.Common.Interfaces.Tools;
+using Application.AI.Common.OpenTelemetry.Metrics;
 using Application.AI.Common.Services.Governance;
+using Domain.AI.Planner;
 using Domain.AI.Skills;
+using Domain.AI.Telemetry.Conventions;
 using Domain.Common.Config.AI.Plugins;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
@@ -18,6 +21,12 @@ namespace Application.AI.Common.Services.Tools;
 /// </summary>
 public class ToolChainBuilder : IToolChainBuilder
 {
+    /// <summary>
+    /// Telemetry policy tag identifying a drop made by the reserved plan-capability filter, so a
+    /// governance dashboard can separate this fail-open closure from ordinary policy violations.
+    /// </summary>
+    private const string ReservedPlanCapabilityPolicy = "reserved_plan_capability";
+
     private readonly ILogger<ToolChainBuilder> _logger;
     private readonly IServiceProvider _serviceProvider;
     private readonly IToolConverter? _toolConverter;
@@ -68,7 +77,7 @@ public class ToolChainBuilder : IToolChainBuilder
                 skill.Id, skill.PluginSource, tools.Count);
 
             var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-            return WrapGoverned(tools.Where(t => seen.Add(t.Name)));
+            return FinalizeChain(tools.Where(t => seen.Add(t.Name)), DescribeSource(skill, "injected MCP tool resolution"));
         }
 
         if (skill.Tools?.Count > 0)
@@ -101,7 +110,7 @@ public class ToolChainBuilder : IToolChainBuilder
         tools = ApplyPluginBoundaryIfPluginSkill(skill, tools);
 
         var seen2 = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        return WrapGoverned(tools.Where(t => seen2.Add(t.Name)));
+        return FinalizeChain(tools.Where(t => seen2.Add(t.Name)), DescribeSource(skill, "managed tool resolution"));
     }
 
     /// <summary>
@@ -122,6 +131,81 @@ public class ToolChainBuilder : IToolChainBuilder
             ? tools
             : ApplyPluginToolBoundary(tools, loadedPlugin.Declaration);
     }
+
+    /// <summary>
+    /// The single exit every resolution path returns through: drops tools whose names collide with a
+    /// reserved <see cref="PlanCapabilities"/> name, then governance-wraps what survives. Every public
+    /// build method funnels here, so a tool that reaches an agent's callable surface has passed both
+    /// checks exactly once.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <strong>Why the reserved filter lives here and not at boot.</strong>
+    /// <c>ReservedPlanCapabilityGuard</c> catches first-party keyed <c>ITool</c> registrations by
+    /// scanning DI descriptors at composition, but MCP-client and plugin-manifest tools are discovered
+    /// at <em>runtime</em> from third-party sources — no boot-time scan can see them. Their names land
+    /// in the same flat, case-insensitively matched string space that <c>CapabilityEnvelope.AllowedTools</c>
+    /// authorizes plan capabilities out of, so an external server publishing a tool called
+    /// <c>rag_retrieval</c> would be handed to the model by any plan envelope that grants retrieval —
+    /// and an envelope granting such a tool would grant plan inference. Excluding the name here, before
+    /// it is ever wrapped or published, closes that in both directions.
+    /// </para>
+    /// <para>
+    /// <strong>Drop, never throw.</strong> A third party editing its tool list must not be able to take
+    /// down every agent turn in the host, so the collision degrades to one loud <c>Error</c> log plus a
+    /// governance-violation counter and the run continues without that tool. The boot guard stays the
+    /// louder, fail-fast check for code we control; this is the safe-degradation check for code we do not.
+    /// </para>
+    /// </remarks>
+    /// <param name="tools">The deduplicated tools resolved by one build path.</param>
+    /// <param name="source">Human-readable description of where the tools were resolved from, for the drop log.</param>
+    private List<AITool> FinalizeChain(IEnumerable<AITool> tools, string source)
+    {
+        var permitted = new List<AITool>();
+        foreach (var tool in tools)
+        {
+            if (PlanCapabilities.IsReserved(tool.Name))
+                ReportReservedPlanCapabilityCollision(tool.Name, source);
+            else
+                permitted.Add(tool);
+        }
+
+        return WrapGoverned(permitted);
+    }
+
+    /// <summary>
+    /// Records a runtime-sourced tool that was dropped for colliding with a reserved plan-capability
+    /// name — loudly, because it means a third-party source is publishing a name the plan engine owns
+    /// and that source needs re-keying.
+    /// </summary>
+    private void ReportReservedPlanCapabilityCollision(string toolName, string source)
+    {
+        var reserved = PlanCapabilities.ReservedNames
+            .First(name => string.Equals(name, toolName, StringComparison.OrdinalIgnoreCase));
+
+        _logger.LogError(
+            "Reserved plan-capability collision: tool '{ToolName}' from {ToolSource} matches reserved " +
+            "plan capability '{ReservedName}' and was excluded from the callable tool chain. Plan " +
+            "capabilities are authorized out of the same CapabilityEnvelope.AllowedTools string space as " +
+            "tool names, so granting that capability would otherwise also grant this tool. Re-key the tool " +
+            "at its source.",
+            toolName, source, reserved);
+
+        // Tagged with the normalised reserved name rather than the verbatim tool name: a case variant is
+        // attacker-influenced text and would put unbounded cardinality on the metric.
+        GovernanceMetrics.Violations.Add(1,
+            new KeyValuePair<string, object?>(GovernanceConventions.PolicyName, ReservedPlanCapabilityPolicy),
+            new KeyValuePair<string, object?>(GovernanceConventions.ToolName, reserved));
+    }
+
+    /// <summary>
+    /// Describes the resolution path a tool arrived on, naming the owning plugin when the skill is
+    /// plugin-sourced so a dropped collision points at the source that needs re-keying.
+    /// </summary>
+    private static string DescribeSource(SkillDefinition skill, string mode) =>
+        string.IsNullOrEmpty(skill.PluginSource)
+            ? $"{mode} for skill '{skill.Id}'"
+            : $"{mode} for skill '{skill.Id}' (plugin '{skill.PluginSource}')";
 
     /// <summary>
     /// Wraps each callable tool function in a <see cref="GovernedAIFunction"/> so a per-invocation
@@ -148,7 +232,7 @@ public class ToolChainBuilder : IToolChainBuilder
         }
 
         var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        return WrapGoverned(tools.Where(t => seen.Add(t.Name)));
+        return FinalizeChain(tools.Where(t => seen.Add(t.Name)), "keyed-DI resolution by name");
     }
 
     /// <inheritdoc />

--- a/src/Content/Application/Application.AI.Common/Services/Tools/ToolChainBuilder.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/ToolChainBuilder.cs
@@ -1,11 +1,9 @@
 using Application.AI.Common.Interfaces;
 using Application.AI.Common.Interfaces.Plugins;
 using Application.AI.Common.Interfaces.Tools;
-using Application.AI.Common.OpenTelemetry.Metrics;
 using Application.AI.Common.Services.Governance;
 using Domain.AI.Planner;
 using Domain.AI.Skills;
-using Domain.AI.Telemetry.Conventions;
 using Domain.Common.Config.AI.Plugins;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
@@ -21,12 +19,6 @@ namespace Application.AI.Common.Services.Tools;
 /// </summary>
 public class ToolChainBuilder : IToolChainBuilder
 {
-    /// <summary>
-    /// Telemetry policy tag identifying a drop made by the reserved plan-capability filter, so a
-    /// governance dashboard can separate this fail-open closure from ordinary policy violations.
-    /// </summary>
-    private const string ReservedPlanCapabilityPolicy = "reserved_plan_capability";
-
     private readonly ILogger<ToolChainBuilder> _logger;
     private readonly IServiceProvider _serviceProvider;
     private readonly IToolConverter? _toolConverter;
@@ -133,70 +125,30 @@ public class ToolChainBuilder : IToolChainBuilder
     }
 
     /// <summary>
-    /// The single exit every resolution path returns through: drops tools whose names collide with a
-    /// reserved <see cref="PlanCapabilities"/> name, then governance-wraps what survives. Every public
-    /// build method funnels here, so a tool that reaches an agent's callable surface has passed both
-    /// checks exactly once.
+    /// The single exit every resolution path in <em>this builder</em> returns through: drops tools whose
+    /// names collide with a reserved <see cref="PlanCapabilities"/> name (via the shared
+    /// <see cref="ReservedPlanCapabilityFilter"/>), then governance-wraps what survives. Every public
+    /// build method funnels here, so a tool the builder publishes has passed both checks exactly once.
     /// </summary>
     /// <remarks>
     /// <para>
-    /// <strong>Why the reserved filter lives here and not at boot.</strong>
-    /// <c>ReservedPlanCapabilityGuard</c> catches first-party keyed <c>ITool</c> registrations by
-    /// scanning DI descriptors at composition, but MCP-client and plugin-manifest tools are discovered
-    /// at <em>runtime</em> from third-party sources — no boot-time scan can see them. Their names land
-    /// in the same flat, case-insensitively matched string space that <c>CapabilityEnvelope.AllowedTools</c>
-    /// authorizes plan capabilities out of, so an external server publishing a tool called
-    /// <c>rag_retrieval</c> would be handed to the model by any plan envelope that grants retrieval —
-    /// and an envelope granting such a tool would grant plan inference. Excluding the name here, before
-    /// it is ever wrapped or published, closes that in both directions.
+    /// The reserved-name check runs here rather than at boot because <c>ReservedPlanCapabilityGuard</c>
+    /// can only see first-party keyed <c>ITool</c> registrations at composition time, while MCP-client and
+    /// plugin-manifest tools are discovered at <em>runtime</em>. See
+    /// <see cref="ReservedPlanCapabilityFilter"/> for why the collision matters and why it degrades rather
+    /// than throwing.
     /// </para>
     /// <para>
-    /// <strong>Drop, never throw.</strong> A third party editing its tool list must not be able to take
-    /// down every agent turn in the host, so the collision degrades to one loud <c>Error</c> log plus a
-    /// governance-violation counter and the run continues without that tool. The boot guard stays the
-    /// louder, fail-fast check for code we control; this is the safe-degradation check for code we do not.
+    /// <strong>This is not the only channel.</strong> The framework also merges tools contributed through
+    /// <c>AIContext.Tools</c> by <c>AIContextProvider</c>s, which never pass through this builder;
+    /// <c>GoverningToolContextProvider</c> applies the same shared filter on that channel. Both call the
+    /// one helper so the two enforcement points cannot drift.
     /// </para>
     /// </remarks>
     /// <param name="tools">The deduplicated tools resolved by one build path.</param>
     /// <param name="source">Human-readable description of where the tools were resolved from, for the drop log.</param>
     private List<AITool> FinalizeChain(IEnumerable<AITool> tools, string source)
-    {
-        var permitted = new List<AITool>();
-        foreach (var tool in tools)
-        {
-            if (PlanCapabilities.IsReserved(tool.Name))
-                ReportReservedPlanCapabilityCollision(tool.Name, source);
-            else
-                permitted.Add(tool);
-        }
-
-        return WrapGoverned(permitted);
-    }
-
-    /// <summary>
-    /// Records a runtime-sourced tool that was dropped for colliding with a reserved plan-capability
-    /// name — loudly, because it means a third-party source is publishing a name the plan engine owns
-    /// and that source needs re-keying.
-    /// </summary>
-    private void ReportReservedPlanCapabilityCollision(string toolName, string source)
-    {
-        var reserved = PlanCapabilities.ReservedNames
-            .First(name => string.Equals(name, toolName, StringComparison.OrdinalIgnoreCase));
-
-        _logger.LogError(
-            "Reserved plan-capability collision: tool '{ToolName}' from {ToolSource} matches reserved " +
-            "plan capability '{ReservedName}' and was excluded from the callable tool chain. Plan " +
-            "capabilities are authorized out of the same CapabilityEnvelope.AllowedTools string space as " +
-            "tool names, so granting that capability would otherwise also grant this tool. Re-key the tool " +
-            "at its source.",
-            toolName, source, reserved);
-
-        // Tagged with the normalised reserved name rather than the verbatim tool name: a case variant is
-        // attacker-influenced text and would put unbounded cardinality on the metric.
-        GovernanceMetrics.Violations.Add(1,
-            new KeyValuePair<string, object?>(GovernanceConventions.PolicyName, ReservedPlanCapabilityPolicy),
-            new KeyValuePair<string, object?>(GovernanceConventions.ToolName, reserved));
-    }
+        => WrapGoverned(ReservedPlanCapabilityFilter.Exclude(tools, source, _logger));
 
     /// <summary>
     /// Describes the resolution path a tool arrived on, naming the owning plugin when the skill is

--- a/src/Content/Application/Application.Core/CQRS/Agents/RunConversation/RunConversationCommand.cs
+++ b/src/Content/Application/Application.Core/CQRS/Agents/RunConversation/RunConversationCommand.cs
@@ -63,6 +63,27 @@ public record ConversationResult
 	public string? Error { get; init; }
 
 	/// <summary>
+	/// Input+output tokens consumed across every turn of this conversation.
+	/// </summary>
+	/// <remarks>
+	/// <para>
+	/// The handler folds the same figure into the conversation-lifetime budget under this
+	/// conversation's own id, then releases that entry when it returns. Surfacing the total lets a
+	/// caller that owns a <em>larger</em> unit of work than one conversation — a plan run spanning
+	/// many single-conversation steps — accumulate spend against its own budget key without trying
+	/// to reach into the entry this handler owns and disposes.
+	/// </para>
+	/// <para>
+	/// <strong>Not an exact meter on the failure path.</strong> A turn that fails returns before its
+	/// usage is folded into the running totals, so a conversation that burned tokens and then errored
+	/// reports zero here. A caller metering spend across many conversations therefore under-counts
+	/// failed ones. That is a deliberate consequence of the existing early-return, not a guarantee:
+	/// treat this as the accounted total, not the billed total.
+	/// </para>
+	/// </remarks>
+	public int TotalTokens { get; init; }
+
+	/// <summary>
 	/// True when the conversation stopped early because it exhausted its lifetime token budget
 	/// (<c>AppConfig.AI.AgentFramework.ConversationTokenBudget</c>). This is a graceful stop, not a
 	/// failure: <see cref="Success"/> stays true and <see cref="Turns"/> holds the turns that ran.

--- a/src/Content/Application/Application.Core/CQRS/Agents/RunConversation/RunConversationCommand.cs
+++ b/src/Content/Application/Application.Core/CQRS/Agents/RunConversation/RunConversationCommand.cs
@@ -76,9 +76,12 @@ public record ConversationResult
 	/// <para>
 	/// <strong>Not an exact meter on the failure path.</strong> A turn that fails returns before its
 	/// usage is folded into the running totals, so a conversation that burned tokens and then errored
-	/// reports zero here. A caller metering spend across many conversations therefore under-counts
-	/// failed ones. That is a deliberate consequence of the existing early-return, not a guarantee:
-	/// treat this as the accounted total, not the billed total.
+	/// reports a <em>partial</em> total: every turn that already succeeded is counted, only the
+	/// failing turn's usage is missing. The figure is zero only in the special case where the first
+	/// turn is the one that fails. A caller metering spend across many conversations therefore
+	/// under-counts each failed one by its final turn. That is a deliberate consequence of the
+	/// existing early-return, not a guarantee: treat this as the accounted total, not the billed
+	/// total.
 	/// </para>
 	/// </remarks>
 	public int TotalTokens { get; init; }

--- a/src/Content/Application/Application.Core/CQRS/Agents/RunConversation/RunConversationCommandHandler.cs
+++ b/src/Content/Application/Application.Core/CQRS/Agents/RunConversation/RunConversationCommandHandler.cs
@@ -133,6 +133,7 @@ public class RunConversationCommandHandler : IRequestHandler<RunConversationComm
 						Turns = turns,
 						FinalResponse = string.Empty,
 						TotalToolInvocations = totalToolInvocations,
+						TotalTokens = totalInputTokens + totalOutputTokens,
 						Error = $"Turn {index + 1} failed: {lastResult.Error}"
 					};
 				}
@@ -205,6 +206,7 @@ public class RunConversationCommandHandler : IRequestHandler<RunConversationComm
 				Turns = turns,
 				FinalResponse = lastResult?.Response ?? string.Empty,
 				TotalToolInvocations = totalToolInvocations,
+				TotalTokens = totalInputTokens + totalOutputTokens,
 				BudgetExhausted = stoppedForBudget,
 				Governance = governanceTraces.Count > 0 ? GovernanceTrace.Merge(governanceTraces) : null
 			};

--- a/src/Content/Application/Application.Core/Permissions/EnvelopePermissionRuleProvider.cs
+++ b/src/Content/Application/Application.Core/Permissions/EnvelopePermissionRuleProvider.cs
@@ -4,6 +4,7 @@ using Application.AI.Common.Services.Governance;
 using Domain.AI.Bundles;
 using Domain.AI.Governance;
 using Domain.AI.Permissions;
+using Microsoft.Extensions.Logging;
 
 namespace Application.Core.Permissions;
 
@@ -19,18 +20,16 @@ namespace Application.Core.Permissions;
 /// every existing deployment is completely unaffected.
 /// </para>
 /// <para>
-/// When an envelope is active it emits two kinds of rule:
+/// When an envelope is active it emits three kinds of rule:
 /// </para>
 /// <list type="number">
 ///   <item>
 ///     <description>
 ///     <strong>Bypass-immune Deny</strong> for every tool the bundle <em>declares</em> (drawn from the
 ///     ambient <see cref="EphemeralAgentOverlay"/>: the ephemeral agent's tool ceiling plus each owned
-///     skill's tools) that the envelope does not grant. A catch-all <c>*</c> Deny cannot express
-///     "deny all but the allowlist" because the resolver evaluates Deny (phase 1b) before Allow — a
-///     wildcard Deny would also kill the granted tools — so the out-of-envelope set is enumerated and
-///     denied by exact name. These denies are <see cref="ToolPermissionRule.IsBypassImmune"/> so no
-///     auto-approve mode can lift them.
+///     skill's tools) that the envelope does not grant. These are ordinary phase-1b Deny rules marked
+///     <see cref="ToolPermissionRule.IsBypassImmune"/>, so no auto-approve mode can lift them and the
+///     denial is attributable to a named declaration rather than to the fallback.
 ///     </description>
 ///   </item>
 ///   <item>
@@ -43,13 +42,37 @@ namespace Application.Core.Permissions;
 ///     loosens it.
 ///     </description>
 ///   </item>
+///   <item>
+///     <description>
+///     <strong>Closing Deny</strong>: one catch-all <c>*</c> baseline Deny at the lowest possible
+///     precedence, which is what makes the envelope an actual allowlist rather than a set of hints. It
+///     is a <em>baseline</em>, not a plain Deny, for two reasons: baselines are resolved only in phase
+///     1.5 (so this cannot pre-empt the granted tools in phase 1b), and they are arbitrated by pattern
+///     specificity (so the per-name grants above, being exact, outrank it). Any name the envelope did
+///     not grant reaches it and is denied inside phase 1.5 — before the resolver can fall through to a
+///     host's generic autonomy-tier <c>*</c> Allow.
+///     </description>
+///   </item>
 /// </list>
 /// <para>
-/// This is the strongest tier of a layered guarantee, not the whole of it: a tool the bundle did
-/// <em>not</em> statically declare but tries to call at runtime is still blocked, because with no matching
-/// Allow or baseline the resolver defaults to Ask and the fail-closed governor turns that into a denial.
-/// Enumerating declared tools lets the common case be an explicit, bypass-immune Deny rather than a
-/// default block.
+/// <strong>Why the closing Deny is load-bearing.</strong> Without it an ungranted name matched no
+/// envelope rule at all, so resolution continued into the tier phase. A host configured with
+/// <c>DefaultBehavior: Allow</c> and an <c>Autonomous</c> default tier — the shipped configuration of
+/// both bundle-capable hosts — emits a <c>*</c> Allow there, and the ungranted tool resolved to
+/// <em>Allow</em>. The envelope was documented as fail-closed while behaving fail-open for exactly the
+/// names it never granted. The closing Deny is the mechanism that makes the documented invariant true;
+/// removing it silently reopens the hole, which is why it is asserted directly in the test suite against
+/// the real production provider set.
+/// </para>
+/// <para>
+/// <strong>Grants are exact names, never patterns.</strong> Entries in
+/// <see cref="CapabilityEnvelope.AllowedTools"/> are matched as literal tool names, matching
+/// <see cref="CapabilityEnvelope.GrantsTool"/> and the exact-membership Deny half below. An entry
+/// containing a wildcard is rejected with an error log and grants nothing: this is an authorization
+/// allowlist, and an operator writing <c>"*"</c> to mean "all tools" would otherwise silently grant the
+/// reserved plan capabilities (<c>llm_call</c>, <c>rag_retrieval</c>) that the envelope exists to gate,
+/// while <c>GrantsTool</c> kept reporting them as ungranted. Widening a grant is not a failure mode an
+/// allowlist may have, so the two halves are held to one meaning.
 /// </para>
 /// </remarks>
 public sealed class EnvelopePermissionRuleProvider : IPermissionRuleProvider
@@ -59,6 +82,17 @@ public sealed class EnvelopePermissionRuleProvider : IPermissionRuleProvider
 
     /// <summary>Apply the autonomy-ceiling baseline after the deny set.</summary>
     private const int BaselinePriority = 5;
+
+    private readonly ILogger<EnvelopePermissionRuleProvider> _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EnvelopePermissionRuleProvider"/> class.
+    /// </summary>
+    /// <param name="logger">Logger for rejected wildcard grants in an envelope's allowlist.</param>
+    public EnvelopePermissionRuleProvider(ILogger<EnvelopePermissionRuleProvider> logger)
+    {
+        _logger = logger;
+    }
 
     /// <inheritdoc />
     public PermissionRuleSource Source => PermissionRuleSource.CapabilityEnvelope;
@@ -73,10 +107,11 @@ public sealed class EnvelopePermissionRuleProvider : IPermissionRuleProvider
             return Task.FromResult<IReadOnlyList<ToolPermissionRule>>([]);
 
         var rules = new List<ToolPermissionRule>();
+        var grantedNames = ValidGrants(envelope);
 
         // 1. Bypass-immune Deny for each declared tool the envelope does not grant. Build the grant set once
         //    so the membership test is O(1) per declared tool rather than a linear scan of the allowlist.
-        var granted = new HashSet<string>(envelope.AllowedTools, StringComparer.OrdinalIgnoreCase);
+        var granted = new HashSet<string>(grantedNames, StringComparer.OrdinalIgnoreCase);
         foreach (var toolName in EnumerateDeclaredTools(agentId))
         {
             if (!granted.Contains(toolName))
@@ -100,7 +135,7 @@ public sealed class EnvelopePermissionRuleProvider : IPermissionRuleProvider
         //    CapabilityEnvelope.AutonomyCeiling; wiring the ceiling into live approval is a follow-up.
         var ceilingBehavior = envelope.AutonomyCeiling.ToDefaultPermissionBehavior();
 
-        foreach (var toolName in envelope.AllowedTools)
+        foreach (var toolName in grantedNames)
         {
             rules.Add(new ToolPermissionRule(
                 toolName,
@@ -111,7 +146,57 @@ public sealed class EnvelopePermissionRuleProvider : IPermissionRuleProvider
                 IsAuthoritativeBaseline: true));
         }
 
+        // 3. Closing Deny — everything the envelope did not grant. Emitted last and least specific so the
+        //    per-name grants above outrank it, and at int.MaxValue priority so any future same-specificity
+        //    baseline also wins. This is what turns the allowlist into a closed set: without it an ungranted
+        //    name matches no envelope rule and resolution falls through to the host's generic autonomy tier,
+        //    which in the shipped bundle-host configuration says Allow.
+        rules.Add(new ToolPermissionRule(
+            "*",
+            null,
+            PermissionBehaviorType.Deny,
+            PermissionRuleSource.CapabilityEnvelope,
+            Priority: int.MaxValue,
+            IsAuthoritativeBaseline: true));
+
         return Task.FromResult<IReadOnlyList<ToolPermissionRule>>(rules);
+    }
+
+    /// <summary>
+    /// The tool names an envelope actually grants: its <see cref="CapabilityEnvelope.AllowedTools"/>
+    /// entries less any that contain a wildcard, which are rejected with an error log.
+    /// </summary>
+    /// <remarks>
+    /// A wildcard entry is treated as a configuration error rather than a broad grant. The rest of the
+    /// envelope — <see cref="CapabilityEnvelope.GrantsTool"/> and the exact-membership Deny half — reads
+    /// these entries as literal names, so honouring a wildcard here would make one list mean two
+    /// different things and would grant, without ever being written down, the reserved plan capabilities
+    /// the envelope exists to gate. Dropping the entry fails closed: the run continues with the grants
+    /// the operator did spell out.
+    /// </remarks>
+    private IReadOnlyList<string> ValidGrants(CapabilityEnvelope envelope)
+    {
+        var names = new List<string>(envelope.AllowedTools.Count);
+
+        foreach (var entry in envelope.AllowedTools)
+        {
+            if (string.IsNullOrWhiteSpace(entry))
+                continue;
+
+            if (entry.Contains('*', StringComparison.Ordinal))
+            {
+                _logger.LogError(
+                    "Capability envelope: AllowedTools entry '{Entry}' contains a wildcard and was rejected. " +
+                    "Envelope grants are exact tool names — list each tool the caller may invoke. A wildcard " +
+                    "grant would also confer the reserved plan capabilities the envelope exists to gate.",
+                    entry);
+                continue;
+            }
+
+            names.Add(entry);
+        }
+
+        return names;
     }
 
     /// <summary>

--- a/src/Content/Application/Application.Core/Permissions/EnvelopePermissionRuleProvider.cs
+++ b/src/Content/Application/Application.Core/Permissions/EnvelopePermissionRuleProvider.cs
@@ -55,6 +55,20 @@ namespace Application.Core.Permissions;
 ///   </item>
 /// </list>
 /// <para>
+/// <strong>The envelope is a grant boundary, not a default — no other provider may widen it.</strong>
+/// Both baseline kinds above carry <see cref="PermissionBaselineTier.GrantBoundary"/>, and the resolver
+/// caps phase 1.5 at whatever the boundary permits for the tool in question. Specificity alone is not
+/// sufficient here: the envelope is not the only provider emitting authoritative baselines, and a peer's
+/// baseline naming a tool exactly is <em>more</em> specific than the closing <c>*</c>. A host loading a
+/// plugin that declares <c>AutonomyLevel: Autonomous</c> gets an exact-name baseline Allow for each of
+/// that plugin's tools; without the boundary tier that Allow outranked the closing Deny and the bundle
+/// could invoke a tool the caller's envelope never granted — the confinement invariant would have held
+/// only for hosts that load no autonomy-declaring plugins. Tightening from outside still works: a
+/// stricter Default-tier baseline (a plugin marked <c>Restricted</c>, say) wins over a granted tool's
+/// Allow, because the ceiling on <see cref="CapabilityEnvelope.AutonomyCeiling"/> caps authority without
+/// establishing a floor.
+/// </para>
+/// <para>
 /// <strong>Why the closing Deny is load-bearing.</strong> Without it an ungranted name matched no
 /// envelope rule at all, so resolution continued into the tier phase. A host configured with
 /// <c>DefaultBehavior: Allow</c> and an <c>Autonomous</c> default tier — the shipped configuration of
@@ -143,7 +157,8 @@ public sealed class EnvelopePermissionRuleProvider : IPermissionRuleProvider
                 ceilingBehavior,
                 PermissionRuleSource.CapabilityEnvelope,
                 Priority: BaselinePriority,
-                IsAuthoritativeBaseline: true));
+                IsAuthoritativeBaseline: true,
+                BaselineTier: PermissionBaselineTier.GrantBoundary));
         }
 
         // 3. Closing Deny — everything the envelope did not grant. Emitted last and least specific so the
@@ -157,7 +172,8 @@ public sealed class EnvelopePermissionRuleProvider : IPermissionRuleProvider
             PermissionBehaviorType.Deny,
             PermissionRuleSource.CapabilityEnvelope,
             Priority: int.MaxValue,
-            IsAuthoritativeBaseline: true));
+            IsAuthoritativeBaseline: true,
+            BaselineTier: PermissionBaselineTier.GrantBoundary));
 
         return Task.FromResult<IReadOnlyList<ToolPermissionRule>>(rules);
     }

--- a/src/Content/Domain/Domain.AI/Bundles/CapabilityEnvelope.cs
+++ b/src/Content/Domain/Domain.AI/Bundles/CapabilityEnvelope.cs
@@ -33,6 +33,19 @@ public sealed record CapabilityEnvelope
     /// The tool names this caller's bundle run may invoke. A tool the bundle requests that is not in this
     /// list is denied. Empty (the default) grants no tools — every tool call is denied.
     /// </summary>
+    /// <remarks>
+    /// <strong>Exact names only.</strong> Entries are literal tool names, matched case-insensitively;
+    /// they are not glob patterns. The rule provider that enforces this allowlist rejects any entry
+    /// containing a wildcard and logs an error, so <c>"*"</c> grants nothing rather than everything. That
+    /// is deliberate for an authorization list: a wildcard would also confer the reserved plan
+    /// capabilities (<see cref="Planner.PlanCapabilities"/>) without them ever appearing in the grant,
+    /// and <see cref="GrantsTool"/> would go on reporting them as ungranted. List each tool explicitly.
+    /// <para>
+    /// Tools reached through a granted MCP server are no exception — <see cref="AllowedMcpServers"/>
+    /// controls which servers may be <em>contacted</em>, while invoking any tool it publishes still
+    /// requires that tool's name here.
+    /// </para>
+    /// </remarks>
     public IReadOnlyList<string> AllowedTools { get; init; } = [];
 
     /// <summary>

--- a/src/Content/Domain/Domain.AI/Governance/GovernanceDenials.cs
+++ b/src/Content/Domain/Domain.AI/Governance/GovernanceDenials.cs
@@ -1,0 +1,25 @@
+namespace Domain.AI.Governance;
+
+/// <summary>
+/// The canonical caller-facing text for a governance denial. Every gate that blocks an operation
+/// returns this exact shape, so a denied caller cannot distinguish <em>why</em> it was denied from
+/// the message alone.
+/// </summary>
+/// <remarks>
+/// The deliberate vagueness is the point: rule ids, matched policy paths, capability internals, and
+/// envelope contents stay in the structured log and the <see cref="GovernanceTrace"/>, never in text
+/// relayed to a model or an HTTP caller. Centralising the wording here also stops the three gates
+/// that emit it (the tool-invocation governor and the plan engine's tool and retrieval steps) from
+/// drifting into three subtly different strings that leak which gate fired.
+/// </remarks>
+public static class GovernanceDenials
+{
+    /// <summary>
+    /// The message returned in place of a result when the named operation is not permitted for the
+    /// current caller, agent, or capability envelope.
+    /// </summary>
+    /// <param name="operationName">The tool or capability name that was denied.</param>
+    /// <returns>The caller-facing denial text.</returns>
+    public static string NotPermitted(string operationName) =>
+        $"Error: tool '{operationName}' is not permitted in the current context.";
+}

--- a/src/Content/Domain/Domain.AI/Permissions/PermissionBaselineTier.cs
+++ b/src/Content/Domain/Domain.AI/Permissions/PermissionBaselineTier.cs
@@ -1,0 +1,41 @@
+namespace Domain.AI.Permissions;
+
+/// <summary>
+/// How much authority a rule flagged <see cref="ToolPermissionRule.IsAuthoritativeBaseline"/> carries
+/// relative to the baselines emitted by <em>other</em> rule providers. Baselines within the same tier
+/// arbitrate against each other by pattern specificity and restrictiveness as usual; the tier only
+/// decides what happens when providers disagree about a name.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The tier exists because "authoritative baseline" is not one thing. Most baselines express a
+/// <em>default posture</em> for a set of tools — a plugin saying "my own tools may auto-run". A few
+/// express a <em>grant boundary</em>: the outer edge of what a caller was authorised to do at all.
+/// Those two are not peers, and leaving them as peers is a real hole: a per-name default from one
+/// provider is more specific than a boundary's catch-all, so specificity arbitration alone lets the
+/// default widen the boundary.
+/// </para>
+/// <para>
+/// Declaring the rank on the rule keeps the resolver out of the business of recognising providers. A
+/// provider that is expressing a boundary says so; the resolver arbitrates on what was declared rather
+/// than on who declared it.
+/// </para>
+/// </remarks>
+public enum PermissionBaselineTier
+{
+    /// <summary>
+    /// An ordinary baseline: a default posture for the tools it names, which other baselines may
+    /// outrank by being more specific or more restrictive. This is what every rule carries unless a
+    /// provider deliberately declares otherwise.
+    /// </summary>
+    Default = 0,
+
+    /// <summary>
+    /// A baseline that describes the outer edge of an authorisation grant rather than a default within
+    /// it. No <see cref="Default"/>-tier baseline may resolve to a <em>less</em> restrictive behavior
+    /// than the boundary allows for that tool, whatever its pattern specificity — a boundary can only be
+    /// tightened from outside, never widened. Emitted by the capability envelope, whose rules are the
+    /// host's per-caller grant for a bundle run.
+    /// </summary>
+    GrantBoundary = 1
+}

--- a/src/Content/Domain/Domain.AI/Permissions/ToolPermissionRule.cs
+++ b/src/Content/Domain/Domain.AI/Permissions/ToolPermissionRule.cs
@@ -26,6 +26,19 @@ namespace Domain.AI.Permissions;
 /// falls through to the Deny. Use a plain (non-baseline) Deny when the intent is an unconditional
 /// prohibition rather than a fallback.
 /// </para>
+/// <para>
+/// Specificity arbitration only holds <em>within</em> a <see cref="BaselineTier"/>. A provider closing an
+/// allowlist that other providers must not be able to widen has to say so with
+/// <see cref="PermissionBaselineTier.GrantBoundary"/>; otherwise a peer provider's exact-name baseline
+/// outranks the catch-all and reopens it.
+/// </para>
+/// </param>
+/// <param name="BaselineTier">
+/// How authoritative this rule is relative to the baselines of <em>other</em> providers. Meaningful only
+/// when <paramref name="IsAuthoritativeBaseline"/> is true. Defaults to
+/// <see cref="PermissionBaselineTier.Default"/>: an ordinary baseline that peers may outrank on
+/// specificity. <see cref="PermissionBaselineTier.GrantBoundary"/> marks a rule as the edge of an
+/// authorisation grant, which no Default-tier baseline may widen past.
 /// </param>
 public sealed record ToolPermissionRule(
     string ToolPattern,
@@ -34,4 +47,5 @@ public sealed record ToolPermissionRule(
     PermissionRuleSource Source,
     int Priority,
     bool IsBypassImmune = false,
-    bool IsAuthoritativeBaseline = false);
+    bool IsAuthoritativeBaseline = false,
+    PermissionBaselineTier BaselineTier = PermissionBaselineTier.Default);

--- a/src/Content/Domain/Domain.AI/Permissions/ToolPermissionRule.cs
+++ b/src/Content/Domain/Domain.AI/Permissions/ToolPermissionRule.cs
@@ -14,10 +14,18 @@ namespace Domain.AI.Permissions;
 /// When true, this rule is an operator-set authoritative baseline for the tools it matches: it takes
 /// precedence over generic tier/default rules in <em>both</em> directions (a specific Allow beats a
 /// generic Ask, and a specific Ask beats a generic Allow), independent of the resolver's normal
-/// Deny&gt;Ask&gt;Allow phase ordering. It is evaluated after safety gates and Deny rules, so a Deny
-/// (including a bypass-immune <c>DeniedTools</c> rule) or a safety gate still wins over it. This is
+/// Deny&gt;Ask&gt;Allow phase ordering. It is evaluated after safety gates and ordinary Deny rules, so a
+/// Deny (including a bypass-immune <c>DeniedTools</c> rule) or a safety gate still wins over it. This is
 /// how a plugin's <c>AutonomyLevel</c> scopes the autonomy of its own tools without editing the
 /// global default tier. Ordinary rules leave this false and are unaffected.
+/// <para>
+/// Baselines are resolved <em>only</em> in the baseline phase — never by the phase-ordered Deny/Ask/Allow
+/// scans — and are arbitrated there by pattern specificity first, then restrictiveness. A provider can
+/// therefore close its own allowlist by pairing per-name baselines with a catch-all
+/// <c>"*"</c> baseline Deny: the named rules are more specific and win, and anything they do not cover
+/// falls through to the Deny. Use a plain (non-baseline) Deny when the intent is an unconditional
+/// prohibition rather than a fallback.
+/// </para>
 /// </param>
 public sealed record ToolPermissionRule(
     string ToolPattern,

--- a/src/Content/Domain/Domain.AI/Planner/PlanCapabilities.cs
+++ b/src/Content/Domain/Domain.AI/Planner/PlanCapabilities.cs
@@ -55,8 +55,14 @@ namespace Domain.AI.Planner;
 /// able to take down every agent turn in the host.
 /// </para>
 /// <para>
-/// Withholding a name here is fail-closed for enveloped plan runs. With no ambient envelope (direct
-/// in-process <c>IPlanExecutor</c> callers) the governor is a pass-through and behavior is unchanged.
+/// <strong>Withholding a name here is fail-closed for enveloped plan runs — by mechanism, not by
+/// convention.</strong> The envelope's rule provider emits a catch-all authoritative-baseline Deny
+/// alongside its per-name grants. An ungranted capability matches only that closing rule and is denied
+/// inside the resolver's baseline phase, so resolution never reaches the host's generic autonomy tier —
+/// which, in the shipped bundle-host configuration, would otherwise answer Allow for any name nobody had
+/// ruled on. Granting is therefore the only way a plan run performs retrieval or inference. With no
+/// ambient envelope (direct in-process <c>IPlanExecutor</c> callers) the provider emits nothing at all,
+/// the governor is a pass-through, and behavior is unchanged.
 /// </para>
 /// </remarks>
 public static class PlanCapabilities

--- a/src/Content/Domain/Domain.AI/Planner/PlanCapabilities.cs
+++ b/src/Content/Domain/Domain.AI/Planner/PlanCapabilities.cs
@@ -32,13 +32,27 @@ namespace Domain.AI.Planner;
 /// </para>
 /// <para>
 /// <strong>These names share a namespace with real tool keys — treat them as reserved.</strong> They
-/// are matched out of the same <c>AllowedTools</c> string space as keyed <c>ITool</c> registrations,
-/// so a host that registers a tool under one of these keys silently merges the two grants: granting
-/// the plan capability would also grant that tool, and vice versa. The DI container itself does not
-/// prevent it, so the harness's composition root refuses the collision at boot: Presentation.Common's
-/// <c>ValidateNoReservedPlanCapabilityToolKeys</c> scans every keyed <c>ITool</c> descriptor against
-/// <see cref="IsReserved"/> and throws, naming the offending key. A consumer host that registers
-/// tools outside that composition root should call the same guard after doing so.
+/// are matched out of the same <c>AllowedTools</c> string space as every other tool name, so a tool
+/// published under one of these names silently merges two grants a caller believes are separate:
+/// granting the plan capability would also grant that tool, and vice versa. Nothing in the tool
+/// plumbing prevents the collision on its own, so two complementary mechanisms cover the two ways a
+/// name can arrive — and neither subsumes the other.
+/// </para>
+/// <para>
+/// <strong>First-party names, refused at boot.</strong> Presentation.Common's
+/// <c>ValidateNoReservedPlanCapabilityToolKeys</c> scans every keyed <c>ITool</c> descriptor in the
+/// container against <see cref="IsReserved"/> and throws, naming the offending key. This covers code
+/// the host owns, where a collision is a wiring bug and failing fast is correct. A consumer host that
+/// registers tools outside the harness composition root should call the same guard after doing so.
+/// </para>
+/// <para>
+/// <strong>Third-party names, dropped at resolution.</strong> MCP-client and plugin-manifest tools are
+/// discovered at <em>runtime</em>, so no boot-time DI scan can see them — an external server can start
+/// publishing <c>rag_retrieval</c> long after the host booted cleanly. <c>ToolChainBuilder</c>
+/// therefore re-checks <see cref="IsReserved"/> at the single point every resolved chain exits, and
+/// excludes a colliding tool from the callable surface before it is governance-wrapped. That path
+/// deliberately logs and drops rather than throwing: a third party editing its tool list must not be
+/// able to take down every agent turn in the host.
 /// </para>
 /// <para>
 /// Withholding a name here is fail-closed for enveloped plan runs. With no ambient envelope (direct

--- a/src/Content/Domain/Domain.AI/Planner/PlanCapabilities.cs
+++ b/src/Content/Domain/Domain.AI/Planner/PlanCapabilities.cs
@@ -34,10 +34,11 @@ namespace Domain.AI.Planner;
 /// <strong>These names share a namespace with real tool keys — treat them as reserved.</strong> They
 /// are matched out of the same <c>AllowedTools</c> string space as keyed <c>ITool</c> registrations,
 /// so a host that registers a tool under one of these keys silently merges the two grants: granting
-/// the plan capability would also grant that tool, and vice versa. Nothing in the DI container
-/// prevents it, because tool registration order is not guaranteed relative to the planner's. Hosts
-/// registering tools should assert <see cref="IsReserved"/> is false for each key — the harness's own
-/// registrations are covered by a test that does exactly that.
+/// the plan capability would also grant that tool, and vice versa. The DI container itself does not
+/// prevent it, so the harness's composition root refuses the collision at boot: Presentation.Common's
+/// <c>ValidateNoReservedPlanCapabilityToolKeys</c> scans every keyed <c>ITool</c> descriptor against
+/// <see cref="IsReserved"/> and throws, naming the offending key. A consumer host that registers
+/// tools outside that composition root should call the same guard after doing so.
 /// </para>
 /// <para>
 /// Withholding a name here is fail-closed for enveloped plan runs. With no ambient envelope (direct

--- a/src/Content/Domain/Domain.AI/Planner/PlanCapabilities.cs
+++ b/src/Content/Domain/Domain.AI/Planner/PlanCapabilities.cs
@@ -31,6 +31,15 @@ namespace Domain.AI.Planner;
 /// which is a strictly larger change than giving the risk table a friendlier number.
 /// </para>
 /// <para>
+/// <strong>These names share a namespace with real tool keys — treat them as reserved.</strong> They
+/// are matched out of the same <c>AllowedTools</c> string space as keyed <c>ITool</c> registrations,
+/// so a host that registers a tool under one of these keys silently merges the two grants: granting
+/// the plan capability would also grant that tool, and vice versa. Nothing in the DI container
+/// prevents it, because tool registration order is not guaranteed relative to the planner's. Hosts
+/// registering tools should assert <see cref="IsReserved"/> is false for each key — the harness's own
+/// registrations are covered by a test that does exactly that.
+/// </para>
+/// <para>
 /// Withholding a name here is fail-closed for enveloped plan runs. With no ambient envelope (direct
 /// in-process <c>IPlanExecutor</c> callers) the governor is a pass-through and behavior is unchanged.
 /// </para>
@@ -52,4 +61,19 @@ public static class PlanCapabilities
     /// fully-constrained envelope from still buying unbounded tokens.
     /// </summary>
     public const string LlmCall = "llm_call";
+
+    /// <summary>
+    /// Every reserved plan-capability name. A tool must never be registered under one of these keys —
+    /// see the collision note in the type remarks.
+    /// </summary>
+    public static IReadOnlyList<string> ReservedNames { get; } = [Retrieval, LlmCall];
+
+    /// <summary>
+    /// Whether <paramref name="name"/> is a reserved plan-capability name and therefore unavailable as
+    /// a tool registration key. Case-insensitive, matching how the envelope matches allowlist entries.
+    /// </summary>
+    /// <param name="name">The candidate tool registration key.</param>
+    /// <returns><c>true</c> when the name is reserved.</returns>
+    public static bool IsReserved(string? name) =>
+        name is not null && ReservedNames.Contains(name, StringComparer.OrdinalIgnoreCase);
 }

--- a/src/Content/Domain/Domain.AI/Planner/PlanCapabilities.cs
+++ b/src/Content/Domain/Domain.AI/Planner/PlanCapabilities.cs
@@ -1,0 +1,55 @@
+namespace Domain.AI.Planner;
+
+/// <summary>
+/// Well-known capability names a caller's <c>CapabilityEnvelope</c> can grant to plan-native
+/// operations that do not flow through a named tool.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The envelope model is tool-shaped: it grants by tool name (<c>AllowedTools</c>), MCP server name
+/// (<c>AllowedMcpServers</c>), and autonomy ceiling. Plan <c>Retrieval</c> and <c>LlmCall</c> steps,
+/// however, invoke the RAG orchestrators and the conversation pipeline directly — there is no tool
+/// name on the wire for the envelope to match. These constants give such operations a stable,
+/// documented name that is authorized through the <em>same</em> tool-invocation governor as any real
+/// tool, so they inherit the full chain: envelope allowlist, autonomy ceiling, graded-autonomy risk
+/// gate, declarative policy, audit, and denial-rate accounting.
+/// </para>
+/// <para>
+/// <strong>Authorize, never match by hand.</strong> A step must never test
+/// <c>AllowedTools.Contains(...)</c> for these names itself. Membership is only one of the inputs the
+/// governor considers: the envelope's rule provider also emits an autonomy-ceiling baseline for every
+/// granted name, so a name present in <c>AllowedTools</c> under a Restricted or Supervised ceiling
+/// still resolves to Ask, which the fail-closed governor blocks. A hand-rolled membership check sees
+/// the grant and misses the ceiling.
+/// </para>
+/// <para>
+/// <strong>Risk classification.</strong> These names resolve no keyed <c>ITool</c>, so
+/// <c>IToolRiskClassifier</c> returns its fail-safe default (Medium blast radius, treated as a state
+/// change). That is deliberately conservative for what are read/inference operations: under graded
+/// autonomy it can tighten a decision to Ask, never loosen one. They are intentionally not registered
+/// as <c>ITool</c> implementations — that would publish them on the agent's callable tool surface,
+/// which is a strictly larger change than giving the risk table a friendlier number.
+/// </para>
+/// <para>
+/// Withholding a name here is fail-closed for enveloped plan runs. With no ambient envelope (direct
+/// in-process <c>IPlanExecutor</c> callers) the governor is a pass-through and behavior is unchanged.
+/// </para>
+/// </remarks>
+public static class PlanCapabilities
+{
+    /// <summary>
+    /// Grants plan <see cref="StepType.Retrieval"/> steps the right to query the RAG pipeline.
+    /// A host that wants an enveloped plan run to perform retrieval must include this name in the
+    /// envelope's <c>AllowedTools</c> <em>and</em> grant an autonomy ceiling that permits it;
+    /// otherwise every Retrieval step in that run fails closed.
+    /// </summary>
+    public const string Retrieval = "rag_retrieval";
+
+    /// <summary>
+    /// Grants plan <see cref="StepType.LlmCall"/> steps the right to drive model inference on the
+    /// host's credential with a plan-authored system prompt. Withholding it confines a caller to a
+    /// plan that performs no inference at all — the control that stops an otherwise
+    /// fully-constrained envelope from still buying unbounded tokens.
+    /// </summary>
+    public const string LlmCall = "llm_call";
+}

--- a/src/Content/Domain/Domain.AI/Planner/PlanRunKeys.cs
+++ b/src/Content/Domain/Domain.AI/Planner/PlanRunKeys.cs
@@ -1,0 +1,52 @@
+namespace Domain.AI.Planner;
+
+/// <summary>
+/// Derives the two distinct identities a plan run needs, so they cannot be conflated: a
+/// <em>per-step conversation id</em> and a <em>run-level budget key</em>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>Why these must be different.</strong> A conversation id is heavily overloaded downstream —
+/// it is the sole key of <c>IAgentConversationCache</c> (which returns a cached agent on a hit and
+/// ignores the requested skills and options entirely), the key of <c>ISkillCompletionTracker</c>, and
+/// the observability session key. Sharing one id across concurrent plan steps therefore makes a step
+/// silently run under a different step's agent — different skills, instructions, allowed tools, and
+/// deployment — and lets whichever step finishes first evict the cache entry and clear the skill
+/// tracking of steps still in flight. Every step consequently gets its own conversation id.
+/// </para>
+/// <para>
+/// <strong>Why the budget key is separate.</strong> <c>RunConversationCommandHandler</c> owns the
+/// whole lifecycle of its conversation's budget entry and calls
+/// <c>IConversationBudgetTracker.Release</c> in a <c>finally</c>, which removes the entry outright.
+/// A budget accumulated under any conversation id it is given is therefore erased the moment that
+/// conversation ends, so cross-step spend cannot be tracked there. The run-level key is namespaced
+/// out of the conversation-id space so no handler owns it, and the plan run accumulates against it
+/// explicitly and releases it when the run finishes.
+/// </para>
+/// </remarks>
+public static class PlanRunKeys
+{
+    /// <summary>
+    /// Prefix marking a budget entry as owned by a plan run rather than by a conversation. Also
+    /// guarantees the key cannot collide with a real conversation id.
+    /// </summary>
+    public const string RunBudgetPrefix = "planrun:";
+
+    /// <summary>
+    /// The conversation id for a single plan step. Unique per step so agent resolution, cache
+    /// eviction, skill-completion tracking, and the observability session all stay isolated.
+    /// </summary>
+    /// <param name="runScope">Identity of the enclosing run (its conversation id or plan id).</param>
+    /// <param name="stepId">The step being executed.</param>
+    /// <returns>The step's conversation id.</returns>
+    public static string StepConversationId(string runScope, PlanStepId stepId) =>
+        $"{runScope}:{stepId.Value}";
+
+    /// <summary>
+    /// The budget key accumulating token spend across every step of one plan run. Owned by the plan
+    /// run — no conversation handler releases it.
+    /// </summary>
+    /// <param name="runScope">Identity of the run (its conversation id or plan id).</param>
+    /// <returns>The run's budget key.</returns>
+    public static string RunBudgetKey(string runScope) => $"{RunBudgetPrefix}{runScope}";
+}

--- a/src/Content/Domain/Domain.AI/Planner/PlanStepErrors.cs
+++ b/src/Content/Domain/Domain.AI/Planner/PlanStepErrors.cs
@@ -27,6 +27,16 @@ public static class PlanStepErrors
     /// <summary>The sandbox threw while executing a tool step.</summary>
     public const string SandboxFailed = "step.sandbox_failed";
 
+    /// <summary>
+    /// The sandbox ran the tool and it reported failure. Distinct from
+    /// <see cref="SandboxFailed"/>, which means the sandbox itself could not complete the execution:
+    /// this one says the tool ran and did not succeed, so a consumer can tell "your tool errored" from
+    /// "we could not run your tool". The sandbox's own failure text is not relayed — it carries raw
+    /// process stderr or container logs, where file-system paths, environment variables, and credentials
+    /// surface — and stays in the structured log instead.
+    /// </summary>
+    public const string ToolFailed = "step.tool_failed";
+
     /// <summary>The step exceeded its per-attempt timeout.</summary>
     public const string Timeout = "step.timeout";
 

--- a/src/Content/Domain/Domain.AI/Planner/PlanStepErrors.cs
+++ b/src/Content/Domain/Domain.AI/Planner/PlanStepErrors.cs
@@ -1,0 +1,44 @@
+namespace Domain.AI.Planner;
+
+/// <summary>
+/// Stable, scrubbed error codes persisted in <see cref="StepExecutionState.ErrorMessage"/> when a
+/// step fails from an exception. These are the only failure text a caller ever sees for those paths.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Step error state is persisted and returned to callers through
+/// <see cref="PlanExecutionSummary.StepStates"/>, which a host surface relays over HTTP. Raw
+/// exception text on that path is a leak channel: sandbox, EF Core, and HTTP-client messages carry
+/// file-system paths, connection strings, and SAS tokens. Every exception is therefore logged in
+/// full via structured logging and reduced to one of these codes before it is persisted.
+/// </para>
+/// <para>
+/// Codes are contract: a consumer may branch on them. Add new ones rather than re-wording existing
+/// ones. Failure text that never originates from an exception — a human gate's reason, a governance
+/// denial (<see cref="Governance.GovernanceDenials.NotPermitted"/>), a validation message the engine
+/// itself composed — is already caller-safe and is not routed through here.
+/// </para>
+/// </remarks>
+public static class PlanStepErrors
+{
+    /// <summary>An unhandled exception escaped the step executor.</summary>
+    public const string ExecutionFailed = "step.execution_failed";
+
+    /// <summary>The sandbox threw while executing a tool step.</summary>
+    public const string SandboxFailed = "step.sandbox_failed";
+
+    /// <summary>The step exceeded its per-attempt timeout.</summary>
+    public const string Timeout = "step.timeout";
+
+    /// <summary>The retrieval pipeline threw while executing a retrieval step.</summary>
+    public const string RetrievalFailed = "step.retrieval_failed";
+
+    /// <summary>The child plan threw while executing a sub-plan step.</summary>
+    public const string SubPlanFailed = "step.subplan_failed";
+
+    /// <summary>
+    /// The plan run's lifetime conversation token budget was already spent, so the step refused to
+    /// start another conversation. A spend control, not an execution fault.
+    /// </summary>
+    public const string BudgetExhausted = "step.budget_exhausted";
+}

--- a/src/Content/Domain/Domain.AI/Planner/PlanStepErrors.cs
+++ b/src/Content/Domain/Domain.AI/Planner/PlanStepErrors.cs
@@ -41,4 +41,11 @@ public static class PlanStepErrors
     /// start another conversation. A spend control, not an execution fault.
     /// </summary>
     public const string BudgetExhausted = "step.budget_exhausted";
+
+    /// <summary>
+    /// The step declared a required autonomy level above the capability envelope's ceiling. Which
+    /// tier was required, and what the ceiling was, stay in the structured log: both describe the
+    /// caller's grant, which is exactly the operator policy detail this field must not relay.
+    /// </summary>
+    public const string AutonomyCeilingExceeded = "step.autonomy_ceiling_exceeded";
 }

--- a/src/Content/Domain/Domain.AI/Planner/StepExecutionResult.cs
+++ b/src/Content/Domain/Domain.AI/Planner/StepExecutionResult.cs
@@ -30,4 +30,25 @@ public sealed record StepExecutionResult
     /// Null for non-branching steps.
     /// </summary>
     public PlanStepId? ActiveEdgeTarget { get; init; }
+
+    /// <summary>
+    /// True when this failure is a governance denial — the capability envelope, permission chain, or
+    /// autonomy ceiling refused the operation — rather than a transient execution failure.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The distinction is load-bearing, not cosmetic. <see cref="RetryPolicy"/> is plan-authored
+    /// data, so a plan can declare <see cref="ErrorRecovery.SkipStep"/> on the very step a policy
+    /// blocks; applying that recovery would let the plan author choose the disposition of the check
+    /// that constrains the plan author, and the run would report Completed with the denial silently
+    /// dropped. An <see cref="ErrorRecovery.Escalate"/> policy is worse: it loops approve → re-run →
+    /// deny → escalate again, asking a human to approve something the envelope will never permit.
+    /// </para>
+    /// <para>
+    /// The executor therefore routes a result carrying this flag to a terminal failure that neither
+    /// the retry budget nor <see cref="RetryPolicy.OnExhausted"/> can soften — the same reasoning
+    /// that keeps a rejected escalation out of the retry policy.
+    /// </para>
+    /// </remarks>
+    public bool IsPolicyDenial { get; init; }
 }

--- a/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.Planner.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.Planner.cs
@@ -70,6 +70,13 @@ public static partial class DependencyInjection
         services.TryAddScoped<IKnowledgeScope, NullKnowledgeScope>();
 
         services.AddScoped<IPlanExecutor, PlanExecutor>();
+
+        // Singleton like IBundleRunExecutor: the executor owns no per-run state itself — it creates a
+        // fresh DI scope per run and arms the caller's capability envelope + governance identity
+        // around IPlanExecutor inside that scope. Registration is unconditional and passive; nothing
+        // resolves it until a host surface (W4) calls it.
+        services.AddSingleton<IPlanRunExecutor, PlanRunExecutor>();
+
         services.AddScoped<IPlanValidator, PlanValidator>();
         services.AddScoped<IPlanGenerator, LlmPlanGeneratorService>();
         services.AddScoped<IPlanStateStore, EfCorePlanStateStore>();

--- a/src/Content/Infrastructure/Infrastructure.AI/Governance/CapabilityEnvelopeResolver.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Governance/CapabilityEnvelopeResolver.cs
@@ -59,7 +59,7 @@ public sealed class CapabilityEnvelopeResolver : ICapabilityEnvelopeResolver
                           ?? principal.FindFirst("sub")?.Value;
 
             if (!string.IsNullOrEmpty(subject) && envelopes.BySubject.TryGetValue(subject, out var bySubject))
-                return Map(bySubject);
+                return WarnIfMcpGrantIsUnusable(Map(bySubject));
 
             var matchingRoles = RoleValues(principal)
                 .Where(role => envelopes.ByRole.ContainsKey(role))
@@ -67,10 +67,45 @@ public sealed class CapabilityEnvelopeResolver : ICapabilityEnvelopeResolver
                 .ToList();
 
             if (matchingRoles.Count > 0)
-                return CombineLeastPrivilege(matchingRoles);
+                return WarnIfMcpGrantIsUnusable(CombineLeastPrivilege(matchingRoles));
         }
 
-        return Map(envelopes.Default);
+        return WarnIfMcpGrantIsUnusable(Map(envelopes.Default));
+    }
+
+    /// <summary>
+    /// Warns when an envelope grants MCP servers but names no tools, and returns it unchanged.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// That shape is almost certainly an operator error rather than a deliberate grant.
+    /// <see cref="CapabilityEnvelope.AllowedMcpServers"/> gates which servers may be <em>contacted</em>;
+    /// invoking any tool one of them publishes still requires that tool's name in
+    /// <see cref="CapabilityEnvelope.AllowedTools"/>. So the run pays to reach every granted server, the
+    /// fetched schemas are published to the model, the model calls one — and the permission resolver
+    /// denies it, because the name is outside the allowlist. The operator sees a bundle that fails every
+    /// call for no visible reason.
+    /// </para>
+    /// <para>
+    /// This warns rather than throwing: the configuration is safe (it fails closed, which is the correct
+    /// direction) and an empty tool list is legitimate for a caller who is meant to have no tool access
+    /// at all. Refusing to start would turn a misconfiguration into an outage.
+    /// </para>
+    /// </remarks>
+    private CapabilityEnvelope WarnIfMcpGrantIsUnusable(CapabilityEnvelope envelope)
+    {
+        if (envelope.AllowedMcpServers.Count > 0 && envelope.AllowedTools.Count == 0)
+        {
+            _logger.LogWarning(
+                "Capability envelope grants {ServerCount} MCP server(s) ({Servers}) but names no tools in " +
+                "AllowedTools, so every tool those servers publish will be denied at invocation. " +
+                "AllowedMcpServers gates which servers may be CONTACTED; AllowedTools gates which tools may " +
+                "be INVOKED — list each MCP tool name in AllowedTools as well.",
+                envelope.AllowedMcpServers.Count,
+                string.Join(", ", envelope.AllowedMcpServers));
+        }
+
+        return envelope;
     }
 
     /// <summary>

--- a/src/Content/Infrastructure/Infrastructure.AI/Permissions/GlobPatternMatcher.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Permissions/GlobPatternMatcher.cs
@@ -38,4 +38,23 @@ public sealed class GlobPatternMatcher : IPatternMatcher
 
         return string.Equals(pattern, value, StringComparison.OrdinalIgnoreCase);
     }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Ranks by how much of a candidate value the pattern pins down: the match-everything pattern
+    /// constrains nothing and ranks 0, a trailing wildcard ranks by the length of the literal prefix it
+    /// requires, and an exact pattern ranks one above its own length. That last <c>+1</c> is what
+    /// guarantees the interface's contract — for any value <c>v</c>, a wildcard matching <c>v</c> can
+    /// require at most <c>v.Length</c> literal characters, so the exact pattern's <c>v.Length + 1</c>
+    /// always wins.
+    /// </remarks>
+    public int Specificity(string pattern)
+    {
+        // An empty pattern matches nothing (see IsMatch), so it can never be the selected rule; rank it
+        // with the catch-all rather than inventing a separate case.
+        if (string.IsNullOrEmpty(pattern) || pattern == "*")
+            return 0;
+
+        return pattern.EndsWith('*') ? pattern.Length - 1 : pattern.Length + 1;
+    }
 }

--- a/src/Content/Infrastructure/Infrastructure.AI/Permissions/ThreePhasePermissionResolver.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Permissions/ThreePhasePermissionResolver.cs
@@ -17,10 +17,18 @@ namespace Infrastructure.AI.Permissions;
 /// <list type="number">
 ///   <item><description><strong>Phase 0 (Rate Limit)</strong>: Check denial tracker for auto-deny before any rule evaluation.</description></item>
 ///   <item><description><strong>Phase 1 (Deny/Safety)</strong>: Check safety gates first, then find the first matching Deny rule.</description></item>
+///   <item><description><strong>Phase 1.5 (Authoritative baseline)</strong>: Arbitrate the rules flagged <see cref="ToolPermissionRule.IsAuthoritativeBaseline"/> by specificity, then restrictiveness.</description></item>
 ///   <item><description><strong>Phase 2 (Ask)</strong>: Find the first matching Ask rule. If bypass-immune, return Ask regardless.</description></item>
 ///   <item><description><strong>Phase 3 (Allow)</strong>: Find the first matching Allow rule. If no match, default to Ask.</description></item>
 /// </list>
 /// <para>Rules are sorted by <see cref="ToolPermissionRule.Priority"/> ascending before evaluation.</para>
+/// <para>
+/// Authoritative baselines are resolved <em>only</em> in phase 1.5 — the phase-ordered scans skip them.
+/// That separation is what lets a rule provider close its own allowlist: it can emit per-name baseline
+/// grants alongside a catch-all baseline Deny, and the specificity arbitration in phase 1.5 gives the
+/// grants precedence while any name they do not cover falls to the Deny. Were baselines also visible to
+/// the phase-ordered scans, the catch-all Deny would match in phase 1b and deny the granted names too.
+/// </para>
 /// </remarks>
 public sealed class ThreePhasePermissionResolver : IToolPermissionService
 {
@@ -177,6 +185,18 @@ public sealed class ThreePhasePermissionResolver : IToolPermissionService
         return allRules;
     }
 
+    /// <summary>
+    /// Finds the first rule matching the tool, operation, and <paramref name="behavior"/> in priority
+    /// order, for the phase-ordered scans (Deny, then Ask, then Allow).
+    /// </summary>
+    /// <remarks>
+    /// Authoritative-baseline rules are deliberately excluded: they are arbitrated as a set in phase 1.5
+    /// by <see cref="FindFirstAuthoritativeBaseline"/>, which weighs specificity against restrictiveness.
+    /// Letting them also participate here would let phase ordering pre-empt that arbitration — a
+    /// catch-all baseline Deny would match in phase 1b and kill the specific baseline Allows that are
+    /// supposed to outrank it. Excluding them costs nothing in the other two phases: any baseline that
+    /// matches has already caused phase 1.5 to return, so phases 2 and 3 never see a matching one.
+    /// </remarks>
     private ToolPermissionRule? FindFirstMatchingRule(
         IReadOnlyList<ToolPermissionRule> rules,
         string toolName,
@@ -185,21 +205,13 @@ public sealed class ThreePhasePermissionResolver : IToolPermissionService
     {
         foreach (var rule in rules)
         {
+            if (rule.IsAuthoritativeBaseline)
+                continue;
+
             if (rule.Behavior != behavior)
                 continue;
 
-            if (!_patternMatcher.IsMatch(rule.ToolPattern, toolName))
-                continue;
-
-            if (rule.OperationPattern is not null
-                && operation is not null
-                && !_patternMatcher.IsMatch(rule.OperationPattern, operation))
-            {
-                continue;
-            }
-
-            // If rule has an operation pattern but no operation was provided, skip
-            if (rule.OperationPattern is not null && operation is null)
+            if (!Matches(rule, toolName, operation))
                 continue;
 
             return rule;
@@ -209,14 +221,55 @@ public sealed class ThreePhasePermissionResolver : IToolPermissionService
     }
 
     /// <summary>
-    /// Selects the governing rule flagged <see cref="ToolPermissionRule.IsAuthoritativeBaseline"/>
-    /// among all that match the tool name and operation. When more than one matches (for example two
-    /// plugins declaring the same tool name with opposite autonomy levels), the <b>most restrictive</b>
-    /// behavior wins — Deny &gt; Ask &gt; Allow — so a permissive baseline can never silently override a
-    /// restrictive one on iteration/load order. Ties within the same behavior fall back to the lowest
-    /// <see cref="ToolPermissionRule.Priority"/>. Returns null when no authoritative-baseline rule
-    /// matches (the overwhelmingly common case).
+    /// Whether <paramref name="rule"/> applies to this tool name and operation. A rule that names an
+    /// operation pattern applies only when an operation was supplied and matches it.
     /// </summary>
+    private bool Matches(ToolPermissionRule rule, string toolName, string? operation)
+    {
+        if (!_patternMatcher.IsMatch(rule.ToolPattern, toolName))
+            return false;
+
+        if (rule.OperationPattern is null)
+            return true;
+
+        return operation is not null && _patternMatcher.IsMatch(rule.OperationPattern, operation);
+    }
+
+    /// <summary>
+    /// Selects the governing rule flagged <see cref="ToolPermissionRule.IsAuthoritativeBaseline"/>
+    /// among all that match the tool name and operation. Returns null when none matches (the
+    /// overwhelmingly common case).
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Arbitration is <b>specificity first, restrictiveness second</b>:
+    /// </para>
+    /// <list type="number">
+    ///   <item><description>
+    ///   The baseline whose pattern selects most narrowly wins outright (see
+    ///   <see cref="IPatternMatcher.Specificity"/>). This is what lets a provider express "deny anything
+    ///   I did not name" as a catch-all baseline alongside per-name grants: the grants are written for
+    ///   one exact name and therefore outrank the catch-all, while a name no grant covers falls through
+    ///   to it. Without specificity ordering the catch-all Deny — being the most restrictive rule in the
+    ///   set — would swallow every grant.
+    ///   </description></item>
+    ///   <item><description>
+    ///   Among equally specific baselines the <b>most restrictive</b> behavior wins — Deny &gt; Ask &gt;
+    ///   Allow — so two plugins declaring the same tool name with opposite autonomy levels resolve to the
+    ///   stricter one and never to whichever happened to load first.
+    ///   </description></item>
+    ///   <item><description>
+    ///   Ties fall back to the lowest <see cref="ToolPermissionRule.Priority"/>.
+    ///   </description></item>
+    /// </list>
+    /// <para>
+    /// Specificity ranks above restrictiveness rather than below it because a broad pattern is a
+    /// <em>default</em> and a narrow one is a <em>decision</em> about a specific name: an operator who
+    /// names a tool explicitly has said something more deliberate than whoever wrote the fallback, in
+    /// either direction. Restrictiveness still governs the case the operator cannot disambiguate —
+    /// two equally specific claims on the same name.
+    /// </para>
+    /// </remarks>
     private ToolPermissionRule? FindFirstAuthoritativeBaseline(
         IReadOnlyList<ToolPermissionRule> rules,
         string toolName,
@@ -229,20 +282,10 @@ public sealed class ThreePhasePermissionResolver : IToolPermissionService
             if (!rule.IsAuthoritativeBaseline)
                 continue;
 
-            if (!_patternMatcher.IsMatch(rule.ToolPattern, toolName))
+            if (!Matches(rule, toolName, operation))
                 continue;
 
-            if (rule.OperationPattern is not null
-                && operation is not null
-                && !_patternMatcher.IsMatch(rule.OperationPattern, operation))
-            {
-                continue;
-            }
-
-            if (rule.OperationPattern is not null && operation is null)
-                continue;
-
-            if (best is null || IsMoreRestrictive(rule, best))
+            if (best is null || Outranks(rule, best))
                 best = rule;
         }
 
@@ -250,13 +293,18 @@ public sealed class ThreePhasePermissionResolver : IToolPermissionService
     }
 
     /// <summary>
-    /// Orders permission behaviors by restrictiveness for authoritative-baseline arbitration:
-    /// Deny (0) is most restrictive, then Ask (1), then Allow (2). A <paramref name="candidate"/> wins
-    /// over the <paramref name="incumbent"/> when it is strictly more restrictive, or equally
-    /// restrictive but with a lower (earlier) priority.
+    /// Whether <paramref name="candidate"/> should govern instead of <paramref name="incumbent"/>:
+    /// a strictly more specific pattern wins; failing that a strictly more restrictive behavior wins
+    /// (Deny &gt; Ask &gt; Allow); failing that the lower (earlier) priority wins.
     /// </summary>
-    private static bool IsMoreRestrictive(ToolPermissionRule candidate, ToolPermissionRule incumbent)
+    private bool Outranks(ToolPermissionRule candidate, ToolPermissionRule incumbent)
     {
+        var candidateSpecificity = _patternMatcher.Specificity(candidate.ToolPattern);
+        var incumbentSpecificity = _patternMatcher.Specificity(incumbent.ToolPattern);
+
+        if (candidateSpecificity != incumbentSpecificity)
+            return candidateSpecificity > incumbentSpecificity;
+
         var candidateRank = RestrictivenessRank(candidate.Behavior);
         var incumbentRank = RestrictivenessRank(incumbent.Behavior);
 

--- a/src/Content/Infrastructure/Infrastructure.AI/Permissions/ThreePhasePermissionResolver.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Permissions/ThreePhasePermissionResolver.cs
@@ -186,10 +186,60 @@ public sealed class ThreePhasePermissionResolver : IToolPermissionService
         foreach (var provider in _ruleProviders)
         {
             var rules = await provider.GetRulesAsync(agentId, cancellationToken);
-            allRules.AddRange(rules);
+
+            foreach (var rule in rules)
+                allRules.Add(EnforceGrantBoundaryOwnership(rule));
         }
 
         return allRules;
+    }
+
+    /// <summary>
+    /// Demotes a <see cref="PermissionBaselineTier.GrantBoundary"/> claim from any source other than
+    /// the capability envelope, so a provider cannot award itself boundary authority.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The grant boundary is the edge of a <em>per-caller authorization</em>, not a posture a provider
+    /// may assert about itself. Boundary rules are arbitrated among themselves by specificity, so a
+    /// provider that both claimed the tier and named a tool exactly would outrank the envelope's
+    /// closing <c>"*"</c> deny and widen the caller's grant to a tool the host never issued — the same
+    /// defect that reached this codebase twice already, one tier up.
+    /// </para>
+    /// <para>
+    /// This is a guard, not arbitration: the ranking logic in <c>Outranks</c> stays free of provider
+    /// identity, and the single place that knows who may declare a boundary is here, at the point the
+    /// claim enters the system. Demote and log rather than throw — a misconfigured extension provider
+    /// should lose its unearned authority, not take down every tool call in the host. This matches how
+    /// <c>ReservedPlanCapabilityFilter</c> treats an illegitimate claim from a runtime source.
+    /// </para>
+    /// <para>
+    /// Not reachable from any provider in this repository — all four registered providers are correct.
+    /// It exists because adding a rule provider is a documented extension point, and a consumer's fifth
+    /// provider is exactly where this stops being true.
+    /// </para>
+    /// </remarks>
+    /// <param name="rule">The rule as emitted by its provider.</param>
+    /// <returns>
+    /// The rule unchanged, or a copy demoted to <see cref="PermissionBaselineTier.Default"/> when it
+    /// claimed a grant boundary it is not entitled to.
+    /// </returns>
+    private ToolPermissionRule EnforceGrantBoundaryOwnership(ToolPermissionRule rule)
+    {
+        if (rule.BaselineTier != PermissionBaselineTier.GrantBoundary
+            || rule.Source == PermissionRuleSource.CapabilityEnvelope)
+        {
+            return rule;
+        }
+
+        _logger.LogError(
+            "Provider source {Source} declared PermissionBaselineTier.GrantBoundary on pattern " +
+            "'{ToolPattern}'. Only the capability envelope may declare a grant boundary; demoting to " +
+            "Default so it cannot widen a caller's envelope.",
+            rule.Source,
+            rule.ToolPattern);
+
+        return rule with { BaselineTier = PermissionBaselineTier.Default };
     }
 
     /// <summary>

--- a/src/Content/Infrastructure/Infrastructure.AI/Permissions/ThreePhasePermissionResolver.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Permissions/ThreePhasePermissionResolver.cs
@@ -17,7 +17,7 @@ namespace Infrastructure.AI.Permissions;
 /// <list type="number">
 ///   <item><description><strong>Phase 0 (Rate Limit)</strong>: Check denial tracker for auto-deny before any rule evaluation.</description></item>
 ///   <item><description><strong>Phase 1 (Deny/Safety)</strong>: Check safety gates first, then find the first matching Deny rule.</description></item>
-///   <item><description><strong>Phase 1.5 (Authoritative baseline)</strong>: Arbitrate the rules flagged <see cref="ToolPermissionRule.IsAuthoritativeBaseline"/> by specificity, then restrictiveness.</description></item>
+///   <item><description><strong>Phase 1.5 (Authoritative baseline)</strong>: Arbitrate the rules flagged <see cref="ToolPermissionRule.IsAuthoritativeBaseline"/> by specificity, then restrictiveness, capped by any grant boundary among them.</description></item>
 ///   <item><description><strong>Phase 2 (Ask)</strong>: Find the first matching Ask rule. If bypass-immune, return Ask regardless.</description></item>
 ///   <item><description><strong>Phase 3 (Allow)</strong>: Find the first matching Allow rule. If no match, default to Ask.</description></item>
 /// </list>
@@ -28,6 +28,13 @@ namespace Infrastructure.AI.Permissions;
 /// grants alongside a catch-all baseline Deny, and the specificity arbitration in phase 1.5 gives the
 /// grants precedence while any name they do not cover falls to the Deny. Were baselines also visible to
 /// the phase-ordered scans, the catch-all Deny would match in phase 1b and deny the granted names too.
+/// </para>
+/// <para>
+/// Specificity alone is not enough to close an allowlist against <em>other</em> providers, because a peer
+/// provider's exact-name baseline is more specific than the catch-all and would outrank it. A provider
+/// that is expressing an authorisation boundary rather than a default therefore declares
+/// <see cref="PermissionBaselineTier.GrantBoundary"/> on its rules, and phase 1.5 caps the outcome at
+/// what that boundary permits. See <see cref="FindFirstAuthoritativeBaseline"/>.
 /// </para>
 /// </remarks>
 public sealed class ThreePhasePermissionResolver : IToolPermissionService
@@ -242,7 +249,25 @@ public sealed class ThreePhasePermissionResolver : IToolPermissionService
     /// </summary>
     /// <remarks>
     /// <para>
-    /// Arbitration is <b>specificity first, restrictiveness second</b>:
+    /// <b>Grant boundaries cap the result.</b> Baselines are arbitrated twice: once across every matching
+    /// baseline, and once across only those declaring
+    /// <see cref="PermissionBaselineTier.GrantBoundary"/>. The more restrictive of the two governs. A
+    /// boundary is the outer edge of what a caller was authorised to do at all — a capability envelope's
+    /// grant for one bundle run — so no ordinary baseline from any other provider may resolve past it,
+    /// however specifically it names the tool. Tightening still works in both directions: a
+    /// <see cref="PermissionBaselineTier.Default"/> baseline that is <em>stricter</em> than the boundary
+    /// wins, because the boundary is a ceiling on authority and not a floor.
+    /// </para>
+    /// <para>
+    /// This is why the tier lives on the rule rather than being inferred from
+    /// <see cref="ToolPermissionRule.Source"/>. Without it, a plugin declaring
+    /// <c>AutonomyLevel: Autonomous</c> emits an exact-name baseline Allow which — being more specific
+    /// than the envelope's catch-all <c>"*"</c> Deny — silently widened the envelope to a tool the host
+    /// never granted. Ranking on a declared property keeps the resolver from having to know which
+    /// providers are privileged, and keeps that knowledge with the provider that is making the claim.
+    /// </para>
+    /// <para>
+    /// Within a single tier, arbitration is <b>specificity first, restrictiveness second</b>:
     /// </para>
     /// <list type="number">
     ///   <item><description>
@@ -276,6 +301,7 @@ public sealed class ThreePhasePermissionResolver : IToolPermissionService
         string? operation)
     {
         ToolPermissionRule? best = null;
+        ToolPermissionRule? boundary = null;
 
         foreach (var rule in rules)
         {
@@ -287,9 +313,38 @@ public sealed class ThreePhasePermissionResolver : IToolPermissionService
 
             if (best is null || Outranks(rule, best))
                 best = rule;
+
+            if (rule.BaselineTier != PermissionBaselineTier.GrantBoundary)
+                continue;
+
+            if (boundary is null || Outranks(rule, boundary))
+                boundary = rule;
         }
 
-        return best;
+        // No boundary in play (every deployment without a capability envelope) leaves `best` untouched,
+        // so this is a pure no-op off the bundle path.
+        return MoreRestrictive(best, boundary);
+    }
+
+    /// <summary>
+    /// The stricter of two candidate rules by <see cref="RestrictivenessRank"/>, treating a null as
+    /// "no opinion". Ties keep <paramref name="governing"/> so the normally-arbitrated winner — the one
+    /// carrying the specificity decision and its rule attribution — survives whenever the boundary agrees
+    /// with it.
+    /// </summary>
+    private static ToolPermissionRule? MoreRestrictive(
+        ToolPermissionRule? governing,
+        ToolPermissionRule? boundary)
+    {
+        if (governing is null)
+            return boundary;
+
+        if (boundary is null)
+            return governing;
+
+        return RestrictivenessRank(boundary.Behavior) < RestrictivenessRank(governing.Behavior)
+            ? boundary
+            : governing;
     }
 
     /// <summary>
@@ -297,6 +352,14 @@ public sealed class ThreePhasePermissionResolver : IToolPermissionService
     /// a strictly more specific pattern wins; failing that a strictly more restrictive behavior wins
     /// (Deny &gt; Ask &gt; Allow); failing that the lower (earlier) priority wins.
     /// </summary>
+    /// <remarks>
+    /// Specificity is ranked on <see cref="ToolPermissionRule.ToolPattern"/> only. An operation-scoped
+    /// rule therefore ties with an operation-agnostic one of the same tool pattern and is decided by
+    /// restrictiveness instead — the safe direction, and unreachable today because both baseline emitters
+    /// pass a null operation. A future provider emitting operation-scoped baselines must not assume its
+    /// narrower operation pattern confers precedence; give it a distinct tool pattern or extend the
+    /// ranking here deliberately.
+    /// </remarks>
     private bool Outranks(ToolPermissionRule candidate, ToolPermissionRule incumbent)
     {
         var candidateSpecificity = _patternMatcher.Specificity(candidate.ToolPattern);

--- a/src/Content/Infrastructure/Infrastructure.AI/Planner/PlanExecutor.EnvelopeCeiling.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Planner/PlanExecutor.EnvelopeCeiling.cs
@@ -40,12 +40,15 @@ public sealed partial class PlanExecutor
         if (violation is null)
             return false;
 
+        // The reason names the step and the envelope's ceiling, so it is logged but never persisted:
+        // StepExecutionState.ErrorMessage is relayed to callers through plan status, and this PR
+        // otherwise reduces that field to opaque PlanStepErrors codes for exactly this reason.
         _logger.LogWarning(
             "Step {StepId} in plan {PlanId} denied by envelope autonomy ceiling: {Reason}",
             step.Id, ctx.PlanId, violation);
 
         await _notifier.NotifyStepStartedAsync(ctx.PlanId, step.Id, step.Name, step.Type, ct);
-        await FailPolicyDeniedStepAsync(step, violation, ctx, ct);
+        await FailPolicyDeniedStepAsync(step, PlanStepErrors.AutonomyCeilingExceeded, ctx, ct);
         return true;
     }
 
@@ -101,10 +104,11 @@ public sealed partial class PlanExecutor
         // anything depending on it cannot legitimately run.
         await SkipDownstreamSubgraphAsync(step.Id, ctx);
 
-        if (result is not null)
-        {
-            await _notifier.NotifyStepCompletedAsync(
-                ctx.PlanId, step.Id, StepExecutionStatus.Failed, result.Duration, result.Output, ct);
-        }
+        // Always pair the started notification with a completed one. The ceiling denial path emits
+        // step-started and then never reaches an executor, so skipping this would leave a subscribed
+        // UI showing a denied step as permanently running.
+        await _notifier.NotifyStepCompletedAsync(
+            ctx.PlanId, step.Id, StepExecutionStatus.Failed,
+            result?.Duration ?? TimeSpan.Zero, result?.Output, ct);
     }
 }

--- a/src/Content/Infrastructure/Infrastructure.AI/Planner/PlanExecutor.EnvelopeCeiling.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Planner/PlanExecutor.EnvelopeCeiling.cs
@@ -1,0 +1,110 @@
+using Application.AI.Common.Services.Governance;
+using Domain.AI.Planner;
+using Microsoft.Extensions.Logging;
+
+namespace Infrastructure.AI.Planner;
+
+/// <summary>
+/// Capability-envelope confinement at the scheduler level: the autonomy ceiling that gates every
+/// step type before its executor is resolved, and the terminal failure path shared by every
+/// governance denial in the engine.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>Why denials are terminal.</strong> <see cref="RetryPolicy"/> — including
+/// <see cref="RetryPolicy.OnExhausted"/> — is plan-authored data. Routing a policy denial through
+/// the ordinary failure path would let a plan declare <see cref="ErrorRecovery.SkipStep"/> on the
+/// very step the envelope blocks: recovery marks it Skipped, the summary sees no Failed state, and
+/// the run reports Completed while a security denial was silently dropped. An
+/// <see cref="ErrorRecovery.Escalate"/> policy fails differently but no better — approve → re-run →
+/// deny → escalate again, asking a human to approve something the envelope will never permit.
+/// Denials therefore bypass <c>HandleStepFailureAsync</c> entirely, exactly as
+/// <c>FailRejectedBlockAsync</c> already does for a rejected escalation and for the same reason.
+/// </para>
+/// <para>
+/// With no ambient envelope (every direct in-process <see cref="IPlanExecutor"/> caller) no ceiling
+/// applies and this partial contributes nothing to execution.
+/// </para>
+/// </remarks>
+public sealed partial class PlanExecutor
+{
+    /// <summary>
+    /// Denies the step when it declares a <see cref="PlanStep.RequiredAutonomyLevel"/> above the
+    /// ambient capability envelope's ceiling, failing it terminally.
+    /// </summary>
+    /// <returns><c>true</c> when the step was denied and must not run; <c>false</c> to proceed.</returns>
+    private async Task<bool> TryDenyForAutonomyCeilingAsync(
+        PlanStep step, PlanExecutionRuntime ctx, CancellationToken ct)
+    {
+        var violation = DescribeAutonomyCeilingViolation(step);
+        if (violation is null)
+            return false;
+
+        _logger.LogWarning(
+            "Step {StepId} in plan {PlanId} denied by envelope autonomy ceiling: {Reason}",
+            step.Id, ctx.PlanId, violation);
+
+        await _notifier.NotifyStepStartedAsync(ctx.PlanId, step.Id, step.Name, step.Type, ct);
+        await FailPolicyDeniedStepAsync(step, violation, ctx, ct);
+        return true;
+    }
+
+    /// <summary>
+    /// Describes why the step violates the ambient capability envelope's autonomy ceiling, or null
+    /// when it may run: no envelope armed, no <see cref="PlanStep.RequiredAutonomyLevel"/> declared,
+    /// or the required tier is within the ceiling. The comparison relies on the numeric ordering of
+    /// <see cref="Domain.AI.Governance.AutonomyLevel"/> (higher value = more trust required).
+    /// </summary>
+    /// <remarks>
+    /// This covers only steps that <em>declare</em> a required tier. A step that declares nothing is
+    /// not exempt from the envelope — its per-operation authorization (tool, retrieval, or inference)
+    /// runs through <c>IToolInvocationGovernor</c>, where the envelope's own autonomy-ceiling baseline
+    /// applies. The two checks are complementary: this one is a static plan-shape assertion, that one
+    /// is the live per-operation gate.
+    /// </remarks>
+    private static string? DescribeAutonomyCeilingViolation(PlanStep step)
+    {
+        var envelope = CapabilityEnvelopeAccessor.Current;
+        if (envelope is null || step.RequiredAutonomyLevel is not { } required)
+            return null;
+
+        return required <= envelope.AutonomyCeiling
+            ? null
+            : $"Step '{step.Name}' requires autonomy level {required} but the capability envelope " +
+              $"permits at most {envelope.AutonomyCeiling}.";
+    }
+
+    /// <summary>
+    /// Fails a step whose operation was refused by governance and skips its downstream subgraph.
+    /// Deliberately does NOT route through <c>HandleStepFailureAsync</c> — see the type remarks.
+    /// </summary>
+    /// <param name="step">The denied step.</param>
+    /// <param name="denialMessage">The caller-facing denial text to persist as the step error.</param>
+    /// <param name="ctx">The running plan's scheduling state.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <param name="result">
+    /// The executor's result when the denial came from a step executor, so the step-completed
+    /// notification carries its real duration. Null for the scheduler's own ceiling denial, which
+    /// never reached an executor.
+    /// </param>
+    private async Task FailPolicyDeniedStepAsync(
+        PlanStep step,
+        string? denialMessage,
+        PlanExecutionRuntime ctx,
+        CancellationToken ct,
+        StepExecutionResult? result = null)
+    {
+        await TransitionStepAsync(
+            ctx.PlanId, step.Id, StepExecutionStatus.Failed, ctx.StepStates, ct, errorMessage: denialMessage);
+
+        // Downstream is skipped, never enqueued: a step the envelope refused produced no output, so
+        // anything depending on it cannot legitimately run.
+        await SkipDownstreamSubgraphAsync(step.Id, ctx);
+
+        if (result is not null)
+        {
+            await _notifier.NotifyStepCompletedAsync(
+                ctx.PlanId, step.Id, StepExecutionStatus.Failed, result.Duration, result.Output, ct);
+        }
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Planner/PlanExecutor.EnvelopeCeiling.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Planner/PlanExecutor.EnvelopeCeiling.cs
@@ -22,6 +22,17 @@ namespace Infrastructure.AI.Planner;
 /// <c>FailRejectedBlockAsync</c> already does for a rejected escalation and for the same reason.
 /// </para>
 /// <para>
+/// <strong>What bypassing that path also gives up.</strong> <c>HandleStepFailureAsync</c> owns the
+/// <c>MarkRemainingAsFailed</c> teardown, so skipping it means a denial does <em>not</em> tear the
+/// plan down even when the plan declares <see cref="ErrorRecovery.FailPlan"/>. Only the denied
+/// step's downstream subgraph is skipped; parallel independent branches keep running to completion,
+/// and the run's status still reports Failed once they drain. That is accepted rather than
+/// overlooked: a denial says the envelope refused <em>one</em> operation, not that the rest of the
+/// plan became unsafe, and every other branch is separately authorized by the same envelope on its
+/// own merits. Restoring <see cref="ErrorRecovery.FailPlan"/> teardown here would mean reading
+/// plan-authored recovery data on a security denial — the exact coupling this path exists to break.
+/// </para>
+/// <para>
 /// With no ambient envelope (every direct in-process <see cref="IPlanExecutor"/> caller) no ceiling
 /// applies and this partial contributes nothing to execution.
 /// </para>

--- a/src/Content/Infrastructure/Infrastructure.AI/Planner/PlanExecutor.Graph.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Planner/PlanExecutor.Graph.cs
@@ -1,0 +1,113 @@
+using System.Collections.Concurrent;
+using Domain.AI.Planner;
+
+namespace Infrastructure.AI.Planner;
+
+/// <summary>
+/// Pure graph and step-state queries backing the scheduler: dependency/dependent map construction,
+/// readiness predicates, upstream output collection, and the atomic Pending → Ready promotion.
+/// </summary>
+/// <remarks>
+/// Every member here is static and side-effect free apart from <see cref="TryMarkReady"/>, which
+/// performs one compare-and-swap on the shared state dictionary. Keeping them separate from
+/// <c>PlanExecutor.Scheduling.cs</c> leaves that file to the scheduling loop and attempt/retry
+/// policy it actually implements.
+/// </remarks>
+public sealed partial class PlanExecutor
+{
+    /// <summary>
+    /// Builds the forward and reverse adjacency maps for the plan: dependencies per step (what it
+    /// waits on) and dependents per step (what it releases, with each edge's type).
+    /// </summary>
+    private static (Dictionary<PlanStepId, HashSet<PlanStepId>> DependencyMap,
+        Dictionary<PlanStepId, List<(PlanStepId Target, EdgeType Type)>> DependentMap) BuildGraphMaps(PlanGraph plan)
+    {
+        var dependencyMap = new Dictionary<PlanStepId, HashSet<PlanStepId>>();
+        var dependentMap = new Dictionary<PlanStepId, List<(PlanStepId, EdgeType)>>();
+
+        foreach (var step in plan.Steps)
+        {
+            dependencyMap[step.Id] = [];
+            dependentMap[step.Id] = [];
+        }
+
+        foreach (var edge in plan.Edges)
+        {
+            dependencyMap[edge.To].Add(edge.From);
+            dependentMap[edge.From].Add((edge.To, edge.Type));
+        }
+
+        return (dependencyMap, dependentMap);
+    }
+
+    /// <summary>
+    /// Atomically promotes a step from Pending to Ready. Returns false when another scheduling pass
+    /// already claimed it, so a step is enqueued exactly once under concurrent completion callbacks.
+    /// </summary>
+    private static bool TryMarkReady(PlanStepId stepId, ConcurrentDictionary<PlanStepId, StepExecutionState> stepStates)
+    {
+        while (true)
+        {
+            var current = stepStates.GetValueOrDefault(stepId);
+            if (current is null || current.Status != StepExecutionStatus.Pending)
+                return false;
+
+            var newState = current with { Status = StepExecutionStatus.Ready };
+            if (stepStates.TryUpdate(stepId, newState, current))
+                return true;
+        }
+    }
+
+    /// <summary>Collects the persisted outputs of the step's completed dependencies.</summary>
+    private static IReadOnlyDictionary<PlanStepId, string> GetUpstreamOutputs(
+        PlanStepId stepId,
+        Dictionary<PlanStepId, HashSet<PlanStepId>> dependencyMap,
+        ConcurrentDictionary<PlanStepId, string> stepOutputs)
+    {
+        var outputs = new Dictionary<PlanStepId, string>();
+        if (!dependencyMap.TryGetValue(stepId, out var dependencies))
+            return outputs;
+
+        foreach (var depId in dependencies)
+        {
+            if (stepOutputs.TryGetValue(depId, out var output))
+                outputs[depId] = output;
+        }
+        return outputs;
+    }
+
+    /// <summary>
+    /// Whether every dependency of the step has reached Completed or Skipped — the only two states
+    /// that release downstream work.
+    /// </summary>
+    private static bool IsStepReady(
+        PlanStepId stepId,
+        ConcurrentDictionary<PlanStepId, StepExecutionState> stepStates,
+        Dictionary<PlanStepId, HashSet<PlanStepId>> dependencyMap)
+    {
+        if (!dependencyMap.TryGetValue(stepId, out var dependencies) || dependencies.Count == 0)
+            return true;
+
+        return dependencies.All(depId =>
+        {
+            var depState = stepStates.GetValueOrDefault(depId);
+            return depState?.Status is StepExecutionStatus.Completed or StepExecutionStatus.Skipped;
+        });
+    }
+
+    /// <summary>Whether no step can make further progress, so the scheduling loop may exit.</summary>
+    private static bool AllStepsTerminal(ConcurrentDictionary<PlanStepId, StepExecutionState> stepStates)
+        => stepStates.Values.All(s => s.Status is StepExecutionStatus.Completed
+            or StepExecutionStatus.Failed
+            or StepExecutionStatus.Skipped
+            or StepExecutionStatus.Blocked
+            or StepExecutionStatus.Cancelled);
+
+    /// <summary>Whether any step is parked awaiting a human decision.</summary>
+    private static bool HasBlockedSteps(ConcurrentDictionary<PlanStepId, StepExecutionState> stepStates)
+        => stepStates.Values.Any(s => s.Status == StepExecutionStatus.Blocked);
+
+    /// <summary>Whether any step is still schedulable in this execution.</summary>
+    private static bool HasPendingOrReadySteps(ConcurrentDictionary<PlanStepId, StepExecutionState> stepStates)
+        => stepStates.Values.Any(s => s.Status is StepExecutionStatus.Pending or StepExecutionStatus.Ready);
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Planner/PlanExecutor.Recovery.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Planner/PlanExecutor.Recovery.cs
@@ -36,16 +36,27 @@ public sealed partial class PlanExecutor
     /// exceptions alike) route into <see cref="HandleStepFailureAsync"/>, so all three failure
     /// modes honour the same FailStep/SkipStep/FailPlan/Escalate policy.
     /// </summary>
+    /// <remarks>
+    /// <strong>Step-completed is a lifecycle signal, not the authoritative status.</strong> Recovery
+    /// runs before the notification, so an Escalate or SkipStep policy re-transitions the step to
+    /// Blocked or Skipped and the completed event that follows still reports Failed. Consumers must
+    /// read status from the state-update stream: the AG-UI bridge emits each transition as a JSON
+    /// Patch replacing <c>/steps/{stepId}/status</c>, and because recovery's transition is emitted
+    /// after the Failed one, the last patch carries the true terminal state. The same ordering
+    /// already applied to the Failed-result path before the notification was made unconditional, so
+    /// this widens an existing contract rather than introducing one.
+    /// </remarks>
     private async Task FailExhaustedStepAsync(PlanStep step, StepAttemptOutcome outcome, PlanExecutionRuntime ctx, CancellationToken ct)
     {
         await TransitionStepAsync(ctx.PlanId, step.Id, StepExecutionStatus.Failed, ctx.StepStates, ct, errorMessage: outcome.ErrorMessage);
         await HandleStepFailureAsync(step, outcome.ErrorMessage, ctx, ct);
 
-        // Completed-notification carries the executor's own result when one exists (a Failed
-        // result); timeout/exception attempts produce no result and — as before this retry loop
-        // existed — no step-completed notification, only the state-update transitions.
-        if (outcome.Result is not null)
-            await _notifier.NotifyStepCompletedAsync(ctx.PlanId, step.Id, StepExecutionStatus.Failed, outcome.Result.Duration, outcome.Result.Output, ct);
+        // Always pair the step-started notification with a completed one, so a subscribed UI never
+        // shows an exhausted step as permanently running. Timeout/exception attempts produce no
+        // result and therefore report zero duration and no output.
+        await _notifier.NotifyStepCompletedAsync(
+            ctx.PlanId, step.Id, StepExecutionStatus.Failed,
+            outcome.Result?.Duration ?? TimeSpan.Zero, outcome.Result?.Output, ct);
     }
 
     /// <summary>

--- a/src/Content/Infrastructure/Infrastructure.AI/Planner/PlanExecutor.Scheduling.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Planner/PlanExecutor.Scheduling.cs
@@ -76,8 +76,9 @@ public sealed partial class PlanExecutor
             // Non-attempt infrastructure failure (executor resolution, state persistence,
             // notification). Attempt-level executor exceptions are consumed by the retry loop, so
             // anything reaching here is outside the retry budget: fail the step and skip downstream.
+            // Persist a stable code, never the raw message — see PlanStepErrors.
             _logger.LogError(ex, "Unhandled exception executing step {StepId} in plan {PlanId}", step.Id, ctx.PlanId);
-            await TransitionStepAsync(ctx.PlanId, step.Id, StepExecutionStatus.Failed, ctx.StepStates, ct, errorMessage: ex.Message);
+            await TransitionStepAsync(ctx.PlanId, step.Id, StepExecutionStatus.Failed, ctx.StepStates, ct, errorMessage: PlanStepErrors.ExecutionFailed);
             await SkipDownstreamSubgraphAsync(step.Id, ctx);
         }
         finally
@@ -105,6 +106,12 @@ public sealed partial class PlanExecutor
     /// </remarks>
     private async Task RunStepWithRetriesAsync(PlanStep step, PlanExecutionRuntime ctx, CancellationToken ct)
     {
+        // Envelope autonomy ceiling: a step declaring a RequiredAutonomyLevel above what the ambient
+        // capability envelope permits must not run at all — for ANY step type, before its executor is
+        // even resolved. See PlanExecutor.EnvelopeCeiling.cs for why this is terminal.
+        if (await TryDenyForAutonomyCeilingAsync(step, ctx, ct))
+            return;
+
         var executor = _serviceProvider.GetRequiredKeyedService<IPlanStepExecutor>(step.Type);
         var upstreamOutputs = GetUpstreamOutputs(step.Id, ctx.DependencyMap, ctx.StepOutputs);
         var firstIteration = true;
@@ -123,25 +130,49 @@ public sealed partial class PlanExecutor
             var attemptsMade = ctx.StepStates[step.Id].AttemptCount;
             var outcome = await ExecuteSingleAttemptAsync(step, executor, upstreamOutputs, ctx, ct);
 
-            if (outcome.Result is not null && outcome.Result.Status != StepExecutionStatus.Failed)
-            {
-                await HandleStepResultAsync(step, outcome.Result, ctx, ct);
-                await _notifier.NotifyStepCompletedAsync(ctx.PlanId, step.Id, outcome.Result.Status, outcome.Result.Duration, outcome.Result.Output, ct);
+            if (await TryFinishAttemptAsync(step, outcome, attemptsMade, ctx, ct))
                 return;
-            }
 
-            if (ShouldRetry(step.RetryPolicy, attemptsMade))
-            {
-                _logger.LogWarning(
-                    "Step {StepId} in plan {PlanId} failed attempt {Attempt} of {MaxAttempts} ({Error}); retrying after backoff",
-                    step.Id, ctx.PlanId, attemptsMade, step.RetryPolicy.MaxRetries + 1, outcome.ErrorMessage);
-                await DelayBeforeRetryAsync(step.RetryPolicy, attemptsMade, ct);
-                continue;
-            }
-
-            await FailExhaustedStepAsync(step, outcome, ctx, ct);
-            return;
+            _logger.LogWarning(
+                "Step {StepId} in plan {PlanId} failed attempt {Attempt} of {MaxAttempts} ({Error}); retrying after backoff",
+                step.Id, ctx.PlanId, attemptsMade, step.RetryPolicy.MaxRetries + 1, outcome.ErrorMessage);
+            await DelayBeforeRetryAsync(step.RetryPolicy, attemptsMade, ct);
         }
+    }
+
+    /// <summary>
+    /// Applies one attempt's outcome and reports whether the step reached a terminal disposition.
+    /// </summary>
+    /// <returns>
+    /// <c>true</c> when the step is finished (completed, parked, denied, or out of retry budget) and
+    /// the retry loop must stop; <c>false</c> when the caller should back off and attempt again.
+    /// </returns>
+    private async Task<bool> TryFinishAttemptAsync(
+        PlanStep step, StepAttemptOutcome outcome, int attemptsMade, PlanExecutionRuntime ctx, CancellationToken ct)
+    {
+        // Completed, or parked in Blocked by a human gate.
+        if (outcome.Result is not null && outcome.Result.Status != StepExecutionStatus.Failed)
+        {
+            await HandleStepResultAsync(step, outcome.Result, ctx, ct);
+            await _notifier.NotifyStepCompletedAsync(
+                ctx.PlanId, step.Id, outcome.Result.Status, outcome.Result.Duration, outcome.Result.Output, ct);
+            return true;
+        }
+
+        // A governance denial is not a transient fault: retrying cannot change the envelope's answer,
+        // and the plan's own OnExhausted policy must not get to decide the disposition of the check
+        // that constrains the plan. Terminal, immediately — see PlanExecutor.EnvelopeCeiling.cs.
+        if (outcome.Result is { IsPolicyDenial: true })
+        {
+            await FailPolicyDeniedStepAsync(step, outcome.Result.ErrorMessage, ctx, ct, outcome.Result);
+            return true;
+        }
+
+        if (ShouldRetry(step.RetryPolicy, attemptsMade))
+            return false;
+
+        await FailExhaustedStepAsync(step, outcome, ctx, ct);
+        return true;
     }
 
     /// <summary>
@@ -182,7 +213,7 @@ public sealed partial class PlanExecutor
             StepExecutionsCounter.Add(1,
                 new KeyValuePair<string, object?>("type", step.Type.ToString()),
                 new KeyValuePair<string, object?>("status", "timeout"));
-            return new StepAttemptOutcome(null, "Step timeout exceeded");
+            return new StepAttemptOutcome(null, PlanStepErrors.Timeout);
         }
         catch (OperationCanceledException)
         {
@@ -191,17 +222,15 @@ public sealed partial class PlanExecutor
         }
         catch (Exception ex)
         {
-            // Unhandled executor exception — counts as a failed, retryable attempt.
+            // Unhandled executor exception — counts as a failed, retryable attempt. The message is
+            // logged in full but reduced to a stable code before it can be persisted onto the step:
+            // step error state is returned to callers, and executor exceptions carry paths and
+            // connection strings.
             _logger.LogError(ex, "Unhandled exception executing step {StepId} in plan {PlanId} (attempt will consume retry budget)", step.Id, ctx.PlanId);
-            return new StepAttemptOutcome(null, ex.Message);
+            return new StepAttemptOutcome(null, PlanStepErrors.ExecutionFailed);
         }
     }
 
-    /// <summary>
-    /// Outcome of a single execution attempt: either the executor's result, or — when
-    /// <see cref="Result"/> is null — a synthesized error for a per-attempt timeout or an
-    /// unhandled executor exception. Both null-result shapes and a Failed result are retryable.
-    /// </summary>
     /// <summary>
     /// The outcome of one step attempt: the executor's result when it produced one, or a
     /// synthesized error for attempts that never returned (timeout, unhandled exception).
@@ -313,83 +342,4 @@ public sealed partial class PlanExecutor
         }
     }
 
-    private static (Dictionary<PlanStepId, HashSet<PlanStepId>> DependencyMap,
-        Dictionary<PlanStepId, List<(PlanStepId Target, EdgeType Type)>> DependentMap) BuildGraphMaps(PlanGraph plan)
-    {
-        var dependencyMap = new Dictionary<PlanStepId, HashSet<PlanStepId>>();
-        var dependentMap = new Dictionary<PlanStepId, List<(PlanStepId, EdgeType)>>();
-
-        foreach (var step in plan.Steps)
-        {
-            dependencyMap[step.Id] = [];
-            dependentMap[step.Id] = [];
-        }
-
-        foreach (var edge in plan.Edges)
-        {
-            dependencyMap[edge.To].Add(edge.From);
-            dependentMap[edge.From].Add((edge.To, edge.Type));
-        }
-
-        return (dependencyMap, dependentMap);
-    }
-
-    private static bool TryMarkReady(PlanStepId stepId, ConcurrentDictionary<PlanStepId, StepExecutionState> stepStates)
-    {
-        while (true)
-        {
-            var current = stepStates.GetValueOrDefault(stepId);
-            if (current is null || current.Status != StepExecutionStatus.Pending)
-                return false;
-
-            var newState = current with { Status = StepExecutionStatus.Ready };
-            if (stepStates.TryUpdate(stepId, newState, current))
-                return true;
-        }
-    }
-
-    private static IReadOnlyDictionary<PlanStepId, string> GetUpstreamOutputs(
-        PlanStepId stepId,
-        Dictionary<PlanStepId, HashSet<PlanStepId>> dependencyMap,
-        ConcurrentDictionary<PlanStepId, string> stepOutputs)
-    {
-        var outputs = new Dictionary<PlanStepId, string>();
-        if (!dependencyMap.TryGetValue(stepId, out var dependencies))
-            return outputs;
-
-        foreach (var depId in dependencies)
-        {
-            if (stepOutputs.TryGetValue(depId, out var output))
-                outputs[depId] = output;
-        }
-        return outputs;
-    }
-
-    private static bool IsStepReady(
-        PlanStepId stepId,
-        ConcurrentDictionary<PlanStepId, StepExecutionState> stepStates,
-        Dictionary<PlanStepId, HashSet<PlanStepId>> dependencyMap)
-    {
-        if (!dependencyMap.TryGetValue(stepId, out var dependencies) || dependencies.Count == 0)
-            return true;
-
-        return dependencies.All(depId =>
-        {
-            var depState = stepStates.GetValueOrDefault(depId);
-            return depState?.Status is StepExecutionStatus.Completed or StepExecutionStatus.Skipped;
-        });
-    }
-
-    private static bool AllStepsTerminal(ConcurrentDictionary<PlanStepId, StepExecutionState> stepStates)
-        => stepStates.Values.All(s => s.Status is StepExecutionStatus.Completed
-            or StepExecutionStatus.Failed
-            or StepExecutionStatus.Skipped
-            or StepExecutionStatus.Blocked
-            or StepExecutionStatus.Cancelled);
-
-    private static bool HasBlockedSteps(ConcurrentDictionary<PlanStepId, StepExecutionState> stepStates)
-        => stepStates.Values.Any(s => s.Status == StepExecutionStatus.Blocked);
-
-    private static bool HasPendingOrReadySteps(ConcurrentDictionary<PlanStepId, StepExecutionState> stepStates)
-        => stepStates.Values.Any(s => s.Status is StepExecutionStatus.Pending or StepExecutionStatus.Ready);
 }

--- a/src/Content/Infrastructure/Infrastructure.AI/Planner/PlanRunExecutor.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Planner/PlanRunExecutor.cs
@@ -1,0 +1,110 @@
+using Application.AI.Common.Interfaces.Agent;
+using Application.AI.Common.Interfaces.Planner;
+using Application.AI.Common.Services.Governance;
+using Domain.AI.Planner;
+using Domain.Common;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Infrastructure.AI.Planner;
+
+/// <summary>
+/// The single arming site for enveloped plan runs: initializes the scoped governance identity, publishes
+/// the caller's capability envelope ambiently, and drives <see cref="IPlanExecutor"/> inside that scope.
+/// Modeled directly on <c>BundleRunExecutor</c> — see <see cref="IPlanRunExecutor"/> for the doctrine.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>Ordering that preserves the invariants.</strong> A fresh DI scope is created per run so the
+/// scoped <see cref="IAgentExecutionContext"/>, tool-invocation governor, and step executors all share one
+/// identity that cannot leak across runs. The execution context is initialized <em>before</em> the envelope
+/// is armed: the governor fails closed on any identity-less tool call made under an ambient envelope (by
+/// design), so arming the envelope first would open a window where a concurrently scheduled step is denied
+/// for the wrong reason. The envelope scope is disposed in a <c>finally</c> (via <c>using</c>) on every
+/// path, and the plan summary is fully materialised before disposal — no deferred enumeration outlives the
+/// scope.
+/// </para>
+/// <para>
+/// <strong>Fail-closed posture.</strong> This path cannot run un-enveloped: a missing envelope or blank
+/// agent identity is rejected with a stable error code before any plan state is touched. Unexpected
+/// executor exceptions are logged in full but surfaced only as <c>plan_run.execution_failed</c> — raw
+/// exception text never reaches the caller.
+/// </para>
+/// </remarks>
+public sealed class PlanRunExecutor : IPlanRunExecutor
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly ILogger<PlanRunExecutor> _logger;
+
+    /// <summary>Initializes a new <see cref="PlanRunExecutor"/>.</summary>
+    /// <param name="scopeFactory">Creates the per-run DI scope the identity and executor resolve from.</param>
+    /// <param name="logger">Structured logger for run auditing.</param>
+    public PlanRunExecutor(IServiceScopeFactory scopeFactory, ILogger<PlanRunExecutor> logger)
+    {
+        ArgumentNullException.ThrowIfNull(scopeFactory);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _scopeFactory = scopeFactory;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<Result<PlanExecutionSummary>> ExecuteAsync(PlanRunRequest request, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        if (request.Envelope is null)
+        {
+            _logger.LogWarning("Plan run {PlanId} rejected: no capability envelope supplied", request.PlanId);
+            return Result<PlanExecutionSummary>.Fail("plan_run.envelope_required");
+        }
+
+        if (string.IsNullOrWhiteSpace(request.AgentId))
+        {
+            _logger.LogWarning("Plan run {PlanId} rejected: no agent identity supplied", request.PlanId);
+            return Result<PlanExecutionSummary>.Fail("plan_run.agent_identity_required");
+        }
+
+        if (!PlanRunRequest.IsWellFormedAgentId(request.AgentId))
+        {
+            // The id is the permission-resolution key and the audit subject. The rejected value is
+            // deliberately not echoed back or logged verbatim — it is attacker-controlled text.
+            _logger.LogWarning(
+                "Plan run {PlanId} rejected: agent identity is malformed (length {Length})",
+                request.PlanId, request.AgentId.Length);
+            return Result<PlanExecutionSummary>.Fail("plan_run.agent_identity_invalid");
+        }
+
+        await using var scope = _scopeFactory.CreateAsyncScope();
+
+        // Identity first, envelope second — the governor fails closed on identity-less enveloped
+        // tool calls, so the scoped execution context must carry the caller's identity before any
+        // step can observe the envelope.
+        var executionContext = scope.ServiceProvider.GetRequiredService<IAgentExecutionContext>();
+        executionContext.Initialize(
+            request.AgentId,
+            request.ConversationId ?? request.PlanId.Value.ToString(),
+            turnNumber: 1);
+
+        var planExecutor = scope.ServiceProvider.GetRequiredService<IPlanExecutor>();
+
+        using (CapabilityEnvelopeAccessor.Begin(request.Envelope))
+        {
+            try
+            {
+                return await planExecutor.ExecuteAsync(request.PlanId, cancellationToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                // Full detail stays in the structured log; the caller sees only a stable code so
+                // infrastructure exception text (paths, connection strings) can never leak out.
+                _logger.LogError(ex, "Plan run {PlanId} threw during enveloped execution", request.PlanId);
+                return Result<PlanExecutionSummary>.Fail("plan_run.execution_failed");
+            }
+        }
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Planner/PlanRunExecutor.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Planner/PlanRunExecutor.cs
@@ -1,3 +1,4 @@
+using Application.AI.Common.Interfaces.AI;
 using Application.AI.Common.Interfaces.Agent;
 using Application.AI.Common.Interfaces.Planner;
 using Application.AI.Common.Services.Governance;
@@ -34,17 +35,24 @@ namespace Infrastructure.AI.Planner;
 public sealed class PlanRunExecutor : IPlanRunExecutor
 {
     private readonly IServiceScopeFactory _scopeFactory;
+    private readonly IConversationBudgetTracker _conversationBudget;
     private readonly ILogger<PlanRunExecutor> _logger;
 
     /// <summary>Initializes a new <see cref="PlanRunExecutor"/>.</summary>
     /// <param name="scopeFactory">Creates the per-run DI scope the identity and executor resolve from.</param>
+    /// <param name="conversationBudget">Holds the run-level token budget this executor owns and releases.</param>
     /// <param name="logger">Structured logger for run auditing.</param>
-    public PlanRunExecutor(IServiceScopeFactory scopeFactory, ILogger<PlanRunExecutor> logger)
+    public PlanRunExecutor(
+        IServiceScopeFactory scopeFactory,
+        IConversationBudgetTracker conversationBudget,
+        ILogger<PlanRunExecutor> logger)
     {
         ArgumentNullException.ThrowIfNull(scopeFactory);
+        ArgumentNullException.ThrowIfNull(conversationBudget);
         ArgumentNullException.ThrowIfNull(logger);
 
         _scopeFactory = scopeFactory;
+        _conversationBudget = conversationBudget;
         _logger = logger;
     }
 
@@ -65,6 +73,18 @@ public sealed class PlanRunExecutor : IPlanRunExecutor
             return Result<PlanExecutionSummary>.Fail("plan_run.agent_identity_required");
         }
 
+        // Null means "derive the run scope from the plan id". A supplied value must be well formed:
+        // blank would yield a blank run scope, which downstream IsNullOrEmpty checks read as "no run
+        // scope", silently disabling the run-level budget gate.
+        if (request.ConversationId is not null
+            && !PlanRunRequest.IsWellFormedAgentId(request.ConversationId))
+        {
+            _logger.LogWarning(
+                "Plan run {PlanId} rejected: conversation id is malformed (length {Length})",
+                request.PlanId, request.ConversationId.Length);
+            return Result<PlanExecutionSummary>.Fail("plan_run.conversation_id_invalid");
+        }
+
         if (!PlanRunRequest.IsWellFormedAgentId(request.AgentId))
         {
             // The id is the permission-resolution key and the audit subject. The rejected value is
@@ -80,11 +100,9 @@ public sealed class PlanRunExecutor : IPlanRunExecutor
         // Identity first, envelope second — the governor fails closed on identity-less enveloped
         // tool calls, so the scoped execution context must carry the caller's identity before any
         // step can observe the envelope.
+        var runScope = request.ConversationId ?? request.PlanId.Value.ToString();
         var executionContext = scope.ServiceProvider.GetRequiredService<IAgentExecutionContext>();
-        executionContext.Initialize(
-            request.AgentId,
-            request.ConversationId ?? request.PlanId.Value.ToString(),
-            turnNumber: 1);
+        executionContext.Initialize(request.AgentId, runScope, turnNumber: 1);
 
         var planExecutor = scope.ServiceProvider.GetRequiredService<IPlanExecutor>();
 
@@ -104,6 +122,12 @@ public sealed class PlanRunExecutor : IPlanRunExecutor
                 // infrastructure exception text (paths, connection strings) can never leak out.
                 _logger.LogError(ex, "Plan run {PlanId} threw during enveloped execution", request.PlanId);
                 return Result<PlanExecutionSummary>.Fail("plan_run.execution_failed");
+            }
+            finally
+            {
+                // This run owns its budget entry — no conversation handler releases it, which is the
+                // whole reason it exists as a separate key. Freed on every exit path.
+                _conversationBudget.Release(PlanRunKeys.RunBudgetKey(runScope));
             }
         }
     }

--- a/src/Content/Infrastructure/Infrastructure.AI/Planner/PlanRunExecutor.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Planner/PlanRunExecutor.cs
@@ -28,8 +28,10 @@ namespace Infrastructure.AI.Planner;
 /// <para>
 /// <strong>Fail-closed posture.</strong> This path cannot run un-enveloped: a missing envelope or blank
 /// agent identity is rejected with a stable error code before any plan state is touched. Unexpected
-/// executor exceptions are logged in full but surfaced only as <c>plan_run.execution_failed</c> — raw
-/// exception text never reaches the caller.
+/// exceptions are logged in full but surfaced only as <c>plan_run.execution_failed</c> — raw exception
+/// text never reaches the caller. That guard spans identity initialization and executor resolution as
+/// well as the run itself, so <see cref="IPlanRunExecutor"/>'s unqualified "never raw exception text"
+/// holds literally rather than by happening to have no throwing setup.
 /// </para>
 /// </remarks>
 public sealed class PlanRunExecutor : IPlanRunExecutor
@@ -97,38 +99,44 @@ public sealed class PlanRunExecutor : IPlanRunExecutor
 
         await using var scope = _scopeFactory.CreateAsyncScope();
 
-        // Identity first, envelope second — the governor fails closed on identity-less enveloped
-        // tool calls, so the scoped execution context must carry the caller's identity before any
-        // step can observe the envelope.
         var runScope = request.ConversationId ?? request.PlanId.Value.ToString();
-        var executionContext = scope.ServiceProvider.GetRequiredService<IAgentExecutionContext>();
-        executionContext.Initialize(request.AgentId, runScope, turnNumber: 1);
 
-        var planExecutor = scope.ServiceProvider.GetRequiredService<IPlanExecutor>();
-
-        using (CapabilityEnvelopeAccessor.Begin(request.Envelope))
+        // Scope resolution and context initialization sit INSIDE the try alongside execution. Neither
+        // is expected to throw — the scope is fresh and IPlanExecutor is ValidateOnBuild-checked — but
+        // IPlanRunExecutor promises the caller a stable error code and "never raw exception text"
+        // without qualification. A guarantee that silently depends on unstated preconditions is worth
+        // less than one the code enforces literally, so the try covers every statement that could
+        // break it.
+        try
         {
-            try
-            {
+            // Identity first, envelope second — the governor fails closed on identity-less enveloped
+            // tool calls, so the scoped execution context must carry the caller's identity before any
+            // step can observe the envelope.
+            var executionContext = scope.ServiceProvider.GetRequiredService<IAgentExecutionContext>();
+            executionContext.Initialize(request.AgentId, runScope, turnNumber: 1);
+
+            var planExecutor = scope.ServiceProvider.GetRequiredService<IPlanExecutor>();
+
+            using (CapabilityEnvelopeAccessor.Begin(request.Envelope))
                 return await planExecutor.ExecuteAsync(request.PlanId, cancellationToken).ConfigureAwait(false);
-            }
-            catch (OperationCanceledException)
-            {
-                throw;
-            }
-            catch (Exception ex)
-            {
-                // Full detail stays in the structured log; the caller sees only a stable code so
-                // infrastructure exception text (paths, connection strings) can never leak out.
-                _logger.LogError(ex, "Plan run {PlanId} threw during enveloped execution", request.PlanId);
-                return Result<PlanExecutionSummary>.Fail("plan_run.execution_failed");
-            }
-            finally
-            {
-                // This run owns its budget entry — no conversation handler releases it, which is the
-                // whole reason it exists as a separate key. Freed on every exit path.
-                _conversationBudget.Release(PlanRunKeys.RunBudgetKey(runScope));
-            }
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            // Full detail stays in the structured log; the caller sees only a stable code so
+            // infrastructure exception text (paths, connection strings) can never leak out.
+            _logger.LogError(ex, "Plan run {PlanId} threw during enveloped setup or execution", request.PlanId);
+            return Result<PlanExecutionSummary>.Fail("plan_run.execution_failed");
+        }
+        finally
+        {
+            // This run owns its budget entry — no conversation handler releases it, which is the
+            // whole reason it exists as a separate key. Freed on every exit path; releasing a key that
+            // a failed setup never created is a no-op remove.
+            _conversationBudget.Release(PlanRunKeys.RunBudgetKey(runScope));
         }
     }
 }

--- a/src/Content/Infrastructure/Infrastructure.AI/Planner/StepExecutors/LlmCallStepExecutor.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Planner/StepExecutors/LlmCallStepExecutor.cs
@@ -1,6 +1,10 @@
 using System.Diagnostics;
+using Application.AI.Common.Interfaces.AI;
+using Application.AI.Common.Interfaces.Agent;
+using Application.AI.Common.Interfaces.Governance;
 using Application.AI.Common.Interfaces.Planner;
 using Application.Core.CQRS.Agents.RunConversation;
+using Domain.AI.Governance;
 using Domain.AI.Planner;
 using MediatR;
 using Microsoft.Extensions.Logging;
@@ -10,25 +14,65 @@ namespace Infrastructure.AI.Planner.StepExecutors;
 /// <summary>
 /// Executes LLM inference steps by delegating to <see cref="RunConversationCommand"/>.
 /// </summary>
+/// <remarks>
+/// <para>
+/// <strong>Envelope confinement.</strong> The step is authorized as the well-known capability
+/// <see cref="PlanCapabilities.LlmCall"/> through <see cref="IToolInvocationGovernor"/>, the same
+/// choke point the tool and retrieval steps use. Without it a caller holding the most restrictive
+/// possible envelope (no tools, Restricted ceiling) could still drive unbounded model inference on
+/// the host's credential with a plan-authored system prompt: tools the resulting agent calls stay
+/// confined, so the exposure is spend and prompt surface rather than privilege escalation, but an
+/// unmetered path defeats the point of confining the run.
+/// </para>
+/// <para>
+/// <strong>Budget.</strong> <c>RunConversationCommandHandler</c> already enforces the lifetime
+/// conversation budget — but it keys on <see cref="RunConversationCommand.ConversationId"/>, which
+/// this executor previously left to its per-command <c>Guid.NewGuid()</c> default. Every step
+/// therefore started a brand-new budget that could never accumulate, so a plan of N LlmCall steps
+/// spent N full budgets. The ambient <see cref="IAgentExecutionContext.ConversationId"/> — set once
+/// per run by <c>PlanRunExecutor</c> — is used as the key instead, so all inference in one plan run
+/// shares one budget, and the step refuses to start another conversation once it is exhausted. With
+/// no ambient conversation (direct in-process callers) the per-step fallback preserves today's
+/// behavior.
+/// </para>
+/// </remarks>
 public sealed class LlmCallStepExecutor : IPlanStepExecutor
 {
     private readonly ISender _sender;
     private readonly IPlanProgressNotifier _notifier;
+    private readonly IToolInvocationGovernor _toolInvocationGovernor;
+    private readonly IConversationBudgetTracker _conversationBudget;
+    private readonly IAgentExecutionContext _agentContext;
     private readonly PlanExecutionContext _executionContext;
     private readonly ILogger<LlmCallStepExecutor> _logger;
 
+    /// <summary>Initializes a new instance of the <see cref="LlmCallStepExecutor"/> class.</summary>
+    /// <param name="sender">Dispatches the conversation command.</param>
+    /// <param name="notifier">Plan progress notifier.</param>
+    /// <param name="toolInvocationGovernor">Authorizes inference against the ambient capability envelope.</param>
+    /// <param name="conversationBudget">Lifetime token budget shared across the plan run's inference.</param>
+    /// <param name="agentContext">Supplies the run's conversation identity for budget keying.</param>
+    /// <param name="executionContext">Current plan execution context.</param>
+    /// <param name="logger">Structured logger.</param>
     public LlmCallStepExecutor(
         ISender sender,
         IPlanProgressNotifier notifier,
+        IToolInvocationGovernor toolInvocationGovernor,
+        IConversationBudgetTracker conversationBudget,
+        IAgentExecutionContext agentContext,
         PlanExecutionContext executionContext,
         ILogger<LlmCallStepExecutor> logger)
     {
         _sender = sender;
         _notifier = notifier;
+        _toolInvocationGovernor = toolInvocationGovernor;
+        _conversationBudget = conversationBudget;
+        _agentContext = agentContext;
         _executionContext = executionContext;
         _logger = logger;
     }
 
+    /// <inheritdoc />
     public async Task<StepExecutionResult> ExecuteAsync(
         PlanStep step,
         IReadOnlyDictionary<PlanStepId, string> upstreamOutputs,
@@ -44,16 +88,34 @@ public sealed class LlmCallStepExecutor : IPlanStepExecutor
             };
         }
 
-        var sw = Stopwatch.StartNew();
+        var denial = await AuthorizeAsync(step, ct);
+        if (denial is not null)
+            return denial;
 
-        var userMessages = BuildUserMessages(config, upstreamOutputs);
+        var conversationId = ResolveConversationId();
+        if (_conversationBudget.GetStatus(conversationId).IsExhausted)
+        {
+            _logger.LogWarning(
+                "LlmCall step {Step} refused: conversation {ConversationId} has exhausted its lifetime token budget",
+                step.Name, conversationId);
+            return new StepExecutionResult
+            {
+                Status = StepExecutionStatus.Failed,
+                Duration = TimeSpan.Zero,
+                ErrorMessage = PlanStepErrors.BudgetExhausted,
+                IsPolicyDenial = true
+            };
+        }
+
+        var sw = Stopwatch.StartNew();
 
         var command = new RunConversationCommand
         {
             AgentName = config.ModelDeploymentKey,
             SystemPrompt = config.SystemPrompt,
-            UserMessages = userMessages,
+            UserMessages = BuildUserMessages(config, upstreamOutputs),
             MaxTurns = 1,
+            ConversationId = conversationId,
             OnProgress = async progress =>
             {
                 _logger.LogDebug("LLM turn {Turn} for step {Step}: {Status}",
@@ -81,6 +143,39 @@ public sealed class LlmCallStepExecutor : IPlanStepExecutor
             ErrorMessage = result.Error ?? "LLM call failed without error details.",
             Duration = sw.Elapsed
         };
+    }
+
+    /// <summary>
+    /// Authorizes the step as <see cref="PlanCapabilities.LlmCall"/> and, when denied, produces the
+    /// failed step result. Returns null when inference may proceed.
+    /// </summary>
+    private async Task<StepExecutionResult?> AuthorizeAsync(PlanStep step, CancellationToken ct)
+    {
+        var decision = await _toolInvocationGovernor.AuthorizeAsync(PlanCapabilities.LlmCall, ct);
+        if (decision.IsAllowed)
+            return null;
+
+        _logger.LogWarning("LlmCall step {Step} denied by invocation governor", step.Name);
+        return new StepExecutionResult
+        {
+            Status = StepExecutionStatus.Failed,
+            Duration = TimeSpan.Zero,
+            ErrorMessage = decision.DeniedMessage ?? GovernanceDenials.NotPermitted(PlanCapabilities.LlmCall),
+            IsPolicyDenial = true
+        };
+    }
+
+    /// <summary>
+    /// The budget key for this step's inference: the run's ambient conversation id when one was armed,
+    /// else the current plan id, else a fresh id. The first case is what makes the budget span the whole
+    /// plan run rather than resetting per step.
+    /// </summary>
+    private string ResolveConversationId()
+    {
+        if (!string.IsNullOrEmpty(_agentContext.ConversationId))
+            return _agentContext.ConversationId;
+
+        return _executionContext.CurrentPlanId?.Value.ToString() ?? Guid.NewGuid().ToString();
     }
 
     private static IReadOnlyList<string> BuildUserMessages(

--- a/src/Content/Infrastructure/Infrastructure.AI/Planner/StepExecutors/LlmCallStepExecutor.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Planner/StepExecutors/LlmCallStepExecutor.cs
@@ -7,6 +7,7 @@ using Application.Core.CQRS.Agents.RunConversation;
 using Domain.AI.Governance;
 using Domain.AI.Planner;
 using MediatR;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
 namespace Infrastructure.AI.Planner.StepExecutors;
@@ -25,20 +26,41 @@ namespace Infrastructure.AI.Planner.StepExecutors;
 /// unmetered path defeats the point of confining the run.
 /// </para>
 /// <para>
-/// <strong>Budget.</strong> <c>RunConversationCommandHandler</c> already enforces the lifetime
-/// conversation budget — but it keys on <see cref="RunConversationCommand.ConversationId"/>, which
-/// this executor previously left to its per-command <c>Guid.NewGuid()</c> default. Every step
-/// therefore started a brand-new budget that could never accumulate, so a plan of N LlmCall steps
-/// spent N full budgets. The ambient <see cref="IAgentExecutionContext.ConversationId"/> — set once
-/// per run by <c>PlanRunExecutor</c> — is used as the key instead, so all inference in one plan run
-/// shares one budget, and the step refuses to start another conversation once it is exhausted. With
-/// no ambient conversation (direct in-process callers) the per-step fallback preserves today's
-/// behavior.
+/// <strong>Two identities, deliberately separate — see <see cref="PlanRunKeys"/>.</strong> Each step
+/// gets its <em>own</em> conversation id. A conversation id is not just a budget key: it is the sole
+/// key of <c>IAgentConversationCache</c>, which returns a cached agent on a hit and ignores the
+/// requested skills and options, so sharing one id across steps would make a step run under another
+/// step's agent (with <c>MaxParallelSteps</c> defaulting to 10, concurrent steps are the normal case)
+/// and would let the first step to finish evict the cache and clear skill tracking for steps still
+/// running. Cross-step spend is instead accumulated against a separate run-level budget key.
+/// </para>
+/// <para>
+/// <strong>Each step's conversation runs in its own DI scope.</strong> The conversation is dispatched
+/// through an <see cref="ISender"/> resolved from a fresh scope rather than the plan's scope, because
+/// <c>IAgentExecutionContext</c> is scoped and single-binding: <c>AgentContextPropagationBehavior</c>
+/// calls <c>Initialize</c> for the nested agent-turn request, whose agent id is the step's
+/// <em>deployment key</em> and whose conversation id is this step's. The plan's scope is already bound
+/// by <c>PlanRunExecutor</c> to the caller's identity and the run's conversation, and re-initializing
+/// one context with a different agent or conversation throws by design (it is normally a scope leak).
+/// Dispatching in a per-step scope gives every turn a clean context to bind, which is also what makes
+/// the per-step cache and skill-tracking isolation real rather than nominal. This mirrors
+/// <c>BundleRunExecutor</c>, which resolves its mediator from its own scope for the same reason. The
+/// capability envelope is ambient (<c>AsyncLocal</c>) and flows into the child scope unchanged, so
+/// confinement is unaffected.
+/// </para>
+/// <para>
+/// <strong>Budget ownership.</strong> <c>RunConversationCommandHandler</c> owns its conversation's
+/// budget entry and <c>Release</c>s it in a <c>finally</c>, so an entry under any conversation id is
+/// erased when that conversation ends and can never carry spend to the next step. Rather than fight
+/// that ownership, the plan run accumulates <see cref="ConversationResult.TotalTokens"/> against its
+/// own <see cref="PlanRunKeys.RunBudgetKey"/> after each step and gates the next step on it;
+/// <c>PlanRunExecutor</c> releases that key when the run ends. With no run scope (an ad-hoc direct
+/// in-process call) there is no run-level budget and behavior is exactly as before.
 /// </para>
 /// </remarks>
 public sealed class LlmCallStepExecutor : IPlanStepExecutor
 {
-    private readonly ISender _sender;
+    private readonly IServiceScopeFactory _scopeFactory;
     private readonly IPlanProgressNotifier _notifier;
     private readonly IToolInvocationGovernor _toolInvocationGovernor;
     private readonly IConversationBudgetTracker _conversationBudget;
@@ -47,7 +69,7 @@ public sealed class LlmCallStepExecutor : IPlanStepExecutor
     private readonly ILogger<LlmCallStepExecutor> _logger;
 
     /// <summary>Initializes a new instance of the <see cref="LlmCallStepExecutor"/> class.</summary>
-    /// <param name="sender">Dispatches the conversation command.</param>
+    /// <param name="scopeFactory">Creates the per-step scope the conversation is dispatched in.</param>
     /// <param name="notifier">Plan progress notifier.</param>
     /// <param name="toolInvocationGovernor">Authorizes inference against the ambient capability envelope.</param>
     /// <param name="conversationBudget">Lifetime token budget shared across the plan run's inference.</param>
@@ -55,7 +77,7 @@ public sealed class LlmCallStepExecutor : IPlanStepExecutor
     /// <param name="executionContext">Current plan execution context.</param>
     /// <param name="logger">Structured logger.</param>
     public LlmCallStepExecutor(
-        ISender sender,
+        IServiceScopeFactory scopeFactory,
         IPlanProgressNotifier notifier,
         IToolInvocationGovernor toolInvocationGovernor,
         IConversationBudgetTracker conversationBudget,
@@ -63,7 +85,7 @@ public sealed class LlmCallStepExecutor : IPlanStepExecutor
         PlanExecutionContext executionContext,
         ILogger<LlmCallStepExecutor> logger)
     {
-        _sender = sender;
+        _scopeFactory = scopeFactory;
         _notifier = notifier;
         _toolInvocationGovernor = toolInvocationGovernor;
         _conversationBudget = conversationBudget;
@@ -92,12 +114,14 @@ public sealed class LlmCallStepExecutor : IPlanStepExecutor
         if (denial is not null)
             return denial;
 
-        var conversationId = ResolveConversationId();
-        if (_conversationBudget.GetStatus(conversationId).IsExhausted)
+        var runScope = ResolveRunScope();
+        var runBudgetKey = runScope is null ? null : PlanRunKeys.RunBudgetKey(runScope);
+
+        if (runBudgetKey is not null && _conversationBudget.GetStatus(runBudgetKey).IsExhausted)
         {
             _logger.LogWarning(
-                "LlmCall step {Step} refused: conversation {ConversationId} has exhausted its lifetime token budget",
-                step.Name, conversationId);
+                "LlmCall step {Step} refused: plan run {RunScope} has exhausted its lifetime token budget",
+                step.Name, runScope);
             return new StepExecutionResult
             {
                 Status = StepExecutionStatus.Failed,
@@ -115,7 +139,11 @@ public sealed class LlmCallStepExecutor : IPlanStepExecutor
             SystemPrompt = config.SystemPrompt,
             UserMessages = BuildUserMessages(config, upstreamOutputs),
             MaxTurns = 1,
-            ConversationId = conversationId,
+            // Per-step, never shared: this id keys the agent cache, skill-completion tracking, and the
+            // observability session. See PlanRunKeys.
+            ConversationId = runScope is null
+                ? Guid.NewGuid().ToString()
+                : PlanRunKeys.StepConversationId(runScope, step.Id),
             OnProgress = async progress =>
             {
                 _logger.LogDebug("LLM turn {Turn} for step {Step}: {Status}",
@@ -124,8 +152,22 @@ public sealed class LlmCallStepExecutor : IPlanStepExecutor
             }
         };
 
-        var result = await _sender.Send(command, ct);
+        // Per-step scope: the turn binds its own IAgentExecutionContext (deployment key + this step's
+        // conversation) without colliding with the run identity the plan's scope already holds.
+        ConversationResult result;
+        await using (var stepScope = _scopeFactory.CreateAsyncScope())
+        {
+            var sender = stepScope.ServiceProvider.GetRequiredService<ISender>();
+            result = await sender.Send(command, ct);
+        }
+
         sw.Stop();
+
+        // Fold this step's spend into the run-level budget the plan owns. The handler already
+        // released its own per-conversation entry by now, which is exactly why this is accounted
+        // separately rather than read back from that entry.
+        if (runBudgetKey is not null && result.TotalTokens > 0)
+            _conversationBudget.RecordUsage(runBudgetKey, result.TotalTokens);
 
         if (result.Success)
         {
@@ -166,17 +208,30 @@ public sealed class LlmCallStepExecutor : IPlanStepExecutor
     }
 
     /// <summary>
-    /// The budget key for this step's inference: the run's ambient conversation id when one was armed,
-    /// else the current plan id, else a fresh id. The first case is what makes the budget span the whole
-    /// plan run rather than resetting per step.
+    /// Identity of the enclosing run, used to derive both the per-step conversation id and the
+    /// run-level budget key — or null when this call belongs to no armed run, in which case there is
+    /// no run-level budget and the step gets a throwaway conversation id.
     /// </summary>
-    private string ResolveConversationId()
-    {
-        if (!string.IsNullOrEmpty(_agentContext.ConversationId))
-            return _agentContext.ConversationId;
-
-        return _executionContext.CurrentPlanId?.Value.ToString() ?? Guid.NewGuid().ToString();
-    }
+    /// <remarks>
+    /// <para>
+    /// <strong>Only an explicitly armed run scope counts.</strong> The scope is read solely from the
+    /// ambient <see cref="IAgentExecutionContext.ConversationId"/>, which only <c>PlanRunExecutor</c>
+    /// sets. It deliberately does <em>not</em> fall back to the current plan id: that fallback would
+    /// create a <c>planrun:</c> budget entry on the ungoverned in-process path, where nothing exists to
+    /// release it. Because the budget tracker is a singleton and an exhausted budget is a
+    /// <em>terminal, non-retryable</em> policy denial, an orphaned entry would make a plan id
+    /// permanently un-runnable in-process after one exhaustion — bounded eviction caps the memory, not
+    /// the semantics. Keying only on the armed scope makes creation and release symmetric: the one
+    /// component that establishes a run scope is the one that releases its key.
+    /// </para>
+    /// <para>
+    /// Sub-plans inherit correctly: <c>SubPlanStepExecutor</c> re-stamps the parent's conversation onto
+    /// the child scope, so an enveloped run shares one budget across its whole sub-plan tree, released
+    /// once when the run ends.
+    /// </para>
+    /// </remarks>
+    private string? ResolveRunScope() =>
+        string.IsNullOrEmpty(_agentContext.ConversationId) ? null : _agentContext.ConversationId;
 
     private static IReadOnlyList<string> BuildUserMessages(
         LlmCallConfig config,

--- a/src/Content/Infrastructure/Infrastructure.AI/Planner/StepExecutors/LlmCallStepExecutor.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Planner/StepExecutors/LlmCallStepExecutor.cs
@@ -225,6 +225,21 @@ public sealed class LlmCallStepExecutor : IPlanStepExecutor
     /// component that establishes a run scope is the one that releases its key.
     /// </para>
     /// <para>
+    /// <strong>Invariant this executor depends on: it may only run under a conversation id armed by
+    /// <c>PlanRunExecutor</c>.</strong> The <c>planrun:</c> budget key is derived from <em>any</em>
+    /// ambient <see cref="IAgentExecutionContext.ConversationId"/>, but only <c>PlanRunExecutor</c>
+    /// releases it. Nothing in this method distinguishes a conversation id that a run armed from one an
+    /// agent turn happened to be carrying, so the two are only kept apart by where plan execution is
+    /// driven from. That holds today because <c>ExecutePlanCommandHandler</c> is the sole in-process
+    /// <c>IPlanExecutor</c> caller and has no production dispatcher, which is why the orphan is
+    /// currently unreachable rather than merely unlikely. A future host that wires plan execution
+    /// <em>inside</em> an agent turn would break it: the step would create a run budget entry keyed on
+    /// the turn's conversation id that no one releases, and because budget exhaustion is a
+    /// <c>IsPolicyDenial</c> — terminal and non-retryable — every subsequent LlmCall step under that
+    /// conversation id would be denied permanently. Any such host must arm the run through
+    /// <c>PlanRunExecutor</c> so creation and release stay paired.
+    /// </para>
+    /// <para>
     /// Sub-plans inherit correctly: <c>SubPlanStepExecutor</c> re-stamps the parent's conversation onto
     /// the child scope, so an enveloped run shares one budget across its whole sub-plan tree, released
     /// once when the run ends.

--- a/src/Content/Infrastructure/Infrastructure.AI/Planner/StepExecutors/RetrievalPlanStepExecutor.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Planner/StepExecutors/RetrievalPlanStepExecutor.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Application.AI.Common.Interfaces.Governance;
 using Application.AI.Common.Interfaces.Planner;
 using Application.AI.Common.Interfaces.RAG;
 using Application.AI.Common.Interfaces.Routing;
@@ -17,6 +18,16 @@ namespace Infrastructure.AI.Planner.StepExecutors;
 /// <see cref="IRetrievalCostTracker"/> and serializes the assembled context as JSON output
 /// for downstream plan steps.
 /// </summary>
+/// <remarks>
+/// Retrieval is authorized as the well-known capability <see cref="PlanCapabilities.Retrieval"/>
+/// through <see cref="IToolInvocationGovernor"/> — the identical choke point
+/// <c>ToolUseStepExecutor</c> uses. Routing through the governor rather than testing the envelope's
+/// allowlist directly is what subjects retrieval to the <em>whole</em> chain: the envelope's
+/// autonomy-ceiling baseline (a granted name under a Restricted or Supervised ceiling still resolves
+/// to Ask, which the governor blocks), declarative policy, audit, the governance trace, and
+/// denial-rate accounting. With no ambient envelope and per-invocation enforcement off the governor
+/// is a pure pass-through, so direct in-process <c>IPlanExecutor</c> callers are unchanged.
+/// </remarks>
 public sealed class RetrievalPlanStepExecutor : IPlanStepExecutor
 {
     private static readonly JsonSerializerOptions SerializerOptions = new()
@@ -31,6 +42,7 @@ public sealed class RetrievalPlanStepExecutor : IPlanStepExecutor
     private readonly ITaskComplexityClassifier _complexityClassifier;
     private readonly IRetrievalCostTracker _costTracker;
     private readonly IPlanProgressNotifier _notifier;
+    private readonly IToolInvocationGovernor _toolInvocationGovernor;
     private readonly PlanExecutionContext _executionContext;
     private readonly ILogger<RetrievalPlanStepExecutor> _logger;
 
@@ -42,6 +54,7 @@ public sealed class RetrievalPlanStepExecutor : IPlanStepExecutor
     /// <param name="complexityClassifier">Task complexity classifier for multi-source routing.</param>
     /// <param name="costTracker">Tracks token usage and latency per retrieval call.</param>
     /// <param name="notifier">Plan progress notifier for real-time status updates.</param>
+    /// <param name="toolInvocationGovernor">Authorizes retrieval against the ambient capability envelope.</param>
     /// <param name="executionContext">Current plan execution context with depth tracking.</param>
     /// <param name="logger">Logger instance.</param>
     public RetrievalPlanStepExecutor(
@@ -50,6 +63,7 @@ public sealed class RetrievalPlanStepExecutor : IPlanStepExecutor
         ITaskComplexityClassifier complexityClassifier,
         IRetrievalCostTracker costTracker,
         IPlanProgressNotifier notifier,
+        IToolInvocationGovernor toolInvocationGovernor,
         PlanExecutionContext executionContext,
         ILogger<RetrievalPlanStepExecutor> logger)
     {
@@ -58,6 +72,7 @@ public sealed class RetrievalPlanStepExecutor : IPlanStepExecutor
         _complexityClassifier = complexityClassifier;
         _costTracker = costTracker;
         _notifier = notifier;
+        _toolInvocationGovernor = toolInvocationGovernor;
         _executionContext = executionContext;
         _logger = logger;
     }
@@ -75,6 +90,21 @@ public sealed class RetrievalPlanStepExecutor : IPlanStepExecutor
                 Status = StepExecutionStatus.Failed,
                 Duration = TimeSpan.Zero,
                 ErrorMessage = $"Step '{step.Name}' has invalid configuration type for Retrieval executor."
+            };
+        }
+
+        var decision = await _toolInvocationGovernor.AuthorizeAsync(PlanCapabilities.Retrieval, ct);
+        if (!decision.IsAllowed)
+        {
+            _logger.LogWarning(
+                "Retrieval step {Step} denied by invocation governor", step.Name);
+            return new StepExecutionResult
+            {
+                Status = StepExecutionStatus.Failed,
+                Duration = TimeSpan.Zero,
+                ErrorMessage = decision.DeniedMessage
+                    ?? Domain.AI.Governance.GovernanceDenials.NotPermitted(PlanCapabilities.Retrieval),
+                IsPolicyDenial = true
             };
         }
 
@@ -106,12 +136,15 @@ public sealed class RetrievalPlanStepExecutor : IPlanStepExecutor
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
             sw.Stop();
+            // Full detail stays in the structured log; only a stable code is persisted onto the step,
+            // because step error state is returned to callers and retrieval-stack exceptions carry
+            // store endpoints and credentials.
             _logger.LogError(ex, "Retrieval step '{StepName}' failed", step.Name);
 
             return new StepExecutionResult
             {
                 Status = StepExecutionStatus.Failed,
-                ErrorMessage = $"Retrieval failed: {ex.Message}",
+                ErrorMessage = PlanStepErrors.RetrievalFailed,
                 Duration = sw.Elapsed
             };
         }

--- a/src/Content/Infrastructure/Infrastructure.AI/Planner/StepExecutors/SubPlanStepExecutor.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Planner/StepExecutors/SubPlanStepExecutor.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Text.Json;
+using Application.AI.Common.Interfaces.Agent;
 using Application.AI.Common.Interfaces.Planner;
 using Domain.AI.Planner;
 using Microsoft.Extensions.DependencyInjection;
@@ -11,12 +12,23 @@ namespace Infrastructure.AI.Planner.StepExecutors;
 /// Invokes a child plan in an isolated DI scope with depth limiting.
 /// The parent step blocks while the child plan executes.
 /// </summary>
+/// <remarks>
+/// The ambient capability envelope flows into the child execution on its own — it is carried by an
+/// <c>AsyncLocal</c>, which crosses DI scope boundaries — so an enveloped parent's grant confines the
+/// child identically (a tool denied in the parent stays denied in every sub-plan). The governance
+/// <em>identity</em> does not flow by itself: <see cref="IAgentExecutionContext"/> is DI-scoped and the
+/// child runs in a fresh scope, whose context would otherwise be empty — and the tool-invocation
+/// governor fails closed on identity-less tool calls whenever an envelope is ambient. This executor
+/// therefore re-stamps the parent's identity onto the child scope, so the child is governed as the same
+/// principal: granted tools keep working, denied tools stay denied.
+/// </remarks>
 public sealed class SubPlanStepExecutor : IPlanStepExecutor
 {
     private readonly IServiceScopeFactory _scopeFactory;
     private readonly IPlanStateStore _planStateStore;
     private readonly IPlanProgressNotifier _notifier;
     private readonly PlanExecutionContext _executionContext;
+    private readonly IAgentExecutionContext _agentContext;
     private readonly ILogger<SubPlanStepExecutor> _logger;
 
     public SubPlanStepExecutor(
@@ -24,12 +36,14 @@ public sealed class SubPlanStepExecutor : IPlanStepExecutor
         IPlanStateStore planStateStore,
         IPlanProgressNotifier notifier,
         PlanExecutionContext executionContext,
+        IAgentExecutionContext agentContext,
         ILogger<SubPlanStepExecutor> logger)
     {
         _scopeFactory = scopeFactory;
         _planStateStore = planStateStore;
         _notifier = notifier;
         _executionContext = executionContext;
+        _agentContext = agentContext;
         _logger = logger;
     }
 
@@ -81,6 +95,8 @@ public sealed class SubPlanStepExecutor : IPlanStepExecutor
             CurrentPlanId = childPlanId
         };
 
+        PropagateGovernanceIdentity(scope.ServiceProvider, childPlanId.Value);
+
         var childExecutor = scope.ServiceProvider.GetRequiredService<IPlanExecutor>();
 
         try
@@ -118,14 +134,35 @@ public sealed class SubPlanStepExecutor : IPlanStepExecutor
         catch (Exception ex)
         {
             sw.Stop();
+            // Full detail stays in the structured log; only a stable code is persisted onto the step,
+            // because step error state is returned to callers and a child plan's failure can surface
+            // EF Core connection strings from the state store.
             _logger.LogError(ex, "Child plan execution threw for step {Step}", step.Name);
             return new StepExecutionResult
             {
                 Status = StepExecutionStatus.Failed,
-                ErrorMessage = $"Child plan exception: {ex.Message}",
+                ErrorMessage = PlanStepErrors.SubPlanFailed,
                 Duration = sw.Elapsed
             };
         }
+    }
+
+    /// <summary>
+    /// Stamps the parent's governance identity onto the child scope's execution context, so tool
+    /// governance inside the sub-plan resolves against the same principal as the parent. No-op when
+    /// the parent carries no identity (an ungoverned direct <c>IPlanExecutor</c> run) — the child then
+    /// behaves exactly as it did before envelope confinement existed.
+    /// </summary>
+    private void PropagateGovernanceIdentity(IServiceProvider childServices, PlanId childPlanId)
+    {
+        if (string.IsNullOrEmpty(_agentContext.AgentId))
+            return;
+
+        var childAgentContext = childServices.GetRequiredService<IAgentExecutionContext>();
+        childAgentContext.Initialize(
+            _agentContext.AgentId,
+            _agentContext.ConversationId ?? childPlanId.Value.ToString(),
+            _agentContext.TurnNumber ?? 1);
     }
 
     private async Task<PlanId?> ResolveChildPlanId(SubPlanConfig config, CancellationToken ct)

--- a/src/Content/Infrastructure/Infrastructure.AI/Planner/StepExecutors/ToolUseStepExecutor.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Planner/StepExecutors/ToolUseStepExecutor.cs
@@ -16,9 +16,18 @@ namespace Infrastructure.AI.Planner.StepExecutors;
 /// Executes tool steps by routing through the appropriate sandbox, verifying attestation,
 /// and enforcing capability-based permissions with never-downgrade isolation.
 /// </summary>
+/// <remarks>
+/// Before any sandbox resource is resolved, the tool call is authorized through
+/// <see cref="IToolInvocationGovernor"/> — the same choke point the live agent tool path uses. With no
+/// ambient capability envelope and per-invocation enforcement off, that authorization is a pure
+/// pass-through, so direct in-process <c>IPlanExecutor</c> callers behave exactly as before. Under an
+/// enveloped run (armed by <c>PlanRunExecutor</c>) the governor enforces the per-caller grant fail-closed:
+/// out-of-envelope tools, autonomy-ceiling violations, and identity-less calls all deny before execution.
+/// </remarks>
 public sealed class ToolUseStepExecutor : IPlanStepExecutor
 {
     private readonly ICapabilityEnforcer _capabilityEnforcer;
+    private readonly IToolInvocationGovernor _toolInvocationGovernor;
     private readonly IServiceProvider _serviceProvider;
     private readonly IAttestationService _attestationService;
     private readonly ICompositeResponseSanitizer _responseSanitizer;
@@ -28,6 +37,7 @@ public sealed class ToolUseStepExecutor : IPlanStepExecutor
 
     public ToolUseStepExecutor(
         ICapabilityEnforcer capabilityEnforcer,
+        IToolInvocationGovernor toolInvocationGovernor,
         IServiceProvider serviceProvider,
         IAttestationService attestationService,
         ICompositeResponseSanitizer responseSanitizer,
@@ -36,6 +46,7 @@ public sealed class ToolUseStepExecutor : IPlanStepExecutor
         ILogger<ToolUseStepExecutor> logger)
     {
         _capabilityEnforcer = capabilityEnforcer;
+        _toolInvocationGovernor = toolInvocationGovernor;
         _serviceProvider = serviceProvider;
         _attestationService = attestationService;
         _responseSanitizer = responseSanitizer;
@@ -61,6 +72,10 @@ public sealed class ToolUseStepExecutor : IPlanStepExecutor
             };
         }
 
+        var denial = await AuthorizeToolAsync(config.ToolName, step.Name, sw, ct);
+        if (denial is not null)
+            return denial;
+
         var profile = await _capabilityEnforcer.ResolveProfileAsync(config.ToolName, ct);
         var isolationLevel = DetermineIsolation(config, profile, step);
 
@@ -83,11 +98,14 @@ public sealed class ToolUseStepExecutor : IPlanStepExecutor
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
             sw.Stop();
+            // Full detail stays in the structured log; only a stable code is persisted onto the step,
+            // because step error state is returned to callers and sandbox exceptions carry host paths,
+            // container ids, and mount configuration.
             _logger.LogError(ex, "Sandbox execution threw for tool {Tool} in step {Step}", config.ToolName, step.Name);
             return new StepExecutionResult
             {
                 Status = StepExecutionStatus.Failed,
-                ErrorMessage = $"Sandbox execution exception: {ex.Message}",
+                ErrorMessage = PlanStepErrors.SandboxFailed,
                 Duration = sw.Elapsed
             };
         }
@@ -148,6 +166,31 @@ public sealed class ToolUseStepExecutor : IPlanStepExecutor
             ErrorMessage = sandboxResult.ErrorMessage ?? "Tool execution failed.",
             Duration = sw.Elapsed,
             Attestation = sandboxResult.Attestation
+        };
+    }
+
+    /// <summary>
+    /// Authorizes the tool call through the invocation governor and, when denied, produces the failed
+    /// step result. Returns null when the call is allowed. The governor's denial message is already
+    /// scrubbed for model/caller consumption (rule ids and policy internals stay in the governance
+    /// trace and structured log), so it is safe to surface as the step error.
+    /// </summary>
+    private async Task<StepExecutionResult?> AuthorizeToolAsync(
+        string toolName, string stepName, Stopwatch sw, CancellationToken ct)
+    {
+        var decision = await _toolInvocationGovernor.AuthorizeAsync(toolName, ct);
+        if (decision.IsAllowed)
+            return null;
+
+        sw.Stop();
+        _logger.LogWarning(
+            "Tool {Tool} denied by invocation governor in step {Step}", toolName, stepName);
+        return new StepExecutionResult
+        {
+            Status = StepExecutionStatus.Failed,
+            ErrorMessage = decision.DeniedMessage ?? GovernanceDenials.NotPermitted(toolName),
+            Duration = sw.Elapsed,
+            IsPolicyDenial = true
         };
     }
 

--- a/src/Content/Infrastructure/Infrastructure.AI/Planner/StepExecutors/ToolUseStepExecutor.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Planner/StepExecutors/ToolUseStepExecutor.cs
@@ -160,10 +160,17 @@ public sealed class ToolUseStepExecutor : IPlanStepExecutor
             };
         }
 
+        // Same treatment as the throw path above: the sandbox's failure text is raw process stderr, a
+        // raw exception message, or raw container logs, and step error state is persisted and returned to
+        // callers. Log it in full, persist only the stable code.
+        _logger.LogWarning(
+            "Tool {Tool} in step {Step} failed in the sandbox: {SandboxError}",
+            config.ToolName, step.Name, sandboxResult.ErrorMessage ?? "(no detail reported)");
+
         return new StepExecutionResult
         {
             Status = StepExecutionStatus.Failed,
-            ErrorMessage = sandboxResult.ErrorMessage ?? "Tool execution failed.",
+            ErrorMessage = PlanStepErrors.ToolFailed,
             Duration = sw.Elapsed,
             Attestation = sandboxResult.Attestation
         };

--- a/src/Content/Presentation/Presentation.Common/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Content/Presentation/Presentation.Common/Extensions/IServiceCollectionExtensions.cs
@@ -42,6 +42,7 @@ using Microsoft.Identity.Web;
 using Presentation.Common.Helpers;
 using Presentation.Common.Hosting;
 using Presentation.Common.Security;
+using Presentation.Common.Startup;
 
 namespace Presentation.Common.Extensions;
 
@@ -320,6 +321,12 @@ public static class IServiceCollectionExtensions
 
         // Project dependencies BEFORE telemetry so ITelemetryConfigurator implementations are registered
         services.AddGlobalProjectDependencies(appConfig);
+
+        // Every keyed ITool registration has now run, so this is the first point at which the
+        // reserved-name collision can be decided. A tool keyed as a PlanCapabilities name silently
+        // merges the plan-capability grant with that tool's grant inside the capability envelope —
+        // fail-open, so it is refused here rather than left to review.
+        services.ValidateNoReservedPlanCapabilityToolKeys();
 
         // OTel pipeline (must be after project deps to pick up configurators)
         services.AddOpenTelemetry(appConfig);

--- a/src/Content/Presentation/Presentation.Common/Startup/ReservedPlanCapabilityGuard.cs
+++ b/src/Content/Presentation/Presentation.Common/Startup/ReservedPlanCapabilityGuard.cs
@@ -1,0 +1,93 @@
+using Application.AI.Common.Interfaces.Tools;
+using Domain.AI.Planner;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Presentation.Common.Startup;
+
+/// <summary>
+/// Composition-time guard that refuses to build a host in which a keyed <see cref="ITool"/> is
+/// registered under a reserved <see cref="PlanCapabilities"/> name.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>The fail-open this closes.</strong> Plan-native operations (Retrieval, LlmCall) are
+/// authorized by name out of the <em>same</em> <c>CapabilityEnvelope.AllowedTools</c> string space
+/// as keyed tool registrations. A tool registered under <c>rag_retrieval</c> or <c>llm_call</c>
+/// therefore merges two grants that a caller believes are separate: granting the plan capability
+/// silently grants the tool, and granting the tool silently grants the capability. Nothing in the
+/// DI container prevents the collision, and nothing at invocation time reports it — the run simply
+/// succeeds with more authority than the envelope's author intended. That is a fail-open default,
+/// so it is refused at composition rather than detected in review.
+/// </para>
+/// <para>
+/// <strong>Why here and not only in a test.</strong> This is a template that consumers clone; a
+/// consumer's host registers its own tools and may not carry the harness's test projects forward.
+/// The check therefore ships as production wiring, on the same boot-time fail-fast footing as
+/// <see cref="StartupRegistrationSmokeCheck"/> and the <c>ValidateOnBuild</c> policy: a mis-wired
+/// graph fails loudly at startup instead of silently at first use.
+/// </para>
+/// <para>
+/// <strong>Where it runs.</strong> <c>BuildGlobalSolutionServices</c> invokes it immediately after
+/// <c>AddGlobalProjectDependencies</c>, the point at which every harness tool registration has run;
+/// all five hosts reach it through <c>GetServices</c>. It inspects
+/// <see cref="ServiceDescriptor.ServiceKey"/> rather than resolving anything, so it constructs no
+/// tools and cannot itself fail a boot that would otherwise succeed. A consumer that registers
+/// additional tools <em>after</em> the harness composition root has returned should call it again —
+/// it is idempotent and public for exactly that reason.
+/// </para>
+/// <para>
+/// Matching is case-insensitive (<see cref="PlanCapabilities.IsReserved"/>) because the envelope
+/// matches allowlist entries case-insensitively, so a key differing only in case is a real
+/// collision even though keyed DI resolution itself is ordinal.
+/// </para>
+/// </remarks>
+public static class ReservedPlanCapabilityGuard
+{
+    /// <summary>
+    /// Throws when any keyed <see cref="ITool"/> registration in <paramref name="services"/> uses a
+    /// reserved plan-capability name.
+    /// </summary>
+    /// <param name="services">The service collection to inspect. Not modified.</param>
+    /// <returns>The same collection, for chaining.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="services"/> is <c>null</c>.</exception>
+    /// <exception cref="InvalidOperationException">
+    /// One or more keyed <see cref="ITool"/> registrations collide with
+    /// <see cref="PlanCapabilities.ReservedNames"/>. The message names every offending key and the
+    /// implementation registered under it.
+    /// </exception>
+    public static IServiceCollection ValidateNoReservedPlanCapabilityToolKeys(
+        this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        var collisions = services
+            .Where(IsReservedToolRegistration)
+            .Select(descriptor => $"'{descriptor.ServiceKey}' registered as {DescribeImplementation(descriptor)}")
+            .Distinct(StringComparer.Ordinal)
+            .ToList();
+
+        if (collisions.Count == 0)
+            return services;
+
+        throw new InvalidOperationException(
+            $"{collisions.Count} keyed ITool registration(s) collide with reserved plan-capability " +
+            $"name(s): {string.Join("; ", collisions)}. Plan capabilities are authorized out of the " +
+            "same CapabilityEnvelope.AllowedTools string space as tool keys, so granting the " +
+            "capability would also grant the tool and vice versa. Re-key the tool(s) to a name that " +
+            "is not in Domain.AI.Planner.PlanCapabilities.ReservedNames.");
+    }
+
+    private static bool IsReservedToolRegistration(ServiceDescriptor descriptor) =>
+        descriptor.ServiceType == typeof(ITool)
+        && descriptor.ServiceKey is string key
+        && PlanCapabilities.IsReserved(key);
+
+    /// <summary>
+    /// Names the implementation behind a keyed descriptor. Factory registrations — the shape every
+    /// harness tool uses — expose no type, so the key alone has to carry the diagnosis there.
+    /// </summary>
+    private static string DescribeImplementation(ServiceDescriptor descriptor) =>
+        descriptor.KeyedImplementationType?.FullName
+        ?? descriptor.KeyedImplementationInstance?.GetType().FullName
+        ?? "a factory-provided implementation";
+}

--- a/src/Content/Presentation/Presentation.Common/Startup/ReservedPlanCapabilityGuard.cs
+++ b/src/Content/Presentation/Presentation.Common/Startup/ReservedPlanCapabilityGuard.cs
@@ -20,6 +20,17 @@ namespace Presentation.Common.Startup;
 /// so it is refused at composition rather than detected in review.
 /// </para>
 /// <para>
+/// <strong>Scope — keyed <see cref="ITool"/> descriptors present in the container, and nothing
+/// else.</strong> This guard sees only registrations that exist when it runs, which means only
+/// first-party wiring. Tools discovered at runtime from an external MCP server or a plugin manifest
+/// never appear as DI descriptors at all, so a collision arriving from a third party is invisible
+/// here no matter when the guard is called. Those are excluded separately, at the point
+/// <c>ToolChainBuilder</c> assembles a chain — see the remarks on
+/// <see cref="PlanCapabilities"/>. The two checks are complementary, not redundant: this one fails
+/// the boot because a first-party collision is our bug; the runtime one logs and drops because a
+/// third party must not be able to fail every agent turn in the host.
+/// </para>
+/// <para>
 /// <strong>Why here and not only in a test.</strong> This is a template that consumers clone; a
 /// consumer's host registers its own tools and may not carry the harness's test projects forward.
 /// The check therefore ships as production wiring, on the same boot-time fail-fast footing as

--- a/src/Content/Tests/Application.AI.Common.Tests/Governance/GoverningToolContextProviderTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Governance/GoverningToolContextProviderTests.cs
@@ -1,18 +1,22 @@
 using Application.AI.Common.Services.Agent;
 using Application.AI.Common.Services.Tools;
+using Domain.AI.Planner;
 using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
 namespace Application.AI.Common.Tests.Governance;
 
 /// <summary>
-/// Verifies the invocation-time wrapping decision used by <see cref="GoverningToolContextProvider"/>
-/// to govern framework/progressive-disclosure tools that bypass the build-time wrap.
+/// Verifies the two checks <see cref="GoverningToolContextProvider"/> applies to the
+/// <c>AIContext.Tools</c> channel — the one route onto the model's callable surface that does not pass
+/// through <see cref="ToolChainBuilder"/>: reserved plan-capability exclusion, and invocation-time
+/// governance wrapping of framework/progressive-disclosure tools.
 /// </summary>
 public sealed class GoverningToolContextProviderTests
 {
-    private static AIFunction MakeFunction() => AIFunctionFactory.Create(
-        () => "ok", new AIFunctionFactoryOptions { Name = "file_system", Description = "t" });
+    private static AIFunction MakeFunction(string name = "file_system") => AIFunctionFactory.Create(
+        () => "ok", new AIFunctionFactoryOptions { Name = name, Description = "t" });
 
     [Fact]
     public void Govern_UnwrappedFunction_WrapsInGovernedAIFunction()
@@ -34,5 +38,58 @@ public sealed class GoverningToolContextProviderTests
         var result = GoverningToolContextProvider.Govern(alreadyGoverned);
 
         Assert.Same(alreadyGoverned, result);
+    }
+
+    [Theory]
+    [InlineData(PlanCapabilities.LlmCall)]
+    [InlineData(PlanCapabilities.Retrieval)]
+    [InlineData("RAG_Retrieval")] // case-insensitive: the envelope matches names that way too
+    public void FilterAndGovern_ReservedName_IsDroppedFromTheContextChannel(string reservedName)
+    {
+        // ToolChainBuilder is not the only way a tool reaches the model — the framework merges
+        // AIContext.Tools from providers. A reserved plan-capability name arriving down THAT channel
+        // would be published to the model and would collide with the envelope's grant namespace, so it
+        // must be dropped here too.
+        var tools = new List<AITool> { MakeFunction(reservedName), MakeFunction("file_system") };
+
+        var result = GoverningToolContextProvider.FilterAndGovern(
+            tools, NullLogger<GoverningToolContextProviderTests>.Instance);
+
+        Assert.NotNull(result);
+        Assert.Single(result);
+        Assert.Equal("file_system", result[0].Name);
+    }
+
+    [Fact]
+    public void FilterAndGovern_NoReservedNames_StillWrapsForGovernance()
+    {
+        var tools = new List<AITool> { MakeFunction() };
+
+        var result = GoverningToolContextProvider.FilterAndGovern(
+            tools, NullLogger<GoverningToolContextProviderTests>.Instance);
+
+        Assert.NotNull(result);
+        Assert.IsType<GovernedAIFunction>(Assert.Single(result));
+    }
+
+    [Fact]
+    public void FilterAndGovern_AlreadyGovernedAndNoCollisions_ReportsNoChange()
+    {
+        // Null means "keep the existing AIContext" — nothing was dropped and nothing needed wrapping.
+        var tools = new List<AITool> { new GovernedAIFunction(MakeFunction()) };
+
+        var result = GoverningToolContextProvider.FilterAndGovern(
+            tools, NullLogger<GoverningToolContextProviderTests>.Instance);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void FilterAndGovern_NoTools_ReportsNoChange()
+    {
+        Assert.Null(GoverningToolContextProvider.FilterAndGovern(
+            null, NullLogger<GoverningToolContextProviderTests>.Instance));
+        Assert.Null(GoverningToolContextProvider.FilterAndGovern(
+            [], NullLogger<GoverningToolContextProviderTests>.Instance));
     }
 }

--- a/src/Content/Tests/Application.AI.Common.Tests/Governance/ToolInvocationGovernorEnvelopeTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Governance/ToolInvocationGovernorEnvelopeTests.cs
@@ -143,4 +143,65 @@ public sealed class ToolInvocationGovernorEnvelopeTests
         _permissions.Verify(x => x.ResolvePermissionAsync(It.IsAny<string>(), It.IsAny<string>(),
             It.IsAny<string?>(), It.IsAny<IReadOnlyDictionary<string, object?>?>(), It.IsAny<CancellationToken>()), Times.Never);
     }
+
+    [Fact]
+    public async Task ResolverAllowsToolTheEnvelopeDoesNotGrant_IsStillDenied()
+    {
+        // The defence-in-depth check, and the reason it exists: the permission resolver was the SOLE
+        // enforcement point for tool names at invocation, and its arbitration has been wrong twice — a
+        // tier default that allowed anything unmatched, then a plugin baseline that outranked the
+        // envelope's closing deny. Both were caught by human review, not by the system refusing.
+        //
+        // This test forces the exact condition those bugs produced: the resolver says Allow for a tool
+        // the armed envelope never granted. The governor must refuse anyway.
+        _permissions
+            .Setup(x => x.ResolvePermissionAsync(It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<string?>(), It.IsAny<IReadOnlyDictionary<string, object?>?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(PermissionDecision.Allow("resolver arbitration bug"));
+        var governor = Build();
+
+        ToolInvocationDecision decision;
+        using (CapabilityEnvelopeAccessor.Begin(Envelope()))
+            decision = await governor.AuthorizeAsync("ungranted_tool", CancellationToken.None);
+
+        Assert.False(decision.IsAllowed);
+        _denialTracker.Verify(x => x.RecordDenial(Agent, "ungranted_tool"), Times.Once);
+    }
+
+    [Fact]
+    public async Task ResolverAllowsToolTheEnvelopeGrants_IsAllowed()
+    {
+        // The other direction, and the one that proves the guard is not simply denying everything.
+        // Without this a "deny unconditionally" regression would leave the test above green.
+        _permissions
+            .Setup(x => x.ResolvePermissionAsync(It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<string?>(), It.IsAny<IReadOnlyDictionary<string, object?>?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(PermissionDecision.Allow("granted"));
+        var governor = Build();
+
+        ToolInvocationDecision decision;
+        using (CapabilityEnvelopeAccessor.Begin(Envelope()))
+            decision = await governor.AuthorizeAsync(Tool, CancellationToken.None);
+
+        Assert.True(decision.IsAllowed);
+    }
+
+    [Fact]
+    public async Task ResolverAllowsToolGrantedInDifferentCase_IsAllowed()
+    {
+        // The envelope matches case-insensitively and keyed DI resolves ordinally, so a case variant is
+        // a real collision rather than a typo. The guard must use the envelope's own comparer, or it
+        // would deny a legitimately granted tool whose casing differs from the registration.
+        _permissions
+            .Setup(x => x.ResolvePermissionAsync(It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<string?>(), It.IsAny<IReadOnlyDictionary<string, object?>?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(PermissionDecision.Allow("granted"));
+        var governor = Build();
+
+        ToolInvocationDecision decision;
+        using (CapabilityEnvelopeAccessor.Begin(Envelope()))
+            decision = await governor.AuthorizeAsync(Tool.ToUpperInvariant(), CancellationToken.None);
+
+        Assert.True(decision.IsAllowed);
+    }
 }

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/AgentConversationCacheTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/AgentConversationCacheTests.cs
@@ -128,6 +128,41 @@ public sealed class AgentConversationCacheTests
     }
 
     [Fact]
+    public async Task GetOrCreateAsync_SameConversationId_ReturnsCachedAgentWithoutConsultingSkills()
+    {
+        // The cache is keyed SOLELY by conversation id: a hit short-circuits before the requested
+        // skills or options are looked at AT ALL. The second request here asks for "deploy" on its
+        // own, which is an invalid skill set — building it throws because its "validate" prerequisite
+        // is absent (see GetOrCreateAsync_SkillWithPrerequisites_ResolvesScopeWithoutThrowing). That
+        // it returns an agent anyway, rather than throwing, proves the requested skills were never
+        // examined.
+        //
+        // This is why concurrent plan steps must never share a conversation id: the second step gets
+        // a cache HIT and silently runs under the first step's agent — its skills, instructions,
+        // allowed tools and deployment. Proven here against the real cache so the plan engine's
+        // per-step id derivation (PlanRunKeys.StepConversationId) has a demonstrated reason to exist.
+        var first = await _cache.GetOrCreateAsync("conv-shared", [ValidateSkillId], new SkillAgentOptions());
+
+        var second = await _cache.GetOrCreateAsync("conv-shared", [DeploySkillId], new SkillAgentOptions());
+
+        second.Should().BeSameAs(first,
+            "a cache hit returns the existing agent even for a skill set that could not have been built");
+    }
+
+    [Fact]
+    public async Task GetOrCreateAsync_DistinctConversationIds_BuildIndependentAgents()
+    {
+        // The converse, and the property the plan engine relies on: distinct ids never collide, so
+        // per-step ids keep agent resolution, eviction and skill tracking isolated per step.
+        var first = await _cache.GetOrCreateAsync(
+            "conv-a", [ValidateSkillId], new SkillAgentOptions());
+        var second = await _cache.GetOrCreateAsync(
+            "conv-b", [ValidateSkillId, DeploySkillId], new SkillAgentOptions());
+
+        second.Should().NotBeSameAs(first);
+    }
+
+    [Fact]
     public async Task Evict_ClearsPrerequisiteCompletionState()
     {
         // Arrange — build the agent, then record a completion under the same scope.

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/ToolChainBuilderReservedCapabilityTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/ToolChainBuilderReservedCapabilityTests.cs
@@ -1,0 +1,179 @@
+using Application.AI.Common.Interfaces;
+using Application.AI.Common.Interfaces.Tools;
+using Application.AI.Common.Services.Tools;
+using Domain.AI.Models;
+using Domain.AI.Planner;
+using Domain.AI.Skills;
+using Domain.AI.Tools;
+using FluentAssertions;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Application.AI.Common.Tests.Services.Tools;
+
+/// <summary>
+/// Tests the runtime half of the reserved plan-capability defence in <see cref="ToolChainBuilder"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>ReservedPlanCapabilityGuard</c> scans DI descriptors at boot, which covers first-party keyed
+/// tools only. MCP-client and plugin-manifest tools are discovered at <em>runtime</em>, so a
+/// third-party server publishing <c>rag_retrieval</c> is invisible to any boot-time scan. Because
+/// plan capabilities are authorized out of the same case-insensitively matched
+/// <c>CapabilityEnvelope.AllowedTools</c> string space as tool names, such a tool would be handed to
+/// the model by any plan envelope that grants retrieval — and an envelope granting the tool would
+/// grant plan inference. These tests pin that a colliding runtime tool never reaches the callable
+/// surface, that casing cannot be used to evade the check, and that non-colliding tools are untouched.
+/// </para>
+/// </remarks>
+public sealed class ToolChainBuilderReservedCapabilityTests
+{
+    private static ToolChainBuilder Builder(IMcpToolProvider mcp) => new(
+        NullLogger<ToolChainBuilder>.Instance,
+        new ServiceCollection().BuildServiceProvider(),
+        toolConverter: null,
+        mcpToolProvider: mcp);
+
+    /// <summary>
+    /// A plugin-sourced skill with no declarations or restrictions, which is what
+    /// <see cref="SkillDefinition.Mode"/> derives as <see cref="SkillMode.Injected"/> — the path that
+    /// passes every MCP tool through wholesale, and therefore the widest third-party inlet.
+    /// </summary>
+    private static SkillDefinition InjectedSkill() =>
+        new() { Id = "s", Name = "s", Instructions = "x", PluginSource = "third-party-plugin" };
+
+    private static IMcpToolProvider McpPublishing(params string[] toolNames)
+    {
+        var mcp = new Mock<IMcpToolProvider>();
+        mcp.Setup(p => p.GetAllToolsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<string, IList<AITool>>
+            {
+                ["third-party"] = [.. toolNames.Select(n => (AITool)AIFunctionFactory.Create(() => "r", n))]
+            });
+        return mcp.Object;
+    }
+
+    [Theory]
+    [InlineData(PlanCapabilities.Retrieval)]
+    [InlineData(PlanCapabilities.LlmCall)]
+    [InlineData("RAG_Retrieval")]
+    [InlineData("LLM_Call")]
+    public async Task InjectedMcpTool_NamedForReservedPlanCapability_IsExcludedFromChain(string publishedName)
+    {
+        // An external MCP server publishes a tool under a reserved plan-capability name. It must never
+        // reach the model's callable surface: an envelope granting the capability would otherwise also
+        // hand over this third-party tool. Casing must not evade the check, because the allowlist that
+        // authorizes the capability matches case-insensitively.
+        var builder = Builder(McpPublishing(publishedName, "safe_tool"));
+
+        var tools = await builder.BuildToolsAsync(InjectedSkill(), new SkillAgentOptions());
+
+        tools.Select(t => t.Name).Should().BeEquivalentTo(["safe_tool"],
+            "a runtime-sourced tool colliding with a reserved plan capability must be dropped, " +
+            "while its non-colliding neighbours pass through");
+    }
+
+    [Fact]
+    public async Task InjectedMcpTools_WithoutCollision_PassThroughUntouched()
+    {
+        var builder = Builder(McpPublishing("weather_lookup", "ticket_search"));
+
+        var tools = await builder.BuildToolsAsync(InjectedSkill(), new SkillAgentOptions());
+
+        tools.Select(t => t.Name).Should().BeEquivalentTo(["weather_lookup", "ticket_search"],
+            "the filter must be inert for every name outside PlanCapabilities.ReservedNames");
+    }
+
+    [Fact]
+    public async Task DeclarationResolvedMcpTool_NamedForReservedPlanCapability_IsExcludedFromChain()
+    {
+        // The managed resolution path is a separate entry point from Injected mode: a ToolDeclaration
+        // satisfied MCP-first brings the third party's names in just the same.
+        var mcp = new Mock<IMcpToolProvider>();
+        mcp.Setup(p => p.GetToolsAsync("third-party", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([
+                AIFunctionFactory.Create(() => "r", PlanCapabilities.Retrieval),
+                AIFunctionFactory.Create(() => "r", "safe_tool")
+            ]);
+
+        var builder = Builder(mcp.Object);
+        var skill = new SkillDefinition
+        {
+            Id = "s",
+            Name = "s",
+            Instructions = "x",
+            ToolDeclarations = [new ToolDeclaration { Name = "third-party" }]
+        };
+
+        var tools = await builder.BuildToolsAsync(skill, new SkillAgentOptions());
+
+        tools.Select(t => t.Name).Should().BeEquivalentTo(["safe_tool"]);
+    }
+
+    [Fact]
+    public async Task MergedChain_UnderEnvelopeGrantingRetrieval_StillExcludesCollidingMcpTool()
+    {
+        // The reachability case in full: the envelope grants rag_retrieval because the plan must be able
+        // to retrieve, and the same string is what the merged-chain allowlist matches on. Without the
+        // filter the third-party tool would be admitted by that very grant.
+        var builder = Builder(McpPublishing(PlanCapabilities.Retrieval, "safe_tool"));
+
+        var merged = await builder.BuildMergedToolsWithSourcesAsync(
+            [InjectedSkill()],
+            new SkillAgentOptions(),
+            allowedTools: [PlanCapabilities.Retrieval, "safe_tool"]);
+
+        merged.Tools.Select(t => t.Name).Should().BeEquivalentTo(["safe_tool"],
+            "granting a plan capability must never silently grant a same-named third-party tool");
+        merged.McpToolNames.Should().NotContain(PlanCapabilities.Retrieval,
+            "a dropped tool must not be attributed as a surviving MCP-sourced tool");
+    }
+
+    [Fact]
+    public void BuildToolsByName_NamedForReservedPlanCapability_IsExcludedFromChain()
+    {
+        // Keyed DI should never legitimately hold such a key — ReservedPlanCapabilityGuard rejects it at
+        // boot — so this deliberately registers one to prove the by-name entry point routes through the
+        // same exit filter rather than around it. A consumer host that registers tools after the harness
+        // composition root returns is exactly the case where the boot guard has already run.
+        var services = new ServiceCollection();
+        services.AddKeyedSingleton<ITool>(PlanCapabilities.LlmCall, (_, _) => new StubTool(PlanCapabilities.LlmCall));
+        services.AddKeyedSingleton<ITool>("safe_tool", (_, _) => new StubTool("safe_tool"));
+
+        var builder = new ToolChainBuilder(
+            NullLogger<ToolChainBuilder>.Instance,
+            services.BuildServiceProvider(),
+            new PassThroughToolConverter(),
+            new Mock<IMcpToolProvider>().Object);
+
+        var tools = builder.BuildToolsByName([PlanCapabilities.LlmCall, "safe_tool"]);
+
+        tools.Select(t => t.Name).Should().BeEquivalentTo(["safe_tool"],
+            "the by-name path must apply the reserved filter, not bypass it");
+    }
+
+    private sealed class StubTool(string name) : ITool
+    {
+        public string Name { get; } = name;
+        public string Description => "stub";
+        public IReadOnlyList<string> SupportedOperations { get; } = ["run"];
+
+        public Task<ToolResult> ExecuteAsync(
+            string operation,
+            IReadOnlyDictionary<string, object?> parameters,
+            CancellationToken cancellationToken = default) => Task.FromResult(ToolResult.Ok("r"));
+    }
+
+    private sealed class PassThroughToolConverter : IToolConverter
+    {
+        public int Priority => 100;
+
+        public bool CanConvert(ITool tool) => true;
+
+        public AITool? Convert(ITool tool, IReadOnlyList<string>? allowedOperations = null) =>
+            AIFunctionFactory.Create(() => "r", tool.Name);
+    }
+}

--- a/src/Content/Tests/Application.Core.Tests/Permissions/EnvelopePermissionRuleProviderTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/Permissions/EnvelopePermissionRuleProviderTests.cs
@@ -8,6 +8,7 @@ using Domain.AI.Permissions;
 using Domain.AI.Skills;
 using Domain.AI.Tools;
 using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
 namespace Application.Core.Tests.Permissions;
@@ -15,12 +16,21 @@ namespace Application.Core.Tests.Permissions;
 /// <summary>
 /// Tests the capability-envelope rule provider — the enforcement half of the per-caller grant. It is inert
 /// off the bundle path (no ambient envelope) and, when an envelope is active, emits bypass-immune Deny for
-/// the tools a bundle declares but is not granted plus an autonomy-ceiling baseline for the granted tools.
-/// The tests set the ambient envelope and overlay directly, exactly how a bundle run will at runtime.
+/// the tools a bundle declares but is not granted, an autonomy-ceiling baseline for the granted tools, and
+/// one closing catch-all Deny that makes the allowlist a closed set. The tests set the ambient envelope and
+/// overlay directly, exactly how a bundle run will at runtime.
 /// </summary>
 public sealed class EnvelopePermissionRuleProviderTests
 {
-    private readonly EnvelopePermissionRuleProvider _provider = new();
+    private readonly EnvelopePermissionRuleProvider _provider =
+        new(NullLogger<EnvelopePermissionRuleProvider>.Instance);
+
+    /// <summary>
+    /// The rules written for a specific tool name, i.e. everything except the closing catch-all. Most
+    /// assertions here are about the per-tool rules; the catch-all has its own dedicated tests.
+    /// </summary>
+    private static IEnumerable<ToolPermissionRule> PerTool(IEnumerable<ToolPermissionRule> rules)
+        => rules.Where(r => r.ToolPattern != "*");
 
     [Fact]
     public void Source_IsCapabilityEnvelope()
@@ -44,7 +54,8 @@ public sealed class EnvelopePermissionRuleProviderTests
         {
             var rules = await _provider.GetRulesAsync("bundle");
 
-            var deny = rules.Should().ContainSingle(r => r.Behavior == PermissionBehaviorType.Deny).Subject;
+            var deny = PerTool(rules).Should()
+                .ContainSingle(r => r.Behavior == PermissionBehaviorType.Deny).Subject;
             deny.ToolPattern.Should().Be("bash", "the declared tool the envelope does not grant is denied by name");
             deny.IsBypassImmune.Should().BeTrue("an out-of-envelope deny cannot be lifted by any auto-approve mode");
             deny.Source.Should().Be(PermissionRuleSource.CapabilityEnvelope);
@@ -60,8 +71,8 @@ public sealed class EnvelopePermissionRuleProviderTests
         {
             var rules = await _provider.GetRulesAsync("bundle");
 
-            rules.Should().NotContain(r => r.Behavior == PermissionBehaviorType.Deny);
-            var baseline = rules.Should().ContainSingle(r => r.IsAuthoritativeBaseline).Subject;
+            PerTool(rules).Should().NotContain(r => r.Behavior == PermissionBehaviorType.Deny);
+            var baseline = PerTool(rules).Should().ContainSingle(r => r.IsAuthoritativeBaseline).Subject;
             baseline.ToolPattern.Should().Be("file_system");
             baseline.Behavior.Should().Be(PermissionBehaviorType.Ask, "Supervised caps autonomy at approval-required");
         }
@@ -77,7 +88,7 @@ public sealed class EnvelopePermissionRuleProviderTests
         {
             var rules = await _provider.GetRulesAsync("bundle");
 
-            rules.Should().ContainSingle(r => r.IsAuthoritativeBaseline)
+            PerTool(rules).Should().ContainSingle(r => r.IsAuthoritativeBaseline)
                 .Which.Behavior.Should().Be(expected);
         }
     }
@@ -93,8 +104,8 @@ public sealed class EnvelopePermissionRuleProviderTests
         {
             var rules = await _provider.GetRulesAsync("bundle");
 
-            rules.Should().OnlyContain(r => r.Behavior == PermissionBehaviorType.Deny && r.IsBypassImmune);
-            rules.Select(r => r.ToolPattern).Should().BeEquivalentTo(["file_system", "bash"]);
+            PerTool(rules).Should().OnlyContain(r => r.Behavior == PermissionBehaviorType.Deny && r.IsBypassImmune);
+            PerTool(rules).Select(r => r.ToolPattern).Should().BeEquivalentTo(["file_system", "bash"]);
         }
     }
 
@@ -109,7 +120,7 @@ public sealed class EnvelopePermissionRuleProviderTests
         {
             var rules = await _provider.GetRulesAsync("bundle");
 
-            rules.Should().NotContain(r => r.Behavior == PermissionBehaviorType.Deny);
+            PerTool(rules).Should().NotContain(r => r.Behavior == PermissionBehaviorType.Deny);
         }
     }
 
@@ -137,7 +148,7 @@ public sealed class EnvelopePermissionRuleProviderTests
         {
             var rules = await _provider.GetRulesAsync("bundle");
 
-            rules.Where(r => r.Behavior == PermissionBehaviorType.Deny).Select(r => r.ToolPattern)
+            PerTool(rules).Where(r => r.Behavior == PermissionBehaviorType.Deny).Select(r => r.ToolPattern)
                 .Should().BeEquivalentTo(["declared_tool"], "only the skill tool outside the envelope is denied");
         }
     }
@@ -154,9 +165,45 @@ public sealed class EnvelopePermissionRuleProviderTests
         {
             var rules = await _provider.GetRulesAsync("some-other-agent");
 
-            rules.Should().NotContain(r => r.Behavior == PermissionBehaviorType.Deny);
-            rules.Should().ContainSingle(r => r.IsAuthoritativeBaseline)
+            PerTool(rules).Should().NotContain(r => r.Behavior == PermissionBehaviorType.Deny);
+            PerTool(rules).Should().ContainSingle(r => r.IsAuthoritativeBaseline)
                 .Which.ToolPattern.Should().Be("file_system");
+        }
+    }
+
+    [Fact]
+    public async Task ActiveEnvelope_EmitsClosingCatchAllDeny()
+    {
+        // The rule that makes the allowlist a CLOSED set. It must be a baseline (so it is arbitrated in
+        // phase 1.5 by specificity rather than swallowing the grants in the phase-1b Deny scan) and sit at
+        // the lowest possible precedence. Without it an ungranted name matches nothing here and falls
+        // through to the host's generic autonomy tier, which ships as "* Allow" on both bundle hosts.
+        using (CapabilityEnvelopeAccessor.Begin(Envelope(tools: ["file_system"])))
+        {
+            var rules = await _provider.GetRulesAsync("bundle");
+
+            var closing = rules.Should().ContainSingle(r => r.ToolPattern == "*").Subject;
+            closing.Behavior.Should().Be(PermissionBehaviorType.Deny);
+            closing.IsAuthoritativeBaseline.Should().BeTrue(
+                "a plain Deny would match in phase 1b and deny the granted tools too");
+            closing.Priority.Should().Be(int.MaxValue, "every other baseline must outrank it on a tie");
+            closing.Source.Should().Be(PermissionRuleSource.CapabilityEnvelope);
+        }
+    }
+
+    [Fact]
+    public async Task WildcardGrant_IsRejected_AndGrantsNothing()
+    {
+        // An operator writing "*" to mean "all tools" must not silently obtain the reserved plan
+        // capabilities. The entry is dropped, so no baseline is emitted for it and only the closing Deny
+        // remains — the run is confined to the grants that were actually spelled out (here, none).
+        using (CapabilityEnvelopeAccessor.Begin(Envelope(tools: ["*", "file_*", "file_system"])))
+        {
+            var rules = await _provider.GetRulesAsync("bundle");
+
+            PerTool(rules).Select(r => r.ToolPattern).Should().BeEquivalentTo(
+                ["file_system"],
+                "only the exact-name grant survives; wildcard entries are rejected");
         }
     }
 

--- a/src/Content/Tests/Infrastructure.AI.RAG.Tests/Orchestration/FullAutonomyIntegrationTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.RAG.Tests/Orchestration/FullAutonomyIntegrationTests.cs
@@ -36,6 +36,11 @@ public sealed class FullAutonomyIntegrationTests
             _mockComplexityClassifier.Object,
             costTracker ?? new RetrievalCostTracker(RagTestData.CreateConfigMonitor()),
             _mockNotifier.Object,
+            // Ungoverned: no envelope armed and enforcement off, so the governor allows.
+            Mock.Of<Application.AI.Common.Interfaces.Governance.IToolInvocationGovernor>(g =>
+                g.AuthorizeAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())
+                    == ValueTask.FromResult(
+                        Application.AI.Common.Interfaces.Governance.ToolInvocationDecision.Allow())),
             new PlanExecutionContext(),
             Mock.Of<ILogger<RetrievalPlanStepExecutor>>());
     }

--- a/src/Content/Tests/Infrastructure.AI.RAG.Tests/Orchestration/ScopedCollectionsChokePointTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.RAG.Tests/Orchestration/ScopedCollectionsChokePointTests.cs
@@ -240,6 +240,11 @@ public sealed class ScopedCollectionsChokePointTests
             Mock.Of<ITaskComplexityClassifier>(),
             new RetrievalCostTracker(RagTestData.CreateConfigMonitor()),
             Mock.Of<IPlanProgressNotifier>(),
+            // Ungoverned: no envelope armed and enforcement off, so the governor allows.
+            Mock.Of<Application.AI.Common.Interfaces.Governance.IToolInvocationGovernor>(g =>
+                g.AuthorizeAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())
+                    == ValueTask.FromResult(
+                        Application.AI.Common.Interfaces.Governance.ToolInvocationDecision.Allow())),
             new PlanExecutionContext(),
             Mock.Of<ILogger<RetrievalPlanStepExecutor>>());
 

--- a/src/Content/Tests/Infrastructure.AI.Tests/Governance/CapabilityEnvelopeResolverTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Governance/CapabilityEnvelopeResolverTests.cs
@@ -5,6 +5,7 @@ using Domain.Common.Config.AI;
 using Domain.Common.Config.AI.BundleExecution;
 using FluentAssertions;
 using Infrastructure.AI.Governance;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Moq;
@@ -20,7 +21,9 @@ namespace Infrastructure.AI.Tests.Governance;
 /// </summary>
 public sealed class CapabilityEnvelopeResolverTests
 {
-    private static CapabilityEnvelopeResolver Resolver(CapabilityEnvelopesConfig envelopes)
+    private static CapabilityEnvelopeResolver Resolver(
+        CapabilityEnvelopesConfig envelopes,
+        ILogger<CapabilityEnvelopeResolver>? logger = null)
     {
         var appConfig = new AppConfig
         {
@@ -32,8 +35,18 @@ public sealed class CapabilityEnvelopeResolverTests
 
         return new CapabilityEnvelopeResolver(
             Mock.Of<IOptionsMonitor<AppConfig>>(o => o.CurrentValue == appConfig),
-            NullLogger<CapabilityEnvelopeResolver>.Instance);
+            logger ?? NullLogger<CapabilityEnvelopeResolver>.Instance);
     }
+
+    /// <summary>
+    /// Counts warnings whose message contains <paramref name="fragment"/>, so an assertion pins the
+    /// specific diagnostic rather than "some warning happened".
+    /// </summary>
+    private static int WarningsContaining(Mock<ILogger<CapabilityEnvelopeResolver>> logger, string fragment) =>
+        logger.Invocations
+            .Count(i => i.Method.Name == nameof(ILogger.Log)
+                        && (LogLevel)i.Arguments[0] == LogLevel.Warning
+                        && i.Arguments[2]?.ToString()?.Contains(fragment, StringComparison.Ordinal) == true);
 
     private static ClaimsPrincipal Principal(string? subject = null, params string[] roles)
     {
@@ -166,6 +179,56 @@ public sealed class CapabilityEnvelopeResolverTests
 
         resolver.Resolve(null).AutonomyCeiling.Should().Be(AutonomyLevel.Restricted,
             "only an exact tier name is accepted; anything else degrades closed rather than silently granting autonomy");
+    }
+
+    [Fact]
+    public void McpServersGrantedButNoTools_Warns_AndStillResolves()
+    {
+        // AllowedMcpServers gates which servers may be CONTACTED; AllowedTools gates which tools may be
+        // INVOKED. Granting servers while naming no tools makes the run fetch and publish every one of
+        // their schemas and then deny every call — a shape that is almost certainly operator error, and
+        // one the shipped onboarding example used to encourage. Warn, never throw: it fails closed, and
+        // an empty tool list is legitimate for a caller meant to have no tool access.
+        var logger = new Mock<ILogger<CapabilityEnvelopeResolver>>();
+        var resolver = Resolver(new CapabilityEnvelopesConfig
+        {
+            Default = new CapabilityEnvelopeConfig
+            {
+                AllowedTools = [],
+                AllowedMcpServers = ["internal-docs"],
+                AutonomyCeiling = "Autonomous"
+            }
+        }, logger.Object);
+
+        var envelope = resolver.Resolve(null);
+
+        envelope.AllowedMcpServers.Should().BeEquivalentTo(["internal-docs"],
+            "the misconfiguration is reported, not silently corrected");
+        WarningsContaining(logger, "internal-docs").Should().Be(1,
+            "the operator must be told which servers were granted with no invocable tools");
+    }
+
+    [Theory]
+    [InlineData(new string[0], new string[0])]                    // grants nothing at all — the fail-closed default
+    [InlineData(new[] { "doc_search" }, new[] { "internal-docs" })] // servers AND their tools named — correct
+    [InlineData(new[] { "file_system" }, new string[0])]           // tools only, no MCP — nothing to warn about
+    public void UsableOrEmptyEnvelope_DoesNotWarn(string[] tools, string[] servers)
+    {
+        var logger = new Mock<ILogger<CapabilityEnvelopeResolver>>();
+        var resolver = Resolver(new CapabilityEnvelopesConfig
+        {
+            Default = new CapabilityEnvelopeConfig
+            {
+                AllowedTools = [.. tools],
+                AllowedMcpServers = [.. servers],
+                AutonomyCeiling = "Autonomous"
+            }
+        }, logger.Object);
+
+        resolver.Resolve(null);
+
+        WarningsContaining(logger, "AllowedMcpServers gates").Should().Be(0,
+            "the warning is scoped to the unusable shape and must not become background noise");
     }
 
     [Fact]

--- a/src/Content/Tests/Infrastructure.AI.Tests/Permissions/EnvelopeEnforcementIntegrationTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Permissions/EnvelopeEnforcementIntegrationTests.cs
@@ -1,4 +1,7 @@
+using Application.AI.Common.Interfaces;
+using Application.AI.Common.Interfaces.Governance;
 using Application.AI.Common.Interfaces.Permissions;
+using Application.AI.Common.Interfaces.Plugins;
 using Application.AI.Common.Services.Bundles;
 using Application.AI.Common.Services.Governance;
 using Application.Core.Permissions;
@@ -6,11 +9,13 @@ using Domain.AI.Agents;
 using Domain.AI.Bundles;
 using Domain.AI.Governance;
 using Domain.AI.Permissions;
+using Domain.AI.Planner;
 using Domain.Common.Config;
 using Domain.Common.Config.AI;
 using Domain.Common.Config.AI.Permissions;
 using FluentAssertions;
 using Infrastructure.AI.Permissions;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Moq;
@@ -20,11 +25,29 @@ namespace Infrastructure.AI.Tests.Permissions;
 
 /// <summary>
 /// End-to-end enforcement of the capability envelope through the <em>real</em>
-/// <see cref="ThreePhasePermissionResolver"/> and glob pattern matcher, driven only by the real
-/// <see cref="EnvelopePermissionRuleProvider"/>. Proves the phase interaction the envelope relies on: an
-/// out-of-envelope tool resolves to a bypass-immune Deny (phase 1b) that wins over the autonomy-ceiling
-/// baseline (phase 1.5), and a granted tool resolves to exactly the ceiling behavior.
+/// <see cref="ThreePhasePermissionResolver"/>, the real glob matcher, and the <em>full production set of
+/// rule providers</em> — envelope, autonomy tier, config, and plugin — wired exactly as
+/// <c>Application.Core</c> and <c>Infrastructure.AI</c> register them.
 /// </summary>
+/// <remarks>
+/// <para>
+/// <strong>Why the whole provider set and not just the envelope provider.</strong> These tests previously
+/// drove the resolver with the envelope provider alone. That rule set does not exist in any deployment,
+/// and it hid a real hole: with the other providers present, a tool the envelope never granted matched no
+/// envelope rule, fell through to the autonomy tier's catch-all, and — under the configuration both
+/// bundle-capable hosts actually ship (<c>DefaultBehavior: Allow</c>, <c>DefaultAutonomyLevel:
+/// Autonomous</c>) — resolved to <b>Allow</b>. The envelope was documented fail-closed while behaving
+/// fail-open. A confinement test is only meaningful against the rule set production assembles, so the
+/// configuration here is copied from the shipped hosts rather than chosen to make assertions pass.
+/// </para>
+/// <para>
+/// <see cref="TierPolicyConfig"/> mirrors <c>Presentation.FoundryHost</c> (which defines
+/// <c>TierPolicies</c> with <c>Autonomous → Allow</c>) and <see cref="FlatConfig"/> mirrors
+/// <c>Presentation.BundleApi</c> (which defines none, so the flat <c>DefaultBehavior</c> applies). Both
+/// resolve the tier catch-all to Allow by different routes, so the confinement assertions run against
+/// both.
+/// </para>
+/// </remarks>
 public sealed class EnvelopeEnforcementIntegrationTests
 {
     private const string AgentId = "bundle";
@@ -32,52 +55,153 @@ public sealed class EnvelopeEnforcementIntegrationTests
     private readonly Mock<ISafetyGateRegistry> _safetyGates = new();
     private readonly Mock<IDenialTracker> _denialTracker = new();
     private readonly GlobPatternMatcher _matcher = new();
-    private readonly IOptionsMonitor<AppConfig> _options;
 
     public EnvelopeEnforcementIntegrationTests()
     {
-        _options = Mock.Of<IOptionsMonitor<AppConfig>>(o => o.CurrentValue == new AppConfig
-        {
-            AI = new AIConfig { Permissions = new PermissionsConfig { DenialRateLimitThreshold = 5 } }
-        });
         _safetyGates
             .Setup(r => r.CheckSafetyGate(It.IsAny<string>(), It.IsAny<IReadOnlyDictionary<string, object?>?>()))
             .Returns((SafetyGate?)null);
     }
 
-    private ThreePhasePermissionResolver Resolver() => new(
-        [new EnvelopePermissionRuleProvider()],
-        _safetyGates.Object,
-        _matcher,
-        _denialTracker.Object,
-        _options,
-        NullLogger<ThreePhasePermissionResolver>.Instance);
-
-    [Fact]
-    public async Task OutOfEnvelopeTool_ResolvesToBypassImmuneDeny()
+    /// <summary>
+    /// The permission configuration <c>Presentation.BundleApi</c> ships: a flat Allow default and an
+    /// Autonomous default tier, with no per-tier policy block.
+    /// </summary>
+    private static PermissionsConfig FlatConfig() => new()
     {
-        var overlay = Overlay("file_system", "bash");
-        using (EphemeralAgentOverlayAccessor.Begin(overlay))
-        using (CapabilityEnvelopeAccessor.Begin(Envelope(["file_system"], AutonomyLevel.Autonomous)))
-        {
-            var decision = await Resolver().ResolvePermissionAsync(AgentId, "bash");
+        DefaultBehavior = "Allow",
+        DefaultAutonomyLevel = "Autonomous",
+        DenialRateLimitThreshold = 5
+    };
 
-            decision.Behavior.Should().Be(PermissionBehaviorType.Deny);
-            decision.MatchedRule!.IsBypassImmune.Should().BeTrue();
-            decision.MatchedRule.Source.Should().Be(PermissionRuleSource.CapabilityEnvelope);
-        }
+    /// <summary>
+    /// The permission configuration <c>Presentation.FoundryHost</c> ships: the same flat defaults plus a
+    /// <c>TierPolicies</c> block whose Autonomous tier also defaults to Allow.
+    /// </summary>
+    private static PermissionsConfig TierPolicyConfig()
+    {
+        var config = FlatConfig();
+        config.TierPolicies = new Dictionary<string, AutonomyTierPolicyConfig>
+        {
+            ["Restricted"] = new() { DefaultBehavior = "Ask" },
+            ["Supervised"] = new() { DefaultBehavior = "Ask" },
+            ["Autonomous"] = new() { DefaultBehavior = "Allow" }
+        };
+        return config;
     }
 
-    [Fact]
-    public async Task GrantedTool_AutonomousCeiling_ResolvesToAllow()
+    public static TheoryData<bool> ShippedHostConfigurations => new() { false, true };
+
+    /// <summary>
+    /// Builds the resolver over the full production provider list, in the order
+    /// <c>Application.Core.DependencyInjection</c> and
+    /// <c>Infrastructure.AI.DependencyInjection.Governance</c> register them.
+    /// </summary>
+    /// <param name="permissions">The permission configuration the host is running under.</param>
+    private ThreePhasePermissionResolver Resolver(PermissionsConfig permissions)
     {
+        var appConfig = new AppConfig { AI = new AIConfig { Permissions = permissions } };
+        var options = Mock.Of<IOptionsMonitor<AppConfig>>(o => o.CurrentValue == appConfig);
+
+        // Agent ids that are not SubagentType names fall to DefaultAutonomyLevel, so the tier resolver is
+        // never consulted for "bundle" — it is present because production wires it.
+        var tierResolver = new Mock<IAutonomyTierResolver>();
+        tierResolver.Setup(r => r.Resolve(It.IsAny<SubagentType>())).Returns(AutonomyLevel.Autonomous);
+
+        var pluginRegistry = new Mock<IPluginRegistry>();
+        pluginRegistry.Setup(r => r.GetLoadedPlugins()).Returns([]);
+
+        var skillRegistry = new Mock<ISkillMetadataRegistry>();
+        skillRegistry.Setup(r => r.GetAll()).Returns([]);
+
+        IPermissionRuleProvider[] providers =
+        [
+            new AutonomyTierRuleProvider(
+                tierResolver.Object, options, NullLogger<AutonomyTierRuleProvider>.Instance),
+            new PluginPermissionRuleProvider(
+                pluginRegistry.Object, skillRegistry.Object, new ServiceCollection().BuildServiceProvider(),
+                NullLogger<PluginPermissionRuleProvider>.Instance),
+            new EnvelopePermissionRuleProvider(NullLogger<EnvelopePermissionRuleProvider>.Instance),
+            new ConfigBasedRuleProvider(options)
+        ];
+
+        return new ThreePhasePermissionResolver(
+            providers,
+            _safetyGates.Object,
+            _matcher,
+            _denialTracker.Object,
+            options,
+            NullLogger<ThreePhasePermissionResolver>.Instance);
+    }
+
+    [Theory]
+    [MemberData(nameof(ShippedHostConfigurations))]
+    public async Task UndeclaredOutOfEnvelopeTool_IsDenied(bool useTierPolicies)
+    {
+        // THE REGRESSION TEST. A tool the bundle never declared (so no per-name Deny is emitted) and the
+        // envelope never granted must be DENIED, not merely left to a default. Before the closing
+        // catch-all existed this resolved to Allow via the tier's "*" rule under exactly this config.
         var overlay = Overlay("file_system");
         using (EphemeralAgentOverlayAccessor.Begin(overlay))
         using (CapabilityEnvelopeAccessor.Begin(Envelope(["file_system"], AutonomyLevel.Autonomous)))
         {
-            var decision = await Resolver().ResolvePermissionAsync(AgentId, "file_system");
+            var decision = await Resolve(useTierPolicies, "surprise_tool");
+
+            decision.Behavior.Should().Be(PermissionBehaviorType.Deny,
+                "the envelope is an allowlist — anything it did not grant is outside the grant");
+            decision.Source.Should().Be(PermissionRuleSource.CapabilityEnvelope,
+                "the denial must come from the envelope's closing rule, not from a permissive tier default");
+        }
+    }
+
+    [Theory]
+    [InlineData(PlanCapabilities.LlmCall)]
+    [InlineData(PlanCapabilities.Retrieval)]
+    public async Task UngrantedReservedPlanCapability_IsDenied(string capability)
+    {
+        // The two capabilities this whole confinement exists to gate. An envelope that grants a tool but
+        // not inference/retrieval must not buy the caller unbounded tokens or corpus access through the
+        // host's permissive tier default.
+        var overlay = Overlay("file_system");
+        using (EphemeralAgentOverlayAccessor.Begin(overlay))
+        using (CapabilityEnvelopeAccessor.Begin(Envelope(["file_system"], AutonomyLevel.Autonomous)))
+        {
+            var decision = await Resolve(useTierPolicies: false, capability);
+
+            decision.Behavior.Should().Be(PermissionBehaviorType.Deny);
+            decision.Source.Should().Be(PermissionRuleSource.CapabilityEnvelope);
+        }
+    }
+
+    [Theory]
+    [InlineData(PlanCapabilities.LlmCall)]
+    [InlineData(PlanCapabilities.Retrieval)]
+    public async Task WildcardGrant_DoesNotConferReservedPlanCapabilities(string capability)
+    {
+        // An operator writing "*" meaning "all tools" must not silently obtain inference and retrieval.
+        // The entry is rejected, so the envelope still grants nothing and the closing rule denies.
+        using (CapabilityEnvelopeAccessor.Begin(Envelope(["*"], AutonomyLevel.Autonomous)))
+        {
+            var decision = await Resolve(useTierPolicies: false, capability);
+
+            decision.Behavior.Should().Be(PermissionBehaviorType.Deny);
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(ShippedHostConfigurations))]
+    public async Task GrantedTool_AutonomousCeiling_ResolvesToAllow(bool useTierPolicies)
+    {
+        // The other half of the guarantee: closing the envelope must not break what it DID grant. The
+        // per-name baseline is more specific than the closing "*" Deny and therefore outranks it.
+        var overlay = Overlay("file_system");
+        using (EphemeralAgentOverlayAccessor.Begin(overlay))
+        using (CapabilityEnvelopeAccessor.Begin(Envelope(["file_system"], AutonomyLevel.Autonomous)))
+        {
+            var decision = await Resolve(useTierPolicies, "file_system");
 
             decision.Behavior.Should().Be(PermissionBehaviorType.Allow);
+            decision.Source.Should().Be(PermissionRuleSource.CapabilityEnvelope);
         }
     }
 
@@ -88,35 +212,60 @@ public sealed class EnvelopeEnforcementIntegrationTests
         using (EphemeralAgentOverlayAccessor.Begin(overlay))
         using (CapabilityEnvelopeAccessor.Begin(Envelope(["file_system"], AutonomyLevel.Supervised)))
         {
-            var decision = await Resolver().ResolvePermissionAsync(AgentId, "file_system");
+            var decision = await Resolve(useTierPolicies: false, "file_system");
 
-            decision.Behavior.Should().Be(PermissionBehaviorType.Ask);
+            decision.Behavior.Should().Be(PermissionBehaviorType.Ask,
+                "the ceiling still caps a granted tool — the closing rule must not override it either way");
         }
     }
 
     [Fact]
-    public async Task UndeclaredOutOfEnvelopeTool_FailsClosedToAsk()
+    public async Task OutOfEnvelopeDeclaredTool_ResolvesToBypassImmuneDeny()
     {
-        // A tool the bundle never declared (so no explicit deny is emitted) and the envelope never granted
-        // must still not resolve to Allow: with no matching allow/baseline the resolver defaults to Ask,
-        // which the fail-closed governor turns into a denial.
-        var overlay = Overlay("file_system");
+        // A DECLARED but ungranted tool is denied by its own bypass-immune rule rather than by the
+        // closing catch-all, so the denial stays attributable and cannot be lifted by auto-approve modes.
+        var overlay = Overlay("file_system", "bash");
         using (EphemeralAgentOverlayAccessor.Begin(overlay))
         using (CapabilityEnvelopeAccessor.Begin(Envelope(["file_system"], AutonomyLevel.Autonomous)))
         {
-            var decision = await Resolver().ResolvePermissionAsync(AgentId, "surprise_tool");
+            var decision = await Resolve(useTierPolicies: false, "bash");
 
-            decision.Behavior.Should().Be(PermissionBehaviorType.Ask);
+            decision.Behavior.Should().Be(PermissionBehaviorType.Deny);
+            decision.MatchedRule!.IsBypassImmune.Should().BeTrue();
+            decision.MatchedRule.ToolPattern.Should().Be("bash", "the named rule wins over the catch-all");
+            decision.MatchedRule.Source.Should().Be(PermissionRuleSource.CapabilityEnvelope);
         }
     }
 
-    [Fact]
-    public async Task NoEnvelope_ProviderContributesNothing_DefaultsToAsk()
+    [Theory]
+    [MemberData(nameof(ShippedHostConfigurations))]
+    public async Task NoEnvelope_InProcessPath_IsUnchanged(bool useTierPolicies)
     {
-        var decision = await Resolver().ResolvePermissionAsync(AgentId, "anything");
+        // No ambient envelope: the provider contributes nothing, so resolution is governed entirely by
+        // the host's own tier configuration exactly as it was before the envelope existed. This is the
+        // guarantee that the closing Deny is scoped to bundle runs and cannot deny in-process callers.
+        var decision = await Resolve(useTierPolicies, "anything_at_all");
 
-        decision.Behavior.Should().Be(PermissionBehaviorType.Ask, "with no rules at all the resolver defaults to Ask");
+        decision.Behavior.Should().Be(PermissionBehaviorType.Allow,
+            "an Allow default tier still governs the non-bundle path");
+        decision.Source.Should().Be(PermissionRuleSource.AutonomyTier,
+            "no capability-envelope rule may participate off the bundle path");
     }
+
+    [Fact]
+    public async Task NoEnvelope_RestrictiveHost_StillAsks()
+    {
+        // The same pass-through property under a host that has NOT opted into a permissive default:
+        // the envelope provider neither tightens nor loosens the in-process path.
+        var restrictive = new PermissionsConfig { DenialRateLimitThreshold = 5 };
+        var decision = await Resolver(restrictive).ResolvePermissionAsync(AgentId, "anything_at_all");
+
+        decision.Behavior.Should().Be(PermissionBehaviorType.Ask);
+    }
+
+    private async Task<PermissionDecision> Resolve(bool useTierPolicies, string toolName)
+        => await Resolver(useTierPolicies ? TierPolicyConfig() : FlatConfig())
+            .ResolvePermissionAsync(AgentId, toolName);
 
     private static EphemeralAgentOverlay Overlay(params string[] declaredTools) => new()
     {

--- a/src/Content/Tests/Infrastructure.AI.Tests/Permissions/EnvelopeEnforcementIntegrationTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Permissions/EnvelopeEnforcementIntegrationTests.cs
@@ -10,9 +10,11 @@ using Domain.AI.Bundles;
 using Domain.AI.Governance;
 using Domain.AI.Permissions;
 using Domain.AI.Planner;
+using Domain.AI.Skills;
 using Domain.Common.Config;
 using Domain.Common.Config.AI;
 using Domain.Common.Config.AI.Permissions;
+using Domain.Common.Config.AI.Plugins;
 using FluentAssertions;
 using Infrastructure.AI.Permissions;
 using Microsoft.Extensions.DependencyInjection;
@@ -97,8 +99,21 @@ public sealed class EnvelopeEnforcementIntegrationTests
     /// <c>Application.Core.DependencyInjection</c> and
     /// <c>Infrastructure.AI.DependencyInjection.Governance</c> register them.
     /// </summary>
+    /// <remarks>
+    /// <strong>The plugin registry is a real input, not scenery.</strong> Most cases here run with no
+    /// plugins loaded, which is the shipped in-repo configuration — but "no plugins" is precisely the
+    /// state in which the plugin provider contributes nothing and cannot contradict the envelope, so a
+    /// suite that only ever passes an empty registry proves less about confinement than it appears to.
+    /// <see cref="AutonomousPluginTool_OutsideTheEnvelope_IsDenied"/> supplies a loaded plugin so the
+    /// second authoritative-baseline emitter is actually exercised.
+    /// </remarks>
     /// <param name="permissions">The permission configuration the host is running under.</param>
-    private ThreePhasePermissionResolver Resolver(PermissionsConfig permissions)
+    /// <param name="plugins">Loaded plugins the plugin provider should see. Empty unless a case needs one.</param>
+    /// <param name="skills">Skill metadata the plugin provider reads tool names from.</param>
+    private ThreePhasePermissionResolver Resolver(
+        PermissionsConfig permissions,
+        IReadOnlyList<LoadedPlugin>? plugins = null,
+        IReadOnlyList<SkillDefinition>? skills = null)
     {
         var appConfig = new AppConfig { AI = new AIConfig { Permissions = permissions } };
         var options = Mock.Of<IOptionsMonitor<AppConfig>>(o => o.CurrentValue == appConfig);
@@ -109,10 +124,10 @@ public sealed class EnvelopeEnforcementIntegrationTests
         tierResolver.Setup(r => r.Resolve(It.IsAny<SubagentType>())).Returns(AutonomyLevel.Autonomous);
 
         var pluginRegistry = new Mock<IPluginRegistry>();
-        pluginRegistry.Setup(r => r.GetLoadedPlugins()).Returns([]);
+        pluginRegistry.Setup(r => r.GetLoadedPlugins()).Returns(plugins ?? []);
 
         var skillRegistry = new Mock<ISkillMetadataRegistry>();
-        skillRegistry.Setup(r => r.GetAll()).Returns([]);
+        skillRegistry.Setup(r => r.GetAll()).Returns(skills ?? []);
 
         IPermissionRuleProvider[] providers =
         [
@@ -263,9 +278,117 @@ public sealed class EnvelopeEnforcementIntegrationTests
         decision.Behavior.Should().Be(PermissionBehaviorType.Ask);
     }
 
+    [Theory]
+    [MemberData(nameof(ShippedHostConfigurations))]
+    public async Task AutonomousPluginTool_OutsideTheEnvelope_IsDenied(bool useTierPolicies)
+    {
+        // THE SECOND-EMITTER REGRESSION TEST. PluginPermissionRuleProvider is the only other authoritative
+        // baseline emitter, and for a plugin declaring AutonomyLevel: Autonomous it emits an EXACT-NAME
+        // baseline Allow per declared tool. The envelope's closing rule is "*", which ranks lowest on
+        // specificity — so before the grant-boundary tier existed the plugin's Allow won phase 1.5
+        // outright and the bundle could invoke a tool the caller was never granted.
+        //
+        // The bundle's overlay declares only file_system, so EnumerateDeclaredTools never sees
+        // k8sgpt_analyze and phase 1b emits no bypass-immune Deny for it. The resolver is the sole
+        // enforcement point for tool names — ToolInvocationGovernor has no independent GrantsTool check —
+        // so if this resolves to anything but Deny, the tool runs.
+        var plugin = AutonomousPlugin("k8s-ops");
+        var skill = PluginSkill("k8s-ops", "k8sgpt_analyze");
+
+        var overlay = Overlay("file_system");
+        using (EphemeralAgentOverlayAccessor.Begin(overlay))
+        using (CapabilityEnvelopeAccessor.Begin(Envelope(["file_system"], AutonomyLevel.Autonomous)))
+        {
+            var resolver = Resolver(
+                useTierPolicies ? TierPolicyConfig() : FlatConfig(), [plugin], [skill]);
+
+            var decision = await resolver.ResolvePermissionAsync(AgentId, "k8sgpt_analyze");
+
+            decision.Behavior.Should().Be(PermissionBehaviorType.Deny,
+                "a plugin's own autonomy declaration is a default within a grant, not a grant — it must " +
+                "never widen the envelope to a tool the host did not authorise for this caller");
+            decision.Source.Should().Be(PermissionRuleSource.CapabilityEnvelope,
+                "the denial must be attributable to the envelope's closing rule");
+        }
+    }
+
+    [Fact]
+    public async Task AutonomousPluginTool_InsideTheEnvelope_StillResolvesToAllow()
+    {
+        // The confinement must not degrade into "plugins are ignored". A plugin tool the envelope DOES
+        // grant still auto-approves: the boundary caps authority, it does not veto everything outside its
+        // own rule set. Without this, a passing Deny above would be indistinguishable from the boundary
+        // simply swallowing all plugin baselines.
+        var plugin = AutonomousPlugin("k8s-ops");
+        var skill = PluginSkill("k8s-ops", "k8sgpt_analyze");
+
+        var overlay = Overlay("k8sgpt_analyze");
+        using (EphemeralAgentOverlayAccessor.Begin(overlay))
+        using (CapabilityEnvelopeAccessor.Begin(Envelope(["k8sgpt_analyze"], AutonomyLevel.Autonomous)))
+        {
+            var resolver = Resolver(FlatConfig(), [plugin], [skill]);
+
+            var decision = await resolver.ResolvePermissionAsync(AgentId, "k8sgpt_analyze");
+
+            decision.Behavior.Should().Be(PermissionBehaviorType.Allow);
+        }
+    }
+
+    [Fact]
+    public async Task RestrictivePluginBaseline_StillTightensAGrantedTool()
+    {
+        // The boundary is a CEILING, not a floor: it stops other providers widening past it but must not
+        // stop them tightening within it. A plugin marked Restricted (baseline Ask) on a tool the envelope
+        // granted with an Autonomous ceiling still forces approval. If the tier had been arbitrated as a
+        // simple "boundary wins outright", this would wrongly resolve to Allow and the envelope's
+        // documented "can only tighten, never loosen" ceiling semantics would be false.
+        var plugin = Plugin("k8s-ops", autonomyLevel: "Restricted");
+        var skill = PluginSkill("k8s-ops", "k8sgpt_analyze");
+
+        var overlay = Overlay("k8sgpt_analyze");
+        using (EphemeralAgentOverlayAccessor.Begin(overlay))
+        using (CapabilityEnvelopeAccessor.Begin(Envelope(["k8sgpt_analyze"], AutonomyLevel.Autonomous)))
+        {
+            var resolver = Resolver(FlatConfig(), [plugin], [skill]);
+
+            var decision = await resolver.ResolvePermissionAsync(AgentId, "k8sgpt_analyze");
+
+            decision.Behavior.Should().Be(PermissionBehaviorType.Ask,
+                "a stricter peer baseline tightens within the envelope; only widening is refused");
+        }
+    }
+
     private async Task<PermissionDecision> Resolve(bool useTierPolicies, string toolName)
         => await Resolver(useTierPolicies ? TierPolicyConfig() : FlatConfig())
             .ResolvePermissionAsync(AgentId, toolName);
+
+    private static LoadedPlugin AutonomousPlugin(string name) => Plugin(name, "Autonomous");
+
+    /// <summary>
+    /// A loaded plugin whose declaration sets <paramref name="autonomyLevel"/> — the manifest shape a
+    /// consumer host writes, which no in-repo manifest currently uses.
+    /// </summary>
+    private static LoadedPlugin Plugin(string name, string autonomyLevel) => new(
+        Name: name,
+        Version: "1.0.0",
+        LocalPath: $"/plugins/{name}",
+        Manifest: new PluginManifest { Name = name, Version = "1.0.0" },
+        Status: PluginLoadStatus.Loaded,
+        SkillPaths: [],
+        McpServerNames: [],
+        Declaration: new PluginDeclaration { Name = name, AutonomyLevel = autonomyLevel });
+
+    /// <summary>
+    /// A skill attributed to <paramref name="pluginName"/> declaring <paramref name="toolName"/>. The
+    /// plugin provider reads these to scope its autonomy baseline to real tool names.
+    /// </summary>
+    private static SkillDefinition PluginSkill(string pluginName, string toolName) => new()
+    {
+        Id = $"{pluginName}.skill",
+        Name = $"{pluginName} skill",
+        PluginSource = pluginName,
+        AllowedTools = [toolName]
+    };
 
     private static EphemeralAgentOverlay Overlay(params string[] declaredTools) => new()
     {

--- a/src/Content/Tests/Infrastructure.AI.Tests/Permissions/GlobPatternMatcherTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Permissions/GlobPatternMatcherTests.cs
@@ -67,4 +67,40 @@ public sealed class GlobPatternMatcherTests
     {
         _matcher.IsMatch("file_system", "").Should().BeFalse();
     }
+
+    [Fact]
+    public void Specificity_CatchAll_RanksLowest()
+    {
+        _matcher.Specificity("*").Should().Be(0);
+        _matcher.Specificity("").Should().Be(0, "an empty pattern matches nothing and can never be selected");
+    }
+
+    [Theory]
+    [InlineData("file_system", "file_*")]
+    [InlineData("file_system", "*")]
+    [InlineData("git:push", "git:*")]
+    [InlineData("git:*", "*")]
+    public void Specificity_NarrowerPattern_OutranksBroaderOne(string narrow, string broad)
+    {
+        _matcher.Specificity(narrow).Should().BeGreaterThan(_matcher.Specificity(broad));
+    }
+
+    [Theory]
+    [InlineData("file_system")]
+    [InlineData("a")]
+    [InlineData("query_knowledge_graph")]
+    public void Specificity_ExactPattern_OutranksEveryWildcardThatAlsoMatchesTheValue(string value)
+    {
+        // The interface contract the permission resolver depends on: whatever wildcard also matches this
+        // value, the pattern that names it exactly must rank above it — otherwise a catch-all rule could
+        // override a rule written for one specific tool.
+        var exact = _matcher.Specificity(value);
+
+        for (var length = 0; length < value.Length; length++)
+        {
+            var wildcard = value[..length] + "*";
+            _matcher.IsMatch(wildcard, value).Should().BeTrue("the generated pattern must actually match");
+            exact.Should().BeGreaterThan(_matcher.Specificity(wildcard));
+        }
+    }
 }

--- a/src/Content/Tests/Infrastructure.AI.Tests/Permissions/ThreePhasePermissionResolverAutonomyTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Permissions/ThreePhasePermissionResolverAutonomyTests.cs
@@ -200,6 +200,106 @@ public sealed class ThreePhasePermissionResolverAutonomyTests
             "the restrictive baseline must win over the permissive one irrespective of order");
     }
 
+    [Theory]
+    [InlineData(false)] // permissive exact-name rule listed first
+    [InlineData(true)]  // restrictive wildcard rule listed first
+    public async Task PluginBaselines_ExactNameAllow_OutranksWildcardAsk(bool wildcardFirst)
+    {
+        // PINS A DELIBERATE BEHAVIOUR CHANGE. Specificity now outranks restrictiveness, which only shows
+        // up when two baselines differ in BOTH — and the equal-specificity case in
+        // AuthoritativeBaseline_MostRestrictiveWins_RegardlessOfOrder cannot see it.
+        //
+        // Two real plugins, both Default-tier, colliding on one tool name:
+        //   Plugin A  allowed-tools: ["deploy_*"]     AutonomyLevel: Restricted  -> ("deploy_*",     Ask)
+        //   Plugin B  allowed-tools: ["deploy_widget"] AutonomyLevel: Autonomous -> ("deploy_widget", Allow)
+        //
+        // Before specificity ranking this resolved to Ask; it now resolves to Allow. An operator's
+        // restrictive wildcard plugin therefore no longer constrains a permissive plugin that names the
+        // tool more precisely, and nothing rejects wildcards in a skill's allowed-tools. That is the price
+        // of letting a provider close its own allowlist with a catch-all, and it is asserted here so the
+        // trade-off is a decision rather than an accident. Operators who need a wildcard restriction to be
+        // unconditional use DeniedTools (bypass-immune Deny), which wins in phase 1b regardless.
+        var wildcardAsk = new ToolPermissionRule("deploy_*", null, PermissionBehaviorType.Ask,
+            PermissionRuleSource.PluginDeclaration, 5, IsAuthoritativeBaseline: true);
+        var exactAllow = new ToolPermissionRule("deploy_widget", null, PermissionBehaviorType.Allow,
+            PermissionRuleSource.PluginDeclaration, 5, IsAuthoritativeBaseline: true);
+
+        var provider = wildcardFirst
+            ? BuildProvider(wildcardAsk, exactAllow)
+            : BuildProvider(exactAllow, wildcardAsk);
+
+        var resolver = CreateResolver(provider.Object);
+
+        var named = await resolver.ResolvePermissionAsync("agent", "deploy_widget");
+        named.Behavior.Should().Be(PermissionBehaviorType.Allow,
+            "the exact name is a decision about that tool; the wildcard is only a default");
+
+        // The wildcard still governs every name the exact rule does not cover.
+        var other = await resolver.ResolvePermissionAsync("agent", "deploy_database");
+        other.Behavior.Should().Be(PermissionBehaviorType.Ask,
+            "the restrictive wildcard still governs names no more-specific baseline claims");
+    }
+
+    [Theory]
+    [InlineData(false)] // boundary rules listed first
+    [InlineData(true)]  // plugin rule listed first
+    public async Task GrantBoundaryCatchAll_OutranksAPeerExactNameBaselineAllow(bool pluginFirst)
+    {
+        // The arbitration unit test behind the envelope-confinement hole. A Default-tier baseline naming a
+        // tool EXACTLY is more specific than a GrantBoundary catch-all "*", so specificity alone hands it
+        // the win. The tier is what stops that: a boundary caps the outcome regardless of how specifically
+        // a peer names the tool.
+        var boundaryGrant = new ToolPermissionRule("file_system", null, PermissionBehaviorType.Allow,
+            PermissionRuleSource.CapabilityEnvelope, 5,
+            IsAuthoritativeBaseline: true, BaselineTier: PermissionBaselineTier.GrantBoundary);
+        var boundaryClose = new ToolPermissionRule("*", null, PermissionBehaviorType.Deny,
+            PermissionRuleSource.CapabilityEnvelope, int.MaxValue,
+            IsAuthoritativeBaseline: true, BaselineTier: PermissionBaselineTier.GrantBoundary);
+        var pluginAllow = new ToolPermissionRule("k8sgpt_analyze", null, PermissionBehaviorType.Allow,
+            PermissionRuleSource.PluginDeclaration, 5, IsAuthoritativeBaseline: true);
+
+        var provider = pluginFirst
+            ? BuildProvider(pluginAllow, boundaryGrant, boundaryClose)
+            : BuildProvider(boundaryGrant, boundaryClose, pluginAllow);
+
+        var resolver = CreateResolver(provider.Object);
+
+        var outside = await resolver.ResolvePermissionAsync("agent", "k8sgpt_analyze");
+        outside.Behavior.Should().Be(PermissionBehaviorType.Deny,
+            "no Default-tier baseline may resolve past a grant boundary, however specific its pattern");
+        outside.MatchedRule!.Source.Should().Be(PermissionRuleSource.CapabilityEnvelope);
+
+        var inside = await resolver.ResolvePermissionAsync("agent", "file_system");
+        inside.Behavior.Should().Be(PermissionBehaviorType.Allow,
+            "boundary rules still arbitrate among themselves by specificity, so the grant survives");
+    }
+
+    [Fact]
+    public async Task GrantBoundaryAllow_IsStillTightenedByAStricterPeerBaseline()
+    {
+        // A boundary is a ceiling on authority, not a floor. A Default-tier baseline that is STRICTER than
+        // the boundary must still win — otherwise marking something a boundary would silently override
+        // every restriction other providers place inside it, and the envelope's documented "can only
+        // tighten, never loosen" ceiling would be false.
+        var provider = BuildProvider(
+            new ToolPermissionRule("deploy_widget", null, PermissionBehaviorType.Allow,
+                PermissionRuleSource.CapabilityEnvelope, 5,
+                IsAuthoritativeBaseline: true, BaselineTier: PermissionBaselineTier.GrantBoundary),
+            new ToolPermissionRule("*", null, PermissionBehaviorType.Deny,
+                PermissionRuleSource.CapabilityEnvelope, int.MaxValue,
+                IsAuthoritativeBaseline: true, BaselineTier: PermissionBaselineTier.GrantBoundary),
+            new ToolPermissionRule("deploy_widget", null, PermissionBehaviorType.Ask,
+                PermissionRuleSource.PluginDeclaration, 5, IsAuthoritativeBaseline: true));
+
+        var resolver = CreateResolver(provider.Object);
+
+        var decision = await resolver.ResolvePermissionAsync("agent", "deploy_widget");
+
+        decision.Behavior.Should().Be(PermissionBehaviorType.Ask);
+        decision.MatchedRule!.Source.Should().Be(PermissionRuleSource.PluginDeclaration,
+            "the stricter peer governs, and the decision stays attributable to it");
+    }
+
     [Fact]
     public async Task CatchAllBaselineDeny_LosesToSpecificBaselineGrant_ButCatchesEverythingElse()
     {

--- a/src/Content/Tests/Infrastructure.AI.Tests/Permissions/ThreePhasePermissionResolverAutonomyTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Permissions/ThreePhasePermissionResolverAutonomyTests.cs
@@ -201,6 +201,75 @@ public sealed class ThreePhasePermissionResolverAutonomyTests
     }
 
     [Fact]
+    public async Task CatchAllBaselineDeny_LosesToSpecificBaselineGrant_ButCatchesEverythingElse()
+    {
+        // The arbitration that lets a provider close its own allowlist: per-name baseline grants paired
+        // with one catch-all baseline Deny. Specificity decides — the exact name is a decision about that
+        // tool, the "*" is only the fallback — so the grant survives and every other name is denied.
+        // Were restrictiveness weighed first, the Deny would swallow the grant and deny everything.
+        var provider = BuildProvider(
+            new ToolPermissionRule("file_system", null, PermissionBehaviorType.Allow,
+                PermissionRuleSource.CapabilityEnvelope, 5, IsAuthoritativeBaseline: true),
+            new ToolPermissionRule("*", null, PermissionBehaviorType.Deny,
+                PermissionRuleSource.CapabilityEnvelope, int.MaxValue, IsAuthoritativeBaseline: true));
+
+        var resolver = CreateResolver(provider.Object);
+
+        var granted = await resolver.ResolvePermissionAsync("agent", "file_system");
+        granted.Behavior.Should().Be(PermissionBehaviorType.Allow,
+            "the exact-name baseline is more specific than the catch-all");
+
+        var ungranted = await resolver.ResolvePermissionAsync("agent", "anything_else");
+        ungranted.Behavior.Should().Be(PermissionBehaviorType.Deny,
+            "a name no baseline covers falls through to the catch-all");
+    }
+
+    [Fact]
+    public async Task CatchAllBaselineDeny_IsNotEvaluatedInThePhase1DenyScan()
+    {
+        // A catch-all baseline Deny must not pre-empt the baseline phase by matching in phase 1b — that
+        // scan is order-driven, so it would deny the granted tool before specificity arbitration ran.
+        // Ordinary (non-baseline) Deny rules are unaffected and still win there.
+        var provider = BuildProvider(
+            new ToolPermissionRule("*", null, PermissionBehaviorType.Deny,
+                PermissionRuleSource.CapabilityEnvelope, int.MaxValue, IsAuthoritativeBaseline: true),
+            new ToolPermissionRule("file_system", null, PermissionBehaviorType.Allow,
+                PermissionRuleSource.CapabilityEnvelope, 5, IsAuthoritativeBaseline: true),
+            new ToolPermissionRule("bash", null, PermissionBehaviorType.Deny,
+                PermissionRuleSource.AgentManifest, 1, IsBypassImmune: true));
+
+        var resolver = CreateResolver(provider.Object);
+
+        (await resolver.ResolvePermissionAsync("agent", "file_system")).Behavior
+            .Should().Be(PermissionBehaviorType.Allow);
+
+        var bash = await resolver.ResolvePermissionAsync("agent", "bash");
+        bash.Behavior.Should().Be(PermissionBehaviorType.Deny);
+        bash.MatchedRule!.Source.Should().Be(PermissionRuleSource.AgentManifest,
+            "an ordinary Deny still resolves in phase 1b, attributed to its own rule");
+    }
+
+    [Fact]
+    public async Task CatchAllBaselineDeny_DoesNotOverrideAMoreSpecificWildcardBaseline()
+    {
+        // Specificity is graded, not binary: a prefix wildcard is narrower than the match-everything
+        // pattern, so a provider can grant a family of tools and still have the closing rule catch the
+        // rest.
+        var provider = BuildProvider(
+            new ToolPermissionRule("file_*", null, PermissionBehaviorType.Allow,
+                PermissionRuleSource.CapabilityEnvelope, 5, IsAuthoritativeBaseline: true),
+            new ToolPermissionRule("*", null, PermissionBehaviorType.Deny,
+                PermissionRuleSource.CapabilityEnvelope, int.MaxValue, IsAuthoritativeBaseline: true));
+
+        var resolver = CreateResolver(provider.Object);
+
+        (await resolver.ResolvePermissionAsync("agent", "file_system")).Behavior
+            .Should().Be(PermissionBehaviorType.Allow);
+        (await resolver.ResolvePermissionAsync("agent", "bash")).Behavior
+            .Should().Be(PermissionBehaviorType.Deny);
+    }
+
+    [Fact]
     public async Task BypassImmuneDeny_BeatsAuthoritativeBaselineAllow()
     {
         // DeniedTools (bypass-immune Deny) must still win over a plugin's Autonomous Allow baseline:

--- a/src/Content/Tests/Infrastructure.AI.Tests/Permissions/ThreePhasePermissionResolverAutonomyTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Permissions/ThreePhasePermissionResolverAutonomyTests.cs
@@ -387,4 +387,51 @@ public sealed class ThreePhasePermissionResolverAutonomyTests
 
         decision.Behavior.Should().Be(PermissionBehaviorType.Deny);
     }
+
+    [Fact]
+    public async Task NonEnvelopeProviderClaimingGrantBoundary_IsDemotedAndCannotWidenTheEnvelope()
+    {
+        // Adding a rule provider is a documented extension point, so a consumer's fifth provider is
+        // where "only the envelope declares a grant boundary" stops being true by inspection. A
+        // provider that claims the boundary tier AND names a tool exactly would outrank the envelope's
+        // closing "*" deny on specificity — structurally identical to the two bypasses already found,
+        // one tier up. The claim must be refused at the point it enters the system.
+        var envelope = BuildProvider(
+            new ToolPermissionRule("*", null, PermissionBehaviorType.Deny,
+                PermissionRuleSource.CapabilityEnvelope, int.MaxValue,
+                IsAuthoritativeBaseline: true, BaselineTier: PermissionBaselineTier.GrantBoundary));
+
+        var impostor = BuildProvider(
+            new ToolPermissionRule("file_system", null, PermissionBehaviorType.Allow,
+                PermissionRuleSource.AgentManifest, 0,
+                IsAuthoritativeBaseline: true, BaselineTier: PermissionBaselineTier.GrantBoundary));
+
+        var resolver = CreateResolver(envelope.Object, impostor.Object);
+
+        var decision = await resolver.ResolvePermissionAsync("agent", "file_system");
+
+        decision.Behavior.Should().Be(PermissionBehaviorType.Deny,
+            "a provider other than the capability envelope must not be able to declare itself a grant " +
+            "boundary and widen a caller's envelope to a tool the host never granted");
+    }
+
+    [Fact]
+    public async Task EnvelopeOwnGrantBoundary_StillGrantsAToolItLists()
+    {
+        // The other direction. Without this, demoting EVERY boundary claim — including the envelope's
+        // own — would leave the test above green while breaking every legitimate grant.
+        var envelope = BuildProvider(
+            new ToolPermissionRule("file_system", null, PermissionBehaviorType.Allow,
+                PermissionRuleSource.CapabilityEnvelope, 5,
+                IsAuthoritativeBaseline: true, BaselineTier: PermissionBaselineTier.GrantBoundary),
+            new ToolPermissionRule("*", null, PermissionBehaviorType.Deny,
+                PermissionRuleSource.CapabilityEnvelope, int.MaxValue,
+                IsAuthoritativeBaseline: true, BaselineTier: PermissionBaselineTier.GrantBoundary));
+
+        var resolver = CreateResolver(envelope.Object);
+
+        var decision = await resolver.ResolvePermissionAsync("agent", "file_system");
+
+        decision.Behavior.Should().Be(PermissionBehaviorType.Allow);
+    }
 }

--- a/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlanExecutorEnvelopeCeilingTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlanExecutorEnvelopeCeilingTests.cs
@@ -1,0 +1,234 @@
+using Application.AI.Common.Interfaces.Escalation;
+using Application.AI.Common.Interfaces.Planner;
+using Application.AI.Common.Services.Governance;
+using Domain.AI.Bundles;
+using Domain.AI.Escalation;
+using Domain.AI.Governance;
+using Domain.AI.Planner;
+using Domain.Common;
+using Infrastructure.AI.Planner;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Planner;
+
+/// <summary>
+/// Verifies the scheduler-level autonomy ceiling: when a capability envelope is ambient, a step whose
+/// <see cref="PlanStep.RequiredAutonomyLevel"/> exceeds the envelope's
+/// <see cref="CapabilityEnvelope.AutonomyCeiling"/> must never reach its executor — it fails through
+/// the step's normal OnExhausted recovery. With no envelope (every direct in-process caller) the
+/// ceiling does not apply and behavior is unchanged.
+/// </summary>
+public sealed class PlanExecutorEnvelopeCeilingTests : IDisposable
+{
+    private readonly Mock<IPlanValidator> _validator = new();
+    private readonly Mock<IPlanStateStore> _stateStore = new();
+    private readonly Mock<IPlanProgressNotifier> _notifier = new();
+    private readonly Mock<IEscalationService> _escalation = new();
+    private readonly Mock<IPlanStepExecutor> _stepExecutor = new();
+    private readonly ServiceProvider _serviceProvider;
+    private readonly PlanExecutor _sut;
+    private int _executorInvocations;
+
+    public PlanExecutorEnvelopeCeilingTests()
+    {
+        _validator.Setup(v => v.ValidateAsync(It.IsAny<PlanGraph>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<PlanValidationResult>.Success(new PlanValidationResult { IsValid = true }));
+
+        _stateStore.Setup(s => s.UpdateStepStateAsync(It.IsAny<StepExecutionState>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Success());
+        _stateStore.Setup(s => s.ResumeAsync(It.IsAny<PlanId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<IReadOnlyDictionary<PlanStepId, StepExecutionState>>.Success(
+                new Dictionary<PlanStepId, StepExecutionState>()));
+
+        _stepExecutor
+            .Setup(e => e.ExecuteAsync(It.IsAny<PlanStep>(), It.IsAny<IReadOnlyDictionary<PlanStepId, string>>(), It.IsAny<CancellationToken>()))
+            .Callback(() => Interlocked.Increment(ref _executorInvocations))
+            .ReturnsAsync(new StepExecutionResult
+            {
+                Status = StepExecutionStatus.Completed,
+                Output = "ok",
+                Duration = TimeSpan.FromMilliseconds(1)
+            });
+
+        var services = new ServiceCollection();
+        services.AddKeyedSingleton(StepType.LlmCall, _stepExecutor.Object);
+        _serviceProvider = services.BuildServiceProvider();
+
+        _sut = new PlanExecutor(
+            _validator.Object,
+            _stateStore.Object,
+            _notifier.Object,
+            _escalation.Object,
+            _serviceProvider,
+            TimeProvider.System,
+            NullLogger<PlanExecutor>.Instance);
+    }
+
+    public void Dispose() => _serviceProvider.Dispose();
+
+    private PlanGraph SingleStepPlan(
+        AutonomyLevel? requiredAutonomy, ErrorRecovery onExhausted = ErrorRecovery.FailStep)
+    {
+        var step = new PlanStep
+        {
+            Id = new PlanStepId(Guid.NewGuid()),
+            Name = "governed-step",
+            Type = StepType.LlmCall,
+            Configuration = new LlmCallConfig { SystemPrompt = "test", ModelDeploymentKey = "gpt-4" },
+            RetryPolicy = new RetryPolicy { MaxRetries = 0, OnExhausted = onExhausted },
+            RequiredAutonomyLevel = requiredAutonomy
+        };
+
+        var plan = new PlanGraph
+        {
+            Id = PlanId.New(),
+            Name = "ceiling-plan",
+            Steps = [step],
+            Edges = [],
+            Configuration = new PlanConfiguration { PlanTimeout = TimeSpan.FromSeconds(10) }
+        };
+
+        _stateStore.Setup(s => s.LoadPlanAsync(plan.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<PlanGraph?>.Success(plan));
+
+        return plan;
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_StepAboveEnvelopeCeiling_FailsWithoutInvokingExecutor()
+    {
+        var plan = SingleStepPlan(AutonomyLevel.Autonomous);
+
+        Result<PlanExecutionSummary> result;
+        using (CapabilityEnvelopeAccessor.Begin(new CapabilityEnvelope { AutonomyCeiling = AutonomyLevel.Supervised }))
+        {
+            result = await _sut.ExecuteAsync(plan.Id, CancellationToken.None);
+        }
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(StepExecutionStatus.Failed, result.Value!.FinalStatus);
+        var stepState = Assert.Single(result.Value.StepStates);
+        Assert.Contains("autonomy", stepState.ErrorMessage, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(0, _executorInvocations);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_StepAtEnvelopeCeiling_Executes()
+    {
+        var plan = SingleStepPlan(AutonomyLevel.Supervised);
+
+        Result<PlanExecutionSummary> result;
+        using (CapabilityEnvelopeAccessor.Begin(new CapabilityEnvelope { AutonomyCeiling = AutonomyLevel.Supervised }))
+        {
+            result = await _sut.ExecuteAsync(plan.Id, CancellationToken.None);
+        }
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(StepExecutionStatus.Completed, result.Value!.FinalStatus);
+        Assert.Equal(1, _executorInvocations);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_NoRequiredAutonomy_RunsUnderMostRestrictiveCeiling()
+    {
+        var plan = SingleStepPlan(requiredAutonomy: null);
+
+        Result<PlanExecutionSummary> result;
+        using (CapabilityEnvelopeAccessor.Begin(new CapabilityEnvelope { AutonomyCeiling = AutonomyLevel.Restricted }))
+        {
+            result = await _sut.ExecuteAsync(plan.Id, CancellationToken.None);
+        }
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(StepExecutionStatus.Completed, result.Value!.FinalStatus);
+        Assert.Equal(1, _executorInvocations);
+    }
+
+    [Theory]
+    [InlineData(ErrorRecovery.SkipStep)]
+    [InlineData(ErrorRecovery.Escalate)]
+    public async Task ExecuteAsync_CeilingDenial_IsTerminalRegardlessOfPlanAuthoredRecovery(ErrorRecovery recovery)
+    {
+        // MED-1: RetryPolicy.OnExhausted is plan-authored data. A plan must not be able to choose the
+        // disposition of the check that constrains it — SkipStep would have marked the step Skipped,
+        // leaving no Failed state and reporting the run Completed with the denial silently dropped;
+        // Escalate would have queued an un-actionable approval and looped on approve → re-run → deny.
+        var plan = SingleStepPlan(AutonomyLevel.Autonomous, recovery);
+
+        Result<PlanExecutionSummary> result;
+        using (CapabilityEnvelopeAccessor.Begin(new CapabilityEnvelope { AutonomyCeiling = AutonomyLevel.Restricted }))
+        {
+            result = await _sut.ExecuteAsync(plan.Id, CancellationToken.None);
+        }
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(StepExecutionStatus.Failed, result.Value!.FinalStatus);
+        Assert.Equal(StepExecutionStatus.Failed, Assert.Single(result.Value.StepStates).Status);
+        Assert.Equal(0, _executorInvocations);
+        _escalation.Verify(
+            e => e.QueueEscalationAsync(It.IsAny<Domain.AI.Escalation.EscalationRequest>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_StepExecutorPolicyDenial_IsTerminalUnderSkipStep()
+    {
+        // The same guarantee for a denial raised inside a step executor (the governor refusing a tool,
+        // retrieval, or inference call) rather than by the scheduler's ceiling check.
+        var plan = SingleStepPlan(requiredAutonomy: null, ErrorRecovery.SkipStep);
+        _stepExecutor
+            .Setup(e => e.ExecuteAsync(It.IsAny<PlanStep>(), It.IsAny<IReadOnlyDictionary<PlanStepId, string>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new StepExecutionResult
+            {
+                Status = StepExecutionStatus.Failed,
+                ErrorMessage = GovernanceDenials.NotPermitted(PlanCapabilities.LlmCall),
+                Duration = TimeSpan.Zero,
+                IsPolicyDenial = true
+            });
+
+        var result = await _sut.ExecuteAsync(plan.Id, CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(StepExecutionStatus.Failed, result.Value!.FinalStatus);
+        Assert.Equal(StepExecutionStatus.Failed, Assert.Single(result.Value.StepStates).Status);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_PolicyDenial_IsNotRetried()
+    {
+        // Retrying cannot change the envelope's answer; spending the retry budget on it only delays
+        // the denial and multiplies audit noise.
+        var plan = SingleStepPlan(requiredAutonomy: null);
+        var attempts = 0;
+        _stepExecutor
+            .Setup(e => e.ExecuteAsync(It.IsAny<PlanStep>(), It.IsAny<IReadOnlyDictionary<PlanStepId, string>>(), It.IsAny<CancellationToken>()))
+            .Callback(() => Interlocked.Increment(ref attempts))
+            .ReturnsAsync(new StepExecutionResult
+            {
+                Status = StepExecutionStatus.Failed,
+                ErrorMessage = GovernanceDenials.NotPermitted("file_system"),
+                Duration = TimeSpan.Zero,
+                IsPolicyDenial = true
+            });
+
+        await _sut.ExecuteAsync(plan.Id, CancellationToken.None);
+
+        Assert.Equal(1, attempts);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_NoEnvelope_CeilingDoesNotApply()
+    {
+        // Absent-envelope posture: direct in-process callers see today's behavior unchanged.
+        var plan = SingleStepPlan(AutonomyLevel.Autonomous);
+
+        var result = await _sut.ExecuteAsync(plan.Id, CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(StepExecutionStatus.Completed, result.Value!.FinalStatus);
+        Assert.Equal(1, _executorInvocations);
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlanRunExecutorTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlanRunExecutorTests.cs
@@ -1,3 +1,4 @@
+using Application.AI.Common.Interfaces.AI;
 using Application.AI.Common.Interfaces.Agent;
 using Application.AI.Common.Interfaces.Planner;
 using Application.AI.Common.Services.Agent;
@@ -9,6 +10,7 @@ using Domain.Common;
 using Infrastructure.AI.Planner;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
 using Xunit;
 
 namespace Infrastructure.AI.Tests.Planner;
@@ -22,6 +24,7 @@ namespace Infrastructure.AI.Tests.Planner;
 public sealed class PlanRunExecutorTests
 {
     private readonly RunCapture _capture = new();
+    private readonly Mock<IConversationBudgetTracker> _budget = new();
     private readonly PlanRunExecutor _sut;
 
     public PlanRunExecutorTests()
@@ -36,6 +39,7 @@ public sealed class PlanRunExecutorTests
 
         _sut = new PlanRunExecutor(
             provider.GetRequiredService<IServiceScopeFactory>(),
+            _budget.Object,
             NullLogger<PlanRunExecutor>.Instance);
     }
 
@@ -136,6 +140,36 @@ public sealed class PlanRunExecutorTests
     }
 
     [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("conv id")]
+    [InlineData("conv*")]
+    public async Task ExecuteAsync_MalformedConversationId_FailsClosedWithoutExecuting(string conversationId)
+    {
+        // A blank conversation id would yield a blank run scope, which the step executor's
+        // IsNullOrEmpty check reads as "no run scope" — silently disabling the run-level budget gate
+        // while the execution context stayed bound to an empty conversation.
+        var result = await _sut.ExecuteAsync(
+            Request(conversationId: conversationId), CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Contains("plan_run.conversation_id_invalid", result.Errors);
+        Assert.Equal(0, _capture.Invocations);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_NullConversationId_IsAcceptedAndDerivesScopeFromThePlan()
+    {
+        // Null is the documented "derive it from the plan id" case, distinct from blank.
+        var request = Request();
+
+        var result = await _sut.ExecuteAsync(request, CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(request.PlanId.Value.ToString(), _capture.ConversationIdDuringRun);
+    }
+
+    [Theory]
     [InlineData("bundle-agent")]
     [InlineData("tenant:team.agent_1")]
     public async Task ExecuteAsync_WellFormedAgentIdentity_Executes(string agentId)
@@ -167,6 +201,22 @@ public sealed class PlanRunExecutorTests
 
         await Assert.ThrowsAsync<OperationCanceledException>(
             () => _sut.ExecuteAsync(Request(), CancellationToken.None));
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task ExecuteAsync_ReleasesTheRunOwnedBudgetKey_OnEveryExitPath(bool throws)
+    {
+        // No conversation handler owns this key — that is the point of it — so the run must free it
+        // itself, including when execution throws.
+        var request = Request(conversationId: "conv-1");
+        if (throws)
+            _capture.ThrowOnExecute = new InvalidOperationException("boom");
+
+        await _sut.ExecuteAsync(request, CancellationToken.None);
+
+        _budget.Verify(b => b.Release(PlanRunKeys.RunBudgetKey("conv-1")), Times.Once);
     }
 
     /// <summary>Shared observation channel between the test and the scoped fake executor.</summary>

--- a/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlanRunExecutorTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlanRunExecutorTests.cs
@@ -1,0 +1,216 @@
+using Application.AI.Common.Interfaces.Agent;
+using Application.AI.Common.Interfaces.Planner;
+using Application.AI.Common.Services.Agent;
+using Application.AI.Common.Services.Governance;
+using Domain.AI.Bundles;
+using Domain.AI.Governance;
+using Domain.AI.Planner;
+using Domain.Common;
+using Infrastructure.AI.Planner;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Planner;
+
+/// <summary>
+/// Verifies the single arming site for enveloped plan runs: <see cref="PlanRunExecutor"/> must
+/// initialize the scoped governance identity and publish the capability envelope for exactly the
+/// duration of the run, fail closed on requests that cannot express a governed run, and never leak
+/// raw exception text into results.
+/// </summary>
+public sealed class PlanRunExecutorTests
+{
+    private readonly RunCapture _capture = new();
+    private readonly PlanRunExecutor _sut;
+
+    public PlanRunExecutorTests()
+    {
+        // Real scoped AgentExecutionContext + a capturing IPlanExecutor resolved from the same
+        // scope, so the test observes exactly what production step executors would observe.
+        var services = new ServiceCollection();
+        services.AddSingleton(_capture);
+        services.AddScoped<IAgentExecutionContext, AgentExecutionContext>();
+        services.AddScoped<IPlanExecutor, CapturingPlanExecutor>();
+        var provider = services.BuildServiceProvider();
+
+        _sut = new PlanRunExecutor(
+            provider.GetRequiredService<IServiceScopeFactory>(),
+            NullLogger<PlanRunExecutor>.Instance);
+    }
+
+    private static PlanRunRequest Request(
+        CapabilityEnvelope? envelope = null, string agentId = "caller-agent", string? conversationId = null) => new()
+    {
+        PlanId = PlanId.New(),
+        Envelope = envelope ?? new CapabilityEnvelope
+        {
+            AllowedTools = ["file_system"],
+            AutonomyCeiling = AutonomyLevel.Autonomous
+        },
+        AgentId = agentId,
+        ConversationId = conversationId
+    };
+
+    [Fact]
+    public async Task ExecuteAsync_ValidRequest_ArmsEnvelopeAndIdentityForTheRun()
+    {
+        var request = Request(conversationId: "conv-1");
+
+        var result = await _sut.ExecuteAsync(request, CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(1, _capture.Invocations);
+        Assert.Same(request.Envelope, _capture.EnvelopeDuringRun);
+        Assert.Equal("caller-agent", _capture.AgentIdDuringRun);
+        Assert.Equal("conv-1", _capture.ConversationIdDuringRun);
+        // The test's own flow never sees the envelope — arming is confined to the run.
+        Assert.Null(CapabilityEnvelopeAccessor.Current);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_NoConversationId_DefaultsToPlanId()
+    {
+        var request = Request();
+
+        await _sut.ExecuteAsync(request, CancellationToken.None);
+
+        Assert.Equal(request.PlanId.Value.ToString(), _capture.ConversationIdDuringRun);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_MissingEnvelope_FailsClosedWithoutExecuting()
+    {
+        // Built directly (not via Request()) so the envelope is genuinely null.
+        var request = new PlanRunRequest
+        {
+            PlanId = PlanId.New(),
+            Envelope = null!,
+            AgentId = "caller-agent"
+        };
+
+        var result = await _sut.ExecuteAsync(request, CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Contains("plan_run.envelope_required", result.Errors);
+        Assert.Equal(0, _capture.Invocations);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task ExecuteAsync_MissingAgentIdentity_FailsClosedWithoutExecuting(string agentId)
+    {
+        var result = await _sut.ExecuteAsync(Request(agentId: agentId), CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Contains("plan_run.agent_identity_required", result.Errors);
+        Assert.Equal(0, _capture.Invocations);
+    }
+
+    [Theory]
+    [InlineData("agent/../admin")]          // path traversal shape
+    [InlineData("agent*")]                   // glob wildcard — permission rules are glob-matched
+    [InlineData("agent\nsubject=admin")]     // newline — audit log forging
+    [InlineData("agent id")]                 // whitespace
+    public async Task ExecuteAsync_MalformedAgentIdentity_FailsClosedWithoutExecuting(string agentId)
+    {
+        // The id is the permission-resolution key and the audit subject, so it is constrained before
+        // it can reach either.
+        var result = await _sut.ExecuteAsync(Request(agentId: agentId), CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Contains("plan_run.agent_identity_invalid", result.Errors);
+        Assert.Equal(0, _capture.Invocations);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_OverlongAgentIdentity_FailsClosedWithoutExecuting()
+    {
+        var result = await _sut.ExecuteAsync(
+            Request(agentId: new string('a', PlanRunRequest.MaxAgentIdLength + 1)), CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Contains("plan_run.agent_identity_invalid", result.Errors);
+        Assert.Equal(0, _capture.Invocations);
+    }
+
+    [Theory]
+    [InlineData("bundle-agent")]
+    [InlineData("tenant:team.agent_1")]
+    public async Task ExecuteAsync_WellFormedAgentIdentity_Executes(string agentId)
+    {
+        var result = await _sut.ExecuteAsync(Request(agentId: agentId), CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(agentId, _capture.AgentIdDuringRun);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ExecutorThrows_ReturnsScrubbedFailureAndDisarms()
+    {
+        _capture.ThrowOnExecute = new InvalidOperationException("DataSource=/secret/path;token=abc");
+
+        var result = await _sut.ExecuteAsync(Request(), CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Contains("plan_run.execution_failed", result.Errors);
+        // Raw exception text (which can carry paths/tokens) must never surface in the result.
+        Assert.DoesNotContain(result.Errors, e => e.Contains("secret"));
+        Assert.Null(CapabilityEnvelopeAccessor.Current);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Cancellation_PropagatesUntouched()
+    {
+        _capture.ThrowOnExecute = new OperationCanceledException();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(
+            () => _sut.ExecuteAsync(Request(), CancellationToken.None));
+    }
+
+    /// <summary>Shared observation channel between the test and the scoped fake executor.</summary>
+    private sealed class RunCapture
+    {
+        public int Invocations;
+        public CapabilityEnvelope? EnvelopeDuringRun;
+        public string? AgentIdDuringRun;
+        public string? ConversationIdDuringRun;
+        public Exception? ThrowOnExecute;
+    }
+
+    /// <summary>
+    /// Fake plan executor that records the ambient envelope and the scoped identity exactly as a
+    /// production step executor would see them mid-run.
+    /// </summary>
+    private sealed class CapturingPlanExecutor(IAgentExecutionContext agentContext, RunCapture capture) : IPlanExecutor
+    {
+        public Task<Result<PlanExecutionSummary>> ExecuteAsync(PlanId planId, CancellationToken ct)
+        {
+            capture.Invocations++;
+            capture.EnvelopeDuringRun = CapabilityEnvelopeAccessor.Current;
+            capture.AgentIdDuringRun = agentContext.AgentId;
+            capture.ConversationIdDuringRun = agentContext.ConversationId;
+
+            if (capture.ThrowOnExecute is not null)
+                throw capture.ThrowOnExecute;
+
+            return Task.FromResult(Result<PlanExecutionSummary>.Success(new PlanExecutionSummary
+            {
+                PlanId = planId,
+                FinalStatus = StepExecutionStatus.Completed,
+                TotalDuration = TimeSpan.Zero,
+                StepStates = []
+            }));
+        }
+
+        public Task<Result<PlanExecutionSummary>> ExecuteAsync(PlanId planId, PlanExecutionContext context, CancellationToken ct)
+            => ExecuteAsync(planId, ct);
+
+        public Task<Result> CancelAsync(PlanId planId, CancellationToken ct)
+            => Task.FromResult(Result.Success());
+
+        public Task<Result> RetryStepAsync(PlanId planId, PlanStepId stepId, CancellationToken ct)
+            => Task.FromResult(Result.Success());
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlanRunLlmCallScopeTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlanRunLlmCallScopeTests.cs
@@ -1,0 +1,283 @@
+using Application.AI.Common.Interfaces.AI;
+using Application.AI.Common.Interfaces.Agent;
+using Application.AI.Common.Interfaces.Governance;
+using Application.AI.Common.Interfaces.Planner;
+using Application.AI.Common.Services.AI;
+using Application.AI.Common.Services.Agent;
+using Application.AI.Common.Services.Governance;
+using Application.Core.CQRS.Agents.RunConversation;
+using Domain.AI.Bundles;
+using Domain.AI.Governance;
+using Domain.AI.Planner;
+using Domain.Common;
+using Domain.Common.Config;
+using Domain.Common.Config.AI;
+using Infrastructure.AI.Planner;
+using Infrastructure.AI.Planner.StepExecutors;
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Planner;
+
+/// <summary>
+/// End-to-end regression coverage for the scoped-identity ownership split in an enveloped plan run,
+/// exercising the <em>real</em> <see cref="AgentExecutionContext"/>, the real
+/// <see cref="PlanRunExecutor"/>, and the real <see cref="LlmCallStepExecutor"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>What this proves.</strong> <c>PlanRunExecutor</c> binds the plan's scoped execution context
+/// to the caller's identity and the run's conversation. Each LlmCall step then drives a conversation
+/// whose nested agent-turn request binds a context to the step's <em>deployment key</em> and the
+/// step's own conversation id. <see cref="AgentExecutionContext.Initialize"/> throws when one instance
+/// is re-bound to a different agent or conversation, so unless every step's conversation is dispatched
+/// in its own DI scope, every LlmCall step in an enveloped run throws — the exact path this PR exists
+/// to make work.
+/// </para>
+/// <para>
+/// <strong>Why nothing here is a mock of the thing under test.</strong> Earlier revisions of this suite
+/// mocked <c>IAgentExecutionContext</c> and <c>ISender</c>, which meant the real <c>Initialize</c>
+/// guard never ran and the defect stayed invisible. The context is real, and the fake sender
+/// faithfully reproduces what <c>AgentContextPropagationBehavior</c> does for the nested turn: resolve
+/// the scoped context <em>from its own scope</em> and initialize it from the request. The assertions
+/// read the values back, so this suite also fails if <c>Initialize</c> were reduced to a no-op.
+/// </para>
+/// </remarks>
+public sealed class PlanRunLlmCallScopeTests
+{
+    private const string CallerAgentId = "caller-agent";
+    private const string RunConversation = "run-conversation";
+
+    /// <summary>What a turn observed on the scoped context it actually ran under.</summary>
+    private sealed record TurnObservation(string AgentId, string ConversationId, string CommandConversationId);
+
+    private readonly List<TurnObservation> _observed = [];
+    private readonly object _observedGate = new();
+
+    [Fact]
+    public async Task EnvelopedRun_MultipleLlmCallSteps_AllSucceedAndBindTheirOwnIdentities()
+    {
+        var (executor, planExecutor) = BuildRun(stepCount: 3);
+
+        var result = await executor.ExecuteAsync(
+            new PlanRunRequest
+            {
+                PlanId = PlanId.New(),
+                Envelope = new CapabilityEnvelope
+                {
+                    AllowedTools = [PlanCapabilities.LlmCall],
+                    AutonomyCeiling = AutonomyLevel.Autonomous
+                },
+                AgentId = CallerAgentId,
+                ConversationId = RunConversation
+            },
+            CancellationToken.None);
+
+        // Before the per-step scope, the very first step threw an AgentExecutionContext scope conflict
+        // and the run failed with plan_run.execution_failed.
+        Assert.True(result.IsSuccess, string.Join("; ", result.Errors));
+        Assert.Equal(3, planExecutor.StepResults.Count);
+        Assert.All(planExecutor.StepResults, r => Assert.Equal(StepExecutionStatus.Completed, r.Status));
+
+        // Each turn bound its OWN identity: the step's deployment key, not the caller's id.
+        Assert.Equal(3, _observed.Count);
+        Assert.All(_observed, o => Assert.NotEqual(CallerAgentId, o.AgentId));
+        Assert.All(_observed, o => Assert.NotEqual(RunConversation, o.ConversationId));
+
+        // Reading the values back is what makes this fail if Initialize became a no-op: the context
+        // would report nulls rather than the request's identity.
+        Assert.All(_observed, o => Assert.Equal(o.CommandConversationId, o.ConversationId));
+        Assert.Equal(
+            ["deployment-0", "deployment-1", "deployment-2"],
+            _observed.Select(o => o.AgentId).OrderBy(a => a, StringComparer.Ordinal));
+
+        // And every step's conversation is distinct — the cache-isolation property, end to end.
+        Assert.Equal(3, _observed.Select(o => o.ConversationId).Distinct(StringComparer.Ordinal).Count());
+    }
+
+    [Fact]
+    public async Task EnvelopedRun_RunScopeIdentity_SurvivesTheStepConversations()
+    {
+        // The plan's own scope must still hold the caller identity after the steps have run: the run
+        // binding is what the governor uses to authorize ToolUse and Retrieval steps.
+        var (executor, planExecutor) = BuildRun(stepCount: 2);
+
+        await executor.ExecuteAsync(
+            new PlanRunRequest
+            {
+                PlanId = PlanId.New(),
+                Envelope = new CapabilityEnvelope { AllowedTools = [PlanCapabilities.LlmCall] },
+                AgentId = CallerAgentId,
+                ConversationId = RunConversation
+            },
+            CancellationToken.None);
+
+        Assert.Equal(CallerAgentId, planExecutor.RunScopeAgentId);
+        Assert.Equal(RunConversation, planExecutor.RunScopeConversationId);
+    }
+
+    /// <summary>
+    /// Wires the real executor graph: a root provider whose scoped services are the real
+    /// <see cref="AgentExecutionContext"/> and a turn-simulating <see cref="ISender"/>, plus a plan
+    /// executor that resolves the real <see cref="LlmCallStepExecutor"/> from the run's scope.
+    /// </summary>
+    private (PlanRunExecutor Executor, RecordingPlanExecutor PlanExecutor) BuildRun(int stepCount)
+    {
+        var budget = new ConversationBudgetTracker(
+            Mock.Of<IOptionsMonitor<AppConfig>>(m => m.CurrentValue == new AppConfig { AI = new AIConfig() }),
+            TimeProvider.System,
+            NullLogger<ConversationBudgetTracker>.Instance);
+
+        var governor = new Mock<IToolInvocationGovernor>();
+        governor.Setup(g => g.AuthorizeAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns(ValueTask.FromResult(ToolInvocationDecision.Allow()));
+
+        var services = new ServiceCollection();
+
+        services.AddSingleton(typeof(Microsoft.Extensions.Logging.ILogger<>), typeof(NullLogger<>));
+
+        // The real scoped context — the whole point of this suite.
+        services.AddScoped<IAgentExecutionContext, AgentExecutionContext>();
+
+        // Reproduces AgentContextPropagationBehavior for the nested agent-turn request: bind the
+        // scope's own context to the turn's agent id (the deployment key) and conversation id.
+        services.AddScoped<ISender>(sp => new TurnSimulatingSender(
+            sp.GetRequiredService<IAgentExecutionContext>(), Record));
+
+        services.AddSingleton<IConversationBudgetTracker>(budget);
+        services.AddSingleton(governor.Object);
+        services.AddSingleton(Mock.Of<IPlanProgressNotifier>());
+        services.AddScoped(_ => new PlanExecutionContext());
+        services.AddScoped<LlmCallStepExecutor>();
+
+        var planExecutor = new RecordingPlanExecutor(stepCount);
+        // sp is the run scope's provider — the same scope PlanRunExecutor bound the identity on, so
+        // the step executor resolved from it is genuinely the one the run would use.
+        services.AddScoped<IPlanExecutor>(sp =>
+        {
+            planExecutor.Scope = sp;
+            return planExecutor;
+        });
+
+        var provider = services.BuildServiceProvider();
+
+        var executor = new PlanRunExecutor(
+            provider.GetRequiredService<IServiceScopeFactory>(),
+            budget,
+            NullLogger<PlanRunExecutor>.Instance);
+
+        return (executor, planExecutor);
+    }
+
+    private void Record(TurnObservation observation)
+    {
+        lock (_observedGate)
+            _observed.Add(observation);
+    }
+
+    /// <summary>
+    /// Stands in for the conversation pipeline: binds the scoped context exactly as
+    /// <c>AgentContextPropagationBehavior</c> does for <c>ExecuteAgentTurnCommand</c> (whose
+    /// <c>AgentId</c> is the agent name), then reports what the context actually holds.
+    /// </summary>
+    private sealed class TurnSimulatingSender(
+        IAgentExecutionContext scopedContext, Action<TurnObservation> record) : ISender
+    {
+        public Task<TResponse> Send<TResponse>(IRequest<TResponse> request, CancellationToken cancellationToken = default)
+        {
+            var command = (RunConversationCommand)(object)request!;
+
+            scopedContext.Initialize(command.AgentName, command.ConversationId, turnNumber: 1);
+
+            record(new TurnObservation(
+                scopedContext.AgentId!, scopedContext.ConversationId!, command.ConversationId));
+
+            return Task.FromResult((TResponse)(object)new ConversationResult
+            {
+                Success = true,
+                Turns = [],
+                FinalResponse = "ok",
+                TotalTokens = 0
+            });
+        }
+
+        public Task<object?> Send(object request, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public Task Send<TRequest>(TRequest request, CancellationToken cancellationToken = default)
+            where TRequest : IRequest => throw new NotSupportedException();
+
+        public IAsyncEnumerable<TResponse> CreateStream<TResponse>(
+            IStreamRequest<TResponse> request, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public IAsyncEnumerable<object?> CreateStream(object request, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+    }
+
+    /// <summary>
+    /// Drives N LlmCall steps through the real <see cref="LlmCallStepExecutor"/> resolved from the
+    /// run's scope, and captures what the run scope's context holds — standing in for the real
+    /// scheduler without dragging plan persistence into the test.
+    /// </summary>
+    private sealed class RecordingPlanExecutor(int stepCount) : IPlanExecutor
+    {
+        public List<StepExecutionResult> StepResults { get; } = [];
+        public string? RunScopeAgentId { get; private set; }
+        public string? RunScopeConversationId { get; private set; }
+
+        /// <summary>Set by the DI factory so the executor can resolve from the run's own scope.</summary>
+        public IServiceProvider? Scope { get; set; }
+
+        public async Task<Result<PlanExecutionSummary>> ExecuteAsync(PlanId planId, CancellationToken ct)
+        {
+            var scope = Scope ?? throw new InvalidOperationException("run scope not wired");
+
+            var runContext = scope.GetRequiredService<IAgentExecutionContext>();
+            RunScopeAgentId = runContext.AgentId;
+            RunScopeConversationId = runContext.ConversationId;
+
+            var stepExecutor = scope.GetRequiredService<LlmCallStepExecutor>();
+
+            for (var i = 0; i < stepCount; i++)
+            {
+                var step = new PlanStep
+                {
+                    Id = PlanStepId.New(),
+                    Name = $"step-{i}",
+                    Type = StepType.LlmCall,
+                    Configuration = new LlmCallConfig
+                    {
+                        SystemPrompt = "p",
+                        ModelDeploymentKey = $"deployment-{i}"
+                    },
+                    RetryPolicy = new RetryPolicy { MaxRetries = 0 }
+                };
+
+                StepResults.Add(await stepExecutor.ExecuteAsync(
+                    step, new Dictionary<PlanStepId, string>(), ct));
+            }
+
+            return Result<PlanExecutionSummary>.Success(new PlanExecutionSummary
+            {
+                PlanId = planId,
+                FinalStatus = StepExecutionStatus.Completed,
+                TotalDuration = TimeSpan.Zero,
+                StepStates = []
+            });
+        }
+
+        public Task<Result<PlanExecutionSummary>> ExecuteAsync(
+            PlanId planId, PlanExecutionContext context, CancellationToken ct) => ExecuteAsync(planId, ct);
+
+        public Task<Result> CancelAsync(PlanId planId, CancellationToken ct)
+            => Task.FromResult(Result.Success());
+
+        public Task<Result> RetryStepAsync(PlanId planId, PlanStepId stepId, CancellationToken ct)
+            => Task.FromResult(Result.Success());
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlannerDiRegistrationTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlannerDiRegistrationTests.cs
@@ -81,15 +81,37 @@ public sealed class PlannerDiRegistrationTests : IDisposable
     {
         // PlanCapabilities names are matched out of the same AllowedTools string space as keyed ITool
         // registrations, so a tool registered under one of these keys would silently merge the two
-        // grants. Nothing in the container prevents it (registration order is not guaranteed), so the
-        // harness's own registrations are asserted here.
-        var offenders = _provider.GetServices<Application.AI.Common.Interfaces.Tools.ITool>()
-            .Select(t => t.Name)
-            .Where(PlanCapabilities.IsReserved)
+        // grants. Production refuses the collision at boot (ReservedPlanCapabilityGuard); this pins
+        // Infrastructure.AI's own registrations without booting a host.
+        //
+        // The keys must come off the ServiceDescriptors, NOT from GetServices<ITool>(): every tool
+        // here is registered with AddKeyedSingleton, and the non-keyed GetServices overload does not
+        // return keyed registrations — asserting over it can never fail.
+        var offenders = CreateServices()
+            .Where(d => d.ServiceType == typeof(Application.AI.Common.Interfaces.Tools.ITool)
+                        && d.ServiceKey is string key
+                        && PlanCapabilities.IsReserved(key))
+            .Select(d => (string)d.ServiceKey!)
             .ToList();
 
         offenders.Should().BeEmpty(
             "a tool registered under a reserved plan-capability name would silently widen that grant");
+    }
+
+    [Fact]
+    public void DependencyInjection_KeyedToolDescriptorsAreVisibleToTheReservedNameScan()
+    {
+        // Guards the guard: the reserved-name assertion above is only meaningful if this scan
+        // actually sees the container's keyed ITool registrations. Its predecessor used
+        // GetServices<ITool>(), which returns nothing for keyed registrations, so it passed
+        // vacuously. If tool registration ever moves off keyed DI this fails and the reserved-name
+        // test must be re-pointed rather than left silently inert.
+        var keyedToolCount = CreateServices()
+            .Count(d => d.ServiceType == typeof(Application.AI.Common.Interfaces.Tools.ITool)
+                        && d.ServiceKey is string);
+
+        keyedToolCount.Should().BeGreaterThan(0,
+            "the reserved-name scan reads keyed ITool descriptors, so there must be some to read");
     }
 
     [Fact]
@@ -163,7 +185,13 @@ public sealed class PlannerDiRegistrationTests : IDisposable
         ctx.Should().NotBeNull();
     }
 
-    private static ServiceProvider CreateServiceProvider()
+    private static ServiceProvider CreateServiceProvider() => CreateServices().BuildServiceProvider();
+
+    /// <summary>
+    /// Composes the same graph the provider is built from, returned un-built so descriptor-level
+    /// assertions (registration keys, lifetimes) can inspect it without resolving anything.
+    /// </summary>
+    private static IServiceCollection CreateServices()
     {
         var appConfig = new AppConfig
         {
@@ -211,7 +239,7 @@ public sealed class PlannerDiRegistrationTests : IDisposable
         // Register all Infrastructure.AI services (now includes planner/sandbox)
         services.AddInfrastructureAIDependencies(appConfig);
 
-        return services.BuildServiceProvider();
+        return services;
     }
 
     private sealed class AppConfigMonitorStub(AppConfig config) : IOptionsMonitor<AppConfig>

--- a/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlannerDiRegistrationTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlannerDiRegistrationTests.cs
@@ -65,6 +65,18 @@ public sealed class PlannerDiRegistrationTests : IDisposable
     }
 
     [Fact]
+    public void DependencyInjection_PlanRunExecutor_RegisteredAsSingleton()
+    {
+        // W2 regression guard: the single arming site for enveloped plan runs must be resolvable
+        // from the root provider (it creates its own per-run scope), mirroring IBundleRunExecutor.
+        var first = _provider.GetService<IPlanRunExecutor>();
+        var second = _provider.GetService<IPlanRunExecutor>();
+
+        first.Should().NotBeNull().And.BeOfType<PlanRunExecutor>();
+        second.Should().BeSameAs(first);
+    }
+
+    [Fact]
     public void DependencyInjection_AllSandboxServices_Resolvable()
     {
         using var scope = _provider.CreateScope();
@@ -163,6 +175,8 @@ public sealed class PlannerDiRegistrationTests : IDisposable
         // knowledge-scope accessor (now consumed by EfCorePlanStateStore for plan ownership)
         // delegates agent identity to it.
         services.AddScoped(_ => new Mock<Application.AI.Common.Interfaces.Agent.IAgentExecutionContext>().Object);
+        services.AddScoped(_ => new Mock<IToolInvocationGovernor>().Object);
+        services.AddSingleton(new Mock<Application.AI.Common.Interfaces.AI.IConversationBudgetTracker>().Object);
         services.AddSingleton<ISender>(new Mock<ISender>().Object);
         services.AddSingleton<IPlanProgressNotifier>(new Mock<IPlanProgressNotifier>().Object);
         services.AddSingleton<ICapabilityEnforcer>(new Mock<ICapabilityEnforcer>().Object);

--- a/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlannerDiRegistrationTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlannerDiRegistrationTests.cs
@@ -77,6 +77,22 @@ public sealed class PlannerDiRegistrationTests : IDisposable
     }
 
     [Fact]
+    public void DependencyInjection_NoToolIsRegisteredUnderAReservedPlanCapabilityName()
+    {
+        // PlanCapabilities names are matched out of the same AllowedTools string space as keyed ITool
+        // registrations, so a tool registered under one of these keys would silently merge the two
+        // grants. Nothing in the container prevents it (registration order is not guaranteed), so the
+        // harness's own registrations are asserted here.
+        var offenders = _provider.GetServices<Application.AI.Common.Interfaces.Tools.ITool>()
+            .Select(t => t.Name)
+            .Where(PlanCapabilities.IsReserved)
+            .ToList();
+
+        offenders.Should().BeEmpty(
+            "a tool registered under a reserved plan-capability name would silently widen that grant");
+    }
+
+    [Fact]
     public void DependencyInjection_AllSandboxServices_Resolvable()
     {
         using var scope = _provider.CreateScope();

--- a/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlannerPresentationBoundaryTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlannerPresentationBoundaryTests.cs
@@ -1,0 +1,91 @@
+using FluentAssertions;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Planner;
+
+/// <summary>
+/// Architecture guard for the plan-run arming boundary: no Presentation-layer code may depend on the
+/// ungoverned <c>IPlanExecutor</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>IPlanRunExecutor</c> is the one place a plan run's capability envelope and governance identity
+/// are armed. <c>IPlanExecutor</c> sits beside it in the same DI container and arms neither — a host
+/// surface that injects it executes plans completely outside the envelope, with no runtime signal
+/// that the whole confinement layer was skipped. XML docs saying "don't" cannot enforce that, so this
+/// test does.
+/// </para>
+/// <para>
+/// Implemented as a source scan rather than reflection because Infrastructure.AI.Tests deliberately
+/// does not reference the Presentation assemblies (that dependency would itself invert the layering
+/// this test defends). It walks up to the repository root and reads the Presentation tree; if that
+/// tree cannot be located the test fails loudly rather than passing vacuously.
+/// </para>
+/// </remarks>
+public sealed class PlannerPresentationBoundaryTests
+{
+    [Fact]
+    public void NoPresentationSourceFile_ReferencesTheUngovernedPlanExecutor()
+    {
+        var presentationRoot = LocatePresentationRoot();
+
+        var offenders = Directory
+            .EnumerateFiles(presentationRoot, "*.cs", SearchOption.AllDirectories)
+            .Where(path => !IsGeneratedOrBuildOutput(path))
+            .Where(path => ReferencesUngovernedExecutor(File.ReadAllText(path)))
+            .Select(path => Path.GetRelativePath(presentationRoot, path))
+            .ToList();
+
+        offenders.Should().BeEmpty(
+            "Presentation must drive plans through IPlanRunExecutor, which arms the caller's capability "
+            + "envelope and governance identity; IPlanExecutor arms neither and silently bypasses "
+            + "envelope confinement");
+    }
+
+    /// <summary>
+    /// Matches <c>IPlanExecutor</c> as a whole identifier so <c>IPlanRunExecutor</c> — the interface
+    /// Presentation is *supposed* to use — does not trip the guard on a naive substring match.
+    /// </summary>
+    private static bool ReferencesUngovernedExecutor(string source)
+    {
+        var index = source.IndexOf("IPlanExecutor", StringComparison.Ordinal);
+        while (index >= 0)
+        {
+            var precededByIdentifierChar = index > 0
+                && (char.IsLetterOrDigit(source[index - 1]) || source[index - 1] == '_');
+
+            var end = index + "IPlanExecutor".Length;
+            var followedByIdentifierChar = end < source.Length
+                && (char.IsLetterOrDigit(source[end]) || source[end] == '_');
+
+            if (!precededByIdentifierChar && !followedByIdentifierChar)
+                return true;
+
+            index = source.IndexOf("IPlanExecutor", index + 1, StringComparison.Ordinal);
+        }
+
+        return false;
+    }
+
+    private static bool IsGeneratedOrBuildOutput(string path) =>
+        path.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal)
+        || path.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.Ordinal);
+
+    private static string LocatePresentationRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+
+        while (directory is not null)
+        {
+            var candidate = Path.Combine(directory.FullName, "src", "Content", "Presentation");
+            if (Directory.Exists(candidate))
+                return candidate;
+
+            directory = directory.Parent;
+        }
+
+        throw new DirectoryNotFoundException(
+            "Could not locate src/Content/Presentation from the test output directory. This guard must "
+            + "not silently pass — fix the path walk rather than deleting the test.");
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Planner/StepExecutors/LlmCallStepExecutorRunIdentityTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Planner/StepExecutors/LlmCallStepExecutorRunIdentityTests.cs
@@ -1,0 +1,245 @@
+using Application.AI.Common.Interfaces.AI;
+using Application.AI.Common.Interfaces.Agent;
+using Application.AI.Common.Interfaces.Governance;
+using Application.AI.Common.Interfaces.Planner;
+using Application.AI.Common.Services.AI;
+using Application.Core.CQRS.Agents.RunConversation;
+using Domain.AI.Planner;
+using Domain.Common.Config;
+using Domain.Common.Config.AI;
+using Infrastructure.AI.Planner.StepExecutors;
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Planner.StepExecutors;
+
+/// <summary>
+/// Regression coverage for the two identities a plan run's LlmCall steps depend on, both of which a
+/// mocked collaborator previously hid.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>Conversation id must be per step.</strong> It is the sole key of
+/// <c>IAgentConversationCache</c> — a hit returns the cached agent and ignores the requested skills
+/// and options entirely — as well as the skill-completion and observability-session key. Sharing one
+/// id across steps makes a step run under another step's agent and lets the first step to finish
+/// evict state belonging to steps still in flight.
+/// </para>
+/// <para>
+/// <strong>The run budget uses the REAL <see cref="ConversationBudgetTracker"/>.</strong> A mocked
+/// tracker cannot reproduce <c>RunConversationCommandHandler</c>'s <c>Release</c>-in-<c>finally</c>,
+/// which removes the entry and makes any budget keyed on a conversation id read back as zero. This
+/// fixture simulates that release explicitly so the cross-step accounting is proven against real
+/// behavior, not against a stub that always agrees.
+/// </para>
+/// </remarks>
+public sealed class LlmCallStepExecutorRunIdentityTests : IDisposable
+{
+    private const string RunScope = "plan-run-conversation";
+
+    private readonly Mock<ISender> _sender = new();
+    private readonly Mock<IAgentExecutionContext> _agentContext = new();
+    private readonly List<RunConversationCommand> _dispatched = [];
+    private readonly List<ServiceProvider> _providers = [];
+
+    public LlmCallStepExecutorRunIdentityTests()
+    {
+        _agentContext.SetupGet(c => c.ConversationId).Returns(RunScope);
+    }
+
+    public void Dispose()
+    {
+        foreach (var provider in _providers)
+            provider.Dispose();
+    }
+
+    /// <summary>
+    /// Builds an executor over the real budget tracker. Each dispatched conversation reports
+    /// <paramref name="tokensPerStep"/> tokens and then releases its own conversation entry, exactly
+    /// as the real handler's <c>finally</c> does.
+    /// </summary>
+    private LlmCallStepExecutor BuildExecutor(
+        IConversationBudgetTracker budget, int tokensPerStep, PlanId? currentPlanId = null)
+    {
+        _sender
+            .Setup(s => s.Send(It.IsAny<RunConversationCommand>(), It.IsAny<CancellationToken>()))
+            .Returns<object, CancellationToken>((c, _) =>
+            {
+                var command = (RunConversationCommand)c;
+                _dispatched.Add(command);
+
+                // What the real handler does: record the turn's usage under its own conversation id,
+                // then release that entry on the way out.
+                budget.RecordUsage(command.ConversationId, tokensPerStep);
+                budget.Release(command.ConversationId);
+
+                return Task.FromResult(new ConversationResult
+                {
+                    Success = true,
+                    Turns = [],
+                    FinalResponse = "ok",
+                    TotalTokens = tokensPerStep
+                });
+            });
+
+        var governor = new Mock<IToolInvocationGovernor>();
+        governor.Setup(g => g.AuthorizeAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns(ValueTask.FromResult(ToolInvocationDecision.Allow()));
+
+        // Dispatch happens through an ISender resolved from a per-step scope; see
+        // PlanRunLlmCallScopeTests for the end-to-end proof that this is what keeps the real
+        // AgentExecutionContext from being re-bound across steps.
+        var services = new ServiceCollection();
+        services.AddScoped(_ => _sender.Object);
+        var provider = services.BuildServiceProvider();
+        _providers.Add(provider);
+
+        return new LlmCallStepExecutor(
+            provider.GetRequiredService<IServiceScopeFactory>(),
+            Mock.Of<IPlanProgressNotifier>(),
+            governor.Object,
+            budget,
+            _agentContext.Object,
+            new PlanExecutionContext { CurrentPlanId = currentPlanId },
+            NullLogger<LlmCallStepExecutor>.Instance);
+    }
+
+    private static ConversationBudgetTracker RealTracker(int ceiling)
+    {
+        var config = new AppConfig
+        {
+            AI = new AIConfig
+            {
+                AgentFramework = new AgentFrameworkConfig { ConversationTokenBudget = ceiling }
+            }
+        };
+
+        return new ConversationBudgetTracker(
+            Mock.Of<IOptionsMonitor<AppConfig>>(m => m.CurrentValue == config),
+            TimeProvider.System,
+            NullLogger<ConversationBudgetTracker>.Instance);
+    }
+
+    private static PlanStep Step(string name, string deploymentKey) => new()
+    {
+        Id = PlanStepId.New(),
+        Name = name,
+        Type = StepType.LlmCall,
+        Configuration = new LlmCallConfig { SystemPrompt = "p", ModelDeploymentKey = deploymentKey },
+        RetryPolicy = new RetryPolicy { MaxRetries = 0 }
+    };
+
+    [Fact]
+    public async Task ExecuteAsync_ParallelStepsWithDifferentDeployments_EachGetTheirOwnConversationId()
+    {
+        // BLOCKING-1: with MaxParallelSteps defaulting to 10, concurrent LlmCall steps are normal. If
+        // both steps share a conversation id, the second gets a cache HIT and silently runs under the
+        // first step's agent — its skills, instructions, tools and deployment.
+        var sut = BuildExecutor(RealTracker(ceiling: 0), tokensPerStep: 0);
+        var researcher = Step("S1", "researcher");
+        var classifier = Step("S2", "classifier");
+
+        await Task.WhenAll(
+            sut.ExecuteAsync(researcher, new Dictionary<PlanStepId, string>(), CancellationToken.None),
+            sut.ExecuteAsync(classifier, new Dictionary<PlanStepId, string>(), CancellationToken.None));
+
+        var ids = _dispatched.Select(c => c.ConversationId).ToList();
+        Assert.Equal(2, ids.Count);
+        Assert.Equal(2, ids.Distinct(StringComparer.Ordinal).Count());
+        Assert.All(ids, id => Assert.NotEqual(RunScope, id));
+        // Each id is derived from its own step, so agent resolution cannot cross over.
+        Assert.Contains(PlanRunKeys.StepConversationId(RunScope, researcher.Id), ids);
+        Assert.Contains(PlanRunKeys.StepConversationId(RunScope, classifier.Id), ids);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ThreeSequentialSteps_ThirdIsRefusedByTheRunBudget()
+    {
+        // BLOCKING-2: the handler releases its per-conversation entry on every exit, so a budget keyed
+        // on a conversation id always reads zero and never refuses anything. The run-level key is
+        // owned by the plan run, so spend genuinely accumulates: 5k + 5k reaches the 10k ceiling and
+        // the third step is refused before dispatching any inference.
+        var budget = RealTracker(ceiling: 10_000);
+        var sut = BuildExecutor(budget, tokensPerStep: 5_000);
+
+        var first = await sut.ExecuteAsync(Step("S1", "a"), new Dictionary<PlanStepId, string>(), CancellationToken.None);
+        var second = await sut.ExecuteAsync(Step("S2", "a"), new Dictionary<PlanStepId, string>(), CancellationToken.None);
+        var third = await sut.ExecuteAsync(Step("S3", "a"), new Dictionary<PlanStepId, string>(), CancellationToken.None);
+
+        Assert.Equal(StepExecutionStatus.Completed, first.Status);
+        Assert.Equal(StepExecutionStatus.Completed, second.Status);
+        Assert.Equal(StepExecutionStatus.Failed, third.Status);
+        Assert.Equal(PlanStepErrors.BudgetExhausted, third.ErrorMessage);
+        Assert.True(third.IsPolicyDenial);
+
+        // The refused step never dispatched inference — only the first two did.
+        Assert.Equal(2, _dispatched.Count);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_RunBudgetKey_IsNamespacedAwayFromConversationIds()
+    {
+        // The run key must not be reachable as a conversation id, or a handler's Release would erase
+        // the run's accumulated spend — the exact failure this design avoids.
+        var budget = RealTracker(ceiling: 10_000);
+        var sut = BuildExecutor(budget, tokensPerStep: 5_000);
+
+        await sut.ExecuteAsync(Step("S1", "a"), new Dictionary<PlanStepId, string>(), CancellationToken.None);
+
+        Assert.Equal(5_000, budget.GetStatus(PlanRunKeys.RunBudgetKey(RunScope)).ConsumedTokens);
+        Assert.StartsWith(PlanRunKeys.RunBudgetPrefix, PlanRunKeys.RunBudgetKey(RunScope));
+        Assert.All(_dispatched, c => Assert.DoesNotContain(PlanRunKeys.RunBudgetPrefix, c.ConversationId));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_UngovernedInProcessRun_DoesNotAccumulateAnUnreleasableBudget()
+    {
+        // The run budget key is created by the armed run scope and released by PlanRunExecutor. An
+        // earlier revision also derived a scope from the current plan id, which meant the ungoverned
+        // in-process path (the default today, including checkpoint/resume) created a planrun: entry
+        // that nothing released. Since the tracker is a singleton and an exhausted budget is a
+        // TERMINAL, non-retryable denial, that made a plan id permanently un-runnable in-process
+        // after one exhaustion. Running the same plan id twice must therefore stay unrefused.
+        _agentContext.SetupGet(c => c.ConversationId).Returns((string?)null);
+        var planId = PlanId.New();
+        var budget = RealTracker(ceiling: 10_000);
+
+        var firstRun = BuildExecutor(budget, tokensPerStep: 50_000, currentPlanId: planId);
+        var first = await firstRun.ExecuteAsync(
+            Step("S1", "a"), new Dictionary<PlanStepId, string>(), CancellationToken.None);
+
+        // A second in-process execution of the SAME plan id — the resume/re-run case.
+        var secondRun = BuildExecutor(budget, tokensPerStep: 50_000, currentPlanId: planId);
+        var second = await secondRun.ExecuteAsync(
+            Step("S2", "a"), new Dictionary<PlanStepId, string>(), CancellationToken.None);
+
+        Assert.Equal(StepExecutionStatus.Completed, first.Status);
+        Assert.Equal(StepExecutionStatus.Completed, second.Status);
+        Assert.NotEqual(PlanStepErrors.BudgetExhausted, second.ErrorMessage);
+
+        // And no orphan key was created under the plan id.
+        Assert.Equal(
+            0, budget.GetStatus(PlanRunKeys.RunBudgetKey(planId.Value.ToString())).ConsumedTokens);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_NoRunScope_HasNoRunBudgetAndAThrowawayConversationId()
+    {
+        // An ad-hoc direct in-process call belongs to no run: unchanged from before this work.
+        _agentContext.SetupGet(c => c.ConversationId).Returns((string?)null);
+        var budget = RealTracker(ceiling: 10_000);
+        var sut = BuildExecutor(budget, tokensPerStep: 50_000);
+
+        var first = await sut.ExecuteAsync(Step("S1", "a"), new Dictionary<PlanStepId, string>(), CancellationToken.None);
+        var second = await sut.ExecuteAsync(Step("S2", "a"), new Dictionary<PlanStepId, string>(), CancellationToken.None);
+
+        Assert.Equal(StepExecutionStatus.Completed, first.Status);
+        Assert.Equal(StepExecutionStatus.Completed, second.Status);
+        Assert.Equal(2, _dispatched.Select(c => c.ConversationId).Distinct(StringComparer.Ordinal).Count());
+    }
+
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Planner/StepExecutors/LlmCallStepExecutorTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Planner/StepExecutors/LlmCallStepExecutorTests.cs
@@ -8,14 +8,16 @@ using Domain.AI.Governance;
 using Domain.AI.Planner;
 using Infrastructure.AI.Planner.StepExecutors;
 using MediatR;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Xunit;
 
 namespace Infrastructure.AI.Tests.Planner.StepExecutors;
 
-public sealed class LlmCallStepExecutorTests
+public sealed class LlmCallStepExecutorTests : IDisposable
 {
+    private readonly ServiceProvider _rootProvider;
     private readonly Mock<ISender> _sender = new();
     private readonly Mock<IPlanProgressNotifier> _notifier = new();
     private readonly Mock<IToolInvocationGovernor> _governor = new();
@@ -34,8 +36,14 @@ public sealed class LlmCallStepExecutorTests
         GovernorReturns(allowed: true);
         _budget.Setup(b => b.GetStatus(It.IsAny<string>())).Returns(ConversationBudgetStatus.Disabled);
 
+        // The executor dispatches through an ISender resolved from a per-step scope, so the fake is
+        // registered in a container rather than injected directly.
+        var services = new ServiceCollection();
+        services.AddScoped(_ => _sender.Object);
+        _rootProvider = services.BuildServiceProvider();
+
         _sut = new LlmCallStepExecutor(
-            _sender.Object,
+            _rootProvider.GetRequiredService<IServiceScopeFactory>(),
             _notifier.Object,
             _governor.Object,
             _budget.Object,
@@ -43,6 +51,8 @@ public sealed class LlmCallStepExecutorTests
             _context,
             NullLogger<LlmCallStepExecutor>.Instance);
     }
+
+    public void Dispose() => _rootProvider.Dispose();
 
     /// <summary>Arms the governor to allow (the ungoverned default) or deny inference.</summary>
     private void GovernorReturns(bool allowed) =>
@@ -71,6 +81,9 @@ public sealed class LlmCallStepExecutorTests
     [Fact]
     public async Task ExecuteAsync_BudgetExhausted_RefusesWithoutDispatchingInference()
     {
+        // The run budget only exists once a run scope is armed — see ResolveRunScope. Without an
+        // ambient conversation there is deliberately no run-level gate at all.
+        _agentContext.SetupGet(c => c.ConversationId).Returns("plan-run-conversation");
         _budget.Setup(b => b.GetStatus(It.IsAny<string>()))
             .Returns(new ConversationBudgetStatus(IsEnabled: true, TotalBudget: 100, ConsumedTokens: 100));
         var step = CreateStep(new LlmCallConfig { SystemPrompt = "x", ModelDeploymentKey = "gpt-4" });
@@ -84,10 +97,28 @@ public sealed class LlmCallStepExecutorTests
     }
 
     [Fact]
-    public async Task ExecuteAsync_KeysBudgetOnTheRunConversation_NotAFreshIdPerStep()
+    public async Task ExecuteAsync_BudgetExhaustedButNoRunScope_StillRuns()
     {
-        // MED-3 root cause: leaving ConversationId at its per-command Guid.NewGuid() default gave
-        // every step its own budget, so a plan of N steps could spend N full budgets.
+        // The ungoverned in-process path keeps its pre-W2 behaviour: no run scope, no run budget, so
+        // a singleton entry left over from some other flow can never refuse it.
+        _budget.Setup(b => b.GetStatus(It.IsAny<string>()))
+            .Returns(new ConversationBudgetStatus(IsEnabled: true, TotalBudget: 100, ConsumedTokens: 100));
+        _sender.Setup(s => s.Send(It.IsAny<RunConversationCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ConversationResult { Success = true, Turns = [], FinalResponse = "ok" });
+        var step = CreateStep(new LlmCallConfig { SystemPrompt = "x", ModelDeploymentKey = "gpt-4" });
+
+        var result = await _sut.ExecuteAsync(step, new Dictionary<PlanStepId, string>(), CancellationToken.None);
+
+        Assert.Equal(StepExecutionStatus.Completed, result.Status);
+        _budget.Verify(b => b.GetStatus(It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_DerivesAPerStepConversationId_AndARunScopedBudgetKey()
+    {
+        // The conversation id must be per step (it keys the agent cache, skill tracking and the
+        // observability session) while the budget is keyed on the run. See PlanRunKeys, and
+        // LlmCallStepExecutorRunIdentityTests for the behavioural proofs.
         _agentContext.SetupGet(c => c.ConversationId).Returns("plan-run-conversation");
         RunConversationCommand? captured = null;
         _sender.Setup(s => s.Send(It.IsAny<RunConversationCommand>(), It.IsAny<CancellationToken>()))
@@ -98,8 +129,10 @@ public sealed class LlmCallStepExecutorTests
         await _sut.ExecuteAsync(step, new Dictionary<PlanStepId, string>(), CancellationToken.None);
 
         Assert.NotNull(captured);
-        Assert.Equal("plan-run-conversation", captured!.ConversationId);
-        _budget.Verify(b => b.GetStatus("plan-run-conversation"), Times.Once);
+        Assert.Equal(
+            PlanRunKeys.StepConversationId("plan-run-conversation", step.Id), captured!.ConversationId);
+        Assert.NotEqual("plan-run-conversation", captured.ConversationId);
+        _budget.Verify(b => b.GetStatus(PlanRunKeys.RunBudgetKey("plan-run-conversation")), Times.Once);
     }
 
     private static PlanStep CreateStep(StepConfiguration config) => new()

--- a/src/Content/Tests/Infrastructure.AI.Tests/Planner/StepExecutors/LlmCallStepExecutorTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Planner/StepExecutors/LlmCallStepExecutorTests.cs
@@ -1,5 +1,10 @@
+using Application.AI.Common.Interfaces.AI;
+using Application.AI.Common.Interfaces.Agent;
+using Application.AI.Common.Interfaces.Governance;
 using Application.AI.Common.Interfaces.Planner;
 using Application.Core.CQRS.Agents.RunConversation;
+using Domain.AI.Budget;
+using Domain.AI.Governance;
 using Domain.AI.Planner;
 using Infrastructure.AI.Planner.StepExecutors;
 using MediatR;
@@ -13,6 +18,9 @@ public sealed class LlmCallStepExecutorTests
 {
     private readonly Mock<ISender> _sender = new();
     private readonly Mock<IPlanProgressNotifier> _notifier = new();
+    private readonly Mock<IToolInvocationGovernor> _governor = new();
+    private readonly Mock<IConversationBudgetTracker> _budget = new();
+    private readonly Mock<IAgentExecutionContext> _agentContext = new();
     private readonly PlanExecutionContext _context = new() { CurrentPlanId = new PlanId(Guid.NewGuid()) };
     private readonly LlmCallStepExecutor _sut;
 
@@ -22,11 +30,76 @@ public sealed class LlmCallStepExecutorTests
             It.IsAny<PlanId>(), It.IsAny<PlanStepId>(), It.IsAny<string>(), It.IsAny<StepType>(), It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
 
+        // Ungoverned, unbudgeted defaults: matches a direct in-process caller.
+        GovernorReturns(allowed: true);
+        _budget.Setup(b => b.GetStatus(It.IsAny<string>())).Returns(ConversationBudgetStatus.Disabled);
+
         _sut = new LlmCallStepExecutor(
             _sender.Object,
             _notifier.Object,
+            _governor.Object,
+            _budget.Object,
+            _agentContext.Object,
             _context,
             NullLogger<LlmCallStepExecutor>.Instance);
+    }
+
+    /// <summary>Arms the governor to allow (the ungoverned default) or deny inference.</summary>
+    private void GovernorReturns(bool allowed) =>
+        _governor.Setup(g => g.AuthorizeAsync(PlanCapabilities.LlmCall, It.IsAny<CancellationToken>()))
+            .Returns(ValueTask.FromResult(allowed
+                ? ToolInvocationDecision.Allow()
+                : ToolInvocationDecision.Deny(GovernanceDenials.NotPermitted(PlanCapabilities.LlmCall))));
+
+    [Fact]
+    public async Task ExecuteAsync_GovernorDenies_FailsWithoutDispatchingInference()
+    {
+        // MED-3: the most restrictive envelope must not still buy tokens. No conversation command
+        // may reach the pipeline, and the failure must be marked as a policy denial.
+        GovernorReturns(allowed: false);
+        var step = CreateStep(new LlmCallConfig { SystemPrompt = "exfiltrate", ModelDeploymentKey = "gpt-4" });
+
+        var result = await _sut.ExecuteAsync(step, new Dictionary<PlanStepId, string>(), CancellationToken.None);
+
+        Assert.Equal(StepExecutionStatus.Failed, result.Status);
+        Assert.True(result.IsPolicyDenial);
+        Assert.Contains("not permitted", result.ErrorMessage);
+        _sender.Verify(
+            s => s.Send(It.IsAny<RunConversationCommand>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_BudgetExhausted_RefusesWithoutDispatchingInference()
+    {
+        _budget.Setup(b => b.GetStatus(It.IsAny<string>()))
+            .Returns(new ConversationBudgetStatus(IsEnabled: true, TotalBudget: 100, ConsumedTokens: 100));
+        var step = CreateStep(new LlmCallConfig { SystemPrompt = "x", ModelDeploymentKey = "gpt-4" });
+
+        var result = await _sut.ExecuteAsync(step, new Dictionary<PlanStepId, string>(), CancellationToken.None);
+
+        Assert.Equal(StepExecutionStatus.Failed, result.Status);
+        Assert.Equal(PlanStepErrors.BudgetExhausted, result.ErrorMessage);
+        _sender.Verify(
+            s => s.Send(It.IsAny<RunConversationCommand>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_KeysBudgetOnTheRunConversation_NotAFreshIdPerStep()
+    {
+        // MED-3 root cause: leaving ConversationId at its per-command Guid.NewGuid() default gave
+        // every step its own budget, so a plan of N steps could spend N full budgets.
+        _agentContext.SetupGet(c => c.ConversationId).Returns("plan-run-conversation");
+        RunConversationCommand? captured = null;
+        _sender.Setup(s => s.Send(It.IsAny<RunConversationCommand>(), It.IsAny<CancellationToken>()))
+            .Callback<object, CancellationToken>((c, _) => captured = (RunConversationCommand)c)
+            .ReturnsAsync(new ConversationResult { Success = true, Turns = [], FinalResponse = "ok" });
+        var step = CreateStep(new LlmCallConfig { SystemPrompt = "x", ModelDeploymentKey = "gpt-4" });
+
+        await _sut.ExecuteAsync(step, new Dictionary<PlanStepId, string>(), CancellationToken.None);
+
+        Assert.NotNull(captured);
+        Assert.Equal("plan-run-conversation", captured!.ConversationId);
+        _budget.Verify(b => b.GetStatus("plan-run-conversation"), Times.Once);
     }
 
     private static PlanStep CreateStep(StepConfiguration config) => new()

--- a/src/Content/Tests/Infrastructure.AI.Tests/Planner/StepExecutors/RetrievalPlanStepExecutorTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Planner/StepExecutors/RetrievalPlanStepExecutorTests.cs
@@ -1,7 +1,9 @@
 using System.Text.Json;
+using Application.AI.Common.Interfaces.Governance;
 using Application.AI.Common.Interfaces.Planner;
 using Application.AI.Common.Interfaces.RAG;
 using Application.AI.Common.Interfaces.Routing;
+using Domain.AI.Governance;
 using Domain.AI.Planner;
 using Domain.AI.RAG.Enums;
 using Domain.AI.RAG.Models;
@@ -41,6 +43,14 @@ public sealed class RetrievalPlanStepExecutorTests
         ]
     };
 
+    private readonly Mock<IToolInvocationGovernor> _governor = new();
+
+    public RetrievalPlanStepExecutorTests()
+    {
+        // Ungoverned default: no envelope armed and enforcement off, so the governor allows.
+        GovernorReturns(allowed: true);
+    }
+
     private RetrievalPlanStepExecutor CreateExecutor()
     {
         return new RetrievalPlanStepExecutor(
@@ -49,9 +59,17 @@ public sealed class RetrievalPlanStepExecutorTests
             _mockComplexityClassifier.Object,
             _mockCostTracker.Object,
             _mockNotifier.Object,
+            _governor.Object,
             _context,
             NullLogger<RetrievalPlanStepExecutor>.Instance);
     }
+
+    /// <summary>Arms the governor to allow (the ungoverned default) or deny retrieval.</summary>
+    private void GovernorReturns(bool allowed) =>
+        _governor.Setup(g => g.AuthorizeAsync(PlanCapabilities.Retrieval, It.IsAny<CancellationToken>()))
+            .Returns(ValueTask.FromResult(allowed
+                ? ToolInvocationDecision.Allow()
+                : ToolInvocationDecision.Deny(GovernanceDenials.NotPermitted(PlanCapabilities.Retrieval))));
 
     private static PlanStep CreateRetrievalStep(RetrievalStepConfiguration config) => new()
     {
@@ -61,6 +79,42 @@ public sealed class RetrievalPlanStepExecutorTests
         Configuration = config,
         RetryPolicy = new RetryPolicy()
     };
+
+    [Fact]
+    public async Task ExecuteAsync_GovernorDenies_FailsWithoutQuerying()
+    {
+        // A denial must fail the step closed before any orchestrator is touched, and must be marked
+        // as a policy denial so the scheduler routes it to a terminal failure the plan's own
+        // OnExhausted policy cannot soften.
+        GovernorReturns(allowed: false);
+        var step = CreateRetrievalStep(new RetrievalStepConfiguration { Query = "confidential lookup" });
+
+        var result = await CreateExecutor().ExecuteAsync(
+            step, new Dictionary<PlanStepId, string>(), CancellationToken.None);
+
+        Assert.Equal(StepExecutionStatus.Failed, result.Status);
+        Assert.True(result.IsPolicyDenial);
+        Assert.Contains("not permitted", result.ErrorMessage);
+        _mockRagOrchestrator.Verify(r => r.SearchAsync(
+            It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<string?>(),
+            It.IsAny<Domain.AI.RAG.Enums.RetrievalStrategy?>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_AuthorizesUnderTheWellKnownRetrievalCapability()
+    {
+        // The name matters: it is what the envelope's allowlist and autonomy-ceiling baseline key on.
+        _mockRagOrchestrator
+            .Setup(r => r.SearchAsync("What is clean architecture?", null, null, null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(_expectedContext);
+        var step = CreateRetrievalStep(new RetrievalStepConfiguration { Query = "What is clean architecture?" });
+
+        var result = await CreateExecutor().ExecuteAsync(
+            step, new Dictionary<PlanStepId, string>(), CancellationToken.None);
+
+        Assert.Equal(StepExecutionStatus.Completed, result.Status);
+        _governor.Verify(g => g.AuthorizeAsync("rag_retrieval", It.IsAny<CancellationToken>()), Times.Once);
+    }
 
     [Fact]
     public async Task ExecuteAsync_BasicRetrieval_CallsOrchestrator()
@@ -172,13 +226,16 @@ public sealed class RetrievalPlanStepExecutorTests
 
         _mockRagOrchestrator
             .Setup(r => r.SearchAsync(It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<string?>(), It.IsAny<RetrievalStrategy?>(), It.IsAny<CancellationToken>()))
-            .ThrowsAsync(new InvalidOperationException("Vector store unavailable"));
+            .ThrowsAsync(new InvalidOperationException("Vector store https://acct.search.windows.net?sig=SECRET unavailable"));
 
         var sut = CreateExecutor();
         var result = await sut.ExecuteAsync(step, new Dictionary<PlanStepId, string>(), CancellationToken.None);
 
         Assert.Equal(StepExecutionStatus.Failed, result.Status);
-        Assert.Contains("Vector store unavailable", result.ErrorMessage);
+        // MED-2: step error state is persisted and returned to callers, so retrieval-stack exception
+        // text — which carries store endpoints and SAS tokens — must never reach it.
+        Assert.Equal(PlanStepErrors.RetrievalFailed, result.ErrorMessage);
+        Assert.DoesNotContain("SECRET", result.ErrorMessage);
         Assert.Null(result.Output);
     }
 

--- a/src/Content/Tests/Infrastructure.AI.Tests/Planner/StepExecutors/SubPlanEnvelopeConfinementTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Planner/StepExecutors/SubPlanEnvelopeConfinementTests.cs
@@ -1,0 +1,222 @@
+using Application.AI.Common.Interfaces.Agent;
+using Application.AI.Common.Interfaces.Governance;
+using Application.AI.Common.Interfaces.Permissions;
+using Application.AI.Common.Interfaces.Planner;
+using Application.AI.Common.Interfaces.Sandbox;
+using Application.AI.Common.Interfaces.Tools;
+using Application.AI.Common.Services.Agent;
+using Application.AI.Common.Services.Governance;
+using Application.Core.Permissions;
+using Domain.AI.Bundles;
+using Domain.AI.Changes;
+using Domain.AI.Governance;
+using Domain.AI.Permissions;
+using Domain.AI.Planner;
+using Domain.Common;
+using Domain.Common.Config;
+using Domain.Common.Config.AI;
+using Domain.Common.Config.AI.Permissions;
+using Domain.Common.Config.AI.Sandbox;
+using Infrastructure.AI.Permissions;
+using Infrastructure.AI.Planner.StepExecutors;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Planner.StepExecutors;
+
+/// <summary>
+/// End-to-end proof that the capability envelope confines sub-plans: the parent arms an envelope and
+/// identity, <see cref="SubPlanStepExecutor"/> recurses into a fresh DI scope, and inside that child
+/// scope the <em>real</em> <see cref="ToolInvocationGovernor"/> — driven by the <em>real</em>
+/// <see cref="ThreePhasePermissionResolver"/> and <see cref="EnvelopePermissionRuleProvider"/> —
+/// still denies an ungranted tool while a granted tool keeps working. Two ambient facts must survive
+/// the recursion for this to hold: the envelope (AsyncLocal, flows on its own) and the governance
+/// identity (DI-scoped, re-stamped by the executor).
+/// </summary>
+public sealed class SubPlanEnvelopeConfinementTests
+{
+    private const string GrantedTool = "file_system";
+    private const string DeniedTool = "bash";
+
+    [Fact]
+    public async Task ExecuteAsync_DeniedToolStaysDenied_InsideSubPlan()
+    {
+        var decisions = new Dictionary<string, bool>();
+        var childPlanId = new PlanId(Guid.NewGuid());
+        var scopeFactory = BuildChildServices(decisions).GetRequiredService<IServiceScopeFactory>();
+
+        var parentContext = new Mock<IAgentExecutionContext>();
+        parentContext.SetupGet(c => c.AgentId).Returns("caller-agent");
+        parentContext.SetupGet(c => c.ConversationId).Returns("conv-1");
+        parentContext.SetupGet(c => c.TurnNumber).Returns(1);
+
+        var sut = new SubPlanStepExecutor(
+            scopeFactory,
+            Mock.Of<IPlanStateStore>(),
+            Mock.Of<IPlanProgressNotifier>(),
+            new PlanExecutionContext { Depth = 0, MaxDepth = 3 },
+            parentContext.Object,
+            NullLogger<SubPlanStepExecutor>.Instance);
+
+        var step = new PlanStep
+        {
+            Id = new PlanStepId(Guid.NewGuid()),
+            Name = "sub-plan-step",
+            Type = StepType.SubPlanInvocation,
+            Configuration = new SubPlanConfig { ChildPlanId = childPlanId },
+            RetryPolicy = new RetryPolicy { MaxRetries = 0 }
+        };
+
+        StepExecutionResult result;
+        using (CapabilityEnvelopeAccessor.Begin(new CapabilityEnvelope
+        {
+            AllowedTools = [GrantedTool],
+            AutonomyCeiling = AutonomyLevel.Autonomous
+        }))
+        {
+            result = await sut.ExecuteAsync(step, new Dictionary<PlanStepId, string>(), CancellationToken.None);
+        }
+
+        Assert.Equal(StepExecutionStatus.Completed, result.Status);
+        Assert.False(decisions[DeniedTool], "an ungranted tool must stay denied inside the sub-plan");
+        Assert.True(decisions[GrantedTool], "a granted tool must keep working inside the sub-plan");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_AmbientEnvelope_FlowsIntoChildPlanExecution()
+    {
+        CapabilityEnvelope? observed = null;
+        var childPlanId = new PlanId(Guid.NewGuid());
+        var childExecutor = new Mock<IPlanExecutor>();
+        childExecutor
+            .Setup(e => e.ExecuteAsync(childPlanId, It.IsAny<PlanExecutionContext>(), It.IsAny<CancellationToken>()))
+            .Callback(() => observed = CapabilityEnvelopeAccessor.Current)
+            .ReturnsAsync(Result<PlanExecutionSummary>.Success(new PlanExecutionSummary
+            {
+                PlanId = childPlanId,
+                FinalStatus = StepExecutionStatus.Completed,
+                TotalDuration = TimeSpan.Zero,
+                StepStates = []
+            }));
+
+        var services = new ServiceCollection();
+        services.AddSingleton(childExecutor.Object);
+        var scopeFactory = services.BuildServiceProvider().GetRequiredService<IServiceScopeFactory>();
+
+        var sut = new SubPlanStepExecutor(
+            scopeFactory,
+            Mock.Of<IPlanStateStore>(),
+            Mock.Of<IPlanProgressNotifier>(),
+            new PlanExecutionContext { Depth = 0, MaxDepth = 3 },
+            Mock.Of<IAgentExecutionContext>(),
+            NullLogger<SubPlanStepExecutor>.Instance);
+
+        var step = new PlanStep
+        {
+            Id = new PlanStepId(Guid.NewGuid()),
+            Name = "sub-plan-step",
+            Type = StepType.SubPlanInvocation,
+            Configuration = new SubPlanConfig { ChildPlanId = childPlanId },
+            RetryPolicy = new RetryPolicy { MaxRetries = 0 }
+        };
+
+        var envelope = new CapabilityEnvelope { AllowedTools = [GrantedTool] };
+        using (CapabilityEnvelopeAccessor.Begin(envelope))
+        {
+            await sut.ExecuteAsync(step, new Dictionary<PlanStepId, string>(), CancellationToken.None);
+        }
+
+        Assert.Same(envelope, observed);
+    }
+
+    /// <summary>
+    /// Builds the child-scope service graph with the real governance chain: real scoped
+    /// <see cref="AgentExecutionContext"/> (stamped by the executor under test), real
+    /// <see cref="ToolInvocationGovernor"/>, and the real three-phase resolver driven only by the
+    /// envelope rule provider. Only leaf dependencies (risk classifier, policy engine, audit,
+    /// capability enforcer, options) are test doubles.
+    /// </summary>
+    private static ServiceProvider BuildChildServices(Dictionary<string, bool> decisions)
+    {
+        var appConfig = new AppConfig
+        {
+            AI = new AIConfig { Permissions = new PermissionsConfig { DenialRateLimitThreshold = 5 } }
+        };
+
+        var safetyGates = new Mock<ISafetyGateRegistry>();
+        safetyGates
+            .Setup(r => r.CheckSafetyGate(It.IsAny<string>(), It.IsAny<IReadOnlyDictionary<string, object?>?>()))
+            .Returns((SafetyGate?)null);
+
+        var capabilityEnforcer = new Mock<ICapabilityEnforcer>();
+        capabilityEnforcer
+            .Setup(x => x.EnforceAsync(It.IsAny<string>(), It.IsAny<Domain.AI.Sandbox.ToolCapability>(),
+                It.IsAny<IReadOnlyList<string>?>(), It.IsAny<IReadOnlyList<string>?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Success());
+
+        var services = new ServiceCollection();
+        services.AddSingleton(typeof(Microsoft.Extensions.Logging.ILogger<>), typeof(NullLogger<>));
+        services.AddSingleton(decisions);
+        services.AddScoped<IAgentExecutionContext, AgentExecutionContext>();
+        services.AddSingleton<IToolPermissionService>(new ThreePhasePermissionResolver(
+            [new EnvelopePermissionRuleProvider()],
+            safetyGates.Object,
+            new GlobPatternMatcher(),
+            new Mock<IDenialTracker>().Object,
+            Mock.Of<IOptionsMonitor<AppConfig>>(m => m.CurrentValue == appConfig),
+            NullLogger<ThreePhasePermissionResolver>.Instance));
+        services.AddSingleton(Mock.Of<IToolRiskClassifier>(
+            c => c.Classify(It.IsAny<string>()) == new ToolRiskProfile(BlastRadius.Low, true)));
+        services.AddSingleton(new Mock<IAutonomyDecisionEvaluator>().Object);
+        services.AddSingleton(Mock.Of<IGovernancePolicyEngine>(p => p.HasPolicies == false));
+        services.AddSingleton(Mock.Of<IGovernanceAuditService>());
+        services.AddSingleton(new Mock<IDenialTracker>().Object);
+        services.AddSingleton(capabilityEnforcer.Object);
+        services.AddSingleton(Mock.Of<IOptionsMonitor<GovernanceConfig>>(
+            m => m.CurrentValue == new GovernanceConfig { EnforceToolInvocation = false }));
+        services.AddSingleton(Mock.Of<IOptionsMonitor<PermissionsConfig>>(
+            m => m.CurrentValue == new PermissionsConfig()));
+        services.AddSingleton(Mock.Of<IOptionsMonitor<SandboxConfig>>(
+            m => m.CurrentValue == new SandboxConfig()));
+        services.AddScoped<IToolInvocationGovernor, ToolInvocationGovernor>();
+        services.AddScoped<IPlanExecutor, GovernorProbePlanExecutor>();
+
+        return services.BuildServiceProvider();
+    }
+
+    /// <summary>
+    /// Stands in for the child plan's execution: asks the child scope's real governor to authorize a
+    /// granted and an ungranted tool, recording both decisions — exactly what the child plan's
+    /// ToolUse steps would do through the same governor.
+    /// </summary>
+    private sealed class GovernorProbePlanExecutor(
+        IToolInvocationGovernor governor, Dictionary<string, bool> decisions) : IPlanExecutor
+    {
+        public async Task<Result<PlanExecutionSummary>> ExecuteAsync(
+            PlanId planId, PlanExecutionContext context, CancellationToken ct)
+        {
+            decisions[DeniedTool] = (await governor.AuthorizeAsync(DeniedTool, ct)).IsAllowed;
+            decisions[GrantedTool] = (await governor.AuthorizeAsync(GrantedTool, ct)).IsAllowed;
+
+            return Result<PlanExecutionSummary>.Success(new PlanExecutionSummary
+            {
+                PlanId = planId,
+                FinalStatus = StepExecutionStatus.Completed,
+                TotalDuration = TimeSpan.Zero,
+                StepStates = []
+            });
+        }
+
+        public Task<Result<PlanExecutionSummary>> ExecuteAsync(PlanId planId, CancellationToken ct)
+            => ExecuteAsync(planId, new PlanExecutionContext(), ct);
+
+        public Task<Result> CancelAsync(PlanId planId, CancellationToken ct)
+            => Task.FromResult(Result.Success());
+
+        public Task<Result> RetryStepAsync(PlanId planId, PlanStepId stepId, CancellationToken ct)
+            => Task.FromResult(Result.Success());
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Planner/StepExecutors/SubPlanEnvelopeConfinementTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Planner/StepExecutors/SubPlanEnvelopeConfinementTests.cs
@@ -162,7 +162,7 @@ public sealed class SubPlanEnvelopeConfinementTests
         services.AddSingleton(decisions);
         services.AddScoped<IAgentExecutionContext, AgentExecutionContext>();
         services.AddSingleton<IToolPermissionService>(new ThreePhasePermissionResolver(
-            [new EnvelopePermissionRuleProvider()],
+            [new EnvelopePermissionRuleProvider(NullLogger<EnvelopePermissionRuleProvider>.Instance)],
             safetyGates.Object,
             new GlobPatternMatcher(),
             new Mock<IDenialTracker>().Object,

--- a/src/Content/Tests/Infrastructure.AI.Tests/Planner/StepExecutors/SubPlanStepExecutorTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Planner/StepExecutors/SubPlanStepExecutorTests.cs
@@ -1,3 +1,4 @@
+using Application.AI.Common.Interfaces.Agent;
 using Application.AI.Common.Interfaces.Planner;
 using Domain.AI.Planner;
 using Domain.Common;
@@ -14,6 +15,7 @@ public sealed class SubPlanStepExecutorTests
     private readonly Mock<IPlanStateStore> _planStateStore = new();
     private readonly Mock<IPlanProgressNotifier> _notifier = new();
     private readonly Mock<IPlanExecutor> _childExecutor = new();
+    private readonly Mock<IAgentExecutionContext> _parentAgentContext = new();
     private readonly PlanExecutionContext _context = new() { Depth = 0, MaxDepth = 3, CurrentPlanId = new PlanId(Guid.NewGuid()) };
     private readonly SubPlanStepExecutor _sut;
 
@@ -32,6 +34,7 @@ public sealed class SubPlanStepExecutorTests
             _planStateStore.Object,
             _notifier.Object,
             _context,
+            _parentAgentContext.Object,
             NullLogger<SubPlanStepExecutor>.Instance);
     }
 
@@ -75,6 +78,7 @@ public sealed class SubPlanStepExecutorTests
             _planStateStore.Object,
             _notifier.Object,
             deepContext,
+            _parentAgentContext.Object,
             NullLogger<SubPlanStepExecutor>.Instance);
 
         var config = new SubPlanConfig { ChildPlanId = new PlanId(Guid.NewGuid()) };
@@ -137,6 +141,80 @@ public sealed class SubPlanStepExecutorTests
     }
 
     [Fact]
+    public async Task ExecuteAsync_ParentIdentity_PropagatedIntoChildScope()
+    {
+        // Governance identity is DI-scoped, so it does not cross into the child's fresh scope by
+        // itself — the executor must re-stamp it or the governor fails closed on every enveloped
+        // tool call inside the sub-plan, granted or not.
+        _parentAgentContext.SetupGet(c => c.AgentId).Returns("caller-agent");
+        _parentAgentContext.SetupGet(c => c.ConversationId).Returns("conv-1");
+        _parentAgentContext.SetupGet(c => c.TurnNumber).Returns(3);
+
+        var (sut, childAgentContext, childPlanId) = BuildExecutorWithChildScope();
+
+        var result = await sut.ExecuteAsync(
+            CreateStep(new SubPlanConfig { ChildPlanId = childPlanId }),
+            new Dictionary<PlanStepId, string>(), CancellationToken.None);
+
+        Assert.Equal(StepExecutionStatus.Completed, result.Status);
+        childAgentContext.Verify(c => c.Initialize("caller-agent", "conv-1", 3), Times.Once);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_NoParentIdentity_ChildContextUntouched()
+    {
+        // An ungoverned direct run carries no identity; the child must not be stamped with one —
+        // its behavior stays exactly as before envelope confinement existed.
+        var (sut, childAgentContext, childPlanId) = BuildExecutorWithChildScope();
+
+        await sut.ExecuteAsync(
+            CreateStep(new SubPlanConfig { ChildPlanId = childPlanId }),
+            new Dictionary<PlanStepId, string>(), CancellationToken.None);
+
+        childAgentContext.Verify(
+            c => c.Initialize(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>()), Times.Never);
+    }
+
+    /// <summary>
+    /// Builds an executor whose child scope exposes its own <see cref="IAgentExecutionContext"/>, so a
+    /// test can assert what the parent did or did not stamp onto it. Returns the executor, the child
+    /// scope's context mock, and the child plan id already wired to succeed.
+    /// </summary>
+    private (SubPlanStepExecutor Sut, Mock<IAgentExecutionContext> ChildContext, PlanId ChildPlanId)
+        BuildExecutorWithChildScope()
+    {
+        var childAgentContext = new Mock<IAgentExecutionContext>();
+        var childPlanId = new PlanId(Guid.NewGuid());
+
+        var services = new ServiceCollection();
+        services.AddSingleton<IPlanExecutor>(_childExecutor.Object);
+        services.AddSingleton(childAgentContext.Object);
+        var scopeFactory = services.BuildServiceProvider().GetRequiredService<IServiceScopeFactory>();
+
+        SetupChildSuccess(childPlanId);
+
+        var sut = new SubPlanStepExecutor(
+            scopeFactory,
+            _planStateStore.Object,
+            _notifier.Object,
+            _context,
+            _parentAgentContext.Object,
+            NullLogger<SubPlanStepExecutor>.Instance);
+
+        return (sut, childAgentContext, childPlanId);
+    }
+
+    private void SetupChildSuccess(PlanId childPlanId) =>
+        _childExecutor.Setup(e => e.ExecuteAsync(childPlanId, It.IsAny<PlanExecutionContext>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<PlanExecutionSummary>.Success(new PlanExecutionSummary
+            {
+                PlanId = childPlanId,
+                FinalStatus = StepExecutionStatus.Completed,
+                TotalDuration = TimeSpan.Zero,
+                StepStates = []
+            }));
+
+    [Fact]
     public async Task ExecuteAsync_ChildPlanThrows_ReturnsFailed()
     {
         var childPlanId = new PlanId(Guid.NewGuid());
@@ -144,11 +222,14 @@ public sealed class SubPlanStepExecutorTests
         var step = CreateStep(config);
 
         _childExecutor.Setup(e => e.ExecuteAsync(childPlanId, It.IsAny<PlanExecutionContext>(), It.IsAny<CancellationToken>()))
-            .ThrowsAsync(new InvalidOperationException("DB connection lost"));
+            .ThrowsAsync(new InvalidOperationException("DataSource=/secret/plans.db;Password=hunter2"));
 
         var result = await _sut.ExecuteAsync(step, new Dictionary<PlanStepId, string>(), CancellationToken.None);
 
         Assert.Equal(StepExecutionStatus.Failed, result.Status);
-        Assert.Contains("DB connection lost", result.ErrorMessage);
+        // MED-2: step error state is persisted and returned to callers, so the raw exception text —
+        // here an EF Core connection string — must never reach it.
+        Assert.Equal(PlanStepErrors.SubPlanFailed, result.ErrorMessage);
+        Assert.DoesNotContain("hunter2", result.ErrorMessage);
     }
 }

--- a/src/Content/Tests/Infrastructure.AI.Tests/Planner/StepExecutors/ToolUseStepExecutorAttestationBindingTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Planner/StepExecutors/ToolUseStepExecutorAttestationBindingTests.cs
@@ -67,8 +67,14 @@ public sealed class ToolUseStepExecutorAttestationBindingTests
         services.AddKeyedSingleton<ISandboxExecutor>(SandboxIsolationLevel.Process, _sandboxExecutor.Object);
         services.AddKeyedSingleton<ISandboxExecutor>(SandboxIsolationLevel.Container, _sandboxExecutor.Object);
 
+        // Ungoverned default: no envelope armed and enforcement off means the governor allows.
+        var toolGovernor = new Mock<IToolInvocationGovernor>();
+        toolGovernor.Setup(g => g.AuthorizeAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns(ValueTask.FromResult(ToolInvocationDecision.Allow()));
+
         _sut = new ToolUseStepExecutor(
             _capabilityEnforcer.Object,
+            toolGovernor.Object,
             services.BuildServiceProvider(),
             _attestationService,
             _responseSanitizer.Object,

--- a/src/Content/Tests/Infrastructure.AI.Tests/Planner/StepExecutors/ToolUseStepExecutorAttestationBindingTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Planner/StepExecutors/ToolUseStepExecutorAttestationBindingTests.cs
@@ -156,6 +156,9 @@ public sealed class ToolUseStepExecutorAttestationBindingTests
         var result = await _sut.ExecuteAsync(CreateStep(), new Dictionary<PlanStepId, string>(), CancellationToken.None);
 
         Assert.Equal(StepExecutionStatus.Failed, result.Status);
-        Assert.Equal("Process timed out", result.ErrorMessage);
+        // The tool-failure code, not the attestation-failure message: the distinction this test exists
+        // for. The sandbox's own text ("Process timed out") stays in the structured log — it can carry
+        // host paths and container ids, and step error state is relayed to callers.
+        Assert.Equal(PlanStepErrors.ToolFailed, result.ErrorMessage);
     }
 }

--- a/src/Content/Tests/Infrastructure.AI.Tests/Planner/StepExecutors/ToolUseStepExecutorSolutionReviewFixTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Planner/StepExecutors/ToolUseStepExecutorSolutionReviewFixTests.cs
@@ -50,8 +50,14 @@ public sealed class ToolUseStepExecutorSolutionReviewFixTests
         services.AddKeyedSingleton<ISandboxExecutor>(SandboxIsolationLevel.Container, new Mock<ISandboxExecutor>().Object);
         var sp = services.BuildServiceProvider();
 
+        // Ungoverned default: no envelope armed and enforcement off means the governor allows.
+        var toolGovernor = new Mock<IToolInvocationGovernor>();
+        toolGovernor.Setup(g => g.AuthorizeAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns(ValueTask.FromResult(ToolInvocationDecision.Allow()));
+
         _sut = new ToolUseStepExecutor(
             _capabilityEnforcer.Object,
+            toolGovernor.Object,
             sp,
             _attestationService.Object,
             _responseSanitizer.Object,

--- a/src/Content/Tests/Infrastructure.AI.Tests/Planner/StepExecutors/ToolUseStepExecutorTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Planner/StepExecutors/ToolUseStepExecutorTests.cs
@@ -126,7 +126,36 @@ public sealed class ToolUseStepExecutorTests
         var result = await _sut.ExecuteAsync(step, new Dictionary<PlanStepId, string>(), CancellationToken.None);
 
         Assert.Equal(StepExecutionStatus.Failed, result.Status);
-        Assert.Equal("Permission denied", result.ErrorMessage);
+        // The sandbox's own text is never relayed — only the stable, scrubbed code. See
+        // ExecuteAsync_FailedExecution_DoesNotLeakSandboxErrorText for why.
+        Assert.Equal(PlanStepErrors.ToolFailed, result.ErrorMessage);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_FailedExecution_DoesNotLeakSandboxErrorText()
+    {
+        // A sandbox failure message is raw process stderr, a raw exception message, or raw container
+        // logs. StepExecutionState.ErrorMessage is persisted and handed back to callers through
+        // PlanExecutionSummary.StepStates, which a host surface relays over HTTP — so anything a tool
+        // printed on the way down (paths, environment variables, credentials) would leave the host.
+        var config = new ToolUseConfig { ToolName = "file_system" };
+        var step = CreateStep(config);
+        const string PlantedSecret = "AZURE_CLIENT_SECRET=hunter2-do-not-leak";
+
+        _sandboxExecutor.Setup(s => s.ExecuteAsync(It.IsAny<SandboxExecutionRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SandboxExecutionResult
+            {
+                Success = false,
+                ErrorMessage = $"sh: line 1: /home/runner/.config/app: {PlantedSecret}",
+                ResourceUsage = new ResourceUsage()
+            });
+
+        var result = await _sut.ExecuteAsync(step, new Dictionary<PlanStepId, string>(), CancellationToken.None);
+
+        Assert.Equal(StepExecutionStatus.Failed, result.Status);
+        Assert.Equal(PlanStepErrors.ToolFailed, result.ErrorMessage);
+        Assert.DoesNotContain("hunter2", result.ErrorMessage);
+        Assert.DoesNotContain("/home/runner", result.ErrorMessage);
     }
 
     [Fact]

--- a/src/Content/Tests/Infrastructure.AI.Tests/Planner/StepExecutors/ToolUseStepExecutorTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Planner/StepExecutors/ToolUseStepExecutorTests.cs
@@ -18,6 +18,7 @@ namespace Infrastructure.AI.Tests.Planner.StepExecutors;
 public sealed class ToolUseStepExecutorTests
 {
     private readonly Mock<ICapabilityEnforcer> _capabilityEnforcer = new();
+    private readonly Mock<IToolInvocationGovernor> _toolGovernor = new();
     private readonly Mock<IAttestationService> _attestationService = new();
     private readonly Mock<ICompositeResponseSanitizer> _responseSanitizer = new();
     private readonly Mock<IPlanProgressNotifier> _notifier = new();
@@ -27,6 +28,10 @@ public sealed class ToolUseStepExecutorTests
 
     public ToolUseStepExecutorTests()
     {
+        // Ungoverned default: no envelope armed and enforcement off means the governor allows.
+        _toolGovernor.Setup(g => g.AuthorizeAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns(ValueTask.FromResult(ToolInvocationDecision.Allow()));
+
         _notifier.Setup(n => n.NotifyStepStartedAsync(
             It.IsAny<PlanId>(), It.IsAny<PlanStepId>(), It.IsAny<string>(), It.IsAny<StepType>(), It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
@@ -48,6 +53,7 @@ public sealed class ToolUseStepExecutorTests
 
         _sut = new ToolUseStepExecutor(
             _capabilityEnforcer.Object,
+            _toolGovernor.Object,
             sp,
             _attestationService.Object,
             _responseSanitizer.Object,
@@ -183,6 +189,41 @@ public sealed class ToolUseStepExecutorTests
         await _sut.ExecuteAsync(step, new Dictionary<PlanStepId, string>(), CancellationToken.None);
 
         _sandboxExecutor.Verify(s => s.ExecuteAsync(It.IsAny<SandboxExecutionRequest>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_GovernorDenies_FailsStepWithoutTouchingSandbox()
+    {
+        // The governance gate must precede every execution resource: no permission profile is
+        // resolved and no sandbox executor is invoked for a denied tool.
+        const string deniedMessage = "Error: tool 'file_system' is not permitted in the current context.";
+        _toolGovernor.Setup(g => g.AuthorizeAsync("file_system", It.IsAny<CancellationToken>()))
+            .Returns(ValueTask.FromResult(ToolInvocationDecision.Deny(deniedMessage)));
+
+        var step = CreateStep(new ToolUseConfig { ToolName = "file_system" });
+
+        var result = await _sut.ExecuteAsync(step, new Dictionary<PlanStepId, string>(), CancellationToken.None);
+
+        Assert.Equal(StepExecutionStatus.Failed, result.Status);
+        Assert.Equal(deniedMessage, result.ErrorMessage);
+        _sandboxExecutor.Verify(
+            s => s.ExecuteAsync(It.IsAny<SandboxExecutionRequest>(), It.IsAny<CancellationToken>()), Times.Never);
+        _capabilityEnforcer.Verify(
+            c => c.ResolveProfileAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_GovernorAllows_AuthorizesExactToolName()
+    {
+        _sandboxExecutor.Setup(s => s.ExecuteAsync(It.IsAny<SandboxExecutionRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SandboxExecutionResult { Success = true, Output = "ok", ResourceUsage = new ResourceUsage() });
+
+        var step = CreateStep(new ToolUseConfig { ToolName = "file_system" });
+
+        var result = await _sut.ExecuteAsync(step, new Dictionary<PlanStepId, string>(), CancellationToken.None);
+
+        Assert.Equal(StepExecutionStatus.Completed, result.Status);
+        _toolGovernor.Verify(g => g.AuthorizeAsync("file_system", It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]

--- a/src/Content/Tests/Infrastructure.AI.Tests/Planner/SubPlanStepExecutorTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Planner/SubPlanStepExecutorTests.cs
@@ -84,6 +84,7 @@ public sealed class SubPlanStepExecutorTests
             Mock.Of<IPlanStateStore>(),
             _notifier.Object,
             new PlanExecutionContext { Depth = 0, MaxDepth = 5 },
+            Mock.Of<Application.AI.Common.Interfaces.Agent.IAgentExecutionContext>(),
             NullLogger<SubPlanStepExecutor>.Instance);
     }
 

--- a/src/Content/Tests/Presentation.Common.Tests/Composition/ReservedPlanCapabilityGuardTests.cs
+++ b/src/Content/Tests/Presentation.Common.Tests/Composition/ReservedPlanCapabilityGuardTests.cs
@@ -1,0 +1,123 @@
+using Application.AI.Common.Interfaces.Tools;
+using Domain.AI.Models;
+using Domain.AI.Planner;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Presentation.Common.Startup;
+using Xunit;
+
+namespace Presentation.Common.Tests.Composition;
+
+/// <summary>
+/// Guards the composition-time refusal of a keyed <see cref="ITool"/> registered under a reserved
+/// <see cref="PlanCapabilities"/> name.
+/// </summary>
+/// <remarks>
+/// The collision is fail-open at runtime: plan capabilities and tool keys share one
+/// <c>CapabilityEnvelope.AllowedTools</c> string space, so a tool keyed <c>llm_call</c> makes a
+/// caller who was granted only the inference capability also able to invoke that tool. Nothing
+/// downstream reports it — the run just succeeds with more authority than intended. These tests
+/// pin the guard that turns it into a boot failure.
+/// </remarks>
+public sealed class ReservedPlanCapabilityGuardTests
+{
+    [Theory]
+    [MemberData(nameof(ReservedNames))]
+    public void Validate_ToolKeyedUnderAnyReservedName_Throws(string reservedName)
+    {
+        // Every reserved name must be covered, not just the two that exist today: a future
+        // PlanCapabilities constant that the guard silently ignores is the same fail-open again.
+        var services = new ServiceCollection();
+        services.AddKeyedSingleton<ITool, StubTool>(reservedName);
+
+        var act = () => services.ValidateNoReservedPlanCapabilityToolKeys();
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage($"*{reservedName}*")
+            .WithMessage($"*{typeof(StubTool).FullName}*");
+    }
+
+    [Fact]
+    public void Validate_ToolKeyedUnderACaseVariantOfAReservedName_Throws()
+    {
+        // Keyed DI resolution is ordinal, but the envelope matches AllowedTools case-insensitively,
+        // so "LLM_Call" is a real collision even though GetKeyedService("llm_call") would miss it.
+        var services = new ServiceCollection();
+        services.AddKeyedSingleton<ITool, StubTool>(PlanCapabilities.LlmCall.ToUpperInvariant());
+
+        var act = () => services.ValidateNoReservedPlanCapabilityToolKeys();
+
+        act.Should().Throw<InvalidOperationException>();
+    }
+
+    [Fact]
+    public void Validate_FactoryRegisteredToolUnderAReservedName_ThrowsWithoutResolvingIt()
+    {
+        // Every harness tool is factory-registered. The guard must catch those too, and must not
+        // invoke the factory to do it — a throwing factory here proves the scan is descriptor-only.
+        var services = new ServiceCollection();
+        services.AddKeyedSingleton<ITool>(
+            PlanCapabilities.Retrieval,
+            (_, _) => throw new InvalidOperationException("factory must never run"));
+
+        var act = () => services.ValidateNoReservedPlanCapabilityToolKeys();
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage($"*{PlanCapabilities.Retrieval}*")
+            .Which.Message.Should().NotContain("factory must never run");
+    }
+
+    [Fact]
+    public void Validate_NonReservedToolKeysAndOtherKeyedServices_DoesNotThrow()
+    {
+        // The guard is scoped to ITool: keyed registrations of other contracts (step executors are
+        // keyed by StepType) and ordinary tool keys must pass untouched.
+        var services = new ServiceCollection();
+        services.AddKeyedSingleton<ITool, StubTool>("file_system");
+        services.AddKeyedSingleton<ITool>("echo_calculate", (_, _) => new StubTool());
+        services.AddKeyedSingleton<StubTool>(StepType.LlmCall);
+        services.AddSingleton<StubTool>();
+
+        var act = () => services.ValidateNoReservedPlanCapabilityToolKeys();
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void Validate_EveryCollision_IsNamedInASingleFailure()
+    {
+        // One boot should report the complete list, matching StartupRegistrationSmokeCheck's
+        // aggregate-then-throw behaviour rather than making an operator fix them one per restart.
+        var services = new ServiceCollection();
+        services.AddKeyedSingleton<ITool, StubTool>(PlanCapabilities.Retrieval);
+        services.AddKeyedSingleton<ITool, StubTool>(PlanCapabilities.LlmCall);
+
+        var act = () => services.ValidateNoReservedPlanCapabilityToolKeys();
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage($"*{PlanCapabilities.Retrieval}*")
+            .WithMessage($"*{PlanCapabilities.LlmCall}*");
+    }
+
+    /// <summary>Every reserved plan-capability name, as xUnit theory data.</summary>
+    public static TheoryData<string> ReservedNames()
+    {
+        var data = new TheoryData<string>();
+        foreach (var name in PlanCapabilities.ReservedNames)
+            data.Add(name);
+        return data;
+    }
+
+    private sealed class StubTool : ITool
+    {
+        public string Name => "stub";
+        public string Description => "stub";
+        public IReadOnlyList<string> SupportedOperations { get; } = ["noop"];
+
+        public Task<ToolResult> ExecuteAsync(
+            string operation,
+            IReadOnlyDictionary<string, object?> parameters,
+            CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+    }
+}


### PR DESCRIPTION
Part of the external-trigger API program (Wave 2). Scope doc: `.claude/plans/external-trigger-api-scope.md` §2.3–2.4, W2 row. **This is the security-critical PR of the wave** — the workflow HTTP API (W4) will sit directly on top of it and expose plan execution to untrusted external automation.

## The gap this closes

The DAG plan engine had no capability confinement on three of its step types. `LlmCall` was already safe by delegation (it routes through the governed agent turn, which is envelope-aware when an envelope is ambient), but `ToolUse` consulted only the static per-tool sandbox profile — never the governor, never the envelope — and `Retrieval` called the retriever directly. `SubPlanInvocation` recursed and inherited the gap. Shipping a workflow endpoint without this would have made a plan's `ToolUse` step remote tool execution outside the envelope: precisely the confinement bundles have, absent.

## What this adds

- **A single arming site.** New `IPlanRunExecutor` is the one place a plan run arms the capability envelope and governance identity, modelled on the `IBundleRunExecutor` doctrine. Identity is initialized *before* the envelope (the governor fails closed on identity-less enveloped calls, by design), and both are released in a `using` scope covering the fully-materialized run. `PlanRunRequest` marks envelope and identity `required`, so the record cannot express an ungoverned run.
- **The three gapped step types now authorize** through the same choke point the live agent path uses, so the envelope allowlist, graded-autonomy risk gate, policy engine, audit trail, and fail-closed identity handling all come for free and cannot drift from the bundle path.
- **The envelope's autonomy ceiling** is applied against step `RequiredAutonomyLevel` at one scheduler choke point before executor dispatch.

**Absent-envelope posture:** the new run-executor path is fail-closed (`plan_run.envelope_required` / `plan_run.agent_identity_required` before any plan state is touched). Every new check in the engine is conditioned on an envelope actually being present, so direct in-process `IPlanExecutor` callers are unchanged. One caveat worth stating plainly: a host that enables global `EnforceToolInvocation` now also governs in-process plan `ToolUse` steps that were previously never authorized. That is the opt-in working as intended, but it is a behaviour change for that configuration.

## What the security review changed

**Retrieval was exempt from the autonomy ceiling** while every other capability was subject to it. My original justification for the hand-rolled check — that the permission resolver has no rules for non-tools — was checked and is **factually wrong**: the rule provider emits a baseline rule for every name in `AllowedTools` with behaviour derived from the ceiling, and unmatched names default to Ask, which the governor turns into a fail-closed block. So an envelope of `{AllowedTools: [rag_retrieval, file_system], AutonomyCeiling: Restricted}` blocked every tool while running every retrieval, with the assembled corpus context readable back from plan status — and produced no decision record, no governance trace, no audit line, and no denial-rate accounting. Fixed by deleting the special case and routing through the governor exactly as `ToolUse` does. The pseudo-tool name resolves to a permissive profile (no required capabilities), so no risk-table registration is needed; it is deliberately *not* registered, because that would publish these names on the agent's callable tool surface — a strictly larger change than the fail-safe default, which can only tighten.

**A plan could launder a security denial into a successful run.** `RetryPolicy.OnExhausted` is plan-authored data, so a plan could mark the very step the ceiling denied as `SkipStep`; recovery marked it skipped, the summary saw no failure, and the run reported `Completed`. Skip is acceptable for a *transient* failure, not for a *policy* denial — the plan author would be choosing the disposition of the check that constrains the plan author. Denials now carry `IsPolicyDenial` and route to a terminal path that bypasses the retry budget entirely, mirroring the existing rejected-block handling. This also kills an escalation treadmill (approve, re-run, deny, new escalation — with an un-actionable request for the approver).

**Raw exception text was persisted into step state and would have surfaced through W4's status reads.** The run executor scrubbed its own top-level exception, but that was defeated one layer down — every per-step failure wrote `ex.Message` into the persisted step error, and sandbox, EF Core, and HTTP-client messages carry file paths, connection strings, and SAS tokens. Replaced with stable codes at all five sites; tests now throw exceptions containing a fake SAS token and a connection-string password and assert neither reaches the persisted error.

**`LlmCall` steps were unconfined, and the root cause was worse than the review found.** A caller holding the most restrictive possible envelope could still drive unbounded model calls with a plan-authored system prompt on the host's credential. Investigating it surfaced the real defect: the conversation budget *was* enforced, but the executor never set `ConversationId`, so the default `Guid.NewGuid()` gave every step its own fresh budget — an N-step plan spent N full budgets. Now gated on an `LlmCall` grant through the same governor and keyed to the run's ambient conversation id with a pre-dispatch exhaustion check. **This extends the original scope**, which said "no changes to the LlmCall path"; that exclusion meant don't re-gate its tool authorization, and an unconfined unbounded-spend path defeats this PR's stated purpose.

**`IPlanExecutor` stayed injectable** beside `IPlanRunExecutor`, so the W4 controller could take the ungoverned interface and evaporate this entire layer with no runtime signal. XML docs saying "don't" is not a control; an architecture test now scans the Presentation tree and fails on any reference, throwing rather than passing vacuously if the tree cannot be located.

## Open decision for W3/W4, flagged not decided

A sub-plan can invoke any **global** (`OwnerId == null`) plan. Cross-*owner* references correctly 404-as-absent, so W1's scope filter does hold, and every step inside stays envelope-confined — this is "run someone's shared plan shape under your own grant", not data exfiltration. But *visible* and *executable* are different rights and the engine currently conflates them. Recommendation is readable-but-not-executable; recorded here rather than decided unilaterally inside the engine.

## Known flaky test, disclosed

`Application.Common.Tests` → `StructuredJsonLoggerProviderTests` fails intermittently under full-solution parallel load (it captures process-global console state). It passes 199/199 in isolation, this PR's diff touches no file in that project, and it was independently reproduced failing 2 of 3 runs on a stashed clean baseline. Warrants a separate ticket, not attribution here.

## Test plan

- 15 new tests: arming/disarming under exception and cancellation, denied tool stays denied inside a sub-plan (real governor + resolver + rule provider, not mocks), Restricted ceiling now denies granted retrieval, ceiling-denied step with `SkipStep` yields a FAILED plan, escalation never queued for a policy denial, secret-bearing exception text never reaches persisted step errors, `AgentId` guard against glob/traversal/newline-injection shapes, Presentation-boundary scan.
- `dotnet build src/AgenticHarness.slnx` — 0 errors, 0 new warnings.
- `dotnet test src/AgenticHarness.slnx` — all 21 projects green (excepting the disclosed pre-existing flake).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BnoLcufW278UxA9ssBM1Tc
