### PR TITLE
feat: stream a workflow run's progress while it runs (W5)

### DIFF
--- a/src/Content/Application/Application.AI.Common/Interfaces/Runs/IRunJobStore.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Runs/IRunJobStore.cs
@@ -94,6 +94,13 @@ public interface IRunJobStore
     /// <param name="targetId">The thing being run.</param>
     RunRecord? FindLiveRunForTarget(RunKind kind, string targetId);
 
-    /// <summary>Drops runs whose retention has elapsed, returning how many were removed.</summary>
-    int SweepExpired();
+    /// <summary>
+    /// Drops runs whose retention has elapsed, returning the identifiers of those removed.
+    /// </summary>
+    /// <remarks>
+    /// Reports which runs went, not merely how many. A run's records are not the only thing keyed by
+    /// its identifier — progress bookkeeping is too — and a sweep that returned a count would leave
+    /// every other holder guessing which entries it may now release.
+    /// </remarks>
+    IReadOnlyList<string> SweepExpired();
 }

--- a/src/Content/Application/Application.AI.Common/Interfaces/Runs/IRunJobStore.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Runs/IRunJobStore.cs
@@ -74,6 +74,26 @@ public interface IRunJobStore
     /// <param name="record">The updated run.</param>
     bool Update(RunRecord record);
 
+    /// <summary>
+    /// Finds the live run against <paramref name="targetId"/>, or <see langword="null"/> when there
+    /// is none.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Answerable at all only because admission permits one live run per target: without that rule
+    /// this question would have no single answer, and progress reported against a target could not be
+    /// attributed to a particular run.
+    /// </para>
+    /// <para>
+    /// Takes no caller and applies no scope. It exists for work already executing under an identity
+    /// the host established, which needs to know which run it is — not for answering a caller. Nothing
+    /// reached through a request may use it to resolve a run it was not given the id of.
+    /// </para>
+    /// </remarks>
+    /// <param name="kind">The kind of work.</param>
+    /// <param name="targetId">The thing being run.</param>
+    RunRecord? FindLiveRunForTarget(RunKind kind, string targetId);
+
     /// <summary>Drops runs whose retention has elapsed, returning how many were removed.</summary>
     int SweepExpired();
 }

--- a/src/Content/Application/Application.AI.Common/Interfaces/Runs/IRunProgressBroker.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Runs/IRunProgressBroker.cs
@@ -58,6 +58,18 @@ public interface IRunProgressBroker
     /// other tenant.
     /// </returns>
     IRunProgressSubscription? Subscribe(string jobId, string ownerId, string? tenantId);
+
+    /// <summary>
+    /// Releases the bookkeeping held for a run that will report no further progress.
+    /// </summary>
+    /// <remarks>
+    /// Separate from unsubscribing on purpose: a watcher leaving does not mean the run is over, and
+    /// deciding that it does is what makes a watcher arriving at the same moment vanish. Called when
+    /// the run's own records are reclaimed, by which point it is terminal and nothing can publish for
+    /// it again. Without a caller, a host holds one entry per run it ever streamed for its whole life.
+    /// </remarks>
+    /// <param name="jobId">The run to forget.</param>
+    void Forget(string jobId);
 }
 
 /// <summary>

--- a/src/Content/Application/Application.AI.Common/Interfaces/Runs/IRunProgressBroker.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Runs/IRunProgressBroker.cs
@@ -1,0 +1,76 @@
+using Domain.AI.Runs;
+
+namespace Application.AI.Common.Interfaces.Runs;
+
+/// <summary>
+/// Carries progress events from a run executing on the dispatcher to whoever is watching it.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>Publishing must never be able to slow a run down.</strong> A watcher is an observer, not a
+/// participant: a slow reader, a stalled network, or a client that opened a stream and walked away
+/// must not hold up work the caller is paying for. Publishing is therefore non-blocking, and a
+/// subscriber that cannot keep up loses events rather than applying backpressure.
+/// </para>
+/// <para>
+/// <strong>Loss is reported, never silent.</strong> Every event carries a sequence number, so a
+/// watcher can see that it missed some. A feed that quietly skipped an event would be worse than one
+/// that admitted it — the watcher would believe it had seen the whole run.
+/// </para>
+/// <para>
+/// <strong>Nothing is buffered for a watcher who has not arrived.</strong> Events published while no
+/// one is subscribed are dropped, because holding them would mean deciding how long to keep a
+/// transcript nobody may ever read. A watcher that connects late is given the run's current state
+/// first and live events after — which is bounded, and truthful about what it can and cannot show.
+/// </para>
+/// </remarks>
+public interface IRunProgressBroker
+{
+    /// <summary>
+    /// Offers an event to whoever is watching <paramref name="jobId"/>. Returns immediately, and does
+    /// nothing at all when nobody is.
+    /// </summary>
+    /// <param name="jobId">The run the event belongs to.</param>
+    /// <param name="kind">What happened.</param>
+    /// <param name="stepId">Identifier of the step involved, for step-scoped kinds.</param>
+    /// <param name="stepName">Name of the step involved, for step-scoped kinds.</param>
+    /// <param name="status">Where the step or run has got to.</param>
+    /// <param name="detail">Caller-safe elaboration, when there is one.</param>
+    void Publish(
+        string jobId,
+        RunProgressKind kind,
+        string? stepId = null,
+        string? stepName = null,
+        string? status = null,
+        string? detail = null);
+
+    /// <summary>
+    /// Starts watching a run. Dispose the subscription to stop, which also releases its buffer.
+    /// </summary>
+    /// <param name="jobId">The run to watch.</param>
+    /// <returns>
+    /// A subscription, or <see langword="null"/> when the host is already carrying as many watchers as
+    /// it permits. Refusing is deliberate: each open stream holds a connection and a buffer, so an
+    /// unbounded number of them is a way to exhaust the host by asking politely.
+    /// </returns>
+    IRunProgressSubscription? Subscribe(string jobId);
+}
+
+/// <summary>
+/// One watcher's view of a run's progress.
+/// </summary>
+public interface IRunProgressSubscription : IDisposable
+{
+    /// <summary>Yields events until the subscription is disposed or the token is cancelled.</summary>
+    /// <param name="cancellationToken">Ends the stream.</param>
+    IAsyncEnumerable<RunProgressEvent> ReadAllAsync(CancellationToken cancellationToken);
+
+    /// <summary>
+    /// How many events this watcher has missed because it could not keep up.
+    /// </summary>
+    /// <remarks>
+    /// Read alongside the events themselves so a stream can tell its client that it fell behind.
+    /// Non-zero means the sequence numbers a client has seen contain gaps.
+    /// </remarks>
+    long DroppedCount { get; }
+}

--- a/src/Content/Application/Application.AI.Common/Interfaces/Runs/IRunProgressBroker.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Runs/IRunProgressBroker.cs
@@ -48,12 +48,16 @@ public interface IRunProgressBroker
     /// Starts watching a run. Dispose the subscription to stop, which also releases its buffer.
     /// </summary>
     /// <param name="jobId">The run to watch.</param>
+    /// <param name="ownerId">Stable identity of the caller the stream is charged to.</param>
+    /// <param name="tenantId">Tenant of that caller, when the host resolves one.</param>
     /// <returns>
-    /// A subscription, or <see langword="null"/> when the host is already carrying as many watchers as
-    /// it permits. Refusing is deliberate: each open stream holds a connection and a buffer, so an
-    /// unbounded number of them is a way to exhaust the host by asking politely.
+    /// A subscription, or <see langword="null"/> when either the host or this caller is already
+    /// carrying as many watchers as it permits. Refusing is deliberate: each open stream holds a
+    /// connection and a buffer, so an unbounded number of them is a way to exhaust the host by asking
+    /// politely — and a purely host-wide ceiling is one any single caller can occupy, denying every
+    /// other tenant.
     /// </returns>
-    IRunProgressSubscription? Subscribe(string jobId);
+    IRunProgressSubscription? Subscribe(string jobId, string ownerId, string? tenantId);
 }
 
 /// <summary>

--- a/src/Content/Application/Application.Core/Validation/WorkflowSubmissionConfigValidator.cs
+++ b/src/Content/Application/Application.Core/Validation/WorkflowSubmissionConfigValidator.cs
@@ -95,6 +95,10 @@ public sealed class WorkflowSubmissionConfigValidator : AbstractValidator<Workfl
             .GreaterThan(0)
             .WithMessage("MaxConcurrentProgressStreams must be > 0 — a non-positive limit would refuse every stream, leaving polling as the only way to follow a run.");
 
+        RuleFor(x => x.MaxProgressStreamsPerOwner)
+            .GreaterThan(0)
+            .WithMessage("MaxProgressStreamsPerOwner must be > 0 — a non-positive per-caller limit would refuse every stream.");
+
         RuleFor(x => x.ProgressBufferSize)
             .GreaterThan(0)
             .WithMessage("ProgressBufferSize must be > 0 — a non-positive buffer would drop every event before any watcher could read it.");

--- a/src/Content/Application/Application.Core/Validation/WorkflowSubmissionConfigValidator.cs
+++ b/src/Content/Application/Application.Core/Validation/WorkflowSubmissionConfigValidator.cs
@@ -91,6 +91,14 @@ public sealed class WorkflowSubmissionConfigValidator : AbstractValidator<Workfl
             .GreaterThan(0)
             .WithMessage("MaxConcurrentDispatchedRuns must be > 0 — a non-positive degree would leave every accepted run queued and never executed.");
 
+        RuleFor(x => x.MaxConcurrentProgressStreams)
+            .GreaterThan(0)
+            .WithMessage("MaxConcurrentProgressStreams must be > 0 — a non-positive limit would refuse every stream, leaving polling as the only way to follow a run.");
+
+        RuleFor(x => x.ProgressBufferSize)
+            .GreaterThan(0)
+            .WithMessage("ProgressBufferSize must be > 0 — a non-positive buffer would drop every event before any watcher could read it.");
+
         RuleFor(x => x.RunSweepInterval)
             .GreaterThan(TimeSpan.Zero)
             .WithMessage("RunSweepInterval must be > 0 — a non-positive interval would spin the sweeper continuously instead of scheduling it.");

--- a/src/Content/Domain/Domain.AI/Runs/RunProgressEvent.cs
+++ b/src/Content/Domain/Domain.AI/Runs/RunProgressEvent.cs
@@ -1,0 +1,75 @@
+namespace Domain.AI.Runs;
+
+/// <summary>
+/// Something that happened part-way through a run, as reported to whoever is watching it.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>Kind-agnostic, like the rest of the substrate.</strong> Every run has a shape a watcher
+/// cares about — it started, a unit of work began, a unit of work ended, it finished — and nothing
+/// here is specific to workflows. A new <see cref="RunKind"/> becomes an executor that publishes these,
+/// not a second streaming endpoint with its own event vocabulary.
+/// </para>
+/// <para>
+/// <strong><see cref="Sequence"/> is what makes a gap detectable.</strong> A watcher that cannot keep
+/// up has events dropped rather than being allowed to slow the run down, and a dropped event must be
+/// visible: a stream that silently skips one is worse than a stream that admits it, because the
+/// watcher believes it saw everything.
+/// </para>
+/// <para>
+/// Every field here is already visible to the caller through the run's own status. Nothing carries
+/// step output, prompts, or tool arguments — a progress feed says how far along the work is, not what
+/// the work said.
+/// </para>
+/// </remarks>
+public sealed record RunProgressEvent
+{
+    /// <summary>The run this describes.</summary>
+    public required string JobId { get; init; }
+
+    /// <summary>Position in this run's event order, starting at 1 and never reused.</summary>
+    public required long Sequence { get; init; }
+
+    /// <summary>What happened.</summary>
+    public required RunProgressKind Kind { get; init; }
+
+    /// <summary>When it happened.</summary>
+    public required DateTimeOffset OccurredAt { get; init; }
+
+    /// <summary>Identifier of the step involved, for the step-scoped kinds.</summary>
+    public string? StepId { get; init; }
+
+    /// <summary>Human-readable name of the step involved, for the step-scoped kinds.</summary>
+    public string? StepName { get; init; }
+
+    /// <summary>
+    /// Where the thing this describes has got to — a step's execution status, or the run's own
+    /// terminal status on <see cref="RunProgressKind.RunFinished"/>.
+    /// </summary>
+    public string? Status { get; init; }
+
+    /// <summary>Caller-safe elaboration, when there is one. Never raw exception or model text.</summary>
+    public string? Detail { get; init; }
+}
+
+/// <summary>
+/// The kinds of thing a run reports while it is running.
+/// </summary>
+/// <remarks>
+/// Deliberately few. This is the vocabulary every kind of run can honestly speak, so it stays the
+/// intersection rather than the union — a richer, kind-specific feed belongs to that kind, not here.
+/// </remarks>
+public enum RunProgressKind
+{
+    /// <summary>The run began executing. Emitted once, before any step event.</summary>
+    RunStarted = 0,
+
+    /// <summary>A step began executing.</summary>
+    StepStarted = 1,
+
+    /// <summary>A step finished, successfully or otherwise.</summary>
+    StepCompleted = 2,
+
+    /// <summary>The run reached a terminal state. Emitted once, last.</summary>
+    RunFinished = 3
+}

--- a/src/Content/Domain/Domain.Common/Config/AI/WorkflowSubmission/WorkflowSubmissionConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/WorkflowSubmission/WorkflowSubmissionConfig.cs
@@ -63,7 +63,8 @@ namespace Domain.Common.Config.AI.WorkflowSubmission;
 /// ├── MaxConcurrentRunsPerOwner — Cap on how many runs one caller may have in flight
 /// ├── RunSweepInterval         — How often expired run records are reclaimed
 /// ├── MaxConcurrentDispatchedRuns — How many runs the host executes at once, across all callers
-/// ├── MaxConcurrentProgressStreams — How many progress streams may be open at once
+/// ├── MaxConcurrentProgressStreams — How many progress streams may be open at once, host-wide
+/// ├── MaxProgressStreamsPerOwner — How many one caller may hold open at once
 /// └── ProgressBufferSize        — How far behind one watcher may fall before it loses events
 /// </code>
 /// </remarks>
@@ -260,6 +261,19 @@ public class WorkflowSubmissionConfig
     /// </remarks>
     /// <value>Default: 64</value>
     public int MaxConcurrentProgressStreams { get; set; } = 64;
+
+    /// <summary>
+    /// How many progress streams one caller may hold open at once.
+    /// </summary>
+    /// <remarks>
+    /// The host-wide ceiling on its own is a ceiling any single caller can occupy: it opens streams to
+    /// its own runs and holds the connections, and every other tenant is refused for as long as it
+    /// does. Rate limiting does not help, because that bounds how often a caller asks, not how long it
+    /// holds what it was given. Mirrors <see cref="MaxConcurrentRunsPerOwner"/>, which bounds work in
+    /// flight for the same reason.
+    /// </remarks>
+    /// <value>Default: 8</value>
+    public int MaxProgressStreamsPerOwner { get; set; } = 8;
 
     /// <summary>
     /// How many progress events one watcher may fall behind by before it starts losing the oldest.

--- a/src/Content/Domain/Domain.Common/Config/AI/WorkflowSubmission/WorkflowSubmissionConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/WorkflowSubmission/WorkflowSubmissionConfig.cs
@@ -62,7 +62,9 @@ namespace Domain.Common.Config.AI.WorkflowSubmission;
 /// ├── RunRecordTtl             — How long a finished run stays readable
 /// ├── MaxConcurrentRunsPerOwner — Cap on how many runs one caller may have in flight
 /// ├── RunSweepInterval         — How often expired run records are reclaimed
-/// └── MaxConcurrentDispatchedRuns — How many runs the host executes at once, across all callers
+/// ├── MaxConcurrentDispatchedRuns — How many runs the host executes at once, across all callers
+/// ├── MaxConcurrentProgressStreams — How many progress streams may be open at once
+/// └── ProgressBufferSize        — How far behind one watcher may fall before it loses events
 /// </code>
 /// </remarks>
 public class WorkflowSubmissionConfig
@@ -246,4 +248,27 @@ public class WorkflowSubmissionConfig
     /// </remarks>
     /// <value>Default: 4</value>
     public int MaxConcurrentDispatchedRuns { get; set; } = 4;
+
+    /// <summary>
+    /// How many progress streams may be open across the host at once.
+    /// </summary>
+    /// <remarks>
+    /// Each open stream holds a connection and a buffer for as long as the client keeps it, so an
+    /// unbounded number of them is a way to exhaust the host by asking politely. A caller that would
+    /// exceed this is refused rather than served slowly, because a stream that cannot keep up is worse
+    /// than one that never opened: it reports a run's progress with gaps in it.
+    /// </remarks>
+    /// <value>Default: 64</value>
+    public int MaxConcurrentProgressStreams { get; set; } = 64;
+
+    /// <summary>
+    /// How many progress events one watcher may fall behind by before it starts losing the oldest.
+    /// </summary>
+    /// <remarks>
+    /// A watcher never applies backpressure — it is an observer, and letting a slow reader hold up
+    /// work the caller is paying for would be the wrong trade. Falling further behind than this drops
+    /// the oldest events, which the stream reports rather than hides.
+    /// </remarks>
+    /// <value>Default: 256</value>
+    public int ProgressBufferSize { get; set; } = 256;
 }

--- a/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.Planner.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.Planner.cs
@@ -91,6 +91,11 @@ public static partial class DependencyInjection
         services.TryAddSingleton<IRunJobStore, InMemoryRunJobStore>();
         services.TryAddSingleton<IRunDispatchQueue, InMemoryRunDispatchQueue>();
 
+        // Singleton for the same reason: the run publishes from the dispatcher and the watcher reads
+        // from a request, so a scoped broker would give each side its own instance and every stream
+        // would sit silent while the run reported into nothing.
+        services.TryAddSingleton<IRunProgressBroker, InMemoryRunProgressBroker>();
+
         // Keyed by RunKind, which is what makes a new kind of work a registration rather than a
         // change to the dispatcher. Scoped: the dispatcher creates a fresh scope per run and resolves
         // the executor inside it, so each run gets its own scoped dependencies.

--- a/src/Content/Infrastructure/Infrastructure.AI/Runs/InMemoryRunJobStore.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Runs/InMemoryRunJobStore.cs
@@ -222,10 +222,10 @@ public sealed class InMemoryRunJobStore : IRunJobStore
     }
 
     /// <inheritdoc />
-    public int SweepExpired()
+    public IReadOnlyList<string> SweepExpired()
     {
         var now = _time.GetUtcNow();
-        var removed = 0;
+        var removed = new List<string>();
 
         foreach (var (jobId, entry) in _entries)
         {
@@ -239,7 +239,7 @@ public sealed class InMemoryRunJobStore : IRunJobStore
                     continue;
 
                 if (_entries.TryRemove(jobId, out _))
-                    removed++;
+                    removed.Add(jobId);
             }
         }
 

--- a/src/Content/Infrastructure/Infrastructure.AI/Runs/InMemoryRunJobStore.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Runs/InMemoryRunJobStore.cs
@@ -199,6 +199,29 @@ public sealed class InMemoryRunJobStore : IRunJobStore
     }
 
     /// <inheritdoc />
