### PR TITLE
fix: find the repo root in a worktree, from one helper instead of five

### DIFF
--- a/src/Content/Tests/Infrastructure.AI.Governance.Tests/Adapters/AgtPolicyEngineAdapterTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Governance.Tests/Adapters/AgtPolicyEngineAdapterTests.cs
@@ -83,7 +83,7 @@ public sealed class AgtPolicyEngineAdapterTests
     [Fact]
     public void EvaluateToolCall_WithArguments_PassesThemAsContext()
     {
-        var args = new Dictionary<string, object> { ["path"] = "/etc/passwd" };
+        var args = new Dictionary<string, object?> { ["path"] = "/etc/passwd" };
 
         var decision = _adapter.EvaluateToolCall("agent-1", "read_file", args);
 

--- a/src/Content/Tests/Infrastructure.AI.Tests/Helpers/RepoRootTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Helpers/RepoRootTests.cs
@@ -1,0 +1,142 @@
+using FluentAssertions;
+using Tests.Common;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Helpers;
+
+/// <summary>
+/// Tests for <see cref="RepoRoot"/>, the shared repository-root finder.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Issue #293. Five test helpers each grew their own copy of this walk and four looked for a
+/// <c>.git</c> <em>directory</em>. In a git worktree <c>.git</c> is a <em>file</em> holding a
+/// <c>gitdir:</c> pointer, so the walk ran off the top of the drive and threw — from a static
+/// initializer, which takes the whole test class with it. 19 tests across four classes.
+/// </para>
+/// <para>
+/// <strong><see cref="Find_WorktreeShapeWhereGitIsAFile_LocatesTheRoot"/> is the regression
+/// test.</strong> It builds the exact directory shape a worktree has and would fail against any
+/// of the four implementations this helper replaced. The others pin the behaviour that shape
+/// depends on.
+/// </para>
+/// </remarks>
+public sealed class RepoRootTests : IDisposable
+{
+    private readonly string _tempRoot;
+
+    public RepoRootTests()
+    {
+        _tempRoot = Path.Combine(Path.GetTempPath(), "reporoot-tests-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempRoot);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempRoot))
+            Directory.Delete(_tempRoot, recursive: true);
+    }
+
+    [Fact]
+    public void Find_WorktreeShapeWhereGitIsAFile_LocatesTheRoot()
+    {
+        // THE regression test. This is precisely what a worktree looks like on disk: .git is a
+        // FILE containing a gitdir: pointer, not a directory. Every implementation this helper
+        // replaced walked past this root and threw.
+        var root = CreateRepoLikeRoot();
+        File.WriteAllText(Path.Combine(root, ".git"), "gitdir: C:/somewhere/.git/worktrees/wt1");
+
+        var start = Path.Combine(root, "src", "Content", "Tests", "bin", "Debug", "net10.0");
+        Directory.CreateDirectory(start);
+
+        RepoRoot.Find(start).Should().Be(root,
+            "a worktree is the arrangement this repo's own gate-runner guidance recommends");
+    }
+
+    [Fact]
+    public void Find_MainCheckoutShapeWhereGitIsADirectory_LocatesTheSameRoot()
+    {
+        // The control: the arrangement that always worked must keep working. Anchoring on the
+        // solution file rather than on .git means both shapes resolve identically.
+        var root = CreateRepoLikeRoot();
+        Directory.CreateDirectory(Path.Combine(root, ".git"));
+
+        var start = Path.Combine(root, "src", "Content", "Tests", "bin", "Debug", "net10.0");
+        Directory.CreateDirectory(start);
+
+        RepoRoot.Find(start).Should().Be(root);
+    }
+
+    [Fact]
+    public void Find_NoGitEntryAtAll_StillLocatesTheRoot()
+    {
+        // A source archive, a CI checkout that stripped .git, a container COPY of the tree: none
+        // of these have a .git entry of any kind, and none of them should stop a test reading a
+        // file that is checked in beside the code.
+        var root = CreateRepoLikeRoot();
+
+        var start = Path.Combine(root, "src", "Content");
+
+        RepoRoot.Find(start).Should().Be(root);
+    }
+
+    [Fact]
+    public void Find_StartingAtTheRootItself_ReturnsIt()
+    {
+        var root = CreateRepoLikeRoot();
+
+        RepoRoot.Find(root).Should().Be(root);
+    }
+
+    [Fact]
+    public void Find_NoAnchorInAnyAncestor_ThrowsNamingTheAnchorAndTheStartingPoint()
+    {
+        // The failure surfaces from a static initializer, where the stack trace says almost
+        // nothing about what was being looked for. The message has to carry that itself.
+        var orphan = Path.Combine(_tempRoot, "no-repo-here", "deep");
+        Directory.CreateDirectory(orphan);
+
+        var act = () => RepoRoot.Find(orphan);
+
+        act.Should().Throw<InvalidOperationException>()
+            .Which.Message.Should()
+                .Contain("src/AgenticHarness.slnx", "the message must name what was missing")
+                .And.Contain(orphan, "and where the search began");
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Find_BlankStartDirectory_Throws(string blank)
+    {
+        var act = () => RepoRoot.Find(blank);
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void Path_ResolvesTheRealRepository()
+    {
+        // Not a tautology: it proves the anchor this helper looks for actually exists in the
+        // checkout the tests are running from, which is what every caller depends on.
+        File.Exists(System.IO.Path.Combine(RepoRoot.Path, "src", "AgenticHarness.slnx"))
+            .Should().BeTrue();
+    }
+
+    [Fact]
+    public void Combine_AppendsSegmentsBelowTheRoot()
+    {
+        RepoRoot.Combine("scripts", "otel-collector", "config.yaml")
+            .Should().Be(System.IO.Path.Combine(
+                RepoRoot.Path, "scripts", "otel-collector", "config.yaml"));
+    }
+
+    /// <summary>Creates a directory tree carrying the anchor file, and returns its root.</summary>
+    private string CreateRepoLikeRoot()
+    {
+        var root = Path.Combine(_tempRoot, "repo");
+        Directory.CreateDirectory(Path.Combine(root, "src"));
+        File.WriteAllText(Path.Combine(root, "src", "AgenticHarness.slnx"), "<Solution />");
+        return root;
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Skills/FrameworkLoaderSpikeTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Skills/FrameworkLoaderSpikeTests.cs
@@ -1,5 +1,6 @@
 using FluentAssertions;
 using Microsoft.Agents.AI;
+using Tests.Common;
 using Xunit;
 
 namespace Infrastructure.AI.Tests.Skills;
@@ -21,7 +22,7 @@ public class FrameworkLoaderSpikeTests
 
     public FrameworkLoaderSpikeTests()
     {
-        var repoRoot = FindRepoRoot(AppContext.BaseDirectory);
+        var repoRoot = RepoRoot.Path;
         _skillsRoot = Path.Combine(
             repoRoot,
             "src", "Content", "Application", "Application.Core", "Agents", "Skills");
@@ -94,18 +95,4 @@ public class FrameworkLoaderSpikeTests
             "AgentSkillsProvider should be an AIContextProvider for agent wiring");
     }
 
-    private static string FindRepoRoot(string startDir)
-    {
-        var dir = startDir;
-        while (dir != null)
-        {
-            if (File.Exists(Path.Combine(dir, "src", "AgenticHarness.slnx")))
-                return dir;
-
-            dir = Path.GetDirectoryName(dir);
-        }
-
-        throw new InvalidOperationException(
-            $"Could not find repo root (containing src/AgenticHarness.slnx) starting from {startDir}");
-    }
 }

--- a/src/Content/Tests/Infrastructure.AI.Tests/Skills/SkillMetadataParserToolDeclarationTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Skills/SkillMetadataParserToolDeclarationTests.cs
@@ -2,6 +2,7 @@ using Domain.AI.Skills;
 using FluentAssertions;
 using Infrastructure.AI.Skills;
 using Microsoft.Extensions.Logging.Abstractions;
+using Tests.Common;
 using Xunit;
 
 namespace Infrastructure.AI.Tests.Skills;
@@ -386,7 +387,7 @@ public sealed class SkillMetadataParserToolDeclarationTests : IDisposable
     public void ParseFromFile_ShippedWorkspacePluginManifest_ParsesAllFiveDeclarations()
     {
         var manifest = Path.Combine(
-            RepositoryRoot(), "plugins", "workspace-skill", "skills", "workspace", "SKILL.md");
+            RepoRoot.Path, "plugins", "workspace-skill", "skills", "workspace", "SKILL.md");
 
         File.Exists(manifest).Should().BeTrue($"the shipped manifest should exist at {manifest}");
 
@@ -399,16 +400,6 @@ public sealed class SkillMetadataParserToolDeclarationTests : IDisposable
         skill.ToolDeclarations[0].Operations.Should().Equal("read");
         skill.ToolDeclarations[0].Description.Should()
             .Be("Read a file from the sandbox-injected working-copy path.");
-    }
-
-    private static string RepositoryRoot()
-    {
-        var dir = new DirectoryInfo(AppContext.BaseDirectory);
-        while (dir is not null && !Directory.Exists(Path.Combine(dir.FullName, ".git")))
-            dir = dir.Parent;
-
-        return dir?.FullName
-            ?? throw new InvalidOperationException("Could not locate the repository root from the test output directory.");
     }
 
     /// <summary>

--- a/src/Content/Tests/Presentation.AgentHub.Tests/Telemetry/CollectorContractTests.cs
+++ b/src/Content/Tests/Presentation.AgentHub.Tests/Telemetry/CollectorContractTests.cs
@@ -1,5 +1,6 @@
 using FluentAssertions;
 using Presentation.AgentHub.Tests.Telemetry.Contracts;
+using Tests.Common;
 using Xunit;
 
 namespace Presentation.AgentHub.Tests.Telemetry;
@@ -13,7 +14,7 @@ namespace Presentation.AgentHub.Tests.Telemetry;
 public sealed class CollectorContractTests
 {
     private static readonly string CollectorConfigPath =
-        Path.Combine(GetRepoRoot(), "scripts", "otel-collector", "config.yaml");
+        RepoRoot.Combine("scripts", "otel-collector", "config.yaml");
 
     private static readonly string Namespace =
         MetricNamingContract.GetCollectorNamespace(CollectorConfigPath);
@@ -135,13 +136,5 @@ public sealed class CollectorContractTests
             allNames.Should().Contain(metric,
                 $"critical metric '{metric}' must exist in the naming contract");
         }
-    }
-
-    private static string GetRepoRoot()
-    {
-        var dir = Directory.GetCurrentDirectory();
-        while (dir != null && !Directory.Exists(Path.Combine(dir, ".git")))
-            dir = Directory.GetParent(dir)?.FullName;
-        return dir ?? throw new InvalidOperationException("Could not find repo root");
     }
 }

--- a/src/Content/Tests/Presentation.AgentHub.Tests/Telemetry/DashboardContractTests.cs
+++ b/src/Content/Tests/Presentation.AgentHub.Tests/Telemetry/DashboardContractTests.cs
@@ -3,6 +3,7 @@ using System.Text.RegularExpressions;
 using FluentAssertions;
 using FluentAssertions.Execution;
 using Presentation.AgentHub.Tests.Telemetry.Contracts;
+using Tests.Common;
 using Xunit;
 
 namespace Presentation.AgentHub.Tests.Telemetry;
@@ -17,7 +18,7 @@ namespace Presentation.AgentHub.Tests.Telemetry;
 public sealed partial class DashboardContractTests
 {
     private static readonly string CollectorConfigPath =
-        Path.Combine(GetRepoRoot(), "scripts", "otel-collector", "config.yaml");
+        RepoRoot.Combine("scripts", "otel-collector", "config.yaml");
 
     private static readonly string Namespace =
         MetricNamingContract.GetCollectorNamespace(CollectorConfigPath);
@@ -126,13 +127,5 @@ public sealed partial class DashboardContractTests
         }
 
         return metricNames;
-    }
-
-    private static string GetRepoRoot()
-    {
-        var dir = Directory.GetCurrentDirectory();
-        while (dir != null && !Directory.Exists(Path.Combine(dir, ".git")))
-            dir = Directory.GetParent(dir)?.FullName;
-        return dir ?? throw new InvalidOperationException("Could not find repo root");
     }
 }

