### PR TITLE
ci: run lint blocking, and fix the two React bugs it was hiding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,10 +80,9 @@ jobs:
   # strength of local runs alone. This job is the first leg — tests only, and blocking from
   # the day it lands because both suites are already green.
   #
-  # Lint is deliberately still absent: it is red (44 errors across the two projects), and a
-  # step that runs without failing the build is not a gate — this repo has already paid for
-  # that lesson twice in the security gate. It arrives in its own PR, blocking on arrival,
-  # once those errors are fixed.
+  # All three legs are now here and all three block: tests (#229), typecheck (#230), lint.
+  # Each arrived only once it was green, because a step that runs without failing the build is
+  # not a gate — this repo has already paid for that lesson twice in the security gate.
   #
   # No `paths:` filter, on purpose. A job that only sometimes runs is the same trap one
   # level up, and these two suites finish in well under the .NET job's five minutes, so
@@ -130,8 +129,16 @@ jobs:
       - name: Typecheck
         run: npm run typecheck
 
-      # Runs even when the typecheck fails, so one CI run reports both signals instead of
-      # hiding the test result behind the first red step.
+      # `--max-warnings 0` is deliberately NOT set. Both projects carry warnings that are
+      # advisory by design — React Compiler's "incompatible library" note on react-hook-form's
+      # watch(), and two exhaustive-deps hints — and failing on them would either force a
+      # suppression or block on someone else's library. Errors block; warnings inform.
+      - name: Lint
+        if: '!cancelled()'
+        run: npm run lint
+
+      # Runs even when an earlier check fails, so one CI run reports every signal instead of
+      # hiding the rest behind the first red step.
       - name: Tests
         if: '!cancelled()'
         run: npm run test

--- a/src/Content/Presentation/Presentation.Dashboard/e2e/helpers.ts
+++ b/src/Content/Presentation/Presentation.Dashboard/e2e/helpers.ts
@@ -40,6 +40,7 @@ export async function getKpiValue(page: Page, testId: string): Promise<number> {
   const el = page.locator(`[data-testid="${testId}-value"]`);
   const text = await el.textContent({ timeout: 20_000 });
   if (!text) return 0;
-  const cleaned = text.replace(/[^0-9.\-]/g, '');
+  // Hyphen last inside the class is already literal; escaping it there is a no-op.
+  const cleaned = text.replace(/[^0-9.-]/g, '');
   return parseFloat(cleaned) || 0;
 }

