### PR TITLE
chore: track the ExecutionApi launch profile like its siblings

### DIFF
--- a/src/Content/Presentation/Presentation.ExecutionApi/Properties/launchSettings.json
+++ b/src/Content/Presentation/Presentation.ExecutionApi/Properties/launchSettings.json
@@ -1,0 +1,12 @@
+{
+  "profiles": {
+    "Presentation.ExecutionApi": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "https://localhost:52904;http://localhost:52905"
+    }
+  }
+}


### PR DESCRIPTION
## What

Commits `src/Content/Presentation/Presentation.ExecutionApi/Properties/launchSettings.json`,
which was the only untracked file under `src/`.

## Why it mattered

The review gate treats **any** uncommitted file under `src/` as unreviewed work — untracked
files included. So this one generated file blocked every `git push` and `gh pr create` whose
branch touched source. On PR #302 it blocked two pushes, and while being shuffled out of the
way it was very nearly replaced by a regenerated copy carrying different localhost ports than
the developer's own.

## Why committed rather than gitignored

The two sibling projects that already answer this question answer it the same way:

```
src/Content/Presentation/Presentation.AgentHub/Properties/launchSettings.json
src/Content/Presentation/Presentation.FoundryHost/Properties/launchSettings.json
```

The file is also a genuine part of how a consumer runs the template, which is the point of a
template. It holds nothing sensitive — a profile name, the Development environment flag, and
two localhost ports.

## Verification

Pushing this branch was the first `src`-touching push of the session that the gate did not
block, which is the behaviour change working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
