### PR TITLE
feat: human gates end-to-end — pause, answer, resume, cancel (W6)

### DIFF
--- a/src/Content/Application/Application.AI.Common/CQRS/Workflows/CancelRun/CancelWorkflowRunCommand.cs
+++ b/src/Content/Application/Application.AI.Common/CQRS/Workflows/CancelRun/CancelWorkflowRunCommand.cs
@@ -24,4 +24,17 @@ public sealed record CancelWorkflowRunCommand : IRequest<Result<CancelWorkflowRu
 
     /// <summary>Tenant of the calling principal, resolved from its token, when the host resolves one.</summary>
     public string? TenantId { get; init; }
+
+    /// <summary>
+    /// The cancelling caller's approver identity, resolved by the transport from its token. Null when
+    /// the host could not establish one.
+    /// </summary>
+    /// <remarks>
+    /// Recorded as who withdrew the run's pending approvals. Distinct from <see cref="OwnerId"/>, which
+    /// is the same person under a different, immutable claim: the withdrawal lands beside approver
+    /// names in the escalation audit, where an owner id reads differently from every other row. Falls
+    /// back to <see cref="OwnerId"/> when absent, because a withdrawal must always be attributable to
+    /// someone — an unattributed one is worse than an awkwardly-shaped one.
+    /// </remarks>
+    public string? CancellerApproverName { get; init; }
 }

--- a/src/Content/Application/Application.AI.Common/CQRS/Workflows/CancelRun/CancelWorkflowRunCommand.cs
+++ b/src/Content/Application/Application.AI.Common/CQRS/Workflows/CancelRun/CancelWorkflowRunCommand.cs
@@ -1,0 +1,27 @@
+using Domain.Common;
+using MediatR;
+
+namespace Application.AI.Common.CQRS.Workflows.CancelRun;
+
+/// <summary>
+/// Stops a run the caller started, and withdraws any approval it was waiting on.
+/// </summary>
+/// <remarks>
+/// Carries the caller's identity for the same reason every other run request does: the store answers
+/// as though another owner's run does not exist, and a command that omitted the caller could stop
+/// anyone's work.
+/// </remarks>
+public sealed record CancelWorkflowRunCommand : IRequest<Result<CancelWorkflowRunResult>>
+{
+    /// <summary>Identifier of the workflow the run belongs to.</summary>
+    public required Guid WorkflowId { get; init; }
+
+    /// <summary>Identifier of the run to stop.</summary>
+    public required string JobId { get; init; }
+
+    /// <summary>Stable identity of the calling principal, resolved from its token.</summary>
+    public required string OwnerId { get; init; }
+
+    /// <summary>Tenant of the calling principal, resolved from its token, when the host resolves one.</summary>
+    public string? TenantId { get; init; }
+}

--- a/src/Content/Application/Application.AI.Common/CQRS/Workflows/CancelRun/CancelWorkflowRunCommandHandler.cs
+++ b/src/Content/Application/Application.AI.Common/CQRS/Workflows/CancelRun/CancelWorkflowRunCommandHandler.cs
@@ -131,8 +131,17 @@ public sealed class CancelWorkflowRunCommandHandler
             status: nameof(RunStatus.Cancelled),
             detail: "The run was cancelled by its owner.");
 
-        var withdrawn = await WithdrawApprovalsAsync(stopped, request.OwnerId, cancellationToken)
-            .ConfigureAwait(false);
+        var withdrawn = await ApprovalWithdrawal.WithdrawAsync(
+            _escalations,
+            _logger,
+            stopped,
+            "The run this approval was raised for was cancelled.",
+
+            // The caller's approver-shaped identity where the host could establish one. This value
+            // lands beside approver names in the escalation audit, so an owner id would read
+            // differently from every other row there — still attributable, but not comparable.
+            request.CancellerApproverName ?? request.OwnerId,
+            cancellationToken).ConfigureAwait(false);
 
         return Result<CancelWorkflowRunResult>.Success(new CancelWorkflowRunResult
         {
@@ -141,61 +150,4 @@ public sealed class CancelWorkflowRunCommandHandler
         });
     }
 
-    /// <summary>
-    /// Withdraws every approval the cancelled run was waiting on, reporting how many were actually
-    /// withdrawn.
-    /// </summary>
-    /// <remarks>
-    /// <para>
-    /// A failure to withdraw one does not fail the cancellation. The run is already stopped by this
-    /// point, and reporting failure would invite the caller to retry a cancel that has nothing left to
-    /// do.
-    /// </para>
-    /// <para>
-    /// <strong>An approval that is no longer pending is the ordinary case, not a fault.</strong> A gate
-    /// can time out, or be decided, in the window between a run parking on it and anyone cancelling
-    /// that run — the escalation service reports that by throwing, which is its documented contract for
-    /// "no pending escalation with this id". Treating it as an error would fill an operator's log with
-    /// warnings about races that resolved themselves correctly. Anything else that goes wrong does
-    /// leave a request sitting in somebody's queue with nothing to decide, and is logged as the problem
-    /// it is.
-    /// </para>
-    /// </remarks>
-    private async Task<int> WithdrawApprovalsAsync(
-        RunRecord cancelled, string cancelledBy, CancellationToken cancellationToken)
-    {
-        var withdrawn = 0;
-
-        foreach (var escalationId in cancelled.AwaitingEscalationIds)
-        {
-            try
-            {
-                await _escalations.CancelEscalationAsync(
-                    escalationId,
-                    "The run this approval was raised for was cancelled.",
-                    cancelledBy,
-                    cancellationToken).ConfigureAwait(false);
-
-                withdrawn++;
-            }
-            catch (InvalidOperationException)
-            {
-                // Documented contract of the escalation service: no pending escalation with that id.
-                // It was decided or timed out between the run parking and this cancellation, so there
-                // is nothing in anyone's queue and nothing to report.
-                _logger.LogDebug(
-                    "Approval {EscalationId} for cancelled run {JobId} was already resolved.",
-                    escalationId, cancelled.JobId);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex,
-                    "Run {JobId} was cancelled but its approval {EscalationId} could not be withdrawn; "
-                    + "it remains pending in its approvers' queues with nothing left to decide.",
-                    cancelled.JobId, escalationId);
-            }
-        }
-
-        return withdrawn;
-    }
 }

--- a/src/Content/Application/Application.AI.Common/CQRS/Workflows/CancelRun/CancelWorkflowRunCommandHandler.cs
+++ b/src/Content/Application/Application.AI.Common/CQRS/Workflows/CancelRun/CancelWorkflowRunCommandHandler.cs
@@ -1,0 +1,201 @@
+using Application.AI.Common.Interfaces.Escalation;
+using Application.AI.Common.Interfaces.Planner;
+using Application.AI.Common.Interfaces.Runs;
+using Domain.AI.Planner;
+using Domain.AI.Runs;
+using Domain.Common;
+using Domain.Common.Config;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Application.AI.Common.CQRS.Workflows.CancelRun;
+
+/// <summary>
+/// Handles <see cref="CancelWorkflowRunCommand"/>: stops a run and withdraws the approvals it was
+/// waiting on.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>Withdrawing the approval is the point, not a tidy-up.</strong> A gate that outlives its run
+/// is a request in a person's queue that can no longer do anything: answering it approves work that
+/// will never happen, and the approver has no way to know that. Worse, leaving it pending means a
+/// later run of the same workflow — which resumes the same persisted plan — would reconcile against a
+/// verdict given for a run that no longer exists.
+/// </para>
+/// <para>
+/// <strong>The run is stopped before its approvals are withdrawn, deliberately.</strong> Withdrawing
+/// first produces a resolved escalation while the run is still parked on it, which is exactly what the
+/// resume check looks for — so the run would be put back to work in the moment between the two steps,
+/// by the cancellation itself.
+/// </para>
+/// <para>
+/// <strong>A run already executing is signalled, not rewritten.</strong> Its terminal state is owned by
+/// the dispatch in flight; writing one here would be overwritten by it. There is a narrow window —
+/// between a run being claimed and its plan registering for cancellation — in which the signal reaches
+/// nothing and the run continues. The caller sees this the same way it sees every other outcome, by
+/// reading the run, which is why this reports whether the run had actually stopped rather than
+/// claiming it had.
+/// </para>
+/// </remarks>
+public sealed class CancelWorkflowRunCommandHandler
+    : IRequestHandler<CancelWorkflowRunCommand, Result<CancelWorkflowRunResult>>
+{
+    private readonly IRunJobStore _runStore;
+    private readonly IRunProgressBroker _progress;
+    private readonly IPlanRunCancellationRegistry _cancellationRegistry;
+    private readonly IEscalationService _escalations;
+    private readonly IOptionsMonitor<AppConfig> _config;
+    private readonly TimeProvider _time;
+    private readonly ILogger<CancelWorkflowRunCommandHandler> _logger;
+
+    /// <summary>Initializes a new <see cref="CancelWorkflowRunCommandHandler"/>.</summary>
+    public CancelWorkflowRunCommandHandler(
+        IRunJobStore runStore,
+        IRunProgressBroker progress,
+        IPlanRunCancellationRegistry cancellationRegistry,
+        IEscalationService escalations,
+        IOptionsMonitor<AppConfig> config,
+        TimeProvider time,
+        ILogger<CancelWorkflowRunCommandHandler> logger)
+    {
+        ArgumentNullException.ThrowIfNull(runStore);
+        ArgumentNullException.ThrowIfNull(progress);
+        ArgumentNullException.ThrowIfNull(cancellationRegistry);
+        ArgumentNullException.ThrowIfNull(escalations);
+        ArgumentNullException.ThrowIfNull(config);
+        ArgumentNullException.ThrowIfNull(time);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _runStore = runStore;
+        _progress = progress;
+        _cancellationRegistry = cancellationRegistry;
+        _escalations = escalations;
+        _config = config;
+        _time = time;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<Result<CancelWorkflowRunResult>> Handle(
+        CancelWorkflowRunCommand request, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (!_config.CurrentValue.AI.WorkflowSubmission.Enabled)
+        {
+            return Result<CancelWorkflowRunResult>.Forbidden(
+                "Workflow submission is disabled. Set AppConfig.AI.WorkflowSubmission.Enabled = true to enable it.");
+        }
+
+        var record = _runStore.Get(request.JobId, request.OwnerId, request.TenantId);
+
+        // Someone else's run, a run that never existed, and a run reached through the wrong workflow's
+        // route are one answer — the same rule reading a run follows, and for the same reason: a
+        // distinguishable response would let a caller discover work it was not given the id of, and
+        // here it would also let them stop it.
+        if (record is null
+            || record.Kind != RunKind.Workflow
+            || !string.Equals(record.TargetId, request.WorkflowId.ToString(), StringComparison.OrdinalIgnoreCase))
+        {
+            return Result<CancelWorkflowRunResult>.NotFound($"No run {request.JobId} found.");
+        }
+
+        if (record.IsTerminal)
+        {
+            return Result<CancelWorkflowRunResult>.Conflict(
+                $"Run {request.JobId} has already finished and cannot be cancelled.");
+        }
+
+        var stopped = _runStore.TryCancel(request.JobId, _time.GetUtcNow());
+        if (stopped is null)
+        {
+            // Executing, or it reached a terminal state between the read above and here. Either way its
+            // status belongs to the dispatch that holds it, so all that is left is to ask it to stop.
+            _cancellationRegistry.TryCancel(new PlanId(request.WorkflowId));
+
+            return Result<CancelWorkflowRunResult>.Success(new CancelWorkflowRunResult
+            {
+                StoppedImmediately = false,
+                WithdrawnApprovals = 0
+            });
+        }
+
+        // Published here because nothing else will: no dispatch is going to run for this job, and the
+        // terminal event is what ends a watcher's stream. Without it, anyone streaming a queued run
+        // holds the connection and a stream slot until they give up.
+        _progress.Publish(
+            stopped.JobId,
+            RunProgressKind.RunFinished,
+            status: nameof(RunStatus.Cancelled),
+            detail: "The run was cancelled by its owner.");
+
+        var withdrawn = await WithdrawApprovalsAsync(stopped, request.OwnerId, cancellationToken)
+            .ConfigureAwait(false);
+
+        return Result<CancelWorkflowRunResult>.Success(new CancelWorkflowRunResult
+        {
+            StoppedImmediately = true,
+            WithdrawnApprovals = withdrawn
+        });
+    }
+
+    /// <summary>
+    /// Withdraws every approval the cancelled run was waiting on, reporting how many were actually
+    /// withdrawn.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A failure to withdraw one does not fail the cancellation. The run is already stopped by this
+    /// point, and reporting failure would invite the caller to retry a cancel that has nothing left to
+    /// do.
+    /// </para>
+    /// <para>
+    /// <strong>An approval that is no longer pending is the ordinary case, not a fault.</strong> A gate
+    /// can time out, or be decided, in the window between a run parking on it and anyone cancelling
+    /// that run — the escalation service reports that by throwing, which is its documented contract for
+    /// "no pending escalation with this id". Treating it as an error would fill an operator's log with
+    /// warnings about races that resolved themselves correctly. Anything else that goes wrong does
+    /// leave a request sitting in somebody's queue with nothing to decide, and is logged as the problem
+    /// it is.
+    /// </para>
+    /// </remarks>
+    private async Task<int> WithdrawApprovalsAsync(
+        RunRecord cancelled, string cancelledBy, CancellationToken cancellationToken)
+    {
+        var withdrawn = 0;
+
+        foreach (var escalationId in cancelled.AwaitingEscalationIds)
+        {
+            try
+            {
+                await _escalations.CancelEscalationAsync(
+                    escalationId,
+                    "The run this approval was raised for was cancelled.",
+                    cancelledBy,
+                    cancellationToken).ConfigureAwait(false);
+
+                withdrawn++;
+            }
+            catch (InvalidOperationException)
+            {
+                // Documented contract of the escalation service: no pending escalation with that id.
+                // It was decided or timed out between the run parking and this cancellation, so there
+                // is nothing in anyone's queue and nothing to report.
+                _logger.LogDebug(
+                    "Approval {EscalationId} for cancelled run {JobId} was already resolved.",
+                    escalationId, cancelled.JobId);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex,
+                    "Run {JobId} was cancelled but its approval {EscalationId} could not be withdrawn; "
+                    + "it remains pending in its approvers' queues with nothing left to decide.",
+                    cancelled.JobId, escalationId);
+            }
+        }
+
+        return withdrawn;
+    }
+}

--- a/src/Content/Application/Application.AI.Common/CQRS/Workflows/CancelRun/CancelWorkflowRunCommandHandler.cs
+++ b/src/Content/Application/Application.AI.Common/CQRS/Workflows/CancelRun/CancelWorkflowRunCommandHandler.cs
@@ -141,7 +141,13 @@ public sealed class CancelWorkflowRunCommandHandler
             // lands beside approver names in the escalation audit, so an owner id would read
             // differently from every other row there — still attributable, but not comparable.
             request.CancellerApproverName ?? request.OwnerId,
-            cancellationToken).ConfigureAwait(false);
+
+            // Deliberately NOT the request's token. The run is already cancelled by this point, so a
+            // caller that hangs up mid-withdrawal would leave the rest of its approvals pending with
+            // nothing to retry them — the parked-run ceiling only looks at parked runs, and this one is
+            // terminal. The same shape as a run being queued on its caller's abort token, which stranded
+            // workflows permanently.
+            CancellationToken.None).ConfigureAwait(false);
 
         return Result<CancelWorkflowRunResult>.Success(new CancelWorkflowRunResult
         {

--- a/src/Content/Application/Application.AI.Common/CQRS/Workflows/CancelRun/CancelWorkflowRunResult.cs
+++ b/src/Content/Application/Application.AI.Common/CQRS/Workflows/CancelRun/CancelWorkflowRunResult.cs
@@ -1,0 +1,29 @@
+namespace Application.AI.Common.CQRS.Workflows.CancelRun;
+
+/// <summary>
+/// What a cancellation actually achieved.
+/// </summary>
+/// <remarks>
+/// The distinction this exists to make: a run that had not started yet is stopped the moment it is
+/// asked for, whereas a run already executing can only be <em>told</em> to stop and will do so when
+/// its work next reaches a point it can. Reporting both as "cancelled" would tell a caller its work
+/// had stopped when a model call may still be in flight — and a caller that believed it had would
+/// immediately start a replacement run, against a workflow the first run still holds.
+/// </remarks>
+public sealed record CancelWorkflowRunResult
+{
+    /// <summary>Whether the run had already stopped when this was answered.</summary>
+    /// <remarks>
+    /// <see langword="false"/> means the run was executing and has been signalled: it will stop, and
+    /// the caller confirms by reading the run's status as it would for any other outcome.
+    /// </remarks>
+    public required bool StoppedImmediately { get; init; }
+
+    /// <summary>How many pending approvals were withdrawn along with the run.</summary>
+    /// <remarks>
+    /// Reported rather than kept internal because it is the visible consequence for other people: each
+    /// one is a request that an approver could see in their queue a moment ago and can no longer act
+    /// on.
+    /// </remarks>
+    public required int WithdrawnApprovals { get; init; }
+}

--- a/src/Content/Application/Application.AI.Common/CQRS/Workflows/Submit/HumanGateStepConfiguration.cs
+++ b/src/Content/Application/Application.AI.Common/CQRS/Workflows/Submit/HumanGateStepConfiguration.cs
@@ -8,18 +8,23 @@ namespace Application.AI.Common.CQRS.Workflows.Submit;
 /// </summary>
 /// <remarks>
 /// <para>
-/// <strong>Rejected at submission until the answering surface exists.</strong> A workflow containing a
-/// human gate would start, reach the gate, park, and wait indefinitely — because the endpoint that
-/// answers a gate and resumes the parked workflow is not yet built. Accepting such a submission would
-/// hand a caller a workflow that can only ever hang, so the validator refuses it with an explicit
-/// reason rather than storing a trap. The restriction lifts when the answering surface ships; the
-/// contract is defined now so it does not change shape at that point.
+/// <strong>Admitted only when the host can say who may answer it.</strong> Every name in
+/// <see cref="Approvers"/> must appear in <c>AI.WorkflowSubmission.PermittedApprovers</c>, which ships
+/// empty — so a host that has not named its approvers refuses every gate. A gate naming someone the
+/// host does not recognise cannot be answered at all: the workflow would run, reach it, park, and be
+/// failed by the parked-run ceiling however long later. Refusing at submission makes that a 400 the
+/// author can act on rather than a workflow that only ever hangs.
 /// </para>
 /// <para>
-/// <see cref="Approvers"/> names who may decide. Names are matched case-insensitively against the
-/// roster, and a decision is attributed to the identity on the approver's own token — never to a name
-/// supplied in the decision request. A caller cannot nominate itself as approver of its own gate and
-/// then self-approve by asserting an identity in a request body.
+/// <strong>The submitter may not be an approver of its own gate.</strong> A gate its author can answer
+/// is not an approval — the workflow pauses and continues on the say-so of the person who wrote it,
+/// while the audit record shows that a human decided. The submitter's identity is taken from its
+/// token, through the same configured claim the decision path reads, so the comparison is between two
+/// forms of the same name.
+/// </para>
+/// <para>
+/// Names are matched case-insensitively (<c>ApproverNames.Comparer</c>), and a decision is attributed
+/// to the identity on the approver's own token — never to a name supplied in the decision request.
 /// </para>
 /// </remarks>
 public sealed record HumanGateStepConfiguration : WorkflowStepConfiguration

--- a/src/Content/Application/Application.AI.Common/CQRS/Workflows/Submit/SubmitWorkflowCommand.cs
+++ b/src/Content/Application/Application.AI.Common/CQRS/Workflows/Submit/SubmitWorkflowCommand.cs
@@ -26,4 +26,25 @@ public sealed record SubmitWorkflowCommand : IRequest<Result<SubmitWorkflowResul
 {
     /// <summary>The workflow to admit and store.</summary>
     public required WorkflowDefinition Definition { get; init; }
+
+    /// <summary>
+    /// The submitting caller's approver identity, resolved by the transport from its token — never
+    /// from the request body. Null when the host could not establish one.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Present only so a caller cannot author a gate that it may then approve itself, which would make
+    /// the gate ceremonial. It is not ownership: ownership still comes from the ambient scope and has
+    /// no field here. It is a <em>different</em> identity from the owner, resolved through a different,
+    /// operator-chosen claim — comparing an owner id against a roster of sign-in names would silently
+    /// never match, and the self-approval check would pass for everyone.
+    /// </para>
+    /// <para>
+    /// A null value refuses human gates rather than skipping the check. That is the whole reason this
+    /// is safe to carry on a command: a transport that forgets to populate it — or a principal that
+    /// carries no usable claim — loses the ability to submit gates, it does not gain the ability to
+    /// self-approve.
+    /// </para>
+    /// </remarks>
+    public string? SubmitterApproverName { get; init; }
 }

--- a/src/Content/Application/Application.AI.Common/CQRS/Workflows/Submit/SubmitWorkflowCommandValidator.cs
+++ b/src/Content/Application/Application.AI.Common/CQRS/Workflows/Submit/SubmitWorkflowCommandValidator.cs
@@ -1,3 +1,4 @@
+using Domain.AI.Escalation;
 using Domain.AI.Planner;
 using Domain.Common.Config.AI;
 using Domain.Common.Config.AI.WorkflowSubmission;
@@ -66,6 +67,21 @@ public sealed class SubmitWorkflowCommandValidator : AbstractValidator<SubmitWor
                 .WithMessage("Step names must be unique within a submission; edges refer to steps by name.")
             .When(x => x.Definition is not null);
 
+        // Human gates, checked where the whole command is visible: one rule needs the host's roster,
+        // the other needs the submitter's identity, and neither is reachable from the per-step child
+        // rules below.
+        RuleFor(x => x.Definition.Steps)
+            .Cascade(CascadeMode.Continue)
+            .Must(GatesNameOnlyPermittedApprovers)
+                .WithMessage("A human gate names an approver this host does not recognise. A gate can "
+                    + "only be answered by someone the host knows, so one naming anyone else would park "
+                    + "the workflow until it was given up on.")
+            .Must((command, steps) => NoGateIsApprovableByItsAuthor(command, steps))
+                .WithMessage("A human gate names its own submitter as an approver. A gate the author "
+                    + "can answer is not an approval — the workflow would pause and continue on the say-so "
+                    + "of the person who wrote it.")
+            .When(x => x.Definition?.Steps is not null);
+
         RuleFor(x => x.Definition.Edges)
             .NotNull().WithMessage("An edge list is required; send an empty list for a single-step workflow.")
             .Must(ContainNoNullElements).WithMessage("A workflow may not contain a null edge.")
@@ -101,6 +117,70 @@ public sealed class SubmitWorkflowCommandValidator : AbstractValidator<SubmitWor
     }
 
     private WorkflowSubmissionConfig Caps => _config.CurrentValue.WorkflowSubmission;
+
+    /// <summary>
+    /// Every approver a submitted gate names must be someone the host recognises.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A gate is answerable only by the people it names, so a name the host does not know is a gate
+    /// that can never be answered: the workflow runs, reaches it, parks, and is failed by the
+    /// parked-run ceiling however long later. Refusing at submission turns that into a 400 the author
+    /// can act on.
+    /// </para>
+    /// <para>
+    /// An empty roster therefore refuses every gate. That is deliberate and is the shipped default —
+    /// a host that has not said who may approve things has said that nothing may be approved, and the
+    /// alternative reading ("no roster means anyone") is a check that exists and enforces nothing.
+    /// </para>
+    /// <para>
+    /// The failure message names no roster entry. Which names the host recognises is not something a
+    /// submission surface should teach a caller who is guessing.
+    /// </para>
+    /// </remarks>
+    private bool GatesNameOnlyPermittedApprovers(IReadOnlyList<WorkflowStep>? steps) =>
+        HumanGatesIn(steps).All(gate =>
+            gate.Approvers.All(approver => Caps.PermittedApprovers.Contains(approver, ApproverNames.Comparer)));
+
+    /// <summary>
+    /// No submitted gate may name the caller submitting it.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A gate its own author can answer is not an approval — the workflow pauses and continues on the
+    /// say-so of the person who wrote it, while the audit record shows a human decided. The whole
+    /// value of a gate is that someone other than the author has to agree.
+    /// </para>
+    /// <para>
+    /// Compares against the identity the transport resolved from the caller's token through the same
+    /// claim the decision path reads, so the two are the same string for the same person. Comparing
+    /// against the owner id instead would compare an object id to a roster of sign-in names and match
+    /// nothing, and this check would pass for everyone while appearing to work.
+    /// </para>
+    /// <para>
+    /// A caller whose approver identity could not be established cannot submit a gate at all. The
+    /// check cannot be performed, and the fail-open reading of that — "we could not tell, so allow
+    /// it" — is exactly the self-approval this exists to prevent.
+    /// </para>
+    /// </remarks>
+    private static bool NoGateIsApprovableByItsAuthor(
+        SubmitWorkflowCommand command, IReadOnlyList<WorkflowStep>? steps)
+    {
+        var gates = HumanGatesIn(steps).ToList();
+        if (gates.Count == 0)
+            return true;
+
+        if (command.SubmitterApproverName is not { } submitter)
+            return false;
+
+        return gates.All(gate => !gate.Approvers.Contains(submitter, ApproverNames.Comparer));
+    }
+
+    /// <summary>The human-gate configurations in a submission, skipping nulls and other step types.</summary>
+    private static IEnumerable<HumanGateStepConfiguration> HumanGatesIn(IReadOnlyList<WorkflowStep>? steps) =>
+        (steps ?? []).Where(step => step is not null)
+            .Select(step => step.Configuration)
+            .OfType<HumanGateStepConfiguration>();
 
     private void ConfigureStepRules(InlineValidator<WorkflowStep> step)
     {

--- a/src/Content/Application/Application.AI.Common/CQRS/Workflows/Submit/SubmitWorkflowCommandValidator.cs
+++ b/src/Content/Application/Application.AI.Common/CQRS/Workflows/Submit/SubmitWorkflowCommandValidator.cs
@@ -140,7 +140,7 @@ public sealed class SubmitWorkflowCommandValidator : AbstractValidator<SubmitWor
     /// </remarks>
     private bool GatesNameOnlyPermittedApprovers(IReadOnlyList<WorkflowStep>? steps) =>
         HumanGatesIn(steps).All(gate =>
-            gate.Approvers.All(approver => Caps.PermittedApprovers.Contains(approver, ApproverNames.Comparer)));
+            ApproversOf(gate).All(approver => Caps.PermittedApprovers.Contains(approver, ApproverNames.Comparer)));
 
     /// <summary>
     /// No submitted gate may name the caller submitting it.
@@ -173,8 +173,22 @@ public sealed class SubmitWorkflowCommandValidator : AbstractValidator<SubmitWor
         if (command.SubmitterApproverName is not { } submitter)
             return false;
 
-        return gates.All(gate => !gate.Approvers.Contains(submitter, ApproverNames.Comparer));
+        return gates.All(gate => !ApproversOf(gate).Contains(submitter, ApproverNames.Comparer));
     }
+
+    /// <summary>
+    /// A gate's approver list, or an empty one when the caller sent <c>"approvers": null</c>.
+    /// </summary>
+    /// <remarks>
+    /// The property carries an empty-list initializer, which System.Text.Json overwrites with null for
+    /// an explicit JSON null — so the initializer is not the guarantee it looks like. Every rule that
+    /// reads the list goes through here, because the alternative is an unhandled dereference and a 500
+    /// on the admission path, which is the same failure a null step element already produced once. The
+    /// empty result then fails the "at least one approver" rule and the caller gets the 400 it should
+    /// have had.
+    /// </remarks>
+    private static IReadOnlyList<string> ApproversOf(HumanGateStepConfiguration gate) =>
+        gate.Approvers ?? [];
 
     /// <summary>The human-gate configurations in a submission, skipping nulls and other step types.</summary>
     private static IEnumerable<HumanGateStepConfiguration> HumanGatesIn(IReadOnlyList<WorkflowStep>? steps) =>
