### PR TITLE
refactor: hand the context-provider rail out read-only and clear the deferred cleanups

### DIFF
--- a/src/Content/Application/Application.AI.Common/Factories/AgentExecutionContextFactory.ContextProviders.cs
+++ b/src/Content/Application/Application.AI.Common/Factories/AgentExecutionContextFactory.ContextProviders.cs
@@ -55,19 +55,12 @@ public partial class AgentExecutionContextFactory
     /// providers at all.
     /// </returns>
     /// <remarks>
-    /// <para>
     /// The rail is returned read-only, so appending to it throws rather than silently displacing the
-    /// per-turn measurer from the last position (issue #277). It leaves this method through a settable
+    /// per-turn measurer from the last position — see <see cref="AppendPerTurnBudgetProvider"/> for why
+    /// that position is load-bearing (issue #277). The rail leaves this method through a settable
     /// <see cref="IList{T}"/> property on the execution context and is handed to the framework as one,
     /// which is why the guard has to be the instance's own behaviour: no type on that path can express
     /// "this list is finished".
-    /// </para>
-    /// <para>
-    /// Displacement is the failure worth refusing. The measurer only measures correctly from last
-    /// place — the runtime feeds each provider the accumulated output of the ones before it — so from
-    /// any earlier position it under-charges the turn, and under-charging means the budget meant to
-    /// bound a conversation stops bounding it without anything erroring.
-    /// </para>
     /// </remarks>
     private IList<AIContextProvider>? BuildMergedAIContextProviders(
         int skillCount,
@@ -106,21 +99,25 @@ public partial class AgentExecutionContextFactory
         // tenant-aware dependency per invocation from the current request scope, so both are safe to
         // attach to a singleton-cached agent; the learnings one injects the most task-relevant lessons
         // at turn start, which is the read half of the self-improving loop.
-        AddRecallProvider(
-            providers,
-            _appConfig.CurrentValue.AI?.KnowledgeBridge?.Enabled == true,
-            scope => new Services.Agent.KnowledgeMemoryContextProvider(
-                scope, _appConfig,
-                _loggerFactory.CreateLogger<Services.Agent.KnowledgeMemoryContextProvider>()),
-            "cross-session recall");
+        if (_appConfig.CurrentValue.AI?.KnowledgeBridge?.Enabled == true)
+        {
+            AddRecallProvider(
+                providers,
+                scope => new Services.Agent.KnowledgeMemoryContextProvider(
+                    scope, _appConfig,
+                    _loggerFactory.CreateLogger<Services.Agent.KnowledgeMemoryContextProvider>()),
+                "cross-session recall");
+        }
 
-        AddRecallProvider(
-            providers,
-            _appConfig.CurrentValue.AI?.LearningsRecall?.Enabled == true,
-            scope => new Services.Agent.LearningsRecallContextProvider(
-                scope, _appConfig,
-                _loggerFactory.CreateLogger<Services.Agent.LearningsRecallContextProvider>()),
-            "task-similarity recall");
+        if (_appConfig.CurrentValue.AI?.LearningsRecall?.Enabled == true)
+        {
+            AddRecallProvider(
+                providers,
+                scope => new Services.Agent.LearningsRecallContextProvider(
+                    scope, _appConfig,
+                    _loggerFactory.CreateLogger<Services.Agent.LearningsRecallContextProvider>()),
+                "task-similarity recall");
+        }
 
         // Governance wrapper — added after the recall providers so it wraps the final, filtered tool
         // set. When tool-invocation enforcement is on, this guarantees the governor gates every tool the
@@ -141,23 +138,22 @@ public partial class AgentExecutionContextFactory
     }
 
     /// <summary>
-    /// Adds one of the two recall providers, when its feature is enabled and a request scope exists.
+    /// Adds one of the two recall providers, when a request scope exists for it to read identity from.
     /// </summary>
-    /// <typeparam name="TProvider">The provider being wired; its name is what gets logged.</typeparam>
     /// <param name="providers">The rail under construction.</param>
-    /// <param name="enabled">Whether this feature's configuration flag is on.</param>
     /// <param name="create">Builds the provider from the resolved ambient scope.</param>
     /// <param name="purpose">What this provider recalls; diagnostics only.</param>
     /// <remarks>
     /// <para>
-    /// The two recall providers are the same five steps with the type swapped — check a flag, resolve
-    /// the ambient scope, skip when absent, construct, log — and were written out twice.
+    /// The two recall providers are the same steps with the type swapped — resolve the ambient scope,
+    /// skip when absent, construct, log — and were written out twice.
     /// </para>
     /// <para>
-    /// <strong>The scope is resolved inside this method, per call, and must stay that way.</strong>
-    /// Both flags default to disabled, so the default path makes zero service lookups; hoisting the
-    /// resolution to a shared local above the two call sites would make one unconditionally, on every
-    /// agent construction, for a feature almost nobody has switched on.
+    /// <strong>The feature flag is checked by the caller, not here, and must stay that way.</strong>
+    /// Both flags default to disabled, so on the default path nothing is called: no service lookup for
+    /// <see cref="IAmbientRequestScope"/>, and not even a delegate allocated for <paramref name="create"/>.
+    /// Taking the flag as a parameter would move both costs onto every agent construction, for a feature
+    /// almost nobody has switched on.
     /// </para>
     /// <para>
     /// A missing <see cref="IAmbientRequestScope"/> is a silent skip rather than a failure because the
@@ -165,23 +161,19 @@ public partial class AgentExecutionContextFactory
     /// without registering the scope gets no recall, not a broken agent.
     /// </para>
     /// </remarks>
