### PR TITLE
fix: clear 5 HIGH .NET advisories + 10 npm advisories, and gate both ecosystems in CI

### DIFF
--- a/.github/dependency-audit-allowlist.json
+++ b/.github/dependency-audit-allowlist.json
@@ -1,0 +1,23 @@
+{
+  "$comment": [
+    "Advisories consciously accepted, checked by .github/scripts/check-dependency-vulnerabilities.mjs.",
+    "Every entry needs a reason that says why the flaw is not reachable in THIS repo, not merely",
+    "that upgrading is inconvenient. Every entry also needs a reviewBy date: the gate fails once it",
+    "passes, so an exception cannot quietly become permanent. The gate also fails on entries that no",
+    "longer match a finding, so a fixed package cannot leave its exception behind."
+  ],
+  "accepted": [
+    {
+      "advisory": "GHSA-qwww-vcr4-c8h2",
+      "package": "react-router",
+      "reason": "RSC-mode CSRF bypass. Neither frontend runs React Router in RSC or framework mode: Presentation.WebUI uses BrowserRouter (declarative) and Presentation.Dashboard uses createBrowserRouter + RouterProvider (data mode), neither project has a react-router.config.* nor depends on @react-router/serve, and no server-side action handling exists for the bypass to reach. The fix is react-router 8.3.0 — a major upgrade across ~27 call sites — which is not justified for a code path that cannot execute. Re-assess if either app adopts framework or RSC mode.",
+      "reviewBy": "2027-02-01"
+    },
+    {
+      "advisory": "GHSA-qwww-vcr4-c8h2",
+      "package": "react-router-dom",
+      "reason": "Same advisory as the react-router entry above; react-router-dom is flagged only because it re-exports the affected package. Identical reasoning and identical review date.",
+      "reviewBy": "2027-02-01"
+    }
+  ]
+}

--- a/.github/dependency-audit-allowlist.json
+++ b/.github/dependency-audit-allowlist.json
@@ -17,7 +17,8 @@
       "advisory": "GHSA-qwww-vcr4-c8h2",
       "package": "react-router-dom",
       "reason": "Same advisory as the react-router entry above; react-router-dom is flagged only because it re-exports the affected package. Identical reasoning and identical review date.",
-      "reviewBy": "2027-02-01"
+      "reviewBy": "2027-02-01",
+      "coversFindingsWithoutAdvisoryUrl": true
     }
   ]
 }

