### PR TITLE
fix: teach the security gate that filesystem confinement is security code

### DIFF
--- a/.github/scripts/security-gate-scope.sh
+++ b/.github/scripts/security-gate-scope.sh
@@ -95,12 +95,48 @@ PATH_RE='(^\.github/|^scripts/rails/|/Auth/|/Identity/|/Security/|/SecurityAttri
 # Grouped by the risk each marker stands for. Markers are deliberately specific:
 # a bare `Token` would match every CancellationToken in the codebase and fire on
 # everything, which degrades to the same uselessness as never firing at all.
+#
+# THE LIST IS A VOCABULARY, AND A MISSING WORD IS A MISSING GATE.
+# The first five groups describe authorization, scope isolation, capability,
+# credentials, and reachable surface. They say nothing about the filesystem — so
+# PR #215, which was *entirely* path confinement (canonicalisation, per-segment
+# symlink resolution, a root-prefix comparison, a confinement latch), raised zero
+# signals and the reviewer was skipped. It reported `pass` in five seconds. The
+# code had been reviewed only because a human ran the reviewer by hand.
+#
+# That is the same failure as the folder-only filter above, one category over: the
+# gate did not fire on the changes it exists to review. The last two groups close
+# the two categories this repo actually has code in — filesystem confinement, and
+# code execution / unsafe deserialization.
+#
+# COUNTS ARE PER TRACKED FILE, NOT PER GREP HIT. Measure with `git ls-files`, never
+# a bare recursive grep: bin/ and obj/ inflate some markers more than tenfold (AntiSSRF
+# reads as 1101 hits and 28 tracked files), and build artifacts can never appear in a
+# diff. A marker judged on the inflated number gets rejected for noise it cannot cause.
+#
+# DELIBERATELY EXCLUDED, so nobody "completes" the list later and breaks it:
+#   HttpClient (101 of 3,208 tracked .cs files) and JsonSerializer.Deserialize (57)
+#   are real SSRF and deserialization signals in the abstract, and useless here — they
+#   appear in nearly every connector and DTO, so adding them makes the gate fire on
+#   every PR. A gate that always fires is triaged as noise and is worth no more than
+#   one that never fires.
+#
+#   SSRF is therefore covered by naming the GUARD rather than the mechanism:
+#   EgressPolicy / EgressAllowlist / AntiSSRF / Ssrf. A PR that weakens or bypasses
+#   egress policy is the SSRF change actually worth reviewing, and those types appear
+#   only in code that is about egress control — so the signal stays specific while
+#   every ordinary outbound call stays silent. Both halves are pinned by tests:
+#   touching the policy fires, holding an HttpClient does not.
 # ---------------------------------------------------------------------------
 CONTENT_RE='(\[Authorize|AllowAnonymous|ClaimsPrincipal|RequireClaim|AuthenticationScheme|AuthorizationPolicy|IAuthorizationHandler'          # authn/authz
 CONTENT_RE="${CONTENT_RE}"'|OwnerId|TenantId|KnowledgeScope|VisibleTo|WritableBy'                                                             # scope isolation — this repo's recurring defect class
 CONTENT_RE="${CONTENT_RE}"'|CapabilityEnvelope|AutonomyLevel|AllowedTools|DeniedTools|Sandbox|GovernanceTrace|PermittedApprovers|Approver'    # capability + governance
 CONTENT_RE="${CONTENT_RE}"'|Jwt|Bearer|AccessToken|RefreshToken|SasToken|ApiKey|Password|Secret|Hmac|Sha256|RandomNumberGenerator'            # credentials + crypto
 CONTENT_RE="${CONTENT_RE}"'|\[Http(Get|Post|Put|Delete|Patch)|MapGet\(|MapPost\(|MapDelete\(|UseCors|RateLimit'                               # externally reachable surface
+CONTENT_RE="${CONTENT_RE}"'|GetFullPath|ResolveLinkTarget|LinkTarget|IsPathRooted|GetRelativePath|DirectorySeparatorChar'                     # filesystem path confinement
+CONTENT_RE="${CONTENT_RE}"'|EgressPolicy|EgressAllowlist|AntiSSRF|Ssrf|SSRF'                                                                   # egress control (the SSRF guard, not the mechanism)
+CONTENT_RE="${CONTENT_RE}"'|FromSqlRaw|FromSqlInterpolated|ExecuteSqlRaw|ExecuteSqlInterpolated'                                               # raw SQL — the one escape from EF Core's parameterisation
+CONTENT_RE="${CONTENT_RE}"'|Process\.Start|ProcessStartInfo|ZipArchive|ExtractToDirectory|BinaryFormatter|TypeNameHandling|XmlSerializer'     # code execution + unsafe deserialization
 CONTENT_RE="${CONTENT_RE}"'|Sanitiz|Redact|Scrub)'                                                                                            # output safety
 
 # Prose is excluded from the content scan — a security guide legitimately says

