### PR TITLE
fix: three real bugs — inert SKILL.md tool declarations, a lock leak, and test state accumulation

### DIFF
--- a/src/Content/Infrastructure/Infrastructure.AI/MetaHarness/FileSystemHarnessCandidateRepository.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/MetaHarness/FileSystemHarnessCandidateRepository.cs
@@ -17,7 +17,7 @@ namespace Infrastructure.AI.MetaHarness;
 public sealed class FileSystemHarnessCandidateRepository : IHarnessCandidateRepository, IDisposable
 {
     private readonly IOptionsMonitor<MetaHarnessConfig> _options;
-    private readonly ConcurrentDictionary<Guid, SemaphoreSlim> _indexLocks = new();
+    private readonly ConcurrentDictionary<Guid, IndexLock> _indexLocks = new();
 
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
@@ -40,6 +40,12 @@ public sealed class FileSystemHarnessCandidateRepository : IHarnessCandidateRepo
         _options = options;
     }
 
+    /// <summary>
+    /// The number of optimization runs currently holding or awaiting the index lock. Exposed so
+    /// the eviction tests can observe it; not part of <see cref="IHarnessCandidateRepository"/>.
+    /// </summary>
+    internal int TrackedIndexLocks => _indexLocks.Count;
+
     /// <inheritdoc/>
     public async Task SaveAsync(HarnessCandidate candidate, CancellationToken ct = default)
     {
@@ -50,8 +56,20 @@ public sealed class FileSystemHarnessCandidateRepository : IHarnessCandidateRepo
         var json = JsonSerializer.Serialize(dto, JsonOptions);
         await WriteAtomicAsync(Path.Combine(dir, "candidate.json"), json, ct);
 
-        var semaphore = _indexLocks.GetOrAdd(candidate.OptimizationRunId, _ => new SemaphoreSlim(1, 1));
-        await semaphore.WaitAsync(ct);
+        var entry = Reserve(candidate.OptimizationRunId);
+
+        try
+        {
+            await entry.Semaphore.WaitAsync(ct);
+        }
+        catch
+        {
+            // Cancelled while queued. The reservation has to come back off, or an abandoned wait
+            // pins the entry for the lifetime of the host — the same leak by a different route.
+            Unreserve(candidate.OptimizationRunId, entry);
+            throw;
+        }
+
         try
         {
             var indexPath = IndexPath(candidate.OptimizationRunId);
@@ -75,7 +93,11 @@ public sealed class FileSystemHarnessCandidateRepository : IHarnessCandidateRepo
         }
         finally
         {
-            semaphore.Release();
+            // Release before unreserving. Unreserving can dispose the semaphore, and disposing one
+            // that has not been released loses the slot for every future acquirer of a re-created
+            // entry — which is a deadlock, not a leak.
+            entry.Semaphore.Release();
+            Unreserve(candidate.OptimizationRunId, entry);
         }
     }
 
@@ -192,10 +214,110 @@ public sealed class FileSystemHarnessCandidateRepository : IHarnessCandidateRepo
     }
 
     /// <inheritdoc/>
