### PR TITLE
ci: make the frontend typecheck real, and fix the 55 errors it exposed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,17 +80,16 @@ jobs:
   # strength of local runs alone. This job is the first leg — tests only, and blocking from
   # the day it lands because both suites are already green.
   #
-  # Typecheck and lint are deliberately NOT here yet. Both are currently red (39 production
-  # type errors across the two projects, 44 lint errors), and a step that runs without
-  # failing the build is not a gate — this repo has already paid for that lesson twice in
-  # the security gate. They arrive in their own PRs, each blocking on arrival, once the
-  # errors they would report are fixed.
+  # Lint is deliberately still absent: it is red (44 errors across the two projects), and a
+  # step that runs without failing the build is not a gate — this repo has already paid for
+  # that lesson twice in the security gate. It arrives in its own PR, blocking on arrival,
+  # once those errors are fixed.
   #
   # No `paths:` filter, on purpose. A job that only sometimes runs is the same trap one
   # level up, and these two suites finish in well under the .NET job's five minutes, so
   # they cost no wall-clock — they run alongside it, not after it.
   frontend-tests:
-    name: frontend tests (${{ matrix.project }})
+    name: frontend (${{ matrix.project }})
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -124,7 +123,17 @@ jobs:
       - name: Install
         run: npm ci
 
+      # `tsc -b`, not `tsc --noEmit`. The root tsconfig is `files: []` plus project
+      # references, and plain --noEmit does not follow references — so the old build step
+      # compiled zero files and exited 0 while every source file went unchecked. Build mode
+      # walks the app, node and test projects.
+      - name: Typecheck
+        run: npm run typecheck
+
+      # Runs even when the typecheck fails, so one CI run reports both signals instead of
+      # hiding the test result behind the first red step.
       - name: Tests
+        if: '!cancelled()'
         run: npm run test
 
   owasp-agentic-gate:

--- a/src/Content/Presentation/Presentation.Dashboard/package.json
+++ b/src/Content/Presentation/Presentation.Dashboard/package.json
@@ -9,7 +9,8 @@
   "scripts": {
     "dev": "vite --port 5174",
     "dev:all": "concurrently -n \"API,DASH\" -c \"cyan,green\" \"dotnet run --project ../Presentation.AgentHub\" \"vite --port 5174\"",
-    "build": "tsc --noEmit && vite build",
+    "build": "tsc -b && vite build",
+    "typecheck": "tsc -b",
     "lint": "eslint .",
     "preview": "vite preview",
     "test": "vitest run",

--- a/src/Content/Presentation/Presentation.Dashboard/src/components/context/ContextDrawer.tsx
+++ b/src/Content/Presentation/Presentation.Dashboard/src/components/context/ContextDrawer.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useMemo, type KeyboardEvent as ReactKeyboardEvent } from 'react';
 import * as Dialog from '@radix-ui/react-dialog';
 import { ChevronLeft, ChevronRight, X } from 'lucide-react';
-import { cn } from '@/lib/utils';
 import { CATEGORY_LABEL, type CategoryKey } from '@/lib/categories';
 import { CategorySwatch } from './CategorySwatch';
 

