### PR TITLE
fix: bind review receipts to reviewed code, and gate .tsx

### DIFF
--- a/.claude/hooks/review-gate.ps1
+++ b/.claude/hooks/review-gate.ps1
@@ -4,21 +4,23 @@
 #
 # Fires on the Claude Code `PreToolUse` event for Bash. Before the agent is allowed
 # to `git push` or `gh pr create` a change that touches compilable source, this proves
-# that `/code-review` AND `/simplify` were actually run against the EXACT commit being
+# that `/code-review` AND `/simplify` were actually run against the EXACT code being
 # pushed — not the agent's recollection that it did them. A missing receipt blocks the
 # push and tells the agent to run the reviews.
 #
 # Why a gate and not a reminder: a written instruction to "run code-review before
 # pushing" is the same class of thing the agent forgets. The only reliable enforcement
-# is mechanical — the push refuses until per-commit review evidence exists. This mirrors
+# is mechanical — the push refuses until per-change review evidence exists. This mirrors
 # the borrowed principle: don't trust the agent to behave, force it with plain machinery.
 #
 # Scope decisions (deliberate, documented):
-#   * Only gates pushes/PRs whose branch diff vs the base touches compilable source
-#     (src/**). Docs-, memory-, and config-only pushes pass without review receipts.
-#   * Receipts are bound to the current HEAD short-SHA, so a review of older code does
-#     not satisfy a later commit. The working tree must be clean under src/ so HEAD is
-#     what actually gets pushed.
+#   * Only gates pushes/PRs whose branch diff vs the base touches reviewable source. The
+#     file list lives in review-scope.ps1 and is shared with the receipt writer.
+#   * Receipts are bound to a FINGERPRINT OF THE REVIEWABLE DIFF, not to the commit SHA.
+#     Reviewing code and then committing a markdown fix no longer discards the review;
+#     changing a single line of source still does. See review-scope.ps1 for the measured
+#     rationale — 6 of 7 receipted commits here changed no C# at all.
+#   * The working tree must be clean under src/ so HEAD is what actually gets pushed.
 #   * Skill-agnostic: it checks for review RECEIPTS, not for a specific tool. Receipts
 #     are written by save-review-receipt.ps1 when /code-review and /simplify complete.
 #   * Honors RAILS_SKIP_REVIEW_GATE=1 as a documented, auditable escape hatch.
@@ -30,6 +32,11 @@
 # Claude Code. A human running `git push` in their own terminal is NOT gated by this; the
 # server-side equivalent is a required CI check. This gate stops the agent from skipping
 # review, not every possible push.
+#
+# IMPORTANT — trust boundary: a receipt's CONTENT is whatever was piped into the writer.
+# This gate proves a receipt exists for this exact code; it cannot prove the review was
+# done well, or done at all. The non-forgeable enforcement is CI (correctness-review,
+# security-review, grader, OWASP), which re-derives its verdict server-side.
 #
 # Contract: emit a PreToolUse hookSpecificOutput with permissionDecision "deny" to block;
 # emit nothing (exit 0) to allow.
@@ -89,54 +96,49 @@ if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
   Allow
 }
 
-# --- Resolve the base to diff against. Prefer origin/main, then main. If neither
-#     resolves (unusual), fall back to the last commit so we can still scope on src/.
-$base = $null
-foreach ($ref in @('origin/main', 'main')) {
-  $resolved = & git rev-parse --verify --quiet "$ref" 2>$null
-  if ($LASTEXITCODE -eq 0 -and $resolved) { $base = $ref; break }
-}
+# Shared scope + fingerprint logic, so the enforcer and the receipt writer cannot drift.
+. (Join-Path $PSScriptRoot 'review-scope.ps1')
 
-if ($base) {
-  $changed = & git diff --name-only "$base...HEAD" 2>$null
-} else {
-  $changed = & git show --name-only --pretty=format: HEAD 2>$null
-}
+# --- Scope: only reviewable source triggers the gate.
+#     $null here means EITHER "nothing reviewable changed" OR "git could not compute the
+#     diff at all". Both allow, which is the pre-existing documented behaviour: the gate
+#     fails open when it cannot tell, and fails closed only when it can prove evidence is
+#     missing. The two are deliberately not distinguished — a gate that wedges the session
+#     on an unreadable repo gets disabled by the first person it blocks.
+$change = Get-ReviewableChange -Base (Resolve-ReviewBase)
+if (-not $change) { Allow }
 
-# Can't compute a diff at all — fail open rather than wedge the session.
-if ($LASTEXITCODE -ne 0) {
-  [Console]::Error.WriteLine('review-gate: could not compute branch diff; skipping.')
-  Allow
-}
-
-# --- Scope: only compilable source under src/ triggers the gate.
-$srcChanged = $changed | Where-Object { $_ -match '^src/.*\.(cs|csproj|slnx|props|targets|razor|cshtml|ts|html)$' }
-if (-not $srcChanged) { Allow }
-
-# --- The committed code under review must equal what gets pushed.
+# --- The committed code under review must equal what gets pushed. Deliberately broad:
+#     ANY dirty path under src/ blocks, not just reviewable ones. That is the fail-closed
+#     direction, and it costs nothing when the tree is clean, which is the normal case.
 $dirtySrc = & git status --porcelain -- 'src' 2>$null
 if ($dirtySrc) {
   Deny("Review gate: you have uncommitted changes under src/. Commit them first so the " +
-       "review covers exactly what you push, then run /code-review and /simplify on the final commit.")
+       "review covers exactly what you push, then run /code-review and /simplify on the final code.")
 }
 
