### PR TITLE
fix: make plan cancellation actually stop the plan (W4 prereq)

### DIFF
--- a/src/Content/Application/Application.AI.Common/Interfaces/Planner/IPlanExecutor.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Planner/IPlanExecutor.cs
@@ -29,10 +29,28 @@ public interface IPlanExecutor
     Task<Result<PlanExecutionSummary>> ExecuteAsync(PlanId planId, PlanExecutionContext context, CancellationToken ct);
 
     /// <summary>
-    /// Cancels a running plan execution. Steps already in progress complete but no new steps start.
+    /// Cancels a plan: signals any in-flight run to stop, then records every step that had not
+    /// finished as cancelled.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Cancellation is cooperative and takes effect promptly — implementations must not wait for the
+    /// run they are cancelling. The in-flight step's own token is signalled; a step that has not yet
+    /// started never starts.
+    /// </para>
+    /// <para>
+    /// Side effects are <b>at-least-once</b>. An in-flight tool call, LLM request, or sub-plan may
+    /// still complete, and any external effect it already had stands. Cancelling stops further work;
+    /// it does not roll back work already done.
+    /// </para>
+    /// <para>
+    /// The plan remains <b>resumable</b>: completed steps keep their state and output, and a later
+    /// <see cref="ExecuteAsync(PlanId, CancellationToken)"/> resumes from that checkpoint rather than
+    /// re-running finished work. Cancelling twice is idempotent.
+    /// </para>
+    /// </remarks>
     /// <param name="planId">Identifier of the plan to cancel.</param>
-    /// <param name="ct">Cancellation token.</param>
+    /// <param name="ct">Cancellation token for the cancel request itself.</param>
     Task<Result> CancelAsync(PlanId planId, CancellationToken ct);
 
     /// <summary>

--- a/src/Content/Application/Application.AI.Common/Interfaces/Planner/IPlanRunCancellationRegistry.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Planner/IPlanRunCancellationRegistry.cs
@@ -38,6 +38,15 @@ public interface IPlanRunCancellationRegistry
     /// <see cref="IPlanExecutor.ExecuteAsync(PlanId, CancellationToken)"/> and disposes the handle
     /// when the run ends.
     /// </summary>
+    /// <remarks>
+    /// <b>Nested runs inherit cancellation.</b> A run started while another run is executing — a
+    /// sub-plan invoked by a step — is registered beneath it, and cancelling the outer run cancels
+    /// it too. The nesting is detected from the execution flow, so an intermediate step executor
+    /// neither forwards anything nor needs to know this exists. That matters: a sub-plan registers
+    /// under the <i>child</i> plan's identifier, so <see cref="TryCancel"/> on the parent would
+    /// otherwise never reach it, and the child's interrupted step would be recorded as a failure
+    /// rather than a cancellation — leaving the plan unresumable.
+    /// </remarks>
     /// <param name="planId">The plan being run.</param>
     /// <returns>A live registration; dispose it to release.</returns>
     PlanRunCancellationRegistration Register(PlanId planId);

--- a/src/Content/Application/Application.AI.Common/Interfaces/Planner/IPlanRunCancellationRegistry.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Planner/IPlanRunCancellationRegistry.cs
@@ -1,0 +1,64 @@
+using Domain.AI.Planner;
+
+namespace Application.AI.Common.Interfaces.Planner;
+
+/// <summary>
+/// Process-wide index of in-flight plan runs and their cooperative-cancellation tokens. This is the
+/// signalling path that makes <see cref="IPlanExecutor.CancelAsync"/> actually stop work rather
+/// than merely rewriting persisted state after the fact.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Why this exists.</b> <see cref="IPlanExecutor"/> serializes per-plan work behind a
+/// process-wide lock that the executing run holds for its entire duration. Without a registry, a
+/// cancel request could only queue behind that lock, so it would wait for the run it is trying to
+/// stop and then rewrite state that the finished run had already written. The registry is a
+/// separate, non-blocking structure: <see cref="TryCancel"/> takes no plan lock and performs no
+/// I/O, so it can signal a run that is mid-flight.
+/// </para>
+/// <para>
+/// <b>Lifetime.</b> Implementations must be registered as a singleton. <see cref="IPlanExecutor"/>
+/// is scoped, and a cancel request arrives on a different scope (and usually a different thread)
+/// from the run it targets; a scoped registry would hand the two callers different indexes and
+/// silently cancel nothing.
+/// </para>
+/// <para>
+/// <b>Concurrent runs of the same plan.</b> Registrations are tracked per run, not per plan, so a
+/// second run queued behind the per-plan lock has its own entry. <see cref="TryCancel"/> signals
+/// every live run for the plan; <see cref="Release"/> removes exactly the registration passed to
+/// it. Releasing by plan identifier alone would let a finishing run tear down a queued run's
+/// registration.
+/// </para>
+/// </remarks>
+public interface IPlanRunCancellationRegistry
+{
+    /// <summary>
+    /// Registers a starting run and returns its cancellation handle. The caller links
+    /// <see cref="PlanRunCancellationRegistration.Token"/> into the token it passes to
+    /// <see cref="IPlanExecutor.ExecuteAsync(PlanId, CancellationToken)"/> and disposes the handle
+    /// when the run ends.
+    /// </summary>
+    /// <param name="planId">The plan being run.</param>
+    /// <returns>A live registration; dispose it to release.</returns>
+    PlanRunCancellationRegistration Register(PlanId planId);
+
+    /// <summary>
+    /// Signals every live run of <paramref name="planId"/>. Non-blocking: acquires no plan lock,
+    /// performs no I/O, and returns as soon as the tokens are signalled. Idempotent — a second
+    /// call against an already-cancelled run signals an already-signalled token.
+    /// </summary>
+    /// <param name="planId">The plan to cancel.</param>
+    /// <returns>
+    /// <see langword="true"/> when at least one live run was signalled; <see langword="false"/>
+    /// when no run of that plan is in flight.
+    /// </returns>
+    bool TryCancel(PlanId planId);
+
+    /// <summary>
+    /// Removes <paramref name="registration"/> from the index and disposes its token source.
+    /// Idempotent. Prefer disposing the registration — <see cref="PlanRunCancellationRegistration.Dispose"/>
+    /// calls straight through to here, which is what keeps registration and release symmetric.
+    /// </summary>
+    /// <param name="registration">The registration returned by <see cref="Register"/>.</param>
+    void Release(PlanRunCancellationRegistration registration);
+}