--- a/.github/scripts/check-dependency-vulnerabilities.mjs
+++ b/.github/scripts/check-dependency-vulnerabilities.mjs
@@ -1,0 +1,285 @@
+#!/usr/bin/env node
+/**
+ * Supply-chain gate for both ecosystems in this repo: NuGet (the .NET solution) and
+ * npm (the two frontend projects).
+ *
+ * WHY THIS EXISTS
+ *
+ * NuGet's audit already detected `System.Security.Cryptography.Xml` 10.0.7 — five HIGH
+ * advisories — and emitted NU1903 on every single build for weeks. Nothing failed, because
+ * `src/Directory.Build.props` sets `TreatWarningsAsErrors=false` and no workflow ran the
+ * scan. The vulnerability was fixed by hand only once somebody happened to read the build
+ * log. This script is the missing enforcement: the next one fails a check instead of
+ * scrolling past.
+ *
+ * THE TWO EXIT-CODE TRAPS (the whole reason this is a script and not two `run:` lines)
+ *
+ *   1. `dotnet list package --vulnerable` exits 0 EVEN WITH HIGH-SEVERITY FINDINGS.
+ *      A naive `run:` step passes silently forever. The findings are only in stdout, so
+ *      the exit code is ignored here and stdout is parsed instead.
+ *
+ *   2. `npm audit` does the opposite — it exits NON-ZERO whenever any advisory exists, at
+ *      any severity. A naive step dies on a `low` finding and can never be green. Its exit
+ *      code is likewise ignored; `--json` output is parsed.
+ *
+ * Severity casing also differs between the two (`High` from dotnet, `high` from npm), so
+ * everything is lowercased before comparison.
+ *
+ * WHAT FAILS THE BUILD
+ *
+ *   - Any high or critical advisory that is not in the allowlist.
+ *   - Any allowlist entry whose `reviewBy` date has passed. An exception that cannot expire
+ *     is just a permanent hole with a comment attached; this forces a re-decision.
+ *   - Any allowlist entry that no longer matches a real finding (stale — delete it).
+ *
+ * Moderate and low findings are reported but do not fail. Raise MIN_FAIL_SEVERITY when the
+ * repo is ready for that.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { readFileSync, existsSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const SOLUTION = join(REPO_ROOT, 'src', 'AgenticHarness.slnx');
+const ALLOWLIST = join(REPO_ROOT, '.github', 'dependency-audit-allowlist.json');
+const NPM_PROJECTS = [
+  'src/Content/Presentation/Presentation.WebUI',
+  'src/Content/Presentation/Presentation.Dashboard',
+];
+
+const FAIL_SEVERITIES = new Set(['high', 'critical']);
+
+// npm ships as a .cmd shim on Windows, which execFileSync cannot spawn by bare name. CI runs
+// on Linux, but this has to work locally too — an unrunnable gate is one nobody checks before
+// pushing.
+const NPM = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+
+/**
+ * Runs a command, returning stdout even when the command exits non-zero.
+ *
+ * `useShell` exists only for npm on Windows: Node refuses to spawn a .cmd shim without a
+ * shell (hardening for CVE-2024-27980). It is deliberately NOT applied to dotnet — this
+ * repo's path contains a space ("Code Repos"), and shell mode joins argv without quoting,
+ * which would split the solution path and silently scan nothing.
+ */
+function runCapturingStdout(cmd, args, cwd, useShell = false) {
+  try {
+    return execFileSync(cmd, args, {
+      cwd,
+      encoding: 'utf8',
+      maxBuffer: 64 * 1024 * 1024,
+      shell: useShell,
+    });
+  } catch (err) {
+    // Both tools report findings on a non-zero exit (npm) or a zero exit (dotnet). Neither
+    // exit code is trustworthy, so take whatever landed on stdout and parse it.
+    if (err.stdout) return err.stdout;
+    throw err;
+  }
+}
+
+/**
+ * Parses `dotnet list package --vulnerable --include-transitive` output.
+ *
+ * The human-readable table is the only output format this command offers. Its shape:
+ *
+ *   Project `Presentation.Common` has the following vulnerable packages
+ *      [net10.0]:
+ *      Transitive Package                 Resolved   Severity   Advisory URL
+ *      > System.Security.Cryptography.Xml 10.0.7     High       https://…/GHSA-cvvh-rhrc-wg4q
+ *                                                    High       https://…/GHSA-g8r8-53c2-pm3f
+ *
+ * Note the second line: when one package carries several advisories, every advisory after
+ * the first is a CONTINUATION ROW with no package name. Matching only `>` rows still blocks
+ * correctly (the package is caught either way), but it would hide those advisory ids from
+ * the allowlist — an entry naming one of them would match nothing and be reported as stale,
+ * failing the build for the wrong reason. So continuation rows are attributed to the most
+ * recent package.
+ */
+function scanNuGet() {
+  if (!existsSync(SOLUTION)) {
+    throw new Error(`Solution not found at ${SOLUTION}`);
+  }
+
+  const stdout = runCapturingStdout(
+    'dotnet',
+    ['list', SOLUTION, 'package', '--vulnerable', '--include-transitive'],
+    REPO_ROOT,
+  );
+
+  const findings = [];
+  let currentProject = null;
+  let currentPackage = null;
+
+  const record = (name, severity, url) =>
+    findings.push({
+      ecosystem: 'nuget',
+      name,
+      severity: severity.toLowerCase(),
+      advisory: url,
+      project: currentProject ?? '(unknown project)',
+    });
+
+  for (const rawLine of stdout.split(/\r?\n/)) {
+    const line = rawLine.trim();
+
+    // dotnet wraps the project name in backticks; strip those so the reported name is clean.
+    const projectMatch = line.match(/^Project\s+[`'"]?(.+?)[`'"]?\s+has the following vulnerable packages/i);
+    if (projectMatch) {
+      currentProject = projectMatch[1];
+      currentPackage = null;
+      continue;
+    }
+
+    // "> Name  [Requested]  Resolved  Severity  URL" — whitespace-padded columns, and the
+    // transitive listing drops the Requested column, so anchor on the two trailing fields.
+    const packageRow = line.match(/^>\s+(\S+)\s+.*?\b(Critical|High|Moderate|Low)\b\s+(\S+)\s*$/i);
+    if (packageRow) {
+      const [, name, severity, url] = packageRow;
+      currentPackage = name;
+      record(name, severity, url);
+      continue;
+    }
+
+    // Continuation row: severity + url only, belonging to the package listed above it.
+    const continuationRow = line.match(/^(Critical|High|Moderate|Low)\s+(https?:\/\/\S+)\s*$/i);
+    if (continuationRow && currentPackage) {
+      const [, severity, url] = continuationRow;
+      record(currentPackage, severity, url);
+    }
+  }
+
+  return findings;
+}
+
+/** Parses `npm audit --json` for one project directory. */
+function scanNpm(relativeDir) {
+  const cwd = join(REPO_ROOT, relativeDir);
+  if (!existsSync(join(cwd, 'package.json'))) return [];
+
+  const stdout = runCapturingStdout(NPM, ['audit', '--json'], cwd, process.platform === 'win32');
+
+  let parsed;
+  try {
+    parsed = JSON.parse(stdout);
+  } catch {
+    throw new Error(`npm audit produced unparseable JSON in ${relativeDir}`);
+  }
+
+  const findings = [];
+  for (const [name, entry] of Object.entries(parsed.vulnerabilities ?? {})) {
+    const severity = String(entry.severity ?? '').toLowerCase();
+
+    // `via` holds either advisory objects or the names of packages that drag the flaw in.
+    // Only the objects carry a GHSA url; a purely indirect entry inherits its parent's.
+    const advisories = (entry.via ?? [])
+      .filter((v) => typeof v === 'object' && v.url)
+      .map((v) => v.url);
+
+    if (advisories.length === 0) {
+      findings.push({ ecosystem: 'npm', name, severity, advisory: null, project: relativeDir });
+      continue;
+    }
+
+    for (const advisory of advisories) {
+      findings.push({ ecosystem: 'npm', name, severity, advisory, project: relativeDir });
+    }
+  }
+
+  return findings;
+}
+
+function loadAllowlist() {
+  if (!existsSync(ALLOWLIST)) return [];
+  const parsed = JSON.parse(readFileSync(ALLOWLIST, 'utf8'));
+  const entries = parsed.accepted ?? [];
+
+  for (const entry of entries) {
+    for (const field of ['advisory', 'package', 'reason', 'reviewBy']) {
+      if (!entry[field]) {
+        throw new Error(`Allowlist entry missing required field "${field}": ${JSON.stringify(entry)}`);
+      }
+    }
+    if (Number.isNaN(Date.parse(entry.reviewBy))) {
+      throw new Error(`Allowlist entry has an unparseable reviewBy date: ${entry.reviewBy}`);
+    }
+  }
+
+  return entries;
+}
+
+function matches(entry, finding) {
+  if (entry.package !== finding.name) return false;
+  // An entry may pin an exact advisory, or cover a package whose finding carries no url.
+  return finding.advisory === null || finding.advisory.includes(entry.advisory);
+}
+
+function main() {
+  const findings = [...scanNuGet(), ...NPM_PROJECTS.flatMap(scanNpm)];
+  const allowlist = loadAllowlist();
+  const today = new Date();
+
+  const blocking = [];
+  const accepted = [];
+
+  for (const finding of findings) {
+    if (!FAIL_SEVERITIES.has(finding.severity)) continue;
+
+    const entry = allowlist.find((e) => matches(e, finding));
+    if (entry) accepted.push({ finding, entry });
+    else blocking.push(finding);
+  }
+
+  const expired = allowlist.filter((e) => new Date(e.reviewBy) < today);
+  // Keyed on package AND advisory: one advisory can legitimately need several entries (a
+  // flaw in a library plus the wrapper that re-exports it), and keying on advisory alone
+  // would let a genuinely stale entry hide behind its sibling.
+  const entryKey = (e) => `${e.package} ${e.advisory}`;
+  const usedEntries = new Set(accepted.map(({ entry }) => entryKey(entry)));
+  const stale = allowlist.filter((e) => !usedEntries.has(entryKey(e)));
+
+  const totals = findings.reduce((acc, f) => {
+    acc[f.severity] = (acc[f.severity] ?? 0) + 1;
+    return acc;
+  }, {});
+  console.log(`Scanned NuGet solution + ${NPM_PROJECTS.length} npm projects.`);
+  console.log(`Findings by severity: ${JSON.stringify(totals)}`);
+
+  if (accepted.length > 0) {
+    console.log('\nAccepted via allowlist:');
+    for (const { finding, entry } of accepted) {
+      console.log(`  - ${finding.name} (${finding.severity}) — ${entry.reason} [review by ${entry.reviewBy}]`);
+    }
+  }
+
+  let failed = false;
+
+  if (blocking.length > 0) {
+    failed = true;
+    console.error(`\n${blocking.length} blocking advisory finding(s):`);
+    for (const f of blocking) {
+      console.error(`  [${f.ecosystem}] ${f.name} (${f.severity}) in ${f.project}`);
+      if (f.advisory) console.error(`      ${f.advisory}`);
+    }
+    console.error('\nFix the package, or add a justified entry to .github/dependency-audit-allowlist.json.');
+  }
+
+  if (expired.length > 0) {
+    failed = true;
+    console.error('\nAllowlist entries past their review date — re-assess or extend:');
+    for (const e of expired) console.error(`  ${e.package} (${e.advisory}) was due ${e.reviewBy}`);
+  }
+
+  if (stale.length > 0) {
+    failed = true;
+    console.error('\nAllowlist entries matching no current finding — delete them:');
+    for (const e of stale) console.error(`  ${e.package} (${e.advisory})`);
+  }
+
+  if (failed) process.exit(1);
+  console.log('\nNo blocking vulnerabilities.');
+}
+
+main();

--- a/.github/scripts/check-dependency-vulnerabilities.mjs
+++ b/.github/scripts/check-dependency-vulnerabilities.mjs
@@ -32,8 +32,13 @@
  *     is just a permanent hole with a comment attached; this forces a re-decision.
  *   - Any allowlist entry that no longer matches a real finding (stale — delete it).
  *
- * Moderate and low findings are reported but do not fail. Raise MIN_FAIL_SEVERITY when the
- * repo is ready for that.
+ * Moderate and low findings are reported but do not fail. Widen FAIL_SEVERITIES when the repo
+ * is ready for that.
+ *
+ * Both scanners FAIL CLOSED: because neither tool's exit code is trustworthy, each parser
+ * demands positive evidence that the scan really ran, and throws rather than reporting an
+ * unscanned project as clean. A gate that can go quietly green is worse than no gate, because
+ * it is believed.
  */
 
 import { execFileSync } from 'node:child_process';
@@ -109,6 +114,23 @@ function scanNuGet() {
     REPO_ROOT,
   );
 
+  // Fail closed. `runCapturingStdout` deliberately swallows a non-zero exit (the command exits
+  // 0 even WITH high findings, so its exit code proves nothing either way). That same swallow
+  // means a genuine failure — a broken command, or an unreachable NuGet audit source, which
+  // merely warns and lists nothing while still exiting 0 — would parse to zero rows and take
+  // the gate green. So require positive evidence the scan actually evaluated projects: every
+  // project must be reported as either clean or vulnerable.
+  const evaluatedProjects =
+    /has no vulnerable packages given the current sources/i.test(stdout) ||
+    /has the following vulnerable packages/i.test(stdout);
+  if (!evaluatedProjects) {
+    throw new Error(
+      'dotnet list package --vulnerable produced no per-project verdict; the scan did not run. ' +
+        'Refusing to report the solution as clean.\n' +
+        stdout.trim().split(/\r?\n/).slice(-15).join('\n'),
+    );
+  }
+
   const findings = [];
   let currentProject = null;
   let currentPackage = null;
@@ -168,8 +190,22 @@ function scanNpm(relativeDir) {
     throw new Error(`npm audit produced unparseable JSON in ${relativeDir}`);
   }
 
+  // Fail closed. A failing `npm audit` — most commonly EUSAGE, when a PR edits package.json
+  // without regenerating the lock — still prints well-formed JSON, but with an `error` key and
+  // NO `vulnerabilities` key. Defaulting that to {} would report the project as clean and take
+  // the gate green on the exact desync it exists to catch. Demand the real shape instead.
+  if (parsed.error) {
+    const detail = parsed.error.summary ?? parsed.error.code ?? JSON.stringify(parsed.error);
+    throw new Error(`npm audit failed in ${relativeDir}: ${detail}`);
+  }
+  if (!parsed.vulnerabilities || typeof parsed.vulnerabilities !== 'object') {
+    throw new Error(
+      `npm audit returned no vulnerabilities map for ${relativeDir}; refusing to report it as clean.`,
+    );
+  }
+
   const findings = [];
-  for (const [name, entry] of Object.entries(parsed.vulnerabilities ?? {})) {
+  for (const [name, entry] of Object.entries(parsed.vulnerabilities)) {
     const severity = String(entry.severity ?? '').toLowerCase();
 
     // `via` holds either advisory objects or the names of packages that drag the flaw in.
@@ -212,8 +248,16 @@ function loadAllowlist() {
 
 function matches(entry, finding) {
   if (entry.package !== finding.name) return false;
-  // An entry may pin an exact advisory, or cover a package whose finding carries no url.
-  return finding.advisory === null || finding.advisory.includes(entry.advisory);
+
+  // Entries are advisory-scoped by default. A finding with no advisory url (an npm package
+  // flagged only because a dependency of it is vulnerable) can still be accepted, but the
+  // entry must OPT IN via `coversFindingsWithoutAdvisoryUrl`. Inferring that from the missing
+  // url instead would silently widen the exception to any FUTURE advisory in the same package
+  // that happens to arrive without a url — an allowlist that reads as advisory-scoped must
+  // not quietly behave as package-scoped.
+  if (finding.advisory === null) return entry.coversFindingsWithoutAdvisoryUrl === true;
+
+  return finding.advisory.includes(entry.advisory);
 }
 
 function main() {

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -1,0 +1,65 @@
+name: Dependency Audit
+
+# Two triggers, and the schedule is the important one.
+#
+# Path filters catch a dependency CHANGE. They cannot catch a newly published advisory
+# against code nobody touched — which is exactly how System.Security.Cryptography.Xml sat
+# vulnerable in this repo. The weekly run is what closes that gap; the path filters just
+# give faster feedback on PRs that move a version.
+on:
+  pull_request:
+    paths:
+      - '**/*.csproj'
+      - 'src/Directory.Packages.props'
+      - 'src/Directory.Build.props'
+      - '**/package.json'
+      - '**/package-lock.json'
+      - '.github/scripts/check-dependency-vulnerabilities.mjs'
+      - '.github/dependency-audit-allowlist.json'
+      - '.github/workflows/dependency-audit.yml'
+  push:
+    branches: [main]
+    paths:
+      - '**/*.csproj'
+      - 'src/Directory.Packages.props'
+      - 'src/Directory.Build.props'
+      - '**/package.json'
+      - '**/package-lock.json'
+      - '.github/scripts/check-dependency-vulnerabilities.mjs'
+      - '.github/dependency-audit-allowlist.json'
+      - '.github/workflows/dependency-audit.yml'
+  schedule:
+    # Mondays at 07:00 UTC. Catches advisories published against unchanged dependencies.
+    - cron: '0 7 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    name: NuGet and npm advisories
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+
+      # Restore populates the dependency graph that `dotnet list package --vulnerable`
+      # reads. Without it the command reports nothing and the gate passes vacuously.
+      - name: Restore NuGet packages
+        run: dotnet restore src/AgenticHarness.slnx
+
+      # No `npm ci` — `npm audit` resolves the tree from package-lock.json alone, and
+      # installing two frontends would triple this job's runtime for no added signal.
+      # No dependencies to install for the script itself; it uses only the Node stdlib.
+      - name: Check for vulnerable dependencies
+        run: node .github/scripts/check-dependency-vulnerabilities.mjs

--- a/src/Content/Presentation/Presentation.Dashboard/package-lock.json
+++ b/src/Content/Presentation/Presentation.Dashboard/package-lock.json
@@ -1269,13 +1269,13 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.14",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.12.tgz",
+      "integrity": "sha512-eWpQYr67tqJLeaSUl0Q+TquuYfUdTibpOJlUMV2FfUP7+KqCC5TufnwnlXL6mobZBJbGAYRd7ZvEBDCbLInjhg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"
@@ -1493,13 +1493,13 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
-      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@hono/node-server": "^1.19.9",
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",
@@ -2980,16 +2980,16 @@
       }
     },
     "node_modules/@ts-morph/common/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/@ts-morph/common/node_modules/minimatch": {
@@ -3380,16 +3380,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
@@ -3722,16 +3722,6 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
-    "node_modules/agent-base": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
-      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/ajv": {
       "version": "6.15.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
@@ -3895,13 +3885,13 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
-      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.19.0.tgz",
+      "integrity": "sha512-ht/iuYZXEjFxLH/Hkezgd7m6JKlHHXEUSneaDz8uZe1Gj5QZtCnpyDsckvAiEnT89OEbCLmnte4R4sn7P0EKFw==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.16.0",
-        "form-data": "^4.0.5",
+        "form-data": "^4.0.6",
         "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
       }
@@ -3962,21 +3952,21 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
-      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "debug": "^4.4.3",
-        "http-errors": "^2.0.0",
-        "iconv-lite": "^0.7.0",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
         "on-finished": "^2.4.1",
-        "qs": "^6.14.1",
-        "raw-body": "^3.0.1",
-        "type-is": "^2.0.1"
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
       },
       "engines": {
         "node": ">=18"
@@ -3986,10 +3976,24 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4344,15 +4348,15 @@
       "license": "MIT"
     },
     "node_modules/concurrently": {
-      "version": "9.2.3",
-      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.3.tgz",
-      "integrity": "sha512-ihjs0E2SxvDgq/MK418hX6YycQgKhsqxpbZuZbHo0yKfqDWdymWMjWYIpCIzqDDLLKClHlXev8whW/8WXmJ0BA==",
+      "version": "9.2.4",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.4.tgz",
+      "integrity": "sha512-TZ0CEhyzvFjgtAvHTusDMgj7wNdihCh7LLLrzdUOXIhdlnL2JBBGA9eJxR24rtqgmdjh3OA3hrN1rCHj6HM8qA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "chalk": "4.1.2",
         "rxjs": "7.8.2",
-        "shell-quote": "1.8.4",
+        "shell-quote": "1.9.0",
         "supports-color": "8.1.1",
         "tree-kill": "1.2.2",
         "yargs": "17.7.2"
@@ -4651,16 +4655,6 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/data-uri-to-buffer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
-      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
       }
     },
     "node_modules/data-urls": {
@@ -5541,9 +5535,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "dev": true,
       "funding": [
         {
@@ -5592,30 +5586,6 @@
         "picomatch": {
           "optional": true
         }
-      }
-    },
-    "node_modules/fetch-blob": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
-      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "node-domexception": "^1.0.0",
-        "web-streams-polyfill": "^3.0.3"
-      },
-      "engines": {
-        "node": "^12.20 || >= 14.13"
       }
     },
     "node_modules/fetch-cookie": {
@@ -5764,19 +5734,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/formdata-polyfill": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
-      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fetch-blob": "^3.1.2"
-      },
-      "engines": {
-        "node": ">=12.20.0"
       }
     },
     "node_modules/forwarded": {
@@ -6140,20 +6097,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/https-proxy-agent": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
-      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.2",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 14"
       }
     },
     "node_modules/human-signals": {
@@ -7413,9 +7356,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "funding": [
         {
           "type": "github",
@@ -7445,27 +7388,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/node-domexception": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-      "deprecated": "Use your platform's native DOMException instead",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "github",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.5.0"
       }
     },
     "node_modules/node-fetch": {
@@ -7929,9 +7851,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "funding": [
         {
           "type": "opencollective",
@@ -7948,7 +7870,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -8270,9 +8192,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.18.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.1.tgz",
-      "integrity": "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.2.tgz",
+      "integrity": "sha512-aUVMjFm3GAPTTZL7oYr5E7ETiqfQCHRLH+B+5afnICvf0r7kkK4eR6SMuwbSTJw/7t+12khT/Kahij49fqOCIg==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -8292,12 +8214,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.18.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.1.tgz",
-      "integrity": "sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.2.tgz",
+      "integrity": "sha512-AIKJ/jgGlFb3EbfCXk5Gzshiwt+l3mqbCrNjmEWMMjqQxNJ3svBa6bgzFyCC2Sw3RA0VWF1kg3uQf2OFhxb8hw==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.18.1"
+        "react-router": "7.18.2"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -8737,9 +8659,9 @@
       "license": "ISC"
     },
     "node_modules/shadcn": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/shadcn/-/shadcn-4.4.0.tgz",
-      "integrity": "sha512-0V1AjVktKwhK1e0ONXb9SeBoyJePH04iTSJeMjl9eROqjjyb8OoWYtWDI39UdBU3GzpUlFBJFohhB9c6fGOkQA==",
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/shadcn/-/shadcn-4.16.1.tgz",
+      "integrity": "sha512-XLFzfNNIUPlUlyheFEzj0H4Vnhi9nI0nl3Nfgg8HYXW1FkUVhVT1X+mgmOUW8aWL5SeG0A+yJIV5fm3Hr9MVkQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8760,10 +8682,7 @@
         "fast-glob": "^3.3.3",
         "fs-extra": "^11.3.1",
         "fuzzysort": "^3.1.0",
-        "https-proxy-agent": "^7.0.6",
         "kleur": "^4.1.5",
-        "msw": "^2.10.4",
-        "node-fetch": "^3.3.2",
         "open": "^11.0.0",
         "ora": "^8.2.0",
         "postcss": "^8.5.6",
@@ -8774,31 +8693,16 @@
         "tailwind-merge": "^3.0.1",
         "ts-morph": "^26.0.0",
         "tsconfig-paths": "^4.2.0",
+        "undici": "^7.27.2",
         "validate-npm-package-name": "^7.0.1",
         "zod": "^3.24.1",
         "zod-to-json-schema": "^3.24.6"
       },
       "bin": {
         "shadcn": "dist/index.js"
-      }
-    },
-    "node_modules/shadcn/node_modules/node-fetch": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
-      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "data-uri-to-buffer": "^4.0.0",
-        "fetch-blob": "^3.1.4",
-        "formdata-polyfill": "^4.0.10"
       },
       "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/node-fetch"
