### PR TITLE
chore: accept the js-yaml advisory that has no fixed release (#303)

### DIFF
--- a/.github/dependency-audit-allowlist.json
+++ b/.github/dependency-audit-allowlist.json
@@ -6,5 +6,12 @@
     "passes, so an exception cannot quietly become permanent. The gate also fails on entries that no",
     "longer match a finding, so a fixed package cannot leave its exception behind."
   ],
-  "accepted": []
+  "accepted": [
+    {
+      "package": "js-yaml",
+      "advisory": "GHSA-5p4m-2wfm-xmqj",
+      "reason": "Quadratic CPU consumption resolving !!omap, with no fixed release published. js-yaml is not a dependency of this repo — it arrives transitively through eslint (@eslint/eslintrc) and shadcn (cosmiconfig) in both frontends. Both are build-time tooling: neither reaches the browser bundle, and the only YAML either parses is this repo's own lint and component configuration. Reaching the flaw would require an attacker who can already edit our config files, at which point running an expensive lint is not the interesting thing they can do. Accepted rather than force-resolved because there is nothing to resolve to yet; revisit when eslint or shadcn bump their transitive, or when a patched js-yaml ships. Tracked in #303.",
+      "reviewBy": "2026-11-07"
+    }
+  ]
 }


### PR DESCRIPTION
Closes #303. Unblocks #302.

## Why this is not "silencing a gate"

The `Dependency Audit` gate is red on **untouched `main`**, and that was measured
rather than assumed:

| Run | Ref | Date | Result |
|---|---|---|---|
| `31111878664` | `main` (push) | 2026-08-06 14:39Z | pass |
| `31188347470` | `main` (workflow_dispatch, unmodified) | 2026-08-07 14:35Z | **fail** |

Nothing in the repo moved between those two runs that touches js-yaml.
`GHSA-5p4m-2wfm-xmqj` was published in the interval, against a dependency nobody
had reason to look at. That is precisely the case the workflow's own header comment
says the weekly schedule exists to catch — the schedule simply had not fired yet,
and a `.csproj` edit in PR #302 tripped the path filter first.

## Why accept rather than fix

`js-yaml` is not a dependency of this repo. It is transitive in both frontends:

```
+-- eslint@9.39.4
| `-- @eslint/eslintrc@3.3.5
|   `-- js-yaml@4.3.0
`-- shadcn@4.16.1
  `-- cosmiconfig@9.0.2
    `-- js-yaml@4.3.0 deduped
```

Both are **build-time tooling**. Neither reaches the browser bundle, and the only
YAML either parses is this repo's own lint and component configuration. The flaw is
quadratic CPU consumption resolving `!!omap`, so exploiting it here requires someone
who can already edit our config files — at which point a slow lint run is not the
interesting thing available to them.

The advisory lists **no fixed release**, so there is nothing to bump to and nothing
to pin via npm `overrides`. That is why this is an acceptance and not an upgrade.

## Why not just leave it red

A gate that is permanently red stops being read, and this one guards real supply-chain
findings. The entry carries a **review date of 2026-11-07** — the checker fails once
that passes, so this cannot quietly become permanent. It also fails on entries matching
no current finding, so it cannot outlive the advisory either.

## Test plan

- Ran `node .github/scripts/check-dependency-vulnerabilities.mjs` locally: both
  findings report as accepted, exit code 0, no blocking vulnerabilities.
- One entry covers both projects — matching is on package + advisory, not project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