@@ -271,7 +285,7 @@ public sealed class SubmitWorkflowCommandValidator : AbstractValidator<SubmitWor
         ToolUseStepConfiguration c => BeWithinStringCap(c.ToolName)
             && c.InputParameters.Values.OfType<string>().All(BeWithinStringCap),
         HumanGateStepConfiguration c => BeWithinStringCap(c.EscalationMessage)
-            && c.Approvers.All(BeWithinStringCap),
+            && ApproversOf(c).All(BeWithinStringCap),
         ConditionalBranchStepConfiguration c => BeWithinStringCap(c.ConditionExpression),
         RetrievalWorkflowStepConfiguration c => BeWithinStringCap(c.Query),
         _ => true
@@ -305,8 +319,8 @@ public sealed class SubmitWorkflowCommandValidator : AbstractValidator<SubmitWor
             && !string.IsNullOrWhiteSpace(c.ModelDeploymentKey),
         ToolUseStepConfiguration c => !string.IsNullOrWhiteSpace(c.ToolName),
         HumanGateStepConfiguration c => !string.IsNullOrWhiteSpace(c.EscalationMessage)
-            && c.Approvers.Count > 0
-            && c.Approvers.All(approver => !string.IsNullOrWhiteSpace(approver)),
+            && ApproversOf(c).Count > 0
+            && ApproversOf(c).All(approver => !string.IsNullOrWhiteSpace(approver)),
         ConditionalBranchStepConfiguration c => !string.IsNullOrWhiteSpace(c.ConditionExpression),
         RetrievalWorkflowStepConfiguration c => !string.IsNullOrWhiteSpace(c.Query),
         _ => true

--- a/src/Content/Application/Application.AI.Common/Interfaces/Escalation/ApprovalWithdrawal.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Escalation/ApprovalWithdrawal.cs
@@ -1,0 +1,92 @@
+using Domain.AI.Runs;
+using Microsoft.Extensions.Logging;
+
+namespace Application.AI.Common.Interfaces.Escalation;
+
+/// <summary>
+/// Withdraws the approvals a run was waiting on when that run is given up on.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Shared because there are two ways a parked run ends without its gate being answered — a caller
+/// cancels it, or the host's parked-run ceiling gives up on it — and both must release the same thing.
+/// An approval that outlives its run sits in a person's queue with nothing left to decide, and
+/// answering it is not harmless: a workflow's plan state outlives any one run, so a verdict given for a
+/// dead run is reconciled by the next one.
+/// </para>
+/// <para>
+/// One implementation rather than two, because the part that is easy to get wrong is not the loop —
+/// it is knowing that a "no pending escalation with that id" failure is the ordinary case rather than a
+/// fault. A second copy that logged it as an error would page an operator every time a gate timed out
+/// microseconds before someone cancelled its run.
+/// </para>
+/// </remarks>
+public static class ApprovalWithdrawal
+{
+    /// <summary>
+    /// Withdraws every approval <paramref name="abandoned"/> was parked on, returning how many were
+    /// actually withdrawn.
+    /// </summary>
+    /// <param name="escalations">The escalation lifecycle service.</param>
+    /// <param name="logger">Records approvals genuinely left pending; never fails the caller.</param>
+    /// <param name="abandoned">The run as it stood while parked, carrying what it was waiting on.</param>
+    /// <param name="reason">Caller-safe reason recorded on the escalation's audit trail.</param>
+    /// <param name="withdrawnBy">
+    /// Who to attribute the withdrawal to. Should be an approver-shaped identity where one is
+    /// available, since it lands beside approver names in the escalation audit.
+    /// </param>
+    /// <param name="cancellationToken">Cancels the withdrawal.</param>
+    /// <returns>
+    /// How many approvals were withdrawn — not how many were attempted. The difference is the ones
+    /// that had already been decided, which is information the caller can legitimately report.
+    /// </returns>
+    /// <remarks>
+    /// A failure to withdraw one never fails the caller. The run is already over by this point, and
+    /// reporting failure would invite a retry of an operation with nothing left to do — while the thing
+    /// that actually went wrong is not something the caller can fix.
+    /// </remarks>
+    public static async Task<int> WithdrawAsync(
+        IEscalationService escalations,
+        ILogger logger,
+        RunRecord abandoned,
+        string reason,
+        string withdrawnBy,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(escalations);
+        ArgumentNullException.ThrowIfNull(logger);
+        ArgumentNullException.ThrowIfNull(abandoned);
+
+        var withdrawn = 0;
+
+        foreach (var escalationId in abandoned.AwaitingEscalationIds)
+        {
+            try
+            {
+                await escalations
+                    .CancelEscalationAsync(escalationId, reason, withdrawnBy, cancellationToken)
+                    .ConfigureAwait(false);
+
+                withdrawn++;
+            }
+            catch (InvalidOperationException)
+            {
+                // Documented contract of the escalation service: no pending escalation with that id.
+                // It was decided or timed out between the run parking and this withdrawal, so there is
+                // nothing in anyone's queue and nothing to report.
+                logger.LogDebug(
+                    "Approval {EscalationId} for abandoned run {JobId} was already resolved.",
+                    escalationId, abandoned.JobId);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex,
+                    "Run {JobId} was given up on but its approval {EscalationId} could not be withdrawn; "
+                    + "it remains pending in its approvers' queues with nothing left to decide.",
+                    abandoned.JobId, escalationId);
+            }
+        }
+
+        return withdrawn;
+    }
+}

--- a/src/Content/Application/Application.AI.Common/Interfaces/Runs/IRunJobStore.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Runs/IRunJobStore.cs
@@ -133,6 +133,34 @@ public interface IRunJobStore
     RunRecord? TryResume(string jobId);
 
     /// <summary>
+    /// Atomically cancels a run that has not started executing, or is parked awaiting a decision,
+    /// returning the run <em>as it stood immediately before</em> the transition.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The previous record is returned, not the updated one, because what the caller needs next is
+    /// what the run was doing — specifically which decisions it was parked on, so those can be
+    /// withdrawn. Reading that separately beforehand would not be the same thing: a run can park
+    /// between the read and the cancel, and the caller would then withdraw nothing while believing it
+    /// had.
+    /// </para>
+    /// <para>
+    /// <strong>A run that is executing is deliberately not cancelled here.</strong> Its status is
+    /// owned by the dispatch in flight, which will write a terminal state when the work stops; writing
+    /// one here would be overwritten by it moments later. Stopping executing work is a matter of
+    /// signalling it, which is a different mechanism from storage.
+    /// </para>
+    /// <para>
+    /// Returns <see langword="null"/> when there is no such run, or when it is executing or already
+    /// terminal — the three being distinguishable by the caller from a prior scoped read, which this
+    /// is not a substitute for.
+    /// </para>
+    /// </remarks>
+    /// <param name="jobId">The run to cancel.</param>
+    /// <param name="cancelledAt">Timestamp to record as the completion time.</param>
+    RunRecord? TryCancel(string jobId, DateTimeOffset cancelledAt);
+
+    /// <summary>
     /// Fails runs that have been parked awaiting a decision for longer than
     /// <paramref name="maxParkedDuration"/>, returning the identifiers of those failed.
     /// </summary>

--- a/src/Content/Application/Application.AI.Common/Interfaces/Runs/IRunJobStore.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Runs/IRunJobStore.cs
@@ -175,9 +175,17 @@ public interface IRunJobStore
     /// Fails rather than deletes. A caller that comes back to a run it started is owed an answer about
     /// what became of it, and "no such run" is the one answer that tells it nothing.
     /// </para>
+    /// <para>
+    /// Returns each run <em>as it stood immediately before</em> being failed, for the same reason
+    /// <see cref="TryCancel"/> does: giving up on a run has to release what it was holding, and the
+    /// approvals it was parked on are part of that. A caller handed only identifiers could not withdraw
+    /// them, and an approval that outlives its run is answerable by someone who cannot know it is moot
+    /// — worse here than on the cancel path, because failing the run unlocks its workflow, so the next
+    /// run inherits the plan the stale verdict will be reconciled against.
+    /// </para>
     /// </remarks>
     /// <param name="maxParkedDuration">How long a run may stay parked before it is given up on.</param>
-    IReadOnlyList<string> ExpireStaleParkedRuns(TimeSpan maxParkedDuration);
+    IReadOnlyList<RunRecord> ExpireStaleParkedRuns(TimeSpan maxParkedDuration);
 
     /// <summary>
     /// Drops runs whose retention has elapsed, returning the identifiers of those removed.

--- a/src/Content/Application/Application.AI.Common/Interfaces/Runs/IRunJobStore.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Runs/IRunJobStore.cs
@@ -95,6 +95,25 @@ public interface IRunJobStore
     RunRecord? FindLiveRunForTarget(RunKind kind, string targetId);
 
     /// <summary>
+    /// Fails runs that have been parked awaiting a decision for longer than
+    /// <paramref name="maxParkedDuration"/>, returning the identifiers of those failed.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A parked run is live, so retention never reclaims it and its target stays locked. That is the
+    /// point — a workflow waiting on an approval is genuinely still in flight — but it means an
+    /// unanswered gate would otherwise hold a workflow and an owner's concurrency slot for the life of
+    /// the process. Failing the run makes it terminal, which lets both go.
+    /// </para>
+    /// <para>
+    /// Fails rather than deletes. A caller that comes back to a run it started is owed an answer about
+    /// what became of it, and "no such run" is the one answer that tells it nothing.
+    /// </para>
+    /// </remarks>
+    /// <param name="maxParkedDuration">How long a run may stay parked before it is given up on.</param>
+    IReadOnlyList<string> ExpireStaleParkedRuns(TimeSpan maxParkedDuration);
+
+    /// <summary>
     /// Drops runs whose retention has elapsed, returning the identifiers of those removed.
     /// </summary>
     /// <remarks>

--- a/src/Content/Application/Application.AI.Common/Interfaces/Runs/IRunJobStore.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Runs/IRunJobStore.cs
@@ -95,6 +95,44 @@ public interface IRunJobStore
     RunRecord? FindLiveRunForTarget(RunKind kind, string targetId);
 
     /// <summary>
+    /// Lists the runs currently parked awaiting a decision.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Takes no caller and applies no scope, for the same reason as
+    /// <see cref="FindLiveRunForTarget"/>: it answers the host's own question — which parked work can
+    /// now continue — rather than any caller's. Nothing reached through a request may use it.
+    /// </para>
+    /// <para>
+    /// Returns the records, not their identifiers, because the caller's next question is what each run
+    /// is waiting on. Handing back ids would make the caller read each one again through a scoped
+    /// accessor it has no identity for.
+    /// </para>
+    /// </remarks>
+    IReadOnlyList<RunRecord> GetParkedRuns();
+
+    /// <summary>
+    /// Atomically returns a parked run to the queue, handing the updated record to the caller that won
+    /// and <see langword="null"/> to everyone else.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The counterpart of <see cref="TryBeginRun"/>, and atomic for the same reason: two resumers that
+    /// both observed the run as parked would both enqueue it, and the second dispatch would execute the
+    /// same plan concurrently with the first. Winning the transition — not observing the verdict — is
+    /// what entitles a caller to enqueue.
+    /// </para>
+    /// <para>
+    /// <see cref="RunRecord.ParkedAt"/> and <see cref="RunRecord.AwaitingEscalationIds"/> are cleared:
+    /// both describe a wait that is over. Leaving them would make a run that parks again look like it
+    /// had been waiting since its first gate, and would keep it eligible for the parked-run ceiling
+    /// while it is running.
+    /// </para>
+    /// </remarks>
+    /// <param name="jobId">The parked run to return to the queue.</param>
+    RunRecord? TryResume(string jobId);
+
+    /// <summary>
     /// Fails runs that have been parked awaiting a decision for longer than
     /// <paramref name="maxParkedDuration"/>, returning the identifiers of those failed.
     /// </summary>

--- a/src/Content/Application/Application.AI.Common/Interfaces/Runs/IRunJobStore.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Runs/IRunJobStore.cs
@@ -133,6 +133,28 @@ public interface IRunJobStore
     RunRecord? TryResume(string jobId);
 
     /// <summary>
+    /// Undoes a <see cref="TryResume"/> whose caller could not go on to queue the run, returning it to
+    /// the parked state it held. Applies only while the run is still queued, and reports whether it
+    /// did.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Exists because a run left <see cref="RunStatus.Queued"/> but absent from the queue is the one
+    /// state nothing recovers from: no dispatcher claims a run it was never handed, and the parked-run
+    /// ceiling only inspects parked runs. Re-parking puts it back under that ceiling and lets the next
+    /// resume attempt try again.
+    /// </para>
+    /// <para>
+    /// Guarded rather than a blind write, for the same reason every other transition here is. In the
+    /// window between the failed queue write and this call, the run's owner may have cancelled it —
+    /// and an unconditional restore would put a cancelled run back to waiting on approvals that have
+    /// already been withdrawn.
+    /// </para>
+    /// </remarks>
+    /// <param name="parked">The record as it stood before it was resumed.</param>
+    bool TryRepark(RunRecord parked);
+
+    /// <summary>
     /// Atomically cancels a run that has not started executing, or is parked awaiting a decision,
     /// returning the run <em>as it stood immediately before</em> the transition.
     /// </summary>

--- a/src/Content/Application/Application.Core/Validation/WorkflowSubmissionConfigValidator.cs
+++ b/src/Content/Application/Application.Core/Validation/WorkflowSubmissionConfigValidator.cs
@@ -111,6 +111,10 @@ public sealed class WorkflowSubmissionConfigValidator : AbstractValidator<Workfl
             .GreaterThan(TimeSpan.Zero)
             .WithMessage("RunSweepInterval must be > 0 — a non-positive interval would spin the sweeper continuously instead of scheduling it.");
 
+        RuleFor(x => x.ParkedRunResumeInterval)
+            .GreaterThan(TimeSpan.Zero)
+            .WithMessage("ParkedRunResumeInterval must be > 0 — a non-positive interval would spin the resume check continuously instead of scheduling it.");
+
         RuleFor(x => x.MaxHumanGateTimeout)
             .GreaterThan(TimeSpan.Zero)
             .WithMessage("MaxHumanGateTimeout must be > 0 — a non-positive ceiling would reject every requested gate timeout.");

--- a/src/Content/Application/Application.Core/Validation/WorkflowSubmissionConfigValidator.cs
+++ b/src/Content/Application/Application.Core/Validation/WorkflowSubmissionConfigValidator.cs
@@ -103,6 +103,10 @@ public sealed class WorkflowSubmissionConfigValidator : AbstractValidator<Workfl
             .GreaterThan(0)
             .WithMessage("ProgressBufferSize must be > 0 — a non-positive buffer would drop every event before any watcher could read it.");
 
+        RuleFor(x => x.MaxParkedRunDuration)
+            .GreaterThan(TimeSpan.Zero)
+            .WithMessage("MaxParkedRunDuration must be > 0 — a non-positive ceiling would expire every gate the moment it parked, so no workflow could ever wait for an approval.");
+
         RuleFor(x => x.RunSweepInterval)
             .GreaterThan(TimeSpan.Zero)
             .WithMessage("RunSweepInterval must be > 0 — a non-positive interval would spin the sweeper continuously instead of scheduling it.");

--- a/src/Content/Domain/Domain.AI/Planner/EscalationStepOutput.cs
+++ b/src/Content/Domain/Domain.AI/Planner/EscalationStepOutput.cs
@@ -1,0 +1,69 @@
+using System.Text.Json;
+
+namespace Domain.AI.Planner;
+
+/// <summary>
+/// The output a step parked in <see cref="StepExecutionStatus.Blocked"/> carries: a reference to the
+/// escalation whose verdict decides its fate.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This exists because the shape is a contract between parties that never call each other. A human
+/// gate writes it, the plan executor reads it back on resume to reconcile the block, and the run
+/// substrate reads it to learn which decisions a parked run is waiting on. Three writers of the same
+/// JSON literal is three chances for one of them to drift, and the failure it produces is silent: a
+/// reader that finds no escalation reference concludes the step has none and leaves it blocked
+/// forever.
+/// </para>
+/// <para>
+/// It is deliberately not a general-purpose step-output envelope. A blocked step carries a reference
+/// and nothing else — the escalation's own record holds the request, the approvers and the verdict —
+/// and this stays that narrow so it cannot become the place step results accumulate.
+/// </para>
+/// </remarks>
+public static class EscalationStepOutput
+{
+    /// <summary>JSON property under which the escalation identifier is stored.</summary>
+    private const string EscalationIdProperty = "escalationId";
+
+    /// <summary>Writes the output a step blocked on <paramref name="escalationId"/> carries.</summary>
+    /// <param name="escalationId">The escalation whose verdict releases the step.</param>
+    /// <returns>The JSON output to store against the blocked step.</returns>
+    public static string Serialize(Guid escalationId) =>
+        JsonSerializer.Serialize(
+            new Dictionary<string, string> { [EscalationIdProperty] = escalationId.ToString() });
+
+    /// <summary>
+    /// Reads the escalation identifier out of a blocked step's stored output.
+    /// </summary>
+    /// <param name="output">The step's stored output, which may be absent or not an escalation reference.</param>
+    /// <returns>
+    /// The referenced escalation, or <see langword="null"/> when the output is absent, is not JSON, or
+    /// carries no escalation reference — all of which mean the same thing to every caller: there is no
+    /// decision to look up.
+    /// </returns>
+    public static Guid? TryReadEscalationId(string? output)
+    {
+        if (string.IsNullOrEmpty(output))
+            return null;
+
+        try
+        {
+            using var doc = JsonDocument.Parse(output);
+            if (doc.RootElement.ValueKind == JsonValueKind.Object
+                && doc.RootElement.TryGetProperty(EscalationIdProperty, out var idElement)
+                && idElement.ValueKind == JsonValueKind.String
+                && Guid.TryParse(idElement.GetString(), out var id))
+            {
+                return id;
+            }
+        }
+        catch (JsonException)
+        {
+            // Not JSON, or corrupt. Indistinguishable from "no reference" to every caller, and a step
+            // whose output cannot be read is left blocked rather than guessed at.
+        }
+
+        return null;
+    }
+}

--- a/src/Content/Domain/Domain.AI/Runs/RunCompletion.cs
+++ b/src/Content/Domain/Domain.AI/Runs/RunCompletion.cs
@@ -27,6 +27,17 @@ public sealed record RunCompletion
     /// </summary>
     public string? Detail { get; init; }
 
+    /// <summary>
+    /// The decisions a parked run is waiting on. Empty for every other status.
+    /// </summary>
+    /// <remarks>
+    /// This is what makes a park recoverable. A run that parks without naming what it waits on can
+    /// only ever be released by the host's parked-run ceiling — which fails it — so the ids are
+    /// carried from the executor that knows them rather than rediscovered later by a reader that
+    /// would have to reach into another subsystem's state to find them.
+    /// </remarks>
+    public IReadOnlyList<Guid> AwaitingEscalationIds { get; init; } = [];
+
     /// <summary>The run produced its result.</summary>
     public static RunCompletion Succeeded() => new() { Status = RunStatus.Succeeded };
 
@@ -42,6 +53,17 @@ public sealed record RunCompletion
 
     /// <summary>The run parked awaiting a decision it cannot make for itself.</summary>
     /// <param name="detail">Caller-safe explanation of what is being waited on.</param>
-    public static RunCompletion Blocked(string detail) =>
-        new() { Status = RunStatus.Blocked, Detail = detail };
+    /// <param name="awaitingEscalationIds">
+    /// The decisions whose verdicts release the run. Required rather than optional: an empty list is a
+    /// legitimate answer — a plan can park with no readable escalation reference — but it means the run
+    /// is unrecoverable except by the host's parked-run ceiling, and a caller should have to say so
+    /// rather than arrive there by omitting an argument.
+    /// </param>
+    public static RunCompletion Blocked(string detail, IReadOnlyList<Guid> awaitingEscalationIds) =>
+        new()
+        {
+            Status = RunStatus.Blocked,
+            Detail = detail,
+            AwaitingEscalationIds = awaitingEscalationIds
+        };
 }

--- a/src/Content/Domain/Domain.AI/Runs/RunProgressEvent.cs
+++ b/src/Content/Domain/Domain.AI/Runs/RunProgressEvent.cs
@@ -71,5 +71,17 @@ public enum RunProgressKind
     StepCompleted = 2,
 
     /// <summary>The run reached a terminal state. Emitted once, last.</summary>
-    RunFinished = 3
+    RunFinished = 3,
+
+    /// <summary>
+    /// The run parked awaiting a decision it cannot make for itself, such as a human approval gate.
+    /// </summary>
+    /// <remarks>
+    /// Separate from <see cref="RunFinished"/> because the run is not over — answering the gate
+    /// continues it under the same job id. It ends a <em>stream</em> without ending the <em>run</em>:
+    /// nothing further will be published until somebody acts, and an approver may take days, so a
+    /// watcher is told to stop waiting rather than being left holding a connection. A client that
+    /// wants to follow the rest of the run opens a new stream once it has answered.
+    /// </remarks>
+    RunParked = 4
 }

--- a/src/Content/Domain/Domain.AI/Runs/RunRecord.cs
+++ b/src/Content/Domain/Domain.AI/Runs/RunRecord.cs
@@ -60,7 +60,10 @@ public sealed record RunRecord
     /// <summary>When the run was accepted and queued.</summary>
     public required DateTimeOffset CreatedAt { get; init; }
 
-    /// <summary>When a dispatcher claimed the run, if it has been claimed.</summary>
+    /// <summary>
+    /// When the run first began executing, if it has. Not re-stamped when a parked run resumes — the
+    /// work started when it started, and <see cref="ParkedAt"/> is what tracks the current wait.
+    /// </summary>
     public DateTimeOffset? StartedAt { get; init; }
 
     /// <summary>When the run reached a terminal state, if it has.</summary>
@@ -73,6 +76,23 @@ public sealed record RunRecord
     /// answers is otherwise indistinguishable from one answered a moment ago.
     /// </remarks>
     public DateTimeOffset? ParkedAt { get; init; }
+
+    /// <summary>
+    /// The decisions this run is parked on. Empty unless the run is parked.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Recorded on the run rather than rediscovered by whatever wants to resume it. The alternative is
+    /// to ask the workflow's plan state which of its steps are blocked and on what — which makes the
+    /// run substrate a reader of the planner's internals, and makes "which run is waiting on this
+    /// decision" a scan of every plan rather than a lookup.
+    /// </para>
+    /// <para>
+    /// Several at once is normal: a plan can reach two gates on parallel branches, park on both, and be
+    /// resumable by either verdict — reconciliation on the next execution re-reads all of them.
+    /// </para>
+    /// </remarks>
+    public IReadOnlyList<Guid> AwaitingEscalationIds { get; init; } = [];
 
     /// <summary>Whether the run has finished and will not change again.</summary>
     /// <remarks>

--- a/src/Content/Domain/Domain.AI/Runs/RunRecord.cs
+++ b/src/Content/Domain/Domain.AI/Runs/RunRecord.cs
@@ -45,9 +45,21 @@ public sealed record RunRecord
     /// The grant this run executes under, resolved from the credential that <em>started</em> it.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// Carried per run rather than re-resolved at execution time, so a run performs exactly what the
     /// caller who triggered it was entitled to at that moment — a later change to that caller's grant
     /// does not retroactively widen work already queued.
+    /// </para>
+    /// <para>
+    /// <strong>Accepted property, disclosed rather than discovered later: the grant is not
+    /// re-evaluated when a parked run resumes.</strong> A workflow waiting on a human gate may sit for
+    /// up to the host's <c>MaxParkedRunDuration</c> — a week by default — and it then continues under
+    /// the grant its submitter held when it started, even if that grant has since been narrowed. It is
+    /// a ceiling on what one caller could already do rather than a way to exceed it, and the window is
+    /// operator-bounded; re-resolving it would need a credential to resolve <em>from</em>, and by then
+    /// there is no request and no principal. A host that needs revocation to take effect sooner than a
+    /// gate can be answered should shorten that ceiling.
+    /// </para>
     /// </remarks>
     public required CapabilityEnvelope Envelope { get; init; }
 

--- a/src/Content/Domain/Domain.AI/Runs/RunRecord.cs
+++ b/src/Content/Domain/Domain.AI/Runs/RunRecord.cs
@@ -66,14 +66,45 @@ public sealed record RunRecord
     /// <summary>When the run reached a terminal state, if it has.</summary>
     public DateTimeOffset? CompletedAt { get; init; }
 
+    /// <summary>When the run parked awaiting a decision, if it is parked.</summary>
+    /// <remarks>
+    /// Distinct from <see cref="StartedAt"/> because a run can park and resume more than once, and the
+    /// thing that needs bounding is how long it has been waiting <em>this</em> time. A gate nobody
+    /// answers is otherwise indistinguishable from one answered a moment ago.
+    /// </remarks>
+    public DateTimeOffset? ParkedAt { get; init; }
+
     /// <summary>Whether the run has finished and will not change again.</summary>
     /// <remarks>
+    /// <para>
     /// Expressed as "not one of the live states" rather than "one of the terminal states" on purpose.
-    /// Queued and Running are the only two the dispatcher can move a run out of, and enumerating the
-    /// terminal side instead means every future outcome added to <see cref="RunStatus"/> is silently
-    /// treated as live until someone remembers to list it here — which would strand it at the
-    /// concurrency cap and keep it from ever being reclaimed.
+    /// The live states are the ones a run can still move out of, and enumerating the terminal side
+    /// instead means every future outcome added to <see cref="RunStatus"/> is silently treated as live
+    /// until someone remembers to list it here — which would strand it at the concurrency cap and keep
+    /// it from ever being reclaimed.
+    /// </para>
+    /// <para>
+    /// <see cref="RunStatus.Blocked"/> is live: a parked run resumes under this same job id when its
+    /// gate is answered. Listing it here is what keeps its workflow locked — admission permits one live
+    /// run per target, so a parked run read as finished would release its workflow to a second run
+    /// against the same plan state machine.
+    /// </para>
     /// </remarks>
     public bool IsTerminal =>
-        Status is not (RunStatus.Queued or RunStatus.Running);
+        Status is not (RunStatus.Queued or RunStatus.Running or RunStatus.Blocked);
+
+    /// <summary>Whether the run is parked awaiting a decision it cannot make for itself.</summary>
+    public bool IsAwaitingDecision => Status is RunStatus.Blocked;
+
+    /// <summary>
+    /// Whether the run will produce nothing further unless something outside it acts.
+    /// </summary>
+    /// <remarks>
+    /// The question a progress watcher actually needs answered, and it is not
+    /// <see cref="IsTerminal"/>. A parked run is live, but nothing will be published for it until a
+    /// human answers its gate — so a stream that waited on it would hold a connection and a slot for
+    /// as long as the approver took, having already said everything it can say. Both quiesced states
+    /// mean "stop waiting"; only one of them means "this is over".
+    /// </remarks>
+    public bool IsQuiescent => IsTerminal || IsAwaitingDecision;
 }

--- a/src/Content/Domain/Domain.AI/Runs/RunStatus.cs
+++ b/src/Content/Domain/Domain.AI/Runs/RunStatus.cs
@@ -36,8 +36,27 @@ public enum RunStatus
 
     /// <summary>
     /// Parked awaiting a decision this run cannot make for itself — typically a human approval gate.
