### PR TITLE
fix: accumulate conversation telemetry across durable runs instead of overwriting it

### DIFF
--- a/src/Content/Application/Application.AI.Common/Models/Conversations/TelemetryAccumulator.cs
+++ b/src/Content/Application/Application.AI.Common/Models/Conversations/TelemetryAccumulator.cs
@@ -23,6 +23,31 @@ public sealed record TelemetryAccumulator(
             CacheRead + cacheRead, CacheWrite + cacheWrite,
             CostUsd + costUsd);
 
+    /// <summary>
+    /// Returns what has been added since <paramref name="baseline"/> — this accumulator minus that one,
+    /// field by field.
+    /// </summary>
+    /// <param name="baseline">An earlier snapshot of the same accumulator.</param>
+    /// <returns>The difference between the two.</returns>
+    /// <remarks>
+    /// Lets a caller that needs both "everything so far" and "my share of it" keep one running total and
+    /// derive the other, rather than accumulating the same events twice. Two counters over one event
+    /// stream are two chances to disagree, which is precisely the defect in issue #255.
+    /// </remarks>
+    public TelemetryAccumulator Since(TelemetryAccumulator baseline)
+    {
+        ArgumentNullException.ThrowIfNull(baseline);
+
+        return new(
+            TurnCount - baseline.TurnCount,
+            ToolCallCount - baseline.ToolCallCount,
+            InputTokens - baseline.InputTokens,
+            OutputTokens - baseline.OutputTokens,
+            CacheRead - baseline.CacheRead,
+            CacheWrite - baseline.CacheWrite,
+            CostUsd - baseline.CostUsd);
+    }
+
     /// <summary>Ratio of cache-read tokens to total input tokens (0..1).</summary>
     public decimal CacheHitRate
     {

--- a/src/Content/Application/Application.Core/CQRS/Agents/RunConversation/DurableTranscript.cs
+++ b/src/Content/Application/Application.Core/CQRS/Agents/RunConversation/DurableTranscript.cs
@@ -44,6 +44,51 @@ internal sealed class DurableTranscript
     }
 
     /// <summary>
+    /// Reads the conversation's observability session and everything it has spent across every run
+    /// before this one.
+    /// </summary>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>
+    /// The conversation's session, or <see cref="Guid.Empty"/> when it has never had one, and its
+    /// totals, never <see langword="null"/>. A conversation the store cannot return reads as neither.
+    /// </returns>
+    /// <remarks>
+    /// <para>
+    /// <strong>Must be called under the turn lease, and is, for the same reason the replay window is.</strong>
+    /// A run that queued behind another host's run would otherwise carry totals read before that run
+    /// existed, add its own, and write back a sum missing everything the other host spent — silently
+    /// deleting a peer's telemetry rather than merely reporting it late.
+    /// </para>
+    /// <para>
+    /// This is a second read of a record the run has already opened, which is the price of taking it at
+    /// the right moment rather than the convenient one. It is paid once per run, not once per turn.
+    /// </para>
+    /// </remarks>
+    public async Task<(Guid SessionId, TelemetryAccumulator Totals)> LoadTelemetryAsync(CancellationToken ct)
+    {
+        var record = await _store.GetAsync(_conversationId, _ownerId, ct);
+
+        return (record?.ObservabilitySessionId ?? Guid.Empty,
+                record?.Telemetry ?? TelemetryAccumulator.Zero);
+    }
+
+    /// <summary>
+    /// Records the conversation's running totals, and the session they belong to, on the conversation
+    /// itself.
+    /// </summary>
+    /// <param name="observabilitySessionId">The conversation's session.</param>
+    /// <param name="totals">Cumulative totals across every run so far, not this run's share.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <remarks>
+    /// This is the second of the two places a conversation's telemetry lives, and the one that survives
+    /// the observability database being absent or switched off. Writing only the session row would leave
+    /// the next <see cref="LoadTelemetryAsync"/> reading zero and starting the overwrite again.
+    /// </remarks>
+    public Task PersistTelemetryAsync(
+        Guid observabilitySessionId, TelemetryAccumulator totals, CancellationToken ct) =>
+        _store.UpdateTelemetryAsync(_conversationId, _ownerId, observabilitySessionId, totals, ct);
+
+    /// <summary>
     /// Returns the most recent <paramref name="maxMessages"/> messages, projected onto the framework's
     /// chat shape, ready to seed the run's first turn.
     /// </summary>

--- a/src/Content/Application/Application.Core/CQRS/Agents/RunConversation/RunConversationCommandHandler.cs
+++ b/src/Content/Application/Application.Core/CQRS/Agents/RunConversation/RunConversationCommandHandler.cs
@@ -172,16 +172,9 @@ public class RunConversationCommandHandler : IRequestHandler<RunConversationComm
 
 		var sw = Stopwatch.StartNew();
 		var turns = new List<TurnSummary>();
-		var totalToolInvocations = 0;
 		var governanceTraces = new List<GovernanceTrace>();
 		AgentTurnResult? lastResult = null;
 		var stoppedForBudget = false;
-
-		// This run's own totals. They answer "what did this call cost", which is what the caller asked
-		// and what the run-scoped metrics below report — deliberately NOT the same quantity as
-		// conversationTotals, which answers "what has this conversation cost in all".
-		int totalInputTokens = 0, totalOutputTokens = 0;
-		decimal totalCostUsd = 0m;
 		string? sessionModel = null;
 
 		// Everything the conversation has spent, this run included as it goes. A durable run resumes
@@ -189,6 +182,12 @@ public class RunConversationCommandHandler : IRequestHandler<RunConversationComm
 		var (existingSessionId, conversationTotals) = transcript is null
 			? (Guid.Empty, TelemetryAccumulator.Zero)
 			: await transcript.LoadTelemetryAsync(cancellationToken);
+
+		// Where this run came in. The caller asked what THIS call cost, and the run-scoped metrics
+		// report the same, so that quantity is derived by subtraction rather than accumulated alongside:
+		// two counters over one stream of turns are two chances to disagree, and a pair of totals
+		// disagreeing about the same turns is the whole of issue #255.
+		var runBaseline = conversationTotals;
 
 		var agentTag = new KeyValuePair<string, object?>(AgentConventions.Name, request.AgentName);
 		var sessionTags = new TagList { { AgentConventions.Name, request.AgentName } };
@@ -223,6 +222,32 @@ public class RunConversationCommandHandler : IRequestHandler<RunConversationComm
 		// normal (success / turn-failure) return path, so the catch block does
 		// not double-end it when an exception escapes after those paths.
 		var sessionEnded = false;
