### PR TITLE
test: assert AIContextProvider rail ORDER

### DIFF
--- a/src/Content/Application/Application.AI.Common/Factories/AgentExecutionContextFactory.ContextProviders.cs
+++ b/src/Content/Application/Application.AI.Common/Factories/AgentExecutionContextFactory.ContextProviders.cs
@@ -45,7 +45,7 @@ public partial class AgentExecutionContextFactory
     /// gap this method could close. It does not make lastness unbreakable: the rail is handed on as a
     /// mutable <see cref="IList{T}"/> through a settable property, so a consumer that appended to it would
     /// still displace the measurer. Nothing does today, and no test would catch it if something started —
-    /// tracked in issue #275.
+    /// tracked in issue #277.
     /// </remarks>
     private IList<AIContextProvider>? BuildMergedAIContextProviders(
         int skillCount,

--- a/src/Content/Application/Application.AI.Common/Factories/AgentExecutionContextFactory.ContextProviders.cs
+++ b/src/Content/Application/Application.AI.Common/Factories/AgentExecutionContextFactory.ContextProviders.cs
@@ -41,8 +41,11 @@ public partial class AgentExecutionContextFactory
     /// <returns>The ordered rail, or <see langword="null"/> when this agent needs no providers at all.</returns>
     /// <remarks>
     /// The per-turn measurer is appended here rather than by the caller, so that "it must be last" is a
-    /// property of this one method instead of a property of a call sequence in another file. It cannot be
-    /// displaced from outside without adding a provider to the returned list, which no caller does.
+    /// property of this one method instead of a property of a call sequence in another file. That closes the
+    /// gap this method could close. It does not make lastness unbreakable: the rail is handed on as a
+    /// mutable <see cref="IList{T}"/> through a settable property, so a consumer that appended to it would
+    /// still displace the measurer. Nothing does today, and no test would catch it if something started —
+    /// tracked in issue #275.
     /// </remarks>
     private IList<AIContextProvider>? BuildMergedAIContextProviders(
         int skillCount,

--- a/src/Content/Application/Application.AI.Common/Factories/AgentExecutionContextFactory.ContextProviders.cs
+++ b/src/Content/Application/Application.AI.Common/Factories/AgentExecutionContextFactory.ContextProviders.cs
@@ -15,7 +15,9 @@ namespace Application.AI.Common.Factories;
 // rail together: any tool-contributing provider must go above ToolPermissionFilter (see the inline
 // comment at that call site), and the per-turn measurer must go last (see AppendPerTurnBudgetProvider).
 // Both are load-bearing — moving a line here changes which tools an agent can call and what its
-// budget records.
+// budget records. AgentExecutionContextFactoryRailOrderTests asserts both, by position rather than by
+// presence, because every other test in this assembly reads the rail with OfType<T>().Single() and so
+// passes whatever the order is.
 //
 // Deliberately a plain comment, not an XML doc: the type's <summary> lives on the primary partial in
 // AgentExecutionContextFactory.cs. A second class-level <summary> on the same type would be merged
@@ -30,10 +32,25 @@ public partial class AgentExecutionContextFactory
     /// <see langword="null"/> when no restriction is active (no filter is wired), or a concrete set —
     /// possibly empty, meaning deny-all — when a restriction applies.
     /// </summary>
+    /// <param name="skillCount">How many skills this agent was built from; diagnostics only.</param>
+    /// <param name="effectiveAllowlist">The one allowlist governing this agent, or <see langword="null"/>.</param>
+    /// <param name="disclosableSkills">The skills the framework provider is given, built once by the caller.</param>
+    /// <param name="agentName">The agent whose budget the per-turn measurer charges.</param>
+    /// <param name="instruction">The static system prompt — the measurer's instruction baseline.</param>
+    /// <param name="toolCount">The tool count the agent was built with — the measurer's tool baseline.</param>
+    /// <returns>The ordered rail, or <see langword="null"/> when this agent needs no providers at all.</returns>
+    /// <remarks>
+    /// The per-turn measurer is appended here rather than by the caller, so that "it must be last" is a
+    /// property of this one method instead of a property of a call sequence in another file. It cannot be
+    /// displaced from outside without adding a provider to the returned list, which no caller does.
+    /// </remarks>
     private IList<AIContextProvider>? BuildMergedAIContextProviders(
         int skillCount,
         IReadOnlyList<string>? effectiveAllowlist,
-        IReadOnlyList<DisclosableSkill> disclosableSkills)
+        IReadOnlyList<DisclosableSkill> disclosableSkills,
+        string agentName,
+        string instruction,
+        int toolCount)
     {
         var providers = new List<AIContextProvider>();
 
@@ -108,6 +125,10 @@ public partial class AgentExecutionContextFactory
             _logger.LogDebug("Wired GoverningToolContextProvider (tool-invocation enforcement enabled)");
         }
 
+        // Last, unconditionally and from inside this method — see the remarks above and on
+        // AppendPerTurnBudgetProvider. An empty rail gets nothing appended, so the null below is unaffected.
+        AppendPerTurnBudgetProvider(providers, agentName, instruction, toolCount);
+
         return providers.Count > 0 ? providers : null;
     }
 
@@ -130,7 +151,9 @@ public partial class AgentExecutionContextFactory
     /// </param>
     /// <remarks>
     /// It must be last: the runtime feeds each provider the previous one's output, so only the final
-    /// position sees everything the others contributed. Placing it after
+    /// position sees everything the others contributed. That is why this is called from the tail of
+    /// <see cref="BuildMergedAIContextProviders"/> rather than by whoever consumes the rail — lastness is
+    /// then a property of the builder, not of a call sequence somewhere else. Placing it after
     /// <see cref="Services.Agent.GoverningToolContextProvider"/> — which is itself documented as going last
     /// — is safe, because this provider neither adds nor removes tools and so cannot escape that governance
     /// wrapper or defeat it. Nothing is appended when no budget tracker is wired in, leaving a host that