-# --- Require a receipt for each review, bound to the exact commit being pushed.
-$sha = (& git rev-parse --short HEAD 2>$null)
-if ($LASTEXITCODE -ne 0 -or -not $sha) { Allow }   # detached/unborn — can't bind; don't wedge.
-$sha = $sha.Trim()
+# --- Require a receipt for each review, bound to the exact code being pushed.
+$fingerprint = Get-ReviewFingerprint -Change $change
+if (-not $fingerprint) {
+  Deny("Review gate: reviewable source changed under src/, but the review fingerprint could " +
+       "not be computed, so review evidence cannot be verified. Re-run the push; if it persists, " +
+       "inspect .claude/hooks/review-scope.ps1. Emergency bypass: set RAILS_SKIP_REVIEW_GATE=1.")
+}
 
 $receiptDir = Join-Path $projectDir '.claude/.review-receipts'
 $missing = @()
-if (-not (Test-Path (Join-Path $receiptDir "$sha.code-review"))) { $missing += '/code-review' }
-if (-not (Test-Path (Join-Path $receiptDir "$sha.simplify")))    { $missing += '/simplify' }
+if (-not (Test-Path (Join-Path $receiptDir "$fingerprint.code-review"))) { $missing += '/code-review' }
+if (-not (Test-Path (Join-Path $receiptDir "$fingerprint.simplify")))    { $missing += '/simplify' }
 
 if ($missing.Count -gt 0) {
   Deny("Review gate: src/ changed but [$($missing -join ', ')] " +
-       "$(if ($missing.Count -eq 1) {'has'} else {'have'}) not been run against commit $sha. " +
+       "$(if ($missing.Count -eq 1) {'has'} else {'have'}) not been run against the current code " +
+       "(fingerprint $fingerprint, $($change.Paths.Count) reviewable file(s)). " +
        "Run the missing review(s), then record each by piping its summary to " +
        ".claude/hooks/save-review-receipt.ps1 (e.g. `'...summary...' | pwsh -NoProfile -File " +
-       ".claude/hooks/save-review-receipt.ps1 -Kind code-review`). Re-run after re-committing any " +
-       "fixes the reviews produce. Emergency bypass: set RAILS_SKIP_REVIEW_GATE=1.")
+       ".claude/hooks/save-review-receipt.ps1 -Kind code-review`). Commits that change no " +
+       "reviewable source (docs, workflows) do NOT invalidate an existing receipt. " +
+       "Emergency bypass: set RAILS_SKIP_REVIEW_GATE=1.")
 }
 
 Allow

