### PR TITLE
fix: parse governance enums by name, in one place, at every layer

### DIFF
--- a/src/Content/Application/Application.AI.Common/Services/Governance/EscalationToolApprovalRouter.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Governance/EscalationToolApprovalRouter.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using Application.AI.Common.Interfaces.Escalation;
 using Application.AI.Common.Interfaces.Governance;
+using Application.Common.Helpers;
 using Domain.AI.Changes;
 using Domain.AI.Escalation;
 using Domain.AI.Governance;
@@ -295,13 +296,24 @@ public sealed class EscalationToolApprovalRouter : IToolApprovalRouter
             : text;
     }
 
+    /// <summary>
+    /// Resolves the blast radius at or above which an approval is raised at Critical priority.
+    /// </summary>
+    /// <remarks>
+    /// Parses by member NAME only. A bare <see cref="Enum.TryParse{TEnum}(string?, bool, out TEnum)"/>
+    /// accepts any integer string, including one outside the defined range: <c>"99"</c> succeeded and
+    /// produced a <see cref="BlastRadius"/> of 99, which is not a member. The comparison below is
+    /// <c>radius >= threshold</c>, so that value silently made it impossible for any call to reach
+    /// Critical priority — the setting's entire purpose, disabled by a typo, with no warning
+    /// because parsing had "succeeded" (#296).
+    /// </remarks>
     private BlastRadius ParseCriticalThreshold(string configured)
     {
-        if (Enum.TryParse<BlastRadius>(configured, ignoreCase: true, out var parsed))
+        if (EnumNameHelper.TryParseName<BlastRadius>(configured, out var parsed))
             return parsed;
 
         _logger.LogWarning(
-            "ToolApproval:CriticalAtBlastRadius '{Configured}' is not a valid blast radius — treating as Critical.",
+            "ToolApproval:CriticalAtBlastRadius '{Configured}' is not a valid blast radius name — treating as Critical.",
             configured);
         return BlastRadius.Critical;
     }
@@ -321,8 +333,22 @@ public sealed class EscalationToolApprovalRouter : IToolApprovalRouter
     private static int QuorumFor(ApprovalStrategyType strategy, int approverCount) =>
         strategy == ApprovalStrategyType.Quorum ? (approverCount / 2) + 1 : 0;
 
+    /// <summary>
+    /// Resolves the configured approval strategy, falling back to <see cref="ApprovalStrategyType.AnyOf"/>.
+    /// </summary>
+    /// <remarks>
+    /// Parses by member NAME only, for the same reason as <see cref="ParseCriticalThreshold"/> and
+    /// with a sharper consequence. <c>DefaultEscalationService</c> resolves the strategy from
+    /// <em>keyed DI</em>, using the enum value as the key. An undefined value taken from a numeric
+    /// string has no registered service, so <c>GetRequiredKeyedService</c> throws — and this class's
+    /// own fail-closed catch converts that into a block. One mistyped character would refuse every
+    /// approval-required tool call for the life of the process, leaving nothing behind but a per-call
+    /// error log. Note that <c>EscalationRequestInvariants</c> does <em>not</em> catch this: it
+    /// checks the quorum threshold, not that the strategy names a defined member. Rejecting the
+    /// value here turns the whole failure into one warning and a documented default (#296).
+    /// </remarks>
     private static ApprovalStrategyType ParseStrategy(string configured) =>
-        Enum.TryParse<ApprovalStrategyType>(configured, ignoreCase: true, out var parsed)
+        EnumNameHelper.TryParseName<ApprovalStrategyType>(configured, out var parsed)
             ? parsed
             : ApprovalStrategyType.AnyOf;
 

