### PR TITLE
refactor: one writer for a conversation's telemetry, not three

### DIFF
--- a/src/Content/Application/Application.AI.Common/DependencyInjection.cs
+++ b/src/Content/Application/Application.AI.Common/DependencyInjection.cs
@@ -14,6 +14,7 @@ using Application.AI.Common.Interfaces.Skills;
 using Application.AI.Common.Interfaces.Tools;
 using Application.AI.Common.MediatRBehaviors;
 using Application.AI.Common.OpenTelemetry;
+using Application.AI.Common.Services.AI;
 using Application.AI.Common.Services.Agent;
 using Application.AI.Common.Services.Context;
 using Application.AI.Common.Services.Sandbox;
@@ -76,6 +77,13 @@ public static class DependencyInjection
         // CQRS surface so handlers actually wire into the pipeline at runtime.
         services.AddMediatR(cfg => cfg.RegisterServicesFromAssembly(assembly));
         services.AddValidatorsFromAssembly(assembly);
+
+        // The one writer of a conversation's telemetry rollup, shared by every transport that runs a
+        // turn (issue #280). Registered here, in the assembly that owns the type and both store
+        // interfaces it needs, rather than beside the observability implementation: three consumers in
+        // three projects depend on it, and a host that wired the CQRS layer without the observability
+        // one would otherwise fail to construct its conversation handler at all.
+        services.AddSingleton<IConversationTelemetryRecorder, ConversationTelemetryRecorder>();
 
         // Agent-specific pipeline behaviors — registered before Application.Common
         // behaviors so they wrap as the outermost layer

