### PR TITLE
feat: confine eval dataset reads and cap what one run may spend

### DIFF
--- a/documentation/security/02-identity-and-access.html
+++ b/documentation/security/02-identity-and-access.html
@@ -150,7 +150,7 @@
                             <em>message</em> envelope in <a href="#a2a">Agent-to-agent authentication</a> below, which
                             is untrusted caller-supplied data.) This
                             surface is off by default and fails closed when half-configured. See
-                            <a href="../17-bundle-api.html">Onboarding&nbsp;&middot;&nbsp;Ch.&nbsp;17 Bundle API</a> and
+                            <a href="../17-bundle-api.html">Onboarding&nbsp;&middot;&nbsp;Ch.&nbsp;17 Execution API</a> and
                             <a href="03-autonomy-and-governance.html">Autonomy &amp; Governance</a>.
                         </div>
                     </div>

--- a/documentation/security/03-autonomy-and-governance.html
+++ b/documentation/security/03-autonomy-and-governance.html
@@ -247,7 +247,7 @@
                                 is the most restrictive of three things: the envelope's ceiling, the host's own
                                 graded-autonomy gate, and the individual tool's blast radius. It can only tighten,
                                 never loosen. See
-                                <a href="../17-bundle-api.html">Onboarding&nbsp;&middot;&nbsp;Ch.&nbsp;17 Bundle API</a>.
+                                <a href="../17-bundle-api.html">Onboarding&nbsp;&middot;&nbsp;Ch.&nbsp;17 Execution API</a>.
                             </p>
                         </div>
                     </div>

--- a/src/Content/Application/Application.Core/CQRS/Evaluation/RunEvalSuite/EvalConfinementLatch.cs
+++ b/src/Content/Application/Application.Core/CQRS/Evaluation/RunEvalSuite/EvalConfinementLatch.cs
@@ -1,0 +1,33 @@
+namespace Application.Core.CQRS.Evaluation.RunEvalSuite;
+
+/// <summary>
+/// Records whether this host verified, <em>at startup</em>, that evaluation dataset reads are confined.
+/// </summary>
+/// <param name="StartedConfined">
+/// <see langword="true"/> only when a composition root checked the configured dataset roots during
+/// startup and refused to boot without them.
+/// </param>
+/// <remarks>
+/// <para>
+/// <strong>Why this is a type and not a field on the guard.</strong> The obvious implementation — latch
+/// the verdict in <c>EvalDatasetPathGuard</c>'s constructor — reads as startup-bound but is not. The
+/// guard is a lazily-constructed singleton, so its constructor first runs on the <em>first eval
+/// dispatch</em>, which can be long after boot. Configuration is bound with <c>reloadOnChange: true</c>,
+/// so a reload that emptied <c>DatasetRoots</c> in between would have the guard latch
+/// "started unconfined" and take the permissive branch — the exact downgrade the latch exists to
+/// prevent, with the comment above it claiming otherwise.
+/// </para>
+/// <para>
+/// Registering the verdict as a value fixes it at composition time, which really is startup, and puts it
+/// where the fail-closed check already lives: the host that refused to boot without roots is the host
+/// that declares this <see langword="true"/>. Nothing else can set it, so the guard cannot be talked out
+/// of confinement by a later configuration change.
+/// </para>
+/// <para>
+/// The default registration is <see langword="false"/> — a plain constant, deliberately not a
+/// configuration read. "No host claimed a startup check" is the honest default, and it costs nothing:
+/// a guard with live roots configured still confines, latch or no latch. The latch only governs whether
+/// <em>removing</em> the roots can loosen anything.
+/// </para>
+/// </remarks>
+public sealed record EvalConfinementLatch(bool StartedConfined);