-    private void AddRecallProvider<TProvider>(
+    private void AddRecallProvider(
         List<AIContextProvider> providers,
-        bool enabled,
-        Func<IAmbientRequestScope, TProvider> create,
+        Func<IAmbientRequestScope, AIContextProvider> create,
         string purpose)
-        where TProvider : AIContextProvider
     {
-        if (!enabled)
-            return;
-
         var ambientScope = _serviceProvider.GetService<IAmbientRequestScope>();
         if (ambientScope is null)
             return;
 
-        providers.Add(create(ambientScope));
+        var provider = create(ambientScope);
+        providers.Add(provider);
 
-        _logger.LogDebug("Wired {ProviderType} for {Purpose}", typeof(TProvider).Name, purpose);
+        _logger.LogDebug("Wired {ProviderType} for {Purpose}", provider.GetType().Name, purpose);
     }
 
     /// <summary>
@@ -206,7 +198,7 @@ public partial class AgentExecutionContextFactory
     /// does not track context with exactly the rail it had before.
     /// </remarks>
     private void AppendPerTurnBudgetProvider(
-        IList<AIContextProvider> providers,
+        List<AIContextProvider> providers,
         PerTurnBudgetBaseline baseline)
     {
         if (_budgetTracker is null || providers.Count == 0)

--- a/src/Content/Application/Application.AI.Common/Factories/AgentExecutionContextFactory.ContextProviders.cs
+++ b/src/Content/Application/Application.AI.Common/Factories/AgentExecutionContextFactory.ContextProviders.cs
@@ -12,18 +12,32 @@ namespace Application.AI.Common.Factories;
 //
 // ORDER ON THIS RAIL IS BEHAVIOUR, NOT STYLE. The runtime feeds each provider the previous one's
 // output, so a provider only sees what everything above it produced. Two positional rules hold the
-// rail together: any tool-contributing provider must go above ToolPermissionFilter (see the inline
-// comment at that call site), and the per-turn measurer must go last (see AppendPerTurnBudgetProvider).
-// Both are load-bearing — moving a line here changes which tools an agent can call and what its
-// budget records. AgentExecutionContextFactoryRailOrderTests asserts both, by position rather than by
-// presence, because every other test in this assembly reads the rail with OfType<T>().Single() and so
-// passes whatever the order is.
+// rail together, and each is stated once where it is enforced rather than restated here:
+// tool contributors go above ToolPermissionFilter (see the inline comment at that call site), and the
+// per-turn measurer goes last (see AppendPerTurnBudgetProvider). Moving a line here changes which
+// tools an agent can call and what its budget records. AgentExecutionContextFactoryRailOrderTests
+// asserts both by position rather than by presence, because every other test in this assembly reads
+// the rail with OfType<T>().Single() and so passes whatever the order is.
 //
 // Deliberately a plain comment, not an XML doc: the type's <summary> lives on the primary partial in
 // AgentExecutionContextFactory.cs. A second class-level <summary> on the same type would be merged
 // into one <member> entry, and which one tooling shows is compile-order dependent.
 public partial class AgentExecutionContextFactory
 {
+    /// <summary>
+    /// What the agent was already charged for before its rail ran — the baseline the per-turn measurer
+    /// subtracts so a turn is billed for what the rail added rather than for the prompt again.
+    /// </summary>
+    /// <param name="AgentName">The agent whose budget the per-turn context is charged to.</param>
+    /// <param name="Instruction">The static system prompt, already charged separately.</param>
+    /// <param name="ToolCount">The number of tools the agent was built with, already charged as schemas.</param>
+    /// <remarks>
+    /// One concept rather than three parameters travelling together through two signatures. The three
+    /// are only ever read as a set, and naming the set is what makes it obvious that a fourth thing the
+    /// measurer needs belongs here rather than as another argument.
+    /// </remarks>
+    private readonly record struct PerTurnBudgetBaseline(string AgentName, string Instruction, int ToolCount);
+
     /// <summary>
     /// Unions the context providers for this agent over <paramref name="disclosableSkills"/>, which the
     /// caller built once so this wiring and the prompt's disclosure decision cannot disagree.
@@ -35,25 +49,31 @@ public partial class AgentExecutionContextFactory
     /// <param name="skillCount">How many skills this agent was built from; diagnostics only.</param>
     /// <param name="effectiveAllowlist">The one allowlist governing this agent, or <see langword="null"/>.</param>
     /// <param name="disclosableSkills">The skills the framework provider is given, built once by the caller.</param>
-    /// <param name="agentName">The agent whose budget the per-turn measurer charges.</param>
-    /// <param name="instruction">The static system prompt — the measurer's instruction baseline.</param>
-    /// <param name="toolCount">The tool count the agent was built with — the measurer's tool baseline.</param>
-    /// <returns>The ordered rail, or <see langword="null"/> when this agent needs no providers at all.</returns>
+    /// <param name="baseline">What the agent was already charged for; see <see cref="PerTurnBudgetBaseline"/>.</param>
+    /// <returns>
+    /// The ordered rail as a read-only list, or <see langword="null"/> when this agent needs no
+    /// providers at all.
+    /// </returns>
     /// <remarks>
-    /// The per-turn measurer is appended here rather than by the caller, so that "it must be last" is a
-    /// property of this one method instead of a property of a call sequence in another file. That closes the
-    /// gap this method could close. It does not make lastness unbreakable: the rail is handed on as a
-    /// mutable <see cref="IList{T}"/> through a settable property, so a consumer that appended to it would
-    /// still displace the measurer. Nothing does today, and no test would catch it if something started —
-    /// tracked in issue #277.
+    /// <para>
+    /// The rail is returned read-only, so appending to it throws rather than silently displacing the
+    /// per-turn measurer from the last position (issue #277). It leaves this method through a settable
+    /// <see cref="IList{T}"/> property on the execution context and is handed to the framework as one,
+    /// which is why the guard has to be the instance's own behaviour: no type on that path can express
+    /// "this list is finished".
+    /// </para>
+    /// <para>
+    /// Displacement is the failure worth refusing. The measurer only measures correctly from last
+    /// place — the runtime feeds each provider the accumulated output of the ones before it — so from
+    /// any earlier position it under-charges the turn, and under-charging means the budget meant to
+    /// bound a conversation stops bounding it without anything erroring.
+    /// </para>
     /// </remarks>
     private IList<AIContextProvider>? BuildMergedAIContextProviders(
         int skillCount,
         IReadOnlyList<string>? effectiveAllowlist,
         IReadOnlyList<DisclosableSkill> disclosableSkills,
-        string agentName,
-        string instruction,
-        int toolCount)
+        PerTurnBudgetBaseline baseline)
     {
         var providers = new List<AIContextProvider>();
 
@@ -82,44 +102,29 @@ public partial class AgentExecutionContextFactory
                 effectiveAllowlist.Count, skillCount);
         }
 
-        // Cross-session memory recall. The provider resolves tenant-aware IKnowledgeMemory per
-        // invocation from the current request scope (via IAmbientRequestScope), so it is safe to
-        // attach to a singleton-cached agent.
-        if (_appConfig.CurrentValue.AI?.KnowledgeBridge?.Enabled == true)
-        {
-            var ambientScope = _serviceProvider.GetService<IAmbientRequestScope>();
-            if (ambientScope is not null)
-            {
-                providers.Add(new Services.Agent.KnowledgeMemoryContextProvider(
-                    ambientScope,
-                    _appConfig,
-                    _loggerFactory.CreateLogger<Services.Agent.KnowledgeMemoryContextProvider>()));
+        // Cross-session memory recall, then task-similarity learnings recall. Both resolve their
+        // tenant-aware dependency per invocation from the current request scope, so both are safe to
+        // attach to a singleton-cached agent; the learnings one injects the most task-relevant lessons
+        // at turn start, which is the read half of the self-improving loop.
+        AddRecallProvider(
+            providers,
+            _appConfig.CurrentValue.AI?.KnowledgeBridge?.Enabled == true,
+            scope => new Services.Agent.KnowledgeMemoryContextProvider(
+                scope, _appConfig,
+                _loggerFactory.CreateLogger<Services.Agent.KnowledgeMemoryContextProvider>()),
+            "cross-session recall");
 
-                _logger.LogDebug("Wired KnowledgeMemoryContextProvider for cross-session recall");
-            }
-        }
+        AddRecallProvider(
+            providers,
+            _appConfig.CurrentValue.AI?.LearningsRecall?.Enabled == true,
+            scope => new Services.Agent.LearningsRecallContextProvider(
+                scope, _appConfig,
+                _loggerFactory.CreateLogger<Services.Agent.LearningsRecallContextProvider>()),
+            "task-similarity recall");
 
-        // Task-similarity learnings recall. Like the memory provider above, it resolves the scoped,
-        // tenant-aware ILearningRecaller per invocation from the current request scope, so it is safe to
-        // attach to a singleton-cached agent. Injects the most task-relevant lessons (every source,
-        // including work-memory synthesis output) at turn start — the read half of the self-improving loop.
-        if (_appConfig.CurrentValue.AI?.LearningsRecall?.Enabled == true)
-        {
-            var ambientScope = _serviceProvider.GetService<IAmbientRequestScope>();
-            if (ambientScope is not null)
-            {
-                providers.Add(new Services.Agent.LearningsRecallContextProvider(
-                    ambientScope,
-                    _appConfig,
-                    _loggerFactory.CreateLogger<Services.Agent.LearningsRecallContextProvider>()));
-
-                _logger.LogDebug("Wired LearningsRecallContextProvider for task-similarity recall");
-            }
-        }
-
-        // Governance wrapper — added LAST so it wraps the final, filtered tool set. When
-        // tool-invocation enforcement is on, this guarantees the governor gates every tool the agent
-        // can call, including framework progressive-disclosure tools that bypass ToolChainBuilder.
+        // Governance wrapper — added after the recall providers so it wraps the final, filtered tool
+        // set. When tool-invocation enforcement is on, this guarantees the governor gates every tool the
+        // agent can call, including framework progressive-disclosure tools that bypass ToolChainBuilder.
         // Inert (and skipped entirely) when enforcement is off, so default behaviour is unchanged.
         if (_appConfig.CurrentValue.AI?.Governance?.EnforceToolInvocation == true)
         {
@@ -128,58 +133,94 @@ public partial class AgentExecutionContextFactory
             _logger.LogDebug("Wired GoverningToolContextProvider (tool-invocation enforcement enabled)");
         }
 
-        // Last, unconditionally and from inside this method — see the remarks above and on
-        // AppendPerTurnBudgetProvider. An empty rail gets nothing appended, so the null below is unaffected.
-        AppendPerTurnBudgetProvider(providers, agentName, instruction, toolCount);
+        AppendPerTurnBudgetProvider(providers, baseline);
 
-        return providers.Count > 0 ? providers : null;
+        // AsReadOnly wraps rather than copies, so the returned list is a live view of a list nothing
+        // else holds a reference to — the local goes out of scope here.
+        return providers.Count > 0 ? providers.AsReadOnly() : null;
+    }
+
+    /// <summary>
+    /// Adds one of the two recall providers, when its feature is enabled and a request scope exists.
+    /// </summary>
+    /// <typeparam name="TProvider">The provider being wired; its name is what gets logged.</typeparam>
+    /// <param name="providers">The rail under construction.</param>
+    /// <param name="enabled">Whether this feature's configuration flag is on.</param>
+    /// <param name="create">Builds the provider from the resolved ambient scope.</param>
+    /// <param name="purpose">What this provider recalls; diagnostics only.</param>
+    /// <remarks>
+    /// <para>
+    /// The two recall providers are the same five steps with the type swapped — check a flag, resolve
+    /// the ambient scope, skip when absent, construct, log — and were written out twice.
+    /// </para>
+    /// <para>
+    /// <strong>The scope is resolved inside this method, per call, and must stay that way.</strong>
+    /// Both flags default to disabled, so the default path makes zero service lookups; hoisting the
+    /// resolution to a shared local above the two call sites would make one unconditionally, on every
+    /// agent construction, for a feature almost nobody has switched on.
+    /// </para>
+    /// <para>
+    /// A missing <see cref="IAmbientRequestScope"/> is a silent skip rather than a failure because the
+    /// provider cannot function without one and the feature is optional — a host that enabled recall
+    /// without registering the scope gets no recall, not a broken agent.
+    /// </para>
+    /// </remarks>
+    private void AddRecallProvider<TProvider>(
+        List<AIContextProvider> providers,
+        bool enabled,
+        Func<IAmbientRequestScope, TProvider> create,
+        string purpose)
+        where TProvider : AIContextProvider
+    {
+        if (!enabled)
+            return;
+
+        var ambientScope = _serviceProvider.GetService<IAmbientRequestScope>();
+        if (ambientScope is null)
+            return;
+
+        providers.Add(create(ambientScope));
+
+        _logger.LogDebug("Wired {ProviderType} for {Purpose}", typeof(TProvider).Name, purpose);
     }
 
     /// <summary>
     /// Appends the measurer that charges whatever <paramref name="providers"/> inject into each turn to
