### PR TITLE
Charge per-turn injected context to the budget, and report real eval token cost

### DIFF
--- a/src/Content/Application/Application.AI.Common/Extensions/UsageDetailsExtensions.cs
+++ b/src/Content/Application/Application.AI.Common/Extensions/UsageDetailsExtensions.cs
@@ -1,0 +1,30 @@
+using Microsoft.Extensions.AI;
+
+namespace Application.AI.Common.Extensions;
+
+/// <summary>
+/// Reads a model provider's reported token usage consistently across the sites that consume it.
+/// </summary>
+/// <remarks>
+/// Providers populate <see cref="UsageDetails"/> inconsistently: some report a total, others report the
+/// input and output counts and leave the total unset. Reading only the total therefore discards real
+/// billing data that is present, and every consumer that discovers this ends up writing the same coalesce
+/// by hand. Written out per site, the rule drifts — and the symptom is two consumers reporting different
+/// costs for the same response, which looks like a provider inconsistency rather than a local bug.
+/// </remarks>
+public static class UsageDetailsExtensions
+{
+    /// <summary>
+    /// Gets the total tokens a response cost, preferring the provider's own total and falling back to the
+    /// sum of its parts.
+    /// </summary>
+    /// <param name="usage">The reported usage. <see langword="null"/> yields 0.</param>
+    /// <returns>
+    /// The provider's total when it reported one, otherwise input plus output. 0 when nothing was reported,
+    /// which callers should treat as "no usage available" rather than as a genuine zero cost.
+    /// </returns>
+    public static long TotalTokens(this UsageDetails? usage) =>
+        usage is null
+            ? 0
+            : usage.TotalTokenCount ?? ((usage.InputTokenCount ?? 0) + (usage.OutputTokenCount ?? 0));
+}

--- a/src/Content/Application/Application.AI.Common/Factories/AgentExecutionContextFactory.cs
+++ b/src/Content/Application/Application.AI.Common/Factories/AgentExecutionContextFactory.cs
@@ -138,11 +138,8 @@ public class AgentExecutionContextFactory
         var middlewareTypes = ResolveMiddlewareTypes(primarySkill, options);
         var aiContextProviders = BuildMergedAIContextProviders(skills.Count, effectiveAllowedTools, disclosableSkills);
 
-        // Everything on that rail contributes to the model's context on every turn and was, until this
-        // line, charged nothing. Appended after the list is complete so it measures the finished context;
-        // see PerTurnBudgetContextProvider for why one measurer at the end beats a wrapper per provider
-        // (issue #266).
-        AppendPerTurnBudgetProvider(aiContextProviders, agentName, instruction, tools?.Count ?? 0);
+        // Charges what that rail injects into every turn — see AppendPerTurnBudgetProvider (issue #266).
+        AppendPerTurnBudgetProvider(aiContextProviders, agentName, instruction, tools.Count);
         var frameworkType = options.FrameworkType
             ?? ResolveFrameworkTypeFromMetadata(primarySkill)
             ?? _appConfig.CurrentValue.AI?.AgentFramework?.ClientType

--- a/src/Content/Application/Application.AI.Common/Factories/AgentExecutionContextFactory.cs
+++ b/src/Content/Application/Application.AI.Common/Factories/AgentExecutionContextFactory.cs
@@ -137,6 +137,12 @@ public class AgentExecutionContextFactory
         var tools = mergedToolChain.Tools.ToList();
         var middlewareTypes = ResolveMiddlewareTypes(primarySkill, options);
         var aiContextProviders = BuildMergedAIContextProviders(skills.Count, effectiveAllowedTools, disclosableSkills);
+
+        // Everything on that rail contributes to the model's context on every turn and was, until this
+        // line, charged nothing. Appended after the list is complete so it measures the finished context;
+        // see PerTurnBudgetContextProvider for why one measurer at the end beats a wrapper per provider
+        // (issue #266).
+        AppendPerTurnBudgetProvider(aiContextProviders, agentName, instruction, tools?.Count ?? 0);
         var frameworkType = options.FrameworkType
             ?? ResolveFrameworkTypeFromMetadata(primarySkill)
             ?? _appConfig.CurrentValue.AI?.AgentFramework?.ClientType
@@ -161,7 +167,7 @@ public class AgentExecutionContextFactory
                     agentName,
                     ContextConventions.BudgetComponents.ToolSchemas,
                     ContextConventions.SourceTypeValues.ToolsSchema,
-                    tools.Count * 50, // ~50 tokens per tool schema
+                    TokenEstimationHelper.EstimateToolSchemaTokens(tools.Count),
                     ContextBudgetMetrics.ToolsSchemaTokens);
             }
         }
@@ -503,6 +509,52 @@ public class AgentExecutionContextFactory
         }
 
         return providers.Count > 0 ? providers : null;
+    }
+
+    /// <summary>
+    /// Appends the measurer that charges whatever <paramref name="providers"/> inject into each turn to
+    /// <paramref name="agentName"/>'s budget.
+    /// </summary>
+    /// <param name="providers">
+    /// The rail built for this agent, mutated in place. <see langword="null"/> or empty means the agent has
+    /// no rail, so there is nothing per-turn to charge and nothing is appended.
+    /// </param>
+    /// <param name="agentName">The agent whose budget the per-turn context is charged to.</param>
+    /// <param name="instruction">
+    /// The static system prompt, already charged separately. It is the baseline the measurer subtracts, so
+    /// only what the rail adds is charged here rather than the prompt being billed again every turn.
+    /// </param>
+    /// <param name="toolCount">
+    /// The number of tools the agent was built with, already charged as tool schemas — the baseline for
+    /// tools the rail contributes, such as the framework's own skill-disclosure tools.
+    /// </param>
+    /// <remarks>
+    /// It must be last: the runtime feeds each provider the previous one's output, so only the final
+    /// position sees everything the others contributed. Placing it after
+    /// <see cref="Services.Agent.GoverningToolContextProvider"/> — which is itself documented as going last
+    /// — is safe, because this provider neither adds nor removes tools and so cannot escape that governance
+    /// wrapper or defeat it. Nothing is appended when no budget tracker is wired in, leaving a host that
+    /// does not track context with exactly the rail it had before.
+    /// </remarks>
+    private void AppendPerTurnBudgetProvider(
+        IList<AIContextProvider>? providers,
+        string agentName,
+        string instruction,
+        int toolCount)
+    {
+        if (_budgetTracker is null || providers is null || providers.Count == 0)
+            return;
+
+        providers.Add(new Services.Agent.PerTurnBudgetContextProvider(
+            agentName,
+            _budgetTracker,
+            instruction,
+            toolCount,
+            _loggerFactory.CreateLogger<Services.Agent.PerTurnBudgetContextProvider>()));
+
+        _logger.LogDebug(
+            "Wired PerTurnBudgetContextProvider for {AgentName} behind {ProviderCount} context provider(s)",
+            agentName, providers.Count - 1);
     }
 
     /// <summary>

--- a/src/Content/Application/Application.AI.Common/Helpers/TokenEstimationHelper.cs
+++ b/src/Content/Application/Application.AI.Common/Helpers/TokenEstimationHelper.cs
@@ -53,6 +53,19 @@ public static class TokenEstimationHelper
         string.IsNullOrEmpty(text) ? 0 : (text.Length + CharsPerToken - 1) / CharsPerToken;
 
     /// <summary>
+    /// Estimates the token count for a span of text.
+    /// </summary>
+    /// <param name="text">The text to estimate. Returns 0 when empty.</param>
+    /// <returns>The estimated token count.</returns>
+    /// <remarks>
+    /// For callers holding a slice of a larger string — measuring what was appended to a prompt, say.
+    /// Materialising the slice just to be measured copies it for nothing, and on a per-turn path that is
+    /// a copy of several kilobytes discarded immediately.
+    /// </remarks>
+    public static int EstimateTokens(ReadOnlySpan<char> text) =>
+        text.IsEmpty ? 0 : (text.Length + CharsPerToken - 1) / CharsPerToken;
+
+    /// <summary>
     /// Estimates the total token count for multiple text segments.
     /// </summary>
     /// <param name="segments">The text segments to estimate.</param>

--- a/src/Content/Application/Application.AI.Common/Helpers/TokenEstimationHelper.cs
+++ b/src/Content/Application/Application.AI.Common/Helpers/TokenEstimationHelper.cs
@@ -22,6 +22,23 @@ public static class TokenEstimationHelper
     /// <summary>Average characters per token for English text.</summary>
     private const int CharsPerToken = 4;
 
+    /// <summary>Nominal token cost of one tool's JSON schema.</summary>
+    private const int TokensPerToolSchema = 50;
+
+    /// <summary>
+    /// Estimates the token cost of sending <paramref name="toolCount"/> tool JSON schemas to the model.
+    /// </summary>
+    /// <param name="toolCount">The number of tools whose schemas are sent. Negative counts estimate 0.</param>
+    /// <returns>The estimated token count.</returns>
+    /// <remarks>
+    /// A flat per-schema figure rather than a measurement of the serialised schema: the schemas are built
+    /// by the model client at request time and are not available to the harness when the budget is charged.
+    /// It lives here so every site charging for tool schemas uses one number — two sites that each hardcode
+    /// their own would drift silently, and the budget would still look plausible.
+    /// </remarks>
+    public static int EstimateToolSchemaTokens(int toolCount) =>
+        toolCount <= 0 ? 0 : toolCount * TokensPerToolSchema;
+
     /// <summary>
     /// Estimates the token count for a text string.
     /// </summary>