+    public RunRecord? FindLiveRunForTarget(RunKind kind, string targetId)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(targetId);
+
+        foreach (var entry in _entries.Values)
+        {
+            lock (entry)
+            {
+                if (entry.Record.IsTerminal)
+                    continue;
+
+                if (entry.Record.Kind == kind
+                    && string.Equals(entry.Record.TargetId, targetId, StringComparison.Ordinal))
+                {
+                    return entry.Record;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /// <inheritdoc />
     public int SweepExpired()
     {
         var now = _time.GetUtcNow();

--- a/src/Content/Infrastructure/Infrastructure.AI/Runs/InMemoryRunProgressBroker.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Runs/InMemoryRunProgressBroker.cs
@@ -97,10 +97,21 @@ public sealed class InMemoryRunProgressBroker : IRunProgressBroker
 
     private readonly ConcurrentDictionary<string, long> _sequences = new(StringComparer.Ordinal);
     private readonly ConcurrentDictionary<string, Lock> _publishLocks = new(StringComparer.Ordinal);
+    private readonly ConcurrentDictionary<string, byte> _pendingForget = new(StringComparer.Ordinal);
     private readonly ConcurrentDictionary<string, int> _perPrincipal = new(StringComparer.Ordinal);
     private readonly IOptionsMonitor<AppConfig> _config;
     private readonly TimeProvider _time;
     private int _openSubscriptions;
+
+    /// <summary>
+    /// How many runs this broker still holds bookkeeping for.
+    /// </summary>
+    /// <remarks>
+    /// Exposed so a test can assert that reclaiming actually happens. The count is the thing that
+    /// grows without bound if it does not, and it is not observable from the outside any other way —
+    /// a leak of this shape is invisible until a host has been up long enough to matter.
+    /// </remarks>
+    public int HeldRunCount => _watchers.Count;
 
     /// <summary>Initializes the broker with the host's streaming limits and clock.</summary>
     public InMemoryRunProgressBroker(IOptionsMonitor<AppConfig> config, TimeProvider time)
@@ -214,11 +225,17 @@ public sealed class InMemoryRunProgressBroker : IRunProgressBroker
 
         subscribers.TryRemove(subscription, out _);
 
-        // Pruning is deliberately NOT done here. Removing the per-run dictionary after observing it
-        // empty is a check-then-act: a watcher subscribing in between is added to a dictionary that
-        // is then unregistered, and it silently receives nothing for the rest of the run. Empty
-        // dictionaries are cheap and are reclaimed with the run's sequence counter when the run's
-        // records are swept.
+        // Pruning a live run's entry is deliberately NOT done here. Removing the per-run dictionary
+        // after observing it empty is a check-then-act: a watcher subscribing in between is added to a
+        // dictionary that is then unregistered, and it silently receives nothing for the rest of the
+        // run. Reclaiming is the sweep's job, and it only ever runs for a run whose records are gone.
+        //
+        // The exception is a run the sweep already tried to forget while this watcher was attached.
+        // Nothing will call Forget for it again, so the last watcher out completes what the sweep
+        // deferred — and it is safe precisely because that run's records are gone, so nothing can
+        // subscribe to or publish for it again.
+        if (subscribers.IsEmpty && _pendingForget.TryRemove(jobId, out _))
+            Purge(jobId);
     }
 
     private void ReleasePrincipal(string principal)
@@ -252,8 +269,23 @@ public sealed class InMemoryRunProgressBroker : IRunProgressBroker
         ArgumentException.ThrowIfNullOrEmpty(jobId);
 
         if (_watchers.TryGetValue(jobId, out var subscribers) && !subscribers.IsEmpty)
-            return;
+        {
+            // Deferred rather than dropped. This is called once per run, so returning here without a
+            // record of having tried would leave the run's entries held for the life of the process —
+            // the last watcher to leave completes it instead.
+            _pendingForget[jobId] = 0;
 
+            // Re-checked because that watcher may have left while the flag was being set, in which
+            // case nobody else is coming to finish the job.
+            if (!subscribers.IsEmpty || !_pendingForget.TryRemove(jobId, out _))
+                return;
+        }
+
+        Purge(jobId);
+    }
+
+    private void Purge(string jobId)
+    {
         _watchers.TryRemove(jobId, out _);
         _sequences.TryRemove(jobId, out _);
         _publishLocks.TryRemove(jobId, out _);

--- a/src/Content/Infrastructure/Infrastructure.AI/Runs/InMemoryRunProgressBroker.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Runs/InMemoryRunProgressBroker.cs
@@ -1,0 +1,165 @@
+using System.Collections.Concurrent;
+using System.Threading.Channels;
+using Application.AI.Common.Interfaces.Runs;
+using Domain.AI.Runs;
+using Domain.Common.Config;
+using Microsoft.Extensions.Options;
+
+namespace Infrastructure.AI.Runs;
+
+/// <summary>
+/// Process-local <see cref="IRunProgressBroker"/>. One bounded buffer per watcher.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>Per watcher, not per run.</strong> Two clients watching the same run read at their own
+/// speeds, so one falling behind must not cost the other events. A single shared buffer would make
+/// the slowest reader the whole run's reader.
+/// </para>
+/// <para>
+/// <strong>Bounded, dropping the oldest.</strong> The alternative on a full buffer is to block the
+/// publisher, which is the run — an observer would then be able to slow down work by reading slowly,
+/// or by stopping. Dropping the oldest keeps the most recent picture, which is what a progress view
+/// is for, and the count of what was dropped travels with the subscription so the gap is visible.
+/// </para>
+/// <para>
+/// <strong>Process-local, and that is a real limit.</strong> A watcher only sees a run executing on
+/// the same instance, exactly like the run store it accompanies. The interface is the seam for a
+/// shared implementation; nothing above it assumes in-process delivery.
+/// </para>
+/// </remarks>
+public sealed class InMemoryRunProgressBroker : IRunProgressBroker
+{
+    private sealed class Subscription : IRunProgressSubscription
+    {
+        private readonly InMemoryRunProgressBroker _broker;
+        private readonly string _jobId;
+        private long _dropped;
+
+        internal Subscription(InMemoryRunProgressBroker broker, string jobId, int capacity)
+        {
+            _broker = broker;
+            _jobId = jobId;
+
+            // DropOldest rather than Wait: TryWrite on a full DropOldest channel always succeeds, so
+            // the publishing run never blocks and never has to care whether anyone is keeping up.
+            Channel = System.Threading.Channels.Channel.CreateBounded<RunProgressEvent>(
+                new BoundedChannelOptions(capacity)
+                {
+                    FullMode = BoundedChannelFullMode.DropOldest,
+                    SingleReader = true,
+                    SingleWriter = false
+                });
+        }
+
+        internal Channel<RunProgressEvent> Channel { get; }
+
+        public long DroppedCount => Interlocked.Read(ref _dropped);
+
+        internal void RecordDrop() => Interlocked.Increment(ref _dropped);
+
+        public IAsyncEnumerable<RunProgressEvent> ReadAllAsync(CancellationToken cancellationToken) =>
+            Channel.Reader.ReadAllAsync(cancellationToken);
+
+        public void Dispose()
+        {
+            _broker.Unsubscribe(_jobId, this);
+            Channel.Writer.TryComplete();
+        }
+    }
+
+    private readonly ConcurrentDictionary<string, ConcurrentDictionary<Subscription, byte>> _watchers =
+        new(StringComparer.Ordinal);
+
+    private readonly ConcurrentDictionary<string, long> _sequences = new(StringComparer.Ordinal);
+    private readonly IOptionsMonitor<AppConfig> _config;
+    private readonly TimeProvider _time;
+    private int _openSubscriptions;
+
+    /// <summary>Initializes the broker with the host's streaming limits and clock.</summary>
+    public InMemoryRunProgressBroker(IOptionsMonitor<AppConfig> config, TimeProvider time)
+    {
+        ArgumentNullException.ThrowIfNull(config);
+        ArgumentNullException.ThrowIfNull(time);
+
+        _config = config;
+        _time = time;
+    }
+
+    /// <inheritdoc />
+    public void Publish(
+        string jobId,
+        RunProgressKind kind,
+        string? stepId = null,
+        string? stepName = null,
+        string? status = null,
+        string? detail = null)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(jobId);
+
+        if (!_watchers.TryGetValue(jobId, out var subscribers) || subscribers.IsEmpty)
+            return;
+
+        // Numbered per run, and only for runs someone is watching. A gap in what a client receives
+        // therefore means events were dropped for that client, not that the run skipped a number.
+        var sequence = _sequences.AddOrUpdate(jobId, 1, static (_, current) => current + 1);
+
+        var evt = new RunProgressEvent
+        {
+            JobId = jobId,
+            Sequence = sequence,
+            Kind = kind,
+            OccurredAt = _time.GetUtcNow(),
+            StepId = stepId,
+            StepName = stepName,
+            Status = status,
+            Detail = detail
+        };
+
+        foreach (var subscription in subscribers.Keys)
+        {
+            // A full DropOldest channel evicts silently, so the eviction is counted here rather than
+            // inferred: the reader compares its own count against the sequence numbers it saw.
+            if (subscription.Channel.Reader.Count >= Capacity)
+                subscription.RecordDrop();
+
+            subscription.Channel.Writer.TryWrite(evt);
+        }
+    }
+
+    /// <inheritdoc />
+    public IRunProgressSubscription? Subscribe(string jobId)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(jobId);
+
+        var limit = _config.CurrentValue.AI.WorkflowSubmission.MaxConcurrentProgressStreams;
+        if (Interlocked.Increment(ref _openSubscriptions) > limit)
+        {
+            Interlocked.Decrement(ref _openSubscriptions);
+            return null;
+        }
+
+        var subscription = new Subscription(this, jobId, Capacity);
+        _watchers.GetOrAdd(jobId, static _ => new ConcurrentDictionary<Subscription, byte>())[subscription] = 0;
+
+        return subscription;
+    }
+
+    private int Capacity => Math.Max(1, _config.CurrentValue.AI.WorkflowSubmission.ProgressBufferSize);
+
+    private void Unsubscribe(string jobId, Subscription subscription)
+    {
+        if (_watchers.TryGetValue(jobId, out var subscribers) && subscribers.TryRemove(subscription, out _))
+        {
+            Interlocked.Decrement(ref _openSubscriptions);
+
+            // The last watcher leaving takes the run's bookkeeping with it. Without this, a host that
+            // has streamed many runs holds a sequence counter for every one of them forever.
+            if (subscribers.IsEmpty)
+            {
+                _watchers.TryRemove(jobId, out _);
+                _sequences.TryRemove(jobId, out _);
+            }
+        }
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Runs/InMemoryRunProgressBroker.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Runs/InMemoryRunProgressBroker.cs
@@ -96,7 +96,6 @@ public sealed class InMemoryRunProgressBroker : IRunProgressBroker
         new(StringComparer.Ordinal);
 
     private readonly ConcurrentDictionary<string, long> _sequences = new(StringComparer.Ordinal);
-    private readonly ConcurrentDictionary<string, Lock> _publishLocks = new(StringComparer.Ordinal);
     private readonly ConcurrentDictionary<string, byte> _pendingForget = new(StringComparer.Ordinal);
     private readonly ConcurrentDictionary<string, int> _perPrincipal = new(StringComparer.Ordinal);
     private readonly IOptionsMonitor<AppConfig> _config;
@@ -141,9 +140,16 @@ public sealed class InMemoryRunProgressBroker : IRunProgressBroker
         // threads can publish at once — and taking a number then writing separately lets the thread
         // that drew 4 write after the thread that drew 5. A watcher would then see 5 before 4 and, on
         // the documented reading of Sequence as position in the run's order, report a gap that never
-        // happened. The lock is per run and held only for the enqueue, which cannot block: a full
-        // buffer drops rather than waits.
-        lock (_publishLocks.GetOrAdd(jobId, static _ => new Lock()))
+        // happened. The lock is held only for the enqueue, which cannot block: a full buffer drops
+        // rather than waits.
+        //
+        // The run's own subscriber dictionary IS the lock, rather than an entry in a second table
+        // keyed by job id. A separate table has to be looked up again here, and that lookup can race
+        // the sweep removing it: one publisher would then hold the old lock object while another
+        // created and held a new one, and the two would number and deliver concurrently — losing
+        // exactly the ordering this exists to guarantee. Both publishers necessarily hold the same
+        // dictionary instance, because that is what they just read the subscribers out of.
+        lock (subscribers)
         {
             var sequence = _sequences.AddOrUpdate(jobId, 1, static (_, current) => current + 1);
 
@@ -288,6 +294,5 @@ public sealed class InMemoryRunProgressBroker : IRunProgressBroker
     {
         _watchers.TryRemove(jobId, out _);
         _sequences.TryRemove(jobId, out _);
-        _publishLocks.TryRemove(jobId, out _);
     }
 }

--- a/src/Content/Infrastructure/Infrastructure.AI/Runs/InMemoryRunProgressBroker.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Runs/InMemoryRunProgressBroker.cs
@@ -96,6 +96,7 @@ public sealed class InMemoryRunProgressBroker : IRunProgressBroker
         new(StringComparer.Ordinal);
 
     private readonly ConcurrentDictionary<string, long> _sequences = new(StringComparer.Ordinal);
+    private readonly ConcurrentDictionary<string, Lock> _publishLocks = new(StringComparer.Ordinal);
     private readonly ConcurrentDictionary<string, int> _perPrincipal = new(StringComparer.Ordinal);
     private readonly IOptionsMonitor<AppConfig> _config;
     private readonly TimeProvider _time;
@@ -125,32 +126,39 @@ public sealed class InMemoryRunProgressBroker : IRunProgressBroker
         if (!_watchers.TryGetValue(jobId, out var subscribers) || subscribers.IsEmpty)
             return;
 
-        // Numbered per run, and only for runs someone is watching. A gap in what a client receives
-        // therefore means events were dropped for that client, not that the run skipped a number.
-        var sequence = _sequences.AddOrUpdate(jobId, 1, static (_, current) => current + 1);
-
-        var evt = new RunProgressEvent
+        // Numbering and delivery happen together, per run. A plan runs steps concurrently, so two
+        // threads can publish at once — and taking a number then writing separately lets the thread
+        // that drew 4 write after the thread that drew 5. A watcher would then see 5 before 4 and, on
+        // the documented reading of Sequence as position in the run's order, report a gap that never
+        // happened. The lock is per run and held only for the enqueue, which cannot block: a full
+        // buffer drops rather than waits.
+        lock (_publishLocks.GetOrAdd(jobId, static _ => new Lock()))
         {
-            JobId = jobId,
-            Sequence = sequence,
-            Kind = kind,
-            OccurredAt = _time.GetUtcNow(),
-            StepId = stepId,
-            StepName = stepName,
-            Status = status,
-            Detail = detail
-        };
+            var sequence = _sequences.AddOrUpdate(jobId, 1, static (_, current) => current + 1);
 
-        foreach (var subscription in subscribers.Keys)
-        {
-            // A full DropOldest channel evicts silently, so the eviction is counted here rather than
-            // inferred: the reader compares its own count against the sequence numbers it saw. The
-            // count is advisory — a reader draining concurrently can make it approximate — and it is
-            // used to say "you missed some", never to say exactly how many.
-            if (subscription.Channel.Reader.Count >= subscription.Capacity)
-                subscription.RecordDrop();
+            var evt = new RunProgressEvent
+            {
+                JobId = jobId,
+                Sequence = sequence,
+                Kind = kind,
+                OccurredAt = _time.GetUtcNow(),
+                StepId = stepId,
+                StepName = stepName,
+                Status = status,
+                Detail = detail
+            };
 
-            subscription.Channel.Writer.TryWrite(evt);
+            foreach (var subscription in subscribers.Keys)
+            {
+                // A full DropOldest channel evicts silently, so the eviction is counted here rather
+                // than inferred: the reader compares its own count against the sequence numbers it
+                // saw. The count is advisory — a reader draining concurrently can make it approximate
+                // — and it is used to say "you missed some", never exactly how many.
+                if (subscription.Channel.Reader.Count >= subscription.Capacity)
+                    subscription.RecordDrop();
+
+                subscription.Channel.Writer.TryWrite(evt);
+            }
         }
     }
 
@@ -213,8 +221,16 @@ public sealed class InMemoryRunProgressBroker : IRunProgressBroker
         // records are swept.
     }
 
-    private void ReleasePrincipal(string principal) =>
-        _perPrincipal.AddOrUpdate(principal, 0, static (_, current) => current > 0 ? current - 1 : 0);
+    private void ReleasePrincipal(string principal)
+    {
+        // Removed at zero rather than left holding a count of none, so the table is bounded by callers
+        // streaming right now instead of by every caller that ever has.
+        var remaining = _perPrincipal.AddOrUpdate(
+            principal, 0, static (_, current) => current > 0 ? current - 1 : 0);
+
+        if (remaining == 0)
+            _perPrincipal.TryRemove(new KeyValuePair<string, int>(principal, 0));
+    }
 
     /// <summary>
     /// Identifies the principal a stream is charged to, on the same two legs — tenant and owner —
@@ -240,5 +256,6 @@ public sealed class InMemoryRunProgressBroker : IRunProgressBroker
 
         _watchers.TryRemove(jobId, out _);
         _sequences.TryRemove(jobId, out _);
+        _publishLocks.TryRemove(jobId, out _);
     }
 }

--- a/src/Content/Infrastructure/Infrastructure.AI/Runs/InMemoryRunProgressBroker.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Runs/InMemoryRunProgressBroker.cs
@@ -1,6 +1,7 @@
 using System.Collections.Concurrent;
 using System.Threading.Channels;
 using Application.AI.Common.Interfaces.Runs;
+using Domain.AI.KnowledgeGraph.Scoping;
 using Domain.AI.Runs;
 using Domain.Common.Config;
 using Microsoft.Extensions.Options;
@@ -23,6 +24,12 @@ namespace Infrastructure.AI.Runs;
 /// is for, and the count of what was dropped travels with the subscription so the gap is visible.
 /// </para>
 /// <para>
+/// <strong>Capacity is bounded per caller as well as host-wide.</strong> A single global ceiling is a
+/// ceiling any one caller can occupy: it opens streams to its own runs until every other tenant is
+/// refused. The run substrate already bounds work per owner for the same reason, and streams follow
+/// it rather than inventing a second, weaker rule.
+/// </para>
+/// <para>
 /// <strong>Process-local, and that is a real limit.</strong> A watcher only sees a run executing on
 /// the same instance, exactly like the run store it accompanies. The interface is the seam for a
 /// shared implementation; nothing above it assumes in-process delivery.