--- a/src/Content/Application/Application.Core/CQRS/Evaluation/RunEvalSuite/EvalDatasetPathGuard.cs
+++ b/src/Content/Application/Application.Core/CQRS/Evaluation/RunEvalSuite/EvalDatasetPathGuard.cs
@@ -1,0 +1,305 @@
+using Domain.Common.Config;
+using Microsoft.Extensions.Options;
+
+namespace Application.Core.CQRS.Evaluation.RunEvalSuite;
+
+/// <summary>
+/// Decides whether a requested evaluation dataset path may be read, and returns the canonical path to
+/// read it from.
+/// </summary>
+/// <remarks>
+/// Separate from the handler so the confinement rules can be tested directly against traversal,
+/// symlink escape, and root-prefix edge cases — a check that only exists inside a handler tends to be
+/// exercised only through the happy path.
+/// </remarks>
+public interface IEvalDatasetPathGuard
+{
+    /// <summary>
+    /// Resolves <paramref name="requestedPath"/> to a canonical absolute path, or explains why it may
+    /// not be read.
+    /// </summary>
+    /// <param name="requestedPath">The path as supplied by the caller.</param>
+    /// <returns>
+    /// The canonical path on success. On failure the message is deliberately coarse when confinement
+    /// is active — see the implementation for why.
+    /// </returns>
+    EvalDatasetPathDecision Resolve(string requestedPath);
+}
+
+/// <summary>The outcome of guarding one dataset path.</summary>
+/// <param name="IsAllowed">Whether the path may be read.</param>
+/// <param name="CanonicalPath">The canonical absolute path when allowed; otherwise <see langword="null"/>.</param>
+/// <param name="Reason">A caller-safe explanation when refused; otherwise <see langword="null"/>.</param>
+public readonly record struct EvalDatasetPathDecision(bool IsAllowed, string? CanonicalPath, string? Reason)
+{
+    /// <summary>Creates an allowing decision.</summary>
+    public static EvalDatasetPathDecision Allow(string canonicalPath) => new(true, canonicalPath, null);
+
+    /// <summary>Creates a refusing decision.</summary>
+    public static EvalDatasetPathDecision Refuse(string reason) => new(false, null, reason);
+}
+
+/// <summary>
+/// Default <see cref="IEvalDatasetPathGuard"/>: confines dataset reads to
+/// <c>AppConfig:AI:Evaluation:DatasetRoots</c> when any root is configured, and leaves them unconfined
+/// when none is.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>Unconfined-by-default is a deliberate compromise, not an oversight.</strong> Evaluation's
+/// only dispatcher today is the EvalRunner CLI, where the caller is a developer on their own machine
+/// and pointing the runner at a file anywhere on disk is the normal workflow. Making roots mandatory
+/// would break that for no gain, because a local developer can read those files anyway. The protection
+/// is needed exactly when the caller is <em>not</em> the machine's owner, and a host in that position
+/// configures roots — the HTTP surface refuses to run without them rather than silently inheriting the
+/// permissive default.
+/// </para>
+/// <para>
+/// <strong>Refusals are deliberately vague when confined.</strong> "Outside the allowed roots" and
+/// "does not exist" are reported identically, because distinguishing them turns the endpoint into a
+/// filesystem oracle: a caller could map the disk by watching which of two error messages came back.
+/// When unconfined there is no untrusted caller to protect against and the specific path is echoed,
+/// which is what makes the CLI usable.
+/// </para>
+/// <para>
+/// <strong>Confinement ratchets one way.</strong> Adding a root at runtime takes effect immediately;
+/// emptying the list does not loosen anything, because a host that started confined refuses every path
+/// rather than reverting to the permissive branch. The startup check that stops an unconfined host
+/// booting runs once, and a later configuration reload would never re-run it.
+/// </para>
+/// <para>
+/// <strong>What this cannot see.</strong> Confinement is path-based, so it follows symbolic links and
+/// junctions but is blind to <em>hard</em> links: a hard link inside a root has no target to resolve and
+/// is indistinguishable from an ordinary file there. That is inherent to the approach, not a gap in the
+/// implementation — it means a configured root must not be writable by anyone the host would not let
+/// read arbitrary files.
+/// </para>
+/// </remarks>
+public sealed class EvalDatasetPathGuard : IEvalDatasetPathGuard
+{
+    private readonly IOptionsMonitor<AppConfig> _config;
+    private readonly EvalConfinementLatch _latch;
+
+    /// <summary>Initializes the guard with live configuration and the host's startup verdict.</summary>
+    /// <param name="config">
+    /// Read per call rather than captured, so <em>adding</em> a root takes effect without a restart.
+    /// </param>
+    /// <param name="latch">
+    /// Whether a composition root verified confinement at startup. Deliberately not derived from
+    /// <paramref name="config"/> here: this guard is a lazy singleton, so its constructor runs on the
+    /// first dispatch rather than at boot, and a latch computed here would record whatever the
+    /// configuration happened to say by then.
+    /// </param>
+    public EvalDatasetPathGuard(IOptionsMonitor<AppConfig> config, EvalConfinementLatch latch)
+    {
+        ArgumentNullException.ThrowIfNull(config);
+        ArgumentNullException.ThrowIfNull(latch);
+        _config = config;
+        _latch = latch;
+    }
+
+    /// <inheritdoc />
+    public EvalDatasetPathDecision Resolve(string requestedPath)
+    {
+        if (string.IsNullOrWhiteSpace(requestedPath))
+            return EvalDatasetPathDecision.Refuse("Dataset paths must not be empty strings.");
+
+        var roots = UsableRoots(_config.CurrentValue);
+
+        // Confinement ratchets one way. Adding a root at runtime tightens and is honoured immediately;
+        // emptying the list cannot loosen, because a host that verified confinement at startup keeps
+        // refusing regardless. Without the latch, a configuration reload that dropped DatasetRoots would
+        // silently downgrade a confined host to arbitrary-file-read.
+        var confined = _latch.StartedConfined || roots.Count > 0;
+
+        if (confined && roots.Count == 0)
+            return EvalDatasetPathDecision.Refuse("Dataset is not available.");
+
+        string canonical;
+        try
+        {
+            // Canonicalise before any comparison. A path containing ".." compares against a root as a
+            // string quite happily while resolving somewhere else entirely.
+            canonical = Path.GetFullPath(requestedPath);
+        }
+        catch (Exception ex) when (ex is ArgumentException or NotSupportedException or PathTooLongException)
+        {
+            return EvalDatasetPathDecision.Refuse(
+                confined ? "Dataset is not available." : $"Dataset path is not a valid path: {requestedPath}");
+        }
+
+        if (!confined)
+        {
+            return File.Exists(canonical)
+                ? EvalDatasetPathDecision.Allow(canonical)
+                : EvalDatasetPathDecision.Refuse($"Dataset file not found: {requestedPath}");
+        }
+
+        // Resolve symlinks only after canonicalising. A link inside a root may point outside it, and
+        // the file the loader ultimately opens is the target, not the link.
+        var walk = new LinkWalk();
+        var effective = ResolveSegments(canonical, walk);
+
+        // A walk that ran out of budget did not finish, so `effective` may still be a link — and a link
+        // that happens to sit inside a root would otherwise be admitted while opening a target outside
+        // it. Not knowing where a path leads is a refusal, not a pass.
+        if (walk.Exhausted)
+            return EvalDatasetPathDecision.Refuse("Dataset is not available.");
+
+        foreach (var root in roots)
+        {
+            string canonicalRoot;
+            try
+            {
+                // Roots go through the SAME link resolution as the candidate. Comparing a fully-resolved
+                // candidate against a merely-canonicalised root refuses everything whenever the root is
+                // reached through a symlinked directory — macOS `/tmp` (a link to `/private/tmp`) and
+                // plenty of container bind mounts are exactly that. It fails closed, so it is an
+                // availability trap rather than a bypass, but a confinement rule that silently rejects
+                // every legitimate path gets switched off by whoever hits it.
+                var rootWalk = new LinkWalk();
+                canonicalRoot = ResolveSegments(Path.GetFullPath(root), rootWalk);
+
+                // An unresolvable root confines nothing knowable, so drop it rather than compare against
+                // a half-resolved path.
+                if (rootWalk.Exhausted)
+                    continue;
+            }
+            catch (Exception ex) when (ex is ArgumentException or NotSupportedException or PathTooLongException)
+            {
+                continue;
+            }
+
+            if (IsInside(effective, canonicalRoot) && File.Exists(effective))
+                return EvalDatasetPathDecision.Allow(effective);
+        }
+
+        // One message for "outside every root" and for "inside a root but absent" — see the class remarks.
+        return EvalDatasetPathDecision.Refuse("Dataset is not available.");
+    }
+
+    /// <summary>
+    /// The configured roots that actually confine anything: blank and whitespace-only entries are
+    /// dropped rather than honoured.
+    /// </summary>
+    /// <remarks>
+    /// An empty string canonicalises to the process's current directory, so treating one as a root would
+    /// quietly widen the allowlist to wherever the host happens to be running from — and would let a
+    /// whitespace entry satisfy the fail-closed startup check.
+    /// </remarks>
+    private static IReadOnlyList<string> UsableRoots(AppConfig config) =>
+        [.. (config.AI.Evaluation.DatasetRoots ?? []).Where(root => !string.IsNullOrWhiteSpace(root))];
+
+    /// <summary>Total symbolic links followed while resolving one path, across every segment.</summary>
+    /// <remarks>
+    /// A budget rather than a per-segment limit: without one, a chain of links each pointing at a path
+    /// containing further links would multiply out instead of terminating.
+    /// </remarks>
+    private const int MaxLinkHops = 16;
+
+    /// <summary>Mutable state threaded through one path walk: links followed, and whether we ran out.</summary>
+    /// <remarks>
+    /// <see cref="Exhausted"/> exists so running out of budget is distinguishable from finishing. Both
+    /// leave a path behind, but only one of them is a path we actually resolved — and an unresolved link
+    /// that happens to sit inside an allowed root would sail through containment.
+    /// </remarks>
+    private sealed class LinkWalk
+    {
+        /// <summary>Links followed so far, across every segment of the path.</summary>
+        public int Hops { get; set; }
+
+        /// <summary>Whether the walk hit <see cref="MaxLinkHops"/> with a link still unresolved.</summary>
+        public bool Exhausted { get; set; }
+    }
+
+    /// <summary>
+    /// Resolves <paramref name="path"/> to the file the operating system would actually open, following
+    /// symbolic links on <em>every</em> segment: the parent chain first, then the segment itself.
+    /// </summary>
+    /// <remarks>
+    /// .NET has no <c>realpath</c>, and the built-in <c>ResolveLinkTarget</c> only inspects the final
+    /// segment. Resolving the leaf alone would leave the obvious evasion open: a <em>directory</em> link
+    /// sitting inside an allowed root, pointing anywhere on disk. Every path under it would then
+    /// canonicalise to something that starts with the root while opening a file that does not.
+    /// </remarks>
+    private static string ResolveSegments(string path, LinkWalk walk)
+    {
+        var parent = Path.GetDirectoryName(path);
+
+        // No parent means a volume root ("C:\", "/"), which terminates the walk.
+        if (string.IsNullOrEmpty(parent))
+            return path;
+
+        var current = Path.Combine(ResolveSegments(parent, walk), Path.GetFileName(path));
+
+        string? linkTarget;
+        try
+        {
+            // The raw target string, not ResolveLinkTarget's FileSystemInfo: a relative target has to be
+            // resolved against the link's own directory, and reconstructing an absolute path from a
+            // FileSystemInfo resolves it against the process's current directory instead.
+            linkTarget = Directory.Exists(current)
+                ? new DirectoryInfo(current).LinkTarget
+                : new FileInfo(current).LinkTarget;
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            // Unreadable is not the same as escaping. Return what we have; the containment check and the
+            // File.Exists probe that follow both fail closed.
+            return current;
+        }
+
+        if (linkTarget is null)
+            return current;
+
+        if (walk.Hops >= MaxLinkHops)
+        {
+            walk.Exhausted = true;
+            return current;
+        }
+
+        walk.Hops++;
+
+        // The target may itself sit beneath further links, so it goes through the same walk rather than
+        // being trusted as final. This is also what bounds a link cycle: each turn costs a hop.
+        string absoluteTarget;
+        try
+        {
+            var linkDirectory = Path.GetDirectoryName(current);
+            absoluteTarget = string.IsNullOrEmpty(linkDirectory)
+                ? Path.GetFullPath(linkTarget)
+                : Path.GetFullPath(linkTarget, linkDirectory);
+        }
+        catch (Exception ex) when (ex is ArgumentException or NotSupportedException or PathTooLongException)
+        {
+            // A reparse point whose stored target is malformed. Unresolvable, so treat it exactly like a
+            // budget exhaustion: we do not know where this leads, and every other failure mode here
+            // refuses rather than guessing. Letting it throw would surface as a 500 instead.
+            walk.Exhausted = true;
+            return current;
+        }
+
+        return ResolveSegments(absoluteTarget, walk);
+    }
+
+    /// <summary>
+    /// Whether <paramref name="candidate"/> sits inside <paramref name="root"/>.
+    /// </summary>
+    /// <remarks>
+    /// Compares against the root plus a separator so <c>/data/evals-secret</c> is not treated as living
+    /// inside <c>/data/evals</c> — a plain <c>StartsWith</c> on the root would admit it. Comparison is
+    /// case-insensitive on Windows and macOS and case-sensitive elsewhere, matching how the filesystem
+    /// itself resolves the two paths.
+    /// </remarks>
+    private static bool IsInside(string candidate, string root)
+    {
+        var comparison = OperatingSystem.IsWindows() || OperatingSystem.IsMacOS()
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+
+        var normalizedRoot = root.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+            + Path.DirectorySeparatorChar;
+
+        return candidate.StartsWith(normalizedRoot, comparison);
+    }
+}

--- a/src/Content/Application/Application.Core/CQRS/Evaluation/RunEvalSuite/RunEvalSuiteCommandHandler.cs
+++ b/src/Content/Application/Application.Core/CQRS/Evaluation/RunEvalSuite/RunEvalSuiteCommandHandler.cs
@@ -1,8 +1,10 @@
 using Application.AI.Common.Evaluation.Interfaces;
 using Domain.AI.Evaluation;
 using Domain.Common;
+using Domain.Common.Config;
 using MediatR;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace Application.Core.CQRS.Evaluation.RunEvalSuite;
 
@@ -22,6 +24,8 @@ public sealed class RunEvalSuiteCommandHandler : IRequestHandler<RunEvalSuiteCom
 
     private readonly IReadOnlyDictionary<string, IEvalDatasetLoader> _loadersByExtension;
     private readonly IEvalRunner _runner;
+    private readonly IEvalDatasetPathGuard _pathGuard;
+    private readonly IOptionsMonitor<AppConfig> _config;
     private readonly ILogger<RunEvalSuiteCommandHandler> _logger;
 
     /// <summary>
@@ -29,14 +33,26 @@ public sealed class RunEvalSuiteCommandHandler : IRequestHandler<RunEvalSuiteCom
     /// </summary>
     /// <param name="loaders">All registered dataset loaders. Each loader's reported extensions are indexed individually.</param>
     /// <param name="runner">The configured eval runner.</param>
+    /// <param name="pathGuard">
+    /// Decides which dataset paths may be read. Applied here rather than at each dispatcher because a
+    /// check every caller must remember to perform is one that will eventually be skipped.
+    /// </param>
+    /// <param name="config">
+    /// Live configuration supplying the per-run cost ceilings. Read at execution time rather than
+    /// captured so tightening a ceiling takes effect without a restart.
+    /// </param>
     /// <param name="logger">Logger for orchestration diagnostics.</param>
     public RunEvalSuiteCommandHandler(
         IEnumerable<IEvalDatasetLoader> loaders,
         IEvalRunner runner,
+        IEvalDatasetPathGuard pathGuard,
+        IOptionsMonitor<AppConfig> config,
         ILogger<RunEvalSuiteCommandHandler> logger)
     {
         ArgumentNullException.ThrowIfNull(loaders);
         ArgumentNullException.ThrowIfNull(runner);
+        ArgumentNullException.ThrowIfNull(pathGuard);
+        ArgumentNullException.ThrowIfNull(config);
         ArgumentNullException.ThrowIfNull(logger);
 
         var index = new Dictionary<string, IEvalDatasetLoader>(StringComparer.OrdinalIgnoreCase);
@@ -59,6 +75,8 @@ public sealed class RunEvalSuiteCommandHandler : IRequestHandler<RunEvalSuiteCom
         }
         _loadersByExtension = index;
         _runner = runner;
+        _pathGuard = pathGuard;
+        _config = config;
         _logger = logger;
     }
 
@@ -89,24 +107,39 @@ public sealed class RunEvalSuiteCommandHandler : IRequestHandler<RunEvalSuiteCom
             _logger.LogWarning("{Warning}", warning);
         }
 
+        var evaluation = _config.CurrentValue.AI.Evaluation;
+        var repeats = Math.Max(1, request.Options.Repeats);
+
         var datasets = new List<EvalDataset>(request.DatasetPaths.Count);
