### PR TITLE
fix: bump the runner that crashes on teardown, and explain it when it does

### DIFF
--- a/.github/scripts/explain-runner-crash.sh
+++ b/.github/scripts/explain-runner-crash.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+#
+# Explains a `dotnet test` failure that is NOT a test failure.
+#
+# The test runner can crash tearing down its symbol reader AFTER every assembly has already reported
+# Passed. The job then ends with nothing but green per-assembly summaries and `Process completed with
+# exit code 1`; the only signal is a `Catastrophic failure` line roughly forty lines above the end,
+# sandwiched between ordinary skip messages. Anyone reading the tail of the log — or the check name
+# alone — concludes a test broke and spends a debugging cycle hunting a product regression that is
+# not there. One occurrence cost exactly that (issue #263).
+#
+# This does not recover the run. It makes the red legible: a GitHub error annotation on the check,
+# and the crash excerpt in the job summary.
+#
+# Usage: explain-runner-crash.sh <path-to-tee'd-test-log>
+# Exit:  always 0 — this is a diagnostic, and it runs when the build has already failed. Failing here
+#        would replace a confusing message with a confusing message plus a second red step.
+
+set -uo pipefail
+
+log="${1:?usage: explain-runner-crash.sh <test-log>}"
+
+if [ ! -f "$log" ]; then
+    echo "explain-runner-crash: no log at '$log' — nothing to explain."
+    exit 0
+fi
+
+if ! grep -q "Catastrophic failure" "$log"; then
+    echo "explain-runner-crash: no runner crash detected — this is a real test failure."
+    exit 0
+fi
+
+echo "::error title=Test runner crashed during teardown::The test RUNNER crashed, not a test. Every assembly may still report Passed. See issue #263."
+
+# GITHUB_STEP_SUMMARY is absent when this is run locally; fall back to stdout so the script is
+# runnable by hand against a downloaded log, which is the situation it exists to serve.
+summary="${GITHUB_STEP_SUMMARY:-/dev/stdout}"
+
+{
+    echo "## Test runner crashed — this is probably not a product regression"
+    echo
+    echo "The runner exited non-zero after the tests had already run, so the per-assembly"
+    echo "summaries may all say **Passed**. Background and remedies: issue #263."
+    echo
+    echo '```'
+    grep -B 2 -A 12 "Catastrophic failure" "$log" | head -60
+    echo '```'
+} >> "$summary"
+
+exit 0

