### PR TITLE
fix: confine skill file reads to a read-only sandbox (#247)

### DIFF
--- a/documentation/security/05-sandbox-and-execution.html
+++ b/documentation/security/05-sandbox-and-execution.html
@@ -489,6 +489,71 @@ var cmd = $"grep {userInput}";           // a shell now interprets metacharacter
                         </div>
                     </div>
 
+                    <h2 id="file-access">What a skill can read: two file sandboxes, not one</h2>
+                    <p>
+                        File access on the host runs through two separate sandboxes with deliberately different
+                        permissions. They share one implementation of the rules — allow/deny geometry, symlink
+                        resolution, hard-link identity checks — so they cannot drift on what "inside" means, but they
+                        permit different directories and offer different operations.
+                    </p>
+                    <table class="data-table">
+                        <thead>
+                            <tr>
+                                <th>Sandbox</th>
+                                <th>Reachable by</th>
+                                <th>Permits</th>
+                                <th>Operations</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                <td><code>IFileSystemService</code></td>
+                                <td>The model, via the <code>file_system</code> tool</td>
+                                <td><code>AppConfig:Infrastructure:FileSystem:AllowedBasePaths</code>, plus the
+                                    configured logs directory</td>
+                                <td>Read, write, list, search</td>
+                            </tr>
+                            <tr>
+                                <td><code>ISkillFileReader</code></td>
+                                <td>The harness's own skill loader only</td>
+                                <td>The configured skill content roots:
+                                    <code>AppConfig:AI:Skills</code>, <code>AppConfig:AI:Agents</code>, and the bundle
+                                    staging root</td>
+                                <td><strong>Read only</strong> — the interface exposes no write operation</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                    <p>
+                        <strong>The guarantee, stated plainly:</strong> skill loading is confined to
+                        <em>configured paths plus configured skill roots</em>, read-only. Everything a skill can load —
+                        its <code>SKILL.md</code>, and any reference or template file it discloses on demand through
+                        <code>read_skill_resource</code> — must live inside one of those roots. A path outside them is
+                        refused with an error, never silently treated as missing.
+                    </p>
+                    <div class="callout callout-warning">
+                        <div class="callout-title">Why these are not one sandbox</div>
+                        <p>
+                            Merging them is the obvious simplification and it is unsafe. Skill content sits outside the
+                            model's sandbox by default — the shipped configuration allows <code>workspace</code> while
+                            skills live in <code>skills</code> — so unifying them means adding the skill roots to the
+                            allowlist the <code>file_system</code> tool uses. That tool exposes an ungated
+                            <code>write</code>. The model would then be able to rewrite its own <code>SKILL.md</code>
+                            files, including the <code>allowed-tools</code> list that constrains which tools it may
+                            call. Two narrow sandboxes over one shared rulebook avoids that; a regression test
+                            (<code>ModelFileSandbox_DoesNotCoverSkillRoots_SoSkillsCannotBeRewritten</code>) fails if
+                            the two allowlists are ever merged.
+                        </p>
+                    </div>
+                    <p>
+                        The skill sandbox resolves its permitted roots from live configuration rather than snapshotting
+                        them at startup. Plugin-supplied skill directories are registered during host start, after the
+                        dependency container is built; a snapshot taken at registration time would refuse exactly the
+                        plugin skills the harness advertises support for. A plugin cannot widen the sandbox arbitrarily
+                        — its skill directory is accepted only after being verified as contained within the plugin's own
+                        directory, and that directory comes from operator configuration under
+                        <code>AppConfig:AI:Plugins:Packages</code>.
+                    </p>
+
                     <h2 id="forward">Where the network side lives</h2>
                     <p>
                         This layer contains what a tool can <em>do on the host</em>: how much it can consume, what it can

--- a/documentation/security/05-sandbox-and-execution.html
+++ b/documentation/security/05-sandbox-and-execution.html
@@ -524,11 +524,19 @@ var cmd = $"grep {userInput}";           // a shell now interprets metacharacter
                         </tbody>
                     </table>
                     <p>
-                        <strong>The guarantee, stated plainly:</strong> skill loading is confined to
-                        <em>configured paths plus configured skill roots</em>, read-only. Everything a skill can load —
-                        its <code>SKILL.md</code>, and any reference or template file it discloses on demand through
-                        <code>read_skill_resource</code> — must live inside one of those roots. A path outside them is
-                        refused with an error, never silently treated as missing.
+                        <strong>The guarantee, stated plainly:</strong> skill loading is confined to the
+                        <em>configured skill content roots</em>, read-only — and to nothing in the model's own file
+                        allowlist. Everything a skill can load — its <code>SKILL.md</code>, and any reference or
+                        template file it discloses on demand through <code>read_skill_resource</code> — must live
+                        inside one of those roots. A path outside them is refused with an error, never silently
+                        treated as missing: a refusal that read as "this directory holds no skills" would be
+                        indistinguishable from a directory that genuinely holds none, so a misconfigured root would
+                        boot an agent quietly missing its skills instead of failing.
+                    </p>
+                    <p>
+                        The two allowlists are disjoint by design, so the guarantee is <em>not</em> the union of the
+                        two — the model's file tool gains nothing from the skill roots, and skill loading gains
+                        nothing from the model's configured paths.
                     </p>
                     <div class="callout callout-warning">
                         <div class="callout-title">Why these are not one sandbox</div>

--- a/src/Content/Application/Application.AI.Common/Exceptions/SkillPathRefusedException.cs
+++ b/src/Content/Application/Application.AI.Common/Exceptions/SkillPathRefusedException.cs
@@ -1,0 +1,42 @@
+namespace Application.AI.Common.Exceptions;
+
+/// <summary>
+/// Thrown when a path is refused by the skill sandbox because it lies outside the configured skill
+/// content roots.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Distinct from <see cref="UnauthorizedAccessException"/> on purpose. Skill discovery is
+/// deliberately tolerant — a malformed manifest is skipped so its siblings still load — but that
+/// tolerance must not extend to a sandbox refusal, because an empty result there is
+/// indistinguishable from a directory that genuinely holds no skills, and a misconfigured root would
+/// boot an agent silently missing its own skills.
+/// </para>
+/// <para>
+/// Filtering on <see cref="UnauthorizedAccessException"/> instead would conflate the two cases the
+/// distinction exists to separate: the operating system raises that same type for an ordinary
+/// file-permission denial on a directory that is perfectly inside the sandbox. Treating that as a
+/// refusal would turn a routine ACL problem into a startup abort. Catching this type means "the
+/// sandbox said no", and nothing else.
+/// </para>
+/// </remarks>
+public sealed class SkillPathRefusedException : UnauthorizedAccessException
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SkillPathRefusedException"/> class.
+    /// </summary>
+    /// <param name="message">A description of why the path was refused.</param>
+    public SkillPathRefusedException(string message) : base(message)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SkillPathRefusedException"/> class.
+    /// </summary>
+    /// <param name="message">A description of why the path was refused.</param>
+    /// <param name="innerException">The refusal raised by the underlying sandbox.</param>
+    public SkillPathRefusedException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+}

--- a/src/Content/Application/Application.AI.Common/Factories/AgentExecutionContextFactory.cs
+++ b/src/Content/Application/Application.AI.Common/Factories/AgentExecutionContextFactory.cs
@@ -37,6 +37,7 @@ public class AgentExecutionContextFactory
     private readonly ILoggerFactory _loggerFactory;
     private readonly IToolChainBuilder _toolChainBuilder;
     private readonly ISkillPrerequisiteResolver _prerequisiteResolver;
+    private readonly ISkillFileReader _skillFileReader;
     private readonly IContextBudgetTracker? _budgetTracker;
     private readonly IExecutionTraceStore? _traceStore;
     private readonly IAgentConfigReporter? _agentConfigReporter;
@@ -49,6 +50,7 @@ public class AgentExecutionContextFactory
         ILoggerFactory loggerFactory,
         IToolChainBuilder toolChainBuilder,
         ISkillPrerequisiteResolver prerequisiteResolver,
+        ISkillFileReader skillFileReader,
         IContextBudgetTracker? budgetTracker = null,
         IExecutionTraceStore? traceStore = null,
         IAgentConfigReporter? agentConfigReporter = null,
@@ -60,6 +62,7 @@ public class AgentExecutionContextFactory
         _loggerFactory = loggerFactory;
         _toolChainBuilder = toolChainBuilder;
         _prerequisiteResolver = prerequisiteResolver;
+        _skillFileReader = skillFileReader ?? throw new ArgumentNullException(nameof(skillFileReader));
         _budgetTracker = budgetTracker;
         _traceStore = traceStore;
         _agentConfigReporter = agentConfigReporter;
@@ -100,7 +103,7 @@ public class AgentExecutionContextFactory
         // One list drives two decisions that must never disagree: which skills the framework provider is
         // given, and which skills may therefore omit their body from the static prompt. Because the prompt's
         // decision is read off the very set that gets registered, the two cannot drift apart.
-        var disclosableSkills = DisclosableSkillFactory.Create(skills, _logger);
+        var disclosableSkills = DisclosableSkillFactory.Create(skills, _skillFileReader, _logger);
         var disclosedOnDemand = disclosableSkills
             .Select(s => s.SkillId)
             .ToHashSet(StringComparer.OrdinalIgnoreCase);

--- a/src/Content/Application/Application.AI.Common/Factories/AgentExecutionContextFactory.cs
+++ b/src/Content/Application/Application.AI.Common/Factories/AgentExecutionContextFactory.cs
@@ -56,13 +56,15 @@ public class AgentExecutionContextFactory
         IAgentConfigReporter? agentConfigReporter = null,
         IResilientChatClientProvider? resilientChatClientProvider = null)
     {
+        ArgumentNullException.ThrowIfNull(skillFileReader);
+
         _logger = logger;
         _appConfig = appConfig;
         _serviceProvider = serviceProvider;
         _loggerFactory = loggerFactory;
         _toolChainBuilder = toolChainBuilder;
         _prerequisiteResolver = prerequisiteResolver;
-        _skillFileReader = skillFileReader ?? throw new ArgumentNullException(nameof(skillFileReader));
+        _skillFileReader = skillFileReader;
         _budgetTracker = budgetTracker;
         _traceStore = traceStore;
         _agentConfigReporter = agentConfigReporter;

--- a/src/Content/Application/Application.AI.Common/Helpers/DisclosableSkillFactory.cs
+++ b/src/Content/Application/Application.AI.Common/Helpers/DisclosableSkillFactory.cs
@@ -1,4 +1,4 @@
-using System.Text;
+using Application.AI.Common.Interfaces.Skills;
 using Domain.AI.Skills;
 using Microsoft.Agents.AI;
 using Microsoft.Extensions.Logging;
@@ -41,6 +41,11 @@ public static class DisclosableSkillFactory
     /// Creates a framework skill for each of <paramref name="skills"/> that can back on-demand disclosure.
     /// </summary>
     /// <param name="skills">The skills composing this agent.</param>
+    /// <param name="fileReader">
+    /// Sandboxed, read-only access to skill content. Every resource the model opens through
+    /// <c>read_skill_resource</c> is read through it, so a skill cannot serve a file from outside
+    /// the configured skill roots (issue #247).
+    /// </param>
     /// <param name="logger">Receives a Debug record of each skill that could not be registered, and why.</param>
     /// <returns>
     /// The registrable skills, in input order. A skill is omitted — and so keeps its body in the static
@@ -49,9 +54,11 @@ public static class DisclosableSkillFactory
     /// </returns>
     public static IReadOnlyList<DisclosableSkill> Create(
         IReadOnlyList<SkillDefinition> skills,
+        ISkillFileReader fileReader,
         ILogger logger)
     {
         ArgumentNullException.ThrowIfNull(skills);
+        ArgumentNullException.ThrowIfNull(fileReader);
         ArgumentNullException.ThrowIfNull(logger);
 
         var created = new List<DisclosableSkill>(skills.Count);
@@ -96,7 +103,7 @@ public static class DisclosableSkillFactory
                 continue;
             }
 
-            AddResources(inline, skill);
+            AddResources(inline, skill, fileReader);
             created.Add(new DisclosableSkill(skill.Id, inline));
         }
 
@@ -114,7 +121,7 @@ public static class DisclosableSkillFactory
     /// registered — the harness runs skill scripts through its own sandboxed tool chain, not through the
     /// framework's runner.
     /// </remarks>
-    private static void AddResources(AgentInlineSkill inline, SkillDefinition skill)
+    private static void AddResources(AgentInlineSkill inline, SkillDefinition skill, ISkillFileReader fileReader)
     {
         var claimed = new HashSet<string>(StringComparer.Ordinal);
 
@@ -133,18 +140,12 @@ public static class DisclosableSkillFactory
             // by the skill, which is held by the provider, which is attached to an agent cached on a
             // sliding expiry. Closing over `resource` instead would pin every SkillResource (and the
             // Content each caches once read) for that whole lifetime; closing over one string does not.
+            // The read goes through the sandboxed reader rather than System.IO: this callback is
+            // invoked when the MODEL asks for a resource, so an unguarded read here would serve the
+            // model any file a skill's manifest happened to name. Closing over the reader is free —
+            // it is a singleton, unlike the resource whose pinning the hoisted path avoids.
             var path = resource.FilePath;
-            inline.AddResource(name, () => ReadResourceAsync(path));
+            inline.AddResource(name, () => fileReader.ReadTextAsync(path));
         }
     }
-
-    /// <summary>
-    /// Reads a resource file as UTF-8, matching how the framework's own file-backed resources are read.
-    /// </summary>
-    /// <remarks>
-    /// Returns the task directly rather than awaiting it — nothing follows the read, so an async state
-    /// machine would be pure overhead on every resource the model opens.
-    /// </remarks>
-    private static Task<string> ReadResourceAsync(string path) =>
-        File.ReadAllTextAsync(path, Encoding.UTF8);
 }

--- a/src/Content/Application/Application.AI.Common/Interfaces/Skills/ISkillFileReader.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Skills/ISkillFileReader.cs
@@ -1,0 +1,95 @@
+namespace Application.AI.Common.Interfaces.Skills;
+
+/// <summary>
+/// Sandboxed, <b>read-only</b> access to skill content on disk: <c>SKILL.md</c> manifests, the
+/// directories they are discovered in, and the supporting files a skill discloses on demand.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Why this exists rather than reusing <c>IFileSystemService</c>.</b> Skill content lives outside
+/// the model's file sandbox by default — the shipped configuration allows <c>workspace</c> while
+/// skills live in <c>skills</c> — so routing skill loading through that service would have required
+/// adding the skill roots to it. That service can write, and the model reaches it through the
+/// <c>file_system</c> tool with no approval gate on writes, so the widening would have handed the
+/// model the ability to rewrite its own <c>SKILL.md</c> files, including the <c>allowed-tools</c>
+/// list that constrains which tools it may call. This interface closes the original bypass — skill
+/// reads that went straight to <c>System.IO</c> and were confined by nothing — without opening that
+/// one (issue #247).
+/// </para>
+/// <para>
+/// <b>The guarantee.</b> Every path handed to an implementation is confined to the configured skill
+/// content roots: <c>AppConfig:AI:Skills</c>, <c>AppConfig:AI:Agents</c> (agent-owned skills live in
+/// <c>&lt;agentDir&gt;/skills</c>), and the bundle staging root. The set is resolved <em>live</em>
+/// rather than snapshotted at startup, because plugin-supplied skill directories are appended to the
+/// skill configuration by <c>PluginStartupLoader</c> after the container is built — a snapshot taken
+/// at registration time would refuse exactly the plugin skills the harness advertises support for.
+/// </para>
+/// <para>
+/// <b>Refusals are loud.</b> A path outside the roots throws <see cref="UnauthorizedAccessException"/>
+/// from every member, including the existence probes. Returning <see langword="false"/> for a refused
+/// path would let a misconfigured root read as "this skill has no manifest", turning a security
+/// refusal into a silently empty skill set.
+/// </para>
+/// </remarks>
+public interface ISkillFileReader
+{
+    /// <summary>
+    /// Reads a skill file as UTF-8 text.
+    /// </summary>
+    /// <remarks>
+    /// Synchronous because skill discovery is a synchronous, cache-filling startup walk
+    /// (<c>ISkillMetadataRegistry</c> exposes a synchronous surface to every consumer). Use
+    /// <see cref="ReadTextAsync"/> on the per-turn disclosure path instead.
+    /// </remarks>
+    /// <param name="path">An absolute path inside a configured skill content root.</param>
+    /// <returns>The file's contents.</returns>
+    /// <exception cref="UnauthorizedAccessException">The path is outside the skill content roots.</exception>
+    /// <exception cref="FileNotFoundException">The path is permitted but names no file.</exception>
+    /// <exception cref="IOException">The file exceeds the read size limit.</exception>
+    string ReadText(string path);
+
+    /// <summary>
+    /// Reads a skill file as UTF-8 text, asynchronously.
+    /// </summary>
+    /// <remarks>
+    /// Used for on-demand resource disclosure, which the agent framework invokes per turn as a
+    /// deferred <c>Func&lt;Task&lt;string&gt;&gt;</c> while the model is waiting.
+    /// </remarks>
+    /// <param name="path">An absolute path inside a configured skill content root.</param>
+    /// <param name="cancellationToken">Token to observe while reading.</param>
+    /// <returns>The file's contents.</returns>
+    /// <exception cref="UnauthorizedAccessException">The path is outside the skill content roots.</exception>
+    /// <exception cref="FileNotFoundException">The path is permitted but names no file.</exception>
+    /// <exception cref="IOException">The file exceeds the read size limit.</exception>
+    Task<string> ReadTextAsync(string path, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Whether a permitted path names an existing file.
+    /// </summary>
+    /// <param name="path">An absolute path inside a configured skill content root.</param>
+    /// <returns><see langword="true"/> when the file exists.</returns>
+    /// <exception cref="UnauthorizedAccessException">The path is outside the skill content roots.</exception>
+    bool FileExists(string path);
+
+    /// <summary>
+    /// Whether a permitted path names an existing directory.
+    /// </summary>
+    /// <param name="path">An absolute path inside a configured skill content root.</param>
+    /// <returns><see langword="true"/> when the directory exists.</returns>
+    /// <exception cref="UnauthorizedAccessException">The path is outside the skill content roots.</exception>
+    bool DirectoryExists(string path);
+
+    /// <summary>
+    /// Lists the immediate subdirectories of a permitted directory, as absolute paths.
+    /// </summary>
+    /// <remarks>
+    /// Subdirectories that the sandbox refuses — a junction pointing outside the skill roots, for
+    /// example — are omitted rather than returned, so a caller walking the result cannot be led out
+    /// of the sandbox by following one.
+    /// </remarks>
+    /// <param name="path">An absolute path inside a configured skill content root.</param>
+    /// <returns>Absolute paths of the immediate subdirectories, empty when there are none.</returns>
+    /// <exception cref="UnauthorizedAccessException">The path is outside the skill content roots.</exception>
+    /// <exception cref="DirectoryNotFoundException">The path is permitted but names no directory.</exception>
+    IReadOnlyList<string> EnumerateDirectories(string path);
+}

--- a/src/Content/Application/Application.AI.Common/Interfaces/Skills/ISkillFileReader.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Skills/ISkillFileReader.cs
@@ -25,8 +25,12 @@ namespace Application.AI.Common.Interfaces.Skills;
 /// at registration time would refuse exactly the plugin skills the harness advertises support for.
 /// </para>
 /// <para>
-/// <b>Refusals are loud.</b> A path outside the roots throws <see cref="UnauthorizedAccessException"/>
-/// from every member, including the existence probes. Returning <see langword="false"/> for a refused
+/// <b>Refusals are loud.</b> A path outside the roots throws
+/// <see cref="Exceptions.SkillPathRefusedException"/> from every member, including the existence
+/// probes. That type is distinct from a plain <see cref="UnauthorizedAccessException"/> on purpose:
+/// the operating system raises the latter for an ordinary permission denial on a directory that is
+/// legitimately inside the sandbox, and callers must be able to tolerate that while treating a
+/// sandbox refusal as fatal. Returning <see langword="false"/> for a refused
 /// path would let a misconfigured root read as "this skill has no manifest", turning a security
 /// refusal into a silently empty skill set.
 /// </para>
@@ -43,7 +47,11 @@ public interface ISkillFileReader
     /// </remarks>
     /// <param name="path">An absolute path inside a configured skill content root.</param>
     /// <returns>The file's contents.</returns>
-    /// <exception cref="UnauthorizedAccessException">The path is outside the skill content roots.</exception>
+    /// <exception cref="ArgumentException">
+    /// The path is empty, or is rejected by the sandbox's input validation — which refuses
+    /// traversal sequences, so a relative path must be resolved to an absolute one first.
+    /// </exception>
+    /// <exception cref="Exceptions.SkillPathRefusedException">The path is outside the skill content roots.</exception>
     /// <exception cref="FileNotFoundException">The path is permitted but names no file.</exception>
     /// <exception cref="IOException">The file exceeds the read size limit.</exception>
     string ReadText(string path);
@@ -58,7 +66,11 @@ public interface ISkillFileReader
     /// <param name="path">An absolute path inside a configured skill content root.</param>
     /// <param name="cancellationToken">Token to observe while reading.</param>
     /// <returns>The file's contents.</returns>
-    /// <exception cref="UnauthorizedAccessException">The path is outside the skill content roots.</exception>
+    /// <exception cref="ArgumentException">
+    /// The path is empty, or is rejected by the sandbox's input validation — which refuses
+    /// traversal sequences, so a relative path must be resolved to an absolute one first.
+    /// </exception>
+    /// <exception cref="Exceptions.SkillPathRefusedException">The path is outside the skill content roots.</exception>
     /// <exception cref="FileNotFoundException">The path is permitted but names no file.</exception>
     /// <exception cref="IOException">The file exceeds the read size limit.</exception>
     Task<string> ReadTextAsync(string path, CancellationToken cancellationToken = default);
@@ -68,7 +80,11 @@ public interface ISkillFileReader
     /// </summary>
     /// <param name="path">An absolute path inside a configured skill content root.</param>
     /// <returns><see langword="true"/> when the file exists.</returns>
-    /// <exception cref="UnauthorizedAccessException">The path is outside the skill content roots.</exception>
+    /// <exception cref="ArgumentException">
+    /// The path is empty, or is rejected by the sandbox's input validation — which refuses
+    /// traversal sequences, so a relative path must be resolved to an absolute one first.
+    /// </exception>
+    /// <exception cref="Exceptions.SkillPathRefusedException">The path is outside the skill content roots.</exception>
     bool FileExists(string path);
 
     /// <summary>
@@ -76,7 +92,11 @@ public interface ISkillFileReader
     /// </summary>
     /// <param name="path">An absolute path inside a configured skill content root.</param>
     /// <returns><see langword="true"/> when the directory exists.</returns>
-    /// <exception cref="UnauthorizedAccessException">The path is outside the skill content roots.</exception>
+    /// <exception cref="ArgumentException">
+    /// The path is empty, or is rejected by the sandbox's input validation — which refuses
+    /// traversal sequences, so a relative path must be resolved to an absolute one first.
+    /// </exception>
+    /// <exception cref="Exceptions.SkillPathRefusedException">The path is outside the skill content roots.</exception>
     bool DirectoryExists(string path);
 
     /// <summary>
@@ -89,7 +109,11 @@ public interface ISkillFileReader
     /// </remarks>
     /// <param name="path">An absolute path inside a configured skill content root.</param>
     /// <returns>Absolute paths of the immediate subdirectories, empty when there are none.</returns>
-    /// <exception cref="UnauthorizedAccessException">The path is outside the skill content roots.</exception>
+    /// <exception cref="ArgumentException">
+    /// The path is empty, or is rejected by the sandbox's input validation — which refuses
+    /// traversal sequences, so a relative path must be resolved to an absolute one first.
+    /// </exception>
+    /// <exception cref="Exceptions.SkillPathRefusedException">The path is outside the skill content roots.</exception>
     /// <exception cref="DirectoryNotFoundException">The path is permitted but names no directory.</exception>
     IReadOnlyList<string> EnumerateDirectories(string path);
 }

