### PR TITLE
feat: run stored workflows and report how they actually ended (W4)

### DIFF
--- a/src/Content/Application/Application.AI.Common/CQRS/Workflows/GetRun/GetWorkflowRunQuery.cs
+++ b/src/Content/Application/Application.AI.Common/CQRS/Workflows/GetRun/GetWorkflowRunQuery.cs
@@ -22,4 +22,12 @@ public sealed record GetWorkflowRunQuery : IRequest<Result<RunRecord>>
 
     /// <summary>Stable identity of the calling principal, resolved from its token.</summary>
     public required string OwnerId { get; init; }
+
+    /// <summary>Tenant of the calling principal, resolved from its token, when the host resolves one.</summary>
+    /// <remarks>
+    /// Carried alongside the owner so run visibility is decided on the same two legs as plan
+    /// ownership. Not <c>required</c>, because a host may legitimately resolve no tenant — a run
+    /// stored without one is then readable only by a caller who also has none.
+    /// </remarks>
+    public string? TenantId { get; init; }
 }

--- a/src/Content/Application/Application.AI.Common/CQRS/Workflows/GetRun/GetWorkflowRunQuery.cs
+++ b/src/Content/Application/Application.AI.Common/CQRS/Workflows/GetRun/GetWorkflowRunQuery.cs
@@ -1,0 +1,25 @@
+using Domain.AI.Runs;
+using Domain.Common;
+using MediatR;
+
+namespace Application.AI.Common.CQRS.Workflows.GetRun;
+
+/// <summary>
+/// Reads the current state of a run the caller started.
+/// </summary>
+/// <remarks>
+/// <see cref="OwnerId"/> is required rather than optional: the store answers as though another
+/// owner's run does not exist, and it can only do that if it is told who is asking. A query that
+/// omitted the caller would read anyone's run.
+/// </remarks>
+public sealed record GetWorkflowRunQuery : IRequest<Result<RunRecord>>
+{
+    /// <summary>Identifier of the workflow the run belongs to.</summary>
+    public required Guid WorkflowId { get; init; }
+
+    /// <summary>Identifier of the run to read.</summary>
+    public required string JobId { get; init; }
+
+    /// <summary>Stable identity of the calling principal, resolved from its token.</summary>
+    public required string OwnerId { get; init; }
+}

--- a/src/Content/Application/Application.AI.Common/CQRS/Workflows/GetRun/GetWorkflowRunQueryHandler.cs
+++ b/src/Content/Application/Application.AI.Common/CQRS/Workflows/GetRun/GetWorkflowRunQueryHandler.cs
@@ -1,0 +1,61 @@
+using Application.AI.Common.Interfaces.Runs;
+using Domain.AI.Runs;
+using Domain.Common;
+using Domain.Common.Config;
+using MediatR;
+using Microsoft.Extensions.Options;
+
+namespace Application.AI.Common.CQRS.Workflows.GetRun;
+
+/// <summary>
+/// Handles <see cref="GetWorkflowRunQuery"/>: reads a run the caller started.
+/// </summary>
+/// <remarks>
+/// Both the owner check and the workflow check answer NotFound rather than Forbidden. A caller
+/// learning "that run exists but is not yours" would be able to enumerate other callers' work by
+/// guessing identifiers, so a run belonging to someone else and a run that never existed are
+/// deliberately the same answer. The workflow is checked too, so a valid job id cannot be read
+/// through the wrong workflow's route and imply a relationship that does not exist.
+/// </remarks>
+public sealed class GetWorkflowRunQueryHandler : IRequestHandler<GetWorkflowRunQuery, Result<RunRecord>>
+{
+    private readonly IRunJobStore _runStore;
+    private readonly IOptionsMonitor<AppConfig> _config;
+
+    /// <summary>Initializes a new <see cref="GetWorkflowRunQueryHandler"/>.</summary>
+    public GetWorkflowRunQueryHandler(IRunJobStore runStore, IOptionsMonitor<AppConfig> config)
+    {
+        ArgumentNullException.ThrowIfNull(runStore);
+        ArgumentNullException.ThrowIfNull(config);
+
+        _runStore = runStore;
+        _config = config;
+    }
+
+    /// <inheritdoc />
+    public Task<Result<RunRecord>> Handle(GetWorkflowRunQuery request, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (!_config.CurrentValue.AI.WorkflowSubmission.Enabled)
+        {
+            return Task.FromResult(Result<RunRecord>.Forbidden(
+                "Workflow submission is disabled. Set AppConfig.AI.WorkflowSubmission.Enabled = true to enable it."));
+        }
+
+        var record = _runStore.Get(request.JobId, request.OwnerId);
+
+        // A run under a different workflow is reported as missing rather than returned: the route
+        // states a relationship, and answering it with a record that contradicts the route would let a
+        // caller confirm which workflow a job belongs to by trying routes until one succeeded.
+        if (record is null
+            || record.Kind != RunKind.Workflow
+            || !string.Equals(record.TargetId, request.WorkflowId.ToString(), StringComparison.OrdinalIgnoreCase))
+        {
+            return Task.FromResult(Result<RunRecord>.NotFound($"No run {request.JobId} found."));
+        }
+
+        return Task.FromResult(Result<RunRecord>.Success(record));
+    }
+}

--- a/src/Content/Application/Application.AI.Common/CQRS/Workflows/GetRun/GetWorkflowRunQueryHandler.cs
+++ b/src/Content/Application/Application.AI.Common/CQRS/Workflows/GetRun/GetWorkflowRunQueryHandler.cs
@@ -44,7 +44,7 @@ public sealed class GetWorkflowRunQueryHandler : IRequestHandler<GetWorkflowRunQ
                 "Workflow submission is disabled. Set AppConfig.AI.WorkflowSubmission.Enabled = true to enable it."));
         }
 
-        var record = _runStore.Get(request.JobId, request.OwnerId);
+        var record = _runStore.Get(request.JobId, request.OwnerId, request.TenantId);
 
         // A run under a different workflow is reported as missing rather than returned: the route
         // states a relationship, and answering it with a record that contradicts the route would let a

--- a/src/Content/Application/Application.AI.Common/CQRS/Workflows/StartRun/StartWorkflowRunCommand.cs
+++ b/src/Content/Application/Application.AI.Common/CQRS/Workflows/StartRun/StartWorkflowRunCommand.cs
@@ -9,9 +9,12 @@ namespace Application.AI.Common.CQRS.Workflows.StartRun;
 /// </summary>
 /// <remarks>
 /// <para>
-/// <strong>Starting a run is a separate right from submitting a workflow.</strong> Submission stores a
-/// definition; this spends the host's model and tool credentials on it. Keeping them apart means a
-/// caller that can author work does not automatically get to execute it.
+/// <strong>Starting a run is kept separable from submitting a workflow.</strong> Submission stores a
+/// definition; this spends the host's model and tool credentials on it. They are distinct operations
+/// so a host <em>can</em> authorize them differently — as shipped both carry the same authorization,
+/// and a consumer that wants the two held apart attaches its own policy to each. What the separation
+/// guarantees today is structural, not enforced: nothing here confers execution on an author, because
+/// a caller can only run workflows it owns and only under its own envelope.
 /// </para>
 /// <para>
 /// <strong><see cref="Envelope"/> is resolved at the transport boundary from the credential that

--- a/src/Content/Application/Application.AI.Common/CQRS/Workflows/StartRun/StartWorkflowRunCommand.cs
+++ b/src/Content/Application/Application.AI.Common/CQRS/Workflows/StartRun/StartWorkflowRunCommand.cs
@@ -1,0 +1,36 @@
+using Domain.AI.Bundles;
+using Domain.Common;
+using MediatR;
+
+namespace Application.AI.Common.CQRS.Workflows.StartRun;
+
+/// <summary>
+/// Queues a stored workflow for execution and returns the job identifier the caller polls.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>Starting a run is a separate right from submitting a workflow.</strong> Submission stores a
+/// definition; this spends the host's model and tool credentials on it. Keeping them apart means a
+/// caller that can author work does not automatically get to execute it.
+/// </para>
+/// <para>
+/// <strong><see cref="Envelope"/> is resolved at the transport boundary from the credential that
+/// invoked this</strong>, not from anything stored with the workflow. A run therefore executes under
+/// the grant of whoever started it, so a workflow authored by a broadly-permitted caller confers
+/// nothing on a narrowly-permitted one that runs it later.
+/// </para>
+/// </remarks>
+public sealed record StartWorkflowRunCommand : IRequest<Result<StartWorkflowRunResult>>
+{
+    /// <summary>Identifier of the stored workflow to run.</summary>
+    public required Guid WorkflowId { get; init; }
+
+    /// <summary>Stable identity of the calling principal, resolved from its token.</summary>
+    public required string OwnerId { get; init; }
+
+    /// <summary>Tenant of the calling principal, when the host resolves one.</summary>
+    public string? TenantId { get; init; }
+
+    /// <summary>The grant this run executes under, resolved from the invoking credential.</summary>
+    public required CapabilityEnvelope Envelope { get; init; }
+}

--- a/src/Content/Application/Application.AI.Common/CQRS/Workflows/StartRun/StartWorkflowRunCommandHandler.cs
+++ b/src/Content/Application/Application.AI.Common/CQRS/Workflows/StartRun/StartWorkflowRunCommandHandler.cs
@@ -1,0 +1,126 @@
+using Application.AI.Common.Interfaces.Planner;
+using Application.AI.Common.Interfaces.Runs;
+using Domain.AI.Planner;
+using Domain.AI.Runs;
+using Domain.Common;
+using Domain.Common.Config;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Application.AI.Common.CQRS.Workflows.StartRun;
+
+/// <summary>
+/// Handles <see cref="StartWorkflowRunCommand"/>: confirms the caller owns the workflow, bounds how
+/// much it may have in flight, records the run, and queues it.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>The workflow is resolved before anything is queued.</strong> The store is scope-filtered,
+/// so a workflow belonging to another caller resolves to nothing and is reported exactly as an
+/// unknown one — a caller cannot discover which identifiers exist by trying to run them.
+/// </para>
+/// <para>
+/// <strong>Nothing executes on this thread.</strong> The command returns as soon as the run is
+/// recorded and queued, so an HTTP caller is never held open for the length of a workflow. Everything
+/// after this point happens on the dispatcher, which is why the run carries its own owner and
+/// envelope rather than expecting an ambient caller.
+/// </para>
+/// </remarks>
+public sealed class StartWorkflowRunCommandHandler
+    : IRequestHandler<StartWorkflowRunCommand, Result<StartWorkflowRunResult>>
+{
+    private readonly IPlanStateStore _planStore;
+    private readonly IRunJobStore _runStore;
+    private readonly IRunDispatchQueue _queue;
+    private readonly IOptionsMonitor<AppConfig> _config;
+    private readonly TimeProvider _time;
+    private readonly ILogger<StartWorkflowRunCommandHandler> _logger;
+
+    /// <summary>Initializes a new <see cref="StartWorkflowRunCommandHandler"/>.</summary>
+    public StartWorkflowRunCommandHandler(
+        IPlanStateStore planStore,
+        IRunJobStore runStore,
+        IRunDispatchQueue queue,
+        IOptionsMonitor<AppConfig> config,
+        TimeProvider time,
+        ILogger<StartWorkflowRunCommandHandler> logger)
+    {
+        ArgumentNullException.ThrowIfNull(planStore);
+        ArgumentNullException.ThrowIfNull(runStore);
+        ArgumentNullException.ThrowIfNull(queue);
+        ArgumentNullException.ThrowIfNull(config);
+        ArgumentNullException.ThrowIfNull(time);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _planStore = planStore;
+        _runStore = runStore;
+        _queue = queue;
+        _config = config;
+        _time = time;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<Result<StartWorkflowRunResult>> Handle(
+        StartWorkflowRunCommand request, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var config = _config.CurrentValue.AI.WorkflowSubmission;
+        if (!config.Enabled)
+        {
+            return Result<StartWorkflowRunResult>.Forbidden(
+                "Workflow submission is disabled. Set AppConfig.AI.WorkflowSubmission.Enabled = true to enable it.");
+        }
+
+        var planId = new PlanId(request.WorkflowId);
+        var owned = await _planStore.IsPlanWritableByCallerAsync(planId, cancellationToken).ConfigureAwait(false);
+        if (!owned.IsSuccess)
+        {
+            _logger.LogError(
+                "Could not resolve workflow {WorkflowId} while starting a run: {Errors}",
+                request.WorkflowId, string.Join("; ", owned.Errors));
+
+            return Result<StartWorkflowRunResult>.Fail("The workflow could not be read.");
+        }
+
+        if (!owned.Value)
+            return Result<StartWorkflowRunResult>.NotFound($"No workflow {request.WorkflowId} found.");
+
+        // Checked after ownership so a caller at its cap is not told about the existence of a
+        // workflow it does not own.
+        var active = _runStore.CountActiveRuns(request.OwnerId);
+        if (active >= config.MaxConcurrentRunsPerOwner)
+        {
+            return Result<StartWorkflowRunResult>.ValidationFailure(
+                [$"This caller already has {active} run(s) in flight, the maximum this host permits. "
+                 + "Wait for one to finish before starting another."]);
+        }
+
+        var record = new RunRecord
+        {
+            JobId = Guid.NewGuid().ToString("N"),
+            Kind = RunKind.Workflow,
+            TargetId = request.WorkflowId.ToString(),
+            OwnerId = request.OwnerId,
+            TenantId = request.TenantId,
+            Envelope = request.Envelope,
+            Status = RunStatus.Queued,
+            CreatedAt = _time.GetUtcNow()
+        };
+
+        _runStore.Create(record);
+
+        // Queued only after the record exists. The other order has a window in which a dispatcher
+        // claims a job the store has never heard of, and the run vanishes with the caller holding an
+        // identifier that will never resolve.
+        await _queue.EnqueueAsync(record.JobId, cancellationToken).ConfigureAwait(false);
+
+        _logger.LogInformation(
+            "Queued run {JobId} for workflow {WorkflowId}.", record.JobId, request.WorkflowId);
+
+        return Result<StartWorkflowRunResult>.Success(new StartWorkflowRunResult { JobId = record.JobId });
+    }
+}

--- a/src/Content/Application/Application.AI.Common/CQRS/Workflows/StartRun/StartWorkflowRunCommandHandler.cs
+++ b/src/Content/Application/Application.AI.Common/CQRS/Workflows/StartRun/StartWorkflowRunCommandHandler.cs
@@ -26,6 +26,12 @@ namespace Application.AI.Common.CQRS.Workflows.StartRun;
 /// after this point happens on the dispatcher, which is why the run carries its own owner and
 /// envelope rather than expecting an ambient caller.
 /// </para>
+/// <para>
+/// <strong>The limits are applied by the store, not here.</strong> Both are read-then-write decisions
+/// — is this workflow already running, is this caller at its ceiling — and asking then inserting
+/// leaves a window in which concurrent requests all see the limit as unmet. This decides what a
+/// refusal <em>means</em> to a caller; the store decides whether one happened.
+/// </para>
 /// </remarks>
 public sealed class StartWorkflowRunCommandHandler
     : IRequestHandler<StartWorkflowRunCommand, Result<StartWorkflowRunResult>>
@@ -89,16 +95,6 @@ public sealed class StartWorkflowRunCommandHandler
         if (!owned.Value)
             return Result<StartWorkflowRunResult>.NotFound($"No workflow {request.WorkflowId} found.");
 
-        // Checked after ownership so a caller at its cap is not told about the existence of a
-        // workflow it does not own.
-        var active = _runStore.CountActiveRuns(request.OwnerId);
-        if (active >= config.MaxConcurrentRunsPerOwner)
-        {
-            return Result<StartWorkflowRunResult>.ValidationFailure(
-                [$"This caller already has {active} run(s) in flight, the maximum this host permits. "
-                 + "Wait for one to finish before starting another."]);
-        }
-
         var record = new RunRecord
         {
             JobId = Guid.NewGuid().ToString("N"),
@@ -111,7 +107,11 @@ public sealed class StartWorkflowRunCommandHandler
             CreatedAt = _time.GetUtcNow()
         };
 
-        _runStore.Create(record);
+        // Admission is offered after ownership, so a caller at its cap is never told about the
+        // existence of a workflow it does not own.
+        var admission = _runStore.TryCreate(record, config.MaxConcurrentRunsPerOwner);
+        if (admission != RunAdmission.Accepted)
+            return Refuse(admission, request.WorkflowId, config.MaxConcurrentRunsPerOwner);
 
         // Queued only after the record exists. The other order has a window in which a dispatcher
         // claims a job the store has never heard of, and the run vanishes with the caller holding an
@@ -123,4 +123,20 @@ public sealed class StartWorkflowRunCommandHandler
 
         return Result<StartWorkflowRunResult>.Success(new StartWorkflowRunResult { JobId = record.JobId });
     }
+
+    /// <summary>Explains a refused admission in terms the caller can act on.</summary>
+    private static Result<StartWorkflowRunResult> Refuse(
+        RunAdmission admission, Guid workflowId, int maxConcurrentRuns) => admission switch
+    {
+        RunAdmission.TargetAlreadyRunning => Result<StartWorkflowRunResult>.Conflict(
+            $"Workflow {workflowId} already has a run in progress. A workflow's execution state is "
+            + "held against the workflow itself, so a second run would share it with the first. Wait "
+            + "for the current run to finish."),
+
+        RunAdmission.OwnerAtCapacity => Result<StartWorkflowRunResult>.ValidationFailure(
+            [$"This caller already has {maxConcurrentRuns} run(s) in flight, the maximum this host "
+             + "permits. Wait for one to finish before starting another."]),
+
+        _ => Result<StartWorkflowRunResult>.Fail("The run could not be accepted.")
+    };
 }

--- a/src/Content/Application/Application.AI.Common/CQRS/Workflows/StartRun/StartWorkflowRunCommandHandler.cs
+++ b/src/Content/Application/Application.AI.Common/CQRS/Workflows/StartRun/StartWorkflowRunCommandHandler.cs
@@ -116,7 +116,34 @@ public sealed class StartWorkflowRunCommandHandler
         // Queued only after the record exists. The other order has a window in which a dispatcher
         // claims a job the store has never heard of, and the run vanishes with the caller holding an
         // identifier that will never resolve.
-        await _queue.EnqueueAsync(record.JobId, cancellationToken).ConfigureAwait(false);
+        //
+        // Deliberately NOT the caller's token. Past the admission above the record is committed, and a
+        // record that is committed but never queued is never claimed, never finishes, and — because
+        // only terminal runs are reclaimed — never goes away: it pins its workflow at 409 and holds one
+        // of the owner's slots for the life of the process. A client that disconnects mid-request is
+        // ordinary, so that must not be reachable by hanging up. Abandoning the run here would be
+        // wrong regardless: the caller was already told it was accepted.
+        try
+        {
+            await _queue.EnqueueAsync(record.JobId, CancellationToken.None).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            // Unreachable with an unbounded in-process channel, which is why the token was the only
+            // live cause. Guarded anyway because the queue is the seam for a durable one, where a
+            // write genuinely can fail — and the cost of an unguarded failure is not a lost run but a
+            // permanently unusable workflow. Recording it terminal releases both holds and tells the
+            // caller the truth.
+            _logger.LogError(ex, "Run {JobId} was accepted but could not be queued.", record.JobId);
+            _runStore.Update(record with
+            {
+                Status = RunStatus.Failed,
+                Error = "The run was accepted but could not be queued for execution.",
+                CompletedAt = _time.GetUtcNow()
+            });
+
+            return Result<StartWorkflowRunResult>.Fail("The run could not be queued for execution.");
+        }
 
         _logger.LogInformation(
             "Queued run {JobId} for workflow {WorkflowId}.", record.JobId, request.WorkflowId);

--- a/src/Content/Application/Application.AI.Common/CQRS/Workflows/StartRun/StartWorkflowRunResult.cs
+++ b/src/Content/Application/Application.AI.Common/CQRS/Workflows/StartRun/StartWorkflowRunResult.cs
@@ -1,0 +1,12 @@
+namespace Application.AI.Common.CQRS.Workflows.StartRun;
+
+/// <summary>What a caller gets back when a run is accepted: the identifier it polls for progress.</summary>
+/// <remarks>
+/// Deliberately carries no status. The run is queued, not finished, and returning a status here would
+/// invite a caller to treat acceptance as completion — the response says only that the work was taken.
+/// </remarks>
+public sealed record StartWorkflowRunResult
+{
+    /// <summary>Server-minted identifier of the queued run.</summary>
+    public required string JobId { get; init; }
+}

--- a/src/Content/Application/Application.AI.Common/Interfaces/Planner/IPlanStateStore.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Planner/IPlanStateStore.cs
@@ -55,13 +55,6 @@ public interface IPlanStateStore
     Task<Result<IReadOnlyList<PlanExecutionLogEntry>>> GetExecutionHistoryAsync(PlanId planId, CancellationToken ct);
 
     /// <summary>
-    /// Lists plans with optional filtering by status and time range.
-    /// </summary>
-    /// <param name="statusFilter">Optional status filter.</param>
-    /// <param name="from">Optional start of time range.</param>
-    /// <param name="to">Optional end of time range.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <summary>
     /// Whether the plan exists and the ambient caller may mutate it.
     /// </summary>
     /// <remarks>

--- a/src/Content/Application/Application.AI.Common/Interfaces/Planner/IPlanStateStore.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Planner/IPlanStateStore.cs
@@ -62,6 +62,25 @@ public interface IPlanStateStore
     /// <param name="to">Optional end of time range.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <summary>
+    /// Whether the plan exists and the ambient caller may mutate it.
+    /// </summary>
+    /// <remarks>
+    /// Exists so a caller can be authorized <em>before</em> an irreversible side effect, not merely
+    /// before a persisted write. Cancellation is the case that forced it: signalling an in-flight run
+    /// stops real work immediately, so checking ownership only at the subsequent state rewrite would
+    /// let one caller abort another's run and then be told the plan was not found — with the run
+    /// already dead.
+    /// </remarks>
+    /// <param name="planId">The plan to probe.</param>
+    /// <param name="ct">Cancels the query.</param>
+    /// <returns>
+    /// <see langword="true"/> only when the plan exists and belongs to the ambient scope. A plan the
+    /// caller can read but not mutate — a globally readable one, for instance — returns
+    /// <see langword="false"/>, and callers must report that identically to a missing plan.
+    /// </returns>
+    Task<Result<bool>> IsPlanWritableByCallerAsync(PlanId planId, CancellationToken ct);
+
+    /// <summary>
     /// Counts the plans the ambient caller owns outright, for quota enforcement.
     /// </summary>
     /// <remarks>

--- a/src/Content/Application/Application.AI.Common/Interfaces/Runs/IRunDispatchQueue.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Runs/IRunDispatchQueue.cs
@@ -1,0 +1,21 @@
+namespace Application.AI.Common.Interfaces.Runs;
+
+/// <summary>
+/// Hands accepted run identifiers to the background dispatcher.
+/// </summary>
+/// <remarks>
+/// Carries identifiers rather than records, deliberately. The store is the single source of truth for
+/// a run's state, so a queued identifier cannot go stale — whereas a queued copy of the record could
+/// describe a run that has since been cancelled, and the dispatcher would act on the stale copy.
+/// </remarks>
+public interface IRunDispatchQueue
+{
+    /// <summary>Queues an accepted run for execution.</summary>
+    /// <param name="jobId">Identifier of the run to dispatch.</param>
+    /// <param name="cancellationToken">Cancels the enqueue.</param>
+    ValueTask EnqueueAsync(string jobId, CancellationToken cancellationToken);
+
+    /// <summary>Yields queued run identifiers until the token is cancelled.</summary>
+    /// <param name="cancellationToken">Ends the stream on host shutdown.</param>
+    IAsyncEnumerable<string> DequeueAllAsync(CancellationToken cancellationToken);
+}

--- a/src/Content/Application/Application.AI.Common/Interfaces/Runs/IRunJobStore.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Runs/IRunJobStore.cs
@@ -41,12 +41,19 @@ public interface IRunJobStore
     RunAdmission TryCreate(RunRecord record, int maxActiveRunsPerOwner);
 
     /// <summary>
-    /// Reads a run visible to <paramref name="ownerId"/>, or <see langword="null"/> when it does not
-    /// exist, has expired, or belongs to someone else — the three are deliberately indistinguishable.
+    /// Reads a run visible to the caller, or <see langword="null"/> when it does not exist, has
+    /// expired, or belongs to someone else — the three are deliberately indistinguishable.
     /// </summary>
+    /// <remarks>
+    /// Scoped by tenant as well as owner, matching how plan ownership is decided on the same request
+    /// path. A single-tenant issuer makes the owner alone sufficient today, so the tenant leg buys
+    /// nothing until a host accepts tokens from a second tenant — at which point its absence would be
+    /// a cross-tenant read, and the record already carries what is needed to prevent it.
+    /// </remarks>
     /// <param name="jobId">The run to read.</param>
     /// <param name="ownerId">Stable identity of the calling principal.</param>
-    RunRecord? Get(string jobId, string ownerId);
+    /// <param name="tenantId">Tenant of the calling principal, when the host resolves one.</param>
+    RunRecord? Get(string jobId, string ownerId, string? tenantId);
 
     /// <summary>
     /// Atomically claims a queued run for execution, returning the updated record to the winner and

--- a/src/Content/Application/Application.AI.Common/Interfaces/Runs/IRunJobStore.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Runs/IRunJobStore.cs
@@ -1,0 +1,70 @@
+using Domain.AI.Runs;
+
+namespace Application.AI.Common.Interfaces.Runs;
+
+/// <summary>
+/// Holds queued and completed runs, and arms each one exactly once.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>Ownership is checked by the store, not by its callers.</strong> Every read takes the
+/// caller's identity and answers as though another owner's run does not exist. Leaving that to
+/// callers would mean every future surface — status, cancel, streaming — had to remember it, and the
+/// one that forgot would be a cross-tenant read.
+/// </para>
+/// <para>
+/// <strong><see cref="TryBeginRun"/> is the single-arming primitive.</strong> It moves a run from
+/// queued to running and returns it only for the caller that won; everyone else gets
+/// <see langword="null"/>. Without an atomic claim, a redelivered queue message or a second
+/// dispatcher would run the same work twice, and duplicate execution here means duplicate model and
+/// tool spend, not just a duplicate row.
+/// </para>
+/// </remarks>
+public interface IRunJobStore
+{
+    /// <summary>Stores a newly accepted run. Throws when the job id already exists.</summary>
+    /// <param name="record">The run to store, already stamped with its owner.</param>
+    void Create(RunRecord record);
+
+    /// <summary>
+    /// Reads a run visible to <paramref name="ownerId"/>, or <see langword="null"/> when it does not
+    /// exist, has expired, or belongs to someone else — the three are deliberately indistinguishable.
+    /// </summary>
+    /// <param name="jobId">The run to read.</param>
+    /// <param name="ownerId">Stable identity of the calling principal.</param>
+    RunRecord? Get(string jobId, string ownerId);
+
+    /// <summary>
+    /// Atomically claims a queued run for execution, returning the updated record to the winner and
+    /// <see langword="null"/> to everyone else.
+    /// </summary>
+    /// <remarks>
+    /// Takes no owner: the dispatcher runs on a background thread with no caller attached, and the
+    /// authorization that mattered happened when the run was accepted. The owner recorded on the
+    /// run is what later reads are checked against.
+    /// </remarks>
+    /// <param name="jobId">The run to claim.</param>
+    /// <param name="startedAt">Timestamp to record as the claim time.</param>
+    RunRecord? TryBeginRun(string jobId, DateTimeOffset startedAt);
+
+    /// <summary>
+    /// Replaces a stored run. Returns <see langword="false"/> when no run with that id is held.
+    /// </summary>
+    /// <param name="record">The updated run.</param>
+    bool Update(RunRecord record);
+
+    /// <summary>
+    /// Counts the runs <paramref name="ownerId"/> currently has queued or executing.
+    /// </summary>
+    /// <remarks>
+    /// In-flight only — finished runs are history, not load. This is what bounds a caller's claim on
+    /// the host at any instant, which neither the per-request rate limit nor any per-workflow ceiling
+    /// expresses: a caller within both can otherwise start every workflow it owns at once, and each
+    /// one then multiplies by its own parallel-step allowance.
+    /// </remarks>
+    /// <param name="ownerId">Stable identity of the calling principal.</param>
+    int CountActiveRuns(string ownerId);
+
+    /// <summary>Drops runs whose retention has elapsed, returning how many were removed.</summary>
+    int SweepExpired();
+}

--- a/src/Content/Application/Application.AI.Common/Interfaces/Runs/IRunJobStore.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Runs/IRunJobStore.cs
@@ -19,12 +19,26 @@ namespace Application.AI.Common.Interfaces.Runs;
 /// dispatcher would run the same work twice, and duplicate execution here means duplicate model and
 /// tool spend, not just a duplicate row.
 /// </para>
