### PR TITLE
feat: reclaim conversation budget rows whose conversation is gone

### DIFF
--- a/src/Content/Domain/Domain.Common/Config/AI/Conversations/ConversationBudgetRetentionConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/Conversations/ConversationBudgetRetentionConfig.cs
@@ -1,0 +1,78 @@
+namespace Domain.Common.Config.AI.Conversations;
+
+/// <summary>
+/// Governs the sweep that reclaims conversation-budget rows nothing can ever read again.
+/// Bound from <c>AppConfig:AI:Conversations:BudgetRetention</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>Why age alone is not the test.</strong> A budget row records how much of a lifetime ceiling a
+/// conversation has spent. Deleting one for a conversation someone later resumes silently resets that
+/// ceiling — the exact failure the whole budget subsystem exists to prevent — and a conversation may
+/// legitimately sit idle for months and come back. So the sweep requires a second condition: the row's
+/// <em>conversation must no longer exist</em>. A deleted conversation cannot be resumed, so removing its
+/// total cannot reset a ceiling anyone will meet again.
+/// </para>
+/// <para>
+/// <strong>That protects durable conversations absolutely, and nothing else.</strong> Stated plainly
+/// because the tempting shorter version — "no conversation row means nobody can resume it" — is false.
+/// A budget key is caller-chosen and opaque, and several writers produce keys that never had a row in
+/// <c>conversations</c> at all rather than having lost one:
+/// </para>
+/// <list type="bullet">
+///   <item>plan runs, under a <c>planrun:</c>-prefixed scope;</item>
+///   <item>self-contained conversation runs — the path taken when no conversation owner is supplied —
+///     which accrue against a caller-supplied id with no transcript behind it;</item>
+///   <item>any future caller, under whatever key it chooses.</item>
+/// </list>
+/// <para>
+/// For those, <see cref="GracePeriod"/> is the only protection there is, which is why it is generous.
+/// It answers a far easier question than user absence: how long before an operation this sweep cannot
+/// recognise is certainly over. Plan runs are bounded by their own timeout, in minutes. A self-contained
+/// run keyed by a stable, caller-supplied id is the case to size against — <strong>if a caller reuses
+/// one such id after a gap longer than this period, its ceiling starts again</strong>. Raise the period
+/// if that describes a deployment; nothing else here needs changing.
+/// </para>
+/// <para>
+/// This bounds the table at roughly one row per conversation that still exists, plus recent unrecognised
+/// keys — near enough the bound the conversation table itself carries. It deliberately does <em>not</em>
+/// reproduce the in-process tracker's fixed 50,000-entry LRU cap: evicting a live conversation's total
+/// to satisfy a row count is the silent-reset failure again, chosen deliberately rather than arrived at
+/// by abandonment.
+/// </para>
+/// </remarks>
+public sealed class ConversationBudgetRetentionConfig
+{
+    /// <summary>
+    /// Whether the sweep runs. Defaults to <see langword="true"/>.
+    /// </summary>
+    /// <remarks>
+    /// On by default because the growth it reclaims is now present on every deployment: the conversation
+    /// ceiling itself ships enabled, so every stock host writes a row per conversation and, before this
+    /// existed, never removed one. A host that switches this off keeps every orphaned row forever, which
+    /// is the state this shipped in — supported, but a choice rather than a default.
+    /// </remarks>
+    public bool Enabled { get; set; } = true;
+
+    /// <summary>
+    /// How often the sweep runs. Defaults to six hours.
+    /// </summary>
+    /// <remarks>
+    /// Reclaiming an orphaned row is never urgent — the row is inert, costs about sixty bytes, and
+    /// nothing behaves differently while it lingers. The interval is therefore set to be
+    /// unnoticeable rather than prompt.
+    /// </remarks>
+    public TimeSpan SweepInterval { get; set; } = TimeSpan.FromHours(6);
+
+    /// <summary>
+    /// How long a row with no conversation must sit untouched before it is reclaimed. Defaults to
+    /// thirty days.
+    /// </summary>
+    /// <remarks>
+    /// This is the only protection for budget keys that never had a conversation row — see the
+    /// type-level remarks for which writers produce those and how to size against them. It has no effect
+    /// on durable conversations: those are never swept at all while their conversation exists, however
+    /// long they have been idle, so shortening this does not make the sweep more aggressive about them.
+    /// </remarks>
+    public TimeSpan GracePeriod { get; set; } = TimeSpan.FromDays(30);
+}

--- a/src/Content/Domain/Domain.Common/Config/AI/Conversations/ConversationsConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/Conversations/ConversationsConfig.cs
@@ -40,6 +40,13 @@ public sealed class ConversationsConfig
     public ConversationTurnLeaseConfig TurnLease { get; set; } = new();
 
     /// <summary>
+    /// Governs the sweep that reclaims budget rows whose conversation no longer exists. Read only by the
+    /// <see cref="ConversationStoreProvider.Sqlite"/> provider — the file-backed provider uses the
+    /// in-process budget tracker, which bounds itself by evicting.
+    /// </summary>
+    public ConversationBudgetRetentionConfig BudgetRetention { get; set; } = new();
+
+    /// <summary>
     /// How many of a conversation's most recent messages are replayed to the model when a durable run
     /// continues it. Bounds prompt growth: a conversation's transcript is unbounded, the window sent to
     /// the model is not.