--- a/src/Content/Application/Application.AI.Common/OpenTelemetry/Metrics/ContextBudgetMetrics.cs
+++ b/src/Content/Application/Application.AI.Common/OpenTelemetry/Metrics/ContextBudgetMetrics.cs
@@ -33,6 +33,10 @@ public static class ContextBudgetMetrics
     public static Histogram<long> ToolsSchemaTokens { get; } =
         AppInstrument.Meter.CreateHistogram<long>(ContextConventions.ToolsSchemaTokens, "{token}", "Tool schemas token load");
 
+    /// <summary>Per-turn context-provider rail token load. Tags: agent.name.</summary>
+    public static Histogram<long> PerTurnContextTokens { get; } =
+        AppInstrument.Meter.CreateHistogram<long>(ContextConventions.PerTurnContextTokens, "{token}", "Per-turn injected context token load");
+
     /// <summary>Budget utilization ratio (0-1). Tags: agent.name.</summary>
     public static Histogram<double> BudgetUtilization { get; } =
         AppInstrument.Meter.CreateHistogram<double>(ContextConventions.BudgetUtilization, "{ratio}", "Context budget utilization ratio");

--- a/src/Content/Application/Application.AI.Common/Services/Agent/PerTurnBudgetContextProvider.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Agent/PerTurnBudgetContextProvider.cs
@@ -1,0 +1,181 @@
+using Application.AI.Common.Extensions;
+using Application.AI.Common.Helpers;
+using Application.AI.Common.Interfaces.Context;
+using Application.AI.Common.OpenTelemetry.Metrics;
+using Domain.AI.Telemetry.Conventions;
+using Microsoft.Agents.AI;
+using Microsoft.Extensions.Logging;
+
+namespace Application.AI.Common.Services.Agent;
+
+/// <summary>
+/// Charges the context every other <see cref="AIContextProvider"/> injects into a turn to
+/// <see cref="IContextBudgetTracker"/> — the skills index card and the framework's disclosure tools,
+/// cross-session memory recall, and task-similarity learnings.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Without this the budget records only what is known when the agent is built: the static system prompt
+/// and the harness's own tool schemas. Everything contributed on the provider rail is paid on <em>every
+/// turn</em> and counted on none, so the gap between what the budget reports and what the model's context
+/// actually holds widens as a conversation runs — fastest on the agents with the most memory to recall and
+/// the most skills to advertise (issue #266).
+/// </para>
+/// <para>
+/// <b>Why one measurer at the end of the rail, and not a wrapper per provider.</b> A per-provider wrapper
+/// would give a finer breakdown, and it cannot be built: the runtime rejects an agent whose providers do
+/// not all carry distinct <see cref="AIContextProvider.StateKeys"/>, and every instance of one wrapper type
+/// shares the default key of that type, so the agent's constructor throws. Even setting that aside, a
+/// delegating provider would have to forward every member of the base — the post-turn notification, the
+/// three message filters, the state keys, service resolution — and forgetting any one of them silently
+/// disables the provider it wraps. This assembly has already shipped that class of defect four times.
+/// Sitting at the end of the chain needs none of it.
+/// </para>
+/// <para>
+/// <b>How it measures.</b> The runtime feeds each provider the accumulated output of the ones before it,
+/// starting from the agent's own instructions and tools. Registered last, this provider therefore receives
+/// the finished context, and what the rail added is the difference between that and the baseline it was
+/// given at construction. It contributes nothing of its own, so it is trivially additive and cannot
+/// disturb what it measures.
+/// </para>
+/// <para>
+/// <b>Charged every turn, on purpose.</b> The system prompt and tool schemas are charged once, when the
+/// agent is built. This cost genuinely recurs — the index card and every recalled block are re-sent with
+/// each request — so charging it once would reproduce the under-reporting this exists to remove.
+/// </para>
+/// <para>
+/// <b>What "measured" means here.</b> Instruction text is captured exactly and converted with the shared
+/// <see cref="TokenEstimationHelper"/>, the same characters-per-token approximation the system prompt and
+/// tool schemas are charged with, so every component of the budget is stated in one unit. Tools contributed
+/// on the rail are charged at the shared flat per-schema estimate, because their serialised schemas are
+/// built by the model client and never pass through the harness.
+/// </para>
+/// <para>
+/// This records consumption; it does not refuse it. <see cref="IContextBudgetTracker.EnsureBudget"/> is
+/// deliberately not called — turning an over-budget turn into a thrown exception is a governance decision
+/// belonging to whoever owns the turn, not to an accounting provider.
+/// </para>
+/// <para>
+/// Instances are shared: the provider is attached to an agent cached across turns that may serve concurrent
+/// ones. All state is the injected collaborators and the immutable baseline, and
+/// <see cref="IContextBudgetTracker"/> is itself thread-safe.
+/// </para>
+/// </remarks>
+public sealed class PerTurnBudgetContextProvider : AIContextProvider
+{
+    /// <summary>The budget component every charge from this provider lands in.</summary>
+    public const string Component = ContextConventions.BudgetComponents.PerTurnContext;
+
+    /// <summary>Contributes nothing — the whole point is to observe without perturbing.</summary>
+    private static readonly AIContext NoContribution = new();
+
+    private readonly string _agentName;
+    private readonly IContextBudgetTracker _budgetTracker;
+    private readonly string _baselineInstructions;
+    private readonly int _baselineToolCount;
+    private readonly ILogger<PerTurnBudgetContextProvider> _logger;
+
+    /// <summary>
+    /// Initialises a measurer for one agent.
+    /// </summary>
+    /// <param name="agentName">
+    /// The agent whose budget is charged. Must be the same name the rest of the context accounting uses,
+    /// or these tokens land in a budget nobody reads.
+    /// </param>
+    /// <param name="budgetTracker">Receives the measured allocations.</param>
+    /// <param name="baselineInstructions">
+    /// The agent's static instructions — what the rail starts from, already charged as the system prompt.
+    /// Everything beyond it is what the rail added.
+    /// </param>
+    /// <param name="baselineToolCount">
+    /// The number of tools the agent was built with, already charged as tool schemas. Tools beyond this
+    /// count were contributed on the rail.
+    /// </param>
+    /// <param name="logger">Receives the diagnostic when the measured shape is not the expected one.</param>
+    public PerTurnBudgetContextProvider(
+        string agentName,
+        IContextBudgetTracker budgetTracker,
+        string? baselineInstructions,
+        int baselineToolCount,
+        ILogger<PerTurnBudgetContextProvider> logger)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(agentName);
+        ArgumentNullException.ThrowIfNull(budgetTracker);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _agentName = agentName;
+        _budgetTracker = budgetTracker;
+        _baselineInstructions = baselineInstructions ?? string.Empty;
+        _baselineToolCount = Math.Max(0, baselineToolCount);
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Charges what the providers ahead of this one put into the turn, and adds nothing.
+    /// </summary>
+    /// <param name="context">The accumulated context, as it will be sent to the model.</param>
+    /// <param name="cancellationToken">Unused — measuring allocates no I/O.</param>
+    /// <returns>An empty contribution.</returns>
+    protected override ValueTask<AIContext> ProvideAIContextAsync(
+        InvokingContext context,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        Charge(context.AIContext);
+        return ValueTask.FromResult(NoContribution);
+    }
+
+    /// <summary>
+    /// Records the difference between <paramref name="accumulated"/> and the construction-time baseline.
+    /// </summary>
+    /// <param name="accumulated">The context as assembled by the providers ahead of this one.</param>
+    private void Charge(AIContext accumulated)
+    {
+        var tokens = EstimateInjectedInstructionTokens(accumulated.Instructions)
+            + TokenEstimationHelper.EstimateToolSchemaTokens(
+                (accumulated.Tools?.Count() ?? 0) - _baselineToolCount);
+
+        if (tokens == 0)
+            return;
+
+        _budgetTracker.RecordAndPublish(
+            _agentName,
+            Component,
+            ContextConventions.SourceTypeValues.PerTurnContext,
+            tokens,
+            ContextBudgetMetrics.PerTurnContextTokens);
+    }
+
+    /// <summary>
+    /// Estimates the tokens the rail added to the instructions.
+    /// </summary>
+    /// <param name="accumulated">The instructions as assembled by the providers ahead of this one.</param>
+    /// <returns>The estimated token count of the added text, or 0 when nothing was added.</returns>
+    /// <remarks>
+    /// The base merge appends each provider's contribution to what it was given, so the accumulated
+    /// instructions begin with the baseline and the tail is what the rail contributed. A provider that
+    /// rewrote the text instead of appending to it would break that assumption and is logged, because the
+    /// resulting figure is then only a best effort — and because rewriting on this hook is itself a defect
+    /// worth surfacing.
+    /// </remarks>
+    private int EstimateInjectedInstructionTokens(string? accumulated)
+    {
+        var text = accumulated ?? string.Empty;
+        var injectedChars = text.Length - _baselineInstructions.Length;
+
+        if (injectedChars <= 0)
+            return 0;
+
+        if (_baselineInstructions.Length > 0
+            && !text.StartsWith(_baselineInstructions, StringComparison.Ordinal))
+        {
+            _logger.LogWarning(
+                "Per-turn context for agent {AgentName} does not begin with the agent's own instructions; " +
+                "a context provider rewrote them rather than appending. The charge is a best-effort estimate.",
+                _agentName);
+        }
+
+        return TokenEstimationHelper.EstimateTokens(text[^injectedChars..]);
+    }
+}