--- a/src/Content/Infrastructure/Infrastructure.AI.MCPServer/Program.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.MCPServer/Program.cs
@@ -1,5 +1,6 @@
 using System.Threading.RateLimiting;
 using Application.AI.Common.Interfaces;
+using Application.AI.Common.Interfaces.Skills;
 using Domain.Common.Config;
 using Infrastructure.AI.MCPServer.Extensions;
 using Infrastructure.AI.Skills;
@@ -47,7 +48,11 @@ public class Program
         // explicitly opted into anonymous serving — regardless of environment.
         builder.Services.AddMcpAuthentication(appConfig);
 
-        // Skill catalog — discovered from the configured skills directory
+        // Skill catalog — discovered from the configured skills directory. This host composes the
+        // skill services itself rather than calling AddAIDependencies, so the read-only skill
+        // sandbox has to be registered here too; without it the parser cannot be constructed and
+        // the server fails at startup (issue #247).
+        builder.Services.AddSingleton<ISkillFileReader, SkillFileReader>();
         builder.Services.AddSingleton<SkillMetadataParser>();
         builder.Services.AddSingleton<ISkillMetadataRegistry, SkillMetadataRegistry>();
 

--- a/src/Content/Infrastructure/Infrastructure.AI.MCPServer/Program.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.MCPServer/Program.cs
@@ -48,13 +48,10 @@ public class Program
         // explicitly opted into anonymous serving — regardless of environment.
         builder.Services.AddMcpAuthentication(appConfig);
 
-        // Skill catalog — discovered from the configured skills directory. This host composes the
-        // skill services itself rather than calling AddAIDependencies, so the read-only skill
-        // sandbox has to be registered here too; without it the parser cannot be constructed and
-        // the server fails at startup (issue #247).
-        builder.Services.AddSingleton<ISkillFileReader, SkillFileReader>();
-        builder.Services.AddSingleton<SkillMetadataParser>();
-        builder.Services.AddSingleton<ISkillMetadataRegistry, SkillMetadataRegistry>();
+        // Skill catalog — discovered from the configured skills directory. This host composes its own
+        // services rather than calling AddAIDependencies, so it registers the discovery trio through
+        // the shared entry point instead of by hand (issue #247).
+        builder.Services.AddSkillDiscovery();
 
         // Rate limiting
         builder.Services.AddRateLimiter(options =>

--- a/src/Content/Infrastructure/Infrastructure.AI/Agents/AgentMetadataRegistry.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Agents/AgentMetadataRegistry.cs
@@ -27,6 +27,7 @@ public sealed class AgentMetadataRegistry : IAgentMetadataRegistry
     private readonly IOptionsMonitor<AppConfig> _appConfig;
     private readonly AgentMetadataParser _parser;
     private readonly SkillMetadataParser _skillParser;
+    private readonly ISkillFileReader _skillFileReader;
     private readonly IAgentOwnedSkillStore _ownedSkills;
 
     private Dictionary<string, AgentDefinition>? _cache;
@@ -38,6 +39,10 @@ public sealed class AgentMetadataRegistry : IAgentMetadataRegistry
     /// <param name="appConfig">Monitor over the live application configuration (agent search paths).</param>
     /// <param name="parser">Parser that reads an <c>AGENT.md</c> file into an <see cref="AgentDefinition"/>.</param>
     /// <param name="skillParser">Parser used to read each agent's own nested <c>SKILL.md</c> files.</param>
+    /// <param name="skillFileReader">
+    /// Sandboxed, read-only access to skill content, confining the nested-skill scan to the
+    /// configured skill and agent roots (issue #247).
+    /// </param>
     /// <param name="ownedSkills">
     /// Store populated during discovery with the skills found under each agent's
     /// <c>&lt;agentDir&gt;/skills/</c> directory, so <c>AgentFactory</c> can resolve them ahead of the
@@ -48,12 +53,16 @@ public sealed class AgentMetadataRegistry : IAgentMetadataRegistry
         IOptionsMonitor<AppConfig> appConfig,
         AgentMetadataParser parser,
         SkillMetadataParser skillParser,
+        ISkillFileReader skillFileReader,
         IAgentOwnedSkillStore ownedSkills)
     {
+        ArgumentNullException.ThrowIfNull(skillFileReader);
+
         _logger = logger;
         _appConfig = appConfig;
         _parser = parser;
         _skillParser = skillParser;
+        _skillFileReader = skillFileReader;
         _ownedSkills = ownedSkills;
     }
 
@@ -219,7 +228,7 @@ public sealed class AgentMetadataRegistry : IAgentMetadataRegistry
     private void DiscoverAgentOwnedSkills(string agentDirectory, string agentId)
     {
         var skillsRoot = Path.Combine(agentDirectory, "skills");
-        foreach (var skill in NestedSkillScanner.Scan(skillsRoot, _skillParser, _logger))
+        foreach (var skill in NestedSkillScanner.Scan(skillsRoot, _skillParser, _skillFileReader, _logger))
         {
             _ownedSkills.Register(agentId, skill);
             _logger.LogDebug(

--- a/src/Content/Infrastructure/Infrastructure.AI/Bundles/BundleStagingService.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Bundles/BundleStagingService.cs
@@ -148,19 +148,10 @@ public sealed class BundleStagingService : IBundleStagingService
         }
     }
 
-    private static string ResolveStagingRoot(BundleExecutionConfig cfg) =>
+    private string ResolveStagingRoot(BundleExecutionConfig cfg) =>
         string.IsNullOrWhiteSpace(cfg.TempRoot)
-            ? Path.Combine(Path.GetTempPath(), "agent-bundles")
-            : ResolveConfiguredPath(cfg.TempRoot);
-
-    /// <summary>
-    /// Resolves a configured path to an absolute one, relative paths being taken against
-    /// <see cref="AppContext.BaseDirectory"/> (the bin folder) to match the registries. Used for both the
-    /// staging root and the discovery roots so the disjointness guard compares like against like — a
-    /// difference here could let an overlapping root slip past.
-    /// </summary>
-    private static string ResolveConfiguredPath(string path) =>
-        Path.IsPathRooted(path) ? path : Path.GetFullPath(path, AppContext.BaseDirectory);
+            ? SkillContentRoots.BundleStaging(_appConfig.CurrentValue)
+            : SkillContentRoots.Resolve(cfg.TempRoot);
 
     /// <summary>
     /// Rejects a staging root that overlaps any configured skill or agent discovery root. The global
@@ -189,12 +180,8 @@ public sealed class BundleStagingService : IBundleStagingService
         return Result.Success();
     }
 
-    private IEnumerable<string> ConfiguredDiscoveryRoots()
-    {
-        var ai = _appConfig.CurrentValue.AI;
-        foreach (var p in ai.Skills.AllPaths.Concat(ai.Agents.AllPaths))
-            yield return ResolveConfiguredPath(p);
-    }
+    private IEnumerable<string> ConfiguredDiscoveryRoots() =>
+        SkillContentRoots.Discovery(_appConfig.CurrentValue);
 
     private async Task<Result<BufferedArchive>> BufferArchiveAsync(
         Stream archive, BundleExecutionConfig cfg, CancellationToken cancellationToken)

--- a/src/Content/Infrastructure/Infrastructure.AI/Bundles/BundleStagingService.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Bundles/BundleStagingService.cs
@@ -1,6 +1,7 @@
 using System.IO.Compression;
 using Application.AI.Common.Interfaces.Bundles;
 using Application.AI.Common.Interfaces.Plugins;
+using Application.AI.Common.Interfaces.Skills;
 using Domain.AI.Bundles;
 using Domain.AI.Skills;
 using Domain.Common;
@@ -41,20 +42,35 @@ public sealed class BundleStagingService : IBundleStagingService
     private readonly IOptionsMonitor<AppConfig> _appConfig;
     private readonly AgentMetadataParser _agentParser;
     private readonly SkillMetadataParser _skillParser;
+    private readonly ISkillFileReader _skillFileReader;
     private readonly IPluginManifestReader _pluginReader;
     private readonly ILogger<BundleStagingService> _logger;
 
     /// <summary>Initialises the staging service with its parsers, configuration, and logger.</summary>
+    /// <param name="appConfig">Monitor over the live application configuration.</param>
+    /// <param name="agentParser">Parser that reads a staged bundle's <c>AGENT.md</c>.</param>
+    /// <param name="skillParser">Parser that reads each of a staged bundle's <c>SKILL.md</c> files.</param>
+    /// <param name="skillFileReader">
+    /// Sandboxed, read-only access to skill content. The staging root is one of its permitted roots,
+    /// so a staged bundle's own skills remain readable while the scan cannot reach outside it
+    /// (issue #247).
+    /// </param>
+    /// <param name="pluginReader">Reader for a staged bundle's plugin manifest.</param>
+    /// <param name="logger">Logger for staging diagnostics.</param>
     public BundleStagingService(
         IOptionsMonitor<AppConfig> appConfig,
         AgentMetadataParser agentParser,
         SkillMetadataParser skillParser,
+        ISkillFileReader skillFileReader,
         IPluginManifestReader pluginReader,
         ILogger<BundleStagingService> logger)
     {
+        ArgumentNullException.ThrowIfNull(skillFileReader);
+
         _appConfig = appConfig;
         _agentParser = agentParser;
         _skillParser = skillParser;
+        _skillFileReader = skillFileReader;
         _pluginReader = pluginReader;
         _logger = logger;
     }
@@ -365,7 +381,8 @@ public sealed class BundleStagingService : IBundleStagingService
         // Reuses the same nested-skill discovery a host agent uses for its own <agentDir>/skills/, so a
         // malformed SKILL.md is skipped-and-warned rather than aborting the whole bundle. This layer only
         // adds bundle-specific de-duplication (keep first) on top of the shared scan.
-        var scanned = NestedSkillScanner.Scan(Path.Combine(bundleDir, "skills"), _skillParser, _logger);
+        var scanned = NestedSkillScanner.Scan(
+            Path.Combine(bundleDir, "skills"), _skillParser, _skillFileReader, _logger);
 
         var byId = new Dictionary<string, SkillDefinition>(StringComparer.OrdinalIgnoreCase);
         foreach (var skill in scanned)

--- a/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.cs
@@ -168,17 +168,9 @@ public static partial class DependencyInjection
 
         // --- Skills and agents ---
 
-        // Read-only sandbox over skill content, DELIBERATELY SEPARATE from IFileSystemService.
-        // That service is what the model reaches through the file_system tool and it can write, so
-        // adding the skill roots to its allowlist — the obvious way to route skill loading through
-        // a sandbox — would have let the model rewrite its own SKILL.md files, allowed-tools list
-        // included. Two narrow sandboxes over one shared rulebook (SandboxedPathGuard) instead.
-        // Resolves its roots from live config on each call so plugin skill directories, appended by
-        // PluginStartupLoader after the container is built, are covered. See issue #247.
-        services.AddSingleton<ISkillFileReader, SkillFileReader>();
-
-        services.AddSingleton<SkillMetadataParser>();
-        services.AddSingleton<ISkillMetadataRegistry, SkillMetadataRegistry>();
+        // Reader + parser + registry as one unit — see AddSkillDiscovery for why they must not be
+        // registered piecemeal, and why the reader is a separate sandbox from IFileSystemService.
+        services.AddSkillDiscovery();
 
         // The owned-skill store and agent registry are decorated so a bundle run can resolve its
         // ephemeral agent and owned skills from an ambient overlay ahead of the persistent registries,

--- a/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.cs
@@ -168,6 +168,15 @@ public static partial class DependencyInjection
 
         // --- Skills and agents ---
 
+        // Read-only sandbox over skill content, DELIBERATELY SEPARATE from IFileSystemService.
+        // That service is what the model reaches through the file_system tool and it can write, so
+        // adding the skill roots to its allowlist — the obvious way to route skill loading through
+        // a sandbox — would have let the model rewrite its own SKILL.md files, allowed-tools list
+        // included. Two narrow sandboxes over one shared rulebook (SandboxedPathGuard) instead.
+        // Resolves its roots from live config on each call so plugin skill directories, appended by
+        // PluginStartupLoader after the container is built, are covered. See issue #247.
+        services.AddSingleton<ISkillFileReader, SkillFileReader>();
+
         services.AddSingleton<SkillMetadataParser>();
         services.AddSingleton<ISkillMetadataRegistry, SkillMetadataRegistry>();
 

--- a/src/Content/Infrastructure/Infrastructure.AI/Skills/NestedSkillScanner.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Skills/NestedSkillScanner.cs
@@ -1,3 +1,4 @@
+using Application.AI.Common.Interfaces.Skills;
 using Domain.AI.Skills;
 using Microsoft.Extensions.Logging;
 
@@ -26,16 +27,21 @@ internal static class NestedSkillScanner
     /// </summary>
     /// <param name="skillsRoot">The <c>skills/</c> directory to scan. A non-existent path yields an empty list.</param>
     /// <param name="parser">Parser used to read each <c>SKILL.md</c>.</param>
+    /// <param name="fileReader">
+    /// Sandboxed, read-only access to skill content. Both the enumeration and the manifest probe go
+    /// through it, confining the scan to the configured skill content roots (issue #247).
+    /// </param>
     /// <param name="logger">Logger for enumeration and per-skill parse diagnostics.</param>