--- a/src/Content/Application/Application.AI.Common/Interfaces/Planner/PlanRunCancellationRegistration.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Planner/PlanRunCancellationRegistration.cs
@@ -30,7 +30,7 @@ namespace Application.AI.Common.Interfaces.Planner;
 public sealed class PlanRunCancellationRegistration : IDisposable
 {
     private readonly IPlanRunCancellationRegistry _registry;
-    private readonly CancellationTokenSource _source = new();
+    private readonly CancellationTokenSource _source;
     private readonly object _gate = new();
     private bool _released;
 
@@ -41,10 +41,27 @@ public sealed class PlanRunCancellationRegistration : IDisposable
     /// </summary>
     /// <param name="registry">The registry that will remove this registration on release.</param>
     /// <param name="planId">The plan whose run this registration cancels.</param>
-    public PlanRunCancellationRegistration(IPlanRunCancellationRegistry registry, PlanId planId)
+    /// <param name="parentRunToken">
+    /// The cancellation token of the run that is invoking this one, when this run is nested (a
+    /// sub-plan). The registration's source is linked to it, so cancelling an outer run cancels
+    /// every run beneath it without the nesting call site having to forward anything. Pass
+    /// <see langword="default"/> for a root run.
+    /// </param>
+    public PlanRunCancellationRegistration(
+        IPlanRunCancellationRegistry registry,
+        PlanId planId,
+        CancellationToken parentRunToken = default)
     {
         _registry = registry;
         PlanId = planId;
+
+        // A linked source when nested, so the framework performs the cascade. A run that starts
+        // while its parent is already cancelling gets an already-signalled token, which is correct:
+        // it must not begin work the operator has asked to stop.
+        _source = parentRunToken.CanBeCanceled
+            ? CancellationTokenSource.CreateLinkedTokenSource(parentRunToken)
+            : new CancellationTokenSource();
+
         Token = _source.Token;
     }
 

--- a/src/Content/Application/Application.AI.Common/Interfaces/Planner/PlanRunCancellationRegistration.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Planner/PlanRunCancellationRegistration.cs
@@ -1,0 +1,101 @@
+using Domain.AI.Planner;
+
+namespace Application.AI.Common.Interfaces.Planner;
+
+/// <summary>
+/// A single in-flight plan run's cooperative-cancellation handle, handed out by
+/// <see cref="IPlanRunCancellationRegistry.Register"/>. The run links <see cref="Token"/> into the
+/// token it passes down its own call tree; a concurrent
+/// <see cref="IPlanRunCancellationRegistry.TryCancel"/> signals that token, which is what actually
+/// stops the work.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Symmetric by construction.</b> The handle is <see cref="IDisposable"/> and
+/// <see cref="Dispose"/> routes back through the registry that created it, so the only supported
+/// release is disposing the object the registering component already holds. A run started with
+/// <c>using var registration = registry.Register(planId);</c> cannot leak its registration on any
+/// exit path — normal return, failure, or exception — and no other component is in a position to
+/// release it on the run's behalf.
+/// </para>
+/// <para>
+/// <b>Thread safety.</b> <see cref="SignalCancellation"/> and <see cref="CompleteRelease"/> are
+/// mutually exclusive under a private gate, so the underlying
+/// <see cref="CancellationTokenSource"/> can never be cancelled and disposed concurrently — the one
+/// race that <see cref="CancellationTokenSource"/> does not tolerate. Cancelling a run that has
+/// already been released is a no-op rather than an error: the run it would have stopped has already
+/// finished, which is precisely why it was released.
+/// </para>
+/// </remarks>
+public sealed class PlanRunCancellationRegistration : IDisposable
+{
+    private readonly IPlanRunCancellationRegistry _registry;
+    private readonly CancellationTokenSource _source = new();
+    private readonly object _gate = new();
+    private bool _released;
+
+    /// <summary>
+    /// Initializes a new registration owned by <paramref name="registry"/>. Constructed by the
+    /// registry itself — callers obtain instances from
+    /// <see cref="IPlanRunCancellationRegistry.Register"/>.
+    /// </summary>
+    /// <param name="registry">The registry that will remove this registration on release.</param>
+    /// <param name="planId">The plan whose run this registration cancels.</param>
+    public PlanRunCancellationRegistration(IPlanRunCancellationRegistry registry, PlanId planId)
+    {
+        _registry = registry;
+        PlanId = planId;
+        Token = _source.Token;
+    }
+
+    /// <summary>The plan whose run this registration cancels.</summary>
+    public PlanId PlanId { get; }
+
+    /// <summary>
+    /// The run's cancellation token. Captured at construction so it stays readable after the
+    /// registration is released; linking new sources off it is only valid while the registration is
+    /// live, which is the whole of the run's lifetime.
+    /// </summary>
+    public CancellationToken Token { get; }
+
+    /// <summary>
+    /// Signals <see cref="Token"/>. Returns <see langword="false"/> when the registration has
+    /// already been released — the run finished before the cancel arrived, so there is nothing left
+    /// to stop.
+    /// </summary>
+    /// <returns><see langword="true"/> when the token was signalled.</returns>
+    public bool SignalCancellation()
+    {
+        lock (_gate)
+        {
+            if (_released)
+                return false;
+
+            _source.Cancel();
+            return true;
+        }
+    }
+
+    /// <summary>
+    /// Disposes the underlying token source. Called by the registry <i>after</i> the registration
+    /// has been removed from its index, so no further <see cref="SignalCancellation"/> can begin.
+    /// Idempotent.
+    /// </summary>
+    public void CompleteRelease()
+    {
+        lock (_gate)
+        {
+            if (_released)
+                return;
+
+            _released = true;
+            _source.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// Releases this registration through its owning registry. Idempotent, and the only release
+    /// path a run should use.
+    /// </summary>
+    public void Dispose() => _registry.Release(this);
+}

--- a/src/Content/Application/Application.AI.Common/Interfaces/Planner/PlanRunCancellationRegistration.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Planner/PlanRunCancellationRegistration.cs
@@ -21,10 +21,19 @@ namespace Application.AI.Common.Interfaces.Planner;
 /// <para>
 /// <b>Thread safety.</b> <see cref="SignalCancellation"/> and <see cref="CompleteRelease"/> are
 /// mutually exclusive under a private gate, so the underlying
-/// <see cref="CancellationTokenSource"/> can never be cancelled and disposed concurrently — the one
-/// race that <see cref="CancellationTokenSource"/> does not tolerate. Cancelling a run that has
-/// already been released is a no-op rather than an error: the run it would have stopped has already
-/// finished, which is precisely why it was released.
+/// <see cref="CancellationTokenSource"/> is never cancelled and disposed concurrently from two
+/// threads — the one race that <see cref="CancellationTokenSource"/> does not tolerate. Cancelling a
+/// run that has already been released is a no-op rather than an error: the run it would have stopped
+/// has already finished, which is precisely why it was released.
+/// </para>
+/// <para>
+/// The gate excludes other <em>threads</em>, not re-entry on the same one. <c>Cancel()</c> runs its
+/// registered callbacks inline while the gate is held, and a <c>lock</c> is reentrant, so a callback
+/// that unwound a run synchronously all the way back to <c>Dispose()</c> on this thread would re-enter
+/// <see cref="CompleteRelease"/> and dispose the source mid-cancel. That cannot happen as the executor
+/// is written — the unwind path is asynchronous through several awaits, so the continuation never runs
+/// on this stack — but the guarantee above is a property of the caller, not of this lock, and should
+/// not be relied on by a future caller that cancels from a synchronous continuation.
 /// </para>
 /// </remarks>
 public sealed class PlanRunCancellationRegistration : IDisposable

--- a/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.Planner.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.Planner.cs
@@ -69,6 +69,12 @@ public static partial class DependencyInjection
         // global plans, preserving today's single-user behavior while staying ValidateOnBuild-safe.
         services.TryAddScoped<IKnowledgeScope, NullKnowledgeScope>();
 
+        // Singleton, deliberately: IPlanExecutor is scoped, and a cancel request arrives on a
+        // different scope (and thread) from the run it targets. A scoped registry would give the
+        // canceller its own empty index, so it would signal nothing and report success — the exact
+        // silent no-op this registry exists to prevent.
+        services.TryAddSingleton<IPlanRunCancellationRegistry, PlanRunCancellationRegistry>();
+
         services.AddScoped<IPlanExecutor, PlanExecutor>();
 
         // Singleton like IBundleRunExecutor: the executor owns no per-run state itself — it creates a

--- a/src/Content/Infrastructure/Infrastructure.AI/Planner/PlanExecutor.Recovery.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Planner/PlanExecutor.Recovery.cs
@@ -143,7 +143,7 @@ public sealed partial class PlanExecutor
                 break;
 
             case ErrorRecovery.FailPlan:
-                MarkRemainingAsFailed(ctx.StepStates, "Plan failed due to step failure with FailPlan recovery");
+                MarkRemainingAs(ctx.StepStates, StepExecutionStatus.Failed, "Plan failed due to step failure with FailPlan recovery");
                 break;
         }
     }
@@ -377,8 +377,23 @@ public sealed partial class PlanExecutor
                 // dependencies and re-enqueues it through the canonical Pending -> Ready promotion
                 // path. Leaving it as Ready would strand it: EnqueueInitialReadyStepsAsync only picks
                 // up Pending steps, so the step would never run yet the plan would report Completed.
-                var state = existing.Status is StepExecutionStatus.Running or StepExecutionStatus.Ready
-                    ? existing with { Status = StepExecutionStatus.Pending }
+                //
+                // Cancelled is renormalised for the same reason. An operator cancel is a pause, not
+                // a verdict on the step: CancelAsync marks every non-terminal step Cancelled, and
+                // Cancelled counts as terminal to the scheduler, so without this a cancelled plan
+                // could never be resumed — re-running it would report Completed having executed
+                // nothing. Completed steps keep their state and output, so resume picks up exactly
+                // where the cancel stopped. Failed deliberately does NOT renormalise: a failure is a
+                // verdict, and re-arming it is the operator's explicit call via RetryStepAsync.
+                //
+                // The prior error text and completion timestamp are cleared on renormalisation.
+                // TransitionStepAsync carries a null ErrorMessage forward from the previous state,
+                // so leaving "Plan cancelled by user" in place would follow the step into its next
+                // Completed state and misreport a successful step as cancelled.
+                var state = existing.Status is StepExecutionStatus.Running
+                    or StepExecutionStatus.Ready
+                    or StepExecutionStatus.Cancelled
+                    ? existing with { Status = StepExecutionStatus.Pending, ErrorMessage = null, CompletedAt = null }
                     : existing;
                 stepStates[step.Id] = state;
             }
@@ -393,7 +408,16 @@ public sealed partial class PlanExecutor
         }
     }
 
-    private static void MarkRemainingAsFailed(ConcurrentDictionary<PlanStepId, StepExecutionState> stepStates, string reason)
+    /// <summary>
+    /// Drives every still-unfinished step to <paramref name="status"/> in the in-memory state map so
+    /// the returned summary describes the run honestly. This is a summary-shaping step, not a
+    /// checkpoint: it does not persist. Persisted state for these steps is written by the step's own
+    /// transition (for one that was in flight) or by <c>CancelAsync</c>'s rewrite.
+    /// </summary>
+    private static void MarkRemainingAs(
+        ConcurrentDictionary<PlanStepId, StepExecutionState> stepStates,
+        StepExecutionStatus status,
+        string reason)
     {
         foreach (var (stepId, state) in stepStates)
         {
@@ -401,7 +425,7 @@ public sealed partial class PlanExecutor
             {
                 stepStates[stepId] = state with
                 {
-                    Status = StepExecutionStatus.Failed,
+                    Status = status,
                     ErrorMessage = reason,
                     CompletedAt = DateTimeOffset.UtcNow
                 };

--- a/src/Content/Infrastructure/Infrastructure.AI/Planner/PlanExecutor.Scheduling.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Planner/PlanExecutor.Scheduling.cs
@@ -179,10 +179,10 @@ public sealed partial class PlanExecutor
             return true;
         }
 
-        // The attempt failed, but if the run is being torn down that failure is a casualty of
-        // cancellation rather than a verdict on the step. Throwing here routes it through
-        // ExecuteStepAsync's cancellation catch, which records Cancelled (renormalised to
-        // Pending on resume) instead of consuming retry budget and firing OnExhausted recovery.
+        // The attempt failed, but if an OPERATOR cancelled the run then that failure is a casualty of
+        // the cancellation rather than a verdict on the step. Throwing here routes it through
+        // ExecuteStepAsync's cancellation catch, which records Cancelled (renormalised to Pending on
+        // resume) instead of consuming retry budget and firing OnExhausted recovery.
         //
         // This must not be left to the caller's DelayBeforeRetryAsync token check: that only runs
         // when retry budget remains, so a step with RetryPolicy.MaxRetries = 0 — a single attempt,
@@ -190,7 +190,13 @@ public sealed partial class PlanExecutor
         // Failed. Failed is terminal on resume, so the plan could never be resumed. A cancellation
         // guarantee that holds only for some retry configurations is not a guarantee, so the check
         // belongs here, before the retry decision.
-        ct.ThrowIfCancellationRequested();
+        //
+        // It reads ctx.RunCancellationToken — the operator-cancel source — and deliberately NOT the
+        // ambient ct, which also folds in CancelAfter(PlanTimeout). A plan that ran out of time is a
+        // failure with a real cause, and its steps must keep reaching FailExhaustedStepAsync so
+        // OnExhausted recovery (Escalate, in particular) still fires and the persisted error names
+        // the actual fault instead of "Cancelled". Timeout is not something to resume from.
+        ctx.RunCancellationToken.ThrowIfCancellationRequested();
 
         if (ShouldRetry(step.RetryPolicy, attemptsMade))
             return false;

--- a/src/Content/Infrastructure/Infrastructure.AI/Planner/PlanExecutor.Scheduling.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Planner/PlanExecutor.Scheduling.cs
@@ -64,11 +64,22 @@ public sealed partial class PlanExecutor
         }
         catch (OperationCanceledException)
         {
-            // Plan-level cancellation (caller token or plan timeout) — deliberately NOT retryable.
-            // Per-attempt timeouts never surface here: ExecuteSingleAttemptAsync converts them into
-            // failed attempts, so an OperationCanceledException at this level always means the
-            // whole plan is being torn down (including cancellation during a backoff delay).
-            await TransitionStepAsync(ctx.PlanId, step.Id, StepExecutionStatus.Failed, ctx.StepStates, CancellationToken.None, errorMessage: "Cancelled");
+            // Plan-level cancellation (operator cancel, caller token, or plan timeout) —
+            // deliberately NOT retryable. Per-attempt timeouts never surface here:
+            // ExecuteSingleAttemptAsync converts them into failed attempts, so an
+            // OperationCanceledException at this level always means the whole plan is being torn
+            // down (including cancellation during a backoff delay).
+            //
+            // An operator cancel records the step Cancelled, not Failed. The distinction is not
+            // cosmetic: Cancelled is renormalised to Pending on resume (see InitializeStepStates)
+            // so the plan picks this step back up, whereas Failed is terminal and needs an explicit
+            // RetryStepAsync. Recording an operator cancel as Failed would leave the plan wedged.
+            // Whatever the step had already done externally still stands — cancellation stops
+            // further work, it does not roll anything back.
+            var cancelledStatus = ctx.RunCancellationToken.IsCancellationRequested
+                ? StepExecutionStatus.Cancelled
+                : StepExecutionStatus.Failed;
+            await TransitionStepAsync(ctx.PlanId, step.Id, cancelledStatus, ctx.StepStates, CancellationToken.None, errorMessage: "Cancelled");
             throw;
         }
         catch (Exception ex)

--- a/src/Content/Infrastructure/Infrastructure.AI/Planner/PlanExecutor.Scheduling.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Planner/PlanExecutor.Scheduling.cs
@@ -179,6 +179,19 @@ public sealed partial class PlanExecutor
             return true;
         }
 
