### PR TITLE
test: serialise environment-variable tests and keep state out of the build output

### DIFF
--- a/src/Content/Tests/Infrastructure.AI.Tests/BuildOutputStaysCleanTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/BuildOutputStaysCleanTests.cs
@@ -14,30 +14,34 @@ namespace Infrastructure.AI.Tests;
 /// it eventually presents as a product regression that reproduces on one machine and nowhere else.
 /// </para>
 /// <para>
-/// <strong>Ordering does not matter and must not.</strong> This asserts on files, and any test that
-/// creates one has already created it by the time this runs — or will, and then this fails on the next
-/// run. It is deliberately not a "run me last" test, because a test that only works in one position is
-/// a test that stops working.
+/// <strong>Ordering does matter, and the runner is what guarantees it.</strong> This sits in a
+/// <c>DisableParallelization</c> collection, and xUnit runs those only once every parallel collection
+/// has finished — so the tests that register stores have all run by the time this reads the directory.
+/// An earlier draft left it unattributed on the reasoning that a leak would simply fail the next run.
+/// That reasoning holds on a developer machine and fails exactly where it matters: CI starts from a
+/// clean checkout every time, so "the next run" never sees it, and the guard was a coin flip against
+/// the very tests it exists to police.
 /// </para>
 /// </remarks>
+[Collection(SerialTailCollection.Name)]
 public sealed class BuildOutputStaysCleanTests
 {
     [Fact]
     public void NoDatabaseIsWrittenIntoTheBuildOutput()
     {
-        var dataDirectory = Path.Combine(AppContext.BaseDirectory, "data");
+        var baseDirectory = AppContext.BaseDirectory;
 
-        // Absent is the normal outcome; present-but-empty is also fine, because registration creates the
-        // directory eagerly for a path it may never write to. Only actual state is the defect.
-        var leftBehind = Directory.Exists(dataDirectory)
-            ? Directory.GetFiles(dataDirectory, "*", SearchOption.AllDirectories)
-            : [];
+        // Every database anywhere under the build output, not just the `data` folder the two known
+        // offenders used. A config path that resolves to empty lands its file at the build-output root
+        // instead, which a folder-scoped check would never see — and an empty path is precisely what a
+        // regression in the isolation helper would produce.
+        var leftBehind = Directory.GetFiles(baseDirectory, "*.db", SearchOption.AllDirectories);
 
         leftBehind.Should().BeEmpty(
-            $"state under AppContext.BaseDirectory is never cleared between runs, so it accumulates "
-            + $"invisibly on a developer machine and shows up as a product regression CI cannot "
-            + $"reproduce. Either a test registered a store without building its config through "
-            + $"IsolatedAppConfig, or this machine still holds state from a run predating that helper "
-            + $"— delete '{dataDirectory}' and run again to tell the two apart");
+            "state under AppContext.BaseDirectory is never cleared between runs, so it accumulates "
+            + "invisibly on a developer machine and shows up as a product regression CI cannot "
+            + "reproduce. Either a test registered a store without building its config through "
+            + $"IsolatedAppConfig, or this machine still holds state from a run predating that helper — "
+            + $"delete the databases under '{baseDirectory}' and run again to tell the two apart");
     }
 }