--- a/src/Content/Application/Application.AI.Common/Factories/AgentExecutionContextFactory.ContextProviders.cs
+++ b/src/Content/Application/Application.AI.Common/Factories/AgentExecutionContextFactory.ContextProviders.cs
@@ -140,8 +140,8 @@ public partial class AgentExecutionContextFactory
     /// <paramref name="agentName"/>'s budget.
     /// </summary>
     /// <param name="providers">
-    /// The rail built for this agent, mutated in place. <see langword="null"/> or empty means the agent has
-    /// no rail, so there is nothing per-turn to charge and nothing is appended.
+    /// The rail built for this agent, mutated in place. An empty rail means the agent has no providers, so
+    /// there is nothing per-turn to charge and nothing is appended.
     /// </param>
     /// <param name="agentName">The agent whose budget the per-turn context is charged to.</param>
     /// <param name="instruction">
@@ -163,12 +163,12 @@ public partial class AgentExecutionContextFactory
     /// does not track context with exactly the rail it had before.
     /// </remarks>
     private void AppendPerTurnBudgetProvider(
-        IList<AIContextProvider>? providers,
+        IList<AIContextProvider> providers,
         string agentName,
         string instruction,
         int toolCount)
     {
-        if (_budgetTracker is null || providers is null || providers.Count == 0)
+        if (_budgetTracker is null || providers.Count == 0)
             return;
 
         providers.Add(new Services.Agent.PerTurnBudgetContextProvider(

--- a/src/Content/Application/Application.AI.Common/Factories/AgentExecutionContextFactory.cs
+++ b/src/Content/Application/Application.AI.Common/Factories/AgentExecutionContextFactory.cs
@@ -145,10 +145,11 @@ public partial class AgentExecutionContextFactory
         var mergedToolChain = await _toolChainBuilder.BuildMergedToolsWithSourcesAsync(skills, options, effectiveAllowedTools);
         var tools = mergedToolChain.Tools.ToList();
         var middlewareTypes = ResolveMiddlewareTypes(primarySkill, options);
-        var aiContextProviders = BuildMergedAIContextProviders(skills.Count, effectiveAllowedTools, disclosableSkills);
+        // The rail ends with the measurer that charges what it injects into every turn — appended inside
+        // the builder, not here, so nothing outside can displace it from last (issues #266, #271).
+        var aiContextProviders = BuildMergedAIContextProviders(
+            skills.Count, effectiveAllowedTools, disclosableSkills, agentName, instruction, tools.Count);
 
-        // Charges what that rail injects into every turn — see AppendPerTurnBudgetProvider (issue #266).
-        AppendPerTurnBudgetProvider(aiContextProviders, agentName, instruction, tools.Count);
         var frameworkType = options.FrameworkType
             ?? ResolveFrameworkTypeFromMetadata(primarySkill)
             ?? _appConfig.CurrentValue.AI?.AgentFramework?.ClientType

--- a/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentExecutionContextFactoryProgressiveDisclosureTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentExecutionContextFactoryProgressiveDisclosureTests.cs
@@ -150,31 +150,15 @@ public sealed class AgentExecutionContextFactoryProgressiveDisclosureTests : IDi
         context.AIContextProviders!.OfType<AgentSkillsProvider>().Single();
 
     /// <summary>
-    /// Drives the agent's whole context-provider rail the way the runtime does — seeded with the agent's
-    /// own instructions and tools, then feeding each provider the previous one's output — and returns the
-    /// finished context.
+    /// Drives the agent's whole context-provider rail the way the runtime does, via the shared
+    /// <see cref="AIContextRailDriver"/>.
     /// </summary>
     /// <remarks>
     /// Invoking one provider in isolation cannot exercise per-turn accounting, because the measurer sits at
     /// the end of the chain and only sees what the providers ahead of it accumulated.
     /// </remarks>
-    private static async Task<AIContext> DriveRailAsync(Domain.AI.Agents.AgentExecutionContext context)
-    {
-        var current = new AIContext
-        {
-            Instructions = context.Instruction,
-            Messages = new List<ChatMessage> { new(ChatRole.User, "go") },
-            Tools = context.Tools is null ? [] : [.. context.Tools]
-        };
-
-        foreach (var provider in context.AIContextProviders!)
-        {
-            current = await provider.InvokingAsync(new AIContextProvider.InvokingContext(
-                new Mock<AIAgent>().Object, new Mock<AgentSession>().Object, current));
-        }
-
-        return current;
-    }
+    private static Task<AIContext> DriveRailAsync(Domain.AI.Agents.AgentExecutionContext context) =>
+        AIContextRailDriver.DriveAsync(context);
 
     // ── Tier 1: the prompt carries the index card, not the body ──────────────
 

--- a/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentExecutionContextFactoryRailOrderTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentExecutionContextFactoryRailOrderTests.cs
@@ -1,12 +1,14 @@
 using Application.AI.Common.Factories;
 using Application.AI.Common.Interfaces;
-using Application.AI.Common.Interfaces.Context;
+using Application.AI.Common.Interfaces.Tools;
 using Application.AI.Common.Services.Agent;
 using Application.AI.Common.Services.Context;
 using Application.AI.Common.Services.Skills;
 using Application.AI.Common.Services.Tools;
 using Application.AI.Common.Tests.Helpers;
+using Domain.AI.Models;
 using Domain.AI.Skills;
+using Domain.AI.Tools;
 using Domain.Common.Config;
 using Domain.Common.Config.AI;
 using FluentAssertions;
@@ -56,10 +58,13 @@ namespace Application.AI.Common.Tests.Factories;
 public sealed class AgentExecutionContextFactoryRailOrderTests : IDisposable
 {
     private const string SkillName = "rail-skill";
-    private const string AllowedTool = "file_system";
 
-    /// <summary>The agent name the factory derives from <see cref="SkillName"/>.</summary>
-    private const string AgentName = "RailSkillAgent";
+    /// <summary>
+    /// The one tool the skill grants. Registered for real below, so the allowlist has something to permit
+    /// as well as something to deny — a filter proven only against denials would pass while stripping
+    /// everything.
+    /// </summary>
+    private const string AllowedTool = "file_system";
 
     private readonly SkillDirectoryFixture _skills = new("railorder");
     private readonly string _skillDir;
@@ -97,7 +102,7 @@ public sealed class AgentExecutionContextFactoryRailOrderTests : IDisposable
     private AgentExecutionContextFactory CreateFactory(
         bool recall = true,
         bool governance = true,
-        IContextBudgetTracker? budgetTracker = null)
+        bool budgetTracker = true)
     {
         var appConfig = new AppConfig
         {
@@ -116,6 +121,9 @@ public sealed class AgentExecutionContextFactoryRailOrderTests : IDisposable
         // The two recall providers are wired only when the factory can reach an ambient request scope —
         // they resolve their tenant-aware collaborator per invocation, so an empty scope is enough here.
         services.AddSingleton(Mock.Of<IAmbientRequestScope>());
+
+        // A real tool behind the name the skill grants, so the agent is actually built holding it.
+        services.AddKeyedSingleton<ITool>(AllowedTool, (_, _) => new StubTool(AllowedTool));
         var sp = services.BuildServiceProvider();
 
         return new AgentExecutionContextFactory(
@@ -123,15 +131,37 @@ public sealed class AgentExecutionContextFactoryRailOrderTests : IDisposable
             Mock.Of<IOptionsMonitor<AppConfig>>(m => m.CurrentValue == appConfig),
             sp,
             NullLoggerFactory.Instance,
-            new ToolChainBuilder(NullLogger<ToolChainBuilder>.Instance, sp),
+            new ToolChainBuilder(NullLogger<ToolChainBuilder>.Instance, sp, new PassThroughToolConverter()),
             new SkillPrerequisiteResolver(),
             new UnsandboxedSkillFileReader(),
-            budgetTracker ?? CreateBudgetTracker());
+            budgetTracker
+                ? new ContextBudgetTracker(
+                    Mock.Of<IOptionsMonitor<AppConfig>>(m => m.CurrentValue == new AppConfig()),
+                    NullLogger<ContextBudgetTracker>.Instance)
+                : null);
     }
 
-    private static ContextBudgetTracker CreateBudgetTracker() => new(
-        Mock.Of<IOptionsMonitor<AppConfig>>(m => m.CurrentValue == new AppConfig()),
-        NullLogger<ContextBudgetTracker>.Instance);
+    private sealed class StubTool(string name) : ITool
+    {
+        public string Name { get; } = name;
+        public string Description => "stub";
+        public IReadOnlyList<string> SupportedOperations { get; } = ["run"];
+
+        public Task<ToolResult> ExecuteAsync(
+            string operation,
+            IReadOnlyDictionary<string, object?> parameters,
+            CancellationToken cancellationToken = default) => Task.FromResult(ToolResult.Ok("r"));
+    }
+
+    private sealed class PassThroughToolConverter : IToolConverter
+    {
+        public int Priority => 100;
+
+        public bool CanConvert(ITool tool) => true;
+
+        public AITool? Convert(ITool tool, IReadOnlyList<string>? allowedOperations = null) =>
+            AIFunctionFactory.Create(() => "r", tool.Name);
+    }
 
     private static IReadOnlyList<Type> RailTypes(Domain.AI.Agents.AgentExecutionContext context) =>
         [.. context.AIContextProviders!.Select(p => p.GetType())];
@@ -186,24 +216,8 @@ public sealed class AgentExecutionContextFactoryRailOrderTests : IDisposable
     {
         // A host that does not track context must get exactly the rail it had before the measurer existed —
         // not a rail with an inert provider on the end of it.
-        var factory = new AgentExecutionContextFactory(
-            NullLogger<AgentExecutionContextFactory>.Instance,
-            Mock.Of<IOptionsMonitor<AppConfig>>(m => m.CurrentValue == new AppConfig
-            {
-                AI = new AIConfig
-                {
-                    AgentFramework = new AgentFrameworkConfig { DefaultDeployment = "gpt-4o" },
-                    Skills = new SkillsConfig { BasePath = _skillsRoot }
-                }
-            }),
-            new ServiceCollection().BuildServiceProvider(),
-            NullLoggerFactory.Instance,
-            new ToolChainBuilder(
-                NullLogger<ToolChainBuilder>.Instance, new ServiceCollection().BuildServiceProvider()),
-            new SkillPrerequisiteResolver(),
-            new UnsandboxedSkillFileReader());
-
-        var context = await factory.MapToAgentContextAsync([MakeSkill()], new SkillAgentOptions());
+        var context = await CreateFactory(recall: false, governance: false, budgetTracker: false)
+            .MapToAgentContextAsync([MakeSkill()], new SkillAgentOptions());
 
         RailTypes(context).Should().Equal([typeof(AgentSkillsProvider), typeof(ToolPermissionFilter)]);
     }
@@ -235,6 +249,15 @@ public sealed class AgentExecutionContextFactoryRailOrderTests : IDisposable
                 || ToolPermissionFilter.SkillDisclosureToolNames.Contains(name),
             "every tool the model is finally offered must be one the allowlist grants or one of the two "
             + "exempt skill-content tools; anything else was contributed after the filter had already run");
+
+        // The other half of the same property: a filter that stripped everything would satisfy the
+        // assertion above. The granted tool and the two exempt ones must all still be there.
+        ToolNames(finished).Should().Contain(
+            [AllowedTool,
+             AgentSkillsProvider.LoadSkillToolName,
+             AgentSkillsProvider.ReadSkillResourceToolName],
+            "the filter denies; it must not also deny what the skill granted, or progressive disclosure "
+            + "and the agent's own capability both die silently");
     }
 
     private static IEnumerable<string> ToolNames(AIContext context) =>

--- a/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentExecutionContextFactoryRailOrderTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentExecutionContextFactoryRailOrderTests.cs
@@ -141,35 +141,13 @@ public sealed class AgentExecutionContextFactoryRailOrderTests : IDisposable
                 : null);
     }
 
