### PR TITLE
ci: run both frontends' test suites, blocking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,59 @@ jobs:
           name: coverage
           path: coverage/
 
+  # Until this job existed, NOTHING in CI ran npm: not a build, not a test, not a lint.
+  # The two frontends carry 527 passing tests (Dashboard 385 in 52 files, WebUI 142 in 26)
+  # that no pipeline had ever executed, and 175 tracked .tsx files that reached main on the
+  # strength of local runs alone. This job is the first leg — tests only, and blocking from
+  # the day it lands because both suites are already green.
+  #
+  # Typecheck and lint are deliberately NOT here yet. Both are currently red (39 production
+  # type errors across the two projects, 44 lint errors), and a step that runs without
+  # failing the build is not a gate — this repo has already paid for that lesson twice in
+  # the security gate. They arrive in their own PRs, each blocking on arrival, once the
+  # errors they would report are fixed.
+  #
+  # No `paths:` filter, on purpose. A job that only sometimes runs is the same trap one
+  # level up, and these two suites finish in well under the .NET job's five minutes, so
+  # they cost no wall-clock — they run alongside it, not after it.
+  frontend-tests:
+    name: frontend tests (${{ matrix.project }})
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    strategy:
+      # Report both frontends on every run. With fail-fast, a Dashboard failure would
+      # cancel the WebUI job and hide whether that one was broken too, turning two
+      # independent signals into one.
+      fail-fast: false
+      matrix:
+        project: [ Presentation.Dashboard, Presentation.WebUI ]
+
+    defaults:
+      run:
+        working-directory: src/Content/Presentation/${{ matrix.project }}
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          # Matches dependency-audit.yml. Both package.json files require >=20.18.1.
+          node-version: '22'
+          cache: npm
+          cache-dependency-path: src/Content/Presentation/${{ matrix.project }}/package-lock.json
+
+      # `npm ci` rather than `npm install`: it installs exactly the tracked lockfile and
+      # fails if package.json and package-lock.json disagree, so a hand-edited dependency
+      # cannot pass CI while resolving to something else on a developer's machine.
+      - name: Install
+        run: npm ci
+
+      - name: Tests
+        run: npm run test
+
   owasp-agentic-gate:
     name: OWASP Agentic Top-10 Gate
     runs-on: ubuntu-latest


### PR DESCRIPTION
## The gap

**Nothing in CI has ever run `npm`** — not a build, not a test, not a lint. The only Node in the pipeline is `npm audit` (dependency-audit) and a docs-link script.

Meanwhile both frontends carry test suites that pass and that no pipeline has ever executed:

| | Tests | Files | Local runtime |
|---|---|---|---|
| Presentation.Dashboard | 385 | 52 | 21s |
| Presentation.WebUI | 142 | 26 | 13s |

**527 tests**, alongside 175 tracked `.tsx` files that reached `main` on the strength of local runs alone.

## Why tests only

This is the first of three PRs. Typecheck and lint are deliberately absent because **both are currently red**:

| | Typecheck | Lint |
|---|---|---|
| Dashboard | 241 errors — 218 share one cause (jest-dom matchers untyped), **14 in production source** | 26 errors, 5 warnings |
| WebUI | 25 errors, **all production source** | 18 errors, 1 warning |

A step that runs without failing the build is not a gate, and this repo has already paid for that lesson twice in the security gate. Typecheck and lint each arrive in their own PR, blocking on arrival, once the errors they would report are fixed.

Tests can go blocking **today** because they already pass.

## Separately found — the typecheck is a no-op even locally

```
CAUSE:     Both frontends' root tsconfig.json is `"files": []` plus project references,
           and their build script runs `tsc --noEmit` (not `tsc -b`), which does not
           follow references. The typecheck step compiles ZERO files.
CONTROL:   Same instrument at tsconfig.app.json: 166 files for Dashboard, and it reports
           real errors. tsc works; the config selects nothing.
COVERAGE:  Explains the no-op typecheck on both frontends. Does NOT explain the missing
           tests/lint — that has no cause beyond "no job was ever written".
```

Verified with `tsc --noEmit --listFiles -p tsconfig.json` → **0 lines** on both. Fixed in PR 2 of 3, together with the errors it exposes.

The 39 production type errors are not cosmetic. `Kpi.tsx:45` passes props to `Sparkline` that do not exist on its type (silently ignored at runtime); `CatalogPage.tsx` passes `string | undefined` where `string` is required in ten places; `useAgentStream.ts:131` shows `@ag-ui/client` bundling **its own duplicate copy of rxjs**, so two incompatible `Subscription` types are in play.

## Design notes

- **No `paths:` filter, on purpose.** A job that only sometimes runs is the same trap one level up. These suites finish well inside the .NET job's five minutes and run *alongside* it, so they cost no wall-clock.
- **`fail-fast: false`** — a Dashboard failure must not cancel the WebUI job and collapse two independent signals into one.
- **`npm ci`, not `npm install`** — fails if `package.json` and the lockfile disagree, so a hand-edited dependency cannot pass CI while resolving differently on a developer's machine. Both lockfiles verified in sync via `npm ci --dry-run`.
- **Job-scoped `permissions: contents: read`.** Most workflows here set one; `ci.yml` is the outlier. Scoped to the new job so the existing jobs' behaviour is untouched.
- **Node 22**, matching `dependency-audit.yml`; both `package.json` files require `>=20.18.1`.

## Test plan

Both suites run green locally (Windows). **Linux is unverified until this workflow runs** — that is what this PR's own CI execution proves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SDpwZrPazixLPuNMcUtEPM