--- a/src/Content/Presentation/Presentation.Dashboard/src/components/context/ScrubStrip.test.tsx
+++ b/src/Content/Presentation/Presentation.Dashboard/src/components/context/ScrubStrip.test.tsx
@@ -55,9 +55,11 @@ describe('ScrubStrip', () => {
   });
 
   it('does not render sparkline when only one turn exists', () => {
+    // turns is the 4-element literal declared above, so index 0 is present by
+    // construction — the non-null assertion states that rather than guessing at it.
     render(
       <ScrubStrip
-        turns={[turns[0]]}
+        turns={[turns[0]!]}
         activeIndex={-1}
         onScrub={() => {}}
         showSparkline

--- a/src/Content/Presentation/Presentation.Dashboard/src/components/panels/PanelGrid.tsx
+++ b/src/Content/Presentation/Presentation.Dashboard/src/components/panels/PanelGrid.tsx
@@ -2,11 +2,16 @@ import { cn } from '@/lib/utils';
 
 interface PanelGridProps {
   children: React.ReactNode;
-  columns?: 2 | 3 | 4;
+  columns?: 1 | 2 | 3 | 4;
   className?: string;
 }
 
+// 1 is a real caller need (BudgetPage's full-width Alerts panel) and was being passed
+// already. Without an entry here `colClasses[1]` was undefined, so the grid rendered with no
+// column class at all and only looked correct because a bare `grid` falls back to one
+// column. Stating it explicitly makes the layout intentional rather than incidental.
 const colClasses = {
+  1: 'grid-cols-1',
   2: 'grid-cols-1 md:grid-cols-2',
   3: 'grid-cols-1 md:grid-cols-2 lg:grid-cols-3',
   4: 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-4',

--- a/src/Content/Presentation/Presentation.Dashboard/src/components/primitives/Kpi.tsx
+++ b/src/Content/Presentation/Presentation.Dashboard/src/components/primitives/Kpi.tsx
@@ -1,14 +1,19 @@
 import { cn } from '@/lib/utils';
-import { Sparkline } from '@/components/charts/Sparkline';
 
+// `sparkData?: number[]` and `sparkColor?: string` used to live here, rendering
+// <Sparkline data={sparkData} .../>. Sparkline takes `dataPoints: MetricDataPoint[]`, not
+// `data`, so the required prop arrived undefined and the component threw on
+// `dataPoints.map(...)`. No caller ever passed sparkData, which is the only reason it never
+// crashed in production — and also why the typecheck that would have caught it was a no-op.
+// Removed rather than repaired: MetricDataPoint requires a timestamp, so adapting number[]
+// would mean fabricating one. Callers that want a sparkline use <Sparkline> directly, as
+// SloBoard.tsx already does.
 interface KpiProps {
   label: string;
   value: string | number;
   unit?: string;
   delta?: number;
   deltaGood?: 'up' | 'down';
-  sparkData?: number[];
-  sparkColor?: string;
   narrative?: string;
   className?: string;
 }
@@ -17,7 +22,7 @@ function formatDelta(n: number): string {
   return (n >= 0 ? '+' : '') + (n * 100).toFixed(1) + '%';
 }
 
-export function Kpi({ label, value, unit, delta, deltaGood, sparkData, sparkColor, narrative, className }: KpiProps) {
+export function Kpi({ label, value, unit, delta, deltaGood, narrative, className }: KpiProps) {
   const isPositive = deltaGood === 'up' ? (delta ?? 0) > 0 : (delta ?? 0) < 0;
   const deltaColor = delta === undefined || delta === 0
     ? 'text-otel-text-mute'
@@ -41,9 +46,6 @@ export function Kpi({ label, value, unit, delta, deltaGood, sparkData, sparkColo
         </span>
         {unit && <span className="text-[11px] text-otel-text-mute mb-0.5">{unit}</span>}
       </div>
-      {sparkData && (
-        <Sparkline data={sparkData} color={sparkColor ?? 'var(--otel-accent)'} height={28} />
-      )}
       {narrative && (
         <div className="text-[11px] text-otel-text-dim leading-snug">{narrative}</div>
       )}

--- a/src/Content/Presentation/Presentation.Dashboard/src/routes/Catalog/CatalogPage.tsx
+++ b/src/Content/Presentation/Presentation.Dashboard/src/routes/Catalog/CatalogPage.tsx
@@ -15,9 +15,11 @@ const tabs = [
 ];
 
 function latestValue(series: MetricSeries): number {
-  const pts = series.dataPoints;
-  if (pts.length === 0) return 0;
-  return parseFloat(pts[pts.length - 1].value) || 0;
+  // Checking `length === 0` does not narrow `pts[i]` — under noUncheckedIndexedAccess every
+  // index access is `T | undefined` regardless of what was proven about the length. Binding
+  // the element and testing IT is what actually narrows, and it covers the empty case too.
+  const last = series.dataPoints[series.dataPoints.length - 1];
+  return last ? parseFloat(last.value) || 0 : 0;
 }
 
 function fmt(n: number): string {
@@ -181,7 +183,12 @@ function AgentsTab() {
     );
   }
 
-  const agentNames = [...new Set(sessionSeries.map((s) => s.labels['agent_name']))].filter(Boolean).sort();
+  // A bare `.filter(Boolean)` drops the empties at runtime but does NOT narrow the type —
+  // the array stays (string | undefined)[] and every downstream use of a name has to be
+  // re-guarded. The predicate form tells the compiler what the filter already does.
+  const agentNames = [...new Set(sessionSeries.map((s) => s.labels['agent_name']))]
+    .filter((n): n is string => Boolean(n))
+    .sort();
 
   const findByAgent = (list: MetricSeries[], name: string) =>
     list.find((s) => s.labels['agent_name'] === name);
@@ -282,7 +289,10 @@ function ToolsTab() {
     );
   }
 
-  const toolNames = [...new Set(callSeries.map((s) => s.labels['tool_name']))].filter(Boolean).sort();
+  // Same predicate-filter reason as agentNames above.
+  const toolNames = [...new Set(callSeries.map((s) => s.labels['tool_name']))]
+    .filter((n): n is string => Boolean(n))
+    .sort();
 
   const findByTool = (list: MetricSeries[], name: string) =>
     list.find((s) => s.labels['tool_name'] === name);

--- a/src/Content/Presentation/Presentation.Dashboard/src/routes/Overview/OverviewPage.test.tsx
+++ b/src/Content/Presentation/Presentation.Dashboard/src/routes/Overview/OverviewPage.test.tsx
@@ -1,4 +1,4 @@
-import { screen, waitFor } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import { describe, it, expect } from 'vitest';
 import { renderPage } from '@/test/helpers/renderPage';
 import OverviewPage from './OverviewPage';

--- a/src/Content/Presentation/Presentation.Dashboard/src/routes/Sessions/ContextInspectorPage.tsx
+++ b/src/Content/Presentation/Presentation.Dashboard/src/routes/Sessions/ContextInspectorPage.tsx
@@ -60,11 +60,14 @@ export default function ContextInspectorPage() {
   // Maintain a parallel { item, turnIndex } map so each row knows which
   // snapshot it came from — same trick ContentsPanel uses.
   const rowsByCategory = useMemo(() => {
-    const result: Record<CategoryKey, { item: LoadedItem; turnIndex: number }[]> =
-      Object.fromEntries(CATEGORY_ORDER.map((k) => [k, []])) as Record<
-        CategoryKey,
-        { item: LoadedItem; turnIndex: number }[]
-      >;
+    // The empty arrays have to be typed at the point they are created. Left bare, they infer
+    // as never[], and Object.fromEntries then yields { [k: string]: never[] } — a type with
+    // no overlap with the target, which is why the assertion was rejected outright rather
+    // than merely being unsound.
+    type CategoryRows = { item: LoadedItem; turnIndex: number }[];
+    const result = Object.fromEntries(
+      CATEGORY_ORDER.map((k) => [k, [] as CategoryRows]),
+    ) as Record<CategoryKey, CategoryRows>;
     for (const snap of snapshots) {
       for (const item of snap.loaded) {
         result[item.cat].push({ item, turnIndex: snap.turnIndex });

--- a/src/Content/Presentation/Presentation.Dashboard/src/routes/Sessions/SessionTableRow.test.tsx
+++ b/src/Content/Presentation/Presentation.Dashboard/src/routes/Sessions/SessionTableRow.test.tsx
@@ -1,7 +1,10 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { SessionTableRow } from './SessionTableRow';
-import type { SessionRecord, CategoryBreakdown } from '@/api/types';
+// CategoryBreakdown lives in @/lib/categories; api/types imports it but does not re-export
+// it, so this was importing a name that module never published.
+import type { SessionRecord } from '@/api/types';
+import type { CategoryBreakdown } from '@/lib/categories';
 
 function session(overrides: Partial<SessionRecord> = {}): SessionRecord {
   return {

--- a/src/Content/Presentation/Presentation.Dashboard/src/routes/Sessions/gem/SessionTimeline.test.tsx
+++ b/src/Content/Presentation/Presentation.Dashboard/src/routes/Sessions/gem/SessionTimeline.test.tsx
@@ -30,6 +30,7 @@ function msg(
     role,
     source: null,
     contentPreview,
+    contentFull: null,
     model: null,
     inputTokens: 0,
     outputTokens: 0,

--- a/src/Content/Presentation/Presentation.Dashboard/src/routes/Sessions/gem/useSessionGemState.test.ts
+++ b/src/Content/Presentation/Presentation.Dashboard/src/routes/Sessions/gem/useSessionGemState.test.ts
@@ -118,7 +118,7 @@ describe('useSessionGemState — drawer', () => {
         messages: [
           {
             id: 'm-0', sessionId: 's', turnIndex: 0, role: 'user',
-            source: null, contentPreview: 'Hello', model: null,
+            source: null, contentPreview: 'Hello', contentFull: null, model: null,
             inputTokens: 0, outputTokens: 0, cacheRead: 0, cacheWrite: 0,
             costUsd: 0, cacheHitPct: 0, toolNames: null,
             createdAt: new Date().toISOString(),

--- a/src/Content/Presentation/Presentation.Dashboard/src/test/mocks/handlers.ts
+++ b/src/Content/Presentation/Presentation.Dashboard/src/test/mocks/handlers.ts
@@ -219,6 +219,10 @@ const mockSessionDetail: SessionDetail = {
       role: 'user',
       source: null,
       contentPreview: 'Help me refactor the authentication module',
+      // Null, not omitted: SessionMessageRecord documents contentFull as null in list
+      // responses (only the per-message deep-link endpoint fills it). These fixtures had
+      // dropped the field entirely, so the mocks were a shape the real API never returns.
+      contentFull: null,
       model: null,
       inputTokens: 150,
       outputTokens: 0,
@@ -236,6 +240,7 @@ const mockSessionDetail: SessionDetail = {
       role: 'assistant',
       source: 'CodeAssistant',
       contentPreview: 'I\'ll analyze the current authentication module and suggest improvements...',
+      contentFull: null,
       model: 'claude-3-opus',
       inputTokens: 5000,
       outputTokens: 2000,
@@ -258,6 +263,11 @@ const mockSessionDetail: SessionDetail = {
       status: 'success',
       errorType: null,
       resultSize: 4096,
+      // callId/args/stdout are documented as detail-endpoint-only on ToolExecutionRecord,
+      // so null is what a list response actually carries. They were missing outright here.
+      callId: null,
+      args: null,
+      stdout: null,
       createdAt: new Date(Date.now() - 3500000).toISOString(),
     },
     {
@@ -270,6 +280,9 @@ const mockSessionDetail: SessionDetail = {
       status: 'success',
       errorType: null,
       resultSize: 2048,
+      callId: null,
+      args: null,
+      stdout: null,
       createdAt: new Date(Date.now() - 3490000).toISOString(),
     },
   ],

--- a/src/Content/Presentation/Presentation.Dashboard/tsconfig.app.json
+++ b/src/Content/Presentation/Presentation.Dashboard/tsconfig.app.json
@@ -4,6 +4,10 @@
     "target": "es2023",
     "lib": ["ES2023", "DOM", "DOM.Iterable"],
     "module": "esnext",
+    // Deliberately NOT carrying @testing-library/jest-dom or vitest/globals. This is the
+    // shipped-code project: if test globals were visible here, production source could call
+    // describe() or expect(...).toBeInTheDocument() and typecheck clean. Tests get those
+    // types from tsconfig.test.json instead.
     "types": ["vite/client"],
     "skipLibCheck": true,
 
@@ -28,5 +32,16 @@
     }
   },
   "include": ["src"],
-  "exclude": ["src/test", "src/__tests__", "src/**/__tests__"]
+  // This project's tests are COLOCATED (52 files as src/**/*.test.tsx), not gathered under
+  // a test directory, so excluding folders alone would leave every one of them in the
+  // shipped-code program — which is how 218 phantom jest-dom errors were being reported
+  // against files this project should not have been checking in the first place.
+  // tsconfig.test.json picks up exactly what is excluded here.
+  "exclude": [
+    "src/test",
+    "src/__tests__",
+    "src/**/__tests__",
+    "src/**/*.test.ts",
+    "src/**/*.test.tsx"
+  ]
 }

--- a/src/Content/Presentation/Presentation.Dashboard/tsconfig.json
+++ b/src/Content/Presentation/Presentation.Dashboard/tsconfig.json
@@ -1,8 +1,14 @@
 {
+  // `files: []` plus references is the solution-style root: it owns no sources itself and
+  // exists only to point `tsc -b` at the real projects. That is also why the previous
+  // `tsc --noEmit` build step was a silent no-op — plain --noEmit does NOT follow
+  // references, so it compiled this file's zero inputs and exited 0 while 166 source files
+  // went unchecked. Build mode (`tsc -b`, wired in package.json) is what walks the list.
   "files": [],
   "references": [
     { "path": "./tsconfig.app.json" },
-    { "path": "./tsconfig.node.json" }
+    { "path": "./tsconfig.node.json" },
+    { "path": "./tsconfig.test.json" }
   ],
   "compilerOptions": {
     "paths": {

--- a/src/Content/Presentation/Presentation.Dashboard/tsconfig.test.json
+++ b/src/Content/Presentation/Presentation.Dashboard/tsconfig.test.json
@@ -1,0 +1,32 @@
+{
+  // Tests are typechecked as their OWN project, separate from tsconfig.app.json, so that
+  // vitest's globals and jest-dom's matchers exist here and NOWHERE ELSE. Registering them
+  // in the app project instead would let shipped code call describe() or
+  // expect(...).toBeInTheDocument() and still typecheck clean — the compiler would stop
+  // being able to tell test code from production code.
+  //
+  // Production files still enter this program as imports of the tests, which is correct:
+  // they must be checked against the same source the tests exercise. The separation that
+  // matters runs the other way — nothing here leaks back into the app project.
+  "extends": "./tsconfig.app.json",
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.test.tsbuildinfo",
+    // An explicit `types` array REPLACES the inherited one rather than extending it, so
+    // vite/client has to be repeated here or `import.meta.env` breaks in every test.
+    "types": ["vite/client", "@testing-library/jest-dom", "vitest/globals"]
+  },
+  // Complementary to tsconfig.app.json's exclude list. The two must stay that way: a
+  // pattern dropped from both leaves those files checked by NEITHER project, which is
+  // precisely the hole this repo just found in `tsc --noEmit` against a `files: []` root.
+  // `extends` INHERITS tsconfig.app.json's exclude list, and exclude beats include — so
+  // without this override the test project resolved to ZERO input files and tsc reported
+  // TS18003 instead of checking anything. This override is what makes the two projects
+  // complementary rather than one of them silently empty.
+  "exclude": ["node_modules"],
+  "include": [
+    "src/**/*.test.ts",
+    "src/**/*.test.tsx",
+    "src/test/**/*",
+    "src/**/__tests__/**/*"
+  ]
+}

--- a/src/Content/Presentation/Presentation.Dashboard/vite.config.ts
+++ b/src/Content/Presentation/Presentation.Dashboard/vite.config.ts
@@ -1,4 +1,7 @@
-import { defineConfig } from 'vite'
+// `vitest/config`, not `vite` — this file carries an inline `test:` block, and vite's own
+// defineConfig has no such property. Vitest re-exports defineConfig with the config type
+// widened to include it. The mismatch was invisible while the typecheck was a no-op.
+import { defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 import path from 'path'

--- a/src/Content/Presentation/Presentation.WebUI/package.json
+++ b/src/Content/Presentation/Presentation.WebUI/package.json
@@ -9,7 +9,8 @@
   "scripts": {
     "dev": "vite",
     "dev:all": "concurrently -n \"API,UI\" -c \"cyan,magenta\" \"dotnet run --project ../Presentation.AgentHub\" \"vite\"",
-    "build": "tsc --noEmit && vite build",
+    "build": "tsc -b && vite build",
+    "typecheck": "tsc -b",
     "lint": "eslint .",
     "preview": "vite preview",
     "test": "vitest run",

--- a/src/Content/Presentation/Presentation.WebUI/src/components/layout/DashboardLayout.tsx
+++ b/src/Content/Presentation/Presentation.WebUI/src/components/layout/DashboardLayout.tsx
@@ -29,7 +29,11 @@ export function DashboardLayout() {
     // (agent removed/renamed between sessions) — otherwise a stale stored id would strand the user on
     // an invalid agent whose turns fail.
     const isValid = selectedAgent !== null && agents.some((a) => a.id === selectedAgent);
-    if (!isValid) setSelectedAgent(agents[0].id);
+    // Bind the first agent rather than indexing inline: with an empty roster there is
+    // nothing to fall back to, and reading .id off agents[0] would throw instead of simply
+    // leaving the selection unset until agents arrive.
+    const first = agents[0];
+    if (!isValid && first) setSelectedAgent(first.id);
   }, [selectedAgent, agentsQuery.data, setSelectedAgent]);
 
   useEffect(() => {

--- a/src/Content/Presentation/Presentation.WebUI/src/components/ui/scroll-area.tsx
+++ b/src/Content/Presentation/Presentation.WebUI/src/components/ui/scroll-area.tsx
@@ -1,6 +1,5 @@
 "use client"
 
-import * as React from "react"
 import { ScrollArea as ScrollAreaPrimitive } from "@base-ui/react/scroll-area"
 
 import { cn } from "@/lib/utils"

--- a/src/Content/Presentation/Presentation.WebUI/src/components/ui/textarea.tsx
+++ b/src/Content/Presentation/Presentation.WebUI/src/components/ui/textarea.tsx
@@ -1,6 +1,12 @@
-import type { TextareaHTMLAttributes } from 'react';
+import type { Ref, TextareaHTMLAttributes } from 'react';
 
-type TextareaProps = TextareaHTMLAttributes<HTMLTextAreaElement>;
+// React 19 delivers `ref` to a function component as an ordinary prop, and the spread below
+// forwards it to the DOM node — which is why ChatInput's mention insertion has always
+// worked at runtime. TextareaHTMLAttributes does not declare `ref`, so only the TYPE was
+// wrong, and nothing was typechecking this file to say so.
+type TextareaProps = TextareaHTMLAttributes<HTMLTextAreaElement> & {
+  ref?: Ref<HTMLTextAreaElement>;
+};
 
 export function Textarea({ className = '', ...props }: TextareaProps) {
   return (

--- a/src/Content/Presentation/Presentation.WebUI/src/features/chat/ChatInput.tsx
+++ b/src/Content/Presentation/Presentation.WebUI/src/features/chat/ChatInput.tsx
@@ -52,8 +52,12 @@ function composeMessage(message: string, attachment: Attachment | null): string 
 function detectTrigger(value: string, caret: number): TriggerState | null {
   for (let i = caret - 1; i >= 0; i--) {
     const ch = value[i];
+    // `caret` is supplied by the DOM and can sit past the end of `value` between a
+    // programmatic value change and the corresponding selection update, so an in-range
+    // loop index is not a guarantee that the character exists.
+    if (ch === undefined) break;
     if (ch === '@' || ch === '/') {
-      const prev = i === 0 ? ' ' : value[i - 1];
+      const prev = i === 0 ? ' ' : (value[i - 1] ?? ' ');
       if (!/\s/.test(prev) && i !== 0) return null;
       return { char: ch, start: i, filter: value.slice(i + 1, caret) };
     }
@@ -232,7 +236,11 @@ export function ChatInput({ disabled = false }: ChatInputProps) {
       }
       if (e.key === 'Enter' || e.key === 'Tab') {
         e.preventDefault();
-        applyMention(filteredItems[pickerIndex]);
+        // pickerIndex is clamped by the arrow-key handlers, but filteredItems is recomputed
+        // from the live filter text — so a keystroke that empties the list between render
+        // and keydown leaves the index pointing past the end.
+        const picked = filteredItems[pickerIndex];
+        if (picked) applyMention(picked);
         return;
       }
       if (e.key === 'Escape') {

--- a/src/Content/Presentation/Presentation.WebUI/src/features/chat/ChatInput.tsx
+++ b/src/Content/Presentation/Presentation.WebUI/src/features/chat/ChatInput.tsx
@@ -53,9 +53,11 @@ function detectTrigger(value: string, caret: number): TriggerState | null {
   for (let i = caret - 1; i >= 0; i--) {
     const ch = value[i];
     // `caret` is supplied by the DOM and can sit past the end of `value` between a
-    // programmatic value change and the corresponding selection update, so an in-range
-    // loop index is not a guarantee that the character exists.
-    if (ch === undefined) break;
+    // programmatic value change and the corresponding selection update, so an in-range loop
+    // index is not a guarantee that the character exists. `continue`, not `break`: skipping
+    // the out-of-range slots and scanning on into the valid prefix is what the old
+    // unguarded code did, whereas aborting would stop detecting the trigger entirely.
+    if (ch === undefined) continue;
     if (ch === '@' || ch === '/') {
       const prev = i === 0 ? ' ' : (value[i - 1] ?? ' ');
       if (!/\s/.test(prev) && i !== 0) return null;

--- a/src/Content/Presentation/Presentation.WebUI/src/features/chat/CodeBlock.tsx
+++ b/src/Content/Presentation/Presentation.WebUI/src/features/chat/CodeBlock.tsx
@@ -70,12 +70,15 @@ function extractLanguage(node: ReactNode): string | null {
   if (!isValidElement<{ className?: string; children?: ReactNode }>(node)) return null;
   const className = node.props.className ?? '';
   const match = className.match(/language-(\w+)/);
-  if (match) return match[1];
+  // A successful match does not prove the capture group is populated as far as the type
+  // system is concerned — match[1] is string | undefined, and this function contracts to
+  // string | null.
+  if (match) return match[1] ?? null;
   // Check children (react-markdown wraps code in pre > code)
   if (isValidElement<{ className?: string }>(node.props.children)) {
     const childClass = node.props.children.props.className ?? '';
     const childMatch = childClass.match(/language-(\w+)/);
-    if (childMatch) return childMatch[1];
+    if (childMatch) return childMatch[1] ?? null;
   }
   return null;
 }

--- a/src/Content/Presentation/Presentation.WebUI/src/features/chat/MessageItem.tsx
+++ b/src/Content/Presentation/Presentation.WebUI/src/features/chat/MessageItem.tsx
@@ -19,20 +19,22 @@ function ToolCallCard({ toolCall }: { toolCall: ToolCallSummary }) {
   return (
     <Collapsible>
       <div className="rounded-lg border border-border/50 bg-card/50 overflow-hidden mt-2">
-        <CollapsibleTrigger asChild>
-          <button
-            type="button"
-            className="flex items-center gap-2 w-full px-3 py-2 text-left text-xs hover:bg-muted/50 transition-colors"
-          >
-            <ChevronDown
-              size={12}
-              className="text-muted-foreground transition-transform [[data-state=closed]_&]:rotate-[-90deg]"
-            />
-            <span className="font-mono font-medium text-foreground/90">{toolCall.toolName}</span>
-            <Badge variant={statusVariant} className="ml-auto text-[10px] px-1.5 py-0">
-              {statusText}
-            </Badge>
-          </button>
+        {/*
+          `asChild` is Radix's API, not Base UI's — this trigger is built on
+          @base-ui/react/collapsible, whose Trigger renders its own <button> and composes via
+          a `render` prop instead. The old markup therefore put a <button> inside a <button>,
+          which is invalid HTML, and spread an unknown `asChild` attribute onto the DOM.
+          Dropping the inner element and styling the Trigger directly is the Base UI form.
+        */}
+        <CollapsibleTrigger className="flex items-center gap-2 w-full px-3 py-2 text-left text-xs hover:bg-muted/50 transition-colors">
+          <ChevronDown
+            size={12}
+            className="text-muted-foreground transition-transform [[data-state=closed]_&]:rotate-[-90deg]"
+          />
+          <span className="font-mono font-medium text-foreground/90">{toolCall.toolName}</span>
+          <Badge variant={statusVariant} className="ml-auto text-[10px] px-1.5 py-0">
+            {statusText}
+          </Badge>
         </CollapsibleTrigger>
         <CollapsibleContent>
           <div className="border-t border-border/50 px-3 py-2 space-y-2">

--- a/src/Content/Presentation/Presentation.WebUI/src/features/chat/__tests__/ChatPanel.test.tsx
+++ b/src/Content/Presentation/Presentation.WebUI/src/features/chat/__tests__/ChatPanel.test.tsx
@@ -44,12 +44,6 @@ vi.mock('../loadConversationHistory', () => ({
 
 const ACTIVE_ID = 'abcd1234-0000-0000-0000-000000000000';
 
-function getSubmitButton(): HTMLButtonElement {
-  const btn = document.querySelector('button[type="submit"]');
-  if (!btn) throw new Error('Submit button not found');
-  return btn as HTMLButtonElement;
-}
-
 function renderPanel() {
   return renderWithProviders(<ChatPanel />);
 }

--- a/src/Content/Presentation/Presentation.WebUI/src/features/chat/completeStreamingMarkdown.ts
+++ b/src/Content/Presentation/Presentation.WebUI/src/features/chat/completeStreamingMarkdown.ts
@@ -41,7 +41,10 @@ export function completeStreamingMarkdown(content: string): string {
     if (match === null) continue;
 
     const run = match[1];
-    const marker = run[0]; // ` or ~
+    if (run === undefined) continue;
+    // charAt, not run[0]: indexing yields string | undefined under noUncheckedIndexedAccess,
+    // while the fence pattern's capture group already guarantees at least one character.
+    const marker = run.charAt(0); // ` or ~
     if (open === null) {
       open = { marker, length: run.length };
     } else if (marker === open.marker && run.length >= open.length) {

--- a/src/Content/Presentation/Presentation.WebUI/src/features/chat/widgets/AgentForm.tsx
+++ b/src/Content/Presentation/Presentation.WebUI/src/features/chat/widgets/AgentForm.tsx
@@ -14,7 +14,11 @@ function initialValues(spec: FormSpec): FormValues {
   return values;
 }
 
-function isBlank(field: FormFieldSpec, value: FieldValue): boolean {
+// `value` is widened to include undefined because that is what a lookup into FormValues
+// actually yields — the spec is agent-supplied and re-validated at render time, so a field
+// whose name is absent from the values map is a reachable state, not an impossible one. The
+// `?? ''` below was already written for it; only the signature disagreed.
+function isBlank(field: FormFieldSpec, value: FieldValue | undefined): boolean {
   return field.type === 'checkbox' ? value !== true : String(value ?? '').trim() === '';
 }
 
@@ -27,7 +31,7 @@ function Field({
   disabled,
 }: {
   field: FormFieldSpec;
-  value: FieldValue;
+  value: FieldValue | undefined;
   onChange: (name: string, value: FieldValue) => void;
   disabled: boolean;
 }) {
@@ -61,13 +65,13 @@ function Field({
   switch (field.type) {
     case 'textarea':
       control = (
-        <Textarea id={id} name={field.name} value={String(value)} rows={3} disabled={disabled}
+        <Textarea id={id} name={field.name} value={String(value ?? '')} rows={3} disabled={disabled}
           onChange={(e) => { onChange(field.name, e.target.value); }} />
       );
       break;
     case 'select':
       control = (
-        <select id={id} name={field.name} value={String(value)} disabled={disabled}
+        <select id={id} name={field.name} value={String(value ?? '')} disabled={disabled}
           onChange={(e) => { onChange(field.name, e.target.value); }}
           className="flex h-9 w-full rounded-md border border-border bg-background px-3 py-1 text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-ring disabled:opacity-50">
           <option value="" disabled>Select…</option>
@@ -79,7 +83,7 @@ function Field({
       // text, number, and date all render a single-line Input; the input type follows the field
       // (only text/number/date reach here — checkbox/textarea/select are handled above).
       control = (
-        <Input id={id} name={field.name} type={field.type} value={String(value)} disabled={disabled}
+        <Input id={id} name={field.name} type={field.type} value={String(value ?? '')} disabled={disabled}
           onChange={(e) => { onChange(field.name, e.target.value); }} />
       );
   }

--- a/src/Content/Presentation/Presentation.WebUI/src/features/chat/widgets/__tests__/AgentForm.test.tsx
+++ b/src/Content/Presentation/Presentation.WebUI/src/features/chat/widgets/__tests__/AgentForm.test.tsx
@@ -50,7 +50,9 @@ describe('AgentForm', () => {
     await user.click(screen.getByRole('button', { name: 'Send it' }));
 
     expect(send).toHaveBeenCalledTimes(1);
-    const message = send.mock.calls[0][0];
+    // toHaveBeenCalledTimes(1) on the line above establishes that calls[0] exists; the
+    // assertion states that for the compiler, which does not read expectations.
+    const message = send.mock.calls[0]![0];
     expect(message).toContain('- Email: a@b.com');
     expect(message).toContain('- Newsletter: Yes');
 

--- a/src/Content/Presentation/Presentation.WebUI/src/features/chat/widgets/__tests__/formTypes.test.ts
+++ b/src/Content/Presentation/Presentation.WebUI/src/features/chat/widgets/__tests__/formTypes.test.ts
@@ -17,7 +17,8 @@ describe('parseFormArgs', () => {
     expect(result.value.submitLabel).toBe('Go');
     expect(result.value.fields).toHaveLength(2);
     expect(result.value.fields[0]).toMatchObject({ name: 'email', type: 'text', required: true });
-    expect(result.value.fields[1].options).toEqual(['red', 'blue']);
+    // toHaveLength(2) directly above pins both indices as present.
+    expect(result.value.fields[1]!.options).toEqual(['red', 'blue']);
   });
 
   it('rejects a spec with no fields', () => {
@@ -52,7 +53,7 @@ describe('parseFormArgs', () => {
     expect(result.ok).toBe(true);
     if (result.ok) {
       expect(result.value.fields).toHaveLength(1);
-      expect(result.value.fields[0].type).toBe('text');
+      expect(result.value.fields[0]!.type).toBe('text');
     }
   });
 });

--- a/src/Content/Presentation/Presentation.WebUI/src/features/conversations/ConversationSidebar.tsx
+++ b/src/Content/Presentation/Presentation.WebUI/src/features/conversations/ConversationSidebar.tsx
@@ -77,8 +77,11 @@ export function ConversationSidebar({ onSelect }: ConversationSidebarProps) {
     if (id === activeId) {
       clearMessages();
       const remaining = conversations?.filter((c) => c.id !== id) ?? [];
-      if (remaining.length > 0) {
-        const next = remaining[0];
+      // Test `next` itself rather than remaining.length: a length check does not narrow an
+      // index access, and this is the same condition expressed against the value actually
+      // dereferenced on the following lines.
+      const next = remaining[0];
+      if (next) {
         if (next.agentName !== selectedAgent) setSelectedAgent(next.agentName);
         navigate(`/chat/${next.id}`);
       } else {

--- a/src/Content/Presentation/Presentation.WebUI/src/features/conversations/useDeleteConversation.ts
+++ b/src/Content/Presentation/Presentation.WebUI/src/features/conversations/useDeleteConversation.ts
@@ -4,7 +4,10 @@ import { CONVERSATIONS_QUERY_KEY, type ConversationSummary } from './useConversa
 
 export function useDeleteConversation() {
   const queryClient = useQueryClient();
-  return useMutation<void, Error, string>({
+  // The fourth generic is TContext. Left off, it defaults to unknown and onError's `context`
+  // arrives as {} — so the optimistic-update rollback below read a property the type did not
+  // have. Naming it is what makes the rollback typecheck against what onMutate returns.
+  return useMutation<void, Error, string, { previous: ConversationSummary[] | undefined }>({
     mutationFn: async (id: string) => {
       await apiClient.delete(`/api/conversations/${id}`);
     },

--- a/src/Content/Presentation/Presentation.WebUI/src/features/mcp/ToolsBrowser.tsx
+++ b/src/Content/Presentation/Presentation.WebUI/src/features/mcp/ToolsBrowser.tsx
@@ -2,7 +2,6 @@ import { useState, useMemo } from 'react';
 import { Wrench, Search, ChevronRight } from 'lucide-react';
 import { useToolsQuery, type McpTool } from './useMcpQuery';
 import { ToolInvoker } from './ToolInvoker';
-import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Input } from '@/components/ui/input';
 import { JsonViewer } from '@/components/ui/json-viewer';

--- a/src/Content/Presentation/Presentation.WebUI/src/hooks/useAgentHub.tsx
+++ b/src/Content/Presentation/Presentation.WebUI/src/hooks/useAgentHub.tsx
@@ -4,7 +4,7 @@ import type { HubConnection } from '@microsoft/signalr';
 import { buildHubConnection } from '@/lib/signalrClient';
 import { loginRequest } from '@/lib/authConfig';
 import { IS_AUTH_DISABLED } from '@/lib/devAuth';
-import { useChatStore, type ChatMessage } from '@/stores/chatStore';
+import { useChatStore } from '@/stores/chatStore';
 
 export type ConnectionState = 'disconnected' | 'connecting' | 'connected' | 'reconnecting';
 

--- a/src/Content/Presentation/Presentation.WebUI/src/hooks/useAgentStream.ts
+++ b/src/Content/Presentation/Presentation.WebUI/src/hooks/useAgentStream.ts
@@ -1,5 +1,16 @@
 import { useMsal } from '@azure/msal-react';
-import type { Subscription } from 'rxjs';
+/**
+ * `@ag-ui/client` bundles its own copy of rxjs (7.8.1) beside the app's (7.8.2), so the
+ * Subscription its observable hands back is a nominally different type from the one `rxjs`
+ * exports, despite being structurally identical. Importing the type from either package
+ * makes one of the two assignments fail.
+ *
+ * `unsubscribe()` is the only member this module ever touches, so describing exactly that is
+ * both accurate and immune to which copy the observable came from. Deduping the two rxjs
+ * versions is the real cleanup, but it is a dependency change and does not belong in a
+ * typecheck PR.
+ */
+type ActiveSubscription = { unsubscribe(): void };
 import { EventType } from '@ag-ui/core';
 import type { BaseEvent, TextMessageContentEvent, TextMessageStartEvent, RunErrorEvent } from '@ag-ui/core';
 import { createAuthenticatedAgUiAgent, postToolResult } from '@/lib/agUiClient';
@@ -77,7 +88,7 @@ async function finishToolCall(threadId: string, callId: string, pending: Pending
 // conversation switch) must be able to cancel the run that another consumer (the send hook) started;
 // with per-instance refs those were separate objects, so a cross-consumer abort() was a silent no-op
 // and the previous conversation's tokens kept streaming into the newly selected transcript.
-let activeSubscription: Subscription | null = null;
+let activeSubscription: ActiveSubscription | null = null;
 const activePendingCalls = new Map<string, PendingCall>();
 
 /**

--- a/src/Content/Presentation/Presentation.WebUI/src/lib/signalrClient.ts
+++ b/src/Content/Presentation/Presentation.WebUI/src/lib/signalrClient.ts
@@ -9,8 +9,12 @@ import {
 const infiniteRetryPolicy: IRetryPolicy = {
   nextRetryDelayInMilliseconds(retryContext: RetryContext): number | null {
     const baseDelays = [0, 2000, 4000, 8000, 16000];
-    if (retryContext.previousRetryCount < baseDelays.length)
-      return baseDelays[retryContext.previousRetryCount];
+    // Binding the element narrows it; the `<  length` comparison does not, because
+    // noUncheckedIndexedAccess types every index access as possibly-undefined regardless of
+    // what was proven about the bounds. Falling through to the steady-state delay is also
+    // the correct behaviour if the lookup ever did miss.
+    const staged = baseDelays[retryContext.previousRetryCount];
+    if (staged !== undefined) return staged;
     return 30_000 + Math.random() * 5000;
   },
 };

--- a/src/Content/Presentation/Presentation.WebUI/tsconfig.app.json
+++ b/src/Content/Presentation/Presentation.WebUI/tsconfig.app.json
@@ -28,5 +28,16 @@
     }
   },
   "include": ["src"],
-  "exclude": ["src/test", "src/__tests__", "src/**/__tests__"]
+  // Mirrors tsconfig.test.json's include, which is the invariant that keeps every file under
+  // src claimed by exactly one project. The colocated *.test.* patterns are listed even
+  // though this project has no colocated tests today: without them the FIRST colocated
+  // Foo.test.tsx would land in BOTH projects and fail here on describe/toBeInTheDocument.
+  // Dashboard needs them for its 52 existing colocated tests; here they are pre-emptive.
+  "exclude": [
+    "src/test",
+    "src/__tests__",
+    "src/**/__tests__",
+    "src/**/*.test.ts",
+    "src/**/*.test.tsx"
+  ]
 }

--- a/src/Content/Presentation/Presentation.WebUI/tsconfig.json
+++ b/src/Content/Presentation/Presentation.WebUI/tsconfig.json
@@ -1,8 +1,12 @@
 {
+  // Solution-style root: owns no sources, exists only to point `tsc -b` at the real
+  // projects. Plain `tsc --noEmit` does NOT follow references, which is why the old build
+  // step compiled this file's zero inputs, exited 0, and left every source file unchecked.
   "files": [],
   "references": [
     { "path": "./tsconfig.app.json" },
-    { "path": "./tsconfig.node.json" }
+    { "path": "./tsconfig.node.json" },
+    { "path": "./tsconfig.test.json" }
   ],
   "compilerOptions": {
     "paths": {

--- a/src/Content/Presentation/Presentation.WebUI/tsconfig.test.json
+++ b/src/Content/Presentation/Presentation.WebUI/tsconfig.test.json
@@ -1,8 +1,21 @@
 {
+  // This file already existed and was never wired in: nothing referenced it from
+  // tsconfig.json, so `tsc -b` never built it and `tsc --noEmit` against the references-only
+  // root built nothing at all. All 26 test files under src/test and src/**/__tests__ were
+  // therefore checked by no project whatsoever. Adding the root reference is what makes it
+  // real; the additions below are what make it correct once it runs.
   "extends": "./tsconfig.app.json",
   "compilerOptions": {
-    "types": ["vite/client", "vitest/globals"]
+    // Build mode needs a distinct build-info path per project, or two projects race on one
+    // file and `tsc -b` reports stale/incorrect up-to-date results.
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.test.tsbuildinfo",
+    // @testing-library/jest-dom was missing. An explicit `types` array REPLACES the
+    // inherited one, so vite/client has to be repeated or `import.meta.env` breaks in
+    // every test.
+    "types": ["vite/client", "vitest/globals", "@testing-library/jest-dom"]
   },
-  "include": ["src/test", "src/**/__tests__"],
-  "exclude": []
+  // Complementary to tsconfig.app.json's exclude list — between them every file under src
+  // must be claimed by exactly one project, or it goes unchecked exactly as these did.
+  "include": ["src/test", "src/**/__tests__", "src/**/*.test.ts", "src/**/*.test.tsx"],
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
PR 2 of 3 on frontend CI. ([#229](https://github.com/MCKRUZ/microsoft-agentic-harness/pull/229) added the test job; lint is PR 3.)

## The typecheck was compiling zero files

```
CAUSE:     Both frontends' build script ran `tsc --noEmit` against a root tsconfig that is
           `files: []` plus project references. Plain --noEmit does NOT follow references,
           so it compiled zero inputs and exited 0.
CONTROL:   Same instrument, same repo. `tsc --noEmit --listFiles -p tsconfig.json` printed
           0 lines on BOTH frontends; pointed at tsconfig.app.json it printed 166 files and
           reported real errors. tsc works — the config selected nothing.
COVERAGE:  Explains the no-op on both projects. It does NOT explain the missing test/lint
           jobs, which had no cause beyond "never written" — that was #229 and PR 3.
```

Build mode (`tsc -b`) walks the references. Both `build` scripts now use it, a `typecheck` script was added, and CI runs it **blocking**.

## Tests are now their own project

Registering jest-dom and vitest globals in the *app* project would let shipped code call `describe()` or `expect(...).toBeInTheDocument()` and still typecheck clean. So each frontend gets a `tsconfig.test.json`; the app project excludes tests and stays production-only.

**The WebUI's `tsconfig.test.json` already existed and was never referenced from its root** — so all 26 of its test files were checked by no project at all. Wiring it in is what makes it real. Same class of defect as the rest of this PR.

Measured with `--listFiles`, not inferred: app project 111 files with **0 test files leaked in**; test project **52 test files in scope**.

## 241 → 23: the phantom errors

Dashboard's 218 `toBeInTheDocument` errors were **one systemic cause** — jest-dom's types unregistered — not 218 defects. That left **55 real errors** across both projects, and several are genuine bugs rather than type noise:

| Defect | Consequence |
|---|---|
| `Kpi` passed `<Sparkline data=...>`; Sparkline requires `dataPoints` | Required prop arrived `undefined`; `.map()` would throw. No caller ever passed `sparkData` — the only reason it never crashed |
| `MessageItem` used Radix's `asChild` on a **Base UI** trigger | Base UI's Trigger renders its own `<button>`, so this nested a button inside a button and spread an unknown attribute onto the DOM |
| `PanelGrid` had no entry for `columns={1}`, which `BudgetPage` passes | Grid rendered with **no column class**; only looked right because a bare `grid` falls back to one column |
| MSW fixtures omitted `contentFull` / `callId` / `args` / `stdout` | Tests were passing against a shape the real API never returns |
| `vite.config.ts` carried an inline `test:` block typed against vite's config | vite's `defineConfig` has no `test` property |
| `AgentForm` rendered `String(value)` on a possibly-absent entry | Would print the literal text `"undefined"` into the input |

The rest are `noUncheckedIndexedAccess` truths: **a length check never narrows an index access**, and **`.filter(Boolean)` does not narrow either**. CatalogPage's ten identical errors were that one pattern — fixed with a type predicate at the two sites that build the arrays, not at the ten that consume them.

`Kpi.sparkData` was **removed rather than repaired**: `MetricDataPoint` requires a `timestamp`, so adapting `number[]` would mean fabricating data, and `SloBoard.tsx:73` already uses `<Sparkline>` correctly. Flagging that as a judgement call.

## Test plan

- `tsc -b` exits **0** on both frontends.
- **527 tests still pass** (Dashboard 385, WebUI 142) — including after the `MessageItem` DOM restructure.
- Deleted `node_modules/.tmp` and re-ran: `tsc` recreates it, so CI's fresh `npm ci` is covered.
- Workflow YAML parsed and asserted: `Tests` carries `if: !cancelled()` so a red typecheck still reports the test result rather than hiding it.

## Worth your attention

**The frontend job is not actually a required check.** The `main-branch-protection` ruleset pins `build-and-test`, `OWASP Agentic Top-10 Gate`, `security-review`, `correctness-review` — the frontend jobs are not in that list, so today they go red without blocking a merge. Adding them is a repo-settings change; say the word and I'll do it after PR 3, when all three legs are green.

Also noted, not acted on: `@ag-ui/client` bundles its own rxjs 7.8.1 beside the app's 7.8.2. `useAgentStream` now uses a structural `{ unsubscribe(): void }` type, which is accurate for what it touches. Deduping is the real fix and is a dependency change that doesn't belong here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SDpwZrPazixLPuNMcUtEPM