-    private sealed class StubTool(string name) : ITool
-    {
-        public string Name { get; } = name;
-        public string Description => "stub";
-        public IReadOnlyList<string> SupportedOperations { get; } = ["run"];
-
-        public Task<ToolResult> ExecuteAsync(
-            string operation,
-            IReadOnlyDictionary<string, object?> parameters,
-            CancellationToken cancellationToken = default) => Task.FromResult(ToolResult.Ok("r"));
-    }
-
-    private sealed class PassThroughToolConverter : IToolConverter
-    {
-        public int Priority => 100;
-
-        public bool CanConvert(ITool tool) => true;
-
-        public AITool? Convert(ITool tool, IReadOnlyList<string>? allowedOperations = null) =>
-            AIFunctionFactory.Create(() => "r", tool.Name);
-    }
-
     private static IReadOnlyList<Type> RailTypes(Domain.AI.Agents.AgentExecutionContext context) =>
         [.. context.AIContextProviders!.Select(p => p.GetType())];
 
     // ── The whole rail, in order ──────────────────────────────────────────────
 
     [Fact]
-    public async Task Rail_WithEveryOptionalProviderEnabled_IsExactlyThisSequence()
+    public async Task MapToAgentContext_EveryOptionalProviderEnabled_RailIsExactlyThisSequence()
     {
         var context = await CreateFactory().MapToAgentContextAsync([MakeSkill()], new SkillAgentOptions());
 
@@ -194,7 +172,7 @@ public sealed class AgentExecutionContextFactoryRailOrderTests : IDisposable
     [InlineData(true, false)]
     [InlineData(false, true)]
     [InlineData(false, false)]
-    public async Task Rail_TheBudgetMeasurerIsLast_WhicheverOptionalProvidersAreOn(bool recall, bool governance)
+    public async Task MapToAgentContext_AnyOptionalProviderCombination_BudgetMeasurerIsLast(bool recall, bool governance)
     {
         var context = await CreateFactory(recall, governance)
             .MapToAgentContextAsync([MakeSkill()], new SkillAgentOptions());
@@ -212,20 +190,34 @@ public sealed class AgentExecutionContextFactoryRailOrderTests : IDisposable
     }
 
     [Fact]
-    public async Task Rail_WithNoBudgetTrackerWired_IsTheSameRailWithoutAMeasurer()
+    public async Task MapToAgentContext_NoBudgetTrackerWired_RailIsTheFullyLoadedRailMinusTheMeasurer()
     {
         // A host that does not track context must get exactly the rail it had before the measurer existed —
         // not a rail with an inert provider on the end of it.
-        var context = await CreateFactory(recall: false, governance: false, budgetTracker: false)
+        //
+        // Run fully loaded on purpose. Asserting this against a two-provider rail would pass for any
+        // factory that merely omits the measurer, including one that also dropped or reordered the
+        // providers that only appear when the optional features are on — the case with something to break.
+        var tracked = await CreateFactory(recall: true, governance: true, budgetTracker: true)
+            .MapToAgentContextAsync([MakeSkill()], new SkillAgentOptions());
+        var untracked = await CreateFactory(recall: true, governance: true, budgetTracker: false)
             .MapToAgentContextAsync([MakeSkill()], new SkillAgentOptions());
 
-        RailTypes(context).Should().Equal([typeof(AgentSkillsProvider), typeof(ToolPermissionFilter)]);
+        // Control: "minus the measurer" is only meaningful if the tracked rail ends with one. Without
+        // this, a factory that appended nothing at all would satisfy the assertion below.
+        RailTypes(tracked)[^1].Should().Be(typeof(PerTurnBudgetContextProvider));
+
+        // Derived from the tracked rail rather than restated, so the sequence has one home. Restating it
+        // would let the two drift apart and still pass, which is the thing this test exists to notice.
+        RailTypes(untracked).Should().Equal(
+            RailTypes(tracked).SkipLast(1),
+            "an untracked host gets the rail unchanged, not a rail that quietly differs in some other way");
     }
 
     // ── Rule 1: the filter's decision survives to the end of the rail ─────────
 
     [Fact]
-    public async Task Rail_NoProviderBelowTheFilterReintroducesADeniedTool()
+    public async Task MapToAgentContext_FullyLoadedRail_NoProviderBelowTheFilterReintroducesADeniedTool()
     {
         var context = await CreateFactory().MapToAgentContextAsync([MakeSkill()], new SkillAgentOptions());
 
@@ -235,12 +227,12 @@ public sealed class AgentExecutionContextFactoryRailOrderTests : IDisposable
         // nothing at all.
         // Driven by identity, not by index: the control must keep holding under exactly the misordering
         // this test exists to catch, or a broken rail would fail here and never reach the assertion below.
-        var contributed = await DriveAsync(context.AIContextProviders!.OfType<AgentSkillsProvider>(), context);
+        var contributed = await AIContextRailDriver.DriveAsync(context.AIContextProviders!.OfType<AgentSkillsProvider>(), context);
         ToolNames(contributed).Should().Contain(
             AgentSkillsProvider.RunSkillScriptToolName,
             "control: the rail must actually offer a tool the allowlist denies, or this test proves nothing");
 
-        var finished = await DriveAsync(context.AIContextProviders!, context);
+        var finished = await AIContextRailDriver.DriveAsync(context.AIContextProviders!, context);
 
         // The security property, read at the end of the rail rather than at the filter. A tool-contributing
         // provider inserted below the filter would surface here and nowhere else.
@@ -262,28 +254,4 @@ public sealed class AgentExecutionContextFactoryRailOrderTests : IDisposable
 
     private static IEnumerable<string> ToolNames(AIContext context) =>
         context.Tools?.Select(t => t.Name) ?? [];
-
-    /// <summary>
-    /// Drives <paramref name="providers"/> the way the runtime does — seeded with the agent's own
-    /// instructions and tools, then feeding each provider the previous one's output.
-    /// </summary>
-    private static async Task<AIContext> DriveAsync(
-        IEnumerable<AIContextProvider> providers,
-        Domain.AI.Agents.AgentExecutionContext context)
-    {
-        var current = new AIContext
-        {
-            Instructions = context.Instruction,
-            Messages = new List<ChatMessage> { new(ChatRole.User, "go") },
-            Tools = context.Tools is null ? [] : [.. context.Tools]
-        };
-
-        foreach (var provider in providers)
-        {
-            current = await provider.InvokingAsync(new AIContextProvider.InvokingContext(
-                new Mock<AIAgent>().Object, new Mock<AgentSession>().Object, current));
-        }
-
-        return current;
-    }
 }

--- a/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentExecutionContextFactoryRailOrderTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentExecutionContextFactoryRailOrderTests.cs
@@ -1,0 +1,266 @@
+using Application.AI.Common.Factories;
+using Application.AI.Common.Interfaces;
+using Application.AI.Common.Interfaces.Context;
+using Application.AI.Common.Services.Agent;
+using Application.AI.Common.Services.Context;
+using Application.AI.Common.Services.Skills;
+using Application.AI.Common.Services.Tools;
+using Application.AI.Common.Tests.Helpers;
+using Domain.AI.Skills;
+using Domain.Common.Config;
+using Domain.Common.Config.AI;
+using FluentAssertions;
+using Microsoft.Agents.AI;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Application.AI.Common.Tests.Factories;
+
+/// <summary>
+/// Pins the <em>position</em> of every provider on the agent's <see cref="AIContextProvider"/> rail, and the
+/// two behaviours that positions decide.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The runtime feeds each provider the accumulated output of the ones before it, so where a provider sits
+/// is what it can see and what it can change. Two rules follow, and both are load-bearing:
+/// </para>
+/// <list type="number">
+///   <item>
+///     Every tool-contributing provider sits <em>above</em> <see cref="ToolPermissionFilter"/>. One added
+///     below it contributes tools the filter has already finished filtering — an agent calling a tool its
+///     allowlist was written to deny, with nothing thrown and nothing logged.
+///   </item>
+///   <item>
+///     <see cref="PerTurnBudgetContextProvider"/> is <em>last</em>. Only the final position sees everything
+///     the rest contributed; anywhere else it silently under-charges by whatever follows it.
+///   </item>
+/// </list>
+/// <para>
+/// Neither rule was asserted anywhere before this class. Every other test that reads the rail does so with
+/// <c>OfType&lt;T&gt;().Single()</c>, which finds its provider at any index and therefore passes whatever
+/// the order happens to be — including an order that has broken rule 1. This is the assembly whose
+/// <c>CLAUDE.md</c> records the additive-hook provider defect shipping <em>four separate times</em>, each
+/// time with green unit tests, so a rule held up only by a code comment is a rule waiting to be broken.
+/// </para>
+/// <para>
+/// The exact-sequence assertion is deliberate rather than lazy: a test that checked only relative pairs
+/// would let a new provider be slotted in anywhere without comment. Failing on any insertion forces whoever
+/// adds one to state where it goes and why, which is the decision that actually needs review.
+/// </para>
+/// </remarks>
+public sealed class AgentExecutionContextFactoryRailOrderTests : IDisposable
+{
+    private const string SkillName = "rail-skill";
+    private const string AllowedTool = "file_system";
+
+    /// <summary>The agent name the factory derives from <see cref="SkillName"/>.</summary>
+    private const string AgentName = "RailSkillAgent";
+
+    private readonly SkillDirectoryFixture _skills = new("railorder");
+    private readonly string _skillDir;
+    private readonly string _skillsRoot;
+
+    public AgentExecutionContextFactoryRailOrderTests()
+    {
+        _skillDir = _skills.CreateSkill(
+            Path.Combine("skills", SkillName),
+            "# Rail Skill\n\nRAIL_BODY",
+            "A skill used to pin context-provider rail order.");
+        _skillsRoot = Path.GetDirectoryName(_skillDir)!;
+    }
+
+    public void Dispose() => _skills.Dispose();
+
+    /// <summary>
+    /// A skill in the shape that wires the most providers: a real directory so it is disclosable, and an
+    /// <c>allowed-tools</c> declaration so a real <see cref="ToolPermissionFilter"/> appears.
+    /// </summary>
+    private SkillDefinition MakeSkill() => new()
+    {
+        Id = SkillName,
+        Name = SkillName,
+        Description = "A skill used to pin context-provider rail order.",
+        Instructions = "# Rail Skill\n\nRAIL_BODY",
+        BaseDirectory = _skillDir,
+        AllowedTools = [AllowedTool]
+    };
+
+    /// <summary>
+    /// Builds the factory with the optional providers switched on or off individually, so the tests can
+    /// assert what holds across configurations rather than only in the fully-loaded one.
+    /// </summary>
+    private AgentExecutionContextFactory CreateFactory(
+        bool recall = true,
+        bool governance = true,
+        IContextBudgetTracker? budgetTracker = null)
+    {
+        var appConfig = new AppConfig
+        {
+            AI = new AIConfig
+            {
+                AgentFramework = new AgentFrameworkConfig { DefaultDeployment = "gpt-4o" },
+                Skills = new SkillsConfig { BasePath = _skillsRoot },
+                KnowledgeBridge = new KnowledgeBridgeConfig { Enabled = recall },
+                LearningsRecall = new LearningsRecallConfig { Enabled = recall },
+                Governance = new GovernanceConfig { EnforceToolInvocation = governance }
+            }
+        };
+
+        var services = new ServiceCollection();
+
+        // The two recall providers are wired only when the factory can reach an ambient request scope —
+        // they resolve their tenant-aware collaborator per invocation, so an empty scope is enough here.
+        services.AddSingleton(Mock.Of<IAmbientRequestScope>());
+        var sp = services.BuildServiceProvider();
+
+        return new AgentExecutionContextFactory(
+            NullLogger<AgentExecutionContextFactory>.Instance,
+            Mock.Of<IOptionsMonitor<AppConfig>>(m => m.CurrentValue == appConfig),
+            sp,
+            NullLoggerFactory.Instance,
+            new ToolChainBuilder(NullLogger<ToolChainBuilder>.Instance, sp),
+            new SkillPrerequisiteResolver(),
+            new UnsandboxedSkillFileReader(),
+            budgetTracker ?? CreateBudgetTracker());
+    }
+
+    private static ContextBudgetTracker CreateBudgetTracker() => new(
+        Mock.Of<IOptionsMonitor<AppConfig>>(m => m.CurrentValue == new AppConfig()),
+        NullLogger<ContextBudgetTracker>.Instance);
+
+    private static IReadOnlyList<Type> RailTypes(Domain.AI.Agents.AgentExecutionContext context) =>
+        [.. context.AIContextProviders!.Select(p => p.GetType())];
+
+    // ── The whole rail, in order ──────────────────────────────────────────────
+
+    [Fact]
+    public async Task Rail_WithEveryOptionalProviderEnabled_IsExactlyThisSequence()
+    {
+        var context = await CreateFactory().MapToAgentContextAsync([MakeSkill()], new SkillAgentOptions());
+
+        RailTypes(context).Should().Equal(
+            [
+                typeof(AgentSkillsProvider),              // contributes the framework's skill tools
+                typeof(ToolPermissionFilter),             // everything above it is filtered; nothing below is
+                typeof(KnowledgeMemoryContextProvider),   // instructions only
+                typeof(LearningsRecallContextProvider),   // instructions only
+                typeof(GoverningToolContextProvider),     // wraps the finished, filtered tool set
+                typeof(PerTurnBudgetContextProvider)      // measures everything above it, so it is last
+            ],
+            "position on this rail is behaviour: each provider sees only what the ones above it produced, "
+            + "so an insertion in the wrong place changes which tools the agent can call or what its budget "
+            + "records. If this list needs to change, the change is the thing to review — not the test");
+    }
+
+    // ── Rule 2: the measurer is last, in every configuration ──────────────────
+
+    [Theory]
+    [InlineData(true, true)]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    [InlineData(false, false)]
+    public async Task Rail_TheBudgetMeasurerIsLast_WhicheverOptionalProvidersAreOn(bool recall, bool governance)
+    {
+        var context = await CreateFactory(recall, governance)
+            .MapToAgentContextAsync([MakeSkill()], new SkillAgentOptions());
+
+        var rail = context.AIContextProviders!;
+
+        // Control: the configurations really do differ, so this is four cases and not the same one asserted
+        // four times. Without it, a factory that ignored both flags would satisfy every row.
+        rail.Count.Should().Be(3 + (recall ? 2 : 0) + (governance ? 1 : 0));
+
+        rail[^1].Should().BeOfType<PerTurnBudgetContextProvider>(
+            "the measurer charges the difference between what it is handed and the baseline it was built "
+            + "with, so anywhere but last it silently omits whatever follows it — the under-reporting it "
+            + "exists to remove, back again and still looking like a working feature");
+    }
+
+    [Fact]
+    public async Task Rail_WithNoBudgetTrackerWired_IsTheSameRailWithoutAMeasurer()
+    {
+        // A host that does not track context must get exactly the rail it had before the measurer existed —
+        // not a rail with an inert provider on the end of it.
+        var factory = new AgentExecutionContextFactory(
+            NullLogger<AgentExecutionContextFactory>.Instance,
+            Mock.Of<IOptionsMonitor<AppConfig>>(m => m.CurrentValue == new AppConfig
+            {
+                AI = new AIConfig
+                {
+                    AgentFramework = new AgentFrameworkConfig { DefaultDeployment = "gpt-4o" },
+                    Skills = new SkillsConfig { BasePath = _skillsRoot }
+                }
+            }),
+            new ServiceCollection().BuildServiceProvider(),
+            NullLoggerFactory.Instance,
+            new ToolChainBuilder(
+                NullLogger<ToolChainBuilder>.Instance, new ServiceCollection().BuildServiceProvider()),
+            new SkillPrerequisiteResolver(),
+            new UnsandboxedSkillFileReader());
+
+        var context = await factory.MapToAgentContextAsync([MakeSkill()], new SkillAgentOptions());
+
+        RailTypes(context).Should().Equal([typeof(AgentSkillsProvider), typeof(ToolPermissionFilter)]);
+    }
+
+    // ── Rule 1: the filter's decision survives to the end of the rail ─────────
+
+    [Fact]
+    public async Task Rail_NoProviderBelowTheFilterReintroducesADeniedTool()
+    {
+        var context = await CreateFactory().MapToAgentContextAsync([MakeSkill()], new SkillAgentOptions());
+
+        // Control. run_skill_script is contributed by the skills provider and is deliberately NOT exempt
+        // from the allowlist (unlike load_skill and read_skill_resource), so the filter must strip it. If it
+        // never appeared above the filter, the assertion below would pass against a rail that filters
+        // nothing at all.
+        // Driven by identity, not by index: the control must keep holding under exactly the misordering
+        // this test exists to catch, or a broken rail would fail here and never reach the assertion below.
+        var contributed = await DriveAsync(context.AIContextProviders!.OfType<AgentSkillsProvider>(), context);
+        ToolNames(contributed).Should().Contain(
+            AgentSkillsProvider.RunSkillScriptToolName,
+            "control: the rail must actually offer a tool the allowlist denies, or this test proves nothing");
+
+        var finished = await DriveAsync(context.AIContextProviders!, context);
+
+        // The security property, read at the end of the rail rather than at the filter. A tool-contributing
+        // provider inserted below the filter would surface here and nowhere else.
+        ToolNames(finished).Should().OnlyContain(
+            name => name == AllowedTool
+                || ToolPermissionFilter.SkillDisclosureToolNames.Contains(name),
+            "every tool the model is finally offered must be one the allowlist grants or one of the two "
+            + "exempt skill-content tools; anything else was contributed after the filter had already run");
+    }
+
+    private static IEnumerable<string> ToolNames(AIContext context) =>
+        context.Tools?.Select(t => t.Name) ?? [];
+
+    /// <summary>
+    /// Drives <paramref name="providers"/> the way the runtime does — seeded with the agent's own
+    /// instructions and tools, then feeding each provider the previous one's output.
+    /// </summary>
+    private static async Task<AIContext> DriveAsync(
+        IEnumerable<AIContextProvider> providers,
+        Domain.AI.Agents.AgentExecutionContext context)
+    {
+        var current = new AIContext
+        {
+            Instructions = context.Instruction,
+            Messages = new List<ChatMessage> { new(ChatRole.User, "go") },
+            Tools = context.Tools is null ? [] : [.. context.Tools]
+        };
+
+        foreach (var provider in providers)
+        {
+            current = await provider.InvokingAsync(new AIContextProvider.InvokingContext(
+                new Mock<AIAgent>().Object, new Mock<AgentSession>().Object, current));
+        }
+
+        return current;
+    }
+}

--- a/src/Content/Tests/Application.AI.Common.Tests/Helpers/AIContextRailDriver.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Helpers/AIContextRailDriver.cs
@@ -1,0 +1,64 @@
+using Domain.AI.Agents;
+using Microsoft.Agents.AI;
+using Microsoft.Extensions.AI;
+using Moq;
+
+namespace Application.AI.Common.Tests;
+
+/// <summary>
+/// Drives an agent's <see cref="AIContextProvider"/> rail the way the runtime does — seeded with the
+/// agent's own instructions and tools, then feeding each provider the previous one's output.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>This is the only correct way to test a provider in this solution, and it is shared so that the
+/// rule has one implementation rather than one per test class.</b> The project's <c>CLAUDE.md</c>
+/// records the additive-hook defect shipping <em>four separate times</em>, every time with green unit
+/// tests, because those tests called the protected <c>ProvideAIContextAsync</c> hook directly instead
+/// of the public <see cref="AIContextProvider.InvokingAsync"/>. Calling the hook skips the base merge,
+/// so a provider that silently drops or double-publishes items still looks correct.
+/// </para>
+/// <para>
+/// Driving the rail rather than one provider also exercises the ordering behaviour: each provider sees
+/// only what the ones ahead of it produced, so anything positional — a filter's removals surviving to
+/// the end, a measurer seeing everything above it — is invisible to a single-provider invocation.
+/// </para>
+/// </remarks>
+internal static class AIContextRailDriver
+{
+    /// <summary>
+    /// Drives the whole rail the factory built for <paramref name="context"/>.
+    /// </summary>
+    internal static Task<AIContext> DriveAsync(AgentExecutionContext context) =>
+        DriveAsync(context.AIContextProviders!, context);
+
+    /// <summary>
+    /// Drives <paramref name="providers"/> against the seed <paramref name="context"/> supplies, so a
+    /// caller can drive a prefix of the rail — for example, to prove a control holds at the point where
+    /// a tool is contributed, before a later provider filters it out.
+    /// </summary>
+    internal static async Task<AIContext> DriveAsync(
+        IEnumerable<AIContextProvider> providers,
+        AgentExecutionContext context)
+    {
+        // Hoisted: the runtime hands every provider the same agent and session, and neither stand-in
+        // carries state, so rebuilding the proxies per provider would only cost time.
+        var agent = new Mock<AIAgent>().Object;
+        var session = new Mock<AgentSession>().Object;
+
+        var current = new AIContext
+        {
+            Instructions = context.Instruction,
+            Messages = new List<ChatMessage> { new(ChatRole.User, "go") },
+            Tools = context.Tools is null ? [] : [.. context.Tools]
+        };
+
+        foreach (var provider in providers)
+        {
+            current = await provider.InvokingAsync(
+                new AIContextProvider.InvokingContext(agent, session, current));
+        }
+
+        return current;
+    }
+}

--- a/src/Content/Tests/Application.AI.Common.Tests/Helpers/StubTool.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Helpers/StubTool.cs
@@ -1,0 +1,53 @@
+using Application.AI.Common.Interfaces.Tools;
+using Domain.AI.Models;
+using Microsoft.Extensions.AI;
+
+namespace Application.AI.Common.Tests;
+
+/// <summary>
+/// A minimal <see cref="ITool"/> that exists only to be registered under a name, for tests whose
+/// subject is which tools reach the model rather than what any tool does.
+/// </summary>
+/// <remarks>
+/// Shared rather than re-declared per test class because it implements a production interface: when
+/// <see cref="ITool"/> gains a member, one copy fails to compile instead of several.
+/// </remarks>
+internal sealed class StubTool(string name) : ITool
+{
+    /// <inheritdoc />
+    public string Name { get; } = name;
+
+    /// <inheritdoc />
+    public string Description => "stub";
+
+    /// <inheritdoc />
+    public IReadOnlyList<string> SupportedOperations { get; } = ["run"];
+
+    /// <inheritdoc />
+    public Task<ToolResult> ExecuteAsync(
+        string operation,
+        IReadOnlyDictionary<string, object?> parameters,
+        CancellationToken cancellationToken = default) => Task.FromResult(ToolResult.Ok("r"));
+}
+
+/// <summary>
+/// An <see cref="IToolConverter"/> that converts every tool, so a test sees the tool set the code under
+/// test assembled rather than a set narrowed by conversion.
+/// </summary>
+/// <remarks>
+/// <b>This double proves nothing about conversion.</b> A test asserting that a particular tool is
+/// refused conversion must not use it — it accepts everything, so the assertion would pass while
+/// checking nothing.
+/// </remarks>
+internal sealed class PassThroughToolConverter : IToolConverter
+{
+    /// <inheritdoc />
+    public int Priority => 100;
+
+    /// <inheritdoc />
+    public bool CanConvert(ITool tool) => true;
+
+    /// <inheritdoc />
+    public AITool? Convert(ITool tool, IReadOnlyList<string>? allowedOperations = null) =>
+        AIFunctionFactory.Create(() => "r", tool.Name);
+}

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/ToolChainBuilderReservedCapabilityTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/ToolChainBuilderReservedCapabilityTests.cs
@@ -155,25 +155,4 @@ public sealed class ToolChainBuilderReservedCapabilityTests
             "the by-name path must apply the reserved filter, not bypass it");
     }
 