+        // The attempt failed, but if the run is being torn down that failure is a casualty of
+        // cancellation rather than a verdict on the step. Throwing here routes it through
+        // ExecuteStepAsync's cancellation catch, which records Cancelled (renormalised to
+        // Pending on resume) instead of consuming retry budget and firing OnExhausted recovery.
+        //
+        // This must not be left to the caller's DelayBeforeRetryAsync token check: that only runs
+        // when retry budget remains, so a step with RetryPolicy.MaxRetries = 0 — a single attempt,
+        // no retries — would fall straight through to FailExhaustedStepAsync below and be recorded
+        // Failed. Failed is terminal on resume, so the plan could never be resumed. A cancellation
+        // guarantee that holds only for some retry configurations is not a guarantee, so the check
+        // belongs here, before the retry decision.
+        ct.ThrowIfCancellationRequested();
+
         if (ShouldRetry(step.RetryPolicy, attemptsMade))
             return false;
 

--- a/src/Content/Infrastructure/Infrastructure.AI/Planner/PlanExecutor.Summary.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Planner/PlanExecutor.Summary.cs
@@ -47,6 +47,12 @@ public sealed partial class PlanExecutor
         };
     }
 
+    /// <param name="RunCancellationToken">
+    /// The operator-cancellation token for this run, from the plan run cancellation registry. It is
+    /// deliberately NOT the token the work runs under (that one also carries the caller's token and
+    /// the plan timeout) — it exists only so an interrupted step can tell an operator cancel apart
+    /// from a timeout or a host shutdown, and record itself Cancelled rather than Failed.
+    /// </param>
     private sealed record PlanExecutionRuntime(
         PlanId PlanId,
         ConcurrentDictionary<PlanStepId, StepExecutionState> StepStates,
@@ -55,5 +61,6 @@ public sealed partial class PlanExecutor
         Dictionary<PlanStepId, List<(PlanStepId Target, EdgeType Type)>> DependentMap,
         Dictionary<PlanStepId, PlanStep> StepLookup,
         ConcurrentQueue<PlanStep> ReadyQueue,
-        SemaphoreSlim Concurrency);
+        SemaphoreSlim Concurrency,
+        CancellationToken RunCancellationToken);
 }

--- a/src/Content/Infrastructure/Infrastructure.AI/Planner/PlanExecutor.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Planner/PlanExecutor.cs
@@ -39,6 +39,7 @@ public sealed partial class PlanExecutor : IPlanExecutor
     private readonly IPlanProgressNotifier _notifier;
     private readonly IEscalationService _escalationService;
     private readonly IServiceProvider _serviceProvider;
+    private readonly IPlanRunCancellationRegistry _cancellationRegistry;
     private readonly TimeProvider _timeProvider;
     private readonly ILogger<PlanExecutor> _logger;
 
@@ -50,6 +51,11 @@ public sealed partial class PlanExecutor : IPlanExecutor
     /// <param name="notifier">Receives plan and step lifecycle notifications.</param>
     /// <param name="escalationService">Resolves human-gate and escalate-on-failure outcomes.</param>
     /// <param name="serviceProvider">Resolves keyed step executors by <see cref="StepType"/>.</param>
+    /// <param name="cancellationRegistry">
+    /// Process-wide index of in-flight runs. <see cref="ExecuteAsync(PlanId, PlanExecutionContext, CancellationToken)"/>
+    /// registers each run here and <see cref="CancelAsync"/> signals it, which is what makes a
+    /// cancel stop work rather than only rewrite state after the run ends.
+    /// </param>
     /// <param name="timeProvider">Clock used for retry backoff delays; injectable for tests.</param>
     /// <param name="logger">Structured logger for execution auditing.</param>
     public PlanExecutor(
@@ -58,6 +64,7 @@ public sealed partial class PlanExecutor : IPlanExecutor
         IPlanProgressNotifier notifier,
         IEscalationService escalationService,
         IServiceProvider serviceProvider,
+        IPlanRunCancellationRegistry cancellationRegistry,
         TimeProvider timeProvider,
         ILogger<PlanExecutor> logger)
     {
@@ -66,6 +73,7 @@ public sealed partial class PlanExecutor : IPlanExecutor
         _notifier = notifier;
         _escalationService = escalationService;
         _serviceProvider = serviceProvider;
+        _cancellationRegistry = cancellationRegistry;
         _timeProvider = timeProvider;
         _logger = logger;
     }
@@ -77,6 +85,14 @@ public sealed partial class PlanExecutor : IPlanExecutor
     {
         if (context.Depth >= context.MaxDepth)
             return Result<PlanExecutionSummary>.Fail($"Maximum sub-plan depth {context.MaxDepth} exceeded at depth {context.Depth}.");
+
+        // Registration is taken BEFORE the plan lock so a run still queued behind an earlier run is
+        // cancellable too — it then acquires the lock with an already-signalled token and unwinds
+        // immediately instead of starting work someone has asked to stop. `using` makes release
+        // symmetric with registration by construction: the component that registers is the only one
+        // that can release, and it does so on every exit path.
+        using var registration = _cancellationRegistry.Register(planId);
+        using var runCts = CancellationTokenSource.CreateLinkedTokenSource(ct, registration.Token);
 
         var planLock = AcquirePlanLockHandle(planId);
         try
@@ -91,7 +107,17 @@ public sealed partial class PlanExecutor : IPlanExecutor
 
         try
         {
-            return await ExecuteCoreAsync(planId, context, ct);
+            return await ExecuteCoreAsync(planId, context, runCts.Token, registration.Token);
+        }
+        catch (OperationCanceledException) when (registration.Token.IsCancellationRequested && !ct.IsCancellationRequested)
+        {
+            // A registry cancel that landed outside the scheduling loop (during load, validation,
+            // blocked-step reconciliation, or the initial enqueue). Inside the loop the existing
+            // handler already unwinds to a summary. Returning a failure Result rather than throwing
+            // keeps ExecuteAsync total for cancellation: a cancel is an expected outcome, so callers
+            // — including a run API — read it from the Result instead of catching.
+            _logger.LogInformation("Plan {PlanId} run cancelled before the scheduling loop completed", planId);
+            return Result<PlanExecutionSummary>.Fail($"Plan {planId} execution was cancelled.");
         }
         finally
         {
@@ -99,9 +125,51 @@ public sealed partial class PlanExecutor : IPlanExecutor
         }
     }
 
+    /// <summary>
+    /// Cancels a plan. Signals any in-flight run first, then rewrites persisted state for every
+    /// step that is not already terminal.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>The signal must come first, and must not take the plan lock.</b> A run holds the per-plan
+    /// lock for its entire duration, so a cancel that acquired the lock before signalling would
+    /// block until the run it is trying to stop had finished naturally, and would then "cancel"
+    /// work that had already completed — a cancel that silently does nothing. The registry pre-pass
+    /// below is non-blocking: it signals the run's token and returns, and the run releases the lock
+    /// as it unwinds, which is what lets the state rewrite that follows describe a genuinely
+    /// stopped plan.
+    /// </para>
+    /// <para>
+    /// <b>Side effects are at-least-once.</b> Cancelling signals the token that the in-flight step
+    /// is executing under; it does not roll anything back. A tool call, LLM request, or sub-plan
+    /// that had already started may complete, and any external effect it had — a file written, a
+    /// message sent, a row inserted — stands. Cancellation stops further work; it does not undo
+    /// work already done.
+    /// </para>
+    /// <para>
+    /// <b>The plan stays resumable.</b> Steps that finished keep their <c>Completed</c> state and
+    /// their output; everything else is recorded as <see cref="StepExecutionStatus.Cancelled"/>.
+    /// A later <see cref="ExecuteAsync(PlanId, CancellationToken)"/> resumes from that checkpoint —
+    /// <c>InitializeStepStates</c> renormalises <c>Cancelled</c> back to <c>Pending</c>, so the plan
+    /// picks up where it stopped rather than re-running completed work.
+    /// </para>
+    /// <para>
+    /// <b>Idempotent.</b> A second cancel signals an already-signalled token (or finds no live run)
+    /// and rewrites state that is already terminal, so it is a no-op that still reports success.
+    /// </para>
+    /// </remarks>
+    /// <param name="planId">Identifier of the plan to cancel.</param>
+    /// <param name="ct">Cancellation token for the cancel request itself.</param>
     public async Task<Result> CancelAsync(PlanId planId, CancellationToken ct)
     {
         _logger.LogInformation("Plan {PlanId} cancellation requested", planId);
+
+        var signalled = _cancellationRegistry.TryCancel(planId);
+        _logger.LogInformation(
+            signalled
+                ? "Plan {PlanId} had an in-flight run; cancellation signalled"
+                : "Plan {PlanId} had no in-flight run to signal; rewriting persisted state only",
+            planId);
 
         var planLock = AcquirePlanLockHandle(planId);
         try
@@ -314,7 +382,16 @@ public sealed partial class PlanExecutor : IPlanExecutor
         public int RefCount { get; set; }
     }
 
-    private async Task<Result<PlanExecutionSummary>> ExecuteCoreAsync(PlanId planId, PlanExecutionContext context, CancellationToken ct)
+    /// <param name="runCancellationToken">
+    /// The registry token alone, without the caller's token folded in. <paramref name="ct"/> is the
+    /// union of the two and drives the work; this one only answers "was this an operator cancel?",
+    /// which decides whether an interrupted step is recorded as Cancelled (resumable) or Failed.
+    /// </param>
+    private async Task<Result<PlanExecutionSummary>> ExecuteCoreAsync(
+        PlanId planId,
+        PlanExecutionContext context,
+        CancellationToken ct,
+        CancellationToken runCancellationToken)
     {
         using var activity = ActivitySource.StartActivity("plan.execute");
         activity?.SetTag("plan.id", planId.Value.ToString());
@@ -383,7 +460,8 @@ public sealed partial class PlanExecutor : IPlanExecutor
         var runningTasks = new HashSet<Task>();
 
         var execCtx = new PlanExecutionRuntime(
-            planId, stepStates, stepOutputs, dependencyMap, dependentMap, stepLookup, readyQueue, concurrency);
+            planId, stepStates, stepOutputs, dependencyMap, dependentMap, stepLookup, readyQueue, concurrency,
+            runCancellationToken);
 
         // Resolve any steps parked in Blocked whose escalation has since been decided. Approved gates
         // complete and release their downstream (which this may enqueue), rejected ones fail through