+
+		// Every path that finishes the session goes through here, so the two rules — this run must own
+		// the session, and it must not end one twice — are decided once. They were applied at each of
+		// the four call sites instead, and review found the exception path had been missed, which ended
+		// a live conversation's session on any transient throw.
+		//
+		// Failures are logged and swallowed rather than propagated. Ending a session is bookkeeping;
+		// a bookkeeping failure must not turn a conversation that completed into one that reports an
+		// error, and it must never mask an exception already on its way out. Cleanup runs on an
+		// uncancelled token so it still completes when the caller's token is the reason we are here.
+		async Task EndRunSessionAsync(string status, string? reason)
+		{
+			if (sessionEnded || !ownsSession)
+				return;
+
+			sessionEnded = true;
+
+			try
+			{
+				await _observabilityStore.EndSessionAsync(dbSessionId, status, reason, CancellationToken.None);
+			}
+			catch (Exception ex)
+			{
+				_logger.LogError(ex, "Failed to end observability session {SessionId}", dbSessionId);
+			}
+		}
 
 		try
 		{
@@ -298,20 +323,17 @@ public class RunConversationCommandHandler : IRequestHandler<RunConversationComm
 					_logger.LogError("Conversation turn {Turn} failed for {AgentName}: {Error}",
 						index + 1, request.AgentName, lastResult.Error);
 
-					if (ownsSession)
-					{
-						await _observabilityStore.EndSessionAsync(
-							dbSessionId, "error", lastResult.Error, cancellationToken);
-						sessionEnded = true;
-					}
+					await EndRunSessionAsync("error", lastResult.Error);
+
+					var partialShare = conversationTotals.Since(runBaseline);
 
 					return new ConversationResult
 					{
 						Success = false,
 						Turns = turns,
 						FinalResponse = string.Empty,
-						TotalToolInvocations = totalToolInvocations,
-						TotalTokens = totalInputTokens + totalOutputTokens,
+						TotalToolInvocations = partialShare.ToolCallCount,
+						TotalTokens = partialShare.InputTokens + partialShare.OutputTokens,
 						Error = $"Turn {index + 1} failed: {lastResult.Error}"
 					};
 				}
@@ -361,14 +383,9 @@ public class RunConversationCommandHandler : IRequestHandler<RunConversationComm
 					ToolsInvoked = lastResult.ToolsInvoked
 				});
 
-				totalToolInvocations += lastResult.ToolsInvoked.Count;
-
 				if (lastResult.Governance is not null)
 					governanceTraces.Add(lastResult.Governance);
 
-				totalInputTokens += lastResult.InputTokens;
-				totalOutputTokens += lastResult.OutputTokens;
-				totalCostUsd += lastResult.CostUsd;
 				sessionModel ??= lastResult.Model;
 
 				conversationTotals = conversationTotals.Add(
@@ -399,8 +416,24 @@ public class RunConversationCommandHandler : IRequestHandler<RunConversationComm
 				// and the only one that survives the observability database being absent or switched off,
 				// so it is written every turn rather than once at the end — a run that dies on its
 				// seventh turn leaves the two agreeing about the six that completed.
+				//
+				// Logged and swallowed, matching what the interactive host does with the same write and
+				// what the observability store does internally: the turn succeeded and its answer is
+				// already in the transcript, so failing it now over a telemetry write would discard real
+				// work to protect a number. The cost is that the next run resumes from a stale total.
 				if (transcript is not null)
-					await transcript.PersistTelemetryAsync(dbSessionId, conversationTotals, cancellationToken);
+				{
+					try
+					{
+						await transcript.PersistTelemetryAsync(dbSessionId, conversationTotals, cancellationToken);
+					}
+					catch (Exception ex) when (ex is not OperationCanceledException)
+					{
+						_logger.LogWarning(ex,
+							"Failed to persist telemetry for conversation {ConversationId}; the next run will "
+							+ "resume from a stale total", request.ConversationId);
+					}
+				}
 
 				if (request.OnProgress != null)
 				{
@@ -415,42 +448,42 @@ public class RunConversationCommandHandler : IRequestHandler<RunConversationComm
 			}
 
 			sw.Stop();
+
+			// What this run alone spent, taken as the difference between where the conversation stands
+			// now and where it stood when the run started. Everything below reports on the run, not the
+			// conversation, so all of it reads from here.
+			var runShare = conversationTotals.Since(runBaseline);
+
 			_logger.LogInformation("Conversation completed: {TurnCount} turns, {ToolCount} tool invocations",
-				turns.Count, totalToolInvocations);
+				turns.Count, runShare.ToolCallCount);
 
 			OrchestrationMetrics.ConversationDuration.Record(sw.Elapsed.TotalMilliseconds, agentTag);
 			OrchestrationMetrics.TurnsPerConversation.Record(turns.Count, agentTag);
-			if (totalToolInvocations > 0)
-				OrchestrationMetrics.ToolCalls.Add(totalToolInvocations, agentTag);
+			if (runShare.ToolCallCount > 0)
+				OrchestrationMetrics.ToolCalls.Add(runShare.ToolCallCount, agentTag);
 
-			if (totalCostUsd > 0)
-				SessionMetrics.SessionCost.Record((double)totalCostUsd, agentTag);
+			if (runShare.CostUsd > 0)
+				SessionMetrics.SessionCost.Record((double)runShare.CostUsd, agentTag);
 
-			if (ownsSession)
-			{
-				await _observabilityStore.EndSessionAsync(
-					dbSessionId, "completed", null, cancellationToken);
-				sessionEnded = true;
-			}
+			await EndRunSessionAsync("completed", null);
 
 			return new ConversationResult
 			{
 				Success = true,
 				Turns = turns,
 				FinalResponse = lastResult?.Response ?? string.Empty,
-				TotalToolInvocations = totalToolInvocations,
-				TotalTokens = totalInputTokens + totalOutputTokens,
+				TotalToolInvocations = runShare.ToolCallCount,
+				TotalTokens = runShare.InputTokens + runShare.OutputTokens,
 				BudgetExhausted = stoppedForBudget,
 				Governance = governanceTraces.Count > 0 ? GovernanceTrace.Merge(governanceTraces) : null
 			};
 		}
 		catch (OperationCanceledException)
 		{
-			// Caller cancellation (e.g. client disconnect) is routine, not exceptional.
-			// End the session as cancelled using a non-cancelled token so the cleanup
-			// write still completes, then rethrow to preserve cancellation semantics.
-			await EndSessionSafelyAsync(dbSessionId, "cancelled", null, sessionEnded || !ownsSession);
-			sessionEnded = true;
+			// Caller cancellation (e.g. client disconnect) is routine, not exceptional — so the session
+			// closes as "cancelled" rather than "error", and the exception is rethrown rather than
+			// turned into a failed result, because a caller that walked away is not a run that failed.
+			await EndRunSessionAsync("cancelled", null);
 			throw;
 		}
 		catch (Exception ex)
@@ -460,8 +493,7 @@ public class RunConversationCommandHandler : IRequestHandler<RunConversationComm
 			// session with a stable scrubbed status code and rethrow.
 			_logger.LogError(ex, "Conversation with {AgentName} failed with an unhandled exception",
 				request.AgentName);
-			await EndSessionSafelyAsync(dbSessionId, "error", "conversation.unhandled_exception", sessionEnded);
-			sessionEnded = true;
+			await EndRunSessionAsync("error", "conversation.unhandled_exception");
 			throw;
 		}
 		finally
@@ -481,32 +513,4 @@ public class RunConversationCommandHandler : IRequestHandler<RunConversationComm
 		}
 	}
 
-	/// <summary>
-	/// Ends the observability session defensively during exception/cancellation
-	/// handling: uses a non-cancelled token so cleanup completes even when the
-	/// caller's token is cancelled, and never lets a cleanup failure mask the
-	/// original exception being propagated.
-	/// </summary>
-	/// <param name="sessionId">The session to end.</param>
-	/// <param name="status">The terminal status to record.</param>
-	/// <param name="reason">A scrubbed reason code, or <see langword="null"/>.</param>
-	/// <param name="alreadyHandled">
-	/// <see langword="true"/> when there is nothing left to do: either a normal return path already
-	/// ended the session, or this run does not own it because it is continuing a durable conversation
-	/// that outlives the run.
-	/// </param>
-	private async Task EndSessionSafelyAsync(Guid sessionId, string status, string? reason, bool alreadyHandled)
-	{
-		if (alreadyHandled)
-			return;
-
-		try
-		{
-			await _observabilityStore.EndSessionAsync(sessionId, status, reason, CancellationToken.None);
-		}
-		catch (Exception endEx)
-		{
-			_logger.LogError(endEx, "Failed to end observability session {SessionId} during cleanup", sessionId);
-		}
-	}
 }

