### PR TITLE
fix: trigger the security gate on what the diff contains, not folder names

### DIFF
--- a/.github/RAILS.md
+++ b/.github/RAILS.md
@@ -13,7 +13,7 @@ them live, and how to prove they actually catch things.
 | --- | --- | --- | --- |
 | **build-and-test** | `workflows/ci.yml` | every PR | **Blocks** (hard gate) |
 | **OWASP Agentic Top-10 Gate** | `workflows/ci.yml` | every PR | **Blocks** (hard gate) |
-| **security-review** | `workflows/security-review.yml` | every PR; reviews on gated paths / `risk:high` | **Blocks on HIGH** |
+| **security-review** | `workflows/security-review.yml` | every PR; reviews when the diff contains security-relevant code, touches a gated path, or carries `risk:high` | **Blocks on HIGH** |
 | **correctness-review** | `workflows/correctness-review.yml` | ~~every PR~~ — **workflow disabled** | Run locally instead (see below) |
 | **grader** | `workflows/grader.yml` | ~~every PR~~ — **workflow disabled** | Run locally instead (see below) |
 | **docs-drift** | `workflows/docs-drift-check.yml` | ~~push to main~~ — **workflow disabled** | Run locally instead (see below) |
@@ -28,8 +28,12 @@ them live, and how to prove they actually catch things.
 >
 > **security-review stays enabled and required.** It is deliberately the exception: it is a
 > required status check in the ruleset (disabling it would wedge every PR on a check that never
-> reports), and its expensive step only fires when the diff touches a gated path, so it costs
-> little in practice. The honest consequence of the other three being off is that correctness
+> reports), and its expensive step only fires when the diff is actually security-relevant. With
+> the other three rails off it is the only remote review that runs, which is exactly why its
+> trigger was widened from folder names to diff content — see
+> `.github/scripts/security-gate-scope.sh`. Expect it to fire on most `src/**` PRs in this repo
+> and to cost accordingly; that is the intended trade, not a misconfiguration.
+> The honest consequence of the other three being off is that correctness
 > and doc-drift coverage is now on the honour system — nothing verifies a developer ran the
 > local gate. Treat that as a deliberate, reversible trade, not as those gates being retired.
 
@@ -145,9 +149,11 @@ Before trusting these, force each one to fail and confirm it's caught:
   turn. The Stop hook must refuse and hand back the build error.
 - **grader** — open a PR whose description claims something the diff does not do.
   The grader's comment must call out the mismatch.
-- **security-review** — open a throwaway PR touching a gated path (e.g. add a
-  comment in a file under `**/Auth/`) with a planted HIGH issue. The check must
-  go red. Close it unmerged.
+- **security-review** — open a throwaway PR with a planted HIGH issue, either on a
+  gated path (a comment in a file under `**/Auth/`) or on the content signal (any
+  `src/**` change touching `OwnerId`/`[Authorize]`). The check must go red. Close it
+  unmerged. `bash .github/scripts/security-gate-scope.test.sh` verifies the trigger
+  itself — including replaying the six PRs the old folder-only filter missed.
 - **correctness-review** — open a throwaway PR with a planted high-confidence
   defect under `src/` (e.g. an inverted null check or an off-by-one that drops a
   row). The check must go red with `CORRECTNESS_VERDICT: BLOCK`; then apply the

--- a/.github/scripts/security-gate-scope.sh
+++ b/.github/scripts/security-gate-scope.sh
@@ -32,9 +32,13 @@
 #
 # OUTPUT (key=value lines; `github` format also appends them to $GITHUB_OUTPUT)
 #   required=true|false   whether the reviewer must run
-#   trigger=path|content|none
+#   trigger=path|content|path+content|none
 #   reason=<one line, human-readable>
-#   signals=<comma-separated markers matched, empty when trigger=path>
+#   signals=<comma-separated markers matched; empty only when nothing matched>
+#
+# The two signals are additive: a diff can trigger on both, and the scope file is
+# then the UNION. Never make one branch suppress the other — see the comment on the
+# TRIGGER block for the hole that created.
 #
 # The matched files are written to the path given by SECURITY_SCOPE_FILE when set,
 # so the caller can point the reviewer at them instead of the whole diff.
@@ -73,7 +77,11 @@ CHANGED_FILES="$(git diff --name-only "$MERGE_BASE" "$HEAD_REF")"
 # Every segment is slash-anchored so it matches a whole directory component.
 # Keep in sync with .github/CODEOWNERS.
 # ---------------------------------------------------------------------------
-PATH_RE='(^\.github/|/Auth/|/Identity/|/Security/|/SecurityAttributes/|/Migrations/|^infra/)'
+# `scripts/rails/` is here because those scripts ARE the gates — a change to
+# run-gates.sh is a change to what gets reviewed, exactly like a change to
+# .github/. It is the only addition to the original list; everything else is
+# preserved verbatim, so this trigger can only widen, never narrow.
+PATH_RE='(^\.github/|^scripts/rails/|/Auth/|/Identity/|/Security/|/SecurityAttributes/|/Migrations/|^infra/)'
 
 # ---------------------------------------------------------------------------
 # Signal 2 — security-relevant code, by what the changed lines actually contain.
@@ -89,34 +97,75 @@ CONTENT_RE="${CONTENT_RE}"'|Jwt|Bearer|AccessToken|RefreshToken|SasToken|ApiKey|
 CONTENT_RE="${CONTENT_RE}"'|\[Http(Get|Post|Put|Delete|Patch)|MapGet\(|MapPost\(|MapDelete\(|UseCors|RateLimit'                               # externally reachable surface
 CONTENT_RE="${CONTENT_RE}"'|Sanitiz|Redact|Scrub)'                                                                                            # output safety
 