-    /// Terminal for the run, because the dispatcher is done with it; acting on the decision starts a
-    /// new run rather than reviving this one.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <strong>Live, not terminal.</strong> The dispatcher is idle on this run, but the work is not
+    /// over: answering the gate continues <em>this</em> run under the same job id. That is what a
+    /// caller means by "my workflow" — one identifier for one unit of work, whatever it had to wait
+    /// for along the way — and it is why <see cref="RunRecord.IsTerminal"/> lists this among the live
+    /// states.
+    /// </para>
+    /// <para>
+    /// Reading it as terminal has a sharper consequence than an untidy status. Admission permits one
+    /// live run per target, so a parked run reported as finished <em>releases its workflow</em>: a
+    /// second run starts against the same plan state machine and can answer the first run's gate. A
+    /// parked run therefore keeps its slot, and keeps the workflow locked, until the gate is resolved.
+    /// </para>
+    /// <para>
+    /// The cost of being live is that retention only reclaims terminal runs, so a gate nobody ever
+    /// answers would hold a slot for the host's life. <c>MaxParkedRunDuration</c> bounds it: a run
+    /// parked longer than that is failed with a caller-safe reason, which makes it terminal and
+    /// reclaimable again.
+    /// </para>
+    /// </remarks>
     Blocked = 5
 }

--- a/src/Content/Domain/Domain.Common/Config/AI/WorkflowSubmission/WorkflowSubmissionConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/WorkflowSubmission/WorkflowSubmissionConfig.cs
@@ -285,4 +285,21 @@ public class WorkflowSubmissionConfig
     /// </remarks>
     /// <value>Default: 256</value>
     public int ProgressBufferSize { get; set; } = 256;
+
+    /// <summary>
+    /// How long a run may stay parked on a human gate before the host gives up on it.
+    /// </summary>
+    /// <remarks>
+    /// A parked run is live, which is what keeps its workflow locked against a second run sharing its
+    /// plan state machine — and which also means retention never reclaims it, because retention only
+    /// reclaims terminal runs. Without a ceiling, one gate nobody ever answers holds a workflow and an
+    /// owner's concurrency slot for the life of the process. Expiring the run fails it with a
+    /// caller-safe reason, which makes it terminal and reclaimable again.
+    /// <para>
+    /// This is a backstop, not the gate's own deadline. An individual gate carries its own
+    /// <c>Timeout</c>; this bounds the case where that timeout never takes effect.
+    /// </para>
+    /// </remarks>
+    /// <value>Default: 7 days</value>
+    public TimeSpan MaxParkedRunDuration { get; set; } = TimeSpan.FromDays(7);
 }

--- a/src/Content/Domain/Domain.Common/Config/AI/WorkflowSubmission/WorkflowSubmissionConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/WorkflowSubmission/WorkflowSubmissionConfig.cs
@@ -65,7 +65,9 @@ namespace Domain.Common.Config.AI.WorkflowSubmission;
 /// ├── MaxConcurrentDispatchedRuns — How many runs the host executes at once, across all callers
 /// ├── MaxConcurrentProgressStreams — How many progress streams may be open at once, host-wide
 /// ├── MaxProgressStreamsPerOwner — How many one caller may hold open at once
-/// └── ProgressBufferSize        — How far behind one watcher may fall before it loses events
+/// ├── ProgressBufferSize        — How far behind one watcher may fall before it loses events
+/// ├── MaxParkedRunDuration      — How long a run may wait on an approval before the host gives up
+/// └── ParkedRunResumeInterval  — How often the host checks whether an approval has been answered
 /// </code>
 /// </remarks>
 public class WorkflowSubmissionConfig
@@ -302,4 +304,23 @@ public class WorkflowSubmissionConfig
     /// </remarks>
     /// <value>Default: 7 days</value>
     public TimeSpan MaxParkedRunDuration { get; set; } = TimeSpan.FromDays(7);
+
+    /// <summary>
+    /// How often the host checks whether a parked run's approval has been answered.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Checking on a clock rather than reacting to each verdict is deliberate. A decision can be taken
+    /// while the host is down — or by a different instance — and an in-process notification is lost in
+    /// both cases, leaving the run parked until the ceiling fails it. Re-reading the verdict is the
+    /// only form of the trigger that survives a restart.
+    /// </para>
+    /// <para>
+    /// Its own setting rather than sharing <see cref="RunSweepInterval"/>: that one paces giving memory
+    /// back, this one paces how long a caller waits after their approver has already said yes, and an
+    /// operator who relaxes the first rarely means to slow the second.
+    /// </para>
+    /// </remarks>
+    /// <value>Default: 5 seconds</value>
+    public TimeSpan ParkedRunResumeInterval { get; set; } = TimeSpan.FromSeconds(5);
 }

--- a/src/Content/Domain/Domain.Common/Config/AI/WorkflowSubmission/WorkflowSubmissionConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/WorkflowSubmission/WorkflowSubmissionConfig.cs
@@ -67,7 +67,8 @@ namespace Domain.Common.Config.AI.WorkflowSubmission;
 /// ├── MaxProgressStreamsPerOwner — How many one caller may hold open at once
 /// ├── ProgressBufferSize        — How far behind one watcher may fall before it loses events
 /// ├── MaxParkedRunDuration      — How long a run may wait on an approval before the host gives up
-/// └── ParkedRunResumeInterval  — How often the host checks whether an approval has been answered
+/// ├── ParkedRunResumeInterval  — How often the host checks whether an approval has been answered
+/// └── PermittedApprovers        — Who a submitted human gate may name; empty refuses gates entirely
 /// </code>
 /// </remarks>
 public class WorkflowSubmissionConfig
@@ -323,4 +324,31 @@ public class WorkflowSubmissionConfig
     /// </remarks>
     /// <value>Default: 5 seconds</value>
     public TimeSpan ParkedRunResumeInterval { get; set; } = TimeSpan.FromSeconds(5);
+
+    /// <summary>
+    /// The people a submitted human gate may name as its approvers.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <strong>Empty means no workflow may contain a human gate.</strong> That is the default, and it
+    /// is the honest one: a gate names who decides it, and a name the host does not recognise is a
+    /// gate nobody can ever answer — the workflow reaches it, parks, and waits out the parked-run
+    /// ceiling. Letting an unset list mean "any name is fine" would turn this into a check that exists
+    /// and enforces nothing, which is worse than not having it.
+    /// </para>
+    /// <para>
+    /// Names are matched with <c>ApproverNames.Comparer</c> and must be written in whatever form
+    /// <c>AI.Governance.Escalation.ApproverClaimType</c> selects — object ids if that is set to
+    /// <c>oid</c>, sign-in names if it is left at <c>preferred_username</c>. Authoring them in one form
+    /// while the host reads the other produces gates that validate at submission and can never be
+    /// answered, which is precisely the failure this list exists to prevent.
+    /// </para>
+    /// <para>
+    /// This is an allowlist for <em>authoring</em>, not the authorization that decides a gate. Whether
+    /// a particular caller may answer a particular escalation is settled at decision time against that
+    /// escalation's own roster, from the caller's token.
+    /// </para>
+    /// </remarks>
+    /// <value>Default: empty — human gates are refused until a host names its approvers</value>
+    public List<string> PermittedApprovers { get; set; } = [];
 }

--- a/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.Planner.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.Planner.cs
@@ -110,6 +110,12 @@ public static partial class DependencyInjection
         // the process.
         services.AddHostedService<RunRecordCleanupService>();
 
+        // And likewise the resume check: a workflow that parks on a human gate is released by nothing
+        // else. Without this the approval machinery still records verdicts correctly and the plan
+        // executor still knows how to act on them — but nothing ever asks it to, so an approved gate
+        // waits out the parked-run ceiling and fails.
+        services.AddHostedService<ParkedRunResumeService>();
+
         services.AddScoped<IPlanValidator, PlanValidator>();
         services.AddScoped<IPlanGenerator, LlmPlanGeneratorService>();
         services.AddScoped<IPlanStateStore, EfCorePlanStateStore>();

--- a/src/Content/Infrastructure/Infrastructure.AI/Planner/PlanExecutor.Recovery.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Planner/PlanExecutor.Recovery.cs
@@ -15,13 +15,6 @@ namespace Infrastructure.AI.Planner;
 public sealed partial class PlanExecutor
 {
     /// <summary>
-    /// JSON property under which a blocked step's escalation identifier is stored in its output.
-    /// Must match the shape written by <c>HumanGateStepExecutor</c> (<c>{ "escalationId": "&lt;guid&gt;" }</c>)
-    /// and by the escalate failure-recovery branch below.
-    /// </summary>
-    private const string EscalationIdProperty = "escalationId";
-
-    /// <summary>
     /// Exponent cap for exponential backoff. Prevents a pathological
     /// <see cref="RetryPolicy.MaxRetries"/> configuration from overflowing
     /// <see cref="TimeSpan"/> arithmetic (2^20 × InitialDelay is already far beyond any
@@ -130,7 +123,7 @@ public sealed partial class PlanExecutor
                 // Persist the escalation id so the resume path can resolve this block. Without it the
                 // escalated step would be a permanent dead end exactly like an unpersisted human gate.
                 await TransitionStepAsync(ctx.PlanId, step.Id, StepExecutionStatus.Blocked, ctx.StepStates, ct,
-                    output: SerializeEscalationRef(escalationId));
+                    output: EscalationStepOutput.Serialize(escalationId));
 
                 _logger.LogWarning(
                     "Step {StepId} in plan {PlanId} escalated as {EscalationId} — step blocked pending human approval",
@@ -188,7 +181,7 @@ public sealed partial class PlanExecutor
             if (state is null || state.Status != StepExecutionStatus.Blocked)
                 continue;
 
-            var escalationId = TryReadEscalationId(state.Output);
+            var escalationId = EscalationStepOutput.TryReadEscalationId(state.Output);
             if (escalationId is null)
                 continue;
 
@@ -253,41 +246,6 @@ public sealed partial class PlanExecutor
 
         await TransitionStepAsync(ctx.PlanId, step.Id, StepExecutionStatus.Failed, ctx.StepStates, ct, errorMessage: reason);
         await SkipDownstreamSubgraphAsync(step.Id, ctx);
-    }
-
-    /// <summary>
-    /// Serializes an escalation identifier into the JSON output shape stored on a blocked step,
-    /// matching the format read by <see cref="TryReadEscalationId"/>.
-    /// </summary>
-    private static string SerializeEscalationRef(Guid escalationId)
-        => JsonSerializer.Serialize(new Dictionary<string, string> { [EscalationIdProperty] = escalationId.ToString() });
-
-    /// <summary>
-    /// Extracts the escalation identifier previously persisted in a blocked step's output, or null
-    /// when the output is absent, malformed, or carries no escalation reference.
-    /// </summary>
-    private static Guid? TryReadEscalationId(string? output)
-    {
-        if (string.IsNullOrEmpty(output))
-            return null;
-
-        try
-        {
-            using var doc = JsonDocument.Parse(output);
-            if (doc.RootElement.ValueKind == JsonValueKind.Object
-                && doc.RootElement.TryGetProperty(EscalationIdProperty, out var idElement)
-                && idElement.ValueKind == JsonValueKind.String
-                && Guid.TryParse(idElement.GetString(), out var id))
-            {
-                return id;
-            }
-        }
-        catch (JsonException)
-        {
-            // Non-JSON or corrupt output — no escalation reference to recover.
-        }
-
-        return null;
     }
 
     private async Task SkipDownstreamSubgraphAsync(PlanStepId fromStepId, PlanExecutionRuntime ctx, bool includeRoot = false)

--- a/src/Content/Infrastructure/Infrastructure.AI/Planner/PlanExecutor.Recovery.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Planner/PlanExecutor.Recovery.cs
@@ -1,5 +1,4 @@
 using System.Collections.Concurrent;
-using System.Text.Json;
 using Application.AI.Common.Interfaces.Planner;
 using Domain.AI.Escalation;
 using Domain.AI.Planner;

--- a/src/Content/Infrastructure/Infrastructure.AI/Planner/StepExecutors/HumanGateStepExecutor.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Planner/StepExecutors/HumanGateStepExecutor.cs
@@ -79,7 +79,12 @@ public sealed class HumanGateStepExecutor : IPlanStepExecutor
         return new StepExecutionResult
         {
             Status = StepExecutionStatus.Blocked,
-            Output = JsonSerializer.Serialize(new { escalationId }),
+
+            // Written through the shared shape rather than an anonymous object: the plan executor
+            // reads this back on resume to reconcile the gate, and the run substrate reads it to learn
+            // which decision the run is waiting on. A local literal here drifting from either reader
+            // fails silently — the gate simply never releases.
+            Output = EscalationStepOutput.Serialize(escalationId),
             Duration = sw.Elapsed
         };
     }

--- a/src/Content/Infrastructure/Infrastructure.AI/Planner/StepExecutors/HumanGateStepExecutor.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Planner/StepExecutors/HumanGateStepExecutor.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics;
-using System.Text.Json;
 using Application.AI.Common.Interfaces.Escalation;
 using Application.AI.Common.Interfaces.Planner;
 using Domain.AI.Escalation;

--- a/src/Content/Infrastructure/Infrastructure.AI/Runs/InMemoryRunJobStore.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Runs/InMemoryRunJobStore.cs
@@ -222,6 +222,47 @@ public sealed class InMemoryRunJobStore : IRunJobStore
     }
 
     /// <inheritdoc />
+    public IReadOnlyList<string> ExpireStaleParkedRuns(TimeSpan maxParkedDuration)
+    {
+        if (maxParkedDuration <= TimeSpan.Zero)
+            return [];
+
+        var now = _time.GetUtcNow();
+        var expired = new List<string>();
+
+        foreach (var entry in _entries.Values)
+        {
+            lock (entry)
+            {
+                if (!entry.Record.IsAwaitingDecision)
+                    continue;
+
+                // A parked run with no ParkedAt cannot be aged, and guessing an age from CreatedAt
+                // would expire a run that parked a moment ago on a workflow submitted last week. Left
+                // alone deliberately: the stamp is written on the same update that sets the status, so
+                // its absence means something wrote Blocked without going through the park path.
+                var parkedAt = entry.Record.ParkedAt;
+                if (parkedAt is null || now - parkedAt.Value < maxParkedDuration)
+                    continue;
+
+                entry.Record = entry.Record with
+                {
+                    Status = RunStatus.Failed,
+                    Error = "The run was waiting for an approval that did not arrive in time.",
+                    CompletedAt = now
+                };
+
+                // Now terminal, so retention applies from this moment — the same rule the ordinary
+                // finishing path follows.
+                entry.ExpiresAt = now + Ttl;
+                expired.Add(entry.Record.JobId);
+            }
+        }
+
+        return expired;
+    }
+
+    /// <inheritdoc />
     public IReadOnlyList<string> SweepExpired()
     {
         var now = _time.GetUtcNow();

--- a/src/Content/Infrastructure/Infrastructure.AI/Runs/InMemoryRunJobStore.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Runs/InMemoryRunJobStore.cs
@@ -310,13 +310,13 @@ public sealed class InMemoryRunJobStore : IRunJobStore
     }
 
     /// <inheritdoc />
-    public IReadOnlyList<string> ExpireStaleParkedRuns(TimeSpan maxParkedDuration)
+    public IReadOnlyList<RunRecord> ExpireStaleParkedRuns(TimeSpan maxParkedDuration)
     {
         if (maxParkedDuration <= TimeSpan.Zero)
             return [];
 
         var now = _time.GetUtcNow();
-        var expired = new List<string>();
+        var expired = new List<RunRecord>();
 
         foreach (var entry in _entries.Values)
         {
@@ -333,17 +333,23 @@ public sealed class InMemoryRunJobStore : IRunJobStore
                 if (parkedAt is null || now - parkedAt.Value < maxParkedDuration)
                     continue;
 
-                entry.Record = entry.Record with
+                // Captured before the write, so the caller can still see which approvals this run was
+                // parked on and withdraw them.
+                var previous = entry.Record;
+
+                entry.Record = previous with
                 {
                     Status = RunStatus.Failed,
                     Error = "The run was waiting for an approval that did not arrive in time.",
-                    CompletedAt = now
+                    CompletedAt = now,
+                    ParkedAt = null,
+                    AwaitingEscalationIds = []
                 };
 
                 // Now terminal, so retention applies from this moment — the same rule the ordinary
                 // finishing path follows.
                 entry.ExpiresAt = now + Ttl;
-                expired.Add(entry.Record.JobId);
+                expired.Add(previous);
             }
         }
 

--- a/src/Content/Infrastructure/Infrastructure.AI/Runs/InMemoryRunJobStore.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Runs/InMemoryRunJobStore.cs
@@ -215,6 +215,40 @@ public sealed class InMemoryRunJobStore : IRunJobStore
     }
 
     /// <inheritdoc />
+    public RunRecord? TryCancel(string jobId, DateTimeOffset cancelledAt)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(jobId);
+
+        if (!_entries.TryGetValue(jobId, out var entry))
+            return null;
+
+        lock (entry)
+        {
+            // Queued and parked only. A running run's status belongs to the dispatch executing it, and
+            // a terminal one has already been answered — cancelling either here would overwrite a fact
+            // with an intention.
+            if (entry.Record.Status is not (RunStatus.Queued or RunStatus.Blocked))
+                return null;
+
+            var previous = entry.Record;
+
+            entry.Record = previous with
+            {
+                Status = RunStatus.Cancelled,
+                CompletedAt = cancelledAt,
+                ParkedAt = null,
+                AwaitingEscalationIds = []
+            };
+
+            // Terminal now, so retention runs from this moment — the same rule every other ending
+            // follows.
+            entry.ExpiresAt = cancelledAt + Ttl;
+
+            return previous;
+        }
+    }
+
+    /// <inheritdoc />
     public IReadOnlyList<RunRecord> GetParkedRuns()
     {
         var parked = new List<RunRecord>();

--- a/src/Content/Infrastructure/Infrastructure.AI/Runs/InMemoryRunJobStore.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Runs/InMemoryRunJobStore.cs
@@ -215,6 +215,27 @@ public sealed class InMemoryRunJobStore : IRunJobStore
     }
 
     /// <inheritdoc />
+    public bool TryRepark(RunRecord parked)
+    {
+        ArgumentNullException.ThrowIfNull(parked);
+
+        if (!_entries.TryGetValue(parked.JobId, out var entry))
+            return false;
+
+        lock (entry)
+        {
+            // Only a run this caller's own resume left queued. Anything else means something acted on
+            // the run in the meantime — most consequentially a cancellation, whose approvals are
+            // already withdrawn and which must not be put back to waiting on them.
+            if (entry.Record.Status != RunStatus.Queued)
+                return false;
+
+            entry.Record = parked;
+            return true;
+        }
+    }
+
+    /// <inheritdoc />
     public RunRecord? TryCancel(string jobId, DateTimeOffset cancelledAt)
     {
         ArgumentException.ThrowIfNullOrEmpty(jobId);

--- a/src/Content/Infrastructure/Infrastructure.AI/Runs/InMemoryRunJobStore.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Runs/InMemoryRunJobStore.cs
@@ -172,9 +172,63 @@ public sealed class InMemoryRunJobStore : IRunJobStore
             if (entry.Record.Status != RunStatus.Queued || IsExpired(entry, _time.GetUtcNow()))
                 return null;
 
-            entry.Record = entry.Record with { Status = RunStatus.Running, StartedAt = startedAt };
+            entry.Record = entry.Record with
+            {
+                Status = RunStatus.Running,
+
+                // First claim only. A run that parked on a gate and was resumed is claimed again, and
+                // overwriting would report the run as having started after the approver answered —
+                // hiding however long it ran before reaching the gate. ParkedAt is what tracks the
+                // current wait; this tracks when the work began.
+                StartedAt = entry.Record.StartedAt ?? startedAt
+            };
+
             return entry.Record;
         }
+    }
+
+    /// <inheritdoc />
+    public RunRecord? TryResume(string jobId)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(jobId);
+
+        if (!_entries.TryGetValue(jobId, out var entry))
+            return null;
+
+        lock (entry)
+        {
+            // Read, decide and write under one lock, exactly as TryBeginRun does: two resumers that
+            // both saw the run parked would both enqueue it, and the second dispatch would run the same
+            // plan alongside the first.
+            if (!entry.Record.IsAwaitingDecision)
+                return null;
+
+            entry.Record = entry.Record with
+            {
+                Status = RunStatus.Queued,
+                ParkedAt = null,
+                AwaitingEscalationIds = []
+            };
+
+            return entry.Record;
+        }
+    }
+
+    /// <inheritdoc />
+    public IReadOnlyList<RunRecord> GetParkedRuns()
+    {
+        var parked = new List<RunRecord>();
+
+        foreach (var entry in _entries.Values)
+        {
+            lock (entry)
+            {
+                if (entry.Record.IsAwaitingDecision)
+                    parked.Add(entry.Record);
+            }
+        }
+
+        return parked;
     }
 
     /// <inheritdoc />

--- a/src/Content/Infrastructure/Infrastructure.AI/Runs/ParkedRunResumeService.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Runs/ParkedRunResumeService.cs
@@ -158,9 +158,12 @@ internal sealed class ParkedRunResumeService : BackgroundService
             // The run is Queued at this point but nothing holds it: no dispatcher will ever claim a run
             // that is not in the queue, and the parked-run ceiling only ever looks at parked runs — so
             // leaving it here strands the run in the one state from which nothing can recover it.
-            // Restoring the record it had a moment ago puts it back under the ceiling and lets the next
-            // pass try again.
-            _store.Update(parked);
+            // Re-parking puts it back under the ceiling and lets the next pass try again.
+            //
+            // Guarded rather than written blind: its owner may have cancelled it in this window, and
+            // restoring a cancelled run would set it waiting on approvals the cancellation has already
+            // withdrawn.
+            _store.TryRepark(parked);
             throw;
         }
 

--- a/src/Content/Infrastructure/Infrastructure.AI/Runs/ParkedRunResumeService.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Runs/ParkedRunResumeService.cs
@@ -1,0 +1,170 @@
+using Application.AI.Common.Interfaces.Escalation;
+using Application.AI.Common.Interfaces.Runs;
+using Domain.AI.Runs;
+using Domain.Common.Config;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Infrastructure.AI.Runs;
+
+/// <summary>
+/// Returns parked runs to the queue once a decision they were waiting on has been answered.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is the trigger that makes a human gate more than a place work stops. Everything either side of
+/// it already existed: a gate queues an escalation and parks its step, and the plan executor reconciles
+/// blocked steps against their verdicts on its next execution. Without something to notice the verdict
+/// and ask for that next execution, an approved gate simply never released.
+/// </para>
+/// <para>
+/// <strong>It re-reads verdicts on a clock rather than reacting to each decision.</strong> An event
+/// would be lower-latency and is the obvious design, but it is lost in exactly the cases that matter:
+/// a decision taken while the host is down, or on another instance, would leave the run parked until
+/// the parked-run ceiling failed it — turning an approval into a silent expiry days later. Re-reading
+/// is the only form of this trigger that survives a restart, and the latency it costs is measured
+/// against a wait that was already however long a human took.
+/// </para>
+/// <para>
+/// <strong>A rejected decision resumes the run too.</strong> Resuming is not "continue the work" — it
+/// is "let the plan act on the answer". A denial has to re-enter execution for the gate to fail and
+/// the run to reach a terminal state; treating only approvals as worth resuming would leave every
+/// rejected workflow parked.
+/// </para>
+/// <para>
+/// <strong>The escalation service is read, never written.</strong> Resuming asks a question of the
+/// governance subsystem and acts within the run substrate. Nothing here can alter a verdict, and the
+/// escalation subsystem knows nothing about runs — which keeps a decision recorded for compliance
+/// independent of whether any run happened to be waiting on it.
+/// </para>
+/// </remarks>
+internal sealed class ParkedRunResumeService : BackgroundService
+{
+    /// <summary>
+    /// Floor on the check interval. Configuration is validated as positive, but a positive value can
+    /// still be small enough to turn this into a spin loop; the floor makes a mis-set value slow
+    /// rather than harmful.
+    /// </summary>
+    private static readonly TimeSpan MinInterval = TimeSpan.FromSeconds(1);
+
+    private readonly IRunJobStore _store;
+    private readonly IRunDispatchQueue _queue;
+    private readonly IEscalationService _escalations;
+    private readonly IOptionsMonitor<AppConfig> _config;
+    private readonly ILogger<ParkedRunResumeService> _logger;
+
+    /// <summary>Initializes a new <see cref="ParkedRunResumeService"/>.</summary>
+    public ParkedRunResumeService(
+        IRunJobStore store,
+        IRunDispatchQueue queue,
+        IEscalationService escalations,
+        IOptionsMonitor<AppConfig> config,
+        ILogger<ParkedRunResumeService> logger)
+    {
+        ArgumentNullException.ThrowIfNull(store);
+        ArgumentNullException.ThrowIfNull(queue);
+        ArgumentNullException.ThrowIfNull(escalations);
+        ArgumentNullException.ThrowIfNull(config);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _store = store;
+        _queue = queue;
+        _escalations = escalations;
+        _config = config;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        try
+        {
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                var interval = _config.CurrentValue.AI.WorkflowSubmission.ParkedRunResumeInterval;
+                if (interval < MinInterval)
+                    interval = MinInterval;
+
+                await Task.Delay(interval, stoppingToken).ConfigureAwait(false);
+                await ResumeAnsweredRunsAsync(stoppingToken).ConfigureAwait(false);
+            }
+        }
+        catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+        {
+            // Host is shutting down — expected.
+        }
+    }
+
+    private async Task ResumeAnsweredRunsAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            foreach (var parked in _store.GetParkedRuns())
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                if (await HasAnsweredDecisionAsync(parked, cancellationToken).ConfigureAwait(false))
+                    await ResumeAsync(parked, cancellationToken).ConfigureAwait(false);
+            }
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            // A failed pass must not take the service down: the next tick would never come, and every
+            // parked run in the host would then wait out the ceiling regardless of its verdict.
+            _logger.LogError(ex, "Parked-run resume check failed; will retry on the next interval.");
+        }
+    }
+
+    /// <summary>
+    /// Whether any decision this run parked on has reached a verdict.
+    /// </summary>
+    /// <remarks>
+    /// Stops at the first answer. A plan parked on two gates needs one verdict to be worth another
+    /// execution — reconciliation re-reads every blocked step anyway, and if the second gate is still
+    /// open the plan simply parks again on that one alone.
+    /// </remarks>
+    private async Task<bool> HasAnsweredDecisionAsync(RunRecord parked, CancellationToken cancellationToken)
+    {
+        foreach (var escalationId in parked.AwaitingEscalationIds)
+        {
+            var outcome = await _escalations.GetOutcomeAsync(escalationId, cancellationToken).ConfigureAwait(false);
+            if (outcome is not null)
+                return true;
+        }
+
+        return false;
+    }
+
+    private async Task ResumeAsync(RunRecord parked, CancellationToken cancellationToken)
+    {
+        // Only the caller that wins the transition enqueues. Deciding from the record read above would
+        // let two passes — or a pass racing the ceiling that is about to fail this very run — both act
+        // on the same park.
+        var resumed = _store.TryResume(parked.JobId);
+        if (resumed is null)
+            return;
+
+        try
+        {
+            await _queue.EnqueueAsync(resumed.JobId, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception)
+        {
+            // The run is Queued at this point but nothing holds it: no dispatcher will ever claim a run
+            // that is not in the queue, and the parked-run ceiling only ever looks at parked runs — so
+            // leaving it here strands the run in the one state from which nothing can recover it.
+            // Restoring the record it had a moment ago puts it back under the ceiling and lets the next
+            // pass try again.
+            _store.Update(parked);
+            throw;
+        }
+
+        _logger.LogInformation(
+            "Run {JobId} resumed: a decision it was waiting on has been answered.", resumed.JobId);
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Runs/RunDispatchBackgroundService.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Runs/RunDispatchBackgroundService.cs
@@ -249,23 +249,6 @@ public sealed class RunDispatchBackgroundService : BackgroundService
     }
 
     /// <summary>
-    /// Writes a claimed run's terminal state, and tells anyone watching that it ended.
-    /// </summary>
-    /// <remarks>
-    /// <para>
-    /// Takes the claimed record rather than re-reading it: the run is Running by this point, so it can
-    /// no longer be re-claimed, and the dispatcher holds no caller identity to read it back with.
-    /// </para>
-    /// <para>
-    /// <strong>The terminal progress event is published here, not by whatever performed the work.</strong>
-    /// This is the one place every claimed run passes through on its way to a terminal state — which is
-    /// exactly the property that makes a watcher's stream end. Sourcing it from the planner instead
-    /// covered only the endings the planner announces: a workflow that parked on a human gate, one an
-    /// operator cancelled, and every run failed before the planner ran at all would each leave a
-    /// watcher's connection open forever, holding a stream slot, on a run that was already over.
-    /// </para>
-    /// </remarks>
-    /// <summary>
     /// Records that a claimed run has parked awaiting a decision, and tells watchers to stop waiting.
     /// </summary>
     /// <remarks>
@@ -297,6 +280,23 @@ public sealed class RunDispatchBackgroundService : BackgroundService
             detail: detail);
     }
 