--- a/src/Content/Application/Application.Common/Helpers/EnumNameHelper.cs
+++ b/src/Content/Application/Application.Common/Helpers/EnumNameHelper.cs
@@ -1,0 +1,84 @@
+namespace Application.Common.Helpers;
+
+/// <summary>
+/// Parses enum values supplied as configuration or wire data, by <em>name</em> only.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>Why this exists rather than calling <see cref="Enum.TryParse{TEnum}(string?, bool, out TEnum)"/>
+/// directly.</strong> That method succeeds for any integer string, including one outside the defined
+/// range. <c>Enum.TryParse&lt;BlastRadius&gt;("99", …)</c> returns <see langword="true"/> and hands
+/// back a <c>BlastRadius</c> whose value is 99 — a member that does not exist. Nothing downstream
+/// has any reason to suspect it: comparisons still compile, <c>ToString()</c> returns "99", and a
+/// severity ordering like <c>radius &gt;= threshold</c> silently stops ever being true.
+/// </para>
+/// <para>
+/// Configuration is exactly where this bites. A typo in a governance setting should be a startup
+/// error or a logged fallback, never a value that is accepted, is not a real member, and quietly
+/// changes a safety comparison.
+/// </para>
+/// <para>
+/// This helper lives in <c>Application.Common</c> deliberately: it is the layer both
+/// <c>Application.Core</c> (which validates these values at boot) and <c>Application.AI.Common</c>
+/// (which parses them again at runtime) can reference. Before #296 the two had separate rules, so
+/// the boot validator rejected <c>"3"</c> while the runtime parser accepted it as <c>High</c>.
+/// </para>
+/// </remarks>
+public static class EnumNameHelper
+{
+    /// <summary>
+    /// Parses an enum member by name, case-insensitively, rejecting numeric forms and undefined
+    /// values.
+    /// </summary>
+    /// <typeparam name="TEnum">The enum type to parse.</typeparam>
+    /// <param name="value">The candidate configuration or wire value.</param>
+    /// <param name="parsed">The parsed member when the method returns <see langword="true"/>.</param>
+    /// <returns>
+    /// <see langword="true"/> when <paramref name="value"/> names a defined member of
+    /// <typeparamref name="TEnum"/>.
+    /// </returns>
+    /// <remarks>
+    /// <para>
+    /// Three checks, each catching something the others do not:
+    /// </para>
+    /// <list type="bullet">
+    /// <item>
+    /// <description>
+    /// A leading digit or sign refuses the numeric wire form even when the number happens to name a
+    /// real member. <c>"2"</c> and <c>"High"</c> must not be interchangeable, or a value can mean
+    /// one thing to a boot validator and another to a runtime parser.
+    /// </description>
+    /// </item>
+    /// <item>
+    /// <description>
+    /// A comma refuses a flag combination. <see cref="Enum.TryParse{TEnum}(string?, bool, out TEnum)"/>
+    /// reads <c>"Low,High"</c> as a bitwise OR, and when that OR happens to land on a defined member
+    /// it is indistinguishable from having named that member directly —
+    /// <see cref="Enum.IsDefined{TEnum}(TEnum)"/> cannot catch it. A <c>[Flags]</c> enum would need a
+    /// different helper; none is parsed this way, and none should silently become parseable here.
+    /// </description>
+    /// </item>
+    /// <item>
+    /// <description>
+    /// <see cref="Enum.IsDefined{TEnum}(TEnum)"/> catches everything else outside the defined range.
+    /// </description>
+    /// </item>
+    /// </list>
+    /// </remarks>
+    public static bool TryParseName<TEnum>(string? value, out TEnum parsed)
+        where TEnum : struct, Enum
+    {
+        parsed = default;
+
+        if (string.IsNullOrWhiteSpace(value))
+            return false;
+
+        if (char.IsAsciiDigit(value[0]) || value[0] is '-' or '+')
+            return false;
+
+        if (value.Contains(',', StringComparison.Ordinal))
+            return false;
+
+        return Enum.TryParse(value, ignoreCase: true, out parsed) && Enum.IsDefined(parsed);
+    }
+}

--- a/src/Content/Application/Application.Core/CQRS/Autonomy/AutonomyValidationRules.cs
+++ b/src/Content/Application/Application.Core/CQRS/Autonomy/AutonomyValidationRules.cs
@@ -1,3 +1,4 @@
+using Application.Common.Helpers;
 using Domain.AI.Changes;
 
 namespace Application.Core.CQRS.Autonomy;