+
+        // Accumulated as each dataset lands rather than summed at the end, so a run that is already over
+        // budget stops loading instead of parsing the rest of the list first. Widened to long so the
+        // multiplication by repeats cannot overflow into a negative that passes the check.
+        long totalCases = 0;
+        long totalExecutions = 0;
 
         foreach (var path in request.DatasetPaths)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            if (string.IsNullOrWhiteSpace(path))
+            // The guard both canonicalises and decides. Reading the caller's path directly from here
+            // on would defeat it: a path containing ".." compares against an allowed root perfectly
+            // well while resolving somewhere else entirely, so what gets opened must be the resolved
+            // path, never the requested one.
+            var decision = _pathGuard.Resolve(path);
+            if (!decision.IsAllowed)
             {
-                return Result<EvalRunReport>.ValidationFailure(["Dataset paths must not be empty strings."]);
+                _logger.LogWarning(
+                    "Eval dataset refused. Requested {Path}. Reason reported to caller: {Reason}",
+                    path,
+                    decision.Reason);
+
+                return Result<EvalRunReport>.NotFound(decision.Reason ?? "Dataset is not available.");
             }
 
-            if (!File.Exists(path))
-            {
-                _logger.LogWarning("Eval dataset not found at {Path}", path);
-                return Result<EvalRunReport>.NotFound($"Dataset file not found: {path}");
-            }
+            var resolvedPath = decision.CanonicalPath!;
 
-            var extension = Path.GetExtension(path).TrimStart('.').ToLowerInvariant();
+            var extension = Path.GetExtension(resolvedPath).TrimStart('.').ToLowerInvariant();
             if (!_loadersByExtension.TryGetValue(extension, out var loader))
             {
                 _logger.LogWarning("No dataset loader registered for extension {Extension} ({Path})", extension, path);
@@ -114,10 +147,38 @@ public sealed class RunEvalSuiteCommandHandler : IRequestHandler<RunEvalSuiteCom
                     $"No dataset loader registered for extension '{extension}' (file: {path}).");
             }
 
+            // Size is checked before the file is opened. The execution ceiling below can only be applied
+            // once cases exist, and producing cases means parsing — so without this, naming one enormous
+            // file makes the parse itself the cost, paid in full before anything is refused.
+            if (!TryMeasure(resolvedPath, out var actualBytes))
+            {
+                _logger.LogWarning("Eval dataset refused: {Path} could not be measured.", path);
+                return Result<EvalRunReport>.Fail($"Dataset '{path}' could not be read.");
+            }
+
+            if (evaluation.MaxDatasetBytes > 0 && actualBytes > evaluation.MaxDatasetBytes)
+            {
+                _logger.LogWarning(
+                    "Eval dataset refused: {Path} is {ActualBytes} bytes, above the configured "
+                    + "MaxDatasetBytes of {MaxBytes}.",
+                    path,
+                    actualBytes,
+                    evaluation.MaxDatasetBytes);
+
+                return Result<EvalRunReport>.ValidationFailure(
+                [
+                    $"Dataset '{path}' is larger than the configured limit of "
+                    + $"{evaluation.MaxDatasetBytes} bytes."
+                ]);
+            }
+
             try
             {
-                var dataset = await loader.LoadAsync(path, cancellationToken).ConfigureAwait(false);
+                var dataset = await loader.LoadAsync(resolvedPath, cancellationToken).ConfigureAwait(false);
                 datasets.Add(dataset);
+
+                totalCases += dataset.Cases?.Count ?? 0;
+                totalExecutions = totalCases * repeats;
             }
             catch (OperationCanceledException)
             {
@@ -133,6 +194,31 @@ public sealed class RunEvalSuiteCommandHandler : IRequestHandler<RunEvalSuiteCom
                 _logger.LogWarning(ex, "Failed to parse dataset {Path}", path);
                 return Result<EvalRunReport>.Fail($"Failed to parse dataset {path}: {ex.Message}");
             }
+
+            // Cost ceiling, applied as soon as it is exceeded rather than after the whole list is
+            // parsed. Every case is a governed agent turn plus its LLM-judge calls, multiplied by
+            // Repeats — so this is the last point at which a run's spend can be refused rather than
+            // incurred. Refuse rather than truncate: quietly evaluating a subset would report a pass
+            // rate for a suite that never ran.
+            if (totalExecutions > evaluation.MaxCaseExecutionsPerRun)
+            {
+                _logger.LogWarning(
+                    "Eval run refused: {TotalCases} cases x {Repeats} repeats = {TotalExecutions} "
+                    + "executions, above the configured ceiling of {MaxExecutions}.",
+                    totalCases,
+                    repeats,
+                    totalExecutions,
+                    evaluation.MaxCaseExecutionsPerRun);
+
+                return Result<EvalRunReport>.ValidationFailure(
+                [
+                    $"This run would perform at least {totalExecutions} case executions "
+                    + $"({totalCases} cases x {repeats} repeats), above the configured ceiling of "
+                    + $"{evaluation.MaxCaseExecutionsPerRun}. Narrow the run with a tag filter, reduce "
+                    + "Repeats, split the datasets, or raise "
+                    + "AppConfig:AI:Evaluation:MaxCaseExecutionsPerRun."
+                ]);
+            }
         }
 
         var report = await _runner.RunAsync(datasets, request.Options, cancellationToken).ConfigureAwait(false);
@@ -145,5 +231,26 @@ public sealed class RunEvalSuiteCommandHandler : IRequestHandler<RunEvalSuiteCom
         }
 
         return Result<EvalRunReport>.Success(report);
+    }
+
+    /// <summary>Measures the dataset at <paramref name="path"/> so its size can be checked before it is parsed.</summary>
+    /// <remarks>
+    /// Returns <see langword="false"/> when the file cannot be measured at all. Waving it through would
+    /// be the wrong direction: the whole point of a size cap is to bound memory <em>before</em> the
+    /// parse, so skipping the check exactly when the size is unknown skips it in the one case where it
+    /// would have mattered.
+    /// </remarks>
+    private static bool TryMeasure(string path, out long actualBytes)
+    {
+        try
+        {
+            actualBytes = new FileInfo(path).Length;
+            return true;
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            actualBytes = 0;
+            return false;
+        }
     }
 }

--- a/src/Content/Application/Application.Core/CQRS/Evaluation/RunEvalSuite/RunEvalSuiteCommandValidator.cs
+++ b/src/Content/Application/Application.Core/CQRS/Evaluation/RunEvalSuite/RunEvalSuiteCommandValidator.cs
@@ -1,4 +1,7 @@
+using Domain.Common.Config;
+using Domain.Common.Config.AI;
 using FluentValidation;
+using Microsoft.Extensions.Options;
 
 namespace Application.Core.CQRS.Evaluation.RunEvalSuite;
 
@@ -6,27 +9,51 @@ namespace Application.Core.CQRS.Evaluation.RunEvalSuite;
 /// Validates <see cref="RunEvalSuiteCommand"/> before execution. Catches obvious
 /// misconfigurations (empty path list, invalid repeats/parallelism) before any work begins.
 /// </summary>
+/// <remarks>
+/// <para>
+/// The ceilings come from <c>AppConfig:AI:Evaluation</c> rather than being hard-coded. Until now
+/// <c>EvalRunOptions.Parallelism</c> had a lower bound and no upper one here: the 1–128 range existed
+/// only in the EvalRunner CLI's argument parsing, so any dispatcher that was not that CLI could ask
+/// for unbounded concurrency against the model provider. Repeats and parallelism both multiply real
+/// spend, so their ceilings belong somewhere an operator can set them.
+/// </para>
+/// <para>
+/// Read through <see cref="IOptionsMonitor{TOptions}"/> per validation so tightening a ceiling takes
+/// effect without a restart — the same reason <c>SearchDocumentsQueryValidator</c> does.
+/// </para>
+/// </remarks>
 public sealed class RunEvalSuiteCommandValidator : AbstractValidator<RunEvalSuiteCommand>
 {
-    /// <summary>Initializes the validator with rules for command shape.</summary>
-    public RunEvalSuiteCommandValidator()
+    /// <summary>Initializes the validator with rules for command shape and configured cost ceilings.</summary>
+    /// <param name="appConfigMonitor">Live application configuration supplying the evaluation ceilings.</param>
+    public RunEvalSuiteCommandValidator(IOptionsMonitor<AppConfig> appConfigMonitor)
     {
+        ArgumentNullException.ThrowIfNull(appConfigMonitor);
+
         RuleFor(x => x.DatasetPaths)
             .NotEmpty().WithMessage("At least one dataset path is required.");
+
+        RuleFor(x => x.DatasetPaths)
+            .Must(paths => paths is null || paths.Count <= Evaluation(appConfigMonitor).MaxDatasetsPerRun)
+            .WithMessage(_ =>
+                $"At most {Evaluation(appConfigMonitor).MaxDatasetsPerRun} datasets may be evaluated in one run.");
 
         RuleForEach(x => x.DatasetPaths)
             .NotEmpty().WithMessage("Dataset paths must not be empty strings.");
 
         RuleFor(x => x.Options.Repeats)
-            .InclusiveBetween(1, 50)
-            .WithMessage("Repeats must be between 1 and 50.");
+            .Must(repeats => repeats >= 1 && repeats <= Evaluation(appConfigMonitor).MaxRepeats)
+            .WithMessage(_ => $"Repeats must be between 1 and {Evaluation(appConfigMonitor).MaxRepeats}.");
 
         RuleFor(x => x.Options.Parallelism)
-            .GreaterThanOrEqualTo(1)
-            .WithMessage("Parallelism must be at least 1.");
+            .Must(parallelism => parallelism >= 1 && parallelism <= Evaluation(appConfigMonitor).MaxParallelism)
+            .WithMessage(_ => $"Parallelism must be between 1 and {Evaluation(appConfigMonitor).MaxParallelism}.");
 
         RuleFor(x => x.Options.FailRateThreshold)
             .InclusiveBetween(0.0, 1.0)
             .WithMessage("FailRateThreshold must be between 0.0 and 1.0.");
     }
+
+    private static EvaluationConfig Evaluation(IOptionsMonitor<AppConfig> monitor) =>
+        monitor.CurrentValue.AI.Evaluation;
 }

--- a/src/Content/Application/Application.Core/DependencyInjection.cs
+++ b/src/Content/Application/Application.Core/DependencyInjection.cs
@@ -50,6 +50,19 @@ public static class DependencyInjection
 		// request-scoped IMediator.
 		services.AddScoped<ILearningRecaller, MediatorLearningRecaller>();
 