@@ -34,12 +41,21 @@ public sealed class InMemoryRunProgressBroker : IRunProgressBroker
     {
         private readonly InMemoryRunProgressBroker _broker;
         private readonly string _jobId;
+        private readonly string _principal;
         private long _dropped;
+        private int _disposed;
 
-        internal Subscription(InMemoryRunProgressBroker broker, string jobId, int capacity)
+        internal Subscription(
+            InMemoryRunProgressBroker broker, string jobId, string principal, int capacity)
         {
             _broker = broker;
             _jobId = jobId;
+            _principal = principal;
+
+            // Captured at subscribe time, not re-read per publish: the channel was created with this
+            // bound, so comparing against a reloaded setting would mis-report drops for the life of
+            // every subscription that predates the change.
+            Capacity = capacity;
 
             // DropOldest rather than Wait: TryWrite on a full DropOldest channel always succeeds, so
             // the publishing run never blocks and never has to care whether anyone is keeping up.
@@ -54,6 +70,8 @@ public sealed class InMemoryRunProgressBroker : IRunProgressBroker
 
         internal Channel<RunProgressEvent> Channel { get; }
 
+        internal int Capacity { get; }
+
         public long DroppedCount => Interlocked.Read(ref _dropped);
 
         internal void RecordDrop() => Interlocked.Increment(ref _dropped);
@@ -63,7 +81,13 @@ public sealed class InMemoryRunProgressBroker : IRunProgressBroker
 
         public void Dispose()
         {
-            _broker.Unsubscribe(_jobId, this);
+            // Exactly once, whatever the caller does. The slot accounting is released here rather than
+            // conditioned on finding this subscription still registered: a lookup that missed would
+            // leak the slot permanently, and enough leaked slots refuse the endpoint to everyone.
+            if (Interlocked.Exchange(ref _disposed, 1) != 0)
+                return;
+
+            _broker.Release(_jobId, _principal, this);
             Channel.Writer.TryComplete();
         }
     }
@@ -72,6 +96,7 @@ public sealed class InMemoryRunProgressBroker : IRunProgressBroker
         new(StringComparer.Ordinal);
 
     private readonly ConcurrentDictionary<string, long> _sequences = new(StringComparer.Ordinal);
+    private readonly ConcurrentDictionary<string, int> _perPrincipal = new(StringComparer.Ordinal);
     private readonly IOptionsMonitor<AppConfig> _config;
     private readonly TimeProvider _time;
     private int _openSubscriptions;
@@ -119,8 +144,10 @@ public sealed class InMemoryRunProgressBroker : IRunProgressBroker
         foreach (var subscription in subscribers.Keys)
         {
             // A full DropOldest channel evicts silently, so the eviction is counted here rather than
-            // inferred: the reader compares its own count against the sequence numbers it saw.
-            if (subscription.Channel.Reader.Count >= Capacity)
+            // inferred: the reader compares its own count against the sequence numbers it saw. The
+            // count is advisory — a reader draining concurrently can make it approximate — and it is
+            // used to say "you missed some", never to say exactly how many.
+            if (subscription.Channel.Reader.Count >= subscription.Capacity)
                 subscription.RecordDrop();
 
             subscription.Channel.Writer.TryWrite(evt);
@@ -128,38 +155,90 @@ public sealed class InMemoryRunProgressBroker : IRunProgressBroker
     }
 
     /// <inheritdoc />
-    public IRunProgressSubscription? Subscribe(string jobId)
+    public IRunProgressSubscription? Subscribe(string jobId, string ownerId, string? tenantId)
     {
         ArgumentException.ThrowIfNullOrEmpty(jobId);
+        ArgumentException.ThrowIfNullOrEmpty(ownerId);
 
-        var limit = _config.CurrentValue.AI.WorkflowSubmission.MaxConcurrentProgressStreams;
-        if (Interlocked.Increment(ref _openSubscriptions) > limit)
-        {
-            Interlocked.Decrement(ref _openSubscriptions);
+        var limits = _config.CurrentValue.AI.WorkflowSubmission;
+        var principal = PrincipalKey(ownerId, tenantId);
+
+        if (!TryReserve(principal, limits.MaxConcurrentProgressStreams, limits.MaxProgressStreamsPerOwner))
             return null;
-        }
 
-        var subscription = new Subscription(this, jobId, Capacity);
+        var subscription = new Subscription(this, jobId, principal, Math.Max(1, limits.ProgressBufferSize));
         _watchers.GetOrAdd(jobId, static _ => new ConcurrentDictionary<Subscription, byte>())[subscription] = 0;
 
         return subscription;
     }
 
-    private int Capacity => Math.Max(1, _config.CurrentValue.AI.WorkflowSubmission.ProgressBufferSize);
-
-    private void Unsubscribe(string jobId, Subscription subscription)
+    /// <summary>
+    /// Takes one host slot and one caller slot together, giving both back if either is exhausted.
+    /// </summary>
+    private bool TryReserve(string principal, int hostLimit, int perOwnerLimit)
     {
-        if (_watchers.TryGetValue(jobId, out var subscribers) && subscribers.TryRemove(subscription, out _))
+        if (Interlocked.Increment(ref _openSubscriptions) > hostLimit)
         {
             Interlocked.Decrement(ref _openSubscriptions);
-
-            // The last watcher leaving takes the run's bookkeeping with it. Without this, a host that
-            // has streamed many runs holds a sequence counter for every one of them forever.
-            if (subscribers.IsEmpty)
-            {
-                _watchers.TryRemove(jobId, out _);
-                _sequences.TryRemove(jobId, out _);
-            }
+            return false;
         }
+
+        var taken = _perPrincipal.AddOrUpdate(principal, 1, static (_, current) => current + 1);
+        if (taken > perOwnerLimit)
+        {
+            ReleasePrincipal(principal);
+            Interlocked.Decrement(ref _openSubscriptions);
+            return false;
+        }
+
+        return true;
+    }
+
+    private void Release(string jobId, string principal, Subscription subscription)
+    {
+        // Accounting first and unconditionally — a slot must come back even if the bookkeeping below
+        // finds nothing to prune.
+        Interlocked.Decrement(ref _openSubscriptions);
+        ReleasePrincipal(principal);
+
+        if (!_watchers.TryGetValue(jobId, out var subscribers))
+            return;
+
+        subscribers.TryRemove(subscription, out _);
+
+        // Pruning is deliberately NOT done here. Removing the per-run dictionary after observing it
+        // empty is a check-then-act: a watcher subscribing in between is added to a dictionary that
+        // is then unregistered, and it silently receives nothing for the rest of the run. Empty
+        // dictionaries are cheap and are reclaimed with the run's sequence counter when the run's
+        // records are swept.
+    }
+
+    private void ReleasePrincipal(string principal) =>
+        _perPrincipal.AddOrUpdate(principal, 0, static (_, current) => current > 0 ? current - 1 : 0);
+
+    /// <summary>
+    /// Identifies the principal a stream is charged to, on the same two legs — tenant and owner —
+    /// that decide whether it may read the run at all.
+    /// </summary>
+    private static string PrincipalKey(string ownerId, string? tenantId) =>
+        $"{ScopeIdentity.Canonicalize(tenantId) ?? "-"}|{ScopeIdentity.Canonicalize(ownerId) ?? "-"}";
+
+    /// <summary>
+    /// Drops the bookkeeping for runs nobody is watching any more.
+    /// </summary>
+    /// <remarks>
+    /// Separate from unsubscribing precisely so that unsubscribing does not have to decide whether a
+    /// run is finished with. Called when run records are swept, by which point the run is terminal and
+    /// no further events can be published for it.
+    /// </remarks>
+    public void Forget(string jobId)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(jobId);
+
+        if (_watchers.TryGetValue(jobId, out var subscribers) && !subscribers.IsEmpty)
+            return;
+
+        _watchers.TryRemove(jobId, out _);
+        _sequences.TryRemove(jobId, out _);
     }
 }

--- a/src/Content/Infrastructure/Infrastructure.AI/Runs/PlanProgressRunBridge.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Runs/PlanProgressRunBridge.cs
@@ -91,7 +91,9 @@ public sealed class PlanProgressRunBridge : IPlanProgressNotifier
     /// <inheritdoc />
     public Task NotifyPlanCompletedAsync(PlanId planId, TimeSpan totalDuration, CancellationToken ct)
     {
-        Publish(planId, RunProgressKind.RunFinished, status: nameof(RunStatus.Succeeded));
+        // Deliberately silent. The run's terminal event is published by the dispatcher, which is the
+        // one place every run passes through on its way to ending — the planner only announces the
+        // endings it produces, and a run can end without it having run at all.
         return Task.CompletedTask;
     }
 
@@ -99,15 +101,9 @@ public sealed class PlanProgressRunBridge : IPlanProgressNotifier
     public Task NotifyPlanFailedAsync(
         PlanId planId, PlanStepId failedStepId, string errorMessage, CancellationToken ct)
     {
-        // The planner's message is caller-safe by the same contract the run's own Error field relies
-        // on, so it passes through: a watcher learns why its own run stopped.
-        Publish(
-            planId,
-            RunProgressKind.RunFinished,
-            stepId: failedStepId.Value.ToString(),
-            status: nameof(RunStatus.Failed),
-            detail: errorMessage);
-
+        // Silent for the same reason as completion. The failing step already reached the watcher as a
+        // step event, and the run's ending — with its caller-safe reason — is the dispatcher's to
+        // report, so that every way a run can end is announced by the same code.
         return Task.CompletedTask;
     }
 