+    /// <summary>
+    /// Writes a claimed run's terminal state, and tells anyone watching that it ended.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Takes the claimed record rather than re-reading it: the run is Running by this point, so it can
+    /// no longer be re-claimed, and the dispatcher holds no caller identity to read it back with.
+    /// </para>
+    /// <para>
+    /// <strong>The terminal progress event is published here, not by whatever performed the work.</strong>
+    /// This is the one place every claimed run passes through on its way to a terminal state — which is
+    /// exactly the property that makes a watcher's stream end. Sourcing it from the planner instead
+    /// covered only the endings the planner announces: a workflow that parked on a human gate, one an
+    /// operator cancelled, and every run failed before the planner ran at all would each leave a
+    /// watcher's connection open forever, holding a stream slot, on a run that was already over.
+    /// </para>
+    /// </remarks>
     private void Finish(RunRecord claimed, RunStatus status, string? error)
     {
         _store.Update(claimed with

--- a/src/Content/Infrastructure/Infrastructure.AI/Runs/RunDispatchBackgroundService.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Runs/RunDispatchBackgroundService.cs
@@ -237,7 +237,7 @@ public sealed class RunDispatchBackgroundService : BackgroundService
         // watcher's stream on a run that is going to carry on.
         if (completion.Status is RunStatus.Blocked)
         {
-            Park(claimed, completion.Detail);
+            Park(claimed, completion.Detail, completion.AwaitingEscalationIds);
             _logger.LogInformation(
                 "Run {JobId} ({RunKind}) parked awaiting a decision.", claimed.JobId, claimed.Kind);
             return;
@@ -281,12 +281,13 @@ public sealed class RunDispatchBackgroundService : BackgroundService
     /// its plan state machine. Resuming re-queues this same job id.
     /// </para>
     /// </remarks>
-    private void Park(RunRecord claimed, string? detail)
+    private void Park(RunRecord claimed, string? detail, IReadOnlyList<Guid> awaitingEscalationIds)
     {
         _store.Update(claimed with
         {
             Status = RunStatus.Blocked,
-            ParkedAt = _time.GetUtcNow()
+            ParkedAt = _time.GetUtcNow(),
+            AwaitingEscalationIds = awaitingEscalationIds
         });
 
         _progress.Publish(

--- a/src/Content/Infrastructure/Infrastructure.AI/Runs/RunDispatchBackgroundService.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Runs/RunDispatchBackgroundService.cs
@@ -231,6 +231,18 @@ public sealed class RunDispatchBackgroundService : BackgroundService
         }
 
         var completion = outcome.Value;
+
+        // Parking is not an ending, and routing it through Finish would claim it was one: a
+        // CompletedAt stamp on work still in progress, and a RunFinished event closing every
+        // watcher's stream on a run that is going to carry on.
+        if (completion.Status is RunStatus.Blocked)
+        {
+            Park(claimed, completion.Detail);
+            _logger.LogInformation(
+                "Run {JobId} ({RunKind}) parked awaiting a decision.", claimed.JobId, claimed.Kind);
+            return;
+        }
+
         Finish(claimed, completion.Status, completion.Detail);
         _logger.LogInformation(
             "Run {JobId} ({RunKind}) ended {RunStatus}.", claimed.JobId, claimed.Kind, completion.Status);
@@ -253,6 +265,37 @@ public sealed class RunDispatchBackgroundService : BackgroundService
     /// watcher's connection open forever, holding a stream slot, on a run that was already over.
     /// </para>
     /// </remarks>
+    /// <summary>
+    /// Records that a claimed run has parked awaiting a decision, and tells watchers to stop waiting.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Deliberately leaves <see cref="RunRecord.CompletedAt"/> unset and <see cref="RunRecord.Error"/>
+    /// alone. Neither is true of a parked run: it has not completed, and waiting for an approval is not
+    /// a fault. <see cref="RunRecord.ParkedAt"/> is stamped instead, which is what bounds how long a
+    /// gate nobody answers may hold the workflow.
+    /// </para>
+    /// <para>
+    /// The status leaves <c>Running</c>, so the claim is released and this dispatcher is done with the
+    /// run — but the run stays live, so its workflow stays locked against a second run that would share
+    /// its plan state machine. Resuming re-queues this same job id.
+    /// </para>
+    /// </remarks>
+    private void Park(RunRecord claimed, string? detail)
+    {
+        _store.Update(claimed with
+        {
+            Status = RunStatus.Blocked,
+            ParkedAt = _time.GetUtcNow()
+        });
+
+        _progress.Publish(
+            claimed.JobId,
+            RunProgressKind.RunParked,
+            status: nameof(RunStatus.Blocked),
+            detail: detail);
+    }
+
     private void Finish(RunRecord claimed, RunStatus status, string? error)
     {
         _store.Update(claimed with

--- a/src/Content/Infrastructure/Infrastructure.AI/Runs/RunRecordCleanupService.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Runs/RunRecordCleanupService.cs
@@ -92,8 +92,10 @@ internal sealed class RunRecordCleanupService : BackgroundService
     {
         try
         {
-            // Ageing out abandoned gates first, so a run that expires on this tick is reclaimable on
-            // this tick rather than waiting a whole interval to become eligible.
+            // Ageing out abandoned gates first, so a run given up on here has released its workflow and
+            // its owner's slot before this same tick's reclaim runs. It is NOT reclaimable yet — being
+            // failed starts its retention window afresh, so its memory comes back a full TTL later,
+            // exactly as for a run that finished normally.
             await ExpireStaleParkedRunsAsync().ConfigureAwait(false);
 
             var reclaimed = _store.SweepExpired();

--- a/src/Content/Infrastructure/Infrastructure.AI/Runs/RunRecordCleanupService.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Runs/RunRecordCleanupService.cs
@@ -80,6 +80,10 @@ internal sealed class RunRecordCleanupService : BackgroundService
     {
         try
         {
+            // Ageing out abandoned gates first, so a run that expires on this tick is reclaimable on
+            // this tick rather than waiting a whole interval to become eligible.
+            ExpireStaleParkedRuns();
+
             var reclaimed = _store.SweepExpired();
             if (reclaimed.Count == 0)
                 return;
@@ -99,5 +103,25 @@ internal sealed class RunRecordCleanupService : BackgroundService
             // retention window would stop being honoured for the life of the process.
             _logger.LogError(ex, "Run record sweep failed; will retry on the next interval.");
         }
+    }
+
+    /// <summary>
+    /// Gives up on runs that have been waiting for an approval far longer than the host permits.
+    /// </summary>
+    /// <remarks>
+    /// Logged at warning rather than information: every run this touches is one a human was asked to
+    /// decide and never did. That is worth someone's attention, whereas an ordinary reclaim is not.
+    /// </remarks>
+    private void ExpireStaleParkedRuns()
+    {
+        var ceiling = _config.CurrentValue.AI.WorkflowSubmission.MaxParkedRunDuration;
+
+        var expired = _store.ExpireStaleParkedRuns(ceiling);
+        if (expired.Count == 0)
+            return;
+
+        _logger.LogWarning(
+            "Failed {Count} run(s) parked longer than {Ceiling} awaiting an approval that never arrived.",
+            expired.Count, ceiling);
     }
 }

--- a/src/Content/Infrastructure/Infrastructure.AI/Runs/RunRecordCleanupService.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Runs/RunRecordCleanupService.cs
@@ -1,3 +1,4 @@
+using Application.AI.Common.Interfaces.Escalation;
 using Application.AI.Common.Interfaces.Runs;
 using Domain.Common.Config;
 using Microsoft.Extensions.Hosting;
@@ -32,8 +33,16 @@ internal sealed class RunRecordCleanupService : BackgroundService
     /// </summary>
     private static readonly TimeSpan MinInterval = TimeSpan.FromSeconds(1);
 
+    /// <summary>
+    /// Attributed to the host, not a person: nobody asked for a ceiling expiry, so naming a human in
+    /// the escalation audit would be untrue. Matches the <c>system:</c> convention
+    /// <see cref="IEscalationService.CancelEscalationAsync"/> documents for internal callers.
+    /// </summary>
+    private const string SystemActor = "system:parked-run-expiry";
+
     private readonly IRunJobStore _store;
     private readonly IRunProgressBroker _progress;
+    private readonly IEscalationService _escalations;
     private readonly IOptionsMonitor<AppConfig> _config;
     private readonly ILogger<RunRecordCleanupService> _logger;
 
@@ -41,16 +50,19 @@ internal sealed class RunRecordCleanupService : BackgroundService
     public RunRecordCleanupService(
         IRunJobStore store,
         IRunProgressBroker progress,
+        IEscalationService escalations,
         IOptionsMonitor<AppConfig> config,
         ILogger<RunRecordCleanupService> logger)
     {
         ArgumentNullException.ThrowIfNull(store);
         ArgumentNullException.ThrowIfNull(progress);
+        ArgumentNullException.ThrowIfNull(escalations);
         ArgumentNullException.ThrowIfNull(config);
         ArgumentNullException.ThrowIfNull(logger);
 
         _store = store;
         _progress = progress;
+        _escalations = escalations;
         _config = config;
         _logger = logger;
     }
@@ -67,7 +79,7 @@ internal sealed class RunRecordCleanupService : BackgroundService
                     interval = MinInterval;
 
                 await Task.Delay(interval, stoppingToken).ConfigureAwait(false);
-                Sweep();
+                await SweepAsync().ConfigureAwait(false);
             }
         }
         catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
@@ -76,13 +88,13 @@ internal sealed class RunRecordCleanupService : BackgroundService
         }
     }
 
-    private void Sweep()
+    private async Task SweepAsync()
     {
         try
         {
             // Ageing out abandoned gates first, so a run that expires on this tick is reclaimable on
             // this tick rather than waiting a whole interval to become eligible.
-            ExpireStaleParkedRuns();
+            await ExpireStaleParkedRunsAsync().ConfigureAwait(false);
 
             var reclaimed = _store.SweepExpired();
             if (reclaimed.Count == 0)
@@ -106,13 +118,28 @@ internal sealed class RunRecordCleanupService : BackgroundService
     }
 
     /// <summary>
-    /// Gives up on runs that have been waiting for an approval far longer than the host permits.
+    /// Gives up on runs that have been waiting for an approval far longer than the host permits, and
+    /// withdraws the approvals they were waiting on.
     /// </summary>
     /// <remarks>
+    /// <para>
+    /// Withdrawing is not tidy-up here, it is the same requirement the cancel path has and for a
+    /// sharper reason. Failing the run makes it terminal, which <em>unlocks its workflow</em> — so a
+    /// second run can start against the same persisted plan, and an approver answering the first run's
+    /// gate would have that verdict reconciled into the second. Leaving the approval pending is
+    /// therefore not merely confusing for the approver; it is a decision applied to work it was never
+    /// about.
+    /// </para>
+    /// <para>
     /// Logged at warning rather than information: every run this touches is one a human was asked to
     /// decide and never did. That is worth someone's attention, whereas an ordinary reclaim is not.
+    /// </para>
+    /// <para>
+    /// Attributed to a system actor rather than a person, because no person asked for this — the host
+    /// gave up on its own schedule, and an audit row naming a human would be untrue.
+    /// </para>
     /// </remarks>
-    private void ExpireStaleParkedRuns()
+    private async Task ExpireStaleParkedRunsAsync()
     {
         var ceiling = _config.CurrentValue.AI.WorkflowSubmission.MaxParkedRunDuration;
 
@@ -123,5 +150,16 @@ internal sealed class RunRecordCleanupService : BackgroundService
         _logger.LogWarning(
             "Failed {Count} run(s) parked longer than {Ceiling} awaiting an approval that never arrived.",
             expired.Count, ceiling);
+
+        foreach (var abandoned in expired)
+        {
+            await ApprovalWithdrawal.WithdrawAsync(
+                _escalations,
+                _logger,
+                abandoned,
+                "The run this approval was raised for waited too long and was given up on.",
+                SystemActor,
+                CancellationToken.None).ConfigureAwait(false);
+        }
     }
 }

--- a/src/Content/Infrastructure/Infrastructure.AI/Runs/WorkflowRunKindExecutor.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Runs/WorkflowRunKindExecutor.cs
@@ -72,11 +72,11 @@ public sealed class WorkflowRunKindExecutor : IRunKindExecutor
         if (summary is null)
             return Result<RunCompletion>.Fail("The run produced no execution summary.");
 
-        return Result<RunCompletion>.Success(Interpret(summary.FinalStatus));
+        return Result<RunCompletion>.Success(Interpret(summary));
     }
 
     /// <summary>
-    /// Translates the plan's final status into how the run ended.
+    /// Translates how the plan ended into how the run ended.
     /// </summary>
     /// <remarks>
     /// Written as "succeed only on <see cref="StepExecutionStatus.Completed"/>", matching
@@ -85,16 +85,47 @@ public sealed class WorkflowRunKindExecutor : IRunKindExecutor
     /// the inverted form both fall through to success, and a workflow parked awaiting an approval
     /// reports to its caller as finished work.
     /// </remarks>
-    private static RunCompletion Interpret(StepExecutionStatus finalStatus) => finalStatus switch
+    private RunCompletion Interpret(PlanExecutionSummary summary) => summary.FinalStatus switch
     {
         StepExecutionStatus.Completed => RunCompletion.Succeeded(),
 
         StepExecutionStatus.Blocked => RunCompletion.Blocked(
-            "The workflow is waiting on an approval before it can continue."),
+            "The workflow is waiting on an approval before it can continue.",
+            ReadAwaitedEscalations(summary)),
 
         StepExecutionStatus.Cancelled => RunCompletion.Cancelled(
             "The workflow was cancelled before it finished."),
 
-        _ => RunCompletion.Failed($"The workflow ended with status {finalStatus}.")
+        _ => RunCompletion.Failed($"The workflow ended with status {summary.FinalStatus}.")
     };
+
+    /// <summary>
+    /// Collects the escalations the plan's blocked steps are waiting on, which is what makes the park
+    /// recoverable: a verdict on any of them is the signal to run this workflow again.
+    /// </summary>
+    /// <remarks>
+    /// An empty result is possible and is not treated as an error — a step can be blocked with an
+    /// output that carries no readable escalation reference. It is logged rather than swallowed,
+    /// because the consequence is severe and otherwise invisible: the run parks with nothing that can
+    /// ever release it, and waits out the host's parked-run ceiling before failing.
+    /// </remarks>
+    private IReadOnlyList<Guid> ReadAwaitedEscalations(PlanExecutionSummary summary)
+    {
+        var escalationIds = summary.StepStates
+            .Where(state => state.Status == StepExecutionStatus.Blocked)
+            .Select(state => EscalationStepOutput.TryReadEscalationId(state.Output))
+            .OfType<Guid>()
+            .Distinct()
+            .ToList();
+
+        if (escalationIds.Count == 0)
+        {
+            _logger.LogWarning(
+                "Plan {PlanId} ended blocked but names no decision that could release it; the run will "
+                + "park until the host's parked-run ceiling fails it.",
+                summary.PlanId.Value);
+        }
+
+        return escalationIds;
+    }
 }

--- a/src/Content/Presentation/Presentation.Common/ChangeProposals/ChangeProposalsController.cs
+++ b/src/Content/Presentation/Presentation.Common/ChangeProposals/ChangeProposalsController.cs
@@ -295,28 +295,23 @@ public sealed class ChangeProposalsController : ControllerBase
     /// one distinct value (per <c>ApproverNames.Comparer</c>) is an ambiguous identity and is
     /// rejected rather than silently first-picked — an attacker who can smuggle a second
     /// instance of the claim must not get to choose which one wins; the same value appearing
-    /// under both forms counts as one. Identical logic to <c>EscalationsController.ResolveApproverName</c> —
-    /// both surfaces share <c>EscalationConfig.ApproverClaimType</c> so one config knob governs
-    /// reviewer identity everywhere.
+    /// under both forms counts as one. All of that lives in
+    /// <c>ClaimsPrincipalExtensions.GetApproverNameOrNull</c>, which every surface reading a roster
+    /// identity shares, so one config knob governs reviewer identity everywhere and no copy of the
+    /// rule can drift. Only the wording of the diagnostic differs here.
     /// </summary>
     private string? ResolveReviewerId()
     {
         var claimType = _config.CurrentValue.ApproverClaimType;
-        var values = ApproverClaimTypes.EquivalentFormsOf(claimType)
-            .SelectMany(form => User.FindAll(form))
-            .Select(c => c.Value)
-            .Where(v => !string.IsNullOrWhiteSpace(v))
-            .Distinct(ApproverNames.Comparer)
-            .ToList();
+        var reviewerId = User.GetApproverNameOrNull(claimType);
+        if (reviewerId is not null)
+            return reviewerId;
 
-        if (values.Count == 1)
-            return values[0];
-
-        // Diagnostic detail (which claim type, how many values) goes to the log only; the HTTP
-        // body stays generic so the response never teaches a caller which claim to forge.
+        // Diagnostic detail (which claim type) goes to the log only; the HTTP body stays generic so
+        // the response never teaches a caller which claim to forge.
         _logger.LogWarning(
-            "Reviewer identity resolution failed: configured claim '{ApproverClaimType}' (incl. mapped forms) yielded {Count} distinct value(s) on the principal",
-            claimType, values.Count);
+            "Reviewer identity resolution failed: configured claim '{ApproverClaimType}' (incl. mapped forms) did not yield exactly one distinct value on the principal",
+            claimType);
         return null;
     }
 

--- a/src/Content/Presentation/Presentation.Common/Escalations/EscalationsController.cs
+++ b/src/Content/Presentation/Presentation.Common/Escalations/EscalationsController.cs
@@ -282,21 +282,15 @@ public sealed class EscalationsController : ControllerBase
     private string? ResolveApproverName()
     {
         var claimType = _config.CurrentValue.ApproverClaimType;
-        var values = ApproverClaimTypes.EquivalentFormsOf(claimType)
-            .SelectMany(form => User.FindAll(form))
-            .Select(c => c.Value)
-            .Where(v => !string.IsNullOrWhiteSpace(v))
-            .Distinct(ApproverNames.Comparer)
-            .ToList();
+        var approverName = User.GetApproverNameOrNull(claimType);
+        if (approverName is not null)
+            return approverName;
 
-        if (values.Count == 1)
-            return values[0];
-
-        // Diagnostic detail (which claim type, how many values) goes to the log only; the HTTP
-        // body stays generic so the response never teaches a caller which claim to forge.
+        // Diagnostic detail (which claim type) goes to the log only; the HTTP body stays generic so
+        // the response never teaches a caller which claim to forge.
         _logger.LogWarning(
-            "Approver identity resolution failed: configured claim '{ApproverClaimType}' (incl. mapped forms) yielded {Count} distinct value(s) on the principal",
-            claimType, values.Count);
+            "Approver identity resolution failed: configured claim '{ApproverClaimType}' (incl. mapped forms) did not yield exactly one distinct value on the principal",
+            claimType);
         return null;
     }
 

--- a/src/Content/Presentation/Presentation.Common/Extensions/ClaimsPrincipalExtensions.cs
+++ b/src/Content/Presentation/Presentation.Common/Extensions/ClaimsPrincipalExtensions.cs
@@ -1,5 +1,6 @@
 using System.Security.Claims;
 using Application.Core.Validation;
+using Domain.AI.Escalation;
 
 namespace Presentation.Common.Extensions;
 
@@ -114,5 +115,56 @@ public static class ClaimsPrincipalExtensions
         }
 
         return null;
+    }
+
+    /// <summary>
+    /// Returns the caller's approver identity — the name compared against escalation rosters — or
+    /// <c>null</c> when the principal does not carry exactly one usable value for
+    /// <paramref name="approverClaimType"/>.
+    /// </summary>
+    /// <param name="principal">The principal to resolve.</param>
+    /// <param name="approverClaimType">
+    /// The configured claim type, from <c>EscalationConfig.ApproverClaimType</c>. A server-side
+    /// setting, never a request parameter: the approver name must come from the validated token, so a
+    /// caller can never assert an identity the token does not carry.
+    /// </param>
+    /// <remarks>
+    /// <para>
+    /// Distinct from <see cref="GetUserIdOrNull"/> and deliberately so. That answers "who owns this
+    /// record", and is restricted to immutable claims because ownership must not follow a reassignable
+    /// name. This answers "which roster entries is this person", which is a different question with a
+    /// different, operator-chosen claim — rosters are authored with human-readable names by default.
+    /// The two can resolve to different strings for the same person, which is exactly why anything
+    /// comparing a caller to a roster must use this one.
+    /// </para>
+    /// <para>
+    /// Lives here, with the other identity resolution, because three surfaces need it — the escalation
+    /// decision path, the change-proposal review path, and workflow submission's self-approval check —
+    /// and a per-controller copy is how one of them silently drifts back to a case-sensitive or
+    /// unmapped comparison.
+    /// </para>
+    /// <para>
+    /// Resolution searches the union of the claim type's equivalent forms, because production tokens
+    /// carry the JWT inbound-mapped form while dev/test principals carry the short one. Across that
+    /// union, more than one distinct value (per <c>ApproverNames.Comparer</c>) is an ambiguous identity
+    /// and yields <c>null</c> rather than a silent first-pick — someone who can smuggle a second
+    /// instance of the claim must not get to choose which one wins. The same value appearing under both
+    /// forms counts as one.
+    /// </para>
+    /// </remarks>
+    public static string? GetApproverNameOrNull(this ClaimsPrincipal principal, string approverClaimType)
+    {
+        ArgumentNullException.ThrowIfNull(principal);
+        ArgumentException.ThrowIfNullOrWhiteSpace(approverClaimType);
+
+        var values = ApproverClaimTypes.EquivalentFormsOf(approverClaimType)
+            .SelectMany(principal.FindAll)
+            .Select(claim => claim.Value)
+            .Where(value => !string.IsNullOrWhiteSpace(value))
+            .Distinct(ApproverNames.Comparer)
+            .Take(2)
+            .ToList();
+
+        return values.Count == 1 ? values[0] : null;
     }
 }

--- a/src/Content/Presentation/Presentation.Common/Extensions/ClaimsPrincipalExtensions.cs
+++ b/src/Content/Presentation/Presentation.Common/Extensions/ClaimsPrincipalExtensions.cs
@@ -157,6 +157,13 @@ public static class ClaimsPrincipalExtensions
         ArgumentNullException.ThrowIfNull(principal);
         ArgumentException.ThrowIfNullOrWhiteSpace(approverClaimType);
 
+        // Matching GetUserIdOrNull rather than reading claims off whatever is handed in. Every caller
+        // today sits behind [Authorize], so this is unreachable — but this method is now the single
+        // authority for roster identity, and an authority whose two halves disagree about what an
+        // unauthenticated principal means is what the next caller trips over.
+        if (principal.Identity?.IsAuthenticated != true)
+            return null;
+
         var values = ApproverClaimTypes.EquivalentFormsOf(approverClaimType)
             .SelectMany(principal.FindAll)
             .Select(claim => claim.Value)

--- a/src/Content/Presentation/Presentation.ExecutionApi/Controllers/WorkflowsController.cs
+++ b/src/Content/Presentation/Presentation.ExecutionApi/Controllers/WorkflowsController.cs
@@ -231,7 +231,12 @@ public sealed class WorkflowsController : ControllerBase
                 WorkflowId = workflowId,
                 JobId = jobId,
                 OwnerId = User.GetUserId(),
-                TenantId = User.GetTenantId()
+                TenantId = User.GetTenantId(),
+
+                // Recorded as who withdrew the run's pending approvals. Resolved through the same claim
+                // the decision path reads, so the withdrawal reads like the approver rows it sits
+                // beside in the escalation audit rather than like an internal identifier.
+                CancellerApproverName = User.GetApproverNameOrNull(_escalationConfig.CurrentValue.ApproverClaimType)
             },
             cancellationToken).ConfigureAwait(false);
 

--- a/src/Content/Presentation/Presentation.ExecutionApi/Controllers/WorkflowsController.cs
+++ b/src/Content/Presentation/Presentation.ExecutionApi/Controllers/WorkflowsController.cs
@@ -5,6 +5,8 @@ using Application.AI.Common.CQRS.Workflows.Submit;
 using Application.AI.Common.Interfaces.Governance;
 using Application.AI.Common.Interfaces.Runs;
 using Domain.Common;
+using Domain.Common.Config.AI.Governance;
+using Microsoft.Extensions.Options;
 using Presentation.ExecutionApi.DTOs;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
@@ -56,20 +58,24 @@ public sealed class WorkflowsController : ControllerBase
     private readonly IMediator _mediator;
     private readonly ICapabilityEnvelopeResolver _envelopeResolver;
     private readonly IRunProgressBroker _progressBroker;
+    private readonly IOptionsMonitor<EscalationConfig> _escalationConfig;
 
     /// <summary>Initializes the controller with its MediatR and envelope-resolver dependencies.</summary>
     public WorkflowsController(
         IMediator mediator,
         ICapabilityEnvelopeResolver envelopeResolver,
-        IRunProgressBroker progressBroker)
+        IRunProgressBroker progressBroker,
+        IOptionsMonitor<EscalationConfig> escalationConfig)
     {
         ArgumentNullException.ThrowIfNull(mediator);
         ArgumentNullException.ThrowIfNull(envelopeResolver);
         ArgumentNullException.ThrowIfNull(progressBroker);
+        ArgumentNullException.ThrowIfNull(escalationConfig);
 
         _mediator = mediator;
         _envelopeResolver = envelopeResolver;
         _progressBroker = progressBroker;
+        _escalationConfig = escalationConfig;
     }
 
     /// <summary>
@@ -90,7 +96,18 @@ public sealed class WorkflowsController : ControllerBase
         ArgumentNullException.ThrowIfNull(definition);
 
         var result = await _mediator
-            .Send(new SubmitWorkflowCommand { Definition = definition }, cancellationToken)
+            .Send(
+                new SubmitWorkflowCommand
+                {
+                    Definition = definition,
+
+                    // From the token, through the same resolver and the same configured claim the
+                    // decision path reads — so the name compared against a gate's roster here is the
+                    // same string that would be compared when someone answers it. There is no field
+                    // for this on the wire; a caller cannot nominate anyone, least of all itself.
+                    SubmitterApproverName = User.GetApproverNameOrNull(_escalationConfig.CurrentValue.ApproverClaimType)
+                },
+                cancellationToken)
             .ConfigureAwait(false);
 
         if (!result.IsSuccess || result.Value is null)