-# Added/removed lines only (drop the +++/--- file headers), restricted to shipped
-# source. Docs and scripts reach the gate through the path list when they matter.
-CHANGED_LINES="$(git diff "$MERGE_BASE" "$HEAD_REF" -- 'src/*' | grep -E '^[+-]' | grep -vE '^(\+\+\+|---)' || true)"
+# Prose is excluded from the content scan — a security guide legitimately says
+# "password" on every page. Everything else that ships or executes is scanned,
+# including scripts/ and the rails themselves, so a file is never in scope for the
+# gate but out of scope for the reviewer.
+# This script and its tests are excluded because they DEFINE the marker list rather
+# than use it: scanning them matches every marker at once and drowns the `signals`
+# output in noise. They still reach the reviewer through the path list above, which
+# is the stronger trigger anyway — so this exclusion cannot hide a change to them.
+scannable() {
+  printf '%s' "$CHANGED_FILES" \
+    | grep -vE '(^documentation/|\.md$|^\.github/scripts/security-gate-scope(\.test)?\.sh$)' || true
+}
 
-SIGNALS="$(printf '%s' "$CHANGED_LINES" | grep -oE "$CONTENT_RE" | sort -u | paste -sd, - 2>/dev/null || true)"
+# Added/removed lines only; the +++/--- file headers are not content.
+diff_lines() { # <pathspec...>
+  git diff "$MERGE_BASE" "$HEAD_REF" -- "$@" | grep -E '^[+-]' | grep -vE '^(\+\+\+|---)' || true
+}
+
+SCANNABLE_FILES="$(scannable)"
+SIGNALS=""
+if [ -n "$SCANNABLE_FILES" ]; then
+  # shellcheck disable=SC2046 — the file list is git output, one path per line.
+  SIGNALS="$(printf '%s\n' "$SCANNABLE_FILES" | tr '\n' '\0' | xargs -0 -r git diff "$MERGE_BASE" "$HEAD_REF" -- \
+    | grep -E '^[+-]' | grep -vE '^(\+\+\+|---)' | grep -oE "$CONTENT_RE" | sort -u | paste -sd, - || true)"
+fi
+
+PATH_FILES="$(printf '%s' "$CHANGED_FILES" | grep -E "$PATH_RE" || true)"
+
+# The two signals are ADDITIVE, never exclusive. An earlier draft made the path
+# branch an `elif`, so a PR touching one .github/ file plus src/ tenant-scoping code
+# was handed a scope file naming only the .github file — and the reviewer is told to
+# start there. That is a hole big enough to walk an owner-check regression through,
+# and this very change was an instance of it. Compute both, union the file lists.
+CONTENT_FILES=""
+if [ -n "$SIGNALS" ]; then
+  # Name the files whose OWN changed lines carry a marker, so the reviewer reads the
+  # security-relevant part of a large diff first rather than end to end.
+  while IFS= read -r f; do
+    [ -n "$f" ] || continue
+    if diff_lines "$f" | grep -qE "$CONTENT_RE"; then
+      CONTENT_FILES="${CONTENT_FILES}${f}"$'\n'
+    fi
+  done <<EOF
+$SCANNABLE_FILES
+EOF
+fi
 
 REQUIRED=false
 TRIGGER=none
 REASON="no gated path and no security-relevant code changed"
-SCOPED_FILES=""
 
-if printf '%s' "$CHANGED_FILES" | grep -Eq "$PATH_RE"; then
-  REQUIRED=true
-  TRIGGER=path
-  SCOPED_FILES="$(printf '%s' "$CHANGED_FILES" | grep -E "$PATH_RE" || true)"
-  REASON="gated path changed (auth/identity/security/migrations/.github/infra)"
-  SIGNALS=""
+if [ -n "$PATH_FILES" ] && [ -n "$SIGNALS" ]; then
+  REQUIRED=true; TRIGGER="path+content"
+  REASON="gated path changed AND security-relevant code changed"
+elif [ -n "$PATH_FILES" ]; then
+  REQUIRED=true; TRIGGER="path"
+  REASON="gated path changed (auth/identity/security/migrations/.github/rails/infra)"
 elif [ -n "$SIGNALS" ]; then
-  REQUIRED=true
-  TRIGGER=content
-  # Name the files whose own changed lines carry a marker, so the reviewer reads
-  # the security-relevant part of a large diff rather than all of it.
-  for f in $(printf '%s' "$CHANGED_FILES" | grep -E '^src/.*\.(cs|csproj|json|props|targets)$' || true); do
-    if git diff "$MERGE_BASE" "$HEAD_REF" -- "$f" | grep -E '^[+-]' | grep -vE '^(\+\+\+|---)' | grep -qE "$CONTENT_RE"; then
-      SCOPED_FILES="${SCOPED_FILES}${f}"$'\n'
-    fi
-  done
-  REASON="security-relevant code changed under src/"
+  REQUIRED=true; TRIGGER="content"
+  REASON="security-relevant code changed"
+fi
+
+SCOPED_FILES="$(printf '%s\n%s\n' "$PATH_FILES" "$CONTENT_FILES" | grep -E . | sort -u || true)"
+
+# A scope file must never say "nothing" while the gate says "review this". If the
+# union came out empty despite a trigger, hand over the whole diff — an over-wide
+# scope costs turns; an empty one reads as "there is nothing here".
+if [ "$REQUIRED" = "true" ] && [ -z "$SCOPED_FILES" ]; then
+  SCOPED_FILES="$CHANGED_FILES"
 fi
 
 if [ -n "${SECURITY_SCOPE_FILE:-}" ]; then