--- a/src/Content/Application/Application.AI.Common/Interfaces/AI/IConversationTelemetryRecorder.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/AI/IConversationTelemetryRecorder.cs
@@ -1,0 +1,79 @@
+using Application.AI.Common.Models.Conversations;
+
+namespace Application.AI.Common.Interfaces.AI;
+
+/// <summary>
+/// Records what a conversation spends, once, for every transport that runs one.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>Why this exists.</strong> Three transports — the CQRS/bundle handler, the AG-UI HTTP
+/// endpoint, and the SignalR hub — each implemented the same policy independently, and had already
+/// drifted four ways: whether an existing session is adopted or a new one always opened, where the
+/// running totals are read from, how the cache hit rate is computed, and which counters are
+/// incremented. The observability row is keyed one-per-conversation and written with SET semantics, so
+/// two of those differences were not cosmetic: they overwrote the conversation's rollup with one
+/// transport's partial view (issues #255, #280).
+/// </para>
+/// <para>
+/// <strong>What it deliberately does not own: ending the session.</strong> That rule genuinely differs
+/// per transport and is not duplication — a bundle run ends the session it opened, a stateless HTTP
+/// request leaves the conversation's session open for the next one, and the hub ends it when the
+/// connection drops. Folding those into one method would mean a flag that selects between three
+/// behaviours, which is the same three implementations with extra steps.
+/// </para>
+/// </remarks>
+public interface IConversationTelemetryRecorder
+{
+    /// <summary>
+    /// Finds where a conversation has got to, opening an observability session for it if it has none.
+    /// </summary>
+    /// <param name="conversationId">The conversation about to take a turn.</param>
+    /// <param name="callerId">
+    /// The authenticated owner, or <see langword="null"/> for a run with no durable transcript — see
+    /// <see cref="ConversationTelemetryState.CallerId"/>. A blank string is rejected rather than treated
+    /// as absent, because an empty identity has been read as "everyone" in this codebase before.
+    /// </param>
+    /// <param name="agentName">The agent about to run, recorded on a session this call opens.</param>
+    /// <param name="knownRecord">
+    /// The conversation record, when the caller has already read it. Supplying it avoids a second read
+    /// of the same row — and, for a caller that reads under a lease or in a deliberate sequence, avoids
+    /// this call quietly inserting a read into the middle of that sequence. Pass
+    /// <see langword="null"/> to have the record fetched.
+    /// </param>
+    /// <param name="cancellationToken">Cancels the call.</param>
+    /// <returns>The conversation's session and running totals.</returns>
+    /// <remarks>
+    /// Adopt-or-open, never open-unconditionally. A conversation has one session row for its whole life;
+    /// opening a second restamps its start time and every duration derived from it.
+    /// </remarks>
+    Task<ConversationTelemetryState> BeginAsync(
+        string conversationId,
+        string? callerId,
+        string agentName,
+        ConversationRecord? knownRecord = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Adds a turn to the conversation's totals and writes the new totals to both stores.
+    /// </summary>
+    /// <param name="state">Where the conversation had got to, from <see cref="BeginAsync"/> or the previous turn.</param>
+    /// <param name="turn">What this turn cost.</param>
+    /// <param name="cancellationToken">Cancels the call.</param>
+    /// <returns>The updated state. Pass it to the next turn.</returns>
+    /// <remarks>
+    /// <para>
+    /// <strong>Cumulative, not per-run.</strong> The observability row is written with SET semantics, so
+    /// what goes into it has to be the conversation's whole total. Writing a run's own share there is
+    /// the overwrite this interface exists to make impossible to spell.
+    /// </para>
+    /// <para>
+    /// Never throws for a store failure. Telemetry that cannot be written is worth a log line, not a
+    /// failed turn the caller has already paid for.
+    /// </para>
+    /// </remarks>
+    Task<ConversationTelemetryState> RecordTurnAsync(
+        ConversationTelemetryState state,
+        ConversationTurnTelemetry turn,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Content/Application/Application.AI.Common/Models/Conversations/ConversationTelemetryState.cs
+++ b/src/Content/Application/Application.AI.Common/Models/Conversations/ConversationTelemetryState.cs
@@ -1,0 +1,46 @@
+namespace Application.AI.Common.Models.Conversations;
+
+/// <summary>
+/// A conversation's telemetry position: which observability session it is being recorded against, and
+/// everything it has spent so far. Handed out by <c>IConversationTelemetryRecorder.BeginAsync</c> and
+/// handed back to it after every turn.
+/// </summary>
+/// <param name="ConversationId">The conversation these totals belong to.</param>
+/// <param name="CallerId">
+/// The authenticated owner, or <see langword="null"/> for a run with no durable transcript. Null means
+/// the totals are not written back to any conversation record — there is none — so they live only for
+/// the length of the run. It is never a wildcard: the store refuses a blank caller outright, and this
+/// type does not offer one.
+/// </param>
+/// <param name="SessionId">The observability session row this conversation's rollup is written to.</param>
+/// <param name="Totals">Everything the conversation has spent, across every run and every transport.</param>
+/// <param name="SessionOpened">
+/// Whether this call opened the session rather than adopting one the conversation already had. The
+/// recorder knows; a caller re-deriving it by testing the record it passed in is the same question
+/// answered twice, and the two answers can disagree once anything else writes a session id.
+/// </param>
+/// <remarks>
+/// <para>
+/// The point of carrying this as one value is that the three transports used to each keep their own
+/// idea of it, and drifted. The SignalR path kept totals on a per-<em>connection</em> object, so
+/// reconnecting reset the conversation's rollup to whatever the new connection had spent (issue #280).
+/// A conversation's totals are a property of the conversation, and this is the shape that says so.
+/// </para>
+/// </remarks>
+public sealed record ConversationTelemetryState(
+    string ConversationId,
+    string? CallerId,
+    Guid SessionId,
+    TelemetryAccumulator Totals,
+    bool SessionOpened = false)
+{
+    /// <summary>
+    /// The number to give the next turn: one past however many the conversation has already taken.
+    /// </summary>
+    /// <remarks>
+    /// Derived from the totals rather than from a message count or a per-connection counter, both of
+    /// which have been used before and both of which produce a different sequence for the same
+    /// conversation depending on how it was reached — a message count advances by two per turn.
+    /// </remarks>
+    public int NextTurnNumber => Totals.TurnCount + 1;
+}

--- a/src/Content/Application/Application.AI.Common/Models/Conversations/ConversationTurnTelemetry.cs
+++ b/src/Content/Application/Application.AI.Common/Models/Conversations/ConversationTurnTelemetry.cs
@@ -1,0 +1,29 @@
+namespace Application.AI.Common.Models.Conversations;
+
+/// <summary>
+/// What one turn cost. The unit every transport hands to <c>IConversationTelemetryRecorder</c>.
+/// </summary>
+/// <param name="InputTokens">Prompt tokens billed for this turn.</param>
+/// <param name="OutputTokens">Completion tokens billed for this turn.</param>
+/// <param name="CacheRead">Tokens served from the provider's prompt cache.</param>
+/// <param name="CacheWrite">Tokens written into the provider's prompt cache.</param>
+/// <param name="CostUsd">The turn's cost in US dollars.</param>
+/// <param name="ToolCalls">How many tools the turn invoked.</param>
+/// <param name="Model">
+/// The model that served the turn, or <see langword="null"/> to leave the session's recorded model as
+/// it is. Carried per turn because a conversation can change model mid-flight.
+/// </param>
+/// <remarks>
+/// Six numbers that always travel together, named once. They were previously spelled out as six
+/// arguments at three call sites, inside a twelve-argument store call — which is three chances to
+/// transpose two <c>int</c>s into columns that would still add up and still look plausible on a
+/// dashboard.
+/// </remarks>
+public sealed record ConversationTurnTelemetry(
+    int InputTokens,
+    int OutputTokens,
+    int CacheRead,
+    int CacheWrite,
+    decimal CostUsd,
+    int ToolCalls,
+    string? Model = null);

--- a/src/Content/Application/Application.AI.Common/Services/AI/ConversationTelemetryRecorder.cs
+++ b/src/Content/Application/Application.AI.Common/Services/AI/ConversationTelemetryRecorder.cs
@@ -1,0 +1,189 @@
+using System.Diagnostics;
+using Application.AI.Common.Interfaces;
+using Application.AI.Common.Interfaces.AI;
+using Application.AI.Common.Models.Conversations;
+using Application.AI.Common.OpenTelemetry.Metrics;
+using Domain.AI.Telemetry.Conventions;
+using Microsoft.Extensions.Logging;
+
+namespace Application.AI.Common.Services.AI;
+
+/// <summary>
+/// The one implementation of <see cref="IConversationTelemetryRecorder"/>: the policy all three
+/// transports used to carry a copy of.
+/// </summary>
+/// <remarks>
+/// Reads and writes two stores. <see cref="IObservabilityStore"/> holds the dashboard-facing session
+/// rollup, keyed one row per conversation and written with SET semantics; <see cref="IConversationStore"/>
+/// holds the same totals on the conversation record, which is what makes them survive a process, a
+/// reconnect, or a switch of transport. Both are written from the same value on every turn, so they
+/// cannot disagree.
+/// </remarks>
+public sealed class ConversationTelemetryRecorder : IConversationTelemetryRecorder
+{
+    private readonly IObservabilityStore _observabilityStore;
+    private readonly IConversationStore _conversationStore;
+    private readonly ILogger<ConversationTelemetryRecorder> _logger;
+
+    /// <summary>Initializes the recorder.</summary>
+    /// <param name="observabilityStore">Receives the dashboard-facing session rollup.</param>
+    /// <param name="conversationStore">Holds the durable copy of the same totals.</param>
+    /// <param name="logger">Receives the warnings emitted when a telemetry write fails.</param>
+    public ConversationTelemetryRecorder(
+        IObservabilityStore observabilityStore,
+        IConversationStore conversationStore,
+        ILogger<ConversationTelemetryRecorder> logger)
+    {
+        ArgumentNullException.ThrowIfNull(observabilityStore);
+        ArgumentNullException.ThrowIfNull(conversationStore);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _observabilityStore = observabilityStore;
+        _conversationStore = conversationStore;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<ConversationTelemetryState> BeginAsync(
+        string conversationId,
+        string? callerId,
+        string agentName,
+        ConversationRecord? knownRecord = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(conversationId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(agentName);
+
+        // Blank is refused rather than coerced to null. An absent caller is a run with no transcript; a
+        // blank one is a bug upstream, and treating it as "nobody in particular, carry on" is how an
+        // empty identity has been read as "everyone" in this codebase before.
+        if (callerId is not null)
+            ArgumentException.ThrowIfNullOrWhiteSpace(callerId);
+
+        (Guid SessionId, TelemetryAccumulator Totals) existing;
+        if (callerId is null)
+        {
+            // No owner means no durable record to read: a self-contained run starts from nothing and
+            // keeps its totals only for the length of the run.
+            existing = (Guid.Empty, TelemetryAccumulator.Zero);
+        }
+        else if (knownRecord is not null)
+        {
+            // Checked rather than trusted. A record for a different conversation, or one read under a
+            // different identity, would have this adopt the wrong session and then persist totals under
+            // the caller supplied here — an identity-shaped assumption, which is the shape of mistake
+            // this codebase has paid for before.
+            if (!string.Equals(knownRecord.Id, conversationId, StringComparison.Ordinal))
+                throw new ArgumentException(
+                    $"The supplied record is for conversation '{knownRecord.Id}', not '{conversationId}'.",
+                    nameof(knownRecord));
+
+            if (!string.Equals(knownRecord.UserId, callerId, StringComparison.Ordinal))
+                throw new ArgumentException(
+                    "The supplied record is owned by someone other than the caller.", nameof(knownRecord));
+
+            existing = (knownRecord.ObservabilitySessionId ?? Guid.Empty,
+                        knownRecord.Telemetry ?? TelemetryAccumulator.Zero);
+        }
+        else
+        {
+            existing = await LoadAsync(conversationId, callerId, cancellationToken);
+        }
+
+        if (existing.SessionId != Guid.Empty)
+        {
+            return new ConversationTelemetryState(
+                conversationId, callerId, existing.SessionId, existing.Totals, SessionOpened: false);
+        }
+
+        var sessionId = await _observabilityStore.StartSessionAsync(
+            conversationId, agentName, model: null, cancellationToken);
+
+        SessionMetrics.SessionsStarted.Add(1, new KeyValuePair<string, object?>(AgentConventions.Name, agentName));
+
+        // User activity needs a user. Previously two of the three transports emitted this and the third
+        // did not, for no reason anyone recorded — the difference was that the third had not been given
+        // an identity to attribute it to, which is now the actual condition rather than an accident of
+        // which file the code lived in.
+        if (callerId is not null)
+        {
+            UserActivityMetrics.SessionsStarted.Add(
+                1, new KeyValuePair<string, object?>(UserConventions.UserId, callerId));
+
+            // Written immediately, before the first turn, so a crash in between does not leave the
+            // conversation opening a second session next time and restamping its start time.
+            await PersistAsync(conversationId, callerId, sessionId, existing.Totals, cancellationToken);
+        }
+
+        return new ConversationTelemetryState(
+            conversationId, callerId, sessionId, existing.Totals, SessionOpened: true);
+    }
+
+    /// <inheritdoc />
+    public async Task<ConversationTelemetryState> RecordTurnAsync(
+        ConversationTelemetryState state,
+        ConversationTurnTelemetry turn,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(state);
+        ArgumentNullException.ThrowIfNull(turn);
+
+        var totals = state.Totals.Add(
+            turn.InputTokens, turn.OutputTokens, turn.CacheRead, turn.CacheWrite, turn.CostUsd, turn.ToolCalls);
+
+        var updated = state with { Totals = totals };
+
+        try
+        {
+            await _observabilityStore.UpdateSessionMetricsAsync(
+                state.SessionId,
+                totals.TurnCount,
+                totals.ToolCallCount,
+                subagentCount: 0,
+                totals.InputTokens,
+                totals.OutputTokens,
+                totals.CacheRead,
+                totals.CacheWrite,
+                totals.CostUsd,
+                Math.Round(totals.CacheHitRate, 4),
+                turn.Model,
+                cancellationToken);
+
+            if (state.CallerId is not null)
+                await PersistAsync(state.ConversationId, state.CallerId, state.SessionId, totals, cancellationToken);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            // The turn has already happened and been paid for. Failing it now to report an accounting
+            // problem would cost the caller the work as well as the record. The returned state still
+            // carries the new totals, so the next turn continues from the right place and the next write
+            // catches the row up.
+            _logger.LogWarning(
+                ex,
+                "Failed to record turn {TurnNumber} telemetry for conversation {ConversationId}; the "
+                    + "rollup is behind by this turn until the next write succeeds",
+                totals.TurnCount,
+                state.ConversationId);
+        }
+
+        return updated;
+    }
+
+    private async Task<(Guid SessionId, TelemetryAccumulator Totals)> LoadAsync(
+        string conversationId, string callerId, CancellationToken cancellationToken)
+    {
+        var record = await _conversationStore.GetAsync(conversationId, callerId, cancellationToken);
+        return (record?.ObservabilitySessionId ?? Guid.Empty, record?.Telemetry ?? TelemetryAccumulator.Zero);
+    }
+
+    private async Task PersistAsync(
+        string conversationId,
+        string callerId,
+        Guid sessionId,
+        TelemetryAccumulator totals,
+        CancellationToken cancellationToken)
+    {
+        await _conversationStore.UpdateTelemetryAsync(
+            conversationId, callerId, sessionId, totals, cancellationToken);
+    }
+}

--- a/src/Content/Application/Application.Core/CQRS/Agents/RunConversation/RunConversationCommandHandler.cs
+++ b/src/Content/Application/Application.Core/CQRS/Agents/RunConversation/RunConversationCommandHandler.cs
@@ -39,6 +39,7 @@ public class RunConversationCommandHandler : IRequestHandler<RunConversationComm
 	private readonly IAgentConversationCache _agentCache;
 	private readonly IConversationBudgetTracker _conversationBudget;
 	private readonly IObservabilityStore _observabilityStore;
+	private readonly IConversationTelemetryRecorder _telemetryRecorder;
 	private readonly IConversationStore _conversationStore;
 	private readonly IConversationTurnLease _turnLease;
 	private readonly IOptions<ConversationsConfig> _conversationsConfig;
@@ -69,6 +70,7 @@ public class RunConversationCommandHandler : IRequestHandler<RunConversationComm
 		IAgentConversationCache agentCache,
 		IConversationBudgetTracker conversationBudget,
 		IObservabilityStore observabilityStore,
+		IConversationTelemetryRecorder telemetryRecorder,
 		IConversationStore conversationStore,
 		IConversationTurnLease turnLease,
 		IOptions<ConversationsConfig> conversationsConfig,
@@ -78,6 +80,7 @@ public class RunConversationCommandHandler : IRequestHandler<RunConversationComm
 		ArgumentNullException.ThrowIfNull(agentCache);
 		ArgumentNullException.ThrowIfNull(conversationBudget);
 		ArgumentNullException.ThrowIfNull(observabilityStore);
+		ArgumentNullException.ThrowIfNull(telemetryRecorder);
 		ArgumentNullException.ThrowIfNull(conversationStore);
 		ArgumentNullException.ThrowIfNull(turnLease);
 		ArgumentNullException.ThrowIfNull(conversationsConfig);
@@ -87,6 +90,7 @@ public class RunConversationCommandHandler : IRequestHandler<RunConversationComm
 		_agentCache = agentCache;
 		_conversationBudget = conversationBudget;
 		_observabilityStore = observabilityStore;
+		_telemetryRecorder = telemetryRecorder;
 		_conversationStore = conversationStore;
 		_turnLease = turnLease;
 		_conversationsConfig = conversationsConfig;
@@ -177,11 +181,20 @@ public class RunConversationCommandHandler : IRequestHandler<RunConversationComm
 		var stoppedForBudget = false;
 		string? sessionModel = null;
 
-		// Everything the conversation has spent, this run included as it goes. A durable run resumes
-		// these from the store; a self-contained run has nothing before it and starts at zero.
-		var (existingSessionId, conversationTotals) = transcript is null
-			? (Guid.Empty, TelemetryAccumulator.Zero)
-			: await transcript.LoadTelemetryAsync(cancellationToken);
+		// Everything the conversation has spent, this run included as it goes, plus the session it is
+		// recorded against — adopted when the conversation already has one, opened when it does not.
+		// A durable run resumes from the store; a self-contained run has nothing before it, starts at
+		// zero, and writes nothing back because there is no record to write to.
+		//
+		// This is the one implementation all three transports share (issue #280). The rule it enforces
+		// is that a conversation gets ONE session for its whole life: re-opening the session it already
+		// has does not open a second, it restamps the first one's start time, and every duration derived
+		// from it then describes only the latest run (issue #255).
+		var telemetry = await _telemetryRecorder.BeginAsync(
+			request.ConversationId, request.ConversationOwnerId, request.AgentName, null, cancellationToken);
+
+		var dbSessionId = telemetry.SessionId;
+		var conversationTotals = telemetry.Totals;
 
 		// Where this run came in. The caller asked what THIS call cost, and the run-scoped metrics
 		// report the same, so that quantity is derived by subtraction rather than accumulated alongside:
@@ -191,24 +204,6 @@ public class RunConversationCommandHandler : IRequestHandler<RunConversationComm
 
 		var agentTag = new KeyValuePair<string, object?>(AgentConventions.Name, request.AgentName);
 		var sessionTags = new TagList { { AgentConventions.Name, request.AgentName } };
-
-		// A conversation gets ONE observability session and keeps it, because the session table holds one
-		// row per conversation. Re-opening the session a conversation already has does not open a second
-		// one — it restamps the first one's start time, and every duration derived from it then describes
-		// only the latest run (issue #255). So a continuing run adopts the session it finds.
-		var dbSessionId = existingSessionId;
-		if (dbSessionId == Guid.Empty)
-		{
-			dbSessionId = await _observabilityStore.StartSessionAsync(
-				request.ConversationId, request.AgentName, null, cancellationToken);
-
-			SessionMetrics.SessionsStarted.Add(1, agentTag);
-
-			// Recorded before the first turn, not after it, so the conversation still points at its
-			// session when a run opens one and then declines every turn on an exhausted budget.
-			if (transcript is not null)
-				await transcript.PersistTelemetryAsync(dbSessionId, conversationTotals, cancellationToken);
-		}
 
 		SessionMetrics.ActiveSessions.Add(1, sessionTags);
 
@@ -388,11 +383,6 @@ public class RunConversationCommandHandler : IRequestHandler<RunConversationComm
 
 				sessionModel ??= lastResult.Model;
 
-				conversationTotals = conversationTotals.Add(
-					lastResult.InputTokens, lastResult.OutputTokens,
-					lastResult.CacheRead, lastResult.CacheWrite,
-					lastResult.CostUsd, lastResult.ToolsInvoked.Count);
-
 				// Fold this turn's input+output into the conversation-lifetime budget (mirrors the
 				// per-turn TokenBudgetBehavior's accounting). The next loop iteration's gate decides
 				// whether the cumulative total has crossed the ceiling.
@@ -401,39 +391,22 @@ public class RunConversationCommandHandler : IRequestHandler<RunConversationComm
 					lastResult.InputTokens + lastResult.OutputTokens,
 					cancellationToken);
 
-				// Cumulative, not this run's share. The session row is written with SET semantics against
-				// a row keyed one-per-conversation, so reporting the run's own totals here replaces the
-				// conversation's with whatever the most recent run happened to spend (issue #255).
-				await _observabilityStore.UpdateSessionMetricsAsync(
-					dbSessionId,
-					conversationTotals.TurnCount, conversationTotals.ToolCallCount, subagentCount: 0,
-					conversationTotals.InputTokens, conversationTotals.OutputTokens,
-					conversationTotals.CacheRead, conversationTotals.CacheWrite,
-					conversationTotals.CostUsd, Math.Round(conversationTotals.CacheHitRate, 4),
-					sessionModel, cancellationToken);
+				// One call for the accumulate and both writes — the observability rollup and the
+				// conversation's own copy of the same totals, always from one value so the two cannot
+				// disagree. Cumulative, not this run's share: the session row is keyed one-per-conversation
+				// and written with SET semantics, so a run's own totals would replace the conversation's
+				// with whatever the latest run happened to spend (issues #255, #280). It never throws —
+				// the turn's answer is already in the transcript, and discarding real work to protect a
+				// number is the wrong trade.
+				telemetry = await _telemetryRecorder.RecordTurnAsync(
+					telemetry,
+					new ConversationTurnTelemetry(
+						lastResult.InputTokens, lastResult.OutputTokens,
+						lastResult.CacheRead, lastResult.CacheWrite,
+						lastResult.CostUsd, lastResult.ToolsInvoked.Count, sessionModel),
+					cancellationToken);
 
-				// The conversation's own copy of the same totals. It is what the next run resumes from,
-				// and the only one that survives the observability database being absent or switched off,
-				// so it is written every turn rather than once at the end — a run that dies on its
-				// seventh turn leaves the two agreeing about the six that completed.
-				//
-				// Logged and swallowed, matching what the interactive host does with the same write and
-				// what the observability store does internally: the turn succeeded and its answer is
-				// already in the transcript, so failing it now over a telemetry write would discard real
-				// work to protect a number. The cost is that the next run resumes from a stale total.
-				if (transcript is not null)
-				{
-					try
-					{
-						await transcript.PersistTelemetryAsync(dbSessionId, conversationTotals, cancellationToken);
-					}
-					catch (Exception ex) when (ex is not OperationCanceledException)
-					{
-						_logger.LogWarning(ex,
-							"Failed to persist telemetry for conversation {ConversationId}; the next run will "
-							+ "resume from a stale total", request.ConversationId);
-					}
-				}
+				conversationTotals = telemetry.Totals;
 
 				if (request.OnProgress != null)
 				{

--- a/src/Content/Presentation/Presentation.AgentHub/AgUi/AgUiRunHandler.cs
+++ b/src/Content/Presentation/Presentation.AgentHub/AgUi/AgUiRunHandler.cs
@@ -30,6 +30,7 @@ public sealed class AgUiRunHandler
     private readonly IMediator _mediator;
     private readonly IConversationStore _conversationStore;
     private readonly IObservabilityStore _observabilityStore;
+    private readonly IConversationTelemetryRecorder _telemetryRecorder;
     private readonly IConversationTurnLease _turnLease;
     private readonly IAgUiEventWriterAccessor _writerAccessor;
     private readonly IConversationBudgetTracker _conversationBudget;
@@ -43,6 +44,7 @@ public sealed class AgUiRunHandler
         IMediator mediator,
         IConversationStore conversationStore,
         IObservabilityStore observabilityStore,
+        IConversationTelemetryRecorder telemetryRecorder,
         IConversationTurnLease turnLease,
         IAgUiEventWriterAccessor writerAccessor,
         IConversationBudgetTracker conversationBudget,
@@ -52,6 +54,7 @@ public sealed class AgUiRunHandler
         _mediator = mediator;
         _conversationStore = conversationStore;
         _observabilityStore = observabilityStore;
+        _telemetryRecorder = telemetryRecorder;
         _turnLease = turnLease;
         _writerAccessor = writerAccessor;
         _conversationBudget = conversationBudget;
@@ -130,22 +133,6 @@ public sealed class AgUiRunHandler
             return;
         }
 
-        var observabilitySessionId = record.ObservabilitySessionId ?? Guid.Empty;
-        if (observabilitySessionId == Guid.Empty)
-        {
-            var agentTag = new KeyValuePair<string, object?>(AgentConventions.Name, record.AgentName);
-            SessionMetrics.SessionsStarted.Add(1, agentTag);
-            SessionMetrics.ActiveSessions.Add(1, new TagList { { AgentConventions.Name, record.AgentName } });
-            UserActivityMetrics.SessionsStarted.Add(1,
-                new KeyValuePair<string, object?>(UserConventions.UserId, callerId));
-
-            observabilitySessionId = await _observabilityStore.StartSessionAsync(
-                input.ThreadId, record.AgentName, model: null, ct);
-
-            await _conversationStore.UpdateTelemetryAsync(
-                input.ThreadId, callerId, observabilitySessionId, TelemetryAccumulator.Zero, ct);
-        }
-
         Activity.Current?.AddBaggage(UserConventions.UserId, callerId);
 
         IConversationTurnLeaseHandle lease;
@@ -169,7 +156,7 @@ public sealed class AgUiRunHandler
 
         await using (lease)
         {
-            await RunLeasedTurnAsync(input, writer, lease, userMessage, callerId, observabilitySessionId, ct);
+            await RunLeasedTurnAsync(input, writer, lease, userMessage, callerId, ct);
         }
     }
 
@@ -194,7 +181,6 @@ public sealed class AgUiRunHandler
         IConversationTurnLeaseHandle lease,
         AgUiMessage userMessage,
         string callerId,
-        Guid observabilitySessionId,
         CancellationToken ct)
     {
         // Losing the lease mid-turn has to stop the turn. Another host now holds it, so anything
@@ -221,11 +207,29 @@ public sealed class AgUiRunHandler
                 return;
             }
 
+            // Telemetry is established from the LEASED record, not the pre-lease snapshot. The turn
+            // number and the running totals both come from it, and the turn this one waited behind may
+            // have advanced them — numbering from the stale copy would collide with a turn already
+            // written.
+            var telemetry = await _telemetryRecorder.BeginAsync(
+                input.ThreadId, callerId, leased.AgentName, leased, turnCts.Token);
+
+            if (telemetry.SessionOpened)
+            {
+                // The gauge, and only the gauge, stays here: this path never ends a session — a
+                // stateless request leaves the conversation's open for the next one — so the rule
+                // differs per transport and the shared recorder deliberately owns none that do.
+                // Read off the recorder rather than re-derived from the record, so the two cannot
+                // disagree about whether a session was just opened.
+                SessionMetrics.ActiveSessions.Add(
+                    1, new TagList { { AgentConventions.Name, leased.AgentName } });
+            }
+
             _writerAccessor.Writer = writer;
             _writerAccessor.ThreadId = input.ThreadId;
             _writerAccessor.CallerId = callerId;
             await ExecuteRunAsync(
-                input, writer, leased, userMessage, callerId, observabilitySessionId, turnCts.Token);
+                input, writer, leased, userMessage, callerId, telemetry, turnCts.Token);
         }
         catch (OperationCanceledException)
         {
@@ -262,7 +266,7 @@ public sealed class AgUiRunHandler
         ConversationRecord record,
         AgUiMessage userMessage,
         string callerId,
-        Guid observabilitySessionId,
+        ConversationTelemetryState telemetry,
         CancellationToken ct)
     {
         var userMessageText = userMessage.Content!;
@@ -288,7 +292,7 @@ public sealed class AgUiRunHandler
         // conversation from the same counter (issue #255). Message count advances two per exchange, so
         // it produced 1, 3, 5… here against 1, 2, 3… there — two writers interleaving into one key
         // space, overwriting each other's turns on any conversation driven from both.
-        var turnNumber = (record.Telemetry?.TurnCount ?? 0) + 1;
+        var turnNumber = telemetry.NextTurnNumber;
 
         // Conversation-lifetime budget gate: decline gracefully (no LLM dispatch) when the
         // conversation has exhausted its cumulative ceiling, emitting the explanatory message as a
@@ -310,7 +314,7 @@ public sealed class AgUiRunHandler
             DeploymentOverride = record.Settings?.DeploymentName,
             Temperature = record.Settings?.Temperature,
             SystemPromptOverride = record.Settings?.SystemPromptOverride,
-            ObservabilitySessionId = observabilitySessionId,
+            ObservabilitySessionId = telemetry.SessionId,
         };
 
         AgentTurnResult result;