--- a/src/Content/Presentation/Presentation.ExecutionApi/Controllers/WorkflowsController.cs
+++ b/src/Content/Presentation/Presentation.ExecutionApi/Controllers/WorkflowsController.cs
@@ -1,3 +1,4 @@
+using Application.AI.Common.CQRS.Workflows.CancelRun;
 using Application.AI.Common.CQRS.Workflows.GetRun;
 using Application.AI.Common.CQRS.Workflows.StartRun;
 using Application.AI.Common.CQRS.Workflows.Submit;
@@ -174,6 +175,58 @@ public sealed class WorkflowsController : ControllerBase
         return result.IsSuccess && result.Value is not null
             ? Ok(WorkflowRunResponse.FromRecord(result.Value))
             : MapFailure(result);
+    }
+
+    /// <summary>Stops a run the caller started, and withdraws any approval it was waiting on.</summary>
+    /// <remarks>
+    /// <para>
+    /// Authorized exactly like reading the run: another caller's run, a job that never existed, and a
+    /// job reached through the wrong workflow's route are one answer. A distinguishable response would
+    /// let a caller discover work it was not given the identifier for — and here it would also let them
+    /// stop it.
+    /// </para>
+    /// <para>
+    /// A run parked on a human gate has that gate withdrawn as part of being cancelled. An approval
+    /// request that outlives its run cannot do anything: answering it would approve work that will
+    /// never happen, and the approver has no way to tell.
+    /// </para>
+    /// <para>
+    /// Answers 200 with <c>stopped: false</c> when the run was already executing. Work in flight can
+    /// only be asked to stop; the caller confirms by reading the run's status as it would for any other
+    /// outcome. Answers 409 for a run that has already finished — there is nothing to cancel, and
+    /// reporting success would suggest this call changed something.
+    /// </para>
+    /// </remarks>
+    /// <param name="workflowId">The workflow the run belongs to.</param>
+    /// <param name="jobId">The run to stop.</param>
+    /// <param name="cancellationToken">Cancels the request.</param>
+    [HttpDelete("{workflowId:guid}/runs/{jobId}")]
+    [ProducesResponseType(typeof(CancelWorkflowRunResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status409Conflict)]
+    public async Task<IActionResult> CancelRun(
+        Guid workflowId, string jobId, CancellationToken cancellationToken)
+    {
+        var result = await _mediator.Send(
+            new CancelWorkflowRunCommand
+            {
+                WorkflowId = workflowId,
+                JobId = jobId,
+                OwnerId = User.GetUserId(),
+                TenantId = User.GetTenantId()
+            },
+            cancellationToken).ConfigureAwait(false);
+
+        if (!result.IsSuccess || result.Value is null)
+            return MapFailure(result);
+
+        return Ok(new CancelWorkflowRunResponse
+        {
+            JobId = jobId,
+            Stopped = result.Value.StoppedImmediately,
+            WithdrawnApprovals = result.Value.WithdrawnApprovals
+        });
     }
 
     /// <summary>Streams a run's progress as Server-Sent-Events until it finishes.</summary>

--- a/src/Content/Presentation/Presentation.ExecutionApi/DTOs/WorkflowRunContracts.cs
+++ b/src/Content/Presentation/Presentation.ExecutionApi/DTOs/WorkflowRunContracts.cs
@@ -12,6 +12,27 @@ public sealed record StartWorkflowRunResponse
     public required string StatusUrl { get; init; }
 }
 
+/// <summary>What a cancellation achieved, as the caller sees it.</summary>
+/// <remarks>
+/// Says whether the run had actually stopped rather than reporting a flat "cancelled". A run that was
+/// already executing can only be asked to stop, and a caller told otherwise would start a replacement
+/// immediately — against a workflow the first run still holds, which is refused.
+/// </remarks>
+public sealed record CancelWorkflowRunResponse
+{
+    /// <summary>Identifier of the run that was cancelled.</summary>
+    public required string JobId { get; init; }
+
+    /// <summary>
+    /// Whether the run had stopped by the time this was answered. When false it has been signalled and
+    /// will stop; read the run's status to confirm.
+    /// </summary>
+    public required bool Stopped { get; init; }
+
+    /// <summary>How many pending approvals were withdrawn along with the run.</summary>
+    public required int WithdrawnApprovals { get; init; }
+}
+
 /// <summary>The caller-visible view of a run.</summary>
 /// <remarks>
 /// A projection rather than the stored record, deliberately. <see cref="RunRecord"/> carries the

--- a/src/Content/Presentation/Presentation.ExecutionApi/Streaming/WorkflowProgressEvents.cs
+++ b/src/Content/Presentation/Presentation.ExecutionApi/Streaming/WorkflowProgressEvents.cs
@@ -81,13 +81,24 @@ public sealed record WorkflowProgressGapEvent(
     [property: JsonPropertyName("droppedCount")] long DroppedCount) : WorkflowProgressEvent;
 
 /// <summary>
-/// Last frame on the stream when the run parked awaiting a decision rather than finishing.
+/// Sent when a run parks awaiting a decision while someone is watching, and is the last frame on that
+/// stream.
 /// </summary>
 /// <remarks>
+/// <para>
 /// Ends the stream without ending the run. A client that treated this as completion would report a
 /// workflow as done while it sits waiting for an approval; one that kept waiting would hold a
 /// connection for however long the approver takes. Neither is what it wants — it wants to know the ball
 /// is in someone else's court, and to come back afterwards.
+/// </para>
+/// <para>
+/// <strong>A stream opened on an <em>already</em>-parked run does not carry this frame.</strong> It
+/// receives the snapshot and ends immediately, because the park happened before anyone was listening
+/// and the substrate does not replay it. The snapshot's <c>status</c> is what distinguishes that from a
+/// dropped connection, which is the same rule that already applies to opening a stream on a run that
+/// has already finished — a client must read the snapshot rather than infer state from which frames
+/// arrive.
+/// </para>
 /// </remarks>
 public sealed record WorkflowProgressParkedEvent(
     /// <summary>Position in this run's event order.</summary>

--- a/src/Content/Presentation/Presentation.ExecutionApi/Streaming/WorkflowProgressEvents.cs
+++ b/src/Content/Presentation/Presentation.ExecutionApi/Streaming/WorkflowProgressEvents.cs
@@ -22,6 +22,7 @@ namespace Presentation.ExecutionApi.Streaming;
 [JsonDerivedType(typeof(WorkflowProgressStepEvent), "STEP")]
 [JsonDerivedType(typeof(WorkflowProgressFinishedEvent), "FINISHED")]
 [JsonDerivedType(typeof(WorkflowProgressGapEvent), "GAP")]
+[JsonDerivedType(typeof(WorkflowProgressParkedEvent), "PARKED")]
 public abstract record WorkflowProgressEvent;
 
 /// <summary>
@@ -79,6 +80,23 @@ public sealed record WorkflowProgressGapEvent(
     /// <summary>How many events have been dropped for this watcher so far.</summary>
     [property: JsonPropertyName("droppedCount")] long DroppedCount) : WorkflowProgressEvent;
 
+/// <summary>
+/// Last frame on the stream when the run parked awaiting a decision rather than finishing.
+/// </summary>
+/// <remarks>
+/// Ends the stream without ending the run. A client that treated this as completion would report a
+/// workflow as done while it sits waiting for an approval; one that kept waiting would hold a
+/// connection for however long the approver takes. Neither is what it wants — it wants to know the ball
+/// is in someone else's court, and to come back afterwards.
+/// </remarks>
+public sealed record WorkflowProgressParkedEvent(
+    /// <summary>Position in this run's event order.</summary>
+    [property: JsonPropertyName("sequence")] long Sequence,
+    /// <summary>When the run parked.</summary>
+    [property: JsonPropertyName("occurredAt")] DateTimeOffset OccurredAt,
+    /// <summary>What the run is waiting for, in caller-safe terms.</summary>
+    [property: JsonPropertyName("detail")] string? Detail) : WorkflowProgressEvent;
+
 /// <summary>Projects substrate progress events onto the caller-visible frames.</summary>
 internal static class WorkflowProgressEventMapper
 {
@@ -90,6 +108,9 @@ internal static class WorkflowProgressEventMapper
 
         RunProgressKind.RunFinished =>
             new WorkflowProgressFinishedEvent(evt.Sequence, evt.OccurredAt, evt.Status, evt.Detail),
+
+        RunProgressKind.RunParked =>
+            new WorkflowProgressParkedEvent(evt.Sequence, evt.OccurredAt, evt.Detail),
 
         // RunStarted is not forwarded: the snapshot frame that opens every stream already says the run
         // is running, and a second frame saying so would only ever be redundant or contradictory.

--- a/src/Content/Presentation/Presentation.ExecutionApi/Streaming/WorkflowProgressStreamer.cs
+++ b/src/Content/Presentation/Presentation.ExecutionApi/Streaming/WorkflowProgressStreamer.cs
@@ -82,9 +82,11 @@ public sealed class WorkflowProgressStreamer
         if (!delivered)
             return;
 
-        // A run that had already finished has nothing further to report, and waiting on its stream
-        // would hold the connection open until the client gave up.
-        if (run.IsTerminal)
+        // A run that has quiesced has nothing further to report, and waiting on its stream would hold
+        // the connection open until the client gave up. That covers a run already finished and a run
+        // parked on a human gate alike: the second is still live, but nothing will be published for it
+        // until somebody answers, and an approver may take days.
+        if (run.IsQuiescent)
             return;
 
         var reportedDrops = 0L;
@@ -115,7 +117,10 @@ public sealed class WorkflowProgressStreamer
                 return;
             }
 
-            if (evt.Kind == RunProgressKind.RunFinished)
+            // Both kinds end the stream; only one ends the run. A parked run will publish nothing
+            // further until somebody answers its gate, so continuing to wait would hold a connection
+            // and a stream slot for as long as that takes.
+            if (evt.Kind is RunProgressKind.RunFinished or RunProgressKind.RunParked)
                 return;
         }
     }

--- a/src/Content/Tests/Application.AI.Common.Tests/CQRS/Workflows/CancelWorkflowRunHandlerTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/CQRS/Workflows/CancelWorkflowRunHandlerTests.cs
@@ -154,6 +154,39 @@ public sealed class CancelWorkflowRunHandlerTests
     }
 
     [Fact]