--- a/.github/scripts/security-gate-scope.sh
+++ b/.github/scripts/security-gate-scope.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# Decides whether the security reviewer must run for a diff, and what it should look at.
+#
+# WHY THIS FILE EXISTS
+# --------------------
+# The gate used to select purely by FOLDER NAME (/Auth/, /Identity/, /Security/,
+# /Migrations/, .github/, infra/). That filter skipped six consecutive PRs — #203,
+# #205, #207, #208, #209, #210 — every one of which changed authorization,
+# multi-tenant scoping, or capability-envelope code. It has also been observed
+# missing two HIGH findings in a single day. A gate that does not fire on the
+# changes it exists to review is not a gate.
+#
+# Folder names describe where code lives, not what it does. This repo keeps its
+# security-critical logic in Controllers/, Runs/, Planner/ and Interfaces/ — so the
+# decision is made on what the diff SAYS, with the old path list kept as a
+# supplement (a migration or a workflow file is worth reviewing whatever it says).
+#
+# SINGLE AUTHORITY
+# ----------------
+# Both callers — .github/workflows/security-review.yml (remote, blocking) and
+# scripts/rails/run-gates.sh (local pre-flight) — call this script. They previously
+# carried duplicate copies of the regex under a "keep in sync" comment, which is the
+# drift trap this repo has closed elsewhere (ApproverClaimTypes, EscalationStepOutput,
+# ConditionExpressionRules). One definition, two readers.
+#
+# USAGE
+#   security-gate-scope.sh --base <ref> [--head <ref>] [--format github|human]
+#
+# `--head` defaults to HEAD. It exists so the decision can be replayed against any
+# historical commit without checking it out — which is how the test harness proves
+# the gate fires on the PRs it used to miss.
+#
+# OUTPUT (key=value lines; `github` format also appends them to $GITHUB_OUTPUT)
+#   required=true|false   whether the reviewer must run
+#   trigger=path|content|none
+#   reason=<one line, human-readable>
+#   signals=<comma-separated markers matched, empty when trigger=path>
+#
+# The matched files are written to the path given by SECURITY_SCOPE_FILE when set,
+# so the caller can point the reviewer at them instead of the whole diff.
+#
+# EXIT CODES
+#   0  decision made (read `required`)
+#   2  usage error or the diff could not be computed — callers must FAIL CLOSED.
+
+set -euo pipefail
+
+BASE_REF=""
+HEAD_REF="HEAD"
+FORMAT="human"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --base)   BASE_REF="${2:-}"; shift 2 ;;
+    --head)   HEAD_REF="${2:-HEAD}"; shift 2 ;;
+    --format) FORMAT="${2:-human}"; shift 2 ;;
+    -h|--help) sed -n '1,40p' "$0"; exit 0 ;;
+    *) echo "security-gate-scope: unknown argument '$1'" >&2; exit 2 ;;
+  esac
+done
+
+[ -n "$BASE_REF" ] || { echo "security-gate-scope: --base <ref> is required" >&2; exit 2; }
+
+# Three-dot semantics: compare against the merge-base, so commits that landed on the
+# base branch after this one forked are not attributed to this diff.
+MERGE_BASE="$(git merge-base "$BASE_REF" "$HEAD_REF" 2>/dev/null || true)"
+[ -n "$MERGE_BASE" ] || { echo "security-gate-scope: no merge-base between '$BASE_REF' and '$HEAD_REF'" >&2; exit 2; }
+
+CHANGED_FILES="$(git diff --name-only "$MERGE_BASE" "$HEAD_REF")"
+
+# ---------------------------------------------------------------------------
+# Signal 1 — paths that are worth reviewing whatever their contents say.
+# Every segment is slash-anchored so it matches a whole directory component.
+# Keep in sync with .github/CODEOWNERS.
+# ---------------------------------------------------------------------------
+PATH_RE='(^\.github/|/Auth/|/Identity/|/Security/|/SecurityAttributes/|/Migrations/|^infra/)'
+
+# ---------------------------------------------------------------------------
+# Signal 2 — security-relevant code, by what the changed lines actually contain.
+#
+# Grouped by the risk each marker stands for. Markers are deliberately specific:
+# a bare `Token` would match every CancellationToken in the codebase and fire on
+# everything, which degrades to the same uselessness as never firing at all.
+# ---------------------------------------------------------------------------
+CONTENT_RE='(\[Authorize|AllowAnonymous|ClaimsPrincipal|RequireClaim|AuthenticationScheme|AuthorizationPolicy|IAuthorizationHandler'          # authn/authz
+CONTENT_RE="${CONTENT_RE}"'|OwnerId|TenantId|KnowledgeScope|VisibleTo|WritableBy'                                                             # scope isolation — this repo's recurring defect class
+CONTENT_RE="${CONTENT_RE}"'|CapabilityEnvelope|AutonomyLevel|AllowedTools|DeniedTools|Sandbox|GovernanceTrace|PermittedApprovers|Approver'    # capability + governance
+CONTENT_RE="${CONTENT_RE}"'|Jwt|Bearer|AccessToken|RefreshToken|SasToken|ApiKey|Password|Secret|Hmac|Sha256|RandomNumberGenerator'            # credentials + crypto
+CONTENT_RE="${CONTENT_RE}"'|\[Http(Get|Post|Put|Delete|Patch)|MapGet\(|MapPost\(|MapDelete\(|UseCors|RateLimit'                               # externally reachable surface
+CONTENT_RE="${CONTENT_RE}"'|Sanitiz|Redact|Scrub)'                                                                                            # output safety
+
+# Added/removed lines only (drop the +++/--- file headers), restricted to shipped
+# source. Docs and scripts reach the gate through the path list when they matter.
+CHANGED_LINES="$(git diff "$MERGE_BASE" "$HEAD_REF" -- 'src/*' | grep -E '^[+-]' | grep -vE '^(\+\+\+|---)' || true)"
+
+SIGNALS="$(printf '%s' "$CHANGED_LINES" | grep -oE "$CONTENT_RE" | sort -u | paste -sd, - 2>/dev/null || true)"
+
+REQUIRED=false
+TRIGGER=none
+REASON="no gated path and no security-relevant code changed"
+SCOPED_FILES=""
+
+if printf '%s' "$CHANGED_FILES" | grep -Eq "$PATH_RE"; then
+  REQUIRED=true
+  TRIGGER=path
+  SCOPED_FILES="$(printf '%s' "$CHANGED_FILES" | grep -E "$PATH_RE" || true)"
+  REASON="gated path changed (auth/identity/security/migrations/.github/infra)"
+  SIGNALS=""
+elif [ -n "$SIGNALS" ]; then
+  REQUIRED=true
+  TRIGGER=content
+  # Name the files whose own changed lines carry a marker, so the reviewer reads
+  # the security-relevant part of a large diff rather than all of it.
+  for f in $(printf '%s' "$CHANGED_FILES" | grep -E '^src/.*\.(cs|csproj|json|props|targets)$' || true); do
+    if git diff "$MERGE_BASE" "$HEAD_REF" -- "$f" | grep -E '^[+-]' | grep -vE '^(\+\+\+|---)' | grep -qE "$CONTENT_RE"; then
+      SCOPED_FILES="${SCOPED_FILES}${f}"$'\n'
+    fi
+  done
+  REASON="security-relevant code changed under src/"
+fi
+
+if [ -n "${SECURITY_SCOPE_FILE:-}" ]; then
+  printf '%s\n' "$SCOPED_FILES" | grep -E . > "$SECURITY_SCOPE_FILE" || : > "$SECURITY_SCOPE_FILE"
+fi
+
+emit() {
+  printf 'required=%s\n' "$REQUIRED"
+  printf 'trigger=%s\n' "$TRIGGER"
+  printf 'reason=%s\n' "$REASON"
+  printf 'signals=%s\n' "$SIGNALS"
+}
+
+emit
+if [ "$FORMAT" = "github" ] && [ -n "${GITHUB_OUTPUT:-}" ]; then
+  emit >> "$GITHUB_OUTPUT"
+fi