@@ -56,22 +57,19 @@ public static class AutonomyValidationRules
     /// <param name="parsed">The parsed member when the method returns <see langword="true"/>.</param>
     /// <returns><see langword="true"/> when <paramref name="value"/> names a defined member.</returns>
     /// <remarks>
-    /// <see cref="Enum.TryParse{TEnum}(string?, bool, out TEnum)"/> alone would accept any
-    /// integer string — including values outside the defined range — so this helper rejects
-    /// leading digits and signs outright and additionally requires
-    /// <see cref="Enum.IsDefined{TEnum}(TEnum)"/>. The wire contract is names only.
+    /// <para>
+    /// The rule itself lives in <see cref="EnumNameHelper.TryParseName{TEnum}"/>, in the layer that
+    /// <c>Application.AI.Common</c> can also reference. This stays as the autonomy read surface's
+    /// name for it: the wire contract is names only, and that statement belongs beside the messages
+    /// that report a violation of it.
+    /// </para>
+    /// <para>
+    /// It was NOT always shared, and the divergence had teeth — the runtime approval router parsed
+    /// the same governance setting with a bare <see cref="Enum.TryParse{TEnum}(string?, bool, out TEnum)"/>,
+    /// which accepts any integer string including one outside the defined range (#296).
+    /// </para>
     /// </remarks>
     public static bool TryParseEnumName<TEnum>(string? value, out TEnum parsed)
-        where TEnum : struct, Enum
-    {
-        parsed = default;
-
-        if (string.IsNullOrWhiteSpace(value))
-            return false;
-
-        if (char.IsAsciiDigit(value[0]) || value[0] is '-' or '+')
-            return false;
-
-        return Enum.TryParse(value, ignoreCase: true, out parsed) && Enum.IsDefined(parsed);
-    }
+        where TEnum : struct, Enum =>
+        EnumNameHelper.TryParseName(value, out parsed);
 }

--- a/src/Content/Application/Application.Core/Validation/ToolApprovalConfigValidator.cs
+++ b/src/Content/Application/Application.Core/Validation/ToolApprovalConfigValidator.cs
@@ -41,11 +41,11 @@ public sealed class ToolApprovalConfigValidator : AbstractValidator<ToolApproval
         // behaviourally equivalent — both reject numeric forms — so this buys shared vocabulary, not
         // stricter parsing. Worth stating plainly, because the reverse is easy to assume.
         //
-        // The genuine divergence is elsewhere and is NOT closed here: EscalationToolApprovalRouter
-        // parses the same setting with a bare Enum.TryParse, which does accept "3". A validated host
-        // never reaches that, since this rule rejects the value at boot; a host that binds
-        // GovernanceConfig without registering these options would. Closing it means moving the
-        // shared parser down to a layer Application.AI.Common can reference — a separate change.
+        // The genuine divergence WAS elsewhere and is now closed (#296): EscalationToolApprovalRouter
+        // parsed the same setting with a bare Enum.TryParse, which accepts "3" — and, worse, "99",
+        // yielding a BlastRadius that is not a member and silently making the router's
+        // `radius >= threshold` comparison unsatisfiable. Both sites now share
+        // EnumNameHelper.TryParseName, in the one layer both can reference.
         RuleFor(x => x.CriticalAtBlastRadius)
             .Must(v => AutonomyValidationRules.TryParseEnumName<BlastRadius>(v, out _))
             .WithMessage($"CriticalAtBlastRadius is invalid. {AutonomyValidationRules.InvalidBlastRadiusMessage}");

--- a/src/Content/Infrastructure/Infrastructure.AI/Agents/CapabilityMatchSupervisor.Escalation.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Agents/CapabilityMatchSupervisor.Escalation.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using Application.AI.Common.OpenTelemetry.Metrics;
 using Application.AI.Common.Services;
+using Application.Common.Helpers;
 using Domain.AI.Agents;
 using Domain.AI.Escalation;
 using Domain.AI.Governance;