-    /// <paramref name="agentName"/>'s budget.
+    /// the budget of the agent named by <paramref name="baseline"/>.
     /// </summary>
     /// <param name="providers">
     /// The rail built for this agent, mutated in place. An empty rail means the agent has no providers, so
     /// there is nothing per-turn to charge and nothing is appended.
     /// </param>
-    /// <param name="agentName">The agent whose budget the per-turn context is charged to.</param>
-    /// <param name="instruction">
-    /// The static system prompt, already charged separately. It is the baseline the measurer subtracts, so
-    /// only what the rail adds is charged here rather than the prompt being billed again every turn.
-    /// </param>
-    /// <param name="toolCount">
-    /// The number of tools the agent was built with, already charged as tool schemas — the baseline for
-    /// tools the rail contributes, such as the framework's own skill-disclosure tools.
-    /// </param>
+    /// <param name="baseline">What the agent was already charged for, which the measurer subtracts.</param>
     /// <remarks>
-    /// It must be last: the runtime feeds each provider the previous one's output, so only the final
-    /// position sees everything the others contributed. That is why this is called from the tail of
+    /// <strong>This is the canonical statement of the lastness rule.</strong> The measurer must be last:
+    /// the runtime feeds each provider the previous one's output, so only the final position sees
+    /// everything the others contributed. That is why it is appended from the tail of
     /// <see cref="BuildMergedAIContextProviders"/> rather than by whoever consumes the rail — lastness is
-    /// then a property of the builder, not of a call sequence somewhere else. Placing it after
-    /// <see cref="Services.Agent.GoverningToolContextProvider"/> — which is itself documented as going last
-    /// — is safe, because this provider neither adds nor removes tools and so cannot escape that governance
+    /// then a property of the builder, not of a call sequence somewhere else — and why that method hands
+    /// the finished rail out read-only. Placing it after
+    /// <see cref="Services.Agent.GoverningToolContextProvider"/>, which is itself documented as going
+    /// last, is safe: this provider neither adds nor removes tools, so it cannot escape that governance
     /// wrapper or defeat it. Nothing is appended when no budget tracker is wired in, leaving a host that
     /// does not track context with exactly the rail it had before.
     /// </remarks>
     private void AppendPerTurnBudgetProvider(
         IList<AIContextProvider> providers,
-        string agentName,
-        string instruction,
-        int toolCount)
+        PerTurnBudgetBaseline baseline)
     {
         if (_budgetTracker is null || providers.Count == 0)
             return;
 
         providers.Add(new Services.Agent.PerTurnBudgetContextProvider(
-            agentName,
+            baseline.AgentName,
             _budgetTracker,
-            instruction,
-            toolCount,
+            baseline.Instruction,
+            baseline.ToolCount,
             _loggerFactory.CreateLogger<Services.Agent.PerTurnBudgetContextProvider>()));
 
         _logger.LogDebug(
             "Wired PerTurnBudgetContextProvider for {AgentName} behind {ProviderCount} context provider(s)",
-            agentName, providers.Count - 1);
+            baseline.AgentName, providers.Count - 1);
     }
 }

