### PR TITLE
feat: run evaluation suites over HTTP, with names on the wire instead of paths

### DIFF
--- a/documentation/onboarding/17-bundle-api.html
+++ b/documentation/onboarding/17-bundle-api.html
@@ -865,11 +865,17 @@ curl -sS -H "Authorization: Bearer $TOKEN" \
                         to check that a change to prompts, models, or tools did not make things worse.
                     </p>
                     <p>
-                        <strong>It is off unless someone turned it on.</strong> Every endpoint below <code>403</code>s
-                        until <code>AppConfig:AI:Evaluation:Enabled</code> is set, and the host refuses to start if that
-                        is set without at least one dataset root. There is a good reason for the double gate: a suite is
-                        hundreds of model calls billed to the host's own credentials, so it should never be something an
-                        authenticated caller discovers by guessing a URL.
+                        <strong>It is off unless someone turned it on, and gated on a role.</strong> Every endpoint
+                        below <code>403</code>s until <code>AppConfig:AI:Evaluation:Enabled</code> is set, and the host
+                        refuses to start if that is set without at least one dataset root. On top of that you need the
+                        <code>Harness.Evals.Execute</code> role &mdash; this is the only surface in this chapter that
+                        asks for one. The reason is that every other route runs <em>your</em> work on <em>your</em>
+                        grant, whereas this one spends the host's model budget on the operator's suites. Holding a valid
+                        token is not the same authority as being allowed to do that.
+                    </p>
+                    <p>
+                        The role does not change ownership: it decides whether you may evaluate at all, and you still
+                        only ever see your own runs.
                     </p>
 
                     <h3>You name a dataset; you never give a path</h3>
@@ -911,7 +917,12 @@ curl -sS -H "Authorization: Bearer $TOKEN" \
                         warned, or errored, the overall verdict, how long it took, and what it cost in dollars.
                     </p>
                     <p>
-                        It does <em>not</em> carry the per-case transcripts. Those contain every test input and the
+                        The report is also filed into the host's own evaluation store automatically, so it shows up
+                        in the dashboard without you posting anything back &mdash; that is the main thing running a
+                        suite server-side buys you over running the CLI.
+                    </p>
+                    <p>
+                        The poll does <em>not</em> carry the per-case transcripts. Those contain every test input and the
                         agent's full response, which is a lot of data to put on a status check and more of the agent's
                         output than any other endpoint here exposes. If you need transcripts, read the report files the
                         evaluation framework writes on the server.

--- a/documentation/onboarding/17-bundle-api.html
+++ b/documentation/onboarding/17-bundle-api.html
@@ -710,6 +710,29 @@ The agent runs with exactly one tool: file_system.</code></pre>
                                 <td><code>200</code></td>
                                 <td>Cancels the run and withdraws any approval it was waiting on. <code>stopped: false</code> means signalled, not yet stopped. <code>409</code> if already terminal.</td>
                             </tr>
+                            <tr>
+                                <td colspan="3" style="background: rgba(127,127,127,0.08)"><strong>Evals</strong> — run the host's own test suites</td>
+                            </tr>
+                            <tr>
+                                <td><code>GET /api/evals/datasets</code></td>
+                                <td><code>200</code></td>
+                                <td>The names you are allowed to run. Empty list on a host with no dataset roots configured — that is the answer, not an error.</td>
+                            </tr>
+                            <tr>
+                                <td><code>POST /api/evals/runs</code></td>
+                                <td><code>202</code></td>
+                                <td>Body: <code>datasets</code> (names, never paths), optional <code>repeats</code>, <code>parallelism</code>, <code>tagFilter</code>, <code>failRateThreshold</code>. Returns a <code>jobId</code> and a <code>statusUrl</code>. <code>404</code> if a name is not one this host serves.</td>
+                            </tr>
+                            <tr>
+                                <td><code>GET /api/evals/runs/{jobId}</code></td>
+                                <td><code>200</code></td>
+                                <td>Status, plus counts/verdict/duration/cost once finished. Not the per-case transcripts.</td>
+                            </tr>
+                            <tr>
+                                <td><code>DELETE /api/evals/runs/{jobId}</code></td>
+                                <td><code>200</code></td>
+                                <td>Cancels a run that has not started. <code>stopped: false</code> means it was already executing and will finish — an eval in flight cannot be interrupted. <code>409</code> if already terminal.</td>
+                            </tr>
                         </tbody>
                     </table>
 
@@ -832,6 +855,92 @@ curl -sS -H "Authorization: Bearer $TOKEN" \
                         continuously</strong>. A token revoked mid-run keeps receiving until the run ends. The exposure
                         is bounded by the run's duration, and the frames carry nothing you could not already read from
                         the status endpoint — but it is a deliberate trade, not an oversight.
+                    </p>
+
+                    <h2 id="evals">Evals: running the host's own test suites</h2>
+                    <p>
+                        The other three surfaces run <em>your</em> work — your bundle, your workflow, your tool call.
+                        This one runs the host's. An evaluation suite is a file of test cases an operator has put on
+                        the server, and running it asks the harness to answer every case and score itself. You use it
+                        to check that a change to prompts, models, or tools did not make things worse.
+                    </p>
+                    <p>
+                        <strong>It is off unless someone turned it on.</strong> Every endpoint below <code>403</code>s
+                        until <code>AppConfig:AI:Evaluation:Enabled</code> is set, and the host refuses to start if that
+                        is set without at least one dataset root. There is a good reason for the double gate: a suite is
+                        hundreds of model calls billed to the host's own credentials, so it should never be something an
+                        authenticated caller discovers by guessing a URL.
+                    </p>
+
+                    <h3>You name a dataset; you never give a path</h3>
+                    <p>
+                        This is the part worth understanding, because it looks like an inconvenience and is actually the
+                        whole security design. The command underneath takes file paths — which is right for the
+                        command-line runner, where a developer points it at a file on their own machine. Over HTTP that
+                        same shape would mean every request carried a filesystem reference, and the only thing standing
+                        between a caller and reading <code>/etc/shadow</code> would be a check remembering to say no.
+                    </p>
+                    <p>
+                        So the wire contract has no path field at all. You send a <em>name</em>; the server finds the
+                        file by listing the directories an operator configured and matching what is actually there. A
+                        name cannot express &ldquo;outside those directories&rdquo;, so the dangerous request is not
+                        rejected — it cannot be written down. Ask for what is available first:
+                    </p>
+                    <div class="code-block">
+<pre><code>curl -sS -H "Authorization: Bearer $TOKEN" http://localhost:5000/api/evals/datasets
+# { "datasets": ["router-accuracy", "safety-refusals"] }</code></pre>
+                    </div>
+                    <p>
+                        Those names are the files sitting directly in a configured root, without their extensions.
+                        Subdirectories are not searched: a name with a slash in it would be a path again, just wearing a
+                        different hat.
+                    </p>
+
+                    <h3>Start a run, then poll it</h3>
+                    <div class="code-block">
+<pre><code>JOB_ID=$(curl -sS -X POST http://localhost:5000/api/evals/runs \
+  -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d '{"datasets":["router-accuracy"],"repeats":3}' | jq -r .jobId)
+
+curl -sS -H "Authorization: Bearer $TOKEN" \
+  http://localhost:5000/api/evals/runs/$JOB_ID</code></pre>
+                    </div>
+                    <p>
+                        The <code>202</code> means the run was accepted, not that it finished — a suite takes as long as
+                        it takes. Once it is done the poll carries a <code>report</code>: how many cases passed, failed,
+                        warned, or errored, the overall verdict, how long it took, and what it cost in dollars.
+                    </p>
+                    <p>
+                        It does <em>not</em> carry the per-case transcripts. Those contain every test input and the
+                        agent's full response, which is a lot of data to put on a status check and more of the agent's
+                        output than any other endpoint here exposes. If you need transcripts, read the report files the
+                        evaluation framework writes on the server.
+                    </p>
+
+                    <div class="callout callout-warning">
+                        <p>
+                            <strong><code>Succeeded</code> does not mean everything passed.</strong> It means the
+                            evaluation <em>ran</em>. A suite where every case failed is still a succeeded run — one
+                            whose report says <code>"verdict": "Fail"</code>. The distinction matters: if the two were
+                            collapsed you could not tell &ldquo;my prompt change broke things&rdquo; from &ldquo;the
+                            host is broken and never answered me&rdquo;.
+                        </p>
+                    </div>
+
+                    <h3>Two limits to know about</h3>
+                    <p>
+                        <strong>Cost is capped before anything runs, not interrupted afterwards.</strong> The host
+                        multiplies the number of cases by your <code>repeats</code> and refuses the whole run if that
+                        exceeds <code>MaxCaseExecutionsPerRun</code>. It refuses rather than quietly running a subset,
+                        because a pass rate for a suite that only half-ran is worse than no answer.
+                    </p>
+                    <p>
+                        <strong>Cancelling only works before the run starts.</strong> <code>DELETE</code> on a queued
+                        run stops it. On a run already executing you get <code>200</code> with
+                        <code>"stopped": false</code>, and it finishes anyway. That is deliberate honesty rather than a
+                        gap: a workflow can be signalled to stop mid-flight, an evaluation cannot, and telling you it
+                        had stopped when the spend was still accruing would be the worse answer. The real protection is
+                        the cost cap above.
                     </p>
 
                     <h2 id="two-ways">Two ways to get the output</h2>
@@ -1049,6 +1158,22 @@ curl -sS -H "Authorization: Bearer $TOKEN" \
                             <tr><td><code>Envelopes</code></td><td>fail-closed</td><td>The per-caller grant table (see above).</td></tr>
                             <tr><td><code>Auth:TenantId</code> / <code>Auth:ClientId</code></td><td>unset</td><td>This API's own Entra audience. Supply both or neither.</td></tr>
                             <tr><td><code>Auth:AllowAnonymous</code></td><td><code>false</code></td><td>Explicit local-development opt-in. Cannot be combined with a configured scheme.</td></tr>
+                        </tbody>
+                    </table>
+
+                    <p>
+                        The eval endpoints read a separate section, <code>AppConfig:AI:Evaluation</code>.
+                    </p>
+                    <table>
+                        <thead><tr><th>Key</th><th>Default</th><th>Purpose</th></tr></thead>
+                        <tbody>
+                            <tr><td><code>Enabled</code></td><td><code>false</code></td><td>Master toggle for <code>/api/evals</code>. Off ⇒ every endpoint <code>403</code>s.</td></tr>
+                            <tr><td><code>DatasetRoots</code></td><td><code>[]</code></td><td>Directories datasets may be read from. Use absolute paths. <strong>Setting <code>Enabled</code> without any root refuses to start.</strong></td></tr>
+                            <tr><td><code>MaxDatasetsPerRun</code></td><td><code>10</code></td><td>Datasets one run may name.</td></tr>
+                            <tr><td><code>MaxCaseExecutionsPerRun</code></td><td><code>500</code></td><td>Cases × repeats — what the run actually costs. Refuses, never truncates.</td></tr>
+                            <tr><td><code>MaxDatasetBytes</code></td><td><code>5242880</code></td><td>Checked before the file is opened, so an oversized dataset is never parsed.</td></tr>
+                            <tr><td><code>MaxRepeats</code></td><td><code>50</code></td><td>Ceiling on <code>repeats</code>.</td></tr>
+                            <tr><td><code>MaxParallelism</code></td><td><code>128</code></td><td>Ceiling on <code>parallelism</code>.</td></tr>
                         </tbody>
                     </table>
 

--- a/documentation/onboarding/assets/openapi/bundle-api.yaml
+++ b/documentation/onboarding/assets/openapi/bundle-api.yaml
@@ -97,6 +97,11 @@ tags:
     description: Start, poll, and stream bundle runs.
   - name: Workflows
     description: Submit workflow definitions and manage their runs.
+  - name: Evals
+    description: >-
+      Run the host's evaluation suites and poll their reports. Off unless
+      `AppConfig:AI:Evaluation:Enabled` is set, and the host refuses to start when it is set without
+      any `DatasetRoots`.
   - name: Tools
     description: >-
       Read-only discovery of the tools the calling credential may invoke. Distinct from AgentHub's
@@ -638,6 +643,142 @@ paths:
             The host or this caller is already at its concurrent-stream ceiling
             (`MaxConcurrentProgressStreams` / `MaxProgressStreamsPerOwner`). Close a stream and retry.
 
+  /api/evals/datasets:
+    get:
+      tags: [Evals]
+      operationId: listEvalDatasets
+      summary: List the dataset names this host will evaluate
+      description: |
+        The datasets are whatever an operator placed at the **top level** of
+        `AppConfig:AI:Evaluation:DatasetRoots`; a name is that file's name without its extension.
+
+        **A host with no roots configured answers an empty list.** It does not fall back to
+        enumerating its working directory - listing is a disclosure, and there is nothing bounded to
+        disclose until an operator says what the bounds are. An empty list is therefore a truthful
+        answer to "what could be run here", not an error.
+
+        Not recursive. A dataset in a subdirectory would need a name that carried structure, and a
+        name with structure is a path with extra steps - which is exactly what this surface avoids.
+      responses:
+        "200":
+          description: The dataset names, in a stable order.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/EvalDatasetsResponse" }
+        "401": { $ref: "#/components/responses/UnauthorizedProblem" }
+        "429": { $ref: "#/components/responses/RateLimited" }
+
+  /api/evals/runs:
+    post:
+      tags: [Evals]
+      operationId: startEvalRun
+      summary: Queue an evaluation run over named datasets
+      description: |
+        Accepts the run and returns immediately with a job id - execution is asynchronous. A suite is
+        hundreds of governed agent turns at the default ceilings, so the response says the work was
+        taken, not that it finished.
+
+        **Datasets are named, never pathed.** There is no path field on this contract, and that is
+        the security property rather than a convenience: a path would make every request a filesystem
+        reference with one guard between it and an arbitrary read. A name cannot express "outside the
+        roots" at all. The server resolves a name by enumerating the configured roots and matching -
+        never by concatenating the name onto a root.
+
+        The capability envelope is resolved from **the credential that starts the run** and is armed
+        around the whole evaluation. Every case is a governed agent turn that can invoke tools, so
+        without it a caller could reach, through an eval case, tools it is denied directly.
+
+        Unknown dataset names are refused **before** anything is queued, so a bad name costs an
+        immediate `404` rather than a `202` followed by a failure the caller has to poll for.
+
+        Cost is bounded at admission, not interrupted afterwards: `MaxCaseExecutionsPerRun` counts
+        cases **x repeats** and refuses rather than truncating, because quietly evaluating a subset
+        would report a pass rate for a suite that never ran.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "#/components/schemas/StartEvalRunRequest" }
+      responses:
+        "202":
+          description: The run was accepted and queued.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/StartEvalRunResponse" }
+        "400":
+          description: >-
+            The request breached a configured ceiling (`MaxDatasetsPerRun`, `MaxRepeats`,
+            `MaxParallelism`), or the caller already holds the maximum concurrent runs allowed per
+            owner.
+        "401": { $ref: "#/components/responses/UnauthorizedProblem" }
+        "403":
+          description: Evaluation is disabled on this host (`AppConfig:AI:Evaluation:Enabled`).
+        "404":
+          description: >-
+            One of the named datasets is not one this host serves. Unknown and malformed names are
+            deliberately indistinguishable.
+        "429": { $ref: "#/components/responses/RateLimited" }
+
+  /api/evals/runs/{jobId}:
+    get:
+      tags: [Evals]
+      operationId: getEvalRun
+      summary: Poll an evaluation run, and read its report once finished
+      description: |
+        Returns counts, verdict, duration and cost - **not** per-case results. Those hold every
+        case's input and the agent's full output, which is not something a status poll should carry;
+        use the framework's own reporters for transcripts.
+
+        A run whose submission has already been reclaimed is still readable: the record and the
+        submission are dropped by the same sweep but not atomically, and a caller polling in that
+        window is owed the run's status rather than a failure. `datasets` is empty and `report` is
+        absent in that case.
+      parameters:
+        - $ref: "#/components/parameters/EvalRunJobId"
+      responses:
+        "200":
+          description: The run's current state, and its report if it has produced one.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/EvalRunResponse" }
+        "401": { $ref: "#/components/responses/UnauthorizedProblem" }
+        "403":
+          description: Evaluation is disabled on this host.
+        "404":
+          description: >-
+            No such run, **or** it belongs to another caller, **or** it is not an evaluation run.
+            The three are one answer so a caller cannot enumerate work it was not given the id for.
+        "429": { $ref: "#/components/responses/RateLimited" }
+    delete:
+      tags: [Evals]
+      operationId: cancelEvalRun
+      summary: Cancel a queued evaluation run
+      description: |
+        A run that has not started is cancelled outright (`stopped: true`). A run **already
+        executing** answers `200` with `stopped: false` and continues to completion.
+
+        That is weaker than cancelling a workflow, and the difference is real rather than an
+        omission: a workflow in flight can be signalled through the plan cancellation registry,
+        whereas an evaluation is a suite of agent turns with no equivalent. Reporting `stopped: true`
+        would tell a caller the spend had stopped when it had not. What bounds a runaway suite is
+        `MaxCaseExecutionsPerRun`, applied before any case runs.
+      parameters:
+        - $ref: "#/components/parameters/EvalRunJobId"
+      responses:
+        "200":
+          description: The run was cancelled, or reported as already executing.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/CancelEvalRunResponse" }
+        "401": { $ref: "#/components/responses/UnauthorizedProblem" }
+        "403":
+          description: Evaluation is disabled on this host.
+        "404":
+          description: No such run, **or** it belongs to another caller, **or** it is not an evaluation run.
+        "409":
+          description: The run has already reached a terminal state.
+        "429": { $ref: "#/components/responses/RateLimited" }
+
 components:
   securitySchemes:
     bearerAuth:
@@ -686,6 +827,12 @@ components:
       in: path
       required: true
       description: The run job id returned by `startWorkflowRun`.
+      schema: { type: string }
+    EvalRunJobId:
+      name: jobId
+      in: path
+      required: true
+      description: The run job id returned by `startEvalRun`.
       schema: { type: string }
     ToolName:
       name: name
@@ -1171,6 +1318,131 @@ components:
       properties:
         jobId: { type: string, description: Server-minted identifier of the queued run. }
         statusUrl: { type: string, description: Where to poll for this run's state. }
+
+    EvalDatasetsResponse:
+      type: object
+      required: [datasets]
+      properties:
+        datasets:
+          type: array
+          items: { type: string }
+          description: Dataset names this host serves. Empty when no roots are configured.
+          example: ["router-accuracy", "safety-refusals"]
+
+    StartEvalRunRequest:
+      type: object
+      description: >-
+        Deliberately narrower than the in-process `EvalRunOptions`. `InvocationOverrides` (a free
+        dictionary flowing into model invocation) and `ForceDeterministic` (local replay) are not on
+        the wire: omitting them means they cannot be sent, which is a stronger statement than
+        validating them away.
+      required: [datasets]
+      properties:
+        datasets:
+          type: array
+          items: { type: string }
+          minItems: 1
+          description: >-
+            Names as `listEvalDatasets` reports them - never file paths. Bounded by
+            `MaxDatasetsPerRun`.
+          example: ["router-accuracy"]
+        repeats:
+          type: integer
+          default: 1
+          description: >-
+            How many times each case is re-invoked, with median-across-repeats aggregation. Bounded
+            by `MaxRepeats`. Multiplies cost linearly.
+        parallelism:
+          type: integer
+          default: 1
+          description: How many cases run at once. Bounded by `MaxParallelism`.
+        tagFilter:
+          type: array
+          items: { type: string }
+          description: When non-empty, only cases carrying one of these tags run.
+        failRateThreshold:
+          type: number
+          format: double
+          default: 0
+          description: >-
+            Fraction of failed cases tolerated before the run's overall verdict is Fail. `0` is
+            strict - any failure fails the run.
+
+    StartEvalRunResponse:
+      type: object
+      required: [jobId, statusUrl]
+      properties:
+        jobId: { type: string, description: Server-minted identifier of the queued run. }
+        statusUrl: { type: string, description: Where to poll for this run's state and report. }
+
+    CancelEvalRunResponse:
+      type: object
+      required: [jobId, stopped]
+      properties:
+        jobId: { type: string }
+        stopped:
+          type: boolean
+          description: >-
+            `false` means the run was already executing and will run to completion - an evaluation in
+            flight cannot be interrupted.
+
+    EvalRunResponse:
+      type: object
+      description: >-
+        A projection of the stored run, not the record itself. The record carries the resolved
+        capability envelope and tenant - the host's authorization state, deliberately never echoed
+        back.
+      required: [jobId, status, datasets, createdAt]
+      properties:
+        jobId: { type: string }
+        status:
+          type: string
+          enum: [Queued, Running, Blocked, Succeeded, Failed, Cancelled]
+          description: >-
+            `Succeeded` means the evaluation **ran**, not that it passed. A failing suite is a
+            succeeded run whose report carries a `Fail` verdict.
+        datasets:
+          type: array
+          items: { type: string }
+          description: The datasets the run was asked to evaluate. Empty once the submission is reclaimed.
+        error:
+          type: string
+          nullable: true
+          description: Caller-safe failure reason. Never raw exception text.
+        createdAt: { type: string, format: date-time }
+        startedAt: { type: string, format: date-time, nullable: true }
+        completedAt: { type: string, format: date-time, nullable: true }
+        report:
+          allOf: [{ $ref: "#/components/schemas/EvalRunSummaryResponse" }]
+          nullable: true
+          description: Absent until the run has produced one.
+
+    EvalRunSummaryResponse:
+      type: object
+      description: >-
+        Counts and a verdict, not the per-case results - those hold every case's input and the
+        agent's full output.
+      required: [runId, verdict, passed, failed, warned, errored, passRate, duration, totalCostUsd, warnings]
+      properties:
+        runId:
+          type: string
+          description: The framework's identifier for the evaluation, as it appears in written reports.
+        verdict: { type: string, enum: [Pass, Warn, Fail] }
+        passed: { type: integer }
+        failed: { type: integer }
+        warned: { type: integer }
+        errored: { type: integer, description: Cases that could not be scored because execution errored. }
+        passRate: { type: number, format: double, description: Passed as a fraction of scored cases. }
+        duration: { type: string, description: ISO-8601 duration. }
+        totalCostUsd:
+          type: number
+          description: >-
+            Cumulative spend across every case, repeat, and metric. Included because it is the number
+            a caller most needs after triggering spend on the host's credentials.
+        warnings:
+          type: array
+          items: { type: string }
+          description: Advisory notes such as cost caveats. Never a failure reason.
 
     WorkflowRunResponse:
       type: object

--- a/documentation/onboarding/assets/openapi/bundle-api.yaml
+++ b/documentation/onboarding/assets/openapi/bundle-api.yaml
@@ -99,7 +99,9 @@ tags:
     description: Submit workflow definitions and manage their runs.
   - name: Evals
     description: >-
-      Run the host's evaluation suites and poll their reports. Off unless
+      Run the host's evaluation suites and poll their reports. Requires the
+      `Harness.Evals.Execute` role - unlike every other route here, this one spends the host's model
+      budget on the operator's suites rather than running the caller's own work. Also off unless
       `AppConfig:AI:Evaluation:Enabled` is set, and the host refuses to start when it is set without
       any `DatasetRoots`.
   - name: Tools
@@ -694,6 +696,9 @@ paths:
         Cost is bounded at admission, not interrupted afterwards: `MaxCaseExecutionsPerRun` counts
         cases **x repeats** and refuses rather than truncating, because quietly evaluating a subset
         would report a pass rate for a suite that never ran.
+
+        On completion the report is filed into the host's durable eval store in-process, so the
+        dashboard sees it without the caller posting anything back.
       requestBody:
         required: true
         content:
@@ -712,7 +717,9 @@ paths:
             owner.
         "401": { $ref: "#/components/responses/UnauthorizedProblem" }
         "403":
-          description: Evaluation is disabled on this host (`AppConfig:AI:Evaluation:Enabled`).
+          description: >-
+            The caller lacks the `Harness.Evals.Execute` role, or evaluation is disabled on this host
+            (`AppConfig:AI:Evaluation:Enabled`).
         "404":
           description: >-
             One of the named datasets is not one this host serves. Unknown and malformed names are

--- a/src/Content/Application/Application.AI.Common/Evaluation/Models/EvalRunSubmission.cs
+++ b/src/Content/Application/Application.AI.Common/Evaluation/Models/EvalRunSubmission.cs
@@ -1,0 +1,50 @@
+using Domain.AI.Evaluation;
+
+namespace Application.AI.Common.Evaluation.Models;
+
+/// <summary>
+/// One evaluation run as the caller asked for it: which datasets, and under what options.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>Datasets are named, never pathed.</strong> The wire contract carries names that mean
+/// something inside the host's configured dataset roots, and the mapping from a name to a file happens
+/// server-side. A path on the wire would make every caller's request a filesystem reference, and the
+/// only thing between that and an arbitrary read would be a guard remembering to refuse — a check that
+/// holds until the day something bypasses it. A name cannot express "outside the roots" at all, so the
+/// dangerous request becomes unrepresentable rather than rejected.
+/// </para>
+/// <para>
+/// <em>The guard still runs underneath.</em> <c>IEvalDatasetPathGuard</c> confines whatever the
+/// resolver produces, so a future caller that reintroduces a path is still contained. Defence in
+/// depth: the wire shape makes the attack unsayable, the guard makes it ineffective.
+/// </para>
+/// <para>
+/// Separate from the run substrate's <c>RunRecord</c> because that record is deliberately
+/// kind-agnostic — it carries identity, ownership and lifecycle, and what a given <c>RunKind</c> needs
+/// beyond that belongs to that kind's own record.
+/// </para>
+/// </remarks>
+public sealed record EvalRunSubmission
+{
+    /// <summary>The run this submission is the input for. Also the run record's <c>TargetId</c>.</summary>
+    public required string JobId { get; init; }
+
+    /// <summary>
+    /// Names of the datasets to evaluate, as they are known inside the host's configured roots.
+    /// </summary>
+    public required IReadOnlyList<string> DatasetNames { get; init; }
+
+    /// <summary>The options the run executes under, already bounded by the configured ceilings.</summary>
+    public required EvalRunOptions Options { get; init; }
+
+    /// <summary>
+    /// The report, once the run has produced one.
+    /// </summary>
+    /// <remarks>
+    /// Held here rather than only logged, so a caller polling the run can read the outcome it paid
+    /// for. A run whose report exists nowhere the caller can reach has spent real model budget to
+    /// produce a log line.
+    /// </remarks>
+    public EvalRunReport? Report { get; init; }
+}

--- a/src/Content/Application/Application.AI.Common/Interfaces/Evaluation/IEvalDatasetCatalog.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Evaluation/IEvalDatasetCatalog.cs
@@ -1,0 +1,44 @@
+namespace Application.AI.Common.Interfaces.Evaluation;
+
+/// <summary>
+/// Maps evaluation dataset <em>names</em> to the files they stand for, inside the host's configured
+/// roots.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>This exists so a filesystem path never has to cross the trust boundary.</strong> The eval
+/// command takes paths, which is right for the CLI — a developer pointing the runner at a file on
+/// their own machine. Exposing that same shape over HTTP would make every request a filesystem
+/// reference, leaving one guard as the only thing between a caller and an arbitrary read. Names
+/// cannot express "outside the roots", so the dangerous request stops being something the API can
+/// describe rather than something it has to reject.
+/// </para>
+/// <para>
+/// <strong>A name is an identifier, not a path fragment.</strong> Implementations must refuse anything
+/// containing a directory separator, a drive qualifier, or a relative segment, and must not treat a
+/// name as something to concatenate onto a root and hope. Resolution works by looking at what is
+/// actually there and matching, which is why <see cref="ListNames"/> and <see cref="Resolve"/> can
+/// never disagree about what exists.
+/// </para>
+/// </remarks>
+public interface IEvalDatasetCatalog
+{
+    /// <summary>
+    /// The dataset names this host will run, across every configured root.
+    /// </summary>
+    /// <returns>
+    /// Distinct names in a stable order. Empty when no roots are configured — an unconfined host has
+    /// no catalog to publish, and enumerating one would mean listing the filesystem.
+    /// </returns>
+    IReadOnlyList<string> ListNames();
+
+    /// <summary>Resolves one dataset name to the absolute file path it stands for.</summary>
+    /// <param name="name">The dataset name, as it appears in <see cref="ListNames"/>.</param>
+    /// <returns>
+    /// The absolute path, or <see langword="null"/> when the name is not one this host serves —
+    /// including when it is malformed. The two are deliberately indistinguishable, for the same reason
+    /// the path guard's refusals are: telling a caller which of their guesses was a <em>valid</em> name
+    /// that simply does not exist turns the endpoint into an oracle.
+    /// </returns>
+    string? Resolve(string name);
+}

--- a/src/Content/Application/Application.AI.Common/Interfaces/Evaluation/IEvalDatasetCatalog.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Evaluation/IEvalDatasetCatalog.cs
@@ -32,13 +32,60 @@ public interface IEvalDatasetCatalog
     /// </returns>
     IReadOnlyList<string> ListNames();
 
-    /// <summary>Resolves one dataset name to the absolute file path it stands for.</summary>
-    /// <param name="name">The dataset name, as it appears in <see cref="ListNames"/>.</param>
-    /// <returns>
-    /// The absolute path, or <see langword="null"/> when the name is not one this host serves —
-    /// including when it is malformed. The two are deliberately indistinguishable, for the same reason
-    /// the path guard's refusals are: telling a caller which of their guesses was a <em>valid</em> name
-    /// that simply does not exist turns the endpoint into an oracle.
-    /// </returns>
-    string? Resolve(string name);
+    /// <summary>
+    /// Resolves a whole set of names to the files they stand for, against one view of the roots.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <strong>The set, not one name at a time.</strong> Resolving is not free: an implementation
+    /// answers by enumerating — this interface requires it — so it walks every configured root and
+    /// confines every file it finds. Asking name by name repeats that walk once per name.
+    /// </para>
+    /// <para>
+    /// It is also the more correct question. Name-at-a-time resolution reads the filesystem at as many
+    /// instants as there are names, so a run could be admitted against a set of files that never
+    /// existed together.
+    /// </para>
+    /// <para>
+    /// <strong>It answers "which one is missing", not just "here is what I found".</strong> Every
+    /// caller needs the same thing — all of them or none, because a suite silently evaluated without
+    /// one of its datasets reports a pass rate for something that never ran. Returning a partial map
+    /// left each caller to rediscover that rule, and both of them wrote the same three lines to do it.
+    /// </para>
+    /// </remarks>
+    /// <param name="names">The names to resolve. Duplicates are permitted.</param>
+    EvalDatasetResolution Resolve(IReadOnlyList<string> names);
+}
+
+/// <summary>
+/// The outcome of resolving a set of dataset names: every file, or the first name that is not one
+/// this host serves.
+/// </summary>
+/// <remarks>
+/// The missing name is carried back so a caller can say which one it was. That is safe to disclose —
+/// it is a name the caller supplied, and it reveals nothing about the filesystem. It says nothing
+/// about <em>why</em>: an unknown name and a malformed one are the same answer, for the same reason
+/// the path guard's refusals do not distinguish forbidden from absent.
+/// </remarks>
+public sealed record EvalDatasetResolution
+{
+    /// <summary>
+    /// The absolute paths, in the order the names were given. Empty unless every name resolved.
+    /// </summary>
+    public IReadOnlyList<string> Paths { get; init; } = [];
+
+    /// <summary>The first name that did not resolve, or <see langword="null"/> when all of them did.</summary>
+    public string? MissingName { get; init; }
+
+    /// <summary>Whether every name resolved.</summary>
+    public bool IsComplete => MissingName is null;
+
+    /// <summary>Every name resolved.</summary>
+    /// <param name="paths">The resolved paths, in the order the names were given.</param>
+    public static EvalDatasetResolution Complete(IReadOnlyList<string> paths) => new() { Paths = paths };
+
+    /// <summary>One name did not resolve, so the set is unusable.</summary>
+    /// <param name="missingName">The name this host does not serve.</param>
+    public static EvalDatasetResolution Missing(string missingName) =>
+        new() { MissingName = missingName };
 }

--- a/src/Content/Application/Application.AI.Common/Interfaces/Evaluation/IEvalDatasetCatalog.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Evaluation/IEvalDatasetCatalog.cs
@@ -85,7 +85,23 @@ public sealed record EvalDatasetResolution
     public static EvalDatasetResolution Complete(IReadOnlyList<string> paths) => new() { Paths = paths };
 
     /// <summary>One name did not resolve, so the set is unusable.</summary>
+    /// <remarks>
+    /// <para>
+    /// A blank or absent name is substituted rather than stored, because <see cref="IsComplete"/> reads
+    /// a null <see cref="MissingName"/> as success. Constructing this factory with a blank name would
+    /// otherwise produce a resolution that <em>claims</em> every name resolved while carrying no paths
+    /// — and a caller checking <see cref="IsComplete"/> would admit a run over zero datasets.
+    /// </para>
+    /// <para>
+    /// Unreachable today: a validator rejects blank names before any handler resolves them. Guarded
+    /// anyway, because it is a silent success — the one failure mode that produces no error, no log,
+    /// and a caller who believes their suite ran.
+    /// </para>
+    /// </remarks>
     /// <param name="missingName">The name this host does not serve.</param>
-    public static EvalDatasetResolution Missing(string missingName) =>
-        new() { MissingName = missingName };
+    public static EvalDatasetResolution Missing(string? missingName) =>
+        new() { MissingName = string.IsNullOrWhiteSpace(missingName) ? UnnamedDataset : missingName };
+
+    /// <summary>Stands in for a blank name, so a refusal can never be mistaken for a success.</summary>
+    public const string UnnamedDataset = "(unnamed)";
 }