-    public static IReadOnlyList<SkillDefinition> Scan(string skillsRoot, SkillMetadataParser parser, ILogger logger)
+    public static IReadOnlyList<SkillDefinition> Scan(
+        string skillsRoot, SkillMetadataParser parser, ISkillFileReader fileReader, ILogger logger)
     {
-        if (!Directory.Exists(skillsRoot))
+        if (!fileReader.DirectoryExists(skillsRoot))
             return [];
 
-        IEnumerable<string> skillDirs;
+        IReadOnlyList<string> skillDirs;
         try
         {
-            skillDirs = Directory.EnumerateDirectories(skillsRoot);
+            skillDirs = fileReader.EnumerateDirectories(skillsRoot);
         }
         catch (Exception ex)
         {
@@ -47,7 +53,7 @@ internal static class NestedSkillScanner
         foreach (var skillDir in skillDirs)
         {
             var skillFile = Path.Combine(skillDir, "SKILL.md");
-            if (!File.Exists(skillFile))
+            if (!fileReader.FileExists(skillFile))
                 continue;
 
             try

--- a/src/Content/Infrastructure/Infrastructure.AI/Skills/NestedSkillScanner.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Skills/NestedSkillScanner.cs
@@ -1,3 +1,4 @@
+using Application.AI.Common.Exceptions;
 using Application.AI.Common.Interfaces.Skills;
 using Domain.AI.Skills;
 using Microsoft.Extensions.Logging;
@@ -25,13 +26,22 @@ internal static class NestedSkillScanner
     /// <c>&lt;subdir&gt;/SKILL.md</c>), in filesystem-enumeration order and possibly containing duplicate
     /// ids if two subdirectories declare the same one — the caller decides how to resolve those.
     /// </summary>
-    /// <param name="skillsRoot">The <c>skills/</c> directory to scan. A non-existent path yields an empty list.</param>
+    /// <param name="skillsRoot">
+    /// The <c>skills/</c> directory to scan. A non-existent path yields an empty list; a path the
+    /// sandbox refuses throws rather than yielding one — see the exception below.
+    /// </param>
     /// <param name="parser">Parser used to read each <c>SKILL.md</c>.</param>
     /// <param name="fileReader">
     /// Sandboxed, read-only access to skill content. Both the enumeration and the manifest probe go
     /// through it, confining the scan to the configured skill content roots (issue #247).
     /// </param>
     /// <param name="logger">Logger for enumeration and per-skill parse diagnostics.</param>
+    /// <exception cref="SkillPathRefusedException">
+    /// <paramref name="skillsRoot"/> lies outside the configured skill content roots. Propagated
+    /// rather than absorbed into an empty result, so a misconfigured root fails loudly instead of
+    /// producing an agent silently missing its own skills. An ordinary permission denial on an
+    /// in-bounds directory is a different type and is still tolerated.
+    /// </exception>
     public static IReadOnlyList<SkillDefinition> Scan(
         string skillsRoot, SkillMetadataParser parser, ISkillFileReader fileReader, ILogger logger)
     {
@@ -43,8 +53,13 @@ internal static class NestedSkillScanner
         {
             skillDirs = fileReader.EnumerateDirectories(skillsRoot);
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not SkillPathRefusedException)
         {
+            // A sandbox refusal is deliberately NOT caught. Returning an empty list for a refused
+            // root reports "this directory holds no skills", which is indistinguishable from a
+            // directory that genuinely holds none — so a misconfigured root would silently produce
+            // an agent with none of its own skills instead of a startup failure. Best-effort
+            // tolerance is for a malformed entry, not for being told the path is out of bounds.
             logger.LogWarning(ex, "Could not enumerate nested skills directory: {Path}", skillsRoot);
             return [];
         }
@@ -62,8 +77,10 @@ internal static class NestedSkillScanner
                 if (!string.IsNullOrEmpty(skill.Id))
                     skills.Add(skill);
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is not SkillPathRefusedException)
             {
+                // Same rule as the enumeration above: a malformed manifest is skipped, a refused
+                // one is not.
                 logger.LogWarning(ex, "Failed to parse nested skill from {Path}", skillFile);
             }
         }

--- a/src/Content/Infrastructure/Infrastructure.AI/Skills/SkillContentRoots.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Skills/SkillContentRoots.cs
@@ -1,0 +1,106 @@
+using Domain.Common.Config;
+
+namespace Infrastructure.AI.Skills;
+
+/// <summary>
+/// The one place that answers "where does skill content live on disk", for every component that
+/// needs to agree on it.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Three answers have to stay identical or a real defect appears, and none of them is enforced by
+/// the compiler:
+/// </para>
+/// <list type="bullet">
+///   <item><description>
+///     <c>SkillFileReader</c> builds its sandbox from these roots. If it resolved a root differently
+///     from the registries, it would refuse the very directory discovery then walks.
+///   </description></item>
+///   <item><description>
+///     <c>SkillMetadataRegistry</c> and <c>AgentMetadataRegistry</c> walk them.
+///   </description></item>
+///   <item><description>
+///     <c>BundleStagingService</c> refuses a staging root that overlaps a discovery root. That guard
+///     compares the staging root against these; resolve either side differently and an overlapping
+///     root slips past, letting the global registries publish a bundle's private skills.
+///   </description></item>
+/// </list>
+/// <para>
+/// Relative paths resolve against <see cref="AppContext.BaseDirectory"/> — the bin folder — rather
+/// than the current working directory, matching where the build copies skills and agents. The
+/// working directory differs between <c>dotnet run</c> and a published deployment, so anchoring
+/// there would make discovery depend on how the host was launched.
+/// </para>
+/// </remarks>
+internal static class SkillContentRoots
+{
+    /// <summary>
+    /// The default staging location for expanded bundles when none is configured.
+    /// </summary>
+    private const string DefaultBundleStagingFolder = "agent-bundles";
+
+    /// <summary>
+    /// Resolves a configured path to an absolute one, taking relative paths against
+    /// <see cref="AppContext.BaseDirectory"/>.
+    /// </summary>
+    /// <param name="path">A configured path, absolute or relative.</param>
+    /// <returns>The absolute form.</returns>
+    public static string Resolve(string path) =>
+        Path.IsPathRooted(path) ? path : Path.GetFullPath(path, AppContext.BaseDirectory);
+
+    /// <summary>
+    /// The configured skill and agent discovery roots, resolved to absolute paths.
+    /// </summary>
+    /// <remarks>
+    /// Agent roots are included because an agent's own skills live in
+    /// <c>&lt;agentDir&gt;/skills</c> — a location that appears in no skills configuration.
+    /// </remarks>
+    /// <param name="config">The live application configuration.</param>
+    /// <returns>The discovery roots; empty when the AI section is absent.</returns>
+    public static IEnumerable<string> Discovery(AppConfig config)
+    {
+        ArgumentNullException.ThrowIfNull(config);
+
+        var ai = config.AI;
+        if (ai is null)
+            yield break;
+
+        foreach (var path in ai.Skills.AllPaths.Concat(ai.Agents.AllPaths))
+        {
+            if (!string.IsNullOrWhiteSpace(path))
+                yield return Resolve(path);
+        }
+    }
+
+    /// <summary>
+    /// The directory under which each bundle is staged in its own subfolder, resolved to an
+    /// absolute path.
+    /// </summary>
+    /// <param name="config">The live application configuration.</param>
+    /// <returns>The configured staging root, or the default under the system temp directory.</returns>
+    public static string BundleStaging(AppConfig config)
+    {
+        ArgumentNullException.ThrowIfNull(config);
+
+        var tempRoot = config.AI?.BundleExecution.TempRoot;
+        return string.IsNullOrWhiteSpace(tempRoot)
+            ? Path.Combine(Path.GetTempPath(), DefaultBundleStagingFolder)
+            : Resolve(tempRoot);
+    }
+
+    /// <summary>
+    /// Every directory skill content may legitimately be read from: the discovery roots plus the
+    /// bundle staging root (a staged bundle carries its own <c>skills/</c> directory).
+    /// </summary>
+    /// <param name="config">The live application configuration.</param>
+    /// <returns>The distinct absolute roots.</returns>
+    public static IReadOnlyList<string> All(AppConfig config)
+    {
+        ArgumentNullException.ThrowIfNull(config);
+
+        if (config.AI is null)
+            return [];
+
+        return [.. Discovery(config).Append(BundleStaging(config)).Distinct(StringComparer.Ordinal)];
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Skills/SkillDiscoveryServiceCollectionExtensions.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Skills/SkillDiscoveryServiceCollectionExtensions.cs
@@ -1,0 +1,47 @@
+using Application.AI.Common.Interfaces;
+using Application.AI.Common.Interfaces.Skills;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Infrastructure.AI.Skills;
+
+/// <summary>
+/// Registers the skill discovery trio as one unit.
+/// </summary>
+public static class SkillDiscoveryServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers the sandboxed skill file reader, the SKILL.md parser, and the skill registry.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// These three must be registered together or not at all: the registry needs the parser, and the
+    /// parser cannot be constructed without the reader. A host that registers the trio by hand and
+    /// omits the reader does not degrade — the container fails to build at startup.
+    /// </para>
+    /// <para>
+    /// That is not hypothetical. The standalone MCP server composes its own skill services rather
+    /// than calling the full AI registration, and adding the reader to only one of the two
+    /// composition roots broke its startup outright (issue #247). One entry point removes the
+    /// opportunity: a future host calls this and cannot get the set wrong.
+    /// </para>
+    /// <para>
+    /// <b>On the reader specifically.</b> It is deliberately a <em>separate</em> sandbox from
+    /// <c>IFileSystemService</c>, which is what the model reaches through the <c>file_system</c>
+    /// tool and which can write. Adding the skill roots to that service — the obvious way to put
+    /// skill loading behind a sandbox — would let the model rewrite its own <c>SKILL.md</c> files,
+    /// <c>allowed-tools</c> list included. See <see cref="ISkillFileReader"/>.
+    /// </para>
+    /// </remarks>
+    /// <param name="services">The service collection to register into.</param>
+    /// <returns>The same collection, for chaining.</returns>
+    public static IServiceCollection AddSkillDiscovery(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.AddSingleton<ISkillFileReader, SkillFileReader>();
+        services.AddSingleton<SkillMetadataParser>();
+        services.AddSingleton<ISkillMetadataRegistry, SkillMetadataRegistry>();
+
+        return services;
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Skills/SkillFileReader.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Skills/SkillFileReader.cs
@@ -1,0 +1,192 @@
+using Application.AI.Common.Interfaces.Skills;
+using Domain.Common.Config;
+using Infrastructure.AI.Tools;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Infrastructure.AI.Skills;
+
+/// <summary>
+/// Confines every skill-content read to the configured skill roots, using the same allow/deny rules
+/// as the model's file sandbox but a different — and read-only — set of permitted directories.
+/// </summary>
+/// <remarks>
+/// <para>
+/// See <see cref="ISkillFileReader"/> for why skill loading has its own sandbox instead of being
+/// added to <see cref="FileSystemService"/>'s, and <see cref="SandboxedPathGuard"/> for the rules
+/// both share.
+/// </para>
+/// <para>
+/// <b>The permitted set is recomputed, not snapshotted.</b> Plugin skill directories are appended to
+/// <c>AppConfig.AI.Skills.AdditionalPaths</c> by <c>PluginStartupLoader</c> during host start —
+/// after the DI container is built, and therefore after any set captured at registration time. A
+/// snapshot would refuse every plugin-supplied skill. Each call compares a cheap signature of the
+/// configured roots against the cached one and rebuilds the guard only when they differ, so the
+/// per-call cost is a string join rather than the handle-opening canonicalization of every root.
+/// </para>
+/// <para>
+/// <b>This does not let a plugin widen the sandbox arbitrarily.</b> A plugin's skill directory is
+/// accepted only after <c>PluginLoader</c> has verified it is contained within the plugin's own
+/// directory, and that directory comes from <c>AppConfig:AI:Plugins:Packages</c> — operator
+/// configuration, not plugin-supplied content.
+/// </para>
+/// </remarks>
+public sealed class SkillFileReader : ISkillFileReader
+{
+    // Matched to FileSystemService deliberately: a manifest or reference file large enough to
+    // exhaust memory is a defect or an attack either way, and two different limits on two sandboxes
+    // over the same disk would be a difference nobody could justify later.
+    private const long MaxFileSizeBytes = 10 * 1024 * 1024; // 10 MB
+
+    private readonly IOptionsMonitor<AppConfig> _appConfig;
+    private readonly ILogger<SkillFileReader> _logger;
+    private readonly Lock _lock = new();
+
+    private string? _cachedSignature;
+    private SandboxedPathGuard? _cachedGuard;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SkillFileReader"/> class.
+    /// </summary>
+    /// <param name="appConfig">Monitor over the live configuration supplying the skill content roots.</param>
+    /// <param name="logger">Logger for sandbox refusals.</param>
+    public SkillFileReader(IOptionsMonitor<AppConfig> appConfig, ILogger<SkillFileReader> logger)
+    {
+        ArgumentNullException.ThrowIfNull(appConfig);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _appConfig = appConfig;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public string ReadText(string path)
+    {
+        var fullPath = ValidateForRead(path);
+        return File.ReadAllText(fullPath);
+    }
+
+    /// <inheritdoc />
+    public async Task<string> ReadTextAsync(string path, CancellationToken cancellationToken = default)
+    {
+        var fullPath = ValidateForRead(path);
+        return await File.ReadAllTextAsync(fullPath, System.Text.Encoding.UTF8, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public bool FileExists(string path) => File.Exists(Guard().ResolveAndValidate(path));
+
+    /// <inheritdoc />
+    public bool DirectoryExists(string path) => Directory.Exists(Guard().ResolveAndValidate(path));
+
+    /// <inheritdoc />
+    public IReadOnlyList<string> EnumerateDirectories(string path)
+    {
+        var guard = Guard();
+        var fullPath = guard.ResolveAndValidate(path);
+
+        if (!Directory.Exists(fullPath))
+            throw new DirectoryNotFoundException($"Directory not found: {path}");
+
+        var results = new List<string>();
+        foreach (var subdirectory in Directory.EnumerateDirectories(fullPath))
+        {
+            // Re-checked rather than trusted because it was enumerated from inside the sandbox: a
+            // junction planted in a skill root enumerates with a legitimate-looking literal path,
+            // and a caller that recursed into it would be walking wherever it points.
+            if (guard.IsPathAllowed(subdirectory))
+                results.Add(subdirectory);
+            else
+                _logger.LogWarning("Skipped skill subdirectory outside the skill sandbox: {Path}", subdirectory);
+        }
+
+        return results;
+    }
+
+    /// <summary>
+    /// Validates a path for reading and enforces the size limit before any content is loaded.
+    /// </summary>
+    private string ValidateForRead(string path)
+    {
+        var fullPath = Guard().ResolveAndValidate(path);
+
+        var fileInfo = new FileInfo(fullPath);
+        if (!fileInfo.Exists)
+            throw new FileNotFoundException($"Skill file not found: {path}");
+
+        if (fileInfo.Length > MaxFileSizeBytes)
+            throw new IOException($"Skill file exceeds size limit ({MaxFileSizeBytes / 1024 / 1024} MB).");
+
+        return fullPath;
+    }
+
+    /// <summary>
+    /// Returns a guard over the currently configured skill content roots, rebuilding it only when
+    /// that set has changed since the last call.
+    /// </summary>
+    private SandboxedPathGuard Guard()
+    {
+        var roots = ResolveContentRoots();
+        var signature = string.Join('\0', roots);
+
+        lock (_lock)
+        {
+            if (_cachedGuard is not null && string.Equals(_cachedSignature, signature, StringComparison.Ordinal))
+                return _cachedGuard;
+
+            // No protected paths: this sandbox permits only skill content roots, and the bundle
+            // staging service already refuses a staging root that overlaps a discovery root. The
+            // governance-state directory is guarded on the surface that can write to it.
+            var guard = new SandboxedPathGuard(_logger, roots);
+
+            if (!guard.HasAllowedPaths)
+            {
+                _logger.LogWarning(
+                    "SkillFileReader initialized with zero skill content roots — all skill reads will be denied");
+            }
+            else
+            {
+                _logger.LogDebug(
+                    "SkillFileReader sandbox covering {PathCount} skill content root(s)", guard.AllowedPathCount);
+            }
+
+            _cachedSignature = signature;
+            _cachedGuard = guard;
+            return guard;
+        }
+    }
+
+    /// <summary>
+    /// The directories skill content may be read from: the configured skill roots, the configured
+    /// agent roots (an agent's own skills live in <c>&lt;agentDir&gt;/skills</c>), and the bundle
+    /// staging root (a staged bundle carries its own <c>skills/</c> directory).
+    /// </summary>
+    /// <remarks>
+    /// Relative paths resolve against <see cref="AppContext.BaseDirectory"/>, matching the registries
+    /// and <c>BundleStagingService</c>. Resolving them any other way here would produce a sandbox
+    /// that refuses the very directories discovery then walks.
+    /// </remarks>
+    private IReadOnlyList<string> ResolveContentRoots()
+    {
+        var ai = _appConfig.CurrentValue.AI;
+        if (ai is null)
+            return [];
+
+        var roots = new List<string>();
+
+        foreach (var path in ai.Skills.AllPaths.Concat(ai.Agents.AllPaths))
+        {
+            if (!string.IsNullOrWhiteSpace(path))
+                roots.Add(Resolve(path));
+        }
+
+        roots.Add(string.IsNullOrWhiteSpace(ai.BundleExecution.TempRoot)
+            ? Path.Combine(Path.GetTempPath(), "agent-bundles")
+            : Resolve(ai.BundleExecution.TempRoot));
+
+        return [.. roots.Distinct(StringComparer.Ordinal)];
+
+        static string Resolve(string path) =>
+            Path.IsPathRooted(path) ? path : Path.GetFullPath(path, AppContext.BaseDirectory);
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Skills/SkillFileReader.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Skills/SkillFileReader.cs
@@ -1,3 +1,4 @@
+using Application.AI.Common.Exceptions;
 using Application.AI.Common.Interfaces.Skills;
 using Domain.Common.Config;
 using Infrastructure.AI.Tools;
@@ -74,16 +75,16 @@ public sealed class SkillFileReader : ISkillFileReader
     }
 
     /// <inheritdoc />
-    public bool FileExists(string path) => File.Exists(Guard().ResolveAndValidate(path));
+    public bool FileExists(string path) => File.Exists(Resolve(path));
 
     /// <inheritdoc />
-    public bool DirectoryExists(string path) => Directory.Exists(Guard().ResolveAndValidate(path));
+    public bool DirectoryExists(string path) => Directory.Exists(Resolve(path));
 
     /// <inheritdoc />
     public IReadOnlyList<string> EnumerateDirectories(string path)
     {
-        var guard = Guard();
-        var fullPath = guard.ResolveAndValidate(path);
+        var guard = CurrentGuard();
+        var fullPath = Resolve(path);
 
         if (!Directory.Exists(fullPath))
             throw new DirectoryNotFoundException($"Directory not found: {path}");
@@ -104,11 +105,35 @@ public sealed class SkillFileReader : ISkillFileReader
     }
 
     /// <summary>
+    /// Validates a path against the current sandbox, reporting a refusal as
+    /// <see cref="SkillPathRefusedException"/>.
+    /// </summary>
+    /// <remarks>
+    /// The translation is the point. Callers must be able to tell "the sandbox said no" — which is
+    /// fatal, because absorbing it into an empty result would boot an agent silently missing its
+    /// skills — apart from an ordinary file-permission denial on a directory that is legitimately
+    /// inside the sandbox, which is not. Both arrive as <see cref="UnauthorizedAccessException"/>,
+    /// so only the one raised here can be distinguished by type.
+    /// </remarks>
+    private string Resolve(string path)
+    {
+        try
+        {
+            return CurrentGuard().ResolveAndValidate(path);
+        }
+        catch (UnauthorizedAccessException ex) when (ex is not SkillPathRefusedException)
+        {
+            throw new SkillPathRefusedException(
+                $"Path is outside the configured skill content roots: {path}", ex);
+        }
+    }
+
+    /// <summary>
     /// Validates a path for reading and enforces the size limit before any content is loaded.
     /// </summary>
     private string ValidateForRead(string path)
     {
-        var fullPath = Guard().ResolveAndValidate(path);
+        var fullPath = Resolve(path);
 
         var fileInfo = new FileInfo(fullPath);
         if (!fileInfo.Exists)
@@ -124,7 +149,7 @@ public sealed class SkillFileReader : ISkillFileReader
     /// Returns a guard over the currently configured skill content roots, rebuilding it only when
     /// that set has changed since the last call.
     /// </summary>
-    private SandboxedPathGuard Guard()
+    private SandboxedPathGuard CurrentGuard()
     {
         var roots = ResolveContentRoots();
         var signature = string.Join('\0', roots);
@@ -139,7 +164,7 @@ public sealed class SkillFileReader : ISkillFileReader
             // governance-state directory is guarded on the surface that can write to it.
             var guard = new SandboxedPathGuard(_logger, roots);
 
-            if (!guard.HasAllowedPaths)
+            if (guard.AllowedPathCount == 0)
             {
                 _logger.LogWarning(
                     "SkillFileReader initialized with zero skill content roots — all skill reads will be denied");
@@ -157,36 +182,14 @@ public sealed class SkillFileReader : ISkillFileReader
     }
 
     /// <summary>
-    /// The directories skill content may be read from: the configured skill roots, the configured
-    /// agent roots (an agent's own skills live in <c>&lt;agentDir&gt;/skills</c>), and the bundle
-    /// staging root (a staged bundle carries its own <c>skills/</c> directory).
+    /// Every directory skill content may be read from, resolved live from configuration.
     /// </summary>
     /// <remarks>
-    /// Relative paths resolve against <see cref="AppContext.BaseDirectory"/>, matching the registries
-    /// and <c>BundleStagingService</c>. Resolving them any other way here would produce a sandbox
-    /// that refuses the very directories discovery then walks.
+    /// Delegates to <see cref="SkillContentRoots"/> rather than resolving roots itself: the same
+    /// answer is needed by the registries that walk these directories and by the staging service
+    /// that refuses a staging root overlapping them, and a sandbox that resolved a root differently
+    /// would refuse the very directory discovery then walks.
     /// </remarks>
-    private IReadOnlyList<string> ResolveContentRoots()
-    {
-        var ai = _appConfig.CurrentValue.AI;
-        if (ai is null)
-            return [];
-
-        var roots = new List<string>();
-
-        foreach (var path in ai.Skills.AllPaths.Concat(ai.Agents.AllPaths))
-        {
-            if (!string.IsNullOrWhiteSpace(path))
-                roots.Add(Resolve(path));
-        }
-
-        roots.Add(string.IsNullOrWhiteSpace(ai.BundleExecution.TempRoot)
-            ? Path.Combine(Path.GetTempPath(), "agent-bundles")
-            : Resolve(ai.BundleExecution.TempRoot));
-
-        return [.. roots.Distinct(StringComparer.Ordinal)];
-
-        static string Resolve(string path) =>
-            Path.IsPathRooted(path) ? path : Path.GetFullPath(path, AppContext.BaseDirectory);
-    }
+    private IReadOnlyList<string> ResolveContentRoots() =>
+        SkillContentRoots.All(_appConfig.CurrentValue);
 }

--- a/src/Content/Infrastructure/Infrastructure.AI/Skills/SkillMetadataParser.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Skills/SkillMetadataParser.cs
@@ -1,3 +1,4 @@
+using Application.AI.Common.Interfaces.Skills;
 using Domain.AI.Egress;
 using Domain.AI.Skills;
 using Microsoft.Extensions.Logging;
@@ -28,10 +29,23 @@ namespace Infrastructure.AI.Skills;
 public sealed partial class SkillMetadataParser
 {
     private readonly ILogger<SkillMetadataParser> _logger;
+    private readonly ISkillFileReader _fileReader;
 
-    public SkillMetadataParser(ILogger<SkillMetadataParser> logger)
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SkillMetadataParser"/> class.
+    /// </summary>
+    /// <param name="logger">Logger for parse diagnostics.</param>
+    /// <param name="fileReader">
+    /// Sandboxed, read-only access to skill content. Every manifest read goes through it so a
+    /// <c>SKILL.md</c> outside the configured skill roots cannot be loaded (issue #247).
+    /// </param>
+    public SkillMetadataParser(ILogger<SkillMetadataParser> logger, ISkillFileReader fileReader)
     {
+        ArgumentNullException.ThrowIfNull(logger);
+        ArgumentNullException.ThrowIfNull(fileReader);
+
         _logger = logger;
+        _fileReader = fileReader;
     }
 
     /// <summary>
@@ -43,7 +57,7 @@ public sealed partial class SkillMetadataParser
     /// <param name="pluginSource">Optional plugin source identifier; set when loading skills from a plugin package.</param>
     public SkillDefinition ParseFromFile(string skillFilePath, string sourcePath, string? pluginSource = null)
     {
-        var raw = File.ReadAllText(skillFilePath);
+        var raw = _fileReader.ReadText(skillFilePath);
         var rawFrontmatter = ExtractFrontmatter(raw);
         var body = ExtractBody(raw, rawFrontmatter);
 
@@ -77,14 +91,19 @@ public sealed partial class SkillMetadataParser
 
         try
         {
-            if (File.Exists(skillFilePath))
+            if (_fileReader.FileExists(skillFilePath))
             {
-                var raw = File.ReadAllText(skillFilePath);
+                var raw = _fileReader.ReadText(skillFilePath);
                 rawFrontmatter = ExtractFrontmatter(raw);
             }
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not UnauthorizedAccessException)
         {
+            // A sandbox refusal is deliberately NOT caught here. Degrading to null frontmatter looks
+            // harmless but is not: SkillFrontmatter.Load(null) yields a skill with an EMPTY
+            // allowed-tools list and no egress policy, which downstream is indistinguishable from a
+            // manifest that legitimately declares neither. A skill whose manifest the sandbox
+            // refuses must fail loudly rather than load with its restrictions quietly dropped.
             _logger.LogWarning(ex, "Could not read custom frontmatter from {Path}", skillFilePath);
         }
 

--- a/src/Content/Infrastructure/Infrastructure.AI/Skills/SkillMetadataParser.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Skills/SkillMetadataParser.cs
@@ -1,3 +1,4 @@
+using Application.AI.Common.Exceptions;
 using Application.AI.Common.Interfaces.Skills;
 using Domain.AI.Egress;
 using Domain.AI.Skills;
@@ -97,7 +98,7 @@ public sealed partial class SkillMetadataParser
                 rawFrontmatter = ExtractFrontmatter(raw);
             }
         }
-        catch (Exception ex) when (ex is not UnauthorizedAccessException)
+        catch (Exception ex) when (ex is not SkillPathRefusedException)
         {
             // A sandbox refusal is deliberately NOT caught here. Degrading to null frontmatter looks
             // harmless but is not: SkillFrontmatter.Load(null) yields a skill with an EMPTY

--- a/src/Content/Infrastructure/Infrastructure.AI/Skills/SkillMetadataRegistry.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Skills/SkillMetadataRegistry.cs
@@ -1,5 +1,6 @@
 using Application.AI.Common.Interfaces;
 using Application.AI.Common.Interfaces.Plugins;
+using Application.AI.Common.Interfaces.Skills;
 using Domain.AI.Skills;
 using Domain.Common.Config;
 using Domain.Common.Helpers;
@@ -30,6 +31,7 @@ public sealed class SkillMetadataRegistry : ISkillMetadataRegistry
     private readonly ILogger<SkillMetadataRegistry> _logger;
     private readonly IOptionsMonitor<AppConfig> _appConfig;
     private readonly SkillMetadataParser _parser;
+    private readonly ISkillFileReader _fileReader;
     private readonly IPluginRegistry? _pluginRegistry;
 
     private Dictionary<string, SkillDefinition>? _cache;
@@ -42,6 +44,10 @@ public sealed class SkillMetadataRegistry : ISkillMetadataRegistry
     /// <param name="logger">Logger for discovery diagnostics.</param>
     /// <param name="appConfig">Monitor over the live application configuration (skill search paths).</param>
     /// <param name="parser">Parser that reads a SKILL.md file into a <see cref="SkillDefinition"/>.</param>
+    /// <param name="fileReader">
+    /// Sandboxed, read-only access to skill content. The discovery walk probes and enumerates
+    /// through it so it cannot be led outside the configured skill roots (issue #247).
+    /// </param>
     /// <param name="pluginRegistry">
     /// Optional registry of loaded plugins. When supplied, each discovered skill whose directory
     /// falls under a loaded plugin's <c>SkillPaths</c> is attributed to that plugin via
@@ -53,11 +59,15 @@ public sealed class SkillMetadataRegistry : ISkillMetadataRegistry
         ILogger<SkillMetadataRegistry> logger,
         IOptionsMonitor<AppConfig> appConfig,
         SkillMetadataParser parser,
+        ISkillFileReader fileReader,
         IPluginRegistry? pluginRegistry = null)
     {
+        ArgumentNullException.ThrowIfNull(fileReader);
+
         _logger = logger;
         _appConfig = appConfig;
         _parser = parser;
+        _fileReader = fileReader;
         _pluginRegistry = pluginRegistry;
     }
 
@@ -143,8 +153,12 @@ public sealed class SkillMetadataRegistry : ISkillMetadataRegistry
         var resolvedPaths = new List<string>();
         foreach (var p in paths)
         {
+            // Resolved to absolute BEFORE the sandbox sees it: configured roots are legitimately
+            // written as traversals relative to the bin folder ("../../.."), which the sandbox's
+            // input validation rejects outright. The sandbox's own allowed set is derived from these
+            // same configured roots, so a root is permitted here by construction.
             var abs = Path.IsPathRooted(p) ? p : Path.GetFullPath(p, AppContext.BaseDirectory);
-            if (Directory.Exists(abs))
+            if (_fileReader.DirectoryExists(abs))
                 resolvedPaths.Add(abs);
             else
                 _logger.LogWarning("Skill path not found, skipping: {Path}", abs);
@@ -230,7 +244,7 @@ public sealed class SkillMetadataRegistry : ISkillMetadataRegistry
 
         var skillFile = Path.Combine(directory, "SKILL.md");
 
-        if (File.Exists(skillFile))
+        if (_fileReader.FileExists(skillFile))
         {
             TryAddSkill(skillFile, directory, pluginPaths, result);
 
@@ -238,10 +252,12 @@ public sealed class SkillMetadataRegistry : ISkillMetadataRegistry
             return;
         }
 
-        // Recurse into subdirectories to find nested skills
+        // Recurse into subdirectories to find nested skills. The reader drops any subdirectory the
+        // sandbox refuses (a junction out of the skill roots, say), so the walk cannot be steered
+        // outside the roots by planting one.
         try
         {
-            foreach (var subDir in Directory.EnumerateDirectories(directory))
+            foreach (var subDir in _fileReader.EnumerateDirectories(directory))
                 DiscoverInDirectory(subDir, depth + 1, pluginPaths, result);
         }
         catch (Exception ex)

--- a/src/Content/Infrastructure/Infrastructure.AI/Skills/SkillMetadataRegistry.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Skills/SkillMetadataRegistry.cs
@@ -1,3 +1,4 @@
+using Application.AI.Common.Exceptions;
 using Application.AI.Common.Interfaces;
 using Application.AI.Common.Interfaces.Plugins;
 using Application.AI.Common.Interfaces.Skills;
@@ -260,8 +261,12 @@ public sealed class SkillMetadataRegistry : ISkillMetadataRegistry
             foreach (var subDir in _fileReader.EnumerateDirectories(directory))
                 DiscoverInDirectory(subDir, depth + 1, pluginPaths, result);
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not SkillPathRefusedException)
         {
+            // A sandbox refusal propagates. Swallowing it would report "no skills here", which is
+            // indistinguishable from an empty directory, so a misconfigured root would boot an
+            // agent with none of its skills rather than failing. Tolerating an unreadable
+            // directory is the point of this catch; tolerating being told it is out of bounds is not.
             _logger.LogWarning(ex, "Could not enumerate directory: {Path}", directory);
         }
     }
@@ -298,8 +303,10 @@ public sealed class SkillMetadataRegistry : ISkillMetadataRegistry
                 "Discovered skill: {SkillId} from {Path} (source: {Source})",
                 definition.Id, directory, pluginSource ?? "built-in");
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not SkillPathRefusedException)
         {
+            // Same rule as the enumeration above: a malformed manifest is skipped, a refused one is
+            // not — dropping it would leave the skill absent with only a warning to say why.
             _logger.LogWarning(ex, "Failed to parse skill from {Path}", skillFile);
         }
     }

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/FileSystemService.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/FileSystemService.cs
@@ -72,7 +72,7 @@ public sealed class FileSystemService : IFileSystemService
         _logger = logger;
         _guard = new SandboxedPathGuard(logger, allowedBasePaths, protectedPaths);
 
-        if (!_guard.HasAllowedPaths)
+        if (_guard.AllowedPathCount == 0)
             _logger.LogWarning("FileSystemService initialized with zero allowed base paths — all operations will be denied");
         else
             _logger.LogInformation("FileSystemService initialized with {PathCount} allowed base paths", _guard.AllowedPathCount);

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/FileSystemService.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/FileSystemService.cs
@@ -11,8 +11,17 @@ namespace Infrastructure.AI.Tools;
 /// Blocks access to system directories, resolves symlinks, and enforces file size limits.
 /// </summary>
 /// <remarks>
-/// Consumed directly by skill loaders, agent parsers, and other non-LLM code paths.
-/// For LLM tool consumption, <see cref="FileSystemTool"/> wraps this service.
+/// <para>
+/// This is the surface the <em>model</em> reaches, through <see cref="FileSystemTool"/>, and it can
+/// write. It is confined to <c>AppConfig:Infrastructure:FileSystem:AllowedBasePaths</c> and nothing
+/// else — in particular <b>not</b> to the skill content roots. Skill loading has its own read-only
+/// sandbox (<c>SkillFileReader</c>) precisely so that widening it cannot widen this; see
+/// <see cref="SandboxedPathGuard"/> for the reasoning.
+/// </para>
+/// <para>
+/// The allow/deny decision itself lives in <see cref="SandboxedPathGuard"/>, shared with that reader
+/// so the two sandboxes cannot drift on what "inside" means.
+/// </para>
 /// </remarks>
 public sealed class FileSystemService : IFileSystemService
 {
@@ -20,36 +29,6 @@ public sealed class FileSystemService : IFileSystemService
     private const int MaxSearchResults = 100;
     private const int MaxFilesScanned = 1_000;
     private const int SnippetMaxLength = 200;
-
-    private static readonly HashSet<string> SystemDirectoryBlocklist = BuildSystemBlocklist();
-
-    // Harness-owned state directories the tool may never read or write, regardless of the
-    // configured allowlist. Holds the governance-state database — pending escalations, their
-    // resolved verdicts, and change proposals. An agent that could read that file could mine the
-    // approval payloads it carries; one that could write it could truncate or corrupt the
-    // harness's own governance state. It could NOT forge an approval verdict: every outcome is
-    // HMAC-sealed by AttestationGovernanceRecordSealer with a key the agent has no access to, the
-    // seal is bound to the row id, and both read paths in EfCoreEscalationStateStore verify it and
-    // quarantine on failure. So the exposure this list closes is disclosure and tamper/denial of
-    // service, not forgery.
-    //
-    // Compared as CANONICAL ABSOLUTE PATHS, never as directory names: name matching is
-    // defeated by a Windows 8.3 short alias (AGENT-~1) or any other alias that resolves to the
-    // same directory but spells it differently. The canonical form comes from the same
-    // resolver the database registration uses, so the two cannot drift.
-    //
-    // This deny list cannot see through a hard link, and nothing path-based can: a hard link is a
-    // second directory entry for the same file, not a reparse point, so there is no link target to
-    // resolve and its canonical form is itself. That gap is closed by asking about the file's
-    // identity instead of its path — see IsSingleLinked — because a hard link needs only the same
-    // VOLUME as its target, which no allowlist geometry can prevent.
-    //
-    // Legitimately EMPTY on a host with no governance state to guard. The composition root
-    // (DependencyInjection.ResolveGovernanceStateProtectedPaths) supplies the governance-state
-    // directory only when a durable-state toggle is on or a database from an earlier run is still
-    // on disk; in the shipped default neither holds. An empty set disarms both this deny list and
-    // the identity check below, which is the correct outcome when there is nothing to alias.
-    private readonly HashSet<string> _protectedPaths;
 
     // Directories skipped during recursive search — build artifacts and VCS internals
     // would exhaust the scan limit before reaching actual source files.
@@ -65,7 +44,7 @@ public sealed class FileSystemService : IFileSystemService
     };
 
     private readonly ILogger<FileSystemService> _logger;
-    private readonly HashSet<string> _allowedBasePaths;
+    private readonly SandboxedPathGuard _guard;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="FileSystemService"/> class.
@@ -91,42 +70,18 @@ public sealed class FileSystemService : IFileSystemService
         ArgumentNullException.ThrowIfNull(allowedBasePaths);
 
         _logger = logger;
+        _guard = new SandboxedPathGuard(logger, allowedBasePaths, protectedPaths);
 
-        // PathScope.Comparer, never a hardcoded StringComparer.OrdinalIgnoreCase: on Linux
-        // "/srv/state" and "/srv/State" are two different directories, and case-insensitive
-        // hashing would collapse them into one entry. For the deny set that collapse is
-        // fail-OPEN — the second protected directory silently stops being protected.
-        _allowedBasePaths = new HashSet<string>(PathScope.Comparer);
-        _protectedPaths = new HashSet<string>(PathScope.Comparer);
-
-        // Both sets are stored in canonical, PathScope-normalized form (absolute, links resolved,
-        // trailing separator trimmed). Normalized because every comparison against them goes
-        // through PathScope.IsSameOrUnderNormalized, which requires normalized inputs on both
-        // sides; canonical because the paths a comparison is fed at runtime are canonicalized, and
-        // comparing a canonical target against a literal base misses whenever the configured base
-        // is itself reached through a link.
-        foreach (var path in protectedPaths ?? [])
-        {
-            if (!string.IsNullOrWhiteSpace(path))
-                _protectedPaths.Add(SandboxPathCanonicalizer.Canonicalize(PathScope.Normalize(path)));
-        }
-
-        foreach (var path in allowedBasePaths)
-        {
-            if (!string.IsNullOrWhiteSpace(path))
-                _allowedBasePaths.Add(SandboxPathCanonicalizer.Canonicalize(PathScope.Normalize(path)));
-        }
-
-        if (_allowedBasePaths.Count == 0)
+        if (!_guard.HasAllowedPaths)
             _logger.LogWarning("FileSystemService initialized with zero allowed base paths — all operations will be denied");
         else
-            _logger.LogInformation("FileSystemService initialized with {PathCount} allowed base paths", _allowedBasePaths.Count);
+            _logger.LogInformation("FileSystemService initialized with {PathCount} allowed base paths", _guard.AllowedPathCount);
     }
 
     /// <inheritdoc />
     public async Task<string> ReadFileAsync(string path, CancellationToken cancellationToken = default)
     {
-        var fullPath = ResolveAndValidate(path);
+        var fullPath = _guard.ResolveAndValidate(path);
 
         var fileInfo = new FileInfo(fullPath);
         if (!fileInfo.Exists)
@@ -146,7 +101,7 @@ public sealed class FileSystemService : IFileSystemService
         if (content.Length > MaxFileSizeBytes)
             throw new IOException($"Content exceeds size limit ({MaxFileSizeBytes / 1024 / 1024} MB).");
 
-        var fullPath = ResolveAndValidate(path, write: true);
+        var fullPath = _guard.ResolveAndValidate(path, write: true);
 
         var directory = Path.GetDirectoryName(fullPath);
         if (!string.IsNullOrEmpty(directory) && !Directory.Exists(directory))
@@ -160,7 +115,7 @@ public sealed class FileSystemService : IFileSystemService
     public Task<IReadOnlyList<string>> ListDirectoryAsync(string path, string? pattern = null, CancellationToken cancellationToken = default)
     {
         ValidatePattern(pattern);
-        var fullPath = ResolveAndValidate(path);
+        var fullPath = _guard.ResolveAndValidate(path);
 
         if (!Directory.Exists(fullPath))
             throw new DirectoryNotFoundException($"Directory not found: {path}");
@@ -191,7 +146,7 @@ public sealed class FileSystemService : IFileSystemService
         string path, string searchTerm, string? pattern = null, CancellationToken cancellationToken = default)
     {
         ValidatePattern(pattern);
-        var fullPath = ResolveAndValidate(path);
+        var fullPath = _guard.ResolveAndValidate(path);
 
         if (!Directory.Exists(fullPath))
             throw new DirectoryNotFoundException($"Directory not found: {path}");
@@ -200,8 +155,9 @@ public sealed class FileSystemService : IFileSystemService
         var searchPattern = string.IsNullOrEmpty(pattern) ? "*.*" : pattern;
         var filesScanned = 0;
 
-        // Lives only for this call — see IsProtectedPath for why it must not become process-wide.
-        var directoryVerdicts = new Dictionary<string, DirectoryVerdict>(PathScope.Comparer);
+        // Lives only for this call — see SandboxedPathGuard.ResolveVerdict for why it must not
+        // become process-wide.
+        var directoryVerdicts = new Dictionary<string, SandboxedPathGuard.DirectoryVerdict>(PathScope.Comparer);
 
         foreach (var file in EnumerateFilesSkippingIgnored(
             fullPath, searchPattern, directoryVerdicts, cancellationToken))
@@ -229,7 +185,7 @@ public sealed class FileSystemService : IFileSystemService
     {
         try
         {
-            var fullPath = ResolveAndValidate(path);
+            var fullPath = _guard.ResolveAndValidate(path);
             return Task.FromResult(File.Exists(fullPath) || Directory.Exists(fullPath));
         }
         catch (UnauthorizedAccessException)
@@ -266,10 +222,12 @@ public sealed class FileSystemService : IFileSystemService
     /// </remarks>
     /// <param name="root">The already-validated absolute search root.</param>
     /// <param name="pattern">The file-name pattern to match.</param>
-    /// <param name="directoryVerdicts">Per-operation verdict memo; see <see cref="ResolveVerdict"/>.</param>
+    /// <param name="directoryVerdicts">
+    /// Per-operation verdict memo; see <see cref="SandboxedPathGuard.ResolveVerdict"/>.
+    /// </param>
     /// <param name="cancellationToken">Token to observe while walking.</param>
     private IEnumerable<string> EnumerateFilesSkippingIgnored(
-        string root, string pattern, Dictionary<string, DirectoryVerdict> directoryVerdicts,
+        string root, string pattern, Dictionary<string, SandboxedPathGuard.DirectoryVerdict> directoryVerdicts,
         CancellationToken cancellationToken)
     {
         var queue = new Queue<string>();
@@ -278,7 +236,7 @@ public sealed class FileSystemService : IFileSystemService
         // Normalized before the verdict call, not only to key the memo: Canonicalize documents a
         // normalized input as a precondition and returns its argument unchanged on the error path.
         var normalizedRoot = PathScope.Normalize(root);
-        directoryVerdicts[normalizedRoot] = ResolveVerdict(normalizedRoot);
+        directoryVerdicts[normalizedRoot] = _guard.ResolveVerdict(normalizedRoot);
 
         while (queue.Count > 0)
         {
@@ -307,10 +265,10 @@ public sealed class FileSystemService : IFileSystemService
 
                 // No memo here, and both arms prune — see this method's remarks for why.
                 var normalizedSub = PathScope.Normalize(sub);
-                var verdict = ResolveVerdict(normalizedSub);
+                var verdict = _guard.ResolveVerdict(normalizedSub);
                 directoryVerdicts[normalizedSub] = verdict;
 
-                if (!verdict.IsProtected && IsUnderAllowedBase(verdict.CanonicalPath))
+                if (!verdict.IsProtected && _guard.IsUnderAllowedBase(verdict.CanonicalPath))
                     queue.Enqueue(sub);
             }
         }
@@ -318,7 +276,7 @@ public sealed class FileSystemService : IFileSystemService
 
     private async Task SearchFileAsync(
         string filePath, string basePath, string searchTerm,
-        List<FileSearchResult> results, Dictionary<string, DirectoryVerdict> directoryVerdicts,
+        List<FileSearchResult> results, Dictionary<string, SandboxedPathGuard.DirectoryVerdict> directoryVerdicts,
         CancellationToken cancellationToken)
     {
         // Last line of defence before any file content is read. The directory filter above
@@ -328,7 +286,7 @@ public sealed class FileSystemService : IFileSystemService
         // a direct read does. "The same gate" is load-bearing and was previously untrue: the
         // direct-read gate resolves links before comparing, and this one compared the literal
         // enumerated path, so a link inside the workspace read through it whatever it pointed at.
-        if (!IsPathAllowed(filePath, directoryVerdicts))
+        if (!_guard.IsPathAllowed(filePath, directoryVerdicts))
         {
             _logger.LogWarning("Skipped search of disallowed path: {Path}", filePath);
             return;
@@ -342,7 +300,7 @@ public sealed class FileSystemService : IFileSystemService
         // opens and reads every one of those files line by line. It is not the per-file link
         // RESOLUTION the directory-verdict memo exists to avoid — that walks parent components and
         // is paid per enumerated entry; this is a single stat-and-open on files already being read.
-        if (!IsSingleLinked(filePath))
+        if (!_guard.IsSingleLinked(filePath))
             return;
 
         try
@@ -372,347 +330,9 @@ public sealed class FileSystemService : IFileSystemService
         }
     }
 
-    /// <summary>
-    /// Resolves a user-supplied path to an absolute path, validates against the
-    /// security sandbox (input validation, allowlist, symlink resolution, write blocklist).
-    /// </summary>
-    private string ResolveAndValidate(string path, bool write = false)
-    {
-        ArgumentException.ThrowIfNullOrWhiteSpace(path);
-
-        // Defense-in-depth: reject traversal patterns, null bytes, shell injection
-        if (!SecureInputValidatorHelper.ValidateFilePath(path))
-            throw new ArgumentException("Path contains invalid characters or traversal patterns.");
-
-        var fullPath = Path.IsPathRooted(path)
-            ? Path.GetFullPath(path)
-            : ResolveRelative(path);
-
-        // Resolve symlinks/junctions to real target, then re-validate
-        fullPath = ResolveSymlinks(fullPath);
-
-        if (!IsPathAllowed(fullPath))
-        {
-            _logger.LogWarning("Blocked access to path outside sandbox: {Path}", fullPath);
-            throw new UnauthorizedAccessException("Path is outside the allowed sandbox.");
-        }
-
-        // Identity, after path. Everything above reasons about what the path spells; this asks the
-        // operating system what file it actually names. Only the second question sees a hard link.
-        if (!IsSingleLinked(fullPath))
-            throw new UnauthorizedAccessException(HardLinkDenialMessage);
-
-        if (write)
-            ValidateWriteTarget(fullPath);
-
-        return fullPath;
-    }
-
-    /// <summary>
-    /// The refusal handed to a caller whose path names a file the sandbox cannot prove is unique.
-    /// </summary>
-    private const string HardLinkDenialMessage =
-        "Path names a file the sandbox cannot prove has a single directory entry, so it cannot " +
-        "rule out that the file is a hard link aliasing protected harness state.";
-
-    /// <summary>
-    /// True when <paramref name="fullPath"/> names a file with exactly one directory entry — the
-    /// only case in which a path-based sandbox decision about it is trustworthy.
-    /// </summary>
-    /// <remarks>
-    /// <para>
-    /// <b>Why a path check is not enough.</b> A hard link is a second directory entry for one file,
-    /// carrying no reparse point, so it resolves to itself and reads to every check above as an
-    /// ordinary workspace file. The startup validator keeps protected directories out of the
-    /// allowed tree, which is worth doing, but it is not what closes this: a hard link requires the
-    /// same VOLUME as its target, not the same subtree, and the shipped default puts
-    /// <c>workspace</c> and <c>.agent-state</c> side by side on one volume. Non-containment is
-    /// strictly narrower than volume separation, and volume separation is unreachable anyway
-    /// because <c>GovernanceStatePaths.Resolve</c> pins the database under the application base
-    /// directory.
-    /// </para>
-    /// <para>
-    /// <b>Fail closed.</b> <see cref="HardLinkInspector.LinkCount.Unknown"/> — an unimplemented
-    /// platform (anything but Windows and Linux), a failed platform call, or an untrustworthy
-    /// count — denies. A consumer running on such a platform with protected paths configured gets
-    /// a closed file tool rather than a silently unguarded one.
-    /// </para>
-    /// <para>
-    /// <b>Scoped to hosts that have something to protect.</b> With no protected paths configured
-    /// there is nothing a hard link could alias, so the inspection is skipped outright and callers
-    /// with no harness state pay nothing — neither the handle open nor the platform restriction.
-    /// This is the shipped default rather than an edge case: the composition root withholds the
-    /// governance-state directory until a durable-state toggle is on or a database from an earlier
-    /// run exists, so an out-of-the-box host runs this tool on every platform, macOS included.
-    /// </para>
-    /// </remarks>
-    /// <param name="fullPath">An absolute path. Need not exist; a file yet to be created passes.</param>
-    private bool IsSingleLinked(string fullPath)
-    {
-        if (_protectedPaths.Count == 0)
-            return true;
-
-        var linkCount = HardLinkInspector.Inspect(fullPath);
-        if (linkCount == HardLinkInspector.LinkCount.Single)
-            return true;
-
-        _logger.LogWarning(
-            "Blocked access to a path the sandbox cannot prove is singly-linked: {Path} ({LinkCount})",
-            fullPath,
-            linkCount);
-        return false;
-    }
-
-    private string ResolveRelative(string path)
-    {
-        foreach (var basePath in _allowedBasePaths)
-        {
-            var combined = Path.GetFullPath(Path.Combine(basePath, path));
-            if (IsPathAllowed(combined) && (File.Exists(combined) || Directory.Exists(combined)))
-                return combined;
-        }
-
-        // Default to first allowed base path (caller configured these explicitly)
-        return _allowedBasePaths.Count > 0
-            ? Path.GetFullPath(Path.Combine(_allowedBasePaths.First(), path))
-            : throw new UnauthorizedAccessException("No allowed base paths configured.");
-    }
-
-    private static string ResolveSymlinks(string path)
-    {
-        // Check the file itself for symlink
-        var info = new FileInfo(path);
-        if (info.LinkTarget is not null)
-            return Path.GetFullPath(info.LinkTarget, Path.GetDirectoryName(path)!);
-
-        // Walk parent directories checking for junction points
-        var dir = new DirectoryInfo(Path.GetDirectoryName(path)!);
-        while (dir is not null)
-        {
-            if (dir.LinkTarget is not null)
-            {
-                var resolvedDir = Path.GetFullPath(dir.LinkTarget);
-                return Path.GetFullPath(Path.Combine(resolvedDir, Path.GetRelativePath(dir.FullName, path)));
-            }
-            dir = dir.Parent;
-        }
-
-        return path;
-    }
-
-    /// <summary>
-    /// The sandbox decision for one path: whether it is denied outright, and the canonical
-    /// location the allowlist comparison must be made against.
-    /// </summary>
-    /// <remarks>
-    /// The two travel together because they are answers to the same question — "what does this
-    /// path actually name?" — and separating them is what let a symlink escape the sandbox: the
-    /// deny arm consumed the canonical form while the allow arm compared the literal one.
-    /// </remarks>
-    /// <param name="IsProtected">
-    /// <see langword="true"/> when the path is, or lives under, a protected harness-state directory.
-    /// </param>
-    /// <param name="CanonicalPath">
-    /// The path's canonical absolute form, with links resolved. Valid on both arms.
-    /// </param>
-    private readonly record struct DirectoryVerdict(bool IsProtected, string CanonicalPath);
-
-    /// <param name="fullPath">An absolute path.</param>
-    /// <param name="directoryVerdicts">
-    /// Optional per-operation sandbox-verdict memo; see <see cref="ResolveVerdict"/>.
-    /// </param>
-    private bool IsPathAllowed(string fullPath, Dictionary<string, DirectoryVerdict>? directoryVerdicts = null)
-    {
-        var verdict = ResolveVerdict(PathScope.Normalize(fullPath), directoryVerdicts);
-
-        // Deny list wins over the allowlist. Protected directories hold the harness's own
-        // governance state — the SQLite database of approval verdicts — and typically sit
-        // under a configured base path, so allowlisting alone would leave them reachable.
-        // An agent able to read that file could mine approval payloads, and one able to write it
-        // could truncate or corrupt the harness's own state; the HMAC seal on every row is what
-        // stops it forging a verdict. The tool must not reach it under any configuration.
-        if (verdict.IsProtected)
-        {
-            _logger.LogWarning(
-                "Blocked access to protected harness state directory: {Path}", verdict.CanonicalPath);
-            return false;
-        }
-
-        // Compared against the CANONICAL path, never the literal one. A junction at
-        // workspace\notes pointing at C:\Users\victim\.ssh yields files whose literal paths all
-        // look like workspace\notes\..., which satisfy any workspace-rooted allowlist; only the
-        // resolved target reveals that they are outside the sandbox.
-        return IsUnderAllowedBase(verdict.CanonicalPath);
-    }
-
-    /// <summary>
-    /// True when <paramref name="canonicalPath"/> sits inside a configured allowed base path.
-    /// </summary>
-    /// <remarks>
-    /// PathScope matches on a directory boundary, so a sibling whose name merely starts with an
-    /// allowed root (<c>C:\workspace-backup</c> against <c>C:\workspace</c>) is not mistaken for a
-    /// child. Both operands are canonical: the argument by contract, the base paths because the
-    /// constructor canonicalizes them once.
-    /// </remarks>
-    /// <param name="canonicalPath">A canonical absolute path.</param>
-    private bool IsUnderAllowedBase(string canonicalPath) =>
-        _allowedBasePaths.Any(basePath => PathScope.IsSameOrUnderNormalized(canonicalPath, basePath));
-
-    /// <summary>
-    /// Canonicalizes <paramref name="normalizedPath"/> and decides whether it is protected,
-    /// returning both halves of the sandbox decision.
-    /// </summary>
-    /// <remarks>
-    /// Compares canonicalized absolute paths on a directory boundary, so a legitimate sibling
-    /// such as <c>.agent-state-docs</c> is unaffected while an alias that merely spells the
-    /// protected directory differently (a Windows 8.3 short name, a symlink, a junctioned parent)
-    /// still matches.
-    /// </remarks>
-    /// <param name="normalizedPath">
-    /// An absolute path, already <see cref="PathScope.Normalize"/>d — the precondition
-    /// <see cref="SandboxPathCanonicalizer.Canonicalize"/> documents.
-    /// </param>
-    /// <param name="directoryVerdicts">
-    /// <para>
-    /// Optional memo of directory path to verdict, scoped to a <em>single</em> search operation and
-    /// threaded through the walk by <see cref="EnumerateFilesSkippingIgnored"/>. Canonicalizing a path
-    /// costs a stat plus a link-resolution handle open; without the memo a recursive search pays that
-    /// for every file it scans rather than for every directory it descends into.
-    /// </para>
-    /// <para>
-    /// The scope is deliberately per-operation and must NOT be promoted to a process-lifetime cache.
-    /// An agent can create a benign file, let its verdict be recorded, then replace it with a symlink
-    /// into the protected directory; a cache that outlives the operation would serve the stale
-    /// "allowed" verdict and hand over the approval-verdict database. Per-operation scope bounds that
-    /// staleness window to the same window the directory prune already has.
-    /// </para>
-    /// </param>
-    private DirectoryVerdict ResolveVerdict(
-        string normalizedPath, Dictionary<string, DirectoryVerdict>? directoryVerdicts = null)
-    {
-        if (directoryVerdicts is not null
-            && TryInheritParentVerdict(normalizedPath, directoryVerdicts, out var inherited))
-        {
-            return inherited;
-        }
-
-        var canonical = SandboxPathCanonicalizer.Canonicalize(normalizedPath);
-        var isProtected = _protectedPaths.Any(protectedPath =>
-            PathScope.IsSameOrUnderNormalized(canonical, protectedPath));
-
-        return new DirectoryVerdict(isProtected, canonical);
-    }
-
-    /// <summary>
-    /// Resolves <paramref name="normalizedPath"/>'s verdict from its already-canonicalized parent
-    /// directory when that is sound, avoiding a link resolution per file.
-    /// </summary>
-    /// <remarks>
-    /// <para>
-    /// Inheritance is only sound for a plain file: a subdirectory can itself be a protected root,
-    /// and a reparse point resolves somewhere its parent says nothing about. Both are rejected
-    /// here, by the method rather than by convention, and fall through to full canonicalization.
-    /// Reading the attributes costs a stat but no handle open, which is the syscall being avoided.
-    /// </para>
-    /// <para>
-    /// For an entry that passes that test the composed path is exact, not an approximation: a
-    /// non-reparse-point entry genuinely lives inside its parent directory, so appending its leaf
-    /// name to the parent's canonical directory names the same location a full canonicalization
-    /// would return. That exactness is what makes the memo safe to feed the allowlist comparison —
-    /// inheriting only the boolean, as this method used to, left the allow arm with a literal path
-    /// whose parent had been canonicalized but which had not.
-    /// </para>
-    /// <para>
-    /// A parent verdict of <see langword="true"/> transfers unconditionally — everything under a
-    /// protected directory is protected, including a link planted there — but is canonicalized in
-    /// full rather than composed, because a reparse point in that position does not occupy the
-    /// composed location. That branch is effectively unreachable during a search (protected
-    /// directories are never enqueued), so the extra resolve costs nothing in practice.
-    /// </para>
-    /// </remarks>
-    private static bool TryInheritParentVerdict(
-        string normalizedPath,
-        Dictionary<string, DirectoryVerdict> directoryVerdicts,
-        out DirectoryVerdict verdict)
-    {
-        verdict = default;
-
-        var parent = Path.GetDirectoryName(normalizedPath);
-        if (parent is null
-            || !directoryVerdicts.TryGetValue(PathScope.Normalize(parent), out var parentVerdict))
-        {
-            return false;
-        }
-
-        if (parentVerdict.IsProtected)
-        {
-            verdict = new DirectoryVerdict(true, SandboxPathCanonicalizer.Canonicalize(normalizedPath));
-            return true;
-        }
-
-        try
-        {
-            // Directory: a subdirectory can itself be a protected root. ReparsePoint: a link
-            // resolves somewhere its parent says nothing about. Enforced here rather than left as a
-            // caller contract, because a caller that gets it wrong fails open and fails silently.
-            var attributes = File.GetAttributes(normalizedPath);
-            if (attributes.HasFlag(FileAttributes.Directory)
-                || attributes.HasFlag(FileAttributes.ReparsePoint))
-            {
-                return false;
-            }
-        }
-        catch (Exception ex) when (ex is IOException
-                                      or UnauthorizedAccessException
-                                      or ArgumentException
-                                      or NotSupportedException)
-        {
-            // Unreadable, already gone, or a path shape the runtime rejects outright: fall through
-            // to the full check rather than guess. NotSupportedException is in the filter so it
-            // produces a clean deny instead of escaping SearchFilesAsync unhandled.
-            return false;
-        }
-
-        verdict = new DirectoryVerdict(
-            false,
-            PathScope.Normalize(Path.Combine(
-                parentVerdict.CanonicalPath, Path.GetFileName(normalizedPath))));
-        return true;
-    }
-
-    private void ValidateWriteTarget(string fullPath)
-    {
-        foreach (var sysDir in SystemDirectoryBlocklist)
-        {
-            if (fullPath.StartsWith(sysDir, StringComparison.OrdinalIgnoreCase))
-            {
-                _logger.LogWarning("Blocked write to system directory: {Path}", fullPath);
-                throw new UnauthorizedAccessException("Cannot write to system directories.");
-            }
-        }
-    }
-
     private static void ValidatePattern(string? pattern)
     {
         if (pattern is not null && (pattern.Contains('/') || pattern.Contains('\\')))
             throw new ArgumentException("Search pattern must not contain path separators.");
-    }
-
-    private static HashSet<string> BuildSystemBlocklist()
-    {
-        var dirs = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-
-        AddIfNotEmpty(dirs, Environment.GetFolderPath(Environment.SpecialFolder.Windows));
-        AddIfNotEmpty(dirs, Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles));
-        AddIfNotEmpty(dirs, Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86));
-        AddIfNotEmpty(dirs, Environment.GetFolderPath(Environment.SpecialFolder.System));
-
-        return dirs;
-
-        static void AddIfNotEmpty(HashSet<string> set, string path)
-        {
-            if (!string.IsNullOrEmpty(path))
-                set.Add(Path.GetFullPath(path));
-        }
     }
 }

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/SandboxedPathGuard.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/SandboxedPathGuard.cs
@@ -1,0 +1,475 @@
+using Domain.Common.Helpers;
+using Microsoft.Extensions.Logging;
+
+namespace Infrastructure.AI.Tools;
+
+/// <summary>
+/// Decides whether a path may be touched: the allow/deny geometry, link resolution, and file-identity
+/// checks that confine a file-access surface to a configured set of directories.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Extracted from <see cref="FileSystemService"/> so the harness can run <em>more than one</em>
+/// sandbox without owning more than one implementation of the rules. There are two today and they
+/// deliberately permit different directories:
+/// </para>
+/// <list type="bullet">
+///   <item><description>
+///     <see cref="FileSystemService"/> — reachable by the model through <see cref="FileSystemTool"/>,
+///     and able to <b>write</b>. Confined to <c>AppConfig:Infrastructure:FileSystem:AllowedBasePaths</c>.
+///   </description></item>
+///   <item><description>
+///     <c>SkillFileReader</c> — the harness's own skill loader. Confined to the configured skill
+///     content roots and exposes <b>no write operation at all</b>.
+///   </description></item>
+/// </list>
+/// <para>
+/// <b>Why they are separate instances rather than one widened allowlist.</b> Skill content lives
+/// outside the model's sandbox by default (<c>skills</c> versus <c>workspace</c>), so routing skill
+/// loading through the model's own service would have required adding the skill roots to it. That
+/// service can write, and <see cref="FileSystemTool"/> exposes its write operation to the model with
+/// no approval gate — so the widening would have handed the model the ability to rewrite its own
+/// <c>SKILL.md</c> files, including the <c>allowed-tools</c> list that constrains it. Two narrow
+/// sandboxes over one shared rulebook is what closes the skill-loading bypass without opening that
+/// one (issue #247).
+/// </para>
+/// </remarks>
+internal sealed class SandboxedPathGuard
+{
+    private static readonly HashSet<string> SystemDirectoryBlocklist = BuildSystemBlocklist();
+
+    // Harness-owned state directories the tool may never read or write, regardless of the
+    // configured allowlist. Holds the governance-state database — pending escalations, their
+    // resolved verdicts, and change proposals. An agent that could read that file could mine the
+    // approval payloads it carries; one that could write it could truncate or corrupt the
+    // harness's own governance state. It could NOT forge an approval verdict: every outcome is
+    // HMAC-sealed by AttestationGovernanceRecordSealer with a key the agent has no access to, the
+    // seal is bound to the row id, and both read paths in EfCoreEscalationStateStore verify it and
+    // quarantine on failure. So the exposure this list closes is disclosure and tamper/denial of
+    // service, not forgery.
+    //
+    // Compared as CANONICAL ABSOLUTE PATHS, never as directory names: name matching is
+    // defeated by a Windows 8.3 short alias (AGENT-~1) or any other alias that resolves to the
+    // same directory but spells it differently. The canonical form comes from the same
+    // resolver the database registration uses, so the two cannot drift.
+    //
+    // This deny list cannot see through a hard link, and nothing path-based can: a hard link is a
+    // second directory entry for the same file, not a reparse point, so there is no link target to
+    // resolve and its canonical form is itself. That gap is closed by asking about the file's
+    // identity instead of its path — see IsSingleLinked — because a hard link needs only the same
+    // VOLUME as its target, which no allowlist geometry can prevent.
+    //
+    // Legitimately EMPTY on a host with no governance state to guard. The composition root
+    // (DependencyInjection.ResolveGovernanceStateProtectedPaths) supplies the governance-state
+    // directory only when a durable-state toggle is on or a database from an earlier run is still
+    // on disk; in the shipped default neither holds. An empty set disarms both this deny list and
+    // the identity check below, which is the correct outcome when there is nothing to alias.
+    private readonly HashSet<string> _protectedPaths;
+
+    private readonly ILogger _logger;
+    private readonly HashSet<string> _allowedBasePaths;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SandboxedPathGuard"/> class.
+    /// </summary>
+    /// <param name="logger">Receives a warning for every refusal, and the path that caused it.</param>
+    /// <param name="allowedBasePaths">
+    /// The set of absolute directory paths this guard permits. Paths are canonicalized and normalized
+    /// once, here. An empty set denies everything — see <see cref="HasAllowedPaths"/>.
+    /// </param>
+    /// <param name="protectedPaths">
+    /// Absolute directory paths denied even when they fall inside <paramref name="allowedBasePaths"/>.
+    /// The deny check wins over the allowlist. Optional; omit for callers with no protected state.
+    /// </param>
+    public SandboxedPathGuard(
+        ILogger logger,
+        IEnumerable<string> allowedBasePaths,
+        IEnumerable<string>? protectedPaths = null)
+    {
+        ArgumentNullException.ThrowIfNull(logger);
+        ArgumentNullException.ThrowIfNull(allowedBasePaths);
+
+        _logger = logger;
+
+        // PathScope.Comparer, never a hardcoded StringComparer.OrdinalIgnoreCase: on Linux
+        // "/srv/state" and "/srv/State" are two different directories, and case-insensitive
+        // hashing would collapse them into one entry. For the deny set that collapse is
+        // fail-OPEN — the second protected directory silently stops being protected.
+        _allowedBasePaths = new HashSet<string>(PathScope.Comparer);
+        _protectedPaths = new HashSet<string>(PathScope.Comparer);
+
+        // Both sets are stored in canonical, PathScope-normalized form (absolute, links resolved,
+        // trailing separator trimmed). Normalized because every comparison against them goes
+        // through PathScope.IsSameOrUnderNormalized, which requires normalized inputs on both
+        // sides; canonical because the paths a comparison is fed at runtime are canonicalized, and
+        // comparing a canonical target against a literal base misses whenever the configured base
+        // is itself reached through a link.
+        foreach (var path in protectedPaths ?? [])
+        {
+            if (!string.IsNullOrWhiteSpace(path))
+                _protectedPaths.Add(SandboxPathCanonicalizer.Canonicalize(PathScope.Normalize(path)));
+        }
+
+        foreach (var path in allowedBasePaths)
+        {
+            if (!string.IsNullOrWhiteSpace(path))
+                _allowedBasePaths.Add(SandboxPathCanonicalizer.Canonicalize(PathScope.Normalize(path)));
+        }
+    }
+
+    /// <summary>
+    /// The number of directories this guard permits. Zero means every operation is refused.
+    /// </summary>
+    public int AllowedPathCount => _allowedBasePaths.Count;
+
+    /// <summary>
+    /// <see langword="false"/> when the guard was given nothing to allow, in which case it denies
+    /// everything. Callers surface this at construction so a misconfiguration is visible in the log
+    /// rather than only as a refusal on first use.
+    /// </summary>
+    public bool HasAllowedPaths => _allowedBasePaths.Count > 0;
+
+    /// <summary>
+    /// The refusal handed to a caller whose path names a file the sandbox cannot prove is unique.
+    /// </summary>
+    public const string HardLinkDenialMessage =
+        "Path names a file the sandbox cannot prove has a single directory entry, so it cannot " +
+        "rule out that the file is a hard link aliasing protected harness state.";
+
+    /// <summary>
+    /// Resolves a caller-supplied path to an absolute path and validates it against the
+    /// sandbox (input validation, allowlist, symlink resolution, file identity, write blocklist).
+    /// </summary>
+    /// <param name="path">The caller-supplied path, absolute or relative to an allowed base.</param>
+    /// <param name="write">When <see langword="true"/>, additionally refuses system directories.</param>
+    /// <returns>The validated absolute path.</returns>
+    /// <exception cref="ArgumentException">The path is empty or contains traversal patterns.</exception>
+    /// <exception cref="UnauthorizedAccessException">The path is refused by the sandbox.</exception>
+    public string ResolveAndValidate(string path, bool write = false)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+
+        // Defense-in-depth: reject traversal patterns, null bytes, shell injection
+        if (!SecureInputValidatorHelper.ValidateFilePath(path))
+            throw new ArgumentException("Path contains invalid characters or traversal patterns.");
+
+        var fullPath = Path.IsPathRooted(path)
+            ? Path.GetFullPath(path)
+            : ResolveRelative(path);
+
+        // Resolve symlinks/junctions to real target, then re-validate
+        fullPath = ResolveSymlinks(fullPath);
+
+        if (!IsPathAllowed(fullPath))
+        {
+            _logger.LogWarning("Blocked access to path outside sandbox: {Path}", fullPath);
+            throw new UnauthorizedAccessException("Path is outside the allowed sandbox.");
+        }
+
+        // Identity, after path. Everything above reasons about what the path spells; this asks the
+        // operating system what file it actually names. Only the second question sees a hard link.
+        if (!IsSingleLinked(fullPath))
+            throw new UnauthorizedAccessException(HardLinkDenialMessage);
+
+        if (write)
+            ValidateWriteTarget(fullPath);
+
+        return fullPath;
+    }
+
+    /// <summary>
+    /// True when <paramref name="fullPath"/> names a file with exactly one directory entry — the
+    /// only case in which a path-based sandbox decision about it is trustworthy.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>Why a path check is not enough.</b> A hard link is a second directory entry for one file,
+    /// carrying no reparse point, so it resolves to itself and reads to every check above as an
+    /// ordinary workspace file. The startup validator keeps protected directories out of the
+    /// allowed tree, which is worth doing, but it is not what closes this: a hard link requires the
+    /// same VOLUME as its target, not the same subtree, and the shipped default puts
+    /// <c>workspace</c> and <c>.agent-state</c> side by side on one volume. Non-containment is
+    /// strictly narrower than volume separation, and volume separation is unreachable anyway
+    /// because <c>GovernanceStatePaths.Resolve</c> pins the database under the application base
+    /// directory.
+    /// </para>
+    /// <para>
+    /// <b>Fail closed.</b> <see cref="HardLinkInspector.LinkCount.Unknown"/> — an unimplemented
+    /// platform (anything but Windows and Linux), a failed platform call, or an untrustworthy
+    /// count — denies. A consumer running on such a platform with protected paths configured gets
+    /// a closed file tool rather than a silently unguarded one.
+    /// </para>
+    /// <para>
+    /// <b>Scoped to hosts that have something to protect.</b> With no protected paths configured
+    /// there is nothing a hard link could alias, so the inspection is skipped outright and callers
+    /// with no harness state pay nothing — neither the handle open nor the platform restriction.
+    /// This is the shipped default rather than an edge case: the composition root withholds the
+    /// governance-state directory until a durable-state toggle is on or a database from an earlier
+    /// run exists, so an out-of-the-box host runs this tool on every platform, macOS included.
+    /// </para>
+    /// </remarks>
+    /// <param name="fullPath">An absolute path. Need not exist; a file yet to be created passes.</param>
+    public bool IsSingleLinked(string fullPath)
+    {
+        if (_protectedPaths.Count == 0)
+            return true;
+
+        var linkCount = HardLinkInspector.Inspect(fullPath);
+        if (linkCount == HardLinkInspector.LinkCount.Single)
+            return true;
+
+        _logger.LogWarning(
+            "Blocked access to a path the sandbox cannot prove is singly-linked: {Path} ({LinkCount})",
+            fullPath,
+            linkCount);
+        return false;
+    }
+
+    private string ResolveRelative(string path)
+    {
+        foreach (var basePath in _allowedBasePaths)
+        {
+            var combined = Path.GetFullPath(Path.Combine(basePath, path));
+            if (IsPathAllowed(combined) && (File.Exists(combined) || Directory.Exists(combined)))
+                return combined;
+        }
+
+        // Default to first allowed base path (caller configured these explicitly)
+        return _allowedBasePaths.Count > 0
+            ? Path.GetFullPath(Path.Combine(_allowedBasePaths.First(), path))
+            : throw new UnauthorizedAccessException("No allowed base paths configured.");
+    }
+
+    private static string ResolveSymlinks(string path)
+    {
+        // Check the file itself for symlink
+        var info = new FileInfo(path);
+        if (info.LinkTarget is not null)
+            return Path.GetFullPath(info.LinkTarget, Path.GetDirectoryName(path)!);
+
+        // Walk parent directories checking for junction points
+        var dir = new DirectoryInfo(Path.GetDirectoryName(path)!);
+        while (dir is not null)
+        {
+            if (dir.LinkTarget is not null)
+            {
+                var resolvedDir = Path.GetFullPath(dir.LinkTarget);
+                return Path.GetFullPath(Path.Combine(resolvedDir, Path.GetRelativePath(dir.FullName, path)));
+            }
+            dir = dir.Parent;
+        }
+
+        return path;
+    }
+
+    /// <summary>
+    /// The sandbox decision for one path: whether it is denied outright, and the canonical
+    /// location the allowlist comparison must be made against.
+    /// </summary>
+    /// <remarks>
+    /// The two travel together because they are answers to the same question — "what does this
+    /// path actually name?" — and separating them is what let a symlink escape the sandbox: the
+    /// deny arm consumed the canonical form while the allow arm compared the literal one.
+    /// </remarks>
+    /// <param name="IsProtected">
+    /// <see langword="true"/> when the path is, or lives under, a protected harness-state directory.
+    /// </param>
+    /// <param name="CanonicalPath">
+    /// The path's canonical absolute form, with links resolved. Valid on both arms.
+    /// </param>
+    public readonly record struct DirectoryVerdict(bool IsProtected, string CanonicalPath);
+
+    /// <param name="fullPath">An absolute path.</param>
+    /// <param name="directoryVerdicts">
+    /// Optional per-operation sandbox-verdict memo; see <see cref="ResolveVerdict"/>.
+    /// </param>
+    public bool IsPathAllowed(string fullPath, Dictionary<string, DirectoryVerdict>? directoryVerdicts = null)
+    {
+        var verdict = ResolveVerdict(PathScope.Normalize(fullPath), directoryVerdicts);
+
+        // Deny list wins over the allowlist. Protected directories hold the harness's own
+        // governance state — the SQLite database of approval verdicts — and typically sit
+        // under a configured base path, so allowlisting alone would leave them reachable.
+        // An agent able to read that file could mine approval payloads, and one able to write it
+        // could truncate or corrupt the harness's own state; the HMAC seal on every row is what
+        // stops it forging a verdict. The tool must not reach it under any configuration.
+        if (verdict.IsProtected)
+        {
+            _logger.LogWarning(
+                "Blocked access to protected harness state directory: {Path}", verdict.CanonicalPath);
+            return false;
+        }
+
+        // Compared against the CANONICAL path, never the literal one. A junction at
+        // workspace\notes pointing at C:\Users\victim\.ssh yields files whose literal paths all
+        // look like workspace\notes\..., which satisfy any workspace-rooted allowlist; only the
+        // resolved target reveals that they are outside the sandbox.
+        return IsUnderAllowedBase(verdict.CanonicalPath);
+    }
+
+    /// <summary>
+    /// True when <paramref name="canonicalPath"/> sits inside a configured allowed base path.
+    /// </summary>
+    /// <remarks>
+    /// PathScope matches on a directory boundary, so a sibling whose name merely starts with an
+    /// allowed root (<c>C:\workspace-backup</c> against <c>C:\workspace</c>) is not mistaken for a
+    /// child. Both operands are canonical: the argument by contract, the base paths because the
+    /// constructor canonicalizes them once.
+    /// </remarks>
+    /// <param name="canonicalPath">A canonical absolute path.</param>
+    public bool IsUnderAllowedBase(string canonicalPath) =>
+        _allowedBasePaths.Any(basePath => PathScope.IsSameOrUnderNormalized(canonicalPath, basePath));
+
+    /// <summary>
+    /// Canonicalizes <paramref name="normalizedPath"/> and decides whether it is protected,
+    /// returning both halves of the sandbox decision.
+    /// </summary>
+    /// <remarks>
+    /// Compares canonicalized absolute paths on a directory boundary, so a legitimate sibling
+    /// such as <c>.agent-state-docs</c> is unaffected while an alias that merely spells the
+    /// protected directory differently (a Windows 8.3 short name, a symlink, a junctioned parent)
+    /// still matches.
+    /// </remarks>
+    /// <param name="normalizedPath">
+    /// An absolute path, already <see cref="PathScope.Normalize"/>d — the precondition
+    /// <see cref="SandboxPathCanonicalizer.Canonicalize"/> documents.
+    /// </param>
+    /// <param name="directoryVerdicts">
+    /// <para>
+    /// Optional memo of directory path to verdict, scoped to a <em>single</em> search operation and
+    /// threaded through the walk by <c>FileSystemService.EnumerateFilesSkippingIgnored</c>.
+    /// Canonicalizing a path costs a stat plus a link-resolution handle open; without the memo a
+    /// recursive search pays that for every file it scans rather than for every directory it
+    /// descends into.
+    /// </para>
+    /// <para>
+    /// The scope is deliberately per-operation and must NOT be promoted to a process-lifetime cache.
+    /// An agent can create a benign file, let its verdict be recorded, then replace it with a symlink
+    /// into the protected directory; a cache that outlives the operation would serve the stale
+    /// "allowed" verdict and hand over the approval-verdict database. Per-operation scope bounds that
+    /// staleness window to the same window the directory prune already has.
+    /// </para>
+    /// </param>
+    public DirectoryVerdict ResolveVerdict(
+        string normalizedPath, Dictionary<string, DirectoryVerdict>? directoryVerdicts = null)
+    {
+        if (directoryVerdicts is not null
+            && TryInheritParentVerdict(normalizedPath, directoryVerdicts, out var inherited))
+        {
+            return inherited;
+        }
+
+        var canonical = SandboxPathCanonicalizer.Canonicalize(normalizedPath);
+        var isProtected = _protectedPaths.Any(protectedPath =>
+            PathScope.IsSameOrUnderNormalized(canonical, protectedPath));
+
+        return new DirectoryVerdict(isProtected, canonical);
+    }
+
+    /// <summary>
+    /// Resolves <paramref name="normalizedPath"/>'s verdict from its already-canonicalized parent
+    /// directory when that is sound, avoiding a link resolution per file.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Inheritance is only sound for a plain file: a subdirectory can itself be a protected root,
+    /// and a reparse point resolves somewhere its parent says nothing about. Both are rejected
+    /// here, by the method rather than by convention, and fall through to full canonicalization.
+    /// Reading the attributes costs a stat but no handle open, which is the syscall being avoided.
+    /// </para>
+    /// <para>
+    /// For an entry that passes that test the composed path is exact, not an approximation: a
+    /// non-reparse-point entry genuinely lives inside its parent directory, so appending its leaf
+    /// name to the parent's canonical directory names the same location a full canonicalization
+    /// would return. That exactness is what makes the memo safe to feed the allowlist comparison —
+    /// inheriting only the boolean, as this method used to, left the allow arm with a literal path
+    /// whose parent had been canonicalized but which had not.
+    /// </para>
+    /// <para>
+    /// A parent verdict of <see langword="true"/> transfers unconditionally — everything under a
+    /// protected directory is protected, including a link planted there — but is canonicalized in
+    /// full rather than composed, because a reparse point in that position does not occupy the
+    /// composed location. That branch is effectively unreachable during a search (protected
+    /// directories are never enqueued), so the extra resolve costs nothing in practice.
+    /// </para>
+    /// </remarks>
+    private static bool TryInheritParentVerdict(
+        string normalizedPath,
+        Dictionary<string, DirectoryVerdict> directoryVerdicts,
+        out DirectoryVerdict verdict)
+    {
+        verdict = default;
+
+        var parent = Path.GetDirectoryName(normalizedPath);
+        if (parent is null
+            || !directoryVerdicts.TryGetValue(PathScope.Normalize(parent), out var parentVerdict))
+        {
+            return false;
+        }
+
+        if (parentVerdict.IsProtected)
+        {
+            verdict = new DirectoryVerdict(true, SandboxPathCanonicalizer.Canonicalize(normalizedPath));
+            return true;
+        }
+
+        try
+        {
+            // Directory: a subdirectory can itself be a protected root. ReparsePoint: a link
+            // resolves somewhere its parent says nothing about. Enforced here rather than left as a
+            // caller contract, because a caller that gets it wrong fails open and fails silently.
+            var attributes = File.GetAttributes(normalizedPath);
+            if (attributes.HasFlag(FileAttributes.Directory)
+                || attributes.HasFlag(FileAttributes.ReparsePoint))
+            {
+                return false;
+            }
+        }
+        catch (Exception ex) when (ex is IOException
+                                      or UnauthorizedAccessException
+                                      or ArgumentException
+                                      or NotSupportedException)
+        {
+            // Unreadable, already gone, or a path shape the runtime rejects outright: fall through
+            // to the full check rather than guess. NotSupportedException is in the filter so it
+            // produces a clean deny instead of escaping SearchFilesAsync unhandled.
+            return false;
+        }
+
+        verdict = new DirectoryVerdict(
+            false,
+            PathScope.Normalize(Path.Combine(
+                parentVerdict.CanonicalPath, Path.GetFileName(normalizedPath))));
+        return true;
+    }
+
+    private void ValidateWriteTarget(string fullPath)
+    {
+        foreach (var sysDir in SystemDirectoryBlocklist)
+        {
+            if (fullPath.StartsWith(sysDir, StringComparison.OrdinalIgnoreCase))
+            {
+                _logger.LogWarning("Blocked write to system directory: {Path}", fullPath);
+                throw new UnauthorizedAccessException("Cannot write to system directories.");
+            }
+        }
+    }
+
+    private static HashSet<string> BuildSystemBlocklist()
+    {
+        var dirs = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        AddIfNotEmpty(dirs, Environment.GetFolderPath(Environment.SpecialFolder.Windows));
+        AddIfNotEmpty(dirs, Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles));
+        AddIfNotEmpty(dirs, Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86));
+        AddIfNotEmpty(dirs, Environment.GetFolderPath(Environment.SpecialFolder.System));
+
+        return dirs;
+
+        static void AddIfNotEmpty(HashSet<string> set, string path)
+        {
+            if (!string.IsNullOrEmpty(path))
+                set.Add(Path.GetFullPath(path));
+        }
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/SandboxedPathGuard.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/SandboxedPathGuard.cs
@@ -75,7 +75,7 @@ internal sealed class SandboxedPathGuard
     /// <param name="logger">Receives a warning for every refusal, and the path that caused it.</param>
     /// <param name="allowedBasePaths">
     /// The set of absolute directory paths this guard permits. Paths are canonicalized and normalized
-    /// once, here. An empty set denies everything — see <see cref="HasAllowedPaths"/>.
+    /// once, here. An empty set denies everything — see <see cref="AllowedPathCount"/>.
     /// </param>
     /// <param name="protectedPaths">
     /// Absolute directory paths denied even when they fall inside <paramref name="allowedBasePaths"/>.
@@ -118,16 +118,11 @@ internal sealed class SandboxedPathGuard
     }
 
     /// <summary>
-    /// The number of directories this guard permits. Zero means every operation is refused.
+    /// The number of directories this guard permits. <b>Zero means every operation is refused</b> —
+    /// callers surface that at construction so a misconfiguration shows up in the log rather than
+    /// only as a refusal on first use.
     /// </summary>
     public int AllowedPathCount => _allowedBasePaths.Count;
-
-    /// <summary>
-    /// <see langword="false"/> when the guard was given nothing to allow, in which case it denies
-    /// everything. Callers surface this at construction so a misconfiguration is visible in the log
-    /// rather than only as a refusal on first use.
-    /// </summary>
-    public bool HasAllowedPaths => _allowedBasePaths.Count > 0;
 
     /// <summary>
     /// The refusal handed to a caller whose path names a file the sandbox cannot prove is unique.

--- a/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentExecutionContextFactoryDualModeTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentExecutionContextFactoryDualModeTests.cs
@@ -58,7 +58,8 @@ public class AgentExecutionContextFactoryDualModeTests
             sp,
             NullLoggerFactory.Instance,
             toolChainBuilder,
-            new SkillPrerequisiteResolver());
+            new SkillPrerequisiteResolver(),
+            new UnsandboxedSkillFileReader());
     }
 
     [Fact]

