### PR TITLE
feat: charge on-demand skill loads to the context budget (#248)

### DIFF
--- a/src/Content/Application/Application.AI.Common/Extensions/ContextBudgetTrackerExtensions.cs
+++ b/src/Content/Application/Application.AI.Common/Extensions/ContextBudgetTrackerExtensions.cs
@@ -1,0 +1,65 @@
+using System.Diagnostics.Metrics;
+using Application.AI.Common.Interfaces.Context;
+using Application.AI.Common.OpenTelemetry.Metrics;
+using Domain.AI.Telemetry.Conventions;
+
+namespace Application.AI.Common.Extensions;
+
+/// <summary>
+/// Records a context-budget allocation and publishes the telemetry that must always accompany it.
+/// </summary>
+/// <remarks>
+/// Charging the budget and reporting the charge are one act, not two. Every component owes three writes:
+/// the allocation itself, a sample on its own component instrument, and a sample on the shared
+/// <see cref="ContextSourceMetrics.SourceTokens"/> histogram that the Context Explorer dashboard reads.
+/// Written out by hand at each site, the third one is the one that gets forgotten — and its absence is
+/// silent, because the budget number stays correct while the dashboard simply stops showing that slice.
+/// This exists so the set cannot be written incompletely.
+/// </remarks>
+public static class ContextBudgetTrackerExtensions
+{
+    /// <summary>
+    /// Charges <paramref name="tokens"/> to a named component of <paramref name="agentName"/>'s budget and
+    /// publishes the component and context-source metrics for it.
+    /// </summary>
+    /// <param name="tracker">The budget being charged.</param>
+    /// <param name="agentName">The agent whose budget this belongs to.</param>
+    /// <param name="component">The budget component, from <see cref="ContextConventions.BudgetComponents"/>.</param>
+    /// <param name="sourceType">
+    /// The context source this counts as, from <see cref="ContextConventions.SourceTypeValues"/>. Several
+    /// components can share one source type — the two skill tiers are both <c>skills</c> — so the dashboard
+    /// can total a source without losing the finer breakdown.
+    /// </param>
+    /// <param name="tokens">The estimated token cost.</param>
+    /// <param name="componentInstrument">The histogram specific to this component.</param>
+    /// <param name="extraTag">
+    /// An optional dimension for <paramref name="componentInstrument"/> only — the skill tier, for instance.
+    /// It is deliberately not applied to the shared source histogram, whose dimensions must stay uniform
+    /// across every component that writes to it.
+    /// </param>
+    public static void RecordAndPublish(
+        this IContextBudgetTracker tracker,
+        string agentName,
+        string component,
+        string sourceType,
+        int tokens,
+        Histogram<long> componentInstrument,
+        KeyValuePair<string, object?>? extraTag = null)
+    {
+        ArgumentNullException.ThrowIfNull(tracker);
+        ArgumentNullException.ThrowIfNull(componentInstrument);
+
+        tracker.RecordAllocation(agentName, component, tokens);
+
+        var agentTag = new KeyValuePair<string, object?>(AgentConventions.Name, agentName);
+
+        if (extraTag is { } tag)
+            componentInstrument.Record(tokens, agentTag, tag);
+        else
+            componentInstrument.Record(tokens, agentTag);
+
+        ContextSourceMetrics.SourceTokens.Record(tokens,
+            new KeyValuePair<string, object?>(ContextConventions.SourceType, sourceType),
+            agentTag);
+    }
+}

--- a/src/Content/Application/Application.AI.Common/Factories/AgentExecutionContextFactory.cs
+++ b/src/Content/Application/Application.AI.Common/Factories/AgentExecutionContextFactory.cs
@@ -111,6 +111,12 @@ public class AgentExecutionContextFactory
             .ToHashSet(StringComparer.OrdinalIgnoreCase);
         LogSkillsExcludedFromDisclosure(skills, disclosedOnDemand);
 
+        // Everything above moves cost OUT of the static prompt and into on-demand pulls the harness never
+        // sees, because they happen inside the framework provider. Left there, the budget recorded below
+        // would under-report by exactly the amount progressive disclosure defers — worst on the turns that
+        // load the most. Wrapping each skill puts harness code back in that path (issue #248).
+        disclosableSkills = ChargeSkillLoadsToBudget(disclosableSkills, agentName);
+
         // Static system prompt. The legacy path merges skill instructions + additional context
         // verbatim (SkillInstructionMerger is the single source of truth for that format). Bodies the
         // framework provider will serve through load_skill are omitted — that is Tier 2 content, and the
@@ -502,6 +508,29 @@ public class AgentExecutionContextFactory
         }
 
         return providers.Count > 0 ? providers : null;
+    }
+
+    /// <summary>
+    /// Wraps each disclosable skill so the tokens its Tier 2 body and Tier 3 files put into the context are
+    /// charged to <paramref name="agentName"/>'s budget when the model pulls them.
+    /// </summary>
+    /// <param name="disclosableSkills">The skills about to be handed to the framework provider.</param>
+    /// <param name="agentName">The agent whose budget the pulls are charged to.</param>
+    /// <returns>
+    /// The same skills, each wrapped — or the input unchanged when no budget tracker is wired in, so a host
+    /// that does not track context passes the framework's own skill objects through untouched.
+    /// </returns>
+    private IReadOnlyList<DisclosableSkill> ChargeSkillLoadsToBudget(
+        IReadOnlyList<DisclosableSkill> disclosableSkills,
+        string agentName)
+    {
+        if (_budgetTracker is null || disclosableSkills.Count == 0)
+            return disclosableSkills;
+
+        return [.. disclosableSkills.Select(s => s with
+        {
+            Skill = new Services.Skills.BudgetChargingSkill(s.Skill, agentName, _budgetTracker)
+        })];
     }
 
     /// <summary>

--- a/src/Content/Application/Application.AI.Common/Factories/AgentExecutionContextFactory.cs
+++ b/src/Content/Application/Application.AI.Common/Factories/AgentExecutionContextFactory.cs
@@ -1,3 +1,4 @@
+using Application.AI.Common.Extensions;
 using Application.AI.Common.Helpers;
 using Application.AI.Common.Interfaces;
 using Application.AI.Common.Interfaces.Context;
