### PR TITLE
refactor: split AgentExecutionContextFactory into partials (#251)

### DIFF
--- a/src/Content/Application/Application.AI.Common/Factories/AgentExecutionContextFactory.ContextProviders.cs
+++ b/src/Content/Application/Application.AI.Common/Factories/AgentExecutionContextFactory.ContextProviders.cs
@@ -1,0 +1,159 @@
+using Application.AI.Common.Helpers;
+using Application.AI.Common.Interfaces;
+using Microsoft.Agents.AI;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Application.AI.Common.Factories;
+
+/// <summary>
+/// Context-provider half of <see cref="AgentExecutionContextFactory"/>: builds the
+/// <see cref="AIContextProvider"/> rail an agent runs on — progressive skill disclosure, the tool
+/// permission filter, cross-session and learnings recall, the governance wrapper, and the per-turn
+/// budget measurer.
+/// </summary>
+/// <remarks>
+/// <strong>Order on this rail is behaviour, not style.</strong> The runtime feeds each provider the
+/// previous one's output, so a provider only sees what everything above it produced. The two
+/// positional rules that hold the rail together are documented on the members below: any
+/// tool-contributing provider must go above <see cref="Services.Agent.ToolPermissionFilter"/>, and
+/// the per-turn measurer must go last. Both are load-bearing — moving a line here changes which
+/// tools an agent can call and what its budget records.
+/// </remarks>
+public partial class AgentExecutionContextFactory
+{
+    /// <summary>
+    /// Unions the context providers for this agent over <paramref name="disclosableSkills"/>, which the
+    /// caller built once so this wiring and the prompt's disclosure decision cannot disagree.
+    /// The <paramref name="effectiveAllowlist"/> (the skills' combined constraint already capped by any
+    /// agent tool ceiling) drives a single <see cref="Services.Agent.ToolPermissionFilter"/>. It is
+    /// <see langword="null"/> when no restriction is active (no filter is wired), or a concrete set —
+    /// possibly empty, meaning deny-all — when a restriction applies.
+    /// </summary>
+    private IList<AIContextProvider>? BuildMergedAIContextProviders(
+        int skillCount,
+        IReadOnlyList<string>? effectiveAllowlist,
+        IReadOnlyList<DisclosableSkill> disclosableSkills)
+    {
+        var providers = new List<AIContextProvider>();
+
+        if (disclosableSkills.Count > 0)
+        {
+            // Registering the agent's own skills, rather than a directory to search, is what keeps
+            // load_skill from advertising skills this agent was never assigned.
+            providers.Add(new AgentSkillsProviderBuilder()
+                .UseSkills(disclosableSkills.Select(s => s.Skill))
+                .UseOptions(SkillDisclosureDefaults.Configure)
+                .Build());
+
+            _logger.LogDebug("Wired AgentSkillsProvider with {SkillCount} skill(s)", disclosableSkills.Count);
+        }
+
+        // Placed immediately after the skills provider so it sees the framework's disclosure tools. Note
+        // what this position does and does not guarantee: the framework feeds each provider the previous
+        // one's output, so the filter's removals survive into everything added below. But a provider added
+        // *after* this line whose own contribution introduces a tool would introduce it unfiltered — the
+        // filter has already run. Any future tool-contributing provider belongs above this line.
+        if (effectiveAllowlist is not null)
+        {
+            providers.Add(new Services.Agent.ToolPermissionFilter(effectiveAllowlist));
+
+            _logger.LogDebug("Wired ToolPermissionFilter with {Count} allowed tool(s) for {SkillCount} skill(s)",
+                effectiveAllowlist.Count, skillCount);
+        }
+
+        // Cross-session memory recall. The provider resolves tenant-aware IKnowledgeMemory per
+        // invocation from the current request scope (via IAmbientRequestScope), so it is safe to
+        // attach to a singleton-cached agent.
+        if (_appConfig.CurrentValue.AI?.KnowledgeBridge?.Enabled == true)
+        {
+            var ambientScope = _serviceProvider.GetService<IAmbientRequestScope>();
+            if (ambientScope is not null)
+            {
+                providers.Add(new Services.Agent.KnowledgeMemoryContextProvider(
+                    ambientScope,
+                    _appConfig,
+                    _loggerFactory.CreateLogger<Services.Agent.KnowledgeMemoryContextProvider>()));
+
+                _logger.LogDebug("Wired KnowledgeMemoryContextProvider for cross-session recall");
+            }
+        }
+
+        // Task-similarity learnings recall. Like the memory provider above, it resolves the scoped,
+        // tenant-aware ILearningRecaller per invocation from the current request scope, so it is safe to
+        // attach to a singleton-cached agent. Injects the most task-relevant lessons (every source,
+        // including work-memory synthesis output) at turn start — the read half of the self-improving loop.
+        if (_appConfig.CurrentValue.AI?.LearningsRecall?.Enabled == true)
+        {
+            var ambientScope = _serviceProvider.GetService<IAmbientRequestScope>();
+            if (ambientScope is not null)
+            {
+                providers.Add(new Services.Agent.LearningsRecallContextProvider(
+                    ambientScope,
+                    _appConfig,
+                    _loggerFactory.CreateLogger<Services.Agent.LearningsRecallContextProvider>()));
+
+                _logger.LogDebug("Wired LearningsRecallContextProvider for task-similarity recall");
+            }
+        }
+
+        // Governance wrapper — added LAST so it wraps the final, filtered tool set. When
+        // tool-invocation enforcement is on, this guarantees the governor gates every tool the agent
+        // can call, including framework progressive-disclosure tools that bypass ToolChainBuilder.
+        // Inert (and skipped entirely) when enforcement is off, so default behaviour is unchanged.
+        if (_appConfig.CurrentValue.AI?.Governance?.EnforceToolInvocation == true)
+        {
+            providers.Add(new Services.Agent.GoverningToolContextProvider(
+                _loggerFactory.CreateLogger<Services.Agent.GoverningToolContextProvider>()));
+            _logger.LogDebug("Wired GoverningToolContextProvider (tool-invocation enforcement enabled)");
+        }
+
+        return providers.Count > 0 ? providers : null;
+    }
+
+    /// <summary>
+    /// Appends the measurer that charges whatever <paramref name="providers"/> inject into each turn to
+    /// <paramref name="agentName"/>'s budget.
+    /// </summary>
+    /// <param name="providers">
+    /// The rail built for this agent, mutated in place. <see langword="null"/> or empty means the agent has
+    /// no rail, so there is nothing per-turn to charge and nothing is appended.
+    /// </param>
+    /// <param name="agentName">The agent whose budget the per-turn context is charged to.</param>
+    /// <param name="instruction">
+    /// The static system prompt, already charged separately. It is the baseline the measurer subtracts, so
+    /// only what the rail adds is charged here rather than the prompt being billed again every turn.
+    /// </param>
+    /// <param name="toolCount">
+    /// The number of tools the agent was built with, already charged as tool schemas — the baseline for
+    /// tools the rail contributes, such as the framework's own skill-disclosure tools.
+    /// </param>
+    /// <remarks>
+    /// It must be last: the runtime feeds each provider the previous one's output, so only the final
+    /// position sees everything the others contributed. Placing it after
+    /// <see cref="Services.Agent.GoverningToolContextProvider"/> — which is itself documented as going last
+    /// — is safe, because this provider neither adds nor removes tools and so cannot escape that governance
+    /// wrapper or defeat it. Nothing is appended when no budget tracker is wired in, leaving a host that
+    /// does not track context with exactly the rail it had before.
+    /// </remarks>
+    private void AppendPerTurnBudgetProvider(
+        IList<AIContextProvider>? providers,
+        string agentName,
+        string instruction,
+        int toolCount)
+    {
+        if (_budgetTracker is null || providers is null || providers.Count == 0)
+            return;
+
+        providers.Add(new Services.Agent.PerTurnBudgetContextProvider(
+            agentName,
+            _budgetTracker,
+            instruction,
+            toolCount,
+            _loggerFactory.CreateLogger<Services.Agent.PerTurnBudgetContextProvider>()));
+
+        _logger.LogDebug(
+            "Wired PerTurnBudgetContextProvider for {AgentName} behind {ProviderCount} context provider(s)",
+            agentName, providers.Count - 1);
+    }
+}

--- a/src/Content/Application/Application.AI.Common/Factories/AgentExecutionContextFactory.ContextProviders.cs
+++ b/src/Content/Application/Application.AI.Common/Factories/AgentExecutionContextFactory.ContextProviders.cs
@@ -6,20 +6,20 @@ using Microsoft.Extensions.Logging;
 
 namespace Application.AI.Common.Factories;
 
-/// <summary>
-/// Context-provider half of <see cref="AgentExecutionContextFactory"/>: builds the
-/// <see cref="AIContextProvider"/> rail an agent runs on — progressive skill disclosure, the tool
-/// permission filter, cross-session and learnings recall, the governance wrapper, and the per-turn
-/// budget measurer.
-/// </summary>
-/// <remarks>
-/// <strong>Order on this rail is behaviour, not style.</strong> The runtime feeds each provider the
-/// previous one's output, so a provider only sees what everything above it produced. The two
-/// positional rules that hold the rail together are documented on the members below: any
-/// tool-contributing provider must go above <see cref="Services.Agent.ToolPermissionFilter"/>, and
-/// the per-turn measurer must go last. Both are load-bearing — moving a line here changes which
-/// tools an agent can call and what its budget records.
-/// </remarks>
+// Context-provider half of AgentExecutionContextFactory: builds the AIContextProvider rail an agent
+// runs on — progressive skill disclosure, the tool permission filter, cross-session and learnings
+// recall, the governance wrapper, and the per-turn budget measurer.
+//
+// ORDER ON THIS RAIL IS BEHAVIOUR, NOT STYLE. The runtime feeds each provider the previous one's
+// output, so a provider only sees what everything above it produced. Two positional rules hold the
+// rail together: any tool-contributing provider must go above ToolPermissionFilter (see the inline
+// comment at that call site), and the per-turn measurer must go last (see AppendPerTurnBudgetProvider).
+// Both are load-bearing — moving a line here changes which tools an agent can call and what its
+// budget records.
+//
+// Deliberately a plain comment, not an XML doc: the type's <summary> lives on the primary partial in
+// AgentExecutionContextFactory.cs. A second class-level <summary> on the same type would be merged
+// into one <member> entry, and which one tooling shows is compile-order dependent.
 public partial class AgentExecutionContextFactory
 {
     /// <summary>

--- a/src/Content/Application/Application.AI.Common/Factories/AgentExecutionContextFactory.Prompt.cs
+++ b/src/Content/Application/Application.AI.Common/Factories/AgentExecutionContextFactory.Prompt.cs
@@ -5,17 +5,11 @@ using Microsoft.Extensions.Logging;
 
 namespace Application.AI.Common.Factories;
 
-/// <summary>
-/// Static-prompt half of <see cref="AgentExecutionContextFactory"/>: composes the authoritative
-/// system prompt through <see cref="ISystemPromptComposer"/> when prompt composition is enabled.
-/// </summary>
-/// <remarks>
-/// This path is fail-open by design. Composition is an improvement on the legacy merged instruction,
-/// never a precondition for running an agent, so every way it can fall short — no request scope, no
-/// composer, a fault, an empty result — returns the legacy instruction unchanged rather than
-/// throwing. That is what keeps the feature safe to enable in a host that has not wired the scoped
-/// composer.
-/// </remarks>
+// Static-prompt half of AgentExecutionContextFactory: composes the authoritative system prompt
+// through ISystemPromptComposer when prompt composition is enabled. Fail-open by design — see the
+// member's own doc for the four ways it falls back.
+//
+// Deliberately a plain comment, not an XML doc — see AgentExecutionContextFactory.ContextProviders.cs.
 public partial class AgentExecutionContextFactory
 {
     /// <summary>

--- a/src/Content/Application/Application.AI.Common/Factories/AgentExecutionContextFactory.Prompt.cs
+++ b/src/Content/Application/Application.AI.Common/Factories/AgentExecutionContextFactory.Prompt.cs
@@ -1,0 +1,83 @@
+using Application.AI.Common.Interfaces;
+using Application.AI.Common.Interfaces.Prompts;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Application.AI.Common.Factories;
+
+/// <summary>
+/// Static-prompt half of <see cref="AgentExecutionContextFactory"/>: composes the authoritative
+/// system prompt through <see cref="ISystemPromptComposer"/> when prompt composition is enabled.
+/// </summary>
+/// <remarks>
+/// This path is fail-open by design. Composition is an improvement on the legacy merged instruction,
+/// never a precondition for running an agent, so every way it can fall short — no request scope, no
+/// composer, a fault, an empty result — returns the legacy instruction unchanged rather than
+/// throwing. That is what keeps the feature safe to enable in a host that has not wired the scoped
+/// composer.
+/// </remarks>
+public partial class AgentExecutionContextFactory
+{
+    /// <summary>
+    /// Builds the authoritative static system prompt via the scoped <see cref="ISystemPromptComposer"/>
+    /// when <c>PromptComposition</c> is enabled. Fails open to <paramref name="legacyInstruction"/>
+    /// (never throws): if no request scope is active, the composer/accessor cannot be resolved, or
+    /// composition faults or yields empty, the legacy merged instruction is returned unchanged.
+    /// </summary>
+    /// <remarks>
+    /// The factory is a singleton while the composer and its section providers are scoped, so the
+    /// scoped services are resolved per invocation from the current request scope via
+    /// <see cref="IAmbientRequestScope"/> — the same idiom used for the Knowledge/Learnings context
+    /// providers. Only the authoritative static section types
+    /// (<see cref="AuthoritativePromptSections.Default"/>) are composed; per-turn dynamic sections are
+    /// deliberately excluded and remain on the <c>AIContextProvider</c> rail.
+    /// </remarks>
+    private async Task<string> ComposeStaticSystemPromptAsync(string agentName, string legacyInstruction)
+    {
+        var scope = _serviceProvider.GetService<IAmbientRequestScope>()?.Current;
+        if (scope is null)
+        {
+            _logger.LogDebug(
+                "PromptComposition enabled but no ambient request scope is active; using legacy instruction for {AgentName}",
+                agentName);
+            return legacyInstruction;
+        }
+
+        var composer = scope.GetService<ISystemPromptComposer>();
+        var accessor = scope.GetService<ISkillInstructionAccessor>();
+        if (composer is null || accessor is null)
+        {
+            _logger.LogDebug(
+                "PromptComposition enabled but composer/accessor unavailable in the request scope; using legacy instruction for {AgentName}",
+                agentName);
+            return legacyInstruction;
+        }
+
+        try
+        {
+            // Source the current agent's merged skill instructions into the scoped section provider.
+            accessor.Set(legacyInstruction);
+
+            var budget = _appConfig.CurrentValue.AI?.ContextManagement?.PromptComposition?.TokenBudget ?? 8000;
+            var composed = await composer.ComposeAsync(agentName, budget, AuthoritativePromptSections.Default);
+
+            if (string.IsNullOrEmpty(composed))
+            {
+                _logger.LogDebug(
+                    "PromptComposition produced an empty prompt for {AgentName}; using legacy instruction",
+                    agentName);
+                return legacyInstruction;
+            }
+
+            _logger.LogDebug("Composed authoritative static system prompt for agent {AgentName}", agentName);
+            return composed;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "PromptComposition failed for agent {AgentName}; falling back to legacy instruction",
+                agentName);
+            return legacyInstruction;
+        }
+    }
+}

--- a/src/Content/Application/Application.AI.Common/Factories/AgentExecutionContextFactory.Resolution.cs
+++ b/src/Content/Application/Application.AI.Common/Factories/AgentExecutionContextFactory.Resolution.cs
@@ -1,0 +1,128 @@
+using Application.AI.Common.Helpers;
+using Domain.AI.Skills;
+using Domain.Common.Config.AI;
+
+namespace Application.AI.Common.Factories;
+
+/// <summary>
+/// Resolution half of <see cref="AgentExecutionContextFactory"/>: the pure decisions that turn a
+/// skill plus its call options into the scalar settings an agent context needs — deployment,
+/// framework type, tool ceiling, middleware chain, additional properties, and agent name.
+/// </summary>
+/// <remarks>
+/// Every member here is a resolver: it reads declarations and configuration and returns a value.
+/// None of them touch the budget tracker, the trace store, or the context-provider rail, which is
+/// why they sit apart from the orchestration in <c>AgentExecutionContextFactory.cs</c>.
+/// </remarks>
+public partial class AgentExecutionContextFactory
+{
+    private static AIAgentFrameworkClientType? ResolveFrameworkTypeFromMetadata(SkillDefinition skill)
+    {
+        if (skill.Metadata?.TryGetValue("framework_type", out var value) == true
+            && Enum.TryParse<AIAgentFrameworkClientType>(value?.ToString(), ignoreCase: true, out var parsed))
+            return parsed;
+
+        return null;
+    }
+
+    private string ResolveDeploymentName(SkillDefinition skill, SkillAgentOptions options)
+    {
+        if (!string.IsNullOrEmpty(options.DeploymentName))
+            return options.DeploymentName;
+
+        if (!string.IsNullOrEmpty(skill.ModelOverride))
+            return skill.ModelOverride;
+
+        if (skill.Metadata?.TryGetValue("deployment", out var deployment) == true)
+            return deployment.ToString() ?? "default";
+
+        return _appConfig.CurrentValue.AI?.AgentFramework?.DefaultDeployment ?? "default";
+    }
+
+    /// <summary>
+    /// Resolves the single effective tool allowlist that governs an agent: the union of its skills'
+    /// <c>AllowedTools</c> constraints, capped by the agent's declared ceiling (<paramref name="options"/>'s
+    /// <see cref="SkillAgentOptions.AllowedTools"/>) and then by any explicit per-call
+    /// <paramref name="explicitAllowlist"/>. Each cap can only tighten (see <see cref="ToolCeilingResolver"/>).
+    /// Returns <see langword="null"/> when nothing restricts the agent (every tool is permitted); a
+    /// non-null list is an active restriction, and an empty one denies every tool.
+    /// </summary>
+    private static IReadOnlyList<string>? ResolveEffectiveAllowlist(
+        IReadOnlyList<SkillDefinition> skills,
+        SkillAgentOptions options,
+        IReadOnlyList<string>? explicitAllowlist)
+    {
+        var effective = ToolCeilingResolver.ApplyCeiling(MergeSkillAllowedTools(skills), options.AllowedTools);
+        return ToolCeilingResolver.ApplyCeiling(effective, explicitAllowlist);
+    }
+
+    /// <summary>
+    /// Deduplicated union of every skill's <c>AllowedTools</c> constraint, case-insensitively, or
+    /// <see langword="null"/> when no skill declares a constraint — the "unbounded" input the ceiling
+    /// resolver expects for "no restriction" (distinct from an empty list, which means deny all).
+    /// </summary>
+    private static IReadOnlyList<string>? MergeSkillAllowedTools(IReadOnlyList<SkillDefinition> skills)
+    {
+        var union = skills
+            .Where(s => s.AllowedTools?.Count > 0)
+            .SelectMany(s => s.AllowedTools!)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        return union.Count > 0 ? union : null;
+    }
+
+    private List<Type>? ResolveMiddlewareTypes(SkillDefinition skill, SkillAgentOptions options)
+    {
+        var types = new List<Type>();
+
+        types.Add(typeof(Middleware.ObservabilityMiddleware));
+        types.Add(typeof(Middleware.ToolDiagnosticsMiddleware));
+
+        if (options.MiddlewareTypes?.Count > 0)
+            types.AddRange(options.MiddlewareTypes);
+
+        return types.Count > 0 ? types : null;
+    }
+
+    private static Dictionary<string, object> BuildAdditionalProperties(SkillDefinition skill, SkillAgentOptions options)
+    {
+        var props = new Dictionary<string, object>
+        {
+            ["skillId"] = skill.Id,
+            ["skillName"] = skill.Name,
+            ["loadedAt"] = skill.LoadedAt.ToString("O")
+        };
+
+        if (!string.IsNullOrEmpty(skill.Category))
+            props["category"] = skill.Category;
+        if (skill.HasTags)
+            props["tags"] = skill.Tags;
+        if (!string.IsNullOrEmpty(skill.Version))
+            props["version"] = skill.Version;
+
+        if (skill.Metadata != null)
+        {
+            foreach (var (key, value) in skill.Metadata)
+                props[$"skill_{key}"] = value;
+        }
+
+        if (options.AdditionalProperties != null)
+        {
+            foreach (var (key, value) in options.AdditionalProperties)
+                props[key] = value;
+        }
+
+        return props;
+    }
+
+    private static string ToAgentName(string skillName)
+    {
+        var parts = skillName.Split(['-', '_', ' '], StringSplitOptions.RemoveEmptyEntries);
+        var pascal = string.Concat(parts.Select(p =>
+            char.ToUpperInvariant(p[0]) + p[1..]));
+        return pascal.EndsWith("Agent", StringComparison.OrdinalIgnoreCase)
+            ? pascal
+            : pascal + "Agent";
+    }
+}

--- a/src/Content/Application/Application.AI.Common/Factories/AgentExecutionContextFactory.Resolution.cs
+++ b/src/Content/Application/Application.AI.Common/Factories/AgentExecutionContextFactory.Resolution.cs
@@ -4,16 +4,15 @@ using Domain.Common.Config.AI;
 
 namespace Application.AI.Common.Factories;
 
-/// <summary>
-/// Resolution half of <see cref="AgentExecutionContextFactory"/>: the pure decisions that turn a
-/// skill plus its call options into the scalar settings an agent context needs — deployment,
-/// framework type, tool ceiling, middleware chain, additional properties, and agent name.
-/// </summary>
-/// <remarks>
-/// Every member here is a resolver: it reads declarations and configuration and returns a value.
-/// None of them touch the budget tracker, the trace store, or the context-provider rail, which is
-/// why they sit apart from the orchestration in <c>AgentExecutionContextFactory.cs</c>.
-/// </remarks>
+// Resolution half of AgentExecutionContextFactory: the per-skill decisions and naming that turn a
+// skill plus its call options into the settings an agent context needs — deployment, framework type,
+// tool ceiling, middleware chain, additional properties, and agent name.
+//
+// What these members have in common is not a shape but an absence: none of them touch the budget
+// tracker, the trace store, or the context-provider rail. They read declarations and configuration
+// and return a value, which is why they sit apart from the orchestration in the primary partial.
+//
+// Deliberately a plain comment, not an XML doc — see AgentExecutionContextFactory.ContextProviders.cs.
 public partial class AgentExecutionContextFactory
 {
     private static AIAgentFrameworkClientType? ResolveFrameworkTypeFromMetadata(SkillDefinition skill)

--- a/src/Content/Application/Application.AI.Common/Factories/AgentExecutionContextFactory.SkillDisclosure.cs
+++ b/src/Content/Application/Application.AI.Common/Factories/AgentExecutionContextFactory.SkillDisclosure.cs
@@ -1,0 +1,76 @@
+using Application.AI.Common.Helpers;
+using Domain.AI.Skills;
+using Microsoft.Extensions.Logging;
+
+namespace Application.AI.Common.Factories;
+
+/// <summary>
+/// Progressive-disclosure half of <see cref="AgentExecutionContextFactory"/>: makes the skills the
+/// framework will serve on demand chargeable to the agent's budget, and reports the ones that had to
+/// stay eagerly in the static prompt.
+/// </summary>
+/// <remarks>
+/// Disclosure only pays for itself if its cost is visible. A skill served on demand is invisible to
+/// the factory's up-front budget records — the tokens arrive later, when the model pulls the body —
+/// and a skill that quietly falls back to eager injection is invisible too, because the agent keeps
+/// working and only the prompt grows. The two members here close both gaps: one charges the pulls,
+/// the other names the fallbacks.
+/// </remarks>
+public partial class AgentExecutionContextFactory
+{
+    /// <summary>
+    /// Wraps each disclosable skill so the tokens its Tier 2 body and Tier 3 files put into the context are
+    /// charged to <paramref name="agentName"/>'s budget when the model pulls them.
+    /// </summary>
+    /// <param name="disclosableSkills">The skills about to be handed to the framework provider.</param>
+    /// <param name="agentName">The agent whose budget the pulls are charged to.</param>
+    /// <returns>
+    /// The same skills, each wrapped — or the input unchanged when no budget tracker is wired in, so a host
+    /// that does not track context passes the framework's own skill objects through untouched.
+    /// </returns>
+    private IReadOnlyList<DisclosableSkill> ChargeSkillLoadsToBudget(
+        IReadOnlyList<DisclosableSkill> disclosableSkills,
+        string agentName)
+    {
+        if (_budgetTracker is null || disclosableSkills.Count == 0)
+            return disclosableSkills;
+
+        return [.. disclosableSkills.Select(s => s with
+        {
+            Skill = new Services.Skills.BudgetChargingSkill(s.Skill, agentName, _budgetTracker)
+        })];
+    }
+
+    /// <summary>
+    /// Records which skills kept their full body in the static prompt because the framework provider will
+    /// not serve them on demand.
+    /// </summary>
+    /// <remarks>
+    /// Falling back to eager injection is the safe outcome, but it is also invisible — the agent works,
+    /// the prompt is just larger than it should be. Without this line the only symptom of a skill that can
+    /// no longer be registered (a name edited out of kebab-case, a description deleted) is a gradual return
+    /// of the token cost progressive disclosure exists to remove. <see cref="DisclosableSkillFactory"/>
+    /// names a reason for the skills it rejects; it stays silent about ones it never considered, so this
+    /// total is the only signal covering those.
+    /// </remarks>
+    private void LogSkillsExcludedFromDisclosure(
+        IReadOnlyList<SkillDefinition> skills,
+        IReadOnlySet<string> disclosedOnDemand)
+    {
+        if (!_logger.IsEnabled(LogLevel.Debug))
+            return;
+
+        var eager = skills
+            .Where(s => !string.IsNullOrEmpty(s.Instructions) && !disclosedOnDemand.Contains(s.Id))
+            .Select(s => s.Id)
+            .ToList();
+
+        if (eager.Count == 0)
+            return;
+
+        _logger.LogDebug(
+            "Skill instructions kept in the static prompt for {Count} skill(s) not registered with the " +
+            "framework skills provider: {SkillIds}",
+            eager.Count, string.Join(", ", eager));
+    }
+}

--- a/src/Content/Application/Application.AI.Common/Factories/AgentExecutionContextFactory.SkillDisclosure.cs
+++ b/src/Content/Application/Application.AI.Common/Factories/AgentExecutionContextFactory.SkillDisclosure.cs
@@ -4,18 +4,13 @@ using Microsoft.Extensions.Logging;
 
 namespace Application.AI.Common.Factories;
 
-/// <summary>
-/// Progressive-disclosure half of <see cref="AgentExecutionContextFactory"/>: makes the skills the
-/// framework will serve on demand chargeable to the agent's budget, and reports the ones that had to
-/// stay eagerly in the static prompt.
-/// </summary>
-/// <remarks>
-/// Disclosure only pays for itself if its cost is visible. A skill served on demand is invisible to
-/// the factory's up-front budget records — the tokens arrive later, when the model pulls the body —
-/// and a skill that quietly falls back to eager injection is invisible too, because the agent keeps
-/// working and only the prompt grows. The two members here close both gaps: one charges the pulls,
-/// the other names the fallbacks.
-/// </remarks>
+// Progressive-disclosure half of AgentExecutionContextFactory. Disclosure only pays for itself if its
+// cost is visible, and both halves of that cost are invisible by default: tokens for an on-demand
+// skill arrive later (when the model pulls the body), and a skill that silently falls back to eager
+// injection shows no symptom at all. The two members here close those gaps — one charges the pulls,
+// the other names the fallbacks.
+//
+// Deliberately a plain comment, not an XML doc — see AgentExecutionContextFactory.ContextProviders.cs.
 public partial class AgentExecutionContextFactory
 {
     /// <summary>

--- a/src/Content/Application/Application.AI.Common/Factories/AgentExecutionContextFactory.cs
+++ b/src/Content/Application/Application.AI.Common/Factories/AgentExecutionContextFactory.cs
@@ -2,7 +2,6 @@ using Application.AI.Common.Extensions;
 using Application.AI.Common.Helpers;
 using Application.AI.Common.Interfaces;
 using Application.AI.Common.Interfaces.Context;
-using Application.AI.Common.Interfaces.Prompts;
 using Application.AI.Common.Interfaces.Resilience;
 using Application.AI.Common.Interfaces.Skills;
 using Application.AI.Common.Interfaces.Tools;
@@ -15,9 +14,6 @@ using Domain.AI.Telemetry.Conventions;
 using Domain.Common.Config;
 using Domain.Common.Config.AI;
 using Domain.Common.MetaHarness;
-using Microsoft.Agents.AI;
-using Microsoft.Extensions.AI;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -27,10 +23,22 @@ namespace Application.AI.Common.Factories;
 /// Bridges declarative skill definitions (SKILL.md) to runtime <see cref="AgentExecutionContext"/>.
 /// Delegates tool provisioning to <see cref="IToolChainBuilder"/> and prerequisite resolution
 /// to <see cref="ISkillPrerequisiteResolver"/>. Handles instruction assembly, middleware
-/// resolution, budget tracking, and wiring of <see cref="AgentSkillsProvider"/> for progressive
+/// resolution, budget tracking, and wiring of <c>AgentSkillsProvider</c> for progressive
 /// skill disclosure.
 /// </summary>
-public class AgentExecutionContextFactory
+/// <remarks>
+/// <para>
+/// Split across partials by responsibility, with this file holding the construction dependencies and
+/// the two public entry points that orchestrate them:
+/// </para>
+/// <list type="bullet">
+///   <item><c>AgentExecutionContextFactory.Prompt.cs</c> — authoritative static system prompt composition.</item>
+///   <item><c>AgentExecutionContextFactory.SkillDisclosure.cs</c> — progressive-disclosure budget charging and fallback reporting.</item>
+///   <item><c>AgentExecutionContextFactory.ContextProviders.cs</c> — the ordered <c>AIContextProvider</c> rail.</item>
+///   <item><c>AgentExecutionContextFactory.Resolution.cs</c> — deployment, framework, tool-ceiling, middleware, and naming resolvers.</item>
+/// </list>
+/// </remarks>
+public partial class AgentExecutionContextFactory
 {
     private readonly ILogger<AgentExecutionContextFactory> _logger;
     private readonly IOptionsMonitor<AppConfig> _appConfig;
@@ -298,369 +306,5 @@ public class AgentExecutionContextFactory
             context.Tools = _toolChainBuilder.BuildToolsByName(toolNames);
 
         return context;
-    }
-
-    private static AIAgentFrameworkClientType? ResolveFrameworkTypeFromMetadata(SkillDefinition skill)
-    {
-        if (skill.Metadata?.TryGetValue("framework_type", out var value) == true
-            && Enum.TryParse<AIAgentFrameworkClientType>(value?.ToString(), ignoreCase: true, out var parsed))
-            return parsed;
-
-        return null;
-    }
-
-    private string ResolveDeploymentName(SkillDefinition skill, SkillAgentOptions options)
-    {
-        if (!string.IsNullOrEmpty(options.DeploymentName))
-            return options.DeploymentName;
-
-        if (!string.IsNullOrEmpty(skill.ModelOverride))
-            return skill.ModelOverride;
-
-        if (skill.Metadata?.TryGetValue("deployment", out var deployment) == true)
-            return deployment.ToString() ?? "default";
-
-        return _appConfig.CurrentValue.AI?.AgentFramework?.DefaultDeployment ?? "default";
-    }
-
-    /// <summary>
-    /// Builds the authoritative static system prompt via the scoped <see cref="ISystemPromptComposer"/>
-    /// when <c>PromptComposition</c> is enabled. Fails open to <paramref name="legacyInstruction"/>
-    /// (never throws): if no request scope is active, the composer/accessor cannot be resolved, or
-    /// composition faults or yields empty, the legacy merged instruction is returned unchanged.
-    /// </summary>
-    /// <remarks>
-    /// The factory is a singleton while the composer and its section providers are scoped, so the
-    /// scoped services are resolved per invocation from the current request scope via
-    /// <see cref="IAmbientRequestScope"/> — the same idiom used for the Knowledge/Learnings context
-    /// providers. Only the authoritative static section types
-    /// (<see cref="AuthoritativePromptSections.Default"/>) are composed; per-turn dynamic sections are
-    /// deliberately excluded and remain on the <c>AIContextProvider</c> rail.
-    /// </remarks>
-    private async Task<string> ComposeStaticSystemPromptAsync(string agentName, string legacyInstruction)
-    {
-        var scope = _serviceProvider.GetService<IAmbientRequestScope>()?.Current;
-        if (scope is null)
-        {
-            _logger.LogDebug(
-                "PromptComposition enabled but no ambient request scope is active; using legacy instruction for {AgentName}",
-                agentName);
-            return legacyInstruction;
-        }
-
-        var composer = scope.GetService<ISystemPromptComposer>();
-        var accessor = scope.GetService<ISkillInstructionAccessor>();
-        if (composer is null || accessor is null)
-        {
-            _logger.LogDebug(
-                "PromptComposition enabled but composer/accessor unavailable in the request scope; using legacy instruction for {AgentName}",
-                agentName);
-            return legacyInstruction;
-        }
-
-        try
-        {
-            // Source the current agent's merged skill instructions into the scoped section provider.
-            accessor.Set(legacyInstruction);
-
-            var budget = _appConfig.CurrentValue.AI?.ContextManagement?.PromptComposition?.TokenBudget ?? 8000;
-            var composed = await composer.ComposeAsync(agentName, budget, AuthoritativePromptSections.Default);
-
-            if (string.IsNullOrEmpty(composed))
-            {
-                _logger.LogDebug(
-                    "PromptComposition produced an empty prompt for {AgentName}; using legacy instruction",
-                    agentName);
-                return legacyInstruction;
-            }
-
-            _logger.LogDebug("Composed authoritative static system prompt for agent {AgentName}", agentName);
-            return composed;
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex,
-                "PromptComposition failed for agent {AgentName}; falling back to legacy instruction",
-                agentName);
-            return legacyInstruction;
-        }
-    }
-
-    /// <summary>
-    /// Resolves the single effective tool allowlist that governs an agent: the union of its skills'
-    /// <c>AllowedTools</c> constraints, capped by the agent's declared ceiling (<paramref name="options"/>'s
-    /// <see cref="SkillAgentOptions.AllowedTools"/>) and then by any explicit per-call
-    /// <paramref name="explicitAllowlist"/>. Each cap can only tighten (see <see cref="ToolCeilingResolver"/>).
-    /// Returns <see langword="null"/> when nothing restricts the agent (every tool is permitted); a
-    /// non-null list is an active restriction, and an empty one denies every tool.
-    /// </summary>
-    private static IReadOnlyList<string>? ResolveEffectiveAllowlist(
-        IReadOnlyList<SkillDefinition> skills,
-        SkillAgentOptions options,
-        IReadOnlyList<string>? explicitAllowlist)
-    {
-        var effective = ToolCeilingResolver.ApplyCeiling(MergeSkillAllowedTools(skills), options.AllowedTools);
-        return ToolCeilingResolver.ApplyCeiling(effective, explicitAllowlist);
-    }
-
-    /// <summary>
-    /// Deduplicated union of every skill's <c>AllowedTools</c> constraint, case-insensitively, or
-    /// <see langword="null"/> when no skill declares a constraint — the "unbounded" input the ceiling
-    /// resolver expects for "no restriction" (distinct from an empty list, which means deny all).
-    /// </summary>
-    private static IReadOnlyList<string>? MergeSkillAllowedTools(IReadOnlyList<SkillDefinition> skills)
-    {
-        var union = skills
-            .Where(s => s.AllowedTools?.Count > 0)
-            .SelectMany(s => s.AllowedTools!)
-            .Distinct(StringComparer.OrdinalIgnoreCase)
-            .ToList();
-
-        return union.Count > 0 ? union : null;
-    }
-
-    /// <summary>
-    /// Unions the context providers for this agent over <paramref name="disclosableSkills"/>, which the
-    /// caller built once so this wiring and the prompt's disclosure decision cannot disagree.
-    /// The <paramref name="effectiveAllowlist"/> (the skills' combined constraint already capped by any
-    /// agent tool ceiling) drives a single <see cref="Services.Agent.ToolPermissionFilter"/>. It is
-    /// <see langword="null"/> when no restriction is active (no filter is wired), or a concrete set —
-    /// possibly empty, meaning deny-all — when a restriction applies.
-    /// </summary>
-    private IList<AIContextProvider>? BuildMergedAIContextProviders(
-        int skillCount,
-        IReadOnlyList<string>? effectiveAllowlist,
-        IReadOnlyList<DisclosableSkill> disclosableSkills)
-    {
-        var providers = new List<AIContextProvider>();
-
-        if (disclosableSkills.Count > 0)
-        {
-            // Registering the agent's own skills, rather than a directory to search, is what keeps
-            // load_skill from advertising skills this agent was never assigned.
-            providers.Add(new AgentSkillsProviderBuilder()
-                .UseSkills(disclosableSkills.Select(s => s.Skill))
-                .UseOptions(SkillDisclosureDefaults.Configure)
-                .Build());
-
-            _logger.LogDebug("Wired AgentSkillsProvider with {SkillCount} skill(s)", disclosableSkills.Count);
-        }
-
-        // Placed immediately after the skills provider so it sees the framework's disclosure tools. Note
-        // what this position does and does not guarantee: the framework feeds each provider the previous
-        // one's output, so the filter's removals survive into everything added below. But a provider added
-        // *after* this line whose own contribution introduces a tool would introduce it unfiltered — the
-        // filter has already run. Any future tool-contributing provider belongs above this line.
-        if (effectiveAllowlist is not null)
-        {
-            providers.Add(new Services.Agent.ToolPermissionFilter(effectiveAllowlist));
-
-            _logger.LogDebug("Wired ToolPermissionFilter with {Count} allowed tool(s) for {SkillCount} skill(s)",
-                effectiveAllowlist.Count, skillCount);
-        }
-
-        // Cross-session memory recall. The provider resolves tenant-aware IKnowledgeMemory per
-        // invocation from the current request scope (via IAmbientRequestScope), so it is safe to
-        // attach to a singleton-cached agent.
-        if (_appConfig.CurrentValue.AI?.KnowledgeBridge?.Enabled == true)
-        {
-            var ambientScope = _serviceProvider.GetService<IAmbientRequestScope>();
-            if (ambientScope is not null)
-            {
-                providers.Add(new Services.Agent.KnowledgeMemoryContextProvider(
-                    ambientScope,
-                    _appConfig,
-                    _loggerFactory.CreateLogger<Services.Agent.KnowledgeMemoryContextProvider>()));
-
-                _logger.LogDebug("Wired KnowledgeMemoryContextProvider for cross-session recall");
-            }
-        }
-
-        // Task-similarity learnings recall. Like the memory provider above, it resolves the scoped,
-        // tenant-aware ILearningRecaller per invocation from the current request scope, so it is safe to
-        // attach to a singleton-cached agent. Injects the most task-relevant lessons (every source,
-        // including work-memory synthesis output) at turn start — the read half of the self-improving loop.
-        if (_appConfig.CurrentValue.AI?.LearningsRecall?.Enabled == true)
-        {
-            var ambientScope = _serviceProvider.GetService<IAmbientRequestScope>();
-            if (ambientScope is not null)
-            {
-                providers.Add(new Services.Agent.LearningsRecallContextProvider(
-                    ambientScope,
-                    _appConfig,
-                    _loggerFactory.CreateLogger<Services.Agent.LearningsRecallContextProvider>()));
-
-                _logger.LogDebug("Wired LearningsRecallContextProvider for task-similarity recall");
-            }
-        }
-
-        // Governance wrapper — added LAST so it wraps the final, filtered tool set. When
-        // tool-invocation enforcement is on, this guarantees the governor gates every tool the agent
-        // can call, including framework progressive-disclosure tools that bypass ToolChainBuilder.
-        // Inert (and skipped entirely) when enforcement is off, so default behaviour is unchanged.
-        if (_appConfig.CurrentValue.AI?.Governance?.EnforceToolInvocation == true)
-        {
-            providers.Add(new Services.Agent.GoverningToolContextProvider(
-                _loggerFactory.CreateLogger<Services.Agent.GoverningToolContextProvider>()));
-            _logger.LogDebug("Wired GoverningToolContextProvider (tool-invocation enforcement enabled)");
-        }
-
-        return providers.Count > 0 ? providers : null;
-    }
-
-    /// <summary>
-    /// Appends the measurer that charges whatever <paramref name="providers"/> inject into each turn to
-    /// <paramref name="agentName"/>'s budget.
-    /// </summary>
-    /// <param name="providers">
-    /// The rail built for this agent, mutated in place. <see langword="null"/> or empty means the agent has
-    /// no rail, so there is nothing per-turn to charge and nothing is appended.
-    /// </param>
-    /// <param name="agentName">The agent whose budget the per-turn context is charged to.</param>
-    /// <param name="instruction">
-    /// The static system prompt, already charged separately. It is the baseline the measurer subtracts, so
-    /// only what the rail adds is charged here rather than the prompt being billed again every turn.
-    /// </param>
-    /// <param name="toolCount">
-    /// The number of tools the agent was built with, already charged as tool schemas — the baseline for
-    /// tools the rail contributes, such as the framework's own skill-disclosure tools.
-    /// </param>
-    /// <remarks>
-    /// It must be last: the runtime feeds each provider the previous one's output, so only the final
-    /// position sees everything the others contributed. Placing it after
-    /// <see cref="Services.Agent.GoverningToolContextProvider"/> — which is itself documented as going last
-    /// — is safe, because this provider neither adds nor removes tools and so cannot escape that governance
-    /// wrapper or defeat it. Nothing is appended when no budget tracker is wired in, leaving a host that
-    /// does not track context with exactly the rail it had before.
-    /// </remarks>
-    private void AppendPerTurnBudgetProvider(
-        IList<AIContextProvider>? providers,
-        string agentName,
-        string instruction,
-        int toolCount)
-    {
-        if (_budgetTracker is null || providers is null || providers.Count == 0)
-            return;
-
-        providers.Add(new Services.Agent.PerTurnBudgetContextProvider(
-            agentName,
-            _budgetTracker,
-            instruction,
-            toolCount,
-            _loggerFactory.CreateLogger<Services.Agent.PerTurnBudgetContextProvider>()));
-
-        _logger.LogDebug(
-            "Wired PerTurnBudgetContextProvider for {AgentName} behind {ProviderCount} context provider(s)",
-            agentName, providers.Count - 1);
-    }
-
-    /// <summary>
-    /// Wraps each disclosable skill so the tokens its Tier 2 body and Tier 3 files put into the context are
-    /// charged to <paramref name="agentName"/>'s budget when the model pulls them.
-    /// </summary>
-    /// <param name="disclosableSkills">The skills about to be handed to the framework provider.</param>
-    /// <param name="agentName">The agent whose budget the pulls are charged to.</param>
-    /// <returns>
-    /// The same skills, each wrapped — or the input unchanged when no budget tracker is wired in, so a host
-    /// that does not track context passes the framework's own skill objects through untouched.
-    /// </returns>
-    private IReadOnlyList<DisclosableSkill> ChargeSkillLoadsToBudget(
-        IReadOnlyList<DisclosableSkill> disclosableSkills,
-        string agentName)
-    {
-        if (_budgetTracker is null || disclosableSkills.Count == 0)
-            return disclosableSkills;
-
-        return [.. disclosableSkills.Select(s => s with
-        {
-            Skill = new Services.Skills.BudgetChargingSkill(s.Skill, agentName, _budgetTracker)
-        })];
-    }
-
-    /// <summary>
-    /// Records which skills kept their full body in the static prompt because the framework provider will
-    /// not serve them on demand.
-    /// </summary>
-    /// <remarks>
-    /// Falling back to eager injection is the safe outcome, but it is also invisible — the agent works,
-    /// the prompt is just larger than it should be. Without this line the only symptom of a skill that can
-    /// no longer be registered (a name edited out of kebab-case, a description deleted) is a gradual return
-    /// of the token cost progressive disclosure exists to remove. <see cref="DisclosableSkillFactory"/>
-    /// names a reason for the skills it rejects; it stays silent about ones it never considered, so this
-    /// total is the only signal covering those.
-    /// </remarks>
-    private void LogSkillsExcludedFromDisclosure(
-        IReadOnlyList<SkillDefinition> skills,
-        IReadOnlySet<string> disclosedOnDemand)
-    {
-        if (!_logger.IsEnabled(LogLevel.Debug))
-            return;
-
-        var eager = skills
-            .Where(s => !string.IsNullOrEmpty(s.Instructions) && !disclosedOnDemand.Contains(s.Id))
-            .Select(s => s.Id)
-            .ToList();
-
-        if (eager.Count == 0)
-            return;
-
-        _logger.LogDebug(
-            "Skill instructions kept in the static prompt for {Count} skill(s) not registered with the " +
-            "framework skills provider: {SkillIds}",
-            eager.Count, string.Join(", ", eager));
-    }
-
-    private List<Type>? ResolveMiddlewareTypes(SkillDefinition skill, SkillAgentOptions options)
-    {
-        var types = new List<Type>();
-
-        types.Add(typeof(Middleware.ObservabilityMiddleware));
-        types.Add(typeof(Middleware.ToolDiagnosticsMiddleware));
-
-        if (options.MiddlewareTypes?.Count > 0)
-            types.AddRange(options.MiddlewareTypes);
-
-        return types.Count > 0 ? types : null;
-    }
-
-    private static Dictionary<string, object> BuildAdditionalProperties(SkillDefinition skill, SkillAgentOptions options)
-    {
-        var props = new Dictionary<string, object>
-        {
-            ["skillId"] = skill.Id,
-            ["skillName"] = skill.Name,
-            ["loadedAt"] = skill.LoadedAt.ToString("O")
-        };
-
-        if (!string.IsNullOrEmpty(skill.Category))
-            props["category"] = skill.Category;
-        if (skill.HasTags)
-            props["tags"] = skill.Tags;
-        if (!string.IsNullOrEmpty(skill.Version))
-            props["version"] = skill.Version;
-
-        if (skill.Metadata != null)
-        {
-            foreach (var (key, value) in skill.Metadata)
-                props[$"skill_{key}"] = value;
-        }
-
-        if (options.AdditionalProperties != null)
-        {
-            foreach (var (key, value) in options.AdditionalProperties)
-                props[key] = value;
-        }
-
-        return props;
-    }
-
-    private static string ToAgentName(string skillName)
-    {
-        var parts = skillName.Split(['-', '_', ' '], StringSplitOptions.RemoveEmptyEntries);
-        var pascal = string.Concat(parts.Select(p =>
-            char.ToUpperInvariant(p[0]) + p[1..]));
-        return pascal.EndsWith("Agent", StringComparison.OrdinalIgnoreCase)
-            ? pascal
-            : pascal + "Agent";
     }
 }

--- a/src/Content/Application/Application.AI.Common/Factories/AgentExecutionContextFactory.cs
+++ b/src/Content/Application/Application.AI.Common/Factories/AgentExecutionContextFactory.cs
@@ -14,6 +14,7 @@ using Domain.AI.Telemetry.Conventions;
 using Domain.Common.Config;
 using Domain.Common.Config.AI;
 using Domain.Common.MetaHarness;
+using Microsoft.Agents.AI;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -23,7 +24,7 @@ namespace Application.AI.Common.Factories;
 /// Bridges declarative skill definitions (SKILL.md) to runtime <see cref="AgentExecutionContext"/>.
 /// Delegates tool provisioning to <see cref="IToolChainBuilder"/> and prerequisite resolution
 /// to <see cref="ISkillPrerequisiteResolver"/>. Handles instruction assembly, middleware
-/// resolution, budget tracking, and wiring of <c>AgentSkillsProvider</c> for progressive
+/// resolution, budget tracking, and wiring of <see cref="AgentSkillsProvider"/> for progressive
 /// skill disclosure.
 /// </summary>
 /// <remarks>
@@ -35,7 +36,7 @@ namespace Application.AI.Common.Factories;
 ///   <item><c>AgentExecutionContextFactory.Prompt.cs</c> — authoritative static system prompt composition.</item>
 ///   <item><c>AgentExecutionContextFactory.SkillDisclosure.cs</c> — progressive-disclosure budget charging and fallback reporting.</item>
 ///   <item><c>AgentExecutionContextFactory.ContextProviders.cs</c> — the ordered <c>AIContextProvider</c> rail.</item>
-///   <item><c>AgentExecutionContextFactory.Resolution.cs</c> — deployment, framework, tool-ceiling, middleware, and naming resolvers.</item>
+///   <item><c>AgentExecutionContextFactory.Resolution.cs</c> — deployment, framework, tool-ceiling, middleware, additional-property, and naming decisions.</item>
 /// </list>
 /// </remarks>
 public partial class AgentExecutionContextFactory


### PR DESCRIPTION
Closes #251.

## What I found before writing any code

#251 has three items. **Two were already fixed before the issue was filed.**

| Item | Status | Control |
|---|---|---|
| "Startup dependency validation is off, hiding ~106 registration gaps" | **Already fixed** | Commit `ec3ed5cb`, **2026-07-09** — four weeks *before* #251 was filed on 2026-08-04 |
| "Five planner step-configuration validators … never wired into the plan validator" | **Already fixed** | Commit `cdc521da`, **2026-07-08** |
| "A context-factory class has grown past the project's own file-size cap" | **This PR** | 666 lines → 310 max |

Both were verified independently, not taken on the commit messages:

- **Validation is on in every host.** `ApplyValidationPolicy` sets `ValidateScopes` + `ValidateOnBuild` for AgentHub and ExecutionApi; `BuildValidatedServiceProvider` does it for ConsoleUI, EvalRunner and FoundryHost; the MCP server inlines the same two flags. LoggerUI has no DI container at all. `ValidateOnBuildSweepTests` passes, and no production code calls a bare `BuildServiceProvider()`.
- **The five step-config validators are wired.** `AddValidatorsFromAssembly` registers them; `PlanValidator.ValidateStepConfigurations` dispatches all five; the "Real DI Wiring" tests in `PlanValidatorTests.cs` guard the seam and even document that a name grep makes them look dead.

## What this PR changes

`AgentExecutionContextFactory` was 666 lines, past this repo's 400-line cap. Split along the four jobs it does, following the documented `PlanExecutor.*` convention:

| File | Lines | Owns |
|---|---|---|
| `AgentExecutionContextFactory.cs` | 310 | dependencies + the two public entry points |
| `.ContextProviders.cs` | 159 | the ordered `AIContextProvider` rail |
| `.Resolution.cs` | 128 | deployment / framework / tool-ceiling / middleware / naming |
| `.Prompt.cs` | 83 | authoritative static system prompt composition |
| `.SkillDisclosure.cs` | 76 | progressive-disclosure budget charging + fallback reporting |

**Commit 1 is a pure move** — the member signature set is byte-identical before and after (diffed mechanically), and no method body was edited. That property is the safety guarantee, which is why every review suggestion that would have touched a body was filed as a follow-up instead of folded in.

**Commit 2 fixes a regression the split introduced.** Giving four partials a class-level `<summary>` was wrong: Roslyn merges class-level docs across partials into one `<member>`, so the generated XML carried five `<summary>` elements and tooling published the alphabetically-first partial's internal note as the type's documentation — compile-order dependent, and the compiler warns about none of it. Measured in `bin/.../Application.AI.Common.xml`: **5 summaries before, 1 after**, and the survivor is the real type summary. The per-partial prose is kept as plain comments; the rail-ordering invariant in particular stays where someone changing the order will read it. Also restored a `cref` the split had degraded to `<c>`.

## Test plan

- `dotnet build src/AgenticHarness.slnx` — green, no new warnings (6 pre-existing, all in test projects I did not touch).
- `dotnet test src/AgenticHarness.slnx` — green except 4 `FileSystemService` failures. **Control measured:** the same 4 fail with these changes stashed, so they are the documented local `TEMP` environment trap, not this change.
- `Application.AI.Common.Tests` — 1697/1697 pass, including all 140 factory tests.
- Generated XML doc inspected directly before and after the doc fix.

## Follow-ups filed, deliberately not done here

Everything below changes bodies or call sites and would cost the pure-move guarantee:

- `ResolveEffectiveAllowlist`/`MergeSkillAllowedTools` encode the union half of the tool-ceiling invariant and belong on `ToolCeilingResolver` next to `ApplyCeiling`.
- `AppendPerTurnBudgetProvider` could fold into `BuildMergedAIContextProviders` so "measurer last" is structural rather than call-sequence-dependent across two files.
- **No test asserts rail *position*, only presence** — worth a contract test in an assembly whose own docs record this family of provider defect shipping four times.
- `ValidateOnBuildSweepTests` builds with empty configuration, so it is structurally blind to exactly the conditionally-registered handlers #251 named.
- `PlanValidator.ValidateConfig` returns `[]` silently when a validator is missing, unlike its sibling `LogUnknownConfigType` — if assembly scanning ever stops finding them, #251's original bug returns with no signal.
- `Factories/AgentFactory.cs` is **653 lines** — same cap breach, same folder, untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SZJogfXvRweW2wbMdetQ5H