--- a/src/Content/Infrastructure/Infrastructure.AI/Runs/PlanProgressRunBridge.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Runs/PlanProgressRunBridge.cs
@@ -1,0 +1,158 @@
+using Application.AI.Common.Interfaces.Planner;
+using Application.AI.Common.Interfaces.Runs;
+using Domain.AI.Planner;
+using Domain.AI.Runs;
+using Domain.AI.Sandbox;
+
+namespace Infrastructure.AI.Runs;
+
+/// <summary>
+/// Republishes plan execution notifications as run progress, so a caller watching a run sees the
+/// workflow it started actually moving.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>Why a bridge rather than publishing from the executor.</strong> The planner already
+/// announces everything worth watching through <see cref="IPlanProgressNotifier"/>, and it announces
+/// it about a <em>plan</em>. A run is a different thing: the same stored workflow can be run many
+/// times over its life. Translating at the boundary keeps the planner unaware that runs exist, and
+/// keeps the run substrate unaware of plans.
+/// </para>
+/// <para>
+/// <strong>The translation is only possible because a workflow has at most one live run.</strong>
+/// Notifications identify a plan, and a stored workflow's id <em>is</em> its plan id — so while a run
+/// is live, plan and run are in one-to-one correspondence and progress can be attributed. Were two
+/// runs of one workflow ever permitted, this would have no correct answer, and the honest failure
+/// would be to publish nothing rather than guess.
+/// </para>
+/// <para>
+/// <strong>Nothing here fails a run.</strong> A plan that runs perfectly while nobody is watching has
+/// not gone wrong, so an unattributable notification is simply dropped. Progress reporting is not
+/// permitted to be a reason work fails.
+/// </para>
+/// </remarks>
+public sealed class PlanProgressRunBridge : IPlanProgressNotifier
+{
+    private readonly IRunJobStore _runStore;
+    private readonly IRunProgressBroker _broker;
+
+    /// <summary>Initializes the bridge.</summary>
+    public PlanProgressRunBridge(IRunJobStore runStore, IRunProgressBroker broker)
+    {
+        ArgumentNullException.ThrowIfNull(runStore);
+        ArgumentNullException.ThrowIfNull(broker);
+
+        _runStore = runStore;
+        _broker = broker;
+    }
+
+    /// <inheritdoc />
+    public Task NotifyPlanStartedAsync(PlanId planId, string planName, PlanGraph graph, CancellationToken ct)
+    {
+        Publish(planId, RunProgressKind.RunStarted, status: nameof(RunStatus.Running), detail: planName);
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public Task NotifyStepStartedAsync(
+        PlanId planId, PlanStepId stepId, string stepName, StepType type, CancellationToken ct)
+    {
+        Publish(
+            planId,
+            RunProgressKind.StepStarted,
+            stepId: stepId.Value.ToString(),
+            stepName: stepName,
+            status: nameof(StepExecutionStatus.Running),
+            detail: type.ToString());
+
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public Task NotifyStepCompletedAsync(
+        PlanId planId,
+        PlanStepId stepId,
+        StepExecutionStatus status,
+        TimeSpan duration,
+        string? outputSummary,
+        CancellationToken ct)
+    {
+        // The output summary is deliberately not forwarded. A progress feed says how far along the
+        // work is; what the work produced belongs to the result, which has its own authorization.
+        Publish(
+            planId,
+            RunProgressKind.StepCompleted,
+            stepId: stepId.Value.ToString(),
+            status: status.ToString());
+
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public Task NotifyPlanCompletedAsync(PlanId planId, TimeSpan totalDuration, CancellationToken ct)
+    {
+        Publish(planId, RunProgressKind.RunFinished, status: nameof(RunStatus.Succeeded));
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public Task NotifyPlanFailedAsync(
+        PlanId planId, PlanStepId failedStepId, string errorMessage, CancellationToken ct)
+    {
+        // The planner's message is caller-safe by the same contract the run's own Error field relies
+        // on, so it passes through: a watcher learns why its own run stopped.
+        Publish(
+            planId,
+            RunProgressKind.RunFinished,
+            stepId: failedStepId.Value.ToString(),
+            status: nameof(RunStatus.Failed),
+            detail: errorMessage);
+
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public Task NotifyStateUpdateAsync(
+        PlanId planId,
+        PlanStepId stepId,
+        StepExecutionStatus previousStatus,
+        StepExecutionStatus newStatus,
+        CancellationToken ct)
+    {
+        // Not republished. Every transition a watcher can act on already arrives as a step start or a
+        // step completion; forwarding the raw transitions as well would double the feed's volume to
+        // say the same things twice, and the buffer that pays for it is the watcher's.
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public Task NotifySandboxStatusAsync(
+        PlanId planId,
+        PlanStepId stepId,
+        string toolName,
+        SandboxIsolationLevel isolationLevel,
+        ResourceUsage usage,
+        string? attestationHash,
+        CancellationToken ct)
+    {
+        // Not republished. Isolation levels, resource usage and attestation hashes describe how the
+        // host executed something, not how far along the caller's work is — and they are the kind of
+        // internal detail a caller-facing feed should not carry.
+        return Task.CompletedTask;
+    }
+
+    private void Publish(
+        PlanId planId,
+        RunProgressKind kind,
+        string? stepId = null,
+        string? stepName = null,
+        string? status = null,
+        string? detail = null)
+    {
+        var run = _runStore.FindLiveRunForTarget(RunKind.Workflow, planId.Value.ToString());
+        if (run is null)
+            return;
+
+        _broker.Publish(run.JobId, kind, stepId, stepName, status, detail);
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Runs/RunDispatchBackgroundService.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Runs/RunDispatchBackgroundService.cs
@@ -55,6 +55,7 @@ public sealed class RunDispatchBackgroundService : BackgroundService
 {
     private readonly IRunDispatchQueue _queue;
     private readonly IRunJobStore _store;
+    private readonly IRunProgressBroker _progress;
     private readonly IServiceScopeFactory _scopeFactory;
     private readonly IOptionsMonitor<AppConfig> _config;
     private readonly TimeProvider _time;
@@ -64,6 +65,7 @@ public sealed class RunDispatchBackgroundService : BackgroundService
     public RunDispatchBackgroundService(
         IRunDispatchQueue queue,
         IRunJobStore store,
+        IRunProgressBroker progress,
         IServiceScopeFactory scopeFactory,
         IOptionsMonitor<AppConfig> config,
         TimeProvider time,
@@ -71,6 +73,7 @@ public sealed class RunDispatchBackgroundService : BackgroundService
     {
         ArgumentNullException.ThrowIfNull(queue);
         ArgumentNullException.ThrowIfNull(store);
+        ArgumentNullException.ThrowIfNull(progress);
         ArgumentNullException.ThrowIfNull(scopeFactory);
         ArgumentNullException.ThrowIfNull(config);
         ArgumentNullException.ThrowIfNull(time);
@@ -78,6 +81,7 @@ public sealed class RunDispatchBackgroundService : BackgroundService
 
         _queue = queue;
         _store = store;
+        _progress = progress;
         _scopeFactory = scopeFactory;
         _config = config;
         _time = time;
@@ -233,15 +237,31 @@ public sealed class RunDispatchBackgroundService : BackgroundService
     }
 
     /// <summary>
-    /// Writes a claimed run's terminal state. Takes the claimed record rather than re-reading it: the
-    /// run is Running by this point, so it can no longer be re-claimed, and the dispatcher holds no
-    /// caller identity to read it back with.
+    /// Writes a claimed run's terminal state, and tells anyone watching that it ended.
     /// </summary>
-    private void Finish(RunRecord claimed, RunStatus status, string? error) =>
+    /// <remarks>
+    /// <para>
+    /// Takes the claimed record rather than re-reading it: the run is Running by this point, so it can
+    /// no longer be re-claimed, and the dispatcher holds no caller identity to read it back with.
+    /// </para>
+    /// <para>
+    /// <strong>The terminal progress event is published here, not by whatever performed the work.</strong>
+    /// This is the one place every claimed run passes through on its way to a terminal state — which is
+    /// exactly the property that makes a watcher's stream end. Sourcing it from the planner instead
+    /// covered only the endings the planner announces: a workflow that parked on a human gate, one an
+    /// operator cancelled, and every run failed before the planner ran at all would each leave a
+    /// watcher's connection open forever, holding a stream slot, on a run that was already over.
+    /// </para>
+    /// </remarks>
+    private void Finish(RunRecord claimed, RunStatus status, string? error)
+    {
         _store.Update(claimed with
         {
             Status = status,
             Error = error,
             CompletedAt = _time.GetUtcNow()
         });
+
+        _progress.Publish(claimed.JobId, RunProgressKind.RunFinished, status: status.ToString(), detail: error);
+    }
 }

--- a/src/Content/Infrastructure/Infrastructure.AI/Runs/RunRecordCleanupService.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Runs/RunRecordCleanupService.cs
@@ -18,7 +18,9 @@ namespace Infrastructure.AI.Runs;
 /// </para>
 /// <para>
 /// Only terminal runs are ever reclaimed — that rule lives in the store, not here, so no scheduling
-/// change can make a run a caller is still polling disappear.
+/// change can make a run a caller is still polling disappear. The progress broker's bookkeeping is
+/// released for the same runs at the same moment, because it is keyed by the same identifier and
+/// nothing can publish for a reclaimed run.
 /// </para>
 /// </remarks>
 internal sealed class RunRecordCleanupService : BackgroundService
@@ -31,20 +33,24 @@ internal sealed class RunRecordCleanupService : BackgroundService
     private static readonly TimeSpan MinInterval = TimeSpan.FromSeconds(1);
 
     private readonly IRunJobStore _store;
+    private readonly IRunProgressBroker _progress;
     private readonly IOptionsMonitor<AppConfig> _config;
     private readonly ILogger<RunRecordCleanupService> _logger;
 
     /// <summary>Initializes a new <see cref="RunRecordCleanupService"/>.</summary>
     public RunRecordCleanupService(
         IRunJobStore store,
+        IRunProgressBroker progress,
         IOptionsMonitor<AppConfig> config,
         ILogger<RunRecordCleanupService> logger)
     {
         ArgumentNullException.ThrowIfNull(store);
+        ArgumentNullException.ThrowIfNull(progress);
         ArgumentNullException.ThrowIfNull(config);
         ArgumentNullException.ThrowIfNull(logger);
 
         _store = store;
+        _progress = progress;
         _config = config;
         _logger = logger;
     }
@@ -75,8 +81,17 @@ internal sealed class RunRecordCleanupService : BackgroundService
         try
         {
             var reclaimed = _store.SweepExpired();
-            if (reclaimed > 0)
-                _logger.LogInformation("Run sweep reclaimed {Count} expired run record(s).", reclaimed);
+            if (reclaimed.Count == 0)
+                return;
+
+            // A run's identifier keys more than its record. Reclaiming one without the other would
+            // trade a bounded leak for an unbounded one — the progress bookkeeping would outlive every
+            // run the host ever streamed.
+            foreach (var jobId in reclaimed)
+                _progress.Forget(jobId);
+
+            _logger.LogInformation(
+                "Run sweep reclaimed {Count} expired run record(s).", reclaimed.Count);
         }
         catch (Exception ex)
         {

--- a/src/Content/Presentation/Presentation.ExecutionApi/Controllers/WorkflowsController.cs
+++ b/src/Content/Presentation/Presentation.ExecutionApi/Controllers/WorkflowsController.cs
@@ -198,6 +198,18 @@ public sealed class WorkflowsController : ControllerBase
     /// the two look interchangeable and are not: removing the broker's per-caller cap on the grounds
     /// that the endpoint "is already rate limited" would leave simultaneous streams unbounded.
     /// </para>
+    /// <para>
+    /// <strong>A stream is authorized once, when it opens, and then runs for the life of the run.</strong>
+    /// The credential is validated at request start and never re-checked, so a token that expires or is
+    /// revoked mid-run keeps delivering until the run ends. This is inherent to a long-lived response
+    /// rather than an oversight, and it is bounded twice over: by the run's own duration, and by the
+    /// frames carrying nothing beyond what the same caller can already read from the run's status —
+    /// no step output, prompts, tool arguments, or host internals. A host that needs revocation to take
+    /// effect sooner than a run can finish should bound run duration, not add a re-check here; the
+    /// alternative is a stream that drops a legitimate watcher part-way through for no observable
+    /// reason. Recorded so the property is a decision on the record rather than something rediscovered
+    /// during the next review.
+    /// </para>
     /// </remarks>
     /// <param name="workflowId">The workflow the run belongs to.</param>
     /// <param name="jobId">The run to watch.</param>
@@ -232,9 +244,13 @@ public sealed class WorkflowsController : ControllerBase
             result.Value.JobId, User.GetUserId(), User.GetTenantId());
         if (subscription is null)
         {
+            // Deliberately does not say which ceiling was reached. The caller's own cap and the
+            // host-wide one are refused identically, so a caller cannot use its own refusals to
+            // measure how busy the host is with everyone else's work. What it can act on is the same
+            // either way: poll, or try again shortly.
             return StatusCode(
                 StatusCodes.Status503ServiceUnavailable,
-                "This host is already carrying as many progress streams as it permits. "
+                "No progress stream is available for this run right now. "
                 + "Poll the run's status instead, or retry shortly.");
         }
 

--- a/src/Content/Presentation/Presentation.ExecutionApi/Controllers/WorkflowsController.cs
+++ b/src/Content/Presentation/Presentation.ExecutionApi/Controllers/WorkflowsController.cs
@@ -210,17 +210,20 @@ public sealed class WorkflowsController : ControllerBase
     public async Task<IActionResult> StreamRun(
         Guid workflowId, string jobId, CancellationToken cancellationToken)
     {
+        // One query, asked twice. The two reads differ only in when they happen, and building the
+        // second by hand invites the pair to drift — an authorization check and a snapshot that no
+        // longer describe the same run is exactly the divergence nothing here would catch.
+        var query = new GetWorkflowRunQuery
+        {
+            WorkflowId = workflowId,
+            JobId = jobId,
+            OwnerId = User.GetUserId(),
+            TenantId = User.GetTenantId()
+        };
+
         // Authorized before anything is subscribed or written, so an unauthorized caller never holds
         // one of the host's stream slots.
-        var result = await _mediator.Send(
-            new GetWorkflowRunQuery
-            {
-                WorkflowId = workflowId,
-                JobId = jobId,
-                OwnerId = User.GetUserId(),
-                TenantId = User.GetTenantId()
-            },
-            cancellationToken).ConfigureAwait(false);
+        var result = await _mediator.Send(query, cancellationToken).ConfigureAwait(false);
 
         if (!result.IsSuccess || result.Value is null)
             return MapFailure(result);
@@ -247,15 +250,7 @@ public sealed class WorkflowsController : ControllerBase
         // anyone was listening, so anything that happened in between would be missing from both the
         // snapshot and the live feed — invisible to the client, because a gap it never saw the far
         // side of looks like nothing happening.
-        var current = await _mediator.Send(
-            new GetWorkflowRunQuery
-            {
-                WorkflowId = workflowId,
-                JobId = jobId,
-                OwnerId = User.GetUserId(),
-                TenantId = User.GetTenantId()
-            },
-            cancellationToken).ConfigureAwait(false);
+        var current = await _mediator.Send(query, cancellationToken).ConfigureAwait(false);
 
         var snapshot = current.IsSuccess && current.Value is not null ? current.Value : result.Value;
 

--- a/src/Content/Presentation/Presentation.ExecutionApi/Controllers/WorkflowsController.cs
+++ b/src/Content/Presentation/Presentation.ExecutionApi/Controllers/WorkflowsController.cs
@@ -2,6 +2,7 @@ using Application.AI.Common.CQRS.Workflows.GetRun;
 using Application.AI.Common.CQRS.Workflows.StartRun;
 using Application.AI.Common.CQRS.Workflows.Submit;
 using Application.AI.Common.Interfaces.Governance;
+using Application.AI.Common.Interfaces.Runs;
 using Domain.Common;
 using Presentation.ExecutionApi.DTOs;
 using MediatR;
@@ -11,6 +12,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.RateLimiting;
 using Presentation.ExecutionApi.Extensions;
 using Presentation.ExecutionApi.Services;
+using Presentation.ExecutionApi.Streaming;
 using Presentation.Common.Extensions;
 
 namespace Presentation.ExecutionApi.Controllers;
@@ -52,15 +54,21 @@ public sealed class WorkflowsController : ControllerBase
 {
     private readonly IMediator _mediator;
     private readonly ICapabilityEnvelopeResolver _envelopeResolver;
+    private readonly IRunProgressBroker _progressBroker;
 
     /// <summary>Initializes the controller with its MediatR and envelope-resolver dependencies.</summary>
-    public WorkflowsController(IMediator mediator, ICapabilityEnvelopeResolver envelopeResolver)
+    public WorkflowsController(
+        IMediator mediator,
+        ICapabilityEnvelopeResolver envelopeResolver,
+        IRunProgressBroker progressBroker)
     {
         ArgumentNullException.ThrowIfNull(mediator);
         ArgumentNullException.ThrowIfNull(envelopeResolver);
+        ArgumentNullException.ThrowIfNull(progressBroker);
 
         _mediator = mediator;
         _envelopeResolver = envelopeResolver;
+        _progressBroker = progressBroker;
     }
 
     /// <summary>
@@ -166,6 +174,68 @@ public sealed class WorkflowsController : ControllerBase
         return result.IsSuccess && result.Value is not null
             ? Ok(WorkflowRunResponse.FromRecord(result.Value))
             : MapFailure(result);
+    }
+
+    /// <summary>Streams a run's progress as Server-Sent-Events until it finishes.</summary>
+    /// <remarks>
+    /// <para>
+    /// Authorized exactly like reading the run: another caller's run, a job that never existed, and a
+    /// job read through the wrong workflow's route are one answer, so a stream cannot be used to
+    /// discover work the caller was not given the identifier for.
+    /// </para>
+    /// <para>
+    /// Answers 503 when the host already carries as many streams as it permits. Each open stream holds
+    /// a connection and a buffer for as long as the client keeps it, and serving one that cannot keep
+    /// up would report the run with gaps in it — so the honest answer is to refuse and let the caller
+    /// poll instead.
+    /// </para>
+    /// </remarks>
+    /// <param name="workflowId">The workflow the run belongs to.</param>
+    /// <param name="jobId">The run to watch.</param>
+    /// <param name="cancellationToken">Ends the stream when the client disconnects.</param>
+    [HttpGet("{workflowId:guid}/runs/{jobId}/stream")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status503ServiceUnavailable)]
+    public async Task<IActionResult> StreamRun(
+        Guid workflowId, string jobId, CancellationToken cancellationToken)
+    {
+        // Authorized before anything is subscribed or written, so an unauthorized caller never holds
+        // one of the host's stream slots.
+        var result = await _mediator.Send(
+            new GetWorkflowRunQuery
+            {
+                WorkflowId = workflowId,
+                JobId = jobId,
+                OwnerId = User.GetUserId(),
+                TenantId = User.GetTenantId()
+            },
+            cancellationToken).ConfigureAwait(false);
+
+        if (!result.IsSuccess || result.Value is null)
+            return MapFailure(result);
+
+        using var subscription = _progressBroker.Subscribe(result.Value.JobId);
+        if (subscription is null)
+        {
+            return StatusCode(
+                StatusCodes.Status503ServiceUnavailable,
+                "This host is already carrying as many progress streams as it permits. "
+                + "Poll the run's status instead, or retry shortly.");
+        }
+
+        Response.Headers.ContentType = "text/event-stream";
+        Response.Headers.CacheControl = "no-cache";
+
+        // Chunked responses must not be buffered by a proxy, or the client receives the whole stream
+        // at once when it is already over — which defeats the point of streaming it.
+        Response.Headers["X-Accel-Buffering"] = "no";
+
+        var streamer = new WorkflowProgressStreamer(Response.Body);
+        await streamer.StreamAsync(result.Value, subscription, cancellationToken).ConfigureAwait(false);
+
+        return new EmptyResult();
     }
 
     private IActionResult MapFailure(Result result) =>

--- a/src/Content/Presentation/Presentation.ExecutionApi/Controllers/WorkflowsController.cs
+++ b/src/Content/Presentation/Presentation.ExecutionApi/Controllers/WorkflowsController.cs
@@ -216,7 +216,8 @@ public sealed class WorkflowsController : ControllerBase
         if (!result.IsSuccess || result.Value is null)
             return MapFailure(result);
 
-        using var subscription = _progressBroker.Subscribe(result.Value.JobId);
+        using var subscription = _progressBroker.Subscribe(
+            result.Value.JobId, User.GetUserId(), User.GetTenantId());
         if (subscription is null)
         {
             return StatusCode(
@@ -232,8 +233,25 @@ public sealed class WorkflowsController : ControllerBase
         // at once when it is already over — which defeats the point of streaming it.
         Response.Headers["X-Accel-Buffering"] = "no";
 
+        // Re-read AFTER subscribing, and stream that. The first read authorized the caller; this one
+        // is the snapshot. Reporting the first read instead would describe the run as it stood before
+        // anyone was listening, so anything that happened in between would be missing from both the
+        // snapshot and the live feed — invisible to the client, because a gap it never saw the far
+        // side of looks like nothing happening.
+        var current = await _mediator.Send(
+            new GetWorkflowRunQuery
+            {
+                WorkflowId = workflowId,
+                JobId = jobId,
+                OwnerId = User.GetUserId(),
+                TenantId = User.GetTenantId()
+            },
+            cancellationToken).ConfigureAwait(false);
+
+        var snapshot = current.IsSuccess && current.Value is not null ? current.Value : result.Value;
+
         var streamer = new WorkflowProgressStreamer(Response.Body);
-        await streamer.StreamAsync(result.Value, subscription, cancellationToken).ConfigureAwait(false);
+        await streamer.StreamAsync(snapshot, subscription, cancellationToken).ConfigureAwait(false);
 
         return new EmptyResult();
     }

--- a/src/Content/Presentation/Presentation.ExecutionApi/Controllers/WorkflowsController.cs
+++ b/src/Content/Presentation/Presentation.ExecutionApi/Controllers/WorkflowsController.cs
@@ -184,10 +184,19 @@ public sealed class WorkflowsController : ControllerBase
     /// discover work the caller was not given the identifier for.
     /// </para>
     /// <para>
-    /// Answers 503 when the host already carries as many streams as it permits. Each open stream holds
-    /// a connection and a buffer for as long as the client keeps it, and serving one that cannot keep
-    /// up would report the run with gaps in it — so the honest answer is to refuse and let the caller
-    /// poll instead.
+    /// Answers 503 when the host, or this caller, already carries as many streams as either permits.
+    /// Each open stream holds a connection and a buffer for as long as the client keeps it, and
+    /// serving one that cannot keep up would report the run with gaps in it — so the honest answer is
+    /// to refuse and let the caller poll instead.
+    /// </para>
+    /// <para>
+    /// <strong>Simultaneous streams are bounded by the broker, not by a concurrency rate-limit
+    /// policy.</strong> This route inherits the controller's fixed-window limiter, which counts
+    /// requests started rather than connections held — on its own that would bound nothing about a
+    /// long-lived stream. What actually bounds it is
+    /// <c>MaxProgressStreamsPerOwner</c>, enforced when the subscription is taken. Recorded because
+    /// the two look interchangeable and are not: removing the broker's per-caller cap on the grounds
+    /// that the endpoint "is already rate limited" would leave simultaneous streams unbounded.
     /// </para>
     /// </remarks>
     /// <param name="workflowId">The workflow the run belongs to.</param>

--- a/src/Content/Presentation/Presentation.ExecutionApi/Controllers/WorkflowsController.cs
+++ b/src/Content/Presentation/Presentation.ExecutionApi/Controllers/WorkflowsController.cs
@@ -254,13 +254,6 @@ public sealed class WorkflowsController : ControllerBase
                 + "Poll the run's status instead, or retry shortly.");
         }
 
-        Response.Headers.ContentType = "text/event-stream";
-        Response.Headers.CacheControl = "no-cache";
-
-        // Chunked responses must not be buffered by a proxy, or the client receives the whole stream
-        // at once when it is already over — which defeats the point of streaming it.
-        Response.Headers["X-Accel-Buffering"] = "no";
-
         // Re-read AFTER subscribing, and stream that. The first read authorized the caller; this one
         // is the snapshot. Reporting the first read instead would describe the run as it stood before
         // anyone was listening, so anything that happened in between would be missing from both the
@@ -268,10 +261,23 @@ public sealed class WorkflowsController : ControllerBase
         // side of looks like nothing happening.
         var current = await _mediator.Send(query, cancellationToken).ConfigureAwait(false);
 
-        var snapshot = current.IsSuccess && current.Value is not null ? current.Value : result.Value;
+        // A run that has gone between the two reads was swept, and only a terminal run is ever swept.
+        // Falling back to the older read would describe it as still live and then wait for events
+        // nothing can publish — a stream that never ends, holding a slot until the client gives up.
+        // Answering as the polling endpoint would is both truthful and something callers already
+        // handle. Nothing has been written yet, so a status code is still available to say it with.
+        if (!current.IsSuccess || current.Value is null)
+            return MapFailure(current);
+
+        Response.Headers.ContentType = "text/event-stream";
+        Response.Headers.CacheControl = "no-cache";
+
+        // Chunked responses must not be buffered by a proxy, or the client receives the whole stream
+        // at once when it is already over — which defeats the point of streaming it.
+        Response.Headers["X-Accel-Buffering"] = "no";
 
         var streamer = new WorkflowProgressStreamer(Response.Body);
-        await streamer.StreamAsync(snapshot, subscription, cancellationToken).ConfigureAwait(false);
+        await streamer.StreamAsync(current.Value, subscription, cancellationToken).ConfigureAwait(false);
 
         return new EmptyResult();
     }

--- a/src/Content/Presentation/Presentation.ExecutionApi/Extensions/ExecutionApiServiceCollectionExtensions.cs
+++ b/src/Content/Presentation/Presentation.ExecutionApi/Extensions/ExecutionApiServiceCollectionExtensions.cs
@@ -1,10 +1,12 @@
 using System.Text.Json.Serialization;
+using Application.AI.Common.Interfaces.Planner;
 using System.Threading.RateLimiting;
 using Domain.Common.Config.AI.BundleExecution;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
+using Infrastructure.AI.Runs;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -67,6 +69,14 @@ public static class ExecutionApiServiceCollectionExtensions
         // service (rather than a plain attribute) because the limit is an operator setting read live,
         // not a compile-time constant.
         services.AddScoped<WorkflowRequestSizeLimitFilter>();
+
+        // Replaces the NullPlanProgressNotifier that Presentation.Common registers as the host-
+        // overridable default, so this host's plan notifications reach the run progress broker instead
+        // of being discarded. Last-write-wins, and this runs after the shared defaults.
+        //
+        // Singleton because it holds no per-request state and its two dependencies are singletons; a
+        // scoped registration would fail to resolve on the dispatcher thread, which has no request.
+        services.AddSingleton<IPlanProgressNotifier, PlanProgressRunBridge>();
 
         services.AddExecutionApiAuthentication(bundleConfig.Auth);
 

--- a/src/Content/Presentation/Presentation.ExecutionApi/Streaming/WorkflowProgressEvents.cs
+++ b/src/Content/Presentation/Presentation.ExecutionApi/Streaming/WorkflowProgressEvents.cs
@@ -1,0 +1,98 @@
+using System.Text.Json.Serialization;
+using Domain.AI.Runs;
+
+namespace Presentation.ExecutionApi.Streaming;
+
+/// <summary>
+/// Base type for the frames the workflow progress endpoint writes as Server-Sent-Events.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A small vocabulary, separate from the bundle stream's. That one reproduces the AG-UI subset a
+/// conversational run needs — assistant text, deltas, message boundaries — and a workflow emits none
+/// of it. Sharing a type here would mean a client parsing frames its feed can never contain.
+/// </para>
+/// <para>
+/// Frames MUST be serialized against this base type: <see cref="JsonPolymorphicAttribute"/> emits the
+/// <c>type</c> discriminator only then, and serializing a derived type directly drops it silently.
+/// </para>
+/// </remarks>
+[JsonPolymorphic(TypeDiscriminatorPropertyName = "type")]
+[JsonDerivedType(typeof(WorkflowProgressSnapshotEvent), "SNAPSHOT")]
+[JsonDerivedType(typeof(WorkflowProgressStepEvent), "STEP")]
+[JsonDerivedType(typeof(WorkflowProgressFinishedEvent), "FINISHED")]
+[JsonDerivedType(typeof(WorkflowProgressGapEvent), "GAP")]
+public abstract record WorkflowProgressEvent;
+
+/// <summary>
+/// First frame on every stream: where the run already is.
+/// </summary>
+/// <remarks>
+/// Sent because a watcher almost never arrives at the instant a run starts, and nothing is buffered
+/// for a watcher who has not arrived. Without it, a client that connected a second late would see an
+/// apparently idle run until the next step happened to finish — or, for a run that had already ended,
+/// nothing at all.
+/// </remarks>
+public sealed record WorkflowProgressSnapshotEvent(
+    /// <summary>The run being watched.</summary>
+    [property: JsonPropertyName("jobId")] string JobId,
+    /// <summary>The workflow the run belongs to.</summary>
+    [property: JsonPropertyName("workflowId")] string WorkflowId,
+    /// <summary>Where the run had got to when the stream opened.</summary>
+    [property: JsonPropertyName("status")] string Status,
+    /// <summary>Whether the run had already finished, in which case no further frames follow.</summary>
+    [property: JsonPropertyName("isTerminal")] bool IsTerminal) : WorkflowProgressEvent;
+
+/// <summary>A step started or finished.</summary>
+public sealed record WorkflowProgressStepEvent(
+    /// <summary>Position in this run's event order. Gaps mean events were dropped.</summary>
+    [property: JsonPropertyName("sequence")] long Sequence,
+    /// <summary>When it happened.</summary>
+    [property: JsonPropertyName("occurredAt")] DateTimeOffset OccurredAt,
+    /// <summary>Identifier of the step.</summary>
+    [property: JsonPropertyName("stepId")] string? StepId,
+    /// <summary>Human-readable name of the step, on the frame that starts it.</summary>
+    [property: JsonPropertyName("stepName")] string? StepName,
+    /// <summary>Where the step has got to.</summary>
+    [property: JsonPropertyName("status")] string? Status) : WorkflowProgressEvent;
+
+/// <summary>Last frame on the stream: the run reached a terminal state.</summary>
+public sealed record WorkflowProgressFinishedEvent(
+    /// <summary>Position in this run's event order.</summary>
+    [property: JsonPropertyName("sequence")] long Sequence,
+    /// <summary>When the run finished.</summary>
+    [property: JsonPropertyName("occurredAt")] DateTimeOffset OccurredAt,
+    /// <summary>The terminal status.</summary>
+    [property: JsonPropertyName("status")] string? Status,
+    /// <summary>Caller-safe reason, when the run did not simply succeed.</summary>
+    [property: JsonPropertyName("detail")] string? Detail) : WorkflowProgressEvent;
+
+/// <summary>
+/// The client fell behind and events were dropped.
+/// </summary>
+/// <remarks>
+/// Sent rather than swallowed. A watcher that cannot keep up loses the oldest events so it cannot slow
+/// the run down — but a feed that hid that would leave the client believing it had seen the whole run,
+/// which is a worse failure than admitting the gap.
+/// </remarks>
+public sealed record WorkflowProgressGapEvent(
+    /// <summary>How many events have been dropped for this watcher so far.</summary>
+    [property: JsonPropertyName("droppedCount")] long DroppedCount) : WorkflowProgressEvent;
+
+/// <summary>Projects substrate progress events onto the caller-visible frames.</summary>
+internal static class WorkflowProgressEventMapper
+{
+    /// <summary>Maps one substrate event, or <see langword="null"/> for kinds the wire does not carry.</summary>
+    internal static WorkflowProgressEvent? ToFrame(RunProgressEvent evt) => evt.Kind switch
+    {
+        RunProgressKind.StepStarted or RunProgressKind.StepCompleted =>
+            new WorkflowProgressStepEvent(evt.Sequence, evt.OccurredAt, evt.StepId, evt.StepName, evt.Status),
+
+        RunProgressKind.RunFinished =>
+            new WorkflowProgressFinishedEvent(evt.Sequence, evt.OccurredAt, evt.Status, evt.Detail),
+
+        // RunStarted is not forwarded: the snapshot frame that opens every stream already says the run
+        // is running, and a second frame saying so would only ever be redundant or contradictory.
+        _ => null
+    };
+}

--- a/src/Content/Presentation/Presentation.ExecutionApi/Streaming/WorkflowProgressStreamer.cs
+++ b/src/Content/Presentation/Presentation.ExecutionApi/Streaming/WorkflowProgressStreamer.cs
@@ -120,12 +120,24 @@ public sealed class WorkflowProgressStreamer
             while (true)
             {
                 var next = events.MoveNextAsync().AsTask();
-                var completed = await Task.WhenAny(next, Task.Delay(KeepAliveInterval, cancellationToken))
-                    .ConfigureAwait(false);
+
+                // The delay deliberately takes no cancellation token. Whichever task loses this race
+                // is abandoned, and an abandoned cancellable delay faults when the token fires — with
+                // nobody left to observe it. That is an unhandled exception on a thread-pool thread
+                // every time a client disconnects, which is the ordinary way a stream ends. The read
+                // already honours cancellation, so the token is not needed here to stop the loop.
+                var keepAlive = Task.Delay(KeepAliveInterval);
+                var completed = await Task.WhenAny(next, keepAlive).ConfigureAwait(false);
 
                 if (completed != next)
                 {
-                    await WriteRawAsync(KeepAliveFrame, cancellationToken).ConfigureAwait(false);
+                    // A client that has gone is the ordinary way a stream ends — a closed tab, a
+                    // dropped connection — and the first the server hears of it is often a failed
+                    // write. Ending quietly is the honest response: the run is unaffected, and there
+                    // is nobody left to tell.
+                    if (!await TryWriteRawAsync(KeepAliveFrame, cancellationToken).ConfigureAwait(false))
+                        yield break;
+
                     yield return null;
                     continue;
                 }
@@ -142,10 +154,21 @@ public sealed class WorkflowProgressStreamer
         }
     }
 
-    private async Task WriteRawAsync(string frame, CancellationToken cancellationToken)
+    /// <summary>Writes a raw frame, reporting whether the client was still there to receive it.</summary>
+    private async Task<bool> TryWriteRawAsync(string frame, CancellationToken cancellationToken)
     {
-        await _body.WriteAsync(Encoding.UTF8.GetBytes(frame), cancellationToken).ConfigureAwait(false);
-        await _body.FlushAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            await _body.WriteAsync(Encoding.UTF8.GetBytes(frame), cancellationToken).ConfigureAwait(false);
+            await _body.FlushAsync(cancellationToken).ConfigureAwait(false);
+            return true;
+        }
+        catch (Exception ex) when (ex is OperationCanceledException or ObjectDisposedException or IOException)
+        {
+            // The three ways a gone client presents itself. Anything else is a real fault and is left
+            // to propagate rather than being swallowed as a disconnect.
+            return false;
+        }
     }
 
     private async Task WriteAsync(WorkflowProgressEvent evt, CancellationToken cancellationToken)

--- a/src/Content/Presentation/Presentation.ExecutionApi/Streaming/WorkflowProgressStreamer.cs
+++ b/src/Content/Presentation/Presentation.ExecutionApi/Streaming/WorkflowProgressStreamer.cs
@@ -32,6 +32,15 @@ public sealed class WorkflowProgressStreamer
         DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
     };
 
+    /// <summary>
+    /// How long a stream may stay silent before it says something. Short enough to sit well inside the
+    /// idle timeouts intermediaries commonly apply, long enough to cost nothing.
+    /// </summary>
+    private static readonly TimeSpan KeepAliveInterval = TimeSpan.FromSeconds(15);
+
+    /// <summary>An SSE comment. Conformant clients ignore it; intermediaries see traffic.</summary>
+    private const string KeepAliveFrame = ": keep-alive\n\n";
+
     private readonly Stream _body;
 
     /// <summary>Initializes a streamer writing to <paramref name="responseBody"/>.</summary>
@@ -65,8 +74,13 @@ public sealed class WorkflowProgressStreamer
 
         var reportedDrops = 0L;
 
-        await foreach (var evt in subscription.ReadAllAsync(cancellationToken).ConfigureAwait(false))
+        await foreach (var evt in HeartbeatAsync(subscription, cancellationToken).ConfigureAwait(false))
         {
+            // A heartbeat is not an event; it has already been written as an SSE comment to keep the
+            // connection observably alive.
+            if (evt is null)
+                continue;
+
             // Checked per frame rather than once: a watcher can start keeping up again, and the count
             // only matters when it has grown since the client was last told.
             var dropped = subscription.DroppedCount;
@@ -83,6 +97,55 @@ public sealed class WorkflowProgressStreamer
             if (evt.Kind == RunProgressKind.RunFinished)
                 return;
         }
+    }
+
+    /// <summary>
+    /// Yields the subscription's events, emitting a keep-alive comment whenever it goes quiet.
+    /// </summary>
+    /// <remarks>
+    /// A workflow step can run for minutes without producing anything to report, and a stream that
+    /// sends no bytes for that long is indistinguishable from a dead one: proxies and load balancers
+    /// with an idle-read timeout close it, and the client sees the run abandoned rather than running.
+    /// An SSE comment is ignored by every conformant client, so this costs the caller nothing to
+    /// consume — it exists so both ends can tell a quiet stream from a broken one.
+    /// </remarks>
+    private async IAsyncEnumerable<RunProgressEvent?> HeartbeatAsync(
+        IRunProgressSubscription subscription,
+        [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        var events = subscription.ReadAllAsync(cancellationToken).GetAsyncEnumerator(cancellationToken);
+
+        try
+        {
+            while (true)
+            {
+                var next = events.MoveNextAsync().AsTask();
+                var completed = await Task.WhenAny(next, Task.Delay(KeepAliveInterval, cancellationToken))
+                    .ConfigureAwait(false);
+
+                if (completed != next)
+                {
+                    await WriteRawAsync(KeepAliveFrame, cancellationToken).ConfigureAwait(false);
+                    yield return null;
+                    continue;
+                }
+
+                if (!await next.ConfigureAwait(false))
+                    yield break;
+
+                yield return events.Current;
+            }
+        }
+        finally
+        {
+            await events.DisposeAsync().ConfigureAwait(false);
+        }
+    }
+
+    private async Task WriteRawAsync(string frame, CancellationToken cancellationToken)
+    {
+        await _body.WriteAsync(Encoding.UTF8.GetBytes(frame), cancellationToken).ConfigureAwait(false);
+        await _body.FlushAsync(cancellationToken).ConfigureAwait(false);
     }
 
     private async Task WriteAsync(WorkflowProgressEvent evt, CancellationToken cancellationToken)

--- a/src/Content/Presentation/Presentation.ExecutionApi/Streaming/WorkflowProgressStreamer.cs
+++ b/src/Content/Presentation/Presentation.ExecutionApi/Streaming/WorkflowProgressStreamer.cs
@@ -73,9 +73,14 @@ public sealed class WorkflowProgressStreamer
         ArgumentNullException.ThrowIfNull(run);
         ArgumentNullException.ThrowIfNull(subscription);
 
-        await WriteAsync(
+        var delivered = await WriteAsync(
             new WorkflowProgressSnapshotEvent(run.JobId, run.TargetId, run.Status.ToString(), run.IsTerminal),
             cancellationToken).ConfigureAwait(false);
+
+        // A client can be gone before the first frame lands — it need only close the tab while the
+        // request was in flight — and there is then nothing to stream to.
+        if (!delivered)
+            return;
 
         // A run that had already finished has nothing further to report, and waiting on its stream
         // would hold the connection open until the client gave up.
@@ -97,12 +102,18 @@ public sealed class WorkflowProgressStreamer
             if (dropped > reportedDrops)
             {
                 reportedDrops = dropped;
-                await WriteAsync(new WorkflowProgressGapEvent(dropped), cancellationToken).ConfigureAwait(false);
+
+                if (!await WriteAsync(new WorkflowProgressGapEvent(dropped), cancellationToken)
+                        .ConfigureAwait(false))
+                    return;
             }
 
             var frame = WorkflowProgressEventMapper.ToFrame(evt);
-            if (frame is not null)
-                await WriteAsync(frame, cancellationToken).ConfigureAwait(false);
+            if (frame is not null
+                && !await WriteAsync(frame, cancellationToken).ConfigureAwait(false))
+            {
+                return;
+            }
 
             if (evt.Kind == RunProgressKind.RunFinished)
                 return;
@@ -125,17 +136,20 @@ public sealed class WorkflowProgressStreamer
     {
         var events = subscription.ReadAllAsync(cancellationToken).GetAsyncEnumerator(cancellationToken);
 
+        // Held across iterations rather than started fresh each time round. When the keep-alive wins
+        // the race below, this read is still outstanding — asking the enumerator for another one while
+        // the first has not finished is two concurrent MoveNextAsync calls on a single async
+        // enumerator, which is undefined and in practice corrupts its state machine. It faulted on a
+        // thread-pool thread with nobody left to observe it, which ends the process, and every step
+        // quieter than the keep-alive interval took that path: the ordinary case for real work, not an
+        // edge one. The pending read is reused until it actually completes.
+        //
+        // Declared outside the try so the finally can see whether a read is still in flight, which
+        // decides whether the enumerator may be disposed at all.
+        Task<bool>? next = null;
+
         try
         {
-            // Held across iterations rather than started fresh each time round. When the keep-alive
-            // wins the race below, this read is still outstanding — asking the enumerator for another
-            // one while the first has not finished is two concurrent MoveNextAsync calls on a single
-            // async enumerator, which is undefined and in practice corrupts its state machine. It
-            // faulted on a thread-pool thread with nobody left to observe it, which ends the process,
-            // and every step quieter than the keep-alive interval took that path: the ordinary case
-            // for real work, not an edge one. The pending read is reused until it actually completes.
-            Task<bool>? next = null;
-
             while (true)
             {
                 next ??= events.MoveNextAsync().AsTask();
@@ -161,21 +175,42 @@ public sealed class WorkflowProgressStreamer
                     continue;
                 }
 
-                if (!await next.ConfigureAwait(false))
-                    yield break;
+                var moved = await next.ConfigureAwait(false);
 
-                var current = events.Current;
-
-                // Cleared only now the read has completed and its value has been taken, so the next
-                // iteration is the only place a fresh one is ever started.
+                // Cleared as soon as the read has completed and its value has been taken. Beyond
+                // reserving the next iteration as the only place a fresh read starts, this is what
+                // makes a non-null value below mean "still in flight" rather than merely "was used".
                 next = null;
 
-                yield return current;
+                if (!moved)
+                    yield break;
+
+                yield return events.Current;
             }
         }
         finally
         {
-            await events.DisposeAsync().ConfigureAwait(false);
+            // An async iterator suspended at an await cannot be disposed — DisposeAsync throws
+            // NotSupportedException — so the enumerator may only be disposed when its read is not in
+            // flight. Exactly one exit leaves one in flight: the client went away while the stream was
+            // quiet, which is an ordinary way for a stream to end rather than a rare one.
+            if (next is null || next.IsCompleted)
+            {
+                await events.DisposeAsync().ConfigureAwait(false);
+            }
+            else
+            {
+                // Left to finish on its own instead. It completes as soon as the request aborts or the
+                // caller disposes the subscription, both of which follow from the client having gone,
+                // and the enumerator becomes collectable with it. The continuation exists only to
+                // observe whatever the read finishes with: an unobserved fault on a detached task is
+                // the exact shape of bug that already took this process down once.
+                _ = next.ContinueWith(
+                    static finished => _ = finished.Exception,
+                    CancellationToken.None,
+                    TaskContinuationOptions.ExecuteSynchronously,
+                    TaskScheduler.Default);
+            }
         }
     }
 
@@ -196,12 +231,18 @@ public sealed class WorkflowProgressStreamer
         }
     }
 
-    private async Task WriteAsync(WorkflowProgressEvent evt, CancellationToken cancellationToken)
+    /// <summary>Writes one frame, reporting whether the client was still there to receive it.</summary>
+    /// <remarks>
+    /// Goes through the same guarded write as the keep-alive rather than writing directly. A client
+    /// disconnecting between events is every bit as ordinary as one disconnecting during a quiet
+    /// patch, and handling only the second would mean the two write paths disagreed about what a
+    /// departed client is: a quiet end on one, an exception out of the request pipeline on the other —
+    /// on a response whose headers have already been sent, so there is not even a status code left to
+    /// say it with.
+    /// </remarks>
+    private Task<bool> WriteAsync(WorkflowProgressEvent evt, CancellationToken cancellationToken)
     {
         var json = JsonSerializer.Serialize(evt, typeof(WorkflowProgressEvent), SerializerOptions);
-        var frame = Encoding.UTF8.GetBytes($"data: {json}\n\n");
-
-        await _body.WriteAsync(frame, cancellationToken).ConfigureAwait(false);
-        await _body.FlushAsync(cancellationToken).ConfigureAwait(false);
+        return TryWriteRawAsync($"data: {json}\n\n", cancellationToken);
     }
 }

--- a/src/Content/Presentation/Presentation.ExecutionApi/Streaming/WorkflowProgressStreamer.cs
+++ b/src/Content/Presentation/Presentation.ExecutionApi/Streaming/WorkflowProgressStreamer.cs
@@ -17,10 +17,11 @@ namespace Presentation.ExecutionApi.Streaming;
 /// stream truthful from its first frame about what it can and cannot show.
 /// </para>
 /// <para>
-/// <strong>The subscription is taken before the snapshot is read.</strong> The other order has a
-/// window in which the run advances after the snapshot but before anyone is listening, and those
-/// events are lost with nothing to indicate it. Subscribing first means the worst case is an event
-/// the client sees twice — which its sequence numbers make obvious — rather than one it never sees.
+/// <strong>The caller subscribes before reading the state this reports.</strong> The other order has
+/// a window in which the run advances after the snapshot but before anyone is listening, and those
+/// events are lost with nothing to indicate it — invisible to the client, because a gap it never saw
+/// the far side of looks like nothing happening. Subscribing first makes the worst case an event the
+/// client sees twice, which its sequence numbers make obvious.
 /// </para>
 /// </remarks>
 public sealed class WorkflowProgressStreamer

--- a/src/Content/Presentation/Presentation.ExecutionApi/Streaming/WorkflowProgressStreamer.cs
+++ b/src/Content/Presentation/Presentation.ExecutionApi/Streaming/WorkflowProgressStreamer.cs
@@ -1,0 +1,95 @@
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Application.AI.Common.Interfaces.Runs;
+using Domain.AI.Runs;
+
+namespace Presentation.ExecutionApi.Streaming;
+
+/// <summary>
+/// Writes one run's progress to a response body as Server-Sent-Events.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>Snapshot first, then live.</strong> Nothing is buffered for a watcher who has not arrived,
+/// so a stream that opened only live events would show an apparently idle run until the next step
+/// happened to finish — and nothing at all for a run that had already ended. The snapshot makes the
+/// stream truthful from its first frame about what it can and cannot show.
+/// </para>
+/// <para>
+/// <strong>The subscription is taken before the snapshot is read.</strong> The other order has a
+/// window in which the run advances after the snapshot but before anyone is listening, and those
+/// events are lost with nothing to indicate it. Subscribing first means the worst case is an event
+/// the client sees twice — which its sequence numbers make obvious — rather than one it never sees.
+/// </para>
+/// </remarks>
+public sealed class WorkflowProgressStreamer
+{
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+    };
+
+    private readonly Stream _body;
+
+    /// <summary>Initializes a streamer writing to <paramref name="responseBody"/>.</summary>
+    public WorkflowProgressStreamer(Stream responseBody)
+    {
+        ArgumentNullException.ThrowIfNull(responseBody);
+        _body = responseBody;
+    }
+
+    /// <summary>
+    /// Streams <paramref name="run"/>'s progress until it finishes, the client disconnects, or the
+    /// host stops.
+    /// </summary>
+    /// <param name="run">The run as it stood when the request was authorized.</param>
+    /// <param name="subscription">Live events for that run. Owned by the caller.</param>
+    /// <param name="cancellationToken">Ends the stream.</param>
+    public async Task StreamAsync(
+        RunRecord run, IRunProgressSubscription subscription, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(run);
+        ArgumentNullException.ThrowIfNull(subscription);
+
+        await WriteAsync(
+            new WorkflowProgressSnapshotEvent(run.JobId, run.TargetId, run.Status.ToString(), run.IsTerminal),
+            cancellationToken).ConfigureAwait(false);
+
+        // A run that had already finished has nothing further to report, and waiting on its stream
+        // would hold the connection open until the client gave up.
+        if (run.IsTerminal)
+            return;
+
+        var reportedDrops = 0L;
+
+        await foreach (var evt in subscription.ReadAllAsync(cancellationToken).ConfigureAwait(false))
+        {
+            // Checked per frame rather than once: a watcher can start keeping up again, and the count
+            // only matters when it has grown since the client was last told.
+            var dropped = subscription.DroppedCount;
+            if (dropped > reportedDrops)
+            {
+                reportedDrops = dropped;
+                await WriteAsync(new WorkflowProgressGapEvent(dropped), cancellationToken).ConfigureAwait(false);
+            }
+
+            var frame = WorkflowProgressEventMapper.ToFrame(evt);
+            if (frame is not null)
+                await WriteAsync(frame, cancellationToken).ConfigureAwait(false);
+
+            if (evt.Kind == RunProgressKind.RunFinished)
+                return;
+        }
+    }
+
+    private async Task WriteAsync(WorkflowProgressEvent evt, CancellationToken cancellationToken)
+    {
+        var json = JsonSerializer.Serialize(evt, typeof(WorkflowProgressEvent), SerializerOptions);
+        var frame = Encoding.UTF8.GetBytes($"data: {json}\n\n");
+
+        await _body.WriteAsync(frame, cancellationToken).ConfigureAwait(false);
+        await _body.FlushAsync(cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/src/Content/Presentation/Presentation.ExecutionApi/Streaming/WorkflowProgressStreamer.cs
+++ b/src/Content/Presentation/Presentation.ExecutionApi/Streaming/WorkflowProgressStreamer.cs
@@ -36,18 +36,28 @@ public sealed class WorkflowProgressStreamer
     /// How long a stream may stay silent before it says something. Short enough to sit well inside the
     /// idle timeouts intermediaries commonly apply, long enough to cost nothing.
     /// </summary>
-    private static readonly TimeSpan KeepAliveInterval = TimeSpan.FromSeconds(15);
+    public static readonly TimeSpan DefaultKeepAliveInterval = TimeSpan.FromSeconds(15);
 
     /// <summary>An SSE comment. Conformant clients ignore it; intermediaries see traffic.</summary>
     private const string KeepAliveFrame = ": keep-alive\n\n";
 
     private readonly Stream _body;
+    private readonly TimeSpan _keepAliveInterval;
 
     /// <summary>Initializes a streamer writing to <paramref name="responseBody"/>.</summary>
-    public WorkflowProgressStreamer(Stream responseBody)
+    /// <param name="responseBody">Where frames are written.</param>
+    /// <param name="keepAliveInterval">
+    /// How long the stream may stay silent before emitting a keep-alive comment. Defaults to
+    /// <see cref="DefaultKeepAliveInterval"/>. Injectable because the quiet path is otherwise only
+    /// reachable by a test that waits out the production interval, which is long enough that nobody
+    /// writes that test — and the quiet path is where this class is least like the busy one.
+    /// </param>
+    public WorkflowProgressStreamer(Stream responseBody, TimeSpan? keepAliveInterval = null)
     {
         ArgumentNullException.ThrowIfNull(responseBody);
+
         _body = responseBody;
+        _keepAliveInterval = keepAliveInterval ?? DefaultKeepAliveInterval;
     }
 
     /// <summary>
@@ -117,16 +127,25 @@ public sealed class WorkflowProgressStreamer
 
         try
         {
+            // Held across iterations rather than started fresh each time round. When the keep-alive
+            // wins the race below, this read is still outstanding — asking the enumerator for another
+            // one while the first has not finished is two concurrent MoveNextAsync calls on a single
+            // async enumerator, which is undefined and in practice corrupts its state machine. It
+            // faulted on a thread-pool thread with nobody left to observe it, which ends the process,
+            // and every step quieter than the keep-alive interval took that path: the ordinary case
+            // for real work, not an edge one. The pending read is reused until it actually completes.
+            Task<bool>? next = null;
+
             while (true)
             {
-                var next = events.MoveNextAsync().AsTask();
+                next ??= events.MoveNextAsync().AsTask();
 
                 // The delay deliberately takes no cancellation token. Whichever task loses this race
                 // is abandoned, and an abandoned cancellable delay faults when the token fires — with
                 // nobody left to observe it. That is an unhandled exception on a thread-pool thread
                 // every time a client disconnects, which is the ordinary way a stream ends. The read
                 // already honours cancellation, so the token is not needed here to stop the loop.
-                var keepAlive = Task.Delay(KeepAliveInterval);
+                var keepAlive = Task.Delay(_keepAliveInterval);
                 var completed = await Task.WhenAny(next, keepAlive).ConfigureAwait(false);
 
                 if (completed != next)
@@ -145,7 +164,13 @@ public sealed class WorkflowProgressStreamer
                 if (!await next.ConfigureAwait(false))
                     yield break;
 
-                yield return events.Current;
+                var current = events.Current;
+
+                // Cleared only now the read has completed and its value has been taken, so the next
+                // iteration is the only place a fresh one is ever started.
+                next = null;
+
+                yield return current;
             }
         }
         finally

--- a/src/Content/Tests/Infrastructure.AI.Tests/Runs/InMemoryRunJobStoreTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Runs/InMemoryRunJobStoreTests.cs
@@ -301,7 +301,7 @@ public sealed class InMemoryRunJobStoreTests
 
         _time.Advance(TimeSpan.FromDays(7));
 
-        sut.SweepExpired().Should().Be(0);
+        sut.SweepExpired().Should().BeEmpty();
         sut.Get("job-1", "alice", null).Should().NotBeNull();
     }
 
@@ -314,10 +314,10 @@ public sealed class InMemoryRunJobStoreTests
         sut.Update(claimed with { Status = RunStatus.Succeeded, CompletedAt = _time.GetUtcNow() });
 
         _time.Advance(TimeSpan.FromMinutes(4));
-        sut.SweepExpired().Should().Be(0);
+        sut.SweepExpired().Should().BeEmpty();
 
         _time.Advance(TimeSpan.FromMinutes(2));
-        sut.SweepExpired().Should().Be(1);
+        sut.SweepExpired().Should().HaveCount(1);
         sut.Get("job-1", "alice", null).Should().BeNull();
     }
 
@@ -334,7 +334,7 @@ public sealed class InMemoryRunJobStoreTests
 
         _time.Advance(TimeSpan.FromMinutes(5));
 
-        sut.SweepExpired().Should().Be(0, "retention runs from completion, not from acceptance");
+        sut.SweepExpired().Should().BeEmpty("retention runs from completion, not from acceptance");
         sut.Get("job-1", "alice", null).Should().NotBeNull();
     }
 