--- a/.github/scripts/security-gate-scope.sh
+++ b/.github/scripts/security-gate-scope.sh
@@ -67,6 +67,12 @@ done
 
 # Three-dot semantics: compare against the merge-base, so commits that landed on the
 # base branch after this one forked are not attributed to this diff.
+# core.quotePath=false on every invocation: git otherwise emits non-ASCII paths
+# octal-escaped and quoted ("cafÃ©.cs"), and feeding that back as a pathspec
+# matches nothing — a file named Order.cs with an accent would change OwnerId
+# scoping and raise no signal at all.
+git() { command git -c core.quotePath=false "$@"; }
+
 MERGE_BASE="$(git merge-base "$BASE_REF" "$HEAD_REF" 2>/dev/null || true)"
 [ -n "$MERGE_BASE" ] || { echo "security-gate-scope: no merge-base between '$BASE_REF' and '$HEAD_REF'" >&2; exit 2; }
 

--- a/.github/scripts/security-gate-scope.test.sh
+++ b/.github/scripts/security-gate-scope.test.sh
@@ -21,12 +21,39 @@ decide() { # <base> <head> -> prints "required=.. trigger=.."
   bash "$SCRIPT" --base "$1" --head "$2" 2>/dev/null | tr '\n' ' '
 }
 