--- a/.github/scripts/tests/explain-runner-crash.tests.sh
+++ b/.github/scripts/tests/explain-runner-crash.tests.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+#
+# Tests for explain-runner-crash.sh, plus the one shell behaviour the CI steps that call it depend
+# on: `set -o pipefail` must preserve a failing exit code through `tee`.
+#
+# That second check is the load-bearing one. `dotnet test ... | tee log` without pipefail reports
+# SUCCESS on every test failure — strictly worse than having no gate at all — and nothing about the
+# YAML would look wrong. The mutation case below is what proves the pipefail line is doing work
+# rather than decorating.
+#
+# Run: bash .github/scripts/tests/explain-runner-crash.tests.sh
+
+set -uo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+subject="$script_dir/../explain-runner-crash.sh"
+fails=0
+
+check() {
+    if [ "$2" = "$3" ]; then
+        printf 'PASS  %s\n' "$1"
+    else
+        printf 'FAIL  %s (expected %q, got %q)\n' "$1" "$3" "$2"
+        fails=$((fails + 1))
+    fi
+}
+
+# ── pipefail through tee: what the calling CI steps rely on ──────────────────
+( set -o pipefail; (exit 7) | tee /dev/null ) >/dev/null 2>&1
+check "failing command through tee, WITH pipefail, propagates" "$?" "7"
+
+# Mutation. Drop pipefail and the same pipeline reports success. If this ever starts matching the
+# case above, pipefail has stopped mattering and the check above has stopped proving anything.
+#
+# `set +o pipefail` explicitly, because a subshell INHERITS the option from this script's own
+# prologue — without the reset, this line silently re-tests the case above and passes for the wrong
+# reason. It did exactly that on first run.
+( set +o pipefail; (exit 7) | tee /dev/null ) >/dev/null 2>&1
+check "failing command through tee, WITHOUT pipefail, is swallowed (the trap)" "$?" "0"
+
+# ── the subject ─────────────────────────────────────────────────────────────
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+cat > "$tmp/crash.log" <<'EOF'
+  Passed!  - Failed: 0, Passed: 2819, Skipped: 3, Total: 2822 - Infrastructure.AI.Tests.dll
+Infrastructure.AI.Tests: Catastrophic failure: System.NullReferenceException
+   at Microsoft.VisualStudio.TestPlatform.ObjectModel.Navigation.PortableSymbolReader.Dispose()
+   at Xunit.Runner.VisualStudio.VsTestRunner.RunTestsInAssembly()
+  Passed!  - Failed: 0, Passed: 410, Skipped: 0, Total: 410 - Presentation.AgentHub.Tests.dll
+EOF
+
+cat > "$tmp/real-failure.log" <<'EOF'
+  [xUnit.net] SomeTests.DoesTheThing [FAIL]
+  Failed!  - Failed: 1, Passed: 2818, Skipped: 3, Total: 2822 - Infrastructure.AI.Tests.dll
+EOF
+
+run_subject() {
+    GITHUB_STEP_SUMMARY="$tmp/summary.md" bash "$subject" "$1" 2>&1
+}
+
+: > "$tmp/summary.md"
+out="$(run_subject "$tmp/crash.log")"
+check "runner-crash log emits the error annotation" \
+    "$(printf '%s' "$out" | grep -c '^::error title=Test runner crashed')" "1"
+check "runner-crash log writes the excerpt to the job summary" \
+    "$(grep -c 'PortableSymbolReader' "$tmp/summary.md")" "1"
+
+: > "$tmp/summary.md"
+out="$(run_subject "$tmp/real-failure.log")"
+check "ordinary test failure emits no annotation" \
+    "$(printf '%s' "$out" | grep -c '^::error')" "0"
+check "ordinary test failure writes nothing to the job summary" \
+    "$(wc -c < "$tmp/summary.md" | tr -d ' ')" "0"
+
+# A build that fails before dotnet writes anything must not turn one confusing red into two.
+: > "$tmp/summary.md"
+run_subject "$tmp/does-not-exist.log" >/dev/null
+check "missing log exits clean" "$?" "0"
+
+# And it stays clean on a crash, because the calling step runs only when the build already failed.
+run_subject "$tmp/crash.log" >/dev/null
+check "crash detected still exits clean" "$?" "0"
+
+echo
+if [ "$fails" -eq 0 ]; then
+    echo "ALL PASS"
+else
+    echo "$fails CHECK(S) FAILED"
+fi
+exit "$fails"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,13 +59,38 @@ jobs:
       - name: Build
         run: dotnet build src/AgenticHarness.slnx --no-restore --configuration Release
 
+      # Output is tee'd to a file so the step below can explain a failure the summary lines hide.
+      # `set -o pipefail` is what stops tee from swallowing dotnet's exit code — without it this
+      # step reports success whenever the tests fail, which is the opposite of a gate.
       - name: Unit and integration tests