--- a/src/Content/Infrastructure/Infrastructure.AI/Conversations/ConversationBudgetRetentionService.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Conversations/ConversationBudgetRetentionService.cs
@@ -1,0 +1,137 @@
+using Domain.Common.Config;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+// Aliased because this file's own namespace and the config namespace both end in `.Conversations`, so
+// the unqualified name binds to neither without help.
+using RetentionConfig = Domain.Common.Config.AI.Conversations.ConversationBudgetRetentionConfig;
+
+namespace Infrastructure.AI.Conversations;
+
+/// <summary>
+/// Reclaims conversation-budget rows whose conversation no longer exists.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Without this, the durable budget table only ever grows. Rows are removed on request by
+/// <see cref="SqliteConversationBudgetTracker.ReleaseAsync"/>, but the interactive callers never call it
+/// — a turn ending is not a conversation ending — so deleting a conversation left its running total
+/// behind permanently. That was tolerable while the conversation ceiling shipped switched off and only
+/// deployments that opted in wrote rows at all; it stopped being conditional when the ceiling became a
+/// default (issue #253).
+/// </para>
+/// <para>
+/// <strong>What is swept, and what is deliberately not.</strong> Only rows whose conversation is gone.
+/// A conversation that merely sits idle keeps its row for as long as it exists, however long that is —
+/// see <see cref="SqliteConversationBudgetTracker.SweepAbandonedAsync"/> for why an age-only rule would
+/// silently reset the ceiling the budget exists to enforce.
+/// </para>
+/// <para>
+/// Registered only on the SQLite branch. The file-backed provider uses the in-process tracker, which
+/// bounds itself by evicting least-recently-used entries and has nothing to sweep.
+/// </para>
+/// <para>
+/// Modelled on <c>RunRecordCleanupService</c>: interval read live so a configuration reload takes
+/// effect, floored so a mis-set value is slow rather than harmful, and every sweep wrapped so a failure
+/// costs one tick rather than the service.
+/// </para>
+/// </remarks>
+internal sealed class ConversationBudgetRetentionService : BackgroundService
+{
+    /// <summary>
+    /// Floor on the sweep interval. A positive but tiny value would turn this into a delete loop against
+    /// the same database the turn lease serialises on; the floor makes a mis-set value slow rather than
+    /// harmful, matching <c>RunRecordCleanupService</c>.
+    /// </summary>
+    private static readonly TimeSpan MinInterval = TimeSpan.FromMinutes(1);
+
+    private readonly SqliteConversationBudgetTracker _tracker;
+    private readonly IOptionsMonitor<AppConfig> _config;
+    private readonly TimeProvider _timeProvider;
+    private readonly ILogger<ConversationBudgetRetentionService> _logger;
+
+    /// <summary>Initializes a new <see cref="ConversationBudgetRetentionService"/>.</summary>
+    /// <param name="tracker">Owns the table and the statement that sweeps it.</param>
+    /// <param name="config">Supplies the interval and grace period, read live on every tick.</param>
+    /// <param name="timeProvider">
+    /// Drives the wait between sweeps. Injected rather than taken from <see cref="Task.Delay(TimeSpan)"/>
+    /// so the schedule is testable at all: with a six-hour default and a one-minute floor, a test on the
+    /// real clock could only assert that nothing has happened yet.
+    /// </param>
+    /// <param name="logger">Receives the per-sweep result and any failure.</param>
+    public ConversationBudgetRetentionService(
+        SqliteConversationBudgetTracker tracker,
+        IOptionsMonitor<AppConfig> config,
+        TimeProvider timeProvider,
+        ILogger<ConversationBudgetRetentionService> logger)
+    {
+        ArgumentNullException.ThrowIfNull(tracker);
+        ArgumentNullException.ThrowIfNull(config);
+        ArgumentNullException.ThrowIfNull(timeProvider);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _tracker = tracker;
+        _config = config;
+        _timeProvider = timeProvider;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        try
+        {
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                var interval = Retention.SweepInterval;
+                if (interval < MinInterval)
+                    interval = MinInterval;
+
+                await Task.Delay(interval, _timeProvider, stoppingToken).ConfigureAwait(false);
+
+                // Read AFTER the wait, not before it. IOptionsMonitor hands back a fresh AppConfig on
+                // reload, so a value captured before a six-hour delay is a value from six hours ago, and
+                // a configuration change would take two intervals to be acted on instead of one.
+                var retention = Retention;
+
+                if (!retention.Enabled)
+                    continue;
+
+                await SweepAsync(retention.GracePeriod).ConfigureAwait(false);
+            }
+        }
+        catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+        {
+            // Host is shutting down — expected.
+        }
+    }
+
+    private RetentionConfig Retention => _config.CurrentValue.AI.Conversations.BudgetRetention;
+
+    private async Task SweepAsync(TimeSpan gracePeriod)
+    {
+        try
+        {
+            // No guard on the grace period here. The tracker refuses a negative one — a cutoff in the
+            // future would sweep rows still in use — and a second copy of that rule in this file is a
+            // second thing to keep in step. A misconfigured value therefore surfaces through the catch
+            // below, named, once per interval.
+            var reclaimed = await _tracker.SweepAbandonedAsync(gracePeriod, CancellationToken.None)
+                .ConfigureAwait(false);
+
+            if (reclaimed > 0)
+            {
+                _logger.LogInformation(
+                    "Conversation budget sweep reclaimed {Count} row(s) whose conversation no longer exists.",
+                    reclaimed);
+            }
+        }
+        catch (Exception ex)
+        {
+            // A failed sweep must not take the service down: the next tick would never come, and the
+            // table would resume growing without bound for the life of the process.
+            _logger.LogError(ex, "Conversation budget sweep failed; will retry on the next interval.");
+        }
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Conversations/SqliteConversationBudgetTracker.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Conversations/SqliteConversationBudgetTracker.cs
@@ -41,12 +41,13 @@ namespace Infrastructure.AI.Conversations;
 /// this type going quietly inert is how the ceiling shipped switched off (issue #279).
 /// </para>
 /// <para>
-/// <strong>Retention.</strong> Rows are removed only by <see cref="ReleaseAsync"/>, and the two
-/// interactive callers never call it because a turn ending is not a conversation ending. Abandoned keys
-/// therefore persist, and unlike the in-process sibling — which caps at 50,000 entries and evicts —
-/// this one has no bound. At roughly 60 bytes per row, 50,000 abandoned keys cost about 3 MB. Because
-/// the budget is on by default, this table grows on every deployment rather than only on ones that
-/// opted in; a retention sweep is tracked in issue #253.
+/// <strong>Retention.</strong> <see cref="ReleaseAsync"/> removes a row on request, but the interactive
+/// callers never call it — a turn ending is not a conversation ending. What reclaims the rest is
+/// <see cref="SweepAbandonedAsync"/>, run on a schedule by <c>ConversationBudgetRetentionService</c>,
+/// and it removes only rows whose conversation no longer exists. The bound that gives is one row per
+/// conversation that still exists, which is deliberately <em>not</em> the in-process sibling's fixed
+/// 50,000-entry LRU cap: evicting a live conversation's running total to satisfy a row count would
+/// silently reset the very ceiling this class exists to enforce (issue #253).
 /// </para>
 /// </remarks>
 public sealed class SqliteConversationBudgetTracker : IConversationBudgetTracker
@@ -189,6 +190,74 @@ public sealed class SqliteConversationBudgetTracker : IConversationBudgetTracker
 
             return new ConversationBudgetStatus(true, budget, 0);
         }