--- a/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentExecutionContextFactoryGovernanceTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentExecutionContextFactoryGovernanceTests.cs
@@ -59,7 +59,8 @@ public sealed class AgentExecutionContextFactoryGovernanceTests
             sp,
             NullLoggerFactory.Instance,
             toolChainBuilder,
-            new SkillPrerequisiteResolver());
+            new SkillPrerequisiteResolver(),
+            new UnsandboxedSkillFileReader());
     }
 
     private void SetupMcpTools(params (string server, string[] tools)[] servers)

--- a/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentExecutionContextFactoryProgressiveDisclosureTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentExecutionContextFactoryProgressiveDisclosureTests.cs
@@ -114,7 +114,8 @@ public sealed class AgentExecutionContextFactoryProgressiveDisclosureTests : IDi
             sp,
             NullLoggerFactory.Instance,
             new ToolChainBuilder(NullLogger<ToolChainBuilder>.Instance, sp),
-            new SkillPrerequisiteResolver());
+            new SkillPrerequisiteResolver(),
+            new UnsandboxedSkillFileReader());
     }
 
     /// <summary>

--- a/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentExecutionContextFactoryPromptComposerTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentExecutionContextFactoryPromptComposerTests.cs
@@ -65,7 +65,8 @@ public sealed class AgentExecutionContextFactoryPromptComposerTests
             serviceProvider,
             NullLoggerFactory.Instance,
             new ToolChainBuilder(NullLogger<ToolChainBuilder>.Instance, serviceProvider),