--- a/src/Content/Tests/Presentation.AgentHub.Tests/Telemetry/Fixtures/PrometheusFixture.cs
+++ b/src/Content/Tests/Presentation.AgentHub.Tests/Telemetry/Fixtures/PrometheusFixture.cs
@@ -3,6 +3,7 @@ using System.Text.Json;
 using DotNet.Testcontainers.Builders;
 using DotNet.Testcontainers.Containers;
 using DotNet.Testcontainers.Networks;
+using Tests.Common;
 using Xunit;
 
 namespace Presentation.AgentHub.Tests.Telemetry.Fixtures;
@@ -48,8 +49,6 @@ public sealed class PrometheusFixture : IAsyncLifetime
     /// <summary>Prometheus HTTP API endpoint on the host (e.g., http://localhost:{port}).</summary>
     public string PrometheusQueryEndpoint { get; private set; } = null!;
 
-    private static readonly string RepoRoot = GetRepoRoot();
-
     /// <inheritdoc/>
     public async Task InitializeAsync()
     {
@@ -68,7 +67,7 @@ public sealed class PrometheusFixture : IAsyncLifetime
             .WithPortBinding(4318, true)
             .WithPortBinding(8889, true)
             .WithResourceMapping(
-                Path.Combine(RepoRoot, "scripts", "otel-collector", "config.yaml"),
+                RepoRoot.Combine("scripts", "otel-collector", "config.yaml"),
                 "/etc/otelcol-contrib/")
             .WithEnvironment("DEPLOYMENT_ENVIRONMENT", "test")
             .WithEnvironment("TEMPO_ENDPOINT", "localhost:4317")
@@ -164,11 +163,4 @@ public sealed class PrometheusFixture : IAsyncLifetime
         if (_network != null) await _network.DeleteAsync();
     }
 