+    }
+
+    /// <summary>
+    /// Reclaims budget rows that no conversation can ever read again, and returns how many were removed.
+    /// </summary>
+    /// <param name="gracePeriod">
+    /// How long a candidate row must have sat untouched before it is eligible. See the remarks — this
+    /// does not exist to judge how long a person might be away.
+    /// </param>
+    /// <param name="cancellationToken">Cancels the sweep.</param>
+    /// <returns>The number of rows removed; zero when nothing qualified or the statement failed.</returns>
+    /// <remarks>
+    /// <para>
+    /// Two conditions, and they do different jobs. <strong>The existence test is what makes this safe for
+    /// durable conversations.</strong> Nobody can resume a conversation that has been deleted, so
+    /// removing its running total cannot reset a ceiling anyone will meet again — and a conversation that
+    /// still exists is never swept, however long it has been idle. Age alone would be indefensible:
+    /// deleting an idle conversation's row silently hands it a fresh ceiling, which is the failure the
+    /// budget exists to prevent, caused by the thing meant to tidy up after it.
+    /// </para>
+    /// <para>
+    /// <strong>The grace period is the only protection for keys that never had a conversation row.</strong>
+    /// Not merely for ones that lost it — several writers produce keys that never had one: plan runs under
+    /// a <c>planrun:</c> scope, self-contained conversation runs accruing against a caller-supplied id
+    /// with no transcript behind it, and any future caller. For those, the existence test is vacuously
+    /// true and staleness is all there is. See
+    /// <see cref="Domain.Common.Config.AI.Conversations.ConversationBudgetRetentionConfig"/> for how to
+    /// size it.
+    /// </para>
+    /// <para>
+    /// Deliberately not prefix-matching on <c>planrun:</c> to exempt known callers. That works only for
+    /// the callers that exist today; the next one to add an unprefixed key would be swept while running,
+    /// and would find out in production. The grace period protects every caller, including ones nobody
+    /// has written yet.
+    /// </para>
+    /// <para>
+    /// Written as SQL for the same reason accrual is: EF cannot express a correlated <c>NOT EXISTS</c>
+    /// delete as one statement, and doing it as read-then-delete would race a conversation being created
+    /// between the two halves.
+    /// </para>
+    /// <para>
+    /// Unlike every other method here, this one <strong>lets failures out</strong>. The others swallow
+    /// because they sit on the turn path, where a database blip must not cost a caller their work. This
+    /// one is called only by a background sweep that already logs and retries, so swallowing here would
+    /// add nothing except a failure mode no test could reach.
+    /// </para>
+    /// </remarks>
+    public async Task<int> SweepAbandonedAsync(
+        TimeSpan gracePeriod,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(gracePeriod, TimeSpan.Zero, nameof(gracePeriod));
+
+        // UtcTicks by hand, as in RecordUsageAsync: the model's value converter applies to the entity,
+        // not to a parameter on a raw statement.
+        var cutoffTicks = _timeProvider.GetUtcNow().Subtract(gracePeriod).UtcTicks;
+
+        await using var context = await _contextFactory.CreateDbContextAsync(cancellationToken);
+
+        return await context.Database.ExecuteSqlInterpolatedAsync(
+            $"""
+            DELETE FROM conversation_budgets
+            WHERE UpdatedAt < {cutoffTicks}
+              AND NOT EXISTS (
+                  SELECT 1 FROM conversations WHERE conversations.Id = conversation_budgets.BudgetKey
+              )
+            """,
+            cancellationToken);
     }
 
     /// <inheritdoc />

--- a/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.Conversations.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.Conversations.cs
@@ -89,7 +89,23 @@ public static partial class DependencyInjection
         // The third member of the same choice. A conversation whose transcript is shared between hosts
         // but whose token ceiling is not lets each host enforce a private copy of one number, and the
         // conversation spends roughly twice it (issue #245).
-        services.AddSingleton<IConversationBudgetTracker, SqliteConversationBudgetTracker>();
+        //
+        // Registered by concrete type with the interface forwarding to it, rather than the usual
+        // interface-to-implementation pair, so the retention sweep below and every budget caller share
+        // one instance. Two registrations of the implementation would give two, each holding its own
+        // schema initializer, and the resulting double schema check is the kind of thing that works
+        // until it does not.
+        services.AddSingleton<SqliteConversationBudgetTracker>();
+        services.AddSingleton<IConversationBudgetTracker>(
+            sp => sp.GetRequiredService<SqliteConversationBudgetTracker>());
+
+        // Nothing removes a budget row when a conversation is deleted — the interactive callers never
+        // release, because a turn ending is not a conversation ending — so before this the table only
+        // grew. Registered unconditionally rather than behind the retention switch: the switch is read
+        // live on every tick, so a host can turn the sweep on without restarting, and a service that
+        // exists but declines to act is easier to explain than one that silently was never created
+        // (issue #253).
+        services.AddHostedService<ConversationBudgetRetentionService>();
     }
 
     /// <summary>

--- a/src/Content/Infrastructure/Infrastructure.AI/Persistence/ConversationDbContext.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Persistence/ConversationDbContext.cs
@@ -106,9 +106,16 @@ public sealed class ConversationDbContext : DbContext
         budget.Property(e => e.ConsumedTokens).IsRequired();
         budget.Property(e => e.UpdatedAt).HasConversion(SqliteValueConverters.DateTimeOffsetAsUtcTicks);
 
-        // No index on UpdatedAt. It would serve an age-based retention sweep and nothing else, and no
-        // sweep exists yet — an index for a caller that has not been written is cost with no reader.
-        // Adding one later is cheap and safe: SqliteAdditiveSchemaReconciler creates indexes a model
-        // has gained, including on databases that already exist.
+        // Still no index on UpdatedAt, now that a reader for one exists. The retention sweep
+        // (SqliteConversationBudgetTracker.SweepAbandonedAsync) filters on it, so an index was the
+        // obvious addition — and it would cost more than it saves. UpdatedAt is rewritten by every
+        // accrual, which is the per-turn hot path, so the index would be maintained on every turn to
+        // speed a query that runs four times a day. It is also poorly selective for that query: in
+        // steady state most surviving rows ARE older than the grace period, and their conversations
+        // still exist, so the age predicate excludes almost nothing and the correlated NOT EXISTS —
+        // which hits `conversations` by primary key — does the real work.
+        //
+        // Revisit if this table ever grows far beyond one row per conversation, which would mean the
+        // sweep has stopped working and the index is not the problem to fix (issue #253).
     }
 }

--- a/src/Content/Presentation/Presentation.AgentHub/README.md
+++ b/src/Content/Presentation/Presentation.AgentHub/README.md
@@ -72,6 +72,10 @@ Presentation.Common → Infrastructure.* → Application.* → Domain.*
 
 A durable lease expires (`AppConfig:AI:Conversations:TurnLease:ExpirySeconds`, default 60) so a host that dies mid-turn does not block its conversation forever, and the holder renews it every third of that while the turn runs. If a lease is nonetheless taken — a stalled host, a suspended container — the losing turn is **cancelled** rather than allowed to finish writing, and the client is told the conversation was continued elsewhere.
 