--- a/src/Content/Presentation/Presentation.Dashboard/eslint.config.js
+++ b/src/Content/Presentation/Presentation.Dashboard/eslint.config.js
@@ -6,7 +6,11 @@ import tseslint from 'typescript-eslint'
 import { defineConfig, globalIgnores } from 'eslint/config'
 
 export default defineConfig([
-  globalIgnores(['dist']),
+  // `coverage` holds the v8/istanbul HTML report, including vendored scripts
+  // (prettify.js, sorter.js, block-navigation.js) that are generated output, not source.
+  // Linting them produced findings nobody can act on and that regenerate on every
+  // `test:coverage` run. `dist` is excluded for the same reason.
+  globalIgnores(['dist', 'coverage']),
   {
     files: ['**/*.{ts,tsx}'],
     extends: [

--- a/src/Content/Presentation/Presentation.Dashboard/playwright.config.ts
+++ b/src/Content/Presentation/Presentation.Dashboard/playwright.config.ts
@@ -1,7 +1,6 @@
 import { defineConfig } from '@playwright/test';
 
 const BASE_URL = process.env.DASHBOARD_URL ?? 'http://localhost:5174';
-const API_URL = process.env.API_URL ?? 'http://localhost:52000';
 
 export default defineConfig({
   testDir: './e2e',

--- a/src/Content/Presentation/Presentation.Dashboard/src/app/router.tsx
+++ b/src/Content/Presentation/Presentation.Dashboard/src/app/router.tsx
@@ -1,3 +1,16 @@
+/* eslint-disable react-refresh/only-export-components --
+ * This module's only export is `router`, but it declares 20 lazy() component bindings, so the
+ * rule fires once per binding — 20 of the repo's errors from one file.
+ *
+ * The rule protects Fast Refresh, which cannot apply to a route table anyway: changing the
+ * route graph remounts the tree, and react-router recreates the browser router wholesale. The
+ * suggested remedy (move the lazy() consts to their own module) would add a file whose sole
+ * purpose is to satisfy a rule that has no effect here, and it would separate each route's
+ * import from the path it serves — the one place a reader wants them together.
+ *
+ * Scoped to this file only. If a real component is ever added and exported here, move it out
+ * rather than widening the disable.
+ */
 import { lazy, Suspense } from 'react';
 import { createBrowserRouter, Navigate } from 'react-router-dom';
 

--- a/src/Content/Presentation/Presentation.Dashboard/src/hooks/useAutoRefresh.ts
+++ b/src/Content/Presentation/Presentation.Dashboard/src/hooks/useAutoRefresh.ts
@@ -2,7 +2,16 @@ import { useEffect, useRef } from 'react';
 
 export function useAutoRefresh(callback: () => void, intervalMs: number, enabled = true): void {
   const savedCallback = useRef(callback);
-  savedCallback.current = callback;
+
+  // Assigning to a ref during render is a side effect in the render phase: React may discard
+  // or re-run a render, so the write can be lost or applied twice, and under concurrent
+  // rendering an interleaved render can leave the ref pointing at a callback from a tree that
+  // was never committed. Syncing after commit is the only ordering that always matches what
+  // is on screen — and the interval below fires asynchronously, so it never observes the ref
+  // before this has run.
+  useEffect(() => {
+    savedCallback.current = callback;
+  }, [callback]);
 
   useEffect(() => {
     if (!enabled || intervalMs <= 0) return;

--- a/src/Content/Presentation/Presentation.Dashboard/src/routes/Sessions/agentRail/useSessionsFilter.ts
+++ b/src/Content/Presentation/Presentation.Dashboard/src/routes/Sessions/agentRail/useSessionsFilter.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import type { SessionRecord } from '@/api/types';
 import type { AgentRollup } from '@/lib/agentRoster';
 
@@ -30,24 +30,28 @@ export function useSessionsFilter({
 }: UseSessionsFilterOptions): SessionsFilterState {
   const [selectedAgentId, setSelectedAgentId] = useState<string | null>(null);
 
-  // Auto-clear the selection when the roster identity transitions and the
-  // previously-selected id is no longer in it. This covers the cold-load
-  // race where the fallback roster (id = agentName) gets clicked, then the
-  // registry resolves and ids switch to canonical 'agent-xxx' values — the
-  // old id would otherwise produce a silent empty list with no active tile.
-  useEffect(() => {
-    if (selectedAgentId === null) return;
-    const exists = roster.some((a) => a.id === selectedAgentId);
-    if (!exists) setSelectedAgentId(null);
-  }, [selectedAgentId, roster]);
+  // Handles the cold-load race where the fallback roster (id = agentName) gets clicked, then
+  // the registry resolves and ids switch to canonical 'agent-xxx' values — the stale id would
+  // otherwise produce a silent empty list with no active tile.
+  //
+  // DERIVED during render rather than corrected by an effect. The effect form set state from
+  // inside useEffect, which costs a second render pass and, in between, paints exactly the
+  // silent-empty-list state it exists to prevent. Deriving means the roster and the selection
+  // can never disagree in a committed render, so the flash cannot occur at all.
+  //
+  // The raw id stays in state deliberately: a roster that briefly empties during a refetch
+  // then returns restores the user's selection instead of silently discarding it.
+  const effectiveAgentId =
+    selectedAgentId !== null && roster.some((a) => a.id === selectedAgentId)
+      ? selectedAgentId
+      : null;
 
   const filteredSessions = useMemo(() => {
     // null id → no filter; full list passes through.
-    if (selectedAgentId === null) return sessions;
-    const selected = roster.find((a) => a.id === selectedAgentId) ?? null;
-    // Selection points at an id the roster doesn't know — return empty so
-    // the user sees the empty state. The useEffect above will clear the
-    // selection on the next paint.
+    if (effectiveAgentId === null) return sessions;
+    const selected = roster.find((a) => a.id === effectiveAgentId) ?? null;
+    // Unreachable now that effectiveAgentId is only non-null when the roster contains it,
+    // but kept as a total branch rather than a non-null assertion.
     if (selected === null) return [];
     // Sessions may carry the agent's display name ("Default Agent") OR its
     // slug/id ("default") depending on which code path persisted them.
@@ -59,17 +63,19 @@ export function useSessionsFilter({
       const k = normalizeKey(s.agentName);
       return k === nameKey || k === idKey;
     });
-  }, [sessions, selectedAgentId, roster]);
+  }, [sessions, effectiveAgentId, roster]);
 
   const selectAgent = useCallback((id: string | null) => {
     setSelectedAgentId(id);
   }, []);
 
+  // The EFFECTIVE id is what callers see, so the highlighted rail tile and the rows in the
+  // table are always describing the same selection.
   return {
-    selectedAgentId,
+    selectedAgentId: effectiveAgentId,
     selectAgent,
     filteredSessions,
-    isFiltered: selectedAgentId !== null,
+    isFiltered: effectiveAgentId !== null,
   };
 }
 

--- a/src/Content/Presentation/Presentation.WebUI/e2e/api-routes.spec.ts
+++ b/src/Content/Presentation/Presentation.WebUI/e2e/api-routes.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, type Request } from '@playwright/test';
+import { test, expect } from '@playwright/test';
 
 /**
  * Catches 404s on known API routes that the frontend attempts to call.

--- a/src/Content/Presentation/Presentation.WebUI/eslint.config.js
+++ b/src/Content/Presentation/Presentation.WebUI/eslint.config.js
@@ -6,7 +6,11 @@ import tseslint from 'typescript-eslint'
 import { defineConfig, globalIgnores } from 'eslint/config'
 
 export default defineConfig([
-  globalIgnores(['dist']),
+  // `coverage` holds the v8/istanbul HTML report, including vendored scripts
+  // (prettify.js, sorter.js, block-navigation.js) that are generated output, not source.
+  // Linting them produced findings nobody can act on and that regenerate on every
+  // `test:coverage` run. `dist` is excluded for the same reason.
+  globalIgnores(['dist', 'coverage']),
   {
     files: ['**/*.{ts,tsx}'],
     extends: [

--- a/src/Content/Presentation/Presentation.WebUI/src/__tests__/ThemeProvider.test.tsx
+++ b/src/Content/Presentation/Presentation.WebUI/src/__tests__/ThemeProvider.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
-import { ThemeProvider, useTheme } from '@/components/theme/ThemeProvider';
+import { ThemeProvider } from '@/components/theme/ThemeProvider';
+import { useTheme } from '@/components/theme/themeContext';
 
 function TestConsumer() {
   const { theme, toggleTheme } = useTheme();

--- a/src/Content/Presentation/Presentation.WebUI/src/components/layout/DashboardLayout.tsx
+++ b/src/Content/Presentation/Presentation.WebUI/src/components/layout/DashboardLayout.tsx
@@ -134,11 +134,18 @@ export function DashboardLayout() {
         <SidebarSwitcher />
         <Outlet />
       </div>
-      <CommandPalette
-        open={paletteOpen}
-        onClose={() => { setPaletteOpen(false); }}
-        commands={commands}
-      />
+      {/*
+        Mounted only while open. The palette used to stay mounted and reset its own query and
+        highlight from a useEffect keyed on `open` — state adjustment from inside an effect,
+        which costs an extra render pass on every open. Mount/unmount gives the same reset for
+        free, because fresh state is what mounting means.
+      */}
+      {paletteOpen && (
+        <CommandPalette
+          onClose={() => { setPaletteOpen(false); }}
+          commands={commands}
+        />
+      )}
     </div>
   );
 }

--- a/src/Content/Presentation/Presentation.WebUI/src/components/layout/Header.tsx
+++ b/src/Content/Presentation/Presentation.WebUI/src/components/layout/Header.tsx
@@ -1,7 +1,7 @@
 import { Moon, Sun, Monitor, Command } from 'lucide-react';
 import { useMsal } from '@azure/msal-react';
 import { useTheme } from '@/hooks/useTheme';
-import type { ThemePreference } from '@/components/theme/ThemeProvider';
+import type { ThemePreference } from '@/components/theme/themeContext';
 import { IS_AUTH_DISABLED } from '@/lib/devAuth';
 import { useAgentHub, type ConnectionState } from '@/hooks/useAgentHub';
 import { cn } from '@/lib/utils';

--- a/src/Content/Presentation/Presentation.WebUI/src/components/theme/ThemeProvider.tsx
+++ b/src/Content/Presentation/Presentation.WebUI/src/components/theme/ThemeProvider.tsx
@@ -1,19 +1,13 @@
-import { createContext, useContext, useEffect, useState, type ReactNode } from 'react';
+import { useEffect, useState, type ReactNode } from 'react';
+import {
+  ThemeContext,
+  THEME_STORAGE_KEY,
+  type ResolvedTheme,
+  type ThemePreference,
+} from './themeContext';
 
-export type ThemePreference = 'light' | 'dark' | 'system';
-export type ResolvedTheme = 'light' | 'dark';
-
-interface ThemeContextValue {
-  theme: ResolvedTheme;
-  preference: ThemePreference;
-  resolvedTheme: ResolvedTheme;
-  setTheme: (pref: ThemePreference) => void;
-  toggleTheme: () => void;
-}
-
-export const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
-
-const STORAGE_KEY = 'theme';
+// Component-only module on purpose: the context, its types and the useTheme hook live in
+// ./themeContext so Fast Refresh can hot-swap this provider instead of forcing a full reload.
 
 function getSystemTheme(): ResolvedTheme {
   if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return 'light';
@@ -22,7 +16,7 @@ function getSystemTheme(): ResolvedTheme {
 
 function getInitialPreference(): ThemePreference {
   if (typeof localStorage === 'undefined') return 'system';
-  const stored = localStorage.getItem(STORAGE_KEY);
+  const stored = localStorage.getItem(THEME_STORAGE_KEY);
   if (stored === 'light' || stored === 'dark' || stored === 'system') return stored;
   return 'system';
 }
@@ -49,7 +43,7 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
 
   useEffect(() => {
     document.documentElement.dataset['theme'] = resolvedTheme;
-    localStorage.setItem(STORAGE_KEY, preference);
+    localStorage.setItem(THEME_STORAGE_KEY, preference);
   }, [resolvedTheme, preference]);
 
   const setTheme = (pref: ThemePreference): void => { setPreference(pref); };
@@ -62,12 +56,4 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
       {children}
     </ThemeContext.Provider>
   );
-}
-
-export function useTheme(): ThemeContextValue {
-  const context = useContext(ThemeContext);
-  if (!context) {
-    throw new Error('useTheme must be used within a ThemeProvider');
-  }
-  return context;
 }

--- a/src/Content/Presentation/Presentation.WebUI/src/components/theme/themeContext.ts
+++ b/src/Content/Presentation/Presentation.WebUI/src/components/theme/themeContext.ts
@@ -1,0 +1,36 @@
+import { createContext, useContext } from 'react';
+
+/**
+ * Context, types and consumer hook for the theme system, kept OUT of ThemeProvider.tsx.
+ *
+ * Fast Refresh only preserves component state for modules that export components and nothing
+ * else. With the context and `useTheme` living beside the provider, every theme change edited
+ * a module with mixed exports and forced a full reload instead of a hot swap. Splitting the
+ * non-component exports here leaves ThemeProvider.tsx component-only.
+ *
+ * This file deliberately has no `.tsx` extension and renders nothing — it is types and a hook.
+ */
+
+export type ThemePreference = 'light' | 'dark' | 'system';
+export type ResolvedTheme = 'light' | 'dark';
+
+export interface ThemeContextValue {
+  theme: ResolvedTheme;
+  preference: ThemePreference;
+  resolvedTheme: ResolvedTheme;
+  setTheme: (pref: ThemePreference) => void;
+  toggleTheme: () => void;
+}
+
+export const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
+
+/** Storage key for the persisted preference. Shared with ThemeProvider. */
+export const THEME_STORAGE_KEY = 'theme';
+
+export function useTheme(): ThemeContextValue {
+  const context = useContext(ThemeContext);
+  if (!context) {
+    throw new Error('useTheme must be used within a ThemeProvider');
+  }
+  return context;
+}

--- a/src/Content/Presentation/Presentation.WebUI/src/components/ui/badge.tsx
+++ b/src/Content/Presentation/Presentation.WebUI/src/components/ui/badge.tsx
@@ -49,4 +49,5 @@ function Badge({
   })
 }
 
-export { Badge, badgeVariants }
+// Not exporting badgeVariants — see the note in button.tsx.
+export { Badge }

--- a/src/Content/Presentation/Presentation.WebUI/src/components/ui/button.tsx
+++ b/src/Content/Presentation/Presentation.WebUI/src/components/ui/button.tsx
@@ -55,4 +55,8 @@ function Button({
   )
 }
 
-export { Button, buttonVariants }
+// `buttonVariants` is intentionally NOT exported: nothing in the app imported it, and a
+// non-component export here is what breaks Fast Refresh for the whole module. If a consumer
+// of this template needs it, move the cva() call to a sibling `button-variants.ts` and export
+// it from there — that is shadcn's own guidance and keeps this file component-only.
+export { Button }

--- a/src/Content/Presentation/Presentation.WebUI/src/components/ui/tabs.tsx
+++ b/src/Content/Presentation/Presentation.WebUI/src/components/ui/tabs.tsx
@@ -79,4 +79,5 @@ function TabsContent({ className, ...props }: TabsPrimitive.Panel.Props) {
   )
 }
 
-export { Tabs, TabsList, TabsTrigger, TabsContent, tabsListVariants }
+// Not exporting tabsListVariants — see the note in button.tsx.
+export { Tabs, TabsList, TabsTrigger, TabsContent }

--- a/src/Content/Presentation/Presentation.WebUI/src/features/chat/ChatPanel.tsx
+++ b/src/Content/Presentation/Presentation.WebUI/src/features/chat/ChatPanel.tsx
@@ -175,7 +175,18 @@ export function ChatPanel() {
   // handler intercepts (so nothing clears the previous conversation's messages first). An
   // optimistic/in-flight transcript that DOES belong to this id (a freshly minted id that was just
   // sent, or a turn mid-stream) is preserved rather than clobbered by a reload.
+  /* eslint-disable react-hooks/set-state-in-effect -- see the note at the top of the effect */
   useEffect(() => {
+    // The rule is right in general: setting state synchronously in an effect costs a second
+    // render pass. It is suppressed here rather than refactored because this effect is the
+    // conversation-load ORCHESTRATOR, not a state adjustment — the readiness flag gates the
+    // transcript render against navigation, an in-flight send, and a mid-stream turn at once,
+    // so it cannot be derived from props during render.
+    //
+    // This is also the code path behind the phantom-chat defects fixed in #174-#176. The
+    // cost of the extra render pass is one frame; the cost of getting a restructure wrong
+    // here is a class of bug this repo has already paid to fix twice. Deliberate trade, not
+    // an oversight. Revisit with the ChatPanel tests as the guard, in a PR of its own.
     if (!activeConversationId) {
       // Blank composer (`/chat` with no id) — ready immediately, nothing to load.
       setConversationReady(true);
@@ -217,6 +228,7 @@ export function ChatPanel() {
       });
     return () => { cancelled = true; };
   }, [activeConversationId, setChatConversationId]);
+  /* eslint-enable react-hooks/set-state-in-effect -- scope ends with the load orchestrator */
 
   if (!selectedAgent) {
     return (

--- a/src/Content/Presentation/Presentation.WebUI/src/features/commands/CommandPalette.tsx
+++ b/src/Content/Presentation/Presentation.WebUI/src/features/commands/CommandPalette.tsx
@@ -11,7 +11,6 @@ export interface CommandItem {
 }
 
 interface CommandPaletteProps {
-  open: boolean;
   onClose: () => void;
   commands: CommandItem[];
 }
@@ -25,34 +24,38 @@ function matches(item: CommandItem, query: string): boolean {
   return (item.keywords ?? []).some((k) => k.toLowerCase().includes(q));
 }
 
-export function CommandPalette({ open, onClose, commands }: CommandPaletteProps) {
+// Rendered only while open (DashboardLayout mounts it conditionally), so there is no `open`
+// prop and no reset effect: mounting IS the reset. The previous form stayed mounted and
+// cleared its own query/highlight from an effect, which is state adjustment inside an effect
+// and cost an extra render pass on every open.
+export function CommandPalette({ onClose, commands }: CommandPaletteProps) {
   const [query, setQuery] = useState('');
   const [activeIndex, setActiveIndex] = useState(0);
   const inputRef = useRef<HTMLInputElement>(null);
   const listRef = useRef<HTMLUListElement>(null);
 
+  // Focus is a genuine post-commit DOM effect, not state adjustment. rAF defers to after the
+  // dialog is painted, which is what makes the caret land reliably on first open.
   useEffect(() => {
-    if (!open) return;
-    setQuery('');
-    setActiveIndex(0);
     requestAnimationFrame(() => { inputRef.current?.focus(); });
-  }, [open]);
+  }, []);
 
   const filtered = useMemo(
     () => commands.filter((c) => matches(c, query)),
     [commands, query],
   );
 
-  useEffect(() => {
-    if (activeIndex >= filtered.length) setActiveIndex(0);
-  }, [filtered, activeIndex]);
+  // Clamped during render rather than corrected by an effect. The effect form committed one
+  // render in which activeIndex pointed past the end of `filtered` — so for a frame the
+  // highlighted row was simply absent, and Enter in that frame resolved against an
+  // out-of-range index. Deriving makes the out-of-range state unrepresentable instead of
+  // merely short-lived.
+  const activeIdx = activeIndex >= filtered.length ? 0 : activeIndex;
 
   useEffect(() => {
-    const el = listRef.current?.children[activeIndex] as HTMLElement | undefined;
+    const el = listRef.current?.children[activeIdx] as HTMLElement | undefined;
     el?.scrollIntoView({ block: 'nearest' });
-  }, [activeIndex]);
-
-  if (!open) return null;
+  }, [activeIdx]);
 
   const runItem = (item: CommandItem): void => {
     item.run();
@@ -68,7 +71,8 @@ export function CommandPalette({ open, onClose, commands }: CommandPaletteProps)
       setActiveIndex((i) => (filtered.length === 0 ? 0 : (i - 1 + filtered.length) % filtered.length));
     } else if (e.key === 'Enter') {
       e.preventDefault();
-      if (filtered[activeIndex]) runItem(filtered[activeIndex]);
+      const item = filtered[activeIdx];
+      if (item) runItem(item);
     } else if (e.key === 'Escape') {
       e.preventDefault();
       onClose();
@@ -119,7 +123,7 @@ export function CommandPalette({ open, onClose, commands }: CommandPaletteProps)
                 </div>
                 {items.map((item) => {
                   flatIndex += 1;
-                  const isActive = flatIndex === activeIndex;
+                  const isActive = flatIndex === activeIdx;
                   const myIndex = flatIndex;
                   return (
                     <li

--- a/src/Content/Presentation/Presentation.WebUI/src/features/commands/CommandPalette.tsx
+++ b/src/Content/Presentation/Presentation.WebUI/src/features/commands/CommandPalette.tsx
@@ -50,7 +50,14 @@ export function CommandPalette({ onClose, commands }: CommandPaletteProps) {
   // highlighted row was simply absent, and Enter in that frame resolved against an
   // out-of-range index. Deriving makes the out-of-range state unrepresentable instead of
   // merely short-lived.
-  const activeIdx = activeIndex >= filtered.length ? 0 : activeIndex;
+  //
+  // The arrow-key updaters below clamp through the SAME function before stepping. Clamping
+  // only the painted value while letting the updaters step from raw state is a half-applied
+  // fix: if `filtered` shrinks without going through onChange — the commands prop resolving
+  // with fewer entries is the live path — the highlight shows row 0 while the next ArrowDown
+  // moves to (staleIndex + 1), landing somewhere the user never selected.
+  const clamp = (i: number): number => (i >= filtered.length ? 0 : i);
+  const activeIdx = clamp(activeIndex);
 
   useEffect(() => {
     const el = listRef.current?.children[activeIdx] as HTMLElement | undefined;
@@ -65,10 +72,10 @@ export function CommandPalette({ onClose, commands }: CommandPaletteProps) {
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>): void => {
     if (e.key === 'ArrowDown') {
       e.preventDefault();
-      setActiveIndex((i) => (filtered.length === 0 ? 0 : (i + 1) % filtered.length));
+      setActiveIndex((i) => (filtered.length === 0 ? 0 : (clamp(i) + 1) % filtered.length));
     } else if (e.key === 'ArrowUp') {
       e.preventDefault();
-      setActiveIndex((i) => (filtered.length === 0 ? 0 : (i - 1 + filtered.length) % filtered.length));
+      setActiveIndex((i) => (filtered.length === 0 ? 0 : (clamp(i) - 1 + filtered.length) % filtered.length));
     } else if (e.key === 'Enter') {
       e.preventDefault();
       const item = filtered[activeIdx];

--- a/src/Content/Presentation/Presentation.WebUI/src/hooks/useAgentHub.tsx
+++ b/src/Content/Presentation/Presentation.WebUI/src/hooks/useAgentHub.tsx
@@ -1,3 +1,19 @@
+/* eslint-disable react-refresh/only-export-components --
+ * `AgentHubProvider` (component) and `useAgentHub` (hook) stay in one module deliberately.
+ *
+ * The rule's remedy is to move the hook to its own file. Four test files bind
+ * `vi.mock('@/hooks/useAgentHub', ...)` to this exact module path and substitute the provider,
+ * the hook, or both; splitting would leave each mock intercepting only half of a pair that the
+ * component under test still uses together, so the real provider would open a live SignalR
+ * connection inside the suite. That is a rewrite of four mock factories.
+ *
+ * What it would buy is Fast Refresh on a module that owns a websocket. Hot-swapping it tears
+ * down and re-establishes the hub connection, so the reload this rule prevents is the
+ * behaviour you actually want here.
+ *
+ * Cost is four fragile test rewrites, benefit is negative. Scoped to this file.
+ * Contrast ThemeProvider, where the same split was clean and was done.
+ */
 import { useContext, createContext, useRef, useState, useEffect, type ReactNode } from 'react';
 import { useMsal } from '@azure/msal-react';
 import type { HubConnection } from '@microsoft/signalr';

--- a/src/Content/Presentation/Presentation.WebUI/src/hooks/useTheme.ts
+++ b/src/Content/Presentation/Presentation.WebUI/src/hooks/useTheme.ts
@@ -1,1 +1,4 @@
-export { useTheme } from '@/components/theme/ThemeProvider';
+// Re-export kept so app code imports the hook from @/hooks like every other hook. The
+// definition moved to the theme context module when ThemeProvider.tsx was made
+// component-only for Fast Refresh.
+export { useTheme } from '@/components/theme/themeContext';

--- a/src/Content/Presentation/Presentation.WebUI/src/stores/conversationSettingsStore.ts
+++ b/src/Content/Presentation/Presentation.WebUI/src/stores/conversationSettingsStore.ts
@@ -27,7 +27,12 @@ export const useConversationSettingsStore = create<ConversationSettingsState>((s
   },
   clear: (conversationId) => {
     set((state) => {
-      const { [conversationId]: _removed, ...rest } = state.byConversationId;
+      // Copy-then-delete rather than a rest-destructure with a discarded binding: the
+      // `{ [k]: _removed, ...rest }` form only compiles by naming a variable it never uses.
+      // `rest` is a fresh object either way, so the store's state is still replaced, never
+      // mutated in place.
+      const rest = { ...state.byConversationId };
+      delete rest[conversationId];
       return { byConversationId: rest };
     });
   },


### PR DESCRIPTION
PR 3 of 3 on frontend CI — the last leg. ([#229](https://github.com/MCKRUZ/microsoft-agentic-harness/pull/229) tests, [#230](https://github.com/MCKRUZ/microsoft-agentic-harness/pull/230) typecheck.) **35 lint errors → 0**, and lint now blocks alongside the other two.

## Two were real React defects, not style

**`useAutoRefresh` assigned to a ref during render.** React may discard or re-run a render, so the write can be lost or applied twice, and a concurrent interleave can leave the ref pointing at a callback from a tree that was never committed. Now synced in an effect — the interval fires asynchronously, so it never observes the ref early.

**`useSessionsFilter` corrected its own state from a `useEffect`.** That cost a second render pass and, in between, painted *exactly the silent-empty-list state the effect existed to prevent* — the old comment even said so ("the useEffect above will clear the selection on the next paint"). Now derived during render, so the roster and the selection cannot disagree in a committed render. The raw id stays in state deliberately, so a roster that briefly empties during a refetch restores the user's selection instead of discarding it.

Also: `CommandPalette` is now mounted only while open, so its query and highlight reset *by mounting* rather than from an effect; and its active index is clamped during render rather than corrected afterwards — the old form committed one render in which Enter resolved against an out-of-range index.

## The 26 react-refresh errors were 6 files, not 26

Twenty came from `router.tsx` alone. Handled by cause rather than uniformly:

| Files | Treatment | Why |
|---|---|---|
| `badge` `button` `tabs` | **Dropped the `*Variants` exports** | Verified dead — no importer anywhere, including inside `components/ui`. Removing them leaves the files component-only |
| `ThemeProvider` | **Split** context + types + `useTheme` into `themeContext.ts` | Clean; one test import updated. Also removed a duplicated storage-key constant |
| `router.tsx` | Scoped disable | Splitting the `lazy()` consts adds a file to satisfy a rule that cannot apply to a route table — changing routes remounts the tree regardless |
| `useAgentHub` | Scoped disable | See below |

**I measured `allowConstantExport` before proposing it and it does not work here** — `cva()` results aren't literal constants, so button.tsx still errored with the option on. I'd told you it would fix these; that was wrong, and I reverted the config rather than ship an option that does nothing.

**I also revised my own plan on `useAgentHub`.** I said I'd split it. On inspection, four test files bind `vi.mock('@/hooks/useAgentHub')` and substitute the provider, the hook, or both — splitting leaves each mock intercepting half a pair, so the real provider would open a live SignalR connection inside the suite. What it buys is hot reload on a module that owns a websocket, where the full reload the rule prevents is the behaviour you actually want. Four fragile test rewrites for negative benefit, so it got a justified disable instead.

## Three suppressions, all scoped and explained in-file

`router.tsx`, `useAgentHub.tsx`, and a **block** disable around `ChatPanel`'s readiness effect — with a matching `eslint-enable`, verified present, so it cannot leak to the rest of the file.

`ChatPanel` keeps its disable on purpose: that effect is the conversation-load *orchestrator*, not a state adjustment, and it's the code path behind the phantom-chat defects fixed in #174–#176. The extra render pass costs a frame; getting a restructure wrong there costs a bug class this repo has already paid to fix twice. Deliberate trade, flagged rather than buried.

## Config

`eslint` now ignores `coverage/` — generated report output, including vendored scripts (`prettify.js`, `sorter.js`), producing findings nobody can act on that regenerate on every `test:coverage`.

`--max-warnings 0` deliberately **not** set. The 3 remaining warnings are advisory by design: React Compiler's "incompatible library" note on react-hook-form's `watch()`, and two `exhaustive-deps` hints. Errors block; warnings inform. Failing on them would force a suppression or block on someone else's library.

## Test plan

Verified by **exit code**, not by reading the summary line:

| | Dashboard | WebUI |
|---|---|---|
| `npm run lint` | exit 0 (0 errors, 2 warnings) | exit 0 (0 errors, 1 warning) |
| `npm run typecheck` (`tsc -b`) | exit 0 | exit 0 |
| `npm run test` | 385 pass / 52 files | 142 pass / 26 files |

## Still outstanding after this lands

**The frontend jobs are not required checks.** The `main-branch-protection` ruleset pins `build-and-test`, `OWASP Agentic Top-10 Gate`, `security-review`, `correctness-review` only — so these three legs go red without blocking a merge. Now that all three are green, that's a one-line settings change; say the word and I'll add `frontend (Presentation.Dashboard)` and `frontend (Presentation.WebUI)` to the ruleset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SDpwZrPazixLPuNMcUtEPM