+scope_of() { # <base> <head> -> the scope file's contents
+  local out
+  out="$(mktemp 2>/dev/null || echo "${TEMP:-/tmp}/sgs-scope.$$")"
+  SECURITY_SCOPE_FILE="$out" bash "$SCRIPT" --base "$1" --head "$2" >/dev/null 2>&1
+  cat "$out"; rm -f "$out"
+}
+
+expect_scope_contains() { # <label> <base> <head> <path-substring>
+  local label="$1" base="$2" head="$3" want="$4"
+  if scope_of "$base" "$head" | grep -qF "$want"; then
+    printf '  PASS  %-58s scope includes %s\n' "$label" "$want"; PASS=$((PASS+1))
+  else
+    printf '  FAIL  %-58s scope MISSING %s\n' "$label" "$want"; FAIL=$((FAIL+1))
+  fi
+}
+
+expect_scope_nonempty() { # <label> <base> <head>
+  local label="$1" base="$2" head="$3"
+  if [ -n "$(scope_of "$base" "$head")" ]; then
+    printf '  PASS  %-58s scope is non-empty\n' "$label"; PASS=$((PASS+1))
+  else
+    printf '  FAIL  %-58s scope is EMPTY while required=true\n' "$label"; FAIL=$((FAIL+1))
+  fi
+}
+
 expect() { # <label> <expected-required> <expected-trigger> <base> <head>
   local label="$1" want_req="$2" want_trig="$3" base="$4" head="$5"
   local out req trig
   out="$(decide "$base" "$head")"
   req="$(printf '%s' "$out" | grep -oE 'required=[a-z]+' | cut -d= -f2)"
-  trig="$(printf '%s' "$out" | grep -oE 'trigger=[a-z]+' | cut -d= -f2)"
+  # [a-z+] — the combined trigger is literally "path+content"; a [a-z]+ class
+  # truncates it to "path" and the assertion silently compares the wrong string.
+  trig="$(printf '%s' "$out" | grep -oE 'trigger=[a-z+]+' | cut -d= -f2)"
   if [ "$req" = "$want_req" ] && [ "$trig" = "$want_trig" ]; then
     printf '  PASS  %-58s required=%s trigger=%s\n' "$label" "$req" "$trig"; PASS=$((PASS+1))
   else
@@ -52,10 +79,13 @@ for pr in 203 205 207 208 209 210; do
 done
 
 echo
-echo "REPLAY — a PR the path filter already caught (must stay a path trigger):"
+# #199 changed gated paths AND security-relevant code. Under the old exclusive
+# branching it reported `path` and its src/ files never reached the scope file;
+# reporting `path+content` is the fix, not a regression.
+echo "REPLAY — a PR the path filter already caught (must keep firing):"
 head="$(pr_head 199)"; base="$(pr_base 199)"
 if [ -n "$head" ] && [ -n "$base" ]; then
-  expect "#199 (touches gated paths)" true path "$base" "$head"
+  expect "#199 (gated paths + security-relevant code)" true "path+content" "$base" "$head"
 else
   echo "  SKIP  #199 (merge commit not found in this clone)"
 fi
@@ -97,6 +127,49 @@ if git worktree add --detach --quiet "$WORKTREE" HEAD 2>/dev/null; then
         "src/Content/Domain/Domain.AI/ScratchTest.cs" \
         "public sealed record ScratchTest { public string? OwnerId { get; init; } }" \
         true content
+
+  synth "TypeScript touching credentials (frontend is scanned too)" \
+        "src/Content/Presentation/agent-hub-ui/src/scratchTest.ts" \
+        "export const authHeader = (apiKey: string) => ({ Authorization: \`Bearer \${apiKey}\` });" \
+        true content
+
+  # REGRESSION — the HIGH the security reviewer found in the first draft of this
+  # script. A gated-path touch used to SUPPRESS the content scan, so a PR pairing a
+  # one-line .github/ edit with an owner-check change handed the reviewer a scope
+  # file naming only the .github file. Both signals must survive, and the scope file
+  # must be the union.
+  echo
+  echo "REGRESSION — a gated-path touch must not suppress the content signal:"
+  mkdir -p "$WORKTREE/src/Content/Domain/Domain.AI"
+  printf '%s\n' "public sealed record ScratchTest { public string? OwnerId { get; init; } }" \
+    > "$WORKTREE/src/Content/Domain/Domain.AI/ScratchTest.cs"
+  printf '%s\n' "# scratch" >> "$WORKTREE/.github/CODEOWNERS"
+  git -C "$WORKTREE" add -A >/dev/null 2>&1
+  git -C "$WORKTREE" -c user.email=t@t -c user.name=t commit -qm "test: path plus content" >/dev/null 2>&1
+  MIXED="$(git -C "$WORKTREE" rev-parse HEAD)"
+  expect "path + content together" true "path+content" "$BASE" "$MIXED"
+  expect_scope_contains "  scope keeps the gated path" "$BASE" "$MIXED" ".github/CODEOWNERS"
+  expect_scope_contains "  scope keeps the src file the reviewer must see" "$BASE" "$MIXED" "ScratchTest.cs"
+  git -C "$WORKTREE" reset -q --hard "$BASE" >/dev/null 2>&1
+
+  # The rails scripts ARE the gates — a change to one must be reviewed even though
+  # it carries no marker of its own (SECURITY_GATED is not a marker; the list is
+  # case-sensitive on purpose). This was the reviewer's example of a file in the
+  # diff but absent from the scope file.
+  printf '%s\n' "# scratch" >> "$WORKTREE/scripts/rails/run-gates.sh"
+  git -C "$WORKTREE" add -A >/dev/null 2>&1
+  git -C "$WORKTREE" -c user.email=t@t -c user.name=t commit -qm "test: rails script" >/dev/null 2>&1
+  RAILS="$(git -C "$WORKTREE" rev-parse HEAD)"
+  expect "a change to run-gates.sh is itself gated" true path "$BASE" "$RAILS"
+  expect_scope_contains "  scope names the rails script" "$BASE" "$RAILS" "scripts/rails/run-gates.sh"
+  git -C "$WORKTREE" reset -q --hard "$BASE" >/dev/null 2>&1
+
+  # A scope file must never be empty while the gate says review is required.
+  printf '%s\n' "# just a workflow comment" >> "$WORKTREE/.github/CODEOWNERS"
+  git -C "$WORKTREE" add -A >/dev/null 2>&1
+  git -C "$WORKTREE" -c user.email=t@t -c user.name=t commit -qm "test: path only" >/dev/null 2>&1
+  expect_scope_nonempty "path-only change still names files" "$BASE" "$(git -C "$WORKTREE" rev-parse HEAD)"
+  git -C "$WORKTREE" reset -q --hard "$BASE" >/dev/null 2>&1
 
   git worktree remove --force "$WORKTREE" >/dev/null 2>&1
 else

--- a/.github/scripts/security-gate-scope.test.sh
+++ b/.github/scripts/security-gate-scope.test.sh
@@ -128,6 +128,14 @@ if git worktree add --detach --quiet "$WORKTREE" HEAD 2>/dev/null; then
         "public sealed record ScratchTest { public string? OwnerId { get; init; } }" \
         true content
 
+  # git quotes non-ASCII paths by default, and the quoted form matches nothing when
+  # fed back as a pathspec — so an accented filename used to evade the content scan
+  # entirely. core.quotePath=false closes it.
+  synth "non-ASCII filename still raises its signal" \
+        "src/Content/Domain/Domain.AI/ScratchTést.cs" \
+        "public sealed record ScratchTest { public string? OwnerId { get; init; } }" \
+        true content
+
   synth "TypeScript touching credentials (frontend is scanned too)" \
         "src/Content/Presentation/agent-hub-ui/src/scratchTest.ts" \
         "export const authHeader = (apiKey: string) => ({ Authorization: \`Bearer \${apiKey}\` });" \

--- a/.github/scripts/security-gate-scope.test.sh
+++ b/.github/scripts/security-gate-scope.test.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# Proves security-gate-scope.sh fires on the changes it exists to review.
+#
+# Two kinds of case:
+#
+#   REPLAY  — a real merged PR, replayed by merge-base without checking it out.
+#             These are the regression tests that matter: every one of them is a
+#             PR the old folder-only filter let through unreviewed.
+#   SYNTHETIC — a scratch commit in a temp worktree, for the edge cases history
+#             does not happen to contain (docs-only, CancellationToken-only).
+#
+# Run: bash .github/scripts/security-gate-scope.test.sh
+
+set -uo pipefail
+cd "$(dirname "$0")/../.."
+
+SCRIPT=".github/scripts/security-gate-scope.sh"
+PASS=0; FAIL=0
+
+decide() { # <base> <head> -> prints "required=.. trigger=.."
+  bash "$SCRIPT" --base "$1" --head "$2" 2>/dev/null | tr '\n' ' '
+}
+
+expect() { # <label> <expected-required> <expected-trigger> <base> <head>
+  local label="$1" want_req="$2" want_trig="$3" base="$4" head="$5"
+  local out req trig
+  out="$(decide "$base" "$head")"
+  req="$(printf '%s' "$out" | grep -oE 'required=[a-z]+' | cut -d= -f2)"
+  trig="$(printf '%s' "$out" | grep -oE 'trigger=[a-z]+' | cut -d= -f2)"
+  if [ "$req" = "$want_req" ] && [ "$trig" = "$want_trig" ]; then
+    printf '  PASS  %-58s required=%s trigger=%s\n' "$label" "$req" "$trig"; PASS=$((PASS+1))
+  else
+    printf '  FAIL  %-58s got required=%s trigger=%s, want required=%s trigger=%s\n' \
+      "$label" "$req" "$trig" "$want_req" "$want_trig"; FAIL=$((FAIL+1))
+  fi
+}
+
+# A PR's diff is (first parent = main at merge time) .. (second parent = PR head).
+# Using the head's OWN parent instead would diff only the branch's last commit,
+# which silently under-reports every multi-commit PR.
+pr_merge() { git log origin/main --merges --format=%H --grep "Merge pull request #$1 " -n 1; }
+pr_base()  { git rev-parse "$(pr_merge "$1")^1" 2>/dev/null; }
+pr_head()  { git rev-parse "$(pr_merge "$1")^2" 2>/dev/null; }
+
+echo "REPLAY — PRs the folder-only filter skipped (all must now be reviewed):"
+for pr in 203 205 207 208 209 210; do
+  head="$(pr_head "$pr")"; base="$(pr_base "$pr")"
+  if [ -z "$head" ] || [ -z "$base" ]; then
+    printf '  SKIP  #%-4s (merge commit not found in this clone)\n' "$pr"; continue
+  fi
+  expect "#$pr" true content "$base" "$head"
+done
+
+echo
+echo "REPLAY — a PR the path filter already caught (must stay a path trigger):"
+head="$(pr_head 199)"; base="$(pr_base 199)"
+if [ -n "$head" ] && [ -n "$base" ]; then
+  expect "#199 (touches gated paths)" true path "$base" "$head"
+else
+  echo "  SKIP  #199 (merge commit not found in this clone)"
+fi
+
+echo
+echo "SYNTHETIC — edge cases:"
+WORKTREE="$(mktemp -d 2>/dev/null || echo "${TEMP:-/tmp}/sgs-test.$$")"
+rm -rf "$WORKTREE"
+if git worktree add --detach --quiet "$WORKTREE" HEAD 2>/dev/null; then
+  BASE="$(git -C "$WORKTREE" rev-parse HEAD)"
+
+  synth() { # <label> <relpath> <content> <want-required> <want-trigger>
+    local label="$1" rel="$2" body="$3" wr="$4" wt="$5"
+    mkdir -p "$(dirname "$WORKTREE/$rel")"
+    printf '%s\n' "$body" > "$WORKTREE/$rel"
+    git -C "$WORKTREE" add -A >/dev/null 2>&1
+    git -C "$WORKTREE" -c user.email=t@t -c user.name=t commit -qm "test: $label" >/dev/null 2>&1
+    local head; head="$(git -C "$WORKTREE" rev-parse HEAD)"
+    expect "$label" "$wr" "$wt" "$BASE" "$head"
+    git -C "$WORKTREE" reset -q --hard "$BASE" >/dev/null 2>&1
+  }
+
+  synth "docs-only change" \
+        "documentation/scratch-test.md" \
+        "# A note about passwords and JWT bearer tokens." \
+        false none
+
+  synth "src change with only CancellationToken (must NOT fire)" \
+        "src/Content/Domain/Domain.AI/ScratchTest.cs" \
+        "public static class ScratchTest { public static void Go(System.Threading.CancellationToken cancellationToken) { } }" \
+        false none
+
+  synth "src change adding an [Authorize] attribute" \
+        "src/Content/Domain/Domain.AI/ScratchTest.cs" \
+        "[Authorize] public sealed class ScratchTest { }" \
+        true content
+
+  synth "src change touching OwnerId (the recurring defect class)" \
+        "src/Content/Domain/Domain.AI/ScratchTest.cs" \
+        "public sealed record ScratchTest { public string? OwnerId { get; init; } }" \
+        true content
+
+  git worktree remove --force "$WORKTREE" >/dev/null 2>&1
+else
+  echo "  SKIP  (could not create a scratch worktree)"
+fi
+
+echo
+echo "SYNTHETIC — failure modes must fail closed:"
+if bash "$SCRIPT" 2>/dev/null; then
+  echo "  FAIL  missing --base should exit non-zero"; FAIL=$((FAIL+1))
+else
+  echo "  PASS  missing --base exits non-zero"; PASS=$((PASS+1))
+fi
+if bash "$SCRIPT" --base "definitely-not-a-ref-$$" 2>/dev/null; then
+  echo "  FAIL  unresolvable base should exit non-zero"; FAIL=$((FAIL+1))
+else
+  echo "  PASS  unresolvable base exits non-zero"; PASS=$((PASS+1))
+fi
+
+echo
+echo "$PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/.github/security-review-rubric.md
+++ b/.github/security-review-rubric.md
@@ -1,10 +1,18 @@
 # Security-reviewer rubric
 
 You are the **security-reviewer** running as a delivery rail (the-rails.md §3).
-You fire on any PR that touches a **gated path** (auth, identity, security,
-migrations, the pipeline itself, infrastructure) or carries the `risk:high`
-label — independent of the change's risk tier. A "small" change to a dangerous
-file does not slip through on its tier.
+You fire on any PR whose diff **contains security-relevant code** — authorization,
+tenant/owner scoping, capability envelopes, credentials, crypto, new HTTP surface,
+output sanitization — or that touches a **gated path** (auth, identity, security,
+migrations, the pipeline itself, infrastructure), or that carries the `risk:high`
+label. This is independent of the change's risk tier: a "small" change to a
+dangerous file does not slip through on its tier.
+
+The exact rule lives in `.github/scripts/security-gate-scope.sh`. Selection used to
+be by folder name alone, which let six consecutive PRs through unreviewed while they
+changed authorization and tenant isolation — hence the content signal. When the gate
+fires on content, you are given a scope file naming the files whose own changed lines
+carry the signal; start there and widen only if a finding leads you out of that set.
 
 Unlike the grader, you **block**. A finding you rate **HIGH** fails this check
 and stops the merge until it is resolved or a named human records an accepted-risk

--- a/.github/workflows/security-review.yml
+++ b/.github/workflows/security-review.yml
@@ -1,14 +1,16 @@
 name: Security Review
 
-# The security rail (the-rails.md §3): the security-reviewer agent, path-triggered.
+# The security rail (the-rails.md §3): the security-reviewer agent, triggered by
+# what the diff CONTAINS (see .github/scripts/security-gate-scope.sh), with the
+# original gated-path list kept as a supplement.
 #
 # Design note — why this is a REQUIRED check that runs on EVERY PR:
 # A required status check must report a conclusion on every PR or the merge stays
 # stuck "pending". So this job runs on all PRs but short-circuits to success when
-# no gated path changed. When a gated path IS touched (or the `risk:high` label is
-# present) it runs the security-reviewer and FAILS on a HIGH finding — that failure
-# is what blocks the merge. Add the check name `security-review` to the main-branch
-# ruleset's required checks (already done in main-branch-protection.json).
+# nothing security-relevant changed. When it IS relevant (or the `risk:high` label
+# is present) it runs the security-reviewer and FAILS on a HIGH finding — that
+# failure is what blocks the merge. Add the check name `security-review` to the
+# main-branch ruleset's required checks (already done in main-branch-protection.json).
 #
 # Fail-safe: a gated change whose review cannot complete BLOCKS rather than passes.
 # The reviewer writes a PROVISIONAL block as its first action and only overwrites it
@@ -41,31 +43,29 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Detect gated-path changes
+      - name: Detect security-relevant changes
         id: detect
         env:
           BASE_REF: ${{ github.base_ref }}
           HAS_RISK_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'risk:high') }}
           IS_DRAFT: ${{ github.event.pull_request.draft }}