--- a/.claude/hooks/review-scope.ps1
+++ b/.claude/hooks/review-scope.ps1
@@ -1,0 +1,131 @@
+#!/usr/bin/env pwsh
+#
+# review-scope.ps1 — the single source of truth for "which code is under review, and what
+# exact content did the reviewer see". Dot-sourced by review-gate.ps1 (which enforces) and
+# save-review-receipt.ps1 (which records), so the two can never disagree about scope. When
+# the enforcer and the recorder each carry their own copy of this logic, they drift, and a
+# drifted gate silently passes unreviewed code.
+#
+# Why a content fingerprint instead of the commit SHA
+# ---------------------------------------------------
+# Receipts used to be named after the HEAD short-SHA. That binds review evidence to the
+# commit rather than to the code, and the two diverge as soon as a branch gains a commit
+# that touches no source. Measured on this repo (2026-08-02): of the 7 commits that carried
+# review receipts, 6 changed no C# whatsoever — 4 docs-only commits on PR #224 and 2
+# .github-only commits on PR #220. Every one of them invalidated both receipts and forced a
+# full re-review of byte-identical source. That was ~12 of 14 review passes spent re-reading
+# code that had not changed.
+#
+# Fingerprinting the reviewable diff fixes precisely that and nothing else:
+#   * a commit that leaves the reviewable source identical yields the SAME fingerprint, so
+#     the existing receipt still applies and no re-review is demanded;
+#   * ANY change to reviewable source yields a DIFFERENT fingerprint, so the gate re-arms
+#     exactly as it did before. Thoroughness is unchanged; only false alarms are removed.
+#
+# The fingerprint is taken over the diff TEXT (not just file names) so that reverting an
+# edit, or changing a file and changing it back, is correctly recognised as "same code".
+
+$ErrorActionPreference = 'Stop'
+# Read native exit codes explicitly; a non-zero git call must not throw before the caller
+# has had a chance to decide whether that means "allow" or "block".
+$PSNativeCommandUseErrorActionPreference = $false
+
+# Reviewable = first-party compilable source under src/. Deliberate inclusions/exclusions:
+#   * tsx/jsx: 175 tracked .tsx files exist across Presentation.WebUI and
+#     Presentation.Dashboard and were previously NOT matched, so every React component in
+#     both frontends escaped the gate entirely. jsx is listed alongside it because leaving
+#     it out would be an arbitrary gap in the same file class, not because any exist today.
+#   * js: only the two eslint.config.js files are first-party today. Included so lint-rule
+#     changes — which govern the quality bar itself — are reviewed.
+#   * json is EXCLUDED on purpose. package-lock.json churns by hundreds of lines on every
+#     dependency bump, and gating on it would reintroduce the exact "re-review unchanged
+#     C# because a non-source file moved" cost this script exists to remove.
+#   * node_modules/bin/obj are gitignored, so they can never appear in a git diff and need
+#     no explicit exclusion here.
+$script:ReviewablePattern = '^src/.*\.(cs|csproj|slnx|props|targets|razor|cshtml|ts|tsx|js|jsx|html)$'
+
+function Resolve-ReviewBase {
+  <#
+  .SYNOPSIS
+    Resolve the ref to diff against: origin/main, else main, else $null.
+  .OUTPUTS
+    The ref name, or $null when neither resolves (caller decides how to degrade).
+  #>
+  foreach ($ref in @('origin/main', 'main')) {
+    $resolved = & git rev-parse --verify --quiet $ref 2>$null
+    if ($LASTEXITCODE -eq 0 -and $resolved) { return $ref }
+  }
+  return $null
+}
+
+function Get-ReviewableChange {
+  <#
+  .SYNOPSIS
+    The reviewable source changed between $Base and $Head, as paths plus the diff text.
+  .DESCRIPTION
+    Uses three-dot (merge-base) diff semantics so that main moving forward underneath an
+    in-flight branch does NOT change the answer — only the branch's own commits do.
+  .OUTPUTS
+    A hashtable @{ Paths = string[]; Diff = string }, or $null when nothing reviewable
+    changed. Throws only if git itself is missing, which callers guard for.
+  #>
+  param(
+    [string]$Base,
+    [string]$Head = 'HEAD'
+  )
+
+  if ($Base) {
+    $changed = & git diff --name-only "$Base...$Head" 2>$null
+  } else {
+    # No base resolved (unusual: shallow clone, unborn main). Fall back to the tip commit's
+    # own files so the gate can still scope on src/ rather than failing silently open.
+    $changed = & git show --name-only --pretty=format: $Head 2>$null
+  }
+  if ($LASTEXITCODE -ne 0) { return $null }
+
+  $paths = @($changed | Where-Object { $_ -match $script:ReviewablePattern })
+  if ($paths.Count -eq 0) { return $null }
+
+  if ($Base) {
+    $diff = & git diff "$Base...$Head" -- $paths 2>$null
+  } else {
+    $diff = & git show --format= $Head -- $paths 2>$null
+  }
+  if ($LASTEXITCODE -ne 0) { return $null }
+
+  return @{
+    Paths = $paths
+    Diff  = ($diff -join "`n")
+  }
+}
+
+function Get-ReviewFingerprint {
+  <#
+  .SYNOPSIS
+    A short, stable hash identifying exactly the reviewable code a reviewer would read.
+  .DESCRIPTION
+    Two commits whose reviewable source diff is byte-identical share a fingerprint, so a
+    receipt recorded against one satisfies the other. Any difference in that diff — a real
+    code edit — produces a different fingerprint and re-arms the gate.
+  .OUTPUTS
+    16 hex characters, or $null when nothing reviewable changed.
+  #>
+  param(
+    [Parameter(Mandatory = $true)]
+    [AllowNull()]
+    $Change
+  )
+
+  if (-not $Change) { return $null }
+
+  $bytes = [System.Text.Encoding]::UTF8.GetBytes($Change.Diff)
+  $sha256 = [System.Security.Cryptography.SHA256]::Create()
+  try {
+    $hash = $sha256.ComputeHash($bytes)
+  } finally {
+    $sha256.Dispose()
+  }
+  # 8 bytes / 16 hex chars: collision risk is negligible for the handful of receipts a
+  # single clone ever holds, and short names keep the receipt directory readable.
+  return (-join ($hash[0..7] | ForEach-Object { $_.ToString('x2') }))
+}

--- a/.claude/hooks/save-review-receipt.ps1
+++ b/.claude/hooks/save-review-receipt.ps1
@@ -1,20 +1,26 @@
 #!/usr/bin/env pwsh
 #
-# save-review-receipt.ps1 — records that a review ran against the current commit, for the
+# save-review-receipt.ps1 — records that a review ran against the current code, for the
 # review gate (review-gate.ps1) to verify before a push/PR.
 #
 # Usage (pipe the review summary on stdin so the receipt is real evidence, not a flag):
-#   "...code-review findings...""  | pwsh -NoProfile -File .claude/hooks/save-review-receipt.ps1 -Kind code-review
-#   "...simplify findings..."       | pwsh -NoProfile -File .claude/hooks/save-review-receipt.ps1 -Kind simplify
+#   "...code-review findings..." | pwsh -NoProfile -File .claude/hooks/save-review-receipt.ps1 -Kind code-review
+#   "...simplify findings..."    | pwsh -NoProfile -File .claude/hooks/save-review-receipt.ps1 -Kind simplify
 #
