### PR TITLE
fix: let an exception declare the HTTP status it surfaces as (#249 item 5b)

### DIFF
--- a/src/Content/Application/Application.AI.Common/Exceptions/SkillPathRefusedException.cs
+++ b/src/Content/Application/Application.AI.Common/Exceptions/SkillPathRefusedException.cs
@@ -1,3 +1,5 @@
+using Application.Common.Exceptions;
+
 namespace Application.AI.Common.Exceptions;
 
 /// <summary>
@@ -19,9 +21,24 @@ namespace Application.AI.Common.Exceptions;
 /// refusal would turn a routine ACL problem into a startup abort. Catching this type means "the
 /// sandbox said no", and nothing else.
 /// </para>
+/// <para>
+/// Declares its own HTTP status rather than inheriting one. Deriving from
+/// <see cref="UnauthorizedAccessException"/> would otherwise surface it as 401, which tells a caller
+/// to authenticate — but the caller already is authenticated, and no amount of re-authenticating
+/// widens a sandbox. 403 says the right thing: the request was understood and refused.
+/// </para>
 /// </remarks>
-public sealed class SkillPathRefusedException : UnauthorizedAccessException
+public sealed class SkillPathRefusedException : UnauthorizedAccessException, IHttpStatusException
 {
+    /// <summary>403 Forbidden. See the type remarks for why this is not 401.</summary>
+    public int StatusCode => 403;
+
+    /// <summary>
+    /// What a production caller is told. Deliberately says nothing about which path was refused or
+    /// where the sandbox boundary lies — that is the detail the refusal exists to withhold.
+    /// </summary>
+    public string SafeMessage => "Forbidden.";
+
     /// <summary>
     /// Initializes a new instance of the <see cref="SkillPathRefusedException"/> class.
     /// </summary>

--- a/src/Content/Application/Application.Common/Exceptions/IHttpStatusException.cs
+++ b/src/Content/Application/Application.Common/Exceptions/IHttpStatusException.cs
@@ -1,0 +1,32 @@
+namespace Application.Common.Exceptions;
+
+/// <summary>
+/// Implemented by an exception that knows which HTTP status it should surface as.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The alternative — a table in the middleware keyed by exception type — cannot express a status for
+/// an exception declared in a layer the middleware sits below. <c>SkillPathRefusedException</c> is the
+/// case that forced this: it lives in the AI application layer, and the only ways to map it from a
+/// central table were to have the lower layer reference the higher one, or to let it inherit a status
+/// that is wrong for it. Both are worse than letting the exception answer for itself.
+/// </para>
+/// <para>
+/// Precedence: an exception implementing this interface wins over any inherited mapping, because a
+/// type that states its own answer is never guessing. Exceptions that do not implement it are mapped
+/// by type as before.
+/// </para>
+/// <para>
+/// <see cref="SafeMessage"/> is what a production client is told. It must reveal nothing the caller
+/// was refused — no resource names, no owners, no reason the check failed — because an error body is
+/// as readable as a successful one.
+/// </para>
+/// </remarks>
+public interface IHttpStatusException
+{
+    /// <summary>The HTTP status code this exception should be surfaced as.</summary>
+    int StatusCode { get; }
+
+    /// <summary>The message safe to return outside development. Must not disclose refused detail.</summary>
+    string SafeMessage { get; }
+}

--- a/src/Content/Infrastructure/Infrastructure.Common/Middleware/ExceptionHandling/GlobalExceptionMiddleware.cs
+++ b/src/Content/Infrastructure/Infrastructure.Common/Middleware/ExceptionHandling/GlobalExceptionMiddleware.cs
@@ -1,3 +1,4 @@
+using Application.Common.Exceptions;
 using Application.Common.Exceptions.ExceptionTypes;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
@@ -50,10 +51,10 @@ public sealed class GlobalExceptionMiddleware
         [typeof(UnauthorizedAccessException)] = (StatusCodes.Status401Unauthorized, "Access denied."),
         [typeof(ForbiddenAccessException)] = (StatusCodes.Status403Forbidden, "Forbidden."),
 
-        // Needs its own entry despite deriving from UnauthorizedAccessException: this map is keyed on
-        // the exact runtime type, so a derived exception matches nothing and would fall through to a
-        // 500. It is deliberately 403 rather than the base type's 401 — the caller is authenticated,
-        // and telling them to authenticate again would send them round a loop that cannot succeed.
+        // Needs its own entry despite deriving from UnauthorizedAccessException. The lookup walks the
+        // base chain and stops at the first hit, so this exact entry wins over the base type's 401 —
+        // deliberately, because the caller is authenticated, and telling them to authenticate again
+        // would send them round a loop that cannot succeed.
         [typeof(ConversationAccessDeniedException)] = (StatusCodes.Status403Forbidden, "Forbidden."),
         [typeof(EntityNotFoundException)] = (StatusCodes.Status404NotFound, "The requested resource was not found."),
         [typeof(DatabaseInteractionException)] = (StatusCodes.Status422UnprocessableEntity, "A data processing error occurred."),
@@ -106,24 +107,54 @@ public sealed class GlobalExceptionMiddleware
 
         context.Response.ContentType = "application/json";
 
-        var exceptionType = ex is AggregateException aggregate
-            ? aggregate.Flatten().InnerExceptions[0].GetType()
-            : ex.GetType();
+        var surfaced = ex is AggregateException aggregate
+            ? aggregate.Flatten().InnerExceptions[0]
+            : ex;
 
-        if (exceptionType == typeof(NoContentException))
+        if (surfaced is NoContentException)
         {
             context.Response.StatusCode = StatusCodes.Status204NoContent;
             return;
         }
 
-        if (ExceptionStatusMap.TryGetValue(exceptionType, out var mapped))
+        if (ResolveStatus(surfaced) is { } mapped)
         {
-            var message = _env.IsDevelopment() ? ex.Message : mapped.SafeMessage;
+            var message = _env.IsDevelopment() ? surfaced.Message : mapped.SafeMessage;
             await WriteErrorResponseAsync(context, mapped.StatusCode, message);
             return;
         }
 
         await WriteUnhandledExceptionResponseAsync(context, ex);
+    }
+
+    /// <summary>
+    /// Decides what status an exception surfaces as: its own answer first, then the nearest mapped
+    /// ancestor, then nothing (which means "unhandled").
+    /// </summary>
+    /// <remarks>
+    /// Order is the whole point. An exception implementing <see cref="IHttpStatusException"/> is
+    /// stating its status, not inheriting one, so it wins — that is how a type declared in a layer
+    /// above this middleware gets the right answer without this layer having to reference it.
+    /// Failing that, the walk starts at the exact runtime type and stops at the first hit, so a
+    /// specific entry always beats the base type's. Reaching <c>null</c> means no ancestor is mapped
+    /// and the exception is genuinely unrecognised — which is a fault, and must keep looking like one.
+    /// </remarks>
+    private static (int StatusCode, string SafeMessage)? ResolveStatus(Exception exception)
+    {
+        if (exception is IHttpStatusException declared)
+        {
+            return (declared.StatusCode, declared.SafeMessage);
+        }
+
+        for (var type = exception.GetType(); type is not null; type = type.BaseType)
+        {
+            if (ExceptionStatusMap.TryGetValue(type, out var mapped))
+            {
+                return mapped;
+            }
+        }
+
+        return null;
     }
 
     private async Task WriteUnhandledExceptionResponseAsync(HttpContext context, Exception ex)

--- a/src/Content/Tests/Infrastructure.Common.Tests/Middleware/ExceptionHandling/GlobalExceptionMiddlewareTests.cs
+++ b/src/Content/Tests/Infrastructure.Common.Tests/Middleware/ExceptionHandling/GlobalExceptionMiddlewareTests.cs
@@ -1,3 +1,5 @@
+using System.Text;
+using Application.Common.Exceptions;
 using Application.Common.Exceptions.ExceptionTypes;
 using FluentAssertions;
 using Infrastructure.Common.Middleware.ExceptionHandling;
@@ -129,5 +131,81 @@ public class GlobalExceptionMiddlewareTests
         await middleware.InvokeAsync(_httpContext);
 
         _httpContext.Response.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_ExceptionDerivedFromAMappedType_UsesTheNearestMappedAncestor()
+    {
+        // Every exception type this project owns is sealed, so UnauthorizedAccessException — supplied
+        // by the framework — is the only mapped type anything can derive from, and therefore the only
+        // place the old exact-type lookup could go wrong. It did: a derived refusal matched nothing
+        // and was reported as an unhandled fault, which says the server is broken when in fact the
+        // request was understood and declined.
+        _envMock.Setup(e => e.EnvironmentName).Returns(Environments.Development);
+        var middleware = CreateMiddleware(_ =>
+            throw new DerivedUnauthorizedException("Token has no tenant claim"));
+
+        await middleware.InvokeAsync(_httpContext);
+
+        _httpContext.Response.StatusCode.Should().Be(StatusCodes.Status401Unauthorized);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_DerivedExceptionWithItsOwnEntry_KeepsItsOwnStatusNotTheBaseTypes()
+    {
+        // Precedence guard. ConversationAccessDeniedException derives from UnauthorizedAccessException
+        // (401) but is deliberately 403: the caller IS authenticated, and telling them to authenticate
+        // again sends them round a loop that cannot succeed. Walking the chain must therefore stop at
+        // the first match, not the last — an exact entry always beats an inherited one.
+        var middleware = CreateMiddleware(_ =>
+            throw new ConversationAccessDeniedException());
+
+        await middleware.InvokeAsync(_httpContext);
+
+        _httpContext.Response.StatusCode.Should().Be(StatusCodes.Status403Forbidden);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_ExceptionDeclaringItsOwnStatus_BeatsWhatItWouldInherit()
+    {
+        // The reason IHttpStatusException exists. This exception derives from
+        // UnauthorizedAccessException and would inherit 401, but it states 403. A type that answers
+        // for itself is never guessing, so its answer must win — otherwise an exception declared in a
+        // layer above this middleware can only ever get a status by inheriting a wrong one.
+        _envMock.Setup(e => e.EnvironmentName).Returns(Environments.Development);
+        var middleware = CreateMiddleware(_ =>
+            throw new SelfDeclaringForbiddenException("Path outside the sandbox"));
+
+        await middleware.InvokeAsync(_httpContext);
+
+        _httpContext.Response.StatusCode.Should().Be(StatusCodes.Status403Forbidden);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_ExceptionDeclaringItsOwnStatus_InProduction_ReturnsOnlyItsSafeMessage()
+    {
+        // The thrown message names what was refused. Outside development the caller must get the
+        // exception's SafeMessage instead — an error body is as readable as a successful one.
+        _envMock.Setup(e => e.EnvironmentName).Returns(Environments.Production);
+        var body = new MemoryStream();
+        _httpContext.Response.Body = body;
+        var middleware = CreateMiddleware(_ =>
+            throw new SelfDeclaringForbiddenException("C:/secrets/master.key is outside the sandbox"));
+
+        await middleware.InvokeAsync(_httpContext);
+
+        var written = Encoding.UTF8.GetString(body.ToArray());
+        written.Should().NotContain("master.key");
+        written.Should().Contain("Forbidden.");
+    }
+
+    private sealed class DerivedUnauthorizedException(string message) : UnauthorizedAccessException(message);
+
+    private sealed class SelfDeclaringForbiddenException(string message)
+        : UnauthorizedAccessException(message), IHttpStatusException
+    {
+        public int StatusCode => StatusCodes.Status403Forbidden;
+
+        public string SafeMessage => "Forbidden.";
     }
 }


### PR DESCRIPTION
Part of #249 — the second half of item 5. Items 1, 2 and 3 remain open.

## The premise was mostly wrong, and the remainder was a security defect

The issue says a derived exception falls through to a 500. Measured first: **every exception type this repo owns is sealed**, so five of the six mapped types cannot produce this at all. The only inheritable mapped type is the framework's `UnauthorizedAccessException`, and exactly two types derive from it.

One (`ConversationAccessDeniedException`) already has its own entry. The other is **`SkillPathRefusedException`** — raised when a skill is refused a path outside its sandbox, and *deliberately* never swallowed: four separate catch sites exclude it by name so a sandbox refusal can never be mistaken for an empty result.

It then reached the client as an unhandled fault. **The one exception the system tries hardest to surface was the one it mislabelled** — reported as "the server broke" rather than "refused".

## Two changes

**1. An exception may declare its own status** (`IHttpStatusException`).

`SkillPathRefusedException` lives in the AI application layer, above this middleware. A central table could only reach it two ways: have the lower layer reference the higher one, or let it inherit 401. 401 tells an already-authenticated caller to authenticate again — a loop that cannot succeed, which is the exact reasoning already recorded on `ConversationAccessDeniedException`. Letting the exception answer for itself removes the need for either.

**2. The type lookup walks the base chain**, stopping at the first hit — so a specific entry still beats an inherited one. That precedence is now asserted rather than implied.

## Evidence

Each mechanism has its own test, and each was proved by breaking it:

| Mutation | Tests red |
|---|---|
| remove the declared-status branch | exactly the 2 covering it |
| reduce the walk to exact-match only | exactly the 1 covering it |

Also covered: in production the caller receives only the safe message — the test asserts the refused path name is **absent** from the response body.

## Test plan

- `dotnet build src/AgenticHarness.slnx` — 0 errors
- Every controller/middleware suite green: Presentation.Common 258, ExecutionApi 122, Application.Common 200, Application.AI.Common 1709, Infrastructure.Common 45 (13 in the middleware tests, 4 new)

**Unrelated environmental failures in my local run, filed separately:** four test helpers find the repo root by looking for a `.git` *directory*, which is a *file* in a git worktree. Control measured — the same suites passed 412/412 in the main checkout twenty minutes earlier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)