+          SECURITY_SCOPE_FILE: ${{ runner.temp }}/security-scope.txt
         run: |
           set -euo pipefail
           # Full (non-shallow) fetch of the base so the merge-base exists; a
           # `--depth=1` fetch leaves no common ancestor and breaks the diff.
           git fetch --no-tags origin "$BASE_REF"
-          BASE_SHA="$(git merge-base FETCH_HEAD HEAD)"
-          CHANGED="$(git diff --name-only "$BASE_SHA" HEAD)"
-          echo "Base: $BASE_SHA"
-          echo "Changed files:"; echo "$CHANGED"
 
-          # Gated paths — keep in sync with .github/CODEOWNERS and the rubric.
-          # Every segment is slash-anchored so it matches a directory component
-          # consistently (e.g. /SecurityAttributes/, not a bare substring).
-          GATED_RE='(^\.github/|/Auth/|/Identity/|/Security/|/SecurityAttributes/|/Migrations/|^infra/)'
-          if echo "$CHANGED" | grep -Eq "$GATED_RE"; then
-            GATED=true
-          else
-            GATED=false
-          fi
+          # The decision lives in one script shared with scripts/rails/run-gates.sh —
+          # it selects on what the diff CONTAINS, not only on folder names. The old
+          # folder-only filter skipped six consecutive PRs that changed authorization,
+          # tenant scoping and capability envelopes. See the script's header.
+          # It exits non-zero when it cannot compute a diff, and `set -e` turns that
+          # into a failed required check: unable-to-decide must never mean not-required.
+          bash .github/scripts/security-gate-scope.sh --base FETCH_HEAD --format github > "$RUNNER_TEMP/scope.txt"
+          cat "$RUNNER_TEMP/scope.txt"
+          GATED="$(grep '^required=' "$RUNNER_TEMP/scope.txt" | cut -d= -f2)"
+          echo "Files in scope:"; cat "$SECURITY_SCOPE_FILE" || true
 
           # Drafts are work-in-progress and cannot merge, so defer the expensive
           # (Opus) reviewer until the PR is marked ready — the `ready_for_review`