+    /// <remarks>
+    /// Entries evict themselves as soon as nothing holds or awaits them, so in a settled host
+    /// this has nothing to do. It remains as the backstop for disposal mid-save.
+    /// </remarks>
     public void Dispose()
     {
-        foreach (var semaphore in _indexLocks.Values)
-            semaphore.Dispose();
+        foreach (var entry in _indexLocks.Values)
+        {
+            // Take the entry's own gate and mark it evicted rather than disposing blind. Disposal
+            // racing an in-flight Unreserve would otherwise dispose the same semaphore twice, and
+            // a reserver that has already published a successor entry would be handed a disposed
+            // one. Marking under the gate makes both paths agree on who disposes.
+            lock (entry.Gate)
+            {
+                if (entry.Evicted)
+                    continue;
+
+                entry.Evicted = true;
+                entry.Semaphore.Dispose();
+            }
+        }
+
+        _indexLocks.Clear();
+    }
+
+    // -------------------------------------------------------------------------
+    // Index-lock lifetime
+    // -------------------------------------------------------------------------
+
+    /// <summary>
+    /// Takes a reference on the run's index lock, creating it if needed.
+    /// </summary>
+    /// <remarks>
+    /// The retry loop closes the window between <c>GetOrAdd</c> handing back an entry and this
+    /// thread taking its reference: a releasing thread may evict that entry in between. Eviction
+    /// sets <see cref="IndexLock.Evicted"/> under the entry's own lock, so a reserver that loses
+    /// the race sees the flag and starts again against whatever is in the dictionary now — rather
+    /// than waiting on a semaphore no future writer will look up.
+    /// <para>
+    /// What makes the retry terminate is that eviction also removes the entry from the dictionary
+    /// under that same lock, so the next <c>GetOrAdd</c> cannot hand back the flagged one.
+    /// Flagging without removing turns this into a spin that never ends.
+    /// </para>
+    /// </remarks>
+    private IndexLock Reserve(Guid optimizationRunId)
+    {
+        while (true)
+        {
+            var entry = _indexLocks.GetOrAdd(optimizationRunId, static _ => new IndexLock());
+
+            lock (entry.Gate)
+            {
+                if (!entry.Evicted)
+                {
+                    entry.References++;
+                    return entry;
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Drops a reference and evicts the entry once nothing holds or awaits it.
+    /// </summary>
+    /// <remarks>
+    /// Disposing the semaphore here is safe precisely because the count reached zero: no thread
+    /// holds it and none is waiting on it, and a thread about to wait is still blocked on
+    /// <see cref="IndexLock.Gate"/> in <see cref="Reserve"/> and will see the eviction flag
+    /// instead. The key-and-value overload of <c>TryRemove</c> matters — removing by key alone
+    /// could delete a successor entry a concurrent reserver has already published.
+    /// </remarks>
+    private void Unreserve(Guid optimizationRunId, IndexLock entry)
+    {
+        lock (entry.Gate)
+        {
+            if (--entry.References > 0)
+                return;
+
+            // Already evicted means Dispose got here first and owns the semaphore.
+            if (entry.Evicted)
+                return;
+
+            entry.Evicted = true;
+            _indexLocks.TryRemove(new KeyValuePair<Guid, IndexLock>(optimizationRunId, entry));
+            entry.Semaphore.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// Per-run index-file lock plus the reference count that decides when it is dropped.
+    /// </summary>
+    private sealed class IndexLock
+    {
+        /// <summary>Guards <see cref="References"/> and <see cref="Evicted"/>. Never held across an await.</summary>
+        public object Gate { get; } = new();
+
+        /// <summary>The binary lock serialising index writes for one optimization run.</summary>
+        public SemaphoreSlim Semaphore { get; } = new(1, 1);
+
+        /// <summary>Holders plus waiters. Guarded by <see cref="Gate"/>.</summary>
+        public int References { get; set; }
+
+        /// <summary>Set once this entry has left the dictionary, so a racing reserver retries.</summary>
+        public bool Evicted { get; set; }
     }
 
     // -------------------------------------------------------------------------

--- a/src/Content/Infrastructure/Infrastructure.AI/Skills/SkillMetadataParser.ToolDeclarations.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Skills/SkillMetadataParser.ToolDeclarations.cs
@@ -135,14 +135,15 @@ public sealed partial class SkillMetadataParser
     {
         var declaration = new ToolDeclaration();
 
-        // Set while a key has been seen whose value is a block sequence rather than an inline
-        // array, so the following '- item' lines are read as that key's entries.
-        string? pendingListKey = null;
+        // Set while `operations:` has been seen with no inline value, so the following '- item'
+        // lines are read as its entries. Operations is the only key that can be a block sequence,
+        // which is why one flag suffices.
+        var operationsPending = false;
 
         var first = lines[startIdx].TrimStart();
         var firstAfterDash = first.Length > 1 ? first[1..].TrimStart() : string.Empty;
         if (!string.IsNullOrEmpty(firstAfterDash))
-            ApplyDeclarationKvp(firstAfterDash, declaration, ref pendingListKey);
+            operationsPending = ApplyDeclarationKvp(firstAfterDash, declaration);
 
         var i = startIdx + 1;
         while (i < lines.Length)
@@ -160,20 +161,17 @@ public sealed partial class SkillMetadataParser
 
             var trimmed = raw.TrimStart();
 
-            if (pendingListKey is not null && trimmed.StartsWith('-'))
+            if (operationsPending && trimmed.StartsWith('-'))
             {
                 var item = trimmed[1..].Trim().Trim('"', '\'');
-                if (!string.IsNullOrEmpty(item) &&
-                    pendingListKey.Equals("operations", StringComparison.OrdinalIgnoreCase))
-                {
+                if (!string.IsNullOrEmpty(item))
                     declaration.Operations.Add(item);
-                }
 
                 i++;
                 continue;
             }
 
-            ApplyDeclarationKvp(trimmed, declaration, ref pendingListKey);
+            operationsPending = ApplyDeclarationKvp(trimmed, declaration);
             i++;
         }
 
@@ -183,18 +181,19 @@ public sealed partial class SkillMetadataParser
             : (declaration, consumed);
     }
 
-    private static void ApplyDeclarationKvp(
-        string trimmed,
-        ToolDeclaration declaration,
-        ref string? pendingListKey)
+    /// <summary>
+    /// Applies one <c>key: value</c> line to <paramref name="declaration"/>. Returns true when the
+    /// line opened <c>operations:</c> with no inline value, meaning the caller should read the
+    /// following <c>- item</c> lines as its entries.
+    /// </summary>
+    private static bool ApplyDeclarationKvp(string trimmed, ToolDeclaration declaration)
     {
         var colon = trimmed.IndexOf(':', StringComparison.Ordinal);
         if (colon <= 0)
-            return;
+            return false;
 
         var key = trimmed[..colon].Trim();
         var value = trimmed[(colon + 1)..].Trim().Trim('"', '\'');
-        pendingListKey = null;
 
         if (key.Equals("name", StringComparison.OrdinalIgnoreCase))
             declaration.Name = value;
@@ -215,9 +214,11 @@ public sealed partial class SkillMetadataParser
             if (value.StartsWith('['))
                 declaration.Operations = [.. ParseInlineStringArray(value)];
             else if (value.Length == 0)
-                pendingListKey = "operations";
+                return true; // a block sequence follows
         }
         // Unknown scalar keys ignored — see the remarks on ParseToolDeclarations.
+
+        return false;
     }
 
     /// <summary>

--- a/src/Content/Infrastructure/Infrastructure.AI/Skills/SkillMetadataParser.ToolDeclarations.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Skills/SkillMetadataParser.ToolDeclarations.cs
@@ -1,0 +1,238 @@
+using Domain.AI.Skills;
+using Domain.AI.Tools;
+
+namespace Infrastructure.AI.Skills;
+
+/// <summary>
+/// The <c>tools:</c> frontmatter block: the one harness field that is a list of maps rather than
+/// a scalar or a flat list, split out from the main parser by responsibility.
+/// </summary>
+public sealed partial class SkillMetadataParser
+{
+    /// <summary>
+    /// Parses the structured <c>tools:</c> block from YAML frontmatter into tool declarations.
+    /// Returns null when the <c>tools</c> key is absent or yields no usable entry, which keeps
+    /// <see cref="SkillDefinition.HasToolDeclarations"/> — and therefore
+    /// <see cref="SkillDefinition.Mode"/> — reading "this skill declared nothing".
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Each list item is a map with keys <c>name</c>, <c>operations</c>, <c>optional</c>,
+    /// <c>fallback</c>, <c>condition</c>, <c>description</c>, <c>when-to-use</c> and
+    /// <c>when-not-to-use</c>. <c>operations</c> accepts both an inline array
+    /// (<c>["read", "list"]</c>) and a block sequence, because the domain type's own
+    /// documentation advertises the block form while every shipped manifest uses the inline one.
+    /// </para>
+    /// <para>
+    /// Unknown <em>scalar</em> keys are ignored, so a manifest that adds one does not break an
+    /// older parser. A nested map under an unknown key is NOT understood: its children are read
+    /// as further keys of the same declaration, so a future field of that shape needs a case
+    /// here rather than relying on the parser to skip it.
+    /// </para>
+    /// <para>
+    /// An entry with no <c>name</c> is dropped rather than emitted nameless: an empty name
+    /// cannot resolve, and <c>ToolChainBuilder</c> would report it far from the manifest that
+    /// caused it. A missing <c>optional</c> means REQUIRED, matching the domain default — the
+    /// direction that fails loudly at resolution rather than silently dropping a tool the skill
+    /// depends on.
+    /// </para>
+    /// <para>
+    /// Hand-rolled for the same reason as the egress block: the surrounding frontmatter parser is
+    /// hand-rolled, and one nested block does not justify a YAML dependency.
+    /// </para>
+    /// </remarks>
+    internal static IList<ToolDeclaration>? ParseToolDeclarations(string? frontmatter)
+    {
+        if (string.IsNullOrEmpty(frontmatter))
+            return null;
+
+        var lines = frontmatter.Split('\n');
+
+        var toolsIdx = -1;
+        for (var i = 0; i < lines.Length; i++)
+        {
+            var line = lines[i];
+            if (line.Length > 0 && (line[0] == ' ' || line[0] == '\t'))
+                continue;
+
+            if (line.Trim().Equals("tools:", StringComparison.OrdinalIgnoreCase))
+            {
+                toolsIdx = i;
+                break;
+            }
+        }
+
+        if (toolsIdx < 0)
+            return null;
+
+        var declarations = ParseToolDeclarationItems(lines, toolsIdx);
+        return declarations.Count > 0 ? declarations : null;
+    }
+
+    private static List<ToolDeclaration> ParseToolDeclarationItems(string[] lines, int toolsIdx)
+    {
+        var declarations = new List<ToolDeclaration>();
+
+        // Establish the list-item indent from the first '- ' line under "tools:".
+        var itemIndent = -1;
+        for (var probe = toolsIdx + 1; probe < lines.Length; probe++)
+        {
+            var raw = lines[probe];
+            if (IsBlank(raw))
+                continue;
+
+            var leading = CountLeadingSpaces(raw);
+            if (leading == 0)
+                return declarations; // out of the tools block entirely
+
+            if (raw.TrimStart().StartsWith('-'))
+            {
+                itemIndent = leading;
+                break;
+            }
+
+            return declarations; // indented but not a list item — malformed
+        }
+
+        if (itemIndent < 0)
+            return declarations;
+
+        var i = toolsIdx + 1;
+        while (i < lines.Length)
+        {
+            var raw = lines[i];
+            if (IsBlank(raw))
+            {
+                i++;
+                continue;
+            }
+
+            if (CountLeadingSpaces(raw) < itemIndent)
+                break;
+
+            if (CountLeadingSpaces(raw) == itemIndent && raw.TrimStart().StartsWith('-'))
+            {
+                var (declaration, consumed) = ReadOneToolDeclaration(lines, i, itemIndent);
+                if (declaration is not null)
+                    declarations.Add(declaration);
+
+                i += consumed;
+            }
+            else
+            {
+                // Unexpected line shape — skip defensively.
+                i++;
+            }
+        }
+
+        return declarations;
+    }
+
+    private static (ToolDeclaration? Declaration, int Consumed) ReadOneToolDeclaration(
+        string[] lines,
+        int startIdx,
+        int itemIndent)
+    {
+        var declaration = new ToolDeclaration();
+
+        // Set while a key has been seen whose value is a block sequence rather than an inline
+        // array, so the following '- item' lines are read as that key's entries.
+        string? pendingListKey = null;
+
+        var first = lines[startIdx].TrimStart();
+        var firstAfterDash = first.Length > 1 ? first[1..].TrimStart() : string.Empty;
+        if (!string.IsNullOrEmpty(firstAfterDash))
+            ApplyDeclarationKvp(firstAfterDash, declaration, ref pendingListKey);
+
+        var i = startIdx + 1;
+        while (i < lines.Length)
+        {
+            var raw = lines[i];
+            if (IsBlank(raw))
+            {
+                i++;
+                continue;
+            }
+
+            // Anything at or shallower than the item indent starts the next entry or ends the block.
+            if (CountLeadingSpaces(raw) <= itemIndent)
+                break;
+
+            var trimmed = raw.TrimStart();
+
+            if (pendingListKey is not null && trimmed.StartsWith('-'))
+            {
+                var item = trimmed[1..].Trim().Trim('"', '\'');
+                if (!string.IsNullOrEmpty(item) &&
+                    pendingListKey.Equals("operations", StringComparison.OrdinalIgnoreCase))
+                {
+                    declaration.Operations.Add(item);
+                }
+
+                i++;
+                continue;
+            }
+
+            ApplyDeclarationKvp(trimmed, declaration, ref pendingListKey);
+            i++;
+        }
+
+        var consumed = i - startIdx;
+        return string.IsNullOrWhiteSpace(declaration.Name)
+            ? (null, consumed)
+            : (declaration, consumed);
+    }
+
+    private static void ApplyDeclarationKvp(
+        string trimmed,
+        ToolDeclaration declaration,
+        ref string? pendingListKey)
+    {
+        var colon = trimmed.IndexOf(':', StringComparison.Ordinal);
+        if (colon <= 0)
+            return;
+
+        var key = trimmed[..colon].Trim();
+        var value = trimmed[(colon + 1)..].Trim().Trim('"', '\'');
+        pendingListKey = null;
+
+        if (key.Equals("name", StringComparison.OrdinalIgnoreCase))
+            declaration.Name = value;
+        else if (key.Equals("description", StringComparison.OrdinalIgnoreCase))
+            declaration.Description = value;
+        else if (key.Equals("fallback", StringComparison.OrdinalIgnoreCase))
+            declaration.Fallback = string.IsNullOrEmpty(value) ? null : value;
+        else if (key.Equals("condition", StringComparison.OrdinalIgnoreCase))
+            declaration.Condition = string.IsNullOrEmpty(value) ? null : value;
+        else if (key.Equals("optional", StringComparison.OrdinalIgnoreCase))
+            declaration.Optional = ParseYamlBoolean(value);
+        else if (key.Equals("when-to-use", StringComparison.OrdinalIgnoreCase))
+            declaration.WhenToUse = value;
+        else if (key.Equals("when-not-to-use", StringComparison.OrdinalIgnoreCase))
+            declaration.WhenNotToUse = value;
+        else if (key.Equals("operations", StringComparison.OrdinalIgnoreCase))
+        {
+            if (value.StartsWith('['))
+                declaration.Operations = [.. ParseInlineStringArray(value)];
+            else if (value.Length == 0)
+                pendingListKey = "operations";
+        }
+        // Unknown scalar keys ignored — see the remarks on ParseToolDeclarations.
+    }
+
+    /// <summary>
+    /// Reads a YAML boolean, accepting <c>true</c> and <c>yes</c>. Anything else is false —
+    /// for <c>optional</c> that means REQUIRED, so a typo surfaces as a loud resolution failure
+    /// rather than a tool quietly dropped from the chain.
+    /// </summary>
+    private static bool ParseYamlBoolean(string value)
+        => value.Equals("true", StringComparison.OrdinalIgnoreCase)
+        || value.Equals("yes", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Whether a line carries nothing an indent-sensitive parser should judge. Whitespace-only
+    /// lines count as blank: a line of spaces has a leading-space count, and treating that as a
+    /// real indent level ends the block early.
+    /// </summary>
+    private static bool IsBlank(string line) => string.IsNullOrWhiteSpace(line);
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Skills/SkillMetadataParser.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Skills/SkillMetadataParser.cs
@@ -473,7 +473,7 @@ public sealed partial class SkillMetadataParser
         for (var probe = i; probe < lines.Length; probe++)
         {
             var raw = lines[probe];
-            if (raw.Length == 0)
+            if (IsBlank(raw))
                 continue;
 
             var leading = CountLeadingSpaces(raw);
@@ -497,7 +497,7 @@ public sealed partial class SkillMetadataParser
         while (i < lines.Length)
         {
             var raw = lines[i];
-            if (raw.Length == 0)
+            if (IsBlank(raw))
             {
                 i++;
                 continue;
@@ -551,7 +551,7 @@ public sealed partial class SkillMetadataParser
         while (i < lines.Length)
         {
             var raw = lines[i];
-            if (raw.Length == 0)
+            if (IsBlank(raw))
             {
                 i++;
                 continue;

--- a/src/Content/Infrastructure/Infrastructure.AI/Skills/SkillMetadataParser.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Skills/SkillMetadataParser.cs
@@ -19,12 +19,13 @@ namespace Infrastructure.AI.Skills;
 /// for the authoritative list. Background: <c>docs/plans/skills-refactor-to-framework.md</c>.
 /// </para>
 /// <para>
-/// It does <em>not</em> parse the structured <c>tools:</c> block that shipped SKILL.md files
-/// declare — <see cref="SkillDefinition.ToolDeclarations"/> is never populated from frontmatter
-/// (issue #222).
+/// That list includes the structured <c>tools:</c> block, which the framework cannot represent
+/// at all: its <c>metadata:</c> escape hatch captures flat strings, while a tool declaration is
+/// a list of maps carrying operations, an optional flag, and a fallback. Parsing it here is what
+/// makes <see cref="SkillDefinition.ToolDeclarations"/> reach the runtime (issue #222).
 /// </para>
 /// </remarks>
-public sealed class SkillMetadataParser
+public sealed partial class SkillMetadataParser
 {
     private readonly ILogger<SkillMetadataParser> _logger;
 
@@ -68,6 +69,7 @@ public sealed class SkillMetadataParser
             AgentId = ParseString(frontmatter, "agent-id"),
             Tags = ParseList(frontmatter, "tags"),
             AllowedTools = ParseList(frontmatter, "allowed-tools"),
+            ToolDeclarations = ParseToolDeclarations(frontmatter),
             Prerequisites = ParseList(frontmatter, "prerequisites"),
             CompletionTool = ParseString(frontmatter, "completion_tool"),
             Metadata = metaBlock?.ToDictionary(kv => kv.Key, kv => (object)kv.Value),
@@ -129,6 +131,7 @@ public sealed class SkillMetadataParser
             AgentId = ParseString(rawFrontmatter, "agent-id"),
             Tags = ParseList(rawFrontmatter, "tags"),
             AllowedTools = ParseList(rawFrontmatter, "allowed-tools"),
+            ToolDeclarations = ParseToolDeclarations(rawFrontmatter),
             Prerequisites = ParseList(rawFrontmatter, "prerequisites"),
             CompletionTool = ParseString(rawFrontmatter, "completion_tool"),
             Metadata = metaBlock?.ToDictionary(kv => kv.Key, kv => (object)kv.Value),
@@ -142,13 +145,20 @@ public sealed class SkillMetadataParser
         };
     }
 
+    /// <remarks>
+    /// Line endings are normalised to LF because every block parser below splits on <c>'\n'</c>
+    /// and then judges a line by its leading whitespace. Left as CRLF, a blank line arrives as
+    /// <c>"\r"</c> — no leading whitespace, which reads as "the block ended" and silently
+    /// truncates the rest of it. Every SKILL.md in this repository is CRLF on disk, so this is
+    /// the normal case rather than an edge one.
+    /// </remarks>
     private static string? ExtractFrontmatter(string raw)
     {
         if (!raw.StartsWith("---", StringComparison.Ordinal))
             return null;
 
         var end = raw.IndexOf("---", 3, StringComparison.Ordinal);
-        return end < 0 ? null : raw[3..end];
+        return end < 0 ? null : raw[3..end].Replace("\r\n", "\n", StringComparison.Ordinal);
     }
 
     private static string ExtractBody(string raw, string? frontmatter)

--- a/src/Content/Tests/Infrastructure.AI.Tests/MetaHarness/FileSystemHarnessCandidateRepositoryEvictionTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/MetaHarness/FileSystemHarnessCandidateRepositoryEvictionTests.cs
@@ -1,0 +1,129 @@
+using Domain.Common.Config.MetaHarness;
+using Domain.Common.MetaHarness;
+using Infrastructure.AI.MetaHarness;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.MetaHarness;
+
+/// <summary>
+/// Issue #244: the repository kept one <see cref="SemaphoreSlim"/> per optimization run in a
+/// dictionary that nothing ever removed from. Because the repository is a singleton and the key
+/// is a per-run <see cref="Guid"/>, a long-lived host accumulated one entry for every run it had
+/// ever executed. These tests pin the eviction and the serialisation guarantee it must not cost.
+/// </summary>
+public sealed class FileSystemHarnessCandidateRepositoryEvictionTests : IDisposable
+{
+    private readonly string _root;
+    private readonly FileSystemHarnessCandidateRepository _sut;
+
+    public FileSystemHarnessCandidateRepositoryEvictionTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), $"repo-eviction-tests-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_root);
+
+        var config = new MetaHarnessConfig { TraceDirectoryRoot = _root };
+        var opts = Mock.Of<IOptionsMonitor<MetaHarnessConfig>>(m => m.CurrentValue == config);
+        _sut = new FileSystemHarnessCandidateRepository(opts);
+    }
+
+    public void Dispose()
+    {
+        _sut.Dispose();
+        Directory.Delete(_root, recursive: true);
+    }
+
+    /// <summary>
+    /// The defect itself: many sequential runs must not leave many index locks behind. Fifty runs
+    /// is arbitrary but well past the point where an accumulating dictionary is unambiguous.
+    /// </summary>
+    [Fact]
+    public async Task SaveAsync_AcrossManyRuns_LeavesNoIndexLocksBehind()
+    {
+        for (var i = 0; i < 50; i++)
+            await _sut.SaveAsync(BuildProposed(Guid.NewGuid()));
+
+        Assert.Equal(0, _sut.TrackedIndexLocks);
+    }
+
+    /// <summary>
+    /// Repeated saves to the SAME run must also settle back to nothing, and must not leave the
+    /// entry pinned by a reference that was taken but never dropped.
+    /// </summary>
+    [Fact]
+    public async Task SaveAsync_RepeatedlyForOneRun_LeavesNoIndexLockBehind()
+    {
+        var runId = Guid.NewGuid();
+
+        for (var i = 0; i < 20; i++)
+            await _sut.SaveAsync(BuildProposed(runId));
+
+        Assert.Equal(0, _sut.TrackedIndexLocks);
+    }
+
+    /// <summary>
+    /// The guarantee eviction must not break. Concurrent saves to one run append to a single
+    /// <c>index.jsonl</c> via read-append-replace, so losing serialisation loses index records
+    /// outright — a correctness failure, not a performance one.
+    /// </summary>
+    [Fact]
+    public async Task SaveAsync_ConcurrentSavesToSameRun_SerialiseAndKeepEveryIndexRecord()
+    {
+        var runId = Guid.NewGuid();
+        const int saves = 40;
+
+        await Task.WhenAll(Enumerable.Range(0, saves)
+            .Select(_ => _sut.SaveAsync(BuildProposed(runId))));
+
+        var indexPath = Path.Combine(
+            _root, "optimizations", runId.ToString("D"), "candidates", "index.jsonl");
+
+        var lines = await File.ReadAllLinesAsync(indexPath);
+        Assert.Equal(saves, lines.Count(l => !string.IsNullOrWhiteSpace(l)));
+        Assert.Equal(0, _sut.TrackedIndexLocks);
+    }
+
+    /// <summary>
+    /// Interleaved concurrent saves across several runs: every run's records survive, and every
+    /// run's lock is gone once its work finishes. This is the case where evicting under the wrong
+    /// lock, or removing by key alone, would drop a successor entry another writer is using.
+    /// </summary>
+    [Fact]
+    public async Task SaveAsync_ConcurrentSavesAcrossRuns_KeepEveryRecordAndEvictEveryLock()
+    {
+        var runIds = Enumerable.Range(0, 8).Select(_ => Guid.NewGuid()).ToArray();
+        const int savesPerRun = 10;
+
+        await Task.WhenAll(runIds.SelectMany(runId =>
+            Enumerable.Range(0, savesPerRun).Select(_ => _sut.SaveAsync(BuildProposed(runId)))));
+
+        foreach (var runId in runIds)
+        {
+            var indexPath = Path.Combine(
+                _root, "optimizations", runId.ToString("D"), "candidates", "index.jsonl");
+            var lines = await File.ReadAllLinesAsync(indexPath);
+            Assert.Equal(savesPerRun, lines.Count(l => !string.IsNullOrWhiteSpace(l)));
+        }
+
+        Assert.Equal(0, _sut.TrackedIndexLocks);
+    }
+
+    private static HarnessSnapshot EmptySnapshot() => new()
+    {
+        SkillFileSnapshots = new Dictionary<string, string>(),
+        SystemPromptSnapshot = string.Empty,
+        ConfigSnapshot = new Dictionary<string, string>(),
+        SnapshotManifest = []
+    };
+
+    private static HarnessCandidate BuildProposed(Guid runId) => new()
+    {
+        CandidateId = Guid.NewGuid(),
+        OptimizationRunId = runId,
+        Iteration = 0,
+        CreatedAt = DateTimeOffset.UtcNow,
+        Snapshot = EmptySnapshot(),
+        Status = HarnessCandidateStatus.Proposed
+    };
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Skills/SkillMetadataParserEgressTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Skills/SkillMetadataParserEgressTests.cs
@@ -79,6 +79,45 @@ public sealed class SkillMetadataParserEgressTests : IDisposable
     }
 
     /// <summary>
+    /// The allowlist must survive a blank line between entries on a CRLF file, and a line of
+    /// spaces. Both look like "no leading whitespace" or "a real indent level" to an
+    /// indent-sensitive parser, and truncating the list here silently NARROWS an egress
+    /// allowlist — a security control losing entries without saying so.
+    /// </summary>
+    [Fact]
+    public void ParseFromFile_CrlfAndWhitespaceLinesInsideAllowlist_KeepsEveryEntry()
+    {
+        // The whitespace-only line sits between "allowlist:" and the FIRST entry. That is the
+        // position that decides the whole block: the item-indent probe reads a line of spaces as
+        // "indented, but not a list item — malformed" and abandons the allowlist entirely.
+        var content = string.Join("\r\n",
+            "---",
+            "name: \"github-reader\"",
+            "description: \"Reads GitHub issues\"",
+            "egress:",
+            "  allowlist:",
+            "    ",
+            "    - host: \"api.github.com\"",
+            "      schemes: [\"https\"]",
+            "      ports: [443]",
+            "",
+            "    - host: \"api.example.com\"",
+            "      schemes: [\"https\"]",
+            "    - hostPattern: \"*.azure-api.net\"",
+            "      schemes: [\"https\"]",
+            "---",
+            "Body content here.");
+
+        var path = WriteSkillFile(content);
+        var skill = _sut.ParseFromFile(path, _tempDir);
+
+        skill.Egress.Should().NotBeNull();
+        skill.Egress!.Allowlist.Should().HaveCount(3);
+        skill.Egress.Allowlist[1].Host.Should().Be("api.example.com");
+        skill.Egress.Allowlist[2].HostPattern.Should().Be("*.azure-api.net");
+    }
+
+    /// <summary>
     /// A skill without an <c>egress</c> block has <see cref="Domain.AI.Skills.SkillDefinition.Egress"/> == null.
     /// Inheritance of the harness-wide default with no additions happens in the resolver.
     /// </summary>

--- a/src/Content/Tests/Infrastructure.AI.Tests/Skills/SkillMetadataParserToolDeclarationTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Skills/SkillMetadataParserToolDeclarationTests.cs
@@ -1,0 +1,439 @@
+using Domain.AI.Skills;
+using FluentAssertions;
+using Infrastructure.AI.Skills;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Skills;
+
+/// <summary>
+/// Issue #222: the structured <c>tools:</c> frontmatter block was never parsed, so
+/// <see cref="SkillDefinition.ToolDeclarations"/> was empty on every skill loaded from disk
+/// and four production consumers (tool-chain resolution, prerequisite mapping, and both
+/// permission-rule providers) silently saw nothing.
+/// </summary>
+/// <remarks>
+/// These tests cover the parser's YAML-to-domain mapping only. Whether a declared tool can
+/// actually be resolved is <c>ToolChainBuilder</c>'s concern, and whether a declaration is
+/// semantically sensible is the consuming layer's.
+/// </remarks>
+public sealed class SkillMetadataParserToolDeclarationTests : IDisposable
+{
+    private readonly SkillMetadataParser _sut;
+    private readonly string _tempDir;
+
+    public SkillMetadataParserToolDeclarationTests()
+    {
+        _sut = new SkillMetadataParser(NullLogger<SkillMetadataParser>.Instance);
+        _tempDir = Path.Combine(Path.GetTempPath(), $"tooldecl-parser-tests-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+    }
+
+    private string WriteSkillFile(string content)
+    {
+        var filePath = Path.Combine(_tempDir, "SKILL.md");
+        File.WriteAllText(filePath, content);
+        return filePath;
+    }
+
+    /// <summary>
+    /// The exact frontmatter shape shipped in <c>plugins/workspace-skill</c> and
+    /// <c>skills/research-agent</c>: inline operations array, explicit optional flag,
+    /// and a per-skill description.
+    /// </summary>
+    [Fact]
+    public void ParseFromFile_InlineOperationsBlock_PopulatesEveryDeclaredField()
+    {
+        var content = """
+            ---
+            name: "research-agent"
+            description: "Finds and analyzes information"
+            tools:
+              - name: "file_system"
+                operations: ["read", "search", "list"]
+                optional: false
+                description: "Read and search project files"
+              - name: "github_repos"
+                optional: true
+                fallback: "file_system"
+                description: "Query GitHub repositories and issues"
+            ---
+            Body content here.
+            """;
+
+        var skill = _sut.ParseFromFile(WriteSkillFile(content), _tempDir);
+
+        skill.ToolDeclarations.Should().NotBeNull();
+        skill.ToolDeclarations!.Should().HaveCount(2);
+
+        var fileSystem = skill.ToolDeclarations[0];
+        fileSystem.Name.Should().Be("file_system");
+        fileSystem.Operations.Should().Equal("read", "search", "list");
+        fileSystem.Optional.Should().BeFalse();
+        fileSystem.Description.Should().Be("Read and search project files");
+        fileSystem.Fallback.Should().BeNull();
+
+        var github = skill.ToolDeclarations[1];
+        github.Name.Should().Be("github_repos");
+        github.Operations.Should().BeEmpty();
+        github.Optional.Should().BeTrue();
+        github.Fallback.Should().Be("file_system");
+        github.HasFallback.Should().BeTrue();
+        github.FallbackIsManual.Should().BeFalse();
+    }
+
+    /// <summary>
+    /// Block-sequence operations — the style <see cref="Domain.AI.Tools.ToolDeclaration"/>'s own
+    /// documentation advertises. A parser that handled only inline arrays would silently drop
+    /// every operation here, which is the failure mode worth guarding.
+    /// </summary>
+    [Fact]
+    public void ParseFromFile_BlockSequenceOperations_ParsesEachOperation()
+    {
+        var content = """
+            ---
+            name: "sprint-planner"
+            description: "Plans sprints"
+            tools:
+              - name: azure_devops_work_items
+                operations:
+                  - create_sprint
+                  - create_work_item
+                fallback: jira_issues
+                optional: true
+            ---
+            Body.
+            """;
+
+        var skill = _sut.ParseFromFile(WriteSkillFile(content), _tempDir);
+
+        skill.ToolDeclarations.Should().ContainSingle();
+        var declaration = skill.ToolDeclarations![0];
+        declaration.Name.Should().Be("azure_devops_work_items");
+        declaration.Operations.Should().Equal("create_sprint", "create_work_item");
+        declaration.HasOperations.Should().BeTrue();
+        declaration.Fallback.Should().Be("jira_issues");
+        declaration.Optional.Should().BeTrue();
+    }
+
+    /// <summary>
+    /// A declaration with no <c>optional</c> key is REQUIRED. This is load-bearing:
+    /// <c>ToolChainBuilder</c> throws when a required declaration cannot be resolved, so a
+    /// parser that defaulted to optional would turn a hard configuration error into silence.
+    /// </summary>
+    [Fact]
+    public void ParseFromFile_OptionalFlagAbsent_DeclarationIsRequired()
+    {
+        var content = """
+            ---
+            name: "orchestrator-agent"
+            description: "Delegates work"
+            tools:
+              - name: "delegate_task"
+                description: "Delegate a subtask to a sub-agent."
+            ---
+            Body.
+            """;
+
+        var skill = _sut.ParseFromFile(WriteSkillFile(content), _tempDir);
+
+        skill.ToolDeclarations.Should().ContainSingle();
+        skill.ToolDeclarations![0].Optional.Should().BeFalse();
+    }
+
+    /// <summary>
+    /// <c>fallback: manual</c> means "a human does it" rather than "substitute another tool",
+    /// and <c>ToolChainBuilder</c> treats it as satisfying a required declaration.
+    /// </summary>
+    [Fact]
+    public void ParseFromFile_ManualFallback_IsRecognisedAsManual()
+    {
+        var content = """
+            ---
+            name: "deployer"
+            description: "Deploys"
+            tools:
+              - name: "deploy_execute"
+                fallback: "manual"
+                condition: "only when the release gate has passed"
+            ---
+            Body.
+            """;
+
+        var skill = _sut.ParseFromFile(WriteSkillFile(content), _tempDir);
+
+        var declaration = skill.ToolDeclarations.Should().ContainSingle().Subject;
+        declaration.FallbackIsManual.Should().BeTrue();
+        declaration.Condition.Should().Be("only when the release gate has passed");
+    }
+
+    /// <summary>
+    /// No <c>tools:</c> key must leave the collection null rather than empty. The distinction
+    /// matters because <see cref="SkillDefinition.Mode"/> reads
+    /// <see cref="SkillDefinition.HasToolDeclarations"/> to decide whether a plugin skill
+    /// receives injected tools.
+    /// </summary>
+    [Fact]
+    public void ParseFromFile_NoToolsBlock_LeavesDeclarationsNull()
+    {
+        var content = """
+            ---
+            name: "plain"
+            description: "No tools declared"
+            tags: ["a", "b"]
+            ---
+            Body.
+            """;
+
+        var skill = _sut.ParseFromFile(WriteSkillFile(content), _tempDir);
+
+        skill.ToolDeclarations.Should().BeNull();
+        skill.HasToolDeclarations.Should().BeFalse();
+    }
+
+    /// <summary>
+    /// The tools block must terminate at the next top-level key and must not consume the
+    /// sibling blocks around it — <c>allowed-tools</c> above it and <c>egress</c> below it are
+    /// parsed by separate code paths over the same text.
+    /// </summary>
+    [Fact]
+    public void ParseFromFile_ToolsBlockBetweenSiblings_DoesNotConsumeThem()
+    {
+        var content = """
+            ---
+            name: "workspace"
+            description: "Sandbox workspace"
+            allowed-tools: ["read_file", "write_file"]
+            tools:
+              - name: "read_file"
+                operations: ["read"]
+                optional: false
+                description: "Read a file from the working copy."
+              - name: "write_file"
+                operations: ["submit"]
+                optional: false
+                description: "Submit a ChangeProposal."
+            egress:
+              allowlist:
+                - host: "api.github.com"
+                  schemes: ["https"]
+                  ports: [443]
+            ---
+            Body.
+            """;
+
+        var skill = _sut.ParseFromFile(WriteSkillFile(content), _tempDir);
+
+        skill.AllowedTools.Should().Equal("read_file", "write_file");
+        skill.ToolDeclarations.Should().HaveCount(2);
+        skill.ToolDeclarations![1].Description.Should().Be("Submit a ChangeProposal.");
+        skill.Egress.Should().NotBeNull();
+        skill.Egress!.Allowlist.Should().ContainSingle()
+            .Which.Host.Should().Be("api.github.com");
+    }
+
+    /// <summary>
+    /// A tool declaration's own <c>description</c> sits indented inside the block and must not
+    /// be mistaken for the skill's top-level description.
+    /// </summary>
+    [Fact]
+    public void ParseFromFile_DeclarationDescription_DoesNotOverwriteSkillDescription()
+    {
+        var content = """
+            ---
+            name: "workspace"
+            description: "The skill description"
+            tools:
+              - name: "read_file"
+                description: "The tool description"
+            ---
+            Body.
+            """;
+
+        var skill = _sut.ParseFromFile(WriteSkillFile(content), _tempDir);
+
+        skill.Description.Should().Be("The skill description");
+        skill.ToolDeclarations![0].Description.Should().Be("The tool description");
+    }
+
+    /// <summary>
+    /// A plugin skill that declares tools but no <c>allowed-tools</c> must resolve as Managed,
+    /// not Injected. Before #222 its declarations were invisible, so it collapsed to Injected
+    /// and received every available MCP tool — the opposite of what the manifest asked for.
+    /// </summary>
+    [Fact]
+    public void ParseFromFile_PluginSkillWithOnlyToolDeclarations_ResolvesAsManaged()
+    {
+        var content = """
+            ---
+            name: "iac-authoring"
+            description: "Authors infrastructure as code"
+            tools:
+              - name: "iac_generate"
+                operations: ["generate"]
+                optional: false
+            ---
+            Body.
+            """;
+
+        var skill = _sut.ParseFromFile(WriteSkillFile(content), _tempDir, pluginSource: "iac-skill");
+
+        skill.IsPluginSkill.Should().BeTrue();
+        skill.HasToolRestrictions.Should().BeFalse();
+        skill.Mode.Should().Be(SkillMode.Managed);
+    }
+
+    /// <summary>
+    /// The framework-loader entry point reads the same frontmatter from disk and must agree
+    /// with <c>ParseFromFile</c>. Both overloads are public API; a fix applied to only one
+    /// leaves the defect waiting for whoever wires the other.
+    /// </summary>
+    [Fact]
+    public void Parse_ToolsBlock_PopulatesDeclarationsIdenticallyToParseFromFile()
+    {
+        var content = """
+            ---
+            name: "research-agent"
+            description: "Finds information"
+            tools:
+              - name: "file_system"
+                operations: ["read", "search"]
+                optional: false
+            ---
+            Body.
+            """;
+
+        WriteSkillFile(content);
+
+        var skill = _sut.Parse("research-agent", "Finds information", "Body.", _tempDir);
+
+        skill.ToolDeclarations.Should().ContainSingle();
+        skill.ToolDeclarations![0].Name.Should().Be("file_system");
+        skill.ToolDeclarations[0].Operations.Should().Equal("read", "search");
+    }
+
+    /// <summary>
+    /// Windows checkouts store SKILL.md with CRLF endings — every shipped manifest in this repo
+    /// is CRLF on disk. The frontmatter is split on '\n', so without normalisation a blank line
+    /// arrives as "\r": it has no leading whitespace, which reads as "the block ended" and
+    /// silently truncates the declarations from that point on.
+    /// </summary>
+    [Fact]
+    public void ParseFromFile_CrlfManifestWithBlankLines_ParsesEveryDeclaration()
+    {
+        var content = string.Join("\r\n",
+            "---",
+            "name: \"workspace\"",
+            "description: \"Sandbox workspace\"",
+            "",
+            "tools:",
+            "  - name: \"read_file\"",
+            "    operations: [\"read\"]",
+            "    optional: false",
+            "",
+            "  - name: \"write_file\"",
+            "    operations: [\"submit\"]",
+            "    optional: false",
+            "---",
+            "Body.");
+
+        var skill = _sut.ParseFromFile(WriteSkillFile(content), _tempDir);
+
+        skill.ToolDeclarations.Should().HaveCount(2);
+        skill.ToolDeclarations![0].Operations.Should().Equal("read");
+        skill.ToolDeclarations[1].Name.Should().Be("write_file");
+    }
+
+    /// <summary>
+    /// A line of spaces has a leading-space count, so an indent-sensitive parser that does not
+    /// treat it as blank reads it as a real indent level and ends the block at that point.
+    /// Editors leave these behind routinely.
+    /// </summary>
+    [Fact]
+    public void ParseFromFile_WhitespaceOnlyLineInsideBlock_DoesNotTruncateDeclarations()
+    {
+        var content = string.Join("\n",
+            "---",
+            "name: \"workspace\"",
+            "description: \"Sandbox workspace\"",
+            "tools:",
+            "  - name: \"read_file\"",
+            "    operations: [\"read\"]",
+            "    ",
+            "  - name: \"write_file\"",
+            "    operations: [\"submit\"]",
+            "---",
+            "Body.");
+
+        var skill = _sut.ParseFromFile(WriteSkillFile(content), _tempDir);
+
+        skill.ToolDeclarations.Should().HaveCount(2);
+        skill.ToolDeclarations![1].Name.Should().Be("write_file");
+    }
+
+    /// <summary>
+    /// Parses the manifest this repository actually ships, straight from disk, rather than a
+    /// fixture written by the test. A hand-rolled parser proven only against hand-written LF
+    /// fixtures is proven against the wrong artefact.
+    /// </summary>
+    [Fact]
+    public void ParseFromFile_ShippedWorkspacePluginManifest_ParsesAllFiveDeclarations()
+    {
+        var manifest = Path.Combine(
+            RepositoryRoot(), "plugins", "workspace-skill", "skills", "workspace", "SKILL.md");
+
+        File.Exists(manifest).Should().BeTrue($"the shipped manifest should exist at {manifest}");
+
+        var skill = _sut.ParseFromFile(manifest, Path.GetDirectoryName(manifest)!);
+
+        skill.ToolDeclarations.Should().HaveCount(5);
+        skill.ToolDeclarations!.Select(d => d.Name).Should()
+            .Equal("read_file", "write_file", "list_files", "run_tests", "run_lint");
+        skill.ToolDeclarations.Should().OnlyContain(d => !d.Optional);
+        skill.ToolDeclarations[0].Operations.Should().Equal("read");
+        skill.ToolDeclarations[0].Description.Should()
+            .Be("Read a file from the sandbox-injected working-copy path.");
+    }
+
+    private static string RepositoryRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !Directory.Exists(Path.Combine(dir.FullName, ".git")))
+            dir = dir.Parent;
+
+        return dir?.FullName
+            ?? throw new InvalidOperationException("Could not locate the repository root from the test output directory.");
+    }
+
+    /// <summary>
+    /// A malformed entry with no recognisable key is skipped rather than producing a
+    /// nameless declaration — a declaration with an empty name would fail tool resolution
+    /// with a confusing message far from the manifest that caused it.
+    /// </summary>
+    [Fact]
+    public void ParseFromFile_EntryWithoutName_IsSkipped()
+    {
+        var content = """
+            ---
+            name: "sloppy"
+            description: "Has a malformed entry"
+            tools:
+              - operations: ["read"]
+              - name: "file_system"
+                operations: ["read"]
+            ---
+            Body.
+            """;
+
+        var skill = _sut.ParseFromFile(WriteSkillFile(content), _tempDir);
+
+        skill.ToolDeclarations.Should().ContainSingle();
+        skill.ToolDeclarations![0].Name.Should().Be("file_system");
+    }
+}

--- a/src/Content/Tests/Presentation.ExecutionApi.Tests/IsolatedStateRoot.cs
+++ b/src/Content/Tests/Presentation.ExecutionApi.Tests/IsolatedStateRoot.cs
@@ -1,0 +1,69 @@
+using System.Runtime.CompilerServices;
+
+namespace Presentation.ExecutionApi.Tests;
+
+/// <summary>
+/// Gives this assembly's test run its own on-disk state, so nothing survives from the last run.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Issue #250. The hosts these tests boot persist to SQLite paths that resolve against the build
+/// output directory, and nothing reset them between runs. State therefore accumulated across every
+/// run a developer had ever done on that machine — the planner database here had reached 540 KB and
+/// grew by roughly 57 KB per run. CI never saw it, because CI always starts from a clean checkout,
+/// which is exactly why it survived. The failure it eventually produces presents as bad requests
+/// from the API, so anyone reading the test output alone goes looking in the product.
+/// </para>
+/// <para>
+/// The redirection happens through ENVIRONMENT VARIABLES rather than per-test configuration for the
+/// reason already recorded in <c>AssemblyInfo.cs</c>: they are the only source that both outranks
+/// appsettings.json and is visible to the eager <c>builder.Configuration</c> read inside
+/// <c>AddExecutionApiServices</c>. Doing it in a module initializer covers all sixteen host
+/// constructions in this assembly at once, and — unlike a per-class fixture — cannot be missed by
+/// the next test class someone adds.
+/// </para>
+/// <para>
+/// Governance durable state is deliberately NOT redirected: <c>GovernanceStatePaths.Resolve</c>
+/// confines that database to the application directory by design and throws for a path outside it.
+/// </para>
+/// </remarks>
+internal static class IsolatedStateRoot
+{
+    [ModuleInitializer]
+    internal static void Redirect()
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"execapi-tests-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(root);
+
+        // Absolute paths survive the hosts' Path.Combine(AppContext.BaseDirectory, configured)
+        // unchanged, which is what moves the file out of the build output.
+        Environment.SetEnvironmentVariable(
+            "AppConfig__AI__Planner__DatabasePath", Path.Combine(root, "planner.db"));
+        Environment.SetEnvironmentVariable(
+            "AppConfig__AI__Conversations__DatabasePath", Path.Combine(root, "conversations.db"));
+        Environment.SetEnvironmentVariable(
+            "AppConfig__AI__Rag__GraphDatabase__DataDirectory", Path.Combine(root, "graph"));
+
+        AppDomain.CurrentDomain.ProcessExit += (_, _) => TryDelete(root);
+    }
+
+    /// <summary>
+    /// Best-effort cleanup. A SQLite handle the host has not finished releasing can still hold the
+    /// file at process exit; leaving a temp directory behind is a far smaller problem than failing
+    /// the run over it, and the per-run name means the next run is unaffected either way.
+    /// </summary>
+    private static void TryDelete(string root)
+    {
+        try
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, recursive: true);
+        }
+        catch (IOException)
+        {
+        }
+        catch (UnauthorizedAccessException)
+        {
+        }
+    }
+}

--- a/src/Content/Tests/Presentation.ExecutionApi.Tests/IsolatedStateRoot.cs
+++ b/src/Content/Tests/Presentation.ExecutionApi.Tests/IsolatedStateRoot.cs
@@ -29,10 +29,14 @@ namespace Presentation.ExecutionApi.Tests;
 /// </remarks>
 internal static class IsolatedStateRoot
 {
+    private const string RootPrefix = "execapi-tests-";
+
     [ModuleInitializer]
     internal static void Redirect()
     {
-        var root = Path.Combine(Path.GetTempPath(), $"execapi-tests-{Guid.NewGuid():N}");
+        SweepAbandonedRoots();
+
+        var root = Path.Combine(Path.GetTempPath(), $"{RootPrefix}{Guid.NewGuid():N}");
         Directory.CreateDirectory(root);
 
         // Absolute paths survive the hosts' Path.Combine(AppContext.BaseDirectory, configured)
@@ -45,6 +49,31 @@ internal static class IsolatedStateRoot
             "AppConfig__AI__Rag__GraphDatabase__DataDirectory", Path.Combine(root, "graph"));
 
         AppDomain.CurrentDomain.ProcessExit += (_, _) => TryDelete(root);
+    }
+
+    /// <summary>
+    /// Removes roots left by earlier runs that never reached their process-exit cleanup — a run
+    /// killed from the IDE, or one whose SQLite handles were still open. Without this, moving the
+    /// state out of the build output would just relocate the accumulation to the temp directory.
+    /// A day's grace keeps it clear of any run still in flight on the same machine.
+    /// </summary>
+    private static void SweepAbandonedRoots()
+    {
+        try
+        {
+            var cutoff = DateTime.UtcNow.AddDays(-1);
+            foreach (var stale in Directory.EnumerateDirectories(Path.GetTempPath(), $"{RootPrefix}*"))
+            {
+                if (Directory.GetCreationTimeUtc(stale) < cutoff)
+                    TryDelete(stale);
+            }
+        }
+        catch (IOException)
+        {
+        }
+        catch (UnauthorizedAccessException)
+        {
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
Closes #222, closes #244, closes #250.

## What was broken

**#222 — tools declared in a SKILL.md were silently ignored.** Every shipped skill manifest declares a structured `tools:` block, and the parser had no path for it. Four consumers — tool-chain resolution, prerequisite mapping, and both permission-rule providers — read an empty list, so declared operations, optional flags and fallbacks reached nothing. Not a regression: no commit in the repo's history ever populated it.

**#244 — a slow memory leak.** The harness candidate repository kept one lock per optimization run in a dictionary nothing removed from. Singleton, per-run GUID key, so a long-lived host grew by one entry per run forever.

**#250 — the Execution API test suite wrote to a database that was never reset.** State accumulated across every local run; past some point it produces bad-request failures that look exactly like a product regression. CI never saw it because CI starts clean.

## Deciding #222's direction

The issue left an explicit design question — fill the parser gap, or delete `tools:` from the manifests as redundant documentation. Evidence for filling it:

- `allowed-tools` is a flat name list. It cannot express `optional`, `fallback`, or `operations`.
- `ToolChainBuilder` has a **live** required-tool enforcement path keyed on exactly those fields — it throws when a required declaration cannot be resolved.

Both of the issue's other open questions are answered: the block was never parsed (`git log -S` over Application + Infrastructure returns nothing), and no skill's resolution mode changes, because every plugin skill declaring `tools:` also declares `allowed-tools`.

Before enabling it, all 16 required declared tool names across the shipped manifests were checked against the literal `ToolName` constants of the registered keyed tools. All 16 resolve, so nothing newly throws.

## A defect the review caught

The first version of the parser judged a line blank by length alone. Every SKILL.md in this repo is **CRLF** on disk, so a blank line arrives as `"\r"` — no leading whitespace, which the indent-sensitive block parsers read as "the block ended". Declarations after a blank line were silently dropped.

The same defect was latent in the **egress allowlist** parser, where truncation silently narrows a security control. Both are fixed by normalising line endings once at the frontmatter boundary, plus a shared blank-line test.

Worth recording: the first test written for the egress case **passed against the unfixed parser** — a whitespace-only line between entries is indented deeper than the item level and is harmlessly ignored. Only a whitespace line *before the first entry* decides the block. The test was corrected until it failed without the fix.

## Verification

- Build: 0 errors, 0 new warnings.
- Full suite: **2782 passed, 4 failed.** All four are the known writable-TEMP `FileSystemService` failures, which fail **identically on unmodified `main`** — measured as the control, not assumed.
- #244: eviction tests fail when eviction is removed; the concurrency tests fail when the lock is widened, so they catch lost serialisation rather than only counting entries.
- #250: two consecutive full runs pass and the build output regains no database files.

## Known gaps, stated rather than hidden

- `SkillDefinition.Tools` (also named in #222) holds pre-created `AITool` instances and **cannot** be built from markdown. `SkillDefinition.Mode` still cannot be computed from every input its documentation lists.
- The unreserve-on-cancel branch in #244 has **no test**. Making the wait lose a race deterministically needs a stalled writer, and the only seam couples the test to which calls sit inside the critical section. A test that cannot fail is not evidence, so none was written.
- #250's sibling traps were checked: the writable-TEMP one is real and reproduced; both it and the Docker-down trap are environment faults, not code defects.

## Deliberately not done

- **Striped lock array** instead of reference-counted eviction — simpler in isolation, but #244 prescribes the eviction pattern and the adjacent `InProcessConversationTurnLease` already implements it with measured invariants.
- **Extracting a shared block-sequence reader** across the egress and tools parsers — real duplication, but it rewrites a security control this branch was not asked to touch. Worth filing separately, along with the observation that YamlDotNet is already referenced in the repo and would replace ~440 lines of hand-rolled parsing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