--- a/src/Content/Application/Application.AI.Common/Services/Agent/PerTurnBudgetContextProvider.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Agent/PerTurnBudgetContextProvider.cs
@@ -51,6 +51,15 @@ namespace Application.AI.Common.Services.Agent;
 /// built by the model client and never pass through the harness.
 /// </para>
 /// <para>
+/// <b>What it does not cover.</b> Only <see cref="AIContext.Instructions"/> and
+/// <see cref="AIContext.Tools"/> are charged. A provider that contributed
+/// <see cref="AIContext.Messages"/> instead would go uncounted: unlike the instructions, whose baseline is
+/// the agent's fixed prompt, the message baseline is the conversation itself and grows every turn, so the
+/// end of the rail cannot tell an injected message from the turn's own. None of the providers wired today
+/// contributes messages. A future one that does needs a baseline captured at the head of the rail rather
+/// than passed in at construction.
+/// </para>
+/// <para>
 /// This records consumption; it does not refuse it. <see cref="IContextBudgetTracker.EnsureBudget"/> is
 /// deliberately not called — turning an over-budget turn into a thrown exception is a governance decision
 /// belonging to whoever owns the turn, not to an accounting provider.
@@ -63,12 +72,6 @@ namespace Application.AI.Common.Services.Agent;
 /// </remarks>
 public sealed class PerTurnBudgetContextProvider : AIContextProvider
 {
-    /// <summary>The budget component every charge from this provider lands in.</summary>
-    public const string Component = ContextConventions.BudgetComponents.PerTurnContext;
-
-    /// <summary>Contributes nothing — the whole point is to observe without perturbing.</summary>
-    private static readonly AIContext NoContribution = new();
-
     private readonly string _agentName;
     private readonly IContextBudgetTracker _budgetTracker;
     private readonly string _baselineInstructions;
@@ -106,7 +109,7 @@ public sealed class PerTurnBudgetContextProvider : AIContextProvider
         _agentName = agentName;
         _budgetTracker = budgetTracker;
         _baselineInstructions = baselineInstructions ?? string.Empty;
-        _baselineToolCount = Math.Max(0, baselineToolCount);
+        _baselineToolCount = baselineToolCount;
         _logger = logger;
     }
 
@@ -120,10 +123,12 @@ public sealed class PerTurnBudgetContextProvider : AIContextProvider
         InvokingContext context,
         CancellationToken cancellationToken = default)
     {
-        ArgumentNullException.ThrowIfNull(context);
-
         Charge(context.AIContext);
-        return ValueTask.FromResult(NoContribution);
+
+        // A fresh instance per turn rather than a shared empty one: AIContext's properties are settable,
+        // and handing the same object to the framework on every turn of every agent would make one
+        // mutation anywhere a cross-agent bug. Allocating an empty record costs nothing worth saving.
+        return ValueTask.FromResult(new AIContext());
     }
 
     /// <summary>
@@ -141,7 +146,7 @@ public sealed class PerTurnBudgetContextProvider : AIContextProvider
 
         _budgetTracker.RecordAndPublish(
             _agentName,
-            Component,
+            ContextConventions.BudgetComponents.PerTurnContext,
             ContextConventions.SourceTypeValues.PerTurnContext,
             tokens,
             ContextBudgetMetrics.PerTurnContextTokens);
@@ -167,7 +172,10 @@ public sealed class PerTurnBudgetContextProvider : AIContextProvider
         if (injectedChars <= 0)
             return 0;
 
-        if (_baselineInstructions.Length > 0
+        // Gated: the comparison scans the whole system prompt on every turn to detect a condition the
+        // merge contract makes essentially impossible, and its only outcome is the warning below.
+        if (_logger.IsEnabled(LogLevel.Warning)
+            && _baselineInstructions.Length > 0
             && !text.StartsWith(_baselineInstructions, StringComparison.Ordinal))
         {
             _logger.LogWarning(
@@ -176,6 +184,8 @@ public sealed class PerTurnBudgetContextProvider : AIContextProvider
                 _agentName);
         }
 
-        return TokenEstimationHelper.EstimateTokens(text[^injectedChars..]);
+        // Sliced as a span, not a substring: the tail is everything the rail injected — index card plus
+        // every recalled block — and copying it only to read its length would allocate kilobytes per turn.
+        return TokenEstimationHelper.EstimateTokens(text.AsSpan(text.Length - injectedChars));
     }
 }

--- a/src/Content/Domain/Domain.AI/Telemetry/Conventions/ContextConventions.cs
+++ b/src/Content/Domain/Domain.AI/Telemetry/Conventions/ContextConventions.cs
@@ -16,6 +16,8 @@ public static class ContextConventions
     public const string SkillsTier = "agent.context.skills_tier";
     /// <summary>Token load from tool JSON schemas sent to the LLM.</summary>
     public const string ToolsSchemaTokens = "agent.context.tools_schema_tokens";
+    /// <summary>Token load injected into every turn by the context-provider rail. Tags: agent.name.</summary>
+    public const string PerTurnContextTokens = "agent.context.per_turn_context_tokens";
     /// <summary>Remaining token budget for the agent session.</summary>
     public const string BudgetRemaining = "agent.context.budget_remaining";
     /// <summary>Budget utilization ratio (0-1, used/limit).</summary>
@@ -41,6 +43,17 @@ public static class ContextConventions
         public const string SkillsTier2 = "skills_tier2";
         /// <summary>Skill supporting files served on demand through <c>read_skill_resource</c>.</summary>
         public const string SkillsTier3 = "skills_tier3";
+
+        /// <summary>
+        /// Everything the <c>AIContextProvider</c> rail adds to a turn: the skills index card (Tier 1) and
+        /// the framework's disclosure tools, cross-session memory recall, and task-similarity learnings.
+        /// </summary>
+        /// <remarks>
+        /// Charged <em>every turn</em>, unlike <see cref="SystemPrompt"/> and <see cref="ToolSchemas"/>,
+        /// which are charged once when the agent is built. That difference is the point of this component:
+        /// this cost recurs, so the gap it closes widens as a conversation goes on (issue #266).
+        /// </remarks>
+        public const string PerTurnContext = "per_turn_context";
     }
 
     /// <summary>
@@ -48,9 +61,12 @@ public static class ContextConventions
     /// paid for. Numeric so a dashboard can order them; the names carry the meaning.
     /// </summary>
     /// <remarks>
-    /// Tier 1 has no value here on purpose. The index card is composed by the framework's skills provider
-    /// rather than pulled on demand, so nothing in the harness is positioned to measure it and no emitter
-    /// would use the constant.
+    /// Tier 1 has no value here on purpose, but not because it is unmeasurable — it is measured, and
+    /// charged under <see cref="BudgetComponents.PerTurnContext"/>. The index card is composed by the
+    /// framework's skills provider and contributed on the context-provider rail rather than pulled on
+    /// demand, so it is not a <em>tier</em> of this instrument's dimension: it arrives every turn whether
+    /// or not any skill is loaded, and it is charged with the rest of that rail's per-turn cost. Nothing
+    /// emits a Tier 1 value here, so no constant exists for one.
     /// </remarks>
     public static class SkillsTierValues
     {
@@ -65,6 +81,9 @@ public static class ContextConventions
         public const string SystemPrompt = "system_prompt";
         public const string Skills = "skills";
         public const string ToolsSchema = "tools_schema";
+        /// <summary>Context contributed by the provider rail on every turn. See
+        /// <see cref="BudgetComponents.PerTurnContext"/>.</summary>
+        public const string PerTurnContext = "per_turn_context";
         public const string Hooks = "hooks";
         public const string UserMessage = "user_message";
         public const string ToolResult = "tool_result";

--- a/src/Content/Infrastructure/Infrastructure.AI.Evaluation/Judges/JudgeCallCore.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.Evaluation/Judges/JudgeCallCore.cs
@@ -3,6 +3,7 @@ using System.Text.Json.Serialization;
 using Application.AI.Common.Evaluation;
 using Application.AI.Common.Evaluation.Models;
 using Application.AI.Common.Evaluation.Outcomes;
+using Application.AI.Common.Extensions;
 using Application.AI.Common.Json;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging;
@@ -258,7 +259,7 @@ internal static class JudgeCallCore
 
         logger.LogInformation(
             "Judge consumed input={InputTokens} output={OutputTokens} total={TotalTokens}",
-            input, output, usage.TotalTokenCount ?? (input + output));
+            input, output, usage.TotalTokens());
     }
 
     private static IList<ChatMessage> BuildMessages(string systemPrompt, string userPrompt, bool stricter)