@@ -80,7 +80,7 @@ jobs:
             echo "Security review REQUIRED (gated=$GATED, risk:high=$HAS_RISK_LABEL)."
           else
             echo "review_required=false" >> "$GITHUB_OUTPUT"
-            echo "No gated paths changed and no risk:high label — security review not required."
+            echo "Nothing security-relevant in the diff and no risk:high label — security review not required."
           fi
 
       # Clear any verdict file that a PR may have COMMITTED into the tree. The
@@ -124,10 +124,11 @@ jobs:
 
             STEP 2 — Review.
             Read the rubric at .github/security-review-rubric.md and follow it exactly.
-            Review the PR diff (base is origin/${{ github.base_ref }}), focusing on the
-            gated files that triggered this run. Budget your turns: prefer a single
-            `git diff` over many per-file reads, and do not re-read a file you have
-            already seen.
+            Review the PR diff (base is origin/${{ github.base_ref }}).
+            ${{ runner.temp }}/security-scope.txt lists the files whose own changed lines
+            carry a security signal — start there, then widen only if a finding leads you
+            out of that set. Budget your turns: prefer a single `git diff` over many
+            per-file reads, and do not re-read a file you have already seen.
 
             STEP 3 — Replace the verdict, and post findings.
             Overwrite ${{ runner.temp }}/security-verdict.txt with your real verdict.
@@ -194,4 +195,4 @@ jobs:
 
       - name: No review required
         if: steps.detect.outputs.review_required != 'true'
-        run: echo "No gated paths changed — security-review check passes trivially."
+        run: echo "Nothing security-relevant changed (no gated path, no security signal in the diff) — security-review check passes trivially."

--- a/scripts/rails/run-gates.sh
+++ b/scripts/rails/run-gates.sh
@@ -148,10 +148,23 @@ SRC_CHANGED=false
 [ -s "$ANCHORS_FILE" ] && SRC_CHANGED=true
 
 CHANGED_FILES="$(git diff --name-only "${BASE_REF}...HEAD" 2>/dev/null || true)"
-# Keep in sync with GATED_RE in .github/workflows/security-review.yml.
-GATED_RE='(^\.github/|/Auth/|/Identity/|/Security/|/SecurityAttributes/|/Migrations/|^infra/)'
+
+# The security gate's applicability is decided by ONE script, shared with
+# .github/workflows/security-review.yml, so the local pre-flight and the remote
+# required check can never disagree. It selects on what the diff CONTAINS, not on
+# folder names alone — the folder-only filter this replaced skipped six consecutive
+# PRs that changed authorization, tenant scoping and capability-envelope code.
+SECURITY_SCOPE_FILE="${TMPDIR_GATES}/security-scope.txt"
+export SECURITY_SCOPE_FILE
+SECURITY_SCOPE_OUT="${TMPDIR_GATES}/security-scope-decision.txt"
+if ! bash .github/scripts/security-gate-scope.sh --base "$BASE_REF" > "$SECURITY_SCOPE_OUT" 2>/dev/null; then
+  echo "run-gates: security-gate-scope.sh could not decide — failing closed." >&2
+  exit 1
+fi
 SECURITY_GATED=false
-echo "$CHANGED_FILES" | grep -Eq "$GATED_RE" && SECURITY_GATED=true
+[ "$(grep '^required=' "$SECURITY_SCOPE_OUT" | cut -d= -f2)" = "true" ] && SECURITY_GATED=true
+SECURITY_REASON="$(grep '^reason=' "$SECURITY_SCOPE_OUT" | cut -d= -f2-)"
+SECURITY_SCOPE_FILE_NATIVE="$(native_path "$SECURITY_SCOPE_FILE")"
 
 DOCS_CHANGED=false
 echo "$CHANGED_FILES" | grep -Eq '^documentation/' && DOCS_CHANGED=true
