### PR TITLE
fix: repair every unresolvable XML doc reference and enforce them

### DIFF
--- a/src/Content/Application/Application.AI.Common/Evaluation/Metrics/Owasp/OwaspAsi05CodeExecMetric.cs
+++ b/src/Content/Application/Application.AI.Common/Evaluation/Metrics/Owasp/OwaspAsi05CodeExecMetric.cs
@@ -24,7 +24,7 @@ namespace Application.AI.Common.Evaluation.Metrics.Owasp;
 /// Payload shape: <c>Output</c> contains a JSON object with fields
 /// <c>commandRejected</c>, <c>pattern</c>, and <c>hmacIssued</c>.
 /// </para>
-/// <para>Harness control exercised: <see cref="ICapabilityEnforcer"/> + sandbox HMAC attestation gate.</para>
+/// <para>Harness control exercised: <see cref="Application.AI.Common.Interfaces.Sandbox.ICapabilityEnforcer"/> + sandbox HMAC attestation gate.</para>
 /// </remarks>
 public sealed class OwaspAsi05CodeExecMetric : IEvalMetric
 {

--- a/src/Content/Application/Application.AI.Common/Evaluation/Metrics/Owasp/OwaspAsi06MemoryPoisonMetric.cs
+++ b/src/Content/Application/Application.AI.Common/Evaluation/Metrics/Owasp/OwaspAsi06MemoryPoisonMetric.cs
@@ -24,7 +24,7 @@ namespace Application.AI.Common.Evaluation.Metrics.Owasp;
 /// Payload shape: <c>Output</c> contains a JSON object with fields
 /// <c>recallResultCount</c>, <c>attackerNodeExists</c>, and <c>attackerNodeSource</c>.
 /// </para>
-/// <para>Harness control exercised: <see cref="IKnowledgeMemory"/> provenance gating on <c>RecallAsync</c>.</para>
+/// <para>Harness control exercised: <see cref="Application.AI.Common.Interfaces.KnowledgeGraph.IKnowledgeMemory"/> provenance gating on <c>RecallAsync</c>.</para>
 /// </remarks>
 public sealed class OwaspAsi06MemoryPoisonMetric : IEvalMetric
 {

--- a/src/Content/Application/Application.AI.Common/Evaluation/Metrics/Owasp/OwaspAsi09HumanTrustMetric.cs
+++ b/src/Content/Application/Application.AI.Common/Evaluation/Metrics/Owasp/OwaspAsi09HumanTrustMetric.cs
@@ -25,7 +25,7 @@ namespace Application.AI.Common.Evaluation.Metrics.Owasp;
 /// Payload shape: <c>Output</c> contains a JSON object with fields
 /// <c>gateBlocked</c>, <c>reasonCode</c>, <c>approvalsPresent</c>, and <c>destructiveToolInvoked</c>.
 /// </para>
-/// <para>Harness control exercised: <see cref="IEscalationService"/> quorum approval strategy.</para>
+/// <para>Harness control exercised: <see cref="Application.AI.Common.Interfaces.Escalation.IEscalationService"/> quorum approval strategy.</para>
 /// </remarks>
 public sealed class OwaspAsi09HumanTrustMetric : IEvalMetric
 {

--- a/src/Content/Application/Application.AI.Common/Evaluation/Metrics/Owasp/OwaspAsi10RogueAgentMetric.cs
+++ b/src/Content/Application/Application.AI.Common/Evaluation/Metrics/Owasp/OwaspAsi10RogueAgentMetric.cs
@@ -24,7 +24,7 @@ namespace Application.AI.Common.Evaluation.Metrics.Owasp;
 /// Payload shape: <c>Output</c> contains a JSON object with fields
 /// <c>spawnDenied</c>, <c>reason</c>, and <c>childProcessCount</c>.
 /// </para>
-/// <para>Harness control exercised: <see cref="ICapabilityEnforcer"/> closed-by-default fork capability check.</para>
+/// <para>Harness control exercised: <see cref="Application.AI.Common.Interfaces.Sandbox.ICapabilityEnforcer"/> closed-by-default fork capability check.</para>
 /// </remarks>
 public sealed class OwaspAsi10RogueAgentMetric : IEvalMetric
 {

--- a/src/Content/Application/Application.AI.Common/Evaluation/Models/EvalRunSummary.cs
+++ b/src/Content/Application/Application.AI.Common/Evaluation/Models/EvalRunSummary.cs
@@ -9,7 +9,7 @@ namespace Application.AI.Common.Evaluation.Models;
 /// </summary>
 /// <remarks>
 /// Per-case detail is fetched lazily on drill-in via
-/// <see cref="IEvalRunStore.GetRunDetailAsync"/>.
+/// <see cref="Application.AI.Common.Evaluation.Interfaces.IEvalRunStore.GetRunDetailAsync"/>.
 /// </remarks>
 public sealed record EvalRunSummary
 {

--- a/src/Content/Application/Application.AI.Common/Evaluation/Models/JudgeOptions.cs
+++ b/src/Content/Application/Application.AI.Common/Evaluation/Models/JudgeOptions.cs
@@ -9,7 +9,7 @@ namespace Application.AI.Common.Evaluation.Models;
 /// <remarks>
 /// <para>
 /// Bind via <c>services.Configure&lt;JudgeOptions&gt;(...)</c>. When unbound, the default
-/// <see cref="IJudgeChatClientProvider"/> falls back to the first available AI provider
+/// <see cref="Application.AI.Common.Evaluation.Interfaces.IJudgeChatClientProvider"/> falls back to the first available AI provider
 /// from <c>IChatClientFactory.GetAvailableProviders()</c> and the supplied
 /// <see cref="Deployment"/> — so a minimal setup only needs to set <see cref="Deployment"/>.
 /// </para>

--- a/src/Content/Application/Application.AI.Common/Evaluation/Models/LlmJudgeResult.cs
+++ b/src/Content/Application/Application.AI.Common/Evaluation/Models/LlmJudgeResult.cs
@@ -7,7 +7,7 @@ namespace Application.AI.Common.Evaluation.Models;
 /// </summary>
 /// <remarks>
 /// <para>
-/// <see cref="Verdict"/> distinguishes a successful score (<see cref="Outcomes.LlmJudgeOutcome.Parsed"/>)
+/// <see cref="Domain.AI.Evaluation.Verdict"/> distinguishes a successful score (<see cref="Outcomes.LlmJudgeOutcome.Parsed"/>)
 /// from a soft failure (<see cref="Outcomes.LlmJudgeOutcome.Malformed"/> after retry,
 /// or <see cref="Outcomes.LlmJudgeOutcome.InvocationFailed"/> on infra error). Callers
 /// translate the outcome to the appropriate <c>Verdict</c> in their <c>MetricScore</c>.

--- a/src/Content/Application/Application.AI.Common/Extensions/AgentContextExtensions.cs
+++ b/src/Content/Application/Application.AI.Common/Extensions/AgentContextExtensions.cs
@@ -36,7 +36,7 @@ public static class AgentContextExtensions
     /// </summary>
     /// <remarks>
     /// Returns <see cref="ExecutionScope"/> (not raw key-value pairs) so that
-    /// <see cref="ExecutionScopeProvider"/> and formatters can recognize the scope.
+    /// <see cref="Application.Common.Logging.ExecutionScopeProvider"/> and formatters can recognize the scope.
     /// Maps agent concepts to generic execution fields.
     /// </remarks>
     public static ExecutionScope? ToExecutionScope(this IAgentExecutionContext context) =>

--- a/src/Content/Application/Application.AI.Common/Interfaces/Agent/IAgentExecutionContext.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Agent/IAgentExecutionContext.cs
@@ -48,7 +48,7 @@ public interface IAgentExecutionContext
     /// <summary>
     /// Stamps the agent's workload identity onto the execution context. Called once
     /// per agent instance during agent construction (by <c>AgentFactory</c>) after the
-    /// <see cref="IAgentIdentityResolver"/> resolves the identity from the credential
+    /// <see cref="Application.AI.Common.Interfaces.Identity.IAgentIdentityResolver"/> resolves the identity from the credential
     /// hierarchy.
     /// </summary>
     /// <remarks>

--- a/src/Content/Application/Application.AI.Common/Interfaces/Changes/ChangeApplyResult.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Changes/ChangeApplyResult.cs
@@ -3,7 +3,7 @@ namespace Application.AI.Common.Interfaces.Changes;
 /// <summary>
 /// The outcome of an <see cref="IChangeApplier"/>'s attempt to apply a proposal's
 /// diff to its target. Returned to the <c>MergeGate</c>; <see cref="Success"/>
-/// drives the proposal to <c>Merged</c>, <see cref="Failure"/> drives it to
+/// drives the proposal to <c>Merged</c>, <see cref="Failed"/> drives it to
 /// <c>Rejected</c> with the failure reason captured.
 /// </summary>
 /// <remarks>

--- a/src/Content/Application/Application.AI.Common/Interfaces/Context/IContextSnapshotComputer.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Context/IContextSnapshotComputer.cs
@@ -12,13 +12,13 @@ namespace Application.AI.Common.Interfaces.Context;
 /// <para>
 /// Implementations MUST be pure functions of their inputs (no I/O, no clocks
 /// other than what is passed in). The
-/// <see cref="ICompositionRoot.CQRS.Agents.ExecuteAgentTurn.ExecuteAgentTurnCommandHandler"/>
+/// <c>Application.Core.CQRS.Agents.ExecuteAgentTurn.ExecuteAgentTurnCommandHandler</c>
 /// calls this once per turn after the assistant message has been recorded,
 /// then passes the result to <see cref="IContextSnapshotNotifier"/>.
 /// </para>
 /// <para>
 /// PR 3 v1 derives the breakdown post-hoc from the turn's
-/// <paramref name="inputTokens"/> usage and the post-turn message history,
+/// <c>inputTokens</c> usage and the post-turn message history,
 /// lumping the entire system-prompt area into <see cref="ContextCategory.System"/>.
 /// A follow-up that plumbs <c>SystemPromptSection</c> data through will replace
 /// the implementation without touching this contract.

--- a/src/Content/Application/Application.AI.Common/Interfaces/Context/IContextSnapshotNotifier.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Context/IContextSnapshotNotifier.cs
@@ -11,7 +11,7 @@ namespace Application.AI.Common.Interfaces.Context;
 /// <remarks>
 /// <para>
 /// Called by
-/// <see cref="CQRS.Agents.ExecuteAgentTurn.ExecuteAgentTurnCommandHandler"/>
+/// <c>Application.Core.CQRS.Agents.ExecuteAgentTurn.ExecuteAgentTurnCommandHandler</c>
 /// after each successful turn, AFTER the assistant message has been recorded.
 /// </para>
 /// <para>

--- a/src/Content/Application/Application.AI.Common/Interfaces/Governance/IAutonomyTierResolver.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Governance/IAutonomyTierResolver.cs
@@ -5,7 +5,7 @@ namespace Application.AI.Common.Interfaces.Governance;
 
 /// <summary>
 /// Resolves the effective autonomy tier for an agent.
-/// Accepts <see cref="SubagentType"/> because <see cref="ISubagentProfileRegistry"/>
+/// Accepts <see cref="SubagentType"/> because <see cref="Application.AI.Common.Interfaces.Agents.ISubagentProfileRegistry"/>
 /// is keyed by type, not agent ID.
 /// </summary>
 public interface IAutonomyTierResolver

--- a/src/Content/Application/Application.AI.Common/Interfaces/IFoundryAgentProvider.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/IFoundryAgentProvider.cs
@@ -17,7 +17,7 @@ namespace Application.AI.Common.Interfaces;
 /// Application layer compiles against only <c>Microsoft.Extensions.*</c> abstractions.
 /// </para>
 /// <para>
-/// The harness middleware pipeline is injected via the <paramref name="clientFactory"/> hook so the
+/// The harness middleware pipeline is injected via the <c>clientFactory</c> hook so the
 /// Foundry-hosted inference path retains OpenTelemetry, function invocation, observability,
 /// prerequisite gating, and distributed caching exactly as the other providers do.
 /// </para>

--- a/src/Content/Application/Application.AI.Common/Interfaces/Identity/IAgentIdentityResolver.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Identity/IAgentIdentityResolver.cs
@@ -26,7 +26,7 @@ namespace Application.AI.Common.Interfaces.Identity;
 /// Returns a failure result with the aggregated <c>agent_identity.no_provider_succeeded</c>
 /// error code when every registered provider has been tried and none succeeded.
 /// Caller MUST NOT proceed without an identity when
-/// <see cref="Domain.Common.Config.AI.AppConfig"/>'s identity flag is enabled.
+/// <see cref="Domain.Common.Config.AppConfig"/>'s identity flag is enabled.
 /// </para>
 /// </remarks>
 public interface IAgentIdentityResolver

--- a/src/Content/Application/Application.AI.Common/Interfaces/Identity/IAgentIdentityValidator.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Identity/IAgentIdentityValidator.cs
@@ -13,7 +13,7 @@ namespace Application.AI.Common.Interfaces.Identity;
 /// <para>
 /// Fail closed: missing policy is treated as deny, not allow. An unregistered tool
 /// key returns <c>false</c>; an identity with <see cref="AgentIdentityKind.Unspecified"/>
-/// returns <c>false</c>. This matches <see cref="IKnowledgeScopeValidator"/>'s
+/// returns <c>false</c>. This matches <see cref="Application.AI.Common.Interfaces.KnowledgeGraph.IKnowledgeScopeValidator"/>'s
 /// behaviour and mirrors the global guidance — security defaults must be the correct
 /// defaults.
 /// </para>

--- a/src/Content/Application/Application.AI.Common/Interfaces/KnowledgeGraph/IKnowledgeGraphStore.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/KnowledgeGraph/IKnowledgeGraphStore.cs
@@ -27,7 +27,7 @@ namespace Application.AI.Common.Interfaces.KnowledgeGraph;
 ///   <item>Edge deduplication is by <see cref="GraphEdge.Id"/>. Duplicate edges are
 ///         silently ignored.</item>
 ///   <item>Graph traversal (<see cref="GetNeighborsAsync"/>) must respect
-///         <paramref name="maxDepth"/> to prevent unbounded expansion.</item>
+///         <c>maxDepth</c> to prevent unbounded expansion.</item>
 /// </list>
 /// </para>
 /// </remarks>

--- a/src/Content/Application/Application.AI.Common/Interfaces/MediatR/IConsumesPrompts.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/MediatR/IConsumesPrompts.cs
@@ -2,7 +2,7 @@ namespace Application.AI.Common.Interfaces.MediatR;
 
 /// <summary>
 /// Marker interface for MediatR requests that resolve and use one or more prompts
-/// from <see cref="Prompts.Interfaces.IPromptRegistry"/> during their execution.
+/// from <see cref="Application.AI.Common.Prompts.Interfaces.IPromptRegistry"/> during their execution.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -11,8 +11,8 @@ namespace Application.AI.Common.Interfaces.MediatR;
 /// <see cref="IConsumesPrompts"/> pass through the behavior without any prompt-usage recording.
 /// </para>
 /// <para>
-/// Handlers for marker-bearing requests should not call <see cref="Prompts.Interfaces.IPromptUsageRecorder"/>
-/// directly — they call <see cref="Prompts.Interfaces.IPromptUsageBag.Track"/> instead, and the
+/// Handlers for marker-bearing requests should not call <see cref="Application.AI.Common.Prompts.Interfaces.IPromptUsageRecorder"/>
+/// directly — they call <see cref="Application.AI.Common.Prompts.Interfaces.IPromptUsageBag.Track"/> instead, and the
 /// behavior drains the bag and records each entry after the handler completes (including on
 /// partial failure). This avoids double-recording when a service intermediate (e.g.
 /// <c>ConversationFactExtractor</c>) also records — services that own their own recording

--- a/src/Content/Application/Application.AI.Common/Interfaces/RAG/IChunkingService.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/RAG/IChunkingService.cs
@@ -11,7 +11,7 @@ namespace Application.AI.Common.Interfaces.RAG;
 /// <remarks>
 /// <para><strong>Implementation guidance:</strong></para>
 /// <list type="bullet">
-///   <item><c>"structure_aware"</c> (default): Uses <paramref name="structure"/> to split at
+///   <item><c>"structure_aware"</c> (default): Uses <c>structure</c> to split at
 ///         heading boundaries, respecting the document's natural organization. Preferred for
 ///         structured documents (specs, docs, reports).</item>
 ///   <item><c>"semantic"</c>: Uses embedding similarity between sentences to detect topic

--- a/src/Content/Application/Application.AI.Common/Interfaces/RAG/ICitationTracker.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/RAG/ICitationTracker.cs
@@ -14,7 +14,7 @@ namespace Application.AI.Common.Interfaces.RAG;
 ///   <item>Register as <c>Transient</c> — each assembly operation gets a fresh tracker
 ///         instance. Do not share across concurrent assemblies.</item>
 ///   <item>Track is called by the assembler as it appends each chunk's text to the output
-///         buffer. The <paramref name="assembledOffset"/> and <paramref name="length"/>
+///         buffer. The <c>assembledOffset</c> and <c>length</c>
 ///         describe the span within the assembled string.</item>
 ///   <item><see cref="GetCitations"/> should return spans sorted by offset ascending
 ///         so consumers can walk citations in document order.</item>

--- a/src/Content/Application/Application.AI.Common/Interfaces/RAG/IContextualEnricher.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/RAG/IContextualEnricher.cs
@@ -12,7 +12,7 @@ namespace Application.AI.Common.Interfaces.RAG;
 /// <remarks>
 /// <para><strong>Implementation guidance:</strong></para>
 /// <list type="bullet">
-///   <item>Use <see cref="IModelRouter"/> to select an economy-tier model — this is a
+///   <item>Use <see cref="Application.AI.Common.Interfaces.Routing.IModelRouter"/> to select an economy-tier model — this is a
 ///         high-volume, low-complexity LLM call (one per chunk).</item>
 ///   <item>Batch chunks to maximize throughput; respect rate limits via retry policies.</item>
 ///   <item>The prompt template should include the full document text (or a large window around

--- a/src/Content/Application/Application.AI.Common/Interfaces/RAG/IDocumentParser.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/RAG/IDocumentParser.cs
@@ -12,7 +12,7 @@ namespace Application.AI.Common.Interfaces.RAG;
 ///   <item>Each parser implementation should target a single document format family.</item>
 ///   <item>Return clean Markdown with heading hierarchy preserved — downstream
 ///         <see cref="IStructureExtractor"/> relies on <c># / ## / ###</c> headings.</item>
-///   <item>Resolve relative URIs (images, links) against <paramref name="documentUri"/>
+///   <item>Resolve relative URIs (images, links) against <c>documentUri</c>
 ///         so extracted content is self-contained.</item>
 ///   <item>Throw <c>NotSupportedException</c> if the URI's extension is not in
 ///         <see cref="SupportedExtensions"/>.</item>

--- a/src/Content/Application/Application.AI.Common/Interfaces/RAG/IGraphRagService.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/RAG/IGraphRagService.cs
@@ -21,7 +21,7 @@ namespace Application.AI.Common.Interfaces.RAG;
 ///   <item><see cref="LocalSearchAsync"/>: Starting from entities mentioned in the query,
 ///         traverse the graph neighborhood to find relevant chunks. Returns results
 ///         compatible with the standard reranking pipeline.</item>
-///   <item>Indexing is expensive (many LLM calls). Use <see cref="IModelRouter"/> to
+///   <item>Indexing is expensive (many LLM calls). Use <see cref="Application.AI.Common.Interfaces.Routing.IModelRouter"/> to
 ///         route entity extraction to an economy-tier model.</item>
 ///   <item>Graph storage: Use a graph database (Neo4j, Cosmos DB Gremlin) or an in-memory
 ///         representation for small corpora.</item>

--- a/src/Content/Application/Application.AI.Common/Interfaces/RAG/IHybridRetriever.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/RAG/IHybridRetriever.cs
@@ -15,7 +15,7 @@ namespace Application.AI.Common.Interfaces.RAG;
 ///         concurrently via <c>Task.WhenAll</c> for optimal latency.</item>
 ///   <item>Apply RRF formula: <c>score = sum(1 / (k + rank_i))</c> where <c>k</c> is typically
 ///         60 (configurable via <c>AppConfig:AI:Rag:RrfK</c>).</item>
-///   <item>Request more candidates from each store than <paramref name="topK"/> (typically 2-3x)
+///   <item>Request more candidates from each store than <c>topK</c> (typically 2-3x)
 ///         to ensure sufficient overlap for meaningful fusion.</item>
 ///   <item>Populate both <see cref="RetrievalResult.DenseScore"/> and
 ///         <see cref="RetrievalResult.SparseScore"/> on each fused result for observability.</item>

--- a/src/Content/Application/Application.AI.Common/Interfaces/RAG/IQueryClassifier.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/RAG/IQueryClassifier.cs
@@ -12,7 +12,7 @@ namespace Application.AI.Common.Interfaces.RAG;
 /// <remarks>
 /// <para><strong>Implementation guidance:</strong></para>
 /// <list type="bullet">
-///   <item>Use a lightweight, fast model (economy tier via <see cref="IModelRouter"/>)
+///   <item>Use a lightweight, fast model (economy tier via <see cref="Application.AI.Common.Interfaces.Routing.IModelRouter"/>)
 ///         since classification is on the critical path for every query.</item>
 ///   <item>Prompt design: Include 2-3 few-shot examples per query type. The prompt should
 ///         output structured JSON with type, strategy, confidence, and reasoning fields.</item>

--- a/src/Content/Application/Application.AI.Common/Interfaces/RAG/IQueryTransformer.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/RAG/IQueryTransformer.cs
@@ -18,7 +18,7 @@ namespace Application.AI.Common.Interfaces.RAG;
 ///         documentation style).</item>
 ///   <item><c>"none"</c>: Returns the original query as a single-element list. Used when
 ///         transformation is disabled or the query classifier indicates a simple lookup.</item>
-///   <item>Use <see cref="IModelRouter"/> to select an economy-tier model for generation —
+///   <item>Use <see cref="Application.AI.Common.Interfaces.Routing.IModelRouter"/> to select an economy-tier model for generation —
 ///         query transformations don't need the best model.</item>
 ///   <item>The returned list always contains at least one query (the original or transformed).</item>
 /// </list>

--- a/src/Content/Application/Application.AI.Common/Interfaces/RAG/IRagContextAssembler.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/RAG/IRagContextAssembler.cs
@@ -15,7 +15,7 @@ namespace Application.AI.Common.Interfaces.RAG;
 ///         deduplication → budget enforcement → text formatting → citation tracking
 ///         (<see cref="ICitationTracker"/>).</item>
 ///   <item>Budget enforcement: Sort by rerank score descending and greedily include chunks
-///         until the <paramref name="maxTokens"/> budget is exhausted. Set
+///         until the <c>maxTokens</c> budget is exhausted. Set
 ///         <see cref="RagAssembledContext.WasTruncated"/> when chunks were dropped.</item>
 ///   <item>Text formatting: Separate chunks with configurable delimiters (e.g.,
 ///         <c>"\n---\n"</c>). Optionally prepend each chunk's <see cref="DocumentChunk.SectionPath"/>

--- a/src/Content/Application/Application.AI.Common/Interfaces/RAG/IRagOrchestrator.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/RAG/IRagOrchestrator.cs
@@ -18,7 +18,7 @@ namespace Application.AI.Common.Interfaces.RAG;
 ///   <item>Use <see cref="IQueryClassifier"/> to determine the retrieval strategy, then
 ///         dispatch to the appropriate retriever (<see cref="IHybridRetriever"/>,
 ///         <see cref="IVectorStore"/>-only, or <see cref="IGraphRagService"/>).</item>
-///   <item>The <paramref name="strategyOverride"/> parameter bypasses classification,
+///   <item>The <c>strategyOverride</c> parameter bypasses classification,
 ///         allowing callers to force a specific strategy for testing or specialized workflows.</item>
 ///   <item>Wrap the entire pipeline in an OpenTelemetry activity span with stage-level
 ///         child spans for end-to-end latency visibility.</item>

--- a/src/Content/Application/Application.AI.Common/Interfaces/RAG/IRaptorSummarizer.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/RAG/IRaptorSummarizer.cs
@@ -14,9 +14,9 @@ namespace Application.AI.Common.Interfaces.RAG;
 /// <list type="bullet">
 ///   <item>Clustering: Use Gaussian Mixture Models (GMM) or k-means on chunk embeddings.
 ///         GMM is preferred because chunks can belong to multiple clusters (soft assignment).</item>
-///   <item>Summarization: Use <see cref="IModelRouter"/> to select an economy-tier model —
+///   <item>Summarization: Use <see cref="Application.AI.Common.Interfaces.Routing.IModelRouter"/> to select an economy-tier model —
 ///         this is a high-volume operation. Each cluster of 5-10 chunks produces one summary.</item>
-///   <item>Recursion depth: <paramref name="maxDepth"/> controls how many levels of summaries
+///   <item>Recursion depth: <c>maxDepth</c> controls how many levels of summaries
 ///         are generated. Typical values: 2-3. Depth 0 means no summarization.</item>
 ///   <item>The returned list includes both the original leaf chunks and all generated summary
 ///         chunks, each tagged with their RAPTOR level in metadata.</item>

--- a/src/Content/Application/Application.AI.Common/Interfaces/RAG/IReranker.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/RAG/IReranker.cs
@@ -21,7 +21,7 @@ namespace Application.AI.Common.Interfaces.RAG;
 ///         Used when reranking is disabled or for benchmarking.</item>
 ///   <item>Reranking is expensive — only process the top N results from retrieval
 ///         (configured via <c>AppConfig:AI:Rag:RerankCandidates</c>, typically 20-50).</item>
-///   <item>Return exactly <paramref name="topK"/> results (or fewer if input is smaller),
+///   <item>Return exactly <c>topK</c> results (or fewer if input is smaller),
 ///         sorted by descending rerank score.</item>
 /// </list>
 /// </remarks>

--- a/src/Content/Application/Application.AI.Common/Interfaces/RAG/IVectorStore.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/RAG/IVectorStore.cs
@@ -17,7 +17,7 @@ namespace Application.AI.Common.Interfaces.RAG;
 ///         normalized to [0, 1] in the returned <see cref="RetrievalResult.DenseScore"/>.</item>
 ///   <item>Collection names enable multi-tenant or multi-corpus isolation within a single
 ///         backend deployment. When null, use the default collection from configuration.</item>
-///   <item>Delete operations remove all chunks for a given <paramref name="documentId"/>,
+///   <item>Delete operations remove all chunks for a given <c>documentId</c>,
 ///         enabling clean re-ingestion workflows.</item>
 ///   <item>Implementations must handle connection pooling and dispose patterns appropriate
 ///         to the backend SDK.</item>

--- a/src/Content/Application/Application.AI.Common/Interfaces/SkillTraining/IRolloutRunner.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/SkillTraining/IRolloutRunner.cs
@@ -15,7 +15,7 @@ namespace Application.AI.Common.Interfaces.SkillTraining;
 /// and tests inject deterministic stubs.
 /// </para>
 /// <para>
-/// Implementations are expected to honor <paramref name="batchSize"/> bounds at the call
+/// Implementations are expected to honor <c>batchSize</c> bounds at the call
 /// site (e.g. via <c>SemaphoreSlim</c>) — the runner returns once all items in the
 /// batch have been scored.
 /// </para>

--- a/src/Content/Application/Application.AI.Common/Notifications/NullContextSnapshotNotifier.cs
+++ b/src/Content/Application/Application.AI.Common/Notifications/NullContextSnapshotNotifier.cs
@@ -9,7 +9,7 @@ namespace Application.AI.Common.Notifications;
 /// </summary>
 /// <remarks>
 /// Registered as the always-on default in the standard composition root so
-/// <see cref="CQRS.Agents.ExecuteAgentTurn.ExecuteAgentTurnCommandHandler"/>
+/// <c>Application.Core.CQRS.Agents.ExecuteAgentTurn.ExecuteAgentTurnCommandHandler</c>
 /// can resolve its dependency unconditionally. The AgentHub host overrides
 /// with a SignalR-backed implementation that also persists to the
 /// observability store. Mirrors <see cref="Evaluation.Notifications.NullEvalRunNotifier"/>.

--- a/src/Content/Application/Application.AI.Common/Prompts/Interfaces/IPromptUsageBag.cs
+++ b/src/Content/Application/Application.AI.Common/Prompts/Interfaces/IPromptUsageBag.cs
@@ -4,7 +4,7 @@ namespace Application.AI.Common.Prompts.Interfaces;
 
 /// <summary>
 /// Request-scoped accumulator for prompts resolved during a MediatR request's lifetime.
-/// Handlers for <see cref="MediatR.IConsumesPrompts"/> requests <see cref="Track"/> each
+/// Handlers for <see cref="Application.AI.Common.Interfaces.MediatR.IConsumesPrompts"/> requests <see cref="Track"/> each
 /// resolved descriptor + context here; the
 /// <see cref="Application.AI.Common.MediatRBehaviors.PromptUsageTrackingBehavior{TRequest,TResponse}"/>
 /// drains the accumulator after the handler completes and forwards every entry to

--- a/src/Content/Application/Application.AI.Common/Services/Agent/AgentExecutionContext.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Agent/AgentExecutionContext.cs
@@ -5,7 +5,7 @@ namespace Application.AI.Common.Services.Agent;
 
 /// <summary>
 /// Scoped ambient context carrying the identity of the currently executing agent.
-/// Set once per request by <see cref="AgentContextPropagationBehavior{TRequest, TResponse}"/>
+/// Set once per request by <see cref="Application.AI.Common.MediatRBehaviors.AgentContextPropagationBehavior{TRequest, TResponse}"/>
 /// and consumed by downstream behaviors, handlers, and services.
 /// </summary>
 /// <remarks>

--- a/src/Content/Application/Application.AI.Common/Services/Agent/KnowledgeMemoryContextProvider.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Agent/KnowledgeMemoryContextProvider.cs
@@ -76,7 +76,7 @@ public sealed class KnowledgeMemoryContextProvider : AIContextProvider
     }
 
     /// <summary>
-    /// Core recall logic, decoupled from <see cref="InvokingContext"/> for testability. Resolves
+    /// Core recall logic, decoupled from <see cref="AIContextProvider.InvokingContext"/> for testability. Resolves
     /// scoped memory from the current request scope, recalls facts relevant to the latest user
     /// message, and formats them as an instructions block to be <em>added</em> to the agent's context.
     /// Returns <see langword="null"/> when recall is disabled, unavailable, or empty — meaning

--- a/src/Content/Application/Application.AI.Common/Services/Agent/LearningsRecallContextProvider.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Agent/LearningsRecallContextProvider.cs
@@ -73,7 +73,7 @@ public sealed class LearningsRecallContextProvider : AIContextProvider
     }
 
     /// <summary>
-    /// Core recall logic, decoupled from <see cref="InvokingContext"/> for testability. Resolves the
+    /// Core recall logic, decoupled from <see cref="AIContextProvider.InvokingContext"/> for testability. Resolves the
     /// scoped recaller from the current request scope, recalls learnings relevant to the latest user
     /// message, and formats them as an instructions block to be <em>added</em> to the agent's context.
     /// Returns <see langword="null"/> when recall is disabled, unavailable, or empty — meaning

--- a/src/Content/Application/Application.Common/Interfaces/Data/ISqlConnectionFactory.cs
+++ b/src/Content/Application/Application.Common/Interfaces/Data/ISqlConnectionFactory.cs
@@ -11,7 +11,7 @@ public interface ISqlConnectionFactory
 {
     /// <summary>
     /// Creates a new database connection using the configured provider and connection string.
-    /// The returned connection is NOT opened — the caller must call <see cref="DbConnection.OpenAsync"/>.
+    /// The returned connection is NOT opened — the caller must call <see cref="System.Data.Common.DbConnection.OpenAsync(System.Threading.CancellationToken)"/>.
     /// </summary>
     DbConnection CreateConnection();
 }

--- a/src/Content/Application/Application.Common/Logging/ExecutionConsoleFormatter.cs
+++ b/src/Content/Application/Application.Common/Logging/ExecutionConsoleFormatter.cs
@@ -10,7 +10,7 @@ namespace Application.Common.Logging;
 /// and optional context indicators.
 /// </summary>
 /// <remarks>
-/// This formatter reads <see cref="ExecutionScope"/> from the scope stack to produce
+/// This formatter reads <see cref="Domain.Common.Logging.ExecutionScope"/> from the scope stack to produce
 /// output like:
 /// <code>
 /// 14:32:01.123 INFO [planner] Starting step 3

--- a/src/Content/Application/Application.Core/Workflows/Orchestration/AgentExecutorFactory.cs
+++ b/src/Content/Application/Application.Core/Workflows/Orchestration/AgentExecutorFactory.cs
@@ -12,7 +12,7 @@ namespace Application.Core.Workflows.Orchestration;
 /// </summary>
 /// <remarks>
 /// <para>
-/// Uses <see cref="ExecutorBindingExtensions.BindAsExecutor{TInput, TOutput}"/> to create
+/// Uses <c>ExecutorBindingExtensions.BindAsExecutor&lt;TInput, TOutput&gt;</c> to create
 /// function-based executors rather than requiring a class per agent. This keeps the workflow
 /// graph construction lightweight: one factory call per agent step.
 /// </para>

--- a/src/Content/Application/Application.Core/Workflows/Orchestration/MultiAgentWorkflow.cs
+++ b/src/Content/Application/Application.Core/Workflows/Orchestration/MultiAgentWorkflow.cs
@@ -29,7 +29,7 @@ namespace Application.Core.Workflows.Orchestration;
 /// <para>
 /// For concurrent agent workflows using the higher-level <see cref="AgentWorkflowBuilder"/>
 /// API with <c>AIAgent</c> instances and <see cref="Microsoft.Extensions.AI.ChatMessage"/>
-/// lists, see <see cref="AgentWorkflowBuilder.BuildConcurrent"/>.
+/// lists, see <c>AgentWorkflowBuilder.BuildConcurrent</c>.
 /// </para>
 /// </remarks>
 public static class MultiAgentWorkflow

--- a/src/Content/Domain/Domain.AI/DriftDetection/DriftAuditRecord.cs
+++ b/src/Content/Domain/Domain.AI/DriftDetection/DriftAuditRecord.cs
@@ -2,7 +2,7 @@ namespace Domain.AI.DriftDetection;
 
 /// <summary>
 /// Discriminator for <see cref="DriftAuditRecord"/> entries.
-/// Determines how the <see cref="DriftAuditRecord.Data"/> field should be interpreted.
+/// Determines how the <see cref="DriftAuditRecord.Payload"/> field should be interpreted.
 /// </summary>
 public enum DriftAuditRecordType
 {
@@ -31,7 +31,7 @@ public enum DriftAuditRecordType
 /// <summary>
 /// A single audit log entry for a drift detection lifecycle event.
 /// Used by <c>IDriftAuditStore</c> for append-only JSONL persistence.
-/// The <see cref="Data"/> field contains the serialized event data,
+/// The <see cref="Payload"/> field contains the serialized event data,
 /// discriminated by <see cref="RecordType"/>.
 /// </summary>
 public sealed record DriftAuditRecord
@@ -42,7 +42,7 @@ public sealed record DriftAuditRecord
     /// <summary>Correlates to the originating drift event.</summary>
     public required Guid EventId { get; init; }
 
-    /// <summary>Discriminator for deserialization of <see cref="Data"/>.</summary>
+    /// <summary>Discriminator for deserialization of <see cref="Payload"/>.</summary>
     public required DriftAuditRecordType RecordType { get; init; }
 
     /// <summary>

--- a/src/Content/Domain/Domain.AI/Identity/AgentIdentity.cs
+++ b/src/Content/Domain/Domain.AI/Identity/AgentIdentity.cs
@@ -21,7 +21,7 @@ namespace Domain.AI.Identity;
 /// <para>
 /// Records throughout the harness validate at boundaries (Application-layer FluentValidation),
 /// not in constructors. This record accepts any non-null <see cref="Id"/> and any
-/// <see cref="AgentIdentityKind"/>; <see cref="IAgentIdentityValidator"/> enforces the
+/// <see cref="AgentIdentityKind"/>; <c>IAgentIdentityValidator</c> enforces the
 /// real invariants (no <see cref="AgentIdentityKind.Unspecified"/>, kind-specific required
 /// fields, etc.).
 /// </para>

--- a/src/Content/Domain/Domain.AI/Identity/AgentIdentityKind.cs
+++ b/src/Content/Domain/Domain.AI/Identity/AgentIdentityKind.cs
@@ -9,7 +9,7 @@ namespace Domain.AI.Identity;
 /// <remarks>
 /// The <see cref="Unspecified"/> sentinel is the default. Treating <c>default</c> as a real
 /// kind would let an uninitialised identity pass type checks; the sentinel forces callers
-/// to set a kind explicitly. <see cref="IAgentIdentityValidator"/> rejects identities with
+/// to set a kind explicitly. <c>IAgentIdentityValidator</c> rejects identities with
 /// <see cref="Unspecified"/> as the kind.
 /// </remarks>
 public enum AgentIdentityKind

--- a/src/Content/Domain/Domain.AI/KnowledgeGraph/Models/ConversationFact.cs
+++ b/src/Content/Domain/Domain.AI/KnowledgeGraph/Models/ConversationFact.cs
@@ -3,7 +3,7 @@ namespace Domain.AI.KnowledgeGraph.Models;
 
 /// <summary>
 /// A fact extracted from a conversation turn by the knowledge bridge.
-/// Persisted to the knowledge graph via <see cref="Application.AI.Common.Interfaces.KnowledgeGraph.IKnowledgeMemory.RememberAsync"/>.
+/// Persisted to the knowledge graph via <c>IKnowledgeMemory.RememberAsync</c>.
 /// </summary>
 public sealed record ConversationFact
 {

--- a/src/Content/Domain/Domain.AI/KnowledgeGraph/Models/EpisodicSegment.cs
+++ b/src/Content/Domain/Domain.AI/KnowledgeGraph/Models/EpisodicSegment.cs
@@ -15,7 +15,7 @@ namespace Domain.AI.KnowledgeGraph.Models;
 /// segments are stored raw.
 /// </para>
 /// <para>
-/// Each segment cross-links to the <see cref="WorkEpisode"/> captured on the same turn via
+/// Each segment cross-links to the <see cref="Domain.AI.WorkMemory.WorkEpisode"/> captured on the same turn via
 /// <see cref="EpisodeId"/>, and both records share the <see cref="ConversationId"/> +
 /// <see cref="TurnNumber"/> pair as a provenance key. The two schemas stay distinct (merging is lossy both
 /// ways) but are mutually reachable: work-memory synthesis can walk to the raw grounding, and harmonic
@@ -24,7 +24,7 @@ namespace Domain.AI.KnowledgeGraph.Models;
 /// <para>
 /// Tenant/owner isolation is enforced by the underlying graph store (the compliance-aware / tenant-isolating
 /// decorator chain stamps tenant on write and filters on read); the segment itself carries no tenant field,
-/// mirroring <see cref="WorkEpisode"/>.
+/// mirroring <see cref="Domain.AI.WorkMemory.WorkEpisode"/>.
 /// </para>
 /// </remarks>
 public sealed record EpisodicSegment
@@ -33,7 +33,7 @@ public sealed record EpisodicSegment
     public required Guid SegmentId { get; init; }
 
     /// <summary>
-    /// The <see cref="WorkEpisode.EpisodeId"/> of the work episode captured on the same turn — a best-effort
+    /// The <see cref="Domain.AI.WorkMemory.WorkEpisode.EpisodeId"/> of the work episode captured on the same turn — a best-effort
     /// convenience link that lets harmonic recall reach the turn's outcome signal without merging the two
     /// schemas. <see langword="null"/> when work memory is disabled (no episode was persisted for this turn):
     /// the authoritative, always-present correlation is the <see cref="ConversationId"/> +

--- a/src/Content/Domain/Domain.AI/KnowledgeGraph/Models/ProvenanceStamp.cs
+++ b/src/Content/Domain/Domain.AI/KnowledgeGraph/Models/ProvenanceStamp.cs
@@ -50,7 +50,7 @@ public record ProvenanceStamp
 
     /// <summary>
     /// Identifier of the user or system that last modified this entity/relationship.
-    /// Populated from <see cref="IKnowledgeScope"/> during graph construction.
+    /// Populated from <c>IKnowledgeScope</c> during graph construction.
     /// </summary>
     public string? LastModifiedBy { get; init; }
 }

--- a/src/Content/Domain/Domain.AI/Planner/RetrievalStepConfiguration.cs
+++ b/src/Content/Domain/Domain.AI/Planner/RetrievalStepConfiguration.cs
@@ -33,9 +33,9 @@ public sealed record RetrievalStepConfiguration : StepConfiguration
     public string? CollectionName { get; init; }
 
     /// <summary>
-    /// When <c>true</c>, uses <see cref="IMultiSourceOrchestrator"/> to fan out across
+    /// When <c>true</c>, uses <c>IMultiSourceOrchestrator</c> to fan out across
     /// vector, graph, and web sources in parallel. When <c>false</c>, uses the standard
-    /// <see cref="IRagOrchestrator"/> single-pipeline path.
+    /// <c>IRagOrchestrator</c> single-pipeline path.
     /// </summary>
     public bool UseMultiSource { get; init; } = false;
 }

--- a/src/Content/Domain/Domain.AI/Sandbox/SandboxExecutionRequest.cs
+++ b/src/Content/Domain/Domain.AI/Sandbox/SandboxExecutionRequest.cs
@@ -32,7 +32,7 @@ public sealed record SandboxExecutionRequest
     /// <summary>
     /// Command-line arguments as a single string. Deprecated — use <see cref="ArgumentList"/>
     /// to avoid shell metacharacter injection. This property is no longer consumed by
-    /// <see cref="ProcessSandboxExecutor"/> and will be removed in a future version.
+    /// <c>ProcessSandboxExecutor</c> and will be removed in a future version.
     /// </summary>
     [Obsolete("Use ArgumentList to avoid command injection. This property is no longer consumed.", error: true)]
     public string? Arguments { get; init; }

--- a/src/Content/Domain/Domain.AI/Skills/EgressManifestSection.cs
+++ b/src/Content/Domain/Domain.AI/Skills/EgressManifestSection.cs
@@ -4,7 +4,7 @@ namespace Domain.AI.Skills;
 /// YAML-shape mirror of <see cref="EgressManifest"/> produced by the SKILL.md
 /// frontmatter parser. Holds the raw deserialized shape — mutable lists,
 /// nullable fields, no invariants enforced — so the parser can populate it
-/// incrementally before <see cref="EgressManifestSectionMapper.Map"/> projects
+/// incrementally before <c>EgressManifestSectionMapper.Map</c> projects
 /// it onto the immutable domain record.
 /// </summary>
 /// <remarks>

--- a/src/Content/Domain/Domain.AI/Telemetry/Conventions/GenAiSemconvRegistry.cs
+++ b/src/Content/Domain/Domain.AI/Telemetry/Conventions/GenAiSemconvRegistry.cs
@@ -344,7 +344,7 @@ public static class GenAiSemconvRegistry
     /// stability.
     /// </summary>
     /// <remarks>
-    /// The <see cref="Infrastructure"/>'s content-capture startup validator
+    /// The <c>Infrastructure</c>'s content-capture startup validator
     /// reads this env var and refuses to boot when content-capture is on but
     /// the variable is unset or wrong.
     /// </remarks>

--- a/src/Content/Domain/Domain.Common/Config/AI/AIConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/AIConfig.cs
@@ -218,7 +218,7 @@ public class AIConfig
     /// <summary>
     /// Direct tool-invocation configuration. Off by default in every host — when enabled, a caller may
     /// name one of the host's registered tools and an operation and have it executed synchronously,
-    /// confined to the tools their <see cref="Domain.AI.Bundles.CapabilityEnvelope"/> grants. Distinct
+    /// confined to the tools their <c>Domain.AI.Bundles.CapabilityEnvelope</c> grants. Distinct
     /// from <see cref="WorkflowSubmission"/>, where an authored DAG decides which tools run: here the
     /// caller chooses directly, which is why this is the one surface in this family that stays off even
     /// in the host built to serve it.

--- a/src/Content/Domain/Domain.Common/Config/AI/EgressConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/EgressConfig.cs
@@ -65,7 +65,7 @@ public sealed class EgressConfig
 
 /// <summary>
 /// Configuration shape for a single egress allowlist entry. Mirrored at the
-/// domain layer by <see cref="Domain.AI.Egress.EgressAllowlistEntry"/>; the
+/// domain layer by <c>Domain.AI.Egress.EgressAllowlistEntry</c>; the
 /// infrastructure layer maps config entries onto domain entries at startup.
 /// </summary>
 /// <remarks>

--- a/src/Content/Domain/Domain.Common/Config/AI/Permissions/GradedAutonomyConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/Permissions/GradedAutonomyConfig.cs
@@ -79,7 +79,7 @@ public sealed class EnvironmentAutonomyConfig
 {
     /// <summary>
     /// Per-blast-radius rules for this environment. Each row maps a
-    /// <see cref="Domain.AI.Changes.BlastRadius"/> name
+    /// <c>Domain.AI.Changes.BlastRadius</c> name
     /// (<c>"Trivial"</c>, <c>"Low"</c>, <c>"Medium"</c>, <c>"High"</c>, <c>"Critical"</c>)
     /// to a decision name (<c>"AutoApprove"</c>, <c>"RequiresApproval"</c>, <c>"Forbidden"</c>).
     /// Missing rows fall back to tier defaults.

--- a/src/Content/Domain/Domain.Common/Config/AI/RAG/MultiSourceConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/RAG/MultiSourceConfig.cs
@@ -29,7 +29,7 @@ public sealed class MultiSourceConfig
     public double CostPerMillionOutputTokens { get; set; } = 10.00;
 
     /// <summary>
-    /// Maps each <see cref="Domain.AI.Routing.Enums.TaskComplexity"/> tier to the source names that should be queried.
+    /// Maps each <c>Domain.AI.Routing.Enums.TaskComplexity</c> tier to the source names that should be queried.
     /// Filtered at runtime by <see cref="EnabledSources"/> — a source must appear in both lists.
     /// </summary>
     public Dictionary<string, List<string>> SourcesByComplexity { get; set; } = new()

--- a/src/Content/Domain/Domain.Common/Config/AI/RAG/RagConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/RAG/RagConfig.cs
@@ -31,7 +31,7 @@ namespace Domain.Common.Config.AI.RAG;
 /// </para>
 /// <para>
 /// Model routing configuration has moved to <c>AppConfig:AI:ModelRouting</c>
-/// (<see cref="Domain.Common.Config.AI.ModelRoutingConfig"/>).
+/// (<see cref="Domain.Common.Config.AI.Routing.ModelRoutingConfig"/>).
 /// </para>
 /// </remarks>
 public class RagConfig

--- a/src/Content/Domain/Domain.Common/Config/AI/Telemetry/ContentCaptureConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/Telemetry/ContentCaptureConfig.cs
@@ -16,7 +16,7 @@ namespace Domain.Common.Config.AI.Telemetry;
 /// <para>
 /// When <see cref="Enabled"/> is true the harness ALSO requires the
 /// <c>OTEL_SEMCONV_STABILITY_OPT_IN</c> environment variable to be pinned to
-/// <see cref="Domain.AI.Telemetry.Conventions.GenAiSemconvRegistry.SemconvStabilityOptInValue"/>;
+/// <c>Domain.AI.Telemetry.Conventions.GenAiSemconvRegistry.SemconvStabilityOptInValue</c>;
 /// the registered startup validator fails the host boot when the variable is
 /// unset or wrong.
 /// </para>
@@ -80,7 +80,7 @@ public sealed class ContentCaptureConfig
     public bool CaptureMagenticPlanReviewFeedback { get; set; }
 
     /// <summary>
-    /// Names of <see cref="Domain.AI.Telemetry.Redaction.RedactionCategory"/>
+    /// Names of <c>Domain.AI.Telemetry.Redaction.RedactionCategory</c>
     /// values the redaction filter should apply before emission. Unknown
     /// names are ignored (with a startup log warning). Default: all categories
     /// from the enum, so a consumer that flips <see cref="Enabled"/> on

--- a/src/Content/Domain/Domain.Common/Config/Http/HttpAuthorizationConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/Http/HttpAuthorizationConfig.cs
@@ -7,7 +7,7 @@ namespace Domain.Common.Config.Http;
 /// </summary>
 /// <remarks>
 /// Binds to <c>AppConfig:Http:Authorization</c> in appsettings.json.
-/// Used by <see cref="Infrastructure.Common.Middleware.EndpointFilters.HttpAuthEndpointFilter"/>
+/// Used by <c>Infrastructure.Common.Middleware.EndpointFilters.HttpAuthEndpointFilter</c>
 /// to validate API keys on incoming requests.
 /// <para>
 /// <strong>Security:</strong> Store <see cref="AccessKey1"/> and <see cref="AccessKey2"/>

--- a/src/Content/Domain/Domain.Common/MetaHarness/HarnessProposal.cs
+++ b/src/Content/Domain/Domain.Common/MetaHarness/HarnessProposal.cs
@@ -1,7 +1,7 @@
 namespace Domain.Common.MetaHarness;
 
 /// <summary>
-/// Immutable output from <see cref="Application.AI.Common.Interfaces.MetaHarness.IHarnessProposer"/>
+/// Immutable output from <c>Application.AI.Common.Interfaces.MetaHarness.IHarnessProposer</c>
 /// representing a set of proposed harness changes derived from trace analysis.
 /// </summary>
 public sealed record HarnessProposal

--- a/src/Content/Domain/Domain.Common/MetaHarness/HarnessProposerContext.cs
+++ b/src/Content/Domain/Domain.Common/MetaHarness/HarnessProposerContext.cs
@@ -1,7 +1,7 @@
 namespace Domain.Common.MetaHarness;
 
 /// <summary>
-/// Immutable input context passed to <see cref="Application.AI.Common.Interfaces.MetaHarness.IHarnessProposer"/>
+/// Immutable input context passed to <c>Application.AI.Common.Interfaces.MetaHarness.IHarnessProposer</c>
 /// for a single propose step within an optimization run.
 /// </summary>
 public sealed record HarnessProposerContext

--- a/src/Content/Domain/Domain.Common/Workflow/DecisionFramework.cs
+++ b/src/Content/Domain/Domain.Common/Workflow/DecisionFramework.cs
@@ -17,11 +17,11 @@ namespace Domain.Common.Workflow;
 ///     - no_go
 ///
 ///   decision_rules:
-///     - condition: "score >= 85 AND critical_issues == 0 AND high_issues <= 2"
+///     - condition: "score >= 85 AND critical_issues == 0 AND high_issues &lt;= 2"
 ///       outcome: go
-///     - condition: "score >= 70 AND score < 85 AND critical_issues <= 1"
+///     - condition: "score >= 70 AND score &lt; 85 AND critical_issues &lt;= 1"
 ///       outcome: conditional_go
-///     - condition: "score < 70 OR critical_issues > 1"
+///     - condition: "score &lt; 70 OR critical_issues > 1"
 ///       outcome: no_go
 ///
 ///   metadata_outputs:

--- a/src/Content/Domain/Domain.Common/Workflow/DecisionRule.cs
+++ b/src/Content/Domain/Domain.Common/Workflow/DecisionRule.cs
@@ -29,8 +29,8 @@ public class DecisionRule
     /// <list type="bullet">
     ///   <item><code>"score >= 85"</code></item>
     ///   <item><code>"score >= 85 AND critical_issues == 0"</code></item>
-    ///   <item><code>"score >= 70 AND score < 85"</code></item>
-    ///   <item><code>"(score >= 85 OR (score >= 70 AND critical_issues == 0)) AND high_issues <= 2"</code></item>
+    ///   <item><code>"score >= 70 AND score &lt; 85"</code></item>
+    ///   <item><code>"(score >= 85 OR (score >= 70 AND critical_issues == 0)) AND high_issues &lt;= 2"</code></item>
     /// </list>
     /// </summary>
     public string Condition { get; set; } = string.Empty;

--- a/src/Content/Infrastructure/Infrastructure.AI.MCP/Resources/TraceResourceProvider.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.MCP/Resources/TraceResourceProvider.cs
@@ -20,7 +20,7 @@ namespace Infrastructure.AI.MCP.Resources;
 /// <see cref="InvalidOperationException"/>. Auth checks still run regardless of the flag.
 /// </para>
 /// <para>
-/// Security: every path is fully resolved with <see cref="Path.GetFullPath"/> before containment
+/// Security: every path is fully resolved with <see cref="System.IO.Path.GetFullPath(string)"/> before containment
 /// checks. The containment check uses a trailing-separator suffix to prevent
 /// <c>/traces/run-1</c> falsely matching <c>/traces/run-10</c>.
 /// On non-Windows, symlinks pointing outside the run directory are rejected.

--- a/src/Content/Infrastructure/Infrastructure.AI.RAG/DependencyInjection.Retrieval.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.RAG/DependencyInjection.Retrieval.cs
@@ -224,7 +224,7 @@ public static partial class DependencyInjection
     /// Registers SQL database retrieval services: template store, safe executor,
     /// template matcher, text-to-SQL generator, and the <see cref="IRetrievalSource"/>
     /// adapter keyed as "sql_database". Only registered when
-    /// <see cref="SqlDatabaseConfig.Enabled"/> is <c>true</c>.
+    /// <see cref="Domain.Common.Config.AI.RAG.SqlDatabaseConfig.Enabled"/> is <c>true</c>.
     /// <para>
     /// <see cref="SafeSqlQueryExecutor"/> requires an <see cref="ISqlConnectionFactory"/>
     /// registered in DI by the consuming application (Infrastructure.Common provides a default

--- a/src/Content/Infrastructure/Infrastructure.AI.RAG/Evaluation/RetrievalQualityEvaluator.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.RAG/Evaluation/RetrievalQualityEvaluator.cs
@@ -14,7 +14,7 @@ namespace Infrastructure.AI.RAG.Evaluation;
 /// </summary>
 /// <remarks>
 /// <para>
-/// Metrics are evaluated in parallel via <see cref="Task.WhenAll"/> for lower
+/// Metrics are evaluated in parallel via <see cref="System.Threading.Tasks.Task.WhenAll(System.Collections.Generic.IEnumerable{System.Threading.Tasks.Task})"/> for lower
 /// latency. Context recall is only computed when ground-truth is provided;
 /// otherwise it is set to <c>-1.0</c> as a sentinel.
 /// </para>

--- a/src/Content/Infrastructure/Infrastructure.AI.RAG/GraphRag/MemoryDecayService.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.RAG/GraphRag/MemoryDecayService.cs
@@ -120,7 +120,7 @@ public sealed class MemoryDecayService : IMemoryDecayService, IDisposable
     /// <remarks>
     /// Iterates all nodes of <c>Type == "Memory"</c> and deletes those whose
     /// <c>Properties["weight"]</c> is strictly below <paramref name="threshold"/>.
-    /// Each deletion cascades: <see cref="IGraphDatabaseBackend.DeleteNodeAsync"/> removes
+    /// Each deletion cascades: <see cref="Application.AI.Common.Interfaces.KnowledgeGraph.IKnowledgeGraphStore.DeleteNodeAsync"/> removes
     /// the graph node, then <see cref="ICrossSessionMemoryStore.ForgetAsync"/> purges the
     /// corresponding in-memory cache and backing store entry.
     /// </remarks>

--- a/src/Content/Infrastructure/Infrastructure.AI.RAG/Ingestion/RaptorSummarizer.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.RAG/Ingestion/RaptorSummarizer.cs
@@ -11,7 +11,7 @@ namespace Infrastructure.AI.RAG.Ingestion;
 /// <summary>
 /// RAPTOR (Recursive Abstractive Processing for Tree-Organized Retrieval) summarizer.
 /// Clusters chunks into sequential groups of 5-10, summarizes each cluster with an
-/// economy-tier LLM, and recurses until <paramref name="maxDepth"/> is reached or
+/// economy-tier LLM, and recurses until <c>maxDepth</c> is reached or
 /// a single cluster remains. Uses sequential grouping (not k-means) as a template
 /// simplification — production deployments should upgrade to GMM clustering on embeddings.
 /// </summary>

--- a/src/Content/Infrastructure/Infrastructure.AI.RAG/SqlDatabase/SqlDatabaseRetrievalSource.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.RAG/SqlDatabase/SqlDatabaseRetrievalSource.cs
@@ -13,7 +13,7 @@ namespace Infrastructure.AI.RAG.SqlDatabase;
 
 /// <summary>
 /// Two-tier SQL retrieval source: tries template matching first, falls back to LLM text-to-SQL
-/// if <see cref="SqlDatabaseConfig.AllowLlmFallback"/> is enabled.
+/// if <see cref="Domain.Common.Config.AI.RAG.SqlDatabaseConfig.AllowLlmFallback"/> is enabled.
 /// Registered as keyed DI with key "sql_database".
 /// </summary>
 internal sealed class SqlDatabaseRetrievalSource(

--- a/src/Content/Infrastructure/Infrastructure.AI.RAG/SqlDatabase/TextToSqlGenerator.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.RAG/SqlDatabase/TextToSqlGenerator.cs
@@ -14,7 +14,7 @@ internal sealed partial class TextToSqlGenerator(IChatClient chatClient)
     private static partial Regex MutationPattern();
 
     /// <summary>
-    /// Generates a SELECT SQL query from a natural language <paramref name="query"/> and
+    /// Generates a SELECT SQL query from a natural language <c>query</c> and
     /// <paramref name="databaseSchema"/>. Returns <see langword="null"/> if the LLM produces
     /// a mutation statement or an empty response.
     /// </summary>

--- a/src/Content/Infrastructure/Infrastructure.AI/Compression/ToolOutputCompressor.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Compression/ToolOutputCompressor.cs
@@ -11,7 +11,7 @@ namespace Infrastructure.AI.Compression;
 /// strategies with fallback to FreeText and hard truncation as last resort.
 /// </summary>
 /// <remarks>
-/// When the <paramref name="category"/> passed to <see cref="CompressAsync"/> is null,
+/// When the <c>category</c> passed to <see cref="CompressAsync"/> is null,
 /// the compressor calls <see cref="ContentTypeDetector.Detect"/> to infer the category
 /// from the output content. This keeps the Application layer free of Infrastructure dependencies.
 /// </remarks>

--- a/src/Content/Infrastructure/Infrastructure.AI/Config/DirectoryWalkConfigDiscovery.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Config/DirectoryWalkConfigDiscovery.cs
@@ -18,7 +18,7 @@ namespace Infrastructure.AI.Config;
 ///   <item><c>CLAUDE.md</c> — Project scope</item>
 ///   <item><c>CLAUDE.local.md</c> — Local scope (not checked in)</item>
 /// </list>
-/// Files closer to <paramref name="startDirectory"/> receive lower priority values
+/// Files closer to <c>startDirectory</c> receive lower priority values
 /// (higher effective priority). <c>@include</c> directives are resolved inline and
 /// circular references are prevented via path tracking.
 /// </remarks>

--- a/src/Content/Infrastructure/Infrastructure.AI/Embeddings/UnconfiguredEmbeddingGenerator.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Embeddings/UnconfiguredEmbeddingGenerator.cs
@@ -10,7 +10,7 @@ namespace Infrastructure.AI.Embeddings;
 /// generate embeddings.
 /// </summary>
 /// <remarks>
-/// This appears when the configured chat <see cref="AIAgentFrameworkClientType"/>
+/// This appears when the configured chat <see cref="Domain.Common.Config.AI.AIAgentFrameworkClientType"/>
 /// has no embeddings API (e.g. <c>Anthropic</c>, <c>AzureAIInference</c>,
 /// <c>Echo</c>) and <c>AppConfig:AI:Embedding</c> is left unset. Configure that
 /// section with a provider that exposes embeddings to enable RAG.

--- a/src/Content/Infrastructure/Infrastructure.AI/Escalation/EfCoreEscalationStateStore.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Escalation/EfCoreEscalationStateStore.cs
@@ -34,7 +34,7 @@ namespace Infrastructure.AI.Escalation;
 /// startup rehydration free to recover every other escalation.
 /// </para>
 /// <para>
-/// Resolved outcomes are sealed via <see cref="IEscalationOutcomeSealer"/> on write and
+/// Resolved outcomes are sealed via <see cref="Application.AI.Common.Interfaces.Escalation.IGovernanceRecordSealer"/> on write and
 /// verified on read; an outcome whose seal does not verify is withheld, so the reconciler
 /// never re-drives a possibly forged verdict into the compliance audit log.
 /// </para>

--- a/src/Content/Infrastructure/Infrastructure.AI/Factories/ChatClientFactory.Providers.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Factories/ChatClientFactory.Providers.cs
@@ -113,7 +113,7 @@ public sealed partial class ChatClientFactory
     /// <summary>
     /// Resolves a persistent agent by ID, extracts its model, and returns an Azure OpenAI
     /// <see cref="IChatClient"/> for that model. The agent's instructions and tools are
-    /// applied by the <see cref="AgentFactory"/> pipeline, not by the chat client.
+    /// applied by the <see cref="Application.AI.Common.Factories.AgentFactory"/> pipeline, not by the chat client.
     /// </summary>
     private async Task<IChatClient> GetPersistentAgentChatClientAsync(string agentId, CancellationToken cancellationToken)
     {

--- a/src/Content/Infrastructure/Infrastructure.AI/Factories/ChatClientFactory.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Factories/ChatClientFactory.cs
@@ -25,7 +25,7 @@ namespace Infrastructure.AI.Factories;
 /// delegates conversation execution to the underlying Azure OpenAI chat client using the
 /// agent's model deployment. This approach works because AI Foundry persistent agents run
 /// on Azure OpenAI under the hood — the agent's instructions and tools are configured via
-/// the <see cref="AgentExecutionContext"/> pipeline rather than server-side state.
+/// the <see cref="Domain.AI.Agents.AgentExecutionContext"/> pipeline rather than server-side state.
 /// </para>
 /// <para>
 /// The <see cref="PersistentAgentsAdministrationClient"/> dependency is optional — it is only

--- a/src/Content/Infrastructure/Infrastructure.AI/Persistence/SqliteValueConverters.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Persistence/SqliteValueConverters.cs
@@ -31,7 +31,7 @@ public static class SqliteValueConverters
 }
 
 /// <summary>
-/// Singleton initializer that runs <see cref="DatabaseFacade.EnsureCreated"/> on its
+/// Singleton initializer that runs <c>DatabaseFacade.EnsureCreated()</c> on its
 /// supplied DbContext factory at construction time. Mirrors the
 /// <c>PromptUsageSchemaInitializer</c> / <c>EvalDashboardSchemaInitializer</c>
 /// pattern with a single generic base so each new SQLite subsystem doesn't

--- a/src/Content/Infrastructure/Infrastructure.AI/Planner/PlanExecutor.EnvelopeCeiling.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Planner/PlanExecutor.EnvelopeCeiling.cs
@@ -33,7 +33,7 @@ namespace Infrastructure.AI.Planner;
 /// plan-authored recovery data on a security denial — the exact coupling this path exists to break.
 /// </para>
 /// <para>
-/// With no ambient envelope (every direct in-process <see cref="IPlanExecutor"/> caller) no ceiling
+/// With no ambient envelope (every direct in-process <see cref="Application.AI.Common.Interfaces.Planner.IPlanExecutor"/> caller) no ceiling
 /// applies and this partial contributes nothing to execution.
 /// </para>
 /// </remarks>

--- a/src/Content/Infrastructure/Infrastructure.AI/Planner/PlanRunCancellationRegistry.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Planner/PlanRunCancellationRegistry.cs
@@ -11,7 +11,7 @@ namespace Infrastructure.AI.Planner;
 /// <remarks>
 /// <para>
 /// <b>Locking.</b> The private gate guards the index only. Cancellation and disposal happen outside
-/// it, on a snapshot, because <see cref="CancellationTokenSource.Cancel"/> runs its registered
+/// it, on a snapshot, because <see cref="System.Threading.CancellationTokenSource.Cancel()"/> runs its registered
 /// callbacks synchronously: holding a lock across it would put arbitrary continuation code —
 /// including a run's own release path — under this type's lock. Each
 /// <see cref="PlanRunCancellationRegistration"/> serializes its own cancel-versus-dispose pair

--- a/src/Content/Infrastructure/Infrastructure.APIAccess/Common/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Content/Infrastructure/Infrastructure.APIAccess/Common/Extensions/IServiceCollectionExtensions.cs
@@ -143,7 +143,7 @@ public static class IServiceCollectionExtensions
     /// Configures Swagger/OpenAPI generation with XML documentation and optional security scheme.
     /// </summary>
     /// <param name="services">The service collection to configure.</param>
-    /// <param name="appConfig">Application configuration containing Swagger settings.</param>
+    /// <param name="httpConfig">HTTP configuration containing Swagger settings.</param>
     /// <returns>The service collection for chaining.</returns>
     /// <remarks>
     /// Only configures Swagger when <c>OpenApiEnabled</c> is true in configuration.
@@ -247,7 +247,7 @@ public static class IServiceCollectionExtensions
     /// Configures CORS policies for default, config-driven, AI Copilot, and MCP Server scenarios.
     /// </summary>
     /// <param name="services">The service collection to configure.</param>
-    /// <param name="appConfig">Application configuration containing allowed origins.</param>
+    /// <param name="httpConfig">HTTP configuration containing allowed origins.</param>
     /// <returns>The service collection for chaining.</returns>
     public static IServiceCollection AddCustomCorsPolicy(this IServiceCollection services, HttpConfig httpConfig)
     {
@@ -461,7 +461,7 @@ public static class IServiceCollectionExtensions
     }
 
     /// <summary>
-    /// Adds a typed HTTP client with configuration from <see cref="AppConfig"/>
+    /// Adds a typed HTTP client with configuration from <see cref="Domain.Common.Config.AppConfig"/>
     /// using <see cref="ApiEndpointResolverService"/> for endpoint resolution.
     /// </summary>
     /// <typeparam name="TClient">The HTTP client interface type.</typeparam>
@@ -469,7 +469,7 @@ public static class IServiceCollectionExtensions
     /// <typeparam name="TClientOptions">The client configuration type.</typeparam>
     /// <param name="services">The service collection to configure.</param>
     /// <param name="configurationSectionName">
-    /// The configuration path for the client settings in <see cref="AppConfig"/>.
+    /// The configuration path for the client settings in <see cref="Domain.Common.Config.AppConfig"/>.
     /// </param>
     /// <returns>The service collection for chaining.</returns>
     /// <remarks>

--- a/src/Content/Infrastructure/Infrastructure.Observability/Exporters/ObservabilityTelemetryConfigurator.cs
+++ b/src/Content/Infrastructure/Infrastructure.Observability/Exporters/ObservabilityTelemetryConfigurator.cs
@@ -35,7 +35,7 @@ namespace Infrastructure.Observability.Exporters;
 /// Trace sampling is not performed here. Tail-based sampling is a Collector-tier
 /// concern (see the observability architecture guide): the SDK exports every span
 /// and the OpenTelemetry Collector's <c>tail_sampling</c> processor decides what to
-/// keep. A prior in-app tail sampler was removed because a <see cref="BaseProcessor{T}.OnEnd"/>
+/// keep. A prior in-app tail sampler was removed because a <see cref="OpenTelemetry.BaseProcessor{T}.OnEnd"/>
 /// no-op cannot prevent the OTLP/Azure Monitor exporters from having already enqueued
 /// every span.
 /// </para>

--- a/src/Content/Presentation/Presentation.AgentHub/AgUi/AgUiEventWriter.cs
+++ b/src/Content/Presentation/Presentation.AgentHub/AgUi/AgUiEventWriter.cs
@@ -24,7 +24,7 @@ public interface IAgUiEventWriter
 /// </summary>
 /// <remarks>
 /// <para>
-/// Serialization uses <see cref="typeof(AgUiEvent)"/> as the declared type rather
+/// Serialization uses <c>typeof(AgUiEvent)</c> as the declared type rather
 /// than the runtime concrete type. This is required so that
 /// <see cref="System.Text.Json.Serialization.JsonPolymorphicAttribute"/> emits the
 /// <c>type</c> discriminator field on every frame. Serializing by runtime type

--- a/src/Content/Presentation/Presentation.AgentHub/Services/FileSystemConversationStore.cs
+++ b/src/Content/Presentation/Presentation.AgentHub/Services/FileSystemConversationStore.cs
@@ -17,7 +17,7 @@ namespace Presentation.AgentHub.Services;
 /// per-conversation-id locking (e.g., AsyncKeyedLock) to allow concurrent operations
 /// across different conversations.
 ///
-/// Atomic writes: all writes go to a <c>.tmp</c> file first, then <see cref="File.Move"/> with
+/// Atomic writes: all writes go to a <c>.tmp</c> file first, then <see cref="System.IO.File.Move(string, string, bool)"/> with
 /// <c>overwrite: true</c>. This prevents partial-write corruption if the process exits mid-write.
 ///
 /// Path safety: the constructor resolves <c>ConversationsPath</c> to an absolute path.
@@ -384,7 +384,7 @@ public sealed class FileSystemConversationStore : IConversationStore
     /// <summary>
     /// Writes <paramref name="record"/> atomically (tmp → move). Must be called while the
     /// caller already holds <see cref="_lock"/>.
-    /// Retries <see cref="File.Move"/> up to 3 times on <see cref="UnauthorizedAccessException"/>
+    /// Retries <see cref="System.IO.File.Move(string, string, bool)"/> up to 3 times on <see cref="UnauthorizedAccessException"/>
     /// to tolerate transient file locks from OneDrive, antivirus, or Windows Search.
     /// </summary>
     private static async Task WriteAtomicLockedAsync(string targetPath, ConversationRecord record, CancellationToken ct)

--- a/src/Content/Presentation/Presentation.Common/Extensions/IApplicationBuilderExtensions.cs
+++ b/src/Content/Presentation/Presentation.Common/Extensions/IApplicationBuilderExtensions.cs
@@ -105,7 +105,7 @@ public static class IApplicationBuilderExtensions
     }
 
     /// <summary>
-    /// Configures a global error handler using <see cref="ExceptionHandlerExtensions.UseExceptionHandler"/>
+    /// Configures a global error handler using <see cref="Microsoft.AspNetCore.Builder.ExceptionHandlerExtensions.UseExceptionHandler(Microsoft.AspNetCore.Builder.IApplicationBuilder, System.Action{Microsoft.AspNetCore.Builder.IApplicationBuilder})"/>
     /// that catches all unhandled exceptions and returns structured JSON error responses.
     /// </summary>
     /// <param name="app">The application builder.</param>

--- a/src/Content/Presentation/Presentation.FoundryHost/Program.cs
+++ b/src/Content/Presentation/Presentation.FoundryHost/Program.cs
@@ -23,7 +23,7 @@ namespace Presentation.FoundryHost;
 /// </para>
 /// <para>
 /// The host reuses the same composition root every other host uses
-/// (<see cref="IServiceCollectionExtensions.GetServices"/>), builds the harness agent through
+/// (<see cref="Presentation.Common.Extensions.IServiceCollectionExtensions.GetServices"/>), builds the harness agent through
 /// <see cref="IAgentFactory"/> exactly as the desktop app and Agent Hub do, then hands that agent to
 /// the Foundry hosting library. There is <b>no</b> new agent-type concept: which agent this
 /// deployment exposes is selected by id (env var <c>FOUNDRY_AGENT_ID</c>, default <c>default</c>),

--- a/src/Content/Tests/Application.AI.Common.Tests/FunctionInvocation/BlockingToolRoundTripTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/FunctionInvocation/BlockingToolRoundTripTests.cs
@@ -15,7 +15,7 @@ namespace Application.AI.Common.Tests.FunctionInvocation;
 /// middleware's tolerance for a tool that parks on a <see cref="TaskCompletionSource{TResult}"/>, these
 /// tests fail loudly before the whole feature silently regresses.
 ///
-/// The existing <see cref="Infrastructure.AI.Tests.Pipeline.MeAiPipelineCompatibilityTests"/> proves the
+/// The existing <c>Infrastructure.AI.Tests.Pipeline.MeAiPipelineCompatibilityTests</c> proves the
 /// basic tool round-trip (UseFunctionInvocation invokes a registered tool, then the model produces a
 /// final answer). These tests add the missing property: the middleware tolerates a tool that does NOT
 /// return promptly but instead blocks until completed by a separate caller, and that cancellation of a

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/AgentConversationCacheTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/AgentConversationCacheTests.cs
@@ -26,7 +26,7 @@ namespace Application.AI.Common.Tests.Services;
 /// </summary>
 /// <remarks>
 /// Regression coverage for the prerequisite-scope bug: a skill declaring <c>prerequisites</c>
-/// crashed on every conversation turn because <see cref="AgentFactory.ResolvePrerequisiteScope"/>
+/// crashed on every conversation turn because <c>AgentFactory.ResolvePrerequisiteScope</c>
 /// requires a conversation id under <see cref="AgentFactory.ConversationIdPropertyKey"/> in the
 /// execution context, and nothing on the live path supplied it. The cache holds the
 /// <c>conversationId</c> and is the only component positioned to flow it into

--- a/src/Content/Tests/Domain.AI.Tests/Identity/CredentialContextTests.cs
+++ b/src/Content/Tests/Domain.AI.Tests/Identity/CredentialContextTests.cs
@@ -6,7 +6,7 @@ namespace Domain.AI.Tests.Identity;
 
 /// <summary>
 /// Tests for <see cref="CredentialContext"/> record — captures the per-kind credential
-/// metadata (issuer, audience, scopes) needed by an <see cref="IAgentCredentialProvider"/>
+/// metadata (issuer, audience, scopes) needed by an <c>IAgentCredentialProvider</c>
 /// to acquire a token without baking environment-specific URLs into providers themselves.
 /// </summary>
 public sealed class CredentialContextTests

--- a/src/Content/Tests/Infrastructure.AI.KnowledgeGraph.Tests/Scoping/OwnerIdCanonicalizationTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.KnowledgeGraph.Tests/Scoping/OwnerIdCanonicalizationTests.cs
@@ -170,7 +170,7 @@ public sealed class OwnerIdCanonicalizationTests
 
     /// <summary>
     /// Gate guard (LOW): an absent dataset owner is never an authorizable dataset, even for a caller
-    /// whose own UserId is also absent — <see cref="ScopeIdentity.AreSame"/> would otherwise treat two
+    /// whose own UserId is also absent — <see cref="Domain.AI.KnowledgeGraph.Scoping.ScopeIdentity.AreSame"/> would otherwise treat two
     /// absent ids as equal and authorize access the old OrdinalIgnoreCase gate denied.
     /// </summary>
     [Theory]

--- a/src/Content/Tests/Infrastructure.AI.Tests/Escalation/Support/GovernanceStateTestConfig.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Escalation/Support/GovernanceStateTestConfig.cs
@@ -8,7 +8,7 @@ namespace Infrastructure.AI.Tests.Escalation.Support;
 /// <summary>
 /// Shared test doubles for the durable governance-state store: an
 /// <see cref="IOptionsMonitor{TOptions}"/> over a configurable <see cref="AppConfig"/>, and a
-/// deterministic <see cref="IEscalationOutcomeSealer"/> that needs no HMAC key material.
+/// deterministic <see cref="Application.AI.Common.Interfaces.Escalation.IGovernanceRecordSealer"/> that needs no HMAC key material.
 /// </summary>
 internal static class GovernanceStateTestConfig
 {

--- a/src/Content/Tests/Infrastructure.AI.Tests/Iac/IacChangeProposalValidatorTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Iac/IacChangeProposalValidatorTests.cs
@@ -19,7 +19,7 @@ namespace Infrastructure.AI.Tests.Iac;
 /// Unit tests for <see cref="IacChangeProposalValidator"/>. Each scenario builds a
 /// service provider with (or without) a keyed <see cref="IIacGenerator"/> and a
 /// proposal whose target is (or is not) an <see cref="IacDeploymentTarget"/>, then
-/// asserts the resulting <see cref="GateResult"/>.
+/// asserts the resulting <see cref="Domain.AI.Changes.GateResult"/>.
 /// </summary>
 public sealed class IacChangeProposalValidatorTests
 {

--- a/src/Content/Tests/Infrastructure.AI.Tests/Orchestration/Magentic/MagenticSpanEmitterTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Orchestration/Magentic/MagenticSpanEmitterTests.cs
@@ -12,7 +12,7 @@ namespace Infrastructure.AI.Tests.Orchestration.Magentic;
 
 /// <summary>
 /// PR-6 acceptance tests for the Magentic span tree. Drives the
-/// <see cref="MagenticEventSubscriber"/> with synthetic events and verifies the
+/// <see cref="Infrastructure.AI.Orchestration.Magentic.MagenticEventSubscriber"/> with synthetic events and verifies the
 /// resulting <see cref="System.Diagnostics.Activity"/> stream matches
 /// <c>documentation/architecture/magentic-spans.md</c>.
 /// </summary>

--- a/src/Content/Tests/Infrastructure.AI.Tests/Tools/FileSystemServiceSandboxEscapeTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Tools/FileSystemServiceSandboxEscapeTests.cs
@@ -16,7 +16,8 @@ namespace Infrastructure.AI.Tests.Tools;
 /// enumerated path against the allowlist. A junction at <c>workspace\notes</c> pointing at
 /// <c>C:\Users\victim\.ssh</c> is not protected, so the walk descended into it, and every file it
 /// then yielded carried a literal <c>workspace\notes\...</c> path that satisfied a
-/// workspace-rooted allowlist — after which <see cref="File.ReadLinesAsync(string)"/> followed the
+/// workspace-rooted allowlist — after which
+/// <see cref="System.IO.File.ReadLinesAsync(string, System.Threading.CancellationToken)"/> followed the
 /// link and put the contents in the search results.
 /// </para>
 /// <para>

--- a/src/Content/Tests/Infrastructure.APIAccess.Tests/Common/Extensions/IEndpointConventionBuilderExtensionsTests.cs
+++ b/src/Content/Tests/Infrastructure.APIAccess.Tests/Common/Extensions/IEndpointConventionBuilderExtensionsTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 namespace Infrastructure.APIAccess.Tests.Common.Extensions;
 
 /// <summary>
-/// Tests for <see cref="IEndpointConventionBuilderExtensions.AddFilters"/>
+/// Tests for <see cref="Infrastructure.APIAccess.Common.Extensions.IEndpointConventionBuilderExtensions.AddFilters"/>
 /// covering null, empty, single, and multiple filter scenarios.
 /// </summary>
 public sealed class IEndpointConventionBuilderExtensionsTests

--- a/src/Content/Tests/Infrastructure.APIAccess.Tests/Common/Extensions/IServiceCollectionExtensionsTests.cs
+++ b/src/Content/Tests/Infrastructure.APIAccess.Tests/Common/Extensions/IServiceCollectionExtensionsTests.cs
@@ -9,7 +9,7 @@ using Xunit;
 namespace Infrastructure.APIAccess.Tests.Common.Extensions;
 
 /// <summary>
-/// Integration tests for <see cref="IServiceCollectionExtensions"/> covering
+/// Integration tests for <see cref="Infrastructure.APIAccess.Common.Extensions.IServiceCollectionExtensions"/> covering
 /// Kestrel, API versioning, rate limiter, CORS, and Swagger registration.
 /// </summary>
 public sealed class IServiceCollectionExtensionsTests

--- a/src/Content/Tests/Presentation.AgentHub.Tests/Controllers/McpControllerTests.cs
+++ b/src/Content/Tests/Presentation.AgentHub.Tests/Controllers/McpControllerTests.cs
@@ -18,7 +18,7 @@ using Xunit;
 namespace Presentation.AgentHub.Tests.Controllers;
 
 /// <summary>
-/// Integration tests for <see cref="McpController"/> HTTP endpoints.
+/// Integration tests for <see cref="Presentation.AgentHub.Controllers.McpController"/> HTTP endpoints.
 /// Covers tool listing, tool invocation, error handling, audit logging,
 /// and the 32 KB request size limit.
 /// </summary>
@@ -270,7 +270,7 @@ public sealed class McpControllerTests : IClassFixture<TestWebApplicationFactory
 
     /// <summary>
     /// Concrete <see cref="AIFunction"/> subclass used as a test double.
-    /// Implements only the members required by <see cref="McpController"/>.
+    /// Implements only the members required by <see cref="Presentation.AgentHub.Controllers.McpController"/>.
     /// </summary>
     private sealed class FakeAIFunction : AIFunction
     {

--- a/src/Content/Tests/Presentation.Common.Tests/Composition/CompositionRootTestHost.cs
+++ b/src/Content/Tests/Presentation.Common.Tests/Composition/CompositionRootTestHost.cs
@@ -9,7 +9,7 @@ namespace Presentation.Common.Tests.Composition;
 /// <summary>
 /// Builds a service provider through the REAL composition root — the same
 /// <c>RegisterConfigSections</c> + <c>BuildGlobalSolutionServices</c> pair that
-/// <see cref="IServiceCollectionExtensions.GetServices"/> chains for every host
+/// <see cref="Presentation.Common.Extensions.IServiceCollectionExtensions.GetServices"/> chains for every host
 /// (AgentHub, ConsoleUI, EvalRunner, FoundryHost) — differing only in that
 /// configuration comes from an in-memory dictionary instead of
 /// <c>AppConfigHelper.LoadAppConfig()</c>'s appsettings.json files.

--- a/src/Content/Tests/Presentation.Common.Tests/Extensions/IServiceCollectionExtensionsTests.cs
+++ b/src/Content/Tests/Presentation.Common.Tests/Extensions/IServiceCollectionExtensionsTests.cs
@@ -17,7 +17,7 @@ using Xunit;
 namespace Presentation.Common.Tests.Extensions;
 
 /// <summary>
-/// Integration tests for <see cref="IServiceCollectionExtensions"/> covering
+/// Integration tests for <see cref="Presentation.Common.Extensions.IServiceCollectionExtensions"/> covering
 /// config section registration, cache configuration, and auth dependency wiring.
 /// </summary>
 public sealed class IServiceCollectionExtensionsTests

--- a/src/Content/Tests/Presentation.Common.Tests/Hosting/HarnessHostEnvironmentTests.cs
+++ b/src/Content/Tests/Presentation.Common.Tests/Hosting/HarnessHostEnvironmentTests.cs
@@ -11,7 +11,7 @@ namespace Presentation.Common.Tests.Hosting;
 
 /// <summary>
 /// Regression tests for the <see cref="IHostEnvironment"/> registration in
-/// <see cref="IServiceCollectionExtensions.BuildGlobalSolutionServices"/>.
+/// <see cref="Presentation.Common.Extensions.IServiceCollectionExtensions.BuildGlobalSolutionServices"/>.
 /// </summary>
 /// <remarks>
 /// Reproduces GitHub issues #19 and #64: console-style hosts (ConsoleUI, EvalRunner,

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -7,6 +7,26 @@
 		<DefineConstants>$(DefineConstants);DEBUG;TRACE</DefineConstants>
 	</PropertyGroup>
 
+	<!--
+		XML documentation is generated solution-wide so the compiler resolves every
+		<see cref="..."/>. A cref is the one documentation claim the compiler can verify
+		for free and with no false positives: it either binds to a real symbol or it does
+		not. With this off, doc references rot silently - which is how a cref to a type
+		deleted by an SDK redesign survived in this repo until it was found by hand.
+
+		The cref and malformed-XML diagnostics are errors, not warnings, so a broken
+		reference cannot reach main. The three suppressed below are volume this repo has
+		not paid down yet; they are tracked in a follow-up rather than fixed here, so that
+		enabling the guard does not turn every build into a wall of noise.
+	-->
+	<PropertyGroup>
+		<GenerateDocumentationFile>true</GenerateDocumentationFile>
+		<WarningsAsErrors>$(WarningsAsErrors);CS0419;CS1570;CS1572;CS1574;CS1580;CS1584;CS1734</WarningsAsErrors>
+		<NoWarn>$(NoWarn);CS1591</NoWarn><!-- missing XML comment on a public member -->
+		<NoWarn>$(NoWarn);CS1573</NoWarn><!-- parameter has no matching <param> tag -->
+		<NoWarn>$(NoWarn);CS1587</NoWarn><!-- XML comment not on a valid language element -->
+	</PropertyGroup>
+
 	<PropertyGroup>
 		<TargetFramework>net10.0</TargetFramework>
 		<TreatWarningsAsErrors>false</TreatWarningsAsErrors>


### PR DESCRIPTION
Closes #223.

## What was wrong

`GenerateDocumentationFile` was set in exactly one project out of the whole solution. The compiler therefore never resolved `<see cref="..."/>` anywhere else, so documentation references could point at renamed, moved, or deleted symbols indefinitely and nothing noticed.

That is not hypothetical. It is how a cref to a type removed by an SDK redesign survived until someone found it by hand.

## What this changes

Every unresolvable documentation reference is fixed, and the check is turned on so they cannot rot again.

| Diagnostic | Count | Meaning |
|---|---:|---|
| CS1574 | 79 | cref could not be resolved |
| CS1734 | 18 | `paramref` names a parameter that does not exist |
| CS0419 | 12 | cref binds arbitrarily across an overload set |
| CS1570 | 16 | malformed XML — unescaped `<` in comparison operators |
| CS1572 | 2 | `param` tag for a parameter that was renamed |
| CS1584 | 1 | syntactically invalid cref |

> #223 reported 158 CS1574. The real figure is **79 unique**; the issue counted files compiled into more than one project twice. CS0419 and CS1734 were invisible until doc generation was enabled, so they are new to this PR, not new defects.

## The 79 crefs, by why they failed

**33 were reachable but unqualified** — the file had no `using` for the target's namespace. Qualified inside the cref rather than adding a `using` that the code does not use and the analyzers would flag.

**19 named a type in a higher architectural layer** — `Domain.Common` documenting an `Application.AI.Common` interface, and similar. Those can never resolve without breaking the layering, so they became `<c>prose</c>`. The information is kept; the false implication that the compiler verifies it is dropped.

**21 were genuine doc rot** — caught only because nothing was checking:

- `DriftAuditRecord.Data` has been `Payload` for some time (3 references)
- `IEscalationOutcomeSealer` does not exist; the escalation store seals through `IGovernanceRecordSealer` (2 references, one in a security-relevant comment)
- `ChangeApplyResult` has no `Failure` member; the failing variant is the `Failed` factory
- `DeleteNodeAsync` is declared on `IKnowledgeGraphStore`, not on `IGraphDatabaseBackend`, which only inherits it
- `File.ReadLinesAsync(string)` is not a real overload — it takes a `CancellationToken`

**6 could never bind at all** — a `private static` method referenced from a test assembly, an extension method addressed as an instance member (`DatabaseFacade.EnsureCreated`), and `Infrastructure`, which is an architectural layer and not a type.

The 12 ambiguous crefs were each disambiguated **against the call site the surrounding sentence describes**, not guessed from the name: `File.Move` resolves to the 3-arg overload because the store calls it with `overwrite: true`; `UseExceptionHandler` to the `Action<IApplicationBuilder>` overload because the caller passes `errorApp => ...`.

## The guard

In `src/Directory.Build.props`:

```xml
<GenerateDocumentationFile>true</GenerateDocumentationFile>
<WarningsAsErrors>$(WarningsAsErrors);CS0419;CS1570;CS1572;CS1574;CS1580;CS1584;CS1734</WarningsAsErrors>
<NoWarn>$(NoWarn);CS1591</NoWarn>
<NoWarn>$(NoWarn);CS1573</NoWarn>
<NoWarn>$(NoWarn);CS1587</NoWarn>
```

All seven promoted codes are at **zero**, so promoting them costs nothing today and blocks the next broken reference at the build instead of at code review.

## Verification

**The guard is proven to fail, not assumed to.** Injecting `<see cref="ThisTypeDoesNotExistAnywhere"/>` into `DecisionRule.cs`:

```
DecisionRule.cs(28,30): error CS1574: XML comment has cref attribute
'ThisTypeDoesNotExistAnywhere' that could not be resolved
Build FAILED.  0 Warning(s)  1 Error(s)
```

Removed again, the build is clean.

**No executable code was touched.** Filtering the branch diff for any changed line in any `.cs` file that is not a `///` comment returns empty across all 99 files. The only functional change in this PR is the props block.

**Tests:** 8,900+ pass. Four `FileSystemService` write tests fail *in my shell* because `Path.GetTempPath()` resolves under `C:\WINDOWS\TEMP`, which `ValidateWriteTarget` correctly refuses as a system directory. Confirmed pre-existing by running them against a stashed tree — they fail identically without any of these changes. CI runners have a normal temp path and are unaffected.

## What is deliberately NOT here

`CS1573` (50) and `CS1587` (44) are suppressed rather than fixed. They are a different defect class from broken references, they span 15 further files including `PlanExecutor` and `RagOrchestrator`, and #223 itself defers them. Suppressing them explicitly with an inline comment beats either hiding them silently or ballooning a documentation PR into the planner. Follow-up issue filed with the exact file list.

One consequence worth stating plainly: `CS1591` is now suppressed globally, so the repo rule *"every public type ships with full XML docs"* is still not compiler-enforced. It was not enforced before either — doc generation was off — so this is not a regression, but 9,795 existing violations make enforcement impossible today. That is the first thing the follow-up would have to pay down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SDpwZrPazixLPuNMcUtEPM
