### PR TITLE
fix: declare the planner's model instead of scanning for it (#249 item 4)

### DIFF
--- a/src/Content/Infrastructure/Infrastructure.AI/Persistence/ConversationDbContext.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Persistence/ConversationDbContext.cs
@@ -10,13 +10,15 @@ namespace Infrastructure.AI.Persistence;
 /// <remarks>
 /// <para>
 /// The model is configured inline here rather than through <c>IEntityTypeConfiguration</c> classes,
-/// matching <c>PromptUsageDbContext</c> and <see cref="GovernanceStateDbContext"/>. This is
-/// load-bearing, not stylistic:
-/// <see cref="PlannerDbContext"/> builds its model with
-/// <c>ApplyConfigurationsFromAssembly(typeof(PlannerDbContext).Assembly)</c>, which picks up
-/// <em>every</em> configuration class in Infrastructure.AI. A conversation configuration class would
-/// therefore be applied to the planner's model too, and <c>EnsureCreated</c> would quietly build
-/// conversation tables inside <c>planner.db</c>.
+/// matching <c>PromptUsageDbContext</c> and <see cref="GovernanceStateDbContext"/>.
+/// </para>
+/// <para>
+/// This used to be load-bearing: <see cref="PlannerDbContext"/> built its model by scanning the whole
+/// Infrastructure.AI assembly, so a conversation configuration class would have been applied to the
+/// planner's model too and <c>EnsureCreated</c> would have quietly built conversation tables inside
+/// <c>planner.db</c>. The planner now declares its five configurations explicitly, so the hazard is
+/// gone and configuration classes are safe here. Inline remains the convention across these contexts;
+/// it is now a style choice rather than a constraint.
 /// </para>
 /// </remarks>
 public sealed class ConversationDbContext : DbContext

--- a/src/Content/Infrastructure/Infrastructure.AI/Persistence/Entities/ChangeProposalEntity.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Persistence/Entities/ChangeProposalEntity.cs
@@ -9,10 +9,12 @@ namespace Infrastructure.AI.Persistence.Entities;
 /// </summary>
 /// <remarks>
 /// <para>
-/// Configured inline in <see cref="Infrastructure.AI.Persistence.GovernanceStateDbContext"/> —
-/// deliberately not via an <c>IEntityTypeConfiguration</c>, which
-/// <see cref="Infrastructure.AI.Persistence.PlannerDbContext"/> would pick up through its
-/// assembly scan. No <c>Version</c> column: <c>SaveAsync</c> is contractually last-write-wins
+/// Configured inline in <see cref="Infrastructure.AI.Persistence.GovernanceStateDbContext"/>,
+/// matching the other contexts here. This used to be forced:
+/// <see cref="Infrastructure.AI.Persistence.PlannerDbContext"/> scanned the whole assembly and
+/// would have applied an <c>IEntityTypeConfiguration</c> for this entity to its own model. The
+/// planner now declares its five configurations explicitly, so inline is a convention rather than
+/// a constraint. No <c>Version</c> column: <c>SaveAsync</c> is contractually last-write-wins
 /// on the proposal id, so the planner's <c>SqliteVersionInterceptor</c> scheme is not applied.
 /// </para>
 /// <para>

--- a/src/Content/Infrastructure/Infrastructure.AI/Persistence/Entities/EscalationStateEntity.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Persistence/Entities/EscalationStateEntity.cs
@@ -8,10 +8,12 @@ namespace Infrastructure.AI.Persistence.Entities;
 /// </summary>
 /// <remarks>
 /// <para>
-/// Configured inline in <see cref="Infrastructure.AI.Persistence.GovernanceStateDbContext"/> —
-/// deliberately not via an <c>IEntityTypeConfiguration</c>, which
-/// <see cref="Infrastructure.AI.Persistence.PlannerDbContext"/> would pick up through its
-/// assembly scan. No <c>Version</c> column: rows are single-writer per escalation (the
+/// Configured inline in <see cref="Infrastructure.AI.Persistence.GovernanceStateDbContext"/>,
+/// matching the other contexts here. This used to be forced:
+/// <see cref="Infrastructure.AI.Persistence.PlannerDbContext"/> scanned the whole assembly and
+/// would have applied an <c>IEntityTypeConfiguration</c> for this entity to its own model. The
+/// planner now declares its five configurations explicitly, so inline is a convention rather than
+/// a constraint. No <c>Version</c> column: rows are single-writer per escalation (the
 /// singleton escalation service serializes writes per record), so the planner's
 /// <c>SqliteVersionInterceptor</c> concurrency scheme is not applied to this context.
 /// </para>