+/// <para>
+/// <strong>Admission is decided here too, for the same reason.</strong> Both limits on accepting a
+/// run — one live run per target, and a ceiling on what one caller may have in flight — are
+/// read-then-write decisions. Deciding them in a handler and inserting afterwards leaves a window in
+/// which concurrent requests all observe the limit as unmet and all proceed.
+/// </para>
 /// </remarks>
 public interface IRunJobStore
 {
-    /// <summary>Stores a newly accepted run. Throws when the job id already exists.</summary>
+    /// <summary>
+    /// Admits a newly accepted run, or refuses it, deciding and inserting as one atomic step.
+    /// </summary>
     /// <param name="record">The run to store, already stamped with its owner.</param>
-    void Create(RunRecord record);
+    /// <param name="maxActiveRunsPerOwner">
+    /// How many runs one owner may have queued or executing at once. Supplied by the caller rather
+    /// than read here, because it is host policy rather than a property of storage.
+    /// </param>
+    /// <returns>Whether the run was admitted, and if not, which limit refused it.</returns>
+    /// <exception cref="InvalidOperationException">The job id is already held.</exception>
+    RunAdmission TryCreate(RunRecord record, int maxActiveRunsPerOwner);
 
     /// <summary>
     /// Reads a run visible to <paramref name="ownerId"/>, or <see langword="null"/> when it does not
@@ -52,18 +66,6 @@ public interface IRunJobStore
     /// </summary>
     /// <param name="record">The updated run.</param>
     bool Update(RunRecord record);
-
-    /// <summary>
-    /// Counts the runs <paramref name="ownerId"/> currently has queued or executing.
-    /// </summary>
-    /// <remarks>
-    /// In-flight only — finished runs are history, not load. This is what bounds a caller's claim on
-    /// the host at any instant, which neither the per-request rate limit nor any per-workflow ceiling
-    /// expresses: a caller within both can otherwise start every workflow it owns at once, and each
-    /// one then multiplies by its own parallel-step allowance.
-    /// </remarks>
-    /// <param name="ownerId">Stable identity of the calling principal.</param>
-    int CountActiveRuns(string ownerId);
 
     /// <summary>Drops runs whose retention has elapsed, returning how many were removed.</summary>
     int SweepExpired();

--- a/src/Content/Application/Application.AI.Common/Interfaces/Runs/IRunKindExecutor.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Runs/IRunKindExecutor.cs
@@ -18,7 +18,15 @@ public interface IRunKindExecutor
     /// <param name="record">The claimed run, carrying its target, owner and capability envelope.</param>
     /// <param name="cancellationToken">Cancels the work.</param>
     /// <returns>
-    /// Success when the work completed, or a failure whose message is safe to hand back to the caller.
+    /// <para>
+    /// On success, how the work ended — which is not the same question as whether this call worked.
+    /// A workflow that parked on a human gate or was cancelled mid-flight ran exactly as asked, and
+    /// says so through <see cref="RunCompletion.Status"/>.
+    /// </para>
+    /// <para>
+    /// A failed result means the executor could not run the work at all, and its message must be safe
+    /// to hand back to the caller.
+    /// </para>
     /// </returns>
-    Task<Result> ExecuteAsync(RunRecord record, CancellationToken cancellationToken);
+    Task<Result<RunCompletion>> ExecuteAsync(RunRecord record, CancellationToken cancellationToken);
 }

--- a/src/Content/Application/Application.AI.Common/Interfaces/Runs/IRunKindExecutor.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Runs/IRunKindExecutor.cs
@@ -1,0 +1,24 @@
+using Domain.AI.Runs;
+using Domain.Common;
+
+namespace Application.AI.Common.Interfaces.Runs;
+
+/// <summary>
+/// Performs the work for one <see cref="RunKind"/>. Registered as a keyed service under that kind,
+/// which is what makes adding a kind a registration rather than a change to the dispatcher.
+/// </summary>
+/// <remarks>
+/// Implementations receive a run that has already been claimed, so they must not re-check the queue
+/// or re-arm anything. They are responsible only for doing the work and reporting how it ended; the
+/// dispatcher owns recording that outcome against the run.
+/// </remarks>
+public interface IRunKindExecutor
+{
+    /// <summary>Executes a claimed run.</summary>
+    /// <param name="record">The claimed run, carrying its target, owner and capability envelope.</param>
+    /// <param name="cancellationToken">Cancels the work.</param>
+    /// <returns>
+    /// Success when the work completed, or a failure whose message is safe to hand back to the caller.
+    /// </returns>
+    Task<Result> ExecuteAsync(RunRecord record, CancellationToken cancellationToken);
+}

--- a/src/Content/Application/Application.Core/Validation/WorkflowSubmissionConfigValidator.cs
+++ b/src/Content/Application/Application.Core/Validation/WorkflowSubmissionConfigValidator.cs
@@ -87,6 +87,10 @@ public sealed class WorkflowSubmissionConfigValidator : AbstractValidator<Workfl
             .GreaterThan(0)
             .WithMessage("MaxConcurrentRunsPerOwner must be > 0 — a non-positive limit would refuse every caller's first run.");
 
+        RuleFor(x => x.MaxConcurrentDispatchedRuns)
+            .GreaterThan(0)
+            .WithMessage("MaxConcurrentDispatchedRuns must be > 0 — a non-positive degree would leave every accepted run queued and never executed.");
+
         RuleFor(x => x.RunSweepInterval)
             .GreaterThan(TimeSpan.Zero)
             .WithMessage("RunSweepInterval must be > 0 — a non-positive interval would spin the sweeper continuously instead of scheduling it.");

--- a/src/Content/Application/Application.Core/Validation/WorkflowSubmissionConfigValidator.cs
+++ b/src/Content/Application/Application.Core/Validation/WorkflowSubmissionConfigValidator.cs
@@ -79,6 +79,14 @@ public sealed class WorkflowSubmissionConfigValidator : AbstractValidator<Workfl
             .GreaterThan(0)
             .WithMessage("MaxStoredWorkflowsPerOwner must be > 0 — a non-positive quota would reject every caller's first submission.");
 
+        RuleFor(x => x.RunRecordTtl)
+            .GreaterThan(TimeSpan.Zero)
+            .WithMessage("RunRecordTtl must be > 0 — a non-positive retention reclaims every run the moment it finishes, so no caller could ever read an outcome.");
+
+        RuleFor(x => x.MaxConcurrentRunsPerOwner)
+            .GreaterThan(0)
+            .WithMessage("MaxConcurrentRunsPerOwner must be > 0 — a non-positive limit would refuse every caller's first run.");
+
         RuleFor(x => x.MaxHumanGateTimeout)
             .GreaterThan(TimeSpan.Zero)
             .WithMessage("MaxHumanGateTimeout must be > 0 — a non-positive ceiling would reject every requested gate timeout.");

--- a/src/Content/Application/Application.Core/Validation/WorkflowSubmissionConfigValidator.cs
+++ b/src/Content/Application/Application.Core/Validation/WorkflowSubmissionConfigValidator.cs
@@ -87,6 +87,10 @@ public sealed class WorkflowSubmissionConfigValidator : AbstractValidator<Workfl
             .GreaterThan(0)
             .WithMessage("MaxConcurrentRunsPerOwner must be > 0 — a non-positive limit would refuse every caller's first run.");
 
+        RuleFor(x => x.RunSweepInterval)
+            .GreaterThan(TimeSpan.Zero)
+            .WithMessage("RunSweepInterval must be > 0 — a non-positive interval would spin the sweeper continuously instead of scheduling it.");
+
         RuleFor(x => x.MaxHumanGateTimeout)
             .GreaterThan(TimeSpan.Zero)
             .WithMessage("MaxHumanGateTimeout must be > 0 — a non-positive ceiling would reject every requested gate timeout.");

--- a/src/Content/Domain/Domain.AI/Runs/RunAdmission.cs
+++ b/src/Content/Domain/Domain.AI/Runs/RunAdmission.cs
@@ -1,0 +1,31 @@
+namespace Domain.AI.Runs;
+
+/// <summary>
+/// Outcome of offering a run to the store: admitted, or refused by a named limit.
+/// </summary>
+/// <remarks>
+/// Named rather than boolean because the two refusals mean opposite things to a caller. Being at
+/// capacity is about the caller and clears on its own as its own work finishes; a target already
+/// running is about that one workflow and clears only when that run ends. A caller told merely "no"
+/// cannot tell whether to back off or to stop asking.
+/// </remarks>
+public enum RunAdmission
+{
+    /// <summary>The run was stored and may be queued.</summary>
+    Accepted = 0,
+
+    /// <summary>
+    /// The target already has a live run. A stored workflow's execution state is singular — it is
+    /// keyed by the workflow, not by the run — so a second concurrent run would share one state
+    /// machine with the first: re-executing steps the first has in flight and adopting its outputs.
+    /// </summary>
+    TargetAlreadyRunning = 1,
+
+    /// <summary>
+    /// The owner already holds as many live runs as the host permits. Bounds one caller's claim on
+    /// the host at any instant, which neither the per-request rate limit nor any per-workflow ceiling
+    /// expresses: a caller within both can otherwise start every workflow it owns at once, and each
+    /// one then multiplies by its own parallel-step allowance.
+    /// </summary>
+    OwnerAtCapacity = 2
+}

--- a/src/Content/Domain/Domain.AI/Runs/RunAdmission.cs
+++ b/src/Content/Domain/Domain.AI/Runs/RunAdmission.cs
@@ -22,10 +22,13 @@ public enum RunAdmission
     TargetAlreadyRunning = 1,
 
     /// <summary>
-    /// The owner already holds as many live runs as the host permits. Bounds one caller's claim on
-    /// the host at any instant, which neither the per-request rate limit nor any per-workflow ceiling
-    /// expresses: a caller within both can otherwise start every workflow it owns at once, and each
-    /// one then multiplies by its own parallel-step allowance.
+    /// The owner already holds as many live runs as the host permits.
     /// </summary>
+    /// <remarks>
+    /// Bounds how much work one caller may have <em>accepted</em> — queued or executing — which
+    /// neither the per-request rate limit nor any per-workflow ceiling expresses: a caller within both
+    /// can otherwise start every workflow it owns at once. It is not a statement about how much runs
+    /// concurrently; that is the host's dispatch degree, and it is not a fairness mechanism either.
+    /// </remarks>
     OwnerAtCapacity = 2
 }

--- a/src/Content/Domain/Domain.AI/Runs/RunCompletion.cs
+++ b/src/Content/Domain/Domain.AI/Runs/RunCompletion.cs
@@ -1,0 +1,47 @@
+namespace Domain.AI.Runs;
+
+/// <summary>
+/// How a run ended, as reported by the executor that performed it.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Work can end in more ways than "it worked" and "it did not". A workflow that parks on a human gate
+/// produced no result and suffered no fault; an operator cancel is a deliberate stop. Collapsing those
+/// into a boolean forces the dispatcher to guess, and the guess that gets made is
+/// <see cref="RunStatus.Succeeded"/> — telling a caller polling for an outcome that work finished when
+/// it is actually sitting awaiting an approval nobody has been asked for.
+/// </para>
+/// <para>
+/// This is the executor's answer to "what happened", separate from whether the executor was
+/// <em>able</em> to answer. An executor that could not run the work at all reports a failed
+/// <c>Result</c> instead, and the dispatcher records that as <see cref="RunStatus.Failed"/>.
+/// </para>
+/// </remarks>
+public sealed record RunCompletion
+{
+    /// <summary>The terminal state the run reached.</summary>
+    public required RunStatus Status { get; init; }
+
+    /// <summary>
+    /// Caller-safe explanation of the outcome, when one adds anything. Never raw exception text.
+    /// </summary>
+    public string? Detail { get; init; }
+
+    /// <summary>The run produced its result.</summary>
+    public static RunCompletion Succeeded() => new() { Status = RunStatus.Succeeded };
+
+    /// <summary>The run ran but did not produce its result.</summary>
+    /// <param name="detail">Caller-safe reason.</param>
+    public static RunCompletion Failed(string detail) =>
+        new() { Status = RunStatus.Failed, Detail = detail };
+
+    /// <summary>The run was stopped on request before it could finish.</summary>
+    /// <param name="detail">Caller-safe reason.</param>
+    public static RunCompletion Cancelled(string detail) =>
+        new() { Status = RunStatus.Cancelled, Detail = detail };
+
+    /// <summary>The run parked awaiting a decision it cannot make for itself.</summary>
+    /// <param name="detail">Caller-safe explanation of what is being waited on.</param>
+    public static RunCompletion Blocked(string detail) =>
+        new() { Status = RunStatus.Blocked, Detail = detail };
+}

--- a/src/Content/Domain/Domain.AI/Runs/RunKind.cs
+++ b/src/Content/Domain/Domain.AI/Runs/RunKind.cs
@@ -1,0 +1,15 @@
+namespace Domain.AI.Runs;
+
+/// <summary>
+/// What kind of work a queued run performs. Selects the executor the dispatcher resolves for a job.
+/// </summary>
+/// <remarks>
+/// An enum rather than a free string, matching the keyed-DI convention already used for plan step
+/// executors. Adding a kind is then a deliberate edit here plus a registration, and a job whose kind
+/// has no registered executor is a startup-visible gap rather than a typo that silently never runs.
+/// </remarks>
+public enum RunKind
+{
+    /// <summary>Executes a stored workflow (plan) through the planner.</summary>
+    Workflow = 0
+}

--- a/src/Content/Domain/Domain.AI/Runs/RunRecord.cs
+++ b/src/Content/Domain/Domain.AI/Runs/RunRecord.cs
@@ -1,0 +1,72 @@
+using Domain.AI.Bundles;
+
+namespace Domain.AI.Runs;
+
+/// <summary>
+/// One queued or completed unit of externally-triggered work: what it runs, who owns it, where it has
+/// got to, and how it ended.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>Deliberately kind-agnostic.</strong> Everything here is true of any run — identity,
+/// ownership, lifecycle, timing — so a new kind of work becomes a <see cref="RunKind"/> member and an
+/// executor registration rather than a second copy of the queue, dispatcher, single-arming and
+/// expiry logic. What each kind needs beyond this belongs to that kind's own stored record, not here.
+/// </para>
+/// <para>
+/// <strong><see cref="OwnerId"/> and <see cref="TenantId"/> are captured at creation, not read back
+/// from an ambient scope later.</strong> A run outlives the request that started it and executes on a
+/// background thread with no caller attached, so the identity that authorized it has to be carried on
+/// the record itself. Reading it back ambiently would resolve to whatever scope the dispatcher
+/// happened to be on — which is none.
+/// </para>
+/// </remarks>
+public sealed record RunRecord
+{
+    /// <summary>Server-minted identifier the caller polls.</summary>
+    public required string JobId { get; init; }
+
+    /// <summary>Which kind of work this is, selecting the executor that will perform it.</summary>
+    public required RunKind Kind { get; init; }
+
+    /// <summary>
+    /// Identifier of the thing being run, interpreted by the executor for <see cref="Kind"/> — a
+    /// stored workflow's id for <see cref="RunKind.Workflow"/>.
+    /// </summary>
+    public required string TargetId { get; init; }
+
+    /// <summary>Stable identity of the caller that started the run, and the only one that may read it.</summary>
+    public required string OwnerId { get; init; }
+
+    /// <summary>Tenant of the caller that started the run, when the host resolves one.</summary>
+    public string? TenantId { get; init; }
+
+    /// <summary>
+    /// The grant this run executes under, resolved from the credential that <em>started</em> it.
+    /// </summary>
+    /// <remarks>
+    /// Carried per run rather than re-resolved at execution time, so a run performs exactly what the
+    /// caller who triggered it was entitled to at that moment — a later change to that caller's grant
+    /// does not retroactively widen work already queued.
+    /// </remarks>
+    public required CapabilityEnvelope Envelope { get; init; }
+
+    /// <summary>Where the run has got to.</summary>
+    public required RunStatus Status { get; init; }
+
+    /// <summary>Caller-safe failure reason once the run has failed. Never raw exception text.</summary>
+    public string? Error { get; init; }
+
+    /// <summary>When the run was accepted and queued.</summary>
+    public required DateTimeOffset CreatedAt { get; init; }
+
+    /// <summary>When a dispatcher claimed the run, if it has been claimed.</summary>
+    public DateTimeOffset? StartedAt { get; init; }
+
+    /// <summary>When the run reached a terminal state, if it has.</summary>
+    public DateTimeOffset? CompletedAt { get; init; }
+
+    /// <summary>Whether the run has finished and will not change again.</summary>
+    public bool IsTerminal =>
+        Status is RunStatus.Succeeded or RunStatus.Failed or RunStatus.Cancelled;
+}

--- a/src/Content/Domain/Domain.AI/Runs/RunRecord.cs
+++ b/src/Content/Domain/Domain.AI/Runs/RunRecord.cs
@@ -67,6 +67,13 @@ public sealed record RunRecord
     public DateTimeOffset? CompletedAt { get; init; }
 
     /// <summary>Whether the run has finished and will not change again.</summary>
+    /// <remarks>
+    /// Expressed as "not one of the live states" rather than "one of the terminal states" on purpose.
+    /// Queued and Running are the only two the dispatcher can move a run out of, and enumerating the
+    /// terminal side instead means every future outcome added to <see cref="RunStatus"/> is silently
+    /// treated as live until someone remembers to list it here — which would strand it at the
+    /// concurrency cap and keep it from ever being reclaimed.
+    /// </remarks>
     public bool IsTerminal =>
-        Status is RunStatus.Succeeded or RunStatus.Failed or RunStatus.Cancelled;
+        Status is not (RunStatus.Queued or RunStatus.Running);
 }

--- a/src/Content/Domain/Domain.AI/Runs/RunStatus.cs
+++ b/src/Content/Domain/Domain.AI/Runs/RunStatus.cs
@@ -1,0 +1,28 @@
+namespace Domain.AI.Runs;
+
+/// <summary>
+/// Lifecycle of a queued run.
+/// </summary>
+/// <remarks>
+/// <see cref="Cancelled"/> is distinct from <see cref="Failed"/> deliberately. Both are terminal, but
+/// one says the work was stopped on purpose and the other says it broke — an operator triaging a
+/// queue needs to tell those apart, and collapsing them makes every deliberate stop look like an
+/// incident.
+/// </remarks>
+public enum RunStatus
+{
+    /// <summary>Accepted and waiting for a dispatcher to claim it.</summary>
+    Queued = 0,
+
+    /// <summary>Claimed by a dispatcher and executing.</summary>
+    Running = 1,
+
+    /// <summary>Finished successfully.</summary>
+    Succeeded = 2,
+
+    /// <summary>Finished unsuccessfully. <see cref="RunRecord.Error"/> carries a caller-safe reason.</summary>
+    Failed = 3,
+
+    /// <summary>Stopped on request before it could finish.</summary>
+    Cancelled = 4
+}

--- a/src/Content/Domain/Domain.AI/Runs/RunStatus.cs
+++ b/src/Content/Domain/Domain.AI/Runs/RunStatus.cs
@@ -4,10 +4,18 @@ namespace Domain.AI.Runs;
 /// Lifecycle of a queued run.
 /// </summary>
 /// <remarks>
+/// <para>
 /// <see cref="Cancelled"/> is distinct from <see cref="Failed"/> deliberately. Both are terminal, but
 /// one says the work was stopped on purpose and the other says it broke — an operator triaging a
 /// queue needs to tell those apart, and collapsing them makes every deliberate stop look like an
 /// incident.
+/// </para>
+/// <para>
+/// <see cref="Blocked"/> is the same argument taken one step further. Work that parked awaiting a
+/// human decision neither succeeded nor broke, and reporting it as either misleads: as
+/// <see cref="Succeeded"/> it claims an outcome that was never produced, and as <see cref="Failed"/>
+/// it sends an operator hunting for a fault when what is actually needed is an approval.
+/// </para>
 /// </remarks>
 public enum RunStatus
 {
@@ -24,5 +32,12 @@ public enum RunStatus
     Failed = 3,
 
     /// <summary>Stopped on request before it could finish.</summary>
-    Cancelled = 4
+    Cancelled = 4,
+
+    /// <summary>
+    /// Parked awaiting a decision this run cannot make for itself — typically a human approval gate.
+    /// Terminal for the run, because the dispatcher is done with it; acting on the decision starts a
+    /// new run rather than reviving this one.
+    /// </summary>
+    Blocked = 5
 }

--- a/src/Content/Domain/Domain.Common/Config/AI/WorkflowSubmission/WorkflowSubmissionConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/WorkflowSubmission/WorkflowSubmissionConfig.cs
@@ -61,7 +61,8 @@ namespace Domain.Common.Config.AI.WorkflowSubmission;
 /// ├── MaxStoredWorkflowsPerOwner — Cap on how many workflows one caller may keep stored
 /// ├── RunRecordTtl             — How long a finished run stays readable
 /// ├── MaxConcurrentRunsPerOwner — Cap on how many runs one caller may have in flight
-/// └── RunSweepInterval         — How often expired run records are reclaimed
+/// ├── RunSweepInterval         — How often expired run records are reclaimed
+/// └── MaxConcurrentDispatchedRuns — How many runs the host executes at once, across all callers
 /// </code>
 /// </remarks>
 public class WorkflowSubmissionConfig
@@ -225,4 +226,24 @@ public class WorkflowSubmissionConfig
     /// </remarks>
     /// <value>Default: 5 minutes</value>
     public TimeSpan RunSweepInterval { get; set; } = TimeSpan.FromMinutes(5);
+
+    /// <summary>
+    /// How many runs the host executes at once, across all callers.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Distinct from <see cref="MaxConcurrentRunsPerOwner"/>, which bounds what one caller may have
+    /// <em>accepted</em>. This bounds what the host actually executes. At 1 the dispatcher is strictly
+    /// serial and a single long workflow delays every other caller's — which makes the per-owner cap
+    /// read as a concurrency guarantee the host does not provide.
+    /// </para>
+    /// <para>
+    /// <strong>This is not a fairness mechanism.</strong> Runs are dispatched in the order they were
+    /// accepted, so a caller that queues many runs at once still occupies the slots ahead of a caller
+    /// that queues one. Per-caller fair scheduling is a separate piece of work; raising this reduces
+    /// how long anyone waits but does not decide who waits.
+    /// </para>
+    /// </remarks>
+    /// <value>Default: 4</value>
+    public int MaxConcurrentDispatchedRuns { get; set; } = 4;
 }

--- a/src/Content/Domain/Domain.Common/Config/AI/WorkflowSubmission/WorkflowSubmissionConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/WorkflowSubmission/WorkflowSubmissionConfig.cs
@@ -58,7 +58,9 @@ namespace Domain.Common.Config.AI.WorkflowSubmission;
 /// ├── MaxHumanGateTimeout      — Ceiling on how long a submitted step may park awaiting approval
 /// ├── MaxTokensPerStep         — Ceiling on a requested LLM response-token count
 /// ├── MaxTopK                  — Ceiling on a requested retrieval result count
-/// └── MaxStoredWorkflowsPerOwner — Cap on how many workflows one caller may keep stored
+/// ├── MaxStoredWorkflowsPerOwner — Cap on how many workflows one caller may keep stored
+/// ├── RunRecordTtl             — How long a finished run stays readable
+/// └── MaxConcurrentRunsPerOwner — Cap on how many runs one caller may have in flight
 /// </code>
 /// </remarks>
 public class WorkflowSubmissionConfig
@@ -186,4 +188,27 @@ public class WorkflowSubmissionConfig
     /// </remarks>
     /// <value>Default: 500</value>
     public int MaxStoredWorkflowsPerOwner { get; set; } = 500;
+
+    /// <summary>
+    /// How long a finished run stays readable before it is reclaimed.
+    /// </summary>
+    /// <remarks>
+    /// The clock starts when the run reaches a terminal state, not when it was accepted, so a run that
+    /// waited a long time in the queue still gets its full readable window afterwards. A run that has
+    /// not finished is never reclaimed at all — expiring one a caller is still polling would make it
+    /// silently disappear rather than report an outcome.
+    /// </remarks>
+    /// <value>Default: 1 hour</value>
+    public TimeSpan RunRecordTtl { get; set; } = TimeSpan.FromHours(1);
+
+    /// <summary>
+    /// Maximum number of runs one caller may have queued or executing at once.
+    /// </summary>
+    /// <remarks>
+    /// Distinct from <see cref="MaxStoredWorkflowsPerOwner"/>, which bounds stored definitions: this
+    /// bounds work in flight. A caller within the storage quota can otherwise start every workflow it
+    /// owns simultaneously, and the per-workflow parallelism ceiling multiplies by that count.
+    /// </remarks>
+    /// <value>Default: 10</value>
+    public int MaxConcurrentRunsPerOwner { get; set; } = 10;
 }

--- a/src/Content/Domain/Domain.Common/Config/AI/WorkflowSubmission/WorkflowSubmissionConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/WorkflowSubmission/WorkflowSubmissionConfig.cs
@@ -60,7 +60,8 @@ namespace Domain.Common.Config.AI.WorkflowSubmission;
 /// ├── MaxTopK                  — Ceiling on a requested retrieval result count
 /// ├── MaxStoredWorkflowsPerOwner — Cap on how many workflows one caller may keep stored
 /// ├── RunRecordTtl             — How long a finished run stays readable
-/// └── MaxConcurrentRunsPerOwner — Cap on how many runs one caller may have in flight
+/// ├── MaxConcurrentRunsPerOwner — Cap on how many runs one caller may have in flight
+/// └── RunSweepInterval         — How often expired run records are reclaimed
 /// </code>
 /// </remarks>
 public class WorkflowSubmissionConfig
@@ -211,4 +212,17 @@ public class WorkflowSubmissionConfig
     /// </remarks>
     /// <value>Default: 10</value>
     public int MaxConcurrentRunsPerOwner { get; set; } = 10;
+
+    /// <summary>
+    /// How often finished runs past their <see cref="RunRecordTtl"/> are reclaimed.
+    /// </summary>
+    /// <remarks>
+    /// Separate from the retention window rather than derived from it. The two answer different
+    /// questions — how long a caller may read a finished run, and how promptly the host gives that
+    /// memory back — and an operator who lengthens the readable window rarely means to make sweeps
+    /// correspondingly rare. Only terminal records are ever reclaimed, so this cannot shorten the life
+    /// of work still in flight.
+    /// </remarks>
+    /// <value>Default: 5 minutes</value>
+    public TimeSpan RunSweepInterval { get; set; } = TimeSpan.FromMinutes(5);
 }

--- a/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.Planner.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.Planner.cs
@@ -100,6 +100,11 @@ public static partial class DependencyInjection
         // host from queueing work that nothing drains.
         services.AddHostedService<RunDispatchBackgroundService>();
 
+        // Likewise the sweeper: without it the configured retention is a claim nothing honours, and
+        // every finished run — each holding the envelope it executed under — is held for the life of
+        // the process.
+        services.AddHostedService<RunRecordCleanupService>();
+
         services.AddScoped<IPlanValidator, PlanValidator>();
         services.AddScoped<IPlanGenerator, LlmPlanGeneratorService>();
         services.AddScoped<IPlanStateStore, EfCorePlanStateStore>();

--- a/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.Planner.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.Planner.cs
@@ -2,14 +2,17 @@ using Application.AI.Common.Interfaces.Attestation;
 using Application.AI.Common.Interfaces.Escalation;
 using Application.AI.Common.Interfaces.KnowledgeGraph;
 using Application.AI.Common.Interfaces.Planner;
+using Application.AI.Common.Interfaces.Runs;
 using Application.AI.Common.Interfaces.Sandbox;
 using Application.AI.Common.Services.KnowledgeGraph;
 using Domain.AI.Planner;
+using Domain.AI.Runs;
 using Domain.AI.Sandbox;
 using Domain.Common.Config;
 using Infrastructure.AI.Attestation;
 using Infrastructure.AI.Persistence;
 using Infrastructure.AI.Planner;
+using Infrastructure.AI.Runs;
 using Infrastructure.AI.Planner.StepExecutors;
 using Infrastructure.AI.Sandbox;
 using Microsoft.EntityFrameworkCore;
@@ -79,9 +82,23 @@ public static partial class DependencyInjection
 
         // Singleton like IBundleRunExecutor: the executor owns no per-run state itself — it creates a
         // fresh DI scope per run and arms the caller's capability envelope + governance identity
-        // around IPlanExecutor inside that scope. Registration is unconditional and passive; nothing
-        // resolves it until a host surface (W4) calls it.
+        // around IPlanExecutor inside that scope.
         services.AddSingleton<IPlanRunExecutor, PlanRunExecutor>();
+
+        // Shared run substrate. Singletons because a run outlives the request that queued it: the
+        // store and queue are the handoff between a request thread and the dispatcher, so a scoped
+        // registration would give each request its own empty queue and nothing would ever run.
+        services.TryAddSingleton<IRunJobStore, InMemoryRunJobStore>();
+        services.TryAddSingleton<IRunDispatchQueue, InMemoryRunDispatchQueue>();
+
+        // Keyed by RunKind, which is what makes a new kind of work a registration rather than a
+        // change to the dispatcher. Scoped: the dispatcher creates a fresh scope per run and resolves
+        // the executor inside it, so each run gets its own scoped dependencies.
+        services.AddKeyedScoped<IRunKindExecutor, WorkflowRunKindExecutor>(RunKind.Workflow);
+
+        // The dispatcher is passive until something enqueues; registering it unconditionally keeps a
+        // host from queueing work that nothing drains.
+        services.AddHostedService<RunDispatchBackgroundService>();
 
         services.AddScoped<IPlanValidator, PlanValidator>();
         services.AddScoped<IPlanGenerator, LlmPlanGeneratorService>();

