### PR TITLE
feat: let a bundle run continue a durable conversation (#235 PR 4/4)

### DIFF
--- a/documentation/onboarding/17-bundle-api.html
+++ b/documentation/onboarding/17-bundle-api.html
@@ -214,8 +214,60 @@
                         Only <code>userMessages</code> is required (1–100 entries, none of them empty).
                         <code>maxTurns</code> defaults to <code>10</code> and must be between 1 and 100;
                         <code>stream</code> defaults to <code>false</code> and is explained under
-                        <a href="#two-ways">Two ways to get the output</a>.
+                        <a href="#two-ways">Two ways to get the output</a>. A fourth field,
+                        <code>conversationId</code>, turns the run into a continuing session — see
+                        <a href="#durable-conversations">Continuing a conversation</a>.
                     </p>
+
+                    <h3 id="durable-conversations">Continuing a conversation across runs</h3>
+                    <p>
+                        By default a run is self-contained: it answers the messages you send and forgets them.
+                        For a one-off question that is exactly what you want. For anything that runs as a
+                        <em>session</em> — a voice channel, a chat widget, a long-lived assistant — it means the
+                        agent starts every turn with no memory, so the only way to be understood is to resend the
+                        entire transcript each time. That gets more expensive and slower with every turn, and it
+                        stops working altogether once the conversation exceeds the 100-message cap.
+                    </p>
+                    <p>
+                        Send a <code>conversationId</code> instead and the harness keeps the transcript for you.
+                        The agent is given the conversation's recent history before the first turn, and this run's
+                        turns are saved for the next one — so each request carries only what is new.
+                    </p>
+                    <div class="code-block">
+                        <div class="code-block-header"><span class="code-block-lang">http · POST /api/bundles/{handle}/runs — continuing a session</span></div>
+                        <pre><code>{
+  "userMessages": [ "And what about the second clause?" ],
+  "conversationId": "voice-session-8f14e45f"
+}</code></pre>
+                    </div>
+                    <p>
+                        The id is yours to choose — a GUID is the obvious pick — and it is created the first time
+                        you use it. A few things worth knowing:
+                    </p>
+                    <ul>
+                        <li>
+                            <strong>The conversation belongs to whoever created it.</strong> Naming a conversation
+                            that belongs to another caller returns <code>404</code>, exactly as an unknown handle
+                            does, so nobody can probe for other people's session ids.
+                        </li>
+                        <li>
+                            <strong>Turns never interleave.</strong> If a second run names a conversation that is
+                            mid-turn, it waits its turn rather than talking over it — including when the two runs
+                            land on different servers.
+                        </li>
+                        <li>
+                            <strong><code>maxTurns</code> and the 100-message cap bound one run, not the
+                            conversation.</strong> A session can run far longer than either. What bounds its total
+                            length is the conversation's lifetime token budget, which is cumulative across every
+                            run; when it is exhausted the run stops gracefully with
+                            <code>budgetExhausted: true</code> rather than failing.
+                        </li>
+                        <li>
+                            <strong>Only recent history is replayed</strong> — the last
+                            <code>AppConfig:AI:Conversations:MaxHistoryMessages</code> messages (50 by default), so
+                            the prompt cannot grow without limit even though the stored transcript does.
+                        </li>
+                    </ul>
                     <div class="code-block">
                         <div class="code-block-header"><span class="code-block-lang">http · → 202 Accepted</span></div>
                         <pre><code>{
@@ -652,7 +704,7 @@ The agent runs with exactly one tool: file_system.</code></pre>
                             <tr>
                                 <td><code>POST /api/bundles/{handle}/runs</code></td>
                                 <td><code>202</code></td>
-                                <td>Body: <code>userMessages</code> (1–100, none empty), <code>maxTurns</code> (1–100, default 10), <code>stream</code> (default false).</td>
+                                <td>Body: <code>userMessages</code> (1–100, none empty), <code>maxTurns</code> (1–100, default 10), <code>stream</code> (default false), <code>conversationId</code> (optional; continues a stored conversation).</td>
                             </tr>
                             <tr>
                                 <td><code>GET /api/bundles/{handle}/runs/{jobId}</code></td>
@@ -1214,10 +1266,10 @@ curl -sS -H "Authorization: Bearer $TOKEN" \
                     <table>
                         <thead><tr><th>Status</th><th>Means</th><th>Do</th></tr></thead>
                         <tbody>
-                            <tr><td><code>400</code></td><td>Archive guard rejection, or an invalid run request (no messages, empty message, <code>maxTurns</code> out of range).</td><td>Read <code>detail</code>; fix the payload. Not retryable as-is.</td></tr>
+                            <tr><td><code>400</code></td><td>Archive guard rejection, or an invalid run request (no messages, empty message, <code>maxTurns</code> out of range, malformed <code>conversationId</code> — letters, digits, hyphens and underscores only, up to 200 characters).</td><td>Read <code>detail</code>; fix the payload. Not retryable as-is.</td></tr>
                             <tr><td><code>401</code></td><td>No/invalid token, or a principal with no usable identity to own resources under.</td><td>Re-authenticate against <code>api://{ClientId}</code>.</td></tr>
                             <tr><td><code>403</code></td><td>Bundle execution is disabled on this host.</td><td>Operator action — <code>Enabled: true</code>. Do not retry.</td></tr>
-                            <tr><td><code>404</code></td><td>Handle or run is unknown, expired, or not yours. The three are deliberately indistinguishable.</td><td>Re-register the bundle to get a fresh handle.</td></tr>
+                            <tr><td><code>404</code></td><td>Handle, run, or named conversation is unknown, expired, or not yours. These are deliberately indistinguishable, so the API never confirms that someone else's resource exists.</td><td>Re-register the bundle to get a fresh handle; check the <code>conversationId</code> is one you created.</td></tr>
                             <tr><td><code>409</code></td><td>The run is not awaiting a stream — it is a background run, already being streamed, or already finished.</td><td>Poll the status endpoint instead.</td></tr>
                             <tr><td><code>429</code></td><td>10/min register; 60/min run, poll, and delete; the stream endpoint is capped by open connections instead.</td><td>Back off; for streams, close one first.</td></tr>
                             <tr><td><code>500</code></td><td>Unexpected server error. The body is deliberately generic.</td><td>The detail is in the host's logs. Retry idempotently.</td></tr>

--- a/documentation/onboarding/assets/openapi/bundle-api.yaml
+++ b/documentation/onboarding/assets/openapi/bundle-api.yaml
@@ -233,6 +233,12 @@ paths:
                   userMessages: ["Walk me through what you found."]
                   maxTurns: 5
                   stream: true
+              continue:
+                summary: Continue a durable conversation — send only the new message
+                value:
+                  userMessages: ["And what about the second clause?"]
+                  maxTurns: 3
+                  conversationId: "voice-session-8f14e45f"
       responses:
         "202":
           description: The run was created. It is queued for background dispatch, or reserved awaiting its stream.
@@ -1078,8 +1084,9 @@ components:
         userMessages:
           type: array
           description: >-
-            The user messages seeding the conversation — one turn per message. At least one, at most
-            100, none empty.
+            The user messages this run contributes — one turn per message. At least one, at most 100,
+            none empty. Without `conversationId` these are the whole conversation; with it, they are
+            appended to what the conversation already holds.
           minItems: 1
           maxItems: 100
           items:
@@ -1087,10 +1094,33 @@ components:
             minLength: 1
         maxTurns:
           type: integer
-          description: Maximum number of turns the conversation may run.
+          description: >-
+            Maximum number of turns **this run** may take. It does not bound the conversation: with
+            `conversationId` set the conversation outlives any one run, and its total length is bounded
+            by the conversation-lifetime token budget instead.
           default: 10
           minimum: 1
           maximum: 100
+        conversationId:
+          type: string
+          description: >-
+            Continues a durable conversation instead of running one-shot. The agent is given the
+            conversation's recent history before the first turn, and this run's turns are saved — so a
+            caller driving a multi-turn session sends only what is new rather than replaying the whole
+            transcript every time, which is what the 100-message cap would otherwise force it to do.
+
+
+            The id is yours to choose and opaque to the API; a GUID is the obvious pick. It is created
+            on first use and owned by the caller that first used it. Naming a conversation owned by
+            someone else returns `404`, identically to an unknown handle, so the endpoint cannot be
+            used to discover other people's conversation ids.
+
+
+            Turns on one conversation are serialised: a second run naming a conversation that is
+            mid-turn waits for it rather than interleaving.
+          pattern: "^[A-Za-z0-9_-]+$"
+          maxLength: 200
+          example: "voice-session-8f14e45f"
         stream:
           type: boolean
           description: >-

--- a/src/Content/Application/Application.AI.Common/CQRS/Bundles/RunBundle/RunBundleCommand.cs
+++ b/src/Content/Application/Application.AI.Common/CQRS/Bundles/RunBundle/RunBundleCommand.cs
@@ -44,6 +44,18 @@ public sealed record RunBundleCommand : IRequest<Result<RunBundleResult>>
     public int MaxTurns { get; init; } = 10;
 
     /// <summary>
+    /// The durable conversation this run continues, or null for a one-shot run. Supplying it is what
+    /// makes a bundle run stateful: prior turns are replayed to the model and this run's turns are
+    /// persisted, so a caller driving a long session sends only what is new rather than replaying the
+    /// whole transcript on every turn.
+    /// </summary>
+    /// <remarks>
+    /// Created on first use, owned by <see cref="OwnerId"/>. A conversation belonging to another caller
+    /// is reported exactly as a missing bundle handle is — the API does not disclose that it exists.
+    /// </remarks>
+    public string? ConversationId { get; init; }
+
+    /// <summary>
     /// Selects the run's dispatch mode. When true the run is reserved for external, streamed execution: the
     /// record is created <see cref="BundleRunStatus.Queued"/> but is <em>not</em> enqueued to the dispatcher, so
     /// its only driver is the transport that later claims and streams it. When false (the default) the run is

--- a/src/Content/Application/Application.AI.Common/CQRS/Bundles/RunBundle/RunBundleCommandHandler.cs
+++ b/src/Content/Application/Application.AI.Common/CQRS/Bundles/RunBundle/RunBundleCommandHandler.cs
@@ -25,6 +25,19 @@ namespace Application.AI.Common.CQRS.Bundles.RunBundle;
 public sealed class RunBundleCommandHandler
     : IRequestHandler<RunBundleCommand, Result<RunBundleResult>>
 {
+    /// <summary>
+    /// The single refusal message for an unknown handle, a handle belonging to someone else, and a
+    /// conversation belonging to someone else.
+    /// </summary>
+    /// <remarks>
+    /// One constant rather than three literals, because their being identical is a security property
+    /// rather than a coincidence: a caller who can tell these apart can enumerate other people's
+    /// handles and conversation ids by watching the response change. Kept in one place so that stays
+    /// true by construction instead of by everyone remembering to copy it exactly.
+    /// </remarks>
+    private const string HandleNotFoundMessage =
+        "Bundle handle not found or expired. Register the bundle again to obtain a fresh handle.";
+
     private readonly IBundleHandleStore _handleStore;
     private readonly IBundleRunJobStore _jobStore;
     private readonly IBundleRunDispatchQueue _dispatchQueue;
@@ -81,8 +94,7 @@ public sealed class RunBundleCommandHandler
         var staged = owner == request.OwnerId ? _handleStore.TryGet(request.Handle) : null;
         if (owner != request.OwnerId || staged is null)
         {
-            return Result<RunBundleResult>.NotFound(
-                "Bundle handle not found or expired. Register the bundle again to obtain a fresh handle.");
+            return Result<RunBundleResult>.NotFound(HandleNotFoundMessage);
         }
 
         // Refuse a conversation belonging to someone else here, while the caller is still on the line.
@@ -92,8 +104,7 @@ public sealed class RunBundleCommandHandler
         if (request.ConversationId is not null
             && !await CanUseConversationAsync(request, cancellationToken).ConfigureAwait(false))
         {
-            return Result<RunBundleResult>.NotFound(
-                "Bundle handle not found or expired. Register the bundle again to obtain a fresh handle.");
+            return Result<RunBundleResult>.NotFound(HandleNotFoundMessage);
         }
 
         var record = new BundleRunRecord

--- a/src/Content/Application/Application.AI.Common/CQRS/Bundles/RunBundle/RunBundleCommandHandler.cs
+++ b/src/Content/Application/Application.AI.Common/CQRS/Bundles/RunBundle/RunBundleCommandHandler.cs
@@ -1,3 +1,4 @@
+using Application.AI.Common.Interfaces.AI;
 using Application.AI.Common.Interfaces.Bundles;
 using Domain.AI.Bundles;
 using Domain.Common;
@@ -26,6 +27,7 @@ public sealed class RunBundleCommandHandler
     private readonly IBundleHandleStore _handleStore;
     private readonly IBundleRunJobStore _jobStore;
     private readonly IBundleRunDispatchQueue _dispatchQueue;
+    private readonly IConversationStore _conversationStore;
     private readonly IOptionsMonitor<AppConfig> _config;
     private readonly TimeProvider _time;
     private readonly ILogger<RunBundleCommandHandler> _logger;
@@ -35,6 +37,7 @@ public sealed class RunBundleCommandHandler
         IBundleHandleStore handleStore,
         IBundleRunJobStore jobStore,
         IBundleRunDispatchQueue dispatchQueue,
+        IConversationStore conversationStore,
         IOptionsMonitor<AppConfig> config,
         TimeProvider time,
         ILogger<RunBundleCommandHandler> logger)
@@ -42,6 +45,7 @@ public sealed class RunBundleCommandHandler
         ArgumentNullException.ThrowIfNull(handleStore);
         ArgumentNullException.ThrowIfNull(jobStore);
         ArgumentNullException.ThrowIfNull(dispatchQueue);
+        ArgumentNullException.ThrowIfNull(conversationStore);
         ArgumentNullException.ThrowIfNull(config);
         ArgumentNullException.ThrowIfNull(time);
         ArgumentNullException.ThrowIfNull(logger);
@@ -49,6 +53,7 @@ public sealed class RunBundleCommandHandler
         _handleStore = handleStore;
         _jobStore = jobStore;
         _dispatchQueue = dispatchQueue;
+        _conversationStore = conversationStore;
         _config = config;
         _time = time;
         _logger = logger;
@@ -79,6 +84,17 @@ public sealed class RunBundleCommandHandler
                 "Bundle handle not found or expired. Register the bundle again to obtain a fresh handle.");
         }
 
+        // Refuse a conversation belonging to someone else here, while the caller is still on the line.
+        // The run itself would refuse it too — the store enforces ownership on every call the executor
+        // makes — but only as an asynchronous failure the caller has to poll for, which reports a
+        // permission decision as though the run had gone wrong.
+        if (request.ConversationId is not null
+            && !await CanUseConversationAsync(request, cancellationToken).ConfigureAwait(false))
+        {
+            return Result<RunBundleResult>.NotFound(
+                "Bundle handle not found or expired. Register the bundle again to obtain a fresh handle.");
+        }
+
         var record = new BundleRunRecord
         {
             JobId = Guid.NewGuid().ToString("N"),
@@ -87,6 +103,7 @@ public sealed class RunBundleCommandHandler
             AgentName = staged.Agent.Id,
             UserMessages = request.UserMessages,
             MaxTurns = request.MaxTurns,
+            ConversationId = request.ConversationId,
             Envelope = request.Envelope,
             Status = BundleRunStatus.Queued,
             Streaming = request.Stream,
@@ -107,5 +124,42 @@ public sealed class RunBundleCommandHandler
             request.Stream ? "awaiting stream" : "queued for background dispatch");
 
         return Result<RunBundleResult>.Success(new RunBundleResult { JobId = record.JobId });
+    }
+
+    /// <summary>
+    /// True when this caller may run against the requested conversation — either because it is theirs,
+    /// or because it does not exist yet and the run will create it.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The ownership decision is the store's, not this handler's: it is made by passing the caller to
+    /// <see cref="IConversationStore.GetAsync"/> and letting it refuse. Nothing here compares owners —
+    /// that comparison was hand-written in six places before it moved into the store, and this would
+    /// have been the seventh.
+    /// </para>
+    /// <para>
+    /// A refusal is reported as "not found", identically to an unknown handle, so a caller cannot use
+    /// this endpoint to discover which conversation ids exist for other people.
+    /// </para>
+    /// </remarks>
+    private async Task<bool> CanUseConversationAsync(
+        RunBundleCommand request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            // The result is discarded deliberately: absent is fine (the run creates it) and present is
+            // fine (it is the caller's, or this would have thrown). Only the refusal carries meaning.
+            await _conversationStore
+                .GetAsync(request.ConversationId!, request.OwnerId, cancellationToken)
+                .ConfigureAwait(false);
+
+            return true;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            // Not logged again: the store already recorded the caller, the conversation and its real
+            // owner. A second line adds no fact and doubles every refusal in the audit trail.
+            return false;
+        }
     }
 }

--- a/src/Content/Application/Application.AI.Common/CQRS/Bundles/RunBundle/RunBundleCommandHandler.cs
+++ b/src/Content/Application/Application.AI.Common/CQRS/Bundles/RunBundle/RunBundleCommandHandler.cs
@@ -1,5 +1,6 @@
 using Application.AI.Common.Interfaces.AI;
 using Application.AI.Common.Interfaces.Bundles;
+using Application.Common.Exceptions.ExceptionTypes;
 using Domain.AI.Bundles;
 using Domain.Common;
 using Domain.Common.Config;