--- a/src/Content/Tests/Infrastructure.AI.Tests/Runs/InMemoryRunProgressBrokerTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Runs/InMemoryRunProgressBrokerTests.cs
@@ -1,0 +1,198 @@
+using Application.AI.Common.Interfaces.Runs;
+using Domain.AI.Runs;
+using Domain.Common.Config;
+using FluentAssertions;
+using Infrastructure.AI.Runs;
+using Infrastructure.AI.Tests.Runs.Support;
+using Microsoft.Extensions.Time.Testing;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Runs;
+
+/// <summary>
+/// Tests for <see cref="InMemoryRunProgressBroker"/>.
+/// </summary>
+/// <remarks>
+/// The properties that carry consequences: publishing must never block the run (a watcher is an
+/// observer, and letting a slow reader hold up paid work would be the wrong trade), a watcher that
+/// falls behind must be told so rather than silently shown an incomplete run, and two watchers of one
+/// run must not cost each other events.
+/// </remarks>
+public sealed class InMemoryRunProgressBrokerTests
+{
+    private readonly FakeTimeProvider _time = new(new DateTimeOffset(2026, 7, 29, 12, 0, 0, TimeSpan.Zero));
+    private readonly AppConfig _config = new();
+
+    private InMemoryRunProgressBroker BuildSut(int buffer = 256, int maxStreams = 64)
+    {
+        _config.AI.WorkflowSubmission.ProgressBufferSize = buffer;
+        _config.AI.WorkflowSubmission.MaxConcurrentProgressStreams = maxStreams;
+        return new InMemoryRunProgressBroker(new StaticOptionsMonitor<AppConfig>(_config), _time);
+    }
+
+    private static async Task<List<RunProgressEvent>> DrainAsync(
+        IRunProgressSubscription subscription, int expected)
+    {
+        var received = new List<RunProgressEvent>();
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+
+        await foreach (var evt in subscription.ReadAllAsync(cts.Token))
+        {
+            received.Add(evt);
+            if (received.Count == expected)
+                break;
+        }
+
+        return received;
+    }
+
+    [Fact]
+    public async Task ASubscriberReceivesWhatIsPublishedForItsRun()
+    {
+        var sut = BuildSut();
+        using var subscription = sut.Subscribe("job-1")!;
+
+        sut.Publish("job-1", RunProgressKind.StepStarted, stepId: "s1", stepName: "first");
+        sut.Publish("job-1", RunProgressKind.StepCompleted, stepId: "s1", status: "Completed");
+
+        var received = await DrainAsync(subscription, 2);
+
+        received.Should().HaveCount(2);
+        received[0].Kind.Should().Be(RunProgressKind.StepStarted);
+        received[0].StepName.Should().Be("first");
+        received[1].Kind.Should().Be(RunProgressKind.StepCompleted);
+    }
+
+    [Fact]
+    public async Task EventsForOtherRunsAreNotDelivered()
+    {
+        // A job identifier is the only thing separating callers here too. A watcher that received
+        // another run's steps would learn about work it was never given the identifier for.
+        var sut = BuildSut();
+        using var subscription = sut.Subscribe("job-1")!;
+
+        sut.Publish("job-2", RunProgressKind.StepStarted, stepId: "not-mine");
+        sut.Publish("job-1", RunProgressKind.StepStarted, stepId: "mine");
+
+        var received = await DrainAsync(subscription, 1);
+
+        received.Should().ContainSingle();
+        received[0].StepId.Should().Be("mine");
+    }
+
+    [Fact]
+    public void PublishingWithNoSubscribers_IsANoOpRatherThanABuffer()
+    {
+        // Holding a transcript for a watcher who may never arrive means deciding how long to keep it.
+        // A late watcher is given the run's current state instead, which is bounded and honest.
+        var sut = BuildSut(buffer: 2);
+
+        for (var i = 0; i < 1000; i++)
+            sut.Publish("job-1", RunProgressKind.StepStarted, stepId: $"s{i}");
+
+        using var subscription = sut.Subscribe("job-1")!;
+        sut.Publish("job-1", RunProgressKind.StepCompleted, stepId: "after");
+
+        subscription.DroppedCount.Should().Be(0, "nothing was buffered, so nothing was dropped");
+    }
+
+    [Fact]
+    public async Task Sequence_StartsAtOneAndIncreasesPerRun()
+    {
+        // The numbering is what makes a gap detectable. Without it a client cannot tell a stream that
+        // skipped an event from one that had nothing to say.
+        var sut = BuildSut();
+        using var first = sut.Subscribe("job-1")!;
+        using var second = sut.Subscribe("job-2")!;
+
+        sut.Publish("job-1", RunProgressKind.StepStarted);
+        sut.Publish("job-1", RunProgressKind.StepCompleted);
+        sut.Publish("job-2", RunProgressKind.StepStarted);
+
+        var firstEvents = await DrainAsync(first, 2);
+        var secondEvents = await DrainAsync(second, 1);
+
+        firstEvents.Select(e => e.Sequence).Should().Equal(1, 2);
+        secondEvents.Select(e => e.Sequence).Should().Equal([1L],
+            "each run is numbered independently, so a second run does not inherit the first's position");
+    }
+
+    [Fact]
+    public void ASlowWatcherLosesEventsAndIsToldSo()
+    {
+        // The alternative on a full buffer is to block the publisher, which is the run — an observer
+        // would then be able to slow paid work down by reading slowly, or by walking away.
+        var sut = BuildSut(buffer: 4);
+        using var subscription = sut.Subscribe("job-1")!;
+
+        for (var i = 0; i < 20; i++)
+            sut.Publish("job-1", RunProgressKind.StepStarted, stepId: $"s{i}");
+
+        subscription.DroppedCount.Should().BeGreaterThan(0,
+            "a watcher that cannot keep up must be able to tell that its view has gaps");
+    }
+
+    [Fact]
+    public async Task ASlowWatcherDoesNotCostAnotherWatcherEvents()
+    {
+        // Per-watcher buffers, not per run. A shared buffer would make the slowest reader the whole
+        // run's reader.
+        var sut = BuildSut(buffer: 4);
+        using var slow = sut.Subscribe("job-1")!;
+        using var fast = sut.Subscribe("job-1")!;
+
+        for (var i = 0; i < 4; i++)
+            sut.Publish("job-1", RunProgressKind.StepStarted, stepId: $"s{i}");
+
+        var received = await DrainAsync(fast, 4);
+
+        received.Should().HaveCount(4);
+        fast.DroppedCount.Should().Be(0);
+    }
+
+    [Fact]
+    public void Subscribe_BeyondTheHostsStreamLimit_IsRefused()
+    {
+        // Each open stream holds a connection and a buffer for as long as the client keeps it, so an
+        // unbounded number of them exhausts the host by asking politely.
+        var sut = BuildSut(maxStreams: 2);
+
+        using var first = sut.Subscribe("job-1");
+        using var second = sut.Subscribe("job-2");
+        var third = sut.Subscribe("job-3");
+
+        first.Should().NotBeNull();
+        second.Should().NotBeNull();
+        third.Should().BeNull();
+    }
+
+    [Fact]
+    public void DisposingASubscription_ReturnsItsSlotToTheHost()
+    {
+        // Without this a host that has served its limit once can never serve another stream, and the
+        // refusal looks identical to genuine saturation.
+        var sut = BuildSut(maxStreams: 1);
+
+        var first = sut.Subscribe("job-1");
+        first.Should().NotBeNull();
+        sut.Subscribe("job-2").Should().BeNull();
+
+        first!.Dispose();
+
+        using var afterRelease = sut.Subscribe("job-2");
+        afterRelease.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void PublishingAfterTheLastWatcherLeaves_IsHarmless()
+    {
+        // Runs outlive their watchers routinely — a client closes the tab and the workflow carries on.
+        var sut = BuildSut();
+        var subscription = sut.Subscribe("job-1")!;
+        subscription.Dispose();
+
+        var act = () => sut.Publish("job-1", RunProgressKind.RunFinished, status: "Succeeded");
+
+        act.Should().NotThrow();
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Runs/InMemoryRunProgressBrokerTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Runs/InMemoryRunProgressBrokerTests.cs
@@ -309,6 +309,47 @@ public sealed class InMemoryRunProgressBrokerTests
     }
 
     [Fact]
+    public void ForgettingARunSomeoneIsStillWatching_CompletesWhenTheyLeave()
+    {
+        // Forget is called once per run, by the sweep. Returning early because a watcher was attached
+        // and recording nothing would hold that run's entries for the life of the process — nothing
+        // calls Forget again. Safe to finish on the watcher's way out precisely because the run's
+        // records are already gone, so nothing can subscribe to or publish for it again.
+        var sut = BuildSut();
+        var watcher = sut.Subscribe("job-1", "alice", "acme")!;
+
+        sut.Forget("job-1");
+        sut.HeldRunCount.Should().Be(1, "the run is still being watched, so nothing is reclaimed yet");
+
+        watcher.Dispose();
+
+        sut.HeldRunCount.Should().Be(0, "the last watcher out finishes what the sweep deferred");
+    }
+
+    [Fact]
+    public void ForgettingAnUnwatchedRun_ReclaimsItImmediately()
+    {
+        var sut = BuildSut();
+        sut.Subscribe("job-1", "alice", "acme")!.Dispose();
+        sut.Publish("job-1", RunProgressKind.StepStarted);
+
+        sut.Forget("job-1");
+
+        sut.HeldRunCount.Should().Be(0);
+    }
+
+    [Fact]
+    public void ARunNobodyForgot_IsStillHeld()
+    {
+        // The negative case, so the two tests above cannot both pass by reclaiming everything.
+        var sut = BuildSut();
+        sut.Subscribe("job-1", "alice", "acme")!.Dispose();
+        sut.Publish("job-1", RunProgressKind.StepStarted);
+
+        sut.HeldRunCount.Should().Be(1, "reclaiming is the sweep's decision, not a side effect of leaving");
+    }
+
+    [Fact]
     public void PublishingAfterTheLastWatcherLeaves_IsHarmless()
     {
         // Runs outlive their watchers routinely — a client closes the tab and the workflow carries on.

--- a/src/Content/Tests/Infrastructure.AI.Tests/Runs/InMemoryRunProgressBrokerTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Runs/InMemoryRunProgressBrokerTests.cs
@@ -23,10 +23,11 @@ public sealed class InMemoryRunProgressBrokerTests
     private readonly FakeTimeProvider _time = new(new DateTimeOffset(2026, 7, 29, 12, 0, 0, TimeSpan.Zero));
     private readonly AppConfig _config = new();
 
-    private InMemoryRunProgressBroker BuildSut(int buffer = 256, int maxStreams = 64)
+    private InMemoryRunProgressBroker BuildSut(int buffer = 256, int maxStreams = 64, int perOwner = 64)
     {
         _config.AI.WorkflowSubmission.ProgressBufferSize = buffer;
         _config.AI.WorkflowSubmission.MaxConcurrentProgressStreams = maxStreams;
+        _config.AI.WorkflowSubmission.MaxProgressStreamsPerOwner = perOwner;
         return new InMemoryRunProgressBroker(new StaticOptionsMonitor<AppConfig>(_config), _time);
     }
 
@@ -50,7 +51,7 @@ public sealed class InMemoryRunProgressBrokerTests
     public async Task ASubscriberReceivesWhatIsPublishedForItsRun()
     {
         var sut = BuildSut();
-        using var subscription = sut.Subscribe("job-1")!;
+        using var subscription = sut.Subscribe("job-1", "alice", "acme")!;
 
         sut.Publish("job-1", RunProgressKind.StepStarted, stepId: "s1", stepName: "first");
         sut.Publish("job-1", RunProgressKind.StepCompleted, stepId: "s1", status: "Completed");
@@ -69,7 +70,7 @@ public sealed class InMemoryRunProgressBrokerTests
         // A job identifier is the only thing separating callers here too. A watcher that received
         // another run's steps would learn about work it was never given the identifier for.
         var sut = BuildSut();
-        using var subscription = sut.Subscribe("job-1")!;
+        using var subscription = sut.Subscribe("job-1", "alice", "acme")!;
 
         sut.Publish("job-2", RunProgressKind.StepStarted, stepId: "not-mine");
         sut.Publish("job-1", RunProgressKind.StepStarted, stepId: "mine");
@@ -90,7 +91,7 @@ public sealed class InMemoryRunProgressBrokerTests
         for (var i = 0; i < 1000; i++)
             sut.Publish("job-1", RunProgressKind.StepStarted, stepId: $"s{i}");
 
-        using var subscription = sut.Subscribe("job-1")!;
+        using var subscription = sut.Subscribe("job-1", "alice", "acme")!;
         sut.Publish("job-1", RunProgressKind.StepCompleted, stepId: "after");
 
         subscription.DroppedCount.Should().Be(0, "nothing was buffered, so nothing was dropped");
@@ -102,8 +103,8 @@ public sealed class InMemoryRunProgressBrokerTests
         // The numbering is what makes a gap detectable. Without it a client cannot tell a stream that
         // skipped an event from one that had nothing to say.
         var sut = BuildSut();
-        using var first = sut.Subscribe("job-1")!;
-        using var second = sut.Subscribe("job-2")!;
+        using var first = sut.Subscribe("job-1", "alice", "acme")!;
+        using var second = sut.Subscribe("job-2", "alice", "acme")!;
 
         sut.Publish("job-1", RunProgressKind.StepStarted);
         sut.Publish("job-1", RunProgressKind.StepCompleted);
@@ -123,7 +124,7 @@ public sealed class InMemoryRunProgressBrokerTests
         // The alternative on a full buffer is to block the publisher, which is the run — an observer
         // would then be able to slow paid work down by reading slowly, or by walking away.
         var sut = BuildSut(buffer: 4);
-        using var subscription = sut.Subscribe("job-1")!;
+        using var subscription = sut.Subscribe("job-1", "alice", "acme")!;
 
         for (var i = 0; i < 20; i++)
             sut.Publish("job-1", RunProgressKind.StepStarted, stepId: $"s{i}");
@@ -138,8 +139,8 @@ public sealed class InMemoryRunProgressBrokerTests
         // Per-watcher buffers, not per run. A shared buffer would make the slowest reader the whole
         // run's reader.
         var sut = BuildSut(buffer: 4);
-        using var slow = sut.Subscribe("job-1")!;
-        using var fast = sut.Subscribe("job-1")!;
+        using var slow = sut.Subscribe("job-1", "alice", "acme")!;
+        using var fast = sut.Subscribe("job-1", "alice", "acme")!;
 
         for (var i = 0; i < 4; i++)
             sut.Publish("job-1", RunProgressKind.StepStarted, stepId: $"s{i}");
@@ -157,9 +158,9 @@ public sealed class InMemoryRunProgressBrokerTests
         // unbounded number of them exhausts the host by asking politely.
         var sut = BuildSut(maxStreams: 2);
 
-        using var first = sut.Subscribe("job-1");
-        using var second = sut.Subscribe("job-2");
-        var third = sut.Subscribe("job-3");
+        using var first = sut.Subscribe("job-1", "alice", "acme");
+        using var second = sut.Subscribe("job-2", "alice", "acme");
+        var third = sut.Subscribe("job-3", "alice", "acme");
 
         first.Should().NotBeNull();
         second.Should().NotBeNull();
@@ -173,14 +174,109 @@ public sealed class InMemoryRunProgressBrokerTests
         // refusal looks identical to genuine saturation.
         var sut = BuildSut(maxStreams: 1);
 
-        var first = sut.Subscribe("job-1");
+        var first = sut.Subscribe("job-1", "alice", "acme");
         first.Should().NotBeNull();
-        sut.Subscribe("job-2").Should().BeNull();
+        sut.Subscribe("job-2", "alice", "acme").Should().BeNull();
 
         first!.Dispose();
 
-        using var afterRelease = sut.Subscribe("job-2");
+        using var afterRelease = sut.Subscribe("job-2", "alice", "acme");
         afterRelease.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void OneCallerCannotOccupyEveryStreamSlot()
+    {
+        // A host-wide ceiling on its own is a ceiling any single caller can take: it opens streams to
+        // its own runs and holds the connections, and every other tenant is refused for as long as it
+        // does. Rate limiting does not help — it bounds how often a caller asks, not how long it holds.
+        var sut = BuildSut(maxStreams: 64, perOwner: 2);
+
+        using var mineOne = sut.Subscribe("job-1", "alice", "acme");
+        using var mineTwo = sut.Subscribe("job-2", "alice", "acme");
+        var mineThree = sut.Subscribe("job-3", "alice", "acme");
+
+        mineThree.Should().BeNull("a caller is bounded by its own ceiling, not only the host's");
+
+        using var theirs = sut.Subscribe("job-4", "bob", "acme");
+        theirs.Should().NotBeNull("one caller at its limit must not deny the endpoint to everyone else");
+    }
+
+    [Fact]
+    public void TheSameOwnerInAnotherTenantIsADifferentPrincipal()
+    {
+        // The same two legs that decide whether a caller may read the run at all.
+        var sut = BuildSut(perOwner: 1);
+
+        using var acme = sut.Subscribe("job-1", "alice", "acme");
+        using var other = sut.Subscribe("job-2", "alice", "other-tenant");
+
+        acme.Should().NotBeNull();
+        other.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void ARefusedSubscriptionDoesNotConsumeASlot()
+    {
+        // A refusal that still charged the caller would ratchet: repeated attempts would exhaust the
+        // very allowance being enforced, and the caller could never recover without a restart.
+        var sut = BuildSut(perOwner: 1);
+
+        using var held = sut.Subscribe("job-1", "alice", "acme");
+        for (var attempt = 0; attempt < 5; attempt++)
+            sut.Subscribe("job-2", "alice", "acme").Should().BeNull();
+
+        held!.Dispose();
+
+        using var afterRelease = sut.Subscribe("job-2", "alice", "acme");
+        afterRelease.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void DisposingTwice_DoesNotHandBackASlotTwice()
+    {
+        // Double disposal is ordinary — a using block around something already disposed. Refunding
+        // twice would inflate the allowance until the caps stopped meaning anything.
+        var sut = BuildSut(perOwner: 1);
+
+        var subscription = sut.Subscribe("job-1", "alice", "acme")!;
+        subscription.Dispose();
+        subscription.Dispose();
+
+        using var first = sut.Subscribe("job-2", "alice", "acme");
+        var second = sut.Subscribe("job-3", "alice", "acme");
+
+        first.Should().NotBeNull();
+        second.Should().BeNull("the caller holds one stream, so its second must still be refused");
+    }
+
+    [Fact]
+    public async Task AWatcherArrivingAsAnotherLeaves_StillReceivesEvents()
+    {
+        // Removing a run's watcher set after observing it empty is a check-then-act: a watcher that
+        // subscribes in between is added to a set that is then unregistered, and receives nothing for
+        // the rest of the run while believing it saw everything.
+        var sut = BuildSut();
+
+        for (var attempt = 0; attempt < 200; attempt++)
+        {
+            var leaving = sut.Subscribe("job-1", "alice", "acme")!;
+            var arriving = sut.Subscribe("job-1", "bob", "acme")!;
+
+            leaving.Dispose();
+            sut.Publish("job-1", RunProgressKind.StepStarted, stepId: $"s{attempt}");
+
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            var received = 0;
+            await foreach (var _ in arriving.ReadAllAsync(cts.Token))
+            {
+                received++;
+                break;
+            }
+
+            received.Should().Be(1, "a watcher that subscribed must receive what is published after it");
+            arriving.Dispose();
+        }
     }
 
     [Fact]
@@ -188,7 +284,7 @@ public sealed class InMemoryRunProgressBrokerTests
     {
         // Runs outlive their watchers routinely — a client closes the tab and the workflow carries on.
         var sut = BuildSut();
-        var subscription = sut.Subscribe("job-1")!;
+        var subscription = sut.Subscribe("job-1", "alice", "acme")!;
         subscription.Dispose();
 
         var act = () => sut.Publish("job-1", RunProgressKind.RunFinished, status: "Succeeded");

--- a/src/Content/Tests/Infrastructure.AI.Tests/Runs/InMemoryRunProgressBrokerTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Runs/InMemoryRunProgressBrokerTests.cs
@@ -280,6 +280,35 @@ public sealed class InMemoryRunProgressBrokerTests
     }
 
     [Fact]
+    public async Task ConcurrentPublishers_DeliverInSequenceOrder()
+    {
+        // A plan runs steps concurrently, so two threads publish at once. Taking a number and then
+        // writing as separate steps lets the thread that drew 4 write after the thread that drew 5 —
+        // and a client reading Sequence as the run's order, which is what it is documented as, would
+        // report a gap that never happened.
+        var sut = BuildSut(buffer: 512);
+        using var subscription = sut.Subscribe("job-1", "alice", "acme")!;
+
+        const int Publishers = 16;
+        const int Each = 20;
+
+        var threads = Enumerable.Range(0, Publishers).Select(_ => new Thread(() =>
+        {
+            for (var i = 0; i < Each; i++)
+                sut.Publish("job-1", RunProgressKind.StepStarted, stepId: "s");
+        })).ToList();
+
+        foreach (var thread in threads) thread.Start();
+        foreach (var thread in threads) thread.Join();
+
+        var received = await DrainAsync(subscription, Publishers * Each);
+        var sequences = received.Select(e => e.Sequence).ToList();
+
+        sequences.Should().BeInAscendingOrder("delivery order must match the numbering a client reads");
+        sequences.Should().OnlyHaveUniqueItems("a number identifies one event, so it is never reused");
+    }
+
+    [Fact]
     public void PublishingAfterTheLastWatcherLeaves_IsHarmless()
     {
         // Runs outlive their watchers routinely — a client closes the tab and the workflow carries on.

--- a/src/Content/Tests/Infrastructure.AI.Tests/Runs/RunDispatchBackgroundServiceTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Runs/RunDispatchBackgroundServiceTests.cs
@@ -76,6 +76,13 @@ public sealed class RunDispatchBackgroundServiceTests
     private readonly AppConfig _config = new();
     private readonly RecordingScopeWriter _scopeWriter = new();
 
+    /// <summary>
+    /// A real broker, so the dispatcher's terminal event is actually publishable. The dispatcher owns
+    /// that event precisely because it is the one place every run reaches a terminal state.
+    /// </summary>
+    private InMemoryRunProgressBroker Progress => field ??= new InMemoryRunProgressBroker(
+        new StaticOptionsMonitor<AppConfig>(_config), _time);
+
     private (RunDispatchBackgroundService Service, IRunJobStore Store, IRunDispatchQueue Queue) Build(
         IRunKindExecutor? executor, bool registerScopeWriter = true)
     {
@@ -91,7 +98,8 @@ public sealed class RunDispatchBackgroundServiceTests
         var queue = new InMemoryRunDispatchQueue();
 
         var service = new RunDispatchBackgroundService(
-            queue, store, services.BuildServiceProvider().GetRequiredService<IServiceScopeFactory>(),
+            queue, store, Progress,
+            services.BuildServiceProvider().GetRequiredService<IServiceScopeFactory>(),
             monitor, _time, NullLogger<RunDispatchBackgroundService>.Instance);
 
         return (service, store, queue);
@@ -240,6 +248,76 @@ public sealed class RunDispatchBackgroundServiceTests
 
         record!.Status.Should().Be(outcome);
         record.Error.Should().Be("waiting on a person");
+    }
+
+    [Theory]
+    [InlineData(RunStatus.Succeeded)]
+    [InlineData(RunStatus.Failed)]
+    [InlineData(RunStatus.Cancelled)]
+    [InlineData(RunStatus.Blocked)]
+    public async Task EveryWayARunCanEnd_TellsAnyoneWatchingThatItEnded(RunStatus outcome)
+    {
+        // A watcher's stream ends on this event and nothing else, so an ending that does not publish
+        // one holds the client's connection — and its stream slot — open on a run that is already over.
+        // Sourcing it from the planner covered only the endings the planner announces: a workflow
+        // parked on a human gate, one an operator cancelled, and every run failed before the planner
+        // ran at all each left a watcher waiting forever.
+        var completion = outcome == RunStatus.Succeeded
+            ? RunCompletion.Succeeded()
+            : new RunCompletion { Status = outcome, Detail = "why it ended" };
+
+        var executor = new StubExecutor(_ => Task.FromResult(Result<RunCompletion>.Success(completion)));
+        var (service, store, queue) = Build(executor);
+        Admit(store, Queued());
+
+        using var watcher = Progress.Subscribe("job-1", "alice", "acme")!;
+        await queue.EnqueueAsync("job-1", CancellationToken.None);
+
+        await DrainUntilTerminalAsync(service, store, "job-1");
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var sawFinish = false;
+
+        await foreach (var evt in watcher.ReadAllAsync(cts.Token))
+        {
+            if (evt.Kind != RunProgressKind.RunFinished)
+                continue;
+
+            evt.Status.Should().Be(outcome.ToString());
+            sawFinish = true;
+            break;
+        }
+
+        sawFinish.Should().BeTrue("a run that ended must say so, however it ended");
+    }
+
+    [Fact]
+    public async Task ARunThatFailsBeforeItsWorkBegins_StillTellsAnyoneWatching()
+    {
+        // The endings that never reach an executor at all: a host that cannot establish the run's
+        // identity, or one with no executor for the kind. The planner never runs, so a planner-sourced
+        // terminal event would never fire and the watcher would wait on a run that is already failed.
+        var (service, store, queue) = Build(executor: null);
+        Admit(store, Queued());
+
+        using var watcher = Progress.Subscribe("job-1", "alice", "acme")!;
+        await queue.EnqueueAsync("job-1", CancellationToken.None);
+
+        await DrainUntilTerminalAsync(service, store, "job-1");
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var statuses = new List<string?>();
+
+        await foreach (var evt in watcher.ReadAllAsync(cts.Token))
+        {
+            if (evt.Kind != RunProgressKind.RunFinished)
+                continue;
+
+            statuses.Add(evt.Status);
+            break;
+        }
+
+        statuses.Should().Equal([nameof(RunStatus.Failed)]);
     }
 
     [Fact]

--- a/src/Content/Tests/Infrastructure.AI.Tests/Runs/RunRecordCleanupServiceTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Runs/RunRecordCleanupServiceTests.cs
@@ -46,6 +46,9 @@ public sealed class RunRecordCleanupServiceTests
 
         public bool Update(RunRecord record) => inner.Update(record);
 
+        public RunRecord? FindLiveRunForTarget(RunKind kind, string targetId) =>
+            inner.FindLiveRunForTarget(kind, targetId);
+
         public int SweepExpired()
         {
             Sweeps++;

--- a/src/Content/Tests/Infrastructure.AI.Tests/Runs/RunRecordCleanupServiceTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Runs/RunRecordCleanupServiceTests.cs
@@ -49,11 +49,11 @@ public sealed class RunRecordCleanupServiceTests
         public RunRecord? FindLiveRunForTarget(RunKind kind, string targetId) =>
             inner.FindLiveRunForTarget(kind, targetId);
 
-        public int SweepExpired()
+        public IReadOnlyList<string> SweepExpired()
         {
             Sweeps++;
             var removed = inner.SweepExpired();
-            Reclaimed += removed;
+            Reclaimed += removed.Count;
             return removed;
         }
     }
@@ -72,6 +72,7 @@ public sealed class RunRecordCleanupServiceTests
 
         var monitor = new StaticOptionsMonitor<AppConfig>(_config);
         var store = new CountingStore(new InMemoryRunJobStore(monitor, _time));
+        var progress = new InMemoryRunProgressBroker(monitor, _time);
 
         store.TryCreate(Queued("finished"), int.MaxValue).Should().Be(RunAdmission.Accepted);
         store.TryCreate(Queued("still-going"), int.MaxValue).Should().Be(RunAdmission.Accepted);
@@ -81,7 +82,8 @@ public sealed class RunRecordCleanupServiceTests
 
         _time.Advance(TimeSpan.FromHours(1));
 
-        var sut = new RunRecordCleanupService(store, monitor, NullLogger<RunRecordCleanupService>.Instance);
+        var sut = new RunRecordCleanupService(
+            store, progress, monitor, NullLogger<RunRecordCleanupService>.Instance);
 
         using var cts = new CancellationTokenSource();
         await sut.StartAsync(cts.Token);
@@ -96,6 +98,67 @@ public sealed class RunRecordCleanupServiceTests
         store.Reclaimed.Should().Be(1, "the finished run was past its retention and its memory is owed back");
         store.Get("still-going", "alice", null).Should().NotBeNull(
             "an unfinished run a caller is still polling must survive every sweep");
+    }
+
+    [Fact]
+    public async Task TheSweepAlsoReleasesTheProgressBookkeepingForTheRunsItReclaims()
+    {
+        // A run identifier keys more than its record. Reclaiming one without the other trades a
+        // bounded leak for an unbounded one: the broker would hold an entry for every run the host
+        // ever streamed, for the life of the process. This is the shape of defect that hides — the
+        // reclaiming method existed, was documented as being called here, and had no caller at all.
+        _config.AI.WorkflowSubmission.RunRecordTtl = TimeSpan.FromMinutes(5);
+        _config.AI.WorkflowSubmission.RunSweepInterval = TimeSpan.Zero;
+
+        var monitor = new StaticOptionsMonitor<AppConfig>(_config);
+        var store = new CountingStore(new InMemoryRunJobStore(monitor, _time));
+        var progress = new RecordingBroker(new InMemoryRunProgressBroker(monitor, _time));
+
+        store.TryCreate(Queued("finished"), int.MaxValue).Should().Be(RunAdmission.Accepted);
+        var claimed = store.TryBeginRun("finished", _time.GetUtcNow())!;
+        store.Update(claimed with { Status = RunStatus.Succeeded, CompletedAt = _time.GetUtcNow() });
+
+        _time.Advance(TimeSpan.FromHours(1));
+
+        var sut = new RunRecordCleanupService(
+            store, progress, monitor, NullLogger<RunRecordCleanupService>.Instance);
+
+        using var cts = new CancellationTokenSource();
+        await sut.StartAsync(cts.Token);
+
+        for (var attempt = 0; attempt < 60 && progress.Forgotten.Count == 0; attempt++)
+            await Task.Delay(100);
+
+        await cts.CancelAsync();
+        await sut.StopAsync(CancellationToken.None);
+
+        progress.Forgotten.Should().Contain("finished");
+    }
+
+    /// <summary>Records which runs the sweeper asked the broker to forget.</summary>
+    private sealed class RecordingBroker(IRunProgressBroker inner) : IRunProgressBroker
+    {
+        public List<string> Forgotten { get; } = [];
+
+        public void Publish(
+            string jobId,
+            RunProgressKind kind,
+            string? stepId = null,
+            string? stepName = null,
+            string? status = null,
+            string? detail = null) =>
+            inner.Publish(jobId, kind, stepId, stepName, status, detail);
+
+        public IRunProgressSubscription? Subscribe(string jobId, string ownerId, string? tenantId) =>
+            inner.Subscribe(jobId, ownerId, tenantId);
+
+        public void Forget(string jobId)
+        {
+            lock (Forgotten)
+                Forgotten.Add(jobId);
+
+            inner.Forget(jobId);
+        }
     }
 
     private RunRecord Queued(string jobId) => new()

--- a/src/Content/Tests/Presentation.ExecutionApi.Tests/WorkflowProgressStreamTests.cs
+++ b/src/Content/Tests/Presentation.ExecutionApi.Tests/WorkflowProgressStreamTests.cs
@@ -121,24 +121,24 @@ public sealed class WorkflowProgressStreamTests
     {
         var frames = new List<JsonElement>();
         using var reader = new StreamReader(stream);
-        using var cts = new CancellationTokenSource(budget);
+        var deadline = Task.Delay(budget);
 
-        try
+        while (true)
         {
-            while (await reader.ReadLineAsync(cts.Token) is { } line)
-            {
-                if (!line.StartsWith("data: ", StringComparison.Ordinal))
-                    continue;
+            // Raced against the deadline rather than cancelled by a token. The test server does not
+            // reliably abort a pending read on cancellation, so a token alone lets a regression hang
+            // the suite instead of failing it — and a hanging test tells whoever is looking at CI far
+            // less than a failing one.
+            var read = reader.ReadLineAsync();
+            if (await Task.WhenAny(read, deadline).ConfigureAwait(false) != read)
+                return (frames, false);
 
+            var line = await read.ConfigureAwait(false);
+            if (line is null)
+                return (frames, true);
+
+            if (line.StartsWith("data: ", StringComparison.Ordinal))
                 frames.Add(JsonDocument.Parse(line[6..]).RootElement.Clone());
-            }
-
-            return (frames, true);
-        }
-        catch (OperationCanceledException)
-        {
-            // Budget spent with the stream still open.
-            return (frames, false);
         }
     }
 

--- a/src/Content/Tests/Presentation.ExecutionApi.Tests/WorkflowProgressStreamTests.cs
+++ b/src/Content/Tests/Presentation.ExecutionApi.Tests/WorkflowProgressStreamTests.cs
@@ -49,6 +49,17 @@ public sealed class WorkflowProgressStreamTests
         }
     }
 
+    /// <summary>
+    /// How long a stream may stay open before the test gives up on it.
+    /// </summary>
+    /// <remarks>
+    /// A deadlock guard, not a performance assertion. A passing test returns the moment the server
+    /// closes the stream, so a generous budget costs nothing — while a tight one turns a loaded build
+    /// agent into a failure, which is what a 20-second budget did here when the rest of the suite was
+    /// competing for the machine.
+    /// </remarks>
+    private static readonly TimeSpan StreamBudget = TimeSpan.FromSeconds(90);
+
     private readonly SemaphoreSlim _release = new(0, 1);
 
     private WebApplicationFactory<Program> CreateFactory() =>
@@ -148,7 +159,7 @@ public sealed class WorkflowProgressStreamTests
         response.Content.Headers.ContentType!.MediaType.Should().Be("text/event-stream");
 
         var stream = await response.Content.ReadAsStreamAsync();
-        var reading = ReadFramesAsync(stream, TimeSpan.FromSeconds(20));
+        var reading = ReadFramesAsync(stream, StreamBudget);
 
         // Released only once the stream is open, so the step's progress cannot have been published
         // before anyone was listening — which is what makes this an assertion about live delivery
@@ -158,10 +169,12 @@ public sealed class WorkflowProgressStreamTests
 
         var (frames, closed) = await reading;
 
-        frames.Should().NotBeEmpty("the stream must carry the run, not merely open");
-        closed.Should().BeTrue("the stream must close when the run ends, not hold the client open");
-
         var types = frames.Select(f => f.GetProperty("type").GetString()).ToList();
+        var seen = string.Join(", ", types);
+
+        frames.Should().NotBeEmpty("the stream must carry the run, not merely open");
+        closed.Should().BeTrue(
+            "the stream must close when the run ends, not hold the client open. Frames seen: [{0}]", seen);
         types.Should().StartWith(["SNAPSHOT"], "every stream opens by saying where the run already is");
         types.Should().Contain("STEP", "the run's steps must actually reach the watcher");
         types.Should().Contain("FINISHED", "the stream must report the run reaching its end");
@@ -198,7 +211,7 @@ public sealed class WorkflowProgressStreamTests
             HttpCompletionOption.ResponseHeadersRead);
 
         var (frames, closed) = await ReadFramesAsync(
-            await response.Content.ReadAsStreamAsync(), TimeSpan.FromSeconds(10));
+            await response.Content.ReadAsStreamAsync(), StreamBudget);
 
         // Closing is the assertion that matters. A stream that sends the snapshot and then waits for
         // events that can never come produces an identical frame list, and the client experiences it

--- a/src/Content/Tests/Presentation.ExecutionApi.Tests/WorkflowProgressStreamTests.cs
+++ b/src/Content/Tests/Presentation.ExecutionApi.Tests/WorkflowProgressStreamTests.cs
@@ -95,8 +95,18 @@ public sealed class WorkflowProgressStreamTests
         return JsonDocument.Parse(body).RootElement.GetProperty("jobId").GetString()!;
     }
 
-    /// <summary>Reads SSE frames until the stream ends or the budget is spent.</summary>
-    private static async Task<List<JsonElement>> ReadFramesAsync(Stream stream, TimeSpan budget)
+    /// <summary>
+    /// Reads SSE frames, reporting both what arrived and whether the server actually closed the
+    /// stream.
+    /// </summary>
+    /// <remarks>
+    /// <c>Closed</c> is load-bearing and not a detail: "sent one frame and finished" and "sent one
+    /// frame then held the connection open until the client gave up" produce identical frame lists.
+    /// A test that only counted frames would pass against a stream that hangs, which is precisely the
+    /// failure a client would experience as the feature being broken.
+    /// </remarks>
+    private static async Task<(List<JsonElement> Frames, bool Closed)> ReadFramesAsync(
+        Stream stream, TimeSpan budget)
     {
         var frames = new List<JsonElement>();
         using var reader = new StreamReader(stream);
@@ -111,13 +121,14 @@ public sealed class WorkflowProgressStreamTests
 
                 frames.Add(JsonDocument.Parse(line[6..]).RootElement.Clone());
             }
+
+            return (frames, true);
         }
         catch (OperationCanceledException)
         {
-            // Budget spent; whatever arrived is what the assertions judge.
+            // Budget spent with the stream still open.
+            return (frames, false);
         }
