### PR TITLE
ci: teach the security gate to name conversation ownership

### DIFF
--- a/.github/scripts/security-gate-scope.sh
+++ b/.github/scripts/security-gate-scope.sh
@@ -190,7 +190,32 @@ CONTENT_RE="${CONTENT_RE}"'|Sanitiz|Redact|Scrub'                               
 # leftmost-longest alternative, so listing it makes `signals` name the additive hook by
 # its own name instead of the generic AIContext. Kept for that legibility, not for reach.
 CONTENT_RE="${CONTENT_RE}"'|AIContext|InvokingCoreAsync|ProvideAIContextAsync|GovernedAIFunction|ToolPermissionFilter|ReservedPlanCapability'  # agent context merge + tool governance
-CONTENT_RE="${CONTENT_RE}"'|GetUserIdOrNull|AsyncLocal|AutoApprove|HumanGate|ContentSafety|PromptInjection)'                                   # identity, ambient scope, approval bypass, content safety
+CONTENT_RE="${CONTENT_RE}"'|GetUserIdOrNull|AsyncLocal|AutoApprove|HumanGate|ContentSafety|PromptInjection'                                    # identity, ambient scope, approval bypass, content safety
+# THE FIFTH MISS — conversation ownership had no word at all.
+# PR #239 made the conversation store SQLite-backed and default: required=false,
+# trigger=none, signals=(none), skipped in 7 seconds. PR #240 then moved the
+# ownership check INTO that store, making it the single enforcement point for
+# "is this conversation yours?" — and it fired only on AsyncLocal, ClaimsPrincipal
+# and OwnerId, i.e. on incidental plumbing, not on the authorization change. A pass
+# earned by coincidence is not coverage; replay both before touching this group.
+#
+# `callerId` is the marker rather than `UserId`, and the difference is measured, not
+# reasoned: UserId is 95 of 3,249 tracked .cs files — the same band as the
+# permanently-excluded ChatMessage (105) and HttpClient (101) — because it labels
+# every DTO, log line and telemetry record in the repo. `callerId` is 50, and appears
+# only where caller identity is THREADED, which is exactly the authorization surface.
+# It also catches a check being deleted: removing an argument puts callerId on a `-`
+# line, and the scan reads removed lines too.
+#
+# The other three name the enforcement machinery, per the #227 lesson that a control
+# can be rewritten, moved, or disabled without any line of the diff mentioning what it
+# protects: ConversationOwnership (the shared rules), ConversationAccessDenied (the
+# refusal), IConversationStore (26 files — the interface that now owes the guarantee;
+# CLAUDE.md forbids re-implementing the check at a call site).
+#
+# Noise cost is measured across the last 25 merges: exactly ONE newly fires — #239,
+# the one it wrongly skipped. Zero collateral on the other 24.
+CONTENT_RE="${CONTENT_RE}"'|callerId|CallerId|ConversationOwnership|ConversationAccessDenied|IConversationStore)'                              # conversation ownership — sole enforcement point since #240
 
 # Prose is excluded from the content scan — a security guide legitimately says
 # "password" on every page. Everything else that ships or executes is scanned,

--- a/.github/scripts/security-gate-scope.test.sh
+++ b/.github/scripts/security-gate-scope.test.sh
@@ -46,6 +46,29 @@ expect_scope_nonempty() { # <label> <base> <head>
   fi
 }
 
