### PR TITLE
feat: disclose the conversation token ceiling at startup

### DIFF
--- a/src/Content/Application/Application.AI.Common/Services/AI/InProcessConversationBudgetTracker.cs
+++ b/src/Content/Application/Application.AI.Common/Services/AI/InProcessConversationBudgetTracker.cs
@@ -26,7 +26,9 @@ namespace Application.AI.Common.Services.AI;
 /// below. When the configured ceiling is ≤ 0 the tracker is instead inert:
 /// <see cref="GetStatusAsync"/> returns <see cref="ConversationBudgetStatus.Disabled"/> and
 /// <see cref="RecordUsageAsync"/> stores nothing, so conversations run unbounded across turns and this
-/// type costs nothing. Reaching that state takes a deliberate <c>0</c> in configuration.
+/// type costs nothing. Reaching that state takes a deliberate <c>0</c> in configuration, and a host that
+/// does is told so at startup — <c>ConversationBudgetStartupDisclosure</c> warns that conversations are
+/// unbounded, because this type going quietly inert is how the ceiling shipped switched off (issue #279).
 /// </para>
 /// <para>
 /// <strong>Bounded memory.</strong> A long-lived interactive host can see many conversations and there is

--- a/src/Content/Infrastructure/Infrastructure.AI/Conversations/ConversationBudgetStartupDisclosure.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Conversations/ConversationBudgetStartupDisclosure.cs
@@ -1,0 +1,84 @@
+using Domain.Common.Config;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Infrastructure.AI.Conversations;
+
+/// <summary>
+/// States at startup whether conversations are bounded by a lifetime token ceiling, and at what figure.
+/// A ceiling of zero or less is reported as a warning, because it means conversations run unbounded.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The two budget trackers go inert when the configured ceiling is not positive: status reads return
+/// <c>Disabled</c>, usage is not recorded, and every conversation runs without a ceiling. Nothing said
+/// so. That silence is not a cosmetic gap — it is how the budget came to ship switched off in the first
+/// place (issue #256), survive a fully green test suite, and reach a published contract that named it as
+/// the only thing bounding a durable conversation's length.
+/// </para>
+/// <para>
+/// The enabled case is disclosed too, at information level. An operator reading startup output should be
+/// able to see what ceiling is actually in force without going to look for the configuration, since the
+/// value that matters is the one the process resolved rather than the one any single file happens to
+/// contain.
+/// </para>
+/// <para>
+/// Read once, at startup, which is the moment that answers "what did this deployment ship with". The
+/// ceiling is read live by the trackers, so a configuration reload takes effect without restarting —
+/// this will not report that, and deliberately does not subscribe to change notifications to say so.
+/// A running host quietly losing its ceiling is a different and much rarer failure than a deployment
+/// that never had one, and watching for it would mean holding a subscription for the process lifetime
+/// to report something no deployment does on purpose.
+/// </para>
+/// </remarks>
+internal sealed class ConversationBudgetStartupDisclosure : IHostedService
+{
+    private readonly IOptionsMonitor<AppConfig> _options;
+    private readonly ILogger<ConversationBudgetStartupDisclosure> _logger;
+
+    /// <summary>Initializes a new <see cref="ConversationBudgetStartupDisclosure"/>.</summary>
+    /// <param name="options">Supplies the configured conversation token ceiling.</param>
+    /// <param name="logger">Receives the disclosure.</param>
+    public ConversationBudgetStartupDisclosure(
+        IOptionsMonitor<AppConfig> options,
+        ILogger<ConversationBudgetStartupDisclosure> logger)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _options = options;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        var ceiling = _options.CurrentValue.AI.AgentFramework.ConversationTokenBudget;
+
+        if (ceiling > 0)
+        {
+            _logger.LogInformation(
+                "Conversations are bounded at {ConversationTokenBudget} cumulative tokens "
+                + "(AppConfig:AI:AgentFramework:ConversationTokenBudget). A conversation that reaches "
+                + "the ceiling declines further turns; a plan run that reaches it fails the step as a "
+                + "policy denial.",
+                ceiling);
+
+            return Task.CompletedTask;
+        }
+
+        _logger.LogWarning(
+            "Conversations are running WITHOUT a lifetime token ceiling "
+            + "(AppConfig:AI:AgentFramework:ConversationTokenBudget={ConversationTokenBudget}). Per-run "
+            + "limits bound a single run, and a durable conversation outlives any run, so nothing bounds "
+            + "how many tokens one conversation can spend in total. This is a deliberate opt-out — set a "
+            + "positive value to restore the ceiling.",
+            ceiling);
+
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Conversations/SqliteConversationBudgetTracker.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Conversations/SqliteConversationBudgetTracker.cs
@@ -36,7 +36,9 @@ namespace Infrastructure.AI.Conversations;
 /// <strong>On by default, switchable off.</strong> The ceiling comes from configuration, which defaults
 /// to a positive value, so a stock deployment is bounded and does write rows here. When the configured
 /// ceiling is ≤ 0 the tracker is instead inert and touches no database at all. Reaching that state takes
-/// a deliberate <c>0</c> in configuration.
+/// a deliberate <c>0</c> in configuration, and a host that does is told so at startup —
+/// <see cref="ConversationBudgetStartupDisclosure"/> warns that conversations are unbounded, because
+/// this type going quietly inert is how the ceiling shipped switched off (issue #279).
 /// </para>
 /// <para>
 /// <strong>Retention.</strong> Rows are removed only by <see cref="ReleaseAsync"/>, and the two

--- a/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.Conversations.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.Conversations.cs
@@ -49,6 +49,13 @@ public static partial class DependencyInjection
         // Application.Common, and TryAdd lets whichever ran first win rather than fighting over it.
         services.TryAddSingleton(TimeProvider.System);
 
+        // Registered for both providers, and unconditionally rather than only when the ceiling is off.
+        // Deciding here which message applies would put the condition in one file and the wording in
+        // another, and the two would drift; the disclosure reads the configuration itself and says what
+        // it finds. Both trackers fall silent below a positive ceiling, which is how the budget shipped
+        // switched off and stayed unnoticed (issues #256, #279).
+        services.AddHostedService<ConversationBudgetStartupDisclosure>();
+
         if (appConfig.AI.Conversations.Provider == ConversationStoreProvider.FileSystem)
         {
             services.AddSingleton<IConversationStore, FileSystemConversationStore>();

--- a/src/Content/Tests/Infrastructure.AI.Tests/Conversations/ConversationBudgetStartupDisclosureTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Conversations/ConversationBudgetStartupDisclosureTests.cs
@@ -35,7 +35,7 @@ public sealed class ConversationBudgetStartupDisclosureTests
     }
 
     [Fact]
-    public async Task StartAsync_NegativeCeiling_WarnsToo()
+    public async Task StartAsync_NegativeCeiling_WarnsThatConversationsAreUnbounded()
     {
         // The trackers go inert at anything not positive, not only at exactly zero. A disclosure that
         // tested for zero would stay quiet on the one value a fat-fingered edit is most likely to leave.

--- a/src/Content/Tests/Infrastructure.AI.Tests/Conversations/ConversationBudgetStartupDisclosureTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Conversations/ConversationBudgetStartupDisclosureTests.cs
@@ -1,0 +1,118 @@
+using Domain.Common.Config;
+using FluentAssertions;
+using Infrastructure.AI.Conversations;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Conversations;
+
+/// <summary>
+/// The startup disclosure that says whether conversations are bounded, and at what figure.
+/// </summary>
+/// <remarks>
+/// The point of this type is that a deployment running without a ceiling cannot do so quietly, so these
+/// tests assert on the <em>level</em> as much as the content: an operator scanning for warnings is the
+/// reader it exists for, and an unbounded deployment reported at information level would be exactly the
+/// silence it was written to end.
+/// </remarks>
+public sealed class ConversationBudgetStartupDisclosureTests
+{
+    [Fact]
+    public async Task StartAsync_CeilingDisabled_WarnsThatConversationsAreUnbounded()
+    {
+        var (disclosure, logger) = Build(ceiling: 0);
+
+        await disclosure.StartAsync(CancellationToken.None);
+
+        var entry = logger.Single();
+        entry.Level.Should().Be(LogLevel.Warning,
+            "an unbounded deployment reported at information level is the silence this exists to end");
+        entry.Message.Should().Contain("WITHOUT a lifetime token ceiling");
+        entry.Message.Should().Contain("AppConfig:AI:AgentFramework:ConversationTokenBudget",
+            "the reader has to be told which setting to change, not just that something is off");
+    }
+
+    [Fact]
+    public async Task StartAsync_NegativeCeiling_WarnsToo()
+    {
+        // The trackers go inert at anything not positive, not only at exactly zero. A disclosure that
+        // tested for zero would stay quiet on the one value a fat-fingered edit is most likely to leave.
+        var (disclosure, logger) = Build(ceiling: -1);
+
+        await disclosure.StartAsync(CancellationToken.None);
+
+        logger.Single().Level.Should().Be(LogLevel.Warning);
+    }
+
+    [Fact]
+    public async Task StartAsync_CeilingConfigured_ReportsTheFigureWithoutWarning()
+    {
+        // The control. Without it, "warns when disabled" would also pass for a disclosure that warned
+        // unconditionally — which would train operators to ignore it.
+        var (disclosure, logger) = Build(ceiling: 250_000);
+
+        await disclosure.StartAsync(CancellationToken.None);
+
+        var entry = logger.Single();
+        entry.Level.Should().Be(LogLevel.Information);
+        entry.Message.Should().Contain("250000", "an operator must be able to see the ceiling in force");
+    }
+
+    [Fact]
+    public async Task StartAsync_StockConfiguration_ReportsBounded()
+    {
+        // Nothing configured at all — the shipped default, which is on. This is the test that would have
+        // caught #256: every other test here states a ceiling, and a default nobody constructs untouched
+        // is a default nothing measures.
+        var (disclosure, logger) = Build(new AppConfig());
+
+        await disclosure.StartAsync(CancellationToken.None);
+
+        logger.Single().Level.Should().Be(LogLevel.Information,
+            "a stock deployment is bounded, so it must not warn");
+    }
+
+    private static (ConversationBudgetStartupDisclosure Disclosure, RecordingLogger Logger) Build(int ceiling)
+    {
+        var config = new AppConfig();
+        config.AI.AgentFramework.ConversationTokenBudget = ceiling;
+        return Build(config);
+    }
+
+    private static (ConversationBudgetStartupDisclosure Disclosure, RecordingLogger Logger) Build(AppConfig config)
+    {
+        var logger = new RecordingLogger();
+        var disclosure = new ConversationBudgetStartupDisclosure(
+            Mock.Of<IOptionsMonitor<AppConfig>>(m => m.CurrentValue == config),
+            logger);
+
+        return (disclosure, logger);
+    }
+
+    /// <summary>
+    /// Captures level and rendered message. Hand-rolled rather than mocked because every assertion here
+    /// is about what an operator would actually read, which a rendered string states directly and a
+    /// verification on a structured-logging call shape does not.
+    /// </summary>
+    private sealed class RecordingLogger : ILogger<ConversationBudgetStartupDisclosure>
+    {
+        private readonly List<(LogLevel Level, string Message)> _entries = [];
+
+        public (LogLevel Level, string Message) Single()
+        {
+            _entries.Should().ContainSingle("the disclosure speaks once at startup, not per branch");
+            return _entries[0];
+        }
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+            Func<TState, Exception?, string> formatter) =>
+            _entries.Add((logLevel, formatter(state, exception)));
+    }
+}

--- a/src/Content/Tests/Presentation.Common.Tests/Composition/ConversationStoreCompositionTests.cs
+++ b/src/Content/Tests/Presentation.Common.Tests/Composition/ConversationStoreCompositionTests.cs
@@ -4,6 +4,7 @@ using FluentAssertions;
 using Infrastructure.AI.Conversations;
 using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Xunit;
 
 namespace Presentation.Common.Tests.Composition;
@@ -68,6 +69,20 @@ public sealed class ConversationStoreCompositionTests : IDisposable
         store.Should().NotBeNull(
             "the transcript store is shared infrastructure — a registration only one host can reach "
             + "is the defect issue #235 exists to fix");
+    }
+
+    [Fact]
+    public async Task CompositionRoot_RegistersTheBudgetDisclosure_ForEveryHost()
+    {
+        // The disclosure exists so a deployment running without a token ceiling cannot do so quietly
+        // (issue #279). Its own unit tests drive it directly, so they stay green with the registration
+        // deleted — and an unregistered hosted service is silent, which is the exact failure it was
+        // written to end. This is the assertion that makes the registration load-bearing.
+        await using var provider = CompositionRootTestHost.BuildProvider(SqliteSettings());
+
+        provider.GetServices<IHostedService>()
+            .Should().Contain(s => s.GetType().Name == "ConversationBudgetStartupDisclosure",
+                "a disclosure nothing resolves discloses nothing");
     }
 
     [Fact]