@@ -111,10 +112,8 @@ public class AgentExecutionContextFactory
             .ToHashSet(StringComparer.OrdinalIgnoreCase);
         LogSkillsExcludedFromDisclosure(skills, disclosedOnDemand);
 
-        // Everything above moves cost OUT of the static prompt and into on-demand pulls the harness never
-        // sees, because they happen inside the framework provider. Left there, the budget recorded below
-        // would under-report by exactly the amount progressive disclosure defers — worst on the turns that
-        // load the most. Wrapping each skill puts harness code back in that path (issue #248).
+        // Everything above defers cost to pulls that happen inside the framework provider; this is what
+        // keeps the budget recorded below able to see them. See BudgetChargingSkill for why (issue #248).
         disclosableSkills = ChargeSkillLoadsToBudget(disclosableSkills, agentName);
 
         // Static system prompt. The legacy path merges skill instructions + additional context
@@ -149,25 +148,21 @@ public class AgentExecutionContextFactory
         // Track context budget allocations
         if (_budgetTracker != null)
         {
-            var instructionTokens = TokenEstimationHelper.EstimateTokens(instruction);
-            _budgetTracker.RecordAllocation(agentName, "system_prompt", instructionTokens);
-
-            ContextBudgetMetrics.SystemPromptTokens.Record(instructionTokens,
-                new KeyValuePair<string, object?>(AgentConventions.Name, agentName));
-            ContextSourceMetrics.SourceTokens.Record(instructionTokens,
-                new KeyValuePair<string, object?>(ContextConventions.SourceType, ContextConventions.SourceTypeValues.SystemPrompt),
-                new KeyValuePair<string, object?>(AgentConventions.Name, agentName));
+            _budgetTracker.RecordAndPublish(
+                agentName,
+                ContextConventions.BudgetComponents.SystemPrompt,
+                ContextConventions.SourceTypeValues.SystemPrompt,
+                TokenEstimationHelper.EstimateTokens(instruction),
+                ContextBudgetMetrics.SystemPromptTokens);
 
             if (tools?.Count > 0)
             {
-                var toolTokens = tools.Count * 50; // ~50 tokens per tool schema
-                _budgetTracker.RecordAllocation(agentName, "tool_schemas", toolTokens);
-
-                ContextBudgetMetrics.ToolsSchemaTokens.Record(toolTokens,
-                    new KeyValuePair<string, object?>(AgentConventions.Name, agentName));
-                ContextSourceMetrics.SourceTokens.Record(toolTokens,
-                    new KeyValuePair<string, object?>(ContextConventions.SourceType, ContextConventions.SourceTypeValues.ToolsSchema),
-                    new KeyValuePair<string, object?>(AgentConventions.Name, agentName));
+                _budgetTracker.RecordAndPublish(
+                    agentName,
+                    ContextConventions.BudgetComponents.ToolSchemas,
+                    ContextConventions.SourceTypeValues.ToolsSchema,
+                    tools.Count * 50, // ~50 tokens per tool schema
+                    ContextBudgetMetrics.ToolsSchemaTokens);
             }
         }
 

--- a/src/Content/Application/Application.AI.Common/Helpers/DisclosableSkillFactory.cs
+++ b/src/Content/Application/Application.AI.Common/Helpers/DisclosableSkillFactory.cs
@@ -13,8 +13,13 @@ namespace Application.AI.Common.Helpers;
 /// The <see cref="SkillDefinition.Id"/> this was built from. Its instructions are served on demand through
 /// <c>load_skill</c> and may therefore be left out of the prompt.
 /// </param>
-/// <param name="Skill">The framework skill handed to <c>AgentSkillsProviderBuilder.UseSkills</c>.</param>
-public sealed record DisclosableSkill(string SkillId, AgentInlineSkill Skill);
+/// <param name="Skill">
+/// The framework skill handed to <c>AgentSkillsProviderBuilder.UseSkills</c>. Typed as the
+/// <see cref="AgentSkill"/> base rather than the concrete inline skill so callers can decorate it —
+/// <see cref="Services.Skills.BudgetChargingSkill"/> does, to charge on-demand pulls to the context
+/// budget — which subclassing cannot achieve, as <see cref="AgentInlineSkill"/> is sealed.
+/// </param>
+public sealed record DisclosableSkill(string SkillId, AgentSkill Skill);
 
 /// <summary>
 /// Builds the framework skills that back progressive (Tier 2/3) disclosure, one per skill actually

--- a/src/Content/Application/Application.AI.Common/Services/Skills/BudgetChargingSkill.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Skills/BudgetChargingSkill.cs
@@ -1,3 +1,4 @@
+using Application.AI.Common.Extensions;
 using Application.AI.Common.Helpers;
 using Application.AI.Common.Interfaces.Context;
 using Application.AI.Common.OpenTelemetry.Metrics;
@@ -32,6 +33,15 @@ namespace Application.AI.Common.Services.Skills;
 /// under-reporting this exists to remove.
 /// </para>
 /// <para>
+/// <b>What "measured" means here.</b> The <em>content</em> is captured exactly — it passes through this
+/// wrapper on its way to the model. The <em>token figure</em> is not exact: it comes from
+/// <see cref="TokenEstimationHelper"/>, a characters-per-token approximation. That is deliberate, and it is
+/// the same estimator the system prompt and tool schemas are charged with, so every component of the
+/// budget is stated in one consistent unit. A tokenizer-accurate count for skills alone would make the
+/// components incomparable, which is worse than a uniform approximation. What this fixes is a component
+/// that was missing altogether, not the precision of the ones already there.
+/// </para>
+/// <para>
 /// This records consumption; it does not refuse it. <see cref="IContextBudgetTracker.EnsureBudget"/> is
 /// deliberately not called here — turning an over-budget skill load into a thrown exception mid-turn is a
 /// governance decision that belongs to whoever owns the turn, not to an accounting wrapper.