@@ -147,16 +148,28 @@ public sealed class RunBundleCommandHandler
     {
         try
         {
+            // Asking for a zero-message window, not the conversation. This needs to know only whether
+            // the conversation exists and whether it is the caller's, and GetAsync would load the whole
+            // transcript to answer that — on the synchronous request path, for a value thrown away. The
+            // store guarantees a non-positive window returns NO messages rather than all of them, and
+            // says so explicitly because the natural SQL translation would do the opposite; there are
+            // contract tests on both implementations holding it to that.
+            //
             // The result is discarded deliberately: absent is fine (the run creates it) and present is
             // fine (it is the caller's, or this would have thrown). Only the refusal carries meaning.
             await _conversationStore
-                .GetAsync(request.ConversationId!, request.OwnerId, cancellationToken)
+                .GetHistoryForDispatch(request.ConversationId!, request.OwnerId, 0, cancellationToken)
                 .ConfigureAwait(false);
 
             return true;
         }
-        catch (UnauthorizedAccessException)
+        catch (ConversationAccessDeniedException)
         {
+            // Deliberately the derived type, not UnauthorizedAccessException. The file-backed store
+            // touches the file system, which raises the BASE type for an ACL or read-only failure that
+            // has nothing to do with ownership — catching that would report an operator's permissions
+            // problem to the caller as "no such conversation" and bury it.
+            //
             // Not logged again: the store already recorded the caller, the conversation and its real
             // owner. A second line adds no fact and doubles every refusal in the audit trail.
             return false;

--- a/src/Content/Application/Application.AI.Common/CQRS/Bundles/RunBundle/RunBundleCommandValidator.cs
+++ b/src/Content/Application/Application.AI.Common/CQRS/Bundles/RunBundle/RunBundleCommandValidator.cs
@@ -13,6 +13,12 @@ public sealed class RunBundleCommandValidator : AbstractValidator<RunBundleComma
     /// <summary>Upper bound on turns — a runaway turn count is almost always a caller bug.</summary>
     public const int MaxTurnsLimit = 100;
 
+    /// <summary>
+    /// Upper bound on a conversation id's length. Ids are caller-supplied and opaque; this stops an
+    /// unbounded one reaching a store that makes it a file name or a primary key.
+    /// </summary>
+    public const int MaxConversationIdLength = 200;
+
     /// <summary>Initializes validation rules.</summary>
     public RunBundleCommandValidator()
     {
@@ -34,5 +40,23 @@ public sealed class RunBundleCommandValidator : AbstractValidator<RunBundleComma
         RuleFor(x => x.MaxTurns)
             .GreaterThan(0).WithMessage("MaxTurns must be greater than zero.")
             .LessThanOrEqualTo(MaxTurnsLimit).WithMessage($"MaxTurns exceeds {MaxTurnsLimit}.");
+
+        // Applied only when a conversation is named, so a one-shot run is unaffected.
+        //
+        // The charset is deliberately narrow, and it is a real control rather than tidiness: the
+        // file-backed store turns an id into a file name and rejects one that escapes its directory,
+        // while the SQLite store accepts whatever it is handed. Validating here means a traversal
+        // attempt is refused identically whichever provider a consumer has configured, instead of
+        // depending on a rejection the store interface explicitly tells callers not to rely on.
+        When(x => x.ConversationId is not null, () =>
+        {
+            RuleFor(x => x.ConversationId)
+                .NotEmpty().WithMessage("ConversationId must not be blank when supplied.")
+                .MaximumLength(MaxConversationIdLength)
+                    .WithMessage($"ConversationId exceeds {MaxConversationIdLength} characters.")
+                .Matches("^[A-Za-z0-9_-]+$")
+                    .WithMessage(
+                        "ConversationId may contain only letters, digits, hyphens and underscores.");
+        });
     }
 }

--- a/src/Content/Application/Application.AI.Common/Interfaces/AI/IConversationStore.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/AI/IConversationStore.cs
@@ -91,6 +91,43 @@ public interface IConversationStore
     /// </exception>
     Task<ConversationRecord> CreateAsync(string agentName, string userId, string? conversationId = null, CancellationToken ct = default);
 
+    /// <summary>
+    /// Returns the conversation with <paramref name="conversationId"/>, creating an empty one owned by
+    /// <paramref name="userId"/> if it does not exist. Never replaces an existing transcript.
+    /// </summary>
+    /// <param name="agentName">The agent to bind a newly created conversation to. Ignored if one exists.</param>
+    /// <param name="userId">The caller, and the owner of a conversation created here. Must be non-blank.</param>
+    /// <param name="conversationId">The conversation to open. Must be non-blank.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <remarks>
+    /// <para>
+    /// This exists because <see cref="CreateAsync"/> <em>replaces</em>, which makes the obvious
+    /// composition — read, and create when the read came back empty — a transcript-destroying race
+    /// rather than merely a redundant one. Two runs opening the same new conversation can both see it
+    /// absent; if the loser's create lands after the winner has already appended a turn, the winner's
+    /// messages are deleted by the cascade and nothing reports an error. The window is one store
+    /// round-trip wide, which is small enough to survive review and far too large to run a transcript
+    /// through.
+    /// </para>
+    /// <para>
+    /// Implementations must make the create atomic against a concurrent create of the same id, and must
+    /// resolve a lost race by returning the winner's record — not by overwriting it. The turn lease
+    /// cannot stand in for this: a lease claims a conversation that already exists, so there is nothing
+    /// for it to hold while one is being created.
+    /// </para>
+    /// <para>
+    /// Ownership is enforced on both outcomes, so losing the create race to another user is refused
+    /// exactly as reading their conversation would be.
+    /// </para>
+    /// </remarks>
+    /// <exception cref="ArgumentException"><paramref name="userId"/> or <paramref name="conversationId"/> is blank.</exception>
+    /// <exception cref="UnauthorizedAccessException">The conversation exists and belongs to another user.</exception>
+    Task<ConversationRecord> GetOrCreateAsync(
+        string agentName,
+        string userId,
+        string conversationId,
+        CancellationToken ct = default);
+
     /// <summary>Appends <paramref name="message"/> to an existing conversation record.</summary>
     /// <param name="conversationId">The conversation to append to.</param>
     /// <param name="callerId">The authenticated caller. Must be non-blank.</param>

--- a/src/Content/Application/Application.AI.Common/Interfaces/AI/IConversationStore.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/AI/IConversationStore.cs
@@ -146,6 +146,45 @@ public interface IConversationStore
     /// </exception>
     Task AppendMessageAsync(string conversationId, string callerId, ConversationMessage message, CancellationToken ct = default);
 
+    /// <summary>
+    /// Appends several messages as one unit, in the order given. Either all of them are stored or none
+    /// is.
+    /// </summary>
+    /// <param name="conversationId">The conversation to append to.</param>
+    /// <param name="callerId">The authenticated caller. Must be non-blank.</param>
+    /// <param name="messages">
+    /// The messages, oldest first. An empty list is a no-op. The same id rules as
+    /// <see cref="AppendMessageAsync"/> apply, and they apply <em>within</em> this batch too: two
+    /// messages here sharing one id is the same defect as one colliding with a stored message.
+    /// </param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <remarks>
+    /// <para>
+    /// This exists for the caller that has a complete exchange to store — a question and the answer it
+    /// produced — and it is not merely a convenience over calling <see cref="AppendMessageAsync"/>
+    /// twice. Two calls are two writes, and both of the shipped stores pay a per-call cost that the
+    /// batch pays once: the file-backed store rewrites the entire transcript on every append, so
+    /// storing a turn as two appends rewrites a linearly growing file twice per turn — quadratic bytes
+    /// over a session, which is precisely the growth the durable-conversation work exists to remove
+    /// from the token bill.
+    /// </para>
+    /// <para>
+    /// Atomicity is the other half. A turn split across two writes can be interrupted between them,
+    /// leaving a question with no answer — and this transcript is replayed to a model, so a half-turn
+    /// is not an incomplete record but a misleading one.
+    /// </para>
+    /// </remarks>
+    /// <exception cref="ArgumentException"><paramref name="callerId"/> is blank.</exception>
+    /// <exception cref="UnauthorizedAccessException">The conversation belongs to another user.</exception>
+    /// <exception cref="InvalidOperationException">
+    /// The conversation does not exist, or a message id is already present. Nothing is written.
+    /// </exception>
+    Task AppendMessagesAsync(
+        string conversationId,
+        string callerId,
+        IReadOnlyList<ConversationMessage> messages,
+        CancellationToken ct = default);
+
     /// <summary>Permanently deletes a conversation record.</summary>
     /// <param name="conversationId">The conversation to delete.</param>
     /// <param name="callerId">The authenticated caller. Must be non-blank.</param>

--- a/src/Content/Application/Application.AI.Common/Models/Conversations/ConversationMessageMapping.cs
+++ b/src/Content/Application/Application.AI.Common/Models/Conversations/ConversationMessageMapping.cs
@@ -25,7 +25,11 @@ public static class ConversationMessageMapping
 {
     /// <summary>Maps a stored message role onto the agent framework's chat role.</summary>
     /// <param name="role">The stored role.</param>
-    public static ChatRole ToChatRole(MessageRole role) => role switch
+    /// <remarks>
+    /// Private deliberately. Every caller wants a whole window projected, not one role converted, and
+    /// in a template consumers clone and extend, a public member is a supported member.
+    /// </remarks>
+    private static ChatRole ToChatRole(MessageRole role) => role switch
     {
         MessageRole.User => ChatRole.User,
         MessageRole.Assistant => ChatRole.Assistant,

--- a/src/Content/Application/Application.AI.Common/Models/Conversations/ConversationMessageMapping.cs
+++ b/src/Content/Application/Application.AI.Common/Models/Conversations/ConversationMessageMapping.cs
@@ -1,0 +1,51 @@
+using Microsoft.Extensions.AI;
+
+namespace Application.AI.Common.Models.Conversations;
+
+/// <summary>
+/// Projects stored transcript messages onto the shape the agent framework dispatches, so every caller
+/// that replays a conversation to a model does it the same way.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This mapping was written out by hand in three places — the SignalR orchestrator, the AG-UI handler,
+/// and the shared multi-turn loop — each an identical <c>switch</c> over the same enum. Three copies of
+/// one mapping is three chances to add a role in one of them: a role missing from a copy does not fail,
+/// it silently replays as the fallback, and the only symptom is a model that was told the wrong speaker
+/// said something.
+/// </para>
+/// <para>
+/// The fallback is deliberate rather than defensive. <see cref="MessageRole"/> is closed and every
+/// member is mapped, so the arm is unreachable today; it exists because a role added later must not
+/// throw halfway through building a prompt, and <see cref="ChatRole.User"/> is the reading that
+/// attributes an unknown speaker to the least privileged one.
+/// </para>
+/// </remarks>
+public static class ConversationMessageMapping
+{
+    /// <summary>Maps a stored message role onto the agent framework's chat role.</summary>
+    /// <param name="role">The stored role.</param>
+    public static ChatRole ToChatRole(MessageRole role) => role switch
+    {
+        MessageRole.User => ChatRole.User,
+        MessageRole.Assistant => ChatRole.Assistant,
+        MessageRole.System => ChatRole.System,
+        MessageRole.Tool => ChatRole.Tool,
+        _ => ChatRole.User,
+    };
+
+    /// <summary>
+    /// Projects a transcript window onto chat messages, oldest first, ready to seed a dispatch.
+    /// </summary>
+    /// <param name="messages">The window, in transcript order.</param>
+    /// <remarks>
+    /// Widget messages carry empty content and are excluded upstream by
+    /// <c>IConversationStore.GetHistoryForDispatch</c>, so this is a straight projection.
+    /// </remarks>
+    public static IReadOnlyList<ChatMessage> ToChatMessages(IReadOnlyList<ConversationMessage> messages)
+    {
+        ArgumentNullException.ThrowIfNull(messages);
+
+        return messages.Select(m => new ChatMessage(ToChatRole(m.Role), m.Content)).ToList();
+    }
+}

--- a/src/Content/Application/Application.Core/CQRS/Agents/RunConversation/DurableTranscript.cs
+++ b/src/Content/Application/Application.Core/CQRS/Agents/RunConversation/DurableTranscript.cs
@@ -77,16 +77,22 @@ internal sealed class DurableTranscript
     /// asked and was ignored, and the model answers accordingly.
     /// </para>
     /// <para>
-    /// The two writes are still two calls, so a failure between them can leave the question alone. That
-    /// is the store's atomicity to fix, not this type's, and the ordering here at least makes the
-    /// window a single failed append wide rather than a whole model round-trip wide.
+    /// Written through the store's batch append, so the pair is one unit: either the whole exchange is
+    /// stored or none of it is. Two separate appends could be interrupted between them — most obviously
+    /// by the lease being lost, which cancels the token both writes run under — and would leave exactly
+    /// the half-turn this method exists to avoid. It is also one file rewrite instead of two on the
+    /// file-backed store, whose appends rewrite the entire transcript.
     /// </para>
     /// </remarks>
-    public async Task AppendTurnAsync(string userMessage, string agentResponse, CancellationToken ct)
-    {
-        await AppendAsync(MessageRole.User, userMessage, ct);
-        await AppendAsync(MessageRole.Assistant, agentResponse, ct);
-    }
+    public Task AppendTurnAsync(string userMessage, string agentResponse, CancellationToken ct) =>
+        _store.AppendMessagesAsync(
+            _conversationId,
+            _ownerId,
+            [
+                NewMessage(MessageRole.User, userMessage),
+                NewMessage(MessageRole.Assistant, agentResponse),
+            ],
+            ct);
 
     /// <remarks>
     /// A fresh id per message rather than a caller-supplied one. The interactive transports preserve the
@@ -94,10 +100,6 @@ internal sealed class DurableTranscript
     /// resolve it; a bundle run has no such client and no such bubble, so minting the id here keeps the
     /// store's "ids are unique within a conversation" rule without inventing a protocol to carry one.
     /// </remarks>
-    private Task AppendAsync(MessageRole role, string content, CancellationToken ct) =>
-        _store.AppendMessageAsync(
-            _conversationId,
-            _ownerId,
-            new ConversationMessage(Guid.NewGuid(), role, content, DateTimeOffset.UtcNow),
-            ct);
+    private static ConversationMessage NewMessage(MessageRole role, string content) =>
+        new(Guid.NewGuid(), role, content, DateTimeOffset.UtcNow);
 }

--- a/src/Content/Application/Application.Core/CQRS/Agents/RunConversation/DurableTranscript.cs
+++ b/src/Content/Application/Application.Core/CQRS/Agents/RunConversation/DurableTranscript.cs
@@ -1,0 +1,99 @@
+using Application.AI.Common.Interfaces.AI;
+using Application.AI.Common.Models.Conversations;
+using Microsoft.Extensions.AI;
+
+namespace Application.Core.CQRS.Agents.RunConversation;
+
+/// <summary>
+/// One conversation's durable transcript, bound to the caller it was opened for. Reads the window of
+/// prior messages a continuing run replays to the model, and writes each turn back as it completes.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This exists so <see cref="RunConversationCommandHandler"/> can hold "the conversation this run is
+/// continuing" as one thing rather than as a store, an id and an owner id threaded separately through
+/// every call. The owner is captured once, at construction, which is what makes it impossible for a
+/// later call in the same run to pass a different one.
+/// </para>
+/// <para>
+/// <strong>It performs no ownership check and must not grow one.</strong> Every method hands the
+/// captured caller id to <see cref="IConversationStore"/>, which refuses a conversation belonging to
+/// someone else. Re-checking here would be the seventh hand-written copy of a comparison this codebase
+/// deliberately moved into the store — see the remarks on <see cref="IConversationStore"/>.
+/// </para>
+/// </remarks>
+internal sealed class DurableTranscript
+{
+    private readonly IConversationStore _store;
+    private readonly string _conversationId;
+    private readonly string _ownerId;
+
+    /// <summary>Binds a transcript to the conversation and caller a run is executing for.</summary>
+    /// <param name="store">The transcript store. Enforces ownership on every call made here.</param>
+    /// <param name="conversationId">The conversation being continued.</param>
+    /// <param name="ownerId">The authenticated caller. Must be non-blank.</param>
+    public DurableTranscript(IConversationStore store, string conversationId, string ownerId)
+    {
+        ArgumentNullException.ThrowIfNull(store);
+        ArgumentException.ThrowIfNullOrWhiteSpace(conversationId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(ownerId);
+
+        _store = store;
+        _conversationId = conversationId;
+        _ownerId = ownerId;
+    }
+
+    /// <summary>
+    /// Returns the most recent <paramref name="maxMessages"/> messages, projected onto the framework's
+    /// chat shape, ready to seed the run's first turn.
+    /// </summary>
+    /// <param name="maxMessages">
+    /// The window size. Passed through unchanged: the store is explicit that a non-positive value
+    /// returns no messages rather than all of them, so "no history" stays a configurable answer here
+    /// instead of silently becoming an unbounded prompt.
+    /// </param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The window, oldest first. Empty when the conversation holds nothing yet.</returns>
+    public async Task<IReadOnlyList<ChatMessage>> LoadHistoryAsync(int maxMessages, CancellationToken ct)
+    {
+        var messages = await _store.GetHistoryForDispatch(_conversationId, _ownerId, maxMessages, ct);
+        if (messages is null || messages.Count == 0)
+            return [];
+
+        return messages.Select(m => new ChatMessage(ToChatRole(m.Role), m.Content)).ToList();
+    }
+
+    /// <summary>Appends the user message that opens a turn.</summary>
+    /// <param name="content">The user's message text.</param>
+    /// <param name="ct">Cancellation token.</param>
+    public Task AppendUserAsync(string content, CancellationToken ct) =>
+        AppendAsync(MessageRole.User, content, ct);
+
+    /// <summary>Appends the assistant message that closes a turn.</summary>
+    /// <param name="content">The agent's response text.</param>
+    /// <param name="ct">Cancellation token.</param>
+    public Task AppendAssistantAsync(string content, CancellationToken ct) =>
+        AppendAsync(MessageRole.Assistant, content, ct);
+
+    /// <remarks>
+    /// A fresh id per message rather than a caller-supplied one. The interactive transports preserve the
+    /// client's id so an optimistic UI bubble and the stored row agree, and retry-from-message can then
+    /// resolve it; a bundle run has no such client and no such bubble, so minting the id here keeps the
+    /// store's "ids are unique within a conversation" rule without inventing a protocol to carry one.
+    /// </remarks>
+    private Task AppendAsync(MessageRole role, string content, CancellationToken ct) =>
+        _store.AppendMessageAsync(
+            _conversationId,
+            _ownerId,
+            new ConversationMessage(Guid.NewGuid(), role, content, DateTimeOffset.UtcNow),
+            ct);
+
+    private static ChatRole ToChatRole(MessageRole role) => role switch
+    {
+        MessageRole.User => ChatRole.User,
+        MessageRole.Assistant => ChatRole.Assistant,
+        MessageRole.System => ChatRole.System,
+        MessageRole.Tool => ChatRole.Tool,
+        _ => ChatRole.User,
+    };
+}

--- a/src/Content/Application/Application.Core/CQRS/Agents/RunConversation/DurableTranscript.cs
+++ b/src/Content/Application/Application.Core/CQRS/Agents/RunConversation/DurableTranscript.cs
@@ -60,20 +60,33 @@ internal sealed class DurableTranscript
         if (messages is null || messages.Count == 0)
             return [];
 
-        return messages.Select(m => new ChatMessage(ToChatRole(m.Role), m.Content)).ToList();
+        return ConversationMessageMapping.ToChatMessages(messages);
     }
 
-    /// <summary>Appends the user message that opens a turn.</summary>
-    /// <param name="content">The user's message text.</param>
+    /// <summary>
+    /// Appends one completed exchange — the question and the answer it produced — to the transcript.
+    /// </summary>
+    /// <param name="userMessage">The user's message that opened the turn.</param>
+    /// <param name="agentResponse">The agent's reply that closed it.</param>
     /// <param name="ct">Cancellation token.</param>
-    public Task AppendUserAsync(string content, CancellationToken ct) =>
-        AppendAsync(MessageRole.User, content, ct);
-
-    /// <summary>Appends the assistant message that closes a turn.</summary>
-    /// <param name="content">The agent's response text.</param>
-    /// <param name="ct">Cancellation token.</param>
-    public Task AppendAssistantAsync(string content, CancellationToken ct) =>
-        AppendAsync(MessageRole.Assistant, content, ct);
+    /// <remarks>
+    /// <para>
+    /// A turn is written as a pair, and only once it has an answer, because this transcript is replayed
+    /// to a model rather than read by a person. A question stored without its answer is not an
+    /// incomplete record, it is a misleading one: the next run replays a conversation in which the user
+    /// asked and was ignored, and the model answers accordingly.
+    /// </para>
+    /// <para>
+    /// The two writes are still two calls, so a failure between them can leave the question alone. That
+    /// is the store's atomicity to fix, not this type's, and the ordering here at least makes the
+    /// window a single failed append wide rather than a whole model round-trip wide.
+    /// </para>
+    /// </remarks>
+    public async Task AppendTurnAsync(string userMessage, string agentResponse, CancellationToken ct)
+    {
+        await AppendAsync(MessageRole.User, userMessage, ct);
+        await AppendAsync(MessageRole.Assistant, agentResponse, ct);
+    }
 
     /// <remarks>
     /// A fresh id per message rather than a caller-supplied one. The interactive transports preserve the
@@ -87,13 +100,4 @@ internal sealed class DurableTranscript
             _ownerId,
             new ConversationMessage(Guid.NewGuid(), role, content, DateTimeOffset.UtcNow),
             ct);
-
-    private static ChatRole ToChatRole(MessageRole role) => role switch
-    {
-        MessageRole.User => ChatRole.User,
-        MessageRole.Assistant => ChatRole.Assistant,
-        MessageRole.System => ChatRole.System,
-        MessageRole.Tool => ChatRole.Tool,
-        _ => ChatRole.User,
-    };
 }

--- a/src/Content/Application/Application.Core/CQRS/Agents/RunConversation/RunConversationCommand.cs
+++ b/src/Content/Application/Application.Core/CQRS/Agents/RunConversation/RunConversationCommand.cs
@@ -49,6 +49,31 @@ public record RunConversationCommand : IRequest<ConversationResult>, IHasTimeout
 	/// Conversation identifier shared across all turns.
 	/// </summary>
 	public string ConversationId { get; init; } = Guid.NewGuid().ToString();
+
+	/// <summary>
+	/// The owner of the durable transcript this conversation belongs to. Setting it makes the run
+	/// <em>continue</em> a conversation rather than start a throwaway one: prior turns are loaded and
+	/// replayed to the model, each turn is persisted as it completes, and the whole run holds the
+	/// conversation's turn lease. Leaving it null keeps the original behaviour — nothing is read and
+	/// nothing is written.
+	/// </summary>
+	/// <remarks>
+	/// <para>
+	/// This is the caller's authenticated identity, not a value the caller chooses. It is passed
+	/// straight to <c>IConversationStore</c>, which refuses a conversation owned by anyone else; the
+	/// handler never compares owners itself. A blank string is rejected rather than treated as "no
+	/// owner", because an absent identity has repeatedly been read as global access in this codebase —
+	/// omit the property to opt out, do not blank it.
+	/// </para>
+	/// <para>
+	/// <strong><see cref="MaxTurns"/> and the seed-message cap bound this run, not the conversation.</strong>
+	/// A durable conversation outlives any one run, so a per-run ceiling cannot also be its lifetime
+	/// ceiling — what bounds total length is the conversation-lifetime token budget, which is durable and
+	/// spans every run. Reading <see cref="MaxTurns"/> as a conversation limit would cap a long-lived
+	/// session at a number chosen for a single request.
+	/// </para>
+	/// </remarks>
+	public string? ConversationOwnerId { get; init; }
 }
 
 /// <summary>
@@ -68,10 +93,11 @@ public record ConversationResult
 	/// <remarks>
 	/// <para>
 	/// The handler folds the same figure into the conversation-lifetime budget under this
-	/// conversation's own id, then releases that entry when it returns. Surfacing the total lets a
-	/// caller that owns a <em>larger</em> unit of work than one conversation — a plan run spanning
-	/// many single-conversation steps — accumulate spend against its own budget key without trying
-	/// to reach into the entry this handler owns and disposes.
+	/// conversation's own id, and — since issue #245 — deliberately does <em>not</em> release that
+	/// entry when it returns, because a conversation now outlives the run that happened to carry it.
+	/// Surfacing the total lets a caller that owns a <em>larger</em> unit of work than one conversation
+	/// — a plan run spanning many single-conversation steps — accumulate spend against its own budget
+	/// key without reading the entry this handler writes.
 	/// </para>
 	/// <para>
 	/// <strong>Not an exact meter on the failure path.</strong> A turn that fails returns before its

--- a/src/Content/Application/Application.Core/CQRS/Agents/RunConversation/RunConversationCommandHandler.cs
+++ b/src/Content/Application/Application.Core/CQRS/Agents/RunConversation/RunConversationCommandHandler.cs
@@ -43,6 +43,26 @@ public class RunConversationCommandHandler : IRequestHandler<RunConversationComm
 	private readonly IOptions<ConversationsConfig> _conversationsConfig;
 	private readonly ILogger<RunConversationCommandHandler> _logger;
 
