### PR TITLE
fix: make the security gate fire on agent-context and gate-config changes

### DIFF
--- a/.github/RAILS.md
+++ b/.github/RAILS.md
@@ -166,7 +166,11 @@ Before trusting these, force each one to fail and confirm it's caught:
   gated path (a comment in a file under `**/Auth/`) or on the content signal (any
   `src/**` change touching `OwnerId`/`[Authorize]`). The check must go red. Close it
   unmerged. `bash .github/scripts/security-gate-scope.test.sh` verifies the trigger
-  itself — including replaying the six PRs the old folder-only filter missed.
+  itself, by replaying every PR the gate is known to have missed: the six the
+  folder-only filter skipped (#203–#210), #215's path confinement, #227's dead
+  tool-permission control, and #226's rewrite of the push gate. Each miss was a
+  category the trigger had no word for, so a new miss belongs in that suite before
+  it is fixed.
 - **correctness-review** — open a throwaway PR with a planted high-confidence
   defect under `src/` (e.g. an inverted null check or an off-by-one that drops a
   row). The check must go red with `CORRECTNESS_VERDICT: BLOCK`; then apply the

--- a/.github/scripts/security-gate-scope.sh
+++ b/.github/scripts/security-gate-scope.sh
@@ -85,9 +85,22 @@ CHANGED_FILES="$(git diff --name-only "$MERGE_BASE" "$HEAD_REF")"
 # ---------------------------------------------------------------------------
 # `scripts/rails/` is here because those scripts ARE the gates — a change to
 # run-gates.sh is a change to what gets reviewed, exactly like a change to
-# .github/. It is the only addition to the original list; everything else is
-# preserved verbatim, so this trigger can only widen, never narrow.
-PATH_RE='(^\.github/|^scripts/rails/|/Auth/|/Identity/|/Security/|/SecurityAttributes/|/Migrations/|^infra/)'
+# .github/. Additions only; everything from the original list is preserved
+# verbatim, so this trigger can only widen, never narrow.
+#
+# `.claude/hooks/` is the same argument one directory over, and it was missed.
+# PR #226 rewrote the push gate — review-gate.ps1, review-scope.ps1,
+# save-review-receipt.ps1 and both of their test suites, five files that decide
+# whether ANY review happens at all — and raised no path signal, because the list
+# named the rails but not the hooks. A change to the thing that decides what gets
+# reviewed is the change most worth reviewing.
+#
+# `.claude/settings.json` is listed with them because it is where the hooks are WIRED.
+# Gating the hook scripts while leaving their registration ungated protects the lock
+# and not the door: deleting the PreToolUse entry disables the push gate completely
+# without touching a single gated file. `.json` is excluded from the CONTENT scan by
+# design (package-lock churn), so only this path entry can catch it.
+PATH_RE='(^\.github/|^scripts/rails/|^\.claude/(hooks/|settings\.json$)|/Auth/|/Identity/|/Security/|/SecurityAttributes/|/Migrations/|^infra/)'
 
 # ---------------------------------------------------------------------------
 # Signal 2 — security-relevant code, by what the changed lines actually contain.
@@ -127,6 +140,32 @@ PATH_RE='(^\.github/|^scripts/rails/|/Auth/|/Identity/|/Security/|/SecurityAttri
 #   only in code that is about egress control — so the signal stays specific while
 #   every ordinary outbound call stays silent. Both halves are pinned by tests:
 #   touching the policy fires, holding an HttpClient does not.
+#
+#   ChatMessage (115 tracked files) is excluded for the same reason as HttpClient: it
+#   is ordinary agent plumbing present in nearly every conversation path. AIContext is
+#   in, at 27 — the two words look adjacent and are two orders of magnitude apart in
+#   how often they appear. Count before adding.
+#
+# THE GAP THAT ADDED THE LAST TWO GROUPS
+# --------------------------------------
+# PR #227 moved GoverningToolContextProvider off AIContextProvider's ADDITIVE
+# ProvideAIContextAsync hook onto InvokingCoreAsync. Implemented on the additive hook
+# the provider was inert: the base merge restores everything it dropped and publishes
+# an unwrapped copy of everything it wrapped, so a tool-permission control that reads
+# as enforcing enforced nothing. That is a security control that was dead in production —
+# and this gate scored the PR that fixed it required=false, trigger=none, signals=(none).
+# Replayed against the isolated fix commit alone it still scored zero, so it was not
+# dilution by a large diff; the vocabulary simply had no word for the agent-context
+# surface. CLAUDE.md records this same defect landing four separate times.
+#
+# The gate is now on its third widening of exactly this shape — folder-only missed
+# #203-#210, the content list missed #215's path confinement, and it missed #227's
+# agent context. Each time the fix was a category the list had no word for, so the two
+# groups below name this repo's remaining AI-security surfaces rather than only the one
+# that just bit: ambient scope propagation (AsyncLocal is how knowledge scope reaches
+# child scopes and post-turn background writes), the sanctioned identity resolver
+# (GetUserIdOrNull — CLAUDE.md forbids a second precedence ladder, so a change here is
+# the scope-isolation defect class), approval bypass, and content-safety.
 # ---------------------------------------------------------------------------
 CONTENT_RE='(\[Authorize|AllowAnonymous|ClaimsPrincipal|RequireClaim|AuthenticationScheme|AuthorizationPolicy|IAuthorizationHandler'          # authn/authz
 CONTENT_RE="${CONTENT_RE}"'|OwnerId|TenantId|KnowledgeScope|VisibleTo|WritableBy'                                                             # scope isolation — this repo's recurring defect class
@@ -137,7 +176,11 @@ CONTENT_RE="${CONTENT_RE}"'|GetFullPath|ResolveLinkTarget|LinkTarget|IsPathRoote
 CONTENT_RE="${CONTENT_RE}"'|EgressPolicy|EgressAllowlist|AntiSSRF|Ssrf|SSRF'                                                                   # egress control (the SSRF guard, not the mechanism)
 CONTENT_RE="${CONTENT_RE}"'|FromSqlRaw|FromSqlInterpolated|ExecuteSqlRaw|ExecuteSqlInterpolated'                                               # raw SQL — the one escape from EF Core's parameterisation
 CONTENT_RE="${CONTENT_RE}"'|Process\.Start|ProcessStartInfo|ZipArchive|ExtractToDirectory|BinaryFormatter|TypeNameHandling|XmlSerializer'     # code execution + unsafe deserialization
-CONTENT_RE="${CONTENT_RE}"'|Sanitiz|Redact|Scrub)'                                                                                            # output safety
+CONTENT_RE="${CONTENT_RE}"'|Sanitiz|Redact|Scrub'                                                                                             # output safety
+# AIContext subsumes AIContextProvider (27 tracked files vs 25) and so also fires on a
+# line that merely builds or returns the context, not only on one naming the base type.
+CONTENT_RE="${CONTENT_RE}"'|AIContext|InvokingCoreAsync|ProvideAIContextAsync|GovernedAIFunction|ToolPermissionFilter|ReservedPlanCapability'  # agent context merge + tool governance
+CONTENT_RE="${CONTENT_RE}"'|GetUserIdOrNull|AsyncLocal|AutoApprove|HumanGate|ContentSafety|PromptInjection)'                                   # identity, ambient scope, approval bypass, content safety
 
 # Prose is excluded from the content scan — a security guide legitimately says
 # "password" on every page. Everything else that ships or executes is scanned,

--- a/.github/scripts/security-gate-scope.sh
+++ b/.github/scripts/security-gate-scope.sh
@@ -100,7 +100,13 @@ CHANGED_FILES="$(git diff --name-only "$MERGE_BASE" "$HEAD_REF")"
 # and not the door: deleting the PreToolUse entry disables the push gate completely
 # without touching a single gated file. `.json` is excluded from the CONTENT scan by
 # design (package-lock churn), so only this path entry can catch it.
-PATH_RE='(^\.github/|^scripts/rails/|^\.claude/(hooks/|settings\.json$)|/Auth/|/Identity/|/Security/|/SecurityAttributes/|/Migrations/|^infra/)'
+#
+# `settings.local.json` is matched too, and deliberately has NO test pinning it: it is
+# gitignored, so it can never appear in a diff and a synthetic case cannot stage one.
+# That unreachability is exactly why the alternative is here rather than omitted — the
+# day someone un-ignores it, the gate should already cover it instead of discovering
+# the hole the way it discovered this one.
+PATH_RE='(^\.github/|^scripts/rails/|^\.claude/(hooks/|settings(\.local)?\.json$)|/Auth/|/Identity/|/Security/|/SecurityAttributes/|/Migrations/|^infra/)'
 
 # ---------------------------------------------------------------------------
 # Signal 2 — security-relevant code, by what the changed lines actually contain.

--- a/.github/scripts/security-gate-scope.sh
+++ b/.github/scripts/security-gate-scope.sh
@@ -141,19 +141,20 @@ PATH_RE='(^\.github/|^scripts/rails/|^\.claude/(hooks/|settings\.json$)|/Auth/|/
 #   every ordinary outbound call stays silent. Both halves are pinned by tests:
 #   touching the policy fires, holding an HttpClient does not.
 #
-#   ChatMessage (115 tracked files) is excluded for the same reason as HttpClient: it
-#   is ordinary agent plumbing present in nearly every conversation path. AIContext is
-#   in, at 27 — the two words look adjacent and are two orders of magnitude apart in
-#   how often they appear. Count before adding.
+#   ChatMessage (105 tracked .cs files, the same basis as the 101 above) is excluded for
+#   the same reason as HttpClient: it is ordinary agent plumbing present in nearly every
+#   conversation path. AIContext is in, at 27. The two words look equally
+#   security-adjacent and differ four-fold in how often they appear, which is the whole
+#   argument for counting rather than reasoning category-by-category. Count before adding.
 #
 # THE GAP THAT ADDED THE LAST TWO GROUPS
 # --------------------------------------
 # PR #227 moved GoverningToolContextProvider off AIContextProvider's ADDITIVE
 # ProvideAIContextAsync hook onto InvokingCoreAsync. Implemented on the additive hook
 # the provider was inert: the base merge restores everything it dropped and publishes
-# an unwrapped copy of everything it wrapped, so a tool-permission control that reads
-# as enforcing enforced nothing. That is a security control that was dead in production —
-# and this gate scored the PR that fixed it required=false, trigger=none, signals=(none).
+# an unwrapped copy of everything it wrapped. A tool-permission control that reads as
+# enforcing was enforcing nothing: a security control dead in production. This gate
+# scored the PR that fixed it required=false, trigger=none, signals=(none).
 # Replayed against the isolated fix commit alone it still scored zero, so it was not
 # dilution by a large diff; the vocabulary simply had no word for the agent-context
 # surface. CLAUDE.md records this same defect landing four separate times.
@@ -179,6 +180,9 @@ CONTENT_RE="${CONTENT_RE}"'|Process\.Start|ProcessStartInfo|ZipArchive|ExtractTo
 CONTENT_RE="${CONTENT_RE}"'|Sanitiz|Redact|Scrub'                                                                                             # output safety
 # AIContext subsumes AIContextProvider (27 tracked files vs 25) and so also fires on a
 # line that merely builds or returns the context, not only on one naming the base type.
+# ProvideAIContextAsync is therefore redundant for TRIGGERING — but grep -oE reports the
+# leftmost-longest alternative, so listing it makes `signals` name the additive hook by
+# its own name instead of the generic AIContext. Kept for that legibility, not for reach.
 CONTENT_RE="${CONTENT_RE}"'|AIContext|InvokingCoreAsync|ProvideAIContextAsync|GovernedAIFunction|ToolPermissionFilter|ReservedPlanCapability'  # agent context merge + tool governance
 CONTENT_RE="${CONTENT_RE}"'|GetUserIdOrNull|AsyncLocal|AutoApprove|HumanGate|ContentSafety|PromptInjection)'                                   # identity, ambient scope, approval bypass, content safety
 

--- a/.github/scripts/security-gate-scope.test.sh
+++ b/.github/scripts/security-gate-scope.test.sh
@@ -65,9 +65,17 @@ expect() { # <label> <expected-required> <expected-trigger> <base> <head>
 # A PR's diff is (first parent = main at merge time) .. (second parent = PR head).
 # Using the head's OWN parent instead would diff only the branch's last commit,
 # which silently under-reports every multi-commit PR.
+#
+# The empty-merge guard is load-bearing on a shallow clone, which is what CI checks out.
+# `git rev-parse "^1"` fails — but it ECHOES `^1` back on stdout before it does, and these
+# helpers capture stdout with stderr suppressed. Without the explicit check the caller
+# receives the non-empty string `^1`, its `[ -z ... ]` SKIP guard never engages, and the
+# replay runs against an unresolvable base: the suite goes red for an environment reason
+# rather than a gate defect. That is the failure mode most likely to get a genuine future
+# regression waved through as "that's just the shallow clone again".
 pr_merge() { git log origin/main --merges --format=%H --grep "Merge pull request #$1 " -n 1; }
-pr_base()  { git rev-parse "$(pr_merge "$1")^1" 2>/dev/null; }
-pr_head()  { git rev-parse "$(pr_merge "$1")^2" 2>/dev/null; }
+pr_base()  { local m; m="$(pr_merge "$1")"; [ -n "$m" ] || return 0; git rev-parse "$m^1" 2>/dev/null; }
+pr_head()  { local m; m="$(pr_merge "$1")"; [ -n "$m" ] || return 0; git rev-parse "$m^2" 2>/dev/null; }
 
 echo "REPLAY — PRs the folder-only filter skipped (all must now be reviewed):"
 for pr in 203 205 207 208 209 210; do
@@ -264,8 +272,9 @@ if git worktree add --detach --quiet "$WORKTREE" HEAD 2>/dev/null; then
 
   # The noise boundary for the new group, pinned in the must-NOT-fire direction.
   # ChatMessage is the adjacent word someone will reach for while reasoning
-  # category-by-category: it looks as security-relevant as AIContext and appears in 115
-  # tracked files against AIContext's 27. Ordinary conversation plumbing is not a signal.
+  # category-by-category: it looks as security-relevant as AIContext and appears in 105
+  # tracked .cs files against AIContext's 27 — the same basis the script's own comment
+  # quotes. Ordinary conversation plumbing is not a signal.
   synth "ordinary ChatMessage use must NOT fire (too common to be a signal)" \
         "src/Content/Domain/Domain.AI/ScratchTest.cs" \
         "public sealed class ScratchTest { public object Make(string t) => new ChatMessage(ChatRole.User, t); }" \

--- a/.github/scripts/security-gate-scope.test.sh
+++ b/.github/scripts/security-gate-scope.test.sh
@@ -95,6 +95,36 @@ else
 fi
 
 echo
+# #227 fixed a security control that was DEAD IN PRODUCTION: GoverningToolContextProvider
+# had been implemented on AIContextProvider's additive ProvideAIContextAsync hook, where
+# the base merge restores every tool it drops and publishes an unwrapped copy of every
+# tool it wraps. The gate scored that PR required=false, signals=(none) — and scored the
+# isolated fix commit the same way, so it was not dilution by a large diff. The list had
+# no word for the agent-context surface at all. This is the #215 failure one category
+# over, and it is the case that must never go quiet again.
+echo "REPLAY — the PR the CONTENT filter skipped (agent context / tool governance):"
+head="$(pr_head 227)"; base="$(pr_base 227)"
+if [ -n "$head" ] && [ -n "$base" ]; then
+  expect "#227 (dead tool-permission control, no authz/scope markers)" true content "$base" "$head"
+  expect_scope_contains "#227 names the provider" "$base" "$head" "GoverningToolContextProvider.cs"
+else
+  echo "  SKIP  #227 (merge commit not found in this clone)"
+fi
+
+echo
+# #226 rewrote the push gate itself — five files under .claude/hooks/ that decide whether
+# any review happens at all — and raised no signal, because the path list named
+# scripts/rails/ but not .claude/hooks/. Same reasoning, one directory over.
+echo "REPLAY — the PR the PATH filter skipped (the review gate itself):"
+head="$(pr_head 226)"; base="$(pr_base 226)"
+if [ -n "$head" ] && [ -n "$base" ]; then
+  expect "#226 (rewrote the push gate)" true path "$base" "$head"
+  expect_scope_contains "#226 names the gate script" "$base" "$head" ".claude/hooks/review-gate.ps1"
+else
+  echo "  SKIP  #226 (merge commit not found in this clone)"
+fi
+
+echo
 # #199 changed gated paths AND security-relevant code. Under the old exclusive
 # branching it reported `path` and its src/ files never reached the scope file;
 # reporting `path+content` is the fix, not a regression.
@@ -201,6 +231,46 @@ if git worktree add --detach --quiet "$WORKTREE" HEAD 2>/dev/null; then
         "public sealed record ScratchTest { public string? OwnerId { get; init; } }" \
         true content
 
+  # The agent-context group. A provider that subtracts or rewrites on the additive hook
+  # is silently inert, so a diff that touches either hook must be read by a human.
+  synth "src change overriding the additive context hook" \
+        "src/Content/Domain/Domain.AI/ScratchTest.cs" \
+        "public sealed class ScratchTest { protected override ValueTask<AIContext> ProvideAIContextAsync(InvokingContext c) => default; }" \
+        true content
+
+  synth "src change overriding the context merge" \
+        "src/Content/Domain/Domain.AI/ScratchTest.cs" \
+        "public sealed class ScratchTest { protected override ValueTask<object> InvokingCoreAsync(object c) => default; }" \
+        true content
+
+  synth "src change wrapping a tool in the governance decorator" \
+        "src/Content/Domain/Domain.AI/ScratchTest.cs" \
+        "public sealed class ScratchTest { public object Wrap(object f) => new GovernedAIFunction(f); }" \
+        true content
+
+  # Ambient scope: AsyncLocal is how knowledge scope reaches child scopes and post-turn
+  # background writes, and an unscoped read is world-readable, not empty.
+  synth "src change to ambient scope propagation" \
+        "src/Content/Domain/Domain.AI/ScratchTest.cs" \
+        "public static class ScratchTest { private static readonly System.Threading.AsyncLocal<string> Current = new(); }" \
+        true content
+
+  # The one sanctioned identity resolver. CLAUDE.md forbids a second precedence ladder,
+  # so any change to it or its callers is the scope-isolation defect class.
+  synth "src change to the sanctioned identity resolver" \
+        "src/Content/Domain/Domain.AI/ScratchTest.cs" \
+        "public static class ScratchTest { public static string? Go(object p) => p.GetUserIdOrNull(); }" \
+        true content
+
+  # The noise boundary for the new group, pinned in the must-NOT-fire direction.
+  # ChatMessage is the adjacent word someone will reach for while reasoning
+  # category-by-category: it looks as security-relevant as AIContext and appears in 115
+  # tracked files against AIContext's 27. Ordinary conversation plumbing is not a signal.
+  synth "ordinary ChatMessage use must NOT fire (too common to be a signal)" \
+        "src/Content/Domain/Domain.AI/ScratchTest.cs" \
+        "public sealed class ScratchTest { public object Make(string t) => new ChatMessage(ChatRole.User, t); }" \
+        false none
+
   synth "TypeScript touching credentials (frontend is scanned too)" \
         "src/Content/Presentation/agent-hub-ui/src/scratchTest.ts" \
         "export const authHeader = (apiKey: string) => ({ Authorization: \`Bearer \${apiKey}\` });" \
@@ -235,6 +305,28 @@ if git worktree add --detach --quiet "$WORKTREE" HEAD 2>/dev/null; then
   RAILS="$(git -C "$WORKTREE" rev-parse HEAD)"
   expect "a change to run-gates.sh is itself gated" true path "$BASE" "$RAILS"
   expect_scope_contains "  scope names the rails script" "$BASE" "$RAILS" "scripts/rails/run-gates.sh"
+  git -C "$WORKTREE" reset -q --hard "$BASE" >/dev/null 2>&1
+
+  # The push-gate hooks ARE the gates, exactly like the rails scripts. A .ps1 carries no
+  # marker of its own, so only the path list can catch it — and it did not, until #226
+  # had already rewritten all five files unreviewed.
+  printf '%s\n' "# scratch" >> "$WORKTREE/.claude/hooks/review-gate.ps1"
+  git -C "$WORKTREE" add -A >/dev/null 2>&1
+  git -C "$WORKTREE" -c user.email=t@t -c user.name=t commit -qm "test: push gate hook" >/dev/null 2>&1
+  HOOKS="$(git -C "$WORKTREE" rev-parse HEAD)"
+  expect "a change to review-gate.ps1 is itself gated" true path "$BASE" "$HOOKS"
+  expect_scope_contains "  scope names the push-gate hook" "$BASE" "$HOOKS" ".claude/hooks/review-gate.ps1"
+  git -C "$WORKTREE" reset -q --hard "$BASE" >/dev/null 2>&1
+
+  # Gating the hook scripts but not their registration protects the lock and not the
+  # door — the PreToolUse entry can be deleted from settings.json alone, disabling the
+  # push gate without touching a gated file. .json is excluded from the content scan,
+  # so the path list is the only thing that can catch this.
+  printf '%s\n' '{"hooks":{}}' > "$WORKTREE/.claude/settings.json"
+  git -C "$WORKTREE" add -A >/dev/null 2>&1
+  git -C "$WORKTREE" -c user.email=t@t -c user.name=t commit -qm "test: unwire the hooks" >/dev/null 2>&1
+  UNWIRE="$(git -C "$WORKTREE" rev-parse HEAD)"
+  expect "unwiring the hooks in settings.json is gated" true path "$BASE" "$UNWIRE"
   git -C "$WORKTREE" reset -q --hard "$BASE" >/dev/null 2>&1
 
   # A scope file must never be empty while the gate says review is required.


### PR DESCRIPTION
## The miss

The security gate scored **PR #227 `required=false, trigger=none, signals=(none)`** — the PR that fixed a tool-permission control (`GoverningToolContextProvider`) which had been **dead in production**, implemented on `AIContextProvider`'s additive hook where the base merge restores every tool it drops and publishes an unwrapped copy of every tool it wraps.

```
CAUSE:     CONTENT_RE had no word for the agent-context surface.
CONTROL:   The gate's own suite, same instrument — 30 passed, 0 failed, including
           synthetic OwnerId, [Authorize], egress-policy, raw-SQL and path-confinement
           cases. The script fires correctly; it did not know these words.
COVERAGE:  Explains #227 completely. Replayed against the ISOLATED fix commit
           (30bf1164) alone it still scored zero, so this was not dilution by a
           large diff. It does NOT explain #226 — that is a second, separate gap.
```

This is the gate's **third miss of the same shape**: folder-only missed #203–#210, the content list missed #215's path confinement, and it missed #227's agent context. Each time the fix was a category the list had no word for — so this change names the repo's remaining AI-security surfaces rather than only the one that just bit.

## The second gap, found while controlling

**PR #226 rewrote the push gate itself** — `review-gate.ps1`, `review-scope.ps1`, `save-review-receipt.ps1` and both test suites, five files that decide whether *any* review happens — and raised no path signal. The list named `scripts/rails/` ("those scripts ARE the gates") but not `.claude/hooks/`. Same argument, one directory over.

`.claude/settings.json` is gated with them because it is where the hooks are **wired**. Gating the hook scripts but not their registration protects the lock and not the door: deleting the `PreToolUse` entry disables the push gate without touching a gated file, and `.json` is excluded from the content scan by design.

## Every added word was counted

Per **tracked file**, not per grep hit — the noisiest addition is `AsyncLocal` at 45 of 3,705. Fire rate measured by replaying both vocabularies across the **last 25 merges to main**:

| Vocabulary | Merges firing |
|---|---|
| Before | 21 / 25 |
| + agent context & tool governance | 22 / 25 (+#227) |
| + identity, ambient scope, approval, content safety | 23 / 25 (+#206, PlanExecutor cancellation, on `AsyncLocal`) |

`ChatMessage` (105 tracked `.cs` files against `AIContext`'s 27) is pinned as **must-NOT-fire** — the adjacent word someone reasoning category-by-category would reach for next.

## Test plan

`bash .github/scripts/security-gate-scope.test.sh` — **43 passed, 0 failed** (was 30).

New: replays of #227 (`content`) and #226 (`path`) with scope-file assertions, five synthetics for the new markers, a `.claude/settings.json` unwiring case, and the `ChatMessage` noise boundary.

**All new assertions were mutation-tested** — each added signal stripped in turn, confirming only its own assertions fail:

| Mutant | Result |
|---|---|
| agent-context group removed | 5 failures, all #227/agent-context |
| identity + ambient-scope group removed | 2 failures, both its own |
| whole `.claude/` path entry removed | 5 failures, all #226/hooks/settings |
| `settings.json` alone removed | 1 failure, the unwiring case |
| `ChatMessage` **added** | 1 failure, the noise boundary rejected it |
| restored | 43 passed, 0 failed |

## Worth flagging

The gate already fires on **84% of merges** (21/25) before this change. The script's own header warns that a gate which always fires gets triaged as noise. Widening is still right — the misses are real and the words are specific — but if fire rate is the concern, the answer is better *scoping* of what the reviewer reads, not a narrower trigger. Raising it as a separate question, not trimming this fix for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SDpwZrPazixLPuNMcUtEPM