-    private static string GetRepoRoot()
-    {
-        var dir = Directory.GetCurrentDirectory();
-        while (dir != null && !Directory.Exists(Path.Combine(dir, ".git")))
-            dir = Directory.GetParent(dir)?.FullName;
-        return dir ?? throw new InvalidOperationException("Could not find repo root (.git directory)");
-    }
 }

--- a/src/Content/Tests/Tests.Common/RepoRoot.cs
+++ b/src/Content/Tests/Tests.Common/RepoRoot.cs
@@ -33,8 +33,21 @@ namespace Tests.Common;
 /// </remarks>
 public static class RepoRoot
 {
-    private const string Anchor = "src/AgenticHarness.slnx";
+    /// <summary>
+    /// The file whose presence marks the repository root, as path segments. The error message is
+    /// derived from these rather than restating them, so renaming the solution cannot leave the
+    /// check looking for one file while the diagnostic names another.
+    /// </summary>
+    private static readonly string[] AnchorSegments = ["src", "AgenticHarness.slnx"];
 
+    private static readonly string AnchorDisplay = string.Join('/', AnchorSegments);
+
+    /// <remarks>
+    /// Anchored on <see cref="AppContext.BaseDirectory"/>, not the current working directory. Three
+    /// of the implementations this replaced used the latter, which any test that calls
+    /// <c>Directory.SetCurrentDirectory</c> can move out from under an unrelated test. The assembly
+    /// location cannot be moved that way.
+    /// </remarks>
     private static readonly Lazy<string> Cached = new(() => Find(AppContext.BaseDirectory));
 
     /// <summary>
@@ -70,14 +83,14 @@ public static class RepoRoot
         var dir = startDirectory;
         while (dir is not null)
         {
-            if (File.Exists(System.IO.Path.Combine(dir, "src", "AgenticHarness.slnx")))
+            if (File.Exists(System.IO.Path.Combine([dir, .. AnchorSegments])))
                 return dir;
 
             dir = System.IO.Path.GetDirectoryName(dir);
         }
 
         throw new InvalidOperationException(
-            $"Could not find the repository root (a directory containing {Anchor}) " +
+            $"Could not find the repository root (a directory containing {AnchorDisplay}) " +
             $"starting from '{startDirectory}'.");
     }
 }