@@ -45,10 +55,22 @@ namespace Application.AI.Common.Services.Skills;
 public sealed class BudgetChargingSkill : AgentSkill
 {
     /// <summary>Budget component recording skill bodies served through <c>load_skill</c>.</summary>
-    public const string Tier2Component = "skills_tier2";
+    public const string Tier2Component = ContextConventions.BudgetComponents.SkillsTier2;
 
     /// <summary>Budget component recording supporting files served through <c>read_skill_resource</c>.</summary>
-    public const string Tier3Component = "skills_tier3";
+    public const string Tier3Component = ContextConventions.BudgetComponents.SkillsTier3;
+
+    /// <summary>
+    /// The budget component and metric dimension a Tier 2 pull is charged under, paired here rather than at
+    /// the call site: mismatch them and the budget stays right while the tier dimension misreports, which
+    /// nothing would fail on.
+    /// </summary>
+    private static readonly (string Component, string Tier) Tier2 =
+        (Tier2Component, ContextConventions.SkillsTierValues.Folder);
+
+    /// <summary>The same pairing for a Tier 3 pull.</summary>
+    private static readonly (string Component, string Tier) Tier3 =
+        (Tier3Component, ContextConventions.SkillsTierValues.FilingCabinet);
 
     private readonly AgentSkill _inner;
     private readonly string _agentName;
@@ -86,7 +108,7 @@ public sealed class BudgetChargingSkill : AgentSkill
     public override async ValueTask<string> GetContentAsync(CancellationToken cancellationToken = default)
     {
         var content = await _inner.GetContentAsync(cancellationToken).ConfigureAwait(false);
-        Charge(Tier2Component, ContextConventions.SkillsTierValues.Folder, content);
+        Charge(Tier2, content);
         return content;
     }
 
@@ -132,25 +154,23 @@ public sealed class BudgetChargingSkill : AgentSkill
 
     /// <summary>
     /// Records <paramref name="text"/>'s estimated token cost against the agent's budget and emits the
-    /// matching context-source telemetry.
+    /// telemetry that goes with it.
     /// </summary>
-    /// <param name="component">The budget component to charge.</param>
-    /// <param name="tier">The disclosure tier, for the metric dimension.</param>
+    /// <param name="tier">The component/dimension pair for the tier being charged.</param>
     /// <param name="text">The content that reached the model.</param>
-    private void Charge(string component, string tier, string? text)
+    private void Charge((string Component, string Tier) tier, string? text)
     {
         var tokens = TokenEstimationHelper.EstimateTokens(text);
         if (tokens == 0)
             return;
 
-        _budgetTracker.RecordAllocation(_agentName, component, tokens);
-
-        ContextBudgetMetrics.SkillsLoadedTokens.Record(tokens,
-            new KeyValuePair<string, object?>(AgentConventions.Name, _agentName),
-            new KeyValuePair<string, object?>(ContextConventions.SkillsTier, tier));
-        ContextSourceMetrics.SourceTokens.Record(tokens,
-            new KeyValuePair<string, object?>(ContextConventions.SourceType, ContextConventions.SourceTypeValues.Skills),
-            new KeyValuePair<string, object?>(AgentConventions.Name, _agentName));
+        _budgetTracker.RecordAndPublish(
+            _agentName,
+            tier.Component,
+            ContextConventions.SourceTypeValues.Skills,
+            tokens,
+            ContextBudgetMetrics.SkillsLoadedTokens,
+            new KeyValuePair<string, object?>(ContextConventions.SkillsTier, tier.Tier));
     }
 
     /// <summary>
@@ -176,7 +196,7 @@ public sealed class BudgetChargingSkill : AgentSkill
             CancellationToken cancellationToken = default)
         {
             var value = await inner.ReadAsync(serviceProvider, cancellationToken).ConfigureAwait(false);
-            owner.Charge(Tier3Component, ContextConventions.SkillsTierValues.FilingCabinet, value?.ToString());
+            owner.Charge(Tier3, value?.ToString());
             return value;
         }
     }