--- a/src/Content/Application/Application.Core/CQRS/Agents/RunConversation/RunConversationCommandHandler.cs
+++ b/src/Content/Application/Application.Core/CQRS/Agents/RunConversation/RunConversationCommandHandler.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using System.Diagnostics.Metrics;
 using Application.AI.Common.Interfaces;
 using Application.AI.Common.Interfaces.AI;
+using Application.AI.Common.Models.Conversations;
 using Application.AI.Common.OpenTelemetry.Metrics;
 using Application.Core.CQRS.Agents.ExecuteAgentTurn;
 using Domain.AI.Governance;
@@ -176,18 +177,47 @@ public class RunConversationCommandHandler : IRequestHandler<RunConversationComm
 		AgentTurnResult? lastResult = null;
 		var stoppedForBudget = false;
 
-		// Running token/cost aggregates for session-level metrics
-		int totalInputTokens = 0, totalOutputTokens = 0, totalCacheRead = 0, totalCacheWrite = 0;
+		// This run's own totals. They answer "what did this call cost", which is what the caller asked
+		// and what the run-scoped metrics below report — deliberately NOT the same quantity as
+		// conversationTotals, which answers "what has this conversation cost in all".
+		int totalInputTokens = 0, totalOutputTokens = 0;
 		decimal totalCostUsd = 0m;
 		string? sessionModel = null;
 
-		var dbSessionId = await _observabilityStore.StartSessionAsync(
-			request.ConversationId, request.AgentName, null, cancellationToken);
+		// Everything the conversation has spent, this run included as it goes. A durable run resumes
+		// these from the store; a self-contained run has nothing before it and starts at zero.
+		var (existingSessionId, conversationTotals) = transcript is null
+			? (Guid.Empty, TelemetryAccumulator.Zero)
+			: await transcript.LoadTelemetryAsync(cancellationToken);
 
 		var agentTag = new KeyValuePair<string, object?>(AgentConventions.Name, request.AgentName);
 		var sessionTags = new TagList { { AgentConventions.Name, request.AgentName } };
-		SessionMetrics.SessionsStarted.Add(1, agentTag);
+
+		// A conversation gets ONE observability session and keeps it, because the session table holds one
+		// row per conversation. Re-opening the session a conversation already has does not open a second
+		// one — it restamps the first one's start time, and every duration derived from it then describes
+		// only the latest run (issue #255). So a continuing run adopts the session it finds.
+		var dbSessionId = existingSessionId;
+		if (dbSessionId == Guid.Empty)
+		{
+			dbSessionId = await _observabilityStore.StartSessionAsync(
+				request.ConversationId, request.AgentName, null, cancellationToken);
+
+			SessionMetrics.SessionsStarted.Add(1, agentTag);
+
+			// Recorded before the first turn, not after it, so the conversation still points at its
+			// session when a run opens one and then declines every turn on an exhausted budget.
+			if (transcript is not null)
+				await transcript.PersistTelemetryAsync(dbSessionId, conversationTotals, cancellationToken);
+		}
+
 		SessionMetrics.ActiveSessions.Add(1, sessionTags);
+
+		// A run is not the conversation. Only a self-contained run may end the session, because only
+		// there are the two the same thing; ending it on a durable run would mark a conversation
+		// finished that the next run — or a user still typing in the interactive host — is about to
+		// continue. The interactive transports have never ended a session per turn for this reason.
+		var ownsSession = transcript is null;
 
 		// Tracks whether the observability session has already been ended on a
 		// normal (success / turn-failure) return path, so the catch block does
@@ -247,7 +277,11 @@ public class RunConversationCommandHandler : IRequestHandler<RunConversationComm
 					// replayed transcript flows through the rest of the run without being re-read.
 					ConversationHistory = lastResult?.UpdatedHistory ?? seedHistory,
 					ConversationId = request.ConversationId,
-					TurnNumber = index + 1,
+
+					// Numbered across the conversation, not within the run. Per-turn observability rows
+					// are keyed by conversation and turn number, so a run that restarted at 1 would
+					// overwrite the first turns of the run before it (issue #255).
+					TurnNumber = conversationTotals.TurnCount + 1,
 					ObservabilitySessionId = dbSessionId
 				};
 
@@ -264,9 +298,12 @@ public class RunConversationCommandHandler : IRequestHandler<RunConversationComm
 					_logger.LogError("Conversation turn {Turn} failed for {AgentName}: {Error}",
 						index + 1, request.AgentName, lastResult.Error);
 
-					await _observabilityStore.EndSessionAsync(
-						dbSessionId, "error", lastResult.Error, cancellationToken);
-					sessionEnded = true;
+					if (ownsSession)
+					{
+						await _observabilityStore.EndSessionAsync(
+							dbSessionId, "error", lastResult.Error, cancellationToken);
+						sessionEnded = true;
+					}
 
 					return new ConversationResult
 					{
@@ -331,10 +368,13 @@ public class RunConversationCommandHandler : IRequestHandler<RunConversationComm
 
 				totalInputTokens += lastResult.InputTokens;
 				totalOutputTokens += lastResult.OutputTokens;
-				totalCacheRead += lastResult.CacheRead;
-				totalCacheWrite += lastResult.CacheWrite;
 				totalCostUsd += lastResult.CostUsd;
 				sessionModel ??= lastResult.Model;
+
+				conversationTotals = conversationTotals.Add(
+					lastResult.InputTokens, lastResult.OutputTokens,
+					lastResult.CacheRead, lastResult.CacheWrite,
+					lastResult.CostUsd, lastResult.ToolsInvoked.Count);
 
 				// Fold this turn's input+output into the conversation-lifetime budget (mirrors the
 				// per-turn TokenBudgetBehavior's accounting). The next loop iteration's gate decides
@@ -344,13 +384,23 @@ public class RunConversationCommandHandler : IRequestHandler<RunConversationComm
 					lastResult.InputTokens + lastResult.OutputTokens,
 					cancellationToken);
 