@@ -365,30 +369,15 @@ public sealed class AgUiRunHandler
         await _conversationBudget.RecordUsageAsync(
             input.ThreadId, result.InputTokens + result.OutputTokens, ct);
 
-        var previousTelemetry = record.Telemetry ?? TelemetryAccumulator.Zero;
-        var updatedTelemetry = previousTelemetry.Add(
-            result.InputTokens, result.OutputTokens,
-            result.CacheRead, result.CacheWrite,
-            result.CostUsd, result.ToolsInvoked.Count);
-
-        try
-        {
-            await _observabilityStore.UpdateSessionMetricsAsync(
-                observabilitySessionId,
-                updatedTelemetry.TurnCount, updatedTelemetry.ToolCallCount, subagentCount: 0,
-                updatedTelemetry.InputTokens, updatedTelemetry.OutputTokens,
-                updatedTelemetry.CacheRead, updatedTelemetry.CacheWrite,
-                updatedTelemetry.CostUsd,
-                Math.Round(updatedTelemetry.CacheHitRate, 4),
-                result.Model, ct);
-
-            await _conversationStore.UpdateTelemetryAsync(
-                input.ThreadId, callerId, observabilitySessionId, updatedTelemetry, ct);
-        }
-        catch (Exception ex) when (ex is not OperationCanceledException)
-        {
-            _logger.LogWarning(ex, "AG-UI run {RunId}: failed to persist session metrics.", input.RunId);
-        }
+        // One call for what used to be an accumulate, a twelve-argument store write, a second store
+        // write and a swallow — spelled out identically in three files, and drifted in four ways
+        // between them (issue #280).
+        await _telemetryRecorder.RecordTurnAsync(
+            telemetry,
+            new ConversationTurnTelemetry(
+                result.InputTokens, result.OutputTokens, result.CacheRead, result.CacheWrite,
+                result.CostUsd, result.ToolsInvoked.Count, result.Model),
+            ct);
 
         // Stream and persist the assistant response under a single stable id. The client
         // references this id (via TEXT_MESSAGE_START) for retry-from-message, so the streamed

