### PR TITLE
fix: residual guard gaps from #251

### DIFF
--- a/src/Content/Infrastructure/Infrastructure.AI/Planner/PlanValidator.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Planner/PlanValidator.cs
@@ -238,7 +238,13 @@ public sealed class PlanValidator : IPlanValidator
         where T : StepConfiguration
     {
         var validator = _serviceProvider.GetService<IValidator<T>>();
-        if (validator is null) return [];
+        if (validator is null)
+        {
+            _logger.LogWarning(
+                "No validator registered for StepConfiguration type '{ConfigType}'; step configurations of this type will pass validation without checking",
+                typeof(T).Name);
+            return [];
+        }
 
         var result = await validator.ValidateAsync(config, ct);
         return result.Errors.Select(e => e.ErrorMessage).ToList();

--- a/src/Content/Tests/Presentation.Common.Tests/Composition/ValidateOnBuildSweepTests.cs
+++ b/src/Content/Tests/Presentation.Common.Tests/Composition/ValidateOnBuildSweepTests.cs
@@ -27,19 +27,51 @@ namespace Presentation.Common.Tests.Composition;
 /// If a future change adds a handler whose dependency has no default, this test fails with
 /// the exact unresolved service — not a customer's production stack trace.
 /// </para>
+/// <para>
+/// #251's original ~106 failures came nearly all from conditionally-registered handlers
+/// whose dependencies are only present under some configurations (e.g., handlers gated by
+/// Governance.Enabled). Testing only the all-features-off baseline is blind to that class.
+/// This test is parameterized to cover both the baseline and representative features-on
+/// configurations, closing the gap that #251's first fix left.
+/// </para>
 /// </remarks>
 public sealed class ValidateOnBuildSweepTests
 {
+    /// <summary>
+    /// All-features-off baseline: the default, all-features-off registration set every host
+    /// shares before its host-specific overrides. This is the baseline that must always
+    /// be constructible.
+    /// </summary>
     [Fact]
-    public void ProductionCompositionRoot_BuildsWithValidateOnBuild()
+    public void ProductionCompositionRoot_AllFeaturesOff_BuildsWithValidateOnBuild()
     {
-        // Empty configuration = the default, all-features-off registration set every host
-        // shares before its host-specific overrides. This is the baseline that must always
-        // be constructible.
         var configuration = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>())
             .Build();
 
+        BuildAndValidate(configuration);
+    }
+
+    /// <summary>
+    /// Governance-enabled configuration: handlers that depend on governance services are only
+    /// registered when <c>AppConfig:AI:Governance:Enabled = true</c>. Validates that the graph
+    /// is constructible when this feature is on.
+    /// </summary>
+    [Fact]
+    public void ProductionCompositionRoot_GovernanceEnabled_BuildsWithValidateOnBuild()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                { "AppConfig:AI:Governance:Enabled", "true" }
+            })
+            .Build();
+
+        BuildAndValidate(configuration);
+    }
+
+    private static void BuildAndValidate(IConfiguration configuration)
+    {
         var services = new ServiceCollection();
         services.AddLogging();
         services.RegisterConfigSections(configuration);


### PR DESCRIPTION
## Summary

Issue #272 records two audit gaps from issue #251's fixes. Both gaps are structural — #251 was already fixed weeks before filing; these are guard improvements that prevent future regressions.

### 1. ValidateOnBuild sweep test blind to feature-gated configurations

The sweep test runs composition-root validation with **empty configuration** (all-features-off), but #251's original failures came from **conditionally-registered handlers** (e.g., handlers that depend on governance services, only registered when `Governance.Enabled = true`). Testing only the all-features-off baseline is structurally blind to that class of handler.

**Fix:** Parameterize the sweep across representative configurations:
- Baseline (all-features-off)
- Governance-enabled

Each configuration validates the full composition root, so the guard covers both the baseline every host shares and the shapes that feature-specific hosts add.

### 2. Silent validator lookup failure in PlanValidator

`PlanValidator.ValidateConfig<T>` silently returns an empty error list when it cannot find a validator for a config type, with no warning. Unlike the sibling `LogUnknownConfigType` (which warns for unknown config types in a pattern match), this path says nothing. If the validator assembly-scan ever stops finding validators, the original bug #251 returns with no signal — only the "Real DI Wiring" test in `PlanValidatorTests` catches it.

**Fix:** Log a warning when a validator is expected but not registered, mirroring the unknown-type case. The warning tells an operator that step configurations of this type will pass validation without checking, making the gap explicit.

## Test Plan

✅ Both sweep configurations pass (all-off and governance-enabled)  
✅ All 27 PlanValidator tests pass  
✅ Build clean (no new warnings)  
✅ Awaiting CI gates on main

🧪 Generated with [Claude Code](https://claude.com/claude-code)