-            new SkillPrerequisiteResolver());
+            new SkillPrerequisiteResolver(),
+            new UnsandboxedSkillFileReader());
 
     /// <summary>
     /// Builds a root provider containing the full prompt-composition graph plus the ambient request

--- a/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentExecutionContextFactoryTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentExecutionContextFactoryTests.cs
@@ -68,6 +68,7 @@ public class AgentExecutionContextFactoryTests
             NullLoggerFactory.Instance,
             toolChainBuilder,
             new SkillPrerequisiteResolver(),
+            new UnsandboxedSkillFileReader(),
             budgetTracker: budgetTracker,
             traceStore: traceStore);
     }
@@ -172,7 +173,8 @@ public class AgentExecutionContextFactoryTests
             sp,
             NullLoggerFactory.Instance,
             new ToolChainBuilder(NullLogger<ToolChainBuilder>.Instance, sp),
-            new SkillPrerequisiteResolver());
+            new SkillPrerequisiteResolver(),
+            new UnsandboxedSkillFileReader());
 
         var context = await factory.MapToAgentContextAsync(SimpleSkill(), new SkillAgentOptions());
 

--- a/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentExecutionContextFactoryToolCeilingTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentExecutionContextFactoryToolCeilingTests.cs
@@ -46,7 +46,8 @@ public sealed class AgentExecutionContextFactoryToolCeilingTests
             sp,
             NullLoggerFactory.Instance,
             new ToolChainBuilder(NullLogger<ToolChainBuilder>.Instance, sp),