-# The receipt is written to .claude/.review-receipts/<HEAD-short-sha>.<kind> so it is bound
-# to the exact commit. If you amend or add commits, the SHA changes and the gate re-arms,
-# forcing a fresh review of the final code. Receipts are gitignored (per-clone evidence).
+# The receipt is written to .claude/.review-receipts/<fingerprint>.<kind>, where the
+# fingerprint identifies the reviewable source diff itself (see review-scope.ps1) rather
+# than the commit that happens to contain it. Consequences, both intended:
+#   * Editing source and re-committing changes the fingerprint, so the gate re-arms and
+#     forces a fresh review of the final code — same as before.
+#   * Committing docs, workflows, or anything else non-reviewable leaves the fingerprint
+#     alone, so an existing receipt still applies and no re-review is demanded.
+# Receipts are gitignored (per-clone evidence).
 #
 # Honest scope: the receipt's CONTENT is whatever is piped in; this script binds it to the
-# commit and timestamps it, but it cannot verify the review was done well — that is on the
-# reviewer. Its value is mechanical: the push is blocked until a commit-bound receipt exists,
-# turning "might forget entirely" into "must produce per-commit, inspectable review evidence."
+# reviewed code and timestamps it, but it cannot verify the review was done well — that is
+# on the reviewer, and ultimately on CI, which re-derives its verdict server-side. This
+# script's value is mechanical: the push is blocked until code-bound review evidence
+# exists, turning "might forget entirely" into "must produce inspectable review evidence."
 
 [CmdletBinding()]
 param(
@@ -34,11 +40,25 @@ if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
   [Console]::Error.WriteLine('save-review-receipt: git not found.'); exit 1
 }
 