--- a/src/Content/Infrastructure/Infrastructure.AI/MetaHarness/AgentEvaluationService.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/MetaHarness/AgentEvaluationService.cs
@@ -142,12 +142,17 @@ public sealed class AgentEvaluationService : IEvaluationService
 
             var output = ExtractContent(response);
             var (passed, failureReason) = Grade(output, task.ExpectedOutputPattern);
-            taskResult = new TaskEvaluationResult(task.TaskId, passed, TokenCost: 0L, failureReason);
+            taskResult = new TaskEvaluationResult(
+                task.TaskId, passed, ResolveTokenCost(response, task.InputPrompt, output), failureReason);
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
             _logger.LogError(ex, "Task {TaskId} failed for candidate {CandidateId}",
                 task.TaskId, candidate.CandidateId);
+
+            // Zero here is a genuine unknown, not a placeholder: without a response there is no usage to
+            // read, and the throw may have come before anything reached the provider or after a full turn
+            // was billed. Estimating would put an invented number into a candidate-selection input.
             taskResult = new TaskEvaluationResult(task.TaskId, Passed: false, TokenCost: 0L, ex.Message);
         }
         finally
@@ -291,6 +296,46 @@ public sealed class AgentEvaluationService : IEvaluationService
         {
             return (false, "regex_timeout");
         }
+    }
+
+    /// <summary>
+    /// Resolves what a completed eval task cost in tokens, preferring the provider's own accounting.
+    /// </summary>
+    /// <param name="response">The agent's response, whose usage the model provider populates.</param>
+    /// <param name="inputPrompt">The prompt sent, used only by the fallback estimate.</param>
+    /// <param name="output">The text produced, used only by the fallback estimate.</param>
+    /// <returns>The task's token cost. Never negative.</returns>
+    /// <remarks>
+    /// <para>
+    /// Cost is one of the two things evaluation reports, and it feeds candidate selection: with it pinned
+    /// to zero a candidate that solved every task by burning three times the context scored as identically
+    /// cheap as one that solved them directly, so the cheaper agent could not win on the axis it wins on
+    /// (issue #267).
+    /// </para>
+    /// <para>
+    /// The provider's own figure is preferred because it is what actually gets billed and it settles
+    /// arguments that an estimate only starts. It is not always present — a provider may omit usage, and
+    /// the echo client used for offline runs reports none — so the fallback is the same
+    /// characters-per-token estimate the context budget uses, over the prompt and the produced text. That
+    /// covers what crossed the wire, not any context the candidate assembled and never sent, so it reads
+    /// low; a low figure derived from real text is still a far better comparison input than zero. Which
+    /// path was taken is logged, so a run whose costs look implausibly uniform can be checked rather than
+    /// guessed at.
+    /// </para>
+    /// </remarks>
+    private long ResolveTokenCost(AgentResponse? response, string inputPrompt, string output)
+    {
+        if (response?.Usage?.TotalTokenCount is { } billed and >= 0)
+            return billed;
+
+        var estimated = TokenEstimationHelper.EstimateTokens(inputPrompt)
+            + TokenEstimationHelper.EstimateTokens(output);
+
+        _logger.LogDebug(
+            "Model provider reported no token usage; falling back to an estimate of {EstimatedTokens} tokens",
+            estimated);
+
+        return estimated;
     }
 
     private static string ExtractContent(object? response)

--- a/src/Content/Infrastructure/Infrastructure.AI/MetaHarness/AgentEvaluationService.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/MetaHarness/AgentEvaluationService.cs
@@ -1,4 +1,5 @@
 using System.Text.RegularExpressions;
+using Application.AI.Common.Extensions;
 using Application.AI.Common.Helpers;
 using Application.AI.Common.Interfaces;
 using Application.AI.Common.Interfaces.MetaHarness;
@@ -313,26 +314,32 @@ public sealed class AgentEvaluationService : IEvaluationService
     /// (issue #267).
     /// </para>
     /// <para>
-    /// The provider's own figure is preferred because it is what actually gets billed and it settles
-    /// arguments that an estimate only starts. It is not always present — a provider may omit usage, and
-    /// the echo client used for offline runs reports none — so the fallback is the same
-    /// characters-per-token estimate the context budget uses, over the prompt and the produced text. That
-    /// covers what crossed the wire, not any context the candidate assembled and never sent, so it reads
-    /// low; a low figure derived from real text is still a far better comparison input than zero. Which
-    /// path was taken is logged, so a run whose costs look implausibly uniform can be checked rather than
+    /// The provider's own figure is preferred because it is what actually gets billed, and it counts the
+    /// whole request — the system prompt and every skill body the candidate loaded included, which is
+    /// exactly the spending being compared. Providers populate usage inconsistently: some report a total,
+    /// while others (the echo client used for offline runs among them) report input and output separately
+    /// and leave the total unset, so both shapes are read before giving up.
+    /// </para>
+    /// <para>
+    /// The fallback is the same characters-per-token estimate the context budget uses, over the prompt and
+    /// the produced text only. It is a floor, not an equivalent: it cannot see the system prompt or the
+    /// skill bodies, so a candidate's real spending is understated on that path. It is kept because a low
+    /// figure derived from real text still orders candidates better than a zero that ranks them all equal.
+    /// Taking it is logged, so a run whose costs look implausibly uniform can be checked rather than
     /// guessed at.
     /// </para>
     /// </remarks>
     private long ResolveTokenCost(AgentResponse? response, string inputPrompt, string output)
     {
-        if (response?.Usage?.TotalTokenCount is { } billed and >= 0)
+        var billed = response?.Usage.TotalTokens() ?? 0;
+        if (billed > 0)
             return billed;
 
         var estimated = TokenEstimationHelper.EstimateTokens(inputPrompt)
             + TokenEstimationHelper.EstimateTokens(output);
 
         _logger.LogDebug(
-            "Model provider reported no token usage; falling back to an estimate of {EstimatedTokens} tokens",
+            "Model provider reported no usable token usage; falling back to an estimate of {EstimatedTokens} tokens",
             estimated);
 
         return estimated;

--- a/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentExecutionContextFactoryProgressiveDisclosureTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentExecutionContextFactoryProgressiveDisclosureTests.cs
@@ -8,6 +8,7 @@ using Application.AI.Common.Services.Skills;
 using Application.AI.Common.Services.Tools;
 using Application.AI.Common.Tests.Helpers;
 using Domain.AI.Skills;
+using Domain.AI.Telemetry.Conventions;
 using Domain.Common.Config;
 using Domain.Common.Config.AI;
 using FluentAssertions;
@@ -147,6 +148,33 @@ public sealed class AgentExecutionContextFactoryProgressiveDisclosureTests : IDi
 
     private static AgentSkillsProvider SkillsProviderOf(Domain.AI.Agents.AgentExecutionContext context) =>
         context.AIContextProviders!.OfType<AgentSkillsProvider>().Single();
+
+    /// <summary>
+    /// Drives the agent's whole context-provider rail the way the runtime does — seeded with the agent's
+    /// own instructions and tools, then feeding each provider the previous one's output — and returns the
+    /// finished context.
+    /// </summary>
+    /// <remarks>
+    /// Invoking one provider in isolation cannot exercise per-turn accounting, because the measurer sits at
+    /// the end of the chain and only sees what the providers ahead of it accumulated.
+    /// </remarks>
+    private static async Task<AIContext> DriveRailAsync(Domain.AI.Agents.AgentExecutionContext context)
+    {
+        var current = new AIContext
+        {
+            Instructions = context.Instruction,
+            Messages = new List<ChatMessage> { new(ChatRole.User, "go") },
+            Tools = context.Tools is null ? [] : [.. context.Tools]
+        };
+
+        foreach (var provider in context.AIContextProviders!)
+        {
+            current = await provider.InvokingAsync(new AIContextProvider.InvokingContext(
+                new Mock<AIAgent>().Object, new Mock<AgentSession>().Object, current));
+        }
+
+        return current;
+    }
 
     // ── Tier 1: the prompt carries the index card, not the body ──────────────
 
@@ -335,6 +363,73 @@ public sealed class AgentExecutionContextFactoryProgressiveDisclosureTests : IDi
             "the tokens the body just put into the context are spent whether or not the harness counts " +
             "them; uncounted, the budget under-reports worst on the turns that load the most skills")
             .WhoseValue.Should().Be(TokenEstimationHelper.EstimateTokens(body?.ToString()));