--- a/.github/scripts/security-gate-scope.test.sh
+++ b/.github/scripts/security-gate-scope.test.sh
@@ -79,6 +79,22 @@ for pr in 203 205 207 208 209 210; do
 done
 
 echo
+# #215 was entirely path confinement — canonicalisation, per-segment symlink
+# resolution, a root-prefix comparison, a startup confinement latch — and carried
+# not one authorization, scope, credential, or HTTP-surface marker. The gate
+# reported `pass` in five seconds without running the reviewer. This is the case
+# that proved the marker list was a vocabulary with a category missing from it, so
+# it is the case that must never go quiet again.
+echo "REPLAY — the PR the CONTENT filter skipped (filesystem path safety):"
+head="$(pr_head 215)"; base="$(pr_base 215)"
+if [ -n "$head" ] && [ -n "$base" ]; then
+  expect "#215 (path confinement, no authz/scope markers)" true content "$base" "$head"
+  expect_scope_contains "#215 names the guard" "$base" "$head" "EvalDatasetPathGuard.cs"
+else
+  echo "  SKIP  #215 (merge commit not found in this clone)"
+fi
+
+echo
 # #199 changed gated paths AND security-relevant code. Under the old exclusive
 # branching it reported `path` and its src/ files never reached the scope file;
 # reporting `path+content` is the fix, not a regression.
@@ -127,6 +143,55 @@ if git worktree add --detach --quiet "$WORKTREE" HEAD 2>/dev/null; then
         "src/Content/Domain/Domain.AI/ScratchTest.cs" \
         "public sealed record ScratchTest { public string? OwnerId { get; init; } }" \
         true content
+
+  synth "src change canonicalising a caller-supplied path" \
+        "src/Content/Domain/Domain.AI/ScratchTest.cs" \
+        "public static class ScratchTest { public static string Go(string p) => System.IO.Path.GetFullPath(p); }" \
+        true content
+
+  synth "src change resolving a symbolic link" \
+        "src/Content/Domain/Domain.AI/ScratchTest.cs" \
+        "public static class ScratchTest { public static string? Go(string p) => new System.IO.FileInfo(p).LinkTarget; }" \
+        true content
+
+  synth "src change starting a process" \
+        "src/Content/Domain/Domain.AI/ScratchTest.cs" \
+        "public static class ScratchTest { public static void Go(string f) { System.Diagnostics.Process.Start(f); } }" \
+        true content
+
+  # SSRF is covered by naming the guard, not the mechanism. Weakening egress policy
+  # is the SSRF change worth reviewing; an ordinary outbound call is not, and the
+  # HttpClient case below pins that the distinction actually holds.
+  synth "src change touching egress policy (the SSRF guard)" \
+        "src/Content/Domain/Domain.AI/ScratchTest.cs" \
+        "public sealed class ScratchTest { public bool Allows(IEgressPolicy p) => true; }" \
+        true content
+
+  # Raw SQL is the one escape from EF Core's automatic parameterisation, and it lives
+  # in Repositories/ and Persistence/ — neither of which is a gated path. Without this
+  # marker an interpolated ExecuteSqlRaw goes unreviewed, which is structurally the
+  # same miss as #215.
+  synth "src change running raw SQL" \
+        "src/Content/Domain/Domain.AI/ScratchTest.cs" \
+        "public static class ScratchTest { public static void Go(object db, string q) { db.Database.ExecuteSqlRaw(q); } }" \
+        true content
+
+  # The noise boundary, pinned in both directions. HttpClient and
+  # JsonSerializer.Deserialize are the two markers most likely to be added later by
+  # someone reasoning category-by-category rather than counting occurrences. They
+  # appear in nearly every connector and DTO in this repo, so adding them makes the
+  # gate fire on every PR — which is triaged as noise and is worth no more than a
+  # gate that never fires. If either starts firing, the list grew a word it cannot
+  # afford.
+  synth "ordinary HttpClient use must NOT fire (too common to be a signal)" \
+        "src/Content/Domain/Domain.AI/ScratchTest.cs" \
+        "public sealed class ScratchTest { private readonly System.Net.Http.HttpClient _http = new(); }" \
+        false none
+
+  synth "ordinary JSON deserialization must NOT fire (too common to be a signal)" \
+        "src/Content/Domain/Domain.AI/ScratchTest.cs" \
+        "public static class ScratchTest { public static int Go(string j) => System.Text.Json.JsonSerializer.Deserialize<int>(j); }" \
+        false none
 
   # git quotes non-ASCII paths by default, and the quoted form matches nothing when
   # fed back as a pathspec — so an accented filename used to evade the content scan