### PR DESCRIPTION
Closes #279.

## The problem

Both conversation budget trackers go inert when the configured ceiling is not positive: status reads return `Disabled`, usage is not recorded, and every conversation runs unbounded. Nothing said so anywhere — no log, no metric, no startup line.

That silence is not cosmetic. It is how the budget came to ship switched off (#256), survive a fully green test suite, and reach a published API contract that named it as the only thing bounding a durable conversation's total length. An operator had no way to know their deployment was unbounded short of reading the source of two trackers.

## What changed

A hosted service that states the position at startup, following the repo's existing convention for "a safety control is off, say so where an operator will see it" — the same shape as `ExecutionApiAnonymousModeStartupWarning`, `McpAnonymousModeStartupWarning`, and `EscalationApiMutableClaimStartupWarning`.

- **Ceiling not positive** → warning naming the exact config key and saying conversations are unbounded.
- **Ceiling configured** → information line stating the figure actually in force, and what happens at the ceiling on each of the two paths (a conversation declines its next turn; a plan run fails the step as a policy denial).

Registered next to the trackers themselves, so every host that resolves a budget tracker gets it. Verified: `RegisterConversationStore` ← `AddInfrastructureAIDependencies` ← `AddGlobalProjectDependencies` ← the one shared composition root, and all five hosts run hosted services (the two web hosts via `WebApplication`; ConsoleUI, EvalRunner and FoundryHost each enumerate `IHostedService` and start them explicitly).

## Two design choices worth naming

**Registered unconditionally, deciding its own message.** Putting the condition in the DI file and the wording in the service would let the two drift, and only an unconditional registration can emit the "bounded at N" line at all. Registration-time config is also a snapshot, whereas `IOptionsMonitor.CurrentValue` at start is what the process actually resolved.

**Startup rather than per-call.** Logging from the tracker constructors fires per construction; logging lazily on the first disabled status means an idle deployment never discloses anything, which is the same silence again. Startup is the moment that answers "what did this deployment ship with".

## Declined, deliberately

- **Watching for a reload to zero.** The ceiling is read live, so a config reload takes effect without a restart and this will not report that. A running host quietly losing its ceiling is a rarer and different failure from a deployment that never had one, and catching it means holding a change subscription for the process lifetime. The class remarks say so rather than leaving a reader to wonder.
- **A metric or health-check contribution.** The disclosure answers "what did we ship with", which is a startup question. A gauge answers "what is true now", which is the reload case above. Not worth a second mechanism until something asks for it.

## Verification

Full solution green. Mutation-tested:

| mutation | result |
|---|---|
| treat a zero ceiling as bounded (`> 0` → `>= 0`) | RED — the disabled test |
| delete the DI registration entirely | RED — the new composition test |

That second one is the finding the review earned. The four unit tests drive the disclosure directly, so **all of them stayed green with the registration deleted** — an unregistered hosted service is silent, which is precisely the failure this issue is about. `ConversationStoreCompositionTests` exists because host-level suites had the same blind spot once before; the assertion now lives there.

The unit tests include a `new AppConfig()` case with nothing configured at all — the shape of test that would have caught #256, where a default nobody constructs untouched is a default nothing measures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
