### PR TITLE
feat: durable escalation and change-proposal state (H5)

### DIFF
--- a/src/Content/Application/Application.AI.Common/Exceptions/EscalationDurableStateException.cs
+++ b/src/Content/Application/Application.AI.Common/Exceptions/EscalationDurableStateException.cs
@@ -1,0 +1,46 @@
+using Application.Common.Exceptions;
+
+namespace Application.AI.Common.Exceptions;
+
+/// <summary>
+/// Thrown when a durable governance-state write fails and the escalation service must fail
+/// closed. Carries a stable, scrubbed <see cref="Code"/> instead of the provider's exception
+/// text, so nothing from the data layer (connection strings, file paths, SQL fragments) can
+/// reach an HTTP response through the MediatR pipeline's rethrow path.
+/// </summary>
+/// <remarks>
+/// The originating exception is preserved as <see cref="Exception.InnerException"/> for
+/// structured logging at the throw site, never for display. Callers that surface failures to
+/// a caller should map <see cref="Code"/>, not <see cref="Exception.Message"/>.
+/// </remarks>
+public sealed class EscalationDurableStateException : ApplicationExceptionBase
+{
+    /// <summary>
+    /// A decision could not be durably recorded. The decision was not accepted; the approver
+    /// may retry once the store recovers.
+    /// </summary>
+    public const string DurableWriteFailedCode = "escalation.durable_write_failed";
+
+    /// <summary>
+    /// A resolution could not be durably recorded. The escalation is not reported resolved and
+    /// stays observable for the reconciler.
+    /// </summary>
+    public const string DurableResolutionFailedCode = "escalation.durable_resolution_failed";
+
+    /// <summary>
+    /// An escalation could not be durably created, so it was not opened.
+    /// </summary>
+    public const string DurableCreateFailedCode = "escalation.durable_create_failed";
+
+    /// <summary>Initializes a new instance with a stable code and the originating exception.</summary>
+    /// <param name="code">One of the <c>escalation.*</c> constants on this type.</param>
+    /// <param name="innerException">The provider exception, preserved for logging only.</param>
+    public EscalationDurableStateException(string code, Exception? innerException = null)
+        : base(code, innerException)
+    {
+        Code = code;
+    }
+
+    /// <summary>The stable, scrubbed error code safe to surface to a caller.</summary>
+    public string Code { get; }
+}

--- a/src/Content/Application/Application.AI.Common/Interfaces/Escalation/EscalationPersistedStatus.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Escalation/EscalationPersistedStatus.cs
@@ -1,0 +1,40 @@
+namespace Application.AI.Common.Interfaces.Escalation;
+
+/// <summary>
+/// Lifecycle status of a durably persisted escalation record in the governance-state store.
+/// Distinct from the in-memory resolution flags: this status exists to make the
+/// "resolved but not yet durably audited" window detectable and recoverable after a crash.
+/// </summary>
+public enum EscalationPersistedStatus
+{
+    /// <summary>
+    /// The escalation is open: decidable, listable, and cancellable. Rehydrated into the
+    /// active in-memory set on startup.
+    /// </summary>
+    Pending = 0,
+
+    /// <summary>
+    /// A resolution (decision, timeout, or cancellation) was reached and durably recorded,
+    /// but the fail-closed compliance audit write did not complete. The escalation must not
+    /// be reported as resolved; it is the stuck state the
+    /// <see cref="IEscalationReconciler"/> detects and re-drives once the audit store
+    /// recovers.
+    /// </summary>
+    ResolvedPendingAudit = 1,
+
+    /// <summary>
+    /// Terminal: the resolution has been durably audited. The outcome is queryable via
+    /// <see cref="IEscalationStateStore.GetResolvedOutcomeAsync"/> even after a restart.
+    /// </summary>
+    Resolved = 2,
+
+    /// <summary>
+    /// A reconcile pass has claimed this record and is re-driving its audit write. The claim
+    /// is what stops two concurrent passes — a timer tick and an operator-triggered run —
+    /// from both writing the compliance line and both firing the resolution notification.
+    /// A pass that crashes mid-claim leaves the record here; the next pass's
+    /// <see cref="IEscalationStateStore.ReleaseClaimAsync"/> sweep returns it to
+    /// <see cref="ResolvedPendingAudit"/> so it stays recoverable rather than stranded.
+    /// </summary>
+    AuditInFlight = 3
+}

--- a/src/Content/Application/Application.AI.Common/Interfaces/Escalation/EscalationReconcileResult.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Escalation/EscalationReconcileResult.cs
@@ -1,0 +1,21 @@
+namespace Application.AI.Common.Interfaces.Escalation;
+
+/// <summary>
+/// The outcome of one <see cref="IEscalationReconciler.ReconcileStuckEscalationsAsync"/> pass.
+/// </summary>
+public sealed record EscalationReconcileResult
+{
+    /// <summary>
+    /// Escalations whose stuck resolution was successfully finalized this pass: the audit
+    /// write was re-driven, the durable record moved to terminal, and the outcome became
+    /// observable to pollers.
+    /// </summary>
+    public required IReadOnlyList<Guid> Recovered { get; init; }
+
+    /// <summary>
+    /// Escalations that were detected as stuck but could not be finalized (typically the
+    /// audit store is still failing). They remain in the stuck state and will be picked up
+    /// by a future reconcile pass; nothing is lost.
+    /// </summary>
+    public required IReadOnlyList<Guid> StillStuck { get; init; }
+}

--- a/src/Content/Application/Application.AI.Common/Interfaces/Escalation/EscalationRequestInvariants.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Escalation/EscalationRequestInvariants.cs
@@ -1,0 +1,92 @@
+using Domain.AI.Escalation;
+
+namespace Application.AI.Common.Interfaces.Escalation;
+
+/// <summary>
+/// The creation-time invariants every escalation must satisfy before it may become live and
+/// decidable. Extracted so the durable rehydration path enforces exactly the same rules the
+/// in-process creation path does.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Rehydration reads from a SQLite file — untrusted input, not a value this process just
+/// constructed. Without these checks a hand-edited or corrupted row could produce a live
+/// escalation that violates an invariant the creation path deliberately fail-closes on:
+/// </para>
+/// <list type="bullet">
+///   <item><description>
+///     An <b>empty approver roster</b> can never be legitimately approved, yet the AllOf
+///     strategy treats "nobody pending" as vacuously unanimous and a timeout action of
+///     <c>Approve</c> would then grant it silently.
+///   </description></item>
+///   <item><description>
+///     A <b>Quorum threshold of zero</b> (or one exceeding the roster size) is the same
+///     failure in a different shape: either instantly satisfied by no votes, or impossible.
+///   </description></item>
+///   <item><description>
+///     A <b>timeout beyond <see cref="MaxTimeoutSeconds"/></b> overflows
+///     <see cref="TimeSpan"/>-based delays; the resulting throw is swallowed by the timeout
+///     loop's catch-all and the escalation becomes immortal — pending forever with no
+///     expiry.
+///   </description></item>
+/// </list>
+/// </remarks>
+public static class EscalationRequestInvariants
+{
+    /// <summary>
+    /// Upper bound on <see cref="EscalationRequest.TimeoutSeconds"/>, in seconds (~24 days).
+    /// Comfortably below the ~49.7-day ceiling at which a delay overflows, with room for the
+    /// deadline arithmetic that resumes a rehydrated escalation's original budget.
+    /// </summary>
+    public const int MaxTimeoutSeconds = 24 * 24 * 60 * 60;
+
+    /// <summary>
+    /// Validates an escalation request against every creation-time invariant.
+    /// </summary>
+    /// <param name="request">The request to validate.</param>
+    /// <param name="violation">
+    /// On failure, a short operator-readable description of the first violated invariant;
+    /// null on success.
+    /// </param>
+    /// <returns>True when the request may become a live escalation.</returns>
+    public static bool TryValidate(EscalationRequest request, out string? violation)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        if (request.Approvers.Count == 0)
+        {
+            violation = "the approver roster is empty, so the escalation could never be approved";
+            return false;
+        }
+
+        if (request.Approvers.Any(string.IsNullOrWhiteSpace))
+        {
+            violation = "the approver roster contains a blank identity";
+            return false;
+        }
+
+        if (request.ApprovalStrategy == ApprovalStrategyType.Quorum &&
+            (request.QuorumThreshold <= 0 || request.QuorumThreshold > request.Approvers.Count))
+        {
+            violation =
+                $"the Quorum threshold ({request.QuorumThreshold}) is outside 1..{request.Approvers.Count}";
+            return false;
+        }
+
+        if (request.TimeoutSeconds < 0)
+        {
+            violation = $"the timeout ({request.TimeoutSeconds}s) is negative";
+            return false;
+        }
+
+        if (request.TimeoutSeconds > MaxTimeoutSeconds)
+        {
+            violation =
+                $"the timeout ({request.TimeoutSeconds}s) exceeds the maximum of {MaxTimeoutSeconds}s";
+            return false;
+        }
+
+        violation = null;
+        return true;
+    }
+}

--- a/src/Content/Application/Application.AI.Common/Interfaces/Escalation/EscalationStateSnapshot.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Escalation/EscalationStateSnapshot.cs
@@ -1,0 +1,39 @@
+using Domain.AI.Escalation;
+
+namespace Application.AI.Common.Interfaces.Escalation;
+
+/// <summary>
+/// A point-in-time view of one durably persisted escalation, as returned by
+/// <see cref="IEscalationStateStore.GetActiveAsync"/>. Carries everything the escalation
+/// service needs to rehydrate a pending escalation after a restart (request, collected
+/// decisions, original creation instant for timeout resumption) or to finalize a stuck
+/// resolution (the pending outcome).
+/// </summary>
+public sealed record EscalationStateSnapshot
+{
+    /// <summary>The original escalation request, exactly as it was created.</summary>
+    public required EscalationRequest Request { get; init; }
+
+    /// <summary>
+    /// The approver decisions collected so far, in submission order. Empty for an
+    /// escalation nobody has decided on yet.
+    /// </summary>
+    public required IReadOnlyList<ApproverDecision> Decisions { get; init; }
+
+    /// <summary>
+    /// When the escalation was created by the service. Timeout resumption after a restart
+    /// is computed from this instant, so downtime counts against the escalation's timeout
+    /// budget rather than resetting it.
+    /// </summary>
+    public required DateTimeOffset CreatedAt { get; init; }
+
+    /// <summary>The persisted lifecycle status of the record.</summary>
+    public required EscalationPersistedStatus Status { get; init; }
+
+    /// <summary>
+    /// The resolved outcome, present only when <see cref="Status"/> is
+    /// <see cref="EscalationPersistedStatus.ResolvedPendingAudit"/> (awaiting the audit
+    /// re-drive) — <see cref="EscalationPersistedStatus.Pending"/> records have none.
+    /// </summary>
+    public EscalationOutcome? Outcome { get; init; }
+}

--- a/src/Content/Application/Application.AI.Common/Interfaces/Escalation/GovernanceRecordSeal.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Escalation/GovernanceRecordSeal.cs
@@ -1,0 +1,34 @@
+namespace Application.AI.Common.Interfaces.Escalation;
+
+/// <summary>
+/// The tamper-evident seal persisted alongside a durable governance record (a resolved
+/// escalation outcome or a change proposal): the signature, the identifier of the key that
+/// produced it (so a rotated key set can still verify historical rows), and the hash fields
+/// the signature was computed over.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The hash fields are carried rather than recomputed at verification time so the sealer never
+/// has to replicate the signing implementation's hash encoding — a silent mismatch there would
+/// make every verification fail closed and strand every parked record. Carrying them is not a
+/// weakness: the signature covers those fields, so editing a stored hash to match a forged
+/// payload invalidates the signature.
+/// </para>
+/// <para>
+/// <b><see cref="InputHash"/> binds the record's identity.</b> It is the hash of the subject id
+/// (the escalation id or proposal id), which makes a seal valid for exactly one row. Without
+/// that binding a seal is portable: an attacker could copy a legitimately approved record's
+/// payload and seal verbatim into a different row, and every byte would still verify.
+/// </para>
+/// </remarks>
+/// <param name="Signature">The signature over the sealed payload.</param>
+/// <param name="KeyVersion">The version identifier of the signing key.</param>
+/// <param name="SignedAt">When the seal was produced. Part of the signed payload.</param>
+/// <param name="InputHash">The signing implementation's hash of the subject id this seal is bound to.</param>
+/// <param name="OutputHash">The signing implementation's hash of the sealed payload.</param>
+public sealed record GovernanceRecordSeal(
+    string Signature,
+    string KeyVersion,
+    DateTimeOffset SignedAt,
+    string InputHash,
+    string OutputHash);

--- a/src/Content/Application/Application.AI.Common/Interfaces/Escalation/IEscalationReconciler.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Escalation/IEscalationReconciler.cs
@@ -1,0 +1,40 @@
+namespace Application.AI.Common.Interfaces.Escalation;
+
+/// <summary>
+/// Operator-facing recovery for escalations stuck in the "resolved but never audited" state.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>The defect this closes:</b> the escalation service's outcome audit write is fail-closed —
+/// when <see cref="IEscalationAuditStore.RecordOutcomeAsync"/> throws during decide, the
+/// decision is not reported accepted and the escalation deliberately stays in the active set.
+/// Before this interface existed, such an escalation was permanently wedged: every further
+/// decision echoed "recorded" without effect, the timeout had already fired or been consumed,
+/// and no operator surface could push it to completion.
+/// </para>
+/// <para>
+/// <see cref="ReconcileStuckEscalationsAsync"/> detects both stuck shapes — in-memory states
+/// whose resolution faulted on the audit write, and (when durable escalation state is enabled)
+/// persisted <c>ResolvedPendingAudit</c> records left behind by a crash — and re-drives the
+/// audit write for each. It is idempotent: an escalation is finalized at most once, a pass over
+/// a healthy system recovers nothing, and a pass while the audit store is still down simply
+/// reports the records as still stuck. Re-driving after a crash <i>may</i> append a duplicate
+/// outcome line to the append-only audit (when the crash landed between the audit write and the
+/// durable finalize) — a duplicate compliance record of the same verdict is the deliberate,
+/// safe trade against losing the verdict.
+/// </para>
+/// <para>
+/// This is intentionally a service-level mechanism, not an HTTP route: operators invoke it from
+/// host tooling (console command, scheduled job, or admin script) via DI.
+/// </para>
+/// </remarks>
+public interface IEscalationReconciler
+{
+    /// <summary>
+    /// Scans for escalations whose resolution was reached but never durably audited, re-drives
+    /// the audit write for each, and finalizes the ones that succeed.
+    /// </summary>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Which escalations were recovered and which remain stuck.</returns>
+    Task<EscalationReconcileResult> ReconcileStuckEscalationsAsync(CancellationToken ct);
+}

--- a/src/Content/Application/Application.AI.Common/Interfaces/Escalation/IEscalationStateStore.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Escalation/IEscalationStateStore.cs
@@ -1,0 +1,140 @@
+using Domain.AI.Escalation;
+
+namespace Application.AI.Common.Interfaces.Escalation;
+
+/// <summary>
+/// Durable persistence for in-flight escalation state, so pending escalations survive host
+/// restarts. Complements — never replaces — the append-only <see cref="IEscalationAuditStore"/>:
+/// the audit store is the compliance record; this store is the recoverable working state.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Failure contract:</b> every write is fail-closed at the call site. Implementations
+/// signal failure by throwing; the escalation service translates a throw into "the operation
+/// was not accepted" (an escalation that cannot be durably created is not created; a decision
+/// that cannot be durably recorded is not reported recorded). The no-op
+/// <c>NullEscalationStateStore</c> is registered when durable escalation state is disabled,
+/// which preserves the in-memory-only behavior exactly.
+/// </para>
+/// <para>
+/// <b>What durability cannot restore:</b> in-process waiters. A caller blocked inside
+/// <c>IEscalationService.RequestEscalationAsync</c> holds a
+/// <see cref="System.Threading.Tasks.TaskCompletionSource"/> that dies with the process. After a
+/// restart the escalation record is rehydrated as pending (decidable, listable, cancellable) and
+/// its outcome is durably queryable, but no code is released by the eventual decision — the
+/// resumed workflow must poll <c>IEscalationService.GetOutcomeAsync</c>, as the plan executor's
+/// resume path already does.
+/// </para>
+/// <para>
+/// Idempotency: <see cref="SavePendingAsync"/> and <see cref="MarkResolvedPendingAuditAsync"/>
+/// are upserts keyed by escalation id; repeating a call with the same payload is a no-op-equivalent.
+/// This is what makes the reconciler's re-drive safe to run repeatedly.
+/// </para>
+/// </remarks>
+public interface IEscalationStateStore
+{
+    /// <summary>
+    /// Persists a newly created escalation as <see cref="EscalationPersistedStatus.Pending"/>
+    /// with an empty decision list. Upserts on the escalation id.
+    /// </summary>
+    /// <param name="request">The escalation request to persist.</param>
+    /// <param name="createdAt">The service-side creation instant, used for timeout resumption.</param>
+    /// <param name="ct">Cancellation token.</param>
+    Task SavePendingAsync(EscalationRequest request, DateTimeOffset createdAt, CancellationToken ct);
+
+    /// <summary>
+    /// Replaces the persisted decision list for a pending escalation with the given snapshot.
+    /// Throws when no record exists for <paramref name="escalationId"/> — a decision must never
+    /// be durably recorded against an escalation that was never durably created.
+    /// </summary>
+    /// <param name="escalationId">The escalation whose decisions changed.</param>
+    /// <param name="decisions">The full decision list after the change, in submission order.</param>
+    /// <param name="ct">Cancellation token.</param>
+    Task SaveDecisionsAsync(Guid escalationId, IReadOnlyList<ApproverDecision> decisions, CancellationToken ct);
+
+    /// <summary>
+    /// Records that a resolution was reached, moving the record to
+    /// <see cref="EscalationPersistedStatus.ResolvedPendingAudit"/> with the outcome attached.
+    /// Called <i>before</i> the fail-closed audit write so that an audit outage leaves a
+    /// detectable stuck state instead of a silently lost verdict. Idempotent upsert on the
+    /// escalation id.
+    /// </summary>
+    /// <param name="outcome">The resolved outcome.</param>
+    /// <param name="ct">Cancellation token.</param>
+    Task MarkResolvedPendingAuditAsync(EscalationOutcome outcome, CancellationToken ct);
+
+    /// <summary>
+    /// Marks the record terminal (<see cref="EscalationPersistedStatus.Resolved"/>) after the
+    /// audit write succeeded. From this point the outcome is served by
+    /// <see cref="GetResolvedOutcomeAsync"/> and the record is excluded from
+    /// <see cref="GetActiveAsync"/>.
+    /// </summary>
+    /// <param name="escalationId">The escalation to finalize.</param>
+    /// <param name="ct">Cancellation token.</param>
+    Task MarkResolvedAsync(Guid escalationId, CancellationToken ct);
+
+    /// <summary>
+    /// Deletes the record for an escalation that was abandoned before resolution (the blocking
+    /// caller cancelled). No-op when the record does not exist.
+    /// </summary>
+    /// <param name="escalationId">The escalation to remove.</param>
+    /// <param name="ct">Cancellation token.</param>
+    Task RemoveAsync(Guid escalationId, CancellationToken ct);
+
+    /// <summary>
+    /// Atomically claims a <see cref="EscalationPersistedStatus.ResolvedPendingAudit"/> record
+    /// for re-drive, moving it to <see cref="EscalationPersistedStatus.AuditInFlight"/>.
+    /// </summary>
+    /// <remarks>
+    /// This is the concurrency control for reconciliation. Without it, a scheduled pass and an
+    /// operator-triggered pass that overlap would each re-drive the same record: a duplicate
+    /// compliance audit line is tolerable, but a duplicate resolution notification — which
+    /// fans out to the drift/AG-UI bridge — is not. Implementations must make the
+    /// read-and-transition a single conditional statement, not a read followed by a write.
+    /// </remarks>
+    /// <param name="escalationId">The escalation to claim.</param>
+    /// <param name="staleClaimBefore">
+    /// Cutoff for reclaiming an abandoned claim. A record already in
+    /// <see cref="EscalationPersistedStatus.AuditInFlight"/> whose last update predates this
+    /// instant is treated as orphaned and may be claimed. Without this, a pass killed between
+    /// claiming and finishing (kill -9, OOM, pod eviction) never releases its claim, and the
+    /// record becomes permanently unclaimable — invisible to every later pass and untouchable
+    /// by the pruner, which correctly refuses to delete non-terminal rows. The bound is what
+    /// prevents a merely-slow live pass from having its claim stolen.
+    /// </param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>True when this caller now owns the re-drive; false when someone else does.</returns>
+    Task<bool> TryClaimResolvedPendingAuditAsync(
+        Guid escalationId, DateTimeOffset staleClaimBefore, CancellationToken ct);
+
+    /// <summary>
+    /// Returns a claimed record to <see cref="EscalationPersistedStatus.ResolvedPendingAudit"/>
+    /// after a failed re-drive, so a future pass can retry it. No-op when the record is not
+    /// currently claimed.
+    /// </summary>
+    /// <param name="escalationId">The escalation whose claim to release.</param>
+    /// <param name="ct">Cancellation token.</param>
+    Task ReleaseClaimAsync(Guid escalationId, CancellationToken ct);
+
+    /// <summary>
+    /// Returns all non-terminal records: <see cref="EscalationPersistedStatus.Pending"/> ones
+    /// (rehydrated into the active set on startup) and
+    /// <see cref="EscalationPersistedStatus.ResolvedPendingAudit"/> ones (finalized by the
+    /// reconciler). Implementations skip and log records that fail to deserialize rather than
+    /// failing the whole read — one poisoned row must not block startup recovery of the rest.
+    /// </summary>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Snapshots of every non-terminal escalation, unordered.</returns>
+    Task<IReadOnlyList<EscalationStateSnapshot>> GetActiveAsync(CancellationToken ct);
+
+    /// <summary>
+    /// Returns the durably audited outcome for an escalation, or null when the escalation is
+    /// unknown, still pending, or resolved-but-not-yet-audited. Deliberately excludes
+    /// <see cref="EscalationPersistedStatus.ResolvedPendingAudit"/> records: an outcome whose
+    /// audit write has not completed must never be observable (fail-closed).
+    /// </summary>
+    /// <param name="escalationId">The escalation to look up.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The audited outcome, or null.</returns>
+    Task<EscalationOutcome?> GetResolvedOutcomeAsync(Guid escalationId, CancellationToken ct);
+}

--- a/src/Content/Application/Application.AI.Common/Interfaces/Escalation/IGovernanceRecordSealer.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Escalation/IGovernanceRecordSealer.cs
@@ -1,0 +1,62 @@
+namespace Application.AI.Common.Interfaces.Escalation;
+
+/// <summary>
+/// Seals a persisted governance record — a resolved escalation outcome or a change proposal —
+/// with a tamper-evident signature bound to that record's identity, and verifies the seal
+/// before the record is ever acted upon again.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The threat this closes: the durable governance-state database is a file. The reconciler
+/// re-drives a stored outcome into <see cref="IEscalationAuditStore.RecordOutcomeAsync"/> — the
+/// hash-chained compliance log — and the plan executor branches a human gate on a stored
+/// verdict. Without a seal, flipping <c>"IsApproved": true</c> in a row would launder a forged
+/// human approval into that log with a valid chain hash. The chain proves the log was not
+/// edited after the fact; it cannot prove what was fed in.
+/// </para>
+/// <para>
+/// <b>Every seal is bound to its record's id via <c>subjectId</c>.</b> Sealing the payload alone
+/// is not enough: the payload of a legitimately approved record could be copied verbatim into
+/// another row and would verify byte-for-byte, so one real approval would approve everything
+/// after it. Binding the id makes a seal valid for exactly one row. Callers must additionally
+/// check that the identity <em>inside</em> the deserialized payload matches the row it was
+/// loaded from — the two checks close different halves of the same hole.
+/// </para>
+/// <para>
+/// The default implementation delegates to the same HMAC key material the sandbox attestation
+/// path uses (User Secrets / Key Vault, never appsettings), so enabling durable governance
+/// state carries the attestation keys as a documented prerequisite. Verification is
+/// fail-closed: a record whose seal is absent, malformed, non-matching, or bound to a different
+/// subject is quarantined rather than used.
+/// </para>
+/// </remarks>
+public interface IGovernanceRecordSealer
+{
+    /// <summary>
+    /// Produces a seal over the exact serialized payload about to be persisted, bound to the
+    /// record's identity.
+    /// </summary>
+    /// <param name="subjectId">
+    /// The record's stable identity — an escalation id or a change-proposal id. Becomes part of
+    /// the signed payload, so the resulting seal is valid only for this record.
+    /// </param>
+    /// <param name="payloadJson">The serialized record, byte-for-byte as it will be stored.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The seal to persist alongside the payload.</returns>
+    Task<GovernanceRecordSeal> SealAsync(string subjectId, string payloadJson, CancellationToken ct);
+
+    /// <summary>
+    /// Verifies that <paramref name="payloadJson"/> is exactly what <paramref name="seal"/> was
+    /// produced over, <em>and</em> that the seal was issued for <paramref name="subjectId"/>.
+    /// </summary>
+    /// <param name="subjectId">The identity of the record being verified.</param>
+    /// <param name="payloadJson">The payload as currently stored.</param>
+    /// <param name="seal">The persisted seal, or null when the row carries none.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>
+    /// True only when a seal is present, was issued for this subject, and verifies against this
+    /// exact payload. A null, mis-bound, or unverifiable seal returns false — never treated as
+    /// "not sealed, therefore fine".
+    /// </returns>
+    Task<bool> VerifyAsync(string subjectId, string payloadJson, GovernanceRecordSeal? seal, CancellationToken ct);
+}

--- a/src/Content/Application/Application.AI.Common/Interfaces/Escalation/IGovernanceStatePruner.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Escalation/IGovernanceStatePruner.cs
@@ -1,0 +1,36 @@
+namespace Application.AI.Common.Interfaces.Escalation;
+
+/// <summary>
+/// Retention for the durable governance-state store. Terminal records — resolved escalations
+/// and closed change proposals — accumulate forever otherwise; this deletes those older than
+/// the configured retention window.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Deliberately a separate contract rather than methods on <c>IEscalationStateStore</c> and
+/// <c>IChangeProposalStore</c>: retention spans both tables, is an operator concern rather
+/// than a workflow concern, and <c>IChangeProposalStore</c> is a shared contract this work is
+/// not permitted to widen.
+/// </para>
+/// <para>
+/// Only terminal rows are eligible. A pending escalation or an in-flight proposal is never
+/// pruned regardless of age — losing one would strand an approval, which is the exact failure
+/// the durable store exists to prevent. Compliance history is unaffected: the JSONL audit
+/// stores are the retained record, and this prunes only the recoverable working state.
+/// </para>
+/// </remarks>
+public interface IGovernanceStatePruner
+{
+    /// <summary>
+    /// Deletes terminal governance-state records last updated before <paramref name="cutoff"/>.
+    /// </summary>
+    /// <param name="cutoff">Records older than this instant are eligible for deletion.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>How many rows were removed from each table.</returns>
+    Task<GovernanceStatePruneResult> PruneAsync(DateTimeOffset cutoff, CancellationToken ct);
+}
+
+/// <summary>The row counts removed by one <see cref="IGovernanceStatePruner.PruneAsync"/> pass.</summary>
+/// <param name="EscalationsRemoved">Terminal escalation-state rows deleted.</param>
+/// <param name="ChangeProposalsRemoved">Terminal change-proposal rows deleted.</param>
+public sealed record GovernanceStatePruneResult(int EscalationsRemoved, int ChangeProposalsRemoved);

--- a/src/Content/Application/Application.Core/CQRS/Escalation/SubmitEscalationDecisionCommandHandler.cs
+++ b/src/Content/Application/Application.Core/CQRS/Escalation/SubmitEscalationDecisionCommandHandler.cs
@@ -11,10 +11,13 @@ namespace Application.Core.CQRS.Escalation;
 /// and submits it via <see cref="IEscalationService.SubmitDecisionAsync"/>. The service's
 /// discriminated statuses — unknown, not-authorized, recorded, resolved — are returned as data,
 /// not failure: each is an expected, reportable outcome that the controller maps to its
-/// documented HTTP status. The one exception is
-/// <see cref="EscalationDecisionStatus.ConflictingDecision"/> (same approver, opposite verdict),
-/// which is a genuine request conflict and is translated to a
-/// <see cref="Result{T}.Conflict"/> failure so the shared failure mapper produces the 409.
+/// documented HTTP status. The exceptions are the two conflict shapes —
+/// <see cref="EscalationDecisionStatus.ConflictingDecision"/> (same approver, opposite verdict) and
+/// <see cref="EscalationDecisionStatus.AwaitingReconciliation"/> (a verdict was already reached but
+/// its durable record could not be written) — which are genuine request conflicts and are translated
+/// here to a <see cref="Result{T}.Conflict"/> failure so the shared failure mapper produces the 409.
+/// Translating in the Application layer, rather than in a controller, keeps the outcome available to
+/// consumers that never touch HTTP.
 /// </summary>
 public sealed class SubmitEscalationDecisionCommandHandler
     : IRequestHandler<SubmitEscalationDecisionCommand, Result<SubmitEscalationDecisionResult>>
@@ -52,13 +55,31 @@ public sealed class SubmitEscalationDecisionCommandHandler
             "Escalation decision: EscalationId={EscalationId}, Approver={ApproverName}, Approve={Approve}, Status={Status}",
             request.EscalationId, request.ApproverName, request.Approve, result.Status);
 
-        if (result.Status == EscalationDecisionStatus.ConflictingDecision)
+        // Both conflict shapes are translated here rather than at any one transport. The statuses are
+        // transport-neutral by design, so a non-HTTP consumer (the console approvals example) would
+        // otherwise inherit nothing from an HTTP-only mapping.
+        var conflictDetail = result.Status switch
         {
-            return Result<SubmitEscalationDecisionResult>.Conflict(
-                "A decision by this approver with the opposite verdict is already recorded; votes cannot be changed.");
-        }
+            EscalationDecisionStatus.ConflictingDecision =>
+                "A decision by this approver with the opposite verdict is already recorded; " +
+                "votes cannot be changed.",
 
-        return Result<SubmitEscalationDecisionResult>.Success(
-            SubmitEscalationDecisionResult.FromDecisionResult(result));
+            // A conflict, not transient unavailability: the escalation already reached a verdict
+            // before this vote arrived, so the vote was NOT counted and never will be — retrying is
+            // guaranteed to produce the same answer. The verdict itself is not lost; reconciliation
+            // re-drives it.
+            EscalationDecisionStatus.AwaitingReconciliation =>
+                "The escalation had already reached a verdict whose durable record could not be " +
+                "written, so it is parked awaiting reconciliation. This decision was not counted " +
+                "and will not be; retrying it will not change that. Poll the escalation by id for " +
+                "the final outcome.",
+
+            _ => null
+        };
+
+        return conflictDetail is not null
+            ? Result<SubmitEscalationDecisionResult>.Conflict(conflictDetail)
+            : Result<SubmitEscalationDecisionResult>.Success(
+                SubmitEscalationDecisionResult.FromDecisionResult(result));
     }
 }

--- a/src/Content/Domain/Domain.AI/Escalation/EscalationDecisionResult.cs
+++ b/src/Content/Domain/Domain.AI/Escalation/EscalationDecisionResult.cs
@@ -37,6 +37,8 @@ public sealed record EscalationDecisionResult
         new() { Status = EscalationDecisionStatus.DecisionRecorded };
     private static readonly EscalationDecisionResult ConflictingInstance =
         new() { Status = EscalationDecisionStatus.ConflictingDecision };
+    private static readonly EscalationDecisionResult AwaitingReconciliationInstance =
+        new() { Status = EscalationDecisionStatus.AwaitingReconciliation };
 
     /// <summary>Creates a result for a decision targeting an escalation that is not pending.</summary>
     public static EscalationDecisionResult UnknownEscalation() => UnknownInstance;
@@ -46,6 +48,13 @@ public sealed record EscalationDecisionResult
 
     /// <summary>Creates a result for a decision that was recorded but left the escalation unresolved.</summary>
     public static EscalationDecisionResult DecisionRecorded() => RecordedInstance;
+
+    /// <summary>
+    /// Creates a result for a decision submitted against an escalation that already resolved but
+    /// whose resolution could not be durably recorded, leaving it parked for reconciliation. The
+    /// decision was not recorded and did not participate in the verdict.
+    /// </summary>
+    public static EscalationDecisionResult AwaitingReconciliation() => AwaitingReconciliationInstance;
 
     /// <summary>
     /// Creates a result for a decision rejected because the same approver already recorded the

--- a/src/Content/Domain/Domain.AI/Escalation/EscalationDecisionStatus.cs
+++ b/src/Content/Domain/Domain.AI/Escalation/EscalationDecisionStatus.cs
@@ -46,5 +46,16 @@ public enum EscalationDecisionStatus
     /// This decision resolved the escalation. <see cref="EscalationDecisionResult.Outcome"/>
     /// carries the final <see cref="EscalationOutcome"/>. Maps naturally to HTTP 200.
     /// </summary>
-    Resolved
+    Resolved,
+
+    /// <summary>
+    /// The escalation already reached a resolution that could not be durably recorded (the
+    /// compliance audit or durable-state write failed), so it is parked awaiting an operator
+    /// reconcile pass. This decision was <em>not</em> recorded and did not participate — the
+    /// verdict was already decided before it arrived. Reporting
+    /// <see cref="DecisionRecorded"/> here would tell an approver their vote counted when it
+    /// was discarded. Poll <c>IEscalationService.GetOutcomeAsync</c>; the verdict becomes
+    /// observable once reconciliation completes. Maps naturally to HTTP 409 or 503.
+    /// </summary>
+    AwaitingReconciliation
 }

--- a/src/Content/Domain/Domain.AI/Escalation/EscalationDecisionStatus.cs
+++ b/src/Content/Domain/Domain.AI/Escalation/EscalationDecisionStatus.cs
@@ -55,7 +55,15 @@ public enum EscalationDecisionStatus
     /// verdict was already decided before it arrived. Reporting
     /// <see cref="DecisionRecorded"/> here would tell an approver their vote counted when it
     /// was discarded. Poll <c>IEscalationService.GetOutcomeAsync</c>; the verdict becomes
-    /// observable once reconciliation completes. Maps naturally to HTTP 409 or 503.
+    /// observable once reconciliation completes — <c>EscalationReconciliationService</c> drives
+    /// that pass on every host, including hosts with durable governance state switched off,
+    /// because this parked state is produced by an <em>audit</em>-store failure and is therefore
+    /// independent of the durability toggles.
+    /// <para>
+    /// Maps to HTTP 409, not 503: the verdict is already decided, so this vote will never be
+    /// counted no matter how often the request is retried. That is a state conflict, not the
+    /// transient unavailability a 503 advertises.
+    /// </para>
     /// </summary>
     AwaitingReconciliation
 }

--- a/src/Content/Domain/Domain.Common/Config/AI/Governance/GovernanceDurableStateConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/Governance/GovernanceDurableStateConfig.cs
@@ -1,0 +1,101 @@
+namespace Domain.Common.Config.AI.Governance;
+
+/// <summary>
+/// Configuration for the durable governance-state store: SQLite-backed persistence of
+/// pending escalations and change proposals so they survive host restarts.
+/// Bound from <c>AppConfig:AI:Governance:DurableState</c> in appsettings.json.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Both toggles default to <c>false</c> — the template ships with the current in-memory
+/// behavior unchanged. When a toggle is off, the corresponding subsystem never touches the
+/// database and no file or directory is created.
+/// </para>
+/// <para>
+/// <b>The toggles are read once, at first service resolution.</b> Durability is a topology
+/// property, not a live tunable: flipping a toggle at runtime would split state between the
+/// in-memory and durable stores (records created before the flip would be invisible to the
+/// other side). Changing either value requires a host restart to take effect.
+/// </para>
+/// <para>
+/// What durability does and does not restore: pending escalations and proposals are
+/// rehydrated on startup as pending — listable, decidable, and cancellable. In-process
+/// waiters (an agent turn blocked on <c>RequestEscalationAsync</c>) are
+/// <see cref="System.Threading.Tasks.TaskCompletionSource"/> instances and cannot survive a
+/// restart; the blocked turn is gone, but the escalation record remains actionable and its
+/// eventual outcome is durably queryable.
+/// </para>
+/// <para>
+/// <b>Prerequisite when either toggle is true:</b> HMAC attestation key material must be
+/// configured (User Secrets / Key Vault, never appsettings). Persisted escalation outcomes and
+/// change proposals are sealed with it, each bound to its own record id, and a record whose
+/// seal does not verify is never served or re-driven — otherwise anyone with write access to
+/// the database file could launder a forged approval into the hash-chained audit log.
+/// </para>
+/// <para>
+/// <b>Key retirement is destructive here.</b> A seal records the key version that produced it,
+/// and verification needs that key. Removing a retired key from the keychain permanently
+/// strands every row still sealed under it: those records fail verification and are quarantined
+/// rather than served. Retire a key only after the records sealed with it have aged out of
+/// <see cref="RetentionDays"/>, or re-seal them first.
+/// </para>
+/// </remarks>
+public sealed class GovernanceDurableStateConfig
+{
+    /// <summary>
+    /// When true, pending escalations (request, collected decisions, and resolution progress)
+    /// are persisted to the governance-state database and rehydrated as pending on startup.
+    /// Durable writes are fail-closed: a decision whose durable write fails is not reported
+    /// as recorded. Default false — in-memory behavior is byte-for-byte unchanged.
+    /// </summary>
+    public bool EscalationsEnabled { get; set; }
+
+    /// <summary>
+    /// When true, <c>IChangeProposalStore</c> resolves to the SQLite-backed implementation
+    /// instead of the in-memory one, so proposals survive host restarts. Default false —
+    /// the in-memory store (and the startup validator's production guard against it)
+    /// remains active.
+    /// </summary>
+    public bool ChangeProposalsEnabled { get; set; }
+
+    /// <summary>
+    /// Path of the SQLite database file holding both escalation state and change proposals.
+    /// Relative paths resolve from the application base directory. The path is normalized and
+    /// must remain under that directory; the containing folder is created lazily, on first use.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately <b>not</b> under <c>.agent-sessions/</c>. That tree is the harness's own
+    /// working area, reachable by the file-system tool; a database holding approval verdicts
+    /// must not sit where an agent can write. <c>.agent-state/</c> is denied to the
+    /// file-system tool (see <c>FileSystemService</c>'s protected-segment list).
+    /// </remarks>
+    public string DatabasePath { get; set; } = ".agent-state/governance-state.db";
+
+    /// <summary>
+    /// How often (in seconds) the background reconciler scans for escalations stuck in the
+    /// "resolved but never audited" state and re-drives them. Values below one minute are
+    /// clamped up; the scan is cheap but is not meant to be a hot loop. Default 5 minutes.
+    /// </summary>
+    public int ReconcileIntervalSeconds { get; set; } = 300;
+
+    /// <summary>
+    /// How long (in days) terminal records are retained before the prune pass deletes them.
+    /// Without this, both tables grow without bound. Zero or negative disables pruning
+    /// entirely (the operator takes over retention). Default 90 days.
+    /// </summary>
+    public int RetentionDays { get; set; } = 90;
+
+    /// <summary>
+    /// Hard cap on the number of non-terminal records read in a single rehydration or
+    /// reconcile scan. Bounds both memory and startup time when a database has accumulated a
+    /// pathological backlog. Default 10,000.
+    /// </summary>
+    public int MaxScanRecords { get; set; } = 10_000;
+
+    /// <summary>
+    /// Hard cap (in bytes) on any single serialized JSON payload column. A payload above this
+    /// is rejected before <c>SaveChangesAsync</c> rather than being written and later failing
+    /// to load. Default 1 MiB — escalations and proposals are human-scale documents.
+    /// </summary>
+    public int MaxPayloadBytes { get; set; } = 1024 * 1024;
+}

--- a/src/Content/Domain/Domain.Common/Config/AI/GovernanceConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/GovernanceConfig.cs
@@ -68,6 +68,14 @@ public sealed class GovernanceConfig
     public EscalationConfig Escalation { get; init; } = new();
 
     /// <summary>
+    /// Durable governance-state persistence (SQLite) for pending escalations and change
+    /// proposals. Both toggles default to off — in-memory behavior is unchanged until a
+    /// consumer opts in. See <see cref="GovernanceDurableStateConfig"/> for restart and
+    /// consistency semantics.
+    /// </summary>
+    public GovernanceDurableStateConfig DurableState { get; init; } = new();
+
+    /// <summary>
     /// Deterministic spin / no-progress guard for the agent's live tool-call path. Opt-in via
     /// <see cref="Governance.ProgressGuardConfig.Enabled"/>; off by default. Independent of
     /// <see cref="EnforceToolInvocation"/> — it answers "is the agent making progress?" rather than

--- a/src/Content/Domain/Domain.Common/Helpers/PathScope.cs
+++ b/src/Content/Domain/Domain.Common/Helpers/PathScope.cs
@@ -9,6 +9,27 @@ namespace Domain.Common.Helpers;
 public static class PathScope
 {
     /// <summary>
+    /// The string comparison that matches the host filesystem's case sensitivity: case-insensitive on
+    /// Windows, ordinal elsewhere. Exposed so callers that need an additional path comparison beyond
+    /// <see cref="IsSameOrUnderNormalized"/> (for example, asserting a path is strictly <em>under</em> a
+    /// root rather than equal to it) reuse these semantics instead of hardcoding a comparison of their
+    /// own. Hardcoding <see cref="StringComparison.OrdinalIgnoreCase"/> is the specific mistake this
+    /// guards against: on Linux <c>/app</c> and <c>/App</c> are different directories, so a
+    /// case-insensitive containment check there accepts paths that actually escape the root.
+    /// </summary>
+    public static StringComparison Comparison => OperatingSystem.IsWindows()
+        ? StringComparison.OrdinalIgnoreCase
+        : StringComparison.Ordinal;
+
+    /// <summary>
+    /// The <see cref="StringComparer"/> form of <see cref="Comparison"/>, for keying a dictionary or
+    /// set of normalized paths so lookups agree with the containment checks above.
+    /// </summary>
+    public static StringComparer Comparer => OperatingSystem.IsWindows()
+        ? StringComparer.OrdinalIgnoreCase
+        : StringComparer.Ordinal;
+
+    /// <summary>
     /// Returns the absolute, separator-trimmed form of <paramref name="path"/> so two paths can be
     /// compared for containment without being tripped up by relative segments or trailing separators.
     /// </summary>
@@ -31,9 +52,7 @@ public static class PathScope
     /// </summary>
     public static bool IsSameOrUnderNormalized(string normalizedTarget, string normalizedBase)
     {
-        var comparison = OperatingSystem.IsWindows()
-            ? StringComparison.OrdinalIgnoreCase
-            : StringComparison.Ordinal;
+        var comparison = Comparison;
 
         return string.Equals(normalizedTarget, normalizedBase, comparison)
             || normalizedTarget.StartsWith(normalizedBase + Path.DirectorySeparatorChar, comparison);

--- a/src/Content/Infrastructure/Infrastructure.AI/Changes/EfCoreChangeProposalStore.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Changes/EfCoreChangeProposalStore.cs
@@ -186,7 +186,8 @@ public sealed class EfCoreChangeProposalStore : IChangeProposalStore
     private async Task<ChangeProposal?> TryLoadAsync(
         string id, string proposalJson, string? sealJson, CancellationToken ct)
     {
-        var proposal = TryDeserialize(id, proposalJson);
+        var proposal = GovernanceStatePayload.TryDeserialize<ChangeProposal>(
+            proposalJson, _logger, "change proposal", id);
         if (proposal is null)
             return null;
 
@@ -202,7 +203,8 @@ public sealed class EfCoreChangeProposalStore : IChangeProposalStore
 
         var seal = sealJson is null
             ? null
-            : TryDeserializeSeal(id, sealJson);
+            : GovernanceStatePayload.TryDeserialize<GovernanceRecordSeal>(
+                sealJson, _logger, "change proposal seal", id);
 
         if (await _sealer.VerifyAsync(id, proposalJson, seal, ct))
             return proposal;
@@ -214,66 +216,15 @@ public sealed class EfCoreChangeProposalStore : IChangeProposalStore
         return null;
     }
 
-    /// <summary>Deserializes a stored seal, logging and returning null when it is unreadable.</summary>
-    /// <param name="id">The owning proposal, for the log line.</param>
-    /// <param name="sealJson">The stored seal JSON.</param>
-    private GovernanceRecordSeal? TryDeserializeSeal(string id, string sealJson)
-    {
-        try
-        {
-            return JsonSerializer.Deserialize<GovernanceRecordSeal>(sealJson, GovernanceStateJson.Options);
-        }
-        catch (Exception ex) when (ex is JsonException or ArgumentException or FormatException or OverflowException)
-        {
-            _logger.LogError(ex, "Failed to deserialize the persisted seal for change proposal {ProposalId}", id);
-            return null;
-        }
-    }
-
-    /// <summary>
-    /// Deserializes one stored proposal, or returns null (with an error log) when the payload
-    /// is unreadable. The row is preserved for manual inspection.
-    /// </summary>
-    /// <param name="id">The proposal id, for the log line.</param>
-    /// <param name="json">The stored aggregate JSON.</param>
-    private ChangeProposal? TryDeserialize(string id, string json)
-    {
-        try
-        {
-            return JsonSerializer.Deserialize<ChangeProposal>(json, GovernanceStateJson.Options);
-        }
-        catch (Exception ex) when (ex is JsonException or ArgumentException or FormatException or OverflowException)
-        {
-            // Matches the escalation store's guard: a corrupt tick value, a bad enum name, and
-            // a truncated target payload all surface here as different exception types, and any
-            // of them must quarantine one row rather than fail the whole list.
-            _logger.LogError(ex,
-                "Skipping unreadable durable change proposal {ProposalId}; the row is preserved for manual inspection",
-                id);
-            return null;
-        }
-    }
-
     /// <summary>
     /// Serializes the aggregate and rejects it when it exceeds the configured cap, so an
     /// oversized proposal fails loudly at the write rather than being stored and failing every
     /// later read.
     /// </summary>
     /// <param name="proposal">The proposal to serialize.</param>
-    private string SerializeGuarded(ChangeProposal proposal)
-    {
-        var json = JsonSerializer.Serialize(proposal, GovernanceStateJson.Options);
-        var maxBytes = Math.Max(1024, _config.CurrentValue.AI.Governance.DurableState.MaxPayloadBytes);
-        var byteCount = System.Text.Encoding.UTF8.GetByteCount(json);
-
-        if (byteCount > maxBytes)
-        {
-            throw new InvalidOperationException(
-                $"Change proposal {proposal.Id} serializes to {byteCount} bytes, exceeding the configured " +
-                $"maximum of {maxBytes}. Raise AppConfig:AI:Governance:DurableState:MaxPayloadBytes or " +
-                "reduce the diff size.");
-        }
-
-        return json;
-    }
+    private string SerializeGuarded(ChangeProposal proposal) =>
+        GovernanceStatePayload.SerializeGuarded(
+            proposal,
+            _config.CurrentValue.AI.Governance.DurableState.MaxPayloadBytes,
+            $"change proposal {proposal.Id}");
 }

--- a/src/Content/Infrastructure/Infrastructure.AI/Changes/EfCoreChangeProposalStore.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Changes/EfCoreChangeProposalStore.cs
@@ -1,0 +1,279 @@
+using System.Text.Json;
+using Application.AI.Common.Interfaces.Changes;
+using Application.AI.Common.Interfaces.Escalation;
+using Domain.AI.Changes;
+using Domain.Common.Config;
+using Infrastructure.AI.Persistence;
+using Infrastructure.AI.Persistence.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Infrastructure.AI.Changes;
+
+/// <summary>
+/// SQLite-backed <see cref="IChangeProposalStore"/> over
+/// <see cref="GovernanceStateDbContext"/>, so proposals survive host restarts. Resolved as the
+/// active store when <c>AppConfig:AI:Governance:DurableState:ChangeProposalsEnabled</c> is
+/// true; otherwise <see cref="InMemoryChangeProposalStore"/> remains active and this type is
+/// never constructed.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Honors the <see cref="IChangeProposalStore"/> contract exactly as the in-memory store does:
+/// <see cref="SaveAsync"/> is an idempotent last-write-wins upsert on the deterministic
+/// proposal id, and <see cref="ListAsync"/> AND-combines the query's filters, orders
+/// most-recently-submitted first, and caps at <c>MaxResults</c> (a non-positive cap yields an
+/// empty list). Filterable dimensions are denormalized into indexed columns so lists translate
+/// to SQL; the aggregate itself round-trips as JSON through
+/// <see cref="GovernanceStateJson"/> (including the polymorphic target via
+/// <see cref="ChangeTargetJsonConverter"/>).
+/// </para>
+/// <para>
+/// Rows whose JSON no longer deserializes are skipped with an error log rather than failing
+/// the read — a poisoned row must not take down every list; it stays in the table for manual
+/// inspection.
+/// </para>
+/// </remarks>
+public sealed class EfCoreChangeProposalStore : IChangeProposalStore
+{
+    private readonly IDbContextFactory<GovernanceStateDbContext> _contextFactory;
+    private readonly IGovernanceRecordSealer _sealer;
+    private readonly IOptionsMonitor<AppConfig> _config;
+    private readonly ILogger<EfCoreChangeProposalStore> _logger;
+
+    /// <summary>
+    /// Initializes a new instance.
+    /// </summary>
+    /// <param name="contextFactory">Factory for short-lived governance-state contexts.</param>
+    /// <param name="schemaInitializer">
+    /// Forces schema creation and evolution before the first operation. Unused beyond its
+    /// construction side effect — mirrors <c>EfCorePlanStateStore</c>.
+    /// </param>
+    /// <param name="sealer">Produces and verifies the tamper-evident seal over stored proposals.</param>
+    /// <param name="config">Supplies the payload-size cap.</param>
+    /// <param name="logger">Structured logger.</param>
+    public EfCoreChangeProposalStore(
+        IDbContextFactory<GovernanceStateDbContext> contextFactory,
+        GovernanceStateSchemaInitializer schemaInitializer,
+        IGovernanceRecordSealer sealer,
+        IOptionsMonitor<AppConfig> config,
+        ILogger<EfCoreChangeProposalStore> logger)
+    {
+        ArgumentNullException.ThrowIfNull(contextFactory);
+        ArgumentNullException.ThrowIfNull(schemaInitializer);
+        ArgumentNullException.ThrowIfNull(sealer);
+        ArgumentNullException.ThrowIfNull(config);
+        ArgumentNullException.ThrowIfNull(logger);
+        _contextFactory = contextFactory;
+        _sealer = sealer;
+        _config = config;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<ChangeProposal?> GetAsync(string id, CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(id);
+        await using var context = await _contextFactory.CreateDbContextAsync(cancellationToken);
+
+        var row = await context.ChangeProposals
+            .AsNoTracking()
+            .Where(p => p.Id == id)
+            .Select(p => new { p.ProposalJson, p.ProposalSealJson })
+            .FirstOrDefaultAsync(cancellationToken);
+
+        return row?.ProposalJson is null
+            ? null
+            : await TryLoadAsync(id, row.ProposalJson, row.ProposalSealJson, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task SaveAsync(ChangeProposal proposal, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(proposal);
+
+        // Serialize (and size-check) before opening a context, so an oversized aggregate is
+        // rejected without ever reaching SaveChangesAsync.
+        var proposalJson = SerializeGuarded(proposal);
+
+        // Seal the exact bytes about to be stored, bound to the proposal id. Without this a
+        // database writer could flip Status to an approved or terminal value, or widen the
+        // target's scope, and every later read would serve it unchallenged.
+        var seal = await _sealer.SealAsync(proposal.Id, proposalJson, cancellationToken);
+        var sealJson = JsonSerializer.Serialize(seal, GovernanceStateJson.Options);
+
+        await using var context = await _contextFactory.CreateDbContextAsync(cancellationToken);
+
+        var entity = await context.ChangeProposals.FindAsync([proposal.Id], cancellationToken);
+        if (entity is null)
+        {
+            entity = new ChangeProposalEntity { Id = proposal.Id };
+            context.ChangeProposals.Add(entity);
+        }
+
+        entity.Status = proposal.Status.ToString();
+        entity.SubmittedByAgentId = proposal.SubmittedBy.Id;
+        entity.BlastRadius = (int)proposal.BlastRadius;
+        entity.TargetKind = proposal.Target.Kind.ToString();
+        entity.SubmittedAtTicks = proposal.SubmittedAt.UtcTicks;
+        entity.ProposalJson = proposalJson;
+        entity.ProposalSealJson = sealJson;
+        await context.SaveChangesAsync(cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<ChangeProposal>> ListAsync(
+        ChangeProposalQuery query,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        await using var context = await _contextFactory.CreateDbContextAsync(cancellationToken);
+
+        var rows = context.ChangeProposals.AsNoTracking();
+
+        if (query.Status.HasValue)
+        {
+            var status = query.Status.Value.ToString();
+            rows = rows.Where(p => p.Status == status);
+        }
+
+        if (!string.IsNullOrEmpty(query.SubmittedByAgentId))
+            rows = rows.Where(p => p.SubmittedByAgentId == query.SubmittedByAgentId);
+
+        if (query.MinimumBlastRadius.HasValue)
+        {
+            var minimum = (int)query.MinimumBlastRadius.Value;
+            rows = rows.Where(p => p.BlastRadius >= minimum);
+        }
+
+        if (query.TargetKind.HasValue)
+        {
+            var kind = query.TargetKind.Value.ToString();
+            rows = rows.Where(p => p.TargetKind == kind);
+        }
+
+        var payloads = await rows
+            .OrderByDescending(p => p.SubmittedAtTicks)
+            .Take(Math.Max(0, query.MaxResults))
+            .Select(p => new { p.Id, p.ProposalJson, p.ProposalSealJson })
+            .ToListAsync(cancellationToken);
+
+        var results = new List<ChangeProposal>(payloads.Count);
+        foreach (var payload in payloads)
+        {
+            if (payload.Id is null || payload.ProposalJson is null)
+                continue;
+
+            var proposal = await TryLoadAsync(
+                payload.Id, payload.ProposalJson, payload.ProposalSealJson, cancellationToken);
+            if (proposal is not null)
+                results.Add(proposal);
+        }
+
+        return results;
+    }
+
+    /// <summary>
+    /// Deserializes a stored proposal and clears it for use: the payload must parse, the id
+    /// inside it must match the row it was loaded from, and its seal must verify against both.
+    /// Any failure quarantines that one row (logged, skipped, preserved on disk).
+    /// </summary>
+    /// <param name="id">The row's primary key.</param>
+    /// <param name="proposalJson">The stored aggregate JSON.</param>
+    /// <param name="sealJson">The stored seal JSON, or null on a row written before sealing.</param>
+    /// <param name="ct">Cancellation token.</param>
+    private async Task<ChangeProposal?> TryLoadAsync(
+        string id, string proposalJson, string? sealJson, CancellationToken ct)
+    {
+        var proposal = TryDeserialize(id, proposalJson);
+        if (proposal is null)
+            return null;
+
+        // Identity gate, independent of the seal: a payload relocated between rows is rejected
+        // before its (id-bound) seal is even consulted.
+        if (!string.Equals(proposal.Id, id, StringComparison.Ordinal))
+        {
+            _logger.LogError(
+                "Stored change proposal under key {RowId} declares id {DeclaredId}; refusing to serve it",
+                id, proposal.Id);
+            return null;
+        }
+
+        var seal = sealJson is null
+            ? null
+            : TryDeserializeSeal(id, sealJson);
+
+        if (await _sealer.VerifyAsync(id, proposalJson, seal, ct))
+            return proposal;
+
+        _logger.LogError(
+            "Change proposal {ProposalId} failed seal verification; refusing to serve it " +
+            "(the row is preserved for investigation)",
+            id);
+        return null;
+    }
+
+    /// <summary>Deserializes a stored seal, logging and returning null when it is unreadable.</summary>
+    /// <param name="id">The owning proposal, for the log line.</param>
+    /// <param name="sealJson">The stored seal JSON.</param>
+    private GovernanceRecordSeal? TryDeserializeSeal(string id, string sealJson)
+    {
+        try
+        {
+            return JsonSerializer.Deserialize<GovernanceRecordSeal>(sealJson, GovernanceStateJson.Options);
+        }
+        catch (Exception ex) when (ex is JsonException or ArgumentException or FormatException or OverflowException)
+        {
+            _logger.LogError(ex, "Failed to deserialize the persisted seal for change proposal {ProposalId}", id);
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Deserializes one stored proposal, or returns null (with an error log) when the payload
+    /// is unreadable. The row is preserved for manual inspection.
+    /// </summary>
+    /// <param name="id">The proposal id, for the log line.</param>
+    /// <param name="json">The stored aggregate JSON.</param>
+    private ChangeProposal? TryDeserialize(string id, string json)
+    {
+        try
+        {
+            return JsonSerializer.Deserialize<ChangeProposal>(json, GovernanceStateJson.Options);
+        }
+        catch (Exception ex) when (ex is JsonException or ArgumentException or FormatException or OverflowException)
+        {
+            // Matches the escalation store's guard: a corrupt tick value, a bad enum name, and
+            // a truncated target payload all surface here as different exception types, and any
+            // of them must quarantine one row rather than fail the whole list.
+            _logger.LogError(ex,
+                "Skipping unreadable durable change proposal {ProposalId}; the row is preserved for manual inspection",
+                id);
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Serializes the aggregate and rejects it when it exceeds the configured cap, so an
+    /// oversized proposal fails loudly at the write rather than being stored and failing every
+    /// later read.
+    /// </summary>
+    /// <param name="proposal">The proposal to serialize.</param>
+    private string SerializeGuarded(ChangeProposal proposal)
+    {
+        var json = JsonSerializer.Serialize(proposal, GovernanceStateJson.Options);
+        var maxBytes = Math.Max(1024, _config.CurrentValue.AI.Governance.DurableState.MaxPayloadBytes);
+        var byteCount = System.Text.Encoding.UTF8.GetByteCount(json);
+
+        if (byteCount > maxBytes)
+        {
+            throw new InvalidOperationException(
+                $"Change proposal {proposal.Id} serializes to {byteCount} bytes, exceeding the configured " +
+                $"maximum of {maxBytes}. Raise AppConfig:AI:Governance:DurableState:MaxPayloadBytes or " +
+                "reduce the diff size.");
+        }
+
+        return json;
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.Changes.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.Changes.cs
@@ -40,7 +40,20 @@ public static partial class DependencyInjection
     private static void RegisterChangesServices(IServiceCollection services)
     {
         // --- Store + audit + evidence ---
-        services.AddSingleton<IChangeProposalStore, InMemoryChangeProposalStore>();
+        // The public IChangeProposalStore is selected ONCE, at first resolution, from
+        // AppConfig:AI:Governance:DurableState:ChangeProposalsEnabled (see
+        // RegisterGovernanceStateServices for the restart-required semantics). Off (default):
+        // the resolved instance IS InMemoryChangeProposalStore — byte-for-byte today's
+        // behavior, and ChangeProposalStartupValidator's `is InMemoryChangeProposalStore`
+        // production guard keeps firing. On: the SQLite-backed EfCoreChangeProposalStore
+        // (registered in RegisterGovernanceStateServices) makes proposals survive restarts,
+        // and the validator correctly treats the host as durably backed.
+        services.AddSingleton<InMemoryChangeProposalStore>();
+        services.AddSingleton<IChangeProposalStore>(sp =>
+            sp.GetRequiredService<Microsoft.Extensions.Options.IOptionsMonitor<Domain.Common.Config.AppConfig>>()
+                .CurrentValue.AI.Governance.DurableState.ChangeProposalsEnabled
+                ? sp.GetRequiredService<EfCoreChangeProposalStore>()
+                : sp.GetRequiredService<InMemoryChangeProposalStore>());
         services.AddSingleton<IChangeAuditWriter, JsonlChangeAuditWriter>();
         services.AddSingleton<IEvidenceStore, FileSystemEvidenceStore>();
 

--- a/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.Governance.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.Governance.cs
@@ -67,7 +67,9 @@ public static partial class DependencyInjection
         // Runs reconciliation in production — the ONLY non-test trigger for the recovery path.
         // Registered AFTER rehydration so hosted-service start order populates the active set
         // before the first pass runs (the pass distinguishes in-memory-recoverable records from
-        // durable-only ones by consulting that set). Gated internally on EscalationsEnabled.
+        // durable-only ones by consulting that set). The pass itself runs on EVERY host: the
+        // stuck state it recovers is caused by an audit-store failure, not by durable state, so
+        // it occurs with the durability toggles off. Only the retention prune is toggle-gated.
         services.AddHostedService<EscalationReconciliationService>();
 
         services.AddSingleton<IEscalationAuditStore, JsonlEscalationAuditStore>();

--- a/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.Governance.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.Governance.cs
@@ -46,12 +46,30 @@ public static partial class DependencyInjection
     }
 
     /// <summary>
-    /// Registers escalation pipeline services: service, audit store, composite notifier,
-    /// and no-op notification channel stubs.
+    /// Registers escalation pipeline services: service (also exposed as the operator-facing
+    /// <see cref="IEscalationReconciler"/>), audit store, composite notifier, no-op
+    /// notification channel stubs, and the startup rehydration step for durable escalation
+    /// state (a no-op while durability is disabled).
     /// </summary>
     private static void RegisterEscalationServices(IServiceCollection services)
     {
-        services.AddSingleton<IEscalationService, DefaultEscalationService>();
+        // Concrete registration with interface forwards so IEscalationService and
+        // IEscalationReconciler resolve to the SAME singleton — the reconciler must see the
+        // exact in-memory state the service accumulates.
+        services.AddSingleton<DefaultEscalationService>();
+        services.AddSingleton<IEscalationService>(sp => sp.GetRequiredService<DefaultEscalationService>());
+        services.AddSingleton<IEscalationReconciler>(sp => sp.GetRequiredService<DefaultEscalationService>());
+
+        // Restores durably persisted pending escalations at host start. With durable state
+        // disabled the Null state store yields nothing and this is a silent no-op.
+        services.AddHostedService<EscalationStateRehydrationService>();
+
+        // Runs reconciliation in production — the ONLY non-test trigger for the recovery path.
+        // Registered AFTER rehydration so hosted-service start order populates the active set
+        // before the first pass runs (the pass distinguishes in-memory-recoverable records from
+        // durable-only ones by consulting that set). Gated internally on EscalationsEnabled.
+        services.AddHostedService<EscalationReconciliationService>();
+
         services.AddSingleton<IEscalationAuditStore, JsonlEscalationAuditStore>();
         services.AddSingleton<IEscalationNotifier, CompositeEscalationNotifier>();
         services.AddSingleton<IEscalationNotificationChannel, NoOpSlackNotifier>();

--- a/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.GovernanceState.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.GovernanceState.cs
@@ -1,0 +1,93 @@
+using Application.AI.Common.Interfaces.Escalation;
+using Domain.Common.Config;
+using Infrastructure.AI.Changes;
+using Infrastructure.AI.Escalation;
+using Infrastructure.AI.Persistence;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
+
+namespace Infrastructure.AI;
+
+public static partial class DependencyInjection
+{
+    /// <summary>
+    /// Registers the durable governance-state store (SQLite): the
+    /// <see cref="GovernanceStateDbContext"/> factory, its schema initializer, the outcome
+    /// sealer, the retention pruner, both EF-backed store implementations, and the
+    /// <see cref="IEscalationStateStore"/> selection. Everything here is passive until a
+    /// <c>AppConfig:AI:Governance:DurableState</c> toggle opts in — with both toggles off
+    /// (the default) no database file, directory, or connection is ever created.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The toggles are read from <see cref="IOptionsMonitor{TOptions}"/> at <b>first
+    /// resolution</b> of the affected service, not per call. Durability is a topology
+    /// property: flipping it mid-process would split state between the in-memory and durable
+    /// stores, so a change requires a host restart (documented on
+    /// <c>GovernanceDurableStateConfig</c>).
+    /// </para>
+    /// <para>
+    /// The EF-backed stores demand <see cref="GovernanceStateSchemaInitializer"/> as a plain
+    /// constructor dependency (ValidateOnBuild-visible), and are only constructed when their
+    /// toggle selects them — which is what defers schema creation until a consumer opts in.
+    /// The database path is normalized and containment-checked at registration; its directory
+    /// is created inside the options callback, on first context materialization.
+    /// </para>
+    /// </remarks>
+    /// <param name="services">The service collection.</param>
+    /// <param name="appConfig">The composed application configuration (for the database path).</param>
+    private static void RegisterGovernanceStateServices(IServiceCollection services, AppConfig appConfig)
+    {
+        var dbPath = GovernanceStatePaths.Resolve(appConfig.AI.Governance.DurableState.DatabasePath);
+        var connectionString = $"DataSource={dbPath}";
+
+        services.AddDbContextFactory<GovernanceStateDbContext>(options =>
+        {
+            // Runs on first context materialization, not at registration — hosts that never
+            // enable durable governance state get zero filesystem side effects.
+            GovernanceStatePaths.EnsureDirectory(dbPath);
+            options.UseSqlite(connectionString);
+        });
+
+        // Derived initializer (not the base EnsureCreated-only one) so a future column addition
+        // reaches pre-existing databases instead of silently no-opping. Resolved lazily by the
+        // stores' constructors; EnsureCreated and the PRAGMA-guarded DDL are both idempotent.
+        services.AddSingleton<GovernanceStateSchemaInitializer>();
+        services.AddSingleton<SchemaInitializer<GovernanceStateDbContext>>(
+            sp => sp.GetRequiredService<GovernanceStateSchemaInitializer>());
+
+        // TimeProvider is registered by Application.Common in composed hosts; TryAdd keeps
+        // Infrastructure.AI standalone-safe without overriding a host's own clock.
+        services.TryAddSingleton(TimeProvider.System);
+
+        // Seals persisted escalation outcomes AND change proposals with the harness's HMAC
+        // attestation keys, each bound to its own record id. Enabling either durable-state
+        // toggle therefore carries attestation key material as a prerequisite — documented on
+        // GovernanceDurableStateConfig.
+        services.AddSingleton<IGovernanceRecordSealer, AttestationGovernanceRecordSealer>();
+
+        services.AddSingleton<IGovernanceStatePruner, GovernanceStatePruner>();
+
+        // Deferred accessor for the reconciliation hosted service. Hosted services are
+        // constructed when the host is built, and constructing the pruner would construct the
+        // schema initializer — whose EnsureCreated would create the database file on EVERY
+        // host, including every host that never enables durability. The factory defers that
+        // to the first prune, which only runs once the enable check has passed.
+        services.AddSingleton<Func<IGovernanceStatePruner>>(
+            sp => sp.GetRequiredService<IGovernanceStatePruner>);
+
+        services.AddSingleton<EfCoreEscalationStateStore>();
+        services.AddSingleton<NullEscalationStateStore>();
+        services.AddSingleton<EfCoreChangeProposalStore>();
+
+        // Toggle read once, at first resolution (see remarks). The Null store preserves the
+        // in-memory-only escalation behavior byte-for-byte when durability is off.
+        services.AddSingleton<IEscalationStateStore>(sp =>
+            sp.GetRequiredService<IOptionsMonitor<AppConfig>>()
+                .CurrentValue.AI.Governance.DurableState.EscalationsEnabled
+                ? sp.GetRequiredService<EfCoreEscalationStateStore>()
+                : sp.GetRequiredService<NullEscalationStateStore>());
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.Tools.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.Tools.cs
@@ -34,11 +34,13 @@ public static partial class DependencyInjection
         IEnumerable<string> allowedBasePaths)
     {
         // File system service — sandboxed file operations for direct consumption.
-        // The governance-state directory is denied unconditionally, even when it falls inside
-        // an allowed base path: it holds approval verdicts, so an agent that could read it
-        // could mine approval payloads and one that could write it could forge a verdict the
-        // reconciler would launder into the compliance audit log. Resolved through the same
-        // helper the database registration uses, so the two paths cannot drift apart.
+        // The governance-state directory is denied unconditionally, even when it falls inside an
+        // allowed base path: it holds approval verdicts, so an agent that could read it could mine
+        // approval payloads and one that could write it could truncate or corrupt the harness's own
+        // governance state. It could not forge a verdict — every row is HMAC-sealed by
+        // AttestationGovernanceRecordSealer and verified fail-closed on read — so the exposure is
+        // disclosure and tamper/denial of service. Resolved through the same helper the database
+        // registration uses, so the two paths cannot drift apart.
         var governanceStateDirectory = Path.GetDirectoryName(
             Persistence.GovernanceStatePaths.Resolve(appConfig.AI.Governance.DurableState.DatabasePath));
 
@@ -50,15 +52,16 @@ public static partial class DependencyInjection
                 allowedBasePaths,
                 protectedPaths));
 
-        // The deny list above is defence in depth; this validator is the load-bearing control.
-        // It refuses to boot when the governance-state directory sits inside an allowed base path,
-        // because a hard link created there would alias the approval-verdict database into the
-        // sandbox and no per-path check can see through a hard link. Both collections are handed
-        // over by value so the assertion covers exactly the paths the service enforces.
+        // Boot-time assertion that the governance-state directory does not sit inside an allowed
+        // base path. That geometry is a misconfiguration worth refusing on, but note what it does
+        // NOT do: it does not close the hard-link bypass. A hard link needs the same VOLUME as its
+        // target, not the same subtree, and the shipped default puts workspace and .agent-state
+        // side by side on one volume. FileSystemService's per-operation link-count check is what
+        // closes that. Both collections are handed over by value so the assertion covers exactly
+        // the paths the service enforces.
         services.AddHostedService(sp => new FileSystemSandboxStartupValidator(
             [.. allowedBasePaths],
             protectedPaths,
-            sp.GetRequiredService<IOptionsMonitor<AppConfig>>(),
             sp.GetRequiredService<ILogger<FileSystemSandboxStartupValidator>>()));
 
         // File system tool — ITool adapter for LLM consumption, registered with keyed DI

--- a/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.Tools.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.Tools.cs
@@ -42,11 +42,24 @@ public static partial class DependencyInjection
         var governanceStateDirectory = Path.GetDirectoryName(
             Persistence.GovernanceStatePaths.Resolve(appConfig.AI.Governance.DurableState.DatabasePath));
 
+        string[] protectedPaths = governanceStateDirectory is null ? [] : [governanceStateDirectory];
+
         services.AddSingleton<IFileSystemService>(sp =>
             new FileSystemService(
                 sp.GetRequiredService<ILogger<FileSystemService>>(),
                 allowedBasePaths,
-                governanceStateDirectory is null ? [] : [governanceStateDirectory]));
+                protectedPaths));
+
+        // The deny list above is defence in depth; this validator is the load-bearing control.
+        // It refuses to boot when the governance-state directory sits inside an allowed base path,
+        // because a hard link created there would alias the approval-verdict database into the
+        // sandbox and no per-path check can see through a hard link. Both collections are handed
+        // over by value so the assertion covers exactly the paths the service enforces.
+        services.AddHostedService(sp => new FileSystemSandboxStartupValidator(
+            [.. allowedBasePaths],
+            protectedPaths,
+            sp.GetRequiredService<IOptionsMonitor<AppConfig>>(),
+            sp.GetRequiredService<ILogger<FileSystemSandboxStartupValidator>>()));
 
         // File system tool — ITool adapter for LLM consumption, registered with keyed DI
         services.AddKeyedSingleton<ITool>(FileSystemTool.ToolName, (sp, _) =>

--- a/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.Tools.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.Tools.cs
@@ -8,6 +8,7 @@ using Azure.AI.Projects;
 using Application.Common.Factories;
 using Domain.Common.Config;
 using Domain.Common.Config.AI;
+using Domain.Common.Config.AI.Governance;
 using Domain.Common.Config.MetaHarness;
 using Infrastructure.AI.Embeddings;
 using Infrastructure.AI.Factories;
@@ -34,17 +35,20 @@ public static partial class DependencyInjection
         IEnumerable<string> allowedBasePaths)
     {
         // File system service — sandboxed file operations for direct consumption.
-        // The governance-state directory is denied unconditionally, even when it falls inside an
-        // allowed base path: it holds approval verdicts, so an agent that could read it could mine
-        // approval payloads and one that could write it could truncate or corrupt the harness's own
-        // governance state. It could not forge a verdict — every row is HMAC-sealed by
+        // The governance-state directory is denied even when it falls inside an allowed base path:
+        // it holds approval verdicts, so an agent that could read it could mine approval payloads
+        // and one that could write it could truncate or corrupt the harness's own governance state.
+        // It could not forge a verdict — every row is HMAC-sealed by
         // AttestationGovernanceRecordSealer and verified fail-closed on read — so the exposure is
         // disclosure and tamper/denial of service. Resolved through the same helper the database
         // registration uses, so the two paths cannot drift apart.
         var governanceStateDirectory = Path.GetDirectoryName(
             Persistence.GovernanceStatePaths.Resolve(appConfig.AI.Governance.DurableState.DatabasePath));
 
-        string[] protectedPaths = governanceStateDirectory is null ? [] : [governanceStateDirectory];
+        // Armed only when there is genuinely something to protect — see the helper for why the
+        // toggles alone are not the whole condition.
+        var protectedPaths = ResolveGovernanceStateProtectedPaths(
+            appConfig.AI.Governance.DurableState, governanceStateDirectory);
 
         services.AddSingleton<IFileSystemService>(sp =>
             new FileSystemService(
@@ -132,6 +136,68 @@ public static partial class DependencyInjection
         // acknowledgement synchronously (non-interactive). General-purpose; opt-in per skill.
         services.AddKeyedSingleton<ITool>(RenderTableTool.ToolName, (sp, _) =>
             new RenderTableTool(sp.GetRequiredService<IClientToolBridge>()));
+    }
+
+    /// <summary>
+    /// Decides whether the governance-state directory is handed to <see cref="FileSystemService"/>
+    /// as a protected path, and returns it in the (at most one element) form the service and its
+    /// startup validator both receive.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>Why this is gated at all.</b> Arming the deny list also arms
+    /// <see cref="FileSystemService"/>'s per-operation hard-link identity check, and that check
+    /// fails closed on any platform <see cref="HardLinkInspector"/> has no implementation for.
+    /// Registering the directory unconditionally therefore made the file-system tool unusable on
+    /// macOS and the BSDs under <em>every</em> configuration — including the shipped default, where
+    /// both durable-state toggles are off and no database has ever existed. A control armed for a
+    /// feature that is not running is cost with no matching benefit.
+    /// </para>
+    /// <para>
+    /// <b>Why the toggles alone are not the condition.</b> A database left behind by an earlier run
+    /// with durability enabled still holds approval verdicts after someone sets the toggles back to
+    /// false. Gating on the toggles alone would silently un-protect that residue, so an existing
+    /// directory arms the protection on its own. The probe is a single
+    /// <see cref="Directory.Exists"/> call at composition — once per host, never per file operation.
+    /// </para>
+    /// <para>
+    /// <b>Why a composition-time snapshot is sound.</b> The directory can only come into existence
+    /// on a host whose composition-time toggles were already on. Every route to
+    /// <c>GovernanceStatePaths.EnsureDirectory</c> runs inside the <c>GovernanceStateDbContext</c>
+    /// options callback, which is reached only by resolving <c>EfCoreEscalationStateStore</c>,
+    /// <c>EfCoreChangeProposalStore</c>, or <c>GovernanceStatePruner</c>: the first two are selected
+    /// by a toggle read once at first resolution, and the third sits behind
+    /// <c>EscalationReconciliationService</c>'s construction-time enable snapshot. Nothing re-reads
+    /// the toggles afterwards, so no live <c>appsettings.json</c> edit can conjure a database that
+    /// this decision did not see. That last property is load-bearing — if the pruner ever goes back
+    /// to reading <see cref="Microsoft.Extensions.Options.IOptionsMonitor{T}"/> per tick, a host
+    /// that booted with nothing to protect could grow a database behind a disarmed deny list.
+    /// </para>
+    /// </remarks>
+    /// <param name="durableState">The durable governance-state configuration.</param>
+    /// <param name="governanceStateDirectory">
+    /// The resolved directory holding the governance-state database. Never <see langword="null"/>
+    /// in practice — <c>GovernanceStatePaths.Resolve</c> rejects a path with no containing
+    /// directory — so the null case is here to satisfy nullable analysis, not to describe a
+    /// reachable configuration.
+    /// </param>
+    /// <returns>
+    /// A single-element array holding the directory when protecting it is meaningful; otherwise an
+    /// empty array, which leaves both the deny list and the hard-link check disarmed.
+    /// </returns>
+    internal static string[] ResolveGovernanceStateProtectedPaths(
+        GovernanceDurableStateConfig durableState,
+        string? governanceStateDirectory)
+    {
+        ArgumentNullException.ThrowIfNull(durableState);
+
+        if (string.IsNullOrWhiteSpace(governanceStateDirectory))
+            return [];
+
+        if (durableState.EscalationsEnabled || durableState.ChangeProposalsEnabled)
+            return [governanceStateDirectory];
+
+        return Directory.Exists(governanceStateDirectory) ? [governanceStateDirectory] : [];
     }
 
     /// <summary>

--- a/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.Tools.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.Tools.cs
@@ -33,11 +33,20 @@ public static partial class DependencyInjection
         AppConfig appConfig,
         IEnumerable<string> allowedBasePaths)
     {
-        // File system service — sandboxed file operations for direct consumption
+        // File system service — sandboxed file operations for direct consumption.
+        // The governance-state directory is denied unconditionally, even when it falls inside
+        // an allowed base path: it holds approval verdicts, so an agent that could read it
+        // could mine approval payloads and one that could write it could forge a verdict the
+        // reconciler would launder into the compliance audit log. Resolved through the same
+        // helper the database registration uses, so the two paths cannot drift apart.
+        var governanceStateDirectory = Path.GetDirectoryName(
+            Persistence.GovernanceStatePaths.Resolve(appConfig.AI.Governance.DurableState.DatabasePath));
+
         services.AddSingleton<IFileSystemService>(sp =>
             new FileSystemService(
                 sp.GetRequiredService<ILogger<FileSystemService>>(),
-                allowedBasePaths));
+                allowedBasePaths,
+                governanceStateDirectory is null ? [] : [governanceStateDirectory]));
 
         // File system tool — ITool adapter for LLM consumption, registered with keyed DI
         services.AddKeyedSingleton<ITool>(FileSystemTool.ToolName, (sp, _) =>

--- a/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.cs
@@ -346,6 +346,13 @@ public static partial class DependencyInjection
         // --- Governance (permissions, escalation, resilience) ---
 
         RegisterGovernanceServices(services);
+
+        // --- Durable governance state (SQLite store for pending escalations and
+        //     change proposals). Passive until AppConfig.AI.Governance.DurableState
+        //     opts in; the escalation service and IChangeProposalStore selection
+        //     resolve its stores at first use. ---
+
+        RegisterGovernanceStateServices(services, appConfig);
         RegisterEscalationServices(services);
         RegisterResilienceServices(services, appConfig);
 

--- a/src/Content/Infrastructure/Infrastructure.AI/Escalation/AttestationGovernanceRecordSealer.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Escalation/AttestationGovernanceRecordSealer.cs
@@ -1,0 +1,125 @@
+using Application.AI.Common.Interfaces.Attestation;
+using Application.AI.Common.Interfaces.Escalation;
+using Domain.AI.Attestation;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Infrastructure.AI.Escalation;
+
+/// <summary>
+/// Seals persisted governance records with the harness's existing HMAC attestation key
+/// material — the same keys the sandbox tool-attestation path uses, sourced from User Secrets
+/// or Key Vault and never from appsettings.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Reuses <see cref="IAttestationService"/> rather than introducing a second signing key:
+/// <see cref="IAttestationService.VerifyBoundAsync"/> already provides exactly the needed
+/// primitive — recompute the content hash of the payload the caller currently holds, compare it
+/// to the attested hash, then verify the HMAC over a payload that embeds both that hash and the
+/// input hash. Passing the record's id as the attestation <c>Input</c> is what binds a seal to
+/// one row: a seal lifted onto a different record carries the wrong <c>InputHash</c>, and
+/// substituting the right one invalidates the signature.
+/// </para>
+/// <para>
+/// <see cref="IAttestationService"/> is registered scoped, so each operation resolves it from a
+/// fresh scope; sealing happens once per record write, a human-scale event. Verification
+/// failures are logged and reported as <c>false</c> — never thrown — so a tampered row
+/// quarantines that one record instead of failing a whole scan.
+/// </para>
+/// </remarks>
+public sealed class AttestationGovernanceRecordSealer : IGovernanceRecordSealer
+{
+    /// <summary>
+    /// The synthetic tool name the attestation payload is bound to, keeping governance seals in
+    /// a distinct namespace from real tool-execution attestations.
+    /// </summary>
+    private const string SealSubject = "governance.record";
+
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly ILogger<AttestationGovernanceRecordSealer> _logger;
+
+    /// <summary>Initializes a new instance.</summary>
+    /// <param name="scopeFactory">Creates the scope the scoped attestation service resolves from.</param>
+    /// <param name="logger">Structured logger.</param>
+    public AttestationGovernanceRecordSealer(
+        IServiceScopeFactory scopeFactory,
+        ILogger<AttestationGovernanceRecordSealer> logger)
+    {
+        ArgumentNullException.ThrowIfNull(scopeFactory);
+        ArgumentNullException.ThrowIfNull(logger);
+        _scopeFactory = scopeFactory;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<GovernanceRecordSeal> SealAsync(string subjectId, string payloadJson, CancellationToken ct)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(subjectId);
+        ArgumentException.ThrowIfNullOrEmpty(payloadJson);
+
+        await using var scope = _scopeFactory.CreateAsyncScope();
+        var attestations = scope.ServiceProvider.GetRequiredService<IAttestationService>();
+
+        // subjectId occupies the attestation Input slot, so its hash lands in the signed
+        // payload and the seal is valid for this record only.
+        var attestation = await attestations.SignAsync(
+            AttestationRequest.Success(SealSubject, subjectId, payloadJson), ct);
+
+        return new GovernanceRecordSeal(
+            attestation.Signature,
+            attestation.KeyVersion,
+            attestation.Timestamp,
+            attestation.InputHash,
+            attestation.OutputHash ?? string.Empty);
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> VerifyAsync(
+        string subjectId, string payloadJson, GovernanceRecordSeal? seal, CancellationToken ct)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(subjectId);
+        ArgumentException.ThrowIfNullOrEmpty(payloadJson);
+
+        if (seal is null || string.IsNullOrEmpty(seal.Signature) || string.IsNullOrEmpty(seal.OutputHash))
+        {
+            // Fail-closed: an unsealed record is indistinguishable from one whose seal was
+            // stripped, so it is never treated as trustworthy.
+            _logger.LogError(
+                "Persisted governance record {SubjectId} carries no usable seal; refusing to treat it as verified",
+                subjectId);
+            return false;
+        }
+
+        try
+        {
+            await using var scope = _scopeFactory.CreateAsyncScope();
+            var attestations = scope.ServiceProvider.GetRequiredService<IAttestationService>();
+
+            // The InputHash is derived from the subject the CALLER asked about, never taken
+            // from the stored seal. A seal lifted from another record therefore fails the
+            // signature check here even though its payload is byte-perfect.
+            var expectedBinding = await attestations.SignAsync(
+                AttestationRequest.Success(SealSubject, subjectId, payloadJson), ct);
+
+            var attestation = new ToolExecutionAttestation
+            {
+                ToolName = SealSubject,
+                InputHash = expectedBinding.InputHash,
+                OutputHash = seal.OutputHash,
+                Timestamp = seal.SignedAt,
+                Signature = seal.Signature,
+                KeyVersion = seal.KeyVersion
+            };
+
+            return await attestations.VerifyBoundAsync(attestation, payloadJson, ct);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "Governance record seal verification failed to run for {SubjectId}; treating the record as unverified",
+                subjectId);
+            return false;
+        }
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Escalation/DefaultEscalationService.Durability.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Escalation/DefaultEscalationService.Durability.cs
@@ -196,9 +196,20 @@ public sealed partial class DefaultEscalationService
 			await ReconcileInMemoryAsync(recovered, stillStuck, ct);
 			await ReconcileDurableAsync(recovered, stillStuck, ct);
 
-			_logger.LogInformation(
-				"Escalation reconcile pass complete: {RecoveredCount} recovered, {StuckCount} still stuck",
-				recovered.Count, stillStuck.Count);
+			// Information only when the pass actually did something. A host with the feature off
+			// still runs this pass on every tick, and an unconditional Information line would ship
+			// hundreds of "0 recovered, 0 stuck" records per host per day through the collector for
+			// no operational value. Idle passes stay observable at Debug.
+			if (recovered.Count > 0 || stillStuck.Count > 0)
+			{
+				_logger.LogInformation(
+					"Escalation reconcile pass complete: {RecoveredCount} recovered, {StuckCount} still stuck",
+					recovered.Count, stillStuck.Count);
+			}
+			else
+			{
+				_logger.LogDebug("Escalation reconcile pass complete: nothing to recover");
+			}
 
 			return new EscalationReconcileResult
 			{

--- a/src/Content/Infrastructure/Infrastructure.AI/Escalation/DefaultEscalationService.Durability.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Escalation/DefaultEscalationService.Durability.cs
@@ -1,0 +1,403 @@
+using Application.AI.Common.Interfaces.Escalation;
+using Application.AI.Common.OpenTelemetry.Metrics;
+using Domain.AI.Escalation;
+using Microsoft.Extensions.Logging;
+
+namespace Infrastructure.AI.Escalation;
+
+/// <summary>
+/// Durability and recovery surface of <see cref="DefaultEscalationService"/>: startup
+/// rehydration of pending escalations from the <see cref="IEscalationStateStore"/>, and the
+/// <see cref="IEscalationReconciler"/> implementation that re-drives resolutions stuck on a
+/// failed durable or audit write.
+/// </summary>
+public sealed partial class DefaultEscalationService
+{
+	/// <summary>
+	/// How long a reconcile claim may sit in <see cref="EscalationPersistedStatus.AuditInFlight"/>
+	/// before another pass may reclaim it as orphaned.
+	/// </summary>
+	/// <remarks>
+	/// A pass that is killed between claiming and finishing never runs its release, so without
+	/// an expiry the record would be permanently unclaimable: skipped by every future pass and
+	/// left alone by the pruner, which correctly refuses to delete non-terminal rows. Ten
+	/// minutes is far longer than a healthy re-drive (a JSONL append plus one row update) yet
+	/// short enough that a stranded approval is recovered on the next scheduled pass.
+	/// </remarks>
+	private static readonly TimeSpan StaleClaimAge = TimeSpan.FromMinutes(10);
+
+	/// <summary>
+	/// Tolerance for a rehydrated record whose <c>CreatedAt</c> is in the future — small enough
+	/// to reject a corrupt or forged far-future timestamp, large enough to absorb ordinary clock
+	/// skew between the writer and this host.
+	/// </summary>
+	private static readonly TimeSpan CreatedAtFutureSkew = TimeSpan.FromMinutes(5);
+
+	/// <summary>
+	/// Loads every <see cref="EscalationPersistedStatus.Pending"/> record from the durable
+	/// store into the active in-memory set, making it decidable, listable, and cancellable
+	/// again, and resumes each escalation's ORIGINAL timeout (downtime counts against the
+	/// budget; an already-expired escalation times out immediately, with a
+	/// <c>TimeoutAction.Approve</c> downgraded to a denial — see <c>ResolveTimeoutApproval</c>).
+	/// </summary>
+	/// <remarks>
+	/// <para>
+	/// Invoked once at host startup by <see cref="EscalationStateRehydrationService"/>. With
+	/// the Null store (durability disabled) this is a no-op returning zero. Blocking waiters
+	/// are NOT restored — they cannot be (see the class remarks); rehydrated escalations
+	/// release nobody when resolved, but their outcomes are durably queryable via
+	/// <see cref="IEscalationService.GetOutcomeAsync"/>.
+	/// </para>
+	/// <para>
+	/// <b>Every row is revalidated.</b> The store is a file, not a value this process just
+	/// constructed, so each snapshot passes <see cref="EscalationRequestInvariants"/> before it
+	/// may become live — the same gate <c>InitializeEscalation</c> applies. A row violating an
+	/// invariant is skipped and logged rather than resurrected: an empty roster with
+	/// <c>TimeoutAction.Approve</c>, or a zero Quorum threshold, would otherwise rehydrate as a
+	/// live escalation nobody can vote on that auto-approves itself on timeout.
+	/// </para>
+	/// <para>
+	/// Records in <see cref="EscalationPersistedStatus.ResolvedPendingAudit"/> or
+	/// <see cref="EscalationPersistedStatus.AuditInFlight"/> are deliberately NOT rehydrated as
+	/// pending — their resolution already happened; they are finalized by
+	/// <see cref="ReconcileStuckEscalationsAsync"/>. Rehydration re-sends no notifications and
+	/// re-writes no audit records: both already happened in the previous process lifetime.
+	/// </para>
+	/// <para>
+	/// Individual unreadable or invalid rows are skipped and logged rather than aborting the
+	/// scan. A scan-level failure propagates to <see cref="EscalationStateRehydrationService"/>,
+	/// which logs it at <c>Critical</c> and lets the host start anyway — see that type's remarks
+	/// for why one corrupt byte must not become a full-availability outage.
+	/// </para>
+	/// </remarks>
+	/// <param name="ct">Cancellation token.</param>
+	/// <returns>The number of escalations restored to the active set.</returns>
+	public async Task<int> RehydratePendingEscalationsAsync(CancellationToken ct)
+	{
+		var snapshots = await _stateStore.GetActiveAsync(ct);
+		var restored = 0;
+
+		foreach (var snapshot in snapshots)
+		{
+			if (snapshot.Status != EscalationPersistedStatus.Pending)
+				continue;
+
+			if (!EscalationRequestInvariants.TryValidate(snapshot.Request, out var violation) ||
+				!TryValidateCreatedAt(snapshot, out violation))
+			{
+				_logger.LogError(
+					"Refusing to rehydrate durable escalation {EscalationId}: {Violation}. " +
+					"The row is preserved for investigation and will not become decidable",
+					snapshot.Request.EscalationId, violation);
+				continue;
+			}
+
+			if (TryRestore(snapshot))
+				restored++;
+		}
+
+		return restored;
+	}
+
+	/// <summary>
+	/// Validates the persisted <c>CreatedAt</c>, which reaches this process as a raw tick value
+	/// and is therefore no more trustworthy than the request payload.
+	/// </summary>
+	/// <remarks>
+	/// <see cref="EscalationRequestInvariants"/> can only cover fields on the request, so the
+	/// timeout ceiling it enforces is reachable around: a far-future <c>CreatedAt</c> that is
+	/// still a valid <see cref="DateTimeOffset"/> makes <c>CreatedAt + TimeoutSeconds</c>
+	/// overflow, the timeout loop's catch-all swallows the throw, and the escalation is pending
+	/// forever — exactly the immortal-escalation harm the ceiling exists to prevent, reached
+	/// through a different field. Both halves are checked here: the instant itself must not be
+	/// meaningfully in the future, and the resulting deadline must be representable.
+	/// </remarks>
+	/// <param name="snapshot">The snapshot being considered for rehydration.</param>
+	/// <param name="violation">On failure, an operator-readable description; null on success.</param>
+	/// <returns>True when the timestamp is usable.</returns>
+	private static bool TryValidateCreatedAt(EscalationStateSnapshot snapshot, out string? violation)
+	{
+		var now = DateTimeOffset.UtcNow;
+		if (snapshot.CreatedAt > now + CreatedAtFutureSkew)
+		{
+			violation =
+				$"the persisted creation time ({snapshot.CreatedAt:O}) is in the future beyond the " +
+				$"{CreatedAtFutureSkew.TotalMinutes:0}-minute skew allowance";
+			return false;
+		}
+
+		try
+		{
+			_ = snapshot.CreatedAt + TimeSpan.FromSeconds(snapshot.Request.TimeoutSeconds);
+		}
+		catch (ArgumentOutOfRangeException)
+		{
+			violation =
+				$"the resumed deadline (created {snapshot.CreatedAt:O} plus " +
+				$"{snapshot.Request.TimeoutSeconds}s) is not representable";
+			return false;
+		}
+
+		violation = null;
+		return true;
+	}
+
+	/// <summary>
+	/// Adds one validated snapshot to the active set and starts its resumed timeout.
+	/// </summary>
+	/// <param name="snapshot">A snapshot that already passed invariant validation.</param>
+	/// <returns>True when the escalation was added; false when one with that id was already active.</returns>
+	private bool TryRestore(EscalationStateSnapshot snapshot)
+	{
+		// Decide expiry ONCE, here, rather than re-testing the deadline after Task.Delay
+		// returns. Timer granularity (~15ms on Windows) or a backwards clock step can leave the
+		// deadline marginally in the future at timeout time, which would skip the fail-closed
+		// downgrade and auto-approve an escalation nobody was re-notified about.
+		var deadline = snapshot.CreatedAt + TimeSpan.FromSeconds(snapshot.Request.TimeoutSeconds);
+		var state = new EscalationState
+		{
+			Request = snapshot.Request,
+			TimeoutCts = new CancellationTokenSource(),
+			CreatedAt = snapshot.CreatedAt,
+			WasRehydrated = true,
+			ExpiredDuringDowntime = deadline <= DateTimeOffset.UtcNow
+		};
+		state.Decisions.AddRange(snapshot.Decisions);
+
+		if (!_activeEscalations.TryAdd(snapshot.Request.EscalationId, state))
+		{
+			state.TimeoutCts.Dispose();
+			state.WriteGate.Dispose();
+			return false;
+		}
+
+		EscalationMetrics.Pending.Add(1);
+		_ = RunTimeoutAsync(state);
+
+		_logger.LogInformation(
+			"Rehydrated pending escalation {EscalationId} for agent {AgentId} ({DecisionCount} decision(s) restored)",
+			snapshot.Request.EscalationId, snapshot.Request.AgentId, snapshot.Decisions.Count);
+		return true;
+	}
+
+	/// <inheritdoc />
+	public async Task<EscalationReconcileResult> ReconcileStuckEscalationsAsync(CancellationToken ct)
+	{
+		// One pass at a time within the process. Combined with the store's conditional durable
+		// claim, this keeps the compliance audit line and the resolution notification firing
+		// once per stuck escalation even when a timer tick and an operator-triggered pass
+		// overlap.
+		await _reconcileGate.WaitAsync(ct);
+		try
+		{
+			var recovered = new List<Guid>();
+			var stillStuck = new List<Guid>();
+
+			await ReconcileInMemoryAsync(recovered, stillStuck, ct);
+			await ReconcileDurableAsync(recovered, stillStuck, ct);
+
+			_logger.LogInformation(
+				"Escalation reconcile pass complete: {RecoveredCount} recovered, {StuckCount} still stuck",
+				recovered.Count, stillStuck.Count);
+
+			return new EscalationReconcileResult
+			{
+				Recovered = recovered,
+				StillStuck = stillStuck
+			};
+		}
+		finally
+		{
+			_reconcileGate.Release();
+		}
+	}
+
+	/// <summary>
+	/// Shape 1 — in-memory stuck states: a resolution was reached this process lifetime but its
+	/// fail-closed durable or audit write faulted, leaving the escalation in the active set with
+	/// <c>IsResolved</c>, a stashed outcome, and a released finalize claim.
+	/// </summary>
+	/// <param name="recovered">Accumulates escalations finalized by this pass.</param>
+	/// <param name="stillStuck">Accumulates escalations that remain stuck.</param>
+	/// <param name="ct">Cancellation token.</param>
+	private async Task ReconcileInMemoryAsync(List<Guid> recovered, List<Guid> stillStuck, CancellationToken ct)
+	{
+		foreach (var state in _activeEscalations.Values)
+		{
+			EscalationOutcome? pending;
+			lock (state.Lock)
+			{
+				pending = state.IsResolved && !state.FinalizeClaimed ? state.PendingOutcome : null;
+				if (pending is not null)
+					state.FinalizeClaimed = true;
+			}
+
+			if (pending is null)
+				continue;
+
+			if (await TryFinalizeStuckStateAsync(state, pending, ct))
+			{
+				recovered.Add(pending.EscalationId);
+			}
+			else
+			{
+				lock (state.Lock)
+				{
+					state.FinalizeClaimed = false;
+				}
+				stillStuck.Add(pending.EscalationId);
+			}
+		}
+	}
+
+	/// <summary>
+	/// Shape 2 — durable-only stuck records: rows parked by a previous process lifetime (the
+	/// crash landed between the resolution and the audit write, or between the audit write and
+	/// the terminal marker). No in-memory state exists for them.
+	/// </summary>
+	/// <remarks>
+	/// Each record is claimed through the store's conditional update before any side effect
+	/// runs, so overlapping passes cannot both append the compliance line and both fire the
+	/// resolution notification. A snapshot whose outcome failed seal verification arrives with
+	/// a null outcome and is skipped — a tampered verdict is never re-driven into the audit log.
+	/// </remarks>
+	/// <param name="recovered">Accumulates escalations finalized by this pass.</param>
+	/// <param name="stillStuck">Accumulates escalations that remain stuck.</param>
+	/// <param name="ct">Cancellation token.</param>
+	private async Task ReconcileDurableAsync(List<Guid> recovered, List<Guid> stillStuck, CancellationToken ct)
+	{
+		var snapshots = await _stateStore.GetActiveAsync(ct);
+		foreach (var snapshot in snapshots)
+		{
+			var escalationId = snapshot.Request.EscalationId;
+			if (!IsDurableStuckCandidate(snapshot) ||
+				recovered.Contains(escalationId) ||
+				stillStuck.Contains(escalationId) ||
+				_activeEscalations.ContainsKey(escalationId))
+			{
+				continue;
+			}
+
+			var staleClaimBefore = DateTimeOffset.UtcNow - StaleClaimAge;
+			if (!await _stateStore.TryClaimResolvedPendingAuditAsync(escalationId, staleClaimBefore, ct))
+			{
+				// An unclaimable ResolvedPendingAudit row means a genuine concurrent pass owns
+				// it — routine. An unclaimable AuditInFlight row means another pass is mid-drive
+				// and its claim has not yet aged out; that is worth surfacing louder, because a
+				// row still being skipped after the staleness window would indicate a claim that
+				// is neither progressing nor expiring.
+				if (snapshot.Status == EscalationPersistedStatus.AuditInFlight)
+				{
+					_logger.LogWarning(
+						"Escalation {EscalationId} is held in AuditInFlight by another reconcile pass and is not yet " +
+						"reclaimable (claims age out after {StaleClaimAge}); skipping this pass",
+						escalationId, StaleClaimAge);
+				}
+				else
+				{
+					_logger.LogDebug(
+						"Escalation {EscalationId} is already claimed by another reconcile pass; skipping",
+						escalationId);
+				}
+				continue;
+			}
+
+			if (await TryFinalizeDurableRecordAsync(snapshot.Outcome!, ct))
+			{
+				recovered.Add(escalationId);
+			}
+			else
+			{
+				await SafeExecuteAsync(
+					() => _stateStore.ReleaseClaimAsync(escalationId, CancellationToken.None),
+					"release reconcile claim", escalationId);
+				stillStuck.Add(escalationId);
+			}
+		}
+	}
+
+	/// <summary>
+	/// True when a snapshot is a durable-only stuck record with a verified outcome available to
+	/// re-drive. An <see cref="EscalationPersistedStatus.AuditInFlight"/> row is included: it
+	/// belongs to a pass that crashed mid-claim, and leaving it would strand the escalation.
+	/// </summary>
+	/// <param name="snapshot">The snapshot to classify.</param>
+	private static bool IsDurableStuckCandidate(EscalationStateSnapshot snapshot) =>
+		snapshot.Outcome is not null &&
+		snapshot.Status is EscalationPersistedStatus.ResolvedPendingAudit
+			or EscalationPersistedStatus.AuditInFlight;
+
+	/// <summary>
+	/// Re-drives the durable marker and audit write for an in-memory stuck state, then
+	/// finalizes it. Returns false (leaving the state stuck and claimable again) when the audit
+	/// or durable store is still failing.
+	/// </summary>
+	/// <param name="state">The stuck escalation state (resolution reached, never finalized).</param>
+	/// <param name="outcome">The stashed resolution to re-drive.</param>
+	/// <param name="ct">Cancellation token.</param>
+	private async Task<bool> TryFinalizeStuckStateAsync(
+		EscalationState state, EscalationOutcome outcome, CancellationToken ct)
+	{
+		try
+		{
+			// Same fail-closed order as ResolveEscalationAsync: durable marker, then audit.
+			// Both are idempotent, so re-driving after a partial earlier attempt is safe (at
+			// worst a duplicate same-content audit line).
+			await _stateStore.MarkResolvedPendingAuditAsync(outcome, ct);
+			await _auditStore.RecordOutcomeAsync(outcome, ct);
+		}
+		catch (Exception ex)
+		{
+			_logger.LogWarning(ex,
+				"Reconcile could not finalize escalation {EscalationId}; it remains stuck for a future pass",
+				outcome.EscalationId);
+			return false;
+		}
+
+		// FinalizeResolvedAsync marks the durable record terminal, publishes the verdict,
+		// removes the escalation from the active set, notifies, and completes the waiter. The
+		// Completion task already faulted when the original write failed, so its TrySetResult
+		// is a deliberate no-op — the blocked caller was already released with the failure,
+		// fail-closed.
+		await FinalizeResolvedAsync(state, outcome);
+
+		_logger.LogInformation(
+			"Reconciled stuck escalation {EscalationId}: {ResolutionType}, approved={IsApproved}",
+			outcome.EscalationId, outcome.ResolutionType, outcome.IsApproved);
+		return true;
+	}
+
+	/// <summary>
+	/// Finalizes a durable-only stuck record left behind by a previous process lifetime:
+	/// re-drives the audit write, marks the record terminal, publishes the outcome for pollers,
+	/// and notifies. Returns false when the audit or durable store is still failing.
+	/// </summary>
+	/// <param name="outcome">The persisted, seal-verified resolution to re-drive.</param>
+	/// <param name="ct">Cancellation token.</param>
+	private async Task<bool> TryFinalizeDurableRecordAsync(EscalationOutcome outcome, CancellationToken ct)
+	{
+		try
+		{
+			await _auditStore.RecordOutcomeAsync(outcome, ct);
+			await _stateStore.MarkResolvedAsync(outcome.EscalationId, ct);
+		}
+		catch (Exception ex)
+		{
+			_logger.LogWarning(ex,
+				"Reconcile could not finalize durable escalation record {EscalationId}; it remains stuck for a future pass",
+				outcome.EscalationId);
+			return false;
+		}
+
+		_resolvedOutcomes[outcome.EscalationId] = outcome;
+
+		await SafeExecuteAsync(
+			() => _notifier.NotifyEscalationResolvedAsync(outcome, CancellationToken.None),
+			"notify reconciled resolution", outcome.EscalationId);
+
+		_logger.LogInformation(
+			"Reconciled durable stuck escalation {EscalationId} from a previous process lifetime: {ResolutionType}, approved={IsApproved}",
+			outcome.EscalationId, outcome.ResolutionType, outcome.IsApproved);
+		return true;
+	}
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Escalation/DefaultEscalationService.Resolution.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Escalation/DefaultEscalationService.Resolution.cs
@@ -1,0 +1,331 @@
+using Application.AI.Common.Exceptions;
+using Application.AI.Common.OpenTelemetry.Metrics;
+using Domain.AI.Escalation;
+using Domain.AI.Telemetry.Conventions;
+using Microsoft.Extensions.Logging;
+
+namespace Infrastructure.AI.Escalation;
+
+/// <summary>
+/// Resolution, timeout, and teardown half of <see cref="DefaultEscalationService"/>: the
+/// fail-closed write ordering that decides whether an escalation may be reported resolved.
+/// </summary>
+public sealed partial class DefaultEscalationService
+{
+	/// <summary>
+	/// Marks a state as resolving under the caller's <c>state.Lock</c>: flips
+	/// <c>IsResolved</c>, stashes the outcome for the reconciler, and takes the finalize claim
+	/// so no concurrent reconcile pass can finalize a resolution this path still owns.
+	/// </summary>
+	/// <param name="state">The escalation being resolved. Caller must hold its lock.</param>
+	/// <param name="outcome">The resolution reached.</param>
+	private static void MarkResolving(EscalationState state, EscalationOutcome outcome)
+	{
+		state.IsResolved = true;
+		state.PendingOutcome = outcome;
+		state.FinalizeClaimed = true;
+		state.ResolutionFailed = false;
+	}
+
+	/// <summary>
+	/// Releases the finalize claim after a fail-closed write failed, so the escalation becomes
+	/// claimable by a reconcile pass, and records that it is parked awaiting reconciliation.
+	/// </summary>
+	/// <param name="state">The escalation whose resolution failed.</param>
+	private static void MarkResolutionFailed(EscalationState state)
+	{
+		lock (state.Lock)
+		{
+			state.FinalizeClaimed = false;
+			state.ResolutionFailed = true;
+		}
+	}
+
+	private async Task ResolveEscalationAsync(EscalationState state, EscalationOutcome outcome)
+	{
+		// Idempotency / teardown guard: if the completion was already settled
+		// (e.g. the service was disposed and cancelled it), don't re-run cleanup.
+		// Each caller (SubmitDecision/Cancel/Timeout) marks the state resolving under
+		// the state lock before calling here, so this runs at most once per escalation.
+		if (state.Completion.Task.IsCompleted)
+			return;
+
+		state.TimeoutCts.Cancel();
+
+		// Durable resolution marker BEFORE the fail-closed audit write below: if the audit
+		// store is down, the durable record parks in ResolvedPendingAudit — the detectable
+		// state the IEscalationReconciler re-drives once the audit store recovers — instead of
+		// the verdict existing only in process memory. Fail-closed with the same semantics as
+		// the audit write: a resolution that cannot be durably recorded is not reported
+		// resolved, and the escalation stays observable in the active set.
+		try
+		{
+			await _stateStore.MarkResolvedPendingAuditAsync(outcome, CancellationToken.None);
+		}
+		catch (Exception ex)
+		{
+			_logger.LogError(ex,
+				"Failed to durably record resolution for escalation {EscalationId}; failing closed (escalation not reported resolved)",
+				outcome.EscalationId);
+			MarkResolutionFailed(state);
+			var scrubbed = new EscalationDurableStateException(
+				EscalationDurableStateException.DurableResolutionFailedCode, ex);
+			state.Completion.TrySetException(scrubbed);
+			throw scrubbed;
+		}
+
+		// Record the audit outcome BEFORE releasing the caller awaiting Completion.Task.
+		// The durable outcome write is fail-CLOSED: if it throws, the escalation must NOT
+		// be reported as resolved. Propagate the failure to the awaiting caller instead of
+		// delivering an approval that was never recorded for compliance. (SafeExecuteAsync
+		// is reserved for best-effort notification, never for the durable audit write.)
+		// The escalation deliberately stays in _activeEscalations on failure: it must remain
+		// observable (a resolved-but-unaudited escalation vanishing entirely would read as an
+		// unknown id to every poller) rather than dropping into a state no reader can see.
+		try
+		{
+			await _auditStore.RecordOutcomeAsync(outcome, CancellationToken.None);
+		}
+		catch (Exception ex)
+		{
+			_logger.LogError(ex,
+				"Failed to record outcome for escalation {EscalationId}; failing closed (escalation not reported resolved)",
+				outcome.EscalationId);
+			MarkResolutionFailed(state);
+			state.Completion.TrySetException(ex);
+			throw;
+		}
+
+		await FinalizeResolvedAsync(state, outcome);
+	}
+
+	/// <summary>
+	/// Completes a resolution whose durable and audit writes both succeeded: marks the durable
+	/// record terminal, publishes the verdict, removes the escalation from the active set,
+	/// records metrics, notifies, and releases the blocked caller.
+	/// </summary>
+	/// <param name="state">The resolved escalation.</param>
+	/// <param name="outcome">The audited outcome.</param>
+	private async Task FinalizeResolvedAsync(EscalationState state, EscalationOutcome outcome)
+	{
+		// Terminal durable marker, deliberately best-effort: the verdict is durably audited at
+		// this point, so faulting the caller now would be dishonest. On failure the row stays
+		// in ResolvedPendingAudit and a later reconcile pass finalizes it — possibly appending
+		// a duplicate (same-content) outcome audit line, the documented safe trade against
+		// losing a verdict. No-op with the Null store.
+		try
+		{
+			await _stateStore.MarkResolvedAsync(outcome.EscalationId, CancellationToken.None);
+		}
+		catch (Exception ex)
+		{
+			_logger.LogWarning(ex,
+				"Failed to finalize durable state for escalation {EscalationId}; outcome is audited, reconcile will finalize the record",
+				outcome.EscalationId);
+		}
+
+		// Retain the verdict ONLY after it has been durably audited, so GetOutcomeAsync — and thus
+		// the plan executor's resume reconciliation — can never act on a verdict that failed the
+		// fail-closed audit write above and was rolled back to the awaiting caller. Publish it
+		// BEFORE removing the escalation from the active set: a reader landing between the two
+		// steps sees at least one view (brief dual presence is fine — readers check the active
+		// set first and simply serve the pending view), never the spurious not-found a
+		// remove-then-publish order produced on exactly the poll the 202 contract prescribes.
+		_resolvedOutcomes[outcome.EscalationId] = outcome;
+		_activeEscalations.TryRemove(state.Request.EscalationId, out _);
+
+		EscalationMetrics.Pending.Add(-1);
+		RecordResolutionMetrics(state, outcome);
+
+		_logger.LogInformation(
+			"Escalation {EscalationId} resolved: {ResolutionType}, approved={IsApproved}",
+			outcome.EscalationId, outcome.ResolutionType, outcome.IsApproved);
+
+		await SafeExecuteAsync(
+			() => _notifier.NotifyEscalationResolvedAsync(outcome, CancellationToken.None),
+			"notify resolution", outcome.EscalationId);
+
+		state.Completion.TrySetResult(outcome);
+	}
+
+	private async Task RunTimeoutAsync(EscalationState state)
+	{
+		try
+		{
+			// The deadline is anchored to CreatedAt rather than "now" so a rehydrated
+			// escalation resumes its ORIGINAL timeout budget — downtime counts against it
+			// instead of resetting it. For freshly created escalations CreatedAt is "now"
+			// and this is the original full delay. An already-expired deadline times out
+			// immediately. TimeoutSeconds is bounded by EscalationRequestInvariants, so the
+			// delay can never overflow and silently make an escalation immortal.
+			var deadline = state.CreatedAt + TimeSpan.FromSeconds(state.Request.TimeoutSeconds);
+			var delay = deadline - DateTimeOffset.UtcNow;
+			if (delay > TimeSpan.Zero)
+				await Task.Delay(delay, state.TimeoutCts.Token);
+
+			await HandleTimeoutAsync(state);
+		}
+		catch (OperationCanceledException)
+		{
+			// Escalation resolved or caller cancelled before timeout -- normal path
+		}
+		catch (Exception ex)
+		{
+			_logger.LogError(ex, "Unexpected error in timeout handler for escalation {EscalationId}",
+				state.Request.EscalationId);
+		}
+	}
+
+	private async Task HandleTimeoutAsync(EscalationState state)
+	{
+		// Takes the same per-escalation gate the decision path uses. Without it a decision's
+		// SaveDecisionsAsync could land AFTER MarkResolvedPendingAuditAsync has sealed the
+		// outcome, leaving DecisionsJson describing a decision set the sealed verdict never saw.
+		//
+		// A disposed gate means the escalation was torn down (service disposal, caller
+		// cancellation) while this timeout task was still in flight. Timing it out is moot at
+		// that point, so bail out quietly rather than faulting a background task.
+		try
+		{
+			await state.WriteGate.WaitAsync(CancellationToken.None);
+		}
+		catch (ObjectDisposedException)
+		{
+			return;
+		}
+
+		try
+		{
+			EscalationOutcome? outcome;
+
+			lock (state.Lock)
+			{
+				if (state.IsResolved)
+					return;
+
+				outcome = new EscalationOutcome
+				{
+					EscalationId = state.Request.EscalationId,
+					IsApproved = ResolveTimeoutApproval(state),
+					Decisions = state.Decisions.ToList().AsReadOnly(),
+					ResolutionType = EscalationResolutionType.TimedOut,
+					ResolvedAt = DateTimeOffset.UtcNow,
+					Approvers = state.Request.Approvers
+				};
+				MarkResolving(state, outcome);
+			}
+
+			EscalationMetrics.Timeouts.Add(1,
+				new KeyValuePair<string, object?>(EscalationConventions.Priority,
+					ToPriorityTag(state.Request.Priority)));
+
+			_logger.LogWarning(
+				"Escalation {EscalationId} timed out with action {TimeoutAction}",
+				state.Request.EscalationId, state.Request.TimeoutAction);
+
+			await ResolveEscalationAsync(state, outcome);
+		}
+		finally
+		{
+			// Same teardown race as the acquire: the gate can be disposed underneath a
+			// long-running resolution when the host shuts down mid-flight.
+			try
+			{
+				state.WriteGate.Release();
+			}
+			catch (ObjectDisposedException)
+			{
+				// Torn down while resolving; nothing left to release.
+			}
+		}
+	}
+
+	/// <summary>
+	/// Decides the verdict a timeout produces, downgrading <c>Approve</c> to a denial for a
+	/// rehydrated escalation whose deadline elapsed while the host was down.
+	/// </summary>
+	/// <remarks>
+	/// <b>The fail-open this closes.</b> A 5-minute escalation queued just before a 30-minute
+	/// deploy would, on restart, fire its timeout microseconds after rehydration — granting
+	/// <c>TimeoutAction.Approve</c> before any approver could possibly have seen it, and
+	/// rehydration deliberately re-sends no notifications, so none ever would. Pre-durability a
+	/// restart merely lost the escalation; auto-approving it is a strictly worse outcome that
+	/// this feature would otherwise introduce.
+	/// <para>
+	/// The chosen rule is <b>deny</b>, not a grace window: a grace window still auto-approves
+	/// on the second restart, and re-notifying would need a notification-idempotency story the
+	/// notifier does not have. Denying is fail-closed, needs no new state, and the requester
+	/// can re-raise the escalation — which re-notifies naturally.
+	/// </para>
+	/// </remarks>
+	/// <param name="state">The timing-out escalation.</param>
+	/// <returns>Whether the timeout grants approval.</returns>
+	private bool ResolveTimeoutApproval(EscalationState state)
+	{
+		var wouldApprove = state.Request.TimeoutAction == EscalationTimeoutAction.Approve;
+
+		// Consults the decision captured at restore rather than re-testing the deadline now:
+		// by the time this runs the delay has already elapsed, so a re-test is subject to timer
+		// granularity and clock steps and can wrongly report the deadline as still in future.
+		if (!wouldApprove || !state.ExpiredDuringDowntime)
+			return wouldApprove;
+
+		_logger.LogWarning(
+			"Rehydrated escalation {EscalationId} expired during downtime; downgrading TimeoutAction.Approve " +
+			"to a denial because no approver could have seen it and rehydration re-sends no notifications",
+			state.Request.EscalationId);
+		return false;
+	}
+
+	private void CleanupCancelledEscalation(EscalationState state)
+	{
+		lock (state.Lock)
+		{
+			if (state.IsResolved)
+				return;
+			state.IsResolved = true;
+		}
+
+		_activeEscalations.TryRemove(state.Request.EscalationId, out _);
+		state.TimeoutCts.Cancel();
+		state.Completion.TrySetCanceled();
+		state.DisposeSynchronizationPrimitives();
+		EscalationMetrics.Pending.Add(-1);
+
+		// Best-effort durable removal (no-op with the Null store): the blocking caller
+		// abandoned the escalation, so its record should not rehydrate. If the removal fails,
+		// the leftover Pending row rehydrates on the next start and resolves via its original
+		// timeout — noisy but safe, and preferable to blocking the caller's cancellation path.
+		_ = SafeExecuteAsync(
+			() => _stateStore.RemoveAsync(state.Request.EscalationId, CancellationToken.None),
+			"remove abandoned escalation state", state.Request.EscalationId);
+
+		_logger.LogWarning("Escalation {EscalationId} cancelled by caller",
+			state.Request.EscalationId);
+	}
+
+	private void RemoveFailedEscalation(EscalationState state)
+	{
+		if (_activeEscalations.TryRemove(state.Request.EscalationId, out _))
+		{
+			state.TimeoutCts.Cancel();
+			state.DisposeSynchronizationPrimitives();
+			EscalationMetrics.Pending.Add(-1);
+		}
+	}
+
+	private static void RecordResolutionMetrics(EscalationState state, EscalationOutcome outcome)
+	{
+		var durationMs = (outcome.ResolvedAt - state.CreatedAt).TotalMilliseconds;
+
+		EscalationMetrics.Resolutions.Add(1,
+			new KeyValuePair<string, object?>(EscalationConventions.ResolutionType,
+				ToResolutionTag(outcome.ResolutionType)),
+			new KeyValuePair<string, object?>(EscalationConventions.Priority,
+				ToPriorityTag(state.Request.Priority)));
+
+		EscalationMetrics.DurationMs.Record(durationMs,
+			new KeyValuePair<string, object?>(EscalationConventions.Priority,
+				ToPriorityTag(state.Request.Priority)));
+	}
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Escalation/DefaultEscalationService.Resolution.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Escalation/DefaultEscalationService.Resolution.cs
@@ -124,6 +124,15 @@ public sealed partial class DefaultEscalationService
 				outcome.EscalationId);
 		}
 
+		// The parked-awaiting-reconciliation marker is now false in fact, so clear it before the
+		// verdict becomes observable. Without this, a decision arriving in the window between the
+		// successful audit write and the removal from the active set below would be told the
+		// escalation is awaiting reconciliation (409) when it has actually just resolved.
+		lock (state.Lock)
+		{
+			state.ResolutionFailed = false;
+		}
+
 		// Retain the verdict ONLY after it has been durably audited, so GetOutcomeAsync — and thus
 		// the plan executor's resume reconciliation — can never act on a verdict that failed the
 		// fail-closed audit write above and was rolled back to the awaiting caller. Publish it
@@ -185,14 +194,8 @@ public sealed partial class DefaultEscalationService
 		// A disposed gate means the escalation was torn down (service disposal, caller
 		// cancellation) while this timeout task was still in flight. Timing it out is moot at
 		// that point, so bail out quietly rather than faulting a background task.
-		try
-		{
-			await state.WriteGate.WaitAsync(CancellationToken.None);
-		}
-		catch (ObjectDisposedException)
-		{
+		if (!await TryEnterWriteGateAsync(state, CancellationToken.None))
 			return;
-		}
 
 		try
 		{
@@ -229,14 +232,7 @@ public sealed partial class DefaultEscalationService
 		{
 			// Same teardown race as the acquire: the gate can be disposed underneath a
 			// long-running resolution when the host shuts down mid-flight.
-			try
-			{
-				state.WriteGate.Release();
-			}
-			catch (ObjectDisposedException)
-			{
-				// Torn down while resolving; nothing left to release.
-			}
+			ReleaseWriteGate(state);
 		}
 	}
 

--- a/src/Content/Infrastructure/Infrastructure.AI/Escalation/DefaultEscalationService.State.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Escalation/DefaultEscalationService.State.cs
@@ -1,0 +1,81 @@
+using Domain.AI.Escalation;
+
+namespace Infrastructure.AI.Escalation;
+
+/// <summary>
+/// The per-escalation mutable state held by <see cref="DefaultEscalationService"/> while an
+/// escalation is active, split out from the main partial so the orchestration logic and the state
+/// shape it guards can be read independently.
+/// </summary>
+public sealed partial class DefaultEscalationService
+{
+	/// <summary>Tracks the mutable state of an active escalation.</summary>
+	private sealed class EscalationState
+	{
+		public required EscalationRequest Request { get; init; }
+		public List<ApproverDecision> Decisions { get; } = [];
+		public TaskCompletionSource<EscalationOutcome> Completion { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+		public required CancellationTokenSource TimeoutCts { get; init; }
+		public required DateTimeOffset CreatedAt { get; init; }
+		public bool IsResolved { get; set; }
+
+		/// <summary>
+		/// True when this state was restored from the durable store rather than created in
+		/// this process.
+		/// </summary>
+		public bool WasRehydrated { get; init; }
+
+		/// <summary>
+		/// True when this state was rehydrated with its deadline ALREADY elapsed. Evaluated
+		/// once, at restore, and never re-derived: re-testing the deadline after the timeout
+		/// delay returns would let timer granularity or a backwards clock step report the
+		/// deadline as still in the future, skipping the fail-closed downgrade of
+		/// <c>TimeoutAction.Approve</c> and auto-approving an escalation no approver was
+		/// re-notified about. See <c>ResolveTimeoutApproval</c>.
+		/// </summary>
+		public bool ExpiredDuringDowntime { get; init; }
+
+		/// <summary>
+		/// The resolved outcome, stashed when <see cref="IsResolved"/> flips true so the
+		/// reconciler can re-drive a resolution whose fail-closed durable/audit writes faulted.
+		/// Null while the escalation is genuinely pending.
+		/// </summary>
+		public EscalationOutcome? PendingOutcome { get; set; }
+
+		/// <summary>
+		/// True while some path owns finalization of this resolution. Set in the SAME lock
+		/// block that sets <see cref="IsResolved"/>, so a reconcile pass can never claim a
+		/// resolution the live path is still driving — the window that otherwise lets a pass
+		/// finalize and notify while the live path then rolls back and tells the approver their
+		/// vote was NOT recorded. Cleared on rollback and on each resolution failure branch, so
+		/// a genuinely stuck state becomes claimable.
+		/// </summary>
+		public bool FinalizeClaimed { get; set; }
+
+		/// <summary>
+		/// True once a fail-closed durable or audit write failed during resolution, leaving the
+		/// escalation resolved-but-unrecorded. Distinguishes "parked awaiting reconciliation"
+		/// from a transient mid-resolution race, so a late decision gets an honest answer.
+		/// </summary>
+		public bool ResolutionFailed { get; set; }
+
+		/// <summary>
+		/// Serializes decision mutation plus its durable write for this escalation, making the
+		/// snapshot-to-persist step atomic against concurrent submissions.
+		/// </summary>
+		public SemaphoreSlim WriteGate { get; } = new(1, 1);
+
+		public readonly object Lock = new();
+
+		/// <summary>
+		/// Releases both disposable primitives this state owns. Every teardown path must call
+		/// this — disposing only <see cref="TimeoutCts"/> leaks the <see cref="WriteGate"/>'s
+		/// wait handle for the life of the process.
+		/// </summary>
+		public void DisposeSynchronizationPrimitives()
+		{
+			TimeoutCts.Dispose();
+			WriteGate.Dispose();
+		}
+	}
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Escalation/DefaultEscalationService.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Escalation/DefaultEscalationService.cs
@@ -301,10 +301,21 @@ public sealed partial class DefaultEscalationService : IEscalationService, IEsca
 	/// concurrent teardown has already disposed it.
 	/// </summary>
 	/// <remarks>
+	/// <para>
 	/// <see cref="CleanupCancelledEscalation"/> and <see cref="Dispose"/> dispose the gate while
-	/// other paths may be between their active-set lookup and this acquire. Every holder — the
-	/// decision path, the timeout path, and cancellation — funnels through this helper and
-	/// <see cref="ReleaseWriteGate"/> so the race is handled identically in all three.
+	/// other paths may be between their active-set lookup and this acquire. The three
+	/// request-driven holders — the decision path, the timeout path, and cancellation — funnel
+	/// through this helper and <see cref="ReleaseWriteGate"/> so the race is handled identically
+	/// in all three.
+	/// </para>
+	/// <para>
+	/// The reconciler is the one writer that does NOT take this gate. Its finalize path
+	/// (<c>TryFinalizeStuckStateAsync</c>, in the Durability partial) is serialized by a different
+	/// invariant: it may only act on a state whose <c>FinalizeClaimed</c> flag it flipped from
+	/// false to true while holding <c>state.Lock</c>, and it restores the flag on failure. That
+	/// claim, not the write gate, is what keeps a reconcile pass from finalizing an escalation
+	/// twice or racing a second pass.
+	/// </para>
 	/// </remarks>
 	/// <param name="state">The escalation whose gate to take.</param>
 	/// <param name="ct">Cancellation token.</param>
@@ -662,73 +673,5 @@ public sealed partial class DefaultEscalationService : IEscalationService, IEsca
 		_ => strategy.ToString().ToLowerInvariant()
 	};
 
-	/// <summary>Tracks the mutable state of an active escalation.</summary>
-	private sealed class EscalationState
-	{
-		public required EscalationRequest Request { get; init; }
-		public List<ApproverDecision> Decisions { get; } = [];
-		public TaskCompletionSource<EscalationOutcome> Completion { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
-		public required CancellationTokenSource TimeoutCts { get; init; }
-		public required DateTimeOffset CreatedAt { get; init; }
-		public bool IsResolved { get; set; }
-
-		/// <summary>
-		/// True when this state was restored from the durable store rather than created in
-		/// this process.
-		/// </summary>
-		public bool WasRehydrated { get; init; }
-
-		/// <summary>
-		/// True when this state was rehydrated with its deadline ALREADY elapsed. Evaluated
-		/// once, at restore, and never re-derived: re-testing the deadline after the timeout
-		/// delay returns would let timer granularity or a backwards clock step report the
-		/// deadline as still in the future, skipping the fail-closed downgrade of
-		/// <c>TimeoutAction.Approve</c> and auto-approving an escalation no approver was
-		/// re-notified about. See <c>ResolveTimeoutApproval</c>.
-		/// </summary>
-		public bool ExpiredDuringDowntime { get; init; }
-
-		/// <summary>
-		/// The resolved outcome, stashed when <see cref="IsResolved"/> flips true so the
-		/// reconciler can re-drive a resolution whose fail-closed durable/audit writes faulted.
-		/// Null while the escalation is genuinely pending.
-		/// </summary>
-		public EscalationOutcome? PendingOutcome { get; set; }
-
-		/// <summary>
-		/// True while some path owns finalization of this resolution. Set in the SAME lock
-		/// block that sets <see cref="IsResolved"/>, so a reconcile pass can never claim a
-		/// resolution the live path is still driving — the window that otherwise lets a pass
-		/// finalize and notify while the live path then rolls back and tells the approver their
-		/// vote was NOT recorded. Cleared on rollback and on each resolution failure branch, so
-		/// a genuinely stuck state becomes claimable.
-		/// </summary>
-		public bool FinalizeClaimed { get; set; }
-
-		/// <summary>
-		/// True once a fail-closed durable or audit write failed during resolution, leaving the
-		/// escalation resolved-but-unrecorded. Distinguishes "parked awaiting reconciliation"
-		/// from a transient mid-resolution race, so a late decision gets an honest answer.
-		/// </summary>
-		public bool ResolutionFailed { get; set; }
-
-		/// <summary>
-		/// Serializes decision mutation plus its durable write for this escalation, making the
-		/// snapshot-to-persist step atomic against concurrent submissions.
-		/// </summary>
-		public SemaphoreSlim WriteGate { get; } = new(1, 1);
-
-		public readonly object Lock = new();
-
-		/// <summary>
-		/// Releases both disposable primitives this state owns. Every teardown path must call
-		/// this — disposing only <see cref="TimeoutCts"/> leaks the <see cref="WriteGate"/>'s
-		/// wait handle for the life of the process.
-		/// </summary>
-		public void DisposeSynchronizationPrimitives()
-		{
-			TimeoutCts.Dispose();
-			WriteGate.Dispose();
-		}
-	}
+	// The nested EscalationState class lives in DefaultEscalationService.State.cs.
 }

--- a/src/Content/Infrastructure/Infrastructure.AI/Escalation/DefaultEscalationService.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Escalation/DefaultEscalationService.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using Application.AI.Common.Exceptions;
 using Application.AI.Common.Interfaces.Escalation;
 using Application.AI.Common.OpenTelemetry.Metrics;
 using Domain.AI.Escalation;
@@ -17,27 +18,46 @@ namespace Infrastructure.AI.Escalation;
 /// <remarks>
 /// <para>
 /// Active escalations are held in memory via <see cref="ConcurrentDictionary{TKey,TValue}"/>.
-/// Process restart loses pending state. The <see cref="IEscalationAuditStore"/> provides
-/// durable compliance records, but automatic recovery from audit logs is not
-/// implemented (Phase 3+).
+/// The <see cref="IEscalationAuditStore"/> provides durable compliance records; the
+/// <see cref="IEscalationStateStore"/> provides durable <i>working</i> state. With the default
+/// <c>NullEscalationStateStore</c> (durability off), process restart loses pending state — the
+/// original in-memory contract, byte-for-byte. With the EF-backed store
+/// (<c>AppConfig:AI:Governance:DurableState:EscalationsEnabled</c>), every lifecycle transition
+/// is durably recorded fail-closed, and <see cref="RehydratePendingEscalationsAsync"/> restores
+/// pending escalations on startup as decidable, listable, and cancellable.
+/// </para>
+/// <para>
+/// What durability cannot restore: the <see cref="TaskCompletionSource{TResult}"/> waiter a
+/// blocking <see cref="RequestEscalationAsync"/> caller holds is inherently per-process. After
+/// a restart no code is released by the eventual decision — resumed workflows poll
+/// <see cref="GetOutcomeAsync"/> (which falls back to the durable store) for the verdict, as the
+/// plan executor's resume path already does.
 /// </para>
 /// <para>
 /// Resolved outcomes are also retained in memory (see <see cref="_resolvedOutcomes"/>) so callers
 /// such as the plan executor can query a verdict via <see cref="GetOutcomeAsync"/> after the
-/// escalation has left the active set. Retention is process-lifetime and consistent with the
-/// active-state model above: a restart that loses a pending escalation would equally lose its
-/// resolved outcome, and such an escalation could never have been approved post-restart anyway.
+/// escalation has left the active set. Retention is process-lifetime; with durability enabled the
+/// durable store additionally serves outcomes resolved in previous process lifetimes.
 /// Escalations are human-scale, low-frequency events, so this retention does not grow unbounded in
 /// practice.
 /// </para>
+/// <para>
+/// The file is split by responsibility: this partial owns the public lifecycle surface,
+/// <c>DefaultEscalationService.Resolution.cs</c> owns resolution/timeout/teardown, and
+/// <c>DefaultEscalationService.Durability.cs</c> owns rehydration and the
+/// <see cref="IEscalationReconciler"/> recovery path for the audit-outage stuck state.
+/// </para>
 /// </remarks>
-public sealed class DefaultEscalationService : IEscalationService, IDisposable
+public sealed partial class DefaultEscalationService : IEscalationService, IEscalationReconciler, IDisposable
 {
 	private readonly ConcurrentDictionary<Guid, EscalationState> _activeEscalations = new();
 	private readonly ConcurrentDictionary<Guid, EscalationOutcome> _resolvedOutcomes = new();
+	private readonly SemaphoreSlim _reconcileGate = new(1, 1);
+	private int _disposed;
 	private readonly IServiceProvider _serviceProvider;
 	private readonly IEscalationNotifier _notifier;
 	private readonly IEscalationAuditStore _auditStore;
+	private readonly IEscalationStateStore _stateStore;
 	private readonly IOptionsMonitor<EscalationConfig> _config;
 	private readonly ILogger<DefaultEscalationService> _logger;
 
@@ -47,18 +67,25 @@ public sealed class DefaultEscalationService : IEscalationService, IDisposable
 	/// <param name="serviceProvider">Service provider for resolving keyed <see cref="IApprovalStrategy"/> instances.</param>
 	/// <param name="notifier">Fan-out notification dispatcher for escalation events.</param>
 	/// <param name="auditStore">Durable audit trail for compliance recording.</param>
+	/// <param name="stateStore">
+	/// Durable working-state store. The composition root supplies the no-op
+	/// <c>NullEscalationStateStore</c> when durable escalation state is disabled (the default),
+	/// which preserves in-memory-only behavior exactly.
+	/// </param>
 	/// <param name="config">Escalation configuration (defaults, priority overrides).</param>
 	/// <param name="logger">Structured logger.</param>
 	public DefaultEscalationService(
 		IServiceProvider serviceProvider,
 		IEscalationNotifier notifier,
 		IEscalationAuditStore auditStore,
+		IEscalationStateStore stateStore,
 		IOptionsMonitor<EscalationConfig> config,
 		ILogger<DefaultEscalationService> logger)
 	{
 		_serviceProvider = serviceProvider;
 		_notifier = notifier;
 		_auditStore = auditStore;
+		_stateStore = stateStore;
 		_config = config;
 		_logger = logger;
 	}
@@ -160,53 +187,143 @@ public sealed class DefaultEscalationService : IEscalationService, IDisposable
 		EscalationMetrics.ApproverResponseMs.Record(elapsed.TotalMilliseconds,
 			new KeyValuePair<string, object?>(EscalationConventions.ApproverName, decision.ApproverName));
 
+		return await ApplyDecisionAsync(state, decision, ct);
+	}
+
+	/// <summary>
+	/// Applies a vetted decision: mutates the in-memory decision list, evaluates the strategy,
+	/// and durably persists the new list — all inside the per-escalation write gate.
+	/// </summary>
+	/// <remarks>
+	/// The gate is what makes "compute the snapshot" and "persist the snapshot" atomic with
+	/// respect to other submissions on the same escalation. Without it, two concurrent
+	/// non-resolving approvals under AllOf can each build a snapshot inside the lock, release,
+	/// and then write out of order: last-write-wins persists the shorter list, so a restart
+	/// silently loses an approval that in-memory state still shows. Serializing per escalation
+	/// (not globally) keeps unrelated escalations independent.
+	/// </remarks>
+	/// <param name="state">The active escalation.</param>
+	/// <param name="decision">The decision to apply.</param>
+	/// <param name="ct">Cancellation token.</param>
+	private async Task<EscalationDecisionResult> ApplyDecisionAsync(
+		EscalationState state, ApproverDecision decision, CancellationToken ct)
+	{
 		var strategy = _serviceProvider.GetRequiredKeyedService<IApprovalStrategy>(state.Request.ApprovalStrategy);
-		EscalationOutcome? outcome;
 
-		lock (state.Lock)
+		await state.WriteGate.WaitAsync(ct);
+		try
 		{
-			// Recorded for audit above, but another decision resolved the escalation
-			// concurrently — this one arrives too late to participate. The caller polls
-			// GetOutcomeAsync for the verdict (see EscalationDecisionStatus.DecisionRecorded).
-			if (state.IsResolved)
-				return EscalationDecisionResult.DecisionRecorded();
+			EscalationOutcome? outcome;
+			IReadOnlyList<ApproverDecision> decisionsSnapshot;
 
-			// Closes the race two concurrent submissions from the same approver can win against
-			// the pre-audit duplicate check: only the first may enter the decision list, and a
-			// contradicting verdict is a conflict here exactly as at the chokepoint above.
-			if (TryGetExistingDecision(state, decision.ApproverName) is { } raced)
+			lock (state.Lock)
 			{
-				return raced.Approved != decision.Approved
-					? EscalationDecisionResult.ConflictingDecision()
-					: EscalationDecisionResult.DecisionRecorded();
+				// A verdict was already reached without this decision. If the resolution is
+				// parked on a failed durable/audit write, say so plainly rather than reporting
+				// a vote recorded that was in fact discarded.
+				if (state.IsResolved)
+				{
+					return state.ResolutionFailed
+						? EscalationDecisionResult.AwaitingReconciliation()
+						: EscalationDecisionResult.DecisionRecorded();
+				}
+
+				// Closes the race two concurrent submissions from the same approver can win against
+				// the pre-audit duplicate check: only the first may enter the decision list, and a
+				// contradicting verdict is a conflict here exactly as at the chokepoint above.
+				if (TryGetExistingDecision(state, decision.ApproverName) is { } raced)
+				{
+					return raced.Approved != decision.Approved
+						? EscalationDecisionResult.ConflictingDecision()
+						: EscalationDecisionResult.DecisionRecorded();
+				}
+
+				state.Decisions.Add(decision);
+				decisionsSnapshot = state.Decisions.ToList().AsReadOnly();
+				outcome = EvaluateResolution(state, strategy);
 			}
 
-			state.Decisions.Add(decision);
-			var evaluation = strategy.EvaluateDecision(state.Request, state.Decisions.AsReadOnly());
+			// Fail-closed durable decision write (no-op with the Null store): the decision must
+			// be durably recorded before it is reported recorded.
+			try
+			{
+				await _stateStore.SaveDecisionsAsync(state.Request.EscalationId, decisionsSnapshot, ct);
+			}
+			catch (Exception ex)
+			{
+				RollBackDecision(state, decision);
+				_logger.LogError(ex,
+					"Durable decision write failed for escalation {EscalationId}; failing closed (decision not recorded)",
+					state.Request.EscalationId);
+				throw new EscalationDurableStateException(
+					EscalationDurableStateException.DurableWriteFailedCode, ex);
+			}
 
-			_logger.LogDebug(
-				"Strategy evaluation for {EscalationId}: IsResolved={IsResolved}, IsApproved={IsApproved}",
-				escalationId, evaluation.IsResolved, evaluation.IsApproved);
-
-			if (!evaluation.IsResolved)
+			if (outcome is null)
 				return EscalationDecisionResult.DecisionRecorded();
 
-			state.IsResolved = true;
-			outcome = new EscalationOutcome
-			{
-				EscalationId = escalationId,
-				IsApproved = evaluation.IsApproved,
-				Decisions = state.Decisions.ToList().AsReadOnly(),
-				ResolutionType = evaluation.IsApproved
-					? EscalationResolutionType.Approved
-					: EscalationResolutionType.Denied,
-				ResolvedAt = DateTimeOffset.UtcNow,
-				Approvers = state.Request.Approvers
-			};
+			await ResolveEscalationAsync(state, outcome);
+			return EscalationDecisionResult.Resolved(outcome);
 		}
+		finally
+		{
+			state.WriteGate.Release();
+		}
+	}
 
-		await ResolveEscalationAsync(state, outcome);
-		return EscalationDecisionResult.Resolved(outcome);
+	/// <summary>
+	/// Evaluates the approval strategy against the current decision list and, when it resolves,
+	/// marks the state resolved and stashes the outcome. Must be called under
+	/// <see cref="EscalationState.Lock"/>.
+	/// </summary>
+	/// <param name="state">The active escalation.</param>
+	/// <param name="strategy">The approval strategy for this escalation.</param>
+	/// <returns>The resolved outcome, or null when the escalation remains pending.</returns>
+	private EscalationOutcome? EvaluateResolution(EscalationState state, IApprovalStrategy strategy)
+	{
+		var evaluation = strategy.EvaluateDecision(state.Request, state.Decisions.AsReadOnly());
+
+		_logger.LogDebug(
+			"Strategy evaluation for {EscalationId}: IsResolved={IsResolved}, IsApproved={IsApproved}",
+			state.Request.EscalationId, evaluation.IsResolved, evaluation.IsApproved);
+
+		if (!evaluation.IsResolved)
+			return null;
+
+		var outcome = new EscalationOutcome
+		{
+			EscalationId = state.Request.EscalationId,
+			IsApproved = evaluation.IsApproved,
+			Decisions = state.Decisions.ToList().AsReadOnly(),
+			ResolutionType = evaluation.IsApproved
+				? EscalationResolutionType.Approved
+				: EscalationResolutionType.Denied,
+			ResolvedAt = DateTimeOffset.UtcNow,
+			Approvers = state.Request.Approvers
+		};
+
+		MarkResolving(state, outcome);
+		return outcome;
+	}
+
+	/// <summary>
+	/// Backs the in-memory mutation out after a failed durable decision write, so a retry once
+	/// the store recovers replays cleanly instead of being rejected as a duplicate by a ghost
+	/// decision the durable store never accepted. Also releases the finalize claim so a
+	/// genuinely stuck state stays claimable by the reconciler.
+	/// </summary>
+	/// <param name="state">The active escalation.</param>
+	/// <param name="decision">The decision to remove.</param>
+	private static void RollBackDecision(EscalationState state, ApproverDecision decision)
+	{
+		lock (state.Lock)
+		{
+			state.Decisions.Remove(decision);
+			state.IsResolved = false;
+			state.PendingOutcome = null;
+			state.FinalizeClaimed = false;
+			state.ResolutionFailed = false;
+		}
 	}
 
 	/// <inheritdoc />
@@ -217,10 +334,16 @@ public sealed class DefaultEscalationService : IEscalationService, IDisposable
 	}
 
 	/// <inheritdoc />
-	public Task<EscalationOutcome?> GetOutcomeAsync(Guid escalationId, CancellationToken ct)
+	public async Task<EscalationOutcome?> GetOutcomeAsync(Guid escalationId, CancellationToken ct)
 	{
-		_resolvedOutcomes.TryGetValue(escalationId, out var outcome);
-		return Task.FromResult(outcome);
+		if (_resolvedOutcomes.TryGetValue(escalationId, out var outcome))
+			return outcome;
+
+		// Post-restart fallback: verdicts resolved and audited in a previous process lifetime
+		// are served from the durable store. The store only surfaces terminally-Resolved
+		// records (never ResolvedPendingAudit) and only when their seal verifies, so neither an
+		// un-audited nor a tampered outcome is observable. Null store returns null (parity).
+		return await _stateStore.GetResolvedOutcomeAsync(escalationId, ct);
 	}
 
 	/// <inheritdoc />
@@ -250,7 +373,6 @@ public sealed class DefaultEscalationService : IEscalationService, IDisposable
 			if (state.IsResolved)
 				throw new InvalidOperationException($"Escalation {escalationId} is already resolved");
 
-			state.IsResolved = true;
 			outcome = new EscalationOutcome
 			{
 				EscalationId = escalationId,
@@ -263,6 +385,7 @@ public sealed class DefaultEscalationService : IEscalationService, IDisposable
 				// so the force-denial is attributable to its actor, not just a log line.
 				CancelledBy = cancelledBy
 			};
+			MarkResolving(state, outcome);
 		}
 
 		_logger.LogInformation(
@@ -273,29 +396,53 @@ public sealed class DefaultEscalationService : IEscalationService, IDisposable
 	}
 
 	/// <inheritdoc />
+	/// <remarks>
+	/// Waits briefly for an in-flight reconcile pass to finish before disposing its gate: a
+	/// pass mid-<c>RecordOutcomeAsync</c> holds the gate, and disposing underneath it would
+	/// surface as an <see cref="ObjectDisposedException"/> from the release in its finally
+	/// block, masking the real shutdown. If the wait times out the gate is left undisposed —
+	/// a bounded leak on a shutting-down process is strictly better than tearing down a
+	/// compliance write mid-flight.
+	/// </remarks>
 	public void Dispose()
 	{
+		// Idempotent: a singleton can be disposed by both the container and a test fixture,
+		// and the reconcile-gate wait below would throw on a second pass.
+		if (Interlocked.Exchange(ref _disposed, 1) != 0)
+			return;
+
 		foreach (var state in _activeEscalations.Values)
 		{
 			state.Completion.TrySetCanceled();
 			state.TimeoutCts.Cancel();
-			state.TimeoutCts.Dispose();
+			state.DisposeSynchronizationPrimitives();
 		}
 		_activeEscalations.Clear();
+
+		if (_reconcileGate.Wait(TimeSpan.FromSeconds(5)))
+		{
+			_reconcileGate.Release();
+			_reconcileGate.Dispose();
+		}
+		else
+		{
+			_logger.LogWarning(
+				"A reconcile pass was still running at shutdown; leaving its gate undisposed rather than " +
+				"faulting the in-flight pass");
+		}
 	}
 
 	private EscalationState InitializeEscalation(EscalationRequest request)
 	{
-		if (request.Approvers.Count == 0)
+		// Fail closed at creation. The same invariants gate the durable rehydration path, so a
+		// hand-edited row can never produce a live escalation the creation path would refuse.
+		if (!EscalationRequestInvariants.TryValidate(request, out var violation))
 		{
-			// Fail closed at creation: an escalation with no approver roster can never be
-			// legitimately approved. Admitting it would let the AllOf strategy treat "nobody
-			// pending" as vacuously unanimous, or the timeout Approve action grant it silently.
 			_logger.LogWarning(
-				"Rejected escalation {EscalationId} for agent {AgentId}: empty approver roster",
-				request.EscalationId, request.AgentId);
+				"Rejected escalation {EscalationId} for agent {AgentId}: {Violation}",
+				request.EscalationId, request.AgentId, violation);
 			throw new InvalidOperationException(
-				$"Escalation {request.EscalationId} has no approvers; refusing to create an escalation that cannot be approved.");
+				$"Escalation {request.EscalationId} is invalid: {violation}.");
 		}
 
 		var state = new EscalationState
@@ -329,168 +476,32 @@ public sealed class DefaultEscalationService : IEscalationService, IDisposable
 		// half-created escalation and surfaces the failure. Notification stays best-effort.
 		await _auditStore.RecordRequestAsync(state.Request, ct);
 
-		await SafeExecuteAsync(
-			() => _notifier.NotifyEscalationRequestedAsync(state.Request, ct),
-			"notify request", state.Request.EscalationId);
-	}
-
-	private void RemoveFailedEscalation(EscalationState state)
-	{
-		if (_activeEscalations.TryRemove(state.Request.EscalationId, out _))
-		{
-			state.TimeoutCts.Cancel();
-			state.TimeoutCts.Dispose();
-			EscalationMetrics.Pending.Add(-1);
-		}
-	}
-
-	private async Task ResolveEscalationAsync(EscalationState state, EscalationOutcome outcome)
-	{
-		// Idempotency / teardown guard: if the completion was already settled
-		// (e.g. the service was disposed and cancelled it), don't re-run cleanup.
-		// Each caller (SubmitDecision/Cancel/Timeout) sets IsResolved under the
-		// state lock before calling here, so this runs at most once per escalation.
-		if (state.Completion.Task.IsCompleted)
-			return;
-
-		state.TimeoutCts.Cancel();
-
-		// Record the audit outcome BEFORE releasing the caller awaiting Completion.Task.
-		// The durable outcome write is fail-CLOSED: if it throws, the escalation must NOT
-		// be reported as resolved. Propagate the failure to the awaiting caller instead of
-		// delivering an approval that was never recorded for compliance. (SafeExecuteAsync
-		// is reserved for best-effort notification, never for the durable audit write.)
-		// The escalation deliberately stays in _activeEscalations on failure: it must remain
-		// observable (a resolved-but-unaudited escalation vanishing entirely would read as an
-		// unknown id to every poller) rather than dropping into a state no reader can see.
+		// Durable working-state write, equally fail-closed: an escalation that cannot be
+		// durably created must not open, or a restart would silently strand an approvable
+		// escalation. No-op with the Null store (durability disabled).
 		try
 		{
-			await _auditStore.RecordOutcomeAsync(outcome, CancellationToken.None);
+			await _stateStore.SavePendingAsync(state.Request, state.CreatedAt, ct);
 		}
 		catch (Exception ex)
 		{
 			_logger.LogError(ex,
-				"Failed to record outcome for escalation {EscalationId}; failing closed (escalation not reported resolved)",
-				outcome.EscalationId);
-			state.Completion.TrySetException(ex);
-			throw;
+				"Durable create failed for escalation {EscalationId}; failing closed (escalation not opened)",
+				state.Request.EscalationId);
+			throw new EscalationDurableStateException(
+				EscalationDurableStateException.DurableCreateFailedCode, ex);
 		}
-
-		// Retain the verdict ONLY after it has been durably audited, so GetOutcomeAsync — and thus
-		// the plan executor's resume reconciliation — can never act on a verdict that failed the
-		// fail-closed audit write above and was rolled back to the awaiting caller. Publish it
-		// BEFORE removing the escalation from the active set: a reader landing between the two
-		// steps sees at least one view (brief dual presence is fine — readers check the active
-		// set first and simply serve the pending view), never the spurious not-found a
-		// remove-then-publish order produced on exactly the poll the 202 contract prescribes.
-		_resolvedOutcomes[outcome.EscalationId] = outcome;
-		_activeEscalations.TryRemove(state.Request.EscalationId, out _);
-
-		EscalationMetrics.Pending.Add(-1);
-		RecordResolutionMetrics(state, outcome);
-
-		_logger.LogInformation(
-			"Escalation {EscalationId} resolved: {ResolutionType}, approved={IsApproved}",
-			outcome.EscalationId, outcome.ResolutionType, outcome.IsApproved);
 
 		await SafeExecuteAsync(
-			() => _notifier.NotifyEscalationResolvedAsync(outcome, CancellationToken.None),
-			"notify resolution", outcome.EscalationId);
-
-		state.Completion.TrySetResult(outcome);
-	}
-
-	private async Task RunTimeoutAsync(EscalationState state)
-	{
-		try
-		{
-			await Task.Delay(
-				TimeSpan.FromSeconds(state.Request.TimeoutSeconds),
-				state.TimeoutCts.Token);
-
-			await HandleTimeoutAsync(state);
-		}
-		catch (OperationCanceledException)
-		{
-			// Escalation resolved or caller cancelled before timeout -- normal path
-		}
-		catch (Exception ex)
-		{
-			_logger.LogError(ex, "Unexpected error in timeout handler for escalation {EscalationId}",
-				state.Request.EscalationId);
-		}
-	}
-
-	private async Task HandleTimeoutAsync(EscalationState state)
-	{
-		EscalationOutcome? outcome;
-
-		lock (state.Lock)
-		{
-			if (state.IsResolved)
-				return;
-
-			state.IsResolved = true;
-
-			outcome = new EscalationOutcome
-			{
-				EscalationId = state.Request.EscalationId,
-				IsApproved = state.Request.TimeoutAction == EscalationTimeoutAction.Approve,
-				Decisions = state.Decisions.ToList().AsReadOnly(),
-				ResolutionType = EscalationResolutionType.TimedOut,
-				ResolvedAt = DateTimeOffset.UtcNow,
-				Approvers = state.Request.Approvers
-			};
-		}
-
-		EscalationMetrics.Timeouts.Add(1,
-			new KeyValuePair<string, object?>(EscalationConventions.Priority,
-				ToPriorityTag(state.Request.Priority)));
-
-		_logger.LogWarning(
-			"Escalation {EscalationId} timed out with action {TimeoutAction}",
-			state.Request.EscalationId, state.Request.TimeoutAction);
-
-		await ResolveEscalationAsync(state, outcome);
-	}
-
-	private void CleanupCancelledEscalation(EscalationState state)
-	{
-		lock (state.Lock)
-		{
-			if (state.IsResolved)
-				return;
-			state.IsResolved = true;
-		}
-
-		_activeEscalations.TryRemove(state.Request.EscalationId, out _);
-		state.TimeoutCts.Cancel();
-		state.Completion.TrySetCanceled();
-		EscalationMetrics.Pending.Add(-1);
-		_logger.LogWarning("Escalation {EscalationId} cancelled by caller",
-			state.Request.EscalationId);
-	}
-
-	private static void RecordResolutionMetrics(EscalationState state, EscalationOutcome outcome)
-	{
-		var durationMs = (outcome.ResolvedAt - state.CreatedAt).TotalMilliseconds;
-
-		EscalationMetrics.Resolutions.Add(1,
-			new KeyValuePair<string, object?>(EscalationConventions.ResolutionType,
-				ToResolutionTag(outcome.ResolutionType)),
-			new KeyValuePair<string, object?>(EscalationConventions.Priority,
-				ToPriorityTag(state.Request.Priority)));
-
-		EscalationMetrics.DurationMs.Record(durationMs,
-			new KeyValuePair<string, object?>(EscalationConventions.Priority,
-				ToPriorityTag(state.Request.Priority)));
+			() => _notifier.NotifyEscalationRequestedAsync(state.Request, ct),
+			"notify request", state.Request.EscalationId);
 	}
 
 	/// <summary>
 	/// Returns this approver's already-recorded decision on the escalation, or null when none
 	/// exists, using <see cref="ApproverNames.Comparer"/> so a casing-variant retry is still a
 	/// duplicate. Takes the state lock itself, so callers may invoke it lock-free; the in-lock
-	/// re-check in <see cref="SubmitDecisionAsync"/> relies on the lock being reentrant for the
+	/// re-check in <see cref="ApplyDecisionAsync"/> relies on the lock being reentrant for the
 	/// same thread.
 	/// </summary>
 	private static ApproverDecision? TryGetExistingDecision(EscalationState state, string approverName)
@@ -549,6 +560,64 @@ public sealed class DefaultEscalationService : IEscalationService, IDisposable
 		public required CancellationTokenSource TimeoutCts { get; init; }
 		public required DateTimeOffset CreatedAt { get; init; }
 		public bool IsResolved { get; set; }
+
+		/// <summary>
+		/// True when this state was restored from the durable store rather than created in
+		/// this process.
+		/// </summary>
+		public bool WasRehydrated { get; init; }
+
+		/// <summary>
+		/// True when this state was rehydrated with its deadline ALREADY elapsed. Evaluated
+		/// once, at restore, and never re-derived: re-testing the deadline after the timeout
+		/// delay returns would let timer granularity or a backwards clock step report the
+		/// deadline as still in the future, skipping the fail-closed downgrade of
+		/// <c>TimeoutAction.Approve</c> and auto-approving an escalation no approver was
+		/// re-notified about. See <c>ResolveTimeoutApproval</c>.
+		/// </summary>
+		public bool ExpiredDuringDowntime { get; init; }
+
+		/// <summary>
+		/// The resolved outcome, stashed when <see cref="IsResolved"/> flips true so the
+		/// reconciler can re-drive a resolution whose fail-closed durable/audit writes faulted.
+		/// Null while the escalation is genuinely pending.
+		/// </summary>
+		public EscalationOutcome? PendingOutcome { get; set; }
+
+		/// <summary>
+		/// True while some path owns finalization of this resolution. Set in the SAME lock
+		/// block that sets <see cref="IsResolved"/>, so a reconcile pass can never claim a
+		/// resolution the live path is still driving — the window that otherwise lets a pass
+		/// finalize and notify while the live path then rolls back and tells the approver their
+		/// vote was NOT recorded. Cleared on rollback and on each resolution failure branch, so
+		/// a genuinely stuck state becomes claimable.
+		/// </summary>
+		public bool FinalizeClaimed { get; set; }
+
+		/// <summary>
+		/// True once a fail-closed durable or audit write failed during resolution, leaving the
+		/// escalation resolved-but-unrecorded. Distinguishes "parked awaiting reconciliation"
+		/// from a transient mid-resolution race, so a late decision gets an honest answer.
+		/// </summary>
+		public bool ResolutionFailed { get; set; }
+
+		/// <summary>
+		/// Serializes decision mutation plus its durable write for this escalation, making the
+		/// snapshot-to-persist step atomic against concurrent submissions.
+		/// </summary>
+		public SemaphoreSlim WriteGate { get; } = new(1, 1);
+
 		public readonly object Lock = new();
+
+		/// <summary>
+		/// Releases both disposable primitives this state owns. Every teardown path must call
+		/// this — disposing only <see cref="TimeoutCts"/> leaks the <see cref="WriteGate"/>'s
+		/// wait handle for the life of the process.
+		/// </summary>
+		public void DisposeSynchronizationPrimitives()
+		{
+			TimeoutCts.Dispose();
+			WriteGate.Dispose();
+		}
 	}
 }

--- a/src/Content/Infrastructure/Infrastructure.AI/Escalation/DefaultEscalationService.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Escalation/DefaultEscalationService.cs
@@ -210,64 +210,133 @@ public sealed partial class DefaultEscalationService : IEscalationService, IEsca
 	{
 		var strategy = _serviceProvider.GetRequiredKeyedService<IApprovalStrategy>(state.Request.ApprovalStrategy);
 
-		await state.WriteGate.WaitAsync(ct);
+		// The gate can be disposed underneath us by a teardown (caller cancellation, service
+		// disposal) that raced the active-set lookup in SubmitDecisionAsync. Report the
+		// escalation as unknown — exactly what a lookup a moment later would say — rather than
+		// letting an ObjectDisposedException escape to the approver as a 500.
+		if (!await TryEnterWriteGateAsync(state, ct))
+		{
+			_logger.LogWarning(
+				"Escalation {EscalationId} was torn down while a decision from {ApproverName} was in flight; " +
+				"reporting it unknown",
+				state.Request.EscalationId, decision.ApproverName);
+			return EscalationDecisionResult.UnknownEscalation();
+		}
+
 		try
 		{
-			EscalationOutcome? outcome;
-			IReadOnlyList<ApproverDecision> decisionsSnapshot;
-
-			lock (state.Lock)
-			{
-				// A verdict was already reached without this decision. If the resolution is
-				// parked on a failed durable/audit write, say so plainly rather than reporting
-				// a vote recorded that was in fact discarded.
-				if (state.IsResolved)
-				{
-					return state.ResolutionFailed
-						? EscalationDecisionResult.AwaitingReconciliation()
-						: EscalationDecisionResult.DecisionRecorded();
-				}
-
-				// Closes the race two concurrent submissions from the same approver can win against
-				// the pre-audit duplicate check: only the first may enter the decision list, and a
-				// contradicting verdict is a conflict here exactly as at the chokepoint above.
-				if (TryGetExistingDecision(state, decision.ApproverName) is { } raced)
-				{
-					return raced.Approved != decision.Approved
-						? EscalationDecisionResult.ConflictingDecision()
-						: EscalationDecisionResult.DecisionRecorded();
-				}
-
-				state.Decisions.Add(decision);
-				decisionsSnapshot = state.Decisions.ToList().AsReadOnly();
-				outcome = EvaluateResolution(state, strategy);
-			}
-
-			// Fail-closed durable decision write (no-op with the Null store): the decision must
-			// be durably recorded before it is reported recorded.
-			try
-			{
-				await _stateStore.SaveDecisionsAsync(state.Request.EscalationId, decisionsSnapshot, ct);
-			}
-			catch (Exception ex)
-			{
-				RollBackDecision(state, decision);
-				_logger.LogError(ex,
-					"Durable decision write failed for escalation {EscalationId}; failing closed (decision not recorded)",
-					state.Request.EscalationId);
-				throw new EscalationDurableStateException(
-					EscalationDurableStateException.DurableWriteFailedCode, ex);
-			}
-
-			if (outcome is null)
-				return EscalationDecisionResult.DecisionRecorded();
-
-			await ResolveEscalationAsync(state, outcome);
-			return EscalationDecisionResult.Resolved(outcome);
+			return await ApplyDecisionUnderGateAsync(state, decision, strategy, ct);
 		}
 		finally
 		{
+			ReleaseWriteGate(state);
+		}
+	}
+
+	/// <summary>
+	/// The body of <see cref="ApplyDecisionAsync"/>, run with the escalation's write gate held.
+	/// </summary>
+	/// <param name="state">The active escalation.</param>
+	/// <param name="decision">The decision to apply.</param>
+	/// <param name="strategy">The approval strategy for this escalation.</param>
+	/// <param name="ct">Cancellation token.</param>
+	private async Task<EscalationDecisionResult> ApplyDecisionUnderGateAsync(
+		EscalationState state, ApproverDecision decision, IApprovalStrategy strategy, CancellationToken ct)
+	{
+		EscalationOutcome? outcome;
+		IReadOnlyList<ApproverDecision> decisionsSnapshot;
+
+		lock (state.Lock)
+		{
+			// A verdict was already reached without this decision. If the resolution is
+			// parked on a failed durable/audit write, say so plainly rather than reporting
+			// a vote recorded that was in fact discarded.
+			if (state.IsResolved)
+			{
+				return state.ResolutionFailed
+					? EscalationDecisionResult.AwaitingReconciliation()
+					: EscalationDecisionResult.DecisionRecorded();
+			}
+
+			// Closes the race two concurrent submissions from the same approver can win against
+			// the pre-audit duplicate check: only the first may enter the decision list, and a
+			// contradicting verdict is a conflict here exactly as at the chokepoint above.
+			if (TryGetExistingDecision(state, decision.ApproverName) is { } raced)
+			{
+				return raced.Approved != decision.Approved
+					? EscalationDecisionResult.ConflictingDecision()
+					: EscalationDecisionResult.DecisionRecorded();
+			}
+
+			state.Decisions.Add(decision);
+			decisionsSnapshot = state.Decisions.ToList().AsReadOnly();
+			outcome = EvaluateResolution(state, strategy);
+		}
+
+		// Fail-closed durable decision write (no-op with the Null store): the decision must
+		// be durably recorded before it is reported recorded.
+		try
+		{
+			await _stateStore.SaveDecisionsAsync(state.Request.EscalationId, decisionsSnapshot, ct);
+		}
+		catch (Exception ex)
+		{
+			RollBackDecision(state, decision);
+			_logger.LogError(ex,
+				"Durable decision write failed for escalation {EscalationId}; failing closed (decision not recorded)",
+				state.Request.EscalationId);
+			throw new EscalationDurableStateException(
+				EscalationDurableStateException.DurableWriteFailedCode, ex);
+		}
+
+		if (outcome is null)
+			return EscalationDecisionResult.DecisionRecorded();
+
+		await ResolveEscalationAsync(state, outcome);
+		return EscalationDecisionResult.Resolved(outcome);
+	}
+
+	/// <summary>
+	/// Acquires an escalation's write gate, reporting false instead of throwing when a
+	/// concurrent teardown has already disposed it.
+	/// </summary>
+	/// <remarks>
+	/// <see cref="CleanupCancelledEscalation"/> and <see cref="Dispose"/> dispose the gate while
+	/// other paths may be between their active-set lookup and this acquire. Every holder — the
+	/// decision path, the timeout path, and cancellation — funnels through this helper and
+	/// <see cref="ReleaseWriteGate"/> so the race is handled identically in all three.
+	/// </remarks>
+	/// <param name="state">The escalation whose gate to take.</param>
+	/// <param name="ct">Cancellation token.</param>
+	/// <returns>True when the gate was acquired; false when it was already disposed.</returns>
+	private static async Task<bool> TryEnterWriteGateAsync(EscalationState state, CancellationToken ct)
+	{
+		try
+		{
+			await state.WriteGate.WaitAsync(ct);
+			return true;
+		}
+		catch (ObjectDisposedException)
+		{
+			return false;
+		}
+	}
+
+	/// <summary>
+	/// Releases an escalation's write gate, tolerating a teardown that disposed it while the
+	/// holder was still working. Never call unless <see cref="TryEnterWriteGateAsync"/> returned
+	/// true.
+	/// </summary>
+	/// <param name="state">The escalation whose gate to release.</param>
+	private static void ReleaseWriteGate(EscalationState state)
+	{
+		try
+		{
 			state.WriteGate.Release();
+		}
+		catch (ObjectDisposedException)
+		{
+			// Torn down while the holder was working; nothing left to release.
 		}
 	}
 
@@ -361,19 +430,66 @@ public sealed partial class DefaultEscalationService : IEscalationService, IEsca
 	}
 
 	/// <inheritdoc />
+	/// <remarks>
+	/// Takes the per-escalation write gate, exactly as the decision and timeout paths do.
+	/// Cancellation <em>resolves</em> an escalation, so running it concurrently with a decision
+	/// corrupts the resolution bookkeeping: a cancel that marks the state resolving while a
+	/// decision's durable write is in flight has that bookkeeping wiped by the write's failure
+	/// path (<see cref="RollBackDecision"/> clears <c>IsResolved</c>/<c>PendingOutcome</c>),
+	/// stranding the durable <c>ResolvedPendingAudit</c> row the cancel already wrote — the
+	/// in-memory reconcile shape skips it because <c>IsResolved</c> is false, the durable shape
+	/// skips it because the id is still in the active set, and the pruner correctly refuses to
+	/// delete a non-terminal row. Serializing on the gate removes the interleaving entirely.
+	/// <para>
+	/// Lock ordering is unchanged and deadlock-free: every holder takes the gate first and
+	/// <c>state.Lock</c> second, and no path holds <c>state.Lock</c> while waiting on the gate.
+	/// </para>
+	/// </remarks>
 	public async Task<EscalationOutcome> CancelEscalationAsync(
 		Guid escalationId, string reason, string cancelledBy, CancellationToken ct)
 	{
 		if (!_activeEscalations.TryGetValue(escalationId, out var state))
 			throw new InvalidOperationException($"No pending escalation found with ID {escalationId}");
 
-		EscalationOutcome outcome;
+		// A disposed gate means the escalation was torn down between the lookup and here; it is
+		// no longer pending, which is the same answer the lookup above would now give.
+		if (!await TryEnterWriteGateAsync(state, ct))
+			throw new InvalidOperationException($"No pending escalation found with ID {escalationId}");
+
+		try
+		{
+			var outcome = BuildCancellationOutcome(state, escalationId, cancelledBy);
+
+			_logger.LogInformation(
+				"Escalation {EscalationId} cancelled by {CancelledBy}: {Reason}",
+				escalationId, cancelledBy, reason);
+			await ResolveEscalationAsync(state, outcome);
+			return outcome;
+		}
+		finally
+		{
+			ReleaseWriteGate(state);
+		}
+	}
+
+	/// <summary>
+	/// Builds the force-denial outcome for a cancellation and marks the state resolving, under
+	/// the state lock. Callers must already hold the escalation's write gate.
+	/// </summary>
+	/// <param name="state">The escalation being cancelled.</param>
+	/// <param name="escalationId">The escalation id (for the failure message).</param>
+	/// <param name="cancelledBy">The actor performing the cancellation.</param>
+	/// <returns>The denial outcome to drive through resolution.</returns>
+	/// <exception cref="InvalidOperationException">The escalation is already resolved.</exception>
+	private static EscalationOutcome BuildCancellationOutcome(
+		EscalationState state, Guid escalationId, string cancelledBy)
+	{
 		lock (state.Lock)
 		{
 			if (state.IsResolved)
 				throw new InvalidOperationException($"Escalation {escalationId} is already resolved");
 
-			outcome = new EscalationOutcome
+			var outcome = new EscalationOutcome
 			{
 				EscalationId = escalationId,
 				IsApproved = false,
@@ -386,13 +502,8 @@ public sealed partial class DefaultEscalationService : IEscalationService, IEsca
 				CancelledBy = cancelledBy
 			};
 			MarkResolving(state, outcome);
+			return outcome;
 		}
-
-		_logger.LogInformation(
-			"Escalation {EscalationId} cancelled by {CancelledBy}: {Reason}",
-			escalationId, cancelledBy, reason);
-		await ResolveEscalationAsync(state, outcome);
-		return outcome;
 	}
 
 	/// <inheritdoc />

--- a/src/Content/Infrastructure/Infrastructure.AI/Escalation/EfCoreEscalationStateStore.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Escalation/EfCoreEscalationStateStore.cs
@@ -78,9 +78,6 @@ public sealed class EfCoreEscalationStateStore : IEscalationStateStore
     private int MaxScanRecords =>
         Math.Max(1, _config.CurrentValue.AI.Governance.DurableState.MaxScanRecords);
 
-    private int MaxPayloadBytes =>
-        Math.Max(1024, _config.CurrentValue.AI.Governance.DurableState.MaxPayloadBytes);
-
     /// <inheritdoc />
     public async Task SavePendingAsync(EscalationRequest request, DateTimeOffset createdAt, CancellationToken ct)
     {
@@ -395,7 +392,7 @@ public sealed class EfCoreEscalationStateStore : IEscalationStateStore
                 Outcome = outcome
             };
         }
-        catch (Exception ex) when (ex is JsonException or ArgumentException or FormatException or OverflowException)
+        catch (Exception ex) when (GovernanceStatePayload.IsUnreadablePayload(ex))
         {
             _logger.LogError(ex,
                 "Skipping unreadable durable escalation record {EscalationId} (status {Status}); " +
@@ -411,20 +408,8 @@ public sealed class EfCoreEscalationStateStore : IEscalationStateStore
     /// <param name="escalationId">The owning escalation, for the log line.</param>
     /// <param name="description">What the payload is, for the log line.</param>
     private T? TryDeserialize<T>(string json, Guid escalationId, string description)
-        where T : class
-    {
-        try
-        {
-            return JsonSerializer.Deserialize<T>(json, GovernanceStateJson.Options);
-        }
-        catch (Exception ex) when (ex is JsonException or ArgumentException or FormatException or OverflowException)
-        {
-            _logger.LogError(ex,
-                "Failed to deserialize the persisted {Description} for escalation {EscalationId}",
-                description, escalationId);
-            return null;
-        }
-    }
+        where T : class =>
+        GovernanceStatePayload.TryDeserialize<T>(json, _logger, description, escalationId);
 
     /// <summary>
     /// Serializes a payload and rejects it when it exceeds the configured cap, so an oversized
@@ -433,22 +418,9 @@ public sealed class EfCoreEscalationStateStore : IEscalationStateStore
     /// <typeparam name="T">The payload type.</typeparam>
     /// <param name="value">The value to serialize.</param>
     /// <param name="columnName">The destination column, for the failure message.</param>
-    private string SerializeGuarded<T>(T value, string columnName)
-    {
-        var json = JsonSerializer.Serialize(value, GovernanceStateJson.Options);
-        var maxBytes = MaxPayloadBytes;
-        var byteCount = System.Text.Encoding.UTF8.GetByteCount(json);
-
-        if (byteCount > maxBytes)
-        {
-            throw new InvalidOperationException(
-                $"Governance-state payload for {columnName} is {byteCount} bytes, exceeding the configured " +
-                $"maximum of {maxBytes}. Raise AppConfig:AI:Governance:DurableState:MaxPayloadBytes or " +
-                "reduce the payload size.");
-        }
-
-        return json;
-    }
+    private string SerializeGuarded<T>(T value, string columnName) =>
+        GovernanceStatePayload.SerializeGuarded(
+            value, _config.CurrentValue.AI.Governance.DurableState.MaxPayloadBytes, columnName);
 
     /// <summary>
     /// Raw column values projected from SQLite, before any throwing conversion.

--- a/src/Content/Infrastructure/Infrastructure.AI/Escalation/EfCoreEscalationStateStore.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Escalation/EfCoreEscalationStateStore.cs
@@ -1,0 +1,479 @@
+using System.Text.Json;
+using Application.AI.Common.Interfaces.Escalation;
+using Domain.AI.Escalation;
+using Domain.Common.Config;
+using Infrastructure.AI.Persistence;
+using Infrastructure.AI.Persistence.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Infrastructure.AI.Escalation;
+
+/// <summary>
+/// SQLite-backed <see cref="IEscalationStateStore"/> over
+/// <see cref="GovernanceStateDbContext"/>. Registered as the active store when
+/// <c>AppConfig:AI:Governance:DurableState:EscalationsEnabled</c> is true.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Uses short-lived contexts from <see cref="IDbContextFactory{TContext}"/> per operation, the
+/// repo's convention for singleton stores. Demands the schema initializer as a plain
+/// constructor dependency (visible to ValidateOnBuild) so the schema exists before the first
+/// write; because this store is only constructed when durable escalation state is enabled,
+/// hosts running with the default-off configuration never create the database file. Write
+/// failures propagate as exceptions — the escalation service's fail-closed contract depends on
+/// that, and the service wraps them in a scrubbed <c>EscalationDurableStateException</c>
+/// before they can reach a transport.
+/// </para>
+/// <para>
+/// <b>Reads treat the database file as untrusted input.</b> Rows are projected as raw
+/// primitives and every conversion — tick-to-<see cref="DateTimeOffset"/>, status parse, JSON
+/// deserialization — happens inside a guarded per-row mapping. Nothing that can throw runs
+/// during query materialization, so one corrupt column quarantines its own row and leaves
+/// startup rehydration free to recover every other escalation.
+/// </para>
+/// <para>
+/// Resolved outcomes are sealed via <see cref="IEscalationOutcomeSealer"/> on write and
+/// verified on read; an outcome whose seal does not verify is withheld, so the reconciler
+/// never re-drives a possibly forged verdict into the compliance audit log.
+/// </para>
+/// </remarks>
+public sealed class EfCoreEscalationStateStore : IEscalationStateStore
+{
+    private readonly IDbContextFactory<GovernanceStateDbContext> _contextFactory;
+    private readonly IGovernanceRecordSealer _sealer;
+    private readonly IOptionsMonitor<AppConfig> _config;
+    private readonly ILogger<EfCoreEscalationStateStore> _logger;
+
+    /// <summary>
+    /// Initializes a new instance.
+    /// </summary>
+    /// <param name="contextFactory">Factory for short-lived governance-state contexts.</param>
+    /// <param name="schemaInitializer">
+    /// Forces schema creation and evolution before the first operation. Unused beyond its
+    /// construction side effect — mirrors <c>EfCorePlanStateStore</c>.
+    /// </param>
+    /// <param name="sealer">Produces and verifies the tamper-evident seal over stored outcomes.</param>
+    /// <param name="config">Supplies the scan bound and payload-size cap.</param>
+    /// <param name="logger">Structured logger.</param>
+    public EfCoreEscalationStateStore(
+        IDbContextFactory<GovernanceStateDbContext> contextFactory,
+        GovernanceStateSchemaInitializer schemaInitializer,
+        IGovernanceRecordSealer sealer,
+        IOptionsMonitor<AppConfig> config,
+        ILogger<EfCoreEscalationStateStore> logger)
+    {
+        ArgumentNullException.ThrowIfNull(contextFactory);
+        ArgumentNullException.ThrowIfNull(schemaInitializer);
+        ArgumentNullException.ThrowIfNull(sealer);
+        ArgumentNullException.ThrowIfNull(config);
+        ArgumentNullException.ThrowIfNull(logger);
+        _contextFactory = contextFactory;
+        _sealer = sealer;
+        _config = config;
+        _logger = logger;
+    }
+
+    private int MaxScanRecords =>
+        Math.Max(1, _config.CurrentValue.AI.Governance.DurableState.MaxScanRecords);
+
+    private int MaxPayloadBytes =>
+        Math.Max(1024, _config.CurrentValue.AI.Governance.DurableState.MaxPayloadBytes);
+
+    /// <inheritdoc />
+    public async Task SavePendingAsync(EscalationRequest request, DateTimeOffset createdAt, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        var requestJson = SerializeGuarded(request, nameof(EscalationStateEntity.RequestJson));
+
+        await using var context = await _contextFactory.CreateDbContextAsync(ct);
+
+        var entity = await context.Escalations.FindAsync([request.EscalationId], ct);
+        if (entity is null)
+        {
+            entity = new EscalationStateEntity
+            {
+                Id = request.EscalationId,
+                CreatedAtTicks = createdAt.UtcTicks
+            };
+            context.Escalations.Add(entity);
+        }
+
+        entity.Status = nameof(EscalationPersistedStatus.Pending);
+        entity.RequestJson = requestJson;
+        entity.DecisionsJson = "[]";
+        entity.OutcomeJson = null;
+        entity.OutcomeSealJson = null;
+        entity.UpdatedAtTicks = DateTimeOffset.UtcNow.UtcTicks;
+        await context.SaveChangesAsync(ct);
+    }
+
+    /// <inheritdoc />
+    public async Task SaveDecisionsAsync(
+        Guid escalationId, IReadOnlyList<ApproverDecision> decisions, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(decisions);
+        var decisionsJson = SerializeGuarded(decisions, nameof(EscalationStateEntity.DecisionsJson));
+
+        await using var context = await _contextFactory.CreateDbContextAsync(ct);
+
+        var entity = await context.Escalations.FindAsync([escalationId], ct)
+            ?? throw new InvalidOperationException(
+                $"No durable state record exists for escalation {escalationId}; refusing to record a decision against it.");
+
+        entity.DecisionsJson = decisionsJson;
+        entity.UpdatedAtTicks = DateTimeOffset.UtcNow.UtcTicks;
+        await context.SaveChangesAsync(ct);
+    }
+
+    /// <inheritdoc />
+    public async Task MarkResolvedPendingAuditAsync(EscalationOutcome outcome, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(outcome);
+
+        var outcomeJson = SerializeGuarded(outcome, nameof(EscalationStateEntity.OutcomeJson));
+        var decisionsJson = SerializeGuarded(outcome.Decisions, nameof(EscalationStateEntity.DecisionsJson));
+
+        // Seal the exact bytes about to be stored, bound to this escalation's id, so a seal
+        // cannot be lifted onto another row and verification later compares like for like.
+        var seal = await _sealer.SealAsync(SubjectId(outcome.EscalationId), outcomeJson, ct);
+        var sealJson = SerializeGuarded(seal, nameof(EscalationStateEntity.OutcomeSealJson));
+
+        await using var context = await _contextFactory.CreateDbContextAsync(ct);
+
+        var entity = await context.Escalations.FindAsync([outcome.EscalationId], ct)
+            ?? throw new InvalidOperationException(
+                $"No durable state record exists for escalation {outcome.EscalationId}; refusing to record its resolution.");
+
+        entity.Status = nameof(EscalationPersistedStatus.ResolvedPendingAudit);
+        entity.OutcomeJson = outcomeJson;
+        entity.OutcomeSealJson = sealJson;
+        entity.DecisionsJson = decisionsJson;
+        entity.UpdatedAtTicks = DateTimeOffset.UtcNow.UtcTicks;
+        await context.SaveChangesAsync(ct);
+    }
+
+    /// <inheritdoc />
+    public async Task MarkResolvedAsync(Guid escalationId, CancellationToken ct)
+    {
+        await using var context = await _contextFactory.CreateDbContextAsync(ct);
+
+        var entity = await context.Escalations.FindAsync([escalationId], ct)
+            ?? throw new InvalidOperationException(
+                $"No durable state record exists for escalation {escalationId}; cannot mark it resolved.");
+
+        entity.Status = nameof(EscalationPersistedStatus.Resolved);
+        entity.UpdatedAtTicks = DateTimeOffset.UtcNow.UtcTicks;
+        await context.SaveChangesAsync(ct);
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> TryClaimResolvedPendingAuditAsync(
+        Guid escalationId, DateTimeOffset staleClaimBefore, CancellationToken ct)
+    {
+        await using var context = await _contextFactory.CreateDbContextAsync(ct);
+        var staleBeforeTicks = staleClaimBefore.UtcTicks;
+
+        // Conditional claim: only the caller whose UPDATE actually matched owns the re-drive.
+        // A concurrent second pass matches zero rows and backs off, so the compliance audit
+        // line and the resolution notification fire once per stuck escalation.
+        //
+        // The second disjunct reclaims ABANDONED claims. A pass that is killed between
+        // claiming and finishing (kill -9, OOM, pod eviction) never reaches ReleaseClaimAsync,
+        // so without this the row would sit in AuditInFlight forever: no claim would ever
+        // match it again, the reconciler would skip it on every pass, and the pruner correctly
+        // refuses to delete a non-terminal row. The staleness bound is what keeps this from
+        // stealing a claim out from under a pass that is merely slow.
+        var claimed = await context.Escalations
+            .Where(e => e.Id == escalationId
+                && (e.Status == nameof(EscalationPersistedStatus.ResolvedPendingAudit)
+                    || (e.Status == nameof(EscalationPersistedStatus.AuditInFlight)
+                        && e.UpdatedAtTicks < staleBeforeTicks)))
+            .ExecuteUpdateAsync(
+                s => s.SetProperty(e => e.Status, nameof(EscalationPersistedStatus.AuditInFlight))
+                      .SetProperty(e => e.UpdatedAtTicks, DateTimeOffset.UtcNow.UtcTicks),
+                ct);
+
+        return claimed > 0;
+    }
+
+    /// <inheritdoc />
+    public async Task ReleaseClaimAsync(Guid escalationId, CancellationToken ct)
+    {
+        await using var context = await _contextFactory.CreateDbContextAsync(ct);
+
+        await context.Escalations
+            .Where(e => e.Id == escalationId
+                && e.Status == nameof(EscalationPersistedStatus.AuditInFlight))
+            .ExecuteUpdateAsync(
+                s => s.SetProperty(e => e.Status, nameof(EscalationPersistedStatus.ResolvedPendingAudit))
+                      .SetProperty(e => e.UpdatedAtTicks, DateTimeOffset.UtcNow.UtcTicks),
+                ct);
+    }
+
+    /// <inheritdoc />
+    public async Task RemoveAsync(Guid escalationId, CancellationToken ct)
+    {
+        await using var context = await _contextFactory.CreateDbContextAsync(ct);
+
+        await context.Escalations
+            .Where(e => e.Id == escalationId)
+            .ExecuteDeleteAsync(ct);
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<EscalationStateSnapshot>> GetActiveAsync(CancellationToken ct)
+    {
+        await using var context = await _contextFactory.CreateDbContextAsync(ct);
+
+        // Status filter pushed into SQL (backed by ix_escalation_state_status_updated_at) and
+        // the scan bounded, so a pathological backlog cannot blow out startup time or memory.
+        // Raw, NULLABLE primitives only — the payload and status columns are as untrusted as
+        // the ticks were, so a NULL in any of them must surface as a null string inside the
+        // guarded mapping rather than as a materialization throw outside it.
+        var rows = await context.Escalations
+            .AsNoTracking()
+            .Where(e => e.Status != nameof(EscalationPersistedStatus.Resolved))
+            .OrderBy(e => e.UpdatedAtTicks)
+            .Take(MaxScanRecords)
+            .Select(e => new RawEscalationRow(
+                e.Id, e.Status, e.RequestJson, e.DecisionsJson,
+                e.OutcomeJson, e.OutcomeSealJson, e.CreatedAtTicks))
+            .ToListAsync(ct);
+
+        var snapshots = new List<EscalationStateSnapshot>(rows.Count);
+        foreach (var row in rows)
+        {
+            var snapshot = TryMapSnapshot(row);
+            if (snapshot is not null)
+                snapshots.Add(await ApplySealVerificationAsync(snapshot, row, ct));
+        }
+
+        return snapshots;
+    }
+
+    /// <inheritdoc />
+    public async Task<EscalationOutcome?> GetResolvedOutcomeAsync(Guid escalationId, CancellationToken ct)
+    {
+        await using var context = await _contextFactory.CreateDbContextAsync(ct);
+
+        var row = await context.Escalations
+            .AsNoTracking()
+            .Where(e => e.Id == escalationId && e.Status == nameof(EscalationPersistedStatus.Resolved))
+            .Select(e => new { e.OutcomeJson, e.OutcomeSealJson })
+            .FirstOrDefaultAsync(ct);
+
+        if (row?.OutcomeJson is null)
+            return null;
+
+        var outcome = TryDeserialize<EscalationOutcome>(row.OutcomeJson, escalationId, "outcome");
+        if (outcome is null)
+            return null;
+
+        // Identity gate. Without it, an approved outcome copied verbatim into another row
+        // would verify byte-for-byte and this method would return escalation A's approval when
+        // asked about escalation B — and PlanExecutor.Recovery branches a human gate on
+        // IsApproved without re-checking the id, so one real approval would approve everything
+        // after it.
+        if (outcome.EscalationId != escalationId)
+        {
+            _logger.LogError(
+                "Stored outcome for escalation {EscalationId} declares {DeclaredId}; refusing to serve it",
+                escalationId, outcome.EscalationId);
+            return null;
+        }
+
+        // A terminal outcome is already in the compliance log, but it still drives caller
+        // decisions (the plan executor resumes a blocked step on it), so a tampered row must
+        // not be served as a verdict.
+        var seal = row.OutcomeSealJson is null
+            ? null
+            : TryDeserialize<GovernanceRecordSeal>(row.OutcomeSealJson, escalationId, "outcome seal");
+
+        if (await _sealer.VerifyAsync(SubjectId(escalationId), row.OutcomeJson, seal, ct))
+            return outcome;
+
+        _logger.LogError(
+            "Persisted outcome for escalation {EscalationId} failed seal verification; refusing to serve it",
+            escalationId);
+        return null;
+    }
+
+    /// <summary>
+    /// Verifies the seal on a snapshot carrying an outcome, stripping that outcome when
+    /// verification fails so the reconciler skips it instead of re-driving a possibly forged
+    /// verdict.
+    /// </summary>
+    /// <param name="snapshot">The mapped snapshot.</param>
+    /// <param name="row">The raw row it came from.</param>
+    /// <param name="ct">Cancellation token.</param>
+    private async Task<EscalationStateSnapshot> ApplySealVerificationAsync(
+        EscalationStateSnapshot snapshot, RawEscalationRow row, CancellationToken ct)
+    {
+        if (snapshot.Outcome is null || row.OutcomeJson is null)
+            return snapshot;
+
+        // Belt-and-braces identity gate. TryMapSnapshot already rejects a relocated payload,
+        // but this is the last checkpoint before the reconciler re-drives a verdict into the
+        // hash-chained compliance log, so the check is repeated rather than assumed.
+        if (snapshot.Outcome.EscalationId != row.Id)
+        {
+            _logger.LogError(
+                "Durable escalation {EscalationId} holds an outcome declaring {DeclaredId}; " +
+                "quarantining it (a verdict relocated between rows is never re-driven)",
+                row.Id, snapshot.Outcome.EscalationId);
+            return snapshot with { Outcome = null };
+        }
+
+        var seal = row.OutcomeSealJson is null
+            ? null
+            : TryDeserialize<GovernanceRecordSeal>(row.OutcomeSealJson, row.Id, "outcome seal");
+
+        if (await _sealer.VerifyAsync(SubjectId(row.Id), row.OutcomeJson, seal, ct))
+            return snapshot;
+
+        _logger.LogError(
+            "Durable escalation {EscalationId} carries an outcome whose seal does not verify; " +
+            "quarantining it (the row is preserved for investigation and will not be re-driven)",
+            row.Id);
+        return snapshot with { Outcome = null };
+    }
+
+    /// <summary>
+    /// Maps one raw row to a snapshot, or returns null (with an error log) when any of its
+    /// values are unreadable. Every conversion that can throw lives inside this guard, which
+    /// is what keeps a single poisoned row from failing an entire scan — and, through the
+    /// startup rehydration path, the host boot.
+    /// </summary>
+    /// <param name="row">The raw row to map.</param>
+    private EscalationStateSnapshot? TryMapSnapshot(RawEscalationRow row)
+    {
+        try
+        {
+            // NULLs in NOT NULL columns are possible in a file this process did not write.
+            if (row.Status is null || row.RequestJson is null)
+                throw new JsonException("Row is missing its status or request payload.");
+
+            var request = JsonSerializer.Deserialize<EscalationRequest>(row.RequestJson, GovernanceStateJson.Options)
+                ?? throw new JsonException("Request payload deserialized to null.");
+            var decisions = row.DecisionsJson is null
+                ? []
+                : JsonSerializer.Deserialize<List<ApproverDecision>>(row.DecisionsJson, GovernanceStateJson.Options) ?? [];
+            var outcome = row.OutcomeJson is null
+                ? null
+                : JsonSerializer.Deserialize<EscalationOutcome>(row.OutcomeJson, GovernanceStateJson.Options);
+
+            // Identity gate, independent of the seal: the escalation id INSIDE a payload must
+            // match the row it was loaded from. A payload relocated between rows is rejected
+            // here even before its (id-bound) seal is checked.
+            if (request.EscalationId != row.Id)
+            {
+                throw new JsonException(
+                    $"Request payload declares escalation {request.EscalationId} but is stored under {row.Id}.");
+            }
+
+            // A relocated OUTCOME strips just the verdict rather than dropping the whole row:
+            // the request may still be legitimate, and an escalation that vanishes entirely is
+            // invisible to operators. A null outcome is already the signal the reconciler uses
+            // to skip a record, so the dangerous half is neutralized either way.
+            if (outcome is not null && outcome.EscalationId != row.Id)
+            {
+                _logger.LogError(
+                    "Durable escalation {EscalationId} holds an outcome declaring {DeclaredId}; " +
+                    "withholding the verdict (a relocated approval is never honoured)",
+                    row.Id, outcome.EscalationId);
+                outcome = null;
+            }
+
+            return new EscalationStateSnapshot
+            {
+                Request = request,
+                Decisions = decisions,
+                CreatedAt = new DateTimeOffset(row.CreatedAtTicks, TimeSpan.Zero),
+                Status = Enum.Parse<EscalationPersistedStatus>(row.Status, ignoreCase: true),
+                Outcome = outcome
+            };
+        }
+        catch (Exception ex) when (ex is JsonException or ArgumentException or FormatException or OverflowException)
+        {
+            _logger.LogError(ex,
+                "Skipping unreadable durable escalation record {EscalationId} (status {Status}); " +
+                "the row is preserved for manual inspection",
+                row.Id, row.Status);
+            return null;
+        }
+    }
+
+    /// <summary>Deserializes a payload, logging and returning null when it is unreadable.</summary>
+    /// <typeparam name="T">The payload type.</typeparam>
+    /// <param name="json">The stored JSON.</param>
+    /// <param name="escalationId">The owning escalation, for the log line.</param>
+    /// <param name="description">What the payload is, for the log line.</param>
+    private T? TryDeserialize<T>(string json, Guid escalationId, string description)
+        where T : class
+    {
+        try
+        {
+            return JsonSerializer.Deserialize<T>(json, GovernanceStateJson.Options);
+        }
+        catch (Exception ex) when (ex is JsonException or ArgumentException or FormatException or OverflowException)
+        {
+            _logger.LogError(ex,
+                "Failed to deserialize the persisted {Description} for escalation {EscalationId}",
+                description, escalationId);
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Serializes a payload and rejects it when it exceeds the configured cap, so an oversized
+    /// document fails loudly at the write rather than being stored and failing every later read.
+    /// </summary>
+    /// <typeparam name="T">The payload type.</typeparam>
+    /// <param name="value">The value to serialize.</param>
+    /// <param name="columnName">The destination column, for the failure message.</param>
+    private string SerializeGuarded<T>(T value, string columnName)
+    {
+        var json = JsonSerializer.Serialize(value, GovernanceStateJson.Options);
+        var maxBytes = MaxPayloadBytes;
+        var byteCount = System.Text.Encoding.UTF8.GetByteCount(json);
+
+        if (byteCount > maxBytes)
+        {
+            throw new InvalidOperationException(
+                $"Governance-state payload for {columnName} is {byteCount} bytes, exceeding the configured " +
+                $"maximum of {maxBytes}. Raise AppConfig:AI:Governance:DurableState:MaxPayloadBytes or " +
+                "reduce the payload size.");
+        }
+
+        return json;
+    }
+
+    /// <summary>
+    /// Raw column values projected from SQLite, before any throwing conversion.
+    /// </summary>
+    /// <remarks>
+    /// Every string is nullable even where the schema declares NOT NULL: the schema constrains
+    /// what this process writes, not what is in the file. The one column that cannot be
+    /// deferred this way is <see cref="Id"/> — EF converts the Guid BLOB during materialization,
+    /// so a truncated blob throws inside the query rather than in the per-row guard. That
+    /// residual case is contained one level up, where the rehydration host service treats a
+    /// scan-level failure as non-fatal (LogCritical and continue) instead of failing host boot.
+    /// </remarks>
+    private sealed record RawEscalationRow(
+        Guid Id,
+        string? Status,
+        string? RequestJson,
+        string? DecisionsJson,
+        string? OutcomeJson,
+        string? OutcomeSealJson,
+        long CreatedAtTicks);
+
+    /// <summary>
+    /// The seal subject for an escalation: its id in a stable, delimiter-free form. Binding
+    /// this into the MAC is what makes a seal valid for exactly one row.
+    /// </summary>
+    /// <param name="escalationId">The escalation the seal belongs to.</param>
+    private static string SubjectId(Guid escalationId) => escalationId.ToString("N");
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Escalation/EscalationReconciliationService.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Escalation/EscalationReconciliationService.cs
@@ -32,11 +32,21 @@ namespace Infrastructure.AI.Escalation;
 /// scan touches the database.
 /// </para>
 /// <para>
-/// Gated on <c>EscalationsEnabled</c>: with durable escalation state off there is no
-/// durable stuck shape to recover and no database to prune, and the in-memory stuck shape is
-/// recoverable only within the process that produced it (where an operator-triggered pass
-/// still works). A pass that throws is logged and retried on the next tick — reconciliation
-/// failing must never take the host down.
+/// <b>The loop is NOT gated on the durability toggles.</b> The in-memory stuck shape — a
+/// resolution reached in this process whose fail-closed <em>audit</em> write threw — is caused
+/// by the audit store, not the state store, so it occurs in the default (durability-off)
+/// configuration too. Gating the whole service on <c>EscalationsEnabled</c> left that shape
+/// with no scheduled recovery on the very configuration most hosts run, which in turn made
+/// <c>EscalationDecisionStatus.AwaitingReconciliation</c>'s own contract ("the verdict
+/// becomes observable once reconciliation completes") false. Each sub-step therefore checks
+/// only the flag it actually needs: the reconcile pass runs always, and the retention prune —
+/// which does touch the database — stays behind the toggles. With durability off the pass's
+/// durable half is a no-op anyway, because <c>NullEscalationStateStore.GetActiveAsync</c>
+/// returns nothing.
+/// </para>
+/// <para>
+/// A pass that throws is logged and retried on the next tick — reconciliation failing must
+/// never take the host down.
 /// </para>
 /// </remarks>
 public sealed class EscalationReconciliationService : BackgroundService
@@ -88,15 +98,11 @@ public sealed class EscalationReconciliationService : BackgroundService
     /// <inheritdoc />
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        var durable = _config.CurrentValue.AI.Governance.DurableState;
-
-        // Gated on EITHER toggle: retention applies to the change-proposal table too, so a host
-        // that enables only ChangeProposalsEnabled must still get the documented retention
-        // window. Each sub-step re-checks its own flag inside the loop.
-        if (!durable.EscalationsEnabled && !durable.ChangeProposalsEnabled)
-            return;
-
-        var interval = ResolveInterval(durable.ReconcileIntervalSeconds);
+        // Deliberately unconditional (see the class remarks): the in-memory stuck shape this
+        // recovers is produced by an audit-store failure and exists with durability off. The
+        // per-sub-step flag checks live in RunPassAsync.
+        var interval = ResolveInterval(
+            _config.CurrentValue.AI.Governance.DurableState.ReconcileIntervalSeconds);
         _logger.LogInformation(
             "Escalation reconciliation active: first pass in {InitialDelay}, then every {Interval}",
             InitialDelay, interval);
@@ -118,41 +124,63 @@ public sealed class EscalationReconciliationService : BackgroundService
     }
 
     /// <summary>
-    /// Runs one reconcile pass followed by one retention prune, swallowing failures so a
-    /// transient store or audit outage never faults the host's background pipeline.
+    /// Runs one reconcile pass followed by one retention prune. Each step swallows its own
+    /// failures so a transient store or audit outage never faults the host's background pipeline,
+    /// and so a failing prune cannot suppress the next reconcile.
     /// </summary>
     /// <param name="ct">Cancellation token.</param>
     private async Task RunPassAsync(CancellationToken ct)
     {
-        var durable = _config.CurrentValue.AI.Governance.DurableState;
+        await RunReconcileAsync(ct);
+        await RunPruneAsync(ct);
+    }
 
-        // Reconciliation is escalation-only: there is no parked-awaiting-audit state for
-        // proposals. A proposals-only host still reaches the prune step below.
-        if (durable.EscalationsEnabled)
+    /// <summary>
+    /// Drives one reconcile pass. Runs on every host regardless of the durability toggles: the
+    /// in-memory stuck shape it recovers comes from a failed audit write, which is independent
+    /// of durable state. With durability off the pass's durable half self-no-ops, because the
+    /// Null state store reports no active records.
+    /// </summary>
+    /// <param name="ct">Cancellation token.</param>
+    private async Task RunReconcileAsync(CancellationToken ct)
+    {
+        try
         {
-            try
+            var result = await _reconciler.ReconcileStuckEscalationsAsync(ct);
+            if (result.Recovered.Count > 0 || result.StillStuck.Count > 0)
             {
-                var result = await _reconciler.ReconcileStuckEscalationsAsync(ct);
-                if (result.Recovered.Count > 0 || result.StillStuck.Count > 0)
-                {
-                    _logger.LogInformation(
-                        "Scheduled reconcile recovered {RecoveredCount} escalation(s); {StuckCount} still stuck",
-                        result.Recovered.Count, result.StillStuck.Count);
-                }
-            }
-            catch (Exception ex) when (ex is not OperationCanceledException)
-            {
-                _logger.LogError(ex, "Scheduled escalation reconcile pass failed; retrying on the next interval");
+                _logger.LogInformation(
+                    "Scheduled reconcile recovered {RecoveredCount} escalation(s); {StuckCount} still stuck",
+                    result.Recovered.Count, result.StillStuck.Count);
             }
         }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogError(ex, "Scheduled escalation reconcile pass failed; retrying on the next interval");
+        }
+    }
 
-        var retentionDays = durable.RetentionDays;
-        if (retentionDays <= 0)
+    /// <summary>
+    /// Prunes terminal governance-state rows past the retention window. Gated on EITHER durable
+    /// toggle — retention applies to the change-proposal table too, so a host that enables only
+    /// <c>ChangeProposalsEnabled</c> must still get the documented window — and skipped entirely
+    /// when both are off, which is what keeps the deferred pruner factory (and with it the
+    /// schema initializer that would create the database file) unresolved on such hosts.
+    /// </summary>
+    /// <param name="ct">Cancellation token.</param>
+    private async Task RunPruneAsync(CancellationToken ct)
+    {
+        var durable = _config.CurrentValue.AI.Governance.DurableState;
+        if (!durable.EscalationsEnabled && !durable.ChangeProposalsEnabled)
+            return;
+
+        if (durable.RetentionDays <= 0)
             return;
 
         try
         {
-            await _prunerFactory().PruneAsync(_timeProvider.GetUtcNow().AddDays(-retentionDays), ct);
+            await _prunerFactory().PruneAsync(
+                _timeProvider.GetUtcNow().AddDays(-durable.RetentionDays), ct);
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {

--- a/src/Content/Infrastructure/Infrastructure.AI/Escalation/EscalationReconciliationService.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Escalation/EscalationReconciliationService.cs
@@ -1,0 +1,170 @@
+using Application.AI.Common.Interfaces.Escalation;
+using Domain.Common.Config;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Infrastructure.AI.Escalation;
+
+/// <summary>
+/// Runs escalation reconciliation in production: one pass shortly after startup, then on a
+/// bounded interval, plus a retention prune of terminal governance-state rows.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Why this service must exist.</b> Without a scheduled trigger,
+/// <see cref="IEscalationReconciler.ReconcileStuckEscalationsAsync"/> would only ever run if a
+/// human happened to invoke it. The crash window it exists for — a host that dies between the
+/// durable resolution write and the compliance audit write — leaves a
+/// <see cref="EscalationPersistedStatus.ResolvedPendingAudit"/> row that rehydration
+/// deliberately does <em>not</em> restore to the active set. That escalation would then be
+/// invisible to pending-list queries, would answer
+/// <c>UnknownEscalation</c> to any decision, and would return null from
+/// <c>GetOutcomeAsync</c> forever: a human-granted approval permanently stranded, with the
+/// plan executor's resume path polling an outcome that will never appear.
+/// </para>
+/// <para>
+/// <b>Ordering.</b> Registered after <see cref="EscalationStateRehydrationService"/> so the
+/// active set is populated before the first pass runs. Reconciliation dedupes its two stuck
+/// shapes by checking the active set, so running it against an unpopulated set would treat
+/// in-memory-recoverable records as durable-only ones and finalize them without their
+/// in-memory state. The initial delay additionally lets a host finish booting before the first
+/// scan touches the database.
+/// </para>
+/// <para>
+/// Gated on <c>EscalationsEnabled</c>: with durable escalation state off there is no
+/// durable stuck shape to recover and no database to prune, and the in-memory stuck shape is
+/// recoverable only within the process that produced it (where an operator-triggered pass
+/// still works). A pass that throws is logged and retried on the next tick — reconciliation
+/// failing must never take the host down.
+/// </para>
+/// </remarks>
+public sealed class EscalationReconciliationService : BackgroundService
+{
+    /// <summary>Grace period before the first pass, letting the host finish booting.</summary>
+    private static readonly TimeSpan InitialDelay = TimeSpan.FromSeconds(30);
+
+    /// <summary>Floor on the configured interval; the scan is cheap but not a hot loop.</summary>
+    private static readonly TimeSpan MinimumInterval = TimeSpan.FromMinutes(1);
+
+    private readonly IEscalationReconciler _reconciler;
+    private readonly Func<IGovernanceStatePruner> _prunerFactory;
+    private readonly IOptionsMonitor<AppConfig> _config;
+    private readonly TimeProvider _timeProvider;
+    private readonly ILogger<EscalationReconciliationService> _logger;
+
+    /// <summary>Initializes a new instance.</summary>
+    /// <param name="reconciler">The reconciler to drive (the escalation service itself).</param>
+    /// <param name="prunerFactory">
+    /// Deferred accessor for the retention pruner. Deliberately <b>not</b> a direct dependency:
+    /// hosted services are constructed when the host is built, and constructing the pruner pulls
+    /// in the schema initializer, whose constructor runs <c>EnsureCreated</c> — which would
+    /// create the governance-state database file on every host, including the ones that never
+    /// enable durability. Resolving it only after the enable check preserves the
+    /// "zero filesystem side effects when off" guarantee.
+    /// </param>
+    /// <param name="config">Supplies the enable flag, interval, and retention window.</param>
+    /// <param name="timeProvider">Clock used for the retention cutoff.</param>
+    /// <param name="logger">Structured logger.</param>
+    public EscalationReconciliationService(
+        IEscalationReconciler reconciler,
+        Func<IGovernanceStatePruner> prunerFactory,
+        IOptionsMonitor<AppConfig> config,
+        TimeProvider timeProvider,
+        ILogger<EscalationReconciliationService> logger)
+    {
+        ArgumentNullException.ThrowIfNull(reconciler);
+        ArgumentNullException.ThrowIfNull(prunerFactory);
+        ArgumentNullException.ThrowIfNull(config);
+        ArgumentNullException.ThrowIfNull(timeProvider);
+        ArgumentNullException.ThrowIfNull(logger);
+        _reconciler = reconciler;
+        _prunerFactory = prunerFactory;
+        _config = config;
+        _timeProvider = timeProvider;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        var durable = _config.CurrentValue.AI.Governance.DurableState;
+
+        // Gated on EITHER toggle: retention applies to the change-proposal table too, so a host
+        // that enables only ChangeProposalsEnabled must still get the documented retention
+        // window. Each sub-step re-checks its own flag inside the loop.
+        if (!durable.EscalationsEnabled && !durable.ChangeProposalsEnabled)
+            return;
+
+        var interval = ResolveInterval(durable.ReconcileIntervalSeconds);
+        _logger.LogInformation(
+            "Escalation reconciliation active: first pass in {InitialDelay}, then every {Interval}",
+            InitialDelay, interval);
+
+        try
+        {
+            await Task.Delay(InitialDelay, _timeProvider, stoppingToken);
+
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                await RunPassAsync(stoppingToken);
+                await Task.Delay(interval, _timeProvider, stoppingToken);
+            }
+        }
+        catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+        {
+            // Normal shutdown.
+        }
+    }
+
+    /// <summary>
+    /// Runs one reconcile pass followed by one retention prune, swallowing failures so a
+    /// transient store or audit outage never faults the host's background pipeline.
+    /// </summary>
+    /// <param name="ct">Cancellation token.</param>
+    private async Task RunPassAsync(CancellationToken ct)
+    {
+        var durable = _config.CurrentValue.AI.Governance.DurableState;
+
+        // Reconciliation is escalation-only: there is no parked-awaiting-audit state for
+        // proposals. A proposals-only host still reaches the prune step below.
+        if (durable.EscalationsEnabled)
+        {
+            try
+            {
+                var result = await _reconciler.ReconcileStuckEscalationsAsync(ct);
+                if (result.Recovered.Count > 0 || result.StillStuck.Count > 0)
+                {
+                    _logger.LogInformation(
+                        "Scheduled reconcile recovered {RecoveredCount} escalation(s); {StuckCount} still stuck",
+                        result.Recovered.Count, result.StillStuck.Count);
+                }
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                _logger.LogError(ex, "Scheduled escalation reconcile pass failed; retrying on the next interval");
+            }
+        }
+
+        var retentionDays = durable.RetentionDays;
+        if (retentionDays <= 0)
+            return;
+
+        try
+        {
+            await _prunerFactory().PruneAsync(_timeProvider.GetUtcNow().AddDays(-retentionDays), ct);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogError(ex, "Governance-state retention prune failed; retrying on the next interval");
+        }
+    }
+
+    /// <summary>Clamps the configured interval up to <see cref="MinimumInterval"/>.</summary>
+    /// <param name="configuredSeconds">The configured interval in seconds.</param>
+    private static TimeSpan ResolveInterval(int configuredSeconds)
+    {
+        var configured = TimeSpan.FromSeconds(Math.Max(1, configuredSeconds));
+        return configured < MinimumInterval ? MinimumInterval : configured;
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Escalation/EscalationReconciliationService.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Escalation/EscalationReconciliationService.cs
@@ -40,9 +40,9 @@ namespace Infrastructure.AI.Escalation;
 /// <c>EscalationDecisionStatus.AwaitingReconciliation</c>'s own contract ("the verdict
 /// becomes observable once reconciliation completes") false. Each sub-step therefore checks
 /// only the flag it actually needs: the reconcile pass runs always, and the retention prune —
-/// which does touch the database — stays behind the toggles. With durability off the pass's
-/// durable half is a no-op anyway, because <c>NullEscalationStateStore.GetActiveAsync</c>
-/// returns nothing.
+/// which does touch the database — stays behind the construction-time snapshot of the toggles.
+/// With durability off the pass's durable half is a no-op anyway, because
+/// <c>NullEscalationStateStore.GetActiveAsync</c> returns nothing.
 /// </para>
 /// <para>
 /// A pass that throws is logged and retried on the next tick — reconciliation failing must
@@ -63,6 +63,12 @@ public sealed class EscalationReconciliationService : BackgroundService
     private readonly TimeProvider _timeProvider;
     private readonly ILogger<EscalationReconciliationService> _logger;
 
+    /// <summary>
+    /// Whether either durability toggle was on when this service was constructed. Snapshotted
+    /// rather than re-read per tick — see the constructor's <c>config</c> parameter for why.
+    /// </summary>
+    private readonly bool _durableStateEnabled;
+
     /// <summary>Initializes a new instance.</summary>
     /// <param name="reconciler">The reconciler to drive (the escalation service itself).</param>
     /// <param name="prunerFactory">
@@ -73,7 +79,20 @@ public sealed class EscalationReconciliationService : BackgroundService
     /// enable durability. Resolving it only after the enable check preserves the
     /// "zero filesystem side effects when off" guarantee.
     /// </param>
-    /// <param name="config">Supplies the enable flag, interval, and retention window.</param>
+    /// <param name="config">
+    /// Supplies the enable flags, interval, and retention window. The interval and retention window
+    /// are read live, because both are safe to retune on a running host. The <b>enable</b> pair is
+    /// snapshotted here instead, for two reasons. First, it makes the restart-required contract
+    /// documented on <c>GovernanceDurableStateConfig</c> actually true: the store selections are
+    /// already frozen at first resolution, so a pruner that honoured a live edit could prune a
+    /// database the stores were not writing, or — in the other direction — stop pruning while the
+    /// frozen stores kept writing, letting retention lapse silently. Second, it is what keeps
+    /// <c>DependencyInjection.ResolveGovernanceStateProtectedPaths</c> sound: that gate decides at
+    /// composition whether the governance-state directory is worth protecting, and resolving the
+    /// pruner is the one remaining route that could create that directory later in the process. A
+    /// live toggle edit reaching this method would create the database on a host whose file-system
+    /// deny list booted disarmed.
+    /// </param>
     /// <param name="timeProvider">Clock used for the retention cutoff.</param>
     /// <param name="logger">Structured logger.</param>
     public EscalationReconciliationService(
@@ -93,6 +112,9 @@ public sealed class EscalationReconciliationService : BackgroundService
         _config = config;
         _timeProvider = timeProvider;
         _logger = logger;
+
+        var durable = config.CurrentValue.AI.Governance.DurableState;
+        _durableStateEnabled = durable.EscalationsEnabled || durable.ChangeProposalsEnabled;
     }
 
     /// <inheritdoc />
@@ -164,23 +186,27 @@ public sealed class EscalationReconciliationService : BackgroundService
     /// Prunes terminal governance-state rows past the retention window. Gated on EITHER durable
     /// toggle — retention applies to the change-proposal table too, so a host that enables only
     /// <c>ChangeProposalsEnabled</c> must still get the documented window — and skipped entirely
-    /// when both are off, which is what keeps the deferred pruner factory (and with it the
-    /// schema initializer that would create the database file) unresolved on such hosts.
+    /// when both were off at construction, which is what keeps the deferred pruner factory (and
+    /// with it the schema initializer that would create the database file) unresolved on such
+    /// hosts. The enable check reads the construction-time snapshot, never
+    /// <see cref="IOptionsMonitor{TOptions}.CurrentValue"/>: see the constructor's <c>config</c>
+    /// parameter for why a live re-read would be unsound. The retention window itself stays live,
+    /// because retuning it on a running host changes only how far back this prune reaches.
     /// </summary>
     /// <param name="ct">Cancellation token.</param>
     private async Task RunPruneAsync(CancellationToken ct)
     {
-        var durable = _config.CurrentValue.AI.Governance.DurableState;
-        if (!durable.EscalationsEnabled && !durable.ChangeProposalsEnabled)
+        if (!_durableStateEnabled)
             return;
 
-        if (durable.RetentionDays <= 0)
+        var retentionDays = _config.CurrentValue.AI.Governance.DurableState.RetentionDays;
+        if (retentionDays <= 0)
             return;
 
         try
         {
             await _prunerFactory().PruneAsync(
-                _timeProvider.GetUtcNow().AddDays(-durable.RetentionDays), ct);
+                _timeProvider.GetUtcNow().AddDays(-retentionDays), ct);
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {

--- a/src/Content/Infrastructure/Infrastructure.AI/Escalation/EscalationStateRehydrationService.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Escalation/EscalationStateRehydrationService.cs
@@ -1,0 +1,76 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Infrastructure.AI.Escalation;
+
+/// <summary>
+/// One-shot startup step that rehydrates durably persisted pending escalations into the
+/// active set of <see cref="DefaultEscalationService"/>, so approvals opened before a restart
+/// remain decidable, listable, and cancellable afterwards.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Registered unconditionally; with durable escalation state disabled (the default) the
+/// service's Null state store yields zero records and this is a silent no-op with zero I/O.
+/// </para>
+/// <para>
+/// A scan-level failure is logged at <c>Critical</c> and swallowed rather than propagated.
+/// Individual bad rows are already quarantined inside the store, but one residual case cannot
+/// be: the row's Guid key is converted during query materialization, outside any per-row guard,
+/// so a single truncated key blob fails the whole scan. Letting that propagate would turn one
+/// corrupt byte into a total availability loss — the host would refuse to boot at all. Booting
+/// with escalations unrestored is bad and must be screamed about; not booting is worse.
+/// </para>
+/// </remarks>
+public sealed class EscalationStateRehydrationService : IHostedService
+{
+    private readonly DefaultEscalationService _escalationService;
+    private readonly ILogger<EscalationStateRehydrationService> _logger;
+
+    /// <summary>
+    /// Initializes a new instance.
+    /// </summary>
+    /// <param name="escalationService">
+    /// The concrete escalation service to rehydrate. Depends on the concrete type (not
+    /// <c>IEscalationService</c>) because rehydration is an implementation detail of the
+    /// default service, not part of the escalation contract.
+    /// </param>
+    /// <param name="logger">Structured logger.</param>
+    public EscalationStateRehydrationService(
+        DefaultEscalationService escalationService,
+        ILogger<EscalationStateRehydrationService> logger)
+    {
+        ArgumentNullException.ThrowIfNull(escalationService);
+        ArgumentNullException.ThrowIfNull(logger);
+        _escalationService = escalationService;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            var restored = await _escalationService.RehydratePendingEscalationsAsync(cancellationToken);
+            if (restored > 0)
+            {
+                _logger.LogInformation(
+                    "Restored {RestoredCount} pending escalation(s) from the durable governance-state store",
+                    restored);
+            }
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            // See the class remarks: a scan-level failure must not be a full-availability DoS.
+            // The reconciler's scheduled passes retry the scan, so a transient fault is
+            // self-healing; a persistent one leaves this Critical line every boot.
+            _logger.LogCritical(ex,
+                "Failed to rehydrate durable escalation state at startup. Pending approvals from before " +
+                "this restart are NOT restored and will not appear in pending lists until the underlying " +
+                "fault is fixed. The host is continuing to start; investigate the governance-state database");
+        }
+    }
+
+    /// <inheritdoc />
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Escalation/NullEscalationStateStore.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Escalation/NullEscalationStateStore.cs
@@ -1,0 +1,60 @@
+using Application.AI.Common.Interfaces.Escalation;
+using Domain.AI.Escalation;
+
+namespace Infrastructure.AI.Escalation;
+
+/// <summary>
+/// No-op <see cref="IEscalationStateStore"/> registered when durable escalation state is
+/// disabled (<c>AppConfig:AI:Governance:DurableState:EscalationsEnabled</c> = false, the
+/// default). Every write completes successfully without persisting anything and every read
+/// returns empty, which preserves the pre-durability, in-memory-only behavior of
+/// <see cref="DefaultEscalationService"/> exactly: no database file is created, no write can
+/// fail, and restarts lose pending escalations — the documented in-memory contract.
+/// </summary>
+public sealed class NullEscalationStateStore : IEscalationStateStore
+{
+    /// <inheritdoc />
+    public Task SavePendingAsync(EscalationRequest request, DateTimeOffset createdAt, CancellationToken ct)
+        => Task.CompletedTask;
+
+    /// <inheritdoc />
+    public Task SaveDecisionsAsync(Guid escalationId, IReadOnlyList<ApproverDecision> decisions, CancellationToken ct)
+        => Task.CompletedTask;
+
+    /// <inheritdoc />
+    public Task MarkResolvedPendingAuditAsync(EscalationOutcome outcome, CancellationToken ct)
+        => Task.CompletedTask;
+
+    /// <inheritdoc />
+    public Task MarkResolvedAsync(Guid escalationId, CancellationToken ct)
+        => Task.CompletedTask;
+
+    /// <inheritdoc />
+    public Task RemoveAsync(Guid escalationId, CancellationToken ct)
+        => Task.CompletedTask;
+
+    /// <summary>
+    /// Always grants the claim. With no durable store there is no cross-pass state to
+    /// coordinate; the escalation service's in-memory claim flag is the only arbiter, and it
+    /// already serializes reconcile passes within the process.
+    /// </summary>
+    /// <param name="escalationId">Ignored.</param>
+    /// <param name="staleClaimBefore">Ignored — there are no durable claims to expire.</param>
+    /// <param name="ct">Ignored.</param>
+    /// <returns>Always true.</returns>
+    public Task<bool> TryClaimResolvedPendingAuditAsync(
+        Guid escalationId, DateTimeOffset staleClaimBefore, CancellationToken ct)
+        => Task.FromResult(true);
+
+    /// <inheritdoc />
+    public Task ReleaseClaimAsync(Guid escalationId, CancellationToken ct)
+        => Task.CompletedTask;
+
+    /// <inheritdoc />
+    public Task<IReadOnlyList<EscalationStateSnapshot>> GetActiveAsync(CancellationToken ct)
+        => Task.FromResult<IReadOnlyList<EscalationStateSnapshot>>([]);
+
+    /// <inheritdoc />
+    public Task<EscalationOutcome?> GetResolvedOutcomeAsync(Guid escalationId, CancellationToken ct)
+        => Task.FromResult<EscalationOutcome?>(null);
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Persistence/ChangeTargetJsonConverter.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Persistence/ChangeTargetJsonConverter.cs
@@ -1,0 +1,140 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Domain.AI.Changes;
+
+namespace Infrastructure.AI.Persistence;
+
+/// <summary>
+/// System.Text.Json converter for the polymorphic <see cref="ChangeTarget"/> hierarchy, used
+/// by the durable governance-state store. Writes a <c>kind</c> discriminator (the
+/// <see cref="ChangeTargetKind"/> enum name) plus each concrete target's constructor fields,
+/// and reconstructs the target through its public constructor so derived values
+/// (<see cref="ChangeTarget.DisplayName"/>, <see cref="ChangeTarget.CanonicalKey"/>) are
+/// rebuilt rather than trusted from storage.
+/// </summary>
+/// <remarks>
+/// Covers the three built-in targets (<see cref="GitRepoTarget"/>,
+/// <see cref="KubernetesResourceTarget"/>, <see cref="IacDeploymentTarget"/>). A consumer who
+/// adds a <see cref="ChangeTarget"/> subclass and enables the durable proposal store must
+/// extend this converter (or register a replacement <c>JsonSerializerOptions</c>-bearing
+/// store); serialization of an unknown subclass throws <see cref="NotSupportedException"/> at
+/// save time — loudly, before any state is half-persisted.
+/// </remarks>
+public sealed class ChangeTargetJsonConverter : JsonConverter<ChangeTarget>
+{
+    private const string KindProperty = "kind";
+
+    /// <inheritdoc />
+    public override ChangeTarget Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        using var document = JsonDocument.ParseValue(ref reader);
+        var root = document.RootElement;
+
+        if (!root.TryGetProperty(KindProperty, out var kindElement) ||
+            !Enum.TryParse<ChangeTargetKind>(kindElement.GetString(), ignoreCase: true, out var kind))
+        {
+            throw new JsonException(
+                "ChangeTarget JSON is missing a recognizable 'kind' discriminator.");
+        }
+
+        return kind switch
+        {
+            ChangeTargetKind.GitRepo => new GitRepoTarget(
+                GetString(root, "repoUrl"),
+                GetString(root, "branch"),
+                GetOptionalString(root, "headSha"),
+                GetString(root, "workingPath")),
+            ChangeTargetKind.KubernetesResource => new KubernetesResourceTarget(
+                GetString(root, "clusterContext"),
+                GetString(root, "apiVersion"),
+                GetString(root, "resourceKind"),
+                GetString(root, "namespace"),
+                GetString(root, "resourceName")),
+            ChangeTargetKind.IacDeployment => new IacDeploymentTarget(
+                GetString(root, "backend"),
+                GetString(root, "deploymentName"),
+                GetString(root, "modulePath"),
+                GetString(root, "environment")),
+            _ => throw new JsonException(
+                $"ChangeTarget kind '{kind}' has no registered deserialization mapping.")
+        };
+    }
+
+    /// <inheritdoc />
+    public override void Write(Utf8JsonWriter writer, ChangeTarget value, JsonSerializerOptions options)
+    {
+        writer.WriteStartObject();
+        writer.WriteString(KindProperty, value.Kind.ToString());
+
+        switch (value)
+        {
+            case GitRepoTarget git:
+                writer.WriteString("repoUrl", git.RepoUrl);
+                writer.WriteString("branch", git.Branch);
+                if (git.HeadSha is not null)
+                    writer.WriteString("headSha", git.HeadSha);
+                writer.WriteString("workingPath", git.WorkingPath);
+                break;
+            case KubernetesResourceTarget k8s:
+                writer.WriteString("clusterContext", k8s.ClusterContext);
+                writer.WriteString("apiVersion", k8s.ApiVersion);
+                writer.WriteString("resourceKind", k8s.ResourceKind);
+                writer.WriteString("namespace", k8s.Namespace);
+                writer.WriteString("resourceName", k8s.ResourceName);
+                break;
+            case IacDeploymentTarget iac:
+                writer.WriteString("backend", iac.Backend);
+                writer.WriteString("deploymentName", iac.DeploymentName);
+                writer.WriteString("modulePath", iac.ModulePath);
+                writer.WriteString("environment", iac.Environment);
+                break;
+            default:
+                throw new NotSupportedException(
+                    $"ChangeTarget subclass '{value.GetType().Name}' is not supported by the durable " +
+                    "governance-state store. Extend ChangeTargetJsonConverter to persist custom targets.");
+        }
+
+        writer.WriteEndObject();
+    }
+
+    /// <summary>
+    /// Reads a required string property, throwing when it is absent.
+    /// </summary>
+    /// <remarks>
+    /// Presence is mandatory even when the value may legitimately be empty. Defaulting an
+    /// absent property to <see cref="string.Empty"/> would silently <em>widen</em> an approved
+    /// proposal's scope on rehydration: per <c>GitRepoTarget</c>'s own contract an empty
+    /// <c>WorkingPath</c> means the diff may touch any path in the repository. A truncated
+    /// payload must fail loudly and quarantine its row, not resurrect as a less restricted
+    /// version of what a human approved.
+    /// </remarks>
+    /// <param name="root">The target JSON object.</param>
+    /// <param name="name">The property name.</param>
+    /// <exception cref="JsonException">The property is absent or is not a string.</exception>
+    private static string GetString(JsonElement root, string name)
+    {
+        if (!root.TryGetProperty(name, out var element) || element.ValueKind != JsonValueKind.String)
+        {
+            throw new JsonException(
+                $"ChangeTarget JSON is missing the required '{name}' property; refusing to " +
+                "reconstruct a target from a truncated payload.");
+        }
+
+        return element.GetString() ?? string.Empty;
+    }
+
+    /// <summary>
+    /// Reads a genuinely optional string property whose absence is meaningful and safe.
+    /// </summary>
+    /// <remarks>
+    /// Only used for properties that are written when — and only when — they are non-null, so
+    /// absence round-trips faithfully rather than dropping a constraint. An explicit JSON
+    /// <c>null</c> is also accepted as "not set".
+    /// </remarks>
+    /// <param name="root">The target JSON object.</param>
+    /// <param name="name">The property name.</param>
+    private static string? GetOptionalString(JsonElement root, string name) =>
+        root.TryGetProperty(name, out var element) && element.ValueKind == JsonValueKind.String
+            ? element.GetString()
+            : null;
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Persistence/Entities/ChangeProposalEntity.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Persistence/Entities/ChangeProposalEntity.cs
@@ -16,9 +16,15 @@ namespace Infrastructure.AI.Persistence.Entities;
 /// on the proposal id, so the planner's <c>SqliteVersionInterceptor</c> scheme is not applied.
 /// </para>
 /// <para>
-/// <see cref="SubmittedAtTicks"/> is a raw UTC-tick <see cref="long"/> for the same reason as
-/// the escalation entity's timestamps: an EF value converter throws during materialization,
-/// outside the store's per-row guard, so one corrupt value would fail an entire list query.
+/// <see cref="SubmittedAtTicks"/> is a raw UTC-tick <see cref="long"/>, diverging from the
+/// <c>SqliteValueConverters.DateTimeOffsetAsUtcTicks</c> converter that
+/// <c>PromptUsageDbContext</c> and <c>EvalDashboardDbContext</c> use for their timestamps. The
+/// reason is schema consistency with <see cref="EscalationStateEntity"/> in the same database and
+/// the same store pair, NOT a materialization hazard of its own: this column is only ever written,
+/// ordered by, and range-filtered server-side — <c>ListAsync</c> does not project it, and the
+/// aggregate's <c>SubmittedAt</c> is read from <see cref="ProposalJson"/> — so a converter here
+/// would have nothing to throw on during a list query. See <see cref="EscalationStateEntity"/> for
+/// the column where the hazard is real and load-bearing.
 /// </para>
 /// </remarks>
 public sealed class ChangeProposalEntity

--- a/src/Content/Infrastructure/Infrastructure.AI/Persistence/Entities/ChangeProposalEntity.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Persistence/Entities/ChangeProposalEntity.cs
@@ -1,0 +1,65 @@
+namespace Infrastructure.AI.Persistence.Entities;
+
+/// <summary>
+/// EF Core row for one durably persisted <c>ChangeProposal</c> in the governance-state store.
+/// The aggregate itself is stored as a JSON document (its diff, history, and polymorphic
+/// target don't map usefully to columns); the dimensions
+/// <c>IChangeProposalStore.ListAsync</c> filters or orders on are denormalized into
+/// first-class, indexed columns and kept in sync on every save.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Configured inline in <see cref="Infrastructure.AI.Persistence.GovernanceStateDbContext"/> —
+/// deliberately not via an <c>IEntityTypeConfiguration</c>, which
+/// <see cref="Infrastructure.AI.Persistence.PlannerDbContext"/> would pick up through its
+/// assembly scan. No <c>Version</c> column: <c>SaveAsync</c> is contractually last-write-wins
+/// on the proposal id, so the planner's <c>SqliteVersionInterceptor</c> scheme is not applied.
+/// </para>
+/// <para>
+/// <see cref="SubmittedAtTicks"/> is a raw UTC-tick <see cref="long"/> for the same reason as
+/// the escalation entity's timestamps: an EF value converter throws during materialization,
+/// outside the store's per-row guard, so one corrupt value would fail an entire list query.
+/// </para>
+/// </remarks>
+public sealed class ChangeProposalEntity
+{
+    /// <summary>The proposal's deterministic id (Base64URL SHA-256; primary key).</summary>
+    public string Id { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The lifecycle status, stored as the <c>ChangeProposalStatus</c> enum name for
+    /// resilience to enum reordering. Indexed — the primary list filter.
+    /// </summary>
+    public string Status { get; set; } = string.Empty;
+
+    /// <summary>The submitting agent's id (<c>ChangeProposal.SubmittedBy.Id</c>). Indexed.</summary>
+    public string SubmittedByAgentId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The proposal's blast radius as the underlying enum integer, so the
+    /// "at or above" list filter translates to an indexed SQL range predicate.
+    /// </summary>
+    public int BlastRadius { get; set; }
+
+    /// <summary>The target kind, stored as the <c>ChangeTargetKind</c> enum name.</summary>
+    public string TargetKind { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The submission instant as UTC ticks. Indexed — lists order by it, most recent first,
+    /// and the retention prune ranges over it.
+    /// </summary>
+    public long SubmittedAtTicks { get; set; }
+
+    /// <summary>JSON of the full <c>ChangeProposal</c> aggregate (source of truth on read).</summary>
+    public string ProposalJson { get; set; } = string.Empty;
+
+    /// <summary>
+    /// JSON of the <c>GovernanceRecordSeal</c> covering <see cref="ProposalJson"/>, bound to
+    /// <see cref="Id"/>. Without it a database writer could move a proposal to an approved or
+    /// terminal <see cref="Status"/>, or widen its target scope, and reads would serve the
+    /// result unchallenged — an exposure the in-memory store did not have, because there was no
+    /// file to edit. Null on rows written before sealing existed; verification treats that as
+    /// unverified (fail-closed).
+    /// </summary>
+    public string? ProposalSealJson { get; set; }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Persistence/Entities/EscalationStateEntity.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Persistence/Entities/EscalationStateEntity.cs
@@ -1,0 +1,69 @@
+namespace Infrastructure.AI.Persistence.Entities;
+
+/// <summary>
+/// EF Core row for one durably persisted escalation in the governance-state store.
+/// The full request / decisions / outcome payloads are JSON documents (the domain records
+/// are rich, nested, and versioned by shape); the columns EF filters or orders on
+/// (status, timestamps) are first-class and indexed.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Configured inline in <see cref="Infrastructure.AI.Persistence.GovernanceStateDbContext"/> —
+/// deliberately not via an <c>IEntityTypeConfiguration</c>, which
+/// <see cref="Infrastructure.AI.Persistence.PlannerDbContext"/> would pick up through its
+/// assembly scan. No <c>Version</c> column: rows are single-writer per escalation (the
+/// singleton escalation service serializes writes per record), so the planner's
+/// <c>SqliteVersionInterceptor</c> concurrency scheme is not applied to this context.
+/// </para>
+/// <para>
+/// Timestamps are stored as raw UTC-tick <see cref="long"/> columns and converted inside the
+/// store's guarded per-row mapping rather than by an EF value converter — a converter throws
+/// during materialization, outside any per-row guard, so a single corrupt tick value would
+/// fail the whole query (and with it, host startup).
+/// </para>
+/// </remarks>
+public sealed class EscalationStateEntity
+{
+    /// <summary>The escalation id (primary key).</summary>
+    public Guid Id { get; set; }
+
+    /// <summary>
+    /// The persisted lifecycle status, stored as the
+    /// <c>Application.AI.Common.Interfaces.Escalation.EscalationPersistedStatus</c> enum name
+    /// ("Pending", "ResolvedPendingAudit", "Resolved") for resilience to enum reordering.
+    /// Indexed — the rehydration and reconcile scans filter on it.
+    /// </summary>
+    public string Status { get; set; } = string.Empty;
+
+    /// <summary>JSON of the originating <c>EscalationRequest</c>.</summary>
+    public string RequestJson { get; set; } = string.Empty;
+
+    /// <summary>JSON array of the collected <c>ApproverDecision</c> records, in submission order.</summary>
+    public string DecisionsJson { get; set; } = "[]";
+
+    /// <summary>
+    /// JSON of the resolved <c>EscalationOutcome</c>; null until a resolution is reached.
+    /// </summary>
+    public string? OutcomeJson { get; set; }
+
+    /// <summary>
+    /// JSON of the <c>EscalationOutcomeSeal</c> covering <see cref="OutcomeJson"/>, produced
+    /// when the resolution was recorded. The reconciler refuses to re-drive an outcome whose
+    /// seal does not verify against the stored payload, so a row edited outside the process
+    /// cannot launder a forged verdict into the compliance audit log. Null on rows written
+    /// before sealing existed, which verification treats as unverified (fail-closed).
+    /// </summary>
+    public string? OutcomeSealJson { get; set; }
+
+    /// <summary>
+    /// When the escalation was created by the service, as UTC ticks. Drives timeout
+    /// resumption for a rehydrated escalation.
+    /// </summary>
+    public long CreatedAtTicks { get; set; }
+
+    /// <summary>
+    /// When this row was last written, as UTC ticks. Part of the composite status index that
+    /// backs the retention prune.
+    /// </summary>
+    public long UpdatedAtTicks { get; set; }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Persistence/Entities/EscalationStateEntity.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Persistence/Entities/EscalationStateEntity.cs
@@ -17,9 +17,22 @@ namespace Infrastructure.AI.Persistence.Entities;
 /// </para>
 /// <para>
 /// Timestamps are stored as raw UTC-tick <see cref="long"/> columns and converted inside the
-/// store's guarded per-row mapping rather than by an EF value converter — a converter throws
-/// during materialization, outside any per-row guard, so a single corrupt tick value would
-/// fail the whole query (and with it, host startup).
+/// store's guarded per-row mapping, rather than by the <c>SqliteValueConverters</c>
+/// <c>DateTimeOffsetAsUtcTicks</c> converter that <c>PromptUsageDbContext</c> and
+/// <c>EvalDashboardDbContext</c> apply to their timestamps. A converter's conversion is compiled
+/// into EF's query shaper, so it runs during materialization — outside the per-row guard — and
+/// <c>new DateTimeOffset(ticks, TimeSpan.Zero)</c> throws for an out-of-range tick. Deferring it
+/// keeps one corrupt row quarantinable instead of failing the scan that reads past it.
+/// </para>
+/// <para>
+/// The divergence from those two sibling contexts is deliberate and rests on a difference in
+/// requirements, not taste: they serve dashboard queries pulled on demand, where failing the query
+/// is an acceptable answer, whereas <see cref="CreatedAtTicks"/> is read by the startup
+/// rehydration scan that restores pending human approvals. Losing that whole scan to one bad row
+/// would strand every pending approval. Note the guarantee is partial by necessity —
+/// <see cref="Id"/> is a Guid BLOB that EF must convert during materialization regardless — which
+/// is why <c>EscalationStateRehydrationService</c> additionally treats a scan-level failure as
+/// non-fatal (LogCritical and continue to boot) rather than letting it stop the host.
 /// </para>
 /// </remarks>
 public sealed class EscalationStateEntity

--- a/src/Content/Infrastructure/Infrastructure.AI/Persistence/GovernanceStateDbContext.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Persistence/GovernanceStateDbContext.cs
@@ -1,0 +1,78 @@
+using Infrastructure.AI.Persistence.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace Infrastructure.AI.Persistence;
+
+/// <summary>
+/// EF Core DbContext for the durable governance-state store: pending escalations and change
+/// proposals that must survive host restarts. Targets SQLite; timestamps are stored as raw
+/// UTC-tick <see cref="long"/> columns (so range scans and ordering work, and a corrupt value
+/// surfaces in the store's guarded per-row mapping rather than throwing during
+/// materialization), and enums are stored as strings for resilience to reordering.
+/// </summary>
+/// <remarks>
+/// <para>
+/// One context for both governance subsystems by design: escalations and change proposals are
+/// the two approval-workflow states the harness tracks, they ship behind the same
+/// <c>AppConfig:AI:Governance:DurableState</c> section, and a single database file keeps the
+/// operator surface (one file to back up, inspect, or wipe) simple. Kept separate from
+/// <see cref="PlannerDbContext"/> (plan execution state) and <c>PromptUsageDbContext</c>
+/// (telemetry history), matching the repo's one-context-per-subsystem convention.
+/// </para>
+/// <para>
+/// Entities are configured inline rather than via <c>IEntityTypeConfiguration</c> classes
+/// because <see cref="PlannerDbContext"/> applies every configuration in this assembly —
+/// inline configuration keeps the two models from bleeding into each other.
+/// </para>
+/// <para>
+/// Every index here backs a real query: the composite <c>(Status, UpdatedAtTicks)</c> serves
+/// both the rehydration/reconcile status scans and the retention prune's status-plus-age
+/// range; the proposal indexes mirror each filter dimension of
+/// <c>IChangeProposalStore.ListAsync</c>, including the <c>BlastRadius</c> range predicate.
+/// </para>
+/// </remarks>
+public sealed class GovernanceStateDbContext : DbContext
+{
+    /// <summary>Durably persisted escalation state records.</summary>
+    public DbSet<EscalationStateEntity> Escalations => Set<EscalationStateEntity>();
+
+    /// <summary>Durably persisted change proposals.</summary>
+    public DbSet<ChangeProposalEntity> ChangeProposals => Set<ChangeProposalEntity>();
+
+    /// <summary>Initializes a new instance.</summary>
+    /// <param name="options">The context options (connection string, provider).</param>
+    public GovernanceStateDbContext(DbContextOptions<GovernanceStateDbContext> options)
+        : base(options)
+    {
+    }
+
+    /// <inheritdoc />
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        var escalation = modelBuilder.Entity<EscalationStateEntity>();
+        escalation.ToTable("escalation_state");
+        escalation.HasKey(e => e.Id);
+        escalation.Property(e => e.Status).IsRequired().HasMaxLength(32);
+        escalation.Property(e => e.RequestJson).IsRequired();
+        escalation.Property(e => e.DecisionsJson).IsRequired();
+        escalation.HasIndex(e => new { e.Status, e.UpdatedAtTicks })
+            .HasDatabaseName("ix_escalation_state_status_updated_at");
+
+        var proposal = modelBuilder.Entity<ChangeProposalEntity>();
+        proposal.ToTable("change_proposal");
+        proposal.HasKey(p => p.Id);
+        proposal.Property(p => p.Id).HasMaxLength(128);
+        proposal.Property(p => p.Status).IsRequired().HasMaxLength(32);
+        proposal.Property(p => p.SubmittedByAgentId).IsRequired().HasMaxLength(256);
+        proposal.Property(p => p.TargetKind).IsRequired().HasMaxLength(64);
+        proposal.Property(p => p.ProposalJson).IsRequired();
+        proposal.HasIndex(p => new { p.Status, p.SubmittedAtTicks })
+            .HasDatabaseName("ix_change_proposal_status_submitted_at");
+        proposal.HasIndex(p => p.SubmittedAtTicks)
+            .HasDatabaseName("ix_change_proposal_submitted_at");
+        proposal.HasIndex(p => p.SubmittedByAgentId)
+            .HasDatabaseName("ix_change_proposal_submitted_by");
+        proposal.HasIndex(p => p.BlastRadius)
+            .HasDatabaseName("ix_change_proposal_blast_radius");
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Persistence/GovernanceStateJson.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Persistence/GovernanceStateJson.cs
@@ -1,0 +1,29 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Infrastructure.AI.Persistence;
+
+/// <summary>
+/// The single <see cref="JsonSerializerOptions"/> instance the durable governance-state store
+/// uses for every payload column (escalation requests, decisions, outcomes, and change
+/// proposals), so all rows in the database share one wire shape.
+/// </summary>
+/// <remarks>
+/// Enums serialize as their names (resilient to reordering, matching the JSONL audit stores'
+/// convention) and the polymorphic <c>ChangeTarget</c> hierarchy round-trips through
+/// <see cref="ChangeTargetJsonConverter"/>. Property names keep their C# casing;
+/// case-insensitive reads tolerate historical rows if that ever changes.
+/// </remarks>
+public static class GovernanceStateJson
+{
+    /// <summary>The shared serializer options for governance-state payload columns.</summary>
+    public static readonly JsonSerializerOptions Options = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters =
+        {
+            new JsonStringEnumConverter(),
+            new ChangeTargetJsonConverter()
+        }
+    };
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Persistence/GovernanceStatePaths.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Persistence/GovernanceStatePaths.cs
@@ -1,3 +1,5 @@
+using Domain.Common.Helpers;
+
 namespace Infrastructure.AI.Persistence;
 
 /// <summary>
@@ -30,18 +32,25 @@ public static class GovernanceStatePaths
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(configuredPath);
 
-        var root = Path.GetFullPath(baseDirectory ?? AppContext.BaseDirectory);
-        var fullPath = Path.GetFullPath(Path.Combine(root, configuredPath));
+        var root = PathScope.Normalize(baseDirectory ?? AppContext.BaseDirectory);
+        var fullPath = PathScope.Normalize(Path.Combine(root, configuredPath));
 
-        var rootWithSeparator = root.EndsWith(Path.DirectorySeparatorChar)
-            ? root
-            : root + Path.DirectorySeparatorChar;
-
-        if (!fullPath.StartsWith(rootWithSeparator, StringComparison.OrdinalIgnoreCase))
+        if (!PathScope.IsSameOrUnderNormalized(fullPath, root))
         {
             throw new ArgumentException(
                 "AppConfig:AI:Governance:DurableState:DatabasePath resolves outside the application " +
                 "directory. Configure a path relative to the application base directory.",
+                nameof(configuredPath));
+        }
+
+        // Containment alone would admit the root directory itself, which names a directory rather than
+        // a database file. PathScope.Comparison keeps this check on the same case-sensitivity rules as
+        // the containment check above, so the two cannot drift apart.
+        if (string.Equals(fullPath, root, PathScope.Comparison))
+        {
+            throw new ArgumentException(
+                "AppConfig:AI:Governance:DurableState:DatabasePath must name a file inside the " +
+                "application directory, not the directory itself.",
                 nameof(configuredPath));
         }
 

--- a/src/Content/Infrastructure/Infrastructure.AI/Persistence/GovernanceStatePaths.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Persistence/GovernanceStatePaths.cs
@@ -1,0 +1,77 @@
+namespace Infrastructure.AI.Persistence;
+
+/// <summary>
+/// Resolves and validates the on-disk location of the governance-state database.
+/// </summary>
+/// <remarks>
+/// The configured path is attacker-relevant: it names the file holding approval verdicts.
+/// A path that escapes the application directory (via <c>..</c> segments, or an absolute
+/// path pointing at a network share) would place that file somewhere the host does not
+/// control. Resolution therefore normalizes first and then asserts containment, rather than
+/// trusting the configured string.
+/// </remarks>
+public static class GovernanceStatePaths
+{
+    /// <summary>
+    /// Normalizes <paramref name="configuredPath"/> against the application base directory and
+    /// verifies the result stays under it.
+    /// </summary>
+    /// <param name="configuredPath">The configured database path, absolute or relative.</param>
+    /// <param name="baseDirectory">
+    /// The permitted root. Defaults to <see cref="AppContext.BaseDirectory"/>; overridable so
+    /// tests can assert the containment rule without writing to the test host's directory.
+    /// </param>
+    /// <returns>The absolute, validated database file path.</returns>
+    /// <exception cref="ArgumentException">
+    /// The path is blank, resolves outside <paramref name="baseDirectory"/>, or names a
+    /// location with no parent directory.
+    /// </exception>
+    public static string Resolve(string configuredPath, string? baseDirectory = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(configuredPath);
+
+        var root = Path.GetFullPath(baseDirectory ?? AppContext.BaseDirectory);
+        var fullPath = Path.GetFullPath(Path.Combine(root, configuredPath));
+
+        var rootWithSeparator = root.EndsWith(Path.DirectorySeparatorChar)
+            ? root
+            : root + Path.DirectorySeparatorChar;
+
+        if (!fullPath.StartsWith(rootWithSeparator, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new ArgumentException(
+                "AppConfig:AI:Governance:DurableState:DatabasePath resolves outside the application " +
+                "directory. Configure a path relative to the application base directory.",
+                nameof(configuredPath));
+        }
+
+        if (string.IsNullOrEmpty(Path.GetDirectoryName(fullPath)))
+        {
+            throw new ArgumentException(
+                "AppConfig:AI:Governance:DurableState:DatabasePath has no containing directory.",
+                nameof(configuredPath));
+        }
+
+        return fullPath;
+    }
+
+    /// <summary>
+    /// Creates the containing directory for a resolved database path. Called lazily, on first
+    /// context materialization, so a host that never enables durable state creates nothing.
+    /// </summary>
+    /// <param name="resolvedDatabasePath">A path already returned by <see cref="Resolve"/>.</param>
+    public static void EnsureDirectory(string resolvedDatabasePath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(resolvedDatabasePath);
+
+        var directory = Path.GetDirectoryName(resolvedDatabasePath);
+        if (string.IsNullOrEmpty(directory))
+        {
+            throw new ArgumentException(
+                "Resolved governance-state database path has no containing directory.",
+                nameof(resolvedDatabasePath));
+        }
+
+        Directory.CreateDirectory(directory);
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Persistence/GovernanceStatePayload.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Persistence/GovernanceStatePayload.cs
@@ -1,0 +1,106 @@
+using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+
+namespace Infrastructure.AI.Persistence;
+
+/// <summary>
+/// Shared read/write guards for the JSON payload columns of the governance-state database.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Both governance-state stores (escalations and change proposals) persist their aggregates as JSON
+/// text and face the same two hazards: a stored payload that no longer deserializes, and a payload
+/// large enough to be worth rejecting at the write. Keeping the guards here rather than once per
+/// store means the exception set below is written once. That matters because the set is easy to get
+/// wrong by omission — miss a type when adding a new payload shape and a row that should have been
+/// quarantined instead throws out of the scan, which is precisely the failure the guard exists to
+/// prevent.
+/// </para>
+/// <para>
+/// Serialization options come from <see cref="GovernanceStateJson"/>, so reads and writes cannot
+/// drift onto different converter sets.
+/// </para>
+/// </remarks>
+public static class GovernanceStatePayload
+{
+    /// <summary>
+    /// The floor applied to the configured payload cap. A cap below this is treated as
+    /// misconfiguration rather than honoured, because a cap of (say) zero would reject every write
+    /// and disable durable governance state entirely.
+    /// </summary>
+    public const int MinimumMaxPayloadBytes = 1024;
+
+    /// <summary>
+    /// Classifies an exception as "this stored payload is unreadable" rather than as an
+    /// infrastructure fault.
+    /// </summary>
+    /// <remarks>
+    /// A corrupt tick value, an unrecognised enum name, and a truncated document surface as
+    /// different exception types; all of them mean one row is bad, and none of them should fail the
+    /// scan that is reading past it.
+    /// </remarks>
+    /// <param name="exception">The exception thrown while reading a payload.</param>
+    /// <returns>True when the exception indicates an unreadable payload.</returns>
+    public static bool IsUnreadablePayload(Exception exception) =>
+        exception is JsonException or ArgumentException or FormatException or OverflowException;
+
+    /// <summary>
+    /// Deserializes one stored payload, returning null and logging when it is unreadable so the
+    /// caller can skip the row while leaving it on disk for manual inspection.
+    /// </summary>
+    /// <typeparam name="T">The payload type.</typeparam>
+    /// <param name="json">The stored JSON.</param>
+    /// <param name="logger">Logger for the failure line.</param>
+    /// <param name="description">What the payload is, for the log line (for example "escalation outcome").</param>
+    /// <param name="recordId">The owning record's id, for the log line.</param>
+    /// <returns>The payload, or null when it is absent or unreadable.</returns>
+    public static T? TryDeserialize<T>(string json, ILogger logger, string description, object recordId)
+        where T : class
+    {
+        ArgumentNullException.ThrowIfNull(logger);
+
+        try
+        {
+            return JsonSerializer.Deserialize<T>(json, GovernanceStateJson.Options);
+        }
+        catch (Exception ex) when (IsUnreadablePayload(ex))
+        {
+            logger.LogError(ex,
+                "Skipping unreadable persisted {Description} for governance record {RecordId}; " +
+                "the row is preserved for manual inspection",
+                description, recordId);
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Serializes a payload and rejects it when it exceeds the configured cap, so an oversized
+    /// document fails loudly at the write rather than being stored and failing every later read.
+    /// </summary>
+    /// <typeparam name="T">The payload type.</typeparam>
+    /// <param name="value">The value to serialize.</param>
+    /// <param name="configuredMaxBytes">
+    /// The raw configured cap. The <see cref="MinimumMaxPayloadBytes"/> floor is applied here, so no
+    /// caller has to remember to apply it.
+    /// </param>
+    /// <param name="subject">What is being written, for the failure message (a column or record).</param>
+    /// <returns>The serialized JSON.</returns>
+    /// <exception cref="InvalidOperationException">The payload exceeds the effective cap.</exception>
+    public static string SerializeGuarded<T>(T value, int configuredMaxBytes, string subject)
+    {
+        var json = JsonSerializer.Serialize(value, GovernanceStateJson.Options);
+        var maxBytes = Math.Max(MinimumMaxPayloadBytes, configuredMaxBytes);
+        var byteCount = Encoding.UTF8.GetByteCount(json);
+
+        if (byteCount > maxBytes)
+        {
+            throw new InvalidOperationException(
+                $"Governance-state payload for {subject} is {byteCount} bytes, exceeding the configured " +
+                $"maximum of {maxBytes}. Raise AppConfig:AI:Governance:DurableState:MaxPayloadBytes or " +
+                "reduce the payload size.");
+        }
+
+        return json;
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Persistence/GovernanceStatePruner.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Persistence/GovernanceStatePruner.cs
@@ -25,6 +25,13 @@ namespace Infrastructure.AI.Persistence;
 /// </remarks>
 public sealed class GovernanceStatePruner : IGovernanceStatePruner
 {
+    // The terminal set is fixed at compile time; materializing it per pass would rebuild the same
+    // array on every retention tick for the lifetime of the host.
+    private static readonly string[] TerminalProposalStatuses = ChangeProposalStateTransitions
+        .TerminalStates
+        .Select(s => s.ToString())
+        .ToArray();
+
     private readonly IDbContextFactory<GovernanceStateDbContext> _contextFactory;
     private readonly ILogger<GovernanceStatePruner> _logger;
 
@@ -50,9 +57,6 @@ public sealed class GovernanceStatePruner : IGovernanceStatePruner
     public async Task<GovernanceStatePruneResult> PruneAsync(DateTimeOffset cutoff, CancellationToken ct)
     {
         var cutoffTicks = cutoff.UtcTicks;
-        var terminalProposalStatuses = ChangeProposalStateTransitions.TerminalStates
-            .Select(s => s.ToString())
-            .ToArray();
 
         await using var context = await _contextFactory.CreateDbContextAsync(ct);
 
@@ -62,7 +66,7 @@ public sealed class GovernanceStatePruner : IGovernanceStatePruner
             .ExecuteDeleteAsync(ct);
 
         var proposalsRemoved = await context.ChangeProposals
-            .Where(p => terminalProposalStatuses.Contains(p.Status)
+            .Where(p => TerminalProposalStatuses.Contains(p.Status)
                 && p.SubmittedAtTicks < cutoffTicks)
             .ExecuteDeleteAsync(ct);
 

--- a/src/Content/Infrastructure/Infrastructure.AI/Persistence/GovernanceStatePruner.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Persistence/GovernanceStatePruner.cs
@@ -1,0 +1,78 @@
+using Application.AI.Common.Interfaces.Escalation;
+using Domain.AI.Changes;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace Infrastructure.AI.Persistence;
+
+/// <summary>
+/// SQLite implementation of <see cref="IGovernanceStatePruner"/>: deletes terminal
+/// governance-state rows older than the retention cutoff.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Eligibility is deliberately narrow. Escalations must be in
+/// <see cref="EscalationPersistedStatus.Resolved"/> — a pending escalation, or one parked
+/// awaiting reconciliation, is never pruned no matter how old, because deleting it would
+/// strand an approval or discard an unaudited verdict. Change proposals must be in a terminal
+/// <see cref="ChangeProposalStatus"/>; anything still moving through the gate pipeline stays.
+/// </para>
+/// <para>
+/// Compliance history is untouched: the hash-chained JSONL audit stores are the retained
+/// record. This prunes only the recoverable working state, which has no value once its
+/// workflow has finished.
+/// </para>
+/// </remarks>
+public sealed class GovernanceStatePruner : IGovernanceStatePruner
+{
+    private readonly IDbContextFactory<GovernanceStateDbContext> _contextFactory;
+    private readonly ILogger<GovernanceStatePruner> _logger;
+
+    /// <summary>Initializes a new instance.</summary>
+    /// <param name="contextFactory">Factory for short-lived governance-state contexts.</param>
+    /// <param name="schemaInitializer">
+    /// Forces schema creation before the first prune. Unused beyond its construction side effect.
+    /// </param>
+    /// <param name="logger">Structured logger.</param>
+    public GovernanceStatePruner(
+        IDbContextFactory<GovernanceStateDbContext> contextFactory,
+        GovernanceStateSchemaInitializer schemaInitializer,
+        ILogger<GovernanceStatePruner> logger)
+    {
+        ArgumentNullException.ThrowIfNull(contextFactory);
+        ArgumentNullException.ThrowIfNull(schemaInitializer);
+        ArgumentNullException.ThrowIfNull(logger);
+        _contextFactory = contextFactory;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<GovernanceStatePruneResult> PruneAsync(DateTimeOffset cutoff, CancellationToken ct)
+    {
+        var cutoffTicks = cutoff.UtcTicks;
+        var terminalProposalStatuses = ChangeProposalStateTransitions.TerminalStates
+            .Select(s => s.ToString())
+            .ToArray();
+
+        await using var context = await _contextFactory.CreateDbContextAsync(ct);
+
+        var escalationsRemoved = await context.Escalations
+            .Where(e => e.Status == nameof(EscalationPersistedStatus.Resolved)
+                && e.UpdatedAtTicks < cutoffTicks)
+            .ExecuteDeleteAsync(ct);
+
+        var proposalsRemoved = await context.ChangeProposals
+            .Where(p => terminalProposalStatuses.Contains(p.Status)
+                && p.SubmittedAtTicks < cutoffTicks)
+            .ExecuteDeleteAsync(ct);
+
+        if (escalationsRemoved > 0 || proposalsRemoved > 0)
+        {
+            _logger.LogInformation(
+                "Pruned governance state older than {Cutoff}: {EscalationCount} escalation(s), {ProposalCount} proposal(s)",
+                cutoff, escalationsRemoved, proposalsRemoved);
+        }
+
+        return new GovernanceStatePruneResult(escalationsRemoved, proposalsRemoved);
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Persistence/GovernanceStateSchemaInitializer.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Persistence/GovernanceStateSchemaInitializer.cs
@@ -1,0 +1,94 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace Infrastructure.AI.Persistence;
+
+/// <summary>
+/// Governance-state schema initializer: runs the base <c>EnsureCreated</c> lifecycle, then
+/// applies idempotent, PRAGMA-guarded DDL for schema additions that <c>EnsureCreated</c>
+/// cannot deliver to a pre-existing database.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Follows <see cref="PlannerSchemaInitializer"/>. The base
+/// <see cref="SchemaInitializer{TContext}"/> only calls <c>EnsureCreated</c>, which no-ops
+/// once the database exists — so a consumer who created a governance-state database before
+/// the outcome-seal columns shipped would never receive them, and the first reconcile scan
+/// would fail with "no such column". Shipping the derived initializer from the start means
+/// the next column addition has a place to live instead of silently breaking existing
+/// deployments.
+/// </para>
+/// <para>
+/// SQLite-specific by design (the governance-state registration is SQLite-only); the
+/// evolution step is skipped for any other provider, where a fresh <c>EnsureCreated</c>
+/// already contains every column.
+/// </para>
+/// </remarks>
+public sealed class GovernanceStateSchemaInitializer : SchemaInitializer<GovernanceStateDbContext>
+{
+    /// <summary>
+    /// Initializes a new instance: ensures the database exists (base), then ensures the
+    /// outcome-seal columns and the composite status index exist on <c>escalation_state</c>.
+    /// </summary>
+    /// <param name="contextFactory">Factory for short-lived governance-state contexts.</param>
+    public GovernanceStateSchemaInitializer(IDbContextFactory<GovernanceStateDbContext> contextFactory)
+        : base(contextFactory)
+    {
+        using var context = contextFactory.CreateDbContext();
+        if (context.Database.IsSqlite())
+            EnsureSealColumns(context);
+    }
+
+    /// <summary>
+    /// Adds the outcome-seal columns to <c>escalation_state</c> when a pre-existing database
+    /// lacks them, and (re)creates the composite status index. Idempotent: guarded by
+    /// <c>PRAGMA table_info</c> and <c>CREATE INDEX IF NOT EXISTS</c>. Existing rows keep
+    /// <c>NULL</c> seals, which verification treats as unsealed and therefore not
+    /// re-drivable — fail-closed, exactly as intended for rows written before sealing existed.
+    /// </summary>
+    /// <param name="context">An open governance-state context on the target database.</param>
+    private static void EnsureSealColumns(GovernanceStateDbContext context)
+    {
+        var columns = ReadColumnNames(context);
+
+        // EnsureCreated short-circuits when the database has ANY table, so a database file
+        // with other tables but no escalation_state would reach this point with zero columns —
+        // ALTER TABLE would then throw at startup. No table means nothing to evolve.
+        if (columns.Count == 0)
+            return;
+
+        if (!columns.Contains("OutcomeSealJson"))
+            context.Database.ExecuteSqlRaw("ALTER TABLE \"escalation_state\" ADD COLUMN \"OutcomeSealJson\" TEXT NULL;");
+
+        var proposalColumns = ReadColumnNames(context, "change_proposal");
+        if (proposalColumns.Count > 0 && !proposalColumns.Contains("ProposalSealJson"))
+            context.Database.ExecuteSqlRaw("ALTER TABLE \"change_proposal\" ADD COLUMN \"ProposalSealJson\" TEXT NULL;");
+
+        context.Database.ExecuteSqlRaw(
+            "CREATE INDEX IF NOT EXISTS \"ix_escalation_state_status_updated_at\" " +
+            "ON \"escalation_state\" (\"Status\", \"UpdatedAtTicks\");");
+    }
+
+    /// <summary>
+    /// Reads the current column names of <c>escalation_state</c> via <c>PRAGMA table_info</c>
+    /// (name is the second result column).
+    /// </summary>
+    /// <param name="context">An open governance-state context on the target database.</param>
+    /// <returns>The case-insensitive set of existing column names.</returns>
+    private static HashSet<string> ReadColumnNames(
+        GovernanceStateDbContext context, string tableName = "escalation_state")
+    {
+        var columns = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var connection = context.Database.GetDbConnection();
+        if (connection.State != System.Data.ConnectionState.Open)
+            connection.Open();
+
+        using var command = connection.CreateCommand();
+        // Table names here are compile-time constants from this class, never user input.
+        command.CommandText = $"PRAGMA table_info(\"{tableName}\");";
+        using var reader = command.ExecuteReader();
+        while (reader.Read())
+            columns.Add(reader.GetString(1));
+
+        return columns;
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/README.md
+++ b/src/Content/Infrastructure/Infrastructure.AI/README.md
@@ -410,8 +410,9 @@ The project reads configuration from `AppConfig` bound via the Options pattern. 
 
 ### File-system sandbox: supported platforms
 
-**The file-system tool runs on Windows and Linux only.** On macOS and the BSDs the host refuses to
-start.
+**With durable governance state in use, the file-system tool runs on Windows and Linux only.** On
+macOS and the BSDs such a host refuses to start. A host with nothing to protect — the shipped
+default — runs the tool on every platform.
 
 The sandbox's last line of defence is a hard-link check. A hard link is a second directory entry for
 the same file — not a shortcut, not a symlink, and carrying nothing for a path check to resolve — so
@@ -427,16 +428,40 @@ fails *open* — silently reporting "one link" for a file that has two — which
 support at all, so none is shipped rather than an unverified guess.
 
 `FileSystemSandboxStartupValidator` turns this into a boot failure naming the platform, rather than
-letting every file operation fail separately with an error that cannot explain itself. Two ways
+letting every file operation fail separately with an error that cannot explain itself. Three ways
 forward:
 
 1. **Run on Windows or Linux.** The supported configuration.
 2. **Add a branch to `HardLinkInspector`** for your platform, verifying the `struct stat` layout
    against the actual target OS and architecture rather than assuming it.
+3. **Run without durable governance state**, so there is nothing to protect and no reason to arm
+   the check. This has *two* conditions — see below.
 
-Note what does *not* help: turning the `AppConfig:AI:Governance:DurableState` toggles off. Those
-control whether durable governance state is *used*; the governance-state directory is registered as
-a protected path unconditionally, so the hard-link check stays armed either way.
+#### When the check is armed
+
+`DependencyInjection.ResolveGovernanceStateProtectedPaths` hands the governance-state directory to
+`FileSystemService` only when protecting it is meaningful:
+
+| `EscalationsEnabled` / `ChangeProposalsEnabled` | Governance-state directory on disk | Protected path registered | macOS / BSD |
+| --- | --- | --- | --- |
+| either `true` | irrelevant | yes | host refuses to start |
+| both `false` | present (left by an earlier run) | yes | host refuses to start |
+| both `false` | absent (**shipped default**) | no | file-system tool works |
+
+The middle row is the one that catches people out. A database left behind by a run that *did* have
+durability enabled still holds approval verdicts, and those do not stop being sensitive because
+someone later set a flag to `false` — so an existing directory arms the protection on its own
+account. Option 3 above therefore means: set **both** toggles to `false` **and** make sure no
+governance-state directory remains at the configured `DatabasePath`. Archive or relocate that
+directory rather than deleting it, unless you are certain the records are no longer needed.
+
+The decision is made once, at composition, with a single `Directory.Exists` probe — never per file
+operation. That is sound because the directory can only be created by a host whose toggles were
+already on at composition: every route to `GovernanceStatePaths.EnsureDirectory` runs inside the
+`GovernanceStateDbContext` options callback, reachable only through `EfCoreEscalationStateStore`,
+`EfCoreChangeProposalStore`, or `GovernanceStatePruner`, and all three sit behind a toggle read that
+is frozen at startup. Editing the toggles on a running host changes nothing until it restarts, which
+is the restart-required contract documented on `GovernanceDurableStateConfig`.
 
 ## Common Tasks
 

--- a/src/Content/Infrastructure/Infrastructure.AI/README.md
+++ b/src/Content/Infrastructure/Infrastructure.AI/README.md
@@ -408,6 +408,36 @@ The project reads configuration from `AppConfig` bound via the Options pattern. 
 }
 ```
 
+### File-system sandbox: supported platforms
+
+**The file-system tool runs on Windows and Linux only.** On macOS and the BSDs the host refuses to
+start.
+
+The sandbox's last line of defence is a hard-link check. A hard link is a second directory entry for
+the same file — not a shortcut, not a symlink, and carrying nothing for a path check to resolve — so
+a hard link planted in `workspace` that points at the governance-state database reads to every
+path-based rule as an ordinary workspace file. The only way to catch it is to ask the operating
+system how many directory entries name the file, which `HardLinkInspector` does via
+`GetFileInformationByHandle` on Windows and `statx` on Linux. There is no portable API for this, and
+the check **fails closed**: a platform it cannot answer for denies the operation.
+
+macOS and the BSDs expose the count only through `struct stat`, whose field order and widths differ
+by operating system *and* by processor architecture. A guessed layout reads the wrong bytes and
+fails *open* — silently reporting "one link" for a file that has two — which is worse than no
+support at all, so none is shipped rather than an unverified guess.
+
+`FileSystemSandboxStartupValidator` turns this into a boot failure naming the platform, rather than
+letting every file operation fail separately with an error that cannot explain itself. Two ways
+forward:
+
+1. **Run on Windows or Linux.** The supported configuration.
+2. **Add a branch to `HardLinkInspector`** for your platform, verifying the `struct stat` layout
+   against the actual target OS and architecture rather than assuming it.
+
+Note what does *not* help: turning the `AppConfig:AI:Governance:DurableState` toggles off. Those
+control whether durable governance state is *used*; the governance-state directory is registered as
+a protected path unconditionally, so the hard-link check stays armed either way.
+
 ## Common Tasks
 
 ### How to Add a New Tool

--- a/src/Content/Infrastructure/Infrastructure.AI/README.md
+++ b/src/Content/Infrastructure/Infrastructure.AI/README.md
@@ -397,7 +397,11 @@ The project reads configuration from `AppConfig` bound via the Options pattern. 
     },
     "Infrastructure": {
       "FileSystem": {
-        "AllowedBasePaths": ["../../../.."] // Sandboxed directories for file tools
+        // Sandboxed directories for file tools, resolved against AppContext.BaseDirectory.
+        // Keep this NARROW. "../../../.." resolves to the project directory, which contains
+        // bin/<config>/<tfm>/.agent-state — the governance-state database — and
+        // FileSystemSandboxStartupValidator refuses to boot on that overlap.
+        "AllowedBasePaths": ["workspace"]
       }
     }
   }

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/FileSystemSandboxStartupValidator.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/FileSystemSandboxStartupValidator.cs
@@ -1,3 +1,4 @@
+using System.Runtime.InteropServices;
 using Domain.Common.Helpers;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -43,12 +44,22 @@ namespace Infrastructure.AI.Tools;
 /// database file — on a host where this validator already warned and moved on. A boot-time
 /// assertion that a live configuration change can invalidate has to hold on every boot.
 /// </para>
+/// <para>
+/// <b>It also refuses a platform the hard-link control cannot run on.</b> That control is what
+/// actually closes the bypass, and it fails closed, so on an unimplemented platform — macOS and the
+/// BSDs — every file operation is denied. Without this check the operator meets that as a stream of
+/// per-call refusals whose message cannot name the real cause, since at the point of denial the
+/// service knows only that the count was unavailable. Meeting it once, at boot, with the platform
+/// named and the ways forward spelled out, is the difference between a documented limitation and an
+/// inexplicably broken template.
+/// </para>
 /// </remarks>
 public sealed class FileSystemSandboxStartupValidator : IHostedService
 {
     private readonly IReadOnlyList<string> _allowedBasePaths;
     private readonly IReadOnlyList<string> _protectedPaths;
     private readonly ILogger<FileSystemSandboxStartupValidator> _logger;
+    private readonly bool _hardLinkInspectionSupported;
 
     /// <summary>
     /// Initializes a new <see cref="FileSystemSandboxStartupValidator"/>.
@@ -66,6 +77,33 @@ public sealed class FileSystemSandboxStartupValidator : IHostedService
         IReadOnlyList<string> allowedBasePaths,
         IReadOnlyList<string> protectedPaths,
         ILogger<FileSystemSandboxStartupValidator> logger)
+        : this(allowedBasePaths, protectedPaths, logger, HardLinkInspector.IsSupportedPlatform)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new <see cref="FileSystemSandboxStartupValidator"/> with the hard-link
+    /// platform-capability signal supplied explicitly.
+    /// </summary>
+    /// <remarks>
+    /// Exists so the platform assertion can be tested on every operating system CI runs on. Faking
+    /// the OS itself is not possible in-process, and a test that could only fail on macOS would
+    /// never run — the repository's CI is Linux-only. Passing the capability in means the branch is
+    /// exercised everywhere, which is the difference between a covered guard and one nobody has
+    /// watched fail.
+    /// </remarks>
+    /// <param name="allowedBasePaths">The base paths the file-system tool may reach, as registered.</param>
+    /// <param name="protectedPaths">The harness-state directories denied to the tool, as registered.</param>
+    /// <param name="logger">Logger for the validation outcome.</param>
+    /// <param name="hardLinkInspectionSupported">
+    /// Whether the running platform has a link-count implementation. Production passes
+    /// <see cref="HardLinkInspector.IsSupportedPlatform"/>.
+    /// </param>
+    internal FileSystemSandboxStartupValidator(
+        IReadOnlyList<string> allowedBasePaths,
+        IReadOnlyList<string> protectedPaths,
+        ILogger<FileSystemSandboxStartupValidator> logger,
+        bool hardLinkInspectionSupported)
     {
         ArgumentNullException.ThrowIfNull(allowedBasePaths);
         ArgumentNullException.ThrowIfNull(protectedPaths);
@@ -74,29 +112,74 @@ public sealed class FileSystemSandboxStartupValidator : IHostedService
         _allowedBasePaths = allowedBasePaths;
         _protectedPaths = protectedPaths;
         _logger = logger;
+        _hardLinkInspectionSupported = hardLinkInspectionSupported;
     }
 
     /// <inheritdoc />
     /// <exception cref="InvalidOperationException">
-    /// A protected harness-state directory lies inside an allowed base path.
+    /// A protected harness-state directory lies inside an allowed base path, or protected
+    /// directories are configured on a platform where the hard-link control cannot run.
     /// </exception>
     public Task StartAsync(CancellationToken cancellationToken)
     {
+        // Geometry first. When both are wrong, the overlap is the one that is a security
+        // misconfiguration in its own right and stays wrong after a move to a supported platform,
+        // so it is the more useful thing to say first.
         var overlaps = FindOverlaps();
-        if (overlaps.Count == 0)
-            return Task.CompletedTask;
+        if (overlaps.Count > 0)
+        {
+            // Logged structurally as well as thrown: the exception message is one string for a
+            // human, while these fields are what a log query can actually group and alert on.
+            _logger.LogError(
+                "Refusing to start: protected harness-state directory {ProtectedPath} lies inside the " +
+                "file-system tool's allowed base path {AllowedBasePath} ({OverlapCount} overlap(s) total).",
+                overlaps[0].ProtectedPath,
+                overlaps[0].AllowedBasePath,
+                overlaps.Count);
 
-        // Logged structurally as well as thrown: the exception message is one string for a human,
-        // while these fields are what a log query can actually group and alert on.
-        _logger.LogError(
-            "Refusing to start: protected harness-state directory {ProtectedPath} lies inside the " +
-            "file-system tool's allowed base path {AllowedBasePath} ({OverlapCount} overlap(s) total).",
-            overlaps[0].ProtectedPath,
-            overlaps[0].AllowedBasePath,
-            overlaps.Count);
+            throw new InvalidOperationException(BuildOverlapFailureMessage(overlaps));
+        }
 
-        throw new InvalidOperationException(BuildFailureMessage(overlaps));
+        if (HasProtectedPaths && !_hardLinkInspectionSupported)
+        {
+            _logger.LogError(
+                "Refusing to start: the file-system tool's hard-link sandbox control has no " +
+                "implementation on {Platform}, and {ProtectedPathCount} protected harness-state " +
+                "director(y/ies) are configured, so every file operation would be denied.",
+                PlatformLabel,
+                _protectedPaths.Count);
+
+            throw new InvalidOperationException(BuildUnsupportedPlatformMessage());
+        }
+
+        return Task.CompletedTask;
     }
+
+    /// <summary>
+    /// Whether any usable protected path is configured — the condition under which the file-system
+    /// tool arms its per-operation hard-link check.
+    /// </summary>
+    /// <remarks>
+    /// Blank entries are discarded to mirror <see cref="FileSystemService"/> exactly: its
+    /// constructor drops them before counting, so a list holding only blanks leaves the runtime
+    /// check disarmed. A validator that counted raw entries would refuse to boot over a
+    /// configuration the tool treats as having nothing to protect.
+    /// </remarks>
+    private bool HasProtectedPaths =>
+        _protectedPaths.Any(p => !string.IsNullOrWhiteSpace(p));
+
+    /// <summary>
+    /// A human-readable name for the running operating system.
+    /// </summary>
+    /// <remarks>
+    /// macOS is spelled out because it is the platform this refusal will overwhelmingly be read on,
+    /// and <see cref="RuntimeInformation.OSDescription"/> reports it as "Darwin" plus a kernel
+    /// version, which reads as an unrelated system to someone who has not met it before.
+    /// </remarks>
+    private static string PlatformLabel =>
+        OperatingSystem.IsMacOS()
+            ? $"macOS ({RuntimeInformation.OSDescription})"
+            : RuntimeInformation.OSDescription;
 
     /// <inheritdoc />
     public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
@@ -137,10 +220,46 @@ public sealed class FileSystemSandboxStartupValidator : IHostedService
     }
 
     /// <summary>
+    /// Builds the boot-failure message for the unimplemented-platform case: what is unavailable,
+    /// what it would cost to ignore, and the only two things that actually resolve it.
+    /// </summary>
+    /// <remarks>
+    /// The message deliberately forecloses the fix an operator would otherwise try first. Turning
+    /// the durable-governance toggles off looks like it should empty the protected list, and it does
+    /// not: <c>RegisterToolServices</c> derives the governance-state directory from
+    /// <c>GovernanceStatePaths.Resolve</c> unconditionally, consulting no toggle, and the configured
+    /// database path defaults to a non-blank value. Sending an operator down that path would cost
+    /// them an hour and end where they started.
+    /// </remarks>
+    private string BuildUnsupportedPlatformMessage()
+    {
+        var firstProtected = _protectedPaths.First(p => !string.IsNullOrWhiteSpace(p));
+
+        return
+            "The file-system tool's hard-link sandbox control has no implementation on this " +
+            $"platform ({PlatformLabel}), and protected harness-state directories are configured " +
+            $"(for example '{firstProtected}'). That control asks the operating system how many " +
+            "directory entries name a file, which is the only question that detects a hard link " +
+            "aliasing protected state; it is implemented with GetFileInformationByHandle on Windows " +
+            "and statx on Linux, and it fails closed everywhere else. Booting anyway would deny " +
+            "every read, write, and search the file-system tool attempts, one call at a time, with " +
+            "an error that cannot name this as the cause. " +
+            "Two ways forward: (1) run the harness on Windows or Linux, the supported platforms; " +
+            "(2) add a branch for this platform to HardLinkInspector — macOS and the BSDs expose the " +
+            "link count only through struct stat, whose field order and widths vary by operating " +
+            "system AND processor architecture, so the layout must be verified against the target " +
+            "rather than assumed; a wrong offset reads the wrong bytes and fails open silently. " +
+            "Note what will NOT work: turning the AppConfig:AI:Governance:DurableState toggles off " +
+            "does not remove the protected paths. The governance-state directory is registered as " +
+            "protected unconditionally, whatever those toggles say, so the file-system tool is " +
+            "unusable on this platform until one of the two options above is taken.";
+    }
+
+    /// <summary>
     /// Builds the boot-failure message: what is wrong, why it matters, and which setting to change.
     /// </summary>
     /// <param name="overlaps">The overlaps found; never empty.</param>
-    private static string BuildFailureMessage(IReadOnlyList<SandboxOverlap> overlaps)
+    private static string BuildOverlapFailureMessage(IReadOnlyList<SandboxOverlap> overlaps)
     {
         var detail = string.Join(
             "; ",

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/FileSystemSandboxStartupValidator.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/FileSystemSandboxStartupValidator.cs
@@ -33,25 +33,45 @@ namespace Infrastructure.AI.Tools;
 /// This validator is defence in depth alongside it.
 /// </para>
 /// <para>
-/// <b>Why it refuses unconditionally.</b> An earlier version downgraded the refusal to a warning
-/// while both durable-state toggles were off, on the reasoning that the toggles are documented as
-/// restart-required so enabling one would re-run this validator before any database could be
-/// written. That does not hold. <c>EscalationReconciliationService.RunPruneAsync</c> re-reads
-/// <c>AI:Governance:DurableState</c> from <see cref="Microsoft.Extensions.Options.IOptionsMonitor{T}"/>
-/// on every reconcile tick, and <c>AppConfigHelper</c> loads appsettings with
-/// <c>reloadOnChange: true</c>, so an operator who edits <c>ChangeProposalsEnabled</c> to true on a
-/// running host resolves the pruner factory — and with it the schema initializer that creates the
-/// database file — on a host where this validator already warned and moved on. A boot-time
-/// assertion that a live configuration change can invalidate has to hold on every boot.
+/// <b>It consults no configuration of its own.</b> This validator takes the two path collections
+/// as registered and asserts about those, rather than re-reading the durable-state toggles to
+/// decide whether the assertion applies. Whether the governance-state directory is worth guarding
+/// at all is decided once, upstream, by
+/// <c>DependencyInjection.ResolveGovernanceStateProtectedPaths</c> — on the toggles <em>or</em> the
+/// presence of a database left behind by an earlier run. By the time the collections reach this
+/// constructor that question is settled, and a protected path in hand means there is something
+/// real to protect. Re-deriving the condition here would create a second copy of a rule that is
+/// already subtle, and a validator asserting against a slightly different set from the one the tool
+/// enforces is worse than none.
 /// </para>
 /// <para>
-/// <b>It also refuses a platform the hard-link control cannot run on.</b> That control is what
-/// actually closes the bypass, and it fails closed, so on an unimplemented platform — macOS and the
-/// BSDs — every file operation is denied. Without this check the operator meets that as a stream of
-/// per-call refusals whose message cannot name the real cause, since at the point of denial the
-/// service knows only that the count was unavailable. Meeting it once, at boot, with the platform
-/// named and the ways forward spelled out, is the difference between a documented limitation and an
-/// inexplicably broken template.
+/// <b>Why the upstream gate can be trusted to be a boot-time decision.</b> A boot assertion that a
+/// live configuration edit could invalidate would be worthless, and this one nearly was: an earlier
+/// design had <c>EscalationReconciliationService.RunPruneAsync</c> re-read
+/// <c>AI:Governance:DurableState</c> from <see cref="Microsoft.Extensions.Options.IOptionsMonitor{T}"/>
+/// on every reconcile tick while <c>AppConfigHelper</c> loads appsettings with
+/// <c>reloadOnChange: true</c>. An operator editing <c>ChangeProposalsEnabled</c> to true on a
+/// running host would then resolve the pruner factory — and with it the schema initializer that
+/// creates the database file — on a host whose deny list had booted disarmed. That service now
+/// snapshots the enable pair at construction, which is what makes the composition-time decision
+/// hold for the life of the process.
+/// </para>
+/// <para>
+/// <b>It also refuses a platform the hard-link control cannot run on — but only when something is
+/// actually protected.</b> That control is what closes the bypass, and it fails closed, so on an
+/// unimplemented platform (macOS and the BSDs) every file operation is denied <em>while protected
+/// paths are configured</em>. <see cref="FileSystemService"/> skips the inspection outright on an
+/// empty protected set, so this refusal arms on <see cref="HasProtectedPaths"/> and on nothing else
+/// — the two must agree, or the host refuses to boot over a configuration that would have run
+/// perfectly well. In the shipped default, with durable governance state off and no database on
+/// disk, the set is empty and the file-system tool runs on every platform.
+/// </para>
+/// <para>
+/// Where the refusal does arm, meeting it once at boot — with the platform named and the ways
+/// forward spelled out — is the difference between a documented limitation and an inexplicably
+/// broken template. Without it the operator meets a stream of per-call refusals whose message
+/// cannot name the real cause, since at the point of denial the service knows only that the link
+/// count was unavailable.
 /// </para>
 /// </remarks>
 public sealed class FileSystemSandboxStartupValidator : IHostedService
@@ -224,12 +244,19 @@ public sealed class FileSystemSandboxStartupValidator : IHostedService
     /// what it would cost to ignore, and the only two things that actually resolve it.
     /// </summary>
     /// <remarks>
-    /// The message deliberately forecloses the fix an operator would otherwise try first. Turning
-    /// the durable-governance toggles off looks like it should empty the protected list, and it does
-    /// not: <c>RegisterToolServices</c> derives the governance-state directory from
-    /// <c>GovernanceStatePaths.Resolve</c> unconditionally, consulting no toggle, and the configured
-    /// database path defaults to a non-blank value. Sending an operator down that path would cost
-    /// them an hour and end where they started.
+    /// <para>
+    /// The third option carries the detail that makes it usable, because it is the one an operator
+    /// will reach for and the one they can get half right. Protection arms on the toggles
+    /// <em>or</em> on a governance-state directory surviving from an earlier run, so setting the
+    /// toggles to false is only half a fix while that directory is still on disk — and the
+    /// half-fix looks like a full one until the next boot fails identically. The message therefore
+    /// states both conditions and says why the leftover directory is not disposable: it holds the
+    /// approval verdicts that motivated protecting it in the first place.
+    /// </para>
+    /// <para>
+    /// An earlier version of this message foreclosed the toggles outright, which was correct when
+    /// <c>RegisterToolServices</c> registered the directory unconditionally and is now wrong.
+    /// </para>
     /// </remarks>
     private string BuildUnsupportedPlatformMessage()
     {
@@ -244,15 +271,18 @@ public sealed class FileSystemSandboxStartupValidator : IHostedService
             "and statx on Linux, and it fails closed everywhere else. Booting anyway would deny " +
             "every read, write, and search the file-system tool attempts, one call at a time, with " +
             "an error that cannot name this as the cause. " +
-            "Two ways forward: (1) run the harness on Windows or Linux, the supported platforms; " +
+            "Three ways forward: (1) run the harness on Windows or Linux, the supported platforms; " +
             "(2) add a branch for this platform to HardLinkInspector — macOS and the BSDs expose the " +
             "link count only through struct stat, whose field order and widths vary by operating " +
             "system AND processor architecture, so the layout must be verified against the target " +
-            "rather than assumed; a wrong offset reads the wrong bytes and fails open silently. " +
-            "Note what will NOT work: turning the AppConfig:AI:Governance:DurableState toggles off " +
-            "does not remove the protected paths. The governance-state directory is registered as " +
-            "protected unconditionally, whatever those toggles say, so the file-system tool is " +
-            "unusable on this platform until one of the two options above is taken.";
+            "rather than assumed; a wrong offset reads the wrong bytes and fails open silently; " +
+            "(3) run without durable governance state, which leaves nothing to protect and no " +
+            "reason to arm the control. Option (3) has TWO conditions, not one: set both " +
+            "AppConfig:AI:Governance:DurableState:EscalationsEnabled and ChangeProposalsEnabled to " +
+            $"false, AND ensure no governance-state directory remains on disk at '{firstProtected}'. " +
+            "A directory left by an earlier run still holds approval verdicts, so it is protected on " +
+            "its own account whatever the toggles say — archive or relocate it rather than deleting " +
+            "it, unless you are certain those records are no longer needed.";
     }
 
     /// <summary>

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/FileSystemSandboxStartupValidator.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/FileSystemSandboxStartupValidator.cs
@@ -1,0 +1,170 @@
+using Domain.Common.Helpers;
+using Domain.Common.Config;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Infrastructure.AI.Tools;
+
+/// <summary>
+/// One-shot startup validator for the file-system tool's sandbox. Runs via
+/// <see cref="IHostedService.StartAsync"/> and refuses to boot the host when a protected
+/// harness-state directory sits inside a directory the file-system tool is allowed to reach.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Why containment, and not just the deny list.</b> <see cref="FileSystemService"/> denies the
+/// governance-state directory outright, and resolves symlinks, junctions and 8.3 short names before
+/// comparing, so no alias of that kind reaches it. Hard links are the gap. A hard link is a second
+/// directory entry for the same file rather than a reparse point: it carries no link target,
+/// <see cref="FileSystemInfo.ResolveLinkTarget(bool)"/> returns nothing for it, and its canonical
+/// form is itself. A hard link created inside the workspace therefore presents as an ordinary,
+/// unprotected file that happens to read and write the approval-verdict database. Creating one
+/// needs no privilege on Windows (<c>mklink /H</c>) or Linux (<c>ln</c>).
+/// </para>
+/// <para>
+/// <b>What containment buys.</b> A hard link cannot span volumes — it is an entry in the same
+/// filesystem as its target. So if no protected directory lies inside any allowed base path, no
+/// hard link inside an allowed base path can name a protected file, whatever the agent does. That
+/// makes the allowlist the load-bearing control and demotes the deny list to genuine defence in
+/// depth, which is the correct ordering: the allowlist is checked on the target's real identity,
+/// the deny list on its spelling.
+/// </para>
+/// <para>
+/// <b>Why this is gated on durable state being enabled.</b> With both durable-state toggles off no
+/// database is ever created and the protected directory holds nothing, so refusing to boot would
+/// cost a consumer their widened Development allowlist for no security gain. The toggles are
+/// documented as restart-required (see <c>GovernanceDurableStateConfig</c>), so enabling one
+/// re-runs this validator before the database can be written. An overlap found while the toggles
+/// are off is logged as a warning rather than swallowed, because a database left behind by an
+/// earlier enabled run is still sitting there.
+/// </para>
+/// </remarks>
+public sealed class FileSystemSandboxStartupValidator : IHostedService
+{
+    private readonly IReadOnlyList<string> _allowedBasePaths;
+    private readonly IReadOnlyList<string> _protectedPaths;
+    private readonly IOptionsMonitor<AppConfig> _config;
+    private readonly ILogger<FileSystemSandboxStartupValidator> _logger;
+
+    /// <summary>
+    /// Initializes a new <see cref="FileSystemSandboxStartupValidator"/>.
+    /// </summary>
+    /// <remarks>
+    /// The two path collections are passed in rather than re-derived from configuration so that
+    /// this validator asserts against the exact values handed to <see cref="FileSystemService"/>.
+    /// Re-deriving them would create a second copy of the resolution rules, and a validator that
+    /// checks a slightly different set of paths from the one actually enforced is worse than none.
+    /// </remarks>
+    /// <param name="allowedBasePaths">The base paths the file-system tool may reach, as registered.</param>
+    /// <param name="protectedPaths">The harness-state directories denied to the tool, as registered.</param>
+    /// <param name="config">Configuration monitor, read for the durable-state toggles.</param>
+    /// <param name="logger">Logger for the validation outcome.</param>
+    public FileSystemSandboxStartupValidator(
+        IReadOnlyList<string> allowedBasePaths,
+        IReadOnlyList<string> protectedPaths,
+        IOptionsMonitor<AppConfig> config,
+        ILogger<FileSystemSandboxStartupValidator> logger)
+    {
+        ArgumentNullException.ThrowIfNull(allowedBasePaths);
+        ArgumentNullException.ThrowIfNull(protectedPaths);
+        ArgumentNullException.ThrowIfNull(config);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _allowedBasePaths = allowedBasePaths;
+        _protectedPaths = protectedPaths;
+        _logger = logger;
+        _config = config;
+    }
+
+    /// <inheritdoc />
+    /// <exception cref="InvalidOperationException">
+    /// A protected harness-state directory lies inside an allowed base path while durable
+    /// governance state is enabled.
+    /// </exception>
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        var overlaps = FindOverlaps();
+        if (overlaps.Count == 0)
+            return Task.CompletedTask;
+
+        var durableState = _config.CurrentValue.AI.Governance.DurableState;
+        if (!durableState.EscalationsEnabled && !durableState.ChangeProposalsEnabled)
+        {
+            _logger.LogWarning(
+                "Protected harness-state directory {ProtectedPath} lies inside the file-system tool's " +
+                "allowed base path {AllowedBasePath}. Durable governance state is currently disabled, so " +
+                "the host is allowed to start, but enabling AppConfig:AI:Governance:DurableState will " +
+                "refuse to boot until the allowlist is narrowed.",
+                overlaps[0].ProtectedPath,
+                overlaps[0].AllowedBasePath);
+
+            return Task.CompletedTask;
+        }
+
+        throw new InvalidOperationException(BuildFailureMessage(overlaps));
+    }
+
+    /// <inheritdoc />
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    /// <summary>
+    /// One protected directory found inside one allowed base path.
+    /// </summary>
+    /// <param name="ProtectedPath">The canonical protected directory.</param>
+    /// <param name="AllowedBasePath">The canonical allowed base path containing it.</param>
+    private readonly record struct SandboxOverlap(string ProtectedPath, string AllowedBasePath);
+
+    /// <summary>
+    /// Returns every (protected path, allowed base path) pair where the former is the same as, or
+    /// nested under, the latter.
+    /// </summary>
+    /// <remarks>
+    /// Both sides are canonicalized first, using the same resolver <see cref="FileSystemService"/>
+    /// applies at runtime, so an overlap reached through a symlinked or 8.3-aliased parent is
+    /// still detected. Only this direction is checked: a protected directory <em>containing</em>
+    /// an allowed base path is incoherent but not exploitable, since the deny list wins over the
+    /// allowlist and every path under it is refused anyway.
+    /// </remarks>
+    private List<SandboxOverlap> FindOverlaps()
+    {
+        var canonicalBases = _allowedBasePaths
+            .Where(p => !string.IsNullOrWhiteSpace(p))
+            .Select(p => SandboxPathCanonicalizer.Canonicalize(PathScope.Normalize(p)))
+            .ToList();
+
+        return (from protectedPath in _protectedPaths
+                where !string.IsNullOrWhiteSpace(protectedPath)
+                let canonicalProtected =
+                    SandboxPathCanonicalizer.Canonicalize(PathScope.Normalize(protectedPath))
+                from basePath in canonicalBases
+                where PathScope.IsSameOrUnderNormalized(canonicalProtected, basePath)
+                select new SandboxOverlap(canonicalProtected, basePath))
+            .ToList();
+    }
+
+    /// <summary>
+    /// Builds the boot-failure message: what is wrong, why it matters, and which setting to change.
+    /// </summary>
+    /// <param name="overlaps">The overlaps found; never empty.</param>
+    private static string BuildFailureMessage(IReadOnlyList<SandboxOverlap> overlaps)
+    {
+        var detail = string.Join(
+            "; ",
+            overlaps.Select(o => $"'{o.ProtectedPath}' inside allowed base path '{o.AllowedBasePath}'"));
+
+        return
+            $"Durable governance state is enabled, but {overlaps.Count} protected harness-state " +
+            $"director{(overlaps.Count == 1 ? "y lies" : "ies lie")} inside a directory the file-system " +
+            $"tool is allowed to reach: {detail}. That directory holds the SQLite database of approval " +
+            "verdicts. The deny list alone cannot protect it there: an agent can create a hard link to " +
+            "the database inside the allowed tree, and a hard link is not a reparse point, so it " +
+            "resolves to itself and reads as an ordinary unprotected file — through which the database " +
+            "can be read and rewritten to forge an approval verdict. " +
+            "Fix: narrow AppConfig:Infrastructure:FileSystem:AllowedBasePaths so it no longer contains " +
+            "the protected directory (the shipped default, 'workspace', already satisfies this). " +
+            "Moving AppConfig:AI:Governance:DurableState:DatabasePath is not an alternative on its own: " +
+            "that path is required to resolve under the application base directory, so an allowlist " +
+            "that covers the application base directory will always contain it.";
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/FileSystemSandboxStartupValidator.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/FileSystemSandboxStartupValidator.cs
@@ -1,8 +1,6 @@
 using Domain.Common.Helpers;
-using Domain.Common.Config;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 
 namespace Infrastructure.AI.Tools;
 
@@ -13,38 +11,43 @@ namespace Infrastructure.AI.Tools;
 /// </summary>
 /// <remarks>
 /// <para>
-/// <b>Why containment, and not just the deny list.</b> <see cref="FileSystemService"/> denies the
-/// governance-state directory outright, and resolves symlinks, junctions and 8.3 short names before
-/// comparing, so no alias of that kind reaches it. Hard links are the gap. A hard link is a second
-/// directory entry for the same file rather than a reparse point: it carries no link target,
-/// <see cref="FileSystemInfo.ResolveLinkTarget(bool)"/> returns nothing for it, and its canonical
-/// form is itself. A hard link created inside the workspace therefore presents as an ordinary,
-/// unprotected file that happens to read and write the approval-verdict database. Creating one
-/// needs no privilege on Windows (<c>mklink /H</c>) or Linux (<c>ln</c>).
+/// <b>What this is, and what it is not.</b> Granting the file-system tool a directory that
+/// contains the harness's own governance-state database is a misconfiguration on its face: it
+/// leaves the deny list as the only thing standing between an agent and the approval-verdict
+/// store, with every alias trick (8.3 short names, symlinks, junctioned parents) aimed straight at
+/// it. Refusing to boot on that geometry is worth doing and this validator does it.
 /// </para>
 /// <para>
-/// <b>What containment buys.</b> A hard link cannot span volumes — it is an entry in the same
-/// filesystem as its target. So if no protected directory lies inside any allowed base path, no
-/// hard link inside an allowed base path can name a protected file, whatever the agent does. That
-/// makes the allowlist the load-bearing control and demotes the deny list to genuine defence in
-/// depth, which is the correct ordering: the allowlist is checked on the target's real identity,
-/// the deny list on its spelling.
+/// <b>It is not the hard-link control, and an earlier version of this file wrongly claimed to be.</b>
+/// The claim was that a hard link cannot span volumes, so a protected directory outside every
+/// allowed base path cannot be hard-linked into one. The premise is true and the conclusion does
+/// not follow: a hard link requires the same VOLUME as its target, not the same SUBTREE.
+/// Non-containment is strictly narrower than volume separation, so eliminating containment
+/// eliminates nothing — and the shipped default, <c>workspace</c> and <c>.agent-state</c> as
+/// siblings under the application base directory, is same-volume by construction. Volume
+/// separation is not reachable by configuration either, because <c>GovernanceStatePaths.Resolve</c>
+/// pins the database under the application base directory. The control that actually closes the
+/// hard-link hole is <see cref="FileSystemService"/>'s per-operation identity check, which asks the
+/// operating system how many directory entries name the file rather than what the path spells.
+/// This validator is defence in depth alongside it.
 /// </para>
 /// <para>
-/// <b>Why this is gated on durable state being enabled.</b> With both durable-state toggles off no
-/// database is ever created and the protected directory holds nothing, so refusing to boot would
-/// cost a consumer their widened Development allowlist for no security gain. The toggles are
-/// documented as restart-required (see <c>GovernanceDurableStateConfig</c>), so enabling one
-/// re-runs this validator before the database can be written. An overlap found while the toggles
-/// are off is logged as a warning rather than swallowed, because a database left behind by an
-/// earlier enabled run is still sitting there.
+/// <b>Why it refuses unconditionally.</b> An earlier version downgraded the refusal to a warning
+/// while both durable-state toggles were off, on the reasoning that the toggles are documented as
+/// restart-required so enabling one would re-run this validator before any database could be
+/// written. That does not hold. <c>EscalationReconciliationService.RunPruneAsync</c> re-reads
+/// <c>AI:Governance:DurableState</c> from <see cref="Microsoft.Extensions.Options.IOptionsMonitor{T}"/>
+/// on every reconcile tick, and <c>AppConfigHelper</c> loads appsettings with
+/// <c>reloadOnChange: true</c>, so an operator who edits <c>ChangeProposalsEnabled</c> to true on a
+/// running host resolves the pruner factory — and with it the schema initializer that creates the
+/// database file — on a host where this validator already warned and moved on. A boot-time
+/// assertion that a live configuration change can invalidate has to hold on every boot.
 /// </para>
 /// </remarks>
 public sealed class FileSystemSandboxStartupValidator : IHostedService
 {
     private readonly IReadOnlyList<string> _allowedBasePaths;
     private readonly IReadOnlyList<string> _protectedPaths;
-    private readonly IOptionsMonitor<AppConfig> _config;
     private readonly ILogger<FileSystemSandboxStartupValidator> _logger;
 
     /// <summary>
@@ -58,29 +61,24 @@ public sealed class FileSystemSandboxStartupValidator : IHostedService
     /// </remarks>
     /// <param name="allowedBasePaths">The base paths the file-system tool may reach, as registered.</param>
     /// <param name="protectedPaths">The harness-state directories denied to the tool, as registered.</param>
-    /// <param name="config">Configuration monitor, read for the durable-state toggles.</param>
     /// <param name="logger">Logger for the validation outcome.</param>
     public FileSystemSandboxStartupValidator(
         IReadOnlyList<string> allowedBasePaths,
         IReadOnlyList<string> protectedPaths,
-        IOptionsMonitor<AppConfig> config,
         ILogger<FileSystemSandboxStartupValidator> logger)
     {
         ArgumentNullException.ThrowIfNull(allowedBasePaths);
         ArgumentNullException.ThrowIfNull(protectedPaths);
-        ArgumentNullException.ThrowIfNull(config);
         ArgumentNullException.ThrowIfNull(logger);
 
         _allowedBasePaths = allowedBasePaths;
         _protectedPaths = protectedPaths;
         _logger = logger;
-        _config = config;
     }
 
     /// <inheritdoc />
     /// <exception cref="InvalidOperationException">
-    /// A protected harness-state directory lies inside an allowed base path while durable
-    /// governance state is enabled.
+    /// A protected harness-state directory lies inside an allowed base path.
     /// </exception>
     public Task StartAsync(CancellationToken cancellationToken)
     {
@@ -88,19 +86,14 @@ public sealed class FileSystemSandboxStartupValidator : IHostedService
         if (overlaps.Count == 0)
             return Task.CompletedTask;
 
-        var durableState = _config.CurrentValue.AI.Governance.DurableState;
-        if (!durableState.EscalationsEnabled && !durableState.ChangeProposalsEnabled)
-        {
-            _logger.LogWarning(
-                "Protected harness-state directory {ProtectedPath} lies inside the file-system tool's " +
-                "allowed base path {AllowedBasePath}. Durable governance state is currently disabled, so " +
-                "the host is allowed to start, but enabling AppConfig:AI:Governance:DurableState will " +
-                "refuse to boot until the allowlist is narrowed.",
-                overlaps[0].ProtectedPath,
-                overlaps[0].AllowedBasePath);
-
-            return Task.CompletedTask;
-        }
+        // Logged structurally as well as thrown: the exception message is one string for a human,
+        // while these fields are what a log query can actually group and alert on.
+        _logger.LogError(
+            "Refusing to start: protected harness-state directory {ProtectedPath} lies inside the " +
+            "file-system tool's allowed base path {AllowedBasePath} ({OverlapCount} overlap(s) total).",
+            overlaps[0].ProtectedPath,
+            overlaps[0].AllowedBasePath,
+            overlaps.Count);
 
         throw new InvalidOperationException(BuildFailureMessage(overlaps));
     }
@@ -154,13 +147,13 @@ public sealed class FileSystemSandboxStartupValidator : IHostedService
             overlaps.Select(o => $"'{o.ProtectedPath}' inside allowed base path '{o.AllowedBasePath}'"));
 
         return
-            $"Durable governance state is enabled, but {overlaps.Count} protected harness-state " +
+            $"{overlaps.Count} protected harness-state " +
             $"director{(overlaps.Count == 1 ? "y lies" : "ies lie")} inside a directory the file-system " +
             $"tool is allowed to reach: {detail}. That directory holds the SQLite database of approval " +
-            "verdicts. The deny list alone cannot protect it there: an agent can create a hard link to " +
-            "the database inside the allowed tree, and a hard link is not a reparse point, so it " +
-            "resolves to itself and reads as an ordinary unprotected file — through which the database " +
-            "can be read and rewritten to forge an approval verdict. " +
+            "verdicts and change proposals. Reaching it lets an agent mine the approval payloads it " +
+            "carries, and truncate or corrupt the harness's own governance state; forging a verdict is " +
+            "separately blocked by the HMAC seal on every row. Granting the tool that directory leaves " +
+            "the deny list as the only barrier, and a deny list compares paths. " +
             "Fix: narrow AppConfig:Infrastructure:FileSystem:AllowedBasePaths so it no longer contains " +
             "the protected directory (the shipped default, 'workspace', already satisfies this). " +
             "Moving AppConfig:AI:Governance:DurableState:DatabasePath is not an alternative on its own: " +

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/FileSystemService.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/FileSystemService.cs
@@ -25,21 +25,24 @@ public sealed class FileSystemService : IFileSystemService
 
     // Harness-owned state directories the tool may never read or write, regardless of the
     // configured allowlist. Holds the governance-state database — pending escalations, their
-    // resolved verdicts, and change proposals. An agent that could read that file could mine
-    // approval payloads; one that could edit it could forge a human approval, which the
-    // reconciler would then re-drive into the hash-chained compliance audit log.
+    // resolved verdicts, and change proposals. An agent that could read that file could mine the
+    // approval payloads it carries; one that could write it could truncate or corrupt the
+    // harness's own governance state. It could NOT forge an approval verdict: every outcome is
+    // HMAC-sealed by AttestationGovernanceRecordSealer with a key the agent has no access to, the
+    // seal is bound to the row id, and both read paths in EfCoreEscalationStateStore verify it and
+    // quarantine on failure. So the exposure this list closes is disclosure and tamper/denial of
+    // service, not forgery.
     //
     // Compared as CANONICAL ABSOLUTE PATHS, never as directory names: name matching is
     // defeated by a Windows 8.3 short alias (AGENT-~1) or any other alias that resolves to the
     // same directory but spells it differently. The canonical form comes from the same
     // resolver the database registration uses, so the two cannot drift.
     //
-    // This deny list is defence in depth, not the load-bearing control. It cannot see through a
-    // hard link: a hard link is a second directory entry for the same file, not a reparse point,
-    // so there is no link target to resolve and its canonical form is itself. The control that
-    // actually closes that hole is FileSystemSandboxStartupValidator, which refuses to boot when
-    // a protected directory sits inside an allowed base path — a hard link cannot span volumes,
-    // so a protected file outside every allowed base path cannot be aliased into one.
+    // This deny list cannot see through a hard link, and nothing path-based can: a hard link is a
+    // second directory entry for the same file, not a reparse point, so there is no link target to
+    // resolve and its canonical form is itself. That gap is closed by asking about the file's
+    // identity instead of its path — see IsSingleLinked — because a hard link needs only the same
+    // VOLUME as its target, which no allowlist geometry can prevent.
     private readonly HashSet<string> _protectedPaths;
 
     // Directories skipped during recursive search — build artifacts and VCS internals
@@ -325,6 +328,17 @@ public sealed class FileSystemService : IFileSystemService
             return;
         }
 
+        // The same identity gate the direct read applies, for the same reason: search returns file
+        // CONTENT, so leaving it out would close reads of a hard-linked database while leaving the
+        // disclosure path — grep the workspace for a needle, read it out of the alias — wide open.
+        // On cost: this is one extra handle open per file actually scanned (bounded by
+        // MaxFilesScanned), paid only on hosts with protected paths, against a method that already
+        // opens and reads every one of those files line by line. It is not the per-file link
+        // RESOLUTION the directory-verdict memo exists to avoid — that walks parent components and
+        // is paid per enumerated entry; this is a single stat-and-open on files already being read.
+        if (!IsSingleLinked(filePath))
+            return;
+
         try
         {
             var lineNumber = 0;
@@ -377,10 +391,67 @@ public sealed class FileSystemService : IFileSystemService
             throw new UnauthorizedAccessException("Path is outside the allowed sandbox.");
         }
 
+        // Identity, after path. Everything above reasons about what the path spells; this asks the
+        // operating system what file it actually names. Only the second question sees a hard link.
+        if (!IsSingleLinked(fullPath))
+            throw new UnauthorizedAccessException(HardLinkDenialMessage);
+
         if (write)
             ValidateWriteTarget(fullPath);
 
         return fullPath;
+    }
+
+    /// <summary>
+    /// The refusal handed to a caller whose path names a file the sandbox cannot prove is unique.
+    /// </summary>
+    private const string HardLinkDenialMessage =
+        "Path names a file the sandbox cannot prove has a single directory entry, so it cannot " +
+        "rule out that the file is a hard link aliasing protected harness state.";
+
+    /// <summary>
+    /// True when <paramref name="fullPath"/> names a file with exactly one directory entry — the
+    /// only case in which a path-based sandbox decision about it is trustworthy.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>Why a path check is not enough.</b> A hard link is a second directory entry for one file,
+    /// carrying no reparse point, so it resolves to itself and reads to every check above as an
+    /// ordinary workspace file. The startup validator keeps protected directories out of the
+    /// allowed tree, which is worth doing, but it is not what closes this: a hard link requires the
+    /// same VOLUME as its target, not the same subtree, and the shipped default puts
+    /// <c>workspace</c> and <c>.agent-state</c> side by side on one volume. Non-containment is
+    /// strictly narrower than volume separation, and volume separation is unreachable anyway
+    /// because <c>GovernanceStatePaths.Resolve</c> pins the database under the application base
+    /// directory.
+    /// </para>
+    /// <para>
+    /// <b>Fail closed.</b> <see cref="HardLinkInspector.LinkCount.Unknown"/> — an unimplemented
+    /// platform (anything but Windows and Linux), a failed platform call, or an untrustworthy
+    /// count — denies. A consumer running on such a platform with protected paths configured gets
+    /// a closed file tool rather than a silently unguarded one.
+    /// </para>
+    /// <para>
+    /// <b>Scoped to hosts that have something to protect.</b> With no protected paths configured
+    /// there is nothing a hard link could alias, so the inspection is skipped outright and callers
+    /// with no harness state pay nothing — neither the handle open nor the platform restriction.
+    /// </para>
+    /// </remarks>
+    /// <param name="fullPath">An absolute path. Need not exist; a file yet to be created passes.</param>
+    private bool IsSingleLinked(string fullPath)
+    {
+        if (_protectedPaths.Count == 0)
+            return true;
+
+        var linkCount = HardLinkInspector.Inspect(fullPath);
+        if (linkCount == HardLinkInspector.LinkCount.Single)
+            return true;
+
+        _logger.LogWarning(
+            "Blocked access to a path the sandbox cannot prove is singly-linked: {Path} ({LinkCount})",
+            fullPath,
+            linkCount);
+        return false;
     }
 
     private string ResolveRelative(string path)
@@ -448,8 +519,9 @@ public sealed class FileSystemService : IFileSystemService
         // Deny list wins over the allowlist. Protected directories hold the harness's own
         // governance state — the SQLite database of approval verdicts — and typically sit
         // under a configured base path, so allowlisting alone would leave them reachable.
-        // An agent able to edit that file could forge an approval verdict, so the tool must
-        // not be able to read or write it under any configuration.
+        // An agent able to read that file could mine approval payloads, and one able to write it
+        // could truncate or corrupt the harness's own state; the HMAC seal on every row is what
+        // stops it forging a verdict. The tool must not reach it under any configuration.
         if (verdict.IsProtected)
         {
             _logger.LogWarning(

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/FileSystemService.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/FileSystemService.cs
@@ -78,19 +78,19 @@ public sealed class FileSystemService : IFileSystemService
         _allowedBasePaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         _protectedPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
+        // Both sets are stored in PathScope-normalized form (absolute, trailing separator trimmed)
+        // because every comparison against them goes through PathScope.IsSameOrUnderNormalized,
+        // which requires normalized inputs on both sides.
         foreach (var path in protectedPaths ?? [])
         {
             if (!string.IsNullOrWhiteSpace(path))
-                _protectedPaths.Add(CanonicalizePath(path));
+                _protectedPaths.Add(CanonicalizePath(PathScope.Normalize(path)));
         }
 
         foreach (var path in allowedBasePaths)
         {
             if (!string.IsNullOrWhiteSpace(path))
-            {
-                var fullPath = Path.GetFullPath(path);
-                _allowedBasePaths.Add(fullPath);
-            }
+                _allowedBasePaths.Add(PathScope.Normalize(path));
         }
 
         if (_allowedBasePaths.Count == 0)
@@ -176,7 +176,11 @@ public sealed class FileSystemService : IFileSystemService
         var searchPattern = string.IsNullOrEmpty(pattern) ? "*.*" : pattern;
         var filesScanned = 0;
 
-        foreach (var file in EnumerateFilesSkippingIgnored(fullPath, searchPattern, cancellationToken))
+        // Lives only for this call — see IsProtectedPath for why it must not become process-wide.
+        var directoryVerdicts = new Dictionary<string, bool>(PathScope.Comparer);
+
+        foreach (var file in EnumerateFilesSkippingIgnored(
+            fullPath, searchPattern, directoryVerdicts, cancellationToken))
         {
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -189,7 +193,7 @@ public sealed class FileSystemService : IFileSystemService
             if (results.Count >= MaxSearchResults)
                 break;
 
-            await SearchFileAsync(file, fullPath, searchTerm, results, cancellationToken);
+            await SearchFileAsync(file, fullPath, searchTerm, results, directoryVerdicts, cancellationToken);
         }
 
         _logger.LogDebug("Search complete: {ResultCount} results from {ScannedCount} files scanned", results.Count, filesScanned);
@@ -215,10 +219,12 @@ public sealed class FileSystemService : IFileSystemService
     }
 
     private IEnumerable<string> EnumerateFilesSkippingIgnored(
-        string root, string pattern, CancellationToken cancellationToken)
+        string root, string pattern, Dictionary<string, bool> directoryVerdicts,
+        CancellationToken cancellationToken)
     {
         var queue = new Queue<string>();
         queue.Enqueue(root);
+        directoryVerdicts[PathScope.Normalize(root)] = IsProtectedPath(root);
 
         while (queue.Count > 0)
         {
@@ -245,7 +251,13 @@ public sealed class FileSystemService : IFileSystemService
                 // list is a performance filter (build artifacts, VCS internals), not a security
                 // boundary. Without this a search rooted at the workspace would descend into the
                 // governance-state directory and read the database's pages as text.
-                if (!SearchSkipDirectories.Contains(Path.GetFileName(sub)) && !IsProtectedPath(sub))
+                if (SearchSkipDirectories.Contains(Path.GetFileName(sub)))
+                    continue;
+
+                var isProtected = IsProtectedPath(sub);
+                directoryVerdicts[PathScope.Normalize(sub)] = isProtected;
+
+                if (!isProtected)
                     queue.Enqueue(sub);
             }
         }
@@ -253,13 +265,14 @@ public sealed class FileSystemService : IFileSystemService
 
     private async Task SearchFileAsync(
         string filePath, string basePath, string searchTerm,
-        List<FileSearchResult> results, CancellationToken cancellationToken)
+        List<FileSearchResult> results, Dictionary<string, bool> directoryVerdicts,
+        CancellationToken cancellationToken)
     {
         // Last line of defence before any file content is read. The directory filter above
         // already prunes protected subtrees; this catches a protected file reached any other
         // way (a file directly under an allowed root, a future enumeration change) so no
         // content leaves this method without having passed the same gate a direct read does.
-        if (!IsPathAllowed(filePath))
+        if (!IsPathAllowed(filePath, directoryVerdicts))
         {
             _logger.LogWarning("Skipped search of disallowed path: {Path}", filePath);
             return;
@@ -360,33 +373,28 @@ public sealed class FileSystemService : IFileSystemService
         return path;
     }
 
-    private bool IsPathAllowed(string fullPath)
+    /// <param name="fullPath">An absolute path.</param>
+    /// <param name="directoryVerdicts">
+    /// Optional per-operation protected-path memo; see <see cref="IsProtectedPath"/>.
+    /// </param>
+    private bool IsPathAllowed(string fullPath, Dictionary<string, bool>? directoryVerdicts = null)
     {
-        var normalized = Path.GetFullPath(fullPath);
+        var normalized = PathScope.Normalize(fullPath);
 
         // Deny list wins over the allowlist. Protected directories hold the harness's own
         // governance state — the SQLite database of approval verdicts — and typically sit
         // under a configured base path, so allowlisting alone would leave them reachable.
         // An agent able to edit that file could forge an approval verdict, so the tool must
         // not be able to read or write it under any configuration.
-        if (IsProtectedPath(normalized))
+        if (IsProtectedPath(normalized, directoryVerdicts))
         {
             _logger.LogWarning("Blocked access to protected harness state directory: {Path}", normalized);
             return false;
         }
 
-        foreach (var basePath in _allowedBasePaths)
-        {
-            // Match on directory boundary, not just string prefix
-            var baseWithSep = basePath.EndsWith(Path.DirectorySeparatorChar)
-                ? basePath
-                : basePath + Path.DirectorySeparatorChar;
-
-            if (normalized.StartsWith(baseWithSep, StringComparison.OrdinalIgnoreCase)
-                || normalized.Equals(basePath, StringComparison.OrdinalIgnoreCase))
-                return true;
-        }
-        return false;
+        // PathScope matches on a directory boundary, so a sibling whose name merely starts with an
+        // allowed root (C:\workspace-backup against C:\workspace) is not mistaken for a child.
+        return _allowedBasePaths.Any(basePath => PathScope.IsSameOrUnderNormalized(normalized, basePath));
     }
 
     /// <summary>
@@ -400,24 +408,69 @@ public sealed class FileSystemService : IFileSystemService
     /// resolved upstream) still matches.
     /// </remarks>
     /// <param name="fullPath">An absolute path.</param>
-    private bool IsProtectedPath(string fullPath)
+    /// <param name="directoryVerdicts">
+    /// <para>
+    /// Optional memo of directory path to verdict, scoped to a <em>single</em> search operation and
+    /// threaded through the walk by <see cref="EnumerateFilesSkippingIgnored"/>. Canonicalizing a path
+    /// costs a stat plus a link-resolution handle open; without the memo a recursive search pays that
+    /// for every file it scans rather than for every directory it descends into.
+    /// </para>
+    /// <para>
+    /// The scope is deliberately per-operation and must NOT be promoted to a process-lifetime cache.
+    /// An agent can create a benign file, let its verdict be recorded, then replace it with a symlink
+    /// into the protected directory; a cache that outlives the operation would serve the stale
+    /// "allowed" verdict and hand over the approval-verdict database. Per-operation scope bounds that
+    /// staleness window to the same window the directory prune already has.
+    /// </para>
+    /// </param>
+    private bool IsProtectedPath(string fullPath, Dictionary<string, bool>? directoryVerdicts = null)
     {
         if (_protectedPaths.Count == 0)
             return false;
 
-        var normalized = CanonicalizePath(fullPath);
-        foreach (var protectedPath in _protectedPaths)
-        {
-            var withSeparator = protectedPath.EndsWith(Path.DirectorySeparatorChar)
-                ? protectedPath
-                : protectedPath + Path.DirectorySeparatorChar;
+        if (directoryVerdicts is not null && TryInheritParentVerdict(fullPath, directoryVerdicts, out var inherited))
+            return inherited;
 
-            if (normalized.Equals(protectedPath, StringComparison.OrdinalIgnoreCase)
-                || normalized.StartsWith(withSeparator, StringComparison.OrdinalIgnoreCase))
-                return true;
+        var normalized = CanonicalizePath(fullPath);
+        return _protectedPaths.Any(protectedPath =>
+            PathScope.IsSameOrUnderNormalized(normalized, protectedPath));
+    }
+
+    /// <summary>
+    /// Resolves <paramref name="fullPath"/>'s verdict from its already-canonicalized parent directory
+    /// when that is sound, avoiding a link resolution per file.
+    /// </summary>
+    /// <remarks>
+    /// A recorded parent verdict of <see langword="true"/> transfers unconditionally — everything under
+    /// a protected directory is protected. A verdict of <see langword="false"/> transfers only when the
+    /// entry is not itself a reparse point, because a symlink sitting in an unprotected directory can
+    /// still resolve into the protected one; those fall through to full canonicalization. Reading the
+    /// attribute costs a stat but no handle open, which is the syscall being avoided.
+    /// </remarks>
+    private static bool TryInheritParentVerdict(
+        string fullPath, Dictionary<string, bool> directoryVerdicts, out bool verdict)
+    {
+        verdict = false;
+
+        var parent = Path.GetDirectoryName(fullPath);
+        if (parent is null || !directoryVerdicts.TryGetValue(PathScope.Normalize(parent), out var parentVerdict))
+            return false;
+
+        if (parentVerdict)
+        {
+            verdict = true;
+            return true;
         }
 
-        return false;
+        try
+        {
+            return !File.GetAttributes(fullPath).HasFlag(FileAttributes.ReparsePoint);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or ArgumentException)
+        {
+            // Unreadable or already gone: fall through to the full check rather than guess.
+            return false;
+        }
     }
 
     /// <summary>
@@ -439,20 +492,27 @@ public sealed class FileSystemService : IFileSystemService
     /// path then names a genuinely different directory rather than aliasing the protected one.
     /// </para>
     /// </remarks>
-    /// <param name="path">The path to canonicalize.</param>
+    /// <param name="path">
+    /// The path to canonicalize. Must already be <see cref="PathScope.Normalize"/>d — every caller
+    /// normalizes before calling, so re-running <see cref="Path.GetFullPath(string)"/> here would
+    /// repeat work already done on a per-file security check.
+    /// </param>
     private static string CanonicalizePath(string path)
     {
-        var full = Path.GetFullPath(path);
         try
         {
-            // ResolveLinkTarget(returnFinalTarget) canonicalizes an existing entry; for a path
-            // that does not exist yet the normalized form is the best available answer.
-            var info = Directory.Exists(full) ? new DirectoryInfo(full) : (FileSystemInfo)new FileInfo(full);
-            return info.Exists ? Path.GetFullPath(info.ResolveLinkTarget(true)?.FullName ?? info.FullName) : full;
+            // One stat answers both "does it exist" and "is it a directory"; a missing entry throws
+            // and is caught below. ResolveLinkTarget(returnFinalTarget) then canonicalizes the entry —
+            // for a path that does not exist yet the normalized form is the best available answer.
+            var info = File.GetAttributes(path).HasFlag(FileAttributes.Directory)
+                ? new DirectoryInfo(path)
+                : (FileSystemInfo)new FileInfo(path);
+
+            return PathScope.Normalize(info.ResolveLinkTarget(true)?.FullName ?? info.FullName);
         }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or ArgumentException)
         {
-            return full;
+            return path;
         }
     }
 

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/FileSystemService.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/FileSystemService.cs
@@ -43,6 +43,12 @@ public sealed class FileSystemService : IFileSystemService
     // resolve and its canonical form is itself. That gap is closed by asking about the file's
     // identity instead of its path — see IsSingleLinked — because a hard link needs only the same
     // VOLUME as its target, which no allowlist geometry can prevent.
+    //
+    // Legitimately EMPTY on a host with no governance state to guard. The composition root
+    // (DependencyInjection.ResolveGovernanceStateProtectedPaths) supplies the governance-state
+    // directory only when a durable-state toggle is on or a database from an earlier run is still
+    // on disk; in the shipped default neither holds. An empty set disarms both this deny list and
+    // the identity check below, which is the correct outcome when there is nothing to alias.
     private readonly HashSet<string> _protectedPaths;
 
     // Directories skipped during recursive search — build artifacts and VCS internals
@@ -435,6 +441,9 @@ public sealed class FileSystemService : IFileSystemService
     /// <b>Scoped to hosts that have something to protect.</b> With no protected paths configured
     /// there is nothing a hard link could alias, so the inspection is skipped outright and callers
     /// with no harness state pay nothing — neither the handle open nor the platform restriction.
+    /// This is the shipped default rather than an edge case: the composition root withholds the
+    /// governance-state directory until a durable-state toggle is on or a database from an earlier
+    /// run exists, so an out-of-the-box host runs this tool on every platform, macOS included.
     /// </para>
     /// </remarks>
     /// <param name="fullPath">An absolute path. Need not exist; a file yet to be created passes.</param>

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/FileSystemService.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/FileSystemService.cs
@@ -421,10 +421,24 @@ public sealed class FileSystemService : IFileSystemService
     }
 
     /// <summary>
-    /// Resolves a path to its canonical absolute form, expanding OS-level aliases that
-    /// <see cref="Path.GetFullPath(string)"/> leaves intact — notably Windows 8.3 short names,
-    /// which would otherwise let <c>AGENT-~1</c> sidestep a comparison against the long name.
+    /// Resolves a path to its canonical absolute form, so an alias cannot sidestep a comparison
+    /// against the long name.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The two steps cover different aliases. <see cref="Path.GetFullPath(string)"/> is what
+    /// handles Windows 8.3 short names: on Windows its normalization expands any component that
+    /// exists on disk, turning <c>PROGRA~1</c> into <c>Program Files</c>. The
+    /// <see cref="FileSystemInfo.ResolveLinkTarget(bool)"/> step then covers symlinks and
+    /// junctions, which <c>GetFullPath</c> does leave intact.
+    /// </para>
+    /// <para>
+    /// A component that does not exist is left exactly as written, because there is nothing on
+    /// disk to expand it against. That is harmless for the protected-path check: a protected
+    /// directory that does not exist holds nothing to protect, and a literal <c>AGENT-~1</c>
+    /// path then names a genuinely different directory rather than aliasing the protected one.
+    /// </para>
+    /// </remarks>
     /// <param name="path">The path to canonicalize.</param>
     private static string CanonicalizePath(string path)
     {

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/FileSystemService.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/FileSystemService.cs
@@ -23,6 +23,18 @@ public sealed class FileSystemService : IFileSystemService
 
     private static readonly HashSet<string> SystemDirectoryBlocklist = BuildSystemBlocklist();
 
+    // Harness-owned state directories the tool may never read or write, regardless of the
+    // configured allowlist. Holds the governance-state database — pending escalations, their
+    // resolved verdicts, and change proposals. An agent that could read that file could mine
+    // approval payloads; one that could edit it could forge a human approval, which the
+    // reconciler would then re-drive into the hash-chained compliance audit log.
+    //
+    // Compared as CANONICAL ABSOLUTE PATHS, never as directory names: name matching is
+    // defeated by a Windows 8.3 short alias (AGENT-~1) or any other alias that resolves to the
+    // same directory but spells it differently. The canonical form comes from the same
+    // resolver the database registration uses, so the two cannot drift.
+    private readonly HashSet<string> _protectedPaths;
+
     // Directories skipped during recursive search — build artifacts and VCS internals
     // would exhaust the scan limit before reaching actual source files.
     private static readonly HashSet<string> SearchSkipDirectories = new(StringComparer.OrdinalIgnoreCase)
@@ -48,15 +60,29 @@ public sealed class FileSystemService : IFileSystemService
     /// Paths are normalized and compared case-insensitively. The caller must
     /// explicitly include the working directory if development access is desired.
     /// </param>
+    /// <param name="protectedPaths">
+    /// Absolute directory paths that are denied even when they fall inside
+    /// <paramref name="allowedBasePaths"/> — the harness's own governance-state directory.
+    /// The deny check wins over the allowlist and applies to reads, writes, and the recursive
+    /// search walk alike. Optional; omit for callers with no protected state.
+    /// </param>
     public FileSystemService(
         ILogger<FileSystemService> logger,
-        IEnumerable<string> allowedBasePaths)
+        IEnumerable<string> allowedBasePaths,
+        IEnumerable<string>? protectedPaths = null)
     {
         ArgumentNullException.ThrowIfNull(logger);
         ArgumentNullException.ThrowIfNull(allowedBasePaths);
 
         _logger = logger;
         _allowedBasePaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        _protectedPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var path in protectedPaths ?? [])
+        {
+            if (!string.IsNullOrWhiteSpace(path))
+                _protectedPaths.Add(CanonicalizePath(path));
+        }
 
         foreach (var path in allowedBasePaths)
         {
@@ -188,7 +214,7 @@ public sealed class FileSystemService : IFileSystemService
         }
     }
 
-    private static IEnumerable<string> EnumerateFilesSkippingIgnored(
+    private IEnumerable<string> EnumerateFilesSkippingIgnored(
         string root, string pattern, CancellationToken cancellationToken)
     {
         var queue = new Queue<string>();
@@ -214,7 +240,12 @@ public sealed class FileSystemService : IFileSystemService
 
             foreach (var sub in subdirs)
             {
-                if (!SearchSkipDirectories.Contains(Path.GetFileName(sub)))
+                // The protected-path check must be repeated here, not just at the search root:
+                // the walk descends from an allowed root into whatever it finds, and the skip
+                // list is a performance filter (build artifacts, VCS internals), not a security
+                // boundary. Without this a search rooted at the workspace would descend into the
+                // governance-state directory and read the database's pages as text.
+                if (!SearchSkipDirectories.Contains(Path.GetFileName(sub)) && !IsProtectedPath(sub))
                     queue.Enqueue(sub);
             }
         }
@@ -224,6 +255,16 @@ public sealed class FileSystemService : IFileSystemService
         string filePath, string basePath, string searchTerm,
         List<FileSearchResult> results, CancellationToken cancellationToken)
     {
+        // Last line of defence before any file content is read. The directory filter above
+        // already prunes protected subtrees; this catches a protected file reached any other
+        // way (a file directly under an allowed root, a future enumeration change) so no
+        // content leaves this method without having passed the same gate a direct read does.
+        if (!IsPathAllowed(filePath))
+        {
+            _logger.LogWarning("Skipped search of disallowed path: {Path}", filePath);
+            return;
+        }
+
         try
         {
             var lineNumber = 0;
@@ -322,6 +363,18 @@ public sealed class FileSystemService : IFileSystemService
     private bool IsPathAllowed(string fullPath)
     {
         var normalized = Path.GetFullPath(fullPath);
+
+        // Deny list wins over the allowlist. Protected directories hold the harness's own
+        // governance state — the SQLite database of approval verdicts — and typically sit
+        // under a configured base path, so allowlisting alone would leave them reachable.
+        // An agent able to edit that file could forge an approval verdict, so the tool must
+        // not be able to read or write it under any configuration.
+        if (IsProtectedPath(normalized))
+        {
+            _logger.LogWarning("Blocked access to protected harness state directory: {Path}", normalized);
+            return false;
+        }
+
         foreach (var basePath in _allowedBasePaths)
         {
             // Match on directory boundary, not just string prefix
@@ -334,6 +387,59 @@ public sealed class FileSystemService : IFileSystemService
                 return true;
         }
         return false;
+    }
+
+    /// <summary>
+    /// True when <paramref name="fullPath"/> is, or lives under, a protected harness-state
+    /// directory.
+    /// </summary>
+    /// <remarks>
+    /// Compares canonicalized absolute paths on a directory boundary, so a legitimate sibling
+    /// such as <c>.agent-state-docs</c> is unaffected while an alias that merely spells the
+    /// protected directory differently (a Windows 8.3 short name, a symlinked parent already
+    /// resolved upstream) still matches.
+    /// </remarks>
+    /// <param name="fullPath">An absolute path.</param>
+    private bool IsProtectedPath(string fullPath)
+    {
+        if (_protectedPaths.Count == 0)
+            return false;
+
+        var normalized = CanonicalizePath(fullPath);
+        foreach (var protectedPath in _protectedPaths)
+        {
+            var withSeparator = protectedPath.EndsWith(Path.DirectorySeparatorChar)
+                ? protectedPath
+                : protectedPath + Path.DirectorySeparatorChar;
+
+            if (normalized.Equals(protectedPath, StringComparison.OrdinalIgnoreCase)
+                || normalized.StartsWith(withSeparator, StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Resolves a path to its canonical absolute form, expanding OS-level aliases that
+    /// <see cref="Path.GetFullPath(string)"/> leaves intact — notably Windows 8.3 short names,
+    /// which would otherwise let <c>AGENT-~1</c> sidestep a comparison against the long name.
+    /// </summary>
+    /// <param name="path">The path to canonicalize.</param>
+    private static string CanonicalizePath(string path)
+    {
+        var full = Path.GetFullPath(path);
+        try
+        {
+            // ResolveLinkTarget(returnFinalTarget) canonicalizes an existing entry; for a path
+            // that does not exist yet the normalized form is the best available answer.
+            var info = Directory.Exists(full) ? new DirectoryInfo(full) : (FileSystemInfo)new FileInfo(full);
+            return info.Exists ? Path.GetFullPath(info.ResolveLinkTarget(true)?.FullName ?? info.FullName) : full;
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or ArgumentException)
+        {
+            return full;
+        }
     }
 
     private void ValidateWriteTarget(string fullPath)

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/FileSystemService.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/FileSystemService.cs
@@ -33,6 +33,13 @@ public sealed class FileSystemService : IFileSystemService
     // defeated by a Windows 8.3 short alias (AGENT-~1) or any other alias that resolves to the
     // same directory but spells it differently. The canonical form comes from the same
     // resolver the database registration uses, so the two cannot drift.
+    //
+    // This deny list is defence in depth, not the load-bearing control. It cannot see through a
+    // hard link: a hard link is a second directory entry for the same file, not a reparse point,
+    // so there is no link target to resolve and its canonical form is itself. The control that
+    // actually closes that hole is FileSystemSandboxStartupValidator, which refuses to boot when
+    // a protected directory sits inside an allowed base path — a hard link cannot span volumes,
+    // so a protected file outside every allowed base path cannot be aliased into one.
     private readonly HashSet<string> _protectedPaths;
 
     // Directories skipped during recursive search — build artifacts and VCS internals
@@ -75,22 +82,30 @@ public sealed class FileSystemService : IFileSystemService
         ArgumentNullException.ThrowIfNull(allowedBasePaths);
 
         _logger = logger;
-        _allowedBasePaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        _protectedPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
-        // Both sets are stored in PathScope-normalized form (absolute, trailing separator trimmed)
-        // because every comparison against them goes through PathScope.IsSameOrUnderNormalized,
-        // which requires normalized inputs on both sides.
+        // PathScope.Comparer, never a hardcoded StringComparer.OrdinalIgnoreCase: on Linux
+        // "/srv/state" and "/srv/State" are two different directories, and case-insensitive
+        // hashing would collapse them into one entry. For the deny set that collapse is
+        // fail-OPEN — the second protected directory silently stops being protected.
+        _allowedBasePaths = new HashSet<string>(PathScope.Comparer);
+        _protectedPaths = new HashSet<string>(PathScope.Comparer);
+
+        // Both sets are stored in canonical, PathScope-normalized form (absolute, links resolved,
+        // trailing separator trimmed). Normalized because every comparison against them goes
+        // through PathScope.IsSameOrUnderNormalized, which requires normalized inputs on both
+        // sides; canonical because the paths a comparison is fed at runtime are canonicalized, and
+        // comparing a canonical target against a literal base misses whenever the configured base
+        // is itself reached through a link.
         foreach (var path in protectedPaths ?? [])
         {
             if (!string.IsNullOrWhiteSpace(path))
-                _protectedPaths.Add(CanonicalizePath(PathScope.Normalize(path)));
+                _protectedPaths.Add(SandboxPathCanonicalizer.Canonicalize(PathScope.Normalize(path)));
         }
 
         foreach (var path in allowedBasePaths)
         {
             if (!string.IsNullOrWhiteSpace(path))
-                _allowedBasePaths.Add(PathScope.Normalize(path));
+                _allowedBasePaths.Add(SandboxPathCanonicalizer.Canonicalize(PathScope.Normalize(path)));
         }
 
         if (_allowedBasePaths.Count == 0)
@@ -177,7 +192,7 @@ public sealed class FileSystemService : IFileSystemService
         var filesScanned = 0;
 
         // Lives only for this call — see IsProtectedPath for why it must not become process-wide.
-        var directoryVerdicts = new Dictionary<string, bool>(PathScope.Comparer);
+        var directoryVerdicts = new Dictionary<string, DirectoryVerdict>(PathScope.Comparer);
 
         foreach (var file in EnumerateFilesSkippingIgnored(
             fullPath, searchPattern, directoryVerdicts, cancellationToken))
@@ -218,13 +233,43 @@ public sealed class FileSystemService : IFileSystemService
         }
     }
 
+    /// <summary>
+    /// Breadth-first walk of <paramref name="root"/>, yielding files while pruning any subtree the
+    /// sandbox refuses, and recording each directory's verdict in <paramref name="directoryVerdicts"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Both arms of the sandbox decision prune, not just the deny arm. A junction or symlink
+    /// planted in the workspace is not <em>protected</em> — its target is somewhere else entirely —
+    /// so a deny-only check descends into it happily, and every file it then yields carries a
+    /// literal, workspace-shaped path that satisfies a workspace-rooted allowlist. Pruning on the
+    /// canonical target is what keeps the walk inside the sandbox, and it has to happen here:
+    /// canonicalization resolves an entry's own link, not links in its parent components, so a
+    /// directory reached <em>below</em> an unpruned link would canonicalize to its literal path and
+    /// look legitimate.
+    /// </para>
+    /// <para>
+    /// Directory verdicts are resolved without the memo. Parent-verdict inheritance is sound for
+    /// files only — a file under an unprotected directory cannot itself be a protected root, but a
+    /// subdirectory can be exactly that, <c>.agent-state</c> being an ordinary non-reparse-point
+    /// directory inside an unprotected workspace.
+    /// </para>
+    /// </remarks>
+    /// <param name="root">The already-validated absolute search root.</param>
+    /// <param name="pattern">The file-name pattern to match.</param>
+    /// <param name="directoryVerdicts">Per-operation verdict memo; see <see cref="ResolveVerdict"/>.</param>
+    /// <param name="cancellationToken">Token to observe while walking.</param>
     private IEnumerable<string> EnumerateFilesSkippingIgnored(
-        string root, string pattern, Dictionary<string, bool> directoryVerdicts,
+        string root, string pattern, Dictionary<string, DirectoryVerdict> directoryVerdicts,
         CancellationToken cancellationToken)
     {
         var queue = new Queue<string>();
         queue.Enqueue(root);
-        directoryVerdicts[PathScope.Normalize(root)] = IsProtectedPath(root);
+
+        // Normalized before the verdict call, not only to key the memo: Canonicalize documents a
+        // normalized input as a precondition and returns its argument unchanged on the error path.
+        var normalizedRoot = PathScope.Normalize(root);
+        directoryVerdicts[normalizedRoot] = ResolveVerdict(normalizedRoot);
 
         while (queue.Count > 0)
         {
@@ -246,18 +291,17 @@ public sealed class FileSystemService : IFileSystemService
 
             foreach (var sub in subdirs)
             {
-                // The protected-path check must be repeated here, not just at the search root:
-                // the walk descends from an allowed root into whatever it finds, and the skip
-                // list is a performance filter (build artifacts, VCS internals), not a security
-                // boundary. Without this a search rooted at the workspace would descend into the
-                // governance-state directory and read the database's pages as text.
+                // A performance filter (build artifacts, VCS internals), never a security boundary
+                // — the sandbox decision below is what prunes protected and escaping subtrees.
                 if (SearchSkipDirectories.Contains(Path.GetFileName(sub)))
                     continue;
 
-                var isProtected = IsProtectedPath(sub);
-                directoryVerdicts[PathScope.Normalize(sub)] = isProtected;
+                // No memo here, and both arms prune — see this method's remarks for why.
+                var normalizedSub = PathScope.Normalize(sub);
+                var verdict = ResolveVerdict(normalizedSub);
+                directoryVerdicts[normalizedSub] = verdict;
 
-                if (!isProtected)
+                if (!verdict.IsProtected && IsUnderAllowedBase(verdict.CanonicalPath))
                     queue.Enqueue(sub);
             }
         }
@@ -265,13 +309,16 @@ public sealed class FileSystemService : IFileSystemService
 
     private async Task SearchFileAsync(
         string filePath, string basePath, string searchTerm,
-        List<FileSearchResult> results, Dictionary<string, bool> directoryVerdicts,
+        List<FileSearchResult> results, Dictionary<string, DirectoryVerdict> directoryVerdicts,
         CancellationToken cancellationToken)
     {
         // Last line of defence before any file content is read. The directory filter above
-        // already prunes protected subtrees; this catches a protected file reached any other
-        // way (a file directly under an allowed root, a future enumeration change) so no
-        // content leaves this method without having passed the same gate a direct read does.
+        // already prunes protected and out-of-sandbox subtrees; this catches a file reached any
+        // other way (a file directly under an allowed root, a file that is itself a link, a future
+        // enumeration change) so no content leaves this method without having passed the same gate
+        // a direct read does. "The same gate" is load-bearing and was previously untrue: the
+        // direct-read gate resolves links before comparing, and this one compared the literal
+        // enumerated path, so a link inside the workspace read through it whatever it pointed at.
         if (!IsPathAllowed(filePath, directoryVerdicts))
         {
             _logger.LogWarning("Skipped search of disallowed path: {Path}", filePath);
@@ -373,41 +420,77 @@ public sealed class FileSystemService : IFileSystemService
         return path;
     }
 
+    /// <summary>
+    /// The sandbox decision for one path: whether it is denied outright, and the canonical
+    /// location the allowlist comparison must be made against.
+    /// </summary>
+    /// <remarks>
+    /// The two travel together because they are answers to the same question — "what does this
+    /// path actually name?" — and separating them is what let a symlink escape the sandbox: the
+    /// deny arm consumed the canonical form while the allow arm compared the literal one.
+    /// </remarks>
+    /// <param name="IsProtected">
+    /// <see langword="true"/> when the path is, or lives under, a protected harness-state directory.
+    /// </param>
+    /// <param name="CanonicalPath">
+    /// The path's canonical absolute form, with links resolved. Valid on both arms.
+    /// </param>
+    private readonly record struct DirectoryVerdict(bool IsProtected, string CanonicalPath);
+
     /// <param name="fullPath">An absolute path.</param>
     /// <param name="directoryVerdicts">
-    /// Optional per-operation protected-path memo; see <see cref="IsProtectedPath"/>.
+    /// Optional per-operation sandbox-verdict memo; see <see cref="ResolveVerdict"/>.
     /// </param>
-    private bool IsPathAllowed(string fullPath, Dictionary<string, bool>? directoryVerdicts = null)
+    private bool IsPathAllowed(string fullPath, Dictionary<string, DirectoryVerdict>? directoryVerdicts = null)
     {
-        var normalized = PathScope.Normalize(fullPath);
+        var verdict = ResolveVerdict(PathScope.Normalize(fullPath), directoryVerdicts);
 
         // Deny list wins over the allowlist. Protected directories hold the harness's own
         // governance state — the SQLite database of approval verdicts — and typically sit
         // under a configured base path, so allowlisting alone would leave them reachable.
         // An agent able to edit that file could forge an approval verdict, so the tool must
         // not be able to read or write it under any configuration.
-        if (IsProtectedPath(normalized, directoryVerdicts))
+        if (verdict.IsProtected)
         {
-            _logger.LogWarning("Blocked access to protected harness state directory: {Path}", normalized);
+            _logger.LogWarning(
+                "Blocked access to protected harness state directory: {Path}", verdict.CanonicalPath);
             return false;
         }
 
-        // PathScope matches on a directory boundary, so a sibling whose name merely starts with an
-        // allowed root (C:\workspace-backup against C:\workspace) is not mistaken for a child.
-        return _allowedBasePaths.Any(basePath => PathScope.IsSameOrUnderNormalized(normalized, basePath));
+        // Compared against the CANONICAL path, never the literal one. A junction at
+        // workspace\notes pointing at C:\Users\victim\.ssh yields files whose literal paths all
+        // look like workspace\notes\..., which satisfy any workspace-rooted allowlist; only the
+        // resolved target reveals that they are outside the sandbox.
+        return IsUnderAllowedBase(verdict.CanonicalPath);
     }
 
     /// <summary>
-    /// True when <paramref name="fullPath"/> is, or lives under, a protected harness-state
-    /// directory.
+    /// True when <paramref name="canonicalPath"/> sits inside a configured allowed base path.
+    /// </summary>
+    /// <remarks>
+    /// PathScope matches on a directory boundary, so a sibling whose name merely starts with an
+    /// allowed root (<c>C:\workspace-backup</c> against <c>C:\workspace</c>) is not mistaken for a
+    /// child. Both operands are canonical: the argument by contract, the base paths because the
+    /// constructor canonicalizes them once.
+    /// </remarks>
+    /// <param name="canonicalPath">A canonical absolute path.</param>
+    private bool IsUnderAllowedBase(string canonicalPath) =>
+        _allowedBasePaths.Any(basePath => PathScope.IsSameOrUnderNormalized(canonicalPath, basePath));
+
+    /// <summary>
+    /// Canonicalizes <paramref name="normalizedPath"/> and decides whether it is protected,
+    /// returning both halves of the sandbox decision.
     /// </summary>
     /// <remarks>
     /// Compares canonicalized absolute paths on a directory boundary, so a legitimate sibling
     /// such as <c>.agent-state-docs</c> is unaffected while an alias that merely spells the
-    /// protected directory differently (a Windows 8.3 short name, a symlinked parent already
-    /// resolved upstream) still matches.
+    /// protected directory differently (a Windows 8.3 short name, a symlink, a junctioned parent)
+    /// still matches.
     /// </remarks>
-    /// <param name="fullPath">An absolute path.</param>
+    /// <param name="normalizedPath">
+    /// An absolute path, already <see cref="PathScope.Normalize"/>d — the precondition
+    /// <see cref="SandboxPathCanonicalizer.Canonicalize"/> documents.
+    /// </param>
     /// <param name="directoryVerdicts">
     /// <para>
     /// Optional memo of directory path to verdict, scoped to a <em>single</em> search operation and
@@ -423,97 +506,97 @@ public sealed class FileSystemService : IFileSystemService
     /// staleness window to the same window the directory prune already has.
     /// </para>
     /// </param>
-    private bool IsProtectedPath(string fullPath, Dictionary<string, bool>? directoryVerdicts = null)
+    private DirectoryVerdict ResolveVerdict(
+        string normalizedPath, Dictionary<string, DirectoryVerdict>? directoryVerdicts = null)
     {
-        if (_protectedPaths.Count == 0)
-            return false;
-
-        if (directoryVerdicts is not null && TryInheritParentVerdict(fullPath, directoryVerdicts, out var inherited))
+        if (directoryVerdicts is not null
+            && TryInheritParentVerdict(normalizedPath, directoryVerdicts, out var inherited))
+        {
             return inherited;
+        }
 
-        var normalized = CanonicalizePath(fullPath);
-        return _protectedPaths.Any(protectedPath =>
-            PathScope.IsSameOrUnderNormalized(normalized, protectedPath));
+        var canonical = SandboxPathCanonicalizer.Canonicalize(normalizedPath);
+        var isProtected = _protectedPaths.Any(protectedPath =>
+            PathScope.IsSameOrUnderNormalized(canonical, protectedPath));
+
+        return new DirectoryVerdict(isProtected, canonical);
     }
 
     /// <summary>
-    /// Resolves <paramref name="fullPath"/>'s verdict from its already-canonicalized parent directory
-    /// when that is sound, avoiding a link resolution per file.
+    /// Resolves <paramref name="normalizedPath"/>'s verdict from its already-canonicalized parent
+    /// directory when that is sound, avoiding a link resolution per file.
     /// </summary>
     /// <remarks>
-    /// A recorded parent verdict of <see langword="true"/> transfers unconditionally — everything under
-    /// a protected directory is protected. A verdict of <see langword="false"/> transfers only when the
-    /// entry is not itself a reparse point, because a symlink sitting in an unprotected directory can
-    /// still resolve into the protected one; those fall through to full canonicalization. Reading the
-    /// attribute costs a stat but no handle open, which is the syscall being avoided.
+    /// <para>
+    /// Inheritance is only sound for a plain file: a subdirectory can itself be a protected root,
+    /// and a reparse point resolves somewhere its parent says nothing about. Both are rejected
+    /// here, by the method rather than by convention, and fall through to full canonicalization.
+    /// Reading the attributes costs a stat but no handle open, which is the syscall being avoided.
+    /// </para>
+    /// <para>
+    /// For an entry that passes that test the composed path is exact, not an approximation: a
+    /// non-reparse-point entry genuinely lives inside its parent directory, so appending its leaf
+    /// name to the parent's canonical directory names the same location a full canonicalization
+    /// would return. That exactness is what makes the memo safe to feed the allowlist comparison —
+    /// inheriting only the boolean, as this method used to, left the allow arm with a literal path
+    /// whose parent had been canonicalized but which had not.
+    /// </para>
+    /// <para>
+    /// A parent verdict of <see langword="true"/> transfers unconditionally — everything under a
+    /// protected directory is protected, including a link planted there — but is canonicalized in
+    /// full rather than composed, because a reparse point in that position does not occupy the
+    /// composed location. That branch is effectively unreachable during a search (protected
+    /// directories are never enqueued), so the extra resolve costs nothing in practice.
+    /// </para>
     /// </remarks>
     private static bool TryInheritParentVerdict(
-        string fullPath, Dictionary<string, bool> directoryVerdicts, out bool verdict)
+        string normalizedPath,
+        Dictionary<string, DirectoryVerdict> directoryVerdicts,
+        out DirectoryVerdict verdict)
     {
-        verdict = false;
+        verdict = default;
 
-        var parent = Path.GetDirectoryName(fullPath);
-        if (parent is null || !directoryVerdicts.TryGetValue(PathScope.Normalize(parent), out var parentVerdict))
-            return false;
-
-        if (parentVerdict)
+        var parent = Path.GetDirectoryName(normalizedPath);
+        if (parent is null
+            || !directoryVerdicts.TryGetValue(PathScope.Normalize(parent), out var parentVerdict))
         {
-            verdict = true;
+            return false;
+        }
+
+        if (parentVerdict.IsProtected)
+        {
+            verdict = new DirectoryVerdict(true, SandboxPathCanonicalizer.Canonicalize(normalizedPath));
             return true;
         }
 
         try
         {
-            return !File.GetAttributes(fullPath).HasFlag(FileAttributes.ReparsePoint);
+            // Directory: a subdirectory can itself be a protected root. ReparsePoint: a link
+            // resolves somewhere its parent says nothing about. Enforced here rather than left as a
+            // caller contract, because a caller that gets it wrong fails open and fails silently.
+            var attributes = File.GetAttributes(normalizedPath);
+            if (attributes.HasFlag(FileAttributes.Directory)
+                || attributes.HasFlag(FileAttributes.ReparsePoint))
+            {
+                return false;
+            }
         }
-        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or ArgumentException)
+        catch (Exception ex) when (ex is IOException
+                                      or UnauthorizedAccessException
+                                      or ArgumentException
+                                      or NotSupportedException)
         {
-            // Unreadable or already gone: fall through to the full check rather than guess.
+            // Unreadable, already gone, or a path shape the runtime rejects outright: fall through
+            // to the full check rather than guess. NotSupportedException is in the filter so it
+            // produces a clean deny instead of escaping SearchFilesAsync unhandled.
             return false;
         }
-    }
 
-    /// <summary>
-    /// Resolves a path to its canonical absolute form, so an alias cannot sidestep a comparison
-    /// against the long name.
-    /// </summary>
-    /// <remarks>
-    /// <para>
-    /// The two steps cover different aliases. <see cref="Path.GetFullPath(string)"/> is what
-    /// handles Windows 8.3 short names: on Windows its normalization expands any component that
-    /// exists on disk, turning <c>PROGRA~1</c> into <c>Program Files</c>. The
-    /// <see cref="FileSystemInfo.ResolveLinkTarget(bool)"/> step then covers symlinks and
-    /// junctions, which <c>GetFullPath</c> does leave intact.
-    /// </para>
-    /// <para>
-    /// A component that does not exist is left exactly as written, because there is nothing on
-    /// disk to expand it against. That is harmless for the protected-path check: a protected
-    /// directory that does not exist holds nothing to protect, and a literal <c>AGENT-~1</c>
-    /// path then names a genuinely different directory rather than aliasing the protected one.
-    /// </para>
-    /// </remarks>
-    /// <param name="path">
-    /// The path to canonicalize. Must already be <see cref="PathScope.Normalize"/>d — every caller
-    /// normalizes before calling, so re-running <see cref="Path.GetFullPath(string)"/> here would
-    /// repeat work already done on a per-file security check.
-    /// </param>
-    private static string CanonicalizePath(string path)
-    {
-        try
-        {
-            // One stat answers both "does it exist" and "is it a directory"; a missing entry throws
-            // and is caught below. ResolveLinkTarget(returnFinalTarget) then canonicalizes the entry —
-            // for a path that does not exist yet the normalized form is the best available answer.
-            var info = File.GetAttributes(path).HasFlag(FileAttributes.Directory)
-                ? new DirectoryInfo(path)
-                : (FileSystemInfo)new FileInfo(path);
-
-            return PathScope.Normalize(info.ResolveLinkTarget(true)?.FullName ?? info.FullName);
-        }
-        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or ArgumentException)
-        {
-            return path;
-        }
+        verdict = new DirectoryVerdict(
+            false,
+            PathScope.Normalize(Path.Combine(
+                parentVerdict.CanonicalPath, Path.GetFileName(normalizedPath))));
+        return true;
     }
 
     private void ValidateWriteTarget(string fullPath)

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/HardLinkInspector.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/HardLinkInspector.cs
@@ -47,6 +47,26 @@ namespace Infrastructure.AI.Tools;
 internal static class HardLinkInspector
 {
     /// <summary>
+    /// Whether this operating system has a link-count implementation in this type.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This is the single authority on platform coverage, not a convenience duplicate of the checks
+    /// in <see cref="InspectFile"/>: that method refuses to run at all when this is
+    /// <see langword="false"/>, so a new platform branch is unreachable until it is also named
+    /// here. The two therefore cannot drift into disagreeing about what is supported.
+    /// </para>
+    /// <para>
+    /// It exists so callers can ask about coverage <em>before</em> they need a verdict.
+    /// <c>FileSystemSandboxStartupValidator</c> uses it to turn what would otherwise be a silent
+    /// per-operation denial on an unimplemented platform into one refusal to boot that names the
+    /// platform and says what to do about it.
+    /// </para>
+    /// </remarks>
+    internal static bool IsSupportedPlatform =>
+        OperatingSystem.IsWindows() || OperatingSystem.IsLinux();
+
+    /// <summary>
     /// How many directory entries the operating system reports for a file.
     /// </summary>
     internal enum LinkCount
@@ -111,6 +131,13 @@ internal static class HardLinkInspector
     /// <param name="path">An absolute path to an entry known not to be a directory.</param>
     private static LinkCount InspectFile(string path)
     {
+        // Asked before the handle is opened, so an unimplemented platform costs nothing per call
+        // and — more importantly — so IsSupportedPlatform is the one place platform coverage is
+        // declared. A branch added below without being named there is unreachable, which is the
+        // failure direction that leaves the guard honest.
+        if (!IsSupportedPlatform)
+            return LinkCount.Unknown;
+
         try
         {
             // FileShare.ReadWrite | Delete so inspecting never contends with a legitimate writer,

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/HardLinkInspector.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/HardLinkInspector.cs
@@ -1,0 +1,274 @@
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+using Microsoft.Win32.SafeHandles;
+
+namespace Infrastructure.AI.Tools;
+
+/// <summary>
+/// Asks the operating system how many directory entries name the file at a given path, so a
+/// sandbox can refuse a file it cannot prove has only one name.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Why this exists.</b> Every other control in <see cref="FileSystemService"/> reasons about a
+/// path. A hard link defeats all of them, because it is not an alias of a path — it is a second,
+/// equally real directory entry for one file. It carries no reparse point, so
+/// <see cref="FileSystemInfo.ResolveLinkTarget(bool)"/> returns nothing and its canonical form is
+/// itself; a hard link planted inside the workspace therefore presents to every path comparison as
+/// an ordinary, unprotected workspace file that happens to read and write protected harness state.
+/// Creating one needs no privilege on Windows (<c>mklink /H</c>) or Linux (<c>ln</c>). The only way
+/// to see it is to stop asking about the path and ask about the file's identity, which is what this
+/// type does.
+/// </para>
+/// <para>
+/// <b>Why the link count and not an identity comparison.</b> Comparing the file's device/inode pair
+/// against every file currently inside a protected directory would be more precise, but it costs an
+/// enumeration of the protected directory per operation and races against files created in it
+/// between the enumeration and the open. The link count needs neither: a file with one directory
+/// entry cannot be an alias of anything, whatever else exists on the volume. Legitimate files in an
+/// agent workspace are written once by the agent and have exactly one entry, so the imprecision
+/// costs nothing in practice — and when it does bite, it bites closed.
+/// </para>
+/// <para>
+/// <b>Why interop.</b> No managed BCL API exposes a link count. Two platform calls are wrapped
+/// here, both taking a handle the caller has already opened rather than a path, and both kept
+/// deliberately small: <c>GetFileInformationByHandle</c> on Windows and <c>statx</c> on Linux.
+/// </para>
+/// <para>
+/// <b>Platform coverage, and what happens beyond it.</b> Windows and Linux are implemented. Every
+/// other platform — macOS and the BSDs — reports <see cref="LinkCount.Unknown"/>, and callers are
+/// contractually required to treat that as a denial. Those platforms expose the count only through
+/// <c>struct stat</c>, whose field order and widths differ by operating system <em>and</em> by
+/// processor architecture; shipping a guessed layout into a template would read the wrong four
+/// bytes and fail open silently, which is strictly worse than an honest closed door. A consumer who
+/// needs macOS support should implement one additional branch here rather than weaken the contract.
+/// </para>
+/// </remarks>
+internal static class HardLinkInspector
+{
+    /// <summary>
+    /// How many directory entries the operating system reports for a file.
+    /// </summary>
+    internal enum LinkCount
+    {
+        /// <summary>
+        /// Exactly one directory entry names the file, or there is nothing to inspect (the entry is
+        /// a directory, or does not exist yet). The file cannot be an alias of another.
+        /// </summary>
+        Single,
+
+        /// <summary>
+        /// More than one directory entry names the file. It is one end of a hard link, and there is
+        /// no way to tell from here which end.
+        /// </summary>
+        Multiple,
+
+        /// <summary>
+        /// The count could not be established: an unimplemented platform, a failed platform call,
+        /// or a reported count the caller has no reason to trust. Callers must fail closed on this.
+        /// </summary>
+        Unknown,
+    }
+
+    /// <summary>
+    /// Reports how many directory entries name the file at <paramref name="path"/>.
+    /// </summary>
+    /// <remarks>
+    /// Directories short-circuit to <see cref="LinkCount.Single"/> without opening a handle. Neither
+    /// platform lets an unprivileged process hard-link a directory, and on Linux every directory
+    /// legitimately carries at least two entries (its own <c>.</c> and its parent's), so counting
+    /// links there would deny every directory operation for no security gain.
+    /// </remarks>
+    /// <param name="path">An absolute path. Need not exist.</param>
+    /// <returns>The link-count classification; never throws.</returns>
+    public static LinkCount Inspect(string path)
+    {
+        try
+        {
+            if (File.GetAttributes(path).HasFlag(FileAttributes.Directory))
+                return LinkCount.Single;
+        }
+        catch (Exception ex) when (ex is FileNotFoundException or DirectoryNotFoundException)
+        {
+            // Nothing on disk: a file about to be created has no second name. This is the ordinary
+            // write-to-a-new-file case, not an error.
+            return LinkCount.Single;
+        }
+        catch (Exception ex) when (ex is IOException
+                                      or UnauthorizedAccessException
+                                      or ArgumentException
+                                      or NotSupportedException)
+        {
+            return LinkCount.Unknown;
+        }
+
+        return InspectFile(path);
+    }
+
+    /// <summary>
+    /// Opens a handle to an existing file and dispatches to the platform call.
+    /// </summary>
+    /// <param name="path">An absolute path to an entry known not to be a directory.</param>
+    private static LinkCount InspectFile(string path)
+    {
+        try
+        {
+            // FileShare.ReadWrite | Delete so inspecting never contends with a legitimate writer,
+            // and FileAccess.Read because that is the least access that yields a usable handle.
+            using var handle = File.OpenHandle(
+                path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
+
+            if (OperatingSystem.IsWindows())
+                return WindowsLinkCount(handle);
+
+            return OperatingSystem.IsLinux() ? LinuxLinkCount(handle) : LinkCount.Unknown;
+        }
+        catch (Exception ex) when (ex is FileNotFoundException or DirectoryNotFoundException)
+        {
+            // Deleted between the attribute read and the open.
+            return LinkCount.Single;
+        }
+        catch (Exception ex) when (ex is IOException
+                                      or UnauthorizedAccessException
+                                      or ArgumentException
+                                      or NotSupportedException
+                                      or DllNotFoundException
+                                      or EntryPointNotFoundException)
+        {
+            // A file that cannot be opened cannot be inspected. The caller denies, which costs
+            // nothing: a file that cannot be opened cannot be read or written either.
+            return LinkCount.Unknown;
+        }
+    }
+
+    /// <summary>
+    /// Turns a raw platform link count into a verdict, distrusting a count of zero.
+    /// </summary>
+    /// <remarks>
+    /// A live file always has at least one directory entry, so zero means the platform call
+    /// reported something this code does not understand — a wrong struct offset being the obvious
+    /// candidate. Treating it as <see cref="LinkCount.Unknown"/> makes that mistake fail closed
+    /// instead of reading as "no links, therefore safe".
+    /// </remarks>
+    /// <param name="rawCount">The count as reported by the platform.</param>
+    private static LinkCount Classify(uint rawCount) => rawCount switch
+    {
+        0 => LinkCount.Unknown,
+        1 => LinkCount.Single,
+        _ => LinkCount.Multiple,
+    };
+
+    // ---- Windows ----------------------------------------------------------------------------
+
+    /// <summary>
+    /// Reads <c>nNumberOfLinks</c> from <c>GetFileInformationByHandle</c>.
+    /// </summary>
+    /// <param name="handle">An open handle to the file.</param>
+    [SupportedOSPlatform("windows")]
+    private static LinkCount WindowsLinkCount(SafeFileHandle handle) =>
+        GetFileInformationByHandle(handle, out var information)
+            ? Classify(information.NumberOfLinks)
+            : LinkCount.Unknown;
+
+    /// <summary>
+    /// The Win32 <c>BY_HANDLE_FILE_INFORMATION</c> structure.
+    /// </summary>
+    /// <remarks>
+    /// Every field is declared, in order, even though only <see cref="NumberOfLinks"/> is read. The
+    /// operating system writes the whole 52-byte structure, so a truncated declaration would be a
+    /// buffer overrun, and declaring the fields is safer than hand-computing one offset. The two
+    /// <c>FILETIME</c> values are spelled as their low/high halves so the type carries no
+    /// dependency beyond the primitives.
+    /// </remarks>
+    [StructLayout(LayoutKind.Sequential)]
+    private struct ByHandleFileInformation
+    {
+        public uint FileAttributes;
+        public uint CreationTimeLow;
+        public uint CreationTimeHigh;
+        public uint LastAccessTimeLow;
+        public uint LastAccessTimeHigh;
+        public uint LastWriteTimeLow;
+        public uint LastWriteTimeHigh;
+        public uint VolumeSerialNumber;
+        public uint FileSizeHigh;
+        public uint FileSizeLow;
+        public uint NumberOfLinks;
+        public uint FileIndexHigh;
+        public uint FileIndexLow;
+    }
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool GetFileInformationByHandle(
+        SafeFileHandle handle, out ByHandleFileInformation information);
+
+    // ---- Linux ------------------------------------------------------------------------------
+
+    /// <summary>Size of the kernel's <c>struct statx</c>, which callers must supply in full.</summary>
+    private const int StatxSize = 256;
+
+    /// <summary><c>STATX_NLINK</c> — request (and confirm receipt of) <c>stx_nlink</c>.</summary>
+    private const uint StatxNlink = 0x0000_0004;
+
+    /// <summary><c>AT_EMPTY_PATH</c> — operate on the descriptor, ignoring the path argument.</summary>
+    private const int AtEmptyPath = 0x1000;
+
+    /// <summary>
+    /// Reads <c>stx_nlink</c> from <c>statx</c>, applied to the already-open descriptor.
+    /// </summary>
+    /// <remarks>
+    /// <c>statx</c> rather than <c>stat</c> deliberately: <c>struct statx</c> is a kernel UAPI
+    /// structure with one fixed layout across every architecture, whereas <c>struct stat</c> is
+    /// arranged differently on x86-64 and AArch64 and reaches glibc through versioned symbols. The
+    /// returned <c>stx_mask</c> is checked rather than assumed, so a kernel or filesystem that did
+    /// not fill the field produces a denial instead of a fabricated count.
+    /// </remarks>
+    /// <param name="handle">An open handle to the file; its descriptor is passed to the syscall.</param>
+    [SupportedOSPlatform("linux")]
+    private static LinkCount LinuxLinkCount(SafeFileHandle handle)
+    {
+        var referenced = false;
+        try
+        {
+            handle.DangerousAddRef(ref referenced);
+            if (!referenced)
+                return LinkCount.Unknown;
+
+            // Empty path + AT_EMPTY_PATH means "the file this descriptor already refers to", so the
+            // count describes the handle the caller opened rather than whatever the path names now.
+            if (Statx((int)handle.DangerousGetHandle(), string.Empty, AtEmptyPath, StatxNlink, out var status) != 0)
+                return LinkCount.Unknown;
+
+            return (status.Mask & StatxNlink) == 0 ? LinkCount.Unknown : Classify(status.LinkCount);
+        }
+        finally
+        {
+            if (referenced)
+                handle.DangerousRelease();
+        }
+    }
+
+    /// <summary>
+    /// The leading fields of the kernel's <c>struct statx</c>.
+    /// </summary>
+    /// <remarks>
+    /// Explicit offsets, taken from the kernel UAPI: <c>stx_mask</c> (u32) at 0, <c>stx_blksize</c>
+    /// (u32) at 4, <c>stx_attributes</c> (u64) at 8, <c>stx_nlink</c> (u32) at 16. The declared size
+    /// is the full structure the kernel writes, so the unread remainder is still allocated.
+    /// </remarks>
+    [StructLayout(LayoutKind.Explicit, Size = StatxSize)]
+    private struct StatxResult
+    {
+        [FieldOffset(0)] public uint Mask;
+        [FieldOffset(16)] public uint LinkCount;
+    }
+
+    [DllImport("libc", EntryPoint = "statx", SetLastError = true)]
+    private static extern int Statx(
+        int dirFd,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string pathname,
+        int flags,
+        uint mask,
+        out StatxResult status);
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/SandboxPathCanonicalizer.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/SandboxPathCanonicalizer.cs
@@ -1,0 +1,78 @@
+using Domain.Common.Helpers;
+
+namespace Infrastructure.AI.Tools;
+
+/// <summary>
+/// Resolves a filesystem path to its canonical absolute form, so an alias cannot sidestep a
+/// comparison against the real location.
+/// </summary>
+/// <remarks>
+/// Shared by <see cref="FileSystemService"/>'s per-path sandbox decisions and by
+/// <see cref="FileSystemSandboxStartupValidator"/>'s boot-time overlap assertion. Both answer the
+/// same question — "which directory does this path actually name?" — and a divergence between them
+/// would let the startup assertion pass on a configuration the runtime check then treats as
+/// overlapping (or the reverse), so the implementation lives in exactly one place.
+/// </remarks>
+internal static class SandboxPathCanonicalizer
+{
+    /// <summary>
+    /// Returns the canonical absolute form of <paramref name="normalizedPath"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Two aliasing mechanisms are covered, by two different steps.
+    /// <see cref="PathScope.Normalize(string)"/> (which the caller has already applied — see the
+    /// parameter contract) is what handles Windows 8.3 short names: on Windows its normalization
+    /// expands any component that exists on disk, turning <c>PROGRA~1</c> into
+    /// <c>Program Files</c>. The <see cref="FileSystemInfo.ResolveLinkTarget(bool)"/> step here
+    /// then covers symlinks and junctions, which normalization leaves intact.
+    /// </para>
+    /// <para>
+    /// A component that does not exist is left exactly as written, because there is nothing on
+    /// disk to expand it against. That is harmless for both callers: a protected directory that
+    /// does not exist holds nothing to protect, and a literal <c>AGENT-~1</c> path then names a
+    /// genuinely different directory rather than aliasing the protected one.
+    /// </para>
+    /// <para>
+    /// Hard links are deliberately <em>not</em> covered, and cannot be: a hard link is a second
+    /// directory entry for the same file, not a reparse point, so there is no link target to
+    /// resolve and the canonical form of a hard link is the hard link itself. Containment of a
+    /// protected directory inside an allowed base path is therefore asserted at boot by
+    /// <see cref="FileSystemSandboxStartupValidator"/> rather than defended per-path here.
+    /// </para>
+    /// </remarks>
+    /// <param name="normalizedPath">
+    /// The path to canonicalize. Must already be <see cref="PathScope.Normalize"/>d. The
+    /// precondition is load-bearing on the error path: when the entry cannot be inspected this
+    /// method returns its input unchanged, so an un-normalized input would leak a relative or
+    /// trailing-separator form into a containment comparison that assumes normalized operands.
+    /// </param>
+    /// <returns>The canonical absolute path, or <paramref name="normalizedPath"/> when the entry
+    /// cannot be inspected (missing, unreadable, or not a supported path shape).</returns>
+    public static string Canonicalize(string normalizedPath)
+    {
+        try
+        {
+            // One stat answers both "does it exist" and "is it a directory"; a missing entry throws
+            // and is caught below. ResolveLinkTarget(returnFinalTarget) then canonicalizes the entry —
+            // for a path that does not exist yet the normalized form is the best available answer.
+            var info = File.GetAttributes(normalizedPath).HasFlag(FileAttributes.Directory)
+                ? new DirectoryInfo(normalizedPath)
+                : (FileSystemInfo)new FileInfo(normalizedPath);
+
+            return PathScope.Normalize(info.ResolveLinkTarget(true)?.FullName ?? info.FullName);
+        }
+        catch (Exception ex) when (ex is IOException
+                                      or UnauthorizedAccessException
+                                      or ArgumentException
+                                      or NotSupportedException)
+        {
+            // Fail closed by returning the literal path: callers treat the result as the entry's
+            // identity, and an unresolvable entry must not be credited with a different one.
+            // NotSupportedException covers path shapes the runtime rejects outright (a Windows
+            // path with an embedded colon, for example); without it the exception would escape
+            // SearchFilesAsync unhandled instead of producing a clean deny.
+            return normalizedPath;
+        }
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/SandboxPathCanonicalizer.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/SandboxPathCanonicalizer.cs
@@ -36,9 +36,10 @@ internal static class SandboxPathCanonicalizer
     /// <para>
     /// Hard links are deliberately <em>not</em> covered, and cannot be: a hard link is a second
     /// directory entry for the same file, not a reparse point, so there is no link target to
-    /// resolve and the canonical form of a hard link is the hard link itself. Containment of a
-    /// protected directory inside an allowed base path is therefore asserted at boot by
-    /// <see cref="FileSystemSandboxStartupValidator"/> rather than defended per-path here.
+    /// resolve and the canonical form of a hard link is the hard link itself. No path-based
+    /// canonicalization can close that, and no allowlist geometry can either — a hard link needs
+    /// only the same volume as its target. It is closed instead by asking the operating system for
+    /// the file's link count, via <see cref="HardLinkInspector"/>, at the point of use.
     /// </para>
     /// </remarks>
     /// <param name="normalizedPath">

--- a/src/Content/Presentation/Presentation.AgentHub/appsettings.json
+++ b/src/Content/Presentation/Presentation.AgentHub/appsettings.json
@@ -28,6 +28,15 @@
         "EnableAudit": true,
         "EnableMetrics": true,
         "InjectionBlockThreshold": "High",
+        "DurableState": {
+          "EscalationsEnabled": false,
+          "ChangeProposalsEnabled": false,
+          "DatabasePath": ".agent-state/governance-state.db",
+          "ReconcileIntervalSeconds": 300,
+          "RetentionDays": 90,
+          "MaxScanRecords": 10000,
+          "MaxPayloadBytes": 1048576
+        },
         "Escalation": {
           "Enabled": true,
           "DefaultTimeoutSeconds": 300,

--- a/src/Content/Presentation/Presentation.BundleApi/appsettings.json
+++ b/src/Content/Presentation/Presentation.BundleApi/appsettings.json
@@ -32,6 +32,15 @@
         "EnableAudit": true,
         "EnableMetrics": true,
         "InjectionBlockThreshold": "High",
+        "DurableState": {
+          "EscalationsEnabled": false,
+          "ChangeProposalsEnabled": false,
+          "DatabasePath": ".agent-state/governance-state.db",
+          "ReconcileIntervalSeconds": 300,
+          "RetentionDays": 90,
+          "MaxScanRecords": 10000,
+          "MaxPayloadBytes": 1048576
+        },
         "Escalation": {
           "Enabled": true,
           "DefaultTimeoutSeconds": 300,

--- a/src/Content/Presentation/Presentation.Common/Escalations/EscalationsController.cs
+++ b/src/Content/Presentation/Presentation.Common/Escalations/EscalationsController.cs
@@ -191,15 +191,19 @@ public sealed class EscalationsController : ControllerBase
     }
 
     /// <summary>
-    /// Maps a decision status to its HTTP response. EVERY <see cref="EscalationDecisionStatus"/>
-    /// member has an explicit arm: an unmapped member falls to the 500 default and turns an
-    /// ordinary, well-understood lifecycle state into a server error, which is the defect this
-    /// exhaustive mapping exists to prevent.
+    /// Maps a decision status to its HTTP response. Every status that reaches this method has an
+    /// explicit arm: an unmapped member falls to the 500 default and turns an ordinary,
+    /// well-understood lifecycle state into a server error, which is the defect the exhaustive
+    /// mapping exists to prevent.
     /// </summary>
     /// <remarks>
-    /// UnknownEscalation → 404, ApproverNotAuthorized → 403, DecisionRecorded → 202,
-    /// Resolved → 200, ConflictingDecision → 409, AwaitingReconciliation → 409. The 500 default
-    /// survives only as a guard for a status added to the enum without being mapped here.
+    /// UnknownEscalation → 404, ApproverNotAuthorized → 403, DecisionRecorded → 202, Resolved → 200.
+    /// The two conflict statuses never arrive here: <see cref="SubmitEscalationDecisionCommandHandler"/>
+    /// converts ConflictingDecision and AwaitingReconciliation into a Conflict failure in the
+    /// Application layer, which <c>MapFailure</c> renders as a 409 — so the conflict is reported the
+    /// same way to every consumer, not just this transport. That handler owns the exhaustiveness
+    /// guarantee for them; the 500 default here survives only as a guard for a status added to the
+    /// enum without being mapped in either place.
     /// </remarks>
     /// <param name="value">The successful decision result to translate.</param>
     private IActionResult MapDecisionStatus(SubmitEscalationDecisionResult value) => value.Status switch
@@ -216,27 +220,6 @@ public sealed class EscalationsController : ControllerBase
             Accepted(new EscalationDecisionResponse(value.Status, null)),
         EscalationDecisionStatus.Resolved =>
             Ok(new EscalationDecisionResponse(value.Status, value.Outcome)),
-
-        // Normally never reaches here: SubmitEscalationDecisionCommandHandler translates a
-        // changed vote into a Conflict failure that MapFailure renders. The arm is kept so a
-        // handler change cannot silently demote that conflict into a 500.
-        EscalationDecisionStatus.ConflictingDecision => Problem(
-            title: "Conflict",
-            detail: "A decision by this approver with the opposite verdict is already recorded; " +
-                    "votes cannot be changed.",
-            statusCode: StatusCodes.Status409Conflict),
-
-        // 409, not 503. The escalation already reached a verdict before this vote arrived, so
-        // the vote was NOT counted and never will be — repeating the request is guaranteed to
-        // produce the same answer, which is a state conflict, not the transient unavailability
-        // 503 would advertise. The verdict itself is not lost: reconciliation re-drives it.
-        EscalationDecisionStatus.AwaitingReconciliation => Problem(
-            title: "Conflict",
-            detail: "The escalation had already reached a verdict whose durable record could not be " +
-                    "written, so it is parked awaiting reconciliation. This decision was not counted " +
-                    "and will not be; retrying it will not change that. Poll GET /api/escalations/{id} " +
-                    "for the final outcome.",
-            statusCode: StatusCodes.Status409Conflict),
 
         _ => Problem(
             title: "Escalation operation failed",

--- a/src/Content/Presentation/Presentation.Common/Escalations/EscalationsController.cs
+++ b/src/Content/Presentation/Presentation.Common/Escalations/EscalationsController.cs
@@ -156,7 +156,12 @@ public sealed class EscalationsController : ControllerBase
     /// <response code="401">Caller is not authenticated.</response>
     /// <response code="403">Caller lacks <see cref="DecideRole"/>, has no approver identity claim, or is not on this escalation's roster.</response>
     /// <response code="404">No pending escalation with the given id.</response>
-    /// <response code="409">This approver already recorded the opposite verdict; votes cannot be changed. (A repeat with the same verdict echoes 202.)</response>
+    /// <response code="409">
+    /// Either this approver already recorded the opposite verdict (votes cannot be changed; a
+    /// repeat with the same verdict echoes 202), or the escalation had already reached a verdict
+    /// that failed its durable/audit write and is parked awaiting reconciliation — in which case
+    /// this decision was not counted and never will be. Poll <c>GET /{id}</c> for the outcome.
+    /// </response>
     [HttpPost("{id:guid}/decision")]
     [Authorize(Roles = DecideRole)]
     [ProducesResponseType(typeof(EscalationDecisionResponse), StatusCodes.Status200OK)]
@@ -182,33 +187,62 @@ public sealed class EscalationsController : ControllerBase
             Reason = request.Reason
         }, cancellationToken).ConfigureAwait(false);
 
-        if (!result.IsSuccess)
-            return MapFailure(result);
-
-        // The four decision statuses map exactly as documented on EscalationDecisionStatus:
-        // UnknownEscalation → 404, ApproverNotAuthorized → 403, DecisionRecorded → 202,
-        // Resolved → 200.
-        var value = result.Value!;
-        return value.Status switch
-        {
-            EscalationDecisionStatus.UnknownEscalation => Problem(
-                title: "Not found",
-                detail: "No pending escalation with the given id.",
-                statusCode: StatusCodes.Status404NotFound),
-            EscalationDecisionStatus.ApproverNotAuthorized => Problem(
-                title: "Forbidden",
-                detail: "The caller is not on this escalation's approver roster.",
-                statusCode: StatusCodes.Status403Forbidden),
-            EscalationDecisionStatus.DecisionRecorded =>
-                Accepted(new EscalationDecisionResponse(value.Status, null)),
-            EscalationDecisionStatus.Resolved =>
-                Ok(new EscalationDecisionResponse(value.Status, value.Outcome)),
-            _ => Problem(
-                title: "Escalation operation failed",
-                detail: "An error occurred processing the request. See server logs for details.",
-                statusCode: StatusCodes.Status500InternalServerError)
-        };
+        return result.IsSuccess ? MapDecisionStatus(result.Value!) : MapFailure(result);
     }
+
+    /// <summary>
+    /// Maps a decision status to its HTTP response. EVERY <see cref="EscalationDecisionStatus"/>
+    /// member has an explicit arm: an unmapped member falls to the 500 default and turns an
+    /// ordinary, well-understood lifecycle state into a server error, which is the defect this
+    /// exhaustive mapping exists to prevent.
+    /// </summary>
+    /// <remarks>
+    /// UnknownEscalation → 404, ApproverNotAuthorized → 403, DecisionRecorded → 202,
+    /// Resolved → 200, ConflictingDecision → 409, AwaitingReconciliation → 409. The 500 default
+    /// survives only as a guard for a status added to the enum without being mapped here.
+    /// </remarks>
+    /// <param name="value">The successful decision result to translate.</param>
+    private IActionResult MapDecisionStatus(SubmitEscalationDecisionResult value) => value.Status switch
+    {
+        EscalationDecisionStatus.UnknownEscalation => Problem(
+            title: "Not found",
+            detail: "No pending escalation with the given id.",
+            statusCode: StatusCodes.Status404NotFound),
+        EscalationDecisionStatus.ApproverNotAuthorized => Problem(
+            title: "Forbidden",
+            detail: "The caller is not on this escalation's approver roster.",
+            statusCode: StatusCodes.Status403Forbidden),
+        EscalationDecisionStatus.DecisionRecorded =>
+            Accepted(new EscalationDecisionResponse(value.Status, null)),
+        EscalationDecisionStatus.Resolved =>
+            Ok(new EscalationDecisionResponse(value.Status, value.Outcome)),
+
+        // Normally never reaches here: SubmitEscalationDecisionCommandHandler translates a
+        // changed vote into a Conflict failure that MapFailure renders. The arm is kept so a
+        // handler change cannot silently demote that conflict into a 500.
+        EscalationDecisionStatus.ConflictingDecision => Problem(
+            title: "Conflict",
+            detail: "A decision by this approver with the opposite verdict is already recorded; " +
+                    "votes cannot be changed.",
+            statusCode: StatusCodes.Status409Conflict),
+
+        // 409, not 503. The escalation already reached a verdict before this vote arrived, so
+        // the vote was NOT counted and never will be — repeating the request is guaranteed to
+        // produce the same answer, which is a state conflict, not the transient unavailability
+        // 503 would advertise. The verdict itself is not lost: reconciliation re-drives it.
+        EscalationDecisionStatus.AwaitingReconciliation => Problem(
+            title: "Conflict",
+            detail: "The escalation had already reached a verdict whose durable record could not be " +
+                    "written, so it is parked awaiting reconciliation. This decision was not counted " +
+                    "and will not be; retrying it will not change that. Poll GET /api/escalations/{id} " +
+                    "for the final outcome.",
+            statusCode: StatusCodes.Status409Conflict),
+
+        _ => Problem(
+            title: "Escalation operation failed",
+            detail: "An error occurred processing the request. See server logs for details.",
+            statusCode: StatusCodes.Status500InternalServerError)
+    };
 
     /// <summary>
     /// Administratively cancels a pending escalation, resolving it as denied and releasing any

--- a/src/Content/Presentation/Presentation.ConsoleUI/appsettings.json
+++ b/src/Content/Presentation/Presentation.ConsoleUI/appsettings.json
@@ -39,6 +39,15 @@
         "EnableAudit": true,
         "EnableMetrics": true,
         "InjectionBlockThreshold": "High",
+        "DurableState": {
+          "EscalationsEnabled": false,
+          "ChangeProposalsEnabled": false,
+          "DatabasePath": ".agent-state/governance-state.db",
+          "ReconcileIntervalSeconds": 300,
+          "RetentionDays": 90,
+          "MaxScanRecords": 10000,
+          "MaxPayloadBytes": 1048576
+        },
         "Escalation": {
           "Enabled": true,
           "DefaultTimeoutSeconds": 300,

--- a/src/Content/Presentation/Presentation.EvalRunner/HarmonicWriteEval/HarmonicWriteEvalCli.cs
+++ b/src/Content/Presentation/Presentation.EvalRunner/HarmonicWriteEval/HarmonicWriteEvalCli.cs
@@ -121,6 +121,12 @@ public static class HarmonicWriteEvalCli
     // Offline runs need no services (deterministic providers touch nothing). The paid path builds the eval
     // host so the chat-client factory + judge resolve; hosted services are intentionally not started — the
     // chat client and judge are constructed on demand and depend only on configuration.
+    //
+    // DO NOT copy this pattern into an agent-bearing host. Not starting hosted services also skips every
+    // startup validator registered as one — FileSystemSandboxStartupValidator among them — so a host built
+    // this way would run agents with its sandbox assertions never having executed. It is safe HERE only
+    // because this container never resolves IFileSystemService, ITool or IMediator and never runs an agent
+    // turn; the moment any of that changes, this must become a started host.
     private static ServiceProvider BuildProvider(bool useLlm)
     {
         var services = new ServiceCollection();

--- a/src/Content/Presentation/Presentation.EvalRunner/appsettings.json
+++ b/src/Content/Presentation/Presentation.EvalRunner/appsettings.json
@@ -39,6 +39,15 @@
         "EnableAudit": true,
         "EnableMetrics": true,
         "InjectionBlockThreshold": "High",
+        "DurableState": {
+          "EscalationsEnabled": false,
+          "ChangeProposalsEnabled": false,
+          "DatabasePath": ".agent-state/governance-state.db",
+          "ReconcileIntervalSeconds": 300,
+          "RetentionDays": 90,
+          "MaxScanRecords": 10000,
+          "MaxPayloadBytes": 1048576
+        },
         "Escalation": {
           "Enabled": true,
           "DefaultTimeoutSeconds": 300,

--- a/src/Content/Presentation/Presentation.FoundryHost/appsettings.json
+++ b/src/Content/Presentation/Presentation.FoundryHost/appsettings.json
@@ -32,6 +32,15 @@
         "EnableAudit": true,
         "EnableMetrics": true,
         "InjectionBlockThreshold": "High",
+        "DurableState": {
+          "EscalationsEnabled": false,
+          "ChangeProposalsEnabled": false,
+          "DatabasePath": ".agent-state/governance-state.db",
+          "ReconcileIntervalSeconds": 300,
+          "RetentionDays": 90,
+          "MaxScanRecords": 10000,
+          "MaxPayloadBytes": 1048576
+        },
         "Escalation": {
           "Enabled": true,
           "DefaultTimeoutSeconds": 300,

--- a/src/Content/Tests/Application.Core.Tests/CQRS/Escalation/SubmitEscalationDecisionCommandHandlerTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/CQRS/Escalation/SubmitEscalationDecisionCommandHandlerTests.cs
@@ -10,9 +10,11 @@ namespace Application.Core.Tests.CQRS.Escalation;
 
 /// <summary>
 /// Tests for <see cref="SubmitEscalationDecisionCommandHandler"/> — the handler builds the
-/// domain decision faithfully (identity, verdict, reason, server-stamped timestamp) and passes
-/// every one of the four discriminated service statuses through as reportable data, never as a
-/// failure.
+/// domain decision faithfully (identity, verdict, reason, server-stamped timestamp), passes the
+/// non-conflict service statuses through as reportable data, and translates the two conflict
+/// statuses into a <c>Conflict</c> failure. That translation lives here, in the Application layer,
+/// so every consumer inherits it rather than each transport re-deriving it; these tests are
+/// therefore the guard that survives a transport dropping its own mapping.
 /// </summary>
 public sealed class SubmitEscalationDecisionCommandHandlerTests
 {
@@ -105,6 +107,94 @@ public sealed class SubmitEscalationDecisionCommandHandlerTests
         result.IsSuccess.Should().BeFalse();
         result.FailureType.Should().Be(Domain.Common.ResultFailureType.Conflict);
     }
+
+    [Fact]
+    public async Task Handle_AwaitingReconciliation_ReturnsConflictFailure()
+    {
+        // Reachable in the DEFAULT durability-off config: approver A's decision resolves the
+        // escalation, the fail-closed audit write throws, the escalation parks with
+        // ResolutionFailed set, and approver B's decision then comes back AwaitingReconciliation.
+        // It is translated HERE rather than at a transport so every consumer — including the
+        // console approvals example, which never touches HTTP — sees the conflict.
+        _service.Setup(s => s.SubmitDecisionAsync(It.IsAny<Guid>(), It.IsAny<ApproverDecision>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(EscalationDecisionResult.AwaitingReconciliation());
+
+        var result = await _handler.Handle(NewCommand(), CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.FailureType.Should().Be(Domain.Common.ResultFailureType.Conflict,
+            "the verdict is already decided, so this vote will never be counted no matter how often " +
+            "the request is retried — a state conflict, not transient unavailability");
+        result.Errors.Should().ContainSingle().Which.Should().Contain("not counted",
+            "the approver must be told plainly that their vote did not participate");
+    }
+
+    [Theory]
+    [InlineData(EscalationDecisionStatus.ConflictingDecision)]
+    [InlineData(EscalationDecisionStatus.AwaitingReconciliation)]
+    public async Task Handle_ConflictStatuses_CarryTheirOwnDistinctDetail(EscalationDecisionStatus status)
+    {
+        // Both conflicts share a status code but not a cause, and an approver acting on the
+        // message needs to know which happened: "your vote was rejected because you already voted
+        // the other way" and "the escalation was already decided without your vote" call for
+        // different next steps. Collapsing them to one generic 409 body would hide that.
+        _service.Setup(s => s.SubmitDecisionAsync(It.IsAny<Guid>(), It.IsAny<ApproverDecision>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ResultForStatus(status));
+
+        var result = await _handler.Handle(NewCommand(), CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        var expectedFragment = status == EscalationDecisionStatus.ConflictingDecision
+            ? "votes cannot be changed"
+            : "awaiting reconciliation";
+        result.Errors.Should().ContainSingle().Which.Should().Contain(expectedFragment);
+    }
+
+    [Fact]
+    public async Task Handle_EveryDecisionStatus_IsEitherConflictFailureOrPassedThroughAsData()
+    {
+        // The guard for the whole defect class, and the reason it lives here rather than in the
+        // controller: a status added to the enum without a decision about its meaning used to
+        // reach the controller's switch and fall through to a 500. This handler is now the single
+        // place that classifies conflicts, so an unclassified member must fail HERE — where every
+        // consumer inherits the answer — not once per transport.
+        foreach (var status in Enum.GetValues<EscalationDecisionStatus>())
+        {
+            _service.Reset();
+            _service.Setup(s => s.SubmitDecisionAsync(It.IsAny<Guid>(), It.IsAny<ApproverDecision>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(ResultForStatus(status));
+
+            var result = await _handler.Handle(NewCommand(), CancellationToken.None);
+
+            if (result.IsSuccess)
+            {
+                result.Value!.Status.Should().Be(status,
+                    $"EscalationDecisionStatus.{status} must reach the transport unchanged when it is not a conflict");
+            }
+            else
+            {
+                result.FailureType.Should().Be(Domain.Common.ResultFailureType.Conflict,
+                    $"EscalationDecisionStatus.{status} is reported as a failure, and Conflict is the only " +
+                    "failure type this handler is allowed to produce — anything else maps to a 5xx");
+                result.Errors.Should().NotBeEmpty(
+                    $"EscalationDecisionStatus.{status} is rejected, so the caller must be told why");
+            }
+        }
+    }
+
+    private static EscalationDecisionResult ResultForStatus(EscalationDecisionStatus status) => status switch
+    {
+        EscalationDecisionStatus.UnknownEscalation => EscalationDecisionResult.UnknownEscalation(),
+        EscalationDecisionStatus.ApproverNotAuthorized => EscalationDecisionResult.ApproverNotAuthorized(),
+        EscalationDecisionStatus.DecisionRecorded => EscalationDecisionResult.DecisionRecorded(),
+        EscalationDecisionStatus.ConflictingDecision => EscalationDecisionResult.ConflictingDecision(),
+        EscalationDecisionStatus.AwaitingReconciliation => EscalationDecisionResult.AwaitingReconciliation(),
+        EscalationDecisionStatus.Resolved =>
+            EscalationDecisionResult.Resolved(EscalationTestData.NewOutcome(Guid.NewGuid(), approved: true)),
+        _ => throw new ArgumentOutOfRangeException(
+            nameof(status), status,
+            "A new EscalationDecisionStatus has no test factory; add one so the exhaustiveness guard covers it.")
+    };
 
     [Fact]
     public async Task Handle_Resolved_ReturnsSuccessCarryingProjectedOutcome()

--- a/src/Content/Tests/Infrastructure.AI.Tests/Changes/EfCoreChangeProposalStoreTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Changes/EfCoreChangeProposalStoreTests.cs
@@ -1,0 +1,253 @@
+using Application.AI.Common.Interfaces.Changes;
+using Domain.AI.Changes;
+using FluentAssertions;
+using Infrastructure.AI.Changes;
+using Infrastructure.AI.Persistence;
+using Infrastructure.AI.Tests.Changes.Support;
+using Infrastructure.AI.Tests.Escalation.Support;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Changes;
+
+/// <summary>
+/// Tests for <see cref="EfCoreChangeProposalStore"/>: contract parity with
+/// <see cref="InMemoryChangeProposalStore"/> (round-trip, idempotent upsert, list filters,
+/// ordering, caps), durability across simulated restarts (a new store instance over the same
+/// database file), and polymorphic <see cref="ChangeTarget"/> round-tripping.
+/// </summary>
+public sealed class EfCoreChangeProposalStoreTests : IDisposable
+{
+    private readonly string _dbPath;
+    private readonly DbContextOptions<GovernanceStateDbContext> _options;
+
+    public EfCoreChangeProposalStoreTests()
+    {
+        _dbPath = Path.Combine(Path.GetTempPath(), $"gov-state-test-{Guid.NewGuid():N}.db");
+        _options = new DbContextOptionsBuilder<GovernanceStateDbContext>()
+            .UseSqlite($"DataSource={_dbPath}")
+            .Options;
+    }
+
+    public void Dispose()
+    {
+        Microsoft.Data.Sqlite.SqliteConnection.ClearAllPools();
+        try
+        {
+            File.Delete(_dbPath);
+        }
+        catch (IOException)
+        {
+            // Best-effort temp cleanup; the OS temp folder reaps leftovers.
+        }
+    }
+
+    private readonly FakeGovernanceRecordSealer _sealer = new();
+
+    private EfCoreChangeProposalStore CreateStore(int maxPayloadBytes = 1024 * 1024)
+    {
+        var factory = new TestContextFactory(_options);
+        return new EfCoreChangeProposalStore(
+            factory,
+            new GovernanceStateSchemaInitializer(factory),
+            _sealer,
+            GovernanceStateTestConfig.Monitor(maxPayloadBytes: maxPayloadBytes),
+            NullLogger<EfCoreChangeProposalStore>.Instance);
+    }
+
+    // ===== Contract parity with the in-memory store =====
+
+    [Fact]
+    public async Task SaveAndGet_RoundTripsFullAggregate()
+    {
+        var store = CreateStore();
+        var proposal = TestProposals.NewProposal() with
+        {
+            History =
+            [
+                new GateDecision
+                {
+                    Timestamp = TestProposals.DefaultTime.AddMinutes(1),
+                    GateKey = "self_validation",
+                    Action = GateAction.Pass,
+                    Reason = "looks fine",
+                    DurationMs = 12
+                }
+            ]
+        };
+
+        await store.SaveAsync(proposal, CancellationToken.None);
+        var fetched = await store.GetAsync(proposal.Id, CancellationToken.None);
+
+        fetched.Should().BeEquivalentTo(proposal);
+    }
+
+    [Fact]
+    public async Task Save_Idempotent_OverwritesByLastWrite()
+    {
+        var store = CreateStore();
+        var initial = TestProposals.NewProposal();
+        await store.SaveAsync(initial, CancellationToken.None);
+        var updated = initial with { Status = ChangeProposalStatus.Validating };
+
+        await store.SaveAsync(updated, CancellationToken.None);
+        var fetched = await store.GetAsync(initial.Id, CancellationToken.None);
+
+        fetched!.Status.Should().Be(ChangeProposalStatus.Validating);
+    }
+
+    [Fact]
+    public async Task Get_UnknownId_ReturnsNull()
+    {
+        var store = CreateStore();
+        var fetched = await store.GetAsync("missing", CancellationToken.None);
+        fetched.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task List_FiltersByStatus()
+    {
+        var store = CreateStore();
+        var draft = TestProposals.NewProposal();
+        var awaiting = draft with { Id = draft.Id + "-2", Status = ChangeProposalStatus.AwaitingApproval };
+        await store.SaveAsync(draft, CancellationToken.None);
+        await store.SaveAsync(awaiting, CancellationToken.None);
+
+        var results = await store.ListAsync(
+            new ChangeProposalQuery { Status = ChangeProposalStatus.AwaitingApproval },
+            CancellationToken.None);
+
+        results.Should().ContainSingle().Which.Status.Should().Be(ChangeProposalStatus.AwaitingApproval);
+    }
+
+    [Fact]
+    public async Task List_FiltersBySubmitterBlastRadiusAndTargetKind()
+    {
+        var store = CreateStore();
+        var low = TestProposals.NewProposal(blastRadius: BlastRadius.Low);
+        var high = TestProposals.NewProposal(blastRadius: BlastRadius.High) with { Id = low.Id + "-high" };
+        var otherAgent = low with
+        {
+            Id = low.Id + "-other",
+            SubmittedBy = TestProposals.DefaultIdentity with { Id = "agent-002" }
+        };
+        await store.SaveAsync(low, CancellationToken.None);
+        await store.SaveAsync(high, CancellationToken.None);
+        await store.SaveAsync(otherAgent, CancellationToken.None);
+
+        var byRadius = await store.ListAsync(
+            new ChangeProposalQuery { MinimumBlastRadius = BlastRadius.High },
+            CancellationToken.None);
+        var bySubmitter = await store.ListAsync(
+            new ChangeProposalQuery { SubmittedByAgentId = "agent-002" },
+            CancellationToken.None);
+        var byKind = await store.ListAsync(
+            new ChangeProposalQuery { TargetKind = ChangeTargetKind.GitRepo },
+            CancellationToken.None);
+
+        byRadius.Should().ContainSingle().Which.Id.Should().Be(high.Id);
+        bySubmitter.Should().ContainSingle().Which.Id.Should().Be(otherAgent.Id);
+        byKind.Should().HaveCount(3);
+    }
+
+    [Fact]
+    public async Task List_OrdersMostRecentFirst_AndRespectsMaxResults()
+    {
+        var store = CreateStore();
+        var baseline = TestProposals.NewProposal();
+        for (var i = 0; i < 5; i++)
+        {
+            var p = baseline with
+            {
+                Id = $"id-{i}",
+                SubmittedAt = TestProposals.DefaultTime.AddMinutes(i)
+            };
+            await store.SaveAsync(p, CancellationToken.None);
+        }
+
+        var results = await store.ListAsync(
+            new ChangeProposalQuery { MaxResults = 2 },
+            CancellationToken.None);
+
+        results.Should().HaveCount(2);
+        results[0].Id.Should().Be("id-4");
+        results[1].Id.Should().Be("id-3");
+    }
+
+    [Fact]
+    public async Task List_NonPositiveMaxResults_ReturnsEmpty()
+    {
+        var store = CreateStore();
+        await store.SaveAsync(TestProposals.NewProposal(), CancellationToken.None);
+
+        var results = await store.ListAsync(
+            new ChangeProposalQuery { MaxResults = 0 },
+            CancellationToken.None);
+
+        results.Should().BeEmpty();
+    }
+
+    // ===== Durability across restart =====
+
+    [Fact]
+    public async Task Get_AfterNewStoreInstanceOverSameDatabase_SurvivesRestart()
+    {
+        var proposal = TestProposals.NewProposal() with { Status = ChangeProposalStatus.AwaitingApproval };
+        await CreateStore().SaveAsync(proposal, CancellationToken.None);
+
+        // Simulated restart: a brand-new store (and context factory) over the same file.
+        var rebooted = CreateStore();
+        var fetched = await rebooted.GetAsync(proposal.Id, CancellationToken.None);
+        var pending = await rebooted.ListAsync(
+            new ChangeProposalQuery { Status = ChangeProposalStatus.AwaitingApproval },
+            CancellationToken.None);
+
+        fetched.Should().BeEquivalentTo(proposal);
+        pending.Should().ContainSingle().Which.Id.Should().Be(proposal.Id);
+    }
+
+    // ===== Polymorphic target round-trip =====
+
+    [Fact]
+    public async Task Save_KubernetesAndIacTargets_RoundTripWithCanonicalKey()
+    {
+        var store = CreateStore();
+        var k8s = ChangeProposal.Create(
+            new KubernetesResourceTarget("ctx", "apps/v1", "Deployment", "default", "api"),
+            [new ChangeEdit { Op = Domain.AI.SkillTraining.EditOp.Replace, Target = "replicas: 1", Content = "replicas: 2" }],
+            TestProposals.DefaultIdentity,
+            "scale api",
+            BlastRadius.Medium,
+            [WellKnownGateKeys.Approval],
+            TestProposals.DefaultTime);
+        var iac = ChangeProposal.Create(
+            new IacDeploymentTarget("bicep", "core-net", "modules/net", "prod"),
+            [new ChangeEdit { Op = Domain.AI.SkillTraining.EditOp.Append, Content = "tag: v2" }],
+            TestProposals.DefaultIdentity,
+            "tag deployment",
+            BlastRadius.High,
+            [WellKnownGateKeys.Approval],
+            TestProposals.DefaultTime);
+        await store.SaveAsync(k8s, CancellationToken.None);
+        await store.SaveAsync(iac, CancellationToken.None);
+
+        var k8sBack = await store.GetAsync(k8s.Id, CancellationToken.None);
+        var iacBack = await store.GetAsync(iac.Id, CancellationToken.None);
+
+        k8sBack!.Target.Should().BeOfType<KubernetesResourceTarget>();
+        k8sBack.Target.CanonicalKey().Should().Be(k8s.Target.CanonicalKey());
+        iacBack!.Target.Should().BeOfType<IacDeploymentTarget>();
+        iacBack.Target.CanonicalKey().Should().Be(iac.Target.CanonicalKey());
+    }
+
+    /// <summary>
+    /// Minimal <see cref="IDbContextFactory{TContext}"/> over fixed options, mirroring the
+    /// planner store tests' factory double.
+    /// </summary>
+    private sealed class TestContextFactory(DbContextOptions<GovernanceStateDbContext> options)
+        : IDbContextFactory<GovernanceStateDbContext>
+    {
+        public GovernanceStateDbContext CreateDbContext() => new(options);
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Escalation/DefaultEscalationServiceTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Escalation/DefaultEscalationServiceTests.cs
@@ -50,6 +50,7 @@ public sealed class DefaultEscalationServiceTests : IDisposable
 			serviceProvider,
 			_notifier.Object,
 			_auditStore.Object,
+			new NullEscalationStateStore(),
 			configMonitor.Object,
 			NullLogger<DefaultEscalationService>.Instance);
 	}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Escalation/DurableEscalationHardeningTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Escalation/DurableEscalationHardeningTests.cs
@@ -365,6 +365,45 @@ public sealed class DurableEscalationHardeningTests : IDisposable
 		resolved.Should().EndWith("governance-state.db");
 	}
 
+	[Fact]
+	public void Resolve_CaseVariantSiblingDirectory_FollowsHostFilesystemCaseRules()
+	{
+		// The containment check must use the HOST's case rules, not a hardcoded case-insensitive
+		// comparison. On Linux — where this ships in containers — /app and /App are different
+		// directories, so a case-insensitive check would accept a path that genuinely escapes the
+		// application directory and let the approval-verdict database be written outside it.
+		var stem = Path.Combine(Path.GetTempPath(), $"gov-root-{Guid.NewGuid():N}");
+		var root = stem + "-lower";
+		var caseVariant = stem + "-LOWER";
+
+		var act = () => GovernanceStatePaths.Resolve(
+			Path.Combine(caseVariant, "governance-state.db"), root);
+
+		if (OperatingSystem.IsWindows())
+		{
+			// Windows paths are case-insensitive, so the variant IS the same directory.
+			act.Should().NotThrow();
+		}
+		else
+		{
+			act.Should().Throw<ArgumentException>(
+				"under ordinal (Linux) semantics the case variant is a different directory, so it " +
+				"escapes the application directory and must be rejected");
+		}
+	}
+
+	[Fact]
+	public void Resolve_ApplicationDirectoryItself_Throws()
+	{
+		// The configured value must name a database FILE. Containment alone would admit the root,
+		// which is a directory — caught here rather than as an opaque SQLite open failure later.
+		var root = Path.Combine(Path.GetTempPath(), $"gov-root-{Guid.NewGuid():N}");
+
+		var act = () => GovernanceStatePaths.Resolve(".", root);
+
+		act.Should().Throw<ArgumentException>();
+	}
+
 	/// <summary>Minimal context factory over fixed options.</summary>
 	private sealed class TestContextFactory(DbContextOptions<GovernanceStateDbContext> options)
 		: IDbContextFactory<GovernanceStateDbContext>

--- a/src/Content/Tests/Infrastructure.AI.Tests/Escalation/DurableEscalationHardeningTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Escalation/DurableEscalationHardeningTests.cs
@@ -1,0 +1,374 @@
+using Application.AI.Common.Interfaces.Escalation;
+using Domain.AI.Escalation;
+using Domain.Common.Config;
+using FluentAssertions;
+using Infrastructure.AI.Escalation;
+using Infrastructure.AI.Persistence;
+using Infrastructure.AI.Tests.Escalation.Support;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Escalation;
+
+/// <summary>
+/// Regression tests for the hardening review findings: a poisoned row must not stop host
+/// startup, an invariant-violating row must not rehydrate as a live escalation, reconciliation
+/// must actually run in a hosted context, concurrent approvals must not lose a decision, and a
+/// tampered outcome must never be re-driven into the compliance audit log.
+/// </summary>
+public sealed class DurableEscalationHardeningTests : IDisposable
+{
+	private readonly Mock<IEscalationNotifier> _notifier = new();
+	private readonly Mock<IEscalationAuditStore> _auditStore = new();
+	private readonly Mock<IApprovalStrategy> _allOfStrategy = new();
+	private readonly IServiceProvider _serviceProvider;
+	private readonly FakeGovernanceRecordSealer _sealer = new();
+	private readonly string _dbPath;
+	private readonly DbContextOptions<GovernanceStateDbContext> _dbOptions;
+	private readonly List<DefaultEscalationService> _services = [];
+
+	public DurableEscalationHardeningTests()
+	{
+		_allOfStrategy.Setup(s => s.StrategyType).Returns(ApprovalStrategyType.AllOf);
+
+		// AllOf: resolves only once every roster member has approved. This is the strategy that
+		// exposes the lost-decision race — non-resolving approvals accumulate.
+		_allOfStrategy
+			.Setup(s => s.EvaluateDecision(
+				It.IsAny<EscalationRequest>(), It.IsAny<IReadOnlyList<ApproverDecision>>()))
+			.Returns((EscalationRequest request, IReadOnlyList<ApproverDecision> decisions) =>
+				new ApprovalEvaluation
+				{
+					IsResolved = decisions.Count >= request.Approvers.Count && decisions.All(d => d.Approved),
+					IsApproved = decisions.Count >= request.Approvers.Count && decisions.All(d => d.Approved),
+					PendingApprovers = []
+				});
+
+		var services = new ServiceCollection();
+		services.AddKeyedSingleton<IApprovalStrategy>(
+			ApprovalStrategyType.AllOf, (_, _) => _allOfStrategy.Object);
+		_serviceProvider = services.BuildServiceProvider();
+
+		_dbPath = Path.Combine(Path.GetTempPath(), $"gov-harden-{Guid.NewGuid():N}.db");
+		_dbOptions = new DbContextOptionsBuilder<GovernanceStateDbContext>()
+			.UseSqlite($"DataSource={_dbPath}")
+			.Options;
+	}
+
+	public void Dispose()
+	{
+		foreach (var service in _services)
+			service.Dispose();
+		SqliteConnection.ClearAllPools();
+		try
+		{
+			File.Delete(_dbPath);
+		}
+		catch (IOException)
+		{
+			// Best-effort temp cleanup.
+		}
+	}
+
+	// --- Helpers ---
+
+	private EfCoreEscalationStateStore CreateDurableStore()
+	{
+		var factory = new TestContextFactory(_dbOptions);
+		return new EfCoreEscalationStateStore(
+			factory,
+			new GovernanceStateSchemaInitializer(factory),
+			_sealer,
+			GovernanceStateTestConfig.Monitor(),
+			NullLogger<EfCoreEscalationStateStore>.Instance);
+	}
+
+	private DefaultEscalationService CreateService(IEscalationStateStore stateStore)
+	{
+		var configMonitor = new Mock<IOptionsMonitor<Domain.Common.Config.AI.Governance.EscalationConfig>>();
+		configMonitor.Setup(m => m.CurrentValue)
+			.Returns(new Domain.Common.Config.AI.Governance.EscalationConfig { Enabled = true });
+
+		var service = new DefaultEscalationService(
+			_serviceProvider,
+			_notifier.Object,
+			_auditStore.Object,
+			stateStore,
+			configMonitor.Object,
+			NullLogger<DefaultEscalationService>.Instance);
+		_services.Add(service);
+		return service;
+	}
+
+	private static EscalationRequest CreateRequest(
+		IReadOnlyList<string>? approvers = null,
+		int timeoutSeconds = 300,
+		EscalationTimeoutAction timeoutAction = EscalationTimeoutAction.DenyAndEscalate) => new()
+		{
+			EscalationId = Guid.NewGuid(),
+			AgentId = "agent-001",
+			ToolName = "dangerous_tool",
+			Arguments = new Dictionary<string, string>(),
+			Description = "Test escalation",
+			RiskLevel = RiskLevel.High,
+			Priority = EscalationPriority.Blocking,
+			ApprovalStrategy = ApprovalStrategyType.AllOf,
+			Approvers = approvers ?? ["approver-1", "approver-2"],
+			TimeoutSeconds = timeoutSeconds,
+			TimeoutAction = timeoutAction,
+			RequestedAt = DateTimeOffset.UtcNow
+		};
+
+	private static ApproverDecision Approval(string approverName) => new()
+	{
+		ApproverName = approverName,
+		Approved = true,
+		RespondedAt = DateTimeOffset.UtcNow
+	};
+
+	private async Task InsertRawRowAsync(
+		Guid id, string status, string requestJson, long createdAtTicks, string decisionsJson = "[]")
+	{
+		await using var context = new GovernanceStateDbContext(_dbOptions);
+		await context.Database.EnsureCreatedAsync();
+		await context.Database.ExecuteSqlRawAsync(
+			"INSERT INTO escalation_state (Id, Status, RequestJson, DecisionsJson, OutcomeJson, OutcomeSealJson, CreatedAtTicks, UpdatedAtTicks) " +
+			"VALUES ({0}, {1}, {2}, {3}, NULL, NULL, {4}, {5});",
+			id, status, requestJson, decisionsJson, createdAtTicks, DateTimeOffset.UtcNow.UtcTicks);
+	}
+
+	private static string SerializeRequest(EscalationRequest request) =>
+		System.Text.Json.JsonSerializer.Serialize(request, GovernanceStateJson.Options);
+
+	// ===== HIGH-3: a poisoned timestamp must not fail startup =====
+
+	[Fact]
+	public async Task GetActiveAsync_RowWithOutOfRangeTimestamp_SkipsRowInsteadOfThrowing()
+	{
+		var healthy = CreateRequest();
+		var poisoned = CreateRequest();
+
+		await InsertRawRowAsync(
+			healthy.EscalationId, nameof(EscalationPersistedStatus.Pending),
+			SerializeRequest(healthy), DateTimeOffset.UtcNow.UtcTicks);
+
+		// long.MaxValue ticks is outside DateTimeOffset's range: converting it throws
+		// ArgumentOutOfRangeException. Before the fix this threw inside ToListAsync — outside
+		// any per-row guard — so GetActiveAsync faulted and took host startup down with it.
+		await InsertRawRowAsync(
+			poisoned.EscalationId, nameof(EscalationPersistedStatus.Pending),
+			SerializeRequest(poisoned), long.MaxValue);
+
+		var active = await CreateDurableStore().GetActiveAsync(CancellationToken.None);
+
+		active.Should().ContainSingle()
+			.Which.Request.EscalationId.Should().Be(healthy.EscalationId);
+	}
+
+	[Fact]
+	public async Task RehydratePendingEscalationsAsync_PoisonedRowPresent_StillRestoresHealthyEscalations()
+	{
+		var healthy = CreateRequest();
+		await InsertRawRowAsync(
+			healthy.EscalationId, nameof(EscalationPersistedStatus.Pending),
+			SerializeRequest(healthy), DateTimeOffset.UtcNow.UtcTicks);
+		await InsertRawRowAsync(
+			Guid.NewGuid(), nameof(EscalationPersistedStatus.Pending),
+			"{ this is not json", DateTimeOffset.UtcNow.UtcTicks);
+
+		var service = CreateService(CreateDurableStore());
+		var restored = await service.RehydratePendingEscalationsAsync(CancellationToken.None);
+
+		restored.Should().Be(1);
+		(await service.GetPendingEscalationAsync(healthy.EscalationId, CancellationToken.None))
+			.Should().NotBeNull();
+	}
+
+	// ===== HIGH-2: invariant-violating rows must not rehydrate =====
+
+	[Fact]
+	public async Task RehydratePendingEscalationsAsync_EmptyRosterWithTimeoutApprove_IsSkipped()
+	{
+		// The exact fail-open shape: nobody can vote, and AllOf would treat "nobody pending" as
+		// vacuously unanimous while TimeoutAction.Approve grants it silently.
+		var invalid = CreateRequest(approvers: [], timeoutAction: EscalationTimeoutAction.Approve);
+		await InsertRawRowAsync(
+			invalid.EscalationId, nameof(EscalationPersistedStatus.Pending),
+			SerializeRequest(invalid), DateTimeOffset.UtcNow.UtcTicks);
+
+		var service = CreateService(CreateDurableStore());
+		var restored = await service.RehydratePendingEscalationsAsync(CancellationToken.None);
+
+		restored.Should().Be(0);
+		(await service.GetPendingEscalationAsync(invalid.EscalationId, CancellationToken.None))
+			.Should().BeNull();
+		(await service.GetOutcomeAsync(invalid.EscalationId, CancellationToken.None))
+			.Should().BeNull();
+	}
+
+	[Fact]
+	public async Task RehydratePendingEscalationsAsync_ZeroQuorumThreshold_IsSkipped()
+	{
+		var invalid = CreateRequest() with
+		{
+			ApprovalStrategy = ApprovalStrategyType.Quorum,
+			QuorumThreshold = 0
+		};
+		await InsertRawRowAsync(
+			invalid.EscalationId, nameof(EscalationPersistedStatus.Pending),
+			SerializeRequest(invalid), DateTimeOffset.UtcNow.UtcTicks);
+
+		var restored = await CreateService(CreateDurableStore())
+			.RehydratePendingEscalationsAsync(CancellationToken.None);
+
+		restored.Should().Be(0);
+	}
+
+	[Fact]
+	public async Task RehydratePendingEscalationsAsync_TimeoutBeyondDelayCeiling_IsSkipped()
+	{
+		// Above the ceiling the resumed Task.Delay throws, RunTimeoutAsync's catch-all swallows
+		// it, and the escalation becomes immortal — pending forever with no expiry.
+		var invalid = CreateRequest(timeoutSeconds: int.MaxValue);
+		await InsertRawRowAsync(
+			invalid.EscalationId, nameof(EscalationPersistedStatus.Pending),
+			SerializeRequest(invalid), DateTimeOffset.UtcNow.UtcTicks);
+
+		var restored = await CreateService(CreateDurableStore())
+			.RehydratePendingEscalationsAsync(CancellationToken.None);
+
+		restored.Should().Be(0);
+	}
+
+	[Fact]
+	public async Task QueueEscalationAsync_TimeoutBeyondDelayCeiling_IsRejectedAtCreation()
+	{
+		var service = CreateService(new NullEscalationStateStore());
+
+		var act = () => service.QueueEscalationAsync(
+			CreateRequest(timeoutSeconds: int.MaxValue), CancellationToken.None);
+
+		await act.Should().ThrowAsync<InvalidOperationException>();
+	}
+
+	// ===== HIGH-4: concurrent approvals must not lose a decision =====
+
+	[Fact]
+	public async Task SubmitDecisionAsync_ConcurrentNonResolvingApprovals_PersistsEveryDecision()
+	{
+		var request = CreateRequest(approvers: ["approver-1", "approver-2", "approver-3"]);
+		var store = CreateDurableStore();
+		var service = CreateService(store);
+		await service.QueueEscalationAsync(request, CancellationToken.None);
+
+		// Two approvals racing. Each builds its snapshot under the state lock; before the fix
+		// the durable write happened after releasing it, so the two writes could land out of
+		// order and last-write-wins persisted the shorter list — silently losing an approval
+		// that in-memory state still showed.
+		await Task.WhenAll(
+			Task.Run(() => service.SubmitDecisionAsync(request.EscalationId, Approval("approver-1"), CancellationToken.None)),
+			Task.Run(() => service.SubmitDecisionAsync(request.EscalationId, Approval("approver-2"), CancellationToken.None)));
+
+		var active = await store.GetActiveAsync(CancellationToken.None);
+		var snapshot = active.Should().ContainSingle().Subject;
+		snapshot.Decisions.Should().HaveCount(2);
+		snapshot.Decisions.Select(d => d.ApproverName)
+			.Should().BeEquivalentTo(["approver-1", "approver-2"]);
+	}
+
+	// ===== MED: tampered outcomes are never re-driven =====
+
+	[Fact]
+	public async Task ReconcileStuckEscalationsAsync_OutcomeSealDoesNotVerify_RefusesToReDrive()
+	{
+		var request = CreateRequest(approvers: ["approver-1"]);
+		var store = CreateDurableStore();
+		await store.SavePendingAsync(request, DateTimeOffset.UtcNow, CancellationToken.None);
+		await store.MarkResolvedPendingAuditAsync(
+			new EscalationOutcome
+			{
+				EscalationId = request.EscalationId,
+				IsApproved = true,
+				Decisions = [],
+				ResolutionType = EscalationResolutionType.Approved,
+				ResolvedAt = DateTimeOffset.UtcNow,
+				Approvers = request.Approvers
+			},
+			CancellationToken.None);
+
+		// Simulates a row edited outside the process: the payload no longer matches its seal.
+		_sealer.ForceVerificationFailure = true;
+
+		var reconcile = await CreateService(store)
+			.ReconcileStuckEscalationsAsync(CancellationToken.None);
+
+		reconcile.Recovered.Should().BeEmpty();
+		_auditStore.Verify(
+			a => a.RecordOutcomeAsync(It.IsAny<EscalationOutcome>(), It.IsAny<CancellationToken>()),
+			Times.Never,
+			"a verdict that fails seal verification must never reach the hash-chained audit log");
+	}
+
+	// ===== MED: rehydrated + expired + TimeoutAction.Approve must not auto-approve =====
+
+	[Fact]
+	public async Task RehydratedEscalation_ExpiredDuringDowntimeWithTimeoutApprove_ResolvesDenied()
+	{
+		var request = CreateRequest(timeoutSeconds: 1, timeoutAction: EscalationTimeoutAction.Approve);
+		var store = CreateDurableStore();
+		// Created well before the deadline elapsed — the "queued before a long deploy" shape.
+		await store.SavePendingAsync(request, DateTimeOffset.UtcNow.AddMinutes(-30), CancellationToken.None);
+
+		var service = CreateService(store);
+		(await service.RehydratePendingEscalationsAsync(CancellationToken.None)).Should().Be(1);
+
+		using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+		EscalationOutcome? outcome = null;
+		while (outcome is null)
+		{
+			outcome = await service.GetOutcomeAsync(request.EscalationId, CancellationToken.None);
+			cts.Token.ThrowIfCancellationRequested();
+			await Task.Delay(20, cts.Token);
+		}
+
+		outcome.ResolutionType.Should().Be(EscalationResolutionType.TimedOut);
+		outcome.IsApproved.Should().BeFalse(
+			"an escalation that expired while the host was down was seen by no approver, and " +
+			"rehydration re-sends no notifications, so granting it would be a fail-open");
+	}
+
+	// ===== Path containment =====
+
+	[Fact]
+	public void Resolve_PathEscapingApplicationDirectory_Throws()
+	{
+		var root = Path.Combine(Path.GetTempPath(), $"gov-root-{Guid.NewGuid():N}");
+
+		var act = () => GovernanceStatePaths.Resolve("../outside/governance-state.db", root);
+
+		act.Should().Throw<ArgumentException>();
+	}
+
+	[Fact]
+	public void Resolve_RelativePathUnderApplicationDirectory_ReturnsAbsolutePath()
+	{
+		var root = Path.Combine(Path.GetTempPath(), $"gov-root-{Guid.NewGuid():N}");
+
+		var resolved = GovernanceStatePaths.Resolve(".agent-state/governance-state.db", root);
+
+		resolved.Should().StartWith(Path.GetFullPath(root));
+		resolved.Should().EndWith("governance-state.db");
+	}
+
+	/// <summary>Minimal context factory over fixed options.</summary>
+	private sealed class TestContextFactory(DbContextOptions<GovernanceStateDbContext> options)
+		: IDbContextFactory<GovernanceStateDbContext>
+	{
+		public GovernanceStateDbContext CreateDbContext() => new(options);
+	}
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Escalation/DurableEscalationServiceTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Escalation/DurableEscalationServiceTests.cs
@@ -1,0 +1,421 @@
+using Application.AI.Common.Interfaces.Escalation;
+using Domain.AI.Escalation;
+using Domain.Common.Config.AI.Governance;
+using FluentAssertions;
+using Application.AI.Common.Exceptions;
+using Infrastructure.AI.Escalation;
+using Infrastructure.AI.Persistence;
+using Infrastructure.AI.Tests.Escalation.Support;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Escalation;
+
+/// <summary>
+/// Durability tests for <see cref="DefaultEscalationService"/>: rehydration after a simulated
+/// restart (a new service instance over the same SQLite file), decide-after-restart, timeout
+/// resumption across downtime, fail-closed behavior when the durable write fails, and the
+/// <see cref="IEscalationReconciler"/> recovery path for the audit-outage stuck state —
+/// in-memory and post-restart shapes, including idempotency of repeated passes.
+/// </summary>
+public sealed class DurableEscalationServiceTests : IDisposable
+{
+	private readonly Mock<IEscalationNotifier> _notifier = new();
+	private readonly Mock<IEscalationAuditStore> _auditStore = new();
+	private readonly Mock<IApprovalStrategy> _anyOfStrategy = new();
+	private readonly IServiceProvider _serviceProvider;
+	private readonly string _dbPath;
+	private readonly DbContextOptions<GovernanceStateDbContext> _dbOptions;
+	private readonly FakeGovernanceRecordSealer _sealer = new();
+	private readonly List<DefaultEscalationService> _services = [];
+
+	public DurableEscalationServiceTests()
+	{
+		_anyOfStrategy.Setup(s => s.StrategyType).Returns(ApprovalStrategyType.AnyOf);
+		_anyOfStrategy
+			.Setup(s => s.EvaluateDecision(
+				It.IsAny<EscalationRequest>(),
+				It.IsAny<IReadOnlyList<ApproverDecision>>()))
+			.Returns((EscalationRequest _, IReadOnlyList<ApproverDecision> decisions) =>
+				decisions.Any(d => d.Approved)
+					? new ApprovalEvaluation { IsResolved = true, IsApproved = true, PendingApprovers = [] }
+					: new ApprovalEvaluation { IsResolved = false, IsApproved = false, PendingApprovers = ["pending"] });
+
+		var services = new ServiceCollection();
+		services.AddKeyedSingleton<IApprovalStrategy>(
+			ApprovalStrategyType.AnyOf, (_, _) => _anyOfStrategy.Object);
+		_serviceProvider = services.BuildServiceProvider();
+
+		_dbPath = Path.Combine(Path.GetTempPath(), $"gov-state-test-{Guid.NewGuid():N}.db");
+		_dbOptions = new DbContextOptionsBuilder<GovernanceStateDbContext>()
+			.UseSqlite($"DataSource={_dbPath}")
+			.Options;
+	}
+
+	public void Dispose()
+	{
+		foreach (var service in _services)
+			service.Dispose();
+		Microsoft.Data.Sqlite.SqliteConnection.ClearAllPools();
+		try
+		{
+			File.Delete(_dbPath);
+		}
+		catch (IOException)
+		{
+			// Best-effort temp cleanup; the OS temp folder reaps leftovers.
+		}
+	}
+
+	// --- Helpers ---
+
+	private DefaultEscalationService CreateService(IEscalationStateStore stateStore)
+	{
+		var configMonitor = new Mock<IOptionsMonitor<EscalationConfig>>();
+		configMonitor.Setup(m => m.CurrentValue).Returns(new EscalationConfig
+		{
+			Enabled = true,
+			DefaultTimeoutSeconds = 300,
+			DefaultApprovalStrategy = "AnyOf"
+		});
+
+		var service = new DefaultEscalationService(
+			_serviceProvider,
+			_notifier.Object,
+			_auditStore.Object,
+			stateStore,
+			configMonitor.Object,
+			NullLogger<DefaultEscalationService>.Instance);
+		_services.Add(service);
+		return service;
+	}
+
+	private EfCoreEscalationStateStore CreateDurableStore()
+	{
+		var factory = new TestContextFactory(_dbOptions);
+		return new EfCoreEscalationStateStore(
+			factory,
+			new GovernanceStateSchemaInitializer(factory),
+			_sealer,
+			GovernanceStateTestConfig.Monitor(),
+			NullLogger<EfCoreEscalationStateStore>.Instance);
+	}
+
+	private static EscalationRequest CreateRequest(int timeoutSeconds = 300) => new()
+	{
+		EscalationId = Guid.NewGuid(),
+		AgentId = "agent-001",
+		ToolName = "dangerous_tool",
+		Arguments = new Dictionary<string, string> { ["arg1"] = "value1" },
+		Description = "Test escalation",
+		RiskLevel = RiskLevel.High,
+		Priority = EscalationPriority.Blocking,
+		ApprovalStrategy = ApprovalStrategyType.AnyOf,
+		Approvers = ["approver-1", "approver-2"],
+		TimeoutSeconds = timeoutSeconds,
+		TimeoutAction = EscalationTimeoutAction.DenyAndEscalate,
+		RequestedAt = DateTimeOffset.UtcNow
+	};
+
+	private static ApproverDecision CreateApproval(string approverName = "approver-1") => new()
+	{
+		ApproverName = approverName,
+		Approved = true,
+		Reason = "Looks good",
+		RespondedAt = DateTimeOffset.UtcNow
+	};
+
+	private void FailOutcomeAudit() =>
+		_auditStore
+			.Setup(a => a.RecordOutcomeAsync(It.IsAny<EscalationOutcome>(), It.IsAny<CancellationToken>()))
+			.ThrowsAsync(new IOException("audit store unavailable"));
+
+	private void HealOutcomeAudit() =>
+		_auditStore
+			.Setup(a => a.RecordOutcomeAsync(It.IsAny<EscalationOutcome>(), It.IsAny<CancellationToken>()))
+			.Returns(Task.CompletedTask);
+
+	private static async Task<EscalationOutcome> PollOutcomeAsync(
+		DefaultEscalationService service, Guid escalationId)
+	{
+		using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+		while (true)
+		{
+			var outcome = await service.GetOutcomeAsync(escalationId, CancellationToken.None);
+			if (outcome is not null)
+				return outcome;
+			cts.Token.ThrowIfCancellationRequested();
+			await Task.Delay(20, cts.Token);
+		}
+	}
+
+	// ===== Rehydration after restart =====
+
+	[Fact]
+	public async Task RehydratePendingEscalationsAsync_AfterRestart_RestoresPendingEscalation()
+	{
+		var request = CreateRequest();
+		var first = CreateService(CreateDurableStore());
+		await first.QueueEscalationAsync(request, CancellationToken.None);
+		first.Dispose();
+
+		// Simulated restart: fresh service + fresh store over the same database file.
+		var rebooted = CreateService(CreateDurableStore());
+		var restored = await rebooted.RehydratePendingEscalationsAsync(CancellationToken.None);
+
+		restored.Should().Be(1);
+		(await rebooted.GetPendingEscalationAsync(request.EscalationId, CancellationToken.None))
+			.Should().BeEquivalentTo(request);
+		(await rebooted.GetPendingEscalationsAsync("approver-1", CancellationToken.None))
+			.Should().ContainSingle().Which.EscalationId.Should().Be(request.EscalationId);
+	}
+
+	[Fact]
+	public async Task SubmitDecisionAsync_AfterRestart_ResolvesAndOutcomeSurvivesSecondRestart()
+	{
+		var request = CreateRequest();
+		var first = CreateService(CreateDurableStore());
+		await first.QueueEscalationAsync(request, CancellationToken.None);
+		first.Dispose();
+
+		var rebooted = CreateService(CreateDurableStore());
+		await rebooted.RehydratePendingEscalationsAsync(CancellationToken.None);
+		var result = await rebooted.SubmitDecisionAsync(
+			request.EscalationId, CreateApproval(), CancellationToken.None);
+
+		result.Status.Should().Be(EscalationDecisionStatus.Resolved);
+
+		// Second restart: the audited outcome must be durably queryable with no rehydration.
+		var third = CreateService(CreateDurableStore());
+		var outcome = await third.GetOutcomeAsync(request.EscalationId, CancellationToken.None);
+		outcome!.IsApproved.Should().BeTrue();
+		outcome.ResolutionType.Should().Be(EscalationResolutionType.Approved);
+	}
+
+	[Fact]
+	public async Task RehydratePendingEscalationsAsync_TimeoutExpiredDuringDowntime_TimesOutImmediately()
+	{
+		var request = CreateRequest(timeoutSeconds: 1);
+		var first = CreateService(CreateDurableStore());
+		await first.QueueEscalationAsync(request, CancellationToken.None);
+		first.Dispose(); // kills the in-process timeout task; the durable row stays Pending
+
+		await Task.Delay(TimeSpan.FromSeconds(1.5));
+
+		var rebooted = CreateService(CreateDurableStore());
+		var restored = await rebooted.RehydratePendingEscalationsAsync(CancellationToken.None);
+		restored.Should().Be(1);
+
+		// Downtime counted against the timeout budget: the rehydrated escalation expires
+		// immediately via its configured timeout action instead of restarting the clock.
+		var outcome = await PollOutcomeAsync(rebooted, request.EscalationId);
+		outcome.ResolutionType.Should().Be(EscalationResolutionType.TimedOut);
+		outcome.IsApproved.Should().BeFalse();
+	}
+
+	// ===== Fail-closed durable writes =====
+
+	[Fact]
+	public async Task QueueEscalationAsync_DurableCreateFails_EscalationNotOpened()
+	{
+		var store = new TogglableStateStore { FailPending = true };
+		var service = CreateService(store);
+		var request = CreateRequest();
+
+		var act = () => service.QueueEscalationAsync(request, CancellationToken.None);
+
+		// Scrubbed at the service boundary: the raw provider exception never escapes toward a
+		// transport, only a stable code, with the original preserved for structured logging.
+		var thrown = await act.Should().ThrowAsync<EscalationDurableStateException>();
+		thrown.Which.Code.Should().Be(EscalationDurableStateException.DurableCreateFailedCode);
+		thrown.Which.Message.Should().NotContain("durable store unavailable");
+		thrown.Which.InnerException.Should().BeOfType<IOException>();
+
+		(await service.GetPendingEscalationAsync(request.EscalationId, CancellationToken.None))
+			.Should().BeNull();
+	}
+
+	[Fact]
+	public async Task SubmitDecisionAsync_DurableDecisionWriteFails_FailsClosedAndRetrySucceeds()
+	{
+		var store = new TogglableStateStore();
+		var service = CreateService(store);
+		var request = CreateRequest();
+		await service.QueueEscalationAsync(request, CancellationToken.None);
+
+		store.FailDecisions = true;
+		var act = () => service.SubmitDecisionAsync(request.EscalationId, CreateApproval(), CancellationToken.None);
+		var thrown = await act.Should().ThrowAsync<EscalationDurableStateException>();
+		thrown.Which.Code.Should().Be(EscalationDurableStateException.DurableWriteFailedCode);
+		thrown.Which.Message.Should().NotContain("durable store unavailable");
+
+		// Fail-closed: still pending, and the ghost decision was backed out — the SAME
+		// approver's retry must not be rejected as a duplicate once the store recovers.
+		(await service.GetPendingEscalationAsync(request.EscalationId, CancellationToken.None))
+			.Should().NotBeNull();
+
+		store.FailDecisions = false;
+		var result = await service.SubmitDecisionAsync(
+			request.EscalationId, CreateApproval(), CancellationToken.None);
+		result.Status.Should().Be(EscalationDecisionStatus.Resolved);
+	}
+
+	// ===== Reconcile: the audit-outage recovery path =====
+
+	[Fact]
+	public async Task ReconcileStuckEscalationsAsync_AuditOutageDuringDecide_RecoversOnceHealed()
+	{
+		var service = CreateService(new NullEscalationStateStore());
+		var request = CreateRequest();
+		await service.QueueEscalationAsync(request, CancellationToken.None);
+
+		FailOutcomeAudit();
+		var act = () => service.SubmitDecisionAsync(request.EscalationId, CreateApproval(), CancellationToken.None);
+		await act.Should().ThrowAsync<IOException>();
+
+		// Fail-closed: not reported resolved, still observable, and no outcome served.
+		(await service.GetPendingEscalationAsync(request.EscalationId, CancellationToken.None))
+			.Should().NotBeNull();
+		(await service.GetOutcomeAsync(request.EscalationId, CancellationToken.None))
+			.Should().BeNull();
+
+		HealOutcomeAudit();
+		var reconcile = await service.ReconcileStuckEscalationsAsync(CancellationToken.None);
+
+		reconcile.Recovered.Should().ContainSingle().Which.Should().Be(request.EscalationId);
+		reconcile.StillStuck.Should().BeEmpty();
+		(await service.GetOutcomeAsync(request.EscalationId, CancellationToken.None))!
+			.IsApproved.Should().BeTrue();
+		(await service.GetPendingEscalationAsync(request.EscalationId, CancellationToken.None))
+			.Should().BeNull();
+
+		// Idempotency: a second pass over a healthy system recovers nothing.
+		var second = await service.ReconcileStuckEscalationsAsync(CancellationToken.None);
+		second.Recovered.Should().BeEmpty();
+		second.StillStuck.Should().BeEmpty();
+	}
+
+	[Fact]
+	public async Task ReconcileStuckEscalationsAsync_AuditStillDown_ReportsStillStuck()
+	{
+		var service = CreateService(new NullEscalationStateStore());
+		var request = CreateRequest();
+		await service.QueueEscalationAsync(request, CancellationToken.None);
+
+		FailOutcomeAudit();
+		var act = () => service.SubmitDecisionAsync(request.EscalationId, CreateApproval(), CancellationToken.None);
+		await act.Should().ThrowAsync<IOException>();
+
+		var reconcile = await service.ReconcileStuckEscalationsAsync(CancellationToken.None);
+
+		reconcile.Recovered.Should().BeEmpty();
+		reconcile.StillStuck.Should().ContainSingle().Which.Should().Be(request.EscalationId);
+		(await service.GetOutcomeAsync(request.EscalationId, CancellationToken.None))
+			.Should().BeNull();
+
+		// The stuck state stays claimable: a later pass with a healed audit store recovers it.
+		HealOutcomeAudit();
+		var healed = await service.ReconcileStuckEscalationsAsync(CancellationToken.None);
+		healed.Recovered.Should().ContainSingle().Which.Should().Be(request.EscalationId);
+	}
+
+	[Fact]
+	public async Task ReconcileStuckEscalationsAsync_AfterRestart_FinalizesDurableStuckRecord()
+	{
+		var request = CreateRequest();
+		var first = CreateService(CreateDurableStore());
+		await first.QueueEscalationAsync(request, CancellationToken.None);
+
+		FailOutcomeAudit();
+		var act = () => first.SubmitDecisionAsync(request.EscalationId, CreateApproval(), CancellationToken.None);
+		await act.Should().ThrowAsync<IOException>();
+		first.Dispose();
+
+		// Restart: the record is ResolvedPendingAudit, so it must NOT rehydrate as pending —
+		// its resolution already happened; only the audit write is owed.
+		var rebooted = CreateService(CreateDurableStore());
+		(await rebooted.RehydratePendingEscalationsAsync(CancellationToken.None)).Should().Be(0);
+
+		HealOutcomeAudit();
+		var reconcile = await rebooted.ReconcileStuckEscalationsAsync(CancellationToken.None);
+
+		reconcile.Recovered.Should().ContainSingle().Which.Should().Be(request.EscalationId);
+		var outcome = await rebooted.GetOutcomeAsync(request.EscalationId, CancellationToken.None);
+		outcome!.IsApproved.Should().BeTrue();
+
+		// A third restart still serves the audited outcome from the durable store.
+		var third = CreateService(CreateDurableStore());
+		(await third.GetOutcomeAsync(request.EscalationId, CancellationToken.None))!
+			.IsApproved.Should().BeTrue();
+	}
+
+	// ===== Flag-off parity =====
+
+	[Fact]
+	public async Task GetOutcomeAsync_NullStore_UnknownEscalation_ReturnsNull()
+	{
+		var service = CreateService(new NullEscalationStateStore());
+
+		var outcome = await service.GetOutcomeAsync(Guid.NewGuid(), CancellationToken.None);
+
+		outcome.Should().BeNull();
+	}
+
+	/// <summary>
+	/// Delegates to <see cref="NullEscalationStateStore"/> with per-operation failure toggles,
+	/// for exercising the fail-closed durable-write paths deterministically.
+	/// </summary>
+	private sealed class TogglableStateStore : IEscalationStateStore
+	{
+		private readonly NullEscalationStateStore _inner = new();
+
+		public bool FailPending { get; set; }
+		public bool FailDecisions { get; set; }
+
+		public Task SavePendingAsync(EscalationRequest request, DateTimeOffset createdAt, CancellationToken ct)
+			=> FailPending
+				? throw new IOException("durable store unavailable")
+				: _inner.SavePendingAsync(request, createdAt, ct);
+
+		public Task SaveDecisionsAsync(Guid escalationId, IReadOnlyList<ApproverDecision> decisions, CancellationToken ct)
+			=> FailDecisions
+				? throw new IOException("durable store unavailable")
+				: _inner.SaveDecisionsAsync(escalationId, decisions, ct);
+
+		public Task MarkResolvedPendingAuditAsync(EscalationOutcome outcome, CancellationToken ct)
+			=> _inner.MarkResolvedPendingAuditAsync(outcome, ct);
+
+		public Task MarkResolvedAsync(Guid escalationId, CancellationToken ct)
+			=> _inner.MarkResolvedAsync(escalationId, ct);
+
+		public Task RemoveAsync(Guid escalationId, CancellationToken ct)
+			=> _inner.RemoveAsync(escalationId, ct);
+
+		public Task<bool> TryClaimResolvedPendingAuditAsync(
+			Guid escalationId, DateTimeOffset staleClaimBefore, CancellationToken ct)
+			=> _inner.TryClaimResolvedPendingAuditAsync(escalationId, staleClaimBefore, ct);
+
+		public Task ReleaseClaimAsync(Guid escalationId, CancellationToken ct)
+			=> _inner.ReleaseClaimAsync(escalationId, ct);
+
+		public Task<IReadOnlyList<EscalationStateSnapshot>> GetActiveAsync(CancellationToken ct)
+			=> _inner.GetActiveAsync(ct);
+
+		public Task<EscalationOutcome?> GetResolvedOutcomeAsync(Guid escalationId, CancellationToken ct)
+			=> _inner.GetResolvedOutcomeAsync(escalationId, ct);
+	}
+
+	/// <summary>
+	/// Minimal <see cref="IDbContextFactory{TContext}"/> over fixed options, mirroring the
+	/// planner store tests' factory double.
+	/// </summary>
+	private sealed class TestContextFactory(DbContextOptions<GovernanceStateDbContext> options)
+		: IDbContextFactory<GovernanceStateDbContext>
+	{
+		public GovernanceStateDbContext CreateDbContext() => new(options);
+	}
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Escalation/EfCoreEscalationStateStoreTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Escalation/EfCoreEscalationStateStoreTests.cs
@@ -1,0 +1,211 @@
+using Application.AI.Common.Interfaces.Escalation;
+using Domain.AI.Escalation;
+using FluentAssertions;
+using Infrastructure.AI.Escalation;
+using Infrastructure.AI.Persistence;
+using Infrastructure.AI.Tests.Escalation.Support;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Escalation;
+
+/// <summary>
+/// Tests for <see cref="EfCoreEscalationStateStore"/>: lifecycle transitions
+/// (Pending → ResolvedPendingAudit → Resolved), the fail-closed visibility rule (an
+/// un-audited outcome is never served), and durability across a new store instance over the
+/// same database file.
+/// </summary>
+public sealed class EfCoreEscalationStateStoreTests : IDisposable
+{
+    private readonly string _dbPath;
+    private readonly DbContextOptions<GovernanceStateDbContext> _options;
+
+    public EfCoreEscalationStateStoreTests()
+    {
+        _dbPath = Path.Combine(Path.GetTempPath(), $"gov-state-test-{Guid.NewGuid():N}.db");
+        _options = new DbContextOptionsBuilder<GovernanceStateDbContext>()
+            .UseSqlite($"DataSource={_dbPath}")
+            .Options;
+    }
+
+    public void Dispose()
+    {
+        Microsoft.Data.Sqlite.SqliteConnection.ClearAllPools();
+        try
+        {
+            File.Delete(_dbPath);
+        }
+        catch (IOException)
+        {
+            // Best-effort temp cleanup; the OS temp folder reaps leftovers.
+        }
+    }
+
+    private readonly FakeGovernanceRecordSealer _sealer = new();
+
+    private EfCoreEscalationStateStore CreateStore(int maxPayloadBytes = 1024 * 1024)
+    {
+        var factory = new TestContextFactory(_options);
+        return new EfCoreEscalationStateStore(
+            factory,
+            new GovernanceStateSchemaInitializer(factory),
+            _sealer,
+            GovernanceStateTestConfig.Monitor(maxPayloadBytes: maxPayloadBytes),
+            NullLogger<EfCoreEscalationStateStore>.Instance);
+    }
+
+    private static EscalationRequest CreateRequest(Guid? id = null) => new()
+    {
+        EscalationId = id ?? Guid.NewGuid(),
+        AgentId = "agent-001",
+        ToolName = "dangerous_tool",
+        Arguments = new Dictionary<string, string> { ["arg1"] = "value1" },
+        Description = "Test escalation",
+        RiskLevel = RiskLevel.High,
+        Priority = EscalationPriority.Blocking,
+        Approvers = ["approver-1", "approver-2"],
+        TimeoutSeconds = 300,
+        RequestedAt = DateTimeOffset.UtcNow
+    };
+
+    private static EscalationOutcome CreateOutcome(Guid escalationId, bool approved = true) => new()
+    {
+        EscalationId = escalationId,
+        IsApproved = approved,
+        Decisions =
+        [
+            new ApproverDecision
+            {
+                ApproverName = "approver-1",
+                Approved = approved,
+                Reason = "reviewed",
+                RespondedAt = DateTimeOffset.UtcNow
+            }
+        ],
+        ResolutionType = approved ? EscalationResolutionType.Approved : EscalationResolutionType.Denied,
+        ResolvedAt = DateTimeOffset.UtcNow,
+        Approvers = ["approver-1", "approver-2"]
+    };
+
+    [Fact]
+    public async Task SavePending_GetActive_RoundTripsRequestAndCreatedAt()
+    {
+        var store = CreateStore();
+        var request = CreateRequest();
+        var createdAt = new DateTimeOffset(2026, 7, 27, 9, 0, 0, TimeSpan.Zero);
+
+        await store.SavePendingAsync(request, createdAt, CancellationToken.None);
+        var active = await store.GetActiveAsync(CancellationToken.None);
+
+        var snapshot = active.Should().ContainSingle().Subject;
+        snapshot.Status.Should().Be(EscalationPersistedStatus.Pending);
+        snapshot.CreatedAt.Should().Be(createdAt);
+        snapshot.Decisions.Should().BeEmpty();
+        snapshot.Outcome.Should().BeNull();
+        snapshot.Request.Should().BeEquivalentTo(request);
+    }
+
+    [Fact]
+    public async Task SaveDecisions_UnknownEscalation_Throws()
+    {
+        var store = CreateStore();
+
+        var act = () => store.SaveDecisionsAsync(Guid.NewGuid(), [], CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+    }
+
+    [Fact]
+    public async Task SaveDecisions_PersistsDecisionList()
+    {
+        var store = CreateStore();
+        var request = CreateRequest();
+        await store.SavePendingAsync(request, DateTimeOffset.UtcNow, CancellationToken.None);
+        var decision = new ApproverDecision
+        {
+            ApproverName = "approver-1",
+            Approved = true,
+            RespondedAt = DateTimeOffset.UtcNow
+        };
+
+        await store.SaveDecisionsAsync(request.EscalationId, [decision], CancellationToken.None);
+        var active = await store.GetActiveAsync(CancellationToken.None);
+
+        active.Should().ContainSingle()
+            .Which.Decisions.Should().ContainSingle()
+            .Which.Should().BeEquivalentTo(decision);
+    }
+
+    [Fact]
+    public async Task MarkResolvedPendingAudit_OutcomeVisibleToReconcile_ButNotToPollers()
+    {
+        var store = CreateStore();
+        var request = CreateRequest();
+        await store.SavePendingAsync(request, DateTimeOffset.UtcNow, CancellationToken.None);
+        var outcome = CreateOutcome(request.EscalationId);
+
+        await store.MarkResolvedPendingAuditAsync(outcome, CancellationToken.None);
+
+        var active = await store.GetActiveAsync(CancellationToken.None);
+        var snapshot = active.Should().ContainSingle().Subject;
+        snapshot.Status.Should().Be(EscalationPersistedStatus.ResolvedPendingAudit);
+        snapshot.Outcome.Should().BeEquivalentTo(outcome);
+
+        // Fail-closed: an outcome whose audit write has not completed must never be served.
+        var polled = await store.GetResolvedOutcomeAsync(request.EscalationId, CancellationToken.None);
+        polled.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task MarkResolved_OutcomeServedToPollers_AndExcludedFromActive()
+    {
+        var store = CreateStore();
+        var request = CreateRequest();
+        await store.SavePendingAsync(request, DateTimeOffset.UtcNow, CancellationToken.None);
+        var outcome = CreateOutcome(request.EscalationId);
+        await store.MarkResolvedPendingAuditAsync(outcome, CancellationToken.None);
+
+        await store.MarkResolvedAsync(request.EscalationId, CancellationToken.None);
+
+        (await store.GetActiveAsync(CancellationToken.None)).Should().BeEmpty();
+        var polled = await store.GetResolvedOutcomeAsync(request.EscalationId, CancellationToken.None);
+        polled.Should().BeEquivalentTo(outcome);
+    }
+
+    [Fact]
+    public async Task Remove_DeletesRecord_AndIsNoOpForUnknownId()
+    {
+        var store = CreateStore();
+        var request = CreateRequest();
+        await store.SavePendingAsync(request, DateTimeOffset.UtcNow, CancellationToken.None);
+
+        await store.RemoveAsync(request.EscalationId, CancellationToken.None);
+        await store.RemoveAsync(Guid.NewGuid(), CancellationToken.None);
+
+        (await store.GetActiveAsync(CancellationToken.None)).Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetActive_AfterNewStoreInstanceOverSameDatabase_SurvivesRestart()
+    {
+        var request = CreateRequest();
+        await CreateStore().SavePendingAsync(request, DateTimeOffset.UtcNow, CancellationToken.None);
+
+        // Simulated restart: a brand-new store (and context factory) over the same file.
+        var active = await CreateStore().GetActiveAsync(CancellationToken.None);
+
+        active.Should().ContainSingle()
+            .Which.Request.EscalationId.Should().Be(request.EscalationId);
+    }
+
+    /// <summary>
+    /// Minimal <see cref="IDbContextFactory{TContext}"/> over fixed options, mirroring the
+    /// planner store tests' factory double.
+    /// </summary>
+    private sealed class TestContextFactory(DbContextOptions<GovernanceStateDbContext> options)
+        : IDbContextFactory<GovernanceStateDbContext>
+    {
+        public GovernanceStateDbContext CreateDbContext() => new(options);
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Escalation/EscalationReconciliationServiceTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Escalation/EscalationReconciliationServiceTests.cs
@@ -69,16 +69,22 @@ public sealed class EscalationReconciliationServiceTests
     }
 
     [Fact]
-    public async Task StartAsync_DurabilityDisabled_NeverReconciles()
+    public async Task StartAsync_DurabilityDisabled_StillReconciles()
     {
+        // The in-memory stuck shape — a resolution whose fail-closed AUDIT write threw — is
+        // caused by the audit store, not the state store, so it happens with durability off.
+        // While the whole loop was gated on the durable toggles, nothing drove recovery in the
+        // default configuration: an escalation parked on an audit outage stayed parked forever,
+        // and AwaitingReconciliation's "poll until reconciliation completes" contract was a lie.
         var service = CreateService(escalationsEnabled: false);
 
         await service.StartAsync(CancellationToken.None);
-        _time.Advance(TimeSpan.FromHours(1));
-        await service.StopAsync(CancellationToken.None);
+        await WaitForReconcileCountAsync(1);
 
-        _reconciler.Verify(
-            r => r.ReconcileStuckEscalationsAsync(It.IsAny<CancellationToken>()), Times.Never);
+        // And it keeps ticking, so a state that gets stuck later is still recovered.
+        await WaitForReconcileCountAsync(2);
+
+        await service.StopAsync(CancellationToken.None);
     }
 
     [Fact]

--- a/src/Content/Tests/Infrastructure.AI.Tests/Escalation/EscalationReconciliationServiceTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Escalation/EscalationReconciliationServiceTests.cs
@@ -1,0 +1,196 @@
+using Application.AI.Common.Interfaces.Escalation;
+using Domain.Common.Config;
+using FluentAssertions;
+using Infrastructure.AI.Escalation;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Time.Testing;
+using Moq;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Escalation;
+
+/// <summary>
+/// Tests for <see cref="EscalationReconciliationService"/> — the production trigger for
+/// escalation reconciliation. Without it the recovery path has no non-test caller, so a crash
+/// between the durable resolution write and the compliance audit write would strand a
+/// human-granted approval permanently.
+/// </summary>
+public sealed class EscalationReconciliationServiceTests
+{
+    private readonly Mock<IEscalationReconciler> _reconciler = new();
+    private readonly Mock<IGovernanceStatePruner> _pruner = new();
+    private readonly FakeTimeProvider _time = new(DateTimeOffset.UtcNow);
+
+    public EscalationReconciliationServiceTests()
+    {
+        _reconciler
+            .Setup(r => r.ReconcileStuckEscalationsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new EscalationReconcileResult { Recovered = [], StillStuck = [] });
+        _pruner
+            .Setup(p => p.PruneAsync(It.IsAny<DateTimeOffset>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new GovernanceStatePruneResult(0, 0));
+    }
+
+    private EscalationReconciliationService CreateService(
+        bool escalationsEnabled, int retentionDays = 90, int intervalSeconds = 300)
+    {
+        var config = new AppConfig();
+        config.AI.Governance.DurableState.EscalationsEnabled = escalationsEnabled;
+        config.AI.Governance.DurableState.RetentionDays = retentionDays;
+        config.AI.Governance.DurableState.ReconcileIntervalSeconds = intervalSeconds;
+
+        var monitor = new Mock<IOptionsMonitor<AppConfig>>();
+        monitor.Setup(m => m.CurrentValue).Returns(config);
+
+        return new EscalationReconciliationService(
+            _reconciler.Object,
+            () => { _prunerResolved = true; return _pruner.Object; },
+            monitor.Object,
+            _time,
+            NullLogger<EscalationReconciliationService>.Instance);
+    }
+
+    private bool _prunerResolved;
+
+    [Fact]
+    public async Task StartAsync_DurabilityDisabled_NeverResolvesThePruner()
+    {
+        // Resolving the pruner constructs the schema initializer, whose EnsureCreated creates
+        // the governance-state database file. A host with durability off must never touch the
+        // filesystem, so the deferred factory must stay uncalled.
+        var service = CreateService(escalationsEnabled: false);
+
+        await service.StartAsync(CancellationToken.None);
+        _time.Advance(TimeSpan.FromHours(1));
+        await service.StopAsync(CancellationToken.None);
+
+        _prunerResolved.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task StartAsync_DurabilityDisabled_NeverReconciles()
+    {
+        var service = CreateService(escalationsEnabled: false);
+
+        await service.StartAsync(CancellationToken.None);
+        _time.Advance(TimeSpan.FromHours(1));
+        await service.StopAsync(CancellationToken.None);
+
+        _reconciler.Verify(
+            r => r.ReconcileStuckEscalationsAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task StartAsync_DurabilityEnabled_RunsFirstPassAfterInitialDelay()
+    {
+        var service = CreateService(escalationsEnabled: true);
+
+        await service.StartAsync(CancellationToken.None);
+
+        // Before the grace period elapses, nothing has run — the host is still booting.
+        _reconciler.Verify(
+            r => r.ReconcileStuckEscalationsAsync(It.IsAny<CancellationToken>()), Times.Never);
+
+        await WaitForReconcileCountAsync(1);
+
+        await service.StopAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task StartAsync_DurabilityEnabled_RunsRepeatedlyOnTheConfiguredInterval()
+    {
+        var service = CreateService(escalationsEnabled: true, intervalSeconds: 300);
+
+        await service.StartAsync(CancellationToken.None);
+        await WaitForReconcileCountAsync(1);
+
+        // The loop keeps ticking: a single pass is not enough, because the stuck records this
+        // recovers can appear at any time after startup.
+        await WaitForReconcileCountAsync(2);
+        await WaitForReconcileCountAsync(3);
+
+        await service.StopAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task StartAsync_ReconcileThrows_KeepsRunningAndRetriesNextInterval()
+    {
+        _reconciler
+            .SetupSequence(r => r.ReconcileStuckEscalationsAsync(It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new IOException("audit store unavailable"))
+            .ReturnsAsync(new EscalationReconcileResult { Recovered = [], StillStuck = [] });
+
+        var service = CreateService(escalationsEnabled: true);
+
+        await service.StartAsync(CancellationToken.None);
+        await WaitForReconcileCountAsync(1);
+
+        // A failing pass must never fault the host's background pipeline.
+        _time.Advance(TimeSpan.FromSeconds(300));
+        await WaitForReconcileCountAsync(2);
+
+        await service.StopAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task StartAsync_RetentionEnabled_PrunesUsingTheConfiguredWindow()
+    {
+        var service = CreateService(escalationsEnabled: true, retentionDays: 30);
+
+        await service.StartAsync(CancellationToken.None);
+        await WaitForReconcileCountAsync(1);
+
+        await WaitForAsync(() => _pruner.Invocations.Count > 0);
+        _pruner.Verify(
+            p => p.PruneAsync(
+                It.Is<DateTimeOffset>(cutoff => cutoff <= _time.GetUtcNow().AddDays(-29)),
+                It.IsAny<CancellationToken>()),
+            Times.AtLeastOnce);
+
+        await service.StopAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task StartAsync_RetentionDisabled_NeverPrunes()
+    {
+        var service = CreateService(escalationsEnabled: true, retentionDays: 0);
+
+        await service.StartAsync(CancellationToken.None);
+        await WaitForReconcileCountAsync(1);
+        await service.StopAsync(CancellationToken.None);
+
+        _pruner.Verify(
+            p => p.PruneAsync(It.IsAny<DateTimeOffset>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    /// <summary>
+    /// Waits until the reconciler has been invoked at least <paramref name="expected"/> times,
+    /// nudging the fake clock while it waits.
+    /// </summary>
+    /// <remarks>
+    /// The loop under test alternates between an <c>await</c> on the reconciler and an
+    /// <c>await Task.Delay(interval, timeProvider)</c>. Its continuations resume on the thread
+    /// pool, so the moment a new timer is registered is not observable from the test thread —
+    /// a single up-front <c>Advance</c> can land before the timer exists and then never fire
+    /// it. Re-advancing on each poll makes the wait independent of that scheduling race while
+    /// still proving the loop actually iterates.
+    /// </remarks>
+    /// <param name="expected">The minimum invocation count to wait for.</param>
+    private Task WaitForReconcileCountAsync(int expected) =>
+        WaitForAsync(() => ReconcileCount >= expected);
+
+    private int ReconcileCount => _reconciler.Invocations.Count(i =>
+        i.Method.Name == nameof(IEscalationReconciler.ReconcileStuckEscalationsAsync));
+
+    private async Task WaitForAsync(Func<bool> condition)
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        while (!condition())
+        {
+            cts.Token.ThrowIfCancellationRequested();
+            _time.Advance(TimeSpan.FromSeconds(31));
+            await Task.Delay(10, cts.Token);
+        }
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Escalation/EscalationReconciliationServiceTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Escalation/EscalationReconciliationServiceTests.cs
@@ -32,6 +32,14 @@ public sealed class EscalationReconciliationServiceTests
             .ReturnsAsync(new GovernanceStatePruneResult(0, 0));
     }
 
+    /// <summary>
+    /// The configuration instance the monitor hands back on every <c>CurrentValue</c> read. Held as
+    /// a field so a test can mutate it mid-run, which is exactly what an operator editing
+    /// <c>appsettings.json</c> does on a host whose configuration was loaded with
+    /// <c>reloadOnChange: true</c>.
+    /// </summary>
+    private AppConfig _config = new();
+
     private EscalationReconciliationService CreateService(
         bool escalationsEnabled, int retentionDays = 90, int intervalSeconds = 300)
     {
@@ -39,6 +47,7 @@ public sealed class EscalationReconciliationServiceTests
         config.AI.Governance.DurableState.EscalationsEnabled = escalationsEnabled;
         config.AI.Governance.DurableState.RetentionDays = retentionDays;
         config.AI.Governance.DurableState.ReconcileIntervalSeconds = intervalSeconds;
+        _config = config;
 
         var monitor = new Mock<IOptionsMonitor<AppConfig>>();
         monitor.Setup(m => m.CurrentValue).Returns(config);
@@ -66,6 +75,47 @@ public sealed class EscalationReconciliationServiceTests
         await service.StopAsync(CancellationToken.None);
 
         _prunerResolved.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task StartAsync_DurabilityEnabledAfterConstruction_StillNeverResolvesThePruner()
+    {
+        // A live edit to appsettings.json must NOT bring the pruner to life, and this is the one
+        // place that guarantee is enforceable. AppConfigHelper loads configuration with
+        // reloadOnChange: true, so IOptionsMonitor.CurrentValue would observe the flip on the very
+        // next tick. Honouring it would resolve the pruner, which constructs the schema
+        // initializer, whose EnsureCreated creates the governance-state database — on a host that
+        // booted with both toggles off.
+        //
+        // Two things break if that happens. The stores are already frozen at first resolution, so
+        // the new database would sit there unwritten while retention pruned a table nothing was
+        // filling. Worse, DependencyInjection.ResolveGovernanceStateProtectedPaths decided at
+        // composition that there was nothing to protect and left the file-system tool's deny list
+        // and hard-link check disarmed — so a database would appear behind a sandbox that had
+        // already concluded it had no reason to guard that directory.
+        var service = CreateService(escalationsEnabled: false);
+
+        await service.StartAsync(CancellationToken.None);
+
+        // Wait for a real pass before touching anything, so the loop is demonstrably running.
+        // Advancing the clock and asserting immediately would prove nothing: the continuation runs
+        // on the thread pool, so the assertion could win the race and pass without a single pass
+        // having executed.
+        await WaitForReconcileCountAsync(1);
+
+        // The operator edits the file. Same instance the monitor hands back, so this is exactly
+        // what a CurrentValue read would observe on the next tick.
+        _config.AI.Governance.DurableState.ChangeProposalsEnabled = true;
+
+        // Three, not two. A pass runs reconcile THEN prune, so observing reconcile #3 is what
+        // proves prune #2 — a prune that unambiguously began after the flip — ran to completion.
+        // Any weaker wait leaves room for the prune step never to have been reached at all.
+        await WaitForReconcileCountAsync(3);
+
+        await service.StopAsync(CancellationToken.None);
+
+        _prunerResolved.Should().BeFalse(
+            "the enable pair is snapshotted at construction, so durability stays off until restart");
     }
 
     [Fact]

--- a/src/Content/Tests/Infrastructure.AI.Tests/Escalation/EscalationResolutionRaceTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Escalation/EscalationResolutionRaceTests.cs
@@ -1,0 +1,521 @@
+using Application.AI.Common.Exceptions;
+using Application.AI.Common.Interfaces.Escalation;
+using Domain.AI.Escalation;
+using Domain.Common.Config;
+using Domain.Common.Config.AI.Governance;
+using FluentAssertions;
+using Infrastructure.AI.Escalation;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Time.Testing;
+using Moq;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Escalation;
+
+/// <summary>
+/// Correctness-review regressions around escalation resolution: the audit-outage parked state
+/// must be recovered on hosts with durable governance state switched OFF, a cancellation racing
+/// a failing decision write must not strand a durable record, and a teardown racing an in-flight
+/// decision must not surface an <see cref="ObjectDisposedException"/> to the approver.
+/// </summary>
+/// <remarks>
+/// All three shapes are reachable in the DEFAULT configuration. The parked state is produced by
+/// the <em>audit</em> store failing, which is independent of the durability toggles, so none of
+/// this is exotic-config-only behaviour.
+/// </remarks>
+public sealed class EscalationResolutionRaceTests : IDisposable
+{
+	private readonly Mock<IEscalationNotifier> _notifier = new();
+	private readonly Mock<IEscalationAuditStore> _auditStore = new();
+	private readonly Mock<IApprovalStrategy> _anyOfStrategy = new();
+	private readonly Mock<IApprovalStrategy> _allOfStrategy = new();
+	private readonly FakeTimeProvider _time = new(DateTimeOffset.UtcNow);
+	private readonly List<DefaultEscalationService> _services = [];
+
+	public EscalationResolutionRaceTests()
+	{
+		// AnyOf: the first approval resolves.
+		_anyOfStrategy.Setup(s => s.StrategyType).Returns(ApprovalStrategyType.AnyOf);
+		_anyOfStrategy
+			.Setup(s => s.EvaluateDecision(
+				It.IsAny<EscalationRequest>(), It.IsAny<IReadOnlyList<ApproverDecision>>()))
+			.Returns((EscalationRequest _, IReadOnlyList<ApproverDecision> decisions) =>
+				decisions.Any(d => d.Approved)
+					? new ApprovalEvaluation { IsResolved = true, IsApproved = true, PendingApprovers = [] }
+					: new ApprovalEvaluation { IsResolved = false, IsApproved = false, PendingApprovers = ["pending"] });
+
+		// AllOf: a single approval on a two-approver roster does NOT resolve. Required by the
+		// cancel-race test — a resolving decision would flip IsResolved inside the state lock
+		// before its durable write even starts, so the cancellation could never reach the
+		// interleaving under test (it would simply see an already-resolved escalation).
+		_allOfStrategy.Setup(s => s.StrategyType).Returns(ApprovalStrategyType.AllOf);
+		_allOfStrategy
+			.Setup(s => s.EvaluateDecision(
+				It.IsAny<EscalationRequest>(), It.IsAny<IReadOnlyList<ApproverDecision>>()))
+			.Returns((EscalationRequest request, IReadOnlyList<ApproverDecision> decisions) =>
+				new ApprovalEvaluation
+				{
+					IsResolved = decisions.Count >= request.Approvers.Count && decisions.All(d => d.Approved),
+					IsApproved = decisions.Count >= request.Approvers.Count && decisions.All(d => d.Approved),
+					PendingApprovers = []
+				});
+	}
+
+	public void Dispose()
+	{
+		foreach (var service in _services)
+			service.Dispose();
+	}
+
+	// --- Helpers ---
+
+	private DefaultEscalationService CreateService(
+		IEscalationStateStore stateStore, IServiceProvider? serviceProvider = null)
+	{
+		var configMonitor = new Mock<IOptionsMonitor<EscalationConfig>>();
+		configMonitor.Setup(m => m.CurrentValue).Returns(new EscalationConfig { Enabled = true });
+
+		var service = new DefaultEscalationService(
+			serviceProvider ?? BuildStrategyProvider(),
+			_notifier.Object,
+			_auditStore.Object,
+			stateStore,
+			configMonitor.Object,
+			NullLogger<DefaultEscalationService>.Instance);
+		_services.Add(service);
+		return service;
+	}
+
+	private IServiceProvider BuildStrategyProvider()
+	{
+		var services = new ServiceCollection();
+		services.AddKeyedSingleton<IApprovalStrategy>(
+			ApprovalStrategyType.AnyOf, (_, _) => _anyOfStrategy.Object);
+		services.AddKeyedSingleton<IApprovalStrategy>(
+			ApprovalStrategyType.AllOf, (_, _) => _allOfStrategy.Object);
+		return services.BuildServiceProvider();
+	}
+
+	/// <summary>
+	/// Builds the hosted reconciliation service over a real reconciler. The pruner factory throws
+	/// on resolution: with both durability toggles off it must never be reached, because
+	/// constructing the pruner creates the governance-state database file.
+	/// </summary>
+	private EscalationReconciliationService CreateReconciliationService(
+		IEscalationReconciler reconciler, bool escalationsEnabled, bool changeProposalsEnabled)
+	{
+		var config = new AppConfig();
+		config.AI.Governance.DurableState.EscalationsEnabled = escalationsEnabled;
+		config.AI.Governance.DurableState.ChangeProposalsEnabled = changeProposalsEnabled;
+
+		var monitor = new Mock<IOptionsMonitor<AppConfig>>();
+		monitor.Setup(m => m.CurrentValue).Returns(config);
+
+		return new EscalationReconciliationService(
+			reconciler,
+			() => throw new InvalidOperationException(
+				"The retention pruner must stay unresolved while both durability toggles are off."),
+			monitor.Object,
+			_time,
+			NullLogger<EscalationReconciliationService>.Instance);
+	}
+
+	private static EscalationRequest CreateRequest(
+		ApprovalStrategyType strategy = ApprovalStrategyType.AnyOf) => new()
+		{
+			EscalationId = Guid.NewGuid(),
+			AgentId = "agent-001",
+			ToolName = "dangerous_tool",
+			Arguments = new Dictionary<string, string>(),
+			Description = "Test escalation",
+			RiskLevel = RiskLevel.High,
+			Priority = EscalationPriority.Blocking,
+			ApprovalStrategy = strategy,
+			Approvers = ["approver-1", "approver-2"],
+			TimeoutSeconds = 300,
+			TimeoutAction = EscalationTimeoutAction.DenyAndEscalate,
+			RequestedAt = DateTimeOffset.UtcNow
+		};
+
+	private static ApproverDecision Approval(string approverName) => new()
+	{
+		ApproverName = approverName,
+		Approved = true,
+		RespondedAt = DateTimeOffset.UtcNow
+	};
+
+	private void FailOutcomeAudit() =>
+		_auditStore
+			.Setup(a => a.RecordOutcomeAsync(It.IsAny<EscalationOutcome>(), It.IsAny<CancellationToken>()))
+			.ThrowsAsync(new IOException("audit store unavailable"));
+
+	private void HealOutcomeAudit() =>
+		_auditStore
+			.Setup(a => a.RecordOutcomeAsync(It.IsAny<EscalationOutcome>(), It.IsAny<CancellationToken>()))
+			.Returns(Task.CompletedTask);
+
+	/// <summary>
+	/// Polls for a verdict while nudging the fake clock, so the hosted service's initial delay and
+	/// interval timers actually fire. Advancing on every poll avoids the scheduling race where a
+	/// single up-front advance lands before the timer is registered.
+	/// </summary>
+	private async Task<EscalationOutcome> PollOutcomeDrivingClockAsync(
+		DefaultEscalationService service, Guid escalationId)
+	{
+		using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(20));
+		while (true)
+		{
+			var outcome = await service.GetOutcomeAsync(escalationId, CancellationToken.None);
+			if (outcome is not null)
+				return outcome;
+			cts.Token.ThrowIfCancellationRequested();
+			_time.Advance(TimeSpan.FromSeconds(31));
+			await Task.Delay(10, cts.Token);
+		}
+	}
+
+	// ===== Finding 2: recovery must run with durability OFF =====
+
+	[Fact]
+	public async Task ReconciliationService_BothToggglesOff_StillRecoversAuditOutageParkedEscalation()
+	{
+		// The default configuration. The escalation parks because the fail-closed AUDIT write
+		// throws — nothing to do with durable state — so gating the whole reconciliation loop on
+		// the durability toggles left this with no scheduled recovery at all, and made
+		// AwaitingReconciliation's own contract ("poll until reconciliation completes") false.
+		var service = CreateService(new NullEscalationStateStore());
+		var request = CreateRequest();
+		await service.QueueEscalationAsync(request, CancellationToken.None);
+
+		FailOutcomeAudit();
+		await Assert.ThrowsAsync<IOException>(() => service.SubmitDecisionAsync(
+			request.EscalationId, Approval("approver-1"), CancellationToken.None));
+
+		// Parked: no verdict is observable, and a second approver is told plainly that their
+		// vote did not participate.
+		(await service.GetOutcomeAsync(request.EscalationId, CancellationToken.None)).Should().BeNull();
+		var late = await service.SubmitDecisionAsync(
+			request.EscalationId, Approval("approver-2"), CancellationToken.None);
+		late.Status.Should().Be(EscalationDecisionStatus.AwaitingReconciliation);
+
+		HealOutcomeAudit();
+
+		var hosted = CreateReconciliationService(
+			service, escalationsEnabled: false, changeProposalsEnabled: false);
+		await hosted.StartAsync(CancellationToken.None);
+		try
+		{
+			var outcome = await PollOutcomeDrivingClockAsync(service, request.EscalationId);
+
+			outcome.IsApproved.Should().BeTrue(
+				"the scheduled reconcile must re-drive the parked verdict even with durable " +
+				"governance state switched off — the parked state is audit-store-induced");
+			(await service.GetPendingEscalationAsync(request.EscalationId, CancellationToken.None))
+				.Should().BeNull("a recovered escalation leaves the active set");
+		}
+		finally
+		{
+			await hosted.StopAsync(CancellationToken.None);
+		}
+	}
+
+	// ===== Finding 4: a cancel racing a failed decision write must not strand a durable row =====
+
+	[Fact]
+	public async Task CancelEscalationAsync_RacingFailedDecisionWrite_DoesNotStrandDurableRecord()
+	{
+		var store = new RecordingStateStore();
+		var service = CreateService(store);
+
+		// AllOf on a two-approver roster: the single approval below does NOT resolve, so the
+		// escalation is still genuinely open when the cancellation arrives. That is what makes
+		// the interleaving reachable at all.
+		var request = CreateRequest(ApprovalStrategyType.AllOf);
+		await service.QueueEscalationAsync(request, CancellationToken.None);
+
+		// A decision that will fail its fail-closed durable write, parked mid-write so the
+		// cancellation below has a window to interleave.
+		store.BlockAndFailDecisionWrite = true;
+		var decisionTask = Task.Run(() => service.SubmitDecisionAsync(
+			request.EscalationId, Approval("approver-1"), CancellationToken.None));
+		await store.DecisionWriteEntered.Task.WaitAsync(TimeSpan.FromSeconds(10));
+
+		// The audit store is down, so the cancellation will park after writing its durable
+		// resolution marker — the exact state the decision's rollback used to erase.
+		FailOutcomeAudit();
+		var cancelTask = Task.Run(() => service.CancelEscalationAsync(
+			request.EscalationId, "superseded", "admin", CancellationToken.None));
+
+		// The heart of the fix: cancellation resolves the escalation, so it must serialize on the
+		// same per-escalation write gate the decision holds. Before the fix it ran straight
+		// through and wrote the durable ResolvedPendingAudit row while the decision was still
+		// parked; the decision's rollback then cleared IsResolved/PendingOutcome, leaving that
+		// row unclaimable by either reconcile shape.
+		var raced = await Task.WhenAny(
+			store.ResolvedPendingAuditWritten.Task, Task.Delay(TimeSpan.FromSeconds(2)));
+		raced.Should().NotBeSameAs(store.ResolvedPendingAuditWritten.Task,
+			"a cancellation must not reach the durable resolution write while a decision write holds the gate");
+
+		store.ReleaseDecisionWrite.TrySetResult();
+		await Assert.ThrowsAsync<EscalationDurableStateException>(() => decisionTask);
+		await Assert.ThrowsAsync<IOException>(() => cancelTask);
+
+		// The invariant: whatever the interleaving, the parked resolution stays claimable, so no
+		// durable row is left behind that reconciliation cannot finish and the pruner (which
+		// correctly refuses to delete non-terminal rows) can never clean up.
+		HealOutcomeAudit();
+		var reconcile = await service.ReconcileStuckEscalationsAsync(CancellationToken.None);
+
+		reconcile.Recovered.Should().ContainSingle().Which.Should().Be(request.EscalationId);
+		store.StatusOf(request.EscalationId).Should().Be(EscalationPersistedStatus.Resolved);
+		store.NonTerminalIds.Should().BeEmpty(
+			"a cancel racing a failed decision write must not strand a durable row");
+	}
+
+	// ===== Finding 3: a teardown racing an in-flight decision must not throw ObjectDisposedException =====
+
+	[Fact]
+	public async Task SubmitDecisionAsync_WriteGateDisposedByConcurrentTeardown_ReportsUnknownEscalation()
+	{
+		// CleanupCancelledEscalation disposes the write gate when the blocking caller abandons
+		// the escalation. A decision already past the active-set lookup then hits a disposed
+		// semaphore: unguarded, that ObjectDisposedException escapes SubmitDecisionAsync and
+		// reaches the approver as a 500 instead of the honest "this escalation no longer exists".
+		var strategyRequested = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+		var releaseStrategy = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+		var services = new ServiceCollection();
+		services.AddKeyedSingleton<IApprovalStrategy>(ApprovalStrategyType.AnyOf, (_, _) =>
+		{
+			// Parks the decision path after the active-set lookup but before the gate acquire —
+			// precisely the window the teardown races.
+			strategyRequested.TrySetResult();
+			releaseStrategy.Task.GetAwaiter().GetResult();
+			return _anyOfStrategy.Object;
+		});
+
+		var service = CreateService(new NullEscalationStateStore(), services.BuildServiceProvider());
+		var request = CreateRequest();
+
+		using var callerCts = new CancellationTokenSource();
+		var blockingCaller = Task.Run(() => service.RequestEscalationAsync(request, callerCts.Token));
+
+		await WaitForPendingAsync(service, request.EscalationId);
+
+		var decisionTask = Task.Run(() => service.SubmitDecisionAsync(
+			request.EscalationId, Approval("approver-1"), CancellationToken.None));
+		await strategyRequested.Task.WaitAsync(TimeSpan.FromSeconds(10));
+
+		// The caller abandons the escalation: cleanup removes it from the active set and disposes
+		// its synchronization primitives, including the gate the parked decision is about to take.
+		await callerCts.CancelAsync();
+		await Assert.ThrowsAnyAsync<OperationCanceledException>(() => blockingCaller);
+
+		releaseStrategy.TrySetResult();
+		var result = await decisionTask;
+
+		result.Status.Should().Be(EscalationDecisionStatus.UnknownEscalation,
+			"a torn-down escalation is not decidable, and that is exactly what a lookup a moment " +
+			"later would report — the approver must never see a disposal fault");
+	}
+
+	private static async Task WaitForPendingAsync(DefaultEscalationService service, Guid escalationId)
+	{
+		using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+		while (await service.GetPendingEscalationAsync(escalationId, CancellationToken.None) is null)
+		{
+			cts.Token.ThrowIfCancellationRequested();
+			await Task.Delay(10, cts.Token);
+		}
+	}
+
+	/// <summary>
+	/// In-memory <see cref="IEscalationStateStore"/> that records the persisted status of every
+	/// record and can park-then-fail the decision write on demand, so a resolution can be forced
+	/// to interleave with a decision deterministically.
+	/// </summary>
+	private sealed class RecordingStateStore : IEscalationStateStore
+	{
+		private readonly Dictionary<Guid, Row> _rows = [];
+		private readonly object _sync = new();
+
+		/// <summary>Signalled once the (blocking) decision write has been entered.</summary>
+		public TaskCompletionSource DecisionWriteEntered { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+		/// <summary>Completed by the test to let the blocked decision write fail.</summary>
+		public TaskCompletionSource ReleaseDecisionWrite { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+		/// <summary>Signalled the first time a durable resolution marker is written.</summary>
+		public TaskCompletionSource ResolvedPendingAuditWritten { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+		/// <summary>When set, the next decision write parks and then throws.</summary>
+		public bool BlockAndFailDecisionWrite { get; set; }
+
+		/// <summary>Ids of records that are not terminal — a stranded row shows up here.</summary>
+		public IReadOnlyList<Guid> NonTerminalIds
+		{
+			get
+			{
+				lock (_sync)
+				{
+					return _rows.Where(r => r.Value.Status != EscalationPersistedStatus.Resolved)
+						.Select(r => r.Key).ToList();
+				}
+			}
+		}
+
+		/// <summary>Returns the persisted status of a record, or null when absent.</summary>
+		/// <param name="escalationId">The record to inspect.</param>
+		public EscalationPersistedStatus? StatusOf(Guid escalationId)
+		{
+			lock (_sync)
+			{
+				return _rows.TryGetValue(escalationId, out var row) ? row.Status : null;
+			}
+		}
+
+		/// <inheritdoc />
+		public Task SavePendingAsync(EscalationRequest request, DateTimeOffset createdAt, CancellationToken ct)
+		{
+			lock (_sync)
+			{
+				_rows[request.EscalationId] = new Row(request, createdAt);
+			}
+			return Task.CompletedTask;
+		}
+
+		/// <inheritdoc />
+		public Task SaveDecisionsAsync(
+			Guid escalationId, IReadOnlyList<ApproverDecision> decisions, CancellationToken ct)
+		{
+			if (BlockAndFailDecisionWrite)
+				return ParkThenFailAsync();
+
+			lock (_sync)
+			{
+				if (_rows.TryGetValue(escalationId, out var row))
+					row.Decisions = decisions;
+			}
+			return Task.CompletedTask;
+
+			async Task ParkThenFailAsync()
+			{
+				DecisionWriteEntered.TrySetResult();
+				await ReleaseDecisionWrite.Task;
+				throw new IOException("durable store unavailable");
+			}
+		}
+
+		/// <inheritdoc />
+		public Task MarkResolvedPendingAuditAsync(EscalationOutcome outcome, CancellationToken ct)
+		{
+			lock (_sync)
+			{
+				if (_rows.TryGetValue(outcome.EscalationId, out var row))
+				{
+					row.Status = EscalationPersistedStatus.ResolvedPendingAudit;
+					row.Outcome = outcome;
+				}
+			}
+			ResolvedPendingAuditWritten.TrySetResult();
+			return Task.CompletedTask;
+		}
+
+		/// <inheritdoc />
+		public Task MarkResolvedAsync(Guid escalationId, CancellationToken ct)
+		{
+			lock (_sync)
+			{
+				if (_rows.TryGetValue(escalationId, out var row))
+					row.Status = EscalationPersistedStatus.Resolved;
+			}
+			return Task.CompletedTask;
+		}
+
+		/// <inheritdoc />
+		public Task RemoveAsync(Guid escalationId, CancellationToken ct)
+		{
+			lock (_sync)
+			{
+				_rows.Remove(escalationId);
+			}
+			return Task.CompletedTask;
+		}
+
+		/// <inheritdoc />
+		public Task<bool> TryClaimResolvedPendingAuditAsync(
+			Guid escalationId, DateTimeOffset staleClaimBefore, CancellationToken ct)
+		{
+			lock (_sync)
+			{
+				if (!_rows.TryGetValue(escalationId, out var row) ||
+					row.Status is not (EscalationPersistedStatus.ResolvedPendingAudit
+						or EscalationPersistedStatus.AuditInFlight))
+				{
+					return Task.FromResult(false);
+				}
+
+				row.Status = EscalationPersistedStatus.AuditInFlight;
+				return Task.FromResult(true);
+			}
+		}
+
+		/// <inheritdoc />
+		public Task ReleaseClaimAsync(Guid escalationId, CancellationToken ct)
+		{
+			lock (_sync)
+			{
+				if (_rows.TryGetValue(escalationId, out var row) &&
+					row.Status == EscalationPersistedStatus.AuditInFlight)
+				{
+					row.Status = EscalationPersistedStatus.ResolvedPendingAudit;
+				}
+			}
+			return Task.CompletedTask;
+		}
+
+		/// <inheritdoc />
+		public Task<IReadOnlyList<EscalationStateSnapshot>> GetActiveAsync(CancellationToken ct)
+		{
+			lock (_sync)
+			{
+				IReadOnlyList<EscalationStateSnapshot> active = _rows.Values
+					.Where(r => r.Status != EscalationPersistedStatus.Resolved)
+					.Select(r => new EscalationStateSnapshot
+					{
+						Request = r.Request,
+						Decisions = r.Decisions,
+						CreatedAt = r.CreatedAt,
+						Status = r.Status,
+						Outcome = r.Outcome
+					})
+					.ToList();
+				return Task.FromResult(active);
+			}
+		}
+
+		/// <inheritdoc />
+		public Task<EscalationOutcome?> GetResolvedOutcomeAsync(Guid escalationId, CancellationToken ct)
+		{
+			lock (_sync)
+			{
+				return Task.FromResult(
+					_rows.TryGetValue(escalationId, out var row) &&
+					row.Status == EscalationPersistedStatus.Resolved
+						? row.Outcome
+						: null);
+			}
+		}
+
+		private sealed class Row(EscalationRequest request, DateTimeOffset createdAt)
+		{
+			public EscalationRequest Request { get; } = request;
+			public DateTimeOffset CreatedAt { get; } = createdAt;
+			public IReadOnlyList<ApproverDecision> Decisions { get; set; } = [];
+			public EscalationPersistedStatus Status { get; set; } = EscalationPersistedStatus.Pending;
+			public EscalationOutcome? Outcome { get; set; }
+		}
+	}
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Escalation/GovernanceSealReplayTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Escalation/GovernanceSealReplayTests.cs
@@ -1,0 +1,265 @@
+using Application.AI.Common.Interfaces.Changes;
+using Application.AI.Common.Interfaces.Escalation;
+using Domain.AI.Changes;
+using Domain.AI.Escalation;
+using FluentAssertions;
+using Infrastructure.AI.Changes;
+using Infrastructure.AI.Escalation;
+using Infrastructure.AI.Persistence;
+using Infrastructure.AI.Tests.Changes.Support;
+using Infrastructure.AI.Tests.Escalation.Support;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Escalation;
+
+/// <summary>
+/// Regression tests for seal replay across records, and for the reclaim of an abandoned
+/// reconcile claim.
+/// </summary>
+/// <remarks>
+/// The replay case is the one that makes the seal worth having. Sealing the payload alone
+/// catches a <em>modified</em> verdict but not a <em>relocated</em> one: an approved outcome
+/// copied verbatim into another escalation's row verifies byte-for-byte, and the plan
+/// executor's resume path branches on <c>IsApproved</c> without re-checking the id — so one
+/// genuine approval would approve every escalation after it.
+/// </remarks>
+public sealed class GovernanceSealReplayTests : IDisposable
+{
+    private readonly FakeGovernanceRecordSealer _sealer = new();
+    private readonly string _dbPath;
+    private readonly DbContextOptions<GovernanceStateDbContext> _options;
+
+    public GovernanceSealReplayTests()
+    {
+        _dbPath = Path.Combine(Path.GetTempPath(), $"gov-replay-{Guid.NewGuid():N}.db");
+        _options = new DbContextOptionsBuilder<GovernanceStateDbContext>()
+            .UseSqlite($"DataSource={_dbPath}")
+            .Options;
+    }
+
+    public void Dispose()
+    {
+        SqliteConnection.ClearAllPools();
+        try
+        {
+            File.Delete(_dbPath);
+        }
+        catch (IOException)
+        {
+            // Best-effort temp cleanup.
+        }
+    }
+
+    private EfCoreEscalationStateStore CreateEscalationStore()
+    {
+        var factory = new TestContextFactory(_options);
+        return new EfCoreEscalationStateStore(
+            factory,
+            new GovernanceStateSchemaInitializer(factory),
+            _sealer,
+            GovernanceStateTestConfig.Monitor(),
+            NullLogger<EfCoreEscalationStateStore>.Instance);
+    }
+
+    private EfCoreChangeProposalStore CreateProposalStore()
+    {
+        var factory = new TestContextFactory(_options);
+        return new EfCoreChangeProposalStore(
+            factory,
+            new GovernanceStateSchemaInitializer(factory),
+            _sealer,
+            GovernanceStateTestConfig.Monitor(),
+            NullLogger<EfCoreChangeProposalStore>.Instance);
+    }
+
+    private static EscalationRequest CreateRequest(Guid id) => new()
+    {
+        EscalationId = id,
+        AgentId = "agent-001",
+        ToolName = "dangerous_tool",
+        Arguments = new Dictionary<string, string>(),
+        Description = "Test escalation",
+        RiskLevel = RiskLevel.High,
+        Priority = EscalationPriority.Blocking,
+        Approvers = ["approver-1"],
+        TimeoutSeconds = 300,
+        RequestedAt = DateTimeOffset.UtcNow
+    };
+
+    private static EscalationOutcome ApprovedOutcome(Guid id) => new()
+    {
+        EscalationId = id,
+        IsApproved = true,
+        Decisions = [],
+        ResolutionType = EscalationResolutionType.Approved,
+        ResolvedAt = DateTimeOffset.UtcNow,
+        Approvers = ["approver-1"]
+    };
+
+    /// <summary>
+    /// Copies escalation A's outcome payload and seal verbatim onto escalation B's row and
+    /// marks B resolved — the exact move a database writer would make to launder one real
+    /// approval into an approval of everything.
+    /// </summary>
+    private async Task ReplayOutcomeAsync(Guid fromId, Guid toId)
+    {
+        await using var context = new GovernanceStateDbContext(_options);
+        var source = await context.Escalations.SingleAsync(e => e.Id == fromId);
+        var target = await context.Escalations.SingleAsync(e => e.Id == toId);
+
+        target.OutcomeJson = source.OutcomeJson;
+        target.OutcomeSealJson = source.OutcomeSealJson;
+        target.Status = nameof(EscalationPersistedStatus.Resolved);
+        await context.SaveChangesAsync();
+    }
+
+    // ===== HIGH: seal replay across escalations =====
+
+    [Fact]
+    public async Task GetResolvedOutcomeAsync_OutcomeAndSealReplayedFromAnotherEscalation_ReturnsNull()
+    {
+        var approvedId = Guid.NewGuid();
+        var victimId = Guid.NewGuid();
+        var store = CreateEscalationStore();
+
+        await store.SavePendingAsync(CreateRequest(approvedId), DateTimeOffset.UtcNow, CancellationToken.None);
+        await store.SavePendingAsync(CreateRequest(victimId), DateTimeOffset.UtcNow, CancellationToken.None);
+        await store.MarkResolvedPendingAuditAsync(ApprovedOutcome(approvedId), CancellationToken.None);
+        await store.MarkResolvedAsync(approvedId, CancellationToken.None);
+
+        await ReplayOutcomeAsync(approvedId, victimId);
+
+        // The genuine record still verifies...
+        (await store.GetResolvedOutcomeAsync(approvedId, CancellationToken.None))
+            .Should().NotBeNull();
+
+        // ...but the relocated copy must not, even though every byte of payload and seal is
+        // untouched. Returning it here would release the victim's human gate.
+        (await store.GetResolvedOutcomeAsync(victimId, CancellationToken.None))
+            .Should().BeNull("a verdict lifted from another escalation must never be served");
+    }
+
+    [Fact]
+    public async Task GetActiveAsync_ParkedOutcomeReplayedFromAnotherEscalation_WithholdsTheOutcome()
+    {
+        var approvedId = Guid.NewGuid();
+        var victimId = Guid.NewGuid();
+        var store = CreateEscalationStore();
+
+        await store.SavePendingAsync(CreateRequest(approvedId), DateTimeOffset.UtcNow, CancellationToken.None);
+        await store.SavePendingAsync(CreateRequest(victimId), DateTimeOffset.UtcNow, CancellationToken.None);
+        await store.MarkResolvedPendingAuditAsync(ApprovedOutcome(approvedId), CancellationToken.None);
+
+        // Park the victim with the approved escalation's payload + seal.
+        await using (var context = new GovernanceStateDbContext(_options))
+        {
+            var source = await context.Escalations.SingleAsync(e => e.Id == approvedId);
+            var target = await context.Escalations.SingleAsync(e => e.Id == victimId);
+            target.OutcomeJson = source.OutcomeJson;
+            target.OutcomeSealJson = source.OutcomeSealJson;
+            target.Status = nameof(EscalationPersistedStatus.ResolvedPendingAudit);
+            await context.SaveChangesAsync();
+        }
+
+        var active = await store.GetActiveAsync(CancellationToken.None);
+        var victim = active.Single(s => s.Request.EscalationId == victimId);
+
+        // A null Outcome is what makes the reconciler skip it — a relocated verdict must never
+        // be re-driven into the hash-chained compliance log under the victim's id.
+        victim.Outcome.Should().BeNull();
+    }
+
+    // ===== MED: change proposals are sealed too =====
+
+    [Fact]
+    public async Task GetAsync_ProposalStatusEditedInTheDatabase_RefusesToServeIt()
+    {
+        var store = CreateProposalStore();
+        var proposal = TestProposals.NewProposal();
+        await store.SaveAsync(proposal, CancellationToken.None);
+
+        // A database writer promotes the proposal to an approved state without re-sealing.
+        await using (var context = new GovernanceStateDbContext(_options))
+        {
+            var row = await context.ChangeProposals.SingleAsync(p => p.Id == proposal.Id);
+            row.ProposalJson = row.ProposalJson.Replace("\"Draft\"", "\"Approved\"", StringComparison.Ordinal);
+            row.Status = nameof(ChangeProposalStatus.Approved);
+            await context.SaveChangesAsync();
+        }
+
+        (await store.GetAsync(proposal.Id, CancellationToken.None)).Should().BeNull();
+        (await store.ListAsync(new ChangeProposalQuery(), CancellationToken.None)).Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetAsync_ProposalSealReplayedFromAnotherProposal_RefusesToServeIt()
+    {
+        var store = CreateProposalStore();
+        var original = TestProposals.NewProposal();
+        var other = original with { Id = original.Id + "-other" };
+        await store.SaveAsync(original, CancellationToken.None);
+        await store.SaveAsync(other, CancellationToken.None);
+
+        await using (var context = new GovernanceStateDbContext(_options))
+        {
+            var source = await context.ChangeProposals.SingleAsync(p => p.Id == original.Id);
+            var target = await context.ChangeProposals.SingleAsync(p => p.Id == other.Id);
+            target.ProposalJson = source.ProposalJson;
+            target.ProposalSealJson = source.ProposalSealJson;
+            await context.SaveChangesAsync();
+        }
+
+        (await store.GetAsync(other.Id, CancellationToken.None))
+            .Should().BeNull("a proposal payload lifted onto another row must not verify");
+    }
+
+    // ===== HIGH: an abandoned AuditInFlight claim is reclaimable =====
+
+    [Fact]
+    public async Task TryClaimResolvedPendingAuditAsync_StaleAuditInFlightRow_IsReclaimed()
+    {
+        var id = Guid.NewGuid();
+        var store = CreateEscalationStore();
+        await store.SavePendingAsync(CreateRequest(id), DateTimeOffset.UtcNow, CancellationToken.None);
+        await store.MarkResolvedPendingAuditAsync(ApprovedOutcome(id), CancellationToken.None);
+
+        // First pass claims it, then dies (kill -9 / OOM / eviction) without releasing.
+        (await store.TryClaimResolvedPendingAuditAsync(id, DateTimeOffset.UtcNow.AddMinutes(-10), CancellationToken.None))
+            .Should().BeTrue();
+
+        // A pass running immediately afterwards must NOT steal a live claim.
+        (await store.TryClaimResolvedPendingAuditAsync(id, DateTimeOffset.UtcNow.AddMinutes(-10), CancellationToken.None))
+            .Should().BeFalse("a claim that is merely in progress must not be stolen");
+
+        // Once the claim ages past the staleness bound it becomes reclaimable — otherwise the
+        // row would sit in AuditInFlight forever, skipped by every pass and left by the pruner.
+        (await store.TryClaimResolvedPendingAuditAsync(id, DateTimeOffset.UtcNow.AddMinutes(1), CancellationToken.None))
+            .Should().BeTrue("an abandoned claim must be reclaimable, not terminally stuck");
+    }
+
+    [Fact]
+    public async Task GetActiveAsync_AuditInFlightRow_IsStillReturnedForReconciliation()
+    {
+        var id = Guid.NewGuid();
+        var store = CreateEscalationStore();
+        await store.SavePendingAsync(CreateRequest(id), DateTimeOffset.UtcNow, CancellationToken.None);
+        await store.MarkResolvedPendingAuditAsync(ApprovedOutcome(id), CancellationToken.None);
+        await store.TryClaimResolvedPendingAuditAsync(id, DateTimeOffset.UtcNow.AddMinutes(-10), CancellationToken.None);
+
+        var active = await store.GetActiveAsync(CancellationToken.None);
+
+        var snapshot = active.Should().ContainSingle().Subject;
+        snapshot.Status.Should().Be(EscalationPersistedStatus.AuditInFlight);
+        snapshot.Outcome.Should().NotBeNull("the reconciler needs the verdict to re-drive it");
+    }
+
+    /// <summary>Minimal context factory over fixed options.</summary>
+    private sealed class TestContextFactory(DbContextOptions<GovernanceStateDbContext> options)
+        : IDbContextFactory<GovernanceStateDbContext>
+    {
+        public GovernanceStateDbContext CreateDbContext() => new(options);
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Escalation/Support/GovernanceStateTestConfig.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Escalation/Support/GovernanceStateTestConfig.cs
@@ -1,0 +1,76 @@
+using Application.AI.Common.Interfaces.Escalation;
+using Domain.Common.Config;
+using Microsoft.Extensions.Options;
+using Moq;
+
+namespace Infrastructure.AI.Tests.Escalation.Support;
+
+/// <summary>
+/// Shared test doubles for the durable governance-state store: an
+/// <see cref="IOptionsMonitor{TOptions}"/> over a configurable <see cref="AppConfig"/>, and a
+/// deterministic <see cref="IEscalationOutcomeSealer"/> that needs no HMAC key material.
+/// </summary>
+internal static class GovernanceStateTestConfig
+{
+    /// <summary>
+    /// Builds an options monitor whose durable-state section carries the given limits.
+    /// </summary>
+    /// <param name="maxScanRecords">Scan bound for rehydration and reconcile.</param>
+    /// <param name="maxPayloadBytes">Per-column serialized payload cap.</param>
+    public static IOptionsMonitor<AppConfig> Monitor(
+        int maxScanRecords = 10_000,
+        int maxPayloadBytes = 1024 * 1024)
+    {
+        var config = new AppConfig();
+        config.AI.Governance.DurableState.MaxScanRecords = maxScanRecords;
+        config.AI.Governance.DurableState.MaxPayloadBytes = maxPayloadBytes;
+
+        var monitor = new Mock<IOptionsMonitor<AppConfig>>();
+        monitor.Setup(m => m.CurrentValue).Returns(config);
+        return monitor.Object;
+    }
+}
+
+/// <summary>
+/// Deterministic in-process sealer for tests: signs with a content hash rather than HMAC key
+/// material, so the seal still detects payload tampering and cross-record replay (the
+/// properties under test) without requiring attestation keys in every fixture.
+/// </summary>
+/// <remarks>
+/// Mirrors the production binding exactly: the signature covers <c>subjectId</c> as well as the
+/// payload, so a seal lifted from one record onto another fails here for the same reason it
+/// fails against real HMAC keys.
+/// </remarks>
+internal sealed class FakeGovernanceRecordSealer : IGovernanceRecordSealer
+{
+    /// <summary>When true, <see cref="VerifyAsync"/> reports failure regardless of the payload.</summary>
+    public bool ForceVerificationFailure { get; set; }
+
+    /// <inheritdoc />
+    public Task<GovernanceRecordSeal> SealAsync(string subjectId, string payloadJson, CancellationToken ct) =>
+        Task.FromResult(new GovernanceRecordSeal(
+            Hash(subjectId + "|" + payloadJson),
+            "test-key",
+            DateTimeOffset.UnixEpoch,
+            Hash(subjectId),
+            Hash(payloadJson)));
+
+    /// <inheritdoc />
+    public Task<bool> VerifyAsync(
+        string subjectId, string payloadJson, GovernanceRecordSeal? seal, CancellationToken ct)
+    {
+        if (ForceVerificationFailure || seal is null)
+            return Task.FromResult(false);
+
+        // Both legs must match: the payload hash AND the id-bound signature.
+        var payloadMatches = string.Equals(seal.OutputHash, Hash(payloadJson), StringComparison.Ordinal);
+        var bindingMatches = string.Equals(
+            seal.Signature, Hash(subjectId + "|" + payloadJson), StringComparison.Ordinal);
+
+        return Task.FromResult(payloadMatches && bindingMatches);
+    }
+
+    private static string Hash(string value) =>
+        Convert.ToHexStringLower(System.Security.Cryptography.SHA256.HashData(
+            System.Text.Encoding.UTF8.GetBytes(value)));
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Tools/FileSystemSandboxStartupValidatorTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Tools/FileSystemSandboxStartupValidatorTests.cs
@@ -131,23 +131,22 @@ public sealed class FileSystemSandboxStartupValidatorTests : IDisposable
     }
 
     [Fact]
-    public async Task StartAsync_OverlapWithDurableStateDisabled_StillThrows()
+    public async Task StartAsync_OverlapWithDurableStateDisabledButDirectoryPresent_StillThrows()
     {
-        // The validator takes no configuration and makes no exception for the durable-state
-        // toggles being off. It used to: the reasoning was that the toggles are restart-required,
-        // so enabling one would re-run this validator before any database could be written. That
-        // reasoning is false. EscalationReconciliationService.RunPruneAsync re-reads
-        // AI:Governance:DurableState from IOptionsMonitor on every reconcile tick and AppConfig is
-        // loaded with reloadOnChange: true, so an operator who edits ChangeProposalsEnabled to true
-        // on a RUNNING host creates the database on a host this validator already waved through.
-        // A boot assertion a live config edit can invalidate has to hold on every boot.
+        // Models the residual case: both durable-state toggles are off, but a governance-state
+        // directory survives from an earlier run that had them on, so
+        // DependencyInjection.ResolveGovernanceStateProtectedPaths still hands it over. The
+        // validator itself reads no configuration — a protected path in hand means there is
+        // something real to protect, and the overlap is refused on that basis alone. A validator
+        // that re-derived the toggle condition here would be a second copy of a subtle rule, and
+        // could wave through a database that still holds approval verdicts.
         var protectedDir = CreateDirectory(".agent-state");
 
         var sut = NewSut([_root], [protectedDir]);
 
         await sut.Invoking(s => s.StartAsync(CancellationToken.None))
             .Should().ThrowAsync<InvalidOperationException>(
-                "the overlap is refused regardless of whether durable state is currently enabled");
+                "the overlap is refused on the paths as registered, not on the toggles' current value");
     }
 
     [Fact]
@@ -190,12 +189,16 @@ public sealed class FileSystemSandboxStartupValidatorTests : IDisposable
         ex.Which.Message.Should().Contain("HardLinkInspector",
             "the message must name the type a consumer would extend to add this platform");
 
-        // The fix an operator would otherwise reach for first, and which does not work: the
-        // governance-state directory is registered as protected unconditionally in
-        // RegisterToolServices, consulting no toggle, so emptying the protected list this way is
-        // not reachable by configuration.
+        // Turning durable governance state off IS a real way forward now that the protected path is
+        // gated — but it is a two-condition fix, and an operator who does only the first half gets
+        // an identical boot failure on the next start with no hint as to why. Both halves have to
+        // be in the message.
         ex.Which.Message.Should().Contain("AppConfig:AI:Governance:DurableState",
-            "the message must foreclose the toggles as a fix rather than leave the operator to try it");
+            "the message must name the toggles, which are now half of a genuine way forward");
+        ex.Which.Message.Should().Contain("ChangeProposalsEnabled",
+            "naming only one toggle would leave the operator with a half-fix that still refuses to boot");
+        ex.Which.Message.Should().Contain(agentState,
+            "the message must name the directory whose mere presence keeps the protection armed");
     }
 
     [Fact]

--- a/src/Content/Tests/Infrastructure.AI.Tests/Tools/FileSystemSandboxStartupValidatorTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Tools/FileSystemSandboxStartupValidatorTests.cs
@@ -1,0 +1,163 @@
+using Domain.Common.Config;
+using FluentAssertions;
+using Infrastructure.AI.Tests.Changes.Support;
+using Infrastructure.AI.Tools;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Tools;
+
+/// <summary>
+/// Covers <see cref="FileSystemSandboxStartupValidator"/> — the boot-time assertion that no
+/// protected harness-state directory lies inside a directory the file-system tool may reach.
+/// </summary>
+/// <remarks>
+/// This assertion, not the deny list, is what closes the hard-link bypass. A hard link is a second
+/// directory entry for the same file rather than a reparse point, so it resolves to itself and
+/// presents to every per-path check as an ordinary unprotected file; read through one, the
+/// approval-verdict database is readable, and written through one it is forgeable. A hard link
+/// cannot span volumes, so keeping the protected directory outside every allowed base path makes
+/// the bypass unconstructible. These tests pin that the assertion fires when it must and stays
+/// silent on the shipped default, because a guard that fires on the default configuration would be
+/// turned off rather than heeded.
+/// </remarks>
+public sealed class FileSystemSandboxStartupValidatorTests : IDisposable
+{
+    private readonly string _root;
+
+    public FileSystemSandboxStartupValidatorTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), $"fss-guard-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_root))
+            Directory.Delete(_root, recursive: true);
+    }
+
+    private static AppConfig ConfigWithDurableState(bool escalations, bool proposals)
+    {
+        var config = new AppConfig();
+        config.AI.Governance.DurableState.EscalationsEnabled = escalations;
+        config.AI.Governance.DurableState.ChangeProposalsEnabled = proposals;
+        return config;
+    }
+
+    private static FileSystemSandboxStartupValidator NewSut(
+        IReadOnlyList<string> allowedBasePaths,
+        IReadOnlyList<string> protectedPaths,
+        AppConfig config) =>
+        new(allowedBasePaths,
+            protectedPaths,
+            new TestConfig.StaticOptionsMonitor<AppConfig>(config),
+            NullLogger<FileSystemSandboxStartupValidator>.Instance);
+
+    private string CreateDirectory(params string[] parts)
+    {
+        var path = Path.Combine([_root, .. parts]);
+        Directory.CreateDirectory(path);
+        return path;
+    }
+
+    [Fact]
+    public async Task StartAsync_ProtectedDirectoryInsideAllowedBasePath_DurableStateEnabled_Throws()
+    {
+        var protectedDir = CreateDirectory(".agent-state");
+
+        var sut = NewSut([_root], [protectedDir], ConfigWithDurableState(escalations: true, proposals: false));
+
+        var ex = await sut.Invoking(s => s.StartAsync(CancellationToken.None))
+            .Should().ThrowAsync<InvalidOperationException>(
+                "a hard link inside the allowed tree would alias the approval-verdict database, " +
+                "and no per-path check can see through a hard link");
+
+        // The operator has to be able to act on this without reading the source.
+        ex.Which.Message.Should().Contain(protectedDir, "the message must name the offending protected path");
+        ex.Which.Message.Should().Contain(_root, "the message must name the allowed base path containing it");
+        ex.Which.Message.Should().Contain("AppConfig:Infrastructure:FileSystem:AllowedBasePaths",
+            "the message must name the setting to change");
+    }
+
+    [Fact]
+    public async Task StartAsync_ProtectedDirectoryEqualsAllowedBasePath_Throws()
+    {
+        // Equality is containment's boundary case: granting the tool the protected directory
+        // itself is the most direct form of the same misconfiguration.
+        var sut = NewSut([_root], [_root], ConfigWithDurableState(escalations: false, proposals: true));
+
+        await sut.Invoking(s => s.StartAsync(CancellationToken.None))
+            .Should().ThrowAsync<InvalidOperationException>();
+    }
+
+    [Fact]
+    public async Task StartAsync_ShippedDefaultLayout_DoesNotThrow()
+    {
+        // Mirrors what the five hosts actually register: AllowedBasePaths ["workspace"] resolved
+        // against the application base directory, and the governance database under
+        // ".agent-state/" — a SIBLING of workspace, not a child. If this ever starts throwing, the
+        // safe default has drifted and every host stops booting.
+        var workspace = CreateDirectory("workspace");
+        var agentState = CreateDirectory(".agent-state");
+
+        var sut = NewSut([workspace], [agentState], ConfigWithDurableState(escalations: true, proposals: true));
+
+        await sut.Invoking(s => s.StartAsync(CancellationToken.None)).Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task StartAsync_SiblingWhoseNameSharesThePrefix_DoesNotThrow()
+    {
+        // Guards the directory-boundary rule in the assertion itself: "workspace-archive" is a
+        // legitimate sibling of "workspace". A plain string-prefix check would fail the boot.
+        var workspace = CreateDirectory("workspace");
+        var lookalike = CreateDirectory("workspace-archive");
+
+        var sut = NewSut([workspace], [lookalike], ConfigWithDurableState(escalations: true, proposals: false));
+
+        await sut.Invoking(s => s.StartAsync(CancellationToken.None)).Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task StartAsync_OverlapButDurableStateDisabled_DoesNotThrow()
+    {
+        // Both toggles off means no database is ever created, so the protected directory holds
+        // nothing and refusing to boot would cost a consumer their widened Development allowlist
+        // for no security gain. The toggles are restart-required, so enabling one re-runs this.
+        var protectedDir = CreateDirectory(".agent-state");
+
+        var sut = NewSut([_root], [protectedDir], ConfigWithDurableState(escalations: false, proposals: false));
+
+        await sut.Invoking(s => s.StartAsync(CancellationToken.None)).Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task StartAsync_NoProtectedPathsConfigured_DoesNotThrow()
+    {
+        var sut = NewSut([_root], [], ConfigWithDurableState(escalations: true, proposals: true));
+
+        await sut.Invoking(s => s.StartAsync(CancellationToken.None)).Should().NotThrowAsync();
+    }
+
+    [SkippableFact]
+    public async Task StartAsync_OverlapReachableOnlyThroughALinkedBasePath_Throws()
+    {
+        // The overlap is invisible to a literal string comparison. The allowed base path is
+        // configured as "base-link", which shares no prefix with the protected directory as
+        // written; only after resolving the link do the two land in the same tree. Canonicalizing
+        // BOTH sides is what catches it — canonicalizing only the protected path would not.
+        var appDirectory = CreateDirectory("app");
+        var protectedDir = CreateDirectory("app", ".agent-state");
+
+        var linkedBase = Path.Combine(_root, "base-link");
+        SandboxLinkFactory.CreateDirectoryLink(linkedBase, appDirectory);
+
+        var sut = NewSut([linkedBase], [protectedDir], ConfigWithDurableState(escalations: true, proposals: false));
+
+        await sut.Invoking(s => s.StartAsync(CancellationToken.None))
+            .Should().ThrowAsync<InvalidOperationException>(
+                "the allowed base path resolves onto the tree holding the protected directory");
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Tools/FileSystemSandboxStartupValidatorTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Tools/FileSystemSandboxStartupValidatorTests.cs
@@ -48,6 +48,19 @@ public sealed class FileSystemSandboxStartupValidatorTests : IDisposable
             protectedPaths,
             NullLogger<FileSystemSandboxStartupValidator>.Instance);
 
+    /// <summary>
+    /// Builds the validator with the hard-link platform-capability signal forced, so the platform
+    /// branch is exercised on whatever operating system the suite happens to run on.
+    /// </summary>
+    private static FileSystemSandboxStartupValidator NewSutWithHardLinkSupport(
+        IReadOnlyList<string> allowedBasePaths,
+        IReadOnlyList<string> protectedPaths,
+        bool supported) =>
+        new(allowedBasePaths,
+            protectedPaths,
+            NullLogger<FileSystemSandboxStartupValidator>.Instance,
+            supported);
+
     private string CreateDirectory(params string[] parts)
     {
         var path = Path.Combine([_root, .. parts]);
@@ -143,6 +156,104 @@ public sealed class FileSystemSandboxStartupValidatorTests : IDisposable
         var sut = NewSut([_root], []);
 
         await sut.Invoking(s => s.StartAsync(CancellationToken.None)).Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task StartAsync_HardLinkInspectionUnsupportedWithProtectedPaths_Throws()
+    {
+        // The macOS case, made runnable everywhere. The hard-link control fails closed, so on a
+        // platform it has no implementation for, EVERY file operation is denied — one call at a
+        // time, with a message that can only say the link count was unavailable. Converting that
+        // into a single boot refusal is the whole point of this check: a consumer's first hour
+        // should end at a documented limitation, not at a tool that fails for no visible reason.
+        var workspace = CreateDirectory("workspace");
+        var agentState = CreateDirectory(".agent-state");
+
+        var sut = NewSutWithHardLinkSupport([workspace], [agentState], supported: false);
+
+        var ex = await sut.Invoking(s => s.StartAsync(CancellationToken.None))
+            .Should().ThrowAsync<InvalidOperationException>(
+                "a fail-closed control with no implementation here denies every file operation, " +
+                "which is worth refusing to boot over rather than discovering call by call");
+
+        // Note the layout: workspace and .agent-state are SIBLINGS, so this is the shipped default
+        // geometry the overlap check waves through. The refusal can only be coming from the
+        // platform check.
+        ex.Which.Message.Should().NotContain("lies inside",
+            "this is the platform refusal, not the overlap refusal");
+
+        // What an operator needs to act without reading the source.
+        ex.Which.Message.Should().Contain("hard-link",
+            "the message must name the control that is unavailable");
+        ex.Which.Message.Should().Contain("Windows or Linux",
+            "the message must name the platforms that do work");
+        ex.Which.Message.Should().Contain("HardLinkInspector",
+            "the message must name the type a consumer would extend to add this platform");
+
+        // The fix an operator would otherwise reach for first, and which does not work: the
+        // governance-state directory is registered as protected unconditionally in
+        // RegisterToolServices, consulting no toggle, so emptying the protected list this way is
+        // not reachable by configuration.
+        ex.Which.Message.Should().Contain("AppConfig:AI:Governance:DurableState",
+            "the message must foreclose the toggles as a fix rather than leave the operator to try it");
+    }
+
+    [Fact]
+    public async Task StartAsync_HardLinkInspectionUnsupportedWithNoProtectedPaths_DoesNotThrow()
+    {
+        // The other half of the pair. With nothing to protect, FileSystemService skips the link
+        // inspection outright (IsSingleLinked returns early on an empty protected set), so the tool
+        // works normally on an unimplemented platform. The validator has to arm on exactly the same
+        // condition, or it refuses to boot a host that would have run perfectly well.
+        var sut = NewSutWithHardLinkSupport([_root], [], supported: false);
+
+        await sut.Invoking(s => s.StartAsync(CancellationToken.None)).Should().NotThrowAsync(
+            "with no protected paths the runtime link check never runs, so the platform is irrelevant");
+    }
+
+    [Fact]
+    public async Task StartAsync_HardLinkInspectionSupportedWithProtectedPaths_DoesNotThrow()
+    {
+        // Pins the cause. Same protected paths as the throwing test, same sibling layout — only the
+        // capability signal differs. Without this, a validator that threw whenever protected paths
+        // existed at all would pass the throwing test for entirely the wrong reason.
+        var workspace = CreateDirectory("workspace");
+        var agentState = CreateDirectory(".agent-state");
+
+        var sut = NewSutWithHardLinkSupport([workspace], [agentState], supported: true);
+
+        await sut.Invoking(s => s.StartAsync(CancellationToken.None)).Should().NotThrowAsync(
+            "protected paths on a platform that implements the control are the ordinary case");
+    }
+
+    [Fact]
+    public async Task StartAsync_HardLinkInspectionUnsupportedWithOnlyBlankProtectedPaths_DoesNotThrow()
+    {
+        // FileSystemService's constructor discards blank entries before it counts, so a list of
+        // blanks leaves its per-operation check disarmed. The validator mirrors that filter; a raw
+        // count would refuse to boot over a configuration the tool treats as having nothing to
+        // protect.
+        var sut = NewSutWithHardLinkSupport([_root], ["", "   "], supported: false);
+
+        await sut.Invoking(s => s.StartAsync(CancellationToken.None)).Should().NotThrowAsync(
+            "blank entries arm nothing at runtime, so they must not arm the boot assertion either");
+    }
+
+    [Fact]
+    public async Task StartAsync_OverlapOnAnUnsupportedPlatform_ReportsTheOverlapFirst()
+    {
+        // Both faults at once. The overlap is a security misconfiguration that survives a move to a
+        // supported platform, so it is the more useful thing to say first; the operator who fixes
+        // the geometry then meets the platform refusal on the next boot.
+        var protectedDir = CreateDirectory(".agent-state");
+
+        var sut = NewSutWithHardLinkSupport([_root], [protectedDir], supported: false);
+
+        var ex = await sut.Invoking(s => s.StartAsync(CancellationToken.None))
+            .Should().ThrowAsync<InvalidOperationException>();
+
+        ex.Which.Message.Should().Contain("lies inside",
+            "the overlap is reported ahead of the platform limitation");
     }
 
     [SkippableFact]

--- a/src/Content/Tests/Infrastructure.AI.Tests/Tools/FileSystemSandboxStartupValidatorTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Tools/FileSystemSandboxStartupValidatorTests.cs
@@ -1,9 +1,6 @@
-using Domain.Common.Config;
 using FluentAssertions;
-using Infrastructure.AI.Tests.Changes.Support;
 using Infrastructure.AI.Tools;
 using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.Extensions.Options;
 using Xunit;
 
 namespace Infrastructure.AI.Tests.Tools;
@@ -13,14 +10,20 @@ namespace Infrastructure.AI.Tests.Tools;
 /// protected harness-state directory lies inside a directory the file-system tool may reach.
 /// </summary>
 /// <remarks>
-/// This assertion, not the deny list, is what closes the hard-link bypass. A hard link is a second
-/// directory entry for the same file rather than a reparse point, so it resolves to itself and
-/// presents to every per-path check as an ordinary unprotected file; read through one, the
-/// approval-verdict database is readable, and written through one it is forgeable. A hard link
-/// cannot span volumes, so keeping the protected directory outside every allowed base path makes
-/// the bypass unconstructible. These tests pin that the assertion fires when it must and stays
-/// silent on the shipped default, because a guard that fires on the default configuration would be
-/// turned off rather than heeded.
+/// <para>
+/// This assertion is defence in depth, and these tests deliberately do NOT claim it closes the
+/// hard-link bypass. It cannot: a hard link needs the same volume as its target, not the same
+/// subtree, so a layout with no containment at all is still linkable. That hole is closed by
+/// <see cref="FileSystemService"/>'s per-operation link-count check and is exercised in
+/// <see cref="FileSystemServiceHardLinkTests"/>. What this validator earns its place for is
+/// refusing a configuration that hands the file-system tool the governance-state directory
+/// outright, leaving a path-comparing deny list as the only barrier.
+/// </para>
+/// <para>
+/// The pairing that matters here is that it fires whenever the geometry is wrong and stays silent
+/// on the shipped default, because a guard that fires on the default configuration gets turned off
+/// rather than heeded.
+/// </para>
 /// </remarks>
 public sealed class FileSystemSandboxStartupValidatorTests : IDisposable
 {
@@ -38,21 +41,11 @@ public sealed class FileSystemSandboxStartupValidatorTests : IDisposable
             Directory.Delete(_root, recursive: true);
     }
 
-    private static AppConfig ConfigWithDurableState(bool escalations, bool proposals)
-    {
-        var config = new AppConfig();
-        config.AI.Governance.DurableState.EscalationsEnabled = escalations;
-        config.AI.Governance.DurableState.ChangeProposalsEnabled = proposals;
-        return config;
-    }
-
     private static FileSystemSandboxStartupValidator NewSut(
         IReadOnlyList<string> allowedBasePaths,
-        IReadOnlyList<string> protectedPaths,
-        AppConfig config) =>
+        IReadOnlyList<string> protectedPaths) =>
         new(allowedBasePaths,
             protectedPaths,
-            new TestConfig.StaticOptionsMonitor<AppConfig>(config),
             NullLogger<FileSystemSandboxStartupValidator>.Instance);
 
     private string CreateDirectory(params string[] parts)
@@ -63,16 +56,16 @@ public sealed class FileSystemSandboxStartupValidatorTests : IDisposable
     }
 
     [Fact]
-    public async Task StartAsync_ProtectedDirectoryInsideAllowedBasePath_DurableStateEnabled_Throws()
+    public async Task StartAsync_ProtectedDirectoryInsideAllowedBasePath_Throws()
     {
         var protectedDir = CreateDirectory(".agent-state");
 
-        var sut = NewSut([_root], [protectedDir], ConfigWithDurableState(escalations: true, proposals: false));
+        var sut = NewSut([_root], [protectedDir]);
 
         var ex = await sut.Invoking(s => s.StartAsync(CancellationToken.None))
             .Should().ThrowAsync<InvalidOperationException>(
-                "a hard link inside the allowed tree would alias the approval-verdict database, " +
-                "and no per-path check can see through a hard link");
+                "granting the file-system tool the governance-state directory leaves a " +
+                "path-comparing deny list as the only barrier to the approval-verdict database");
 
         // The operator has to be able to act on this without reading the source.
         ex.Which.Message.Should().Contain(protectedDir, "the message must name the offending protected path");
@@ -86,7 +79,7 @@ public sealed class FileSystemSandboxStartupValidatorTests : IDisposable
     {
         // Equality is containment's boundary case: granting the tool the protected directory
         // itself is the most direct form of the same misconfiguration.
-        var sut = NewSut([_root], [_root], ConfigWithDurableState(escalations: false, proposals: true));
+        var sut = NewSut([_root], [_root]);
 
         await sut.Invoking(s => s.StartAsync(CancellationToken.None))
             .Should().ThrowAsync<InvalidOperationException>();
@@ -99,10 +92,14 @@ public sealed class FileSystemSandboxStartupValidatorTests : IDisposable
         // against the application base directory, and the governance database under
         // ".agent-state/" — a SIBLING of workspace, not a child. If this ever starts throwing, the
         // safe default has drifted and every host stops booting.
+        //
+        // Read this alongside FileSystemServiceHardLinkTests: the very layout green-lit here is
+        // same-volume, so it IS hard-linkable. This test asserts the validator tolerates the
+        // shipped default, not that the shipped default is safe on its own.
         var workspace = CreateDirectory("workspace");
         var agentState = CreateDirectory(".agent-state");
 
-        var sut = NewSut([workspace], [agentState], ConfigWithDurableState(escalations: true, proposals: true));
+        var sut = NewSut([workspace], [agentState]);
 
         await sut.Invoking(s => s.StartAsync(CancellationToken.None)).Should().NotThrowAsync();
     }
@@ -115,28 +112,35 @@ public sealed class FileSystemSandboxStartupValidatorTests : IDisposable
         var workspace = CreateDirectory("workspace");
         var lookalike = CreateDirectory("workspace-archive");
 
-        var sut = NewSut([workspace], [lookalike], ConfigWithDurableState(escalations: true, proposals: false));
+        var sut = NewSut([workspace], [lookalike]);
 
         await sut.Invoking(s => s.StartAsync(CancellationToken.None)).Should().NotThrowAsync();
     }
 
     [Fact]
-    public async Task StartAsync_OverlapButDurableStateDisabled_DoesNotThrow()
+    public async Task StartAsync_OverlapWithDurableStateDisabled_StillThrows()
     {
-        // Both toggles off means no database is ever created, so the protected directory holds
-        // nothing and refusing to boot would cost a consumer their widened Development allowlist
-        // for no security gain. The toggles are restart-required, so enabling one re-runs this.
+        // The validator takes no configuration and makes no exception for the durable-state
+        // toggles being off. It used to: the reasoning was that the toggles are restart-required,
+        // so enabling one would re-run this validator before any database could be written. That
+        // reasoning is false. EscalationReconciliationService.RunPruneAsync re-reads
+        // AI:Governance:DurableState from IOptionsMonitor on every reconcile tick and AppConfig is
+        // loaded with reloadOnChange: true, so an operator who edits ChangeProposalsEnabled to true
+        // on a RUNNING host creates the database on a host this validator already waved through.
+        // A boot assertion a live config edit can invalidate has to hold on every boot.
         var protectedDir = CreateDirectory(".agent-state");
 
-        var sut = NewSut([_root], [protectedDir], ConfigWithDurableState(escalations: false, proposals: false));
+        var sut = NewSut([_root], [protectedDir]);
 
-        await sut.Invoking(s => s.StartAsync(CancellationToken.None)).Should().NotThrowAsync();
+        await sut.Invoking(s => s.StartAsync(CancellationToken.None))
+            .Should().ThrowAsync<InvalidOperationException>(
+                "the overlap is refused regardless of whether durable state is currently enabled");
     }
 
     [Fact]
     public async Task StartAsync_NoProtectedPathsConfigured_DoesNotThrow()
     {
-        var sut = NewSut([_root], [], ConfigWithDurableState(escalations: true, proposals: true));
+        var sut = NewSut([_root], []);
 
         await sut.Invoking(s => s.StartAsync(CancellationToken.None)).Should().NotThrowAsync();
     }
@@ -154,7 +158,7 @@ public sealed class FileSystemSandboxStartupValidatorTests : IDisposable
         var linkedBase = Path.Combine(_root, "base-link");
         SandboxLinkFactory.CreateDirectoryLink(linkedBase, appDirectory);
 
-        var sut = NewSut([linkedBase], [protectedDir], ConfigWithDurableState(escalations: true, proposals: false));
+        var sut = NewSut([linkedBase], [protectedDir]);
 
         await sut.Invoking(s => s.StartAsync(CancellationToken.None))
             .Should().ThrowAsync<InvalidOperationException>(

--- a/src/Content/Tests/Infrastructure.AI.Tests/Tools/FileSystemServiceHardLinkTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Tools/FileSystemServiceHardLinkTests.cs
@@ -1,0 +1,160 @@
+using FluentAssertions;
+using Infrastructure.AI.Tools;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Tools;
+
+/// <summary>
+/// Covers the hard-link bypass of <see cref="FileSystemService"/>'s sandbox — an agent creating a
+/// second directory entry, inside the workspace, for the harness's own governance-state database.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Why this geometry.</b> Every test here lays the workspace and the protected directory out as
+/// SIBLINGS under one root, because that is exactly what the five hosts ship:
+/// <c>AllowedBasePaths: ["workspace"]</c> and the governance database under <c>.agent-state/</c>,
+/// both resolved against the application base directory. A hard link needs the same VOLUME as its
+/// target, not the same subtree, so siblings on one volume are linkable and the boot-time
+/// containment assertion — which passes on this layout by design — stops nothing.
+/// </para>
+/// <para>
+/// <b>Why a path check cannot do this.</b> A hard link carries no reparse point. On the machine
+/// these were written on, the link reports <c>Archive</c> attributes, a null <c>LinkTarget</c> and a
+/// null <c>ResolveLinkTarget(true)</c>, so canonicalization returns the literal in-workspace path,
+/// the deny list says "not protected" and the allowlist says "allowed". Only the file's link count
+/// distinguishes it, which is what <see cref="HardLinkInspector"/> asks the operating system for.
+/// </para>
+/// <para>
+/// <b>What is at stake, precisely.</b> Reading the database discloses approval payloads; writing
+/// through the alias truncates the shared inode and destroys governance state. Forging a verdict is
+/// NOT reachable this way — every row is HMAC-sealed and verified fail-closed on read — so these
+/// tests defend against disclosure and tamper, and say so rather than overstating.
+/// </para>
+/// </remarks>
+public sealed class FileSystemServiceHardLinkTests : IDisposable
+{
+    private const string DatabaseContent = "approval-verdict-payloads needle";
+
+    private readonly string _root;
+    private readonly string _workspace;
+    private readonly string _protectedDir;
+    private readonly string _database;
+    private readonly FileSystemService _sut;
+
+    public FileSystemServiceHardLinkTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), $"fss-hardlink-{Guid.NewGuid():N}");
+        _workspace = Path.Combine(_root, "workspace");
+        _protectedDir = Path.Combine(_root, ".agent-state");
+        Directory.CreateDirectory(_workspace);
+        Directory.CreateDirectory(_protectedDir);
+
+        _database = Path.Combine(_protectedDir, "governance-state.db");
+        File.WriteAllText(_database, DatabaseContent);
+
+        // The shipped registration: the workspace is allowed, its sibling protected directory is
+        // denied. Note that the startup validator finds NO overlap here and would boot happily.
+        _sut = new FileSystemService(
+            NullLogger<FileSystemService>.Instance,
+            [_workspace],
+            [_protectedDir]);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_root))
+            Directory.Delete(_root, recursive: true);
+    }
+
+    /// <summary>
+    /// Plants the attack: an ordinary-looking workspace file that is a second name for the database.
+    /// </summary>
+    /// <returns>The in-workspace path of the hard link.</returns>
+    private string PlantHardLinkToDatabase()
+    {
+        var link = Path.Combine(_workspace, "innocent.txt");
+        SandboxLinkFactory.CreateHardLink(link, _database);
+        return link;
+    }
+
+    [SkippableFact]
+    public async Task ReadFileAsync_HardLinkToProtectedSibling_IsDenied()
+    {
+        var link = PlantHardLinkToDatabase();
+
+        var act = async () => await _sut.ReadFileAsync(link);
+
+        await act.Should().ThrowAsync<UnauthorizedAccessException>(
+            "the link names the approval-verdict database, and reading it would disclose the " +
+            "approval payloads the sandbox exists to keep from the agent");
+    }
+
+    [SkippableFact]
+    public async Task WriteFileAsync_HardLinkToProtectedSibling_IsDeniedAndLeavesTheDatabaseIntact()
+    {
+        var link = PlantHardLinkToDatabase();
+
+        var act = async () => await _sut.WriteFileAsync(link, "truncated");
+
+        await act.Should().ThrowAsync<UnauthorizedAccessException>(
+            "writing through the alias truncates the shared inode");
+
+        // The denial has to be the reason the file survived, so assert the file, not just the
+        // throw: a guard that threw after opening the target for truncation would pass the first
+        // assertion and still have destroyed the governance state.
+        var onDisk = await File.ReadAllTextAsync(_database);
+        onDisk.Should().Be(DatabaseContent, "the governance state must be byte-for-byte untouched");
+    }
+
+    [SkippableFact]
+    public async Task SearchFilesAsync_HardLinkToProtectedSibling_DisclosesNothing()
+    {
+        PlantHardLinkToDatabase();
+
+        var results = await _sut.SearchFilesAsync(_workspace, "needle");
+
+        results.Should().BeEmpty(
+            "search returns file content, so a gate on reads alone would leave the disclosure " +
+            "path open: grep the workspace for a needle and read the database out of the alias");
+    }
+
+    [Fact]
+    public async Task ReadFileAsync_OrdinaryWorkspaceFile_IsStillAllowed()
+    {
+        // The anti-vacuity guard for every test above. A link-count check that denied everything
+        // would satisfy all three denials while breaking the tool outright; this is what fails if
+        // the gate over-blocks, and it is deliberately a [Fact] so it can never be skipped away.
+        var ordinary = Path.Combine(_workspace, "notes.txt");
+        await File.WriteAllTextAsync(ordinary, "ordinary content");
+
+        var content = await _sut.ReadFileAsync(ordinary);
+
+        content.Should().Be("ordinary content", "a file with one directory entry is unremarkable");
+    }
+
+    [Fact]
+    public async Task WriteFileAsync_NewWorkspaceFile_IsStillAllowed()
+    {
+        // A file that does not exist yet cannot be inspected for links. That must read as "no
+        // second name", not as "cannot establish, therefore deny" — otherwise the tool can never
+        // create a file at all.
+        var fresh = Path.Combine(_workspace, "created.txt");
+
+        await _sut.WriteFileAsync(fresh, "fresh content");
+
+        (await File.ReadAllTextAsync(fresh)).Should().Be("fresh content");
+    }
+
+    [Fact]
+    public async Task SearchFilesAsync_OrdinaryWorkspaceFile_IsStillFound()
+    {
+        // The search-path counterpart of the read anti-vacuity guard: proves the extra gate added
+        // to the walk denies the alias without silently emptying every search result.
+        await File.WriteAllTextAsync(Path.Combine(_workspace, "notes.txt"), "a needle here");
+
+        var results = await _sut.SearchFilesAsync(_workspace, "needle");
+
+        results.Should().ContainSingle("an ordinary singly-linked file is still searchable");
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Tools/FileSystemServiceProtectedPathTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Tools/FileSystemServiceProtectedPathTests.cs
@@ -1,0 +1,124 @@
+using FluentAssertions;
+using Infrastructure.AI.Tools;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Tools;
+
+/// <summary>
+/// Covers <see cref="FileSystemService"/>'s protected-path deny list — the rule that keeps the
+/// harness's own governance-state directory unreachable even when it sits inside an allowed base
+/// path.
+/// </summary>
+/// <remarks>
+/// The stakes are why these are worth their runtime: the protected directory holds the SQLite
+/// database of approval verdicts. An agent that could read it could mine approval payloads; one
+/// that could write it could forge a human approval, which the reconciler would then re-drive into
+/// the hash-chained compliance audit log. Every test here is a bypass that would achieve one of
+/// those, so each must stay closed independently of the others.
+/// </remarks>
+public sealed class FileSystemServiceProtectedPathTests : IDisposable
+{
+    private readonly string _root;
+    private readonly string _protectedDir;
+    private readonly FileSystemService _sut;
+
+    public FileSystemServiceProtectedPathTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), $"fss-prot-{Guid.NewGuid():N}");
+        _protectedDir = Path.Combine(_root, ".agent-state");
+        Directory.CreateDirectory(_protectedDir);
+
+        _sut = new FileSystemService(
+            NullLogger<FileSystemService>.Instance,
+            [_root],
+            [_protectedDir]);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_root))
+            Directory.Delete(_root, recursive: true);
+    }
+
+    [Fact]
+    public async Task ReadFileAsync_FileInsideProtectedDirectory_IsDenied()
+    {
+        var secret = Path.Combine(_protectedDir, "governance-state.db");
+        await File.WriteAllTextAsync(secret, "approval-verdicts");
+
+        var act = async () => await _sut.ReadFileAsync(secret);
+
+        await act.Should().ThrowAsync<UnauthorizedAccessException>(
+            "the deny list must win over the allowlist the protected directory sits inside");
+    }
+
+    [Fact]
+    public async Task SearchFilesAsync_DoesNotDescendIntoProtectedDirectory()
+    {
+        await File.WriteAllTextAsync(
+            Path.Combine(_protectedDir, "governance-state.db"), "needle-in-verdicts");
+        await File.WriteAllTextAsync(Path.Combine(_root, "ordinary.txt"), "needle-in-workspace");
+
+        var results = await _sut.SearchFilesAsync(_root, "needle");
+
+        results.Should().ContainSingle(
+            "the ordinary file matches and the protected one must never be scanned");
+        results[0].FilePath.Should().Contain("ordinary.txt");
+    }
+
+    [Fact]
+    public async Task SearchFilesAsync_SiblingWhoseNameSharesThePrefix_IsStillSearchable()
+    {
+        // Guards the directory-boundary rule: ".agent-state-docs" is a legitimate sibling, not a
+        // child of ".agent-state". A plain string-prefix check would wrongly deny it.
+        var sibling = Path.Combine(_root, ".agent-state-docs");
+        Directory.CreateDirectory(sibling);
+        await File.WriteAllTextAsync(Path.Combine(sibling, "notes.txt"), "needle-in-docs");
+
+        var results = await _sut.SearchFilesAsync(_root, "needle");
+
+        results.Should().ContainSingle("the sibling directory is not protected");
+        results[0].FilePath.Should().Contain("notes.txt");
+    }
+
+    [SkippableFact]
+    public async Task SearchFilesAsync_SymlinkIntoProtectedDirectory_IsStillDenied()
+    {
+        // The per-operation directory-verdict memo lets a file inherit its parent directory's
+        // verdict, which is what keeps a recursive search from resolving links once per file. This
+        // is the case that inheritance must NOT swallow: the parent directory is legitimately
+        // unprotected, but the file inside it is a symlink whose target is the governance-state
+        // database. Inheriting "allowed" here would publish approval verdicts into search results.
+        var target = Path.Combine(_protectedDir, "governance-state.db");
+        await File.WriteAllTextAsync(target, "needle-in-verdicts");
+
+        var link = Path.Combine(_root, "innocent.txt");
+        TryCreateSymlink(target, link);
+
+        var results = await _sut.SearchFilesAsync(_root, "needle");
+
+        results.Should().BeEmpty(
+            "a symlink is resolved to its target before the deny check, so it cannot be used to " +
+            "read the protected database through an unprotected directory");
+    }
+
+    /// <summary>
+    /// Creates a file symlink, skipping the test when the host forbids it (Windows without
+    /// Developer Mode or elevation). Skipping is honest here: the assertion is meaningless if the
+    /// link was never created, and a silently-passing test would be worse than no test.
+    /// </summary>
+    /// <param name="target">The link target.</param>
+    /// <param name="link">The link path to create.</param>
+    private static void TryCreateSymlink(string target, string link)
+    {
+        try
+        {
+            File.CreateSymbolicLink(link, target);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or PlatformNotSupportedException)
+        {
+            Skip.If(true, $"This host does not permit creating symlinks: {ex.GetType().Name}");
+        }
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Tools/FileSystemServiceProtectedPathTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Tools/FileSystemServiceProtectedPathTests.cs
@@ -12,10 +12,11 @@ namespace Infrastructure.AI.Tests.Tools;
 /// </summary>
 /// <remarks>
 /// The stakes are why these are worth their runtime: the protected directory holds the SQLite
-/// database of approval verdicts. An agent that could read it could mine approval payloads; one
-/// that could write it could forge a human approval, which the reconciler would then re-drive into
-/// the hash-chained compliance audit log. Every test here is a bypass that would achieve one of
-/// those, so each must stay closed independently of the others.
+/// database of approval verdicts. An agent that could read it could mine the approval payloads it
+/// carries; one that could write it could truncate or corrupt the harness's own governance state.
+/// It could not forge a verdict — every row is HMAC-sealed and verified fail-closed on read — so
+/// what these defend is disclosure and tamper. Every test here is a bypass that would achieve one
+/// of those, so each must stay closed independently of the others.
 /// </remarks>
 public sealed class FileSystemServiceProtectedPathTests : IDisposable
 {

--- a/src/Content/Tests/Infrastructure.AI.Tests/Tools/FileSystemServiceProtectedPathTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Tools/FileSystemServiceProtectedPathTests.cs
@@ -82,6 +82,54 @@ public sealed class FileSystemServiceProtectedPathTests : IDisposable
         results[0].FilePath.Should().Contain("notes.txt");
     }
 
+    [Fact]
+    public async Task SearchFilesAsync_ProtectedDirectoryNestedBelowAnAllowedParent_IsStillPruned()
+    {
+        // The per-operation verdict memo must never decide a DIRECTORY's verdict. A protected
+        // directory is an ordinary, non-reparse-point directory whose parent is legitimately
+        // unprotected, so parent-verdict inheritance — which is sound for files — reports it as
+        // allowed, prunes nothing, and the walk reads the approval-verdict database. Nesting it a
+        // level down is what puts an already-memoized parent above it and exercises that path.
+        var nestedProtected = Path.Combine(_root, "deep", ".agent-state");
+        Directory.CreateDirectory(nestedProtected);
+        await File.WriteAllTextAsync(
+            Path.Combine(nestedProtected, "governance-state.db"), "needle-in-verdicts");
+
+        var sut = new FileSystemService(
+            NullLogger<FileSystemService>.Instance, [_root], [nestedProtected]);
+
+        var results = await sut.SearchFilesAsync(_root, "needle");
+
+        results.Should().BeEmpty("a protected directory is pruned wherever it sits in the walk");
+    }
+
+    [SkippableFact]
+    public async Task SearchFilesAsync_CaseDistinctProtectedDirectories_AreBothDenied()
+    {
+        Skip.If(
+            OperatingSystem.IsWindows(),
+            "Windows paths are case-insensitive, so 'state' and 'State' name one directory and the " +
+            "de-duplication this test detects cannot arise. It runs on the Linux CI runners.");
+
+        // The deny set must be keyed by PathScope.Comparer, never a hardcoded OrdinalIgnoreCase.
+        // On a case-sensitive filesystem these are two different directories; a case-insensitive
+        // HashSet collapses them into one entry and the survivor silently stops being protected.
+        // That failure direction is fail-OPEN, which is why it belongs in the deny set's tests.
+        var lower = Path.Combine(_root, "state");
+        var upper = Path.Combine(_root, "State");
+        Directory.CreateDirectory(lower);
+        Directory.CreateDirectory(upper);
+        await File.WriteAllTextAsync(Path.Combine(lower, "a.db"), "needle-lower-verdicts");
+        await File.WriteAllTextAsync(Path.Combine(upper, "b.db"), "needle-upper-verdicts");
+
+        var sut = new FileSystemService(
+            NullLogger<FileSystemService>.Instance, [_root], [lower, upper]);
+
+        var results = await sut.SearchFilesAsync(_root, "needle");
+
+        results.Should().BeEmpty("both case-distinct protected directories must survive the set");
+    }
+
     [SkippableFact]
     public async Task SearchFilesAsync_SymlinkIntoProtectedDirectory_IsStillDenied()
     {

--- a/src/Content/Tests/Infrastructure.AI.Tests/Tools/FileSystemServiceSandboxEscapeTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Tools/FileSystemServiceSandboxEscapeTests.cs
@@ -1,0 +1,131 @@
+using FluentAssertions;
+using Infrastructure.AI.Tools;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Tools;
+
+/// <summary>
+/// Covers <see cref="FileSystemService"/>'s allowlist arm against links that point out of the
+/// sandbox — the recursive-search path specifically.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The direct-read path resolves links before comparing against the allowlist. The search walk did
+/// not: it canonicalized a path only to answer "is this protected?", then compared the raw
+/// enumerated path against the allowlist. A junction at <c>workspace\notes</c> pointing at
+/// <c>C:\Users\victim\.ssh</c> is not protected, so the walk descended into it, and every file it
+/// then yielded carried a literal <c>workspace\notes\...</c> path that satisfied a
+/// workspace-rooted allowlist — after which <see cref="File.ReadLinesAsync(string)"/> followed the
+/// link and put the contents in the search results.
+/// </para>
+/// <para>
+/// This is the more reachable of the two escapes the branch was reviewed for: <c>mklink /J</c>
+/// needs no privilege on Windows, and git can carry symlinks into a cloned workspace, so an
+/// attacker does not need a foothold beyond the workspace the agent is already pointed at.
+/// </para>
+/// </remarks>
+public sealed class FileSystemServiceSandboxEscapeTests : IDisposable
+{
+    private const string Secret = "needle-private-key-material";
+
+    private readonly string _sandboxRoot;
+    private readonly string _outsideRoot;
+    private readonly FileSystemService _sut;
+
+    public FileSystemServiceSandboxEscapeTests()
+    {
+        var scope = Path.Combine(Path.GetTempPath(), $"fss-esc-{Guid.NewGuid():N}");
+        _sandboxRoot = Path.Combine(scope, "workspace");
+        _outsideRoot = Path.Combine(scope, "victim");
+
+        Directory.CreateDirectory(_sandboxRoot);
+        Directory.CreateDirectory(_outsideRoot);
+        File.WriteAllText(Path.Combine(_outsideRoot, "id_rsa"), Secret);
+
+        // Only the workspace is allowed. "victim" is a sibling, exactly as a user's home directory
+        // is a sibling of the agent's sandbox — reachable on the same volume, never allowlisted.
+        _sut = new FileSystemService(
+            NullLogger<FileSystemService>.Instance,
+            [_sandboxRoot]);
+    }
+
+    public void Dispose()
+    {
+        var scope = Path.GetDirectoryName(_sandboxRoot);
+        if (scope is not null && Directory.Exists(scope))
+            Directory.Delete(scope, recursive: true);
+    }
+
+    [SkippableFact]
+    public async Task SearchFilesAsync_DirectoryLinkPointingOutsideTheSandbox_LeaksNothing()
+    {
+        SandboxLinkFactory.CreateDirectoryLink(Path.Combine(_sandboxRoot, "notes"), _outsideRoot);
+
+        var results = await _sut.SearchFilesAsync(_sandboxRoot, "needle");
+
+        results.Should().BeEmpty(
+            "the walk must prune a subdirectory whose canonical target is outside every allowed " +
+            "base path, however workspace-shaped its literal path looks");
+    }
+
+    [SkippableFact]
+    public async Task SearchFilesAsync_FileLinkPointingOutsideTheSandbox_LeaksNothing()
+    {
+        // The per-file gate, not the directory prune: the link sits directly in an allowed
+        // directory whose verdict has already been recorded, which is exactly the case the
+        // parent-verdict memo is tempted to wave through.
+        SandboxLinkFactory.CreateFileLink(Path.Combine(_sandboxRoot, "innocent.txt"),
+            Path.Combine(_outsideRoot, "id_rsa"));
+
+        var results = await _sut.SearchFilesAsync(_sandboxRoot, "needle");
+
+        results.Should().BeEmpty(
+            "a file link is resolved before the allowlist comparison, so it cannot read a file " +
+            "outside the sandbox through an allowed directory");
+    }
+
+    [SkippableFact]
+    public async Task SearchFilesAsync_NestedFileBeneathADirectoryLink_LeaksNothing()
+    {
+        // The deepest form: the file is neither the link nor a direct child of an allowed
+        // directory. Its parent's verdict is inherited from the memo, so the inherited entry has
+        // to carry the parent's CANONICAL path — inheriting only "not protected" leaves the
+        // allowlist comparing the literal workspace-shaped path and the file leaks.
+        Directory.CreateDirectory(Path.Combine(_outsideRoot, "nested"));
+        await File.WriteAllTextAsync(Path.Combine(_outsideRoot, "nested", "deep.txt"), Secret);
+
+        SandboxLinkFactory.CreateDirectoryLink(Path.Combine(_sandboxRoot, "notes"), _outsideRoot);
+
+        var results = await _sut.SearchFilesAsync(_sandboxRoot, "needle");
+
+        results.Should().BeEmpty();
+    }
+
+    [SkippableFact]
+    public async Task ReadFileAsync_ThroughADirectoryLinkPointingOutsideTheSandbox_IsDenied()
+    {
+        // Parity check for the claim the search gate documents about itself: the direct-read path
+        // must reach the same verdict on the same path. If this ever diverges from the search
+        // results above, one of the two gates has drifted.
+        SandboxLinkFactory.CreateDirectoryLink(Path.Combine(_sandboxRoot, "notes"), _outsideRoot);
+
+        var act = async () => await _sut.ReadFileAsync(Path.Combine(_sandboxRoot, "notes", "id_rsa"));
+
+        await act.Should().ThrowAsync<UnauthorizedAccessException>();
+    }
+
+    [Fact]
+    public async Task SearchFilesAsync_OrdinaryFileInsideTheSandbox_IsStillFound()
+    {
+        // The escape fix prunes on the canonical path, which is also the path an ordinary file is
+        // now judged by. If canonicalization ever stopped agreeing with the configured base paths,
+        // the tool would deny everything and every test above would pass vacuously.
+        await File.WriteAllTextAsync(Path.Combine(_sandboxRoot, "notes.txt"), "needle-in-workspace");
+
+        var results = await _sut.SearchFilesAsync(_sandboxRoot, "needle");
+
+        results.Should().ContainSingle();
+        results[0].FilePath.Should().Contain("notes.txt");
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Tools/GovernanceStateProtectionGateTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Tools/GovernanceStateProtectionGateTests.cs
@@ -1,0 +1,144 @@
+using Domain.Common.Config.AI.Governance;
+using FluentAssertions;
+using Infrastructure.AI.Tools;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Tools;
+
+/// <summary>
+/// Covers <c>DependencyInjection.ResolveGovernanceStateProtectedPaths</c> — the composition-time
+/// decision about whether the governance-state directory is worth denying to the file-system tool.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The decision is load-bearing well beyond the deny list. Handing
+/// <see cref="FileSystemService"/> a protected path also arms its per-operation hard-link identity
+/// check, and that check fails closed on any platform <c>HardLinkInspector</c> has no
+/// implementation for. Arming it therefore costs macOS and BSD consumers the entire file-system
+/// tool. Before this gate existed the directory was registered unconditionally, so that cost was
+/// paid under every configuration — including the shipped default, where durable governance state
+/// is off and no database has ever been written. That is a control armed for a feature that is not
+/// running.
+/// </para>
+/// <para>
+/// Each test asserts the gate's output <em>and</em> the boot outcome that output produces, because
+/// the two halves are only interesting together. A test that checked the returned array alone would
+/// still pass if <see cref="FileSystemSandboxStartupValidator"/> stopped arming on the same
+/// condition, which is exactly the drift that would make a consumer's host refuse to boot over a
+/// configuration with nothing to protect.
+/// </para>
+/// </remarks>
+public sealed class GovernanceStateProtectionGateTests : IDisposable
+{
+    private readonly string _root;
+    private readonly string _workspace;
+    private readonly string _governanceStateDirectory;
+
+    public GovernanceStateProtectionGateTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), $"gov-gate-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_root);
+
+        // Siblings, mirroring the shipped layout: AllowedBasePaths ["workspace"] and the database
+        // under ".agent-state". Non-overlapping on purpose — the validator reports an overlap ahead
+        // of the platform limitation, so an overlapping layout would mask the branch under test.
+        _workspace = Path.Combine(_root, "workspace");
+        Directory.CreateDirectory(_workspace);
+        _governanceStateDirectory = Path.Combine(_root, ".agent-state");
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_root))
+            Directory.Delete(_root, recursive: true);
+    }
+
+    private static GovernanceDurableStateConfig Durable(
+        bool escalations = false, bool changeProposals = false) =>
+        new() { EscalationsEnabled = escalations, ChangeProposalsEnabled = changeProposals };
+
+    /// <summary>
+    /// Boots a validator over the paths the gate produced, with the hard-link platform capability
+    /// forced off so the macOS branch is exercised on whatever OS the suite runs on.
+    /// </summary>
+    private Task BootOnAPlatformWithoutHardLinkSupport(IReadOnlyList<string> protectedPaths) =>
+        new FileSystemSandboxStartupValidator(
+                [_workspace],
+                protectedPaths,
+                NullLogger<FileSystemSandboxStartupValidator>.Instance,
+                hardLinkInspectionSupported: false)
+            .StartAsync(CancellationToken.None);
+
+    [Fact]
+    public async Task BothTogglesOffAndNoDirectory_RegistersNothingAndBootsOnAnUnsupportedPlatform()
+    {
+        // The shipped default, and the whole reason for the gate. Nothing has ever written a
+        // governance-state database, so there is no file to disclose, truncate, or alias — and no
+        // justification for a control whose cost is the file-system tool on macOS and the BSDs.
+        Directory.Exists(_governanceStateDirectory).Should().BeFalse("the premise is that no run has created it");
+
+        var protectedPaths = DependencyInjection.ResolveGovernanceStateProtectedPaths(
+            Durable(), _governanceStateDirectory);
+
+        protectedPaths.Should().BeEmpty(
+            "with the feature off and no database on disk there is nothing to protect");
+
+        await FluentActions.Awaiting(() => BootOnAPlatformWithoutHardLinkSupport(protectedPaths))
+            .Should().NotThrowAsync(
+                "a host with nothing to protect must run the file-system tool on every platform");
+    }
+
+    [Fact]
+    public async Task BothTogglesOffButDirectoryPresent_RegistersItAndRefusesOnAnUnsupportedPlatform()
+    {
+        // The residual case, and the reason the gate cannot read the toggles alone. A database left
+        // behind by a run that DID have durability enabled still holds approval verdicts; those
+        // records do not stop being sensitive because someone later set a flag to false. Gating on
+        // the toggles only would silently un-protect them.
+        Directory.CreateDirectory(_governanceStateDirectory);
+
+        var protectedPaths = DependencyInjection.ResolveGovernanceStateProtectedPaths(
+            Durable(), _governanceStateDirectory);
+
+        protectedPaths.Should().ContainSingle().Which.Should().Be(
+            _governanceStateDirectory,
+            "verdicts left by an earlier run stay sensitive after the toggles go back to false");
+
+        await FluentActions.Awaiting(() => BootOnAPlatformWithoutHardLinkSupport(protectedPaths))
+            .Should().ThrowAsync<InvalidOperationException>(
+                "there is genuinely something to protect here, so a platform that cannot run the " +
+                "hard-link control must be refused rather than silently left unguarded");
+    }
+
+    [Theory]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    [InlineData(true, true)]
+    public async Task EitherToggleOn_RegistersTheDirectoryEvenBeforeItExists(
+        bool escalations, bool changeProposals)
+    {
+        // Both toggles, because either one on its own puts records in that database — escalations
+        // write escalation_state, change proposals write change_proposal — and a gate that checked
+        // only EscalationsEnabled would leave a change-proposal-only host unguarded.
+        //
+        // The directory deliberately does NOT exist yet: on a first run with durability enabled the
+        // gate is evaluated at composition, before anything resolves the DbContext factory that
+        // creates it. A gate that waited for the directory to appear would leave the very first run
+        // — the one that populates the database — running with the deny list disarmed.
+        Directory.Exists(_governanceStateDirectory).Should().BeFalse(
+            "the point of this case is that the directory has not been created yet");
+
+        var protectedPaths = DependencyInjection.ResolveGovernanceStateProtectedPaths(
+            Durable(escalations, changeProposals), _governanceStateDirectory);
+
+        protectedPaths.Should().ContainSingle().Which.Should().Be(
+            _governanceStateDirectory,
+            "the feature is on, so the database is about to exist and must be protected from the start");
+
+        await FluentActions.Awaiting(() => BootOnAPlatformWithoutHardLinkSupport(protectedPaths))
+            .Should().ThrowAsync<InvalidOperationException>(
+                "durable governance state on a platform without the hard-link control is the " +
+                "documented unsupported combination");
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Tools/Support/SandboxLinkFactory.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Tools/Support/SandboxLinkFactory.cs
@@ -1,0 +1,119 @@
+using System.Diagnostics;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Tools;
+
+/// <summary>
+/// Creates the filesystem links the sandbox-escape tests need, using the same primitives an
+/// attacker would, and skips the calling test rather than passing vacuously when the host forbids
+/// every one of them.
+/// </summary>
+/// <remarks>
+/// Two mechanisms are tried in order, because their privilege requirements differ and the point of
+/// these tests is that the attack needs no privilege. <see cref="Directory.CreateSymbolicLink"/>
+/// works freely on Linux but needs Developer Mode or elevation on Windows; a Windows directory
+/// junction (<c>mklink /J</c>) needs neither, which is precisely why it is the more reachable
+/// attack. Falling back to the junction keeps the test real on a stock Windows agent instead of
+/// silently skipping there.
+/// </remarks>
+internal static class SandboxLinkFactory
+{
+    private static readonly TimeSpan MkLinkTimeout = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// Creates a directory link at <paramref name="link"/> resolving to <paramref name="target"/>.
+    /// </summary>
+    /// <param name="link">The link path to create; must not already exist.</param>
+    /// <param name="target">The existing directory the link resolves to.</param>
+    public static void CreateDirectoryLink(string link, string target)
+    {
+        if (TryCreateSymbolicLink(link, target, out var symlinkFailure))
+            return;
+
+        if (!OperatingSystem.IsWindows())
+        {
+            Skip.If(true, $"This host does not permit creating directory symlinks: {symlinkFailure}");
+            return;
+        }
+
+        var junctionFailure = TryCreateJunction(link, target);
+        Skip.If(
+            junctionFailure is not null,
+            $"This host permits neither directory symlinks ({symlinkFailure}) nor junctions ({junctionFailure}).");
+    }
+
+    /// <summary>
+    /// Creates a file link at <paramref name="link"/> resolving to <paramref name="target"/>.
+    /// </summary>
+    /// <remarks>
+    /// There is no unprivileged Windows fallback for a file symlink — <c>mklink /H</c> creates a
+    /// hard link, which is a different attack with a different defence (the boot-time containment
+    /// assertion, not link resolution) — so this skips when symlinks are unavailable.
+    /// </remarks>
+    /// <param name="link">The link path to create; must not already exist.</param>
+    /// <param name="target">The existing file the link resolves to.</param>
+    public static void CreateFileLink(string link, string target)
+    {
+        try
+        {
+            File.CreateSymbolicLink(link, target);
+        }
+        catch (Exception ex) when (ex is IOException
+                                      or UnauthorizedAccessException
+                                      or PlatformNotSupportedException)
+        {
+            Skip.If(true, $"This host does not permit creating file symlinks: {ex.GetType().Name}");
+        }
+    }
+
+    private static bool TryCreateSymbolicLink(string link, string target, out string? failure)
+    {
+        try
+        {
+            Directory.CreateSymbolicLink(link, target);
+            failure = null;
+            return true;
+        }
+        catch (Exception ex) when (ex is IOException
+                                      or UnauthorizedAccessException
+                                      or PlatformNotSupportedException)
+        {
+            failure = ex.GetType().Name;
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Runs <c>cmd /c mklink /J</c>. Returns <see langword="null"/> on success, or a short reason.
+    /// </summary>
+    private static string? TryCreateJunction(string link, string target)
+    {
+        try
+        {
+            using var process = Process.Start(new ProcessStartInfo("cmd.exe")
+            {
+                // ArgumentList quotes each entry, so paths with spaces survive intact.
+                ArgumentList = { "/c", "mklink", "/J", link, target },
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+            });
+
+            if (process is null)
+                return "cmd.exe did not start";
+
+            if (!process.WaitForExit(MkLinkTimeout))
+            {
+                process.Kill(entireProcessTree: true);
+                return "mklink timed out";
+            }
+
+            return Directory.Exists(link) ? null : $"mklink exited {process.ExitCode}";
+        }
+        catch (Exception ex) when (ex is System.ComponentModel.Win32Exception or InvalidOperationException)
+        {
+            return ex.GetType().Name;
+        }
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Tools/Support/SandboxLinkFactory.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Tools/Support/SandboxLinkFactory.cs
@@ -47,8 +47,9 @@ internal static class SandboxLinkFactory
     /// </summary>
     /// <remarks>
     /// There is no unprivileged Windows fallback for a file symlink — <c>mklink /H</c> creates a
-    /// hard link, which is a different attack with a different defence (the boot-time containment
-    /// assertion, not link resolution) — so this skips when symlinks are unavailable.
+    /// hard link, which is a different attack with a different defence (the per-operation link-count
+    /// check, not link resolution; see <see cref="CreateHardLink"/>) — so this skips when symlinks
+    /// are unavailable.
     /// </remarks>
     /// <param name="link">The link path to create; must not already exist.</param>
     /// <param name="target">The existing file the link resolves to.</param>
@@ -64,6 +65,36 @@ internal static class SandboxLinkFactory
         {
             Skip.If(true, $"This host does not permit creating file symlinks: {ex.GetType().Name}");
         }
+    }
+
+    /// <summary>
+    /// Creates a hard link at <paramref name="link"/> naming the same file as
+    /// <paramref name="target"/>, skipping the calling test when the host forbids it.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// There is no managed API for this, so both platforms shell out to the same unprivileged
+    /// command an attacker would use: <c>mklink /H</c> on Windows, <c>ln</c> everywhere else.
+    /// Neither needs elevation, neither needs Developer Mode, and the resulting entry carries no
+    /// reparse point — which is exactly why the sandbox's path canonicalization cannot see it.
+    /// </para>
+    /// <para>
+    /// The link and target must be on the same volume, which every caller satisfies by putting
+    /// both under one temporary root. That is not a limitation of the test: it is the shipped
+    /// default's geometry, where <c>workspace</c> and <c>.agent-state</c> are siblings.
+    /// </para>
+    /// </remarks>
+    /// <param name="link">The hard-link path to create; must not already exist.</param>
+    /// <param name="target">The existing file to create a second directory entry for.</param>
+    public static void CreateHardLink(string link, string target)
+    {
+        var failure = OperatingSystem.IsWindows()
+            ? RunLinkCommand("cmd.exe", ["/c", "mklink", "/H", link, target])
+            : RunLinkCommand("/bin/ln", [target, link]);
+
+        Skip.If(
+            failure is not null || !File.Exists(link),
+            $"This host does not permit creating hard links: {failure ?? "the link was not created"}.");
     }
 
     private static bool TryCreateSymbolicLink(string link, string target, out string? failure)
@@ -88,28 +119,49 @@ internal static class SandboxLinkFactory
     /// </summary>
     private static string? TryCreateJunction(string link, string target)
     {
+        var failure = RunLinkCommand("cmd.exe", ["/c", "mklink", "/J", link, target]);
+        if (failure is not null)
+            return failure;
+
+        return Directory.Exists(link) ? null : "mklink created no junction";
+    }
+
+    /// <summary>
+    /// Runs a link-creating command to completion. Returns <see langword="null"/> when it exited
+    /// zero, or a short human-readable reason otherwise.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="ProcessStartInfo.ArgumentList"/> rather than a joined argument string: it quotes
+    /// each entry, so the temporary paths these tests build survive spaces intact.
+    /// </remarks>
+    /// <param name="fileName">The executable to run.</param>
+    /// <param name="arguments">Arguments, one entry per argument.</param>
+    private static string? RunLinkCommand(string fileName, string[] arguments)
+    {
         try
         {
-            using var process = Process.Start(new ProcessStartInfo("cmd.exe")
+            var startInfo = new ProcessStartInfo(fileName)
             {
-                // ArgumentList quotes each entry, so paths with spaces survive intact.
-                ArgumentList = { "/c", "mklink", "/J", link, target },
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,
                 UseShellExecute = false,
                 CreateNoWindow = true,
-            });
+            };
 
+            foreach (var argument in arguments)
+                startInfo.ArgumentList.Add(argument);
+
+            using var process = Process.Start(startInfo);
             if (process is null)
-                return "cmd.exe did not start";
+                return $"{fileName} did not start";
 
             if (!process.WaitForExit(MkLinkTimeout))
             {
                 process.Kill(entireProcessTree: true);
-                return "mklink timed out";
+                return $"{fileName} timed out";
             }
 
-            return Directory.Exists(link) ? null : $"mklink exited {process.ExitCode}";
+            return process.ExitCode == 0 ? null : $"{fileName} exited {process.ExitCode}";
         }
         catch (Exception ex) when (ex is System.ComponentModel.Win32Exception or InvalidOperationException)
         {

--- a/src/Content/Tests/Presentation.Common.Tests/Escalations/EscalationsControllerTests.cs
+++ b/src/Content/Tests/Presentation.Common.Tests/Escalations/EscalationsControllerTests.cs
@@ -1,4 +1,5 @@
 using System.Security.Claims;
+using Application.AI.Common.Interfaces.Escalation;
 using Application.Core.CQRS.Escalation;
 using Domain.AI.Escalation;
 using Domain.Common;
@@ -308,17 +309,16 @@ public sealed class EscalationsControllerTests
     }
 
     [Fact]
-    public async Task SubmitDecision_AwaitingReconciliation_Returns409NotServerError()
+    public async Task SubmitDecision_ConflictFailure_Returns409WithTheHandlersDetail()
     {
-        // Reachable in the DEFAULT durability-off config: approver A's decision resolves the
-        // escalation, the fail-closed audit write throws, the escalation parks with
-        // ResolutionFailed set and stays in the active set, and approver B's decision then comes
-        // back AwaitingReconciliation. With no arm for it the switch fell through to the 500
-        // default, so an ordinary lifecycle state read to the caller as a server fault.
-        SetupDecision(new SubmitEscalationDecisionResult
-        {
-            Status = EscalationDecisionStatus.AwaitingReconciliation
-        });
+        // End-to-end proof that a conflict still surfaces as 409 now that the controller has no
+        // hand-rolled arm for it. SubmitEscalationDecisionCommandHandler classifies both conflict
+        // statuses in the Application layer; the controller's only job is to let the shared
+        // failure mapper render that verdict, detail intact.
+        _mediator.Setup(m => m.Send(It.IsAny<SubmitEscalationDecisionCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<SubmitEscalationDecisionResult>.Conflict(
+                "The escalation had already reached a verdict whose durable record could not be " +
+                "written, so it is parked awaiting reconciliation. This decision was not counted."));
 
         var result = await CreateSut(ApproverClaim()).SubmitDecision(
             Guid.NewGuid(), new SubmitEscalationDecisionRequest(true), CancellationToken.None);
@@ -331,44 +331,24 @@ public sealed class EscalationsControllerTests
         var details = problem.Value.Should().BeAssignableTo<ProblemDetails>().Subject;
         details.Detail.Should().Contain("not counted",
             "the approver must be told plainly that their vote did not participate");
-        details.Detail.Should().Contain("GET /api/escalations",
-            "the caller needs the poll target for the verdict that reconciliation will publish");
     }
 
     [Fact]
-    public async Task SubmitDecision_ConflictingDecision_Returns409NotServerError()
+    public async Task SubmitDecision_EveryStatusTheHandlerPassesThrough_MapsToSomethingOtherThan500()
     {
-        // The handler normally translates this to a Conflict failure, so this status should not
-        // arrive here. It is mapped anyway: a handler change must not be able to silently demote
-        // a votes-cannot-be-changed conflict into a 500.
-        SetupDecision(new SubmitEscalationDecisionResult
-        {
-            Status = EscalationDecisionStatus.ConflictingDecision
-        });
-
-        var result = await CreateSut(ApproverClaim()).SubmitDecision(
-            Guid.NewGuid(), new SubmitEscalationDecisionRequest(true), CancellationToken.None);
-
-        result.Should().BeOfType<ObjectResult>()
-            .Which.StatusCode.Should().Be(StatusCodes.Status409Conflict);
-    }
-
-    [Fact]
-    public async Task SubmitDecision_EveryDecisionStatus_MapsToSomethingOtherThan500()
-    {
-        // The guard for the whole defect class: adding a member to EscalationDecisionStatus
-        // without an arm in the controller silently turns it into a 500. This fails the moment
-        // that happens, naming the unmapped member.
+        // The transport half of the exhaustiveness guard. The handler owns classification (see
+        // SubmitEscalationDecisionCommandHandlerTests); what must hold HERE is that every status
+        // the handler forwards as data has an explicit arm. Running the real handler to decide
+        // which statuses those are keeps this test from hardcoding — and then silently
+        // disagreeing with — the handler's list.
         foreach (var status in Enum.GetValues<EscalationDecisionStatus>())
         {
+            var handlerResult = await RunRealHandlerAsync(status);
+            if (!handlerResult.IsSuccess)
+                continue;
+
             _mediator.Reset();
-            SetupDecision(new SubmitEscalationDecisionResult
-            {
-                Status = status,
-                Outcome = status == EscalationDecisionStatus.Resolved
-                    ? NewOutcomeSummary(Guid.NewGuid())
-                    : null
-            });
+            SetupDecision(handlerResult.Value!);
 
             var result = await CreateSut(ApproverClaim()).SubmitDecision(
                 Guid.NewGuid(), new SubmitEscalationDecisionRequest(true), CancellationToken.None);
@@ -382,6 +362,53 @@ public sealed class EscalationsControllerTests
             statusCode.Should().NotBe(StatusCodes.Status500InternalServerError,
                 $"EscalationDecisionStatus.{status} has no explicit arm in the controller's mapping");
         }
+    }
+
+    /// <summary>
+    /// Runs the real command handler over a stubbed escalation service so this test can ask the
+    /// Application layer — rather than a copy of its rules — which statuses reach the controller.
+    /// </summary>
+    /// <param name="status">The service status to simulate.</param>
+    private static async Task<Result<SubmitEscalationDecisionResult>> RunRealHandlerAsync(
+        EscalationDecisionStatus status)
+    {
+        var outcome = new EscalationOutcome
+        {
+            EscalationId = Guid.NewGuid(),
+            IsApproved = true,
+            ResolutionType = EscalationResolutionType.Approved,
+            ResolvedAt = DateTimeOffset.UtcNow,
+            Decisions = []
+        };
+
+        var decisionResult = status switch
+        {
+            EscalationDecisionStatus.UnknownEscalation => EscalationDecisionResult.UnknownEscalation(),
+            EscalationDecisionStatus.ApproverNotAuthorized => EscalationDecisionResult.ApproverNotAuthorized(),
+            EscalationDecisionStatus.DecisionRecorded => EscalationDecisionResult.DecisionRecorded(),
+            EscalationDecisionStatus.ConflictingDecision => EscalationDecisionResult.ConflictingDecision(),
+            EscalationDecisionStatus.AwaitingReconciliation => EscalationDecisionResult.AwaitingReconciliation(),
+            EscalationDecisionStatus.Resolved => EscalationDecisionResult.Resolved(outcome),
+            _ => throw new ArgumentOutOfRangeException(
+                nameof(status), status,
+                "A new EscalationDecisionStatus has no test factory; add one so this guard covers it.")
+        };
+
+        var service = new Mock<IEscalationService>();
+        service.Setup(s => s.SubmitDecisionAsync(
+                It.IsAny<Guid>(), It.IsAny<ApproverDecision>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(decisionResult);
+
+        var handler = new SubmitEscalationDecisionCommandHandler(
+            service.Object, NullLogger<SubmitEscalationDecisionCommandHandler>.Instance);
+
+        return await handler.Handle(new SubmitEscalationDecisionCommand
+        {
+            EscalationId = Guid.NewGuid(),
+            ApproverName = "alice@contoso.com",
+            Approve = true,
+            Reason = null
+        }, CancellationToken.None);
     }
 
     // --- Read/cancel Result mapping through the shared failure mapper ---

--- a/src/Content/Tests/Presentation.Common.Tests/Escalations/EscalationsControllerTests.cs
+++ b/src/Content/Tests/Presentation.Common.Tests/Escalations/EscalationsControllerTests.cs
@@ -21,7 +21,8 @@ namespace Presentation.Common.Tests.Escalations;
 /// is stamped exclusively from the principal's configured claim (the body cannot supply it),
 /// that a missing claim fails closed with 403 before any dispatch, and that every
 /// <see cref="EscalationDecisionStatus"/> maps to its documented HTTP status
-/// (404 / 403 / 202 / 200). Wire-level auth and routing coverage lives in
+/// (404 / 403 / 202 / 200 / 409) — including an exhaustiveness guard proving no member falls
+/// through to a 500. Wire-level auth and routing coverage lives in
 /// <c>Presentation.AgentHub.Tests</c>.
 /// </summary>
 public sealed class EscalationsControllerTests
@@ -304,6 +305,83 @@ public sealed class EscalationsControllerTests
         var body = ok.Value.Should().BeOfType<EscalationDecisionResponse>().Subject;
         body.Status.Should().Be(EscalationDecisionStatus.Resolved);
         body.Outcome!.EscalationId.Should().Be(id);
+    }
+
+    [Fact]
+    public async Task SubmitDecision_AwaitingReconciliation_Returns409NotServerError()
+    {
+        // Reachable in the DEFAULT durability-off config: approver A's decision resolves the
+        // escalation, the fail-closed audit write throws, the escalation parks with
+        // ResolutionFailed set and stays in the active set, and approver B's decision then comes
+        // back AwaitingReconciliation. With no arm for it the switch fell through to the 500
+        // default, so an ordinary lifecycle state read to the caller as a server fault.
+        SetupDecision(new SubmitEscalationDecisionResult
+        {
+            Status = EscalationDecisionStatus.AwaitingReconciliation
+        });
+
+        var result = await CreateSut(ApproverClaim()).SubmitDecision(
+            Guid.NewGuid(), new SubmitEscalationDecisionRequest(true), CancellationToken.None);
+
+        var problem = result.Should().BeOfType<ObjectResult>().Subject;
+        problem.StatusCode.Should().Be(StatusCodes.Status409Conflict,
+            "the verdict is already decided, so this vote will never be counted no matter how " +
+            "often the request is retried — a state conflict, not the transient unavailability 503 implies");
+
+        var details = problem.Value.Should().BeAssignableTo<ProblemDetails>().Subject;
+        details.Detail.Should().Contain("not counted",
+            "the approver must be told plainly that their vote did not participate");
+        details.Detail.Should().Contain("GET /api/escalations",
+            "the caller needs the poll target for the verdict that reconciliation will publish");
+    }
+
+    [Fact]
+    public async Task SubmitDecision_ConflictingDecision_Returns409NotServerError()
+    {
+        // The handler normally translates this to a Conflict failure, so this status should not
+        // arrive here. It is mapped anyway: a handler change must not be able to silently demote
+        // a votes-cannot-be-changed conflict into a 500.
+        SetupDecision(new SubmitEscalationDecisionResult
+        {
+            Status = EscalationDecisionStatus.ConflictingDecision
+        });
+
+        var result = await CreateSut(ApproverClaim()).SubmitDecision(
+            Guid.NewGuid(), new SubmitEscalationDecisionRequest(true), CancellationToken.None);
+
+        result.Should().BeOfType<ObjectResult>()
+            .Which.StatusCode.Should().Be(StatusCodes.Status409Conflict);
+    }
+
+    [Fact]
+    public async Task SubmitDecision_EveryDecisionStatus_MapsToSomethingOtherThan500()
+    {
+        // The guard for the whole defect class: adding a member to EscalationDecisionStatus
+        // without an arm in the controller silently turns it into a 500. This fails the moment
+        // that happens, naming the unmapped member.
+        foreach (var status in Enum.GetValues<EscalationDecisionStatus>())
+        {
+            _mediator.Reset();
+            SetupDecision(new SubmitEscalationDecisionResult
+            {
+                Status = status,
+                Outcome = status == EscalationDecisionStatus.Resolved
+                    ? NewOutcomeSummary(Guid.NewGuid())
+                    : null
+            });
+
+            var result = await CreateSut(ApproverClaim()).SubmitDecision(
+                Guid.NewGuid(), new SubmitEscalationDecisionRequest(true), CancellationToken.None);
+
+            var statusCode = result switch
+            {
+                ObjectResult o => o.StatusCode,
+                StatusCodeResult s => s.StatusCode,
+                _ => null
+            };
+            statusCode.Should().NotBe(StatusCodes.Status500InternalServerError,
+                $"EscalationDecisionStatus.{status} has no explicit arm in the controller's mapping");
+        }
     }
 
     // --- Read/cancel Result mapping through the shared failure mapper ---


### PR DESCRIPTION
Durable, crash-recoverable state for escalations and change proposals (H5). Both toggles default **off**; with them off no database file is created and the host behaves as it does today.

## What this adds

- EF-backed stores for escalation and change-proposal state, behind `AppConfig:AI:Governance:DurableState`
- A reconciliation host that recovers approvals stranded by a crash or an audit-store outage
- HMAC record sealing bound to the row id, so a seal lifted onto another record fails verification
- Retention pruning for terminal records

## Defects found and fixed during review

The correctness gate blocked the first cut. A new decision status — "your vote arrived after the verdict but before it could be safely recorded" — had no mapping in the web layer, so an approver got a **500 on a path reachable in the default, durability-off configuration**. Pre-change the same request returned 202. Fixed by mapping it in the Application layer (409) rather than the controller, so the console consumer inherits it too.

Underneath that was the real gap: the in-memory recovery pass was gated on the *durable-state* toggles, but the stranded state it recovers is caused by an **audit-store** failure, which happens regardless. So in the default configuration the status doc promised "poll for the verdict once reconciliation completes" and reconciliation never ran. The loop now always runs; only the durable and pruning passes stay gated.

## Two working exploits, both closed

The CI security gate **skips this diff** — it selects by folder name and none of these files live in a folder named for security. Reviews were commissioned manually; both found real, demonstrated attacks.

**NTFS hardlink read/write of the approval-verdict database.** A hardlink is not a reparse point, so path canonicalisation could not see it. Verified by creating one: read the database through it, then overwrote it. The first fix — asserting the protected directory sits outside the agent's allowed paths — **did not work**, because a hardlink requires the same *volume*, not the same *subtree*, and the shipped layout puts them side by side. Closed properly by gating on file identity (link count) via a fail-closed interop shim, verified on Windows and Linux.

Impact is narrower than it first appears, and the code comments overstated it: approval outcomes are HMAC-sealed with keys held outside the application, so **forging an approval was never possible**. Real exposure was disclosure and tamper/DoS. Comments corrected.

**Junction/symlink escape from the search sandbox.** `IsPathAllowed` canonicalised for the *protected* decision but compared the literal path for the *allowlist* decision, so a junction inside the workspace pointing at, say, a user's SSH directory leaked file contents. Creating one needs no privilege and git can carry one into a cloned workspace.

## Platform limitation, stated plainly

The hardlink control is implemented for Windows and Linux only; on macOS it fails closed. Rather than document that as a wall, the protection now arms only when there is something to protect — the feature is on, or a database from an earlier run still exists. A macOS developer on the default configuration is unaffected; enabling durable governance gives an explicit startup message naming the platform and the options.

## Verification

Build 0 errors (explicit grep, not tailed). Full suite 21/21 assemblies, 0 failures. Zero new warnings. Every fix mutation-tested — broken, observed failing, restored. Three vacuous or premise-broken tests found and corrected during the work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BnoLcufW278UxA9ssBM1Tc