--- a/src/Content/Application/Application.AI.Common/Services/Skills/BudgetChargingSkill.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Skills/BudgetChargingSkill.cs
@@ -1,0 +1,183 @@
+using Application.AI.Common.Helpers;
+using Application.AI.Common.Interfaces.Context;
+using Application.AI.Common.OpenTelemetry.Metrics;
+using Domain.AI.Telemetry.Conventions;
+using Microsoft.Agents.AI;
+
+namespace Application.AI.Common.Services.Skills;
+
+/// <summary>
+/// Wraps a framework skill so the tokens it puts into the model's context when the model pulls it on
+/// demand are charged to <see cref="IContextBudgetTracker"/> — the Tier 2 body served by
+/// <c>load_skill</c>, and the Tier 3 supporting files served by <c>read_skill_resource</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Without this, those pulls happen entirely inside the framework's <see cref="AgentSkillsProvider"/>.
+/// The harness records the static system prompt and the tool schemas at agent construction and then sees
+/// nothing further, so a turn that loads several large skills mid-flight spends context the tracker still
+/// believes is free. The budget then under-reports on precisely the turns most likely to exhaust it
+/// (issue #248).
+/// </para>
+/// <para>
+/// <b>Why a wrapper and not a skills-source decorator.</b> The framework's source abstraction hands over
+/// the skill <em>list</em>; the content pull happens later, per skill. Wrapping the source would give
+/// exact accounting of nothing. This sits where the content actually flows. It also cannot be a subclass
+/// of <see cref="AgentInlineSkill"/> — that type is sealed — so it derives from the <see cref="AgentSkill"/>
+/// base and forwards every member.
+/// </para>
+/// <para>
+/// <b>Charged per pull, not per skill.</b> Each <c>load_skill</c> call appends its own tool-result message
+/// to the conversation, so a skill loaded twice really does cost twice. Deduplicating would restore the
+/// under-reporting this exists to remove.
+/// </para>
+/// <para>
+/// This records consumption; it does not refuse it. <see cref="IContextBudgetTracker.EnsureBudget"/> is
+/// deliberately not called here — turning an over-budget skill load into a thrown exception mid-turn is a
+/// governance decision that belongs to whoever owns the turn, not to an accounting wrapper.
+/// </para>
+/// <para>
+/// Instances are shared: the skill is held by a provider attached to an agent that is cached across turns
+/// and may serve concurrent ones. All state here is the injected collaborators, and
+/// <see cref="IContextBudgetTracker"/> is itself thread-safe.
+/// </para>
+/// </remarks>
+public sealed class BudgetChargingSkill : AgentSkill
+{
+    /// <summary>Budget component recording skill bodies served through <c>load_skill</c>.</summary>
+    public const string Tier2Component = "skills_tier2";
+
+    /// <summary>Budget component recording supporting files served through <c>read_skill_resource</c>.</summary>
+    public const string Tier3Component = "skills_tier3";
+
+    private readonly AgentSkill _inner;
+    private readonly string _agentName;
+    private readonly IContextBudgetTracker _budgetTracker;
+
+    /// <summary>
+    /// Initialises a wrapper that charges <paramref name="inner"/>'s on-demand pulls to
+    /// <paramref name="agentName"/>'s budget.
+    /// </summary>
+    /// <param name="inner">The skill whose content pulls are being accounted for.</param>
+    /// <param name="agentName">
+    /// The agent whose budget is charged. Must be the same name the rest of the context accounting uses,
+    /// or the skill tokens land in a budget nobody reads.
+    /// </param>
+    /// <param name="budgetTracker">Receives the measured allocations.</param>
+    public BudgetChargingSkill(AgentSkill inner, string agentName, IContextBudgetTracker budgetTracker)
+    {
+        ArgumentNullException.ThrowIfNull(inner);
+        ArgumentException.ThrowIfNullOrWhiteSpace(agentName);
+        ArgumentNullException.ThrowIfNull(budgetTracker);
+
+        _inner = inner;
+        _agentName = agentName;
+        _budgetTracker = budgetTracker;
+    }
+
+    /// <summary>The wrapped skill's frontmatter, unchanged — this wrapper alters no Tier 1 content.</summary>
+    public override AgentSkillFrontmatter Frontmatter => _inner.Frontmatter;
+
+    /// <summary>
+    /// Serves the skill body (Tier 2) and charges what it measures to the agent's budget.
+    /// </summary>
+    /// <param name="cancellationToken">Cancels the underlying pull.</param>
+    /// <returns>The wrapped skill's content, byte for byte.</returns>
+    public override async ValueTask<string> GetContentAsync(CancellationToken cancellationToken = default)
+    {
+        var content = await _inner.GetContentAsync(cancellationToken).ConfigureAwait(false);
+        Charge(Tier2Component, ContextConventions.SkillsTierValues.Folder, content);
+        return content;
+    }
+
+    /// <summary>
+    /// Resolves a supporting file (Tier 3), wrapping it so the charge lands when its content is actually
+    /// read rather than when it is merely resolved.
+    /// </summary>
+    /// <param name="name">The resource name the model asked for.</param>
+    /// <param name="cancellationToken">Cancels the underlying lookup.</param>
+    /// <returns>
+    /// A charging wrapper over the resolved resource, or <see langword="null"/> when the wrapped skill owns
+    /// no resource by that name — a miss costs the model nothing, so it must cost the budget nothing.
+    /// </returns>
+    /// <remarks>
+    /// This returns a descriptor, not content: the framework calls
+    /// <see cref="AgentSkillResource.ReadAsync"/> on it afterwards. Charging here would bill for a file the
+    /// model may never receive, and would miss the size of the one it does.
+    /// </remarks>
+    public override async ValueTask<AgentSkillResource?> GetResourceAsync(
+        string name,
+        CancellationToken cancellationToken = default)
+    {
+        var resource = await _inner.GetResourceAsync(name, cancellationToken).ConfigureAwait(false);
+        return resource is null ? null : new ChargingResource(resource, this);
+    }
+
+    /// <summary>
+    /// Forwards a script lookup unchanged.
+    /// </summary>
+    /// <param name="name">The script name the model asked for.</param>
+    /// <param name="cancellationToken">Cancels the underlying lookup.</param>
+    /// <returns>The wrapped skill's script, or <see langword="null"/>.</returns>
+    /// <remarks>
+    /// Deliberately not charged. This returns the script definition, not its output — what would enter the
+    /// context is whatever the script produces when run, and the harness runs skill scripts through its own
+    /// sandboxed tool chain rather than the framework's runner, so that output is accounted for there. On
+    /// the production path no scripts are registered at all and this always returns <see langword="null"/>.
+    /// </remarks>
+    public override ValueTask<AgentSkillScript?> GetScriptAsync(
+        string name,
+        CancellationToken cancellationToken = default)
+        => _inner.GetScriptAsync(name, cancellationToken);
+
+    /// <summary>
+    /// Records <paramref name="text"/>'s estimated token cost against the agent's budget and emits the
+    /// matching context-source telemetry.
+    /// </summary>
+    /// <param name="component">The budget component to charge.</param>
+    /// <param name="tier">The disclosure tier, for the metric dimension.</param>
+    /// <param name="text">The content that reached the model.</param>
+    private void Charge(string component, string tier, string? text)
+    {
+        var tokens = TokenEstimationHelper.EstimateTokens(text);
+        if (tokens == 0)
+            return;
+
+        _budgetTracker.RecordAllocation(_agentName, component, tokens);
+
+        ContextBudgetMetrics.SkillsLoadedTokens.Record(tokens,
+            new KeyValuePair<string, object?>(AgentConventions.Name, _agentName),
+            new KeyValuePair<string, object?>(ContextConventions.SkillsTier, tier));
+        ContextSourceMetrics.SourceTokens.Record(tokens,
+            new KeyValuePair<string, object?>(ContextConventions.SourceType, ContextConventions.SourceTypeValues.Skills),
+            new KeyValuePair<string, object?>(AgentConventions.Name, _agentName));
+    }
+
+    /// <summary>
+    /// A resource descriptor that charges its content to the owning skill's budget as it is read.
+    /// </summary>
+    /// <param name="inner">The resolved resource whose read is being accounted for.</param>
+    /// <param name="owner">The skill whose budget the read is charged to.</param>
+    private sealed class ChargingResource(AgentSkillResource inner, BudgetChargingSkill owner)
+        : AgentSkillResource(inner.Name, inner.Description)
+    {
+        /// <summary>
+        /// Reads the wrapped resource and charges what it returns.
+        /// </summary>
+        /// <param name="serviceProvider">Passed through to the wrapped resource.</param>
+        /// <param name="cancellationToken">Cancels the underlying read.</param>
+        /// <returns>The wrapped resource's value, unchanged.</returns>
+        /// <remarks>
+        /// The framework serialises this value on its way to the model, so measuring its string form is
+        /// the closest honest estimate available without re-doing that serialisation.
+        /// </remarks>
+        public override async Task<object?> ReadAsync(
+            IServiceProvider? serviceProvider = null,
+            CancellationToken cancellationToken = default)
+        {
+            var value = await inner.ReadAsync(serviceProvider, cancellationToken).ConfigureAwait(false);
+            owner.Charge(Tier3Component, ContextConventions.SkillsTierValues.FilingCabinet, value?.ToString());
+            return value;
+        }
+    }
+}