-
-        return frames;
     }
 
     [Fact]
@@ -145,9 +156,10 @@ public sealed class WorkflowProgressStreamTests
         await Task.Delay(500);
         _release.Release();
 
-        var frames = await reading;
+        var (frames, closed) = await reading;
 
         frames.Should().NotBeEmpty("the stream must carry the run, not merely open");
+        closed.Should().BeTrue("the stream must close when the run ends, not hold the client open");
 
         var types = frames.Select(f => f.GetProperty("type").GetString()).ToList();
         types.Should().StartWith(["SNAPSHOT"], "every stream opens by saying where the run already is");
@@ -185,8 +197,13 @@ public sealed class WorkflowProgressStreamTests
             Request(HttpMethod.Get, $"/api/workflows/{workflowId}/runs/{jobId}/stream", null, "alice"),
             HttpCompletionOption.ResponseHeadersRead);
 
-        var frames = await ReadFramesAsync(await response.Content.ReadAsStreamAsync(), TimeSpan.FromSeconds(10));
+        var (frames, closed) = await ReadFramesAsync(
+            await response.Content.ReadAsStreamAsync(), TimeSpan.FromSeconds(10));
 
+        // Closing is the assertion that matters. A stream that sends the snapshot and then waits for
+        // events that can never come produces an identical frame list, and the client experiences it
+        // as the feature hanging.
+        closed.Should().BeTrue("a finished run's stream must end rather than hold the connection open");
         frames.Should().ContainSingle("a finished run has nothing left to report beyond where it ended");
         frames[0].GetProperty("type").GetString().Should().Be("SNAPSHOT");
         frames[0].GetProperty("isTerminal").GetBoolean().Should().BeTrue();