+        "node": ">=20.18.1"
       }
     },
     "node_modules/shadcn/node_modules/zod": {
@@ -8835,9 +8739,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
-      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.9.0.tgz",
+      "integrity": "sha512-Iov+JwFv/2HcTpcwNMKd8+IWNb8tboQJNQTkAY/LLVK7gGH9jy+LGkVqPxfekHl+yMmiqXszdGWXgkfml7hjqA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9415,18 +9319,36 @@
       }
     },
     "node_modules/type-is": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
-      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "media-typer": "^1.1.0",
         "mime-types": "^3.0.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/type-is/node_modules/mime-db": {
@@ -9894,16 +9816,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/web-streams-polyfill": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
-      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/webidl-conversions": {

--- a/src/Content/Presentation/Presentation.WebUI/package-lock.json
+++ b/src/Content/Presentation/Presentation.WebUI/package-lock.json
@@ -1325,13 +1325,13 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.14",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.12.tgz",
+      "integrity": "sha512-eWpQYr67tqJLeaSUl0Q+TquuYfUdTibpOJlUMV2FfUP7+KqCC5TufnwnlXL6mobZBJbGAYRd7ZvEBDCbLInjhg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"
@@ -1563,13 +1563,13 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
-      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@hono/node-server": "^1.19.9",
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",
@@ -2824,16 +2824,16 @@
       }
     },
     "node_modules/@ts-morph/common/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/@ts-morph/common/node_modules/minimatch": {
@@ -3207,16 +3207,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
@@ -3555,16 +3555,6 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
-    "node_modules/agent-base": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
-      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/ajv": {
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
@@ -3728,13 +3718,13 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
-      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.19.0.tgz",
+      "integrity": "sha512-ht/iuYZXEjFxLH/Hkezgd7m6JKlHHXEUSneaDz8uZe1Gj5QZtCnpyDsckvAiEnT89OEbCLmnte4R4sn7P0EKFw==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.16.0",
-        "form-data": "^4.0.5",
+        "form-data": "^4.0.6",
         "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
       }