-        run: >
-          dotnet test src/AgenticHarness.slnx
-          --no-build
-          --configuration Release
-          --collect:"XPlat Code Coverage"
-          --results-directory coverage
+        id: tests
+        run: |
+          set -euo pipefail
+          dotnet test src/AgenticHarness.slnx \
+            --no-build \
+            --configuration Release \
+            --collect:"XPlat Code Coverage" \
+            --results-directory coverage 2>&1 | tee test-output.log
+
+      # Says nothing unless the failure was the runner crashing rather than a test failing. See the
+      # script for what that failure looks like and why it is worth a step of its own.
+      #
+      # Conditioned on the tests step rather than a bare failure(), so a Build or schema failure does
+      # not send it looking at a file that was never written.
+      - name: Explain a test-runner crash
+        if: steps.tests.outcome == 'failure'
+        run: .github/scripts/explain-runner-crash.sh test-output.log
+
+      # The log outlives the workspace on purpose. This crash took one occurrence in four runs to
+      # appear and could not be reproduced, so the run that catches it next is the only evidence
+      # there will be — and a 60-line excerpt in a job summary is not enough to diagnose from.
+      - name: Upload test output
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: test-output
+          path: test-output.log
+          if-no-files-found: ignore
 
       - name: Upload coverage
         uses: actions/upload-artifact@v7
@@ -162,17 +187,28 @@ jobs:
         run: dotnet build src/AgenticHarness.slnx --no-restore --configuration Release
 
       - name: Run OWASP Agentic eval fixtures (hard gate)
+        id: owasp-tests
         # Any Verdict.Fail causes a non-zero exit code and blocks the merge.
         # To document a legitimate bypass, add an entry to .github/eval-bypasses.md
         # with the case id, reason, and expiry date — but the gate still runs.
-        run: >
-          dotnet test
-          src/Content/Tests/Application.AI.Common.Tests/Application.AI.Common.Tests.csproj
-          --no-build
-          --configuration Release
-          --filter "Category=OwaspAgentic"
-          --logger "trx;LogFileName=owasp-agentic-gate.trx"
-          --results-directory owasp-results
+        #
+        # Tee'd like the main test job, and for the same reason: this step asks for a TRX log, which
+        # records per-test source file and line, so it engages the same symbol-reading path the
+        # runner has crashed in (issue #263). A gate that can go red with every test passing is worth
+        # six lines to explain wherever it can happen — not just where it happened first.
+        run: |
+          set -euo pipefail
+          dotnet test \
+            src/Content/Tests/Application.AI.Common.Tests/Application.AI.Common.Tests.csproj \
+            --no-build \
+            --configuration Release \
+            --filter "Category=OwaspAgentic" \
+            --logger "trx;LogFileName=owasp-agentic-gate.trx" \
+            --results-directory owasp-results 2>&1 | tee owasp-test-output.log
+
+      - name: Explain a test-runner crash
+        if: steps.owasp-tests.outcome == 'failure'
+        run: .github/scripts/explain-runner-crash.sh owasp-test-output.log
 
       - name: Upload OWASP gate results
         uses: actions/upload-artifact@v7

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -164,7 +164,23 @@
     <PackageVersion Include="Testcontainers" Version="4.3.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="Xunit.SkippableFact" Version="1.5.23" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.0" />