--- a/src/Content/Tests/Presentation.ExecutionApi.Tests/WorkflowProgressStreamTests.cs
+++ b/src/Content/Tests/Presentation.ExecutionApi.Tests/WorkflowProgressStreamTests.cs
@@ -1,0 +1,233 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Application.AI.Common.Interfaces.Planner;
+using Domain.AI.Planner;
+using FluentAssertions;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using static Presentation.ExecutionApi.Tests.WorkflowRequests;
+
+namespace Presentation.ExecutionApi.Tests;
+
+/// <summary>
+/// Watches a real workflow run over Server-Sent-Events, through the real host.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The whole feature is a chain of things that each look fine alone: the planner announces progress,
+/// a bridge attributes it to a run, a broker fans it out, and an endpoint writes it. Any one of those
+/// links being absent produces the same symptom — a stream that opens, says nothing, and closes — so
+/// only an end-to-end assertion distinguishes "working" from "silently disconnected". The ExecutionApi
+/// host in particular received the no-op notifier by default until this wave replaced it.
+/// </para>
+/// <para>
+/// Only the model call is substituted. Everything else is the host's own.
+/// </para>
+/// </remarks>
+public sealed class WorkflowProgressStreamTests
+{
+    /// <summary>Stands in for the model call, holding the step open until the test releases it.</summary>
+    private sealed class GatedStepExecutor(SemaphoreSlim release) : IPlanStepExecutor
+    {
+        public async Task<StepExecutionResult> ExecuteAsync(
+            PlanStep step,
+            IReadOnlyDictionary<PlanStepId, string> upstreamOutputs,
+            CancellationToken ct)
+        {
+            await release.WaitAsync(ct);
+
+            return new StepExecutionResult
+            {
+                Status = StepExecutionStatus.Completed,
+                Output = "done",
+                Duration = TimeSpan.FromMilliseconds(1)
+            };
+        }
+    }
+
+    private readonly SemaphoreSlim _release = new(0, 1);
+
+    private WebApplicationFactory<Program> CreateFactory() =>
+        new WebApplicationFactory<Program>().WithWebHostBuilder(builder =>
+            builder.ConfigureTestServices(services =>
+            {
+                services
+                    .AddAuthentication(HeaderIdentityAuthenticationHandler.SchemeName)
+                    .AddScheme<AuthenticationSchemeOptions, HeaderIdentityAuthenticationHandler>(
+                        HeaderIdentityAuthenticationHandler.SchemeName, _ => { });
+
+                services.AddKeyedScoped<IPlanStepExecutor>(
+                    StepType.LlmCall, (_, _) => new GatedStepExecutor(_release));
+            }));
+
+    private static HttpRequestMessage Request(HttpMethod method, string url, object? body, string oid)
+    {
+        var request = new HttpRequestMessage(method, url);
+        if (body is not null)
+            request.Content = JsonContent.Create(body);
+
+        request.Headers.Add(HeaderIdentityAuthenticationHandler.UserHeader, oid);
+        request.Headers.Add(HeaderIdentityAuthenticationHandler.TenantHeader, "acme");
+        return request;
+    }
+
+    private static async Task<Guid> SubmitAsync(HttpClient client, string oid)
+    {
+        var response = await client.SendAsync(
+            Request(HttpMethod.Post, "/api/workflows", Definition([LlmStep("only")]), oid));
+
+        var body = await response.Content.ReadAsStringAsync();
+        response.StatusCode.Should().Be(HttpStatusCode.Created, "submission failed with body: {0}", body);
+        return JsonDocument.Parse(body).RootElement.GetProperty("workflowId").GetGuid();
+    }
+
+    private static async Task<string> StartAsync(HttpClient client, Guid workflowId, string oid)
+    {
+        var started = await client.SendAsync(
+            Request(HttpMethod.Post, $"/api/workflows/{workflowId}/runs", body: null, oid));
+
+        var body = await started.Content.ReadAsStringAsync();
+        started.StatusCode.Should().Be(HttpStatusCode.Accepted, "start failed with body: {0}", body);
+        return JsonDocument.Parse(body).RootElement.GetProperty("jobId").GetString()!;
+    }
+
+    /// <summary>Reads SSE frames until the stream ends or the budget is spent.</summary>
+    private static async Task<List<JsonElement>> ReadFramesAsync(Stream stream, TimeSpan budget)
+    {
+        var frames = new List<JsonElement>();
+        using var reader = new StreamReader(stream);
+        using var cts = new CancellationTokenSource(budget);
+
+        try
+        {
+            while (await reader.ReadLineAsync(cts.Token) is { } line)
+            {
+                if (!line.StartsWith("data: ", StringComparison.Ordinal))
+                    continue;
+
+                frames.Add(JsonDocument.Parse(line[6..]).RootElement.Clone());
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Budget spent; whatever arrived is what the assertions judge.
+        }
+
+        return frames;
+    }
+
+    [Fact]
+    public async Task AWatcherSeesTheRunProgressAndFinish()
+    {
+        using var factory = CreateFactory();
+        using var client = factory.CreateClient();
+
+        var workflowId = await SubmitAsync(client, "alice");
+        var jobId = await StartAsync(client, workflowId, "alice");
+
+        var response = await client.SendAsync(
+            Request(HttpMethod.Get, $"/api/workflows/{workflowId}/runs/{jobId}/stream", null, "alice"),
+            HttpCompletionOption.ResponseHeadersRead);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Content.Headers.ContentType!.MediaType.Should().Be("text/event-stream");
+
+        var stream = await response.Content.ReadAsStreamAsync();
+        var reading = ReadFramesAsync(stream, TimeSpan.FromSeconds(20));
+
+        // Released only once the stream is open, so the step's progress cannot have been published
+        // before anyone was listening — which is what makes this an assertion about live delivery
+        // rather than about the snapshot.
+        await Task.Delay(500);
+        _release.Release();
+
+        var frames = await reading;
+
+        frames.Should().NotBeEmpty("the stream must carry the run, not merely open");
+
+        var types = frames.Select(f => f.GetProperty("type").GetString()).ToList();
+        types.Should().StartWith(["SNAPSHOT"], "every stream opens by saying where the run already is");
+        types.Should().Contain("STEP", "the run's steps must actually reach the watcher");
+        types.Should().Contain("FINISHED", "the stream must report the run reaching its end");
+    }
+
+    [Fact]
+    public async Task AStreamForARunThatAlreadyFinished_ReportsItAndCloses()
+    {
+        // A watcher that arrives late must not hang waiting for events that will never come.
+        using var factory = CreateFactory();
+        using var client = factory.CreateClient();
+
+        _release.Release();
+
+        var workflowId = await SubmitAsync(client, "alice");
+        var jobId = await StartAsync(client, workflowId, "alice");
+
+        for (var attempt = 0; attempt < 40; attempt++)
+        {
+            await Task.Delay(250);
+            var poll = await client.SendAsync(
+                Request(HttpMethod.Get, $"/api/workflows/{workflowId}/runs/{jobId}", null, "alice"));
+
+            if (poll.StatusCode != HttpStatusCode.OK)
+                continue;
+
+            var status = (await poll.Content.ReadFromJsonAsync<JsonElement>()).GetProperty("status").GetString();
+            if (status is not ("Queued" or "Running"))
+                break;
+        }
+
+        var response = await client.SendAsync(
+            Request(HttpMethod.Get, $"/api/workflows/{workflowId}/runs/{jobId}/stream", null, "alice"),
+            HttpCompletionOption.ResponseHeadersRead);
+
+        var frames = await ReadFramesAsync(await response.Content.ReadAsStreamAsync(), TimeSpan.FromSeconds(10));
+
+        frames.Should().ContainSingle("a finished run has nothing left to report beyond where it ended");
+        frames[0].GetProperty("type").GetString().Should().Be("SNAPSHOT");
+        frames[0].GetProperty("isTerminal").GetBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task StreamingSomeoneElsesRun_Is404()
+    {
+        // Same answer as reading it. A stream that distinguished "not yours" from "not there" would
+        // let a caller discover work it was never given the identifier for.
+        using var factory = CreateFactory();
+        using var client = factory.CreateClient();
+
+        var workflowId = await SubmitAsync(client, "alice");
+        var jobId = await StartAsync(client, workflowId, "alice");
+
+        var stolen = await client.SendAsync(
+            Request(HttpMethod.Get, $"/api/workflows/{workflowId}/runs/{jobId}/stream", null, "mallory"),
+            HttpCompletionOption.ResponseHeadersRead);
+
+        stolen.StatusCode.Should().Be(HttpStatusCode.NotFound);
+
+        _release.Release();
+    }
+
+    [Fact]
+    public async Task StreamingARunUnderTheWrongWorkflow_Is404()
+    {
+        using var factory = CreateFactory();
+        using var client = factory.CreateClient();
+
+        var workflowId = await SubmitAsync(client, "alice");
+        var otherWorkflowId = await SubmitAsync(client, "alice");
+        var jobId = await StartAsync(client, workflowId, "alice");
+
+        var crossed = await client.SendAsync(
+            Request(HttpMethod.Get, $"/api/workflows/{otherWorkflowId}/runs/{jobId}/stream", null, "alice"),
+            HttpCompletionOption.ResponseHeadersRead);
+
+        crossed.StatusCode.Should().Be(HttpStatusCode.NotFound);
+
+        _release.Release();
+    }
+}

--- a/src/Content/Tests/Presentation.ExecutionApi.Tests/WorkflowProgressStreamerTests.cs
+++ b/src/Content/Tests/Presentation.ExecutionApi.Tests/WorkflowProgressStreamerTests.cs
@@ -1,0 +1,149 @@
+using System.Text;
+using System.Threading.Channels;
+using Application.AI.Common.Interfaces.Runs;
+using Domain.AI.Bundles;
+using Domain.AI.Runs;
+using FluentAssertions;
+using Presentation.ExecutionApi.Streaming;
+using Xunit;
+
+namespace Presentation.ExecutionApi.Tests;
+
+/// <summary>
+/// Drives <see cref="WorkflowProgressStreamer"/> directly, over the quiet path.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The host-level tests all describe runs that produce events promptly, so they exercise the streamer
+/// only while it is busy. A workflow step calling a model can easily run for minutes saying nothing,
+/// and the code that carries a stream through that silence is the part least like the code the other
+/// tests cover — it races a timer against a pending read, which is where this class can go wrong in
+/// ways that finish fine when events keep arriving.
+/// </para>
+/// <para>
+/// The keep-alive interval is injected so the silence is milliseconds rather than the production
+/// quarter-minute. A test that waited out the real interval would be one nobody runs.
+/// </para>
+/// </remarks>
+public sealed class WorkflowProgressStreamerTests
+{
+    /// <summary>A subscription the test feeds by hand, so silence is something it can choose.</summary>
+    private sealed class ManualSubscription : IRunProgressSubscription
+    {
+        private readonly Channel<RunProgressEvent> _events =
+            Channel.CreateUnbounded<RunProgressEvent>();
+
+        public long DroppedCount => 0;
+
+        public IAsyncEnumerable<RunProgressEvent> ReadAllAsync(CancellationToken cancellationToken) =>
+            _events.Reader.ReadAllAsync(cancellationToken);
+
+        public void Publish(RunProgressEvent evt) => _events.Writer.TryWrite(evt);
+
+        public void Dispose() => _events.Writer.TryComplete();
+    }
+
+    /// <summary>A stream whose bytes the test can read while the streamer is still writing.</summary>
+    private sealed class RecordingStream : Stream
+    {
+        private readonly Lock _gate = new();
+        private readonly MemoryStream _written = new();
+
+        public string Text
+        {
+            get
+            {
+                lock (_gate)
+                    return Encoding.UTF8.GetString(_written.ToArray());
+            }
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            lock (_gate)
+                _written.Write(buffer, offset, count);
+        }
+
+        public override ValueTask WriteAsync(
+            ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            lock (_gate)
+                _written.Write(buffer.Span);
+
+            return ValueTask.CompletedTask;
+        }
+
+        public override bool CanRead => false;
+        public override bool CanSeek => false;
+        public override bool CanWrite => true;
+        public override long Length => _written.Length;
+        public override long Position { get => 0; set { } }
+        public override void Flush() { }
+        public override Task FlushAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+        public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+    }
+
+    private static readonly TimeSpan ShortKeepAlive = TimeSpan.FromMilliseconds(100);
+
+    /// <summary>A deadlock guard. A working stream returns as soon as the run finishes.</summary>
+    private static readonly TimeSpan Budget = TimeSpan.FromSeconds(30);
+
+    private static RunRecord LiveRun() => new()
+    {
+        JobId = "job-1",
+        Kind = RunKind.Workflow,
+        TargetId = "workflow-1",
+        OwnerId = "alice",
+        TenantId = "acme",
+        Envelope = new CapabilityEnvelope(),
+        Status = RunStatus.Running,
+        CreatedAt = DateTimeOffset.UnixEpoch
+    };
+
+    private static RunProgressEvent Finished() => new()
+    {
+        JobId = "job-1",
+        Sequence = 1,
+        Kind = RunProgressKind.RunFinished,
+        OccurredAt = DateTimeOffset.UnixEpoch,
+        Status = nameof(RunStatus.Succeeded)
+    };
+
+    [Fact]
+    public async Task AStreamThatGoesQuietForSeveralIntervals_StaysUsable()
+    {
+        // The bug this pins: the loop raced the pending read against a keep-alive timer and, when the
+        // timer won, went round and started a *second* read on the same enumerator while the first was
+        // still outstanding. Concurrent MoveNextAsync on one async enumerator is undefined, and here it
+        // faulted on a thread-pool thread with nobody to observe it — taking the whole process down.
+        // Every workflow step slower than the keep-alive interval reaches this path, so it is the
+        // ordinary case for real work, not an edge one.
+        using var subscription = new ManualSubscription();
+        var body = new RecordingStream();
+        var streamer = new WorkflowProgressStreamer(body, ShortKeepAlive);
+
+        var streaming = streamer.StreamAsync(LiveRun(), subscription, CancellationToken.None);
+
+        // Long enough for several keep-alives, so the loop must survive going round on the quiet path
+        // repeatedly rather than merely once.
+        await Task.Delay(TimeSpan.FromMilliseconds(550));
+
+        streaming.IsFaulted.Should().BeFalse(
+            "a quiet stream must not fault: {0}", streaming.Exception?.ToString() ?? "(none)");
+
+        subscription.Publish(Finished());
+
+        var completed = await Task.WhenAny(streaming, Task.Delay(Budget));
+        completed.Should().BeSameAs(
+            streaming, "the stream must still deliver events after going quiet, and close when the run ends");
+
+        // Surfaces the real exception rather than letting the assertion below describe the symptom.
+        await streaming;
+
+        var text = body.Text;
+        text.Should().Contain(": keep-alive", "a stream that goes quiet must keep saying so");
+        text.Should().Contain("FINISHED", "the event published after the silence must still arrive");
+    }
+}

--- a/src/Content/Tests/Presentation.ExecutionApi.Tests/WorkflowProgressStreamerTests.cs
+++ b/src/Content/Tests/Presentation.ExecutionApi.Tests/WorkflowProgressStreamerTests.cs
@@ -85,6 +85,38 @@ public sealed class WorkflowProgressStreamerTests
         public override void SetLength(long value) => throw new NotSupportedException();
     }
 
+    /// <summary>A stream that starts refusing writes, the way a departed client's does.</summary>
+    private sealed class DepartingStream : Stream
+    {
+        private int _writes;
+
+        /// <summary>How many writes succeed before the client is treated as gone.</summary>
+        public required int WritesBeforeLeaving { get; init; }
+
+        public override ValueTask WriteAsync(
+            ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            if (Interlocked.Increment(ref _writes) > WritesBeforeLeaving)
+                throw new IOException("The client has gone.");
+
+            return ValueTask.CompletedTask;
+        }
+
+        public override void Write(byte[] buffer, int offset, int count) =>
+            WriteAsync(buffer.AsMemory(offset, count)).AsTask().GetAwaiter().GetResult();
+
+        public override bool CanRead => false;
+        public override bool CanSeek => false;
+        public override bool CanWrite => true;
+        public override long Length => 0;
+        public override long Position { get => 0; set { } }
+        public override void Flush() { }
+        public override Task FlushAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+        public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+    }
+
     private static readonly TimeSpan ShortKeepAlive = TimeSpan.FromMilliseconds(100);
 
     /// <summary>A deadlock guard. A working stream returns as soon as the run finishes.</summary>
@@ -145,5 +177,34 @@ public sealed class WorkflowProgressStreamerTests
         var text = body.Text;
         text.Should().Contain(": keep-alive", "a stream that goes quiet must keep saying so");
         text.Should().Contain("FINISHED", "the event published after the silence must still arrive");
+    }
+
+    [Fact]
+    public async Task AClientThatLeavesWhileTheStreamIsQuiet_EndsItQuietly()
+    {
+        // The other half of the quiet path, and the ordinary way one of these streams actually ends:
+        // the client closes the tab during a silence, and the server finds out when the keep-alive
+        // fails to write. At that moment a read is still in flight, and an async iterator suspended at
+        // an await cannot be disposed — DisposeAsync throws NotSupportedException. So the loop must
+        // not simply stop; it has to leave the pending read alone.
+        //
+        // The failure this pins is not a hang or a wrong frame: it is an exception escaping the
+        // request pipeline on a response whose headers have already gone, where there is no status
+        // code left to report it with.
+        using var subscription = new ManualSubscription();
+
+        // One write for the snapshot, then the client is gone — so the first keep-alive is what
+        // discovers it, which is the interleaving that leaves a read outstanding.
+        var body = new DepartingStream { WritesBeforeLeaving = 1 };
+        var streamer = new WorkflowProgressStreamer(body, ShortKeepAlive);
+
+        var streaming = streamer.StreamAsync(LiveRun(), subscription, CancellationToken.None);
+
+        var completed = await Task.WhenAny(streaming, Task.Delay(Budget));
+        completed.Should().BeSameAs(streaming, "a departed client must end the stream, not hang it");
+
+        // The assertion: this await must not throw. Nothing is published for this run and nothing
+        // ever will be, so the stream ends because the client did.
+        await streaming;
     }
 }