--- a/src/Content/Presentation/Presentation.AgentHub/Services/ConversationOrchestrator.cs
+++ b/src/Content/Presentation/Presentation.AgentHub/Services/ConversationOrchestrator.cs
@@ -30,6 +30,7 @@ public sealed class ConversationOrchestrator : IConversationOrchestrator
     private readonly IConversationTurnLease _turnLease;
     private readonly ISessionHealthTracker _healthTracker;
     private readonly IObservabilityStore _observabilityStore;
+    private readonly IConversationTelemetryRecorder _telemetryRecorder;
     private readonly IConnectionTracker _connectionTracker;
     private readonly IConversationBudgetTracker _conversationBudget;
     private readonly AgentHubConfig _config;
@@ -42,6 +43,7 @@ public sealed class ConversationOrchestrator : IConversationOrchestrator
         IConversationTurnLease turnLease,
         ISessionHealthTracker healthTracker,
         IObservabilityStore observabilityStore,
+        IConversationTelemetryRecorder telemetryRecorder,
         IConnectionTracker connectionTracker,
         IConversationBudgetTracker conversationBudget,
         IOptions<AgentHubConfig> config,
@@ -53,6 +55,7 @@ public sealed class ConversationOrchestrator : IConversationOrchestrator
         _turnLease = turnLease;
         _healthTracker = healthTracker;
         _observabilityStore = observabilityStore;
+        _telemetryRecorder = telemetryRecorder;
         _connectionTracker = connectionTracker;
         _conversationBudget = conversationBudget;
         _config = config.Value;
@@ -280,13 +283,17 @@ public sealed class ConversationOrchestrator : IConversationOrchestrator
         Activity.Current?.AddBaggage("agent.conversation_id", conversationId);
         Activity.Current?.AddBaggage(UserConventions.UserId, callerId);
 
-        await EnsureSessionTrackedAsync(sessionKey, conversationId, agentName, callerId, ct);
+        var telemetry = await EnsureSessionTrackedAsync(sessionKey, conversationId, agentName, callerId, ct);
 
         var history = await _conversationStore.GetHistoryForDispatch(
             conversationId, callerId, _config.MaxHistoryMessages, ct) ?? [];
 
         var updatedRecord = await _conversationStore.GetAsync(conversationId, callerId, ct);
-        var turnNumber = updatedRecord?.Messages.Count ?? 0;
+
+        // Numbered from the conversation's turn count, not its message count. A message count advances
+        // by two per turn, so the same conversation produced a different sequence over this transport
+        // than over the bundle path — in one key space, on one dashboard (issues #255, #280).
+        var turnNumber = telemetry.NextTurnNumber;
 
         // Conversation-lifetime budget gate: if prior turns already exhausted the cumulative token
         // ceiling, decline this turn gracefully (no LLM dispatch, no cost) with an explanatory
@@ -295,7 +302,7 @@ public sealed class ConversationOrchestrator : IConversationOrchestrator
         if (budgetStatus.IsExhausted)
             return await BuildBudgetExhaustedOutcomeAsync(conversationId, callerId, agentName, turnNumber, ct);
 
-        var obsSessionId = _connectionTracker.Get(sessionKey)?.ObservabilitySessionId ?? Guid.Empty;
+        var obsSessionId = telemetry.SessionId;
 
         var command = new ExecuteAgentTurnCommand
         {
@@ -378,7 +385,7 @@ public sealed class ConversationOrchestrator : IConversationOrchestrator
         var userAgentTag = new KeyValuePair<string, object?>(AgentConventions.Name, agentName);
         UserActivityMetrics.Turns.Add(1, userTag, userAgentTag);
 
-        await UpdateSessionMetricsAsync(sessionKey, result);
+        await RecordTurnAsync(sessionKey, telemetry, result, ct);
 
         // Token deltas were already streamed to the caller during dispatch via the
         // ambient AgentTurnStreamSink. The final authoritative text rides TurnComplete.
@@ -399,69 +406,102 @@ public sealed class ConversationOrchestrator : IConversationOrchestrator
         };
     }
 