@@ -36,14 +37,18 @@ public sealed partial class CapabilityMatchSupervisor
             Description = $"Delegation blocked by autonomy tier ({minimumTier}): {taskDescription}",
             RiskLevel = RiskLevel.Medium,
             Priority = EscalationPriority.Blocking,
-            ApprovalStrategy = Enum.TryParse<ApprovalStrategyType>(
-                escalationConfig.DefaultApprovalStrategy, true, out var strategy)
+            // Parsed by member NAME only. A bare Enum.TryParse accepts any integer string, including
+            // one outside the defined range, and the strategy is later resolved from keyed DI by its
+            // enum value — an undefined value has no registered service and throws at resolution.
+            // Same defect, same config keys, third site (#296).
+            ApprovalStrategy = EnumNameHelper.TryParseName<ApprovalStrategyType>(
+                escalationConfig.DefaultApprovalStrategy, out var strategy)
                 ? strategy : ApprovalStrategyType.AnyOf,
             Approvers = [],
             QuorumThreshold = 1,
             TimeoutSeconds = escalationConfig.DefaultTimeoutSeconds,
-            TimeoutAction = Enum.TryParse<EscalationTimeoutAction>(
-                escalationConfig.DefaultTimeoutAction, true, out var timeoutAction)
+            TimeoutAction = EnumNameHelper.TryParseName<EscalationTimeoutAction>(
+                escalationConfig.DefaultTimeoutAction, out var timeoutAction)
                 ? timeoutAction : EscalationTimeoutAction.DenyAndEscalate,
             RequestedAt = DateTimeOffset.UtcNow
         };

--- a/src/Content/Tests/Application.AI.Common.Tests/Governance/EscalationToolApprovalRouterTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Governance/EscalationToolApprovalRouterTests.cs
@@ -279,6 +279,124 @@ public sealed class EscalationToolApprovalRouterTests
         Assert.Equal(expected, captured.Priority);
     }
 