--- a/src/Content/Application/Application.AI.Common/Factories/AgentExecutionContextFactory.Resolution.cs
+++ b/src/Content/Application/Application.AI.Common/Factories/AgentExecutionContextFactory.Resolution.cs
@@ -33,10 +33,21 @@ public partial class AgentExecutionContextFactory
             return skill.ModelOverride;
 
         if (skill.Metadata?.TryGetValue("deployment", out var deployment) == true)
-            return deployment.ToString() ?? "default";
+            return deployment.ToString() ?? DefaultDeployment;
 
-        return _appConfig.CurrentValue.AI?.AgentFramework?.DefaultDeployment ?? "default";
+        return DefaultDeployment;
     }
+
+    /// <summary>
+    /// The deployment an agent gets when nothing more specific applies.
+    /// </summary>
+    /// <remarks>
+    /// Read by <see cref="ResolveDeploymentName"/> and by the delegation path, which used to spell the
+    /// same <c>?? DefaultDeployment ?? "default"</c> tail out for itself. The two now live in different
+    /// files, so a second copy is one an edit that does not grep would miss.
+    /// </remarks>
+    private string DefaultDeployment =>
+        _appConfig.CurrentValue.AI?.AgentFramework?.DefaultDeployment ?? "default";
 
     /// <summary>
     /// Resolves the single effective tool allowlist that governs an agent: the union of its skills'
@@ -51,37 +62,34 @@ public partial class AgentExecutionContextFactory
         SkillAgentOptions options,
         IReadOnlyList<string>? explicitAllowlist)
     {
-        var effective = ToolCeilingResolver.ApplyCeiling(MergeSkillAllowedTools(skills), options.AllowedTools);
+        var granted = ToolCeilingResolver.Union(skills.Select(s => s.AllowedTools));
+        var effective = ToolCeilingResolver.ApplyCeiling(granted, options.AllowedTools);
         return ToolCeilingResolver.ApplyCeiling(effective, explicitAllowlist);
     }
 
     /// <summary>
-    /// Deduplicated union of every skill's <c>AllowedTools</c> constraint, case-insensitively, or
-    /// <see langword="null"/> when no skill declares a constraint — the "unbounded" input the ceiling
-    /// resolver expects for "no restriction" (distinct from an empty list, which means deny all).
+    /// The middleware chain every agent runs, plus whatever the caller adds.
     /// </summary>
-    private static IReadOnlyList<string>? MergeSkillAllowedTools(IReadOnlyList<SkillDefinition> skills)
+    /// <param name="options">Supplies any caller-declared middleware to append.</param>
+    /// <returns>The chain, always non-empty.</returns>
+    /// <remarks>
+    /// Non-nullable, because the two unconditional entries mean it can never be empty. It used to
+    /// return <c>List&lt;Type&gt;?</c> with a <c>Count > 0</c> check that no input could fail, which
+    /// made every caller null-check for a case that does not exist. It also took the skill and ignored
+    /// it.
+    /// </remarks>
+    private static List<Type> ResolveMiddlewareTypes(SkillAgentOptions options)
     {
-        var union = skills
-            .Where(s => s.AllowedTools?.Count > 0)
-            .SelectMany(s => s.AllowedTools!)
-            .Distinct(StringComparer.OrdinalIgnoreCase)
-            .ToList();
-
-        return union.Count > 0 ? union : null;
-    }
-
-    private List<Type>? ResolveMiddlewareTypes(SkillDefinition skill, SkillAgentOptions options)
-    {
-        var types = new List<Type>();
-
-        types.Add(typeof(Middleware.ObservabilityMiddleware));
-        types.Add(typeof(Middleware.ToolDiagnosticsMiddleware));
+        var types = new List<Type>
+        {
+            typeof(Middleware.ObservabilityMiddleware),
+            typeof(Middleware.ToolDiagnosticsMiddleware)
+        };
 
         if (options.MiddlewareTypes?.Count > 0)
             types.AddRange(options.MiddlewareTypes);
 
-        return types.Count > 0 ? types : null;
+        return types;
     }
 
     private static Dictionary<string, object> BuildAdditionalProperties(SkillDefinition skill, SkillAgentOptions options)

--- a/src/Content/Application/Application.AI.Common/Factories/AgentExecutionContextFactory.Resolution.cs
+++ b/src/Content/Application/Application.AI.Common/Factories/AgentExecutionContextFactory.Resolution.cs
@@ -24,6 +24,17 @@ public partial class AgentExecutionContextFactory
         return null;
     }
 
+    /// <summary>
+    /// The deployment a skill's agent runs against: an explicit per-call name, then the skill's own
+    /// override, then a <c>deployment</c> metadata entry, then <see cref="DefaultDeployment"/>.
+    /// </summary>
+    /// <remarks>
+    /// One deliberate behaviour change while routing this through <see cref="DefaultDeployment"/>: a
+    /// <c>deployment</c> metadata entry whose value stringifies to <see langword="null"/> used to fall
+    /// back to the literal <c>"default"</c>, bypassing the host's configured deployment. It now falls
+    /// back to the configured one like every other path here. Unreachable with config-loaded metadata,
+    /// where values are strings, but the old literal was a config bypass rather than a fallback.
+    /// </remarks>
     private string ResolveDeploymentName(SkillDefinition skill, SkillAgentOptions options)
     {
         if (!string.IsNullOrEmpty(options.DeploymentName))

--- a/src/Content/Application/Application.AI.Common/Factories/AgentExecutionContextFactory.cs
+++ b/src/Content/Application/Application.AI.Common/Factories/AgentExecutionContextFactory.cs
@@ -144,11 +144,15 @@ public partial class AgentExecutionContextFactory
         var effectiveAllowedTools = ResolveEffectiveAllowlist(skills, options, allowedTools);
         var mergedToolChain = await _toolChainBuilder.BuildMergedToolsWithSourcesAsync(skills, options, effectiveAllowedTools);
         var tools = mergedToolChain.Tools.ToList();
-        var middlewareTypes = ResolveMiddlewareTypes(primarySkill, options);
+        var middlewareTypes = ResolveMiddlewareTypes(options);
         // The rail ends with the measurer that charges what it injects into every turn — appended inside
-        // the builder, not here, so nothing outside can displace it from last (issues #266, #271).
+        // the builder and handed back read-only, so nothing out here can displace it from last
+        // (issues #266, #271, #277). The rule itself is stated on AppendPerTurnBudgetProvider.
         var aiContextProviders = BuildMergedAIContextProviders(
-            skills.Count, effectiveAllowedTools, disclosableSkills, agentName, instruction, tools.Count);
+            skills.Count,
+            effectiveAllowedTools,
+            disclosableSkills,
+            new PerTurnBudgetBaseline(agentName, instruction, tools.Count));
 
         var frameworkType = options.FrameworkType
             ?? ResolveFrameworkTypeFromMetadata(primarySkill)
@@ -158,26 +162,7 @@ public partial class AgentExecutionContextFactory
         // Resolve or create a trace scope for this execution
         var traceScope = options.TraceScope ?? TraceScope.ForExecution(Guid.NewGuid());
 