+    }
+
+    [Fact]
+    public async Task TheRail_ChargesItsTier1IndexCardToTheContextBudget_OnEveryTurn()
+    {
+        var budget = CreateBudgetTracker();
+        var context = await CreateFactory(budget).MapToAgentContextAsync([MakeSkill()], new SkillAgentOptions());
+
+        // What the skills provider contributes on its own: the Tier 1 index card. Measured from an empty
+        // input so it is the card alone, and used below as an independent expectation rather than a
+        // restatement of the measurer's own arithmetic.
+        var indexCard = await InvokeSkillsProviderAsync(SkillsProviderOf(context));
+        indexCard.Instructions.Should().Contain(
+            SkillName, "control: a provider advertising nothing would make every assertion below vacuous");
+
+        // Control. Building the agent charges the static prompt and the tool schemas; nothing on the rail
+        // has run yet, so a per-turn charge appearing here would mean the measurer bills at construction —
+        // the opposite error, and equally wrong.
+        budget.GetBreakdown(AgentName).Should().NotContainKey(
+            ContextConventions.BudgetComponents.PerTurnContext);
+
+        await DriveRailAsync(context);
+        var afterOneTurn = budget.GetBreakdown(AgentName)[ContextConventions.BudgetComponents.PerTurnContext];
+
+        afterOneTurn.Should().BeGreaterThanOrEqualTo(
+            TokenEstimationHelper.EstimateTokens(indexCard.Instructions),
+            "the index card is composed by the framework and injected on every turn; uncounted, the budget " +
+            "under-reports by its full size on each one");
+
+        await DriveRailAsync(context);
+
+        budget.GetBreakdown(AgentName)[ContextConventions.BudgetComponents.PerTurnContext]
+            .Should().Be(afterOneTurn * 2,
+                "this cost recurs — charging it once would leave the reported budget drifting further from " +
+                "the real context the longer a conversation runs, which is the defect, not the fix");
+    }
+
+    [Fact]
+    public async Task TheRail_ChargesTheSameAmount_HoweverLargeTheStaticSystemPromptIs()
+    {
+        // Two agents differing only in the size of their static prompt. The rail contributes the same
+        // index card to both, so the per-turn charge must be identical — that is what "the baseline is
+        // excluded" means, stated without restating the measurer's own arithmetic.
+        var longPrompt = string.Join(" ", Enumerable.Repeat("STATIC-PROMPT-FILLER", 200));
+
+        var withoutPrompt = CreateBudgetTracker();
+        var withPrompt = CreateBudgetTracker();
+
+        var bare = await CreateFactory(withoutPrompt)
+            .MapToAgentContextAsync([MakeSkill()], new SkillAgentOptions());
+        var padded = await CreateFactory(withPrompt)
+            .MapToAgentContextAsync([MakeSkill()], new SkillAgentOptions { AgentInstructions = longPrompt });
+
+        // Control: the two really do differ where the test claims they differ. Without this, two agents
+        // that both ended up with an empty prompt would satisfy the equality below and prove nothing.
+        TokenEstimationHelper.EstimateTokens(padded.Instruction).Should().BeGreaterThan(
+            TokenEstimationHelper.EstimateTokens(bare.Instruction) + 1000);
+
+        await DriveRailAsync(bare);
+        await DriveRailAsync(padded);
+
+        var component = ContextConventions.BudgetComponents.PerTurnContext;
+        withPrompt.GetBreakdown(AgentName)[component].Should().Be(
+            withoutPrompt.GetBreakdown(AgentName)[component],
+            "the measurer sees the static prompt in the accumulated context on every turn; charging what " +
+            "it sees rather than what the rail added would re-bill the whole prompt each turn — a larger " +
+            "error than the one being fixed, and one that would still look like a working feature");
     }
 
     [Fact]

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/Agent/AIContextProviderMergeContractTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/Agent/AIContextProviderMergeContractTests.cs
@@ -1,4 +1,5 @@
 using Application.AI.Common.Interfaces;
+using Application.AI.Common.Interfaces.Context;
 using Application.AI.Common.Interfaces.KnowledgeGraph;
 using Application.AI.Common.Interfaces.Learnings;
 using Application.AI.Common.Services.Agent;
@@ -81,6 +82,12 @@ public sealed class AIContextProviderMergeContractTests
             new GoverningToolContextProvider(NullLogger<GoverningToolContextProvider>.Instance),
         [nameof(KnowledgeMemoryContextProvider)] = BuildKnowledgeMemory,
         [nameof(LearningsRecallContextProvider)] = BuildLearningsRecall,