@@ -400,13 +478,21 @@ public sealed partial class PlanExecutor : IPlanExecutor
         {
             _logger.LogWarning("Plan {PlanId} timed out after {Timeout}", planId, plan.Configuration.PlanTimeout);
             try { await Task.WhenAll(runningTasks); } catch (OperationCanceledException) { }
-            MarkRemainingAsFailed(stepStates, "Plan timeout exceeded");
+            MarkRemainingAs(stepStates, StepExecutionStatus.Failed, "Plan timeout exceeded");
         }
         catch (OperationCanceledException) when (ct.IsCancellationRequested)
         {
-            _logger.LogInformation("Plan {PlanId} cancelled by caller", planId);
+            // An operator cancel is a pause, not a failure: its steps are recorded Cancelled so the
+            // plan resumes from this checkpoint. A caller-token cancel (host shutdown, request
+            // abort) keeps the historical Failed marking.
+            var wasOperatorCancel = runCancellationToken.IsCancellationRequested;
+            _logger.LogInformation(
+                "Plan {PlanId} cancelled ({Origin})", planId, wasOperatorCancel ? "operator" : "caller");
             try { await Task.WhenAll(runningTasks); } catch (OperationCanceledException) { }
-            MarkRemainingAsFailed(stepStates, "Execution cancelled");
+            MarkRemainingAs(
+                stepStates,
+                wasOperatorCancel ? StepExecutionStatus.Cancelled : StepExecutionStatus.Failed,
+                "Execution cancelled");
         }
 
         sw.Stop();

--- a/src/Content/Infrastructure/Infrastructure.AI/Planner/PlanRunCancellationRegistry.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Planner/PlanRunCancellationRegistry.cs
@@ -30,10 +30,26 @@ public sealed class PlanRunCancellationRegistry : IPlanRunCancellationRegistry
     private readonly Dictionary<PlanId, List<PlanRunCancellationRegistration>> _runs = [];
     private readonly object _gate = new();
 
+    /// <summary>
+    /// The run currently executing on this async flow, used to give a nested run its parent.
+    /// <see cref="AsyncLocal{T}"/> flows into the step tasks a run spawns and onward into any
+    /// sub-plan those steps invoke, which is exactly the nesting relationship being captured — and
+    /// it flows without the intervening step executor having to forward anything, so a nesting path
+    /// cannot be added later that forgets to participate.
+    /// </summary>
+    private readonly AsyncLocal<AmbientRun?> _ambientRun = new();
+
     /// <inheritdoc />
     public PlanRunCancellationRegistration Register(PlanId planId)
     {
-        var registration = new PlanRunCancellationRegistration(this, planId);
+        var parent = _ambientRun.Value;
+        var registration = new PlanRunCancellationRegistration(
+            this, planId, parent?.Registration.Token ?? default);
+
+        // Published before returning, so a sub-plan started by this run registers beneath it.
+        // Writing an AsyncLocal affects this flow and the flows it spawns, never the caller's, so
+        // sibling runs on other flows are unaffected.
+        _ambientRun.Value = new AmbientRun(registration, parent);
 
         lock (_gate)
         {
@@ -87,8 +103,22 @@ public sealed class PlanRunCancellationRegistry : IPlanRunCancellationRegistry
             }
         }
 
+        // Pop the ambient run, but only when this registration is the one on top of THIS flow.
+        // Release normally runs on the same flow as Register (the run disposes its own handle), so
+        // the pop restores the parent and a subsequent sibling run on the same flow is not treated
+        // as nested. The identity check keeps a Release called from an unrelated flow from
+        // corrupting that flow's ambient state.
+        if (ReferenceEquals(_ambientRun.Value?.Registration, registration))
+            _ambientRun.Value = _ambientRun.Value!.Parent;
+
         // Outside the gate, and only once the registration is unreachable from the index, so no
         // TryCancel can start signalling it after this point.
         registration.CompleteRelease();
     }
+
+    /// <summary>
+    /// One frame of the run-nesting stack for an async flow: the run executing on it and the run
+    /// that invoked it. Held by <see cref="AsyncLocal{T}"/>, so each flow sees its own chain.
+    /// </summary>
+    private sealed record AmbientRun(PlanRunCancellationRegistration Registration, AmbientRun? Parent);
 }

--- a/src/Content/Infrastructure/Infrastructure.AI/Planner/PlanRunCancellationRegistry.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Planner/PlanRunCancellationRegistry.cs
@@ -1,0 +1,94 @@
+using Application.AI.Common.Interfaces.Planner;
+using Domain.AI.Planner;
+
+namespace Infrastructure.AI.Planner;
+
+/// <summary>
+/// In-memory <see cref="IPlanRunCancellationRegistry"/>. Holds one entry per in-flight run, keyed
+/// by plan, so a cancel request can signal a running plan without waiting on the per-plan execution
+/// lock.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Locking.</b> The private gate guards the index only. Cancellation and disposal happen outside
+/// it, on a snapshot, because <see cref="CancellationTokenSource.Cancel"/> runs its registered
+/// callbacks synchronously: holding a lock across it would put arbitrary continuation code —
+/// including a run's own release path — under this type's lock. Each
+/// <see cref="PlanRunCancellationRegistration"/> serializes its own cancel-versus-dispose pair
+/// internally, so dropping the index lock before signalling is safe.
+/// </para>
+/// <para>
+/// <b>Scope.</b> This registry is deliberately process-local. A multi-instance deployment cancels
+/// only runs hosted by the instance that receives the request; cancelling across instances needs a
+/// distributed signal (the persisted state rewrite in
+/// <see cref="IPlanExecutor.CancelAsync"/> still applies everywhere, so a run on another instance
+/// is stopped at its next checkpoint rather than immediately).
+/// </para>
+/// </remarks>
+public sealed class PlanRunCancellationRegistry : IPlanRunCancellationRegistry
+{
+    private readonly Dictionary<PlanId, List<PlanRunCancellationRegistration>> _runs = [];
+    private readonly object _gate = new();
+
+    /// <inheritdoc />
+    public PlanRunCancellationRegistration Register(PlanId planId)
+    {
+        var registration = new PlanRunCancellationRegistration(this, planId);
+
+        lock (_gate)
+        {
+            if (!_runs.TryGetValue(planId, out var registrations))
+            {
+                registrations = [];
+                _runs[planId] = registrations;
+            }
+
+            registrations.Add(registration);
+        }
+
+        return registration;
+    }
+
+    /// <inheritdoc />
+    public bool TryCancel(PlanId planId)
+    {
+        PlanRunCancellationRegistration[] snapshot;
+        lock (_gate)
+        {
+            if (!_runs.TryGetValue(planId, out var registrations) || registrations.Count == 0)
+                return false;
+
+            snapshot = [.. registrations];
+        }
+
+        var signalled = false;
+        foreach (var registration in snapshot)
+        {
+            // A registration released between the snapshot and here returns false: its run had
+            // already finished, so there was nothing left to stop.
+            signalled |= registration.SignalCancellation();
+        }
+
+        return signalled;
+    }
+
+    /// <inheritdoc />
+    public void Release(PlanRunCancellationRegistration registration)
+    {
+        ArgumentNullException.ThrowIfNull(registration);
+
+        lock (_gate)
+        {
+            if (_runs.TryGetValue(registration.PlanId, out var registrations))
+            {
+                registrations.Remove(registration);
+                if (registrations.Count == 0)
+                    _runs.Remove(registration.PlanId);
+            }
+        }
+
+        // Outside the gate, and only once the registration is unreachable from the index, so no
+        // TryCancel can start signalling it after this point.
+        registration.CompleteRelease();
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Planner/PlanRunCancellationRegistry.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Planner/PlanRunCancellationRegistry.cs
@@ -47,8 +47,12 @@ public sealed class PlanRunCancellationRegistry : IPlanRunCancellationRegistry
             this, planId, parent?.Registration.Token ?? default);
 
         // Published before returning, so a sub-plan started by this run registers beneath it.
-        // Writing an AsyncLocal affects this flow and the flows it spawns, never the caller's, so
-        // sibling runs on other flows are unaffected.
+        //
+        // Register is synchronous, so this write lands in the CALLING async method's context — which
+        // is the mechanism, not a leak: it is what makes the run visible to that method's own
+        // continuations and to every step task it spawns. What it does not do is escape further, to
+        // that method's caller or to sibling runs on other flows, because an async method restores
+        // its own execution context on return.
         _ambientRun.Value = new AmbientRun(registration, parent);
 
         lock (_gate)

--- a/src/Content/Infrastructure/Infrastructure.AI/Planner/StepExecutors/SubPlanStepExecutor.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Planner/StepExecutors/SubPlanStepExecutor.cs
@@ -131,7 +131,13 @@ public sealed class SubPlanStepExecutor : IPlanStepExecutor
                 Duration = sw.Elapsed
             };
         }
-        catch (Exception ex)
+        // OperationCanceledException is deliberately excluded, matching ToolUseStepExecutor and
+        // RetrievalPlanStepExecutor. Swallowing it would turn plan cancellation into an ordinary
+        // step failure: the executor would consume a retry and re-invoke the child plan while the
+        // plan was being torn down, and the step would be recorded Failed rather than Cancelled —
+        // which is terminal on resume, so a cancelled plan containing a sub-plan step could never
+        // be resumed. Cancellation must propagate so PlanExecutor can unwind the run.
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             sw.Stop();
             // Full detail stays in the structured log; only a stable code is persisted onto the step,

--- a/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlanExecutorCancellationTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlanExecutorCancellationTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using Application.AI.Common.Interfaces.Agent;
 using Application.AI.Common.Interfaces.Escalation;
 using Application.AI.Common.Interfaces.Planner;
 using Domain.AI.Planner;
@@ -582,6 +583,7 @@ public sealed class PlanExecutorCancellationTests
                         Mock.Of<IPlanStateStore>(),
                         Mock.Of<IPlanProgressNotifier>(),
                         new PlanExecutionContext(),
+                        Mock.Of<IAgentExecutionContext>(),
                         NullLogger<global::Infrastructure.AI.Planner.StepExecutors.SubPlanStepExecutor>.Instance));
             }
 