-        // Track context budget allocations
-        if (_budgetTracker != null)
-        {
-            _budgetTracker.RecordAndPublish(
-                agentName,
-                ContextConventions.BudgetComponents.SystemPrompt,
-                ContextConventions.SourceTypeValues.SystemPrompt,
-                TokenEstimationHelper.EstimateTokens(instruction),
-                ContextBudgetMetrics.SystemPromptTokens);
-
-            if (tools?.Count > 0)
-            {
-                _budgetTracker.RecordAndPublish(
-                    agentName,
-                    ContextConventions.BudgetComponents.ToolSchemas,
-                    ContextConventions.SourceTypeValues.ToolsSchema,
-                    TokenEstimationHelper.EstimateToolSchemaTokens(tools.Count),
-                    ContextBudgetMetrics.ToolsSchemaTokens);
-            }
-        }
+        RecordStaticContextBudget(agentName, instruction, tools.Count);
 
         var additionalProps = BuildAdditionalProperties(primarySkill, options);
 
@@ -187,51 +172,8 @@ public partial class AgentExecutionContextFactory
         if (prerequisiteMap.HasAnyPrerequisites)
             additionalProps[SkillPrerequisiteMap.AdditionalPropertiesKey] = prerequisiteMap;
 
-        // Stash the composed resilient chat client for AgentFactory to consume. Gated on:
-        // (a) ResilienceConfig.Enabled — when off the provider would return the PRIMARY raw
-        //     client, which must not override the per-context resolution above; and
-        // (b) ResilientClientEligibility — the fallback chain can only stand in for a context
-        //     that resolved to exactly the primary configured provider + default deployment.
-        //     Per-skill/per-options overrides, PersistentAgents (AgentId-bound), FoundryResponses,
-        //     and Echo contexts keep their raw client.
-        if (_resilientChatClientProvider is not null
-            && _appConfig.CurrentValue.AI?.Resilience?.Enabled == true)
-        {
-            if (ResilientClientEligibility.IsEligible(
-                    frameworkType, deploymentName, _appConfig.CurrentValue.AI?.AgentFramework))
-            {
-                var resilientClient = await _resilientChatClientProvider.GetResilientChatClientAsync();
-                additionalProps[IResilientChatClientProvider.AdditionalPropertiesKey] = resilientClient;
-
-                _logger.LogDebug("Stashed resilient chat client (fallback chain) for agent {AgentName}", agentName);
-            }
-            else
-            {
-                _logger.LogDebug(
-                    "Resilience enabled but agent {AgentName} keeps its raw client: resolved {FrameworkType}/{Deployment} is not the primary configured provider/deployment",
-                    agentName, frameworkType, deploymentName);
-            }
-        }
-
-        // Start a trace run when a store is wired in
-        if (_traceStore != null)
-        {
-            var metadata = new RunMetadata
-            {
-                AgentName = agentName,
-                StartedAt = DateTimeOffset.UtcNow
-            };
-            var traceWriter = await _traceStore.StartRunAsync(traceScope, metadata);
-            additionalProps[ITraceWriter.AdditionalPropertiesKey] = traceWriter;
-
-            // Set candidate baggage on the current Activity for CausalSpanAttributionProcessor
-            if (traceScope.CandidateId.HasValue)
-            {
-                System.Diagnostics.Activity.Current?.AddBaggage(
-                    Domain.AI.Telemetry.Conventions.ToolConventions.HarnessCandidateId,
-                    traceScope.CandidateId.Value.ToString("D"));
-            }
-        }
+        await StashResilientChatClientAsync(additionalProps, agentName, frameworkType, deploymentName);
+        await StartTraceRunAsync(additionalProps, agentName, traceScope);
 
         var context = new AgentExecutionContext
         {
@@ -267,6 +209,119 @@ public partial class AgentExecutionContextFactory
     }
 
     /// <summary>
+    /// Records what the agent's static context costs before a single turn runs: the system prompt and
+    /// the tool schemas.
+    /// </summary>
+    /// <param name="agentName">The agent whose budget these are charged to.</param>
+    /// <param name="instruction">The composed static system prompt.</param>
+    /// <param name="toolCount">How many tool schemas the agent ships with.</param>
+    /// <remarks>
+    /// These two are charged once, at construction, because they are the same on every turn. What the
+    /// context-provider rail adds per turn is charged separately by
+    /// <see cref="Services.Agent.PerTurnBudgetContextProvider"/>, which subtracts exactly these figures
+    /// as its baseline so the prompt is not billed again every turn.
+    /// </remarks>
+    private void RecordStaticContextBudget(string agentName, string instruction, int toolCount)
+    {
+        if (_budgetTracker is null)
+            return;
+
+        _budgetTracker.RecordAndPublish(
+            agentName,
+            ContextConventions.BudgetComponents.SystemPrompt,
+            ContextConventions.SourceTypeValues.SystemPrompt,
+            TokenEstimationHelper.EstimateTokens(instruction),
+            ContextBudgetMetrics.SystemPromptTokens);
+
+        if (toolCount > 0)
+        {
+            _budgetTracker.RecordAndPublish(
+                agentName,
+                ContextConventions.BudgetComponents.ToolSchemas,
+                ContextConventions.SourceTypeValues.ToolsSchema,
+                TokenEstimationHelper.EstimateToolSchemaTokens(toolCount),
+                ContextBudgetMetrics.ToolsSchemaTokens);
+        }
+    }
+
+    /// <summary>
+    /// Stashes the composed resilient chat client for <c>AgentFactory</c> to consume, when this agent is
+    /// one the fallback chain may stand in for.
+    /// </summary>
+    /// <param name="additionalProps">The context's property bag, written to on success.</param>
+    /// <param name="agentName">The agent being built; diagnostics only.</param>
+    /// <param name="frameworkType">The framework this context resolved to.</param>
+    /// <param name="deploymentName">The deployment this context resolved to.</param>
+    /// <remarks>
+    /// Two gates, and both matter. <c>ResilienceConfig.Enabled</c>, because when resilience is off the
+    /// provider returns the PRIMARY raw client, which must not override the per-context resolution
+    /// already made. And <see cref="ResilientClientEligibility"/>, because the fallback chain can
+    /// only stand in for a context that resolved to exactly the primary configured provider and default
+    /// deployment — per-skill or per-options overrides, <c>PersistentAgents</c> (which is AgentId-bound),
+    /// <c>FoundryResponses</c> and <c>Echo</c> all keep their raw client.
+    /// </remarks>
+    private async Task StashResilientChatClientAsync(
+        Dictionary<string, object> additionalProps,
+        string agentName,
+        AIAgentFrameworkClientType frameworkType,
+        string deploymentName)
+    {
+        if (_resilientChatClientProvider is null
+            || _appConfig.CurrentValue.AI?.Resilience?.Enabled != true)
+            return;
+
+        if (!ResilientClientEligibility.IsEligible(
+                frameworkType, deploymentName, _appConfig.CurrentValue.AI?.AgentFramework))
+        {
+            _logger.LogDebug(
+                "Resilience enabled but agent {AgentName} keeps its raw client: resolved {FrameworkType}/{Deployment} is not the primary configured provider/deployment",
+                agentName, frameworkType, deploymentName);
+            return;
+        }
+
+        additionalProps[IResilientChatClientProvider.AdditionalPropertiesKey] =
+            await _resilientChatClientProvider.GetResilientChatClientAsync();
+
+        _logger.LogDebug("Stashed resilient chat client (fallback chain) for agent {AgentName}", agentName);
+    }
+
+    /// <summary>
+    /// Starts a trace run for this execution and stashes its writer, when a trace store is wired in.
+    /// </summary>
+    /// <param name="additionalProps">The context's property bag, written to on success.</param>
+    /// <param name="agentName">The agent being traced.</param>
+    /// <param name="traceScope">The scope this execution runs under.</param>
+    /// <remarks>
+    /// The candidate baggage is set on the ambient activity rather than passed anywhere, because
+    /// <c>CausalSpanAttributionProcessor</c> reads it off the activity from inside the exporter pipeline
+    /// — there is no call path between the two to hand it along.
+    /// </remarks>
+    private async Task StartTraceRunAsync(
+        Dictionary<string, object> additionalProps,
+        string agentName,
+        TraceScope traceScope)
+    {
+        if (_traceStore is null)
+            return;
+
+        var metadata = new RunMetadata
+        {
+            AgentName = agentName,
+            StartedAt = DateTimeOffset.UtcNow
+        };
+
+        additionalProps[ITraceWriter.AdditionalPropertiesKey] =
+            await _traceStore.StartRunAsync(traceScope, metadata);
+
+        if (traceScope.CandidateId.HasValue)
+        {
+            System.Diagnostics.Activity.Current?.AddBaggage(
+                Domain.AI.Telemetry.Conventions.ToolConventions.HarnessCandidateId,
+                traceScope.CandidateId.Value.ToString("D"));
+        }
+    }
+
+    /// <summary>
     /// Creates an execution context for a delegated agent. Used by <see cref="Interfaces.Agents.ISupervisor"/>
     /// when delegating a task. Bypasses skill-based tool resolution — tools are resolved separately
     /// by the supervisor using <see cref="Interfaces.Agents.ISubagentToolResolver"/>.