### PR DESCRIPTION
## The miss

PR #215 was reviewed by nobody. The `security-review` check reported **pass in five seconds**:

```
required=false
reason=no gated path and no security-relevant code changed
Run security-reviewer ......... skipped
```

That PR was *entirely* path confinement — canonicalisation, per-segment symlink resolution, a root-prefix comparison, a startup confinement latch. It merged reviewed only because the reviewer was run by hand.

## Why

The marker list is a **vocabulary**, and a missing word is a missing gate. Its five groups described authorization, scope isolation, capability, credentials, and reachable surface. None of them says anything about the filesystem, so #215 raised zero signals — correctly, by the rule as written.

This is the same failure as the folder-only filter this script replaced, one category over: *the gate did not fire on the changes it exists to review.*

## What this adds

| Group | Markers | Closes |
| --- | --- | --- |
| Filesystem confinement | `GetFullPath`, `ResolveLinkTarget`, `LinkTarget`, `IsPathRooted`, `GetRelativePath`, `DirectorySeparatorChar` | #215's exact miss |
| Egress control | `EgressPolicy`, `EgressAllowlist`, `AntiSSRF`, `Ssrf`, `SSRF` | SSRF |
| Raw SQL | `FromSqlRaw`, `FromSqlInterpolated`, `ExecuteSqlRaw`, `ExecuteSqlInterpolated` | Injection |
| Execution / deserialization | `Process.Start`, `ProcessStartInfo`, `ZipArchive`, `ExtractToDirectory`, `BinaryFormatter`, `TypeNameHandling`, `XmlSerializer` | RCE-shaped changes |

SSRF is covered by naming the **guard**, not the mechanism. A PR weakening egress policy is the SSRF change worth reviewing; an ordinary outbound call is not.

## The noise boundary is now a test, not a comment

`HttpClient` (101 of 3,208 tracked `.cs` files) and `JsonSerializer.Deserialize` (57) stay excluded on purpose. They are real signals in the abstract and useless here — they appear in nearly every connector and DTO, so adding them makes the gate fire on every PR, which is triaged as noise and is worth no more than a gate that never fires.

They are the two markers most likely to be added later by someone reasoning category-by-category, so both now have a test asserting they do **not** fire.

One correction worth recording: my first counts came from a recursive grep and were inflated more than tenfold by `bin/`+`obj/` — `AntiSSRF` reads as 1,101 hits and 28 tracked files. A marker judged on the inflated number gets rejected for noise it cannot possibly cause, since build artifacts never appear in a diff. The header now says to measure with `git ls-files`.

## Evidence

**30/30 tests pass**, including #215 replayed by merge-base as a regression case, asserting `required=true trigger=content` *and* that the scope file names `EvalDatasetPathGuard.cs`.

Two mutations:

| Mutation | Result |
| --- | --- |
| Drop the filesystem marker group | 4 fail — the #215 replay, its scope assertion, and both path synthetics |
| Make the regex uncompilable | **19 of 30 fail** |

The second one matters most. `grep -oE "$CONTENT_RE" ... \|\| true` swallows grep's exit 2, so a malformed regex would empty `SIGNALS` and report `required=false` cleanly — the content signal silently off for every PR. The reviewer named this as the one way this change could have been a HIGH. It cannot land quietly.

## Reviewed by the thing it changes

The gate fires on itself through `^\.github/`, so the security reviewer ran against both drafts. It found the SSRF gap (my own comment prescribed the fix and I hadn't applied it), the missing SQL category, the `Ssrf` casing gap, and the inflated counts. All four are fixed here.

## Known remaining gap

Deserialization is covered only for the dangerous formatters. Ordinary `JsonSerializer.Deserialize` of untrusted input raises no signal, and no cheap marker distinguishes it from the 57 files doing it safely — flagged rather than papered over.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BnoLcufW278UxA9ssBM1Tc