+	/// <summary>Initializes a new <see cref="RunConversationCommandHandler"/>.</summary>
+	/// <param name="mediator">Dispatches each turn.</param>
+	/// <param name="agentCache">Per-conversation agent cache, evicted when the run ends.</param>
+	/// <param name="conversationBudget">The conversation-lifetime token ceiling, gated before every turn.</param>
+	/// <param name="observabilityStore">Session-level telemetry for the run.</param>
+	/// <param name="conversationStore">
+	/// The durable transcript. Used only when the command carries an owner; it also enforces ownership,
+	/// which is why this handler never compares owners itself.
+	/// </param>
+	/// <param name="turnLease">
+	/// Serialises turns on one conversation across hosts. Held for a whole durable run.
+	/// </param>
+	/// <param name="conversationsConfig">Supplies the bounded replay window.</param>
+	/// <param name="logger">Diagnostic logger.</param>
+	/// <remarks>
+	/// The last three are ordinary required dependencies rather than optional ones, even though a
+	/// self-contained run never touches them. A host that composes this handler without conversation
+	/// storage then fails at startup, which is a fixable misconfiguration, instead of on its first
+	/// durable run, which is an outage.
+	/// </remarks>
 	public RunConversationCommandHandler(
 		IMediator mediator,
 		IAgentConversationCache agentCache,
@@ -53,6 +73,15 @@ public class RunConversationCommandHandler : IRequestHandler<RunConversationComm
 		IOptions<ConversationsConfig> conversationsConfig,
 		ILogger<RunConversationCommandHandler> logger)
 	{
+		ArgumentNullException.ThrowIfNull(mediator);
+		ArgumentNullException.ThrowIfNull(agentCache);
+		ArgumentNullException.ThrowIfNull(conversationBudget);
+		ArgumentNullException.ThrowIfNull(observabilityStore);
+		ArgumentNullException.ThrowIfNull(conversationStore);
+		ArgumentNullException.ThrowIfNull(turnLease);
+		ArgumentNullException.ThrowIfNull(conversationsConfig);
+		ArgumentNullException.ThrowIfNull(logger);
+
 		_mediator = mediator;
 		_agentCache = agentCache;
 		_conversationBudget = conversationBudget;
@@ -199,13 +228,6 @@ public class RunConversationCommandHandler : IRequestHandler<RunConversationComm
 					});
 				}
 
-				// Persist the question before asking it, so a turn that fails still leaves a transcript
-				// showing what was asked. The interactive transports append in this order for the same
-				// reason. Deliberately after the budget gate: a turn declined for budget never ran, and
-				// recording its question would leave the next run replaying a question nobody answered.
-				if (transcript is not null)
-					await transcript.AppendUserAsync(userMessage, cancellationToken);
-
 				var turnCommand = new ExecuteAgentTurnCommand
 				{
 					AgentName = request.AgentName,
@@ -248,12 +270,21 @@ public class RunConversationCommandHandler : IRequestHandler<RunConversationComm
 					};
 				}
 
-				// Close the turn in the transcript as soon as it succeeds, rather than writing the whole
-				// run back at the end. A run that dies on its seventh turn then keeps the six that
-				// completed, which is the difference between a durable conversation and a durable
-				// summary of one.
+				// Write the turn as soon as it succeeds, rather than writing the whole run back at the
+				// end: a run that dies on its seventh turn keeps the six that completed, which is the
+				// difference between a durable conversation and a durable summary of one.
+				//
+				// Question and answer are written TOGETHER, and only once there is an answer. Writing
+				// the question up-front — which is what the interactive transports do, so that a live
+				// user can see what they asked — is wrong here for two reasons that both come back to
+				// this transcript being REPLAYED to a model rather than read by a person. A turn that
+				// fails, or one cut short by a lost lease, would leave a question with no answer, and
+				// the next run would replay a conversation in which the user apparently asked twice
+				// and was ignored once. And the second write happens on a token the lost lease has
+				// already cancelled, so the pair would be split precisely when the lease was taken —
+				// the one moment the transcript must not be half-written.
 				if (transcript is not null)
-					await transcript.AppendAssistantAsync(lastResult.Response, cancellationToken);
+					await transcript.AppendTurnAsync(userMessage, lastResult.Response, cancellationToken);
 
 				turns.Add(new TurnSummary
 				{

--- a/src/Content/Application/Application.Core/CQRS/Agents/RunConversation/RunConversationCommandHandler.cs
+++ b/src/Content/Application/Application.Core/CQRS/Agents/RunConversation/RunConversationCommandHandler.cs
@@ -102,7 +102,7 @@ public class RunConversationCommandHandler : IRequestHandler<RunConversationComm
 		// IsNullOrWhiteSpace test: an empty identity has been read as "everyone" in this codebase before,
 		// and treating it as "nobody in particular, carry on" is how that happens again.
 		return request.ConversationOwnerId is null
-			? RunAsync(request, seedHistory: [], transcript: null, cancellationToken)
+			? RunAsync(request, transcript: null, cancellationToken)
 			: RunDurableAsync(request, cancellationToken);
 	}
 
@@ -139,24 +139,33 @@ public class RunConversationCommandHandler : IRequestHandler<RunConversationComm
 
 		var transcript = new DurableTranscript(_conversationStore, request.ConversationId, ownerId);
 
-		// Read under the lease, not before it: the turn this run queued behind may have appended to the
-		// transcript, and a window read earlier would omit exactly the messages that turn just wrote.
-		var seedHistory = await transcript.LoadHistoryAsync(
-			_conversationsConfig.Value.MaxHistoryMessages, turnCts.Token);
-
-		_logger.LogInformation(
-			"Continuing durable conversation {ConversationId} with {HistoryCount} prior message(s) replayed.",
-			request.ConversationId, seedHistory.Count);
-
-		return await RunAsync(request, seedHistory, transcript, turnCts.Token);
+		return await RunAsync(request, transcript, turnCts.Token);
 	}
 
 	private async Task<ConversationResult> RunAsync(
 		RunConversationCommand request,
-		IReadOnlyList<ChatMessage> seedHistory,
 		DurableTranscript? transcript,
 		CancellationToken cancellationToken)
 	{
+		// Derived from the transcript rather than passed alongside it: the two are one piece of state,
+		// and a signature that took both would let a caller pass a seed with no transcript, or a window
+		// belonging to some other conversation, with nothing to object.
+		//
+		// Read here rather than before the lease was taken: the turn this run queued behind may have
+		// appended to the transcript, and a window read earlier would omit exactly the messages that
+		// turn just wrote.
+		var seedHistory = transcript is null
+			? []
+			: await transcript.LoadHistoryAsync(
+				_conversationsConfig.Value.MaxHistoryMessages, cancellationToken);
+
+		if (transcript is not null)
+		{
+			_logger.LogInformation(
+				"Continuing durable conversation {ConversationId} with {HistoryCount} prior message(s) replayed.",
+				request.ConversationId, seedHistory.Count);
+		}
+
 		_logger.LogInformation("Starting conversation with {AgentName}, {MessageCount} messages, max {MaxTurns} turns",
 			request.AgentName, request.UserMessages.Count, request.MaxTurns);
 

--- a/src/Content/Application/Application.Core/CQRS/Agents/RunConversation/RunConversationCommandHandler.cs
+++ b/src/Content/Application/Application.Core/CQRS/Agents/RunConversation/RunConversationCommandHandler.cs
@@ -6,8 +6,11 @@ using Application.AI.Common.OpenTelemetry.Metrics;
 using Application.Core.CQRS.Agents.ExecuteAgentTurn;
 using Domain.AI.Governance;
 using Domain.AI.Telemetry.Conventions;
+using Domain.Common.Config.AI.Conversations;
 using MediatR;
+using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace Application.Core.CQRS.Agents.RunConversation;
 
@@ -15,12 +18,29 @@ namespace Application.Core.CQRS.Agents.RunConversation;
 /// Handles <see cref="RunConversationCommand"/> by executing sequential turns
 /// with the specified agent, feeding each response back as context.
 /// </summary>
+/// <remarks>
+/// <para>
+/// <strong>Two modes, one loop.</strong> Without <see cref="RunConversationCommand.ConversationOwnerId"/>
+/// the run is self-contained: it starts from nothing and leaves nothing behind. With it, the run
+/// <em>continues</em> a durable conversation — prior turns seed the first dispatch, every turn is
+/// persisted as it completes, and the run holds the conversation's turn lease throughout.
+/// </para>
+/// <para>
+/// The continuation logic lives here, in the one place turns are actually executed, rather than in the
+/// Execution API caller that first needed it (issue #235). Putting it in the caller would have made
+/// durability visible only as a finished lump — a run that died on its seventh turn would persist
+/// nothing — and would have left the next consumer to build it again.
+/// </para>
+/// </remarks>
 public class RunConversationCommandHandler : IRequestHandler<RunConversationCommand, ConversationResult>
 {
 	private readonly IMediator _mediator;
 	private readonly IAgentConversationCache _agentCache;
 	private readonly IConversationBudgetTracker _conversationBudget;
 	private readonly IObservabilityStore _observabilityStore;
+	private readonly IConversationStore _conversationStore;
+	private readonly IConversationTurnLease _turnLease;
+	private readonly IOptions<ConversationsConfig> _conversationsConfig;
 	private readonly ILogger<RunConversationCommandHandler> _logger;
 
 	public RunConversationCommandHandler(
@@ -28,16 +48,85 @@ public class RunConversationCommandHandler : IRequestHandler<RunConversationComm
 		IAgentConversationCache agentCache,
 		IConversationBudgetTracker conversationBudget,
 		IObservabilityStore observabilityStore,
+		IConversationStore conversationStore,
+		IConversationTurnLease turnLease,
+		IOptions<ConversationsConfig> conversationsConfig,
 		ILogger<RunConversationCommandHandler> logger)
 	{
 		_mediator = mediator;
 		_agentCache = agentCache;
 		_conversationBudget = conversationBudget;
 		_observabilityStore = observabilityStore;
+		_conversationStore = conversationStore;
+		_turnLease = turnLease;
+		_conversationsConfig = conversationsConfig;
 		_logger = logger;
 	}
 
-	public async Task<ConversationResult> Handle(RunConversationCommand request, CancellationToken cancellationToken)
+	/// <inheritdoc/>
+	public Task<ConversationResult> Handle(RunConversationCommand request, CancellationToken cancellationToken)
+	{
+		ArgumentNullException.ThrowIfNull(request);
+
+		// Only an ABSENT owner opts out. A blank one falls through to the durable path, where the store
+		// rejects it — the same fail-closed reading the store documents, and the reason this is not an
+		// IsNullOrWhiteSpace test: an empty identity has been read as "everyone" in this codebase before,
+		// and treating it as "nobody in particular, carry on" is how that happens again.
+		return request.ConversationOwnerId is null
+			? RunAsync(request, seedHistory: [], transcript: null, cancellationToken)
+			: RunDurableAsync(request, cancellationToken);
+	}
+
+	/// <summary>
+	/// Runs the conversation against its durable transcript: opens it, takes its turn lease, replays the
+	/// bounded history window, and hands the loop a transcript to write each turn back to.
+	/// </summary>
+	/// <remarks>
+	/// <para>
+	/// <strong>Order is load-bearing.</strong> The conversation is opened <em>before</em> the lease is
+	/// taken because a durable lease claims an existing conversation row and throws when there is none —
+	/// so the lease cannot be what protects the opening. That is why opening is a single atomic
+	/// <see cref="IConversationStore.GetOrCreateAsync"/> rather than a read followed by a create: two
+	/// runs opening the same new conversation both see it absent, and the composed version lets the
+	/// loser's create delete the winner's turns.
+	/// </para>
+	/// <para>
+	/// <strong>Losing the lease mid-run cancels the run.</strong> Another host holding the lease means
+	/// any turn written from here on is exactly the concurrent turn the lease exists to prevent, so the
+	/// lost-lease token is linked into the token every turn runs under.
+	/// </para>
+	/// </remarks>
+	private async Task<ConversationResult> RunDurableAsync(
+		RunConversationCommand request, CancellationToken cancellationToken)
+	{
+		var ownerId = request.ConversationOwnerId!;
+
+		await _conversationStore.GetOrCreateAsync(
+			request.AgentName, ownerId, request.ConversationId, cancellationToken);
+
+		await using var lease = await _turnLease.AcquireAsync(request.ConversationId, cancellationToken);
+		using var turnCts = CancellationTokenSource.CreateLinkedTokenSource(
+			cancellationToken, lease.LeaseLost);
+
+		var transcript = new DurableTranscript(_conversationStore, request.ConversationId, ownerId);
+
+		// Read under the lease, not before it: the turn this run queued behind may have appended to the
+		// transcript, and a window read earlier would omit exactly the messages that turn just wrote.
+		var seedHistory = await transcript.LoadHistoryAsync(
+			_conversationsConfig.Value.MaxHistoryMessages, turnCts.Token);
+
+		_logger.LogInformation(
+			"Continuing durable conversation {ConversationId} with {HistoryCount} prior message(s) replayed.",
+			request.ConversationId, seedHistory.Count);
+
+		return await RunAsync(request, seedHistory, transcript, turnCts.Token);
+	}
+
+	private async Task<ConversationResult> RunAsync(
+		RunConversationCommand request,
+		IReadOnlyList<ChatMessage> seedHistory,
+		DurableTranscript? transcript,
+		CancellationToken cancellationToken)
 	{
 		_logger.LogInformation("Starting conversation with {AgentName}, {MessageCount} messages, max {MaxTurns} turns",
 			request.AgentName, request.UserMessages.Count, request.MaxTurns);
@@ -79,7 +168,14 @@ public class RunConversationCommandHandler : IRequestHandler<RunConversationComm
 
 				// Conversation-lifetime budget gate: checked before starting a turn so a conversation
 				// that exhausted its cumulative token ceiling on a prior turn stops gracefully here
-				// rather than running another. The first turn always proceeds (nothing recorded yet).
+				// rather than running another.
+				//
+				// This turn is NOT exempt just because it is the run's first. That used to be true, and
+				// stopped being true when a conversation started outliving the run carrying it: the
+				// budget is keyed by conversation and is durable, so a run continuing a conversation that
+				// was already exhausted declines before its first dispatch — which is the whole point of
+				// a lifetime ceiling. A self-contained run still proceeds, because nothing has been
+				// recorded under an id nobody has used before.
 				var budgetStatus = await _conversationBudget.GetStatusAsync(
 					request.ConversationId, cancellationToken);
 
@@ -103,11 +199,22 @@ public class RunConversationCommandHandler : IRequestHandler<RunConversationComm
 					});
 				}
 
+				// Persist the question before asking it, so a turn that fails still leaves a transcript
+				// showing what was asked. The interactive transports append in this order for the same
+				// reason. Deliberately after the budget gate: a turn declined for budget never ran, and
+				// recording its question would leave the next run replaying a question nobody answered.
+				if (transcript is not null)
+					await transcript.AppendUserAsync(userMessage, cancellationToken);
+
 				var turnCommand = new ExecuteAgentTurnCommand
 				{
 					AgentName = request.AgentName,
 					UserMessage = userMessage,
-					ConversationHistory = lastResult?.UpdatedHistory ?? [],
+
+					// The seed is used only by the first turn; from then on each turn carries the one
+					// before it, and UpdatedHistory already includes whatever was passed in — so the
+					// replayed transcript flows through the rest of the run without being re-read.
+					ConversationHistory = lastResult?.UpdatedHistory ?? seedHistory,
 					ConversationId = request.ConversationId,
 					TurnNumber = index + 1,
 					ObservabilitySessionId = dbSessionId
@@ -140,6 +247,13 @@ public class RunConversationCommandHandler : IRequestHandler<RunConversationComm
 						Error = $"Turn {index + 1} failed: {lastResult.Error}"
 					};
 				}