--- a/src/Content/Domain/Domain.AI/Telemetry/Conventions/ContextConventions.cs
+++ b/src/Content/Domain/Domain.AI/Telemetry/Conventions/ContextConventions.cs
@@ -27,13 +27,33 @@ public static class ContextConventions
     public const string SourceType = "agent.context.source_type";
 
     /// <summary>
+    /// The named components a context budget is broken down by. One home for these names because the
+    /// breakdown is only meaningful if every writer and every reader spells a component identically — a
+    /// typo does not fail, it silently splits one slice of the budget into two.
+    /// </summary>
+    public static class BudgetComponents
+    {
+        /// <summary>The composed static system prompt, charged once when the agent is built.</summary>
+        public const string SystemPrompt = "system_prompt";
+        /// <summary>The tool JSON schemas sent to the model, charged once when the agent is built.</summary>
+        public const string ToolSchemas = "tool_schemas";
+        /// <summary>Skill bodies served on demand through <c>load_skill</c>.</summary>
+        public const string SkillsTier2 = "skills_tier2";
+        /// <summary>Skill supporting files served on demand through <c>read_skill_resource</c>.</summary>
+        public const string SkillsTier3 = "skills_tier3";
+    }
+
+    /// <summary>
     /// Values for the <see cref="SkillsTier"/> dimension — which disclosure tier a skill's tokens were
     /// paid for. Numeric so a dashboard can order them; the names carry the meaning.
     /// </summary>
+    /// <remarks>
+    /// Tier 1 has no value here on purpose. The index card is composed by the framework's skills provider
+    /// rather than pulled on demand, so nothing in the harness is positioned to measure it and no emitter
+    /// would use the constant.
+    /// </remarks>
     public static class SkillsTierValues
     {
-        /// <summary>Tier 1 — the name/description index card, present from the first turn.</summary>
-        public const string IndexCard = "1";
         /// <summary>Tier 2 — the skill body, pulled when the model calls <c>load_skill</c>.</summary>
         public const string Folder = "2";
         /// <summary>Tier 3 — a supporting file, pulled when the model calls <c>read_skill_resource</c>.</summary>

--- a/src/Content/Domain/Domain.AI/Telemetry/Conventions/ContextConventions.cs
+++ b/src/Content/Domain/Domain.AI/Telemetry/Conventions/ContextConventions.cs
@@ -26,6 +26,20 @@ public static class ContextConventions
     /// <summary>Context source type dimension label.</summary>
     public const string SourceType = "agent.context.source_type";
 
+    /// <summary>
+    /// Values for the <see cref="SkillsTier"/> dimension — which disclosure tier a skill's tokens were
+    /// paid for. Numeric so a dashboard can order them; the names carry the meaning.
+    /// </summary>
+    public static class SkillsTierValues
+    {
+        /// <summary>Tier 1 — the name/description index card, present from the first turn.</summary>
+        public const string IndexCard = "1";
+        /// <summary>Tier 2 — the skill body, pulled when the model calls <c>load_skill</c>.</summary>
+        public const string Folder = "2";
+        /// <summary>Tier 3 — a supporting file, pulled when the model calls <c>read_skill_resource</c>.</summary>
+        public const string FilingCabinet = "3";
+    }
+
     public static class SourceTypeValues
     {
         public const string SystemPrompt = "system_prompt";

--- a/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentExecutionContextFactoryProgressiveDisclosureTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentExecutionContextFactoryProgressiveDisclosureTests.cs
@@ -1,6 +1,9 @@
 using Application.AI.Common.Factories;
+using Application.AI.Common.Helpers;
+using Application.AI.Common.Interfaces.Context;
 using Application.AI.Common.Interfaces.Skills;
 using Application.AI.Common.Services.Agent;
+using Application.AI.Common.Services.Context;
 using Application.AI.Common.Services.Skills;
 using Application.AI.Common.Services.Tools;
 using Application.AI.Common.Tests.Helpers;
@@ -95,7 +98,7 @@ public sealed class AgentExecutionContextFactoryProgressiveDisclosureTests : IDi
         AllowedTools = ["file_system"]
     };
 
-    private AgentExecutionContextFactory CreateFactory()
+    private AgentExecutionContextFactory CreateFactory(IContextBudgetTracker? budgetTracker = null)
     {
         var appConfig = new AppConfig
         {
@@ -115,8 +118,18 @@ public sealed class AgentExecutionContextFactoryProgressiveDisclosureTests : IDi
             NullLoggerFactory.Instance,
             new ToolChainBuilder(NullLogger<ToolChainBuilder>.Instance, sp),
             new SkillPrerequisiteResolver(),
-            new UnsandboxedSkillFileReader());
+            new UnsandboxedSkillFileReader(),
+            budgetTracker);
     }
+
+    private static ContextBudgetTracker CreateBudgetTracker() => new(
+        Mock.Of<IOptionsMonitor<AppConfig>>(m => m.CurrentValue == new AppConfig()),
+        NullLogger<ContextBudgetTracker>.Instance);
+
+    /// <summary>
+    /// The agent name the factory derives from the skill name, which is the key the budget is filed under.
+    /// </summary>
+    private const string AgentName = "DemoSkillAgent";
 
     /// <summary>
     /// Drives the framework skills provider exactly as the agent runtime does and returns the
@@ -288,5 +301,73 @@ public sealed class AgentExecutionContextFactoryProgressiveDisclosureTests : IDi
             ReferenceMarker,
             "Tier 3 exists so bulk reference material stays out of the prompt until asked for; if the read " +
             "does not return the file's contents, that material is simply unreachable");