+		// Evaluation dataset path guard — decides which dataset files a run may read. Registered
+		// unconditionally so the confinement rule is applied by the handler on EVERY dispatch, not
+		// only the ones a caller remembered to route through it. Unconfined until an operator sets
+		// AppConfig:AI:Evaluation:DatasetRoots, which preserves the EvalRunner CLI's local workflow.
+		services.AddSingleton<CQRS.Evaluation.RunEvalSuite.IEvalDatasetPathGuard,
+			CQRS.Evaluation.RunEvalSuite.EvalDatasetPathGuard>();
+
+		// Default confinement latch: no host has claimed a startup check. A host that verifies dataset
+		// roots at boot re-registers this as true (last-write-wins), which is what stops a later config
+		// reload from loosening confinement. Deliberately a constant rather than a configuration read —
+		// see EvalConfinementLatch for why deriving it lazily would defeat the point.
+		services.AddSingleton(new CQRS.Evaluation.RunEvalSuite.EvalConfinementLatch(StartedConfined: false));
+
 		// Autonomy tier rule provider — generates baseline permission rules from agent tier
 		services.AddSingleton<IPermissionRuleProvider, AutonomyTierRuleProvider>();
 

--- a/src/Content/Domain/Domain.Common/Config/AI/AIConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/AIConfig.cs
@@ -214,6 +214,14 @@ public class AIConfig
     /// </summary>
     public WorkflowSubmissionConfig WorkflowSubmission { get; set; } = new();
 
+    /// <summary>
+    /// Server-side evaluation configuration: the directories dataset files may be read from, and the
+    /// ceilings on what a single run may spend. The defaults are unconfined and permissive because
+    /// they preserve the EvalRunner CLI's local workflow; a host that exposes evaluation to any caller
+    /// it does not trust must set <see cref="EvaluationConfig.DatasetRoots"/>.
+    /// </summary>
+    public EvaluationConfig Evaluation { get; set; } = new();
+
     /// <summary>Agent Governance Toolkit configuration.</summary>
     public GovernanceConfig Governance { get; init; } = new();
 

--- a/src/Content/Domain/Domain.Common/Config/AI/EvaluationConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/EvaluationConfig.cs
@@ -1,0 +1,128 @@
+namespace Domain.Common.Config.AI;
+
+/// <summary>
+/// Server-side evaluation configuration: where dataset files may be read from, and the ceilings on
+/// what one run may spend. Bound from <c>AppConfig:AI:Evaluation</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>Why this exists.</strong> Evaluation was built for the EvalRunner CLI, where the caller is
+/// a developer on their own machine and every input is trusted. The ceilings that keep a run bounded
+/// (parallelism 1–128, a sensible case count) lived only in that CLI's argument parsing, and
+/// <c>RunEvalSuiteCommand</c> accepted raw filesystem paths validated solely as non-empty. Both are
+/// correct for a local tool and neither survives contact with an HTTP caller: unbounded parallelism
+/// is a cost and rate-limit amplifier, and a raw path is an arbitrary-file-read probe.
+/// </para>
+/// <para>
+/// <strong>Confinement is opt-in, and that is deliberate.</strong> When <see cref="DatasetRoots"/> is
+/// empty, dataset paths are unconfined — which preserves the CLI workflow of pointing the runner at a
+/// file anywhere on disk. When it is non-empty, <em>every</em> dispatch of the command is confined,
+/// regardless of who dispatched it. The enforcement therefore lives at the handler, not at each
+/// caller: a check the HTTP surface has to remember to perform is a check that will eventually be
+/// forgotten. A host exposing evaluation over HTTP must configure roots, and the HTTP surface refuses
+/// to run without them rather than falling back to the unconfined behaviour.
+/// </para>
+/// </remarks>
+public class EvaluationConfig
+{
+    /// <summary>
+    /// Whether this host wires the evaluation framework at all. Off by default: the framework brings
+    /// a YAML loader, twelve metric singletons, three reporters, and the harness agent invoker, and a
+    /// host that never evaluates should not pay for them on every cold start.
+    /// </summary>
+    /// <remarks>
+    /// Turning this on in a host that serves untrusted callers <strong>requires</strong>
+    /// <see cref="DatasetRoots"/>. The host refuses to start otherwise rather than falling back to the
+    /// unconfined default, which is correct for the CLI and wrong for anything reachable over a
+    /// network.
+    /// </remarks>
+    public bool Enabled { get; set; }
+
+    /// <summary>
+    /// Directories that dataset files may be read from. Empty (the default) means unconfined, which is
+    /// correct only for a trusted local caller such as the EvalRunner CLI.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Paths are compared after full canonicalisation, so <c>..</c> traversal and symbolic links that
+    /// point outside a root are rejected rather than resolved through — on every path segment, not just
+    /// the last one.
+    /// </para>
+    /// <para>
+    /// <strong>Configure absolute paths.</strong> A relative entry is resolved against the process's
+    /// current working directory, which is not reliably the content root: a service unit, a Windows
+    /// service, or a container whose <c>WORKDIR</c> differs will each resolve it somewhere else, and the
+    /// resulting root would confine to a directory nobody intended.
+    /// </para>
+    /// <para>
+    /// Blank and whitespace-only entries are dropped. Once a host has started with roots configured,
+    /// removing them at runtime does not restore unconfined reads — it refuses everything instead.
+    /// </para>
+    /// <para>
+    /// <strong>Deployment invariant: a root must not be writable by anyone the host would not already
+    /// let read arbitrary files.</strong> This is not a code guarantee and cannot be made one. Anyone who
+    /// can write inside a root can place a hard link there (which has no target to resolve and is
+    /// indistinguishable from an ordinary file), or swap a file for a symbolic link between the moment
+    /// the path is checked and the moment it is opened. Confinement bounds which <em>paths</em> a caller
+    /// may name; it cannot bound what the contents of a writable directory turn out to be.
+    /// </para>
+    /// </remarks>
+    public List<string> DatasetRoots { get; set; } = [];
+
+    /// <summary>
+    /// Maximum number of dataset files one run may load. Guards against a caller submitting a large
+    /// list to multiply the run's cost.
+    /// </summary>
+    /// <value>Default: 10.</value>
+    public int MaxDatasetsPerRun { get; set; } = 10;
+
+    /// <summary>
+    /// Maximum number of case <em>executions</em> one run may perform — the loaded case count multiplied
+    /// by <c>Repeats</c>, which is what the run actually costs.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Counting cases alone would leave the ceiling trivially bypassable: 500 cases at the default 50
+    /// repeats is 25,000 governed agent turns plus their judge calls, all from a request that passed a
+    /// "500" limit. Repeats multiply spend, so they belong inside the number being capped.
+    /// </para>
+    /// <para>
+    /// Counted from the datasets as loaded, <em>before</em> any tag filter narrows them. That
+    /// over-estimates a filtered run, and deliberately so: the error direction refuses a run that might
+    /// have fitted rather than admitting one that does not.
+    /// </para>
+    /// <para>
+    /// A run that would exceed this is refused rather than truncated — silently evaluating a subset
+    /// would report a pass rate for a suite that never ran.
+    /// </para>
+    /// </remarks>
+    /// <value>Default: 500.</value>
+    public int MaxCaseExecutionsPerRun { get; set; } = 500;
+
+    /// <summary>
+    /// Maximum size of a single dataset file, in bytes. Checked before the file is opened.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="MaxCaseExecutionsPerRun"/> bounds what a run may <em>execute</em>, but it can only be
+    /// evaluated once cases exist — which means parsing. Without a size cap the parse itself is the
+    /// attack: a caller names a file large enough to exhaust memory and the run is refused only
+    /// afterwards, having already paid the cost. This bounds the work done before that decision.
+    /// </remarks>
+    /// <value>Default: 5 MiB — far above any realistic hand-authored suite.</value>
+    public long MaxDatasetBytes { get; set; } = 5 * 1024 * 1024;
+
+    /// <summary>
+    /// Ceiling on <c>EvalRunOptions.Repeats</c>. Each repeat re-invokes every case and its LLM judge,
+    /// so cost scales linearly with this.
+    /// </summary>
+    /// <value>Default: 50, matching the validator's long-standing bound.</value>
+    public int MaxRepeats { get; set; } = 50;
+
+    /// <summary>
+    /// Ceiling on <c>EvalRunOptions.Parallelism</c>. Previously enforced only by the EvalRunner CLI's
+    /// argument parsing, so any other dispatcher could request unbounded concurrency against the
+    /// model provider.
+    /// </summary>
+    /// <value>Default: 128, matching the CLI's long-standing bound.</value>
+    public int MaxParallelism { get; set; } = 128;
+}

--- a/src/Content/Presentation/Presentation.ExecutionApi/Extensions/ExecutionApiEvaluationExtensions.cs
+++ b/src/Content/Presentation/Presentation.ExecutionApi/Extensions/ExecutionApiEvaluationExtensions.cs
@@ -1,0 +1,72 @@
+using Application.Core.CQRS.Evaluation.RunEvalSuite;
+using Domain.Common.Config;
+using Infrastructure.AI.Evaluation;
+
+namespace Presentation.ExecutionApi.Extensions;
+
+/// <summary>
+/// Opt-in wiring for the evaluation framework in this host.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The framework is not registered by the shared composition root — a host that never evaluates should
+/// not carry the YAML loader, the metric singletons, the reporters, and the harness agent invoker on
+/// every cold start. Hosts that do evaluate call this after <c>GetServices</c>, so the real
+/// <c>IEvalRunner</c> replaces the fail-fast <c>NotConfiguredEvalRunner</c> default by last-write-wins.
+/// </para>
+/// </remarks>
+public static class ExecutionApiEvaluationExtensions
+{
+    /// <summary>
+    /// Registers the evaluation framework when <c>AppConfig:AI:Evaluation:Enabled</c> is set, and
+    /// refuses to start when it is set without any dataset root configured.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="configuration">Configuration to read the evaluation section from.</param>
+    /// <returns>The service collection, for chaining.</returns>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when evaluation is enabled but <c>DatasetRoots</c> is empty. This is a deliberate
+    /// startup failure rather than a warning: an empty root list means "read any path the process
+    /// can reach", which is the correct default for the local CLI and never correct for a host that
+    /// serves callers it does not trust. A host that booted anyway would look configured while
+    /// honouring whatever path a caller sent.
+    /// </exception>
+    public static IServiceCollection AddExecutionApiEvaluation(
+        this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        var evaluation = configuration
+            .GetSection("AppConfig:AI:Evaluation")
+            .Get<Domain.Common.Config.AI.EvaluationConfig>() ?? new Domain.Common.Config.AI.EvaluationConfig();
+
+        if (!evaluation.Enabled)
+            return services;
+
+        var roots = evaluation.DatasetRoots
+            .Where(root => !string.IsNullOrWhiteSpace(root))
+            .ToList();
+
+        if (roots.Count == 0)
+        {
+            throw new InvalidOperationException(
+                "AppConfig:AI:Evaluation:Enabled is true but DatasetRoots is empty. Evaluation reads "
+                + "dataset files named by the caller, and with no roots configured that is unconfined. "
+                + "Configure at least one directory under AppConfig:AI:Evaluation:DatasetRoots, or set "
+                + "Enabled to false.");
+        }
+
+        services.AddEvaluationDependencies();
+
+        // Record that confinement was verified HERE, at startup, while the roots above were proven
+        // non-empty. The guard cannot derive this for itself: it is a lazy singleton, so its constructor
+        // first runs on the first eval dispatch, and configuration is bound with reloadOnChange — a
+        // reload that emptied DatasetRoots in between would have it conclude the host started
+        // unconfined. Latching the verdict at composition time is what makes the ratchet real.
+        services.AddSingleton(new EvalConfinementLatch(StartedConfined: true));
+
+        return services;
+    }
+}