@@ -3805,21 +3795,21 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
-      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "debug": "^4.4.3",
-        "http-errors": "^2.0.0",
-        "iconv-lite": "^0.7.0",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
         "on-finished": "^2.4.1",
-        "qs": "^6.14.1",
-        "raw-body": "^3.0.1",
-        "type-is": "^2.0.1"
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
       },
       "engines": {
         "node": ">=18"
@@ -3829,10 +3819,24 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4212,15 +4216,15 @@
       "license": "MIT"
     },
     "node_modules/concurrently": {
-      "version": "9.2.3",
-      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.3.tgz",
-      "integrity": "sha512-ihjs0E2SxvDgq/MK418hX6YycQgKhsqxpbZuZbHo0yKfqDWdymWMjWYIpCIzqDDLLKClHlXev8whW/8WXmJ0BA==",
+      "version": "9.2.4",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.4.tgz",
+      "integrity": "sha512-TZ0CEhyzvFjgtAvHTusDMgj7wNdihCh7LLLrzdUOXIhdlnL2JBBGA9eJxR24rtqgmdjh3OA3hrN1rCHj6HM8qA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "chalk": "4.1.2",
         "rxjs": "7.8.2",
-        "shell-quote": "1.8.4",
+        "shell-quote": "1.9.0",
         "supports-color": "8.1.1",
         "tree-kill": "1.2.2",
         "yargs": "17.7.2"
@@ -4389,16 +4393,6 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
-    },
-    "node_modules/data-uri-to-buffer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
-      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
-      }
     },
     "node_modules/data-urls": {
       "version": "7.0.0",
@@ -5310,9 +5304,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "dev": true,
       "funding": [
         {
@@ -5351,30 +5345,6 @@
         "picomatch": {
           "optional": true
         }
-      }
-    },
-    "node_modules/fetch-blob": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
-      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "node-domexception": "^1.0.0",
-        "web-streams-polyfill": "^3.0.3"
-      },
-      "engines": {
-        "node": "^12.20 || >= 14.13"
       }
     },
     "node_modules/fetch-cookie": {
@@ -5523,19 +5493,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/formdata-polyfill": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
-      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fetch-blob": "^3.1.2"
-      },
-      "engines": {
-        "node": ">=12.20.0"
       }
     },
     "node_modules/forwarded": {
@@ -6001,20 +5958,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/https-proxy-agent": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
-      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.2",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 14"
       }
     },
     "node_modules/human-signals": {
@@ -8225,9 +8168,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "funding": [
         {
           "type": "github",
@@ -8257,27 +8200,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/node-domexception": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-      "deprecated": "Use your platform's native DOMException instead",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "github",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.5.0"
       }
     },
     "node_modules/node-fetch": {
@@ -8799,9 +8721,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "funding": [
         {
           "type": "opencollective",
@@ -8818,7 +8740,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -9176,9 +9098,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.18.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.1.tgz",
-      "integrity": "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.2.tgz",
+      "integrity": "sha512-aUVMjFm3GAPTTZL7oYr5E7ETiqfQCHRLH+B+5afnICvf0r7kkK4eR6SMuwbSTJw/7t+12khT/Kahij49fqOCIg==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -9198,12 +9120,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.18.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.1.tgz",
-      "integrity": "sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.2.tgz",
+      "integrity": "sha512-AIKJ/jgGlFb3EbfCXk5Gzshiwt+l3mqbCrNjmEWMMjqQxNJ3svBa6bgzFyCC2Sw3RA0VWF1kg3uQf2OFhxb8hw==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.18.1"
+        "react-router": "7.18.2"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -9687,9 +9609,9 @@
       "license": "ISC"
     },
     "node_modules/shadcn": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/shadcn/-/shadcn-4.2.0.tgz",
-      "integrity": "sha512-ZDuV340itidaUd4Gi1BxQX+Y7Ush6BHp6URZBM2RyxUUBZ6yFtOWIr4nVY+Ro+YRSpo82v7JrsmtcU5xoBCMJQ==",
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/shadcn/-/shadcn-4.16.1.tgz",
+      "integrity": "sha512-XLFzfNNIUPlUlyheFEzj0H4Vnhi9nI0nl3Nfgg8HYXW1FkUVhVT1X+mgmOUW8aWL5SeG0A+yJIV5fm3Hr9MVkQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9710,10 +9632,7 @@
         "fast-glob": "^3.3.3",
         "fs-extra": "^11.3.1",
         "fuzzysort": "^3.1.0",
-        "https-proxy-agent": "^7.0.6",
         "kleur": "^4.1.5",
-        "msw": "^2.10.4",
-        "node-fetch": "^3.3.2",
         "open": "^11.0.0",
         "ora": "^8.2.0",
         "postcss": "^8.5.6",
@@ -9724,31 +9643,16 @@
         "tailwind-merge": "^3.0.1",
         "ts-morph": "^26.0.0",
         "tsconfig-paths": "^4.2.0",
+        "undici": "^7.27.2",
         "validate-npm-package-name": "^7.0.1",
         "zod": "^3.24.1",
         "zod-to-json-schema": "^3.24.6"
       },
       "bin": {
         "shadcn": "dist/index.js"
-      }
-    },
-    "node_modules/shadcn/node_modules/node-fetch": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
-      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "data-uri-to-buffer": "^4.0.0",
-        "fetch-blob": "^3.1.4",
-        "formdata-polyfill": "^4.0.10"
       },
       "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/node-fetch"