+    }
+
+    // ── The budget sees what the tiers defer ──────────────────────────────────
+
+    [Fact]
+    public async Task LoadSkill_ChargesTheBodyItServedToTheContextBudget()
+    {
+        var budget = CreateBudgetTracker();
+        var context = await CreateFactory(budget).MapToAgentContextAsync([MakeSkill()], new SkillAgentOptions());
+        var aiContext = await InvokeSkillsProviderAsync(SkillsProviderOf(context));
+
+        var beforeLoad = budget.GetBreakdown(AgentName);
+        var body = await aiContext.Tools!
+            .OfType<AIFunction>()
+            .Single(t => t.Name == AgentSkillsProvider.LoadSkillToolName)
+            .InvokeAsync(new AIFunctionArguments { ["skillName"] = SkillName });
+
+        // Positive control: without this, a provider that served nothing would satisfy the assertion below
+        // by charging nothing, and the test would pass while proving the opposite of what it claims.
+        body?.ToString().Should().Contain(BodyMarker, "the load must actually have served the body");
+
+        beforeLoad.Should().NotContainKey(
+            BudgetChargingSkill.Tier2Component,
+            "Tier 2 is deferred — nothing is owed for it until the model asks");
+        budget.GetBreakdown(AgentName).Should().ContainKey(
+            BudgetChargingSkill.Tier2Component,
+            "the tokens the body just put into the context are spent whether or not the harness counts " +
+            "them; uncounted, the budget under-reports worst on the turns that load the most skills")
+            .WhoseValue.Should().Be(TokenEstimationHelper.EstimateTokens(body?.ToString()));
+    }
+
+    [Fact]
+    public async Task ReadSkillResource_ChargesTheFileItServedToTheContextBudget()
+    {
+        var referencePath = Path.Combine(_skillDir, "references", "guide.md");
+        Directory.CreateDirectory(Path.GetDirectoryName(referencePath)!);
+        await File.WriteAllTextAsync(referencePath, ReferenceMarker);
+
+        var skill = MakeSkill();
+        skill.References.Add(new SkillResource
+        {
+            FileName = "guide.md",
+            RelativePath = "references/guide.md",
+            FilePath = referencePath,
+            ResourceType = SkillResourceType.Reference
+        });
+
+        var budget = CreateBudgetTracker();
+        var context = await CreateFactory(budget).MapToAgentContextAsync([skill], new SkillAgentOptions());
+        var aiContext = await InvokeSkillsProviderAsync(SkillsProviderOf(context));
+
+        var readArguments = new AIFunctionArguments
+        {
+            ["skillName"] = SkillName,
+            ["resourceName"] = "references/guide.md"
+        };
+        readArguments.Services = new ServiceCollection().BuildServiceProvider();
+
+        var resource = await aiContext.Tools!
+            .OfType<AIFunction>()
+            .Single(t => t.Name == AgentSkillsProvider.ReadSkillResourceToolName)
+            .InvokeAsync(readArguments);
+
+        resource?.ToString().Should().Contain(ReferenceMarker, "the read must actually have served the file");
+        budget.GetBreakdown(AgentName).Should().ContainKey(
+            BudgetChargingSkill.Tier3Component,
+            "Tier 3 is where the bulk lives — supporting files are exactly the material progressive " +
+            "disclosure defers, so a budget blind to them is blind to the largest on-demand cost");
     }
 }

--- a/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentExecutionContextFactoryProgressiveDisclosureTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentExecutionContextFactoryProgressiveDisclosureTests.cs
@@ -322,9 +322,14 @@ public sealed class AgentExecutionContextFactoryProgressiveDisclosureTests : IDi
         // by charging nothing, and the test would pass while proving the opposite of what it claims.
         body?.ToString().Should().Contain(BodyMarker, "the load must actually have served the body");
 