-    private async Task EnsureSessionTrackedAsync(
+    /// <summary>
+    /// Finds where this conversation has got to, and keeps the connection tracker in step.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The session id and the running totals come from <see cref="IConversationTelemetryRecorder"/>,
+    /// which reads them off the conversation. They used to be opened fresh here on every conversation
+    /// switch and accumulated on a per-<em>connection</em> object — so reconnecting restamped the
+    /// session's start time and then overwrote the conversation's rollup with whatever the new
+    /// connection had spent, which is nothing (issue #280).
+    /// </para>
+    /// <para>
+    /// The connection tracker stays, because it answers a different question: which conversation this
+    /// connection is on, for idle cleanup and the active-conversation view. It is no longer the source
+    /// of truth for what the conversation has spent.
+    /// </para>
+    /// </remarks>
+    private async Task<ConversationTelemetryState> EnsureSessionTrackedAsync(
         string sessionKey, string conversationId, string agentName, string callerId, CancellationToken ct)
     {
         var tracked = _connectionTracker.Get(sessionKey);
-        if (tracked?.ConversationId == conversationId)
-            return;
 
-        if (tracked is not null)
+        // A connection moving to a different conversation still ends the one it is leaving, exactly as
+        // before. It is tempting not to — the conversation is not over, this connection just stopped
+        // looking at it — but nothing else would ever end it: the disconnect and idle-cleanup paths both
+        // end whatever the tracker currently holds, which by then is the NEW conversation. Dropping this
+        // would leave the old session `running` forever, which is worse than ending it early.
+        //
+        // What it costs, stated because the recorder now adopts rather than restarts: coming back to
+        // that conversation writes further turns into a row already marked completed. That is the
+        // session lifetime being per-connection while the session row is per-conversation, which is a
+        // design gap this change surfaces rather than creates — tracked separately.
+        if (tracked is not null && tracked.ConversationId != conversationId)
         {
             SessionMetrics.ActiveSessions.Add(-1, new TagList { { AgentConventions.Name, tracked.AgentName } });
-            await _observabilityStore.EndSessionAsync(tracked.ObservabilitySessionId, "completed", cancellationToken: ct);
+            await _observabilityStore.EndSessionAsync(
+                tracked.ObservabilitySessionId, "completed", cancellationToken: ct);
         }
 
-        var newSessionId = await _observabilityStore.StartSessionAsync(
-            conversationId, agentName, model: null, ct);
+        var state = await _telemetryRecorder.BeginAsync(
+            conversationId, callerId, agentName, knownRecord: null, ct);
 
-        if (newSessionId == Guid.Empty)
-            _logger.LogWarning("StartSessionAsync returned empty GUID for conversation {ConversationId}", conversationId);
+        // Debug, not warning: an empty id is what a host running without an observability database gets
+        // on every turn, and that is a supported configuration. At warning level this filled the log of
+        // every such deployment with a line about a feature it had chosen not to switch on.
+        if (state.SessionId == Guid.Empty)
+            _logger.LogDebug("No observability session for conversation {ConversationId}", conversationId);
+
+        if (tracked?.ConversationId == conversationId)
+            return state;
 
         _connectionTracker.Track(sessionKey, new ActiveConversationInfo(
-            conversationId, agentName, callerId, DateTimeOffset.UtcNow, 0, newSessionId));
+            conversationId, agentName, callerId, DateTimeOffset.UtcNow,
+            state.Totals.TurnCount, state.SessionId,
+            state.Totals.InputTokens, state.Totals.OutputTokens,
+            state.Totals.CacheRead, state.Totals.CacheWrite,
+            state.Totals.CostUsd, state.Totals.ToolCallCount));
 
         SessionMetrics.ActiveSessions.Add(1, new TagList { { AgentConventions.Name, agentName } });
-        SessionMetrics.SessionsStarted.Add(1, new KeyValuePair<string, object?>(AgentConventions.Name, agentName));
-        UserActivityMetrics.SessionsStarted.Add(1,
-            new KeyValuePair<string, object?>(UserConventions.UserId, callerId));
+        return state;
     }
 
-    private async Task UpdateSessionMetricsAsync(string sessionKey, AgentTurnResult result)
+    /// <summary>
+    /// Records the turn against the conversation, and mirrors the new totals onto the connection view.
+    /// </summary>
+    /// <remarks>
+    /// The write itself belongs to the shared recorder — including the cache hit rate, which this path
+    /// used to compute with a different denominator than the other two transports, so the same column
+    /// meant different things depending on how the conversation was reached.
+    /// </remarks>
+    private async Task<ConversationTelemetryState> RecordTurnAsync(
+        string sessionKey, ConversationTelemetryState state, AgentTurnResult result, CancellationToken ct)
     {
-        var convInfo = _connectionTracker.Get(sessionKey);
-        if (convInfo is null) return;
+        var updated = await _telemetryRecorder.RecordTurnAsync(
+            state,
+            new ConversationTurnTelemetry(
+                result.InputTokens, result.OutputTokens, result.CacheRead, result.CacheWrite,
+                result.CostUsd, result.ToolsInvoked.Count, result.Model),
+            ct);
 
-        var updated = convInfo with
+        if (_connectionTracker.Get(sessionKey) is { } convInfo)
         {
-            TurnCount = convInfo.TurnCount + 1,
-            LastActivityAt = DateTimeOffset.UtcNow,
-            ToolCallCount = convInfo.ToolCallCount + result.ToolsInvoked.Count,
-            TotalInputTokens = convInfo.TotalInputTokens + result.InputTokens,
-            TotalOutputTokens = convInfo.TotalOutputTokens + result.OutputTokens,
-            TotalCacheRead = convInfo.TotalCacheRead + result.CacheRead,
-            TotalCacheWrite = convInfo.TotalCacheWrite + result.CacheWrite,
-            TotalCostUsd = convInfo.TotalCostUsd + result.CostUsd,
-        };
-        _connectionTracker.Track(sessionKey, updated);
+            _connectionTracker.Track(sessionKey, convInfo with
+            {
+                LastActivityAt = DateTimeOffset.UtcNow,
+                TurnCount = updated.Totals.TurnCount,
+                ToolCallCount = updated.Totals.ToolCallCount,
+                TotalInputTokens = updated.Totals.InputTokens,
+                TotalOutputTokens = updated.Totals.OutputTokens,
+                TotalCacheRead = updated.Totals.CacheRead,
+                TotalCacheWrite = updated.Totals.CacheWrite,
+                TotalCostUsd = updated.Totals.CostUsd,
+            });
+        }
 