--- a/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlanExecutorCancellationTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlanExecutorCancellationTests.cs
@@ -1,0 +1,417 @@
+using System.Collections.Concurrent;
+using Application.AI.Common.Interfaces.Escalation;
+using Application.AI.Common.Interfaces.Planner;
+using Domain.AI.Planner;
+using Domain.Common;
+using Infrastructure.AI.Planner;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Planner;
+
+/// <summary>
+/// Tests for cooperative run cancellation.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The defect these cover: <c>CancelAsync</c> used to acquire the same per-plan lock that a running
+/// <c>ExecuteAsync</c> holds for the whole run, so cancelling an in-flight plan blocked until that
+/// plan had finished on its own and then rewrote state for work that was already over. There was no
+/// signalling path at all — a cancel returned success having stopped nothing, which on an operation
+/// whose entire purpose is halting expensive work is worse than having no cancel.
+/// </para>
+/// <para>
+/// <see cref="CancelAsync_WhileStepInFlight_SignalsPromptlyWithoutDeadlocking"/> is the reproducer:
+/// against the pre-fix executor it does not fail on an assertion, it hangs — the cancel waits on the
+/// run and the run waits for a cancel that never arrives.
+/// </para>
+/// </remarks>
+public sealed class PlanExecutorCancellationTests
+{
+    /// <summary>Bounds the reproducer so a regression fails the run instead of hanging it.</summary>
+    private static readonly TimeSpan DeadlockBudget = TimeSpan.FromSeconds(10);
+
+    [Fact]
+    public async Task CancelAsync_WhileStepInFlight_SignalsPromptlyWithoutDeadlocking()
+    {
+        var planId = PlanId.New();
+        var plan = BuildPlan(planId, stepCount: 1);
+
+        var stepEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var stepObservedCancellation = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var harness = new Harness(plan);
+        harness.OnStep = async (_, ct) =>
+        {
+            stepEntered.TrySetResult();
+            try
+            {
+                // Runs until cancelled. Pre-fix nothing ever signals this token, so the plan timeout
+                // is the only thing that ends the run — which is the hang being reproduced.
+                await Task.Delay(Timeout.Infinite, ct);
+            }
+            catch (OperationCanceledException)
+            {
+                stepObservedCancellation.TrySetResult();
+                throw;
+            }
+
+            return Completed();
+        };
+
+        var sut = harness.CreateSut();
+        var run = Task.Run(() => sut.ExecuteAsync(planId, CancellationToken.None));
+
+        await stepEntered.Task.WaitAsync(DeadlockBudget);
+
+        var cancel = sut.CancelAsync(planId, CancellationToken.None);
+
+        // The signal must reach the running step without the cancel first waiting on the run.
+        await stepObservedCancellation.Task.WaitAsync(DeadlockBudget);
+
+        var cancelResult = await cancel.WaitAsync(DeadlockBudget);
+        Assert.True(cancelResult.IsSuccess);
+
+        await run.WaitAsync(DeadlockBudget);
+    }
+
+    [Fact]
+    public async Task CancelAsync_BetweenCheckpointAndNextStep_KeepsFinishedStepCompletedAndLeavesRestResumable()
+    {
+        var planId = PlanId.New();
+        var plan = BuildPlan(planId, stepCount: 2, chained: true);
+        var firstStepId = plan.Steps[0].Id;
+        var secondStepId = plan.Steps[1].Id;
+
+        var firstStepDone = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseSecondStep = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var secondStepStarted = false;
+
+        var harness = new Harness(plan);
+        harness.OnStep = async (step, ct) =>
+        {
+            if (step.Id == firstStepId)
+                return Completed("first-output");
+
+            // The window under test: the first step is checkpointed Completed and the second has
+            // been dispatched but is held at its threshold. The cancel lands here.
+            secondStepStarted = true;
+            firstStepDone.TrySetResult();
+            await releaseSecondStep.Task.WaitAsync(ct);
+            return Completed("second-output");
+        };
+
+        var sut = harness.CreateSut();
+        var run = Task.Run(() => sut.ExecuteAsync(planId, CancellationToken.None));
+
+        await firstStepDone.Task.WaitAsync(DeadlockBudget);
+        var cancelResult = await sut.CancelAsync(planId, CancellationToken.None).WaitAsync(DeadlockBudget);
+        await run.WaitAsync(DeadlockBudget);
+
+        Assert.True(cancelResult.IsSuccess);
+
+        // Guards the premise: if the second step never ran, the "unstarted step" assertion below
+        // would pass vacuously against a plan that had simply stopped after step one.
+        Assert.True(secondStepStarted, "Second step never started — the checkpoint window under test was not reached.");
+
+        var persisted = harness.PersistedStates;
+        Assert.Equal(StepExecutionStatus.Completed, persisted[firstStepId].Status);
+        Assert.Equal("first-output", persisted[firstStepId].Output);
+        Assert.Equal(StepExecutionStatus.Cancelled, persisted[secondStepId].Status);
+
+        // Resumability is the property that matters, so assert it by actually resuming: the
+        // completed step must not re-run, and the cancelled step must.
+        var executions = new ConcurrentBag<PlanStepId>();
+        harness.OnStep = (step, _) =>
+        {
+            executions.Add(step.Id);
+            return Task.FromResult(Completed($"{step.Name}-resumed"));
+        };
+
+        var resumed = await harness.CreateSut().ExecuteAsync(planId, CancellationToken.None).WaitAsync(DeadlockBudget);
+
+        Assert.True(resumed.IsSuccess);
+        Assert.Equal(StepExecutionStatus.Completed, resumed.Value!.FinalStatus);
+        Assert.DoesNotContain(firstStepId, executions);
+        Assert.Contains(secondStepId, executions);
+    }
+
+    [Fact]
+    public async Task CancelAsync_CalledTwiceWhileRunning_IsIdempotent()
+    {
+        var planId = PlanId.New();
+        var plan = BuildPlan(planId, stepCount: 1);
+
+        var stepEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var harness = new Harness(plan);
+        harness.OnStep = async (_, ct) =>
+        {
+            stepEntered.TrySetResult();
+            await Task.Delay(Timeout.Infinite, ct);
+            return Completed();
+        };
+
+        var sut = harness.CreateSut();
+        var run = Task.Run(() => sut.ExecuteAsync(planId, CancellationToken.None));
+        await stepEntered.Task.WaitAsync(DeadlockBudget);
+
+        var first = await sut.CancelAsync(planId, CancellationToken.None).WaitAsync(DeadlockBudget);
+        await run.WaitAsync(DeadlockBudget);
+        var second = await sut.CancelAsync(planId, CancellationToken.None).WaitAsync(DeadlockBudget);
+        var third = await sut.CancelAsync(planId, CancellationToken.None).WaitAsync(DeadlockBudget);
+
+        Assert.True(first.IsSuccess);
+        Assert.True(second.IsSuccess);
+        Assert.True(third.IsSuccess);
+
+        var persisted = harness.PersistedStates;
+        Assert.All(persisted.Values, s => Assert.Equal(StepExecutionStatus.Cancelled, s.Status));
+    }
+
+    /// <summary>
+    /// Concurrency evidence for the question "is signalling a run from another thread safe next to
+    /// the executor's static per-plan lock dictionary?". The registry is a separate structure and is
+    /// never touched by the lock bookkeeping, but the two run concurrently on the same plan id, so
+    /// this hammers register/signal/release against acquire/release/dispose of the plan lock. A
+    /// registration disposed mid-signal would surface as <see cref="ObjectDisposedException"/>.
+    /// </summary>
+    [Fact]
+    public async Task Registry_ConcurrentRegisterCancelRelease_NeverThrowsAndAlwaysSignalsLiveRuns()
+    {
+        var registry = new PlanRunCancellationRegistry();
+        var planId = PlanId.New();
+        var failures = new ConcurrentBag<Exception>();
+        var observedCancellations = 0;
+
+        // Iteration-bounded rather than wall-clock bounded, and yielding rather than spinning: this
+        // assembly also holds child-process tests whose timing a CPU-saturating loop destabilises.
+        const int Iterations = 4000;
+
+        var registrars = Enumerable.Range(0, 3).Select(_ => Task.Run(() =>
+        {
+            for (var i = 0; i < Iterations; i++)
+            {
+                try
+                {
+                    using var registration = registry.Register(planId);
+                    Thread.Yield();
+                    if (registration.Token.IsCancellationRequested)
+                        Interlocked.Increment(ref observedCancellations);
+                }
+                catch (Exception ex)
+                {
+                    failures.Add(ex);
+                }
+            }
+        })).ToArray();
+
+        var cancellers = Enumerable.Range(0, 2).Select(_ => Task.Run(() =>
+        {
+            for (var i = 0; i < Iterations; i++)
+            {
+                try
+                {
+                    registry.TryCancel(planId);
+                    Thread.Yield();
+                }
+                catch (Exception ex)
+                {
+                    failures.Add(ex);
+                }
+            }
+        })).ToArray();
+
+        await Task.WhenAll(registrars.Concat(cancellers));
+
+        Assert.True(failures.IsEmpty, $"Expected no exceptions; first was: {failures.FirstOrDefault()}");
+
+        // Proves the run did what it claims: if no registration ever observed a signal, the loop
+        // above would pass while testing nothing.
+        Assert.True(observedCancellations > 0, "No registration ever observed cancellation — the race was never exercised.");
+
+        // Every registration was disposed, so the index must be empty and a further cancel a no-op.
+        Assert.False(registry.TryCancel(planId));
+    }
+
+    [Fact]
+    public void Registry_ReleaseIsIdempotentAndUnregisteredCancelReportsNothingSignalled()
+    {
+        var registry = new PlanRunCancellationRegistry();
+        var planId = PlanId.New();
+
+        Assert.False(registry.TryCancel(planId));
+
+        var registration = registry.Register(planId);
+        Assert.True(registry.TryCancel(planId));
+        Assert.True(registration.Token.IsCancellationRequested);
+
+        registration.Dispose();
+        registration.Dispose();
+
+        Assert.False(registry.TryCancel(planId));
+    }
+
+    [Fact]
+    public void Registry_ConcurrentRunsOfSamePlan_ReleaseOfOneLeavesTheOtherSignallable()
+    {
+        var registry = new PlanRunCancellationRegistry();
+        var planId = PlanId.New();
+
+        using var queued = registry.Register(planId);
+        var running = registry.Register(planId);
+
+        // The finishing run releases. Releasing by plan id alone would tear down the queued run's
+        // registration too, leaving it silently uncancellable.
+        running.Dispose();
+
+        Assert.True(registry.TryCancel(planId));
+        Assert.True(queued.Token.IsCancellationRequested);
+    }
+
+    /// <summary>
+    /// Cancel latency is bounded by the slowest step executor, so each must let cancellation
+    /// propagate rather than converting it into a step failure. <c>SubPlanStepExecutor</c> caught
+    /// every exception, which swallowed <see cref="OperationCanceledException"/> and turned a plan
+    /// cancellation into a retryable failure of the sub-plan step.
+    /// </summary>
+    [Fact]
+    public async Task SubPlanStepExecutor_WhenChildPlanIsCancelled_PropagatesInsteadOfReportingStepFailure()
+    {
+        var childPlanId = PlanId.New();
+        var childExecutor = new Mock<IPlanExecutor>();
+        childExecutor
+            .Setup(e => e.ExecuteAsync(It.IsAny<PlanId>(), It.IsAny<PlanExecutionContext>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new OperationCanceledException());
+
+        var services = new ServiceCollection();
+        services.AddScoped(_ => childExecutor.Object);
+
+        var sut = new global::Infrastructure.AI.Planner.StepExecutors.SubPlanStepExecutor(
+            services.BuildServiceProvider().GetRequiredService<IServiceScopeFactory>(),
+            Mock.Of<IPlanStateStore>(),
+            Mock.Of<IPlanProgressNotifier>(),
+            new PlanExecutionContext(),
+            NullLogger<global::Infrastructure.AI.Planner.StepExecutors.SubPlanStepExecutor>.Instance);
+
+        var step = new PlanStep
+        {
+            Id = new PlanStepId(Guid.NewGuid()),
+            Name = "sub-plan-step",
+            Type = StepType.SubPlanInvocation,
+            Configuration = new SubPlanConfig { ChildPlanId = childPlanId },
+            RetryPolicy = new RetryPolicy { MaxRetries = 0 }
+        };
+
+        await Assert.ThrowsAsync<OperationCanceledException>(
+            () => sut.ExecuteAsync(step, new Dictionary<PlanStepId, string>(), CancellationToken.None));
+    }
+
+    private static StepExecutionResult Completed(string output = "ok") => new()
+    {
+        Status = StepExecutionStatus.Completed,
+        Output = output,
+        Duration = TimeSpan.FromMilliseconds(1)
+    };
+
+    private static PlanGraph BuildPlan(PlanId planId, int stepCount, bool chained = false)
+    {
+        var steps = Enumerable.Range(0, stepCount).Select(i => new PlanStep
+        {
+            Id = new PlanStepId(Guid.NewGuid()),
+            Name = $"step-{i}",
+            Type = StepType.LlmCall,
+            Configuration = new LlmCallConfig { SystemPrompt = "test", ModelDeploymentKey = "gpt-4" },
+            RetryPolicy = new RetryPolicy { MaxRetries = 0 },
+            Timeout = TimeSpan.FromSeconds(30)
+        }).ToList();
+
+        var edges = chained
+            ? Enumerable.Range(0, stepCount - 1)
+                .Select(i => new PlanEdge(steps[i].Id, steps[i + 1].Id, EdgeType.ControlFlow))
+                .ToList()
+            : [];
+
+        return new PlanGraph
+        {
+            Id = planId,
+            Name = "cancellation-plan",
+            Steps = steps,
+            Edges = edges,
+            Configuration = new PlanConfiguration
+            {
+                PlanTimeout = TimeSpan.FromSeconds(60),
+                MaxParallelSteps = 2
+            }
+        };
+    }
+
+    /// <summary>
+    /// A <see cref="PlanExecutor"/> wired to an in-memory state store, so resume genuinely reads back
+    /// what the previous run persisted rather than a canned dictionary. The registry is shared across
+    /// every executor the harness builds, mirroring its singleton registration.
+    /// </summary>
+    private sealed class Harness
+    {
+        private readonly PlanGraph _plan;
+        private readonly PlanRunCancellationRegistry _registry = new();
+        private readonly ConcurrentDictionary<PlanStepId, StepExecutionState> _states = new();
+
+        public Harness(PlanGraph plan) => _plan = plan;
+
+        public Func<PlanStep, CancellationToken, Task<StepExecutionResult>> OnStep { get; set; } =
+            (_, _) => Task.FromResult(Completed());
+
+        public IReadOnlyDictionary<PlanStepId, StepExecutionState> PersistedStates => _states;
+
+        public PlanExecutor CreateSut()
+        {
+            var validator = new Mock<IPlanValidator>();
+            validator.Setup(v => v.ValidateAsync(It.IsAny<PlanGraph>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(Result<PlanValidationResult>.Success(new PlanValidationResult { IsValid = true }));
+
+            var stateStore = new Mock<IPlanStateStore>();
+            stateStore.Setup(s => s.LoadPlanAsync(It.IsAny<PlanId>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(Result<PlanGraph?>.Success(_plan));
+            stateStore.Setup(s => s.ResumeAsync(It.IsAny<PlanId>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(() => Result<IReadOnlyDictionary<PlanStepId, StepExecutionState>>.Success(Snapshot()));
+            stateStore.Setup(s => s.LoadStepStatesAsync(It.IsAny<PlanId>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(() => Result<IReadOnlyDictionary<PlanStepId, StepExecutionState>>.Success(Snapshot()));
+            stateStore.Setup(s => s.UpdateStepStateAsync(It.IsAny<StepExecutionState>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((StepExecutionState state, CancellationToken _) =>
+                {
+                    _states[state.StepId] = state;
+                    return Result.Success();
+                });
+            stateStore.Setup(s => s.CheckpointAsync(
+                    It.IsAny<PlanId>(), It.IsAny<IReadOnlyList<StepExecutionState>>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((PlanId _, IReadOnlyList<StepExecutionState> states, CancellationToken _) =>
+                {
+                    foreach (var state in states)
+                        _states[state.StepId] = state;
+                    return Result.Success();
+                });
+
+            var services = new ServiceCollection();
+            var stepExecutor = new Mock<IPlanStepExecutor>();
+            stepExecutor.Setup(e => e.ExecuteAsync(
+                    It.IsAny<PlanStep>(), It.IsAny<IReadOnlyDictionary<PlanStepId, string>>(), It.IsAny<CancellationToken>()))
+                .Returns<PlanStep, IReadOnlyDictionary<PlanStepId, string>, CancellationToken>((step, _, ct) => OnStep(step, ct));
+            services.AddKeyedSingleton<IPlanStepExecutor>(StepType.LlmCall, stepExecutor.Object);
+
+            return new PlanExecutor(
+                validator.Object,
+                stateStore.Object,
+                Mock.Of<IPlanProgressNotifier>(),
+                Mock.Of<IEscalationService>(),
+                services.BuildServiceProvider(),
+                _registry,
+                TimeProvider.System,
+                NullLogger<PlanExecutor>.Instance);
+        }
+
+        private IReadOnlyDictionary<PlanStepId, StepExecutionState> Snapshot()
+            => new Dictionary<PlanStepId, StepExecutionState>(_states);
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlanExecutorCancellationTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlanExecutorCancellationTests.cs
@@ -222,6 +222,7 @@ public sealed class PlanExecutorCancellationTests
         var planId = PlanId.New();
         var failures = new ConcurrentBag<Exception>();
         var observedCancellations = 0;
+        var cancelRounds = 0;
 
         // Iteration-bounded rather than wall-clock bounded, and yielding rather than spinning: this
         // assembly also holds child-process tests whose timing a CPU-saturating loop destabilises.
@@ -234,7 +235,18 @@ public sealed class PlanExecutorCancellationTests
                 try
                 {
                     using var registration = registry.Register(planId);
-                    Thread.Yield();
+
+                    // Hold the registration open until a canceller has completed at least one round
+                    // since it was taken, so the signal genuinely lands on a LIVE registration.
+                    // A bare Thread.Yield() here made the overlap a matter of luck: on a runner with
+                    // fewer cores the registrars can drain their whole loop between canceller
+                    // iterations, and the premise assertion below then fails the build for a
+                    // scheduling accident rather than a defect. Bounded so a stalled canceller
+                    // cannot hang the run.
+                    var roundsAtEntry = Volatile.Read(ref cancelRounds);
+                    for (var spin = 0; spin < 1000 && Volatile.Read(ref cancelRounds) == roundsAtEntry; spin++)
+                        Thread.Yield();
+
                     if (registration.Token.IsCancellationRequested)
                         Interlocked.Increment(ref observedCancellations);
                 }
@@ -252,6 +264,7 @@ public sealed class PlanExecutorCancellationTests
                 try
                 {
                     registry.TryCancel(planId);
+                    Interlocked.Increment(ref cancelRounds);
                     Thread.Yield();
                 }
                 catch (Exception ex)

--- a/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlanExecutorCancellationTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlanExecutorCancellationTests.cs
@@ -271,41 +271,199 @@ public sealed class PlanExecutorCancellationTests
     }
 
     /// <summary>
-    /// Cancel latency is bounded by the slowest step executor, so each must let cancellation
-    /// propagate rather than converting it into a step failure. <c>SubPlanStepExecutor</c> caught
-    /// every exception, which swallowed <see cref="OperationCanceledException"/> and turned a plan
-    /// cancellation into a retryable failure of the sub-plan step.
+    /// Cancellation must survive one level of nesting. A sub-plan registers under the CHILD plan's
+    /// identifier, so <c>TryCancel(parentPlanId)</c> does not reach it directly; without the
+    /// registry linking a nested run to the run that invoked it, the child's interrupted step is
+    /// recorded <c>Failed</c> rather than <c>Cancelled</c>. <c>Failed</c> is terminal on resume, so
+    /// the child could never re-run, its downstream step would never become ready, and the parent
+    /// step would fail on every subsequent resume — permanently unresumable.
     /// </summary>
-    [Fact]
-    public async Task SubPlanStepExecutor_WhenChildPlanIsCancelled_PropagatesInsteadOfReportingStepFailure()
+    /// <remarks>
+    /// Deliberately built from two REAL <see cref="PlanExecutor"/> instances over one shared
+    /// registry and a real <see cref="global::Infrastructure.AI.Planner.StepExecutors.SubPlanStepExecutor"/>.
+    /// An earlier version of this test stubbed the child <see cref="IPlanExecutor"/> to throw
+    /// <see cref="OperationCanceledException"/>; the real executor catches that internally and
+    /// returns a summary instead, so the stub tested a shape production never produces and the
+    /// nesting defect stayed invisible. A test whose subject is nesting cannot stub the thing being
+    /// nested.
+    /// </remarks>
+    /// <param name="childStepMaxRetries">
+    /// Exercised at both 0 and 3. With no retry budget the parent step bypasses the backoff delay
+    /// whose token check used to be the only thing recording it Cancelled, so the guarantee held
+    /// only for retry-enabled steps.
+    /// </param>
+    [Theory]
+    [InlineData(0)]
+    [InlineData(3)]
+    public async Task CancelAsync_WhileSubPlanStepInFlight_RecordsChildAndParentCancelledAndStaysResumable(
+        int childStepMaxRetries)
     {
+        var registry = new PlanRunCancellationRegistry();
+        var parentPlanId = PlanId.New();
         var childPlanId = PlanId.New();
-        var childExecutor = new Mock<IPlanExecutor>();
-        childExecutor
-            .Setup(e => e.ExecuteAsync(It.IsAny<PlanId>(), It.IsAny<PlanExecutionContext>(), It.IsAny<CancellationToken>()))
-            .ThrowsAsync(new OperationCanceledException());
 
-        var services = new ServiceCollection();
-        services.AddScoped(_ => childExecutor.Object);
+        var childHarness = new Harness(BuildPlan(childPlanId, stepCount: 2, chained: true), registry);
+        var childStep1 = childHarness.Plan.Steps[0].Id;
+        var childStep2 = childHarness.Plan.Steps[1].Id;
 
-        var sut = new global::Infrastructure.AI.Planner.StepExecutors.SubPlanStepExecutor(
-            services.BuildServiceProvider().GetRequiredService<IServiceScopeFactory>(),
-            Mock.Of<IPlanStateStore>(),
-            Mock.Of<IPlanProgressNotifier>(),
-            new PlanExecutionContext(),
-            NullLogger<global::Infrastructure.AI.Planner.StepExecutors.SubPlanStepExecutor>.Instance);
-
-        var step = new PlanStep
+        var childStep1Running = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        childHarness.OnStep = async (step, ct) =>
         {
-            Id = new PlanStepId(Guid.NewGuid()),
-            Name = "sub-plan-step",
-            Type = StepType.SubPlanInvocation,
-            Configuration = new SubPlanConfig { ChildPlanId = childPlanId },
-            RetryPolicy = new RetryPolicy { MaxRetries = 0 }
+            if (step.Id != childStep1)
+                return Completed("child-step-2");
+
+            childStep1Running.TrySetResult();
+            await Task.Delay(Timeout.Infinite, ct);
+            return Completed("child-step-1");
         };
 
-        await Assert.ThrowsAsync<OperationCanceledException>(
-            () => sut.ExecuteAsync(step, new Dictionary<PlanStepId, string>(), CancellationToken.None));
+        // The parent's single step is a real SubPlanInvocation into the child plan.
+        var parentStep = new PlanStep
+        {
+            Id = new PlanStepId(Guid.NewGuid()),
+            Name = "invoke-child",
+            Type = StepType.SubPlanInvocation,
+            Configuration = new SubPlanConfig { ChildPlanId = childPlanId },
+            RetryPolicy = new RetryPolicy { MaxRetries = childStepMaxRetries, InitialDelay = TimeSpan.FromMilliseconds(50) },
+            Timeout = TimeSpan.FromSeconds(30)
+        };
+        var parentPlan = new PlanGraph
+        {
+            Id = parentPlanId,
+            Name = "parent-plan",
+            Steps = [parentStep],
+            Edges = [],
+            Configuration = new PlanConfiguration { PlanTimeout = TimeSpan.FromSeconds(60), MaxParallelSteps = 2 }
+        };
+
+        var parentHarness = new Harness(parentPlan, registry);
+        var parentSut = parentHarness.CreateSut(subPlanChild: childHarness.CreateSut());
+
+        var parentRun = Task.Run(() => parentSut.ExecuteAsync(parentPlanId, CancellationToken.None));
+        await childStep1Running.Task.WaitAsync(DeadlockBudget);
+
+        // Cancel the PARENT. Nothing here names the child plan.
+        var cancelResult = await parentSut.CancelAsync(parentPlanId, CancellationToken.None).WaitAsync(DeadlockBudget);
+        await parentRun.WaitAsync(DeadlockBudget);
+
+        Assert.True(cancelResult.IsSuccess);
+
+        // The child's in-flight step must be Cancelled, not Failed — Failed would be terminal.
+        Assert.Equal(StepExecutionStatus.Cancelled, childHarness.PersistedStates[childStep1].Status);
+        Assert.NotEqual(StepExecutionStatus.Failed, childHarness.PersistedStates[childStep1].Status);
+
+        // The parent step likewise, independent of its retry budget.
+        Assert.Equal(StepExecutionStatus.Cancelled, parentHarness.PersistedStates[parentStep.Id].Status);
+
+        // Resumability is the property that matters: resume the child and confirm it finishes.
+        var childExecutions = new ConcurrentBag<PlanStepId>();
+        childHarness.OnStep = (step, _) =>
+        {
+            childExecutions.Add(step.Id);
+            return Task.FromResult(Completed($"{step.Name}-resumed"));
+        };
+
+        var resumedChild = await childHarness.CreateSut()
+            .ExecuteAsync(childPlanId, CancellationToken.None)
+            .WaitAsync(DeadlockBudget);
+
+        Assert.True(resumedChild.IsSuccess);
+        Assert.Equal(StepExecutionStatus.Completed, resumedChild.Value!.FinalStatus);
+        Assert.Contains(childStep1, childExecutions);
+        Assert.Contains(childStep2, childExecutions);
+    }
+
+    /// <summary>
+    /// Guards the premise of the nesting test above: the child plan must genuinely reach its second
+    /// step when nothing cancels it. Without this, the resume assertions could pass against a child
+    /// that had simply never progressed.
+    /// </summary>
+    [Fact]
+    public async Task SubPlanInvocation_WithoutCancellation_RunsChildPlanToCompletion()
+    {
+        var registry = new PlanRunCancellationRegistry();
+        var parentPlanId = PlanId.New();
+        var childPlanId = PlanId.New();
+
+        var childHarness = new Harness(BuildPlan(childPlanId, stepCount: 2, chained: true), registry);
+        var childExecutions = new ConcurrentBag<PlanStepId>();
+        childHarness.OnStep = (step, _) =>
+        {
+            childExecutions.Add(step.Id);
+            return Task.FromResult(Completed($"{step.Name}-ok"));
+        };
+
+        var parentStep = new PlanStep
+        {
+            Id = new PlanStepId(Guid.NewGuid()),
+            Name = "invoke-child",
+            Type = StepType.SubPlanInvocation,
+            Configuration = new SubPlanConfig { ChildPlanId = childPlanId },
+            RetryPolicy = new RetryPolicy { MaxRetries = 0 },
+            Timeout = TimeSpan.FromSeconds(30)
+        };
+        var parentPlan = new PlanGraph
+        {
+            Id = parentPlanId,
+            Name = "parent-plan",
+            Steps = [parentStep],
+            Edges = [],
+            Configuration = new PlanConfiguration { PlanTimeout = TimeSpan.FromSeconds(60), MaxParallelSteps = 2 }
+        };
+
+        var parentHarness = new Harness(parentPlan, registry);
+        var parentSut = parentHarness.CreateSut(subPlanChild: childHarness.CreateSut());
+
+        var result = await parentSut.ExecuteAsync(parentPlanId, CancellationToken.None).WaitAsync(DeadlockBudget);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(StepExecutionStatus.Completed, result.Value!.FinalStatus);
+        Assert.Equal(2, childExecutions.Distinct().Count());
+        Assert.Equal(StepExecutionStatus.Completed, parentHarness.PersistedStates[parentStep.Id].Status);
+    }
+
+    /// <summary>
+    /// A child plan cancelled directly, while its parent is not, is a genuine failure of the parent
+    /// step — the parent was not asked to stop. Pins the boundary of the cascade so it is not
+    /// mistaken for "any child cancellation cancels the parent".
+    /// </summary>
+    [Fact]
+    public async Task Registry_CancellingChildOnly_DoesNotCancelParentRun()
+    {
+        var registry = new PlanRunCancellationRegistry();
+        var parentPlanId = PlanId.New();
+        var childPlanId = PlanId.New();
+
+        using var parent = registry.Register(parentPlanId);
+
+        // Simulates the child registering from within the parent's execution flow.
+        using var child = registry.Register(childPlanId);
+
+        Assert.True(registry.TryCancel(childPlanId));
+        Assert.True(child.Token.IsCancellationRequested);
+        Assert.False(parent.Token.IsCancellationRequested);
+    }
+
+    /// <summary>
+    /// The cascade itself, at the registry level: a run registered inside another run's flow is
+    /// signalled when the outer run is cancelled, without the outer cancel naming it.
+    /// </summary>
+    [Fact]
+    public async Task Registry_CancellingParent_CascadesToRunRegisteredWithinItsFlow()
+    {
+        var registry = new PlanRunCancellationRegistry();
+        var parentPlanId = PlanId.New();
+        var childPlanId = PlanId.New();
+
+        using var parent = registry.Register(parentPlanId);
+
+        // Registered on a spawned flow, mirroring a step task invoking a sub-plan.
+        var child = await Task.Run(() => registry.Register(childPlanId));
+
+        Assert.True(registry.TryCancel(parentPlanId));
+        Assert.True(child.Token.IsCancellationRequested);
+
+        child.Dispose();
     }
 
     private static StepExecutionResult Completed(string output = "ok") => new()
@@ -355,17 +513,29 @@ public sealed class PlanExecutorCancellationTests
     private sealed class Harness
     {
         private readonly PlanGraph _plan;
-        private readonly PlanRunCancellationRegistry _registry = new();
+        private readonly PlanRunCancellationRegistry _registry;
         private readonly ConcurrentDictionary<PlanStepId, StepExecutionState> _states = new();
 
-        public Harness(PlanGraph plan) => _plan = plan;
+        public Harness(PlanGraph plan, PlanRunCancellationRegistry? registry = null)
+        {
+            _plan = plan;
+            _registry = registry ?? new PlanRunCancellationRegistry();
+        }
+
+        public PlanGraph Plan => _plan;
 
         public Func<PlanStep, CancellationToken, Task<StepExecutionResult>> OnStep { get; set; } =
             (_, _) => Task.FromResult(Completed());
 
         public IReadOnlyDictionary<PlanStepId, StepExecutionState> PersistedStates => _states;
 
-        public PlanExecutor CreateSut()
+        /// <summary>
+        /// Builds the executor. When <paramref name="subPlanChild"/> is supplied, a real
+        /// <c>SubPlanStepExecutor</c> is registered for <see cref="StepType.SubPlanInvocation"/>
+        /// and resolves that executor as the child — so nesting runs through production code rather
+        /// than a stub.
+        /// </summary>
+        public PlanExecutor CreateSut(PlanExecutor? subPlanChild = null)
         {
             var validator = new Mock<IPlanValidator>();
             validator.Setup(v => v.ValidateAsync(It.IsAny<PlanGraph>(), It.IsAny<CancellationToken>()))
@@ -399,6 +569,21 @@ public sealed class PlanExecutorCancellationTests
                     It.IsAny<PlanStep>(), It.IsAny<IReadOnlyDictionary<PlanStepId, string>>(), It.IsAny<CancellationToken>()))
                 .Returns<PlanStep, IReadOnlyDictionary<PlanStepId, string>, CancellationToken>((step, _, ct) => OnStep(step, ct));
             services.AddKeyedSingleton<IPlanStepExecutor>(StepType.LlmCall, stepExecutor.Object);
+
+            if (subPlanChild is not null)
+            {
+                // The real SubPlanStepExecutor, resolving the real child PlanExecutor from the
+                // scope it creates. Nothing about the nesting is stubbed.
+                services.AddScoped<IPlanExecutor>(_ => subPlanChild);
+                services.AddKeyedSingleton<IPlanStepExecutor>(
+                    StepType.SubPlanInvocation,
+                    (sp, _) => new global::Infrastructure.AI.Planner.StepExecutors.SubPlanStepExecutor(
+                        sp.GetRequiredService<IServiceScopeFactory>(),
+                        Mock.Of<IPlanStateStore>(),
+                        Mock.Of<IPlanProgressNotifier>(),
+                        new PlanExecutionContext(),
+                        NullLogger<global::Infrastructure.AI.Planner.StepExecutors.SubPlanStepExecutor>.Instance));
+            }
 
             return new PlanExecutor(
                 validator.Object,

--- a/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlanExecutorCancellationTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlanExecutorCancellationTests.cs
@@ -140,6 +140,43 @@ public sealed class PlanExecutorCancellationTests
     }
 
     [Fact]
+    public async Task PlanTimeout_WithNoRetryBudget_KeepsTheRealErrorAndDoesNotRecordCancelled()
+    {
+        // The distinction the operator-cancel check must preserve. Both a cancel and a timeout end the
+        // run, but they mean opposite things: a cancel is "stop, I will resume this", a timeout is
+        // "this failed, and here is why".
+        //
+        // The step must FAIL rather than throw, so the outcome reaches TryFinishAttemptAsync with the
+        // plan token already cancelled — that is the only path through the check under test. A step
+        // that honours the token instead throws out of ExecuteSingleAttemptAsync and is handled by
+        // ExecuteStepAsync's cancellation catch, never reaching the check at all. (A first version of
+        // this test did exactly that and passed against both the fixed and the broken code.)
+        const string realError = "upstream-service-unavailable";
+        var planId = PlanId.New();
+        var plan = BuildPlan(planId, stepCount: 1, chained: false, planTimeout: TimeSpan.FromMilliseconds(150));
+        var stepId = plan.Steps[0].Id;
+
+        var harness = new Harness(plan);
+        harness.OnStep = async (_, _) =>
+        {
+            // Deliberately ignores the token: outlast the plan timeout, then report a real failure.
+            await Task.Delay(TimeSpan.FromMilliseconds(600), CancellationToken.None);
+            return new StepExecutionResult
+            {
+                Status = StepExecutionStatus.Failed,
+                ErrorMessage = realError,
+                Duration = TimeSpan.FromMilliseconds(1)
+            };
+        };
+
+        await harness.CreateSut().ExecuteAsync(planId, CancellationToken.None).WaitAsync(DeadlockBudget);
+
+        var persisted = harness.PersistedStates[stepId];
+        Assert.Equal(StepExecutionStatus.Failed, persisted.Status);
+        Assert.Equal(realError, persisted.ErrorMessage);
+    }
+
+    [Fact]
     public async Task CancelAsync_CalledTwiceWhileRunning_IsIdempotent()
     {
         var planId = PlanId.New();
@@ -261,7 +298,14 @@ public sealed class PlanExecutorCancellationTests
         var planId = PlanId.New();
 
         using var queued = registry.Register(planId);
-        var running = registry.Register(planId);
+
+        // Registered on an INDEPENDENT flow. Calling Register again here would inherit the ambient run
+        // published by the line above and make `running` a CHILD of `queued`, which is the nesting
+        // case — not the sibling case this test is named for. Suppressing execution-context flow is
+        // what makes the second run a genuine peer.
+        PlanRunCancellationRegistration running;
+        using (ExecutionContext.SuppressFlow())
+            running = Task.Run(() => registry.Register(planId)).GetAwaiter().GetResult();
 
         // The finishing run releases. Releasing by plan id alone would tear down the queued run's
         // registration too, leaving it silently uncancellable.
@@ -429,7 +473,7 @@ public sealed class PlanExecutorCancellationTests
     /// mistaken for "any child cancellation cancels the parent".
     /// </summary>
     [Fact]
-    public async Task Registry_CancellingChildOnly_DoesNotCancelParentRun()
+    public void Registry_CancellingChildOnly_DoesNotCancelParentRun()
     {
         var registry = new PlanRunCancellationRegistry();
         var parentPlanId = PlanId.New();
@@ -475,6 +519,9 @@ public sealed class PlanExecutorCancellationTests
     };
 
     private static PlanGraph BuildPlan(PlanId planId, int stepCount, bool chained = false)
+        => BuildPlan(planId, stepCount, chained, TimeSpan.FromSeconds(60));
+
+    private static PlanGraph BuildPlan(PlanId planId, int stepCount, bool chained, TimeSpan planTimeout)
     {
         var steps = Enumerable.Range(0, stepCount).Select(i => new PlanStep
         {
@@ -500,7 +547,7 @@ public sealed class PlanExecutorCancellationTests
             Edges = edges,
             Configuration = new PlanConfiguration
             {
-                PlanTimeout = TimeSpan.FromSeconds(60),
+                PlanTimeout = planTimeout,
                 MaxParallelSteps = 2
             }
         };

--- a/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlanExecutorEnvelopeCeilingTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlanExecutorEnvelopeCeilingTests.cs
@@ -63,6 +63,7 @@ public sealed class PlanExecutorEnvelopeCeilingTests : IDisposable
             _notifier.Object,
             _escalation.Object,
             _serviceProvider,
+            new PlanRunCancellationRegistry(),
             TimeProvider.System,
             NullLogger<PlanExecutor>.Instance);
     }

--- a/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlanExecutorHumanGateLifecycleTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlanExecutorHumanGateLifecycleTests.cs
@@ -289,6 +289,7 @@ public sealed class PlanExecutorHumanGateLifecycleTests : IDisposable
             _notifier.Object,
             _escalation.Object,
             provider,
+            new PlanRunCancellationRegistry(),
             TimeProvider.System,
             NullLogger<PlanExecutor>.Instance);
     }
@@ -310,6 +311,7 @@ public sealed class PlanExecutorHumanGateLifecycleTests : IDisposable
             _notifier.Object,
             _escalation.Object,
             provider,
+            new PlanRunCancellationRegistry(),
             TimeProvider.System,
             NullLogger<PlanExecutor>.Instance);
     }

--- a/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlanExecutorResumeRecoveryTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlanExecutorResumeRecoveryTests.cs
@@ -198,6 +198,7 @@ public sealed class PlanExecutorResumeRecoveryTests : IDisposable
             _notifier.Object,
             _escalation.Object,
             provider,
+            new PlanRunCancellationRegistry(),
             TimeProvider.System,
             NullLogger<PlanExecutor>.Instance);
     }

--- a/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlanExecutorRetryPolicyTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlanExecutorRetryPolicyTests.cs
@@ -387,6 +387,7 @@ public sealed class PlanExecutorRetryPolicyTests : IDisposable
             _notifier.Object,
             _escalation.Object,
             _serviceProvider,
+            new PlanRunCancellationRegistry(),
             _time,
             NullLogger<PlanExecutor>.Instance);
     }

--- a/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlanExecutorSolutionReviewFixTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlanExecutorSolutionReviewFixTests.cs
@@ -127,6 +127,7 @@ public sealed class PlanExecutorSolutionReviewFixTests
             notifier.Object,
             escalation.Object,
             provider,
+            new PlanRunCancellationRegistry(),
             TimeProvider.System,
             NullLogger<PlanExecutor>.Instance);
     }

--- a/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlanExecutorTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlanExecutorTests.cs
@@ -58,6 +58,7 @@ public sealed class PlanExecutorTests : IDisposable
             _notifier.Object,
             _escalation.Object,
             _serviceProvider,
+            new PlanRunCancellationRegistry(),
             TimeProvider.System,
             NullLogger<PlanExecutor>.Instance);
     }


### PR DESCRIPTION
`CancelAsync` acquired the same per-plan lock a running `ExecuteAsync` holds for the whole run. Cancelling an in-flight plan therefore blocked until that plan finished on its own, then rewrote state for work that was already over. There was no signalling path at all — **a cancel returned success having stopped nothing.** On an operation whose entire purpose is halting expensive work, that is worse than having no cancel.

Prerequisite for W4: a run/status API without a working cancel is an API that can start spend it cannot stop.

## What changes

- **A cancellation registry** signals the live run before taking the plan lock, so a cancel never queues behind the run it is cancelling.
- **Cascade into nested sub-plans.** A sub-plan registers under the *child* plan id, so `TryCancel(parentPlanId)` could not reach it. The registry links a nested run to the run that invoked it via an ambient chain.
- **A cancelled step is `Cancelled`, not `Failed`.** `Cancelled` renormalises to `Pending` on resume; `Failed` is terminal and needs an explicit retry. Recording an operator cancel as `Failed` left the plan permanently wedged.
- **The check sits before the retry decision**, so a step with `MaxRetries = 0` — one attempt, no retries — is covered too. A cancellation guarantee that holds only for some retry configurations is not a guarantee.

## Advisories closed during review

| Finding | Resolution |
|---|---|
| The cancellation check read the ambient token, which folds in `CancelAfter(PlanTimeout)` — so a timed-out step lost `OnExhausted` recovery and its real error text | Reads `ctx.RunCancellationToken`. A cancel is resumable; a timeout is a failure with a cause |
| `CS1998` async-without-await | Dropped `async` |
| Sibling-run registry test registered both handles on one flow, making the second a **child** of the first — the nesting case, not the sibling case it was named for | Registers with execution-context flow suppressed |
| Class doc claimed the gate prevents cancel/dispose re-entry; a `lock` is reentrant, so it prevents it across *threads* only | Doc now states the actual mechanism and names the caller property it depends on |
| Comment said the `AsyncLocal` write never affects the caller's flow — it does, and that is what makes the feature work | Corrected |

**The regression test for the first item was vacuous on its first attempt** — it passed against both the fixed and the broken code, because a step that honours the token throws before ever reaching the check. Rewritten so the step fails rather than throws; the mutation now kills it.

## Carried forward to W4 — please read

Security review raised a **MEDIUM**: `TryCancel`/`CancelAsync` are **unscoped by tenant and owner**. Harmless today — `CancelPlanCommand` has no HTTP or hub caller, plan ids are unguessable GUIDs, and the planner deliberately registers `NullKnowledgeScope`. But **W4 is exactly the change that exposes it**, and at that moment this becomes a cross-tenant abort primitive. The scope check belongs before `TryCancel`, not after.

## Verification

Build 0 errors. Full suite 21/21 assemblies, 0 failures. Local gates: grader PASS, correctness CORRECT, security PASS (forced — the folder-name filter skipped it), docs-drift advisory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BnoLcufW278UxA9ssBM1Tc