+    <!--
+      3.1.5, not 3.1.0, because of a double-dispose bug in this package — NOT in the test platform,
+      despite the stack (issue #263). CI failed once with a NullReferenceException thrown from the
+      test platform's PortableSymbolReader.Dispose, called from this runner's own DisposeAsync, after
+      every assembly had already reported Passed; the job exited 1 with no failing test anywhere in
+      the log. The path is only engaged because CI collects coverage, which is why it never
+      reproduced locally.
+      microsoft/vstest#15231 carries a byte-identical stack, and the test-platform maintainer's
+      verdict is that the regression came from this package and was fixed in 3.1.3. One honest
+      caveat: they attribute it to 3.1.1 and this repo was on 3.1.0, so our occurrence may not be the
+      same instance. 3.1.5 clears the known one either way.
+      Deliberately NOT paired with a Microsoft.NET.Test.Sdk bump. The fix is here, and 17.13 -> 18.x
+      is a major platform change whose blast radius includes coverlet.collector 6.0.4 (unchanged) —
+      whose failure mode is silently empty coverage, which nothing in CI would notice. That upgrade
+      deserves its own change, judged on its own evidence.
+    -->
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
 
   </ItemGroup>
 


### PR DESCRIPTION
Closes #263.

CI failed once with every test passing. Every assembly reported `Passed`, there was no `[FAIL]` anywhere, and the job simply exited 1. The only signal was a `Catastrophic failure` line about forty lines above the end: the test *runner* threw a `NullReferenceException` disposing its symbol reader, after the tests had already finished.

The issue filed it as "treat as tooling flake until it recurs". Two things changed that: the upstream fix turns out to be documented, and the deceptive failure mode is worth closing regardless of whether the crash ever comes back.

## The bump — and why only one of them

`xunit.runner.visualstudio` **3.1.0 → 3.1.5**.

The stack points squarely at Microsoft's test platform, which is why the issue's remedy list named both packages. It is misleading. [microsoft/vstest#15231](https://github.com/microsoft/vstest/issues/15231) carries a **byte-identical stack**, and the test-platform maintainer's verdict there is that the regression came from the *runner* package and was **fixed in 3.1.3**. A second issue attributes it to a double-dispose on the xunit side, same fix window.

So `Microsoft.NET.Test.Sdk` is **not** bumped. It was in the first draft of this change and came back out once the evidence landed: 17.13 → 18.x is a major platform change that is not the mechanism, and it raises an unresolved question about `coverlet.collector` 6.0.4 — four majors stale, unchanged here — whose failure mode with the newer platform is *silently empty coverage*, which nothing in CI would notice. That upgrade deserves its own change judged on its own evidence, not a ride-along on a flake fix.

One caveat is kept in the source rather than smoothed over: upstream attributes the regression to 3.1.1, and this repo was on 3.1.0. Our occurrence may be a different instance that happens to share a stack. 3.1.5 clears the known one either way.

## The half that is deterministic

The bump is a bet on someone else's fix. This part is not.

Both jobs that run tests now capture their output, and a shared script turns a runner crash into an **error annotation on the check** — where the misreading actually happens — plus the crash excerpt in the **job summary**. Nothing is said when the failure is an ordinary test failure.

Three things worth calling out:

- **The OWASP gate got it too.** It was not in scope, but it asks for a TRX log, which records per-test source file and line — the same symbol-reading path the runner died in. A gate that can go red with every test passing is worth covering wherever it can happen, not only where it happened first.
- **The logic is a script, not YAML.** Covering the second job would have meant duplicating twenty lines of shell. Extracting it made it testable — and runnable by hand against a downloaded log, which is the situation it exists to serve.
- **The log is uploaded.** A crash seen once in four runs and never reproduced locally deserves better evidence than a sixty-line excerpt that dies with the workspace.

## The trap inside the fix

Piping test output through `tee` to capture it **discards the exit code** unless `pipefail` is set. Get that wrong and `build-and-test` reports success on every test failure — strictly worse than having no gate, and nothing in the YAML would look wrong.

That is not a line to take on trust, so it is a committed test with the mutation beside it: the same pipeline with `pipefail` returns the failure, without it returns success. If those two ever agree, the guard has stopped guarding.

That test earned its place immediately — on its first run it **passed for the wrong reason**. The mutation subshell inherited `pipefail` from the test script's own prologue, so it was quietly re-running the passing case. An unexpected pass is a finding; the fix and the reason are both in the file.

## Deliberately not done

A settings file disabling source-information collection, which the issue names as an alternative remedy and which removes the crashing code path outright rather than betting on a patch. Rejected because the patch is documented and shipped: this would permanently trade away per-test source file and line to route around a fixed bug. If the crash recurs on 3.1.5, that is when the evidence supports paying the price.

## Verification

Full solution green across all 21 assemblies. The workflow parses, both new shell blocks pass a syntax check, and the script's 8 tests pass — including the missing-log path (a build failure must not turn one confusing red into two) and the ordinary-test-failure path (stay quiet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