+    [Theory]
+    [InlineData("3")]
+    [InlineData("99")]
+    [InlineData("-1")]
+    public async Task RequestApprovalAsync_NumericCriticalThreshold_FallsBackToCriticalRatherThanBeingHonoured(
+        string configured)
+    {
+        // #296. A bare Enum.TryParse accepts ANY integer string, including one outside the defined
+        // range. "99" produced a BlastRadius of 99 — not a member — and the comparison is
+        // `radius >= threshold`, so nothing could ever reach Critical priority again. The setting's
+        // entire purpose, silently disabled by a typo, with no warning because parsing "succeeded".
+        //
+        // Critical is the safe fallback: it pages the widest audience, so a misconfiguration
+        // over-notifies rather than under-notifies.
+        EscalationRequest? captured = null;
+        _escalation
+            .Setup(x => x.RequestEscalationAsync(It.IsAny<EscalationRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<EscalationRequest, CancellationToken>((r, _) => captured = r)
+            .ReturnsAsync(Outcome(approved: true, EscalationResolutionType.Approved));
+
+        await Route(WithCriticalThreshold(configured), BlastRadius.Critical);
+
+        Assert.NotNull(captured);
+        Assert.Equal(EscalationPriority.Critical, captured.Priority);
+    }
+
+    [Fact]
+    public async Task RequestApprovalAsync_NamedCriticalThreshold_IsStillHonoured()
+    {
+        // The control. Rejecting numeric forms must not have broken the values that always worked:
+        // a threshold of High means a High-radius call pages at Critical priority.
+        EscalationRequest? captured = null;
+        _escalation
+            .Setup(x => x.RequestEscalationAsync(It.IsAny<EscalationRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<EscalationRequest, CancellationToken>((r, _) => captured = r)
+            .ReturnsAsync(Outcome(approved: true, EscalationResolutionType.Approved));
+
+        await Route(WithCriticalThreshold("High"), BlastRadius.High);
+
+        Assert.NotNull(captured);
+        Assert.Equal(EscalationPriority.Critical, captured.Priority);
+    }
+
+    [Theory]
+    [InlineData("2")]
+    [InlineData("99")]
+    public async Task RequestApprovalAsync_NumericApprovalStrategy_FallsBackToADefinedStrategy(
+        string configured)
+    {
+        // #296, the sharper half. DefaultEscalationService resolves the strategy from KEYED DI using
+        // the enum value as the key, so an undefined value has no registered service and throws at
+        // resolution — which this router's own fail-closed catch turns into a block. One mistyped
+        // character would have refused every approval-required tool call for the life of the process.
+        // EscalationRequestInvariants does not catch it: it checks the quorum threshold, not that the
+        // strategy names a defined member.
+        EscalationRequest? captured = null;
+        _escalation
+            .Setup(x => x.RequestEscalationAsync(It.IsAny<EscalationRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<EscalationRequest, CancellationToken>((r, _) => captured = r)
+            .ReturnsAsync(Outcome(approved: true, EscalationResolutionType.Approved));
+
+        await Route(WithApprovalStrategy(configured), BlastRadius.Low);
+
+        Assert.NotNull(captured);
+        Assert.True(Enum.IsDefined(captured.ApprovalStrategy),
+            "an undefined strategy has no keyed service and throws when the escalation service resolves it");
+        Assert.Equal(ApprovalStrategyType.AnyOf, captured.ApprovalStrategy);
+    }
+
+    [Fact]
+    public async Task RequestApprovalAsync_NamedApprovalStrategy_IsStillHonoured()
+    {
+        // The control for the strategy half: a named strategy must survive unchanged, including the
+        // quorum threshold it alone carries.
+        EscalationRequest? captured = null;
+        _escalation
+            .Setup(x => x.RequestEscalationAsync(It.IsAny<EscalationRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<EscalationRequest, CancellationToken>((r, _) => captured = r)
+            .ReturnsAsync(Outcome(approved: true, EscalationResolutionType.Approved));
+
+        await Route(WithApprovalStrategy("Quorum"), BlastRadius.Low);
+
+        Assert.NotNull(captured);
+        Assert.Equal(ApprovalStrategyType.Quorum, captured.ApprovalStrategy);
+        Assert.Equal(1, captured.QuorumThreshold);
+    }
+
+    private static GovernanceConfig WithCriticalThreshold(string criticalAtBlastRadius)
+    {
+        var config = Config();
+        return new GovernanceConfig
+        {
+            Escalation = config.Escalation,
+            ToolApproval = new ToolApprovalConfig
+            {
+                Enabled = true,
+                Approvers = ["alice"],
+                CriticalAtBlastRadius = criticalAtBlastRadius
+            }
+        };
+    }
+
+    private static GovernanceConfig WithApprovalStrategy(string strategy)
+    {
+        var config = Config();
+        return new GovernanceConfig
+        {
+            Escalation = new EscalationConfig
+            {
+                Enabled = true,
+                DefaultTimeoutSeconds = config.Escalation.DefaultTimeoutSeconds,
+                DefaultTimeoutAction = config.Escalation.DefaultTimeoutAction,
+                DefaultApprovalStrategy = strategy
+            },
+            ToolApproval = config.ToolApproval
+        };
+    }
+
     [Fact]
     public async Task RequestApprovalAsync_TimeoutOverride_BoundsHowLongATurnCanStall()
     {

--- a/src/Content/Tests/Application.Common.Tests/Helpers/EnumNameHelperTests.cs
+++ b/src/Content/Tests/Application.Common.Tests/Helpers/EnumNameHelperTests.cs
@@ -1,0 +1,131 @@
+using Application.Common.Helpers;
+using FluentAssertions;
+using Xunit;
+
+namespace Application.Common.Tests.Helpers;
+
+/// <summary>
+/// Tests for <see cref="EnumNameHelper"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The whole point of this helper is the gap between "parsing succeeded" and "the result is a real
+/// member". <see cref="Enum.TryParse{TEnum}(string?, bool, out TEnum)"/> returns <c>true</c> for any
+/// integer string, including one outside the defined range, and hands back a value that compiles,
+/// compares, and prints — while being a member that does not exist.
+/// </para>
+/// <para>
+/// <see cref="TryParseName_UndefinedNumericValue_IsRejected"/> is the test that matters: it is the
+/// case that shipped as a real defect (#296), where a governance threshold parsed to an undefined
+/// value and silently disabled the comparison it existed to drive.
+/// </para>
+/// </remarks>
+public class EnumNameHelperTests
+{
+    /// <summary>
+    /// A stand-in with a small defined range, so "outside the range" is testable. Public because a
+    /// <c>[Theory]</c> parameter cannot be less accessible than the test method.
+    /// </summary>
+    public enum Severity
+    {
+        Low = 0,
+        Medium = 1,
+        High = 2
+    }
+
+    [Theory]
+    [InlineData("Low", Severity.Low)]
+    [InlineData("Medium", Severity.Medium)]
+    [InlineData("High", Severity.High)]
+    public void TryParseName_DefinedMemberName_Parses(string value, Severity expected)
+    {
+        EnumNameHelper.TryParseName<Severity>(value, out var parsed).Should().BeTrue();
+        parsed.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("low")]
+    [InlineData("LOW")]
+    [InlineData("LoW")]
+    public void TryParseName_IsCaseInsensitive(string value)
+    {
+        // Configuration is hand-written, so casing must not be a trap. The rejection is about
+        // numeric forms, not about being fussy.
+        EnumNameHelper.TryParseName<Severity>(value, out var parsed).Should().BeTrue();
+        parsed.Should().Be(Severity.Low);
+    }
+
+    [Fact]
+    public void TryParseName_UndefinedNumericValue_IsRejected()
+    {
+        // THE regression case. Enum.TryParse succeeds here and yields Severity=99 — not a member.
+        // Downstream, a comparison like `value >= threshold` then silently stops ever being true.
+        EnumNameHelper.TryParseName<Severity>("99", out var parsed).Should().BeFalse();
+        parsed.Should().Be(default(Severity));
+
+        // Proof the guard is load-bearing rather than decorative: the framework call this replaces
+        // accepts the same input and produces the undefined value.
+        Enum.TryParse<Severity>("99", ignoreCase: true, out var viaFramework).Should().BeTrue();
+        Enum.IsDefined(viaFramework).Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData("0")]
+    [InlineData("1")]
+    [InlineData("2")]
+    public void TryParseName_NumericFormOfADefinedMember_IsStillRejected(string value)
+    {
+        // Rejected even though the number does name a real member. The contract is names only, so
+        // that configuration reads the same everywhere and a value cannot mean one thing at boot
+        // and another at runtime — which is exactly what #296 was.
+        EnumNameHelper.TryParseName<Severity>(value, out _).Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData("-1")]
+    [InlineData("+1")]
+    public void TryParseName_SignedNumericValue_IsRejected(string value)
+    {
+        EnumNameHelper.TryParseName<Severity>(value, out _).Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void TryParseName_NullOrBlank_IsRejected(string? value)
+    {
+        EnumNameHelper.TryParseName<Severity>(value, out _).Should().BeFalse();
+    }
+
+    [Fact]
+    public void TryParseName_NameThatIsNotAMember_IsRejected()
+    {
+        EnumNameHelper.TryParseName<Severity>("Catastrophic", out _).Should().BeFalse();
+    }
+
+    [Fact]
+    public void TryParseName_CommaSeparatedNames_AreRejectedEvenWhenTheCombinationIsDefined()
+    {
+        // Found by this test failing on its first run, which made it a finding rather than a
+        // formality. Enum.TryParse reads a comma list as a bitwise OR: Low(0) | High(2) is 2, which
+        // IS a defined member — so Enum.IsDefined cannot catch it, and "Low,High" was silently
+        // accepted as "High". A comma check is the only thing that refuses it.
+        EnumNameHelper.TryParseName<Severity>("Low,High", out _).Should().BeFalse();
+
+        // The framework call this replaces accepts it and yields a value indistinguishable from
+        // having named High directly — which is precisely why IsDefined is not sufficient alone.
+        Enum.TryParse<Severity>("Low,High", ignoreCase: true, out var viaFramework).Should().BeTrue();
+        viaFramework.Should().Be(Severity.High);
+        Enum.IsDefined(viaFramework).Should().BeTrue();
+    }
+
+    [Fact]
+    public void TryParseName_Rejection_LeavesTheOutParameterAtDefault()
+    {
+        // Callers use this as `TryParseName(...) ? parsed : Fallback`. A rejection must never leave a
+        // half-parsed value behind for a caller that ignores the bool.
+        EnumNameHelper.TryParseName<Severity>("nonsense", out var parsed).Should().BeFalse();
+        parsed.Should().Be(default(Severity));
+    }
+}


### PR DESCRIPTION
Closes #296.

## What this is, in plain terms

Two governance settings — *how risky a tool call has to be before we page someone urgently*, and *how
many approvers must agree* — were being read from configuration in a way that quietly accepted
nonsense.

The issue reported that one of them disagreed with itself: the startup check rejected `3`, while the
code that runs at request time accepted it. That was true. It also understated the problem twice over.

## What was actually happening

The .NET method being used accepts **any number**, including one that isn't a real setting value at
all. Feeding it `99` doesn't fail — it hands back a value of 99 for a setting whose only valid values
are 0 to 4. Nothing downstream can tell the difference: it compiles, it compares, it even prints as
"99".

That produced two silent failures:

**1. The urgency threshold could be switched off by a typo.** The code asks "is this call at least as
risky as the threshold?" With a threshold of 99, the answer is permanently no. No call could ever be
escalated urgently again — the setting's entire purpose, disabled, with no warning, because the parse
had "succeeded".

**2. The approval strategy was worse.** The strategy value is used as a lookup key to find the code
that implements it. An invalid value finds nothing and throws. The approval router catches that and —
correctly, by design — treats a failure as a refusal. So **one mistyped character would have refused
every approval-required tool call for the life of the process**, leaving nothing behind but a
per-request error log.

## A claim I had to go and check

I initially wrote in a code comment that a validation layer would catch the bad strategy value before
it got that far. It doesn't — that layer checks something else entirely. I read it rather than trust
it, and the comment now describes the mechanism I actually verified. Worth flagging because the
wrong version was more reassuring than the truth.

## Three places, not one

A third file parses the same two settings the same way. It's fixed here too. Leaving one site behind
is exactly how this class of bug survives — a pattern this repository has hit repeatedly.

The parser now lives in the one layer that both the startup validator and the runtime code can reach,
so the two cannot drift apart again.

## A bug found by a test that failed when it shouldn't have

I wrote a test asserting that comma-separated values were already rejected. **It failed** — they
weren't. The framework reads `"Low,High"` as a combination, and when that combination happens to land
on a real value, there is no way to tell it apart from having named that value directly. So
`"Low,High"` was silently being accepted as `"High"`.

Fixed, and documented — including the note that a genuine flags-style setting would need a different
helper, so nobody assumes this one covers that case.

## Evidence

- **Mutation test:** removed the guards and re-ran. Failures appeared at **all three layers** — the
  helper's own tests, the startup validator, and the runtime router. That spread is the point: each
  layer independently depends on the guard, rather than only the helper's unit tests noticing.
- **Controls:** a named threshold (`High`) and a named strategy (`Quorum`, including the approver
  count it alone carries) behave exactly as before. The fix narrows what is accepted without changing
  any configuration that was already valid.
- Full suite: **9,886 passing, 0 failing**.

## Deliberately out of scope

A sweep turned up roughly 50 places across the codebase using the same permissive parse. Most are not
this bug — they read values we wrote ourselves, where accepting a number is harmless. Filing that
review separately rather than widening this change.

One supporting detail worth recording: another file had already hand-rolled its own name-only check,
with a comment explaining why. A third author independently hit this and worked around it locally.
That is the argument for the shared helper being the default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