+        // Captured after the provider composed its index card but before load_skill ran. This is the
+        // control for the assertion that follows: it proves the charge tracks the model's pull and not
+        // merely the provider being invoked, which would over-report on every turn — the inverse of the
+        // bug being fixed, and just as wrong.
         beforeLoad.Should().NotContainKey(
             BudgetChargingSkill.Tier2Component,
-            "Tier 2 is deferred — nothing is owed for it until the model asks");
+            "Tier 2 is deferred — building the index card reads the frontmatter, never the body, so " +
+            "nothing is owed for it until the model actually asks");
         budget.GetBreakdown(AgentName).Should().ContainKey(
             BudgetChargingSkill.Tier2Component,
             "the tokens the body just put into the context are spent whether or not the harness counts " +

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/Skills/BudgetChargingSkillTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/Skills/BudgetChargingSkillTests.cs
@@ -1,0 +1,203 @@
+using Application.AI.Common.Helpers;
+using Application.AI.Common.Services.Context;
+using Application.AI.Common.Services.Skills;
+using Domain.Common.Config;
+using FluentAssertions;
+using Microsoft.Agents.AI;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Application.AI.Common.Tests.Services.Skills;
+
+/// <summary>
+/// Tests <see cref="BudgetChargingSkill"/>, which makes the framework's on-demand skill pulls visible to
+/// the context budget.
+/// </summary>
+/// <remarks>
+/// The failure this guards against is silent in both directions. Charge nothing and the budget under-reports
+/// on the turns that load the most, which is the opposite of when a governance number needs to be right.
+/// Charge and alter what comes back, and the model receives content the harness edited on its way through.
+/// Every test below therefore asserts the charge <em>and</em> that the payload is unchanged.
+/// </remarks>
+public sealed class BudgetChargingSkillTests
+{
+    private const string AgentName = "DemoAgent";
+    private const string SkillName = "demo-skill";
+    private const string SkillBody = "# Demo\n\nDo the demo thing, carefully and at some length.";
+
+    private readonly ContextBudgetTracker _tracker = new(
+        Mock.Of<IOptionsMonitor<AppConfig>>(m => m.CurrentValue == new AppConfig()),
+        NullLogger<ContextBudgetTracker>.Instance);
+
+    private static AgentInlineSkill Inline(string body = SkillBody) =>
+        new(SkillName, "A demo skill.", body);
+
+    private BudgetChargingSkill Wrap(AgentSkill inner) => new(inner, AgentName, _tracker);
+
+    private int Charged(string component) =>
+        _tracker.GetBreakdown(AgentName).TryGetValue(component, out var tokens) ? tokens : 0;
+
+    // ── Tier 2: the skill body served by load_skill ───────────────────────────
+
+    [Fact]
+    public async Task GetContent_ChargesTheBodyItServed()
+    {
+        var skill = Wrap(Inline());
+
+        var content = await skill.GetContentAsync();
+
+        Charged(BudgetChargingSkill.Tier2Component).Should().Be(
+            TokenEstimationHelper.EstimateTokens(content),
+            "the charge has to be measured from what actually reached the model — a fixed or estimated " +
+            "figure would drift from the real cost the moment a skill body changed size");
+    }
+
+    [Fact]
+    public async Task GetContent_ReturnsTheBodyUnchanged()
+    {
+        var inner = Inline();
+        var expected = await inner.GetContentAsync();
+
+        var actual = await Wrap(Inline()).GetContentAsync();
+
+        actual.Should().Be(
+            expected,
+            "accounting must be transparent to the model; a wrapper that edits the body would change what " +
+            "the agent was instructed to do in order to count it");
+    }
+
+    [Fact]
+    public async Task GetContent_CalledTwice_ChargesTwice()
+    {
+        var skill = Wrap(Inline());
+
+        var first = await skill.GetContentAsync();
+        await skill.GetContentAsync();
+
+        Charged(BudgetChargingSkill.Tier2Component).Should().Be(
+            TokenEstimationHelper.EstimateTokens(first) * 2,
+            "each load_skill call appends its own tool-result message, so a skill loaded twice really does " +
+            "occupy the context twice — deduplicating would reinstate the under-reporting this exists to fix");
+    }
+
+    [Fact]
+    public async Task GetContent_EmptyBody_ChargesNothing()
+    {
+        // A skill whose content pull yields nothing costs the model nothing.
+        var skill = Wrap(new EmptyContentSkill(Inline().Frontmatter));
+
+        var content = await skill.GetContentAsync();
+
+        content.Should().BeEmpty();
+        _tracker.GetTotalAllocated(AgentName).Should().Be(0);
+    }
+
+    // ── Tier 3: supporting files served by read_skill_resource ────────────────
+
+    [Fact]
+    public async Task ReadResource_ChargesTheFileItServed()
+    {
+        const string fileContent = "reference material the model asked for";
+        var inline = Inline();
+        inline.AddResource("references/guide.md", () => Task.FromResult(fileContent));
+
+        var resource = await Wrap(inline).GetResourceAsync("references/guide.md");
+        var value = await resource!.ReadAsync(new ServiceCollection().BuildServiceProvider());
+
+        value?.ToString().Should().Be(fileContent, "the file must reach the model unedited");
+        Charged(BudgetChargingSkill.Tier3Component).Should().Be(
+            TokenEstimationHelper.EstimateTokens(fileContent),
+            "Tier 3 is where the bulk lives — a budget blind to it is blind to the largest on-demand cost");
+    }
+
+    [Fact]
+    public async Task GetResource_WithoutReading_ChargesNothing()
+    {
+        var inline = Inline();
+        inline.AddResource("references/guide.md", () => Task.FromResult("never read"));
+
+        var resource = await Wrap(inline).GetResourceAsync("references/guide.md");
+
+        resource.Should().NotBeNull();
+        _tracker.GetTotalAllocated(AgentName).Should().Be(
+            0,
+            "resolving a resource returns a descriptor, not content; billing here would charge for a file " +
+            "the model may never receive and would miss the size of the one it does");
+    }
+
+    [Fact]
+    public async Task GetResource_UnknownName_IsAMissAndCostsNothing()
+    {
+        var resource = await Wrap(Inline()).GetResourceAsync("references/absent.md");
+
+        resource.Should().BeNull("a miss must stay a miss — inventing a descriptor would make the framework " +
+            "report a file that does not exist");
+        _tracker.GetTotalAllocated(AgentName).Should().Be(0);
+    }
+
+    [Fact]
+    public async Task GetResource_PreservesTheDescriptorIdentity()
+    {
+        var inline = Inline();
+        inline.AddResource("references/guide.md", () => Task.FromResult("content"));
+
+        var inner = await inline.GetResourceAsync("references/guide.md");
+        var wrapped = await Wrap(inline).GetResourceAsync("references/guide.md");
+
+        wrapped!.Name.Should().Be(
+            inner!.Name,
+            "the framework resolves and reports resources by name; a wrapper that renamed one would make it " +
+            "unreachable through the very tool that just found it");
+        wrapped.Description.Should().Be(inner.Description);
+    }
+
+    // ── Forwarding: everything this wrapper does not account for ──────────────
+
+    [Fact]
+    public void Frontmatter_IsTheWrappedSkills()
+    {
+        var inline = Inline();
+
+        var skill = Wrap(inline);
+
+        skill.Frontmatter.Name.Should().Be(inline.Frontmatter.Name);
+        skill.Frontmatter.Description.Should().Be(inline.Frontmatter.Description);
+    }
+
+    [Fact]
+    public async Task GetScript_IsForwardedAndNotCharged()
+    {
+        // Skill scripts run through the harness's own sandboxed tool chain, so their output is accounted
+        // for there. This call returns the definition, not the output — there is nothing here to charge.
+        var skill = Wrap(Inline());
+
+        var script = await skill.GetScriptAsync("anything");
+
+        script.Should().BeNull("no scripts are registered on the production path");
+        _tracker.GetTotalAllocated(AgentName).Should().Be(0);
+    }
+
+    [Fact]
+    public void Construction_RequiresAnAgentToChargeTo()
+    {
+        // The budget is keyed by agent name. A blank one would file the tokens under a budget nothing reads,
+        // which looks identical to not charging at all.
+        var act = () => new BudgetChargingSkill(Inline(), "  ", _tracker);
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    /// <summary>
+    /// A skill whose content pull yields nothing, for proving an empty pull is not charged.
+    /// </summary>
+    private sealed class EmptyContentSkill(AgentSkillFrontmatter frontmatter) : AgentSkill
+    {
+        public override AgentSkillFrontmatter Frontmatter { get; } = frontmatter;
+
+        public override ValueTask<string> GetContentAsync(CancellationToken cancellationToken = default)
+            => ValueTask.FromResult(string.Empty);
+    }
+}

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/Skills/BudgetChargingSkillTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/Skills/BudgetChargingSkillTests.cs
@@ -43,7 +43,7 @@ public sealed class BudgetChargingSkillTests
     // ── Tier 2: the skill body served by load_skill ───────────────────────────
 
     [Fact]
-    public async Task GetContent_ChargesTheBodyItServed()
+    public async Task GetContent_BodyServed_ChargesItsMeasuredTokens()
     {
         var skill = Wrap(Inline());
 
@@ -56,7 +56,7 @@ public sealed class BudgetChargingSkillTests
     }
 
     [Fact]
-    public async Task GetContent_ReturnsTheBodyUnchanged()
+    public async Task GetContent_BodyServed_ReturnsItUnchanged()
     {
         var inner = Inline();
         var expected = await inner.GetContentAsync();
@@ -98,7 +98,7 @@ public sealed class BudgetChargingSkillTests
     // ── Tier 3: supporting files served by read_skill_resource ────────────────
 
     [Fact]
-    public async Task ReadResource_ChargesTheFileItServed()
+    public async Task ReadResource_FileServed_ChargesItsMeasuredTokens()
     {
         const string fileContent = "reference material the model asked for";
         var inline = Inline();
@@ -139,7 +139,7 @@ public sealed class BudgetChargingSkillTests
     }
 
     [Fact]
-    public async Task GetResource_PreservesTheDescriptorIdentity()
+    public async Task GetResource_KnownName_PreservesTheDescriptorIdentity()
     {
         var inline = Inline();
         inline.AddResource("references/guide.md", () => Task.FromResult("content"));
@@ -157,7 +157,7 @@ public sealed class BudgetChargingSkillTests
     // ── Forwarding: everything this wrapper does not account for ──────────────
 
     [Fact]
-    public void Frontmatter_IsTheWrappedSkills()
+    public void Frontmatter_AnyWrappedSkill_IsForwardedUnchanged()
     {
         var inline = Inline();
 
@@ -168,7 +168,7 @@ public sealed class BudgetChargingSkillTests
     }
 
     [Fact]
-    public async Task GetScript_IsForwardedAndNotCharged()
+    public async Task GetScript_NoScriptRegistered_IsForwardedAndNotCharged()
     {
         // Skill scripts run through the harness's own sandboxed tool chain, so their output is accounted
         // for there. This call returns the definition, not the output — there is nothing here to charge.
@@ -181,7 +181,7 @@ public sealed class BudgetChargingSkillTests
     }
 
     [Fact]
-    public void Construction_RequiresAnAgentToChargeTo()
+    public void Construction_BlankAgentName_Throws()
     {
         // The budget is keyed by agent name. A blank one would file the tokens under a budget nothing reads,
         // which looks identical to not charging at all.


### PR DESCRIPTION
Closes #248. Implements **Option B** as decided: every on-demand skill pull now passes through harness code and is charged to the context budget.

## The problem

Progressive disclosure moves a skill's body and supporting files out of the static system prompt and into pulls the framework's skills provider performs later. Those pulls happened entirely inside the SDK. The harness recorded the system prompt and tool schemas when the agent was built and then saw nothing further — so the budget under-reported by exactly the amount disclosure defers, worst on the turns that load the most skills.

## The seam — and a correction to the issue

The issue proposed wrapping "the framework's skills source". That would not have worked, for two independent reasons: this harness does not use a skills source (it registers explicit skills, which is what confines `load_skill` to the agent's own set — a deliberate #225 decision), and a source hands over the skill *list*, not content, so a source wrapper would have given exact accounting of nothing.

The seam that does work was verified by compiling against the pinned `Microsoft.Agents.AI` 1.13.0, not by reading docs:

- `AgentSkill` declares exactly four members, all overridable — but `AgentInlineSkill` is **sealed**, so this decorates the base type rather than subclassing the concrete one. `DisclosableSkill.Skill` widens to `AgentSkill` accordingly.
- `GetResourceAsync` returns a resource **handle**, not content. A single-method decorator would have accounted for Tier 2 only, so `ChargingResource` wraps `ReadAsync` as well.

## What is charged

| Tier | Trigger | Charged |
|---|---|---|
| 1 — index card | provider builds its instructions | no — reads frontmatter, never the body |
| 2 — skill body | `load_skill` | yes, on the content served |
| 3 — supporting file | `read_skill_resource` | yes, on read rather than on resolve |

Charged **per pull**: each call appends its own tool-result message, so a skill loaded twice really does cost twice. It records consumption without refusing it — turning an over-budget load into a mid-turn throw is a governance decision belonging to whoever owns the turn.

**On "exact":** the *content* is captured exactly. The *token figure* is an estimate from the shared chars-per-token estimator — the same one the system prompt and tool schemas use, deliberately, so every component of the budget is stated in one comparable unit. What this fixes is a component that was missing altogether, not the precision of the ones already there.

This also gives `ContextBudgetMetrics.SkillsLoadedTokens` its first production emitter — it was declared and never recorded.

## Second commit — review findings

The `/code-review` and `/simplify` passes converged on the budget-recording invariant: charging the budget and reporting the charge are one act (an allocation, a component histogram sample, and a sample on the shared `SourceTokens` histogram the Context Explorer reads), and it had been written out by hand at three sites. The third write is the one that gets forgotten, silently — the budget stays right while the dashboard loses a slice. `ContextBudgetTrackerExtensions.RecordAndPublish` makes the set impossible to write incompletely, and component names move to `ContextConventions.BudgetComponents` beside the source types they pair with.

## Test plan

- `BudgetChargingSkillTests` — 11 unit tests, each asserting the charge **and** that the payload reaches the model unedited.
- `AgentExecutionContextFactoryProgressiveDisclosureTests` — two wiring tests driving the real provider's `load_skill` and `read_skill_resource` tools, with a positive control that the load actually served content, and a control proving the provider composing its index card charges nothing before the model asks.
- **Mutation-tested:** disabling the factory wiring fails both wiring tests and nothing else; disabling the Tier 2 charge fails exactly the three Tier 2 tests; disabling the Tier 3 charge fails exactly the two Tier 3 tests.
- Full solution build clean. Full suite green apart from four known local `TEMP`-path `FileSystemService` failures, unrelated and present on a clean tree.

## Known boundary

`AgentEvaluationService` builds its provider from a directory and is not covered. That is a pre-existing hole rather than one this change opens — that path has no `IContextBudgetTracker` wired at all and already hardcodes `TokenCost: 0`. Wrapping skills there would fix a fraction of it; it wants its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SZJogfXvRweW2wbMdetQ5H