-				var totalInput = totalInputTokens + totalCacheRead;
-				var cacheHitRate = totalInput > 0 ? (decimal)totalCacheRead / totalInput : 0m;
-
+				// Cumulative, not this run's share. The session row is written with SET semantics against
+				// a row keyed one-per-conversation, so reporting the run's own totals here replaces the
+				// conversation's with whatever the most recent run happened to spend (issue #255).
 				await _observabilityStore.UpdateSessionMetricsAsync(
-					dbSessionId, index + 1, totalToolInvocations, 0,
-					totalInputTokens, totalOutputTokens, totalCacheRead, totalCacheWrite,
-					totalCostUsd, Math.Round(cacheHitRate, 4), sessionModel, cancellationToken);
+					dbSessionId,
+					conversationTotals.TurnCount, conversationTotals.ToolCallCount, subagentCount: 0,
+					conversationTotals.InputTokens, conversationTotals.OutputTokens,
+					conversationTotals.CacheRead, conversationTotals.CacheWrite,
+					conversationTotals.CostUsd, Math.Round(conversationTotals.CacheHitRate, 4),
+					sessionModel, cancellationToken);
+
+				// The conversation's own copy of the same totals. It is what the next run resumes from,
+				// and the only one that survives the observability database being absent or switched off,
+				// so it is written every turn rather than once at the end — a run that dies on its
+				// seventh turn leaves the two agreeing about the six that completed.
+				if (transcript is not null)
+					await transcript.PersistTelemetryAsync(dbSessionId, conversationTotals, cancellationToken);
 
 				if (request.OnProgress != null)
 				{
@@ -376,9 +426,12 @@ public class RunConversationCommandHandler : IRequestHandler<RunConversationComm
 			if (totalCostUsd > 0)
 				SessionMetrics.SessionCost.Record((double)totalCostUsd, agentTag);
 
-			await _observabilityStore.EndSessionAsync(
-				dbSessionId, "completed", null, cancellationToken);
-			sessionEnded = true;
+			if (ownsSession)
+			{
+				await _observabilityStore.EndSessionAsync(
+					dbSessionId, "completed", null, cancellationToken);
+				sessionEnded = true;
+			}
 
 			return new ConversationResult
 			{
@@ -396,7 +449,7 @@ public class RunConversationCommandHandler : IRequestHandler<RunConversationComm
 			// Caller cancellation (e.g. client disconnect) is routine, not exceptional.
 			// End the session as cancelled using a non-cancelled token so the cleanup
 			// write still completes, then rethrow to preserve cancellation semantics.
-			await EndSessionSafelyAsync(dbSessionId, "cancelled", null, sessionEnded);
+			await EndSessionSafelyAsync(dbSessionId, "cancelled", null, sessionEnded || !ownsSession);
 			sessionEnded = true;
 			throw;
 		}
@@ -430,14 +483,21 @@ public class RunConversationCommandHandler : IRequestHandler<RunConversationComm
 
 	/// <summary>
 	/// Ends the observability session defensively during exception/cancellation
-	/// handling: skips the write if the session was already ended on a normal
-	/// return path, uses a non-cancelled token so cleanup completes even when the
+	/// handling: uses a non-cancelled token so cleanup completes even when the
 	/// caller's token is cancelled, and never lets a cleanup failure mask the
 	/// original exception being propagated.
 	/// </summary>
-	private async Task EndSessionSafelyAsync(Guid sessionId, string status, string? reason, bool alreadyEnded)
+	/// <param name="sessionId">The session to end.</param>
+	/// <param name="status">The terminal status to record.</param>
+	/// <param name="reason">A scrubbed reason code, or <see langword="null"/>.</param>
+	/// <param name="alreadyHandled">
+	/// <see langword="true"/> when there is nothing left to do: either a normal return path already
+	/// ended the session, or this run does not own it because it is continuing a durable conversation
+	/// that outlives the run.
+	/// </param>
+	private async Task EndSessionSafelyAsync(Guid sessionId, string status, string? reason, bool alreadyHandled)
 	{
-		if (alreadyEnded)
+		if (alreadyHandled)
 			return;
 
 		try

--- a/src/Content/Presentation/Presentation.AgentHub/AgUi/AgUiRunHandler.cs
+++ b/src/Content/Presentation/Presentation.AgentHub/AgUi/AgUiRunHandler.cs
@@ -282,7 +282,13 @@ public sealed class AgUiRunHandler
         // Use a reasonable default — the hub reads this from config; we use 50 here
         // since AgUiRunHandler is not wired to AgentHubConfig directly.
         var history = await _conversationStore.GetHistoryForDispatch(input.ThreadId, callerId, 50, ct) ?? [];
-        var turnNumber = record.Messages.Count + 1;
+
+        // Counted from the conversation's completed turns, not its message count. Per-turn observability
+        // rows are keyed by conversation AND turn number, and the bundle-run path numbers the same
+        // conversation from the same counter (issue #255). Message count advances two per exchange, so
+        // it produced 1, 3, 5… here against 1, 2, 3… there — two writers interleaving into one key
+        // space, overwriting each other's turns on any conversation driven from both.
+        var turnNumber = (record.Telemetry?.TurnCount ?? 0) + 1;
 
         // Conversation-lifetime budget gate: decline gracefully (no LLM dispatch) when the
         // conversation has exhausted its cumulative ceiling, emitting the explanatory message as a

--- a/src/Content/Tests/Application.Core.Tests/CQRS/RunConversationDurableTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/CQRS/RunConversationDurableTests.cs
@@ -39,8 +39,15 @@ public sealed class RunConversationDurableTests
     private const string ConversationId = "conv-235";
     private const string Owner = "owner-1";
 
+    private static readonly Guid NewSessionId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    private static readonly Guid ExistingSessionId = Guid.Parse("22222222-2222-2222-2222-222222222222");
+
+    /// <summary>When each turn was dispatched, so writes can be ordered against turns.</summary>
+    private readonly List<int> _dispatchSequences = [];
+
     private readonly Mock<IMediator> _mediator = new();
     private readonly Mock<IConversationBudgetTracker> _budget = new();
+    private readonly Mock<IObservabilityStore> _observability = new();
     private readonly FakeConversationStore _store = new();
     private readonly FakeTurnLease _lease = new();
 
@@ -49,6 +56,13 @@ public sealed class RunConversationDurableTests
         _budget
             .Setup(b => b.GetStatusAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(ConversationBudgetStatus.Disabled);
+
+        // A store that answered Guid.Empty would make "the run adopted the session it found" and "the
+        // run opened one" indistinguishable, since both would end up writing against Empty.
+        _observability
+            .Setup(o => o.StartSessionAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(NewSessionId);
     }
 
     private RunConversationCommandHandler BuildSut(int maxHistoryMessages = 50) =>
@@ -56,11 +70,19 @@ public sealed class RunConversationDurableTests
             _mediator.Object,
             new Mock<IAgentConversationCache>().Object,
             _budget.Object,
-            new Mock<IObservabilityStore>().Object,
+            _observability.Object,
             _store,
             _lease,
             Options.Create(new ConversationsConfig { MaxHistoryMessages = maxHistoryMessages }),
             NullLogger<RunConversationCommandHandler>.Instance);
+
+    private static RunConversationCommand SelfContained(params string[] messages) => new()
+    {
+        AgentName = "TestAgent",
+        ConversationId = ConversationId,
+        UserMessages = messages.Length > 0 ? messages : ["hello"],
+        MaxTurns = 10
+    };
 
     private static RunConversationCommand Durable(params string[] messages) => new()
     {
@@ -396,6 +418,167 @@ public sealed class RunConversationDurableTests
             m => m.Send(It.IsAny<ExecuteAgentTurnCommand>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
+    // -- Telemetry continuity (issue #255) --
+
+    [Fact]
+    public async Task Handle_DurableRun_AddsToTheConversationsTotalsInsteadOfReplacingThem()
+    {
+        // The defect itself. The session row is keyed one-per-conversation and written with SET
+        // semantics, so a run reporting its own totals silently replaces everything spent before it —
+        // a conversation that has cost dollars reads as costing whatever its most recent run did.
+        _store.ObservabilitySessionId = ExistingSessionId;
+        _store.Telemetry = new TelemetryAccumulator(
+            TurnCount: 4, ToolCallCount: 3, InputTokens: 800, OutputTokens: 400,
+            CacheRead: 200, CacheWrite: 100, CostUsd: 1.50m);
+        SetupTurnsWithUsage(inputTokens: 10, outputTokens: 5, toolCalls: 1);
+
+        await BuildSut().Handle(Durable("one more"), CancellationToken.None);
+
+        _observability.Verify(o => o.UpdateSessionMetricsAsync(
+            ExistingSessionId,
+            5,      // turns:      4 + 1
+            4,      // tool calls: 3 + 1
+            0,
+            810,    // input:      800 + 10
+            405,    // output:     400 + 5
+            200, 100,
+            1.50m,  // this turn cost nothing, so the conversation's total is unchanged
+            It.IsAny<decimal>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()),
+            Times.Once,
+            "a run continues a conversation's spend; it does not restate it");
+    }
+
+    [Fact]
+    public async Task Handle_DurableRun_AdoptsTheSessionTheConversationAlreadyHas()
+    {
+        // Opening a session that exists does not create a second one — the row is unique per
+        // conversation, so the upsert restamps the first one's start time and every duration derived
+        // from it collapses to the latest run.
+        _store.ObservabilitySessionId = ExistingSessionId;
+        var dispatched = CaptureDispatchedTurns();
+
+        await BuildSut().Handle(Durable(), CancellationToken.None);
+
+        _observability.Verify(o => o.StartSessionAsync(
+            It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()),
+            Times.Never,
+            "the conversation already had a session, and it only ever gets one");
+        dispatched[0].ObservabilitySessionId.Should().Be(ExistingSessionId);
+    }
+
+    [Fact]
+    public async Task Handle_DurableRunOnAConversationWithNoSessionYet_OpensOneAndRecordsItBeforeTheFirstTurn()
+    {
+        // The control for the test above: the run does still open a session when there is none, so
+        // "never called StartSessionAsync" there is about the session being found, not about this
+        // handler having stopped opening sessions altogether.
+        //
+        // Recorded BEFORE the first turn, so a run that opens a session and then declines every turn
+        // on an exhausted budget still leaves the conversation pointing at it. Otherwise the next run
+        // opens another and restamps the clock.
+        var dispatched = CaptureDispatchedTurns();
+
+        await BuildSut().Handle(Durable(), CancellationToken.None);
+
+        _observability.Verify(o => o.StartSessionAsync(
+            ConversationId, "TestAgent", null, It.IsAny<CancellationToken>()), Times.Once);
+        dispatched[0].ObservabilitySessionId.Should().Be(NewSessionId);
+
+        _store.TelemetryWrites.Should().NotBeEmpty();
+        _store.TelemetryWrites[0].SessionId.Should().Be(NewSessionId);
+        _store.TelemetryWrites[0].Sequence.Should().BeLessThan(
+            _dispatchSequences[0], "the session is recorded before the first turn runs, not after it");
+    }
+
+    [Fact]
+    public async Task Handle_DurableRun_NumbersTurnsAcrossTheConversationNotWithinTheRun()
+    {
+        // Per-turn observability rows are keyed by conversation and turn number. A run that restarted
+        // its numbering at 1 would overwrite the opening turns of the run before it.
+        _store.Telemetry = TelemetryAccumulator.Zero with { TurnCount = 4 };
+        var dispatched = CaptureDispatchedTurns();
+
+        await BuildSut().Handle(Durable("fifth", "sixth"), CancellationToken.None);
+
+        dispatched.Select(d => d.TurnNumber).Should().Equal([5, 6]);
+    }
+
+    [Fact]
+    public async Task Handle_SelfContainedRun_NumbersTurnsFromOne()
+    {
+        // Control for the test above. A run with nothing behind it must still number from 1 — the
+        // change is "continue the conversation's count", not "add an offset from somewhere".
+        var dispatched = CaptureDispatchedTurns();
+
+        await BuildSut().Handle(SelfContained("first", "second"), CancellationToken.None);
+
+        dispatched.Select(d => d.TurnNumber).Should().Equal([1, 2]);
+    }
+
+    [Fact]
+    public async Task Handle_DurableRun_LeavesTheConversationsSessionOpen()
+    {
+        // A run finishing is not the conversation finishing. Ending the session here marks a
+        // conversation complete that the next run — or a user still typing in the interactive host —
+        // is about to continue.
+        _store.ObservabilitySessionId = ExistingSessionId;
+        SetupTurns("answer");
+
+        await BuildSut().Handle(Durable(), CancellationToken.None);
+
+        _observability.Verify(o => o.EndSessionAsync(
+            It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_SelfContainedRun_EndsTheSessionItOpened()
+    {
+        // Control for the test above, and the reason it is not simply "the handler no longer ends
+        // sessions": where the run IS the whole conversation, leaving the session open forever would
+        // be the regression.
+        SetupTurns("answer");
+
+        await BuildSut().Handle(SelfContained(), CancellationToken.None);
+
+        _observability.Verify(o => o.EndSessionAsync(
+            NewSessionId, "completed", null, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_DurableRun_WritesTheRunningTotalToTheConversationAfterEveryTurn()
+    {
+        // The conversation's own copy is what the next run resumes from, and the only one that
+        // survives the observability database being absent. Written per turn, not once at the end, so
+        // a run that dies mid-way leaves behind what it actually spent.
+        // Given an existing session so the only writes here are the per-turn ones. A conversation with
+        // no session yet also gets a registration write up front, which is asserted separately.
+        _store.ObservabilitySessionId = ExistingSessionId;
+        _store.Telemetry = TelemetryAccumulator.Zero with { InputTokens = 100 };
+        SetupTurnsWithUsage(inputTokens: 10, outputTokens: 5);
+
+        await BuildSut().Handle(Durable("one", "two"), CancellationToken.None);
+
+        _store.TelemetryWrites.Select(w => w.Telemetry.InputTokens).Should().Equal([110, 120]);
+        _store.TelemetryWrites.Should().OnlyContain(w => w.CallerId == Owner,
+            "the store enforces ownership on this write like every other");
+    }
+
+    [Fact]
+    public async Task Handle_DurableRun_ReadsTheConversationsTotalsUnderTheLease()
+    {
+        // Read before the lease, a run queued behind another host's run would carry totals taken
+        // before that run existed, add its own, and write back a sum missing everything the peer
+        // spent — deleting a peer's telemetry rather than reporting it late.
+        SetupTurns("answer");
+
+        await BuildSut().Handle(Durable(), CancellationToken.None);
+
+        _store.GetSequences.Should().ContainSingle("the totals are read once per run, not per turn");
+        _store.GetSequences[0].Should().BeGreaterThan(
+            _lease.AcquireSequence, "the totals must be read after the lease is held");
+    }
+
     // -- Helpers --
 
     private List<ExecuteAgentTurnCommand> CaptureDispatchedTurns()
@@ -408,6 +591,7 @@ public sealed class RunConversationDurableTests
                 ct.ThrowIfCancellationRequested();
                 _lease.NoteTurn();
                 dispatched.Add(cmd);
+                _dispatchSequences.Add(CallSequence.Next());
 
                 var response = $"answer {dispatched.Count}";
                 return Task.FromResult(new AgentTurnResult
@@ -423,6 +607,36 @@ public sealed class RunConversationDurableTests
                 });
             });
         return dispatched;
+    }
+
+    /// <summary>
+    /// Turns that report token usage, so the accumulation assertions have something to accumulate.
+    /// </summary>
+    private void SetupTurnsWithUsage(int inputTokens, int outputTokens, int toolCalls = 0)
+    {
+        _mediator
+            .Setup(m => m.Send(It.IsAny<ExecuteAgentTurnCommand>(), It.IsAny<CancellationToken>()))
+            .Returns((ExecuteAgentTurnCommand cmd, CancellationToken ct) =>
+            {
+                ct.ThrowIfCancellationRequested();
+                _lease.NoteTurn();
+                _dispatchSequences.Add(CallSequence.Next());
+
+                return Task.FromResult(new AgentTurnResult
+                {
+                    Success = true,
+                    Response = "answer",
+                    InputTokens = inputTokens,
+                    OutputTokens = outputTokens,
+                    ToolsInvoked = [.. Enumerable.Range(0, toolCalls).Select(i => $"tool-{i}")],
+                    UpdatedHistory =
+                    [
+                        .. cmd.ConversationHistory,
+                        new ChatMessage(ChatRole.User, cmd.UserMessage),
+                        new ChatMessage(ChatRole.Assistant, "answer")
+                    ]
+                });
+            });
     }
 
     private static ConversationMessage Message(MessageRole role, string content) =>
@@ -456,6 +670,17 @@ public sealed class RunConversationDurableTests
         public IReadOnlyList<ConversationMessage> History { get; set; } = [];
         public int GetOrCreateCalls { get; private set; }
         public int GetOrCreateSequence { get; private set; }
+
+        /// <summary>What the conversation has already spent, as a prior run left it.</summary>
+        public TelemetryAccumulator? Telemetry { get; set; }
+
+        /// <summary>The session a prior run opened for this conversation, if any.</summary>
+        public Guid? ObservabilitySessionId { get; set; }
+
+        public List<(string CallerId, Guid SessionId, TelemetryAccumulator Telemetry, int Sequence)>
+            TelemetryWrites { get; } = [];
+
+        public List<int> GetSequences { get; } = [];
 
         /// <summary>When set, the next open fails with this — the store's refusals, reproduced.</summary>
         public Exception? GetOrCreateThrows { get; set; }
@@ -518,8 +743,21 @@ public sealed class RunConversationDurableTests
             return Task.CompletedTask;
         }
 
-        public Task<ConversationRecord?> GetAsync(string conversationId, string callerId, CancellationToken ct = default) =>
-            throw new NotSupportedException();
+        public Task<ConversationRecord?> GetAsync(string conversationId, string callerId, CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            GetSequences.Add(CallSequence.Next());
+
+            return Task.FromResult<ConversationRecord?>(new ConversationRecord(
+                Id: conversationId,
+                AgentName: "TestAgent",
+                UserId: callerId,
+                CreatedAt: DateTimeOffset.UtcNow,
+                UpdatedAt: DateTimeOffset.UtcNow,
+                Messages: History,
+                ObservabilitySessionId: ObservabilitySessionId,
+                Telemetry: Telemetry));
+        }
         public Task<IReadOnlyList<ConversationRecord>> ListAsync(string userId, CancellationToken ct = default) =>
             throw new NotSupportedException();
         public Task<ConversationRecord> CreateAsync(string agentName, string userId, string? conversationId = null, CancellationToken ct = default) =>
@@ -530,8 +768,19 @@ public sealed class RunConversationDurableTests
             throw new NotSupportedException();
         public Task<ConversationRecord?> UpdateSettingsAsync(string conversationId, string callerId, ConversationSettings settings, CancellationToken ct = default) =>
             throw new NotSupportedException();
-        public Task<ConversationRecord?> UpdateTelemetryAsync(string conversationId, string callerId, Guid observabilitySessionId, TelemetryAccumulator telemetry, CancellationToken ct = default) =>
-            throw new NotSupportedException();
+        /// <remarks>
+        /// Records rather than applies: keeping <see cref="Telemetry"/> fixed is what lets a test set up
+        /// "the conversation has already spent this much" once and read every write the run made against
+        /// it, instead of chasing a value the run is mutating underneath the assertion.
+        /// </remarks>
+        public Task<ConversationRecord?> UpdateTelemetryAsync(
+            string conversationId, string callerId, Guid observabilitySessionId,
+            TelemetryAccumulator telemetry, CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            TelemetryWrites.Add((callerId, observabilitySessionId, telemetry, CallSequence.Next()));
+            return Task.FromResult<ConversationRecord?>(null);
+        }
     }
 
     /// <summary>A turn lease that records how it was used and can be made to lose itself mid-run.</summary>

--- a/src/Content/Tests/Application.Core.Tests/CQRS/RunConversationDurableTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/CQRS/RunConversationDurableTests.cs
@@ -93,31 +93,49 @@ public sealed class RunConversationDurableTests
         MaxTurns = 10
     };
 
-    private void SetupTurns(params string[] responses)
+    /// <summary>
+    /// The one place turns are stubbed. Every variant below supplies only what it varies — the
+    /// response and its usage — and inherits the three things every stub here must do.
+    /// </summary>
+    /// <remarks>
+    /// Those three are load-bearing and were previously repeated per stub, which is how they drifted:
+    /// honouring the token is what lets the lost-lease test observe a stopped run rather than one that
+    /// finished anyway; <c>NoteTurn</c> is what lets the lease count turns and drop itself between two
+    /// of them; and recording the dispatch sequence is what lets writes be ordered against turns. Two
+    /// of the three stubs recorded the sequence and one did not, so swapping stubs silently lost
+    /// ordering data from a test that still passed.
+    /// </remarks>
+    private void SetupTurnCore(Func<ExecuteAgentTurnCommand, AgentTurnResult> respond)
     {
-        var queue = new Queue<string>(responses);
         _mediator
             .Setup(m => m.Send(It.IsAny<ExecuteAgentTurnCommand>(), It.IsAny<CancellationToken>()))
             .Returns((ExecuteAgentTurnCommand cmd, CancellationToken ct) =>
             {
-                // Honouring the token is what lets the lost-lease test observe a stopped run rather
-                // than a run that finished anyway.
                 ct.ThrowIfCancellationRequested();
                 _lease.NoteTurn();
+                _dispatchSequences.Add(CallSequence.Next());
 
-                var response = queue.Count > 0 ? queue.Dequeue() : "done";
-                return Task.FromResult(new AgentTurnResult
-                {
-                    Success = true,
-                    Response = response,
-                    UpdatedHistory =
-                    [
-                        .. cmd.ConversationHistory,
-                        new ChatMessage(ChatRole.User, cmd.UserMessage),
-                        new ChatMessage(ChatRole.Assistant, response)
-                    ]
-                });
+                return Task.FromResult(respond(cmd));
             });
+    }
+
+    /// <summary>Builds a successful turn whose reply is <paramref name="response"/>.</summary>
+    private static AgentTurnResult Answer(ExecuteAgentTurnCommand cmd, string response) => new()
+    {
+        Success = true,
+        Response = response,
+        UpdatedHistory =
+        [
+            .. cmd.ConversationHistory,
+            new ChatMessage(ChatRole.User, cmd.UserMessage),
+            new ChatMessage(ChatRole.Assistant, response)
+        ]
+    };
+
+    private void SetupTurns(params string[] responses)
+    {
+        var queue = new Queue<string>(responses);
+        SetupTurnCore(cmd => Answer(cmd, queue.Count > 0 ? queue.Dequeue() : "done"));
     }
 
     // -- Continuity --
@@ -426,26 +444,67 @@ public sealed class RunConversationDurableTests
         // The defect itself. The session row is keyed one-per-conversation and written with SET
         // semantics, so a run reporting its own totals silently replaces everything spent before it —
         // a conversation that has cost dollars reads as costing whatever its most recent run did.
+        // Every figure is distinct, and every one this turn adds is distinct too, so a transposed pair
+        // of arguments anywhere in the chain shows up as a wrong number rather than an equal one.
         _store.ObservabilitySessionId = ExistingSessionId;
         _store.Telemetry = new TelemetryAccumulator(
             TurnCount: 4, ToolCallCount: 3, InputTokens: 800, OutputTokens: 400,
             CacheRead: 200, CacheWrite: 100, CostUsd: 1.50m);
-        SetupTurnsWithUsage(inputTokens: 10, outputTokens: 5, toolCalls: 1);
+        SetupTurnsWithUsage(
+            inputTokens: 10, outputTokens: 5, toolCalls: 1,
+            cacheRead: 7, cacheWrite: 3, costUsd: 0.25m);
 
         await BuildSut().Handle(Durable("one more"), CancellationToken.None);
 
         _observability.Verify(o => o.UpdateSessionMetricsAsync(
             ExistingSessionId,
-            5,      // turns:      4 + 1
-            4,      // tool calls: 3 + 1
+            5,      // turns:       4 + 1
+            4,      // tool calls:  3 + 1
             0,
-            810,    // input:      800 + 10
-            405,    // output:     400 + 5
-            200, 100,
-            1.50m,  // this turn cost nothing, so the conversation's total is unchanged
+            810,    // input:     800 + 10
+            405,    // output:    400 + 5
+            207,    // cacheRead: 200 + 7
+            103,    // cacheWrite:100 + 3
+            1.75m,  // cost:      1.50 + 0.25
             It.IsAny<decimal>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()),
             Times.Once,
             "a run continues a conversation's spend; it does not restate it");
+    }
+
+    [Fact]
+    public async Task Handle_DurableRunThatThrows_LeavesTheConversationsSessionOpen()
+    {
+        // The exception path is the one that was missed when each call site applied the ownership rule
+        // itself: a transient throw inside a durable run ended the whole conversation's session, and
+        // every later run then wrote metrics into a row already marked finished.
+        _store.ObservabilitySessionId = ExistingSessionId;
+        _mediator
+            .Setup(m => m.Send(It.IsAny<ExecuteAgentTurnCommand>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("the model client fell over"));
+
+        var act = () => BuildSut().Handle(Durable(), CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+        _observability.Verify(o => o.EndSessionAsync(
+            It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_SelfContainedRunThatThrows_EndsTheSessionItOpened()
+    {
+        // Control for the test above: where the run is the whole conversation, an unhandled failure
+        // must still close its session out, or a crashed run leaves a row active forever.
+        _mediator
+            .Setup(m => m.Send(It.IsAny<ExecuteAgentTurnCommand>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("the model client fell over"));
+
+        var act = () => BuildSut().Handle(SelfContained(), CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+        _observability.Verify(o => o.EndSessionAsync(
+            NewSessionId, "error", "conversation.unhandled_exception", It.IsAny<CancellationToken>()),
+            Times.Once);
     }
 
     [Fact]
@@ -584,60 +643,29 @@ public sealed class RunConversationDurableTests
     private List<ExecuteAgentTurnCommand> CaptureDispatchedTurns()
     {
         var dispatched = new List<ExecuteAgentTurnCommand>();
-        _mediator
-            .Setup(m => m.Send(It.IsAny<ExecuteAgentTurnCommand>(), It.IsAny<CancellationToken>()))
-            .Returns((ExecuteAgentTurnCommand cmd, CancellationToken ct) =>
-            {
-                ct.ThrowIfCancellationRequested();
-                _lease.NoteTurn();
-                dispatched.Add(cmd);
-                _dispatchSequences.Add(CallSequence.Next());
-
-                var response = $"answer {dispatched.Count}";
-                return Task.FromResult(new AgentTurnResult
-                {
-                    Success = true,
-                    Response = response,
-                    UpdatedHistory =
-                    [
-                        .. cmd.ConversationHistory,
-                        new ChatMessage(ChatRole.User, cmd.UserMessage),
-                        new ChatMessage(ChatRole.Assistant, response)
-                    ]
-                });
-            });
+        SetupTurnCore(cmd =>
+        {
+            dispatched.Add(cmd);
+            return Answer(cmd, $"answer {dispatched.Count}");
+        });
         return dispatched;
     }
 
     /// <summary>
     /// Turns that report token usage, so the accumulation assertions have something to accumulate.
     /// </summary>
-    private void SetupTurnsWithUsage(int inputTokens, int outputTokens, int toolCalls = 0)
-    {
-        _mediator
-            .Setup(m => m.Send(It.IsAny<ExecuteAgentTurnCommand>(), It.IsAny<CancellationToken>()))
-            .Returns((ExecuteAgentTurnCommand cmd, CancellationToken ct) =>
-            {
-                ct.ThrowIfCancellationRequested();
-                _lease.NoteTurn();
-                _dispatchSequences.Add(CallSequence.Next());
-
-                return Task.FromResult(new AgentTurnResult
-                {
-                    Success = true,
-                    Response = "answer",
-                    InputTokens = inputTokens,
-                    OutputTokens = outputTokens,
-                    ToolsInvoked = [.. Enumerable.Range(0, toolCalls).Select(i => $"tool-{i}")],
-                    UpdatedHistory =
-                    [
-                        .. cmd.ConversationHistory,
-                        new ChatMessage(ChatRole.User, cmd.UserMessage),
-                        new ChatMessage(ChatRole.Assistant, "answer")
-                    ]
-                });
-            });
-    }
+    private void SetupTurnsWithUsage(
+        int inputTokens, int outputTokens, int toolCalls = 0,
+        int cacheRead = 0, int cacheWrite = 0, decimal costUsd = 0m) =>
+        SetupTurnCore(cmd => Answer(cmd, "answer") with
+        {
+            InputTokens = inputTokens,
+            OutputTokens = outputTokens,
+            CacheRead = cacheRead,
+            CacheWrite = cacheWrite,
+            CostUsd = costUsd,
+            ToolsInvoked = [.. Enumerable.Range(0, toolCalls).Select(i => $"tool-{i}")],
+        });
 
     private static ConversationMessage Message(MessageRole role, string content) =>
         new(Guid.NewGuid(), role, content, DateTimeOffset.UtcNow);

--- a/src/Content/Tests/Infrastructure.AI.Tests/Conversations/DurableConversationContinuityTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Conversations/DurableConversationContinuityTests.cs
@@ -112,8 +112,28 @@ public sealed class DurableConversationContinuityTests : IDisposable
         var record = await _store.GetAsync(conversationId, Owner);
 
         record.Should().NotBeNull();
+
+        // "answer 2" for the second run, not "answer 1": the double answers with the turn number it was
+        // given, and turn numbering runs across the conversation rather than restarting each run.
         record!.Messages.Select(m => m.Content).Should().Equal(
-            "first", "answer 1", "second", "answer 1");
+            "first", "answer 1", "second", "answer 2");
+    }
+
+    [Fact]
+    public async Task TurnNumbering_ContinuesAcrossRuns()
+    {
+        // Against the real store, because this is the number per-turn observability rows are keyed by
+        // together with the conversation id. Restarting at 1 each run makes run 2's opening turn collide
+        // with run 1's and overwrite it (issue #255) — a collision no in-memory double would show.
+        var conversationId = $"conv-{Guid.NewGuid():N}";
+        var dispatched = new List<ExecuteAgentTurnCommand>();
+        var handler = BuildHandler(dispatched);
+
+        await handler.Handle(Durable(conversationId, "one"), CancellationToken.None);
+        await handler.Handle(Durable(conversationId, "two"), CancellationToken.None);
+        await handler.Handle(Durable(conversationId, "three"), CancellationToken.None);
+
+        dispatched.Select(d => d.TurnNumber).Should().Equal([1, 2, 3]);
     }
 
     [Fact]
@@ -150,8 +170,10 @@ public sealed class DurableConversationContinuityTests : IDisposable
         await handler.Handle(Durable(conversationId, "two"), CancellationToken.None);
         await handler.Handle(Durable(conversationId, "three"), CancellationToken.None);
 
+        // "answer 2" is the second run's reply — the double echoes the turn number it was handed, and
+        // that number now continues across runs rather than restarting.
         dispatched[2].ConversationHistory.Select(m => m.Text).Should().Equal(
-            "two", "answer 1");
+            "two", "answer 2");
 
         var record = await _store.GetAsync(conversationId, Owner);
         record!.Messages.Should().HaveCount(6, "the transcript keeps every turn the window does not replay");

--- a/src/Content/Tests/Presentation.AgentHub.Tests/AgUi/AgUiRunHandlerTests.cs
+++ b/src/Content/Tests/Presentation.AgentHub.Tests/AgUi/AgUiRunHandlerTests.cs
@@ -126,6 +126,10 @@ public sealed class AgUiRunHandlerTests
         const string userId = "user-1";
 
         var stale = MakeRecord(threadId, userId);
+
+        // The turn that landed while this one queued wrote BOTH halves of what it produces: the
+        // exchange, and the conversation's running telemetry. A fixture that advanced only the
+        // transcript would describe a state no completed turn can leave behind.
         var fresh = stale with
         {
             Messages =
@@ -133,6 +137,7 @@ public sealed class AgUiRunHandlerTests
                 new ConversationMessage(Guid.NewGuid(), MessageRole.User, "earlier", DateTimeOffset.UtcNow),
                 new ConversationMessage(Guid.NewGuid(), MessageRole.Assistant, "answered", DateTimeOffset.UtcNow),
             ],
+            Telemetry = TelemetryAccumulator.Zero with { TurnCount = 1 },
         };
 
         var mediator = new Mock<IMediator>();
@@ -158,9 +163,9 @@ public sealed class AgUiRunHandlerTests
         await handler.HandleRunAsync(MakeInput(threadId, "Hi"), new AgUiEventWriter(ms), MakeUser(userId));
 
         dispatched.Should().NotBeNull();
-        dispatched!.TurnNumber.Should().Be(fresh.Messages.Count + 1,
-            "the turn must be numbered from the transcript as it stands once the lease is held, not "
-            + "from the snapshot taken before waiting for it");
+        dispatched!.TurnNumber.Should().Be(fresh.Telemetry!.TurnCount + 1,
+            "the turn must be numbered from the conversation as it stands once the lease is held, not "
+            + "from the snapshot taken before waiting for it — the stale record would number this 1");
     }
 
     [Fact]


### PR DESCRIPTION
Closes #255.

## The issue's premise was wrong, and the truth is worse

#255 said each durable run opens its own observability session, so telemetry is never aggregated. The schema says otherwise: `sessions.conversation_id` is `TEXT NOT NULL UNIQUE` (`Dashboards/init-db/01-schema.sql:20`), and `StartSessionAsync` is `INSERT … ON CONFLICT (conversation_id) DO UPDATE SET started_at = NOW() RETURNING id`. A second run gets the **same** session id. There is one session row per conversation and there always has been.

So nothing was un-aggregated. A run counted from zero and wrote its own totals into a conversation-scoped row with SET semantics:

```
CAUSE:     Run-local totals written into a conversation-scoped row with SET semantics,
           so each run replaced the conversation's totals with its own share.
CONTROL:   The AG-UI interactive path, measured against the same store — it reads the
           conversation's running total, adds the turn, and writes the cumulative
           figure to the same SET-based call. Identical write, correct result.
COVERAGE:  Explains the reported symptom and three effects the issue did not name.
           Does NOT cover the SignalR path, which has the same defect — filed as #280.
```

Three effects #255 did not mention:

- **The clock reset.** The upsert restamped `started_at`, and both `EndSessionAsync` and `UpdateSessionMetricsAsync` derive `duration_ms` from it, so duration reported only the latest run.
- **Per-turn rows were overwritten.** `TurnNumber` restarted at 1 each run, and context snapshots are keyed `ON CONFLICT (conversation_id, turn_index) DO UPDATE`.
- **Two stores disagreed.** `ConversationRecord.Telemetry` — the field that exists to be the conversation-level accumulator — was never read or written on this path.

## Decision

The parked decision ("should a run be its own session?") had already been made by the schema: it cannot be, without dropping that UNIQUE constraint and reworking the dashboard read side. Confirmed with Matt: **keep one row per conversation and fix the writer.** Per-run breakdown is not wanted; the per-turn `session_messages` rows still carry it.

## What changed

**`RunConversationCommandHandler`** — a durable run now adopts the session the conversation already has, resumes its totals, adds each turn, and writes the cumulative figure to both the session row and the conversation record. Turn numbers continue across the conversation. It no longer ends the session: a run finishing is not the conversation finishing, which is what the interactive transports have always assumed.

A self-contained run is unchanged in every respect — it opens a session, counts from zero, and ends it, because there the run *is* the whole conversation. Every new behaviour has that control asserted next to it.

**`DurableTranscript`** — gained `LoadTelemetryAsync` and `PersistTelemetryAsync`. The read is deliberately **under the turn lease**, for the same reason the replay window already was: a run that queued behind another host would otherwise carry totals taken before that host's run existed, add its own, and write back a sum missing everything the peer spent — deleting a peer's telemetry rather than reporting it late.

**`AgUiRunHandler`** — turn numbering moved from `record.Messages.Count + 1` to the conversation's turn counter. Message count advances two per exchange, so it produced 1, 3, 5… against the bundle path's 1, 2, 3… — two writers interleaving into one key space. Both now count the same thing.

**`TelemetryAccumulator.Since`** — new. Lets the handler keep one running total and derive the run's own share by subtraction instead of accumulating the same turns twice. Two counters over one event stream are two chances to disagree, which is the whole of this bug.

## Verification

Full solution green. Every new guard mutation-tested — the behaviour was broken on purpose and the matching test watched to fail:

| mutation | result |
|---|---|
| write run-local totals into the session row (the original defect) | RED — accumulation test |
| always open a new session | RED — 3 tests |
| restart turn numbering each run | RED — unit + end-to-end |
| let a durable run end the conversation's session | RED — success and exception paths |
| skip the per-turn write to the conversation | RED |
| drop the session-ownership guard | RED — 2 tests |
| restore AG-UI's message-count numbering | RED — the re-read test |

Two existing end-to-end tests changed expectation. Their double answers with the turn number it is handed, so a second run's reply is now "answer 2" rather than "answer 1" — the assertions were incidentally coupled to per-run numbering. `TurnNumbering_ContinuesAcrossRuns` was added against the real store to assert that directly rather than by accident.

## Found by review, fixed here

- The ownership rule was applied at four call sites and **missed at the exception path**, so a transient throw ended a live conversation's session. The rule now lives in one place that every path goes through — it was missed precisely because it lived at four.
- The per-turn write to the conversation was unguarded while the interactive host swallows the same failure. A telemetry write must not fail a turn whose answer is already in the transcript.
- The accumulation test used turns with zero cache usage, so a transposed argument pair would have passed. Every figure is now distinct.

## Found by review, filed not fixed

**#280** — the SignalR path (`ConversationOrchestrator`) has the same overwrite defect from per-connection totals, restamps `started_at`, and computes the cache hit rate with a different denominator. Three writers now implement one policy independently and have drifted four ways. That wants a shared recorder, which is a larger change than this issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