+        [nameof(PerTurnBudgetContextProvider)] = () => new PerTurnBudgetContextProvider(
+            "MergeContractAgent",
+            new Mock<IContextBudgetTracker>().Object,
+            SystemSentinel,
+            baselineToolCount: 2,
+            NullLogger<PerTurnBudgetContextProvider>.Instance),
     };
 
     public static TheoryData<string> AllProviders

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/Agent/AIContextProviderRailContractTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/Agent/AIContextProviderRailContractTests.cs
@@ -1,0 +1,125 @@
+using Application.AI.Common.Tests.Fakes;
+using FluentAssertions;
+using Microsoft.Agents.AI;
+using Microsoft.Extensions.AI;
+using Xunit;
+
+namespace Application.AI.Common.Tests.Services.Agent;
+
+/// <summary>
+/// Pins the two facts about the framework's context-provider rail that
+/// <see cref="Application.AI.Common.Services.Agent.PerTurnBudgetContextProvider"/> is built on, by driving a
+/// real <see cref="ChatClientAgent"/> rather than by hand-rolling the chain.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Per-turn budget accounting depends entirely on the runtime feeding each provider the accumulated output
+/// of the ones before it, seeded with the agent's own instructions and tools. If a future SDK handed every
+/// provider the same untouched input instead, the measurer at the end of the rail would see only the
+/// baseline, charge nothing, and the budget would silently return to under-reporting — with every test that
+/// drives the chain by hand still green. This assembly has shipped that exact shape of defect four times
+/// (see <c>AIContextProviderMergeContractTests</c>), which is why the assumption is pinned against the real
+/// runtime here and not merely documented.
+/// </para>
+/// <para>
+/// A failure here is a breaking SDK change, not a bug in the harness — but it is the signal that the
+/// accounting built on top has stopped working.
+/// </para>
+/// </remarks>
+public sealed class AIContextProviderRailContractTests
+{
+    private const string SystemPrompt = "STATIC-SYSTEM-PROMPT";
+    private const string FirstContribution = "[FIRST-CONTRIBUTION]";
+
+    /// <summary>
+    /// Records the context it was handed, then contributes <paramref name="contribution"/>.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="AIContextProvider.StateKeys"/> is overridden because the runtime refuses an agent whose
+    /// providers do not all carry distinct keys, and the default is the concrete type name — so two
+    /// instances of one provider type cannot coexist on a rail.
+    /// </remarks>
+    private sealed class RecordingProvider(string key, string? contribution) : AIContextProvider
+    {
+        public AIContext? Saw { get; private set; }
+
+        public override IReadOnlyList<string> StateKeys => [key];
+
+        protected override ValueTask<AIContext> ProvideAIContextAsync(
+            InvokingContext context,
+            CancellationToken cancellationToken = default)
+        {
+            Saw = context.AIContext;
+            return ValueTask.FromResult(new AIContext { Instructions = contribution });
+        }
+    }
+
+    private static async Task<(RecordingProvider First, RecordingProvider Last)> RunOneTurnAsync()
+    {
+        var first = new RecordingProvider("first", FirstContribution);
+        var last = new RecordingProvider("last", contribution: null);
+
+        var agent = new ChatClientAgent(
+            new FakeChatClient().WithDefaultResponse("ok"),
+            new ChatClientAgentOptions
+            {
+                Name = "RailContractAgent",
+                ChatOptions = new ChatOptions
+                {
+                    Instructions = SystemPrompt,
+                    Tools = [AIFunctionFactory.Create(
+                        () => "x", new AIFunctionFactoryOptions { Name = "agent_own_tool", Description = "t" })]
+                },
+                AIContextProviders = [first, last]
+            });
+
+        await agent.RunAsync("hello");
+
+        return (first, last);
+    }
+
+    [Fact]
+    public async Task TheRail_SeedsTheFirstProviderWithTheAgentsOwnInstructionsAndTools()
+    {
+        var (first, _) = await RunOneTurnAsync();
+
+        // The measurer subtracts a baseline it is handed at construction. That subtraction is only correct
+        // because the rail starts from the agent's own prompt and tools rather than from empty.
+        first.Saw!.Instructions.Should().Be(SystemPrompt);
+        first.Saw.Tools!.Select(t => t.Name).Should().Equal("agent_own_tool");
+    }
+
+    [Fact]
+    public async Task TheRail_FeedsEachProviderTheAccumulatedOutputOfTheOnesBeforeIt()
+    {
+        var (_, last) = await RunOneTurnAsync();
+
+        // The whole reason one measurer at the end of the rail can account for every provider ahead of it.
+        // Were this to become "every provider gets the same input", the measurer would see only the
+        // baseline and charge zero forever.
+        last.Saw!.Instructions.Should().Contain(SystemPrompt).And.Contain(FirstContribution);
+        last.Saw.Instructions.Should().NotBe(SystemPrompt);
+    }
+
+    [Fact]
+    public void TheRail_RefusesProvidersThatShareAStateKey()
+    {
+        // Why the measurer is one instance at the end rather than a wrapper around each provider: every
+        // instance of a single wrapper type would carry that type's name as its state key, and the agent
+        // would not construct at all.
+        var act = () => new ChatClientAgent(
+            new FakeChatClient(),
+            new ChatClientAgentOptions
+            {
+                Name = "CollidingAgent",
+                AIContextProviders =
+                [
+                    new RecordingProvider("same-key", contribution: null),
+                    new RecordingProvider("same-key", contribution: null)
+                ]
+            });
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*same state key*");
+    }
+}

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/Agent/PerTurnBudgetContextProviderTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/Agent/PerTurnBudgetContextProviderTests.cs
@@ -1,0 +1,196 @@
+using Application.AI.Common.Helpers;
+using Application.AI.Common.Interfaces.Context;
+using Application.AI.Common.Services.Agent;
+using Domain.AI.Telemetry.Conventions;
+using FluentAssertions;
+using Microsoft.Agents.AI;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Application.AI.Common.Tests.Services.Agent;
+
+/// <summary>
+/// Tests for <see cref="PerTurnBudgetContextProvider"/>, the measurer that charges what the context-provider
+/// rail injects into every turn (issue #266).
+/// </summary>
+/// <remarks>
+/// Every test drives the public <see cref="AIContextProvider.InvokingAsync"/> rather than the protected
+/// hook, because that is what the runtime calls and because the base merge is part of the behaviour under
+/// test — a provider that measured correctly but disturbed the context it measured would pass a hook-level
+/// test and corrupt every turn.
+/// </remarks>
+public sealed class PerTurnBudgetContextProviderTests
+{
+    private const string Agent = "BudgetAgent";
+    private const string Baseline = "STATIC-SYSTEM-PROMPT";
+
+    /// <summary>Records what the provider charged, in the order it charged it.</summary>
+    private sealed class RecordingTracker : Mock<IContextBudgetTracker>
+    {
+        public List<(string Agent, string Component, int Tokens)> Charges { get; } = [];
+
+        public RecordingTracker() =>
+            Setup(t => t.RecordAllocation(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>()))
+                .Callback<string, string, int>((a, c, t) => Charges.Add((a, c, t)));
+    }
+
+    private static AITool MakeTool(string name) => AIFunctionFactory.Create(
+        () => "ok", new AIFunctionFactoryOptions { Name = name, Description = "t" });
+
+    private static AIContextProvider.InvokingContext MakeContext(AIContext aiContext) =>
+        new(new Mock<AIAgent>().Object, new Mock<AgentSession>().Object, aiContext);
+
+    private static PerTurnBudgetContextProvider Create(
+        IContextBudgetTracker tracker,
+        string? baseline = Baseline,
+        int baselineToolCount = 0) =>
+        new(Agent, tracker, baseline, baselineToolCount,
+            NullLogger<PerTurnBudgetContextProvider>.Instance);
+
+    /// <summary>The context as the rail hands it over: baseline plus whatever earlier providers appended.</summary>
+    private static AIContext Accumulated(string injected, params string[] toolNames) => new()
+    {
+        Instructions = Baseline + injected,
+        Messages = new List<ChatMessage> { new(ChatRole.User, "go") },
+        Tools = [.. toolNames.Select(MakeTool)]
+    };
+
+    [Fact]
+    public async Task Charges_TheInjectedText_NotTheSystemPromptItWasAppendedTo()
+    {
+        const string injected = "\nRelevant remembered context: the user prefers dark mode.";
+        var tracker = new RecordingTracker();
+
+        await Create(tracker.Object).InvokingAsync(MakeContext(Accumulated(injected)));
+
+        // The exact token figure, not merely "something was charged": billing the whole accumulated
+        // string would double-charge the system prompt on every single turn, which is a larger error
+        // than the one this class exists to fix and would look like a working feature.
+        tracker.Charges.Should().ContainSingle()
+            .Which.Tokens.Should().Be(TokenEstimationHelper.EstimateTokens(injected));
+    }
+
+    [Fact]
+    public async Task Charges_EveryTurn_BecauseThisCostRecurs()
+    {
+        const string injected = "\nthe skills index card, re-sent with every request";
+        var tracker = new RecordingTracker();
+        var provider = Create(tracker.Object);
+
+        await provider.InvokingAsync(MakeContext(Accumulated(injected)));
+        await provider.InvokingAsync(MakeContext(Accumulated(injected)));
+        await provider.InvokingAsync(MakeContext(Accumulated(injected)));
+
+        // This is the whole point of #266. A once-only charge would leave the budget drifting further
+        // from reality the longer a conversation runs, which is the defect, not the fix.
+        var expected = TokenEstimationHelper.EstimateTokens(injected);
+        tracker.Charges.Should().HaveCount(3);
+        tracker.Charges.Should().OnlyContain(c => c.Tokens == expected);
+    }
+
+    [Fact]
+    public async Task Charges_ToolsTheRailContributed_AboveTheAgentsOwnTools()
+    {
+        var tracker = new RecordingTracker();
+
+        // Two tools were charged at build time; the framework's three disclosure tools arrive here.
+        await Create(tracker.Object, baselineToolCount: 2)
+            .InvokingAsync(MakeContext(Accumulated(
+                injected: string.Empty,
+                "file_system", "calculator",
+                "load_skill", "read_skill_resource", "run_skill_script")));
+
+        tracker.Charges.Should().ContainSingle()
+            .Which.Tokens.Should().Be(TokenEstimationHelper.EstimateToolSchemaTokens(3));
+    }
+
+    [Fact]
+    public async Task Charges_Nothing_WhenTheRailAddedNothing()
+    {
+        var tracker = new RecordingTracker();
+
+        await Create(tracker.Object, baselineToolCount: 2)
+            .InvokingAsync(MakeContext(Accumulated(injected: string.Empty, "alpha", "beta")));
+
+        tracker.Charges.Should().BeEmpty(
+            "an agent whose providers contributed nothing this turn spent nothing this turn");
+    }
+
+    [Fact]
+    public async Task Charges_Nothing_AndDoesNotThrow_WhenTheContextIsSmallerThanTheBaseline()
+    {
+        var tracker = new RecordingTracker();
+
+        var shrunk = new AIContext
+        {
+            Instructions = "tiny",
+            Messages = new List<ChatMessage> { new(ChatRole.User, "go") },
+            Tools = []
+        };
+
+        var act = async () => await Create(tracker.Object, baselineToolCount: 5)
+            .InvokingAsync(MakeContext(shrunk));
+
+        await act.Should().NotThrowAsync();
+        tracker.Charges.Should().BeEmpty("a negative difference is not a negative cost");
+    }
+
+    [Fact]
+    public async Task Charges_UnderTheSharedComponentName()
+    {
+        var tracker = new RecordingTracker();
+
+        await Create(tracker.Object).InvokingAsync(MakeContext(Accumulated("\nsomething")));
+
+        // A component name spelled differently here than the dashboard reads does not fail anything —
+        // it silently splits one slice of the budget into two.
+        tracker.Charges.Should().ContainSingle()
+            .Which.Should().Match<(string Agent, string Component, int Tokens)>(c =>
+                c.Agent == Agent && c.Component == ContextConventions.BudgetComponents.PerTurnContext);
+    }
+
+    [Fact]
+    public async Task ContributesNothing_LeavingTheContextExactlyAsItFoundIt()
+    {
+        var tracker = new RecordingTracker();
+        var incoming = Accumulated("\ninjected block", "alpha", "beta");
+
+        var result = await Create(tracker.Object).InvokingAsync(MakeContext(incoming));
+
+        // Observing must not perturb. The base merge appends whatever a provider returns, so anything
+        // other than an empty contribution would add text or duplicate tools on every turn.
+        result.Instructions.Should().Be(incoming.Instructions);
+        result.Tools?.Select(t => t.Name).Should().BeEquivalentTo(["alpha", "beta"]);
+    }
+
+    [Fact]
+    public async Task Charges_TheWholeContext_WhenTheAgentHasNoStaticPrompt()
+    {
+        var tracker = new RecordingTracker();
+        var noBaseline = new AIContext
+        {
+            Instructions = "everything here came from the rail",
+            Messages = new List<ChatMessage> { new(ChatRole.User, "go") },
+            Tools = []
+        };
+
+        await Create(tracker.Object, baseline: null).InvokingAsync(MakeContext(noBaseline));
+
+        tracker.Charges.Should().ContainSingle()
+            .Which.Tokens.Should().Be(TokenEstimationHelper.EstimateTokens(noBaseline.Instructions));
+    }
+
+    [Fact]
+    public void Constructor_RefusesABlankAgentName()
+    {
+        // A blank name would file these tokens under a budget nobody reads, and the under-reporting
+        // this class exists to fix would persist while looking fixed.
+        var act = () => new PerTurnBudgetContextProvider(
+            "  ", new RecordingTracker().Object, Baseline, 0,
+            NullLogger<PerTurnBudgetContextProvider>.Instance);
+
+        act.Should().Throw<ArgumentException>();
+    }
+}

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/Agent/PerTurnBudgetContextProviderTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/Agent/PerTurnBudgetContextProviderTests.cs
@@ -1,11 +1,13 @@
 using Application.AI.Common.Helpers;
-using Application.AI.Common.Interfaces.Context;
 using Application.AI.Common.Services.Agent;
+using Application.AI.Common.Services.Context;
 using Domain.AI.Telemetry.Conventions;
+using Domain.Common.Config;
 using FluentAssertions;
 using Microsoft.Agents.AI;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using Moq;
 using Xunit;
 
@@ -16,25 +18,33 @@ namespace Application.AI.Common.Tests.Services.Agent;
 /// rail injects into every turn (issue #266).
 /// </summary>
 /// <remarks>