+        "node": ">=20.18.1"
       }
     },
     "node_modules/shadcn/node_modules/zod": {
@@ -9785,9 +9689,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
-      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.9.0.tgz",
+      "integrity": "sha512-Iov+JwFv/2HcTpcwNMKd8+IWNb8tboQJNQTkAY/LLVK7gGH9jy+LGkVqPxfekHl+yMmiqXszdGWXgkfml7hjqA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10393,18 +10297,36 @@
       }
     },
     "node_modules/type-is": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
-      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "media-typer": "^1.1.0",
         "mime-types": "^3.0.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/type-is/node_modules/mime-db": {
@@ -10987,16 +10909,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/web-streams-polyfill": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
-      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/webidl-conversions": {

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -130,7 +130,14 @@
     <PackageVersion Include="Microsoft.Extensions.Configuration.AzureAppConfiguration" Version="8.1.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.9" />
     <PackageVersion Include="Microsoft.AspNetCore.SpaProxy" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Identity.Web" Version="4.11.0" />
+    <!--
+      4.14.2 (not 4.11.0) because its Microsoft.Identity.Web.TokenCache dependency moved
+      System.Security.Cryptography.Xml from 10.0.7 to the patched 10.0.10. 10.0.0-10.0.9 carry five
+      HIGH advisories (CVE-2026-47302, -47304, -50525, -50527, -50648). Fixing it here rather than
+      pinning the transitive package keeps the graph honest: there is no direct dependency on
+      System.Security.Cryptography.Xml to explain. Do not lower this below 4.14.2.
+    -->
+    <PackageVersion Include="Microsoft.Identity.Web" Version="4.14.2" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />


### PR DESCRIPTION
## Why

Five HIGH advisories in `System.Security.Cryptography.Xml` 10.0.7 were resolving transitively into four projects. NuGet **had already detected them** — `NU1903` was emitted on every build for weeks — but `src/Directory.Build.props` sets `TreatWarningsAsErrors=false` and no workflow ran a scan, so nothing ever failed.

This matters more than usual here: consumers clone this template, so a vulnerable graph propagates to every downstream repo.

## What changed

**1. `.NET` — `Microsoft.Identity.Web` 4.11.0 → 4.14.2** (`d91946cf`)

The vulnerable package arrives via `Identity.Web → TokenCache`. 4.14.2 lifts that dependency to the patched **10.0.10** at source, so no direct `PackageReference` to a package nothing calls has to be introduced and later explained. Identity.Web 4.12–4.14 ship no breaking changes.

Clears CVE-2026-47302, -47304, -50525, -50527 (DoS) and -50648 (security feature bypass).

**2. Frontend — 10 of 12 advisories per app** (`0cea903b`)

`axios 1.16.1→1.19.0` · `postcss 8.5.16→8.5.25` · `shell-quote 1.8.4→1.9.0` · `fast-uri 3.1.2→3.1.5` · `brace-expansion 1.1.14→1.1.18` · `concurrently 9.2.3→9.2.4`

Lockfile-only — the declared `^` ranges already permitted the patched versions, so `package.json` is untouched in both apps.

**3. CI gate — `.github/workflows/dependency-audit.yml`** (`0cea903b`)

Scans NuGet **and** npm, fails on any un-allowlisted high/critical.

It is a script rather than two `run:` lines because both tools have **opposite exit-code traps**:

| Tool | Trap |
|---|---|
| `dotnet list package --vulnerable` | **Exits 0 WITH high findings** — a naive step passes forever |
| `npm audit` | **Exits non-zero on any finding, incl. `low`** — a naive step can never be green |

Both exit codes are ignored; stdout is parsed. Severity casing also differs (`High` vs `high`).

The allowlist requires a `reason` **and** a `reviewBy` date. The gate fails on **expired** entries, so an exception cannot quietly become permanent, and on entries matching **no finding**, so a fixed package cannot leave its exception behind.

The **weekly cron** matters more than the path filters: filters catch a dependency *change*, but only the schedule catches an advisory newly published against untouched code — exactly how the .NET one accumulated.

## Known exception

`react-router` / `react-router-dom` (GHSA-qwww-vcr4-c8h2) is allowlisted, not fixed. It is an **RSC-mode** CSRF bypass and neither app runs RSC or framework mode (WebUI uses `BrowserRouter`, Dashboard uses `createBrowserRouter`+`RouterProvider`, neither has `react-router.config.*` or `@react-router/serve`). The real fix is react-router **8.3.0** — a major upgrade across ~27 call sites — tracked separately.

Note `npm audit` proposes "7.11.0" for this, which is a **downgrade** below the vulnerable range opening at 7.12.0, not a fix. `fixAvailable` is not trustworthy here.

## Test plan

Verified by mutation, not by watching it pass:

- Revert Identity.Web to 4.11.0 → gate reports all 5 NuGet advisories, exits 1
- Remove the allowlist → gate blocks the 4 react-router findings, exits 1
- Backdate `reviewBy` → fails on expiry
- Add an entry for a healthy package → fails as stale
- Fixed tree → exits 0

Plus:

- Solution-wide `dotnet list package --vulnerable --include-transitive` now returns **nothing**
- Full build: **0 errors**
- **9,227 .NET tests pass**; the 25 failures are all the identical `Docker is either not running` Testcontainers error (no containers on the dev box) and are unrelated
- WebUI builds, **142 tests pass**; Dashboard builds, **385 tests pass**

Running the gate locally also caught two real bugs in it that review alone would not have: Node 22 refuses to spawn `npm.cmd` without `shell: true` (CVE-2024-27980 hardening), and the dotnet table hides extra advisories on continuation rows carrying no package name.

## Reviewer notes

- `main()` in the audit script is ~52 code lines against the under-50 convention — flat, unnested, left as-is rather than churning; happy to split into `analyse()`/`report()`.
- The workflow's path-filter list is duplicated for `pull_request` and `push`. GitHub Actions has no YAML anchors, so this is unavoidable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)