+# Asserts WHICH marker carried the decision, not merely that one did.
+#
+# It exists because `required=true` is a weak assertion: a PR can pass the gate on a
+# marker that has nothing to do with what the PR is about, and then the case is a test
+# that cannot fail. PR #240 was exactly that — the ownership lift fired on AsyncLocal,
+# ClaimsPrincipal and OwnerId, and both of its assertions survived deleting the entire
+# ownership vocabulary. Pin the reason, not just the verdict.
+expect_signal() { # <label> <base> <head> <marker>
+  local label="$1" base="$2" head="$3" want="$4"
+  local got
+  # `decide` flattens the key=value lines into one space-separated string, so this
+  # cannot anchor on a line start. `signals` is safe to read as a single space-free
+  # field — its value is the comma-joined marker list — whereas `reason` is prose and
+  # would need the opposite treatment.
+  got="$(decide "$base" "$head" | grep -oE 'signals=[^ ]*' | cut -d= -f2)"
+  case ",$got," in
+    *",$want,"*)
+      printf '  PASS  %-58s signals name %s\n' "$label" "$want"; PASS=$((PASS+1)) ;;
+    *)
+      printf '  FAIL  %-58s signals=%s, want %s among them\n' "$label" "$got" "$want"; FAIL=$((FAIL+1)) ;;
+  esac
+}
+
 expect() { # <label> <expected-required> <expected-trigger> <base> <head>
   local label="$1" want_req="$2" want_trig="$3" base="$4" head="$5"
   local out req trig
@@ -130,6 +153,38 @@ if [ -n "$head" ] && [ -n "$base" ]; then
   expect_scope_contains "#226 names the gate script" "$base" "$head" ".claude/hooks/review-gate.ps1"
 else
   echo "  SKIP  #226 (merge commit not found in this clone)"
+fi
+
+echo
+# #239 made the conversation store SQLite-backed and the registered default. The gate
+# scored it required=false, trigger=none, signals=(none) and skipped in 7 seconds — the
+# store holds every user's transcript, and the vocabulary had no word for it.
+#
+# The control matters more than the skip. #240 then moved the ownership check INTO that
+# store, making it the sole enforcement point for "is this conversation yours?", and it
+# fired on AsyncLocal, ClaimsPrincipal and OwnerId — incidental plumbing, not one marker
+# naming the authorization change. So #240 is asserted here too: it must keep firing, and
+# it must fire because the diff says `callerId`, not by coincidence.
+echo "REPLAY — the PRs the CONTENT filter skipped or caught by accident (conversation ownership):"
+head="$(pr_head 239)"; base="$(pr_base 239)"
+if [ -n "$head" ] && [ -n "$base" ]; then
+  expect "#239 (conversation store made durable, no authz markers)" true content "$base" "$head"
+  expect_signal "#239 fires on the store contract" "$base" "$head" "IConversationStore"
+  expect_scope_contains "#239 names the store" "$base" "$head" "EfCoreConversationStore.cs"
+else
+  echo "  SKIP  #239 (merge commit not found in this clone)"
+fi
+
+head="$(pr_head 240)"; base="$(pr_base 240)"
+if [ -n "$head" ] && [ -n "$base" ]; then
+  expect "#240 (ownership moved into the store)" true content "$base" "$head"
+  # required=true alone is not the assertion here — #240 was ALREADY true before this
+  # group existed, on AsyncLocal/ClaimsPrincipal/OwnerId. What must hold is that the
+  # gate now fires because the diff threads caller identity.
+  expect_signal "#240 fires on caller identity, not on plumbing" "$base" "$head" "callerId"
+  expect_scope_contains "#240 names the shared ownership rules" "$base" "$head" "ConversationOwnership.cs"
+else
+  echo "  SKIP  #240 (merge commit not found in this clone)"
 fi
 
 echo
@@ -278,6 +333,35 @@ if git worktree add --detach --quiet "$WORKTREE" HEAD 2>/dev/null; then
   synth "ordinary ChatMessage use must NOT fire (too common to be a signal)" \
         "src/Content/Domain/Domain.AI/ScratchTest.cs" \
         "public sealed class ScratchTest { public object Make(string t) => new ChatMessage(ChatRole.User, t); }" \
+        false none
+
+  # Conversation ownership. Since #240 the store is the single place that answers
+  # "is this conversation yours?", so threading caller identity IS the authorization
+  # surface — and deleting a check puts callerId on a removed line, which the scan reads.
+  synth "src change threading caller identity" \
+        "src/Content/Domain/Domain.AI/ScratchTest.cs" \
+        "public static class ScratchTest { public static bool Go(string callerId) => callerId.Length > 0; }" \
+        true content
+
+  synth "src change to the shared ownership rules" \
+        "src/Content/Domain/Domain.AI/ScratchTest.cs" \
+        "public static class ScratchTest { public static void Go(string c) => ConversationOwnership.RequireCallerId(c); }" \
+        true content
+
+  synth "src change to the conversation store contract" \
+        "src/Content/Domain/Domain.AI/ScratchTest.cs" \
+        "public sealed class ScratchTest { public ScratchTest(IConversationStore s) { } }" \
+        true content
+
+  # The noise boundary for the ownership group, pinned in the must-NOT-fire direction.
+  # UserId is the word the issue originally proposed and the one someone will reach for
+  # next: it reads as the ownership field, and it is — but it also labels every DTO, log
+  # line and telemetry record, at 95 of 3,249 tracked .cs files. That is the same band as
+  # ChatMessage (105) and HttpClient (101), both permanently excluded. callerId covers the
+  # same surface at 50 because it appears only where identity is threaded. Do not add UserId.
+  synth "a bare UserId property must NOT fire (too common to be a signal)" \
+        "src/Content/Domain/Domain.AI/ScratchTest.cs" \
+        "public sealed record ScratchTest { public string? UserId { get; init; } }" \
         false none
 
   synth "TypeScript touching credentials (frontend is scanned too)" \


### PR DESCRIPTION
## The finding

The security gate **skipped PR #239 entirely** — `required=false, trigger=none, signals=`, 7 seconds — and that PR made the conversation store SQLite-backed and the registered default. The store holds every user's transcript.

The control is worse than the skip. Replaying **#240**, the PR that moved the ownership check *into* `IConversationStore` and made it the single enforcement point for "is this conversation yours?":

```
required=true
trigger=content
signals=AsyncLocal,ClaimsPrincipal,OwnerId
```

It fired on the ambient accessor and the claims lookup. Not one marker named the authorization change. **A pass earned by coincidence is not coverage**, and a replay case asserting only `required=true` would have been a test that cannot fail — deleting the entire new vocabulary leaves both of #240's original assertions green.

## The fix

A fifth content group: `callerId|CallerId|ConversationOwnership|ConversationAccessDenied|IConversationStore`.

**`callerId`, not `UserId`** — measured, not reasoned. `UserId` is **95 of 3,249** tracked `.cs` files, the same band as the permanently-excluded `ChatMessage` (105) and `HttpClient` (101), because it labels every DTO, log line and telemetry record. `callerId` is **50**, and appears only where caller identity is *threaded* — exactly the authorization surface. It also catches a check being **deleted**: removing an argument puts `callerId` on a `-` line, and the scan reads removed lines.

The other three name the **enforcement machinery**, per the #227 lesson that a control can be rewritten, moved, or disabled without any line of the diff mentioning what it protects.

## Noise cost — measured across the last 25 merges

| | |
|---|---|
| Already fire | 24 |
| **Newly fire** | **1** — #239, the one it wrongly skipped |
| Collateral | **0** |

## New in the harness

`expect_signal` asserts **which** marker carried the decision, not merely that one did. #240 is the case that motivated it.

## Verification

- Suite **43 → 53 passed, 0 failed**.
- **Mutation-verified**: replacing the group with a nonsense word fails exactly the 7 new assertions and nothing else. The #240 failure prints the evidence verbatim — `signals=AsyncLocal,ClaimsPrincipal,OwnerId, want callerId among them`.
- Gate run against **its own diff**: `required=true, trigger=path`. (`signals=` empty is correct — the gate script and its tests are excluded from the content scan because they *define* the markers; the path trigger is the stronger one anyway.)
- The regex compiles: an uncompilable one would silently empty `SIGNALS` via `grep -oE ... || true` swallowing exit 2, and 19 tests would fail.

Closes nothing — this is the follow-up recorded while shipping #240.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