--- a/src/Content/Infrastructure/Infrastructure.AI/Persistence/PlannerDbContext.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Persistence/PlannerDbContext.cs
@@ -1,3 +1,4 @@
+using Infrastructure.AI.Persistence.Configurations;
 using Infrastructure.AI.Persistence.Entities;
 using Microsoft.EntityFrameworkCore;
 
@@ -29,8 +30,23 @@ public sealed class PlannerDbContext : DbContext
     {
     }
 
+    /// <summary>
+    /// Declares the planner's model explicitly, one configuration at a time.
+    /// </summary>
+    /// <remarks>
+    /// This deliberately does <b>not</b> scan the assembly. Infrastructure.AI hosts several
+    /// unrelated databases, and a scan pulls in every <see cref="IEntityTypeConfiguration{TEntity}"/>
+    /// it finds — so any configuration added anywhere in this assembly, for any other subsystem,
+    /// would silently acquire a table in the planner's database. The other contexts here already
+    /// route around the scan by configuring themselves inline; the planner declares its five.
+    /// <c>PlannerDbContext_Model_ContainsOnlyPlannerEntities</c> fails if that stops being true.
+    /// </remarks>
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        modelBuilder.ApplyConfigurationsFromAssembly(typeof(PlannerDbContext).Assembly);
+        modelBuilder.ApplyConfiguration(new PlanGraphEntityConfiguration());
+        modelBuilder.ApplyConfiguration(new PlanStepEntityConfiguration());
+        modelBuilder.ApplyConfiguration(new PlanEdgeEntityConfiguration());
+        modelBuilder.ApplyConfiguration(new StepExecutionStateEntityConfiguration());
+        modelBuilder.ApplyConfiguration(new PlanExecutionLogEntityConfiguration());
     }
 }

--- a/src/Content/Tests/Infrastructure.AI.Tests/Persistence/PlannerDbContextTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Persistence/PlannerDbContextTests.cs
@@ -60,6 +60,30 @@ public sealed class PlannerDbContextTests : IDisposable
     }
 
     [Fact]
+    public void PlannerDbContext_Model_ContainsOnlyPlannerEntities()
+    {
+        using var ctx = CreateContext();
+
+        var entities = ctx.Model.GetEntityTypes()
+            .Select(e => e.ClrType.Name)
+            .OrderBy(n => n, StringComparer.Ordinal)
+            .ToArray();
+
+        // The planner owns exactly these five. Anything else in this list means an entity from
+        // another subsystem has been pulled into the planner's database — which is what happens
+        // the moment this context goes back to configuring itself by scanning its whole assembly.
+        entities.Should().BeEquivalentTo(
+            [
+                nameof(PlanEdgeEntity),
+                nameof(PlanExecutionLogEntity),
+                nameof(PlanGraphEntity),
+                nameof(PlanStepEntity),
+                nameof(StepExecutionStateEntity)
+            ],
+            "the planner's model must be declared, not discovered");
+    }
+
+    [Fact]
     public async Task PlanGraphEntity_Insert_PersistsAllFields()
     {
         var id = Guid.NewGuid();


### PR DESCRIPTION
Part of #249 — **item 4 only**. The other four items stay open; the issue itself asks for it to be split if one is picked up alone.

## The problem

`PlannerDbContext` built its model with `ApplyConfigurationsFromAssembly`, which applies **every** `IEntityTypeConfiguration` in Infrastructure.AI. That assembly hosts several unrelated databases. So the next configuration class added for any other subsystem would have been applied to the planner's model, and the schema initializer would then have created that entity's table inside `planner.db` — silently, with nothing failing.

Not a live defect today: all five configuration classes in the assembly happen to be planner ones. It was a trap waiting for the next person.

## The change

The five planner configurations are registered explicitly. A guard test asserts the model contains exactly those five entities, so the trap cannot be reopened without a red test.

## Proof, with a control

A probe `IEntityTypeConfiguration` for a **foreign** entity (`ChangeProposalEntity`, which belongs to the governance database) was added to the assembly:

| | with the probe present |
|---|---|
| assembly scan (before) | guard test **RED** |
| explicit registration (after) | guard test **GREEN** |

The probe was still in the assembly for the green run — the fix is what excluded it, not its removal. Probe then deleted.

## Also in this diff

`ConversationDbContext` carried a remark stating that inline configuration there was "load-bearing, not stylistic" *because* of the planner's scan. This change makes that false. Rewritten to say what is now true rather than left as a wrong claim in the code.

## Test plan

- `dotnet build src/AgenticHarness.slnx` — 0 errors (6 pre-existing test warnings unchanged)
- `Infrastructure.AI.Tests` — 2832 passed, 0 failed, 3 skipped, including `PlannerSchemaInitializerTests` and `PlannerDbContext_Migrate_CreatesAllTables`

🤖 Generated with [Claude Code](https://claude.com/claude-code)