--- a/src/Content/Presentation/Presentation.ExecutionApi/Program.cs
+++ b/src/Content/Presentation/Presentation.ExecutionApi/Program.cs
@@ -14,6 +14,16 @@ builder.Services.GetServices(includeHealthChecksUI: false);
 // and per-path rate limiting.
 builder.Services.AddExecutionApiServices(builder.Configuration);
 
+// Evaluation framework — opt-in, and registered AFTER GetServices so its real IEvalRunner wins over the
+// fail-fast NotConfiguredEvalRunner default (last-write-wins, the documented pattern in
+// Presentation.Common/Extensions/IServiceCollectionExtensions.cs).
+//
+// Fail-closed on the dataset roots. Evaluation reads files named by the caller, and with no roots configured
+// that is unconfined by design — correct for the EvalRunner CLI on a developer's machine, and an
+// arbitrary-file-read probe on a host reachable by anyone else. Refusing to start is the honest response:
+// booting anyway would leave a host that looks configured and reads whatever it is asked for.
+builder.Services.AddExecutionApiEvaluation(builder.Configuration);
+
 // Enforce the harness's boot-time DI validation policy (ValidateScopes + ValidateOnBuild) in ALL environments,
 // single-sourced so hosts cannot drift: it catches captive dependencies and turns a mis-wired handler into a
 // caught-at-startup failure rather than a first-dispatch crash.

--- a/src/Content/Presentation/Presentation.ExecutionApi/README.md
+++ b/src/Content/Presentation/Presentation.ExecutionApi/README.md
@@ -14,6 +14,7 @@ It is a composition root, exactly like `Presentation.AgentHub`: `builder.Service
 │                                                                              │
 │  Program.cs → GetServices(includeHealthChecksUI: false)                      │
 │             → AddExecutionApiServices(configuration)                            │
+│             → AddExecutionApiEvaluation(configuration)  ← opt-in, fail-closed │
 │             → UseDefaultServiceProvider(ApplyValidationPolicy)  ← all envs   │
 │                                                                              │
 │  Middleware: SecurityHeaders → GlobalException → [HSTS/HTTPS] → Routing      │
@@ -124,7 +125,8 @@ Presentation.ExecutionApi/
 │   ├── WorkflowRunContracts.cs      Run start/cancel/status projections
 │   └── ToolCatalogContracts.cs      Catalog entry + listing; RiskTier travels as a name, not an ordinal
 ├── Extensions/
-│   └── ExecutionApiServiceCollectionExtensions.cs   Controllers, auth, FormOptions cap, rate limiters
+│   ├── ExecutionApiServiceCollectionExtensions.cs   Controllers, auth, FormOptions cap, rate limiters
+│   └── ExecutionApiEvaluationExtensions.cs          Opt-in eval framework; throws if enabled without roots
 ├── Services/
 │   ├── BundleCallerIdentity.cs      Stable per-caller id (oid → objectidentifier → nameid → sub)
 │   ├── AnonymousAuthenticationHandler.cs
@@ -161,6 +163,50 @@ Everything lives under `AppConfig:AI:BundleExecution` (`Domain.Common/Config/AI/
 | `Auth:AllowAnonymous` | `false` | Explicit local-dev opt-in; `Environment=Development` alone does not disable auth |
 
 The shipped `appsettings.json` sets `Enabled: true` with an empty `Auth` block, so it boots only in Development — where the shipped `appsettings.Development.json` opts into anonymous auth. Every other environment fails closed at startup until a real scheme is configured.
+
+### Evaluation (`AppConfig:AI:Evaluation`)
+
+Separate section, separate opt-in. The evaluation framework is **not** wired by `GetServices()` — a
+host that never evaluates should not carry the YAML loader, the metric singletons, the reporters, and
+the harness agent invoker on every cold start. `AddExecutionApiEvaluation` adds them, and runs
+*after* `AddExecutionApiServices` so the real `IEvalRunner` replaces the fail-fast
+`NotConfiguredEvalRunner` by last-write-wins.
+
+| Key | Default | Notes |
+|-----|---------|-------|
+| `Enabled` | `false` | Off ⇒ framework unregistered; any dispatch hits `NotConfiguredEvalRunner` and throws loudly rather than appearing to work |
+| `DatasetRoots` | `[]` | Directories dataset files may be read from. **Empty means unconfined.** Use absolute paths — a relative entry resolves against the working directory, not the content root. Blank entries are dropped |
+| `MaxDatasetBytes` | 5 MiB | Checked before the file is opened, so an oversized dataset is never parsed |
+| `MaxDatasetsPerRun` | 10 | Enforced by the validator |
+| `MaxCaseExecutionsPerRun` | 500 | Cases **× `Repeats`** — what the run actually costs. Counted before tag filtering (over-estimates, so it errs toward refusing); enforced by the handler |
+| `MaxRepeats` | 50 | Was the validator's hard-coded bound |
+| `MaxParallelism` | 128 | Previously enforced **only** by the EvalRunner CLI's argument parsing |
+
+> **`Enabled: true` with no usable `DatasetRoots` throws at startup.** This is deliberate, and it is
+> the whole reason the section exists. Evaluation reads dataset files named by the caller; with no
+> roots configured that is unconfined — correct for the CLI on a developer's own machine, and an
+> arbitrary-file-read probe on a host anyone else can reach. A host that booted anyway would *look*
+> configured while honouring whatever path it was sent. Whitespace-only entries do not count: a gate
+> you can tick with a space is not a gate.
+
+Confinement itself lives in `EvalDatasetPathGuard`, applied by `RunEvalSuiteCommandHandler` rather
+than by each caller — a check every dispatcher must remember to perform is one that will eventually
+be skipped. It canonicalises before comparing (so `..` cannot walk out), resolves symlinks to their
+final target (a link inside a root can point anywhere), and compares against the root **plus a
+separator** (without it, `/data/evals-secret` reads as inside `/data/evals`). Refusals do not
+distinguish *forbidden* from *absent*, or the endpoint becomes a filesystem oracle.
+
+**Confinement ratchets.** Adding a root at runtime tightens immediately; emptying the list refuses
+everything rather than returning to unconfined. That verdict is latched at composition time by
+`AddExecutionApiEvaluation` (as an `EvalConfinementLatch`) rather than derived inside the guard,
+because the guard is a lazy singleton — a latch it computed for itself would first run on the initial
+eval dispatch and record whatever a `reloadOnChange` had done to the config by then.
+
+> **Deployment invariant — a configured root must not be writable by anyone you would not already let
+> read arbitrary files.** This one cannot be enforced in code. Anyone who can write inside a root can
+> place a *hard* link there (no target to resolve, indistinguishable from an ordinary file), or swap a
+> file for a symlink between the check and the open. Confinement bounds which **paths** a caller may
+> name; it cannot bound what a writable directory turns out to contain.
 
 ## How to Run
 
@@ -251,6 +297,8 @@ consumers cannot tell which third is missing.
 | `BundleRunStreamerTests.cs` | Frame sequencing, terminal-frame exclusivity, sink cleanup |
 | `ExecutionApiAuthenticationTests.cs` | The three fail-closed startup guards |
 | `BundleCallerIdentityTests.cs` | Claim-precedence for the stable id |
