### PR TITLE
fix: bound a durable conversation by default (#256)

### DIFF
--- a/documentation/onboarding/02-configuration.html
+++ b/documentation/onboarding/02-configuration.html
@@ -452,6 +452,9 @@
                                     conversation meets. Set it to <code>0</code> to disable, but note that
                                     <strong>nothing else</strong> bounds a durable conversation's total length: the
                                     per-run <code>maxTurns</code> and message caps deliberately do not.
+                                    <strong>Upgrading:</strong> this previously shipped disabled, so a deployment that
+                                    pins <code>0</code> in its own <code>appsettings.json</code> keeps that value and
+                                    stays unbounded — remove the pin to pick up the bound.
                                 </td>
                             </tr>
                         </tbody>

--- a/documentation/onboarding/02-configuration.html
+++ b/documentation/onboarding/02-configuration.html
@@ -441,13 +441,17 @@
                             </tr>
                             <tr>
                                 <td><code>ConversationTokenBudget</code></td>
-                                <td><code>—</code></td>
+                                <td><code>1000000</code></td>
                                 <td>
                                     Cross-turn ceiling for the whole conversation, enforced by the
                                     <code>IConversationBudgetTracker</code> singleton — distinct from the per-turn
                                     <code>DefaultTokenBudget</code>. When exhausted, the loop breaks gracefully. There
                                     is <strong>no</strong> <code>MaxTurnsPerConversation</code> property; budgets are
-                                    token-based, not turn-count-based.
+                                    token-based, not turn-count-based. The default is roughly 50–100 exchanges once
+                                    each turn's resent history is counted — a runaway guard, not a limit an ordinary
+                                    conversation meets. Set it to <code>0</code> to disable, but note that
+                                    <strong>nothing else</strong> bounds a durable conversation's total length: the
+                                    per-run <code>maxTurns</code> and message caps deliberately do not.
                                 </td>
                             </tr>
                         </tbody>

--- a/documentation/onboarding/05-skills.html
+++ b/documentation/onboarding/05-skills.html
@@ -366,8 +366,8 @@ skills:
                                 <code>AppConfig:AI:AgentFramework:DefaultTokenBudget</code> (default
                                 <strong>200,000</strong> tokens). A separate <code>IConversationBudgetTracker</code>
                                 (a singleton) enforces a <em>cross-turn</em> ceiling for the whole conversation
-                                (<code>ConversationTokenBudget</code>, default <strong>1,000,000</strong> tokens) and
-                                gracefully breaks the loop when a long session runs out of budget. If you're seeing skills "disappear" mid-conversation, the
+                                (<code>ConversationTokenBudget</code>, default <strong>1,000,000</strong>
+                                tokens) and gracefully breaks the loop when a long session runs out. If you're seeing skills "disappear" mid-conversation, the
                                 per-turn tracker is preserving budget; if a run stops cleanly after many turns, that's
                                 the conversation tracker. (Note: there is no <code>MaxTurnsPerConversation</code>
                                 property — budgets are token-based, not turn-count-based.)

--- a/documentation/onboarding/05-skills.html
+++ b/documentation/onboarding/05-skills.html
@@ -366,8 +366,8 @@ skills:
                                 <code>AppConfig:AI:AgentFramework:DefaultTokenBudget</code> (default
                                 <strong>200,000</strong> tokens). A separate <code>IConversationBudgetTracker</code>
                                 (a singleton) enforces a <em>cross-turn</em> ceiling for the whole conversation
-                                (<code>ConversationTokenBudget</code>) and can gracefully break the loop when a long
-                                session runs out of budget. If you're seeing skills "disappear" mid-conversation, the
+                                (<code>ConversationTokenBudget</code>, default <strong>1,000,000</strong> tokens) and
+                                gracefully breaks the loop when a long session runs out of budget. If you're seeing skills "disappear" mid-conversation, the
                                 per-turn tracker is preserving budget; if a run stops cleanly after many turns, that's
                                 the conversation tracker. (Note: there is no <code>MaxTurnsPerConversation</code>
                                 property — budgets are token-based, not turn-count-based.)

--- a/src/Content/Application/Application.AI.Common/Services/AI/InProcessConversationBudgetTracker.cs
+++ b/src/Content/Application/Application.AI.Common/Services/AI/InProcessConversationBudgetTracker.cs
@@ -21,12 +21,12 @@ namespace Application.AI.Common.Services.AI;
 /// conversation store and turn lease.
 /// </para>
 /// <para>
-/// <strong>On by default, and switchable off.</strong> The ceiling comes from configuration, which since
-/// #256 defaults to a positive value — so a stock deployment <em>is</em> bounded and does pay the
-/// per-call dictionary work below. When the configured ceiling is ≤ 0 the tracker is instead inert:
+/// <strong>On by default, switchable off.</strong> The ceiling comes from configuration, which defaults
+/// to a positive value, so a stock deployment is bounded and does pay the per-call dictionary work
+/// below. When the configured ceiling is ≤ 0 the tracker is instead inert:
 /// <see cref="GetStatusAsync"/> returns <see cref="ConversationBudgetStatus.Disabled"/> and
 /// <see cref="RecordUsageAsync"/> stores nothing, so conversations run unbounded across turns and this
-/// type costs nothing. That is a deliberate opt-out, no longer the shipped default.
+/// type costs nothing. Reaching that state takes a deliberate <c>0</c> in configuration.
 /// </para>
 /// <para>
 /// <strong>Bounded memory.</strong> A long-lived interactive host can see many conversations and there is

--- a/src/Content/Application/Application.AI.Common/Services/AI/InProcessConversationBudgetTracker.cs
+++ b/src/Content/Application/Application.AI.Common/Services/AI/InProcessConversationBudgetTracker.cs
@@ -21,10 +21,12 @@ namespace Application.AI.Common.Services.AI;
 /// conversation store and turn lease.
 /// </para>
 /// <para>
-/// <strong>Opt-in.</strong> When the configured ceiling is ≤ 0 the tracker is inert:
+/// <strong>On by default, and switchable off.</strong> The ceiling comes from configuration, which since
+/// #256 defaults to a positive value — so a stock deployment <em>is</em> bounded and does pay the
+/// per-call dictionary work below. When the configured ceiling is ≤ 0 the tracker is instead inert:
 /// <see cref="GetStatusAsync"/> returns <see cref="ConversationBudgetStatus.Disabled"/> and
-/// <see cref="RecordUsageAsync"/> stores nothing, so the default deployment does no per-call dictionary
-/// work and conversations run unbounded across turns.
+/// <see cref="RecordUsageAsync"/> stores nothing, so conversations run unbounded across turns and this
+/// type costs nothing. That is a deliberate opt-out, no longer the shipped default.
 /// </para>
 /// <para>
 /// <strong>Bounded memory.</strong> A long-lived interactive host can see many conversations and there is

--- a/src/Content/Domain/Domain.Common/Config/AI/AgentFrameworkConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/AgentFrameworkConfig.cs
@@ -62,21 +62,24 @@ public class AgentFrameworkConfig
     /// <para>
     /// Defaults to 1,000,000 tokens — roughly 50–100 exchanges once each turn's resent history is counted,
     /// which is a long support or voice session rather than a limit an ordinary conversation reaches. It is
-    /// deliberately a runaway guard, not a business rule: a conversation that loops or is never closed stops
-    /// itself at a bounded cost instead of billing indefinitely.
+    /// a runaway guard, not a business rule: work that loops or is never closed stops at a bounded cost
+    /// instead of billing indefinitely.
     /// </para>
     /// <para>
-    /// <strong>This default is load-bearing, not decoration.</strong> A durable conversation outlives any
-    /// single run, so the per-run caps (<c>maxTurns</c> and the seed-message cap) deliberately do not bound
-    /// it — this budget is the only thing that does, and the Execution API contract says so. Shipping it
-    /// disabled left that documented promise unbacked on stock configuration, which is what #256 recorded.
+    /// <strong>The default has to be positive.</strong> A durable conversation outlives any single run, so
+    /// the per-run caps (<c>maxTurns</c> and the seed-message cap) deliberately do not bound it — this
+    /// budget is the only thing that does, and the Execution API contract says so. Set it to <c>0</c> to
+    /// disable, and that is what <em>unbounded</em> means: nothing else is watching.
     /// </para>
     /// <para>
-    /// Set to <c>0</c> to disable, restoring genuinely unbounded multi-turn conversations. Do that only
-    /// deliberately: with it off, nothing bounds a conversation's total length. Tune via
-    /// <c>AppConfig:AI:AgentFramework:ConversationTokenBudget</c>. Enforced by
-    /// <c>IConversationBudgetTracker</c> between turns, never mid-turn (intra-turn cost is bounded by
-    /// <see cref="DefaultTokenBudget"/>), so a turn already in flight always finishes.
+    /// <strong>Applies per budget key, of which there are two kinds.</strong> Conversational turns key by
+    /// conversation, and an exhausted conversation declines further turns gracefully with an explanatory
+    /// message — no model call, no error. Plan execution keys by plan run instead, and an exhausted run
+    /// fails the step as a policy denial. Same ceiling, two units and two failure shapes.
+    /// </para>
+    /// <para>
+    /// Enforced by <c>IConversationBudgetTracker</c> between turns, never mid-turn — a turn already in
+    /// flight always finishes, and its own cost is bounded by <see cref="DefaultTokenBudget"/>.
     /// </para>
     /// </remarks>
     public int ConversationTokenBudget { get; set; } = 1_000_000;

--- a/src/Content/Domain/Domain.Common/Config/AI/AgentFrameworkConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/AgentFrameworkConfig.cs
@@ -59,13 +59,27 @@ public class AgentFrameworkConfig
     /// rather than throwing. Distinct from <see cref="DefaultTokenBudget"/>, which caps a single turn.
     /// </summary>
     /// <remarks>
-    /// Defaults to <c>0</c> = <strong>disabled</strong> (opt-in): conversations are unbounded across
-    /// turns unless a positive ceiling is configured, preserving existing multi-turn behaviour. Tune via
+    /// <para>
+    /// Defaults to 1,000,000 tokens — roughly 50–100 exchanges once each turn's resent history is counted,
+    /// which is a long support or voice session rather than a limit an ordinary conversation reaches. It is
+    /// deliberately a runaway guard, not a business rule: a conversation that loops or is never closed stops
+    /// itself at a bounded cost instead of billing indefinitely.
+    /// </para>
+    /// <para>
+    /// <strong>This default is load-bearing, not decoration.</strong> A durable conversation outlives any
+    /// single run, so the per-run caps (<c>maxTurns</c> and the seed-message cap) deliberately do not bound
+    /// it — this budget is the only thing that does, and the Execution API contract says so. Shipping it
+    /// disabled left that documented promise unbacked on stock configuration, which is what #256 recorded.
+    /// </para>
+    /// <para>
+    /// Set to <c>0</c> to disable, restoring genuinely unbounded multi-turn conversations. Do that only
+    /// deliberately: with it off, nothing bounds a conversation's total length. Tune via
     /// <c>AppConfig:AI:AgentFramework:ConversationTokenBudget</c>. Enforced by
     /// <c>IConversationBudgetTracker</c> between turns, never mid-turn (intra-turn cost is bounded by
-    /// <see cref="DefaultTokenBudget"/>).
+    /// <see cref="DefaultTokenBudget"/>), so a turn already in flight always finishes.
+    /// </para>
     /// </remarks>
-    public int ConversationTokenBudget { get; set; }
+    public int ConversationTokenBudget { get; set; } = 1_000_000;
 
     /// <summary>
     /// Gets or sets whether to enable Anthropic prompt caching on the OpenAI-compatible client path

--- a/src/Content/Infrastructure/Infrastructure.AI/Conversations/SqliteConversationBudgetTracker.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Conversations/SqliteConversationBudgetTracker.cs
@@ -33,18 +33,18 @@ namespace Infrastructure.AI.Conversations;
 /// Hosts on different machines with different files each keep their own totals.
 /// </para>
 /// <para>
-/// <strong>On by default, and switchable off.</strong> The ceiling comes from configuration, which
-/// defaults to a positive value, so a stock deployment is bounded and does write rows here. When the
-/// configured ceiling is ≤ 0 the tracker is instead inert and touches no database at all — a deliberate
-/// opt-out rather than the shipped default.
+/// <strong>On by default, switchable off.</strong> The ceiling comes from configuration, which defaults
+/// to a positive value, so a stock deployment is bounded and does write rows here. When the configured
+/// ceiling is ≤ 0 the tracker is instead inert and touches no database at all. Reaching that state takes
+/// a deliberate <c>0</c> in configuration.
 /// </para>
 /// <para>
 /// <strong>Retention.</strong> Rows are removed only by <see cref="ReleaseAsync"/>, and the two
 /// interactive callers never call it because a turn ending is not a conversation ending. Abandoned keys
 /// therefore persist, and unlike the in-process sibling — which caps at 50,000 entries and evicts —
-/// this one has no bound. At roughly 60 bytes per row, 50,000 abandoned keys cost about 3 MB. Note that
-/// this table now grows on <em>every</em> deployment rather than only on ones that opted in, so the
-/// retention sweep tracked in issue #253 matters more than it did when the budget shipped disabled.
+/// this one has no bound. At roughly 60 bytes per row, 50,000 abandoned keys cost about 3 MB. Because
+/// the budget is on by default, this table grows on every deployment rather than only on ones that
+/// opted in; a retention sweep is tracked in issue #253.
 /// </para>
 /// </remarks>
 public sealed class SqliteConversationBudgetTracker : IConversationBudgetTracker

--- a/src/Content/Infrastructure/Infrastructure.AI/Conversations/SqliteConversationBudgetTracker.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Conversations/SqliteConversationBudgetTracker.cs
@@ -33,15 +33,18 @@ namespace Infrastructure.AI.Conversations;
 /// Hosts on different machines with different files each keep their own totals.
 /// </para>
 /// <para>
-/// <strong>Opt-in.</strong> When the configured ceiling is ≤ 0 the tracker is inert and touches no
-/// database at all, so the default deployment pays nothing for a feature it has not turned on.
+/// <strong>On by default, and switchable off.</strong> The ceiling comes from configuration, which
+/// defaults to a positive value, so a stock deployment is bounded and does write rows here. When the
+/// configured ceiling is ≤ 0 the tracker is instead inert and touches no database at all — a deliberate
+/// opt-out rather than the shipped default.
 /// </para>
 /// <para>
 /// <strong>Retention.</strong> Rows are removed only by <see cref="ReleaseAsync"/>, and the two
 /// interactive callers never call it because a turn ending is not a conversation ending. Abandoned keys
 /// therefore persist, and unlike the in-process sibling — which caps at 50,000 entries and evicts —
-/// this one has no bound. At roughly 60 bytes per row, 50,000 abandoned keys cost about 3 MB, which is
-/// small enough that a sweep is a separate decision rather than a prerequisite.
+/// this one has no bound. At roughly 60 bytes per row, 50,000 abandoned keys cost about 3 MB. Note that
+/// this table now grows on <em>every</em> deployment rather than only on ones that opted in, so the
+/// retention sweep tracked in issue #253 matters more than it did when the budget shipped disabled.
 /// </para>
 /// </remarks>
 public sealed class SqliteConversationBudgetTracker : IConversationBudgetTracker

--- a/src/Content/Presentation/Presentation.AgentHub/appsettings.json
+++ b/src/Content/Presentation/Presentation.AgentHub/appsettings.json
@@ -18,7 +18,8 @@
       "AgentFramework": {
         "DefaultDeployment": "gpt-4o",
         "ClientType": "AzureOpenAI",
-        "ConversationTokenBudget": 0
+        "//ConversationTokenBudget": "Cumulative token ceiling across every turn of one conversation; the conversation stops itself gracefully between turns when it is reached. Matches the code default. Set to 0 to disable, but note that nothing else bounds a durable conversation's total length — per-run caps do not.",
+        "ConversationTokenBudget": 1000000
       },
       "Governance": {
         "Enabled": true,

--- a/src/Content/Presentation/Presentation.AgentHub/appsettings.json
+++ b/src/Content/Presentation/Presentation.AgentHub/appsettings.json
@@ -18,8 +18,7 @@
       "AgentFramework": {
         "DefaultDeployment": "gpt-4o",
         "ClientType": "AzureOpenAI",
-        "//ConversationTokenBudget": "Cumulative token ceiling across every turn of one conversation; the conversation stops itself gracefully between turns when it is reached. Matches the code default. Set to 0 to disable, but note that nothing else bounds a durable conversation's total length — per-run caps do not.",
-        "ConversationTokenBudget": 1000000
+        "//": "ConversationTokenBudget (cumulative token ceiling across every turn of one conversation) is deliberately NOT pinned here — it inherits the code default so there is one source of truth. Add it only to override. Setting it to 0 disables it, at which point nothing bounds a durable conversation's total length: the per-run maxTurns and message caps deliberately do not."
       },
       "Governance": {
         "Enabled": true,

--- a/src/Content/Presentation/Presentation.AgentHub/appsettings.json
+++ b/src/Content/Presentation/Presentation.AgentHub/appsettings.json
@@ -18,7 +18,7 @@
       "AgentFramework": {
         "DefaultDeployment": "gpt-4o",
         "ClientType": "AzureOpenAI",
-        "//": "ConversationTokenBudget (cumulative token ceiling across every turn of one conversation) is deliberately NOT pinned here — it inherits the code default so there is one source of truth. Add it only to override. Setting it to 0 disables it, at which point nothing bounds a durable conversation's total length: the per-run maxTurns and message caps deliberately do not."
+        "//": "ConversationTokenBudget is deliberately NOT pinned here — it inherits the code default so there is one source of truth. Add it only to override, and see the XML docs on AgentFrameworkConfig.ConversationTokenBudget before setting it to 0."
       },
       "Governance": {
         "Enabled": true,

--- a/src/Content/Presentation/Presentation.ExecutionApi/README.md
+++ b/src/Content/Presentation/Presentation.ExecutionApi/README.md
@@ -197,13 +197,16 @@ Two caps that now mean something narrower than they read: `userMessages` (100) a
 bound **one run**. A durable conversation outlives any run, so what bounds its total length is the
 conversation-lifetime token budget, which is durable and spans every run against that conversation.
 
-That budget is `AppConfig:AI:AgentFramework:ConversationTokenBudget`, and it is **on by default** at
-1,000,000 cumulative tokens -- roughly 50-100 exchanges once each turn's resent history is counted. It
-is a runaway guard rather than a business rule: a conversation that loops or is never closed stops
-itself at a bounded cost instead of billing indefinitely. When it is reached the next turn is declined
-gracefully between turns, never mid-answer. Setting it to `0` disables it, at which point **nothing**
-bounds a conversation's total length -- the per-run caps above deliberately do not. It shipped at `0`
-until #256.
+That budget is `AppConfig:AI:AgentFramework:ConversationTokenBudget`, **on by default** at 1,000,000
+cumulative tokens. An exhausted conversation declines further turns gracefully with an explanatory
+message -- no model call, no error, and never mid-answer. Setting it to `0` disables it, at which point
+**nothing** bounds a conversation's total length, because the per-run caps above deliberately do not.
+See the XML docs on `AgentFrameworkConfig.ConversationTokenBudget` for the rationale and for how the
+same ceiling applies to plan runs.
+
+**Upgrading:** this shipped at `0` (disabled) before. A deployment whose own `appsettings.json` pins
+`ConversationTokenBudget` to `0` keeps that value and stays unbounded -- the new default only reaches
+hosts that never set it. Remove the pinned `0` to pick up the bound.
 
 A conversation is created on first use and owned by the caller that first used it. A run naming
 someone else's conversation is refused **synchronously** as `404` -- identically to an unknown handle,

--- a/src/Content/Presentation/Presentation.ExecutionApi/README.md
+++ b/src/Content/Presentation/Presentation.ExecutionApi/README.md
@@ -197,6 +197,14 @@ Two caps that now mean something narrower than they read: `userMessages` (100) a
 bound **one run**. A durable conversation outlives any run, so what bounds its total length is the
 conversation-lifetime token budget, which is durable and spans every run against that conversation.
 
+That budget is `AppConfig:AI:AgentFramework:ConversationTokenBudget`, and it is **on by default** at
+1,000,000 cumulative tokens -- roughly 50-100 exchanges once each turn's resent history is counted. It
+is a runaway guard rather than a business rule: a conversation that loops or is never closed stops
+itself at a bounded cost instead of billing indefinitely. When it is reached the next turn is declined
+gracefully between turns, never mid-answer. Setting it to `0` disables it, at which point **nothing**
+bounds a conversation's total length -- the per-run caps above deliberately do not. It shipped at `0`
+until #256.
+
 A conversation is created on first use and owned by the caller that first used it. A run naming
 someone else's conversation is refused **synchronously** as `404` -- identically to an unknown handle,
 so the endpoint cannot be used to enumerate other callers' conversation ids. Ownership itself is

--- a/src/Content/Tests/Domain.Common.Tests/Config/AIConfigTests.cs
+++ b/src/Content/Tests/Domain.Common.Tests/Config/AIConfigTests.cs
@@ -47,6 +47,28 @@ public class AgentFrameworkConfigTests
     }
 
     [Fact]
+    public void ConversationTokenBudget_DefaultsToOneMillion()
+    {
+        var config = new AgentFrameworkConfig();
+
+        // The figure is a product decision (#256): roughly 50-100 exchanges once each turn's resent
+        // history is counted. Pinned so that changing it is a deliberate edit with this test in the diff.
+        config.ConversationTokenBudget.Should().Be(1_000_000);
+    }
+
+    [Fact]
+    public void ConversationTokenBudget_IsNotZero_BecauseZeroSilentlyMeansUnbounded()
+    {
+        // Deliberately separate from the figure above, because this is the part that must not change. A
+        // durable conversation outlives any single run, so the per-run caps do not bound it — the
+        // Execution API contract names this budget as the only thing that does. At 0 the tracker reports
+        // Disabled and records nothing, so the documented bound silently ceases to exist. That was the
+        // shipped state #256 was filed against. Tuning the number is fine; returning it to 0 is not.
+        new AgentFrameworkConfig().ConversationTokenBudget.Should().BePositive(
+            "a conversation with no ceiling has nothing else bounding its total length");
+    }
+
+    [Fact]
     public void IsConfigured_WithNoApiKey_ReturnsFalse()
     {
         var config = new AgentFrameworkConfig();

--- a/src/Content/Tests/Domain.Common.Tests/Config/AIConfigTests.cs
+++ b/src/Content/Tests/Domain.Common.Tests/Config/AIConfigTests.cs
@@ -49,12 +49,9 @@ public class AgentFrameworkConfigTests
     [Fact]
     public void ConversationTokenBudget_Unconfigured_DefaultsToOneMillion()
     {
-        // A durable conversation outlives any single run, so the per-run caps do not bound it — the
-        // Execution API contract names this budget as the only thing that does. At 0 the tracker reports
-        // Disabled and records nothing, so that documented bound silently ceases to exist; tuning the
-        // figure is fine, returning it to 0 is not. The figure itself is roughly 50-100 exchanges once
-        // each turn's resent history is counted, and is pinned so that changing it is a deliberate edit
-        // with this test in the diff.
+        // Pinned so that changing the figure is a deliberate edit with this test in the diff, and so a
+        // return to 0 — which silently means unbounded — cannot happen quietly. Rationale for both the
+        // figure and the floor lives on the property's own XML docs.
         new AgentFrameworkConfig().ConversationTokenBudget.Should().Be(
             1_000_000,
             "a conversation with no ceiling has nothing else bounding its total length");

--- a/src/Content/Tests/Domain.Common.Tests/Config/AIConfigTests.cs
+++ b/src/Content/Tests/Domain.Common.Tests/Config/AIConfigTests.cs
@@ -47,24 +47,16 @@ public class AgentFrameworkConfigTests
     }
 
     [Fact]
-    public void ConversationTokenBudget_DefaultsToOneMillion()
+    public void ConversationTokenBudget_Unconfigured_DefaultsToOneMillion()
     {
-        var config = new AgentFrameworkConfig();
-
-        // The figure is a product decision (#256): roughly 50-100 exchanges once each turn's resent
-        // history is counted. Pinned so that changing it is a deliberate edit with this test in the diff.
-        config.ConversationTokenBudget.Should().Be(1_000_000);
-    }
-
-    [Fact]
-    public void ConversationTokenBudget_IsNotZero_BecauseZeroSilentlyMeansUnbounded()
-    {
-        // Deliberately separate from the figure above, because this is the part that must not change. A
-        // durable conversation outlives any single run, so the per-run caps do not bound it — the
+        // A durable conversation outlives any single run, so the per-run caps do not bound it — the
         // Execution API contract names this budget as the only thing that does. At 0 the tracker reports
-        // Disabled and records nothing, so the documented bound silently ceases to exist. That was the
-        // shipped state #256 was filed against. Tuning the number is fine; returning it to 0 is not.
-        new AgentFrameworkConfig().ConversationTokenBudget.Should().BePositive(
+        // Disabled and records nothing, so that documented bound silently ceases to exist; tuning the
+        // figure is fine, returning it to 0 is not. The figure itself is roughly 50-100 exchanges once
+        // each turn's resent history is counted, and is pinned so that changing it is a deliberate edit
+        // with this test in the diff.
+        new AgentFrameworkConfig().ConversationTokenBudget.Should().Be(
+            1_000_000,
             "a conversation with no ceiling has nothing else bounding its total length");
     }
 

--- a/src/Content/Tests/Infrastructure.AI.Tests/Conversations/SqliteConversationBudgetTrackerTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Conversations/SqliteConversationBudgetTrackerTests.cs
@@ -58,12 +58,18 @@ public sealed class SqliteConversationBudgetTrackerTests
     /// <inheritdoc />
     protected override IConversationBudgetTracker DisabledTracker => _disabled;
 
+    /// <param name="contextFactory">Supplies contexts over the test database.</param>
+    /// <param name="ceiling">
+    /// The ceiling to configure, or <see langword="null"/> to leave it unset so the tracker runs on the
+    /// shipped default — which is what a stock deployment gets.
+    /// </param>
     private static SqliteConversationBudgetTracker Build(
         IDbContextFactory<ConversationDbContext> contextFactory,
-        int ceiling)
+        int? ceiling)
     {
         var config = new AppConfig();
-        config.AI.AgentFramework.ConversationTokenBudget = ceiling;
+        if (ceiling is not null)
+            config.AI.AgentFramework.ConversationTokenBudget = ceiling.Value;
 
         return new SqliteConversationBudgetTracker(
             contextFactory,
@@ -75,29 +81,25 @@ public sealed class SqliteConversationBudgetTrackerTests
 
     /// <summary>
     /// A stock deployment must actually bound a conversation. This is the tracker a stock deployment
-    /// gets — <c>AppConfig.AI.Conversations.Provider</c> defaults to SQLite — so this is the end-to-end
-    /// form of #256: not "the config object holds a number" but "a conversation configured with nothing
-    /// at all stops".
+    /// gets — <c>AppConfig.AI.Conversations.Provider</c> defaults to SQLite — so this asserts the whole
+    /// claim rather than half of it: not "the config object holds a number" but "a conversation
+    /// configured with nothing at all stops".
     /// </summary>
     /// <remarks>
-    /// Every other test in this file and its contract passes an explicit ceiling, which is correct for
-    /// asserting budget behaviour but means none of them touches the default. Before this test, changing
-    /// the shipped default from enforcing to disabled broke no test in the solution — the reason #256's
-    /// gap survived shipping. Deliberately asserts the <em>property</em> (a conversation is bounded), not
-    /// the figure; the figure is pinned once, in <c>AgentFrameworkConfigTests</c>.
+    /// Every other test in this file and its contract passes an explicit ceiling, which is right for
+    /// asserting budget behaviour but leaves the default untouched — so without this one, flipping the
+    /// shipped default between enforcing and disabled breaks no test in the solution. Asserts the
+    /// <em>property</em> (a conversation is bounded), not the figure; the figure is pinned once, in
+    /// <c>AgentFrameworkConfigTests</c>.
     /// </remarks>
     [Fact]
     public async Task GetStatusAsync_StockConfiguration_BoundsTheConversation()
     {
-        var config = new AppConfig();
-        var stock = new SqliteConversationBudgetTracker(
-            _contextFactory,
-            Mock.Of<IOptionsMonitor<AppConfig>>(m => m.CurrentValue == config),
-            new FakeTimeProvider(Origin),
-            NullLogger<SqliteConversationBudgetTracker>.Instance,
-            new SchemaInitializer<ConversationDbContext>(_contextFactory));
+        var stock = Build(_contextFactory, ceiling: null);
 
-        var ceiling = config.AI.AgentFramework.ConversationTokenBudget;
+        // Read rather than hardcoded, so this test asserts that the shipped default bounds a
+        // conversation without also restating what the figure is. That is pinned once, elsewhere.
+        var ceiling = new AppConfig().AI.AgentFramework.ConversationTokenBudget;
         var key = NewKey();
 
         // Control: a fresh conversation is enabled and has room. Without this, the exhaustion assertion

--- a/src/Content/Tests/Infrastructure.AI.Tests/Conversations/SqliteConversationBudgetTrackerTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Conversations/SqliteConversationBudgetTrackerTests.cs
@@ -87,7 +87,7 @@ public sealed class SqliteConversationBudgetTrackerTests
     /// the figure; the figure is pinned once, in <c>AgentFrameworkConfigTests</c>.
     /// </remarks>
     [Fact]
-    public async Task StockConfiguration_BoundsAConversation_WithNothingConfigured()
+    public async Task GetStatusAsync_StockConfiguration_BoundsTheConversation()
     {
         var config = new AppConfig();
         var stock = new SqliteConversationBudgetTracker(

--- a/src/Content/Tests/Infrastructure.AI.Tests/Conversations/SqliteConversationBudgetTrackerTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Conversations/SqliteConversationBudgetTrackerTests.cs
@@ -74,6 +74,47 @@ public sealed class SqliteConversationBudgetTrackerTests
     }
 
     /// <summary>
+    /// A stock deployment must actually bound a conversation. This is the tracker a stock deployment
+    /// gets — <c>AppConfig.AI.Conversations.Provider</c> defaults to SQLite — so this is the end-to-end
+    /// form of #256: not "the config object holds a number" but "a conversation configured with nothing
+    /// at all stops".
+    /// </summary>
+    /// <remarks>
+    /// Every other test in this file and its contract passes an explicit ceiling, which is correct for
+    /// asserting budget behaviour but means none of them touches the default. Before this test, changing
+    /// the shipped default from enforcing to disabled broke no test in the solution — the reason #256's
+    /// gap survived shipping. Deliberately asserts the <em>property</em> (a conversation is bounded), not
+    /// the figure; the figure is pinned once, in <c>AgentFrameworkConfigTests</c>.
+    /// </remarks>
+    [Fact]
+    public async Task StockConfiguration_BoundsAConversation_WithNothingConfigured()
+    {
+        var config = new AppConfig();
+        var stock = new SqliteConversationBudgetTracker(
+            _contextFactory,
+            Mock.Of<IOptionsMonitor<AppConfig>>(m => m.CurrentValue == config),
+            new FakeTimeProvider(Origin),
+            NullLogger<SqliteConversationBudgetTracker>.Instance,
+            new SchemaInitializer<ConversationDbContext>(_contextFactory));
+
+        var ceiling = config.AI.AgentFramework.ConversationTokenBudget;
+        var key = NewKey();
+
+        // Control: a fresh conversation is enabled and has room. Without this, the exhaustion assertion
+        // below would also pass against a tracker that reported exhausted from the very first turn.
+        var fresh = await stock.GetStatusAsync(key);
+        fresh.IsEnabled.Should().BeTrue("a stock deployment must enforce a ceiling, not run unbounded");
+        fresh.IsExhausted.Should().BeFalse("a conversation that has spent nothing has not exhausted anything");
+
+        await stock.RecordUsageAsync(key, ceiling);
+
+        var spent = await stock.GetStatusAsync(key);
+        spent.IsExhausted.Should().BeTrue(
+            "the Execution API contract names this budget as the only thing bounding a durable "
+            + "conversation's total length, so on stock configuration it has to actually stop one");
+    }
+
+    /// <summary>
     /// The reason this implementation exists. Two hosts running turns of one conversation must enforce
     /// one ceiling between them; with a per-process total they each enforce a private copy and the
     /// conversation spends roughly twice what was configured.


### PR DESCRIPTION
Closes #256.

## The problem

The Execution API contract tells consumers that the per-run caps (`maxTurns`, the seed-message cap) deliberately do **not** bound a durable conversation, and that the conversation-lifetime token budget is what does. That budget shipped at `0`, which means disabled, and `Presentation.AgentHub/appsettings.json` pinned `0` on top of it.

So on stock configuration nothing bounded a conversation's total length, and the documented answer pointed at an inert control. A long-lived session — the voice case the feature exists for — grew until something else stopped it.

## What changed

`AgentFrameworkConfig.ConversationTokenBudget` now defaults to **1,000,000** cumulative tokens: roughly 50–100 exchanges once each turn's resent history is counted. It is a runaway guard rather than a business rule — work that loops or is never closed stops at a bounded cost instead of billing indefinitely. The figure is a product decision, taken by the repo owner from the options on #256.

The AgentHub config no longer pins the value at all. It inherits the code default, so there is one source of truth; a pinned copy would have silently kept the old number the next time the default moved.

Enforcement itself needed no work — it was already built and already graceful.

## Why it survived shipping, and what stops it recurring

**Nothing tested the default.** Every existing budget test passes an explicit ceiling, which is correct for asserting budget behaviour but leaves the shipped value untouched. I verified this before writing anything: flipping the default between enforcing and disabled broke **no test in the solution**.

Two guards now close that:

- `AgentFrameworkConfigTests` pins the figure, so changing it is a deliberate edit with the test in the diff.
- `SqliteConversationBudgetTrackerTests.GetStatusAsync_StockConfiguration_BoundsTheConversation` asserts the property end to end against the tracker a stock deployment actually gets (`Conversations.Provider` defaults to SQLite): a conversation configured with nothing at all still stops. It carries a control proving a fresh conversation is enabled and has room, so it cannot pass against a tracker that reports exhausted from turn one.

Mutation-tested: reverting the default to `0` fails both.

## Things worth knowing before merging

**Two budget keys, two failure shapes.** Conversational turns key by conversation and decline gracefully with an explanatory message — no model call, no error. Plan execution keys by *plan run* and fails an exhausted step as a policy denial. Same ceiling, different unit and different outcome. Turning the budget on by default makes the plan path reachable on stock configuration, so the property's docs now say this rather than describing only conversations.

**Upgrading is not automatic.** A deployment whose own `appsettings.json` pins `ConversationTokenBudget` to `0` keeps that value and stays unbounded — the new default only reaches hosts that never set it. Recorded in the Execution API README and the onboarding configuration page.

**#253 matters more now.** The durable tracker never removes abandoned budget rows, and its sizing argument was written when stock config wrote nothing at all. Every deployment now writes a row per conversation. Slow and small, not urgent, but no longer opt-in — noted on that issue.

**Cost was measured, not assumed.** Both trackers going active adds two small SQLite statements per turn against a one-row-per-conversation table, on a turn that already writes its transcript to the same file and makes a model call. Roughly 1/10,000th of the turn. Nothing to optimise.

## Deliberately not in scope

Both trackers still go **silently** inert at a configured `0`, which is the property that let this ship unnoticed — an env var or configmap landing `0` produces no runtime evidence. #256 offered "require it when durable conversations are used" as an option and the owner chose the non-zero default instead, so a startup signal is filed separately rather than folded in here.

## Verification

- Full solution build clean (6 pre-existing warnings, all in untouched test files).
- 21 test suites, 0 failures.
- Both review axes run and applied; deferred items and reasoning recorded on their issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