-    private sealed class StubTool(string name) : ITool
-    {
-        public string Name { get; } = name;
-        public string Description => "stub";
-        public IReadOnlyList<string> SupportedOperations { get; } = ["run"];
-
-        public Task<ToolResult> ExecuteAsync(
-            string operation,
-            IReadOnlyDictionary<string, object?> parameters,
-            CancellationToken cancellationToken = default) => Task.FromResult(ToolResult.Ok("r"));
-    }
-
-    private sealed class PassThroughToolConverter : IToolConverter
-    {
-        public int Priority => 100;
-
-        public bool CanConvert(ITool tool) => true;
-
-        public AITool? Convert(ITool tool, IReadOnlyList<string>? allowedOperations = null) =>
-            AIFunctionFactory.Create(() => "r", tool.Name);
-    }
 }


### PR DESCRIPTION
Closes #271.

## The problem

Where a provider sits on the agent's context rail is behaviour, not style. The runtime feeds each provider the accumulated output of the ones before it, so a provider's position decides what it can see and what it can change. Two rules follow:

1. **Every tool-contributing provider sits above `ToolPermissionFilter`.** One added below it contributes tools the filter has already finished filtering — an agent calling a tool its allowlist was written to deny, with nothing thrown and nothing logged.
2. **`PerTurnBudgetContextProvider` is last.** Only the final position sees everything the rest contributed; anywhere else it under-charges the turn by whatever follows it, and under-charging is the bad direction — the budget meant to bound a conversation stops bounding it.