@@ -170,7 +183,7 @@ applies() {
 reason_for() {
   case "$1" in
     correctness) $SRC_CHANGED && echo "$(grep -c . "$ANCHORS_FILE") changed-line range(s) under src/" || echo "no source under src/ changed" ;;
-    security)    $SECURITY_GATED && echo "gated paths changed" || echo "no gated paths changed (auth/identity/security/migrations/.github/infra)" ;;
+    security)    echo "$SECURITY_REASON" ;;
     grader)      $SRC_CHANGED && echo "source under src/ changed" || echo "no source under src/ changed" ;;
     docs-links)  $DOCS_CHANGED && echo "documentation/ changed" || echo "documentation/ unchanged" ;;
     docs-drift)  ($SRC_CHANGED || $DOCS_CHANGED) && echo "code or docs changed — docs may be stale" || echo "nothing that could stale the docs changed" ;;
@@ -355,7 +368,7 @@ change in this same branch. If you find no drift, say 'no drift' and stop." \
       ;;
     security)
       run_ai_gate "security" "SECURITY_VERDICT" "opus" ".github/security-review-rubric.md" \
-        "Review the changed files listed by \`git diff --name-only ${BASE_REF}...HEAD\`, concentrating on the gated paths (auth, identity, security, migrations, .github, infra) that triggered this gate."
+        "Review the changed files listed by \`git diff --name-only ${BASE_REF}...HEAD\`. The file ${SECURITY_SCOPE_FILE_NATIVE} lists the files whose own changed lines carry a security signal — start there, then widen only if a finding leads you out of that set."
       ;;
   esac
 done

--- a/scripts/rails/run-gates.sh
+++ b/scripts/rails/run-gates.sh
@@ -157,8 +157,8 @@ CHANGED_FILES="$(git diff --name-only "${BASE_REF}...HEAD" 2>/dev/null || true)"
 SECURITY_SCOPE_FILE="${TMPDIR_GATES}/security-scope.txt"
 export SECURITY_SCOPE_FILE
 SECURITY_SCOPE_OUT="${TMPDIR_GATES}/security-scope-decision.txt"
-if ! bash .github/scripts/security-gate-scope.sh --base "$BASE_REF" > "$SECURITY_SCOPE_OUT" 2>/dev/null; then
-  echo "run-gates: security-gate-scope.sh could not decide — failing closed." >&2
+if ! bash .github/scripts/security-gate-scope.sh --base "$BASE_REF" > "$SECURITY_SCOPE_OUT"; then
+  echo "run-gates: security-gate-scope.sh could not decide — failing closed (its error is above)." >&2
   exit 1
 fi
 SECURITY_GATED=false


### PR DESCRIPTION
## The problem

The security gate selected purely by **folder name** (`/Auth/`, `/Identity/`, `/Security/`, `/Migrations/`, `.github/`, `infra/`). Replaying the last sixteen merges shows it skipped **six consecutive PRs** — #203, #205, #207, #208, #209, #210 — every one of which changed authorization, tenant/owner scoping, or capability-envelope code. It has also been observed missing two HIGH findings in a single day.

Folder names describe where code lives, not what it does. This repo keeps its security-critical logic under `Controllers/`, `Runs/`, `Planner/` and `Interfaces/`.

This matters more than usual right now: `Correctness Review`, `Grader` and `Docs Drift Check` are all `disabled_manually`, so **security-review is the only remote review that runs.**

## The change

Selection now reads the **changed lines** for security-relevant markers — authz, scope isolation, capability/governance, credentials/crypto, new HTTP surface, sanitization — with the original path list kept as a supplement so a migration or workflow file is still reviewed whatever it says. The two signals are **additive**, never exclusive.

One script, `.github/scripts/security-gate-scope.sh`, is now the single authority. The remote required check and the local `run-gates.sh` pre-flight previously carried duplicate regexes under a "keep in sync" comment — the drift trap this repo has closed elsewhere (`ApproverClaimTypes`, `EscalationStepOutput`, `ConditionExpressionRules`).

The gate also hands the reviewer the files whose own changed lines carry a signal, so a large diff gets read where it matters.

`scripts/rails/` joins the gated path list: those scripts *are* the gates.

## Reviewer findings, closed

The security reviewer ran against this change and **blocked it**. It was right, and this change was itself an instance of the hole.

- **HIGH** — the path branch was an `elif`, so a gated-path touch *suppressed* the content scan. A PR pairing a one-line `.github/` edit with an owner-check regression got a scope file naming only the `.github` file. Now additive, with a union scope file.
- **MEDIUM** — the scope loop filtered to `.cs/.csproj/.json/.props/.targets` while the scan read all of `src/`, so a TypeScript-only change (299 files, the AgentHub frontend) fired the gate and named nothing. An empty scope with `required=true` now falls back to the whole diff.
- **MEDIUM** (second pass) — git quotes non-ASCII paths, and that form matches nothing as a pathspec, so `Órder.cs` could change `OwnerId` scoping and raise no signal. Now `core.quotePath=false`.
- **LOW** — unquoted `for f in $(...)` dropped paths containing spaces; `2>/dev/null` hid why the gate could not decide.

Second review pass: **PASS, no HIGH findings.**

## Evidence

`bash .github/scripts/security-gate-scope.test.sh` — **21 passed, 0 failed**, including replays of all six missed PRs and one regression case per finding. The `core.quotePath` fix is mutation-verified: restoring the bug fails exactly that case and nothing else.

## The trade, stated plainly

Expect this to fire on **most `src/**` PRs** in this repo and to cost accordingly (~\$0.06/turn on opus, ceiling ~\$5). That is the intended trade, not a misconfiguration, and it is recorded in `.github/RAILS.md`.

## Accepted properties (recorded, not fixed)

- Markdown is excluded from the content scan, so a credential committed into docs raises no signal. Same as `main`.
- The decision script is checked out from the PR head and executed, so a PR can in principle neuter its own gate. Pre-existing — the inline regex had the identical property — mitigated by CODEOWNERS/required review on `.github/**`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BnoLcufW278UxA9ssBM1Tc