@@ -277,13 +332,15 @@ public partial class AgentExecutionContextFactory
         int delegationDepth,
         Guid delegationId)
     {
-        var deploymentName = definition.ModelOverride
-            ?? _appConfig.CurrentValue.AI?.AgentFramework?.DefaultDeployment
-            ?? "default";
+        var deploymentName = definition.ModelOverride ?? DefaultDeployment;
 
         var context = new AgentExecutionContext
         {
-            Name = definition.AgentType + "Agent",
+            // Through ToAgentName, which already owns this rule and is idempotent for a name that
+            // already ends in "Agent". The hand-written concatenation here produced the same string
+            // today only because AgentType is an enum and so is never "Agent"-suffixed — a second copy
+            // of a rule, correct by coincidence.
+            Name = ToAgentName(definition.AgentType.ToString()),
             Instruction = definition.SystemPromptOverride,
             DeploymentName = deploymentName,
             DelegationDepth = delegationDepth,

--- a/src/Content/Application/Application.AI.Common/Factories/AgentExecutionContextFactory.cs
+++ b/src/Content/Application/Application.AI.Common/Factories/AgentExecutionContextFactory.cs
@@ -145,6 +145,12 @@ public partial class AgentExecutionContextFactory
         var mergedToolChain = await _toolChainBuilder.BuildMergedToolsWithSourcesAsync(skills, options, effectiveAllowedTools);
         var tools = mergedToolChain.Tools.ToList();
         var middlewareTypes = ResolveMiddlewareTypes(options);
+
+        // What the agent is charged for up front. The same figures are recorded once below and handed to
+        // the per-turn measurer as the baseline it subtracts, so the two MUST agree — which is why they
+        // travel as one value rather than as three arguments spelled out twice.
+        var staticBudget = new PerTurnBudgetBaseline(agentName, instruction, tools.Count);
+
         // The rail ends with the measurer that charges what it injects into every turn — appended inside
         // the builder and handed back read-only, so nothing out here can displace it from last
         // (issues #266, #271, #277). The rule itself is stated on AppendPerTurnBudgetProvider.
@@ -152,7 +158,7 @@ public partial class AgentExecutionContextFactory
             skills.Count,
             effectiveAllowedTools,
             disclosableSkills,
-            new PerTurnBudgetBaseline(agentName, instruction, tools.Count));
+            staticBudget);
 
         var frameworkType = options.FrameworkType
             ?? ResolveFrameworkTypeFromMetadata(primarySkill)
@@ -162,7 +168,7 @@ public partial class AgentExecutionContextFactory
         // Resolve or create a trace scope for this execution
         var traceScope = options.TraceScope ?? TraceScope.ForExecution(Guid.NewGuid());
 
-        RecordStaticContextBudget(agentName, instruction, tools.Count);
+        RecordStaticContextBudget(staticBudget);
 
         var additionalProps = BuildAdditionalProperties(primarySkill, options);
 
@@ -212,34 +218,36 @@ public partial class AgentExecutionContextFactory
     /// Records what the agent's static context costs before a single turn runs: the system prompt and
     /// the tool schemas.
     /// </summary>
-    /// <param name="agentName">The agent whose budget these are charged to.</param>
-    /// <param name="instruction">The composed static system prompt.</param>
-    /// <param name="toolCount">How many tool schemas the agent ships with.</param>
+    /// <param name="baseline">
+    /// The figures to charge. This is the same value handed to the rail builder, deliberately: the
+    /// measurer subtracts exactly what is recorded here, and taking one value rather than three
+    /// arguments is what stops the two from being spelled out differently.
+    /// </param>
     /// <remarks>
     /// These two are charged once, at construction, because they are the same on every turn. What the
     /// context-provider rail adds per turn is charged separately by
     /// <see cref="Services.Agent.PerTurnBudgetContextProvider"/>, which subtracts exactly these figures
     /// as its baseline so the prompt is not billed again every turn.
     /// </remarks>
-    private void RecordStaticContextBudget(string agentName, string instruction, int toolCount)
+    private void RecordStaticContextBudget(PerTurnBudgetBaseline baseline)
     {
         if (_budgetTracker is null)
             return;
 
         _budgetTracker.RecordAndPublish(
-            agentName,
+            baseline.AgentName,
             ContextConventions.BudgetComponents.SystemPrompt,
             ContextConventions.SourceTypeValues.SystemPrompt,
-            TokenEstimationHelper.EstimateTokens(instruction),
+            TokenEstimationHelper.EstimateTokens(baseline.Instruction),
             ContextBudgetMetrics.SystemPromptTokens);
 
-        if (toolCount > 0)
+        if (baseline.ToolCount > 0)
         {
             _budgetTracker.RecordAndPublish(
-                agentName,
+                baseline.AgentName,
                 ContextConventions.BudgetComponents.ToolSchemas,
                 ContextConventions.SourceTypeValues.ToolsSchema,
-                TokenEstimationHelper.EstimateToolSchemaTokens(toolCount),
+                TokenEstimationHelper.EstimateToolSchemaTokens(baseline.ToolCount),
                 ContextBudgetMetrics.ToolsSchemaTokens);
         }
     }

--- a/src/Content/Application/Application.AI.Common/Helpers/ToolCeilingResolver.cs
+++ b/src/Content/Application/Application.AI.Common/Helpers/ToolCeilingResolver.cs
@@ -62,8 +62,7 @@ public static class ToolCeilingResolver
         ArgumentNullException.ThrowIfNull(declarations);
 
         var union = declarations