--- a/src/Content/Application/Application.AI.Common/Interfaces/Evaluation/IEvalRunSubmissionStore.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Evaluation/IEvalRunSubmissionStore.cs
@@ -1,0 +1,63 @@
+using Application.AI.Common.Evaluation.Models;
+using Application.AI.Common.Interfaces.Runs;
+using Domain.AI.Evaluation;
+
+namespace Application.AI.Common.Interfaces.Evaluation;
+
+/// <summary>
+/// Holds what an evaluation run needs beyond the kind-agnostic run record: which datasets it named,
+/// and the report it produced.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>Why this is not on <c>RunRecord</c>.</strong> That record is deliberately kind-agnostic —
+/// identity, ownership, lifecycle, timing — so the queue, the dispatcher, single-arming and expiry are
+/// written once for every kind of work. Dataset names and an evaluation report are true of exactly one
+/// kind, and putting them there would make the next kind's inputs the third set of mostly-null columns.
+/// </para>
+/// <para>
+/// <strong>Ownership is not checked here, and that is deliberate.</strong> Entries are keyed by job id
+/// and reached only after <c>IRunJobStore.Get</c> has already answered for the caller — a run that
+/// belongs to someone else resolves to nothing there, so nothing asks this store about it. Adding a
+/// second identity check would be an unreachable one, which reads as protection that is never
+/// exercised. The rule this depends on is that <em>no</em> caller-facing path may reach this store
+/// without a scoped read first.
+/// </para>
+/// <para>
+/// Implements <see cref="IRunReclaimListener"/> rather than leaving cleanup to a caller: a report is
+/// held per run, so an implementation that never dropped one would grow for the life of the process.
+/// Requiring it on the interface makes that a decision every implementation has to make rather than
+/// one an author can omit.
+/// </para>
+/// </remarks>
+public interface IEvalRunSubmissionStore : IRunReclaimListener
+{
+    /// <summary>Records a submission for a run that has just been accepted.</summary>
+    /// <param name="submission">The submission, keyed by its <see cref="EvalRunSubmission.JobId"/>.</param>
+    /// <exception cref="InvalidOperationException">A submission for that job id is already held.</exception>
+    void Add(EvalRunSubmission submission);
+
+    /// <summary>
+    /// Reads a submission, or <see langword="null"/> when none is held for that run.
+    /// </summary>
+    /// <remarks>
+    /// A missing entry for a run the caller could read is possible and is not an error: the record and
+    /// the submission are reclaimed on the same sweep, but nothing makes the two writes atomic, and a
+    /// caller polling in that window is owed the run's status rather than a failure.
+    /// </remarks>
+    /// <param name="jobId">The run to read.</param>
+    EvalRunSubmission? Get(string jobId);
+
+    /// <summary>
+    /// Attaches the report a finished run produced, reporting whether a submission was there to attach
+    /// it to.
+    /// </summary>
+    /// <remarks>
+    /// Separate from <see cref="Add"/> because the report does not exist when the run is accepted, and
+    /// the run is accepted long before anything executes. A run whose report is held nowhere the caller
+    /// can reach has spent real model budget to produce a log line.
+    /// </remarks>
+    /// <param name="jobId">The run that produced the report.</param>
+    /// <param name="report">The report to attach.</param>
+    bool AttachReport(string jobId, EvalRunReport report);
+}

--- a/src/Content/Application/Application.AI.Common/Interfaces/Runs/IRunReclaimListener.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Runs/IRunReclaimListener.cs
@@ -1,0 +1,37 @@
+namespace Application.AI.Common.Interfaces.Runs;
+
+/// <summary>
+/// Releases whatever it holds against a run whose record has been reclaimed.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>A run's identifier keys more than its record.</strong> Progress bookkeeping is held against
+/// it, and so is whatever a given <see cref="Domain.AI.Runs.RunKind"/> needs beyond the kind-agnostic
+/// record — an evaluation's dataset names and its report, for instance. Each of those is a side table
+/// that grows for the life of the process unless something drops its entry when the run goes.
+/// </para>
+/// <para>
+/// <strong>Why a seam rather than a dependency per table.</strong> The sweeper is the one place that
+/// knows a run has been reclaimed. Naming each holder there means every future kind of run adds a
+/// constructor parameter to a service that has nothing to do with it — and the kind whose author
+/// forgets is not a compile error, it is an unbounded leak nobody observes until the host runs out of
+/// memory. Listening instead makes releasing a property of holding.
+/// </para>
+/// <para>
+/// <strong>Implementations must not throw.</strong> The sweep is a loop over every listener; one that
+/// fails would stop the rest from being told, so a run's record would be gone while another holder
+/// still had its entry — the exact leak this exists to close. Log and carry on.
+/// </para>
+/// </remarks>
+public interface IRunReclaimListener
+{
+    /// <summary>
+    /// Drops everything held for the given runs. Identifiers that were never held are ignored.
+    /// </summary>
+    /// <remarks>
+    /// Takes the whole batch rather than one identifier at a time so an implementation backed by
+    /// something with a per-call cost — a round trip, a lock, a transaction — can pay it once.
+    /// </remarks>
+    /// <param name="jobIds">The runs whose records have been reclaimed.</param>
+    void OnRunsReclaimed(IReadOnlyList<string> jobIds);
+}

--- a/src/Content/Application/Application.Core/CQRS/Evaluation/RunEvalSuite/EvalDatasetCatalog.cs
+++ b/src/Content/Application/Application.Core/CQRS/Evaluation/RunEvalSuite/EvalDatasetCatalog.cs
@@ -1,0 +1,148 @@
+using Application.AI.Common.Interfaces.Evaluation;
+using Domain.Common.Config;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Application.Core.CQRS.Evaluation.RunEvalSuite;
+
+/// <summary>
+/// Default <see cref="IEvalDatasetCatalog"/>: the datasets are the files sitting at the top level of
+/// the configured roots, and their names are those files' names without the extension.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>Resolution is by enumeration, not by concatenation.</strong> The tempting implementation is
+/// <c>Path.Combine(root, name + ".yaml")</c> with a validity check on <c>name</c> — and that is a
+/// path-building routine wearing a name-shaped interface, one missed character class away from
+/// traversal. Listing what is actually in the root and matching against it cannot construct a path
+/// the caller influenced, so there is no character class to get wrong.
+/// </para>
+/// <para>
+/// <strong>Top level only, deliberately.</strong> Datasets in subdirectories would need names that
+/// carry structure, and a name with structure is a path with extra steps — it would have to be split,
+/// rejoined, and validated, which is the concatenation problem again. A flat namespace per root keeps
+/// a name an opaque identifier. The cost is that operators organise by root rather than by folder,
+/// which is a real constraint and is documented on <c>EvaluationConfig.DatasetRoots</c>.
+/// </para>
+/// <para>
+/// <strong>No catalog without roots.</strong> An unconfined host — the CLI's shipped default — returns
+/// nothing rather than enumerating whatever directory it happens to be running from. Listing is a
+/// disclosure, and there is no bounded thing to disclose until an operator says what the bounds are.
+/// </para>
+/// </remarks>
+public sealed class EvalDatasetCatalog : IEvalDatasetCatalog
+{
+    private readonly IOptionsMonitor<AppConfig> _config;
+    private readonly IEvalDatasetPathGuard _guard;
+    private readonly ILogger<EvalDatasetCatalog> _logger;
+
+    /// <summary>Initializes the catalog.</summary>
+    /// <param name="config">Supplies the dataset roots, read per call so a new root needs no restart.</param>
+    /// <param name="guard">
+    /// Confines every resolved path. Applied here as well as in the handler on purpose: this class
+    /// decides what is reachable by name, and it should not be able to publish a name whose file the
+    /// handler will then refuse.
+    /// </param>
+    /// <param name="logger">Records name collisions across roots, which are otherwise silent.</param>
+    public EvalDatasetCatalog(
+        IOptionsMonitor<AppConfig> config,
+        IEvalDatasetPathGuard guard,
+        ILogger<EvalDatasetCatalog> logger)
+    {
+        ArgumentNullException.ThrowIfNull(config);
+        ArgumentNullException.ThrowIfNull(guard);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _config = config;
+        _guard = guard;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public IReadOnlyList<string> ListNames() => [.. Discover().Keys.OrderBy(n => n, StringComparer.Ordinal)];
+
+    /// <inheritdoc />
+    public string? Resolve(string name)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+            return null;
+
+        // A name is an identifier. Anything that could steer resolution — a separator, a drive
+        // qualifier, a relative segment — is refused before it is compared, so a name that looks like
+        // a path never gets as far as being looked up. Enumeration would not honour it anyway; this
+        // just makes the intent explicit rather than incidental.
+        if (name.AsSpan().IndexOfAny('/', '\\', ':') >= 0 || name is "." or "..")
+            return null;
+
+        return Discover().TryGetValue(name, out var path) ? path : null;
+    }
+
+    /// <summary>
+    /// Builds the name-to-path map from what is currently on disk under the configured roots.
+    /// </summary>
+    /// <remarks>
+    /// Not cached. The roots are a small, operator-curated set of directories, and a stale catalog
+    /// would report a dataset that has since been removed — a caller then submits a run that fails at
+    /// load time, having already been admitted and queued. Reading the directory per call is cheap
+    /// next to the model spend of the run it authorizes.
+    /// </remarks>
+    private Dictionary<string, string> Discover()
+    {
+        var found = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        var roots = _config.CurrentValue.AI.Evaluation.DatasetRoots ?? [];
+
+        foreach (var root in roots)
+        {
+            if (string.IsNullOrWhiteSpace(root))
+                continue;
+
+            string[] files;
+            try
+            {
+                files = Directory.GetFiles(Path.GetFullPath(root));
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException
+                                          or ArgumentException or NotSupportedException
+                                          or PathTooLongException)
+            {
+                // A root that cannot be read contributes nothing. It is not an error for the caller:
+                // the effect is that its datasets are absent, which is exactly what an absent name
+                // already means.
+                _logger.LogWarning(ex, "Evaluation dataset root {Root} could not be read.", root);
+                continue;
+            }
+
+            foreach (var file in files)
+            {
+                var name = Path.GetFileNameWithoutExtension(file);
+                if (string.IsNullOrWhiteSpace(name))
+                    continue;
+
+                // The guard has the final say on every path this class hands out, so the catalog can
+                // never publish a name the handler would then refuse to load.
+                var decision = _guard.Resolve(file);
+                if (!decision.IsAllowed)
+                    continue;
+
+                if (found.TryGetValue(name, out var existing))
+                {
+                    if (!string.Equals(existing, decision.CanonicalPath, StringComparison.Ordinal))
+                    {
+                        _logger.LogWarning(
+                            "Evaluation dataset name {Name} is defined in more than one root; keeping "
+                            + "the first and ignoring {Ignored}.",
+                            name,
+                            file);
+                    }
+
+                    continue;
+                }
+
+                found[name] = decision.CanonicalPath!;
+            }
+        }
+
+        return found;
+    }
+}

--- a/src/Content/Application/Application.Core/CQRS/Evaluation/RunEvalSuite/EvalDatasetPathGuard.cs
+++ b/src/Content/Application/Application.Core/CQRS/Evaluation/RunEvalSuite/EvalDatasetPathGuard.cs
@@ -146,30 +146,8 @@ public sealed class EvalDatasetPathGuard : IEvalDatasetPathGuard
         if (walk.Exhausted)
             return EvalDatasetPathDecision.Refuse("Dataset is not available.");
 
-        foreach (var root in roots)
+        foreach (var canonicalRoot in ResolvedRoots(roots))
         {
-            string canonicalRoot;
-            try
-            {
-                // Roots go through the SAME link resolution as the candidate. Comparing a fully-resolved
-                // candidate against a merely-canonicalised root refuses everything whenever the root is
-                // reached through a symlinked directory — macOS `/tmp` (a link to `/private/tmp`) and
-                // plenty of container bind mounts are exactly that. It fails closed, so it is an
-                // availability trap rather than a bypass, but a confinement rule that silently rejects
-                // every legitimate path gets switched off by whoever hits it.
-                var rootWalk = new LinkWalk();
-                canonicalRoot = ResolveSegments(Path.GetFullPath(root), rootWalk);
-
-                // An unresolvable root confines nothing knowable, so drop it rather than compare against
-                // a half-resolved path.
-                if (rootWalk.Exhausted)
-                    continue;
-            }
-            catch (Exception ex) when (ex is ArgumentException or NotSupportedException or PathTooLongException)
-            {
-                continue;
-            }
-
             if (IsInside(effective, canonicalRoot) && File.Exists(effective))
                 return EvalDatasetPathDecision.Allow(effective);
         }
@@ -189,6 +167,70 @@ public sealed class EvalDatasetPathGuard : IEvalDatasetPathGuard
     /// </remarks>
     private static IReadOnlyList<string> UsableRoots(AppConfig config) =>
         [.. (config.AI.Evaluation.DatasetRoots ?? []).Where(root => !string.IsNullOrWhiteSpace(root))];
+
+    /// <summary>
+    /// The configured roots, fully link-resolved, reusing the previous answer while the roots are
+    /// unchanged.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Roots go through the SAME link resolution as the candidate. Comparing a fully-resolved candidate
+    /// against a merely-canonicalised root refuses everything whenever the root is reached through a
+    /// symlinked directory — macOS <c>/tmp</c> (a link to <c>/private/tmp</c>) and plenty of container
+    /// bind mounts are exactly that. It fails closed, so it is an availability trap rather than a
+    /// bypass, but a confinement rule that silently rejects every legitimate path gets switched off by
+    /// whoever hits it.
+    /// </para>
+    /// <para>
+    /// <strong>Memoized because the roots do not vary with the candidate.</strong> Resolving them
+    /// inside the per-candidate loop repeated the same link walk for every path checked — which was
+    /// tolerable when a check meant one dataset, and is not now that the name catalog confines every
+    /// file in every root on each listing. Only the resolution is reused; the containment comparison
+    /// and the <c>File.Exists</c> still happen per candidate, so nothing about the decision is cached.
+    /// </para>
+    /// <para>
+    /// The cache is keyed on the configured roots themselves, so a configuration reload that changes
+    /// them recomputes rather than serving a stale allowlist — which is the direction that matters:
+    /// a stale <em>wider</em> allowlist would be a bypass.
+    /// </para>
+    /// </remarks>
+    private IReadOnlyList<string> ResolvedRoots(IReadOnlyList<string> roots)
+    {
+        var cached = _resolvedRoots;
+        if (cached is not null && cached.Configured.SequenceEqual(roots, StringComparer.Ordinal))
+            return cached.Resolved;
+
+        var resolved = new List<string>(roots.Count);
+        foreach (var root in roots)
+        {
+            try
+            {
+                var rootWalk = new LinkWalk();
+                var canonicalRoot = ResolveSegments(Path.GetFullPath(root), rootWalk);
+
+                // An unresolvable root confines nothing knowable, so drop it rather than compare
+                // against a half-resolved path.
+                if (!rootWalk.Exhausted)
+                    resolved.Add(canonicalRoot);
+            }
+            catch (Exception ex) when (ex is ArgumentException or NotSupportedException or PathTooLongException)
+            {
+                // A malformed root contributes nothing rather than refusing every path.
+            }
+        }
+
+        // A plain field write, not a lock. Two threads racing here compute the same answer from the
+        // same configuration, so the loser's work is wasted rather than wrong, and a torn read is not
+        // possible for a reference.
+        _resolvedRoots = new RootCache(roots, resolved);
+        return resolved;
+    }
+
+    /// <summary>The last root resolution, held so an unchanged configuration is not re-walked.</summary>
+    private volatile RootCache? _resolvedRoots;
+
+    /// <summary>One resolution of the configured roots, and the configuration it was computed from.</summary>
+    private sealed record RootCache(IReadOnlyList<string> Configured, IReadOnlyList<string> Resolved);
 
     /// <summary>Total symbolic links followed while resolving one path, across every segment.</summary>
     /// <remarks>

--- a/src/Content/Application/Application.Core/CQRS/Evaluation/Runs/CancelEvalRunCommand.cs
+++ b/src/Content/Application/Application.Core/CQRS/Evaluation/Runs/CancelEvalRunCommand.cs
@@ -1,0 +1,41 @@
+using Domain.Common;
+using MediatR;
+
+namespace Application.Core.CQRS.Evaluation.Runs;
+
+/// <summary>Stops an evaluation run the caller started, if it has not begun executing.</summary>
+public sealed record CancelEvalRunCommand : IRequest<Result<CancelEvalRunResult>>
+{
+    /// <summary>The run to stop.</summary>
+    public required string JobId { get; init; }
+
+    /// <summary>Stable identity of the calling principal.</summary>
+    public required string OwnerId { get; init; }
+
+    /// <summary>Tenant of the calling principal, when the host resolves one.</summary>
+    public string? TenantId { get; init; }
+}
+
+/// <summary>What a cancellation achieved, as the caller sees it.</summary>
+public sealed record CancelEvalRunResult
+{
+    /// <summary>
+    /// Whether the run had stopped by the time this was answered.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <strong>False means the run is executing and will continue.</strong> This is weaker than the
+    /// workflow path's answer, and the difference is real rather than an omission: a workflow executing
+    /// through the planner can be signalled through <c>IPlanRunCancellationRegistry</c>, whereas an
+    /// evaluation in flight is a suite of agent turns with no equivalent registry to signal. Cancelling
+    /// a queued or already-finished evaluation is exact; cancelling one mid-suite is not offered rather
+    /// than being offered and quietly not honoured.
+    /// </para>
+    /// <para>
+    /// The practical bound on a runaway suite is therefore the configured
+    /// <c>MaxCaseExecutionsPerRun</c>, which is applied before any case runs — the spend is capped at
+    /// admission rather than interrupted afterwards.
+    /// </para>
+    /// </remarks>
+    public required bool Stopped { get; init; }
+}

--- a/src/Content/Application/Application.Core/CQRS/Evaluation/Runs/CancelEvalRunCommand.cs
+++ b/src/Content/Application/Application.Core/CQRS/Evaluation/Runs/CancelEvalRunCommand.cs
@@ -15,27 +15,3 @@ public sealed record CancelEvalRunCommand : IRequest<Result<CancelEvalRunResult>
     /// <summary>Tenant of the calling principal, when the host resolves one.</summary>
     public string? TenantId { get; init; }
 }
-
-/// <summary>What a cancellation achieved, as the caller sees it.</summary>
-public sealed record CancelEvalRunResult
-{
-    /// <summary>
-    /// Whether the run had stopped by the time this was answered.
-    /// </summary>
-    /// <remarks>
-    /// <para>
-    /// <strong>False means the run is executing and will continue.</strong> This is weaker than the
-    /// workflow path's answer, and the difference is real rather than an omission: a workflow executing
-    /// through the planner can be signalled through <c>IPlanRunCancellationRegistry</c>, whereas an
-    /// evaluation in flight is a suite of agent turns with no equivalent registry to signal. Cancelling
-    /// a queued or already-finished evaluation is exact; cancelling one mid-suite is not offered rather
-    /// than being offered and quietly not honoured.
-    /// </para>
-    /// <para>
-    /// The practical bound on a runaway suite is therefore the configured
-    /// <c>MaxCaseExecutionsPerRun</c>, which is applied before any case runs — the spend is capped at
-    /// admission rather than interrupted afterwards.
-    /// </para>
-    /// </remarks>
-    public required bool Stopped { get; init; }
-}

--- a/src/Content/Application/Application.Core/CQRS/Evaluation/Runs/CancelEvalRunCommandHandler.cs
+++ b/src/Content/Application/Application.Core/CQRS/Evaluation/Runs/CancelEvalRunCommandHandler.cs
@@ -1,0 +1,105 @@
+using Application.AI.Common.Interfaces.Runs;
+using Domain.AI.Runs;
+using Domain.Common;
+using Domain.Common.Config;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Application.Core.CQRS.Evaluation.Runs;
+
+/// <summary>
+/// Handles <see cref="CancelEvalRunCommand"/>: stops an evaluation run that has not started executing.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>Simpler than the workflow cancel path, because an evaluation holds less.</strong> A workflow
+/// can be parked on a human gate whose approval has to be withdrawn, and can be signalled mid-flight
+/// through the plan cancellation registry. An evaluation parks on nothing and has no such registry, so
+/// what is left is the transition itself.
+/// </para>
+/// <para>
+/// Authorized exactly like reading the run: another caller's run, a job that never existed, and a run
+/// of another kind are one answer. A distinguishable response would let a caller discover work it was
+/// not given the identifier for — and here it would also let them stop it.
+/// </para>
+/// </remarks>
+public sealed class CancelEvalRunCommandHandler
+    : IRequestHandler<CancelEvalRunCommand, Result<CancelEvalRunResult>>
+{
+    private readonly IRunJobStore _runStore;
+    private readonly IRunProgressBroker _progress;
+    private readonly IOptionsMonitor<AppConfig> _config;
+    private readonly TimeProvider _time;
+    private readonly ILogger<CancelEvalRunCommandHandler> _logger;
+
+    /// <summary>Initializes a new <see cref="CancelEvalRunCommandHandler"/>.</summary>
+    public CancelEvalRunCommandHandler(
+        IRunJobStore runStore,
+        IRunProgressBroker progress,
+        IOptionsMonitor<AppConfig> config,
+        TimeProvider time,
+        ILogger<CancelEvalRunCommandHandler> logger)
+    {
+        ArgumentNullException.ThrowIfNull(runStore);
+        ArgumentNullException.ThrowIfNull(progress);
+        ArgumentNullException.ThrowIfNull(config);
+        ArgumentNullException.ThrowIfNull(time);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _runStore = runStore;
+        _progress = progress;
+        _config = config;
+        _time = time;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public Task<Result<CancelEvalRunResult>> Handle(
+        CancelEvalRunCommand request, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (!_config.CurrentValue.AI.Evaluation.Enabled)
+        {
+            return Task.FromResult(Result<CancelEvalRunResult>.Forbidden(
+                "Evaluation is disabled. Set AppConfig.AI.Evaluation.Enabled = true to enable it."));
+        }
+
+        var record = _runStore.Get(request.JobId, request.OwnerId, request.TenantId);
+
+        if (record is null || record.Kind != RunKind.Evaluation)
+            return Task.FromResult(Result<CancelEvalRunResult>.NotFound($"No run {request.JobId} found."));
+
+        if (record.IsTerminal)
+        {
+            return Task.FromResult(Result<CancelEvalRunResult>.Conflict(
+                $"Run {request.JobId} has already finished and cannot be cancelled."));
+        }
+
+        var stopped = _runStore.TryCancel(request.JobId, _time.GetUtcNow());
+        if (stopped is null)
+        {
+            // Executing, or it reached a terminal state between the read above and here. Either way its
+            // status belongs to the dispatch holding it. Reported truthfully rather than as a success:
+            // a caller told the run had stopped would assume the spend had stopped with it.
+            return Task.FromResult(Result<CancelEvalRunResult>.Success(
+                new CancelEvalRunResult { Stopped = false }));
+        }
+
+        // Published here because nothing else will: no dispatch is going to run for this job, and the
+        // terminal event is what ends a watcher's stream. Without it, anyone streaming a queued run
+        // holds the connection and a stream slot until they give up.
+        _progress.Publish(
+            stopped.JobId,
+            RunProgressKind.RunFinished,
+            status: nameof(RunStatus.Cancelled),
+            detail: "The run was cancelled by its owner.");
+
+        _logger.LogInformation("Evaluation run {JobId} was cancelled by its owner.", stopped.JobId);
+
+        return Task.FromResult(Result<CancelEvalRunResult>.Success(
+            new CancelEvalRunResult { Stopped = true }));
+    }
+}

--- a/src/Content/Application/Application.Core/CQRS/Evaluation/Runs/CancelEvalRunResult.cs
+++ b/src/Content/Application/Application.Core/CQRS/Evaluation/Runs/CancelEvalRunResult.cs
@@ -1,0 +1,25 @@
+namespace Application.Core.CQRS.Evaluation.Runs;
+
+/// <summary>What a cancellation achieved, as the caller sees it.</summary>
+public sealed record CancelEvalRunResult
+{
+    /// <summary>
+    /// Whether the run had stopped by the time this was answered.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <strong>False means the run is executing and will continue.</strong> This is weaker than the
+    /// workflow path's answer, and the difference is real rather than an omission: a workflow executing
+    /// through the planner can be signalled through <c>IPlanRunCancellationRegistry</c>, whereas an
+    /// evaluation in flight is a suite of agent turns with no equivalent registry to signal. Cancelling
+    /// a queued or already-finished evaluation is exact; cancelling one mid-suite is not offered rather
+    /// than being offered and quietly not honoured.
+    /// </para>
+    /// <para>
+    /// The practical bound on a runaway suite is therefore the configured
+    /// <c>MaxCaseExecutionsPerRun</c>, which is applied before any case runs — the spend is capped at
+    /// admission rather than interrupted afterwards.
+    /// </para>
+    /// </remarks>
+    public required bool Stopped { get; init; }
+}

--- a/src/Content/Application/Application.Core/CQRS/Evaluation/Runs/EvalRunView.cs
+++ b/src/Content/Application/Application.Core/CQRS/Evaluation/Runs/EvalRunView.cs
@@ -1,0 +1,29 @@
+using Domain.AI.Evaluation;
+using Domain.AI.Runs;
+
+namespace Application.Core.CQRS.Evaluation.Runs;
+
+/// <summary>
+/// One evaluation run as its owner sees it: the substrate's record, what it was asked to evaluate, and
+/// the report if it produced one.
+/// </summary>
+/// <remarks>
+/// Three pieces rather than one because they are stored in three places for good reasons — the record
+/// is kind-agnostic, the request and report belong to this kind alone. Joining them here rather than at
+/// the transport keeps the "a run with no submission is still a readable run" rule in one place instead
+/// of in every surface that reads one.
+/// </remarks>
+public sealed record EvalRunView
+{
+    /// <summary>The run's identity, ownership and lifecycle.</summary>
+    public required RunRecord Run { get; init; }
+
+    /// <summary>
+    /// The datasets the run was asked to evaluate. Empty when the submission has already been
+    /// reclaimed, which is possible for a run whose own record has not been swept yet.
+    /// </summary>
+    public IReadOnlyList<string> DatasetNames { get; init; } = [];
+
+    /// <summary>The report, once the run has produced one.</summary>
+    public EvalRunReport? Report { get; init; }
+}

--- a/src/Content/Application/Application.Core/CQRS/Evaluation/Runs/GetEvalRunQuery.cs
+++ b/src/Content/Application/Application.Core/CQRS/Evaluation/Runs/GetEvalRunQuery.cs
@@ -1,0 +1,44 @@
+using Domain.AI.Evaluation;
+using Domain.AI.Runs;
+using Domain.Common;
+using MediatR;
+
+namespace Application.Core.CQRS.Evaluation.Runs;
+
+/// <summary>Reads an evaluation run the caller started, and its report once there is one.</summary>
+public sealed record GetEvalRunQuery : IRequest<Result<EvalRunView>>
+{
+    /// <summary>The run to read.</summary>
+    public required string JobId { get; init; }
+
+    /// <summary>Stable identity of the calling principal.</summary>
+    public required string OwnerId { get; init; }
+
+    /// <summary>Tenant of the calling principal, when the host resolves one.</summary>
+    public string? TenantId { get; init; }
+}
+
+/// <summary>
+/// One evaluation run as its owner sees it: the substrate's record, what it was asked to evaluate, and
+/// the report if it produced one.
+/// </summary>
+/// <remarks>
+/// Three pieces rather than one because they are stored in three places for good reasons — the record
+/// is kind-agnostic, the request and report belong to this kind alone. Joining them here rather than at
+/// the transport keeps the "a run with no submission is still a readable run" rule in one place instead
+/// of in every surface that reads one.
+/// </remarks>
+public sealed record EvalRunView
+{
+    /// <summary>The run's identity, ownership and lifecycle.</summary>
+    public required RunRecord Run { get; init; }
+
+    /// <summary>
+    /// The datasets the run was asked to evaluate. Empty when the submission has already been
+    /// reclaimed, which is possible for a run whose own record has not been swept yet.
+    /// </summary>
+    public IReadOnlyList<string> DatasetNames { get; init; } = [];
+
+    /// <summary>The report, once the run has produced one.</summary>
+    public EvalRunReport? Report { get; init; }
+}

--- a/src/Content/Application/Application.Core/CQRS/Evaluation/Runs/GetEvalRunQuery.cs
+++ b/src/Content/Application/Application.Core/CQRS/Evaluation/Runs/GetEvalRunQuery.cs
@@ -17,28 +17,3 @@ public sealed record GetEvalRunQuery : IRequest<Result<EvalRunView>>
     /// <summary>Tenant of the calling principal, when the host resolves one.</summary>
     public string? TenantId { get; init; }
 }