--- a/src/Content/Tests/Tests.Common/RepoRoot.cs
+++ b/src/Content/Tests/Tests.Common/RepoRoot.cs
@@ -1,0 +1,83 @@
+namespace Tests.Common;
+
+/// <summary>
+/// Locates the repository root for tests that need to read a file checked in alongside the code —
+/// an OpenTelemetry collector config, a dashboard definition, a sample SKILL.md.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>Why this is anchored on the solution file and not on <c>.git</c>.</strong> Five test
+/// helpers grew their own copy of this walk, and four of them looked for a <c>.git</c>
+/// <em>directory</em>. In a git worktree <c>.git</c> is a <em>file</em> containing a
+/// <c>gitdir:</c> pointer, so the walk ran past the root, off the top of the drive, and threw.
+/// Because these helpers are called from static initializers, the throw took whole test classes
+/// with it — 19 tests across four classes (#293).
+/// </para>
+/// <para>
+/// That matters more than a normal test-only bug because a worktree is the arrangement this repo's
+/// own guidance recommends: the gate runner reads the working checkout, so running gates while
+/// doing other work requires a second copy. The recommended setup could not run these tests.
+/// </para>
+/// <para>
+/// <c>src/AgenticHarness.slnx</c> is the right anchor because it is unambiguous in both
+/// arrangements: it is a file in a worktree and a file in the main checkout, so there is no
+/// file-versus-directory question to get wrong. Accepting "<c>.git</c> as either a file or a
+/// directory" would have fixed the reported symptom while leaving the same trap for the next
+/// copy of the walk — which is why the four copies are gone rather than patched.
+/// </para>
+/// <para>
+/// This does mean the root is defined as "the directory containing the solution", not "the
+/// directory git considers the root". For reading checked-in files those are the same directory,
+/// and for a worktree the former is the one a test actually wants.
+/// </para>
+/// </remarks>
+public static class RepoRoot
+{
+    private const string Anchor = "src/AgenticHarness.slnx";
+
+    private static readonly Lazy<string> Cached = new(() => Find(AppContext.BaseDirectory));
+
+    /// <summary>
+    /// The repository root, resolved once per process.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// The anchor file was not found in any ancestor directory.
+    /// </exception>
+    public static string Path => Cached.Value;
+
+    /// <summary>
+    /// Combines <see cref="Path"/> with the given repo-relative segments.
+    /// </summary>
+    /// <param name="segments">Path segments below the repository root.</param>
+    /// <returns>An absolute path.</returns>
+    public static string Combine(params string[] segments) =>
+        System.IO.Path.Combine([Path, .. segments]);
+
+    /// <summary>
+    /// Walks up from <paramref name="startDirectory"/> looking for the anchor file.
+    /// </summary>
+    /// <param name="startDirectory">The directory to start from.</param>
+    /// <returns>The directory containing <c>src/AgenticHarness.slnx</c>.</returns>
+    /// <exception cref="InvalidOperationException">
+    /// No ancestor contains the anchor. The message names the anchor and the starting point,
+    /// because the failure surfaces from a static initializer where the stack trace alone says
+    /// very little about what was actually being looked for.
+    /// </exception>
+    public static string Find(string startDirectory)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(startDirectory);
+
+        var dir = startDirectory;
+        while (dir is not null)
+        {
+            if (File.Exists(System.IO.Path.Combine(dir, "src", "AgenticHarness.slnx")))
+                return dir;
+
+            dir = System.IO.Path.GetDirectoryName(dir);
+        }
+
+        throw new InvalidOperationException(
+            $"Could not find the repository root (a directory containing {Anchor}) " +
+            $"starting from '{startDirectory}'.");
+    }
+}