--- a/src/Content/Infrastructure/Infrastructure.AI/Planner/EfCorePlanStateStore.Reads.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Planner/EfCorePlanStateStore.Reads.cs
@@ -12,6 +12,16 @@ public sealed partial class EfCorePlanStateStore
 {
     /// <inheritdoc />
     /// <inheritdoc />
+    public async Task<Result<bool>> IsPlanWritableByCallerAsync(PlanId planId, CancellationToken ct)
+    {
+        await using var ctx = _factory.CreateDbContext();
+
+        var writable = await IsPlanWritableAsync(ctx, planId.Value, ct).ConfigureAwait(false);
+
+        return Result<bool>.Success(writable);
+    }
+
+    /// <inheritdoc />
     public async Task<Result<int>> CountOwnedPlansAsync(CancellationToken ct)
     {
         await using var ctx = _factory.CreateDbContext();

--- a/src/Content/Infrastructure/Infrastructure.AI/Planner/EfCorePlanStateStore.Reads.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Planner/EfCorePlanStateStore.Reads.cs
@@ -11,7 +11,6 @@ namespace Infrastructure.AI.Planner;
 public sealed partial class EfCorePlanStateStore
 {
     /// <inheritdoc />
-    /// <inheritdoc />
     public async Task<Result<bool>> IsPlanWritableByCallerAsync(PlanId planId, CancellationToken ct)
     {
         await using var ctx = _factory.CreateDbContext();

--- a/src/Content/Infrastructure/Infrastructure.AI/Planner/PlanExecutor.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Planner/PlanExecutor.cs
@@ -164,6 +164,22 @@ public sealed partial class PlanExecutor : IPlanExecutor
     {
         _logger.LogInformation("Plan {PlanId} cancellation requested", planId);
 
+        // Authorize BEFORE signalling. Signalling stops real work immediately and irreversibly, so a
+        // scope check placed only at the persisted rewrite below would let one caller abort another
+        // tenant's in-flight run and then receive NotFound — with the run already dead. The probe is
+        // scope-filtered, and a plan the caller may read but not mutate answers false, so a
+        // cross-owner cancel is reported identically to a cancel of a plan that does not exist.
+        var writable = await _stateStore.IsPlanWritableByCallerAsync(planId, ct);
+        if (!writable.IsSuccess)
+            return Result.Fail(writable.Errors.ToArray());
+
+        if (!writable.Value)
+        {
+            _logger.LogInformation(
+                "Plan {PlanId} cancellation refused: not present in the calling scope", planId);
+            return Result.NotFound($"No plan {planId} found.");
+        }
+
         var signalled = _cancellationRegistry.TryCancel(planId);
         _logger.LogInformation(
             signalled

--- a/src/Content/Infrastructure/Infrastructure.AI/Planner/PlanExecutor.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Planner/PlanExecutor.cs
@@ -169,7 +169,7 @@ public sealed partial class PlanExecutor : IPlanExecutor
         // tenant's in-flight run and then receive NotFound — with the run already dead. The probe is
         // scope-filtered, and a plan the caller may read but not mutate answers false, so a
         // cross-owner cancel is reported identically to a cancel of a plan that does not exist.
-        var writable = await _stateStore.IsPlanWritableByCallerAsync(planId, ct);
+        var writable = await _stateStore.IsPlanWritableByCallerAsync(planId, ct).ConfigureAwait(false);
         if (!writable.IsSuccess)
             return Result.Fail(writable.Errors.ToArray());
 

--- a/src/Content/Infrastructure/Infrastructure.AI/Planner/StepExecutors/ConditionalBranchStepExecutor.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Planner/StepExecutors/ConditionalBranchStepExecutor.cs
@@ -1,6 +1,5 @@
 using System.Diagnostics;
 using System.Text.Json;
-using System.Text.RegularExpressions;
 using Application.AI.Common.Interfaces.Planner;
 using Domain.AI.Planner;
 using Microsoft.Extensions.Logging;
@@ -11,7 +10,7 @@ namespace Infrastructure.AI.Planner.StepExecutors;
 /// Evaluates a condition expression against upstream outputs and activates the appropriate edge.
 /// Pure logic — no external service dependencies.
 /// </summary>
-public sealed partial class ConditionalBranchStepExecutor : IPlanStepExecutor
+public sealed class ConditionalBranchStepExecutor : IPlanStepExecutor
 {
 
     private readonly ILogger<ConditionalBranchStepExecutor> _logger;

--- a/src/Content/Infrastructure/Infrastructure.AI/Runs/InMemoryRunDispatchQueue.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Runs/InMemoryRunDispatchQueue.cs
@@ -1,0 +1,34 @@
+using System.Threading.Channels;
+using Application.AI.Common.Interfaces.Runs;
+
+namespace Infrastructure.AI.Runs;
+
+/// <summary>
+/// Process-local <see cref="IRunDispatchQueue"/> over an unbounded channel.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Unbounded is safe here only because admission bounds what can reach it: a caller cannot enqueue
+/// beyond its concurrent-run cap, and each enqueue costs a rate-limited request. The queue is not the
+/// backpressure mechanism and must not become one — if the caps are ever removed, this needs a bound.
+/// </para>
+/// <para>
+/// Single reader, many writers: one dispatcher drains it while any number of request threads enqueue.
+/// </para>
+/// </remarks>
+public sealed class InMemoryRunDispatchQueue : IRunDispatchQueue
+{
+    private readonly Channel<string> _channel = Channel.CreateUnbounded<string>(
+        new UnboundedChannelOptions { SingleReader = true, SingleWriter = false });
+
+    /// <inheritdoc />
+    public ValueTask EnqueueAsync(string jobId, CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(jobId);
+        return _channel.Writer.WriteAsync(jobId, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public IAsyncEnumerable<string> DequeueAllAsync(CancellationToken cancellationToken)
+        => _channel.Reader.ReadAllAsync(cancellationToken);
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Runs/InMemoryRunJobStore.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Runs/InMemoryRunJobStore.cs
@@ -65,7 +65,7 @@ public sealed class InMemoryRunJobStore : IRunJobStore
 
         lock (_admission)
         {
-            var (targetIsRunning, ownerActiveRuns) = SurveyActiveRuns(record.Kind, record.TargetId, record.OwnerId);
+            var (targetIsRunning, ownerActiveRuns) = SurveyActiveRuns(record);
 
             if (targetIsRunning)
                 return RunAdmission.TargetAlreadyRunning;
@@ -86,11 +86,16 @@ public sealed class InMemoryRunJobStore : IRunJobStore
     }
 
     /// <summary>
-    /// Answers both admission questions in one pass: whether <paramref name="targetId"/> already has a
-    /// live run of <paramref name="kind"/>, and how many live runs <paramref name="ownerId"/> holds.
+    /// Answers both admission questions in one pass: whether the target of <paramref name="candidate"/>
+    /// already has a live run, and how many live runs its caller holds.
     /// </summary>
-    private (bool TargetIsRunning, int OwnerActiveRuns) SurveyActiveRuns(
-        RunKind kind, string targetId, string ownerId)
+    /// <remarks>
+    /// The two questions are scoped differently on purpose. A target conflict is about the workflow's
+    /// state, so it ignores who is asking — a second caller with access to the same workflow would
+    /// corrupt the first caller's run just as surely. The capacity count is about the caller, so it is
+    /// scoped to that principal by tenant and owner, the same pair every other read here compares.
+    /// </remarks>
+    private (bool TargetIsRunning, int OwnerActiveRuns) SurveyActiveRuns(RunRecord candidate)
     {
         var targetIsRunning = false;
         var ownerActiveRuns = 0;
@@ -106,18 +111,24 @@ public sealed class InMemoryRunJobStore : IRunJobStore
                 record = entry.Record;
             }
 
-            if (record.Kind == kind && string.Equals(record.TargetId, targetId, StringComparison.Ordinal))
+            if (record.Kind == candidate.Kind
+                && string.Equals(record.TargetId, candidate.TargetId, StringComparison.Ordinal))
+            {
                 targetIsRunning = true;
+            }
 
-            if (ScopeIdentity.AreSame(record.OwnerId, ownerId))
+            if (ScopeIdentity.AreSame(record.OwnerId, candidate.OwnerId)
+                && ScopeIdentity.AreSame(record.TenantId, candidate.TenantId))
+            {
                 ownerActiveRuns++;
+            }
         }
 
         return (targetIsRunning, ownerActiveRuns);
     }
 
     /// <inheritdoc />
-    public RunRecord? Get(string jobId, string ownerId)
+    public RunRecord? Get(string jobId, string ownerId, string? tenantId)
     {
         ArgumentException.ThrowIfNullOrEmpty(jobId);
         ArgumentException.ThrowIfNullOrEmpty(ownerId);
@@ -130,11 +141,18 @@ public sealed class InMemoryRunJobStore : IRunJobStore
             if (IsExpired(entry, _time.GetUtcNow()))
                 return null;
 
-            // Canonicalized, which is how plan ownership is compared (PlannerScopeFilter) and how the
-            // identity on this record was stamped. A stricter comparison here would deny a caller its
-            // own run whenever a token differed only in casing from the one that started it, while
-            // the plan store went on treating the two as the same principal.
-            return ScopeIdentity.AreSame(entry.Record.OwnerId, ownerId) ? entry.Record : null;
+            // Tenant AND owner, canonicalized — the same two legs and the same canonical form that
+            // decide plan ownership (PlannerScopeFilter.WritableBy) on this very request path. Owner
+            // alone is sufficient while an issuer is pinned to one tenant, which is exactly why the
+            // divergence would be invisible until the day it is a cross-tenant read.
+            //
+            // Canonicalized rather than compared strictly: a stricter comparison would deny a caller
+            // its own run whenever a token differed only in casing from the one that started it,
+            // while the plan store went on treating the two as the same principal.
+            return ScopeIdentity.AreSame(entry.Record.OwnerId, ownerId)
+                && ScopeIdentity.AreSame(entry.Record.TenantId, tenantId)
+                    ? entry.Record
+                    : null;
         }
     }
 
@@ -188,14 +206,18 @@ public sealed class InMemoryRunJobStore : IRunJobStore
 
         foreach (var (jobId, entry) in _entries)
         {
-            bool expired;
+            // Decided and removed under the same lock. Only terminal entries expire today and nothing
+            // re-arms a terminal entry, so splitting the two would be harmless right now — but it
+            // would be a live race the moment any non-terminal state becomes reclaimable, and the
+            // thing being raced away is a run a caller may still be polling.
             lock (entry)
             {
-                expired = IsExpired(entry, now);
-            }
+                if (!IsExpired(entry, now))
+                    continue;
 
-            if (expired && _entries.TryRemove(jobId, out _))
-                removed++;
+                if (_entries.TryRemove(jobId, out _))
+                    removed++;
+            }
         }
 
         return removed;

--- a/src/Content/Infrastructure/Infrastructure.AI/Runs/InMemoryRunJobStore.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Runs/InMemoryRunJobStore.cs
@@ -1,0 +1,180 @@
+using System.Collections.Concurrent;
+using Application.AI.Common.Interfaces.Runs;
+using Domain.AI.Runs;
+using Domain.Common.Config;
+using Microsoft.Extensions.Options;
+
+namespace Infrastructure.AI.Runs;
+
+/// <summary>
+/// Process-local <see cref="IRunJobStore"/>. One entry per run, expired on a retention clock.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>Process-local, deliberately, and that is a real limit.</strong> A run is only visible to
+/// the instance that accepted it, so a multi-instance deployment must route a caller's status polls
+/// back to the instance that took the submission, or replace this with a shared store. Recorded here
+/// rather than discovered later: the interface is the seam for that replacement, and nothing above it
+/// assumes in-process storage.
+/// </para>
+/// <para>
+/// <strong>Locking is per entry, not global.</strong> Claiming one run must not serialize status
+/// reads of every other run — polling is the common operation and there will be far more of it than
+/// claiming. The concurrent dictionary handles lookup; the per-entry lock makes each
+/// read-decide-write atomic, which is what <see cref="TryBeginRun"/> needs to arm exactly once.
+/// </para>
+/// </remarks>
+public sealed class InMemoryRunJobStore : IRunJobStore
+{
+    private sealed class Entry(RunRecord record, DateTimeOffset expiresAt)
+    {
+        public RunRecord Record { get; set; } = record;
+        public DateTimeOffset ExpiresAt { get; set; } = expiresAt;
+    }
+
+    private readonly ConcurrentDictionary<string, Entry> _entries = new(StringComparer.Ordinal);
+    private readonly IOptionsMonitor<AppConfig> _config;
+    private readonly TimeProvider _time;
+
+    /// <summary>Initializes the store with the host's retention configuration and clock.</summary>
+    public InMemoryRunJobStore(IOptionsMonitor<AppConfig> config, TimeProvider time)
+    {
+        ArgumentNullException.ThrowIfNull(config);
+        ArgumentNullException.ThrowIfNull(time);
+
+        _config = config;
+        _time = time;
+    }
+
+    private TimeSpan Ttl => _config.CurrentValue.AI.WorkflowSubmission.RunRecordTtl;
+
+    /// <inheritdoc />
+    public void Create(RunRecord record)
+    {
+        ArgumentNullException.ThrowIfNull(record);
+
+        // A queued run is not yet reclaimable, so it is seeded with an expiry far enough out that it
+        // cannot be swept while waiting; the real retention clock starts when it reaches a terminal
+        // state. Seeding it with the TTL directly would let a run that sat in a long queue vanish
+        // before it ever ran.
+        var entry = new Entry(record, _time.GetUtcNow() + Ttl);
+
+        if (!_entries.TryAdd(record.JobId, entry))
+            throw new InvalidOperationException($"A run with job id '{record.JobId}' already exists.");
+    }
+
+    /// <inheritdoc />
+    public RunRecord? Get(string jobId, string ownerId)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(jobId);
+        ArgumentException.ThrowIfNullOrEmpty(ownerId);
+
+        if (!_entries.TryGetValue(jobId, out var entry))
+            return null;
+
+        lock (entry)
+        {
+            if (IsExpired(entry, _time.GetUtcNow()))
+                return null;
+
+            // Ordinal, matching how ownership is compared everywhere else in this solution. A
+            // case-insensitive match here would let two identities that the rest of the system treats
+            // as distinct read each other's runs.
+            return string.Equals(entry.Record.OwnerId, ownerId, StringComparison.Ordinal)
+                ? entry.Record
+                : null;
+        }
+    }
+
+    /// <inheritdoc />
+    public RunRecord? TryBeginRun(string jobId, DateTimeOffset startedAt)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(jobId);
+
+        if (!_entries.TryGetValue(jobId, out var entry))
+            return null;
+
+        lock (entry)
+        {
+            // The whole claim is inside the lock: reading the status, deciding, and writing the new
+            // one. Split across the lock boundary, two dispatchers could both observe Queued and both
+            // proceed — and duplicate execution here is duplicate model and tool spend.
+            if (entry.Record.Status != RunStatus.Queued || IsExpired(entry, _time.GetUtcNow()))
+                return null;
+
+            entry.Record = entry.Record with { Status = RunStatus.Running, StartedAt = startedAt };
+            return entry.Record;
+        }
+    }
+
+    /// <inheritdoc />
+    public bool Update(RunRecord record)
+    {
+        ArgumentNullException.ThrowIfNull(record);
+
+        if (!_entries.TryGetValue(record.JobId, out var entry))
+            return false;
+
+        lock (entry)
+        {
+            entry.Record = record;
+
+            // Retention starts when the run finishes, so a completed run is readable for a full TTL
+            // from completion rather than from whenever it happened to be accepted.
+            if (record.IsTerminal)
+                entry.ExpiresAt = _time.GetUtcNow() + Ttl;
+        }
+
+        return true;
+    }
+
+    /// <inheritdoc />
+    public int CountActiveRuns(string ownerId)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(ownerId);
+
+        var active = 0;
+        foreach (var entry in _entries.Values)
+        {
+            lock (entry)
+            {
+                if (!entry.Record.IsTerminal
+                    && string.Equals(entry.Record.OwnerId, ownerId, StringComparison.Ordinal))
+                {
+                    active++;
+                }
+            }
+        }
+
+        return active;
+    }
+
+    /// <inheritdoc />
+    public int SweepExpired()
+    {
+        var now = _time.GetUtcNow();
+        var removed = 0;
+
+        foreach (var (jobId, entry) in _entries)
+        {
+            bool expired;
+            lock (entry)
+            {
+                expired = IsExpired(entry, now);
+            }
+
+            if (expired && _entries.TryRemove(jobId, out _))
+                removed++;
+        }
+
+        return removed;
+    }
+
+    /// <summary>
+    /// Whether an entry may be reclaimed. Only terminal runs expire — an accepted run that has not
+    /// finished is never swept, however long it has been queued or running, because reclaiming it
+    /// would make a run the caller is still polling silently disappear.
+    /// </summary>
+    private static bool IsExpired(Entry entry, DateTimeOffset now) =>
+        entry.Record.IsTerminal && now >= entry.ExpiresAt;
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Runs/InMemoryRunJobStore.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Runs/InMemoryRunJobStore.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using Application.AI.Common.Interfaces.Runs;
+using Domain.AI.KnowledgeGraph.Scoping;
 using Domain.AI.Runs;
 using Domain.Common.Config;
 using Microsoft.Extensions.Options;
@@ -23,6 +24,14 @@ namespace Infrastructure.AI.Runs;
 /// claiming. The concurrent dictionary handles lookup; the per-entry lock makes each
 /// read-decide-write atomic, which is what <see cref="TryBeginRun"/> needs to arm exactly once.
 /// </para>
+/// <para>
+/// <strong>Admission is the one exception, and takes a store-wide lock.</strong> Deciding it means
+/// reading across entries — is this target already running, is this owner at capacity — so no
+/// per-entry lock can make it atomic. It is serialized deliberately: starting a run is rare next to
+/// polling one, and each admission is followed by an LLM workflow, so a scan of the entries costs
+/// nothing measurable against what it gates. Held while the per-entry locks are taken, never the
+/// reverse, so the two cannot deadlock.
+/// </para>
 /// </remarks>
 public sealed class InMemoryRunJobStore : IRunJobStore
 {
@@ -33,6 +42,7 @@ public sealed class InMemoryRunJobStore : IRunJobStore
     }
 
     private readonly ConcurrentDictionary<string, Entry> _entries = new(StringComparer.Ordinal);
+    private readonly Lock _admission = new();
     private readonly IOptionsMonitor<AppConfig> _config;
     private readonly TimeProvider _time;
 
@@ -49,18 +59,61 @@ public sealed class InMemoryRunJobStore : IRunJobStore
     private TimeSpan Ttl => _config.CurrentValue.AI.WorkflowSubmission.RunRecordTtl;
 
     /// <inheritdoc />
-    public void Create(RunRecord record)
+    public RunAdmission TryCreate(RunRecord record, int maxActiveRunsPerOwner)
     {
         ArgumentNullException.ThrowIfNull(record);
 
-        // A queued run is not yet reclaimable, so it is seeded with an expiry far enough out that it
-        // cannot be swept while waiting; the real retention clock starts when it reaches a terminal
-        // state. Seeding it with the TTL directly would let a run that sat in a long queue vanish
-        // before it ever ran.
-        var entry = new Entry(record, _time.GetUtcNow() + Ttl);
+        lock (_admission)
+        {
+            var (targetIsRunning, ownerActiveRuns) = SurveyActiveRuns(record.Kind, record.TargetId, record.OwnerId);
 
-        if (!_entries.TryAdd(record.JobId, entry))
-            throw new InvalidOperationException($"A run with job id '{record.JobId}' already exists.");
+            if (targetIsRunning)
+                return RunAdmission.TargetAlreadyRunning;
+
+            if (ownerActiveRuns >= maxActiveRunsPerOwner)
+                return RunAdmission.OwnerAtCapacity;
+
+            // The expiry seeded here is a placeholder that never elapses in practice: IsExpired only
+            // reclaims terminal runs, and Update restamps the expiry the moment a run becomes one. It
+            // exists so an entry always carries a value, not because a queued run is on a clock.
+            var entry = new Entry(record, _time.GetUtcNow() + Ttl);
+
+            if (!_entries.TryAdd(record.JobId, entry))
+                throw new InvalidOperationException($"A run with job id '{record.JobId}' already exists.");
+
+            return RunAdmission.Accepted;
+        }
+    }
+
+    /// <summary>
+    /// Answers both admission questions in one pass: whether <paramref name="targetId"/> already has a
+    /// live run of <paramref name="kind"/>, and how many live runs <paramref name="ownerId"/> holds.
+    /// </summary>
+    private (bool TargetIsRunning, int OwnerActiveRuns) SurveyActiveRuns(
+        RunKind kind, string targetId, string ownerId)
+    {
+        var targetIsRunning = false;
+        var ownerActiveRuns = 0;
+
+        foreach (var entry in _entries.Values)
+        {
+            RunRecord record;
+            lock (entry)
+            {
+                if (entry.Record.IsTerminal)
+                    continue;
+
+                record = entry.Record;
+            }
+
+            if (record.Kind == kind && string.Equals(record.TargetId, targetId, StringComparison.Ordinal))
+                targetIsRunning = true;
+
+            if (ScopeIdentity.AreSame(record.OwnerId, ownerId))
+                ownerActiveRuns++;
+        }
+
+        return (targetIsRunning, ownerActiveRuns);
     }
 
     /// <inheritdoc />
@@ -77,12 +130,11 @@ public sealed class InMemoryRunJobStore : IRunJobStore
             if (IsExpired(entry, _time.GetUtcNow()))
                 return null;
 
-            // Ordinal, matching how ownership is compared everywhere else in this solution. A
-            // case-insensitive match here would let two identities that the rest of the system treats
-            // as distinct read each other's runs.
-            return string.Equals(entry.Record.OwnerId, ownerId, StringComparison.Ordinal)
-                ? entry.Record
-                : null;
+            // Canonicalized, which is how plan ownership is compared (PlannerScopeFilter) and how the
+            // identity on this record was stamped. A stricter comparison here would deny a caller its
+            // own run whenever a token differed only in casing from the one that started it, while
+            // the plan store went on treating the two as the same principal.
+            return ScopeIdentity.AreSame(entry.Record.OwnerId, ownerId) ? entry.Record : null;
         }
     }
 
@@ -126,27 +178,6 @@ public sealed class InMemoryRunJobStore : IRunJobStore
         }
 
         return true;
-    }
-
-    /// <inheritdoc />
-    public int CountActiveRuns(string ownerId)
-    {
-        ArgumentException.ThrowIfNullOrEmpty(ownerId);
-
-        var active = 0;
-        foreach (var entry in _entries.Values)
-        {
-            lock (entry)
-            {
-                if (!entry.Record.IsTerminal
-                    && string.Equals(entry.Record.OwnerId, ownerId, StringComparison.Ordinal))
-                {
-                    active++;
-                }
-            }
-        }
-
-        return active;
     }
 
     /// <inheritdoc />

--- a/src/Content/Infrastructure/Infrastructure.AI/Runs/RunDispatchBackgroundService.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Runs/RunDispatchBackgroundService.cs
@@ -1,9 +1,12 @@
+using System.Collections.Concurrent;
 using Application.AI.Common.Interfaces.KnowledgeGraph;
 using Application.AI.Common.Interfaces.Runs;
 using Domain.AI.Runs;
+using Domain.Common.Config;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace Infrastructure.AI.Runs;
 
@@ -43,6 +46,7 @@ public sealed class RunDispatchBackgroundService : BackgroundService
     private readonly IRunDispatchQueue _queue;
     private readonly IRunJobStore _store;
     private readonly IServiceScopeFactory _scopeFactory;
+    private readonly IOptionsMonitor<AppConfig> _config;
     private readonly TimeProvider _time;
     private readonly ILogger<RunDispatchBackgroundService> _logger;
 
@@ -51,18 +55,21 @@ public sealed class RunDispatchBackgroundService : BackgroundService
         IRunDispatchQueue queue,
         IRunJobStore store,
         IServiceScopeFactory scopeFactory,
+        IOptionsMonitor<AppConfig> config,
         TimeProvider time,
         ILogger<RunDispatchBackgroundService> logger)
     {
         ArgumentNullException.ThrowIfNull(queue);
         ArgumentNullException.ThrowIfNull(store);
         ArgumentNullException.ThrowIfNull(scopeFactory);
+        ArgumentNullException.ThrowIfNull(config);
         ArgumentNullException.ThrowIfNull(time);
         ArgumentNullException.ThrowIfNull(logger);
 
         _queue = queue;
         _store = store;
         _scopeFactory = scopeFactory;
+        _config = config;
         _time = time;
         _logger = logger;
     }