-            new SkillPrerequisiteResolver());
+            new SkillPrerequisiteResolver(),
+            new UnsandboxedSkillFileReader());
     }
 
     private static SkillDefinition Skill(string id, params string[] allowedTools) => new()

--- a/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentExecutionContextFactoryToolEnforcementTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentExecutionContextFactoryToolEnforcementTests.cs
@@ -48,7 +48,8 @@ public class AgentExecutionContextFactoryToolEnforcementTests
             sp,
             NullLoggerFactory.Instance,
             new ToolChainBuilder(NullLogger<ToolChainBuilder>.Instance, sp),
-            new SkillPrerequisiteResolver());
+            new SkillPrerequisiteResolver(),
+            new UnsandboxedSkillFileReader());
     }
 
     [Fact]

--- a/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentFactoryAgentOwnedSkillTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentFactoryAgentOwnedSkillTests.cs
@@ -73,7 +73,7 @@ public sealed class AgentFactoryAgentOwnedSkillTests
             monitor,
             new ServiceCollection().BuildServiceProvider(),
             NullLoggerFactory.Instance,
-            null!, null!, null!, null!, null!, null!);
+            null!, null!, new UnsandboxedSkillFileReader(), null!, null!, null!, null!);
 
         _contextFactory
             .Setup(f => f.MapToAgentContextAsync(

--- a/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentFactoryCompactionWiringTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentFactoryCompactionWiringTests.cs
@@ -76,7 +76,7 @@ public sealed class AgentFactoryCompactionWiringTests
             monitor,
             new ServiceCollection().BuildServiceProvider(),
             NullLoggerFactory.Instance,
-            null!, null!, null!, null!, null!, null!);
+            null!, null!, new UnsandboxedSkillFileReader(), null!, null!, null!, null!);
 
         var services = new ServiceCollection();
         services.AddSingleton(compactionService);