-
-/// <summary>
-/// One evaluation run as its owner sees it: the substrate's record, what it was asked to evaluate, and
-/// the report if it produced one.
-/// </summary>
-/// <remarks>
-/// Three pieces rather than one because they are stored in three places for good reasons — the record
-/// is kind-agnostic, the request and report belong to this kind alone. Joining them here rather than at
-/// the transport keeps the "a run with no submission is still a readable run" rule in one place instead
-/// of in every surface that reads one.
-/// </remarks>
-public sealed record EvalRunView
-{
-    /// <summary>The run's identity, ownership and lifecycle.</summary>
-    public required RunRecord Run { get; init; }
-
-    /// <summary>
-    /// The datasets the run was asked to evaluate. Empty when the submission has already been
-    /// reclaimed, which is possible for a run whose own record has not been swept yet.
-    /// </summary>
-    public IReadOnlyList<string> DatasetNames { get; init; } = [];
-
-    /// <summary>The report, once the run has produced one.</summary>
-    public EvalRunReport? Report { get; init; }
-}

--- a/src/Content/Application/Application.Core/CQRS/Evaluation/Runs/GetEvalRunQueryHandler.cs
+++ b/src/Content/Application/Application.Core/CQRS/Evaluation/Runs/GetEvalRunQueryHandler.cs
@@ -1,0 +1,81 @@
+using Application.AI.Common.Interfaces.Evaluation;
+using Application.AI.Common.Interfaces.Runs;
+using Domain.AI.Runs;
+using Domain.Common;
+using Domain.Common.Config;
+using MediatR;
+using Microsoft.Extensions.Options;
+
+namespace Application.Core.CQRS.Evaluation.Runs;
+
+/// <summary>
+/// Handles <see cref="GetEvalRunQuery"/>: reads an evaluation run the caller started.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Answers NotFound for a run belonging to someone else, a run that never existed, and a run of another
+/// kind alike. A caller learning "that exists but is not yours" could enumerate other callers' work by
+/// guessing identifiers, so the three are deliberately one answer.
+/// </para>
+/// <para>
+/// <strong>The kind is checked, not assumed.</strong> Job ids are minted from one sequence for every
+/// kind of run, so without this a caller could read a workflow run through the evaluation route. It
+/// would disclose little on its own — the projection carries no envelope — but it would confirm that a
+/// job id it holds belongs to a workflow, and the same omission on the cancel path would let it stop
+/// one.
+/// </para>
+/// </remarks>
+public sealed class GetEvalRunQueryHandler : IRequestHandler<GetEvalRunQuery, Result<EvalRunView>>
+{
+    private readonly IRunJobStore _runStore;
+    private readonly IEvalRunSubmissionStore _submissions;
+    private readonly IOptionsMonitor<AppConfig> _config;
+
+    /// <summary>Initializes a new <see cref="GetEvalRunQueryHandler"/>.</summary>
+    public GetEvalRunQueryHandler(
+        IRunJobStore runStore,
+        IEvalRunSubmissionStore submissions,
+        IOptionsMonitor<AppConfig> config)
+    {
+        ArgumentNullException.ThrowIfNull(runStore);
+        ArgumentNullException.ThrowIfNull(submissions);
+        ArgumentNullException.ThrowIfNull(config);
+
+        _runStore = runStore;
+        _submissions = submissions;
+        _config = config;
+    }
+
+    /// <inheritdoc />
+    public Task<Result<EvalRunView>> Handle(GetEvalRunQuery request, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (!_config.CurrentValue.AI.Evaluation.Enabled)
+        {
+            return Task.FromResult(Result<EvalRunView>.Forbidden(
+                "Evaluation is disabled. Set AppConfig.AI.Evaluation.Enabled = true to enable it."));
+        }
+
+        // Scoped by owner and tenant inside the store, which is what makes the submission read below
+        // safe: that store applies no scope of its own and must never be reached without this first.
+        var record = _runStore.Get(request.JobId, request.OwnerId, request.TenantId);
+
+        if (record is null || record.Kind != RunKind.Evaluation)
+            return Task.FromResult(Result<EvalRunView>.NotFound($"No run {request.JobId} found."));
+
+        // Absent is normal, not an error: the record and the submission are dropped by the same sweep,
+        // but nothing makes the two writes atomic. A caller polling in that window is owed the run's
+        // status rather than a failure — the run genuinely happened, and its lifecycle is the part that
+        // still answers.
+        var submission = _submissions.Get(record.JobId);
+
+        return Task.FromResult(Result<EvalRunView>.Success(new EvalRunView
+        {
+            Run = record,
+            DatasetNames = submission?.DatasetNames ?? [],
+            Report = submission?.Report
+        }));
+    }
+}

--- a/src/Content/Application/Application.Core/CQRS/Evaluation/Runs/StartEvalRunCommand.cs
+++ b/src/Content/Application/Application.Core/CQRS/Evaluation/Runs/StartEvalRunCommand.cs
@@ -1,0 +1,51 @@
+using Application.AI.Common.Evaluation.Models;
+using Domain.AI.Bundles;
+using Domain.Common;
+using MediatR;
+
+namespace Application.Core.CQRS.Evaluation.Runs;
+
+/// <summary>
+/// Accepts an evaluation run and queues it, returning the identifier to poll. Nothing is evaluated on
+/// the calling thread.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>Datasets are named, never pathed.</strong> Names mean something inside the host's configured
+/// dataset roots and are resolved server-side. This is why the command carries no path: a path on the
+/// wire would make every request a filesystem reference, and the only thing between that and an
+/// arbitrary read would be a guard remembering to refuse. The guard still runs underneath — but the
+/// attack is unsayable here rather than merely rejected there.
+/// </para>
+/// <para>
+/// <strong>Ownership and the envelope come from the transport, never from the request body.</strong>
+/// There is no field a caller could use to nominate a different owner or a wider grant. Both are
+/// captured on the run record because a run outlives the request that started it and executes on a
+/// thread with no caller attached.
+/// </para>
+/// </remarks>
+public sealed record StartEvalRunCommand : IRequest<Result<StartEvalRunResult>>
+{
+    /// <summary>Names of the datasets to evaluate, as this host publishes them.</summary>
+    public required IReadOnlyList<string> DatasetNames { get; init; }
+
+    /// <summary>How the run executes. Bounded by the configured ceilings before it is accepted.</summary>
+    public EvalRunOptions Options { get; init; } = new();
+
+    /// <summary>Stable identity of the calling principal, resolved at the transport boundary.</summary>
+    public required string OwnerId { get; init; }
+
+    /// <summary>Tenant of the calling principal, when the host resolves one.</summary>
+    public string? TenantId { get; init; }
+
+    /// <summary>
+    /// The grant the run executes under, resolved from the credential that made <em>this</em> request.
+    /// </summary>
+    /// <remarks>
+    /// Every evaluation case is a governed agent turn that can invoke tools, so an evaluation run needs
+    /// an envelope for the same reason a workflow run does. Resolved per request rather than stored
+    /// with anything, so a suite authored under a broad grant confers nothing on a caller who runs it
+    /// later under a narrow one.
+    /// </remarks>
+    public required CapabilityEnvelope Envelope { get; init; }
+}

--- a/src/Content/Application/Application.Core/CQRS/Evaluation/Runs/StartEvalRunCommandHandler.cs
+++ b/src/Content/Application/Application.Core/CQRS/Evaluation/Runs/StartEvalRunCommandHandler.cs
@@ -80,11 +80,14 @@ public sealed class StartEvalRunCommandHandler
                 + "AppConfig.AI.Evaluation.DatasetRoots, to enable it.");
         }
 
-        foreach (var name in request.DatasetNames)
-        {
-            if (_catalog.Resolve(name) is null)
-                return Result<StartEvalRunResult>.NotFound($"No dataset named '{name}' is available.");
-        }
+        // Resolved before anything is queued, so a bad name costs an immediate answer rather than a
+        // 202 followed by a failure the caller has to poll for — having spent a concurrency slot to
+        // say so. The paths are discarded here: what matters at admission is only that every name
+        // resolves. The executor resolves again when it runs, which is what catches a dataset removed
+        // in between.
+        var resolution = _catalog.Resolve(request.DatasetNames);
+        if (!resolution.IsComplete)
+            return Result<StartEvalRunResult>.NotFound($"No dataset named '{resolution.MissingName}' is available.");
 
         var jobId = Guid.NewGuid().ToString("N");
 
@@ -121,10 +124,29 @@ public sealed class StartEvalRunCommandHandler
         if (admission != RunAdmission.Accepted)
             return Refuse(admission, config.AI.WorkflowSubmission.MaxConcurrentRunsPerOwner);
 