--- a/src/Content/Tests/Infrastructure.AI.Tests/BuildOutputStaysCleanTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/BuildOutputStaysCleanTests.cs
@@ -1,0 +1,43 @@
+using FluentAssertions;
+using Xunit;
+
+namespace Infrastructure.AI.Tests;
+
+/// <summary>
+/// This assembly must not persist anything into its own build output.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Issue #262, and #250 and #259 before it. State written under <c>AppContext.BaseDirectory</c> is never
+/// cleared between runs, so it accumulates across every run a developer has ever done on that machine.
+/// CI never sees it, because CI starts from a clean checkout — which is exactly why it survives, and why
+/// it eventually presents as a product regression that reproduces on one machine and nowhere else.
+/// </para>
+/// <para>
+/// <strong>Ordering does not matter and must not.</strong> This asserts on files, and any test that
+/// creates one has already created it by the time this runs — or will, and then this fails on the next
+/// run. It is deliberately not a "run me last" test, because a test that only works in one position is
+/// a test that stops working.
+/// </para>
+/// </remarks>
+public sealed class BuildOutputStaysCleanTests
+{
+    [Fact]
+    public void NoDatabaseIsWrittenIntoTheBuildOutput()
+    {
+        var dataDirectory = Path.Combine(AppContext.BaseDirectory, "data");
+
+        // Absent is the normal outcome; present-but-empty is also fine, because registration creates the
+        // directory eagerly for a path it may never write to. Only actual state is the defect.
+        var leftBehind = Directory.Exists(dataDirectory)
+            ? Directory.GetFiles(dataDirectory, "*", SearchOption.AllDirectories)
+            : [];
+
+        leftBehind.Should().BeEmpty(
+            $"state under AppContext.BaseDirectory is never cleared between runs, so it accumulates "
+            + $"invisibly on a developer machine and shows up as a product regression CI cannot "
+            + $"reproduce. Either a test registered a store without building its config through "
+            + $"IsolatedAppConfig, or this machine still holds state from a run predating that helper "
+            + $"— delete '{dataDirectory}' and run again to tell the two apart");
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/DependencyInjectionTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/DependencyInjectionTests.cs
@@ -22,7 +22,7 @@ public sealed class DependencyInjectionTests
 {
     private static ServiceCollection CreateBaseServices(AppConfig? appConfig = null)
     {
-        var config = appConfig ?? new AppConfig();
+        var config = IsolatedAppConfig.Isolate(appConfig ?? new AppConfig());
         var services = new ServiceCollection();
 
         // Register dependencies that Infrastructure.AI expects
@@ -45,7 +45,7 @@ public sealed class DependencyInjectionTests
     public void AddInfrastructureAIDependencies_RegistersIChatClientFactory()
     {
         var services = CreateBaseServices();
-        services.AddInfrastructureAIDependencies(new AppConfig());
+        services.AddInfrastructureAIDependencies(IsolatedAppConfig.Create());
         using var provider = services.BuildServiceProvider();
 
         var factory = provider.GetService<IChatClientFactory>();
@@ -57,7 +57,7 @@ public sealed class DependencyInjectionTests
     public void AddInfrastructureAIDependencies_RegistersIToolPermissionService()
     {
         var services = CreateBaseServices();
-        services.AddInfrastructureAIDependencies(new AppConfig());
+        services.AddInfrastructureAIDependencies(IsolatedAppConfig.Create());
         using var provider = services.BuildServiceProvider();
 
         var permissionService = provider.GetService<IToolPermissionService>();
@@ -69,7 +69,7 @@ public sealed class DependencyInjectionTests
     public void AddInfrastructureAIDependencies_RegistersISkillMetadataRegistry()
     {
         var services = CreateBaseServices();
-        services.AddInfrastructureAIDependencies(new AppConfig());
+        services.AddInfrastructureAIDependencies(IsolatedAppConfig.Create());
         using var provider = services.BuildServiceProvider();
 
         var registry = provider.GetService<ISkillMetadataRegistry>();
@@ -80,7 +80,7 @@ public sealed class DependencyInjectionTests
     [Fact]
     public void RegisterAIClients_UnconfiguredConfig_DoesNotRegisterAnyClients()
     {
-        var config = new AppConfig(); // ApiKey is null => IsConfigured = false
+        var config = IsolatedAppConfig.Create(); // ApiKey is null => IsConfigured = false
         var services = CreateBaseServices(config);
         services.AddInfrastructureAIDependencies(config);
         using var provider = services.BuildServiceProvider();
@@ -95,7 +95,7 @@ public sealed class DependencyInjectionTests
     public void AddInfrastructureAIDependencies_RegistersIEscalationService()
     {
         var services = CreateBaseServices();
-        services.AddInfrastructureAIDependencies(new AppConfig());
+        services.AddInfrastructureAIDependencies(IsolatedAppConfig.Create());
         using var provider = services.BuildServiceProvider();
 
         var svc = provider.GetService<IEscalationService>();
@@ -107,7 +107,7 @@ public sealed class DependencyInjectionTests
     public void AddInfrastructureAIDependencies_RegistersIEscalationAuditStore()
     {
         var services = CreateBaseServices();
-        services.AddInfrastructureAIDependencies(new AppConfig());
+        services.AddInfrastructureAIDependencies(IsolatedAppConfig.Create());
         using var provider = services.BuildServiceProvider();
 
         var store = provider.GetService<IEscalationAuditStore>();
@@ -119,7 +119,7 @@ public sealed class DependencyInjectionTests
     public void AddInfrastructureAIDependencies_RegistersIEscalationNotifier()
     {
         var services = CreateBaseServices();
-        services.AddInfrastructureAIDependencies(new AppConfig());
+        services.AddInfrastructureAIDependencies(IsolatedAppConfig.Create());
         using var provider = services.BuildServiceProvider();
 
         var notifier = provider.GetService<IEscalationNotifier>();
@@ -131,7 +131,7 @@ public sealed class DependencyInjectionTests
     public void AddInfrastructureAIDependencies_RegistersNotificationChannels()
     {
         var services = CreateBaseServices();
-        services.AddInfrastructureAIDependencies(new AppConfig());
+        services.AddInfrastructureAIDependencies(IsolatedAppConfig.Create());
         using var provider = services.BuildServiceProvider();
 
         var channels = provider.GetServices<IEscalationNotificationChannel>().ToList();
@@ -144,7 +144,7 @@ public sealed class DependencyInjectionTests
     public void AddInfrastructureAIDependencies_RegistersIProviderHealthMonitor()
     {
         var services = CreateBaseServices();
-        services.AddInfrastructureAIDependencies(new AppConfig());
+        services.AddInfrastructureAIDependencies(IsolatedAppConfig.Create());
         using var provider = services.BuildServiceProvider();
 
         var monitor = provider.GetService<IProviderHealthMonitor>();
@@ -156,7 +156,7 @@ public sealed class DependencyInjectionTests
     public void AddInfrastructureAIDependencies_RegistersIResilientChatClientProvider()
     {
         var services = CreateBaseServices();
-        services.AddInfrastructureAIDependencies(new AppConfig());
+        services.AddInfrastructureAIDependencies(IsolatedAppConfig.Create());
         using var provider = services.BuildServiceProvider();
 
         var resilientProvider = provider.GetService<IResilientChatClientProvider>();
@@ -167,7 +167,7 @@ public sealed class DependencyInjectionTests
     [Fact]
     public void AddInfrastructureAIDependencies_ResilienceEnabled_RegistersLlmRetryQueueHostedService()
     {
-        var config = new AppConfig { AI = { Resilience = new ResilienceConfig { Enabled = true } } };
+        var config = IsolatedAppConfig.Isolate(new AppConfig { AI = { Resilience = new ResilienceConfig { Enabled = true } } });
         var services = CreateBaseServices(config);
         services.AddSingleton(TimeProvider.System);
         services.AddInfrastructureAIDependencies(config);
@@ -181,7 +181,7 @@ public sealed class DependencyInjectionTests
     [Fact]
     public void AddInfrastructureAIDependencies_ResilienceDisabled_DoesNotRegisterLlmRetryQueueHostedService()
     {
-        var config = new AppConfig { AI = { Resilience = new ResilienceConfig { Enabled = false } } };
+        var config = IsolatedAppConfig.Isolate(new AppConfig { AI = { Resilience = new ResilienceConfig { Enabled = false } } });
         var services = CreateBaseServices(config);
         services.AddInfrastructureAIDependencies(config);
         using var provider = services.BuildServiceProvider();
@@ -195,7 +195,7 @@ public sealed class DependencyInjectionTests
     public void AddInfrastructureAIDependencies_CompositeNotifier_DoesNotContainItself()
     {
         var services = CreateBaseServices();
-        services.AddInfrastructureAIDependencies(new AppConfig());
+        services.AddInfrastructureAIDependencies(IsolatedAppConfig.Create());
         using var provider = services.BuildServiceProvider();
 
         var channels = provider.GetServices<IEscalationNotificationChannel>().ToList();
@@ -211,7 +211,7 @@ public sealed class DependencyInjectionTests
         // HttpClient.Timeout would race that pipeline and could truncate the retry budget
         // mid-attempt; the registration must leave the client timeout infinite so the pipeline
         // owns the budget — consistent with the default (non-typed) clients.
-        var config = new AppConfig();
+        var config = IsolatedAppConfig.Create();
         config.AI.AgentFramework.ClientType = Domain.Common.Config.AI.AIAgentFrameworkClientType.OpenAI;
         config.AI.AgentFramework.EnablePromptCaching = true;
         config.AI.AgentFramework.Endpoint = "https://openrouter.ai/api/v1";

--- a/src/Content/Tests/Infrastructure.AI.Tests/DriftLearningsDiTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/DriftLearningsDiTests.cs
@@ -189,14 +189,14 @@ public sealed class DriftLearningsDiTests
 
     private static ServiceProvider CreateServiceProvider(bool learningsEnabled = true)
     {
-        var appConfig = new AppConfig
+        var appConfig = IsolatedAppConfig.Isolate(new AppConfig
         {
             AI = new AIConfig
             {
                 DriftDetection = new DriftDetectionConfig(),
                 Learnings = new LearningsConfig { Enabled = learningsEnabled }
             }
-        };
+        });
 
         var services = new ServiceCollection();
         services.AddOptions();

--- a/src/Content/Tests/Infrastructure.AI.Tests/Infrastructure.AI.Tests.csproj
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Infrastructure.AI.Tests.csproj
@@ -36,6 +36,7 @@
     <ProjectReference Include="../../Infrastructure/Infrastructure.AI.MCP/Infrastructure.AI.MCP.csproj" />
     <ProjectReference Include="../../Application/Application.AI.Common/Application.AI.Common.csproj" />
     <ProjectReference Include="../../Application/Application.Core/Application.Core.csproj" />
+    <ProjectReference Include="../Tests.Common/Tests.Common.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Content/Tests/Infrastructure.AI.Tests/IsolatedAppConfig.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/IsolatedAppConfig.cs
@@ -35,15 +35,32 @@ internal static class IsolatedAppConfig
     /// <param name="config">The configuration to adjust, typically built with test-specific settings.</param>
     /// <returns>The same instance, for chaining onto an object initializer.</returns>
     /// <remarks>
-    /// Sets every path this assembly can cause to be written, not only the two currently observed in the
-    /// build output. A registration that starts persisting something new is then already covered, and
-    /// setting a path a given test never reaches costs nothing.
+    /// <para>
+    /// Sets the three paths this assembly's registrations are known to write: the planner database, the
+    /// conversation database, and the graph data directory. It is <em>not</em> an exhaustive sweep of
+    /// every path in <see cref="AppConfig"/> — several others (audit receipt and drift audit paths,
+    /// prompt-usage) resolve under the build output too but nothing here currently reaches them.
+    /// <c>BuildOutputStaysCleanTests</c> is what catches it if that changes, which is why that guard
+    /// scans for databases anywhere under the build output rather than only in the folder these three
+    /// use.
+    /// </para>
+    /// <para>
+    /// Governance durable state is deliberately excluded: <c>GovernanceStatePaths.Resolve</c> confines
+    /// that database to the application directory by design and throws for a path outside it, so
+    /// redirecting it here would break the control rather than isolate it.
+    /// </para>
     /// </remarks>
     public static AppConfig Isolate(AppConfig config)
     {
         ArgumentNullException.ThrowIfNull(config);
 
         var root = IsolatedStateRoot.Root;
+
+        // An empty root would silently produce a relative path, which registration then resolves against
+        // AppContext.BaseDirectory — putting the database back in the build output this exists to keep
+        // clean, and doing it quietly. The module initializer makes this unreachable today; the guard is
+        // here so that stops being something a reader has to work out.
+        ArgumentException.ThrowIfNullOrWhiteSpace(root, nameof(IsolatedStateRoot.Root));
 
         config.AI.Planner.DatabasePath = Path.Combine(root, "planner.db");
         config.AI.Conversations.DatabasePath = Path.Combine(root, "conversations.db");

--- a/src/Content/Tests/Infrastructure.AI.Tests/IsolatedAppConfig.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/IsolatedAppConfig.cs
@@ -1,0 +1,54 @@
+using Domain.Common.Config;
+
+namespace Infrastructure.AI.Tests;
+
+/// <summary>
+/// Builds an <see cref="AppConfig"/> whose on-disk paths point at this run's own temporary directory
+/// rather than at the build output.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Issue #262. Registering the harness's dependencies creates a database wherever the configuration
+/// says, and <see cref="AppConfig"/>'s defaults are the production ones — <c>data/planner.db</c> and
+/// <c>data/conversations.db</c>, resolved against <c>AppContext.BaseDirectory</c>. A test that hands
+/// registration a bare <c>new AppConfig()</c> therefore writes into its own build output, where nothing
+/// clears it and it accumulates across every run the machine has ever done.
+/// </para>
+/// <para>
+/// <strong>Use this anywhere a test passes an <see cref="AppConfig"/> into service registration.</strong>
+/// <see cref="Create"/> for the common case; <see cref="Isolate"/> to wrap a config a test has built
+/// with settings of its own, which keeps the object-initializer shape those tests already use.
+/// </para>
+/// <para>
+/// The paths are absolute, which is what carries them through the
+/// <c>Path.Combine(AppContext.BaseDirectory, configured)</c> that registration applies — a relative
+/// path would simply land somewhere else inside the build output.
+/// </para>
+/// </remarks>
+internal static class IsolatedAppConfig
+{
+    /// <summary>A default configuration with its on-disk paths pointed at this run's temp directory.</summary>
+    /// <returns>The configuration. Safe to mutate further.</returns>
+    public static AppConfig Create() => Isolate(new AppConfig());
+
+    /// <summary>Points an existing configuration's on-disk paths at this run's temp directory.</summary>
+    /// <param name="config">The configuration to adjust, typically built with test-specific settings.</param>
+    /// <returns>The same instance, for chaining onto an object initializer.</returns>
+    /// <remarks>
+    /// Sets every path this assembly can cause to be written, not only the two currently observed in the
+    /// build output. A registration that starts persisting something new is then already covered, and
+    /// setting a path a given test never reaches costs nothing.
+    /// </remarks>
+    public static AppConfig Isolate(AppConfig config)
+    {
+        ArgumentNullException.ThrowIfNull(config);
+
+        var root = IsolatedStateRoot.Root;
+
+        config.AI.Planner.DatabasePath = Path.Combine(root, "planner.db");
+        config.AI.Conversations.DatabasePath = Path.Combine(root, "conversations.db");
+        config.AI.Rag.GraphDatabase.DataDirectory = Path.Combine(root, "graph");
+
+        return config;
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/IsolatedStateRoot.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/IsolatedStateRoot.cs
@@ -1,0 +1,40 @@
+using System.Runtime.CompilerServices;
+using Domain.Common.Config;
+using Tests.Common;
+
+namespace Infrastructure.AI.Tests;
+
+/// <summary>
+/// Gives this assembly's test run its own on-disk state, so nothing survives from the last run.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Issue #262. This assembly left a 96 KB planner database and a 44 KB conversation database in its
+/// build output, growing across every run a developer had ever done. CI never sees it, because CI
+/// starts from a clean checkout — which is exactly why it survives locally and eventually presents as
+/// a product regression.
+/// </para>
+/// <para>
+/// <strong>Why the environment-variable redirect alone is not enough here, and is still done.</strong>
+/// <see cref="TestStateRoot.Redirect"/> works by setting environment variables, which outrank
+/// <c>appsettings.json</c> and are visible to the eager configuration reads inside host registration.
+/// That helps only when something <em>binds configuration</em>. Most tests in this assembly do not boot
+/// a host — they construct <see cref="AppConfig"/> in code, so the values come from the POCO defaults
+/// (<c>"data/planner.db"</c>) and no environment variable is ever consulted. The redirect is still
+/// performed, because it costs nothing and covers anything here that does bind; the gap it leaves is
+/// closed by <see cref="IsolatedAppConfig"/>, which stamps the same paths onto a config object
+/// directly.
+/// </para>
+/// <para>
+/// The initializer has to live in this assembly: a module initializer runs when its own module loads,
+/// so one in <c>Tests.Common</c> could run after a test here had already resolved a path.
+/// </para>
+/// </remarks>
+internal static class IsolatedStateRoot
+{
+    /// <summary>The directory this run's on-disk state lives in. Set before any test runs.</summary>
+    internal static string Root { get; private set; } = string.Empty;
+
+    [ModuleInitializer]
+    internal static void Redirect() => Root = TestStateRoot.Redirect("infrastructure-ai-tests-");
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlannerDiRegistrationTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlannerDiRegistrationTests.cs
@@ -212,10 +212,7 @@ public sealed class PlannerDiRegistrationTests : IDisposable
     /// </summary>
     private static IServiceCollection CreateServices()
     {
-        var appConfig = new AppConfig
-        {
-            AI = new AIConfig()
-        };
+        var appConfig = IsolatedAppConfig.Create();
 
         var services = new ServiceCollection();
         services.AddOptions();

--- a/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlannerInterceptorWiringTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlannerInterceptorWiringTests.cs
@@ -143,16 +143,11 @@ public sealed class PlannerInterceptorWiringTests : IDisposable
     {
         Directory.CreateDirectory(dbDirectory);
 
-        var appConfig = new AppConfig
-        {
-            AI = new AIConfig
-            {
-                Planner = new Domain.Common.Config.AI.Planner.PlannerOptions
-                {
-                    DatabasePath = Path.Combine(dbDirectory, "planner.db")
-                }
-            }
-        };
+        // Isolated first, then the planner path is pointed at this test's own directory — the test
+        // asserts against that database by name, so it keeps its explicit path while the conversation
+        // and graph paths still move out of the build output (issue #262).
+        var appConfig = IsolatedAppConfig.Create();
+        appConfig.AI.Planner.DatabasePath = Path.Combine(dbDirectory, "planner.db");
 
         var services = new ServiceCollection();
         services.AddOptions();

--- a/src/Content/Tests/Infrastructure.AI.Tests/ProcessEnvironmentCollection.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/ProcessEnvironmentCollection.cs
@@ -1,0 +1,34 @@
+using Xunit;
+
+namespace Infrastructure.AI.Tests;
+
+/// <summary>
+/// Serialises every test in this assembly that reads or writes a <em>process-wide</em> environment
+/// variable, so they cannot observe or clear one another's.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Environment variables are per-process, not per-test, and xUnit runs collections in parallel. A test
+/// that sets a variable and clears it in a <c>finally</c> can therefore clear it out from under a
+/// sibling still running, or a sibling can observe one it expected to be absent. Both failures are
+/// intermittent and look like product defects — one of them named a sandbox isolation control and read
+/// as a security regression on first sight (issue #269).
+/// </para>
+/// <para>
+/// <strong>One collection, not one per class.</strong> Two classes each in their own
+/// <c>DisableParallelization</c> collection are serialised against everything, which happens to include
+/// each other — but only incidentally, and nothing states the relationship. Naming the shared hazard
+/// gives the next test that touches <c>Environment.SetEnvironmentVariable</c> an obvious home and says
+/// why it belongs there.
+/// </para>
+/// <para>
+/// Same family as the <c>Presentation.AgentHub.Tests</c> assembly-wide serialisation (issue #261), where
+/// the shared state is OpenTelemetry's global meter rather than the environment block.
+/// </para>
+/// </remarks>
+[CollectionDefinition(Name, DisableParallelization = true)]
+public sealed class ProcessEnvironmentCollection
+{
+    /// <summary>The collection name. Apply with <c>[Collection(ProcessEnvironmentCollection.Name)]</c>.</summary>
+    public const string Name = "ProcessEnvironment";
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Sandbox/ProcessSandboxEnvironmentIsolationTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Sandbox/ProcessSandboxEnvironmentIsolationTests.cs
@@ -18,7 +18,16 @@ namespace Infrastructure.AI.Tests.Sandbox;
 /// These tests assert the child environment is cleared and rebuilt from an explicit,
 /// closed-by-default allowlist plus per-request grants.
 /// </summary>
+/// <remarks>
+/// Two tests here set a canary <em>process-wide</em> environment variable and clear it in a
+/// <c>finally</c>, and the sandbox subprocess inherits whatever the environment holds when it spawns.
+/// Run in parallel with anything else that touches the environment block, a canary can be cleared out
+/// from under a sibling or observed by one that expected it absent — which is what made this class fail
+/// intermittently under full-solution runs while passing alone (issue #269). The failure named an
+/// isolation control, so it read as a hole in the sandbox rather than a test-isolation problem.
+/// </remarks>
 [Trait("Category", "WindowsOnly")]
+[Collection(ProcessEnvironmentCollection.Name)]
 public class ProcessSandboxEnvironmentIsolationTests
 {
     private readonly Mock<IProcessResourceLimiter> _limiter = new();

--- a/src/Content/Tests/Infrastructure.AI.Tests/Sandbox/ProcessSandboxEnvironmentIsolationTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Sandbox/ProcessSandboxEnvironmentIsolationTests.cs
@@ -21,10 +21,15 @@ namespace Infrastructure.AI.Tests.Sandbox;
 /// <remarks>
 /// Two tests here set a canary <em>process-wide</em> environment variable and clear it in a
 /// <c>finally</c>, and the sandbox subprocess inherits whatever the environment holds when it spawns.
-/// Run in parallel with anything else that touches the environment block, a canary can be cleared out
-/// from under a sibling or observed by one that expected it absent — which is what made this class fail
-/// intermittently under full-solution runs while passing alone (issue #269). The failure named an
-/// isolation control, so it read as a hole in the sandbox rather than a test-isolation problem.
+/// Membership of <see cref="ProcessEnvironmentCollection"/> keeps that hazard from ever mattering: no
+/// other test in the assembly that touches the environment block can run alongside these.
+/// <para>
+/// It is a guard, not the fix for issue #269. That issue attributed an intermittent failure here to
+/// exactly this race, and the attribution does not hold — these tests share one class, xUnit does not
+/// run tests within a collection in parallel, and the assembly's only other environment-variable class
+/// was already serialised. The observed failure's cause remains unmeasured; the assertions now report
+/// what the sandbox actually said so the next occurrence identifies itself.
+/// </para>
 /// </remarks>
 [Trait("Category", "WindowsOnly")]
 [Collection(ProcessEnvironmentCollection.Name)]
@@ -70,7 +75,7 @@ public class ProcessSandboxEnvironmentIsolationTests
 
             var result = await CreateSut().ExecuteAsync(request, CancellationToken.None);
 
-            result.Success.Should().BeTrue();
+            result.Success.Should().BeTrue(WhyItFailed(result));
             result.Output.Should().NotContain(canaryValue,
                 "the child process environment must be cleared — host secrets must never leak into sandboxed tools");
         }
@@ -90,7 +95,7 @@ public class ProcessSandboxEnvironmentIsolationTests
 
         var result = await CreateSut().ExecuteAsync(request, CancellationToken.None);
 
-        result.Success.Should().BeTrue();
+        result.Success.Should().BeTrue(WhyItFailed(result));
         result.Output!.Trim().Should().Be(
             Environment.GetEnvironmentVariable("SystemRoot"),
             "allowlisted system variables must still flow through so child processes remain functional");
@@ -115,7 +120,7 @@ public class ProcessSandboxEnvironmentIsolationTests
 
             var result = await CreateSut().ExecuteAsync(request, CancellationToken.None);
 
-            result.Success.Should().BeTrue();
+            result.Success.Should().BeTrue(WhyItFailed(result));
             result.Output.Should().NotContain(canaryValue,
                 "only variables named in the configured allowlist may cross the sandbox boundary");
         }
@@ -140,7 +145,7 @@ public class ProcessSandboxEnvironmentIsolationTests
 
         var result = await CreateSut().ExecuteAsync(request, CancellationToken.None);
 
-        result.Success.Should().BeTrue();
+        result.Success.Should().BeTrue(WhyItFailed(result));
         result.Output.Should().Contain("explicitly-granted-value",
             "explicit per-request environment grants are the sanctioned channel for passing values into the sandbox");
     }
@@ -163,7 +168,7 @@ public class ProcessSandboxEnvironmentIsolationTests
 
         var result = await sut.ExecuteAsync(request, CancellationToken.None);
 
-        result.Success.Should().BeTrue();
+        result.Success.Should().BeTrue(WhyItFailed(result));
         result.Output!.Trim().Should().Be(workspaceDir,
             "TEMP must point inside the disposable sandbox workspace, not at the host temp directory");
     }
@@ -195,6 +200,24 @@ public class ProcessSandboxEnvironmentIsolationTests
         result.Attestation.Should().NotBeNull("the rejection must leave a signed audit record");
         result.Attestation!.IsFailureAttestation.Should().BeTrue();
     }
+
+    /// <summary>
+    /// Explains a failed sandbox run in the assertion message, so a failure identifies its own cause.
+    /// </summary>
+    /// <param name="result">The result being asserted on.</param>
+    /// <returns>A reason string naming the error and exit code the run reported.</returns>
+    /// <remarks>
+    /// Issue #269 recorded an intermittent failure here under full-solution runs and attributed it to a
+    /// race on process-wide environment variables. That hypothesis is disproven — these tests share one
+    /// class, xUnit never runs tests within a collection in parallel, and the assembly's only other
+    /// environment-variable class was already serialised, so no two of them could overlap. The real
+    /// cause is still unmeasured, and the bare <c>BeTrue()</c> assertions were part of why: a run that
+    /// timed out and one that was denied produced the same message. The next occurrence now says which.
+    /// </remarks>
+    private static string WhyItFailed(SandboxExecutionResult result) =>
+        $"the sandboxed process was expected to run; it reported ErrorMessage='{result.ErrorMessage}', "
+        + $"ExitCode={result.ExitCode?.ToString() ?? "none"} (a null exit code means it was killed or "
+        + $"never started — which is what exceeding the request's 10s timeout looks like)";
 
     private static SandboxExecutionRequest CreateRequest(string[] argumentList) => new()
     {

--- a/src/Content/Tests/Infrastructure.AI.Tests/SerialTailCollection.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/SerialTailCollection.cs
@@ -1,0 +1,26 @@
+using Xunit;
+
+namespace Infrastructure.AI.Tests;
+
+/// <summary>
+/// For tests that must observe the state every other test in this assembly has left behind.
+/// </summary>
+/// <remarks>
+/// <para>
+/// xUnit runs collections marked <c>DisableParallelization</c> only after every parallel collection has
+/// completed. Membership here is therefore "run me once the rest of the assembly has finished" — a
+/// property of the runner rather than a hope about ordering.
+/// </para>
+/// <para>
+/// Reserve it for assertions about assembly-wide side effects. A test that merely needs isolation from
+/// one specific hazard belongs in a collection that names that hazard, the way
+/// <see cref="ProcessEnvironmentCollection"/> does — a catch-all serial collection would quietly become
+/// the place slow or flaky tests go to hide.
+/// </para>
+/// </remarks>
+[CollectionDefinition(Name, DisableParallelization = true)]
+public sealed class SerialTailCollection
+{
+    /// <summary>The collection name. Apply with <c>[Collection(SerialTailCollection.Name)]</c>.</summary>
+    public const string Name = "SerialTail";
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Telemetry/ContentCaptureStartupValidatorTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Telemetry/ContentCaptureStartupValidatorTests.cs
@@ -17,7 +17,7 @@ namespace Infrastructure.AI.Tests.Telemetry;
 /// process state, so each test that touches it restores the prior value in a
 /// <c>finally</c>.
 /// </summary>
-[Collection("ContentCaptureEnvVar")]
+[Collection(ProcessEnvironmentCollection.Name)]
 public sealed class ContentCaptureStartupValidatorTests
 {
     private static ContentCaptureStartupValidator Build(
@@ -128,11 +128,3 @@ public sealed class ContentCaptureStartupValidatorTests
         await act.Should().NotThrowAsync();
     }
 }
-
-/// <summary>
-/// Serializes tests that mutate the process-global
-/// <c>OTEL_SEMCONV_STABILITY_OPT_IN</c> environment variable so they do not
-/// interfere with one another when xUnit runs collections in parallel.
-/// </summary>
-[CollectionDefinition("ContentCaptureEnvVar", DisableParallelization = true)]
-public sealed class ContentCaptureEnvVarCollection;


### PR DESCRIPTION
Closes #269. Closes #262.

Two test-isolation issues in the same assembly. Both produce failures that read as product regressions, and both are invisible to CI — which is exactly why they survive.

## #269 — the filed hypothesis is disproven; this ships a guard, not a cure

The issue attributed an intermittent failure in `ProcessSandboxEnvironmentIsolationTests` to two of its tests clearing each other's process-wide canary variable. **They cannot run concurrently.** Both live in one class, xUnit does not parallelise within a collection, and the assembly's only other environment-variable class was already in a `DisableParallelization` collection — which xUnit runs only after every parallel collection has finished. Those are the assembly's only two writers of the environment block, so no interleaving was available.

```
CAUSE:     Unmeasured. The filed environment-variable race is ruled out.
CONTROL:   xUnit's collection semantics, checked against the runner rather than assumed.
COVERAGE:  Explains why the filed hypothesis is wrong. Explains none of the observed failure.
```

A live alternative, equally unmeasured: the request carries a **10-second timeout**, and the assertion that failed was `result.Success.Should().BeTrue()`. A full-solution run spawns processes across many assemblies at once, and a `cmd.exe` launch exceeding ten seconds under that contention fails exactly that assertion, does not reproduce when the class runs alone, and takes nothing else down with it. Not proven — and the timeout is deliberately **not** raised on a guess, which would be the same error one layer along.

What ships instead:

1. **The guard.** One shared `ProcessEnvironmentCollection` serialises every test in the assembly that touches the environment block. The race was unavailable before; it becomes available the moment someone adds a second environment-variable class without noticing, and the shared collection gives that person an obvious home and states why.
2. **The diagnosis, for next time.** All five `result.Success.Should().BeTrue()` assertions now report the sandbox's own `ErrorMessage` and `ExitCode` — a null exit code being what a timeout looks like. The bare assertion is part of why this cost an investigation: a timed-out run and a denied run produced the same message.

## #262 — state accumulating in the build output

The assembly left a 96 KB planner database and a 44 KB conversation database under its own build output, growing across every run the machine had ever done. Same family as #250 and #259; CI never sees it because CI starts clean.

The #259 fix does not reach here, and the issue is right about why. `TestStateRoot.Redirect` sets environment variables, which only help when something **binds configuration**. Most tests here do not boot a host — they construct `AppConfig` in code, so values come from the POCO defaults (`"data/planner.db"`) and no environment variable is ever consulted.

**Fix:** `IsolatedAppConfig` stamps this run's temp paths straight onto the config object. `Create()` for the common case, `Isolate(...)` to wrap a config a test builds with settings of its own — which keeps the object-initializer shape those tests already use, so each of the 33 registration sites changes by one token rather than being rewritten. The environment redirect is still performed alongside it: it costs nothing, covers anything here that *does* bind, and a host-booting test added later is then already handled.

`PlannerInterceptorWiringTests` keeps its explicit planner path — it asserts against that database by name — and now has its conversation and graph paths isolated too, which it did not before.

## Verification

Full solution green, and measured rather than inferred: after clearing the accumulated `data/` directory and running the assembly in full, no database exists anywhere under the build output. Both environment-variable classes still run after joining the shared collection — 18 tests, none skipped — because a test-isolation change that silently stops running tests would be worse than the flake it fixes.

Mutation-tested: neutering `IsolatedAppConfig.Isolate` so the paths stay at their defaults turns the new guard red.

## Found by review, fixed here

Three findings, all in my own work:

- **The guard was racy in CI.** `BuildOutputStaysCleanTests` sat in no collection, so it ran in the parallel phase alongside the very tests that create databases — a regression created after it read the directory would pass. My rationale for that ("a leak simply fails the next run") holds on a developer machine and fails precisely where it matters: CI starts clean every time, so there is no next run. It now sits in a `DisableParallelization` collection, which the runner executes after all parallel ones. That is a property of the runner, not a hope about ordering.
- **The guard scanned the wrong scope.** It looked only in `data/`. A config path that resolved to empty would land its database at the build-output *root*, unseen. It now scans for databases anywhere under the build output — which is also what would catch a path this helper does not yet set.
- **A comment claimed more than the code did** — "sets every path this assembly can cause to be written" against a method that sets three. Corrected to name the three, name the ones deliberately left (governance state is confined to the application directory by design and throws for a path outside it), and point at the guard as the thing that catches the gap.

`IsolatedAppConfig` also now refuses an empty root rather than silently producing a relative path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