--- a/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentFactoryEphemeralOverlayTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentFactoryEphemeralOverlayTests.cs
@@ -60,7 +60,7 @@ public sealed class AgentFactoryEphemeralOverlayTests
             monitor,
             new ServiceCollection().BuildServiceProvider(),
             NullLoggerFactory.Instance,
-            null!, null!, null!, null!, null!, null!);
+            null!, null!, new UnsandboxedSkillFileReader(), null!, null!, null!, null!);
 
         _contextFactory
             .Setup(f => f.MapToAgentContextAsync(

--- a/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentFactoryFoundryResponsesTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentFactoryFoundryResponsesTests.cs
@@ -60,7 +60,7 @@ public class AgentFactoryFoundryResponsesTests
             monitor,
             new ServiceCollection().BuildServiceProvider(),
             NullLoggerFactory.Instance,
-            null!, null!, null!, null!, null!, null!);
+            null!, null!, new UnsandboxedSkillFileReader(), null!, null!, null!, null!);
 
         return new AgentFactory(
             NullLogger<AgentFactory>.Instance,

--- a/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentFactoryPrerequisiteScopeSolutionReviewFixTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentFactoryPrerequisiteScopeSolutionReviewFixTests.cs
@@ -67,7 +67,7 @@ public class AgentFactoryPrerequisiteScopeSolutionReviewFixTests
             monitor,
             new ServiceCollection().BuildServiceProvider(),
             NullLoggerFactory.Instance,
-            null!, null!, null!, null!, null!, null!);
+            null!, null!, new UnsandboxedSkillFileReader(), null!, null!, null!, null!);
 
         _factory = new AgentFactory(
             NullLogger<AgentFactory>.Instance,

--- a/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentFactoryResilienceWiringTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentFactoryResilienceWiringTests.cs
@@ -75,7 +75,7 @@ public sealed class AgentFactoryResilienceWiringTests
             monitor,
             new ServiceCollection().BuildServiceProvider(),
             NullLoggerFactory.Instance,
-            null!, null!, null!, null!, null!, null!);
+            null!, null!, new UnsandboxedSkillFileReader(), null!, null!, null!, null!);
 
         var factory = new AgentFactory(
             NullLogger<AgentFactory>.Instance,
@@ -246,6 +246,7 @@ public sealed class AgentFactoryResilienceWiringTests
             NullLoggerFactory.Instance,
             new ToolChainBuilder(NullLogger<ToolChainBuilder>.Instance, services),
             new SkillPrerequisiteResolver(),
+            new UnsandboxedSkillFileReader(),
             resilientChatClientProvider: resilientProvider);
     }
 

--- a/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentFactorySolutionReviewFixTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentFactorySolutionReviewFixTests.cs
@@ -60,7 +60,7 @@ public class AgentFactorySolutionReviewFixTests
             monitor,
             new ServiceCollection().BuildServiceProvider(),
             NullLoggerFactory.Instance,
-            null!, null!, null!, null!, null!, null!);
+            null!, null!, new UnsandboxedSkillFileReader(), null!, null!, null!, null!);
 
         _factory = new AgentFactory(
             NullLogger<AgentFactory>.Instance,

--- a/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentFactoryTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentFactoryTests.cs
@@ -72,7 +72,7 @@ public class AgentFactoryTests
             monitor,
             new ServiceCollection().BuildServiceProvider(),
             NullLoggerFactory.Instance,
-            null!, null!, null!, null!, null!, null!);
+            null!, null!, new UnsandboxedSkillFileReader(), null!, null!, null!, null!);
 
         _factory = new AgentFactory(
             NullLogger<AgentFactory>.Instance,

--- a/src/Content/Tests/Application.AI.Common.Tests/Helpers/DisclosableSkillFactoryTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Helpers/DisclosableSkillFactoryTests.cs
@@ -1,6 +1,8 @@
 using Application.AI.Common.Helpers;
+using Application.AI.Common.Interfaces.Skills;
 using Domain.AI.Skills;
 using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
@@ -36,6 +38,61 @@ public sealed class DisclosableSkillFactoryTests
 
     private static IReadOnlyList<DisclosableSkill> Create(params SkillDefinition[] skills) =>
         DisclosableSkillFactory.Create(skills, new UnsandboxedSkillFileReader(), NullLogger.Instance);
+
+    [Fact]
+    public async Task RegisteredResource_IsServedThroughTheSandboxedReader_NotRawFileIo()
+    {
+        // Tier-3 disclosure is the one path the MODEL drives: it names a resource, the framework
+        // invokes this callback, and whatever comes back is handed to the model. Every other test
+        // here injects a permissive double, so nothing else would notice if this reverted to
+        // File.ReadAllTextAsync — which is exactly the unguarded read issue #247 closed. The spy
+        // returns content no file on disk holds, so a raw read cannot produce it.
+        var reader = new RecordingSkillFileReader("served through the sandbox");
+        var skill = Skill();
+        skill.References.Add(new SkillResource
+        {
+            FileName = "api.md",
+            RelativePath = "references/api.md",
+            FilePath = Path.Combine("Z:", "not-a-real-path", "references", "api.md"),
+        });
+
+        var created = DisclosableSkillFactory.Create([skill], reader, NullLogger.Instance);
+
+        // GetResourceAsync returns the resource DESCRIPTOR; ReadAsync is what invokes the callback
+        // and therefore what actually exercises the wiring under test.
+        var resource = await created.Single().Skill.GetResourceAsync("references/api.md");
+        resource.Should().NotBeNull();
+        var content = await resource!.ReadAsync(new ServiceCollection().BuildServiceProvider());
+
+        content?.ToString().Should().Contain("served through the sandbox");
+        reader.RequestedPaths.Should().ContainSingle()
+            .Which.Should().EndWith(Path.Combine("references", "api.md"));
+    }
+
+    /// <summary>
+    /// Records what was asked for and returns a sentinel, so a test can prove the read went through
+    /// <see cref="ISkillFileReader"/> rather than the file system.
+    /// </summary>
+    private sealed class RecordingSkillFileReader(string content) : ISkillFileReader
+    {
+        public List<string> RequestedPaths { get; } = [];
+
+        public Task<string> ReadTextAsync(string path, CancellationToken cancellationToken = default)
+        {
+            RequestedPaths.Add(path);
+            return Task.FromResult(content);
+        }
+
+        public string ReadText(string path)
+        {
+            RequestedPaths.Add(path);
+            return content;
+        }
+
+        public bool FileExists(string path) => true;
+        public bool DirectoryExists(string path) => true;
+        public IReadOnlyList<string> EnumerateDirectories(string path) => [];
+    }
 
     [Fact]
     public void Create_WellFormedSkill_IsRegisteredUnderItsDeclaredName()

--- a/src/Content/Tests/Application.AI.Common.Tests/Helpers/DisclosableSkillFactoryTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Helpers/DisclosableSkillFactoryTests.cs
@@ -35,7 +35,7 @@ public sealed class DisclosableSkillFactoryTests
         };
 
     private static IReadOnlyList<DisclosableSkill> Create(params SkillDefinition[] skills) =>
-        DisclosableSkillFactory.Create(skills, NullLogger.Instance);
+        DisclosableSkillFactory.Create(skills, new UnsandboxedSkillFileReader(), NullLogger.Instance);
 
     [Fact]
     public void Create_WellFormedSkill_IsRegisteredUnderItsDeclaredName()

--- a/src/Content/Tests/Application.AI.Common.Tests/Helpers/UnsandboxedSkillFileReader.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Helpers/UnsandboxedSkillFileReader.cs
@@ -1,0 +1,35 @@
+using Application.AI.Common.Interfaces.Skills;
+
+namespace Application.AI.Common.Tests;
+
+/// <summary>
+/// An <see cref="ISkillFileReader"/> with <b>no sandbox at all</b>, for tests whose subject is agent
+/// or skill composition rather than confinement.
+/// </summary>
+/// <remarks>
+/// <b>This double proves nothing about the sandbox.</b> Confinement is covered by
+/// <c>SkillFileReaderTests</c> in <c>Infrastructure.AI.Tests</c> against the real implementation. A
+/// test that means to assert a path is refused must not use this class — it permits everything, so
+/// such a test would pass while asserting nothing.
+/// </remarks>
+internal sealed class UnsandboxedSkillFileReader : ISkillFileReader
+{
+    /// <inheritdoc />
+    public string ReadText(string path) => File.ReadAllText(path);
+
+    /// <inheritdoc />
+    public Task<string> ReadTextAsync(string path, CancellationToken cancellationToken = default) =>
+        File.ReadAllTextAsync(path, System.Text.Encoding.UTF8, cancellationToken);
+
+    /// <inheritdoc />
+    public bool FileExists(string path) => File.Exists(path);
+
+    /// <inheritdoc />
+    public bool DirectoryExists(string path) => Directory.Exists(path);
+
+    /// <inheritdoc />
+    public IReadOnlyList<string> EnumerateDirectories(string path) =>
+        Directory.Exists(path)
+            ? [.. Directory.EnumerateDirectories(path)]
+            : throw new DirectoryNotFoundException($"Directory not found: {path}");
+}

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/AgentConversationCacheTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/AgentConversationCacheTests.cs
@@ -65,7 +65,8 @@ public sealed class AgentConversationCacheTests
             services,
             NullLoggerFactory.Instance,
             new ToolChainBuilder(NullLogger<ToolChainBuilder>.Instance, services, null, null),
-            new SkillPrerequisiteResolver());
+            new SkillPrerequisiteResolver(),
+            new UnsandboxedSkillFileReader());
 
         // Registry returns a two-skill graph where "deploy" depends on "validate".
         var registry = new Mock<ISkillMetadataRegistry>();

--- a/src/Content/Tests/Infrastructure.AI.Tests/Agents/AgentMetadataRegistryTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Agents/AgentMetadataRegistryTests.cs
@@ -40,7 +40,8 @@ public sealed class AgentMetadataRegistryTests
             NullLogger<AgentMetadataRegistry>.Instance,
             new OptionsMonitorStub(appConfig),
             new AgentMetadataParser(NullLogger<AgentMetadataParser>.Instance),
-            new SkillMetadataParser(NullLogger<SkillMetadataParser>.Instance),
+            new SkillMetadataParser(NullLogger<SkillMetadataParser>.Instance, new UnsandboxedSkillFileReader()),
+            new UnsandboxedSkillFileReader(),
             ownedSkills);
     }
 
@@ -135,6 +136,8 @@ public sealed class AgentMetadataRegistryTests
         services.AddLogging();
         services.AddSingleton<IOptionsMonitor<AppConfig>>(new OptionsMonitorStub(new AppConfig()));
         services.AddSingleton<AgentMetadataParser>();
+        services.AddSingleton<Application.AI.Common.Interfaces.Skills.ISkillFileReader,
+            Infrastructure.AI.Skills.SkillFileReader>();
         services.AddSingleton<SkillMetadataParser>();
         services.AddSingleton<IAgentOwnedSkillStore, AgentOwnedSkillStore>();
         services.AddSingleton<IAgentMetadataRegistry, AgentMetadataRegistry>();

--- a/src/Content/Tests/Infrastructure.AI.Tests/Agents/CapabilityMatchSupervisorEscalationTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Agents/CapabilityMatchSupervisorEscalationTests.cs
@@ -85,7 +85,8 @@ public sealed class CapabilityMatchSupervisorEscalationTests : IDisposable
             Mock.Of<IServiceProvider>(),
             NullLoggerFactory.Instance,
             Mock.Of<IToolChainBuilder>(),
-            Mock.Of<ISkillPrerequisiteResolver>());
+            Mock.Of<ISkillPrerequisiteResolver>(),
+            new UnsandboxedSkillFileReader());
 
         _supervisor = new CapabilityMatchSupervisor(
             _strategyMock.Object,

--- a/src/Content/Tests/Infrastructure.AI.Tests/Agents/CapabilityMatchSupervisorTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Agents/CapabilityMatchSupervisorTests.cs
@@ -82,7 +82,8 @@ public sealed class CapabilityMatchSupervisorTests : IDisposable
             Mock.Of<IServiceProvider>(),
             NullLoggerFactory.Instance,
             Mock.Of<IToolChainBuilder>(),
-            Mock.Of<ISkillPrerequisiteResolver>());
+            Mock.Of<ISkillPrerequisiteResolver>(),
+            new UnsandboxedSkillFileReader());
 
         SetupDefaults();
 

--- a/src/Content/Tests/Infrastructure.AI.Tests/Bundles/BundleStagingServiceTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Bundles/BundleStagingServiceTests.cs
@@ -209,7 +209,8 @@ public sealed class BundleStagingServiceTests : IDisposable
         new(
             new OptionsMonitorStub(appConfig),
             new AgentMetadataParser(NullLogger<AgentMetadataParser>.Instance),
-            new SkillMetadataParser(NullLogger<SkillMetadataParser>.Instance),
+            new SkillMetadataParser(NullLogger<SkillMetadataParser>.Instance, new UnsandboxedSkillFileReader()),
+            new UnsandboxedSkillFileReader(),
             new PluginManifestReader(NullLogger<PluginManifestReader>.Instance),
             NullLogger<BundleStagingService>.Instance);
 

--- a/src/Content/Tests/Infrastructure.AI.Tests/Skills/PluginGovernanceWiringTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Skills/PluginGovernanceWiringTests.cs
@@ -79,7 +79,8 @@ public sealed class PluginGovernanceWiringTests : IDisposable
         return new SkillMetadataRegistry(
             NullLogger<SkillMetadataRegistry>.Instance,
             new OptionsMonitorStub(appConfig),
-            new SkillMetadataParser(NullLogger<SkillMetadataParser>.Instance),
+            new SkillMetadataParser(NullLogger<SkillMetadataParser>.Instance, new UnsandboxedSkillFileReader()),
+            new UnsandboxedSkillFileReader(),
             pluginRegistry);
     }
 

--- a/src/Content/Tests/Infrastructure.AI.Tests/Skills/SkillFileReaderTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Skills/SkillFileReaderTests.cs
@@ -1,0 +1,195 @@
+using Application.AI.Common.Interfaces.Skills;
+using Domain.Common.Config;
+using Domain.Common.Config.AI;
+using Domain.Common.Config.AI.BundleExecution;
+using FluentAssertions;
+using Infrastructure.AI.Skills;
+using Infrastructure.AI.Tools;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Skills;
+
+/// <summary>
+/// Confinement tests for <see cref="SkillFileReader"/> — the sandbox that replaced the unguarded
+/// <c>System.IO</c> reads the skill subsystem used to perform (issue #247).
+/// </summary>
+/// <remarks>
+/// The decisive test here is <see cref="ModelFileSandbox_DoesNotCoverSkillRoots_SoSkillsCannotBeRewritten"/>.
+/// The obvious way to close the original bypass was to add the skill roots to the model's own
+/// <c>IFileSystemService</c> allowlist; that service can write and the model reaches it through the
+/// <c>file_system</c> tool with no approval gate, so doing so would have let the model rewrite its
+/// own <c>SKILL.md</c> — <c>allowed-tools</c> included. That test fails if anyone later merges the
+/// two allowlists.
+/// </remarks>
+public sealed class SkillFileReaderTests : IDisposable
+{
+    private readonly string _root;
+    private readonly string _skillsRoot;
+    private readonly string _agentsRoot;
+    private readonly string _stagingRoot;
+    private readonly string _outsideRoot;
+
+    public SkillFileReaderTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "skill-file-reader-" + Guid.NewGuid().ToString("N"));
+        _skillsRoot = Path.Combine(_root, "skills");
+        _agentsRoot = Path.Combine(_root, "agents");
+        _stagingRoot = Path.Combine(_root, "staging");
+        _outsideRoot = Path.Combine(_root, "outside");
+
+        foreach (var dir in new[] { _skillsRoot, _agentsRoot, _stagingRoot, _outsideRoot })
+            Directory.CreateDirectory(dir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_root))
+            Directory.Delete(_root, recursive: true);
+    }
+
+    [Fact]
+    public void ReadText_SkillManifestInsideConfiguredSkillRoot_IsRead()
+    {
+        var manifest = WriteSkill(_skillsRoot, "do-thing", "body text");
+        var reader = CreateReader();
+
+        reader.ReadText(manifest).Should().Contain("body text");
+    }
+
+    [Fact]
+    public void ReadText_PathOutsideEverySkillRoot_IsRefused()
+    {
+        var secret = Path.Combine(_outsideRoot, "secret.md");
+        File.WriteAllText(secret, "not skill content");
+        var reader = CreateReader();
+
+        var act = () => reader.ReadText(secret);
+
+        act.Should().Throw<UnauthorizedAccessException>();
+    }
+
+    [Fact]
+    public void ReadText_AgentOwnedSkill_IsRead()
+    {
+        // Agent-owned skills live under <agentDir>/skills and are discovered by NestedSkillScanner,
+        // not by the skills-config walk — so the agent roots must be permitted too.
+        var agentSkills = Path.Combine(_agentsRoot, "planner", "skills");
+        Directory.CreateDirectory(agentSkills);
+        var manifest = WriteSkill(agentSkills, "own-skill", "agent owned");
+        var reader = CreateReader();
+
+        reader.ReadText(manifest).Should().Contain("agent owned");
+    }
+
+    [Fact]
+    public void ReadText_BundleStagedSkill_IsRead()
+    {
+        var bundleSkills = Path.Combine(_stagingRoot, "bundle-1", "skills", "staged");
+        Directory.CreateDirectory(bundleSkills);
+        var manifest = Path.Combine(bundleSkills, "SKILL.md");
+        File.WriteAllText(manifest, "staged bundle skill");
+        var reader = CreateReader();
+
+        reader.ReadText(manifest).Should().Contain("staged bundle skill");
+    }
+
+    [Fact]
+    public void ReadText_PluginRootAddedAfterFirstUse_IsPermittedWithoutRestart()
+    {
+        // The regression this guards: PluginStartupLoader appends plugin skill directories to
+        // SkillsConfig.AdditionalPaths during host start — AFTER the DI container is built. A reader
+        // that snapshotted its allowed set at construction would refuse every plugin skill. So the
+        // first call here must be made BEFORE the plugin path is added, to prove the set is
+        // recomputed rather than merely resolved late.
+        var appConfig = BuildConfig();
+        var reader = new SkillFileReader(new OptionsMonitorStub(appConfig), NullLogger<SkillFileReader>.Instance);
+
+        var pluginSkills = Path.Combine(_root, "plugins", "acme", "skills", "acme-skill");
+        Directory.CreateDirectory(pluginSkills);
+        var manifest = Path.Combine(pluginSkills, "SKILL.md");
+        File.WriteAllText(manifest, "plugin supplied");
+
+        var beforeRegistration = () => reader.ReadText(manifest);
+        beforeRegistration.Should().Throw<UnauthorizedAccessException>(
+            "the plugin directory is not yet a configured skill root");
+
+        appConfig.AI.Skills.AdditionalPaths = [Path.Combine(_root, "plugins", "acme", "skills")];
+
+        reader.ReadText(manifest).Should().Contain("plugin supplied");
+    }
+
+    [Fact]
+    public void EnumerateDirectories_ReturnsAbsolutePathsOfImmediateChildren()
+    {
+        Directory.CreateDirectory(Path.Combine(_skillsRoot, "alpha"));
+        Directory.CreateDirectory(Path.Combine(_skillsRoot, "beta"));
+        var reader = CreateReader();
+
+        var result = reader.EnumerateDirectories(_skillsRoot);
+
+        result.Should().HaveCount(2);
+        result.Should().OnlyContain(p => Path.IsPathRooted(p));
+        result.Select(Path.GetFileName).Should().BeEquivalentTo(["alpha", "beta"]);
+    }
+
+    [Fact]
+    public void DirectoryExists_PathOutsideSkillRoots_IsRefusedRatherThanReportedMissing()
+    {
+        // Fail-loud, not fail-silent: returning false here would let a misconfigured root read as
+        // "this directory holds no skills", turning a refusal into a silently empty skill set.
+        var reader = CreateReader();
+
+        var act = () => reader.DirectoryExists(_outsideRoot);
+
+        act.Should().Throw<UnauthorizedAccessException>();
+    }
+
+    [Fact]
+    public async Task ModelFileSandbox_DoesNotCoverSkillRoots_SoSkillsCannotBeRewritten()
+    {
+        // The whole reason SkillFileReader exists as a separate sandbox. FileSystemService is what
+        // the model reaches through the file_system tool, and that tool exposes an ungated write.
+        var workspace = Path.Combine(_root, "workspace");
+        Directory.CreateDirectory(workspace);
+        var modelSandbox = new FileSystemService(
+            NullLogger<FileSystemService>.Instance, [workspace]);
+
+        var manifest = WriteSkill(_skillsRoot, "victim", "original instructions");
+
+        var write = async () => await modelSandbox.WriteFileAsync(manifest, "allowed-tools: [everything]");
+        await write.Should().ThrowAsync<UnauthorizedAccessException>();
+
+        File.ReadAllText(manifest).Should().Contain("original instructions");
+    }
+
+    private static string WriteSkill(string root, string name, string body)
+    {
+        var dir = Path.Combine(root, name);
+        Directory.CreateDirectory(dir);
+        var path = Path.Combine(dir, "SKILL.md");
+        File.WriteAllText(path, body);
+        return path;
+    }
+
+    private SkillFileReader CreateReader() =>
+        new(new OptionsMonitorStub(BuildConfig()), NullLogger<SkillFileReader>.Instance);
+
+    private AppConfig BuildConfig() => new()
+    {
+        AI = new AIConfig
+        {
+            Skills = new SkillsConfig { BasePath = _skillsRoot },
+            Agents = new AgentsConfig { BasePath = _agentsRoot },
+            BundleExecution = new BundleExecutionConfig { TempRoot = _stagingRoot },
+        }
+    };
+
+    private sealed class OptionsMonitorStub(AppConfig value) : IOptionsMonitor<AppConfig>
+    {
+        public AppConfig CurrentValue { get; } = value;
+        public AppConfig Get(string? name) => CurrentValue;
+        public IDisposable? OnChange(Action<AppConfig, string?> listener) => null;
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Skills/SkillFileReaderTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Skills/SkillFileReaderTests.cs
@@ -147,6 +147,92 @@ public sealed class SkillFileReaderTests : IDisposable
     }
 
     [Fact]