-            .Where(d => d is not null)
-            .SelectMany(d => d!)
+            .SelectMany(d => d ?? [])
             .Distinct(StringComparer.OrdinalIgnoreCase)
             .ToList();
 

--- a/src/Content/Application/Application.AI.Common/Helpers/ToolCeilingResolver.cs
+++ b/src/Content/Application/Application.AI.Common/Helpers/ToolCeilingResolver.cs
@@ -27,6 +27,50 @@ namespace Application.AI.Common.Helpers;
 public static class ToolCeilingResolver
 {
     /// <summary>
+    /// Combines the allowlists several declarations each grant into the single unbounded-or-bounded
+    /// input <see cref="ApplyCeiling"/> expects.
+    /// </summary>
+    /// <param name="declarations">
+    /// One allowlist per declaration. A <see langword="null"/> or empty entry is a declaration that
+    /// restricts nothing and contributes nothing. Typed as a sequence of sequences rather than of
+    /// lists because callers hold these as <c>IList</c>, <c>IReadOnlyList</c> and arrays, and neither
+    /// list interface converts to the other in this position.
+    /// </param>
+    /// <returns>
+    /// The de-duplicated union, or <see langword="null"/> when no declaration restricted anything —
+    /// <em>unbounded</em>, which is what a ceiling then caps.
+    /// </returns>
+    /// <remarks>
+    /// <para>
+    /// This is the step that <em>produces</em> the null-versus-empty distinction the rest of this type
+    /// depends on, so it belongs beside <see cref="ApplyCeiling"/> rather than in the factory that
+    /// happens to call it. It lived there, private, which meant the union half of the invariant could
+    /// only be exercised by constructing an entire agent factory with four collaborators.
+    /// </para>
+    /// <para>
+    /// Union, not intersection, and deliberately: an agent built from several skills may use what any
+    /// of them grants. Narrowing happens afterwards and only through <see cref="ApplyCeiling"/>, which
+    /// is the one place that can tighten.
+    /// </para>
+    /// <para>
+    /// Kept to strings so this helper takes no dependency on the skill domain model, and so the same
+    /// primitive serves any future caller whose declarations are not skills.
+    /// </para>
+    /// </remarks>
+    public static IReadOnlyList<string>? Union(IEnumerable<IEnumerable<string>?> declarations)
+    {
+        ArgumentNullException.ThrowIfNull(declarations);
+
+        var union = declarations
+            .Where(d => d is not null)
+            .SelectMany(d => d!)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        return union.Count > 0 ? union : null;
+    }
+
+    /// <summary>
     /// Caps <paramref name="current"/> by an optional tool <paramref name="ceiling"/>, tighten-only.
     /// </summary>
     /// <param name="current">

--- a/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentExecutionContextFactoryRailOrderTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentExecutionContextFactoryRailOrderTests.cs
@@ -165,7 +165,32 @@ public sealed class AgentExecutionContextFactoryRailOrderTests : IDisposable
             + "records. If this list needs to change, the change is the thing to review — not the test");
     }
 
-    // ── Rule 2: the measurer is last, in every configuration ──────────────────
+    // ── Rule 2: the measurer is last, and stays last ──────────────────────────
+
+    [Fact]
+    public async Task MapToAgentContext_AppendingToTheBuiltRail_IsRefused()
+    {
+        // The rail leaves the factory through a settable IList property and is handed to the framework
+        // as one, so no type on that path can express "this list is finished". Refusing the append is
+        // therefore the instance's own job (issue #277).
+        //
+        // Displacement is the failure this refuses. A provider appended after the measurer pushes it out
+        // of last place, and from any earlier position it charges the turn for less than the turn
+        // actually cost — so the budget meant to bound a conversation stops bounding it, silently, in
+        // the direction nobody notices.
+        var context = await CreateFactory().MapToAgentContextAsync([MakeSkill()], new SkillAgentOptions());
+
+        var append = () => context.AIContextProviders!.Add(new ToolPermissionFilter([AllowedTool]));
+
+        append.Should().Throw<NotSupportedException>(
+            "a consumer that appends to a finished rail must fail loudly rather than silently displace "
+            + "the per-turn measurer from the last position");
+
+        RailTypes(context)[^1].Should().Be(typeof(PerTurnBudgetContextProvider),
+            "the refused append must also leave the rail as it was");
+    }
+
+    // ── Rule 2 continued: the measurer is last, in every configuration ────────
 
     [Theory]
     [InlineData(true, true)]

--- a/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentExecutionContextFactoryRailOrderTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentExecutionContextFactoryRailOrderTests.cs
@@ -190,6 +190,37 @@ public sealed class AgentExecutionContextFactoryRailOrderTests : IDisposable
             "the refused append must also leave the rail as it was");
     }
 
+    [Fact]
+    public async Task MapToAgentContext_TheReadOnlyRail_IsAcceptedByTheFrameworkAgentItIsBuiltFor()
+    {
+        // The other half of #277. Refusing the append is only safe if the framework itself never needed to
+        // mutate the rail — and nothing else in this suite would notice if a future Microsoft.Agents.AI
+        // upgrade started to, because every other test reads the rail without ever handing it to a real
+        // agent. That would surface in production as a NotSupportedException at agent construction.
+        var context = await CreateFactory().MapToAgentContextAsync([MakeSkill()], new SkillAgentOptions());
+
+        // Control: the instrument can fail. Without this, an agent that quietly ignored the rail entirely
+        // would satisfy the assertion below just as well as one that handles it correctly.
+        var append = () => context.AIContextProviders!.Add(new ToolPermissionFilter([AllowedTool]));
+        append.Should().Throw<NotSupportedException>(
+            "control: the rail handed over below must be one that would throw if the framework mutated it");
+
+        // Built the way AgentFactory builds it, so this exercises the shape production actually hands over.
+        using var chatClient = new Fakes.FakeChatClient().WithDefaultResponse("ok");
+        var agent = new ChatClientAgent(chatClient, new ChatClientAgentOptions
+        {
+            Name = context.Name,
+            ChatOptions = new ChatOptions { Instructions = context.Instruction },
+            AIContextProviders = context.AIContextProviders
+        });
+
+        var run = async () => await agent.RunAsync("hello");
+
+        await run.Should().NotThrowAsync(
+            "the framework consumes the rail as a sequence and copies it, so handing it out read-only is "
+            + "safe; if an upgrade changes that, this fails here rather than in a host's production logs");
+    }
+
     // ── Rule 2 continued: the measurer is last, in every configuration ────────
 
     [Theory]

--- a/src/Content/Tests/Application.AI.Common.Tests/Helpers/ToolCeilingResolverTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Helpers/ToolCeilingResolverTests.cs
@@ -151,4 +151,44 @@ public sealed class ToolCeilingResolverTests
 
         result.Should().BeNull();
     }