-        try
-        {
-            await _observabilityStore.UpdateSessionMetricsAsync(
-                updated.ObservabilitySessionId,
-                updated.TurnCount, updated.ToolCallCount, subagentCount: 0,
-                updated.TotalInputTokens, updated.TotalOutputTokens,
-                updated.TotalCacheRead, updated.TotalCacheWrite,
-                updated.TotalCostUsd,
-                updated.TotalInputTokens > 0
-                    ? (decimal)updated.TotalCacheRead / updated.TotalInputTokens
-                    : 0m,
-                result.Model);
-        }
-        catch (Exception ex) when (ex is not OperationCanceledException)
-        {
-            _logger.LogWarning(ex, "Failed to persist session metrics for session {SessionId}", updated.ObservabilitySessionId);
-        }
+        return updated;
     }
 
     private async Task<TurnOutcome> HandleTurnErrorAsync(

--- a/src/Content/Tests/Application.AI.Common.Tests/DependencyInjectionTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/DependencyInjectionTests.cs
@@ -11,6 +11,7 @@ using Application.AI.Common.Services.Agent;
 using Application.AI.Common.Services.Context;
 using Application.AI.Common.Services.Governance;
 using Application.AI.Common.Services.Skills;
+using Application.AI.Common.Services.AI;
 using Application.AI.Common.Services.Tools;
 using Application.Common.Interfaces.Telemetry;
 using FluentAssertions;
@@ -30,6 +31,29 @@ public class DependencyInjectionTests
         var services = new ServiceCollection();
         services.AddApplicationAIDependencies();
         return services;
+    }
+
+    /// <summary>
+    /// The shared telemetry recorder must be registered here, in the assembly that owns it.
+    /// </summary>
+    /// <remarks>
+    /// Its own unit tests construct it directly, so they stay green with this registration deleted —
+    /// and three transports take it as a constructor dependency, so a host missing it fails to build its
+    /// conversation handler at all. Same trap as issue #279: a registration is untested unless something
+    /// resolves it from the real composition method.
+    /// </remarks>
+    [Fact]
+    public void AddApplicationAIDependencies_RegistersTheSharedTelemetryRecorder()
+    {
+        var services = CreateServicesWithAIDependencies();
+
+        var descriptor = services.FirstOrDefault(
+            d => d.ServiceType == typeof(IConversationTelemetryRecorder));
+
+        descriptor.Should().NotBeNull(
+            "three transports take this as a constructor dependency; unregistered, none of them can be built");
+        descriptor!.Lifetime.Should().Be(ServiceLifetime.Singleton);
+        descriptor.ImplementationType.Should().Be<ConversationTelemetryRecorder>();
     }
 
     [Fact]

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/AI/ConversationTelemetryRecorderTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/AI/ConversationTelemetryRecorderTests.cs
@@ -1,0 +1,223 @@
+using Application.AI.Common.Interfaces;
+using Application.AI.Common.Interfaces.AI;
+using Application.AI.Common.Models.Conversations;
+using Application.AI.Common.Services.AI;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Application.AI.Common.Tests.Services.AI;
+
+/// <summary>
+/// The one policy three transports used to carry a copy of (issue #280), tested directly rather than
+/// only through them.
+/// </summary>
+/// <remarks>
+/// Each transport's own tests prove it delegates here. What they cannot show — because each exercises
+/// one shape of caller — is that the policy itself is right for every shape: adopting instead of
+/// re-opening, refusing a blank identity, writing nothing durable for a run that has no record, and
+/// never failing a turn to report an accounting problem.
+/// </remarks>
+public sealed class ConversationTelemetryRecorderTests
+{
+    private const string ConversationId = "conv-280";
+    private const string Owner = "owner-1";
+
+    private static readonly Guid ExistingSession = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    private static readonly Guid NewSession = Guid.Parse("22222222-2222-2222-2222-222222222222");
+
+    private readonly Mock<IObservabilityStore> _observability = new();
+    private readonly Mock<IConversationStore> _conversations = new();
+
+    public ConversationTelemetryRecorderTests()
+    {
+        _observability
+            .Setup(o => o.StartSessionAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(NewSession);
+    }
+
+    private ConversationTelemetryRecorder Sut() =>
+        new(_observability.Object, _conversations.Object, NullLogger<ConversationTelemetryRecorder>.Instance);
+
+    private static ConversationRecord Record(Guid? session, TelemetryAccumulator? totals = null) =>
+        new(ConversationId, "agent", Owner, DateTimeOffset.UnixEpoch, DateTimeOffset.UnixEpoch, [])
+        {
+            ObservabilitySessionId = session,
+            Telemetry = totals,
+        };
+
+    // ── Adopt or open ────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task BeginAsync_ConversationAlreadyHasASession_AdoptsItWithoutOpeningAnother()
+    {
+        var totals = new TelemetryAccumulator(5, 2, 100, 50, 10, 5, 0.5m);
+        _conversations
+            .Setup(s => s.GetAsync(ConversationId, Owner, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Record(ExistingSession, totals));
+
+        var state = await Sut().BeginAsync(ConversationId, Owner, "agent");
+
+        state.SessionId.Should().Be(ExistingSession);
+        state.Totals.Should().Be(totals);
+        state.SessionOpened.Should().BeFalse();
+
+        _observability.Verify(
+            o => o.StartSessionAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()),
+            Times.Never,
+            "a conversation has one session for its whole life — opening a second restamps the first "
+            + "one's start time and every duration derived from it");
+    }
+
+    [Fact]
+    public async Task BeginAsync_NoSessionYet_OpensOneAndRecordsItBeforeAnyTurn()
+    {
+        _conversations
+            .Setup(s => s.GetAsync(ConversationId, Owner, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Record(session: null));
+
+        var state = await Sut().BeginAsync(ConversationId, Owner, "agent");
+
+        state.SessionId.Should().Be(NewSession);
+        state.SessionOpened.Should().BeTrue();
+
+        // Written before the first turn, so a crash in between does not leave the conversation opening
+        // a second session next time.
+        _conversations.Verify(
+            s => s.UpdateTelemetryAsync(
+                ConversationId, Owner, NewSession, TelemetryAccumulator.Zero, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task BeginAsync_TurnNumberContinuesTheConversation()
+    {
+        _conversations
+            .Setup(s => s.GetAsync(ConversationId, Owner, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Record(ExistingSession, TelemetryAccumulator.Zero with { TurnCount = 6 }));
+
+        var state = await Sut().BeginAsync(ConversationId, Owner, "agent");
+
+        state.NextTurnNumber.Should().Be(7);
+    }
+
+    // ── Identity ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task BeginAsync_BlankCaller_IsRefusedRatherThanTreatedAsAbsent()
+    {
+        // A null caller is a run with no transcript. A blank one is a bug upstream, and this codebase
+        // has read an empty identity as "everyone" before — so the two must not collapse.
+        var begin = async () => await Sut().BeginAsync(ConversationId, "   ", "agent");
+
+        await begin.Should().ThrowAsync<ArgumentException>();
+    }
+
+    [Fact]
+    public async Task BeginAsync_NoCaller_TouchesNoConversationRecordAtAll()
+    {
+        var strict = new Mock<IConversationStore>(MockBehavior.Strict);
+        var sut = new ConversationTelemetryRecorder(
+            _observability.Object, strict.Object, NullLogger<ConversationTelemetryRecorder>.Instance);
+
+        var state = await sut.BeginAsync(ConversationId, callerId: null, "agent");
+
+        // Strict: any call at all would throw. A run with no owner has no record to read or write, and
+        // guessing one would be the identity-shaped mistake this guards against.
+        state.SessionId.Should().Be(NewSession);
+        state.CallerId.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task BeginAsync_KnownRecordForADifferentConversation_IsRefused()
+    {
+        var wrong = new ConversationRecord(
+            "someone-elses-conversation", "agent", Owner, DateTimeOffset.UnixEpoch, DateTimeOffset.UnixEpoch, []);
+
+        var begin = async () => await Sut().BeginAsync(ConversationId, Owner, "agent", wrong);
+
+        await begin.Should().ThrowAsync<ArgumentException>(
+            "adopting a session off the wrong record would write this conversation's turns into another "
+            + "conversation's row");
+    }
+
+    [Fact]
+    public async Task BeginAsync_KnownRecordOwnedBySomeoneElse_IsRefused()
+    {
+        var wrong = new ConversationRecord(
+            ConversationId, "agent", "a-different-owner", DateTimeOffset.UnixEpoch, DateTimeOffset.UnixEpoch, []);
+
+        var begin = async () => await Sut().BeginAsync(ConversationId, Owner, "agent", wrong);
+
+        await begin.Should().ThrowAsync<ArgumentException>();
+    }
+
+    // ── Recording ────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task RecordTurnAsync_WritesTheConversationsCumulativeTotals_NotTheTurnsOwn()
+    {
+        var state = new ConversationTelemetryState(
+            ConversationId, Owner, ExistingSession,
+            new TelemetryAccumulator(3, 1, 1_000, 500, 200, 100, 2m));
+
+        var updated = await Sut().RecordTurnAsync(
+            state, new ConversationTurnTelemetry(10, 20, 5, 5, 0.25m, 2, "gpt-4o"));
+
+        updated.Totals.TurnCount.Should().Be(4);
+        updated.Totals.InputTokens.Should().Be(1_010);
+
+        _observability.Verify(
+            o => o.UpdateSessionMetricsAsync(
+                ExistingSession, 4, 3, 0, 1_010, 520, 205, 105, 2.25m,
+                It.IsAny<decimal>(), "gpt-4o", It.IsAny<CancellationToken>()),
+            Times.Once,
+            "the row is keyed one-per-conversation and written with SET semantics, so a run's own share "
+            + "would replace the conversation's history with it");
+    }
+
+    [Fact]
+    public async Task RecordTurnAsync_NoCaller_WritesTheRollupButNoConversationRecord()
+    {
+        var strict = new Mock<IConversationStore>(MockBehavior.Strict);
+        var sut = new ConversationTelemetryRecorder(
+            _observability.Object, strict.Object, NullLogger<ConversationTelemetryRecorder>.Instance);
+
+        var state = new ConversationTelemetryState(
+            ConversationId, CallerId: null, NewSession, TelemetryAccumulator.Zero);
+
+        await sut.RecordTurnAsync(state, new ConversationTurnTelemetry(1, 1, 0, 0, 0m, 0));
+
+        _observability.Verify(
+            o => o.UpdateSessionMetricsAsync(
+                NewSession, 1, 0, 0, 1, 1, 0, 0, 0m,
+                It.IsAny<decimal>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task RecordTurnAsync_StoreThrows_DoesNotFailTheTurn()
+    {
+        // The contract the interface states, and the one that matters: the turn has already happened and
+        // its answer is already in the transcript, so discarding real work to report an accounting
+        // problem is the wrong trade.
+        _observability
+            .Setup(o => o.UpdateSessionMetricsAsync(
+                It.IsAny<Guid>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(),
+                It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<decimal>(),
+                It.IsAny<decimal>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("observability database is down"));
+
+        var state = new ConversationTelemetryState(
+            ConversationId, Owner, ExistingSession, TelemetryAccumulator.Zero);
+
+        var updated = await Sut().RecordTurnAsync(state, new ConversationTurnTelemetry(7, 3, 0, 0, 0m, 0));
+
+        updated.Totals.TurnCount.Should().Be(1,
+            "the returned state still has to carry the turn, or the next one resumes from the wrong "
+            + "place and the failure compounds instead of being caught up by the next write");
+        updated.Totals.InputTokens.Should().Be(7);
+    }
+}

--- a/src/Content/Tests/Application.Core.Tests/CQRS/AgentPipelineIntegrationTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/CQRS/AgentPipelineIntegrationTests.cs
@@ -8,6 +8,8 @@ using Application.AI.Common.Services.Agent;
 using Application.Core.CQRS.Agents.ExecuteAgentTurn;
 using Application.Core.CQRS.Agents.RunConversation;
 using Application.Core.Tests.Helpers;
+using Application.AI.Common.Interfaces.AI;
+using Application.AI.Common.Services.AI;
 using Domain.AI.Skills;
 using FluentAssertions;
 using MediatR;
@@ -90,6 +92,11 @@ public class AgentPipelineIntegrationTests
 
         // Observability store — no-op mock for integration tests
         services.AddSingleton(new Mock<IObservabilityStore>().Object);
+
+        // The real shared telemetry recorder, resolved from the container like everything else. A
+        // self-contained run reads and writes no conversation record, so the strict store registered
+        // below stays untouched through it — which is the same guard, one layer along.
+        services.AddSingleton<IConversationTelemetryRecorder, ConversationTelemetryRecorder>();
 
         // Durable-conversation collaborators. Strict and unstubbed on purpose: every conversation this
         // pipeline runs is self-contained (no ConversationOwnerId), so a call to either would mean the

--- a/src/Content/Tests/Application.Core.Tests/CQRS/RunConversationCommandHandlerSolutionReviewFixTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/CQRS/RunConversationCommandHandlerSolutionReviewFixTests.cs
@@ -2,6 +2,7 @@ using Application.AI.Common.Interfaces;
 using Application.AI.Common.Interfaces.AI;
 using Application.Core.CQRS.Agents.ExecuteAgentTurn;
 using Application.Core.CQRS.Agents.RunConversation;
+using Application.AI.Common.Services.AI;
 using Domain.AI.Budget;
 using Domain.Common.Config.AI.Conversations;
 using FluentAssertions;
@@ -44,12 +45,18 @@ public class RunConversationCommandHandlerSolutionReviewFixTests
 
         // Strict and unstubbed: these tests run self-contained conversations, so any call to the
         // transcript store or the turn lease means the handler took the durable path by mistake.
+        var strictStore = new Mock<IConversationStore>(MockBehavior.Strict).Object;
+
         _handler = new RunConversationCommandHandler(
             _mediator.Object,
             _agentCache.Object,
             budget.Object,
             _observabilityStore.Object,
-            new Mock<IConversationStore>(MockBehavior.Strict).Object,
+            // The strict store is shared with the recorder deliberately: a self-contained run must not
+            // touch it, and the recorder is now the thing that would.
+            new ConversationTelemetryRecorder(
+                _observabilityStore.Object, strictStore, NullLogger<ConversationTelemetryRecorder>.Instance),
+            strictStore,
             new Mock<IConversationTurnLease>(MockBehavior.Strict).Object,
             Options.Create(new ConversationsConfig()),
             NullLogger<RunConversationCommandHandler>.Instance);

--- a/src/Content/Tests/Application.Core.Tests/CQRS/RunConversationCommandHandlerTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/CQRS/RunConversationCommandHandlerTests.cs
@@ -2,6 +2,7 @@ using Application.AI.Common.Interfaces;
 using Application.AI.Common.Interfaces.AI;
 using Application.Core.CQRS.Agents.ExecuteAgentTurn;
 using Application.Core.CQRS.Agents.RunConversation;
+using Application.AI.Common.Services.AI;
 using Domain.AI.Budget;
 using Domain.Common.Config.AI.Conversations;
 using FluentAssertions;
@@ -30,12 +31,19 @@ public class RunConversationCommandHandlerTests
         // Store and lease are strict about being unused here: every test in this class runs a
         // self-contained conversation (no ConversationOwnerId), and touching either would mean the
         // handler had silently taken the durable path. A throwing double says so immediately.
+        var observability = new Mock<IObservabilityStore>().Object;
+        var strictStore = new Mock<IConversationStore>(MockBehavior.Strict).Object;
+
         _handler = new RunConversationCommandHandler(
             _mediator.Object,
             new Mock<IAgentConversationCache>().Object,
             _budget.Object,
-            new Mock<IObservabilityStore>().Object,
-            new Mock<IConversationStore>(MockBehavior.Strict).Object,
+            observability,
+            // The strict store is shared with the recorder deliberately: a self-contained run must not
+            // touch it, and the recorder is now the thing that would.
+            new ConversationTelemetryRecorder(
+                observability, strictStore, NullLogger<ConversationTelemetryRecorder>.Instance),
+            strictStore,
             new Mock<IConversationTurnLease>(MockBehavior.Strict).Object,
             Options.Create(new ConversationsConfig()),
             NullLogger<RunConversationCommandHandler>.Instance);

--- a/src/Content/Tests/Application.Core.Tests/CQRS/RunConversationDurableTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/CQRS/RunConversationDurableTests.cs
@@ -4,6 +4,7 @@ using Application.AI.Common.Models.Conversations;
 using Application.Common.Exceptions.ExceptionTypes;
 using Application.Core.CQRS.Agents.ExecuteAgentTurn;
 using Application.Core.CQRS.Agents.RunConversation;
+using Application.AI.Common.Services.AI;
 using Domain.AI.Budget;
 using Domain.Common.Config.AI.Conversations;
 using FluentAssertions;
@@ -71,6 +72,11 @@ public sealed class RunConversationDurableTests
             new Mock<IAgentConversationCache>().Object,
             _budget.Object,
             _observability.Object,
+            // The real recorder over this fixture's own stores. A mocked recorder would turn every
+            // assertion below — adopt-or-open, cumulative totals, turn numbering — into an assertion
+            // about an interface rather than about what reaches the observability row.
+            new ConversationTelemetryRecorder(
+                _observability.Object, _store, NullLogger<ConversationTelemetryRecorder>.Instance),
             _store,
             _lease,
             Options.Create(new ConversationsConfig { MaxHistoryMessages = maxHistoryMessages }),

--- a/src/Content/Tests/Infrastructure.AI.Tests/Conversations/DurableConversationContinuityTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Conversations/DurableConversationContinuityTests.cs
@@ -3,6 +3,7 @@ using Application.AI.Common.Interfaces.AI;
 using Application.Common.Exceptions.ExceptionTypes;
 using Application.Core.CQRS.Agents.ExecuteAgentTurn;
 using Application.Core.CQRS.Agents.RunConversation;
+using Application.AI.Common.Services.AI;
 using Domain.AI.Budget;
 using Domain.Common.Config.AI.Conversations;
 using FluentAssertions;
@@ -264,11 +265,17 @@ public sealed class DurableConversationContinuityTests : IDisposable
             .Setup(b => b.GetStatusAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(ConversationBudgetStatus.Disabled);
 
+        var observability = new Mock<IObservabilityStore>().Object;
+
         return new RunConversationCommandHandler(
             mediator.Object,
             new Mock<IAgentConversationCache>().Object,
             budget.Object,
-            new Mock<IObservabilityStore>().Object,
+            observability,
+            // The real recorder over the real store this fixture uses, so continuity across runs is
+            // exercised end to end rather than stubbed.
+            new ConversationTelemetryRecorder(
+                observability, _store, NullLogger<ConversationTelemetryRecorder>.Instance),
             _store,
             _lease,
             Options.Create(new ConversationsConfig { MaxHistoryMessages = maxHistoryMessages }),

--- a/src/Content/Tests/Presentation.AgentHub.Tests/AgUi/AgUiRunHandlerTests.cs
+++ b/src/Content/Tests/Presentation.AgentHub.Tests/AgUi/AgUiRunHandlerTests.cs
@@ -3,6 +3,7 @@ using System.Text;
 using System.Text.Json;
 using Application.AI.Common.Interfaces;
 using Application.AI.Common.Interfaces.AI;
+using Application.AI.Common.Services.AI;
 using Application.Common.Exceptions.ExceptionTypes;
 using Application.Core.CQRS.Agents.ExecuteAgentTurn;
 using Domain.AI.Budget;
@@ -385,6 +386,11 @@ public sealed class AgUiRunHandlerTests
             mediator.Object,
             store.Object,
             observability.Object,
+            // The real recorder over the mocked stores, for the same reason as the lease below: a mocked
+            // recorder would make these tests assertions about an interface rather than about what
+            // actually reaches the observability row, which is the whole subject.
+            new ConversationTelemetryRecorder(
+                observability.Object, store.Object, NullLogger<ConversationTelemetryRecorder>.Instance),
             // The real in-process lease by default, not a mock: a mocked one returns a null handle,
             // and every test below would then run a turn that never leased anything.
             turnLease ?? new InProcessConversationTurnLease(),

--- a/src/Content/Tests/Presentation.AgentHub.Tests/Services/ConversationOrchestratorTests.cs
+++ b/src/Content/Tests/Presentation.AgentHub.Tests/Services/ConversationOrchestratorTests.cs
@@ -1,6 +1,7 @@
 using Application.AI.Common.Interfaces;
 using Application.AI.Common.Interfaces.AI;
 using Application.AI.Common.Services;
+using Application.AI.Common.Services.AI;
 using Application.Common.Exceptions.ExceptionTypes;
 using Application.Core.CQRS.Agents.ExecuteAgentTurn;
 using Domain.AI.Budget;
@@ -57,6 +58,11 @@ public class ConversationOrchestratorTests
             _turnLease,
             _healthTracker.Object,
             _obsStore.Object,
+            // The real recorder over the mocked stores, not a mocked recorder. A mock would make every
+            // assertion below about the recorder's interface rather than about what actually reaches the
+            // observability row — and the defect this replaced was entirely about what reached that row.
+            new ConversationTelemetryRecorder(
+                _obsStore.Object, _store.Object, NullLogger<ConversationTelemetryRecorder>.Instance),
             _connectionTracker.Object,
             _budget.Object,
             Options.Create(_config),
@@ -624,6 +630,102 @@ public class ConversationOrchestratorTests
 
         _obsStore.Verify(s => s.StartSessionAsync("c1", "agent", null, It.IsAny<CancellationToken>()), Times.Once);
         _connectionTracker.Verify(t => t.Track("conn1", It.Is<ActiveConversationInfo>(i => i.ConversationId == "c1")), Times.AtLeastOnce);
+    }
+
+    /// <summary>
+    /// A conversation that already has a session and totals must be continued, not restarted.
+    /// </summary>
+    /// <remarks>
+    /// The defect this replaces (issue #280): the hub opened a session on every conversation switch and
+    /// accumulated totals on a per-<em>connection</em> object that starts at zero. Because the
+    /// observability row is keyed one-per-conversation and written with SET semantics, reconnecting
+    /// restamped the session's start time and then overwrote the conversation's whole rollup with what
+    /// the new connection had spent. Nothing errored; the dashboard just showed a long conversation as
+    /// a short one.
+    /// </remarks>
+    [Fact]
+    public async Task SendMessage_ReconnectingToAConversationWithHistory_ContinuesItsTotals()
+    {
+        var existingSession = Guid.NewGuid();
+        var record = new ConversationRecord("c1", "agent", "user1", DateTimeOffset.UtcNow, DateTimeOffset.UtcNow, [])
+        {
+            ObservabilitySessionId = existingSession,
+            Telemetry = new TelemetryAccumulator(
+                TurnCount: 7, ToolCallCount: 3, InputTokens: 1_000, OutputTokens: 500,
+                CacheRead: 200, CacheWrite: 100, CostUsd: 1.25m),
+        };
+        _store.Setup(s => s.GetAsync("c1", "user1", It.IsAny<CancellationToken>())).ReturnsAsync(record);
+        _store.Setup(s => s.GetHistoryForDispatch("c1", "user1", 20, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<ConversationMessage>());
+
+        // A brand-new connection, exactly as after a reconnect: it knows nothing about the conversation.
+        _connectionTracker.Setup(t => t.Get("conn-fresh")).Returns((ActiveConversationInfo?)null);
+
+        _mediator.Setup(m => m.Send(It.IsAny<ExecuteAgentTurnCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AgentTurnResult
+            {
+                Success = true, Response = "Hi", UpdatedHistory = [],
+                InputTokens = 10, OutputTokens = 20, CostUsd = 0.5m,
+            });
+
+        var orchestrator = CreateOrchestrator();
+        await orchestrator.SendMessageAsync(
+            "conn-fresh", "c1", Guid.NewGuid(), "Hello", "user1", null, CancellationToken.None);
+
+        _obsStore.Verify(
+            s => s.StartSessionAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()),
+            Times.Never,
+            "the conversation already has a session; opening a second restamps its start time and every "
+            + "duration derived from it");
+
+        _obsStore.Verify(
+            s => s.UpdateSessionMetricsAsync(
+                existingSession,
+                8,              // turn count: continued from 7, not restarted at 1
+                3,              // tool calls carried forward
+                0,
+                1_010,          // input tokens: 1,000 + this turn's 10
+                520,
+                200,
+                100,
+                1.75m,
+                It.IsAny<decimal>(),
+                It.IsAny<string?>(),
+                It.IsAny<CancellationToken>()),
+            Times.Once,
+            "the row is written with SET semantics, so anything but the conversation's cumulative total "
+            + "silently replaces its history with one connection's share of it");
+    }
+
+    /// <summary>
+    /// The turn number a reconnected client sees continues the conversation's sequence.
+    /// </summary>
+    /// <remarks>
+    /// It used to come from the message count, which advances by two per turn — so the same conversation
+    /// produced one sequence over the hub and a different one over the bundle path, in one key space.
+    /// </remarks>
+    [Fact]
+    public async Task SendMessage_ConversationWithHistory_NumbersTheTurnFromTheConversationsTurnCount()
+    {
+        var record = new ConversationRecord("c1", "agent", "user1", DateTimeOffset.UtcNow, DateTimeOffset.UtcNow, [])
+        {
+            ObservabilitySessionId = Guid.NewGuid(),
+            Telemetry = TelemetryAccumulator.Zero with { TurnCount = 4 },
+        };
+        _store.Setup(s => s.GetAsync("c1", "user1", It.IsAny<CancellationToken>())).ReturnsAsync(record);
+        _store.Setup(s => s.GetHistoryForDispatch("c1", "user1", 20, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<ConversationMessage>());
+        _connectionTracker.Setup(t => t.Get("conn1")).Returns((ActiveConversationInfo?)null);
+
+        ExecuteAgentTurnCommand? dispatched = null;
+        _mediator.Setup(m => m.Send(It.IsAny<ExecuteAgentTurnCommand>(), It.IsAny<CancellationToken>()))
+            .Callback<object, CancellationToken>((c, _) => dispatched = (ExecuteAgentTurnCommand)c)
+            .ReturnsAsync(new AgentTurnResult { Success = true, Response = "Hi", UpdatedHistory = [] });
+
+        var orchestrator = CreateOrchestrator();
+        await orchestrator.SendMessageAsync("conn1", "c1", Guid.NewGuid(), "Hello", "user1", null, CancellationToken.None);
+
+        dispatched!.TurnNumber.Should().Be(5);
     }
 
     // ── Streaming ────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #280.

The SignalR path kept a conversation's running totals on a per-**connection** object that starts at zero, and wrote them into a row keyed one-per-conversation with SET semantics. Reconnecting therefore replaced the conversation's whole rollup with what the new connection had spent — which is nothing. Nothing errored. A long conversation simply showed as a short one.

That is the same defect #255 fixed on the bundle path, in the third writer. And the reason there was a third writer is that all three implemented one policy independently, having already drifted four ways:

| | bundle runs | AG-UI | SignalR |
|---|---|---|---|
| adopt-or-open the session | yes | yes | **no — always opened** |
| totals source | conversation record | conversation record | **per-connection tracker** |
| cache hit rate | accumulator | accumulator | **hand-rolled, different denominator** |
| user-activity counter | **no** | yes | yes |

## The shape

`IConversationTelemetryRecorder` is that policy, once. `BeginAsync` adopts the conversation's session or opens one; `RecordTurnAsync` adds a turn and writes the cumulative total to both stores from a single value, so they cannot disagree. All three transports take it, and the twelve-argument store call now exists in one place instead of three.

**It deliberately does not own ending the session.** That rule genuinely differs per transport — a bundle run ends what it opened, a stateless HTTP request leaves the conversation's session open for the next one, the hub ends it when the connection drops — and folding three behaviours behind a flag is three implementations with extra steps.

## Two behaviour changes, said out loud

- **Bundle runs that carry an owner now count toward user-activity sessions.** They never did, for no reason anyone had recorded. The condition is now "a session was opened and there is a user to attribute it to" rather than an accident of which file the code lived in. Expect a step change on that series.
- **SignalR turns are numbered from the conversation's turn count, not its message count.** A message count advances by two per turn, so the same conversation produced 1, 3, 5 over the hub against 1, 2, 3 over the bundle path — two writers interleaving into one key space.

## A regression I introduced, and the review that caught it

I removed the `EndSessionAsync` that fires when a connection switches conversations, reasoning that a conversation is not over just because a connection looked away. Both reviewers independently found what that missed: **nothing else would ever end it.** The disconnect and idle-cleanup paths both end whatever the connection tracker currently holds, which by then is the *new* conversation, so the old one's session would have stayed `running` forever.

Restored — and the reason it is not obviously right is now written next to it. Because the recorder adopts rather than restarts, returning to that conversation writes further turns into a row already marked completed. That is session lifetime being per-connection while the session row is per-conversation, a design gap this change **surfaces rather than creates**. Filed separately rather than smuggled in here.

## Also from review

- **`knownRecord` was trusted unverified.** The optional parameter that lets a caller pass a record it has already read — added because the AG-UI path reads under a lease and a third read wedged into that sequence broke it — accepted any record. One for a different conversation, or read under a different identity, would have adopted the wrong session and then persisted under the caller supplied here. Both now refused, with tests. This codebase has paid for identity-shaped assumptions before.
- **One question, answered twice.** The AG-UI caller re-derived "was a session just opened" from the record the recorder had already consumed. The recorder knows; it now returns `SessionOpened`.
- **A warning on every turn** for hosts running without an observability database — a supported configuration. Downgraded to Debug.

## Verification

Full solution green, all 21 assemblies, zero failures. Ten new unit tests cover the recorder directly — adopt-vs-open, blank-caller refusal, the no-caller path leaving a **strict** conversation store untouched, both identity refusals, cumulative writes, and the documented never-throw contract — plus a registration guard, because a type three transports take as a constructor dependency is exactly the one that must be proved registered (#279's lesson).

Mutation-tested:

| mutation | result |
|---|---|
| always open a session instead of adopting | RED — the adopt test |
| delete the DI registration | RED — the registration guard |
| number SignalR turns from the message count again | RED — the new turn-numbering test |


🤖 Generated with [Claude Code](https://claude.com/claude-code)