+
+				// Close the turn in the transcript as soon as it succeeds, rather than writing the whole
+				// run back at the end. A run that dies on its seventh turn then keeps the six that
+				// completed, which is the difference between a durable conversation and a durable
+				// summary of one.
+				if (transcript is not null)
+					await transcript.AppendAssistantAsync(lastResult.Response, cancellationToken);
 
 				turns.Add(new TurnSummary
 				{

--- a/src/Content/Application/Application.Core/CQRS/Agents/RunConversation/RunConversationCommandHandler.cs
+++ b/src/Content/Application/Application.Core/CQRS/Agents/RunConversation/RunConversationCommandHandler.cs
@@ -292,8 +292,29 @@ public class RunConversationCommandHandler : IRequestHandler<RunConversationComm
 				// and was ignored once. And the second write happens on a token the lost lease has
 				// already cancelled, so the pair would be split precisely when the lease was taken —
 				// the one moment the transcript must not be half-written.
+				//
+				// A turn that succeeds with NO text is not a complete exchange either, and storing it
+				// would produce the very half-turn described above by a longer route: both stores drop
+				// empty-content messages from the dispatch window (that is how widget messages are kept
+				// out of prompts), so the answer would be written, filtered out on the next read, and
+				// leave the question standing alone. A turn can end this way legitimately — a model
+				// replying with tool calls and no prose — so this is skipped rather than treated as a
+				// failure, and logged so it is visible rather than silent.
 				if (transcript is not null)
-					await transcript.AppendTurnAsync(userMessage, lastResult.Response, cancellationToken);
+				{
+					if (string.IsNullOrWhiteSpace(lastResult.Response))
+					{
+						_logger.LogWarning(
+							"Turn {Turn} of conversation {ConversationId} produced no text; not persisted, "
+							+ "because an empty answer is filtered from the replay window and would leave "
+							+ "the question unanswered.",
+							index + 1, request.ConversationId);
+					}
+					else
+					{
+						await transcript.AppendTurnAsync(userMessage, lastResult.Response, cancellationToken);
+					}
+				}
 
 				turns.Add(new TurnSummary
 				{

--- a/src/Content/Application/Application.Core/CQRS/Agents/RunConversation/RunConversationCommandValidator.cs
+++ b/src/Content/Application/Application.Core/CQRS/Agents/RunConversation/RunConversationCommandValidator.cs
@@ -17,5 +17,18 @@ public class RunConversationCommandValidator : AbstractValidator<RunConversation
 
 		RuleFor(x => x.MaxTurns)
 			.InclusiveBetween(1, 100).WithMessage("Max turns must be between 1 and 100.");
+
+		// Applied only when the property is present, so omitting it stays the way to run a
+		// self-contained conversation. Supplying it blank is rejected outright rather than read as
+		// omission: a blank identity that flows onward widens access instead of narrowing it.
+		RuleFor(x => x.ConversationOwnerId)
+			.NotEmpty().WithMessage("Conversation owner id must not be blank when supplied.")
+			.When(x => x.ConversationOwnerId is not null);
+
+		// A durable conversation is addressed by this id, so it has to name something. The default is a
+		// fresh GUID, which is fine for a throwaway run and meaningless for a continuing one.
+		RuleFor(x => x.ConversationId)
+			.NotEmpty().WithMessage("Conversation id is required for a durable conversation.")
+			.When(x => x.ConversationOwnerId is not null);
 	}
 }

--- a/src/Content/Domain/Domain.AI/Bundles/BundleRunRecord.cs
+++ b/src/Content/Domain/Domain.AI/Bundles/BundleRunRecord.cs
@@ -56,6 +56,25 @@ public sealed record BundleRunRecord
     public required int MaxTurns { get; init; }
 
     /// <summary>
+    /// The durable conversation this run continues, or null for a self-contained run. When set, the run
+    /// replays that conversation's recent history before its first turn and appends every turn it takes,
+    /// so a caller driving a long session sends only the new messages instead of the whole transcript.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Caller-supplied and opaque. A run naming a conversation that does not exist creates it, owned by
+    /// <see cref="OwnerId"/>; a run naming one owned by somebody else is refused exactly as an unknown
+    /// handle is, so the API never confirms that another caller's conversation exists.
+    /// </para>
+    /// <para>
+    /// <see cref="MaxTurns"/> and the seed-message cap still bound <em>this run</em> and say nothing
+    /// about the conversation's total length — what bounds that is the conversation-lifetime token
+    /// budget, which is durable and spans every run.
+    /// </para>
+    /// </remarks>
+    public string? ConversationId { get; init; }
+
+    /// <summary>
     /// The per-caller capability grant resolved for this run. The dispatcher re-publishes it ambiently for
     /// the whole run so the permission gate chain and tool-chain builder confine the ephemeral agent.
     /// </summary>

--- a/src/Content/Domain/Domain.Common/Config/AI/Conversations/ConversationsConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/Conversations/ConversationsConfig.cs
@@ -40,6 +40,28 @@ public sealed class ConversationsConfig
     public ConversationTurnLeaseConfig TurnLease { get; set; } = new();
 
     /// <summary>
+    /// How many of a conversation's most recent messages are replayed to the model when a durable run
+    /// continues it. Bounds prompt growth: a conversation's transcript is unbounded, the window sent to
+    /// the model is not.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Read by the shared multi-turn loop, so it applies to every caller that opts into a durable
+    /// conversation rather than to one host. It deliberately does <em>not</em> govern the interactive
+    /// AgentHub paths: the SignalR hub and orchestrator read <c>AppConfig:AgentHub:MaxHistoryMessages</c>
+    /// (20), and the AG-UI handler carries its own hardcoded 50. Three settings for one concept is one
+    /// too many, and consolidating them changes interactive behaviour, so it is flagged here rather than
+    /// done quietly as part of unrelated work.
+    /// </para>
+    /// <para>
+    /// Zero or negative sends no history at all — every turn starts cold. That is a real configuration,
+    /// not a disabled feature, and the store reads it that way too: <c>GetHistoryForDispatch</c> is
+    /// explicit that a non-positive window returns nothing rather than everything.
+    /// </para>
+    /// </remarks>
+    public int MaxHistoryMessages { get; set; } = 50;
+
+    /// <summary>
     /// File system path where conversation records are persisted by the
     /// <see cref="ConversationStoreProvider.FileSystem"/> provider. Ignored by the SQLite provider.
     /// </summary>

--- a/src/Content/Infrastructure/Infrastructure.AI/Bundles/BundleRunExecutor.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Bundles/BundleRunExecutor.cs
@@ -173,12 +173,17 @@ public sealed class BundleRunExecutor : IBundleRunExecutor
         using (EphemeralAgentOverlayAccessor.Begin(overlay))
         using (CapabilityEnvelopeAccessor.Begin(record.Envelope))
         {
+            // A run that names a conversation continues it; one that does not gets an id of its own so
+            // its budget and telemetry still have somewhere to accumulate. The owner rides along only in
+            // the first case — it is what switches the shared loop into durable mode, so passing it for
+            // a self-contained run would make every one-shot run write a transcript nobody asked for.
             var command = new RunConversationCommand
             {
                 AgentName = record.AgentName,
                 UserMessages = record.UserMessages,
                 MaxTurns = record.MaxTurns,
-                ConversationId = record.JobId
+                ConversationId = record.ConversationId ?? record.JobId,
+                ConversationOwnerId = record.ConversationId is null ? null : record.OwnerId
             };
 
             return await mediator.Send(command, cancellationToken).ConfigureAwait(false);

--- a/src/Content/Infrastructure/Infrastructure.AI/Conversations/EfCoreConversationStore.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Conversations/EfCoreConversationStore.cs
@@ -277,22 +277,43 @@ public sealed class EfCoreConversationStore : IConversationStore
     private const int SqliteConstraintPrimaryKey = 1555;
 
     /// <inheritdoc/>
-    public async Task AppendMessageAsync(
+    public Task AppendMessageAsync(
         string conversationId,
         string callerId,
         ConversationMessage message,
+        CancellationToken ct = default) =>
+        AppendMessagesAsync(conversationId, callerId, [message], ct);
+
+    /// <inheritdoc/>
+    /// <remarks>
+    /// The batch is the real implementation and the single-message append delegates to it, rather than
+    /// the other way round: one transaction, one header update and one round trip however many messages
+    /// arrive. Writing a turn as two calls would open two transactions to store one exchange, and would
+    /// let the pair be interrupted halfway.
+    /// </remarks>
+    public async Task AppendMessagesAsync(
+        string conversationId,
+        string callerId,
+        IReadOnlyList<ConversationMessage> messages,
         CancellationToken ct = default)
     {
         ConversationOwnership.RequireCallerId(callerId);
+        ArgumentNullException.ThrowIfNull(messages);
+
+        if (messages.Count == 0)
+            return;
 
         var now = _timeProvider.GetUtcNow();
 
         // A title is derived from the first user message only. Passing null for every other case
         // lets the UPDATE below express "keep the existing title" as a coalesce, so no read is
-        // needed to decide whether one is already set.
-        var candidateTitle = message.Role == MessageRole.User
-            ? ConversationRecordTitleDerivation.Derive(message.Content)
-            : null;
+        // needed to decide whether one is already set. Across a batch that is the first USER message
+        // in it — a turn arrives question-first, so this is the same message it would have been had
+        // the batch been appended one at a time.
+        var firstUserMessage = messages.FirstOrDefault(m => m.Role == MessageRole.User);
+        var candidateTitle = firstUserMessage is null
+            ? null
+            : ConversationRecordTitleDerivation.Derive(firstUserMessage.Content);
 
         await using var context = await _contextFactory.CreateDbContextAsync(ct);
         await using var transaction = await context.Database.BeginTransactionAsync(ct);
@@ -313,7 +334,8 @@ public sealed class EfCoreConversationStore : IConversationStore
             throw new InvalidOperationException($"Conversation '{conversationId}' does not exist.");
         }
 
-        context.ConversationMessages.Add(ConversationEntityMapper.ToEntity(conversationId, message));
+        foreach (var message in messages)
+            context.ConversationMessages.Add(ConversationEntityMapper.ToEntity(conversationId, message));
 
         try
         {
@@ -325,8 +347,15 @@ public sealed class EfCoreConversationStore : IConversationStore
             // id the conversation already holds. The unique index has to reject it — truncation
             // resolves an id to a cut point, and two rows sharing one id makes that cut arbitrary —
             // but the caller is owed a defined failure rather than whatever the provider threw.
+            //
+            // The failing id is not named across a batch: the provider reports which statement failed,
+            // not which of ours, and guessing would put a specific and possibly wrong id into an error
+            // message. The transaction rolls back either way, so nothing is written.
             throw new InvalidOperationException(
-                $"Message '{message.Id}' already exists in conversation '{conversationId}'.", ex);
+                messages.Count == 1
+                    ? $"Message '{messages[0].Id}' already exists in conversation '{conversationId}'."
+                    : $"One of the messages already exists in conversation '{conversationId}'.",
+                ex);
         }
 
         await transaction.CommitAsync(ct);

--- a/src/Content/Infrastructure/Infrastructure.AI/Conversations/EfCoreConversationStore.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Conversations/EfCoreConversationStore.cs
@@ -192,6 +192,91 @@ public sealed class EfCoreConversationStore : IConversationStore
     }
 
     /// <inheritdoc/>
+    /// <remarks>
+    /// Atomic where <see cref="CreateAsync"/> is not, and by a different mechanism: nothing is deleted
+    /// and nothing depends on the read deciding the write. The insert either lands or violates the
+    /// primary key, and the primary key is enforced by the database rather than by the gap between two
+    /// of our statements. Losing that race is not an error here — the winner created the same empty
+    /// conversation this call wanted — so the loser re-reads and returns it, which also re-applies the
+    /// ownership check against whoever actually won.
+    /// </remarks>
+    public async Task<ConversationRecord> GetOrCreateAsync(
+        string agentName,
+        string userId,
+        string conversationId,
+        CancellationToken ct = default)
+    {
+        ConversationOwnership.RequireCallerId(userId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(conversationId);
+
+        // GetAsync applies the ownership check, so a conversation belonging to someone else is refused
+        // here rather than falling through to an insert that would collide with their row.
+        var existing = await GetAsync(conversationId, userId, ct);
+        if (existing is not null)
+            return existing;
+
+        var now = _timeProvider.GetUtcNow();
+
+        await using var context = await _contextFactory.CreateDbContextAsync(ct);
+        context.Conversations.Add(new ConversationEntity
+        {
+            Id = conversationId,
+            AgentName = agentName,
+            UserId = userId,
+            CreatedAt = now,
+            UpdatedAt = now,
+        });
+
+        try
+        {
+            await context.SaveChangesAsync(ct);
+        }
+        catch (DbUpdateException ex) when (IsDuplicateConversationId(ex))
+        {
+            // Someone created this conversation between the read above and this insert. Re-read rather
+            // than overwrite: the winner may already have appended a turn, and this call promised never
+            // to destroy a transcript. The re-read refuses it if the winner was another user.
+            var raced = await GetAsync(conversationId, userId, ct);
+            if (raced is not null)
+                return raced;
+
+            // The row collided but is now unreadable — it was deleted between the two. Nothing sensible
+            // is left to return, and retrying could loop, so surface the original failure.
+            throw;
+        }
+
+        _logger.LogDebug(
+            "Opened conversation {ConversationId} for user {UserId} (created).", conversationId, userId);
+
+        return new ConversationRecord(
+            Id: conversationId,
+            AgentName: agentName,
+            UserId: userId,
+            CreatedAt: now,
+            UpdatedAt: now,
+            Messages: []);
+    }
+
+    /// <summary>
+    /// True when <paramref name="ex"/> is the conversation table's primary-key collision rather than
+    /// any other write failure.
+    /// </summary>
+    /// <remarks>
+    /// SQLite reports a clashing <em>primary</em> key as <c>SQLITE_CONSTRAINT_PRIMARYKEY</c>, not as
+    /// <c>SQLITE_CONSTRAINT_UNIQUE</c> — the code the message-id check matches. Both are accepted
+    /// because which one arrives depends on how the key is declared, and a store that recognised only
+    /// the unique variant would turn the ordinary lost-create race into an unhandled write failure.
+    /// </remarks>
+    private static bool IsDuplicateConversationId(DbUpdateException ex) =>
+        ex.InnerException is SqliteException
+        {
+            SqliteExtendedErrorCode: SqliteConstraintPrimaryKey or SqliteConstraintUnique
+        };
+
+    /// <summary>SQLite's <c>SQLITE_CONSTRAINT_PRIMARYKEY</c> extended result code.</summary>
+    private const int SqliteConstraintPrimaryKey = 1555;
+
+    /// <inheritdoc/>
     public async Task AppendMessageAsync(
         string conversationId,
         string callerId,

--- a/src/Content/Infrastructure/Infrastructure.AI/Conversations/FileSystemConversationStore.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Conversations/FileSystemConversationStore.cs
@@ -187,6 +187,68 @@ public sealed class FileSystemConversationStore : IConversationStore
     }
 
     /// <inheritdoc/>
+    /// <remarks>
+    /// The check and the write share one lock acquisition, which is what makes this atomic here — the
+    /// same arrangement <see cref="CreateAsync"/> uses, applied to the opposite decision: that one
+    /// approves an overwrite, this one refuses to perform it. The guarantee reaches exactly as far as
+    /// this store's does, which is one process; the store is already documented as unsafe for two.
+    /// </remarks>
+    public async Task<ConversationRecord> GetOrCreateAsync(
+        string agentName,
+        string userId,
+        string conversationId,
+        CancellationToken ct = default)
+    {
+        ConversationOwnership.RequireCallerId(userId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(conversationId);
+
+        var path = ResolveAndValidatePath(conversationId);
+
+        await _lock.WaitAsync(ct);
+        try
+        {
+            if (File.Exists(path))
+            {
+                var existingJson = await File.ReadAllTextAsync(path, ct);
+                var existing = JsonSerializer.Deserialize<ConversationRecord>(existingJson, ConversationJson.Options);
+                if (existing is not null)
+                {
+                    RequireOwner(conversationId, userId, existing.UserId);
+
+                    // Same backfill GetAsync performs. Returning the record unmigrated would hand the
+                    // caller messages with empty ids, which a later truncation cannot resolve to a
+                    // cut point.
+                    var migrated = MigrateMissingIds(existing);
+                    if (migrated is null)
+                        return existing;
+
+                    await WriteAtomicLockedAsync(path, migrated, ct);
+                    return migrated;
+                }
+            }
+
+            var now = _timeProvider.GetUtcNow();
+            var record = new ConversationRecord(
+                Id: conversationId,
+                AgentName: agentName,
+                UserId: userId,
+                CreatedAt: now,
+                UpdatedAt: now,
+                Messages: []);
+
+            await WriteAtomicLockedAsync(path, record, ct);
+
+            _logger.LogDebug(
+                "Opened conversation {ConversationId} for user {UserId} (created).", conversationId, userId);
+            return record;
+        }
+        finally
+        {
+            _lock.Release();
+        }
+    }
+
+    /// <inheritdoc/>
     public async Task AppendMessageAsync(string conversationId, string callerId, ConversationMessage message, CancellationToken ct = default)
     {
         ConversationOwnership.RequireCallerId(callerId);

--- a/src/Content/Infrastructure/Infrastructure.AI/Conversations/FileSystemConversationStore.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Conversations/FileSystemConversationStore.cs
@@ -249,9 +249,34 @@ public sealed class FileSystemConversationStore : IConversationStore
     }
 
     /// <inheritdoc/>
-    public async Task AppendMessageAsync(string conversationId, string callerId, ConversationMessage message, CancellationToken ct = default)
+    public Task AppendMessageAsync(string conversationId, string callerId, ConversationMessage message, CancellationToken ct = default) =>
+        AppendMessagesAsync(conversationId, callerId, [message], ct);
+
+    /// <inheritdoc/>
+    /// <remarks>
+    /// <para>
+    /// The batch is the real implementation and the single-message append delegates to it. That matters
+    /// far more here than in the SQLite store: every append re-reads, re-serialises and rewrites the
+    /// <em>whole</em> transcript file, so storing a turn as two calls rewrites a linearly growing file
+    /// twice per turn. Over a long session that is quadratic bytes — the shape the durable-conversation
+    /// work exists to remove from the token bill, reappearing on disk.
+    /// </para>
+    /// <para>
+    /// One lock acquisition covers the whole batch, which is also what makes it atomic and stops an
+    /// unrelated conversation's append from being serialised behind the second half of this one.
+    /// </para>
+    /// </remarks>
+    public async Task AppendMessagesAsync(
+        string conversationId,
+        string callerId,
+        IReadOnlyList<ConversationMessage> messages,
+        CancellationToken ct = default)
     {
         ConversationOwnership.RequireCallerId(callerId);
+        ArgumentNullException.ThrowIfNull(messages);
+
+        if (messages.Count == 0)
+            return;
 
         var path = ResolveAndValidatePath(conversationId);
 
@@ -271,20 +296,29 @@ public sealed class FileSystemConversationStore : IConversationStore
             // id the conversation already holds. Rejected rather than appended: a transcript with two
             // rows sharing one id makes a retry's cut point arbitrary, since truncation resolves an id
             // to the first match. The SQLite store gets the same rejection from a unique index.
-            if (message.Id != Guid.Empty && existing.Messages.Any(m => m.Id == message.Id))
+            //
+            // Checked against the incoming batch as well as the stored transcript. The unique index the
+            // other store relies on does not care which statement a colliding id arrived in, so a batch
+            // carrying the same id twice must be refused here too or the two stores disagree.
+            var seen = new HashSet<Guid>(existing.Messages.Select(m => m.Id));
+            foreach (var message in messages)
             {
-                throw new InvalidOperationException(
-                    $"Message '{message.Id}' already exists in conversation '{conversationId}'.");
+                if (message.Id != Guid.Empty && !seen.Add(message.Id))
+                {
+                    throw new InvalidOperationException(
+                        $"Message '{message.Id}' already exists in conversation '{conversationId}'.");
+                }
             }
 
+            var firstUserMessage = messages.FirstOrDefault(m => m.Role == MessageRole.User);
             var derivedTitle = existing.Title
-                ?? (message.Role == MessageRole.User
-                    ? ConversationRecordTitleDerivation.Derive(message.Content)
-                    : null);
+                ?? (firstUserMessage is null
+                    ? null
+                    : ConversationRecordTitleDerivation.Derive(firstUserMessage.Content));
 
             var updated = existing with
             {
-                Messages = [..existing.Messages, message],
+                Messages = [.. existing.Messages, .. messages],
                 UpdatedAt = _timeProvider.GetUtcNow(),
                 Title = derivedTitle,
             };

--- a/src/Content/Presentation/Presentation.AgentHub/AgUi/AgUiRunHandler.cs
+++ b/src/Content/Presentation/Presentation.AgentHub/AgUi/AgUiRunHandler.cs
@@ -462,19 +462,11 @@ public sealed class AgUiRunHandler
             ? parsed
             : Guid.NewGuid();
 
-    // Widget (empty-content) messages are already excluded upstream by GetHistoryForDispatch, so this is
-    // a straight projection of the dispatch history to the framework's chat-message shape.
+    // Delegates to the shared projection rather than repeating the role switch. This file, the SignalR
+    // orchestrator and the durable multi-turn loop each carried a byte-identical copy; a role added to
+    // one of three copies does not fail, it silently replays as the fallback.
     private static IReadOnlyList<ChatMessage> ToMeaiHistory(IReadOnlyList<ConversationMessage> messages) =>
-        messages.Select(m => new ChatMessage(ToChatRole(m.Role), m.Content)).ToList();
-
-    private static ChatRole ToChatRole(MessageRole role) => role switch
-    {
-        MessageRole.User => ChatRole.User,
-        MessageRole.Assistant => ChatRole.Assistant,
-        MessageRole.System => ChatRole.System,
-        MessageRole.Tool => ChatRole.Tool,
-        _ => ChatRole.User,
-    };
+        ConversationMessageMapping.ToChatMessages(messages);
 
     private static async Task TryWriteErrorAsync(IAgUiEventWriter writer, string message, CancellationToken ct)
     {

--- a/src/Content/Presentation/Presentation.AgentHub/Services/ConversationOrchestrator.cs
+++ b/src/Content/Presentation/Presentation.AgentHub/Services/ConversationOrchestrator.cs
@@ -535,15 +535,8 @@ public sealed class ConversationOrchestrator : IConversationOrchestrator
         };
     }
 
+    // Delegates to the shared projection rather than repeating the role switch — see
+    // ConversationMessageMapping for why three copies of one mapping was a latent bug.
     private static IReadOnlyList<ChatMessage> ToMeaiHistory(IReadOnlyList<ConversationMessage> messages) =>
-        messages.Select(m => new ChatMessage(ToChatRole(m.Role), m.Content)).ToList();
-
-    private static ChatRole ToChatRole(MessageRole role) => role switch
-    {
-        MessageRole.User => ChatRole.User,
-        MessageRole.Assistant => ChatRole.Assistant,
-        MessageRole.System => ChatRole.System,
-        MessageRole.Tool => ChatRole.Tool,
-        _ => ChatRole.User,
-    };
+        ConversationMessageMapping.ToChatMessages(messages);
 }

--- a/src/Content/Presentation/Presentation.AgentHub/Services/ConversationOrchestrator.cs
+++ b/src/Content/Presentation/Presentation.AgentHub/Services/ConversationOrchestrator.cs
@@ -67,24 +67,22 @@ public sealed class ConversationOrchestrator : IConversationOrchestrator
         // The only entry point that may arrive without an id — "start me a fresh conversation". Every
         // other one takes a non-null id and reads through the store directly, which is where the
         // ownership refusal now comes from.
-        var existing = string.IsNullOrWhiteSpace(conversationId)
-            ? null
-            : await _conversationStore.GetAsync(conversationId, callerId, ct);
-
+        //
+        // A supplied id goes through the store's atomic open rather than the read-then-create this used
+        // to compose. That composition is a transcript-destroying race, because CreateAsync REPLACES:
+        // two clients reconnecting on the same id can both see it absent, and the loser's create
+        // deletes the winner's turns. A freshly minted id cannot collide, so that branch still creates.
         ConversationRecord record;
-        if (existing is null)
+        if (string.IsNullOrWhiteSpace(conversationId))
         {
-            record = await _conversationStore.CreateAsync(
-                agentName, callerId,
-                conversationId: string.IsNullOrWhiteSpace(conversationId) ? null : conversationId,
-                ct: ct);
+            record = await _conversationStore.CreateAsync(agentName, callerId, conversationId: null, ct: ct);
 
             _logger.LogInformation("Created conversation {ConversationId} for user {UserId}.",
                 record.Id, callerId);
         }
         else
         {
-            record = existing;
+            record = await _conversationStore.GetOrCreateAsync(agentName, callerId, conversationId, ct);
         }
 
         var history = await _conversationStore.GetHistoryForDispatch(

--- a/src/Content/Presentation/Presentation.AgentHub/appsettings.json
+++ b/src/Content/Presentation/Presentation.AgentHub/appsettings.json
@@ -280,6 +280,7 @@
         "Provider": "Sqlite",
         "DatabasePath": "data/conversations.db",
         "ConversationsPath": "C:/temp/agentic-harness/conversations",
+        "MaxHistoryMessages": 50,
         "TurnLease": {
           "ExpirySeconds": 60,
           "PollIntervalMilliseconds": 250

--- a/src/Content/Presentation/Presentation.ExecutionApi/Controllers/BundlesController.cs
+++ b/src/Content/Presentation/Presentation.ExecutionApi/Controllers/BundlesController.cs
@@ -99,6 +99,7 @@ public sealed class BundlesController : ControllerBase
             Handle = handle,
             UserMessages = request.UserMessages,
             MaxTurns = request.MaxTurns,
+            ConversationId = request.ConversationId,
             Envelope = envelope,
             OwnerId = callerId,
             Stream = request.Stream

--- a/src/Content/Presentation/Presentation.ExecutionApi/DTOs/BundleApiContracts.cs
+++ b/src/Content/Presentation/Presentation.ExecutionApi/DTOs/BundleApiContracts.cs
@@ -19,7 +19,24 @@ public sealed record RunBundleRequest
     public IReadOnlyList<string> UserMessages { get; init; } = [];
 
     /// <summary>The maximum number of turns the conversation may run. Defaults to 10.</summary>
+    /// <remarks>
+    /// Bounds <em>this run</em>. When <see cref="ConversationId"/> is set the conversation outlives the
+    /// run, and its total length is bounded by the conversation-lifetime token budget instead.
+    /// </remarks>
     public int MaxTurns { get; init; } = 10;
+
+    /// <summary>
+    /// Continues a durable conversation instead of starting a one-shot run. Prior turns are replayed to
+    /// the agent and this run's turns are saved, so a caller driving a multi-turn session sends only the
+    /// new messages rather than the whole transcript every time. Omit it for a self-contained run.
+    /// </summary>
+    /// <remarks>
+    /// Caller-chosen and opaque — a GUID is the obvious choice. It is created on first use and owned by
+    /// the caller that first used it; naming a conversation belonging to someone else is reported as
+    /// <c>404</c>, exactly as an unknown handle is. Letters, digits, hyphens and underscores only, up to
+    /// 200 characters.
+    /// </remarks>
+    public string? ConversationId { get; init; }
 
     /// <summary>
     /// When true the run is reserved for a live stream instead of background dispatch: it is not executed until

--- a/src/Content/Presentation/Presentation.ExecutionApi/README.md
+++ b/src/Content/Presentation/Presentation.ExecutionApi/README.md
@@ -25,6 +25,7 @@ It is a composition root, exactly like `Presentation.AgentHub`: `builder.Service
 │  │                                                                        │ │
 │  │  POST   /                        → RegisterBundleCommand               │ │
 │  │  POST   /{handle}/runs           → RunBundleCommand   ← envelope bound  │ │
+│  │           optional conversationId → run continues a durable transcript  │ │
 │  │  GET    /{handle}/runs/{jobId}   → GetBundleRunQuery                   │ │
 │  │  GET    /{handle}/runs/{jobId}/stream → BundleRunStreamer (SSE)        │ │
 │  │  DELETE /{handle}                → DeleteBundleCommand                 │ │
@@ -178,6 +179,28 @@ Everything lives under `AppConfig:AI:BundleExecution` (`Domain.Common/Config/AI/
 | `Auth:AllowAnonymous` | `false` | Explicit local-dev opt-in; `Environment=Development` alone does not disable auth |
 
 The shipped `appsettings.json` sets `Enabled: true` with an empty `Auth` block, so it boots only in Development — where the shipped `appsettings.Development.json` opts into anonymous auth. Every other environment fails closed at startup until a real scheme is configured.
+
+### Durable conversations (`AppConfig:AI:Conversations`)
+
+A run may carry a `conversationId`, which makes it *continue* a stored conversation rather than run
+one-shot: prior turns are replayed to the agent and this run's turns are appended (#235). The
+transcript store, its turn lease and its token budget are shared infrastructure registered by
+`Infrastructure.AI`, not by this host -- see `Domain.Common/Config/AI/Conversations/`.
+
+| Key | Default | Notes |
+|-----|---------|-------|
+| `Provider` | `Sqlite` | `Sqlite` or `FileSystem`. Store, turn lease and budget switch together -- they are one choice, never mix them |
+| `DatabasePath` | `data/conversations.db` | **Relative resolves against each host's own output directory.** Sharing conversations between this host and AgentHub therefore takes a deliberate *absolute* path in both |
+| `MaxHistoryMessages` | 50 | How many recent messages are replayed to the model. Bounds prompt growth; the transcript itself is unbounded |
+
+Two caps that now mean something narrower than they read: `userMessages` (100) and `maxTurns` (100)
+bound **one run**. A durable conversation outlives any run, so what bounds its total length is the
+conversation-lifetime token budget, which is durable and spans every run against that conversation.
+
+A conversation is created on first use and owned by the caller that first used it. A run naming
+someone else's conversation is refused **synchronously** as `404` -- identically to an unknown handle,
+so the endpoint cannot be used to enumerate other callers' conversation ids. Ownership itself is
+enforced inside `IConversationStore`, never re-derived here.
 
 ### Direct tool invocation (`AppConfig:AI:DirectToolInvocation`)
 

--- a/src/Content/Tests/Application.AI.Common.Tests/CQRS/Bundles/RunBundleCommandHandlerTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/CQRS/Bundles/RunBundleCommandHandlerTests.cs
@@ -137,7 +137,8 @@ public sealed class RunBundleCommandHandlerTests
 
         created!.ConversationId.Should().BeNull();
         _conversations.Verify(
-            c => c.GetAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            c => c.GetHistoryForDispatch(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>()),
             Times.Never);
     }
 
@@ -151,7 +152,8 @@ public sealed class RunBundleCommandHandlerTests
         _handleStore.Setup(h => h.GetOwner("handle-1")).Returns("owner-1");
         _handleStore.Setup(h => h.TryGet("handle-1")).Returns(Staged());
         _conversations
-            .Setup(c => c.GetAsync("conv-theirs", "owner-1", It.IsAny<CancellationToken>()))
+            .Setup(c => c.GetHistoryForDispatch(
+                "conv-theirs", "owner-1", It.IsAny<int>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new ConversationAccessDeniedException());
 
         var result = await BuildSut(enabled: true)
@@ -169,11 +171,20 @@ public sealed class RunBundleCommandHandlerTests
         // store returns null by default, which is exactly that case.
         _handleStore.Setup(h => h.GetOwner("handle-1")).Returns("owner-1");
         _handleStore.Setup(h => h.TryGet("handle-1")).Returns(Staged());
+        BundleRunRecord? created = null;
+        _jobStore.Setup(j => j.Create(It.IsAny<BundleRunRecord>())).Callback<BundleRunRecord>(r => created = r);
 
         var result = await BuildSut(enabled: true)
             .Handle(Command() with { ConversationId = "conv-new" }, CancellationToken.None);
 
         result.IsSuccess.Should().BeTrue();
+        created!.ConversationId.Should().Be("conv-new");
+
+        // Asserting the probe HAPPENED, not just that the result was a success — success is the default
+        // outcome, so without this the test stays green with the whole pre-check deleted.
+        _conversations.Verify(
+            c => c.GetHistoryForDispatch("conv-new", "owner-1", 0, It.IsAny<CancellationToken>()),
+            Times.Once);
     }
 
     [Fact]
@@ -187,8 +198,12 @@ public sealed class RunBundleCommandHandlerTests
         await BuildSut(enabled: true)
             .Handle(Command() with { ConversationId = "conv-1" }, CancellationToken.None);
 
+        // Zero messages: this needs existence and ownership, not the transcript. Asking for the whole
+        // conversation to throw it away would put a full transcript load on the synchronous request
+        // path of every run — the cost this issue exists to remove, reintroduced one layer down.
         _conversations.Verify(
-            c => c.GetAsync("conv-1", "owner-1", It.IsAny<CancellationToken>()), Times.Once);
+            c => c.GetHistoryForDispatch("conv-1", "owner-1", 0, It.IsAny<CancellationToken>()),
+            Times.Once);
     }
 
     [Fact]

--- a/src/Content/Tests/Application.AI.Common.Tests/CQRS/Bundles/RunBundleCommandHandlerTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/CQRS/Bundles/RunBundleCommandHandlerTests.cs
@@ -1,5 +1,7 @@
 using Application.AI.Common.CQRS.Bundles.RunBundle;
+using Application.AI.Common.Interfaces.AI;
 using Application.AI.Common.Interfaces.Bundles;
+using Application.Common.Exceptions.ExceptionTypes;
 using Domain.AI.Agents;
 using Domain.AI.Bundles;
 using Domain.Common;
@@ -24,6 +26,7 @@ public sealed class RunBundleCommandHandlerTests
     private readonly Mock<IBundleHandleStore> _handleStore = new();
     private readonly Mock<IBundleRunJobStore> _jobStore = new();
     private readonly Mock<IBundleRunDispatchQueue> _queue = new();
+    private readonly Mock<IConversationStore> _conversations = new();
 
     private sealed class StaticOptionsMonitor<T>(T value) : IOptionsMonitor<T>
     {
@@ -37,7 +40,7 @@ public sealed class RunBundleCommandHandlerTests
         var cfg = new AppConfig();
         cfg.AI.BundleExecution.Enabled = enabled;
         return new RunBundleCommandHandler(
-            _handleStore.Object, _jobStore.Object, _queue.Object,
+            _handleStore.Object, _jobStore.Object, _queue.Object, _conversations.Object,
             new StaticOptionsMonitor<AppConfig>(cfg), _time,
             NullLogger<RunBundleCommandHandler>.Instance);
     }
@@ -98,6 +101,94 @@ public sealed class RunBundleCommandHandlerTests
         created.MaxTurns.Should().Be(4);
         result.Value!.JobId.Should().Be(created.JobId);
         _queue.Verify(q => q.EnqueueAsync(created.JobId, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    // -- Conversation continuity (#235) --
+
+    [Fact]
+    public async Task Handle_WithConversationId_CarriesItOntoTheRunRecord()
+    {
+        // The id is what makes the run continue a conversation rather than start a throwaway one. If it
+        // is dropped here, the run still succeeds — it just silently forgets, which is the failure mode
+        // this whole issue is about.
+        _handleStore.Setup(h => h.GetOwner("handle-1")).Returns("owner-1");
+        _handleStore.Setup(h => h.TryGet("handle-1")).Returns(Staged());
+        BundleRunRecord? created = null;
+        _jobStore.Setup(j => j.Create(It.IsAny<BundleRunRecord>())).Callback<BundleRunRecord>(r => created = r);
+
+        var result = await BuildSut(enabled: true)
+            .Handle(Command() with { ConversationId = "conv-1" }, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        created!.ConversationId.Should().Be("conv-1");
+    }
+
+    [Fact]
+    public async Task Handle_WithoutConversationId_LeavesTheRunSelfContainedAndNeverTouchesTheStore()
+    {
+        // A one-shot run must not consult the transcript store at all — reaching it would make every
+        // bundle run pay for a lookup it has no use for.
+        _handleStore.Setup(h => h.GetOwner("handle-1")).Returns("owner-1");
+        _handleStore.Setup(h => h.TryGet("handle-1")).Returns(Staged());
+        BundleRunRecord? created = null;
+        _jobStore.Setup(j => j.Create(It.IsAny<BundleRunRecord>())).Callback<BundleRunRecord>(r => created = r);
+
+        await BuildSut(enabled: true).Handle(Command(), CancellationToken.None);
+
+        created!.ConversationId.Should().BeNull();
+        _conversations.Verify(
+            c => c.GetAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_ConversationOwnedByAnotherCaller_ReturnsNotFound_AndDoesNotRun()
+    {
+        // Refused the same way a foreign handle is, and reported identically: a caller must not be able
+        // to discover which conversation ids exist for other people by watching the status code change.
+        // The refusal has to happen HERE, while the caller is still on the line — deferring it to the
+        // background run turns a permission decision into a polled failure.
+        _handleStore.Setup(h => h.GetOwner("handle-1")).Returns("owner-1");
+        _handleStore.Setup(h => h.TryGet("handle-1")).Returns(Staged());
+        _conversations
+            .Setup(c => c.GetAsync("conv-theirs", "owner-1", It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new ConversationAccessDeniedException());
+
+        var result = await BuildSut(enabled: true)
+            .Handle(Command() with { ConversationId = "conv-theirs" }, CancellationToken.None);
+
+        result.FailureType.Should().Be(ResultFailureType.NotFound);
+        _jobStore.Verify(j => j.Create(It.IsAny<BundleRunRecord>()), Times.Never);
+        _queue.Verify(q => q.EnqueueAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_ConversationNotYetCreated_IsAcceptedSoTheRunCanCreateIt()
+    {
+        // An absent conversation is the ordinary first turn of a new session, not an error. The mocked
+        // store returns null by default, which is exactly that case.
+        _handleStore.Setup(h => h.GetOwner("handle-1")).Returns("owner-1");
+        _handleStore.Setup(h => h.TryGet("handle-1")).Returns(Staged());
+
+        var result = await BuildSut(enabled: true)
+            .Handle(Command() with { ConversationId = "conv-new" }, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Handle_ChecksTheConversationAgainstTheCallingOwnerNotTheHandleOwner()
+    {
+        // The store is what refuses a foreign conversation, and it can only do so if this handler hands
+        // it the caller. Passing anything else would defeat the check without appearing to remove it.
+        _handleStore.Setup(h => h.GetOwner("handle-1")).Returns("owner-1");
+        _handleStore.Setup(h => h.TryGet("handle-1")).Returns(Staged());
+
+        await BuildSut(enabled: true)
+            .Handle(Command() with { ConversationId = "conv-1" }, CancellationToken.None);
+
+        _conversations.Verify(
+            c => c.GetAsync("conv-1", "owner-1", It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]

--- a/src/Content/Tests/Application.AI.Common.Tests/CQRS/Bundles/RunBundleCommandValidatorTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/CQRS/Bundles/RunBundleCommandValidatorTests.cs
@@ -1,0 +1,89 @@
+using Application.AI.Common.CQRS.Bundles.RunBundle;
+using Domain.AI.Bundles;
+using FluentAssertions;
+using Xunit;
+
+namespace Application.AI.Common.Tests.CQRS.Bundles;
+
+/// <summary>
+/// Validation of <see cref="RunBundleCommand"/>, concentrating on the conversation id introduced for
+/// durable bundle runs (#235).
+/// </summary>
+/// <remarks>
+/// The id's charset is a security control rather than tidiness. The file-backed transcript store turns
+/// an id into a file name and rejects one that escapes its directory; the SQLite store accepts whatever
+/// it is handed. Validating at this boundary means a traversal attempt is refused identically whichever
+/// provider a consumer has configured — the store interface explicitly tells callers not to depend on a
+/// particular implementation's rejection.
+/// </remarks>
+public sealed class RunBundleCommandValidatorTests
+{
+    private readonly RunBundleCommandValidator _validator = new();
+
+    private static RunBundleCommand Command(string? conversationId = null) => new()
+    {
+        Handle = "handle-1",
+        UserMessages = ["hello"],
+        Envelope = new CapabilityEnvelope(),
+        OwnerId = "owner-1",
+        MaxTurns = 4,
+        ConversationId = conversationId
+    };
+
+    [Fact]
+    public void Validate_NoConversationId_IsValid()
+    {
+        // Omitting it is how a caller asks for a one-shot run; the rules must not fire.
+        _validator.Validate(Command()).IsValid.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("conv-1")]
+    [InlineData("8f14e45fceea167a5a36dedd4bea2543")]
+    [InlineData("voice_session_42")]
+    public void Validate_OpaqueConversationId_IsValid(string id)
+    {
+        _validator.Validate(Command(id)).IsValid.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Validate_BlankConversationId_IsRejected(string id)
+    {
+        // Supplied-but-blank is a caller bug, and must not be read as "omitted". A blank identity or id
+        // that flows onward is how this codebase has previously widened access rather than narrowing it.
+        _validator.Validate(Command(id)).IsValid.Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData("../../etc/passwd")]
+    [InlineData("..\\..\\windows\\system32")]
+    [InlineData("conv/../other")]
+    [InlineData("conv/nested")]
+    [InlineData("conv\\nested")]
+    [InlineData("conv:1")]
+    [InlineData("conv id")]
+    [InlineData("conv\n1")]
+    public void Validate_ConversationIdWithPathOrControlCharacters_IsRejected(string id)
+    {
+        _validator.Validate(Command(id)).IsValid.Should().BeFalse(
+            "an id reaches a store that may turn it into a file name");
+    }
+
+    [Fact]
+    public void Validate_ConversationIdAtTheLengthLimit_IsValid()
+    {
+        var id = new string('a', RunBundleCommandValidator.MaxConversationIdLength);
+
+        _validator.Validate(Command(id)).IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Validate_ConversationIdOverTheLengthLimit_IsRejected()
+    {
+        var id = new string('a', RunBundleCommandValidator.MaxConversationIdLength + 1);
+
+        _validator.Validate(Command(id)).IsValid.Should().BeFalse();
+    }
+}

--- a/src/Content/Tests/Application.Core.Tests/CQRS/AgentPipelineIntegrationTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/CQRS/AgentPipelineIntegrationTests.cs
@@ -91,6 +91,18 @@ public class AgentPipelineIntegrationTests
         // Observability store — no-op mock for integration tests
         services.AddSingleton(new Mock<IObservabilityStore>().Object);
 
+        // Durable-conversation collaborators. Strict and unstubbed on purpose: every conversation this
+        // pipeline runs is self-contained (no ConversationOwnerId), so a call to either would mean the
+        // handler had taken the durable path. They are registered rather than omitted because the
+        // handler demands them as ordinary constructor dependencies — which is what makes a host that
+        // forgets to compose conversation storage fail at startup instead of on its first durable run.
+        services.AddSingleton(
+            new Mock<Application.AI.Common.Interfaces.AI.IConversationStore>(MockBehavior.Strict).Object);
+        services.AddSingleton(
+            new Mock<Application.AI.Common.Interfaces.AI.IConversationTurnLease>(MockBehavior.Strict).Object);
+        services.AddSingleton(Microsoft.Extensions.Options.Options.Create(
+            new Domain.Common.Config.AI.Conversations.ConversationsConfig()));
+
         // LLM usage capture — scoped mock matching production DI lifetime
         var usageCaptureMock = new Mock<ILlmUsageCapture>();
         usageCaptureMock.Setup(c => c.TakeSnapshot())

--- a/src/Content/Tests/Application.Core.Tests/CQRS/RunConversationCommandHandlerSolutionReviewFixTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/CQRS/RunConversationCommandHandlerSolutionReviewFixTests.cs
@@ -3,9 +3,11 @@ using Application.AI.Common.Interfaces.AI;
 using Application.Core.CQRS.Agents.ExecuteAgentTurn;
 using Application.Core.CQRS.Agents.RunConversation;
 using Domain.AI.Budget;
+using Domain.Common.Config.AI.Conversations;
 using FluentAssertions;
 using MediatR;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using Moq;
 using Xunit;
 
@@ -40,11 +42,16 @@ public class RunConversationCommandHandlerSolutionReviewFixTests
             .Setup(b => b.GetStatusAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(ConversationBudgetStatus.Disabled);
 
+        // Strict and unstubbed: these tests run self-contained conversations, so any call to the
+        // transcript store or the turn lease means the handler took the durable path by mistake.
         _handler = new RunConversationCommandHandler(
             _mediator.Object,
             _agentCache.Object,
             budget.Object,
             _observabilityStore.Object,
+            new Mock<IConversationStore>(MockBehavior.Strict).Object,
+            new Mock<IConversationTurnLease>(MockBehavior.Strict).Object,
+            Options.Create(new ConversationsConfig()),
             NullLogger<RunConversationCommandHandler>.Instance);
     }
 

--- a/src/Content/Tests/Application.Core.Tests/CQRS/RunConversationCommandHandlerTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/CQRS/RunConversationCommandHandlerTests.cs
@@ -3,10 +3,12 @@ using Application.AI.Common.Interfaces.AI;
 using Application.Core.CQRS.Agents.ExecuteAgentTurn;
 using Application.Core.CQRS.Agents.RunConversation;
 using Domain.AI.Budget;
+using Domain.Common.Config.AI.Conversations;
 using FluentAssertions;
 using MediatR;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using Moq;
 using Xunit;
 
@@ -25,11 +27,17 @@ public class RunConversationCommandHandlerTests
             .Setup(b => b.GetStatusAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(ConversationBudgetStatus.Disabled);
 
+        // Store and lease are strict about being unused here: every test in this class runs a
+        // self-contained conversation (no ConversationOwnerId), and touching either would mean the
+        // handler had silently taken the durable path. A throwing double says so immediately.
         _handler = new RunConversationCommandHandler(
             _mediator.Object,
             new Mock<IAgentConversationCache>().Object,
             _budget.Object,
             new Mock<IObservabilityStore>().Object,
+            new Mock<IConversationStore>(MockBehavior.Strict).Object,
+            new Mock<IConversationTurnLease>(MockBehavior.Strict).Object,
+            Options.Create(new ConversationsConfig()),
             NullLogger<RunConversationCommandHandler>.Instance);
     }
 

--- a/src/Content/Tests/Application.Core.Tests/CQRS/RunConversationDurableTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/CQRS/RunConversationDurableTests.cs
@@ -472,10 +472,24 @@ public sealed class RunConversationDurableTests
         /// the thing it stands in for does not simplify a test, it silences one.
         /// </remarks>
         public Task AppendMessageAsync(
-            string conversationId, string callerId, ConversationMessage message, CancellationToken ct = default)
+            string conversationId, string callerId, ConversationMessage message, CancellationToken ct = default) =>
+            AppendMessagesAsync(conversationId, callerId, [message], ct);
+
+        /// <remarks>
+        /// All-or-nothing, like the real stores: the batch is recorded only once the token has been
+        /// checked. A double that recorded messages one at a time and then threw would leave a
+        /// half-written turn the production stores cannot produce, and the test asserting that a lost
+        /// lease writes nothing would be asserting against a fiction.
+        /// </remarks>
+        public Task AppendMessagesAsync(
+            string conversationId, string callerId, IReadOnlyList<ConversationMessage> messages,
+            CancellationToken ct = default)
         {
             ct.ThrowIfCancellationRequested();
-            Appended.Add((conversationId, callerId, message));
+
+            foreach (var message in messages)
+                Appended.Add((conversationId, callerId, message));
+
             return Task.CompletedTask;
         }
 

--- a/src/Content/Tests/Application.Core.Tests/CQRS/RunConversationDurableTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/CQRS/RunConversationDurableTests.cs
@@ -209,10 +209,12 @@ public sealed class RunConversationDurableTests
     }
 
     [Fact]
-    public async Task Handle_TurnFails_KeepsTheQuestionAndRecordsNoAnswer()
+    public async Task Handle_TurnFails_LeavesNoHalfTurnBehind()
     {
-        // Persisting per turn is the reason a run that dies partway keeps what it completed. The
-        // question survives because it was written before the dispatch that failed.
+        // A failed turn must leave the transcript holding only complete exchanges. Writing the question
+        // up-front — which the interactive transports do, so a live user can see what they asked — would
+        // be wrong here: nobody is watching, and the next run REPLAYS this transcript to a model, which
+        // would then see the user ask and go unanswered and would answer as if asked twice.
         _mediator
             .Setup(m => m.Send(It.IsAny<ExecuteAgentTurnCommand>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new AgentTurnResult
@@ -226,9 +228,7 @@ public sealed class RunConversationDurableTests
         var result = await BuildSut().Handle(Durable("did this survive?"), CancellationToken.None);
 
         result.Success.Should().BeFalse();
-        _store.Appended.Should().ContainSingle();
-        _store.Appended[0].Message.Role.Should().Be(MessageRole.User);
-        _store.Appended[0].Message.Content.Should().Be("did this survive?");
+        _store.Appended.Should().BeEmpty();
     }
 
     // -- Conversation-lifetime token budget --
@@ -290,15 +290,19 @@ public sealed class RunConversationDurableTests
         // Losing the lease means another host is now taking turns on this conversation. Continuing
         // would produce exactly the interleaved transcript the lease exists to prevent, so the run has
         // to stop — which only happens if the lost-lease signal is linked into the token the turns run
-        // under. Unlink it and this test hangs on to completion with three turns instead of one.
+        // under. Unlink it and this runs to completion with three turns instead of stopping after one.
+        //
+        // The lease drops during the SECOND turn, so the first is fully written and the second leaves
+        // nothing: a turn interrupted between its question and its answer must not be half-persisted.
         SetupTurns("one", "two", "three");
-        _lease.LoseLeaseAfterTurns = 1;
+        _lease.LoseLeaseAfterTurns = 2;
 
         var act = () => BuildSut().Handle(Durable("a", "b", "c"), CancellationToken.None);
 
         await act.Should().ThrowAsync<OperationCanceledException>();
-        _store.Appended.Count(a => a.Message.Role == MessageRole.Assistant).Should().Be(1,
-            "only the turn that completed before the lease was lost may reach the transcript");
+        _store.Appended.Select(a => (a.Message.Role, a.Message.Content)).Should().Equal(
+            (MessageRole.User, "a"),
+            (MessageRole.Assistant, "one"));
     }
 
     [Fact]
@@ -434,6 +438,8 @@ public sealed class RunConversationDurableTests
         public Task<ConversationRecord> GetOrCreateAsync(
             string agentName, string userId, string conversationId, CancellationToken ct = default)
         {
+            ct.ThrowIfCancellationRequested();
+
             if (GetOrCreateThrows is not null)
                 return Task.FromException<ConversationRecord>(GetOrCreateThrows);
 
@@ -453,13 +459,22 @@ public sealed class RunConversationDurableTests
         public Task<IReadOnlyList<ConversationMessage>?> GetHistoryForDispatch(
             string conversationId, string callerId, int maxMessages, CancellationToken ct = default)
         {
+            ct.ThrowIfCancellationRequested();
             HistoryRequests.Add((conversationId, callerId, maxMessages, CallSequence.Next()));
             return Task.FromResult<IReadOnlyList<ConversationMessage>?>(History);
         }
 
+        /// <remarks>
+        /// <strong>Honours the cancellation token, and that is load-bearing.</strong> An earlier version
+        /// of this double ignored it, which made the lost-lease test pass for the wrong reason: the
+        /// handler was writing to the transcript on a token the lost lease had already cancelled, a real
+        /// store would have thrown, and the test could not see it. A double that is more permissive than
+        /// the thing it stands in for does not simplify a test, it silences one.
+        /// </remarks>
         public Task AppendMessageAsync(
             string conversationId, string callerId, ConversationMessage message, CancellationToken ct = default)
         {
+            ct.ThrowIfCancellationRequested();
             Appended.Add((conversationId, callerId, message));
             return Task.CompletedTask;
         }
@@ -494,8 +509,18 @@ public sealed class RunConversationDurableTests
 
         public bool Released => _handles.Count > 0 && _handles.TrueForAll(h => h.Disposed);
 
-        /// <summary>How many turns were dispatched while a lease was held.</summary>
+        /// <summary>
+        /// How many turns were dispatched while a lease was actually held — counted only when a handle
+        /// exists and has not been disposed.
+        /// </summary>
+        /// <remarks>
+        /// The "actually held" part is the whole value of the counter. Incrementing unconditionally
+        /// counted turns whether or not the lease was still in hand, so a handler that released the
+        /// lease before running a single turn would have left the assertion green.
+        /// </remarks>
         public int TurnsWhileHeld { get; private set; }
+
+        private Handle? Current => _handles.Count > 0 ? _handles[^1] : null;
 
         public Task<IConversationTurnLeaseHandle> AcquireAsync(
             string conversationId, CancellationToken ct = default)
@@ -515,10 +540,16 @@ public sealed class RunConversationDurableTests
         /// </summary>
         public void NoteTurn()
         {
-            TurnsWhileHeld++;
-            if (LoseLeaseAfterTurns > 0 && TurnsWhileHeld >= LoseLeaseAfterTurns)
-                _handles[^1].Lose();
+            _turnsDispatched++;
+
+            if (Current is { Disposed: false })
+                TurnsWhileHeld++;
+
+            if (LoseLeaseAfterTurns > 0 && _turnsDispatched >= LoseLeaseAfterTurns)
+                Current?.Lose();
         }
+
+        private int _turnsDispatched;
 
         private sealed class Handle : IConversationTurnLeaseHandle
         {

--- a/src/Content/Tests/Application.Core.Tests/CQRS/RunConversationDurableTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/CQRS/RunConversationDurableTests.cs
@@ -1,0 +1,540 @@
+using Application.AI.Common.Interfaces;
+using Application.AI.Common.Interfaces.AI;
+using Application.AI.Common.Models.Conversations;
+using Application.Common.Exceptions.ExceptionTypes;
+using Application.Core.CQRS.Agents.ExecuteAgentTurn;
+using Application.Core.CQRS.Agents.RunConversation;
+using Domain.AI.Budget;
+using Domain.Common.Config.AI.Conversations;
+using FluentAssertions;
+using MediatR;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Application.Core.Tests.CQRS;
+
+/// <summary>
+/// The durable half of <see cref="RunConversationCommandHandler"/>: what happens when a run continues a
+/// stored conversation instead of starting a throwaway one (issue #235).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Every test here is written so that removing the behaviour it covers turns it red. The four
+/// invariants the issue calls load-bearing — ownership, the conversation-lifetime token budget, turn
+/// serialisation, and a bounded replay window — were already solved once in the interactive host, and a
+/// second implementation that quietly dropped one would be a regression wearing a feature's clothes.
+/// Tests that merely pass while a control happens to be present would not have caught that.
+/// </para>
+/// <para>
+/// Ownership is deliberately <em>not</em> re-asserted as a comparison in the handler: the store enforces
+/// it. What is asserted here is that the handler hands the caller's identity to the store on every call,
+/// which is the only thing it can get wrong.
+/// </para>
+/// </remarks>
+public sealed class RunConversationDurableTests
+{
+    private const string ConversationId = "conv-235";
+    private const string Owner = "owner-1";
+
+    private readonly Mock<IMediator> _mediator = new();
+    private readonly Mock<IConversationBudgetTracker> _budget = new();
+    private readonly FakeConversationStore _store = new();
+    private readonly FakeTurnLease _lease = new();
+
+    public RunConversationDurableTests()
+    {
+        _budget
+            .Setup(b => b.GetStatusAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ConversationBudgetStatus.Disabled);
+    }
+
+    private RunConversationCommandHandler BuildSut(int maxHistoryMessages = 50) =>
+        new(
+            _mediator.Object,
+            new Mock<IAgentConversationCache>().Object,
+            _budget.Object,
+            new Mock<IObservabilityStore>().Object,
+            _store,
+            _lease,
+            Options.Create(new ConversationsConfig { MaxHistoryMessages = maxHistoryMessages }),
+            NullLogger<RunConversationCommandHandler>.Instance);
+
+    private static RunConversationCommand Durable(params string[] messages) => new()
+    {
+        AgentName = "TestAgent",
+        ConversationId = ConversationId,
+        ConversationOwnerId = Owner,
+        UserMessages = messages.Length > 0 ? messages : ["hello"],
+        MaxTurns = 10
+    };
+
+    private void SetupTurns(params string[] responses)
+    {
+        var queue = new Queue<string>(responses);
+        _mediator
+            .Setup(m => m.Send(It.IsAny<ExecuteAgentTurnCommand>(), It.IsAny<CancellationToken>()))
+            .Returns((ExecuteAgentTurnCommand cmd, CancellationToken ct) =>
+            {
+                // Honouring the token is what lets the lost-lease test observe a stopped run rather
+                // than a run that finished anyway.
+                ct.ThrowIfCancellationRequested();
+                _lease.NoteTurn();
+
+                var response = queue.Count > 0 ? queue.Dequeue() : "done";
+                return Task.FromResult(new AgentTurnResult
+                {
+                    Success = true,
+                    Response = response,
+                    UpdatedHistory =
+                    [
+                        .. cmd.ConversationHistory,
+                        new ChatMessage(ChatRole.User, cmd.UserMessage),
+                        new ChatMessage(ChatRole.Assistant, response)
+                    ]
+                });
+            });
+    }
+
+    // -- Continuity --
+
+    [Fact]
+    public async Task Handle_DurableRun_ReplaysStoredHistoryIntoTheFirstTurn()
+    {
+        // The feature itself: without this, a caller continuing a conversation is talking to an agent
+        // that has never heard of it, and the only way to be understood is to resend the transcript.
+        _store.History =
+        [
+            Message(MessageRole.User, "what did I ask before?"),
+            Message(MessageRole.Assistant, "you asked about the weather")
+        ];
+        SetupTurns("continuing");
+
+        var dispatched = CaptureDispatchedTurns();
+
+        await BuildSut().Handle(Durable("and today?"), CancellationToken.None);
+
+        dispatched.Should().ContainSingle();
+        dispatched[0].ConversationHistory.Select(m => m.Text).Should().ContainInOrder(
+            "what did I ask before?", "you asked about the weather");
+    }
+
+    [Fact]
+    public async Task Handle_DurableRun_ReadsTheStoredWindowOnceAndCarriesItThroughLaterTurns()
+    {
+        // Later turns must build on the turn before them, not re-read the store — re-reading mid-run
+        // would replay the messages this run has itself just appended, duplicating them in the prompt.
+        _store.History = [Message(MessageRole.User, "earlier")];
+
+        // CaptureDispatchedTurns answers each turn with "answer {n}", which is what the second turn's
+        // inherited history must therefore contain.
+        var dispatched = CaptureDispatchedTurns();
+
+        await BuildSut().Handle(Durable("first", "second"), CancellationToken.None);
+
+        _store.HistoryRequests.Should().ContainSingle("the replay window is read once, under the lease");
+        dispatched.Should().HaveCount(2);
+        dispatched[1].ConversationHistory.Select(m => m.Text).Should().ContainInOrder(
+            "earlier", "first", "answer 1");
+    }
+
+    [Fact]
+    public async Task Handle_SelfContainedRun_NeitherReadsNorWritesAnyTranscript()
+    {
+        // Opting out has to be total. Every existing caller of this handler omits the owner, and a
+        // handler that wrote transcripts for them anyway would silently accumulate storage for
+        // conversations nobody asked to keep.
+        SetupTurns("answer");
+
+        var command = new RunConversationCommand
+        {
+            AgentName = "TestAgent",
+            UserMessages = ["hello"]
+        };
+
+        await BuildSut().Handle(command, CancellationToken.None);
+
+        _store.GetOrCreateCalls.Should().Be(0);
+        _store.HistoryRequests.Should().BeEmpty();
+        _store.Appended.Should().BeEmpty();
+        _lease.AcquireCount.Should().Be(0);
+    }
+
+    // -- Bounded replay window --
+
+    [Fact]
+    public async Task Handle_DurableRun_RequestsExactlyTheConfiguredHistoryWindow()
+    {
+        // A transcript is unbounded; the prompt built from it must not be. Fails if the window is
+        // hardcoded rather than read from configuration.
+        SetupTurns("answer");
+
+        await BuildSut(maxHistoryMessages: 7).Handle(Durable(), CancellationToken.None);
+
+        _store.HistoryRequests.Should().ContainSingle()
+            .Which.MaxMessages.Should().Be(7);
+    }
+
+    // -- Per-turn persistence --
+
+    [Fact]
+    public async Task Handle_DurableRun_PersistsUserThenAssistantForEveryTurn()
+    {
+        SetupTurns("first answer", "second answer");
+
+        await BuildSut().Handle(Durable("first question", "second question"), CancellationToken.None);
+
+        _store.Appended.Select(a => (a.Message.Role, a.Message.Content)).Should().Equal(
+            (MessageRole.User, "first question"),
+            (MessageRole.Assistant, "first answer"),
+            (MessageRole.User, "second question"),
+            (MessageRole.Assistant, "second answer"));
+    }
+
+    [Fact]
+    public async Task Handle_DurableRun_AttributesEveryWriteToTheCallingOwner()
+    {
+        // The store is what refuses another user's conversation, and it can only do that if the caller
+        // reaches it. A handler that passed anything else here would defeat the control without
+        // touching it.
+        SetupTurns("answer");
+
+        await BuildSut().Handle(Durable(), CancellationToken.None);
+
+        _store.Appended.Should().OnlyContain(a => a.CallerId == Owner);
+        _store.HistoryRequests.Should().OnlyContain(r => r.CallerId == Owner);
+        _store.GetOrCreateOwners.Should().Equal(Owner);
+    }
+
+    [Fact]
+    public async Task Handle_TurnFails_KeepsTheQuestionAndRecordsNoAnswer()
+    {
+        // Persisting per turn is the reason a run that dies partway keeps what it completed. The
+        // question survives because it was written before the dispatch that failed.
+        _mediator
+            .Setup(m => m.Send(It.IsAny<ExecuteAgentTurnCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AgentTurnResult
+            {
+                Success = false,
+                Response = string.Empty,
+                UpdatedHistory = [],
+                Error = "model unavailable"
+            });
+
+        var result = await BuildSut().Handle(Durable("did this survive?"), CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+        _store.Appended.Should().ContainSingle();
+        _store.Appended[0].Message.Role.Should().Be(MessageRole.User);
+        _store.Appended[0].Message.Content.Should().Be("did this survive?");
+    }
+
+    // -- Conversation-lifetime token budget --
+
+    [Fact]
+    public async Task Handle_ConversationAlreadyExhausted_DispatchesNothingAndWritesNothing()
+    {
+        // The budget is durable and keyed by conversation, so a run continuing an exhausted one must
+        // decline before its FIRST dispatch. A gate that exempted the opening turn of each run would
+        // hand every new run a fresh allowance and make a lifetime ceiling meaningless.
+        _budget
+            .Setup(b => b.GetStatusAsync(ConversationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ConversationBudgetStatus(true, 5_000, 5_000));
+        SetupTurns("should never run");
+
+        var result = await BuildSut().Handle(Durable("please answer"), CancellationToken.None);
+
+        result.BudgetExhausted.Should().BeTrue();
+        result.Turns.Should().BeEmpty();
+        _mediator.Verify(
+            m => m.Send(It.IsAny<ExecuteAgentTurnCommand>(), It.IsAny<CancellationToken>()), Times.Never);
+        _store.Appended.Should().BeEmpty(
+            "a question that was never asked must not appear in the transcript");
+    }
+
+    [Fact]
+    public async Task Handle_DurableRun_GatesTheBudgetUnderTheConversationIdNotTheRunId()
+    {
+        // Keying the budget by anything run-scoped would reset the ceiling on every run.
+        SetupTurns("answer");
+
+        await BuildSut().Handle(Durable(), CancellationToken.None);
+
+        _budget.Verify(
+            b => b.GetStatusAsync(ConversationId, It.IsAny<CancellationToken>()), Times.AtLeastOnce);
+        _budget.Verify(
+            b => b.RecordUsageAsync(ConversationId, It.IsAny<int>(), It.IsAny<CancellationToken>()),
+            Times.AtLeastOnce);
+    }
+
+    // -- Turn serialisation --
+
+    [Fact]
+    public async Task Handle_DurableRun_HoldsTheTurnLeaseForTheWholeRunAndReleasesIt()
+    {
+        SetupTurns("one", "two");
+
+        await BuildSut().Handle(Durable("first", "second"), CancellationToken.None);
+
+        _lease.AcquireCount.Should().Be(1, "the run holds one lease, not one per turn");
+        _lease.ConversationIds.Should().Equal(ConversationId);
+        _lease.Released.Should().BeTrue("a lease that is never released blocks the conversation forever");
+        _lease.TurnsWhileHeld.Should().Be(2, "every turn ran inside the lease");
+    }
+
+    [Fact]
+    public async Task Handle_LeaseLostMidRun_StopsTheRunInsteadOfWritingOnRegardless()
+    {
+        // Losing the lease means another host is now taking turns on this conversation. Continuing
+        // would produce exactly the interleaved transcript the lease exists to prevent, so the run has
+        // to stop — which only happens if the lost-lease signal is linked into the token the turns run
+        // under. Unlink it and this test hangs on to completion with three turns instead of one.
+        SetupTurns("one", "two", "three");
+        _lease.LoseLeaseAfterTurns = 1;
+
+        var act = () => BuildSut().Handle(Durable("a", "b", "c"), CancellationToken.None);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+        _store.Appended.Count(a => a.Message.Role == MessageRole.Assistant).Should().Be(1,
+            "only the turn that completed before the lease was lost may reach the transcript");
+    }
+
+    [Fact]
+    public async Task Handle_DurableRun_OpensTheConversationBeforeTakingItsLease()
+    {
+        // Order is a real constraint, not a preference: the durable lease claims an existing
+        // conversation row and throws when there is none, so opening has to come first.
+        SetupTurns("answer");
+
+        await BuildSut().Handle(Durable(), CancellationToken.None);
+
+        _store.GetOrCreateSequence.Should().BeLessThan(_lease.AcquireSequence);
+    }
+
+    [Fact]
+    public async Task Handle_DurableRun_ReadsTheReplayWindowOnlyAfterTheLeaseIsHeld()
+    {
+        // The turn this run queued behind may have appended to the transcript. A window read before
+        // the lease omits exactly those messages — the ones the run most needs to see.
+        SetupTurns("answer");
+
+        await BuildSut().Handle(Durable(), CancellationToken.None);
+
+        _store.HistoryRequests.Should().ContainSingle()
+            .Which.Sequence.Should().BeGreaterThan(_lease.AcquireSequence);
+    }
+
+    // -- Fail-closed identity --
+
+    [Fact]
+    public async Task Handle_BlankOwner_IsRefusedRatherThanRunAsSelfContained()
+    {
+        // A blank identity must never read as "no owner, carry on". This codebase has repeatedly had an
+        // absent identity resolve to global access, so the empty string takes the durable path and is
+        // rejected there rather than quietly opting out of persistence.
+        _store.GetOrCreateThrows = new ArgumentException("callerId must be non-blank");
+        SetupTurns("answer");
+
+        var command = new RunConversationCommand
+        {
+            AgentName = "TestAgent",
+            ConversationId = ConversationId,
+            ConversationOwnerId = "",
+            UserMessages = ["hello"]
+        };
+
+        var act = () => BuildSut().Handle(command, CancellationToken.None);
+
+        await act.Should().ThrowAsync<ArgumentException>();
+        _mediator.Verify(
+            m => m.Send(It.IsAny<ExecuteAgentTurnCommand>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_ConversationOwnedByAnotherUser_PropagatesTheStoresRefusal()
+    {
+        // The handler must not swallow the refusal into a failed-but-successful-looking result: a
+        // permission decision that reads as a model failure is a permission decision nobody audits.
+        _store.GetOrCreateThrows = new ConversationAccessDeniedException();
+        SetupTurns("answer");
+
+        var act = () => BuildSut().Handle(Durable(), CancellationToken.None);
+
+        await act.Should().ThrowAsync<ConversationAccessDeniedException>();
+        _mediator.Verify(
+            m => m.Send(It.IsAny<ExecuteAgentTurnCommand>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    // -- Helpers --
+
+    private List<ExecuteAgentTurnCommand> CaptureDispatchedTurns()
+    {
+        var dispatched = new List<ExecuteAgentTurnCommand>();
+        _mediator
+            .Setup(m => m.Send(It.IsAny<ExecuteAgentTurnCommand>(), It.IsAny<CancellationToken>()))
+            .Returns((ExecuteAgentTurnCommand cmd, CancellationToken ct) =>
+            {
+                ct.ThrowIfCancellationRequested();
+                _lease.NoteTurn();
+                dispatched.Add(cmd);
+
+                var response = $"answer {dispatched.Count}";
+                return Task.FromResult(new AgentTurnResult
+                {
+                    Success = true,
+                    Response = response,
+                    UpdatedHistory =
+                    [
+                        .. cmd.ConversationHistory,
+                        new ChatMessage(ChatRole.User, cmd.UserMessage),
+                        new ChatMessage(ChatRole.Assistant, response)
+                    ]
+                });
+            });
+        return dispatched;
+    }
+
+    private static ConversationMessage Message(MessageRole role, string content) =>
+        new(Guid.NewGuid(), role, content, DateTimeOffset.UtcNow);
+
+    /// <summary>
+    /// Shared monotonic counter, so tests can assert the ORDER of calls that land on two different
+    /// collaborators — which is what "open before leasing" and "read the window after leasing" are.
+    /// </summary>
+    private static class CallSequence
+    {
+        private static int _next;
+
+        public static int Next() => Interlocked.Increment(ref _next);
+    }
+
+    /// <summary>
+    /// An in-memory transcript store that records what it was asked for and by whom.
+    /// </summary>
+    /// <remarks>
+    /// Hand-rolled rather than mocked because nearly every assertion here is about the arguments the
+    /// handler passed and the order it passed them in, which a recording double states more directly
+    /// than a pile of verifications. It enforces no ownership of its own — that is the real store's
+    /// job, and a double that enforced it would prove only that the double works.
+    /// </remarks>
+    private sealed class FakeConversationStore : IConversationStore
+    {
+        public List<(string ConversationId, string CallerId, ConversationMessage Message)> Appended { get; } = [];
+        public List<(string ConversationId, string CallerId, int MaxMessages, int Sequence)> HistoryRequests { get; } = [];
+        public List<string> GetOrCreateOwners { get; } = [];
+        public IReadOnlyList<ConversationMessage> History { get; set; } = [];
+        public int GetOrCreateCalls { get; private set; }
+        public int GetOrCreateSequence { get; private set; }
+
+        /// <summary>When set, the next open fails with this — the store's refusals, reproduced.</summary>
+        public Exception? GetOrCreateThrows { get; set; }
+
+        public Task<ConversationRecord> GetOrCreateAsync(
+            string agentName, string userId, string conversationId, CancellationToken ct = default)
+        {
+            if (GetOrCreateThrows is not null)
+                return Task.FromException<ConversationRecord>(GetOrCreateThrows);
+
+            GetOrCreateCalls++;
+            GetOrCreateSequence = CallSequence.Next();
+            GetOrCreateOwners.Add(userId);
+
+            return Task.FromResult(new ConversationRecord(
+                Id: conversationId,
+                AgentName: agentName,
+                UserId: userId,
+                CreatedAt: DateTimeOffset.UtcNow,
+                UpdatedAt: DateTimeOffset.UtcNow,
+                Messages: History));
+        }
+
+        public Task<IReadOnlyList<ConversationMessage>?> GetHistoryForDispatch(
+            string conversationId, string callerId, int maxMessages, CancellationToken ct = default)
+        {
+            HistoryRequests.Add((conversationId, callerId, maxMessages, CallSequence.Next()));
+            return Task.FromResult<IReadOnlyList<ConversationMessage>?>(History);
+        }
+
+        public Task AppendMessageAsync(
+            string conversationId, string callerId, ConversationMessage message, CancellationToken ct = default)
+        {
+            Appended.Add((conversationId, callerId, message));
+            return Task.CompletedTask;
+        }
+
+        public Task<ConversationRecord?> GetAsync(string conversationId, string callerId, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+        public Task<IReadOnlyList<ConversationRecord>> ListAsync(string userId, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+        public Task<ConversationRecord> CreateAsync(string agentName, string userId, string? conversationId = null, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+        public Task<bool> DeleteAsync(string conversationId, string callerId, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+        public Task<ConversationRecord?> TruncateFromMessageAsync(string conversationId, string callerId, Guid messageId, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+        public Task<ConversationRecord?> UpdateSettingsAsync(string conversationId, string callerId, ConversationSettings settings, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+        public Task<ConversationRecord?> UpdateTelemetryAsync(string conversationId, string callerId, Guid observabilitySessionId, TelemetryAccumulator telemetry, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+    }
+
+    /// <summary>A turn lease that records how it was used and can be made to lose itself mid-run.</summary>
+    private sealed class FakeTurnLease : IConversationTurnLease
+    {
+        private readonly List<Handle> _handles = [];
+
+        public int AcquireCount { get; private set; }
+        public int AcquireSequence { get; private set; }
+        public List<string> ConversationIds { get; } = [];
+
+        /// <summary>Turns to allow before cancelling the lease-lost token. Zero disables it.</summary>
+        public int LoseLeaseAfterTurns { get; set; }
+
+        public bool Released => _handles.Count > 0 && _handles.TrueForAll(h => h.Disposed);
+
+        /// <summary>How many turns were dispatched while a lease was held.</summary>
+        public int TurnsWhileHeld { get; private set; }
+
+        public Task<IConversationTurnLeaseHandle> AcquireAsync(
+            string conversationId, CancellationToken ct = default)
+        {
+            AcquireCount++;
+            AcquireSequence = CallSequence.Next();
+            ConversationIds.Add(conversationId);
+
+            var handle = new Handle();
+            _handles.Add(handle);
+            return Task.FromResult<IConversationTurnLeaseHandle>(handle);
+        }
+
+        /// <summary>
+        /// Called by the test's turn double so the lease can count turns and, when configured, drop
+        /// itself between two of them.
+        /// </summary>
+        public void NoteTurn()
+        {
+            TurnsWhileHeld++;
+            if (LoseLeaseAfterTurns > 0 && TurnsWhileHeld >= LoseLeaseAfterTurns)
+                _handles[^1].Lose();
+        }
+
+        private sealed class Handle : IConversationTurnLeaseHandle
+        {
+            private readonly CancellationTokenSource _lost = new();
+
+            public CancellationToken LeaseLost => _lost.Token;
+            public bool Disposed { get; private set; }
+
+            public void Lose() => _lost.Cancel();
+
+            public ValueTask DisposeAsync()
+            {
+                Disposed = true;
+                _lost.Dispose();
+                return ValueTask.CompletedTask;
+            }
+        }
+    }
+}

--- a/src/Content/Tests/Application.Core.Tests/CQRS/RunConversationDurableTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/CQRS/RunConversationDurableTests.cs
@@ -231,6 +231,31 @@ public sealed class RunConversationDurableTests
         _store.Appended.Should().BeEmpty();
     }
 
+    [Fact]
+    public async Task Handle_TurnSucceedsWithNoText_WritesNothingRatherThanAnAnswerThatVanishesOnRead()
+    {
+        // A turn can legitimately succeed with no prose — a model replying with tool calls only. Storing
+        // it would take the long way round to the same half-turn a failed turn would leave: BOTH stores
+        // drop empty-content messages from the dispatch window (that is how widget messages are kept out
+        // of prompts), so the answer would be written, filtered out on the next read, and the question
+        // would stand alone forever. Every other test here uses a non-empty response, which is exactly
+        // why this needs its own.
+        _mediator
+            .Setup(m => m.Send(It.IsAny<ExecuteAgentTurnCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AgentTurnResult
+            {
+                Success = true,
+                Response = string.Empty,
+                UpdatedHistory = []
+            });
+
+        var result = await BuildSut().Handle(Durable("any tool calls?"), CancellationToken.None);
+
+        result.Success.Should().BeTrue("an answer with no prose is not a failed turn");
+        _store.Appended.Should().BeEmpty(
+            "a question whose answer would be filtered out on read must not be stored alone");
+    }
+
     // -- Conversation-lifetime token budget --
 
     [Fact]

--- a/src/Content/Tests/Infrastructure.AI.Tests/Bundles/BundleRunExecutorTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Bundles/BundleRunExecutorTests.cs
@@ -102,6 +102,53 @@ public sealed class BundleRunExecutorTests : IDisposable
         TotalToolInvocations = 1
     };
 
+    // -- Conversation continuity (#235) --
+
+    [Fact]
+    public async Task ExecuteAsync_RunWithConversationId_ContinuesThatConversationAsItsOwner()
+    {
+        // Two things have to be right together. The conversation id must become the run's conversation
+        // — not the job id — so the transcript, the lifetime token budget and the turn lease all key off
+        // the same thing across runs. And the owner must ride along, because that is what switches the
+        // shared loop into durable mode at all.
+        RunConversationCommand? dispatched = null;
+        var mediator = new Mock<IMediator>();
+        mediator.Setup(m => m.Send(It.IsAny<RunConversationCommand>(), It.IsAny<CancellationToken>()))
+            .Callback<object, CancellationToken>((c, _) => dispatched = (RunConversationCommand)c)
+            .ReturnsAsync(Ok());
+
+        var (executor, jobStore, handleStore) = BuildSut(mediator.Object);
+        var handle = handleStore.Register(StageOnDisk("b1"), "owner-1");
+        jobStore.Create(QueuedRecord("j1", handle, "agent-b1") with { ConversationId = "conv-1" });
+
+        await executor.ExecuteAsync("j1", CancellationToken.None);
+
+        dispatched.Should().NotBeNull();
+        dispatched!.ConversationId.Should().Be("conv-1");
+        dispatched.ConversationOwnerId.Should().Be("owner-1");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_RunWithoutConversationId_StaysSelfContainedUnderItsJobId()
+    {
+        // Passing an owner here would make every one-shot run write a transcript nobody asked for, and
+        // keying the run by anything but its own job id would let two unrelated runs share a budget.
+        RunConversationCommand? dispatched = null;
+        var mediator = new Mock<IMediator>();
+        mediator.Setup(m => m.Send(It.IsAny<RunConversationCommand>(), It.IsAny<CancellationToken>()))
+            .Callback<object, CancellationToken>((c, _) => dispatched = (RunConversationCommand)c)
+            .ReturnsAsync(Ok());
+
+        var (executor, jobStore, handleStore) = BuildSut(mediator.Object);
+        var handle = handleStore.Register(StageOnDisk("b2"), "owner-1");
+        jobStore.Create(QueuedRecord("j1", handle, "agent-b2"));
+
+        await executor.ExecuteAsync("j1", CancellationToken.None);
+
+        dispatched!.ConversationId.Should().Be("j1");
+        dispatched.ConversationOwnerId.Should().BeNull();
+    }
+
     [Fact]
     public async Task ExecuteAsync_UnknownJobId_ReturnsNotFound()
     {

--- a/src/Content/Tests/Infrastructure.AI.Tests/Conversations/ConversationStoreContractTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Conversations/ConversationStoreContractTests.cs
@@ -303,6 +303,114 @@ public abstract class ConversationStoreContractTests
         retrieved.Messages.Should().BeEmpty("a replaced conversation does not inherit the old transcript");
     }
 
+    // -- GetOrCreateAsync --
+    //
+    // The operation exists because the obvious composition — read, then create when the read came back
+    // empty — is a transcript-destroying race, since CreateAsync REPLACES. The tests that matter here
+    // are therefore the ones asserting what it must never do.
+
+    [Fact]
+    public async Task GetOrCreate_UnknownConversation_CreatesItUnderTheGivenIdAndOwner()
+    {
+        var id = $"conv-{Guid.NewGuid():N}";
+
+        var record = await Store.GetOrCreateAsync("agent", Owner, id);
+
+        record.Id.Should().Be(id);
+        record.UserId.Should().Be(Owner);
+        record.AgentName.Should().Be("agent");
+        record.Messages.Should().BeEmpty();
+        (await Store.GetAsync(id, Owner)).Should().NotBeNull("the conversation must actually be stored");
+    }
+
+    [Fact]
+    public async Task GetOrCreate_ExistingConversation_ReturnsItWithItsTranscriptIntact()
+    {
+        // The whole point of the operation. If this ever returns an empty record, a second run
+        // continuing a conversation silently starts it over — and CreateAsync would have done exactly
+        // that, which is why this is not simply a call to CreateAsync.
+        var created = await Store.CreateAsync("agent", Owner);
+        await Store.AppendMessageAsync(created.Id, Owner, UserMessage("first turn"));
+
+        var reopened = await Store.GetOrCreateAsync("agent", Owner, created.Id);
+
+        reopened.Messages.Should().ContainSingle().Which.Content.Should().Be("first turn");
+    }
+
+    [Fact]
+    public async Task GetOrCreate_ExistingConversation_DoesNotDestroyItEvenWhenTheAgentDiffers()
+    {
+        // A caller naming a different agent must not be read as "make me a new one". CreateAsync's
+        // replace semantics make that the natural mistake for an implementation to inherit.
+        var created = await Store.CreateAsync("original-agent", Owner);
+        await Store.AppendMessageAsync(created.Id, Owner, UserMessage("keep me"));
+
+        var reopened = await Store.GetOrCreateAsync("a-different-agent", Owner, created.Id);
+
+        reopened.AgentName.Should().Be("original-agent", "an existing conversation keeps its own agent");
+        reopened.Messages.Should().ContainSingle().Which.Content.Should().Be("keep me");
+    }
+
+    [Fact]
+    public async Task GetOrCreate_ConversationOwnedByAnotherUser_IsRefusedAndLeavesItIntact()
+    {
+        // Without this, the operation is a way to take over any id you can guess: the refusal is what
+        // stops a stranger's conversation being replaced by an empty one they then own.
+        var created = await Store.CreateAsync("agent", Owner);
+        await Store.AppendMessageAsync(created.Id, Owner, UserMessage("mine"));
+
+        var act = () => Store.GetOrCreateAsync("agent", Stranger, created.Id);
+
+        await act.Should().ThrowAsync<ConversationAccessDeniedException>();
+        (await Store.GetAsync(created.Id, Owner))!.Messages.Should().ContainSingle(
+            "a refused open must not have replaced the conversation");
+    }
+
+    [Fact]
+    public async Task GetOrCreate_BlankCallerId_IsRejectedRatherThanTreatedAsGlobal()
+    {
+        var act = () => Store.GetOrCreateAsync("agent", "  ", $"conv-{Guid.NewGuid():N}");
+
+        await act.Should().ThrowAsync<ArgumentException>();
+    }
+
+    [Fact]
+    public async Task GetOrCreate_BlankConversationId_IsRejected()
+    {
+        // Distinct from CreateAsync, where an absent id means "mint me one". Here the id is the thing
+        // being opened, so a blank one has no reading that is not a caller bug.
+        var act = () => Store.GetOrCreateAsync("agent", Owner, "  ");
+
+        await act.Should().ThrowAsync<ArgumentException>();
+    }
+
+    [Fact]
+    public async Task GetOrCreate_ConcurrentOpensOfOneNewConversation_AllAgreeAndNoneDestroysTheTranscript()
+    {
+        // Twenty callers open the same brand-new id at once. Exactly one create can win, and every
+        // loser must be handed the winner's record instead of failing or replacing it — an
+        // implementation that inserts without handling the collision leaves nineteen of these throwing.
+        //
+        // What this does NOT prove, stated so nobody reads more into a green run than is there: it
+        // cannot force a loser's write to land AFTER a message has been appended, which is the exact
+        // interleaving that makes a read-then-create implementation destroy a transcript. All twenty
+        // opens have completed before anything is appended here. The deterministic half of that
+        // guarantee is covered by the two "existing conversation" tests above; this one covers the
+        // concurrent half only as far as a test without a seam into the store can reach.
+        var id = $"conv-{Guid.NewGuid():N}";
+
+        var opens = Enumerable.Range(0, 20)
+            .Select(_ => Task.Run(() => Store.GetOrCreateAsync("agent", Owner, id)))
+            .ToArray();
+
+        var records = await Task.WhenAll(opens);
+
+        records.Should().OnlyContain(r => r.Id == id && r.UserId == Owner);
+
+        await Store.AppendMessageAsync(id, Owner, UserMessage("survived"));
+        (await Store.GetAsync(id, Owner))!.Messages.Should().ContainSingle();
+    }
+
     // -- ListAsync --
 
     [Fact]

--- a/src/Content/Tests/Infrastructure.AI.Tests/Conversations/ConversationStoreContractTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Conversations/ConversationStoreContractTests.cs
@@ -411,6 +411,119 @@ public abstract class ConversationStoreContractTests
         (await Store.GetAsync(id, Owner))!.Messages.Should().ContainSingle();
     }
 
+    // -- AppendMessagesAsync --
+    //
+    // The batch exists so a complete exchange is stored as one unit. All-or-nothing is the property
+    // that matters: this transcript is replayed to a model, so a half-written turn is not an incomplete
+    // record but a misleading one.
+
+    [Fact]
+    public async Task AppendMessages_StoresThemAllInOrder()
+    {
+        var record = await Store.CreateAsync("agent", Owner);
+
+        await Store.AppendMessagesAsync(record.Id, Owner, [
+            UserMessage("what is my name?"),
+            AssistantMessage("Sam"),
+        ]);
+
+        (await Store.GetAsync(record.Id, Owner))!.Messages.Select(m => m.Content).Should().Equal(
+            "what is my name?", "Sam");
+    }
+
+    [Fact]
+    public async Task AppendMessages_EmptyBatch_IsANoOp()
+    {
+        var record = await Store.CreateAsync("agent", Owner);
+
+        await Store.AppendMessagesAsync(record.Id, Owner, []);
+
+        (await Store.GetAsync(record.Id, Owner))!.Messages.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task AppendMessages_ToAnotherUsersConversation_IsRefusedAndWritesNothing()
+    {
+        var record = await Store.CreateAsync("agent", Owner);
+
+        var act = () => Store.AppendMessagesAsync(record.Id, Stranger, [
+            UserMessage("not mine"),
+            AssistantMessage("nor this"),
+        ]);
+
+        await act.Should().ThrowAsync<ConversationAccessDeniedException>();
+        (await Store.GetAsync(record.Id, Owner))!.Messages.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task AppendMessages_ToAnUnknownConversation_FailsAndWritesNothing()
+    {
+        var act = () => Store.AppendMessagesAsync($"missing-{Guid.NewGuid():N}", Owner, [
+            UserMessage("nowhere to go"),
+        ]);
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+    }
+
+    [Fact]
+    public async Task AppendMessages_DuplicateIdInsideTheBatch_IsRejectedAndNothingIsWritten()
+    {
+        // The whole batch is refused, not merely the offending message. A partially applied batch is
+        // the failure this operation exists to prevent, so failing halfway would be worse than the two
+        // separate appends it replaces.
+        var record = await Store.CreateAsync("agent", Owner);
+        var shared = Guid.NewGuid();
+
+        var act = () => Store.AppendMessagesAsync(record.Id, Owner, [
+            new ConversationMessage(shared, MessageRole.User, "first", Clock.GetUtcNow()),
+            new ConversationMessage(shared, MessageRole.Assistant, "second", Clock.GetUtcNow()),
+        ]);
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+        (await Store.GetAsync(record.Id, Owner))!.Messages.Should().BeEmpty(
+            "a batch that cannot be stored whole must not be stored in part");
+    }
+
+    [Fact]
+    public async Task AppendMessages_IdAlreadyInTheConversation_IsRejectedAndTheEarlierBatchSurvives()
+    {
+        var record = await Store.CreateAsync("agent", Owner);
+        var first = UserMessage("already here");
+        await Store.AppendMessagesAsync(record.Id, Owner, [first]);
+
+        var act = () => Store.AppendMessagesAsync(record.Id, Owner, [
+            AssistantMessage("fine on its own"),
+            new ConversationMessage(first.Id, MessageRole.User, "a replay", Clock.GetUtcNow()),
+        ]);
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+        (await Store.GetAsync(record.Id, Owner))!.Messages.Select(m => m.Content).Should().Equal(
+            "already here");
+    }
+
+    [Fact]
+    public async Task AppendMessages_DerivesTheTitleFromTheFirstUserMessageInTheBatch()
+    {
+        // Same rule the single append follows, so a turn stored as one batch and the same turn stored
+        // as two appends cannot end up with different titles.
+        var record = await Store.CreateAsync("agent", Owner);
+
+        await Store.AppendMessagesAsync(record.Id, Owner, [
+            UserMessage("the opening question"),
+            AssistantMessage("the reply"),
+        ]);
+
+        (await Store.GetAsync(record.Id, Owner))!.Title.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public async Task AppendMessages_BlankCallerId_IsRejectedRatherThanTreatedAsGlobal()
+    {
+        var act = () => Store.AppendMessagesAsync("any", "  ", [UserMessage("nope")]);
+
+        await act.Should().ThrowAsync<ArgumentException>();
+    }
+
     // -- ListAsync --
 
     [Fact]

--- a/src/Content/Tests/Infrastructure.AI.Tests/Conversations/DurableConversationContinuityTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Conversations/DurableConversationContinuityTests.cs
@@ -1,0 +1,269 @@
+using Application.AI.Common.Interfaces;
+using Application.AI.Common.Interfaces.AI;
+using Application.Common.Exceptions.ExceptionTypes;
+using Application.Core.CQRS.Agents.ExecuteAgentTurn;
+using Application.Core.CQRS.Agents.RunConversation;
+using Domain.AI.Budget;
+using Domain.Common.Config.AI.Conversations;
+using FluentAssertions;
+using Infrastructure.AI.Conversations;
+using Infrastructure.AI.Persistence;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Conversations;
+
+/// <summary>
+/// The headline promise of issue #235, proven end to end: <em>"An Execution API bundle run can attach
+/// to an existing conversation and see prior turns."</em>
+/// </summary>
+/// <remarks>
+/// <para>
+/// Everything else covering this feature is a unit test against a double — the command handler carries
+/// the id, the executor carries the id and owner, the loop replays from a fake store. Each is worth
+/// having and none of them touches the seam that actually has to work: a real SQLite transcript, a real
+/// durable turn lease, and a second run reading what the first one wrote. Doubles agree with whatever
+/// the code does; only the real store can disagree.
+/// </para>
+/// <para>
+/// This drives <see cref="RunConversationCommandHandler"/> rather than booting a web host, because the
+/// controller and executor layers above it are thin pass-throughs already covered by their own tests,
+/// whereas the store, the lease and the loop are where continuity is actually decided.
+/// </para>
+/// </remarks>
+public sealed class DurableConversationContinuityTests : IDisposable
+{
+    private const string Owner = "owner-1";
+    private const string Stranger = "someone-else";
+
+    private readonly string _databasePath = Path.Combine(
+        Path.GetTempPath(), $"durable-continuity-{Guid.NewGuid():N}.db");
+
+    private readonly ServiceProvider _provider;
+    private readonly EfCoreConversationStore _store;
+    private readonly IConversationTurnLease _lease;
+
+    /// <summary>
+    /// Real time, deliberately — the one place in this suite where a frozen clock is wrong.
+    /// </summary>
+    /// <remarks>
+    /// The durable lease discovers that a lease has been released by polling, and it waits between
+    /// polls on this clock. Under a <c>FakeTimeProvider</c> nobody advances it, so the wait never
+    /// elapses and a run queued behind another blocks forever — the serialisation test hangs rather
+    /// than fails, which is a worse outcome than either. Nothing here asserts on a timestamp, so real
+    /// time costs this suite nothing.
+    /// </remarks>
+    private readonly TimeProvider _clock = TimeProvider.System;
+
+    public DurableConversationContinuityTests()
+    {
+        var services = new ServiceCollection();
+        services.AddDbContextFactory<ConversationDbContext>(o => o.UseSqlite($"DataSource={_databasePath}"));
+        services.AddSingleton<SchemaInitializer<ConversationDbContext>>();
+        _provider = services.BuildServiceProvider();
+
+        _store = new EfCoreConversationStore(
+            _provider.GetRequiredService<IDbContextFactory<ConversationDbContext>>(),
+            _clock,
+            NullLogger<EfCoreConversationStore>.Instance,
+            _provider.GetRequiredService<SchemaInitializer<ConversationDbContext>>());
+
+        _lease = new SqliteConversationTurnLease(
+            _provider.GetRequiredService<IDbContextFactory<ConversationDbContext>>(),
+            Options.Create(new ConversationsConfig()),
+            _clock,
+            NullLogger<SqliteConversationTurnLease>.Instance,
+            _provider.GetRequiredService<SchemaInitializer<ConversationDbContext>>());
+    }
+
+    [Fact]
+    public async Task ASecondRun_SeesWhatTheFirstRunSaid()
+    {
+        // The feature. Run one asks and is answered; run two sends only its new message and must still
+        // be dispatched with the earlier exchange in front of it.
+        var conversationId = $"conv-{Guid.NewGuid():N}";
+        var dispatched = new List<ExecuteAgentTurnCommand>();
+        var handler = BuildHandler(dispatched);
+
+        await handler.Handle(Durable(conversationId, "my name is Sam"), CancellationToken.None);
+        await handler.Handle(Durable(conversationId, "what is my name?"), CancellationToken.None);
+
+        dispatched.Should().HaveCount(2);
+
+        dispatched[0].ConversationHistory.Should().BeEmpty(
+            "the first run opened a conversation that did not exist yet");
+
+        dispatched[1].ConversationHistory.Select(m => m.Text).Should().Equal(
+            "my name is Sam", "answer 1");
+    }
+
+    [Fact]
+    public async Task TheTranscriptSurvivesAsCompleteTurns_InOrder()
+    {
+        var conversationId = $"conv-{Guid.NewGuid():N}";
+        var handler = BuildHandler([]);
+
+        await handler.Handle(Durable(conversationId, "first"), CancellationToken.None);
+        await handler.Handle(Durable(conversationId, "second"), CancellationToken.None);
+
+        var record = await _store.GetAsync(conversationId, Owner);
+
+        record.Should().NotBeNull();
+        record!.Messages.Select(m => m.Content).Should().Equal(
+            "first", "answer 1", "second", "answer 1");
+    }
+
+    [Fact]
+    public async Task AnotherUsersConversation_IsRefusedByTheRealStore()
+    {
+        // Ownership is enforced inside the store, so it has to hold against the real one — a mocked
+        // store enforces nothing, and every other test of this path uses a double.
+        var conversationId = $"conv-{Guid.NewGuid():N}";
+        await BuildHandler([]).Handle(Durable(conversationId, "mine"), CancellationToken.None);
+
+        var intruder = BuildHandler([]);
+        var act = () => intruder.Handle(
+            Durable(conversationId, "let me read that") with { ConversationOwnerId = Stranger },
+            CancellationToken.None);
+
+        await act.Should().ThrowAsync<ConversationAccessDeniedException>();
+
+        var record = await _store.GetAsync(conversationId, Owner);
+        record!.Messages.Should().HaveCount(2, "the refused run must not have written or replaced anything");
+    }
+
+    [Fact]
+    public async Task TheReplayWindowIsBounded_EvenThoughTheTranscriptIsNot()
+    {
+        // Prompt growth is what the window exists to stop. The stored transcript keeps everything; only
+        // the tail is replayed.
+        var conversationId = $"conv-{Guid.NewGuid():N}";
+        var dispatched = new List<ExecuteAgentTurnCommand>();
+
+        // Window of 2: the run before last contributes nothing to the final dispatch.
+        var handler = BuildHandler(dispatched, maxHistoryMessages: 2);
+
+        await handler.Handle(Durable(conversationId, "one"), CancellationToken.None);
+        await handler.Handle(Durable(conversationId, "two"), CancellationToken.None);
+        await handler.Handle(Durable(conversationId, "three"), CancellationToken.None);
+
+        dispatched[2].ConversationHistory.Select(m => m.Text).Should().Equal(
+            "two", "answer 1");
+
+        var record = await _store.GetAsync(conversationId, Owner);
+        record!.Messages.Should().HaveCount(6, "the transcript keeps every turn the window does not replay");
+    }
+
+    [Fact]
+    public async Task ASecondRunOnTheSameConversation_WaitsForTheFirstToFinishItsTurn()
+    {
+        // Turn serialisation against the real durable lease. The second run is admitted only after the
+        // first has released, so its dispatch sees the first run's exchange rather than racing it.
+        var conversationId = $"conv-{Guid.NewGuid():N}";
+        var firstTurnEntered = new TaskCompletionSource();
+        var releaseFirstTurn = new TaskCompletionSource();
+        var dispatched = new List<ExecuteAgentTurnCommand>();
+
+        var blocking = BuildHandler(dispatched, onTurn: async () =>
+        {
+            firstTurnEntered.TrySetResult();
+            await releaseFirstTurn.Task;
+        });
+
+        var first = blocking.Handle(Durable(conversationId, "hold the lease"), CancellationToken.None);
+        await firstTurnEntered.Task;
+
+        var second = BuildHandler(dispatched).Handle(
+            Durable(conversationId, "queued behind it"), CancellationToken.None);
+
+        // The lease polls, so give the second run a real opportunity to barge in if it can.
+        var bargedIn = await Task.WhenAny(second, Task.Delay(TimeSpan.FromMilliseconds(750)));
+        bargedIn.Should().NotBeSameAs(second, "the second run must wait for the first run's lease");
+
+        releaseFirstTurn.SetResult();
+        await first;
+        await second;
+
+        dispatched.Should().HaveCount(2);
+        dispatched[1].ConversationHistory.Select(m => m.Text).Should().Equal(
+            "hold the lease", "answer 1");
+    }
+
+    // -- Helpers --
+
+    private static RunConversationCommand Durable(string conversationId, string message) => new()
+    {
+        AgentName = "TestAgent",
+        ConversationId = conversationId,
+        ConversationOwnerId = Owner,
+        UserMessages = [message],
+        MaxTurns = 10
+    };
+
+    /// <summary>
+    /// Builds a handler over the REAL store and lease, with only the model turn itself faked — that is
+    /// the one collaborator a test cannot have.
+    /// </summary>
+    private RunConversationCommandHandler BuildHandler(
+        List<ExecuteAgentTurnCommand> dispatched,
+        int maxHistoryMessages = 50,
+        Func<Task>? onTurn = null)
+    {
+        var mediator = new Mock<IMediator>();
+        mediator
+            .Setup(m => m.Send(It.IsAny<ExecuteAgentTurnCommand>(), It.IsAny<CancellationToken>()))
+            .Returns(async (ExecuteAgentTurnCommand cmd, CancellationToken ct) =>
+            {
+                lock (dispatched)
+                    dispatched.Add(cmd);
+
+                if (onTurn is not null)
+                    await onTurn();
+
+                var response = $"answer {cmd.TurnNumber}";
+                return new AgentTurnResult
+                {
+                    Success = true,
+                    Response = response,
+                    UpdatedHistory =
+                    [
+                        .. cmd.ConversationHistory,
+                        new ChatMessage(ChatRole.User, cmd.UserMessage),
+                        new ChatMessage(ChatRole.Assistant, response)
+                    ]
+                };
+            });
+
+        var budget = new Mock<IConversationBudgetTracker>();
+        budget
+            .Setup(b => b.GetStatusAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ConversationBudgetStatus.Disabled);
+
+        return new RunConversationCommandHandler(
+            mediator.Object,
+            new Mock<IAgentConversationCache>().Object,
+            budget.Object,
+            new Mock<IObservabilityStore>().Object,
+            _store,
+            _lease,
+            Options.Create(new ConversationsConfig { MaxHistoryMessages = maxHistoryMessages }),
+            NullLogger<RunConversationCommandHandler>.Instance);
+    }
+
+    public void Dispose()
+    {
+        _provider.Dispose();
+
+        // The connection pool holds the file open until it is cleared, so a delete before this is a
+        // no-op that leaves a stray database behind on every run.
+        Microsoft.Data.Sqlite.SqliteConnection.ClearAllPools();
+        if (File.Exists(_databasePath))
+            File.Delete(_databasePath);
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Conversations/DurableConversationContinuityTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Conversations/DurableConversationContinuityTests.cs
@@ -9,9 +9,7 @@ using FluentAssertions;
 using Infrastructure.AI.Conversations;
 using Infrastructure.AI.Persistence;
 using MediatR;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.AI;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Moq;
@@ -42,10 +40,9 @@ public sealed class DurableConversationContinuityTests : IDisposable
     private const string Owner = "owner-1";
     private const string Stranger = "someone-else";
 
-    private readonly string _databasePath = Path.Combine(
-        Path.GetTempPath(), $"durable-continuity-{Guid.NewGuid():N}.db");
-
-    private readonly ServiceProvider _provider;
+    private readonly string _tempDir;
+    private readonly TestConversationDbContextFactory _contextFactory;
+    private readonly SchemaInitializer<ConversationDbContext> _schema;
     private readonly EfCoreConversationStore _store;
     private readonly IConversationTurnLease _lease;
 
@@ -63,23 +60,23 @@ public sealed class DurableConversationContinuityTests : IDisposable
 
     public DurableConversationContinuityTests()
     {
-        var services = new ServiceCollection();
-        services.AddDbContextFactory<ConversationDbContext>(o => o.UseSqlite($"DataSource={_databasePath}"));
-        services.AddSingleton<SchemaInitializer<ConversationDbContext>>();
-        _provider = services.BuildServiceProvider();
+        // The shared fixture, not a hand-rolled one. It disables connection pooling, which is what lets
+        // the database file be deleted at the end of the test rather than staying open until the pool
+        // is cleared — a hand-rolled factory in this same folder had to call ClearAllPools to compensate.
+        _tempDir = Path.Combine(Path.GetTempPath(), $"durable-continuity-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+        _contextFactory = new TestConversationDbContextFactory(Path.Combine(_tempDir, "conversations.db"));
+        _schema = new SchemaInitializer<ConversationDbContext>(_contextFactory);
 
         _store = new EfCoreConversationStore(
-            _provider.GetRequiredService<IDbContextFactory<ConversationDbContext>>(),
-            _clock,
-            NullLogger<EfCoreConversationStore>.Instance,
-            _provider.GetRequiredService<SchemaInitializer<ConversationDbContext>>());
+            _contextFactory, _clock, NullLogger<EfCoreConversationStore>.Instance, _schema);
 
         _lease = new SqliteConversationTurnLease(
-            _provider.GetRequiredService<IDbContextFactory<ConversationDbContext>>(),
+            _contextFactory,
             Options.Create(new ConversationsConfig()),
             _clock,
             NullLogger<SqliteConversationTurnLease>.Instance,
-            _provider.GetRequiredService<SchemaInitializer<ConversationDbContext>>());
+            _schema);
     }
 
     [Fact]
@@ -258,12 +255,8 @@ public sealed class DurableConversationContinuityTests : IDisposable
 
     public void Dispose()
     {
-        _provider.Dispose();
-
-        // The connection pool holds the file open until it is cleared, so a delete before this is a
-        // no-op that leaves a stray database behind on every run.
-        Microsoft.Data.Sqlite.SqliteConnection.ClearAllPools();
-        if (File.Exists(_databasePath))
-            File.Delete(_databasePath);
+        // Takes the WAL and shared-memory sidecars with it, same as the other SQLite suites here.
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
     }
 }

--- a/src/Content/Tests/Presentation.AgentHub.Tests/AgUi/AgUiClientToolBridgeTests.cs
+++ b/src/Content/Tests/Presentation.AgentHub.Tests/AgUi/AgUiClientToolBridgeTests.cs
@@ -198,6 +198,8 @@ public sealed class AgUiClientToolBridgeTests
             throw new NotSupportedException();
         public Task<ConversationRecord> CreateAsync(string agentName, string userId, string? conversationId = null, CancellationToken ct = default) =>
             throw new NotSupportedException();
+        public Task<ConversationRecord> GetOrCreateAsync(string agentName, string userId, string conversationId, CancellationToken ct = default) =>
+            throw new NotSupportedException();
         public Task<bool> DeleteAsync(string conversationId, string callerId, CancellationToken ct = default) =>
             throw new NotSupportedException();
         public Task<IReadOnlyList<ConversationMessage>?> GetHistoryForDispatch(string conversationId, string callerId, int maxMessages, CancellationToken ct = default) =>

--- a/src/Content/Tests/Presentation.AgentHub.Tests/AgUi/AgUiClientToolBridgeTests.cs
+++ b/src/Content/Tests/Presentation.AgentHub.Tests/AgUi/AgUiClientToolBridgeTests.cs
@@ -200,6 +200,8 @@ public sealed class AgUiClientToolBridgeTests
             throw new NotSupportedException();
         public Task<ConversationRecord> GetOrCreateAsync(string agentName, string userId, string conversationId, CancellationToken ct = default) =>
             throw new NotSupportedException();
+        public Task AppendMessagesAsync(string conversationId, string callerId, IReadOnlyList<ConversationMessage> messages, CancellationToken ct = default) =>
+            throw new NotSupportedException();
         public Task<bool> DeleteAsync(string conversationId, string callerId, CancellationToken ct = default) =>
             throw new NotSupportedException();
         public Task<IReadOnlyList<ConversationMessage>?> GetHistoryForDispatch(string conversationId, string callerId, int maxMessages, CancellationToken ct = default) =>

--- a/src/Content/Tests/Presentation.AgentHub.Tests/Services/ConversationOrchestratorTests.cs
+++ b/src/Content/Tests/Presentation.AgentHub.Tests/Services/ConversationOrchestratorTests.cs
@@ -87,8 +87,12 @@ public class ConversationOrchestratorTests
     [Fact]
     public async Task StartConversation_ExistingConversation_ReturnsExistingRecord()
     {
+        // A supplied id now goes through the store's atomic open. The read-then-create this replaced
+        // was a race: CreateAsync REPLACES, so two clients reconnecting on the same id could both see
+        // it absent and the loser's create would delete the winner's transcript.
         var existing = new ConversationRecord("c1", "agent", "user1", DateTimeOffset.UtcNow, DateTimeOffset.UtcNow, []);
-        _store.Setup(s => s.GetAsync("c1", "user1", It.IsAny<CancellationToken>())).ReturnsAsync(existing);
+        _store.Setup(s => s.GetOrCreateAsync("agent", "user1", "c1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existing);
         _store.Setup(s => s.GetHistoryForDispatch("c1", "user1", 20, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<ConversationMessage>());
 
@@ -96,7 +100,8 @@ public class ConversationOrchestratorTests
         var (record, _) = await orchestrator.StartConversationAsync("conn1", "agent", "c1", "user1", CancellationToken.None);
 
         record.Should().Be(existing);
-        _store.Verify(s => s.CreateAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()), Times.Never);
+        _store.Verify(s => s.CreateAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()), Times.Never,
+            "a caller-supplied id must never reach the replacing create path");
     }
 
     [Fact]
@@ -105,7 +110,10 @@ public class ConversationOrchestratorTests
         // Keyed on the attacker, because the store is the thing that decides now: it is asked as the
         // caller who actually made the request, and refuses. What the orchestrator still owes is that
         // it asks with the real caller and lets the refusal out — not that it re-derives the rule.
-        _store.Setup(s => s.GetAsync("c1", "attacker", It.IsAny<CancellationToken>()))
+        //
+        // Stubbed explicitly, and it has to be: a MOCKED store enforces nothing, so without this the
+        // test would assert an intruder is refused while nothing in the run does any refusing.
+        _store.Setup(s => s.GetOrCreateAsync("agent", "attacker", "c1", It.IsAny<CancellationToken>()))
             .ThrowsAsync(new ConversationAccessDeniedException());
 
         var orchestrator = CreateOrchestrator();


### PR DESCRIPTION
Closes #235. The last of four PRs; #238, #239, #240 (plus #243 and #252) are already merged.

## What this does

A bundle run was **one-shot**. It invented a throwaway conversation id, ran its messages, and forgot them. Any caller driving a session — a voice channel, an IVR, a chat widget — had to replay the whole transcript on every turn: cost and latency grew with the conversation, and the 100-message cap was a hard ceiling on how long a session could get.

A run may now carry a `conversationId`. When it does, the run **continues** that conversation — prior turns are replayed to the agent, and this run's turns are persisted.

```http
POST /api/bundles/{handle}/runs
{ "userMessages": ["And what about the second clause?"],
  "conversationId": "voice-session-8f14e45f" }
```

## Where the logic lives, and why

In `RunConversationCommandHandler` — the one place turns are actually executed — behind an opt-in `ConversationOwnerId`. Omit it and nothing is read or written; existing callers are untouched.

The alternative was to put it in the Execution API caller. That would have made durability visible only as a finished lump: a run dying on its seventh turn would persist nothing, and the next consumer that wanted durable turns would have built it again. This is the failure mode the issue was filed about.

## The four invariants, carried across rather than re-derived

| Invariant | How |
|---|---|
| Ownership | Stays inside `IConversationStore`. Nothing here compares owners — that comparison was hand-written in six places before it moved into the store, and this would have been the seventh. |
| Token budget | Already keyed by conversation id; passing the real id makes it span the conversation. A run continuing an exhausted conversation declines before its **first** dispatch. |
| Turn serialisation | The run holds the conversation's durable turn lease throughout. Losing it mid-run stops the run. |
| Bounded replay | `AppConfig:AI:Conversations:MaxHistoryMessages` (50). The transcript is unbounded; the prompt built from it is not. |

The issue asked for "tests that fail if each is removed, not merely tests that pass." Five mutations were applied and each observed red, then reverted: dropping the replayed history, unlinking the lost-lease signal, disabling the ownership pre-check, hardcoding the history window, and exempting the first turn from the budget gate. One control — turn serialisation — is **not** code-mutated: leasing a different id blocks rather than skipping serialisation, so the mutation tested nothing. It is covered instead by an end-to-end test where a queued run must observe the earlier run's exchange.

## New store operations, and why each earns its place

**`GetOrCreateAsync`** — composing read-then-create over the existing `CreateAsync` is a transcript-destroying race, because `CreateAsync` **replaces**: two runs opening the same new conversation both see it absent, and the loser's create deletes the winner's turns. SQLite makes the insert atomic against the primary key and resolves a lost race by returning the winner's record; the file store does it under the lock it already holds. `ConversationOrchestrator` had that exact race and now uses this too.

**`AppendMessagesAsync`** — a turn is stored as one atomic question+answer pair. Two appends were quadratic on the file-backed store, which rewrites the entire transcript on every append, and they were interruptible: a lease lost between them left a question with no answer. That matters more than it sounds, because this transcript is **replayed to a model** — a half-turn is misleading, not merely partial.

## Decisions the issue asked for

**`maxTurns` and the 100-message cap bound one run, not the conversation.** A durable conversation outlives any run, so a per-run ceiling cannot also be its lifetime ceiling. What bounds total length is the conversation-lifetime token budget, which is durable and spans every run.

**A run naming an unknown conversation creates it,** owned by the caller. One naming someone else's is refused **synchronously** as `404`, identically to an unknown handle, so the endpoint cannot enumerate other callers' conversation ids.

## Known gaps, stated rather than hidden

- **Observability session continuity.** A durable run still opens its own session rather than continuing the conversation's, so `ConversationRecord.Telemetry` is not accumulated across runs. Not in the issue's done-means; flagged rather than half-implemented.
- **The budget that bounds conversation length ships disabled.** `ConversationTokenBudget` defaults to `0`. The decision above is documented but requires operator configuration to take effect — changing a shipped default is a behaviour change for every consumer and is not made here.
- **Three `MaxHistoryMessages` settings now exist** (SignalR 20, AG-UI 50, this one 50). Consolidating them changes interactive behaviour, so the divergence is documented in `ConversationsConfig` rather than averaged silently.

## Test plan

- `dotnet build src/AgenticHarness.slnx` — clean.
- Full solution suite green, except 4 pre-existing `FileSystemService` failures caused by `TEMP=C:\WINDOWS\TEMP` locally (documented environment trap, unrelated).
- `DurableConversationContinuityTests` — new, drives a **real** SQLite store and a **real** durable lease: a second run sees the first run's turns; the transcript holds complete turns in order; a stranger is refused by the real store; the replay window is bounded while the transcript is not; a queued run waits for the lease.
- `ConversationStoreContractTests` — new `GetOrCreateAsync` and `AppendMessagesAsync` sections run against **both** providers.
- `Presentation.AgentHub.Tests` 410/410 — proves the AG-UI/SignalR behaviour is unchanged by the shared role mapper and the orchestrator's atomic open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