-        // After the record, before the queue. The submission's lifetime is the record's — it is
-        // reclaimed by the same sweep — so storing it first would leave an entry nothing ever collects
-        // whenever admission refuses. Storing it after the queue would be worse: a dispatcher can claim
-        // the run the instant it is enqueued and would find no submission to execute.
+        return await ArmAsync(record, request).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Stores the admitted run's request and hands it to the dispatcher, undoing the admission if
+    /// either step fails.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <strong>Submission first, queue second.</strong> The submission's lifetime is the record's — the
+    /// same sweep reclaims both — so storing it before admission would leave an entry nothing ever
+    /// collects whenever admission refuses. Storing it after the queue would be worse: a dispatcher can
+    /// claim the run the instant it is enqueued, and would find no request to execute.
+    /// </para>
+    /// <para>
+    /// Separate from <see cref="Handle"/> because everything above it decides <em>whether</em> the run
+    /// happens and everything here makes it happen — and because both failure paths share one
+    /// non-obvious obligation, which is easier to state once: a run that is committed but never queued
+    /// is never claimed, never finishes, and (only terminal runs being reclaimed) never released.
+    /// </para>
+    /// </remarks>
+    private async Task<Result<StartEvalRunResult>> ArmAsync(RunRecord record, StartEvalRunCommand request)
+    {
         try
         {
             _submissions.Add(new EvalRunSubmission
@@ -136,18 +158,16 @@ public sealed class StartEvalRunCommandHandler
         }
         catch (InvalidOperationException ex)
         {
-            // Unreachable with a freshly minted job id. Guarded because the alternative is a run that
-            // is committed, never queued, never claimed and — since only terminal runs are reclaimed —
-            // never released, holding one of the caller's slots for the life of the process.
+            // Unreachable with a freshly minted job id, and guarded anyway — the cost of an unguarded
+            // failure is not a lost run but one of the caller's slots held for the life of the process.
             _logger.LogError(ex, "Run {JobId} was admitted but its submission could not be stored.", record.JobId);
             Abandon(record, "The run was accepted but its request could not be stored.");
 
             return Result<StartEvalRunResult>.Fail("The run could not be accepted.");
         }
 
-        // Deliberately NOT the caller's token: past admission the record is committed, and a committed
-        // record that is never queued is never claimed and never reclaimed. A client that hangs up
-        // mid-request is ordinary, so that must not be reachable by hanging up.
+        // Deliberately NOT the caller's token: past admission the record is committed, and a client
+        // that hangs up mid-request is ordinary — stranding a run must not be reachable by hanging up.
         try
         {
             await _queue.EnqueueAsync(record.JobId, CancellationToken.None).ConfigureAwait(false);

--- a/src/Content/Application/Application.Core/CQRS/Evaluation/Runs/StartEvalRunCommandHandler.cs
+++ b/src/Content/Application/Application.Core/CQRS/Evaluation/Runs/StartEvalRunCommandHandler.cs
@@ -1,0 +1,202 @@
+using Application.AI.Common.Evaluation.Models;
+using Application.AI.Common.Interfaces.Evaluation;
+using Application.AI.Common.Interfaces.Runs;
+using Domain.AI.Runs;
+using Domain.Common;
+using Domain.Common.Config;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Application.Core.CQRS.Evaluation.Runs;
+
+/// <summary>
+/// Handles <see cref="StartEvalRunCommand"/>: resolves the named datasets, records the run and its
+/// submission, and queues it.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>Names are resolved before anything is queued.</strong> A run accepted against a dataset that
+/// does not exist would be a 202 followed by a failure the caller has to poll for — and it would have
+/// consumed one of their concurrency slots to say so. Resolving first turns that into an immediate,
+/// actionable answer.
+/// </para>
+/// <para>
+/// <strong>Nothing executes on this thread.</strong> The command returns as soon as the run is recorded
+/// and queued, so an HTTP caller is never held open for the length of a suite — which, at the default
+/// ceilings, is hundreds of governed agent turns.
+/// </para>
+/// </remarks>
+public sealed class StartEvalRunCommandHandler
+    : IRequestHandler<StartEvalRunCommand, Result<StartEvalRunResult>>
+{
+    private readonly IEvalDatasetCatalog _catalog;
+    private readonly IEvalRunSubmissionStore _submissions;
+    private readonly IRunJobStore _runStore;
+    private readonly IRunDispatchQueue _queue;
+    private readonly IOptionsMonitor<AppConfig> _config;
+    private readonly TimeProvider _time;
+    private readonly ILogger<StartEvalRunCommandHandler> _logger;
+
+    /// <summary>Initializes a new <see cref="StartEvalRunCommandHandler"/>.</summary>
+    public StartEvalRunCommandHandler(
+        IEvalDatasetCatalog catalog,
+        IEvalRunSubmissionStore submissions,
+        IRunJobStore runStore,
+        IRunDispatchQueue queue,
+        IOptionsMonitor<AppConfig> config,
+        TimeProvider time,
+        ILogger<StartEvalRunCommandHandler> logger)
+    {
+        ArgumentNullException.ThrowIfNull(catalog);
+        ArgumentNullException.ThrowIfNull(submissions);
+        ArgumentNullException.ThrowIfNull(runStore);
+        ArgumentNullException.ThrowIfNull(queue);
+        ArgumentNullException.ThrowIfNull(config);
+        ArgumentNullException.ThrowIfNull(time);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _catalog = catalog;
+        _submissions = submissions;
+        _runStore = runStore;
+        _queue = queue;
+        _config = config;
+        _time = time;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<Result<StartEvalRunResult>> Handle(
+        StartEvalRunCommand request, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var config = _config.CurrentValue;
+        if (!config.AI.Evaluation.Enabled)
+        {
+            return Result<StartEvalRunResult>.Forbidden(
+                "Evaluation is disabled. Set AppConfig.AI.Evaluation.Enabled = true, and configure "
+                + "AppConfig.AI.Evaluation.DatasetRoots, to enable it.");
+        }
+
+        foreach (var name in request.DatasetNames)
+        {
+            if (_catalog.Resolve(name) is null)
+                return Result<StartEvalRunResult>.NotFound($"No dataset named '{name}' is available.");
+        }
+
+        var jobId = Guid.NewGuid().ToString("N");
+
+        var record = new RunRecord
+        {
+            JobId = jobId,
+            Kind = RunKind.Evaluation,
+
+            // The run IS the target. Deliberate, and not a placeholder: admission refuses a second live
+            // run against the same target, which for a workflow protects one shared plan state machine.
+            // Evaluations share no such state — two callers evaluating one dataset are two independent
+            // reads — so a target derived from the datasets would serialize unrelated work and let one
+            // caller's long suite lock everybody else out of it. A per-run target makes the check
+            // correctly inert here rather than switching it off somewhere it also governs workflows.
+            TargetId = jobId,
+            OwnerId = request.OwnerId,
+            TenantId = request.TenantId,
+            Envelope = request.Envelope,
+            Status = RunStatus.Queued,
+            CreatedAt = _time.GetUtcNow()
+        };
+
+        // Admission and insertion in one atomic step, in the store, for the same reason the workflow
+        // path does it there: "is this caller at its ceiling" is a read-then-write decision, and asking
+        // here then inserting leaves a window in which concurrent requests all see the limit as unmet.
+        //
+        // The ceiling is the run substrate's, not evaluation's, and the store counts every kind of run
+        // one caller has in flight. Its configuration lives under WorkflowSubmission because that is
+        // where the substrate was introduced — as does RunRecordTtl, which the store also reads. The
+        // section name reads narrower than what it governs; the alternative, a second per-owner ceiling
+        // applied to the same cross-kind counter, would mean the limit that bound a caller depended on
+        // which endpoint they happened to call last.
+        var admission = _runStore.TryCreate(record, config.AI.WorkflowSubmission.MaxConcurrentRunsPerOwner);
+        if (admission != RunAdmission.Accepted)
+            return Refuse(admission, config.AI.WorkflowSubmission.MaxConcurrentRunsPerOwner);
+
+        // After the record, before the queue. The submission's lifetime is the record's — it is
+        // reclaimed by the same sweep — so storing it first would leave an entry nothing ever collects
+        // whenever admission refuses. Storing it after the queue would be worse: a dispatcher can claim
+        // the run the instant it is enqueued and would find no submission to execute.
+        try
+        {
+            _submissions.Add(new EvalRunSubmission
+            {
+                JobId = record.JobId,
+                DatasetNames = request.DatasetNames,
+                Options = request.Options
+            });
+        }
+        catch (InvalidOperationException ex)
+        {
+            // Unreachable with a freshly minted job id. Guarded because the alternative is a run that
+            // is committed, never queued, never claimed and — since only terminal runs are reclaimed —
+            // never released, holding one of the caller's slots for the life of the process.
+            _logger.LogError(ex, "Run {JobId} was admitted but its submission could not be stored.", record.JobId);
+            Abandon(record, "The run was accepted but its request could not be stored.");
+
+            return Result<StartEvalRunResult>.Fail("The run could not be accepted.");
+        }
+
+        // Deliberately NOT the caller's token: past admission the record is committed, and a committed
+        // record that is never queued is never claimed and never reclaimed. A client that hangs up
+        // mid-request is ordinary, so that must not be reachable by hanging up.
+        try
+        {
+            await _queue.EnqueueAsync(record.JobId, CancellationToken.None).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Run {JobId} was accepted but could not be queued.", record.JobId);
+            Abandon(record, "The run was accepted but could not be queued for execution.");
+
+            return Result<StartEvalRunResult>.Fail("The run could not be queued for execution.");
+        }
+
+        _logger.LogInformation(
+            "Queued evaluation run {JobId} over {DatasetCount} dataset(s).",
+            record.JobId, request.DatasetNames.Count);
+
+        return Result<StartEvalRunResult>.Success(new StartEvalRunResult { JobId = record.JobId });
+    }
+
+    /// <summary>
+    /// Records an admitted run as failed when it could not be set up to execute.
+    /// </summary>
+    /// <remarks>
+    /// Failed rather than deleted, and the submission is left alone. The record is what the sweeper
+    /// reclaims, and it only reclaims terminal runs — so making this one terminal is what eventually
+    /// releases both it and the submission keyed by the same id. Removing either by hand here would
+    /// split a lifetime that is deliberately shared.
+    /// </remarks>
+    private void Abandon(RunRecord record, string error) =>
+        _runStore.Update(record with
+        {
+            Status = RunStatus.Failed,
+            Error = error,
+            CompletedAt = _time.GetUtcNow()
+        });
+
+    /// <summary>Explains a refused admission in terms the caller can act on.</summary>
+    /// <remarks>
+    /// <see cref="RunAdmission.TargetAlreadyRunning"/> is unreachable here — the target is this run's
+    /// own freshly-minted id — so it falls to the generic arm rather than being given a message that
+    /// describes a conflict evaluations cannot have.
+    /// </remarks>
+    private static Result<StartEvalRunResult> Refuse(RunAdmission admission, int maxConcurrentRuns) =>
+        admission switch
+        {
+            RunAdmission.OwnerAtCapacity => Result<StartEvalRunResult>.ValidationFailure(
+                [$"This caller already has {maxConcurrentRuns} run(s) in flight, the maximum this host "
+                 + "permits. Wait for one to finish before starting another."]),
+
+            _ => Result<StartEvalRunResult>.Fail("The run could not be accepted.")
+        };
+}

--- a/src/Content/Application/Application.Core/CQRS/Evaluation/Runs/StartEvalRunCommandValidator.cs
+++ b/src/Content/Application/Application.Core/CQRS/Evaluation/Runs/StartEvalRunCommandValidator.cs
@@ -1,0 +1,67 @@
+using Domain.Common.Config;
+using Domain.Common.Config.AI;
+using FluentValidation;
+using Microsoft.Extensions.Options;
+
+namespace Application.Core.CQRS.Evaluation.Runs;
+
+/// <summary>
+/// Validates <see cref="StartEvalRunCommand"/> against the host's configured evaluation ceilings,
+/// before a run is admitted.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>Why these bounds are repeated here.</strong> <c>RunEvalSuiteCommandValidator</c> already
+/// applies them — but it applies them when the run <em>executes</em>, which on this path is after the
+/// caller has been told 202, has been given a job id, and has spent one of its concurrency slots. A
+/// caller asking for a thousand repeats would get an acceptance and then have to poll to discover a
+/// refusal. Checking at admission turns that into an immediate answer, and the duplication is the
+/// point: the execution-time check stays, because it is what protects every <em>other</em> dispatcher
+/// of that command.
+/// </para>
+/// <para>
+/// Read through <see cref="IOptionsMonitor{TOptions}"/> per validation so tightening a ceiling takes
+/// effect without a restart, matching <c>RunEvalSuiteCommandValidator</c>.
+/// </para>
+/// </remarks>
+public sealed class StartEvalRunCommandValidator : AbstractValidator<StartEvalRunCommand>
+{
+    /// <summary>Initializes the validator with the configured evaluation ceilings.</summary>
+    /// <param name="appConfigMonitor">Live application configuration supplying the ceilings.</param>
+    public StartEvalRunCommandValidator(IOptionsMonitor<AppConfig> appConfigMonitor)
+    {
+        ArgumentNullException.ThrowIfNull(appConfigMonitor);
+
+        RuleFor(x => x.DatasetNames)
+            .NotEmpty().WithMessage("At least one dataset name is required.");
+
+        RuleFor(x => x.DatasetNames)
+            .Must(names => names is null || names.Count <= Evaluation(appConfigMonitor).MaxDatasetsPerRun)
+            .WithMessage(_ =>
+                $"At most {Evaluation(appConfigMonitor).MaxDatasetsPerRun} datasets may be evaluated in one run.");
+
+        RuleForEach(x => x.DatasetNames)
+            .NotEmpty().WithMessage("Dataset names must not be empty strings.");
+
+        RuleFor(x => x.Options.Repeats)
+            .Must(repeats => repeats >= 1 && repeats <= Evaluation(appConfigMonitor).MaxRepeats)
+            .WithMessage(_ => $"Repeats must be between 1 and {Evaluation(appConfigMonitor).MaxRepeats}.");
+
+        RuleFor(x => x.Options.Parallelism)
+            .Must(parallelism => parallelism >= 1 && parallelism <= Evaluation(appConfigMonitor).MaxParallelism)
+            .WithMessage(_ => $"Parallelism must be between 1 and {Evaluation(appConfigMonitor).MaxParallelism}.");
+
+        RuleFor(x => x.Options.FailRateThreshold)
+            .InclusiveBetween(0.0, 1.0)
+            .WithMessage("FailRateThreshold must be between 0.0 and 1.0.");
+
+        // Not a duplicate of the run substrate's own identity handling: this is the assertion that the
+        // transport resolved an identity at all. An unowned run would be readable by nobody and, worse,
+        // would be stamped with an owner the scope filters read as global.
+        RuleFor(x => x.OwnerId)
+            .NotEmpty().WithMessage("The run's owner could not be established.");
+    }
+
+    private static EvaluationConfig Evaluation(IOptionsMonitor<AppConfig> monitor) =>
+        monitor.CurrentValue.AI.Evaluation;
+}

--- a/src/Content/Application/Application.Core/CQRS/Evaluation/Runs/StartEvalRunResult.cs
+++ b/src/Content/Application/Application.Core/CQRS/Evaluation/Runs/StartEvalRunResult.cs
@@ -1,0 +1,8 @@
+namespace Application.Core.CQRS.Evaluation.Runs;
+
+/// <summary>What an accepted evaluation run gives the caller: an identifier to poll.</summary>
+public sealed record StartEvalRunResult
+{
+    /// <summary>Server-minted identifier of the queued run.</summary>
+    public required string JobId { get; init; }
+}

--- a/src/Content/Application/Application.Core/DependencyInjection.cs
+++ b/src/Content/Application/Application.Core/DependencyInjection.cs
@@ -57,6 +57,12 @@ public static class DependencyInjection
 		services.AddSingleton<CQRS.Evaluation.RunEvalSuite.IEvalDatasetPathGuard,
 			CQRS.Evaluation.RunEvalSuite.EvalDatasetPathGuard>();
 
+		// Dataset name catalog — the only way an HTTP caller names a dataset. Registered beside the
+		// guard because it is the other half of the same rule: the guard confines paths, this makes a
+		// path something a caller cannot supply in the first place.
+		services.AddSingleton<Application.AI.Common.Interfaces.Evaluation.IEvalDatasetCatalog,
+			CQRS.Evaluation.RunEvalSuite.EvalDatasetCatalog>();
+
 		// Default confinement latch: no host has claimed a startup check. A host that verifies dataset
 		// roots at boot re-registers this as true (last-write-wins), which is what stops a later config
 		// reload from loosening confinement. Deliberately a constant rather than a configuration read —

--- a/src/Content/Application/Application.Core/DependencyInjection.cs
+++ b/src/Content/Application/Application.Core/DependencyInjection.cs
@@ -57,11 +57,10 @@ public static class DependencyInjection
 		services.AddSingleton<CQRS.Evaluation.RunEvalSuite.IEvalDatasetPathGuard,
 			CQRS.Evaluation.RunEvalSuite.EvalDatasetPathGuard>();
 
-		// Dataset name catalog — the only way an HTTP caller names a dataset. Registered beside the
-		// guard because it is the other half of the same rule: the guard confines paths, this makes a
-		// path something a caller cannot supply in the first place.
-		services.AddSingleton<Application.AI.Common.Interfaces.Evaluation.IEvalDatasetCatalog,
-			CQRS.Evaluation.RunEvalSuite.EvalDatasetCatalog>();
+		// The dataset name catalog — the other half of the same rule, since the guard confines paths
+		// and the catalog makes a path something a caller cannot supply in the first place — is NOT
+		// registered here. It reads directories, so it lives in Infrastructure.AI and is registered
+		// with the run substrate.
 
 		// Default confinement latch: no host has claimed a startup check. A host that verifies dataset
 		// roots at boot re-registers this as true (last-write-wins), which is what stops a later config

--- a/src/Content/Domain/Domain.AI/Runs/RunKind.cs
+++ b/src/Content/Domain/Domain.AI/Runs/RunKind.cs
@@ -11,5 +11,8 @@ namespace Domain.AI.Runs;
 public enum RunKind
 {
     /// <summary>Executes a stored workflow (plan) through the planner.</summary>
-    Workflow = 0
+    Workflow = 0,
+
+    /// <summary>Executes a submitted evaluation suite through the eval runner.</summary>
+    Evaluation = 1
 }

--- a/src/Content/Domain/Domain.AI/Runs/RunRecord.cs
+++ b/src/Content/Domain/Domain.AI/Runs/RunRecord.cs
@@ -33,6 +33,21 @@ public sealed record RunRecord
     /// Identifier of the thing being run, interpreted by the executor for <see cref="Kind"/> — a
     /// stored workflow's id for <see cref="RunKind.Workflow"/>.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <strong>This is also what admission's "one live run per target" rule is keyed on</strong>, which
+    /// exists so two runs cannot share one workflow's plan state machine.
+    /// </para>
+    /// <para>
+    /// <strong>A kind whose work has no shared target sets this to the run's own
+    /// <see cref="JobId"/>.</strong> <see cref="RunKind.Evaluation"/> does: two callers evaluating one
+    /// dataset are independent reads with nothing between them to corrupt. A unique target makes the
+    /// exclusivity rule correctly inert for that kind, rather than switching a rule off where it still
+    /// governs workflows. Do <em>not</em> reach for a constant instead — that would serialize an entire
+    /// kind down to one concurrent run host-wide, which looks like a mysterious queue rather than a
+    /// refusal.
+    /// </para>
+    /// </remarks>
     public required string TargetId { get; init; }
 
     /// <summary>Stable identity of the caller that started the run, and the only one that may read it.</summary>

--- a/src/Content/Domain/Domain.Common/Config/AI/WorkflowSubmission/WorkflowSubmissionConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/WorkflowSubmission/WorkflowSubmissionConfig.cs
@@ -210,12 +210,23 @@ public class WorkflowSubmissionConfig
     public TimeSpan RunRecordTtl { get; set; } = TimeSpan.FromHours(1);
 
     /// <summary>
-    /// Maximum number of runs one caller may have queued or executing at once.
+    /// Maximum number of runs one caller may have queued or executing at once, <strong>across every
+    /// kind of run</strong> — not workflows alone.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// Distinct from <see cref="MaxStoredWorkflowsPerOwner"/>, which bounds stored definitions: this
     /// bounds work in flight. A caller within the storage quota can otherwise start every workflow it
     /// owns simultaneously, and the per-workflow parallelism ceiling multiplies by that count.
+    /// </para>
+    /// <para>
+    /// <strong>The section name reads narrower than what this governs.</strong> It lives here because
+    /// this is where the shared run substrate was introduced — as does <see cref="RunRecordTtl"/>,
+    /// which the run store also reads — and the store counts every kind a caller has in flight against
+    /// one number. That is deliberate: a second per-kind ceiling applied to the same cross-kind counter
+    /// would mean the limit that bound a caller depended on which endpoint they happened to call last.
+    /// An evaluation run started through <c>/api/evals</c> consumes one of these slots.
+    /// </para>
     /// </remarks>
     /// <value>Default: 10</value>
     public int MaxConcurrentRunsPerOwner { get; set; } = 10;

--- a/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.Planner.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.Planner.cs
@@ -11,6 +11,7 @@ using Domain.AI.Runs;
 using Domain.AI.Sandbox;
 using Domain.Common.Config;
 using Infrastructure.AI.Attestation;
+using Infrastructure.AI.Evaluation;
 using Infrastructure.AI.Persistence;
 using Infrastructure.AI.Planner;
 using Infrastructure.AI.Runs;
@@ -105,17 +106,22 @@ public static partial class DependencyInjection
         // can execute, and the endpoints refuse unless evaluation is enabled.
         services.TryAddSingleton<IEvalRunSubmissionStore, InMemoryEvalRunSubmissionStore>();
 
-        // Both holders of run-scoped state are released when a run's record is reclaimed, through the
-        // same seam, rather than by the sweeper naming either of them.
-        //
-        // Registered two different ways for one real reason: the submission store implements
-        // IRunReclaimListener, so it is resolved as itself; the progress broker does not, so a named
-        // adapter supplies the behaviour. TryAddEnumerable needs an implementation type to tell
-        // registrations apart and rejects factory descriptors, which is why the adapter is a type
-        // rather than a lambda.
+        // The dataset name catalog. In Infrastructure because it reads directories, and registered
+        // here rather than in the host that serves evaluation for the same reason as the store above:
+        // the CQRS handlers that depend on it are found by assembly scanning, so they exist in every
+        // host and a conditional registration would fail ValidateOnBuild in all of them.
+        services.TryAddSingleton<IEvalDatasetCatalog, EvalDatasetCatalog>();
+
+        // Every holder of run-scoped state is released when a run's record is reclaimed, through this
+        // one seam rather than by the sweeper naming each of them. Both go through a named adapter:
+        // TryAddEnumerable distinguishes registrations by implementation type and rejects factory
+        // descriptors, so a lambda would either throw here or, as a plain AddSingleton, register again
+        // on every composition — and the substrate uses TryAdd throughout precisely so composing it
+        // twice is harmless.
         services.TryAddEnumerable(
             ServiceDescriptor.Singleton<IRunReclaimListener, RunProgressReclaimListener>());
-        services.AddSingleton<IRunReclaimListener>(sp => sp.GetRequiredService<IEvalRunSubmissionStore>());
+        services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<IRunReclaimListener, EvalSubmissionReclaimListener>());
 
         // Keyed by RunKind, which is what makes a new kind of work a registration rather than a
         // change to the dispatcher. Scoped: the dispatcher creates a fresh scope per run and resolves

--- a/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.Planner.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.Planner.cs
@@ -1,5 +1,6 @@
 using Application.AI.Common.Interfaces.Attestation;
 using Application.AI.Common.Interfaces.Escalation;
+using Application.AI.Common.Interfaces.Evaluation;
 using Application.AI.Common.Interfaces.KnowledgeGraph;
 using Application.AI.Common.Interfaces.Planner;
 using Application.AI.Common.Interfaces.Runs;
@@ -95,6 +96,26 @@ public static partial class DependencyInjection
         // from a request, so a scoped broker would give each side its own instance and every stream
         // would sit silent while the run reported into nothing.
         services.TryAddSingleton<IRunProgressBroker, InMemoryRunProgressBroker>();
+
+        // Holds what an evaluation run needs beyond the kind-agnostic record. Registered here with the
+        // rest of the substrate rather than in the host that serves evaluation over HTTP, because the
+        // CQRS handlers that depend on it are discovered by assembly scanning and therefore exist in
+        // EVERY host — a conditional registration makes each of those hosts fail ValidateOnBuild.
+        // Being registered is not being reachable: without a RunKind.Evaluation executor no eval run
+        // can execute, and the endpoints refuse unless evaluation is enabled.
+        services.TryAddSingleton<IEvalRunSubmissionStore, InMemoryEvalRunSubmissionStore>();
+
+        // Both holders of run-scoped state are released when a run's record is reclaimed, through the
+        // same seam, rather than by the sweeper naming either of them.
+        //
+        // Registered two different ways for one real reason: the submission store implements
+        // IRunReclaimListener, so it is resolved as itself; the progress broker does not, so a named
+        // adapter supplies the behaviour. TryAddEnumerable needs an implementation type to tell
+        // registrations apart and rejects factory descriptors, which is why the adapter is a type
+        // rather than a lambda.
+        services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<IRunReclaimListener, RunProgressReclaimListener>());
+        services.AddSingleton<IRunReclaimListener>(sp => sp.GetRequiredService<IEvalRunSubmissionStore>());
 
         // Keyed by RunKind, which is what makes a new kind of work a registration rather than a
         // change to the dispatcher. Scoped: the dispatcher creates a fresh scope per run and resolves

--- a/src/Content/Infrastructure/Infrastructure.AI/Evaluation/EvalDatasetCatalog.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Evaluation/EvalDatasetCatalog.cs
@@ -120,7 +120,17 @@ public sealed class EvalDatasetCatalog : IEvalDatasetCatalog
     {
         var found = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
-        var roots = _config.CurrentValue.AI.Evaluation.DatasetRoots ?? [];
+        var evaluation = _config.CurrentValue.AI.Evaluation;
+
+        // A host with evaluation switched off publishes nothing and resolves nothing, even if roots
+        // are still configured — turning the feature off is the operator saying this host does not do
+        // this, and leaving the inventory readable would make that only half true. Checked here rather
+        // than at the endpoints because it then also holds for resolution: a disabled host cannot map
+        // a name to a file at all, so no path past the handlers' own checks could run one.
+        if (!evaluation.Enabled)
+            return found;
+
+        var roots = evaluation.DatasetRoots ?? [];
 
         foreach (var root in roots)
         {
@@ -159,10 +169,16 @@ public sealed class EvalDatasetCatalog : IEvalDatasetCatalog
                 {
                     if (!string.Equals(existing, decision.CanonicalPath, StringComparison.Ordinal))
                     {
+                        // Deliberately does not say "in more than one root": the same branch fires for
+                        // two files in ONE root that differ only by extension (suite.yaml /
+                        // suite.json) or by case, since names are matched case-insensitively. Naming
+                        // both files lets an operator see which case they actually hit.
                         _logger.LogWarning(
-                            "Evaluation dataset name {Name} is defined in more than one root; keeping "
-                            + "the first and ignoring {Ignored}.",
+                            "Evaluation dataset name {Name} is claimed by more than one file; keeping "
+                            + "{Kept} and ignoring {Ignored}. Which one wins depends on enumeration "
+                            + "order, so rename one of them.",
                             name,
+                            existing,
                             file);
                     }
 

--- a/src/Content/Infrastructure/Infrastructure.AI/Evaluation/EvalDatasetCatalog.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Evaluation/EvalDatasetCatalog.cs
@@ -1,9 +1,10 @@
 using Application.AI.Common.Interfaces.Evaluation;
+using Application.Core.CQRS.Evaluation.RunEvalSuite;
 using Domain.Common.Config;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
-namespace Application.Core.CQRS.Evaluation.RunEvalSuite;
+namespace Infrastructure.AI.Evaluation;
 
 /// <summary>
 /// Default <see cref="IEvalDatasetCatalog"/>: the datasets are the files sitting at the top level of
@@ -28,6 +29,12 @@ namespace Application.Core.CQRS.Evaluation.RunEvalSuite;
 /// <strong>No catalog without roots.</strong> An unconfined host — the CLI's shipped default — returns
 /// nothing rather than enumerating whatever directory it happens to be running from. Listing is a
 /// disclosure, and there is no bounded thing to disclose until an operator says what the bounds are.
+/// </para>
+/// <para>
+/// Lives in Infrastructure, not beside the command it serves, because it reads directories:
+/// <c>.claude/rules/clean-architecture.md</c> places anything touching the filesystem here. Its
+/// sibling <c>EvalDatasetPathGuard</c> stays in Application deliberately and is not a precedent — that
+/// one does path-string arithmetic and only ever asks whether a file exists, whereas this enumerates.
 /// </para>
 /// </remarks>
 public sealed class EvalDatasetCatalog : IEvalDatasetCatalog
@@ -62,20 +69,43 @@ public sealed class EvalDatasetCatalog : IEvalDatasetCatalog
     public IReadOnlyList<string> ListNames() => [.. Discover().Keys.OrderBy(n => n, StringComparer.Ordinal)];
 
     /// <inheritdoc />
-    public string? Resolve(string name)
+    public EvalDatasetResolution Resolve(IReadOnlyList<string> names)
     {
-        if (string.IsNullOrWhiteSpace(name))
-            return null;
+        ArgumentNullException.ThrowIfNull(names);
 
-        // A name is an identifier. Anything that could steer resolution — a separator, a drive
-        // qualifier, a relative segment — is refused before it is compared, so a name that looks like
-        // a path never gets as far as being looked up. Enumeration would not honour it anyway; this
-        // just makes the intent explicit rather than incidental.
-        if (name.AsSpan().IndexOfAny('/', '\\', ':') >= 0 || name is "." or "..")
-            return null;
+        if (names.Count == 0)
+            return EvalDatasetResolution.Complete([]);
 
-        return Discover().TryGetValue(name, out var path) ? path : null;
+        // One pass over the roots for the whole set. Discovering per name would re-walk every root and
+        // re-confine every file it holds, once per name — and would read the filesystem at as many
+        // different instants as there are names.
+        var available = Discover();
+        var paths = new List<string>(names.Count);
+
+        foreach (var name in names)
+        {
+            if (!IsWellFormed(name) || !available.TryGetValue(name, out var path))
+                return EvalDatasetResolution.Missing(name);
+
+            paths.Add(path);
+        }
+
+        return EvalDatasetResolution.Complete(paths);
     }
+
+    /// <summary>
+    /// Whether a name is an identifier rather than something that could steer resolution.
+    /// </summary>
+    /// <remarks>
+    /// A separator, a drive qualifier, or a relative segment is refused before the name is compared,
+    /// so a name shaped like a path never gets as far as being looked up. Enumeration would not honour
+    /// one anyway — this makes the intent explicit rather than incidental, and keeps the rule true if
+    /// the lookup is ever reimplemented.
+    /// </remarks>
+    private static bool IsWellFormed(string name) =>
+        !string.IsNullOrWhiteSpace(name)
+        && name.AsSpan().IndexOfAny('/', '\\', ':') < 0
+        && name is not ("." or "..");
 
     /// <summary>
     /// Builds the name-to-path map from what is currently on disk under the configured roots.

--- a/src/Content/Infrastructure/Infrastructure.AI/Runs/EvalRunKindExecutor.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Runs/EvalRunKindExecutor.cs
@@ -1,0 +1,148 @@
+using Application.AI.Common.Interfaces.Evaluation;
+using Application.AI.Common.Interfaces.Runs;
+using Application.AI.Common.Services.Governance;
+using Application.Core.CQRS.Evaluation.RunEvalSuite;
+using Domain.AI.Runs;
+using Domain.Common;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace Infrastructure.AI.Runs;
+
+/// <summary>
+/// Runs a submitted evaluation suite for the shared run substrate, delegating to
+/// <c>RunEvalSuiteCommand</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Thin on purpose, exactly as <see cref="WorkflowRunKindExecutor"/> is. Everything that makes an eval
+/// run safe — dataset confinement, the per-run cost ceilings, the size cap, loader dispatch — already
+/// lives behind that command and applies to <em>every</em> caller of it, not only this one. What this
+/// adds is the two things only the run path knows: turning the caller's dataset names back into paths,
+/// and turning a report into an outcome.
+/// </para>
+/// <para>
+/// <strong>Names become paths here, at the last possible moment.</strong> The submission holds names
+/// because a path must never cross the trust boundary, and this is the first point at which a path is
+/// unavoidable — the command reads files. Resolution goes through <see cref="IEvalDatasetCatalog"/>,
+/// which produces only paths it found by enumerating a configured root, and the command's own guard
+/// then confines whatever it is handed. A name that no longer resolves fails the run rather than being
+/// skipped: a suite silently evaluated without one of its datasets reports a pass rate for something
+/// that never ran.
+/// </para>
+/// </remarks>
+public sealed class EvalRunKindExecutor : IRunKindExecutor
+{
+    private readonly IMediator _mediator;
+    private readonly IEvalDatasetCatalog _catalog;
+    private readonly IEvalRunSubmissionStore _submissions;
+    private readonly ILogger<EvalRunKindExecutor> _logger;
+
+    /// <summary>Initializes the executor.</summary>
+    public EvalRunKindExecutor(
+        IMediator mediator,
+        IEvalDatasetCatalog catalog,
+        IEvalRunSubmissionStore submissions,
+        ILogger<EvalRunKindExecutor> logger)
+    {
+        ArgumentNullException.ThrowIfNull(mediator);
+        ArgumentNullException.ThrowIfNull(catalog);
+        ArgumentNullException.ThrowIfNull(submissions);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _mediator = mediator;
+        _catalog = catalog;
+        _submissions = submissions;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<Result<RunCompletion>> ExecuteAsync(RunRecord record, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(record);
+
+        var submission = _submissions.Get(record.JobId);
+        if (submission is null)
+        {
+            // Unreachable on the accepted path — the submission is stored before the run is queued, and
+            // it is only reclaimed once the record is, by which point nothing dispatches. Answered
+            // rather than thrown so a missing entry fails this one run instead of surfacing as an
+            // unexpected dispatcher exception.
+            _logger.LogError("Run {JobId} has no stored evaluation submission.", record.JobId);
+            return Result<RunCompletion>.Fail("The run's evaluation request could not be read.");
+        }
+
+        var paths = new List<string>(submission.DatasetNames.Count);
+        foreach (var name in submission.DatasetNames)
+        {
+            var path = _catalog.Resolve(name);
+            if (path is null)
+            {
+                // The name resolved when the run was accepted and does not now — the file was removed
+                // or a root was reconfigured in between. The caller is told which name, because it is
+                // one they supplied and one they can act on; nothing about the filesystem is disclosed
+                // by naming it back.
+                _logger.LogWarning(
+                    "Run {JobId} names dataset {Dataset}, which no longer resolves.", record.JobId, name);
+
+                return Result<RunCompletion>.Fail($"Dataset '{name}' is no longer available.");
+            }
+
+            paths.Add(path);
+        }
+
+        // The caller's grant is armed for the whole evaluation, exactly as PlanRunExecutor arms it for
+        // a workflow. An evaluation is not a passive read: every case is a governed agent turn that
+        // can invoke tools, so without this the suite would run outside the envelope the caller was
+        // resolved to hold — a caller could reach, through an eval case, tools it is denied directly.
+        // Ambient (AsyncLocal), so it flows into the per-case scopes the agent invoker creates.
+        //
+        // Identity is not armed here: AgentContextPropagationBehavior initializes the execution
+        // context per agent turn, inside those same scopes. That ordering matters — the governor fails
+        // closed on identity-less enveloped tool calls — and it holds because the behaviour runs on
+        // every turn dispatched below this point.
+        using var granted = CapabilityEnvelopeAccessor.Begin(record.Envelope);
+
+        var outcome = await _mediator.Send(
+            new RunEvalSuiteCommand
+            {
+                DatasetPaths = paths,
+                Options = submission.Options
+            },
+            cancellationToken).ConfigureAwait(false);
+
+        if (!outcome.IsSuccess || outcome.Value is null)
+        {
+            // The command's failures are already caller-safe — refusals name a ceiling or a dataset,
+            // never a path or exception text — so they pass through rather than being flattened into
+            // "it failed". A caller learns why its own run did not work.
+            return Result<RunCompletion>.Fail(
+                outcome.Errors.Count > 0 ? [.. outcome.Errors] : ["The evaluation produced no report."]);
+        }
+
+        var report = outcome.Value;
+
+        if (!_submissions.AttachReport(record.JobId, report))
+        {
+            // Logged, not failed. The evaluation ran and cost what it cost; reporting the run as failed
+            // because the result could not be filed would be untrue about the work and would not give
+            // the spend back. The caller sees a succeeded run with no report, which is the honest
+            // description of what happened.
+            _logger.LogWarning(
+                "Run {JobId} finished but its submission was gone, so its report could not be attached.",
+                record.JobId);
+        }
+
+        // Succeeded means the suite ran, not that it passed. A run whose cases mostly failed is a
+        // completed evaluation with a Fail verdict in its report, and collapsing the two would leave a
+        // caller unable to tell a failing suite from a broken host — the first is the answer they asked
+        // for, the second means they never got one.
+        _logger.LogInformation(
+            "Run {JobId} evaluated {Cases} case(s) with verdict {Verdict}.",
+            record.JobId,
+            report.Results.Count,
+            report.OverallVerdict);
+
+        return Result<RunCompletion>.Success(RunCompletion.Succeeded());
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Runs/EvalRunKindExecutor.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Runs/EvalRunKindExecutor.cs
@@ -1,7 +1,9 @@
+using Application.AI.Common.CQRS.Evaluation.IngestEvalRun;
 using Application.AI.Common.Interfaces.Evaluation;
 using Application.AI.Common.Interfaces.Runs;
 using Application.AI.Common.Services.Governance;
 using Application.Core.CQRS.Evaluation.RunEvalSuite;
+using Domain.AI.Evaluation;
 using Domain.AI.Runs;
 using Domain.Common;
 using MediatR;
@@ -72,23 +74,18 @@ public sealed class EvalRunKindExecutor : IRunKindExecutor
             return Result<RunCompletion>.Fail("The run's evaluation request could not be read.");
         }
 
-        var paths = new List<string>(submission.DatasetNames.Count);
-        foreach (var name in submission.DatasetNames)
+        var resolution = _catalog.Resolve(submission.DatasetNames);
+        if (!resolution.IsComplete)
         {
-            var path = _catalog.Resolve(name);
-            if (path is null)
-            {
-                // The name resolved when the run was accepted and does not now — the file was removed
-                // or a root was reconfigured in between. The caller is told which name, because it is
-                // one they supplied and one they can act on; nothing about the filesystem is disclosed
-                // by naming it back.
-                _logger.LogWarning(
-                    "Run {JobId} names dataset {Dataset}, which no longer resolves.", record.JobId, name);
+            // The name resolved when the run was accepted and does not now — the file was removed or a
+            // root was reconfigured in between. Failing the whole run rather than skipping the dataset:
+            // a suite quietly evaluated without one of its parts reports a pass rate for something that
+            // never ran.
+            _logger.LogWarning(
+                "Run {JobId} names dataset {Dataset}, which no longer resolves.",
+                record.JobId, resolution.MissingName);
 
-                return Result<RunCompletion>.Fail($"Dataset '{name}' is no longer available.");
-            }
-
-            paths.Add(path);
+            return Result<RunCompletion>.Fail($"Dataset '{resolution.MissingName}' is no longer available.");
         }
 
         // The caller's grant is armed for the whole evaluation, exactly as PlanRunExecutor arms it for
@@ -106,7 +103,7 @@ public sealed class EvalRunKindExecutor : IRunKindExecutor
         var outcome = await _mediator.Send(
             new RunEvalSuiteCommand
             {
-                DatasetPaths = paths,
+                DatasetPaths = resolution.Paths,
                 Options = submission.Options
             },
             cancellationToken).ConfigureAwait(false);
@@ -133,6 +130,8 @@ public sealed class EvalRunKindExecutor : IRunKindExecutor
                 record.JobId);
         }
 
+        await IngestAsync(record.JobId, report, cancellationToken).ConfigureAwait(false);
+
         // Succeeded means the suite ran, not that it passed. A run whose cases mostly failed is a
         // completed evaluation with a Fail verdict in its report, and collapsing the two would leave a
         // caller unable to tell a failing suite from a broken host — the first is the answer they asked
@@ -144,5 +143,56 @@ public sealed class EvalRunKindExecutor : IRunKindExecutor
             report.OverallVerdict);
 
         return Result<RunCompletion>.Success(RunCompletion.Succeeded());
+    }
+
+    /// <summary>
+    /// Files the report into the durable eval store the dashboard reads, in-process.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This is what a server-side run buys over the CLI: the CLI produces a report and then posts it
+    /// back over HTTP to be ingested, and a run that already executes inside the host has no reason to
+    /// leave the process to file its own result. Without this the report lives only in the submission
+    /// store and disappears with it at <c>RunRecordTtl</c> — an evaluation whose history no dashboard
+    /// ever sees, which is most of the reason to keep evaluations at all.
+    /// </para>
+    /// <para>
+    /// <strong>A failed ingest does not fail the run.</strong> The evaluation ran, the spend is already
+    /// incurred, and the caller can still read the report from its own run. Marking the run failed
+    /// would misreport the work, and would invite a retry that pays for the whole suite again to fix a
+    /// bookkeeping problem. It is logged at warning because a silently unrecorded run is exactly the
+    /// kind of gap that is invisible until someone asks why the dashboard is missing a week.
+    /// </para>
+    /// <para>
+    /// Ingest is idempotent on <c>RunId</c>, so a re-dispatched run cannot double-count.
+    /// </para>
+    /// </remarks>
+    private async Task IngestAsync(string jobId, EvalRunReport report, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var ingested = await _mediator
+                .Send(new IngestEvalRunCommand { Report = report }, cancellationToken)
+                .ConfigureAwait(false);
+
+            if (!ingested.IsSuccess)
+            {
+                _logger.LogWarning(
+                    "Run {JobId} produced report {RunId} but it could not be recorded for the "
+                    + "dashboard: {Errors}",
+                    jobId, report.RunId, string.Join("; ", ingested.Errors));
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            // A host that has not registered the eval store at all reaches here rather than taking the
+            // run down with it. The evaluation still succeeded.
+            _logger.LogWarning(
+                ex, "Run {JobId} produced report {RunId} but ingest threw.", jobId, report.RunId);
+        }
     }
 }

--- a/src/Content/Infrastructure/Infrastructure.AI/Runs/EvalSubmissionReclaimListener.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Runs/EvalSubmissionReclaimListener.cs
@@ -1,0 +1,32 @@
+using Application.AI.Common.Interfaces.Evaluation;
+using Application.AI.Common.Interfaces.Runs;
+
+namespace Infrastructure.AI.Runs;
+
+/// <summary>
+/// Releases an evaluation run's stored request and report when its record is reclaimed.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A named type rather than a factory registration, for the same reason
+/// <see cref="RunProgressReclaimListener"/> is one: <c>TryAddEnumerable</c> distinguishes
+/// registrations by implementation type and rejects factory descriptors, so a lambda resolving the
+/// store would either throw at composition or — registered with plain <c>AddSingleton</c> — register
+/// again every time the substrate is composed. The run substrate is wired with <c>TryAdd</c>
+/// throughout precisely so composing it twice is harmless; this keeps that true.
+/// </para>
+/// <para>
+/// The store already implements <see cref="IRunReclaimListener"/> — that is deliberate, so every
+/// implementation has to answer the reclaim question rather than leave it to whoever registers it.
+/// This delegates to that implementation rather than duplicating it.
+/// </para>
+/// </remarks>
+/// <param name="submissions">The store whose per-run entries this releases.</param>
+public sealed class EvalSubmissionReclaimListener(IEvalRunSubmissionStore submissions) : IRunReclaimListener
+{
+    private readonly IEvalRunSubmissionStore _submissions =
+        submissions ?? throw new ArgumentNullException(nameof(submissions));
+
+    /// <inheritdoc />
+    public void OnRunsReclaimed(IReadOnlyList<string> jobIds) => _submissions.OnRunsReclaimed(jobIds);
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Runs/InMemoryEvalRunSubmissionStore.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Runs/InMemoryEvalRunSubmissionStore.cs
@@ -1,0 +1,79 @@
+using System.Collections.Concurrent;
+using Application.AI.Common.Evaluation.Models;
+using Application.AI.Common.Interfaces.Evaluation;
+using Domain.AI.Evaluation;
+
+namespace Infrastructure.AI.Runs;
+
+/// <summary>
+/// Process-local <see cref="IEvalRunSubmissionStore"/>. One entry per accepted evaluation run, dropped
+/// when that run's record is reclaimed.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>Process-local, and that is a real limit — the same one the run store carries.</strong> A
+/// submission is visible only to the instance that accepted it, so a multi-instance deployment must
+/// route a caller's polls back to that instance or replace both stores together. Replacing one alone
+/// would be worse than replacing neither: a caller would reach a shared run record on any instance and
+/// find its report missing on all but one.
+/// </para>
+/// <para>
+/// <strong>Lifetime is borrowed, never independent.</strong> Entries go when
+/// <see cref="OnRunsReclaimed"/> says the run's record has gone. Giving this store a retention clock of
+/// its own would put two schedules in charge of one run's memory, and the two would disagree: the
+/// shorter one silently strips the report off a run the caller can still read.
+/// </para>
+/// </remarks>
+public sealed class InMemoryEvalRunSubmissionStore : IEvalRunSubmissionStore
+{
+    private readonly ConcurrentDictionary<string, EvalRunSubmission> _submissions =
+        new(StringComparer.Ordinal);
+
+    /// <inheritdoc />
+    public void Add(EvalRunSubmission submission)
+    {
+        ArgumentNullException.ThrowIfNull(submission);
+        ArgumentException.ThrowIfNullOrEmpty(submission.JobId);
+
+        // Throws rather than overwrites, matching IRunJobStore.TryCreate on the same identifier. A
+        // second submission under one job id means two runs are sharing an entry, and the one that
+        // lost would report the other's datasets and the other's report to its caller.
+        if (!_submissions.TryAdd(submission.JobId, submission))
+            throw new InvalidOperationException($"A submission for job id '{submission.JobId}' already exists.");
+    }
+
+    /// <inheritdoc />
+    public EvalRunSubmission? Get(string jobId)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(jobId);
+
+        return _submissions.GetValueOrDefault(jobId);
+    }
+
+    /// <inheritdoc />
+    public bool AttachReport(string jobId, EvalRunReport report)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(jobId);
+        ArgumentNullException.ThrowIfNull(report);
+
+        // Compare-and-swap rather than read-modify-write. The record is immutable, so the update is a
+        // new instance either way — but a plain overwrite would clobber a concurrent sweep's removal
+        // and resurrect an entry nothing will ever reclaim again.
+        while (_submissions.TryGetValue(jobId, out var existing))
+        {
+            if (_submissions.TryUpdate(jobId, existing with { Report = report }, existing))
+                return true;
+        }
+
+        return false;
+    }
+
+    /// <inheritdoc />
+    public void OnRunsReclaimed(IReadOnlyList<string> jobIds)
+    {
+        ArgumentNullException.ThrowIfNull(jobIds);
+
+        foreach (var jobId in jobIds)
+            _submissions.TryRemove(jobId, out _);
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Runs/InMemoryEvalRunSubmissionStore.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Runs/InMemoryEvalRunSubmissionStore.cs
@@ -56,16 +56,14 @@ public sealed class InMemoryEvalRunSubmissionStore : IEvalRunSubmissionStore
         ArgumentException.ThrowIfNullOrEmpty(jobId);
         ArgumentNullException.ThrowIfNull(report);
 
-        // Compare-and-swap rather than read-modify-write. The record is immutable, so the update is a
-        // new instance either way — but a plain overwrite would clobber a concurrent sweep's removal
-        // and resurrect an entry nothing will ever reclaim again.
-        while (_submissions.TryGetValue(jobId, out var existing))
-        {
-            if (_submissions.TryUpdate(jobId, existing with { Report = report }, existing))
-                return true;
-        }
-
-        return false;
+        // Compare-and-swap rather than read-modify-write: a plain overwrite would clobber a concurrent
+        // sweep's removal and resurrect an entry nothing will ever reclaim again.
+        //
+        // Not a retry loop, deliberately. One run produces one report, so this is the only writer to
+        // this key; the only competing write is the sweep's removal, and losing to that means the entry
+        // is gone rather than changed. Retrying would re-add what the sweep just dropped.
+        return _submissions.TryGetValue(jobId, out var existing)
+            && _submissions.TryUpdate(jobId, existing with { Report = report }, existing);
     }
 
     /// <inheritdoc />

--- a/src/Content/Infrastructure/Infrastructure.AI/Runs/RunProgressReclaimListener.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Runs/RunProgressReclaimListener.cs
@@ -1,0 +1,37 @@
+using Application.AI.Common.Interfaces.Runs;
+
+namespace Infrastructure.AI.Runs;
+
+/// <summary>
+/// Releases the progress broker's bookkeeping for reclaimed runs, through the same seam every other
+/// holder of run-scoped state uses.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>Why an adapter rather than making the broker itself a listener.</strong> Registering a
+/// listener that resolves through <c>IRunProgressBroker</c> means a factory descriptor, and
+/// <c>TryAddEnumerable</c> refuses those — it distinguishes registrations by implementation type, and a
+/// factory has none to offer. A named type is what makes the registration idempotent, which matters
+/// because the run substrate is registered with <c>TryAdd</c> throughout and may be composed more than
+/// once.
+/// </para>
+/// <para>
+/// It resolves <see cref="IRunProgressBroker"/> rather than the in-memory broker directly, so a host
+/// that substituted its own broker has <em>that</em> one released rather than the default it replaced.
+/// </para>
+/// </remarks>
+/// <param name="broker">The broker whose per-run bookkeeping this releases.</param>
+public sealed class RunProgressReclaimListener(IRunProgressBroker broker) : IRunReclaimListener
+{
+    private readonly IRunProgressBroker _broker =
+        broker ?? throw new ArgumentNullException(nameof(broker));
+
+    /// <inheritdoc />
+    public void OnRunsReclaimed(IReadOnlyList<string> jobIds)
+    {
+        ArgumentNullException.ThrowIfNull(jobIds);
+
+        foreach (var jobId in jobIds)
+            _broker.Forget(jobId);
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Runs/RunRecordCleanupService.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Runs/RunRecordCleanupService.cs
@@ -19,9 +19,15 @@ namespace Infrastructure.AI.Runs;
 /// </para>
 /// <para>
 /// Only terminal runs are ever reclaimed — that rule lives in the store, not here, so no scheduling
-/// change can make a run a caller is still polling disappear. The progress broker's bookkeeping is
-/// released for the same runs at the same moment, because it is keyed by the same identifier and
-/// nothing can publish for a reclaimed run.
+/// change can make a run a caller is still polling disappear. Everything else keyed by the same
+/// identifier is released at the same moment, through <see cref="IRunReclaimListener"/>.
+/// </para>
+/// <para>
+/// <strong>Holders are told, not named.</strong> A run's identifier keys progress bookkeeping, and
+/// whatever each <c>RunKind</c> holds beyond the kind-agnostic record. Taking a dependency on each
+/// would make this service grow a constructor parameter per kind of run — and the kind whose author
+/// forgot would leak silently rather than fail to compile. Listening makes releasing a property of
+/// holding.
 /// </para>
 /// </remarks>
 internal sealed class RunRecordCleanupService : BackgroundService
@@ -41,7 +47,7 @@ internal sealed class RunRecordCleanupService : BackgroundService
     private const string SystemActor = "system:parked-run-expiry";
 
     private readonly IRunJobStore _store;
-    private readonly IRunProgressBroker _progress;
+    private readonly IReadOnlyList<IRunReclaimListener> _reclaimListeners;
     private readonly IEscalationService _escalations;
     private readonly IOptionsMonitor<AppConfig> _config;
     private readonly ILogger<RunRecordCleanupService> _logger;
@@ -49,19 +55,19 @@ internal sealed class RunRecordCleanupService : BackgroundService
     /// <summary>Initializes a new <see cref="RunRecordCleanupService"/>.</summary>
     public RunRecordCleanupService(
         IRunJobStore store,
-        IRunProgressBroker progress,
+        IEnumerable<IRunReclaimListener> reclaimListeners,
         IEscalationService escalations,
         IOptionsMonitor<AppConfig> config,
         ILogger<RunRecordCleanupService> logger)
     {
         ArgumentNullException.ThrowIfNull(store);
-        ArgumentNullException.ThrowIfNull(progress);
+        ArgumentNullException.ThrowIfNull(reclaimListeners);
         ArgumentNullException.ThrowIfNull(escalations);
         ArgumentNullException.ThrowIfNull(config);
         ArgumentNullException.ThrowIfNull(logger);
 
         _store = store;
-        _progress = progress;
+        _reclaimListeners = [.. reclaimListeners];
         _escalations = escalations;
         _config = config;
         _logger = logger;
@@ -103,10 +109,9 @@ internal sealed class RunRecordCleanupService : BackgroundService
                 return;
 
             // A run's identifier keys more than its record. Reclaiming one without the other would
-            // trade a bounded leak for an unbounded one — the progress bookkeeping would outlive every
-            // run the host ever streamed.
-            foreach (var jobId in reclaimed)
-                _progress.Forget(jobId);
+            // trade a bounded leak for an unbounded one — progress bookkeeping, and whatever each run
+            // kind holds, would outlive every run the host ever accepted.
+            NotifyReclaimed(reclaimed);
 
             _logger.LogInformation(
                 "Run sweep reclaimed {Count} expired run record(s).", reclaimed.Count);
@@ -116,6 +121,35 @@ internal sealed class RunRecordCleanupService : BackgroundService
             // A failed sweep must not take the service down: the next tick would never come, and the
             // retention window would stop being honoured for the life of the process.
             _logger.LogError(ex, "Run record sweep failed; will retry on the next interval.");
+        }
+    }
+
+    /// <summary>
+    /// Tells every holder of run-scoped state that these runs are gone.
+    /// </summary>
+    /// <remarks>
+    /// Each listener is guarded separately. One that throws must not stop the rest from being told:
+    /// the records are already gone by this point, so a listener skipped here holds its entries for
+    /// the life of the process with nothing that will ever come back for them — which is the
+    /// unbounded leak this call exists to prevent, reintroduced by a fault in an unrelated holder.
+    /// </remarks>
+    private void NotifyReclaimed(IReadOnlyList<string> reclaimed)
+    {
+        foreach (var listener in _reclaimListeners)
+        {
+            try
+            {
+                listener.OnRunsReclaimed(reclaimed);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(
+                    ex,
+                    "{Listener} failed to release state for {Count} reclaimed run(s); its entries for "
+                    + "those runs will not be recovered.",
+                    listener.GetType().Name,
+                    reclaimed.Count);
+            }
         }
     }
 

--- a/src/Content/Presentation/Presentation.ExecutionApi/Controllers/EvalsController.cs
+++ b/src/Content/Presentation/Presentation.ExecutionApi/Controllers/EvalsController.cs
@@ -1,0 +1,203 @@
+using Application.AI.Common.Evaluation.Models;
+using Application.AI.Common.Interfaces.Evaluation;
+using Application.AI.Common.Interfaces.Governance;
+using Application.Core.CQRS.Evaluation.Runs;
+using Domain.Common;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+using Presentation.Common.Extensions;
+using Presentation.ExecutionApi.DTOs;
+using Presentation.ExecutionApi.Extensions;
+
+namespace Presentation.ExecutionApi.Controllers;
+
+/// <summary>
+/// REST surface for running the host's evaluation suites. A run is accepted, queued on the shared run
+/// substrate, and polled for its report.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>A caller names datasets; it never supplies paths or content.</strong> What may be evaluated
+/// is whatever an operator placed in <c>AppConfig:AI:Evaluation:DatasetRoots</c>, and the mapping from
+/// a name to a file happens server-side through <c>IEvalDatasetCatalog</c>. This is the whole
+/// authorization argument for the surface: unlike a submitted workflow, an evaluation is not
+/// caller-authored work, so what a caller can make this host do is bounded by what its operator chose
+/// to publish.
+/// </para>
+/// <para>
+/// <strong>Authorized exactly like the workflow surface — <c>[Authorize]</c>, no bespoke role.</strong>
+/// Worth stating because the instinct runs the other way: an eval run spends real model budget, so a
+/// dedicated role looks like the cautious choice. It is not, for two reasons. This host has no role
+/// policy infrastructure, so a role nothing issues would make the endpoint unreachable in the anonymous
+/// development mode and in every deployment that had not been told to grant it — a control that is
+/// really an outage. And an evaluation is <em>strictly less</em> powerful than a workflow run, which
+/// sits behind the same plain <c>[Authorize]</c>: a workflow is arbitrary caller-authored steps, an
+/// evaluation is an operator-curated dataset. What actually bounds this surface is that evaluation is
+/// off by default, refuses to start without roots, and caps per-run spend before a case runs.
+/// </para>
+/// <para>
+/// Ownership is never taken from the request. There is no owner field on the wire; the identity the
+/// authenticated principal resolves to is what the run is stamped with and what every later read is
+/// checked against.
+/// </para>
+/// </remarks>
+[ApiController]
+[Route("api/evals")]
+[Authorize]
+[EnableRateLimiting(ExecutionApiServiceCollectionExtensions.DefaultRateLimitPolicy)]
+public sealed class EvalsController : ControllerBase
+{
+    private readonly IMediator _mediator;
+    private readonly IEvalDatasetCatalog _catalog;
+    private readonly ICapabilityEnvelopeResolver _envelopeResolver;
+
+    /// <summary>Initializes the controller.</summary>
+    public EvalsController(
+        IMediator mediator,
+        IEvalDatasetCatalog catalog,
+        ICapabilityEnvelopeResolver envelopeResolver)
+    {
+        ArgumentNullException.ThrowIfNull(mediator);
+        ArgumentNullException.ThrowIfNull(catalog);
+        ArgumentNullException.ThrowIfNull(envelopeResolver);
+
+        _mediator = mediator;
+        _catalog = catalog;
+        _envelopeResolver = envelopeResolver;
+    }
+
+    /// <summary>Lists the dataset names this host will evaluate.</summary>
+    /// <remarks>
+    /// Answers an empty list rather than 404 when nothing is configured. "This host publishes no
+    /// datasets" is a true and complete answer to the question asked, and a caller can act on it —
+    /// whereas 404 on a route that exists would suggest the surface itself was absent.
+    /// </remarks>
+    [HttpGet("datasets")]
+    [ProducesResponseType(typeof(EvalDatasetsResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public IActionResult ListDatasets() =>
+        Ok(new EvalDatasetsResponse { Datasets = _catalog.ListNames() });
+
+    /// <summary>
+    /// Starts an evaluation run over the named datasets, returning a job identifier to poll.
+    /// </summary>
+    /// <remarks>
+    /// Accepts and queues; it does not wait. A suite is hundreds of governed agent turns at the default
+    /// ceilings, so the response says the work was taken, not that it finished — which is why it carries
+    /// a status URL rather than a report.
+    /// </remarks>
+    /// <param name="request">The datasets to evaluate and how.</param>
+    /// <param name="cancellationToken">Cancels the request.</param>
+    [HttpPost("runs")]
+    [ProducesResponseType(typeof(StartEvalRunResponse), StatusCodes.Status202Accepted)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> StartRun(
+        [FromBody] StartEvalRunRequest request, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        // Resolved here, at the transport boundary, from the credential that invoked THIS request. Every
+        // evaluation case is a governed agent turn that can invoke tools, so a run carries a grant for
+        // the same reason a workflow run does — and it is the grant of whoever started it.
+        var envelope = _envelopeResolver.Resolve(User);
+
+        var result = await _mediator.Send(
+            new StartEvalRunCommand
+            {
+                DatasetNames = request.Datasets,
+                Options = new EvalRunOptions
+                {
+                    Repeats = request.Repeats,
+                    Parallelism = request.Parallelism,
+                    TagFilter = request.TagFilter,
+                    FailRateThreshold = request.FailRateThreshold
+                },
+                OwnerId = User.GetUserId(),
+                TenantId = User.GetTenantId(),
+                Envelope = envelope
+            },
+            cancellationToken).ConfigureAwait(false);
+
+        if (!result.IsSuccess || result.Value is null)
+            return MapFailure(result);
+
+        var statusUrl = $"/api/evals/runs/{result.Value.JobId}";
+        return Accepted(statusUrl, new StartEvalRunResponse
+        {
+            JobId = result.Value.JobId,
+            StatusUrl = statusUrl
+        });
+    }
+
+    /// <summary>Reads the state of an evaluation run the caller started, and its report once finished.</summary>
+    /// <param name="jobId">The run to read.</param>
+    /// <param name="cancellationToken">Cancels the request.</param>
+    [HttpGet("runs/{jobId}")]
+    [ProducesResponseType(typeof(EvalRunResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> GetRun(string jobId, CancellationToken cancellationToken)
+    {
+        var result = await _mediator.Send(
+            new GetEvalRunQuery
+            {
+                JobId = jobId,
+                OwnerId = User.GetUserId(),
+                TenantId = User.GetTenantId()
+            },
+            cancellationToken).ConfigureAwait(false);
+
+        return result.IsSuccess && result.Value is not null
+            ? Ok(EvalRunResponse.FromView(result.Value))
+            : MapFailure(result);
+    }
+
+    /// <summary>Stops an evaluation run the caller started, if it has not begun executing.</summary>
+    /// <remarks>
+    /// <para>
+    /// Answers 200 with <c>stopped: false</c> when the run was already executing. Unlike a workflow,
+    /// an evaluation in flight cannot be signalled to stop — it is a suite of agent turns with no
+    /// cancellation registry behind it — so this reports the truth rather than claiming an interruption
+    /// that will not happen. What bounds a runaway suite is the per-run execution ceiling, applied
+    /// before any case runs.
+    /// </para>
+    /// <para>
+    /// Answers 409 for a run that has already finished: there is nothing to cancel, and reporting
+    /// success would suggest this call changed something.
+    /// </para>
+    /// </remarks>
+    /// <param name="jobId">The run to stop.</param>
+    /// <param name="cancellationToken">Cancels the request.</param>
+    [HttpDelete("runs/{jobId}")]
+    [ProducesResponseType(typeof(CancelEvalRunResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status409Conflict)]
+    public async Task<IActionResult> CancelRun(string jobId, CancellationToken cancellationToken)
+    {
+        var result = await _mediator.Send(
+            new CancelEvalRunCommand
+            {
+                JobId = jobId,
+                OwnerId = User.GetUserId(),
+                TenantId = User.GetTenantId()
+            },
+            cancellationToken).ConfigureAwait(false);
+
+        if (!result.IsSuccess || result.Value is null)
+            return MapFailure(result);
+
+        return Ok(new CancelEvalRunResponse { JobId = jobId, Stopped = result.Value.Stopped });
+    }
+
+    private IActionResult MapFailure(Result result) =>
+        this.FailureResponse(result, "Evaluation operation failed");
+}

--- a/src/Content/Presentation/Presentation.ExecutionApi/Controllers/EvalsController.cs
+++ b/src/Content/Presentation/Presentation.ExecutionApi/Controllers/EvalsController.cs
@@ -28,28 +28,44 @@ namespace Presentation.ExecutionApi.Controllers;
 /// to publish.
 /// </para>
 /// <para>
-/// <strong>Authorized exactly like the workflow surface — <c>[Authorize]</c>, no bespoke role.</strong>
-/// Worth stating because the instinct runs the other way: an eval run spends real model budget, so a
-/// dedicated role looks like the cautious choice. It is not, for two reasons. This host has no role
-/// policy infrastructure, so a role nothing issues would make the endpoint unreachable in the anonymous
-/// development mode and in every deployment that had not been told to grant it — a control that is
-/// really an outage. And an evaluation is <em>strictly less</em> powerful than a workflow run, which
-/// sits behind the same plain <c>[Authorize]</c>: a workflow is arbitrary caller-authored steps, an
-/// evaluation is an operator-curated dataset. What actually bounds this surface is that evaluation is
-/// off by default, refuses to start without roots, and caps per-run spend before a case runs.
+/// <strong>Gated on a role, not merely on being authenticated.</strong> Every other route this host
+/// serves runs the caller's <em>own</em> work — its bundle, its workflow, its tool call — under the
+/// caller's own grant. This one spends the host's model budget on the operator's suites, and a
+/// suite is hundreds of governed agent turns. That is a different kind of authority from "you hold a
+/// valid token for this API", so it gets its own claim, following the same
+/// <c>Harness.&lt;area&gt;.&lt;verb&gt;</c> convention as <c>Harness.Drift.Operate</c> and
+/// <c>Harness.Learnings.Read</c>.
+/// </para>
+/// <para>
+/// The role is granted to the synthetic principal in the anonymous development mode, so a local
+/// developer is not locked out of a surface that has no other way to be exercised. That mode is an
+/// explicit opt-in that already boots with a startup warning; it is not a way to reach this in a
+/// deployment.
 /// </para>
 /// <para>
 /// Ownership is never taken from the request. There is no owner field on the wire; the identity the
 /// authenticated principal resolves to is what the run is stamped with and what every later read is
-/// checked against.
+/// checked against. The role decides <em>whether you may evaluate at all</em>; ownership decides
+/// <em>which runs are yours</em>. Holding the role does not let a caller read another's run.
 /// </para>
 /// </remarks>
 [ApiController]
 [Route("api/evals")]
-[Authorize]
+[Authorize(Roles = ExecuteRole)]
 [EnableRateLimiting(ExecutionApiServiceCollectionExtensions.DefaultRateLimitPolicy)]
 public sealed class EvalsController : ControllerBase
 {
+    /// <summary>
+    /// Role required to reach any evaluation endpoint.
+    /// </summary>
+    /// <remarks>
+    /// One role for the whole surface rather than a read/execute split. The read endpoints only ever
+    /// answer about the caller's <em>own</em> runs, so a reader who cannot start one has nothing to
+    /// read — the split would grant access to an empty set. Contrast <c>DriftController</c>, whose
+    /// read surface describes host-wide state and therefore genuinely separates from its operate role.
+    /// </remarks>
+    public const string ExecuteRole = "Harness.Evals.Execute";
+
     private readonly IMediator _mediator;
     private readonly IEvalDatasetCatalog _catalog;
     private readonly ICapabilityEnvelopeResolver _envelopeResolver;

--- a/src/Content/Presentation/Presentation.ExecutionApi/DTOs/EvalRunContracts.cs
+++ b/src/Content/Presentation/Presentation.ExecutionApi/DTOs/EvalRunContracts.cs
@@ -1,0 +1,204 @@
+using Application.Core.CQRS.Evaluation.Runs;
+using Domain.AI.Evaluation;
+
+namespace Presentation.ExecutionApi.DTOs;
+
+/// <summary>The datasets this host will evaluate.</summary>
+/// <remarks>
+/// Published so a caller can discover what to name without guessing. Safe to expose because the list is
+/// operator-curated by construction — it is the top level of the configured dataset roots, so it
+/// discloses nothing the operator did not deliberately place there. A host with no roots configured
+/// publishes nothing rather than enumerating its filesystem.
+/// </remarks>
+public sealed record EvalDatasetsResponse
+{
+    /// <summary>Dataset names, in a stable order.</summary>
+    public required IReadOnlyList<string> Datasets { get; init; }
+}
+
+/// <summary>A request to evaluate one or more named datasets.</summary>
+/// <remarks>
+/// <para>
+/// <strong>There is no path field, and that is the security property.</strong> Datasets are named; the
+/// host resolves a name inside its configured roots. A path on the wire would make every request a
+/// filesystem reference with one guard between it and an arbitrary read. A name cannot express
+/// "outside the roots" at all, so the dangerous request is unrepresentable rather than rejected.
+/// </para>
+/// <para>
+/// <strong>The option surface is narrower than <c>EvalRunOptions</c>, deliberately.</strong>
+/// <c>InvocationOverrides</c> and <c>ForceDeterministic</c> are not accepted here: the first is a free
+/// dictionary that flows into model invocation — caller-controlled model configuration, which is the
+/// CLI's business and not a remote caller's — and the second exists for local replay. Both remain
+/// available to in-process dispatchers of <c>RunEvalSuiteCommand</c>. Omitting them from the wire means
+/// they cannot be sent, which is a stronger statement than validating them away.
+/// </para>
+/// </remarks>
+public sealed record StartEvalRunRequest
+{
+    /// <summary>Names of the datasets to evaluate, as <see cref="EvalDatasetsResponse"/> reports them.</summary>
+    public IReadOnlyList<string> Datasets { get; init; } = [];
+
+    /// <summary>
+    /// How many times each case is re-invoked, with median-across-repeats aggregation. Bounded by
+    /// <c>AppConfig:AI:Evaluation:MaxRepeats</c>.
+    /// </summary>
+    public int Repeats { get; init; } = 1;
+
+    /// <summary>
+    /// How many cases run at once. Bounded by <c>AppConfig:AI:Evaluation:MaxParallelism</c>.
+    /// </summary>
+    public int Parallelism { get; init; } = 1;
+
+    /// <summary>Optional tag filter; when non-empty, only cases carrying one of these tags run.</summary>
+    public IReadOnlyList<string>? TagFilter { get; init; }
+
+    /// <summary>
+    /// The fraction of failed cases the run tolerates before its overall verdict is Fail. 0.0 is
+    /// strict: any failure fails the run.
+    /// </summary>
+    public double FailRateThreshold { get; init; }
+}
+
+/// <summary>Response to an accepted evaluation run: what to poll, and under what identifier.</summary>
+public sealed record StartEvalRunResponse
+{
+    /// <summary>Server-minted identifier of the queued run.</summary>
+    public required string JobId { get; init; }
+
+    /// <summary>Where to poll for the run's state and, once it finishes, its report.</summary>
+    public required string StatusUrl { get; init; }
+}
+
+/// <summary>What a cancellation achieved, as the caller sees it.</summary>
+public sealed record CancelEvalRunResponse
+{
+    /// <summary>Identifier of the run that was cancelled.</summary>
+    public required string JobId { get; init; }
+
+    /// <summary>
+    /// Whether the run had stopped by the time this was answered. False means it was already executing
+    /// and will run to completion; an evaluation in flight cannot be interrupted.
+    /// </summary>
+    public required bool Stopped { get; init; }
+}
+
+/// <summary>The caller-visible view of an evaluation run.</summary>
+/// <remarks>
+/// A projection rather than the stored record. <c>RunRecord</c> carries the caller's resolved capability
+/// envelope and tenant — the host's authorization state, not the caller's business — so returning it
+/// directly would publish the exact grant a run holds.
+/// </remarks>
+public sealed record EvalRunResponse
+{
+    /// <summary>Identifier of the run.</summary>
+    public required string JobId { get; init; }
+
+    /// <summary>Where the run has got to.</summary>
+    public required string Status { get; init; }
+
+    /// <summary>The datasets the run was asked to evaluate.</summary>
+    public required IReadOnlyList<string> Datasets { get; init; }
+
+    /// <summary>Caller-safe failure reason once the run has failed.</summary>
+    public string? Error { get; init; }
+
+    /// <summary>When the run was accepted.</summary>
+    public required DateTimeOffset CreatedAt { get; init; }
+
+    /// <summary>When execution began, if it has.</summary>
+    public DateTimeOffset? StartedAt { get; init; }
+
+    /// <summary>When the run reached a terminal state, if it has.</summary>
+    public DateTimeOffset? CompletedAt { get; init; }
+
+    /// <summary>The outcome, once the run has produced one.</summary>
+    public EvalRunSummaryResponse? Report { get; init; }
+
+    /// <summary>Projects a run and its report onto the caller-visible shape.</summary>
+    /// <param name="view">The run, its datasets, and its report if it has one.</param>
+    public static EvalRunResponse FromView(EvalRunView view)
+    {
+        ArgumentNullException.ThrowIfNull(view);
+
+        return new EvalRunResponse
+        {
+            JobId = view.Run.JobId,
+            Status = view.Run.Status.ToString(),
+            Datasets = view.DatasetNames,
+            Error = view.Run.Error,
+            CreatedAt = view.Run.CreatedAt,
+            StartedAt = view.Run.StartedAt,
+            CompletedAt = view.Run.CompletedAt,
+            Report = view.Report is null ? null : EvalRunSummaryResponse.FromReport(view.Report)
+        };
+    }
+}
+
+/// <summary>The caller-visible summary of an evaluation report.</summary>
+/// <remarks>
+/// <para>
+/// <strong>Counts and a verdict, not the per-case results.</strong> <c>EvalRunReport.Results</c> holds
+/// every case's input and the agent's full output — which for an evaluation of a harness means model
+/// responses, tool traces, and whatever the dataset's inputs contained. Returning those on a poll would
+/// make a status endpoint the largest response the API serves, and would put agent output on a path
+/// nothing else on this surface exposes. A caller who needs the transcripts has the reporters the
+/// framework already writes; a caller polling a job needs to know how it went.
+/// </para>
+/// <para>
+/// Cost is included because it is the number a caller most needs after triggering spend on someone
+/// else's credentials, and it is an aggregate that reveals nothing about content.
+/// </para>
+/// </remarks>
+public sealed record EvalRunSummaryResponse
+{
+    /// <summary>The framework's identifier for the evaluation, as it appears in written reports.</summary>
+    public required string RunId { get; init; }
+
+    /// <summary>The run's overall verdict.</summary>
+    public required string Verdict { get; init; }
+
+    /// <summary>Cases whose overall verdict was Pass.</summary>
+    public required int Passed { get; init; }
+
+    /// <summary>Cases whose overall verdict was Fail.</summary>
+    public required int Failed { get; init; }
+
+    /// <summary>Cases whose overall verdict was Warn.</summary>
+    public required int Warned { get; init; }
+
+    /// <summary>Cases that could not be scored because execution errored.</summary>
+    public required int Errored { get; init; }
+
+    /// <summary>Passed as a fraction of scored cases, 0.0–1.0.</summary>
+    public required double PassRate { get; init; }
+
+    /// <summary>How long the evaluation took.</summary>
+    public required TimeSpan Duration { get; init; }
+
+    /// <summary>Cumulative cost in USD across every case, repeat, and metric.</summary>
+    public required decimal TotalCostUsd { get; init; }
+
+    /// <summary>Advisory notes the run produced, such as cost caveats. Never a failure reason.</summary>
+    public required IReadOnlyList<string> Warnings { get; init; }
+
+    /// <summary>Projects a report onto the caller-visible summary.</summary>
+    /// <param name="report">The report the run produced.</param>
+    public static EvalRunSummaryResponse FromReport(EvalRunReport report)
+    {
+        ArgumentNullException.ThrowIfNull(report);
+
+        return new EvalRunSummaryResponse
+        {
+            RunId = report.RunId,
+            Verdict = report.OverallVerdict.ToString(),
+            Passed = report.PassedCount,
+            Failed = report.FailedCount,
+            Warned = report.WarnedCount,
+            Errored = report.ErroredCount,
+            PassRate = report.PassRate,
+            Duration = report.Duration,
+            TotalCostUsd = report.TotalCostUsd,
+            Warnings = report.Warnings
+        };
+    }
+}

--- a/src/Content/Presentation/Presentation.ExecutionApi/Extensions/ExecutionApiEvaluationExtensions.cs
+++ b/src/Content/Presentation/Presentation.ExecutionApi/Extensions/ExecutionApiEvaluationExtensions.cs
@@ -1,6 +1,9 @@
+using Application.AI.Common.Interfaces.Runs;
 using Application.Core.CQRS.Evaluation.RunEvalSuite;
+using Domain.AI.Runs;
 using Domain.Common.Config;
 using Infrastructure.AI.Evaluation;
+using Infrastructure.AI.Runs;
 
 namespace Presentation.ExecutionApi.Extensions;
 
@@ -66,6 +69,21 @@ public static class ExecutionApiEvaluationExtensions
         // reload that emptied DatasetRoots in between would have it conclude the host started
         // unconfined. Latching the verdict at composition time is what makes the ratchet real.
         services.AddSingleton(new EvalConfinementLatch(StartedConfined: true));
+
+        // The executor, registered only inside this branch — the one piece that is genuinely
+        // host-specific. A host that has not enabled evaluation has no executor for
+        // RunKind.Evaluation at all, and the dispatcher fails a run whose kind has no executor. That is
+        // the fail-closed order: the endpoints refuse first, and if anything ever queued an eval run
+        // past them, the dispatcher still would not execute it.
+        //
+        // Keyed by RunKind and scoped, exactly as the workflow executor is: the dispatcher creates a
+        // fresh scope per run and resolves the executor inside it.
+        //
+        // The submission store it reads is registered unconditionally with the rest of the run
+        // substrate. It has to be: the eval CQRS handlers are discovered by assembly scanning, so they
+        // exist in every host, and a conditionally-registered dependency would fail ValidateOnBuild
+        // everywhere evaluation is off.
+        services.AddKeyedScoped<IRunKindExecutor, EvalRunKindExecutor>(RunKind.Evaluation);
 
         return services;
     }

--- a/src/Content/Presentation/Presentation.ExecutionApi/README.md
+++ b/src/Content/Presentation/Presentation.ExecutionApi/README.md
@@ -36,6 +36,16 @@ It is a composition root, exactly like `Presentation.AgentHub`: `builder.Service
 │  │  GET    /{name}                  → IToolCatalog.FindGranted (404 both  │ │
 │  │                                    for absent AND ungranted)           │ │
 │  └───────────────────────────────┬────────────────────────────────────────┘ │
+│  ┌───────────────────────────────┴────────────────────────────────────────┐ │
+│  │  EvalsController  [Authorize]  /api/evals    ← off unless Enabled      │ │
+│  │                                                                        │ │
+│  │  GET    /datasets                → IEvalDatasetCatalog.ListNames       │ │
+│  │  POST   /runs                    → StartEvalRunCommand ← envelope bound│ │
+│  │  GET    /runs/{jobId}            → GetEvalRunQuery (status + report)   │ │
+│  │  DELETE /runs/{jobId}            → CancelEvalRunCommand                │ │
+│  │                                                                        │ │
+│  │  Datasets are NAMED, never pathed — see "Evaluation" below             │ │
+│  └───────────────────────────────┬────────────────────────────────────────┘ │
 └──────────────────────────────────┼──────────────────────────────────────────┘
                                    │ MediatR (validation + audit behaviors)
                                    ▼
@@ -119,14 +129,17 @@ Presentation.ExecutionApi/
 ├── Controllers/
 │   ├── BundlesController.cs         The five endpoints; resolves the envelope; maps Result → ProblemDetails
 │   ├── WorkflowsController.cs       Workflow submission, runs, progress stream, cancel
-│   └── ToolsController.cs           Read-only tool discovery, filtered by the caller's envelope
+│   ├── ToolsController.cs           Read-only tool discovery, filtered by the caller's envelope
+│   └── EvalsController.cs            Dataset listing + eval runs; names on the wire, never paths
 ├── DTOs/
 │   ├── BundleApiContracts.cs        Register/Start/Run responses; BundleRunResponse projects the record
 │   ├── WorkflowRunContracts.cs      Run start/cancel/status projections
-│   └── ToolCatalogContracts.cs      Catalog entry + listing; RiskTier travels as a name, not an ordinal
+│   ├── ToolCatalogContracts.cs      Catalog entry + listing; RiskTier travels as a name, not an ordinal
+│   └── EvalRunContracts.cs          Eval request/response; report projects counts + cost, never transcripts
 ├── Extensions/
 │   ├── ExecutionApiServiceCollectionExtensions.cs   Controllers, auth, FormOptions cap, rate limiters
-│   └── ExecutionApiEvaluationExtensions.cs          Opt-in eval framework; throws if enabled without roots
+│   └── ExecutionApiEvaluationExtensions.cs          Opt-in eval framework + RunKind.Evaluation executor;
+│                                                    throws if enabled without roots
 ├── Services/
 │   ├── BundleCallerIdentity.cs      Stable per-caller id (oid → objectidentifier → nameid → sub)
 │   ├── AnonymousAuthenticationHandler.cs
@@ -207,6 +220,49 @@ eval dispatch and record whatever a `reloadOnChange` had done to the config by t
 > place a *hard* link there (no target to resolve, indistinguishable from an ordinary file), or swap a
 > file for a symlink between the check and the open. Confinement bounds which **paths** a caller may
 > name; it cannot bound what a writable directory turns out to contain.
+
+#### The HTTP surface: names, not paths
+
+`RunEvalSuiteCommand` takes dataset **paths**, which is right for the CLI — a developer pointing the
+runner at a file on their own machine. `/api/evals` never exposes that shape. A caller names a
+dataset; `IEvalDatasetCatalog` maps the name to a file by **enumerating** the configured roots and
+matching, never by concatenating the name onto a root. The distinction is the whole design:
+
+- **There is no path field on the wire.** A name cannot express "outside the roots", so the dangerous
+  request is *unrepresentable* rather than rejected. The guard still runs underneath, so a future
+  caller that reintroduced a path would still be confined — the wire shape makes the attack unsayable,
+  the guard makes it ineffective.
+- **A dataset is whatever an operator put at the top level of a root.** Not recursive: a name carrying
+  structure would be a path with extra steps, needing to be split, rejoined and validated. Operators
+  organise by root, not by folder.
+- **No roots ⇒ no catalog.** `GET /datasets` answers empty rather than enumerating the working
+  directory. Listing is a disclosure, and there is nothing bounded to disclose until an operator says
+  what the bounds are.
+- **`Resolve` cannot distinguish "unknown" from "malformed".** Both answer nothing, for the same
+  reason the guard's refusals do not distinguish forbidden from absent.
+
+Runs execute on the **shared run substrate** (`RunKind.Evaluation`), not inline: a suite is hundreds
+of governed agent turns at the default ceilings, so `POST /runs` answers 202 with a job id. Three
+properties are worth knowing:
+
+| Property | Why |
+|----------|-----|
+| The caller's `CapabilityEnvelope` is armed around the evaluation | Every case is a governed agent turn that can invoke tools. Without it, a caller reaches tools it is denied directly by putting them in an eval case |
+| `TargetId` is the run's own job id | Admission refuses a second live run per target — right for a workflow's shared plan state, wrong for evaluations, which share nothing. A per-run target makes the check correctly inert here instead of switching it off where it also governs workflows |
+| The per-owner ceiling is `AI:WorkflowSubmission:MaxConcurrentRunsPerOwner` | The store's counter is cross-kind, and the substrate's other knobs (`RunRecordTtl`, sweep interval) already live in that section. The name reads narrower than what it governs; a second ceiling on the same counter would mean the limit binding a caller depended on which endpoint they last called |
+
+**Cancelling is weaker than on the workflow path, deliberately.** A queued run is cancelled exactly; a
+run already executing answers `200` with `stopped: false`. A workflow in flight can be signalled
+through `IPlanRunCancellationRegistry`; an evaluation is a suite of agent turns with no equivalent, so
+the honest answer is to report that rather than claim an interruption that will not happen. What
+bounds a runaway suite is `MaxCaseExecutionsPerRun`, applied *before* any case runs.
+
+**A run's report lives beside its record, not on it.** `RunRecord` is deliberately kind-agnostic, so
+`IEvalRunSubmissionStore` holds the dataset names and the report, keyed by the same job id and
+reclaimed by the same sweep — through `IRunReclaimListener`, so the sweeper does not grow a dependency
+per run kind. `GET /runs/{jobId}` returns counts, verdict, duration and cost, **not** per-case results:
+those hold every case's input and the agent's full output, which is not something a status poll should
+carry.
 
 ## How to Run
 
@@ -299,6 +355,14 @@ consumers cannot tell which third is missing.
 | `BundleCallerIdentityTests.cs` | Claim-precedence for the stable id |
 | `ToolsControllerIntegrationTests.cs` | Envelope-filtered discovery, 404 for ungranted, 401 against a configured host, and that every catalogued name resolves to a tool agreeing with it |
 | `ExecutionApiEvaluationEnablementTests.cs` | The evaluation opt-in: default leaves the fail-fast runner, enabled-without-roots refuses to boot, blank roots do not satisfy it |
+| `EvalRunsIntegrationTests.cs` | That `/api/evals` is mounted, closed to anonymous callers on every route, and serves nothing while evaluation is disabled -- the default this host ships with |
+
+Evaluation's behaviour once *enabled* -- admission, ownership, reports, cancellation -- is covered in
+`Infrastructure.AI.Evaluation.Tests/Runs/EvalRunHandlerTests.cs` against the real run and submission
+stores, which can drive it without standing up an agent and a model provider. `EvalDatasetCatalogTests`
+covers name resolution against real directories, deliberately: the property under test is that
+resolution happens by *enumerating what is there*, and a faked filesystem would pass just as happily
+against an implementation that concatenated the name onto a root.
 
 ```bash
 dotnet test src/Content/Tests/Presentation.ExecutionApi.Tests

--- a/src/Content/Presentation/Presentation.ExecutionApi/README.md
+++ b/src/Content/Presentation/Presentation.ExecutionApi/README.md
@@ -37,7 +37,7 @@ It is a composition root, exactly like `Presentation.AgentHub`: `builder.Service
 │  │                                    for absent AND ungranted)           │ │
 │  └───────────────────────────────┬────────────────────────────────────────┘ │
 │  ┌───────────────────────────────┴────────────────────────────────────────┐ │
-│  │  EvalsController  [Authorize]  /api/evals    ← off unless Enabled      │ │
+│  │  EvalsController  /api/evals    ← role-gated, off unless Enabled       │ │
 │  │                                                                        │ │
 │  │  GET    /datasets                → IEvalDatasetCatalog.ListNames       │ │
 │  │  POST   /runs                    → StartEvalRunCommand ← envelope bound│ │
@@ -241,6 +241,19 @@ matching, never by concatenating the name onto a root. The distinction is the wh
 - **`Resolve` cannot distinguish "unknown" from "malformed".** Both answer nothing, for the same
   reason the guard's refusals do not distinguish forbidden from absent.
 
+**This surface is role-gated, unlike every other route this host serves.** Bundles, workflows and
+tool discovery all run the *caller's own* work under the caller's own grant; this one spends the
+host's model budget on the operator's suites. That is a different kind of authority from holding a
+valid token, so it carries `Harness.Evals.Execute`, following the same `Harness.<area>.<verb>`
+convention as `Harness.Drift.Operate`. One role covers the whole surface rather than a read/execute
+split: the read endpoints only ever answer about the caller's *own* runs, so a reader who cannot
+start one has nothing to read. The anonymous development principal is granted the role so a local
+developer can exercise the surface at all -- that mode is an explicit opt-in that already boots with
+a warning.
+
+The role decides *whether you may evaluate*; ownership still decides *which runs are yours*. Holding
+it does not let a caller read another's run.
+
 Runs execute on the **shared run substrate** (`RunKind.Evaluation`), not inline: a suite is hundreds
 of governed agent turns at the default ceilings, so `POST /runs` answers 202 with a job id. Three
 properties are worth knowing:
@@ -256,6 +269,13 @@ run already executing answers `200` with `stopped: false`. A workflow in flight 
 through `IPlanRunCancellationRegistry`; an evaluation is a suite of agent turns with no equivalent, so
 the honest answer is to report that rather than claim an interruption that will not happen. What
 bounds a runaway suite is `MaxCaseExecutionsPerRun`, applied *before* any case runs.
+
+**A finished run's report is filed in-process.** The executor dispatches `IngestEvalRunCommand`
+itself, which is what a server-side run buys over the CLI -- the CLI produces a report and posts it
+back over HTTP to be ingested, and a run already executing inside the host has no reason to leave the
+process to file its own result. A failed ingest is logged and never fails the run: the evaluation
+ran, the spend is incurred, and marking it failed would invite a retry that pays for the whole suite
+again to fix a bookkeeping problem.
 
 **A run's report lives beside its record, not on it.** `RunRecord` is deliberately kind-agnostic, so
 `IEvalRunSubmissionStore` holds the dataset names and the report, keyed by the same job id and

--- a/src/Content/Presentation/Presentation.ExecutionApi/Services/AnonymousAuthenticationHandler.cs
+++ b/src/Content/Presentation/Presentation.ExecutionApi/Services/AnonymousAuthenticationHandler.cs
@@ -60,6 +60,14 @@ public sealed class AnonymousAuthenticationHandler : AuthenticationHandler<Authe
                 // Stable identity so the knowledge scope is non-null and consistent. NOT NameIdentifier —
                 // see the type remarks: that claim is the capability-envelope subject.
                 new Claim("oid", AnonymousUserId),
+
+                // The role-gated surfaces this host serves, granted so a local developer can exercise
+                // them. This mirrors AgentHub's DevAuthHandler and carries the same caveat: a consumer
+                // who copies this handler as the shape of their own authentication inherits a principal
+                // holding every role, so the gate is never exercised by running the app — only by the
+                // controllers' tests. In a real deployment Harness.Evals.Execute is granted separately,
+                // and this handler is not reachable at all unless Auth:AllowAnonymous was set.
+                new Claim(ClaimTypes.Role, Controllers.EvalsController.ExecuteRole),
             ],
             SchemeName);
         var principal = new ClaimsPrincipal(identity);

--- a/src/Content/Tests/Infrastructure.AI.Evaluation.Tests/CQRS/EvalDatasetCatalogTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Evaluation.Tests/CQRS/EvalDatasetCatalogTests.cs
@@ -1,0 +1,261 @@
+using Application.Core.CQRS.Evaluation.RunEvalSuite;
+using Domain.Common.Config;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Infrastructure.AI.Evaluation.Tests.CQRS;
+
+/// <summary>
+/// Tests for <see cref="EvalDatasetCatalog"/> — the mapping from a dataset <em>name</em> to the file it
+/// stands for.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This class is what makes "no filesystem paths on the wire" structural rather than aspirational. The
+/// cases below are the ways a caller would try to make a name behave like a path, plus the disclosure
+/// rules: an unconfined host publishes nothing, and a name that does not resolve is indistinguishable
+/// from one that is malformed.
+/// </para>
+/// <para>
+/// Exercised against real directories rather than an abstracted filesystem, because the property under
+/// test is that resolution happens by <em>enumerating what is actually there</em>. A fake filesystem
+/// would answer whatever the test told it to and would pass just as happily against an implementation
+/// that concatenated the name onto a root.
+/// </para>
+/// </remarks>
+public sealed class EvalDatasetCatalogTests : IDisposable
+{
+    private readonly string _base = Directory.CreateTempSubdirectory("eval-catalog-").FullName;
+    private readonly string _root;
+    private readonly string _second;
+
+    /// <summary>
+    /// Both roots are nested inside one base directory, so a traversal test has somewhere real to
+    /// traverse <em>to</em>. A test whose traversal target does not exist proves nothing: an
+    /// implementation that concatenated the name onto the root would also find nothing there, and
+    /// would pass.
+    /// </summary>
+    public EvalDatasetCatalogTests()
+    {
+        _root = Directory.CreateDirectory(Path.Combine(_base, "root")).FullName;
+        _second = Directory.CreateDirectory(Path.Combine(_base, "second")).FullName;
+    }
+
+    public void Dispose() => TryDelete(_base);
+
+    [Fact]
+    public void Lists_the_files_sitting_in_a_configured_root()
+    {
+        WriteDataset(_root, "alpha.yaml");
+        WriteDataset(_root, "beta.yaml");
+
+        Catalog(_root).ListNames().Should().BeEquivalentTo(["alpha", "beta"]);
+    }
+
+    [Fact]
+    public void A_name_resolves_to_the_file_it_stands_for()
+    {
+        var path = WriteDataset(_root, "alpha.yaml");
+
+        Catalog(_root).Resolve("alpha").Should().Be(path);
+    }
+
+    [Fact]
+    public void Names_are_reported_in_a_stable_order()
+    {
+        // A listing whose order depends on the filesystem makes a caller's diff of two responses noise.
+        WriteDataset(_root, "zeta.yaml");
+        WriteDataset(_root, "alpha.yaml");
+
+        Catalog(_root).ListNames().Should().ContainInOrder("alpha", "zeta");
+    }
+
+    [Fact]
+    public void An_unconfined_host_publishes_nothing()
+    {
+        // Listing is a disclosure. With no roots configured there is no bounded thing to disclose, and
+        // enumerating whatever directory the process happens to run from would be a filesystem read.
+        Catalog().ListNames().Should().BeEmpty();
+    }
+
+    [Fact]
+    public void An_unconfined_host_resolves_nothing()
+    {
+        // The stronger half of the same rule: an empty listing would be cosmetic if a caller could
+        // still name a dataset and have it resolve.
+        WriteDataset(_root, "alpha.yaml");
+
+        Catalog().Resolve("alpha").Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData("../outside")]
+    [InlineData("..\\outside")]
+    [InlineData("../second/beta")]
+    [InlineData("..\\second\\beta")]
+    public void A_name_cannot_traverse_out_of_its_root_to_a_file_that_really_is_there(string name)
+    {
+        // The traversal targets exist. That is the whole point of the case: an implementation that
+        // built a path by concatenating the name onto the root would reach both of these, so a test
+        // aimed at somewhere empty would pass against exactly the implementation it is meant to
+        // forbid.
+        WriteDataset(_base, "outside.yaml");
+        WriteDataset(_second, "beta.yaml");
+        WriteDataset(_root, "alpha.yaml");
+
+        Catalog(_root).Resolve(name).Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData("sub/alpha")]
+    [InlineData("sub\\alpha")]
+    [InlineData("C:alpha")]
+    [InlineData("..")]
+    [InlineData(".")]
+    public void A_name_that_looks_like_a_path_resolves_to_nothing(string name)
+    {
+        WriteDataset(_root, "alpha.yaml");
+        WriteDataset(Directory.CreateDirectory(Path.Combine(_root, "sub")).FullName, "alpha.yaml");
+
+        Catalog(_root).Resolve(name).Should().BeNull();
+    }
+
+    [Fact]
+    public void A_file_in_a_subdirectory_is_not_published()
+    {
+        // Top level only, deliberately: a name that carried structure would be a path with extra steps,
+        // needing to be split, rejoined and validated — the concatenation problem again.
+        var nested = Directory.CreateDirectory(Path.Combine(_root, "sub"));
+        WriteDataset(nested.FullName, "buried.yaml");
+
+        var catalog = Catalog(_root);
+
+        catalog.ListNames().Should().BeEmpty();
+        catalog.Resolve("buried").Should().BeNull();
+    }
+
+    [Fact]
+    public void A_name_nobody_published_resolves_to_nothing()
+    {
+        WriteDataset(_root, "alpha.yaml");
+
+        Catalog(_root).Resolve("nonexistent").Should().BeNull();
+    }
+
+    [Fact]
+    public void An_empty_name_resolves_to_nothing()
+    {
+        WriteDataset(_root, "alpha.yaml");
+
+        Catalog(_root).Resolve("   ").Should().BeNull();
+    }
+
+    [Fact]
+    public void Datasets_across_several_roots_are_all_published()
+    {
+        WriteDataset(_root, "alpha.yaml");
+        WriteDataset(_second, "beta.yaml");
+
+        Catalog(_root, _second).ListNames().Should().BeEquivalentTo(["alpha", "beta"]);
+    }
+
+    [Fact]
+    public void A_name_defined_in_two_roots_resolves_to_the_first()
+    {
+        // First-root-wins is arbitrary but has to be deterministic: a name that resolved differently
+        // from one request to the next would run a different suite each time it was named.
+        var first = WriteDataset(_root, "alpha.yaml");
+        WriteDataset(_second, "alpha.yaml");
+
+        Catalog(_root, _second).Resolve("alpha").Should().Be(first);
+    }
+
+    [Fact]
+    public void A_name_defined_in_two_roots_is_published_once()
+    {
+        WriteDataset(_root, "alpha.yaml");
+        WriteDataset(_second, "alpha.yaml");
+
+        Catalog(_root, _second).ListNames().Should().ContainSingle().Which.Should().Be("alpha");
+    }
+
+    [Fact]
+    public void A_root_that_does_not_exist_contributes_nothing_rather_than_failing()
+    {
+        // An operator's typo must not take the whole catalog down with it — the datasets in the roots
+        // that do exist are still perfectly runnable.
+        WriteDataset(_root, "alpha.yaml");
+
+        Catalog(Path.Combine(_root, "no-such-directory"), _root)
+            .ListNames().Should().BeEquivalentTo(["alpha"]);
+    }
+
+    [Fact]
+    public void A_dataset_added_after_startup_is_published_without_a_restart()
+    {
+        // Not cached: a stale catalog would admit a run against a dataset that has since been removed,
+        // which then fails at load time having already been queued.
+        var catalog = Catalog(_root);
+        catalog.ListNames().Should().BeEmpty();
+
+        WriteDataset(_root, "alpha.yaml");
+
+        catalog.ListNames().Should().BeEquivalentTo(["alpha"]);
+    }
+
+    [Fact]
+    public void A_dataset_the_guard_refuses_is_never_published()
+    {
+        // The catalog must not be able to publish a name whose file the handler would then refuse to
+        // load — the two would disagree, and the caller would see an accepted run fail on dispatch.
+        WriteDataset(_root, "alpha.yaml");
+
+        var guard = new Mock<IEvalDatasetPathGuard>();
+        guard.Setup(g => g.Resolve(It.IsAny<string>()))
+            .Returns(EvalDatasetPathDecision.Refuse("Dataset is not available."));
+
+        var catalog = new EvalDatasetCatalog(
+            Monitor(_root), guard.Object, NullLogger<EvalDatasetCatalog>.Instance);
+
+        catalog.ListNames().Should().BeEmpty();
+        catalog.Resolve("alpha").Should().BeNull();
+    }
+
+    private EvalDatasetCatalog Catalog(params string[] roots) => new(
+        Monitor(roots),
+        new EvalDatasetPathGuard(Monitor(roots), new EvalConfinementLatch(StartedConfined: roots.Length > 0)),
+        NullLogger<EvalDatasetCatalog>.Instance);
+
+    private static IOptionsMonitor<AppConfig> Monitor(params string[] roots)
+    {
+        var config = new AppConfig();
+        config.AI.Evaluation.DatasetRoots = [.. roots];
+
+        var monitor = new Mock<IOptionsMonitor<AppConfig>>();
+        monitor.SetupGet(m => m.CurrentValue).Returns(config);
+        return monitor.Object;
+    }
+
+    private static string WriteDataset(string directory, string fileName)
+    {
+        var path = Path.Combine(directory, fileName);
+        File.WriteAllText(path, "cases: []");
+        return path;
+    }
+
+    private static void TryDelete(string directory)
+    {
+        try
+        {
+            if (Directory.Exists(directory))
+                Directory.Delete(directory, recursive: true);
+        }
+        catch (IOException)
+        {
+            // A leftover temp directory is not worth failing a test run over.
+        }
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Evaluation.Tests/CQRS/EvalDatasetCatalogTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Evaluation.Tests/CQRS/EvalDatasetCatalogTests.cs
@@ -60,7 +60,7 @@ public sealed class EvalDatasetCatalogTests : IDisposable
     {
         var path = WriteDataset(_root, "alpha.yaml");
 
-        Catalog(_root).Resolve("alpha").Should().Be(path);
+        Catalog(_root).Resolve(["alpha"]).Paths.Should().ContainSingle().Which.Should().Be(path);
     }
 
     [Fact]
@@ -88,7 +88,7 @@ public sealed class EvalDatasetCatalogTests : IDisposable
         // still name a dataset and have it resolve.
         WriteDataset(_root, "alpha.yaml");
 
-        Catalog().Resolve("alpha").Should().BeNull();
+        Catalog().Resolve(["alpha"]).IsComplete.Should().BeFalse();
     }
 
     [Theory]
@@ -106,7 +106,7 @@ public sealed class EvalDatasetCatalogTests : IDisposable
         WriteDataset(_second, "beta.yaml");
         WriteDataset(_root, "alpha.yaml");
 
-        Catalog(_root).Resolve(name).Should().BeNull();
+        Catalog(_root).Resolve([name]).IsComplete.Should().BeFalse();
     }
 
     [Theory]
@@ -120,7 +120,32 @@ public sealed class EvalDatasetCatalogTests : IDisposable
         WriteDataset(_root, "alpha.yaml");
         WriteDataset(Directory.CreateDirectory(Path.Combine(_root, "sub")).FullName, "alpha.yaml");
 
-        Catalog(_root).Resolve(name).Should().BeNull();
+        Catalog(_root).Resolve([name]).IsComplete.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Resolved_paths_come_back_in_the_order_the_names_were_given()
+    {
+        // The paths are handed straight to the eval command, whose report is ordered by dataset. A
+        // resolution that reordered them would silently mislabel which suite produced which result.
+        var alpha = WriteDataset(_root, "alpha.yaml");
+        var zeta = WriteDataset(_root, "zeta.yaml");
+
+        Catalog(_root).Resolve(["zeta", "alpha"]).Paths.Should().ContainInOrder(zeta, alpha);
+    }
+
+    [Fact]
+    public void One_unknown_name_makes_the_whole_set_unresolved()
+    {
+        // All of them or none: a suite quietly evaluated without one of its datasets reports a pass
+        // rate for something that never ran. The caller is told which name so it can act on it.
+        WriteDataset(_root, "alpha.yaml");
+
+        var resolution = Catalog(_root).Resolve(["alpha", "nonexistent"]);
+
+        resolution.IsComplete.Should().BeFalse();
+        resolution.MissingName.Should().Be("nonexistent");
+        resolution.Paths.Should().BeEmpty("a partial answer invites a caller to run part of a suite");
     }
 
     [Fact]
@@ -134,7 +159,7 @@ public sealed class EvalDatasetCatalogTests : IDisposable
         var catalog = Catalog(_root);
 
         catalog.ListNames().Should().BeEmpty();
-        catalog.Resolve("buried").Should().BeNull();
+        catalog.Resolve(["buried"]).IsComplete.Should().BeFalse();
     }
 
     [Fact]
@@ -142,7 +167,7 @@ public sealed class EvalDatasetCatalogTests : IDisposable
     {
         WriteDataset(_root, "alpha.yaml");
 
-        Catalog(_root).Resolve("nonexistent").Should().BeNull();
+        Catalog(_root).Resolve(["nonexistent"]).IsComplete.Should().BeFalse();
     }
 
     [Fact]
@@ -150,7 +175,7 @@ public sealed class EvalDatasetCatalogTests : IDisposable
     {
         WriteDataset(_root, "alpha.yaml");
 
-        Catalog(_root).Resolve("   ").Should().BeNull();
+        Catalog(_root).Resolve(["   "]).IsComplete.Should().BeFalse();
     }
 
     [Fact]
@@ -170,7 +195,7 @@ public sealed class EvalDatasetCatalogTests : IDisposable
         var first = WriteDataset(_root, "alpha.yaml");
         WriteDataset(_second, "alpha.yaml");
 
-        Catalog(_root, _second).Resolve("alpha").Should().Be(first);
+        Catalog(_root, _second).Resolve(["alpha"]).Paths.Should().ContainSingle().Which.Should().Be(first);
     }
 
     [Fact]
@@ -221,7 +246,7 @@ public sealed class EvalDatasetCatalogTests : IDisposable
             Monitor(_root), guard.Object, NullLogger<EvalDatasetCatalog>.Instance);
 
         catalog.ListNames().Should().BeEmpty();
-        catalog.Resolve("alpha").Should().BeNull();
+        catalog.Resolve(["alpha"]).IsComplete.Should().BeFalse();
     }
 
     private EvalDatasetCatalog Catalog(params string[] roots) => new(

--- a/src/Content/Tests/Infrastructure.AI.Evaluation.Tests/CQRS/EvalDatasetCatalogTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Evaluation.Tests/CQRS/EvalDatasetCatalogTests.cs
@@ -254,9 +254,44 @@ public sealed class EvalDatasetCatalogTests : IDisposable
         new EvalDatasetPathGuard(Monitor(roots), new EvalConfinementLatch(StartedConfined: roots.Length > 0)),
         NullLogger<EvalDatasetCatalog>.Instance);
 
-    private static IOptionsMonitor<AppConfig> Monitor(params string[] roots)
+    [Fact]
+    public void A_disabled_host_publishes_and_resolves_nothing_even_with_roots_configured()
+    {
+        // Turning evaluation off is an operator saying this host does not do this. Leaving the
+        // inventory readable would make that only half true, and leaving names resolvable would leave
+        // a disabled host one bypassed handler check away from running a suite.
+        WriteDataset(_root, "alpha.yaml");
+
+        var catalog = new EvalDatasetCatalog(
+            Monitor(false, _root),
+            new EvalDatasetPathGuard(Monitor(false, _root), new EvalConfinementLatch(StartedConfined: true)),
+            NullLogger<EvalDatasetCatalog>.Instance);
+
+        catalog.ListNames().Should().BeEmpty();
+        catalog.Resolve(["alpha"]).IsComplete.Should().BeFalse();
+    }
+
+    [Fact]
+    public void A_blank_name_never_reports_as_a_complete_resolution()
+    {
+        // EvalDatasetResolution.IsComplete reads a null MissingName as success, so a refusal carrying
+        // a blank name would claim every name resolved while carrying no paths — and a caller would
+        // admit a run over zero datasets. A validator makes this unreachable in production; the type
+        // must not depend on that.
+        WriteDataset(_root, "alpha.yaml");
+
+        var resolution = Catalog(_root).Resolve(["  "]);
+
+        resolution.IsComplete.Should().BeFalse();
+        resolution.MissingName.Should().NotBeNullOrWhiteSpace();
+    }
+
+    private static IOptionsMonitor<AppConfig> Monitor(params string[] roots) => Monitor(true, roots);
+
+    private static IOptionsMonitor<AppConfig> Monitor(bool enabled, params string[] roots)
     {
         var config = new AppConfig();
+        config.AI.Evaluation.Enabled = enabled;
         config.AI.Evaluation.DatasetRoots = [.. roots];
 
         var monitor = new Mock<IOptionsMonitor<AppConfig>>();

--- a/src/Content/Tests/Infrastructure.AI.Evaluation.Tests/CQRS/EvalDatasetPathGuardTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Evaluation.Tests/CQRS/EvalDatasetPathGuardTests.cs
@@ -307,6 +307,35 @@ public sealed class EvalDatasetPathGuardTests : IDisposable
     }
 
     [Fact]
+    public void SwappingOneRootForAnother_StopsAdmittingFilesUnderTheOldOne()
+    {
+        // The guard memoizes its link-resolved roots, because resolving them per candidate repeated the
+        // same walk for every file the dataset catalog confines. That cache is keyed on the configured
+        // roots, and this is the case that proves the key works: a cache that ignored a configuration
+        // change would keep honouring a root an operator had REMOVED, which is a widened allowlist
+        // surviving the change meant to narrow it.
+        //
+        // Deliberately one guard instance across both reads. Every other ratchet test builds a fresh
+        // guard, so none of them ever populates the cache before the configuration moves.
+        var config = new AppConfig();
+        config.AI.Evaluation.DatasetRoots = [_root];
+
+        var guard = GuardOver(config, startedConfined: true);
+
+        var underOldRoot = WriteFile(_root, "suite.yaml");
+        guard.Resolve(underOldRoot).IsAllowed.Should().BeTrue("the file is inside the configured root");
+
+        var otherRoot = Directory.CreateDirectory(Path.Combine(_outside, "other-root")).FullName;
+        var underNewRoot = WriteFile(otherRoot, "suite.yaml");
+        config.AI.Evaluation.DatasetRoots = [otherRoot];
+
+        guard.Resolve(underOldRoot).IsAllowed.Should().BeFalse(
+            "the old root was removed, so nothing under it may still be admitted");
+        guard.Resolve(underNewRoot).IsAllowed.Should().BeTrue(
+            "the new root was added, so files under it are admitted without a restart");
+    }
+
+    [Fact]
     public void RootsAlreadyGoneWhenTheGuardIsFirstBuilt_StillRefuse()
     {
         // The case a latch computed inside the constructor would miss entirely. The guard is a lazy

--- a/src/Content/Tests/Infrastructure.AI.Evaluation.Tests/Infrastructure.AI.Evaluation.Tests.csproj
+++ b/src/Content/Tests/Infrastructure.AI.Evaluation.Tests/Infrastructure.AI.Evaluation.Tests.csproj
@@ -13,6 +13,7 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" />
     <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Moq" />
     <PackageReference Include="xunit" />

--- a/src/Content/Tests/Infrastructure.AI.Evaluation.Tests/Runs/EvalRunHandlerTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Evaluation.Tests/Runs/EvalRunHandlerTests.cs
@@ -39,7 +39,7 @@ public sealed class EvalRunHandlerTests
 
     private readonly AppConfig _config = new();
     private readonly FakeTimeProvider _time = new(DateTimeOffset.UnixEpoch);
-    private readonly Mock<IEvalDatasetCatalog> _catalog = new();
+    private readonly FakeCatalog _catalog = new();
     private readonly InMemoryEvalRunSubmissionStore _submissions = new();
     private readonly RecordingQueue _queue = new();
     private readonly IRunJobStore _runs;
@@ -52,7 +52,7 @@ public sealed class EvalRunHandlerTests
 
         _monitor = new StaticMonitor(_config);
         _runs = new InMemoryRunJobStore(_monitor, _time);
-        _catalog.Setup(c => c.Resolve("alpha")).Returns("/data/alpha.yaml");
+        _catalog.Publish("alpha", "/data/alpha.yaml");
 
         // Lets the queue observe whether the submission was already stored when the run was handed to
         // it — the ordering a dispatcher depends on and nothing else would catch.
@@ -291,7 +291,7 @@ public sealed class EvalRunHandlerTests
 
     private Task<Domain.Common.Result<StartEvalRunResult>> Start(IReadOnlyList<string> datasets) =>
         new StartEvalRunCommandHandler(
-                _catalog.Object, _submissions, _runs, _queue, _monitor, _time,
+                _catalog, _submissions, _runs, _queue, _monitor, _time,
                 NullLogger<StartEvalRunCommandHandler>.Instance)
             .Handle(
                 new StartEvalRunCommand
@@ -374,6 +374,37 @@ public sealed class EvalRunHandlerTests
         {
             await Task.CompletedTask;
             yield break;
+        }
+    }
+
+    /// <summary>
+    /// A catalog over an in-memory name-to-path map.
+    /// </summary>
+    /// <remarks>
+    /// Hand-written rather than mocked because <c>Resolve</c> and <c>ResolveAll</c> must agree — a
+    /// mock lets a test stub one and leave the other answering null, which would pass while the real
+    /// pairing was broken.
+    /// </remarks>
+    private sealed class FakeCatalog : IEvalDatasetCatalog
+    {
+        private readonly Dictionary<string, string> _published = new(StringComparer.OrdinalIgnoreCase);
+
+        public void Publish(string name, string path) => _published[name] = path;
+
+        public IReadOnlyList<string> ListNames() => [.. _published.Keys];
+
+        public EvalDatasetResolution Resolve(IReadOnlyList<string> names)
+        {
+            var paths = new List<string>(names.Count);
+            foreach (var name in names)
+            {
+                if (!_published.TryGetValue(name, out var path))
+                    return EvalDatasetResolution.Missing(name);
+
+                paths.Add(path);
+            }
+
+            return EvalDatasetResolution.Complete(paths);
         }
     }
 

--- a/src/Content/Tests/Infrastructure.AI.Evaluation.Tests/Runs/EvalRunHandlerTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Evaluation.Tests/Runs/EvalRunHandlerTests.cs
@@ -1,0 +1,388 @@
+using Application.AI.Common.Evaluation.Models;
+using Application.AI.Common.Interfaces.Evaluation;
+using Application.AI.Common.Interfaces.Runs;
+using Application.Core.CQRS.Evaluation.Runs;
+using Domain.AI.Bundles;
+using Domain.AI.Evaluation;
+using Domain.AI.Runs;
+using Domain.Common.Config;
+using FluentAssertions;
+using Infrastructure.AI.Runs;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Time.Testing;
+using Moq;
+using Xunit;
+
+namespace Infrastructure.AI.Evaluation.Tests.Runs;
+
+/// <summary>
+/// Tests for the evaluation run endpoints' handlers: starting, reading, and cancelling a run.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Built on the real <c>InMemoryRunJobStore</c> and <c>InMemoryEvalRunSubmissionStore</c> rather than
+/// mocks. The behaviours worth asserting here — a caller's run being invisible to another caller, a
+/// record and its submission staying in step, a queue failure not stranding a slot — are properties of
+/// those stores' interaction, and a mocked store would let every one of them pass while broken.
+/// </para>
+/// <para>
+/// The recurring theme is non-disclosure: a run belonging to someone else, a run that never existed,
+/// and a run of a different kind must be one answer. Anything else lets a caller enumerate work it was
+/// never given the identifier for.
+/// </para>
+/// </remarks>
+public sealed class EvalRunHandlerTests
+{
+    private const string Owner = "alice";
+    private const string Stranger = "mallory";
+
+    private readonly AppConfig _config = new();
+    private readonly FakeTimeProvider _time = new(DateTimeOffset.UnixEpoch);
+    private readonly Mock<IEvalDatasetCatalog> _catalog = new();
+    private readonly InMemoryEvalRunSubmissionStore _submissions = new();
+    private readonly RecordingQueue _queue = new();
+    private readonly IRunJobStore _runs;
+    private readonly IOptionsMonitor<AppConfig> _monitor;
+
+    public EvalRunHandlerTests()
+    {
+        _config.AI.Evaluation.Enabled = true;
+        _config.AI.WorkflowSubmission.MaxConcurrentRunsPerOwner = 10;
+
+        _monitor = new StaticMonitor(_config);
+        _runs = new InMemoryRunJobStore(_monitor, _time);
+        _catalog.Setup(c => c.Resolve("alpha")).Returns("/data/alpha.yaml");
+
+        // Lets the queue observe whether the submission was already stored when the run was handed to
+        // it — the ordering a dispatcher depends on and nothing else would catch.
+        _queue.Observes(_submissions);
+    }
+
+    // ---- starting -------------------------------------------------------------------------------
+
+    [Fact]
+    public async Task Starting_a_run_queues_it_and_returns_an_id_to_poll()
+    {
+        var result = await Start(["alpha"]);
+
+        result.IsSuccess.Should().BeTrue();
+        _queue.Enqueued.Should().ContainSingle().Which.Should().Be(result.Value!.JobId);
+    }
+
+    [Fact]
+    public async Task Starting_a_run_stores_its_datasets_where_the_executor_will_find_them()
+    {
+        // The record is deliberately kind-agnostic, so the dataset names live beside it. A run queued
+        // without them is dispatched and immediately fails, having already consumed a slot.
+        var result = await Start(["alpha"]);
+
+        _submissions.Get(result.Value!.JobId)!.DatasetNames.Should().BeEquivalentTo(["alpha"]);
+    }
+
+    [Fact]
+    public async Task A_run_is_never_queued_before_its_request_is_stored()
+    {
+        // A dispatcher can claim a run the instant it is enqueued. Storing the submission afterwards
+        // leaves a window in which the executor finds nothing to execute.
+        await Start(["alpha"]);
+
+        _queue.SubmissionPresentPerEnqueue.Should().NotBeEmpty().And.AllBeEquivalentTo(
+            true, "the dispatcher may claim the run the moment it is queued");
+    }
+
+    [Fact]
+    public async Task Evaluation_being_disabled_refuses_the_run()
+    {
+        _config.AI.Evaluation.Enabled = false;
+
+        var result = await Start(["alpha"]);
+
+        result.IsSuccess.Should().BeFalse();
+        _queue.Enqueued.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task An_unknown_dataset_name_is_refused_before_anything_is_queued()
+    {
+        // Accepting it would be a 202 followed by a failure the caller has to poll for — having spent
+        // one of their concurrency slots to say so.
+        var result = await Start(["nonexistent"]);
+
+        result.IsSuccess.Should().BeFalse();
+        _queue.Enqueued.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task One_unknown_name_refuses_the_whole_run()
+    {
+        // Running the datasets that did resolve would report a pass rate for a suite that never fully
+        // ran, which is worse than refusing.
+        var result = await Start(["alpha", "nonexistent"]);
+
+        result.IsSuccess.Should().BeFalse();
+        _queue.Enqueued.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task A_caller_at_its_concurrency_ceiling_is_refused()
+    {
+        _config.AI.WorkflowSubmission.MaxConcurrentRunsPerOwner = 1;
+        await Start(["alpha"]);
+
+        var second = await Start(["alpha"]);
+
+        second.IsSuccess.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Two_runs_over_the_same_dataset_are_both_admitted()
+    {
+        // Evaluations share no state, unlike two runs of one workflow. A target derived from the
+        // datasets would serialize unrelated work and let one caller's long suite lock out everyone
+        // else's.
+        await Start(["alpha"]);
+
+        var second = await Start(["alpha"]);
+
+        second.IsSuccess.Should().BeTrue("two evaluations of one dataset are independent reads");
+    }
+
+    [Fact]
+    public async Task A_run_that_cannot_be_queued_is_failed_rather_than_left_holding_a_slot()
+    {
+        // Only terminal runs are reclaimed, so a committed record that is never queued is never
+        // claimed, never finishes, and never goes away — it holds one of the caller's slots for the
+        // life of the process.
+        _queue.FailNext = true;
+
+        var result = await Start(["alpha"]);
+        result.IsSuccess.Should().BeFalse();
+
+        _config.AI.WorkflowSubmission.MaxConcurrentRunsPerOwner = 1;
+        var next = await Start(["alpha"]);
+
+        next.IsSuccess.Should().BeTrue("the abandoned run must not still count against the caller");
+    }
+
+    // ---- reading --------------------------------------------------------------------------------
+
+    [Fact]
+    public async Task An_owner_can_read_the_run_it_started()
+    {
+        var started = await Start(["alpha"]);
+
+        var read = await Read(started.Value!.JobId, Owner);
+
+        read.Value!.Run.JobId.Should().Be(started.Value.JobId);
+        read.Value.DatasetNames.Should().BeEquivalentTo(["alpha"]);
+    }
+
+    [Fact]
+    public async Task Another_callers_run_reads_as_missing()
+    {
+        var started = await Start(["alpha"]);
+
+        var read = await Read(started.Value!.JobId, Stranger);
+
+        read.IsSuccess.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task A_workflow_run_cannot_be_read_through_the_evaluation_route()
+    {
+        // Job ids are minted from one sequence for every kind. Without the kind check a caller could
+        // confirm that an id it holds belongs to a workflow.
+        var workflow = Workflow("wf-job");
+        _runs.TryCreate(workflow, 10).Should().Be(RunAdmission.Accepted);
+
+        var read = await Read("wf-job", Owner);
+
+        read.IsSuccess.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task A_run_whose_submission_has_gone_is_still_readable()
+    {
+        // The record and the submission are dropped by the same sweep, but not atomically. A caller
+        // polling in that window is owed the run's status, not a failure.
+        var started = await Start(["alpha"]);
+        _submissions.OnRunsReclaimed([started.Value!.JobId]);
+
+        var read = await Read(started.Value.JobId, Owner);
+
+        read.IsSuccess.Should().BeTrue();
+        read.Value!.DatasetNames.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task A_finished_runs_report_is_surfaced_to_its_owner()
+    {
+        var started = await Start(["alpha"]);
+        _submissions.AttachReport(started.Value!.JobId, Report());
+
+        var read = await Read(started.Value.JobId, Owner);
+
+        read.Value!.Report!.OverallVerdict.Should().Be(Verdict.Fail);
+    }
+
+    // ---- cancelling -----------------------------------------------------------------------------
+
+    [Fact]
+    public async Task Cancelling_a_queued_run_stops_it()
+    {
+        var started = await Start(["alpha"]);
+
+        var cancelled = await Cancel(started.Value!.JobId, Owner);
+
+        cancelled.Value!.Stopped.Should().BeTrue();
+        _runs.Get(started.Value.JobId, Owner, null)!.Status.Should().Be(RunStatus.Cancelled);
+    }
+
+    [Fact]
+    public async Task Cancelling_a_run_already_executing_reports_that_it_did_not_stop()
+    {
+        // An evaluation in flight has no cancellation registry behind it. Reporting success would tell
+        // a caller the spend had stopped when it has not.
+        var started = await Start(["alpha"]);
+        _runs.TryBeginRun(started.Value!.JobId, _time.GetUtcNow());
+
+        var cancelled = await Cancel(started.Value.JobId, Owner);
+
+        cancelled.IsSuccess.Should().BeTrue();
+        cancelled.Value!.Stopped.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Cancelling_a_finished_run_conflicts()
+    {
+        var started = await Start(["alpha"]);
+        var claimed = _runs.TryBeginRun(started.Value!.JobId, _time.GetUtcNow())!;
+        _runs.Update(claimed with { Status = RunStatus.Succeeded, CompletedAt = _time.GetUtcNow() });
+
+        var cancelled = await Cancel(started.Value.JobId, Owner);
+
+        cancelled.IsSuccess.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Another_caller_cannot_cancel_a_run_it_does_not_own()
+    {
+        var started = await Start(["alpha"]);
+
+        var cancelled = await Cancel(started.Value!.JobId, Stranger);
+
+        cancelled.IsSuccess.Should().BeFalse();
+        _runs.Get(started.Value.JobId, Owner, null)!.Status.Should().Be(RunStatus.Queued);
+    }
+
+    [Fact]
+    public async Task A_workflow_run_cannot_be_cancelled_through_the_evaluation_route()
+    {
+        _runs.TryCreate(Workflow("wf-job"), 10).Should().Be(RunAdmission.Accepted);
+
+        var cancelled = await Cancel("wf-job", Owner);
+
+        cancelled.IsSuccess.Should().BeFalse();
+        _runs.Get("wf-job", Owner, null)!.Status.Should().Be(RunStatus.Queued);
+    }
+
+    // ---- harness --------------------------------------------------------------------------------
+
+    private Task<Domain.Common.Result<StartEvalRunResult>> Start(IReadOnlyList<string> datasets) =>
+        new StartEvalRunCommandHandler(
+                _catalog.Object, _submissions, _runs, _queue, _monitor, _time,
+                NullLogger<StartEvalRunCommandHandler>.Instance)
+            .Handle(
+                new StartEvalRunCommand
+                {
+                    DatasetNames = datasets,
+                    Options = new EvalRunOptions(),
+                    OwnerId = Owner,
+                    Envelope = new CapabilityEnvelope()
+                },
+                CancellationToken.None);
+
+    private Task<Domain.Common.Result<EvalRunView>> Read(string jobId, string owner) =>
+        new GetEvalRunQueryHandler(_runs, _submissions, _monitor)
+            .Handle(new GetEvalRunQuery { JobId = jobId, OwnerId = owner }, CancellationToken.None);
+
+    private Task<Domain.Common.Result<CancelEvalRunResult>> Cancel(string jobId, string owner) =>
+        new CancelEvalRunCommandHandler(
+                _runs, new InMemoryRunProgressBroker(_monitor, _time), _monitor, _time,
+                NullLogger<CancelEvalRunCommandHandler>.Instance)
+            .Handle(new CancelEvalRunCommand { JobId = jobId, OwnerId = owner }, CancellationToken.None);
+
+    private static RunRecord Workflow(string jobId) => new()
+    {
+        JobId = jobId,
+        Kind = RunKind.Workflow,
+        TargetId = Guid.NewGuid().ToString(),
+        OwnerId = Owner,
+        Envelope = new CapabilityEnvelope(),
+        Status = RunStatus.Queued,
+        CreatedAt = DateTimeOffset.UnixEpoch
+    };
+
+    private static EvalRunReport Report() => new()
+    {
+        RunId = "run-1",
+        StartedAtUtc = DateTimeOffset.UnixEpoch,
+        CompletedAtUtc = DateTimeOffset.UnixEpoch,
+        Duration = TimeSpan.Zero,
+        Datasets = [],
+        Results = [],
+        OverallVerdict = Verdict.Fail
+    };
+
+    /// <summary>
+    /// Records what was queued, and whether the submission was already in place when it was — the
+    /// ordering a dispatcher depends on.
+    /// </summary>
+    private sealed class RecordingQueue : IRunDispatchQueue
+    {
+        private IEvalRunSubmissionStore? _submissions;
+
+        public List<string> Enqueued { get; } = [];
+
+        public bool FailNext { get; set; }
+
+        /// <summary>
+        /// Whether the submission was already stored, recorded once per enqueue rather than as a
+        /// single flag. A flag would keep only the last answer, so an implementation that queued the
+        /// run early and again later would overwrite the evidence of the early one and pass.
+        /// </summary>
+        public List<bool> SubmissionPresentPerEnqueue { get; } = [];
+
+        public void Observes(IEvalRunSubmissionStore submissions) => _submissions = submissions;
+
+        public ValueTask EnqueueAsync(string jobId, CancellationToken cancellationToken)
+        {
+            if (FailNext)
+            {
+                FailNext = false;
+                throw new InvalidOperationException("the queue is unavailable");
+            }
+
+            SubmissionPresentPerEnqueue.Add(_submissions?.Get(jobId) is not null);
+            Enqueued.Add(jobId);
+            return ValueTask.CompletedTask;
+        }
+
+        /// <summary>Nothing drains in these tests; the handler only ever enqueues.</summary>
+        public async IAsyncEnumerable<string> DequeueAllAsync(CancellationToken cancellationToken)
+        {
+            await Task.CompletedTask;
+            yield break;
+        }
+    }
+
+    private sealed class StaticMonitor(AppConfig value) : IOptionsMonitor<AppConfig>
+    {
+        public AppConfig CurrentValue { get; } = value;
+
+        public AppConfig Get(string? name) => CurrentValue;
+
+        public IDisposable? OnChange(Action<AppConfig, string?> listener) => null;
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Runs/EvalRunKindExecutorTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Runs/EvalRunKindExecutorTests.cs
@@ -1,0 +1,211 @@
+using Application.AI.Common.Evaluation.Models;
+using Application.AI.Common.Interfaces.Evaluation;
+using Application.AI.Common.Services.Governance;
+using Application.Core.CQRS.Evaluation.RunEvalSuite;
+using Domain.AI.Bundles;
+using Domain.AI.Evaluation;
+using Domain.AI.Runs;
+using Domain.Common;
+using FluentAssertions;
+using Infrastructure.AI.Runs;
+using MediatR;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Runs;
+
+/// <summary>
+/// Tests for <see cref="EvalRunKindExecutor"/> — how a queued evaluation run is actually performed.
+/// </summary>
+/// <remarks>
+/// Two properties here are worth more than the rest. The run's capability envelope must be armed
+/// around the evaluation, or a caller reaches tools it is denied directly by putting them in an eval
+/// case. And a suite whose cases failed is a <em>succeeded</em> run — collapsing that into a failure
+/// leaves a caller unable to tell a failing suite from a broken host.
+/// </remarks>
+public sealed class EvalRunKindExecutorTests
+{
+    private readonly Mock<IMediator> _mediator = new();
+    private readonly Mock<IEvalDatasetCatalog> _catalog = new();
+    private readonly InMemoryEvalRunSubmissionStore _submissions = new();
+
+    [Fact]
+    public async Task Arms_the_runs_capability_envelope_around_the_evaluation()
+    {
+        // Every eval case is a governed agent turn that can invoke tools. Without the envelope armed,
+        // EnvelopePermissionRuleProvider emits nothing and the suite runs outside the grant the caller
+        // was resolved to hold.
+        CapabilityEnvelope? observed = null;
+        var envelope = new CapabilityEnvelope { AllowedTools = ["file_system"] };
+
+        Given("alpha", "/data/alpha.yaml");
+        WhenEvaluated(() => observed = CapabilityEnvelopeAccessor.Current, Passing());
+
+        await Execute(Record(envelope), "alpha");
+
+        observed.Should().BeSameAs(envelope);
+    }
+
+    [Fact]
+    public async Task Leaves_no_envelope_armed_once_the_run_is_over()
+    {
+        // Ambient state that outlived its run would be inherited by whatever the dispatcher thread does
+        // next — one caller's grant applied to another caller's work.
+        Given("alpha", "/data/alpha.yaml");
+        WhenEvaluated(() => { }, Passing());
+
+        await Execute(Record(), "alpha");
+
+        CapabilityEnvelopeAccessor.Current.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Resolves_every_named_dataset_to_a_path_through_the_catalog()
+    {
+        // The submission holds names precisely so a path never crosses the trust boundary. This is the
+        // one place they become paths, and it must be the catalog that decides which.
+        Given("alpha", "/data/alpha.yaml");
+        Given("beta", "/data/beta.yaml");
+
+        IReadOnlyList<string>? dispatched = null;
+        _mediator
+            .Setup(m => m.Send(It.IsAny<RunEvalSuiteCommand>(), It.IsAny<CancellationToken>()))
+            .Callback<object, CancellationToken>((c, _) => dispatched = ((RunEvalSuiteCommand)c).DatasetPaths)
+            .ReturnsAsync(Result<EvalRunReport>.Success(Passing()));
+
+        await Execute(Record(), "alpha", "beta");
+
+        dispatched.Should().BeEquivalentTo(["/data/alpha.yaml", "/data/beta.yaml"]);
+    }
+
+    [Fact]
+    public async Task Fails_the_run_when_a_named_dataset_no_longer_resolves()
+    {
+        // The name resolved at admission and does not now — a file removed, or a root reconfigured.
+        // Skipping it would report a pass rate for a suite that never fully ran.
+        Given("alpha", "/data/alpha.yaml");
+        _catalog.Setup(c => c.Resolve("beta")).Returns((string?)null);
+
+        var result = await Execute(Record(), "alpha", "beta");
+
+        result.IsSuccess.Should().BeFalse();
+        result.Errors.Should().ContainSingle().Which.Should().Contain("beta");
+    }
+
+    [Fact]
+    public async Task Evaluates_nothing_when_any_named_dataset_is_missing()
+    {
+        // Resolution completes before dispatch, so a partially-resolvable request costs nothing. The
+        // opposite order would run the datasets that did resolve and then fail — real spend, no answer.
+        Given("alpha", "/data/alpha.yaml");
+        _catalog.Setup(c => c.Resolve("beta")).Returns((string?)null);
+
+        await Execute(Record(), "alpha", "beta");
+
+        _mediator.Verify(
+            m => m.Send(It.IsAny<RunEvalSuiteCommand>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Fails_the_run_when_its_submission_is_missing()
+    {
+        Given("alpha", "/data/alpha.yaml");
+
+        var result = await Sut().ExecuteAsync(Record(), CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Attaches_the_report_so_the_caller_can_read_it()
+    {
+        // A run whose report is held nowhere the caller can reach has spent real model budget to
+        // produce a log line.
+        Given("alpha", "/data/alpha.yaml");
+        WhenEvaluated(() => { }, Passing("run-7"));
+
+        var record = Record();
+        await Execute(record, "alpha");
+
+        _submissions.Get(record.JobId)!.Report!.RunId.Should().Be("run-7");
+    }
+
+    [Fact]
+    public async Task Reports_a_failing_suite_as_a_succeeded_run()
+    {
+        // "Succeeded" means the evaluation ran, not that it passed. A caller that could not tell a
+        // failing suite from a broken host would have to guess whether it got an answer at all.
+        Given("alpha", "/data/alpha.yaml");
+        WhenEvaluated(() => { }, Passing(verdict: Verdict.Fail));
+
+        var result = await Execute(Record(), "alpha");
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.Status.Should().Be(RunStatus.Succeeded);
+    }
+
+    [Fact]
+    public async Task Passes_the_evaluations_own_refusal_back_to_the_caller()
+    {
+        // The command's refusals name a ceiling or a dataset and are caller-safe by contract. Flattening
+        // them into "it failed" would leave a caller unable to act on a limit it could have respected.
+        Given("alpha", "/data/alpha.yaml");
+        _mediator
+            .Setup(m => m.Send(It.IsAny<RunEvalSuiteCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<EvalRunReport>.ValidationFailure(["This run would perform 900 case executions"]));
+
+        var result = await Execute(Record(), "alpha");
+
+        result.Errors.Should().ContainSingle().Which.Should().Contain("900 case executions");
+    }
+
+    private EvalRunKindExecutor Sut() => new(
+        _mediator.Object,
+        _catalog.Object,
+        _submissions,
+        NullLogger<EvalRunKindExecutor>.Instance);
+
+    private void Given(string name, string path) => _catalog.Setup(c => c.Resolve(name)).Returns(path);
+
+    /// <summary>Answers the evaluation dispatch, running <paramref name="probe"/> while it is in flight.</summary>
+    private void WhenEvaluated(Action probe, EvalRunReport report) =>
+        _mediator
+            .Setup(m => m.Send(It.IsAny<RunEvalSuiteCommand>(), It.IsAny<CancellationToken>()))
+            .Callback(probe)
+            .ReturnsAsync(Result<EvalRunReport>.Success(report));
+
+    private async Task<Result<RunCompletion>> Execute(RunRecord record, params string[] datasets)
+    {
+        _submissions.Add(new EvalRunSubmission
+        {
+            JobId = record.JobId,
+            DatasetNames = datasets,
+            Options = new EvalRunOptions()
+        });
+
+        return await Sut().ExecuteAsync(record, CancellationToken.None);
+    }
+
+    private static RunRecord Record(CapabilityEnvelope? envelope = null) => new()
+    {
+        JobId = Guid.NewGuid().ToString("N"),
+        Kind = RunKind.Evaluation,
+        TargetId = "target",
+        OwnerId = "owner",
+        Envelope = envelope ?? new CapabilityEnvelope(),
+        Status = RunStatus.Running,
+        CreatedAt = DateTimeOffset.UnixEpoch
+    };
+
+    private static EvalRunReport Passing(string runId = "run-1", Verdict verdict = Verdict.Pass) => new()
+    {
+        RunId = runId,
+        StartedAtUtc = DateTimeOffset.UnixEpoch,
+        CompletedAtUtc = DateTimeOffset.UnixEpoch,
+        Duration = TimeSpan.Zero,
+        Datasets = [],
+        Results = [],
+        OverallVerdict = verdict
+    };
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Runs/EvalRunKindExecutorTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Runs/EvalRunKindExecutorTests.cs
@@ -1,3 +1,4 @@
+using Application.AI.Common.CQRS.Evaluation.IngestEvalRun;
 using Application.AI.Common.Evaluation.Models;
 using Application.AI.Common.Interfaces.Evaluation;
 using Application.AI.Common.Services.Governance;
@@ -27,7 +28,7 @@ namespace Infrastructure.AI.Tests.Runs;
 public sealed class EvalRunKindExecutorTests
 {
     private readonly Mock<IMediator> _mediator = new();
-    private readonly Mock<IEvalDatasetCatalog> _catalog = new();
+    private readonly FakeCatalog _catalog = new();
     private readonly InMemoryEvalRunSubmissionStore _submissions = new();
 
     [Fact]
@@ -85,7 +86,6 @@ public sealed class EvalRunKindExecutorTests
         // The name resolved at admission and does not now — a file removed, or a root reconfigured.
         // Skipping it would report a pass rate for a suite that never fully ran.
         Given("alpha", "/data/alpha.yaml");
-        _catalog.Setup(c => c.Resolve("beta")).Returns((string?)null);
 
         var result = await Execute(Record(), "alpha", "beta");
 
@@ -99,7 +99,6 @@ public sealed class EvalRunKindExecutorTests
         // Resolution completes before dispatch, so a partially-resolvable request costs nothing. The
         // opposite order would run the datasets that did resolve and then fail — real spend, no answer.
         Given("alpha", "/data/alpha.yaml");
-        _catalog.Setup(c => c.Resolve("beta")).Returns((string?)null);
 
         await Execute(Record(), "alpha", "beta");
 
@@ -160,13 +159,77 @@ public sealed class EvalRunKindExecutorTests
         result.Errors.Should().ContainSingle().Which.Should().Contain("900 case executions");
     }
 
+    [Fact]
+    public async Task Files_the_report_into_the_durable_store_the_dashboard_reads()
+    {
+        // The point of running an evaluation server-side rather than from the CLI: the CLI produces a
+        // report and posts it back over HTTP to be ingested, and a run executing inside the host has
+        // no reason to leave the process to file its own result. Without this the report lives only in
+        // the submission store and disappears with it at RunRecordTtl.
+        Given("alpha", "/data/alpha.yaml");
+        WhenEvaluated(() => { }, Passing("run-7"));
+
+        EvalRunReport? ingested = null;
+        _mediator
+            .Setup(m => m.Send(It.IsAny<IngestEvalRunCommand>(), It.IsAny<CancellationToken>()))
+            .Callback<object, CancellationToken>((c, _) => ingested = ((IngestEvalRunCommand)c).Report)
+            .ReturnsAsync(Result<IngestEvalRunResult>.Success(Ingested("run-7")));
+
+        await Execute(Record(), "alpha");
+
+        ingested!.RunId.Should().Be("run-7");
+    }
+
+    [Fact]
+    public async Task A_failed_ingest_does_not_fail_the_run()
+    {
+        // The evaluation ran and the spend is already incurred. Reporting the run as failed would
+        // misdescribe the work and would invite a retry that pays for the whole suite again to fix a
+        // bookkeeping problem — and the caller can still read the report from its own run.
+        Given("alpha", "/data/alpha.yaml");
+        WhenEvaluated(() => { }, Passing());
+
+        _mediator
+            .Setup(m => m.Send(It.IsAny<IngestEvalRunCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<IngestEvalRunResult>.Fail("the eval store is unavailable"));
+
+        var result = await Execute(Record(), "alpha");
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.Status.Should().Be(RunStatus.Succeeded);
+    }
+
+    [Fact]
+    public async Task An_ingest_that_throws_does_not_fail_the_run()
+    {
+        // A host that never registered the eval store reaches here. Same reasoning: the evaluation
+        // succeeded, and a bookkeeping fault must not be reported as failed work.
+        Given("alpha", "/data/alpha.yaml");
+        WhenEvaluated(() => { }, Passing());
+
+        _mediator
+            .Setup(m => m.Send(It.IsAny<IngestEvalRunCommand>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("no eval store registered"));
+
+        var result = await Execute(Record(), "alpha");
+
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    private static IngestEvalRunResult Ingested(string runId) => new()
+    {
+        RunId = runId,
+        Inserted = true,
+        ReceivedAtUtc = DateTimeOffset.UnixEpoch
+    };
+
     private EvalRunKindExecutor Sut() => new(
         _mediator.Object,
-        _catalog.Object,
+        _catalog,
         _submissions,
         NullLogger<EvalRunKindExecutor>.Instance);
 
-    private void Given(string name, string path) => _catalog.Setup(c => c.Resolve(name)).Returns(path);
+    private void Given(string name, string path) => _catalog.Publish(name, path);
 
     /// <summary>Answers the evaluation dispatch, running <paramref name="probe"/> while it is in flight.</summary>
     private void WhenEvaluated(Action probe, EvalRunReport report) =>
@@ -185,6 +248,33 @@ public sealed class EvalRunKindExecutorTests
         });
 
         return await Sut().ExecuteAsync(record, CancellationToken.None);
+    }
+
+    /// <summary>
+    /// A catalog over an in-memory name-to-path map. Hand-written rather than mocked so
+    /// <c>Resolve</c> and <c>ResolveAll</c> cannot disagree.
+    /// </summary>
+    private sealed class FakeCatalog : IEvalDatasetCatalog
+    {
+        private readonly Dictionary<string, string> _published = new(StringComparer.OrdinalIgnoreCase);
+
+        public void Publish(string name, string path) => _published[name] = path;
+
+        public IReadOnlyList<string> ListNames() => [.. _published.Keys];
+
+        public EvalDatasetResolution Resolve(IReadOnlyList<string> names)
+        {
+            var paths = new List<string>(names.Count);
+            foreach (var name in names)
+            {
+                if (!_published.TryGetValue(name, out var path))
+                    return EvalDatasetResolution.Missing(name);
+
+                paths.Add(path);
+            }
+
+            return EvalDatasetResolution.Complete(paths);
+        }
     }
 
     private static RunRecord Record(CapabilityEnvelope? envelope = null) => new()

--- a/src/Content/Tests/Infrastructure.AI.Tests/Runs/InMemoryEvalRunSubmissionStoreTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Runs/InMemoryEvalRunSubmissionStoreTests.cs
@@ -1,0 +1,139 @@
+using Application.AI.Common.Evaluation.Models;
+using Domain.AI.Evaluation;
+using FluentAssertions;
+using Infrastructure.AI.Runs;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Runs;
+
+/// <summary>
+/// Tests for <see cref="InMemoryEvalRunSubmissionStore"/> — the side table holding what an evaluation
+/// run was asked to do and what it produced.
+/// </summary>
+/// <remarks>
+/// The cases that matter are the lifetime ones. This store holds a whole report per run, so an entry
+/// that is never dropped is an unbounded leak, and an entry dropped too eagerly silently strips the
+/// result off a run its owner can still read.
+/// </remarks>
+public sealed class InMemoryEvalRunSubmissionStoreTests
+{
+    [Fact]
+    public void Get_returns_what_was_added()
+    {
+        var sut = new InMemoryEvalRunSubmissionStore();
+        sut.Add(Submission("job-1", "alpha"));
+
+        sut.Get("job-1")!.DatasetNames.Should().ContainSingle().Which.Should().Be("alpha");
+    }
+
+    [Fact]
+    public void Get_returns_null_for_a_run_it_never_held()
+    {
+        var sut = new InMemoryEvalRunSubmissionStore();
+
+        sut.Get("never-seen").Should().BeNull();
+    }
+
+    [Fact]
+    public void Adding_a_second_submission_under_one_job_id_throws()
+    {
+        // Two runs sharing an entry means the loser reports the winner's datasets and the winner's
+        // report to its own caller. Refusing loudly matches IRunJobStore.TryCreate on the same id.
+        var sut = new InMemoryEvalRunSubmissionStore();
+        sut.Add(Submission("job-1", "alpha"));
+
+        var act = () => sut.Add(Submission("job-1", "beta"));
+
+        act.Should().Throw<InvalidOperationException>();
+    }
+
+    [Fact]
+    public void AttachReport_makes_the_report_readable()
+    {
+        var sut = new InMemoryEvalRunSubmissionStore();
+        sut.Add(Submission("job-1", "alpha"));
+
+        sut.AttachReport("job-1", Report("run-7")).Should().BeTrue();
+
+        sut.Get("job-1")!.Report!.RunId.Should().Be("run-7");
+    }
+
+    [Fact]
+    public void AttachReport_leaves_the_rest_of_the_submission_alone()
+    {
+        // The report is added to the submission, not substituted for it. A caller polling a finished
+        // run is owed both what it asked for and what came back.
+        var sut = new InMemoryEvalRunSubmissionStore();
+        sut.Add(Submission("job-1", "alpha", "beta"));
+
+        sut.AttachReport("job-1", Report("run-7"));
+
+        sut.Get("job-1")!.DatasetNames.Should().BeEquivalentTo(["alpha", "beta"]);
+    }
+
+    [Fact]
+    public void AttachReport_reports_false_when_the_submission_is_already_gone()
+    {
+        // The run outlived its entry — reclaimed mid-flight. The executor treats this as "log it and
+        // report success", so a silent true here would hide a report that went nowhere.
+        var sut = new InMemoryEvalRunSubmissionStore();
+
+        sut.AttachReport("job-1", Report("run-7")).Should().BeFalse();
+    }
+
+    [Fact]
+    public void A_reclaimed_run_loses_its_submission()
+    {
+        var sut = new InMemoryEvalRunSubmissionStore();
+        sut.Add(Submission("job-1", "alpha"));
+        sut.AttachReport("job-1", Report("run-7"));
+
+        sut.OnRunsReclaimed(["job-1"]);
+
+        sut.Get("job-1").Should().BeNull();
+    }
+
+    [Fact]
+    public void Reclaiming_one_run_leaves_every_other_run_intact()
+    {
+        // The sweep hands over a batch. Dropping more than the batch named would make a caller's live
+        // run lose its report because an unrelated run expired.
+        var sut = new InMemoryEvalRunSubmissionStore();
+        sut.Add(Submission("job-1", "alpha"));
+        sut.Add(Submission("job-2", "beta"));
+
+        sut.OnRunsReclaimed(["job-1"]);
+
+        sut.Get("job-2").Should().NotBeNull();
+    }
+
+    [Fact]
+    public void Reclaiming_a_run_it_never_held_is_not_an_error()
+    {
+        // The sweeper reclaims runs of every kind and tells every listener about all of them, so most
+        // identifiers this store is handed were never its own.
+        var sut = new InMemoryEvalRunSubmissionStore();
+
+        var act = () => sut.OnRunsReclaimed(["a-workflow-run"]);
+
+        act.Should().NotThrow();
+    }
+
+    private static EvalRunSubmission Submission(string jobId, params string[] datasets) => new()
+    {
+        JobId = jobId,
+        DatasetNames = datasets,
+        Options = new EvalRunOptions()
+    };
+
+    private static EvalRunReport Report(string runId) => new()
+    {
+        RunId = runId,
+        StartedAtUtc = DateTimeOffset.UnixEpoch,
+        CompletedAtUtc = DateTimeOffset.UnixEpoch,
+        Duration = TimeSpan.Zero,
+        Datasets = [],
+        Results = [],
+        OverallVerdict = Verdict.Pass
+    };
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Runs/RunRecordCleanupServiceTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Runs/RunRecordCleanupServiceTests.cs
@@ -133,7 +133,7 @@ public sealed class RunRecordCleanupServiceTests
         _time.Advance(TimeSpan.FromDays(1));
 
         var sut = new RunRecordCleanupService(
-            store, progress, _escalations.Object, monitor,
+            store, [new RunProgressReclaimListener(progress)], _escalations.Object, monitor,
             NullLogger<RunRecordCleanupService>.Instance);
 
         using var cts = new CancellationTokenSource();
@@ -183,7 +183,7 @@ public sealed class RunRecordCleanupServiceTests
         _time.Advance(TimeSpan.FromHours(1));
 
         var sut = new RunRecordCleanupService(
-            store, progress, _escalations.Object, monitor,
+            store, [new RunProgressReclaimListener(progress)], _escalations.Object, monitor,
             NullLogger<RunRecordCleanupService>.Instance);
 
         using var cts = new CancellationTokenSource();
@@ -222,7 +222,7 @@ public sealed class RunRecordCleanupServiceTests
         _time.Advance(TimeSpan.FromHours(1));
 
         var sut = new RunRecordCleanupService(
-            store, progress, _escalations.Object, monitor,
+            store, [new RunProgressReclaimListener(progress)], _escalations.Object, monitor,
             NullLogger<RunRecordCleanupService>.Instance);
 
         using var cts = new CancellationTokenSource();
@@ -235,6 +235,92 @@ public sealed class RunRecordCleanupServiceTests
         await sut.StopAsync(CancellationToken.None);
 
         progress.Forgotten.Should().Contain("finished");
+    }
+
+    [Fact]
+    public async Task EveryHolderOfRunScopedStateIsToldAboutAReclaimedRun()
+    {
+        // The broker is no longer the only thing keyed by a job id — an evaluation run's datasets and
+        // report are too, and future kinds will add more. Telling only the first registered holder
+        // would leak every one after it, silently.
+        var first = new RecordingListener();
+        var second = new RecordingListener();
+
+        await SweepOneFinishedRun([first, second]);
+
+        first.Released.Should().Contain("finished");
+        second.Released.Should().Contain("finished", "a second holder leaks unless it is told too");
+    }
+
+    [Fact]
+    public async Task AHolderThatThrowsDoesNotStopTheOthersBeingTold()
+    {
+        // The records are already gone by this point, so a holder skipped here keeps its entries for
+        // the life of the process with nothing that will ever come back for them. An unrelated
+        // listener's fault must not reintroduce the exact leak this notification exists to prevent.
+        var faulty = new ThrowingListener();
+        var healthy = new RecordingListener();
+
+        await SweepOneFinishedRun([faulty, healthy]);
+
+        healthy.Released.Should().Contain(
+            "finished", "one holder's fault must not strand every holder registered after it");
+    }
+
+    /// <summary>
+    /// Runs one finished, expired run through a real sweep and returns once the listeners have been
+    /// told — the shared arrangement behind the reclaim-notification cases.
+    /// </summary>
+    private async Task SweepOneFinishedRun(IReadOnlyList<IRunReclaimListener> listeners)
+    {
+        _config.AI.WorkflowSubmission.RunRecordTtl = TimeSpan.FromMinutes(5);
+        _config.AI.WorkflowSubmission.RunSweepInterval = TimeSpan.Zero;
+
+        var monitor = new StaticOptionsMonitor<AppConfig>(_config);
+        var store = new CountingStore(new InMemoryRunJobStore(monitor, _time));
+
+        store.TryCreate(Queued("finished"), int.MaxValue).Should().Be(RunAdmission.Accepted);
+        var claimed = store.TryBeginRun("finished", _time.GetUtcNow())!;
+        store.Update(claimed with { Status = RunStatus.Succeeded, CompletedAt = _time.GetUtcNow() });
+
+        _time.Advance(TimeSpan.FromHours(1));
+
+        var sut = new RunRecordCleanupService(
+            store, listeners, _escalations.Object, monitor,
+            NullLogger<RunRecordCleanupService>.Instance);
+
+        using var cts = new CancellationTokenSource();
+        await sut.StartAsync(cts.Token);
+
+        for (var attempt = 0; attempt < 60 && store.Reclaimed == 0; attempt++)
+            await Task.Delay(100);
+
+        await cts.CancelAsync();
+        await sut.StopAsync(CancellationToken.None);
+    }
+
+    /// <summary>Records which runs it was told to release.</summary>
+    private sealed class RecordingListener : IRunReclaimListener
+    {
+        private readonly List<string> _released = [];
+
+        public IReadOnlyList<string> Released
+        {
+            get { lock (_released) return [.. _released]; }
+        }
+
+        public void OnRunsReclaimed(IReadOnlyList<string> jobIds)
+        {
+            lock (_released)
+                _released.AddRange(jobIds);
+        }
+    }
+
+    /// <summary>A holder whose release path is broken, standing in for any listener that faults.</summary>
+    private sealed class ThrowingListener : IRunReclaimListener
+    {
+        public void OnRunsReclaimed(IReadOnlyList<string> jobIds) =>
+            throw new InvalidOperationException("this holder is broken");
     }
 
     /// <summary>Records which runs the sweeper asked the broker to forget.</summary>

--- a/src/Content/Tests/Presentation.ExecutionApi.Tests/EvalRunsIntegrationTests.cs
+++ b/src/Content/Tests/Presentation.ExecutionApi.Tests/EvalRunsIntegrationTests.cs
@@ -1,0 +1,119 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Presentation.ExecutionApi.Tests;
+
+/// <summary>
+/// Full-stack tests for the evaluation endpoints, driven through the real host.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The properties worth proving here are the ones only the real pipeline can show: that the routes
+/// exist and are mounted, that they are closed to unauthenticated callers, and — most importantly —
+/// that a host which has not enabled evaluation serves nothing. Everything the surface can do costs
+/// model spend on the host's own credentials, so "off unless an operator turned it on" is the claim
+/// that has to hold against the composed host rather than against a handler in isolation.
+/// </para>
+/// <para>
+/// This host ships with evaluation disabled, so these run against that default. The behaviour once it
+/// is enabled — admission, ownership, reports — is covered against the real stores in
+/// <c>EvalRunHandlerTests</c>, which can drive it without standing up an agent and a model provider.
+/// </para>
+/// </remarks>
+public sealed class EvalRunsIntegrationTests
+{
+    private static WebApplicationFactory<Program> CreateFactory() =>
+        new WebApplicationFactory<Program>().WithWebHostBuilder(builder =>
+            builder.ConfigureTestServices(services => services
+                .AddAuthentication(HeaderIdentityAuthenticationHandler.SchemeName)
+                .AddScheme<AuthenticationSchemeOptions, HeaderIdentityAuthenticationHandler>(
+                    HeaderIdentityAuthenticationHandler.SchemeName, _ => { })));
+
+    private static HttpRequestMessage Request(HttpMethod method, string url, object? body, string? oid)
+    {
+        var request = new HttpRequestMessage(method, url);
+        if (body is not null)
+            request.Content = JsonContent.Create(body);
+
+        if (oid is not null)
+        {
+            request.Headers.Add(HeaderIdentityAuthenticationHandler.UserHeader, oid);
+            request.Headers.Add(HeaderIdentityAuthenticationHandler.TenantHeader, "acme");
+        }
+
+        return request;
+    }
+
+    [Fact]
+    public async Task StartingARun_IsRefusedWhileEvaluationIsDisabled()
+    {
+        // The default this host ships with. An eval run spends real model budget on the host's own
+        // credentials, so it must take a deliberate operator action to become reachable — not merely
+        // an authenticated caller who knows the route.
+        using var factory = CreateFactory();
+        using var client = factory.CreateClient();
+
+        var response = await client.SendAsync(Request(
+            HttpMethod.Post, "/api/evals/runs", new { datasets = new[] { "anything" } }, "alice"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task ReadingARun_IsRefusedWhileEvaluationIsDisabled()
+    {
+        // The read path is gated too. Left open it would report on runs from a period when evaluation
+        // had been enabled, after an operator turned it off precisely to stop that.
+        using var factory = CreateFactory();
+        using var client = factory.CreateClient();
+
+        var response = await client.SendAsync(Request(
+            HttpMethod.Get, "/api/evals/runs/some-job", body: null, "alice"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task ADisabledHostPublishesNoDatasets()
+    {
+        // The listing is deliberately not gated on Enabled — it answers "what could be run here" and
+        // an empty answer is truthful and actionable. What must hold is that it discloses nothing: with
+        // no roots configured there is no catalog, and it must not fall back to enumerating the
+        // process's working directory.
+        using var factory = CreateFactory();
+        using var client = factory.CreateClient();
+
+        var response = await client.SendAsync(
+            Request(HttpMethod.Get, "/api/evals/datasets", body: null, "alice"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("datasets").EnumerateArray().Should().BeEmpty();
+    }
+
+    [Theory]
+    [InlineData("GET", "/api/evals/datasets")]
+    [InlineData("POST", "/api/evals/runs")]
+    [InlineData("GET", "/api/evals/runs/some-job")]
+    [InlineData("DELETE", "/api/evals/runs/some-job")]
+    public async Task EveryEvaluationRouteRefusesAnUnauthenticatedCaller(string method, string url)
+    {
+        // Including the listing. A dataset name is a small disclosure, but it is the operator's
+        // inventory and there is no reason an anonymous caller should have it.
+        using var factory = CreateFactory();
+        using var client = factory.CreateClient();
+
+        var response = await client.SendAsync(
+            Request(new HttpMethod(method), url, body: null, oid: null));
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+}

--- a/src/Content/Tests/Presentation.ExecutionApi.Tests/EvalRunsIntegrationTests.cs
+++ b/src/Content/Tests/Presentation.ExecutionApi.Tests/EvalRunsIntegrationTests.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
+using Presentation.ExecutionApi.Controllers;
 using Xunit;
 
 namespace Presentation.ExecutionApi.Tests;
@@ -36,7 +37,8 @@ public sealed class EvalRunsIntegrationTests
                 .AddScheme<AuthenticationSchemeOptions, HeaderIdentityAuthenticationHandler>(
                     HeaderIdentityAuthenticationHandler.SchemeName, _ => { })));
 
-    private static HttpRequestMessage Request(HttpMethod method, string url, object? body, string? oid)
+    private static HttpRequestMessage Request(
+        HttpMethod method, string url, object? body, string? oid, bool withRole = true)
     {
         var request = new HttpRequestMessage(method, url);
         if (body is not null)
@@ -46,6 +48,12 @@ public sealed class EvalRunsIntegrationTests
         {
             request.Headers.Add(HeaderIdentityAuthenticationHandler.UserHeader, oid);
             request.Headers.Add(HeaderIdentityAuthenticationHandler.TenantHeader, "acme");
+
+            if (withRole)
+            {
+                request.Headers.Add(
+                    HeaderIdentityAuthenticationHandler.RolesHeader, EvalsController.ExecuteRole);
+            }
         }
 
         return request;
@@ -115,5 +123,27 @@ public sealed class EvalRunsIntegrationTests
             Request(new HttpMethod(method), url, body: null, oid: null));
 
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Theory]
+    [InlineData("GET", "/api/evals/datasets")]
+    [InlineData("POST", "/api/evals/runs")]
+    [InlineData("GET", "/api/evals/runs/some-job")]
+    [InlineData("DELETE", "/api/evals/runs/some-job")]
+    public async Task EveryEvaluationRouteRefusesAnAuthenticatedCallerWithoutTheRole(
+        string method, string url)
+    {
+        // The case the role gate exists for. Every other route this host serves runs the caller's own
+        // work under the caller's own grant; this one spends the host's model budget on the operator's
+        // suites, which is a different kind of authority from holding a valid token. A caller who is
+        // authenticated but not entitled must be refused — 403, not 401: they are who they say, they
+        // just may not do this.
+        using var factory = CreateFactory();
+        using var client = factory.CreateClient();
+
+        var response = await client.SendAsync(
+            Request(new HttpMethod(method), url, body: null, oid: "alice", withRole: false));
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
     }
 }

--- a/src/Content/Tests/Presentation.ExecutionApi.Tests/HeaderIdentityAuthenticationHandler.cs
+++ b/src/Content/Tests/Presentation.ExecutionApi.Tests/HeaderIdentityAuthenticationHandler.cs
@@ -30,6 +30,12 @@ internal sealed class HeaderIdentityAuthenticationHandler : AuthenticationHandle
     /// </summary>
     public const string ApproverHeader = "X-Test-Approver";
 
+    /// <summary>
+    /// Comma-separated roles to grant this request. Absent means the principal holds none, so a
+    /// role-gated endpoint is reached only by a test that asks for it explicitly.
+    /// </summary>
+    public const string RolesHeader = "X-Test-Roles";
+
     public HeaderIdentityAuthenticationHandler(
         IOptionsMonitor<AuthenticationSchemeOptions> options,
         ILoggerFactory logger,
@@ -62,6 +68,17 @@ internal sealed class HeaderIdentityAuthenticationHandler : AuthenticationHandle
         var approver = Request.Headers[ApproverHeader].ToString();
         if (!string.IsNullOrEmpty(approver))
             claims.Add(new Claim("preferred_username", approver));
+
+        // Roles are opt-in per request, never granted by default. A test principal that silently held
+        // every role would make the role-gated surfaces pass their tests while the gate did nothing —
+        // and the point of a gate is the caller who does not get through it.
+        var roles = Request.Headers[RolesHeader].ToString();
+        if (!string.IsNullOrEmpty(roles))
+        {
+            claims.AddRange(roles
+                .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .Select(role => new Claim(ClaimTypes.Role, role)));
+        }
 
         return Task.FromResult(Success(claims));
     }


### PR DESCRIPTION
Closes Wave 3 item **E2** from `.claude/plans/external-trigger-api-scope.md`: `POST /api/evals/runs` as a 202 job on the W4 run substrate, plus dataset listing, status polling, cancellation, and in-process ingest on completion.

## The design point: datasets are named, never pathed

`RunEvalSuiteCommand` takes filesystem paths, which is right for the CLI — a developer pointing the runner at a file on their own machine. Exposing that shape over HTTP would make every request a filesystem reference, with a single guard standing between a caller and an arbitrary read.

So the wire contract has no path field. A caller sends a **name**; `IEvalDatasetCatalog` maps it to a file by **enumerating** the configured roots and matching what is actually there — never by concatenating the name onto a root. A name cannot express "outside the roots", so the dangerous request becomes unrepresentable rather than rejected. E1's `EvalDatasetPathGuard` stays underneath as the backstop: the wire shape makes the attack unsayable, the guard makes it ineffective.

Two consequences worth knowing: the catalog is top-level-only (a name carrying structure is a path with extra steps), and a host with no roots configured publishes nothing rather than enumerating its working directory.

## Security properties

| Property | Why |
|---|---|
| Gated on `Harness.Evals.Execute` | Every other route here runs the *caller's* work on the *caller's* grant. This one spends the host's model budget on the operator's suites — a different authority from holding a valid token. |
| The caller's `CapabilityEnvelope` is armed around the evaluation | Every case is a governed agent turn that can invoke tools. Without it, a caller reaches tools it is denied directly by putting them in an eval case. |
| Off by default, refuses to start without roots | Unchanged from E1. |
| Spend capped at admission | `MaxCaseExecutionsPerRun` counts cases × repeats and refuses rather than truncating. |
| A run's `TargetId` is its own job id | Admission refuses a second live run per target, which protects a workflow's shared plan state. Evaluations share nothing, so a dataset-derived target would serialize unrelated work rather than protect anything. |

## Substrate change

Run-scoped side tables are now released through `IRunReclaimListener` rather than by the sweeper naming each holder. The eval submission store is the second such holder after the progress broker; a third would otherwise be a constructor parameter someone could forget — an unbounded leak that does not fail to compile.

## Accepted limitation, stated rather than hidden

Cancelling a **queued** run stops it; a run already executing answers `200 {"stopped": false}` and runs to completion. A workflow in flight can be signalled through `IPlanRunCancellationRegistry`; an evaluation is a suite of agent turns with no equivalent. Claiming an interruption that will not happen would tell a caller the spend had stopped when it had not. The cost ceiling above is the real control.

## Test plan

- `EvalDatasetCatalogTests` — name resolution against **real directories**, deliberately: the property under test is that resolution enumerates, and a faked filesystem would pass just as happily against a concatenating implementation. Traversal cases plant real files at the traversal target.
- `EvalRunHandlerTests` — admission, ownership non-disclosure, submission/queue ordering, cancellation, against the real run and submission stores.
- `EvalRunKindExecutorTests` — envelope arming, resolution, report attachment, ingest, and that a failing suite is a *succeeded* run.
- `InMemoryEvalRunSubmissionStoreTests`, `RunRecordCleanupServiceTests` — reclaim fan-out and fault isolation.
- `EvalRunsIntegrationTests` — routes mounted; 401 unauthenticated, 403 authenticated-without-the-role, nothing served while disabled.

**21 mutations run; all killed.** Three tests were found vacuous by mutation and strengthened — the traversal cases had no file at the traversal target, the queue-ordering fake recorded only the last enqueue, and the guard's new root-cache invalidation had no test at all until its mutant survived.

Full solution: builds 0 errors, all eval/ExecutionApi/Core/Domain suites green. The 30 remaining failures are pre-existing and environmental (Postgres/Neo4j, metrics collector, and this machine's `TEMP` sitting under `C:\WINDOWS`).

## Reviewer note

The two-axis review caught a **factual error I had written into the code**: I justified skipping the spec's role gate by claiming this host has no role infrastructure. Five controllers already use `[Authorize(Roles = ...)]`. Both spec clauses I had missed — the role and in-process ingest — are implemented in the second commit.

Docs updated per the canonical *Change the wire contract* list: OpenAPI spec, Chapter 17, and the host README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BnoLcufW278UxA9ssBM1Tc