@@ -70,26 +77,73 @@ public sealed class RunDispatchBackgroundService : BackgroundService
     /// <inheritdoc />
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        await foreach (var jobId in _queue.DequeueAllAsync(stoppingToken).ConfigureAwait(false))
-        {
-            if (stoppingToken.IsCancellationRequested)
-                break;
+        // Bounded parallelism rather than one-at-a-time. Awaiting each run to completion before
+        // dequeuing the next makes host-wide throughput exactly one, so any caller's long workflow
+        // delays every other caller's — and it makes the per-owner cap read as a concurrency
+        // allowance the host never honours.
+        //
+        // Safe to run runs side by side because nothing here is what keeps them apart: TryBeginRun
+        // arms each run exactly once, and admission permits only one live run per workflow, so two
+        // dispatched runs can never be the same work nor share one plan's execution state.
+        //
+        // The degree is read once, at start. A host that changes it takes effect on restart, which is
+        // the honest bound — reshaping a running drain loop mid-flight buys nothing and would make
+        // the number of in-flight runs unpredictable.
+        var degree = Math.Max(1, _config.CurrentValue.AI.WorkflowSubmission.MaxConcurrentDispatchedRuns);
+        using var slots = new SemaphoreSlim(degree, degree);
+        var inFlight = new ConcurrentDictionary<Task, byte>();
 
-            try
+        try
+        {
+            await foreach (var jobId in _queue.DequeueAllAsync(stoppingToken).ConfigureAwait(false))
             {
-                await DispatchAsync(jobId, stoppingToken).ConfigureAwait(false);
+                if (stoppingToken.IsCancellationRequested)
+                    break;
+
+                await slots.WaitAsync(stoppingToken).ConfigureAwait(false);
+
+                var task = DispatchGuardedAsync(jobId, slots, stoppingToken);
+                inFlight[task] = 0;
+                _ = task.ContinueWith(
+                    completed => inFlight.TryRemove(completed, out _),
+                    CancellationToken.None,
+                    TaskContinuationOptions.ExecuteSynchronously,
+                    TaskScheduler.Default);
             }
-            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
-            {
-                break;
-            }
-            catch (Exception ex)
-            {
-                // Reached only when the claim itself failed, so no run was moved to Running and none
-                // is left stranded. A failure after the claim is handled inside DispatchAsync, which
-                // holds the claimed record and can mark it terminal.
-                _logger.LogError(ex, "Run {JobId} could not be dispatched.", jobId);
-            }
+        }
+        catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+        {
+            // Host shutdown while waiting for a slot or for the next job.
+        }
+
+        // Runs already dispatched are awaited rather than abandoned. Each one holds a claimed record
+        // that only its own dispatch can move out of Running, so walking away here would leave those
+        // runs stranded for whatever remains of the process.
+        await Task.WhenAll(inFlight.Keys).ConfigureAwait(false);
+    }
+
+    /// <summary>Dispatches one run and always releases its slot, whatever happens.</summary>
+    private async Task DispatchGuardedAsync(string jobId, SemaphoreSlim slots, CancellationToken stoppingToken)
+    {
+        try
+        {
+            await DispatchAsync(jobId, stoppingToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+        {
+            // Host shutdown. DispatchAsync has already recorded the run as cancelled if it had claimed
+            // one, so there is nothing left to record here.
+        }
+        catch (Exception ex)
+        {
+            // Reached only when the claim itself failed, so no run was moved to Running and none is
+            // left stranded. A failure after the claim is handled inside DispatchAsync, which holds
+            // the claimed record and can mark it terminal.
+            _logger.LogError(ex, "Run {JobId} could not be dispatched.", jobId);
+        }
+        finally
+        {
+            slots.Release();
         }
     }
 

--- a/src/Content/Infrastructure/Infrastructure.AI/Runs/RunDispatchBackgroundService.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Runs/RunDispatchBackgroundService.cs
@@ -1,3 +1,4 @@
+using Application.AI.Common.Interfaces.KnowledgeGraph;
 using Application.AI.Common.Interfaces.Runs;
 using Domain.AI.Runs;
 using Microsoft.Extensions.DependencyInjection;
@@ -22,6 +23,19 @@ namespace Infrastructure.AI.Runs;
 /// <strong>An unregistered kind fails the run rather than the dispatcher.</strong> A missing executor
 /// is a wiring gap, and taking the whole loop down for it would stop every other kind of work in the
 /// host — turning one mis-registration into a total outage.
+/// </para>
+/// <para>
+/// <strong>The caller's knowledge scope is re-established per job, here rather than in each
+/// executor.</strong> Scope is ambient (<c>AsyncLocal</c>) and set at an HTTP entry point; it does not
+/// survive the hop onto this thread. Every run carries the owner and tenant that authorized it for
+/// exactly this reason, and re-arming them is a property of dispatching any run, not of any one kind
+/// — leaving it to executors means the next kind added inherits the bug. The token is disposed per
+/// job, so one caller's identity can never stay ambient for the next.
+/// </para>
+/// <para>
+/// A run whose scope cannot be established is <em>failed</em>, never executed. Running unscoped is not
+/// a degraded mode: an absent owner reads as a global record, so the work would silently see and
+/// touch every caller's data.
 /// </para>
 /// </remarks>
 public sealed class RunDispatchBackgroundService : BackgroundService
@@ -114,6 +128,7 @@ public sealed class RunDispatchBackgroundService : BackgroundService
     private async Task ExecuteClaimedAsync(RunRecord claimed, CancellationToken stoppingToken)
     {
         await using var scope = _scopeFactory.CreateAsyncScope();
+
         var executor = scope.ServiceProvider.GetKeyedService<IRunKindExecutor>(claimed.Kind);
         if (executor is null)
         {
@@ -125,20 +140,45 @@ public sealed class RunDispatchBackgroundService : BackgroundService
             return;
         }
 
-        var outcome = await executor.ExecuteAsync(claimed, stoppingToken).ConfigureAwait(false);
-
-        if (outcome.IsSuccess)
+        // Required, not optional. A host that has not registered the scope writer cannot tell this
+        // work who it is acting as, and the work would run as nobody — which reads as everybody.
+        var scopeWriter = scope.ServiceProvider.GetService<IKnowledgeScopeWriter>();
+        if (scopeWriter is null)
         {
-            Finish(claimed, RunStatus.Succeeded, error: null);
-            _logger.LogInformation("Run {JobId} ({RunKind}) succeeded.", claimed.JobId, claimed.Kind);
+            _logger.LogError(
+                "Run {JobId} cannot execute: this host registers no {Writer}, so the run's identity "
+                + "cannot be established and it must not run unscoped.",
+                claimed.JobId, nameof(IKnowledgeScopeWriter));
+
+            Finish(claimed, RunStatus.Failed, "This host cannot establish the run's identity.");
             return;
         }
 
-        // The executor's messages are caller-safe by contract, so they pass through rather than being
-        // flattened into "it failed" — a caller learns why its own run did not work.
-        var error = string.Join("; ", outcome.Errors);
-        Finish(claimed, RunStatus.Failed, error);
-        _logger.LogWarning("Run {JobId} ({RunKind}) failed: {Error}", claimed.JobId, claimed.Kind, error);
+        // Disposed before the next job is claimed, restoring whatever was ambient before. Without the
+        // restore, job N's owner stays ambient for job N+1 and the second run executes as the first
+        // caller.
+        using var identity = scopeWriter.SetScope(claimed.OwnerId, claimed.TenantId);
+
+        var outcome = await executor.ExecuteAsync(claimed, stoppingToken).ConfigureAwait(false);
+
+        if (!outcome.IsSuccess || outcome.Value is null)
+        {
+            // The executor could not run the work. Its messages are caller-safe by contract, so they
+            // pass through rather than being flattened into "it failed" — a caller learns why its own
+            // run did not work.
+            var error = outcome.Errors.Count > 0
+                ? string.Join("; ", outcome.Errors)
+                : "The run reported no outcome.";
+
+            Finish(claimed, RunStatus.Failed, error);
+            _logger.LogWarning("Run {JobId} ({RunKind}) failed: {Error}", claimed.JobId, claimed.Kind, error);
+            return;
+        }
+
+        var completion = outcome.Value;
+        Finish(claimed, completion.Status, completion.Detail);
+        _logger.LogInformation(
+            "Run {JobId} ({RunKind}) ended {RunStatus}.", claimed.JobId, claimed.Kind, completion.Status);
     }
 
     /// <summary>

--- a/src/Content/Infrastructure/Infrastructure.AI/Runs/RunDispatchBackgroundService.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Runs/RunDispatchBackgroundService.cs
@@ -1,4 +1,3 @@
-using System.Collections.Concurrent;
 using Application.AI.Common.Interfaces.KnowledgeGraph;
 using Application.AI.Common.Interfaces.Runs;
 using Domain.AI.Runs;
@@ -42,7 +41,7 @@ namespace Infrastructure.AI.Runs;
 /// </para>
 /// <para>
 /// <strong>Two things here rest on both seams being in-process, and stop being true when either is
-/// replaced.</strong> A job taken off the queue is lost if the host stops before a slot frees, leaving
+/// replaced.</strong> A job taken off the queue is lost if the host stops before its body runs, leaving
 /// its record <c>Queued</c> — harmless only because an in-memory store dies with the process, and
 /// because a durable queue would redeliver an unacknowledged message. Pair a durable store with a
 /// non-redelivering queue and that record is stranded: never claimed, never terminal, never reclaimed,
@@ -101,40 +100,31 @@ public sealed class RunDispatchBackgroundService : BackgroundService
         // the honest bound — reshaping a running drain loop mid-flight buys nothing and would make
         // the number of in-flight runs unpredictable.
         var degree = Math.Max(1, _config.CurrentValue.AI.WorkflowSubmission.MaxConcurrentDispatchedRuns);
-        using var slots = new SemaphoreSlim(degree, degree);
-        var inFlight = new ConcurrentDictionary<Task, byte>();
 
         try
         {
-            await foreach (var jobId in _queue.DequeueAllAsync(stoppingToken).ConfigureAwait(false))
-            {
-                if (stoppingToken.IsCancellationRequested)
-                    break;
-
-                await slots.WaitAsync(stoppingToken).ConfigureAwait(false);
-
-                var task = DispatchGuardedAsync(jobId, slots, stoppingToken);
-                inFlight[task] = 0;
-                _ = task.ContinueWith(
-                    completed => inFlight.TryRemove(completed, out _),
-                    CancellationToken.None,
-                    TaskContinuationOptions.ExecuteSynchronously,
-                    TaskScheduler.Default);
-            }
+            // Parallel.ForEachAsync already is this loop: it bounds concurrency, keeps pulling as slots
+            // free, and does not return until every started item has finished — that last part being
+            // the one that matters at shutdown, since each in-flight run holds a claimed record only
+            // its own dispatch can move out of Running.
+            //
+            // Its one sharp edge is that a body which throws tears down the whole loop.
+            // DispatchGuardedAsync is written never to, so this ends only when the queue completes or
+            // the host stops.
+            await Parallel.ForEachAsync(
+                _queue.DequeueAllAsync(stoppingToken),
+                new ParallelOptions { MaxDegreeOfParallelism = degree, CancellationToken = stoppingToken },
+                async (jobId, token) => await DispatchGuardedAsync(jobId, token).ConfigureAwait(false))
+                .ConfigureAwait(false);
         }
         catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
         {
-            // Host shutdown while waiting for a slot or for the next job.
+            // Host shutdown.
         }
-
-        // Runs already dispatched are awaited rather than abandoned. Each one holds a claimed record
-        // that only its own dispatch can move out of Running, so walking away here would leave those
-        // runs stranded for whatever remains of the process.
-        await Task.WhenAll(inFlight.Keys).ConfigureAwait(false);
     }
 
-    /// <summary>Dispatches one run and always releases its slot, whatever happens.</summary>
-    private async Task DispatchGuardedAsync(string jobId, SemaphoreSlim slots, CancellationToken stoppingToken)
+    /// <summary>Dispatches one run, never letting a failure escape into the drain loop.</summary>
+    private async Task DispatchGuardedAsync(string jobId, CancellationToken stoppingToken)
     {
         try
         {
@@ -151,10 +141,6 @@ public sealed class RunDispatchBackgroundService : BackgroundService
             // left stranded. A failure after the claim is handled inside DispatchAsync, which holds
             // the claimed record and can mark it terminal.
             _logger.LogError(ex, "Run {JobId} could not be dispatched.", jobId);
-        }
-        finally
-        {
-            slots.Release();
         }
     }
 

--- a/src/Content/Infrastructure/Infrastructure.AI/Runs/RunDispatchBackgroundService.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Runs/RunDispatchBackgroundService.cs
@@ -1,0 +1,156 @@
+using Application.AI.Common.Interfaces.Runs;
+using Domain.AI.Runs;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Infrastructure.AI.Runs;
+
+/// <summary>
+/// Drains the run queue, claims each run exactly once, resolves the executor for its kind, and records
+/// how it ended.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>The dispatcher owns the outcome, not the executors.</strong> Each
+/// <see cref="IRunKindExecutor"/> reports success or failure and this records it. Leaving executors to
+/// write their own terminal state would mean every kind reimplemented the same thing, and the one
+/// that threw before writing would leave a run stuck at <see cref="RunStatus.Running"/> forever, with
+/// a caller polling it indefinitely.
+/// </para>
+/// <para>
+/// <strong>An unregistered kind fails the run rather than the dispatcher.</strong> A missing executor
+/// is a wiring gap, and taking the whole loop down for it would stop every other kind of work in the
+/// host — turning one mis-registration into a total outage.
+/// </para>
+/// </remarks>
+public sealed class RunDispatchBackgroundService : BackgroundService
+{
+    private readonly IRunDispatchQueue _queue;
+    private readonly IRunJobStore _store;
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly TimeProvider _time;
+    private readonly ILogger<RunDispatchBackgroundService> _logger;
+
+    /// <summary>Initializes the dispatcher.</summary>
+    public RunDispatchBackgroundService(
+        IRunDispatchQueue queue,
+        IRunJobStore store,
+        IServiceScopeFactory scopeFactory,
+        TimeProvider time,
+        ILogger<RunDispatchBackgroundService> logger)
+    {
+        ArgumentNullException.ThrowIfNull(queue);
+        ArgumentNullException.ThrowIfNull(store);
+        ArgumentNullException.ThrowIfNull(scopeFactory);
+        ArgumentNullException.ThrowIfNull(time);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _queue = queue;
+        _store = store;
+        _scopeFactory = scopeFactory;
+        _time = time;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        await foreach (var jobId in _queue.DequeueAllAsync(stoppingToken).ConfigureAwait(false))
+        {
+            if (stoppingToken.IsCancellationRequested)
+                break;
+
+            try
+            {
+                await DispatchAsync(jobId, stoppingToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                // Reached only when the claim itself failed, so no run was moved to Running and none
+                // is left stranded. A failure after the claim is handled inside DispatchAsync, which
+                // holds the claimed record and can mark it terminal.
+                _logger.LogError(ex, "Run {JobId} could not be dispatched.", jobId);
+            }
+        }
+    }
+
+    private async Task DispatchAsync(string jobId, CancellationToken stoppingToken)
+    {
+        var claimed = _store.TryBeginRun(jobId, _time.GetUtcNow());
+        if (claimed is null)
+        {
+            // Already claimed, already finished, or swept. All three mean there is nothing to do, and
+            // none of them is an error: the claim is exactly what makes redelivery harmless.
+            _logger.LogDebug("Run {JobId} was not claimable; skipping.", jobId);
+            return;
+        }
+
+        // Everything past the claim is guarded, because the run is now Running and only this method
+        // can move it out of that state. An escape here would leave it Running forever, with a caller
+        // polling a run nothing will ever finish.
+        try
+        {
+            await ExecuteClaimedAsync(claimed, stoppingToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+        {
+            // Host shutdown, not a fault of the run. Recorded as cancelled so an operator can tell it
+            // apart from work that broke, and so it is terminal rather than stranded at Running.
+            Finish(claimed, RunStatus.Cancelled, "The host shut down before the run completed.");
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Run {JobId} ({RunKind}) threw.", claimed.JobId, claimed.Kind);
+            Finish(claimed, RunStatus.Failed, "The run failed unexpectedly.");
+        }
+    }
+
+    private async Task ExecuteClaimedAsync(RunRecord claimed, CancellationToken stoppingToken)
+    {
+        await using var scope = _scopeFactory.CreateAsyncScope();
+        var executor = scope.ServiceProvider.GetKeyedService<IRunKindExecutor>(claimed.Kind);
+        if (executor is null)
+        {
+            _logger.LogError(
+                "Run {JobId} declares kind {RunKind}, which has no registered executor.",
+                claimed.JobId, claimed.Kind);
+
+            Finish(claimed, RunStatus.Failed, "This host cannot execute that kind of run.");
+            return;
+        }
+
+        var outcome = await executor.ExecuteAsync(claimed, stoppingToken).ConfigureAwait(false);
+
+        if (outcome.IsSuccess)
+        {
+            Finish(claimed, RunStatus.Succeeded, error: null);
+            _logger.LogInformation("Run {JobId} ({RunKind}) succeeded.", claimed.JobId, claimed.Kind);
+            return;
+        }
+
+        // The executor's messages are caller-safe by contract, so they pass through rather than being
+        // flattened into "it failed" — a caller learns why its own run did not work.
+        var error = string.Join("; ", outcome.Errors);
+        Finish(claimed, RunStatus.Failed, error);
+        _logger.LogWarning("Run {JobId} ({RunKind}) failed: {Error}", claimed.JobId, claimed.Kind, error);
+    }
+
+    /// <summary>
+    /// Writes a claimed run's terminal state. Takes the claimed record rather than re-reading it: the
+    /// run is Running by this point, so it can no longer be re-claimed, and the dispatcher holds no
+    /// caller identity to read it back with.
+    /// </summary>
+    private void Finish(RunRecord claimed, RunStatus status, string? error) =>
+        _store.Update(claimed with
+        {
+            Status = status,
+            Error = error,
+            CompletedAt = _time.GetUtcNow()
+        });
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Runs/RunDispatchBackgroundService.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Runs/RunDispatchBackgroundService.cs
@@ -40,6 +40,17 @@ namespace Infrastructure.AI.Runs;
 /// a degraded mode: an absent owner reads as a global record, so the work would silently see and
 /// touch every caller's data.
 /// </para>
+/// <para>
+/// <strong>Two things here rest on both seams being in-process, and stop being true when either is
+/// replaced.</strong> A job taken off the queue is lost if the host stops before a slot frees, leaving
+/// its record <c>Queued</c> — harmless only because an in-memory store dies with the process, and
+/// because a durable queue would redeliver an unacknowledged message. Pair a durable store with a
+/// non-redelivering queue and that record is stranded: never claimed, never terminal, never reclaimed,
+/// pinning its workflow and holding one of its owner's slots. Likewise a run that ends by throwing
+/// <see cref="OperationCanceledException"/> for any reason other than host shutdown is recorded
+/// Failed rather than Cancelled, losing a distinction <see cref="RunStatus"/> exists to make; today
+/// no executor does that, because <c>IPlanRunExecutor</c> reports cancellation as a result.
+/// </para>
 /// </remarks>
 public sealed class RunDispatchBackgroundService : BackgroundService
 {

--- a/src/Content/Infrastructure/Infrastructure.AI/Runs/RunRecordCleanupService.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Runs/RunRecordCleanupService.cs
@@ -1,0 +1,88 @@
+using Application.AI.Common.Interfaces.Runs;
+using Domain.Common.Config;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Infrastructure.AI.Runs;
+
+/// <summary>
+/// Reclaims run records whose retention window has elapsed.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Without this the configured retention is a claim the host never honours: every finished run stays
+/// held for the life of the process, each one carrying the capability envelope it executed under, so
+/// sustained authenticated use grows memory without bound. Mirrors
+/// <c>BundleWorkspaceCleanupService</c>, which does the same job for the bundle path.
+/// </para>
+/// <para>
+/// Only terminal runs are ever reclaimed — that rule lives in the store, not here, so no scheduling
+/// change can make a run a caller is still polling disappear.
+/// </para>
+/// </remarks>
+internal sealed class RunRecordCleanupService : BackgroundService
+{
+    /// <summary>
+    /// Floor on the sweep interval. Configuration is validated as positive, but a value of, say, a
+    /// microsecond is positive and would turn this into a spin loop; the floor makes a mis-set value
+    /// slow rather than harmful.
+    /// </summary>
+    private static readonly TimeSpan MinInterval = TimeSpan.FromSeconds(1);
+
+    private readonly IRunJobStore _store;
+    private readonly IOptionsMonitor<AppConfig> _config;
+    private readonly ILogger<RunRecordCleanupService> _logger;
+
+    /// <summary>Initializes a new <see cref="RunRecordCleanupService"/>.</summary>
+    public RunRecordCleanupService(
+        IRunJobStore store,
+        IOptionsMonitor<AppConfig> config,
+        ILogger<RunRecordCleanupService> logger)
+    {
+        ArgumentNullException.ThrowIfNull(store);
+        ArgumentNullException.ThrowIfNull(config);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _store = store;
+        _config = config;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        try
+        {
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                var interval = _config.CurrentValue.AI.WorkflowSubmission.RunSweepInterval;
+                if (interval < MinInterval)
+                    interval = MinInterval;
+
+                await Task.Delay(interval, stoppingToken).ConfigureAwait(false);
+                Sweep();
+            }
+        }
+        catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+        {
+            // Host is shutting down — expected.
+        }
+    }
+
+    private void Sweep()
+    {
+        try
+        {
+            var reclaimed = _store.SweepExpired();
+            if (reclaimed > 0)
+                _logger.LogInformation("Run sweep reclaimed {Count} expired run record(s).", reclaimed);
+        }
+        catch (Exception ex)
+        {
+            // A failed sweep must not take the service down: the next tick would never come, and the
+            // retention window would stop being honoured for the life of the process.
+            _logger.LogError(ex, "Run record sweep failed; will retry on the next interval.");
+        }
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Runs/WorkflowRunKindExecutor.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Runs/WorkflowRunKindExecutor.cs
@@ -34,7 +34,7 @@ public sealed class WorkflowRunKindExecutor : IRunKindExecutor
     }
 
     /// <inheritdoc />
-    public async Task<Result> ExecuteAsync(RunRecord record, CancellationToken cancellationToken)
+    public async Task<Result<RunCompletion>> ExecuteAsync(RunRecord record, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(record);
 
@@ -44,7 +44,7 @@ public sealed class WorkflowRunKindExecutor : IRunKindExecutor
             // is still answered rather than thrown, because a malformed target must fail this one run
             // instead of surfacing as an unexpected dispatcher exception.
             _logger.LogError("Run {JobId} names a target that is not a workflow id.", record.JobId);
-            return Result.Fail("The run names a workflow that cannot be resolved.");
+            return Result<RunCompletion>.Fail("The run names a workflow that cannot be resolved.");
         }
 
         var outcome = await _planRunExecutor.ExecuteAsync(
@@ -66,17 +66,35 @@ public sealed class WorkflowRunKindExecutor : IRunKindExecutor
             cancellationToken).ConfigureAwait(false);
 
         if (!outcome.IsSuccess)
-            return Result.Fail([.. outcome.Errors]);
+            return Result<RunCompletion>.Fail([.. outcome.Errors]);
 
         var summary = outcome.Value;
         if (summary is null)
-            return Result.Fail("The run produced no execution summary.");
+            return Result<RunCompletion>.Fail("The run produced no execution summary.");
 
-        // A plan that ran to completion but ended in a failed state is a failed run. Reporting it as
-        // success because the executor returned Success would tell a caller polling for an outcome
-        // that work succeeded when its steps did not.
-        return summary.FinalStatus == StepExecutionStatus.Failed
-            ? Result.Fail($"The workflow completed with status {summary.FinalStatus}.")
-            : Result.Success();
+        return Result<RunCompletion>.Success(Interpret(summary.FinalStatus));
     }
+
+    /// <summary>
+    /// Translates the plan's final status into how the run ended.
+    /// </summary>
+    /// <remarks>
+    /// Written as "succeed only on <see cref="StepExecutionStatus.Completed"/>", matching
+    /// <c>SubPlanStepExecutor</c>, rather than "fail only on <see cref="StepExecutionStatus.Failed"/>".
+    /// The two read the same until you notice that a plan can also end Blocked or Cancelled — under
+    /// the inverted form both fall through to success, and a workflow parked awaiting an approval
+    /// reports to its caller as finished work.
+    /// </remarks>
+    private static RunCompletion Interpret(StepExecutionStatus finalStatus) => finalStatus switch
+    {
+        StepExecutionStatus.Completed => RunCompletion.Succeeded(),
+
+        StepExecutionStatus.Blocked => RunCompletion.Blocked(
+            "The workflow is waiting on an approval before it can continue."),
+
+        StepExecutionStatus.Cancelled => RunCompletion.Cancelled(
+            "The workflow was cancelled before it finished."),
+
+        _ => RunCompletion.Failed($"The workflow ended with status {finalStatus}.")
+    };
 }

--- a/src/Content/Infrastructure/Infrastructure.AI/Runs/WorkflowRunKindExecutor.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Runs/WorkflowRunKindExecutor.cs
@@ -1,0 +1,82 @@
+using Application.AI.Common.Interfaces.Planner;
+using Application.AI.Common.Interfaces.Runs;
+using Domain.AI.Planner;
+using Domain.AI.Runs;
+using Domain.Common;
+using Microsoft.Extensions.Logging;
+
+namespace Infrastructure.AI.Runs;
+
+/// <summary>
+/// Runs a stored workflow for the shared run substrate, delegating to <see cref="IPlanRunExecutor"/>.
+/// </summary>
+/// <remarks>
+/// Deliberately thin. Every hard part of running a plan safely — the fresh service scope, arming the
+/// caller's capability envelope and governance identity inside it, the conversation budget, and
+/// returning stable scrubbed error codes rather than exception text — already lives in
+/// <see cref="IPlanRunExecutor"/>. This translates one shape into another and nothing else, which is
+/// what "a new run kind is a registration" is supposed to mean.
+/// </remarks>
+public sealed class WorkflowRunKindExecutor : IRunKindExecutor
+{
+    private readonly IPlanRunExecutor _planRunExecutor;
+    private readonly ILogger<WorkflowRunKindExecutor> _logger;
+
+    /// <summary>Initializes the executor.</summary>
+    public WorkflowRunKindExecutor(
+        IPlanRunExecutor planRunExecutor, ILogger<WorkflowRunKindExecutor> logger)
+    {
+        ArgumentNullException.ThrowIfNull(planRunExecutor);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _planRunExecutor = planRunExecutor;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<Result> ExecuteAsync(RunRecord record, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(record);
+
+        if (!Guid.TryParse(record.TargetId, out var workflowId))
+        {
+            // Unreachable through the HTTP surface, which parses the id before accepting the run. It
+            // is still answered rather than thrown, because a malformed target must fail this one run
+            // instead of surfacing as an unexpected dispatcher exception.
+            _logger.LogError("Run {JobId} names a target that is not a workflow id.", record.JobId);
+            return Result.Fail("The run names a workflow that cannot be resolved.");
+        }
+
+        var outcome = await _planRunExecutor.ExecuteAsync(
+            new PlanRunRequest
+            {
+                PlanId = new PlanId(workflowId),
+                Envelope = record.Envelope,
+
+                // The workflow itself is the audit subject, not the caller. The caller is already
+                // recorded on the run and is what the envelope was resolved from, and an owner id
+                // comes from token text that need not satisfy the identifier charset this field
+                // requires — deriving from the server-minted workflow id always does.
+                AgentId = $"workflow:{workflowId}",
+
+                // Null lets the run scope derive from the plan id, which is what bounds the run-level
+                // conversation budget.
+                ConversationId = null
+            },
+            cancellationToken).ConfigureAwait(false);
+
+        if (!outcome.IsSuccess)
+            return Result.Fail([.. outcome.Errors]);
+
+        var summary = outcome.Value;
+        if (summary is null)
+            return Result.Fail("The run produced no execution summary.");
+
+        // A plan that ran to completion but ended in a failed state is a failed run. Reporting it as
+        // success because the executor returned Success would tell a caller polling for an outcome
+        // that work succeeded when its steps did not.
+        return summary.FinalStatus == StepExecutionStatus.Failed
+            ? Result.Fail($"The workflow completed with status {summary.FinalStatus}.")
+            : Result.Success();
+    }
+}

--- a/src/Content/Presentation/Presentation.ExecutionApi/Controllers/WorkflowsController.cs
+++ b/src/Content/Presentation/Presentation.ExecutionApi/Controllers/WorkflowsController.cs
@@ -21,10 +21,12 @@ namespace Presentation.ExecutionApi.Controllers;
 /// </summary>
 /// <remarks>
 /// <para>
-/// <strong>Submission and execution are deliberately separate rights.</strong> This endpoint stores a
-/// workflow and nothing more. A caller who can author one therefore does not automatically hold the
-/// right to spend the host's model and tool credentials running it, and the two can be authorized
-/// independently.
+/// <strong>Submission and execution are deliberately separable.</strong> Submitting stores a workflow
+/// and nothing more; running one spends the host's model and tool credentials. They are distinct
+/// endpoints so a consumer <em>can</em> attach a different policy to each — as shipped both carry the
+/// same class-level authorization, so the separation is structural rather than enforced. It still
+/// holds that authoring confers nothing: a caller can only run workflows it owns, under its own
+/// envelope.
 /// </para>
 /// <para>
 /// <strong>Ownership is never taken from the request.</strong> There is no owner field on the wire and
@@ -156,7 +158,8 @@ public sealed class WorkflowsController : ControllerBase
             {
                 WorkflowId = workflowId,
                 JobId = jobId,
-                OwnerId = User.GetUserId()
+                OwnerId = User.GetUserId(),
+                TenantId = User.GetTenantId()
             },
             cancellationToken).ConfigureAwait(false);
 

--- a/src/Content/Presentation/Presentation.ExecutionApi/Controllers/WorkflowsController.cs
+++ b/src/Content/Presentation/Presentation.ExecutionApi/Controllers/WorkflowsController.cs
@@ -1,5 +1,9 @@
+using Application.AI.Common.CQRS.Workflows.GetRun;
+using Application.AI.Common.CQRS.Workflows.StartRun;
 using Application.AI.Common.CQRS.Workflows.Submit;
+using Application.AI.Common.Interfaces.Governance;
 using Domain.Common;
+using Presentation.ExecutionApi.DTOs;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
@@ -45,12 +49,16 @@ namespace Presentation.ExecutionApi.Controllers;
 public sealed class WorkflowsController : ControllerBase
 {
     private readonly IMediator _mediator;
+    private readonly ICapabilityEnvelopeResolver _envelopeResolver;
 
-    /// <summary>Initializes the controller with its MediatR dependency.</summary>
-    public WorkflowsController(IMediator mediator)
+    /// <summary>Initializes the controller with its MediatR and envelope-resolver dependencies.</summary>
+    public WorkflowsController(IMediator mediator, ICapabilityEnvelopeResolver envelopeResolver)
     {
         ArgumentNullException.ThrowIfNull(mediator);
+        ArgumentNullException.ThrowIfNull(envelopeResolver);
+
         _mediator = mediator;
+        _envelopeResolver = envelopeResolver;
     }
 
     /// <summary>
@@ -80,6 +88,75 @@ public sealed class WorkflowsController : ControllerBase
         return Created($"/api/workflows/{result.Value.WorkflowId}", result.Value);
     }
 
+
+    /// <summary>
+    /// Starts a run of a stored workflow, returning a job identifier to poll.
+    /// </summary>
+    /// <remarks>
+    /// Accepts and queues; it does not wait. The response says the work was taken, not that it
+    /// finished, which is why it carries a status URL rather than a result.
+    /// </remarks>
+    /// <param name="workflowId">The stored workflow to run.</param>
+    /// <param name="cancellationToken">Cancels the request.</param>
+    [HttpPost("{workflowId:guid}/runs")]
+    [ProducesResponseType(typeof(StartWorkflowRunResponse), StatusCodes.Status202Accepted)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> StartRun(Guid workflowId, CancellationToken cancellationToken)
+    {
+        // Resolved here, at the transport boundary, from the credential that invoked THIS request —
+        // never from anything stored with the workflow. A run therefore executes under the grant of
+        // whoever started it, so a workflow authored by a broadly-permitted caller confers nothing on
+        // a narrowly-permitted one that runs it later.
+        var envelope = _envelopeResolver.Resolve(User);
+
+        var result = await _mediator.Send(
+            new StartWorkflowRunCommand
+            {
+                WorkflowId = workflowId,
+                OwnerId = User.GetUserId(),
+                TenantId = User.GetTenantId(),
+                Envelope = envelope
+            },
+            cancellationToken).ConfigureAwait(false);
+
+        if (!result.IsSuccess || result.Value is null)
+            return MapFailure(result);
+
+        var statusUrl = $"/api/workflows/{workflowId}/runs/{result.Value.JobId}";
+        return Accepted(statusUrl, new StartWorkflowRunResponse
+        {
+            JobId = result.Value.JobId,
+            StatusUrl = statusUrl
+        });
+    }
+
+    /// <summary>Reads the current state of a run the caller started.</summary>
+    /// <param name="workflowId">The workflow the run belongs to.</param>
+    /// <param name="jobId">The run to read.</param>
+    /// <param name="cancellationToken">Cancels the request.</param>
+    [HttpGet("{workflowId:guid}/runs/{jobId}")]
+    [ProducesResponseType(typeof(WorkflowRunResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> GetRun(
+        Guid workflowId, string jobId, CancellationToken cancellationToken)
+    {
+        var result = await _mediator.Send(
+            new GetWorkflowRunQuery
+            {
+                WorkflowId = workflowId,
+                JobId = jobId,
+                OwnerId = User.GetUserId()
+            },
+            cancellationToken).ConfigureAwait(false);
+
+        return result.IsSuccess && result.Value is not null
+            ? Ok(WorkflowRunResponse.FromRecord(result.Value))
+            : MapFailure(result);
+    }
+
     private IActionResult MapFailure(Result result) =>
-        this.FailureResponse(result, "Workflow submission failed");
+        this.FailureResponse(result, "Workflow operation failed");
 }

--- a/src/Content/Presentation/Presentation.ExecutionApi/Controllers/WorkflowsController.cs
+++ b/src/Content/Presentation/Presentation.ExecutionApi/Controllers/WorkflowsController.cs
@@ -93,8 +93,15 @@ public sealed class WorkflowsController : ControllerBase
     /// Starts a run of a stored workflow, returning a job identifier to poll.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// Accepts and queues; it does not wait. The response says the work was taken, not that it
     /// finished, which is why it carries a status URL rather than a result.
+    /// </para>
+    /// <para>
+    /// Answers 409 while the workflow already has a run in progress. A workflow's execution state is
+    /// held against the workflow rather than the run, so a second concurrent run would not be a second
+    /// independent execution — it would share one state machine with the first.
+    /// </para>
     /// </remarks>
     /// <param name="workflowId">The stored workflow to run.</param>
     /// <param name="cancellationToken">Cancels the request.</param>
@@ -103,6 +110,7 @@ public sealed class WorkflowsController : ControllerBase
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status409Conflict)]
     public async Task<IActionResult> StartRun(Guid workflowId, CancellationToken cancellationToken)
     {
         // Resolved here, at the transport boundary, from the credential that invoked THIS request —

--- a/src/Content/Presentation/Presentation.ExecutionApi/DTOs/WorkflowRunContracts.cs
+++ b/src/Content/Presentation/Presentation.ExecutionApi/DTOs/WorkflowRunContracts.cs
@@ -1,0 +1,61 @@
+using Domain.AI.Runs;
+
+namespace Presentation.ExecutionApi.DTOs;
+
+/// <summary>Response to an accepted run request: what to poll, and under what identifier.</summary>
+public sealed record StartWorkflowRunResponse
+{
+    /// <summary>Server-minted identifier of the queued run.</summary>
+    public required string JobId { get; init; }
+
+    /// <summary>Where to poll for the run's state.</summary>
+    public required string StatusUrl { get; init; }
+}
+
+/// <summary>The caller-visible view of a run.</summary>
+/// <remarks>
+/// A projection rather than the stored record, deliberately. <see cref="RunRecord"/> carries the
+/// caller's resolved capability envelope and tenant, which are the host's authorization state and not
+/// the caller's business — returning the record directly would publish the exact grant a run holds.
+/// </remarks>
+public sealed record WorkflowRunResponse
+{
+    /// <summary>Identifier of the run.</summary>
+    public required string JobId { get; init; }
+
+    /// <summary>Identifier of the workflow the run belongs to.</summary>
+    public required string WorkflowId { get; init; }
+
+    /// <summary>Where the run has got to.</summary>
+    public required string Status { get; init; }
+
+    /// <summary>Caller-safe failure reason once the run has failed.</summary>
+    public string? Error { get; init; }
+
+    /// <summary>When the run was accepted.</summary>
+    public required DateTimeOffset CreatedAt { get; init; }
+
+    /// <summary>When execution began, if it has.</summary>
+    public DateTimeOffset? StartedAt { get; init; }
+
+    /// <summary>When the run reached a terminal state, if it has.</summary>
+    public DateTimeOffset? CompletedAt { get; init; }
+
+    /// <summary>Projects a stored run onto the caller-visible shape.</summary>
+    /// <param name="record">The stored run.</param>
+    public static WorkflowRunResponse FromRecord(RunRecord record)
+    {
+        ArgumentNullException.ThrowIfNull(record);
+
+        return new WorkflowRunResponse
+        {
+            JobId = record.JobId,
+            WorkflowId = record.TargetId,
+            Status = record.Status.ToString(),
+            Error = record.Error,
+            CreatedAt = record.CreatedAt,
+            StartedAt = record.StartedAt,
+            CompletedAt = record.CompletedAt
+        };
+    }
+}

--- a/src/Content/Tests/Application.AI.Common.Tests/CQRS/Workflows/WorkflowRunHandlerTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/CQRS/Workflows/WorkflowRunHandlerTests.cs
@@ -40,13 +40,21 @@ public sealed class WorkflowRunHandlerTests
     private readonly FakeTimeProvider _time = new(new DateTimeOffset(2026, 7, 29, 12, 0, 0, TimeSpan.Zero));
     private readonly AppConfig _config = new();
 
-    private StartWorkflowRunCommandHandler BuildStartSut(bool ownsWorkflow = true, int maxConcurrent = 10)
+    private StartWorkflowRunCommandHandler BuildStartSut(
+        bool ownsWorkflow = true,
+        int maxConcurrent = 10,
+        RunAdmission admission = RunAdmission.Accepted)
     {
         _config.AI.WorkflowSubmission.Enabled = true;
         _config.AI.WorkflowSubmission.MaxConcurrentRunsPerOwner = maxConcurrent;
 
         _planStore.Setup(s => s.IsPlanWritableByCallerAsync(It.IsAny<PlanId>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result<bool>.Success(ownsWorkflow));
+
+        _runStore.Setup(s => s.TryCreate(It.IsAny<RunRecord>(), It.IsAny<int>())).Returns(admission);
+
+        _queue.Setup(q => q.EnqueueAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns(ValueTask.CompletedTask);
 
         return new StartWorkflowRunCommandHandler(
             _planStore.Object, _runStore.Object, _queue.Object,
@@ -79,7 +87,7 @@ public sealed class WorkflowRunHandlerTests
         result.FailureType.Should().Be(ResultFailureType.NotFound,
             "not-yours and not-there must be the same answer, or the endpoint enumerates other callers' work");
 
-        _runStore.Verify(s => s.Create(It.IsAny<RunRecord>()), Times.Never);
+        _runStore.Verify(s => s.TryCreate(It.IsAny<RunRecord>(), It.IsAny<int>()), Times.Never);
         _queue.Verify(q => q.EnqueueAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
@@ -91,7 +99,10 @@ public sealed class WorkflowRunHandlerTests
         var sut = BuildStartSut();
         var sequence = new List<string>();
 
-        _runStore.Setup(s => s.Create(It.IsAny<RunRecord>())).Callback(() => sequence.Add("create"));
+        _runStore.Setup(s => s.TryCreate(It.IsAny<RunRecord>(), It.IsAny<int>()))
+            .Callback(() => sequence.Add("create"))
+            .Returns(RunAdmission.Accepted);
+
         _queue.Setup(q => q.EnqueueAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .Callback(() => sequence.Add("enqueue"))
             .Returns(ValueTask.CompletedTask);
@@ -110,10 +121,9 @@ public sealed class WorkflowRunHandlerTests
         // authorized it has to travel on the record itself.
         var sut = BuildStartSut();
         RunRecord? created = null;
-        _runStore.Setup(s => s.Create(It.IsAny<RunRecord>()))
-            .Callback<RunRecord>(record => created = record);
-        _queue.Setup(q => q.EnqueueAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .Returns(ValueTask.CompletedTask);
+        _runStore.Setup(s => s.TryCreate(It.IsAny<RunRecord>(), It.IsAny<int>()))
+            .Callback<RunRecord, int>((record, _) => created = record)
+            .Returns(RunAdmission.Accepted);
 
         var workflowId = Guid.NewGuid();
         await sut.Handle(StartCommand(workflowId), CancellationToken.None);
@@ -127,29 +137,42 @@ public sealed class WorkflowRunHandlerTests
     }
 
     [Fact]
+    public async Task Start_PassesTheConfiguredCapToTheStoreRatherThanCheckingItHere()
+    {
+        // The cap has to be applied where it can be applied atomically. Deciding it here and inserting
+        // afterwards leaves a window in which concurrent requests all see room and all proceed.
+        var sut = BuildStartSut(maxConcurrent: 4);
+
+        await sut.Handle(StartCommand(Guid.NewGuid()), CancellationToken.None);
+
+        _runStore.Verify(s => s.TryCreate(It.IsAny<RunRecord>(), 4), Times.Once);
+    }
+
+    [Fact]
     public async Task Start_WhenTheCallerIsAtItsConcurrencyCap_IsRefused()
     {
-        var sut = BuildStartSut(maxConcurrent: 2);
-        _runStore.Setup(s => s.CountActiveRuns("alice")).Returns(2);
+        var sut = BuildStartSut(maxConcurrent: 2, admission: RunAdmission.OwnerAtCapacity);
 
         var result = await sut.Handle(StartCommand(Guid.NewGuid()), CancellationToken.None);
 
         result.IsSuccess.Should().BeFalse();
         result.Errors.Should().ContainMatch("*in flight*");
-        _runStore.Verify(s => s.Create(It.IsAny<RunRecord>()), Times.Never);
+        _queue.Verify(q => q.EnqueueAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [Fact]
-    public async Task Start_WhenTheCallerIsBelowItsCap_IsAccepted()
+    public async Task Start_WhenTheWorkflowIsAlreadyRunning_IsAConflict()
     {
-        var sut = BuildStartSut(maxConcurrent: 2);
-        _runStore.Setup(s => s.CountActiveRuns("alice")).Returns(1);
-        _queue.Setup(q => q.EnqueueAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .Returns(ValueTask.CompletedTask);
+        // Distinct from being at capacity, and distinct from a validation error: the caller is not at
+        // fault and nothing about the request is malformed. It is a state that clears on its own, and
+        // 409 is what tells a caller to retry rather than to change what it asked for.
+        var sut = BuildStartSut(admission: RunAdmission.TargetAlreadyRunning);
 
         var result = await sut.Handle(StartCommand(Guid.NewGuid()), CancellationToken.None);
 
-        result.IsSuccess.Should().BeTrue();
+        result.FailureType.Should().Be(ResultFailureType.Conflict);
+        result.Errors.Should().ContainMatch("*already has a run in progress*");
+        _queue.Verify(q => q.EnqueueAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [Fact]
@@ -161,7 +184,7 @@ public sealed class WorkflowRunHandlerTests
         var result = await sut.Handle(StartCommand(Guid.NewGuid()), CancellationToken.None);
 
         result.FailureType.Should().Be(ResultFailureType.Forbidden);
-        _runStore.Verify(s => s.Create(It.IsAny<RunRecord>()), Times.Never);
+        _runStore.Verify(s => s.TryCreate(It.IsAny<RunRecord>(), It.IsAny<int>()), Times.Never);
     }
 
     [Fact]

--- a/src/Content/Tests/Application.AI.Common.Tests/CQRS/Workflows/WorkflowRunHandlerTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/CQRS/Workflows/WorkflowRunHandlerTests.cs
@@ -1,0 +1,233 @@
+using Application.AI.Common.CQRS.Workflows.GetRun;
+using Application.AI.Common.CQRS.Workflows.StartRun;
+using Application.AI.Common.Interfaces.Planner;
+using Application.AI.Common.Interfaces.Runs;
+using Domain.AI.Bundles;
+using Domain.AI.Planner;
+using Domain.AI.Runs;
+using Domain.Common;
+using Domain.Common.Config;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Time.Testing;
+using Moq;
+using Xunit;
+
+namespace Application.AI.Common.Tests.CQRS.Workflows;
+
+/// <summary>
+/// Tests for the run start and status handlers.
+/// </summary>
+/// <remarks>
+/// The load-bearing properties are that a caller cannot start or read a run against a workflow it
+/// does not own, and that neither refusal reveals whether the thing exists — a job identifier is the
+/// only thing separating callers, so an answer that distinguishes "not yours" from "not there" turns
+/// the endpoint into a way to enumerate other people's work.
+/// </remarks>
+public sealed class WorkflowRunHandlerTests
+{
+    private sealed class StaticOptionsMonitor<T>(T value) : IOptionsMonitor<T>
+    {
+        public T CurrentValue { get; } = value;
+        public T Get(string? name) => CurrentValue;
+        public IDisposable? OnChange(Action<T, string?> listener) => null;
+    }
+
+    private readonly Mock<IPlanStateStore> _planStore = new();
+    private readonly Mock<IRunJobStore> _runStore = new();
+    private readonly Mock<IRunDispatchQueue> _queue = new();
+    private readonly FakeTimeProvider _time = new(new DateTimeOffset(2026, 7, 29, 12, 0, 0, TimeSpan.Zero));
+    private readonly AppConfig _config = new();
+
+    private StartWorkflowRunCommandHandler BuildStartSut(bool ownsWorkflow = true, int maxConcurrent = 10)
+    {
+        _config.AI.WorkflowSubmission.Enabled = true;
+        _config.AI.WorkflowSubmission.MaxConcurrentRunsPerOwner = maxConcurrent;
+
+        _planStore.Setup(s => s.IsPlanWritableByCallerAsync(It.IsAny<PlanId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<bool>.Success(ownsWorkflow));
+
+        return new StartWorkflowRunCommandHandler(
+            _planStore.Object, _runStore.Object, _queue.Object,
+            new StaticOptionsMonitor<AppConfig>(_config), _time,
+            NullLogger<StartWorkflowRunCommandHandler>.Instance);
+    }
+
+    private GetWorkflowRunQueryHandler BuildGetSut()
+    {
+        _config.AI.WorkflowSubmission.Enabled = true;
+        return new GetWorkflowRunQueryHandler(_runStore.Object, new StaticOptionsMonitor<AppConfig>(_config));
+    }
+
+    private static StartWorkflowRunCommand StartCommand(Guid workflowId, string ownerId = "alice") => new()
+    {
+        WorkflowId = workflowId,
+        OwnerId = ownerId,
+        TenantId = "acme",
+        Envelope = new CapabilityEnvelope()
+    };
+
+    [Fact]
+    public async Task Start_WorkflowTheCallerDoesNotOwn_IsNotFoundAndQueuesNothing()
+    {
+        var sut = BuildStartSut(ownsWorkflow: false);
+
+        var result = await sut.Handle(StartCommand(Guid.NewGuid()), CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.FailureType.Should().Be(ResultFailureType.NotFound,
+            "not-yours and not-there must be the same answer, or the endpoint enumerates other callers' work");
+
+        _runStore.Verify(s => s.Create(It.IsAny<RunRecord>()), Times.Never);
+        _queue.Verify(q => q.EnqueueAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Start_OwnedWorkflow_RecordsTheRunBeforeQueueingIt()
+    {
+        // Order matters: queued first, a dispatcher could claim a job the store has never heard of and
+        // the run would vanish while the caller holds an identifier that never resolves.
+        var sut = BuildStartSut();
+        var sequence = new List<string>();
+
+        _runStore.Setup(s => s.Create(It.IsAny<RunRecord>())).Callback(() => sequence.Add("create"));
+        _queue.Setup(q => q.EnqueueAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Callback(() => sequence.Add("enqueue"))
+            .Returns(ValueTask.CompletedTask);
+
+        var result = await sut.Handle(StartCommand(Guid.NewGuid()), CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.JobId.Should().NotBeNullOrWhiteSpace();
+        sequence.Should().Equal("create", "enqueue");
+    }
+
+    [Fact]
+    public async Task Start_RecordsTheCallerAndTheirEnvelopeOnTheRun()
+    {
+        // The run outlives the request and executes with no caller attached, so the identity that
+        // authorized it has to travel on the record itself.
+        var sut = BuildStartSut();
+        RunRecord? created = null;
+        _runStore.Setup(s => s.Create(It.IsAny<RunRecord>()))
+            .Callback<RunRecord>(record => created = record);
+        _queue.Setup(q => q.EnqueueAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns(ValueTask.CompletedTask);
+
+        var workflowId = Guid.NewGuid();
+        await sut.Handle(StartCommand(workflowId), CancellationToken.None);
+
+        created.Should().NotBeNull();
+        created!.OwnerId.Should().Be("alice");
+        created.TenantId.Should().Be("acme");
+        created.TargetId.Should().Be(workflowId.ToString());
+        created.Kind.Should().Be(RunKind.Workflow);
+        created.Status.Should().Be(RunStatus.Queued);
+    }
+
+    [Fact]
+    public async Task Start_WhenTheCallerIsAtItsConcurrencyCap_IsRefused()
+    {
+        var sut = BuildStartSut(maxConcurrent: 2);
+        _runStore.Setup(s => s.CountActiveRuns("alice")).Returns(2);
+
+        var result = await sut.Handle(StartCommand(Guid.NewGuid()), CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Errors.Should().ContainMatch("*in flight*");
+        _runStore.Verify(s => s.Create(It.IsAny<RunRecord>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Start_WhenTheCallerIsBelowItsCap_IsAccepted()
+    {
+        var sut = BuildStartSut(maxConcurrent: 2);
+        _runStore.Setup(s => s.CountActiveRuns("alice")).Returns(1);
+        _queue.Setup(q => q.EnqueueAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns(ValueTask.CompletedTask);
+
+        var result = await sut.Handle(StartCommand(Guid.NewGuid()), CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Start_WhenSubmissionIsDisabled_IsRefused()
+    {
+        var sut = BuildStartSut();
+        _config.AI.WorkflowSubmission.Enabled = false;
+
+        var result = await sut.Handle(StartCommand(Guid.NewGuid()), CancellationToken.None);
+
+        result.FailureType.Should().Be(ResultFailureType.Forbidden);
+        _runStore.Verify(s => s.Create(It.IsAny<RunRecord>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Get_RunBelongingToAnotherCaller_IsNotFound()
+    {
+        // The store answers null for another owner, and the handler must not soften that into
+        // anything that distinguishes it from a job id that was never issued.
+        var sut = BuildGetSut();
+        _runStore.Setup(s => s.Get("job-1", "mallory")).Returns((RunRecord?)null);
+
+        var result = await sut.Handle(
+            new GetWorkflowRunQuery { WorkflowId = Guid.NewGuid(), JobId = "job-1", OwnerId = "mallory" },
+            CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.FailureType.Should().Be(ResultFailureType.NotFound);
+    }
+
+    [Fact]
+    public async Task Get_RunBelongingToADifferentWorkflow_IsNotFound()
+    {
+        // The route asserts a relationship. Answering it with a record that contradicts the route
+        // would let a caller discover which workflow a job belongs to by trying routes until one hit.
+        var sut = BuildGetSut();
+        var requested = Guid.NewGuid();
+
+        _runStore.Setup(s => s.Get("job-1", "alice")).Returns(new RunRecord
+        {
+            JobId = "job-1",
+            Kind = RunKind.Workflow,
+            TargetId = Guid.NewGuid().ToString(),
+            OwnerId = "alice",
+            Envelope = new CapabilityEnvelope(),
+            Status = RunStatus.Queued,
+            CreatedAt = _time.GetUtcNow()
+        });
+
+        var result = await sut.Handle(
+            new GetWorkflowRunQuery { WorkflowId = requested, JobId = "job-1", OwnerId = "alice" },
+            CancellationToken.None);
+
+        result.FailureType.Should().Be(ResultFailureType.NotFound);
+    }
+
+    [Fact]
+    public async Task Get_TheCallersOwnRun_IsReturned()
+    {
+        var sut = BuildGetSut();
+        var workflowId = Guid.NewGuid();
+
+        _runStore.Setup(s => s.Get("job-1", "alice")).Returns(new RunRecord
+        {
+            JobId = "job-1",
+            Kind = RunKind.Workflow,
+            TargetId = workflowId.ToString(),
+            OwnerId = "alice",
+            Envelope = new CapabilityEnvelope(),
+            Status = RunStatus.Running,
+            CreatedAt = _time.GetUtcNow()
+        });
+
+        var result = await sut.Handle(
+            new GetWorkflowRunQuery { WorkflowId = workflowId, JobId = "job-1", OwnerId = "alice" },
+            CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.Status.Should().Be(RunStatus.Running);
+    }
+}

--- a/src/Content/Tests/Application.AI.Common.Tests/CQRS/Workflows/WorkflowRunHandlerTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/CQRS/Workflows/WorkflowRunHandlerTests.cs
@@ -176,6 +176,55 @@ public sealed class WorkflowRunHandlerTests
     }
 
     [Fact]
+    public async Task Start_DoesNotQueueOnTheCallersToken()
+    {
+        // Past admission the record is committed. A record that is committed but never queued is never
+        // claimed, never finishes, and — because only terminal runs are reclaimed — never goes away:
+        // it pins its workflow at 409 and holds one of the owner's slots for the life of the process.
+        // Hanging up mid-request is ordinary client behaviour and must not be able to do that.
+        var sut = BuildStartSut();
+        CancellationToken observed = default;
+        _queue.Setup(q => q.EnqueueAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Callback<string, CancellationToken>((_, token) => observed = token)
+            .Returns(ValueTask.CompletedTask);
+
+        using var cts = new CancellationTokenSource();
+        await sut.Handle(StartCommand(Guid.NewGuid()), cts.Token);
+
+        observed.CanBeCanceled.Should().BeFalse(
+            "the caller's token must not be able to abandon a run the caller was already told was accepted");
+    }
+
+    [Fact]
+    public async Task Start_WhenQueueingFails_TheRunIsRecordedTerminalRatherThanLeftQueued()
+    {
+        // Unreachable with an in-process channel, but the queue is the seam for a durable one. The cost
+        // of an unguarded failure is not a lost run: it is a workflow no caller can ever start again.
+        var sut = BuildStartSut();
+        RunRecord? created = null;
+        RunRecord? updated = null;
+
+        _runStore.Setup(s => s.TryCreate(It.IsAny<RunRecord>(), It.IsAny<int>()))
+            .Callback<RunRecord, int>((record, _) => created = record)
+            .Returns(RunAdmission.Accepted);
+
+        _runStore.Setup(s => s.Update(It.IsAny<RunRecord>()))
+            .Callback<RunRecord>(record => updated = record)
+            .Returns(true);
+
+        _queue.Setup(q => q.EnqueueAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Throws(new InvalidOperationException("the queue is gone"));
+
+        var result = await sut.Handle(StartCommand(Guid.NewGuid()), CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        updated.Should().NotBeNull("a committed record that cannot be queued must be released, not stranded");
+        updated!.JobId.Should().Be(created!.JobId);
+        updated.IsTerminal.Should().BeTrue();
+        updated.Error.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
     public async Task Start_WhenSubmissionIsDisabled_IsRefused()
     {
         var sut = BuildStartSut();
@@ -193,7 +242,7 @@ public sealed class WorkflowRunHandlerTests
         // The store answers null for another owner, and the handler must not soften that into
         // anything that distinguishes it from a job id that was never issued.
         var sut = BuildGetSut();
-        _runStore.Setup(s => s.Get("job-1", "mallory")).Returns((RunRecord?)null);
+        _runStore.Setup(s => s.Get("job-1", "mallory", It.IsAny<string?>())).Returns((RunRecord?)null);
 
         var result = await sut.Handle(
             new GetWorkflowRunQuery { WorkflowId = Guid.NewGuid(), JobId = "job-1", OwnerId = "mallory" },
@@ -211,7 +260,7 @@ public sealed class WorkflowRunHandlerTests
         var sut = BuildGetSut();
         var requested = Guid.NewGuid();
 
-        _runStore.Setup(s => s.Get("job-1", "alice")).Returns(new RunRecord
+        _runStore.Setup(s => s.Get("job-1", "alice", It.IsAny<string?>())).Returns(new RunRecord
         {
             JobId = "job-1",
             Kind = RunKind.Workflow,
@@ -235,7 +284,7 @@ public sealed class WorkflowRunHandlerTests
         var sut = BuildGetSut();
         var workflowId = Guid.NewGuid();
 
-        _runStore.Setup(s => s.Get("job-1", "alice")).Returns(new RunRecord
+        _runStore.Setup(s => s.Get("job-1", "alice", It.IsAny<string?>())).Returns(new RunRecord
         {
             JobId = "job-1",
             Kind = RunKind.Workflow,

--- a/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlanExecutorCancellationTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlanExecutorCancellationTests.cs
@@ -603,6 +603,10 @@ public sealed class PlanExecutorCancellationTests
                 .ReturnsAsync(Result<PlanValidationResult>.Success(new PlanValidationResult { IsValid = true }));
 
             var stateStore = new Mock<IPlanStateStore>();
+            // The caller owns the plan here. CancelAsync authorizes through this probe BEFORE it
+            // signals, so leaving it unset makes the plan read as absent and no cancel reaches the run.
+            stateStore.Setup(s => s.IsPlanWritableByCallerAsync(It.IsAny<PlanId>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(Result<bool>.Success(true));
             stateStore.Setup(s => s.LoadPlanAsync(It.IsAny<PlanId>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(Result<PlanGraph?>.Success(_plan));
             stateStore.Setup(s => s.ResumeAsync(It.IsAny<PlanId>(), It.IsAny<CancellationToken>()))

--- a/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlanExecutorSolutionReviewFixTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlanExecutorSolutionReviewFixTests.cs
@@ -75,6 +75,10 @@ public sealed class PlanExecutorSolutionReviewFixTests
             .ReturnsAsync(Result<PlanValidationResult>.Success(new PlanValidationResult { IsValid = true }));
 
         var stateStore = new Mock<IPlanStateStore>();
+        // The caller owns the plan here. CancelAsync authorizes through this probe BEFORE it
+        // signals, so leaving it unset makes the plan read as absent and no cancel reaches the run.
+        stateStore.Setup(s => s.IsPlanWritableByCallerAsync(It.IsAny<PlanId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<bool>.Success(true));
         stateStore.Setup(s => s.LoadPlanAsync(plan.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result<PlanGraph?>.Success(plan));
         stateStore.Setup(s => s.ResumeAsync(It.IsAny<PlanId>(), It.IsAny<CancellationToken>()))

--- a/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlanExecutorTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlanExecutorTests.cs
@@ -42,6 +42,11 @@ public sealed class PlanExecutorTests : IDisposable
 
         _stateStore.Setup(s => s.UpdateStepStateAsync(It.IsAny<StepExecutionState>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Success());
+        // The caller owns the plan in every scenario here. Cancellation authorizes through this probe
+        // BEFORE it signals, so a mock that leaves it unset reports the plan as absent and no cancel
+        // reaches the run — which is the point of the check, not an artefact of the mock.
+        _stateStore.Setup(s => s.IsPlanWritableByCallerAsync(It.IsAny<PlanId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<bool>.Success(true));
         _stateStore.Setup(s => s.ResumeAsync(It.IsAny<PlanId>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result<IReadOnlyDictionary<PlanStepId, StepExecutionState>>.Success(
                 new Dictionary<PlanStepId, StepExecutionState>()));
@@ -1052,5 +1057,58 @@ public sealed class PlanExecutorTests : IDisposable
     public void Dispose()
     {
         _serviceProvider?.Dispose();
+    }
+
+    [Fact]
+    public async Task CancelAsync_PlanNotWritableByCaller_NeitherSignalsNorRewritesState()
+    {
+        // The security property: signalling stops real work immediately and irreversibly. Checking
+        // ownership only at the persisted rewrite would let one tenant abort another's in-flight run
+        // and merely receive NotFound afterwards — with the run already dead.
+        var planId = PlanId.New();
+        var registry = new Mock<IPlanRunCancellationRegistry>();
+
+        _stateStore.Setup(s => s.IsPlanWritableByCallerAsync(planId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<bool>.Success(false));
+
+        var sut = new PlanExecutor(
+            _validator.Object, _stateStore.Object, _notifier.Object, _escalation.Object,
+            _serviceProvider, registry.Object, TimeProvider.System,
+            NullLogger<PlanExecutor>.Instance);
+
+        var result = await sut.CancelAsync(planId, CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+
+        // NotFound, not Forbidden: a cross-owner cancel must be indistinguishable from cancelling a
+        // plan that does not exist, or the response becomes an existence oracle for other tenants.
+        Assert.Equal(ResultFailureType.NotFound, result.FailureType);
+
+        registry.Verify(r => r.TryCancel(It.IsAny<PlanId>()), Times.Never);
+        _stateStore.Verify(
+            s => s.CheckpointAsync(It.IsAny<PlanId>(), It.IsAny<IReadOnlyList<StepExecutionState>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task CancelAsync_WhenTheWritabilityProbeFaults_DoesNotSignal()
+    {
+        // A store fault must not be read as permission. Failing open here would make a transient
+        // database error the way to cancel anyone's run.
+        var planId = PlanId.New();
+        var registry = new Mock<IPlanRunCancellationRegistry>();
+
+        _stateStore.Setup(s => s.IsPlanWritableByCallerAsync(planId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<bool>.Fail("database is locked"));
+
+        var sut = new PlanExecutor(
+            _validator.Object, _stateStore.Object, _notifier.Object, _escalation.Object,
+            _serviceProvider, registry.Object, TimeProvider.System,
+            NullLogger<PlanExecutor>.Instance);
+
+        var result = await sut.CancelAsync(planId, CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        registry.Verify(r => r.TryCancel(It.IsAny<PlanId>()), Times.Never);
     }
 }

--- a/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlannerDiRegistrationTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlannerDiRegistrationTests.cs
@@ -16,6 +16,7 @@ using Infrastructure.AI.KnowledgeGraph;
 using Infrastructure.AI.Persistence;
 using Infrastructure.AI.Planner;
 using Infrastructure.AI.Planner.StepExecutors;
+using Infrastructure.AI.Runs;
 using Infrastructure.AI.Sandbox;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
@@ -53,6 +54,21 @@ public sealed class PlannerDiRegistrationTests : IDisposable
         sp.GetService<IPlanValidator>().Should().NotBeNull().And.BeOfType<PlanValidator>();
         sp.GetService<IPlanGenerator>().Should().NotBeNull().And.BeOfType<LlmPlanGeneratorService>();
         sp.GetService<IPlanStateStore>().Should().NotBeNull().And.BeOfType<EfCorePlanStateStore>();
+    }
+
+    [Fact]
+    public void DependencyInjection_RunSubstrate_HasBothADispatcherAndASweeper()
+    {
+        // Registration is the whole feature for these two. Each is a background loop nothing else
+        // calls, so an unregistered one is not a failure anyone sees — the dispatcher's absence leaves
+        // every run sitting Queued, and the sweeper's leaves the configured retention as a claim the
+        // host never honours while finished runs accumulate for the life of the process.
+        var hosted = _provider.GetServices<Microsoft.Extensions.Hosting.IHostedService>()
+            .Select(service => service.GetType())
+            .ToList();
+
+        hosted.Should().Contain(typeof(RunDispatchBackgroundService));
+        hosted.Should().Contain(typeof(RunRecordCleanupService));
     }
 
     [Fact]

--- a/src/Content/Tests/Infrastructure.AI.Tests/Runs/InMemoryRunJobStoreTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Runs/InMemoryRunJobStoreTests.cs
@@ -14,13 +14,16 @@ namespace Infrastructure.AI.Tests.Runs;
 /// Tests for <see cref="InMemoryRunJobStore"/>.
 /// </summary>
 /// <remarks>
-/// Two properties carry real consequences and are tested hardest: a run must be armed exactly once,
-/// because duplicate execution here is duplicate model and tool spend rather than a duplicate row;
-/// and a run must be invisible to anyone but its owner, because the job identifier is the only thing
-/// standing between callers.
+/// Three properties carry real consequences and are tested hardest: a run must be armed exactly once,
+/// because duplicate execution here is duplicate model and tool spend rather than a duplicate row; a
+/// workflow must never have two live runs, because its execution state is keyed by the workflow and a
+/// second run would share that state machine with the first; and a run must be invisible to anyone but
+/// its owner, because the job identifier is the only thing standing between callers.
 /// </remarks>
 public sealed class InMemoryRunJobStoreTests
 {
+    private const int UncappedOwner = int.MaxValue;
+
     private sealed class StaticOptionsMonitor<T>(T value) : IOptionsMonitor<T>
     {
         public T CurrentValue { get; } = value;
@@ -37,16 +40,24 @@ public sealed class InMemoryRunJobStoreTests
         return new InMemoryRunJobStore(new StaticOptionsMonitor<AppConfig>(_config), _time);
     }
 
-    private RunRecord Queued(string jobId = "job-1", string ownerId = "alice") => new()
+    private RunRecord Queued(
+        string jobId = "job-1", string ownerId = "alice", string? targetId = null) => new()
     {
         JobId = jobId,
         Kind = RunKind.Workflow,
-        TargetId = Guid.NewGuid().ToString(),
+        TargetId = targetId ?? Guid.NewGuid().ToString(),
         OwnerId = ownerId,
         Envelope = new CapabilityEnvelope(),
         Status = RunStatus.Queued,
         CreatedAt = _time.GetUtcNow()
     };
+
+    /// <summary>Admits a run, asserting it was accepted, and returns it.</summary>
+    private static RunRecord Admit(IRunJobStore store, RunRecord record, int cap = UncappedOwner)
+    {
+        store.TryCreate(record, cap).Should().Be(RunAdmission.Accepted);
+        return record;
+    }
 
     [Fact]
     public void TryBeginRun_UnderConcurrency_ArmsExactlyOnce()
@@ -54,7 +65,7 @@ public sealed class InMemoryRunJobStoreTests
         // The property duplicate execution depends on. A redelivered queue message or a second
         // dispatcher must lose, not run the same workflow again.
         var sut = BuildSut();
-        sut.Create(Queued());
+        Admit(sut, Queued());
 
         var winners = 0;
         var threads = Enumerable.Range(0, 32).Select(_ => new Thread(() =>
@@ -73,7 +84,7 @@ public sealed class InMemoryRunJobStoreTests
     public void TryBeginRun_AlreadyRunning_ReturnsNull()
     {
         var sut = BuildSut();
-        sut.Create(Queued());
+        Admit(sut, Queued());
 
         sut.TryBeginRun("job-1", _time.GetUtcNow()).Should().NotBeNull();
         sut.TryBeginRun("job-1", _time.GetUtcNow()).Should().BeNull();
@@ -83,7 +94,7 @@ public sealed class InMemoryRunJobStoreTests
     public void TryBeginRun_RecordsTheClaimTimeAndMovesToRunning()
     {
         var sut = BuildSut();
-        sut.Create(Queued());
+        Admit(sut, Queued());
         var claimedAt = _time.GetUtcNow();
 
         var claimed = sut.TryBeginRun("job-1", claimedAt);
@@ -93,10 +104,152 @@ public sealed class InMemoryRunJobStoreTests
     }
 
     [Fact]
+    public void TryCreate_ASecondRunOfALiveWorkflow_IsRefused()
+    {
+        // A stored workflow's execution state is keyed by the workflow, not by the run. A second
+        // concurrent run would not be a second independent execution — it would resume the first one's
+        // state: re-running steps the first has in flight and adopting its completed outputs.
+        var sut = BuildSut();
+        var workflow = Guid.NewGuid().ToString();
+        Admit(sut, Queued("job-1", targetId: workflow));
+
+        var second = sut.TryCreate(Queued("job-2", targetId: workflow), UncappedOwner);
+
+        second.Should().Be(RunAdmission.TargetAlreadyRunning);
+        sut.Get("job-2", "alice").Should().BeNull("a refused run must not be stored");
+    }
+
+    [Fact]
+    public void TryCreate_ASecondRunOfALiveWorkflow_IsRefusedEvenToADifferentOwner()
+    {
+        // The conflict is about the workflow's state, not about who asked. Scoping the check to the
+        // owner would let a second caller with access to the same workflow corrupt the first's run.
+        var sut = BuildSut();
+        var workflow = Guid.NewGuid().ToString();
+        Admit(sut, Queued("job-1", ownerId: "alice", targetId: workflow));
+
+        sut.TryCreate(Queued("job-2", ownerId: "bob", targetId: workflow), UncappedOwner)
+            .Should().Be(RunAdmission.TargetAlreadyRunning);
+    }
+
+    [Fact]
+    public void TryCreate_AFurtherRunOfAWorkflow_IsAdmittedOnceTheEarlierOneEnds()
+    {
+        // The refusal is about live state, not a permanent lock: once the first run is terminal its
+        // state is settled and the next run may resume from it.
+        var sut = BuildSut();
+        var workflow = Guid.NewGuid().ToString();
+        Admit(sut, Queued("job-1", targetId: workflow));
+
+        var claimed = sut.TryBeginRun("job-1", _time.GetUtcNow())!;
+        sut.Update(claimed with { Status = RunStatus.Succeeded, CompletedAt = _time.GetUtcNow() });
+
+        sut.TryCreate(Queued("job-2", targetId: workflow), UncappedOwner)
+            .Should().Be(RunAdmission.Accepted);
+    }
+
+    [Fact]
+    public void TryCreate_ARunOfADifferentWorkflow_IsUnaffected()
+    {
+        var sut = BuildSut();
+        Admit(sut, Queued("job-1", targetId: Guid.NewGuid().ToString()));
+
+        sut.TryCreate(Queued("job-2", targetId: Guid.NewGuid().ToString()), UncappedOwner)
+            .Should().Be(RunAdmission.Accepted);
+    }
+
+    [Fact]
+    public void TryCreate_UnderConcurrency_AdmitsOneRunPerWorkflow()
+    {
+        // Deciding and inserting have to be one step. Split apart, concurrent requests all observe the
+        // workflow as idle and all proceed — which is exactly the state-sharing this prevents.
+        var sut = BuildSut();
+        var workflow = Guid.NewGuid().ToString();
+
+        var admitted = 0;
+        var threads = Enumerable.Range(0, 32).Select(i => new Thread(() =>
+        {
+            if (sut.TryCreate(Queued($"job-{i}", targetId: workflow), UncappedOwner) == RunAdmission.Accepted)
+                Interlocked.Increment(ref admitted);
+        })).ToList();
+
+        foreach (var thread in threads) thread.Start();
+        foreach (var thread in threads) thread.Join();
+
+        admitted.Should().Be(1);
+    }
+
+    [Fact]
+    public void TryCreate_WhenTheOwnerIsAtItsCap_IsRefused()
+    {
+        var sut = BuildSut();
+        Admit(sut, Queued("job-1"), cap: 2);
+        Admit(sut, Queued("job-2"), cap: 2);
+
+        sut.TryCreate(Queued("job-3"), maxActiveRunsPerOwner: 2)
+            .Should().Be(RunAdmission.OwnerAtCapacity);
+    }
+
+    [Fact]
+    public void TryCreate_UnderConcurrency_NeverOvershootsTheOwnersCap()
+    {
+        // Counting then inserting leaves a window in which every concurrent request sees room. The cap
+        // is a spend control, so overshoot is real cost rather than a cosmetic off-by-one.
+        var sut = BuildSut();
+
+        var admitted = 0;
+        var threads = Enumerable.Range(0, 32).Select(i => new Thread(() =>
+        {
+            if (sut.TryCreate(Queued($"job-{i}"), maxActiveRunsPerOwner: 3) == RunAdmission.Accepted)
+                Interlocked.Increment(ref admitted);
+        })).ToList();
+
+        foreach (var thread in threads) thread.Start();
+        foreach (var thread in threads) thread.Join();
+
+        admitted.Should().Be(3);
+    }
+
+    [Fact]
+    public void TryCreate_CountsOnlyTheOwnersOwnLiveRunsAgainstTheCap()
+    {
+        var sut = BuildSut();
+        Admit(sut, Queued("job-1", ownerId: "mallory"), cap: 1);
+
+        sut.TryCreate(Queued("job-2", ownerId: "alice"), maxActiveRunsPerOwner: 1)
+            .Should().Be(RunAdmission.Accepted, "another caller's load is not this caller's");
+    }
+
+    [Fact]
+    public void TryCreate_DoesNotCountFinishedRunsAgainstTheCap()
+    {
+        var sut = BuildSut();
+        Admit(sut, Queued("job-1"), cap: 1);
+
+        var claimed = sut.TryBeginRun("job-1", _time.GetUtcNow())!;
+        sut.Update(claimed with { Status = RunStatus.Succeeded, CompletedAt = _time.GetUtcNow() });
+
+        sut.TryCreate(Queued("job-2"), maxActiveRunsPerOwner: 1)
+            .Should().Be(RunAdmission.Accepted, "a finished run is history, not load");
+    }
+
+    [Fact]
+    public void TryCreate_TreatsAnOwnerAsTheSamePrincipalRegardlessOfCasing()
+    {
+        // Ownership is canonicalized wherever else it is compared (PlannerScopeFilter). Comparing it
+        // more strictly here would let one principal exceed its cap by varying the casing of a token.
+        var sut = BuildSut();
+        Admit(sut, Queued("job-1", ownerId: "Alice"), cap: 1);
+
+        sut.TryCreate(Queued("job-2", ownerId: "alice"), maxActiveRunsPerOwner: 1)
+            .Should().Be(RunAdmission.OwnerAtCapacity);
+    }
+
+    [Fact]
     public void Get_ByAnotherOwner_IsIndistinguishableFromMissing()
     {
         var sut = BuildSut();
-        sut.Create(Queued(ownerId: "alice"));
+        Admit(sut, Queued(ownerId: "alice"));
 
         sut.Get("job-1", "mallory").Should().BeNull();
         sut.Get("no-such-job", "mallory").Should().BeNull();
@@ -104,14 +257,15 @@ public sealed class InMemoryRunJobStoreTests
     }
 
     [Fact]
-    public void Get_OwnerComparison_IsOrdinal()
+    public void Get_TreatsAnOwnerAsTheSamePrincipalRegardlessOfCasing()
     {
-        // Ordinal everywhere, matching how ownership is compared elsewhere. A case-insensitive match
-        // here would let two identities the rest of the system treats as distinct read each other.
+        // The same canonicalization the plan store applies. Comparing more strictly here would deny a
+        // caller its own run whenever a token differed only in casing from the one that started it,
+        // while the plan store went on treating the two as one principal.
         var sut = BuildSut();
-        sut.Create(Queued(ownerId: "Alice"));
+        Admit(sut, Queued(ownerId: "Alice"));
 
-        sut.Get("job-1", "alice").Should().BeNull();
+        sut.Get("job-1", "alice").Should().NotBeNull();
     }
 
     [Fact]
@@ -119,7 +273,7 @@ public sealed class InMemoryRunJobStoreTests
     {
         // A queued or running job the caller is still polling must not vanish, however long it takes.
         var sut = BuildSut(ttl: TimeSpan.FromMinutes(5));
-        sut.Create(Queued());
+        Admit(sut, Queued());
 
         _time.Advance(TimeSpan.FromDays(7));
 
@@ -131,7 +285,7 @@ public sealed class InMemoryRunJobStoreTests
     public void SweepExpired_ReclaimsAFinishedRunOnlyAfterItsRetentionElapses()
     {
         var sut = BuildSut(ttl: TimeSpan.FromMinutes(5));
-        sut.Create(Queued());
+        Admit(sut, Queued());
         var claimed = sut.TryBeginRun("job-1", _time.GetUtcNow())!;
         sut.Update(claimed with { Status = RunStatus.Succeeded, CompletedAt = _time.GetUtcNow() });
 
@@ -148,7 +302,7 @@ public sealed class InMemoryRunJobStoreTests
     {
         // A run that waited a long time in the queue still gets its full readable window afterwards.
         var sut = BuildSut(ttl: TimeSpan.FromMinutes(10));
-        sut.Create(Queued());
+        Admit(sut, Queued());
 
         _time.Advance(TimeSpan.FromMinutes(9));
         var claimed = sut.TryBeginRun("job-1", _time.GetUtcNow())!;
@@ -160,29 +314,34 @@ public sealed class InMemoryRunJobStoreTests
         sut.Get("job-1", "alice").Should().NotBeNull();
     }
 
-    [Fact]
-    public void CountActiveRuns_CountsOnlyTheCallersUnfinishedRuns()
+    [Theory]
+    [InlineData(RunStatus.Succeeded)]
+    [InlineData(RunStatus.Failed)]
+    [InlineData(RunStatus.Cancelled)]
+    [InlineData(RunStatus.Blocked)]
+    public void AnyOutcomeReleasesTheWorkflowAndTheOwnersCapacity(RunStatus outcome)
     {
+        // Every way a run can end has to free what it held. An outcome treated as still-live would pin
+        // its workflow permanently and consume one of the caller's slots for the process lifetime —
+        // which is what happens if a new RunStatus is added and IsTerminal is not updated to match.
         var sut = BuildSut();
-        sut.Create(Queued("a", "alice"));
-        sut.Create(Queued("b", "alice"));
-        sut.Create(Queued("c", "mallory"));
+        var workflow = Guid.NewGuid().ToString();
+        Admit(sut, Queued("job-1", targetId: workflow), cap: 1);
 
-        var finished = sut.TryBeginRun("b", _time.GetUtcNow())!;
-        sut.Update(finished with { Status = RunStatus.Succeeded, CompletedAt = _time.GetUtcNow() });
+        var claimed = sut.TryBeginRun("job-1", _time.GetUtcNow())!;
+        sut.Update(claimed with { Status = outcome, CompletedAt = _time.GetUtcNow() });
 
-        sut.CountActiveRuns("alice").Should().Be(1, "a finished run is history, not load");
-        sut.CountActiveRuns("mallory").Should().Be(1);
-        sut.CountActiveRuns("nobody").Should().Be(0);
+        sut.TryCreate(Queued("job-2", targetId: workflow), maxActiveRunsPerOwner: 1)
+            .Should().Be(RunAdmission.Accepted);
     }
 
     [Fact]
-    public void Create_WithADuplicateJobId_Throws()
+    public void TryCreate_WithADuplicateJobId_Throws()
     {
         var sut = BuildSut();
-        sut.Create(Queued());
+        Admit(sut, Queued(targetId: "target-a"));
 
-        var act = () => sut.Create(Queued());
+        var act = () => sut.TryCreate(Queued(targetId: "target-b"), UncappedOwner);
 
         act.Should().Throw<InvalidOperationException>();
     }

--- a/src/Content/Tests/Infrastructure.AI.Tests/Runs/InMemoryRunJobStoreTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Runs/InMemoryRunJobStoreTests.cs
@@ -4,6 +4,7 @@ using Domain.AI.Runs;
 using Domain.Common.Config;
 using FluentAssertions;
 using Infrastructure.AI.Runs;
+using Infrastructure.AI.Tests.Runs.Support;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Time.Testing;
 using Xunit;
@@ -23,13 +24,6 @@ namespace Infrastructure.AI.Tests.Runs;
 public sealed class InMemoryRunJobStoreTests
 {
     private const int UncappedOwner = int.MaxValue;
-
-    private sealed class StaticOptionsMonitor<T>(T value) : IOptionsMonitor<T>
-    {
-        public T CurrentValue { get; } = value;
-        public T Get(string? name) => CurrentValue;
-        public IDisposable? OnChange(Action<T, string?> listener) => null;
-    }
 
     private readonly FakeTimeProvider _time = new(new DateTimeOffset(2026, 7, 29, 12, 0, 0, TimeSpan.Zero));
     private readonly AppConfig _config = new();

--- a/src/Content/Tests/Infrastructure.AI.Tests/Runs/InMemoryRunJobStoreTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Runs/InMemoryRunJobStoreTests.cs
@@ -41,12 +41,16 @@ public sealed class InMemoryRunJobStoreTests
     }
 
     private RunRecord Queued(
-        string jobId = "job-1", string ownerId = "alice", string? targetId = null) => new()
+        string jobId = "job-1",
+        string ownerId = "alice",
+        string? targetId = null,
+        string? tenantId = null) => new()
     {
         JobId = jobId,
         Kind = RunKind.Workflow,
         TargetId = targetId ?? Guid.NewGuid().ToString(),
         OwnerId = ownerId,
+        TenantId = tenantId,
         Envelope = new CapabilityEnvelope(),
         Status = RunStatus.Queued,
         CreatedAt = _time.GetUtcNow()
@@ -116,7 +120,7 @@ public sealed class InMemoryRunJobStoreTests
         var second = sut.TryCreate(Queued("job-2", targetId: workflow), UncappedOwner);
 
         second.Should().Be(RunAdmission.TargetAlreadyRunning);
-        sut.Get("job-2", "alice").Should().BeNull("a refused run must not be stored");
+        sut.Get("job-2", "alice", null).Should().BeNull("a refused run must not be stored");
     }
 
     [Fact]
@@ -251,9 +255,35 @@ public sealed class InMemoryRunJobStoreTests
         var sut = BuildSut();
         Admit(sut, Queued(ownerId: "alice"));
 
-        sut.Get("job-1", "mallory").Should().BeNull();
-        sut.Get("no-such-job", "mallory").Should().BeNull();
-        sut.Get("job-1", "alice").Should().NotBeNull();
+        sut.Get("job-1", "mallory", null).Should().BeNull();
+        sut.Get("no-such-job", "mallory", null).Should().BeNull();
+        sut.Get("job-1", "alice", null).Should().NotBeNull();
+    }
+
+    [Fact]
+    public void Get_ByTheSameOwnerIdInAnotherTenant_IsIndistinguishableFromMissing()
+    {
+        // Plan ownership is decided on tenant AND owner on this same request path. Comparing only the
+        // owner here is invisible while an issuer is pinned to one tenant — and is a cross-tenant read
+        // the day it is not.
+        var sut = BuildSut();
+        Admit(sut, Queued(ownerId: "alice", tenantId: "acme"));
+
+        sut.Get("job-1", "alice", "other-tenant").Should().BeNull();
+        sut.Get("job-1", "alice", null).Should().BeNull();
+        sut.Get("job-1", "alice", "acme").Should().NotBeNull();
+    }
+
+    [Fact]
+    public void TryCreate_CountsTheSameOwnerInAnotherTenantSeparately()
+    {
+        // Same two legs as the read. One principal's load is its own; another tenant's caller sharing
+        // an identifier string is a different principal and must not consume this one's allowance.
+        var sut = BuildSut();
+        Admit(sut, Queued("job-1", ownerId: "alice", tenantId: "acme"), cap: 1);
+
+        sut.TryCreate(Queued("job-2", ownerId: "alice", tenantId: "other-tenant"), maxActiveRunsPerOwner: 1)
+            .Should().Be(RunAdmission.Accepted);
     }
 
     [Fact]
@@ -265,7 +295,7 @@ public sealed class InMemoryRunJobStoreTests
         var sut = BuildSut();
         Admit(sut, Queued(ownerId: "Alice"));
 
-        sut.Get("job-1", "alice").Should().NotBeNull();
+        sut.Get("job-1", "alice", null).Should().NotBeNull();
     }
 
     [Fact]
@@ -278,7 +308,7 @@ public sealed class InMemoryRunJobStoreTests
         _time.Advance(TimeSpan.FromDays(7));
 
         sut.SweepExpired().Should().Be(0);
-        sut.Get("job-1", "alice").Should().NotBeNull();
+        sut.Get("job-1", "alice", null).Should().NotBeNull();
     }
 
     [Fact]
@@ -294,7 +324,7 @@ public sealed class InMemoryRunJobStoreTests
 
         _time.Advance(TimeSpan.FromMinutes(2));
         sut.SweepExpired().Should().Be(1);
-        sut.Get("job-1", "alice").Should().BeNull();
+        sut.Get("job-1", "alice", null).Should().BeNull();
     }
 
     [Fact]
@@ -311,7 +341,7 @@ public sealed class InMemoryRunJobStoreTests
         _time.Advance(TimeSpan.FromMinutes(5));
 
         sut.SweepExpired().Should().Be(0, "retention runs from completion, not from acceptance");
-        sut.Get("job-1", "alice").Should().NotBeNull();
+        sut.Get("job-1", "alice", null).Should().NotBeNull();
     }
 
     [Theory]

--- a/src/Content/Tests/Infrastructure.AI.Tests/Runs/InMemoryRunJobStoreTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Runs/InMemoryRunJobStoreTests.cs
@@ -1,0 +1,189 @@
+using Application.AI.Common.Interfaces.Runs;
+using Domain.AI.Bundles;
+using Domain.AI.Runs;
+using Domain.Common.Config;
+using FluentAssertions;
+using Infrastructure.AI.Runs;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Time.Testing;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Runs;
+
+/// <summary>
+/// Tests for <see cref="InMemoryRunJobStore"/>.
+/// </summary>
+/// <remarks>
+/// Two properties carry real consequences and are tested hardest: a run must be armed exactly once,
+/// because duplicate execution here is duplicate model and tool spend rather than a duplicate row;
+/// and a run must be invisible to anyone but its owner, because the job identifier is the only thing
+/// standing between callers.
+/// </remarks>
+public sealed class InMemoryRunJobStoreTests
+{
+    private sealed class StaticOptionsMonitor<T>(T value) : IOptionsMonitor<T>
+    {
+        public T CurrentValue { get; } = value;
+        public T Get(string? name) => CurrentValue;
+        public IDisposable? OnChange(Action<T, string?> listener) => null;
+    }
+
+    private readonly FakeTimeProvider _time = new(new DateTimeOffset(2026, 7, 29, 12, 0, 0, TimeSpan.Zero));
+    private readonly AppConfig _config = new();
+
+    private IRunJobStore BuildSut(TimeSpan? ttl = null)
+    {
+        _config.AI.WorkflowSubmission.RunRecordTtl = ttl ?? TimeSpan.FromHours(1);
+        return new InMemoryRunJobStore(new StaticOptionsMonitor<AppConfig>(_config), _time);
+    }
+
+    private RunRecord Queued(string jobId = "job-1", string ownerId = "alice") => new()
+    {
+        JobId = jobId,
+        Kind = RunKind.Workflow,
+        TargetId = Guid.NewGuid().ToString(),
+        OwnerId = ownerId,
+        Envelope = new CapabilityEnvelope(),
+        Status = RunStatus.Queued,
+        CreatedAt = _time.GetUtcNow()
+    };
+
+    [Fact]
+    public void TryBeginRun_UnderConcurrency_ArmsExactlyOnce()
+    {
+        // The property duplicate execution depends on. A redelivered queue message or a second
+        // dispatcher must lose, not run the same workflow again.
+        var sut = BuildSut();
+        sut.Create(Queued());
+
+        var winners = 0;
+        var threads = Enumerable.Range(0, 32).Select(_ => new Thread(() =>
+        {
+            if (sut.TryBeginRun("job-1", _time.GetUtcNow()) is not null)
+                Interlocked.Increment(ref winners);
+        })).ToList();
+
+        foreach (var thread in threads) thread.Start();
+        foreach (var thread in threads) thread.Join();
+
+        winners.Should().Be(1, "exactly one caller may claim a queued run");
+    }
+
+    [Fact]
+    public void TryBeginRun_AlreadyRunning_ReturnsNull()
+    {
+        var sut = BuildSut();
+        sut.Create(Queued());
+
+        sut.TryBeginRun("job-1", _time.GetUtcNow()).Should().NotBeNull();
+        sut.TryBeginRun("job-1", _time.GetUtcNow()).Should().BeNull();
+    }
+
+    [Fact]
+    public void TryBeginRun_RecordsTheClaimTimeAndMovesToRunning()
+    {
+        var sut = BuildSut();
+        sut.Create(Queued());
+        var claimedAt = _time.GetUtcNow();
+
+        var claimed = sut.TryBeginRun("job-1", claimedAt);
+
+        claimed!.Status.Should().Be(RunStatus.Running);
+        claimed.StartedAt.Should().Be(claimedAt);
+    }
+
+    [Fact]
+    public void Get_ByAnotherOwner_IsIndistinguishableFromMissing()
+    {
+        var sut = BuildSut();
+        sut.Create(Queued(ownerId: "alice"));
+
+        sut.Get("job-1", "mallory").Should().BeNull();
+        sut.Get("no-such-job", "mallory").Should().BeNull();
+        sut.Get("job-1", "alice").Should().NotBeNull();
+    }
+
+    [Fact]
+    public void Get_OwnerComparison_IsOrdinal()
+    {
+        // Ordinal everywhere, matching how ownership is compared elsewhere. A case-insensitive match
+        // here would let two identities the rest of the system treats as distinct read each other.
+        var sut = BuildSut();
+        sut.Create(Queued(ownerId: "Alice"));
+
+        sut.Get("job-1", "alice").Should().BeNull();
+    }
+
+    [Fact]
+    public void SweepExpired_NeverReclaimsAnUnfinishedRun()
+    {
+        // A queued or running job the caller is still polling must not vanish, however long it takes.
+        var sut = BuildSut(ttl: TimeSpan.FromMinutes(5));
+        sut.Create(Queued());
+
+        _time.Advance(TimeSpan.FromDays(7));
+
+        sut.SweepExpired().Should().Be(0);
+        sut.Get("job-1", "alice").Should().NotBeNull();
+    }
+
+    [Fact]
+    public void SweepExpired_ReclaimsAFinishedRunOnlyAfterItsRetentionElapses()
+    {
+        var sut = BuildSut(ttl: TimeSpan.FromMinutes(5));
+        sut.Create(Queued());
+        var claimed = sut.TryBeginRun("job-1", _time.GetUtcNow())!;
+        sut.Update(claimed with { Status = RunStatus.Succeeded, CompletedAt = _time.GetUtcNow() });
+
+        _time.Advance(TimeSpan.FromMinutes(4));
+        sut.SweepExpired().Should().Be(0);
+
+        _time.Advance(TimeSpan.FromMinutes(2));
+        sut.SweepExpired().Should().Be(1);
+        sut.Get("job-1", "alice").Should().BeNull();
+    }
+
+    [Fact]
+    public void Update_RestartsRetentionFromCompletionNotAcceptance()
+    {
+        // A run that waited a long time in the queue still gets its full readable window afterwards.
+        var sut = BuildSut(ttl: TimeSpan.FromMinutes(10));
+        sut.Create(Queued());
+
+        _time.Advance(TimeSpan.FromMinutes(9));
+        var claimed = sut.TryBeginRun("job-1", _time.GetUtcNow())!;
+        sut.Update(claimed with { Status = RunStatus.Succeeded, CompletedAt = _time.GetUtcNow() });
+
+        _time.Advance(TimeSpan.FromMinutes(5));
+
+        sut.SweepExpired().Should().Be(0, "retention runs from completion, not from acceptance");
+        sut.Get("job-1", "alice").Should().NotBeNull();
+    }
+
+    [Fact]
+    public void CountActiveRuns_CountsOnlyTheCallersUnfinishedRuns()
+    {
+        var sut = BuildSut();
+        sut.Create(Queued("a", "alice"));
+        sut.Create(Queued("b", "alice"));
+        sut.Create(Queued("c", "mallory"));
+
+        var finished = sut.TryBeginRun("b", _time.GetUtcNow())!;
+        sut.Update(finished with { Status = RunStatus.Succeeded, CompletedAt = _time.GetUtcNow() });
+
+        sut.CountActiveRuns("alice").Should().Be(1, "a finished run is history, not load");
+        sut.CountActiveRuns("mallory").Should().Be(1);
+        sut.CountActiveRuns("nobody").Should().Be(0);
+    }
+
+    [Fact]
+    public void Create_WithADuplicateJobId_Throws()
+    {
+        var sut = BuildSut();
+        sut.Create(Queued());
+
+        var act = () => sut.Create(Queued());
+
+        act.Should().Throw<InvalidOperationException>();
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Runs/RunDispatchBackgroundServiceTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Runs/RunDispatchBackgroundServiceTests.cs
@@ -92,12 +92,13 @@ public sealed class RunDispatchBackgroundServiceTests
         if (registerScopeWriter)
             services.AddSingleton<IKnowledgeScopeWriter>(_scopeWriter);
 
-        var store = new InMemoryRunJobStore(new StaticOptionsMonitor<AppConfig>(_config), _time);
+        var monitor = new StaticOptionsMonitor<AppConfig>(_config);
+        var store = new InMemoryRunJobStore(monitor, _time);
         var queue = new InMemoryRunDispatchQueue();
 
         var service = new RunDispatchBackgroundService(
             queue, store, services.BuildServiceProvider().GetRequiredService<IServiceScopeFactory>(),
-            _time, NullLogger<RunDispatchBackgroundService>.Instance);
+            monitor, _time, NullLogger<RunDispatchBackgroundService>.Instance);
 
         return (service, store, queue);
     }
@@ -127,7 +128,7 @@ public sealed class RunDispatchBackgroundServiceTests
         RunRecord? record = null;
         for (var attempt = 0; attempt < 200; attempt++)
         {
-            record = store.Get(jobId, "alice");
+            record = store.Get(jobId, "alice", "acme");
             if (record?.IsTerminal == true)
                 break;
 
@@ -283,7 +284,7 @@ public sealed class RunDispatchBackgroundServiceTests
         // never configured to execute that kind of work — a different problem with a different fix.
         orphan.Error.Should().Contain("cannot execute that kind of run");
 
-        store.Get("job-1", "alice")!.IsTerminal.Should().BeTrue(
+        store.Get("job-1", "alice", "acme")!.IsTerminal.Should().BeTrue(
             "the dispatcher must keep draining after a run it cannot execute");
     }
 
@@ -305,6 +306,95 @@ public sealed class RunDispatchBackgroundServiceTests
         await service.StopAsync(CancellationToken.None);
 
         executor.Invocations.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task RunsExecuteConcurrentlyUpToTheConfiguredDegree()
+    {
+        // Awaiting each run before dequeuing the next makes host-wide throughput exactly one, so any
+        // caller's long workflow delays every other caller's — and it makes the per-owner cap read as
+        // a concurrency allowance the host never honours.
+        _config.AI.WorkflowSubmission.MaxConcurrentDispatchedRuns = 3;
+
+        var running = 0;
+        var peak = 0;
+        using var release = new SemaphoreSlim(0, 3);
+
+        var executor = new StubExecutor(async _ =>
+        {
+            var now = Interlocked.Increment(ref running);
+            InterlockedMax(ref peak, now);
+            await release.WaitAsync();
+            Interlocked.Decrement(ref running);
+            return Result<RunCompletion>.Success(RunCompletion.Succeeded());
+        });
+
+        var (service, store, queue) = Build(executor);
+        for (var i = 0; i < 3; i++)
+        {
+            Admit(store, Queued($"job-{i}"));
+            await queue.EnqueueAsync($"job-{i}", CancellationToken.None);
+        }
+
+        using var cts = new CancellationTokenSource();
+        await service.StartAsync(cts.Token);
+
+        for (var attempt = 0; attempt < 200 && Volatile.Read(in peak) < 3; attempt++)
+            await Task.Delay(10);
+
+        release.Release(3);
+        await cts.CancelAsync();
+        await service.StopAsync(CancellationToken.None);
+
+        peak.Should().Be(3, "the dispatcher must run up to its configured degree at once");
+    }
+
+    [Fact]
+    public async Task NoMoreRunsExecuteAtOnceThanTheConfiguredDegree()
+    {
+        // The other half of the same property. Unbounded dispatch would let one burst of accepted work
+        // start every run simultaneously, which is what the degree exists to prevent.
+        _config.AI.WorkflowSubmission.MaxConcurrentDispatchedRuns = 2;
+
+        var running = 0;
+        var peak = 0;
+        using var release = new SemaphoreSlim(0, 6);
+
+        var executor = new StubExecutor(async _ =>
+        {
+            var now = Interlocked.Increment(ref running);
+            InterlockedMax(ref peak, now);
+            await release.WaitAsync();
+            Interlocked.Decrement(ref running);
+            return Result<RunCompletion>.Success(RunCompletion.Succeeded());
+        });
+
+        var (service, store, queue) = Build(executor);
+        for (var i = 0; i < 6; i++)
+        {
+            Admit(store, Queued($"job-{i}"));
+            await queue.EnqueueAsync($"job-{i}", CancellationToken.None);
+        }
+
+        using var cts = new CancellationTokenSource();
+        await service.StartAsync(cts.Token);
+        await Task.Delay(250);
+
+        peak.Should().BeLessThanOrEqualTo(2);
+
+        release.Release(6);
+        await cts.CancelAsync();
+        await service.StopAsync(CancellationToken.None);
+    }
+
+    private static void InterlockedMax(ref int target, int candidate)
+    {
+        int seen;
+        while ((seen = Volatile.Read(in target)) < candidate
+               && Interlocked.CompareExchange(ref target, candidate, seen) != seen)
+        {
+            // Another thread moved the peak while we were deciding; re-read and try again.
+        }
     }
 
     [Fact]

--- a/src/Content/Tests/Infrastructure.AI.Tests/Runs/RunDispatchBackgroundServiceTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Runs/RunDispatchBackgroundServiceTests.cs
@@ -1,0 +1,203 @@
+using Application.AI.Common.Interfaces.Runs;
+using Domain.AI.Bundles;
+using Domain.AI.Runs;
+using Domain.Common;
+using Domain.Common.Config;
+using FluentAssertions;
+using Infrastructure.AI.Runs;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Time.Testing;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Runs;
+
+/// <summary>
+/// Tests for <see cref="RunDispatchBackgroundService"/>.
+/// </summary>
+/// <remarks>
+/// The property that matters most is that a claimed run always reaches a terminal state. Once a run
+/// is claimed it is <see cref="RunStatus.Running"/>, and only the dispatcher can move it out of that
+/// state — so any path that escapes without recording an outcome leaves a caller polling a run
+/// nothing will ever finish.
+/// </remarks>
+public sealed class RunDispatchBackgroundServiceTests
+{
+    private sealed class StaticOptionsMonitor<T>(T value) : IOptionsMonitor<T>
+    {
+        public T CurrentValue { get; } = value;
+        public T Get(string? name) => CurrentValue;
+        public IDisposable? OnChange(Action<T, string?> listener) => null;
+    }
+
+    private sealed class StubExecutor(Func<RunRecord, Task<Result>> behaviour) : IRunKindExecutor
+    {
+        public int Invocations { get; private set; }
+
+        public Task<Result> ExecuteAsync(RunRecord record, CancellationToken cancellationToken)
+        {
+            Invocations++;
+            return behaviour(record);
+        }
+    }
+
+    private readonly FakeTimeProvider _time = new(new DateTimeOffset(2026, 7, 29, 12, 0, 0, TimeSpan.Zero));
+    private readonly AppConfig _config = new();
+
+    private (RunDispatchBackgroundService Service, IRunJobStore Store, IRunDispatchQueue Queue) Build(
+        IRunKindExecutor? executor)
+    {
+        var services = new ServiceCollection();
+        if (executor is not null)
+            services.AddKeyedSingleton(RunKind.Workflow, executor);
+
+        var store = new InMemoryRunJobStore(new StaticOptionsMonitor<AppConfig>(_config), _time);
+        var queue = new InMemoryRunDispatchQueue();
+
+        var service = new RunDispatchBackgroundService(
+            queue, store, services.BuildServiceProvider().GetRequiredService<IServiceScopeFactory>(),
+            _time, NullLogger<RunDispatchBackgroundService>.Instance);
+
+        return (service, store, queue);
+    }
+
+    private RunRecord Queued(string jobId = "job-1") => new()
+    {
+        JobId = jobId,
+        Kind = RunKind.Workflow,
+        TargetId = Guid.NewGuid().ToString(),
+        OwnerId = "alice",
+        Envelope = new CapabilityEnvelope(),
+        Status = RunStatus.Queued,
+        CreatedAt = _time.GetUtcNow()
+    };
+
+    /// <summary>Runs the dispatcher until <paramref name="jobId"/> is terminal, or the attempt budget is spent.</summary>
+    private static async Task<RunRecord?> DrainUntilTerminalAsync(
+        RunDispatchBackgroundService service, IRunJobStore store, string jobId)
+    {
+        using var cts = new CancellationTokenSource();
+        await service.StartAsync(cts.Token);
+
+        RunRecord? record = null;
+        for (var attempt = 0; attempt < 200; attempt++)
+        {
+            record = store.Get(jobId, "alice");
+            if (record?.IsTerminal == true)
+                break;
+
+            await Task.Delay(10);
+        }
+
+        await cts.CancelAsync();
+        await service.StopAsync(CancellationToken.None);
+        return record;
+    }
+
+    [Fact]
+    public async Task ASuccessfulRun_IsRecordedSucceeded()
+    {
+        var executor = new StubExecutor(_ => Task.FromResult(Result.Success()));
+        var (service, store, queue) = Build(executor);
+        store.Create(Queued());
+        await queue.EnqueueAsync("job-1", CancellationToken.None);
+
+        var record = await DrainUntilTerminalAsync(service, store, "job-1");
+
+        record!.Status.Should().Be(RunStatus.Succeeded);
+        record.CompletedAt.Should().NotBeNull();
+        executor.Invocations.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task AFailedRun_KeepsTheExecutorsReason()
+    {
+        // The executor's messages are caller-safe by contract, so they reach the caller rather than
+        // being flattened into a uniform "it failed" that says nothing actionable.
+        var executor = new StubExecutor(_ => Task.FromResult(Result.Fail("the model deployment was rejected")));
+        var (service, store, queue) = Build(executor);
+        store.Create(Queued());
+        await queue.EnqueueAsync("job-1", CancellationToken.None);
+
+        var record = await DrainUntilTerminalAsync(service, store, "job-1");
+
+        record!.Status.Should().Be(RunStatus.Failed);
+        record.Error.Should().Contain("the model deployment was rejected");
+    }
+
+    [Fact]
+    public async Task AnExecutorThatThrows_StillLeavesTheRunTerminal()
+    {
+        // The stranding case. Without a guard around the claimed run, this leaves it Running forever
+        // and a caller polls a job nothing will ever finish.
+        var executor = new StubExecutor(_ => throw new InvalidOperationException("boom"));
+        var (service, store, queue) = Build(executor);
+        store.Create(Queued());
+        await queue.EnqueueAsync("job-1", CancellationToken.None);
+
+        var record = await DrainUntilTerminalAsync(service, store, "job-1");
+
+        record!.Status.Should().Be(RunStatus.Failed);
+        record.Error.Should().NotContain("boom", "the caller gets a stable reason, not exception text");
+    }
+
+    [Fact]
+    public async Task AKindWithNoRegisteredExecutor_FailsThatRunRatherThanTheDispatcher()
+    {
+        // A wiring gap must not take the loop down: that would turn one mis-registration into an
+        // outage for every other kind of work in the host.
+        var (service, store, queue) = Build(executor: null);
+        store.Create(Queued("orphan"));
+        store.Create(Queued("job-1"));
+        await queue.EnqueueAsync("orphan", CancellationToken.None);
+        await queue.EnqueueAsync("job-1", CancellationToken.None);
+
+        var orphan = await DrainUntilTerminalAsync(service, store, "orphan");
+
+        orphan!.Status.Should().Be(RunStatus.Failed);
+
+        // The reason must name the wiring gap. Letting this fall through to the generic
+        // "failed unexpectedly" guard would tell an operator the run broke, when in fact the host was
+        // never configured to execute that kind of work — a different problem with a different fix.
+        orphan.Error.Should().Contain("cannot execute that kind of run");
+
+        store.Get("job-1", "alice")!.IsTerminal.Should().BeTrue(
+            "the dispatcher must keep draining after a run it cannot execute");
+    }
+
+    [Fact]
+    public async Task ARunAlreadyClaimed_IsSkippedRatherThanRunTwice()
+    {
+        // Redelivery is harmless precisely because the claim is what gates execution.
+        var executor = new StubExecutor(_ => Task.FromResult(Result.Success()));
+        var (service, store, queue) = Build(executor);
+        store.Create(Queued());
+        store.TryBeginRun("job-1", _time.GetUtcNow());
+
+        await queue.EnqueueAsync("job-1", CancellationToken.None);
+
+        using var cts = new CancellationTokenSource();
+        await service.StartAsync(cts.Token);
+        await Task.Delay(150);
+        await cts.CancelAsync();
+        await service.StopAsync(CancellationToken.None);
+
+        executor.Invocations.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task AnUnknownJobId_IsSkippedWithoutStoppingTheLoop()
+    {
+        var executor = new StubExecutor(_ => Task.FromResult(Result.Success()));
+        var (service, store, queue) = Build(executor);
+        store.Create(Queued("real"));
+
+        await queue.EnqueueAsync("never-existed", CancellationToken.None);
+        await queue.EnqueueAsync("real", CancellationToken.None);
+
+        var record = await DrainUntilTerminalAsync(service, store, "real");
+
+        record!.Status.Should().Be(RunStatus.Succeeded);
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Runs/RunDispatchBackgroundServiceTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Runs/RunDispatchBackgroundServiceTests.cs
@@ -1,3 +1,4 @@
+using Application.AI.Common.Interfaces.KnowledgeGraph;
 using Application.AI.Common.Interfaces.Runs;
 using Domain.AI.Bundles;
 using Domain.AI.Runs;
@@ -17,10 +18,18 @@ namespace Infrastructure.AI.Tests.Runs;
 /// Tests for <see cref="RunDispatchBackgroundService"/>.
 /// </summary>
 /// <remarks>
+/// <para>
 /// The property that matters most is that a claimed run always reaches a terminal state. Once a run
 /// is claimed it is <see cref="RunStatus.Running"/>, and only the dispatcher can move it out of that
 /// state — so any path that escapes without recording an outcome leaves a caller polling a run
 /// nothing will ever finish.
+/// </para>
+/// <para>
+/// The second is that the run executes as the caller who started it. Scope is ambient and set at an
+/// HTTP entry point; it does not survive the hop onto this thread. Unscoped is not a harmless default
+/// in this codebase — an absent owner reads as a global record — so the dispatcher must either
+/// establish the run's identity or refuse to run it.
+/// </para>
 /// </remarks>
 public sealed class RunDispatchBackgroundServiceTests
 {
@@ -31,26 +40,57 @@ public sealed class RunDispatchBackgroundServiceTests
         public IDisposable? OnChange(Action<T, string?> listener) => null;
     }
 
-    private sealed class StubExecutor(Func<RunRecord, Task<Result>> behaviour) : IRunKindExecutor
+    private sealed class StubExecutor(Func<RunRecord, Task<Result<RunCompletion>>> behaviour) : IRunKindExecutor
     {
         public int Invocations { get; private set; }
 
-        public Task<Result> ExecuteAsync(RunRecord record, CancellationToken cancellationToken)
+        public Task<Result<RunCompletion>> ExecuteAsync(RunRecord record, CancellationToken cancellationToken)
         {
             Invocations++;
             return behaviour(record);
         }
     }
 
+    /// <summary>
+    /// Records the scope armed around each job, and whether it was still armed when the executor ran.
+    /// </summary>
+    private sealed class RecordingScopeWriter : IKnowledgeScopeWriter
+    {
+        private sealed class Restore(RecordingScopeWriter owner) : IDisposable
+        {
+            public void Dispose() => owner.Current = null;
+        }
+
+        public (string? UserId, string? TenantId)? Current { get; private set; }
+
+        public List<(string? UserId, string? TenantId)> Armed { get; } = [];
+
+        public IDisposable SetScope(
+            string? userId = null,
+            string? tenantId = null,
+            string? datasetId = null,
+            string? datasetName = null,
+            string? datasetOwnerId = null)
+        {
+            Current = (userId, tenantId);
+            Armed.Add((userId, tenantId));
+            return new Restore(this);
+        }
+    }
+
     private readonly FakeTimeProvider _time = new(new DateTimeOffset(2026, 7, 29, 12, 0, 0, TimeSpan.Zero));
     private readonly AppConfig _config = new();
+    private readonly RecordingScopeWriter _scopeWriter = new();
 
     private (RunDispatchBackgroundService Service, IRunJobStore Store, IRunDispatchQueue Queue) Build(
-        IRunKindExecutor? executor)
+        IRunKindExecutor? executor, bool registerScopeWriter = true)
     {
         var services = new ServiceCollection();
         if (executor is not null)
             services.AddKeyedSingleton(RunKind.Workflow, executor);
+
+        if (registerScopeWriter)
+            services.AddSingleton<IKnowledgeScopeWriter>(_scopeWriter);
 
         var store = new InMemoryRunJobStore(new StaticOptionsMonitor<AppConfig>(_config), _time);
         var queue = new InMemoryRunDispatchQueue();
@@ -62,16 +102,20 @@ public sealed class RunDispatchBackgroundServiceTests
         return (service, store, queue);
     }
 
-    private RunRecord Queued(string jobId = "job-1") => new()
+    private RunRecord Queued(string jobId = "job-1", string ownerId = "alice", string? tenantId = "acme") => new()
     {
         JobId = jobId,
         Kind = RunKind.Workflow,
         TargetId = Guid.NewGuid().ToString(),
-        OwnerId = "alice",
+        OwnerId = ownerId,
+        TenantId = tenantId,
         Envelope = new CapabilityEnvelope(),
         Status = RunStatus.Queued,
         CreatedAt = _time.GetUtcNow()
     };
+
+    private static void Admit(IRunJobStore store, RunRecord record) =>
+        store.TryCreate(record, int.MaxValue).Should().Be(RunAdmission.Accepted);
 
     /// <summary>Runs the dispatcher until <paramref name="jobId"/> is terminal, or the attempt budget is spent.</summary>
     private static async Task<RunRecord?> DrainUntilTerminalAsync(
@@ -98,9 +142,9 @@ public sealed class RunDispatchBackgroundServiceTests
     [Fact]
     public async Task ASuccessfulRun_IsRecordedSucceeded()
     {
-        var executor = new StubExecutor(_ => Task.FromResult(Result.Success()));
+        var executor = new StubExecutor(_ => Task.FromResult(Result<RunCompletion>.Success(RunCompletion.Succeeded())));
         var (service, store, queue) = Build(executor);
-        store.Create(Queued());
+        Admit(store, Queued());
         await queue.EnqueueAsync("job-1", CancellationToken.None);
 
         var record = await DrainUntilTerminalAsync(service, store, "job-1");
@@ -111,19 +155,96 @@ public sealed class RunDispatchBackgroundServiceTests
     }
 
     [Fact]
+    public async Task TheRunsOwnerAndTenantAreArmedBeforeTheExecutorRuns()
+    {
+        // The whole point of carrying identity on the record. Without this the executor runs as nobody,
+        // and in this codebase nobody reads as everybody — so the caller's own plan is invisible to its
+        // own run while every global record is not.
+        (string? UserId, string? TenantId)? seenByExecutor = null;
+        var executor = new StubExecutor(_ =>
+        {
+            seenByExecutor = _scopeWriter.Current;
+            return Task.FromResult(Result<RunCompletion>.Success(RunCompletion.Succeeded()));
+        });
+
+        var (service, store, queue) = Build(executor);
+        Admit(store, Queued(ownerId: "alice", tenantId: "acme"));
+        await queue.EnqueueAsync("job-1", CancellationToken.None);
+
+        await DrainUntilTerminalAsync(service, store, "job-1");
+
+        seenByExecutor.Should().Be(("alice", "acme"));
+    }
+
+    [Fact]
+    public async Task TheRunsScopeIsReleasedBeforeTheNextJob()
+    {
+        // Disposed per job, not per loop. Left armed, job N's caller stays ambient for job N+1 and the
+        // second run executes as the first user — a cross-owner read with no attacker required.
+        var executor = new StubExecutor(_ => Task.FromResult(Result<RunCompletion>.Success(RunCompletion.Succeeded())));
+        var (service, store, queue) = Build(executor);
+        Admit(store, Queued());
+        await queue.EnqueueAsync("job-1", CancellationToken.None);
+
+        await DrainUntilTerminalAsync(service, store, "job-1");
+
+        _scopeWriter.Armed.Should().ContainSingle();
+        _scopeWriter.Current.Should().BeNull("the scope must not outlive the job it was armed for");
+    }
+
+    [Fact]
+    public async Task AHostThatCannotEstablishIdentity_FailsTheRunRatherThanRunningItUnscoped()
+    {
+        // Running unscoped is not a degraded mode. An absent owner is read as a global record, so the
+        // work would silently see and touch every caller's data.
+        var executor = new StubExecutor(_ => Task.FromResult(Result<RunCompletion>.Success(RunCompletion.Succeeded())));
+        var (service, store, queue) = Build(executor, registerScopeWriter: false);
+        Admit(store, Queued());
+        await queue.EnqueueAsync("job-1", CancellationToken.None);
+
+        var record = await DrainUntilTerminalAsync(service, store, "job-1");
+
+        record!.Status.Should().Be(RunStatus.Failed);
+        record.Error.Should().Contain("identity");
+        executor.Invocations.Should().Be(0, "the work must not run at all");
+    }
+
+    [Fact]
     public async Task AFailedRun_KeepsTheExecutorsReason()
     {
         // The executor's messages are caller-safe by contract, so they reach the caller rather than
         // being flattened into a uniform "it failed" that says nothing actionable.
-        var executor = new StubExecutor(_ => Task.FromResult(Result.Fail("the model deployment was rejected")));
+        var executor = new StubExecutor(_ =>
+            Task.FromResult(Result<RunCompletion>.Fail("the model deployment was rejected")));
+
         var (service, store, queue) = Build(executor);
-        store.Create(Queued());
+        Admit(store, Queued());
         await queue.EnqueueAsync("job-1", CancellationToken.None);
 
         var record = await DrainUntilTerminalAsync(service, store, "job-1");
 
         record!.Status.Should().Be(RunStatus.Failed);
         record.Error.Should().Contain("the model deployment was rejected");
+    }
+
+    [Theory]
+    [InlineData(RunStatus.Cancelled)]
+    [InlineData(RunStatus.Blocked)]
+    public async Task AnOutcomeThatIsNeitherSuccessNorFailure_IsRecordedAsItself(RunStatus outcome)
+    {
+        // Work can end in more ways than worked and broke. Collapsing those onto a boolean is what
+        // makes a workflow parked awaiting an approval report to its caller as finished work.
+        var completion = new RunCompletion { Status = outcome, Detail = "waiting on a person" };
+        var executor = new StubExecutor(_ => Task.FromResult(Result<RunCompletion>.Success(completion)));
+
+        var (service, store, queue) = Build(executor);
+        Admit(store, Queued());
+        await queue.EnqueueAsync("job-1", CancellationToken.None);
+
+        var record = await DrainUntilTerminalAsync(service, store, "job-1");
+
+        record!.Status.Should().Be(outcome);
+        record.Error.Should().Be("waiting on a person");
     }
 
     [Fact]
@@ -133,7 +254,7 @@ public sealed class RunDispatchBackgroundServiceTests
         // and a caller polls a job nothing will ever finish.
         var executor = new StubExecutor(_ => throw new InvalidOperationException("boom"));
         var (service, store, queue) = Build(executor);
-        store.Create(Queued());
+        Admit(store, Queued());
         await queue.EnqueueAsync("job-1", CancellationToken.None);
 
         var record = await DrainUntilTerminalAsync(service, store, "job-1");
@@ -148,8 +269,8 @@ public sealed class RunDispatchBackgroundServiceTests
         // A wiring gap must not take the loop down: that would turn one mis-registration into an
         // outage for every other kind of work in the host.
         var (service, store, queue) = Build(executor: null);
-        store.Create(Queued("orphan"));
-        store.Create(Queued("job-1"));
+        Admit(store, Queued("orphan"));
+        Admit(store, Queued("job-1"));
         await queue.EnqueueAsync("orphan", CancellationToken.None);
         await queue.EnqueueAsync("job-1", CancellationToken.None);
 
@@ -170,9 +291,9 @@ public sealed class RunDispatchBackgroundServiceTests
     public async Task ARunAlreadyClaimed_IsSkippedRatherThanRunTwice()
     {
         // Redelivery is harmless precisely because the claim is what gates execution.
-        var executor = new StubExecutor(_ => Task.FromResult(Result.Success()));
+        var executor = new StubExecutor(_ => Task.FromResult(Result<RunCompletion>.Success(RunCompletion.Succeeded())));
         var (service, store, queue) = Build(executor);
-        store.Create(Queued());
+        Admit(store, Queued());
         store.TryBeginRun("job-1", _time.GetUtcNow());
 
         await queue.EnqueueAsync("job-1", CancellationToken.None);
@@ -189,9 +310,9 @@ public sealed class RunDispatchBackgroundServiceTests
     [Fact]
     public async Task AnUnknownJobId_IsSkippedWithoutStoppingTheLoop()
     {
-        var executor = new StubExecutor(_ => Task.FromResult(Result.Success()));
+        var executor = new StubExecutor(_ => Task.FromResult(Result<RunCompletion>.Success(RunCompletion.Succeeded())));
         var (service, store, queue) = Build(executor);
-        store.Create(Queued("real"));
+        Admit(store, Queued("real"));
 
         await queue.EnqueueAsync("never-existed", CancellationToken.None);
         await queue.EnqueueAsync("real", CancellationToken.None);

--- a/src/Content/Tests/Infrastructure.AI.Tests/Runs/RunDispatchBackgroundServiceTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Runs/RunDispatchBackgroundServiceTests.cs
@@ -378,9 +378,18 @@ public sealed class RunDispatchBackgroundServiceTests
 
         using var cts = new CancellationTokenSource();
         await service.StartAsync(cts.Token);
-        await Task.Delay(250);
 
-        peak.Should().BeLessThanOrEqualTo(2);
+        // Waits for dispatch to saturate rather than sleeping a fixed interval, then gives the loop a
+        // brief window to overshoot if it is going to. Six jobs are already queued before the service
+        // starts, so an unbounded loop would have all six running by the end of that window — the
+        // recorded peak is what catches it.
+        for (var attempt = 0; attempt < 200 && Volatile.Read(in peak) < 2; attempt++)
+            await Task.Delay(10);
+
+        await Task.Delay(50);
+
+        peak.Should().Be(2, "dispatch must reach the configured degree and must never exceed it");
+        Volatile.Read(in running).Should().BeLessThanOrEqualTo(2);
 
         release.Release(6);
         await cts.CancelAsync();

--- a/src/Content/Tests/Infrastructure.AI.Tests/Runs/RunDispatchBackgroundServiceTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Runs/RunDispatchBackgroundServiceTests.cs
@@ -6,6 +6,7 @@ using Domain.Common;
 using Domain.Common.Config;
 using FluentAssertions;
 using Infrastructure.AI.Runs;
+using Infrastructure.AI.Tests.Runs.Support;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
@@ -33,13 +34,6 @@ namespace Infrastructure.AI.Tests.Runs;
 /// </remarks>
 public sealed class RunDispatchBackgroundServiceTests
 {
-    private sealed class StaticOptionsMonitor<T>(T value) : IOptionsMonitor<T>
-    {
-        public T CurrentValue { get; } = value;
-        public T Get(string? name) => CurrentValue;
-        public IDisposable? OnChange(Action<T, string?> listener) => null;
-    }
-
     private sealed class StubExecutor(Func<RunRecord, Task<Result<RunCompletion>>> behaviour) : IRunKindExecutor
     {
         public int Invocations { get; private set; }

--- a/src/Content/Tests/Infrastructure.AI.Tests/Runs/RunRecordCleanupServiceTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Runs/RunRecordCleanupServiceTests.cs
@@ -4,6 +4,7 @@ using Domain.AI.Runs;
 using Domain.Common.Config;
 using FluentAssertions;
 using Infrastructure.AI.Runs;
+using Infrastructure.AI.Tests.Runs.Support;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Time.Testing;
@@ -23,13 +24,6 @@ namespace Infrastructure.AI.Tests.Runs;
 /// </remarks>
 public sealed class RunRecordCleanupServiceTests
 {
-    private sealed class StaticOptionsMonitor<T>(T value) : IOptionsMonitor<T>
-    {
-        public T CurrentValue { get; } = value;
-        public T Get(string? name) => CurrentValue;
-        public IDisposable? OnChange(Action<T, string?> listener) => null;
-    }
-
     /// <summary>
     /// Counts sweeps and what they reclaimed. Both are needed: an expired record is already hidden
     /// from <see cref="Get"/> before anything reclaims it, so absence proves nothing about whether the

--- a/src/Content/Tests/Infrastructure.AI.Tests/Runs/RunRecordCleanupServiceTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Runs/RunRecordCleanupServiceTests.cs
@@ -1,0 +1,113 @@
+using Application.AI.Common.Interfaces.Runs;
+using Domain.AI.Bundles;
+using Domain.AI.Runs;
+using Domain.Common.Config;
+using FluentAssertions;
+using Infrastructure.AI.Runs;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Time.Testing;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Runs;
+
+/// <summary>
+/// Tests for <see cref="RunRecordCleanupService"/>.
+/// </summary>
+/// <remarks>
+/// The store knows how to reclaim expired runs; the question here is whether anything ever asks it to.
+/// Without a caller the configured retention is a claim the host never honours, and every finished run
+/// — each holding the capability envelope it executed under — is held for the life of the process.
+/// That is exactly the shape of defect that hides from unit tests: the reclaiming logic is covered, so
+/// coverage looks complete while nothing invokes it.
+/// </remarks>
+public sealed class RunRecordCleanupServiceTests
+{
+    private sealed class StaticOptionsMonitor<T>(T value) : IOptionsMonitor<T>
+    {
+        public T CurrentValue { get; } = value;
+        public T Get(string? name) => CurrentValue;
+        public IDisposable? OnChange(Action<T, string?> listener) => null;
+    }
+
+    /// <summary>
+    /// Counts sweeps and what they reclaimed. Both are needed: an expired record is already hidden
+    /// from <see cref="Get"/> before anything reclaims it, so absence proves nothing about whether the
+    /// memory was ever given back.
+    /// </summary>
+    private sealed class CountingStore(IRunJobStore inner) : IRunJobStore
+    {
+        public int Sweeps { get; private set; }
+
+        public int Reclaimed { get; private set; }
+
+        public RunAdmission TryCreate(RunRecord record, int maxActiveRunsPerOwner) =>
+            inner.TryCreate(record, maxActiveRunsPerOwner);
+
+        public RunRecord? Get(string jobId, string ownerId) => inner.Get(jobId, ownerId);
+
+        public RunRecord? TryBeginRun(string jobId, DateTimeOffset startedAt) =>
+            inner.TryBeginRun(jobId, startedAt);
+
+        public bool Update(RunRecord record) => inner.Update(record);
+
+        public int SweepExpired()
+        {
+            Sweeps++;
+            var removed = inner.SweepExpired();
+            Reclaimed += removed;
+            return removed;
+        }
+    }
+
+    private readonly FakeTimeProvider _time = new(new DateTimeOffset(2026, 7, 29, 12, 0, 0, TimeSpan.Zero));
+    private readonly AppConfig _config = new();
+
+    [Fact]
+    public async Task TheServiceActuallyReclaimsFinishedRunsPastTheirRetention()
+    {
+        _config.AI.WorkflowSubmission.RunRecordTtl = TimeSpan.FromMinutes(5);
+
+        // Below the service's own floor, which clamps it to one second — the shortest a real sweep can
+        // be scheduled, and short enough for a test to observe one.
+        _config.AI.WorkflowSubmission.RunSweepInterval = TimeSpan.Zero;
+
+        var monitor = new StaticOptionsMonitor<AppConfig>(_config);
+        var store = new CountingStore(new InMemoryRunJobStore(monitor, _time));
+
+        store.TryCreate(Queued("finished"), int.MaxValue).Should().Be(RunAdmission.Accepted);
+        store.TryCreate(Queued("still-going"), int.MaxValue).Should().Be(RunAdmission.Accepted);
+
+        var claimed = store.TryBeginRun("finished", _time.GetUtcNow())!;
+        store.Update(claimed with { Status = RunStatus.Succeeded, CompletedAt = _time.GetUtcNow() });
+
+        _time.Advance(TimeSpan.FromHours(1));
+
+        var sut = new RunRecordCleanupService(store, monitor, NullLogger<RunRecordCleanupService>.Instance);
+
+        using var cts = new CancellationTokenSource();
+        await sut.StartAsync(cts.Token);
+
+        for (var attempt = 0; attempt < 60 && store.Sweeps == 0; attempt++)
+            await Task.Delay(100);
+
+        await cts.CancelAsync();
+        await sut.StopAsync(CancellationToken.None);
+
+        store.Sweeps.Should().BeGreaterThan(0, "nothing reclaims runs unless this service asks");
+        store.Reclaimed.Should().Be(1, "the finished run was past its retention and its memory is owed back");
+        store.Get("still-going", "alice").Should().NotBeNull(
+            "an unfinished run a caller is still polling must survive every sweep");
+    }
+
+    private RunRecord Queued(string jobId) => new()
+    {
+        JobId = jobId,
+        Kind = RunKind.Workflow,
+        TargetId = Guid.NewGuid().ToString(),
+        OwnerId = "alice",
+        Envelope = new CapabilityEnvelope(),
+        Status = RunStatus.Queued,
+        CreatedAt = _time.GetUtcNow()
+    };
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Runs/RunRecordCleanupServiceTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Runs/RunRecordCleanupServiceTests.cs
@@ -44,7 +44,8 @@ public sealed class RunRecordCleanupServiceTests
         public RunAdmission TryCreate(RunRecord record, int maxActiveRunsPerOwner) =>
             inner.TryCreate(record, maxActiveRunsPerOwner);
 
-        public RunRecord? Get(string jobId, string ownerId) => inner.Get(jobId, ownerId);
+        public RunRecord? Get(string jobId, string ownerId, string? tenantId) =>
+            inner.Get(jobId, ownerId, tenantId);
 
         public RunRecord? TryBeginRun(string jobId, DateTimeOffset startedAt) =>
             inner.TryBeginRun(jobId, startedAt);
@@ -96,7 +97,7 @@ public sealed class RunRecordCleanupServiceTests
 
         store.Sweeps.Should().BeGreaterThan(0, "nothing reclaims runs unless this service asks");
         store.Reclaimed.Should().Be(1, "the finished run was past its retention and its memory is owed back");
-        store.Get("still-going", "alice").Should().NotBeNull(
+        store.Get("still-going", "alice", null).Should().NotBeNull(
             "an unfinished run a caller is still polling must survive every sweep");
     }
 

--- a/src/Content/Tests/Infrastructure.AI.Tests/Runs/Support/RunTestConfig.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Runs/Support/RunTestConfig.cs
@@ -1,0 +1,24 @@
+using Microsoft.Extensions.Options;
+
+namespace Infrastructure.AI.Tests.Runs.Support;
+
+/// <summary>
+/// Shared configuration plumbing for the run-substrate tests.
+/// </summary>
+/// <remarks>
+/// Every test class here needs the same thing: a monitor that hands back one fixed
+/// <c>AppConfig</c> the test mutates directly. Following the <c>Support/TestConfig</c> shape already
+/// used by the Changes and Egress areas of this assembly, rather than each class carrying its own
+/// copy.
+/// </remarks>
+internal sealed class StaticOptionsMonitor<T>(T value) : IOptionsMonitor<T>
+{
+    /// <summary>The single configuration value this monitor reports.</summary>
+    public T CurrentValue { get; } = value;
+
+    /// <summary>Named options resolve to the same value; these tests use no named options.</summary>
+    public T Get(string? name) => CurrentValue;
+
+    /// <summary>No reload source exists, so nothing ever fires.</summary>
+    public IDisposable? OnChange(Action<T, string?> listener) => null;
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Runs/WorkflowRunKindExecutorTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Runs/WorkflowRunKindExecutorTests.cs
@@ -1,0 +1,141 @@
+using Application.AI.Common.Interfaces.Planner;
+using Domain.AI.Bundles;
+using Domain.AI.Planner;
+using Domain.AI.Runs;
+using Domain.Common;
+using FluentAssertions;
+using Infrastructure.AI.Runs;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Runs;
+
+/// <summary>
+/// Tests for <see cref="WorkflowRunKindExecutor"/>.
+/// </summary>
+/// <remarks>
+/// Almost all of this class is a translation: a plan's final status becomes a run's outcome. That
+/// translation is the whole of its risk. A plan can end in four ways and a run in four ways, and any
+/// mapping that folds two of them together tells a caller something untrue about work it paid for —
+/// most damagingly by reporting a workflow parked awaiting an approval as finished.
+/// </remarks>
+public sealed class WorkflowRunKindExecutorTests
+{
+    private readonly Mock<IPlanRunExecutor> _planRunExecutor = new();
+
+    private WorkflowRunKindExecutor BuildSut() =>
+        new(_planRunExecutor.Object, NullLogger<WorkflowRunKindExecutor>.Instance);
+
+    private static RunRecord Record(string? targetId = null) => new()
+    {
+        JobId = "job-1",
+        Kind = RunKind.Workflow,
+        TargetId = targetId ?? Guid.NewGuid().ToString(),
+        OwnerId = "alice",
+        TenantId = "acme",
+        Envelope = new CapabilityEnvelope(),
+        Status = RunStatus.Running,
+        CreatedAt = DateTimeOffset.UnixEpoch
+    };
+
+    private void PlanEndsWith(StepExecutionStatus finalStatus) =>
+        _planRunExecutor
+            .Setup(e => e.ExecuteAsync(It.IsAny<PlanRunRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<PlanExecutionSummary>.Success(new PlanExecutionSummary
+            {
+                PlanId = new PlanId(Guid.NewGuid()),
+                FinalStatus = finalStatus,
+                TotalDuration = TimeSpan.FromSeconds(1),
+                StepStates = []
+            }));
+
+    [Theory]
+    [InlineData(StepExecutionStatus.Completed, RunStatus.Succeeded)]
+    [InlineData(StepExecutionStatus.Failed, RunStatus.Failed)]
+    [InlineData(StepExecutionStatus.Cancelled, RunStatus.Cancelled)]
+    [InlineData(StepExecutionStatus.Blocked, RunStatus.Blocked)]
+    public async Task ThePlansFinalStatusBecomesTheRunsOutcome(
+        StepExecutionStatus finalStatus, RunStatus expected)
+    {
+        PlanEndsWith(finalStatus);
+
+        var result = await BuildSut().ExecuteAsync(Record(), CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue("the executor ran the work; how it ended is the answer, not a failure");
+        result.Value!.Status.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(StepExecutionStatus.Failed)]
+    [InlineData(StepExecutionStatus.Cancelled)]
+    [InlineData(StepExecutionStatus.Blocked)]
+    public async Task AnOutcomeThatIsNotSuccessCarriesAReason(StepExecutionStatus finalStatus)
+    {
+        // A caller that asked for work and did not get it is owed something it can act on. "Blocked"
+        // alone does not say a person has to approve something; "Cancelled" alone does not say the run
+        // was stopped rather than never started.
+        PlanEndsWith(finalStatus);
+
+        var result = await BuildSut().ExecuteAsync(Record(), CancellationToken.None);
+
+        result.Value!.Detail.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public async Task ThePlanIsRunUnderTheEnvelopeRecordedOnTheRun()
+    {
+        // The grant travels on the record precisely because the request that authorized it is long
+        // gone. Re-resolving it here would let a later change to the caller's permissions retroactively
+        // widen or narrow work already accepted.
+        PlanEndsWith(StepExecutionStatus.Completed);
+        PlanRunRequest? sent = null;
+        _planRunExecutor
+            .Setup(e => e.ExecuteAsync(It.IsAny<PlanRunRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<PlanRunRequest, CancellationToken>((request, _) => sent = request)
+            .ReturnsAsync(Result<PlanExecutionSummary>.Success(new PlanExecutionSummary
+            {
+                PlanId = new PlanId(Guid.NewGuid()),
+                FinalStatus = StepExecutionStatus.Completed,
+                TotalDuration = TimeSpan.Zero,
+                StepStates = []
+            }));
+
+        var workflowId = Guid.NewGuid();
+        var record = Record(workflowId.ToString());
+
+        await BuildSut().ExecuteAsync(record, CancellationToken.None);
+
+        sent.Should().NotBeNull();
+        sent!.PlanId.Should().Be(new PlanId(workflowId));
+        sent.Envelope.Should().BeSameAs(record.Envelope);
+    }
+
+    [Fact]
+    public async Task ATargetThatIsNotAWorkflowId_FailsThatRunRatherThanThrowing()
+    {
+        // Unreachable through the HTTP surface, which parses the id before accepting the run. It is
+        // still answered rather than thrown, so a malformed target fails one run instead of surfacing
+        // as an unexpected dispatcher exception.
+        var result = await BuildSut().ExecuteAsync(Record("not-a-guid"), CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        _planRunExecutor.Verify(
+            e => e.ExecuteAsync(It.IsAny<PlanRunRequest>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task AnExecutorThatCouldNotRunThePlan_IsAFailedResultRatherThanAnOutcome()
+    {
+        // The distinction the return type exists for: "I ran it and it ended this way" is not the same
+        // statement as "I could not run it", and only the second is a failed result.
+        _planRunExecutor
+            .Setup(e => e.ExecuteAsync(It.IsAny<PlanRunRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<PlanExecutionSummary>.Fail("plan_run.execution_failed"));
+
+        var result = await BuildSut().ExecuteAsync(Record(), CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Errors.Should().Contain("plan_run.execution_failed");
+    }
+}

--- a/src/Content/Tests/Presentation.ExecutionApi.Tests/WorkflowRunExecutionTests.cs
+++ b/src/Content/Tests/Presentation.ExecutionApi.Tests/WorkflowRunExecutionTests.cs
@@ -1,0 +1,214 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Application.AI.Common.Interfaces.Planner;
+using Domain.AI.Planner;
+using FluentAssertions;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using static Presentation.ExecutionApi.Tests.WorkflowRequests;
+
+namespace Presentation.ExecutionApi.Tests;
+
+/// <summary>
+/// Drives a submitted workflow all the way to a terminal status through the real host.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Every other test in this suite stops at acceptance — it asserts that a run was taken and that
+/// another caller cannot see it. That leaves the entire execution path unasserted, and two defects
+/// lived in exactly that gap: the dispatcher never re-established the caller's knowledge scope, so
+/// every run failed to load its own plan; and any plan that ended Blocked or Cancelled was reported to
+/// the caller as Succeeded. Both are invisible to a test that never polls past Queued.
+/// </para>
+/// <para>
+/// Only the leaf is substituted. The step executor for the step type under test is replaced so no
+/// model is called, and everything above it — admission, storage, the dispatcher, the scope, plan
+/// loading, the scheduler, status mapping, and the HTTP projection — is the host's own.
+/// </para>
+/// </remarks>
+public sealed class WorkflowRunExecutionTests
+{
+    /// <summary>Stands in for the model call, so the run's outcome is chosen by the test.</summary>
+    private sealed class ScriptedStepExecutor(StepExecutionStatus status, string? error = null) : IPlanStepExecutor
+    {
+        public Task<StepExecutionResult> ExecuteAsync(
+            PlanStep step,
+            IReadOnlyDictionary<PlanStepId, string> upstreamOutputs,
+            CancellationToken ct) =>
+            Task.FromResult(new StepExecutionResult
+            {
+                Status = status,
+                Output = status == StepExecutionStatus.Completed ? "done" : null,
+                ErrorMessage = error,
+                Duration = TimeSpan.FromMilliseconds(1)
+            });
+    }
+
+    private static WebApplicationFactory<Program> CreateFactory(StepExecutionStatus stepOutcome) =>
+        new WebApplicationFactory<Program>().WithWebHostBuilder(builder =>
+            builder.ConfigureTestServices(services =>
+            {
+                services
+                    .AddAuthentication(HeaderIdentityAuthenticationHandler.SchemeName)
+                    .AddScheme<AuthenticationSchemeOptions, HeaderIdentityAuthenticationHandler>(
+                        HeaderIdentityAuthenticationHandler.SchemeName, _ => { });
+
+                services.AddKeyedScoped<IPlanStepExecutor>(
+                    StepType.LlmCall, (_, _) => new ScriptedStepExecutor(stepOutcome));
+            }));
+
+    private static HttpRequestMessage Request(HttpMethod method, string url, object? body, string oid)
+    {
+        var request = new HttpRequestMessage(method, url);
+        if (body is not null)
+            request.Content = JsonContent.Create(body);
+
+        request.Headers.Add(HeaderIdentityAuthenticationHandler.UserHeader, oid);
+        request.Headers.Add(HeaderIdentityAuthenticationHandler.TenantHeader, "acme");
+        return request;
+    }
+
+    private static async Task<Guid> SubmitWorkflowAsync(HttpClient client, string oid)
+    {
+        var response = await client.SendAsync(
+            Request(HttpMethod.Post, "/api/workflows", Definition([LlmStep("only")]), oid));
+
+        var body = await response.Content.ReadAsStringAsync();
+        response.StatusCode.Should().Be(HttpStatusCode.Created, "submission failed with body: {0}", body);
+        return JsonDocument.Parse(body).RootElement.GetProperty("workflowId").GetGuid();
+    }
+
+    private static async Task<string> StartRunAsync(HttpClient client, Guid workflowId, string oid)
+    {
+        var started = await client.SendAsync(
+            Request(HttpMethod.Post, $"/api/workflows/{workflowId}/runs", body: null, oid));
+
+        var body = await started.Content.ReadAsStringAsync();
+        started.StatusCode.Should().Be(HttpStatusCode.Accepted, "start failed with body: {0}", body);
+        return JsonDocument.Parse(body).RootElement.GetProperty("jobId").GetString()!;
+    }
+
+    /// <summary>
+    /// Polls the run until it leaves the live states, then returns the final body.
+    /// </summary>
+    /// <remarks>
+    /// Paced at an interval a real client could sustain. The endpoint permits 60 requests a minute per
+    /// caller, and polling is the only way to learn a run's outcome, so a tight loop exhausts the
+    /// caller's whole budget in seconds and gets 503s that look like execution failures. A throttled
+    /// poll is treated as "ask again", not as an outcome — the overall attempt budget is what bounds
+    /// the wait.
+    /// </remarks>
+    private static async Task<JsonElement> PollUntilSettledAsync(
+        HttpClient client, Guid workflowId, string jobId, string oid)
+    {
+        var last = "no response";
+
+        for (var attempt = 0; attempt < 40; attempt++)
+        {
+            await Task.Delay(250);
+
+            var response = await client.SendAsync(
+                Request(HttpMethod.Get, $"/api/workflows/{workflowId}/runs/{jobId}", body: null, oid));
+
+            if (response.StatusCode == HttpStatusCode.ServiceUnavailable)
+            {
+                last = "throttled";
+                continue;
+            }
+
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+            last = body.ToString();
+
+            var status = body.GetProperty("status").GetString();
+            if (status is not ("Queued" or "Running"))
+                return body;
+        }
+
+        throw new Xunit.Sdk.XunitException($"The run never left the live states. Last response: {last}");
+    }
+
+    [Fact]
+    public async Task AWorkflowThatCompletes_IsReportedSucceeded()
+    {
+        // The headline capability. It failed 100% of the time before the dispatcher was taught to
+        // re-establish the run's identity: the plan was stored under alice, the dispatcher loaded it
+        // as nobody, and an owned plan is invisible to nobody — so every run died "Plan not found".
+        using var factory = CreateFactory(StepExecutionStatus.Completed);
+        using var client = factory.CreateClient();
+
+        var workflowId = await SubmitWorkflowAsync(client, "alice");
+        var jobId = await StartRunAsync(client, workflowId, "alice");
+
+        var body = await PollUntilSettledAsync(client, workflowId, jobId, "alice");
+
+        body.GetProperty("status").GetString().Should().Be("Succeeded");
+        body.GetProperty("completedAt").ValueKind.Should().NotBe(JsonValueKind.Null);
+    }
+
+    [Fact]
+    public async Task AWorkflowWhoseStepFails_IsReportedFailed()
+    {
+        using var factory = CreateFactory(StepExecutionStatus.Failed);
+        using var client = factory.CreateClient();
+
+        var workflowId = await SubmitWorkflowAsync(client, "alice");
+        var jobId = await StartRunAsync(client, workflowId, "alice");
+
+        var body = await PollUntilSettledAsync(client, workflowId, jobId, "alice");
+
+        body.GetProperty("status").GetString().Should().Be("Failed");
+        body.GetProperty("error").GetString().Should().NotBeNullOrWhiteSpace(
+            "a caller that asked for work is owed a reason it did not happen");
+    }
+
+    [Fact]
+    public async Task AWorkflowThatParksAwaitingAnApproval_IsNotReportedSucceeded()
+    {
+        // A plan can end Blocked, and a plan that ends Blocked produced no result. Reporting it as
+        // Succeeded tells a caller polling for an outcome that finished work exists, when in fact
+        // nothing has run past the gate and nobody has been asked to approve anything.
+        using var factory = CreateFactory(StepExecutionStatus.Blocked);
+        using var client = factory.CreateClient();
+
+        var workflowId = await SubmitWorkflowAsync(client, "alice");
+        var jobId = await StartRunAsync(client, workflowId, "alice");
+
+        var body = await PollUntilSettledAsync(client, workflowId, jobId, "alice");
+
+        body.GetProperty("status").GetString().Should().Be("Blocked");
+    }
+
+    [Fact]
+    public async Task ASecondRunOfALiveWorkflow_IsRefusedRatherThanSharingTheFirstsState()
+    {
+        // A workflow's execution state is keyed by the workflow, so two concurrent runs are not two
+        // executions — they are two schedulers driving one state machine, re-running each other's
+        // in-flight steps and adopting each other's outputs.
+        using var factory = CreateFactory(StepExecutionStatus.Completed);
+        using var client = factory.CreateClient();
+
+        var workflowId = await SubmitWorkflowAsync(client, "alice");
+        var jobId = await StartRunAsync(client, workflowId, "alice");
+
+        var second = await client.SendAsync(
+            Request(HttpMethod.Post, $"/api/workflows/{workflowId}/runs", body: null, "alice"));
+
+        // Either the first run is still live and the second is refused, or the first already finished
+        // and the second is admitted. Both are correct; what must never happen is two live at once.
+        if (second.StatusCode == HttpStatusCode.Accepted)
+        {
+            var first = await PollUntilSettledAsync(client, workflowId, jobId, "alice");
+            first.GetProperty("status").GetString().Should().NotBe("Running",
+                "a second run was admitted, so the first must already have been terminal");
+            return;
+        }
+
+        second.StatusCode.Should().Be(HttpStatusCode.Conflict);
+        await PollUntilSettledAsync(client, workflowId, jobId, "alice");
+    }
+}

--- a/src/Content/Tests/Presentation.ExecutionApi.Tests/WorkflowRunsIntegrationTests.cs
+++ b/src/Content/Tests/Presentation.ExecutionApi.Tests/WorkflowRunsIntegrationTests.cs
@@ -1,0 +1,180 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using static Presentation.ExecutionApi.Tests.WorkflowRequests;
+
+namespace Presentation.ExecutionApi.Tests;
+
+/// <summary>
+/// Full-stack tests for starting a workflow run and polling its status, driven through the real host
+/// with two distinct authenticated identities.
+/// </summary>
+/// <remarks>
+/// These exercise the whole path a caller actually takes — submit, start, poll — and the isolation
+/// between callers at each step. A job identifier is the only thing separating one caller's work from
+/// another's, so the cross-owner cases matter as much as the happy path.
+/// </remarks>
+public sealed class WorkflowRunsIntegrationTests
+{
+    private static WebApplicationFactory<Program> CreateFactory() =>
+        new WebApplicationFactory<Program>().WithWebHostBuilder(builder =>
+            builder.ConfigureTestServices(services => services
+                .AddAuthentication(HeaderIdentityAuthenticationHandler.SchemeName)
+                .AddScheme<AuthenticationSchemeOptions, HeaderIdentityAuthenticationHandler>(
+                    HeaderIdentityAuthenticationHandler.SchemeName, _ => { })));
+
+    private static HttpRequestMessage Request(HttpMethod method, string url, object? body, string oid)
+    {
+        var request = new HttpRequestMessage(method, url);
+        if (body is not null)
+            request.Content = JsonContent.Create(body);
+
+        request.Headers.Add(HeaderIdentityAuthenticationHandler.UserHeader, oid);
+        request.Headers.Add(HeaderIdentityAuthenticationHandler.TenantHeader, "acme");
+        return request;
+    }
+
+    private static async Task<Guid> SubmitWorkflowAsync(HttpClient client, string oid)
+    {
+        var response = await client.SendAsync(
+            Request(HttpMethod.Post, "/api/workflows", Definition([LlmStep("only")]), oid));
+
+        var body = await response.Content.ReadAsStringAsync();
+        response.StatusCode.Should().Be(HttpStatusCode.Created, "submission failed with body: {0}", body);
+        return JsonDocument.Parse(body).RootElement.GetProperty("workflowId").GetGuid();
+    }
+
+    [Fact]
+    public async Task StartingARun_IsAcceptedAndPollable()
+    {
+        using var factory = CreateFactory();
+        using var client = factory.CreateClient();
+
+        var workflowId = await SubmitWorkflowAsync(client, "alice");
+
+        var started = await client.SendAsync(
+            Request(HttpMethod.Post, $"/api/workflows/{workflowId}/runs", body: null, "alice"));
+
+        // Accepted, not OK: the work was taken, not finished. A 200 here would invite a caller to
+        // treat acceptance as a result.
+        started.StatusCode.Should().Be(HttpStatusCode.Accepted);
+
+        var startedBody = await started.Content.ReadFromJsonAsync<JsonElement>();
+        var jobId = startedBody.GetProperty("jobId").GetString();
+        jobId.Should().NotBeNullOrWhiteSpace();
+        startedBody.GetProperty("statusUrl").GetString().Should().Contain(jobId);
+
+        var status = await client.SendAsync(
+            Request(HttpMethod.Get, $"/api/workflows/{workflowId}/runs/{jobId}", body: null, "alice"));
+
+        status.StatusCode.Should().Be(HttpStatusCode.OK);
+        var statusBody = await status.Content.ReadFromJsonAsync<JsonElement>();
+        statusBody.GetProperty("jobId").GetString().Should().Be(jobId);
+        statusBody.GetProperty("workflowId").GetString().Should().Be(workflowId.ToString());
+    }
+
+    [Fact]
+    public async Task StatusResponse_NeverPublishesTheRunsCapabilityEnvelope()
+    {
+        // The envelope is the host's authorization state for the run, not the caller's business.
+        // Returning the stored record directly would publish the exact grant the run holds.
+        using var factory = CreateFactory();
+        using var client = factory.CreateClient();
+
+        var workflowId = await SubmitWorkflowAsync(client, "alice");
+        var started = await client.SendAsync(
+            Request(HttpMethod.Post, $"/api/workflows/{workflowId}/runs", body: null, "alice"));
+        var jobId = (await started.Content.ReadFromJsonAsync<JsonElement>()).GetProperty("jobId").GetString();
+
+        var status = await client.SendAsync(
+            Request(HttpMethod.Get, $"/api/workflows/{workflowId}/runs/{jobId}", body: null, "alice"));
+
+        var raw = await status.Content.ReadAsStringAsync();
+        raw.Should().NotContainAny("envelope", "allowedTools", "autonomyCeiling", "tenantId");
+    }
+
+    [Fact]
+    public async Task StartingARunOnSomeoneElsesWorkflow_Is404()
+    {
+        using var factory = CreateFactory();
+        using var client = factory.CreateClient();
+
+        var workflowId = await SubmitWorkflowAsync(client, "alice");
+
+        var stolen = await client.SendAsync(
+            Request(HttpMethod.Post, $"/api/workflows/{workflowId}/runs", body: null, "mallory"));
+
+        // 404, not 403: a caller must not be able to confirm a workflow exists by trying to run it.
+        stolen.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task PollingSomeoneElsesRun_Is404()
+    {
+        using var factory = CreateFactory();
+        using var client = factory.CreateClient();
+
+        var workflowId = await SubmitWorkflowAsync(client, "alice");
+        var started = await client.SendAsync(
+            Request(HttpMethod.Post, $"/api/workflows/{workflowId}/runs", body: null, "alice"));
+        var jobId = (await started.Content.ReadFromJsonAsync<JsonElement>()).GetProperty("jobId").GetString();
+
+        var peeked = await client.SendAsync(
+            Request(HttpMethod.Get, $"/api/workflows/{workflowId}/runs/{jobId}", body: null, "mallory"));
+
+        peeked.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task PollingARunUnderTheWrongWorkflow_Is404()
+    {
+        using var factory = CreateFactory();
+        using var client = factory.CreateClient();
+
+        var workflowId = await SubmitWorkflowAsync(client, "alice");
+        var otherWorkflowId = await SubmitWorkflowAsync(client, "alice");
+
+        var started = await client.SendAsync(
+            Request(HttpMethod.Post, $"/api/workflows/{workflowId}/runs", body: null, "alice"));
+        var jobId = (await started.Content.ReadFromJsonAsync<JsonElement>()).GetProperty("jobId").GetString();
+
+        var crossed = await client.SendAsync(
+            Request(HttpMethod.Get, $"/api/workflows/{otherWorkflowId}/runs/{jobId}", body: null, "alice"));
+
+        crossed.StatusCode.Should().Be(HttpStatusCode.NotFound,
+            "the route asserts a relationship, and answering against a different workflow would let a "
+            + "caller discover which workflow a job belongs to by trying routes");
+    }
+
+    [Fact]
+    public async Task StartingARunOnAWorkflowThatDoesNotExist_Is404()
+    {
+        using var factory = CreateFactory();
+        using var client = factory.CreateClient();
+
+        var response = await client.SendAsync(
+            Request(HttpMethod.Post, $"/api/workflows/{Guid.NewGuid()}/runs", body: null, "alice"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task PollingAJobIdThatWasNeverIssued_Is404()
+    {
+        using var factory = CreateFactory();
+        using var client = factory.CreateClient();
+
+        var workflowId = await SubmitWorkflowAsync(client, "alice");
+
+        var response = await client.SendAsync(
+            Request(HttpMethod.Get, $"/api/workflows/{workflowId}/runs/never-issued", body: null, "alice"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+}


### PR DESCRIPTION
Third wave of the external-trigger API. W3 let a caller submit a workflow; this lets them run one and poll it.

`POST /api/workflows/{id}/runs` accepts and queues; `GET .../runs/{jobId}` reports where it got to. Both are off unless `AppConfig.AI.WorkflowSubmission.Enabled` is set.

## The shared run substrate

Rather than a second copy of the bundle path's machinery, this adds the generic pieces — `IRunJobStore`, `IRunDispatchQueue`, `IRunKindExecutor` keyed by `RunKind` — and puts workflows on them. Adding a kind of externally-triggered work is now a registration, not another queue, dispatcher, single-arming and expiry implementation. The shipped bundle path is untouched; migrating it is a later decision.

## What the reviewers found, and what changed

Both gates ran twice. The first pass blocked on two defects, the second on one, and all three were real.

**Every run failed to start.** Knowledge scope is ambient and established at the HTTP entry point; it does not survive the hop onto the dispatcher thread. `RunRecord` has carried its owner and tenant from the beginning for exactly this reason — and nothing re-armed them. So a workflow stored as *alice* was loaded as *nobody*, and an owned plan is invisible to nobody. The dispatcher now establishes the run's identity per job, disposes it before the next, and **fails the run rather than executing it** when it cannot: in this codebase an absent owner reads as a *global* record, so unscoped is not a degraded mode. This is the fourth landing of the defect class `CLAUDE.md` records.

**A workflow parked on a human approval reported as finished.** A plan can end four ways; the mapping recognised two, and Blocked and Cancelled both fell through to success. Executors now return a `RunCompletion`, and success maps only from `Completed`. `RunStatus.Blocked` is new, and W6 will need it.

**Two runs of one workflow shared a state machine.** Found while scoping W5. Plan execution state is keyed by the workflow, not the run, and resume treats an in-flight step as a crashed one — so a second concurrent run re-executed steps the first had live and adopted its completed outputs. A workflow now permits one live run; a second is `409`. The per-caller cap moved into the same atomic admission, closing its own read-then-write window.

**A client hanging up could brick a workflow permanently.** Introduced by the fix above and caught by the second gate pass. The record is committed by admission and was then queued on the caller's request-abort token; a disconnect during the ownership lookup left a `Queued` record that nothing claims, finishes, or reclaims — pinning its workflow at 409 and holding an owner slot for the life of the process. Queueing no longer takes that token, and a queue failure from any other cause marks the run terminal.

**The per-owner cap promised concurrency the host never delivered.** Both reviewers flagged it independently: the dispatcher awaited each run to completion, so host-wide throughput was one and any long workflow head-of-lined every other caller. Dispatch is now bounded-parallel with a configured degree — safe because single-arming and one-live-run-per-workflow already keep runs apart. Fair scheduling is a separate problem, and the config says so rather than implying otherwise.

Also: run reads compare tenant as well as owner (matching how plan ownership is decided on the same path); the configured run retention is now actually honoured by a sweeper; and two doc blocks that claimed the submit/run split was *enforced* now say it is structural.

## Evidence

- **9,061 tests pass, 0 failures, 0 build errors.**
- **19 mutations applied, every one killed by a named test.** Both blocking defects are proven twice over — at the unit level and through the real host over HTTP.
- The gap that hid both blockers is closed: no test previously polled a run past acceptance. `WorkflowRunExecutionTests` now drives a workflow to a terminal status through the real host, substituting only the model call.
- Correctness gate: **pass**. Security gate: **pass**, no HIGH findings (forced to run — its folder-based path filter does not select new HTTP surface, the third PR in a row it would have skipped).

## Test plan

- `dotnet build src/AgenticHarness.slnx`
- `dotnet test src/AgenticHarness.slnx`
- Off by default; a host must set `AppConfig.AI.WorkflowSubmission.Enabled`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)