+    public async Task TheWithdrawalIsAttributedToTheCallersApproverIdentity()
+    {
+        // This value lands beside approver names in the escalation audit. The owner id is the same
+        // person under a different, immutable claim, so recording it there produces a row that reads
+        // unlike every other row in the same column — attributable, but not comparable with the
+        // approvers it sits among.
+        var parked = Run(RunStatus.Blocked, Guid.NewGuid());
+        StoreHolds(visible: parked, cancelReturns: parked);
+
+        await BuildSut().Handle(
+            Command() with { CancellerApproverName = "dave@contoso.com" }, CancellationToken.None);
+
+        _escalations.Verify(e => e.CancelEscalationAsync(
+            It.IsAny<Guid>(), It.IsAny<string>(), "dave@contoso.com", It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task WhenNoApproverIdentityResolves_TheWithdrawalIsStillAttributedToSomeone()
+    {
+        // An awkwardly-shaped attribution beats none. A withdrawal recorded against nobody leaves the
+        // audit unable to answer who ended the request, which is the one question it exists for.
+        var parked = Run(RunStatus.Blocked, Guid.NewGuid());
+        StoreHolds(visible: parked, cancelReturns: parked);
+
+        await BuildSut().Handle(
+            Command() with { CancellerApproverName = null }, CancellationToken.None);
+
+        _escalations.Verify(e => e.CancelEscalationAsync(
+            It.IsAny<Guid>(), It.IsAny<string>(), "alice", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
     public async Task TheRunIsStoppedBeforeItsApprovalIsWithdrawn()
     {
         // Order is a correctness property, not a style choice. Withdrawing first resolves the

--- a/src/Content/Tests/Application.AI.Common.Tests/CQRS/Workflows/CancelWorkflowRunHandlerTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/CQRS/Workflows/CancelWorkflowRunHandlerTests.cs
@@ -1,0 +1,335 @@
+using Application.AI.Common.CQRS.Workflows.CancelRun;
+using Application.AI.Common.Interfaces.Escalation;
+using Application.AI.Common.Interfaces.Planner;
+using Application.AI.Common.Interfaces.Runs;
+using Domain.AI.Bundles;
+using Domain.AI.Escalation;
+using Domain.AI.Planner;
+using Domain.AI.Runs;
+using Domain.Common;
+using Domain.Common.Config;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Time.Testing;
+using Moq;
+using Xunit;
+
+namespace Application.AI.Common.Tests.CQRS.Workflows;
+
+/// <summary>
+/// Tests for <see cref="CancelWorkflowRunCommandHandler"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Two things are load-bearing here and they are different in kind. The first is the same rule every
+/// run endpoint follows — a caller may only act on its own run, and a refusal must not reveal whether
+/// anyone else's exists. Cancelling raises the stakes: an endpoint that leaked existence here would
+/// let one caller stop another's work.
+/// </para>
+/// <para>
+/// The second is that cancelling a run has to take its pending approval with it. An approval request
+/// that outlives its run sits in a person's queue with nothing left to decide, and answering it
+/// affects a later run of the same workflow — which resumes the same persisted plan.
+/// </para>
+/// </remarks>
+public sealed class CancelWorkflowRunHandlerTests
+{
+    private sealed class StaticOptionsMonitor<T>(T value) : IOptionsMonitor<T>
+    {
+        public T CurrentValue { get; } = value;
+        public T Get(string? name) => CurrentValue;
+        public IDisposable? OnChange(Action<T, string?> listener) => null;
+    }
+
+    private readonly Mock<IRunJobStore> _runStore = new();
+    private readonly Mock<IRunProgressBroker> _progress = new();
+    private readonly Mock<IPlanRunCancellationRegistry> _registry = new();
+    private readonly Mock<IEscalationService> _escalations = new();
+    private readonly FakeTimeProvider _time = new(new DateTimeOffset(2026, 7, 29, 12, 0, 0, TimeSpan.Zero));
+    private readonly AppConfig _config = new();
+    private readonly Guid _workflowId = Guid.NewGuid();
+
+    /// <summary>Records the order in which the handler touched each collaborator.</summary>
+    private readonly List<string> _calls = [];
+
+    private readonly RecordingLogger _logger = new();
+
+    /// <summary>
+    /// Captures the severity of what the handler logged.
+    /// </summary>
+    /// <remarks>
+    /// Severity is behaviour here, not decoration. An approval that resolved between a run parking and
+    /// being cancelled is a benign race that resolves itself; logging it as an error puts a page in
+    /// front of an operator with nothing to fix, and does so on the exact path that races most.
+    /// </remarks>
+    private sealed class RecordingLogger : ILogger<CancelWorkflowRunCommandHandler>
+    {
+        public List<LogLevel> Levels { get; } = [];
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+            Func<TState, Exception?, string> formatter) => Levels.Add(logLevel);
+    }
+
+    private CancelWorkflowRunCommandHandler BuildSut()
+    {
+        _config.AI.WorkflowSubmission.Enabled = true;
+
+        return new CancelWorkflowRunCommandHandler(
+            _runStore.Object, _progress.Object, _registry.Object, _escalations.Object,
+            new StaticOptionsMonitor<AppConfig>(_config), _time, _logger);
+    }
+
+    private CancelWorkflowRunCommand Command(string jobId = "job-1", string ownerId = "alice") => new()
+    {
+        WorkflowId = _workflowId,
+        JobId = jobId,
+        OwnerId = ownerId,
+        TenantId = "acme"
+    };
+
+    private RunRecord Run(RunStatus status, params Guid[] awaiting) => new()
+    {
+        JobId = "job-1",
+        Kind = RunKind.Workflow,
+        TargetId = _workflowId.ToString(),
+        OwnerId = "alice",
+        TenantId = "acme",
+        Envelope = new CapabilityEnvelope(),
+        Status = status,
+        CreatedAt = _time.GetUtcNow(),
+        AwaitingEscalationIds = awaiting
+    };
+
+    /// <summary>The run the store reports to a scoped read, and what the store does when told to cancel.</summary>
+    private void StoreHolds(RunRecord? visible, RunRecord? cancelReturns)
+    {
+        _runStore
+            .Setup(s => s.Get(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string?>()))
+            .Returns(visible);
+
+        _runStore
+            .Setup(s => s.TryCancel(It.IsAny<string>(), It.IsAny<DateTimeOffset>()))
+            .Callback(() => _calls.Add("cancel-run"))
+            .Returns(cancelReturns);
+
+        _escalations
+            .Setup(e => e.CancelEscalationAsync(
+                It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Callback(() => _calls.Add("withdraw-approval"))
+            .ReturnsAsync((Guid id, string _, string _, CancellationToken _) => new EscalationOutcome
+            {
+                EscalationId = id,
+                IsApproved = false,
+                Decisions = [],
+                ResolutionType = EscalationResolutionType.Denied,
+                ResolvedAt = DateTimeOffset.UnixEpoch,
+                Approvers = ["carol"]
+            });
+    }
+
+    [Fact]
+    public async Task CancellingAParkedRun_WithdrawsTheApprovalItWasWaitingOn()
+    {
+        // The decision this wave settled. A gate left pending after its run is gone asks a person to
+        // decide something that cannot happen — and because a workflow's plan state outlives any one
+        // run, a verdict given for a dead run would be reconciled by the next one.
+        var escalation = Guid.NewGuid();
+        var parked = Run(RunStatus.Blocked, escalation);
+        StoreHolds(visible: parked, cancelReturns: parked);
+
+        var result = await BuildSut().Handle(Command(), CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.StoppedImmediately.Should().BeTrue();
+        result.Value.WithdrawnApprovals.Should().Be(1);
+
+        _escalations.Verify(e => e.CancelEscalationAsync(
+            escalation, It.IsAny<string>(), "alice", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task TheRunIsStoppedBeforeItsApprovalIsWithdrawn()
+    {
+        // Order is a correctness property, not a style choice. Withdrawing first resolves the
+        // escalation while the run is still parked on it — which is precisely what the resume check
+        // watches for, so the cancellation would put the run back to work on its way to stopping it.
+        var parked = Run(RunStatus.Blocked, Guid.NewGuid());
+        StoreHolds(visible: parked, cancelReturns: parked);
+
+        await BuildSut().Handle(Command(), CancellationToken.None);
+
+        _calls.Should().Equal("cancel-run", "withdraw-approval");
+    }
+
+    [Fact]
+    public async Task CancellingAQueuedRun_TellsAnyoneWatchingThatItEnded()
+    {
+        // No dispatch will ever run for this job, and the dispatcher is what normally publishes the
+        // terminal event. Without one here, a client streaming a queued run holds its connection and a
+        // stream slot waiting for an end that nothing will announce.
+        var queued = Run(RunStatus.Queued);
+        StoreHolds(visible: queued, cancelReturns: queued);
+
+        await BuildSut().Handle(Command(), CancellationToken.None);
+
+        _progress.Verify(p => p.Publish(
+            "job-1", RunProgressKind.RunFinished, null, null, nameof(RunStatus.Cancelled), It.IsAny<string>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task CancellingARunningRun_SignalsItRatherThanClaimingItStopped()
+    {
+        // Work in flight can only be asked to stop. Reporting it as stopped would have the caller
+        // start a replacement immediately — which is refused, because the first run still holds the
+        // workflow, so the caller would be told its own cancellation had failed.
+        StoreHolds(visible: Run(RunStatus.Running), cancelReturns: null);
+
+        var result = await BuildSut().Handle(Command(), CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.StoppedImmediately.Should().BeFalse();
+        _registry.Verify(r => r.TryCancel(new PlanId(_workflowId)), Times.Once);
+    }
+
+    [Fact]
+    public async Task CancellingAFinishedRun_IsAConflictAndStopsNothing()
+    {
+        // There is nothing to cancel, and answering success would suggest this call changed something.
+        StoreHolds(visible: Run(RunStatus.Succeeded), cancelReturns: null);
+
+        var result = await BuildSut().Handle(Command(), CancellationToken.None);
+
+        result.FailureType.Should().Be(ResultFailureType.Conflict);
+        _runStore.Verify(s => s.TryCancel(It.IsAny<string>(), It.IsAny<DateTimeOffset>()), Times.Never);
+        _registry.Verify(r => r.TryCancel(It.IsAny<PlanId>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ARunTheCallerCannotSee_IsNotFoundAndIsNotCancelled()
+    {
+        // The store answers as though another owner's run does not exist. Distinguishing the two here
+        // would hand one caller a way to stop another's work by guessing identifiers.
+        StoreHolds(visible: null, cancelReturns: null);
+
+        var result = await BuildSut().Handle(Command(), CancellationToken.None);
+
+        result.FailureType.Should().Be(ResultFailureType.NotFound);
+        _runStore.Verify(s => s.TryCancel(It.IsAny<string>(), It.IsAny<DateTimeOffset>()), Times.Never);
+        _registry.Verify(r => r.TryCancel(It.IsAny<PlanId>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task AJobReachedThroughTheWrongWorkflowsRoute_IsNotFound()
+    {
+        // The route asserts a relationship. Honouring a request that contradicts it would confirm which
+        // workflow a job belongs to by trying routes until one worked.
+        StoreHolds(visible: Run(RunStatus.Blocked) with { TargetId = Guid.NewGuid().ToString() },
+            cancelReturns: null);
+
+        var result = await BuildSut().Handle(Command(), CancellationToken.None);
+
+        result.FailureType.Should().Be(ResultFailureType.NotFound);
+        _runStore.Verify(s => s.TryCancel(It.IsAny<string>(), It.IsAny<DateTimeOffset>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task AnApprovalThatCannotBeWithdrawn_DoesNotFailTheCancellation()
+    {
+        // The run is already stopped by this point. Reporting failure would invite a retry of a cancel
+        // with nothing left to do, and the caller cannot fix what actually went wrong.
+        var parked = Run(RunStatus.Blocked, Guid.NewGuid(), Guid.NewGuid());
+        StoreHolds(visible: parked, cancelReturns: parked);
+
+        var attempts = 0;
+        _escalations
+            .Setup(e => e.CancelEscalationAsync(
+                It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns(() => Interlocked.Increment(ref attempts) == 1
+                ? throw new TimeoutException("the escalation store is down")
+                : Task.FromResult(new EscalationOutcome
+                {
+                    EscalationId = Guid.NewGuid(),
+                    IsApproved = false,
+                    Decisions = [],
+                    ResolutionType = EscalationResolutionType.Denied,
+                    ResolvedAt = DateTimeOffset.UnixEpoch,
+                    Approvers = ["carol"]
+                }));
+
+        var result = await BuildSut().Handle(Command(), CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.StoppedImmediately.Should().BeTrue();
+        result.Value.WithdrawnApprovals.Should().Be(1,
+            "the count is what was actually withdrawn, not what was attempted — one approval is still "
+            + "sitting in someone's queue and the caller should be able to tell");
+        attempts.Should().Be(2, "one failure must not abandon the approvals after it");
+    }
+
+    [Fact]
+    public async Task AnApprovalAlreadyDecided_IsNotTreatedAsAFailure()
+    {
+        // The ordinary race, not a fault: a gate can time out or be answered between a run parking on
+        // it and anyone cancelling that run. The escalation service reports that by throwing, and it is
+        // the same exception a genuinely broken store would surface — so the two are distinguished by
+        // its documented contract rather than by hoping they differ.
+        var parked = Run(RunStatus.Blocked, Guid.NewGuid());
+        StoreHolds(visible: parked, cancelReturns: parked);
+
+        _escalations
+            .Setup(e => e.CancelEscalationAsync(
+                It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("No pending escalation found with ID ..."));
+
+        var result = await BuildSut().Handle(Command(), CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.StoppedImmediately.Should().BeTrue();
+        result.Value.WithdrawnApprovals.Should().Be(0,
+            "nothing was withdrawn because there was nothing left pending to withdraw");
+
+        _logger.Levels.Should().NotContain(LogLevel.Error,
+            "a race that resolved itself correctly must not page an operator who has nothing to fix");
+    }
+
+    [Fact]
+    public async Task AnApprovalLeftPendingByAFailure_IsLoggedAsAProblem()
+    {
+        // The other side of the same judgement. This one really did leave a request in somebody's
+        // queue with nothing left to decide, and nothing else will ever notice — the caller has been
+        // told its run stopped, which is true.
+        var parked = Run(RunStatus.Blocked, Guid.NewGuid());
+        StoreHolds(visible: parked, cancelReturns: parked);
+
+        _escalations
+            .Setup(e => e.CancelEscalationAsync(
+                It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new TimeoutException("the escalation store is down"));
+
+        await BuildSut().Handle(Command(), CancellationToken.None);
+
+        _logger.Levels.Should().Contain(LogLevel.Error);
+    }
+
+    [Fact]
+    public async Task WhenWorkflowSubmissionIsDisabled_NothingIsCancelled()
+    {
+        // The feature gate is the whole surface, not just its entry point. Leaving cancel reachable
+        // while the rest is off would let a caller act on runs the host has stopped offering.
+        StoreHolds(visible: Run(RunStatus.Blocked), cancelReturns: null);
+        var sut = BuildSut();
+        _config.AI.WorkflowSubmission.Enabled = false;
+
+        var result = await sut.Handle(Command(), CancellationToken.None);
+
+        result.FailureType.Should().Be(ResultFailureType.Forbidden);
+        _runStore.Verify(s => s.Get(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string?>()), Times.Never);
+    }
+}

--- a/src/Content/Tests/Application.AI.Common.Tests/CQRS/Workflows/CancelWorkflowRunHandlerTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/CQRS/Workflows/CancelWorkflowRunHandlerTests.cs
@@ -187,6 +187,46 @@ public sealed class CancelWorkflowRunHandlerTests
     }
 
     [Fact]
+    public async Task ACallerHangingUpMidCancel_DoesNotStrandTheRemainingApprovals()
+    {
+        // The run is already cancelled by the time withdrawal starts, so abandoning the loop on the
+        // caller's token leaves approvals pending with nothing to retry them — the ceiling only looks
+        // at parked runs and this one is terminal. Same shape as queueing a run on its caller's abort
+        // token, which stranded workflows permanently.
+        var parked = Run(RunStatus.Blocked, Guid.NewGuid(), Guid.NewGuid());
+        StoreHolds(visible: parked, cancelReturns: parked);
+
+        // Cancelled part-way through rather than up front: the handler refuses a request that arrives
+        // already abandoned, so an up-front cancellation would never reach the loop this is about.
+        using var hangsUpMidway = new CancellationTokenSource();
+        var seen = new List<CancellationToken>();
+        _escalations
+            .Setup(e => e.CancelEscalationAsync(
+                It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Callback<Guid, string, string, CancellationToken>((_, _, _, token) =>
+            {
+                seen.Add(token);
+                hangsUpMidway.Cancel();
+            })
+            .ReturnsAsync(new EscalationOutcome
+            {
+                EscalationId = Guid.NewGuid(),
+                IsApproved = false,
+                Decisions = [],
+                ResolutionType = EscalationResolutionType.Denied,
+                ResolvedAt = DateTimeOffset.UnixEpoch,
+                Approvers = ["carol"]
+            });
+
+        var result = await BuildSut().Handle(Command(), hangsUpMidway.Token);
+
+        result.Value!.WithdrawnApprovals.Should().Be(2, "both approvals must still be withdrawn");
+        seen.Should().OnlyContain(token => !token.CanBeCanceled,
+            "the withdrawal must not run on the caller's token — the run is already cancelled, and "
+            + "nothing retries the approvals it abandons");
+    }
+
+    [Fact]
     public async Task TheRunIsStoppedBeforeItsApprovalIsWithdrawn()
     {
         // Order is a correctness property, not a style choice. Withdrawing first resolves the

--- a/src/Content/Tests/Application.AI.Common.Tests/CQRS/Workflows/SubmitWorkflowCommandValidatorTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/CQRS/Workflows/SubmitWorkflowCommandValidatorTests.cs
@@ -412,6 +412,33 @@ public sealed class SubmitWorkflowCommandValidatorTests
     }
 
     [Fact]
+    public void Validate_HumanGateWithANullApproverList_IsRejectedRatherThanThrowing()
+    {
+        // `"approvers": null` on the wire overwrites the property's empty-list initializer, so every
+        // rule that reads the list would dereference null. The caller is authenticated and the outcome
+        // would be a 500 from the admission path — the same shape a null step element produced once
+        // before, and the reason every collection predicate here has to tolerate one.
+        _config.WorkflowSubmission.PermittedApprovers = ["alice"];
+
+        var gate = new WorkflowStep
+        {
+            Name = "gate",
+            Type = StepType.HumanGate,
+            Configuration = new HumanGateStepConfiguration
+            {
+                EscalationMessage = "approve the spend",
+                ApprovalStrategy = ApprovalStrategy.AnyOf,
+                Approvers = null!
+            }
+        };
+
+        var act = () => Sut.Validate(Command([gate]) with { SubmitterApproverName = "dave" });
+
+        act.Should().NotThrow();
+        act().IsValid.Should().BeFalse("a gate nobody can answer is refused, not accepted");
+    }
+
+    [Fact]
     public void Validate_AWorkflowWithNoGate_IsUnaffectedByTheApproverRules()
     {
         // The roster governs gates, not submissions. A workflow that asks nobody to approve anything

--- a/src/Content/Tests/Application.AI.Common.Tests/CQRS/Workflows/SubmitWorkflowCommandValidatorTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/CQRS/Workflows/SubmitWorkflowCommandValidatorTests.cs
@@ -314,6 +314,114 @@ public sealed class SubmitWorkflowCommandValidatorTests
         Sut.Validate(Command([gate])).IsValid.Should().BeFalse();
     }
 
+    /// <summary>A well-formed gate naming <paramref name="approvers"/>.</summary>
+    private static WorkflowStep GateStep(params string[] approvers) => new()
+    {
+        Name = "gate",
+        Type = StepType.HumanGate,
+        Configuration = new HumanGateStepConfiguration
+        {
+            EscalationMessage = "approve the spend",
+            ApprovalStrategy = ApprovalStrategy.AnyOf,
+            Approvers = approvers
+        }
+    };
+
+    private SubmitWorkflowCommand GateCommand(string? submitter, params string[] approvers) =>
+        Command([GateStep(approvers)]) with { SubmitterApproverName = submitter };
+
+    [Fact]
+    public void Validate_HumanGate_WhenTheHostNamesNoApprovers_IsRejected()
+    {
+        // The shipped default, and deliberately fail-closed. A host that has not said who may approve
+        // things has said that nothing may be approved — reading an unset roster as "anyone" would make
+        // this a check that exists and enforces nothing, which is worse than not having it.
+        _config.WorkflowSubmission.PermittedApprovers = [];
+
+        var result = Sut.Validate(GateCommand("dave", "alice"));
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.ErrorMessage.Contains("does not recognise"));
+    }
+
+    [Fact]
+    public void Validate_HumanGate_NamingSomeoneTheHostDoesNotKnow_IsRejected()
+    {
+        // A gate can only be answered by the people it names. One naming a stranger parks the workflow
+        // for as long as the host permits and is then failed — so the honest place to say no is here,
+        // where the author can still fix it.
+        _config.WorkflowSubmission.PermittedApprovers = ["alice", "bob"];
+
+        Sut.Validate(GateCommand("dave", "alice", "mallory")).IsValid.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Validate_HumanGate_NamingPermittedApprovers_IsAccepted()
+    {
+        // The door this wave opens. Everything the gate needs now exists — a roster the host
+        // recognises, a resume trigger, and a way to cancel — so a workflow containing one is no longer
+        // a trap.
+        _config.WorkflowSubmission.PermittedApprovers = ["alice", "bob"];
+
+        Sut.Validate(GateCommand("dave", "alice", "bob")).IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Validate_HumanGate_MatchesTheRosterCaseInsensitively()
+    {
+        // Rosters are operator-authored and tokens are issuer-minted; casing differences between them
+        // are accidental, not semantic. Matching case-sensitively here while the decision path matches
+        // case-insensitively would reject gates naming approvers who could in fact answer them.
+        _config.WorkflowSubmission.PermittedApprovers = ["Alice@contoso.com"];
+
+        Sut.Validate(GateCommand("dave", "alice@CONTOSO.com")).IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Validate_HumanGate_NamingItsOwnSubmitter_IsRejected()
+    {
+        // A gate its author can answer is not an approval: the workflow pauses and continues on the
+        // say-so of the person who wrote it, while the audit record shows a human decided.
+        _config.WorkflowSubmission.PermittedApprovers = ["alice", "dave"];
+
+        var result = Sut.Validate(GateCommand("dave", "alice", "dave"));
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.ErrorMessage.Contains("own submitter"));
+    }
+
+    [Fact]
+    public void Validate_HumanGate_NamingItsSubmitterInDifferentCasing_IsStillRejected()
+    {
+        // Self-approval must not be reachable by typing your own name differently. The roster match is
+        // case-insensitive, so a case-sensitive self-check would let the same person through.
+        _config.WorkflowSubmission.PermittedApprovers = ["Dave@contoso.com"];
+
+        Sut.Validate(GateCommand("dave@CONTOSO.com", "Dave@contoso.com")).IsValid.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Validate_HumanGate_WhenTheSubmittersIdentityIsUnknown_IsRejected()
+    {
+        // The check cannot be performed, and the fail-open reading of that — "we could not tell, so
+        // allow it" — is exactly the self-approval it exists to prevent. Refusing costs a caller with
+        // no usable claim the ability to author gates; permitting costs everyone the guarantee.
+        _config.WorkflowSubmission.PermittedApprovers = ["alice"];
+
+        Sut.Validate(GateCommand(submitter: null, "alice")).IsValid.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Validate_AWorkflowWithNoGate_IsUnaffectedByTheApproverRules()
+    {
+        // The roster governs gates, not submissions. A workflow that asks nobody to approve anything
+        // must not be refused because the host has not named any approvers.
+        _config.WorkflowSubmission.PermittedApprovers = [];
+
+        Sut.Validate(Command([LlmStep("only")]) with { SubmitterApproverName = null })
+            .IsValid.Should().BeTrue();
+    }
+
     [Fact]
     public void Validate_HumanGateWithABlankMessage_IsRejected()
     {

--- a/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlannerDiRegistrationTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlannerDiRegistrationTests.cs
@@ -57,18 +57,21 @@ public sealed class PlannerDiRegistrationTests : IDisposable
     }
 
     [Fact]
-    public void DependencyInjection_RunSubstrate_HasBothADispatcherAndASweeper()
+    public void DependencyInjection_RunSubstrate_HasADispatcherASweeperAndAResumeCheck()
     {
-        // Registration is the whole feature for these two. Each is a background loop nothing else
+        // Registration is the whole feature for these three. Each is a background loop nothing else
         // calls, so an unregistered one is not a failure anyone sees — the dispatcher's absence leaves
-        // every run sitting Queued, and the sweeper's leaves the configured retention as a claim the
-        // host never honours while finished runs accumulate for the life of the process.
+        // every run sitting Queued, the sweeper's leaves the configured retention as a claim the host
+        // never honours while finished runs accumulate for the life of the process, and the resume
+        // check's leaves every approved human gate to wait out the parked-run ceiling and fail, days
+        // after the approver said yes.
         var hosted = _provider.GetServices<Microsoft.Extensions.Hosting.IHostedService>()
             .Select(service => service.GetType())
             .ToList();
 
         hosted.Should().Contain(typeof(RunDispatchBackgroundService));
         hosted.Should().Contain(typeof(RunRecordCleanupService));
+        hosted.Should().Contain(typeof(ParkedRunResumeService));
     }
 
     [Fact]

--- a/src/Content/Tests/Infrastructure.AI.Tests/Runs/InMemoryRunJobStoreTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Runs/InMemoryRunJobStoreTests.cs
@@ -586,6 +586,53 @@ public sealed class InMemoryRunJobStoreTests
     }
 
     [Fact]
+    public void TryRepark_RestoresARunWhoseResumeCouldNotQueueIt()
+    {
+        // Queued-but-not-in-the-queue is the one state nothing recovers from: no dispatcher claims a
+        // run it was never handed, and the ceiling only inspects parked runs. Re-parking puts it back
+        // where something can act on it.
+        var sut = BuildSut();
+        Admit(sut, Queued());
+        var claimed = sut.TryBeginRun("job-1", _time.GetUtcNow())!;
+        var escalation = Guid.NewGuid();
+        var parked = claimed with
+        {
+            Status = RunStatus.Blocked,
+            ParkedAt = _time.GetUtcNow(),
+            AwaitingEscalationIds = [escalation]
+        };
+        sut.Update(parked);
+        sut.TryResume("job-1").Should().NotBeNull();
+
+        sut.TryRepark(parked).Should().BeTrue();
+
+        var restored = sut.Get("job-1", "alice", null)!;
+        restored.Status.Should().Be(RunStatus.Blocked);
+        restored.ParkedAt.Should().NotBeNull("the ceiling can only age a run whose wait it can measure");
+        restored.AwaitingEscalationIds.Should().Equal([escalation],
+            "the next resume attempt has to know what to ask about");
+    }
+
+    [Fact]
+    public void TryRepark_RefusesToResurrectARunThatWasCancelledInTheMeantime()
+    {
+        // The window is narrow but the consequence is not: the cancellation has already withdrawn this
+        // run's approvals, so restoring it would leave a run waiting on decisions nobody can make and
+        // nobody has been asked for.
+        var sut = BuildSut();
+        Admit(sut, Queued());
+        var claimed = sut.TryBeginRun("job-1", _time.GetUtcNow())!;
+        var parked = claimed with { Status = RunStatus.Blocked, ParkedAt = _time.GetUtcNow() };
+        sut.Update(parked);
+
+        sut.TryResume("job-1").Should().NotBeNull();
+        sut.TryCancel("job-1", _time.GetUtcNow()).Should().NotBeNull();
+
+        sut.TryRepark(parked).Should().BeFalse();
+        sut.Get("job-1", "alice", null)!.Status.Should().Be(RunStatus.Cancelled);
+    }
+
+    [Fact]
     public void TryCancel_ReturnsWhatTheRunWasDoing_SoItsApprovalsCanBeWithdrawn()
     {
         // The previous record, not the updated one. Reading the awaited approvals separately beforehand

--- a/src/Content/Tests/Infrastructure.AI.Tests/Runs/InMemoryRunJobStoreTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Runs/InMemoryRunJobStoreTests.cs
@@ -414,8 +414,14 @@ public sealed class InMemoryRunJobStoreTests
         var workflow = Guid.NewGuid().ToString();
         Admit(sut, Queued("job-1", targetId: workflow), cap: 1);
 
+        var gateEscalation = Guid.NewGuid();
         var claimed = sut.TryBeginRun("job-1", _time.GetUtcNow())!;
-        sut.Update(claimed with { Status = RunStatus.Blocked, ParkedAt = _time.GetUtcNow() });
+        sut.Update(claimed with
+        {
+            Status = RunStatus.Blocked,
+            ParkedAt = _time.GetUtcNow(),
+            AwaitingEscalationIds = [gateEscalation]
+        });
 
         var ceiling = TimeSpan.FromDays(7);
 
@@ -423,13 +429,19 @@ public sealed class InMemoryRunJobStoreTests
 
         _time.Advance(ceiling + TimeSpan.FromMinutes(1));
 
-        sut.ExpireStaleParkedRuns(ceiling).Should().BeEquivalentTo(["job-1"]);
+        var expired = sut.ExpireStaleParkedRuns(ceiling);
 
-        var expired = sut.Get("job-1", "alice", null)!;
-        expired.Status.Should().Be(RunStatus.Failed);
-        expired.IsTerminal.Should().BeTrue();
-        expired.Error.Should().NotBeNullOrWhiteSpace("a caller is owed a reason it can act on");
-        expired.CompletedAt.Should().NotBeNull();
+        // The records as they stood while parked, not their identifiers: giving up on a run has to
+        // release what it was holding, and the caller cannot withdraw approvals it cannot see.
+        expired.Select(run => run.JobId).Should().BeEquivalentTo(["job-1"]);
+        expired[0].AwaitingEscalationIds.Should().Equal([gateEscalation]);
+
+        var stored = sut.Get("job-1", "alice", null)!;
+        stored.Status.Should().Be(RunStatus.Failed);
+        stored.IsTerminal.Should().BeTrue();
+        stored.Error.Should().NotBeNullOrWhiteSpace("a caller is owed a reason it can act on");
+        stored.CompletedAt.Should().NotBeNull();
+        stored.AwaitingEscalationIds.Should().BeEmpty("the run is no longer waiting on anyone");
 
         sut.TryCreate(Queued("job-2", targetId: workflow), maxActiveRunsPerOwner: 1)
             .Should().Be(RunAdmission.Accepted, "expiring the run must release the workflow it held");

--- a/src/Content/Tests/Infrastructure.AI.Tests/Runs/InMemoryRunJobStoreTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Runs/InMemoryRunJobStoreTests.cs
@@ -453,6 +453,127 @@ public sealed class InMemoryRunJobStoreTests
     }
 
     [Fact]
+    public void TryResume_ReturnsAParkedRunToTheQueueAndClearsWhatItWasWaitingFor()
+    {
+        // The transition the whole gate feature turns on. Queued is the only status a dispatcher will
+        // claim, so a resume that left the run in any other state would enqueue an id nothing acts on.
+        var sut = BuildSut();
+        Admit(sut, Queued());
+        var claimed = sut.TryBeginRun("job-1", _time.GetUtcNow())!;
+        var escalation = Guid.NewGuid();
+        sut.Update(claimed with
+        {
+            Status = RunStatus.Blocked,
+            ParkedAt = _time.GetUtcNow(),
+            AwaitingEscalationIds = [escalation]
+        });
+
+        var resumed = sut.TryResume("job-1");
+
+        resumed.Should().NotBeNull();
+        resumed!.Status.Should().Be(RunStatus.Queued);
+        resumed.ParkedAt.Should().BeNull("the wait this recorded is over");
+        resumed.AwaitingEscalationIds.Should().BeEmpty(
+            "a run that is running again is not waiting on anyone, and leaving the id would resume it "
+            + "on the same verdict on every later pass");
+    }
+
+    [Fact]
+    public void AResumedRunKeepsTheJobIdAndTheEnvelopeItWasAcceptedUnder()
+    {
+        // The caller's contract: one submission, one id, whatever happens in between. And the grant is
+        // the one resolved when the run was accepted — a gate approval authorizes the work to continue,
+        // not to continue with anything more than it started with.
+        var sut = BuildSut();
+        var original = Admit(sut, Queued());
+        var claimed = sut.TryBeginRun("job-1", _time.GetUtcNow())!;
+        sut.Update(claimed with { Status = RunStatus.Blocked, ParkedAt = _time.GetUtcNow() });
+
+        var resumed = sut.TryResume("job-1")!;
+
+        resumed.JobId.Should().Be("job-1");
+        resumed.Envelope.Should().BeSameAs(original.Envelope);
+        resumed.OwnerId.Should().Be(original.OwnerId);
+    }
+
+    [Fact]
+    public void TryResume_UnderConcurrency_ReleasesExactlyOnce()
+    {
+        // Same hazard TryBeginRun exists for. Two resumers both observing the run as parked would both
+        // enqueue it, and the second dispatch would execute the same plan alongside the first — two
+        // schedulers writing one plan's step states.
+        var sut = BuildSut();
+        Admit(sut, Queued());
+        var claimed = sut.TryBeginRun("job-1", _time.GetUtcNow())!;
+        sut.Update(claimed with { Status = RunStatus.Blocked, ParkedAt = _time.GetUtcNow() });
+
+        var winners = 0;
+        Parallel.For(0, 64, _ =>
+        {
+            if (sut.TryResume("job-1") is not null)
+                Interlocked.Increment(ref winners);
+        });
+
+        winners.Should().Be(1);
+    }
+
+    [Fact]
+    public void TryResume_RefusesARunThatIsNotParked()
+    {
+        // Resuming is only ever a transition out of Blocked. Applied to a finished run it would
+        // resurrect completed work; applied to a running one it would queue a second execution of a
+        // plan already in flight.
+        var sut = BuildSut();
+        Admit(sut, Queued("job-running"));
+        sut.TryBeginRun("job-running", _time.GetUtcNow());
+
+        Admit(sut, Queued("job-done"));
+        var done = sut.TryBeginRun("job-done", _time.GetUtcNow())!;
+        sut.Update(done with { Status = RunStatus.Succeeded, CompletedAt = _time.GetUtcNow() });
+
+        sut.TryResume("job-running").Should().BeNull();
+        sut.TryResume("job-done").Should().BeNull();
+        sut.TryResume("job-never-existed").Should().BeNull();
+    }
+
+    [Fact]
+    public void AResumedRunDoesNotHaveItsStartTimeRewritten()
+    {
+        // StartedAt answers "when did this work begin", and a caller reads it to know how long the run
+        // has been going. Restamping it on resume would report a workflow that ran for an hour, waited
+        // a day for approval, and then finished as having started after the approver answered.
+        var sut = BuildSut();
+        Admit(sut, Queued());
+        var firstStart = _time.GetUtcNow();
+        var claimed = sut.TryBeginRun("job-1", firstStart)!;
+        sut.Update(claimed with { Status = RunStatus.Blocked, ParkedAt = _time.GetUtcNow() });
+
+        _time.Advance(TimeSpan.FromDays(1));
+        sut.TryResume("job-1");
+        var reclaimed = sut.TryBeginRun("job-1", _time.GetUtcNow())!;
+
+        reclaimed.StartedAt.Should().Be(firstStart);
+    }
+
+    [Fact]
+    public void GetParkedRuns_ListsOnlyRunsActuallyWaitingOnADecision()
+    {
+        // What the resume check iterates. Including a queued or running run would have it asking the
+        // escalation service about work nobody is gating; missing a parked one would leave that run to
+        // the ceiling however promptly its approver answered.
+        var sut = BuildSut();
+        Admit(sut, Queued("job-parked"));
+        var claimed = sut.TryBeginRun("job-parked", _time.GetUtcNow())!;
+        sut.Update(claimed with { Status = RunStatus.Blocked, ParkedAt = _time.GetUtcNow() });
+
+        Admit(sut, Queued("job-queued"));
+        Admit(sut, Queued("job-running"));
+        sut.TryBeginRun("job-running", _time.GetUtcNow());
+
+        sut.GetParkedRuns().Select(run => run.JobId).Should().BeEquivalentTo(["job-parked"]);
+    }
+
+    [Fact]
     public void TryCreate_WithADuplicateJobId_Throws()
     {
         var sut = BuildSut();

--- a/src/Content/Tests/Infrastructure.AI.Tests/Runs/InMemoryRunJobStoreTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Runs/InMemoryRunJobStoreTests.cs
@@ -342,12 +342,13 @@ public sealed class InMemoryRunJobStoreTests
     [InlineData(RunStatus.Succeeded)]
     [InlineData(RunStatus.Failed)]
     [InlineData(RunStatus.Cancelled)]
-    [InlineData(RunStatus.Blocked)]
     public void AnyOutcomeReleasesTheWorkflowAndTheOwnersCapacity(RunStatus outcome)
     {
-        // Every way a run can end has to free what it held. An outcome treated as still-live would pin
+        // Every way a run can END has to free what it held. An outcome treated as still-live would pin
         // its workflow permanently and consume one of the caller's slots for the process lifetime —
-        // which is what happens if a new RunStatus is added and IsTerminal is not updated to match.
+        // which is what happens if a new terminal RunStatus is added and IsTerminal is not updated to
+        // match. Blocked is deliberately absent: it is the one outcome that is not an ending, and the
+        // test below states the opposite requirement for it.
         var sut = BuildSut();
         var workflow = Guid.NewGuid().ToString();
         Admit(sut, Queued("job-1", targetId: workflow), cap: 1);
@@ -357,6 +358,98 @@ public sealed class InMemoryRunJobStoreTests
 
         sut.TryCreate(Queued("job-2", targetId: workflow), maxActiveRunsPerOwner: 1)
             .Should().Be(RunAdmission.Accepted);
+    }
+
+    [Fact]
+    public void AParkedRunKeepsItsWorkflowLockedAndItsOwnersSlot()
+    {
+        // The inverse of the test above, and it is the whole reason Blocked is a live state. Plan
+        // execution state is keyed by the workflow's id, so a second run of the same workflow shares
+        // the first's state machine — it re-executes live steps, adopts the first's outputs, and can
+        // answer the first's gate. Reporting a parked run as finished is precisely what would let that
+        // second run in, so this asserts the refusal rather than the outcome's tidiness.
+        var sut = BuildSut();
+        var workflow = Guid.NewGuid().ToString();
+        Admit(sut, Queued("job-1", targetId: workflow), cap: 1);
+
+        var claimed = sut.TryBeginRun("job-1", _time.GetUtcNow())!;
+        sut.Update(claimed with { Status = RunStatus.Blocked, ParkedAt = _time.GetUtcNow() });
+
+        sut.TryCreate(Queued("job-2", targetId: workflow), maxActiveRunsPerOwner: 1)
+            .Should().Be(
+                RunAdmission.TargetAlreadyRunning,
+                "a workflow waiting on an approval is still in flight, and a second run would share its plan state");
+
+        sut.TryCreate(Queued("job-3", targetId: Guid.NewGuid().ToString()), maxActiveRunsPerOwner: 1)
+            .Should().Be(
+                RunAdmission.OwnerAtCapacity,
+                "the parked run still occupies one of the owner's slots, because the work is still live");
+    }
+
+    [Fact]
+    public void AParkedRunIsNeverReclaimedByRetention()
+    {
+        // Retention only reclaims terminal runs, so a parked one must survive the sweep however long it
+        // waits. If it did not, a caller polling a workflow that is waiting on its own approver would
+        // find the run had silently vanished.
+        var sut = BuildSut();
+        Admit(sut, Queued("job-1"));
+
+        var claimed = sut.TryBeginRun("job-1", _time.GetUtcNow())!;
+        sut.Update(claimed with { Status = RunStatus.Blocked, ParkedAt = _time.GetUtcNow() });
+
+        _time.Advance(TimeSpan.FromDays(365));
+
+        sut.SweepExpired().Should().BeEmpty("a parked run has not finished, so retention does not apply");
+        sut.Get("job-1", "alice", null).Should().NotBeNull();
+    }
+
+    [Fact]
+    public void AGateNobodyAnswers_IsEventuallyFailedAndReleasesWhatItHeld()
+    {
+        // The price of Blocked being live: retention cannot reclaim it, so without a ceiling one
+        // unanswered gate holds a workflow and an owner's slot for the life of the process. Expiring it
+        // fails the run — rather than deleting it, so a caller coming back still learns what happened.
+        var sut = BuildSut();
+        var workflow = Guid.NewGuid().ToString();
+        Admit(sut, Queued("job-1", targetId: workflow), cap: 1);
+
+        var claimed = sut.TryBeginRun("job-1", _time.GetUtcNow())!;
+        sut.Update(claimed with { Status = RunStatus.Blocked, ParkedAt = _time.GetUtcNow() });
+
+        var ceiling = TimeSpan.FromDays(7);
+
+        sut.ExpireStaleParkedRuns(ceiling).Should().BeEmpty("the gate has only just been raised");
+
+        _time.Advance(ceiling + TimeSpan.FromMinutes(1));
+
+        sut.ExpireStaleParkedRuns(ceiling).Should().BeEquivalentTo(["job-1"]);
+
+        var expired = sut.Get("job-1", "alice", null)!;
+        expired.Status.Should().Be(RunStatus.Failed);
+        expired.IsTerminal.Should().BeTrue();
+        expired.Error.Should().NotBeNullOrWhiteSpace("a caller is owed a reason it can act on");
+        expired.CompletedAt.Should().NotBeNull();
+
+        sut.TryCreate(Queued("job-2", targetId: workflow), maxActiveRunsPerOwner: 1)
+            .Should().Be(RunAdmission.Accepted, "expiring the run must release the workflow it held");
+    }
+
+    [Fact]
+    public void ExpireStaleParkedRuns_LeavesRunsThatAreNotParked()
+    {
+        // Scoped strictly to parked runs. A queued or running run has no ParkedAt and is not waiting on
+        // anyone, so ageing it out would kill work that is making progress.
+        var sut = BuildSut();
+        Admit(sut, Queued("job-queued"));
+        Admit(sut, Queued("job-running"));
+        sut.TryBeginRun("job-running", _time.GetUtcNow());
+
+        _time.Advance(TimeSpan.FromDays(365));
+
+        sut.ExpireStaleParkedRuns(TimeSpan.FromDays(7)).Should().BeEmpty();
+        sut.Get("job-queued", "alice", null)!.Status.Should().Be(RunStatus.Queued);
+        sut.Get("job-running", "alice", null)!.Status.Should().Be(RunStatus.Running);
     }
 
     [Fact]

--- a/src/Content/Tests/Infrastructure.AI.Tests/Runs/InMemoryRunJobStoreTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Runs/InMemoryRunJobStoreTests.cs
@@ -574,6 +574,127 @@ public sealed class InMemoryRunJobStoreTests
     }
 
     [Fact]
+    public void TryCancel_ReturnsWhatTheRunWasDoing_SoItsApprovalsCanBeWithdrawn()
+    {
+        // The previous record, not the updated one. Reading the awaited approvals separately beforehand
+        // is not the same thing: a run can park between that read and the cancel, and the caller would
+        // then withdraw nothing while believing it had.
+        var sut = BuildSut();
+        Admit(sut, Queued());
+        var claimed = sut.TryBeginRun("job-1", _time.GetUtcNow())!;
+        var escalation = Guid.NewGuid();
+        sut.Update(claimed with
+        {
+            Status = RunStatus.Blocked,
+            ParkedAt = _time.GetUtcNow(),
+            AwaitingEscalationIds = [escalation]
+        });
+
+        var previous = sut.TryCancel("job-1", _time.GetUtcNow());
+
+        previous.Should().NotBeNull();
+        previous!.Status.Should().Be(RunStatus.Blocked);
+        previous.AwaitingEscalationIds.Should().Equal([escalation]);
+
+        var now = sut.Get("job-1", "alice", null)!;
+        now.Status.Should().Be(RunStatus.Cancelled);
+        now.IsTerminal.Should().BeTrue();
+        now.CompletedAt.Should().NotBeNull();
+        now.ParkedAt.Should().BeNull("the run is no longer waiting on anyone");
+    }
+
+    [Fact]
+    public void ACancelledRunReleasesTheWorkflowItHeld()
+    {
+        // A cancelled run that kept its workflow locked would leave the caller unable to start the
+        // replacement its cancellation was for — and the run it is waiting on is one it just stopped.
+        var workflow = Guid.NewGuid().ToString();
+        var sut = BuildSut();
+        Admit(sut, Queued(targetId: workflow));
+        var claimed = sut.TryBeginRun("job-1", _time.GetUtcNow())!;
+        sut.Update(claimed with { Status = RunStatus.Blocked, ParkedAt = _time.GetUtcNow() });
+
+        sut.TryCancel("job-1", _time.GetUtcNow()).Should().NotBeNull();
+
+        sut.TryCreate(Queued("job-2", targetId: workflow), maxActiveRunsPerOwner: 1)
+            .Should().Be(RunAdmission.Accepted);
+    }
+
+    [Fact]
+    public void ACancelledRunIsReadableForAFullRetentionWindowFromWhenItWasCancelled()
+    {
+        // Retention runs from the ending, not from admission — the same rule every other outcome
+        // follows. A run parked for longer than the window before being cancelled would otherwise be
+        // reclaimed on the very next sweep, so the caller that cancelled it would poll and be told no
+        // such run exists rather than that its cancellation worked.
+        var ttl = TimeSpan.FromMinutes(5);
+        var sut = BuildSut(ttl: ttl);
+        Admit(sut, Queued());
+        var claimed = sut.TryBeginRun("job-1", _time.GetUtcNow())!;
+        sut.Update(claimed with { Status = RunStatus.Blocked, ParkedAt = _time.GetUtcNow() });
+
+        // Long past the expiry the entry was seeded with at admission.
+        _time.Advance(TimeSpan.FromHours(1));
+        sut.TryCancel("job-1", _time.GetUtcNow()).Should().NotBeNull();
+
+        sut.SweepExpired().Should().NotContain("job-1", "the run was cancelled a moment ago");
+        sut.Get("job-1", "alice", null).Should().NotBeNull();
+
+        _time.Advance(ttl + TimeSpan.FromMinutes(1));
+        sut.SweepExpired().Should().Contain("job-1", "and it is reclaimed once its own window elapses");
+    }
+
+    [Fact]
+    public void TryCancel_RefusesARunningRun_BecauseItsOutcomeBelongsToTheDispatchExecutingIt()
+    {
+        // Writing a terminal state here would be overwritten moments later by the dispatch that holds
+        // the run — so it would read as cancelled and then silently revert to whatever the work did.
+        var sut = BuildSut();
+        Admit(sut, Queued());
+        sut.TryBeginRun("job-1", _time.GetUtcNow());
+
+        sut.TryCancel("job-1", _time.GetUtcNow()).Should().BeNull();
+        sut.Get("job-1", "alice", null)!.Status.Should().Be(RunStatus.Running);
+    }
+
+    [Fact]
+    public void TryCancel_UnderConcurrency_CancelsExactlyOnce()
+    {
+        // Only one caller may believe it cancelled the run, because that caller is the one that then
+        // withdraws the approvals — and withdrawing twice would report a withdrawal to an approver that
+        // had already been made.
+        var sut = BuildSut();
+        Admit(sut, Queued());
+        var claimed = sut.TryBeginRun("job-1", _time.GetUtcNow())!;
+        sut.Update(claimed with { Status = RunStatus.Blocked, ParkedAt = _time.GetUtcNow() });
+
+        var winners = 0;
+        Parallel.For(0, 64, _ =>
+        {
+            if (sut.TryCancel("job-1", _time.GetUtcNow()) is not null)
+                Interlocked.Increment(ref winners);
+        });
+
+        winners.Should().Be(1);
+    }
+
+    [Fact]
+    public void ACancelledRunIsNeverResumed()
+    {
+        // The two transitions have to be mutually exclusive. A verdict arriving on a withdrawn approval
+        // must not put a run the caller stopped back to work.
+        var sut = BuildSut();
+        Admit(sut, Queued());
+        var claimed = sut.TryBeginRun("job-1", _time.GetUtcNow())!;
+        sut.Update(claimed with { Status = RunStatus.Blocked, ParkedAt = _time.GetUtcNow() });
+
+        sut.TryCancel("job-1", _time.GetUtcNow()).Should().NotBeNull();
+
+        sut.TryResume("job-1").Should().BeNull();
+        sut.GetParkedRuns().Should().BeEmpty();
+    }
+
+    [Fact]
     public void TryCreate_WithADuplicateJobId_Throws()
     {
         var sut = BuildSut();

--- a/src/Content/Tests/Infrastructure.AI.Tests/Runs/ParkedRunResumeServiceTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Runs/ParkedRunResumeServiceTests.cs
@@ -1,0 +1,302 @@
+using System.Collections.Concurrent;
+using Application.AI.Common.Interfaces.Escalation;
+using Application.AI.Common.Interfaces.Runs;
+using Domain.AI.Bundles;
+using Domain.AI.Escalation;
+using Domain.AI.Runs;
+using Domain.Common.Config;
+using FluentAssertions;
+using Infrastructure.AI.Runs;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Time.Testing;
+using Moq;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Runs;
+
+/// <summary>
+/// Tests for <see cref="ParkedRunResumeService"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This service is the trigger that makes a human gate more than a place work stops. Everything on
+/// either side of it already worked: a gate queues an escalation and parks its step, and the plan
+/// executor reconciles blocked steps against their verdicts whenever it next runs. Nothing asked it to
+/// run again — so an approved gate released nothing, and the run waited out the parked-run ceiling and
+/// failed, days after the approver said yes.
+/// </para>
+/// <para>
+/// That is the defect shape these tests exist for: every part present and correct, and no caller. It
+/// does not show up in a unit test of any one part, because each part passes.
+/// </para>
+/// </remarks>
+public sealed class ParkedRunResumeServiceTests
+{
+    /// <summary>
+    /// Longest a test waits for a pass to happen. The service's interval floor is one second, so a
+    /// pass costs about that; this is generous enough to survive a loaded agent and short enough that
+    /// a genuinely stuck service fails the test rather than hanging the suite.
+    /// </summary>
+    private static readonly TimeSpan Budget = TimeSpan.FromSeconds(20);
+
+    private readonly FakeTimeProvider _time = new(new DateTimeOffset(2026, 7, 29, 12, 0, 0, TimeSpan.Zero));
+    private readonly AppConfig _config = new();
+    private readonly Mock<IEscalationService> _escalations = new();
+
+    private IRunJobStore _store = null!;
+    private RecordingQueue _queue = null!;
+
+    public ParkedRunResumeServiceTests()
+    {
+        // Below the service's own floor, which clamps it to one second — the shortest a real pass can
+        // be scheduled, and short enough for a test to observe one.
+        _config.AI.WorkflowSubmission.ParkedRunResumeInterval = TimeSpan.Zero;
+    }
+
+    /// <summary>Records what the service asked the dispatcher to run, and can refuse to accept it.</summary>
+    private sealed class RecordingQueue : IRunDispatchQueue
+    {
+        private readonly ConcurrentQueue<string> _enqueued = new();
+
+        /// <summary>When set, every enqueue throws this — standing in for a closed channel.</summary>
+        public Exception? FailWith { get; set; }
+
+        public IReadOnlyList<string> Enqueued => [.. _enqueued];
+
+        public ValueTask EnqueueAsync(string jobId, CancellationToken cancellationToken)
+        {
+            if (FailWith is not null)
+                throw FailWith;
+
+            _enqueued.Enqueue(jobId);
+            return ValueTask.CompletedTask;
+        }
+
+        public IAsyncEnumerable<string> DequeueAllAsync(CancellationToken cancellationToken) =>
+            throw new NotSupportedException("Nothing drains the queue in these tests.");
+    }
+
+    [Fact]
+    public async Task AnAnsweredGate_PutsTheRunBackInTheQueueUnderTheSameJobId()
+    {
+        // The whole point of the wave, and of the same-job-id decision: a caller submits once, polls
+        // one id, and gets an answer — the approval is an event inside that run, not a new one.
+        var escalation = Guid.NewGuid();
+        ParkRun("job-1", escalation);
+        Answered(escalation, approved: true);
+
+        await RunUntilAsync(() => _queue.Enqueued.Count > 0);
+
+        _queue.Enqueued.Should().Equal("job-1");
+        _store.Get("job-1", "alice", null)!.Status.Should().Be(
+            RunStatus.Queued, "only a queued run is claimable, so anything else enqueues an id nothing acts on");
+    }
+
+    [Fact]
+    public async Task ADeniedGate_ResumesTheRunToo()
+    {
+        // Resuming is not "continue the work" — it is "let the plan act on the answer". A denial has to
+        // re-enter execution for the gate to fail and the run to reach a terminal state. Resuming only
+        // on approval would leave every rejected workflow parked until the ceiling failed it, which
+        // reports a decision that was made as a decision that never came.
+        var escalation = Guid.NewGuid();
+        ParkRun("job-1", escalation);
+        Answered(escalation, approved: false);
+
+        await RunUntilAsync(() => _queue.Enqueued.Count > 0);
+
+        _queue.Enqueued.Should().Equal("job-1");
+    }
+
+    [Fact]
+    public async Task AGateNobodyHasAnsweredYet_LeavesTheRunParked()
+    {
+        // The other half of the contract. Resuming on an open gate would re-run the plan, which would
+        // re-park immediately — a busy loop against the LLM and tool budget for as long as the approver
+        // takes to answer.
+        var escalation = Guid.NewGuid();
+        ParkRun("job-1", escalation);
+        StillOpen(escalation);
+
+        await RunForAtLeastOnePassAsync();
+
+        _queue.Enqueued.Should().BeEmpty();
+        _store.Get("job-1", "alice", null)!.Status.Should().Be(RunStatus.Blocked);
+    }
+
+    [Fact]
+    public async Task OneOfTwoGatesAnswered_IsEnoughToResume()
+    {
+        // A plan can reach two gates on parallel branches. Waiting for both would stall on whichever
+        // approver is slower even when the other's verdict is enough to release work — and if the
+        // second gate is still open, reconciliation simply parks the run again on that one alone.
+        var answered = Guid.NewGuid();
+        var open = Guid.NewGuid();
+        ParkRun("job-1", answered, open);
+        Answered(answered, approved: true);
+        StillOpen(open);
+
+        await RunUntilAsync(() => _queue.Enqueued.Count > 0);
+
+        _queue.Enqueued.Should().Equal("job-1");
+    }
+
+    [Fact]
+    public async Task ARunIsResumedOnlyOnce_HoweverManyPassesRun()
+    {
+        // The verdict does not go away once read, so every later pass would see the same answered
+        // escalation. Enqueuing again would run the plan a second time concurrently with the first —
+        // two schedulers writing one plan's step states, and the caller billed twice.
+        var escalation = Guid.NewGuid();
+        ParkRun("job-1", escalation);
+        Answered(escalation, approved: true);
+
+        await RunUntilAsync(() => _queue.Enqueued.Count > 0, thenKeepRunningFor: TimeSpan.FromSeconds(3));
+
+        _queue.Enqueued.Should().Equal("job-1");
+    }
+
+    [Fact]
+    public async Task AnEnqueueThatFails_LeavesTheRunParkedRatherThanStranded()
+    {
+        // The one state nothing can recover from: Queued but not in the queue. No dispatcher claims a
+        // run it was never handed, and the parked-run ceiling only looks at parked runs — so the run
+        // would sit untouched and unreadable-as-finished for the life of the process. Putting it back
+        // costs one retried pass.
+        var escalation = Guid.NewGuid();
+        ParkRun("job-1", escalation);
+        Answered(escalation, approved: true);
+        _queue.FailWith = new InvalidOperationException("the queue is closed");
+
+        await RunForAtLeastOnePassAsync();
+
+        var run = _store.Get("job-1", "alice", null)!;
+        run.Status.Should().Be(RunStatus.Blocked);
+        run.ParkedAt.Should().NotBeNull("the ceiling can only give up on a run whose wait it can measure");
+        run.AwaitingEscalationIds.Should().Equal([escalation], "the next pass has to know what to ask about");
+    }
+
+    [Fact]
+    public async Task AFailedPass_DoesNotStopTheService()
+    {
+        // A background loop that dies on one bad pass takes every parked run in the host with it, and
+        // does so silently — the symptom is gates that stop releasing, not an error anyone sees.
+        var escalation = Guid.NewGuid();
+        ParkRun("job-1", escalation);
+
+        var asked = 0;
+        _escalations
+            .Setup(e => e.GetOutcomeAsync(escalation, It.IsAny<CancellationToken>()))
+            .Returns(() => Interlocked.Increment(ref asked) == 1
+                ? throw new InvalidOperationException("the escalation store is down")
+                : Task.FromResult<EscalationOutcome?>(Outcome(escalation, approved: true)));
+
+        await RunUntilAsync(() => _queue.Enqueued.Count > 0);
+
+        _queue.Enqueued.Should().Equal("job-1");
+    }
+
+    private void ParkRun(string jobId, params Guid[] awaiting)
+    {
+        _store = new InMemoryRunJobStore(new Support.StaticOptionsMonitor<AppConfig>(_config), _time);
+        _queue = new RecordingQueue();
+
+        var record = new RunRecord
+        {
+            JobId = jobId,
+            Kind = RunKind.Workflow,
+            TargetId = Guid.NewGuid().ToString(),
+            OwnerId = "alice",
+            Envelope = new CapabilityEnvelope(),
+            Status = RunStatus.Queued,
+            CreatedAt = _time.GetUtcNow()
+        };
+
+        _store.TryCreate(record, int.MaxValue).Should().Be(RunAdmission.Accepted);
+
+        // Parked the way the dispatcher parks it, rather than by writing the status directly, so these
+        // tests break if the dispatcher's park shape and the resume check's expectations diverge.
+        var claimed = _store.TryBeginRun(jobId, _time.GetUtcNow())!;
+        _store.Update(claimed with
+        {
+            Status = RunStatus.Blocked,
+            ParkedAt = _time.GetUtcNow(),
+            AwaitingEscalationIds = awaiting
+        });
+    }
+
+    private void Answered(Guid escalationId, bool approved) =>
+        _escalations
+            .Setup(e => e.GetOutcomeAsync(escalationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Outcome(escalationId, approved));
+
+    private void StillOpen(Guid escalationId) =>
+        _escalations
+            .Setup(e => e.GetOutcomeAsync(escalationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((EscalationOutcome?)null);
+
+    private static EscalationOutcome Outcome(Guid escalationId, bool approved) => new()
+    {
+        EscalationId = escalationId,
+        IsApproved = approved,
+        Decisions = [],
+        ResolutionType = approved
+            ? EscalationResolutionType.Approved
+            : EscalationResolutionType.Denied,
+        ResolvedAt = DateTimeOffset.UnixEpoch,
+        Approvers = ["carol"]
+    };
+
+    private ParkedRunResumeService BuildSut() =>
+        new(_store, _queue, _escalations.Object,
+            new Support.StaticOptionsMonitor<AppConfig>(_config),
+            NullLogger<ParkedRunResumeService>.Instance);
+
+    /// <summary>Runs the service until <paramref name="reached"/> holds, or the budget expires.</summary>
+    private async Task RunUntilAsync(Func<bool> reached, TimeSpan? thenKeepRunningFor = null)
+    {
+        var sut = BuildSut();
+        using var cts = new CancellationTokenSource();
+        await sut.StartAsync(cts.Token);
+
+        try
+        {
+            var deadline = DateTime.UtcNow + Budget;
+            while (!reached() && DateTime.UtcNow < deadline)
+                await Task.Delay(50);
+
+            reached().Should().BeTrue("the service had {0} to act on an answered decision", Budget);
+
+            if (thenKeepRunningFor is { } extra)
+                await Task.Delay(extra);
+        }
+        finally
+        {
+            await cts.CancelAsync();
+            await sut.StopAsync(CancellationToken.None);
+        }
+    }
+
+    /// <summary>
+    /// Runs the service long enough that at least one pass has certainly happened, for the tests whose
+    /// claim is that nothing changed.
+    /// </summary>
+    private async Task RunForAtLeastOnePassAsync()
+    {
+        var sut = BuildSut();
+        using var cts = new CancellationTokenSource();
+        await sut.StartAsync(cts.Token);
+
+        try
+        {
+            // Two intervals plus slack. A shorter wait would pass even against a service that never ran
+            // a pass at all, which is precisely the failure these tests are looking for.
+            await Task.Delay(TimeSpan.FromSeconds(3));
+        }
+        finally
+        {
+            await cts.CancelAsync();
+            await sut.StopAsync(CancellationToken.None);
+        }
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Runs/RunDispatchBackgroundServiceTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Runs/RunDispatchBackgroundServiceTests.cs
@@ -121,8 +121,23 @@ public sealed class RunDispatchBackgroundServiceTests
         store.TryCreate(record, int.MaxValue).Should().Be(RunAdmission.Accepted);
 
     /// <summary>Runs the dispatcher until <paramref name="jobId"/> is terminal, or the attempt budget is spent.</summary>
-    private static async Task<RunRecord?> DrainUntilTerminalAsync(
-        RunDispatchBackgroundService service, IRunJobStore store, string jobId)
+    private static Task<RunRecord?> DrainUntilTerminalAsync(
+        RunDispatchBackgroundService service, IRunJobStore store, string jobId) =>
+        DrainUntilAsync(service, store, jobId, r => r.IsTerminal);
+
+    /// <summary>
+    /// Runs the dispatcher until <paramref name="reached"/> holds for the run, or the attempts run out.
+    /// </summary>
+    /// <remarks>
+    /// Predicated rather than fixed on terminality, because not every state the dispatcher drives a run
+    /// into is terminal any more: a parked run has left <c>Running</c> and will never become terminal on
+    /// its own, so waiting for terminality would time out on exactly the case under test.
+    /// </remarks>
+    private static async Task<RunRecord?> DrainUntilAsync(
+        RunDispatchBackgroundService service,
+        IRunJobStore store,
+        string jobId,
+        Func<RunRecord, bool> reached)
     {
         using var cts = new CancellationTokenSource();
         await service.StartAsync(cts.Token);
@@ -131,7 +146,7 @@ public sealed class RunDispatchBackgroundServiceTests
         for (var attempt = 0; attempt < 200; attempt++)
         {
             record = store.Get(jobId, "alice", "acme");
-            if (record?.IsTerminal == true)
+            if (record is not null && reached(record))
                 break;
 
             await Task.Delay(10);
@@ -232,12 +247,11 @@ public sealed class RunDispatchBackgroundServiceTests
 
     [Theory]
     [InlineData(RunStatus.Cancelled)]
-    [InlineData(RunStatus.Blocked)]
     public async Task AnOutcomeThatIsNeitherSuccessNorFailure_IsRecordedAsItself(RunStatus outcome)
     {
         // Work can end in more ways than worked and broke. Collapsing those onto a boolean is what
         // makes a workflow parked awaiting an approval report to its caller as finished work.
-        var completion = new RunCompletion { Status = outcome, Detail = "waiting on a person" };
+        var completion = new RunCompletion { Status = outcome, Detail = "stopped on request" };
         var executor = new StubExecutor(_ => Task.FromResult(Result<RunCompletion>.Success(completion)));
 
         var (service, store, queue) = Build(executor);
@@ -247,14 +261,40 @@ public sealed class RunDispatchBackgroundServiceTests
         var record = await DrainUntilTerminalAsync(service, store, "job-1");
 
         record!.Status.Should().Be(outcome);
-        record.Error.Should().Be("waiting on a person");
+        record.Error.Should().Be("stopped on request");
+    }
+
+    [Fact]
+    public async Task AParkedRun_IsRecordedAsWaitingRatherThanAsFinishedOrFaulted()
+    {
+        // Parking is not an ending, and the record has to say so in every field a caller or an operator
+        // reads. A CompletedAt stamp would claim work finished that has not; an Error would send someone
+        // hunting for a fault when what is needed is an approval. ParkedAt is what carries the one fact
+        // that is true — and it is also what bounds how long the gate may hold the workflow, so a park
+        // that forgot to stamp it would park forever.
+        var completion = RunCompletion.Blocked("waiting on a person");
+        var executor = new StubExecutor(_ => Task.FromResult(Result<RunCompletion>.Success(completion)));
+
+        var (service, store, queue) = Build(executor);
+        Admit(store, Queued());
+        await queue.EnqueueAsync("job-1", CancellationToken.None);
+
+        var record = await DrainUntilAsync(
+            service, store, "job-1", r => r.Status == RunStatus.Blocked);
+
+        record.Should().NotBeNull("the run must leave Running even though it has not finished");
+        record!.Status.Should().Be(RunStatus.Blocked);
+        record.IsTerminal.Should().BeFalse("a parked run is live — that is what keeps its workflow locked");
+        record.IsAwaitingDecision.Should().BeTrue();
+        record.ParkedAt.Should().NotBeNull("without this stamp the gate can never be aged out");
+        record.CompletedAt.Should().BeNull("the run has not completed");
+        record.Error.Should().BeNull("waiting for an approval is not a fault");
     }
 
     [Theory]
     [InlineData(RunStatus.Succeeded)]
     [InlineData(RunStatus.Failed)]
     [InlineData(RunStatus.Cancelled)]
-    [InlineData(RunStatus.Blocked)]
     public async Task EveryWayARunCanEnd_TellsAnyoneWatchingThatItEnded(RunStatus outcome)
     {
         // A watcher's stream ends on this event and nothing else, so an ending that does not publish
@@ -289,6 +329,45 @@ public sealed class RunDispatchBackgroundServiceTests
         }
 
         sawFinish.Should().BeTrue("a run that ended must say so, however it ended");
+    }
+
+    [Fact]
+    public async Task AParkedRun_TellsWatchersToStopWaiting_WithoutClaimingItFinished()
+    {
+        // Two requirements at once, and they pull in opposite directions. A watcher must be released —
+        // nothing more will be published until a human acts, and an approver may take days, so a stream
+        // left open holds a connection and a stream slot for all of it. But it must NOT be told the run
+        // finished, because it did not: a client that recorded RunFinished here would report a workflow
+        // as complete while it sits waiting for approval.
+        var executor = new StubExecutor(_ =>
+            Task.FromResult(Result<RunCompletion>.Success(RunCompletion.Blocked("two approvals needed"))));
+
+        var (service, store, queue) = Build(executor);
+        Admit(store, Queued());
+
+        using var watcher = Progress.Subscribe("job-1", "alice", "acme")!;
+        await queue.EnqueueAsync("job-1", CancellationToken.None);
+
+        await DrainUntilAsync(service, store, "job-1", r => r.Status == RunStatus.Blocked);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var kinds = new List<RunProgressKind>();
+
+        await foreach (var evt in watcher.ReadAllAsync(cts.Token))
+        {
+            kinds.Add(evt.Kind);
+
+            if (evt.Kind != RunProgressKind.RunParked)
+                continue;
+
+            evt.Status.Should().Be(nameof(RunStatus.Blocked));
+            evt.Detail.Should().Be("two approvals needed", "the watcher is owed what the run is waiting for");
+            break;
+        }
+
+        kinds.Should().Contain(RunProgressKind.RunParked, "a parked run must release its watchers");
+        kinds.Should().NotContain(
+            RunProgressKind.RunFinished, "parking is not finishing, and a watcher must not be told it was");
     }
 
     [Fact]

--- a/src/Content/Tests/Infrastructure.AI.Tests/Runs/RunDispatchBackgroundServiceTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Runs/RunDispatchBackgroundServiceTests.cs
@@ -272,7 +272,8 @@ public sealed class RunDispatchBackgroundServiceTests
         // hunting for a fault when what is needed is an approval. ParkedAt is what carries the one fact
         // that is true — and it is also what bounds how long the gate may hold the workflow, so a park
         // that forgot to stamp it would park forever.
-        var completion = RunCompletion.Blocked("waiting on a person");
+        var escalation = Guid.NewGuid();
+        var completion = RunCompletion.Blocked("waiting on a person", [escalation]);
         var executor = new StubExecutor(_ => Task.FromResult(Result<RunCompletion>.Success(completion)));
 
         var (service, store, queue) = Build(executor);
@@ -289,6 +290,9 @@ public sealed class RunDispatchBackgroundServiceTests
         record.ParkedAt.Should().NotBeNull("without this stamp the gate can never be aged out");
         record.CompletedAt.Should().BeNull("the run has not completed");
         record.Error.Should().BeNull("waiting for an approval is not a fault");
+        record.AwaitingEscalationIds.Should().Equal([escalation],
+            "what the run is waiting on is the only thing that can ever release it — a park that "
+            + "dropped it would sit until the ceiling failed it, however promptly the approver answered");
     }
 
     [Theory]
@@ -340,7 +344,8 @@ public sealed class RunDispatchBackgroundServiceTests
         // finished, because it did not: a client that recorded RunFinished here would report a workflow
         // as complete while it sits waiting for approval.
         var executor = new StubExecutor(_ =>
-            Task.FromResult(Result<RunCompletion>.Success(RunCompletion.Blocked("two approvals needed"))));
+            Task.FromResult(Result<RunCompletion>.Success(
+                RunCompletion.Blocked("two approvals needed", [Guid.NewGuid(), Guid.NewGuid()]))));
 
         var (service, store, queue) = Build(executor);
         Admit(store, Queued());

--- a/src/Content/Tests/Infrastructure.AI.Tests/Runs/RunRecordCleanupServiceTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Runs/RunRecordCleanupServiceTests.cs
@@ -56,6 +56,8 @@ public sealed class RunRecordCleanupServiceTests
 
         public RunRecord? TryResume(string jobId) => inner.TryResume(jobId);
 
+        public bool TryRepark(RunRecord parked) => inner.TryRepark(parked);
+
         public RunRecord? TryCancel(string jobId, DateTimeOffset cancelledAt) =>
             inner.TryCancel(jobId, cancelledAt);
 

--- a/src/Content/Tests/Infrastructure.AI.Tests/Runs/RunRecordCleanupServiceTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Runs/RunRecordCleanupServiceTests.cs
@@ -49,6 +49,10 @@ public sealed class RunRecordCleanupServiceTests
         public RunRecord? FindLiveRunForTarget(RunKind kind, string targetId) =>
             inner.FindLiveRunForTarget(kind, targetId);
 
+        public IReadOnlyList<RunRecord> GetParkedRuns() => inner.GetParkedRuns();
+
+        public RunRecord? TryResume(string jobId) => inner.TryResume(jobId);
+
         /// <summary>The ceilings the service asked the store to apply, in order.</summary>
         public List<TimeSpan> ParkedCeilings { get; } = [];
 

--- a/src/Content/Tests/Infrastructure.AI.Tests/Runs/RunRecordCleanupServiceTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Runs/RunRecordCleanupServiceTests.cs
@@ -1,5 +1,7 @@
+using Application.AI.Common.Interfaces.Escalation;
 using Application.AI.Common.Interfaces.Runs;
 using Domain.AI.Bundles;
+using Domain.AI.Escalation;
 using Domain.AI.Runs;
 using Domain.Common.Config;
 using FluentAssertions;
@@ -8,6 +10,7 @@ using Infrastructure.AI.Tests.Runs.Support;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Time.Testing;
+using Moq;
 using Xunit;
 
 namespace Infrastructure.AI.Tests.Runs;
@@ -59,7 +62,7 @@ public sealed class RunRecordCleanupServiceTests
         /// <summary>The ceilings the service asked the store to apply, in order.</summary>
         public List<TimeSpan> ParkedCeilings { get; } = [];
 
-        public IReadOnlyList<string> ExpireStaleParkedRuns(TimeSpan maxParkedDuration)
+        public IReadOnlyList<RunRecord> ExpireStaleParkedRuns(TimeSpan maxParkedDuration)
         {
             // Recorded rather than merely forwarded: the ceiling reaching the store is the whole of
             // what this service contributes to the parked-run rule, and a service that read the wrong
@@ -79,6 +82,82 @@ public sealed class RunRecordCleanupServiceTests
 
     private readonly FakeTimeProvider _time = new(new DateTimeOffset(2026, 7, 29, 12, 0, 0, TimeSpan.Zero));
     private readonly AppConfig _config = new();
+    private readonly Mock<IEscalationService> _escalations = new();
+
+    [Fact]
+    public async Task GivingUpOnAParkedRunAlsoWithdrawsTheApprovalItWasWaitingOn()
+    {
+        // The hazard is sharper here than on the cancel path. Failing the run makes it terminal, which
+        // UNLOCKS its workflow — so a second run can start against the same persisted plan, and an
+        // approver answering the first run's gate would have that verdict reconciled into the second.
+        // Leaving the approval pending is not merely confusing for the approver; it is a decision
+        // applied to work it was never about.
+        _config.AI.WorkflowSubmission.RunSweepInterval = TimeSpan.Zero;
+        _config.AI.WorkflowSubmission.MaxParkedRunDuration = TimeSpan.FromHours(1);
+
+        var monitor = new StaticOptionsMonitor<AppConfig>(_config);
+        var store = new CountingStore(new InMemoryRunJobStore(monitor, _time));
+        var progress = new InMemoryRunProgressBroker(monitor, _time);
+
+        var escalation = Guid.NewGuid();
+        store.TryCreate(Queued("abandoned"), int.MaxValue).Should().Be(RunAdmission.Accepted);
+        var claimed = store.TryBeginRun("abandoned", _time.GetUtcNow())!;
+        store.Update(claimed with
+        {
+            Status = RunStatus.Blocked,
+            ParkedAt = _time.GetUtcNow(),
+            AwaitingEscalationIds = [escalation]
+        });
+
+        var withdrawn = new List<(Guid Id, string By)>();
+        _escalations
+            .Setup(e => e.CancelEscalationAsync(
+                It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Callback<Guid, string, string, CancellationToken>((id, _, by, _) =>
+            {
+                lock (withdrawn)
+                    withdrawn.Add((id, by));
+            })
+            .ReturnsAsync(new EscalationOutcome
+            {
+                EscalationId = escalation,
+                IsApproved = false,
+                Decisions = [],
+                ResolutionType = EscalationResolutionType.Denied,
+                ResolvedAt = DateTimeOffset.UnixEpoch,
+                Approvers = ["carol"]
+            });
+
+        _time.Advance(TimeSpan.FromDays(1));
+
+        var sut = new RunRecordCleanupService(
+            store, progress, _escalations.Object, monitor,
+            NullLogger<RunRecordCleanupService>.Instance);
+
+        using var cts = new CancellationTokenSource();
+        await sut.StartAsync(cts.Token);
+
+        for (var attempt = 0; attempt < 60; attempt++)
+        {
+            lock (withdrawn)
+            {
+                if (withdrawn.Count > 0)
+                    break;
+            }
+
+            await Task.Delay(100);
+        }
+
+        await cts.CancelAsync();
+        await sut.StopAsync(CancellationToken.None);
+
+        withdrawn.Should().ContainSingle();
+        withdrawn[0].Id.Should().Be(escalation);
+        withdrawn[0].By.Should().StartWith("system:",
+            "nobody asked for a ceiling expiry, so an audit row naming a human would be untrue");
+
+        store.Get("abandoned", "alice", null)!.Status.Should().Be(RunStatus.Failed);
+    }
 
     [Fact]
     public async Task TheServiceActuallyReclaimsFinishedRunsPastTheirRetention()
@@ -102,7 +181,8 @@ public sealed class RunRecordCleanupServiceTests
         _time.Advance(TimeSpan.FromHours(1));
 
         var sut = new RunRecordCleanupService(
-            store, progress, monitor, NullLogger<RunRecordCleanupService>.Instance);
+            store, progress, _escalations.Object, monitor,
+            NullLogger<RunRecordCleanupService>.Instance);
 
         using var cts = new CancellationTokenSource();
         await sut.StartAsync(cts.Token);
@@ -140,7 +220,8 @@ public sealed class RunRecordCleanupServiceTests
         _time.Advance(TimeSpan.FromHours(1));
 
         var sut = new RunRecordCleanupService(
-            store, progress, monitor, NullLogger<RunRecordCleanupService>.Instance);
+            store, progress, _escalations.Object, monitor,
+            NullLogger<RunRecordCleanupService>.Instance);
 
         using var cts = new CancellationTokenSource();
         await sut.StartAsync(cts.Token);

--- a/src/Content/Tests/Infrastructure.AI.Tests/Runs/RunRecordCleanupServiceTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Runs/RunRecordCleanupServiceTests.cs
@@ -49,6 +49,18 @@ public sealed class RunRecordCleanupServiceTests
         public RunRecord? FindLiveRunForTarget(RunKind kind, string targetId) =>
             inner.FindLiveRunForTarget(kind, targetId);
 
+        /// <summary>The ceilings the service asked the store to apply, in order.</summary>
+        public List<TimeSpan> ParkedCeilings { get; } = [];
+
+        public IReadOnlyList<string> ExpireStaleParkedRuns(TimeSpan maxParkedDuration)
+        {
+            // Recorded rather than merely forwarded: the ceiling reaching the store is the whole of
+            // what this service contributes to the parked-run rule, and a service that read the wrong
+            // config value would forward a plausible-looking TimeSpan that expired nothing.
+            ParkedCeilings.Add(maxParkedDuration);
+            return inner.ExpireStaleParkedRuns(maxParkedDuration);
+        }
+
         public IReadOnlyList<string> SweepExpired()
         {
             Sweeps++;

--- a/src/Content/Tests/Infrastructure.AI.Tests/Runs/RunRecordCleanupServiceTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Runs/RunRecordCleanupServiceTests.cs
@@ -53,6 +53,9 @@ public sealed class RunRecordCleanupServiceTests
 
         public RunRecord? TryResume(string jobId) => inner.TryResume(jobId);
 
+        public RunRecord? TryCancel(string jobId, DateTimeOffset cancelledAt) =>
+            inner.TryCancel(jobId, cancelledAt);
+
         /// <summary>The ceilings the service asked the store to apply, in order.</summary>
         public List<TimeSpan> ParkedCeilings { get; } = [];
 

--- a/src/Content/Tests/Infrastructure.AI.Tests/Runs/WorkflowRunKindExecutorTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Runs/WorkflowRunKindExecutorTests.cs
@@ -125,6 +125,99 @@ public sealed class WorkflowRunKindExecutorTests
     }
 
     [Fact]
+    public async Task AParkedPlan_NamesTheDecisionsThatCouldReleaseIt()
+    {
+        // Without these ids the park is unrecoverable. Nothing else on the run says what it is waiting
+        // for, so the resume check has nothing to ask about and the run sits until the host's
+        // parked-run ceiling fails it — an approval turning into a silent expiry days later.
+        var gateEscalation = Guid.NewGuid();
+
+        PlanEndsWithStates(StepExecutionStatus.Blocked,
+        [
+            State(StepExecutionStatus.Completed, output: "the real output of a finished step"),
+            State(StepExecutionStatus.Blocked, output: EscalationStepOutput.Serialize(gateEscalation))
+        ]);
+
+        var result = await BuildSut().ExecuteAsync(Record(), CancellationToken.None);
+
+        result.Value!.AwaitingEscalationIds.Should().Equal(gateEscalation);
+    }
+
+    [Fact]
+    public async Task TwoGatesReachedAtOnce_AreBothNamed()
+    {
+        // Parallel branches can both reach a gate before the plan drains. Reporting only the first
+        // would tie the run's resume to one approver: if the other answered first, nothing would
+        // notice, and the run would wait on a decision that had already been made.
+        var first = Guid.NewGuid();
+        var second = Guid.NewGuid();
+
+        PlanEndsWithStates(StepExecutionStatus.Blocked,
+        [
+            State(StepExecutionStatus.Blocked, output: EscalationStepOutput.Serialize(first)),
+            State(StepExecutionStatus.Blocked, output: EscalationStepOutput.Serialize(second))
+        ]);
+
+        var result = await BuildSut().ExecuteAsync(Record(), CancellationToken.None);
+
+        result.Value!.AwaitingEscalationIds.Should().BeEquivalentTo([first, second]);
+    }
+
+    [Fact]
+    public async Task AStepBlockedWithNoReadableEscalation_StillParksRatherThanFailing()
+    {
+        // The run is genuinely blocked and saying otherwise would be worse than saying nothing: a
+        // caller told the work failed would retry it, against a plan whose gate is still pending. The
+        // honest report is "parked, with nothing named" — which the ceiling eventually resolves.
+        PlanEndsWithStates(StepExecutionStatus.Blocked,
+        [
+            State(StepExecutionStatus.Blocked, output: "{\"somethingElse\":\"not an escalation\"}")
+        ]);
+
+        var result = await BuildSut().ExecuteAsync(Record(), CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.Status.Should().Be(RunStatus.Blocked);
+        result.Value.AwaitingEscalationIds.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task AnEscalationOnAStepThatIsNotBlocked_IsNotWaitedOn()
+    {
+        // A gate that was approved on an earlier resume keeps its escalation reference in history.
+        // Treating it as still-awaited would resume the run on a verdict it has already acted on,
+        // every single pass, for as long as the run lives.
+        PlanEndsWithStates(StepExecutionStatus.Blocked,
+        [
+            State(StepExecutionStatus.Completed, output: EscalationStepOutput.Serialize(Guid.NewGuid())),
+            State(StepExecutionStatus.Blocked, output: null)
+        ]);
+
+        var result = await BuildSut().ExecuteAsync(Record(), CancellationToken.None);
+
+        result.Value!.AwaitingEscalationIds.Should().BeEmpty();
+    }
+
+    private static StepExecutionState State(StepExecutionStatus status, string? output) => new()
+    {
+        StepId = new PlanStepId(Guid.NewGuid()),
+        Status = status,
+        Output = output
+    };
+
+    private void PlanEndsWithStates(
+        StepExecutionStatus finalStatus, IReadOnlyList<StepExecutionState> stepStates) =>
+        _planRunExecutor
+            .Setup(e => e.ExecuteAsync(It.IsAny<PlanRunRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<PlanExecutionSummary>.Success(new PlanExecutionSummary
+            {
+                PlanId = new PlanId(Guid.NewGuid()),
+                FinalStatus = finalStatus,
+                TotalDuration = TimeSpan.FromSeconds(1),
+                StepStates = stepStates
+            }));
+
+    [Fact]
     public async Task AnExecutorThatCouldNotRunThePlan_IsAFailedResultRatherThanAnOutcome()
     {
         // The distinction the return type exists for: "I ran it and it ended this way" is not the same

--- a/src/Content/Tests/Presentation.ExecutionApi.Tests/HeaderIdentityAuthenticationHandler.cs
+++ b/src/Content/Tests/Presentation.ExecutionApi.Tests/HeaderIdentityAuthenticationHandler.cs
@@ -21,6 +21,15 @@ internal sealed class HeaderIdentityAuthenticationHandler : AuthenticationHandle
     /// <summary>Mints two conflicting <c>oid</c> claims — an authenticated but unresolvable caller.</summary>
     public const string AmbiguousHeader = "X-Test-Ambiguous";
 
+    /// <summary>
+    /// Mints the caller's approver identity, under the claim <c>EscalationConfig.ApproverClaimType</c>
+    /// selects by default. Separate from <see cref="UserHeader"/> on purpose: ownership and roster
+    /// identity are different claims that resolve to different strings for the same person, and a test
+    /// harness that conflated them would hide the mismatch that makes a self-approval check silently
+    /// match nothing.
+    /// </summary>
+    public const string ApproverHeader = "X-Test-Approver";
+
     public HeaderIdentityAuthenticationHandler(
         IOptionsMonitor<AuthenticationSchemeOptions> options,
         ILoggerFactory logger,
@@ -49,6 +58,10 @@ internal sealed class HeaderIdentityAuthenticationHandler : AuthenticationHandle
         var tid = Request.Headers[TenantHeader].ToString();
         if (!string.IsNullOrEmpty(tid))
             claims.Add(new Claim("tid", tid));
+
+        var approver = Request.Headers[ApproverHeader].ToString();
+        if (!string.IsNullOrEmpty(approver))
+            claims.Add(new Claim("preferred_username", approver));
 
         return Task.FromResult(Success(claims));
     }

--- a/src/Content/Tests/Presentation.ExecutionApi.Tests/WorkflowRequests.cs
+++ b/src/Content/Tests/Presentation.ExecutionApi.Tests/WorkflowRequests.cs
@@ -29,6 +29,20 @@ internal static class WorkflowRequests
         configuration = new { type = "sub_plan", childWorkflowId }
     };
 
+    /// <summary>A human-gate step naming <paramref name="approvers"/>.</summary>
+    internal static object GateStep(string name, params string[] approvers) => new
+    {
+        name,
+        type = "HumanGate",
+        configuration = new
+        {
+            type = "human_gate",
+            escalationMessage = "approve the spend",
+            approvalStrategy = "AnyOf",
+            approvers
+        }
+    };
+
     /// <summary>A workflow definition wrapping <paramref name="steps"/> and optional <paramref name="edges"/>.</summary>
     internal static object Definition(object[] steps, object[]? edges = null, string name = "test-workflow") => new
     {

--- a/src/Content/Tests/Presentation.ExecutionApi.Tests/WorkflowRunsIntegrationTests.cs
+++ b/src/Content/Tests/Presentation.ExecutionApi.Tests/WorkflowRunsIntegrationTests.cs
@@ -177,4 +177,72 @@ public sealed class WorkflowRunsIntegrationTests
 
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
     }
+
+    [Fact]
+    public async Task CancellingARun_StopsItAndReportsWhatItAchieved()
+    {
+        // Route binding and the response's wire shape are only reachable over HTTP. The handler tests
+        // prove the decisions; this proves a caller can actually make them, and reads back the run to
+        // confirm the cancellation is what the status endpoint reports rather than merely what the
+        // cancel call claimed.
+        using var factory = CreateFactory();
+        using var client = factory.CreateClient();
+
+        var workflowId = await SubmitWorkflowAsync(client, "alice");
+
+        var started = await client.SendAsync(
+            Request(HttpMethod.Post, $"/api/workflows/{workflowId}/runs", body: null, "alice"));
+        var jobId = (await started.Content.ReadFromJsonAsync<JsonElement>()).GetProperty("jobId").GetString();
+
+        var cancelled = await client.SendAsync(
+            Request(HttpMethod.Delete, $"/api/workflows/{workflowId}/runs/{jobId}", body: null, "alice"));
+
+        cancelled.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var body = await cancelled.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("jobId").GetString().Should().Be(jobId);
+        body.GetProperty("withdrawnApprovals").GetInt32().Should().Be(
+            0, "this workflow has no gate, so there was nothing to withdraw");
+
+        // A single-step workflow may already have run to completion, in which case cancelling is a
+        // conflict rather than a stop — so this asserts what is true either way: whatever the run's
+        // final state, it is terminal and the cancel call did not leave it live.
+        var polled = await client.SendAsync(
+            Request(HttpMethod.Get, $"/api/workflows/{workflowId}/runs/{jobId}", body: null, "alice"));
+        polled.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task CancellingAnotherCallersRun_Is404AndDoesNotStopIt()
+    {
+        // Cancelling raises the stakes of the ownership rule every run endpoint follows: an endpoint
+        // that distinguished "not yours" from "not there" would hand one caller a way to stop
+        // another's work by guessing identifiers.
+        using var factory = CreateFactory();
+        using var client = factory.CreateClient();
+
+        var workflowId = await SubmitWorkflowAsync(client, "alice");
+        var started = await client.SendAsync(
+            Request(HttpMethod.Post, $"/api/workflows/{workflowId}/runs", body: null, "alice"));
+        var jobId = (await started.Content.ReadFromJsonAsync<JsonElement>()).GetProperty("jobId").GetString();
+
+        var response = await client.SendAsync(
+            Request(HttpMethod.Delete, $"/api/workflows/{workflowId}/runs/{jobId}", body: null, "mallory"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task CancellingAJobIdThatWasNeverIssued_Is404()
+    {
+        using var factory = CreateFactory();
+        using var client = factory.CreateClient();
+
+        var workflowId = await SubmitWorkflowAsync(client, "alice");
+
+        var response = await client.SendAsync(
+            Request(HttpMethod.Delete, $"/api/workflows/{workflowId}/runs/never-issued", body: null, "alice"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
 }

--- a/src/Content/Tests/Presentation.ExecutionApi.Tests/WorkflowRunsIntegrationTests.cs
+++ b/src/Content/Tests/Presentation.ExecutionApi.Tests/WorkflowRunsIntegrationTests.cs
@@ -197,16 +197,24 @@ public sealed class WorkflowRunsIntegrationTests
         var cancelled = await client.SendAsync(
             Request(HttpMethod.Delete, $"/api/workflows/{workflowId}/runs/{jobId}", body: null, "alice"));
 
-        cancelled.StatusCode.Should().Be(HttpStatusCode.OK);
+        // Two honest outcomes, decided by whether this single-step run finished first: it is stopped,
+        // or it had already ended and cancelling is a conflict. Asserting only one would either flake
+        // or quietly pass for the wrong reason, so this pins the pair and then checks the answer is
+        // well-formed for whichever arrived — which is what proves the route and its wire shape.
+        cancelled.StatusCode.Should().BeOneOf(HttpStatusCode.OK, HttpStatusCode.Conflict);
 
-        var body = await cancelled.Content.ReadFromJsonAsync<JsonElement>();
-        body.GetProperty("jobId").GetString().Should().Be(jobId);
-        body.GetProperty("withdrawnApprovals").GetInt32().Should().Be(
-            0, "this workflow has no gate, so there was nothing to withdraw");
+        if (cancelled.StatusCode == HttpStatusCode.OK)
+        {
+            var body = await cancelled.Content.ReadFromJsonAsync<JsonElement>();
+            body.GetProperty("jobId").GetString().Should().Be(jobId);
+            body.GetProperty("withdrawnApprovals").GetInt32().Should().Be(
+                0, "this workflow has no gate, so there was nothing to withdraw");
+            body.TryGetProperty("stopped", out _).Should().BeTrue(
+                "the caller has to be able to tell a stop from a request to stop");
+        }
 
-        // A single-step workflow may already have run to completion, in which case cancelling is a
-        // conflict rather than a stop — so this asserts what is true either way: whatever the run's
-        // final state, it is terminal and the cancel call did not leave it live.
+        // True either way, and the property that matters: the run is readable and the cancel call did
+        // not leave it in a state the status endpoint cannot answer for.
         var polled = await client.SendAsync(
             Request(HttpMethod.Get, $"/api/workflows/{workflowId}/runs/{jobId}", body: null, "alice"));
         polled.StatusCode.Should().Be(HttpStatusCode.OK);

--- a/src/Content/Tests/Presentation.ExecutionApi.Tests/WorkflowsControllerIntegrationTests.cs
+++ b/src/Content/Tests/Presentation.ExecutionApi.Tests/WorkflowsControllerIntegrationTests.cs
@@ -2,7 +2,9 @@ using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
 using FluentAssertions;
+using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 using static Presentation.ExecutionApi.Tests.WorkflowRequests;
 
@@ -253,6 +255,111 @@ public sealed class WorkflowsControllerIntegrationTests : IClassFixture<WebAppli
 
         accepted.StatusCode.Should().Be(HttpStatusCode.Created);
         rejected.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    /// <summary>
+    /// A host with <paramref name="variables"/> applied <em>and</em> the header-identity scheme
+    /// mounted, so a test can be a specific caller.
+    /// </summary>
+    /// <remarks>
+    /// Both halves have to happen inside one lock. The environment overrides are only visible during
+    /// the eager configuration read at startup, and <c>WithWebHostBuilder</c> returns a factory that
+    /// has not started yet — so applying them separately would boot the identity-bearing host after the
+    /// variables had already been cleared.
+    /// </remarks>
+    private static WebApplicationFactory<Program> CreateIdentityFactoryWith(Dictionary<string, string?> variables)
+    {
+        lock (EnvironmentLock)
+        {
+            foreach (var (key, value) in variables)
+                Environment.SetEnvironmentVariable(key, value);
+
+            var factory = new WebApplicationFactory<Program>().WithWebHostBuilder(builder =>
+                builder.ConfigureServices(services => services
+                    .AddAuthentication(HeaderIdentityAuthenticationHandler.SchemeName)
+                    .AddScheme<AuthenticationSchemeOptions, HeaderIdentityAuthenticationHandler>(
+                        HeaderIdentityAuthenticationHandler.SchemeName, _ => { })));
+            try
+            {
+                _ = factory.Server; // Force startup while the overrides are visible.
+                return factory;
+            }
+            catch
+            {
+                factory.Dispose();
+                throw;
+            }
+            finally
+            {
+                foreach (var key in variables.Keys)
+                    Environment.SetEnvironmentVariable(key, null);
+            }
+        }
+    }
+
+    /// <summary>A client acting as <c>dave@contoso.com</c>, whose owner id is a different string.</summary>
+    private static HttpClient DaveClient(WebApplicationFactory<Program> factory)
+    {
+        var client = factory.CreateClient();
+        client.DefaultRequestHeaders.Add(HeaderIdentityAuthenticationHandler.UserHeader, "dave-oid");
+        client.DefaultRequestHeaders.Add(HeaderIdentityAuthenticationHandler.ApproverHeader, "dave@contoso.com");
+        return client;
+    }
+
+    [Fact]
+    public async Task Submit_HumanGate_WhenTheHostNamesNoApprovers_IsRefused()
+    {
+        // The shipped default. Nothing in the request is wrong — the gate is well-formed, names a
+        // plausible person, and the caller has a perfectly good identity — but a host that has not said
+        // who may approve things has said that nothing may be approved.
+        using var host = CreateIdentityFactoryWith([]);
+        using var client = DaveClient(host);
+
+        var response = await client.PostAsJsonAsync(
+            "/api/workflows", Definition([GateStep("gate", "alice@contoso.com")]));
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task Submit_HumanGate_NamingAPermittedApprover_IsAccepted()
+    {
+        // The end-to-end proof that the controller actually resolves the submitter's approver identity
+        // from the token and hands it to the validator. Everything else about this rule is unit-tested;
+        // what no unit test can establish is that the wiring exists at all — and its absence would
+        // refuse every gate ever submitted, on a host whose operator had configured a roster.
+        using var host = CreateIdentityFactoryWith(new Dictionary<string, string?>
+        {
+            ["AppConfig__AI__WorkflowSubmission__PermittedApprovers__0"] = "alice@contoso.com"
+        });
+
+        using var client = DaveClient(host);
+
+        var response = await client.PostAsJsonAsync(
+            "/api/workflows", Definition([GateStep("gate", "alice@contoso.com")]));
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+    }
+
+    [Fact]
+    public async Task Submit_HumanGate_NamingItsOwnSubmitter_IsRefused()
+    {
+        // The same host and the same caller as the accepted case above; the only difference is that
+        // the gate names the caller. A gate its author can answer is not an approval, and the identity
+        // being compared comes from the token — which is what this proves, since nothing in the request
+        // body says who is submitting.
+        using var host = CreateIdentityFactoryWith(new Dictionary<string, string?>
+        {
+            ["AppConfig__AI__WorkflowSubmission__PermittedApprovers__0"] = "alice@contoso.com",
+            ["AppConfig__AI__WorkflowSubmission__PermittedApprovers__1"] = "dave@contoso.com"
+        });
+
+        using var client = DaveClient(host);
+
+        var response = await client.PostAsJsonAsync(
+            "/api/workflows", Definition([GateStep("gate", "alice@contoso.com", "dave@contoso.com")]));
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
     }
 
     [Fact]


### PR DESCRIPTION
The last wave of the external-trigger API program. A workflow can now contain a human approval gate, pause on it, and carry on when someone answers — under the same job id it was submitted with.

## The gap this closes

Every part of the approval machinery already existed and worked. A gate raised an approval request and parked its step; the plan executor knew how to reconcile a parked step against a verdict on its next execution; the approval endpoints were live. **Nothing asked for that next execution.** Approve a gate and nothing happened, ever, until the run was eventually given up on.

Two findings while building it:

- **The wire contract documented a restriction the code never had.** `HumanGateStepConfiguration` said gates were "rejected at submission until the answering surface exists". No validator ever did that. Gates were accepted, parked, and hung.
- **Therefore a live bug, not a latent one.** `RunStatus.Blocked` satisfied `IsTerminal`, so a parked run *released its workflow* — a second run could start against the same plan state machine and answer the first one's gate.

## What ships

**A parked run stays live** (`c3677875`). `IsTerminal` is now `not (Queued or Running or Blocked)`, which is what keeps the workflow locked. Parking is split from finishing: no `CompletedAt`, no `Error`, no `RunFinished`. A new `PARKED` SSE frame releases watchers without claiming the run ended — a stream left open for an approver who takes days holds a connection and a slot for all of it. `MaxParkedRunDuration` (7d) bounds an unanswered gate, and **fails** rather than deletes the run, because a caller coming back is owed an answer.

**Answering re-queues the run** (`9899ba9a`). A parked run records the escalations it awaits, lifted from the plan's blocked steps by `WorkflowRunKindExecutor` rather than rediscovered by a reader walking the planner's state. `ParkedRunResumeService` re-reads those verdicts and returns the run to the queue via an atomic `TryResume`.

*Re-reading on a clock, not reacting to an event* — a verdict reached while the host is down, or on another instance, is lost to an in-process event, and the latency is measured against a wait that was already however long a person took. *A denial resumes too*: the plan must re-enter execution for the gate to fail and the run to end.

**Cancelling withdraws the approval** (`1e43a5d9`). There was no cancel surface at all — the cooperative registry existed but nothing outside the process reached it. `DELETE /api/workflows/{id}/runs/{jobId}` now does, and takes the pending gate with it: an approval outliving its run is answerable by someone who cannot know it is moot, and because plan state outlives any one run, that verdict lands on the next one.

The run is stopped **before** its approvals are withdrawn — the other order resolves the escalation while the run is still parked on it, which is exactly what the resume check watches for. A run already executing is *signalled*, not rewritten; the response says which happened, because a caller told its work stopped would start a replacement and be refused.

**Only then, the door** (`42557d83`). Approvers must come from `PermittedApprovers`, which ships empty — a host that has not said who may approve has said nothing may be approved. And the submitter may not name itself: a gate its author can answer is not an approval, though the audit shows a human decided. That check compares the **approver** identity from the token, not the owner id — they are different strings for the same person, and comparing them would match nothing while appearing to work.

## Review rounds

Three, each smaller than the last:

1. The parked-run ceiling failed a run **without** withdrawing its approval — the same hazard the cancel path exists to prevent, and sharper, because failing the run unlocks the workflow. Both give-up paths now share one `ApprovalWithdrawal`.
2. Withdrawal ran on the caller's cancellation token (a hangup stranded approvals with nothing to retry them); the resume compensator wrote back unguarded (could resurrect a run cancelled in the window); `GetApproverNameOrNull` lacked the `IsAuthenticated` guard its sibling has.
3. A null approver list 500'd the admission path — two of the four dereference sites predated this wave.

## Deliberately not fixed, disclosed instead

A run's grant is **not** re-evaluated when it resumes, so a workflow parked for up to `MaxParkedRunDuration` continues under the grant its submitter held when it started. Re-resolving needs a credential to resolve *from*, and by then there is no request and no principal. It is a ceiling on what that caller could already do, and the window is operator-bounded. Now in `RunRecord`'s own docs.

## Verification

- **9,148 tests, 0 failures.** Full-suite runs show the documented pre-existing load flake (a different set each run — `StructuredJsonLoggerProvider`, `ProcessSandboxEnvironmentIsolation`, `AgentFactoryToolSpan`); all pass in isolation and this branch touches none of that code.
- **43 mutations applied, all killed.** Two of my own tests failed that bar first time and were rewritten — one was passing for an accidental reason.
- Local gates all pass, **including the security review, which had to be forced**: its path filter selects by folder name and does not select this branch, though the wave changes an authorization rule. That is now six consecutive PRs it has skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)