### PR DESCRIPTION
Closes #293.

## What was broken

You could not run the test suite from a git worktree. Nineteen tests across four classes died on
startup.

The cause: five test helpers each had their own copy of "walk up the directory tree until you find
the repository root", and four of them looked for a `.git` **directory**. In a worktree, `.git` is a
**file** — it holds a pointer to the real git data elsewhere. So those four walked straight past the
root, off the top of the drive, and threw. Because they run inside static initializers, the throw
took the entire test class with it rather than failing one test.

This matters more than a test-only bug usually would: a worktree is the arrangement this repo's own
guidance recommends. The gate runner reads the working checkout, so running gates while doing other
work needs a second copy of the tree — and that second copy could not run these tests.

## The detail the issue missed

The issue said four sites. **There are five.** The fifth already anchored on the solution file and
already worked in a worktree.

So the correct implementation had been sitting in the repository the whole time, in a file none of
the other four authors had any reason to open. That is the real cost of copy-paste: not just
duplicated code, but a correct version nobody can find. It is now the shared one, and all five copies
are gone.

## Why not just accept a `.git` file

That fixes the reported symptom at the shallowest possible depth and leaves the identical trap for
the sixth copy of the walk.

Anchoring on `src/AgenticHarness.slnx` removes the question entirely — it is a file in a worktree and
a file in a normal checkout, so there is no file-versus-directory distinction left to get wrong. It
also works when there is no `.git` entry at all: a source archive, a CI checkout that stripped git
history, a container image built by copying the tree.

Deleting the five copies is what makes the fix stick. A shared helper that four files still bypass is
not a fix.

## Evidence

- **Mutation test:** reverted the helper to the old `.git`-directory check. The worktree regression
  test failed, along with the no-git-at-all and start-at-the-root cases.
- **The control:** the normal-checkout case passed under **both** implementations. That is what
  proves this did not trade one arrangement for the other.
- Full suite: **9,870 passing, 0 failing**.

## Also in here

One line in `AgtPolicyEngineAdapterTests`: a nullability warning that #294 introduced when it widened
the policy engine's signature and I did not update this call site. It is mine and it is one line —
leaving a warning behind to keep a diff tidy is the wrong trade.

## Known and deliberately not fixed

The issue also noted test hosts failing with *"The filename or extension is too long"* when a worktree
sits under a deep temporary path. That is a constraint on **where** a worktree is placed, not a defect
in this repository — place them shallow, e.g. `C:\wt\<name>`. Recorded so the two problems do not get
conflated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