+**Budget retention:** the durable token budget writes one row per conversation and, until issue #253, never removed one — so a deleted conversation left its running total behind for good. A background sweep now reclaims those (`AppConfig:AI:Conversations:BudgetRetention`, on by default, every 6 hours).
+
+It removes a row only when the conversation no longer exists, so **a conversation that merely sits idle keeps its ceiling however long it has been away** — deleting it would silently reset the ceiling the budget exists to enforce. The `GracePeriod` (30 days) is not about idle users at all: it protects budget keys that never had a conversation row, which is the case for plan runs and for self-contained runs made without a conversation owner. If a caller reuses a stable id on that path after a gap longer than the grace period, its ceiling starts again — raise the period if that describes your deployment.
+
 **Transcript persistence:** this host does not own the conversation store. `IConversationStore` lives in `Application.AI.Common/Interfaces/AI/`, its DTOs in `Application.AI.Common/Models/Conversations/`, and both implementations in `Infrastructure.AI/Conversations/`, registered by `AddInfrastructureAIDependencies`. It moved out of this project because the Execution API needs the same transcripts and peer Presentation projects cannot reference each other.
 
 **Ownership is enforced by the store, not by this host.** Every `IConversationStore` operation that

--- a/src/Content/Presentation/Presentation.AgentHub/appsettings.json
+++ b/src/Content/Presentation/Presentation.AgentHub/appsettings.json
@@ -284,6 +284,11 @@
         "TurnLease": {
           "ExpirySeconds": 60,
           "PollIntervalMilliseconds": 250
+        },
+        "BudgetRetention": {
+          "Enabled": true,
+          "SweepInterval": "06:00:00",
+          "GracePeriod": "30.00:00:00"
         }
       },
       "Planner": {

--- a/src/Content/Tests/Infrastructure.AI.Tests/Conversations/ConversationBudgetRetentionServiceTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Conversations/ConversationBudgetRetentionServiceTests.cs
@@ -1,0 +1,325 @@
+using Domain.Common.Config;
+using FluentAssertions;
+using Infrastructure.AI.Conversations;
+using Infrastructure.AI.Persistence;
+using Infrastructure.AI.Persistence.Entities;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Time.Testing;
+using Moq;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Conversations;
+
+/// <summary>
+/// The schedule around <see cref="SqliteConversationBudgetTracker.SweepAbandonedAsync"/> — that it runs
+/// at all, that the switch works, and that a failed sweep costs one tick rather than the service.
+/// </summary>
+/// <remarks>
+/// The sweep's own correctness is covered by <see cref="SqliteConversationBudgetSweepTests"/>. What is
+/// left here is everything that has ever made a background sweep a claim rather than a behaviour: a
+/// service that never ticks, a switch read once at startup, or a single failure that silently ends the
+/// loop for the life of the process.
+/// </remarks>
+public sealed class ConversationBudgetRetentionServiceTests : IDisposable
+{
+    private static readonly DateTimeOffset Origin = new(2026, 8, 6, 12, 0, 0, TimeSpan.Zero);
+
+    /// <summary>
+    /// How long to wait for a scheduled continuation before calling it a hang. Generous on purpose:
+    /// these waits end as soon as the loop signals, so the only run that pays this is one that is
+    /// genuinely stuck, and a CI machine under load must not be the difference between green and red.
+    /// </summary>
+    private static readonly TimeSpan Patience = TimeSpan.FromSeconds(30);
+
+    private readonly string _tempDir;
+    private readonly TestConversationDbContextFactory _contextFactory;
+    private readonly ObservableFakeClock _clock = new(Origin);
+
+    // Not readonly: one test replaces the whole instance to model what a configuration reload really
+    // does. Mutating a shared instance instead is what let an earlier version of that test pass against
+    // an implementation reading stale configuration.
+    private AppConfig _config = new();
+    private readonly SqliteConversationBudgetTracker _tracker;
+
+    /// <summary>Creates an isolated on-disk database and the tracker the service sweeps through.</summary>
+    public ConversationBudgetRetentionServiceTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"convretention-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+        _contextFactory = new TestConversationDbContextFactory(Path.Combine(_tempDir, "conversations.db"));
+
+        _config.AI.AgentFramework.ConversationTokenBudget = 10_000;
+        _config.AI.Conversations.BudgetRetention.SweepInterval = TimeSpan.FromHours(1);
+        _config.AI.Conversations.BudgetRetention.GracePeriod = TimeSpan.FromDays(30);
+
+        _tracker = new SqliteConversationBudgetTracker(
+            _contextFactory,
+            Options(),
+            _clock,
+            NullLogger<SqliteConversationBudgetTracker>.Instance,
+            new SchemaInitializer<ConversationDbContext>(_contextFactory));
+    }
+
+    [Fact]
+    public async Task Sweeps_OnTheConfiguredInterval()
+    {
+        await GivenAnOrphanedRowOlderThanTheGracePeriod();
+
+        // Control: nothing has swept yet, so a service that deleted on construction — or a test that
+        // measured after the fact — could not be mistaken for one that swept on schedule.
+        BudgetKeys().Should().ContainSingle("control: the row must survive until a tick happens");
+
+        using var service = CreateService();
+        await StartAndWaitForFirstTimer(service);
+
+        await AdvanceAndSettle(TimeSpan.FromHours(1));
+
+        BudgetKeys().Should().BeEmpty("the first tick after the configured interval must sweep");
+    }
+
+    [Fact]
+    public async Task Disabled_SweepsNothing()
+    {
+        _config.AI.Conversations.BudgetRetention.Enabled = false;
+        await GivenAnOrphanedRowOlderThanTheGracePeriod();
+
+        using var service = CreateService();
+        await StartAndWaitForFirstTimer(service);
+
+        await AdvanceAndSettle(TimeSpan.FromHours(4));
+
+        BudgetKeys().Should().ContainSingle("a host that switched the sweep off keeps its rows");
+    }
+
+    /// <summary>
+    /// A configuration reload during the wait is acted on at the end of that wait, not one whole
+    /// interval later.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This models a reload the way <c>IOptionsMonitor</c> really does it — by handing back a
+    /// <strong>new</strong> <see cref="AppConfig"/> instance. That detail is the whole test. An earlier
+    /// version mutated one shared instance, which meant a service that snapshotted the config before its
+    /// wait still saw the change, and the test passed against both the correct implementation and the
+    /// one that reads six-hour-old configuration. A mutation probe found it by passing when it should
+    /// have failed.
+    /// </para>
+    /// <para>
+    /// One interval versus two matters at the shipped default: a host turning the sweep on would wait
+    /// twelve hours rather than six, with nothing to indicate why.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public async Task ConfigurationReloadedDuringTheWait_IsActedOnAtTheEndOfThatWait()
+    {
+        _config.AI.Conversations.BudgetRetention.Enabled = false;
+        await GivenAnOrphanedRowOlderThanTheGracePeriod();
+
+        using var service = CreateService();
+        await StartAndWaitForFirstTimer(service);
+
+        // Replace the instance rather than mutate it, exactly as a reload does. A service holding the
+        // old object now holds a stale one, which is the difference this test exists to detect.
+        var reloaded = CloneConfig();
+        reloaded.AI.Conversations.BudgetRetention.Enabled = true;
+        _config = reloaded;
+
+        await AdvanceAndSettle(TimeSpan.FromHours(1));
+
+        BudgetKeys().Should().BeEmpty(
+            "the switch must be read after the wait, or a reload takes two intervals to take effect");
+    }
+
+    /// <summary>
+    /// A sweep interval below the floor must be clamped, not honoured. A positive but tiny value is
+    /// valid configuration and would otherwise turn this into a delete loop against the same database
+    /// the turn lease serialises on.
+    /// </summary>
+    [Fact]
+    public async Task SweepIntervalBelowTheFloor_IsClamped()
+    {
+        _config.AI.Conversations.BudgetRetention.SweepInterval = TimeSpan.FromMilliseconds(1);
+        await GivenAnOrphanedRowOlderThanTheGracePeriod();
+
+        using var service = CreateService();
+        await StartAndWaitForFirstTimer(service);
+
+        // No settle on this one, deliberately: half the floor must NOT fire the timer, so there is no
+        // iteration to wait for. Nothing can have run, which is what makes the assertion immediately
+        // safe rather than merely early.
+        _clock.Advance(TimeSpan.FromSeconds(30));
+        BudgetKeys().Should().ContainSingle(
+            "a one-millisecond interval must have been clamped to the one-minute floor, so half a minute "
+            + "is not yet enough");
+
+        await AdvanceAndSettle(TimeSpan.FromSeconds(31));
+        BudgetKeys().Should().BeEmpty("past the floor, the sweep runs");
+    }
+
+    /// <summary>
+    /// Starts the service and waits until its first wait is actually registered against the fake clock.
+    /// </summary>
+    /// <remarks>
+    /// <c>StartAsync</c> returns as soon as the background loop yields, which may be before it has asked
+    /// the clock for a timer. Advancing a <see cref="FakeTimeProvider"/> only fires timers that already
+    /// exist, so without this wait the advance lands in the gap and nothing ever ticks — the whole test
+    /// then passes or fails on thread scheduling. Found the hard way: the first version of these tests
+    /// failed for exactly this reason and looked like a broken sweep.
+    /// </remarks>
+    /// <summary>
+    /// A failed sweep costs one tick, not the service.
+    /// </summary>
+    /// <remarks>
+    /// This is the failure that turns a bounded table back into an unbounded one without anything
+    /// saying so: an exception escaping the loop ends it for the life of the process, and every
+    /// subsequent tick that would have reclaimed rows simply never happens. Reachable as a test only
+    /// because the sweep lets its exceptions out — while the tracker swallowed them, this could not be
+    /// written at all.
+    /// </remarks>
+    [Fact]
+    public async Task SweepThatThrows_KeepsTheLoopAlive()
+    {
+        await GivenAnOrphanedRowOlderThanTheGracePeriod();
+
+        // A negative grace period makes the tracker throw. Any failure would do; this one needs no
+        // broken database, and it exercises the same catch.
+        _config.AI.Conversations.BudgetRetention.GracePeriod = TimeSpan.FromDays(-1);
+
+        using var service = CreateService();
+        await StartAndWaitForFirstTimer(service);
+
+        await AdvanceAndSettle(TimeSpan.FromHours(1));
+
+        // Control: the failing tick really did fail — nothing was reclaimed.
+        BudgetKeys().Should().ContainSingle();
+
+        _config.AI.Conversations.BudgetRetention.GracePeriod = TimeSpan.FromDays(30);
+        await AdvanceAndSettle(TimeSpan.FromHours(1));
+
+        BudgetKeys().Should().BeEmpty(
+            "the loop must survive a failed sweep, or one bad tick stops retention for the life of the "
+            + "process and the table silently resumes growing");
+    }
+
+    private async Task StartAndWaitForFirstTimer(ConversationBudgetRetentionService service)
+    {
+        var armed = _clock.NextTimer;
+        await service.StartAsync(CancellationToken.None);
+
+        await armed.WaitAsync(Patience);
+    }
+
+    private ConversationBudgetRetentionService CreateService() =>
+        new(_tracker, Options(), _clock, NullLogger<ConversationBudgetRetentionService>.Instance);
+
+    /// <summary>
+    /// A monitor that reads the field live, so a test replacing the whole <see cref="AppConfig"/> is
+    /// visible to the service — which is what a real reload looks like.
+    /// </summary>
+    private IOptionsMonitor<AppConfig> Options()
+    {
+        var monitor = new Mock<IOptionsMonitor<AppConfig>>();
+        monitor.Setup(m => m.CurrentValue).Returns(() => _config);
+        return monitor.Object;
+    }
+
+    private AppConfig CloneConfig()
+    {
+        var clone = new AppConfig();
+        clone.AI.AgentFramework.ConversationTokenBudget = _config.AI.AgentFramework.ConversationTokenBudget;
+
+        var from = _config.AI.Conversations.BudgetRetention;
+        var to = clone.AI.Conversations.BudgetRetention;
+        to.Enabled = from.Enabled;
+        to.SweepInterval = from.SweepInterval;
+        to.GracePeriod = from.GracePeriod;
+
+        return clone;
+    }
+
+    /// <summary>
+    /// Advances the fake clock and waits until the service's loop has completed that iteration.
+    /// </summary>
+    /// <remarks>
+    /// Advancing a <see cref="FakeTimeProvider"/> fires the timer synchronously, but what it releases is
+    /// an <c>await</c> whose continuation is scheduled — so the sweep runs on another thread shortly
+    /// afterwards, and every assertion here would otherwise race it. The signal is the loop arming its
+    /// <em>next</em> timer, which cannot happen until the current iteration is done; captured before the
+    /// advance so a fast iteration cannot complete before anyone is listening. No polling and no
+    /// wall-clock assumptions, so a slow machine makes this slower rather than red.
+    /// </remarks>
+    private async Task AdvanceAndSettle(TimeSpan by)
+    {
+        var reArmed = _clock.NextTimer;
+        _clock.Advance(by);
+        await reArmed.WaitAsync(Patience);
+    }
+
+    private async Task GivenAnOrphanedRowOlderThanTheGracePeriod()
+    {
+        // No conversation row is ever created for this key, which is what makes it an orphan.
+        await _tracker.RecordUsageAsync("orphan", 100);
+        _clock.Advance(TimeSpan.FromDays(31));
+    }
+
+    private List<string> BudgetKeys()
+    {
+        using var context = _contextFactory.CreateDbContext();
+        return [.. context.ConversationBudgets.Select(b => b.BudgetKey)];
+    }
+
+    /// <summary>Releases the temporary database directory.</summary>
+    public void Dispose()
+    {
+        SqliteConnection.ClearAllPools();
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+    }
+
+    /// <summary>
+    /// A <see cref="FakeTimeProvider"/> that also says when something has started waiting on it.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <see cref="FakeTimeProvider"/> fires only timers that already exist when the clock is advanced,
+    /// and it exposes no way to ask whether any are pending. Without a signal, a test has to guess how
+    /// long to wait before advancing — a race dressed as a test.
+    /// <c>Task.Delay(TimeSpan, TimeProvider, CancellationToken)</c> goes through <c>CreateTimer</c>, so
+    /// intercepting that is an exact answer rather than an estimate.
+    /// </para>
+    /// <para>
+    /// Deliberately multi-shot. A one-shot signal covers only the service's first wait, and every
+    /// subsequent advance then races the loop re-arming — which is the same bug one iteration further
+    /// along. Because the loop creates a timer at the top of every iteration, awaiting the next
+    /// creation is also a precise "the previous iteration has finished its work" signal, which is what
+    /// removes wall-clock polling from these tests entirely.
+    /// </para>
+    /// </remarks>
+    private sealed class ObservableFakeClock(DateTimeOffset start) : FakeTimeProvider(start)
+    {
+        private TaskCompletionSource _next = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        /// <summary>
+        /// Completes when the next timer is created. Capture this <em>before</em> advancing the clock —
+        /// capturing it afterwards can miss a creation that already happened.
+        /// </summary>
+        public Task NextTimer => Volatile.Read(ref _next).Task;
+
+        /// <inheritdoc />
+        public override ITimer CreateTimer(
+            TimerCallback callback, object? state, TimeSpan dueTime, TimeSpan period)
+        {
+            var timer = base.CreateTimer(callback, state, dueTime, period);
+
+            // Install the replacement first, then complete the one callers are holding, so a
+            // continuation that immediately asks for the next signal cannot get the one just fired.
+            Interlocked.Exchange(ref _next, new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously))
+                .TrySetResult();
+
+            return timer;
+        }
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Conversations/SqliteConversationBudgetSweepTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Conversations/SqliteConversationBudgetSweepTests.cs
@@ -1,0 +1,238 @@
+using Domain.Common.Config;
+using FluentAssertions;
+using Infrastructure.AI.Conversations;
+using Infrastructure.AI.Persistence;
+using Infrastructure.AI.Persistence.Entities;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Time.Testing;
+using Moq;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Conversations;
+
+/// <summary>
+/// The retention sweep on <see cref="SqliteConversationBudgetTracker"/> (issue #253).
+/// </summary>
+/// <remarks>
+/// <para>
+/// A budget row records how much of a lifetime ceiling a conversation has spent, so deleting the wrong
+/// one hands that conversation a fresh ceiling with nothing erroring — the exact failure the budget
+/// exists to prevent, caused by the thing meant to tidy up after it. These tests are therefore weighted
+/// towards what must <em>survive</em> a sweep rather than what must be removed.
+/// </para>
+/// <para>
+/// Against a real SQLite file, like the rest of this store's tests: the sweep is one correlated SQL
+/// statement across two tables, and an in-memory fake of either would test the fake.
+/// </para>
+/// </remarks>
+public sealed class SqliteConversationBudgetSweepTests : IDisposable
+{
+    private static readonly DateTimeOffset Origin = new(2026, 8, 6, 12, 0, 0, TimeSpan.Zero);
+    private static readonly TimeSpan Grace = TimeSpan.FromDays(30);
+
+    private readonly string _tempDir;
+    private readonly string _databasePath;
+    private readonly TestConversationDbContextFactory _contextFactory;
+    private readonly FakeTimeProvider _clock = new(Origin);
+    private readonly SqliteConversationBudgetTracker _tracker;
+
+    /// <summary>Creates an isolated on-disk database and the tracker under test.</summary>
+    public SqliteConversationBudgetSweepTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"convsweep-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+        _databasePath = Path.Combine(_tempDir, "conversations.db");
+        _contextFactory = new TestConversationDbContextFactory(_databasePath);
+
+        var config = new AppConfig();
+        config.AI.AgentFramework.ConversationTokenBudget = 10_000;
+
+        _tracker = new SqliteConversationBudgetTracker(
+            _contextFactory,
+            Mock.Of<IOptionsMonitor<AppConfig>>(m => m.CurrentValue == config),
+            _clock,
+            NullLogger<SqliteConversationBudgetTracker>.Instance,
+            new SchemaInitializer<ConversationDbContext>(_contextFactory));
+    }
+
+    /// <summary>
+    /// The case the sweep exists for: a conversation was deleted and its running total stayed behind.
+    /// </summary>
+    [Fact]
+    public async Task SweepAbandonedAsync_ConversationWasDeleted_ReclaimsItsRow()
+    {
+        const string key = "conv-deleted";
+        GivenConversation(key);
+        await _tracker.RecordUsageAsync(key, 500);
+
+        // Control. Without it, a sweep that deletes everything — or a tracker that never wrote the row
+        // in the first place — would satisfy the assertion below just as well as a correct one.
+        BudgetKeys().Should().Contain(key, "control: the row must exist before a sweep can be said to remove it");
+
+        DeleteConversation(key);
+        _clock.Advance(Grace + TimeSpan.FromDays(1));
+
+        var reclaimed = await _tracker.SweepAbandonedAsync(Grace);
+
+        reclaimed.Should().Be(1);
+        BudgetKeys().Should().NotContain(key);
+    }
+
+    /// <summary>
+    /// The load-bearing one. A conversation that merely sits idle keeps its total for as long as it
+    /// exists, no matter how long that is.
+    /// </summary>
+    /// <remarks>
+    /// An age-only sweep would pass every other test in this file and fail here, and the damage it does
+    /// is invisible: the user returns after a long absence, their ceiling has silently reset, and the
+    /// conversation runs to twice the configured length with nothing logged. Ten years, deliberately —
+    /// any threshold someone might later think defensible is well inside it.
+    /// </remarks>
+    [Fact]
+    public async Task SweepAbandonedAsync_ConversationStillExists_KeepsItsRowHoweverOld()
+    {
+        const string key = "conv-idle-for-years";
+        GivenConversation(key);
+        await _tracker.RecordUsageAsync(key, 500);
+
+        _clock.Advance(TimeSpan.FromDays(365 * 10));
+
+        var reclaimed = await _tracker.SweepAbandonedAsync(Grace);
+
+        reclaimed.Should().Be(0);
+        BudgetKeys().Should().Contain(key,
+            "a conversation that still exists can still be resumed, and removing its total would hand it "
+            + "a fresh ceiling — the silent reset the whole budget exists to prevent");
+        (await _tracker.GetStatusAsync(key)).ConsumedTokens.Should().Be(500,
+            "surviving the sweep must mean the total survived, not merely that some row did");
+    }
+
+    /// <summary>
+    /// A budget key with no conversation is not necessarily abandoned — it may belong to an in-flight
+    /// plan run, or to a caller nobody has written yet. The grace period is what protects those.
+    /// </summary>
+    [Fact]
+    public async Task SweepAbandonedAsync_PlanRunKeyWithinTheGracePeriod_IsKept()
+    {
+        const string key = "planrun:in-flight";
+        await _tracker.RecordUsageAsync(key, 300);
+
+        // Old enough to look abandoned by any casual reading, still comfortably inside the window.
+        _clock.Advance(Grace - TimeSpan.FromDays(1));
+
+        var reclaimed = await _tracker.SweepAbandonedAsync(Grace);
+
+        reclaimed.Should().Be(0);
+        BudgetKeys().Should().Contain(key,
+            "no conversation row exists for a plan run, so the existence test alone would delete the "
+            + "budget of an operation that is still running");
+    }
+
+    /// <summary>
+    /// The same key once the window has passed. Together with the test above this pins the grace period
+    /// as the thing deciding, rather than leaving both outcomes explainable by the key's shape.
+    /// </summary>
+    [Fact]
+    public async Task SweepAbandonedAsync_PlanRunKeyBeyondTheGracePeriod_IsReclaimed()
+    {
+        const string key = "planrun:leaked";
+        await _tracker.RecordUsageAsync(key, 300);
+
+        _clock.Advance(Grace + TimeSpan.FromDays(1));
+
+        var reclaimed = await _tracker.SweepAbandonedAsync(Grace);
+
+        reclaimed.Should().Be(1);
+        BudgetKeys().Should().NotContain(key);
+    }
+
+    /// <summary>
+    /// One sweep must not be able to take a live conversation with it. Runs both cases through a single
+    /// statement, which is where a mistaken join or a stray <c>OR</c> would show.
+    /// </summary>
+    [Fact]
+    public async Task SweepAbandonedAsync_MixedTable_ReclaimsOnlyTheOrphans()
+    {
+        GivenConversation("live-a");
+        GivenConversation("live-b");
+        GivenConversation("deleted-c");
+
+        foreach (var key in new[] { "live-a", "live-b", "deleted-c", "planrun:old" })
+            await _tracker.RecordUsageAsync(key, 100);
+
+        DeleteConversation("deleted-c");
+        _clock.Advance(Grace + TimeSpan.FromDays(1));
+
+        var reclaimed = await _tracker.SweepAbandonedAsync(Grace);
+
+        reclaimed.Should().Be(2);
+        BudgetKeys().Should().BeEquivalentTo(["live-a", "live-b"]);
+    }
+
+    /// <summary>
+    /// A zero grace period is a valid configuration and must still respect the existence test — the two
+    /// conditions are an AND, and a sweep that treated zero as "delete everything old" would be an OR.
+    /// </summary>
+    [Fact]
+    public async Task SweepAbandonedAsync_ZeroGracePeriod_StillKeepsLiveConversations()
+    {
+        GivenConversation("live");
+        await _tracker.RecordUsageAsync("live", 100);
+        await _tracker.RecordUsageAsync("orphan", 100);
+
+        _clock.Advance(TimeSpan.FromSeconds(1));
+
+        var reclaimed = await _tracker.SweepAbandonedAsync(TimeSpan.Zero);
+
+        reclaimed.Should().Be(1);
+        BudgetKeys().Should().BeEquivalentTo(["live"]);
+    }
+
+    /// <summary>A negative grace period would move the cutoff into the future; refuse it outright.</summary>
+    [Fact]
+    public async Task SweepAbandonedAsync_NegativeGracePeriod_Throws()
+    {
+        var sweep = async () => await _tracker.SweepAbandonedAsync(TimeSpan.FromDays(-1));
+
+        await sweep.Should().ThrowAsync<ArgumentOutOfRangeException>();
+    }
+
+    private void GivenConversation(string id)
+    {
+        using var context = _contextFactory.CreateDbContext();
+        context.Conversations.Add(new ConversationEntity
+        {
+            Id = id,
+            AgentName = "agent",
+            UserId = "owner",
+            CreatedAt = Origin,
+            UpdatedAt = Origin,
+        });
+        context.SaveChanges();
+    }
+
+    private void DeleteConversation(string id)
+    {
+        using var context = _contextFactory.CreateDbContext();
+        context.Conversations.Where(c => c.Id == id).ExecuteDelete();
+    }
+
+    private List<string> BudgetKeys()
+    {
+        using var context = _contextFactory.CreateDbContext();
+        return [.. context.ConversationBudgets.Select(b => b.BudgetKey)];
+    }
+
+    /// <summary>Releases the temporary database directory.</summary>
+    public void Dispose()
+    {
+        // Pooled connections keep a handle on the file, so the directory delete below fails without
+        // this — the same reason the sibling store tests clear the pool.
+        SqliteConnection.ClearAllPools();
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/IsolatedAppConfig.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/IsolatedAppConfig.cs
@@ -49,6 +49,15 @@ internal static class IsolatedAppConfig
     /// that database to the application directory by design and throws for a path outside it, so
     /// redirecting it here would break the control rather than isolate it.
     /// </para>
+    /// <para>
+    /// <strong>Every call gets its own subdirectory, not a shared one.</strong> A single per-assembly
+    /// directory kept the databases out of the build output but still handed every test the same file,
+    /// and xUnit runs test classes in parallel — so two classes building providers would both find a
+    /// table missing, both run <c>EnsureCreated</c>, and one would fail with "table already exists". That
+    /// surfaced the moment a hosted service began demanding the conversation schema at construction
+    /// (issue #253): a different DI test failed on each run, and none of them was at fault. Sharing a
+    /// database between parallel tests is the defect; the hosted service only exposed it.
+    /// </para>
     /// </remarks>
     public static AppConfig Isolate(AppConfig config)
     {
@@ -62,9 +71,15 @@ internal static class IsolatedAppConfig
         // here so that stops being something a reader has to work out.
         ArgumentException.ThrowIfNullOrWhiteSpace(root, nameof(IsolatedStateRoot.Root));
 
-        config.AI.Planner.DatabasePath = Path.Combine(root, "planner.db");
-        config.AI.Conversations.DatabasePath = Path.Combine(root, "conversations.db");
-        config.AI.Rag.GraphDatabase.DataDirectory = Path.Combine(root, "graph");
+        // Unique per call: two configurations must never name one database, however many tests are in
+        // flight. Created eagerly so a caller that writes a file rather than a database still lands
+        // somewhere that exists.
+        var slot = Path.Combine(root, Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(slot);
+
+        config.AI.Planner.DatabasePath = Path.Combine(slot, "planner.db");
+        config.AI.Conversations.DatabasePath = Path.Combine(slot, "conversations.db");
+        config.AI.Rag.GraphDatabase.DataDirectory = Path.Combine(slot, "graph");
 
         return config;
     }

--- a/src/Content/Tests/Presentation.Common.Tests/Composition/ConversationStoreCompositionTests.cs
+++ b/src/Content/Tests/Presentation.Common.Tests/Composition/ConversationStoreCompositionTests.cs
@@ -86,6 +86,33 @@ public sealed class ConversationStoreCompositionTests : IDisposable
     }
 
     [Fact]
+    public async Task CompositionRoot_RegistersTheBudgetRetentionSweep_OnTheSqliteProvider()
+    {
+        // Same lesson one issue later. The sweep's own tests construct the service directly, so they
+        // stay green with this registration deleted — and a sweep nothing resolves sweeps nothing,
+        // leaving the table growing exactly as it did before (issue #253).
+        await using var provider = CompositionRootTestHost.BuildProvider(SqliteSettings());
+
+        provider.GetServices<IHostedService>()
+            .Should().Contain(s => s.GetType().Name == "ConversationBudgetRetentionService",
+                "a retention sweep nothing resolves reclaims nothing");
+    }
+
+    [Fact]
+    public async Task CompositionRoot_BudgetTrackerAndSweep_ShareOneInstance()
+    {
+        // The tracker is registered by concrete type with the interface forwarding to it, precisely so
+        // the sweep and the budget callers are the same object. Registering the implementation twice
+        // would compile, resolve, and quietly give two — each with its own schema initializer.
+        await using var provider = CompositionRootTestHost.BuildProvider(SqliteSettings());
+
+        var viaInterface = provider.GetRequiredService<IConversationBudgetTracker>();
+        var viaConcrete = provider.GetRequiredService<SqliteConversationBudgetTracker>();
+
+        viaConcrete.Should().BeSameAs(viaInterface);
+    }
+
+    [Fact]
     public async Task CompositionRoot_RegistersConversationStore_AsSingleton()
     {
         await using var provider = CompositionRootTestHost.BuildProvider(SqliteSettings());


### PR DESCRIPTION
Closes #253.

Nothing removed a conversation's budget row when the conversation was deleted. `ReleaseAsync` exists, but the interactive callers never call it — a turn ending is not a conversation ending — so the table only ever grew. That was tolerable while the token ceiling shipped switched off and only opted-in deployments wrote rows at all; #256 made the ceiling a default, which is what the issue's own follow-up comment recorded, and the growth stopped being conditional on anything.

## The question the issue asked, and why the answer is a different question

#253 framed it as **"how old is abandoned?"** — and that threshold cannot be defended. A conversation may legitimately sit idle for months and resume. Deleting its row hands it a fresh ceiling with nothing erroring, which is precisely the failure the budget subsystem exists to prevent, caused by the thing meant to tidy up after it.

So the sweep does not decide that. It requires the conversation to be **gone**. Nobody resumes a deleted conversation, so removing its total cannot reset a ceiling anyone will meet again — and a conversation that still exists is never swept, however long it has been quiet.

## Where that guarantee stops, said out loud

The tempting shorter version — *"no conversation row means nobody can resume it"* — is **false**, and review caught me writing it. A budget key is caller-chosen, and several writers produce keys that never had a conversation row at all rather than having lost one:

- plan runs, under a `planrun:` scope;
- **self-contained conversation runs** — the path taken when no conversation owner is supplied — which accrue against a caller-supplied id with no transcript behind it;
- any future caller, under whatever key it picks.

For those, the grace period is the only protection there is. It answers a far easier question than user absence — how long before an operation this sweep cannot recognise is certainly over — and thirty days answers it comfortably for plan runs, which are bounded by their own timeout in minutes.

The case to size against is a caller reusing a **stable** id on the self-contained path: if it returns after a longer gap, its ceiling starts again. That is now written down in the config type, on the sweep itself, and in the AgentHub README, with the remedy (raise the period). A documented exposure beats a comforting invariant that is wrong.

## Deliberately no index

The sweep filters on `UpdatedAt`, so an index on it looked like the obvious companion — and it is a net loss. That column is rewritten by **every accrual**, which is the per-turn hot path, so the index would be maintained on every turn to speed a query that runs four times a day. It is also poorly selective for that query: in steady state most surviving rows *are* older than the grace period while their conversations still exist, and the correlated `NOT EXISTS` — which hits `conversations` by primary key — does the real work. The reasoning sits in the model, where the next person will look for it.

## A test-isolation bug this exposed, and the control that found it

Adding the hosted service made DI tests fail **non-deterministically** — a different one each run, always `table conversation_budgets already exists`.

```
CAUSE:     the retention service takes the budget tracker, and the tracker demands the schema
           initializer — so any test enumerating hosted services now ran EnsureCreated. Several
           such classes shared ONE database path from the per-assembly isolation added in #262,
           and xUnit runs test classes in parallel.
CONTROL:   measured. Same assembly, same command, change stashed: 2,822 pass, zero failures.
COVERAGE:  explains every failure observed; all were provider-building tests, none of them at fault.
```

Fixed at the layer that was actually wrong: every `IsolatedAppConfig` call now gets its own subdirectory. Sharing a database between parallel tests was the defect; the hosted service only made it visible.

## Also from review

- **Configuration reload took two intervals, not one.** The loop snapshotted config before a six-hour wait, and `IOptionsMonitor` hands back a fresh object on reload. Worse, the test could not see it — it mutated one shared instance, so the stale-read version passed. Rewritten to replace the whole instance the way a reload does; the mutation now goes red where it went green.
- **Two layers of error handling meant neither was testable.** The sweep swallowed its own exceptions *and* the service caught them. The sweep now lets them out — it is off the turn path, unlike its siblings, which is why they swallow and it should not — so "a failed sweep costs one tick, not the service" is a real test.
- **The config was invisible.** No `appsettings` entry, no README. Both added: a sweep that deletes rows should be visible in the settings file of a template people clone.

## Verification

Full solution green, all 21 assemblies. Mutation-tested, each with the discriminating test named:

| mutation | result |
|---|---|
| make the sweep age-blind (drop the existence test) | RED — 4 tests, led by the idle-conversation guard |
| delete the DI registration | RED — the composition guard |
| remove the loop's catch | RED — loop survival |
| snapshot configuration before the wait | RED — the reload test |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