+
+    // ── Union: the step that PRODUCES the null-versus-empty distinction ───────
+    //
+    // This half of the invariant used to live private inside the agent factory, where exercising it
+    // meant constructing the whole factory with four collaborators to assert a six-line pure function.
+    // The distinction it produces is what every ApplyCeiling test above depends on.
+
+    [Fact]
+    public void Union_NoDeclarationRestrictsAnything_IsUnbounded()
+    {
+        // The case that matters most: null means "nothing restricted this", which a later ceiling then
+        // caps from "everything". Returning an empty list here instead would mean deny-all, and an
+        // agent whose skills declare no allowlist would silently lose every tool.
+        var result = ToolCeilingResolver.Union([null, [], null]);
+
+        result.Should().BeNull(
+            "no declaration restricting anything is unbounded, not a restriction that permits nothing");
+    }
+
+    [Fact]
+    public void Union_SeveralDeclarations_CombinesThemCaseInsensitivelyWithoutDuplicates()
+    {
+        var result = ToolCeilingResolver.Union([["read", "write"], ["READ", "search"], null]);
+
+        result.Should().BeEquivalentTo(["read", "write", "search"]);
+    }
+
+    [Fact]
+    public void Union_ThenCeiling_NarrowsRatherThanWidens()
+    {
+        // The two halves composed, which is how the factory uses them: several declarations grant a
+        // union, and the agent's own ceiling can only cut that down. A ceiling naming a tool no
+        // declaration granted must not add it.
+        var granted = ToolCeilingResolver.Union([["read", "write"], ["search"]]);
+
+        var capped = ToolCeilingResolver.ApplyCeiling(granted, ["read", "delete"]);
+
+        capped.Should().BeEquivalentTo(["read"],
+            "a ceiling tightens the granted set and can never introduce a tool nothing granted");
+    }
 }


### PR DESCRIPTION
Closes #277. Closes #274.

Both are follow-ups from the `AgentExecutionContextFactory` split (#270/#251) and its review pass (#271/#275), and both live in the same two files, so they ship together.

## #277 — the rail is now handed out read-only

`BuildMergedAIContextProviders` already appended the per-turn budget measurer from its own tail, so "the measurer is last" was a property of the builder rather than of a call sequence elsewhere. It was still only a property of *construction*: the rail left the factory as a mutable `IList<AIContextProvider>` on a settable property, so anything that appended to it displaced the measurer.

That direction of failure is the bad one. The measurer only measures correctly from last place — the runtime feeds each provider the accumulated output of the ones before it — so from any earlier position it under-charges the turn, and the budget meant to bound a conversation quietly stops bounding it with nothing erroring.

The builder now returns `providers.AsReadOnly()`. Appending throws instead. The issue offered three options; this is option 1.

**The issue said the framework's acceptance of a read-only list "needs verifying before planning anything", and it does — so it was verified rather than assumed.** Two independent ways:

- **Decompiling the shipped `Microsoft.Agents.AI` 1.13.0 assembly.** `ChatClientAgentOptions.AIContextProviders` is typed `IEnumerable<AIContextProvider>`, so `Add` is not reachable through the declared type at all; and the `ChatClientAgent` constructor calls `options.Clone()`, which copies the providers into a framework-owned `List<T>` before doing anything else. Zero mutation verbs across all 13 references to the member, in both the `net9.0` and `net10.0` assets.
- **A runtime probe.** Constructed and ran an agent with a mutable `List` control and a `ReadOnlyCollection` subject, plus a positive instrument check confirming `Add()` on that exact collection does throw. Neither case mutated.

Worth knowing as a side effect: because the framework *copies* the rail at construction, mutating it afterwards never affected the agent anyway. `AsReadOnly()` enforces what the framework already assumed.

Two tests now hold this. One appends to a built rail and asserts the refusal. The other hands a factory-built rail to a real `ChatClientAgent` and runs a turn, with the append refusal as its control — so a future MAF upgrade that starts rejecting or mutating read-only lists fails here rather than in a host's production logs. Nothing in the suite covered that before: every other test reads the rail without ever giving it to an agent.

## #274 — the eight deferred cleanups

**1. The tool-ceiling invariant is no longer split across two files.** `ToolCeilingResolver.Union` sits beside `ApplyCeiling`, where it belongs: it is the step that *produces* the null-means-unbounded versus empty-means-deny-all distinction the rest of that type depends on. It lived private inside the factory, so exercising it meant constructing an entire agent factory with four collaborators to assert a six-line pure function. Three tests now cover it directly, including the composition of both halves.

Typed as a sequence of sequences rather than of lists, because `SkillDefinition.AllowedTools` is `IList<string>` and neither list interface converts to the other in that position — found by the compiler, not by guessing.

**2 & 3. Two rules that were written twice.** `CreateFromDelegation` hand-wrote the default-deployment fallback and the agent-naming rule, both of which already had owners in a different file after the split — so an edit that did not grep would have missed one. Both now call through. The naming one produced the same string today only because `AgentType` is an enum and so is never already "Agent"-suffixed: correct by coincidence.

**4. `ResolveMiddlewareTypes` no longer advertises a case that cannot happen.** It is `static`, ignores no parameter, and returns a non-nullable list — its two unconditional entries mean it could never return null, so every caller was null-checking for nothing.

**5. The orchestration method is 107 lines, from ~170.** Three self-contained stanzas became named methods: recording what the static context costs, stashing the resilient chat client, and starting the trace run. Pure extraction — same calls, same order, same conditions.

**6. The two recall providers were the same five steps written twice.** One generic helper now wires either. The lazy resolution of `IAmbientRequestScope` is preserved deliberately and said so in the docs: both feature flags default to disabled, so the default path still makes zero service lookups, and hoisting the resolution would make one unconditionally on every agent construction. The builder is 70 lines, from 79.

**7. Three parameters became one named concept.** `PerTurnBudgetBaseline(AgentName, Instruction, ToolCount)` — they were only ever read as a set, and threading them through two signatures was three chances to reorder two strings. Review caught that the first pass packed the value at one line and unpacked it into three loose arguments at the next; the recording call takes the value too, so the two figures that *must* agree — what is charged, and what the measurer subtracts — now agree structurally.

**8. The lastness rule is stated once.** It was in four places in one file; it is now canonical on `AppendPerTurnBudgetProvider` and referenced from the other three. Four places to edit for one rule is four places that can disagree.

### Also from review

- `AddRecallProvider` originally took the feature flag as a parameter, which meant both call sites allocated a closure on the **default** path — where the old inline code allocated none — for two features that are off unless a host turns them on. The flag check moved to the call site, and the generic type parameter, which existed only to produce a log string, went with it.
- One behaviour change surfaced that was not a mechanical cleanup and is called out rather than buried: a `deployment` metadata entry that stringifies to null used to fall back to the literal `"default"`, **bypassing the host's configured deployment**. It now falls back to the configured one like every other branch. Unreachable with config-loaded metadata, but the old literal was a config bypass rather than a fallback.

## Verification

Full solution green. Mutation-tested:

| mutation | result |
|---|---|
| hand the rail back mutable (`providers` instead of `providers.AsReadOnly()`) | RED — the new append test |

The remaining seven items are behaviour-preserving by construction, and the existing suite is what says so: the rail-order tests assert the exact provider sequence, and `ToolCeilingResolverTests` now covers both halves of the ceiling invariant rather than one.

## Rejected, with the reason

The phase-typed rail builder (`AddToolContributor` → `SealTools` → `AddInstructionProvider` → `Build`) that #274 recorded as the only genuinely structural option. It would make an invalid order unexpressible rather than merely asserted, but it is a new type plus a rewrite of the builder to protect a closed six-item set with no extension point. The read-only hand-off closes the hazard that actually exists; revisit the phase types only if the rail becomes externally extensible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