Neither rule was asserted anywhere. Every existing test reads the rail with `OfType<T>().Single()`, which finds its provider at any index and therefore passes whatever the order happens to be, including an order that has already broken rule 1. This is the assembly whose `CLAUDE.md` records the additive-hook provider defect shipping **four separate times**, each time with green unit tests.

## What this changes

**Tests** — `AgentExecutionContextFactoryRailOrderTests`, seven cases:

- The exact emitted sequence, fully loaded and with no budget tracker.
- Rule 2 as a property across all four combinations of the two optional features, with a count control proving the four rows really are different configurations.
- Rule 1 read behaviourally at the *end* of the rail rather than at the filter: a tool the allowlist denies must be gone, and the granted tool plus the two exempt disclosure tools must survive. Both sides matter — a filter that stripped everything would satisfy the deny half alone.

**Production** — `AppendPerTurnBudgetProvider` is now called from the tail of `BuildMergedAIContextProviders` instead of by the caller, so "the measurer is last" is a property of one method rather than of a call sequence in another file.

## What this does not do — read before closing #271

**The production move has no test of its own, and cannot have one.** Revert it — put the append back at the call site — and every test here still passes, because the emitted rail is identical either way. It removes a way for a future caller to get this wrong; it does not change observable behaviour, so there is nothing to assert. Called out rather than dressed up as verified.

**Lastness is still breakable from outside.** The rail leaves the factory as a mutable `IList<AIContextProvider>` on a settable property, so any consumer that appends displaces the measurer. Nothing appends today and no test would catch it if something started. Tracked in **#277**, which also names the cheaper partial fix (making the property read-only and init-only) that this PR did not take.

## Verification

- Mutation-tested, not assumed: moving the measurer above the governance provider fails 3 of the 7 tests, and correctly leaves the two governance-off rows green — those are the configurations where nothing follows the measurer, so there is genuinely nothing to catch. The tests discriminate rather than over-fire.
- 1704/1704 in `Application.AI.Common.Tests`; full solution build clean (6 pre-existing warnings, all in untouched files).
- Review findings applied in `c1fe1a62`: test naming brought onto the repo convention, the rail driver and tool doubles de-duplicated into `Helpers/`, and the no-tracker test rewritten after review found it could not fail for anything the loaded rail got wrong. Deferred items and the reasoning for each are recorded on #274.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