+/// <para>
 /// Every test drives the public <see cref="AIContextProvider.InvokingAsync"/> rather than the protected
 /// hook, because that is what the runtime calls and because the base merge is part of the behaviour under
 /// test — a provider that measured correctly but disturbed the context it measured would pass a hook-level
 /// test and corrupt every turn.
+/// </para>
+/// <para>
+/// The budget is the real <see cref="ContextBudgetTracker"/> rather than a mock, so the assertions run
+/// through the same <c>RecordAndPublish</c> path production uses and read back the same breakdown a
+/// dashboard would. A mocked tracker would prove the provider called something, not that the tokens landed
+/// in a component anyone reads.
+/// </para>
+/// <para>
+/// That the rail really does accumulate — the assumption every measurement here depends on — is pinned
+/// separately against a real agent in <see cref="AIContextProviderRailContractTests"/>.
+/// </para>
 /// </remarks>
 public sealed class PerTurnBudgetContextProviderTests
 {
     private const string Agent = "BudgetAgent";
     private const string Baseline = "STATIC-SYSTEM-PROMPT";
 
-    /// <summary>Records what the provider charged, in the order it charged it.</summary>
-    private sealed class RecordingTracker : Mock<IContextBudgetTracker>
-    {
-        public List<(string Agent, string Component, int Tokens)> Charges { get; } = [];
+    private static readonly string Component = ContextConventions.BudgetComponents.PerTurnContext;
 
-        public RecordingTracker() =>
-            Setup(t => t.RecordAllocation(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>()))
-                .Callback<string, string, int>((a, c, t) => Charges.Add((a, c, t)));
-    }
+    private static ContextBudgetTracker NewBudget() => new(
+        Mock.Of<IOptionsMonitor<AppConfig>>(m => m.CurrentValue == new AppConfig()),
+        NullLogger<ContextBudgetTracker>.Instance);
 
     private static AITool MakeTool(string name) => AIFunctionFactory.Create(
         () => "ok", new AIFunctionFactoryOptions { Name = name, Description = "t" });
@@ -43,10 +53,10 @@ public sealed class PerTurnBudgetContextProviderTests
         new(new Mock<AIAgent>().Object, new Mock<AgentSession>().Object, aiContext);
 
     private static PerTurnBudgetContextProvider Create(
-        IContextBudgetTracker tracker,
+        ContextBudgetTracker budget,
         string? baseline = Baseline,
         int baselineToolCount = 0) =>
-        new(Agent, tracker, baseline, baselineToolCount,
+        new(Agent, budget, baseline, baselineToolCount,
             NullLogger<PerTurnBudgetContextProvider>.Instance);
 
     /// <summary>The context as the rail hands it over: baseline plus whatever earlier providers appended.</summary>
@@ -61,23 +71,23 @@ public sealed class PerTurnBudgetContextProviderTests
     public async Task Charges_TheInjectedText_NotTheSystemPromptItWasAppendedTo()
     {
         const string injected = "\nRelevant remembered context: the user prefers dark mode.";
-        var tracker = new RecordingTracker();
+        var budget = NewBudget();
 
-        await Create(tracker.Object).InvokingAsync(MakeContext(Accumulated(injected)));
+        await Create(budget).InvokingAsync(MakeContext(Accumulated(injected)));
 
         // The exact token figure, not merely "something was charged": billing the whole accumulated
         // string would double-charge the system prompt on every single turn, which is a larger error
         // than the one this class exists to fix and would look like a working feature.
-        tracker.Charges.Should().ContainSingle()
-            .Which.Tokens.Should().Be(TokenEstimationHelper.EstimateTokens(injected));
+        budget.GetBreakdown(Agent)[Component]
+            .Should().Be(TokenEstimationHelper.EstimateTokens(injected));
     }
 
     [Fact]
     public async Task Charges_EveryTurn_BecauseThisCostRecurs()
     {
         const string injected = "\nthe skills index card, re-sent with every request";
-        var tracker = new RecordingTracker();
-        var provider = Create(tracker.Object);
+        var budget = NewBudget();
+        var provider = Create(budget);
 
         await provider.InvokingAsync(MakeContext(Accumulated(injected)));
         await provider.InvokingAsync(MakeContext(Accumulated(injected)));
@@ -85,43 +95,42 @@ public sealed class PerTurnBudgetContextProviderTests
 
         // This is the whole point of #266. A once-only charge would leave the budget drifting further
         // from reality the longer a conversation runs, which is the defect, not the fix.
-        var expected = TokenEstimationHelper.EstimateTokens(injected);
-        tracker.Charges.Should().HaveCount(3);
-        tracker.Charges.Should().OnlyContain(c => c.Tokens == expected);
+        budget.GetBreakdown(Agent)[Component]
+            .Should().Be(TokenEstimationHelper.EstimateTokens(injected) * 3);
     }
 
     [Fact]
     public async Task Charges_ToolsTheRailContributed_AboveTheAgentsOwnTools()
     {
-        var tracker = new RecordingTracker();
+        var budget = NewBudget();
 
         // Two tools were charged at build time; the framework's three disclosure tools arrive here.
-        await Create(tracker.Object, baselineToolCount: 2)
+        await Create(budget, baselineToolCount: 2)
             .InvokingAsync(MakeContext(Accumulated(
                 injected: string.Empty,
                 "file_system", "calculator",
                 "load_skill", "read_skill_resource", "run_skill_script")));
 
-        tracker.Charges.Should().ContainSingle()
-            .Which.Tokens.Should().Be(TokenEstimationHelper.EstimateToolSchemaTokens(3));
+        budget.GetBreakdown(Agent)[Component]
+            .Should().Be(TokenEstimationHelper.EstimateToolSchemaTokens(3));
     }
 
     [Fact]
     public async Task Charges_Nothing_WhenTheRailAddedNothing()
     {
-        var tracker = new RecordingTracker();
+        var budget = NewBudget();
 
-        await Create(tracker.Object, baselineToolCount: 2)
+        await Create(budget, baselineToolCount: 2)
             .InvokingAsync(MakeContext(Accumulated(injected: string.Empty, "alpha", "beta")));
 
-        tracker.Charges.Should().BeEmpty(
+        budget.GetBreakdown(Agent).Should().NotContainKey(Component,
             "an agent whose providers contributed nothing this turn spent nothing this turn");
     }
 
     [Fact]
     public async Task Charges_Nothing_AndDoesNotThrow_WhenTheContextIsSmallerThanTheBaseline()
     {
-        var tracker = new RecordingTracker();
+        var budget = NewBudget();
 
         var shrunk = new AIContext
         {
@@ -130,34 +139,35 @@ public sealed class PerTurnBudgetContextProviderTests
             Tools = []
         };
 
-        var act = async () => await Create(tracker.Object, baselineToolCount: 5)
+        var act = async () => await Create(budget, baselineToolCount: 5)
             .InvokingAsync(MakeContext(shrunk));
 
         await act.Should().NotThrowAsync();
-        tracker.Charges.Should().BeEmpty("a negative difference is not a negative cost");
+        budget.GetBreakdown(Agent).Should().NotContainKey(Component,
+            "a negative difference is not a negative cost");
     }
 
     [Fact]
-    public async Task Charges_UnderTheSharedComponentName()
+    public async Task Charges_TheAgentItWasBuiltFor_UnderTheSharedComponentName()
     {
-        var tracker = new RecordingTracker();
+        var budget = NewBudget();
 
-        await Create(tracker.Object).InvokingAsync(MakeContext(Accumulated("\nsomething")));
+        await Create(budget).InvokingAsync(MakeContext(Accumulated("\nsomething")));
 
         // A component name spelled differently here than the dashboard reads does not fail anything —
-        // it silently splits one slice of the budget into two.
-        tracker.Charges.Should().ContainSingle()
-            .Which.Should().Match<(string Agent, string Component, int Tokens)>(c =>
-                c.Agent == Agent && c.Component == ContextConventions.BudgetComponents.PerTurnContext);
+        // it silently splits one slice of the budget into two. Likewise a charge filed under the wrong
+        // agent lands in a budget nobody reads.
+        budget.GetBreakdown(Agent).Should().ContainKey(Component);
+        budget.GetTotalAllocated(Agent).Should().BeGreaterThan(0);
+        budget.GetTotalAllocated("SomeOtherAgent").Should().Be(0);
     }
 
     [Fact]
     public async Task ContributesNothing_LeavingTheContextExactlyAsItFoundIt()
     {
-        var tracker = new RecordingTracker();
         var incoming = Accumulated("\ninjected block", "alpha", "beta");
 
-        var result = await Create(tracker.Object).InvokingAsync(MakeContext(incoming));
+        var result = await Create(NewBudget()).InvokingAsync(MakeContext(incoming));
 
         // Observing must not perturb. The base merge appends whatever a provider returns, so anything
         // other than an empty contribution would add text or duplicate tools on every turn.
@@ -168,7 +178,7 @@ public sealed class PerTurnBudgetContextProviderTests
     [Fact]
     public async Task Charges_TheWholeContext_WhenTheAgentHasNoStaticPrompt()
     {
-        var tracker = new RecordingTracker();
+        var budget = NewBudget();
         var noBaseline = new AIContext
         {
             Instructions = "everything here came from the rail",
@@ -176,10 +186,10 @@ public sealed class PerTurnBudgetContextProviderTests
             Tools = []
         };
 
-        await Create(tracker.Object, baseline: null).InvokingAsync(MakeContext(noBaseline));
+        await Create(budget, baseline: null).InvokingAsync(MakeContext(noBaseline));
 
-        tracker.Charges.Should().ContainSingle()
-            .Which.Tokens.Should().Be(TokenEstimationHelper.EstimateTokens(noBaseline.Instructions));
+        budget.GetBreakdown(Agent)[Component]
+            .Should().Be(TokenEstimationHelper.EstimateTokens(noBaseline.Instructions));
     }
 
     [Fact]
@@ -188,7 +198,7 @@ public sealed class PerTurnBudgetContextProviderTests
         // A blank name would file these tokens under a budget nobody reads, and the under-reporting
         // this class exists to fix would persist while looking fixed.
         var act = () => new PerTurnBudgetContextProvider(
-            "  ", new RecordingTracker().Object, Baseline, 0,
+            "  ", NewBudget(), Baseline, 0,
             NullLogger<PerTurnBudgetContextProvider>.Instance);
 
         act.Should().Throw<ArgumentException>();

--- a/src/Content/Tests/Infrastructure.AI.Tests/MetaHarness/AgentEvaluationServiceTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/MetaHarness/AgentEvaluationServiceTests.cs
@@ -1,3 +1,4 @@
+using Application.AI.Common.Helpers;
 using Application.AI.Common.Interfaces;
 using Application.AI.Common.Interfaces.MetaHarness;
 using Application.AI.Common.Interfaces.Traces;
@@ -317,6 +318,78 @@ public class AgentEvaluationServiceTests : IAsyncDisposable
         var taskResult = Assert.Single(result.PerExampleResults);
         Assert.False(taskResult.Passed);
         Assert.Contains("resolves outside", taskResult.FailureReason);
+    }
+
+    // ── Token cost: the second thing evaluation reports (issue #267) ──────────
+
+    /// <summary>
+    /// The provider's own billed figure is what a cost comparison should use, so it must reach the result.
+    /// </summary>
+    [Fact]
+    public async Task EvaluateAsync_ProviderReportsUsage_ReportsThatCostRatherThanZero()
+    {
+        _agentFactoryMock
+            .Setup(f => f.CreateAgentAsync(It.IsAny<AgentExecutionContext>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new TestableAIAgent(_ => new AgentResponse(
+                new ChatMessage(ChatRole.Assistant, "the answer is 42"))
+            {
+                Usage = new UsageDetails { InputTokenCount = 900, OutputTokenCount = 100, TotalTokenCount = 1000 }
+            }));
+
+        var sut = BuildSut();
+        var tasks = new[] { BuildTask("t1", "question 1"), BuildTask("t2", "question 2") };
+
+        var result = await sut.EvaluateAsync(BuildCandidate(), tasks);
+
+        // Cost feeds candidate selection. Pinned to zero, an agent that burned three times the context
+        // scored as identically cheap to one that did not, so the cheaper agent could never win.
+        Assert.Equal(2000L, result.TotalTokenCost);
+        Assert.All(result.PerExampleResults, r => Assert.Equal(1000L, r.TokenCost));
+    }
+
+    /// <summary>
+    /// Providers that report no usage — the echo client used offline among them — must still yield a
+    /// comparable figure rather than falling back to the zero this issue exists to remove.
+    /// </summary>
+    [Fact]
+    public async Task EvaluateAsync_ProviderReportsNoUsage_EstimatesRatherThanReportingZero()
+    {
+        const string prompt = "a question long enough to estimate above zero tokens";
+        const string answer = "an answer long enough to estimate above zero tokens";
+
+        _agentFactoryMock
+            .Setup(f => f.CreateAgentAsync(It.IsAny<AgentExecutionContext>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new TestableAIAgent(answer));
+
+        var sut = BuildSut();
+        var result = await sut.EvaluateAsync(BuildCandidate(), [BuildTask("t1", prompt)]);
+
+        var expected = TokenEstimationHelper.EstimateTokens(prompt)
+            + TokenEstimationHelper.EstimateTokens(answer);
+
+        // Control on the control: an estimate that happened to be zero would make this assertion vacuous.
+        Assert.True(expected > 0);
+        Assert.Equal(expected, Assert.Single(result.PerExampleResults).TokenCost);
+    }
+
+    /// <summary>
+    /// A task that threw has no response to read usage from, and the throw may have come before anything
+    /// reached the provider or after a full turn was billed. Zero is recorded as a genuine unknown, and
+    /// this pins that as a decision rather than leaving it to look like the defect that was just fixed.
+    /// </summary>
+    [Fact]
+    public async Task EvaluateAsync_TaskThrew_ReportsZeroBecauseTheCostIsUnknowable()
+    {
+        _agentFactoryMock
+            .Setup(f => f.CreateAgentAsync(It.IsAny<AgentExecutionContext>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(TestableAIAgent.Throwing(new InvalidOperationException("provider exploded")));
+
+        var sut = BuildSut();
+        var result = await sut.EvaluateAsync(BuildCandidate(), [BuildTask("t1", "question")]);
+
+        var taskResult = Assert.Single(result.PerExampleResults);
+        Assert.False(taskResult.Passed);
+        Assert.Equal(0L, taskResult.TokenCost);
     }
 
     public async ValueTask DisposeAsync()


### PR DESCRIPTION
Closes #266. Closes #267.

## What was wrong

The context budget counted what was known when an agent was built — the system prompt and the harness's own tool schemas — and nothing after. Content that reaches the model on the `AIContextProvider` rail **every turn** was charged nothing:

- the skills index card (Tier 1),
- the framework's three disclosure tools (`load_skill`, `read_skill_resource`, `run_skill_script`),
- cross-session memory recall,
- task-similarity learnings recall.

Because that cost recurs while the build-time components are paid once, the reported budget drifted further from the real context the longer a conversation ran — fastest on exactly the agents with the most memory and the most skills to advertise.

The framework disclosure tools were a fourth source the issue did not anticipate; they arrive on the rail, so the tool-schema line never saw them.

## What was measured

Driving a real skills provider through the public rail, for an agent holding **three** skills:

- **~1,300 characters (~330 tokens) per turn** of index card and usage instructions,
- **plus three tools**.

## The design, and why

`PerTurnBudgetContextProvider` is appended last on the rail. The runtime seeds the chain with the agent's own instructions and tools and feeds each provider the accumulated output of the ones before it, so the final position sees everything the others contributed; the charge is the difference from the baseline the factory already accounts for.

**One measurer at the end rather than a wrapper per provider** — the issue's Option B — for two reasons found by measurement, not preference:

1. The runtime **rejects an agent whose providers share a state key**, and the default key is the concrete type name. Every instance of a single wrapper type would collide and the agent constructor would throw.
2. A delegating provider must forward seven-plus base members (post-turn notification, three message filters, state keys, service resolution). Forgetting one silently disables the provider it wraps — a defect this assembly has already shipped four times.

That SDK behaviour is now **pinned against a real `ChatClientAgent`** in `AIContextProviderRailContractTests`, not merely documented. Without it, a future SDK that stopped accumulating would return the budget to under-reporting with every hand-rolled test still green.

## Evaluation token cost (#267)

`AgentEvaluationService` hardcoded every candidate's token cost to zero on both the success and failure paths, while that number feeds candidate promotion — so an agent that burned three times the context scored as identically cheap as one that did not.

It now reports the provider's own billed usage. Providers populate usage inconsistently: some report a total, others report input and output and leave the total unset (the echo client does exactly this), so both shapes are read before falling back to the shared estimator. That rule now lives once, in `UsageDetailsExtensions.TotalTokens()`, adopted by the judge path that had hand-written the same expression.

## Stated boundaries, not silently left

- **`AIContext.Messages` is uncounted.** Unlike instructions, whose baseline is the agent's fixed prompt, the message baseline is the conversation and grows every turn, so an end-of-rail measurer cannot tell an injected message from the turn's own. No provider wired today contributes messages. Documented on the class.
- **The #267 estimate fallback is a floor**, not an equivalent — it cannot see the system prompt or loaded skill bodies. Kept because a low figure from real text orders candidates better than a zero that ranks them equal. Taking it is logged.
- **The failure path still reports zero**, deliberately: with no response there is nothing to read, and the throw may have preceded any request. Inventing a number would corrupt a selection input. Now tested as a decision.

## Verification

- Build: 0 errors, 0 new warnings.
- Full solution: **21 test assemblies, 0 failures.**
- **Mutation-tested**, since a test that cannot fail is not evidence:
  - billing the whole context instead of the delta → 3 tests fail
  - removing the factory wiring → 2 tests fail
  - reverting eval cost to zero → 2 tests fail
  - reordering the rail so the measurer sees no accumulation → 1 test fails
- `/code-review` (standards + spec) and `/simplify` both run, findings applied in `79fc9756`.

One note for reviewers: a claim in `ContextConventions` that the Tier 1 index card could not be measured was **false** and is corrected. It was true of the layer examined in #248 (wrapping the skill) and wrong at this one (the provider rail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SZJogfXvRweW2wbMdetQ5H