+| `ToolsControllerIntegrationTests.cs` | Envelope-filtered discovery, 404 for ungranted, 401 against a configured host, and that every catalogued name resolves to a tool agreeing with it |
+| `ExecutionApiEvaluationEnablementTests.cs` | The evaluation opt-in: default leaves the fail-fast runner, enabled-without-roots refuses to boot, blank roots do not satisfy it |
 
 ```bash
 dotnet test src/Content/Tests/Presentation.ExecutionApi.Tests

--- a/src/Content/Tests/Infrastructure.AI.Evaluation.Tests/CQRS/EvalDatasetPathGuardTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Evaluation.Tests/CQRS/EvalDatasetPathGuardTests.cs
@@ -1,0 +1,352 @@
+using Application.Core.CQRS.Evaluation.RunEvalSuite;
+using Domain.Common.Config;
+using FluentAssertions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Infrastructure.AI.Evaluation.Tests.CQRS;
+
+/// <summary>
+/// Tests for <see cref="EvalDatasetPathGuard"/> — which dataset files a run may read.
+/// </summary>
+/// <remarks>
+/// These are the tests that matter for exposing evaluation over HTTP. Without confinement,
+/// <c>RunEvalSuiteCommand</c> accepts any path the process can read and reports whether it exists,
+/// which is an arbitrary-file-read probe and a filesystem oracle in one. Each case below is a way a
+/// caller would try to get outside the allowed roots.
+/// </remarks>
+public sealed class EvalDatasetPathGuardTests : IDisposable
+{
+    private readonly string _root;
+    private readonly string _outside;
+
+    public EvalDatasetPathGuardTests()
+    {
+        var baseDir = Path.Combine(Path.GetTempPath(), "eval-guard-" + Guid.NewGuid().ToString("N"));
+        _root = Path.Combine(baseDir, "allowed");
+        _outside = Path.Combine(baseDir, "secret");
+        Directory.CreateDirectory(_root);
+        Directory.CreateDirectory(_outside);
+    }
+
+    public void Dispose()
+    {
+        var parent = Path.GetDirectoryName(_root);
+        if (parent is not null && Directory.Exists(parent))
+            Directory.Delete(parent, recursive: true);
+    }
+
+    private static EvalDatasetPathGuard GuardWith(params string[] roots)
+    {
+        var config = new AppConfig();
+        config.AI.Evaluation.DatasetRoots = [.. roots];
+        return GuardOver(config, startedConfined: false);
+    }
+
+    /// <summary>
+    /// Builds a guard over live <paramref name="config"/> so a test can mutate it afterwards and observe
+    /// what the guard does with the change.
+    /// </summary>
+    /// <param name="startedConfined">
+    /// What the composition root recorded at boot. Passed in rather than derived, exactly as in
+    /// production — the guard is a lazy singleton, so a latch it computed for itself would record
+    /// whatever configuration said at first dispatch instead of at startup.
+    /// </param>
+    private static EvalDatasetPathGuard GuardOver(AppConfig config, bool startedConfined)
+    {
+        var monitor = new Mock<IOptionsMonitor<AppConfig>>();
+        monitor.SetupGet(m => m.CurrentValue).Returns(config);
+        return new EvalDatasetPathGuard(monitor.Object, new EvalConfinementLatch(startedConfined));
+    }
+
+    private string WriteFile(string directory, string name)
+    {
+        var path = Path.Combine(directory, name);
+        File.WriteAllText(path, "cases: []");
+        return path;
+    }
+
+    [Fact]
+    public void NoRootsConfigured_AllowsAnyExistingFile()
+    {
+        // The shipped default. The EvalRunner CLI's whole workflow is pointing at a file anywhere on
+        // disk, and a local developer can read those files regardless — making roots mandatory would
+        // break the tool for no security gain.
+        var outsideFile = WriteFile(_outside, "local.yaml");
+
+        var decision = GuardWith().Resolve(outsideFile);
+
+        decision.IsAllowed.Should().BeTrue();
+        decision.CanonicalPath.Should().Be(Path.GetFullPath(outsideFile));
+    }
+
+    [Fact]
+    public void NoRootsConfigured_StillRefusesAMissingFile()
+    {
+        var decision = GuardWith().Resolve(Path.Combine(_outside, "absent.yaml"));
+
+        decision.IsAllowed.Should().BeFalse();
+    }
+
+    [Fact]
+    public void RootConfigured_AllowsAFileInsideIt()
+    {
+        var inside = WriteFile(_root, "suite.yaml");
+
+        var decision = GuardWith(_root).Resolve(inside);
+
+        decision.IsAllowed.Should().BeTrue();
+        decision.CanonicalPath.Should().Be(Path.GetFullPath(inside));
+    }
+
+    [Fact]
+    public void RootConfigured_RefusesAFileOutsideIt()
+    {
+        var outsideFile = WriteFile(_outside, "secrets.yaml");
+
+        GuardWith(_root).Resolve(outsideFile).IsAllowed.Should().BeFalse();
+    }
+
+    [Fact]
+    public void RootConfigured_RefusesTraversalOutOfTheRoot()
+    {
+        // The attack the canonicalisation exists for: this string starts with the allowed root and
+        // resolves outside it. A guard comparing raw strings would admit it.
+        WriteFile(_outside, "secrets.yaml");
+        var traversal = Path.Combine(_root, "..", "secret", "secrets.yaml");
+
+        var decision = GuardWith(_root).Resolve(traversal);
+
+        decision.IsAllowed.Should().BeFalse();
+    }
+
+    [Fact]
+    public void RootConfigured_RefusesASiblingRootSharingThePrefix()
+    {
+        // "/…/allowed-elsewhere" starts with "/…/allowed" as a string but is a different directory.
+        // Comparing without a trailing separator would admit every sibling whose name extends the root.
+        var sibling = _root + "-elsewhere";
+        Directory.CreateDirectory(sibling);
+        var file = WriteFile(sibling, "suite.yaml");
+
+        GuardWith(_root).Resolve(file).IsAllowed.Should().BeFalse();
+    }
+
+    [Fact]
+    public void RootConfigured_RefusalsDoNotDistinguishAbsentFromForbidden()
+    {
+        // Distinguishing them turns the endpoint into a filesystem oracle: a caller could map the disk
+        // by watching which message came back for each probe.
+        var forbidden = WriteFile(_outside, "exists-but-forbidden.yaml");
+        var absent = Path.Combine(_root, "does-not-exist.yaml");
+
+        var guard = GuardWith(_root);
+
+        guard.Resolve(forbidden).Reason.Should().Be(guard.Resolve(absent).Reason);
+    }
+
+    [Fact]
+    public void RootConfigured_RefusesASymlinkInsideTheRootPointingOutside()
+    {
+        // A link that lives inside the root but resolves outside it. The file the loader ultimately
+        // opens is the target, so the target is what must be checked.
+        var target = WriteFile(_outside, "secrets.yaml");
+        var link = Path.Combine(_root, "innocent.yaml");
+
+        try
+        {
+            File.CreateSymbolicLink(link, target);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or PlatformNotSupportedException)
+        {
+            // Windows needs Developer Mode or elevation to create symlinks. Skipping is honest here;
+            // the assertion below would otherwise pass for the wrong reason (link never created).
+            return;
+        }
+
+        GuardWith(_root).Resolve(link).IsAllowed.Should().BeFalse();
+    }
+
+    [Fact]
+    public void RootConfigured_RefusesAFileBeneathADirectoryLinkPointingOutside()
+    {
+        // The evasion that resolving only the final path segment leaves open. Nothing about
+        // "…/allowed/window/secrets.yaml" looks suspicious — it canonicalises to a path starting with
+        // the allowed root — but "window" is a link and the file opened lives outside. Every segment
+        // has to be resolved, not just the leaf.
+        var target = WriteFile(_outside, "secrets.yaml");
+        var linkedDirectory = Path.Combine(_root, "window");
+
+        try
+        {
+            Directory.CreateSymbolicLink(linkedDirectory, _outside);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or PlatformNotSupportedException)
+        {
+            // Windows needs Developer Mode or elevation. Skipping is honest; the assertion would
+            // otherwise pass because the link was never created.
+            return;
+        }
+
+        var throughTheLink = Path.Combine(linkedDirectory, Path.GetFileName(target));
+        File.Exists(throughTheLink).Should().BeTrue("the link must actually reach the file, or this proves nothing");
+
+        GuardWith(_root).Resolve(throughTheLink).IsAllowed.Should().BeFalse();
+    }
+
+    [Fact]
+    public void RootConfigured_RefusesAChainLongerThanTheHopBudget()
+    {
+        // Running out of budget means the walk did not finish, so the path in hand may still be a link.
+        // Here every link of the chain lives inside the allowed root while the real file does not — so
+        // giving up and answering with whatever segment we stopped on would pass containment and hand
+        // the loader an escape. Not knowing where a path leads has to refuse, like every other failure
+        // mode in this guard.
+        var target = WriteFile(_outside, "secrets.yaml");
+        var chain = new List<string>();
+
+        try
+        {
+            // Longer than MaxLinkHops (16). Built tail-first so each link points at the one after it.
+            var next = target;
+            for (var i = 0; i < 20; i++)
+            {
+                var link = Path.Combine(_root, $"hop-{i}.yaml");
+                File.CreateSymbolicLink(link, next);
+                chain.Add(link);
+                next = link;
+            }
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or PlatformNotSupportedException)
+        {
+            return; // Windows without Developer Mode — skipping beats passing for the wrong reason.
+        }
+
+        var head = chain[^1];
+        File.Exists(head).Should().BeTrue("the OS must resolve the whole chain, or this proves nothing");
+
+        GuardWith(_root).Resolve(head).IsAllowed.Should().BeFalse();
+    }
+
+    [Fact]
+    public void RootReachedThroughASymlinkedDirectory_StillAllowsFilesInsideIt()
+    {
+        // macOS `/tmp` is a link to `/private/tmp`, and container bind mounts are often the same shape.
+        // If roots were only canonicalised while candidates were fully link-resolved, the two would
+        // never share a prefix and a correctly-configured root would refuse every legitimate path. That
+        // fails closed, so it is not a bypass — but a confinement rule that rejects everything is one
+        // somebody switches off.
+        var realRoot = Path.Combine(Path.GetDirectoryName(_root)!, "real-root");
+        Directory.CreateDirectory(realRoot);
+        var linkedRoot = Path.Combine(Path.GetDirectoryName(_root)!, "linked-root");
+
+        try
+        {
+            Directory.CreateSymbolicLink(linkedRoot, realRoot);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or PlatformNotSupportedException)
+        {
+            return; // Windows without Developer Mode.
+        }
+
+        var file = WriteFile(realRoot, "suite.yaml");
+
+        // The root is configured by its linked name; the file is named by its real one.
+        GuardWith(linkedRoot).Resolve(file).IsAllowed.Should().BeTrue();
+    }
+
+    [Fact]
+    public void RootConfigured_StillAllowsARealFileBeneathARealSubdirectory()
+    {
+        // The other half of segment-walking: resolving every segment must not start refusing ordinary
+        // nested paths. Without this, the test above is satisfied by a guard that refuses everything.
+        var nested = Path.Combine(_root, "suites", "regression");
+        Directory.CreateDirectory(nested);
+        var file = WriteFile(nested, "suite.yaml");
+
+        GuardWith(_root).Resolve(file).IsAllowed.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void BlankPath_IsRefused(string path)
+    {
+        GuardWith(_root).Resolve(path).IsAllowed.Should().BeFalse();
+    }
+
+    [Fact]
+    public void MultipleRoots_AllowsAFileInAnyOfThem()
+    {
+        var second = _root + "-second";
+        Directory.CreateDirectory(second);
+        var file = WriteFile(second, "suite.yaml");
+
+        GuardWith(_root, second).Resolve(file).IsAllowed.Should().BeTrue();
+    }
+
+    [Fact]
+    public void RootsRemovedAfterStartup_RefuseEverythingRatherThanReturningToUnconfined()
+    {
+        // The startup check that stops an unconfined host booting runs once. If emptying DatasetRoots at
+        // runtime dropped this guard back to the permissive branch, a configuration reload would silently
+        // convert a confined host into arbitrary-file-read — with no error and nothing in the log.
+        var config = new AppConfig();
+        config.AI.Evaluation.DatasetRoots = [_root];
+
+        var guard = GuardOver(config, startedConfined: true);
+
+        var inside = WriteFile(_root, "suite.yaml");
+        guard.Resolve(inside).IsAllowed.Should().BeTrue("the guard starts confined and the file is inside");
+
+        config.AI.Evaluation.DatasetRoots = [];
+
+        guard.Resolve(inside).IsAllowed.Should().BeFalse(
+            "a host that started confined must not be talked back into unconfined reads");
+    }
+
+    [Fact]
+    public void RootsAlreadyGoneWhenTheGuardIsFirstBuilt_StillRefuse()
+    {
+        // The case a latch computed inside the constructor would miss entirely. The guard is a lazy
+        // singleton, so it is first built on the first eval dispatch — potentially long after boot, and
+        // after a config reload has emptied the roots. The startup verdict has to be passed in, or the
+        // guard concludes it started unconfined and reads anything.
+        var config = new AppConfig();
+        config.AI.Evaluation.DatasetRoots = [];
+
+        var guard = GuardOver(config, startedConfined: true);
+
+        var outsideFile = WriteFile(_outside, "secrets.yaml");
+
+        guard.Resolve(outsideFile).IsAllowed.Should().BeFalse(
+            "the host verified confinement at startup; the guard being built later cannot undo that");
+    }
+
+    [Fact]
+    public void RootsAddedAfterStartup_TakeEffectImmediately()
+    {
+        // The ratchet only blocks loosening. Tightening still applies live, which is what makes reading
+        // configuration per call worth doing at all.
+        var config = new AppConfig();
+        var guard = GuardOver(config, startedConfined: false);
+
+        var outsideFile = WriteFile(_outside, "secrets.yaml");
+        guard.Resolve(outsideFile).IsAllowed.Should().BeTrue("unconfined at construction");
+
+        config.AI.Evaluation.DatasetRoots = [_root];
+
+        guard.Resolve(outsideFile).IsAllowed.Should().BeFalse("adding a root must confine immediately");
+    }
+
+    [Fact]
+    public void BlankRootEntry_IsIgnoredRatherThanTreatedAsAllowingEverything()
+    {
+        // An empty string canonicalises to the current directory. Treating it as a root would quietly
+        // widen the allowlist to wherever the host happens to be running from.
+        var outsideFile = WriteFile(_outside, "secrets.yaml");
+
+        GuardWith("", _root).Resolve(outsideFile).IsAllowed.Should().BeFalse();
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Evaluation.Tests/CQRS/RunEvalSuiteCommandHandlerTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Evaluation.Tests/CQRS/RunEvalSuiteCommandHandlerTests.cs
@@ -4,6 +4,8 @@ using Application.Core.CQRS.Evaluation.RunEvalSuite;
 using Domain.AI.Evaluation;
 using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
+using Domain.Common.Config;
+using Microsoft.Extensions.Options;
 using Moq;
 using Xunit;
 
@@ -66,12 +68,163 @@ public sealed class RunEvalSuiteCommandHandlerTests : IDisposable
         return mock;
     }
 
+    /// <summary>
+    /// Builds the handler with a real, UNCONFINED path guard — the shipped default, which is what the
+    /// EvalRunner CLI runs under. A stub guard would make these tests blind to the handler actually
+    /// consulting it; confinement itself is covered directly in <c>EvalDatasetPathGuardTests</c>.
+    /// </summary>
     private static RunEvalSuiteCommandHandler MakeSut(
         IEnumerable<IEvalDatasetLoader> loaders,
-        IEvalRunner runner) => new(
+        IEvalRunner runner,
+        AppConfig? config = null) => new(
             loaders,
             runner,
+            new EvalDatasetPathGuard(MonitorFor(config ?? new AppConfig()), new EvalConfinementLatch(false)),
+            MonitorFor(config ?? new AppConfig()),
             NullLogger<RunEvalSuiteCommandHandler>.Instance);
+
+    private static IOptionsMonitor<AppConfig> MonitorFor(AppConfig config)
+    {
+        var monitor = new Mock<IOptionsMonitor<AppConfig>>();
+        monitor.SetupGet(m => m.CurrentValue).Returns(config);
+        return monitor.Object;
+    }
+
+    [Fact]
+    public async Task Refuses_a_run_whose_case_count_exceeds_the_configured_ceiling()
+    {
+        // Every case is a governed agent turn plus its LLM-judge calls, multiplied by Repeats. This is
+        // the last point at which the spend can be refused instead of incurred, so the check has to
+        // happen BEFORE the runner is handed anything - asserting the runner was never invoked is the
+        // part that matters; a test that only checked the returned failure would pass even if the run
+        // had already been paid for.
+        var config = new AppConfig();
+        config.AI.Evaluation.MaxCaseExecutionsPerRun = 1;
+
+        var path1 = CreateFile("a.yaml");
+        var path2 = CreateFile("b.yaml");
+        var loader = Loader([".yaml"]);
+        var runner = new Mock<IEvalRunner>();
+
+        var sut = MakeSut([loader.Object], runner.Object, config);
+
+        var result = await sut.Handle(
+            new RunEvalSuiteCommand { DatasetPaths = [path1, path2] }, CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        runner.Verify(
+            r => r.RunAsync(It.IsAny<IReadOnlyList<EvalDataset>>(), It.IsAny<EvalRunOptions>(), It.IsAny<CancellationToken>()),
+            Times.Never,
+            "the ceiling must refuse the run before any model spend");
+    }
+
+    [Fact]
+    public async Task Allows_a_run_at_exactly_the_configured_ceiling()
+    {
+        // Boundary: the ceiling is inclusive. An off-by-one here would refuse a legitimate suite that
+        // an operator had sized deliberately.
+        var config = new AppConfig();
+        config.AI.Evaluation.MaxCaseExecutionsPerRun = 2;
+
+        var path1 = CreateFile("a.yaml");
+        var path2 = CreateFile("b.yaml");
+        var loader = Loader([".yaml"]);
+        var runner = new Mock<IEvalRunner>();
+        runner.Setup(r => r.RunAsync(It.IsAny<IReadOnlyList<EvalDataset>>(), It.IsAny<EvalRunOptions>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeReport());
+
+        var sut = MakeSut([loader.Object], runner.Object, config);
+
+        var result = await sut.Handle(
+            new RunEvalSuiteCommand { DatasetPaths = [path1, path2] }, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Refuses_an_oversized_dataset_without_parsing_it()
+    {
+        // The execution ceiling can only be applied once cases exist, and producing cases means parsing.
+        // So the size check has to come first, and the loader must never be called — otherwise the parse
+        // cost of an arbitrarily large file is paid in full before anything is refused.
+        var config = new AppConfig();
+        config.AI.Evaluation.MaxDatasetBytes = 32;
+
+        var path = CreateFile("big.yaml", new string('x', 1024));
+        var loader = Loader([".yaml"]);
+        var runner = new Mock<IEvalRunner>();
+
+        var sut = MakeSut([loader.Object], runner.Object, config);
+
+        var result = await sut.Handle(
+            new RunEvalSuiteCommand { DatasetPaths = [path] }, CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        loader.Verify(
+            l => l.LoadAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never,
+            "the size cap exists to avoid the parse, so refusing after parsing would defeat it");
+    }
+
+    [Fact]
+    public async Task Stops_loading_as_soon_as_the_ceiling_is_exceeded()
+    {
+        // Summing at the end would parse every named file before deciding. Bailing on the dataset that
+        // crosses the ceiling is what keeps the refusal cheaper than the run.
+        var config = new AppConfig();
+        config.AI.Evaluation.MaxCaseExecutionsPerRun = 1;
+
+        var path1 = CreateFile("a.yaml");
+        var path2 = CreateFile("b.yaml");
+        var path3 = CreateFile("c.yaml");
+        var loader = Loader([".yaml"]);
+        var runner = new Mock<IEvalRunner>();
+
+        var sut = MakeSut([loader.Object], runner.Object, config);
+
+        var result = await sut.Handle(
+            new RunEvalSuiteCommand { DatasetPaths = [path1, path2, path3] }, CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+
+        // One case each: the first is at the ceiling, the second crosses it, the third is never reached.
+        loader.Verify(
+            l => l.LoadAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Exactly(2),
+            "loading must stop at the dataset that crosses the ceiling, not continue through the list");
+    }
+
+    [Fact]
+    public async Task Counts_repeats_against_the_ceiling_rather_than_cases_alone()
+    {
+        // The ceiling exists to bound spend, and Repeats multiplies spend: each one re-invokes every
+        // case and its judge. A ceiling counting cases alone would cap nothing, because the same two
+        // cases could be asked for fifty times over and still read as "2".
+        var config = new AppConfig();
+        config.AI.Evaluation.MaxCaseExecutionsPerRun = 5;
+
+        var path1 = CreateFile("a.yaml");
+        var path2 = CreateFile("b.yaml");
+        var loader = Loader([".yaml"]);
+        var runner = new Mock<IEvalRunner>();
+
+        var sut = MakeSut([loader.Object], runner.Object, config);
+
+        // Two cases — comfortably under 5. Four repeats makes it eight executions, which is not.
+        var result = await sut.Handle(
+            new RunEvalSuiteCommand
+            {
+                DatasetPaths = [path1, path2],
+                Options = new EvalRunOptions { Repeats = 4 },
+            },
+            CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        runner.Verify(
+            r => r.RunAsync(It.IsAny<IReadOnlyList<EvalDataset>>(), It.IsAny<EvalRunOptions>(), It.IsAny<CancellationToken>()),
+            Times.Never,
+            "repeats must be priced in before the run is handed to the runner");
+    }
 
     [Fact]
     public async Task Loads_each_dataset_via_extension_match_and_passes_to_runner()

--- a/src/Content/Tests/Presentation.ExecutionApi.Tests/ExecutionApiEvaluationEnablementTests.cs
+++ b/src/Content/Tests/Presentation.ExecutionApi.Tests/ExecutionApiEvaluationEnablementTests.cs
@@ -1,0 +1,94 @@
+using Application.AI.Common.Evaluation;
+using Application.AI.Common.Evaluation.Interfaces;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Presentation.ExecutionApi.Tests;
+
+/// <summary>
+/// Tests for opting the evaluation framework into this host.
+/// </summary>
+/// <remarks>
+/// Evaluation reads dataset files named by the caller. With no roots configured that is unconfined —
+/// correct for the EvalRunner CLI on a developer's own machine, and an arbitrary-file-read probe on a
+/// host anyone else can reach. These pin that the host refuses to start in that state rather than
+/// booting into it.
+/// </remarks>
+public sealed class ExecutionApiEvaluationEnablementTests
+{
+    private static WebApplicationFactory<Program> BootWith(Dictionary<string, string?> variables)
+    {
+        foreach (var (key, value) in variables)
+            Environment.SetEnvironmentVariable(key, value);
+
+        try
+        {
+            var factory = new WebApplicationFactory<Program>();
+            _ = factory.Server; // Force startup while the overrides are visible.
+            return factory;
+        }
+        finally
+        {
+            foreach (var key in variables.Keys)
+                Environment.SetEnvironmentVariable(key, null);
+        }
+    }
+
+    [Fact]
+    public void EvaluationDisabled_LeavesTheFailFastRunnerInPlace()
+    {
+        // The shipped default. The framework's cost is not paid, and any dispatch fails loudly rather
+        // than appearing to work.
+        using var factory = new WebApplicationFactory<Program>();
+
+        factory.Services.GetRequiredService<IEvalRunner>()
+            .Should().BeOfType<NotConfiguredEvalRunner>();
+    }
+
+    [Fact]
+    public void EvaluationEnabledWithoutDatasetRoots_RefusesToStart()
+    {
+        // The failure this whole design exists to prevent: a host that looks configured for evaluation
+        // and reads whatever path a caller sends it.
+        var act = () => BootWith(new Dictionary<string, string?>
+        {
+            ["AppConfig__AI__Evaluation__Enabled"] = "true",
+        });
+
+        act.Should().Throw<Exception>()
+            .Which.Should().Match<Exception>(ex =>
+                ex.Message.Contains("DatasetRoots", StringComparison.Ordinal)
+                || (ex.InnerException != null
+                    && ex.InnerException.Message.Contains("DatasetRoots", StringComparison.Ordinal)));
+    }
+
+    [Fact]
+    public void EvaluationEnabledWithARoot_WiresTheRealRunner()
+    {
+        using var factory = BootWith(new Dictionary<string, string?>
+        {
+            ["AppConfig__AI__Evaluation__Enabled"] = "true",
+            ["AppConfig__AI__Evaluation__DatasetRoots__0"] = Path.GetTempPath(),
+        });
+
+        factory.Services.GetRequiredService<IEvalRunner>()
+            .Should().NotBeOfType<NotConfiguredEvalRunner>(
+                "enabling evaluation must replace the fail-fast default, or the feature is inert");
+    }
+
+    [Fact]
+    public void EvaluationEnabledWithOnlyBlankRoots_RefusesToStart()
+    {
+        // A whitespace entry binds as a root but confines nothing — it must not satisfy the
+        // requirement, or the fail-closed check becomes a formality anyone can tick.
+        var act = () => BootWith(new Dictionary<string, string?>
+        {
+            ["AppConfig__AI__Evaluation__Enabled"] = "true",
+            ["AppConfig__AI__Evaluation__DatasetRoots__0"] = "   ",
+        });
+
+        act.Should().Throw<Exception>();
+    }
+}

--- a/src/Content/Tests/Presentation.ExecutionApi.Tests/ToolsControllerIntegrationTests.cs
+++ b/src/Content/Tests/Presentation.ExecutionApi.Tests/ToolsControllerIntegrationTests.cs
@@ -206,13 +206,17 @@ public sealed class ToolsControllerIntegrationTests
     {
         var keys = new List<string>();
 
-        factory.WithWebHostBuilder(builder => builder.ConfigureServices(services =>
+        // WithWebHostBuilder returns a NEW factory owning its own TestServer and host, so it has to be
+        // disposed — the derived one, not the caller's.
+        using var derived = factory.WithWebHostBuilder(builder => builder.ConfigureServices(services =>
             keys.AddRange(services
                 .Where(descriptor => descriptor.IsKeyedService && descriptor.ServiceType == typeof(ITool))
                 .Select(descriptor => descriptor.ServiceKey as string)
                 .Where(key => !string.IsNullOrWhiteSpace(key))
-                .Select(key => key!))))
-            .Services.GetService<IToolCatalog>();
+                .Select(key => key!))));
+
+        // Forces the host to build so ConfigureServices above actually runs.
+        derived.Services.GetService<IToolCatalog>();
 
         return keys;
     }


### PR DESCRIPTION
## What this closes

Evaluation was built for the `EvalRunner` CLI, where the caller is a developer on their own machine and every input is trusted. Wave 3 is about exposing it over HTTP. Two properties that are correct for a local tool do not survive that move, and both had to be closed before `POST /api/evals/runs` (E2) can exist at all.

### 1. Dataset paths were unconfined — and an existence oracle

`RunEvalSuiteCommand` accepted any filesystem path, validated only as non-empty, and reported back whether it existed. That is an arbitrary-file-read probe and a filesystem-mapping oracle in one.

`IEvalDatasetPathGuard` now canonicalises the requested path, follows symlinks to their final target, and confines the result to `AppConfig:AI:Evaluation:DatasetRoots`. "Outside the allowed roots" and "does not exist" return the **identical** refusal message — distinguishing them is what makes the endpoint an oracle.

Two subtleties worth calling out, because a naive implementation gets both wrong:

- Comparison is against `root + separator`, not `root`. Without the trailing separator, `/data/evals-secret` reads as inside `/data/evals`, and every sibling directory whose name merely extends the root is admitted.
- The *target* of a symlink is what is checked, not the link. A link that lives inside a root can point anywhere, and the loader opens the target.

### 2. Cost ceilings did not exist outside the CLI

`EvalRunOptions.Parallelism` had a lower bound in the validator and no upper one. The 1–128 range lived only in the CLI's argument parsing — so every other dispatcher could request unbounded concurrency against the model provider. `Repeats`, dataset count, and total case count were similarly unbounded.

All four ceilings now come from configuration, read through `IOptionsMonitor` so tightening one takes effect without a restart. The case-count check sits at the last point before the runner is handed anything, and **refuses rather than truncates**: silently evaluating a subset would report a pass rate for a suite that never ran.

## Two design decisions

**Confinement lives in the handler, not at each caller.** A check that every dispatcher must remember to perform is a check that will eventually be skipped. Enforcing it at the single choke point means no future HTTP surface, MCP tool, or scheduled job can bypass it by forgetting.

**Confinement is inactive by default, and that is deliberate.** With no roots configured, paths are unconfined — which preserves the CLI workflow of pointing the runner at a file anywhere on disk, and costs nothing, because a local developer can read those files regardless.

What stops "inactive by default" from becoming "inactive in production" is that `AddExecutionApiEvaluation` **throws at startup** when evaluation is enabled without a usable root. A host that booted anyway would look configured while honouring whatever path a caller sent it.

## Evidence

Four mutations, each killed by exactly the intended test:

| Mutation | Test that caught it |
| --- | --- |
| Drop the trailing-separator check | `RootConfigured_RefusesASiblingRootSharingThePrefix` |
| Skip symlink resolution | `RootConfigured_RefusesASymlinkInsideTheRootPointingOutside` |
| Accept blank root entries | `EvaluationEnabledWithOnlyBlankRoots_RefusesToStart` |
| Remove the case ceiling | `Refuses_a_run_whose_case_count_exceeds_the_configured_ceiling` |

The blank-root one is the least obvious and the most worth keeping: a whitespace entry binds as a root, confines nothing, and would otherwise satisfy the fail-closed startup check. A gate you can tick with a space is not a gate.

`Allows_a_run_at_exactly_the_configured_ceiling` pins the boundary as inclusive, so the ceiling cannot drift by one.

## What the reviewers changed

Eight findings from the local security and correctness gates were acted on, not filed. The four worth naming:

**The symlink walk only resolved the last path segment.** A *directory* link inside an allowed root, pointing anywhere, made every path beneath it canonicalise to something starting with the root while opening a file that did not. .NET has no `realpath` and `ResolveLinkTarget` inspects only the leaf, so the guard now walks every segment under a shared hop budget.

**The confinement latch was derived in the guard's constructor** — which reads as startup-bound and is not. The guard is a lazy singleton, so that constructor first runs on the *initial eval dispatch*; configuration is bound with `reloadOnChange`, so a reload emptying `DatasetRoots` in between would have it record "started unconfined" and take the permissive branch. That is the exact downgrade the latch existed to prevent, with the comment above it claiming otherwise. The verdict is now an `EvalConfinementLatch` registered at composition time by the host that performed the fail-closed check.

**Budget exhaustion failed open.** Running out of hops returned a possibly-still-a-link path; if it sat inside a root, containment passed. Every other failure mode here refuses. Now this one does too.

**Roots were canonicalised but not link-resolved**, while candidates were fully resolved — so a root reached through a symlinked directory (macOS `/tmp` → `/private/tmp`, many container bind mounts) would refuse *every* legitimate path. It fails closed, so not a bypass, but a confinement rule that rejects everything is one somebody switches off.

## Evidence

Ten mutations across three rounds, each killed by exactly the intended test and no others. The most valuable were the ones testing a *plausible wrong implementation* rather than an absent one — replacing the injected latch with a config-derived one, and the every-segment walk with a leaf-only walk. Both look correct and both fail.

Paired negative tests where a refuse-everything guard would otherwise pass: the directory-link test is joined by one proving ordinary nested paths still resolve, and the symlinked-root test proves the root walk did not simply break containment.

## Known-good boundaries, stated rather than papered over

Path confinement cannot see **hard links**, and cannot close the TOCTOU between checking a path and opening it. Both need write access *inside* a configured root. That is now a documented deployment invariant in `EvaluationConfig` and the host README: a root must not be writable by anyone you would not already let read arbitrary files.

## Test-gate note

`Application.Common.Tests.StructuredJsonLoggerProviderTests.Log_WithException_IncludesExceptionInJsonOutput` fails locally on this machine. It reproduces identically on unmodified `origin/main` in a clean worktree, no logging file is in this diff, and the assertion is an empty-file read — a flush race. Called out rather than hidden; remote CI is the boundary.

## Not in scope

`POST /api/evals/runs` itself. This is its hard prerequisite; E2 builds the endpoint on the W4 job substrate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BnoLcufW278UxA9ssBM1Tc