### PR DESCRIPTION
Wave 5 of the external-trigger API. Adds `GET /api/workflows/{workflowId}/runs/{jobId}/stream` — a caller watches a run's progress live instead of polling for it.

Polling was the only option, and the endpoint allows 60 requests a minute per caller across everything, so following a long workflow closely consumed the caller's whole budget to learn mostly nothing had changed.

## What it adds

- **`IRunProgressBroker`** — kind-agnostic, like the rest of the run substrate. One bounded buffer *per watcher*, dropping the oldest when a watcher falls behind, so an observer can never slow down the work it is watching. What was dropped travels with the subscription, so the gap is reported rather than hidden.
- **`PlanProgressRunBridge`** — translates plan notifications into run progress. This replaces the `NullPlanProgressNotifier` the ExecutionApi host had been silently using, which is why the host produced no progress at all before this wave.
- **SSE endpoint** — `SNAPSHOT` first (a watcher almost never arrives at the instant a run starts, and nothing is buffered for someone who has not arrived), then live `STEP` frames, a terminal `FINISHED`, and `GAP` when the watcher fell behind. Keep-alive comments carry a quiet stream past intermediary idle timeouts.
- **Three config knobs**, all validated at startup: `MaxConcurrentProgressStreams`, `MaxProgressStreamsPerOwner`, `ProgressBufferSize`.

## Authorization

Identical to reading the run: another caller's run, a job that never existed, and a job requested through the wrong workflow's route are one answer, so a stream cannot be used to discover work the caller was never given the identifier for. The run is authorized *before* a subscription is taken, so an unauthorized caller never occupies a stream slot.

## What review caught

Two rounds of reviewers plus mutation testing found nine defects, several of them mine and introduced by earlier fixes in this same branch:

1. **The stream never ended for four kinds of run.** Sourcing the terminal event from the planner covered only the endings the planner produces — a run parked on a human gate, one an operator cancelled, and any run that failed before the planner started each left the connection open forever on a run that was already over, holding a stream slot with it. Now sourced from the dispatcher, the one place every run passes through.
2. **A slot leak**, found independently by both reviewers: one viewer disconnecting as another connected could strand the newcomer — receiving nothing, believing it had seen everything, slot never returned.
3. **One caller could deny streaming to everyone** — the limit was host-wide only.
4. **`Forget` was documented as being called by the sweeper and had nothing calling it** — this project's signature "inert machinery" defect, reproduced by me.
5. **A quiet stream took the whole process down.** The keep-alive loop started a second read on the same async enumerator while the first was still pending; that corrupted its state machine and faulted on a thread-pool thread with nobody to observe it. Every step quieter than 15 seconds took that path, which is the ordinary case for real work.
6. **A client leaving during a silence threw out of the request pipeline** — the loop stopped with a read in flight and the `finally` disposed an enumerator suspended at an await, which throws `NotSupportedException`, on a response whose headers had already gone.
7. **Real frames were written unguarded while keep-alives were not**, so the two write paths disagreed about what a departed client is.
8. **A run swept between the authorizing read and the snapshot read** was described as still live, opening a stream that waited for events nothing could publish.
9. **`Publish` looked its lock up in a table the sweep could remove underneath it**, so two publishers could hold different locks and lose the ordering the lock exists to guarantee.

## Verification

- **9,090 tests pass** across the solution (21 assemblies).
- **17 mutations, all killed.** Each one breaks a specific behaviour and names the test that must fail; defects 5, 6 and 7 were found *by* this, not by reading.
- **Gates on `cd76c4ba`:** build, owasp, grader, correctness, security, docs-drift all pass. The security gate does not select these paths by its own path filter, so it was **forced on** rather than skipped — it reports no HIGH findings.

The test gate reports the pre-existing full-solution load flake — a different two or three tests each run (`StructuredJsonLoggerProvider`, `ProcessSandbox*`), all green in isolation in Release, none in code this diff touches.

## Carried forward, not addressed here

- `MaxConcurrentProgressStreams` 64 against `MaxProgressStreamsPerOwner` 8 means eight busy callers can occupy the host ceiling. The per-caller cap bounds the unfairness and polling stays available; the right default depends on expected tenant count, so it is left for a deliberate decision rather than guessed at.
- A stream is authorized once when it opens and delivers for the life of the run, so a token revoked mid-run keeps receiving. Now recorded in the endpoint's own docs as an accepted property, bounded by run duration and by the frames carrying nothing the caller cannot already read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BnoLcufW278UxA9ssBM1Tc