-$sha = (& git rev-parse --short HEAD 2>$null)
-if ($LASTEXITCODE -ne 0 -or -not $sha) {
-  [Console]::Error.WriteLine('save-review-receipt: cannot resolve HEAD.'); exit 1
+# Shared scope + fingerprint logic, so the receipt is named by exactly the rule the gate
+# will later check against.
+. (Join-Path $PSScriptRoot 'review-scope.ps1')
+
+$change = Get-ReviewableChange -Base (Resolve-ReviewBase)
+if (-not $change) {
+  [Console]::Error.WriteLine(
+    'save-review-receipt: no reviewable source changed vs the base, so there is nothing for ' +
+    'the gate to require a receipt for. Nothing written.')
+  exit 0
 }
-$sha = $sha.Trim()
+
+$fingerprint = Get-ReviewFingerprint -Change $change
+if (-not $fingerprint) {
+  [Console]::Error.WriteLine('save-review-receipt: could not compute the review fingerprint.'); exit 1
+}
+
+$sha = (& git rev-parse --short HEAD 2>$null)
+if ($LASTEXITCODE -ne 0 -or -not $sha) { $sha = '(unresolved)' } else { $sha = $sha.Trim() }
 
 $receiptDir = Join-Path $projectDir '.claude/.review-receipts'
 New-Item -ItemType Directory -Force -Path $receiptDir | Out-Null
@@ -46,8 +66,19 @@ New-Item -ItemType Directory -Force -Path $receiptDir | Out-Null
 $summary = [Console]::In.ReadToEnd()
 if (-not $summary) { $summary = "($Kind run; no summary piped)" }
 
-$header = "# $Kind receipt`ncommit: $sha`n`n"
-$path = Join-Path $receiptDir "$sha.$Kind"
+# Record the covered file list in the receipt so a human can audit what the review saw,
+# not just that some review happened.
+$header = @(
+  "# $Kind receipt",
+  "fingerprint: $fingerprint",
+  "recorded-at-commit: $sha",
+  "reviewed-files:"
+  ($change.Paths | ForEach-Object { "  - $_" })
+  ""
+) | Out-String
+
+$path = Join-Path $receiptDir "$fingerprint.$Kind"
 Set-Content -Path $path -Value ($header + $summary) -Encoding UTF8
 
-Write-Output "Saved $Kind receipt for commit $sha at .claude/.review-receipts/$sha.$Kind"
+Write-Output ("Saved $Kind receipt for fingerprint $fingerprint " +
+              "($($change.Paths.Count) reviewable file(s)) at .claude/.review-receipts/$fingerprint.$Kind")

--- a/.claude/hooks/tests/review-gate.tests.ps1
+++ b/.claude/hooks/tests/review-gate.tests.ps1
@@ -1,0 +1,170 @@
+#!/usr/bin/env pwsh
+#
+# review-gate.tests.ps1 — end-to-end proof that the review gate actually blocks and actually
+# releases, driven through its real stdin contract against a throwaway git repository.
+#
+# review-scope.tests.ps1 proves the scoping/fingerprint rules in isolation. This suite proves
+# the decision the agent actually experiences: deny when review evidence is missing for the
+# code being pushed, allow once it exists, keep allowing across a non-source commit, and deny
+# again the moment source changes. A gate that never blocks is worse than no gate, so the
+# blocking cases are asserted first and are not skippable.
+#
+# Run:  pwsh -NoProfile -File .claude/hooks/tests/review-gate.tests.ps1
+
+$ErrorActionPreference = 'Stop'
+$PSNativeCommandUseErrorActionPreference = $false
+
+$hooksDir  = Split-Path -Parent $PSScriptRoot
+$gate      = Join-Path $hooksDir 'review-gate.ps1'
+$writer    = Join-Path $hooksDir 'save-review-receipt.ps1'
+
+$script:Failures = 0
+$script:Ran = 0
+
+function Assert-That([string]$Name, [bool]$Condition, [string]$Detail = '') {
+  $script:Ran++
+  if ($Condition) {
+    Write-Host "  PASS  $Name" -ForegroundColor Green
+  } else {
+    $script:Failures++
+    Write-Host "  FAIL  $Name" -ForegroundColor Red
+    if ($Detail) { Write-Host "        $Detail" -ForegroundColor Red }
+  }
+}
+
+function Invoke-Gate([string]$Command, [string]$ToolName = 'Bash') {
+  <#
+    Drive the hook exactly as Claude Code does: a PreToolUse JSON payload on stdin. Returns
+    $true when the gate DENIED (emitted a deny decision), $false when it allowed.
+  #>
+  $payload = @{
+    tool_name  = $ToolName
+    tool_input = @{ command = $Command }
+  } | ConvertTo-Json -Compress -Depth 5
+
+  $out = $payload | pwsh -NoProfile -File $gate 2>$null
+  if (-not $out) { return $false }
+  return ([string]$out -match '"permissionDecision"\s*:\s*"deny"')
+}
+
+# --- Build a throwaway repo so the real one is never dirtied and real receipts are untouched.
+$tmp = Join-Path ([System.IO.Path]::GetTempPath()) ("review-gate-test-" + [guid]::NewGuid().ToString('N').Substring(0, 8))
+New-Item -ItemType Directory -Force -Path $tmp | Out-Null
+
+$originalProjectDir = $env:CLAUDE_PROJECT_DIR
+$originalSkip = $env:RAILS_SKIP_REVIEW_GATE
+$env:RAILS_SKIP_REVIEW_GATE = $null
+
+try {
+  & git -C $tmp init -b main --quiet
+  & git -C $tmp config user.email 'test@example.com'
+  & git -C $tmp config user.name 'Gate Test'
+
+  New-Item -ItemType Directory -Force -Path (Join-Path $tmp 'src/Content') | Out-Null
+  Set-Content -Path (Join-Path $tmp 'src/Content/Widget.cs') -Value 'public class Widget { }' -Encoding UTF8
+  Set-Content -Path (Join-Path $tmp 'README.md') -Value 'base' -Encoding UTF8
+  & git -C $tmp add -A
+  & git -C $tmp commit -q -m 'base'
+
+  & git -C $tmp checkout -q -b feature
+  Set-Content -Path (Join-Path $tmp 'src/Content/Widget.cs') -Value 'public class Widget { public int N; }' -Encoding UTF8
+  & git -C $tmp add -A
+  & git -C $tmp commit -q -m 'feat: change source'
+
+  $env:CLAUDE_PROJECT_DIR = $tmp
+
+  Write-Host ''
+  Write-Host 'Gating: which commands are even considered' -ForegroundColor Cyan
+
+  Assert-That 'a non-Bash tool is ignored' `
+    (-not (Invoke-Gate -Command 'git push' -ToolName 'Edit'))
+
+  Assert-That 'an unrelated Bash command is ignored' `
+    (-not (Invoke-Gate 'git status'))
+
+  Assert-That 'the word "git push" inside a quoted string does not trip the gate' `
+    (-not (Invoke-Gate 'echo "remember to git push later"'))
+
+  Write-Host ''
+  Write-Host 'Blocking: unreviewed source must NOT reach the remote' -ForegroundColor Cyan
+
+  Assert-That 'git push is DENIED with no receipts' `
+    (Invoke-Gate 'git push -u origin feature')
+
+  Assert-That 'gh pr create is DENIED with no receipts' `
+    (Invoke-Gate 'gh pr create --fill')
+
+  Assert-That 'git -C <path> push is DENIED too' `
+    (Invoke-Gate 'git -C . push')
+
+  Write-Host ''
+  Write-Host 'Releasing: recorded reviews unblock the push' -ForegroundColor Cyan
+
+  'code-review: no findings' | & pwsh -NoProfile -File $writer -Kind code-review | Out-Null
+  Assert-That 'still DENIED with only one of the two reviews' `
+    (Invoke-Gate 'git push')
+
+  'simplify: no findings' | & pwsh -NoProfile -File $writer -Kind simplify | Out-Null
+  Assert-That 'ALLOWED once both reviews are recorded' `
+    (-not (Invoke-Gate 'git push'))
+
+  Write-Host ''
+  Write-Host 'Economy: a non-source commit must not discard the reviews' -ForegroundColor Cyan
+
+  Set-Content -Path (Join-Path $tmp 'README.md') -Value 'docs update' -Encoding UTF8
+  & git -C $tmp add -A
+  & git -C $tmp commit -q -m 'docs: update readme'
+
+  Assert-That 'still ALLOWED after a docs-only commit' `
+    (-not (Invoke-Gate 'git push'))
+
+  Write-Host ''
+  Write-Host 'Thoroughness: a source change must re-arm the gate' -ForegroundColor Cyan
+
+  Set-Content -Path (Join-Path $tmp 'src/Content/Widget.cs') -Value 'public class Widget { public int N; public int M; }' -Encoding UTF8
+  & git -C $tmp add -A
+  & git -C $tmp commit -q -m 'feat: change source again'
+
+  Assert-That 'DENIED again after source changes' `
+    (Invoke-Gate 'git push')
+
+  # A .tsx-only change must gate too: before 2026-08-02 it did not, so every React component
+  # in both frontends could be pushed unreviewed.
+  & git -C $tmp checkout -q -b tsx-only main
+  New-Item -ItemType Directory -Force -Path (Join-Path $tmp 'src/Content/ui') | Out-Null
+  Set-Content -Path (Join-Path $tmp 'src/Content/ui/Panel.tsx') -Value 'export const Panel = () => null;' -Encoding UTF8
+  & git -C $tmp add -A
+  & git -C $tmp commit -q -m 'feat: add a react component'
+
+  Assert-That 'a .tsx-only change is DENIED without receipts' `
+    (Invoke-Gate 'git push')
+
+  Write-Host ''
+  Write-Host 'Escape hatch' -ForegroundColor Cyan
+
+  $env:RAILS_SKIP_REVIEW_GATE = '1'
+  Assert-That 'RAILS_SKIP_REVIEW_GATE=1 allows the push' `
+    (-not (Invoke-Gate 'git push'))
+  $env:RAILS_SKIP_REVIEW_GATE = $null
+
+  Write-Host ''
+  Write-Host 'Uncommitted work' -ForegroundColor Cyan
+
+  & git -C $tmp checkout -q feature
+  Set-Content -Path (Join-Path $tmp 'src/Content/Widget.cs') -Value 'public class Widget { public int Uncommitted; }' -Encoding UTF8
+  Assert-That 'a dirty src/ tree is DENIED' `
+    (Invoke-Gate 'git push')
+
+} finally {
+  $env:CLAUDE_PROJECT_DIR = $originalProjectDir
+  $env:RAILS_SKIP_REVIEW_GATE = $originalSkip
+  Remove-Item -Recurse -Force -Path $tmp -ErrorAction SilentlyContinue
+}
+
+Write-Host ''
+if ($script:Failures -gt 0) {
+  Write-Host "$script:Failures of $script:Ran assertions FAILED" -ForegroundColor Red
+  exit 1
+}
+Write-Host "All $script:Ran assertions passed" -ForegroundColor Green
+exit 0

--- a/.claude/hooks/tests/review-scope.tests.ps1
+++ b/.claude/hooks/tests/review-scope.tests.ps1
@@ -1,0 +1,135 @@
+#!/usr/bin/env pwsh
+#
+# review-scope.tests.ps1 — proves the review gate's scoping and fingerprint rules against
+# REAL history in this repository, not synthetic fixtures. Every commit referenced below
+# actually caused (or correctly caused) a review re-arm, so the test encodes why the
+# behaviour matters rather than merely what the function returns.
+#
+# Run:  pwsh -NoProfile -File .claude/hooks/tests/review-scope.tests.ps1
+# Exits non-zero on any failure so it can be wired into a gate later.
+#
+# The suite deliberately asserts in BOTH directions — pairs that must share a fingerprint
+# and pairs that must not. A fingerprint function that returned a constant would fail the
+# "differs" cases; one that returned noise would fail the "same" cases. Neither can pass
+# this suite trivially.
+
+$ErrorActionPreference = 'Stop'
+$PSNativeCommandUseErrorActionPreference = $false
+
+. (Join-Path $PSScriptRoot '..' 'review-scope.ps1')
+
+$script:Failures = 0
+$script:Ran = 0
+
+function Assert-That([string]$Name, [bool]$Condition, [string]$Detail = '') {
+  $script:Ran++
+  if ($Condition) {
+    Write-Host "  PASS  $Name" -ForegroundColor Green
+  } else {
+    $script:Failures++
+    Write-Host "  FAIL  $Name" -ForegroundColor Red
+    if ($Detail) { Write-Host "        $Detail" -ForegroundColor Red }
+  }
+}
+
+function Get-Fp([string]$Base, [string]$Head) {
+  $change = Get-ReviewableChange -Base $Base -Head $Head
+  return (Get-ReviewFingerprint -Change $change)
+}
+
+Write-Host ''
+Write-Host 'Scope: which files count as reviewable' -ForegroundColor Cyan
+
+# 175 tracked .tsx files exist across both frontends and were NOT matched by the gate's
+# original pattern, so every React component escaped review. This is the coverage fix.
+Assert-That 'a .tsx component under src/ is reviewable' `
+  ('src/Content/Presentation/Presentation.Dashboard/src/routes/Cost/CostPage.tsx' -match $script:ReviewablePattern)
+
+Assert-That 'a .ts module under src/ is reviewable' `
+  ('src/Content/Presentation/Presentation.Dashboard/src/lib/metricCatalog.ts' -match $script:ReviewablePattern)
+
+Assert-That 'a .cs file under src/ is reviewable' `
+  ('src/Content/Domain/Domain.AI/Skills/SkillAgentOptions.cs' -match $script:ReviewablePattern)
+
+Assert-That 'a first-party eslint.config.js is reviewable' `
+  ('src/Content/Presentation/Presentation.WebUI/eslint.config.js' -match $script:ReviewablePattern)
+
+# json is excluded on purpose: package-lock.json churns by hundreds of lines per dependency
+# bump, and gating on it would reintroduce the very waste this design removes.
+Assert-That 'package-lock.json is NOT reviewable' `
+  (-not ('src/Content/Presentation/Presentation.WebUI/package-lock.json' -match $script:ReviewablePattern))
+
+Assert-That 'a markdown file under src/ is NOT reviewable' `
+  (-not ('src/Content/Application/Application.AI.Common/README.md' -match $script:ReviewablePattern))
+
+Assert-That 'a file outside src/ is NOT reviewable' `
+  (-not ('documentation/onboarding/05-skills.html' -match $script:ReviewablePattern))
+
+Write-Host ''
+Write-Host 'Economy: non-source commits must NOT re-arm the gate' -ForegroundColor Cyan
+
+# PR #220 (base 6f53d285): d91946cf changed src/Directory.Packages.props; 0cea903b and
+# 504ef90d changed only .github/**. Under the old SHA binding all three demanded fresh
+# /code-review AND /simplify receipts — four review passes spent re-reading identical
+# source. All three must now share one fingerprint.
+$fp220_src     = Get-Fp '6f53d285' 'd91946cf'
+$fp220_github1 = Get-Fp '6f53d285' '0cea903b'
+$fp220_github2 = Get-Fp '6f53d285' '504ef90d'
+
+Assert-That 'PR #220 source commit produces a fingerprint' `
+  ($null -ne $fp220_src) "got: $fp220_src"
+
+Assert-That 'a .github-only follow-up keeps the same fingerprint' `
+  ($fp220_src -eq $fp220_github1) "$fp220_src vs $fp220_github1"
+
+Assert-That 'a second .github-only follow-up still keeps it' `
+  ($fp220_src -eq $fp220_github2) "$fp220_src vs $fp220_github2"
+
+# PR #224 (base c087decf): f19eb8ea changed source; 2fc6417c changed only a docs/ markdown
+# file. The docs commit must not discard the review.
+$fp224_src  = Get-Fp 'c087decf' 'f19eb8ea'
+$fp224_docs = Get-Fp 'c087decf' '2fc6417c'
+
+Assert-That 'a docs-only follow-up keeps the same fingerprint' `
+  ($fp224_src -eq $fp224_docs) "$fp224_src vs $fp224_docs"
+
+Write-Host ''
+Write-Host 'Thoroughness: real source changes MUST re-arm the gate' -ForegroundColor Cyan
+
+# 25519cc5 edited two .cs files on top of the docs commit. Its re-arm was legitimate and
+# must survive this change — this is the guard against buying economy with coverage.
+$fp224_code2 = Get-Fp 'c087decf' '25519cc5'
+
+Assert-That 'adding .cs edits changes the fingerprint' `
+  ($fp224_docs -ne $fp224_code2) "$fp224_docs vs $fp224_code2"
+
+# PR #225 (base 5de3fa1d): both commits changed C#. 46932441 fixed a real over-disclosure
+# defect found by reviewing 45c45a09, so the re-arm between them had to happen.
+$fp225_first  = Get-Fp '5de3fa1d' '45c45a09'
+$fp225_second = Get-Fp '5de3fa1d' '46932441'
+
+Assert-That 'PR #225 first commit produces a fingerprint' `
+  ($null -ne $fp225_first) "got: $fp225_first"
+
+Assert-That 'a follow-up source fix changes the fingerprint' `
+  ($fp225_first -ne $fp225_second) "$fp225_first vs $fp225_second"
+
+Write-Host ''
+Write-Host 'Degenerate cases' -ForegroundColor Cyan
+
+# A range touching no reviewable source must yield no fingerprint at all, so the gate
+# allows the push rather than demanding a receipt that could never be satisfied.
+$fpNone = Get-Fp '0cea903b' '504ef90d'
+Assert-That 'a range with no reviewable change yields no fingerprint' `
+  ($null -eq $fpNone) "got: $fpNone"
+
+Assert-That 'a null change yields no fingerprint' `
+  ($null -eq (Get-ReviewFingerprint -Change $null))
+
+Write-Host ''
+if ($script:Failures -gt 0) {
+  Write-Host "$script:Failures of $script:Ran assertions FAILED" -ForegroundColor Red
+  exit 1
+}
+Write-Host "All $script:Ran assertions passed" -ForegroundColor Green
+exit 0

--- a/.claude/rules/review-cadence.md
+++ b/.claude/rules/review-cadence.md
@@ -12,20 +12,33 @@ Do NOT skip these. Run them even when changes seem straightforward.
 
 This cadence is not an honor system. A `PreToolUse` hook (`.claude/hooks/review-gate.ps1`, wired
 in `.claude/settings.json`) **blocks `git push` and `gh pr create`** when the branch's diff touches
-compilable source (`src/**`) unless `/code-review` **and** `/simplify` have been recorded against the
-exact `HEAD` commit being pushed.
+reviewable source unless `/code-review` **and** `/simplify` have been recorded against the exact
+**code** being pushed.
 
-- **Recording a review:** pipe its summary to the helper, which binds the receipt to the current
-  commit:
+- **Recording a review:** pipe its summary to the helper, which binds the receipt to the reviewed
+  code:
   `"<review summary>" | pwsh -NoProfile -File .claude/hooks/save-review-receipt.ps1 -Kind code-review`
   (and again with `-Kind simplify`). Receipts live in the gitignored `.claude/.review-receipts/`.
-- **Re-arming:** amending or adding commits changes `HEAD`, so the gate demands a fresh review of the
-  final code. Run the reviews on the commit you actually push.
+- **Re-arming is content-based, not commit-based.** Receipts are named after a fingerprint of the
+  reviewable source diff (`.claude/hooks/review-scope.ps1`), so:
+  - changing a single line of source re-arms the gate and forces a fresh review — as before;
+  - committing docs, workflow YAML, or anything else non-reviewable **does not** discard the review.
+    Under the old `HEAD`-SHA binding it did, which cost four review passes on PR #220 alone
+    re-reading byte-identical source.
+- **Reviewable source** is `src/**` with a `.cs .csproj .slnx .props .targets .razor .cshtml .ts
+  .tsx .js .jsx .html` extension. `.tsx` matters: 175 tracked React components live under
+  `src/Content/Presentation/**` and were **not** gated before 2026-08-02. `.json` is excluded on
+  purpose so `package-lock.json` churn cannot force a full C# re-review.
 - **Scope:** docs-, memory-, and config-only pushes pass without receipts.
 - **Coverage boundary:** the hook only fires for pushes made *through Claude Code* — a human pushing
   from their own terminal is not gated (that is the server-side CI check's job). The hook stops the
   *agent* from skipping review.
+- **Trust boundary:** a receipt's content is whatever was piped in, so the gate proves a review was
+  recorded for this code, not that it was done well. The non-forgeable enforcement is CI
+  (`correctness-review`, `security-review`, `grader`, OWASP), which re-derives its verdict server-side.
 - **Emergency bypass:** set `RAILS_SKIP_REVIEW_GATE=1` (auditable; use sparingly).
+- **Tests:** `pwsh -NoProfile -File .claude/hooks/tests/review-scope.tests.ps1` asserts the scoping
+  and re-arm rules against real commits in this repo's history.
 
 ## After a Full Layer is Complete
 Run this additional skill:

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -19,7 +19,15 @@
       "Bash(gh pr diff:*)",
       "Bash(gh run list:*)",
       "Bash(gh run view:*)",
-      "Bash(gh api repos/:*)"
+      "Bash(gh pr checks:*)",
+      "Bash(gh issue list:*)",
+      "Bash(gh issue view:*)",
+      "Bash(gh api repos/:*)",
+      "Bash(git rev-parse:*)",
+      "Bash(git ls-files:*)",
+      "Bash(git merge-base:*)",
+      "Bash(dotnet list package:*)",
+      "Bash(ls:*)"
     ],
     "ask": [
       "Bash(git push:*)",


### PR DESCRIPTION
## What

Two changes to the review gate, both driven by measurement of this repo's own history.

### 1. Receipts bind to the code, not the commit

Receipts were named after the `HEAD` short-SHA. That binds review evidence to the *commit* rather than to the *code*, and the two diverge as soon as a branch gains a commit touching no source.

Measured on PR #220: `0cea903b` and `504ef90d` changed only `.github/**`. Each discarded both receipts and forced a full re-review of byte-identical C# — four review passes spent re-reading unchanged code.

Receipts are now named after a fingerprint of the reviewable source diff. A non-source commit carries the review forward; any real code change re-arms the gate exactly as before. **No thoroughness is traded away** — only false alarms are removed.

### 2. `.tsx` was never gated

The reviewable-file pattern matched `.ts` but not `.tsx`, so all **175 tracked React components** under `src/Content/Presentation/**` could be pushed without any review receipt. Adds `tsx`, `jsx`, `js`.

`.json` stays excluded on purpose — gating it would let `package-lock.json` churn force a full C# re-review, which is the exact cost this PR removes.

### Structure

Scope and fingerprint logic moved into `review-scope.ps1`, dot-sourced by both the enforcer and the receipt writer. Two copies of this rule would drift, and a drifted gate silently passes unreviewed code.

## Honest scope

This does **not** reduce re-reviews caused by reviews finding real defects — those re-arms are correct and were the majority of recent ones. Verified tally across the 7 receipted commits: only 2 were genuine waste. The win here is real but modest; the `.tsx` hole is arguably the bigger find.

## Test plan

Two new suites, 29 assertions, run with:

```
pwsh -NoProfile -File .claude/hooks/tests/review-scope.tests.ps1   # 16 assertions
pwsh -NoProfile -File .claude/hooks/tests/review-gate.tests.ps1    # 13 assertions
```

- `review-scope.tests.ps1` asserts against **real commits** in this repo (#220, #224, #225) — the same commits that caused the waste.
- `review-gate.tests.ps1` drives the hook through its real stdin contract against a throwaway git repo: denies without receipts, denies with only one of two, releases on both, **stays released across a docs commit**, re-arms on source change, denies a `.tsx`-only change, honors the bypass, denies a dirty tree.

Both suites mutation-tested. Dropping `tsx` from the pattern, neutering the fingerprint, and reintroducing SHA binding each fail the suites in the predicted place — the SHA-binding mutation fails **exactly one** assertion (the economy one) with every safety assertion still passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)