+    public async Task ReadTextAsync_SkillResourceInsideSkillRoot_IsRead()
+    {
+        // The member the MODEL reaches, through the framework's read_skill_resource tool.
+        var reference = Path.Combine(_skillsRoot, "do-thing", "references");
+        Directory.CreateDirectory(reference);
+        var path = Path.Combine(reference, "api.md");
+        await File.WriteAllTextAsync(path, "reference body");
+        var reader = CreateReader();
+
+        (await reader.ReadTextAsync(path)).Should().Contain("reference body");
+    }
+
+    [Fact]
+    public async Task ReadTextAsync_PathOutsideEverySkillRoot_IsRefused()
+    {
+        var secret = Path.Combine(_outsideRoot, "secret.md");
+        await File.WriteAllTextAsync(secret, "not skill content");
+        var reader = CreateReader();
+
+        var act = async () => await reader.ReadTextAsync(secret);
+
+        await act.Should().ThrowAsync<UnauthorizedAccessException>();
+    }
+
+    [Fact]
+    public void FileExists_DistinguishesPresentFromAbsentInsideTheSandbox()
+    {
+        var manifest = WriteSkill(_skillsRoot, "present", "body");
+        var reader = CreateReader();
+
+        reader.FileExists(manifest).Should().BeTrue();
+        reader.FileExists(Path.Combine(_skillsRoot, "present", "MISSING.md")).Should().BeFalse();
+    }
+
+    [Fact]
+    public void FileExists_PathOutsideSkillRoots_IsRefusedRatherThanReportedMissing()
+    {
+        var reader = CreateReader();
+
+        var act = () => reader.FileExists(Path.Combine(_outsideRoot, "secret.md"));
+
+        act.Should().Throw<UnauthorizedAccessException>();
+    }
+
+    [Fact]
+    public void ReadText_FileBeyondTheSizeLimit_IsRefusedBeforeItIsLoaded()
+    {
+        // Bounds memory on a path that reads whatever a manifest names. 10 MB + 1 byte.
+        var dir = Path.Combine(_skillsRoot, "huge");
+        Directory.CreateDirectory(dir);
+        var path = Path.Combine(dir, "SKILL.md");
+        File.WriteAllBytes(path, new byte[(10 * 1024 * 1024) + 1]);
+        var reader = CreateReader();
+
+        var act = () => reader.ReadText(path);
+
+        act.Should().Throw<IOException>();
+    }
+
+    [Fact]
+    public void ReadText_PermittedPathNamingNoFile_ThrowsFileNotFound()
+    {
+        var reader = CreateReader();
+
+        var act = () => reader.ReadText(Path.Combine(_skillsRoot, "nothing-here", "SKILL.md"));
+
+        act.Should().Throw<FileNotFoundException>();
+    }
+
+    [Fact]
+    public void NestedSkillScanner_RefusedRoot_ThrowsInsteadOfReportingNoSkills()
+    {
+        // The scanner is best-effort by design — a malformed manifest is skipped so its siblings
+        // still load. That tolerance must not extend to a sandbox refusal: returning an empty list
+        // there is indistinguishable from a directory that genuinely holds no skills, so a
+        // misconfigured root would boot an agent silently missing all of its own skills.
+        var reader = CreateReader();
+        var parser = new SkillMetadataParser(NullLogger<SkillMetadataParser>.Instance, reader);
+
+        var act = () => NestedSkillScanner.Scan(
+            _outsideRoot, parser, reader, NullLogger<SkillFileReaderTests>.Instance);
+
+        act.Should().Throw<UnauthorizedAccessException>();
+    }
+
+    [Fact]
     public async Task ModelFileSandbox_DoesNotCoverSkillRoots_SoSkillsCannotBeRewritten()
     {
         // The whole reason SkillFileReader exists as a separate sandbox. FileSystemService is what

--- a/src/Content/Tests/Infrastructure.AI.Tests/Skills/SkillFrontmatterContractTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Skills/SkillFrontmatterContractTests.cs
@@ -18,7 +18,7 @@ public sealed class SkillFrontmatterContractTests : IDisposable
 
     public SkillFrontmatterContractTests()
     {
-        _sut = new SkillMetadataParser(NullLogger<SkillMetadataParser>.Instance);
+        _sut = new SkillMetadataParser(NullLogger<SkillMetadataParser>.Instance, new UnsandboxedSkillFileReader());
         _tempDir = Path.Combine(Path.GetTempPath(), $"frontmatter-contract-{Guid.NewGuid():N}");
         Directory.CreateDirectory(_tempDir);
     }

--- a/src/Content/Tests/Infrastructure.AI.Tests/Skills/SkillMetadataParserEgressTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Skills/SkillMetadataParserEgressTests.cs
@@ -18,7 +18,7 @@ public sealed class SkillMetadataParserEgressTests : IDisposable
 
     public SkillMetadataParserEgressTests()
     {
-        _sut = new SkillMetadataParser(NullLogger<SkillMetadataParser>.Instance);
+        _sut = new SkillMetadataParser(NullLogger<SkillMetadataParser>.Instance, new UnsandboxedSkillFileReader());
         _tempDir = Path.Combine(Path.GetTempPath(), $"egress-parser-tests-{Guid.NewGuid():N}");
         Directory.CreateDirectory(_tempDir);
     }

--- a/src/Content/Tests/Infrastructure.AI.Tests/Skills/SkillMetadataParserNestedYamlTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Skills/SkillMetadataParserNestedYamlTests.cs
@@ -15,7 +15,7 @@ public sealed class SkillMetadataParserNestedYamlTests : IDisposable
 
     public SkillMetadataParserNestedYamlTests()
     {
-        _sut = new SkillMetadataParser(NullLogger<SkillMetadataParser>.Instance);
+        _sut = new SkillMetadataParser(NullLogger<SkillMetadataParser>.Instance, new UnsandboxedSkillFileReader());
         _tempDir = Path.Combine(Path.GetTempPath(), $"skill-nested-yaml-tests-{Guid.NewGuid():N}");
         Directory.CreateDirectory(_tempDir);
     }

--- a/src/Content/Tests/Infrastructure.AI.Tests/Skills/SkillMetadataParserPrerequisiteTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Skills/SkillMetadataParserPrerequisiteTests.cs
@@ -16,7 +16,7 @@ public sealed class SkillMetadataParserPrerequisiteTests : IDisposable
 
     public SkillMetadataParserPrerequisiteTests()
     {
-        _sut = new SkillMetadataParser(NullLogger<SkillMetadataParser>.Instance);
+        _sut = new SkillMetadataParser(NullLogger<SkillMetadataParser>.Instance, new UnsandboxedSkillFileReader());
         _tempDir = Path.Combine(Path.GetTempPath(), $"prereq-parser-tests-{Guid.NewGuid():N}");
         Directory.CreateDirectory(_tempDir);
     }

--- a/src/Content/Tests/Infrastructure.AI.Tests/Skills/SkillMetadataParserTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Skills/SkillMetadataParserTests.cs
@@ -17,7 +17,7 @@ public sealed class SkillMetadataParserTests : IDisposable
 
     public SkillMetadataParserTests()
     {
-        _sut = new SkillMetadataParser(NullLogger<SkillMetadataParser>.Instance);
+        _sut = new SkillMetadataParser(NullLogger<SkillMetadataParser>.Instance, new UnsandboxedSkillFileReader());
         _tempDir = Path.Combine(Path.GetTempPath(), $"skill-parser-tests-{Guid.NewGuid():N}");
         Directory.CreateDirectory(_tempDir);
     }

--- a/src/Content/Tests/Infrastructure.AI.Tests/Skills/SkillMetadataParserToolDeclarationTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Skills/SkillMetadataParserToolDeclarationTests.cs
@@ -24,7 +24,7 @@ public sealed class SkillMetadataParserToolDeclarationTests : IDisposable
 
     public SkillMetadataParserToolDeclarationTests()
     {
-        _sut = new SkillMetadataParser(NullLogger<SkillMetadataParser>.Instance);
+        _sut = new SkillMetadataParser(NullLogger<SkillMetadataParser>.Instance, new UnsandboxedSkillFileReader());
         _tempDir = Path.Combine(Path.GetTempPath(), $"tooldecl-parser-tests-{Guid.NewGuid():N}");
         Directory.CreateDirectory(_tempDir);
     }

--- a/src/Content/Tests/Infrastructure.AI.Tests/Skills/SkillMetadataRegistryTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Skills/SkillMetadataRegistryTests.cs
@@ -31,9 +31,9 @@ public sealed class SkillMetadataRegistryTests
         };
         var optionsMonitor = new OptionsMonitorStub(appConfig);
         var logger = NullLogger<SkillMetadataRegistry>.Instance;
-        var parser = new SkillMetadataParser(NullLogger<SkillMetadataParser>.Instance);
+        var parser = new SkillMetadataParser(NullLogger<SkillMetadataParser>.Instance, new UnsandboxedSkillFileReader());
 
-        return new SkillMetadataRegistry(logger, optionsMonitor, parser);
+        return new SkillMetadataRegistry(logger, optionsMonitor, parser, new UnsandboxedSkillFileReader());
     }
 
     [Fact]
@@ -58,7 +58,8 @@ public sealed class SkillMetadataRegistryTests
         var registry = new SkillMetadataRegistry(
             NullLogger<SkillMetadataRegistry>.Instance,
             new OptionsMonitorStub(appConfig),
-            new SkillMetadataParser(NullLogger<SkillMetadataParser>.Instance),
+            new SkillMetadataParser(NullLogger<SkillMetadataParser>.Instance, new UnsandboxedSkillFileReader()),
+            new UnsandboxedSkillFileReader(),
             pluginRegistry: null);
 
         var act = () => registry.GetAll();
@@ -165,6 +166,8 @@ public sealed class SkillMetadataRegistryTests
         var services = new ServiceCollection();
         services.AddLogging();
         services.AddSingleton<IOptionsMonitor<AppConfig>>(new OptionsMonitorStub(new AppConfig()));
+        services.AddSingleton<Application.AI.Common.Interfaces.Skills.ISkillFileReader,
+            Infrastructure.AI.Skills.SkillFileReader>();
         services.AddSingleton<SkillMetadataParser>();
         services.AddSingleton<ISkillMetadataRegistry, SkillMetadataRegistry>();
 

--- a/src/Content/Tests/Infrastructure.AI.Tests/Skills/SkillParserExtensionTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Skills/SkillParserExtensionTests.cs
@@ -11,7 +11,7 @@ namespace Infrastructure.AI.Tests.Skills;
 public sealed class SkillParserExtensionTests
 {
     private static SkillMetadataParser CreateParser() =>
-        new(NullLogger<SkillMetadataParser>.Instance);
+        new(NullLogger<SkillMetadataParser>.Instance, new UnsandboxedSkillFileReader());
 
     [Fact]
     public void SkillParser_WithObjectivesSection_ExtractsObjectivesContent()

--- a/src/Content/Tests/Infrastructure.AI.Tests/Skills/UnsandboxedSkillFileReader.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Skills/UnsandboxedSkillFileReader.cs
@@ -1,0 +1,42 @@
+using Application.AI.Common.Interfaces.Skills;
+
+namespace Infrastructure.AI.Tests;
+
+/// <summary>
+/// An <see cref="ISkillFileReader"/> with <b>no sandbox at all</b>, for tests whose subject is
+/// parsing or discovery rather than confinement.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Those tests write fixtures to a temporary directory, which no correctly-configured skill sandbox
+/// would permit — so injecting the real <c>SkillFileReader</c> would make every one of them fail for
+/// a reason unrelated to what it asserts.
+/// </para>
+/// <para>
+/// <b>This double proves nothing about the sandbox.</b> Confinement is covered by
+/// <c>SkillFileReaderTests</c> against the real implementation. A test that means to assert a path
+/// is refused must not use this class — it permits everything, so such a test would pass while
+/// asserting nothing.
+/// </para>
+/// </remarks>
+internal sealed class UnsandboxedSkillFileReader : ISkillFileReader
+{
+    /// <inheritdoc />
+    public string ReadText(string path) => File.ReadAllText(path);
+
+    /// <inheritdoc />
+    public Task<string> ReadTextAsync(string path, CancellationToken cancellationToken = default) =>
+        File.ReadAllTextAsync(path, System.Text.Encoding.UTF8, cancellationToken);
+
+    /// <inheritdoc />
+    public bool FileExists(string path) => File.Exists(path);
+
+    /// <inheritdoc />
+    public bool DirectoryExists(string path) => Directory.Exists(path);
+
+    /// <inheritdoc />
+    public IReadOnlyList<string> EnumerateDirectories(string path) =>
+        Directory.Exists(path)
+            ? [.. Directory.EnumerateDirectories(path)]
+            : throw new DirectoryNotFoundException($"Directory not found: {path}");
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Tools/Workspace/WorkspaceSkillManifestTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Tools/Workspace/WorkspaceSkillManifestTests.cs
@@ -22,7 +22,7 @@ public sealed class WorkspaceSkillManifestTests
         File.Exists(skillPath).Should().BeTrue(
             $"the workspace SKILL.md must ship in the repo at {skillPath}");
 
-        var parser = new SkillMetadataParser(NullLogger<SkillMetadataParser>.Instance);
+        var parser = new SkillMetadataParser(NullLogger<SkillMetadataParser>.Instance, new UnsandboxedSkillFileReader());
         var skill = parser.ParseFromFile(skillPath, Path.GetDirectoryName(skillPath)!, pluginSource: "workspace-skill");
 
         skill.Name.Should().Be("workspace");


### PR DESCRIPTION
Closes #247.

## The gap was wider than the issue described

The issue named one on-demand resource read in the Application layer. That read is currently unreachable — nothing in production populates skill resources yet. The **live** gap was that the entire skill subsystem read from disk with no confinement at all: every `SKILL.md` parse, every discovery walk, agent-owned skills, and bundle-staged skills went straight to `System.IO`.

## Why not Option A literally

Option A said to widen `IFileSystemService`'s allowlist to include the skill roots. That service is a single shared instance that also backs `FileSystemTool` — the LLM-facing tool — whose `write` operation has no approval gate. Widening it would have let the model rewrite its own `SKILL.md` files, including the `allowed-tools` list that constrains which tools it may call. One bypass closed, a worse one opened.

Raised with @MCKRUZ before building; the chosen shape is a **separate read-only sandbox** for skill loading, sharing one rules implementation (`SandboxedPathGuard`, extracted from `FileSystemService`) so the two cannot drift on what "inside" means. `ISkillFileReader` has no write member to misuse.

A second problem the issue didn't anticipate: plugin skill directories are registered during host start, **after** the DI container is built. A permitted-set snapshotted at registration time would refuse exactly the plugin skills the harness advertises. The roots are recomputed.

## The guarantee

Skill loading is confined to the **configured skill content roots** — skills, agents, and the bundle staging root — read-only, and to nothing in the model's own file allowlist. The two allowlists are disjoint by design. Written into `documentation/security/05-sandbox-and-execution.html`.

## Also fixed here

A **real startup failure**: the standalone MCP server composes its skill services itself and would not have booted. Caught by the test suite. Both composition roots now go through one `AddSkillDiscovery()` call so a third host cannot get the set wrong.

## Test plan

Full solution green — **0 failures across 22 projects**.

- The guard extraction is proven behaviour-neutral against the existing 262 sandbox tests (escape, hard-link, protected-path suites), unchanged.
- 15 confinement tests on the new reader, including `ModelFileSandbox_DoesNotCoverSkillRoots_SoSkillsCannotBeRewritten`, which fails if anyone ever merges the two allowlists.
- Four deliberate mutations, each failing only the test written to catch it: snapshot the roots → the plugin live-resolution test; widen confinement → the refusal tests; merge the two allowlists → the separation test; revert the resource read to raw file IO → the disclosure-wiring test.

The disclosure-wiring test was mutation-checked twice. The first attempt asserted against the resource descriptor rather than its content and so proved nothing — the full run caught it, and the corrected version now fails for the right reason.

## Review

`/code-review` (Standards + Spec) and `/simplify` (4 agents) both run; all findings fixed. One `/simplify` suggestion was **rejected on evidence**: switching root resolution to `IOptionsMonitor.OnChange` invalidation would never fire, because the plugin loader mutates the settings object directly rather than reloading configuration — it would have silently refused every plugin skill.

Two items noted for follow-up rather than fixed here: `Infrastructure.AI.RAG`'s `MarkdownDocumentParser` still hand-rolls a third copy of the confinement rule and structurally cannot reach the shared guard; and `ISkillFileReader` is named more narrowly than it behaves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
